### PR TITLE
Fix/#402 same provider for all modes

### DIFF
--- a/.changeset/fix-model-override.md
+++ b/.changeset/fix-model-override.md
@@ -1,0 +1,10 @@
+---
+"packages/types": patch
+"kilocode": patch
+---
+
+Fix: "Use this model for all modes" toggle now correctly restores per-mode model selections.
+
+Previously, the "use this model for all modes" feature only handled provider-level configurations, not model-specific selections. This meant that when the toggle was disabled, users' previous per-mode model customizations were not restored.
+
+This change enhances the feature to properly save and restore per-mode model configurations. When the toggle is enabled, the current model is applied globally, and the previous per-mode settings are backed up. When the toggle is disabled, the backed-up model selections are restored, allowing users to seamlessly switch between a unified model and individual mode customizations.

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -100,6 +100,8 @@ export const globalSettingsSchema = z.object({
 
 	mode: z.string().optional(),
 	modeApiConfigs: z.record(z.string(), z.string()).optional(),
+	savedModeApiConfigs: z.record(z.string(), z.string()).optional(),
+	useSameProviderForAllModes: z.boolean().optional(),
 	customModes: z.array(modeConfigSchema).optional(),
 	customModePrompts: customModePromptsSchema.optional(),
 	customSupportPrompts: customSupportPromptsSchema.optional(),
@@ -142,9 +144,12 @@ export const GLOBAL_SETTINGS_KEYS = keysOf<GlobalSettings>()([
 
 	"browserToolEnabled",
 	"browserViewportSize",
+	"showAutoApproveMenu", // kilocode_change
+	"workflowToggles", // kilocode_change
 	"screenshotQuality",
 	"remoteBrowserEnabled",
 	"remoteBrowserHost",
+	"cachedChromeHostUrl",
 
 	"enableCheckpoints",
 
@@ -186,15 +191,13 @@ export const GLOBAL_SETTINGS_KEYS = keysOf<GlobalSettings>()([
 
 	"mode",
 	"modeApiConfigs",
+	"savedModeApiConfigs",
+	"useSameProviderForAllModes",
 	"customModes",
 	"customModePrompts",
 	"customSupportPrompts",
 	"enhancementApiConfigId",
-	"cachedChromeHostUrl",
 	"historyPreviewCollapsed",
-
-	"showAutoApproveMenu", // kilocode_change
-	"workflowToggles", // kilocode_change
 ])
 
 /**

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -101,6 +101,8 @@ export const globalSettingsSchema = z.object({
 	mode: z.string().optional(),
 	modeApiConfigs: z.record(z.string(), z.string()).optional(),
 	savedModeApiConfigs: z.record(z.string(), z.string()).optional(),
+	modeModelConfigs: z.record(z.string(), z.string()).optional(), // kilocode_change: Track model selections per mode
+	savedModeModelConfigs: z.record(z.string(), z.string()).optional(), // kilocode_change: Backup for restoration
 	useSameProviderForAllModes: z.boolean().optional(),
 	customModes: z.array(modeConfigSchema).optional(),
 	customModePrompts: customModePromptsSchema.optional(),
@@ -192,6 +194,8 @@ export const GLOBAL_SETTINGS_KEYS = keysOf<GlobalSettings>()([
 	"mode",
 	"modeApiConfigs",
 	"savedModeApiConfigs",
+	"modeModelConfigs", // kilocode_change
+	"savedModeModelConfigs", // kilocode_change
 	"useSameProviderForAllModes",
 	"customModes",
 	"customModePrompts",

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -784,6 +784,13 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 
 		await this.updateGlobalState("mode", newMode)
 
+		// If useSameProviderForAllModes is enabled, we don't need to do anything.
+		const { useSameProviderForAllModes } = await this.getState()
+		if (useSameProviderForAllModes) {
+			await this.postStateToWebview()
+			return
+		}
+
 		// Load the saved API config for the new mode if it exists
 		const savedConfigId = await this.providerSettingsManager.getModeConfigId(newMode)
 		const listApiConfig = await this.providerSettingsManager.listConfig()
@@ -1327,6 +1334,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			customCondensingPrompt,
 			codebaseIndexConfig,
 			codebaseIndexModels,
+			useSameProviderForAllModes,
 		} = await this.getState()
 
 		const machineId = vscode.env.machineId
@@ -1438,6 +1446,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 				codebaseIndexEmbedderBaseUrl: "",
 				codebaseIndexEmbedderModelId: "",
 			},
+			useSameProviderForAllModes: useSameProviderForAllModes ?? false,
 		}
 	}
 
@@ -1546,6 +1555,8 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			listApiConfigMeta: stateValues.listApiConfigMeta ?? [],
 			pinnedApiConfigs: stateValues.pinnedApiConfigs ?? {},
 			modeApiConfigs: stateValues.modeApiConfigs ?? ({} as Record<Mode, string>),
+			savedModeApiConfigs: stateValues.savedModeApiConfigs ?? ({} as Record<Mode, string>),
+			useSameProviderForAllModes: stateValues.useSameProviderForAllModes ?? false,
 			customModePrompts: stateValues.customModePrompts ?? {},
 			customSupportPrompts: stateValues.customSupportPrompts ?? {},
 			enhancementApiConfigId: stateValues.enhancementApiConfigId,

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -242,6 +242,7 @@ export type ExtensionState = Pick<
 
 	autoCondenseContext: boolean
 	autoCondenseContextPercent: number
+	useSameProviderForAllModes?: boolean
 }
 
 export interface ClineSayTool {

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -172,6 +172,7 @@ export interface WebviewMessage {
 		| "indexCleared"
 		| "codebaseIndexConfig"
 		| "telemetrySetting"
+		| "toggleUseSameProviderForAllModes"
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useEffect, useMemo, useState } from "react"
 import { convertHeadersToObject } from "./utils/headers"
 import { useDebounce } from "react-use"
 import { VSCodeButtonLink } from "../common/VSCodeButtonLink"
-import { VSCodeLink, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeCheckbox, VSCodeLink, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 
 import { getKiloCodeBackendAuthUrl } from "../kilocode/helpers" // kilocode_change
 
@@ -77,6 +77,7 @@ export interface ApiOptionsProps {
 	setErrorMessage: React.Dispatch<React.SetStateAction<string | undefined>>
 	hideKiloCodeButton?: boolean // kilocode_change
 	currentApiConfigName?: string // kilocode_change
+	handleToggleUseSameProvider?: () => void
 }
 
 const ApiOptions = ({
@@ -89,6 +90,7 @@ const ApiOptions = ({
 	setErrorMessage,
 	hideKiloCodeButton = false,
 	currentApiConfigName, // kilocode_change
+	handleToggleUseSameProvider,
 }: ApiOptionsProps) => {
 	const { t } = useAppTranslation()
 	const { organizationAllowList } = useExtensionState()
@@ -289,6 +291,8 @@ const ApiOptions = ({
 		}
 	}, [selectedProvider])
 
+	const { useSameProviderForAllModes } = useExtensionState()
+
 	return (
 		<div className="flex flex-col gap-3">
 			<div className="flex flex-col gap-1 relative">
@@ -308,16 +312,24 @@ const ApiOptions = ({
 					</SelectTrigger>
 					<SelectContent>
 						{PROVIDERS.map(({ value, label }, i) => (
-							<>
-								<SelectItem key={value} value={value}>
-									{label}
-								</SelectItem>
+							<React.Fragment key={value}>
+								<SelectItem value={value}>{label}</SelectItem>
 								{/*  kilocode_change */}
 								{i === 0 ? <SelectSeparator /> : null}
-							</>
+							</React.Fragment>
 						))}
 					</SelectContent>
 				</Select>
