### PR TITLE
✨ feat(extension): Add auto-restart for core changes in dev mode

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,9 +68,11 @@ To run the extension in development mode:
 ### Hot Reloading
 
 - **Webview UI changes**: Changes to the webview UI will appear immediately without restarting
-- **Core extension changes**: Changes to the core extension code require a restart of the extension host
+- **Core extension changes**: Changes to the core extension code will automatically reload the ext host
 
-> **Important**: When making changes to the core extension, you need to:
+In development mode (NODE_ENV="development"), changing the core code will trigger a `workbench.action.reloadWindow` command, so it is no longer necessary to manually start/stop the debugger and tasks.
+
+> **Important**: In production builds, when making changes to the core extension, you need to:
 >
 > 1. Stop the debugging process
 > 2. Kill any npm tasks running in the background (see screenshot below)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,6 +135,21 @@ export async function activate(context: vscode.ExtensionContext) {
 	// Implements the `RooCodeAPI` interface.
 	const socketPath = process.env.ROO_CODE_IPC_SOCKET_PATH
 	const enableLogging = typeof socketPath === "string"
+
+	// Watch the core files and automatically reload the extension host
+	const enableCoreAutoReload = process.env?.NODE_ENV === "development"
+	if (enableCoreAutoReload) {
+		console.log(`♻️♻️♻️ Core auto-reloading is ENABLED!`)
+		const watcher = vscode.workspace.createFileSystemWatcher(
+			new vscode.RelativePattern(context.extensionPath, "src/**/*.ts"),
+		)
+		watcher.onDidChange((uri) => {
+			console.log(`♻️ File changed: ${uri.fsPath}. Reloading host…`)
+			vscode.commands.executeCommand("workbench.action.reloadWindow")
+		})
+		context.subscriptions.push(watcher)
+	}
+
 	return new API(outputChannel, provider, socketPath, enableLogging)
 }
 


### PR DESCRIPTION
Until now, it was necessary to halt the debugging process, terminate all tasks, and restart the extension host to see `core` changes. Now, with this change, we now monitor the files within the core directory. If any changes are detected, we trigger a reload command within the extension, effectively enabling hot reloading within the extension

Dev notes
* I was originally going to make this a new env var something like `ENABLE_CORE_AUTO_RESTART`, but instead just based it on the NODE_ENV. Let me know if you think the env var would be better! (or something else!)

- implement file system watcher for core files
- automatically reload extension host on changes
- enhance development experience by eliminating manual restarts

📝 docs(DEVELOPMENT.md): update hot reloading instructions

- clarify auto-reload behavior for core extension changes
- specify development mode requirements for auto-reloading
