### PR TITLE
feat: add support for claude 4 models for anthropic provider

### DIFF
--- a/.changeset/great-baboons-grin.md
+++ b/.changeset/great-baboons-grin.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Also include support for claude 4 models via the Anthropic provider

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -1,6 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
-import { Stream as AnthropicStream } from "@anthropic-ai/sdk/streaming"
 import { CacheControlEphemeral } from "@anthropic-ai/sdk/resources"
+import { Stream as AnthropicStream } from "@anthropic-ai/sdk/streaming"
 import {
 	anthropicDefaultModelId,
 	AnthropicModelId,
@@ -8,11 +8,11 @@ import {
 	ApiHandlerOptions,
 	ModelInfo,
 } from "../../shared/api"
+import { getModelParams } from "../getModelParams"
+import { SingleCompletionHandler } from "../index"
 import { ApiStream } from "../transform/stream"
 import { BaseProvider } from "./base-provider"
 import { ANTHROPIC_DEFAULT_MAX_TOKENS } from "./constants"
-import { SingleCompletionHandler } from "../index"
-import { getModelParams } from "../getModelParams"
 
 export class AnthropicHandler extends BaseProvider implements SingleCompletionHandler {
 	private options: ApiHandlerOptions
@@ -37,9 +37,11 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 		let { id: modelId, maxTokens, thinking, temperature, virtualId } = this.getModel()
 
 		switch (modelId) {
+			case "claude-sonnet-4-20250514":
 			case "claude-3-7-sonnet-20250219":
 			case "claude-3-5-sonnet-20241022":
 			case "claude-3-5-haiku-20241022":
+			case "claude-opus-4-20250514":
 			case "claude-3-opus-20240229":
 			case "claude-3-haiku-20240307": {
 				/**
@@ -100,6 +102,8 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 
 						// Then check for models that support prompt caching
 						switch (modelId) {
+							case "claude-sonnet-4-20250514":
+							case "claude-opus-4-20250514":
 							case "claude-3-7-sonnet-20250219":
 							case "claude-3-5-sonnet-20241022":
 							case "claude-3-5-haiku-20241022":

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -7,8 +7,28 @@ export type ApiHandlerOptions = Omit<ProviderSettings, "apiProvider" | "id">
 // Anthropic
 // https://docs.anthropic.com/en/docs/about-claude/models
 export type AnthropicModelId = keyof typeof anthropicModels
-export const anthropicDefaultModelId: AnthropicModelId = "claude-3-7-sonnet-20250219"
+export const anthropicDefaultModelId: AnthropicModelId = "claude-sonnet-4-20250514"
 export const anthropicModels = {
+	"claude-sonnet-4-20250514": {
+		maxTokens: 8192,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+	},
+	"claude-opus-4-20250514": {
+		maxTokens: 4096,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 15.0,
+		outputPrice: 75.0,
+		cacheWritesPrice: 18.75,
+		cacheReadsPrice: 1.5,
+	},
 	"claude-3-7-sonnet-20250219:thinking": {
 		maxTokens: 128_000,
 		contextWindow: 200_000,


### PR DESCRIPTION
## Context

Adding support for Claude 4 models (Sonnet 4 and Opus 4) to Kilo Code extension. These are Anthropic's latest models with enhanced capabilities and performance, released on May 14, 2025. The PR makes Claude Sonnet 4 the new default model due to its improved performance-to-cost ratio.

## Implementation

The implementation focuses on adding the new model specifications and ensuring proper integration:

1. Added new Claude 4 model specifications to `src/shared/api.ts`:
   - claude-sonnet-4-20250514: 200K context window with 8192 max tokens
   - claude-opus-4-20250514: 200K context window with 4096 max tokens

2. Set claude-sonnet-4-20250514 as the new default model

3. Updated the switch statements in `src/api/providers/anthropic.ts` to include the new models for:
   - Standard API call handling
   - Prompt caching functionality

4. Minor code organization improvements by alphabetically sorting imports in anthropic.ts

## Screenshots

| before | after |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/93d84389-cae8-4589-9fda-89eeea7d6df3) |![image](https://github.com/user-attachments/assets/7cf8aac4-99fa-4c3f-8e54-28dfd2d864bf) |

## How to Test

- Ensure your Anthropic API key is configured in the extension settings
- Open a Kilo Code chat and create a new conversation
- Verify that Claude Sonnet 4 is now the default model in the model selector
- Test both new models by selecting them from the dropdown and confirming they handle requests properly
- Verify the model's capabilities with a complex prompt that utilizes a large context window
- Check that prompt caching works correctly with the new models when enabled

## Get in Touch

If you have any questions or would like to discuss this implementation, you can find me in the [Kilo Code Discord](https://kilocode.ai/discord) as @wally_24.