### PR TITLE
fix(i18n): unify the multilingual translations of the brand name "Kilo Code"

### DIFF
--- a/src/i18n/locales/ar/kilocode.json
+++ b/src/i18n/locales/ar/kilocode.json
@@ -65,15 +65,15 @@
 				"lastCompletion": "الإكمال الأخير:",
 				"model": "النموذج:"
 			},
-			"disabled": "$(circle-slash) Kilo مكتمل",
-			"warning": "$(warning) اكتمل Kilo",
-			"enabled": "$(sparkle) Kilo مكتمل",
+			"disabled": "$(circle-slash) Kilo إكمال تلقائي",
+			"warning": "$(warning) Kilo إكمال تلقائي",
+			"enabled": "$(sparkle) Kilo إكمال تلقائي",
 			"cost": {
 				"zero": "0.00 دولار",
 				"lessThanCent": "<$0.01"
 			}
 		},
-		"toggleMessage": "Kilo كُمبليت {{status}}"
+		"toggleMessage": "Kilo إكمال تلقائي {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -81,26 +81,26 @@
 			"showing": "عرض التعديلات المقترحة...",
 			"generating": "جاري توليد التعديلات المقترحة...",
 			"processing": "جارِ معالجة التعديلات المقترحة...",
-			"title": "كيلو كود"
+			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "كود كيلو: مهمة سريعة",
+			"title": "Kilo Code: مهمة سريعة",
 			"placeholder": "مثلاً، 'أعد هيكلة هذه الدالة لتكون أكثر كفاءة'"
 		},
 		"commands": {
 			"displaySuggestions": "عرض التعديلات المقترحة",
-			"generateSuggestions": "كود كيلو: توليد تعديلات مقترحة",
+			"generateSuggestions": "Kilo Code: توليد تعديلات مقترحة",
 			"applyCurrentSuggestion": "تطبيق التعديل المُقترح الحالي",
 			"cancelSuggestions": "إلغاء التعديلات المقترحة",
 			"promptCodeSuggestion": "مهمة سريعة",
 			"applyAllSuggestions": "تطبيق كافة التعديلات المقترحة",
-			"category": "كيلو كود"
+			"category": "Kilo Code"
 		},
 		"codeAction": {
-			"title": "كيلو كود: التعديلات المقترحة"
+			"title": "Kilo Code: التعديلات المقترحة"
 		},
 		"chatParticipant": {
-			"fullName": "وكيل كيلو كود",
+			"fullName": "Kilo Code وكيل",
 			"description": "يمكنني مساعدتك بالمهام السريعة والتعديلات المقترحة.",
 			"name": "وكيل"
 		},

--- a/src/i18n/locales/ca/kilocode.json
+++ b/src/i18n/locales/ca/kilocode.json
@@ -53,23 +53,23 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"warning": "$(warning) Quilogram Completat",
-			"enabled": "$(sparkle) Quilòmetre complet",
+			"warning": "$(warning) Kilo Autocompletat",
+			"enabled": "$(sparkle) Kilo Autocompletat",
 			"tooltip": {
-				"basic": "Autocompletat Kilo Code",
-				"disabled": "Kilo Code Autocomplete (desactivat)",
+				"basic": "Kilo Code Autocompletat",
+				"disabled": "Kilo Code Autocompletat (desactivat)",
 				"tokenError": "Cal establir un token vàlid per utilitzar l'autocompleció",
 				"lastCompletion": "Última compleció:",
 				"sessionTotal": "Cost total de la sessió:",
 				"model": "Model:"
 			},
-			"disabled": "$(circle-slash) Kilo Complet",
+			"disabled": "$(circle-slash) Kilo Autocompletat",
 			"cost": {
 				"zero": "0,00 €",
 				"lessThanCent": "<0,01 €"
 			}
 		},
-		"toggleMessage": "Quilòmetre completat {{status}}"
+		"toggleMessage": "Kilo Autocompletat {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,27 +77,27 @@
 			"generating": "Generant suggeriments d'edició...",
 			"processing": "Processant les edicions suggerides...",
 			"showing": "Mostrant edicions suggerides...",
-			"title": "Codi Kilo"
+			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Codi Kilo: Tasca Ràpida",
+			"title": "Kilo Code: Tasca Ràpida",
 			"placeholder": "p. ex., 'refactora aquesta funció perquè sigui més eficient'"
 		},
 		"commands": {
-			"generateSuggestions": "Codi Kilo: Genera suggeriments d'edició",
+			"generateSuggestions": "Kilo Code: Genera suggeriments d'edició",
 			"displaySuggestions": "Mostrar Suggeriments d'Edició",
 			"cancelSuggestions": "Cancel·la les edicions suggerides",
 			"applyAllSuggestions": "Aplica totes les edicions suggerides",
 			"applyCurrentSuggestion": "Aplica l'edició suggerida actual",
 			"promptCodeSuggestion": "Petició de Tasca Ràpida",
-			"category": "Codi Kilo"
+			"category": "Kilo Code"
 		},
 		"codeAction": {
-			"title": "Codi Kilo: Edicions suggerides"
+			"title": "Kilo Code: Edicions suggerides"
 		},
 		"chatParticipant": {
 			"name": "Agent",
-			"fullName": "Agent de Codi Kilo",
+			"fullName": "Kilo Code Agent",
 			"description": "Et puc ajudar amb tasques ràpides i edicions suggerides."
 		},
 		"messages": {

--- a/src/i18n/locales/cs/kilocode.json
+++ b/src/i18n/locales/cs/kilocode.json
@@ -53,23 +53,23 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"enabled": "$(sparkle) Kilo Dokončeno",
-			"disabled": "$(circle-slash) Kilo Dokončeno",
+			"enabled": "$(sparkle) Kilo Automatické dokončování",
+			"disabled": "$(circle-slash) Kilo Automatické dokončování",
 			"tooltip": {
 				"tokenError": "Pro použití automatického dokončování musí být nastaven platný token",
-				"basic": "Kilo Code Autocomplete",
+				"basic": "Kilo Code Automatické dokončování",
 				"lastCompletion": "Poslední dokončení:",
 				"model": "Model:",
 				"sessionTotal": "Celkové náklady na relaci:",
-				"disabled": "Kilo Code Autocomplete (deaktivováno)"
+				"disabled": "Kilo Code Automatické dokončování (deaktivováno)"
 			},
-			"warning": "$(warning) Kilo Hotovo",
+			"warning": "$(warning) Kilo Automatické dokončování",
 			"cost": {
 				"zero": "0,00 Kč",
 				"lessThanCent": "<0,01 $"
 			}
 		},
-		"toggleMessage": "Kilo hotovo {{status}}"
+		"toggleMessage": "Kilo Automatické dokončování {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,10 +77,10 @@
 			"analyzing": "Analyzuji váš kód...",
 			"processing": "Zpracování navržených úprav...",
 			"showing": "Zobrazuji navrhované úpravy...",
