### PR TITLE
feat(autocomplete): select profile to use for autocomplete

### DIFF
--- a/.changeset/twelve-cats-search.md
+++ b/.changeset/twelve-cats-search.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Allow configuring autocomplete API provider

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -113,6 +113,7 @@ export const globalSettingsSchema = z.object({
 	customModePrompts: customModePromptsSchema.optional(),
 	customSupportPrompts: customSupportPromptsSchema.optional(),
 	enhancementApiConfigId: z.string().optional(),
+	autocompleteApiConfigId: z.string().optional(), // kilocode_change
 	commitMessageApiConfigId: z.string().optional(), // kilocode_change
 	historyPreviewCollapsed: z.boolean().optional(),
 	profileThresholds: z.record(z.string(), z.number()).optional(),

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1467,6 +1467,7 @@ export class ClineProvider
 			organizationAllowList,
 			maxConcurrentFileReads,
 			allowVeryLargeReads, // kilocode_change
+			autocompleteApiConfigId, // kilocode_change
 			condensingApiConfigId,
 			customCondensingPrompt,
 			codebaseIndexConfig,
@@ -1576,6 +1577,7 @@ export class ClineProvider
 			cloudIsAuthenticated: cloudIsAuthenticated ?? false,
 			sharingEnabled: sharingEnabled ?? false,
 			organizationAllowList,
+			autocompleteApiConfigId, // kilocode_change
 			condensingApiConfigId,
 			customCondensingPrompt,
 			codebaseIndexModels: codebaseIndexModels ?? EMBEDDING_MODEL_PROFILES,
@@ -1718,6 +1720,7 @@ export class ClineProvider
 			customSupportPrompts: stateValues.customSupportPrompts ?? {},
 			enhancementApiConfigId: stateValues.enhancementApiConfigId,
 			commitMessageApiConfigId: stateValues.commitMessageApiConfigId, // kilocode_change
+			autocompleteApiConfigId: stateValues.autocompleteApiConfigId, // kilocode_change
 			experiments: stateValues.experiments ?? experimentDefault,
 			autoApprovalEnabled: stateValues.autoApprovalEnabled ?? true,
 			customModes,

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1226,6 +1226,10 @@ export const webviewMessageHandler = async (
 			await updateGlobalState("commitMessageApiConfigId", message.text)
 			await provider.postStateToWebview()
 			break
+		case "autocompleteApiConfigId":
+			await updateGlobalState("autocompleteApiConfigId", message.text)
+			await provider.postStateToWebview()
+			break
 		// kilocode_change end
 		case "condensingApiConfigId":
 			await updateGlobalState("condensingApiConfigId", message.text)

--- a/src/i18n/locales/ar/kilocode.json
+++ b/src/i18n/locales/ar/kilocode.json
@@ -54,5 +54,25 @@
 		"tokenRequired": "يتطلب توليد الرسالة رمز Kilo Code",
 		"activationFailed": "Kilo: فشل تفعيل مولّد الرسائل: {{error}}",
 		"providerRegistered": "Kilo: تم تسجيل موفر رسائل الاعتماد"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"tooltip": {
+				"basic": "كيلو كود الإكمال التلقائي",
+				"disabled": "إكمال تلقائي لكود كيلو (معطل)",
+				"sessionTotal": "التكلفة الإجمالية للجلسة:",
+				"tokenError": "يجب تعيين رمز صالح لاستخدام الإكمال التلقائي",
+				"lastCompletion": "الإكمال الأخير:",
+				"model": "النموذج:"
+			},
+			"disabled": "$(circle-slash) كيلو مكتمل",
+			"warning": "$(warning) اكتمل كيلو",
+			"enabled": "$(sparkle) كيلو مكتمل",
+			"cost": {
+				"zero": "0.00 دولار",
+				"lessThanCent": "<$0.01"
+			}
+		},
+		"toggleMessage": "كيلو كُمبليت {{status}}"
 	}
 }

--- a/src/i18n/locales/ca/kilocode.json
+++ b/src/i18n/locales/ca/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Missatge de commit generat!",
 		"generationFailed": "Kilo: No s'ha pogut generar el missatge de confirmació: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Generant missatge utilitzant canvis no preparats"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"warning": "$(warning) Quilogram Completat",
+			"enabled": "$(sparkle) Quilòmetre complet",
+			"tooltip": {
+				"basic": "Autocompletat Kilo Code",
+				"disabled": "Kilo Code Autocomplete (desactivat)",
+				"tokenError": "Cal establir un token vàlid per utilitzar l'autocompleció",
+				"lastCompletion": "Última compleció:",
+				"sessionTotal": "Cost total de la sessió:",
+				"model": "Model:"
+			},
+			"disabled": "$(circle-slash) Kilo Complet",
+			"cost": {
+				"zero": "0,00 €",
+				"lessThanCent": "<0,01 €"
+			}
+		},
+		"toggleMessage": "Quilòmetre completat {{status}}"
 	}
 }

--- a/src/i18n/locales/cs/kilocode.json
+++ b/src/i18n/locales/cs/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Zpráva byla vygenerována!",
 		"generationFailed": "Kilo: Nepodařilo se vygenerovat zprávu commitu: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Generování zprávy s použitím nenapojených změn"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(sparkle) Kilo Dokončeno",
+			"disabled": "$(circle-slash) Kilo Dokončeno",
+			"tooltip": {
+				"tokenError": "Pro použití automatického dokončování musí být nastaven platný token",
+				"basic": "Kilo Code Autocomplete",
+				"lastCompletion": "Poslední dokončení:",
+				"model": "Model:",
+				"sessionTotal": "Celkové náklady na relaci:",
+				"disabled": "Kilo Code Autocomplete (deaktivováno)"
+			},
+			"warning": "$(warning) Kilo Hotovo",
+			"cost": {
+				"zero": "0,00 Kč",
+				"lessThanCent": "<0,01 $"
+			}
+		},
+		"toggleMessage": "Kilo hotovo {{status}}"
 	}
 }

--- a/src/i18n/locales/de/kilocode.json
+++ b/src/i18n/locales/de/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Commit-Nachricht generiert!",
 		"generationFailed": "Kilo: Fehler beim Generieren der Commit-Nachricht: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Nachricht mit nicht bereitgestellten Änderungen generieren"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"disabled": "$(circle-slash) Kilo abgeschlossen",
+			"tooltip": {
+				"basic": "Kilo Code Autocomplete",
+				"sessionTotal": "Gesamtkosten der Sitzung:",
+				"disabled": "Kilo Code Autocomplete (deaktiviert)",
+				"tokenError": "Ein gültiges Token muss eingestellt werden, um die Autovervollständigung zu verwenden",
+				"lastCompletion": "Letzte Vervollständigung:",
+				"model": "Modell:"
+			},
+			"warning": "$(warning) Kilo Abgeschlossen",
+			"enabled": "$(sparkle) Kilo Abgeschlossen",
+			"cost": {
+				"lessThanCent": "<0,01 €",
+				"zero": "0,00 €"
+			}
+		},
+		"toggleMessage": "Kilo vollständig {{status}}"
 	}
 }

