### PR TITLE
[Experimental] Prompt Debugger View with templates and variables!

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,10 +10,9 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceFolder}/src"],
+			"args": ["--extensionDevelopmentPath=${workspaceFolder}/src", "--disable-extensions"],
 			"sourceMaps": true,
 			"outFiles": ["${workspaceFolder}/dist/**/*.js"],
-			"preLaunchTask": "${defaultBuildTask}",
 			"env": {
 				"NODE_ENV": "development",
 				"VSCODE_DEBUG_MODE": "true"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,6 +583,9 @@ importers:
       fzf:
         specifier: ^0.5.2
         version: 0.5.2
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.8
       i18next:
         specifier: ^24.2.2
         version: 24.2.3(typescript@5.8.3)
@@ -5166,6 +5169,11 @@ packages:
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
+  handlebars@4.7.8:
+    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
   harmony-reflect@1.6.2:
     resolution: {integrity: sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==}
 
@@ -6574,6 +6582,9 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
@@ -8229,6 +8240,11 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -8656,6 +8672,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   workerpool@6.5.1:
     resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
@@ -14361,6 +14380,15 @@ snapshots:
 
   hachure-fill@0.5.2: {}
 
+  handlebars@4.7.8:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
   harmony-reflect@1.6.2: {}
 
   has-bigints@1.1.0: {}
@@ -16344,6 +16372,8 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  neo-async@2.6.2: {}
+
   netmask@2.0.2: {}
 
   nock@14.0.5:
@@ -18267,6 +18297,9 @@ snapshots:
 
   ufo@1.6.1: {}
 
+  uglify-js@3.19.3:
+    optional: true
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -18814,6 +18847,8 @@ snapshots:
       execa: 8.0.1
 
   word-wrap@1.2.5: {}
+
+  wordwrap@1.0.0: {}
 
   workerpool@6.5.1: {}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -81,6 +81,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 	private view?: vscode.WebviewView | vscode.WebviewPanel
 	private clineStack: Task[] = []
 	private codeIndexStatusSubscription?: vscode.Disposable
+	public editorStateSubscriptions: vscode.Disposable[] = []
 	private _workspaceTracker?: WorkspaceTracker // workSpaceTracker read-only for access outside this class
 	public get workspaceTracker(): WorkspaceTracker | undefined {
 		return this._workspaceTracker
@@ -233,6 +234,15 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		await this.mcpHub?.unregisterClient()
 		this.mcpHub = undefined
 		this.customModesManager?.dispose()
+
+		// Clean up editor state subscriptions
+		while (this.editorStateSubscriptions.length) {
+			const subscription = this.editorStateSubscriptions.pop()
+			if (subscription) {
+				subscription.dispose()
+			}
+		}
+
 		this.log("Disposed all disposables")
 		ClineProvider.activeInstances.delete(this)
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -35,6 +35,7 @@ export interface ExtensionMessage {
 		| "workspaceUpdated"
 		| "invoke"
 		| "partialMessage"
+		| "promptDebuggerPartialMessage" // New dedicated type for prompt debugger streaming responses
 		| "mcpServers"
 		| "enhancedPrompt"
 		| "commitSearchResults"
@@ -97,6 +98,7 @@ export interface ExtensionMessage {
 		path?: string
 	}>
 	partialMessage?: ClineMessage
+	responseId?: string // Added for prompt debugger LLM API integration
 	routerModels?: RouterModels
 	openAiModels?: string[]
 	ollamaModels?: string[]

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -36,6 +36,8 @@ export interface ExtensionMessage {
 		| "invoke"
 		| "partialMessage"
 		| "promptDebuggerPartialMessage" // New dedicated type for prompt debugger streaming responses
+		| "editorStateUpdate" // New type for sending editor state to prompt debugger
+		| "editorStateUpdate" // New type for sending editor state to prompt debugger
 		| "mcpServers"
 		| "enhancedPrompt"
 		| "commitSearchResults"
@@ -127,6 +129,7 @@ export interface ExtensionMessage {
 	setting?: string
 	value?: any
 	payload?: ProfileDataResponsePayload | BalanceDataResponsePayload // New: Add payload for profile and balance data
+	editorState?: EditorState // Editor state information for prompt debugger
 }
 
 export type ExtensionState = Pick<
@@ -313,6 +316,29 @@ export interface ClineApiReqInfo {
 	cost?: number
 	cancelReason?: ClineApiReqCancelReason
 	streamingFailedMessage?: string
+}
+
+export interface EditorState {
+	document: {
+		path: string
+		name: string
+		language: string
+		lineCount: number
+	}
+	selection: {
+		text: string
+		lineNumber: number
+		column: number
+	}
+	cursor: {
+		line: number
+		column: number
+	}
+	content: {
+		beforeCursor: string
+		afterCursor: string
+		all: string
+	}
 }
 
 export type ClineApiReqCancelReason = "streaming_failed" | "user_cancelled"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -163,6 +163,7 @@ export interface WebviewMessage {
 		| "indexCleared"
 		| "codebaseIndexConfig"
 		| "telemetrySetting"
+		| "promptDebuggerReady" // Added for prompt debugger to request editor state updates
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -154,6 +154,7 @@ export interface WebviewMessage {
 		| "balanceDataResponse" // kilocode_change
 		| "condense" // kilocode_change
 		| "toggleWorkflow" // kilocode_change
+		| "promptDebuggerCallLLM" // Added for prompt debugger LLM API integration
 		| "condenseTaskContextRequest"
 		| "requestIndexingStatus"
 		| "startIndexing"
@@ -198,6 +199,9 @@ export interface WebviewMessage {
 	modeConfig?: ModeConfig
 	timeout?: number
 	payload?: WebViewMessagePayload
+	systemPrompt?: string // Added for prompt debugger LLM API integration
+	userPrompt?: string // Added for prompt debugger LLM API integration
+	responseId?: string // Added for prompt debugger LLM API integration
 	source?: "global" | "project"
 	requestId?: string
 	ids?: string[]

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -45,6 +45,7 @@
 		"dompurify": "^3.2.6",
 		"fast-deep-equal": "^3.1.3",
 		"fzf": "^0.5.2",
+		"handlebars": "^4.7.8",
 		"i18next": "^24.2.2",
 		"i18next-http-backend": "^3.0.2",
 		"knuth-shuffle-seeded": "^1.0.6",

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -27,16 +27,6 @@ const tabsByMessageAction: Partial<Record<NonNullable<ExtensionMessage["action"]
 	profileButtonClicked: "profile",
 }
 
-// Custom handler for the prompt debugger button
-// This is a workaround since we can't modify the ExtensionMessage interface
-const handlePromptDebuggerButtonClick = () => {
-	return (tab: Tab) => {
-		if (tab !== "prompt-debugger") {
-			(window as any).switchToPromptDebugger?.();
-		}
-	};
-};
-
 const App = () => {
 	const { didHydrateState, showWelcome, shouldShowAnnouncement } = useExtensionState()
 
@@ -118,7 +108,7 @@ const App = () => {
 	// Add a global function to switch to the prompt debugger tab for testing
 	// This is temporary and would be replaced with proper navigation in a real implementation
 	useEffect(() => {
-		(window as any).switchToPromptDebugger = () => {
+		;(window as any).switchToPromptDebugger = () => {
 			switchTab("prompt-debugger")
 		}
 	}, [switchTab])
@@ -143,7 +133,7 @@ const App = () => {
 			)}
 			{tab === "profile" && <ProfileView onDone={() => switchTab("chat")} />}
 
-				{tab === "prompt-debugger" && <PromptDebuggerView onDone={() => switchTab("chat")} />}
+			{tab === "prompt-debugger" && <PromptDebuggerView onDone={() => switchTab("chat")} />}
 
 			<ChatView
 				ref={chatViewRef}

--- a/webview-ui/src/components/chat/BottomControls.tsx
+++ b/webview-ui/src/components/chat/BottomControls.tsx
@@ -9,8 +9,22 @@ const BottomControls: React.FC = () => {
 		vscode.postMessage({ type: "showFeedbackOptions" })
 	}
 
+	const openPromptDebugger = () => {
+		// Use the global function we added to App.tsx
+		(window as any).switchToPromptDebugger?.()
+	}
+
 	return (
 		<div className="flex flex-row justify-end w-auto h-[30px] mx-3.5 mb-1">
+			{/* Prompt Debugger Button */}
+			<button
+				className="vscode-button flex items-center gap-1.5 p-0.75 rounded-sm text-vscode-foreground cursor-pointer hover:bg-vscode-list-hoverBackground mr-2"
+				title="Prompt Debugger"
+				onClick={openPromptDebugger}>
+				<span className="codicon codicon-debug text-sm"></span>
+			</button>
+
+			{/* Feedback Button */}
 			<button
 				className="vscode-button flex items-center gap-1.5 p-0.75 rounded-sm text-vscode-foreground cursor-pointer hover:bg-vscode-list-hoverBackground"
 				title={t("common:feedback.title")}

--- a/webview-ui/src/components/prompt-debugger/EditableCodeBlock.tsx
+++ b/webview-ui/src/components/prompt-debugger/EditableCodeBlock.tsx
@@ -1,0 +1,279 @@
+import React, { useState, useRef, useEffect, useCallback, forwardRef } from "react"
+import styled from "styled-components"
+import { getHighlighter, isLanguageLoaded, normalizeLanguage, ExtendedLanguage } from "@src/utils/highlighter"
+import { CODE_BLOCK_BG_COLOR } from "@src/components/common/CodeBlock"
+
+interface EditableCodeBlockProps {
+	value: string
+	onChange: (value: string) => void
+	language: string
+	placeholder?: string
+	className?: string
+	rows?: number
+}
+
+const EditorContainer = styled.div`
+	position: relative;
+	width: 100%;
+	font-family: var(--vscode-editor-font-family);
+	font-size: var(--vscode-editor-font-size, var(--vscode-font-size, 12px));
+	line-height: 1.5;
+	background-color: ${CODE_BLOCK_BG_COLOR};
+	border-radius: 5px;
+	overflow: hidden;
+	display: block;
+	box-sizing: border-box;
+`
+
+const HiddenTextArea = styled.textarea`
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	padding: 10px;
+	margin: 0;
+	border: none;
+	resize: none;
+	color: transparent;
+	background: transparent;
+	caret-color: var(--vscode-editor-foreground);
+	z-index: 2;
+	white-space: pre-wrap;
+	word-break: break-word;
+	overflow-wrap: break-word;
+	overflow: auto;
+	font-family: var(--vscode-editor-font-family);
+	font-size: var(--vscode-editor-font-size, var(--vscode-font-size, 12px));
+	line-height: 1.5;
+	outline: none;
+	tab-size: 4;
+
+	&::selection {
+		background-color: var(--vscode-editor-selectionBackground);
+		color: transparent;
+	}
+`
+
+const SyntaxHighlightedContent = styled.div`
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	padding: 10px;
+	margin: 0;
+	pointer-events: none;
+	white-space: pre-wrap;
+	word-break: break-word;
+	overflow-wrap: break-word;
+	overflow: hidden;
+	z-index: 1;
+	tab-size: 4;
+
+	pre {
+		margin: 0;
+		padding: 0;
+		background: transparent;
+		white-space: pre-wrap;
+		word-break: break-word;
+		overflow-wrap: break-word;
+		tab-size: 4;
+	}
+
+	code {
+		font-family: var(--vscode-editor-font-family);
+		font-size: var(--vscode-editor-font-size, var(--vscode-font-size, 12px));
+		line-height: 1.5;
+		white-space: pre-wrap;
+		word-break: break-word;
+		overflow-wrap: break-word;
+		tab-size: 4;
+	}
+
+	.hljs {
+		color: var(--vscode-editor-foreground, #fff);
+		background-color: transparent;
+		white-space: pre-wrap;
+		word-break: break-word;
+		overflow-wrap: break-word;
+	}
+`
+
+const EditableCodeBlock = forwardRef<HTMLTextAreaElement, EditableCodeBlockProps>(
+	({ value, onChange, language, placeholder = "Enter code here...", className, rows = 5 }, ref) => {
+		const [highlightedCode, setHighlightedCode] = useState<string>("")
+		const [currentLanguage, setCurrentLanguage] = useState<ExtendedLanguage>(() => normalizeLanguage(language))
+		const textAreaRef = useRef<HTMLTextAreaElement>(null)
+
+		// Sync internal ref with forwarded ref
+		useEffect(() => {
+			if (typeof ref === "function") {
+				ref(textAreaRef.current)
+			} else if (ref) {
+				ref.current = textAreaRef.current
+			}
+		}, [ref])
+		const containerRef = useRef<HTMLDivElement>(null)
+		const [height, setHeight] = useState<number>(0)
+
+		// Update current language when prop changes
+		useEffect(() => {
+			const normalizedLang = normalizeLanguage(language)
+			if (normalizedLang !== currentLanguage) {
+				setCurrentLanguage(normalizedLang)
+			}
+		}, [language, currentLanguage])
+
+		// Syntax highlighting with Shiki
+		useEffect(() => {
+			const fallback = `<pre><code class="hljs language-${currentLanguage || "txt"}">${value || ""}</code></pre>`
+
+			const highlight = async () => {
+				// Show plain text if language needs to be loaded
+				if (currentLanguage && !isLanguageLoaded(currentLanguage)) {
+					setHighlightedCode(fallback)
+				}
+
+				const highlighter = await getHighlighter(currentLanguage)
+
+				const html = await highlighter.codeToHtml(value || "", {
+					lang: currentLanguage || "txt",
+					theme: document.body.className.toLowerCase().includes("light") ? "github-light" : "github-dark",
+					transformers: [
+						{
+							pre(node) {
+								node.properties.style = "padding: 0; margin: 0; background: transparent;"
+								return node
+							},
+							code(node) {
+								// Add hljs classes for consistent styling
+								node.properties.class = `hljs language-${currentLanguage}`
+								return node
+							},
+							line(node) {
+								// Preserve existing line handling
+								node.properties.class = node.properties.class || ""
+								return node
+							},
+						},
+					],
+				})
+
+				setHighlightedCode(html)
+			}
+
+			highlight().catch((e) => {
+				console.error("[EditableCodeBlock] Syntax highlighting error:", e)
+				setHighlightedCode(fallback)
+			})
+		}, [value, currentLanguage])
+
+		// Update height based on content
+		useEffect(() => {
+			if (textAreaRef.current) {
+				const lineHeight = parseInt(getComputedStyle(textAreaRef.current).lineHeight) || 20
+				const minHeight = lineHeight * rows
+				const scrollHeight = textAreaRef.current.scrollHeight
+
+				// Add a small buffer to ensure all content is visible
+				const newHeight = Math.max(minHeight, scrollHeight + 10)
+				setHeight(newHeight)
+
+				// Force a re-render of the syntax highlighting when content changes
+				// This helps keep the highlighting in sync with the textarea
+				const fallback = `<pre><code class="hljs language-${currentLanguage || "txt"}">${value || ""}</code></pre>`
+				setHighlightedCode(fallback)
+
+				// Schedule a proper highlight after the DOM has updated
+				setTimeout(async () => {
+					try {
+						const highlighter = await getHighlighter(currentLanguage)
+						const html = await highlighter.codeToHtml(value || "", {
+							lang: currentLanguage || "txt",
+							theme: document.body.className.toLowerCase().includes("light")
+								? "github-light"
+								: "github-dark",
+							transformers: [
+								{
+									pre(node) {
+										node.properties.style = "padding: 0; margin: 0; background: transparent;"
+										return node
+									},
+									code(node) {
+										node.properties.class = `hljs language-${currentLanguage}`
+										return node
+									},
+									line(node) {
+										node.properties.class = node.properties.class || ""
+										return node
+									},
+								},
+							],
+						})
+						setHighlightedCode(html)
+					} catch (e) {
+						console.error("[EditableCodeBlock] Syntax highlighting error:", e)
+					}
+				}, 10)
+			}
+		}, [value, rows, currentLanguage])
+
+		// Handle input changes
+		const handleChange = useCallback(
+			(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+				onChange(e.target.value)
+			},
+			[onChange],
+		)
+
+		// Handle tab key for indentation
+		const handleKeyDown = useCallback(
+			(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+				if (e.key === "Tab") {
+					e.preventDefault()
+					const target = e.target as HTMLTextAreaElement
+					const start = target.selectionStart
+					const end = target.selectionEnd
+
+					// Insert tab at cursor position
+					const newValue = value.substring(0, start) + "    " + value.substring(end)
+					onChange(newValue)
+
+					// Move cursor after the inserted tab
+					setTimeout(() => {
+						if (textAreaRef.current) {
+							textAreaRef.current.selectionStart = textAreaRef.current.selectionEnd = start + 4
+						}
+					}, 0)
+				}
+			},
+			[value, onChange],
+		)
+
+		return (
+			<EditorContainer
+				ref={containerRef}
+				className={className}
+				style={{ height: `${height}px`, minHeight: `${rows * 20}px` }}>
+				<HiddenTextArea
+					ref={textAreaRef}
+					value={value}
+					onChange={handleChange}
+					onKeyDown={handleKeyDown}
+					placeholder={placeholder}
+					spellCheck={false}
+					autoCapitalize="off"
+					autoComplete="off"
+					autoCorrect="off"
+					data-gramm="false"
+				/>
+				<SyntaxHighlightedContent
+					dangerouslySetInnerHTML={{ __html: highlightedCode || `<pre><code>${placeholder}</code></pre>` }}
+				/>
+			</EditorContainer>
+		)
+	},
+)
+
+export default EditableCodeBlock

--- a/webview-ui/src/components/prompt-debugger/PromptDebuggerView.tsx
+++ b/webview-ui/src/components/prompt-debugger/PromptDebuggerView.tsx
@@ -1,146 +1,311 @@
-import React, { useState } from "react"
-import { VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
-import { Trans } from "react-i18next"
+import { useState, useEffect, useRef } from "react"
+import Handlebars from "handlebars"
+import { defaultTemplates } from "./templates"
 
-import { vscode } from "@src/utils/vscode"
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { useExtensionState } from "@src/context/ExtensionStateContext"
 import { Tab, TabContent, TabHeader } from "@src/components/common/Tab"
-import {
-    Button,
-    Input,
-    Textarea,
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@src/components/ui"
+import { Button, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@src/components/ui"
 import BottomControls from "../chat/BottomControls"
+import EditableCodeBlock from "./EditableCodeBlock"
 
 type PromptDebuggerViewProps = {
-    onDone: () => void
+	onDone: () => void
 }
 
 const PromptDebuggerView = ({ onDone }: PromptDebuggerViewProps) => {
-    const { t } = useAppTranslation()
-    const { listApiConfigMeta, currentApiConfigName } = useExtensionState()
+	const { t } = useAppTranslation()
+	const { listApiConfigMeta, currentApiConfigName } = useExtensionState()
 
-    // State for prompt input
-    const [promptInput, setPromptInput] = useState("")
+	// State for prompt templates
+	const [templates, _setTemplates] = useState(defaultTemplates)
 
-    // State for model selection
-    const [selectedModel, setSelectedModel] = useState(currentApiConfigName)
+	// State for selected template
+	const [selectedTemplate, setSelectedTemplate] = useState("documentation")
 
-    // State for debug output
-    const [debugOutput, setDebugOutput] = useState("")
+	// State for prompt input (Handlebars template)
+	const [promptInput, setPromptInput] = useState(defaultTemplates[0].content)
 
-    // State for loading
-    const [isLoading, setIsLoading] = useState(false)
+	// State for model selection - use the first available model
+	const [selectedModel, setSelectedModel] = useState(() => {
+		// Use the first available model if there are any, otherwise use the current config
+		return listApiConfigMeta && listApiConfigMeta.length > 0 ? listApiConfigMeta[0].id : currentApiConfigName
+	})
 
-    // Handle prompt submission
-    const handleSubmitPrompt = () => {
-        if (!promptInput.trim()) return
+	// State for debug output
+	const [debugOutput, setDebugOutput] = useState("")
 
-        setIsLoading(true)
+	// State for loading
+	const [isLoading, setIsLoading] = useState(false)
 
-        // Here we would send the prompt to the extension for processing
-        // For now, we'll just simulate a response since we're building the UI
-        // In a real implementation, we would need to add a new message type to ExtensionMessage
-        // and handle it in the extension
+	// State for rendered template preview
+	const [renderedPreview, setRenderedPreview] = useState("")
 
-        // Simulate processing
-        setDebugOutput(`Simulated debug results for prompt: "${promptInput}"\nUsing model: ${selectedModel}\n\nThis is a placeholder for actual debug output that would come from the extension.`)
+	// State for LLM response
+	const [llmResponse, setLlmResponse] = useState("")
 
-        // For now, just simulate a response
-        setTimeout(() => {
-            setDebugOutput(`Debug results for prompt: "${promptInput}"\nUsing model: ${selectedModel}\n\nThis is a placeholder for actual debug output.`)
-            setIsLoading(false)
-        }, 1000)
-    }
+	// State for test variables
+	const [testVariables, _setTestVariables] = useState({
+		user: {
+			name: "John Doe",
+			email: "john.doe@example.com",
+			role: "Developer",
+		},
+		project: {
+			name: "Awesome Project",
+			description: "A really cool project",
+			version: "1.0.0",
+		},
+		date: new Date().toLocaleDateString(),
+		items: ["Item 1", "Item 2", "Item 3"],
+	})
 
-    // Handle model selection change
-    const handleModelChange = (value: string) => {
-        setSelectedModel(value)
-    }
+	// Reference to the code editor for cursor position
+	const codeEditorRef = useRef<HTMLTextAreaElement | null>(null)
 
-    // Handle clearing the form
-    const handleClear = () => {
-        setPromptInput("")
-        setDebugOutput("")
-    }
+	// Update rendered preview whenever the template changes
+	useEffect(() => {
+		try {
+			const template = Handlebars.compile(promptInput)
+			const rendered = template(testVariables)
+			setRenderedPreview(rendered)
+		} catch (error) {
+			// If there's an error in the template, show the error in the preview
+			setRenderedPreview(`Template Error: ${(error as Error).message}`)
+		}
+	}, [promptInput, testVariables])
 
-    return (
-        <Tab>
-            <TabHeader className="flex justify-between items-center">
-                <h3 className="text-vscode-foreground m-0">{t("Prompt Debugger")}</h3>
-                <Button onClick={onDone}>{t("Done")}</Button>
-            </TabHeader>
+	// Handle template selection change
+	const handleTemplateChange = (templateId: string) => {
+		setSelectedTemplate(templateId)
+		const template = templates.find((t) => t.id === templateId)
+		if (template) {
+			setPromptInput(template.content)
+		}
+	}
 
-            <TabContent>
-                <div className="mb-5">
-                    <div className="mb-2">
-                        <h4 className="text-vscode-foreground m-0 mb-2">{t("Model Selection")}</h4>
-                        <Select value={selectedModel} onValueChange={handleModelChange}>
-                            <SelectTrigger data-testid="api-config-select" className="w-full">
-                                <SelectValue placeholder={t("Select a model")} />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {(listApiConfigMeta || []).map((config) => (
-                                    <SelectItem key={config.id} value={config.id}>
-                                        {config.name}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                    </div>
+	// Handle prompt submission
+	const handleSubmitPrompt = () => {
+		if (!promptInput.trim()) return
 
-                    <div className="mb-4">
-                        <h4 className="text-vscode-foreground m-0 mb-2">{t("Prompt Input")}</h4>
-                        <VSCodeTextArea
-                            className="w-full"
-                            rows={5}
-                            value={promptInput}
-                            onChange={(e) => {
-                                const target = e.target as HTMLTextAreaElement
-                                setPromptInput(target.value)
-                            }}
-                            placeholder={t("Enter your prompt here...")}
-                        />
-                    </div>
+		setIsLoading(true)
 
-                    <div className="flex gap-2 mb-4">
-                        <Button
-                            onClick={handleSubmitPrompt}
-                            disabled={isLoading || !promptInput.trim()}
-                        >
-                            {isLoading ? t("Processing...") : t("Debug Prompt")}
-                        </Button>
-                        <Button
-                            variant="outline"
-                            onClick={handleClear}
-                            disabled={isLoading}
-                        >
-                            {t("Clear")}
-                        </Button>
-                    </div>
+		// Here we would send the prompt to the extension for processing
+		// For now, we'll just simulate a response since we're building the UI
+		// In a real implementation, we would need to add a new message type to ExtensionMessage
+		// and handle it in the extension
 
-                    {debugOutput && (
-                        <div className="mb-4">
-                            <h4 className="text-vscode-foreground m-0 mb-2">{t("Debug Output")}</h4>
-                            <div className="bg-vscode-editor-background p-4 rounded border border-vscode-panel-border whitespace-pre-wrap">
-                                {debugOutput}
-                            </div>
-                        </div>
-                    )}
-                </div>
-            </TabContent>
+		// Simulate processing
+		setDebugOutput(
+			`Simulated debug results for prompt: "${promptInput}"\nUsing model: ${selectedModel}\n\nRendered output: "${renderedPreview}"`,
+		)
 
-            <div className="fixed inset-0 top-auto">
-                <BottomControls />
-            </div>
-        </Tab>
-    )
+		// For now, just simulate a response
+		setTimeout(() => {
+			setDebugOutput(
+				`Debug results for prompt: "${promptInput}"\nUsing model: ${selectedModel}\n\nRendered output: "${renderedPreview}"`,
+			)
+			setIsLoading(false)
+		}, 1000)
+	}
+
+	// Handle LLM API call
+	const handleCallLLM = () => {
+		if (!promptInput.trim()) return
+
+		setIsLoading(true)
+		setLlmResponse("")
+
+		// Simulate streaming response
+		let response = ""
+		const fullResponse =
+			"This is a simulated LLM response based on your template. In a real implementation, this would be the actual response from the selected model using the rendered template as input. The response would stream in character by character to provide a realistic experience."
+		let index = 0
+
+		const streamInterval = setInterval(() => {
+			if (index < fullResponse.length) {
+				response += fullResponse[index]
+				setLlmResponse(response)
+				index++
+			} else {
+				clearInterval(streamInterval)
+				setIsLoading(false)
+			}
+		}, 30)
+	}
+
+	// Insert variable at cursor position
+	const insertVariable = (variablePath: string) => {
+		// Get the textarea element using the ref instead of querySelector
+		if (!codeEditorRef.current) {
+			// Try to find it with querySelector as fallback
+			const textArea = document.querySelector("textarea") as HTMLTextAreaElement
+			if (!textArea) return
+
+			// Store the reference for future use
+			codeEditorRef.current = textArea
+		}
+
+		const textArea = codeEditorRef.current
+		const cursorPos = textArea.selectionStart
+		const textBefore = promptInput.substring(0, cursorPos)
+		const textAfter = promptInput.substring(cursorPos)
+
+		// Insert the variable with Handlebars syntax
+		const newText = `${textBefore}{{${variablePath}}}${textAfter}`
+		setPromptInput(newText)
+
+		// Focus back on the textarea and set cursor position after the inserted variable
+		setTimeout(() => {
+			textArea.focus()
+			const newCursorPos = cursorPos + variablePath.length + 4 // +4 for the {{ and }}
+			textArea.setSelectionRange(newCursorPos, newCursorPos)
+		}, 10) // Increased timeout to ensure DOM updates
+	}
+
+	// Handle model selection change
+	const handleModelChange = (value: string) => {
+		setSelectedModel(value)
+	}
+
+	// Handle clearing the form
+	const handleClear = () => {
+		setPromptInput("")
+		setDebugOutput("")
+		setRenderedPreview("")
+		setLlmResponse("")
+	}
+
+	return (
+		<Tab>
+			<TabHeader className="flex justify-between items-center">
+				<h3 className="text-vscode-foreground m-0">{t("Prompt Debugger")}</h3>
+				<Button onClick={onDone}>{t("Done")}</Button>
+			</TabHeader>
+
+			<TabContent>
+				<div className="mb-5">
+					<div className="grid grid-cols-2 gap-4 mb-4">
+						<div>
+							<h4 className="text-vscode-foreground m-0 mb-2">{t("Template Selection")}</h4>
+							<Select value={selectedTemplate} onValueChange={handleTemplateChange}>
+								<SelectTrigger className="w-full">
+									<SelectValue placeholder={t("Select a template")} />
+								</SelectTrigger>
+								<SelectContent>
+									{templates.map((template) => (
+										<SelectItem key={template.id} value={template.id}>
+											{template.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div>
+							<h4 className="text-vscode-foreground m-0 mb-2">{t("Model Selection")}</h4>
+							<Select value={selectedModel} onValueChange={handleModelChange}>
+								<SelectTrigger data-testid="api-config-select" className="w-full">
+									<SelectValue placeholder={t("Select a model")} />
+								</SelectTrigger>
+								<SelectContent>
+									{(listApiConfigMeta || []).map((config) => (
+										<SelectItem key={config.id} value={config.id}>
+											{config.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					</div>
+
+					<div className="mb-2">
+						<div className="flex flex-wrap gap-2 mb-2 p-2 bg-vscode-editor-background rounded border border-vscode-panel-border">
+							<Button variant="outline" size="sm" onClick={() => insertVariable("user.name")}>
+								user.name
+							</Button>
+							<Button variant="outline" size="sm" onClick={() => insertVariable("user.email")}>
+								user.email
+							</Button>
+							<Button variant="outline" size="sm" onClick={() => insertVariable("user.role")}>
+								user.role
+							</Button>
+							<Button variant="outline" size="sm" onClick={() => insertVariable("project.name")}>
+								project.name
+							</Button>
+							<Button variant="outline" size="sm" onClick={() => insertVariable("project.description")}>
+								project.description
+							</Button>
+							<Button variant="outline" size="sm" onClick={() => insertVariable("project.version")}>
+								project.version
+							</Button>
+							<Button variant="outline" size="sm" onClick={() => insertVariable("date")}>
+								date
+							</Button>
+							<Button variant="outline" size="sm" onClick={() => insertVariable("items")}>
+								items
+							</Button>
+						</div>
+					</div>
+
+					<div className="grid grid-cols-2 gap-4 mb-4">
+						<div>
+							<h4 className="text-vscode-foreground m-0 mb-2">{t("Handlebars Template")}</h4>
+							<EditableCodeBlock
+								ref={codeEditorRef}
+								value={promptInput}
+								onChange={setPromptInput}
+								language="handlebars"
+								placeholder={t("Enter your Handlebars template here... (e.g. Hello {{user.name}}!)")}
+								rows={8}
+								className="w-full"
+							/>
+						</div>
+						<div>
+							<h4 className="text-vscode-foreground m-0 mb-2">{t("Rendered Preview")}</h4>
+							<div className="bg-vscode-editor-background p-4 rounded border border-vscode-panel-border whitespace-pre-wrap h-[calc(100%-2.5rem)] overflow-auto">
+								{renderedPreview || t("Preview will appear here...")}
+							</div>
+						</div>
+					</div>
+
+					<div className="flex gap-2 mb-4">
+						<Button onClick={handleCallLLM} disabled={isLoading || !promptInput.trim()}>
+							{isLoading ? t("Processing...") : t("Call LLM")}
+						</Button>
+						<Button
+							onClick={handleSubmitPrompt}
+							disabled={isLoading || !promptInput.trim()}
+							variant="outline">
+							{t("Debug Prompt")}
+						</Button>
+						<Button variant="outline" onClick={handleClear} disabled={isLoading}>
+							{t("Clear")}
+						</Button>
+					</div>
+
+					<div className="mb-4">
+						<h4 className="text-vscode-foreground m-0 mb-2">{t("LLM Response")}</h4>
+						<div className="bg-vscode-editor-background p-4 rounded border border-vscode-panel-border whitespace-pre-wrap min-h-[100px]">
+							{llmResponse || t("LLM response will appear here after clicking 'Call LLM'...")}
+						</div>
+					</div>
+
+					{debugOutput && (
+						<div className="mb-4">
+							<h4 className="text-vscode-foreground m-0 mb-2">{t("Debug Output")}</h4>
+							<div className="bg-vscode-editor-background p-4 rounded border border-vscode-panel-border whitespace-pre-wrap">
+								{debugOutput}
+							</div>
+						</div>
+					)}
+				</div>
+			</TabContent>
+
+			<div className="fixed inset-0 top-auto">
+				<BottomControls />
+			</div>
+		</Tab>
+	)
 }
 
 export default PromptDebuggerView

--- a/webview-ui/src/components/prompt-debugger/PromptDebuggerView.tsx
+++ b/webview-ui/src/components/prompt-debugger/PromptDebuggerView.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from "react"
+import { VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
+import { Trans } from "react-i18next"
+
+import { vscode } from "@src/utils/vscode"
+import { useAppTranslation } from "@src/i18n/TranslationContext"
+import { useExtensionState } from "@src/context/ExtensionStateContext"
+import { Tab, TabContent, TabHeader } from "@src/components/common/Tab"
+import {
+    Button,
+    Input,
+    Textarea,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@src/components/ui"
+import BottomControls from "../chat/BottomControls"
+
+type PromptDebuggerViewProps = {
+    onDone: () => void
+}
+
+const PromptDebuggerView = ({ onDone }: PromptDebuggerViewProps) => {
+    const { t } = useAppTranslation()
+    const { listApiConfigMeta, currentApiConfigName } = useExtensionState()
+
+    // State for prompt input
+    const [promptInput, setPromptInput] = useState("")
+
+    // State for model selection
+    const [selectedModel, setSelectedModel] = useState(currentApiConfigName)
+
+    // State for debug output
+    const [debugOutput, setDebugOutput] = useState("")
+
+    // State for loading
+    const [isLoading, setIsLoading] = useState(false)
+
+    // Handle prompt submission
+    const handleSubmitPrompt = () => {
+        if (!promptInput.trim()) return
+
+        setIsLoading(true)
+
+        // Here we would send the prompt to the extension for processing
+        // For now, we'll just simulate a response since we're building the UI
+        // In a real implementation, we would need to add a new message type to ExtensionMessage
+        // and handle it in the extension
+
+        // Simulate processing
+        setDebugOutput(`Simulated debug results for prompt: "${promptInput}"\nUsing model: ${selectedModel}\n\nThis is a placeholder for actual debug output that would come from the extension.`)
+
+        // For now, just simulate a response
+        setTimeout(() => {
+            setDebugOutput(`Debug results for prompt: "${promptInput}"\nUsing model: ${selectedModel}\n\nThis is a placeholder for actual debug output.`)
+            setIsLoading(false)
+        }, 1000)
+    }
+
+    // Handle model selection change
+    const handleModelChange = (value: string) => {
+        setSelectedModel(value)
+    }
+
+    // Handle clearing the form
+    const handleClear = () => {
+        setPromptInput("")
+        setDebugOutput("")
+    }
+
+    return (
+        <Tab>
+            <TabHeader className="flex justify-between items-center">
+                <h3 className="text-vscode-foreground m-0">{t("Prompt Debugger")}</h3>
+                <Button onClick={onDone}>{t("Done")}</Button>
+            </TabHeader>
+
+            <TabContent>
+                <div className="mb-5">
+                    <div className="mb-2">
+                        <h4 className="text-vscode-foreground m-0 mb-2">{t("Model Selection")}</h4>
+                        <Select value={selectedModel} onValueChange={handleModelChange}>
+                            <SelectTrigger data-testid="api-config-select" className="w-full">
+                                <SelectValue placeholder={t("Select a model")} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {(listApiConfigMeta || []).map((config) => (
+                                    <SelectItem key={config.id} value={config.id}>
+                                        {config.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <div className="mb-4">
+                        <h4 className="text-vscode-foreground m-0 mb-2">{t("Prompt Input")}</h4>
+                        <VSCodeTextArea
+                            className="w-full"
+                            rows={5}
+                            value={promptInput}
+                            onChange={(e) => {
+                                const target = e.target as HTMLTextAreaElement
+                                setPromptInput(target.value)
+                            }}
+                            placeholder={t("Enter your prompt here...")}
+                        />
+                    </div>
+
+                    <div className="flex gap-2 mb-4">
+                        <Button
+                            onClick={handleSubmitPrompt}
+                            disabled={isLoading || !promptInput.trim()}
+                        >
+                            {isLoading ? t("Processing...") : t("Debug Prompt")}
+                        </Button>
+                        <Button
+                            variant="outline"
+                            onClick={handleClear}
+                            disabled={isLoading}
+                        >
+                            {t("Clear")}
+                        </Button>
+                    </div>
+
+                    {debugOutput && (
+                        <div className="mb-4">
+                            <h4 className="text-vscode-foreground m-0 mb-2">{t("Debug Output")}</h4>
+                            <div className="bg-vscode-editor-background p-4 rounded border border-vscode-panel-border whitespace-pre-wrap">
+                                {debugOutput}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </TabContent>
+
+            <div className="fixed inset-0 top-auto">
+                <BottomControls />
+            </div>
+        </Tab>
+    )
+}
+
+export default PromptDebuggerView

--- a/webview-ui/src/components/prompt-debugger/README.md
+++ b/webview-ui/src/components/prompt-debugger/README.md
@@ -1,0 +1,72 @@
+# Prompt Debugger Components
+
+## EditableCodeBlock
+
+The `EditableCodeBlock` component provides a code editor with syntax highlighting for the prompt debugger. It allows users to edit template code while seeing syntax highlighting in real-time.
+
+### Implementation Details
+
+The component uses a layered approach:
+
+1. A hidden textarea captures all user input and keyboard events
+2. A visible div displays the syntax-highlighted code using Shiki
+3. The two layers are synchronized to provide a seamless editing experience
+
+### Key Features
+
+- Real-time syntax highlighting using Shiki (same engine as VS Code)
+- Support for multiple programming languages
+- Tab key handling for proper indentation
+- Automatic height adjustment based on content
+- Cursor and selection styling that matches VS Code
+
+### Usage
+
+```tsx
+import EditableCodeBlock from "./EditableCodeBlock"
+
+// Basic usage
+<EditableCodeBlock
+  value={code}
+  onChange={setCode}
+  language="javascript"
+/>
+
+// With all props
+<EditableCodeBlock
+  value={code}
+  onChange={setCode}
+  language="javascript"
+  placeholder="Enter your code here..."
+  className="custom-class"
+  rows={10}
+/>
+```
+
+### Props
+
+| Prop          | Type     | Default              | Description                                      |
+| ------------- | -------- | -------------------- | ------------------------------------------------ |
+| `value`       | string   | (required)           | The code content to display and edit             |
+| `onChange`    | function | (required)           | Callback function when the code changes          |
+| `language`    | string   | (required)           | The programming language for syntax highlighting |
+| `placeholder` | string   | "Enter code here..." | Placeholder text when the editor is empty        |
+| `className`   | string   | undefined            | Additional CSS class names                       |
+| `rows`        | number   | 5                    | Minimum number of rows to display                |
+
+### How It Works
+
+The component uses a technique where:
+
+1. A transparent textarea captures all user input
+2. The input is processed and passed to Shiki for syntax highlighting
+3. The highlighted HTML is rendered in a div positioned behind the textarea
+4. CSS is used to ensure the cursor and selection appear correctly
+
+This approach provides the best of both worlds: the native editing experience of a textarea with the visual richness of syntax highlighting.
+
+### Maintenance Notes
+
+- The component extends the functionality of the existing `CodeBlock` component but is fully independent to avoid conflicts with upstream repositories
+- Shiki is used for syntax highlighting to maintain consistency with the rest of the application
+- The component is designed to be lightweight and not dependent on external editor libraries

--- a/webview-ui/src/components/prompt-debugger/__tests__/EditableCodeBlock.test.tsx
+++ b/webview-ui/src/components/prompt-debugger/__tests__/EditableCodeBlock.test.tsx
@@ -1,0 +1,53 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import EditableCodeBlock from "../EditableCodeBlock"
+
+// Mock the highlighter module
+jest.mock("@src/utils/highlighter", () => ({
+	getHighlighter: jest.fn().mockImplementation(() => ({
+		codeToHtml: jest.fn().mockImplementation((code, options) => {
+			return Promise.resolve(`<pre><code class="hljs language-${options.lang}">${code}</code></pre>`)
+		}),
+	})),
+	isLanguageLoaded: jest.fn().mockReturnValue(true),
+	normalizeLanguage: jest.fn().mockImplementation((lang) => lang),
+}))
+
+describe("EditableCodeBlock", () => {
+	it("renders with default props", () => {
+		const onChange = jest.fn()
+		render(<EditableCodeBlock value="" onChange={onChange} language="javascript" />)
+
+		// Check if textarea exists
+		const textarea = screen.getByRole("textbox")
+		expect(textarea).toBeInTheDocument()
+	})
+
+	it("handles input changes", () => {
+		const onChange = jest.fn()
+		render(<EditableCodeBlock value="" onChange={onChange} language="javascript" />)
+
+		const textarea = screen.getByRole("textbox")
+		fireEvent.change(textarea, { target: { value: "const x = 1;" } })
+
+		expect(onChange).toHaveBeenCalledWith("const x = 1;")
+	})
+
+	it("handles tab key for indentation", () => {
+		const onChange = jest.fn()
+		render(<EditableCodeBlock value="function test() {" onChange={onChange} language="javascript" />)
+
+		const textarea = screen.getByRole("textbox")
+		fireEvent.keyDown(textarea, { key: "Tab" })
+
+		expect(onChange).toHaveBeenCalledWith("function test() {    ")
+	})
+
+	it("displays placeholder when value is empty", () => {
+		const onChange = jest.fn()
+		const placeholder = "Custom placeholder"
+		render(<EditableCodeBlock value="" onChange={onChange} language="javascript" placeholder={placeholder} />)
+
+		expect(screen.getByText(placeholder)).toBeInTheDocument()
+	})
+})

--- a/webview-ui/src/components/prompt-debugger/templates.ts
+++ b/webview-ui/src/components/prompt-debugger/templates.ts
@@ -1,20 +1,30 @@
 // Template definitions for the Prompt Debugger
 
-export const documentationTemplate = `# {{project.name}} Documentation
+export const documentationTemplate = `# Document Analysis: {{document.name}}
 
-## Overview
-{{project.description}}
-Version: {{project.version}}
+## File Information
+- **Path:** {{document.path}}
+- **Language:** {{document.language}}
+- **Line Count:** {{document.lineCount}}
 
-## User Information
-- **Name:** {{user.name}}
-- **Email:** {{user.email}}
-- **Role:** {{user.role}}
+## Current Selection
+\`\`\`{{document.language}}
+{{selection.text}}
+\`\`\`
 
-## Project Items
-{{#each items}}
-- {{this}}
-{{/each}}
+## Cursor Position
+- Line: {{cursor.line}}
+- Column: {{cursor.column}}
+
+## Content Before Cursor
+\`\`\`{{document.language}}
+{{content.beforeCursor}}
+\`\`\`
+
+## Content After Cursor
+\`\`\`{{document.language}}
+{{content.afterCursor}}
+\`\`\`
 
 ## Generated on: {{date}}
 `
@@ -22,14 +32,19 @@ Version: {{project.version}}
 export const holeFillTemplate = `You are a HOLE FILLER. You are provided with a file containing holes, formatted as '{{HOLE_NAME}}'.
 Your TASK is to complete with a string to replace this hole with, including context-aware indentation, if needed.
 
+## Current file information
+- File: {{document.name}}
+- Language: {{document.language}}
+
 ## Current file content with hole:
-\`\`\`
-function hypothenuse(a, b) {
-  return Math.sqrt({{FILL_HERE}}b ** 2);
-}
+\`\`\`{{document.language}}
+{{content.all}}
 \`\`\`
 
-TASK: Fill the {{FILL_HERE}} hole. Answer only with the CORRECT completion.`
+## Cursor is at position: Line {{cursor.line}}, Column {{cursor.column}}
+
+TASK: Fill in the code at the cursor position, ensuring it fits properly with the surrounding context.
+Answer only with the CORRECT completion.`
 
 // Default templates array
 export const defaultTemplates = [

--- a/webview-ui/src/components/prompt-debugger/templates.ts
+++ b/webview-ui/src/components/prompt-debugger/templates.ts
@@ -1,0 +1,38 @@
+// Template definitions for the Prompt Debugger
+
+export const documentationTemplate = `# {{project.name}} Documentation
+
+## Overview
+{{project.description}}
+Version: {{project.version}}
+
+## User Information
+- **Name:** {{user.name}}
+- **Email:** {{user.email}}
+- **Role:** {{user.role}}
+
+## Project Items
+{{#each items}}
+- {{this}}
+{{/each}}
+
+## Generated on: {{date}}
+`
+
+export const holeFillTemplate = `You are a HOLE FILLER. You are provided with a file containing holes, formatted as '{{HOLE_NAME}}'.
+Your TASK is to complete with a string to replace this hole with, including context-aware indentation, if needed.
+
+## Current file content with hole:
+\`\`\`
+function hypothenuse(a, b) {
+  return Math.sqrt({{FILL_HERE}}b ** 2);
+}
+\`\`\`
+
+TASK: Fill the {{FILL_HERE}} hole. Answer only with the CORRECT completion.`
+
+// Default templates array
+export const defaultTemplates = [
+	{ id: "documentation", name: "Documentation Template", content: documentationTemplate },
+	{ id: "holeFiller", name: "Hole Filler Template", content: holeFillTemplate },
+]

--- a/webview-ui/src/components/settings/ExperimentalSettings.tsx
+++ b/webview-ui/src/components/settings/ExperimentalSettings.tsx
@@ -226,6 +226,26 @@ export const ExperimentalSettings = ({
 					</div>
 				)}
 
+				{/* Prompt Debugger Section */}
+				<div className="flex flex-col gap-3 mt-4">
+					<div className="flex items-center gap-4 font-bold">
+						<span className="codicon codicon-debug" />
+						<div>{t("Prompt Debugger")}</div>
+					</div>
+					<div>
+						<div className="text-[13px] text-vscode-descriptionForeground mb-2">
+							Access the prompt debugger to test and debug prompts with different models.
+						</div>
+						<Button
+							onClick={() => {
+								// Use the global function we added to App.tsx
+								(window as any).switchToPromptDebugger?.()
+							}}>
+							Open Prompt Debugger
+						</Button>
+					</div>
+				</div>
+
 				<CodeIndexSettings
 					codebaseIndexModels={codebaseIndexModels}
 					codebaseIndexConfig={codebaseIndexConfig}

--- a/webview-ui/src/utils/highlighter.ts
+++ b/webview-ui/src/utils/highlighter.ts
@@ -56,6 +56,8 @@ const languageAliases: Record<string, ExtendedLanguage> = {
 
 	// HTML variants
 	htm: "html",
+	handlebars: "html",
+	hbs: "html",
 
 	// YAML variants
 	yml: "yaml",


### PR DESCRIPTION
A vibe-coded prompt debugger!!

The idea is that will would make debugging and playing around with autocomplete and other more complex prompts / reponses easier.

We can pipe in certain variables from VScode (I added a few random examples here inspired by the HOLE FILLER template)
then you can test out the prompts. I'm not 100% sure how this fits into the product UX and the way you get to it doesn't make sense, but this is the rough idea!

<img width="676" alt="image" src="https://github.com/user-attachments/assets/6eed33fa-509c-4292-adba-804e7bf1963c" />
<img width="645" alt="image" src="https://github.com/user-attachments/assets/484ccd75-8062-437d-a2a7-3cb1662dadb5" />
