### PR TITLE
Fix: display the actual model used in frontend when using kilocode provider

### DIFF
--- a/src/api/providers/kilocode-openrouter.ts
+++ b/src/api/providers/kilocode-openrouter.ts
@@ -1,6 +1,7 @@
 import { ApiHandlerOptions } from "../../shared/api"
 import { OpenRouterHandler } from "./openrouter"
 import { getModelParams } from "../getModelParams"
+import { kilocodeOpenrouterModels } from "../../shared/kilocode/api"
 
 /**
  * A custom OpenRouter handler that overrides the getModel function
@@ -24,33 +25,11 @@ export class KilocodeOpenrouterHandler extends OpenRouterHandler {
 
 		// TODO: use the models that have been fetched from openrouter.
 		// for now we are using the hardcoded models
-		if (selectedModel === "claude37") {
-			id = "anthropic/claude-3.7-sonnet"
-			info = {
-				maxTokens: 8192,
-				contextWindow: 200_000,
-				supportsImages: true,
-				supportsComputerUse: true,
-				supportsPromptCache: true,
-				inputPrice: 3.0,
-				outputPrice: 15.0,
-				cacheWritesPrice: 3.75,
-				cacheReadsPrice: 0.3,
-				description: "Claude 3.7 Sonnet via OpenRouter",
-				thinking: false,
-			}
-		} else if (selectedModel === "gemini25") {
+		// when updating, be sure to also update 'normalizeApiConfiguration' in ApiOptions.tsx
+		// because frontend needs to display the proper model
+		if (selectedModel === "gemini25") {
 			id = "google/gemini-2.5-pro-preview-03-25"
-			info = {
-				maxTokens: 65_536,
-				contextWindow: 1_000_000,
-				supportsImages: true,
-				supportsComputerUse: true,
-				supportsPromptCache: true,
-				inputPrice: 1.25,
-				outputPrice: 10,
-				description: "Gemini 2.5 Pro via OpenRouter",
-			}
+			info = kilocodeOpenrouterModels["google/gemini-2.5-pro-preview-03-25"]
 		} else {
 			throw new Error(`Unsupported model: ${selectedModel}`)
 		}

--- a/src/shared/kilocode/api.ts
+++ b/src/shared/kilocode/api.ts
@@ -1,0 +1,12 @@
+export const kilocodeOpenrouterModels = {
+	"google/gemini-2.5-pro-preview-03-25": {
+		maxTokens: 65_536,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsComputerUse: true,
+		supportsPromptCache: true,
+		inputPrice: 1.25,
+		outputPrice: 10,
+		description: "Gemini 2.5 Pro via OpenRouter",
+	},
+}

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -39,6 +39,7 @@ import {
 	fireworksModels,
 	ApiProvider,
 } from "../../../../src/shared/api"
+import { kilocodeOpenrouterModels } from "../../../../src/shared/kilocode/api" // kilocode_change
 import { ExtensionMessage } from "../../../../src/shared/ExtensionMessage"
 
 import { vscode } from "@/utils/vscode"
@@ -1876,6 +1877,19 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration) {
 			}
 		case "fireworks":
 			return getProviderData(fireworksModels, fireworksDefaultModelId)
+		// begin kilocode_change
+		case "kilocode":
+			// TODO: in line with kilocode-openrouter provider use hardcoded for now but info needs to be fetched later
+			return {
+				selectedProvider: provider,
+				selectedModelId:
+					apiConfiguration?.kilocodeModel === "gemini25" ? "Gemini 2.5 Pro" : "Claude 3.7 Sonnet",
+				selectedModelInfo:
+					apiConfiguration?.kilocodeModel === "gemini25"
+						? kilocodeOpenrouterModels["google/gemini-2.5-pro-preview-03-25"]
+						: anthropicModels["claude-3-7-sonnet-20250219"],
+			}
+		// end kilocode_change
 		default:
 			return getProviderData(anthropicModels, anthropicDefaultModelId)
 	}


### PR DESCRIPTION
As mentioned [on Discord](https://discord.com/channels/1349288496988160052/1349358609678598277/1360954717404139592) the wrong model id was displayed in the frontend when using kilocode as a provider. This fixes that