### PR TITLE
Make sure to comment out all telemetry for now

### DIFF
--- a/.changeset/icy-zoos-return.md
+++ b/.changeset/icy-zoos-return.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix issue with attempt_completion wanting to initialize telemetry (Roo leftover), we don't want telemetry

--- a/packages/cloud/src/CloudService.ts
+++ b/packages/cloud/src/CloudService.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode"
 
 import type { CloudUserInfo, TelemetryEvent, OrganizationAllowList } from "@roo-code/types"
-import { TelemetryService } from "@roo-code/telemetry"
+// import { TelemetryService } from "@roo-code/telemetry" // kilocode_change
 
 import { CloudServiceCallbacks } from "./types"
 import { AuthService } from "./AuthService"
@@ -46,7 +46,7 @@ export class CloudService {
 			this.telemetryClient = new TelemetryClient(this.authService, this.settingsService)
 
 			try {
-				TelemetryService.instance.register(this.telemetryClient)
+				// TelemetryService.instance.register(this.telemetryClient)
 			} catch (error) {
 				console.warn("[CloudService] Failed to register TelemetryClient:", error)
 			}

--- a/src/core/condense/__tests__/index.test.ts
+++ b/src/core/condense/__tests__/index.test.ts
@@ -724,7 +724,8 @@ describe("summarizeConversation with custom settings", () => {
 	/**
 	 * Test that telemetry is called for custom prompt usage
 	 */
-	it("should capture telemetry when using custom prompt", async () => {
+	// kilocode_change: skip
+	it.skip("should capture telemetry when using custom prompt", async () => {
 		await summarizeConversation(
 			sampleMessages,
 			mockMainApiHandler,
@@ -747,7 +748,8 @@ describe("summarizeConversation with custom settings", () => {
 	/**
 	 * Test that telemetry is called for custom API handler usage
 	 */
-	it("should capture telemetry when using custom API handler", async () => {
+	// kilocode_change: skip
+	it.skip("should capture telemetry when using custom API handler", async () => {
 		await summarizeConversation(
 			sampleMessages,
 			mockMainApiHandler,
@@ -771,7 +773,8 @@ describe("summarizeConversation with custom settings", () => {
 	/**
 	 * Test that telemetry is called with both custom prompt and API handler
 	 */
-	it("should capture telemetry when using both custom prompt and API handler", async () => {
+	// kilocode_change: skip
+	it.skip("should capture telemetry when using both custom prompt and API handler", async () => {
 		await summarizeConversation(
 			sampleMessages,
 			mockMainApiHandler,

--- a/src/core/condense/index.ts
+++ b/src/core/condense/index.ts
@@ -90,12 +90,14 @@ export async function summarizeConversation(
 	customCondensingPrompt?: string,
 	condensingApiHandler?: ApiHandler,
 ): Promise<SummarizeResponse> {
-	TelemetryService.instance.captureContextCondensed(
-		taskId,
-		isAutomaticTrigger ?? false,
-		!!customCondensingPrompt?.trim(),
-		!!condensingApiHandler,
-	)
+	// kilocode_change start
+	// TelemetryService.instance.captureContextCondensed(
+	// 	taskId,
+	// 	isAutomaticTrigger ?? false,
+	// 	!!customCondensingPrompt?.trim(),
+	// 	!!condensingApiHandler,
+	// )
+	// kilocode_change end
 
 	const response: SummarizeResponse = { messages, cost: 0, summary: "" }
 	const messagesToSummarize = getMessagesSinceLastSummary(messages.slice(0, -N_MESSAGES_TO_KEEP))

--- a/src/core/config/importExport.ts
+++ b/src/core/config/importExport.ts
@@ -83,7 +83,8 @@ export const importSettings = async ({ providerSettingsManager, contextProxy, cu
 
 		if (e instanceof ZodError) {
 			error = e.issues.map((issue) => `[${issue.path.join(".")}]: ${issue.message}`).join("\n")
-			TelemetryService.instance.captureSchemaValidationError({ schemaName: "ImportExport", error: e })
+			// kilocode_change: do not get instance
+			// TelemetryService.instance.captureSchemaValidationError({ schemaName: "ImportExport", error: e })
 		} else if (e instanceof Error) {
 			error = e.message
 		}

--- a/src/core/sliding-window/index.ts
+++ b/src/core/sliding-window/index.ts
@@ -38,7 +38,8 @@ export async function estimateTokenCount(
  * @returns {ApiMessage[]} The truncated conversation messages.
  */
 export function truncateConversation(messages: ApiMessage[], fracToRemove: number, taskId: string): ApiMessage[] {
-	TelemetryService.instance.captureSlidingWindowTruncation(taskId)
+	// kilocode_change: do not get instance
+	// TelemetryService.instance.captureSlidingWindowTruncation(taskId)
 	const truncatedMessages = [messages[0]]
 	const rawMessagesToRemove = Math.floor((messages.length - 1) * fracToRemove)
 	const messagesToRemove = rawMessagesToRemove - (rawMessagesToRemove % 2)

--- a/src/core/tools/attemptCompletionTool.ts
+++ b/src/core/tools/attemptCompletionTool.ts
@@ -46,7 +46,8 @@ export async function attemptCompletionTool(
 					// we have command string, which means we have the result as well, so finish it (doesnt have to exist yet)
 					await cline.say("completion_result", removeClosingTag("result", result), undefined, false)
 
-					TelemetryService.instance.captureTaskCompleted(cline.taskId)
+					// kilocode_change: do not get instance
+					// TelemetryService.instance.captureTaskCompleted(cline.taskId)
 					cline.emit("taskCompleted", cline.taskId, cline.getTokenUsage(), cline.toolUsage)
 
 					await cline.ask("command", removeClosingTag("command", command), block.partial).catch(() => {})
@@ -72,7 +73,8 @@ export async function attemptCompletionTool(
 				if (lastMessage && lastMessage.ask !== "command") {
 					// Haven't sent a command message yet so first send completion_result then command.
 					await cline.say("completion_result", result, undefined, false)
-					TelemetryService.instance.captureTaskCompleted(cline.taskId)
+					// kilocode_change: do not get instance
+					// TelemetryService.instance.captureTaskCompleted(cline.taskId)
 					cline.emit("taskCompleted", cline.taskId, cline.getTokenUsage(), cline.toolUsage)
 				}
 
@@ -97,7 +99,8 @@ export async function attemptCompletionTool(
 				commandResult = execCommandResult
 			} else {
 				await cline.say("completion_result", result, undefined, false)
-				TelemetryService.instance.captureTaskCompleted(cline.taskId)
+				// kilocode_change: do not get instance
+				// TelemetryService.instance.captureTaskCompleted(cline.taskId)
 				cline.emit("taskCompleted", cline.taskId, cline.getTokenUsage(), cline.toolUsage)
 			}
 

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1497,8 +1497,10 @@ export const webviewMessageHandler = async (provider: ClineProvider, message: We
 		case "telemetrySetting": {
 			const telemetrySetting = message.text as TelemetrySetting
 			await updateGlobalState("telemetrySetting", telemetrySetting)
-			const isOptedIn = telemetrySetting === "enabled"
-			TelemetryService.instance.updateTelemetryState(isOptedIn)
+			// kilocode_change: do not get instance
+			// const isOptedIn = telemetrySetting === "enabled"
+
+			// TelemetryService.instance.updateTelemetryState(isOptedIn)
 			await provider.postStateToWebview()
 			break
 		}
@@ -1509,7 +1511,8 @@ export const webviewMessageHandler = async (provider: ClineProvider, message: We
 		}
 		case "rooCloudSignIn": {
 			try {
-				TelemetryService.instance.captureEvent(TelemetryEventName.AUTHENTICATION_INITIATED)
+				// kilocode_change: do not get instance
+				// TelemetryService.instance.captureEvent(TelemetryEventName.AUTHENTICATION_INITIATED)
 				await CloudService.instance.login()
 			} catch (error) {
 				provider.log(`AuthService#login failed: ${error}`)


### PR DESCRIPTION
Some errors surrounding the telemetry service (that should not be used) are propagating in the tool usage in the chat. This is a quickfix to get it out of the door. I'll work on actually putting up a mock telemetryservice next so it can just be "used" without actually collecting anything, makes Roo merges easier as well of course.