### PR TITLE
✨ feat(extension): Add the ability to run an "autoLaunch" prompt as soon as the extension activates

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,8 @@ import { TerminalRegistry } from "./integrations/terminal/TerminalRegistry"
 import { McpServerManager } from "./services/mcp/McpServerManager"
 import { CodeIndexManager } from "./services/code-index/manager"
 import { migrateSettings } from "./utils/migrateSettings"
+import { maybeRunAutoLaunchPrompt } from "./utils/autoLaunchPrompt"
+import { registerAutocomplete } from "./services/autocomplete/AutocompleteProvider"
 import { API } from "./extension/api"
 
 import {
@@ -37,7 +39,6 @@ import {
 	CodeActionProvider,
 } from "./activate"
 import { initializeI18n } from "./i18n"
-import { registerAutocomplete } from "./services/autocomplete/AutocompleteProvider"
 
 /**
  * Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -208,6 +209,8 @@ export async function activate(context: vscode.ExtensionContext) {
 			context.subscriptions.push(watcher)
 		})
 	}
+
+	maybeRunAutoLaunchPrompt(context) // kilocode_change
 
 	return new API(outputChannel, provider, socketPath, enableLogging)
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ import { TerminalRegistry } from "./integrations/terminal/TerminalRegistry"
 import { McpServerManager } from "./services/mcp/McpServerManager"
 import { CodeIndexManager } from "./services/code-index/manager"
 import { migrateSettings } from "./utils/migrateSettings"
-import { maybeRunAutoLaunchPrompt } from "./utils/autoLaunchPrompt"
+import { checkAndRunAutoLaunchingTask as checkAndRunAutoLaunchingTask } from "./utils/autoLaunchingTask"
 import { registerAutocomplete } from "./services/autocomplete/AutocompleteProvider"
 import { API } from "./extension/api"
 
@@ -210,7 +210,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		})
 	}
 
-	maybeRunAutoLaunchPrompt(context) // kilocode_change
+	await checkAndRunAutoLaunchingTask(context) // kilocode_change
 
 	return new API(outputChannel, provider, socketPath, enableLogging)
 }

--- a/src/utils/autoLaunchPrompt.ts
+++ b/src/utils/autoLaunchPrompt.ts
@@ -1,0 +1,30 @@
+import * as vscode from "vscode"
+
+/**
+ * Checks for a file in .kilocode/launchPrompt.md and runs it immediately if it exists.
+ */
+export async function maybeRunAutoLaunchPrompt(context: vscode.ExtensionContext): Promise<void> {
+	if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+		return
+	}
+
+	const workspaceFolderUri = vscode.workspace.workspaceFolders[0].uri
+	const promptFilePath = vscode.Uri.joinPath(workspaceFolderUri, ".kilocode", "launchPrompt.md")
+
+	try {
+		const fileContent = await vscode.workspace.fs.readFile(promptFilePath)
+		const prompt = Buffer.from(fileContent).toString("utf8")
+		console.log(`Auto-launching task from '${promptFilePath}' with content:\n${prompt}`)
+
+		await new Promise((resolve) => setTimeout(resolve, 500))
+		await vscode.commands.executeCommand("kilo-code.SidebarProvider.focus")
+
+		vscode.commands.executeCommand("kilo-code.newTask", { prompt })
+	} catch (error) {
+		if (error instanceof vscode.FileSystemError && error.code === "FileNotFound") {
+			// File not found, which is expected if no launchPrompt.md exists
+			return
+		}
+		console.error(`Error running .kilocode/launchPrompt.md: ${error}`)
+	}
+}

--- a/src/utils/autoLaunchingTask.ts
+++ b/src/utils/autoLaunchingTask.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode"
 /**
  * Checks for a file in .kilocode/launchPrompt.md and runs it immediately if it exists.
  */
-export async function maybeRunAutoLaunchPrompt(context: vscode.ExtensionContext): Promise<void> {
+export async function checkAndRunAutoLaunchingTask(context: vscode.ExtensionContext): Promise<void> {
 	if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
 		return
 	}
@@ -14,7 +14,7 @@ export async function maybeRunAutoLaunchPrompt(context: vscode.ExtensionContext)
 	try {
 		const fileContent = await vscode.workspace.fs.readFile(promptFilePath)
 		const prompt = Buffer.from(fileContent).toString("utf8")
-		console.log(`Auto-launching task from '${promptFilePath}' with content:\n${prompt}`)
+		console.log(`🚀 Auto-launching task from '${promptFilePath}' with content:\n${prompt}`)
 
 		await new Promise((resolve) => setTimeout(resolve, 500))
 		await vscode.commands.executeCommand("kilo-code.SidebarProvider.focus")
@@ -22,8 +22,7 @@ export async function maybeRunAutoLaunchPrompt(context: vscode.ExtensionContext)
 		vscode.commands.executeCommand("kilo-code.newTask", { prompt })
 	} catch (error) {
 		if (error instanceof vscode.FileSystemError && error.code === "FileNotFound") {
-			// File not found, which is expected if no launchPrompt.md exists
-			return
+			return // File not found, which is expected if no launchPrompt.md exists
 		}
 		console.error(`Error running .kilocode/launchPrompt.md: ${error}`)
 	}


### PR DESCRIPTION
This adds the ability to automatically start a prompt right when VSCode is launched. When the extension activates, it will check for a file `.kilocode/launchPrompt.md`. If found, it will immediately start executing the prompt.

This allows us to do some really cool testing automations– this would give the extension the ability to test itself! You could write a prompt into a dir, then launch `code` to that dir. The prompt could tell Kilo to test out it's own functionality and then write out a bug report when it's done.

If there's a better way to trigger prompts automatically, please let me know! But this feature would let me continue to experiment in my own dev workflows and eventually Kilo can fully build itself!

- integrate maybeRunAutoLaunchPrompt to auto launch prompt if available
- create autoLaunchPrompt utility to check and execute launchPrompt.md file
