### PR TITLE
Add JS code execution in browser action

### DIFF
--- a/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
@@ -2721,6 +2721,10 @@ Parameters:
         - Use with the \`text\` parameter to provide the string to type.
     * scroll_down: Scroll down the page by one page height.
     * scroll_up: Scroll up the page by one page height.
+    * execute_js: Execute JavaScript code in the browser context.
+        - Use with the \`text\` parameter to provide the JavaScript code to execute.
+        - Returns the result of the JavaScript evaluation directly in the response.
+        - Useful for extracting data from the page or modifying the page's content.
     * close: Close the Puppeteer-controlled browser instance. This **must always be the final browser action**.
         - Example: \`<action>close</action>\`
 - url: (optional) Use this for providing the URL for the \`launch\` action.
@@ -3632,6 +3636,10 @@ Parameters:
         - Use with the \`text\` parameter to provide the string to type.
     * scroll_down: Scroll down the page by one page height.
     * scroll_up: Scroll up the page by one page height.
+    * execute_js: Execute JavaScript code in the browser context.
+        - Use with the \`text\` parameter to provide the JavaScript code to execute.
+        - Returns the result of the JavaScript evaluation directly in the response.
+        - Useful for extracting data from the page or modifying the page's content.
     * close: Close the Puppeteer-controlled browser instance. This **must always be the final browser action**.
         - Example: \`<action>close</action>\`
 - url: (optional) Use this for providing the URL for the \`launch\` action.

--- a/src/core/prompts/tools/browser-action.ts
+++ b/src/core/prompts/tools/browser-action.ts
@@ -24,11 +24,12 @@ Parameters:
     * scroll_down: Scroll down the page by one page height.
     * scroll_up: Scroll up the page by one page height.` +
 		// kilocode_change
-		`* execute_js: Execute JavaScript code in the browser context.
+		`
+    * execute_js: Execute JavaScript code in the browser context.
         - Use with the \`text\` parameter to provide the JavaScript code to execute.
         - Returns the result of the JavaScript evaluation directly in the response.
-        - Useful for extracting data from the page or modifying the page's content.` +
-		`* close: Close the Puppeteer-controlled browser instance. This **must always be the final browser action**.
+        - Useful for extracting data from the page or modifying the page's content.
+    * close: Close the Puppeteer-controlled browser instance. This **must always be the final browser action**.
         - Example: \`<action>close</action>\`
 - url: (optional) Use this for providing the URL for the \`launch\` action.
     * Example: <url>https://example.com</url>

--- a/src/core/prompts/tools/browser-action.ts
+++ b/src/core/prompts/tools/browser-action.ts
@@ -22,6 +22,10 @@ Parameters:
         - Use with the \`text\` parameter to provide the string to type.
     * scroll_down: Scroll down the page by one page height.
     * scroll_up: Scroll up the page by one page height.
+    * execute_js: Execute JavaScript code in the browser context.
+        - Use with the \`text\` parameter to provide the JavaScript code to execute.
+        - Returns the result of the JavaScript evaluation directly in the response.
+        - Useful for extracting data from the page or modifying the page's content.
     * close: Close the Puppeteer-controlled browser instance. This **must always be the final browser action**.
         - Example: \`<action>close</action>\`
 - url: (optional) Use this for providing the URL for the \`launch\` action.

--- a/src/core/prompts/tools/browser-action.ts
+++ b/src/core/prompts/tools/browser-action.ts
@@ -4,7 +4,8 @@ export function getBrowserActionDescription(args: ToolArgs): string | undefined 
 	if (!args.supportsComputerUse) {
 		return undefined
 	}
-	return `## browser_action
+	return (
+		`## browser_action
 Description: Request to interact with a Puppeteer-controlled browser. Every action, except \`close\`, will be responded to with a screenshot of the browser's current state, along with any new console logs. You may only perform one browser action per message, and wait for the user's response including a screenshot and logs to determine the next action.
 - The sequence of actions **must always start with** launching the browser at a URL, and **must always end with** closing the browser. If you need to visit a new URL that is not possible to navigate to from the current webpage, you must first close the browser, then launch again at the new URL.
 - While the browser is active, only the \`browser_action\` tool can be used. No other tools should be called during this time. You may proceed to use other tools only after closing the browser. For example if you run into an error and need to fix a file, you must close the browser, then use other tools to make the necessary changes, then re-launch the browser to verify the result.
@@ -21,12 +22,13 @@ Parameters:
     * type: Type a string of text on the keyboard. You might use this after clicking on a text field to input text.
         - Use with the \`text\` parameter to provide the string to type.
     * scroll_down: Scroll down the page by one page height.
-    * scroll_up: Scroll up the page by one page height.
-    * execute_js: Execute JavaScript code in the browser context.
+    * scroll_up: Scroll up the page by one page height.` +
+		// kilocode_change
+		`* execute_js: Execute JavaScript code in the browser context.
         - Use with the \`text\` parameter to provide the JavaScript code to execute.
         - Returns the result of the JavaScript evaluation directly in the response.
-        - Useful for extracting data from the page or modifying the page's content.
-    * close: Close the Puppeteer-controlled browser instance. This **must always be the final browser action**.
+        - Useful for extracting data from the page or modifying the page's content.` +
+		`* close: Close the Puppeteer-controlled browser instance. This **must always be the final browser action**.
         - Example: \`<action>close</action>\`
 - url: (optional) Use this for providing the URL for the \`launch\` action.
     * Example: <url>https://example.com</url>
@@ -53,4 +55,5 @@ Example: Requesting to click on the element at coordinates 450,300
 <action>click</action>
 <coordinate>450,300</coordinate>
 </browser_action>`
+	)
 }

