### PR TITLE
feat(chat): Highlight context window progress red when near limit

### DIFF
--- a/.changeset/poor-chicken-ring.md
+++ b/.changeset/poor-chicken-ring.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Highlight the context window progress bar red when near the limit

--- a/apps/storybook/stories/ContextWindowProgress.stories.tsx
+++ b/apps/storybook/stories/ContextWindowProgress.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { ContextWindowProgress } from "../../../webview-ui/src/components/chat/ContextWindowProgress"
+
+const meta = {
+	title: "Chat/ContextWindowProgress",
+	component: ContextWindowProgress,
+	parameters: {
+		layout: "padded",
+	},
+	tags: ["autodocs"],
+	argTypes: {
+		contextWindow: {
+			control: { type: "number" },
+			description: "Total context window size in tokens",
+		},
+		contextTokens: {
+			control: { type: "number" },
+			description: "Current tokens used in context",
+		},
+		maxTokens: {
+			control: { type: "number" },
+			description: "Maximum tokens reserved for model output",
+		},
+	},
+} satisfies Meta<typeof ContextWindowProgress>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const UnderLimit: Story = {
+	args: {
+		contextWindow: 128000,
+		contextTokens: 45000, // ~35% usage
+		maxTokens: 4096,
+	},
+}
+
+export const OverLimit: Story = {
+	args: {
+		contextWindow: 128000,
+		contextTokens: 75000, // ~59% usage
+		maxTokens: 4096,
+	},
+}

--- a/apps/storybook/stories/TaskHeader.stories.tsx
+++ b/apps/storybook/stories/TaskHeader.stories.tsx
@@ -37,7 +37,6 @@ export const Default: Story = {
 		onClose: fn(),
 		groupedMessages: createTaskHeaderMessages(),
 		onMessageClick: fn(),
-		currentMessageIndex: 4,
 		isTaskActive: true,
 	},
 }

--- a/webview-ui/src/components/chat/ContextWindowProgress.tsx
+++ b/webview-ui/src/components/chat/ContextWindowProgress.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 
 import { formatLargeNumber } from "@/utils/format"
 import { calculateTokenDistribution } from "@/utils/model-utils"
