### PR TITLE
Switch mode icons from unicode emojis to codicons

### DIFF
--- a/.changeset/nervous-llamas-retire.md
+++ b/.changeset/nervous-llamas-retire.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Switch mode icons from unicode emojis to codicons

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -286,6 +286,7 @@ type GlobalSettings = {
 					  ]
 				)[]
 				source?: ("global" | "project") | undefined
+				iconName?: string | undefined
 		  }[]
 		| undefined
 	customModePrompts?:

--- a/src/exports/types.ts
+++ b/src/exports/types.ts
@@ -289,6 +289,7 @@ type GlobalSettings = {
 					  ]
 				)[]
 				source?: ("global" | "project") | undefined
+				iconName?: string | undefined
 		  }[]
 		| undefined
 	customModePrompts?:

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -233,6 +233,7 @@ export const modeConfigSchema = z.object({
 	customInstructions: z.string().optional(),
 	groups: groupEntryArraySchema,
 	source: z.enum(["global", "project"]).optional(),
+	iconName: z.string().optional(),
 })
 
 export type ModeConfig = z.infer<typeof modeConfigSchema>

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -233,7 +233,7 @@ export const modeConfigSchema = z.object({
 	customInstructions: z.string().optional(),
 	groups: groupEntryArraySchema,
 	source: z.enum(["global", "project"]).optional(),
-	iconName: z.string().optional(),
+	iconName: z.string().optional(), // kilocode_change
 })
 
 export type ModeConfig = z.infer<typeof modeConfigSchema>

