### PR TITLE
Use different task groups for the pnpm and bundle tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,10 +22,10 @@
 			"type": "shell",
 			"command": "npx",
 			"args": ["nodemon", "--watch", "pnpm-lock.yaml", "--exec", "pnpm install"],
-			"group": "build",
+			"group": "none",
 			"isBackground": true,
 			"presentation": {
-				"group": "watch",
+				"group": "none",
 				"reveal": "always"
 			},
 			"problemMatcher": {
@@ -86,11 +86,11 @@
 			"dependsOn": ["watch:pnpm"],
 			"type": "shell",
 			"command": "npx turbo watch:tsc",
-			"group": "build",
+			"group": "none",
 			"problemMatcher": "$tsc-watch",
 			"isBackground": true,
 			"presentation": {
-				"group": "watch",
+				"group": "none",
 				"reveal": "always"
 			}
 		},


### PR DESCRIPTION
So the terminal isn't split 4 ways, making it very hard to see what's happening

Now it's only split into two panes:
![2025-07-29 10 42 00](https://github.com/user-attachments/assets/2691c732-baef-4a66-abc8-eea7b95f6c96)

Before:
<img width="2040" height="528" alt="CleanShot 2025-07-29 at 10 44 51@2x" src="https://github.com/user-attachments/assets/c5234851-26b4-4f59-955d-c1b335c4e377" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated task configuration to change how tasks are grouped and displayed in the VSCode task UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->