### PR TITLE
Fix i18n zh-CN, zh-TW and update translation mode to clearly specify the translation requirements for proper nouns

### DIFF
--- a/.changeset/clean-spiders-act.md
+++ b/.changeset/clean-spiders-act.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Improve Chinese translations

--- a/.kilocodemodes
+++ b/.kilocodemodes
@@ -14,7 +14,7 @@
 					}
 				]
 			],
-			"customInstructions": "When translating content:\n- Maintain consistent terminology across all translations\n- Respect the JSON structure of translation files\n- Consider context when translating UI strings\n- Watch for placeholders (like {{variable}}) and preserve them in translations\n- Be mindful of text length in UI elements when translating to languages that might require more characters\n- If you need context for a translation, use read_file to examine the components using these strings\n- Specifically "Kilo" "Kilo Code" and similar terms are project names and proper nouns and must remain unchanged in English translation"
+			"customInstructions": "When translating content:\n- Maintain consistent terminology across all translations\n- Respect the JSON structure of translation files\n- Consider context when translating UI strings\n- Watch for placeholders (like {{variable}}) and preserve them in translations\n- Be mindful of text length in UI elements when translating to languages that might require more characters\n- If you need context for a translation, use read_file to examine the components using these strings\n- Specifically "Kilo", "Kilo Code" and similar terms are project names and proper nouns and must remain unchanged in translations"
 		},
 		{
 			"slug": "test",

--- a/.kilocodemodes
+++ b/.kilocodemodes
@@ -14,7 +14,7 @@
 					}
 				]
 			],
-			"customInstructions": "When translating content:\n- Maintain consistent terminology across all translations\n- Respect the JSON structure of translation files\n- Consider context when translating UI strings\n- Watch for placeholders (like {{variable}}) and preserve them in translations\n- Be mindful of text length in UI elements when translating to languages that might require more characters\n- If you need context for a translation, use read_file to examine the components using these strings"
+			"customInstructions": "When translating content:\n- Maintain consistent terminology across all translations\n- Respect the JSON structure of translation files\n- Consider context when translating UI strings\n- Watch for placeholders (like {{variable}}) and preserve them in translations\n- Be mindful of text length in UI elements when translating to languages that might require more characters\n- If you need context for a translation, use read_file to examine the components using these strings\n- Specifically "Kilo" "Kilo Code" and similar terms are project names and proper nouns and must remain unchanged in English translation"
 		},
 		{
 			"slug": "test",

--- a/src/i18n/locales/zh-CN/kilocode.json
+++ b/src/i18n/locales/zh-CN/kilocode.json
@@ -43,16 +43,16 @@
 		"activated": "Kilo: 提交信息生成器已启动",
 		"gitNotFound": "⚠️ Git 仓库未找到或 git 不可用",
 		"gitInitError": "⚠️ Git 初始化错误：{{error}}",
-		"generating": "Kilo：正在生成提交信息...",
-		"noChanges": "Kilo：未发现可分析的更改",
+		"generating": "Kilo: 正在生成提交信息...",
+		"noChanges": "Kilo: 未发现可分析的更改",
 		"generated": "Kilo: 已生成提交信息！",
 		"generationFailed": "Kilo：生成提交信息失败：{{errorMessage}}",
 		"generatingFromUnstaged": "Kilo：使用未暂存的更改生成消息"
 	},
 	"autocomplete": {
 		"statusBar": {
-			"warning": "$(warning) KiloCode自动补全",
-			"enabled": "$(sparkle) KiloCode自动补全",
+			"warning": "$(warning) Kilo自动补全",
+			"enabled": "$(sparkle) Kilo自动补全",
 			"disabled": "$(circle-slash) Kilo自动补全已禁用",
 			"tooltip": {
 				"disabled": "Kilo自动补全（已禁用）",

--- a/src/i18n/locales/zh-CN/kilocode.json
+++ b/src/i18n/locales/zh-CN/kilocode.json
@@ -40,25 +40,25 @@
 		}
 	},
 	"commitMessage": {
-		"activated": "千行代码提交信息生成器已启动",
+		"activated": "Kilo: 提交信息生成器已启动",
 		"gitNotFound": "⚠️ Git 仓库未找到或 git 不可用",
 		"gitInitError": "⚠️ Git 初始化错误：{{error}}",
 		"generating": "Kilo：正在生成提交信息...",
-		"noChanges": "千米：未发现可分析的更改",
+		"noChanges": "Kilo：未发现可分析的更改",
 		"generated": "Kilo: 已生成提交信息！",
 		"generationFailed": "Kilo：生成提交信息失败：{{errorMessage}}",
 		"generatingFromUnstaged": "Kilo：使用未暂存的更改生成消息"
 	},
 	"autocomplete": {
 		"statusBar": {
-			"warning": "$(warning) 千米完成",
-			"enabled": "$(sparkle) 千米完成",
-			"disabled": "$(circle-slash) 公里已完成",
+			"warning": "$(warning) KiloCode自动补全",
+			"enabled": "$(sparkle) KiloCode自动补全",
+			"disabled": "$(circle-slash) Kilo自动补全已禁用",
 			"tooltip": {
-				"disabled": "千行代码自动补全（已禁用）",
+				"disabled": "Kilo自动补全（已禁用）",
 				"lastCompletion": "上一次完成：",
 				"sessionTotal": "会话总费用：",
-				"basic": "千行代码自动补全",
+				"basic": "Kilo自动补全",
 				"tokenError": "必须设置有效令牌才能使用自动完成功能",
 				"model": "模型："
 			},
@@ -67,6 +67,6 @@
 				"zero": "¥0.00"
 			}
 		},
-		"toggleMessage": "千米完成 {{status}}"
+		"toggleMessage": "Kilo自动补全 {{status}}"
 	}
 }

