### PR TITLE
Fix indexing badge being too dark

### DIFF
--- a/webview-ui/src/components/chat/IndexingStatusBadge.tsx
+++ b/webview-ui/src/components/chat/IndexingStatusBadge.tsx
@@ -113,7 +113,7 @@ export const IndexingStatusBadge: React.FC<IndexingStatusBadgeProps> = ({ classN
 						"relative inline-flex items-center justify-center",
 						"bg-transparent border-none p-1.5",
 						"rounded-md min-w-[28px] min-h-[28px]",
-						"opacity-85 text-vscode-foreground",
+						"opacity-60 text-vscode-foreground", // kilocode_change: opacity to match paperclip
 						"transition-all duration-150",
 						"hover:opacity-100 hover:bg-[rgba(255,255,255,0.03)] hover:border-[rgba(255,255,255,0.15)]",
 						"focus:outline-none focus-visible:ring-1 focus-visible:ring-vscode-focusBorder",


### PR DESCRIPTION
Before: 
<img width="94" height="47" alt="CleanShot 2025-07-16 at 11 09 01" src="https://github.com/user-attachments/assets/f89103de-19a0-43f4-b739-a5b3ad3949c1" />

After:
<img width="90" height="40" alt="CleanShot 2025-07-16 at 11 09 35" src="https://github.com/user-attachments/assets/c978d1eb-c33b-4837-9942-acb27c037002" />