--- a/src/shared/__tests__/modes.test.ts
+++ b/src/shared/__tests__/modes.test.ts
@@ -271,7 +271,7 @@ describe("FileRestrictionError", () => {
 			expect(debugMode).toBeDefined()
 			expect(debugMode).toMatchObject({
 				slug: "debug",
-				name: "🪲 Debug",
+				name: "Debug",
 				roleDefinition:
 					"You are Kilo Code, an expert software debugger specializing in systematic problem diagnosis and resolution.",
 				groups: ["read", "edit", "browser", "command", "mcp"],
@@ -292,7 +292,7 @@ describe("FileRestrictionError", () => {
 			const result = await getFullModeDetails("debug")
 			expect(result).toMatchObject({
 				slug: "debug",
-				name: "🪲 Debug",
+				name: "Debug",
 				roleDefinition:
 					"You are Kilo Code, an expert software debugger specializing in systematic problem diagnosis and resolution.",
 			})

--- a/src/shared/__tests__/modes.test.ts
+++ b/src/shared/__tests__/modes.test.ts
@@ -271,7 +271,7 @@ describe("FileRestrictionError", () => {
 			expect(debugMode).toBeDefined()
 			expect(debugMode).toMatchObject({
 				slug: "debug",
-				name: "Debug",
+				name: "Debug", // kilocode_change
 				roleDefinition:
 					"You are Kilo Code, an expert software debugger specializing in systematic problem diagnosis and resolution.",
 				groups: ["read", "edit", "browser", "command", "mcp"],
@@ -292,7 +292,7 @@ describe("FileRestrictionError", () => {
 			const result = await getFullModeDetails("debug")
 			expect(result).toMatchObject({
 				slug: "debug",
-				name: "Debug",
+				name: "Debug", // kilocode_change
 				roleDefinition:
 					"You are Kilo Code, an expert software debugger specializing in systematic problem diagnosis and resolution.",
 			})

--- a/src/shared/modes.ts
+++ b/src/shared/modes.ts
@@ -54,14 +54,16 @@ export function getToolsForMode(groups: readonly GroupEntry[]): string[] {
 export const modes: readonly ModeConfig[] = [
 	{
 		slug: "code",
-		name: "💻 Code",
+		name: "Code",
+		iconName: "codicon-code",
 		roleDefinition:
 			"You are Kilo Code, a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.",
 		groups: ["read", "edit", "browser", "command", "mcp"],
 	},
 	{
 		slug: "architect",
-		name: "🏗️ Architect",
+		name: "Architect",
+		iconName: "codicon-type-hierarchy-sub",
 		roleDefinition:
 			"You are Kilo Code, an experienced technical leader who is inquisitive and an excellent planner. Your goal is to gather information and get context to create a detailed plan for accomplishing the user's task, which the user will review and approve before they switch into another mode to implement the solution.",
 		groups: ["read", ["edit", { fileRegex: "\\.md$", description: "Markdown files only" }], "browser", "mcp"],
@@ -70,7 +72,8 @@ export const modes: readonly ModeConfig[] = [
 	},
 	{
 		slug: "ask",
-		name: "❓ Ask",
+		name: "Ask",
+		iconName: "codicon-question",
 		roleDefinition:
 			"You are Kilo Code, a knowledgeable technical assistant focused on answering questions and providing information about software development, technology, and related topics.",
 		groups: ["read", "browser", "mcp"],
@@ -79,7 +82,8 @@ export const modes: readonly ModeConfig[] = [
 	},
 	{
 		slug: "debug",
-		name: "🪲 Debug",
+		name: "Debug",
+		iconName: "codicon-bug",
 		roleDefinition:
 			"You are Kilo Code, an expert software debugger specializing in systematic problem diagnosis and resolution.",
 		groups: ["read", "edit", "browser", "command", "mcp"],
@@ -88,7 +92,8 @@ export const modes: readonly ModeConfig[] = [
 	},
 	{
 		slug: "orchestrator",
-		name: "🪃 Orchestrator",
+		name: "Orchestrator",
+		iconName: "codicon-run-all",
 		roleDefinition:
 			"You are Kilo Code, a strategic workflow orchestrator who coordinates complex tasks by delegating them to appropriate specialized modes. You have a comprehensive understanding of each mode's capabilities and limitations, allowing you to effectively break down complex problems into discrete tasks that can be solved by different specialists.",
 		groups: [],

--- a/src/shared/modes.ts
+++ b/src/shared/modes.ts
@@ -54,16 +54,20 @@ export function getToolsForMode(groups: readonly GroupEntry[]): string[] {
 export const modes: readonly ModeConfig[] = [
 	{
 		slug: "code",
+		// kilocode_change start
 		name: "Code",
 		iconName: "codicon-code",
+		// kilocode_change end
 		roleDefinition:
 			"You are Kilo Code, a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.",
 		groups: ["read", "edit", "browser", "command", "mcp"],
 	},
 	{
 		slug: "architect",
+		// kilocode_change start
 		name: "Architect",
 		iconName: "codicon-type-hierarchy-sub",
+		// kilocode_change end
 		roleDefinition:
 			"You are Kilo Code, an experienced technical leader who is inquisitive and an excellent planner. Your goal is to gather information and get context to create a detailed plan for accomplishing the user's task, which the user will review and approve before they switch into another mode to implement the solution.",
 		groups: ["read", ["edit", { fileRegex: "\\.md$", description: "Markdown files only" }], "browser", "mcp"],
@@ -72,8 +76,10 @@ export const modes: readonly ModeConfig[] = [
 	},
 	{
 		slug: "ask",
+		// kilocode_change start
 		name: "Ask",
 		iconName: "codicon-question",
+		// kilocode_change end
 		roleDefinition:
 			"You are Kilo Code, a knowledgeable technical assistant focused on answering questions and providing information about software development, technology, and related topics.",
 		groups: ["read", "browser", "mcp"],
@@ -82,8 +88,10 @@ export const modes: readonly ModeConfig[] = [
 	},
 	{
 		slug: "debug",
+		// kilocode_change start
 		name: "Debug",
 		iconName: "codicon-bug",
+		// kilocode_change end
 		roleDefinition:
 			"You are Kilo Code, an expert software debugger specializing in systematic problem diagnosis and resolution.",
 		groups: ["read", "edit", "browser", "command", "mcp"],
@@ -92,8 +100,10 @@ export const modes: readonly ModeConfig[] = [
 	},
 	{
 		slug: "orchestrator",
+		// kilocode_change start
 		name: "Orchestrator",
 		iconName: "codicon-run-all",
+		// kilocode_change end
 		roleDefinition:
 			"You are Kilo Code, a strategic workflow orchestrator who coordinates complex tasks by delegating them to appropriate specialized modes. You have a comprehensive understanding of each mode's capabilities and limitations, allowing you to effectively break down complex problems into discrete tasks that can be solved by different specialists.",
 		groups: [],

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1150,6 +1150,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									...getAllModes(customModes).map((mode) => ({
 										value: mode.slug,
 										label: mode.name,
+										codicon: mode.iconName,
 										type: DropdownOptionType.ITEM,
 									})),
 									{

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1150,7 +1150,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									...getAllModes(customModes).map((mode) => ({
 										value: mode.slug,
 										label: mode.name,
-										codicon: mode.iconName,
+										codicon: mode.iconName, // kilocode_change
 										type: DropdownOptionType.ITEM,
 									})),
 									{

--- a/webview-ui/src/components/ui/select-dropdown.tsx
+++ b/webview-ui/src/components/ui/select-dropdown.tsx
@@ -18,6 +18,7 @@ export enum DropdownOptionType {
 export interface DropdownOption {
 	value: string
 	label: string
+	codicon?: string
 	disabled?: boolean
 	type?: DropdownOptionType
 	pinned?: boolean
@@ -183,6 +184,7 @@ export const SelectDropdown = React.memo(
 				[onChange, options],
 			)
 
+			debugger
 			return (
 				<Popover open={open} onOpenChange={onOpenChange} data-testid="dropdown-root">
 					<PopoverTrigger
@@ -200,6 +202,13 @@ export const SelectDropdown = React.memo(
 							triggerClassName,
 						)}>
 						<CaretUpIcon className="pointer-events-none opacity-80 flex-shrink-0 size-3" />
+						{selectedOption?.codicon && (
+							<span
+								slot="start"
+								style={{ fontSize: "12px" }}
+								className={cn("codicon opacity-80 mr", selectedOption?.codicon)}
+							/>
+						)}
 						<span className="truncate">{displayText}</span>
 					</PopoverTrigger>
 					<PopoverContent
@@ -281,6 +290,14 @@ export const SelectDropdown = React.memo(
 														renderItem(option)
 													) : (
 														<>
+															<span
+																slot="start"
+																style={{ fontSize: "12px" }}
+																className={cn(
+																	"codicon opacity-80 mr-1.5",
+																	option.codicon,
+																)}
+															/>
 															<span>{option.label}</span>
 															{option.value === value && (
 																<Check className="ml-auto size-4 p-0.5" />

--- a/webview-ui/src/components/ui/select-dropdown.tsx
+++ b/webview-ui/src/components/ui/select-dropdown.tsx
@@ -18,7 +18,7 @@ export enum DropdownOptionType {
 export interface DropdownOption {
 	value: string
 	label: string
-	codicon?: string
+	codicon?: string // kilocode_change
 	disabled?: boolean
 	type?: DropdownOptionType
 	pinned?: boolean
@@ -202,6 +202,8 @@ export const SelectDropdown = React.memo(
 							triggerClassName,
 						)}>
 						<CaretUpIcon className="pointer-events-none opacity-80 flex-shrink-0 size-3" />
+
+						{/* kilocode_change start */}
 						{selectedOption?.codicon && (
 							<span
 								slot="start"
@@ -209,6 +211,7 @@ export const SelectDropdown = React.memo(
 								className={cn("codicon opacity-80 mr", selectedOption?.codicon)}
 							/>
 						)}
+						{/* kilocode_change end */}
 						<span className="truncate">{displayText}</span>
 					</PopoverTrigger>
 					<PopoverContent
@@ -290,6 +293,7 @@ export const SelectDropdown = React.memo(
 														renderItem(option)
 													) : (
 														<>
+															{/* kilocode_change start */}
 															<span
 																slot="start"
 																style={{ fontSize: "12px" }}
@@ -298,6 +302,7 @@ export const SelectDropdown = React.memo(
 																	option.codicon,
 																)}
 															/>
+															{/* kilocode_change end */}
 															<span>{option.label}</span>
 															{option.value === value && (
 																<Check className="ml-auto size-4 p-0.5" />


### PR DESCRIPTION
Switch mode icons from unicode emojis to codicons
Some users are unable to see the bug and orchestrator icons because they were only included in recent versions of unicode. In order to get the mode icons to appear for all users, this PR switches them to use codicon icons instead.

In the future we may remove these entirely, but it should fix the user reported issues in the meantime!

**New appearance**
<img width="432" alt="image" src="https://github.com/user-attachments/assets/cc5306a2-b578-47b9-8069-f4977d7de6bb" />

**Old appearance**
![image](https://github.com/user-attachments/assets/8768a330-8d53-4469-90ef-643a66c85bf7)

**Fixes Bug with missing icons**
![image](https://github.com/user-attachments/assets/fd195fe2-9417-4874-aff2-958ec3bbdcea)
https://github.com/Kilo-Org/kilocode/issues/322

Dev notes:
Adds iconName property to `ModeConfig` schema for unique icon association
Removes emoji characters from mode names and introduces iconName with codicon class names
Updates UI components to incorporate and display the new icon property in mode selection dropdowns
