### PR TITLE
Fix kilo settings fail to save (#392)

### DIFF
--- a/evals/packages/types/src/roo-code.ts
+++ b/evals/packages/types/src/roo-code.ts
@@ -5,7 +5,6 @@ import { Equals, Keys, AssertEqual } from "./utils.js"
 /**
  * ProviderName
  */
-
 export const providerNames = [
 	"anthropic",
 	"glama",
@@ -25,6 +24,7 @@ export const providerNames = [
 	"human-relay",
 	"fake-ai",
 	"xai",
+	"kilocode", // kilocode change
 ] as const
 
 export const providerNamesSchema = z.enum(providerNames)
@@ -477,6 +477,13 @@ const litellmSchema = z.object({
 	litellmModelId: z.string().optional(),
 })
 
+// kilocode_change start
+const kilocodeSchema = z.object({
+	kilocodeToken: z.string().optional(),
+	kilocodeModel: z.string().optional(),
+})
+// kilocode_change end
+
 const defaultSchema = z.object({
 	apiProvider: z.undefined(),
 })
@@ -588,6 +595,13 @@ export const providerSettingsSchemaDiscriminated = z
 				apiProvider: z.literal("litellm"),
 			}),
 		),
+		// kilocode_change start
+		kilocodeSchema.merge(
+			z.object({
+				apiProvider: z.literal("kilocode"),
+			}),
+		),
+		// kilocode_change end
 		defaultSchema,
 	])
 	.and(genericProviderSettingsSchema)
@@ -615,6 +629,7 @@ export const providerSettingsSchema = z.object({
 	...groqSchema.shape,
 	...chutesSchema.shape,
 	...litellmSchema.shape,
+	...kilocodeSchema.shape, // kilocode_change
 	...genericProviderSettingsSchema.shape,
 })
 
@@ -716,6 +731,11 @@ const providerSettingsRecord: ProviderSettingsRecord = {
 	litellmBaseUrl: undefined,
 	litellmApiKey: undefined,
 	litellmModelId: undefined,
+	// kilocode_change start
+	// Kilocode
+	kilocodeToken: undefined,
+	kilocodeModel: undefined,
+	// kilocode_change end
 }
 
 export const PROVIDER_SETTINGS_KEYS = Object.keys(providerSettingsRecord) as Keys<ProviderSettings>[]
@@ -910,6 +930,7 @@ export type SecretState = Pick<
 	| "unboundApiKey"
 	| "requestyApiKey"
 	| "xaiApiKey"
+	| "kilocodeToken" // kilocode_change
 >
 
 type SecretStateRecord = Record<Keys<SecretState>, undefined>
