### PR TITLE
Hide documentation links for now

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -788,10 +788,12 @@ export const ChatRowContent = ({
 									<br />
 									Please update VSCode (<code>CMD/CTRL + Shift + P</code> → "Update") and make sure
 									you're using a supported shell: zsh, bash, fish, or PowerShell (
-									<code>CMD/CTRL + Shift + P</code> → "Terminal: Select Default Profile").{" "}
+									<code>CMD/CTRL + Shift + P</code> → "Terminal: Select Default Profile"). //
+									kilocode_change
 									<a
 										href="http://docs.roocode.com/troubleshooting/shell-integration/"
-										style={{ color: "inherit", textDecoration: "underline" }}>
+										// kilocode_change: do not display until we have actual docs
+										style={{ color: "inherit", textDecoration: "underline", display: "none" }}>
 										{t("chat:shellIntegration.troubleshooting")}
 									</a>
 								</div>

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -282,7 +282,8 @@ const ApiOptions = ({
 				<div className="flex justify-between items-center">
 					<label className="block font-medium mb-1">{t("settings:providers.apiProvider")}</label>
 					{getSelectedProviderDocUrl() && (
-						<div className="text-xs text-vscode-descriptionForeground">
+						// kilocode_change do not display until we have our own docs
+						<div className="hidden ext-xs text-vscode-descriptionForeground">
 							<VSCodeLink
 								href={getSelectedProviderDocUrl()!.url}
 								className="hover:text-vscode-foreground"


### PR DESCRIPTION
We are still in the progress of creating our own documentation, so for now we do not display links as these will not provide proper documentation on the changes that we made

- Resolves #130