### PR TITLE
Fix the Playwright type error blocking the Changeset Release

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -41,6 +41,11 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Type check Playwright E2E
+              run: |
+                  cd apps/playwright-e2e
+                  pnpm check-types
+
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
 

--- a/apps/playwright-e2e/tests/chat-with-response.test.ts
+++ b/apps/playwright-e2e/tests/chat-with-response.test.ts
@@ -1,4 +1,4 @@
-import { test } from "./playwright-base-test"
+import { test, type TestFixtures } from "./playwright-base-test"
 import {
 	verifyExtensionInstalled,
 	waitForWebviewText,
@@ -7,7 +7,7 @@ import {
 } from "../helpers/webview-helpers"
 
 test.describe("Full E2E Test", () => {
-	test("should configure credentials and send a message", async ({ workbox: page }) => {
+	test("should configure credentials and send a message", async ({ workbox: page }: TestFixtures) => {
 		await verifyExtensionInstalled(page)
 
 		await waitForWebviewText(page, "Welcome to Kilo Code!")

--- a/apps/playwright-e2e/tsconfig.json
+++ b/apps/playwright-e2e/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "@roo-code/config-typescript/base.json",
 	"compilerOptions": {
 		"module": "ESNext",
-		"moduleResolution": "Node",
+		"moduleResolution": "Bundler",
 		"target": "ES2022",
 		"lib": ["ES2022", "ESNext.Disposable", "DOM"],
 		"sourceMap": true,


### PR DESCRIPTION
Adds a type checking step for the Playwright E2E application in the CI workflow. This helps catch type-related issues earlier.

Also updates module resolution and imports in Playwright E2E files to use NodeNext which fixes the error happening in the changeset-pr-version-bump: https://github.com/Kilo-Org/kilocode/actions/runs/16181387470/job/45678597375

