### PR TITLE
Only show the colorful gutter bars when hovering over the TaskTimeline

### DIFF
--- a/.changeset/angry-beans-warn.md
+++ b/.changeset/angry-beans-warn.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Only show the colorful gutter bars when hovering over the Task Timeline

--- a/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -7,6 +7,7 @@ import { consolidateMessagesForTimeline } from "../../utils/timeline/consolidate
 import { calculateTaskTimelineSizes } from "../../utils/timeline/calculateTaskTimelineSizes"
 import { getTaskTimelineMessageColor } from "../../utils/messageColors"
 import { TooltipProvider } from "../ui/tooltip"
+import { useExtensionState } from "../../context/ExtensionStateContext"
 
 // We hide the scrollbars for the TaskTimeline by wrapping it in a container with
 // overflow hidden. This hides the scrollbars for the actual Virtuoso element
@@ -20,8 +21,17 @@ interface TaskTimelineProps {
 }
 
 export const TaskTimeline = memo<TaskTimelineProps>(({ groupedMessages, onMessageClick, isTaskActive = false }) => {
+	const { setHoveringTaskTimeline } = useExtensionState()
 	const virtuosoRef = useRef<VirtuosoHandle>(null)
 	const previousGroupedLengthRef = useRef(groupedMessages.length)
+
+	const handleMouseEnter = useCallback(() => {
+		setHoveringTaskTimeline(true)
+	}, [setHoveringTaskTimeline])
+
+	const handleMouseLeave = useCallback(() => {
+		setHoveringTaskTimeline(false)
+	}, [setHoveringTaskTimeline])
 
 	const timelineMessagesData = useMemo(() => {
 		const { processedMessages, messageToOriginalIndex } = consolidateMessagesForTimeline(groupedMessages)
@@ -72,7 +82,11 @@ export const TaskTimeline = memo<TaskTimelineProps>(({ groupedMessages, onMessag
 
 	return (
 		<TooltipProvider>
-			<div className="w-full px-2 overflow-hidden" style={{ height: `${TASK_TIMELINE_MAX_HEIGHT_PX}px` }}>
+			<div
+				className="w-full px-2 overflow-hidden"
+				style={{ height: `${TASK_TIMELINE_MAX_HEIGHT_PX}px` }}
+				onMouseEnter={handleMouseEnter}
+				onMouseLeave={handleMouseLeave}>
 				<Virtuoso
 					ref={virtuosoRef}
 					data={timelineMessagesData}

--- a/webview-ui/src/components/kilocode/chat/KiloChatRowGutterBar.tsx
+++ b/webview-ui/src/components/kilocode/chat/KiloChatRowGutterBar.tsx
@@ -9,7 +9,7 @@ export function KiloChatRowGutterBar({ message }: { message: ClineMessage }) {
 	return (
 		<div
 			className={cn(
-				"absolute left-0 top-0 bottom-0 w-0.5 opacity-0 transition-opacity",
+				"absolute w-[4px] left-[4px] top-0 bottom-0  opacity-0 transition-opacity",
 				getTaskTimelineMessageColor(message),
 				hoveringTaskTimeline && "opacity-70",
 			)}

--- a/webview-ui/src/components/kilocode/chat/KiloChatRowGutterBar.tsx
+++ b/webview-ui/src/components/kilocode/chat/KiloChatRowGutterBar.tsx
@@ -1,9 +1,18 @@
+import { useExtensionState } from "@/context/ExtensionStateContext"
 import { cn } from "@/lib/utils"
 import { getTaskTimelineMessageColor } from "@/utils/messageColors"
 import type { ClineMessage } from "@roo-code/types"
 
 export function KiloChatRowGutterBar({ message }: { message: ClineMessage }) {
+	const { hoveringTaskTimeline } = useExtensionState()
+
 	return (
-		<div className={cn("absolute left-0 top-0 bottom-0 w-0.5 opacity-70", getTaskTimelineMessageColor(message))} />
+		<div
+			className={cn(
+				"absolute left-0 top-0 bottom-0 w-0.5 opacity-0 transition-opacity",
+				getTaskTimelineMessageColor(message),
+				hoveringTaskTimeline && "opacity-70",
+			)}
+		/>
 	)
 }

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -27,6 +27,9 @@ import { ClineRulesToggles } from "@roo/cline-rules" // kilocode_change
 export interface ExtensionStateContextType extends ExtensionState {
 	historyPreviewCollapsed?: boolean // Add the new state property
 	showTaskTimeline?: boolean // kilocode_change
+	setShowTaskTimeline: (value: boolean) => void // kilocode_change
+	hoveringTaskTimeline?: boolean // kilocode_change
+	setHoveringTaskTimeline: (value: boolean) => void // kilocode_change
 	didHydrateState: boolean
 	showWelcome: boolean
 	theme: any
@@ -129,7 +132,6 @@ export interface ExtensionStateContextType extends ExtensionState {
 	terminalCompressProgressBar?: boolean
 	setTerminalCompressProgressBar: (value: boolean) => void
 	setHistoryPreviewCollapsed: (value: boolean) => void
-	setShowTaskTimeline: (value: boolean) => void // kilocode_change
 	autoCondenseContext: boolean
 	setAutoCondenseContext: (value: boolean) => void
 	autoCondenseContextPercent: number
@@ -477,6 +479,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setHistoryPreviewCollapsed: (value) =>
 			setState((prevState) => ({ ...prevState, historyPreviewCollapsed: value })),
 		setShowTaskTimeline: (value) => setState((prevState) => ({ ...prevState, showTaskTimeline: value })), // kilocode_change
+		setHoveringTaskTimeline: (value) => setState((prevState) => ({ ...prevState, hoveringTaskTimeline: value })),
 
 		setAutoCondenseContext: (value) => setState((prevState) => ({ ...prevState, autoCondenseContext: value })),
 		setAutoCondenseContextPercent: (value) =>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -447,6 +447,9 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		// kilocode_change start
 		setCommitMessageApiConfigId: (value) =>
 			setState((prevState) => ({ ...prevState, commitMessageApiConfigId: value })),
+		setShowAutoApproveMenu: (value) => setState((prevState) => ({ ...prevState, showAutoApproveMenu: value })),
+		setShowTaskTimeline: (value) => setState((prevState) => ({ ...prevState, showTaskTimeline: value })),
+		setHoveringTaskTimeline: (value) => setState((prevState) => ({ ...prevState, hoveringTaskTimeline: value })),
 		// kilocode_change end
 		setAutoApprovalEnabled: (value) => setState((prevState) => ({ ...prevState, autoApprovalEnabled: value })),
 		setCustomModes: (value) => setState((prevState) => ({ ...prevState, customModes: value })),
@@ -454,7 +457,6 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setMaxWorkspaceFiles: (value) => setState((prevState) => ({ ...prevState, maxWorkspaceFiles: value })),
 		setBrowserToolEnabled: (value) => setState((prevState) => ({ ...prevState, browserToolEnabled: value })),
 		setShowRooIgnoredFiles: (value) => setState((prevState) => ({ ...prevState, showRooIgnoredFiles: value })),
-		setShowAutoApproveMenu: (value) => setState((prevState) => ({ ...prevState, showAutoApproveMenu: value })), // kilocode_Change
 		setRemoteBrowserEnabled: (value) => setState((prevState) => ({ ...prevState, remoteBrowserEnabled: value })),
 		setAwsUsePromptCache: (value) => setState((prevState) => ({ ...prevState, awsUsePromptCache: value })),
 		setMaxReadFileLine: (value) => setState((prevState) => ({ ...prevState, maxReadFileLine: value })),
@@ -478,8 +480,6 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 			}),
 		setHistoryPreviewCollapsed: (value) =>
 			setState((prevState) => ({ ...prevState, historyPreviewCollapsed: value })),
-		setShowTaskTimeline: (value) => setState((prevState) => ({ ...prevState, showTaskTimeline: value })), // kilocode_change
-		setHoveringTaskTimeline: (value) => setState((prevState) => ({ ...prevState, hoveringTaskTimeline: value })),
 
 		setAutoCondenseContext: (value) => setState((prevState) => ({ ...prevState, autoCondenseContext: value })),
 		setAutoCondenseContextPercent: (value) =>

--- a/webview-ui/src/utils/messageColors.ts
+++ b/webview-ui/src/utils/messageColors.ts
@@ -14,6 +14,7 @@ export const taskTimelineColorPalette = {
 	SUCCESS: "bg-[var(--vscode-editorGutter-addedBackground)]", // Green for success
 	ERROR: "bg-[var(--vscode-errorForeground)]", // Red for errors
 	ASSISTANT_MUTTERING: "bg-[var(--vscode-descriptionForeground)]", // Gray for reasoning/text
+	ASSISTANT_QUESTION: "bg-[color-mix(in_srgb,var(--vscode-editor-findMatchBackground)_60%,var(--vscode-foreground))]", // Yellowish/tan
 	GROUPED: "bg-[var(--vscode-textLink-activeForeground)]", // Cyan for grouped messages
 	DEFAULT: "bg-[var(--vscode-badge-background)]", // Fallback gray
 }
@@ -46,7 +47,7 @@ export const TASK_TIMELINE_MESSAGE_TYPES: Record<string, TaskTimelineMessageType
 		translationKey: "kilocode:taskTimeline.tooltip.messageTypes.command",
 	},
 	"ask:followup": {
-		color: taskTimelineColorPalette.USER_INTERACTION,
+		color: taskTimelineColorPalette.ASSISTANT_QUESTION,
 		translationKey: "kilocode:taskTimeline.tooltip.messageTypes.followup",
 	},
 


### PR DESCRIPTION
Following @Juice10's feedback–

Introduces a new `hoveringTaskTimeline` state in the `ExtensionStateContext` to track when the user is hovering over the TaskTimeline component.

The `TaskTimeline` component now updates this state on `mouseenter` and `mouseleave` events. The `KiloChatRowGutterBar` component uses this state to dynamically adjust its opacity, making the gutter bars more visible when the timeline is hovered. This improves the user experience by providing visual feedback and highlighting the associated messages.

![2025-06-26 13 47 25](https://github.com/user-attachments/assets/ad3227dd-6cf5-4021-b5c2-11aa4b89485d)

Also make the "question" color a tan/yellow instead of orange
![image](https://github.com/user-attachments/assets/75bd78c6-5e4f-4001-ac71-f6a2d2d8d1cb)

