### PR TITLE
Do not show "not logged" in message when logged in but no model is selected

### DIFF
--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -86,7 +86,7 @@ export function validateApiConfiguration(apiConfiguration: ProviderSettings): st
 			break
 		// kilocode_change start
 		case "kilocode":
-			if (!apiConfiguration.kilocodeToken || !apiConfiguration.kilocodeModel) {
+			if (!apiConfiguration.kilocodeToken) {
 				return i18next.t("settings:validation.apiKey")
 			}
 			break


### PR DESCRIPTION
Do not display "not logged in" error message when user is logged in but no model is selected.
fixes https://github.com/Kilo-Org/kilocode/issues/414