### PR TITLE
feat(commit-message): Improve progress bar for commit message generation

### DIFF
--- a/.changeset/tall-weeks-grin.md
+++ b/.changeset/tall-weeks-grin.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Improve the progress bar during commit message generation

--- a/src/services/commit-message/__tests__/CommitMessageProvider.test.ts
+++ b/src/services/commit-message/__tests__/CommitMessageProvider.test.ts
@@ -110,7 +110,10 @@ describe("CommitMessageProvider", () => {
 
 			expect(vi.mocked(mockGitService.gatherChanges)).toHaveBeenCalledWith({ staged: true })
 			expect(vi.mocked(mockGitService.gatherChanges)).toHaveBeenCalledTimes(1)
-			expect(vi.mocked(mockGitService.getCommitContext)).toHaveBeenCalledWith(mockChanges, { staged: true })
+			expect(vi.mocked(mockGitService.getCommitContext)).toHaveBeenCalledWith(
+				mockChanges,
+				expect.objectContaining({ staged: true }),
+			)
 			expect(singleCompletionHandler).toHaveBeenCalled()
 			expect(vi.mocked(mockGitService.setCommitMessage)).toHaveBeenCalled()
 		})
@@ -166,9 +169,12 @@ describe("CommitMessageProvider", () => {
 
 			expect(vi.mocked(mockGitService.gatherChanges)).toHaveBeenCalledWith({ staged: true })
 			expect(vi.mocked(mockGitService.gatherChanges)).toHaveBeenCalledWith({ staged: false })
-			expect(vi.mocked(mockGitService.getCommitContext)).toHaveBeenCalledWith(mockUnstagedChanges, {
-				staged: false,
-			})
+			expect(vi.mocked(mockGitService.getCommitContext)).toHaveBeenCalledWith(
+				mockUnstagedChanges,
+				expect.objectContaining({
+					staged: false,
+				}),
+			)
 			expect(singleCompletionHandler).toHaveBeenCalled()
 			expect(vi.mocked(mockGitService.setCommitMessage)).toHaveBeenCalled()
 			expect(vscode.window.showInformationMessage).toHaveBeenCalledWith("commitMessage.generatingFromUnstaged")

--- a/src/services/commit-message/__tests__/GitExtensionService.spec.ts
+++ b/src/services/commit-message/__tests__/GitExtensionService.spec.ts
@@ -40,7 +40,7 @@ describe("GitExtensionService", () => {
 	})
 
 	describe("getDiffForChanges", () => {
-		it("should generate diffs per file and exclude files properly for staged changes", () => {
+		it("should generate diffs per file and exclude files properly for staged changes", async () => {
 			const stagedFiles = ["src/test.ts", "package-lock.json", "src/utils.ts"]
 			const mockFileListOutput = stagedFiles.join("\n")
 
@@ -53,7 +53,7 @@ describe("GitExtensionService", () => {
 				.mockReturnValueOnce({ status: 0, stdout: utilsTsDiff, stderr: "", error: null })
 
 			const getDiffForChanges = (service as any).getDiffForChanges
-			const result = getDiffForChanges.call(service, { staged: true })
+			const result = await getDiffForChanges.call(service, { staged: true })
 
 			expect(mockSpawnSync).toHaveBeenNthCalledWith(
 				1,
@@ -87,17 +87,17 @@ describe("GitExtensionService", () => {
 			expect(result).toBe(`${testTsDiff}\n${utilsTsDiff}`)
 		})
 
-		it("should return empty string when no staged files", () => {
+		it("should return empty string when no staged files", async () => {
 			mockSpawnSync.mockReturnValue({ status: 0, stdout: "", stderr: "", error: null })
 
 			const getDiffForChanges = (service as any).getDiffForChanges
-			const result = getDiffForChanges.call(service, { staged: true })
+			const result = await getDiffForChanges.call(service, { staged: true })
 
 			expect(result).toBe("")
 			expect(mockSpawnSync).toHaveBeenCalledTimes(1)
 		})
 
-		it("should handle file paths with special characters", () => {
+		it("should handle file paths with special characters", async () => {
 			const stagedFiles = ["src/file with spaces.ts", "src/file'with'quotes.ts"]
 			const mockFileListOutput = stagedFiles.join("\n")
 			const spaceDiff = "diff --git a/src/file with spaces.ts b/src/file with spaces.ts\n+content"
@@ -109,7 +109,7 @@ describe("GitExtensionService", () => {
 				.mockReturnValueOnce({ status: 0, stdout: quoteDiff, stderr: "", error: null })
 
 			const getDiffForChanges = (service as any).getDiffForChanges
-			const result = getDiffForChanges.call(service, { staged: true })
+			const result = await getDiffForChanges.call(service, { staged: true })
 
 			// Should handle file paths with special characters without manual escaping
 			expect(mockSpawnSync).toHaveBeenNthCalledWith(
@@ -177,7 +177,7 @@ describe("GitExtensionService", () => {
 		})
 	})
 
-	it("should generate diffs per file and exclude files properly for unstaged changes", () => {
+	it("should generate diffs per file and exclude files properly for unstaged changes", async () => {
 		const unstagedFiles = ["src/test.ts", "package-lock.json", "src/utils.ts"]
 		const mockFileListOutput = unstagedFiles.join("\n")
 
@@ -190,7 +190,7 @@ describe("GitExtensionService", () => {
 			.mockReturnValueOnce({ status: 0, stdout: utilsTsDiff, stderr: "", error: null })
 
 		const getDiffForChanges = (service as any).getDiffForChanges
-		const result = getDiffForChanges.call(service, { staged: false })
+		const result = await getDiffForChanges.call(service, { staged: false })
 
 		expect(mockSpawnSync).toHaveBeenNthCalledWith(1, "git", ["diff", "--name-only"], expect.any(Object))
 
@@ -202,18 +202,18 @@ describe("GitExtensionService", () => {
 		expect(result).toBe(`${testTsDiff}\n${utilsTsDiff}`)
 	})
 
-	it("should return empty string when no unstaged files", () => {
+	it("should return empty string when no unstaged files", async () => {
 		mockSpawnSync.mockReturnValue({ status: 0, stdout: "", stderr: "", error: null })
 
 		const getDiffForChanges = (service as any).getDiffForChanges
-		const result = getDiffForChanges.call(service, { staged: false })
+		const result = await getDiffForChanges.call(service, { staged: false })
 
 		expect(result).toBe("")
 		expect(mockSpawnSync).toHaveBeenCalledTimes(1)
 	})
 
 	describe("getCommitContext", () => {
-		it("should generate context for staged changes by default", () => {
+		it("should generate context for staged changes by default", async () => {
 			const mockChanges = [{ filePath: "file1.ts", status: "Modified" }]
 
 			mockSpawnSync
@@ -223,13 +223,13 @@ describe("GitExtensionService", () => {
 				.mockReturnValueOnce({ status: 0, stdout: "main", stderr: "", error: null })
 				.mockReturnValueOnce({ status: 0, stdout: "abc123 commit", stderr: "", error: null })
 
-			const result = service.getCommitContext(mockChanges, { staged: true })
+			const result = await service.getCommitContext(mockChanges, { staged: true })
 
 			expect(result).toContain("Full Diff of Staged Changes")
 			expect(result).not.toContain("Full Diff of Unstaged Changes")
 		})
 
-		it("should generate context for unstaged changes when specified", () => {
+		it("should generate context for unstaged changes when specified", async () => {
 			const mockChanges = [{ filePath: "file1.ts", status: "Modified" }]
 
 			mockSpawnSync
@@ -239,7 +239,7 @@ describe("GitExtensionService", () => {
 				.mockReturnValueOnce({ status: 0, stdout: "main", stderr: "", error: null })
 				.mockReturnValueOnce({ status: 0, stdout: "abc123 commit", stderr: "", error: null })
 
-			const result = service.getCommitContext(mockChanges, { staged: false })
+			const result = await service.getCommitContext(mockChanges, { staged: false })
 
 			expect(result).toContain("Full Diff of Unstaged Changes")
 			expect(result).not.toContain("Full Diff of Staged Changes")

--- a/src/services/commit-message/__tests__/progress-reporting.spec.ts
+++ b/src/services/commit-message/__tests__/progress-reporting.spec.ts
@@ -1,0 +1,87 @@
+// Test to verify progress reporting functionality
+import { spawnSync } from "child_process"
+import type { Mock } from "vitest"
+import { GitExtensionService } from "../GitExtensionService"
+
+vi.mock("child_process", () => ({
+	spawnSync: vi.fn(),
+}))
+
+vi.mock("vscode", () => ({
+	workspace: {
+		workspaceFolders: [{ uri: { fsPath: "/test/workspace" } }],
+		createFileSystemWatcher: vi.fn(() => ({
+			onDidCreate: vi.fn(),
+			onDidChange: vi.fn(),
+			onDidDelete: vi.fn(),
+			dispose: vi.fn(),
+		})),
+	},
+	extensions: {
+		getExtension: vi.fn(),
+	},
+	env: {
+		clipboard: { writeText: vi.fn() },
+	},
+	window: { showInformationMessage: vi.fn() },
+	RelativePattern: vi.fn().mockImplementation((base, pattern) => ({ base, pattern })),
+}))
+
+const mockSpawnSync = spawnSync as Mock
+
+describe("Progress Reporting", () => {
+	let service: GitExtensionService
+
+	beforeEach(() => {
+		service = new GitExtensionService()
+		mockSpawnSync.mockClear()
+	})
+
+	it("should report progress during diff collection", async () => {
+		const progressCallback = vi.fn()
+		const stagedFiles = ["src/file1.ts", "src/file2.ts", "src/file3.ts"]
+		const mockFileListOutput = stagedFiles.join("\n")
+
+		// Mock git responses
+		mockSpawnSync
+			.mockReturnValueOnce({ status: 0, stdout: mockFileListOutput, stderr: "", error: null })
+			.mockReturnValueOnce({ status: 0, stdout: "diff1", stderr: "", error: null })
+			.mockReturnValueOnce({ status: 0, stdout: "diff2", stderr: "", error: null })
+			.mockReturnValueOnce({ status: 0, stdout: "diff3", stderr: "", error: null })
+
+		const getDiffForChanges = (service as any).getDiffForChanges
+		await getDiffForChanges.call(service, { staged: true, onProgress: progressCallback })
+
+		// Verify progress was reported for each file
+		expect(progressCallback).toHaveBeenCalledTimes(3)
+		expect(progressCallback.mock.calls[0][0]).toBeCloseTo(33.33, 1) // After first file (1/3 * 100)
+		expect(progressCallback.mock.calls[1][0]).toBeCloseTo(66.67, 1) // After second file (2/3 * 100)
+		expect(progressCallback.mock.calls[2][0]).toBe(100) // After third file (3/3 * 100)
+	})
+
+	it("should handle progress reporting with no files", async () => {
+		const progressCallback = vi.fn()
+		mockSpawnSync.mockReturnValue({ status: 0, stdout: "", stderr: "", error: null })
+
+		const getDiffForChanges = (service as any).getDiffForChanges
+		await getDiffForChanges.call(service, { staged: true, onProgress: progressCallback })
+
+		// No progress should be reported when there are no files
+		expect(progressCallback).not.toHaveBeenCalled()
+	})
+
+	it("should work without progress callback", async () => {
+		const stagedFiles = ["src/file1.ts"]
+		const mockFileListOutput = stagedFiles.join("\n")
+
+		mockSpawnSync
+			.mockReturnValueOnce({ status: 0, stdout: mockFileListOutput, stderr: "", error: null })
+			.mockReturnValueOnce({ status: 0, stdout: "diff1", stderr: "", error: null })
+
+		const getDiffForChanges = (service as any).getDiffForChanges
+		const result = await getDiffForChanges.call(service, { staged: true })
+
+		expect(result).toBe("diff1")
+		expect(mockSpawnSync).toHaveBeenCalledTimes(2)
+	})
+})


### PR DESCRIPTION
Enhance the commit message generation process by providing more granular progress updates. The progress bar now reflects the progress of collecting Git diffs, which can be a time-consuming step, and then updates again before the AI call.

Test plan: Manully verified

![2025-07-08 12 28 28](https://github.com/user-attachments/assets/46b2ad28-9f50-4026-a6f0-da49b7f620b9)