### PR TITLE
Ignore invalid Anthropic apiKey in KiloCodeAnthropicHandler initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kilo-code",
-	"version": "4.9.1",
+	"version": "4.9.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kilo-code",
-			"version": "4.9.1",
+			"version": "4.9.2",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",
 				"@anthropic-ai/sdk": "^0.37.0",
@@ -13669,6 +13669,7 @@
 			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
 			"integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Kilo Code",
 	"description": "A whole dev team of AI agents in your editor.",
 	"publisher": "kilocode",
-	"version": "4.9.1",
+	"version": "4.9.2",
 	"icon": "assets/icons/logo-outline-black.png",
 	"galleryBanner": {
 		"color": "#FFFFFF",

--- a/src/api/providers/kilocode.ts
+++ b/src/api/providers/kilocode.ts
@@ -63,6 +63,7 @@ export class KiloCodeAnthropicHandler extends BaseProvider implements SingleComp
 		this.client = new Anthropic({
 			authToken: this.options.kilocodeToken,
 			baseURL: `${this.baseURL}/api/claude/`,
+			apiKey: null, //ignore anthropic apiKey, even if set in env vars - it's not valid for KiloCode anyhow
 		})
 	}
 


### PR DESCRIPTION
Fixes broken kilo-code for users that have the api key in the env e.g. for other LLM tools or the anthropic provider.

 - Likely resolve #129
 - Also resolve internal issue fix https://github.com/Kilo-Org/kilocode-backend/issues/142

It's easy to try this out: just set ANTHROPIC_API_KEY in the environtment, log in to kilocode, and before this PR the extension will appear logged in yet all prompts return 401; after this PR they don't.