### PR TITLE
fix(chat): Prevent input clearing when clicking chat buttons

### DIFF
--- a/.changeset/calm-pears-fry.md
+++ b/.changeset/calm-pears-fry.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": patch
+---
+
+The chat box is no longer cleared when clicking buttons
+
+Previously, if either of the buttons in the agent chat was clicked, the ChatTextArea would get cleared. Now, the ChatTextArea will only get cleared if a message is sent as part of the response.

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -658,12 +658,12 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							text: trimmedInput,
 							images: images,
 						})
+						// Clear input state after sending
+						setInputValue("")
+						setSelectedImages([])
 					} else {
 						vscode.postMessage({ type: "askResponse", askResponse: "yesButtonClicked" })
 					}
-					// Clear input state after sending
-					setInputValue("")
-					setSelectedImages([])
 					break
 				case "completion_result":
 				case "resume_completed_task":
@@ -721,13 +721,13 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							text: trimmedInput,
 							images: images,
 						})
+						// Clear input state after sending
+						setInputValue("")
+						setSelectedImages([])
 					} else {
 						// Responds to the API with a "This operation failed" and lets it try again
 						vscode.postMessage({ type: "askResponse", askResponse: "noButtonClicked" })
 					}
-					// Clear input state after sending
-					setInputValue("")
-					setSelectedImages([])
 					break
 				case "command_output":
 					vscode.postMessage({ type: "terminalOperation", terminalOperation: "abort" })
@@ -1909,7 +1909,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 												appearance="primary"
 												disabled={!enableButtons}
 												className={secondaryButtonText ? "flex-1 mr-[6px]" : "flex-[2] mr-0"}
-												onClick={() => handlePrimaryButtonClick(inputValue, selectedImages)}>
+												onClick={() => handlePrimaryButtonClick()}>
 												{primaryButtonText}
 											</VSCodeButton>
 										</StandardTooltip>
@@ -1931,7 +1931,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 												appearance="secondary"
 												disabled={!enableButtons && !(isStreaming && !didClickCancel)}
 												className={isStreaming ? "flex-[2] ml-0" : "flex-1 ml-[6px]"}
-												onClick={() => handleSecondaryButtonClick(inputValue, selectedImages)}>
+												onClick={() => handleSecondaryButtonClick()}>
 												{isStreaming ? t("chat:cancel.title") : secondaryButtonText}
 											</VSCodeButton>
 										</StandardTooltip>


### PR DESCRIPTION
Previously, we had a bug where if either of the buttons in the agent chat was clicked, the ChatTextArea would get cleared. Now, the text box will only get cleared if the message is sent as part of the response.

Moved input clearing logic to only execute when a message is successfully sent, preventing the input field from clearing prematurely when clicking "yes" or "no" buttons in the chat interface. This improves user experience by retaining the input content if an action fails or requires further interaction

Fixes #1520

![2025-07-25 12 53 57](https://github.com/user-attachments/assets/d48119aa-38dc-4a2c-bdef-471e148f5174)

Opened the same PR on the Roo side: https://github.com/RooCodeInc/Roo-Code/pull/6222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The chat input box is now only cleared after a message is successfully sent, rather than on every button click. This prevents accidental loss of unsent text or images in the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->