+				<div className="flex items-center gap-2 mt-2">
+					<VSCodeCheckbox
+						checked={!!useSameProviderForAllModes}
+						onChange={handleToggleUseSameProvider}
+						data-testid="use-same-provider-for-all-modes-checkbox">
+						{selectedModelId
+							? `Use ${selectedModelId} for all modes`
+							: t("settings:providers.useSameProviderForAllModes")}
+					</VSCodeCheckbox>
+				</div>
 			</div>
 
 			{errorMessage && <ApiErrorMessage errorMessage={errorMessage} />}

--- a/webview-ui/src/components/settings/ModelPicker.tsx
+++ b/webview-ui/src/components/settings/ModelPicker.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback, useEffect, useRef } from "react"
+import React, { useMemo, useState, useCallback, useEffect, useRef } from "react"
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { Trans } from "react-i18next"
 import { ChevronsUpDown, Check, X } from "lucide-react"
@@ -193,7 +193,7 @@ export const ModelPicker = ({
 											models?.[modelIds[i - 1]]?.preferredIndex !== null
 
 										return (
-											<>
+											<React.Fragment key={model}>
 												{!isPreferred && previousModelWasPreferred ? <SelectSeparator /> : null}
 												<CommandItem
 													key={model}
@@ -208,7 +208,7 @@ export const ModelPicker = ({
 														)}
 													/>
 												</CommandItem>
-											</>
+											</React.Fragment>
 										)
 									})}
 									{/* kilocode_change end */}

