### PR TITLE
Allow canceling / reverting prompt enhancement

### DIFF
--- a/.changeset/old-socks-decide.md
+++ b/.changeset/old-socks-decide.md
@@ -1,0 +1,8 @@
+---
+"kilo-code": minor
+---
+
+Support for canceling / reverting the 'enhance prompt' action
+
+Now, clicking the enhance prompt button while it loads will cancel the enhancement.
+Once the prompt has been enhanced, the button will become a revert button, which returns the prompt to it's original text.

--- a/apps/playwright-e2e/helpers/enhance-prompt-helpers.ts
+++ b/apps/playwright-e2e/helpers/enhance-prompt-helpers.ts
@@ -1,0 +1,47 @@
+import { type Page, expect } from "@playwright/test"
+import { findWebview } from "./webview-helpers"
+
+export type EnhanceButtonState = "enhance" | "cancel" | "revert"
+
+const ENHANCE_BUTTON_LABELS = {
+	enhance: "Enhance prompt with additional context",
+	cancel: "Cancel enhancement",
+	revert: "Revert to original prompt",
+} as const
+
+export async function getEnhanceButton(page: Page) {
+	const webviewFrame = await findWebview(page)
+	const enhanceButton = webviewFrame.locator('[data-testid="enhance-prompt-button"]')
+	await enhanceButton.waitFor({ timeout: 10000 })
+	return enhanceButton
+}
+
+export async function waitForEnhanceButtonState(
+	page: Page,
+	state: EnhanceButtonState,
+	timeout: number = 30000,
+): Promise<void> {
+	const enhanceButton = await getEnhanceButton(page)
+	const expectedLabel = ENHANCE_BUTTON_LABELS[state]
+	await expect(enhanceButton).toHaveAttribute("aria-label", expectedLabel, { timeout })
+}
+
+export async function clickEnhanceButton(
+	page: Page,
+	waitForState?: EnhanceButtonState,
+	timeout?: number,
+): Promise<void> {
+	const enhanceButton = await getEnhanceButton(page)
+	await enhanceButton.click()
+
+	if (waitForState) {
+		await waitForEnhanceButtonState(page, waitForState, timeout)
+	}
+}
+
+export async function verifyEnhanceButtonReady(page: Page): Promise<void> {
+	const enhanceButton = await getEnhanceButton(page)
+	await expect(enhanceButton).toHaveAttribute("aria-label", ENHANCE_BUTTON_LABELS.enhance)
+	await expect(enhanceButton).toBeVisible()
+	await expect(enhanceButton).toBeEnabled()
+}

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -681,29 +681,31 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				}
 			},
 			[
-				showSlashCommandsMenu, // kilocode_change
 				sendingDisabled,
+				onSend,
 				showContextMenu,
-				selectedSlashCommandsIndex,
-				slashCommandsQuery,
-				handleSlashCommandsSelect,
-				selectedMenuIndex,
 				searchQuery,
-				inputValue,
+				selectedMenuIndex,
+				handleMentionSelect,
 				selectedType,
+				inputValue,
+				cursorPosition,
+				setInputValue,
+				justDeletedSpaceAfterMention,
 				queryItems,
 				allModes,
 				fileSearchResults,
 				handleHistoryNavigation,
 				resetHistoryNavigation,
-				cursorPosition,
-				customModes,
-				handleMentionSelect,
-				justDeletedSpaceAfterMention,
-				onSend,
-				setInputValue,
-				localWorkflows, // kilocode_change
-				globalWorkflows, // kilocode_change
+				// kilocode_change start
+				customModes, // kilo
+				globalWorkflows, // kilo
+				handleSlashCommandsSelect, // kilo
+				localWorkflows, // kilo
+				selectedSlashCommandsIndex, // kilo
+				showSlashCommandsMenu, // kilo
+				slashCommandsQuery, // kilo
+				// kilocode_change end
 			],
 		)
 

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -728,8 +728,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				resetOnInputChange()
 
 				const newCursorPosition = e.target.selectionStart
-				setInputValue(newValue) // kilocode_change
 				setCursorPosition(newCursorPosition)
+
 				// kilocode_change start: pull slash commands from Cline
 				let showMenu = shouldShowContextMenu(newValue, newCursorPosition)
 				const showSlashCommandsMenu = shouldShowSlashCommandsMenu(newValue, newCursorPosition)

