### PR TITLE
Fix POSIX shell compatibility in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -18,7 +18,7 @@ fi
 NEW_CHANGESETS=$(find .changeset -name "*.md" ! -name "README.md" | wc -l | tr -d ' ')
 echo "Changeset files: $NEW_CHANGESETS"
 
-if [ "$NEW_CHANGESETS" == "0" ]; then
+if [ "$NEW_CHANGESETS" = "0" ]; then
   echo "-------------------------------------------------------------------------------------"
   echo "Changes detected. Please run 'npm run changeset' to create a changeset if applicable."
   echo "-------------------------------------------------------------------------------------"


### PR DESCRIPTION
## Context

Fix POSIX shell compatibility issue in `.husky/pre-push` script.

The current script produces `.husky/pre-push: 21: [: 1: unexpected operator` error when executed on Ubuntu systems, preventing the pre-push hook from running properly.

## Implementation

Changed the conditional test on line 22 from `[ "$NEW_CHANGESETS" == "0" ]` to `[ "$NEW_CHANGESETS" = "0" ]`. This change:

- Resolves the "unexpected operator" execution error on Ubuntu systems
- Uses standard POSIX shell syntax for better cross-platform compatibility
- Ensures consistency throughout the script, as all other conditional tests already use `=` instead of `==`

The issue occurs because different systems' default shells have varying support for the `==` operator. Using the standard `=` maintains consistency with the existing codebase and ensures the script works reliably across all environments.

## How to Test

1. Run `git push` on an Ubuntu system to trigger the pre-push hook
2. Verify that the "unexpected operator" error no longer appears
3. Confirm that the changeset validation functionality still works correctly