### PR TITLE
Sometimes changeset branch doesn't have a remote

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -131,7 +131,7 @@ jobs:
                   echo "--------------------------------------------------------------------------------"
                   echo "Pushing to remote..."
                   echo "--------------------------------------------------------------------------------"
-                  git push
+                  git push origin
 
             # Add label to indicate changelog has been formatted
             - name: Add changelog-ready label


### PR DESCRIPTION
I did this change before, but it got overridden by the changeset job, so here it is again.

Ex. https://github.com/Kilo-Org/kilocode/actions/runs/15709012352/job/44261815270