### PR TITLE
Fix: Add mocked streamableHttp package

### DIFF
--- a/src/__mocks__/@modelcontextprotocol/sdk/client/streamableHttp.js
+++ b/src/__mocks__/@modelcontextprotocol/sdk/client/streamableHttp.js
@@ -1,0 +1,14 @@
+class StreamableHttpClientTransport {
+	constructor(url, options = {}) {
+		this.url = url
+		this.options = options
+		this.onerror = null
+		this.connect = jest.fn().mockResolvedValue()
+		this.close = jest.fn().mockResolvedValue()
+		this.start = jest.fn().mockResolvedValue()
+	}
+}
+
+module.exports = {
+	StreamableHttpClientTransport,
+}


### PR DESCRIPTION
This fixes the unit tests, which were previously unable to run because of a missing file.
