### PR TITLE
Fix unavailable provider when switch models

### DIFF
--- a/.changeset/slimy-ideas-boil.md
+++ b/.changeset/slimy-ideas-boil.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent selection of incompatible provider when you switch a model

--- a/.changeset/slimy-ideas-boil.md
+++ b/.changeset/slimy-ideas-boil.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Prevent selection of incompatible provider when you switch a model
+Prevent selection of incompatible providers when you switch models

--- a/webview-ui/src/components/kilocode/chat/ModelSelector.tsx
+++ b/webview-ui/src/components/kilocode/chat/ModelSelector.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react"
 import { SelectDropdown, DropdownOptionType } from "@/components/ui"
-import type { ProviderSettings } from "@roo-code/types"
+import { OPENROUTER_DEFAULT_PROVIDER_NAME, type ProviderSettings } from "@roo-code/types"
 import { vscode } from "@src/utils/vscode"
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { cn } from "@src/lib/utils"
@@ -48,6 +48,7 @@ export const ModelSelector = ({ currentApiConfigName, apiConfiguration, fallback
 			apiConfiguration: {
 				...apiConfiguration,
 				[modelIdKey]: value,
+				openRouterSpecificProvider: OPENROUTER_DEFAULT_PROVIDER_NAME,
 			},
 		})
 	}

--- a/webview-ui/src/components/kilocode/settings/providers/KiloCodeAdvanced.tsx
+++ b/webview-ui/src/components/kilocode/settings/providers/KiloCodeAdvanced.tsx
@@ -39,13 +39,10 @@ export const KiloCodeAdvanced = ({
 			return
 		}
 		if (
-			openRouterModelProviders === undefined &&
-			apiConfiguration?.openRouterSpecificProvider !== OPENROUTER_DEFAULT_PROVIDER_NAME
+			(openRouterModelProviders === undefined &&
+				apiConfiguration?.openRouterSpecificProvider !== OPENROUTER_DEFAULT_PROVIDER_NAME) ||
+			!Object.keys(openRouterModelProviders || {}).includes(apiConfiguration?.openRouterSpecificProvider)
 		) {
-			setApiConfigurationField("openRouterSpecificProvider", OPENROUTER_DEFAULT_PROVIDER_NAME)
-			return
-		}
-		if (!Object.keys(openRouterModelProviders || {}).includes(apiConfiguration?.openRouterSpecificProvider)) {
 			setApiConfigurationField("openRouterSpecificProvider", OPENROUTER_DEFAULT_PROVIDER_NAME)
 			return
 		}

--- a/webview-ui/src/components/kilocode/settings/providers/KiloCodeAdvanced.tsx
+++ b/webview-ui/src/components/kilocode/settings/providers/KiloCodeAdvanced.tsx
@@ -7,6 +7,7 @@ import {
 	OPENROUTER_DEFAULT_PROVIDER_NAME,
 } from "@src/components/ui/hooks/useOpenRouterModelProviders"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@src/components/ui"
+import { useEffect } from "react"
 
 type KiloCodeAdvancedProps = {
 	apiConfiguration: ProviderSettings
@@ -32,6 +33,23 @@ export const KiloCodeAdvanced = ({
 				apiConfiguration.kilocodeModel in routerModels.openrouter,
 		},
 	)
+
+	useEffect(() => {
+		if (apiConfiguration?.openRouterSpecificProvider === undefined) {
+			return
+		}
+		if (
+			openRouterModelProviders === undefined &&
+			apiConfiguration?.openRouterSpecificProvider !== OPENROUTER_DEFAULT_PROVIDER_NAME
+		) {
+			setApiConfigurationField("openRouterSpecificProvider", OPENROUTER_DEFAULT_PROVIDER_NAME)
+			return
+		}
+		if (!Object.keys(openRouterModelProviders || {}).includes(apiConfiguration?.openRouterSpecificProvider)) {
+			setApiConfigurationField("openRouterSpecificProvider", OPENROUTER_DEFAULT_PROVIDER_NAME)
+			return
+		}
+	}, [setApiConfigurationField, openRouterModelProviders, apiConfiguration?.openRouterSpecificProvider])
 
 	return (
 		<>


### PR DESCRIPTION
## Context

This PR fixes an issue where switching models could result in an incompatible provider selection. The fix ensures that when models are changed, the OpenRouter provider is reset to a default compatible provider, preventing configuration mismatches.

## Implementation

- Adds validation logic to reset provider to default when incompatible providers are detected
- Automatically resets provider to default when switching models in the chat interface