--- a/webview-ui/src/i18n/locales/ar/kilocode.json
+++ b/webview-ui/src/i18n/locales/ar/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code يقترح تلخيص المحادثة",
 			"condenseConversation": "تلخيص المحادثة"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "إلغاء التحسين",
+			"revertEnhancement": "الرجوع إلى المطالبة الأصلية"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/ca/kilocode.json
+++ b/webview-ui/src/i18n/locales/ca/kilocode.json
@@ -57,6 +57,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code vol condensar la teva conversa",
 			"condenseConversation": "Condensar Conversa"
+		},
+		"enhancePrompt": {
+			"revertEnhancement": "Tornar a l'indicador original",
+			"cancelEnhancement": "Cancel·lar millora"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/cs/kilocode.json
+++ b/webview-ui/src/i18n/locales/cs/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code chce zkrátit tvou konverzaci",
 			"condenseConversation": "Zkrátit konverzaci"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "Zrušit vylepšení",
+			"revertEnhancement": "Vrátit se k původnímu zadání"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/de/kilocode.json
+++ b/webview-ui/src/i18n/locales/de/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code möchte deine Unterhaltung zusammenfassen",
 			"condenseConversation": "Unterhaltung zusammenfassen"
+		},
+		"enhancePrompt": {
+			"revertEnhancement": "Zum ursprünglichen Prompt zurückkehren",
+			"cancelEnhancement": "Verbesserung abbrechen"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/en/kilocode.json
+++ b/webview-ui/src/i18n/locales/en/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code wants to condense your conversation",
 			"condenseConversation": "Condense Conversation"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "Cancel enhancement",
+			"revertEnhancement": "Revert to original prompt"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/es/kilocode.json
+++ b/webview-ui/src/i18n/locales/es/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code quiere condensar tu conversación",
 			"condenseConversation": "Condensar Conversación"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "Cancelar mejora",
+			"revertEnhancement": "Volver al mensaje original"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/fr/kilocode.json
+++ b/webview-ui/src/i18n/locales/fr/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code souhaite condenser votre conversation",
 			"condenseConversation": "Condenser la Conversation"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "Annuler l'amélioration",
+			"revertEnhancement": "Revenir à l'invite originale"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/hi/kilocode.json
+++ b/webview-ui/src/i18n/locales/hi/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code तुम्हारी बातचीत को संक्षिप्त करना चाहता है",
 			"condenseConversation": "बातचीत संक्षिप्त करें"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "वृद्धि रद्द करें",
+			"revertEnhancement": "मूल प्रॉम्प्ट पर वापस जाएँ"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/id/kilocode.json
+++ b/webview-ui/src/i18n/locales/id/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code ingin mengondensasi percakapan kamu",
 			"condenseConversation": "Kondensasi Percakapan"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "Batalkan peningkatan",
+			"revertEnhancement": "Kembalikan ke prompt asli"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/it/kilocode.json
+++ b/webview-ui/src/i18n/locales/it/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code vuole condensare la tua conversazione",
 			"condenseConversation": "Condensa Conversazione"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "Annulla potenziamento",
+			"revertEnhancement": "Ripristina il prompt originale"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/ja/kilocode.json
+++ b/webview-ui/src/i18n/locales/ja/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Codeは会話を要約したいと思っています",
 			"condenseConversation": "会話を要約する"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "高度化をキャンセル",
+			"revertEnhancement": "元のプロンプトに戻す"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/ko/kilocode.json
+++ b/webview-ui/src/i18n/locales/ko/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code가 대화를 요약하고자 합니다",
 			"condenseConversation": "대화 요약하기"
+		},
+		"enhancePrompt": {
+			"revertEnhancement": "원래 프롬프트로 되돌리기",
+			"cancelEnhancement": "향상 취소"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/nl/kilocode.json
+++ b/webview-ui/src/i18n/locales/nl/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code wil je gesprek samenvatten",
 			"condenseConversation": "Gesprek samenvatten"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "Verbetering annuleren",
+			"revertEnhancement": "Terugzetten naar oorspronkelijke opdracht"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/pl/kilocode.json
+++ b/webview-ui/src/i18n/locales/pl/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code chce skondensować Twoją rozmowę",
 			"condenseConversation": "Skondensuj Rozmowę"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "Anuluj ulepszenie",
+			"revertEnhancement": "Przywróć oryginalne polecenie"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/pt-BR/kilocode.json
+++ b/webview-ui/src/i18n/locales/pt-BR/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code quer condensar sua conversa",
 			"condenseConversation": "Condensar Conversa"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "Cancelar melhoria",
+			"revertEnhancement": "Reverter para a solicitação original"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/ru/kilocode.json
+++ b/webview-ui/src/i18n/locales/ru/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code хочет сократить твой разговор",
 			"condenseConversation": "Сократить разговор"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "Отменить улучшение",
+			"revertEnhancement": "Вернуться к исходной инструкции"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/th/kilocode.json
+++ b/webview-ui/src/i18n/locales/th/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code ต้องการย่อการสนทนาของคุณ",
 			"condenseConversation": "ย่อการสนทนา"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "ยกเลิกการเพิ่มประสิทธิภาพ",
+			"revertEnhancement": "กลับคืนสู่คำแนะนำเริ่มต้น"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/tr/kilocode.json
+++ b/webview-ui/src/i18n/locales/tr/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code konuşmanı özetlemek istiyor",
 			"condenseConversation": "Konuşmayı Özetle"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "İyileştirmeyi iptal et",
+			"revertEnhancement": "Orijinal talimata dön"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/uk/kilocode.json
+++ b/webview-ui/src/i18n/locales/uk/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code хоче стиснути твою розмову",
 			"condenseConversation": "Стиснути розмову"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "Скасувати покращення",
+			"revertEnhancement": "Повернутися до початкової підказки"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/vi/kilocode.json
+++ b/webview-ui/src/i18n/locales/vi/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code muốn tóm tắt cuộc trò chuyện của bạn",
 			"condenseConversation": "Tóm tắt cuộc trò chuyện"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "Hủy nâng cấp",
+			"revertEnhancement": "Quay lại lệnh ban đầu"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/zh-CN/kilocode.json
+++ b/webview-ui/src/i18n/locales/zh-CN/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code 想要压缩你的对话",
 			"condenseConversation": "压缩对话"
+		},
+		"enhancePrompt": {
+			"revertEnhancement": "恢复到原始提示",
+			"cancelEnhancement": "取消增强"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/zh-TW/kilocode.json
+++ b/webview-ui/src/i18n/locales/zh-TW/kilocode.json
@@ -52,7 +52,7 @@
 			"condenseConversation": "壓縮對話"
 		},
 		"enhancePrompt": {
-			"cancelEnhancement": "取消增强功能",
+			"cancelEnhancement": "取消增強功能",
 			"revertEnhancement": "恢复到原始提示"
 		}
 	},

