### PR TITLE
Persist of kilocode router provider

### DIFF
--- a/.changeset/vast-corners-press.md
+++ b/.changeset/vast-corners-press.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Kilo Code profile persist of Routing Provider

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -237,6 +237,7 @@ const litellmSchema = baseProviderSettingsSchema.extend({
 const kilocodeSchema = baseProviderSettingsSchema.extend({
 	kilocodeToken: z.string().optional(),
 	kilocodeModel: z.string().optional(),
+	openRouterSpecificProvider: z.string().optional(),
 })
 
 const fireworksSchema = baseProviderSettingsSchema.extend({


### PR DESCRIPTION
## Context

This PR implements persistence for the Kilocode router provider across different profiles. When users switch between profiles with different "Kilo Code - OpenRouter Provider Routing" configurations, the routing provider setting will now be saved and restored appropriately.

## Implementation

Adds schema support for persisting OpenRouter provider routing settings

## How to Test

- Create multiples profiles with different "Kilo Code - OpenRouter Provider Routing"
- When you switch between the profiles the routing provider should be change and persist as expected