--- a/webview-ui/src/components/settings/PromptsSettings.tsx
+++ b/webview-ui/src/components/settings/PromptsSettings.tsx
@@ -14,8 +14,7 @@ import { MessageSquare } from "lucide-react"
 const PromptsSettings = () => {
 	const { t } = useAppTranslation()
 
-	const { customSupportPrompts, listApiConfigMeta, enhancementApiConfigId, setEnhancementApiConfigId } =
-		useExtensionState()
+	const { customSupportPrompts, listApiConfigMeta, enhancementApiConfigId } = useExtensionState()
 
 	const [testPrompt, setTestPrompt] = useState("")
 	const [isEnhancing, setIsEnhancing] = useState(false)
@@ -133,10 +132,9 @@ const PromptsSettings = () => {
 								<Select
 									value={enhancementApiConfigId || "-"}
 									onValueChange={(value) => {
-										setEnhancementApiConfigId(value === "-" ? "" : value)
 										vscode.postMessage({
 											type: "enhancementApiConfigId",
-											text: value,
+											text: value === "-" ? "" : value,
 										})
 									}}>
 									<SelectTrigger data-testid="api-config-select" className="w-full">

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -192,19 +192,20 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 
 	useEffect(() => {
 		// Update only when currentApiConfigName is changed.
-		// Expected to be triggered by loadApiConfiguration/upsertApiConfiguration.
 		if (prevApiConfigName.current === currentApiConfigName) {
 			return
 		}
 
-		setCachedState((prevCachedState) => ({
-			...prevCachedState,
-			...extensionState,
-			useSameProviderForAllModes: prevCachedState.useSameProviderForAllModes,
-		}))
+		// When a new API config is loaded, update the cached state
+		// but preserve the user's unsaved change to the checkbox.
+		setCachedState((prevCachedState) => {
+			const newCachedState = { ...extensionState }
+			newCachedState.useSameProviderForAllModes = prevCachedState.useSameProviderForAllModes
+			return newCachedState
+		})
+
 		prevApiConfigName.current = currentApiConfigName
-		setChangeDetected(false)
-	}, [currentApiConfigName, extensionState, isChangeDetected])
+	}, [currentApiConfigName, extensionState])
 
 	// kilocode_change start
 	// Temporary way of making sure that the Settings view updates its local state properly when receiving

