### PR TITLE
Close the local browser when used as fallback for remote

### DIFF
--- a/.changeset/neat-cases-double.md
+++ b/.changeset/neat-cases-double.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Close the browsertool properly when a remote browser is configured but a fallback local one is used

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -21,6 +21,7 @@ export class BrowserSession {
 	private page?: Page
 	private currentMousePosition?: string
 	private lastConnectionAttempt?: number
+	private isUsingRemoteBrowser: boolean = false
 
 	constructor(context: vscode.ExtensionContext) {
 		this.context = context
@@ -70,6 +71,7 @@ export class BrowserSession {
 			defaultViewport: this.getViewport(),
 			// headless: false,
 		})
+		this.isUsingRemoteBrowser = false
 	}
 
 	/**
@@ -86,6 +88,7 @@ export class BrowserSession {
 			console.log(`Connected to remote browser at ${chromeHostUrl}`)
 			this.context.globalState.update("cachedChromeHostUrl", chromeHostUrl)
 			this.lastConnectionAttempt = Date.now()
+			this.isUsingRemoteBrowser = true
 
 			return true
 		} catch (error) {
@@ -192,8 +195,7 @@ export class BrowserSession {
 		if (this.browser || this.page) {
 			console.log("closing browser...")
 
-			const remoteBrowserEnabled = this.context.globalState.get("remoteBrowserEnabled") as boolean | undefined
-			if (remoteBrowserEnabled && this.browser) {
+			if (this.isUsingRemoteBrowser && this.browser) {
 				await this.browser.disconnect().catch(() => {})
 			} else {
 				await this.browser?.close().catch(() => {})
@@ -212,6 +214,7 @@ export class BrowserSession {
 		this.browser = undefined
 		this.page = undefined
 		this.currentMousePosition = undefined
+		this.isUsingRemoteBrowser = false
 	}
 
 	async doAction(action: (page: Page) => Promise<void>): Promise<BrowserActionResult> {

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -21,7 +21,7 @@ export class BrowserSession {
 	private page?: Page
 	private currentMousePosition?: string
 	private lastConnectionAttempt?: number
-	private isUsingRemoteBrowser: boolean = false
+	private isUsingRemoteBrowser: boolean = false // kilocode_change https://github.com/Kilo-Org/kilocode/pull/747
 
 	constructor(context: vscode.ExtensionContext) {
 		this.context = context
@@ -71,7 +71,7 @@ export class BrowserSession {
 			defaultViewport: this.getViewport(),
 			// headless: false,
 		})
-		this.isUsingRemoteBrowser = false
+		this.isUsingRemoteBrowser = false // kilocode_change https://github.com/Kilo-Org/kilocode/pull/747
 	}
 
 	/**
@@ -88,7 +88,7 @@ export class BrowserSession {
 			console.log(`Connected to remote browser at ${chromeHostUrl}`)
 			this.context.globalState.update("cachedChromeHostUrl", chromeHostUrl)
 			this.lastConnectionAttempt = Date.now()
-			this.isUsingRemoteBrowser = true
+			this.isUsingRemoteBrowser = true // kilocode_change https://github.com/Kilo-Org/kilocode/pull/747
 
 			return true
 		} catch (error) {
@@ -195,7 +195,10 @@ export class BrowserSession {
 		if (this.browser || this.page) {
 			console.log("closing browser...")
 
+			// kilocode_change start https://github.com/Kilo-Org/kilocode/pull/747
 			if (this.isUsingRemoteBrowser && this.browser) {
+				// kilocode_change end https://github.com/Kilo-Org/kilocode/pull/747
+
 				await this.browser.disconnect().catch(() => {})
 			} else {
 				await this.browser?.close().catch(() => {})
@@ -214,7 +217,7 @@ export class BrowserSession {
 		this.browser = undefined
 		this.page = undefined
 		this.currentMousePosition = undefined
-		this.isUsingRemoteBrowser = false
+		this.isUsingRemoteBrowser = false // kilocode_change https://github.com/Kilo-Org/kilocode/pull/747
 	}
 
 	async doAction(action: (page: Page) => Promise<void>): Promise<BrowserActionResult> {


### PR DESCRIPTION
## Context

When we configure kilo to use the remote browser, but none is available, it falls back to a local browser, but when closing the browser it does not honour that fallback. This PR fixes that.

Issue #723

## Implementation

Administrate what browser is actually used in isUsingRemoteBrowser and use this to determine to close which browser when closing the browser.

## How to Test

Ask kilo to go to a news site and ask it for headline ; check that after the task is done all chromium helpers are closed in the activity monitor (sort by name)
