### PR TITLE
Fix wrong model after login (#213)

### DIFF
--- a/.changeset/sharp-colts-add.md
+++ b/.changeset/sharp-colts-add.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix wrong model after login (#213)

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -194,16 +194,22 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 	// kilocode_change start
 	// Temporary way of making sure that the Settings view updates its local state properly when receiving
 	// api keys from providers that support url callbacks. This whole Settings View needs proper with this local state thing later
+	const { kilocodeToken, openRouterApiKey, glamaApiKey, requestyApiKey } = extensionState.apiConfiguration ?? {}
 	useEffect(() => {
-		setCachedState((prevCachedState) => ({ ...prevCachedState, ...extensionState }))
-		setChangeDetected(false)
+		setCachedState((prevCachedState) => ({
+			...prevCachedState,
+			apiConfiguration: {
+				...prevCachedState.apiConfiguration,
+				// Only set specific tokens/keys instead of spreading the entire
+				// `prevCachedState.apiConfiguration` since it may contain unsaved changes
+				kilocodeToken,
+				openRouterApiKey,
+				glamaApiKey,
+				requestyApiKey,
+			},
+		}))
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [
-		extensionState.apiConfiguration?.kilocodeToken,
-		extensionState.apiConfiguration?.openRouterApiKey,
-		extensionState.apiConfiguration?.glamaApiKey,
-		extensionState.apiConfiguration?.requestyApiKey,
-	])
+	}, [kilocodeToken, openRouterApiKey, glamaApiKey, requestyApiKey])
 
 	useEffect(() => {
 		// Only update if we're not already detecting changes

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -344,7 +344,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 				// Discard changes: Reset state and flag
 				setCachedState(extensionState) // Revert to original state
 				setChangeDetected(false) // Reset change flag
-				setTimeout(() => confirmDialogHandler.current?.(), 0) // Execute the pending action (e.g., tab switch)
+				confirmDialogHandler.current?.() // Execute the pending action (e.g., tab switch)
 			}
 			// If confirm is false (Cancel), do nothing, dialog closes automatically
 		},


### PR DESCRIPTION
Previously we were spreading the entire `prevCachedState.apiConfiguration` object when the keys changed, which would wipe out unsaved changes the user might have made to things like `prevCachedState.apiConfiguration.kiloModel`. Now we only set the keys that might be set via callback and don't trigger a save explicitly. The user will need to click 'save' in order to exit the SettingView like normal (same as changing any other setting).

![213-fix-wrong-model-after-login](https://github.com/user-attachments/assets/4b2381d3-22ca-414c-a12b-f65940ef8749)


- update state with specific tokens/keys to avoid overwriting unsaved changes
- simplify useEffect dependencies by using direct variables

**Dev thoughts**
This does make me think.. should "login" keys / tokens be a "setting"? seems like it should be in the Settings view UI, but possibly separate from the other settings state of the api. I feel like it's not intuitive to have to click a "save" button once you login to something for it to remain saved.

**Test plan**: Verified that logging in / out no longer overwrites other non-saved changes in the Settings. Now users will have to click save for any changes they make, including login state. (This should be ok since we have that confirmation dialog if they don't.)

- Fixes #213 