### PR TITLE
Fix settingview appearing not to save when hitting save button

### DIFF
--- a/.changeset/five-games-run.md
+++ b/.changeset/five-games-run.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix settingview appearing not to save when hitting save button

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -167,13 +167,12 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, o
 		setChangeDetected(false)
 	}, [currentApiConfigName, extensionState, isChangeDetected])
 
-	// kilocode_change
+	// kilocode_change start
 	// Temporary way of making sure that the Settings view updates its local state properly when receiving
 	// api keys from providers that support url callbacks. This whole Settings View needs proper with this local state thing later
 	useEffect(() => {
 		setCachedState((prevCachedState) => ({ ...prevCachedState, ...extensionState }))
 		setChangeDetected(false)
-		// }
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		extensionState.apiConfiguration?.kilocodeToken,
@@ -181,6 +180,15 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, o
 		extensionState.apiConfiguration?.glamaApiKey,
 		extensionState.apiConfiguration?.requestyApiKey,
 	])
+
+	useEffect(() => {
+		// Only update if we're not already detecting changes
+		// This prevents overwriting user changes that haven't been saved yet
+		if (!isChangeDetected) {
+			setCachedState(extensionState)
+		}
+	}, [extensionState, isChangeDetected])
+	// kilocode_change end
 
 	// Bust the cache when settings are imported.
 	useEffect(() => {
@@ -276,6 +284,9 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, o
 			vscode.postMessage({ type: "alwaysAllowModeSwitch", bool: alwaysAllowModeSwitch })
 			vscode.postMessage({ type: "alwaysAllowSubtasks", bool: alwaysAllowSubtasks })
 			vscode.postMessage({ type: "upsertApiConfiguration", text: currentApiConfigName, apiConfiguration })
+
+			// Update cachedState to match the current state to prevent isChangeDetected from being set back to true
+			setCachedState((prevState) => ({ ...prevState, ...extensionState }))
 			setChangeDetected(false)
 		}
 	}


### PR DESCRIPTION
This fixes the save button re-enabling itself when hitting it in certain cases. The real issue is the useEffect used for detecting changes which we will attack in our settings menu revamp but this quickfix enables users to see that their changes are actually saved which is quite important of course.

- fixes #246 