### PR TITLE
Fix: Workaround for detected changes in SettingsView upon rendering

### DIFF
--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -350,6 +350,24 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 		},
 		[setCachedState, setChangeDetected, extensionState], // Depend on extensionState to get the latest original state
 	)
+
+	// From time to time there's a bug that triggers unsaved changes upon rendering the SettingsView
+	// This is a (nasty) workaround to detect when this happens, and to force overwrite the unsaved changes
+	const renderStart = useRef<null | number>()
+	useEffect(() => {
+		renderStart.current = performance.now()
+	}, [])
+	useEffect(() => {
+		if (renderStart.current) {
+			const renderEnd = performance.now()
+			const renderTime = renderEnd - renderStart.current
+
+			if (renderTime < 100 && isChangeDetected) {
+				console.info("Overwriting unsaved changes in less than 100ms")
+				onConfirmDialogResult(true)
+			}
+		}
+	}, [isChangeDetected, onConfirmDialogResult])
 	// kilocode_change end
 
 	// Handle tab changes with unsaved changes check

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -358,7 +358,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 		renderStart.current = performance.now()
 	}, [])
 	useEffect(() => {
-		if (renderStart.current) {
+		if (renderStart.current && process.env.NODE_ENV !== "test") {
 			const renderEnd = performance.now()
 			const renderTime = renderEnd - renderStart.current
 


### PR DESCRIPTION
I've been going down a rabbit hole, trying to figure out why some users were seeing unsaved changes upon rendering the SettingsView for the first time.

We've been dealing with this issue multiple times in the past, most recently in #354.

I'm of the opinion that at some point we should rework the SettingsView and especially how state is being managed inside of it. There's simply too many opportunity to run into these situations because individual components are in charge of defaults and fallbacks, which will always keep triggering unsaved changes upon first render. With this workaround I simply make sure that we get users out of the state that poisoned their settings state.
