### PR TITLE
Make MCP server toggles easier accessible with button in the top bar

### DIFF
--- a/.changeset/tough-kiwis-tease.md
+++ b/.changeset/tough-kiwis-tease.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Make MCP server toggles easier accessible with button in the top bar

--- a/src/package.json
+++ b/src/package.json
@@ -321,7 +321,7 @@
 					"when": "view == kilo-code.SidebarProvider"
 				},
 				{
-					"command": "kilo-code.promptsButtonClicked",
+					"command": "kilo-code.mcpButtonClicked",
 					"group": "navigation@2",
 					"when": "view == kilo-code.SidebarProvider"
 				},
@@ -347,7 +347,7 @@
 				},
 				{
 					"command": "kilo-code.helpButtonClicked",
-					"group": "navigation@7",
+					"group": "navigation@8",
 					"when": "false && view == kilo-code.SidebarProvider"
 				}
 			],
@@ -358,7 +358,7 @@
 					"when": "activeWebviewPanelId == kilo-code.TabPanelProvider"
 				},
 				{
-					"command": "kilo-code.promptsButtonClicked",
+					"command": "kilo-code.mcpButtonClicked",
 					"group": "navigation@2",
 					"when": "activeWebviewPanelId == kilo-code.TabPanelProvider"
 				},

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -15,7 +15,7 @@ import HistoryView from "./components/history/HistoryView"
 import SettingsView, { SettingsViewRef } from "./components/settings/SettingsView"
 import WelcomeView from "./components/kilocode/Welcome/WelcomeView" // kilocode_change
 import ProfileView from "./components/kilocode/profile/ProfileView" // kilocode_change
-// import McpView from "./components/mcp/McpView" kilocode_change: rendered in settings instead
+import McpView from "./components/mcp/McpView"
 // import { MarketplaceView } from "./components/marketplace/MarketplaceView" // kilocode_change: rendered in settings
 import ModesView from "./components/modes/ModesView"
 import { HumanRelayDialog } from "./components/human-relay/HumanRelayDialog"
@@ -181,7 +181,7 @@ const App = () => {
 	) : (
 		<>
 			{tab === "modes" && <ModesView onDone={() => switchTab("chat")} />}
-			{/* {tab === "mcp" && <McpView onDone={() => switchTab("chat")} />} kilocode_change: we render this in settings */}
+			{tab === "mcp" && <McpView onDone={() => switchTab("chat")} />}
 			{tab === "history" && <HistoryView onDone={() => switchTab("chat")} />}
 			{tab === "settings" && (
 				<SettingsView ref={settingsRef} onDone={() => switchTab("chat")} targetSection={currentSection} /> // kilocode_change

--- a/webview-ui/src/components/kilocodeMcp/McpView.tsx
+++ b/webview-ui/src/components/kilocodeMcp/McpView.tsx
@@ -66,7 +66,7 @@ const McpView = () => {
 					{/* Content container */}
 					<div style={{ width: "100%" }}>
 						{activeTab === "marketplace" && <MarketplaceView stateManager={marketplaceStateManager} />}
-						{activeTab === "installed" && <RooMcpView onDone={() => {}} />}
+						{activeTab === "installed" && <RooMcpView hideHeader onDone={() => {}} />}
 					</div>
 				</div>
 			</Section>

--- a/webview-ui/src/components/mcp/McpView.tsx
+++ b/webview-ui/src/components/mcp/McpView.tsx
@@ -34,9 +34,10 @@ import { McpErrorRow } from "./McpErrorRow"
 
 type McpViewProps = {
 	onDone: () => void
+	hideHeader?: boolean // kilocode_change
 }
 
-const McpView = ({ onDone }: McpViewProps) => {
+const McpView = ({ onDone, hideHeader = false }: McpViewProps) => {
 	const {
 		mcpServers: servers,
 		alwaysAllowMcp,
@@ -50,8 +51,8 @@ const McpView = ({ onDone }: McpViewProps) => {
 	return (
 		// kilocode_change: add relative className
 		<Tab className="relative">
-			{/*  kilocode_change: disable header */}
-			<TabHeader style={{ display: "none" }} className="flex justify-between items-center">
+			{/*  kilocode_change: display header conditionally */}
+			<TabHeader style={{ display: hideHeader ? "none" : "flex" }} className="flex justify-between items-center">
 				<h3 className="text-vscode-foreground m-0">{t("mcp:title")}</h3>
 				<Button onClick={onDone}>{t("mcp:done")}</Button>
 			</TabHeader>


### PR DESCRIPTION
Makes the MCP server view accessible from the top bar as well as from the installed tab in the MCP settings.

- Resolves #1104