### PR TITLE
Specify the default model in one place in the code

### DIFF
--- a/.changeset/fluffy-cloths-think.md
+++ b/.changeset/fluffy-cloths-think.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Specify the default model in one place in the code

--- a/webview-ui/src/components/kilocode/hooks/useProviderModels.ts
+++ b/webview-ui/src/components/kilocode/hooks/useProviderModels.ts
@@ -28,6 +28,7 @@ import {
 	glamaDefaultModelId,
 	unboundDefaultModelId,
 	litellmDefaultModelId,
+	kilocodeDefaultModelId,
 } from "@roo-code/types"
 import { cerebrasModels, cerebrasDefaultModelId } from "@roo/api"
 import type { ModelRecord, RouterModels } from "@roo/api"
@@ -166,7 +167,7 @@ const getModelsByProvider = ({
 		case "kilocode": {
 			return {
 				models: routerModels["kilocode-openrouter"],
-				defaultModel: "anthropic/claude-3.7-sonnet",
+				defaultModel: kilocodeDefaultModelId,
 			}
 		}
 		default: {

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -34,6 +34,7 @@ import {
 	litellmDefaultModelId,
 	claudeCodeDefaultModelId,
 	claudeCodeModels,
+	kilocodeDefaultModelId,
 } from "@roo-code/types"
 
 import { cerebrasModels, cerebrasDefaultModelId } from "@roo/api" // kilocode_change
@@ -258,8 +259,8 @@ function getSelectedModel({
 
 			// Fallback to anthropic model if no match found
 			return {
-				id: "anthropic/claude-3.7-sonnet",
-				info: routerModels["kilocode-openrouter"]["anthropic/claude-3.7-sonnet"],
+				id: kilocodeDefaultModelId,
+				info: routerModels["kilocode-openrouter"][kilocodeDefaultModelId],
 			}
 		}
 		// kilocode_change end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default model selection for the "kilocode" provider to use a centralized, configurable default model instead of a hardcoded value.

* **Chores**
  * Added documentation to clarify that the default model is now specified in a single location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->