--- a/src/i18n/locales/el/kilocode.json
+++ b/src/i18n/locales/el/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Το μήνυμα commit δημιουργήθηκε!",
 		"generationFailed": "Kilo: Αποτυχία δημιουργίας μηνύματος commit: {{errorMessage}}",
 		"generatingFromUnstaged": "Κιλό: Δημιουργία μηνύματος με χρήση μη καταχωρημένων αλλαγών"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"warning": "$(warning) Κίλο Ολοκληρώθηκε",
+			"enabled": "$(sparkle) Κιλό Ολοκληρώθηκε",
+			"tooltip": {
+				"basic": "Αυτόματη Συμπλήρωση Κώδικα Kilo",
+				"tokenError": "Πρέπει να οριστεί ένα έγκυρο διακριτικό για να χρησιμοποιηθεί η αυτόματη συμπλήρωση",
+				"disabled": "Αυτόματη Συμπλήρωση Kilo Code (απενεργοποιημένη)",
+				"sessionTotal": "Συνολικό κόστος συνεδρίας:",
+				"lastCompletion": "Τελευταία ολοκλήρωση:",
+				"model": "Μοντέλο:"
+			},
+			"disabled": "$(circle-slash) Kilo Ολοκληρώθηκε",
+			"cost": {
+				"lessThanCent": "<0,01$",
+				"zero": "0,00 €"
+			}
+		},
+		"toggleMessage": "Κιλό Ολοκληρώθηκε {{status}}"
 	}
 }

--- a/src/i18n/locales/en/kilocode.json
+++ b/src/i18n/locales/en/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Commit message generated!",
 		"generationFailed": "Kilo: Failed to generate commit message: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Generating message using unstaged changes"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(sparkle) Kilo Complete",
+			"disabled": "$(circle-slash) Kilo Complete",
+			"warning": "$(warning) Kilo Complete",
+			"tooltip": {
+				"basic": "Kilo Code Autocomplete",
+				"disabled": "Kilo Code Autocomplete (disabled)",
+				"tokenError": "A valid token must be set to use autocomplete",
+				"lastCompletion": "Last completion:",
+				"sessionTotal": "Session total cost:",
+				"model": "Model:"
+			},
+			"cost": {
+				"zero": "$0.00",
+				"lessThanCent": "<$0.01"
+			}
+		},
+		"toggleMessage": "Kilo Complete {{status}}"
 	}
 }

--- a/src/i18n/locales/es/kilocode.json
+++ b/src/i18n/locales/es/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: ¡Mensaje de commit generado!",
 		"generationFailed": "Kilo: Error al generar mensaje de confirmación: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Generando mensaje usando cambios no preparados"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(sparkle) Kilo Completado",
+			"disabled": "$(circle-slash) Kilo Completo",
+			"warning": "$(warning) Kilo Completo",
+			"tooltip": {
+				"disabled": "Autocompletar de Kilo Code (desactivado)",
+				"basic": "Autocompletado de Kilo Code",
+				"sessionTotal": "Costo total de la sesión:",
+				"lastCompletion": "Última finalización:",
+				"tokenError": "Se debe establecer un token válido para usar el autocompletado",
+				"model": "Modelo:"
+			},
+			"cost": {
+				"zero": "$0,00",
+				"lessThanCent": "<$0.01"
+			}
+		},
+		"toggleMessage": "Kilo Completo {{status}}"
 	}
 }

--- a/src/i18n/locales/fil/kilocode.json
+++ b/src/i18n/locales/fil/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Nagenerahan ang mensahe ng commit!",
 		"generationFailed": "Kilo: Nabigong gumawa ng commit message: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Gumagawa ng mensahe gamit ang mga hindi naka-stage na pagbabago"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"disabled": "$(circle-slash) Kilometro Kumpleto",
+			"enabled": "$(sparkle) Kilo Kumpleto",
+			"warning": "$(warning) Kilo Kumpleto",
+			"tooltip": {
+				"basic": "Kilo Code Autocomplete",
+				"disabled": "Kilo Code Autocomplete (naka-disable)",
+				"tokenError": "Dapat may nakatakdang wastong token para magamit ang autocomplete",
+				"lastCompletion": "Huling pagkumpleto:",
+				"sessionTotal": "Kabuuang gastos ng session:",
+				"model": "Modelo:"
+			},
+			"cost": {
+				"lessThanCent": "<$0.01",
+				"zero": "₱0.00"
+			}
+		},
+		"toggleMessage": "Kilo Complete {{status}}"
 	}
 }

--- a/src/i18n/locales/fr/kilocode.json
+++ b/src/i18n/locales/fr/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo : Message de commit généré !",
 		"generationFailed": "Kilo: Échec de génération du message de commit : {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo : Génération du message à partir des modifications non indexées"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"disabled": "$(circle-slash) Kilo Terminé",
+			"enabled": "$(sparkle) Kilo Terminé",
+			"warning": "$(warning) Kilo Terminé",
+			"tooltip": {
+				"disabled": "Autocomplétion Kilo Code (désactivée)",
+				"tokenError": "Un jeton valide doit être défini pour utiliser l'autocomplétion",
+				"sessionTotal": "Coût total de la séance :",
+				"basic": "Autocomplétion Kilo Code",
+				"lastCompletion": "Dernière complétion :",
+				"model": "Modèle :"
+			},
+			"cost": {
+				"lessThanCent": "<0,01 $",
+				"zero": "0,00 $"
+			}
+		},
+		"toggleMessage": "Kilo Terminé {{status}}"
 	}
 }

--- a/src/i18n/locales/hi/kilocode.json
+++ b/src/i18n/locales/hi/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "किलो: कमिट मैसेज जनरेट हो गया!",
 		"generationFailed": "किलो: प्रतिबद्धता संदेश उत्पन्न करने में विफल: {{errorMessage}}",
 		"generatingFromUnstaged": "किलो: अपरिवर्तित परिवर्तनों का उपयोग करके संदेश उत्पन्न कर रहा है"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"disabled": "$(circle-slash) किलो पूर्ण",
