### PR TITLE
Add colors to the Inline Assist decorations

### DIFF
--- a/.changeset/flat-meals-care.md
+++ b/.changeset/flat-meals-care.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Improve the styles for the Inline Assist suggestion previews

--- a/src/services/ghost/GhostDecorations.ts
+++ b/src/services/ghost/GhostDecorations.ts
@@ -4,10 +4,11 @@ import { GhostSuggestionsState } from "./GhostSuggestions"
 const ADDITION_DECORATION_OPTIONS: vscode.DecorationRenderOptions = {
 	after: {
 		margin: "0 0 0 0.1em",
-		color: new vscode.ThemeColor("editorInlayHint.foreground"),
+		color: new vscode.ThemeColor("editor.foreground"),
+		backgroundColor: new vscode.ThemeColor("editorGutter.addedBackground"),
 	},
 	isWholeLine: false,
-	overviewRulerColor: new vscode.ThemeColor("diffEditor.insertedTextBackground"),
+	overviewRulerColor: new vscode.ThemeColor("editorGutter.addedBackground"),
 	overviewRulerLane: vscode.OverviewRulerLane.Right,
 }
 
@@ -15,7 +16,7 @@ const ADDITION_ACTIVE_DECORATION_OPTIONS: vscode.DecorationRenderOptions = {
 	...ADDITION_DECORATION_OPTIONS,
 	after: {
 		...ADDITION_DECORATION_OPTIONS.after,
-		borderColor: new vscode.ThemeColor("editorInlayHint.foreground"),
+		borderColor: new vscode.ThemeColor("editorGutter.addedSecondaryBackground"),
 		border: "1px solid",
 		fontWeight: "bold",
 	},
@@ -23,16 +24,16 @@ const ADDITION_ACTIVE_DECORATION_OPTIONS: vscode.DecorationRenderOptions = {
 
 const DELETION_DECORATION_OPTIONS: vscode.DecorationRenderOptions = {
 	isWholeLine: false,
-	textDecoration: "line-through",
-	color: new vscode.ThemeColor("editorInlayHint.foreground"),
+	color: new vscode.ThemeColor("editor.foreground"),
+	backgroundColor: new vscode.ThemeColor("editorGutter.deletedBackground"),
 	opacity: "0.8",
-	overviewRulerColor: new vscode.ThemeColor("diffEditor.removedTextBackground"),
+	overviewRulerColor: new vscode.ThemeColor("editorGutter.deletedBackground"),
 	overviewRulerLane: vscode.OverviewRulerLane.Right,
 }
 
 const DELETION_ACTIVE_DECORATION_OPTIONS: vscode.DecorationRenderOptions = {
 	...DELETION_DECORATION_OPTIONS,
-	borderColor: new vscode.ThemeColor("editorInlayHint.foreground"),
+	borderColor: new vscode.ThemeColor("editorGutter.deletedSecondaryBackground"),
 	borderStyle: "solid",
 	borderWidth: "1px",
 	fontWeight: "bold",


### PR DESCRIPTION
## Context

This PR adds colors to Inline Assist decorations by updating theme color references in the GhostDecorations configuration. The changes enhance visual distinction between addition and deletion decorations by switching from generic inlay hint colors to more specific editor gutter colors.

## Implementation

- Updated addition decorations to use green gutter colors for better visual feedback
- Updated deletion decorations to use red gutter colors and removed line-through styling
- Enhanced active state decorations with secondary background colors for borders

## Screenshots

<img width="709" height="733" alt="Screenshot 2025-07-29 at 9 52 30 AM" src="https://github.com/user-attachments/assets/e0e104ac-e65c-4c1e-9561-1f557b0cb90a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the color and background styling of ghost decorations for additions and deletions in the editor for improved visual consistency.
  * Addition and deletion highlights now use editor-specific colors for better integration with themes.
  * Deletion decorations no longer display a line-through effect.
  * Improved styles for Inline Assist suggestion previews for a clearer user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->