### PR TITLE
feat(terminal): Add WORKSPACE_ROOT environment variable

### DIFF
--- a/.changeset/terminal-workspace-root.md
+++ b/.changeset/terminal-workspace-root.md
@@ -1,0 +1,9 @@
+---
+"kilo-code": minor
+---
+
+Add $WORKSPACE_ROOT environment variable to terminal sessions for easier workspace navigation
+
+Terminal sessions now automatically include a `$WORKSPACE_ROOT` environment variable that points to your current workspace root directory. In multi-workspace setups, this points to the workspace folder containing your currently active file. This makes it easier to navigate back to your project root from anywhere in the terminal using commands like `cd $WORKSPACE_ROOT` or referencing files relative to your workspace.
+
+This enhancement is particularly useful when working in deeply nested directories or when you need to quickly reference files or tests at the root level.

--- a/.changeset/terminal-workspace-root.md
+++ b/.changeset/terminal-workspace-root.md
@@ -4,6 +4,6 @@
 
 Add $WORKSPACE_ROOT environment variable to terminal sessions for easier workspace navigation
 
-Terminal sessions now automatically include a `$WORKSPACE_ROOT` environment variable that points to your current workspace root directory. This makes it easier for the agent to run terminal commands in sub-directories for example, running just one directory's tests: `cd $WORKSPACE_ROOT && npx jest`.
+Terminal sessions now automatically include a `$WORKSPACE_ROOT` environment variable that points to your current workspace root directory. This makes it easier for the agent to run terminal commands in sub-directories, for example, running just one directory's tests: `cd $WORKSPACE_ROOT && npx jest`.
 
 This enhancement is particularly useful when working in deeply nested directories or when you need to quickly reference files or tests at the root level. In multi-workspace setups, this points to the workspace folder containing your currently active file.

--- a/.changeset/terminal-workspace-root.md
+++ b/.changeset/terminal-workspace-root.md
@@ -4,6 +4,6 @@
 
 Add $WORKSPACE_ROOT environment variable to terminal sessions for easier workspace navigation
 
-Terminal sessions now automatically include a `$WORKSPACE_ROOT` environment variable that points to your current workspace root directory. In multi-workspace setups, this points to the workspace folder containing your currently active file. This makes it easier to navigate back to your project root from anywhere in the terminal using commands like `cd $WORKSPACE_ROOT` or referencing files relative to your workspace.
+Terminal sessions now automatically include a `$WORKSPACE_ROOT` environment variable that points to your current workspace root directory. This makes it easier for the agent to run terminal commands in sub-directories for example, running just one directory's tests: `cd $WORKSPACE_ROOT && npx jest`.
 
-This enhancement is particularly useful when working in deeply nested directories or when you need to quickly reference files or tests at the root level.
+This enhancement is particularly useful when working in deeply nested directories or when you need to quickly reference files or tests at the root level. In multi-workspace setups, this points to the workspace folder containing your currently active file.

--- a/src/integrations/terminal/Terminal.ts
+++ b/src/integrations/terminal/Terminal.ts
@@ -6,6 +6,7 @@ import { BaseTerminal } from "./BaseTerminal"
 import { TerminalProcess } from "./TerminalProcess"
 import { ShellIntegrationManager } from "./ShellIntegrationManager"
 import { mergePromise } from "./mergePromise"
