### PR TITLE
logout when resetting data

### DIFF
--- a/.changeset/bright-grapes-joke.md
+++ b/.changeset/bright-grapes-joke.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Log out kilo code provider when resetting data

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1821,9 +1821,19 @@ export class ClineProvider
 			return
 		}
 
+		// Logout from Kilo Code provider before resetting (same approach as ProfileView logout)
+		const { apiConfiguration, currentApiConfigName } = await this.getState()
+		if (apiConfiguration.kilocodeToken) {
+			await this.upsertProviderProfile(currentApiConfigName, {
+				...apiConfiguration,
+				kilocodeToken: "",
+			})
+		}
+
 		await this.contextProxy.resetAllState()
 		await this.providerSettingsManager.resetAllConfigs()
 		await this.customModesManager.resetCustomModes()
+
 		await this.removeClineFromStack()
 		await this.postStateToWebview()
 		await this.postMessageToWebview({ type: "action", action: "chatButtonClicked" })


### PR DESCRIPTION
fixes #1402

Now when we remove all data we also get logged out, so the state is properly reset:
<img width="708" height="1476" alt="CleanShot 2025-07-19 at 17 03 10@2x" src="https://github.com/user-attachments/assets/82367cdc-cac1-4ae4-a705-38c5ed8690d7" />
