### PR TITLE
Expose full context window for Kimi K2

### DIFF
--- a/.changeset/flat-cars-matter.md
+++ b/.changeset/flat-cars-matter.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Kilo Code provider can now use the full 131k context window for Kimi K2!

--- a/src/api/providers/fetchers/openrouter.ts
+++ b/src/api/providers/fetchers/openrouter.ts
@@ -127,6 +127,7 @@ export async function getOpenRouterModels(
 				const kimi = models[id]
 				kimi.contextWindow = 131_000
 				kimi.maxTokens = 131_000
+				kimi.supportsPromptCache = true
 			}
 			// kilocode_change end
 		}

--- a/src/api/providers/fetchers/openrouter.ts
+++ b/src/api/providers/fetchers/openrouter.ts
@@ -121,6 +121,14 @@ export async function getOpenRouterModels(
 				maxTokens: top_provider?.max_completion_tokens,
 				supportedParameters: supported_parameters,
 			})
+
+			// kilocode_change start
+			if (id == "moonshotai/kimi-k2" && baseURL == "https://kilocode.ai/api/openrouter") {
+				const kimi = models[id]
+				kimi.contextWindow = 131_000
+				kimi.maxTokens = 131_000
+			}
+			// kilocode_change end
 		}
 	} catch (error) {
 		console.error(


### PR DESCRIPTION
We would have to ensure in the backend you always get routed to a provider with the full context