### PR TITLE
Make release workflow scripts more robust and adjust changelog

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -19,6 +19,7 @@ jobs:
             ( github.event_name == 'pull_request' &&
             github.event.pull_request.merged == true &&
             github.event.pull_request.base.ref == 'main' &&
+            !contains(github.event.pull_request.title, 'Changeset version bump') &&
             github.actor != 'kilocode-bot' ) ||
             github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
@@ -66,60 +67,56 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.CROSS_REPO_ACCESS_TOKEN }}
 
-    # Job 2: Process version bump PR created by kilocode-bot
-    changeset-pr-edit-approve:
-        name: Auto approve Bump version PRs
-        runs-on: ubuntu-latest
-        permissions:
-            contents: write
-            pull-requests: write
-        if: >
-            github.event_name == 'pull_request' &&
-            github.event.pull_request.base.ref == 'main' &&
-            github.actor == 'kilocode-bot' &&
-            contains(github.event.pull_request.title, 'Changeset version bump')
-        steps:
-            - name: Determine checkout ref
-              id: checkout-ref
-              run: |
-                  echo "Event action: ${{ github.event.action }}"
-                  echo "Actor: ${{ github.actor }}"
-                  echo "Head ref: ${{ github.head_ref }}"
-                  echo "PR SHA: ${{ github.event.pull_request.head.sha }}"
-
-                  if [[ "${{ github.event.action }}" == "opened" && "${{ github.actor }}" == "kilocode-bot" ]]; then
-                    echo "Using branch ref: ${{ github.head_ref }}"
-                    echo "git_ref=${{ github.head_ref }}" >> $GITHUB_OUTPUT
-                  else
-                    echo "Using SHA ref: ${{ github.event.pull_request.head.sha }}"
-                    echo "git_ref=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
-                  fi
-
-            - name: Checkout Repo
-              uses: actions/checkout@v4
+            # Remove changelog-ready label from changeset PR if present
+            - name: Remove changelog-ready label from changeset PR
+              if: steps.changesets.outputs.pullRequestNumber
+              uses: actions/github-script@v7
               with:
-                  token: ${{ secrets.CROSS_REPO_ACCESS_TOKEN }}
-                  fetch-depth: 0
-                  ref: ${{ steps.checkout-ref.outputs.git_ref }}
+                  github-token: ${{ secrets.CROSS_REPO_ACCESS_TOKEN }}
+                  script: |
+                      try {
+                        await github.rest.issues.removeLabel({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: ${{ steps.changesets.outputs.pullRequestNumber }},
+                          name: 'changelog-ready'
+                        });
+                        console.log('Removed changelog-ready label from changeset PR');
+                      } catch (error) {
+                        if (error.status === 404) {
+                          console.log('changelog-ready label was not present on changeset PR');
+                        } else {
+                          throw error;
+                        }
+                      }
 
             # Get current and previous versions to edit changelog entry
             - name: Get version
               id: get_version
               run: |
-                  VERSION=$(git show HEAD:package.json | jq -r '.version')
+                  VERSION=$(git show HEAD:src/package.json | jq -r '.version')
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
-                  PREV_VERSION=$(git show origin/main:package.json | jq -r '.version')
+                  PREV_VERSION=$(git show origin/main:src/package.json | jq -r '.version')
                   echo "prev_version=$PREV_VERSION" >> $GITHUB_OUTPUT
                   echo "version=$VERSION"
                   echo "prev_version=$PREV_VERSION"
-
-            # Update CHANGELOG.md with proper format
+              # Update CHANGELOG.md with proper format
             - name: Update Changelog Format
               if: ${{ !contains(github.event.pull_request.labels.*.name, 'changelog-ready') }}
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
                   PREV_VERSION: ${{ steps.get_version.outputs.prev_version }}
-              run: python .github/scripts/overwrite_changeset_changelog.py
+              run: |
+                  echo "Running changelog formatting script..."
+                  echo "VERSION: $VERSION"
+                  echo "PREV_VERSION: $PREV_VERSION"
+                  echo "Current changelog start:"
+                  head -20 CHANGELOG.md
+                  echo "===================="
+                  python .github/scripts/overwrite_changeset_changelog.py
+                  echo "===================="
+                  echo "Updated changelog start:"
+                  head -20 CHANGELOG.md
 
             # Commit and push changelog updates
             - name: Push Changelog updates
@@ -138,21 +135,14 @@ jobs:
 
             # Add label to indicate changelog has been formatted
             - name: Add changelog-ready label
-              if: ${{ !contains(github.event.pull_request.labels.*.name, 'changelog-ready') }}
+              if: ${{ steps.changesets.outputs.pullRequestNumber && !contains(github.event.pull_request.labels.*.name, 'changelog-ready') }}
               uses: actions/github-script@v7
               with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  github-token: ${{ secrets.CROSS_REPO_ACCESS_TOKEN }}
                   script: |
                       await github.rest.issues.addLabels({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
-                        issue_number: context.issue.number,
+                        issue_number: ${{ steps.changesets.outputs.pullRequestNumber }},
                         labels: ['changelog-ready']
                       });