-			"title": "Kilo Kód"
+			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Kilo kód: Rychlý úkol",
+			"title": "Kilo Code: Rychlý úkol",
 			"placeholder": "např. \"přepracovat tuto funkci, aby byla efektivnější\""
 		},
 		"commands": {
@@ -90,14 +90,14 @@
 			"cancelSuggestions": "Zrušit navrhované úpravy",
 			"applyAllSuggestions": "Použít všechny navrhované úpravy",
 			"promptCodeSuggestion": "Rychlý úkol",
-			"category": "Kilo Kód"
+			"category": "Kilo Code"
 		},
 		"codeAction": {
-			"title": "Kilo kód: Navrhované úpravy"
+			"title": "Kilo Code: Navrhované úpravy"
 		},
 		"chatParticipant": {
 			"name": "Agent",
-			"fullName": "Agentní Systém Kilo Code",
+			"fullName": "Kilo Code Agent",
 			"description": "Mohu vám pomoci s rychlými úkoly a navrženými úpravami."
 		},
 		"messages": {

--- a/src/i18n/locales/de/kilocode.json
+++ b/src/i18n/locales/de/kilocode.json
@@ -53,23 +53,23 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"disabled": "$(circle-slash) Kilo abgeschlossen",
+			"disabled": "$(circle-slash) Kilo Autovervollständigung",
 			"tooltip": {
-				"basic": "Kilo Code Autocomplete",
+				"basic": "Kilo Code Autovervollständigung",
 				"sessionTotal": "Gesamtkosten der Sitzung:",
-				"disabled": "Kilo Code Autocomplete (deaktiviert)",
+				"disabled": "Kilo Code Autovervollständigung (deaktiviert)",
 				"tokenError": "Ein gültiges Token muss eingestellt werden, um die Autovervollständigung zu verwenden",
 				"lastCompletion": "Letzte Vervollständigung:",
 				"model": "Modell:"
 			},
-			"warning": "$(warning) Kilo Abgeschlossen",
-			"enabled": "$(sparkle) Kilo Abgeschlossen",
+			"warning": "$(warning) Kilo Autovervollständigung",
+			"enabled": "$(sparkle) Kilo Autovervollständigung",
 			"cost": {
 				"lessThanCent": "<0,01 €",
 				"zero": "0,00 €"
 			}
 		},
-		"toggleMessage": "Kilo vollständig {{status}}"
+		"toggleMessage": "Kilo Autovervollständigung {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -80,7 +80,7 @@
 			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Kilo-Code: Schnellaufgabe",
+			"title": "Kilo Code: Schnellaufgabe",
 			"placeholder": "z.B. 'diese Funktion umgestalten, um effizienter zu sein'"
 		},
 		"commands": {

--- a/src/i18n/locales/el/kilocode.json
+++ b/src/i18n/locales/el/kilocode.json
@@ -53,8 +53,8 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"warning": "$(warning) Kilo Ολοκληρώθηκε",
-			"enabled": "$(sparkle) Kilo Ολοκληρώθηκε",
+			"warning": "$(warning) Kilo Αυτόματη Συμπλήρωση",
+			"enabled": "$(sparkle) Kilo Αυτόματη Συμπλήρωση",
 			"tooltip": {
 				"basic": "Kilo Code Αυτόματη Συμπλήρωση",
 				"tokenError": "Πρέπει να οριστεί ένα έγκυρο διακριτικό για να χρησιμοποιηθεί η αυτόματη συμπλήρωση",
@@ -63,13 +63,13 @@
 				"lastCompletion": "Τελευταία ολοκλήρωση:",
 				"model": "Μοντέλο:"
 			},
-			"disabled": "$(circle-slash) Kilo Ολοκληρώθηκε",
+			"disabled": "$(circle-slash) Kilo Αυτόματη Συμπλήρωση",
 			"cost": {
 				"lessThanCent": "<0,01$",
 				"zero": "0,00 €"
 			}
 		},
-		"toggleMessage": "Kilo Ολοκληρώθηκε {{status}}"
+		"toggleMessage": "Kilo Αυτόματη Συμπλήρωση {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,23 +77,23 @@
 			"generating": "Δημιουργία προτεινόμενων επεξεργασιών...",
 			"processing": "Επεξεργασία προτεινόμενων αλλαγών...",
 			"showing": "Εμφάνιση προτεινόμενων αλλαγών...",
-			"title": "Κιλό Κώδικα"
+			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Κωδικός Kilo: Γρήγορη Εργασία",
+			"title": "Kilo Code: Γρήγορη Εργασία",
 			"placeholder": "π.χ., 'αναδιοργάνωσε αυτή τη συνάρτηση ώστε να είναι πιο αποδοτική'"
 		},
 		"commands": {
 			"cancelSuggestions": "Ακύρωση Προτεινόμενων Αλλαγών",
-			"generateSuggestions": "Κωδικός Kilo: Δημιουργία Προτεινόμενων Επεξεργασιών",
+			"generateSuggestions": "Kilo Code: Δημιουργία Προτεινόμενων Επεξεργασιών",
 			"displaySuggestions": "Προβολή Προτεινόμενων Τροποποιήσεων",
 			"promptCodeSuggestion": "Γρήγορη Εργασία με Prompt",
 			"applyCurrentSuggestion": "Εφαρμογή Τρέχουσας Προτεινόμενης Επεξεργασίας",
-			"category": "Κωδικός Κιλό",
+			"category": "Kilo Code",
 			"applyAllSuggestions": "Εφαρμογή Όλων των Προτεινόμενων Αλλαγών"
 		},
 		"codeAction": {
-			"title": "Κωδικός Kilo: Προτεινόμενες Αλλαγές"
+			"title": "Kilo Code: Προτεινόμενες Αλλαγές"
 		},
 		"chatParticipant": {
 			"name": "Πράκτορας",

--- a/src/i18n/locales/es/kilocode.json
+++ b/src/i18n/locales/es/kilocode.json
@@ -53,12 +53,12 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"enabled": "$(sparkle) Kilo Completado",
-			"disabled": "$(circle-slash) Kilo Completo",
-			"warning": "$(warning) Kilo Completo",
+			"enabled": "$(sparkle) Kilo Autocompletado",
+			"disabled": "$(circle-slash) Kilo Autocompletado",
+			"warning": "$(warning) Kilo Autocompletado",
 			"tooltip": {
-				"disabled": "Autocompletar de Kilo Code (desactivado)",
-				"basic": "Autocompletado de Kilo Code",
+				"disabled": "Kilo Code Autocompletado (desactivado)",
+				"basic": "Kilo Code Autocompletado",
 				"sessionTotal": "Costo total de la sesión:",
 				"lastCompletion": "Última finalización:",
 				"tokenError": "Se debe establecer un token válido para usar el autocompletado",
@@ -69,7 +69,7 @@
 				"lessThanCent": "<$0.01"
 			}
 		},
-		"toggleMessage": "Kilo Completo {{status}}"
+		"toggleMessage": "Kilo Autocompletado {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,10 +77,10 @@
 			"processing": "Procesando ediciones sugeridas...",
 			"generating": "Generando sugerencias de edición...",
 			"showing": "Mostrando ediciones sugeridas...",
