### PR TITLE
feat(telemetry): Add memory usage telemetry events

### DIFF
--- a/packages/telemetry/src/TelemetryService.ts
+++ b/packages/telemetry/src/TelemetryService.ts
@@ -238,6 +238,12 @@ export class TelemetryService {
 		this.captureEvent(TelemetryEventName.TITLE_BUTTON_CLICKED, { button })
 	}
 
+	// kilocode_change start
+	public captureMemoryUsage(memoryMetrics: import("@roo-code/types").MemoryMetrics): void {
+		this.captureEvent(TelemetryEventName.MEMORY_USAGE, memoryMetrics)
+	}
+	// kilocode_change end
+
 	/**
 	 * Checks if telemetry is currently enabled
 	 * @returns Whether telemetry is enabled

--- a/packages/telemetry/src/__tests__/PostHogTelemetryClient.test.ts
+++ b/packages/telemetry/src/__tests__/PostHogTelemetryClient.test.ts
@@ -202,7 +202,10 @@ describe("PostHogTelemetryClient", () => {
 				properties: { customProp: "value" },
 			})
 
-			expect(result).toEqual({ customProp: "value" })
+			expect(result).toEqual({
+				customProp: "value",
+				exception: expect.stringContaining("Error: Provider error"),
+			})
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
 				expect.stringContaining("Error getting telemetry properties: Provider error"),
 			)

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -27,6 +27,7 @@ export enum TelemetryEventName {
 	CHECKPOINT_FAILURE = "Checkpoint Failure",
 	EXCESSIVE_RECURSION = "Excessive Recursion",
 	NOTIFICATION_CLICKED = "Notification Clicked",
+	MEMORY_USAGE = "Memory Usage",
 	// kilocode_change end
 
 	TASK_CREATED = "Task Created",
@@ -148,6 +149,7 @@ export const rooCodeTelemetryEventSchema = z.discriminatedUnion("type", [
 			TelemetryEventName.INLINE_ASSIST_AUTO_TASK,
 			TelemetryEventName.INLINE_ASSIST_ACCEPT_SUGGESTION,
 			TelemetryEventName.INLINE_ASSIST_REJECT_SUGGESTION,
+			TelemetryEventName.MEMORY_USAGE,
 			// kilocode_change end
 			TelemetryEventName.TASK_CREATED,
 			TelemetryEventName.TASK_RESTARTED,
@@ -210,6 +212,16 @@ export const rooCodeTelemetryEventSchema = z.discriminatedUnion("type", [
 ])
 
 export type RooCodeTelemetryEvent = z.infer<typeof rooCodeTelemetryEventSchema>
+
+
+// kilocode_change start
+export interface MemoryMetrics {
+	heapUsed: number
+	heapTotal: number
+	external: number
+	rss: number
+}
+// kilocode_change end
 
 /**
  * TelemetryEventSubscription

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import { TerminalRegistry } from "./integrations/terminal/TerminalRegistry"
 import { McpServerManager } from "./services/mcp/McpServerManager"
 import { CodeIndexManager } from "./services/code-index/manager"
 import { registerCommitMessageProvider } from "./services/commit-message"
+import { registerMemoryService } from "./services/memory" // kilocode_change
 import { MdmService } from "./services/mdm/MdmService"
 import { migrateSettings } from "./utils/migrateSettings"
 import { checkAndRunAutoLaunchingTask as checkAndRunAutoLaunchingTask } from "./utils/autoLaunchingTask"
@@ -205,6 +206,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	registerGhostProvider(context, provider) // kilocode_change
 	registerCommitMessageProvider(context, outputChannel) // kilocode_change
+	registerMemoryService(context) // kilocode_change
 	registerCodeActions(context)
 	registerTerminalActions(context)
 

--- a/src/services/memory/MemoryService.ts
+++ b/src/services/memory/MemoryService.ts
@@ -1,0 +1,62 @@
+import * as vscode from "vscode"
+import { TelemetryService } from "@roo-code/telemetry"
+import type { MemoryMetrics } from "@roo-code/types"
+
+/**
+ * Service that periodically monitors and reports memory usage metrics via telemetry
+ */
+export class MemoryService {
+	private intervalId: NodeJS.Timeout | null = null
+	private readonly intervalMs: number = 60 * 1000 // 1 minute
+
+	constructor(private readonly context: vscode.ExtensionContext) {}
+
+	public start(): void {
+		if (this.intervalId) {
+			return
+		}
+		this.reportMemoryUsage()
+
+		// Set up periodic reporting
+		this.intervalId = setInterval(() => {
+			this.reportMemoryUsage()
+		}, this.intervalMs)
+
+		// Register cleanup on extension deactivation
+		this.context.subscriptions.push({
+			dispose: () => this.stop(),
+		})
+	}
+
+	public stop(): void {
+		if (this.intervalId) {
+			clearInterval(this.intervalId)
+			this.intervalId = null
+		}
+	}
+
+	private reportMemoryUsage(): void {
+		try {
+			const memoryUsage = process.memoryUsage()
+
+			const metrics: MemoryMetrics = {
+				heapUsed: this.bytesToMegabytes(memoryUsage.heapUsed),
+				heapTotal: this.bytesToMegabytes(memoryUsage.heapTotal),
+				external: this.bytesToMegabytes(memoryUsage.external),
+				rss: this.bytesToMegabytes(memoryUsage.rss),
+			}
+
+			if (TelemetryService.hasInstance()) {
+				TelemetryService.instance.captureMemoryUsage(metrics)
+			}
+		} catch (error) {
+			console.error(
+				`[MemoryService] Error reporting memory usage: ${error instanceof Error ? error.message : String(error)}`,
+			)
+		}
+	}
+
+	private bytesToMegabytes(bytes: number): number {
+		return Math.round((bytes / 1024 / 1024) * 100) / 100
+	}
+}