--- a/webview-ui/src/components/settings/__tests__/ApiOptions.test.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiOptions.test.tsx
@@ -21,6 +21,18 @@ jest.mock("@vscode/webview-ui-toolkit/react", () => ({
 	VSCodeRadio: ({ value, checked }: any) => <input type="radio" value={value} checked={checked} />,
 	VSCodeRadioGroup: ({ children }: any) => <div>{children}</div>,
 	VSCodeButton: ({ children }: any) => <div>{children}</div>,
+	VSCodeCheckbox: ({ children, onClick, checked, "data-testid": dataTestId }: any) => (
+		<label>
+			<input
+				type="checkbox"
+				checked={checked}
+				onClick={onClick}
+				aria-label={typeof children === "string" ? children : undefined}
+				data-testid={dataTestId}
+			/>
+			{children}
+		</label>
+	),
 }))
 
 // Mock other components

--- a/webview-ui/src/components/ui/alert-dialog.tsx
+++ b/webview-ui/src/components/ui/alert-dialog.tsx
@@ -8,17 +8,25 @@ function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimit
 	return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
 }
 
-function AlertDialogTrigger({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
-	return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
-}
+const AlertDialogTrigger = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Trigger>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Trigger>
+>((props, ref) => {
+	return <AlertDialogPrimitive.Trigger ref={ref} data-slot="alert-dialog-trigger" {...props} />
+})
+AlertDialogTrigger.displayName = AlertDialogPrimitive.Trigger.displayName
 
 function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
 	return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
 }
 