-			"title": "Código Kilo"
+			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Código Kilo: Tarea Rápida",
+			"title": "Kilo Code: Tarea Rápida",
 			"placeholder": "p. ej., 'refactorizar esta función para que sea más eficiente'"
 		},
 		"commands": {
@@ -93,12 +93,12 @@
 			"applyAllSuggestions": "Aplicar todas las ediciones sugeridas"
 		},
 		"chatParticipant": {
-			"fullName": "Agente de Código Kilo",
+			"fullName": "Kilo Code Agente",
 			"description": "Puedo ayudarte con tareas rápidas y ediciones sugeridas.",
 			"name": "Agente"
 		},
 		"codeAction": {
-			"title": "Código Kilo: Ediciones sugeridas"
+			"title": "Kilo Code: Ediciones sugeridas"
 		},
 		"messages": {
 			"provideCodeSuggestions": "Proporcionando sugerencias de código..."

--- a/src/i18n/locales/fil/kilocode.json
+++ b/src/i18n/locales/fil/kilocode.json
@@ -53,9 +53,9 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"disabled": "$(circle-slash) Kilo Kumpleto",
-			"enabled": "$(sparkle) Kilo Kumpleto",
-			"warning": "$(warning) Kilo Kumpleto",
+			"disabled": "$(circle-slash) Kilo Autocomplete",
+			"enabled": "$(sparkle) Kilo Autocomplete",
+			"warning": "$(warning) Kilo Autocomplete",
 			"tooltip": {
 				"basic": "Kilo Code Autocomplete",
 				"disabled": "Kilo Code Autocomplete (naka-disable)",
@@ -69,7 +69,7 @@
 				"zero": "₱0.00"
 			}
 		},
-		"toggleMessage": "Kilo Complete {{status}}"
+		"toggleMessage": "Kilo Autocomplete {{status}}"
 	},
 	"ghost": {
 		"progress": {

--- a/src/i18n/locales/fr/kilocode.json
+++ b/src/i18n/locales/fr/kilocode.json
@@ -53,9 +53,9 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"disabled": "$(circle-slash) Kilo Terminé",
-			"enabled": "$(sparkle) Kilo Terminé",
-			"warning": "$(warning) Kilo Terminé",
+			"disabled": "$(circle-slash) Kilo Autocomplétion",
+			"enabled": "$(sparkle) Kilo Autocomplétion",
+			"warning": "$(warning) Kilo Autocomplétion",
 			"tooltip": {
 				"disabled": "Autocomplétion Kilo Code (désactivée)",
 				"tokenError": "Un jeton valide doit être défini pour utiliser l'autocomplétion",
@@ -69,7 +69,7 @@
 				"zero": "0,00 $"
 			}
 		},
-		"toggleMessage": "Kilo Terminé {{status}}"
+		"toggleMessage": "Kilo Autocomplétion {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -80,7 +80,7 @@
 			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Code Kilo : Tâche Rapide",
+			"title": "Kilo Code : Tâche Rapide",
 			"placeholder": "par ex., 'refactorisez cette fonction pour la rendre plus efficace'"
 		},
 		"commands": {

--- a/src/i18n/locales/hi/kilocode.json
+++ b/src/i18n/locales/hi/kilocode.json
@@ -48,14 +48,14 @@
 		"generated": "Kilo: कमिट मैसेज जनरेट हो गया!",
 		"generationFailed": "Kilo: प्रतिबद्धता संदेश उत्पन्न करने में विफल: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: अपरिवर्तित परिवर्तनों का उपयोग करके संदेश उत्पन्न कर रहा है",
-    "activationFailed": "किलो: संदेश जनरेटर सक्रिय करने में विफल: {{error}}",
+    "activationFailed": "Kilo: संदेश जनरेटर सक्रिय करने में विफल: {{error}}",
 		"providerRegistered": "किलो: कमिट संदेश प्रदाता पंजीकृत"
 	},
 	"autocomplete": {
 		"statusBar": {
-			"disabled": "$(circle-slash) Kilo पूर्ण",
-			"warning": "$(warning) Kilo पूरा हुआ",
-			"enabled": "$(sparkle) Kilo पूरा हो गया",
+			"disabled": "$(circle-slash) Kilo ऑटोकम्प्लीट",
+			"warning": "$(warning) Kilo ऑटोकम्प्लीट",
+			"enabled": "$(sparkle) Kilo ऑटोकम्प्लीट",
 			"tooltip": {
 				"basic": "Kilo Code ऑटोकम्प्लीट",
 				"tokenError": "स्वतः पूर्ण का उपयोग करने के लिए एक वैध टोकन सेट किया जाना चाहिए",
@@ -69,7 +69,7 @@
 				"lessThanCent": "<₹0.01"
 			}
 		},
-		"toggleMessage": "Kilo कम्पलीट {{status}}"
+		"toggleMessage": "Kilo ऑटोकम्प्लीट {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,28 +77,28 @@
 			"analyzing": "आपके कोड का विश्लेषण किया जा रहा है...",
 			"generating": "सुझाएँ गए संपादन उत्पन्न हो रहे हैं...",
 			"showing": "सुझाए गए संपादन प्रदर्शित किए जा रहे हैं...",
-			"title": "किलो कोड"
+			"title": "Kilo Code"
 		},
 		"input": {
 			"placeholder": "उदाहरण के लिए, 'इस फंक्शन को अधिक कुशल होने के लिए रीफैक्टर करें'",
-			"title": "किलो कोड: त्वरित कार्य"
+			"title": "Kilo Code: त्वरित कार्य"
 		},
 		"commands": {
 			"cancelSuggestions": "सुझाए गए संपादनों को रद्द करें",
 			"displaySuggestions": "सुझाए गए संपादन दिखाएं",
-			"generateSuggestions": "किलो कोड: सुझाये गए संपादन उत्पन्न करें",
+			"generateSuggestions": "Kilo Code: सुझाये गए संपादन उत्पन्न करें",
 			"applyCurrentSuggestion": "वर्तमान सुझाए गए संपादन को लागू करें",
-			"category": "किलो कोड",
+			"category": "Kilo Code",
 			"applyAllSuggestions": "सभी सुझाए गए संपादन लागू करें",
 			"promptCodeSuggestion": "त्वरित कार्य संकेत"
 		},
 		"chatParticipant": {
-			"fullName": "किलो कोड एजेंट",
+			"fullName": "Kilo Code एजेंट",
 			"name": "एजेंट",
 			"description": "मैं आपकी त्वरित कार्यों और सुझाए गए संपादनों में मदद कर सकता हूँ।"
 		},
 		"codeAction": {
-			"title": "किलो कोड: सुझाए गए संपादन"
+			"title": "Kilo Code: सुझाए गए संपादन"
 		},
 		"messages": {
 			"provideCodeSuggestions": "कोड सुझाव प्रदान किए जा रहे हैं..."

--- a/src/i18n/locales/id/kilocode.json
+++ b/src/i18n/locales/id/kilocode.json
@@ -53,8 +53,8 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"disabled": "$(circle-slash) Kilo Selesai",
-			"enabled": "$(sparkle) Kilo Selesai",
+			"disabled": "$(circle-slash) Kilo Autocomplete",
+			"enabled": "$(sparkle) Kilo Autocomplete",
 			"tooltip": {
 				"basic": "Kilo Code Autocomplete",
 				"disabled": "Kilo Code Autocomplete (dinonaktifkan)",
@@ -63,13 +63,13 @@
 				"sessionTotal": "Biaya total sesi:",
 				"model": "Model:"
 			},
-			"warning": "$(warning) Kilo Selesai",
+			"warning": "$(warning) Kilo Autocomplete",
 			"cost": {
 				"zero": "Rp0,00",
 				"lessThanCent": "<Rp0,01"
 			}
 		},