-import { cn } from "@/lib/utils"
+import { KiloContextWindowProgressTokensUsed } from "../kilocode/chat/KiloContextWindowProgressTokensUsed"
 
 interface ContextWindowProgressProps {
 	contextWindow: number
@@ -26,7 +26,6 @@ export const ContextWindowProgress = ({ contextWindow, contextTokens, maxTokens 
 	// For display purposes
 	const safeContextWindow = Math.max(0, contextWindow)
 	const safeContextTokens = Math.max(0, contextTokens)
-	const highlightNearLimit = currentPercent >= 50 // kilocode_change
 
 	return (
 		<>
@@ -41,15 +40,7 @@ export const ContextWindowProgress = ({ contextWindow, contextTokens, maxTokens 
 					/>
 
 					{/* Main progress bar container */}
-					{/* kilocode_change start - use errorForeground when highlightNearLimit */}
-					<div
-						className={cn(
-							"flex items-center h-1 rounded-[2px] overflow-hidden w-full",
-							"bg-[color-mix(in_srgb,var(--vscode-foreground)_20%,transparent)]",
-							highlightNearLimit &&
-								"bg-[color-mix(in_srgb,var(--vscode-errorForeground)_20%,transparent)]",
-						)}>
-						{/* kilocode_change end */}
+					<div className="flex items-center h-1 rounded-[2px] overflow-hidden w-full bg-[color-mix(in_srgb,var(--vscode-foreground)_20%,transparent)]">
 						{/* Current tokens container */}
 						<div className="relative h-full" style={{ width: `${currentPercent}%` }}>
 							{/* Invisible overlay for current tokens section */}
@@ -62,14 +53,7 @@ export const ContextWindowProgress = ({ contextWindow, contextTokens, maxTokens 
 								data-testid="context-tokens-used"
 							/>
 							{/* Current tokens used - darkest */}
-							{/* kilocode_change start - use errorForeground when highlightNearLimit */}
-							<div
-								className={cn(
-									"h-full w-full bg-[var(--vscode-foreground)] transition-width transition-color duration-300 ease-out",
-									highlightNearLimit && "bg-[var(--vscode-errorForeground)]",
-								)}
-							/>
-							{/* kilocode_change end */}
+							<KiloContextWindowProgressTokensUsed currentPercent={currentPercent} />
 						</div>
 
 						{/* Container for reserved tokens */}

--- a/webview-ui/src/components/chat/ContextWindowProgress.tsx
+++ b/webview-ui/src/components/chat/ContextWindowProgress.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 
 import { formatLargeNumber } from "@/utils/format"
 import { calculateTokenDistribution } from "@/utils/model-utils"
+import { cn } from "@/lib/utils"
 
 interface ContextWindowProgressProps {
 	contextWindow: number
@@ -25,6 +26,7 @@ export const ContextWindowProgress = ({ contextWindow, contextTokens, maxTokens 
 	// For display purposes
 	const safeContextWindow = Math.max(0, contextWindow)
 	const safeContextTokens = Math.max(0, contextTokens)
+	const highlightNearLimit = currentPercent >= 50 // kilocode_change
 
 	return (
 		<>
@@ -39,7 +41,15 @@ export const ContextWindowProgress = ({ contextWindow, contextTokens, maxTokens 
 					/>
 
 					{/* Main progress bar container */}
-					<div className="flex items-center h-1 rounded-[2px] overflow-hidden w-full bg-[color-mix(in_srgb,var(--vscode-foreground)_20%,transparent)]">
+					{/* kilocode_change start - use errorForeground when highlightNearLimit */}
+					<div
+						className={cn(
+							"flex items-center h-1 rounded-[2px] overflow-hidden w-full",
+							"bg-[color-mix(in_srgb,var(--vscode-foreground)_20%,transparent)]",
+							highlightNearLimit &&
+								"bg-[color-mix(in_srgb,var(--vscode-errorForeground)_20%,transparent)]",
+						)}>
+						{/* kilocode_change end */}
 						{/* Current tokens container */}
 						<div className="relative h-full" style={{ width: `${currentPercent}%` }}>
 							{/* Invisible overlay for current tokens section */}
@@ -52,7 +62,14 @@ export const ContextWindowProgress = ({ contextWindow, contextTokens, maxTokens 
 								data-testid="context-tokens-used"
 							/>
 							{/* Current tokens used - darkest */}
-							<div className="h-full w-full bg-[var(--vscode-foreground)] transition-width duration-300 ease-out" />
+							{/* kilocode_change start - use errorForeground when highlightNearLimit */}
+							<div
+								className={cn(
+									"h-full w-full bg-[var(--vscode-foreground)] transition-width transition-color duration-300 ease-out",
+									highlightNearLimit && "bg-[var(--vscode-errorForeground)]",
+								)}
+							/>
+							{/* kilocode_change end */}
 						</div>
 
 						{/* Container for reserved tokens */}

--- a/webview-ui/src/components/kilocode/chat/KiloContextWindowProgressTokensUsed.tsx
+++ b/webview-ui/src/components/kilocode/chat/KiloContextWindowProgressTokensUsed.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+export function KiloContextWindowProgressTokensUsed({ currentPercent }: { currentPercent: number }) {
+	const highlightNearLimit = currentPercent >= 50 // kilocode_change
+	return (
+		<div
+			className={cn(
+				"h-full w-full bg-[var(--vscode-foreground)] transition-width transition-color duration-300 ease-out",
+				highlightNearLimit && "bg-[color-mix(in_srgb,var(--vscode-errorForeground)_60%,rgba(128,0,0,1))]",
+			)}
+		/>
+	)
+}


### PR DESCRIPTION
Introduces visual highlighting for the context window progress bar when token usage exceeds 50%. The progress bar and text will now turn red to indicate high usage, providing a clear visual cue to the user.

Adds Storybook stories for the `ContextWindowProgress` component to demonstrate both under-limit and over-limit states. 

![image](https://github.com/user-attachments/assets/528b653c-c7ba-4a7f-8199-a2ff242662d3)