+			"warning": "$(warning) किलो पूरा हुआ",
+			"enabled": "$(sparkle) किलो पूरा हो गया",
+			"tooltip": {
+				"basic": "किलो कोड ऑटोकम्प्लीट",
+				"tokenError": "स्वतः पूर्ण का उपयोग करने के लिए एक वैध टोकन सेट किया जाना चाहिए",
+				"model": "मॉडल:",
+				"sessionTotal": "सत्र की कुल लागत:",
+				"lastCompletion": "अंतिम पूर्णता:",
+				"disabled": "किलो कोड स्वतः पूर्ण (अक्षम)"
+			},
+			"cost": {
+				"zero": "₹0.00",
+				"lessThanCent": "<₹0.01"
+			}
+		},
+		"toggleMessage": "किलो कम्पलीट {{status}}"
 	}
 }

--- a/src/i18n/locales/id/kilocode.json
+++ b/src/i18n/locales/id/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Pesan commit telah dibuat!",
 		"generationFailed": "Kilo: Gagal menghasilkan pesan commit: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Membuat pesan menggunakan perubahan yang belum di-stage"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"disabled": "$(circle-slash) Kilo Selesai",
+			"enabled": "$(sparkle) Kilo Selesai",
+			"tooltip": {
+				"basic": "Kilo Code Autocomplete",
+				"disabled": "Kilo Code Autocomplete (dinonaktifkan)",
+				"tokenError": "Token yang valid harus ditetapkan untuk menggunakan autocomplete",
+				"lastCompletion": "Penyelesaian terakhir:",
+				"sessionTotal": "Biaya total sesi:",
+				"model": "Model:"
+			},
+			"warning": "$(warning) Kilo Selesai",
+			"cost": {
+				"zero": "Rp0,00",
+				"lessThanCent": "<Rp0,01"
+			}
+		},
+		"toggleMessage": "Kilo Selesai {{status}}"
 	}
 }

--- a/src/i18n/locales/it/kilocode.json
+++ b/src/i18n/locales/it/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Messaggio di commit generato!",
 		"generationFailed": "Kilo: Impossibile generare il messaggio di commit: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Generazione del messaggio usando modifiche non in staging"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(sparkle) Kilo Completato",
+			"tooltip": {
+				"basic": "Completamento Automatico Kilo Code",
+				"sessionTotal": "Costo totale della sessione:",
+				"lastCompletion": "Ultimo completamento:",
+				"model": "Modello:",
+				"tokenError": "È necessario impostare un token valido per utilizzare l'autocompletamento",
+				"disabled": "Completamento Automatico Kilo Code (disabilitato)"
+			},
+			"disabled": "$(circle-slash) Kilo Completato",
+			"warning": "$(warning) Kilo Completato",
+			"cost": {
+				"zero": "€0,00",
+				"lessThanCent": "<€0,01"
+			}
+		},
+		"toggleMessage": "Kilo Completato {{status}}"
 	}
 }

--- a/src/i18n/locales/ja/kilocode.json
+++ b/src/i18n/locales/ja/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: コミットメッセージが生成されました！",
 		"generationFailed": "Kilo: コミットメッセージの生成に失敗しました: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: ステージングされていない変更を使用してメッセージを生成中"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(sparkle) キロ完了",
+			"disabled": "$(circle-slash) キロ コンプリート",
+			"warning": "$(warning) キロ完了",
+			"tooltip": {
+				"disabled": "キロ コード オートコンプリート (無効)",
+				"tokenError": "オートコンプリートを使用するには有効なトークンを設定する必要があります",
+				"lastCompletion": "最後の回答:",
+				"basic": "キロ コード オートコンプリート",
+				"model": "モデル:",
+				"sessionTotal": "セッション合計費用:"
+			},
+			"cost": {
+				"zero": "¥0",
+				"lessThanCent": "<$0.01"
+			}
+		},
+		"toggleMessage": "キロ コンプリート {{status}}"
 	}
 }

--- a/src/i18n/locales/ko/kilocode.json
+++ b/src/i18n/locales/ko/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "킬로: 커밋 메시지가 생성되었습니다!",
 		"generationFailed": "Kilo: 커밋 메시지 생성 실패: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: 스테이징되지 않은 변경사항을 사용하여 메시지 생성"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"disabled": "$(circle-slash) 킬로 완료",
+			"enabled": "$(sparkle) 킬로 완료",
+			"tooltip": {
+				"disabled": "킬로 코드 자동완성 (비활성화됨)",
+				"basic": "킬로 코드 자동완성",
+				"tokenError": "자동완성을 사용하려면 유효한 토큰을 설정해야 합니다",
+				"sessionTotal": "세션 총 비용:",
+				"lastCompletion": "마지막 완료:",
+				"model": "모델:"
+			},
+			"warning": "$(warning) 킬로 완료",
+			"cost": {
+				"lessThanCent": "<$0.01",
+				"zero": "0원"
+			}
+		},
+		"toggleMessage": "킬로 완료 {{status}}"
 	}
 }

--- a/src/i18n/locales/nl/kilocode.json
+++ b/src/i18n/locales/nl/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Commitbericht gegenereerd!",
 		"generationFailed": "Kilo: Mislukt bij het genereren van een commit-bericht: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Bericht genereren met niet-gecommitteerde wijzigingen"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(sparkle) Kilo Voltooid",
+			"warning": "$(warning) Kilo Voltooid",
+			"tooltip": {
+				"basic": "Kilo Code Automatische Aanvulling",
+				"tokenError": "Een geldige token moet ingesteld worden om automatisch aanvullen te gebruiken",
+				"disabled": "Kilo Code Automatisch aanvullen (uitgeschakeld)",
+				"lastCompletion": "Laatste voltooiing:",
+				"sessionTotal": "Totale sessiekosten:",
+				"model": "Model:"
+			},
+			"disabled": "$(circle-slash) Kilo Voltooid",
+			"cost": {
+				"zero": "€ 0,00",
+				"lessThanCent": "<€0,01"
+			}
+		},
+		"toggleMessage": "Kilo Voltooid {{status}}"
 	}
 }

--- a/src/i18n/locales/pl/kilocode.json
+++ b/src/i18n/locales/pl/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Wiadomość commitu wygenerowana!",
 		"generationFailed": "Kilo: Nie udało się wygenerować komunikatu zatwierdzenia: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Generowanie wiadomości na podstawie niezatwierdzonych zmian"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"disabled": "$(circle-slash) Kilo Ukończone",
+			"enabled": "$(sparkle) Kilo Ukończone",
+			"tooltip": {
+				"lastCompletion": "Ostatnie zakończenie:",
+				"disabled": "Kilo Code automatyczne uzupełnianie (wyłączone)",
+				"basic": "Kilo Code Autocomplete",
+				"tokenError": "Aby korzystać z autouzupełniania, należy ustawić prawidłowy token",
+				"sessionTotal": "Całkowity koszt sesji:",
+				"model": "Model:"
+			},
+			"warning": "$(warning) Kilo - Wykonane",
+			"cost": {
+				"lessThanCent": "<0,01 zł",
+				"zero": "0,00 zł"
+			}
+		},
+		"toggleMessage": "Kilo Zakończone {{status}}"
 	}
 }

