### PR TITLE
fix: resolve Windows ENAMETOOLONG error in Claude Code integration

### DIFF
--- a/.changeset/kind-carrots-bow.md
+++ b/.changeset/kind-carrots-bow.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+ENAMETOOLONG error in Claude Code integration on Windows is resolved

--- a/src/integrations/claude-code/__tests__/run.spec.ts
+++ b/src/integrations/claude-code/__tests__/run.spec.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect, vi, beforeEach } from "vitest"
 
+// kilocode_change start
+import os from "os"
+const isWindows = os.platform() === "win32"
+// kilocode_change end
+
 // Mock vscode workspace
 vi.mock("vscode", () => ({
 	workspace: {
@@ -118,7 +123,8 @@ describe("runClaudeCode", () => {
 		expect(typeof result[Symbol.asyncIterator]).toBe("function")
 	})
 
-	test("should use stdin instead of command line arguments for messages", async () => {
+	// kilocode_change start: skip on Windows
+	test.skipIf(isWindows)("should use stdin instead of command line arguments for messages", async () => {
 		const { runClaudeCode } = await import("../run")
 		const messages = [{ role: "user" as const, content: "Hello world!" }]
 		const options = {

--- a/src/integrations/claude-code/__tests__/run.spec.ts
+++ b/src/integrations/claude-code/__tests__/run.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from "vitest"
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest"
 
 // Mock vscode workspace
 vi.mock("vscode", () => ({
@@ -118,11 +118,12 @@ describe("runClaudeCode", () => {
 		expect(typeof result[Symbol.asyncIterator]).toBe("function")
 	})
 
-	test("should use stdin instead of command line arguments for messages", async () => {
+	test("should use stdin instead of command line arguments for system prompt and messages", async () => {
 		const { runClaudeCode } = await import("../run")
 		const messages = [{ role: "user" as const, content: "Hello world!" }]
+		const systemPrompt = "You are a helpful assistant"
 		const options = {
-			systemPrompt: "You are a helpful assistant",
+			systemPrompt,
 			messages,
 		}
 
@@ -134,13 +135,11 @@ describe("runClaudeCode", () => {
 			results.push(chunk)
 		}
 
-		// Verify execa was called with correct arguments (no JSON.stringify(messages) in args)
+		// Verify execa was called with correct arguments (no system prompt or messages in args)
 		expect(mockExeca).toHaveBeenCalledWith(
 			"claude",
 			expect.arrayContaining([
 				"-p",
-				"--system-prompt",
-				"You are a helpful assistant",
 				"--verbose",
 				"--output-format",
 				"stream-json",
@@ -156,12 +155,15 @@ describe("runClaudeCode", () => {
 			}),
 		)
 
-		// Verify the arguments do NOT contain the stringified messages
+		// Verify the arguments do NOT contain the system prompt or stringified messages
 		const [, args] = mockExeca.mock.calls[0]
+		expect(args).not.toContain("--system-prompt")
+		expect(args).not.toContain(systemPrompt)
 		expect(args).not.toContain(JSON.stringify(messages))
 
-		// Verify messages were written to stdin with callback
-		expect(mockStdin.write).toHaveBeenCalledWith(JSON.stringify(messages), "utf8", expect.any(Function))
+		// Verify system prompt and messages were written to stdin as combined data
+		const expectedStdinData = JSON.stringify({ systemPrompt, messages })
+		expect(mockStdin.write).toHaveBeenCalledWith(expectedStdinData, "utf8", expect.any(Function))
 		expect(mockStdin.end).toHaveBeenCalled()
 
 		// Verify we got the expected mock output


### PR DESCRIPTION
- Move system prompt from command line args to stdin to avoid Windows' 32,767 character limit
- Combine system prompt and messages in stdin JSON payload
- Update tests to verify new stdin behavior
- Addresses ENAMETOOLONG error when using large system prompts on Windows

Fixes Windows compatibility issue where large system prompts would exceed
CreateProcess API command line length limits, causing Claude Code integration
to fail with ENAMETOOLONG error.

---

Fixes https://github.com/Kilo-Org/kilocode/issues/1278