### PR TITLE
Hide login button when user is logged in already

### DIFF
--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -284,9 +284,11 @@ const ApiOptions = ({
 					<div style={{ marginTop: "0px" }} className="text-sm text-vscode-descriptionForeground -mt-2">
 						Uses Claude 3.7 Sonnet. You get $15 for free.
 					</div>
-					<VSCodeButtonLink variant="secondary" href={getKiloCodeBackendAuthUrl()}>
-						Log in at Kilo Code
-					</VSCodeButtonLink>
+					{apiConfiguration.kilocodeToken ? null : (
+						<VSCodeButtonLink variant="secondary" href={getKiloCodeBackendAuthUrl()}>
+							Log in at Kilo Code
+						</VSCodeButtonLink>
+					)}
 				</>
 			)}
 


### PR DESCRIPTION
Before this would be confusing when you went to the extension settings.
Before (when already logged in):
<img width="393" alt="Screenshot 2025-03-13 at 21 28 28" src="https://github.com/user-attachments/assets/2211b41a-dd6f-4ae0-9d7b-393285b4479b" />

After (when already logged in):
<img width="401" alt="Screenshot 2025-03-13 at 21 28 37" src="https://github.com/user-attachments/assets/992a3a39-4b95-4507-93c2-1370542e9012" />

Logout is facilitated for now by the 'reset settings' button