-		"toggleMessage": "Kilo Selesai {{status}}"
+		"toggleMessage": "Kilo Autocomplete {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,7 +77,7 @@
 			"generating": "Membuat saran pengeditan...",
 			"processing": "Memproses saran pengeditan...",
 			"showing": "Menampilkan saran pengeditan...",
-			"title": "Kilo Kode"
+			"title": "Kilo Code"
 		},
 		"input": {
 			"title": "Kilo Code: Tugas Cepat",
@@ -90,13 +90,13 @@
 			"applyAllSuggestions": "Terapkan Semua Suntingan yang Disarankan",
 			"displaySuggestions": "Tampilkan Saran Pengeditan",
 			"promptCodeSuggestion": "Tugas Cepat Prompt",
-			"category": "Kode Kilo"
+			"category": "Kilo Code"
 		},
 		"codeAction": {
-			"title": "Kode Kilo: Saran Penyuntingan"
+			"title": "Kilo Code: Saran Penyuntingan"
 		},
 		"chatParticipant": {
-			"fullName": "Agen Kode Kilo",
+			"fullName": "Kilo Code Agen",
 			"name": "Agen",
 			"description": "Saya dapat membantu Anda dengan tugas cepat dan saran pengeditan."
 		},

--- a/src/i18n/locales/it/kilocode.json
+++ b/src/i18n/locales/it/kilocode.json
@@ -53,7 +53,7 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"enabled": "$(sparkle) Kilo Completato",
+			"enabled": "$(sparkle) Kilo Autocompletamento",
 			"tooltip": {
 				"basic": "Completamento Automatico Kilo Code",
 				"sessionTotal": "Costo totale della sessione:",
@@ -62,14 +62,14 @@
 				"tokenError": "È necessario impostare un token valido per utilizzare l'autocompletamento",
 				"disabled": "Completamento Automatico Kilo Code (disabilitato)"
 			},
-			"disabled": "$(circle-slash) Kilo Completato",
-			"warning": "$(warning) Kilo Completato",
+			"disabled": "$(circle-slash) Kilo Autocompletamento",
+			"warning": "$(warning) Kilo Autocompletamento",
 			"cost": {
 				"zero": "€0,00",
 				"lessThanCent": "<€0,01"
 			}
 		},
-		"toggleMessage": "Kilo Completato {{status}}"
+		"toggleMessage": "Kilo Autocompletamento {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -80,11 +80,11 @@
 			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Codice Kilo: Compito Rapido",
+			"title": "Kilo Code: Compito Rapido",
 			"placeholder": "ad es., 'ristruttura questa funzione per renderla più efficiente'"
 		},
 		"commands": {
-			"generateSuggestions": "Codice Kilo: Genera Suggerimenti di Modifica",
+			"generateSuggestions": "Kilo Code: Genera Suggerimenti di Modifica",
 			"promptCodeSuggestion": "Compito Veloce",
 			"cancelSuggestions": "Annulla Modifiche Suggerite",
 			"displaySuggestions": "Mostra Modifiche Suggerite",

--- a/src/i18n/locales/ja/kilocode.json
+++ b/src/i18n/locales/ja/kilocode.json
@@ -53,9 +53,9 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"enabled": "$(sparkle) Kilo完了",
-			"disabled": "$(circle-slash) Kilo コンプリート",
-			"warning": "$(warning) Kilo完了",
+			"enabled": "$(sparkle) Kilo 自動補完",
+			"disabled": "$(circle-slash) Kilo 自動補完",
+			"warning": "$(warning) Kilo 自動補完",
 			"tooltip": {
 				"disabled": "Kilo Code オートコンプリート (無効)",
 				"tokenError": "オートコンプリートを使用するには有効なトークンを設定する必要があります",
@@ -69,7 +69,7 @@
 				"lessThanCent": "<$0.01"
 			}
 		},
-		"toggleMessage": "Kilo コンプリート {{status}}"
+		"toggleMessage": "Kilo 自動補完 {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,18 +77,18 @@
 			"generating": "編集候補を生成中...",
 			"processing": "編集の提案を処理中...",
 			"showing": "提案された編集を表示中...",
-			"title": "キロ・コード"
+			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "キロコード：クイックタスク",
+			"title": "Kilo Code：クイックタスク",
 			"placeholder": "例：「この関数をより効率的になるようにリファクタリングする」"
 		},
 		"commands": {
 			"displaySuggestions": "提案された編集を表示",
-			"generateSuggestions": "キロコード：推奨編集の生成",
+			"generateSuggestions": "Kilo Code：推奨編集の生成",
 			"applyCurrentSuggestion": "現在の提案された編集を適用する",
 			"cancelSuggestions": "提案された編集をキャンセル",
-			"category": "キロコード",
+			"category": "Kilo Code",
 			"applyAllSuggestions": "提案された編集をすべて適用する",
 			"promptCodeSuggestion": "プロンプト クイックタスク"
 		},
@@ -98,7 +98,7 @@
 			"name": "エージェント"
 		},
 		"codeAction": {
-			"title": "キロ コード: 提案された編集"
+			"title": "Kilo Code: 提案された編集"
 		},
 		"messages": {
 			"provideCodeSuggestions": "コードを提案中..."

--- a/src/i18n/locales/ko/kilocode.json
+++ b/src/i18n/locales/ko/kilocode.json
@@ -53,8 +53,8 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"disabled": "$(circle-slash) Kilo 완료",
-			"enabled": "$(sparkle) Kilo 완료",
+			"disabled": "$(circle-slash) Kilo 자동완성",
+			"enabled": "$(sparkle) Kilo 자동완성",
 			"tooltip": {
 				"disabled": "Kilo Code 자동완성 (비활성화됨)",
 				"basic": "Kilo Code 자동완성",
@@ -63,13 +63,13 @@
 				"lastCompletion": "마지막 완료:",
 				"model": "모델:"
 			},
-			"warning": "$(warning) Kilo 완료",
+			"warning": "$(warning) Kilo 자동완성",
 			"cost": {
 				"lessThanCent": "<$0.01",
 				"zero": "0원"
 			}
 		},
-		"toggleMessage": "Kilo 완료 {{status}}"
+		"toggleMessage": "Kilo 자동완성 {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,28 +77,28 @@
 			"generating": "수정 제안 생성 중...",
 			"processing": "제안된 편집 처리 중...",
 			"showing": "추천 편집 표시 중...",