--- a/src/i18n/locales/zh-TW/kilocode.json
+++ b/src/i18n/locales/zh-TW/kilocode.json
@@ -40,33 +40,33 @@
 		}
 	},
 	"commitMessage": {
-		"activated": "代码提交消息生成器已激活",
+		"activated": "Kilo: 代码提交消息生成器已激活",
 		"gitNotFound": "⚠️ Git 仓库未找到或 git 不可用",
 		"gitInitError": "⚠️ Git 初始化错误：{{error}}",
 		"generating": "Kilo: 正在生成提交信息...",
-		"noChanges": "千羽: 未发现可供分析的变更",
+		"noChanges": "Kilo: 未发现可供分析的变更",
 		"generated": "Kilo：提交信息已生成！",
 		"generationFailed": "Kilo：无法生成提交信息：{{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: 使用未暂存的更改生成消息"
 	},
 	"autocomplete": {
 		"statusBar": {
-			"disabled": "$(circle-slash) 千字节已完成",
-			"enabled": "$(sparkle) 千米完成",
+			"disabled": "$(circle-slash) Kilo自动补全",
+			"enabled": "$(sparkle) Kilo自动补全",
 			"tooltip": {
-				"basic": "千行代码自动补全",
+				"basic": "Kilo自动补全",
 				"lastCompletion": "上次完成：",
-				"disabled": "Kilo Code 代码自动补全（已禁用）",
+				"disabled": "Kilo自动补全（已禁用）",
 				"sessionTotal": "会话总费用:",
 				"tokenError": "必须设置有效令牌才能使用自动完成功能",
 				"model": "模型："
 			},
-			"warning": "$(warning) 千字节完成",
+			"warning": "$(warning) Kilo自动补全",
 			"cost": {
 				"lessThanCent": "<$0.01",
 				"zero": "¥0.00"
 			}
 		},
-		"toggleMessage": "千米完成 {{status}}"
+		"toggleMessage": "Kilo自动补全 {{status}}"
 	}
 }


### PR DESCRIPTION
## Context

Fix the I8n Chinese translation issue and add a clarification requirement for the translation of proper nouns in translation mode

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
