### PR TITLE
Enable Timeline by default and add preview in the Display Settings

### DIFF
--- a/.changeset/puny-cycles-decide.md
+++ b/.changeset/puny-cycles-decide.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Enable the TaskTimeline by default

--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -44,7 +44,7 @@ const preview: Preview = {
 			},
 		},
 	},
-	decorators: [withQueryClient, withExtensionState, withTheme, withI18n, withChromaticDecorator],
+	decorators: [withI18n, withQueryClient, withExtensionState, withTheme, withChromaticDecorator],
 }
 
 export default preview

--- a/apps/storybook/src/decorators/withI18n.tsx
+++ b/apps/storybook/src/decorators/withI18n.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react"
 import type { Decorator } from "@storybook/react"
 import i18n from "../../../../webview-ui/src/i18n/setup"
 import { loadTranslations } from "../../../../webview-ui/src/i18n/setup"
+import TranslationProvider from "@/i18n/TranslationContext"
 
 /**
  * Storybook decorator that sets up i18n for all stories
@@ -13,5 +14,9 @@ export const withI18n: Decorator = (Story) => {
 		i18n.changeLanguage("en") // English
 	}, [])
 
-	return <Story />
+	return (
+		<TranslationProvider>
+			<Story />
+		</TranslationProvider>
+	)
 }

--- a/apps/storybook/stories/DisplaySettings.stories.tsx
+++ b/apps/storybook/stories/DisplaySettings.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { fn } from "@storybook/test"
+import { DisplaySettings } from "../../../webview-ui/src/components/settings/DisplaySettings"
+
+const meta = {
+	title: "Settings/DisplaySettings",
+	component: DisplaySettings,
+	parameters: {
+		layout: "padded",
+	},
+	tags: ["autodocs"],
+	argTypes: {
+		showTaskTimeline: {
+			control: { type: "boolean" },
+			description: "Whether the task timeline is enabled",
+		},
+	},
+	args: {
+		setCachedStateField: fn(),
+	},
+} satisfies Meta<typeof DisplaySettings>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1506,7 +1506,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			machineId,
 			showRooIgnoredFiles: showRooIgnoredFiles ?? true,
 			showAutoApproveMenu: showAutoApproveMenu ?? false, // kilocode_change
-			showTaskTimeline: showTaskTimeline ?? false, // kilocode_change
+			showTaskTimeline: showTaskTimeline ?? true, // kilocode_change
 			language, // kilocode_change
 			renderContext: this.renderContext,
 			maxReadFileLine: maxReadFileLine ?? -1,
@@ -1663,7 +1663,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			browserToolEnabled: stateValues.browserToolEnabled ?? true,
 			showRooIgnoredFiles: stateValues.showRooIgnoredFiles ?? true,
 			showAutoApproveMenu: stateValues.showAutoApproveMenu ?? false, // kilocode_change
-			showTaskTimeline: stateValues.showTaskTimeline ?? false, // kilocode_change
+			showTaskTimeline: stateValues.showTaskTimeline ?? true, // kilocode_change
 			maxReadFileLine: stateValues.maxReadFileLine ?? -1,
 			maxConcurrentFileReads: stateValues.maxConcurrentFileReads ?? 5,
 			historyPreviewCollapsed: stateValues.historyPreviewCollapsed ?? false,

--- a/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -11,7 +11,7 @@ import { TooltipProvider } from "../ui/tooltip"
 // We hide the scrollbars for the TaskTimeline by wrapping it in a container with
 // overflow hidden. This hides the scrollbars for the actual Virtuoso element
 // by clipping them out view. This just needs to be greater than the webview scrollbar width.
-const SCROLLBAR_WIDTH_PX = 15
+const SCROLLBAR_WIDTH_PX = 25
 
 interface TaskTimelineProps {
 	groupedMessages: (ClineMessage | ClineMessage[])[]

--- a/webview-ui/src/components/settings/DisplaySettings.tsx
+++ b/webview-ui/src/components/settings/DisplaySettings.tsx
@@ -6,6 +6,8 @@ import { Monitor } from "lucide-react"
 import { SetCachedStateField } from "./types"
 import { SectionHeader } from "./SectionHeader"
 import { Section } from "./Section"
+import { TaskTimeline } from "../chat/TaskTimeline"
+import { generateSampleTimelineData } from "../../utils/timeline/mockData"
 
 type DisplaySettingsProps = HTMLAttributes<HTMLDivElement> & {
 	showTaskTimeline?: boolean
@@ -14,6 +16,8 @@ type DisplaySettingsProps = HTMLAttributes<HTMLDivElement> & {
 
 export const DisplaySettings = ({ showTaskTimeline, setCachedStateField, ...props }: DisplaySettingsProps) => {
 	const { t } = useAppTranslation()
+
+	const sampleTimelineData = generateSampleTimelineData()
 
 	return (
 		<div {...props}>
@@ -35,6 +39,14 @@ export const DisplaySettings = ({ showTaskTimeline, setCachedStateField, ...prop
 					</VSCodeCheckbox>
 					<div className="text-vscode-descriptionForeground text-sm mt-1">
 						{t("settings:display.taskTimeline.description")}
+					</div>
+
+					{/* Sample TaskTimeline preview */}
+					<div className="mt-3">
+						<div className="font-medium text-vscode-foreground text-xs mb-4 font-medium">Preview</div>
+						<div className="opacity-60">
+							<TaskTimeline groupedMessages={sampleTimelineData} isTaskActive={false} />
+						</div>
 					</div>
 				</div>
 			</Section>

