### PR TITLE
Add missing language

### DIFF
--- a/packages/types/src/kiloLanguages.ts
+++ b/packages/types/src/kiloLanguages.ts
@@ -1,1 +1,1 @@
-export const kiloLanguages = ["ar", "cs", "el", "sv", "th", "uk"] as const
+export const kiloLanguages = ["ar", "cs", "el", "fil", "sv", "th", "uk"] as const


### PR DESCRIPTION
Not sure how bad this is... seems like you can still select it in Settings? I see no usage in PostHog though.