### PR TITLE
Show cache read data for non-Google models

### DIFF
--- a/.changeset/full-rabbits-go.md
+++ b/.changeset/full-rabbits-go.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix cache read stats not being shown in the Chat window

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -172,7 +172,11 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 				outputTokens: lastUsage.completion_tokens || 0,
 				// Waiting on OpenRouter to figure out what this represents in the Gemini case
 				// and how to best support it.
-				// cacheReadTokens: lastUsage.prompt_tokens_details?.cached_tokens,
+				// kilocode_change start: show cached tokens for non-Google models
+				cacheReadTokens: modelId.startsWith("google/")
+					? undefined
+					: lastUsage.prompt_tokens_details?.cached_tokens,
+				// kilocode_change end
 				reasoningTokens: lastUsage.completion_tokens_details?.reasoning_tokens,
 				totalCost: (lastUsage.is_byok ? BYOK_COST_MULTIPLIER : 1) * (lastUsage.cost || 0),
 			}


### PR DESCRIPTION
The comment suggests this is OK

Note 1: this change potentially affects this call: https://github.com/Kilo-Org/kilocode/blob/f81f8e28dff559e397371f6a0e43f3c6beb42bb2/src/core/task/Task.ts#L1293

Note 2: I think the comment actually meant Gemini 2.5, for which the check is potentially not necessary, because manual caching is disabled and we don't show the display in that case (but imo this is the safer reasonable effort change).

Numbers seem reasonable for Sonnet:

<img width="540" alt="Screenshot 2025-06-20 at 10 29 52" src="https://github.com/user-attachments/assets/cc780682-52c2-446e-9f5b-9525c4d55340" />

![Screenshot 2025-06-20 at 10 47 43](https://github.com/user-attachments/assets/9c004d38-38a5-4b60-a7c9-47271e3b7e26)

Related: https://github.com/Kilo-Org/kilocode/issues/789