### PR TITLE
Fix fetch openrouter models on autocomplete api initialization

### DIFF
--- a/.changeset/clever-parts-win.md
+++ b/.changeset/clever-parts-win.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix autocomplete init with custom openrouter models

--- a/src/services/autocomplete/AutocompleteProvider.ts
+++ b/src/services/autocomplete/AutocompleteProvider.ts
@@ -17,6 +17,7 @@ import { AutocompleteStatusBar } from "./AutocompleteStatusBar"
 import { ProviderSettingsManager } from "../../core/config/ProviderSettingsManager"
 import { getAutocompleteConfiguration } from "./utils/autocompleteConfig"
 import { t } from "../../i18n"
+import { OpenRouterHandler } from "../../api/providers"
 
 export const UI_UPDATE_DEBOUNCE_MS = 250
 export const BAIL_OUT_TOO_MANY_LINES_LIMIT = 100
@@ -92,6 +93,9 @@ function setupAutocomplete(context: vscode.ExtensionContext): vscode.Disposable 
 		try {
 			const autocompleteConfig = await getAutocompleteConfiguration(providerSettingsManager)
 			apiHandler = autocompleteConfig ? buildApiHandler(autocompleteConfig) : null
+			if (apiHandler instanceof OpenRouterHandler) {
+				await apiHandler.fetchModel()
+			}
 		} catch (error) {
 			console.warn("Failed to update autocomplete API handler:", error)
 			apiHandler = null


### PR DESCRIPTION
## Context

- The openrouter providers require fetch the available models

## Implementation

- Imports OpenRouterHandler and conditionally calls fetchModel() on setup.

## Screenshots

<img width="853" height="352" alt="image" src="https://github.com/user-attachments/assets/89909189-b019-427b-8016-81b4c6375e14" />

## How to Test

- Configure a profile with a openrouter provider and a non standard model like `codestral`
- Select this profile for the Autocomplete feature
- Check the status bar 
