### PR TITLE
fix(ghost): adjust ghost text decoration colors for visibility

### DIFF
--- a/src/services/ghost/GhostDecorations.ts
+++ b/src/services/ghost/GhostDecorations.ts
@@ -4,9 +4,10 @@ import { GhostSuggestionsState } from "./GhostSuggestions"
 const ADDITION_DECORATION_OPTIONS: vscode.DecorationRenderOptions = {
 	after: {
 		margin: "0 0 0 0.1em",
-		color: new vscode.ThemeColor("editor.foreground"),
+		color: new vscode.ThemeColor("editor.background"),
 		backgroundColor: new vscode.ThemeColor("editorGutter.addedBackground"),
 	},
+	opacity: "0.8",
 	isWholeLine: false,
 	overviewRulerColor: new vscode.ThemeColor("editorGutter.addedBackground"),
 	overviewRulerLane: vscode.OverviewRulerLane.Right,
@@ -24,7 +25,7 @@ const ADDITION_ACTIVE_DECORATION_OPTIONS: vscode.DecorationRenderOptions = {
 
 const DELETION_DECORATION_OPTIONS: vscode.DecorationRenderOptions = {
 	isWholeLine: false,
-	color: new vscode.ThemeColor("editor.foreground"),
+	color: new vscode.ThemeColor("editor.background"),
 	backgroundColor: new vscode.ThemeColor("editorGutter.deletedBackground"),
 	opacity: "0.8",
 	overviewRulerColor: new vscode.ThemeColor("editorGutter.deletedBackground"),


### PR DESCRIPTION
Switched the text color to `background` so it's slightly more readable in more themes:

![2025-07-30 16 33 51](https://github.com/user-attachments/assets/5a837603-2229-4fd3-acd7-b077c32a1c2a)

