### PR TITLE
fix(chat): Cancel auto-approve timer when editing follow-up suggestion

### DIFF
--- a/.changeset/kind-horses-sniff.md
+++ b/.changeset/kind-horses-sniff.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Cancel auto-approve timer when editing follow-up suggestion

--- a/webview-ui/src/components/chat/FollowUpSuggest.tsx
+++ b/webview-ui/src/components/chat/FollowUpSuggest.tsx
@@ -134,6 +134,9 @@ export const FollowUpSuggest = ({
 								className="absolute top-0 right-0 opacity-0 group-hover:opacity-100 transition-opacity"
 								onClick={(e) => {
 									e.stopPropagation()
+									// Cancel the auto-approve timer when edit button is clicked
+									setSuggestionSelected(true)
+									onCancelAutoApproval?.()
 									// Simulate shift-click by directly calling the handler with shiftKey=true.
 									onSuggestionClick?.(suggestion, { ...e, shiftKey: true })
 								}}>


### PR DESCRIPTION
So users to don't have to race against the clock to type their message

Fixes: https://github.com/Kilo-Org/kilocode/issues/1262
Roo PR: https://github.com/RooCodeInc/Roo-Code/pull/6226

![2025-07-25 15 14 15](https://github.com/user-attachments/assets/6a0e7e14-14cd-40af-acd2-235b08eb7f08)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-approval timer for follow-up suggestions is now canceled if a suggestion is edited, ensuring changes are not auto-approved unintentionally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->