### PR TITLE
Add i18n-ally localesPaths to VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
 		"dist": true // set this to false to include "dist" folder in search results
 	},
 	// Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-	"typescript.tsc.autoDetect": "off"
+	"typescript.tsc.autoDetect": "off",
+	"i18n-ally.localesPaths": ["webview-ui/src/i18n", "webview-ui/src/__mocks__/i18n", "webview-ui/src/i18n/locales"]
 }


### PR DESCRIPTION
Include paths for i18n-ally localization files in the VSCode settings to enhance internationalization support.