### PR TITLE
Fix model search being prefilled in dropdown to prevent confusion

### DIFF
--- a/.changeset/olive-months-smell.md
+++ b/.changeset/olive-months-smell.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix model search being prefilled in dropdown to prevent confusion in available models

--- a/webview-ui/src/components/settings/ModelPicker.tsx
+++ b/webview-ui/src/components/settings/ModelPicker.tsx
@@ -103,7 +103,7 @@ export const ModelPicker = ({
 
 	const { id: selectedModelId, info: selectedModelInfo } = useSelectedModel(apiConfiguration)
 
-	const [searchValue, setSearchValue] = useState(selectedModelId || "")
+	const [searchValue, setSearchValue] = useState("") // kilocode_change
 
 	const onSelect = useCallback(
 		(modelId: string) => {
@@ -120,7 +120,7 @@ export const ModelPicker = ({
 			}
 
 			// Delay to ensure the popover is closed before setting the search value.
-			selectTimeoutRef.current = setTimeout(() => setSearchValue(modelId), 100)
+			selectTimeoutRef.current = setTimeout(() => setSearchValue(""), 100) // kilocode_change: reset value on select
 		},
 		[modelIdKey, setApiConfigurationField],
 	)
@@ -136,11 +136,11 @@ export const ModelPicker = ({
 					clearTimeout(closeTimeoutRef.current)
 				}
 
-				// Delay to ensure the popover is closed before setting the search value.
-				closeTimeoutRef.current = setTimeout(() => setSearchValue(selectedModelId), 100)
+				// Clear the search value when closing instead of prefilling it
+				closeTimeoutRef.current = setTimeout(() => setSearchValue(""), 100) // kilocode_change: reset value on select
 			}
 		},
-		[selectedModelId],
+		[] /* kilocode_change */,
 	)
 
 	const onClearSearch = useCallback(() => {


### PR DESCRIPTION
This prevents the search from openeing like this:
<img width="373" alt="image" src="https://github.com/user-attachments/assets/40c9a1fa-88c8-46bd-8ca9-83e7cdbf5420" />

and makes it open like this, which is much more logical and less confusing:
<img width="412" alt="image" src="https://github.com/user-attachments/assets/5dca451c-321e-4b1f-81c8-bbb682361d6d" />

Will upstream this as well 

Resolves
- #1066