### PR TITLE
Add webview memory usage telemetry

### DIFF
--- a/.changeset/quick-wasps-hope.md
+++ b/.changeset/quick-wasps-hope.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add webview memory metrics to telemetry

--- a/packages/telemetry/src/__tests__/PostHogTelemetryClient.test.ts
+++ b/packages/telemetry/src/__tests__/PostHogTelemetryClient.test.ts
@@ -202,7 +202,10 @@ describe("PostHogTelemetryClient", () => {
 				properties: { customProp: "value" },
 			})
 
-			expect(result).toEqual({ customProp: "value" })
+			expect(result).toEqual({
+				customProp: "value",
+				exception: expect.stringContaining("Error: Provider error"),
+			})
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
 				expect.stringContaining("Error getting telemetry properties: Provider error"),
 			)

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -144,13 +144,14 @@ export const rooCodeTelemetryEventSchema = z.discriminatedUnion("type", [
 	z.object({
 		type: z.enum([
 			// kilocode_change start
-			TelemetryEventName.COMMIT_MSG_GENERATED,
-			TelemetryEventName.INLINE_ASSIST_QUICK_TASK,
-			TelemetryEventName.INLINE_ASSIST_AUTO_TASK,
-			TelemetryEventName.INLINE_ASSIST_ACCEPT_SUGGESTION,
-			TelemetryEventName.INLINE_ASSIST_REJECT_SUGGESTION,
-			TelemetryEventName.WEBVIEW_MEMORY_USAGE,
+			TelemetryEventName.COMMIT_MSG_GENERATED, // kilocode_change
+			TelemetryEventName.INLINE_ASSIST_QUICK_TASK, // kilocode_change
+			TelemetryEventName.INLINE_ASSIST_AUTO_TASK, // kilocode_change
+			TelemetryEventName.INLINE_ASSIST_ACCEPT_SUGGESTION, // kilocode_change
+			TelemetryEventName.INLINE_ASSIST_REJECT_SUGGESTION, // kilocode_change
+			TelemetryEventName.WEBVIEW_MEMORY_USAGE, // kilocode_change
 			// kilocode_change end
+
 			TelemetryEventName.TASK_CREATED,
 			TelemetryEventName.TASK_RESTARTED,
 			TelemetryEventName.TASK_COMPLETED,

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -27,6 +27,7 @@ export enum TelemetryEventName {
 	CHECKPOINT_FAILURE = "Checkpoint Failure",
 	EXCESSIVE_RECURSION = "Excessive Recursion",
 	NOTIFICATION_CLICKED = "Notification Clicked",
+	WEBVIEW_MEMORY_USAGE = "Webview Memory Usage",
 	// kilocode_change end
 
 	TASK_CREATED = "Task Created",
@@ -148,6 +149,7 @@ export const rooCodeTelemetryEventSchema = z.discriminatedUnion("type", [
 			TelemetryEventName.INLINE_ASSIST_AUTO_TASK,
 			TelemetryEventName.INLINE_ASSIST_ACCEPT_SUGGESTION,
 			TelemetryEventName.INLINE_ASSIST_REJECT_SUGGESTION,
+			TelemetryEventName.WEBVIEW_MEMORY_USAGE,
 			// kilocode_change end
 			TelemetryEventName.TASK_CREATED,
 			TelemetryEventName.TASK_RESTARTED,

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -28,6 +28,7 @@ import { useAddNonInteractiveClickListener } from "./components/ui/hooks/useNonI
 import { TooltipProvider } from "./components/ui/tooltip"
 import { STANDARD_TOOLTIP_DELAY } from "./components/ui/standard-tooltip"
 import { useKiloIdentity } from "./utils/kilocode/useKiloIdentity"
+import { MemoryService } from "./services/MemoryService"
 
 type Tab = "settings" | "history" | "mcp" | "modes" | "chat" | "marketplace" | "account" | "profile" // kilocode_change: add "profile"
 
@@ -204,6 +205,10 @@ const App = () => {
 	useEffect(() => {
 		if (didHydrateState) {
 			telemetryClient.updateTelemetryState(telemetrySetting, telemetryKey, telemetryDistinctId)
+
+			const memoryService = new MemoryService()
+			memoryService.start()
+			return () => memoryService.stop()
 		}
 	}, [telemetrySetting, telemetryKey, telemetryDistinctId, didHydrateState])
 	// kilocode_change end

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -21,6 +21,7 @@ import McpView from "./components/mcp/McpView"
 import ModesView from "./components/modes/ModesView"
 import { HumanRelayDialog } from "./components/human-relay/HumanRelayDialog"
 import BottomControls from "./components/kilocode/BottomControls" // kilocode_change
+import { MemoryService } from "./services/MemoryService" // kilocode_change
 import { DeleteMessageDialog, EditMessageDialog } from "./components/chat/MessageModificationConfirmationDialog"
 import ErrorBoundary from "./components/ErrorBoundary"
 // import { AccountView } from "./components/account/AccountView" // kilocode_change: we have our own profile view
@@ -28,7 +29,6 @@ import { useAddNonInteractiveClickListener } from "./components/ui/hooks/useNonI
 import { TooltipProvider } from "./components/ui/tooltip"
 import { STANDARD_TOOLTIP_DELAY } from "./components/ui/standard-tooltip"
 import { useKiloIdentity } from "./utils/kilocode/useKiloIdentity"
-import { MemoryService } from "./services/MemoryService"
 
 type Tab = "settings" | "history" | "mcp" | "modes" | "chat" | "marketplace" | "account" | "profile" // kilocode_change: add "profile"
 
@@ -206,9 +206,11 @@ const App = () => {
 		if (didHydrateState) {
 			telemetryClient.updateTelemetryState(telemetrySetting, telemetryKey, telemetryDistinctId)
 
+			// kilocode_change start
 			const memoryService = new MemoryService()
 			memoryService.start()
 			return () => memoryService.stop()
+			// kilocode_change end
 		}
 	}, [telemetrySetting, telemetryKey, telemetryDistinctId, didHydrateState])
 	// kilocode_change end

--- a/webview-ui/src/services/MemoryService.ts
+++ b/webview-ui/src/services/MemoryService.ts
@@ -1,0 +1,44 @@
+// kilocode_change - new file
+import { telemetryClient } from "../utils/TelemetryClient"
+import { TelemetryEventName } from "@roo-code/types"
+
+interface PerformanceMemory {
+	usedJSHeapSize?: number
+	totalJSHeapSize?: number
+}
+
+export class MemoryService {
+	private intervalId: number | null = null
+	private readonly intervalMs: number = 60 * 1000 // 1 min
+
+	public start(): void {
+		if (this.intervalId) {
+			return
+		}
+		this.reportMemoryUsage()
+
+		this.intervalId = window.setInterval(() => {
+			this.reportMemoryUsage()
+		}, this.intervalMs)
+	}
+
+	public stop(): void {
+		if (this.intervalId) {
+			window.clearInterval(this.intervalId)
+			this.intervalId = null
+		}
+	}
+
+	private reportMemoryUsage(): void {
+		const memory = (performance as Performance & { memory?: PerformanceMemory }).memory
+		const memoryInfo = {
+			heapUsedMb: this.bytesToMegabytes(memory?.usedJSHeapSize || 0),
+			heapTotalMb: this.bytesToMegabytes(memory?.totalJSHeapSize || 0),
+		}
+		telemetryClient.capture(TelemetryEventName.WEBVIEW_MEMORY_USAGE, memoryInfo)
+	}
+
+	private bytesToMegabytes(bytes: number): number {
+		return Math.round((bytes / 1024 / 1024) * 100) / 100
+	}
+}


### PR DESCRIPTION
Introduces a new telemetry event `WEBVIEW_MEMORY_USAGE` to track memory metrics (heapUsed, heapTotal) from the webview.

- Adds `WEBVIEW_MEMORY_USAGE` to `TelemetryEventName` enum.
- Integrates `MemoryService` into `App.tsx` to start and stop memory tracking.
