### PR TITLE
Enable browser use for all browsers that support images

### DIFF
--- a/.changeset/legal-wasps-shine.md
+++ b/.changeset/legal-wasps-shine.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Enable browser tool for Gemini, GPT and all other models that can read images

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1709,7 +1709,8 @@ export class Task extends EventEmitter<ClineEvents> {
 			return SYSTEM_PROMPT(
 				provider.context,
 				this.cwd,
-				(this.api.getModel().info.supportsComputerUse ?? false) && (browserToolEnabled ?? true),
+				// kilocode_change: supports images => supports browser, frontrunning on https://github.com/RooCodeInc/Roo-Code/pull/5026
+				(this.api.getModel().info.supportsImages ?? false) && (browserToolEnabled ?? true),
 				mcpHub,
 				this.diffStrategy,
 				browserViewportSize,

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1709,7 +1709,7 @@ export class Task extends EventEmitter<ClineEvents> {
 			return SYSTEM_PROMPT(
 				provider.context,
 				this.cwd,
-				// kilocode_change: supports images => supports browser, frontrunning on https://github.com/RooCodeInc/Roo-Code/pull/5026
+				// kilocode_change: supports images => supports browser, front-running on https://github.com/RooCodeInc/Roo-Code/pull/5026
 				(this.api.getModel().info.supportsImages ?? false) && (browserToolEnabled ?? true),
 				mcpHub,
 				this.diffStrategy,


### PR DESCRIPTION
https://github.com/RooCodeInc/Roo-Code/pull/5026 does this more thoroughly,
but limits browser use to Claude and Gemini for some reason.

From my testing it additionally also works with GPT-4.1, Mistral Medium 3 and Qwen 2.5 VL

<img width="423" alt="Screenshot 2025-06-29 at 15 58 18" src="https://github.com/user-attachments/assets/73b6242d-467e-41f4-b3ce-d12d59f25762" />
