### PR TITLE
Update codebase indexing documentation link

### DIFF
--- a/webview-ui/src/components/chat/CodeIndexPopover.tsx
+++ b/webview-ui/src/components/chat/CodeIndexPopover.tsx
@@ -509,7 +509,7 @@ export const CodeIndexPopover: React.FC<CodeIndexPopoverProps> = ({
 						<p className="my-0 pr-4 text-sm w-full">
 							<Trans i18nKey="settings:codeIndex.description">
 								<VSCodeLink
-									href={buildDocLink("features/experimental/codebase-indexing", "settings")}
+									href={buildDocLink("features/codebase-indexing", "settings")}
 									style={{ display: "inline" }}
 								/>
 							</Trans>


### PR DESCRIPTION
## Context

Fixes #1381 - Encounterd 404 when clicking "Find out more" link button. Tiny but important to ensure users view the correct documentation when setting up Codebase Indexing.

## Implementation

Remove 'experimental' from documentation URL path as codebase indexing is no longer considered an experimental feature.

## How to Test

- Open Codebase Indexing and click on "Find out more" link button.

## Get in Touch

noviadi on Discord


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation link in the Code Index popover to point to the latest codebase indexing feature page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->