### PR TITLE
Fix edit project MCP button not opening file

### DIFF
--- a/.changeset/public-planes-refuse.md
+++ b/.changeset/public-planes-refuse.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix project mcp settings button not opening file

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -632,6 +632,8 @@ export const webviewMessageHandler = async (
 				if (!exists) {
 					await safeWriteJson(mcpPath, { mcpServers: {} })
 				}
+
+				openFile(mcpPath) // kilocode_change
 			} catch (error) {
 				vscode.window.showErrorMessage(t("mcp:errors.create_json", { error: `${error}` }))
 			}

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -633,7 +633,7 @@ export const webviewMessageHandler = async (
 					await safeWriteJson(mcpPath, { mcpServers: {} })
 				}
 
-				openFile(mcpPath) // kilocode_change
+				openFile(mcpPath)
 			} catch (error) {
 				vscode.window.showErrorMessage(t("mcp:errors.create_json", { error: `${error}` }))
 			}


### PR DESCRIPTION
## Context

Fixes the `Edit Project MCP` button not opening the file.

Fixes #944 

## Implementation

Add script to actually open the file after checking if the file exists.

## How to Test

- Open a project
- Go to the KiloCode extension -> Settings -> MCP Servers -> Installed
- Click on the `Edit Project MCP` button
- Either opens the existing settings or creates a new file

