### PR TITLE
Fix history selection view with overlaying feedback button

### DIFF
--- a/.changeset/shiny-gifts-brush.md
+++ b/.changeset/shiny-gifts-brush.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix feedback button overlapping selection action button in history view

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -142,7 +142,7 @@ const App = () => {
 				onCancel={(requestId) => vscode.postMessage({ type: "humanRelayCancel", requestId })}
 			/>
 			{/* kilocode_change */}
-			{/* Chat view and prompts view contain their own bottom controls */}
+			{/* Chat, prompts and history view contain their own bottom controls */}
 			{!["chat", "prompts", "history"].includes(tab) && (
 				<div className="fixed inset-0 top-auto">
 					<BottomControls />

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -143,7 +143,7 @@ const App = () => {
 			/>
 			{/* kilocode_change */}
 			{/* Chat view and prompts view contain their own bottom controls */}
-			{!["chat", "prompts"].includes(tab) && (
+			{!["chat", "prompts", "history"].includes(tab) && (
 				<div className="fixed inset-0 top-auto">
 					<BottomControls />
 				</div>

--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useState } from "react"
+import BottomControls from "../chat/BottomControls" // kilocode_change
 import { DeleteTaskDialog } from "./DeleteTaskDialog"
 import { BatchDeleteTaskDialog } from "./BatchDeleteTaskDialog"
 import prettyBytes from "pretty-bytes"
@@ -488,6 +489,12 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 						}
 					}}
 				/>
+			)}
+			{/* kilocode_change */}
+			{selectedTaskIds.length === 0 && (
+				<div className="fixed bottom-0 right-0">
+					<BottomControls />
+				</div>
 			)}
 		</Tab>
 	)


### PR DESCRIPTION
## Context

- Fixes #323

Task selection window in History view, lower panel buttons are non-clickable because of an overlaying element

## Implementation

Similar to what we do in the chat an prompts view, the history view imports its own BottomControls (which includes the overlaying feedback icon). And we hide the feedback button when history items are selected for deletion. Expecting the feedback button to be moved elsewhere in the future.

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/f146c12f-ad02-419d-adac-d2ceb4e3f06f)
    
### After
<img width="479" alt="image" src="https://github.com/user-attachments/assets/32832236-d358-44cc-a73a-5dc6161cc532" />

## How to Test

- Task History
- Selection
- Make selection
- Try to delete tasks or clean selection