--- a/src/i18n/locales/pt-BR/kilocode.json
+++ b/src/i18n/locales/pt-BR/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Mensagem de commit gerada!",
 		"generationFailed": "Kilo: Falha ao gerar mensagem de commit: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Gerando mensagem usando alterações não preparadas"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(sparkle) Kilo Completo",
+			"disabled": "$(circle-slash) Kilo Completo",
+			"tooltip": {
+				"disabled": "Preenchimento Automático do Kilo Code (desativado)",
+				"tokenError": "Um token válido deve ser definido para usar o preenchimento automático",
+				"basic": "Kilo Code Autocomplete",
+				"lastCompletion": "Última conclusão:",
+				"sessionTotal": "Custo total da sessão:",
+				"model": "Modelo:"
+			},
+			"warning": "$(warning) Kilo Completo",
+			"cost": {
+				"zero": "R$ 0,00",
+				"lessThanCent": "<R$0,01"
+			}
+		},
+		"toggleMessage": "Kilo Completo {{status}}"
 	}
 }

--- a/src/i18n/locales/ru/kilocode.json
+++ b/src/i18n/locales/ru/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Сообщение коммита сгенерировано!",
 		"generationFailed": "Kilo: Не удалось создать сообщение коммита: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Генерация сообщения с использованием неподготовленных изменений"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(sparkle) Кило Выполнено",
+			"warning": "$(warning) Кило завершено",
+			"disabled": "$(circle-slash) Кило завершено",
+			"tooltip": {
+				"sessionTotal": "Общая стоимость сессии:",
+				"disabled": "Автодополнение Kilo Code (отключено)",
+				"model": "Модель:",
+				"tokenError": "Для использования автозаполнения должен быть установлен действительный токен",
+				"lastCompletion": "Последнее завершение:",
+				"basic": "Автодополнение Kilo Code"
+			},
+			"cost": {
+				"lessThanCent": "<$0,01",
+				"zero": "0,00 ₽"
+			}
+		},
+		"toggleMessage": "Кило Выполнено {{status}}"
 	}
 }

--- a/src/i18n/locales/sv/kilocode.json
+++ b/src/i18n/locales/sv/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Commit-meddelande genererat!",
 		"generationFailed": "Kilo: Misslyckades med att generera commit-meddelande: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Genererar meddelande med ej iscensatta ändringar"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(sparkle) Kilo Slutfört",
+			"warning": "$(warning) Kilo Komplett",
+			"disabled": "$(circle-slash) Kilo Slutfört",
+			"tooltip": {
+				"disabled": "Kilo Code Autocomplete (inaktiverad)",
+				"basic": "Kilo Kod Automatisk komplettering",
+				"tokenError": "En giltig token måste anges för att använda automatisk komplettering",
+				"lastCompletion": "Senaste slutförande:",
+				"sessionTotal": "Sessionens totala kostnad:",
+				"model": "Modell:"
+			},
+			"cost": {
+				"zero": "0,00 kr",
+				"lessThanCent": "<0,01 kr"
+			}
+		},
+		"toggleMessage": "Kilo Fullständig {{status}}"
 	}
 }

--- a/src/i18n/locales/th/kilocode.json
+++ b/src/i18n/locales/th/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "กิโลเมตร: สร้างข้อความคอมมิตแล้ว!",
 		"generationFailed": "กิโล: ไม่สามารถสร้างข้อความคอมมิตได้: {{errorMessage}}",
 		"generatingFromUnstaged": "กิโล: กำลังสร้างข้อความโดยใช้การเปลี่ยนแปลงที่ยังไม่ได้นำเข้าสู่ขั้นตอน"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"warning": "$(warning) กิโลสมบูรณ์",
+			"enabled": "$(sparkle) กิโลสำเร็จแล้ว",
+			"disabled": "$(circle-slash) กิโลสมบูรณ์",
+			"tooltip": {
+				"lastCompletion": "การป้อนข้อมูลล่าสุด:",
+				"disabled": "คำสั่งอัตโนมัติของ Kilo Code (ปิดการใช้งาน)",
+				"tokenError": "ต้องตั้งค่าโทเค็นที่ถูกต้องเพื่อใช้การเติมข้อความอัตโนมัติ",
+				"basic": "การเติมคำอัตโนมัติ Kilo Code",
+				"model": "โมเดล:",
+				"sessionTotal": "ค่าใช้จ่ายรวมของเซสชัน:"
+			},
+			"cost": {
+				"zero": "฿0.00",
+				"lessThanCent": "<฿0.01"
+			}
+		},
+		"toggleMessage": "กิโลเสร็จสิ้น {{status}}"
 	}
 }

--- a/src/i18n/locales/tr/kilocode.json
+++ b/src/i18n/locales/tr/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: İşleme mesajı oluşturuldu!",
 		"generationFailed": "Kilo: Taahhüt mesajı oluşturulamadı: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Evrelenmemiş değişiklikleri kullanarak mesaj oluşturuluyor"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(sparkle) Kilo Tamamlandı",
+			"disabled": "$(circle-slash) Kilo Tamamlandı",
+			"tooltip": {
+				"basic": "Kilo Kod Otomatik Tamamlama",
+				"disabled": "Kilo Kod Otomatik Tamamlama (devre dışı)",
+				"tokenError": "Otomatik tamamlama özelliğini kullanmak için geçerli bir belirteç ayarlanmalıdır",
+				"sessionTotal": "Oturum toplam maliyeti:",
+				"lastCompletion": "Son tamamlama:",
+				"model": "Model:"
+			},
+			"warning": "$(warning) Kilo Tamamlandı",
+			"cost": {
+				"zero": "0,00 ₺",
+				"lessThanCent": "<0,01$"
+			}
+		},
+		"toggleMessage": "Kilo Tamamlandı {{status}}"
 	}
 }

--- a/src/i18n/locales/uk/kilocode.json
+++ b/src/i18n/locales/uk/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Повідомлення коміту згенеровано!",
 		"generationFailed": "Kilo: Не вдалося створити повідомлення коміту: {{errorMessage}}",
 		"generatingFromUnstaged": "Кіло: Створення повідомлення з використанням незафіксованих змін"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(sparkle) Кіло Виконано",
+			"disabled": "$(circle-slash) Кіло завершено",
+			"tooltip": {
+				"basic": "Автодоповнення Kilo Code",
+				"tokenError": "Для використання автозаповнення необхідно встановити дійсний токен",
+				"disabled": "Kilo Code Автозаповнення (вимкнено)",
+				"lastCompletion": "Останнє завершення:",
+				"model": "Модель:",
+				"sessionTotal": "Загальна вартість сеансу:"
+			},
+			"warning": "$(warning) Кіло виконано",
+			"cost": {
+				"zero": "0,00 ₴",
+				"lessThanCent": "<$0,01"
+			}
+		},
+		"toggleMessage": "Кіло виконано {{status}}"
 	}
 }

