### PR TITLE
Fix OpenRouter models response validation

### DIFF
--- a/.changeset/poor-clouds-go.md
+++ b/.changeset/poor-clouds-go.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed bug in SettingsView that caused issues with detecting/saving changes

--- a/src/api/providers/fetchers/openrouter.ts
+++ b/src/api/providers/fetchers/openrouter.ts
@@ -17,7 +17,7 @@ export const openRouterModelSchema = z.object({
 	description: z.string().optional(),
 	context_length: z.number(),
 	max_completion_tokens: z.number().nullish(),
-	preferredIndex: z.number().optional(), // kilocode_change
+	preferredIndex: z.number().nullish(), // kilocode_change
 	architecture: z
 		.object({
 			modality: z.string().nullish(),

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -246,7 +246,7 @@ type ProviderSettings = {
 	openAiModelId?: string | undefined
 	openAiCustomModelInfo?:
 		| ({
-				preferredIndex?: number | undefined
+				preferredIndex?: (number | null) | undefined
 				maxTokens?: (number | null) | undefined
 				maxThinkingTokens?: (number | null) | undefined
 				contextWindow: number

--- a/src/exports/types.ts
+++ b/src/exports/types.ts
@@ -249,7 +249,7 @@ type ProviderSettings = {
 	openAiModelId?: string | undefined
 	openAiCustomModelInfo?:
 		| ({
-				preferredIndex?: number | undefined
+				preferredIndex?: (number | null) | undefined
 				maxTokens?: (number | null) | undefined
 				maxThinkingTokens?: (number | null) | undefined
 				contextWindow: number

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -106,7 +106,7 @@ export type ReasoningEffort = z.infer<typeof reasoningEffortsSchema>
  */
 
 export const modelInfoSchema = z.object({
-	preferredIndex: z.number().optional(), // kilocode_change
+	preferredIndex: z.number().nullish(), // kilocode_change
 	maxTokens: z.number().nullish(),
 	maxThinkingTokens: z.number().nullish(),
 	contextWindow: z.number(),


### PR DESCRIPTION
## Context

preferredIndex is not always present in the OpenRouter response, which means that zod will raise an error.

Nullish in zod terms means that an item is both optional and nullable, which resolves the validation error.

Note: This change also resolved a bug for me in the SettingsView that caused it to detect changes any time I opened it. However, going back to a clean `main` I can't replicate the issue any longer, so I'm not 100% sure if this fixed it. (It feels like maybe the cache was in a bad state which kept triggering the changes, and somehow this change fixed that?)

## How to Test

- On `main`, make sure you're on the `Kilo Code` provider
- Open up the Debug Console
- Notice that there's an error: `OpenRouter models response is invalid`
- Now checkout this branch, and notice the error is gone 🎉 
