### PR TITLE
Attempt to work around missing vscode dependency error

### DIFF
--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -96,6 +96,7 @@ export default defineConfig(({ mode }) => {
 			reportCompressedSize: false,
 			sourcemap: true,
 			rollupOptions: {
+				external: ["vscode"], // kilocode_change: we inadvertenly import vscode into the webview: @roo/modes => src/shared/modes => ../core/prompts/sections/custom-instructions
 				output: {
 					entryFileNames: `assets/[name].js`,
 					chunkFileNames: (chunkInfo) => {
@@ -151,7 +152,7 @@ export default defineConfig(({ mode }) => {
 				"dagre", // Explicitly include dagre for pre-bundling
 				// Add other known large mermaid dependencies if identified
 			],
-			exclude: ["@vscode/codicons", "vscode-oniguruma", "shiki"],
+			exclude: ["@vscode/codicons", "vscode-oniguruma", "shiki", "vscode" /*kilocode_change*/],
 		},
 		assetsInclude: ["**/*.wasm", "**/*.wav"],
 	}

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -96,7 +96,7 @@ export default defineConfig(({ mode }) => {
 			reportCompressedSize: false,
 			sourcemap: true,
 			rollupOptions: {
-				external: ["vscode"], // kilocode_change: we inadvertenly import vscode into the webview: @roo/modes => src/shared/modes => ../core/prompts/sections/custom-instructions
+				external: ["vscode"], // kilocode_change: we inadvertently import vscode into the webview: @roo/modes => src/shared/modes => ../core/prompts/sections/custom-instructions
 				output: {
 					entryFileNames: `assets/[name].js`,
 					chunkFileNames: (chunkInfo) => {


### PR DESCRIPTION
When the vite watcher is started for the first time after certain changes, it gives an error that vscode is not available in the webview. On the next attempt, the build seems to succeed, presumably because of caching effects.

This change seems to work around the issue. Fixing it properly would require either not using vscode in custom-instruction or doing some restructuring of shared/modes (custom-instruction is not actually used in the webview, it only gets imported, but changing this is probably hard because of Roo merge compatibility)
