### PR TITLE
fix(ui): Update icon path back to PNG format

### DIFF
--- a/.changeset/six-signs-burn.md
+++ b/.changeset/six-signs-burn.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Attempt to fix the 'kilo icon missing' bug by switching back to PNG icons

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -294,8 +294,8 @@ export const openClineInNewTab = async ({ context, outputChannel }: Omit<Registe
 	setPanel(newPanel, "tab")
 
 	newPanel.iconPath = {
-		light: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "kilo-light.svg"),
-		dark: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "kilo-dark.svg"),
+		light: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "kilo.png"),
+		dark: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "kilo-dark.png"),
 	}
 
 	await tabProvider.resolveWebviewView(newPanel)


### PR DESCRIPTION
In https://github.com/Kilo-Org/kilocode/pull/1154 we switched these to svgs, but ever since then users have been complained the the Kilo icon "doesn't show up". I haven't been able to reproduce the issue in VSC, but I figure trying switching them back to pngs won't hurt anything!

Might Fix: https://github.com/Kilo-Org/kilocode/issues/1453


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the icons for the new tab panel to use PNG files for both light and dark themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->