### PR TITLE
Continue to show commit message generation progress while waiting for LLM response

### DIFF
--- a/.changeset/bitter-grapes-double.md
+++ b/.changeset/bitter-grapes-double.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Continue to show commit message generation progress while waiting for LLM response

--- a/src/services/commit-message/CommitMessageProvider.ts
+++ b/src/services/commit-message/CommitMessageProvider.ts
@@ -9,6 +9,7 @@ import { t } from "../../i18n"
 import { addCustomInstructions } from "../../core/prompts/sections/custom-instructions"
 import { getWorkspacePath } from "../../utils/path"
 import type { ProviderSettings } from "@roo-code/types"
+import delay from "delay"
 
 /**
  * Provides AI-powered commit message generation for source control management.
@@ -140,7 +141,14 @@ export class CommitMessageProvider {
 		}, 100)
 
 		try {
-			return await this.callAIForCommitMessage(gitContextString)
+			const message = await this.callAIForCommitMessage(gitContextString)
+
+			// Now, animate the bar to 100% to make it look nicer :)
+			for (let i = 0; i < maxProgress - totalProgressUsed; i++) {
+				progress.report({ increment: 1 })
+				await delay(25)
+			}
+			return message
 		} finally {
 			clearInterval(progressInterval) // Always clear when done
 		}

--- a/src/services/commit-message/CommitMessageProvider.ts
+++ b/src/services/commit-message/CommitMessageProvider.ts
@@ -99,16 +99,13 @@ export class CommitMessageProvider {
 						staged,
 						onProgress: onDiffProgress,
 					})
-					progress.report({ increment: 10, message: t("kilocode:commitMessage.generating") })
 
-					const generatedMessage = await this.callAIForCommitMessage(gitContextString)
-					this.gitService.setCommitMessage(generatedMessage)
+					const generatedMessage = await this.callAIForCommitMessageWithProgress(gitContextString, progress)
 
 					// Store the current context and message for future reference
 					this.previousGitContext = gitContextString
 					this.previousCommitMessage = generatedMessage
-
-					progress.report({ increment: 10, message: t("kilocode:commitMessage.generated") })
+					this.gitService.setCommitMessage(generatedMessage)
 				} catch (error) {
 					const errorMessage = error instanceof Error ? error.message : "Unknown error occurred"
 					vscode.window.showErrorMessage(t("kilocode:commitMessage.generationFailed", { errorMessage }))
@@ -116,6 +113,37 @@ export class CommitMessageProvider {
 				}
 			},
 		)
+	}
+
+	private async callAIForCommitMessageWithProgress(
+		gitContextString: string,
+		progress: vscode.Progress<{ increment?: number; message?: string }>,
+	): Promise<string> {
+		let totalProgressUsed = 0
+		const maxProgress = 20 // We have 20% reserved for AI processing
+		const maxIncrement = 1.0 // Start with bigger increments
+		const minIncrement = 0.05 // Minimum increment to keep progress moving
+
+		// Start interval timer to update the progress while we wait for the reponse
+		// Use exponential decay: start with larger increments, decrease as we approach the limit
+		// Formula: increment = remainingProgress^2 * maxIncrement + minIncrement
+		const progressInterval = setInterval(() => {
+			const remainingProgress = (maxProgress - totalProgressUsed) / maxProgress // percentage (0 to 1)
+
+			const incrementLimited = Math.max(
+				remainingProgress * remainingProgress * maxIncrement + minIncrement,
+				minIncrement,
+			)
+			const increment = Math.min(incrementLimited, maxProgress - totalProgressUsed)
+			progress.report({ increment: increment, message: t("kilocode:commitMessage.generating") })
+			totalProgressUsed += increment
+		}, 100)
+
+		try {
+			return await this.callAIForCommitMessage(gitContextString)
+		} finally {
+			clearInterval(progressInterval) // Always clear when done
+		}
 	}
 
 	/**


### PR DESCRIPTION
Previously, the progress bar would "freeze" in place while we waited for the response from the AI, and now we increment it while we wait for the response, so progress never looks like it stops entirely.

![2025-07-10 17 43 22](https://github.com/user-attachments/assets/70661c30-5753-491c-a931-df7a9147bf64)