--- a/src/i18n/locales/vi/kilocode.json
+++ b/src/i18n/locales/vi/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: Đã tạo thông điệp commit!",
 		"generationFailed": "Kilo: Không thể tạo thông điệp commit: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Tạo tin nhắn sử dụng các thay đổi chưa được đưa vào dàn dựng"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(sparkle) Hoàn thành Kilo",
+			"disabled": "$(circle-slash) Hoàn Tất Kilo",
+			"warning": "$(warning) Kilo Hoàn Thành",
+			"tooltip": {
+				"disabled": "Tự động hoàn thành Kilo Code (đã tắt)",
+				"basic": "Tự động hoàn thiện Kilo Code",
+				"tokenError": "Phải thiết lập một token hợp lệ để sử dụng tính năng tự động hoàn thành",
+				"lastCompletion": "Lượt hoàn thành cuối cùng:",
+				"model": "Mô hình:",
+				"sessionTotal": "Tổng chi phí phiên:"
+			},
+			"cost": {
+				"zero": "0₫",
+				"lessThanCent": "<$0,01"
+			}
+		},
+		"toggleMessage": "Kilo Hoàn thành {{status}}"
 	}
 }

--- a/src/i18n/locales/zh-CN/kilocode.json
+++ b/src/i18n/locales/zh-CN/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo: 已生成提交信息！",
 		"generationFailed": "Kilo：生成提交信息失败：{{errorMessage}}",
 		"generatingFromUnstaged": "Kilo：使用未暂存的更改生成消息"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"warning": "$(warning) 千米完成",
+			"enabled": "$(sparkle) 千米完成",
+			"disabled": "$(circle-slash) 公里已完成",
+			"tooltip": {
+				"disabled": "千行代码自动补全（已禁用）",
+				"lastCompletion": "上一次完成：",
+				"sessionTotal": "会话总费用：",
+				"basic": "千行代码自动补全",
+				"tokenError": "必须设置有效令牌才能使用自动完成功能",
+				"model": "模型："
+			},
+			"cost": {
+				"lessThanCent": "<$0.01",
+				"zero": "¥0.00"
+			}
+		},
+		"toggleMessage": "千米完成 {{status}}"
 	}
 }

--- a/src/i18n/locales/zh-TW/kilocode.json
+++ b/src/i18n/locales/zh-TW/kilocode.json
@@ -48,5 +48,25 @@
 		"generated": "Kilo：提交信息已生成！",
 		"generationFailed": "Kilo：无法生成提交信息：{{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: 使用未暂存的更改生成消息"
+	},
+	"autocomplete": {
+		"statusBar": {
+			"disabled": "$(circle-slash) 千字节已完成",
+			"enabled": "$(sparkle) 千米完成",
+			"tooltip": {
+				"basic": "千行代码自动补全",
+				"lastCompletion": "上次完成：",
+				"disabled": "Kilo Code 代码自动补全（已禁用）",
+				"sessionTotal": "会话总费用:",
+				"tokenError": "必须设置有效令牌才能使用自动完成功能",
+				"model": "模型："
+			},
+			"warning": "$(warning) 千字节完成",
+			"cost": {
+				"lessThanCent": "<$0.01",
+				"zero": "¥0.00"
+			}
+		},
+		"toggleMessage": "千米完成 {{status}}"
 	}
 }

--- a/src/services/autocomplete/AutocompleteProvider.ts
+++ b/src/services/autocomplete/AutocompleteProvider.ts
@@ -8,16 +8,19 @@ import { createDebouncedFn } from "./utils/createDebouncedFn"
 import { AutocompleteDecorationAnimation } from "./AutocompleteDecorationAnimation"
 import { isHumanEdit } from "./utils/EditDetectionUtils"
 import { ExperimentId } from "@roo-code/types"
+import { EXPERIMENT_IDS } from "../../shared/experiments"
 import { AutocompleteCache } from "./AutocompleteCache"
 import { holeFillerStrategy } from "./strategies/holeFiller"
 import { createInlineCompletionItem } from "./AutocompleteActions"
 import { processTextInsertion } from "./utils/CompletionTextProcessor"
 import { AutocompleteStatusBar } from "./AutocompleteStatusBar"
+import { ProviderSettingsManager } from "../../core/config/ProviderSettingsManager"
+import { getAutocompleteConfiguration } from "./utils/autocompleteConfig"
+import { t } from "../../i18n"
 
 export const UI_UPDATE_DEBOUNCE_MS = 250
 export const BAIL_OUT_TOO_MANY_LINES_LIMIT = 100
 export const MAX_COMPLETIONS_PER_CONTEXT = 5 // Per-given prefix/suffix lines, how many different per-line options to cache
