### PR TITLE
Fix feedback button overlapping mode creation view

### DIFF
--- a/.changeset/early-months-report.md
+++ b/.changeset/early-months-report.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix: Feedback button overlaps new mode creation dialog

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -143,8 +143,8 @@ const App = () => {
 				onCancel={(requestId) => vscode.postMessage({ type: "humanRelayCancel", requestId })}
 			/>
 			{/* kilocode_change */}
-			{/* Chat, prompts and history view contain their own bottom controls */}
-			{!["chat", "prompts", "history"].includes(tab) && (
+			{/* Chat, modes and history view contain their own bottom controls */}
+			{!["chat", "modes", "history"].includes(tab) && (
 				<div className="fixed inset-0 top-auto">
 					<BottomControls />
 				</div>


### PR DESCRIPTION
- Resolves  #685

Prompts view was renamed to modes view so the button showed up again. Quickfix since we're going to remove the button from that place altogether most likely anyway.

<img width="566" alt="image" src="https://github.com/user-attachments/assets/88fc1819-11f1-49a3-b0d2-662b788caca0" />