-			"title": "킬로 코드"
+			"title": "Kilo Code"
 		},
 		"input": {
 			"placeholder": "예: '이 함수를 더 효율적으로 리팩터링하세요'",
-			"title": "킬로 코드: 빠른 작업"
+			"title": "Kilo Code: 빠른 작업"
 		},
 		"commands": {
 			"displaySuggestions": "추천 편집 표시하기",
-			"generateSuggestions": "킬로 코드: 수정 제안 생성하기",
+			"generateSuggestions": "Kilo Code: 수정 제안 생성하기",
 			"cancelSuggestions": "제안된 편집 취소",
-			"category": "킬로 코드",
+			"category": "Kilo Code",
 			"applyAllSuggestions": "제안된 편집 모두 적용",
 			"applyCurrentSuggestion": "현재 제안된 편집 적용",
 			"promptCodeSuggestion": "프롬프트 빠른 작업"
 		},
 		"chatParticipant": {
-			"fullName": "킬로 코드 에이전트",
+			"fullName": "Kilo Code 에이전트",
 			"name": "에이전트",
 			"description": "빠른 작업과 추천 편집을 도와드릴 수 있습니다."
 		},
 		"codeAction": {
-			"title": "킬로 코드: 제안된 편집"
+			"title": "Kilo Code: 제안된 편집"
 		},
 		"messages": {
 			"provideCodeSuggestions": "코드 제안 중..."

--- a/src/i18n/locales/nl/kilocode.json
+++ b/src/i18n/locales/nl/kilocode.json
@@ -53,23 +53,23 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"enabled": "$(sparkle) Kilo Voltooid",
-			"warning": "$(warning) Kilo Voltooid",
+			"enabled": "$(sparkle) Kilo Automatisch aanvullen",
+			"warning": "$(warning) Kilo Automatisch aanvullen",
 			"tooltip": {
-				"basic": "Kilo Code Automatische Aanvulling",
+				"basic": "Kilo Code Automatisch aanvullen",
 				"tokenError": "Een geldige token moet ingesteld worden om automatisch aanvullen te gebruiken",
 				"disabled": "Kilo Code Automatisch aanvullen (uitgeschakeld)",
 				"lastCompletion": "Laatste voltooiing:",
 				"sessionTotal": "Totale sessiekosten:",
 				"model": "Model:"
 			},
-			"disabled": "$(circle-slash) Kilo Voltooid",
+			"disabled": "$(circle-slash) Kilo Automatisch aanvullen",
 			"cost": {
 				"zero": "€ 0,00",
 				"lessThanCent": "<€0,01"
 			}
 		},
-		"toggleMessage": "Kilo Voltooid {{status}}"
+		"toggleMessage": "Kilo Automatisch aanvullen {{status}}"
 	},
 	"ghost": {
 		"progress": {

--- a/src/i18n/locales/pl/kilocode.json
+++ b/src/i18n/locales/pl/kilocode.json
@@ -53,23 +53,23 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"disabled": "$(circle-slash) Kilo Ukończone",
-			"enabled": "$(sparkle) Kilo Ukończone",
+			"disabled": "$(circle-slash) Kilo Autouzupełnianie",
+			"enabled": "$(sparkle) Kilo Autouzupełnianie",
 			"tooltip": {
 				"lastCompletion": "Ostatnie zakończenie:",
 				"disabled": "Kilo Code automatyczne uzupełnianie (wyłączone)",
-				"basic": "Kilo Code Autocomplete",
+				"basic": "Kilo Code Autouzupełnianie",
 				"tokenError": "Aby korzystać z autouzupełniania, należy ustawić prawidłowy token",
 				"sessionTotal": "Całkowity koszt sesji:",
 				"model": "Model:"
 			},
-			"warning": "$(warning) Kilo - Wykonane",
+			"warning": "$(warning) Kilo Autouzupełnianie",
 			"cost": {
 				"lessThanCent": "<0,01 zł",
 				"zero": "0,00 zł"
 			}
 		},
-		"toggleMessage": "Kilo Zakończone {{status}}"
+		"toggleMessage": "Kilo Autouzupełnianie {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -80,7 +80,7 @@
 			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Kod Kilo: Szybkie Zadanie",
+			"title": "Kilo Code: Szybkie Zadanie",
 			"placeholder": "np. „zrefaktoruj tę funkcję, aby była bardziej wydajna\""
 		},
 		"commands": {
@@ -93,7 +93,7 @@
 			"category": "Kilo Code"
 		},
 		"codeAction": {
-			"title": "Kod Kilo: Sugerowane edycje"
+			"title": "Kilo Code: Sugerowane edycje"
 		},
 		"chatParticipant": {
 			"name": "Agent",

--- a/src/i18n/locales/pt-BR/kilocode.json
+++ b/src/i18n/locales/pt-BR/kilocode.json
@@ -53,23 +53,23 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"enabled": "$(sparkle) Kilo Completo",
-			"disabled": "$(circle-slash) Kilo Completo",
+			"enabled": "$(sparkle) Kilo Preenchimento automático",
+			"disabled": "$(circle-slash) Kilo Preenchimento automático",
 			"tooltip": {
 				"disabled": "Preenchimento Automático do Kilo Code (desativado)",
 				"tokenError": "Um token válido deve ser definido para usar o preenchimento automático",
-				"basic": "Kilo Code Autocomplete",
+				"basic": "Kilo Code Preenchimento automático",
 				"lastCompletion": "Última conclusão:",
 				"sessionTotal": "Custo total da sessão:",
 				"model": "Modelo:"
 			},
-			"warning": "$(warning) Kilo Completo",
+			"warning": "$(warning) Kilo Preenchimento automático",
 			"cost": {
 				"zero": "R$ 0,00",
 				"lessThanCent": "<R$0,01"
 			}
 		},
-		"toggleMessage": "Kilo Completo {{status}}"
+		"toggleMessage": "Kilo Preenchimento automático {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,27 +77,27 @@
 			"processing": "Processando sugestões de edição...",
 			"generating": "Gerando edições sugeridas...",
 			"showing": "Exibindo edições sugeridas…",
