### PR TITLE
Fix Custom Headers are not saved for OpenAI Compatible providers (#383)

### DIFF
--- a/.changeset/cold-tips-tease.md
+++ b/.changeset/cold-tips-tease.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Custom Headers are not saved for OpenAI Compatible providers

--- a/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react"
+import { useState, useCallback, useEffect } from "react"
 import { useEvent } from "react-use"
 import { Checkbox } from "vscrui"
 import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
@@ -91,6 +91,15 @@ export const OpenAICompatible = ({ apiConfiguration, setApiConfigurationField }:
 	}, [])
 
 	useEvent("message", onMessage)
+
+	// kilocode_change start
+	// Update the main configuration whenever custom headers change
+	useEffect(() => {
+		// Convert the array of [key, value] pairs to an object, filtering out headers with empty keys
+		const headersObject = Object.fromEntries(customHeaders.filter(([key]) => key.trim() !== ""))
+		setApiConfigurationField("openAiHeaders", headersObject)
+	}, [customHeaders, setApiConfigurationField])
+	// kilocode_change end
 
 	return (
 		<>


### PR DESCRIPTION
The issue was that when users added or modified custom headers, the changes were only stored in the local component state but never propagated to the main configuration object that gets saved.

The fix adds a `useEffect` hook that updates the main configuration whenever the custom headers change, ensuring they're properly saved when the user clicks the "Save" button.

Now users can successfully add custom headers to their OpenAI Compatible provider configurations.

![fix-headers-dont-save](https://github.com/user-attachments/assets/a4e0f23a-f37f-4854-a960-c07d76e780ec)

Test plan:
- Added a header confirmed it saved
- Added header, discarded changes, confirmed header is gone

Fixes: https://github.com/Kilo-Org/kilocode/issues/383