+import { getWorkspacePath } from "../../utils/path"
 
 export class Terminal extends BaseTerminal {
 	public terminal: vscode.Terminal
@@ -151,12 +152,15 @@ export class Terminal extends BaseTerminal {
 	}
 
 	public static getEnv(): Record<string, string> {
+		const workspaceRoot = getWorkspacePath() // kilocode_change
 		const env: Record<string, string> = {
 			PAGER: process.platform === "win32" ? "" : "cat",
 
 			// VTE must be disabled because it prevents the prompt command from executing
 			// See https://wiki.gnome.org/Apps/Terminal/VTE
 			VTE_VERSION: "0",
+
+			WORKSPACE_ROOT: workspaceRoot, // kilocode_change
 		}
 
 		// Set Oh My Zsh shell integration if enabled

--- a/src/integrations/terminal/Terminal.ts
+++ b/src/integrations/terminal/Terminal.ts
@@ -6,7 +6,7 @@ import { BaseTerminal } from "./BaseTerminal"
 import { TerminalProcess } from "./TerminalProcess"
 import { ShellIntegrationManager } from "./ShellIntegrationManager"
 import { mergePromise } from "./mergePromise"
-import { getWorkspacePath } from "../../utils/path"
+import { getWorkspacePath } from "../../utils/path" // kilocode_change
 
 export class Terminal extends BaseTerminal {
 	public terminal: vscode.Terminal

--- a/src/integrations/terminal/Terminal.ts
+++ b/src/integrations/terminal/Terminal.ts
@@ -152,7 +152,6 @@ export class Terminal extends BaseTerminal {
 	}
 
 	public static getEnv(): Record<string, string> {
-		const workspaceRoot = getWorkspacePath() // kilocode_change
 		const env: Record<string, string> = {
 			PAGER: process.platform === "win32" ? "" : "cat",
 
@@ -160,7 +159,7 @@ export class Terminal extends BaseTerminal {
 			// See https://wiki.gnome.org/Apps/Terminal/VTE
 			VTE_VERSION: "0",
 
-			WORKSPACE_ROOT: workspaceRoot, // kilocode_change
+			WORKSPACE_ROOT: getWorkspacePath(), // kilocode_change
 		}
 
 		// Set Oh My Zsh shell integration if enabled

--- a/src/integrations/terminal/__tests__/Terminal.env.test.ts
+++ b/src/integrations/terminal/__tests__/Terminal.env.test.ts
@@ -1,0 +1,38 @@
+import { Terminal } from "../Terminal"
+import { getWorkspacePath } from "../../../utils/path"
+
+jest.mock("../../../utils/path", () => ({ getWorkspacePath: jest.fn() }))
+
+describe("Terminal Environment Variables", () => {
+	const mockWorkspacePath = "/Users/test/workspace"
+	const mockGetWorkspacePath = getWorkspacePath as jest.MockedFunction<typeof getWorkspacePath>
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	it("should include WORKSPACE_ROOT environment variable", () => {
+		mockGetWorkspacePath.mockReturnValue(mockWorkspacePath)
+
+		const env = Terminal.getEnv()
+		expect(env.WORKSPACE_ROOT).toBe(mockWorkspacePath)
+		expect(mockGetWorkspacePath).toHaveBeenCalledTimes(1)
+	})
+
+	it("should handle empty workspace path", () => {
+		mockGetWorkspacePath.mockReturnValue("")
+
+		const env = Terminal.getEnv()
+		expect(env.WORKSPACE_ROOT).toBe("")
+		expect(mockGetWorkspacePath).toHaveBeenCalledTimes(1)
+	})
+
+	it("should include other required environment variables", () => {
+		mockGetWorkspacePath.mockReturnValue(mockWorkspacePath)
+
+		const env = Terminal.getEnv()
+		expect(env.PAGER).toBeDefined()
+		expect(env.VTE_VERSION).toBe("0")
+		expect(env.WORKSPACE_ROOT).toBe(mockWorkspacePath)
+	})
+})

--- a/src/integrations/terminal/__tests__/TerminalRegistry.test.ts
+++ b/src/integrations/terminal/__tests__/TerminalRegistry.test.ts
@@ -43,6 +43,8 @@ jest.mock("execa", () => ({
 	execa: jest.fn(),
 }))
 
+jest.mock("../../../utils/path", () => ({ getWorkspacePath: jest.fn(() => "/test/workspace") }))
+
 describe("TerminalRegistry", () => {
 	beforeEach(() => {
 		mockCreateTerminal.mockClear()
@@ -68,6 +70,7 @@ describe("TerminalRegistry", () => {
 				env: {
 					PAGER,
 					VTE_VERSION: "0",
+					WORKSPACE_ROOT: "/test/workspace", // kilocode_change
 					PROMPT_EOL_MARK: "",
 				},
 			})
@@ -89,6 +92,7 @@ describe("TerminalRegistry", () => {
 						PAGER,
 						PROMPT_COMMAND: "sleep 0.05",
 						VTE_VERSION: "0",
+						WORKSPACE_ROOT: "/test/workspace", // kilocode_change
 						PROMPT_EOL_MARK: "",
 					},
 				})
@@ -110,6 +114,7 @@ describe("TerminalRegistry", () => {
 					env: {
 						PAGER,
 						VTE_VERSION: "0",
+						WORKSPACE_ROOT: "/test/workspace", // kilocode_change
 						PROMPT_EOL_MARK: "",
 						ITERM_SHELL_INTEGRATION_INSTALLED: "Yes",
 					},
@@ -131,6 +136,7 @@ describe("TerminalRegistry", () => {
 					env: {
 						PAGER,
 						VTE_VERSION: "0",
+						WORKSPACE_ROOT: "/test/workspace", // kilocode_change
 						PROMPT_EOL_MARK: "",
 						POWERLEVEL9K_TERM_SHELL_INTEGRATION: "true",
 					},

--- a/src/integrations/terminal/__tests__/TerminalRegistry.test.ts
+++ b/src/integrations/terminal/__tests__/TerminalRegistry.test.ts
@@ -43,7 +43,7 @@ jest.mock("execa", () => ({
 	execa: jest.fn(),
 }))
 
-jest.mock("../../../utils/path", () => ({ getWorkspacePath: jest.fn(() => "/test/workspace") }))
+jest.mock("../../../utils/path", () => ({ getWorkspacePath: jest.fn(() => "/test/workspace") })) // kilocode_change
 
 describe("TerminalRegistry", () => {
 	beforeEach(() => {


### PR DESCRIPTION
Terminal sessions now include a `$WORKSPACE_ROOT` environment variable pointing to the workspace root. In multi-workspace setups, this points to the folder containing the active file.

This allows the agent to easily navigate to the workspace root from within the terminal using commands like `cd $WORKSPACE_ROOT/webview && npx jest`.
This allows for repeatable running of commands that are relative to the workspace root!

Test plan: Tried it out with my local memory bank and now my agent easily re-runs tests in sub directories!
