### PR TITLE
Add link to top up upon credit depletion

### DIFF
--- a/src/api/providers/kilocode.ts
+++ b/src/api/providers/kilocode.ts
@@ -180,6 +180,12 @@ export class KiloCodeHandler extends BaseProvider implements SingleCompletionHan
 						"Kilo Code has a free tier with $15 worth of Claude 3.7 Sonnet tokens.\n" +
 						"We'll give out more free tokens if you leave useful feedback.",
 				}
+			}
+			if (error.status === 402) {
+				yield {
+					type: "text",
+					text: "Go to https://kilocode.ai/profile to purchase more credits.",
+				}
 			} else {
 				yield {
 					type: "text",


### PR DESCRIPTION
## Context

This change adds a link to top up after credits are depleted in the kilocode provider.
Currently the user has no way to find the credit purchase page.

## Screenshots

| before | after |
| ------ | ----- |
|![Screenshot 2025-03-27 at 12 22 30](https://github.com/user-attachments/assets/e38a381b-7a60-4fda-971c-e95d644371d4) | ![Screenshot 2025-03-27 at 12 13 09](https://github.com/user-attachments/assets/6f0802eb-ceef-482b-a639-a7571f59804e)|

## How to Test

Run out of credits

