### PR TITLE
Fix checkpoints do not always include a revert option

### DIFF
--- a/.changeset/strong-chairs-bow.md
+++ b/.changeset/strong-chairs-bow.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix checkpoints do not always include a revert option

--- a/webview-ui/src/components/chat/checkpoints/CheckpointSaved.tsx
+++ b/webview-ui/src/components/chat/checkpoints/CheckpointSaved.tsx
@@ -26,7 +26,12 @@ export const CheckpointSaved = ({ checkpoint, ...props }: CheckpointSavedProps) 
 			return undefined
 		}
 
-		return result.data
+		// kilocode_change start
+		return {
+			...result.data,
+			isFirst: result.data.from === result.data.to,
+		}
+		// kilocode_change end
 	}, [checkpoint])
 
 	if (!metadata) {

--- a/webview-ui/src/components/chat/checkpoints/CheckpointSaved.tsx
+++ b/webview-ui/src/components/chat/checkpoints/CheckpointSaved.tsx
@@ -27,6 +27,8 @@ export const CheckpointSaved = ({ checkpoint, ...props }: CheckpointSavedProps) 
 		}
 
 		// kilocode_change start
+		// ifFirst is misscalculated by the ShadowCheckpointService because use the lenght of the array of the checkpoint
+		// insead of the from-to attributes and need to be removed from the checkpointShema and calculated on the frontend
 		return {
 			...result.data,
 			isFirst: result.data.from === result.data.to,

--- a/webview-ui/src/components/chat/checkpoints/CheckpointSaved.tsx
+++ b/webview-ui/src/components/chat/checkpoints/CheckpointSaved.tsx
@@ -27,8 +27,9 @@ export const CheckpointSaved = ({ checkpoint, ...props }: CheckpointSavedProps) 
 		}
 
 		// kilocode_change start
-		// ifFirst is misscalculated by the ShadowCheckpointService because use the length of the array of the checkpoint
-		// insead of the from-to attributes and need to be removed from the checkpointShema and calculated on the frontend
+		// ifFirst is misscalculated by the ShadowCheckpointService because use the length of the array of checkpoints
+		// insead of the from-to attributes.
+		// ifFirst need to be removed from the checkpointShema and the core pkg and move the logic to the frontend
 		return {
 			...result.data,
 			isFirst: result.data.from === result.data.to,

--- a/webview-ui/src/components/chat/checkpoints/CheckpointSaved.tsx
+++ b/webview-ui/src/components/chat/checkpoints/CheckpointSaved.tsx
@@ -27,7 +27,7 @@ export const CheckpointSaved = ({ checkpoint, ...props }: CheckpointSavedProps) 
 		}
 
 		// kilocode_change start
-		// ifFirst is misscalculated by the ShadowCheckpointService because use the lenght of the array of the checkpoint
+		// ifFirst is misscalculated by the ShadowCheckpointService because use the length of the array of the checkpoint
 		// insead of the from-to attributes and need to be removed from the checkpointShema and calculated on the frontend
 		return {
 			...result.data,


### PR DESCRIPTION
## Context

Resolve #366 

The shadow git it's computing the isFirst in base of the current checkpoint array, this produce some side effect that happen when you modify the git history stoping and re inti the cline task.
This value it's only used on the frontend so I made this simple fix to don't involve a refactor on the core making the fix retro compatible.
The final fix should remove the `isFirst` attribute on all checkpoint types and use this logic on the frontend to get that.

## Implementation

This PR ensures the isFirst flag is always present on checkpoint data (for backwards compatibility) by computing it on the frontend based on from and to values, restoring the revert option for legacy checkpoints.

- Replaces direct result.data return with an object that spreads result.data and adds isFirst
- Computes isFirst as result.data.from === result.data.to
- Includes temporary kilocode_change comment markers around the new logic

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/40429076-ef23-4c55-b398-d818335c11a3)

### After
![image](https://github.com/user-attachments/assets/a5ee0774-23e1-4a72-b287-ca23ba8fd875)

## How to Test

- You need modify the git history restoring the task to any point and continue making prompts to made checkpoints
