### PR TITLE
Add ability to edit global and local workspace mcp servers back

### DIFF
--- a/src/core/prompts/__tests__/custom-system-prompt.test.ts
+++ b/src/core/prompts/__tests__/custom-system-prompt.test.ts
@@ -90,7 +90,8 @@ describe("File-Based Custom System Prompt", () => {
 		const fileCustomSystemPrompt = "Custom system prompt from file"
 		// When called with utf-8 encoding, return a string
 		mockedFs.readFile.mockImplementation((filePath, options) => {
-			if (toPosix(filePath).includes(`.roo/system-prompt-${defaultModeSlug}`) && options === "utf-8") {
+			// kilocode_change
+			if (toPosix(filePath).includes(`.kilocode/system-prompt-${defaultModeSlug}`) && options === "utf-8") {
 				return Promise.resolve(fileCustomSystemPrompt)
 			}
 			return Promise.reject({ code: "ENOENT" })
@@ -125,7 +126,8 @@ describe("File-Based Custom System Prompt", () => {
 		// Mock the readFile to return content from a file
 		const fileCustomSystemPrompt = "Custom system prompt from file"
 		mockedFs.readFile.mockImplementation((filePath, options) => {
-			if (toPosix(filePath).includes(`.roo/system-prompt-${defaultModeSlug}`) && options === "utf-8") {
+			// kilocode_change
+			if (toPosix(filePath).includes(`.kilocode/system-prompt-${defaultModeSlug}`) && options === "utf-8") {
 				return Promise.resolve(fileCustomSystemPrompt)
 			}
 			return Promise.reject({ code: "ENOENT" })

--- a/src/core/prompts/sections/custom-system-prompt.ts
+++ b/src/core/prompts/sections/custom-system-prompt.ts
@@ -24,11 +24,12 @@ async function safeReadFile(filePath: string): Promise<string> {
  * Get the path to a system prompt file for a specific mode
  */
 export function getSystemPromptFilePath(cwd: string, mode: Mode): string {
-	return path.join(cwd, ".roo", `system-prompt-${mode}`)
+	// kilocode_change
+	return path.join(cwd, ".kilocode", `system-prompt-${mode}`)
 }
 
 /**
- * Loads custom system prompt from a file at .roo/system-prompt-[mode slug]
+ * Loads custom system prompt from a file at .kilocode/system-prompt-[mode slug]
  * If the file doesn't exist, returns an empty string
  */
 export async function loadSystemPromptFile(cwd: string, mode: Mode): Promise<string> {
@@ -37,10 +38,11 @@ export async function loadSystemPromptFile(cwd: string, mode: Mode): Promise<str
 }
 
 /**
- * Ensures the .roo directory exists, creating it if necessary
+ * Ensures the .kilocode directory exists, creating it if necessary
  */
 export async function ensureRooDirectory(cwd: string): Promise<void> {
-	const rooDir = path.join(cwd, ".roo")
+	// kilocode_change
+	const rooDir = path.join(cwd, ".kilocode")
 
 	// Check if directory already exists
 	if (await fileExistsAtPath(rooDir)) {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1245,7 +1245,8 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 						}
 
 						const workspaceFolder = vscode.workspace.workspaceFolders[0]
-						const rooDir = path.join(workspaceFolder.uri.fsPath, ".roo")
+						// kilocode_change
+						const rooDir = path.join(workspaceFolder.uri.fsPath, ".kilocode")
 						const mcpPath = path.join(rooDir, "mcp.json")
 
 						try {
@@ -2074,22 +2075,24 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 						}
 						break
 
-					case "fetchMcpMarketplace": { // kilocode_change
+					// kilocode_change
+					case "fetchMcpMarketplace": {
 						await this.fetchMcpMarketplace(message.bool)
 						break
 					}
 
-					case "downloadMcp": { // kilocode_change
+					case "downloadMcp": {
 						if (message.mcpId) {
 							await this.downloadMcp(message.mcpId)
 						}
 						break
 					}
 
-					case "silentlyRefreshMcpMarketplace": { // kilocode_change
+					case "silentlyRefreshMcpMarketplace": {
 						await this.silentlyRefreshMcpMarketplace()
 						break
 					}
+					// end kilocode_change
 				}
 			},
 			null,

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2075,7 +2075,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 						}
 						break
 
-					// kilocode_change
+					// kilocode_change_start
 					case "fetchMcpMarketplace": {
 						await this.fetchMcpMarketplace(message.bool)
 						break

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -2032,7 +2032,8 @@ describe("Project MCP Settings", () => {
 
 		// Verify directory was created
 		expect(fs.mkdir).toHaveBeenCalledWith(
-			expect.stringContaining(".roo"),
+			// kilocode_change
+			expect.stringContaining(".kilocode"),
 			expect.objectContaining({ recursive: true }),
 		)
 
@@ -2075,7 +2076,8 @@ describe("Project MCP Settings", () => {
 
 		// Verify error message was shown
 		expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-			expect.stringContaining("Failed to create or open .roo/mcp.json"),
+			// kilocode_change
+			expect.stringContaining("Failed to create or open .kilocode/mcp.json"),
 		)
 	})
 })

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -386,7 +386,8 @@ export class McpHub {
 		}
 
 		const workspaceFolder = vscode.workspace.workspaceFolders[0]
-		const projectMcpDir = path.join(workspaceFolder.uri.fsPath, ".roo")
+		// kilocode_change
+		const projectMcpDir = path.join(workspaceFolder.uri.fsPath, ".kilocode")
 		const projectMcpPath = path.join(projectMcpDir, "mcp.json")
 
 		try {

--- a/webview-ui/src/components/kilocodeMcp/McpView.tsx
+++ b/webview-ui/src/components/kilocodeMcp/McpView.tsx
@@ -21,6 +21,7 @@ import McpMarketplaceView from "./marketplace/McpMarketplaceView"
 import McpResourceRow from "./McpResourceRow"
 import McpToolRow from "./McpToolRow"
 import DangerButton from "../common/DangerButton"
+import { useAppTranslation } from "../../i18n/TranslationContext"
 
 type McpViewProps = {
 	onDone: () => void
@@ -29,6 +30,7 @@ type McpViewProps = {
 const McpView = ({ onDone }: McpViewProps) => {
 	const { mcpServers: servers } = useExtensionState()
 	const [activeTab, setActiveTab] = useState("marketplace")
+	const { t } = useAppTranslation()
 
 	const handleTabChange = (tab: string) => {
 		setActiveTab(tab)
@@ -98,19 +100,14 @@ const McpView = ({ onDone }: McpViewProps) => {
 									Model Context Protocol
 								</VSCodeLink>{" "}
 								enables communication with locally running MCP servers that provide additional tools and
-								resources to extend Cline's capabilities. You can use{" "}
+								resources to extend Kilo Code's capabilities. You can use{" "}
 								<VSCodeLink
 									href="https://github.com/modelcontextprotocol/servers"
 									style={{ display: "inline" }}>
 									community-made servers
 								</VSCodeLink>{" "}
-								or ask Cline to create new tools specific to your workflow (e.g., "add a tool that gets
-								the latest npm docs").{" "}
-								<VSCodeLink
-									href="https://x.com/sdrzn/status/1867271665086074969"
-									style={{ display: "inline" }}>
-									See a demo here.
-								</VSCodeLink>
+								or ask Kilo Code to create new tools specific to your workflow (e.g., "add a tool that
+								gets the latest npm docs").{" "}
 							</div>
 
 							{servers.length > 0 ? (
@@ -139,30 +136,26 @@ const McpView = ({ onDone }: McpViewProps) => {
 								</div>
 							)}
 
-							{/* Settings Section */}
-							<div style={{ marginBottom: "20px", marginTop: 10 }}>
+							{/* Edit Settings Buttons */}
+							<div style={{ marginTop: "10px", width: "100%", display: "flex", gap: "10px" }}>
 								<VSCodeButton
 									appearance="secondary"
-									style={{ width: "100%", marginBottom: "5px" }}
+									style={{ flex: 1 }}
 									onClick={() => {
 										vscode.postMessage({ type: "openMcpSettings" })
 									}}>
-									<span className="codicon codicon-server" style={{ marginRight: "6px" }}></span>
-									Configure MCP Servers
+									<span className="codicon codicon-edit" style={{ marginRight: "6px" }}></span>
+									{t("mcp:editGlobalMCP")}
 								</VSCodeButton>
-								{/* TODO: what to do with this? */}
-								<div style={{ textAlign: "center" }}>
-									<VSCodeLink
-										onClick={() => {
-											vscode.postMessage({
-												type: "openExtensionSettings",
-												text: "kilo-code.mcp",
-											})
-										}}
-										style={{ fontSize: "12px" }}>
-										Advanced MCP Settings
-									</VSCodeLink>
-								</div>
+								<VSCodeButton
+									appearance="secondary"
+									style={{ flex: 1 }}
+									onClick={() => {
+										vscode.postMessage({ type: "openProjectMcpSettings" })
+									}}>
+									<span className="codicon codicon-edit" style={{ marginRight: "6px" }}></span>
+									{t("mcp:editProjectMCP")}
+								</VSCodeButton>
 							</div>
 						</div>
 					)}

--- a/webview-ui/src/components/kilocodeMcp/McpView.tsx
+++ b/webview-ui/src/components/kilocodeMcp/McpView.tsx
@@ -22,6 +22,7 @@ import McpResourceRow from "./McpResourceRow"
 import McpToolRow from "./McpToolRow"
 import DangerButton from "../common/DangerButton"
 import { useAppTranslation } from "../../i18n/TranslationContext"
+import { Trans } from "react-i18next"
 
 type McpViewProps = {
 	onDone: () => void
@@ -94,20 +95,18 @@ const McpView = ({ onDone }: McpViewProps) => {
 									marginTop: "5px",
 								}}>
 								The{" "}
-								<VSCodeLink
-									href="https://github.com/modelcontextprotocol"
-									style={{ display: "inline" }}>
-									Model Context Protocol
-								</VSCodeLink>{" "}
-								enables communication with locally running MCP servers that provide additional tools and
-								resources to extend Kilo Code's capabilities. You can use{" "}
-								<VSCodeLink
-									href="https://github.com/modelcontextprotocol/servers"
-									style={{ display: "inline" }}>
-									community-made servers
-								</VSCodeLink>{" "}
-								or ask Kilo Code to create new tools specific to your workflow (e.g., "add a tool that
-								gets the latest npm docs").{" "}
+								<Trans i18nKey="mcp:description">
+									<VSCodeLink
+										href="https://github.com/modelcontextprotocol"
+										style={{ display: "inline" }}>
+										Model Context Protocol
+									</VSCodeLink>
+									<VSCodeLink
+										href="https://github.com/modelcontextprotocol/servers"
+										style={{ display: "inline" }}>
+										community-made servers
+									</VSCodeLink>
+								</Trans>
 							</div>
 
 							{servers.length > 0 ? (

--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -873,7 +873,8 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 
 													vscode.postMessage({
 														type: "openFile",
-														text: `./.roo/system-prompt-${currentMode.slug}`,
+														// kilocode_change
+														text: `./.kilocode/system-prompt-${currentMode.slug}`,
 														values: {
 															create: true,
 															content: "",


### PR DESCRIPTION
To have the best of both worlds bringing this feature (editing not only global but also local workspace MCP servers) back from Roo and merging it with Cline's MCP settings 