### PR TITLE
Simplify backend debugging

### DIFF
--- a/src/api/providers/kilocode.ts
+++ b/src/api/providers/kilocode.ts
@@ -24,7 +24,7 @@ export class KiloCodeHandler extends BaseProvider implements SingleCompletionHan
 			this.handler = new KiloCodeAnthropicHandler(options)
 		} else if (openrouterModels.includes(modelType)) {
 			// Determine the correct OpenRouter model ID based on the selected KiloCode model type
-			const baseUri = KiloBaseUri(options)
+			const baseUri = getKiloBaseUri(options)
 			const openrouterOptions = {
 				...options,
 				openRouterBaseUrl: `${baseUri}/api/openrouter/`,
@@ -82,7 +82,7 @@ export class KiloCodeAnthropicHandler extends BaseProvider implements SingleComp
 	constructor(options: ApiHandlerOptions) {
 		super()
 		this.options = options
-		const baseUri = KiloBaseUri(options)
+		const baseUri = getKiloBaseUri(options)
 		this.client = new Anthropic({
 			authToken: this.options.kilocodeToken,
 			baseURL: `${baseUri}/api/claude/`,
@@ -322,7 +322,7 @@ export class KiloCodeAnthropicHandler extends BaseProvider implements SingleComp
 	}
 }
 
-function KiloBaseUri(options: ApiHandlerOptions) {
+function getKiloBaseUri(options: ApiHandlerOptions) {
 	try {
 		const token = options.kilocodeToken as string
 		const payload_string = token.split(".")[1]

--- a/src/api/providers/kilocode.ts
+++ b/src/api/providers/kilocode.ts
@@ -24,11 +24,10 @@ export class KiloCodeHandler extends BaseProvider implements SingleCompletionHan
 			this.handler = new KiloCodeAnthropicHandler(options)
 		} else if (openrouterModels.includes(modelType)) {
 			// Determine the correct OpenRouter model ID based on the selected KiloCode model type
-
+			const baseUri = KiloBaseUri(options)
 			const openrouterOptions = {
 				...options,
-				openRouterBaseUrl: "https://kilocode.ai/api/openrouter/",
-				// openRouterBaseUrl: "http://localhost:3000/api/openrouter/",
+				openRouterBaseUrl: `${baseUri}/api/openrouter/`,
 				openRouterApiKey: options.kilocodeToken,
 			}
 
@@ -79,29 +78,16 @@ export class KiloCodeHandler extends BaseProvider implements SingleCompletionHan
 export class KiloCodeAnthropicHandler extends BaseProvider implements SingleCompletionHandler {
 	private options: ApiHandlerOptions
 	private client: Anthropic
-	private baseURL: string = "https://kilocode.ai"
-	// private baseURL: string = "https://localhost:3000"
 
 	constructor(options: ApiHandlerOptions) {
 		super()
 		this.options = options
-		this.getBaseURL()
+		const baseUri = KiloBaseUri(options)
 		this.client = new Anthropic({
 			authToken: this.options.kilocodeToken,
-			baseURL: `${this.baseURL}/api/claude/`,
+			baseURL: `${baseUri}/api/claude/`,
 			apiKey: null, //ignore anthropic apiKey, even if set in env vars - it's not valid for KiloCode anyhow
 		})
-	}
-
-	private getBaseURL() {
-		try {
-			const token = this.options.kilocodeToken as string
-			const payload_string = token.split(".")[1]
-			const payload = JSON.parse(Buffer.from(payload_string, "base64").toString())
-			if (payload.env === "development") this.baseURL = "http://localhost:3000"
-		} catch (_error) {
-			console.warn("Failed to get base URL from Kilo Code token")
-		}
 	}
 
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
@@ -334,4 +320,17 @@ export class KiloCodeAnthropicHandler extends BaseProvider implements SingleComp
 			return super.countTokens(content)
 		}
 	}
+}
+
+function KiloBaseUri(options: ApiHandlerOptions) {
+	try {
+		const token = options.kilocodeToken as string
+		const payload_string = token.split(".")[1]
+		const payload = JSON.parse(Buffer.from(payload_string, "base64").toString())
+		//note: this is UNTRUSTED, so we need to make sure we're OK with this being manipulated by an attacker; e.g. we should not read uri's from the JWT directly.
+		if (payload.env === "development") return "http://localhost:3000"
+	} catch (_error) {
+		console.warn("Failed to get base URL from Kilo Code token")
+	}
+	return "https://kilocode.ai"
 }


### PR DESCRIPTION
Refactor KiloCode handlers to share the same dynamic base URI based on environment, so we can debug our backend without needing to hack a url into a second locally running extension just for the url.


works on my machine