-			"title": "Código Kilo"
+			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Código Kilo: Tarefa Rápida",
+			"title": "Kilo Code: Tarefa Rápida",
 			"placeholder": "p. ex., 'refatore esta função para ser mais eficiente'"
 		},
 		"commands": {
-			"generateSuggestions": "Código Kilo: Gerar Edições Sugeridas",
+			"generateSuggestions": "Kilo Code: Gerar Edições Sugeridas",
 			"displaySuggestions": "Exibir Edições Sugeridas",
 			"cancelSuggestions": "Cancelar Edições Sugeridas",
 			"applyAllSuggestions": "Aplicar Todas as Edições Sugeridas",
 			"applyCurrentSuggestion": "Aplicar Edição Sugerida Atual",
 			"promptCodeSuggestion": "Tarefa Rápida",
-			"category": "Código Kilo"
+			"category": "Kilo Code"
 		},
 		"codeAction": {
 			"title": "Kilo Code: Edições Sugeridas"
 		},
 		"chatParticipant": {
 			"name": "Agente",
-			"fullName": "Agente de Código Kilo",
+			"fullName": "Kilo Code Agente",
 			"description": "Posso ajudar você com tarefas rápidas e sugestões de edição."
 		},
 		"messages": {

--- a/src/i18n/locales/ru/kilocode.json
+++ b/src/i18n/locales/ru/kilocode.json
@@ -48,14 +48,14 @@
 		"generated": "Kilo: Сообщение коммита сгенерировано!",
 		"generationFailed": "Kilo: Не удалось создать сообщение коммита: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: Генерация сообщения с использованием неподготовленных изменений",
-		"activationFailed": "Килобайт: Не удалось активировать генератор сообщений: {{error}}",
+		"activationFailed": "Kilo: Не удалось активировать генератор сообщений: {{error}}",
 		"providerRegistered": "Kilo: Поставщик сообщения коммита зарегистрирован"
 	},
 	"autocomplete": {
 		"statusBar": {
-			"enabled": "$(sparkle) Kilo Выполнено",
-			"warning": "$(warning) Kilo завершено",
-			"disabled": "$(circle-slash) Kilo завершено",
+			"enabled": "$(sparkle) Kilo Автодополнение",
+			"warning": "$(warning) Kilo Автодополнение",
+			"disabled": "$(circle-slash) Kilo Автодополнение",
 			"tooltip": {
 				"sessionTotal": "Общая стоимость сессии:",
 				"disabled": "Автодополнение Kilo Code (отключено)",
@@ -69,7 +69,7 @@
 				"zero": "0,00 ₽"
 			}
 		},
-		"toggleMessage": "Kilo Выполнено {{status}}"
+		"toggleMessage": "Kilo Автодополнение {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,7 +77,7 @@
 			"generating": "Создание предлагаемых правок...",
 			"processing": "Обработка предлагаемых правок...",
 			"showing": "Отображение предложенных правок...",
-			"title": "Кило Код"
+			"title": "Kilo Code"
 		},
 		"input": {
 			"title": "Kilo Code: Быстрая Задача",
@@ -88,16 +88,16 @@
 			"generateSuggestions": "Kilo Code: Создать Предлагаемые Изменения",
 			"cancelSuggestions": "Отменить предложенные правки",
 			"applyCurrentSuggestion": "Применить текущее предложенное изменение",
-			"category": "Кило Код",
+			"category": "Kilo Code",
 			"applyAllSuggestions": "Применить все предложенные правки",
 			"promptCodeSuggestion": "Быстрое задание"
 		},
 		"codeAction": {
-			"title": "Код Кило: Предлагаемые правки"
+			"title": "Kilo Code: Предлагаемые правки"
 		},
 		"chatParticipant": {
 			"description": "Я могу помочь вам с быстрыми задачами и предложенными изменениями.",
-			"fullName": "Агент Кило Код",
+			"fullName": "Kilo Code Агент",
 			"name": "Агент"
 		},
 		"messages": {

--- a/src/i18n/locales/sv/kilocode.json
+++ b/src/i18n/locales/sv/kilocode.json
@@ -53,9 +53,9 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"enabled": "$(sparkle) Kilo Slutfört",
-			"warning": "$(warning) Kilo Komplett",
-			"disabled": "$(circle-slash) Kilo Slutfört",
+			"enabled": "$(sparkle) Kilo Autocomplete",
+			"warning": "$(warning) Kilo Autocomplete",
+			"disabled": "$(circle-slash) Kilo Autocomplete",
 			"tooltip": {
 				"disabled": "Kilo Code Autocomplete (inaktiverad)",
 				"basic": "Kilo Code Autocomplete",
@@ -69,7 +69,7 @@
 				"lessThanCent": "<0,01 kr"
 			}
 		},
-		"toggleMessage": "Kilo Fullständig {{status}}"
+		"toggleMessage": "Kilo Autocomplete {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,10 +77,10 @@
 			"generating": "Genererar föreslagna ändringar...",
 			"processing": "Bearbetar föreslagna ändringar...",
 			"showing": "Visar föreslagna ändringar...",
-			"title": "Kilo Kod"
+			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Kilo Kod: Snabb Uppgift",
+			"title": "Kilo Code: Snabb Uppgift",
 			"placeholder": "t.ex. 'omstrukturera den här funktionen för att göra den mer effektiv'"
 		},
 		"commands": {
@@ -89,11 +89,11 @@
 			"cancelSuggestions": "Avbryt föreslagna ändringar",
 			"applyCurrentSuggestion": "Tillämpa nuvarande förslag på ändring",
 			"applyAllSuggestions": "Tillämpa Alla Föreslagna Ändringar",
-			"category": "Kilo Kod",
+			"category": "Kilo Code",
 			"promptCodeSuggestion": "Snabb uppgift"
 		},
 		"codeAction": {
-			"title": "Kilo-kod: Föreslagna ändringar"
+			"title": "Kilo Code: Föreslagna ändringar"
 		},
 		"chatParticipant": {
 			"name": "Agent",

--- a/src/i18n/locales/th/kilocode.json
+++ b/src/i18n/locales/th/kilocode.json
@@ -48,14 +48,14 @@
 		"generated": "Kilo: สร้างข้อความคอมมิตแล้ว!",
 		"generationFailed": "Kilo: ไม่สามารถสร้างข้อความคอมมิตได้: {{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: กำลังสร้างข้อความโดยใช้การเปลี่ยนแปลงที่ยังไม่ได้นำเข้าสู่ขั้นตอน",
-    "activationFailed": "กิโล: ล้มเหลวในการเปิดใช้งานตัวสร้างข้อความ: {{error}}",
+    "activationFailed": "Kilo: ล้มเหลวในการเปิดใช้งานตัวสร้างข้อความ: {{error}}",
 		"providerRegistered": "Kilo: ลงทะเบียนผู้ให้บริการข้อความคอมมิตแล้ว"
 	},
 	"autocomplete": {
 		"statusBar": {
-			"warning": "$(warning) Kilo สมบูรณ์",
-			"enabled": "$(sparkle) Kilo สำเร็จแล้ว",
-			"disabled": "$(circle-slash) Kilo สมบูรณ์",
+			"warning": "$(warning) Kilo เติมคำอัตโนมัติ",
+			"enabled": "$(sparkle) Kilo เติมคำอัตโนมัติ",
+			"disabled": "$(circle-slash) Kilo เติมคำอัตโนมัติ",
 			"tooltip": {
 				"lastCompletion": "การป้อนข้อมูลล่าสุด:",
 				"disabled": "คำสั่งอัตโนมัติของ Kilo Code (ปิดการใช้งาน)",
@@ -69,7 +69,7 @@
 				"lessThanCent": "<฿0.01"
 			}
 		},
-		"toggleMessage": "Kilo เสร็จสิ้น {{status}}"
+		"toggleMessage": "Kilo เติมคำอัตโนมัติ {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,26 +77,26 @@
 			"analyzing": "กำลังวิเคราะห์โค้ดของคุณ...",
 			"processing": "กำลังประมวลผลข้อแก้ไขที่แนะนำ...",
 			"showing": "กำลังแสดงข้อเสนอแนะในการแก้ไข...",
-			"title": "คีโลโค้ด"
+			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "รหัสกิโล: งานด่วน",
+			"title": "Kilo Code: งานด่วน",
 			"placeholder": "เช่น 'ปรับโครงสร้างฟังก์ชันนี้ให้มีประสิทธิภาพมากขึ้น'"
 		},
 		"commands": {
-			"generateSuggestions": "รหัสโคด: สร้างการแก้ไขที่แนะนำ",
+			"generateSuggestions": "Kilo Code: สร้างการแก้ไขที่แนะนำ",
 			"displaySuggestions": "แสดงคำแนะนำการแก้ไข",
 			"applyCurrentSuggestion": "ใช้การแก้ไขที่แนะนำในปัจจุบัน",
 			"cancelSuggestions": "ยกเลิกการแก้ไขที่แนะนำ",
 			"applyAllSuggestions": "ใช้การแก้ไขที่แนะนำทั้งหมด",
-			"category": "กิโลโค้ด",
+			"category": "Kilo Code",
 			"promptCodeSuggestion": "งานด่วนพร้อมคำแนะนำ"
 		},
 		"codeAction": {
 			"title": "Kilo Code: การแก้ไขที่แนะนำ"
 		},
 		"chatParticipant": {
-			"fullName": "คิโล โค้ด เอเจนท์",
+			"fullName": "Kilo Code เอเจนท์",
 			"name": "ตัวแทน",
 			"description": "ฉันสามารถช่วยคุณในการทำงานที่รวดเร็วและแนะนำการแก้ไขได้"
 		},

