### PR TITLE
Move development information out of README

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,25 @@
+1. **Clone** the repo:
+    ```bash
+    git clone https://github.com/Kilo-Org/kilocode.git
+    ```
+2. **Install dependencies**:
+    ```bash
+    npm run install:all
+    ```
+3. **Build** the extension:
+    ```bash
+    npm run build
+    ```
+    - A `.vsix` file will appear in the `bin/` directory.
+4. **Install** the `.vsix` manually if desired:
+    ```bash
+    code --install-extension bin/kilo-code-4.0.0.vsix
+    ```
+5. **Start the webview (Vite/React app with HMR)**:
+    ```bash
+    npm run dev
+    ```
+6. **Debug**:
+    - Press `F5` (or **Run** → **Start Debugging**) in VSCode to open a new session with Kilo Code loaded.
+
+Changes to the webview will appear immediately. Changes to the core extension will require a restart of the extension host.

--- a/README.md
+++ b/README.md
@@ -46,28 +46,4 @@ Get started with $20 of free credits to experience the power of Gemini 2.5 Pro, 
 
 ## Local Setup & Development
 
-1. **Clone** the repo:
-    ```bash
-    git clone https://github.com/Kilo-Org/kilocode.git
-    ```
-2. **Install dependencies**:
-    ```bash
-    npm run install:all
-    ```
-3. **Build** the extension:
-    ```bash
-    npm run build
-    ```
-    - A `.vsix` file will appear in the `bin/` directory.
-4. **Install** the `.vsix` manually if desired:
-    ```bash
-    code --install-extension bin/kilo-code-4.0.0.vsix
-    ```
-5. **Start the webview (Vite/React app with HMR)**:
-    ```bash
-    npm run dev
-    ```
-6. **Debug**:
-    - Press `F5` (or **Run** → **Start Debugging**) in VSCode to open a new session with Kilo Code loaded.
-
-Changes to the webview will appear immediately. Changes to the core extension will require a restart of the extension host.
+See [DEVELOPMENT.md](/DEVELOPMENT.md)


### PR DESCRIPTION
## Context

Multiple users have been confused by the development information in the README (that goes into the VSCode Marketplace listing)

## Implementation

This removes it and moves it to a DEVELOPMENT.md

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->
