### PR TITLE
Add shortkey to activate Kilo Code and activate chatbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kilo-code",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kilo-code",
-			"version": "4.10.0",
+			"version": "4.11.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",
 				"@anthropic-ai/sdk": "^0.37.0",

--- a/package.json
+++ b/package.json
@@ -227,6 +227,19 @@
 				"command": "kilo-code.setCustomStoragePath",
 				"title": "Set Custom Storage Path",
 				"category": "Kilo Code"
+			},
+			{
+				"command": "kilo-code.focusChatInput",
+				"title": "Focus Chat Input",
+				"category": "Kilo Code"
+			}
+		],
+		"keybindings": [
+			{
+				"command": "kilo-code.focusChatInput",
+				"key": "ctrl+shift+i",
+				"mac": "cmd+shift+i",
+				"when": "editorTextFocus || terminalFocus || viewFocus"
 			}
 		],
 		"menus": {

--- a/package.json
+++ b/package.json
@@ -118,8 +118,15 @@
 			"activitybar": [
 				{
 					"id": "kilo-code-ActivityBar",
-					"title": "Kilo Code",
-					"icon": "assets/icons/kilo.png"
+					"title": "Kilo Code (⇧⌘I)",
+					"icon": "assets/icons/kilo.png",
+					"when": "isMac"
+				},
+				{
+					"id": "kilo-code-ActivityBar",
+					"title": "Kilo Code (shift-ctrl-I)",
+					"icon": "assets/icons/kilo.png",
+					"when": "!isMac"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Kilo Code",
 	"description": "A whole dev team of AI agents in your editor.",
 	"publisher": "kilocode",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"icon": "assets/icons/logo-outline-black.png",
 	"galleryBanner": {
 		"color": "#FFFFFF",

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -114,6 +114,27 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 			const { promptForCustomStoragePath } = await import("../shared/storagePathManager")
 			await promptForCustomStoragePath()
 		},
+		// kilocode_change begin
+		"kilo-code.focusChatInput": async () => {
+			let visibleProvider = getVisibleProviderOrLog(outputChannel)
+
+			if (!visibleProvider) {
+				await vscode.commands.executeCommand("kilo-code.SidebarProvider.focus")
+				await delay(100)
+
+				visibleProvider = getVisibleProviderOrLog(outputChannel)
+
+				// If still no visible provider, try opening in a new tab
+				if (!visibleProvider) {
+					const tabProvider = await openClineInNewTab({ context, outputChannel })
+					await delay(100)
+					visibleProvider = tabProvider
+				}
+			}
+
+			visibleProvider?.postMessageToWebview({ type: "action", action: "focusChatInput" })
+		},
+		// kilocode_change end
 	}
 }
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -79,6 +79,7 @@ export interface ExtensionMessage {
 		| "historyButtonClicked"
 		| "promptsButtonClicked"
 		| "didBecomeVisible"
+		| "focusChatInput" // kilocode_change
 	invoke?: "newChat" | "sendMessage" | "primaryButtonClick" | "secondaryButtonClick" | "setChatBoxMessage"
 	state?: ExtensionState
 	images?: string[]

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -43,6 +43,7 @@ const App = () => {
 	})
 
 	const settingsRef = useRef<SettingsViewRef>(null)
+	const chatViewRef = useRef<{ focusInput: () => void }>(null) // kilocode_change
 
 	const switchTab = useCallback((newTab: Tab) => {
 		if (settingsRef.current?.checkUnsaveChanges) {
@@ -57,6 +58,16 @@ const App = () => {
 			const message: ExtensionMessage = e.data
 
 			if (message.type === "action" && message.action) {
+				// kilocode_change begin
+				if (message.action === "focusChatInput") {
+					if (tab !== "chat") {
+						switchTab("chat")
+					}
+					chatViewRef.current?.focusInput()
+					return
+				}
+				// kilocode_change end
+
 				const newTab = tabsByMessageAction[message.action]
 
 				if (newTab) {
@@ -69,7 +80,8 @@ const App = () => {
 				setHumanRelayDialogState({ isOpen: true, requestId, promptText })
 			}
 		},
-		[switchTab],
+		// kilocode_change: add tab
+		[tab, switchTab],
 	)
 
 	useEvent("message", onMessage)
@@ -101,6 +113,7 @@ const App = () => {
 				<SettingsView ref={settingsRef} onDone={() => setTab("chat")} onOpenMcp={() => setTab("mcp")} />
 			)}
 			<ChatView
+				ref={chatViewRef}
 				isHidden={tab !== "chat"}
 				showAnnouncement={showAnnouncement}
 				hideAnnouncement={() => setShowAnnouncement(false)}

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1,6 +1,6 @@
 import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import debounce from "debounce"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react" // kilocode_change
 import { useDeepCompareEffect, useEvent, useMount } from "react-use"
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import styled from "styled-components"
@@ -45,7 +45,10 @@ export const MAX_IMAGES_PER_MESSAGE = 20 // Anthropic limits to 20 images
 
 const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0
 
-const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryView }: ChatViewProps) => {
+const ChatView = (
+	{ isHidden, showAnnouncement, hideAnnouncement, showHistoryView }: ChatViewProps,
+	ref: React.ForwardedRef<{ focusInput: () => void }>, // kilocode_change
+) => {
 	const { t } = useAppTranslation()
 	const modeShortcutText = `${isMac ? "⌘" : "Ctrl"} + . ${t("chat:forNextMode")}`
 	const {
@@ -81,6 +84,16 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	const textAreaRef = useRef<HTMLTextAreaElement>(null)
 	const [textAreaDisabled, setTextAreaDisabled] = useState(false)
 	const [selectedImages, setSelectedImages] = useState<string[]>([])
+
+	// kilocode_change begin
+	React.useImperativeHandle(ref, () => ({
+		focusInput: () => {
+			if (textAreaRef.current) {
+				textAreaRef.current.focus()
+			}
+		},
+	}))
+	// kilcode_change end
 
 	// we need to hold on to the ask because useEffect > lastMessage will always let us know when an ask comes in and handle it, but by the time handleMessage is called, the last message might not be the ask anymore (it could be a say that followed)
 	const [clineAsk, setClineAsk] = useState<ClineAsk | undefined>(undefined)
@@ -1373,6 +1386,8 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	)
 }
 
+const ChatViewWithRef = React.forwardRef<{ focusInput: () => void }, ChatViewProps>(ChatView) // kilocode_change
+
 const ScrollToBottomButton = styled.div`
 	background-color: color-mix(in srgb, var(--vscode-toolbar-hoverBackground) 55%, transparent);
 	border-radius: 3px;
@@ -1393,4 +1408,4 @@ const ScrollToBottomButton = styled.div`
 	}
 `
 
-export default ChatView
+export default ChatViewWithRef // kilocode_Change: export ChatViewWithRef instead of ChatView


### PR DESCRIPTION
As suggested on [Discord](https://discord.com/channels/1349288496988160052/1355527689272033391/1358215673045848274), adding a key-combination to activate Kilo Code and focus in the chat box. Still thinking about the exact key combo to use that won't interfere with anything. Any suggestions are welcome!

- Resolves #150 