### PR TITLE
feat(storybook): fix changing timestamps causing snapshot flakes

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -12,6 +12,7 @@
 		"clean": "rimraf storybook-static .turbo stories/generated public/screenshots"
 	},
 	"dependencies": {
+		"@roo-code/types": "workspace:^",
 		"@radix-ui/react-slot": "^1.1.2",
 		"@tanstack/react-query": "^5.62.7",
 		"@vscode/codicons": "^0.0.36",

--- a/apps/storybook/src/mockData/clineMessages.ts
+++ b/apps/storybook/src/mockData/clineMessages.ts
@@ -1,4 +1,4 @@
-import type { ClineMessage } from "../../../../src/exports/types"
+import { ClineMessage } from "@roo-code/types"
 import { randomInterval } from "../utils/randomUtils"
 
 // Fixed base timestamp for consistent snapshots (January 1, 2024, 12:00:00 UTC)

--- a/apps/storybook/stories/ChatView.stories.tsx
+++ b/apps/storybook/stories/ChatView.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { fn } from "storybook/test"
 
 import ChatView from "../../../webview-ui/src/components/chat/ChatView"
-import { createTaskHeaderMessages, createMockTask } from "../src/mockData/clineMessages"
+import { createTaskHeaderMessages, createMockTask, BASE_TIMESTAMP } from "../src/mockData/clineMessages"
 
 const meta = {
 	title: "Chat/ChatView",
@@ -57,7 +57,7 @@ export const Default: Story = {
 			dismissedNotificationIds: [], // Add this for consistency
 			currentTaskItem: {
 				id: "task-1",
-				ts: Date.now(),
+				ts: BASE_TIMESTAMP,
 				task: "Create a React component with TypeScript",
 				tokensIn: 1250,
 				tokensOut: 850,
@@ -74,7 +74,7 @@ export const Default: Story = {
 			taskHistory: [
 				{
 					id: "task-1",
-					ts: Date.now() - 3600000,
+					ts: BASE_TIMESTAMP - 3600000, // 1 hour ago
 					task: "Previous completed task",
 					tokensIn: 800,
 					tokensOut: 600,
@@ -176,7 +176,7 @@ export const EmptyWithNotificationsAndHistory: Story = {
 			taskHistory: [
 				{
 					id: "task-1",
-					ts: Date.now() - 7200000, // 2 hours ago
+					ts: BASE_TIMESTAMP - 7200000, // 2 hours ago
 					task: "Create a responsive navigation component with TypeScript",
 					tokensIn: 1850,
 					tokensOut: 1200,
@@ -192,7 +192,7 @@ export const EmptyWithNotificationsAndHistory: Story = {
 				},
 				{
 					id: "task-2",
-					ts: Date.now() - 3600000, // 1 hour ago
+					ts: BASE_TIMESTAMP - 3600000, // 1 hour ago
 					task: "Debug authentication flow and fix login issues",
 					tokensIn: 950,
 					tokensOut: 720,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.2.3(@types/react@18.3.23)(react@18.3.1)
+      '@roo-code/types':
+        specifier: workspace:^
+        version: link:../../packages/types
       '@tanstack/react-query':
         specifier: ^5.62.7
         version: 5.79.0(react@18.3.1)
@@ -12857,7 +12860,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13213,7 +13216,7 @@ snapshots:
 
   '@puppeteer/browsers@2.10.5':
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -13226,7 +13229,7 @@ snapshots:
 
   '@puppeteer/browsers@2.6.1':
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -15464,7 +15467,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -15985,7 +15988,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -16763,10 +16766,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.1:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.1(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -17502,7 +17501,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -17540,7 +17539,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -17650,7 +17649,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -17918,7 +17917,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18232,7 +18231,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18246,7 +18245,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -20655,7 +20654,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       get-uri: 6.0.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -21015,7 +21014,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -21060,7 +21059,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.6.1
       chromium-bidi: 0.11.0(devtools-protocol@0.0.1367902)
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       devtools-protocol: 0.0.1367902
       typed-query-selector: 2.12.0
       ws: 8.18.2
@@ -21074,7 +21073,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.10.5
       chromium-bidi: 5.1.0(devtools-protocol@0.0.1452169)
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       devtools-protocol: 0.0.1452169
       typed-query-selector: 2.12.0
       ws: 8.18.2
@@ -21605,7 +21604,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -21692,7 +21691,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -21861,7 +21860,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21901,7 +21900,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -22508,7 +22507,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       esbuild: 0.25.5
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -22931,7 +22930,7 @@ snapshots:
   vite-node@3.2.4(@types/node@20.19.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.3.5(@types/node@20.19.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
@@ -23013,7 +23012,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3


### PR DESCRIPTION
Modifies `ChatView.stories.tsx` to use a fixed `BASE_TIMESTAMP` for consistent snapshot testing, replacing `Date.now()` calls. This ensures Storybook stories are reproducible and not affected by the current time.

<img width="1880" height="994" alt="CleanShot 2025-07-30 at 12 58 45@2x" src="https://github.com/user-attachments/assets/f5986493-526e-4e54-8777-c511b78a0582" />
