### PR TITLE
Improve Autocomplete Text Insertion when prefix/suffix matches existing text in the Document

### DIFF
--- a/src/services/autocomplete/AutocompleteDecorationAnimation.ts
+++ b/src/services/autocomplete/AutocompleteDecorationAnimation.ts
@@ -6,7 +6,6 @@ export const UI_SHOW_LOADING_DELAY_MS = 150
  * Manages the animated decoration for autocomplete loading indicator
  */
 export class AutocompleteDecorationAnimation {
-	private static instance: AutocompleteDecorationAnimation
 	private animationInitialWaitTimer: NodeJS.Timeout | null = null
 	private animationInterval: NodeJS.Timeout | null = null
 	private decorationType: vscode.TextEditorDecorationType
@@ -17,7 +16,7 @@ export class AutocompleteDecorationAnimation {
 	private editor: vscode.TextEditor | null = null
 	private range: vscode.Range | null = null
 
-	private constructor() {
+	constructor() {
 		this.decorationType = vscode.window.createTextEditorDecorationType({
 			after: {
 				color: new vscode.ThemeColor("editorGhostText.foreground"),
@@ -26,13 +25,6 @@ export class AutocompleteDecorationAnimation {
 			},
 			rangeBehavior: vscode.DecorationRangeBehavior.ClosedOpen,
 		})
-	}
-
-	public static getInstance(): AutocompleteDecorationAnimation {
-		if (!AutocompleteDecorationAnimation.instance) {
-			AutocompleteDecorationAnimation.instance = new AutocompleteDecorationAnimation()
-		}
-		return AutocompleteDecorationAnimation.instance
 	}
 
 	/**

--- a/src/services/autocomplete/AutocompleteProvider.ts
+++ b/src/services/autocomplete/AutocompleteProvider.ts
@@ -74,6 +74,7 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 		enabled: true,
 		lastCompletionCost: 0,
 		totalSessionCost: 0,
+		lastCompletionTime: 0,
 		model: DEFAULT_MODEL,
 		hasValidToken: !!ContextProxy.instance.getProviderSettings().kilocodeToken,
 	}
@@ -119,6 +120,9 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 		codeContext: CodeContext,
 	): Promise<{ autocompletion: Autocompletion | null; cost: number }> => {
 		if (!apiHandler) throw new Error("apiHandler must be set before calling generateCompletion!")
+
+		// Start timing the completion
+		const startTime = performance.now()
 
 		abortController?.abort() // Abort any previous request
 		abortController = new AbortController()
@@ -169,12 +173,19 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 			processedCompletion = ""
 		}
 
-		// Update cost tracking variables
+		// Calculate completion time
+		const endTime = performance.now()
+		const completionTimeMs = endTime - startTime
+		const completionTimeSeconds = completionTimeMs / 1000
+
+		// Update cost and timing tracking variables
 		state.totalSessionCost += completionCost
 		state.lastCompletionCost = completionCost
+		state.lastCompletionTime = completionTimeSeconds
 		console.log(`🚀💰 Completion cost: ${formatCost(completionCost)}`)
+		console.log(`🚀⏱️ Completion time: ${completionTimeSeconds.toFixed(1)}s`)
 
-		// Update status bar with cost information
+		// Update status bar with cost and timing information
 		statusBar.updateDisplay(state)
 
 		// Stop animation when completion is done

--- a/src/services/autocomplete/AutocompleteProvider.ts
+++ b/src/services/autocomplete/AutocompleteProvider.ts
@@ -140,7 +140,7 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 
 		abortController?.abort() // Abort any previous request
 		abortController = new AbortController()
-		animationManager.startAnimation()
+		const stopAnimation = animationManager.startAnimation()
 
 		const snippets = [
 			...generateImportSnippets(true, codeContext.imports, codeContext.document.uri.fsPath),
@@ -202,8 +202,8 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 		// Update status bar with cost and timing information
 		statusBar.updateDisplay(state)
 
-		// Stop animation when completion is done
-		animationManager.stopAnimation()
+		// Stop this animation (no-op if superseded by newer animation)
+		stopAnimation()
 
 		// Process the completion text for insertion
 		if (processedCompletion) {

--- a/src/services/autocomplete/AutocompleteProvider.ts
+++ b/src/services/autocomplete/AutocompleteProvider.ts
@@ -86,7 +86,6 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 	let lastCompletionCost = 0 // Track the cost of the last completion
 	let totalSessionCost = 0 // Track the total cost of all completions in the session
 
-	// LRU Cache for completions
 	const completionsCache = new LRUCache<string, string[]>({
 		max: 50,
 		ttl: 1000 * 60 * 60 * 24, // Cache for 24 hours
@@ -94,12 +93,11 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 
 	// Services
 	const contextGatherer = new ContextGatherer()
-	const animationManager = AutocompleteDecorationAnimation.getInstance()
+	const animationManager = new AutocompleteDecorationAnimation()
 
-	// Initialize API handler only if we have a valid token
+	// API Handling
 	let apiHandler: ApiHandler | null = null
 	const kilocodeToken = ContextProxy.instance.getProviderSettings().kilocodeToken
-
 	if (kilocodeToken) {
 		apiHandler = buildApiHandler({
 			apiProvider: "kilocode",
@@ -108,6 +106,7 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 		})
 	}
 
+	// Helper Functions
 	const clearState = () => {
 		vscode.commands.executeCommand("editor.action.inlineSuggest.hide")
 		animationManager.stopAnimation()

--- a/src/services/autocomplete/AutocompleteStatusBar.ts
+++ b/src/services/autocomplete/AutocompleteStatusBar.ts
@@ -1,0 +1,48 @@
+import * as vscode from "vscode"
+import { formatCost } from "./utils/costFormatting"
+
+export interface AutocompleteState {
+	enabled: boolean
+	lastCompletionCost: number
+	totalSessionCost: number
+	model: string
+	hasValidToken: boolean
+}
+
+export class AutocompleteStatusBar implements vscode.Disposable {
+	private statusBarItem: vscode.StatusBarItem
+
+	constructor() {
+		this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100)
+		this.statusBarItem.command = "kilo-code.toggleAutocomplete"
+		this.statusBarItem.show()
+	}
+
+	updateDisplay(state: AutocompleteState): void {
+		if (!state.enabled) {
+			this.statusBarItem.text = "$(circle-slash) Kilo Complete"
+			this.statusBarItem.tooltip = "Kilo Code Autocomplete (disabled)"
+			return
+		}
+
+		if (!state.hasValidToken) {
+			this.statusBarItem.text = "$(warning) Kilo Complete"
+			this.statusBarItem.tooltip = "A valid Kilocode token must be set to use autocomplete"
+			return
+		}
+
+		const totalCostFormatted = formatCost(state.totalSessionCost)
+		this.statusBarItem.text = `$(sparkle) Kilo Complete (${totalCostFormatted})`
+		this.statusBarItem.tooltip = `\
+Kilo Code Autocomplete
+
+Last completion: $${state.lastCompletionCost.toFixed(5)}
+Session total cost: ${formatCost(state.totalSessionCost)}
+Model: ${state.model}\
+`
+	}
+
+	dispose(): void {
+		this.statusBarItem.dispose()
+	}
+}

--- a/src/services/autocomplete/AutocompleteStatusBar.ts
+++ b/src/services/autocomplete/AutocompleteStatusBar.ts
@@ -33,7 +33,8 @@ export class AutocompleteStatusBar implements vscode.Disposable {
 		}
 
 		const totalCostFormatted = formatCost(state.totalSessionCost)
-		this.statusBarItem.text = `$(sparkle) Kilo Complete (${totalCostFormatted})`
+		const timingText = state.lastCompletionTime > 0 ? ` ${state.lastCompletionTime.toFixed(1)}s` : ""
+		this.statusBarItem.text = `$(sparkle) Kilo Complete (${totalCostFormatted}${timingText})`
 		this.statusBarItem.tooltip = `\
 Kilo Code Autocomplete
 

--- a/src/services/autocomplete/AutocompleteStatusBar.ts
+++ b/src/services/autocomplete/AutocompleteStatusBar.ts
@@ -5,6 +5,7 @@ export interface AutocompleteState {
 	enabled: boolean
 	lastCompletionCost: number
 	totalSessionCost: number
+	lastCompletionTime: number
 	model: string
 	hasValidToken: boolean
 }
@@ -32,11 +33,12 @@ export class AutocompleteStatusBar implements vscode.Disposable {
 		}
 
 		const totalCostFormatted = formatCost(state.totalSessionCost)
-		this.statusBarItem.text = `$(sparkle) Kilo Complete (${totalCostFormatted})`
+		const timeDisplay = state.lastCompletionTime > 0 ? `${state.lastCompletionTime.toFixed(1)}s` : ""
+		this.statusBarItem.text = `$(sparkle) Kilo Complete (${totalCostFormatted}) [${timeDisplay}]`
 		this.statusBarItem.tooltip = `\
 Kilo Code Autocomplete
 
-Last completion: $${state.lastCompletionCost.toFixed(5)}
+Last completion: $${state.lastCompletionCost.toFixed(5)}${state.lastCompletionTime > 0 ? ` (${state.lastCompletionTime.toFixed(1)}s)` : ""}
 Session total cost: ${formatCost(state.totalSessionCost)}
 Model: ${state.model}\
 `

--- a/src/services/autocomplete/AutocompleteStatusBar.ts
+++ b/src/services/autocomplete/AutocompleteStatusBar.ts
@@ -33,8 +33,7 @@ export class AutocompleteStatusBar implements vscode.Disposable {
 		}
 
 		const totalCostFormatted = formatCost(state.totalSessionCost)
-		const timeDisplay = state.lastCompletionTime > 0 ? `${state.lastCompletionTime.toFixed(1)}s` : ""
-		this.statusBarItem.text = `$(sparkle) Kilo Complete (${totalCostFormatted}) [${timeDisplay}]`
+		this.statusBarItem.text = `$(sparkle) Kilo Complete (${totalCostFormatted})`
 		this.statusBarItem.tooltip = `\
 Kilo Code Autocomplete
 

--- a/src/services/autocomplete/ContextGatherer.ts
+++ b/src/services/autocomplete/ContextGatherer.ts
@@ -57,6 +57,8 @@ export interface CodeContext {
 	followingLines: string[]
 	imports: string[] // Keep this for simple import strings
 	definitions: CodeContextDefinition[] // This will now hold combined context
+	document: vscode.TextDocument
+	position: vscode.Position
 }
 
 // PLANREF: continue/extensions/vscode/src/autocomplete/recentlyEdited.ts
@@ -735,6 +737,8 @@ export class ContextGatherer {
 			followingLines,
 			imports: importStrings,
 			definitions: allDefinitions,
+			document,
+			position,
 		}
 	}
 

--- a/src/services/autocomplete/__tests__/AutocompleteStatusBar.test.ts
+++ b/src/services/autocomplete/__tests__/AutocompleteStatusBar.test.ts
@@ -40,6 +40,7 @@ describe("AutocompleteStatusBar", () => {
 				enabled: false,
 				lastCompletionCost: 0,
 				totalSessionCost: 0,
+				lastCompletionTime: 0,
 				model: "test-model",
 				hasValidToken: true,
 			}
@@ -55,6 +56,7 @@ describe("AutocompleteStatusBar", () => {
 				enabled: true,
 				lastCompletionCost: 0,
 				totalSessionCost: 0,
+				lastCompletionTime: 0,
 				model: "test-model",
 				hasValidToken: false,
 			}
@@ -70,14 +72,15 @@ describe("AutocompleteStatusBar", () => {
 				enabled: true,
 				lastCompletionCost: 0.00123,
 				totalSessionCost: 0.05,
+				lastCompletionTime: 1.5,
 				model: "test-model",
 				hasValidToken: true,
 			}
 
 			statusBar.updateDisplay(state)
 
-			expect(mockStatusBarItem.text).toBe("$(sparkle) Kilo Complete ($0.05)")
-			expect(mockStatusBarItem.tooltip).toContain("Last completion: $0.00123")
+			expect(mockStatusBarItem.text).toBe("$(sparkle) Kilo Complete ($0.05 1.5s)")
+			expect(mockStatusBarItem.tooltip).toContain("Last completion: $0.00123 (1.5s)")
 			expect(mockStatusBarItem.tooltip).toContain("Session total cost: $0.05")
 			expect(mockStatusBarItem.tooltip).toContain("Model: test-model")
 		})
@@ -87,12 +90,13 @@ describe("AutocompleteStatusBar", () => {
 				enabled: true,
 				lastCompletionCost: 0.005,
 				totalSessionCost: 0.002,
+				lastCompletionTime: 2.3,
 				model: "test-model",
 				hasValidToken: true,
 			}
 
 			statusBar.updateDisplay(state)
-			expect(mockStatusBarItem.text).toBe("$(sparkle) Kilo Complete (<$0.01)")
+			expect(mockStatusBarItem.text).toBe("$(sparkle) Kilo Complete (<$0.01 2.3s)")
 		})
 
 		it("should format zero cost correctly", () => {
@@ -100,12 +104,44 @@ describe("AutocompleteStatusBar", () => {
 				enabled: true,
 				lastCompletionCost: 0,
 				totalSessionCost: 0,
+				lastCompletionTime: 0,
 				model: "test-model",
 				hasValidToken: true,
 			}
 
 			statusBar.updateDisplay(state)
 			expect(mockStatusBarItem.text).toBe("$(sparkle) Kilo Complete ($0.00)")
+		})
+
+		it("should show timing information when available", () => {
+			const state: AutocompleteState = {
+				enabled: true,
+				lastCompletionCost: 0.001,
+				totalSessionCost: 0.01,
+				lastCompletionTime: 2.7,
+				model: "test-model",
+				hasValidToken: true,
+			}
+
+			statusBar.updateDisplay(state)
+			expect(mockStatusBarItem.text).toBe("$(sparkle) Kilo Complete ($0.01 2.7s)")
+			expect(mockStatusBarItem.tooltip).toContain("Last completion: $0.00100 (2.7s)")
+		})
+
+		it("should not show timing when lastCompletionTime is 0", () => {
+			const state: AutocompleteState = {
+				enabled: true,
+				lastCompletionCost: 0.001,
+				totalSessionCost: 0.01,
+				lastCompletionTime: 0,
+				model: "test-model",
+				hasValidToken: true,
+			}
+
+			statusBar.updateDisplay(state)
+			expect(mockStatusBarItem.text).toBe("$(sparkle) Kilo Complete ($0.01)")
+			expect(mockStatusBarItem.tooltip).toContain("Last completion: $0.00100")
+			expect(mockStatusBarItem.tooltip).not.toContain("(0.0s)")
 		})
 	})
 

--- a/src/services/autocomplete/__tests__/AutocompleteStatusBar.test.ts
+++ b/src/services/autocomplete/__tests__/AutocompleteStatusBar.test.ts
@@ -1,0 +1,118 @@
+import * as vscode from "vscode"
+import { AutocompleteStatusBar } from "../AutocompleteStatusBar"
+import { AutocompleteState } from "../types"
+
+// Mock VSCode API
+jest.mock("vscode", () => ({
+	window: {
+		createStatusBarItem: jest.fn(),
+	},
+	StatusBarAlignment: {
+		Right: 2,
+	},
+}))
+
+describe("AutocompleteStatusBar", () => {
+	let mockStatusBarItem: any
+	let statusBar: AutocompleteStatusBar
+
+	beforeEach(() => {
+		mockStatusBarItem = {
+			text: "",
+			tooltip: "",
+			command: "",
+			show: jest.fn(),
+			dispose: jest.fn(),
+		}
+		;(vscode.window.createStatusBarItem as jest.Mock).mockReturnValue(mockStatusBarItem)
+
+		statusBar = new AutocompleteStatusBar()
+	})
+
+	afterEach(() => {
+		statusBar.dispose()
+		jest.clearAllMocks()
+	})
+
+	describe("updateDisplay", () => {
+		it("should show disabled state when enabled is false", () => {
+			const state: AutocompleteState = {
+				enabled: false,
+				lastCompletionCost: 0,
+				totalSessionCost: 0,
+				model: "test-model",
+				hasValidToken: true,
+			}
+
+			statusBar.updateDisplay(state)
+
+			expect(mockStatusBarItem.text).toBe("$(circle-slash) Kilo Complete")
+			expect(mockStatusBarItem.tooltip).toBe("Kilo Code Autocomplete (disabled)")
+		})
+
+		it("should show warning state when token is invalid", () => {
+			const state: AutocompleteState = {
+				enabled: true,
+				lastCompletionCost: 0,
+				totalSessionCost: 0,
+				model: "test-model",
+				hasValidToken: false,
+			}
+
+			statusBar.updateDisplay(state)
+
+			expect(mockStatusBarItem.text).toBe("$(warning) Kilo Complete")
+			expect(mockStatusBarItem.tooltip).toBe("A valid Kilocode token must be set to use autocomplete")
+		})
+
+		it("should show enabled state with cost information", () => {
+			const state: AutocompleteState = {
+				enabled: true,
+				lastCompletionCost: 0.00123,
+				totalSessionCost: 0.05,
+				model: "test-model",
+				hasValidToken: true,
+			}
+
+			statusBar.updateDisplay(state)
+
+			expect(mockStatusBarItem.text).toBe("$(sparkle) Kilo Complete ($0.05)")
+			expect(mockStatusBarItem.tooltip).toContain("Last completion: $0.00123")
+			expect(mockStatusBarItem.tooltip).toContain("Session total cost: $0.05")
+			expect(mockStatusBarItem.tooltip).toContain("Model: test-model")
+		})
+
+		it("should format small costs correctly", () => {
+			const state: AutocompleteState = {
+				enabled: true,
+				lastCompletionCost: 0.005,
+				totalSessionCost: 0.002,
+				model: "test-model",
+				hasValidToken: true,
+			}
+
+			statusBar.updateDisplay(state)
+			expect(mockStatusBarItem.text).toBe("$(sparkle) Kilo Complete (<$0.01)")
+		})
+
+		it("should format zero cost correctly", () => {
+			const state: AutocompleteState = {
+				enabled: true,
+				lastCompletionCost: 0,
+				totalSessionCost: 0,
+				model: "test-model",
+				hasValidToken: true,
+			}
+
+			statusBar.updateDisplay(state)
+			expect(mockStatusBarItem.text).toBe("$(sparkle) Kilo Complete ($0.00)")
+		})
+	})
+
+	describe("disposal", () => {
+		it("should dispose of status bar item", () => {
+			statusBar.dispose()
+			expect(mockStatusBarItem.dispose).toHaveBeenCalled()
+		})
+	})
+})

--- a/src/services/autocomplete/__tests__/CompletionTextProcessor.test.ts
+++ b/src/services/autocomplete/__tests__/CompletionTextProcessor.test.ts
@@ -1,0 +1,105 @@
+import "./autocompleteTestSetup"
+import * as vscode from "vscode"
+import { processTextInsertion, InsertionContext } from "../utils/CompletionTextProcessor"
+import { MockTextEditor } from "./MockTextEditor"
+
+describe("CompletionTextProcessor", () => {
+	test("should trim beginning when first line of completion starts with existing text", () => {
+		const completionText = "const x = 1 + 2;\nconsole.log(x);"
+		const { document, cursorPosition } = MockTextEditor.create("const x = ␣")
+
+		const result = processTextInsertion({ document, position: cursorPosition, textToInsert: completionText })
+		expect(result?.processedText).toBe("1 + 2;\nconsole.log(x);")
+	})
+
+	test("should trim end when last line of completion matches existing text", () => {
+		const completionText = "function add(a, b) {\n  return a + b;\n}"
+		const { document, cursorPosition } = MockTextEditor.create("function add(a, b) {␣\n}")
+
+		const result = processTextInsertion({ document, position: cursorPosition, textToInsert: completionText })
+		expect(result?.processedText).toBe("\n  return a + b;") // only the non-overlapping part
+	})
+
+	test("should trim both beginning and end when both match", () => {
+		const completionText = "if (condition) {\n  doSomething();\n}"
+		const { document, cursorPosition } = MockTextEditor.create("if (condition) {␣\n}")
+
+		const result = processTextInsertion({ document, position: cursorPosition, textToInsert: completionText })
+		expect(result?.processedText).toBe("\n  doSomething();") // only the non-overlapping part
+	})
+
+	test("should return null when completion text is completely contained in existing text", () => {
+		const completionText = "const x = 1;"
+		const { document, cursorPosition } = MockTextEditor.create("const x = 1;␣")
+
+		const result = processTextInsertion({ document, position: cursorPosition, textToInsert: completionText })
+		expect(result).toBeNull()
+	})
+
+	test("should return original completion when there's no overlap", () => {
+		const completionText = "const y = 2;"
+		const { document, cursorPosition } = MockTextEditor.create("const x = 1;␣")
+
+		const result = processTextInsertion({ document, position: cursorPosition, textToInsert: completionText })
+		expect(result?.processedText).toBe("const y = 2;")
+	})
+
+	test("should handle the example case from the code", () => {
+		const completionText = "a + b\n}"
+		const { document, cursorPosition } = MockTextEditor.create("a + ␣")
+
+		const result = processTextInsertion({ document, position: cursorPosition, textToInsert: completionText })
+		expect(result?.processedText).toBe("b\n}")
+	})
+
+	test("should handle auto-closing parenthesis", () => {
+		const completionText = "a, b) {\n  return a + b\n}"
+		const { document, cursorPosition } = MockTextEditor.create(`function sum(␣)`)
+
+		const result = processTextInsertion({ document, position: cursorPosition, textToInsert: completionText })
+		expect(result?.processedText).toBe("a, b) {\n  return a + b\n}")
+		expect(result?.insertRange).toEqual(new vscode.Range(cursorPosition, cursorPosition.translate(0, 1)))
+	})
+
+	test("should handle the case where closing brace already exists", () => {
+		const completionText = "a + b\n}"
+		const { document, cursorPosition } = MockTextEditor.create("a + ␣\n}")
+
+		const result = processTextInsertion({ document, position: cursorPosition, textToInsert: completionText })
+		expect(result?.processedText).toBe("b")
+	})
+
+	test("should handle common prefix with different suffixes", () => {
+		const completionText = "export function calculateSum(a: number, b: number)\n  return a + b;"
+		const { document, cursorPosition } = MockTextEditor.create("export function calculate␣): number {")
+
+		const result = processTextInsertion({ document, position: cursorPosition, textToInsert: completionText })
+		// Should find the common prefix "export function calculate" and only return the remaining part
+		expect(result?.processedText).toBe("Sum(a: number, b: number)\n  return a + b;")
+	})
+
+	test("should provide modification information", () => {
+		const completionText = "const x = 1 + 2;\nconsole.log(x);"
+		const { document, cursorPosition } = MockTextEditor.create("const x = ␣")
+
+		const result = processTextInsertion({ document, position: cursorPosition, textToInsert: completionText })
+		expect(result?.modifications).toEqual({
+			prefixTrimmed: 10, // "const x = " plus trailing space
+			suffixTrimmed: 0,
+			originalLength: completionText.length,
+		})
+	})
+
+	test("should handle whitespace before completion text", () => {
+		const completionText = "return a + b"
+		const { document, cursorPosition } = MockTextEditor.create(
+			`\
+function sum(a:number, b:number): number {
+  return ␣
+}`,
+		)
+
+		const result = processTextInsertion({ document, position: cursorPosition, textToInsert: completionText })
+		expect(result?.processedText).toBe("a + b")
+	})
+})

--- a/src/services/autocomplete/__tests__/MockTextDocument.ts
+++ b/src/services/autocomplete/__tests__/MockTextDocument.ts
@@ -1,0 +1,66 @@
+import * as vscode from "vscode"
+
+/**
+ * Create a mock TextDocument for testing
+ * This implementation does not contain cursor position information
+ */
+export class MockTextDocument {
+	private contentLines: string[]
+
+	constructor(content: string) {
+		this.contentLines = content.split("\n")
+	}
+
+	getText(range?: vscode.Range): string {
+		if (!range) {
+			return this.contentLines.join("\n")
+		}
+
+		const startLine = range.start.line
+		const endLine = range.end.line
+
+		if (startLine === endLine) {
+			return this.contentLines[startLine].substring(range.start.character, range.end.character)
+		}
+
+		const lines: string[] = []
+		for (let i = startLine; i <= endLine && i < this.contentLines.length; i++) {
+			if (i === startLine) {
+				lines.push(this.contentLines[i].substring(range.start.character))
+			} else if (i === endLine) {
+				lines.push(this.contentLines[i].substring(0, range.end.character))
+			} else {
+				lines.push(this.contentLines[i])
+			}
+		}
+
+		return lines.join("\n")
+	}
+
+	get lineCount(): number {
+		return this.contentLines.length
+	}
+
+	/**
+	 * Returns information about a specific line in the document
+	 * @param lineNumber The zero-based line number
+	 * @returns A simplified TextLine object containing the text and position information
+	 */
+	lineAt(lineNumber: number): vscode.TextLine {
+		if (lineNumber < 0 || lineNumber >= this.contentLines.length) {
+			throw new Error(`Invalid line number: ${lineNumber}`)
+		}
+
+		const text = this.contentLines[lineNumber]
+		const range = new vscode.Range(new vscode.Position(lineNumber, 0), new vscode.Position(lineNumber, text.length))
+
+		return {
+			text,
+			range,
+			lineNumber,
+			rangeIncludingLineBreak: range,
+			firstNonWhitespaceCharacterIndex: text.search(/\S|$/),
+			isEmptyOrWhitespace: !/\S/.test(text),
+		} as vscode.TextLine
+	}
+}

--- a/src/services/autocomplete/__tests__/MockTextEditor.ts
+++ b/src/services/autocomplete/__tests__/MockTextEditor.ts
@@ -1,0 +1,53 @@
+import * as vscode from "vscode"
+import { MockTextDocument } from "./MockTextDocument"
+
+/**
+ * Special character used to mark cursor position in test documents.
+ * Using "␣" (U+2423, OPEN BOX) as it's visually distinct and unlikely to be in normal code.
+ */
+export const CURSOR_MARKER = "␣"
+
+/**
+ * MockTextEditor encapsulates both a TextDocument and cursor position
+ * for simpler testing of editor-related functionality
+ */
+export class MockTextEditor {
+	private _document: vscode.TextDocument
+	private _cursorPosition: vscode.Position
+
+	/**
+	 * Creates a new MockTextEditor
+	 * @param content Text content with required cursor marker (CURSOR_MARKER)
+	 */
+	constructor(content: string) {
+		// Find cursor position and remove the marker
+		const cursorOffset = content.indexOf(CURSOR_MARKER)
+		if (cursorOffset === -1) {
+			throw new Error(`Cursor marker ${CURSOR_MARKER} not found in test content`)
+		}
+
+		// Remove the cursor marker
+		const cleanContent = content.substring(0, cursorOffset) + content.substring(cursorOffset + CURSOR_MARKER.length)
+
+		// Calculate line and character for cursor position
+		const beforeCursor = content.substring(0, cursorOffset)
+		const lines = beforeCursor.split("\n")
+		const line = lines.length - 1
+		const character = lines[line].length
+
+		this._cursorPosition = new vscode.Position(line, character)
+		this._document = new MockTextDocument(cleanContent) as unknown as vscode.TextDocument
+	}
+
+	get document(): vscode.TextDocument {
+		return this._document
+	}
+
+	get cursorPosition(): vscode.Position {
+		return this._cursorPosition
+	}
+
+	static create(content: string): MockTextEditor {
+		return new MockTextEditor(content)
+	}
+}

--- a/src/services/autocomplete/__tests__/autocompleteTestSetup.ts
+++ b/src/services/autocomplete/__tests__/autocompleteTestSetup.ts
@@ -1,0 +1,41 @@
+// This file should be imported at the top of test files
+// It sets up common mocks used in tests
+
+// Mock the vscode module
+jest.mock("vscode", () => ({
+	Position: class {
+		constructor(
+			public line: number,
+			public character: number,
+		) {
+			this.line = line
+			this.character = character
+		}
+
+		translate(lineDelta: number, characterDelta: number): any {
+			return new (jest.requireMock("vscode").Position)(this.line + lineDelta, this.character + characterDelta)
+		}
+	},
+	Range: class {
+		constructor(
+			public start: any,
+			public end: any,
+		) {
+			this.start = start
+			this.end = end
+		}
+	},
+	InlineCompletionItem: class {
+		constructor(
+			public text: string,
+			public range: any,
+		) {
+			this.text = text
+			this.range = range
+		}
+	},
+	EndOfLine: {
+		LF: 1,
+		CRLF: 2,
+	},
+}))

--- a/src/services/autocomplete/__tests__/createApiHandler.test.ts
+++ b/src/services/autocomplete/__tests__/createApiHandler.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Test file to verify the API handler creation logic refactoring.
+ * This tests the logic that was extracted into the createApiHandler helper function.
+ */
+
+import { ContextProxy } from "../../../core/config/ContextProxy"
+import { buildApiHandler } from "../../../api"
+
+// Mock the dependencies
+jest.mock("../../../core/config/ContextProxy")
+jest.mock("../../../api")
+
+const mockBuildApiHandler = buildApiHandler as jest.MockedFunction<typeof buildApiHandler>
+const mockContextProxy = {
+	getProviderSettings: jest.fn(),
+} as any
+
+describe("API handler creation logic (refactored into createApiHandler)", () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+		;(ContextProxy as any).instance = mockContextProxy
+	})
+
+	/**
+	 * Tests the logic that was duplicated in two places and is now centralized
+	 * in the createApiHandler helper function
+	 */
+	const testApiHandlerCreation = (settings: any) => {
+		const { kilocodeToken, openRouterApiKey } = settings
+		const apiProvider = "kilocode"
+
+		if (kilocodeToken && !openRouterApiKey) {
+			return buildApiHandler({
+				apiProvider,
+				kilocodeModel: "google/gemini-2.5-flash-preview",
+				openRouterModelId: "google/gemini-2.5-flash-preview",
+				...settings,
+			})
+		}
+		return null
+	}
+
+	it("should create API handler when kilocodeToken exists and openRouterApiKey does not", () => {
+		const mockSettings = {
+			kilocodeToken: "test-token",
+			openRouterApiKey: undefined,
+			someOtherSetting: "value",
+		}
+
+		mockContextProxy.getProviderSettings.mockReturnValue(mockSettings)
+		mockBuildApiHandler.mockReturnValue({} as any)
+
+		const result = testApiHandlerCreation(mockSettings)
+
+		expect(result).toBeDefined()
+		expect(mockBuildApiHandler).toHaveBeenCalledWith({
+			apiProvider: "kilocode",
+			kilocodeToken: "test-token",
+			kilocodeModel: "google/gemini-2.5-flash-preview",
+			openRouterModelId: "google/gemini-2.5-flash-preview",
+			someOtherSetting: "value",
+		})
+	})
+
+	it("should return null when kilocodeToken is missing", () => {
+		const mockSettings = {
+			kilocodeToken: undefined,
+			openRouterApiKey: undefined,
+		}
+
+		const result = testApiHandlerCreation(mockSettings)
+
+		expect(result).toBeNull()
+		expect(mockBuildApiHandler).not.toHaveBeenCalled()
+	})
+
+	it("should return null when openRouterApiKey exists", () => {
+		const mockSettings = {
+			kilocodeToken: "test-token",
+			openRouterApiKey: "openrouter-key",
+		}
+
+		const result = testApiHandlerCreation(mockSettings)
+
+		expect(result).toBeNull()
+		expect(mockBuildApiHandler).not.toHaveBeenCalled()
+	})
+})

--- a/src/services/autocomplete/__tests__/tokenValidation.test.ts
+++ b/src/services/autocomplete/__tests__/tokenValidation.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Test file to verify the token validation logic refactoring.
+ * This tests that hasValidToken is correctly derived from the API handler state.
+ */
+
+import { ContextProxy } from "../../../core/config/ContextProxy"
+import { buildApiHandler } from "../../../api"
+
+// Mock the dependencies
+jest.mock("../../../core/config/ContextProxy")
+jest.mock("../../../api")
+
+const mockBuildApiHandler = buildApiHandler as jest.MockedFunction<typeof buildApiHandler>
+const mockContextProxy = {
+	getProviderSettings: jest.fn(),
+} as any
+
+describe("Token validation logic (using API handler state)", () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+		;(ContextProxy as any).instance = mockContextProxy
+	})
+
+	/**
+	 * Simulates the createApiHandler function from AutocompleteProvider.ts
+	 */
+	const createApiHandler = () => {
+		const { kilocodeToken, openRouterApiKey } = mockContextProxy.getProviderSettings()
+		const useOpenRouter = false // Use this to try out OpenRouter. Seems slightly faster?
+		const apiProvider = useOpenRouter ? "openrouter" : "kilocode"
+		if ((apiProvider === "kilocode" && kilocodeToken) || (apiProvider === "openrouter" && openRouterApiKey)) {
+			return buildApiHandler({
+				apiProvider,
+				kilocodeToken,
+				kilocodeModel: "google/gemini-2.5-flash-preview",
+				openRouterModelId: "google/gemini-2.5-flash-preview",
+				...mockContextProxy.getProviderSettings(),
+			})
+		}
+		return null
+	}
+
+	/**
+	 * Simulates the updateTokenStatus function from AutocompleteProvider.ts
+	 */
+	const updateTokenStatus = (apiHandler: any) => {
+		return apiHandler !== null
+	}
+
+	it("should return true for hasValidToken when API handler is created successfully", () => {
+		const mockSettings = {
+			kilocodeToken: "test-token",
+			openRouterApiKey: undefined,
+		}
+
+		mockContextProxy.getProviderSettings.mockReturnValue(mockSettings)
+		mockBuildApiHandler.mockReturnValue({} as any) // Mock successful API handler creation
+
+		const apiHandler = createApiHandler()
+		const hasValidToken = updateTokenStatus(apiHandler)
+
+		expect(hasValidToken).toBe(true)
+		expect(apiHandler).toBeDefined()
+		expect(mockBuildApiHandler).toHaveBeenCalled()
+	})
+
+	it("should return false for hasValidToken when API handler creation fails (no token)", () => {
+		const mockSettings = {
+			kilocodeToken: undefined,
+			openRouterApiKey: undefined,
+		}
+
+		mockContextProxy.getProviderSettings.mockReturnValue(mockSettings)
+
+		const apiHandler = createApiHandler()
+		const hasValidToken = updateTokenStatus(apiHandler)
+
+		expect(hasValidToken).toBe(false)
+		expect(apiHandler).toBeNull()
+		expect(mockBuildApiHandler).not.toHaveBeenCalled()
+	})
+
+	it("should return false for hasValidToken when API handler creation fails (empty token)", () => {
+		const mockSettings = {
+			kilocodeToken: "",
+			openRouterApiKey: undefined,
+		}
+
+		mockContextProxy.getProviderSettings.mockReturnValue(mockSettings)
+
+		const apiHandler = createApiHandler()
+		const hasValidToken = updateTokenStatus(apiHandler)
+
+		expect(hasValidToken).toBe(false)
+		expect(apiHandler).toBeNull()
+		expect(mockBuildApiHandler).not.toHaveBeenCalled()
+	})
+
+	it("should work correctly with OpenRouter when enabled", () => {
+		// This test simulates what would happen if useOpenRouter was true
+		const mockSettings = {
+			kilocodeToken: "test-token",
+			openRouterApiKey: "openrouter-key",
+		}
+
+		mockContextProxy.getProviderSettings.mockReturnValue(mockSettings)
+		mockBuildApiHandler.mockReturnValue({} as any)
+
+		// Simulate the logic when useOpenRouter = true
+		const createApiHandlerWithOpenRouter = () => {
+			const { kilocodeToken, openRouterApiKey } = mockContextProxy.getProviderSettings()
+			const useOpenRouter = true // Simulate OpenRouter being enabled
+			const apiProvider = useOpenRouter ? "openrouter" : "kilocode"
+			if ((apiProvider === "kilocode" && kilocodeToken) || (apiProvider === "openrouter" && openRouterApiKey)) {
+				return buildApiHandler({
+					apiProvider,
+					kilocodeToken,
+					kilocodeModel: "google/gemini-2.5-flash-preview",
+					openRouterModelId: "google/gemini-2.5-flash-preview",
+					...mockContextProxy.getProviderSettings(),
+				})
+			}
+			return null
+		}
+
+		const apiHandler = createApiHandlerWithOpenRouter()
+		const hasValidToken = updateTokenStatus(apiHandler)
+
+		expect(hasValidToken).toBe(true)
+		expect(apiHandler).toBeDefined()
+		expect(mockBuildApiHandler).toHaveBeenCalledWith({
+			apiProvider: "openrouter",
+			kilocodeToken: "test-token",
+			kilocodeModel: "google/gemini-2.5-flash-preview",
+			openRouterModelId: "google/gemini-2.5-flash-preview",
+			openRouterApiKey: "openrouter-key",
+		})
+	})
+})

