### PR TITLE
Add Simple ChatView Story

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -47,6 +47,12 @@ const config: StorybookConfig = {
 			"@src/utils/clipboard": resolve(currentDirname, "../src/mocks/utils"),
 			"@src/utils/highlighter": resolve(currentDirname, "../src/mocks/utils"),
 			"@src/i18n/TranslationContext": resolve(currentDirname, "../src/mocks/utils"),
+			"@roo/ProfileValidator": resolve(currentDirname, "../src/mocks/ProfileValidator"),
+		}
+
+		config.define = {
+			...config.define,
+			"process.env": {}, // Inject a dummy `process.env`
 		}
 
 		// Add Tailwind CSS plugin to process the webview-ui's CSS

--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -1,10 +1,11 @@
 import type { Preview } from "@storybook/react"
-import isChromatic from "chromatic/isChromatic"
 
 import { withExtensionState } from "../src/decorators/withExtensionState"
 import { withQueryClient } from "../src/decorators/withQueryClient"
 import { withTheme } from "../src/decorators/withTheme"
 import { withI18n } from "../src/decorators/withI18n"
+import { withTooltipProvider } from "../src/decorators/withTooltipProvider"
+import { withFixedContainment } from "../src/decorators/withFixedContainment"
 import { withChromaticDecorator } from "./ChromaticDecorator"
 
 import "./storybook.css"
@@ -44,7 +45,15 @@ const preview: Preview = {
 			},
 		},
 	},
-	decorators: [withI18n, withQueryClient, withExtensionState, withTheme, withChromaticDecorator],
+	decorators: [
+		withI18n,
+		withQueryClient,
+		withExtensionState,
+		withTheme,
+		withTooltipProvider,
+		withFixedContainment,
+		withChromaticDecorator,
+	],
 }
 
 export default preview

--- a/apps/storybook/src/decorators/withFixedContainment.tsx
+++ b/apps/storybook/src/decorators/withFixedContainment.tsx
@@ -1,0 +1,11 @@
+import type { Decorator } from "@storybook/react"
+
+// Wraps stories with an element that will "contain" any `position: fixed` elements
+// the `translate-0` is a noop, but causes any children to be contained in this element.
+export const withFixedContainment: Decorator = (Story) => {
+	return (
+		<div className="overflow-hidden translate-0">
+			<Story />
+		</div>
+	)
+}

--- a/apps/storybook/src/decorators/withTooltipProvider.tsx
+++ b/apps/storybook/src/decorators/withTooltipProvider.tsx
@@ -1,0 +1,10 @@
+import type { Decorator } from "@storybook/react"
+import { TooltipProvider } from "@/components/ui/tooltip"
+
+export const withTooltipProvider: Decorator = (Story) => {
+	return (
+		<TooltipProvider>
+			<Story />
+		</TooltipProvider>
+	)
+}

--- a/apps/storybook/src/mockData/clineMessages.ts
+++ b/apps/storybook/src/mockData/clineMessages.ts
@@ -278,7 +278,11 @@ export const createTaskHeaderMessages = (): ClineMessage[] => {
 		{
 			type: "say",
 			say: "api_req_started",
-			text: "Making API request to Claude...",
+			text: JSON.stringify({
+				cost: undefined, // API request in progress
+				provider: "anthropic",
+				model: "claude-3-sonnet-20240229",
+			}),
 		},
 		[500, 1000],
 	)

--- a/apps/storybook/src/mocks/ProfileValidator.ts
+++ b/apps/storybook/src/mocks/ProfileValidator.ts
@@ -1,0 +1,6 @@
+export class ProfileValidator {
+	static isProfileAllowed(apiConfiguration: any, organizationAllowList: any): boolean {
+		// Mock implementation for Storybook - always return true
+		return true
+	}
+}

--- a/apps/storybook/stories/ChatView.stories.tsx
+++ b/apps/storybook/stories/ChatView.stories.tsx
@@ -1,0 +1,104 @@
+// kilocode_change - new file
+import type { Meta, StoryObj } from "@storybook/react"
+import { fn } from "@storybook/test"
+
+import ChatView from "../../../webview-ui/src/components/chat/ChatView"
+import { createTaskHeaderMessages, createMockTask } from "../src/mockData/clineMessages"
+
+const meta = {
+	title: "Chat/ChatView",
+	component: ChatView,
+	tags: ["autodocs"],
+	argTypes: {
+		isHidden: {
+			control: "boolean",
+			description: "Whether the chat view is hidden",
+		},
+		showAnnouncement: {
+			control: "boolean",
+			description: "Whether to show the announcement banner",
+		},
+		hideAnnouncement: {
+			action: "hideAnnouncement",
+			description: "Function to hide the announcement",
+		},
+	},
+	args: {
+		isHidden: false,
+		showAnnouncement: false,
+		hideAnnouncement: fn(),
+	},
+	decorators: [
+		(Story) => (
+			<div className="min-h-[600px]">
+				<Story />
+			</div>
+		),
+	],
+} satisfies Meta<typeof ChatView>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: {
+		isHidden: false,
+		showAnnouncement: false,
+		hideAnnouncement: fn(),
+	},
+	parameters: {
+		extensionState: {
+			clineMessages: [createMockTask(), ...createTaskHeaderMessages()],
+			organizationAllowList: {
+				allowAll: true,
+				providers: {},
+			},
+			currentTaskItem: {
+				id: "task-1",
+				ts: Date.now(),
+				task: "Create a React component with TypeScript",
+				tokensIn: 1250,
+				tokensOut: 850,
+				cacheWrites: 45,
+				cacheReads: 120,
+				totalCost: 0.15,
+				conversationStats: {
+					messagesTotal: 12,
+					messagesEnvironment: 3,
+					messagesUser: 2,
+					messagesAssistant: 7,
+				},
+			},
+			taskHistory: [
+				{
+					id: "task-1",
+					ts: Date.now() - 3600000,
+					task: "Previous completed task",
+					tokensIn: 800,
+					tokensOut: 600,
+					cacheWrites: 20,
+					cacheReads: 80,
+					totalCost: 0.08,
+					conversationStats: {
+						messagesTotal: 8,
+						messagesEnvironment: 2,
+						messagesUser: 1,
+						messagesAssistant: 5,
+					},
+				},
+			],
+			apiConfiguration: {
+				apiProvider: "anthropic",
+				apiModelId: "claude-3-5-sonnet-20241022",
+				apiKey: "mock-key",
+			},
+			mcpServers: [],
+			allowedCommands: [],
+			mode: "code",
+			customModes: [],
+			gitCommits: [],
+			openedTabs: [{ path: "src/components/ChatView.tsx", isDirty: false }],
+			filePaths: ["src/components/ChatView.tsx", "package.json", "README.md"],
+		},
+	},
+}


### PR DESCRIPTION
This will give us a good base to add new designs for the queued messages / design improvements going forward!

**Dev notes**
I added a few Decorators to make it appear nicely in Storybook. Since the ChatView is `fixed` positioning, I had to add a special semi-hacky wrapper to properly "contain" it within the Storybook page

![image](https://github.com/user-attachments/assets/b96a1d56-9ee6-45d9-a6f2-67325508222c)
