### PR TITLE
fix(webview): Send workflow and rules data immediately on webview load

### DIFF
--- a/.changeset/new-laws-drive.md
+++ b/.changeset/new-laws-drive.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed issue causing workflows and rules not to load immediately when the extension loads

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -69,6 +69,7 @@ export const webviewMessageHandler = async (
 			await refreshWorkflowToggles(provider.context, provider.cwd) // kilocode_change
 
 			provider.postStateToWebview()
+			provider.postRulesDataToWebview() // kilocode_change: send workflows and rules immediately
 			provider.workspaceTracker?.initializeFilePaths() // Don't await.
 
 			getTheme().then((theme) => provider.postMessageToWebview({ type: "theme", text: JSON.stringify(theme) }))


### PR DESCRIPTION
Previously, we'd load the workflows when the webview loaded, but we wouldn't post them to the webview. Now we post them immediately after loading them.

This fixes a bug where the workflows would not be available as slash commands in the ChatView immediately after the extension loads.

![image](https://github.com/user-attachments/assets/be74fde1-0b73-42ba-8ccd-677e21fda771)

Fixes: https://github.com/Kilo-Org/kilocode/issues/815