--- a/webview-ui/src/i18n/locales/zh-TW/kilocode.json
+++ b/webview-ui/src/i18n/locales/zh-TW/kilocode.json
@@ -53,7 +53,7 @@
 		},
 		"enhancePrompt": {
 			"cancelEnhancement": "取消增強功能",
-			"revertEnhancement": "恢复到原始提示"
+			"revertEnhancement": "恢復到原始提示"
 		}
 	},
 	"newTaskPreview": {

--- a/webview-ui/src/i18n/locales/zh-TW/kilocode.json
+++ b/webview-ui/src/i18n/locales/zh-TW/kilocode.json
@@ -50,6 +50,10 @@
 		"condense": {
 			"wantsToCondense": "Kilo Code 想要壓縮你的對話",
 			"condenseConversation": "壓縮對話"
+		},
+		"enhancePrompt": {
+			"cancelEnhancement": "取消增强功能",
+			"revertEnhancement": "恢复到原始提示"
 		}
 	},
 	"newTaskPreview": {


### PR DESCRIPTION
Allow canceling / reverting prompt enhancement!

![2025-07-21 11 03 35](https://github.com/user-attachments/assets/5968642c-adc7-43a0-bec3-5eec177c2df6)

* Clicking the button again while it loads will cancel the enhancement
* After enhancement, the button turns into a "revert" button
* If the enhanced prompt is changed at all, the revert button becomes an 'enhance' button again



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to cancel an ongoing prompt enhancement or revert to the original prompt after enhancement in the chat interface.
  * The enhance prompt button now dynamically changes its function, tooltip, aria-label, and icon based on the current state (enhance, cancel, revert).

* **Bug Fixes**
  * Improved handling of prompt enhancement cancellation and revert actions to ensure consistent user experience.

* **Tests**
  * Enhanced and extended test coverage for prompt enhancement, including scenarios for canceling and reverting enhancements.

* **Localization**
  * Added new translations for prompt enhancement actions ("Cancel enhancement" and "Revert to original prompt") across all supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->