### PR TITLE
Make sure to pusblish a release on Github with assets before trying t…

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -51,14 +51,6 @@ jobs:
                   git tag -a "v${current_package_version}" -m "Release v${current_package_version}"
                   git push origin "v${current_package_version}"
                   echo "Successfully created and pushed git tag v${current_package_version}"
-            - name: Publish Extension
-              env:
-                  VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
-                  OVSX_PAT: ${{ secrets.OVSX_TOKEN }}
-              run: |
-                  current_package_version=$(node -p "require('./package.json').version")
-                  npm run publish:marketplace
-                  echo "Successfully published version $current_package_version to VS Code Marketplace"
             - name: Create GitHub Release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -84,3 +76,11 @@ jobs:
                     --target ${{ env.GIT_REF }} \
                     bin/kilo-code-${current_package_version}.vsix
                   echo "Successfully created GitHub Release v${current_package_version}"
+            - name: Publish Extension
+              env:
+                  VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
+                  OVSX_PAT: ${{ secrets.OVSX_TOKEN }}
+              run: |
+                  current_package_version=$(node -p "require('./package.json').version")
+                  npm run publish:marketplace
+                  echo "Successfully published version $current_package_version to VS Code Marketplace"


### PR DESCRIPTION
This makes releasing to the market places the last step so that even if it fails we can re-run it or manually publish them but we will have a proper release with release notes instead of only a tag like now.