### PR TITLE
changeset update: create branch if it does not exist

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -131,7 +131,7 @@ jobs:
                   echo "--------------------------------------------------------------------------------"
                   echo "Pushing to remote..."
                   echo "--------------------------------------------------------------------------------"
-                  git push origin
+                  git push --set-upstream origin HEAD
 
             # Add label to indicate changelog has been formatted
             - name: Add changelog-ready label


### PR DESCRIPTION
fixes #791

I see no reason not to do this, this creates the branch if it isnt there, if it is, it's just a regular push