### PR TITLE
Fix: Remove rule loading from commit message generation

### DIFF
--- a/.changeset/evil-jeans-create.md
+++ b/.changeset/evil-jeans-create.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Temporarily remove .kilocode/rule loading for commit message generation until it works better

--- a/src/services/commit-message/CommitMessageProvider.ts
+++ b/src/services/commit-message/CommitMessageProvider.ts
@@ -118,10 +118,6 @@ export class CommitMessageProvider {
 	 * Builds the AI prompt for commit message generation.
 	 */
 	private async buildCommitMessagePrompt(context: string): Promise<string> {
-		// Load rules from the workspace
-		const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
-		const rules = workspaceRoot ? await loadRuleFiles(workspaceRoot) : ""
-
 		// Check if we should generate a different message than the previous one
 		const shouldGenerateDifferentMessage =
 			this.previousGitContext === context && this.previousCommitMessage !== null
@@ -217,15 +213,12 @@ When analyzing staged changes:
 
 For significant changes, include a detailed body explaining the changes.`
 
-		// Append rules if they exist
-		const rulesSection = rules ? `\n\nAdditional Rules:${rules}` : ""
-
 		// Add a final reminder if we need a different message
 		const finalReminder = shouldGenerateDifferentMessage
 			? `\n\nFINAL REMINDER: Your message MUST be COMPLETELY DIFFERENT from the previous message: "${this.previousCommitMessage}". This is a critical requirement.`
 			: ""
 
-		return `${basePrompt}${rulesSection}${finalReminder}\n\nReturn ONLY the commit message in the conventional format, nothing else.`
+		return `${basePrompt}${finalReminder}\n\nReturn ONLY the commit message in the conventional format, nothing else.`
 	}
 
 	/**


### PR DESCRIPTION
Temporarily remove the workspace rule loading– it's causing memory bank messages like this to appear in the commits "🧠✅ kilo-dev-mcp-server: MCP server implementation providing tools for AI assistants. The MCP server is ALWAYS running automatically and should never be manually started."

Let's remove it for now since it's not well documented anyway and bring it back in a new PR soon.


Fix this:
![image](https://github.com/user-attachments/assets/34b80ad3-d11f-4c8c-aba3-344d3cd1992f)
