### PR TITLE
Fix "Some text unreadable in Light high contrast theme" issue

### DIFF
--- a/.changeset/slow-bears-peel.md
+++ b/.changeset/slow-bears-peel.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix "Some text unreadable in Light high contrast theme" issue

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,7 +13,7 @@
     - A `.vsix` file will appear in the `bin/` directory.
 4. **Install** the `.vsix` manually if desired:
     ```bash
-    code --install-extension bin/kilo-code-4.0.0.vsix
+    code --install-extension "$(ls -1v bin/kilo-code-*.vsix | tail -n1)"
     ```
 5. **Start the webview (Vite/React app with HMR)**:
     ```bash

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -103,8 +103,8 @@ const StyledMarkdown = styled.div`
 		overflow-wrap: anywhere;
 	}
 
-	/* Target only Dark High Contrast theme using the data attribute VS Code adds to the body */
-	body[data-vscode-theme-kind="vscode-high-contrast"] & code:not(pre > code) {
+	/* Target only high-contrast theme(s) using the data attribute VS Code adds to the body */
+	body[data-vscode-theme-kind*="high-contrast"] & code:not(pre > code) {
 		color: var(
 			--vscode-editorInlayHint-foreground,
 			var(--vscode-symbolIcon-stringForeground, var(--vscode-charts-orange, #e9a700))
@@ -160,7 +160,7 @@ const StyledPre = styled.pre<{ theme: any }>`
 
 	${(props) =>
 		Object.keys(props.theme)
-			.map((key, index) => {
+			.map((key) => {
 				return `
       & ${key} {
         color: ${props.theme[key]};
@@ -195,7 +195,7 @@ const MarkdownBlock = memo(({ markdown }: MarkdownBlockProps) => {
 		],
 		rehypeReactOptions: {
 			components: {
-				pre: ({ node, children, ...preProps }: any) => {
+				pre: ({ _node, children, ...preProps }: any) => {
 					if (Array.isArray(children) && children.length === 1 && React.isValidElement(children[0])) {
 						const child = children[0] as React.ReactElement<{ className?: string }>
 						if (child.props?.className?.includes("language-mermaid")) {


### PR DESCRIPTION
Fix "Some text unreadable in Light high contrast theme" issue
https://github.com/Kilo-Org/kilocode/issues/249

Previously the code selector was only matching the high contrast dark theme, but now it will also apply to the light HC theme as well.

**Before**
<img width="383" alt="image" src="https://github.com/user-attachments/assets/b73d70dc-3ceb-49d3-a32d-6e0ae94ab5e3" />

**After**
<img width="386" alt="image" src="https://github.com/user-attachments/assets/a36cd474-2ab9-497b-b38f-751ca3578e85" />

Does not break other themes:
<img width="384" alt="image" src="https://github.com/user-attachments/assets/f8e0d421-a5bf-4838-91b7-9891ecffc4a5" />
<img width="383" alt="image" src="https://github.com/user-attachments/assets/cbe515e2-5766-4e9e-a554-6dfb6152660c" />

