### PR TITLE
Improve the background color of the "Help Improve Kilo Code" banner

### DIFF
--- a/.changeset/thirty-peaches-tell.md
+++ b/.changeset/thirty-peaches-tell.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Improve the background color of the "Help Improve Kilo Code" banner

--- a/apps/storybook/stories/TelemetryBanner.stories.tsx
+++ b/apps/storybook/stories/TelemetryBanner.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import TelemetryBanner from "../../../webview-ui/src/components/common/TelemetryBanner"
+
+const meta = {
+	title: "Component/TelemetryBanner",
+	component: TelemetryBanner,
+	tags: ["autodocs"],
+} satisfies Meta<typeof TelemetryBanner>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/webview-ui/src/components/common/TelemetryBanner.tsx
+++ b/webview-ui/src/components/common/TelemetryBanner.tsx
@@ -9,7 +9,7 @@ import { vscode } from "@src/utils/vscode"
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 
 const BannerContainer = styled.div`
-	background-color: var(--vscode-banner-background);
+	background-color: var(--vscode-notifications-background);
 	padding: 12px 20px;
 	display: flex;
 	flex-direction: column;

--- a/webview-ui/src/components/common/TelemetryBanner.tsx
+++ b/webview-ui/src/components/common/TelemetryBanner.tsx
@@ -9,7 +9,8 @@ import { vscode } from "@src/utils/vscode"
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 
 const BannerContainer = styled.div`
-	background-color: var(--vscode-notifications-background);
+	border: 1px solid var(--vscode-checkbox-border); // kilocode_change
+	background-color: var(--vscode-editorSuggestWidget-background); // kilocode_change
 	padding: 12px 20px;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Use the notification color background: 
<img width="1584" height="239" alt="CleanShot 2025-07-25 at 11 01 11" src="https://github.com/user-attachments/assets/9bbdbf10-9073-4a8d-be8c-68aeb46de678" />

`vscode-banner-background` isn't used anywhere else 🤷‍♂️ 