### PR TITLE
Load project ID from Gemini CLI's .env file

### DIFF
--- a/.changeset/loud-owls-beam.md
+++ b/.changeset/loud-owls-beam.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Load project ID from Gemini CLI's .env file

--- a/src/api/providers/gemini-cli.ts
+++ b/src/api/providers/gemini-cli.ts
@@ -4,6 +4,7 @@ import * as fs from "fs/promises"
 import * as path from "path"
 import * as os from "os"
 import axios from "axios"
+import dotenvx from "@dotenvx/dotenvx"
 
 import { type ModelInfo, type GeminiCliModelId, geminiCliDefaultModelId, geminiCliModels } from "@roo-code/types"
 
@@ -141,6 +142,20 @@ export class GeminiCliHandler extends BaseProvider implements SingleCompletionHa
 
 		// Lookup for the project id from the env variable
 		// with a fallback to a default project ID (can be anything for personal OAuth)
+		const envPath = this.options.geminiCliOAuthPath || path.join(os.homedir(), ".gemini", ".env")
+
+		const { parsed, error } = dotenvx.config({ path: envPath })
+
+		if (error) {
+			console.warn("[GeminiCLI] .env file not found or invalid format, proceeding with default project ID")
+		}
+
+		// If the project ID was in the .env file, use it and return early.
+		if (parsed?.GOOGLE_CLOUD_PROJECT) {
+			this.projectId = parsed.GOOGLE_CLOUD_PROJECT
+			return this.projectId
+		}
+
 		const initialProjectId = process.env.GOOGLE_CLOUD_PROJECT ?? "default"
 
 		// Prepare client metadata


### PR DESCRIPTION
This allows the `GOOGLE_CLOUD_PROJECT` to be loaded from `~/.gemini/.env`.

Fixes a 403 `PERMISSION_DENIED` error when a user's Gemini Code Assist subscription is on a non-default project.

## Context

This change allows the Gemini CLI provider to load the **`GOOGLE_CLOUD_PROJECT`** ID from a local **`.env`** file.

This is necessary to fix a **`403 PERMISSION_DENIED`** error that affects users who have a Gemini Code Assist subscription on a specific, non-default Google Cloud project. The previous logic would fail because it couldn't discover the correct project ID and would fall back to a "default" project for which the user's credentials were not authorized.


## Implementation

The `discoverProjectId` method in `GeminiCliHandler.ts` was updated to allow loading the project ID from an environment file before attempting API-based discovery.

1.  The `@dotenvx/dotenvx` dependency was added to parse the `.env` file.
2.  The handler now checks for a `.env` file at `~/.gemini/.env`.
3.  If `GOOGLE_CLOUD_PROJECT` is found in that file, its value is used, and the API discovery process is skipped.
4.  If the file or variable isn't present, the existing discovery logic runs as a fallback.


## How to Test


To test this, you'll need to simulate the environment of a user whose Gemini Code Assist is tied to a specific project.

1.  Create a `.env` file in your home directory at `~/.gemini/.env`.
2.  Add the following line to the file, replacing the value with a valid Google Cloud Project ID:
    ```
    GOOGLE_CLOUD_PROJECT=your-gcp-project-id-here
    ```
3.  Run the application and make a request using the Gemini CLI provider.
4.  **Verification**: The request should succeed without a `403 PERMISSION_DENIED` error. The application logs should indicate that it's operating on behalf of the project ID you specified.

## Get in Touch

stephen.nyamweya.o@gmail.com
