### PR TITLE
Fix max_tokens limit for moonshotai/kimi-k2-instruct on Groq (#5740)

### DIFF
--- a/.changeset/silver-clouds-fetch.md
+++ b/.changeset/silver-clouds-fetch.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix max_tokens limit for moonshotai/kimi-k2-instruct on Groq

--- a/packages/types/src/providers/groq.ts
+++ b/packages/types/src/providers/groq.ts
@@ -89,7 +89,7 @@ export const groqModels = {
 		description: "DeepSeek R1 Distill Llama 70B model, 128K context.",
 	},
 	"moonshotai/kimi-k2-instruct": {
-		maxTokens: 131072,
+		maxTokens: 16384,
 		contextWindow: 131072,
 		supportsImages: false,
 		supportsPromptCache: false,


### PR DESCRIPTION
Fix cherry-picked 

Groq + Kimi K2: 400 max_tokens must be less than or equal to 16384
https://github.com/Kilo-Org/kilocode/issues/1330#issuecomment-3074410189
https://github.com/RooCodeInc/Roo-Code/pull/5740