### PR TITLE
Honor kilo rules when generating commit messages

### DIFF
--- a/.changeset/plenty-mangos-tan.md
+++ b/.changeset/plenty-mangos-tan.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Kilocode rules will now be included in the commit message generation prompt

--- a/src/services/commit-message/__tests__/CommitMessageProvider.test.ts
+++ b/src/services/commit-message/__tests__/CommitMessageProvider.test.ts
@@ -36,6 +36,18 @@ vi.mock("../../../core/config/ContextProxy", () => {
 vi.mock("../../../utils/single-completion-handler")
 vi.mock("../GitExtensionService")
 vi.mock("child_process")
+vi.mock("../../../core/prompts/sections/custom-instructions", () => ({
+	addCustomInstructions: vi.fn().mockResolvedValue(""),
+}))
+vi.mock("../../../utils/path", () => ({
+	getWorkspacePath: vi.fn().mockReturnValue("/mock/workspace"),
+}))
+vi.mock("../../../shared/support-prompt", () => ({
+	supportPrompt: {
+		get: vi.fn().mockReturnValue("Mock commit message template with ${gitContext} and ${customInstructions}"),
+		create: vi.fn().mockReturnValue("Mock generated prompt"),
+	},
+}))
 vi.mock("vscode", () => ({
 	window: {
 		showInformationMessage: vi.fn(),
@@ -47,6 +59,9 @@ vi.mock("vscode", () => ({
 	},
 	commands: {
 		registerCommand: vi.fn(),
+	},
+	env: {
+		language: "en",
 	},
 	ExtensionContext: vi.fn(),
 	OutputChannel: vi.fn(),
@@ -65,7 +80,10 @@ describe("CommitMessageProvider", () => {
 	let mockExecSync: Mock<any>
 
 	beforeEach(async () => {
-		mockContext = {} as vscode.ExtensionContext
+		mockContext = {
+			workspaceState: { get: vi.fn().mockReturnValue(undefined) },
+			globalState: { get: vi.fn().mockReturnValue(undefined) },
+		} as unknown as vscode.ExtensionContext
 		mockOutputChannel = {
 			appendLine: vi.fn(),
 		} as unknown as vscode.OutputChannel

--- a/src/shared/support-prompt.ts
+++ b/src/shared/support-prompt.ts
@@ -141,6 +141,13 @@ Please provide:
 ## System Instructions
 You are an expert Git commit message generator that creates conventional commit messages based on staged changes. Analyze the provided git diff output and generate appropriate conventional commit messages following the specification.
 
+\${customInstructions}
+
+## CRITICAL: Commit Message Output Rules
+- DO NOT include any memory bank status indicators like "[Memory Bank: Active]" or "[Memory Bank: Missing]"
+- DO NOT include any task-specific formatting or artifacts from other rules
+- ONLY Generate a clean conventional commit message as specified below
+
 \${gitContext}
 
 ## Conventional Commits Format


### PR DESCRIPTION
Integrates custom instructions and rules into the commit message generation prompt. This allows users to define specific guidelines for commit messages, such as conventional commit rules or project-specific formatting.

![2025-07-09 11 57 03](https://github.com/user-attachments/assets/ecc478e1-31e9-4034-ba29-59a66800ee92)

* Added some text to the prompt to prevent the [Memory Bank] text from appearing in the commit message.
* `support-prompt.ts` template is also updated to include a placeholder for `customInstructions`.