### PR TITLE
anx/better error messages

### DIFF
--- a/src/api/providers/kilocode.ts
+++ b/src/api/providers/kilocode.ts
@@ -138,10 +138,10 @@ export class KiloCodeAnthropicHandler extends BaseProvider implements SingleComp
 									typeof message.content === "string"
 										? [{ type: "text", text: message.content, cache_control: cacheControl }]
 										: message.content.map((content, contentIndex) =>
-											contentIndex === message.content.length - 1
-												? { ...content, cache_control: cacheControl }
-												: content,
-										),
+												contentIndex === message.content.length - 1
+													? { ...content, cache_control: cacheControl }
+													: content,
+											),
 							}
 						}
 						return message
@@ -254,8 +254,8 @@ export class KiloCodeAnthropicHandler extends BaseProvider implements SingleComp
 						"---\n" +
 						`### 🔒 [Login Now](${this.options.baseURL}/profile?source=${vscodeEnv.uriScheme})\n` +
 						"---\n" +
-						"Please log in to Kilo Code.\n" +
-						"Kilo Code has a free tier with $20 worth of Claude 3.7 Sonnet tokens.\n" +
+						"#### Please log in to Kilo Code.\n" +
+						"Kilo Code has a free tier with $20 worth of Claude 3.7 Sonnet tokens.\n\n" +
 						"We'll give out more free tokens if you leave useful feedback.",
 				}
 			}
@@ -265,10 +265,9 @@ export class KiloCodeAnthropicHandler extends BaseProvider implements SingleComp
 					text:
 						"## 😭 Credits depleted\n" +
 						"---\n" +
-						`### 💳 [Top-up now](${this.options.baseURL}/payments/extension/topup?source=${vscodeEnv.uriScheme})\n` +
-						"#### 💫 To keep the magic going... 💫\n" +
+						`### 👤 [Top-up on your Profile](${this.options.baseURL}/profile)\n` +
 						"---\n" +
-						`### 👤 [Show Profile](${this.options.baseURL}/profile)\n`,
+						"💫 To keep the magic going... 💫\n",
 				}
 			} else {
 				yield {
@@ -277,8 +276,9 @@ export class KiloCodeAnthropicHandler extends BaseProvider implements SingleComp
 						`If you need any help please check [our homepage](${this.options.baseURL})\n\n` +
 						"Or contact us to ask for help:\n" +
 						" - [eMail](mailto:hi@kilocode.ai)\n\n" +
-						" - [Discord](https://discord.gg/4q3v6J7a)\n\n" +
-						" - [GitHub Discussions](https://github.com/kilocode/discussions)\n",
+						" - [Discord](https://kilocode.ai/discord)\n\n" +
+						" - [GitHub Discussions](https://github.com/Kilo-Org/kilocode/discussions)\n" +
+						" - [Report a bug](https://github.com/Kilo-Org/kilocode/issues)\n",
 				}
 			}
 

--- a/src/api/providers/kilocode.ts
+++ b/src/api/providers/kilocode.ts
@@ -265,7 +265,7 @@ export class KiloCodeAnthropicHandler extends BaseProvider implements SingleComp
 					text:
 						"## 😭 Credits depleted\n" +
 						"---\n" +
-						`### 💳 [Top-up now](${this.options.baseURL}/profile?highlight=top-up&source=${vscodeEnv.uriScheme})\n` +
+						`### 💳 [Top-up now](${this.options.baseURL}/payments/extension/topup?source=${vscodeEnv.uriScheme})\n` +
 						"#### 💫 To keep the magic going... 💫\n" +
 						"---\n" +
 						`### 👤 [Show Profile](${this.options.baseURL}/profile)\n`,


### PR DESCRIPTION
This is my take on giving the user better error messages (you may or may not choose to keep/change the emojis)
This is specific to the anthropic handler, could be adopted for openrouter.

## Not logged in
When the user click the link they are sent to their browser immediately once they click the link. After sign-in the user should be bounced back to their IDE.
![image](https://github.com/user-attachments/assets/52f2acf2-1314-4a12-aa6f-7bb8cad58fd0)
## Out of credits
This could offer immediate top-up (requires backend changes) but for now offers the user a to-up via the profile page.
![image](https://github.com/user-attachments/assets/f2d01004-b242-44db-b7cb-3feb9169863e)
## Generic Errors
The previous version repeated the error message because the extension logged it and we included it in our message... also added some working links to get actual help :)
![image](https://github.com/user-attachments/assets/e6e00bee-b187-4b5e-8747-2267b7bc5a9e)