--- a/src/i18n/locales/tr/kilocode.json
+++ b/src/i18n/locales/tr/kilocode.json
@@ -40,7 +40,7 @@
 		}
 	},
 	"commitMessage": {
-		"activated": "Kilo Kod taahhüt mesajı oluşturucu etkinleştirildi",
+		"activated": "Kilo Code taahhüt mesajı oluşturucu etkinleştirildi",
 		"gitNotFound": "⚠️ Git deposu bulunamadı veya git kullanılabilir değil",
 		"gitInitError": "⚠️ Git başlatma hatası: {{error}}",
 		"generating": "Kilo: İşlem mesajı oluşturuluyor...",
@@ -53,8 +53,8 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"enabled": "$(sparkle) Kilo Tamamlandı",
-			"disabled": "$(circle-slash) Kilo Tamamlandı",
+			"enabled": "$(sparkle) Kilo Otomatik Tamamlama",
+			"disabled": "$(circle-slash) Kilo Otomatik Tamamlama",
 			"tooltip": {
 				"basic": "Kilo Code Otomatik Tamamlama",
 				"disabled": "Kilo Code Otomatik Tamamlama (devre dışı)",
@@ -63,13 +63,13 @@
 				"lastCompletion": "Son tamamlama:",
 				"model": "Model:"
 			},
-			"warning": "$(warning) Kilo Tamamlandı",
+			"warning": "$(warning) Kilo Otomatik Tamamlama",
 			"cost": {
 				"zero": "0,00 ₺",
 				"lessThanCent": "<0,01$"
 			}
 		},
-		"toggleMessage": "Kilo Tamamlandı {{status}}"
+		"toggleMessage": "Kilo Otomatik Tamamlama {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,10 +77,10 @@
 			"generating": "Düzenleme önerileri oluşturuluyor...",
 			"processing": "Önerilen düzeltmeler işleniyor...",
 			"showing": "Önerilen düzenlemeler görüntüleniyor...",
-			"title": "Kilo Kodu"
+			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Kilo Kodu: Hızlı Görev",
+			"title": "Kilo Code: Hızlı Görev",
 			"placeholder": "örneğin, 'bu fonksiyonu daha verimli olacak şekilde yeniden düzenleyin'"
 		},
 		"commands": {
@@ -88,17 +88,17 @@
 			"displaySuggestions": "Önerilen Düzenlemeleri Göster",
 			"cancelSuggestions": "Önerilen Düzenlemeleri İptal Et",
 			"applyCurrentSuggestion": "Mevcut Önerilen Düzenlemeyi Uygula",
-			"category": "Kilo Kod",
+			"category": "Kilo Code",
 			"applyAllSuggestions": "Önerilen Düzenlemelerin Tümünü Uygula",
 			"promptCodeSuggestion": "Hızlı Görev İsteği"
 		},
 		"chatParticipant": {
-			"fullName": "Kilo Kod Ajanı",
+			"fullName": "Kilo Code Ajanı",
 			"name": "Temsilci",
 			"description": "Hızlı görevler ve önerilen düzenlemeler konusunda size yardımcı olabilirim."
 		},
 		"codeAction": {
-			"title": "Kilo Kod: Önerilen Düzenlemeler"
+			"title": "Kilo Code: Önerilen Düzenlemeler"
 		},
 		"messages": {
 			"provideCodeSuggestions": "Kod önerileri sunuluyor..."

--- a/src/i18n/locales/uk/kilocode.json
+++ b/src/i18n/locales/uk/kilocode.json
@@ -53,8 +53,8 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"enabled": "$(sparkle) Kilo Виконано",
-			"disabled": "$(circle-slash) Kilo завершено",
+			"enabled": "$(sparkle) Kilo Автодоповнення",
+			"disabled": "$(circle-slash) Kilo Автодоповнення",
 			"tooltip": {
 				"basic": "Автодоповнення Kilo Code",
 				"tokenError": "Для використання автозаповнення необхідно встановити дійсний токен",
@@ -63,13 +63,13 @@
 				"model": "Модель:",
 				"sessionTotal": "Загальна вартість сеансу:"
 			},
-			"warning": "$(warning) Kilo виконано",
+			"warning": "$(warning) Kilo Автодоповнення",
 			"cost": {
 				"zero": "0,00 ₴",
 				"lessThanCent": "<$0,01"
 			}
 		},
-		"toggleMessage": "Kilo виконано {{status}}"
+		"toggleMessage": "Kilo Автодоповнення {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,10 +77,10 @@
 			"processing": "Обробка запропонованих редагувань...",
 			"generating": "Генерування запропонованих виправлень...",
 			"showing": "Відображення запропонованих змін...",
-			"title": "Кіло Код"
+			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Кіло Код: Швидке Завдання",
+			"title": "Kilo Code: Швидке Завдання",
 			"placeholder": "наприклад, 'переробіть цю функцію, щоб вона була ефективнішою'"
 		},
 		"commands": {
@@ -89,14 +89,14 @@
 			"applyCurrentSuggestion": "Застосувати поточну запропоновану правку",
 			"cancelSuggestions": "Скасувати запропоновані правки",
 			"promptCodeSuggestion": "Швидке Завдання",
-			"category": "Кіло Код",
+			"category": "Kilo Code",
 			"applyAllSuggestions": "Застосувати всі запропоновані редагування"
 		},
 		"codeAction": {
-			"title": "Кіло Код: Запропоновані правки"
+			"title": "Kilo Code: Запропоновані правки"
 		},
 		"chatParticipant": {
-			"fullName": "Кіло-код Агент",
+			"fullName": "Kilo Code Агент",
 			"description": "Я можу допомогти вам зі швидкими завданнями та запропонувати правки.",
 			"name": "Агент"
 		},