--- a/src/core/tools/browserActionTool.ts
+++ b/src/core/tools/browserActionTool.ts
@@ -112,6 +112,9 @@ export async function browserActionTool(
 					case "scroll_up":
 						browserActionResult = await cline.browserSession.scrollUp()
 						break
+					case "execute_js":
+						browserActionResult = await cline.browserSession.executeJs(text!)
+						break
 					case "close":
 						browserActionResult = await cline.browserSession.closeBrowser()
 						break
@@ -124,10 +127,19 @@ export async function browserActionTool(
 				case "type":
 				case "scroll_down":
 				case "scroll_up":
+				case "execute_js":
 					await cline.say("browser_action_result", JSON.stringify(browserActionResult))
 					pushToolResult(
 						formatResponse.toolResult(
-							`The browser action has been executed. The console logs and screenshot have been captured for your analysis.\n\nConsole logs:\n${
+							`The browser action has been executed. The console logs and screenshot have been captured for your analysis.\n\n${
+								action === "execute_js" && browserActionResult?.evaluationResult !== undefined
+									? `JavaScript Evaluation Result:\n${
+											typeof browserActionResult.evaluationResult === "object"
+												? JSON.stringify(browserActionResult.evaluationResult, null, 2)
+												: String(browserActionResult.evaluationResult)
+										}\n\n`
+									: ""
+							}Console logs:\n${
 								browserActionResult?.logs || "(No new logs)"
 							}\n\n(REMEMBER: if you need to proceed to using non-\`browser_action\` tools or launch a new browser, you MUST first close cline browser. For example, if after analyzing the logs and screenshot you need to edit a file, you must first close the browser before you can use the write_to_file tool.)`,
 							browserActionResult?.screenshot ? [browserActionResult.screenshot] : [],

--- a/src/core/tools/browserActionTool.ts
+++ b/src/core/tools/browserActionTool.ts
@@ -112,6 +112,7 @@ export async function browserActionTool(
 					case "scroll_up":
 						browserActionResult = await cline.browserSession.scrollUp()
 						break
+					// kilocode_change
 					case "execute_js":
 						browserActionResult = await cline.browserSession.executeJs(text!)
 						break
@@ -127,11 +128,13 @@ export async function browserActionTool(
 				case "type":
 				case "scroll_down":
 				case "scroll_up":
+				// kilocode_change
 				case "execute_js":
 					await cline.say("browser_action_result", JSON.stringify(browserActionResult))
 					pushToolResult(
 						formatResponse.toolResult(
 							`The browser action has been executed. The console logs and screenshot have been captured for your analysis.\n\n${
+								// kilocode_change
 								action === "execute_js" && browserActionResult?.evaluationResult !== undefined
 									? `JavaScript Evaluation Result:\n${
 											typeof browserActionResult.evaluationResult === "object"

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -538,4 +538,15 @@ export class BrowserSession {
 			})
 		})
 	}
+
+	async executeJs(code: string): Promise<BrowserActionResult> {
+		let evaluationResult: any = undefined
+		const result = await this.doAction(async (page) => {
+			evaluationResult = await page.evaluate(code)
+		})
+		return {
+			...result,
+			evaluationResult: evaluationResult,
+		}
+	}
 }

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -538,7 +538,7 @@ export class BrowserSession {
 			})
 		})
 	}
-
+	// kilocode_change
 	async executeJs(code: string): Promise<BrowserActionResult> {
 		let evaluationResult: any = undefined
 		const result = await this.doAction(async (page) => {

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -240,6 +240,7 @@ export const browserActions = [
 	"type",
 	"scroll_down",
 	"scroll_up",
+	// kilocode_change
 	"execute_js",
 	"close",
 ] as const
@@ -256,6 +257,7 @@ export type BrowserActionResult = {
 	logs?: string
 	currentUrl?: string
 	currentMousePosition?: string
+	// kilocode_change
 	evaluationResult?: any
 }
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -233,7 +233,16 @@ export interface ClineSayTool {
 }
 
 // Must keep in sync with system prompt.
-export const browserActions = ["launch", "click", "hover", "type", "scroll_down", "scroll_up", "close"] as const
+export const browserActions = [
+	"launch",
+	"click",
+	"hover",
+	"type",
+	"scroll_down",
+	"scroll_up",
+	"execute_js",
+	"close",
+] as const
 
 export type BrowserAction = (typeof browserActions)[number]
 
@@ -242,12 +251,12 @@ export interface ClineSayBrowserAction {
 	coordinate?: string
 	text?: string
 }
-
 export type BrowserActionResult = {
 	screenshot?: string
 	logs?: string
 	currentUrl?: string
 	currentMousePosition?: string
+	evaluationResult?: any
 }
 
 export interface ClineAskUseMcpServer {

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -252,6 +252,7 @@ export interface ClineSayBrowserAction {
 	coordinate?: string
 	text?: string
 }
+
 export type BrowserActionResult = {
 	screenshot?: string
 	logs?: string


### PR DESCRIPTION
## Context

Currently, the browser action cannot execute arbitrary JavaScript code. This feature is essential for finding items on a page during testing or preparing test scenarios.

## Implementation

Analogous to other actions

## Task completion examples 

```xml
Now I'll change the background color to red using JavaScript:

<browser_action>
<action>execute_js</action>
<text>document.body.style.backgroundColor = 'red';</text>
</browser_action>

---

**User:**

[browser_action for 'execute_js'] Result:
The browser action has been executed. The console logs and screenshot have been captured for your analysis.

JavaScript Evaluation Result:
red

Console logs:
(No new logs)
```
```xml
Now I'll get all the page content as innerText:

<browser_action>
<action>execute_js</action>
<text>document.body.innerText;</text>
</browser_action>

---

**User:**

[browser_action for 'execute_js'] Result:
The browser action has been executed. The console logs and screenshot have been captured for your analysis.

JavaScript Evaluation Result:
Wikipedia
The Free Encyclopedia
English
6,974,000+ articles
日本語
```
## How to Test

Ask the agent to navigate to a website and copy text or html from it or change the appearance in the browser.


