### PR TITLE
Fix 'failure to apply changes' when Git diff views are open

### DIFF
--- a/.changeset/lemon-grapes-bake.md
+++ b/.changeset/lemon-grapes-bake.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix 'failure to apply changes to files' when Git diff views are open

--- a/src/core/environment/getEnvironmentDetails.ts
+++ b/src/core/environment/getEnvironmentDetails.ts
@@ -65,7 +65,8 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 	const maxTabs = maxOpenTabsContext ?? 20
 	const openTabPaths = vscode.window.tabGroups.all
 		.flatMap((group) => group.tabs)
-		.map((tab) => (tab.input as vscode.TabInputText)?.uri?.fsPath)
+		.filter((tab) => tab.input instanceof vscode.TabInputText)
+		.map((tab) => (tab.input as vscode.TabInputText).uri.fsPath)
 		.filter(Boolean)
 		.map((absolutePath) => path.relative(cline.cwd, absolutePath).toPosix())
 		.slice(0, maxTabs)


### PR DESCRIPTION
## Bug Description

`apply_diff` tool would fail consistently when Git diff views were open in VSCode.

![2025-07-29 14 17 53](https://github.com/user-attachments/assets/9709c534-1132-4a81-bacc-52f982bae9a5)

## Root Cause

The bug was caused by **environment context contamination** in `src/core/environment/getEnvironmentDetails.ts`. When Git diff views are open, the environment details gathering code was incorrectly processing non-text tabs:

1. **Improper type casting**: Line 68 used `(tab.input as vscode.TabInputText)?.uri?.fsPath` without filtering, casting all tab inputs as `TabInputText` regardless of their actual type
2. **Processing incompatible tab types**: Git diff tabs have input types like `TabInputTextDiff`, not `TabInputText`
3. **Malformed environment data**: This resulted in unexpected/malformed data being included in the environment context sent to the AI
4. **AI parsing interference**: The contaminated context affected how the AI parsed multi-file `apply_diff` requests, causing them to fail

## Fix

Added proper tab type filtering before processing:

```typescript
// Before (BROKEN)
.map((tab) => (tab.input as vscode.TabInputText)?.uri?.fsPath)

// After (FIXED)
.filter((tab) => tab.input instanceof vscode.TabInputText)
.map((tab) => (tab.input as vscode.TabInputText).uri.fsPath)
```

This matches the correct pattern already used in other parts of the codebase like `DiffViewProvider.ts` and `WorkspaceTracker.ts`.

## Impact

- Multi-file edits now work reliably when Git diff views are open
- Environment context data is properly filtered and type-safe
- Consistent tab processing across the codebase

Fixes: https://github.com/Kilo-Org/kilocode/issues/712
Roo PR: https://github.com/RooCodeInc/Roo-Code/pull/6350