### PR TITLE
when logging in on kilocode.ai, open specific page to open vscode

### DIFF
--- a/.changeset/mean-candies-rest.md
+++ b/.changeset/mean-candies-rest.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Minor improvement to login process for Kilocode provider

--- a/webview-ui/src/components/kilocode/helpers.ts
+++ b/webview-ui/src/components/kilocode/helpers.ts
@@ -1,7 +1,7 @@
 export function getKiloCodeBackendSignInUrl(uriScheme: string = "vscode", uiKind: string = "Desktop") {
 	const baseUrl = "https://kilocode.ai"
 	const source = uiKind === "Web" ? "web" : uriScheme
-	return `${baseUrl}/users/sign_in?source=${source}`
+	return `${baseUrl}/sign-in-to-editor?source=${source}`
 }
 
 export function getKiloCodeBackendSignUpUrl(uriScheme: string = "vscode", uiKind: string = "Desktop") {


### PR DESCRIPTION
instead of opening the profile page

That way when something goes wrong when opening vscode (or cursor, ..) we can more clearly communicate to the user what is happening