### PR TITLE
Fix changelog script to always wrap versions in brackets

### DIFF
--- a/.github/scripts/overwrite_changeset_changelog.py
+++ b/.github/scripts/overwrite_changeset_changelog.py
@@ -39,11 +39,13 @@ def overwrite_changelog_section(changelog_text: str, new_content: str):
     notes_end_index = changelog_text.find(prev_version_pattern, notes_start_index) if PREV_VERSION and prev_version_pattern in changelog_text else len(changelog_text)
 
     if new_content:
-        return changelog_text[:notes_start_index] + f"{new_content}\n" + changelog_text[notes_end_index:]
+        updated_changelog = changelog_text[:notes_start_index] + f"{new_content}\n" + changelog_text[notes_end_index:]
+        updated_changelog = updated_changelog.replace(f"## {VERSION}", f"## [{VERSION}]")
+        return updated_changelog
     else:
         changeset_lines = changelog_text[notes_start_index:notes_end_index].split("\n")
         # Remove the first two lines from the regular changeset format, ex: \n### Patch Changes
-        parsed_lines = "\n".join(changeset_lines[2:]) 
+        parsed_lines = "\n".join(changeset_lines[2:])
         updated_changelog = changelog_text[:notes_start_index] + parsed_lines + changelog_text[notes_end_index:]
         updated_changelog = updated_changelog.replace(f"## {VERSION}", f"## [{VERSION}]")
         return updated_changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # kilo-code
 
-## 4.24.0
+## [4.24.0]
 
 ### Minor Changes
 
@@ -14,7 +14,7 @@
 
 - [#354](https://github.com/Kilo-Org/kilocode/pull/354) [`106b722`](https://github.com/Kilo-Org/kilocode/commit/106b722e747f98edb15b5a8e7a65e19db31028db) Thanks [@hassoncs](https://github.com/hassoncs)! - Fix wrong model after login (#213)
 
-## 4.23.0
+## [4.23.0]
 
 ### Minor Changes
 
@@ -22,7 +22,7 @@
 
 - [#303](https://github.com/Kilo-Org/kilocode/pull/303) [`b69a57e`](https://github.com/Kilo-Org/kilocode/commit/b69a57e316a740470a8be40d77dad50efde5c35c) Thanks [@drakonen](https://github.com/drakonen)! - Kilo Code Provider can now do all the OpenRouter models
 
-## 4.22.0
+## [4.22.0]
 
 ### Minor Changes
 
@@ -33,7 +33,7 @@
 - Fixed UI Issue - Unreadable transparent section at bottom of chat textArea. Thanks to @agape-apps for reporting this issue! See [Kilo-Org/kilocode#306](https://github.com/Kilo-Org/kilocode/issues/306)
 - Fix feedback button overlapping selection action button in history view
 
-## 4.21.0
+## [4.21.0]
 
 ### Minor Changes
 
@@ -43,7 +43,7 @@
 
 - Fix issue with removed slash commands for changing modes
 
-## 4.20.1
+## [4.20.1]
 
 ### Patch Changes
 
@@ -54,14 +54,14 @@
 
 - Include slash commands from Cline, include /newtask command
 
-## 4.19.1
+## [4.19.1]
 
 ### Patch Changes
 
 - Fix translations for system notifications
 - Include changes from Roo Code v3.14.3
 
-## 4.19.0
+## [4.19.0]
 
 ### Minor Changes
 
@@ -71,7 +71,7 @@
 
 - Small UI improvements for dark themes
 
-## 4.18.0
+## [4.18.0]
 
 ### Minor Changes
 
@@ -82,7 +82,7 @@
 - Fix settingview appearing not to save when hitting save button
 - Fix dark buttons on light vscode themes (thanks @Aikiboy123)
 
-## 4.17.0
+## [4.17.0]
 
 ### Minor Changes
 
@@ -104,7 +104,7 @@
 
 - Fix http referer header
 
-## 4.16.0
+## [4.16.0]
 
 ### Minor Changes
 


### PR DESCRIPTION
This makes sure the publish action can properly pick up on the changelog and generate github release notes