### PR TITLE
fix: remove double colon typo in Automated Refactoring feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 - **Code Generation:** Generate code using natural language.
 - **Task Automation:** Automate repetitive coding tasks.
-- **Automated Refactoring:**: Refactor and improve existing code.
+- **Automated Refactoring:** Refactor and improve existing code.
 - **MCP Server Marketplace**: Easily find, and use MCP servers to extend the agent capabilities.
 - **Multi Mode**: Plan with Architect, Code with Coder, and Debug with Debugger, and make your own custom modes.
 


### PR DESCRIPTION
## Context

This PR fixes a minor typo in the `readme.md` file under the "Key Features" section. The typo was an extra colon in the "Automated Refactoring" bullet point.

## Implementation

- Removed the double colon (`::`) after "**Automated Refactoring:**" so it now reads correctly.
- No code or logic changes—documentation only.

## Screenshots

| before | after |
| ------ | ----- |
| **Automated Refactoring:**: Refactor and improve existing code. | **Automated Refactoring:** Refactor and improve existing code. |

## How to Test

- Open `temp/readme.md`
- Scroll to the "Key Features" section
- Confirm that the "Automated Refactoring" bullet point no longer has a double colon