--- a/src/services/memory/__tests__/MemoryService.spec.ts
+++ b/src/services/memory/__tests__/MemoryService.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import * as vscode from "vscode"
+import { TelemetryService } from "@roo-code/telemetry"
+import { MemoryService } from "../MemoryService"
+
+// Mock TelemetryService
+vi.mock("@roo-code/telemetry", () => ({
+	TelemetryService: {
+		hasInstance: vi.fn(),
+		instance: {
+			captureMemoryUsage: vi.fn(),
+		},
+	},
+}))
+
+describe("MemoryService", () => {
+	let memoryService: MemoryService
+	let mockContext: vscode.ExtensionContext
+	let mockTelemetryService: any
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.useFakeTimers()
+
+		mockContext = {
+			subscriptions: [],
+		} as any
+
+		mockTelemetryService = TelemetryService as any
+		mockTelemetryService.hasInstance.mockReturnValue(true)
+
+		memoryService = new MemoryService(mockContext)
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	describe("start", () => {
+		it("should start memory monitoring and report initial usage", () => {
+			memoryService.start()
+
+			expect(mockTelemetryService.instance.captureMemoryUsage).toHaveBeenCalledTimes(1)
+		})
+
+		it("should not start if already running", () => {
+			memoryService.start()
+			vi.clearAllMocks()
+
+			memoryService.start()
+
+			// Service should not report again when already running
+			expect(mockTelemetryService.instance.captureMemoryUsage).not.toHaveBeenCalled()
+		})
+
+		it("should register cleanup with context subscriptions", () => {
+			memoryService.start()
+
+			expect(mockContext.subscriptions).toHaveLength(1)
+			expect(mockContext.subscriptions[0]).toHaveProperty("dispose")
+		})
+
+		it("should report memory usage periodically", () => {
+			memoryService.start()
+			vi.clearAllMocks()
+
+			// Fast-forward 1 minute
+			vi.advanceTimersByTime(60 * 1000)
+
+			expect(mockTelemetryService.instance.captureMemoryUsage).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe("stop", () => {
+		it("should stop memory monitoring", () => {
+			memoryService.start()
+			memoryService.stop()
+
+			// Verify that subsequent timer ticks don't report memory usage
+			vi.clearAllMocks()
+			vi.advanceTimersByTime(60 * 1000)
+			expect(mockTelemetryService.instance.captureMemoryUsage).not.toHaveBeenCalled()
+		})
+
+		it("should not report memory usage after stopping", () => {
+			memoryService.start()
+			memoryService.stop()
+			vi.clearAllMocks()
+
+			// Fast-forward 1 minute
+			vi.advanceTimersByTime(60 * 1000)
+
+			expect(mockTelemetryService.instance.captureMemoryUsage).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("memory reporting", () => {
+		it("should convert memory usage from bytes to megabytes", () => {
+			// Mock process.memoryUsage to return known values
+			const originalMemoryUsage = process.memoryUsage
+			process.memoryUsage = vi.fn(() => ({
+				heapUsed: 10 * 1024 * 1024, // 10 MB
+				heapTotal: 20 * 1024 * 1024, // 20 MB
+				external: 5 * 1024 * 1024, // 5 MB
+				rss: 30 * 1024 * 1024, // 30 MB
+				arrayBuffers: 0,
+			})) as any
+
+			memoryService.start()
+
+			expect(mockTelemetryService.instance.captureMemoryUsage).toHaveBeenCalledWith({
+				heapUsed: 10,
+				heapTotal: 20,
+				external: 5,
+				rss: 30,
+			})
+
+			// Restore original function
+			process.memoryUsage = originalMemoryUsage
+		})
+
+		it("should handle telemetry service not being available", () => {
+			mockTelemetryService.hasInstance.mockReturnValue(false)
+
+			expect(() => memoryService.start()).not.toThrow()
+		})
+
+		it("should handle errors gracefully", () => {
+			// Mock console.error to verify error handling
+			const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+			// Mock process.memoryUsage to throw an error
+			const originalMemoryUsage = process.memoryUsage
+			process.memoryUsage = vi.fn(() => {
+				throw new Error("Memory access failed")
+			}) as any
+
+			memoryService.start()
+
+			expect(consoleSpy).toHaveBeenCalledWith(
+				"[MemoryService] Error reporting memory usage: Memory access failed",
+			)
+
+			// Restore original functions
+			process.memoryUsage = originalMemoryUsage
+			consoleSpy.mockRestore()
+		})
+	})
+})

--- a/src/services/memory/index.ts
+++ b/src/services/memory/index.ts
@@ -1,0 +1,11 @@
+import * as vscode from "vscode"
+import { MemoryService } from "./MemoryService"
+
+/**
+ * Registers the memory monitoring service with the extension context.
+ * This function should be called during extension activation.
+ */
+export function registerMemoryService(context: vscode.ExtensionContext): void {
+	const memoryService = new MemoryService(context)
+	memoryService.start()
+}


### PR DESCRIPTION
Introduces a new `MemoryService` to periodically monitor and report the extension's memory usage metrics (heapUsed, heapTotal, external, rss) via telemetry. This helps in understanding and optimizing the extension's resource consumption.

- Adds `TelemetryEventName.MEMORY_USAGE_REPORTED` to `packages/types/src/telemetry.ts`.
- Implements `captureMemoryUsage` method in `TelemetryService` to send memory metrics.
- Creates `src/services/memory/MemoryService.ts` for periodic memory collection and reporting.
- Registers the `MemoryService` in `src/extension.ts` to start monitoring on activation.
- Includes unit tests for `MemoryService` in `src/services/memory/__tests__/MemoryService.spec.ts`.