--- a/src/services/autocomplete/cache/AutocompleteCache.ts
+++ b/src/services/autocomplete/cache/AutocompleteCache.ts
@@ -1,0 +1,116 @@
+import { LRUCache } from "lru-cache"
+import { CodeContext } from "../ContextGatherer"
+import { processTextInsertion } from "../utils/CompletionTextProcessor"
+import * as vscode from "vscode"
+
+/**
+ * Manages caching of code completions to improve response time and reduce API calls
+ */
+export class AutocompleteCache {
+	private cache: LRUCache<string, string[]>
+	private readonly maxCompletionsPerContext = 5
+	private readonly maxLinesToConsider = 5
+
+	/**
+	 * Creates a new AutocompleteCache instance
+	 * @param options Configuration options for the cache
+	 */
+	constructor(options?: { maxSize?: number; ttlMs?: number }) {
+		this.cache = new LRUCache<string, string[]>({
+			max: options?.maxSize ?? 50,
+			ttl: options?.ttlMs ?? 1000 * 60 * 60 * 24, // Default: Cache for 24 hours
+		})
+	}
+
+	/**
+	 * Finds a matching completion from the cache that starts with the current line prefix
+	 * @returns Processed text ready for insertion if found, null otherwise
+	 */
+	public findMatchingCompletion(
+		context: CodeContext,
+		document: vscode.TextDocument,
+		position: vscode.Position,
+	): { processedText: string; insertRange: vscode.Range } | null {
+		const linePrefix = document
+			.getText(new vscode.Range(new vscode.Position(position.line, 0), position))
+			.trimStart()
+
+		const cachedCompletions = this.getCompletionsInternal(context)
+
+		for (const completion of cachedCompletions) {
+			if (completion.startsWith(linePrefix)) {
+				// Process the completion text to avoid duplicating existing text in the document
+				const processedResult = processTextInsertion({
+					document,
+					position,
+					textToInsert: completion,
+				})
+
+				if (processedResult) {
+					return processedResult
+				}
+			}
+		}
+
+		return null
+	}
+
+	/**
+	 * Adds a new completion to the cache
+	 * @returns true if the completion was added, false if it was already in the cache
+	 */
+	public addCompletion(
+		context: CodeContext,
+		document: vscode.TextDocument,
+		position: vscode.Position,
+		completion: string,
+	): boolean {
+		const linePrefix = document
+			.getText(new vscode.Range(new vscode.Position(position.line, 0), position))
+			.trimStart()
+
+		const fullCompletion = linePrefix + completion
+		const key = this.generateKey(context)
+		const completions = this.cache.get(key) ?? []
+
+		// Add the new completion if it's not already in the list
+		if (completions.includes(fullCompletion)) {
+			return false
+		}
+
+		completions.push(fullCompletion)
+
+		// Prune the array if it exceeds the maximum size
+		// Keep the most recent completions (remove from the beginning)
+		if (completions.length > this.maxCompletionsPerContext) {
+			completions.splice(0, completions.length - this.maxCompletionsPerContext)
+		}
+
+		this.cache.set(key, completions)
+		return true
+	}
+
+	/**
+	 * Gets raw completions from the cache for a given context (private helper)
+	 */
+	private getCompletionsInternal(context: CodeContext): string[] {
+		const key = this.generateKey(context)
+		return this.cache.get(key) ?? []
+	}
+
+	/**
+	 * Generates a cache key based on context's preceding and following lines
+	 */
+	private generateKey(context: CodeContext): string {
+		const precedingContext = context.precedingLines.slice(-this.maxLinesToConsider).join("\n")
+		const followingContext = context.followingLines.slice(0, this.maxLinesToConsider).join("\n")
+		return `${precedingContext}|||${followingContext}`
+	}
+
+	/**
+	 * Clears the entire cache
+	 */
+	public clear(): void {
+		this.cache.clear()
+	}
+}

