### PR TITLE
Move vital buttons below the chat and make space for feedback icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,34 +222,19 @@
 			],
 			"view/title": [
 				{
-					"command": "kilo-code.plusButtonClicked",
-					"group": "navigation@1",
-					"when": "view == kilo-code.SidebarProvider"
-				},
-				{
-					"command": "kilo-code.promptsButtonClicked",
-					"group": "navigation@2",
-					"when": "view == kilo-code.SidebarProvider"
-				},
-				{
-					"command": "kilo-code.historyButtonClicked",
-					"group": "navigation@3",
-					"when": "view == kilo-code.SidebarProvider"
-				},
-				{
 					"command": "kilo-code.popoutButtonClicked",
 					"group": "navigation@4",
 					"when": "view == kilo-code.SidebarProvider"
 				},
 				{
 					"command": "kilo-code.settingsButtonClicked",
-					"group": "navigation@5",
+					"group": "navigation@1",
 					"when": "view == kilo-code.SidebarProvider"
 				},
 				{
 					"command": "kilo-code.helpButtonClicked",
 					"group": "navigation@6",
-					"when": "view == kilo-code.SidebarProvider"
+					"when": "false && view == kilo-code.SidebarProvider"
 				}
 			]
 		},

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -14,6 +14,7 @@ import WelcomeView from "./components/welcome/WelcomeView"
 import McpView from "./components/mcp/McpView"
 import PromptsView from "./components/prompts/PromptsView"
 import { HumanRelayDialog } from "./components/human-relay/HumanRelayDialog"
+import BottomControls from "./components/chat/BottomControls"
 
 type Tab = "settings" | "history" | "mcp" | "prompts" | "chat"
 
@@ -113,6 +114,12 @@ const App = () => {
 				onSubmit={(requestId, text) => vscode.postMessage({ type: "humanRelayResponse", requestId, text })}
 				onCancel={(requestId) => vscode.postMessage({ type: "humanRelayCancel", requestId })}
 			/>
+			{/* Chat view contains its own bottom controls */}
+			{tab !== "chat" && (
+				<div className="fixed inset-0 top-auto">
+					<BottomControls />
+				</div>
+			)}
 		</>
 	)
 }

--- a/webview-ui/src/components/chat/BottomControls.tsx
+++ b/webview-ui/src/components/chat/BottomControls.tsx
@@ -2,11 +2,7 @@ import React from "react"
 import { vscode } from "../../utils/vscode"
 import { useAppTranslation } from "@/i18n/TranslationContext"
 
