### PR TITLE
Fix prompt enhancement doesn't work with some providers

### DIFF
--- a/.changeset/hot-friends-swim.md
+++ b/.changeset/hot-friends-swim.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Enhance Prompt feature doesn't work with Claude Code provider

--- a/.changeset/hot-friends-swim.md
+++ b/.changeset/hot-friends-swim.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Fix Enhance Prompt feature doesn't work with Claude Code provider
+Enhance Prompt feature now works with Claude Code provider

--- a/src/utils/__tests__/enhance-prompt.spec.ts
+++ b/src/utils/__tests__/enhance-prompt.spec.ts
@@ -77,10 +77,18 @@ describe("enhancePrompt", () => {
 		)
 	})
 
-	it("throws error for API provider that does not support prompt enhancement", async () => {
+	// kilocode_change start - updated tests to work with createMessage fallback
+	it("falls back to createMessage for API provider without completePrompt", async () => {
+		const mockStream = {
+			async *[Symbol.asyncIterator]() {
+				yield { type: "text", text: "Fallback " }
+				yield { type: "text", text: "response" }
+				yield { type: "usage", totalCost: 0.01 }
+			},
+		}
+
 		;(buildApiHandler as any).mockReturnValue({
-			// No completePrompt method
-			createMessage: vi.fn(),
+			createMessage: vi.fn().mockReturnValue(mockStream),
 			getModel: vi.fn().mockReturnValue({
 				id: "test-model",
 				info: {
@@ -91,10 +99,45 @@ describe("enhancePrompt", () => {
 			}),
 		})
 
-		await expect(singleCompletionHandler(mockApiConfig, "Test prompt")).rejects.toThrow(
-			"The selected API provider does not support prompt enhancement",
-		)
+		const result = await singleCompletionHandler(mockApiConfig, "Test prompt")
+
+		expect(result).toBe("Fallback response")
+		const handler = buildApiHandler(mockApiConfig)
+		expect((handler as any).createMessage).toHaveBeenCalledWith("", [
+			{ role: "user", content: [{ type: "text", text: "Test prompt" }] },
+		])
 	})
+
+	it("handles streaming errors gracefully in fallback mode", async () => {
+		const mockStream = {
+			async *[Symbol.asyncIterator]() {
+				yield { type: "text", text: "Partial " }
+				throw new Error("Stream error")
+			},
+		}
+
+		;(buildApiHandler as any).mockReturnValue({
+			// No completePrompt method
+			createMessage: vi.fn().mockReturnValue(mockStream), // kilocode_change
+			getModel: vi.fn().mockReturnValue({
+				id: "test-model",
+				info: {
+					maxTokens: 4096,
+					contextWindow: 8192,
+					supportsPromptCache: false,
+				},
+			}),
+		})
+
+		const result = await singleCompletionHandler(mockApiConfig, "Test prompt")
+		expect(result).toBe("")
+
+		const handler = buildApiHandler(mockApiConfig)
+		expect((handler as any).createMessage).toHaveBeenCalledWith("", [
+			{ role: "user", content: [{ type: "text", text: "Test prompt" }] },
+		])
+	})
+	// kilocode_change end - updated tests to work with createMessage fallback
 
 	it("uses appropriate model based on provider", async () => {
 		const openRouterConfig: ProviderSettings = {

--- a/src/utils/__tests__/enhance-prompt.spec.ts
+++ b/src/utils/__tests__/enhance-prompt.spec.ts
@@ -129,8 +129,7 @@ describe("enhancePrompt", () => {
 			}),
 		})
 
-		const result = await singleCompletionHandler(mockApiConfig, "Test prompt")
-		expect(result).toBe("")
+		await expect(singleCompletionHandler(mockApiConfig, "Test prompt")).rejects.toThrow("Stream error")
 
 		const handler = buildApiHandler(mockApiConfig)
 		expect((handler as any).createMessage).toHaveBeenCalledWith("", [

--- a/src/utils/single-completion-handler.ts
+++ b/src/utils/single-completion-handler.ts
@@ -1,6 +1,6 @@
 import type { ProviderSettings } from "@roo-code/types"
 
-import { buildApiHandler, SingleCompletionHandler } from "../api"
+import { buildApiHandler, SingleCompletionHandler, ApiHandler } from "../api"
 
 /**
  * Enhances a prompt using the configured API without creating a full Cline instance or task history.
@@ -18,8 +18,30 @@ export async function singleCompletionHandler(apiConfiguration: ProviderSettings
 
 	// Check if handler supports single completions
 	if (!("completePrompt" in handler)) {
-		throw new Error("The selected API provider does not support prompt enhancement")
+		// kilocode_change start - stream responses for handlers without completePrompt
+		// throw new Error("The selected API provider does not support prompt enhancement")
+		return await streamResponseFromHandler(handler, promptText)
+		// kilocode_change end
 	}
 
 	return (handler as SingleCompletionHandler).completePrompt(promptText)
 }
+
+// kilocode_change start - Stream responses using createMessage
+async function streamResponseFromHandler(handler: ApiHandler, promptText: string): Promise<string> {
+	const stream = handler.createMessage("", [{ role: "user", content: [{ type: "text", text: promptText }] }])
+
+	let response: string = ""
+	try {
+		for await (const chunk of stream) {
+			if (chunk.type === "text") {
+				response += chunk.text
+			}
+		}
+	} catch (error) {
+		response = ""
+	}
+
+	return response
+}
+// kilocode_change end - streamResponseFromHandler

--- a/src/utils/single-completion-handler.ts
+++ b/src/utils/single-completion-handler.ts
@@ -1,6 +1,5 @@
 import type { ProviderSettings } from "@roo-code/types"
-
-import { buildApiHandler, SingleCompletionHandler, ApiHandler } from "../api"
+import { buildApiHandler, SingleCompletionHandler, ApiHandler } from "../api" //kilocode_change
 
 /**
  * Enhances a prompt using the configured API without creating a full Cline instance or task history.
@@ -32,16 +31,11 @@ async function streamResponseFromHandler(handler: ApiHandler, promptText: string
 	const stream = handler.createMessage("", [{ role: "user", content: [{ type: "text", text: promptText }] }])
 
 	let response: string = ""
-	try {
-		for await (const chunk of stream) {
-			if (chunk.type === "text") {
-				response += chunk.text
-			}
+	for await (const chunk of stream) {
+		if (chunk.type === "text") {
+			response += chunk.text
 		}
-	} catch (error) {
-		response = ""
 	}
-
 	return response
 }
 // kilocode_change end - streamResponseFromHandler


### PR DESCRIPTION
The `singleCompletionHandler` now gracefully falls back to using `createMessage` when the API provider does not support `completePrompt`. This ensures that providers like Claude, which may not have a dedicated prompt enhancement method, can still stream responses.

![2025-07-16 11 14 46](https://github.com/user-attachments/assets/53a572e6-4ec5-44a4-a8cb-655e3de81b19)

This change also includes:
- Handling streaming errors gracefully in fallback mode.
- Updating tests to reflect the new fallback behavior.

Fixes #1347
