### PR TITLE
chore: add nix command check to .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,4 @@
-use flake
+# Check if nix command is available before trying to use flake
+if command -v nix >/dev/null 2>&1; then
+    use flake
+fi


### PR DESCRIPTION
The .envrc file now checks if the `nix` command is available before attempting to use `use flake`. This prevents errors when `nix` is not installed or not in the PATH

This was causing errors on my system on OSX, but this seems to fix it!