### PR TITLE
Make the models-dropdown work when using a dev-mode JWT.

### DIFF
--- a/src/api/providers/fetchers/modelCache.ts
+++ b/src/api/providers/fetchers/modelCache.ts
@@ -70,13 +70,12 @@ export const getModels = async (options: GetModelsOptions): Promise<ModelRecord>
 				models = await getLiteLLMModels(options.apiKey, options.baseUrl)
 				break
 			// kilocode_change start
-			case "kilocode-openrouter": {
+			case "kilocode-openrouter":
 				models = await getOpenRouterModels({
-					baseUrl: getKiloBaseUriFromToken(options.kilocodeToken ?? "") + "/api/openrouter",
+					openRouterBaseUrl: getKiloBaseUriFromToken(options.kilocodeToken ?? "") + "/api/openrouter",
 					headers: { Authorization: `Bearer ${options.kilocodeToken}` },
 				})
 				break
-			}
 			// kilocode_change end
 			default: {
 				// Ensures router is exhaustively checked if RouterName is a strict union

--- a/src/api/providers/fetchers/modelCache.ts
+++ b/src/api/providers/fetchers/modelCache.ts
@@ -14,6 +14,7 @@ import { getGlamaModels } from "./glama"
 import { getUnboundModels } from "./unbound"
 import { getLiteLLMModels } from "./litellm"
 import { GetModelsOptions } from "../../../shared/api"
+import { getKiloBaseUriFromToken } from "../kilocode-openrouter"
 const memoryCache = new NodeCache({ stdTTL: 5 * 60, checkperiod: 5 * 60 })
 
 async function writeModels(router: RouterName, data: ModelRecord) {
@@ -70,15 +71,10 @@ export const getModels = async (options: GetModelsOptions): Promise<ModelRecord>
 				break
 			// kilocode_change start
 			case "kilocode-openrouter": {
-				const kilocodeToken = ContextProxy.instance.getProviderSettings().kilocodeToken
-				const options: any = {
-					openRouterBaseUrl: "https://kilocode.ai/api/openrouter",
-					headers: {
-						Authorization: `Bearer ${kilocodeToken}`,
-					},
-				}
-
-				models = await getOpenRouterModels(options)
+				models = await getOpenRouterModels({
+					baseUrl: getKiloBaseUriFromToken(options.kilocodeToken ?? "") + "/api/openrouter",
+					headers: { Authorization: `Bearer ${options.kilocodeToken}` },
+				})
 				break
 			}
 			// kilocode_change end

--- a/src/api/providers/fetchers/modelCache.ts
+++ b/src/api/providers/fetchers/modelCache.ts
@@ -14,7 +14,7 @@ import { getGlamaModels } from "./glama"
 import { getUnboundModels } from "./unbound"
 import { getLiteLLMModels } from "./litellm"
 import { GetModelsOptions } from "../../../shared/api"
-import { getKiloBaseUriFromToken } from "../kilocode-openrouter"
+import { getKiloBaseUriFromToken } from "../../../utils/kilocode-token"
 const memoryCache = new NodeCache({ stdTTL: 5 * 60, checkperiod: 5 * 60 })
 
 async function writeModels(router: RouterName, data: ModelRecord) {

--- a/src/api/providers/fetchers/openrouter.ts
+++ b/src/api/providers/fetchers/openrouter.ts
@@ -1,4 +1,4 @@
-import axios, { RawAxiosRequestHeaders } from "axios"
+import axios, { type RawAxiosRequestHeaders /*kilocode_change*/ } from "axios"
 import { z } from "zod"
 
 import { type ModelInfo, isModelParameter } from "@roo-code/types"

--- a/src/api/providers/fetchers/openrouter.ts
+++ b/src/api/providers/fetchers/openrouter.ts
@@ -93,15 +93,16 @@ type OpenRouterModelEndpointsResponse = z.infer<typeof openRouterModelEndpointsR
  * getOpenRouterModels
  */
 
-export async function getOpenRouterModels(options?: ApiHandlerOptions): Promise<Record<string, ModelInfo>> {
+export async function getOpenRouterModels({
+	baseUrl = "https://openrouter.ai/api/v1",
+	headers,
+}: { baseUrl?: string; headers?: Record<string, string> } = {}): Promise<Record<string, ModelInfo>> {
 	const models: Record<string, ModelInfo> = {}
-	const baseURL = options?.openRouterBaseUrl || "https://openrouter.ai/api/v1"
 
 	try {
 		// kilocode_change begin
 		// Use optional headers if provided in options
-		const headers = (options as any)?.headers || {}
-		const response = await axios.get<OpenRouterModelsResponse>(`${baseURL}/models`, { headers })
+		const response = await axios.get<OpenRouterModelsResponse>(`${baseUrl}/models`, { headers })
 		// kilocode_change end
 		const result = openRouterModelsResponseSchema.safeParse(response.data)
 		const data = result.success ? result.data.data : response.data.data

--- a/src/api/providers/fetchers/openrouter.ts
+++ b/src/api/providers/fetchers/openrouter.ts
@@ -1,4 +1,4 @@
-import axios from "axios"
+import axios, { RawAxiosRequestHeaders } from "axios"
 import { z } from "zod"
 
 import { type ModelInfo, isModelParameter } from "@roo-code/types"
@@ -93,17 +93,16 @@ type OpenRouterModelEndpointsResponse = z.infer<typeof openRouterModelEndpointsR
  * getOpenRouterModels
  */
 
-export async function getOpenRouterModels({
-	baseUrl = "https://openrouter.ai/api/v1",
-	headers,
-}: { baseUrl?: string; headers?: Record<string, string> } = {}): Promise<Record<string, ModelInfo>> {
+export async function getOpenRouterModels(
+	options?: ApiHandlerOptions & { headers?: RawAxiosRequestHeaders }, // kilocode_change: added headers
+): Promise<Record<string, ModelInfo>> {
 	const models: Record<string, ModelInfo> = {}
+	const baseURL = options?.openRouterBaseUrl || "https://openrouter.ai/api/v1"
 
 	try {
-		// kilocode_change begin
-		// Use optional headers if provided in options
-		const response = await axios.get<OpenRouterModelsResponse>(`${baseUrl}/models`, { headers })
-		// kilocode_change end
+		const response = await axios.get<OpenRouterModelsResponse>(`${baseURL}/models`, {
+			headers: options?.headers, // kilocode_change: added headers
+		})
 		const result = openRouterModelsResponseSchema.safeParse(response.data)
 		const data = result.success ? result.data.data : response.data.data
 

--- a/src/api/providers/kilocode-openrouter.ts
+++ b/src/api/providers/kilocode-openrouter.ts
@@ -3,6 +3,7 @@ import { OpenRouterHandler } from "./openrouter"
 import { getModelParams } from "../transform/model-params"
 import { getModels } from "./fetchers/modelCache"
 import { DEEP_SEEK_DEFAULT_TEMPERATURE } from "./constants"
+import { getKiloBaseUriFromToken } from "../../utils/kilocode-token"
 
 /**
  * A custom OpenRouter handler that overrides the getModel function
@@ -77,16 +78,4 @@ export class KilocodeOpenrouterHandler extends OpenRouterHandler {
 
 function getKiloBaseUri(options: ApiHandlerOptions) {
 	return getKiloBaseUriFromToken(options.kilocodeToken ?? "")
-}
-
-export function getKiloBaseUriFromToken(kilocodeToken: string) {
-	try {
-		const payload_string = kilocodeToken.split(".")[1]
-		const payload = JSON.parse(Buffer.from(payload_string, "base64").toString())
-		//note: this is UNTRUSTED, so we need to make sure we're OK with this being manipulated by an attacker; e.g. we should not read uri's from the JWT directly.
-		if (payload.env === "development") return "http://localhost:3000"
-	} catch (_error) {
-		console.warn("Failed to get base URL from Kilo Code token")
-	}
-	return "https://kilocode.ai"
 }

--- a/src/api/providers/kilocode-openrouter.ts
+++ b/src/api/providers/kilocode-openrouter.ts
@@ -64,15 +64,24 @@ export class KilocodeOpenrouterHandler extends OpenRouterHandler {
 	}
 
 	public override async fetchModel() {
-		this.models = await getModels({ provider: "kilocode-openrouter" })
+		if (!this.options.kilocodeToken || !this.options.openRouterBaseUrl) {
+			throw new Error("KiloCode toke + baseUrl is required to fetch models")
+		}
+		this.models = await getModels({
+			provider: "kilocode-openrouter",
+			kilocodeToken: this.options.kilocodeToken,
+		})
 		return this.getModel()
 	}
 }
 
 function getKiloBaseUri(options: ApiHandlerOptions) {
+	return getKiloBaseUriFromToken(options.kilocodeToken ?? "")
+}
+
+export function getKiloBaseUriFromToken(kilocodeToken: string) {
 	try {
-		const token = options.kilocodeToken as string
-		const payload_string = token.split(".")[1]
+		const payload_string = kilocodeToken.split(".")[1]
 		const payload = JSON.parse(Buffer.from(payload_string, "base64").toString())
 		//note: this is UNTRUSTED, so we need to make sure we're OK with this being manipulated by an attacker; e.g. we should not read uri's from the JWT directly.
 		if (payload.env === "development") return "http://localhost:3000"

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -322,7 +322,10 @@ export const webviewMessageHandler = async (provider: ClineProvider, message: We
 				{ key: "requesty", options: { provider: "requesty", apiKey: apiConfiguration.requestyApiKey } },
 				{ key: "glama", options: { provider: "glama" } },
 				{ key: "unbound", options: { provider: "unbound", apiKey: apiConfiguration.unboundApiKey } },
-				{ key: "kilocode-openrouter", options: { provider: "kilocode-openrouter" } }, // kilocode_change
+				{
+					key: "kilocode-openrouter",
+					options: { provider: "kilocode-openrouter", kilocodeToken: apiConfiguration.kilocodeToken },
+				}, // kilocode_change
 			]
 
 			const litellmApiKey = apiConfiguration.litellmApiKey || message?.values?.litellmApiKey

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -2081,4 +2081,4 @@ export type GetModelsOptions =
 	| { provider: "requesty"; apiKey?: string }
 	| { provider: "unbound"; apiKey?: string }
 	| { provider: "litellm"; apiKey: string; baseUrl: string }
-	| { provider: "kilocode-openrouter" } // kilocode_change
+	| { provider: "kilocode-openrouter"; kilocodeToken?: string } // kilocode_change

--- a/src/utils/kilocode-token.ts
+++ b/src/utils/kilocode-token.ts
@@ -1,0 +1,11 @@
+export function getKiloBaseUriFromToken(kilocodeToken: string) {
+	try {
+		const payload_string = kilocodeToken.split(".")[1]
+		const payload = JSON.parse(Buffer.from(payload_string, "base64").toString())
+		//note: this is UNTRUSTED, so we need to make sure we're OK with this being manipulated by an attacker; e.g. we should not read uri's from the JWT directly.
+		if (payload.env === "development") return "http://localhost:3000"
+	} catch (_error) {
+		console.warn("Failed to get base URL from Kilo Code token")
+	}
+	return "https://kilocode.ai"
+}


### PR DESCRIPTION
 - noticed while implementing #397 
 
 Basically, if you're running the dev-mode backend, then the extension won't work correctly now since it hard-coded prod-uri's for these things.
 
There is an alternative here, to _not_ proxy the models endpoint at all -  https://openrouter.ai/docs/api-reference/list-available-models doesn't actually require an api key at all, so none of this actually needs to go via our infrastructure. IIRC @drakonen chose this route for some control and the possibility for the backend to sort models by preference, so if we dump the proxy, we'd need to do that a different way.