### PR TITLE
Add logout from Kilo Code button

### DIFF
--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -291,7 +291,25 @@ const ApiOptions = ({
 					<div style={{ marginTop: "0px" }} className="text-sm text-vscode-descriptionForeground -mt-2">
 						Uses Claude 3.7 Sonnet. You get $15 for free.
 					</div>
-					{apiConfiguration.kilocodeToken ? null : (
+					{apiConfiguration.kilocodeToken ? (
+						<div>
+							<Button
+								variant="secondary"
+								onClick={async () => {
+									setApiConfigurationField("kilocodeToken", "")
+
+									vscode.postMessage({
+										type: "upsertApiConfiguration",
+										apiConfiguration: {
+											...apiConfiguration,
+											kilocodeToken: "",
+										},
+									})
+								}}>
+								Log out from Kilo Code
+							</Button>
+						</div>
+					) : (
 						<VSCodeButtonLink variant="secondary" href={getKiloCodeBackendAuthUrl()}>
 							Log in at Kilo Code
 						</VSCodeButtonLink>


### PR DESCRIPTION
To at least already have a log out button in but I will work on it a bit more in a later PR to prevent the settings dialog from showing 'save' and 'done' when hitting this button (redundant) and to make this button show up when coming back from the log in flow from the settings dialog instead of the welcome screen

<img width="452" alt="image" src="https://github.com/user-attachments/assets/9ef30809-9921-4286-93f1-f777e17596e8" />
