### PR TITLE
Support project id set in env.GOOGLE_CLOUD_PROJECT for Gemini CLI

### DIFF
--- a/.changeset/red-seals-jog.md
+++ b/.changeset/red-seals-jog.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add support for project id set in env.GOOGLE_CLOUD_PROJECT for Gemini CLI (thanks @kamilchm!)

--- a/src/api/providers/gemini-cli.ts
+++ b/src/api/providers/gemini-cli.ts
@@ -139,8 +139,9 @@ export class GeminiCliHandler extends BaseProvider implements SingleCompletionHa
 			return this.projectId
 		}
 
-		// Start with a default project ID (can be anything for personal OAuth)
-		const initialProjectId = "default"
+		// Lookup for the project id from the env variable
+		// with a fallback to a default project ID (can be anything for personal OAuth)
+		const initialProjectId = process.env.GOOGLE_CLOUD_PROJECT ?? "default"
 
 		// Prepare client metadata
 		const clientMetadata = {


### PR DESCRIPTION
This is needed for using Code Assist subscription.
 
See https://github.com/cline/cline/issues/4526