### PR TITLE
add id to description

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,7 @@ description: File a bug report
 type: "Bug"
 body:
     - type: textarea
+      id: description
       attributes:
           label: Add a description (be as detailed as possible)
           description: |


### PR DESCRIPTION
## Context
Adding an id to description in the bug_report.yml file so that I can create new issues easily with the `/reportbug` slash command