### PR TITLE
Add a vscode task to watch and automatically run pnpm install

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
 	"tasks": [
 		{
 			"label": "watch",
-			"dependsOn": ["watch:webview", "watch:bundle", "watch:tsc"],
+			"dependsOn": ["watch:pnpm", "watch:webview", "watch:bundle", "watch:tsc"],
 			"presentation": {
 				"reveal": "never"
 			},
@@ -18,15 +18,34 @@
 			}
 		},
 		{
+			"label": "watch:pnpm",
+			"type": "shell",
+			"command": "npx",
+			"args": ["nodemon", "--watch", "pnpm-lock.yaml", "--exec", "pnpm install"],
+			"group": "build",
+			"isBackground": true,
+			"presentation": {
+				"group": "watch",
+				"reveal": "always"
+			},
+			"problemMatcher": {
+				"pattern": { "regexp": "^$" },
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": "\\[nodemon\\] starting",
+					"endsPattern": "\\[nodemon\\] clean exit - waiting for changes before restart"
+				}
+			}
+		},
+		{
 			"label": "watch:webview",
+			"dependsOn": ["watch:pnpm"],
 			"type": "shell",
 			"command": "pnpm --filter @roo-code/vscode-webview dev",
 			"group": "build",
 			"problemMatcher": {
 				"owner": "vite",
-				"pattern": {
-					"regexp": "^$"
-				},
+				"pattern": { "regexp": "^$" },
 				"background": {
 					"activeOnStart": true,
 					"beginsPattern": ".*VITE.*",
@@ -41,6 +60,7 @@
 		},
 		{
 			"label": "watch:bundle",
+			"dependsOn": ["watch:pnpm"],
 			"type": "shell",
 			"command": "npx turbo watch:bundle",
 			"group": "build",
@@ -63,6 +83,7 @@
 		},
 		{
 			"label": "watch:tsc",
+			"dependsOn": ["watch:pnpm"],
 			"type": "shell",
 			"command": "npx turbo watch:tsc",
 			"group": "build",


### PR DESCRIPTION
We currently have three watch tasks that auto run when vs code launches. The problem is if the packages changes, some of these tasks will start to silently fail. Now, we've added a new `pnpm:watch` task that will watch the pnpm-lockfile for changes and auto run `pnpm i` when it changes. The other tasks now depend on the `pnpm` task now.

Hopefully this will make switching branches easier without having to manually mess with the tasks.

![image](https://github.com/user-attachments/assets/be522d31-f196-45fc-ae18-3fd64e544ace)
