### PR TITLE
Use upstream_inference_cost when calculating OpenRouter cost

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -49,11 +49,12 @@ interface CompletionUsage {
 	total_tokens?: number
 	cost?: number
 	is_byok?: boolean
+	// kilocode_change start
+	cost_details?: {
+		upstream_inference_cost?: number // this seems to be null when !is_byok
+	}
+	// kilocode_change end
 }
-
-// with bring your own key, OpenRouter charges 5% of what it normally would: https://openrouter.ai/docs/use-cases/byok
-// so we multiply the cost reported by OpenRouter to get an estimate of what the request actually cost
-const BYOK_COST_MULTIPLIER = 20
 
 export class OpenRouterHandler extends BaseProvider implements SingleCompletionHandler {
 	protected options: ApiHandlerOptions
@@ -177,7 +178,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 				// and how to best support it.
 				cacheReadTokens: lastUsage.prompt_tokens_details?.cached_tokens, // kilocode_change: uncomment
 				reasoningTokens: lastUsage.completion_tokens_details?.reasoning_tokens,
-				totalCost: (lastUsage.is_byok ? BYOK_COST_MULTIPLIER : 1) * (lastUsage.cost || 0),
+				totalCost: (lastUsage.cost_details?.upstream_inference_cost || 0) + (lastUsage.cost || 0), // kilocode_change +upstream_inference_cost
 			}
 		}
 	}

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -48,10 +48,9 @@ interface CompletionUsage {
 	}
 	total_tokens?: number
 	cost?: number
-	is_byok?: boolean
 	// kilocode_change start
 	cost_details?: {
-		upstream_inference_cost?: number // this seems to be null when !is_byok
+		upstream_inference_cost?: number
 	}
 	// kilocode_change end
 }


### PR DESCRIPTION
https://openrouter.ai/docs/use-cases/usage-accounting#cost-breakdown

# Non-BYOK Gemini 2.5 Pro request

<details>

<summary>Non-BYOK Gemini 2.5 Pro request</summary>

<img width="596" alt="Screenshot 2025-06-24 at 11 56 19" src="https://github.com/user-attachments/assets/e18765af-c4e8-45aa-bd20-df2cebca0c19" />

## AI generated calculation

Total Cost: $0.1366
Cost Breakdown:

Input tokens: $0.0984 (78,700 tokens × $1.25/1M tokens)
Output tokens: $0.0180 (1,800 tokens × $10.00/1M tokens)
Cache reads: $0.0203 (65,400 tokens × $0.31/1M tokens)

Cache Savings:
The implicit caching feature saved you $0.0615 (31.0%):

Cost without caching: $0.1981
Cost with caching: $0.1366

Key Points:

Gemini 2.5 Pro costs $1.25 per million input tokens and $10.00 per million output tokens for prompts ≤ 200k tokens
Context caching is priced at $0.31 per million tokens for prompts ≤ 200k tokens
Cached tokens provide a 75% discount compared to regular input tokens [Gemini 2.5 Models now support implicit caching](https://developers.googleblog.com/en/gemini-2-5-models-now-support-implicit-caching/), which is reflected in the much lower cache pricing ($0.31/1M vs $1.25/1M)
As instructed, I subtracted the 65.4k cache reads from your total input tokens, leaving 78.7k billable input tokens

The caching system automatically recognized that 65.4k of your input tokens matched previous requests and applied the discounted rate, resulting in significant cost savings.

</details>

# BYOK GPT-4.1 request

<details>

<summary>BYOK GPT-4.1 request</summary>

<img width="599" alt="Screenshot 2025-06-24 at 11 58 15" src="https://github.com/user-attachments/assets/b4b76832-e96a-4225-b061-9d5357f87501" />

## AI generated calculation

Token Usage:

Total input tokens: 86,800
Cache read tokens: 42,500
Actual input tokens (after subtracting cache): 44,300
Output tokens: 1,900

Cost Calculation:

Input tokens: 44,300 tokens × $2.00/million = $0.088600 [Livechatai](https://livechatai.com/gpt-4-1-pricing-calculator)[Livechatai](https://livechatai.com/gpt-4-1-mini-pricing-calculator)
Output tokens: 1,900 tokens × $8.00/million = $0.015200 [Livechatai](https://livechatai.com/gpt-4-1-pricing-calculator)[Livechatai](https://livechatai.com/gpt-4-1-mini-pricing-calculator)
Cache reads: 42,500 tokens × $0.50/million = $0.021250 (75% discount) [GPT‑4.1 Pricing Calculator - Compare GPT‑4.1, Mini & Nano](https://livechatai.com/gpt-4-1-pricing-calculator)

Total before OpenRouter tax: $0.125050
With 5% OpenRouter tax: $0.006253
Final cost: $0.131302
The calculation takes advantage of GPT-4.1's enhanced prompt caching discount of 75% (compared to 50% previously) [GPT‑4.1 Pricing Calculator - Compare GPT‑4.1, Mini & Nano](https://livechatai.com/gpt-4-1-pricing-calculator), which significantly reduces the cost of the cache read tokens from the standard input rate.

</details>