--- a/src/i18n/locales/vi/kilocode.json
+++ b/src/i18n/locales/vi/kilocode.json
@@ -53,9 +53,9 @@
 	},
 	"autocomplete": {
 		"statusBar": {
-			"enabled": "$(sparkle) Hoàn thành Kilo",
-			"disabled": "$(circle-slash) Hoàn Tất Kilo",
-			"warning": "$(warning) Kilo Hoàn Thành",
+			"enabled": "$(sparkle) Kilo Tự động hoàn thành",
+			"disabled": "$(circle-slash) Kilo Tự động hoàn thành",
+			"warning": "$(warning) Kilo Tự động hoàn thành",
 			"tooltip": {
 				"disabled": "Tự động hoàn thành Kilo Code (đã tắt)",
 				"basic": "Tự động hoàn thiện Kilo Code",
@@ -69,7 +69,7 @@
 				"lessThanCent": "<$0,01"
 			}
 		},
-		"toggleMessage": "Kilo Hoàn thành {{status}}"
+		"toggleMessage": "Kilo Tự động hoàn thành {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -80,7 +80,7 @@
 			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "Mã Kilo: Nhiệm Vụ Nhanh",
+			"title": "Kilo Code: Nhiệm Vụ Nhanh",
 			"placeholder": "ví dụ, 'cấu trúc lại hàm này để hiệu quả hơn'"
 		},
 		"commands": {
@@ -93,11 +93,11 @@
 			"category": "Kilo Code"
 		},
 		"codeAction": {
-			"title": "Mã Kilo: Gợi ý chỉnh sửa"
+			"title": "Kilo Code: Gợi ý chỉnh sửa"
 		},
 		"chatParticipant": {
 			"description": "Tôi có thể giúp bạn với các tác vụ nhanh và các chỉnh sửa được đề xuất.",
-			"fullName": "Đại Diện Mã Kilo",
+			"fullName": "Kilo Code Đại lý",
 			"name": "Đại lý"
 		},
 		"messages": {

--- a/src/i18n/locales/zh-CN/kilocode.json
+++ b/src/i18n/locales/zh-CN/kilocode.json
@@ -40,7 +40,7 @@
 		}
 	},
 	"commitMessage": {
-		"activated": "Kilo: 提交信息生成器已启动",
+		"activated": "Kilo Code: 提交信息生成器已启动",
 		"gitNotFound": "⚠️ Git 仓库未找到或 git 不可用",
 		"gitInitError": "⚠️ Git 初始化错误：{{error}}",
 		"generating": "Kilo: 正在生成提交信息...",
@@ -49,7 +49,7 @@
 		"generationFailed": "Kilo：生成提交信息失败：{{errorMessage}}",
 		"generatingFromUnstaged": "Kilo：使用未暂存的更改生成消息",
 		"providerRegistered": "Kilo：提交消息提供程序已注册",
-		"activationFailed": "千瓦：消息生成器激活失败：{{error}}"
+		"activationFailed": "Kilo：消息生成器激活失败：{{error}}"
 	},
 	"autocomplete": {
 		"statusBar": {
@@ -69,7 +69,7 @@
 				"zero": "¥0.00"
 			}
 		},
-		"toggleMessage": "Kilo自动补全 {{status}}"
+		"toggleMessage": "Kilo 自动补全 {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,26 +77,26 @@
 			"generating": "正在生成建议修改...",
 			"processing": "正在处理建议的编辑...",
 			"showing": "显示建议的编辑...",
-			"title": "千行代码"
+			"title": "Kilo Code"
 		},
 		"input": {
-			"title": "公里码：快速任务",
+			"title": "Kilo：快速任务",
 			"placeholder": "例如，\"重构这个函数使其更高效\""
 		},
 		"commands": {
 			"displaySuggestions": "显示建议的编辑",
 			"applyCurrentSuggestion": "应用当前建议的编辑",
-			"generateSuggestions": "千行代码：生成建议的编辑",
+			"generateSuggestions": "Kilo：生成建议的编辑",
 			"cancelSuggestions": "取消建议的编辑",
 			"applyAllSuggestions": "应用所有建议的编辑",
 			"promptCodeSuggestion": "快速任务提示",
-			"category": "千字代码"
+			"category": "Kilo Code"
 		},
 		"codeAction": {
-			"title": "千米代码：建议编辑"
+			"title": "Kilo Code：建议编辑"
 		},
 		"chatParticipant": {
-			"fullName": "公里码代理",
+			"fullName": "Kilo Code 代理",
 			"description": "我可以帮助你完成快速任务和提供建议的编辑。",
 			"name": "代理"
 		},

--- a/src/i18n/locales/zh-TW/kilocode.json
+++ b/src/i18n/locales/zh-TW/kilocode.json
@@ -40,7 +40,7 @@
 		}
 	},
 	"commitMessage": {
-		"activated": "Kilo: 代码提交消息生成器已激活",
+		"activated": "Kilo Code: 代码提交消息生成器已激活",
 		"gitNotFound": "⚠️ Git 仓库未找到或 git 不可用",
 		"gitInitError": "⚠️ Git 初始化错误：{{error}}",
 		"generating": "Kilo: 正在生成提交信息...",
@@ -48,13 +48,13 @@
 		"generated": "Kilo：提交信息已生成！",
 		"generationFailed": "Kilo：无法生成提交信息：{{errorMessage}}",
 		"generatingFromUnstaged": "Kilo: 使用未暂存的更改生成消息",
-		"activationFailed": "千欧（Kilo）：未能激活消息生成器：{{error}}",
+		"activationFailed": "Kilo：未能激活消息生成器：{{error}}",
 		"providerRegistered": "Kilo：提交消息提供者已注册"
 	},
 	"autocomplete": {
 		"statusBar": {
-			"disabled": "$(circle-slash) Kilo自动补全",
-			"enabled": "$(sparkle) Kilo自动补全",
+			"disabled": "$(circle-slash) Kilo 自动补全",
+			"enabled": "$(sparkle) Kilo 自动补全",
 			"tooltip": {
 				"basic": "Kilo自动补全",
 				"lastCompletion": "上次完成：",
@@ -69,7 +69,7 @@
 				"zero": "¥0.00"
 			}
 		},
-		"toggleMessage": "Kilo自动补全 {{status}}"
+		"toggleMessage": "Kilo 自动补全 {{status}}"
 	},
 	"ghost": {
 		"progress": {
@@ -77,7 +77,7 @@
 			"analyzing": "正在分析您的代码...",
 			"showing": "显示建议的编辑...",
 			"processing": "处理建议的编辑...",
-			"title": "千克码"
+			"title": "Kilo Code"
 		},
 		"input": {
 			"title": "Kilo Code：快速任务",
@@ -88,16 +88,16 @@
 			"generateSuggestions": "Kilo Code: 生成建议的修改",
 			"cancelSuggestions": "取消建议的编辑",
 			"displaySuggestions": "显示建议的编辑",
-			"category": "千字代码",
+			"category": "Kilo Code",
 			"promptCodeSuggestion": "快速任务提示",
 			"applyAllSuggestions": "应用所有建议的编辑"
 		},
 		"codeAction": {
-			"title": "千码：建议的编辑"
+			"title": "Kilo Code：建议的编辑"
 		},
 		"chatParticipant": {
 			"name": "代理",
-			"fullName": "千个代码助理",
+			"fullName": "Kilo Code 代理",
 			"description": "我可以帮你处理快速任务和提供建议的编辑。"
 		},
 		"messages": {


### PR DESCRIPTION

## Context

The translation of "Kilo" is incorrect

## Implementation

Checked and revised translations in all languages
Correct and unify multilingual translations across multiple language files by standardizing the translation of "Kilo Code" to the original brand name "Kilo Code" to ensure brand consistency.
At the same time, revise ambiguous terms related to the autocomplete feature such as "completion" to the more precise "autocomplete" or its corresponding translations, improving the clarity of the user interface.

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
