### PR TITLE
Hardcode the chromatic token in chromatic.yml

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -48,8 +48,7 @@ jobs:
               id: chromatic
               uses: chromaui/action@latest
               with:
-                  # Project token is now public in package.json for open source contributions
-                  projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+                  projectToken: chpt_f6ec377cea9b457
                   storybookBaseDir: apps/storybook/
                   storybookBuildDir: apps/storybook/storybook-static
                   onlyChanged: true


### PR DESCRIPTION
Our chromatic token is already public, so let's just hardcode it in our chromatic workflow so the chromatic setup doesn't fail for non-kilo users.

Should prevent broken builds like this one:
https://github.com/Kilo-Org/kilocode/actions/runs/16034137521/job/45241813825?pr=947