### PR TITLE
Restore some more telemetry code

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1747,6 +1747,32 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		return true
 	}
 
+	/**
+	 * Returns properties to be included in every telemetry event
+	 * This method is called by the telemetry service to get context information
+	 * like the current mode, API provider, etc.
+	 */
+	public async getTelemetryProperties(): Promise<TelemetryProperties> {
+		const { mode, apiConfiguration, language } = await this.getState()
+		const task = this.getCurrentCline()
+
+		const packageJSON = this.context.extension?.packageJSON
+
+		return {
+			appName: packageJSON?.name ?? Package.name,
+			appVersion: packageJSON?.version ?? Package.version,
+			vscodeVersion: vscode.version,
+			platform: process.platform,
+			editorName: vscode.env.appName,
+			language,
+			mode,
+			apiProvider: apiConfiguration?.apiProvider,
+			modelId: task?.api?.getModel().id,
+			diffStrategy: task?.diffStrategy?.getName(),
+			isSubtask: task ? !!task.parentTask : undefined,
+		}
+	}
+
 	// kilocode_change:
 	// MCP Marketplace
 	private async fetchMcpMarketplaceFromApi(silent: boolean = false): Promise<McpMarketplaceCatalog | undefined> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,7 +111,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	}
 
 	const provider = new ClineProvider(context, outputChannel, "sidebar", contextProxy, codeIndexManager, mdmService)
-	// TelemetryService.instance.setProvider(provider) // kilocode_change no telemetry
+	TelemetryService.instance.setProvider(provider) // kilocode_change no telemetry
 
 	if (codeIndexManager) {
 		context.subscriptions.push(codeIndexManager)

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -7,6 +7,8 @@ import TranslationProvider from "./i18n/TranslationContext"
 // import { MarketplaceViewStateManager } from "./components/marketplace/MarketplaceViewStateManager" // kilocode_change: we have our own marketplace
 
 import { vscode } from "./utils/vscode"
+import { telemetryClient } from "./utils/TelemetryClient"
+import { TelemetryEventName } from "@roo-code/types"
 import { ExtensionStateContextProvider, useExtensionState } from "./context/ExtensionStateContext"
 import ChatView, { ChatViewRef } from "./components/chat/ChatView"
 import HistoryView from "./components/history/HistoryView"
@@ -153,7 +155,7 @@ const App = () => {
 	// Track marketplace tab views
 	useEffect(() => {
 		if (tab === "marketplace") {
-			// telemetryClient.capture(TelemetryEventName.MARKETPLACE_TAB_VIEWED) // kilocode_change commented out
+			telemetryClient.capture(TelemetryEventName.MARKETPLACE_TAB_VIEWED)
 		}
 	}, [tab])
 


### PR DESCRIPTION
The telemetry code should be harmless after: https://github.com/Kilo-Org/kilocode/pull/813

There's more telemetry code we could restore, but we also deleted a bunch without kilocode_change markers, so it's hard to find.