### PR TITLE
Fix unreadable transparent chat section

### DIFF
--- a/.changeset/light-olives-knock.md
+++ b/.changeset/light-olives-knock.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed UI Issue - Unreadable transparent section at bottom of chat textArea

--- a/.changeset/light-olives-knock.md
+++ b/.changeset/light-olives-knock.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Fixed UI Issue - Unreadable transparent section at bottom of chat textArea. Thanks to agape-apps for reporting this issue!
+Fixed UI Issue - Unreadable transparent section at bottom of chat textArea. Thanks to @agape-apps for reporting this issue!

--- a/.changeset/light-olives-knock.md
+++ b/.changeset/light-olives-knock.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Fixed UI Issue - Unreadable transparent section at bottom of chat textArea. Thanks to @agape-apps for reporting this issue!
+Fixed UI Issue - Unreadable transparent section at bottom of chat textArea. Thanks to @agape-apps for reporting this issue! See [Kilo-Org/kilocode#306](https://github.com/Kilo-Org/kilocode/issues/306)

--- a/.changeset/light-olives-knock.md
+++ b/.changeset/light-olives-knock.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Fixed UI Issue - Unreadable transparent section at bottom of chat textArea
+Fixed UI Issue - Unreadable transparent section at bottom of chat textArea. Thanks to agape-apps for reporting this issue!

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1084,8 +1084,14 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									"z-[2]",
 									"scrollbar-none",
 									"pb-16", // Increased padding to prevent overlap with control bar
+									"scroll-pb-16", // Increased padding to prevent overlap with control bar
 								)}
 								onScroll={() => updateHighlights()}
+							/>
+							{/* kilocode_change {Transparent overlay at bottom of textArea to avoid text overlap } */}
+							<div
+								className="absolute bottom-[1px] left-2 right-2 h-16 bg-gradient-to-t from-[var(--vscode-input-background)] via-[var(--vscode-input-background)] to-transparent pointer-events-none z-[2]"
+								aria-hidden="true"
 							/>
 							{isTtsPlaying && (
 								<Button


### PR DESCRIPTION
## Context

- Fixes #306 

Had Unreadable transparent "Mode" and "API Configuration" section

Almost invisible transparent icon buttons for Add Context, Send Message

## Implementation

Added a decorative div for softening the bottom edge of the chat text area with a gradient that transitions from the VS Code input background color to transparent. 

## Screenshots / Screen recording

### Before

![image](https://github.com/user-attachments/assets/26efcb09-687c-41cf-a280-79ccfd168416)

### After

https://github.com/user-attachments/assets/da42be6d-6187-4e7c-a449-4f8a95c2cf8d

## How to Test

Open the extension and add a longer text prompt
