### PR TITLE
feat(ui): Add tooltip to context window progress bar

### DIFF
--- a/.changeset/metal-pants-hear.md
+++ b/.changeset/metal-pants-hear.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Add tooltip showing the percentage used when hovering over the context window progress bar

--- a/webview-ui/src/components/chat/ContextWindowProgress.tsx
+++ b/webview-ui/src/components/chat/ContextWindowProgress.tsx
@@ -27,14 +27,7 @@ export const ContextWindowProgress = ({ contextWindow, contextTokens, maxTokens 
 	const { currentPercent: currentPercentRaw } = tokenDistribution
 	const { autoCondenseContextPercent } = useExtensionState()
 	const highlightNearLimit = currentPercentRaw >= 50
-	const tooltipContent = useMemo(() => {
-		const currentPercent = Math.round(currentPercentRaw)
-		if (highlightNearLimit) {
-			return t("kilocode:contextWindow.nearLimit", { currentPercent, autoCondenseContextPercent })
-		} else {
-			return t("kilocode:contextWindow.progress", { currentPercent, autoCondenseContextPercent })
-		}
-	}, [autoCondenseContextPercent, highlightNearLimit, currentPercentRaw, t])
+	const currentPercent = Math.round(currentPercentRaw)
 
 	return (
 		<TooltipProvider>
@@ -50,7 +43,11 @@ export const ContextWindowProgress = ({ contextWindow, contextTokens, maxTokens 
 					</div>
 				</TooltipTrigger>
 				<TooltipContent>
-					<div>{tooltipContent}</div>
+					<div>
+						{highlightNearLimit
+							? t("kilocode:contextWindow.nearLimit", { currentPercent, autoCondenseContextPercent })
+							: t("kilocode:contextWindow.progress", { currentPercent, autoCondenseContextPercent })}
+					</div>
 					<div>
 						{t("kilocode:contextWindow.willAutoCondense", {
 							autoCondenseContextPercent,

--- a/webview-ui/src/components/chat/ContextWindowProgress.tsx
+++ b/webview-ui/src/components/chat/ContextWindowProgress.tsx
@@ -2,9 +2,11 @@ import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
 import { formatLargeNumber } from "@/utils/format"
-import { calculateTokenDistribution } from "@/utils/model-utils"
+import { calculateTokenDistribution, TokenDistributionResult } from "@/utils/model-utils"
 import { KiloContextWindowProgressTokensUsed } from "../kilocode/chat/KiloContextWindowProgressTokensUsed"
 import { StandardTooltip } from "@/components/ui"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/tooltip"
+import { useExtensionState } from "@/context/ExtensionStateContext"
 
 interface ContextWindowProgressProps {
 	contextWindow: number
@@ -20,6 +22,57 @@ export const ContextWindowProgress = ({ contextWindow, contextTokens, maxTokens 
 		() => calculateTokenDistribution(contextWindow, contextTokens, maxTokens),
 		[contextWindow, contextTokens, maxTokens],
 	)
+
+	// kilocode_change start - ContextWindowProgressInner split from ContextWindowProgress to wrap with Tooltip
+	const { currentPercent: currentPercentRaw } = tokenDistribution
+	const { autoCondenseContextPercent } = useExtensionState()
+	const highlightNearLimit = currentPercentRaw >= 50
+	const tooltipContent = useMemo(() => {
+		const currentPercent = Math.round(currentPercentRaw)
+		if (highlightNearLimit) {
+			return t("kilocode:contextWindow.nearLimit", { currentPercent, autoCondenseContextPercent })
+		} else {
+			return t("kilocode:contextWindow.progress", { currentPercent, autoCondenseContextPercent })
+		}
+	}, [autoCondenseContextPercent, highlightNearLimit, currentPercentRaw, t])
+
+	return (
+		<TooltipProvider>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<div className="cursor-help flex flex-1 [&_*]:pointer-events-none">
+						<ContextWindowProgressInner
+							contextWindow={contextWindow}
+							contextTokens={contextTokens}
+							maxTokens={maxTokens}
+							tokenDistribution={tokenDistribution}
+						/>
+					</div>
+				</TooltipTrigger>
+				<TooltipContent>
+					<div>{tooltipContent}</div>
+					<div>
+						{t("kilocode:contextWindow.willAutoCondense", {
+							autoCondenseContextPercent,
+						})}
+					</div>
+				</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	)
+}
+type ContextWindowProgressInnerProps = {
+	tokenDistribution?: TokenDistributionResult
+} & ContextWindowProgressProps
+
+export const ContextWindowProgressInner = ({
+	contextWindow,
+	contextTokens,
+	tokenDistribution,
+}: ContextWindowProgressInnerProps) => {
+	const { t } = useTranslation()
+	if (!tokenDistribution) return null
+	// kilocode_change end - ContextWindowProgressInner split from ContextWindowProgress to wrap with Tooltip
 
 	// Destructure the values we need
 	const { currentPercent, reservedPercent, availableSize, reservedForOutput, availablePercent } = tokenDistribution
@@ -54,6 +107,8 @@ export const ContextWindowProgress = ({ contextWindow, contextTokens, maxTokens 
 		</div>
 	)
 
+	const highlightNearLimit = currentPercent >= 50 // kilocode_change
+
 	return (
 		<>
 			<div className="flex items-center gap-2 flex-1 whitespace-nowrap px-2">
@@ -68,7 +123,7 @@ export const ContextWindowProgress = ({ contextWindow, contextTokens, maxTokens 
 								style={{ width: `${currentPercent}%` }}
 								data-testid="context-tokens-used">
 								{/* Current tokens used - darkest */}
-								<KiloContextWindowProgressTokensUsed currentPercent={currentPercent} />
+								<KiloContextWindowProgressTokensUsed highlightNearLimit={highlightNearLimit} />
 							</div>
 
 							{/* Container for reserved tokens */}

--- a/webview-ui/src/components/kilocode/chat/KiloContextWindowProgressTokensUsed.tsx
+++ b/webview-ui/src/components/kilocode/chat/KiloContextWindowProgressTokensUsed.tsx
@@ -1,7 +1,10 @@
 import { cn } from "@/lib/utils"
 
-export function KiloContextWindowProgressTokensUsed({ currentPercent }: { currentPercent: number }) {
-	const highlightNearLimit = currentPercent >= 50 // kilocode_change
+interface KiloContextWindowProgressTokensUsedProps {
+	highlightNearLimit: boolean
+}
+
+export function KiloContextWindowProgressTokensUsed({ highlightNearLimit }: KiloContextWindowProgressTokensUsedProps) {
 	return (
 		<div
 			className={cn(

--- a/webview-ui/src/i18n/locales/ar/kilocode.json
+++ b/webview-ui/src/i18n/locales/ar/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "إلغاء",
 		"send": "إرسال",
 		"restoreAndSend": "استرجاع وإرسال"
+	},
+	"contextWindow": {
+		"progress": "{{currentPercent}}% من السياق المستخدم",
+		"nearLimit": "⚠️ اقتراب من حد السياق - تم استخدام {{currentPercent}}%",
+		"willAutoCondense": "(سيتم التكثيف تلقائيًا بنسبة {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/ca/kilocode.json
+++ b/webview-ui/src/i18n/locales/ca/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Cancel·lar",
 		"send": "Enviar",
 		"restoreAndSend": "Restaurar i Enviar"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ A punt d'assolir el límit de context - {{currentPercent}}% utilitzat",
+		"progress": "{{currentPercent}}% de context utilitzat",
+		"willAutoCondense": "(s'auto-condensarà al {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/cs/kilocode.json
+++ b/webview-ui/src/i18n/locales/cs/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Zrušit",
 		"send": "Odeslat",
 		"restoreAndSend": "Obnovit a odeslat"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ Blížíte se k limitu kontextu - využito {{currentPercent}}%",
+		"progress": "{{currentPercent}}% kontextu využito",
+		"willAutoCondense": "(automaticky zkondenzováno na {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/de/kilocode.json
+++ b/webview-ui/src/i18n/locales/de/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Abbrechen",
 		"send": "Senden",
 		"restoreAndSend": "Wiederherstellen & Senden"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ Kontextlimit fast erreicht - {{currentPercent}}% verwendet",
+		"progress": "{{currentPercent}}% des Kontextes genutzt",
+		"willAutoCondense": "(wird automatisch bei {{autoCondenseContextPercent}}% komprimiert)"
 	}
 }

--- a/webview-ui/src/i18n/locales/el/kilocode.json
+++ b/webview-ui/src/i18n/locales/el/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Ακύρωση",
 		"send": "Αποστολή",
 		"restoreAndSend": "Επαναφορά & Αποστολή"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ Πλησιάζει το όριο περιεχομένου - {{currentPercent}}% σε χρήση",
+		"progress": "{{currentPercent}}% του πλαισίου χρησιμοποιήθηκε",
+		"willAutoCondense": "(θα συμπυκνωθεί αυτόματα στο {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/en/kilocode.json
+++ b/webview-ui/src/i18n/locales/en/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Add Credit",
 		"lowBalance": "Your Kilo Code balance is low"
 	},
+	"contextWindow": {
+		"nearLimit": "⚠️ Nearing context limit - {{currentPercent}}% used",
+		"progress": "{{currentPercent}}% of context used",
+		"willAutoCondense": "(will auto-condense at {{autoCondenseContextPercent}}%)"
+	},
 	"notifications": {
 		"toolRequest": "Tool request waiting for approval",
 		"browserAction": "Browser action waiting for approval",

--- a/webview-ui/src/i18n/locales/es/kilocode.json
+++ b/webview-ui/src/i18n/locales/es/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Cancelar",
 		"send": "Enviar",
 		"restoreAndSend": "Restaurar y Enviar"
+	},
+	"contextWindow": {
+		"progress": "{{currentPercent}}% del contexto utilizado",
+		"nearLimit": "⚠️ Acercándose al límite de contexto - {{currentPercent}}% usado",
+		"willAutoCondense": "(se auto-condensará al {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/fil/kilocode.json
+++ b/webview-ui/src/i18n/locales/fil/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Kanselahin",
 		"send": "Ipadala",
 		"restoreAndSend": "Ibalik at Ipadala"
+	},
+	"contextWindow": {
+		"progress": "{{currentPercent}}% ng konteksto ang nagamit",
+		"nearLimit": "⚠️ Malapit nang maabot ang limit ng konteksto - {{currentPercent}}% ang nagamit na",
+		"willAutoCondense": "(awtomatikong magkokondensa sa {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/fr/kilocode.json
+++ b/webview-ui/src/i18n/locales/fr/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Annuler",
 		"send": "Envoyer",
 		"restoreAndSend": "Restaurer et Envoyer"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ Limite de contexte presque atteinte - {{currentPercent}}% utilisé",
+		"progress": "{{currentPercent}}% du contexte utilisé",
+		"willAutoCondense": "(s'auto-condensera à {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/hi/kilocode.json
+++ b/webview-ui/src/i18n/locales/hi/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "रद्द करें",
 		"send": "भेजें",
 		"restoreAndSend": "पुनर्स्थापित करें और भेजें"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ संदर्भ सीमा के पास - {{currentPercent}}% उपयोग किया गया है",
+		"progress": "{{currentPercent}}% संदर्भ का उपयोग किया गया",
+		"willAutoCondense": "({{autoCondenseContextPercent}}% पर स्वतः संघनित हो जाएगा)"
 	}
 }

--- a/webview-ui/src/i18n/locales/id/kilocode.json
+++ b/webview-ui/src/i18n/locales/id/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Batal",
 		"send": "Kirim",
 		"restoreAndSend": "Pulihkan & Kirim"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ Mendekati batas konteks - {{currentPercent}}% terpakai",
+		"progress": "{{currentPercent}}% dari konteks telah digunakan",
+		"willAutoCondense": "(akan secara otomatis diringkas pada {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/it/kilocode.json
+++ b/webview-ui/src/i18n/locales/it/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Annulla",
 		"send": "Invia",
 		"restoreAndSend": "Ripristina e Invia"
+	},
+	"contextWindow": {
+		"progress": "{{currentPercent}}% di contesto utilizzato",
+		"nearLimit": "⚠️ Limite di contesto quasi raggiunto - {{currentPercent}}% utilizzato",
+		"willAutoCondense": "(si auto-condensa al {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/ja/kilocode.json
+++ b/webview-ui/src/i18n/locales/ja/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "キャンセル",
 		"send": "送信",
 		"restoreAndSend": "復元して送信"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ コンテキスト制限に近づいています - {{currentPercent}}% 使用済み",
+		"progress": "コンテキストの{{currentPercent}}%を使用中",
+		"willAutoCondense": "({{autoCondenseContextPercent}}%で自動的に要約されます)"
 	}
 }

--- a/webview-ui/src/i18n/locales/ko/kilocode.json
+++ b/webview-ui/src/i18n/locales/ko/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "취소",
 		"send": "보내기",
 		"restoreAndSend": "복원 및 보내기"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ 컨텍스트 한도에 근접 - {{currentPercent}}% 사용됨",
+		"progress": "{{currentPercent}}% 컨텍스트 사용됨",
+		"willAutoCondense": "({{autoCondenseContextPercent}}%에서 자동 축소)"
 	}
 }

--- a/webview-ui/src/i18n/locales/nl/kilocode.json
+++ b/webview-ui/src/i18n/locales/nl/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Annuleren",
 		"send": "Verzenden",
 		"restoreAndSend": "Herstellen & Verzenden"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ Contextlimiet bijna bereikt - {{currentPercent}}% gebruikt",
+		"progress": "{{currentPercent}}% van de context gebruikt",
+		"willAutoCondense": "(wordt automatisch samengevat bij {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/pl/kilocode.json
+++ b/webview-ui/src/i18n/locales/pl/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Anuluj",
 		"send": "Wyślij",
 		"restoreAndSend": "Przywróć i Wyślij"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ Zbliżasz się do limitu kontekstu - wykorzystano {{currentPercent}}%",
+		"progress": "{{currentPercent}}% wykorzystanego kontekstu",
+		"willAutoCondense": "(automatycznie skondensowane przy {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/pt-BR/kilocode.json
+++ b/webview-ui/src/i18n/locales/pt-BR/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Cancelar",
 		"send": "Enviar",
 		"restoreAndSend": "Restaurar e Enviar"
+	},
+	"contextWindow": {
+		"progress": "{{currentPercent}}% do contexto utilizado",
+		"nearLimit": "⚠️ Aproximando-se do limite de contexto - {{currentPercent}}% utilizado",
+		"willAutoCondense": "(será condensado automaticamente em {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/ru/kilocode.json
+++ b/webview-ui/src/i18n/locales/ru/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Отмена",
 		"send": "Отправить",
 		"restoreAndSend": "Восстановить и отправить"
+	},
+	"contextWindow": {
+		"progress": "{{currentPercent}}% контекста использовано",
+		"nearLimit": "⚠️ Приближается предел контекста - использовано {{currentPercent}}%",
+		"willAutoCondense": "(автоматическое сжатие на {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/sv/kilocode.json
+++ b/webview-ui/src/i18n/locales/sv/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Avbryt",
 		"send": "Skicka",
 		"restoreAndSend": "Återställ & Skicka"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ Närmar sig kontextgräns - {{currentPercent}}% använt",
+		"progress": "{{currentPercent}}% av kontexten använd",
+		"willAutoCondense": "(kommer automatiskt att kondenseras vid {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/th/kilocode.json
+++ b/webview-ui/src/i18n/locales/th/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "ยกเลิก",
 		"send": "ส่ง",
 		"restoreAndSend": "คืนค่าและส่ง"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ ใกล้เต็มความจุบริบท - ใช้ไปแล้ว {{currentPercent}}%",
+		"progress": "ใช้บริบทไปแล้ว {{currentPercent}}%",
+		"willAutoCondense": "(จะย่อโดยอัตโนมัติที่ {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/tr/kilocode.json
+++ b/webview-ui/src/i18n/locales/tr/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "İptal",
 		"send": "Gönder",
 		"restoreAndSend": "Geri Yükle ve Gönder"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ Bağlam sınırına yaklaşılıyor - %{{currentPercent}} kullanıldı",
+		"progress": "Bağlamın {{currentPercent}}%'i kullanıldı",
+		"willAutoCondense": "(otomatik olarak %{{autoCondenseContextPercent}} oranında yoğunlaşacaktır)"
 	}
 }

--- a/webview-ui/src/i18n/locales/uk/kilocode.json
+++ b/webview-ui/src/i18n/locales/uk/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Скасувати",
 		"send": "Надіслати",
 		"restoreAndSend": "Відновити та надіслати"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ Наближення до ліміту контексту - використано {{currentPercent}}%",
+		"progress": "{{currentPercent}}% контексту використано",
+		"willAutoCondense": "(автоматично згорнеться на {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/vi/kilocode.json
+++ b/webview-ui/src/i18n/locales/vi/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "Hủy",
 		"send": "Gửi",
 		"restoreAndSend": "Khôi phục & Gửi"
+	},
+	"contextWindow": {
+		"progress": "{{currentPercent}}% ngữ cảnh đã sử dụng",
+		"nearLimit": "⚠️ Gần đạt giới hạn ngữ cảnh - đã sử dụng {{currentPercent}}%",
+		"willAutoCondense": "(sẽ tự động cô đọng ở mức {{autoCondenseContextPercent}}%)"
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-CN/kilocode.json
+++ b/webview-ui/src/i18n/locales/zh-CN/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "取消",
 		"send": "发送",
 		"restoreAndSend": "恢复并发送"
+	},
+	"contextWindow": {
+		"progress": "{{currentPercent}}% 的上下文已使用",
+		"nearLimit": "⚠️ 接近上下文限制 - 已使用 {{currentPercent}}%",
+		"willAutoCondense": "(将以 {{autoCondenseContextPercent}}% 自动压缩)"
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-TW/kilocode.json
+++ b/webview-ui/src/i18n/locales/zh-TW/kilocode.json
@@ -117,5 +117,10 @@
 		"editCancel": "取消",
 		"send": "發送",
 		"restoreAndSend": "恢復並發送"
+	},
+	"contextWindow": {
+		"nearLimit": "⚠️ 接近上下文限制 - 已使用{{currentPercent}}%",
+		"progress": "{{currentPercent}}% 的上下文已使用",
+		"willAutoCondense": "(将以{{autoCondenseContextPercent}}%自动缩减)"
 	}
 }


### PR DESCRIPTION
The tooltip displays the current context usage percentage and highlights when near the limit.

**Dev notes**
Splits `ContextWindowProgress` into `ContextWindowProgressInner` to wrap the component with a tooltip without causing too many conflicts

<img width="587" alt="image" src="https://github.com/user-attachments/assets/f89cbfb1-cc26-4e87-a3fe-32751c17c7c0" />
<img width="242" alt="image" src="https://github.com/user-attachments/assets/c7424a42-88b1-44ac-8af0-fa81a2768db8" />