--- a/webview-ui/src/utils/timeline/mockData.ts
+++ b/webview-ui/src/utils/timeline/mockData.ts
@@ -1,0 +1,62 @@
+import type { ClineMessage } from "@roo-code/types"
+
+// Fixed base timestamp for consistent snapshots (January 1, 2024, 12:00:00 UTC)
+const BASE_TIMESTAMP = 1704110400000
+
+export function generateSampleTimelineData(): ClineMessage[] {
+	const messages: ClineMessage[] = []
+
+	const messageTemplates = [
+		{
+			type: "ask",
+			ask: "command",
+			texts: ["Create a React component", "Build a todo app", "Fix the login bug", "Add dark mode support"],
+		},
+		{
+			type: "say",
+			say: "text",
+			texts: [
+				"I'll help you with that",
+				"Let me analyze the requirements",
+				"I'll start by examining the code",
+				"Let me understand the current setup",
+			],
+		},
+		{
+			type: "ask",
+			ask: "tool",
+			texts: [
+				JSON.stringify({ tool: "read_file", path: "src/App.tsx" }),
+				JSON.stringify({ tool: "list_files", path: "src/components" }),
+				JSON.stringify({ tool: "search_files", query: "useState" }),
+				JSON.stringify({ tool: "read_file", path: "package.json" }),
+			],
+		},
+		{
+			type: "say",
+			say: "command_output",
+			texts: ["File created successfully", "Changes applied", "Build completed", "Tests passed"],
+		},
+		{ type: "say", say: "checkpoint_saved", texts: ["Checkpoint saved", "Progress saved", "State preserved"] },
+		{
+			type: "say",
+			say: "completion_result",
+			texts: ["Task completed successfully!", "All done!", "Implementation finished", "Ready to use"],
+		},
+	]
+
+	for (let cycle = 0; cycle < 8; cycle++) {
+		messageTemplates.forEach((template, i) => {
+			const randomText = template.texts[Math.floor(Math.random() * template.texts.length)]
+			messages.push({
+				ts: BASE_TIMESTAMP + (cycle * 8 + i) * (1000 + Math.random() * 3000),
+				type: template.type as "ask" | "say",
+				...(template.ask && { ask: template.ask as any }),
+				...(template.say && { say: template.say as any }),
+				text: randomText,
+			})
+		})
+	}
+
+	return messages
+}


### PR DESCRIPTION
The `showTaskTimeline` flag is now set to `true` by default in both the initial state and the state restoration logic within `ClineProvider`. This change makes the task timeline feature visible and active for all users without requiring explicit configuration.

Also properly setup the i18n for Storybook - it wasn't quite working right before

![image](https://github.com/user-attachments/assets/d100ab69-4d0a-4d6a-8b45-c7c6b148a6e7)