-
-            # Auto-approve PR only after it has been labeled
-            - name: Auto approve PR
-              if: contains(github.event.pull_request.labels.*.name, 'changelog-ready')
-              uses: hmarr/auto-approve-action@v4
-              with:
-                  review-message: "I'm approving since it's a bump version PR"

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -83,7 +83,11 @@ jobs:
 
                   # Extract changelog for current version
                   echo "Extracting changelog for version ${current_package_version}"
-                  changelog_content=$(sed -n "/## \\[${current_package_version}\\]/,/## \\[/p" CHANGELOG.md | sed '$d')
+                  # Try with 'v' prefix first (newer format), then without (older format)
+                  changelog_content=$(sed -n "/## \\[v${current_package_version}\\]/,/## \\[/p" CHANGELOG.md | sed '$d')
+                  if [ -z "$changelog_content" ]; then
+                    changelog_content=$(sed -n "/## \\[${current_package_version}\\]/,/## \\[/p" CHANGELOG.md | sed '$d')
+                  fi
 
                   # If changelog extraction failed, use a default message
                   if [ -z "$changelog_content" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # kilo-code
 
-## 4.32.0
+## [v4.32.0]
 
 ### Minor Changes
 
@@ -14,7 +14,7 @@
 
 - [#561](https://github.com/Kilo-Org/kilocode/pull/561) [`4e8c7f2`](https://github.com/Kilo-Org/kilocode/commit/4e8c7f2394af0e0bef642a209acc6d6572602297) Thanks [@kevinvandijk](https://github.com/kevinvandijk)! - Revert previous update, we found some issues, apologies
 
-## 4.30.0
+## [v4.30.0]
 
 ### Minor Changes
 
@@ -30,15 +30,15 @@
 
 - [#551](https://github.com/Kilo-Org/kilocode/pull/551) [`b6bc484`](https://github.com/Kilo-Org/kilocode/commit/b6bc4845b9e545d913bc76db2dae63fb744f87d1) Thanks [@chrarnoldus](https://github.com/chrarnoldus)! - Kilo Code now has a menu item label on the right side panel
 
-## [4.29.2]
+## [v4.29.2]
 
 - [#524](https://github.com/Kilo-Org/kilocode/pull/524) [`e1d59f1`](https://github.com/Kilo-Org/kilocode/commit/e1d59f1278916b98ac4f1fa8a02cb694633b475e) Thanks [@chrarnoldus](https://github.com/chrarnoldus)! - Fix menu stops working when Kilo Code is moved between primary and secondary sidebars
 
-## [4.29.1]
+## [v4.29.1]
 
 - [#520](https://github.com/Kilo-Org/kilocode/pull/520) [`2e53902`](https://github.com/Kilo-Org/kilocode/commit/2e539020b1d4d19beba9c9a5929055cacd11f292) Thanks [@kevinvandijk](https://github.com/kevinvandijk)! - Change recommended model to Claude 4 Sonnet
 
-## 4.29.0
+## [v4.29.0]
 
 ### Minor Changes
 
@@ -52,11 +52,11 @@
 
 - [#507](https://github.com/Kilo-Org/kilocode/pull/507) [`6734fd9`](https://github.com/Kilo-Org/kilocode/commit/6734fd903eaa8617369dd2a07a1a03610970017e) Thanks [@daliovic](https://github.com/daliovic)! - Also include support for claude 4 models via the Anthropic provider
 
-## [4.28.1]
+## [v4.28.1]
 
 - [#488](https://github.com/Kilo-Org/kilocode/pull/488) [`cd22ade`](https://github.com/Kilo-Org/kilocode/commit/cd22adee2290bb45951973584f37ed731065c63b) Thanks [@EamonNerbonne](https://github.com/EamonNerbonne)! - Enable caching for the new anthropic models
 
-## 4.28.0
+## [v4.28.0]
 
 ### Minor Changes
 
@@ -66,7 +66,7 @@
 
 - [#484](https://github.com/Kilo-Org/kilocode/pull/484) [`dd15860`](https://github.com/Kilo-Org/kilocode/commit/dd158603d42a996094de6bce7ead5bcc5077c754) Thanks [@RSO](https://github.com/RSO)! - Fixed rendering of avatars in the Profile section
 
-## 4.27.0
+## [v4.27.0]
 
 ### Minor Changes
 
@@ -74,7 +74,7 @@
 
 - [#476](https://github.com/Kilo-Org/kilocode/pull/476) [`262e7a2`](https://github.com/Kilo-Org/kilocode/commit/262e7a23c6c8f28742d11160982454762240940e) Thanks [@kevinvandijk](https://github.com/kevinvandijk)! - Add /smol command (thanks Cline and @0xToshii)
 
-## 4.26.0
+## [v4.26.0]
 
 ### Minor Changes
 
@@ -84,7 +84,7 @@
 
 - [#442](https://github.com/Kilo-Org/kilocode/pull/442) [`b1b0f58`](https://github.com/Kilo-Org/kilocode/commit/b1b0f5857a5d86ac6b8fd455171c6fcdaef31722) Thanks [@chrarnoldus](https://github.com/chrarnoldus)! - The Kilo Code Provider now supports web-based IDEs, such as FireBase Studio, through an alternative authentication flow. The user should copy and paste the API Key manually in this case.
 
-## 4.25.0
+## [v4.25.0]
 
 ### Minor Changes
 
@@ -100,7 +100,7 @@
 
 - [#434](https://github.com/Kilo-Org/kilocode/pull/434) [`f38e83c`](https://github.com/Kilo-Org/kilocode/commit/f38e83c3b640772bb376504ed65804e2da921fa0) Thanks [@RSO](https://github.com/RSO)! - Fixed bug in SettingsView that caused issues with detecting/saving changes
 
-## [4.24.0]
+## [v4.24.0]
 
 ### Minor Changes
 
@@ -114,7 +114,7 @@
 
 - [#354](https://github.com/Kilo-Org/kilocode/pull/354) [`106b722`](https://github.com/Kilo-Org/kilocode/commit/106b722e747f98edb15b5a8e7a65e19db31028db) Thanks [@hassoncs](https://github.com/hassoncs)! - Fix wrong model after login (#213)
 
-## [4.23.0]
+## [v4.23.0]
 
 ### Minor Changes
 
@@ -122,7 +122,7 @@
 
 - [#303](https://github.com/Kilo-Org/kilocode/pull/303) [`b69a57e`](https://github.com/Kilo-Org/kilocode/commit/b69a57e316a740470a8be40d77dad50efde5c35c) Thanks [@drakonen](https://github.com/drakonen)! - Kilo Code Provider can now do all the OpenRouter models
 
-## [4.22.0]
+## [v4.22.0]
 
 ### Minor Changes
 
@@ -133,7 +133,7 @@
 - Fixed UI Issue - Unreadable transparent section at bottom of chat textArea. Thanks to @agape-apps for reporting this issue! See [Kilo-Org/kilocode#306](https://github.com/Kilo-Org/kilocode/issues/306)
 - Fix feedback button overlapping selection action button in history view
 
-## [4.21.0]
+## [v4.21.0]
 
 ### Minor Changes
 
@@ -143,25 +143,25 @@
 
 - Fix issue with removed slash commands for changing modes
 
-## [4.20.1]
+## [v4.20.1]
 
 ### Patch Changes
 
 - Use the phrase feature-merge instead of superset in displayName and README
 - Fix "Some text unreadable in Light high contrast theme" issue
 
-## [4.20.0]
+## [v4.20.0]
 
 - Include slash commands from Cline, include /newtask command
 
-## [4.19.1]
+## [v4.19.1]
 
 ### Patch Changes
 
 - Fix translations for system notifications
 - Include changes from Roo Code v3.14.3
 
-## [4.19.0]
+## [v4.19.0]
 
 ### Minor Changes
 
@@ -171,7 +171,7 @@
 
 - Small UI improvements for dark themes
 
-## [4.18.0]
+## [v4.18.0]
 
 ### Minor Changes
 
@@ -182,7 +182,7 @@
 - Fix settingview appearing not to save when hitting save button
 - Fix dark buttons on light vscode themes (thanks @Aikiboy123)
 
-## [4.17.0]
+## [v4.17.0]
 
 ### Minor Changes
 
@@ -196,15 +196,15 @@
 - Fix feedback button overlapping create mode button in prompts view
 - Fix image thumbnails after pasting image (thanks @Aikiboy123)
 
-## [4.16.2]
+## [v4.16.2]
 
 - Include Roo Code v3.12.3 changes
 
-## [4.16.1]
+## [v4.16.1]
 
 - Fix http referer header
 
-## [4.16.0]
+## [v4.16.0]
 
 ### Minor Changes
 
@@ -215,6 +215,6 @@
 - Fix confirmation dialog not closing in settings view
 - Add support for Gemini 2.5 Flash Preview for Kilo Code provider
 
-## [4.15.0]
+## [v4.15.0]
 
 - Pull in updates from Roo Code v3.11.7


### PR DESCRIPTION
Fixed the workflow files and adjusted the overwrite_changelog file so that the changelog is now properly auto-generated on release. Also makes sure to adjust the Changeset PR properly instead of with a malformed changelog