@@ -929,6 +950,7 @@ const secretStateRecord: SecretStateRecord = {
 	unboundApiKey: undefined,
 	requestyApiKey: undefined,
 	xaiApiKey: undefined,
+	kilocodeToken: undefined, // kilocode_change
 }
 
 export const SECRET_STATE_KEYS = Object.keys(secretStateRecord) as Keys<SecretState>[]

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -386,7 +386,11 @@ describe("ClineProvider", () => {
 			taskHistory: [],
 			shouldShowAnnouncement: false,
 			apiConfiguration: {
+				// kilocode_change start
 				apiProvider: "kilocode",
+				kilocodeModel: "gemini25",
+				kilocodeToken: "kilocode-token",
+				// kilocode_change end
 			},
 			customInstructions: undefined,
 			alwaysAllowReadOnly: false,

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -12,8 +12,7 @@ import { McpState } from "../shared/kilocode/mcp"
  */
 
 export const providerNames = [
-	// kilocode_change
-	"kilocode",
+	"kilocode", // kilocode_change
 	"fireworks",
 	"anthropic",
 	"glama",
@@ -504,6 +503,13 @@ const litellmSchema = baseProviderSettingsSchema.extend({
 	litellmModelId: z.string().optional(),
 })
 
+// kilocode_change start
+const kilocodeSchema = baseProviderSettingsSchema.extend({
+	kilocodeToken: z.string().optional(),
+	kilocodeModel: z.string().optional(),
+})
+// kilocode_change end
+
 const defaultSchema = z.object({
 	apiProvider: z.undefined(),
 })
@@ -530,6 +536,7 @@ export const providerSettingsSchemaDiscriminated = z.discriminatedUnion("apiProv
 	groqSchema.merge(z.object({ apiProvider: z.literal("groq") })),
 	chutesSchema.merge(z.object({ apiProvider: z.literal("chutes") })),
 	litellmSchema.merge(z.object({ apiProvider: z.literal("litellm") })),
+	kilocodeSchema.merge(z.object({ apiProvider: z.literal("kilocode") })), // kilocode_change
 	defaultSchema,
 ])
 
@@ -558,6 +565,7 @@ export const providerSettingsSchema = z
 	.merge(groqSchema)
 	.merge(chutesSchema)
 	.merge(litellmSchema)
+	.merge(kilocodeSchema) // kilocode_change
 
 export type ProviderSettings = z.infer<typeof providerSettingsSchema>
 
@@ -650,9 +658,10 @@ const providerSettingsRecord: ProviderSettingsRecord = {
 	// kilocode_change start
 	kilocodeToken: undefined,
 	kilocodeModel: undefined,
+	// kilocode_change end
+	// Fireworks
 	fireworksModelId: undefined,
 	fireworksApiKey: undefined,
-	// kilocode_change end
 	// X.AI (Grok)
 	xaiApiKey: undefined,
 	// Groq

--- a/webview-ui/src/components/settings/__tests__/SettingsView.test.tsx
+++ b/webview-ui/src/components/settings/__tests__/SettingsView.test.tsx
@@ -10,6 +10,14 @@ import SettingsView from "../SettingsView"
 // Mock vscode API
 jest.mock("@src/utils/vscode", () => ({ vscode: { postMessage: jest.fn() } }))
 
+// kilocode_change start
+// Mock the validate functions to prevent validation errors
+jest.mock("@src/utils/validate", () => ({
+	validateApiConfiguration: jest.fn().mockReturnValue(undefined),
+	validateModelId: jest.fn().mockReturnValue(undefined),
+}))
+// kilocode_change end
+
 // Mock all lucide-react icons with a proxy to handle any icon requested
 jest.mock("lucide-react", () => {
 	return new Proxy(

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -84,6 +84,13 @@ export function validateApiConfiguration(apiConfiguration: ProviderSettings): st
 				return "You must provide a valid API key or choose a different provider."
 			}
 			break
+		// kilocode_change start
+		case "kilocode":
+			if (!apiConfiguration.kilocodeToken) {
+				return i18next.t("settings:validation.apiKey")
+			}
+			break
+		// kilocode_change end
 	}
 
 	return undefined

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -86,7 +86,7 @@ export function validateApiConfiguration(apiConfiguration: ProviderSettings): st
 			break
 		// kilocode_change start
 		case "kilocode":
-			if (!apiConfiguration.kilocodeToken) {
+			if (!apiConfiguration.kilocodeToken || !apiConfiguration.kilocodeModel) {
 				return i18next.t("settings:validation.apiKey")
 			}
 			break


### PR DESCRIPTION
The 'kilocode' provider name was missing in a bunch of the apiProvider validation schemas/logic. This PR adds it, fixing the bug where settings would not save.

- integrate kilocode into providerNames and related schemas
- update providerSettingsSchema to include kilocode settings
- add validation for kilocodeToken in validateApiConfiguration

Test plan:
- Change Kilo settings, hit save, confirm no error
- Change Kilo setting, discard, confirm discarded
- Change non-Kilo setting, hit save, confirm saved

Dev notes
- The Roo codebase seems to have the same properties in like 3-4 different places. I wish things were a little more DRY :)