### PR TITLE
feat(vscode): add isolated extension launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,26 @@
 				"group": "tasks",
 				"order": 1
 			}
+		},
+		{
+			"name": "Run Extension [Isolated]",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}/src",
+				"--disable-extensions",
+				"${workspaceFolder}/launch"
+			],
+			"sourceMaps": true,
+			"outFiles": ["${workspaceFolder}/dist/**/*.js"],
+			"preLaunchTask": "${defaultBuildTask}",
+			"env": {
+				"NODE_ENV": "development",
+				"VSCODE_DEBUG_MODE": "true"
+			},
+			"resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
+			"presentation": { "hidden": false, "group": "tasks", "order": 1 }
 		}
 	]
 }

--- a/launch/README.md
+++ b/launch/README.md
@@ -1,0 +1,3 @@
+# Isolated Launch Root
+
+This file will exist when you run the extension using the [Run Extension [Isolated]](../.vscode/launch.json) run configuration in [launch.json]](../.vscode/launch.json).


### PR DESCRIPTION
Adds a new launch configuration "Run Extension [Isolated]" to `.vscode/launch.json`. This allows running the VS Code extension in an isolated environment, disabling other extensions and pointing to a specific launch root.

I find myself changing this in a lot of my branches and then having to revert it so I thought it might be nice to make it an official configuration in case others want to use it!

A `launch/README.md` file is also added to serve as a placeholder for the isolated launch root.

![image](https://github.com/user-attachments/assets/d99a02aa-d614-4564-80cb-efab0ec8bc8f)