--- a/src/services/autocomplete/templating/AutocompleteTemplate.ts
+++ b/src/services/autocomplete/templating/AutocompleteTemplate.ts
@@ -11,12 +11,7 @@ import { CodeContext, CodeContextDefinition } from "../ContextGatherer"
 export interface AutocompleteTemplate {
 	compilePrefixSuffix?: (prefix: string, suffix: string) => [string, string]
 	getSystemPrompt: () => string
-	template: (
-		codeContext: CodeContext,
-		document: vscode.TextDocument,
-		position: vscode.Position,
-		snippets: AutocompleteSnippet[],
-	) => string
+	template: (codeContext: CodeContext, snippets: AutocompleteSnippet[]) => string
 	completionOptions?: Partial<CompletionOptions>
 }
 
@@ -121,12 +116,9 @@ function hypothenuse(a, b) {
 `
 		return SYSTEM_MSG
 	},
-	template: (
-		codeContext: CodeContext,
-		document: vscode.TextDocument,
-		position: vscode.Position,
-		snippets: AutocompleteSnippet[],
-	) => {
+	template: (codeContext: CodeContext, snippets: AutocompleteSnippet[]) => {
+		const { document, position } = codeContext
+
 		const offset = document.offsetAt(position)
 		const fileContent = document.getText()
 		const currentFileWithFillPlaceholder =

--- a/src/services/autocomplete/templating/AutocompleteTemplate.ts
+++ b/src/services/autocomplete/templating/AutocompleteTemplate.ts
@@ -32,85 +32,13 @@ export const holeFillerTemplate: AutocompleteTemplate = {
 		const SYSTEM_MSG = `You are a HOLE FILLER. You are provided with a file containing holes, formatted as '{{HOLE_NAME}}'.
 		Your TASK is to complete with a string to replace this hole with, inside a <COMPLETION/> XML tag, including context-aware indentation, if needed.
 		All completions MUST be truthful, accurate, well-written and correct.
-## EXAMPLE QUERY:
-
-<QUERY>
-function sum_evens(lim) {
-  var sum = 0;
-  for (var i = 0; i < lim; ++i) {
-    {{FILL_HERE}}
-  }
-  return sum;
-}
-</QUERY>
-
-TASK: Fill the {{FILL_HERE}} hole.
-
-## CORRECT COMPLETION
-
-<COMPLETION>if (i % 2 === 0) {
-      sum += i;
-    }</COMPLETION>
-
-## EXAMPLE QUERY:
-
-<QUERY>
-def sum_list(lst):
-  total = 0
-  for x in lst:
-  {{FILL_HERE}}
-  return total
-
-print sum_list([1, 2, 3])
-</QUERY>
-
-## CORRECT COMPLETION:
-
-<COMPLETION>  total += x</COMPLETION>
-
-## EXAMPLE QUERY:
-
-<QUERY>
-// data Tree a = Node (Tree a) (Tree a) | Leaf a
-
-// sum :: Tree Int -> Int
-// sum (Node lft rgt) = sum lft + sum rgt
-// sum (Leaf val)     = val
-
-// convert to TypeScript:
-{{FILL_HERE}}
-</QUERY>
-
-## CORRECT COMPLETION:
-
-<COMPLETION>type Tree<T>
-  = {$:"Node", lft: Tree<T>, rgt: Tree<T>}
-  | {$:"Leaf", val: T};
-
-function sum(tree: Tree<number>): number {
-  switch (tree.$) {
-    case "Node":
-      return sum(tree.lft) + sum(tree.rgt);
-    case "Leaf":
-      return tree.val;
-  }
-}</COMPLETION>
-
-## EXAMPLE QUERY:
-
-The 5th {{FILL_HERE}} is Jupiter.
-
-## CORRECT COMPLETION:
-
-<COMPLETION>planet from the Sun</COMPLETION>
-
-## EXAMPLE QUERY:
+## EXAMPLE QUERY
 
 function hypothenuse(a, b) {
   return Math.sqrt({{FILL_HERE}}b ** 2);
 }
 
-## CORRECT COMPLETION:
+## CORRECT COMPLETION
 
 <COMPLETION>a ** 2 + </COMPLETION>
 `
@@ -157,7 +85,13 @@ function hypothenuse(a, b) {
 
 		const queryContent = queryContextStrings.join("\n\n")
 
-		const userPrompt = `\n\n<QUERY>\n${queryContent}\n</QUERY>\nTASK: Fill the {{FILL_HERE}} hole. Answer only with the CORRECT completion, and NOTHING ELSE. Do it now.\n<COMPLETION>`
+		const userPrompt = `
+		
+<QUERY>
+${queryContent}
+</QUERY>
+TASK: Fill the {{FILL_HERE}} hole. Answer only with the CORRECT completion, and NOTHING ELSE. Do it now.
+`
 		return userPrompt
 	},
 	completionOptions: {

--- a/src/services/autocomplete/types.ts
+++ b/src/services/autocomplete/types.ts
@@ -1,5 +1,6 @@
 //PLANREF: continue/core/autocomplete/util/types.ts
 //PLANREF: continue/core/autocomplete/types.ts
+import * as vscode from "vscode"
 import { Position } from "vscode"
 import { RangeInFile, Range, RangeInFileWithContents } from "./ide-types"
 
@@ -80,4 +81,10 @@ export interface AutocompleteState {
 	totalSessionCost: number
 	model: string
 	hasValidToken: boolean
+}
+
+export interface Autocompletion {
+	text: string // Full line including prefix
+	range: vscode.Range
+	originalPrefix: string // Store the prefix for subtraction
 }

--- a/src/services/autocomplete/types.ts
+++ b/src/services/autocomplete/types.ts
@@ -79,6 +79,7 @@ export interface AutocompleteState {
 	enabled: boolean
 	lastCompletionCost: number
 	totalSessionCost: number
+	lastCompletionTime: number // Time in seconds for the last completion
 	model: string
 	hasValidToken: boolean
 }

--- a/src/services/autocomplete/types.ts
+++ b/src/services/autocomplete/types.ts
@@ -73,3 +73,11 @@ export interface Prediction {
 export type AutocompleteSnippetDeprecated = RangeInFileWithContents & {
 	score?: number
 }
+
+export interface AutocompleteState {
+	enabled: boolean
+	lastCompletionCost: number
+	totalSessionCost: number
+	model: string
+	hasValidToken: boolean
+}

--- a/src/services/autocomplete/utils/AutocompleteCompletionItem.ts
+++ b/src/services/autocomplete/utils/AutocompleteCompletionItem.ts
@@ -1,0 +1,19 @@
+import * as vscode from "vscode"
+import { Autocompletion } from "../types"
+
+export const TRACK_ACCEPTED_SUGGESTION_COMMAND = "kilo-code.trackAcceptedSuggestion"
+
+/**
+ * Specialized InlineCompletionItem for autocomplete that includes tracking functionality
+ */
+export class AutocompleteCompletionItem extends vscode.InlineCompletionItem {
+	constructor(completion: Autocompletion) {
+		super(completion.text, completion.range)
+
+		this.command = {
+			command: TRACK_ACCEPTED_SUGGESTION_COMMAND,
+			title: "Track Accepted Suggestion",
+			arguments: [completion.text],
+		}
+	}
+}

--- a/src/services/autocomplete/utils/CompletionTextProcessor.ts
+++ b/src/services/autocomplete/utils/CompletionTextProcessor.ts
@@ -1,0 +1,183 @@
+import * as vscode from "vscode"
+
+/**
+ * Configuration options for text insertion processing
+ */
+export interface TextInsertionOptions {
+	/** Whether to trim overlapping prefix text */
+	trimPrefix?: boolean
+	/** Whether to trim overlapping suffix text */
+	trimSuffix?: boolean
+}
+
+/**
+ * Result of text insertion processing
+ */
+export interface TextInsertionResult {
+	/** The processed text ready for insertion */
+	processedText: string
+	/** The range where the text should be inserted */
+	insertRange: vscode.Range
+	/** Information about what modifications were made */
+	modifications: {
+		prefixTrimmed: number
+		suffixTrimmed: number
+		originalLength: number
+	}
+}
+
+/**
+ * Context information about the insertion point
+ */
+export interface InsertionContext {
+	/** The document where text will be inserted */
+	document: vscode.TextDocument
+	/** The position where text will be inserted */
+	position: vscode.Position
+	/** The text to be inserted */
+	textToInsert: string
+}
+
+/**
+ * Finds the longest common prefix between two strings, trimming whitespace
+ * @param str1 First string
+ * @param str2 Second string
+ * @returns The length of the prefix in str2 that should be removed
+ */
+function findMaxPrefixOverlap(textBefore: string, completionText: string): number {
+	// Check for exact overlap
+	for (let i = Math.min(textBefore.length, completionText.length); i > 0; i--) {
+		if (textBefore.endsWith(completionText.substring(0, i))) {
+			return i
+		}
+	}
+
+	// Handle whitespace before keywords
+	const trimmedTextBefore = textBefore.trim()
+	if (trimmedTextBefore) {
+		// See if the trimmed text is at the start of the completion
+		if (completionText.trim().startsWith(trimmedTextBefore)) {
+			// Find where this keyword actually ends in the completion text
+			const startPos = completionText.indexOf(trimmedTextBefore)
+			if (startPos >= 0) {
+				let endPos = startPos + trimmedTextBefore.length
+				// Include whitespace after the keyword
+				while (endPos < completionText.length && completionText[endPos] === " ") {
+					endPos++
+				}
+				return endPos
+			}
+		}
+	}
+
+	return 0
+}
+
+/**
+ * Finds the longest common suffix between two strings
+ * @param completionText The completion text
+ * @param textAfter The text after the cursor
+ * @returns The length of the suffix in completionText that should be removed
+ */
+function findMaxSuffixOverlap(completionText: string, textAfter: string): number {
+	// Check for exact overlap
+	for (let i = Math.min(textAfter.length, completionText.length); i > 0; i--) {
+		if (completionText.endsWith(textAfter.substring(0, i))) {
+			return i
+		}
+	}
+
+	return 0
+}
+
+/**
+ * Gets the text context around an insertion point
+ */
+function getInsertionContext(
+	document: vscode.TextDocument,
+	position: vscode.Position,
+): {
+	textBefore: string
+	textAfter: string
+	contextRange: vscode.Range
+} {
+	// Get text before cursor - go from start of file to be thorough
+	const startOfDoc = new vscode.Position(0, 0)
+	const beforeRange = new vscode.Range(startOfDoc, position)
+	const textBefore = document.getText(beforeRange)
+
+	// Get text after cursor - go to end of file to be thorough
+	const endOfDoc = new vscode.Position(document.lineCount - 1, Infinity)
+	const afterRange = new vscode.Range(position, endOfDoc)
+	const textAfter = document.getText(afterRange)
+
+	const contextRange = new vscode.Range(startOfDoc, endOfDoc)
+
+	return {
+		textBefore,
+		textAfter,
+		contextRange,
+	}
+}
+
+/**
+ * Processes text for insertion, removing overlaps with existing content
+ * @param context The insertion context
+ * @param options Processing options
+ * @returns Processed insertion result or null if nothing to insert
+ */
+export function processTextInsertion(
+	context: InsertionContext,
+	options: TextInsertionOptions = {},
+): TextInsertionResult | null {
+	const { trimPrefix = true, trimSuffix = true } = options
+	const { document, position, textToInsert } = context
+
+	if (!textToInsert || textToInsert.length === 0) {
+		return null
+	}
+
+	const originalLength = textToInsert.length
+	const { textBefore, textAfter } = getInsertionContext(document, position)
+
+	let processedText = textToInsert
+	let prefixTrimmed = 0
+	let suffixTrimmed = 0
+
+	// Handle prefix overlap
+	if (trimPrefix && textBefore.length > 0) {
+		prefixTrimmed = findMaxPrefixOverlap(textBefore, textToInsert)
+		if (prefixTrimmed > 0) {
+			processedText = textToInsert.substring(prefixTrimmed)
+		}
+	}
+
+	// Handle suffix overlap
+	if (trimSuffix && textAfter.length > 0) {
+		suffixTrimmed = findMaxSuffixOverlap(processedText, textAfter)
+
+		if (suffixTrimmed > 0) {
+			processedText = processedText.substring(0, processedText.length - suffixTrimmed)
+		}
+	}
+
+	if (processedText.length === 0) {
+		return null
+	}
+
+	// Adjust the insertRange to account for any text that might already be on the line.
+	// This is important to handle the autoClosing braces that VSCode adds as you type.
+	const firstLine = textToInsert.match(/^.*$/m)?.[0] ?? processedText
+	const removeCharCount = firstLine.includes(textAfter) ? textAfter.length : 0
+	const insertRange = new vscode.Range(position, position.translate(0, removeCharCount))
+
+	return {
+		processedText,
+		insertRange,
+		modifications: {
+			prefixTrimmed,
+			suffixTrimmed,
+			originalLength,
+		},
+	}
+}

--- a/src/services/autocomplete/utils/CompletionTextProcessor.ts
+++ b/src/services/autocomplete/utils/CompletionTextProcessor.ts
@@ -1,16 +1,6 @@
 import * as vscode from "vscode"
 
 /**
- * Configuration options for text insertion processing
- */
-export interface TextInsertionOptions {
-	/** Whether to trim overlapping prefix text */
-	trimPrefix?: boolean
-	/** Whether to trim overlapping suffix text */
-	trimSuffix?: boolean
-}
-
-/**
  * Result of text insertion processing
  */
 export interface TextInsertionResult {
@@ -126,11 +116,7 @@ function getInsertionContext(
  * @param options Processing options
  * @returns Processed insertion result or null if nothing to insert
  */
-export function processTextInsertion(
-	context: InsertionContext,
-	options: TextInsertionOptions = {},
-): TextInsertionResult | null {
-	const { trimPrefix = true, trimSuffix = true } = options
+export function processTextInsertion(context: InsertionContext): TextInsertionResult | null {
 	const { document, position, textToInsert } = context
 
 	if (!textToInsert || textToInsert.length === 0) {
@@ -145,7 +131,7 @@ export function processTextInsertion(
 	let suffixTrimmed = 0
 
 	// Handle prefix overlap
-	if (trimPrefix && textBefore.length > 0) {
+	if (textBefore.length > 0) {
 		prefixTrimmed = findMaxPrefixOverlap(textBefore, textToInsert)
 		if (prefixTrimmed > 0) {
 			processedText = textToInsert.substring(prefixTrimmed)
@@ -153,7 +139,7 @@ export function processTextInsertion(
 	}
 
 	// Handle suffix overlap
-	if (trimSuffix && textAfter.length > 0) {
+	if (textAfter.length > 0) {
 		suffixTrimmed = findMaxSuffixOverlap(processedText, textAfter)
 
 		if (suffixTrimmed > 0) {

--- a/src/services/autocomplete/utils/__tests__/abortableDelay.test.ts
+++ b/src/services/autocomplete/utils/__tests__/abortableDelay.test.ts
@@ -1,0 +1,29 @@
+import { abortableDelay } from "../abortableDelay"
+
+describe("abortableDelay", () => {
+	test("should resolve after specified delay", async () => {
+		const startTime = Date.now()
+		const abortController = new AbortController()
+
+		await abortableDelay(50, abortController.signal)
+
+		const elapsed = Date.now() - startTime
+		expect(elapsed).toBeGreaterThanOrEqual(45) // Allow some tolerance
+	})
+
+	test("should reject when aborted before delay completes", async () => {
+		const abortController = new AbortController()
+
+		// Abort after 25ms
+		setTimeout(() => abortController.abort(), 25)
+
+		await expect(abortableDelay(100, abortController.signal)).rejects.toThrow("Aborted")
+	})
+
+	test("should reject immediately if signal is already aborted", async () => {
+		const abortController = new AbortController()
+		abortController.abort()
+
+		await expect(abortableDelay(50, abortController.signal)).rejects.toThrow("Aborted")
+	})
+})

--- a/src/services/autocomplete/utils/__tests__/costFormatting.test.ts
+++ b/src/services/autocomplete/utils/__tests__/costFormatting.test.ts
@@ -1,0 +1,33 @@
+import { formatCost } from "../costFormatting"
+
+describe("formatCost", () => {
+	it("should format zero cost correctly", () => {
+		expect(formatCost(0)).toBe("$0.00")
+	})
+
+	it("should format costs less than one cent", () => {
+		expect(formatCost(0.001)).toBe("<$0.01")
+		expect(formatCost(0.005)).toBe("<$0.01")
+		expect(formatCost(0.009)).toBe("<$0.01")
+	})
+
+	it("should format costs one cent and above", () => {
+		expect(formatCost(0.01)).toBe("$0.01")
+		expect(formatCost(0.99)).toBe("$0.99")
+		expect(formatCost(1.0)).toBe("$1.00")
+		expect(formatCost(1.234)).toBe("$1.23")
+		expect(formatCost(10.567)).toBe("$10.57")
+		expect(formatCost(100.999)).toBe("$101.00")
+	})
+
+	it("should handle large amounts", () => {
+		expect(formatCost(1000.5)).toBe("$1000.50")
+		expect(formatCost(999999.99)).toBe("$999999.99")
+	})
+
+	it("should round to two decimal places", () => {
+		expect(formatCost(1.234567)).toBe("$1.23")
+		expect(formatCost(1.235)).toBe("$1.24") // Rounds up
+		expect(formatCost(1.999)).toBe("$2.00") // Rounds up
+	})
+})

--- a/src/services/autocomplete/utils/abortableDelay.ts
+++ b/src/services/autocomplete/utils/abortableDelay.ts
@@ -1,0 +1,28 @@
+/**
+ * Promise-based delay that can be aborted using an AbortSignal
+ * @param ms - Milliseconds to delay
+ * @param signal - AbortSignal to cancel the delay
+ * @returns Promise that resolves after the delay or rejects if aborted
+ */
+export function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal.aborted) {
+			reject(new Error("Aborted"))
+			return
+		}
+
+		const timeout = setTimeout(() => {
+			// Clean up the abort listener when timeout completes normally
+			signal.removeEventListener("abort", abortHandler)
+			resolve()
+		}, ms)
+
+		const abortHandler = () => {
+			clearTimeout(timeout)
+			signal.removeEventListener("abort", abortHandler)
+			reject(new Error("Aborted"))
+		}
+
+		signal.addEventListener("abort", abortHandler)
+	})
+}

--- a/src/services/autocomplete/utils/costFormatting.ts
+++ b/src/services/autocomplete/utils/costFormatting.ts
@@ -1,0 +1,10 @@
+/**
+ * Formats cost with special handling for small amounts
+ * @param cost The cost value to format
+ * @returns A formatted cost string
+ */
+export function formatCost(cost: number): string {
+	if (cost === 0) return "$0.00"
+	if (cost > 0 && cost < 0.01) return "<$0.01" // Less than one cent
+	return `$${cost.toFixed(2)}`
+}


### PR DESCRIPTION
This improves the behavior of autocomplete in cases where the text in the document may already contain a prefix or suffix from the completion. 

Now, with this change, we add more complex prefix and suffix checking, and we only insert the completion preview with matching text removed, greatly improving the issue where we duplicate closing braces.

![image](https://github.com/user-attachments/assets/74e9377f-e98f-4cff-8469-17714e8b3b82)
![2025-06-03 11 11 12](https://github.com/user-attachments/assets/8c91f916-bcaa-4a27-9635-3a452d935499)
![2025-06-02 07 43 59](https://github.com/user-attachments/assets/2c16421d-d5a0-40da-900f-49af6f061b28)