-const DEFAULT_MODEL = "google/gemini-2.5-flash-preview-05-20"
 
 /**
  * Sets up autocomplete with experiment flag checking.
@@ -27,20 +30,23 @@ const DEFAULT_MODEL = "google/gemini-2.5-flash-preview-05-20"
 export function registerAutocomplete(context: vscode.ExtensionContext): void {
 	let autocompleteDisposable: vscode.Disposable | null = null
 	let isCurrentlyEnabled = false
+	let currentConfigId: string | undefined = undefined
 
-	// Function to check experiment flag and update provider
 	const checkAndUpdateProvider = () => {
 		const experiments =
 			(ContextProxy.instance?.getGlobalState("experiments") as Record<ExperimentId, boolean>) ?? {}
-		const shouldBeEnabled = experiments.autocomplete ?? false
+		const shouldBeEnabled = experiments[EXPERIMENT_IDS.AUTOCOMPLETE] ?? false
+		const newConfigId = ContextProxy.instance?.getValues?.()?.autocompleteApiConfigId
 
-		// Only take action if the state has changed
-		if (shouldBeEnabled !== isCurrentlyEnabled) {
-			console.log(`🚀🔍 Autocomplete experiment flag changed to: ${shouldBeEnabled}`)
+		const experimentChanged = shouldBeEnabled !== isCurrentlyEnabled
+		const configChanged = newConfigId !== currentConfigId
 
+		if (experimentChanged || (shouldBeEnabled && configChanged)) {
 			autocompleteDisposable?.dispose()
 			autocompleteDisposable = shouldBeEnabled ? setupAutocomplete(context) : null
+
 			isCurrentlyEnabled = shouldBeEnabled
+			currentConfigId = newConfigId
 		}
 	}
 
@@ -57,37 +63,41 @@ export function registerAutocomplete(context: vscode.ExtensionContext): void {
 }
 
 function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable {
-	// State
-	let enabled = true // User toggle state (default to enabled)
+	let enabled = true
 	let activeRequestId: string | null = null
-	let isBackspaceOperation = false // Flag to track backspace operations
-	let justAcceptedSuggestion = false // Flag to track if a suggestion was just accepted
-	let lastCompletionCost = 0 // Track the cost of the last completion
-	let totalSessionCost = 0 // Track the total cost of all completions in the session
+	let isBackspaceOperation = false
+	let justAcceptedSuggestion = false
+	let lastCompletionCost = 0
+	let totalSessionCost = 0
 
-	// Initialize API handler only if we have a valid token
 	let apiHandler: ApiHandler | null = null
-	const kilocodeToken = ContextProxy.instance.getProviderSettings().kilocodeToken
+	const providerSettingsManager = new ProviderSettingsManager(context)
 
-	if (kilocodeToken) {
-		apiHandler = buildApiHandler({
-			apiProvider: "kilocode",
-			kilocodeToken,
-			kilocodeModel: DEFAULT_MODEL,
-		})
-	}
-
-	// Services
 	const autocompleteCache = new AutocompleteCache()
 	const contextGatherer = new ContextGatherer()
 	const animationManager = AutocompleteDecorationAnimation.getInstance()
-	const statusBar = new AutocompleteStatusBar({
-		enabled,
-		model: DEFAULT_MODEL,
-		lastCompletionCost,
-		totalSessionCost,
-		kilocodeToken,
-	})
+	const statusBar = new AutocompleteStatusBar({ enabled })
+
+	const updateStatusBar = () => {
+		statusBar.update({
+			enabled,
+			totalSessionCost,
+			lastCompletionCost,
+			model: apiHandler?.getModel().id || "default",
+			hasValidToken: apiHandler !== null,
+		})
+	}
+
+	const updateApiHandler = async (providerSettingsManager: ProviderSettingsManager) => {
+		try {
+			const autocompleteConfig = await getAutocompleteConfiguration(providerSettingsManager)
+			apiHandler = autocompleteConfig ? buildApiHandler(autocompleteConfig) : null
+		} catch (error) {
+			console.warn("Failed to update autocomplete API handler:", error)
+			apiHandler = null
+		}
+		updateStatusBar() // Update status bar with new model and token validity
+	}
 
 	const clearState = () => {
 		vscode.commands.executeCommand("editor.action.inlineSuggest.hide")
@@ -153,12 +163,7 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 		// Update cost tracking variables
 		totalSessionCost += completionCost
 		lastCompletionCost = completionCost
-
-		// Update status bar with cost information
-		statusBar.update({
-			totalSessionCost,
-			lastCompletionCost,
-		})
+		updateStatusBar()
 
 		if (activeRequestId === requestId) {
 			animationManager.stopAnimation()
@@ -171,17 +176,7 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 
 	const provider: vscode.InlineCompletionItemProvider = {
 		async provideInlineCompletionItems(document, position, context, token) {
-			if (!enabled || !vscode.window.activeTextEditor) return null
-
-			const kilocodeToken = ContextProxy.instance.getProviderSettings().kilocodeToken
-			if (!kilocodeToken) {
-				return null
-			}
-
-			// Create or recreate the API handler if needed
-			apiHandler =
-				apiHandler ??
-				buildApiHandler({ apiProvider: "kilocode", kilocodeToken: kilocodeToken, kilocodeModel: DEFAULT_MODEL })
+			if (!enabled || !vscode.window.activeTextEditor || !apiHandler) return null
 
 			// Skip providing completions if this was triggered by a backspace operation of if we just accepted a suggestion
 			if (isBackspaceOperation || justAcceptedSuggestion) {
@@ -263,8 +258,10 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 
 	const toggleCommand = vscode.commands.registerCommand("kilo-code.toggleAutocomplete", () => {
 		enabled = !enabled
-		statusBar.update({ enabled })
-		vscode.window.showInformationMessage(`Kilo Complete ${enabled ? "enabled" : "disabled"}`)
+		updateStatusBar()
+		vscode.window.showInformationMessage(
+			t("kilocode:autocomplete.toggleMessage", { status: enabled ? "enabled" : "disabled" }),
+		)
 	})
 
 	// Command to track when a suggestion is accepted
@@ -320,6 +317,12 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 
 	// Still register with context for safety
 	context.subscriptions.push(disposable)
+
+	// Initialize the handler and status bar
+	updateApiHandler(providerSettingsManager).catch((error) => {
+		console.warn("Failed to initialize autocomplete API handler:", error)
+	})
+	updateStatusBar()
 
 	return disposable
 }

--- a/src/services/autocomplete/AutocompleteStatusBar.ts
+++ b/src/services/autocomplete/AutocompleteStatusBar.ts
@@ -1,9 +1,10 @@
 import * as vscode from "vscode"
+import { t } from "../../i18n"
 
 interface AutocompleteStatusBarStateParams {
 	enabled?: boolean
 	model?: string
-	kilocodeToken?: string
+	hasValidToken?: boolean
 	totalSessionCost?: number
 	lastCompletionCost?: number
 }
@@ -12,7 +13,7 @@ export class AutocompleteStatusBar {
 	statusBar: vscode.StatusBarItem
 	enabled: boolean
 	model: string
-	kilocodeToken?: string
+	hasValidToken: boolean
 	totalSessionCost?: number
 	lastCompletionCost?: number
 
@@ -20,7 +21,7 @@ export class AutocompleteStatusBar {
 		this.statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100)
 		this.enabled = params.enabled || false
 		this.model = params.model || "default"
-		this.kilocodeToken = params.kilocodeToken
+		this.hasValidToken = params.hasValidToken || false
 		this.totalSessionCost = params.totalSessionCost
 		this.lastCompletionCost = params.lastCompletionCost
 
@@ -28,8 +29,8 @@ export class AutocompleteStatusBar {
 	}
 
 	private init() {
-		this.statusBar.text = "$(sparkle) Kilo Complete"
-		this.statusBar.tooltip = "Kilo Code Autocomplete"
+		this.statusBar.text = t("kilocode:autocomplete.statusBar.enabled")
+		this.statusBar.tooltip = t("kilocode:autocomplete.statusBar.tooltip.basic")
 		this.statusBar.command = "kilo-code.toggleAutocomplete"
 		this.show()
 	}
@@ -47,14 +48,15 @@ export class AutocompleteStatusBar {
 	}
 
 	private humanFormatCost(cost: number): string {
-		if (cost === 0) return "$0.00"
-		if (cost > 0 && cost < 0.01) return "<$0.01" // Less than one cent
+		if (cost === 0) return t("kilocode:autocomplete.statusBar.cost.zero")
+		if (cost > 0 && cost < 0.01) return t("kilocode:autocomplete.statusBar.cost.lessThanCent") // Less than one cent
 		return `$${cost.toFixed(2)}`
 	}
 
 	public update(params: AutocompleteStatusBarStateParams) {
 		this.enabled = params.enabled !== undefined ? params.enabled : this.enabled
-		this.kilocodeToken = params.kilocodeToken !== undefined ? params.kilocodeToken : this.kilocodeToken
+		this.model = params.model !== undefined ? params.model : this.model
+		this.hasValidToken = params.hasValidToken !== undefined ? params.hasValidToken : this.hasValidToken
 		this.totalSessionCost = params.totalSessionCost !== undefined ? params.totalSessionCost : this.totalSessionCost
 		this.lastCompletionCost =
 			params.lastCompletionCost !== undefined ? params.lastCompletionCost : this.lastCompletionCost
@@ -62,24 +64,24 @@ export class AutocompleteStatusBar {
 	}
 
 	private renderDisabled() {
-		this.statusBar.text = "$(circle-slash) Kilo Complete"
-		this.statusBar.tooltip = "Kilo Code Autocomplete (disabled)"
+		this.statusBar.text = t("kilocode:autocomplete.statusBar.disabled")
+		this.statusBar.tooltip = t("kilocode:autocomplete.statusBar.tooltip.disabled")
 	}
 
 	private renderTokenError() {
-		this.statusBar.text = "$(warning) Kilo Complete"
-		this.statusBar.tooltip = "A valid Kilocode token must be set to use autocomplete"
+		this.statusBar.text = t("kilocode:autocomplete.statusBar.warning")
+		this.statusBar.tooltip = t("kilocode:autocomplete.statusBar.tooltip.tokenError")
 	}
 
 	private renderDefault() {
 		const totalCostFormatted = this.humanFormatCost(this.totalSessionCost || 0)
 		const lastCompletionCostFormatted = this.lastCompletionCost?.toFixed(5) || 0
-		this.statusBar.text = `$(sparkle) Kilo Complete (${totalCostFormatted})`
+		this.statusBar.text = `${t("kilocode:autocomplete.statusBar.enabled")} (${totalCostFormatted})`
 		this.statusBar.tooltip = `\
-Kilo Code Autocomplete
-• Last completion: $${lastCompletionCostFormatted}
-• Session total cost: ${totalCostFormatted}
-• Model: ${this.model}\
+${t("kilocode:autocomplete.statusBar.tooltip.basic")}
+• ${t("kilocode:autocomplete.statusBar.tooltip.lastCompletion")} $${lastCompletionCostFormatted}
+• ${t("kilocode:autocomplete.statusBar.tooltip.sessionTotal")} ${totalCostFormatted}
+• ${t("kilocode:autocomplete.statusBar.tooltip.model")} ${this.model}\
 `
 	}
 
@@ -87,7 +89,7 @@ Kilo Code Autocomplete
 		if (!this.enabled) {
 			return this.renderDisabled()
 		}
-		if (!this.kilocodeToken) {
+		if (!this.hasValidToken) {
 			return this.renderTokenError()
 		}
 		return this.renderDefault()

--- a/src/services/autocomplete/__tests__/AutocompleteStatusBar.spec.ts
+++ b/src/services/autocomplete/__tests__/AutocompleteStatusBar.spec.ts
@@ -1,6 +1,24 @@
 import { AutocompleteStatusBar } from "../AutocompleteStatusBar"
 
-// Mock vscode module
+vi.mock("../../../i18n", () => ({
+	t: vi.fn((key: string) => {
+		const translations: Record<string, string> = {
+			"kilocode:autocomplete.statusBar.enabled": "$(sparkle) Kilo Complete",
+			"kilocode:autocomplete.statusBar.disabled": "$(circle-slash) Kilo Complete",
+			"kilocode:autocomplete.statusBar.warning": "$(warning) Kilo Complete",
+			"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+			"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (disabled)",
+			"kilocode:autocomplete.statusBar.tooltip.tokenError": "A valid token must be set to use autocomplete",
+			"kilocode:autocomplete.statusBar.tooltip.lastCompletion": "Last completion:",
+			"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Session total cost:",
+			"kilocode:autocomplete.statusBar.tooltip.model": "Model:",
+			"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+			"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+		}
+		return translations[key] || key
+	}),
+}))
+
 vi.mock("vscode", () => ({
 	window: {
 		createStatusBarItem: vi.fn(() => ({
@@ -25,7 +43,7 @@ describe("AutocompleteStatusBar", () => {
 		statusBar = new AutocompleteStatusBar({
 			enabled: true,
 			model: "test-model",
-			kilocodeToken: "test-token",
+			hasValidToken: true,
 		})
 	})
 

--- a/src/services/autocomplete/utils/autocompleteConfig.ts
+++ b/src/services/autocomplete/utils/autocompleteConfig.ts
@@ -1,0 +1,23 @@
+// kilocode_change - new file
+import { ContextProxy } from "../../../core/config/ContextProxy"
+import { ProviderSettingsManager } from "../../../core/config/ProviderSettingsManager"
+import { ProviderSettings } from "@roo-code/types"
+
+export async function getAutocompleteConfiguration(
+	providerSettingsManager: ProviderSettingsManager,
+): Promise<ProviderSettings | undefined> {
+	await providerSettingsManager.initialize()
+
+	// If we have a specific API config ID for autocomplete, try to get the profile.
+	const contextProxy = ContextProxy.instance
+	const autocompleteApiConfigId = contextProxy?.getValues().autocompleteApiConfigId
+	if (autocompleteApiConfigId) {
+		try {
+			return await providerSettingsManager.getProfile({ id: autocompleteApiConfigId })
+		} catch (error) {
+			console.error("Failed to get autocomplete profile:", error)
+		}
+	}
+
+	return undefined
+}

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -251,6 +251,7 @@ export type ExtensionState = Pick<
 	| "localRulesToggles" // kilocode_change
 	| "globalWorkflowToggles" // kilocode_change
 	| "commitMessageApiConfigId" // kilocode_change
+	| "autocompleteApiConfigId" // kilocode_change
 	| "condensingApiConfigId"
 	| "customCondensingPrompt"
 	| "codebaseIndexConfig"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -137,6 +137,7 @@ export interface WebviewMessage {
 		| "systemPrompt"
 		| "enhancementApiConfigId"
 		| "commitMessageApiConfigId" // kilocode_change
+		| "autocompleteApiConfigId" // kilocode_change
 		| "updateExperimental"
 		| "autoApprovalEnabled"
 		| "updateCustomMode"

--- a/webview-ui/src/components/settings/AutocompletePromptSettings.tsx
+++ b/webview-ui/src/components/settings/AutocompletePromptSettings.tsx
@@ -1,0 +1,44 @@
+// kilocode_change - new file
+import { useAppTranslation } from "@src/i18n/TranslationContext"
+import { useExtensionState } from "@src/context/ExtensionStateContext"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@src/components/ui"
+import { vscode } from "@src/utils/vscode"
+
+const AutocompletePromptSettings = () => {
+	const { t } = useAppTranslation()
+	const { listApiConfigMeta, autocompleteApiConfigId, setAutocompleteApiConfigId } = useExtensionState()
+
+	return (
+		<div className="mb-4 flex flex-col gap-3 pl-3">
+			<div>
+				<label className="block font-medium mb-1">{t("prompts:supportPrompts.enhance.apiConfiguration")}</label>
+				<Select
+					value={autocompleteApiConfigId || "-"}
+					onValueChange={(value) => {
+						setAutocompleteApiConfigId(value === "-" ? "" : value)
+						vscode.postMessage({ type: "autocompleteApiConfigId", text: value })
+					}}>
+					<SelectTrigger data-testid="autocomplete-api-config-select" className="w-full">
+						<SelectValue placeholder={t("prompts:supportPrompts.enhance.useCurrentConfig")} />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="-">{t("prompts:supportPrompts.enhance.useCurrentConfig")}</SelectItem>
+						{(listApiConfigMeta || []).map((config) => (
+							<SelectItem
+								key={config.id}
+								value={config.id}
+								data-testid={`autocomplete-${config.id}-option`}>
+								{config.name} ({config.apiProvider})
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+				<div className="text-sm text-vscode-descriptionForeground mt-1">
+					{t("prompts:supportPrompts.enhance.apiConfigDescription")}
+				</div>
+			</div>
+		</div>
+	)
+}
+
+export default AutocompletePromptSettings

--- a/webview-ui/src/components/settings/ExperimentalSettings.tsx
+++ b/webview-ui/src/components/settings/ExperimentalSettings.tsx
@@ -14,6 +14,7 @@ import { SectionHeader } from "./SectionHeader"
 import { Section } from "./Section"
 import { ExperimentalFeature } from "./ExperimentalFeature"
 import { CodeIndexSettings } from "./CodeIndexSettings"
+import AutocompletePromptSettings from "./AutocompletePromptSettings"
 
 type ExperimentalSettingsProps = HTMLAttributes<HTMLDivElement> & {
 	experiments: Experiments
@@ -65,6 +66,26 @@ export const ExperimentalSettings = ({
 										setExperimentEnabled(EXPERIMENT_IDS.MULTI_FILE_APPLY_DIFF, enabled)
 									}
 								/>
+							)
+						}
+						if (config[0] === "AUTOCOMPLETE") {
+							const enabled =
+								experiments[EXPERIMENT_IDS[config[0] as keyof typeof EXPERIMENT_IDS]] ?? false
+							return (
+								<>
+									<ExperimentalFeature
+										key={config[0]}
+										experimentKey={config[0]}
+										enabled={enabled}
+										onChange={(enabled) =>
+											setExperimentEnabled(
+												EXPERIMENT_IDS[config[0] as keyof typeof EXPERIMENT_IDS],
+												enabled,
+											)
+										}
+									/>
+									{enabled && <AutocompletePromptSettings />}
+								</>
 							)
 						}
 						return (

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -200,6 +200,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 		systemNotificationsEnabled, // kilocode_change
 		alwaysAllowFollowupQuestions,
 		followupAutoApproveTimeoutMs,
+		autocompleteApiConfigId, // kilocode_change
 	} = cachedState
 
 	const apiConfiguration = useMemo(() => cachedState.apiConfiguration ?? {}, [cachedState.apiConfiguration])
@@ -368,6 +369,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 			vscode.postMessage({ type: "alwaysAllowModeSwitch", bool: alwaysAllowModeSwitch })
 			vscode.postMessage({ type: "alwaysAllowSubtasks", bool: alwaysAllowSubtasks })
 			vscode.postMessage({ type: "showTaskTimeline", bool: showTaskTimeline }) // kilocode_change
+			vscode.postMessage({ type: "autocompleteApiConfigId", text: autocompleteApiConfigId }) // kilocode_change
 			vscode.postMessage({ type: "alwaysAllowFollowupQuestions", bool: alwaysAllowFollowupQuestions })
 			vscode.postMessage({ type: "followupAutoApproveTimeoutMs", value: followupAutoApproveTimeoutMs })
 			vscode.postMessage({ type: "condensingApiConfigId", text: condensingApiConfigId || "" })

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -122,6 +122,8 @@ export interface ExtensionStateContextType extends ExtensionState {
 	setEnhancementApiConfigId: (value: string) => void
 	commitMessageApiConfigId?: string // kilocode_change
 	setCommitMessageApiConfigId: (value: string) => void // kilocode_change
+	autocompleteApiConfigId?: string // kilocode_change
+	setAutocompleteApiConfigId: (value: string) => void // kilocode_change
 	setExperimentEnabled: (id: ExperimentId, enabled: boolean) => void
 	setAutoApprovalEnabled: (value: boolean) => void
 	customModes: ModeConfig[]
@@ -206,6 +208,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		experiments: experimentDefault,
 		enhancementApiConfigId: "",
 		commitMessageApiConfigId: "", // kilocode_change
+		autocompleteApiConfigId: "", // kilocode_change
 		condensingApiConfigId: "", // Default empty string for condensing API config ID
 		customCondensingPrompt: "", // Default empty string for custom condensing prompt
 		hasOpenedModeSelector: false, // Default to false (not opened yet)
@@ -474,6 +477,8 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setEnhancementApiConfigId: (value) =>
 			setState((prevState) => ({ ...prevState, enhancementApiConfigId: value })),
 		// kilocode_change start
+		setAutocompleteApiConfigId: (value) =>
+			setState((prevState) => ({ ...prevState, autocompleteApiConfigId: value })),
 		setCommitMessageApiConfigId: (value) =>
 			setState((prevState) => ({ ...prevState, commitMessageApiConfigId: value })),
 		setShowAutoApproveMenu: (value) => setState((prevState) => ({ ...prevState, showAutoApproveMenu: value })),


### PR DESCRIPTION
## Context

Having only `google/gemini-2.5-flash-preview-05-20` is quite limited.
Added a way for users to select a profile for autocomplete so the user can choose the provider and the model he wants.

## Implementation

Added a new configuration item `autocompleteApiConfigId` that helps keep track of the selected profile to use for autocomplete.

## Screenshots

<img width="383" alt="image" src="https://github.com/user-attachments/assets/044022f1-f7ab-45d3-a06e-cc7f72572dc6" />

## How to Test

- Checkout this PR, run the extension.
- Go to experimental settings and select "Use experimental "autocomplete" feature"
- You should see the form to select the profile you want to use for autocomplete

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
