### PR TITLE
Start tasks automatically and don't block launching the extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,6 @@
 			"args": ["--extensionDevelopmentPath=${workspaceFolder}"],
 			"sourceMaps": true,
 			"outFiles": ["${workspaceFolder}/dist/**/*.js"],
-			"preLaunchTask": "${defaultBuildTask}",
 			"env": {
 				"NODE_ENV": "development",
 				"VSCODE_DEBUG_MODE": "true"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,6 +12,9 @@
 			"group": {
 				"kind": "build",
 				"isDefault": true
+			},
+			"runOptions": {
+				"runOn": "folderOpen"
 			}
 		},
 		{


### PR DESCRIPTION
This fixes an annoyance where the extension could not be launched if the tasks were already running. Now the tasks will start running automatically once you start VSCode and shouldn't ever really need to be re-run. This unblocks the extension from starting and stopping normally by removing the `preLaunchTask` from `launch.json`. 

Test plan: Tried it out locally– it's nice!