-function AlertDialogOverlay({ className, ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+const AlertDialogOverlay = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => {
 	return (
 		<AlertDialogPrimitive.Overlay
+			ref={ref}
 			data-slot="alert-dialog-overlay"
 			className={cn(
 				"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
@@ -27,13 +35,18 @@ function AlertDialogOverlay({ className, ...props }: React.ComponentProps<typeof
 			{...props}
 		/>
 	)
-}
+})
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
 
-function AlertDialogContent({ className, ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+const AlertDialogContent = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Content>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => {
 	return (
 		<AlertDialogPortal>
 			<AlertDialogOverlay />
 			<AlertDialogPrimitive.Content
+				ref={ref}
 				data-slot="alert-dialog-content"
 				className={cn(
 					"bg-vscode-editor-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-3 rounded-sm border border-vscode-panel-border p-4 shadow-lg duration-200 sm:max-w-md",
@@ -43,7 +56,8 @@ function AlertDialogContent({ className, ...props }: React.ComponentProps<typeof
 			/>
 		</AlertDialogPortal>
 	)
-}
+})
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
 
 function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
 	return <div data-slot="alert-dialog-header" className={cn("flex flex-col gap-1 text-left", className)} {...props} />
@@ -59,9 +73,13 @@ function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">)
 	)
 }
 
-function AlertDialogTitle({ className, ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+const AlertDialogTitle = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Title>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => {
 	return (
 		<AlertDialogPrimitive.Title
+			ref={ref}
 			data-slot="alert-dialog-title"
 			className={cn(
 				"text-base font-medium text-vscode-editor-foreground flex items-center gap-2 text-left",
@@ -70,24 +88,31 @@ function AlertDialogTitle({ className, ...props }: React.ComponentProps<typeof A
 			{...props}
 		/>
 	)
-}
+})
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
 
-function AlertDialogDescription({
-	className,
-	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+const AlertDialogDescription = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Description>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => {
 	return (
 		<AlertDialogPrimitive.Description
+			ref={ref}
 			data-slot="alert-dialog-description"
 			className={cn("text-vscode-descriptionForeground text-sm text-left", className)}
 			{...props}
 		/>
 	)
-}
+})
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName
 
-function AlertDialogAction({ className, ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+const AlertDialogAction = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Action>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => {
 	return (
 		<AlertDialogPrimitive.Action
+			ref={ref}
 			className={cn(
 				buttonVariants(),
 				"bg-vscode-button-background text-vscode-button-foreground hover:bg-vscode-button-hoverBackground h-6 px-3 py-1 border",
@@ -96,11 +121,16 @@ function AlertDialogAction({ className, ...props }: React.ComponentProps<typeof 
 			{...props}
 		/>
 	)
-}
+})
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
 
-function AlertDialogCancel({ className, ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+const AlertDialogCancel = React.forwardRef<
+	React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+	React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => {
 	return (
 		<AlertDialogPrimitive.Cancel
+			ref={ref}
 			className={cn(
 				buttonVariants({ variant: "outline" }),
 				"bg-vscode-button-secondaryBackground text-vscode-button-secondaryForeground hover:bg-vscode-button-secondaryHoverBackground h-6 px-3 py-1 border",
@@ -109,7 +139,8 @@ function AlertDialogCancel({ className, ...props }: React.ComponentProps<typeof 
 			{...props}
 		/>
 	)
-}
+})
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
 
 export {
 	AlertDialog,

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -120,6 +120,7 @@ export interface ExtensionStateContextType extends ExtensionState {
 	autoCondenseContextPercent: number
 	setAutoCondenseContextPercent: (value: number) => void
 	routerModels?: RouterModels
+	useSameProviderForAllModes?: boolean
 }
 
 export const ExtensionStateContext = createContext<ExtensionStateContextType | undefined>(undefined)
@@ -217,6 +218,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 			codebaseIndexEmbedderModelId: "",
 		},
 		codebaseIndexModels: { ollama: {}, openai: {} },
+		useSameProviderForAllModes: false,
 	})
 
 	const [didHydrateState, setDidHydrateState] = useState(false)

--- a/webview-ui/src/setupTests.tsx
+++ b/webview-ui/src/setupTests.tsx
@@ -4,6 +4,9 @@ import { setupI18nForTests } from "./i18n/test-utils"
 // Set up i18n for all tests
 setupI18nForTests()
 
+// Mock scrollIntoView
+window.HTMLElement.prototype.scrollIntoView = jest.fn()
+
 // Mock crypto.getRandomValues
 Object.defineProperty(window, "crypto", {
 	value: {


### PR DESCRIPTION
## Context

This PR fixes issue #405 - the "use the same provider for all modes" feature request

## Implementation

The implementation adds model-level configuration tracking. Here's how it works:

**Key Components:**
1. **State Management**: Utilized existing `modeModelConfigs` and `savedModeModelConfigs` fields to track model selections per mode
2. **Toggle Handler** ([`webviewMessageHandler.ts:1608-1694`](src/core/webview/webviewMessageHandler.ts:1608)): Enhanced to:
   - Save current model configurations to `savedModeModelConfigs` before applying global selection
   - Apply the current model to all modes when enabled
   - Restore saved configurations when disabled
3. **Mode Switching** ([`ClineProvider.ts:778-874`](src/core/webview/ClineProvider.ts:778)): Updated to:
   - Save the current mode's model selection before switching
   - Restore the target mode's model selection after switching
   - Skip model tracking when the toggle is enabled
4. **Model Change Tracking** ([`webviewMessageHandler.ts:1200-1214`](src/core/webview/webviewMessageHandler.ts:1200)): Added tracking in `upsertApiConfiguration` to save model selections per mode when toggle is disabled

**Flow:**
- **State 0**: Each mode has customized model selections
- **Enable Toggle**: Save current state → Apply current model globally
- **While Enabled**: All modes use the same model
- **Disable Toggle**: Restore to State 0 configurations

## Screenshots

Video demonstration: https://youtu.be/caYgLhwXH-w

## How to Test

1. Open Kilo Code settings
2. Select different models for different modes (e.g., Claude 3.5 for Code mode, GPT-4 for Architect mode)
3. Switch between modes and verify each mode remembers its model selection
4. Enable "Use [current model] for all modes" checkbox
5. Switch between modes - all should now use the same model
6. Disable the checkbox
7. Switch between modes again - each mode should restore its previous model selection (note: clicking save here with a different model than selected at model for it in step 2 will over ride the current mode's model as normal, but only for that model in use, this is normal behavior.) 
8. Verify the restored selections match what was set in step 2

## Get in Touch
Mnehmos
<!-- Please add your Discord handle if you're in the Kilo Code Discord -->


































