### PR TITLE
Update settings view properly when receiving kilo code token

### DIFF
--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -110,6 +110,16 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 		setChangeDetected(false)
 	}, [currentApiConfigName, extensionState, isChangeDetected])
 
+	// Temporary way of making sure that the Settings view displays the logout button properly when receiving the kilocodeToken
+	// from the backend
+	useEffect(() => {
+		if (extensionState.apiConfiguration?.kilocodeToken) {
+			setCachedState((prevCachedState) => ({ ...prevCachedState, ...extensionState }))
+			setChangeDetected(false)
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [extensionState.apiConfiguration?.kilocodeToken])
+
 	const setCachedStateField: SetCachedStateField<keyof ExtensionStateContextType> = useCallback((field, value) => {
 		setCachedState((prevState) => {
 			if (prevState[field] === value) {


### PR DESCRIPTION
For now this will update the cached state in the view when the kilo code token is received but in the future we might want to change how this settings view caches things. I don't think it should cache all settings the way it does now