### PR TITLE
Add Prompts icon to topbar

### DIFF
--- a/.changeset/happy-toys-refuse.md
+++ b/.changeset/happy-toys-refuse.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Make the prompts view accessible through the topbar

--- a/package.json
+++ b/package.json
@@ -301,8 +301,13 @@
 					"when": "view == kilo-code.SidebarProvider"
 				},
 				{
-					"command": "kilo-code.historyButtonClicked",
+					"command": "kilo-code.promptsButtonClicked",
 					"group": "navigation@2",
+					"when": "view == kilo-code.SidebarProvider"
+				},
+				{
+					"command": "kilo-code.historyButtonClicked",
+					"group": "navigation@3",
 					"when": "view == kilo-code.SidebarProvider"
 				},
 				{


### PR DESCRIPTION
## Context

Fixes #403

## Implementation

While I realize that this is not /exactly/ what we discussed in the ticket, after some consideration I've opted to go with the direction that Roo has chosen.

Basically, adapting the prompts panel so that it would fit inside of the SettingsView would mean that we'd have to diverge the whole PromptsView from Roo, which would make future merges more challenging. I agree with the worry that the topbar is getting a bit crowded, but for now it's the easiest way to make the PromptsView accessible from all other panels.

## Screenshots

| before | after |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/e5f8f8c7-96c9-4e05-83c2-fdfb42f828a5) |  ![image](https://github.com/user-attachments/assets/f2e20ba6-5e43-49c6-891d-a4beff186b1f) |

## How to Test

Basically, this change means that we're going back to how Roo does it, so I think it's all good.

