### PR TITLE
fix(ollama): prefer num_ctx from model.parameters over context_length…

### DIFF
--- a/.changeset/shiny-taxis-remain.md
+++ b/.changeset/shiny-taxis-remain.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix(ollama): prefer num_ctx from model.parameters over context_length from model.info

--- a/src/api/providers/fetchers/ollama.ts
+++ b/src/api/providers/fetchers/ollama.ts
@@ -38,9 +38,16 @@ type OllamaModelsResponse = z.infer<typeof OllamaModelsResponseSchema>
 type OllamaModelInfoResponse = z.infer<typeof OllamaModelInfoResponseSchema>
 
 export const parseOllamaModel = (rawModel: OllamaModelInfoResponse): ModelInfo => {
+	const contextLengthFromModelParameters =
+		typeof rawModel.parameters === "string"
+			? parseInt(rawModel.parameters.match(/^num_ctx\s+(\d+)/m)?.[1] ?? "", 10) || undefined
+			: undefined
+
 	const contextKey = Object.keys(rawModel.model_info).find((k) => k.includes("context_length"))
-	const contextWindow =
+	const contextLengthFromModelInfo =
 		contextKey && typeof rawModel.model_info[contextKey] === "number" ? rawModel.model_info[contextKey] : undefined
+
+	const contextWindow = contextLengthFromModelParameters ?? contextLengthFromModelInfo
 
 	const modelInfo: ModelInfo = Object.assign({}, ollamaDefaultModelInfo, {
 		description: `Family: ${rawModel.details.family}, Context: ${contextWindow}, Size: ${rawModel.details.parameter_size}`,

--- a/src/api/providers/fetchers/ollama.ts
+++ b/src/api/providers/fetchers/ollama.ts
@@ -38,6 +38,7 @@ type OllamaModelsResponse = z.infer<typeof OllamaModelsResponseSchema>
 type OllamaModelInfoResponse = z.infer<typeof OllamaModelInfoResponseSchema>
 
 export const parseOllamaModel = (rawModel: OllamaModelInfoResponse): ModelInfo => {
+	// kilocode_change start
 	const contextLengthFromModelParameters =
 		typeof rawModel.parameters === "string"
 			? parseInt(rawModel.parameters.match(/^num_ctx\s+(\d+)/m)?.[1] ?? "", 10) || undefined
@@ -48,6 +49,7 @@ export const parseOllamaModel = (rawModel: OllamaModelInfoResponse): ModelInfo =
 		contextKey && typeof rawModel.model_info[contextKey] === "number" ? rawModel.model_info[contextKey] : undefined
 
 	const contextWindow = contextLengthFromModelParameters ?? contextLengthFromModelInfo
+	// kilocode_change end
 
 	const modelInfo: ModelInfo = Object.assign({}, ollamaDefaultModelInfo, {
 		description: `Family: ${rawModel.details.family}, Context: ${contextWindow}, Size: ${rawModel.details.parameter_size}`,


### PR DESCRIPTION
## Context

This PR addresses [#1571](https://github.com/Kilo-Org/kilocode/issues/1571), which describes a problem where users running Ollama on memory-constrained systems cannot control the `num_ctx` (context length) value sent to the API. The existing implementation always sends `model.info.contextWindow`, which overrides custom `num_ctx` values in Modelfiles or Ollama settings. This can lead to degraded performance if the context becomes too large to fit in VRAM.

## Implementation

* Updates the request-building logic to first check for `model.parameters.num_ctx`, and use that if present.
* Falls back to `model_info.context_length` only if `num_ctx` is not explicitly defined.
* This preserves user-intended configuration on custom models tuned performance needs.
* The change is backwards-compatible and doesn't affect users who don't specify `num_ctx`.

> No large refactors were necessary. The change was kept scoped to preserve intent and maintain readability.

## Screenshots
<img width="1340" height="744" alt="Screenshot from 2025-07-30 12-38-33" src="https://github.com/user-attachments/assets/9d8feaf2-d86f-4f04-87ad-a93b0fb7903a" />

## How to Test

* Use a [custom Ollama model](https://github.com/ollama/ollama/blob/main/docs/modelfile.md) with a small `num_ctx` value in the Modelfile (e.g., `num_ctx 512`)
* Start Ollama with this model
* Run `tcpdump -i lo port 11434 -A` to begin watching requests to Ollama
* Run Kilo Code pointing at this model
* Confirm that the `num_ctx` sent in the request matches the Modelfile's value (not the full context_length of the model)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the context window size is determined for the "ollama" feature, now prioritizing the value from model parameters for more accurate context length handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->