### PR TITLE
show error when a task could not be read, and mark it red

### DIFF
--- a/.changeset/silly-dots-follow.md
+++ b/.changeset/silly-dots-follow.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add debugging info for when we cannot read a task file

--- a/packages/types/src/history.ts
+++ b/packages/types/src/history.ts
@@ -17,6 +17,7 @@ export const historyItemSchema = z.object({
 	size: z.number().optional(),
 	workspace: z.string().optional(),
 	isFavorited: z.boolean().optional(), // kilocode_change
+	fileNotfound: z.boolean().optional(), // kilocode_change
 })
 
 export type HistoryItem = z.infer<typeof historyItemSchema>

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1168,12 +1168,19 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 					uiMessagesFilePath,
 					apiConversationHistory,
 				}
+			} else {
+				vscode.window.showErrorMessage(
+					`Task file not found for task ID: ${id} (file ${apiConversationHistoryFilePath})`,
+				) //kilocode_change show extra debugging information to debug task not found issues
 			}
+		} else {
+			vscode.window.showErrorMessage(`Task with ID: ${id} not found in history.`) // kilocode_change show extra debugging information to debug task not found issues
 		}
 
 		// if we tried to get a task that doesn't exist, remove it from state
 		// FIXME: this seems to happen sometimes when the json file doesnt save to disk for some reason
-		await this.deleteTaskFromState(id)
+		// await this.deleteTaskFromState(id) // kilocode_change disable confusing behaviour
+		await this.setTaskFileNotFound(id) // kilocode_change
 		throw new Error("Task not found")
 	}
 
@@ -2071,5 +2078,18 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			await this.deleteTaskWithId(id)
 		}
 	}
+
+	async setTaskFileNotFound(id: string) {
+		const history = this.getGlobalState("taskHistory") ?? []
+		const updatedHistory = history.map((item) => {
+			if (item.id === id) {
+				return { ...item, fileNotfound: true }
+			}
+			return item
+		})
+		await this.updateGlobalState("taskHistory", updatedHistory)
+		await this.postStateToWebview()
+	}
+
 	// kilocode_change end
 }

--- a/webview-ui/src/components/history/TaskItem.tsx
+++ b/webview-ui/src/components/history/TaskItem.tsx
@@ -48,7 +48,11 @@ const TaskItem = ({
 			key={item.id}
 			data-testid={`task-item-${item.id}`}
 			className={cn(
-				"cursor-pointer group bg-vscode-editor-background rounded relative overflow-hidden hover:border-vscode-toolbar-hoverBackground/60",
+				"cursor-pointer group rounded relative overflow-hidden hover:border-vscode-toolbar-hoverBackground/60",
+				{
+					"bg-red-900 text-white": item.fileNotfound, // kilocode_change added this state instead of removing
+					"bg-vscode-editor-background": !item.fileNotfound, //kilocode_change this is the default normally in the regular classname list
+				},
 				className,
 			)}
 			onClick={handleClick}>


### PR DESCRIPTION
instead of removing it.

At first I showed only the error, but that way it seems like you can click on it, but nothing happens ( https://www.youtube.com/watch?v=oD7QIZ7zFA0 ), as the error is quite far away from where you click, so also made the whole thing red:

![image](https://github.com/user-attachments/assets/aa9c6d17-4156-4b39-895b-bf9b8b2d95fe)

TBC: this is persisted, but it doesn't actually change operation. If we find the cause we can remove this whole thing again imho
