### PR TITLE
Add install-dev-extension vscode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -115,6 +115,21 @@
 				"reveal": "always",
 				"panel": "new"
 			}
+		},
+		{
+			"label": "install-dev-extension",
+			"type": "shell",
+			"command": "pnpm i && npm run build && code --install-extension \"$(ls -1v bin/kilo-code-*.vsix | tail -n1)\"",
+			"group": "build",
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": false,
+				"panel": "shared",
+				"showReuseMessage": true,
+				"clear": false
+			},
+			"problemMatcher": []
 		}
 	]
 }


### PR DESCRIPTION
Now you can easily build/install the extension using this new task, `install-dev-extension`

This will build and install whatever code you currently checked out into your current VS Code. It's nice if you want to run a unpublished branch locally outside of running the dev version of the extension using the launch.json configuration.