-interface BottomControlsProps {
-	// Add any props you might need here
-}
-
-const BottomControls: React.FC<BottomControlsProps> = (props) => {
+const BottomControls: React.FC = () => {
 	const { t } = useAppTranslation()
 
 	const startNewTask = () => {

--- a/webview-ui/src/components/chat/BottomControls.tsx
+++ b/webview-ui/src/components/chat/BottomControls.tsx
@@ -10,7 +10,10 @@ const BottomControls: React.FC<BottomControlsProps> = (props) => {
 	const { t } = useAppTranslation()
 
 	const startNewTask = () => {
+		// switches to new chat in chat view
 		vscode.postMessage({ type: "clearTask" })
+		// switches to new chat in all other views
+		window.postMessage({ type: "action", action: "chatButtonClicked" }, "*")
 	}
 
 	return (

--- a/webview-ui/src/components/chat/BottomControls.tsx
+++ b/webview-ui/src/components/chat/BottomControls.tsx
@@ -34,15 +34,7 @@ const BottomControls: React.FC<BottomControlsProps> = (props) => {
 				</button>
 			</div>
 			{/* Right group */}
-			<div className="flex items-center">
-				{/* TODO: add feedback button (out of scope for this PR) */}
-				<button
-					className="vscode-button flex items-center gap-1.5 p-0.75 rounded-sm text-vscode-button-secondaryForeground cursor-pointer hover:bg-vscode-button-secondaryHoverBackground"
-					title={t("chat:startNewTask.title")}
-					onClick={startNewTask}>
-					<span className="codicon codicon-add text-sm"></span>
-				</button>
-			</div>
+			<div className="flex items-center">{/* TODO: add feedback button (out of scope for this PR) */}</div>
 		</div>
 	)
 }

--- a/webview-ui/src/components/chat/BottomControls.tsx
+++ b/webview-ui/src/components/chat/BottomControls.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+import { vscode } from "../../utils/vscode"
+import { useAppTranslation } from "@/i18n/TranslationContext"
+
+interface BottomControlsProps {
+	// Add any props you might need here
+}
+
+const BottomControls: React.FC<BottomControlsProps> = (props) => {
+	const { t } = useAppTranslation()
+
+	const startNewTask = () => {
+		vscode.postMessage({ type: "clearTask" })
+	}
+
+	return (
+		<div className="flex flex-row items-center justify-between w-auto h-[30px] mx-3.5 mb-1">
+			{/* Left group */}
+			<div className="flex items-center gap-1">
+				<button
+					className="vscode-button flex items-center gap-1.5 p-0.75 rounded-sm text-vscode-button-secondaryForeground cursor-pointer hover:bg-vscode-button-secondaryHoverBackground"
+					title={t("chat:startNewTask.title")}
+					onClick={startNewTask}>
+					<span className="codicon codicon-add text-sm"></span>
+				</button>
+				<button
+					className="vscode-button flex items-center gap-1.5 p-0.75 rounded-sm text-vscode-button-secondaryForeground cursor-pointer hover:bg-vscode-button-secondaryHoverBackground"
+					title={t("chat:history.title")}
+					onClick={() => window.postMessage({ type: "action", action: "historyButtonClicked" }, "*")}>
+					<span className="codicon codicon-history text-sm"></span>
+				</button>
+			</div>
+			{/* Right group */}
+			<div className="flex items-center">
+				{/* TODO: add feedback button (out of scope for this PR) */}
+				<button
+					className="vscode-button flex items-center gap-1.5 p-0.75 rounded-sm text-vscode-button-secondaryForeground cursor-pointer hover:bg-vscode-button-secondaryHoverBackground"
+					title={t("chat:startNewTask.title")}
+					onClick={startNewTask}>
+					<span className="codicon codicon-add text-sm"></span>
+				</button>
+			</div>
+		</div>
+	)
+}
+
+export default BottomControls

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -26,6 +26,7 @@ import ChatRow from "./ChatRow"
 import ChatTextArea from "./ChatTextArea"
 import TaskHeader from "./TaskHeader"
 import AutoApproveMenu from "./AutoApproveMenu"
+import BottomControls from "./BottomControls"
 import { AudioType } from "../../../../src/shared/WebviewMessage"
 import { validateCommand } from "../../utils/command-validation"
 import { getAllModes } from "../../../../src/shared/modes"
@@ -1306,7 +1307,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				setMode={setMode}
 				modeShortcutText={modeShortcutText}
 			/>
-
+			<BottomControls />
 			<div id="roo-portal" />
 		</div>
 	)

--- a/webview-ui/src/components/common/Tab.tsx
+++ b/webview-ui/src/components/common/Tab.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils"
 type TabProps = HTMLAttributes<HTMLDivElement>
 
 export const Tab = ({ className, children, ...props }: TabProps) => (
-	<div className={cn("fixed inset-0 flex flex-col overflow-hidden", className)} {...props}>
+	<div className={cn("fixed inset-0 bottom-9 flex flex-col overflow-hidden", className)} {...props}>
 		{children}
 	</div>
 )

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -72,6 +72,8 @@
 	--color-vscode-button-background: var(--vscode-button-background);
 	--color-vscode-button-secondaryForeground: var(--vscode-button-secondaryForeground);
 	--color-vscode-button-secondaryBackground: var(--vscode-button-secondaryBackground);
+	--color-vscode-button-hoverBackground: var(--vscode-button-hoverBackground);
+	--color-vscode-button-secondaryHoverBackground: var(--vscode-button-secondaryHoverBackground);
 
 	--color-vscode-dropdown-foreground: var(--vscode-dropdown-foreground);
 	--color-vscode-dropdown-background: var(--vscode-dropdown-background);


### PR DESCRIPTION
Introduce bottom controls for chat views, streamline top controls by hiding redundancies.

**Introduce bottom controls for chat views, streamline top controls by hiding redundancies.**

| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/7df0aeae-03bd-4014-95dc-f9498f4f2f6a) | ![After](https://github.com/user-attachments/assets/f4fd03ae-f5b7-4e6b-acbb-e4f2bcd45a9e) |

About is hidden for now since it points to a docs site we don't have yet