### PR TITLE
Improve Playwright Screenshot flakes

### DIFF
--- a/apps/playwright-e2e/helpers/webview-helpers.ts
+++ b/apps/playwright-e2e/helpers/webview-helpers.ts
@@ -3,6 +3,8 @@ import { type Page, type FrameLocator, expect } from "@playwright/test"
 import type { WebviewMessage } from "../../../src/shared/WebviewMessage"
 import { ProviderSettings } from "@roo-code/types"
 
+const modifier = process.platform === "darwin" ? "Meta" : "Control"
+
 const defaultPlaywrightApiConfig = {
 	apiProvider: "openrouter" as const,
 	openRouterApiKey: process.env.OPENROUTER_API_KEY,
@@ -82,4 +84,17 @@ export async function configureApiKeyThroughUI(page: Page): Promise<void> {
 	await submitButton.waitFor()
 	await submitButton.click()
 	console.log("✅ Provider configured!")
+}
+
+export async function closeAllTabs(page: Page): Promise<void> {
+	const labelNameElements = page.locator(".tab a.label-name")
+	const count = await labelNameElements.count()
+	if (count > 0) {
+		// Close all editor tabs using the default keyboard command
+		await page.keyboard.press(`${modifier}+K`)
+		await page.keyboard.press(`${modifier}+W`)
+
+		const dismissedLabelNameElements = page.locator(".tab a.label-name")
+		await expect(dismissedLabelNameElements).not.toBeVisible()
+	}
 }

--- a/apps/playwright-e2e/helpers/webview-helpers.ts
+++ b/apps/playwright-e2e/helpers/webview-helpers.ts
@@ -87,14 +87,14 @@ export async function configureApiKeyThroughUI(page: Page): Promise<void> {
 }
 
 export async function closeAllTabs(page: Page): Promise<void> {
-	const labelNameElements = page.locator(".tab a.label-name")
-	const count = await labelNameElements.count()
+	const tabs = page.locator(".tab a.label-name")
+	const count = await tabs.count()
 	if (count > 0) {
-		// Close all editor tabs using the default keyboard command
+		// Close all editor tabs using the default keyboard command [Cmd+K Cmd+W]
 		await page.keyboard.press(`${modifier}+K`)
 		await page.keyboard.press(`${modifier}+W`)
 
-		const dismissedLabelNameElements = page.locator(".tab a.label-name")
-		await expect(dismissedLabelNameElements).not.toBeVisible()
+		const dismissedTabs = page.locator(".tab a.label-name")
+		await expect(dismissedTabs).not.toBeVisible()
 	}
 }

--- a/apps/playwright-e2e/tests/chat-with-response.test.ts
+++ b/apps/playwright-e2e/tests/chat-with-response.test.ts
@@ -6,12 +6,14 @@ test.describe("E2E Chat Test", () => {
 	test("should configure credentials and send a message", async ({ workbox: page, takeScreenshot }: TestFixtures) => {
 		await verifyExtensionInstalled(page)
 		await waitForWebviewText(page, "Welcome to Kilo Code!")
+
+		await page.waitForTimeout(1000) // Let the page settle to avoid flakes
 		await takeScreenshot("welcome")
 
 		await configureApiKeyThroughUI(page)
 		await waitForWebviewText(page, "Generate, refactor, and debug code with AI assistance")
 
-		await page.waitForTimeout(1000) // Let the page settle to avoid flakey screenshots
+		await page.waitForTimeout(1000) // Let the page settle to avoid flakes
 		await takeScreenshot("ready-to-chat")
 
 		// Don't take any more screenshots after the reponse starts-

--- a/apps/playwright-e2e/tests/playwright-base-test.ts
+++ b/apps/playwright-e2e/tests/playwright-base-test.ts
@@ -42,6 +42,13 @@ export const test = base.extend<TestFixtures>({
 
 		const electronApp = await _electron.launch({
 			executablePath: vscodePath,
+			env: {
+				...process.env,
+				VSCODE_DISABLE_CRASH_REPORTING: "1",
+				VSCODE_SKIP_GETTING_STARTED: "1",
+				VSCODE_DISABLE_WORKSPACE_TRUST: "1",
+				ELECTRON_DISABLE_SECURITY_WARNINGS: "1",
+			},
 			args: [
 				"--no-sandbox",
 				"--disable-gpu-sandbox",
@@ -60,6 +67,15 @@ export const test = base.extend<TestFixtures>({
 				"--disable-crash-reporter",
 				"--enable-logging",
 				"--log-level=0",
+				"--disable-extensions-except=kilocode.kilo-code",
+				"--disable-extension-recommendations",
+				"--disable-extension-update-check",
+				"--disable-default-apps",
+				"--disable-background-timer-throttling",
+				"--disable-backgrounding-occluded-windows",
+				"--disable-renderer-backgrounding",
+				"--disable-features=TranslateUI",
+				"--disable-component-extensions-with-background-pages",
 				`--extensionDevelopmentPath=${path.resolve(__dirname, "..", "..", "..", "src")}`,
 				`--extensions-dir=${path.join(defaultCachePath, "extensions")}`,
 				`--user-data-dir=${path.join(defaultCachePath, "user-data")}`,

--- a/apps/playwright-e2e/tests/playwright-base-test.ts
+++ b/apps/playwright-e2e/tests/playwright-base-test.ts
@@ -47,7 +47,6 @@ export const test = base.extend<TestFixtures>({
 			executablePath: vscodePath,
 			env: {
 				...process.env,
-				VSCODE_DISABLE_CRASH_REPORTING: "1",
 				VSCODE_SKIP_GETTING_STARTED: "1",
 				VSCODE_DISABLE_WORKSPACE_TRUST: "1",
 				ELECTRON_DISABLE_SECURITY_WARNINGS: "1",
@@ -75,9 +74,7 @@ export const test = base.extend<TestFixtures>({
 				"--disable-extension-update-check",
 				"--disable-default-apps",
 				"--disable-background-timer-throttling",
-				"--disable-backgrounding-occluded-windows",
 				"--disable-renderer-backgrounding",
-				"--disable-features=TranslateUI",
 				"--disable-component-extensions-with-background-pages",
 				`--extensionDevelopmentPath=${path.resolve(__dirname, "..", "..", "..", "src")}`,
 				`--extensions-dir=${path.join(defaultCachePath, "extensions")}`,
@@ -224,7 +221,7 @@ function seedUserSettings(userDataDir: string) {
 	fs.mkdirSync(userDir, { recursive: true })
 
 	const settings = {
-		"workbench.startupEditor": "none", // <- hides Get Started
+		"workbench.startupEditor": "none", // hides 'Get Started'
 		"workbench.tips.enabled": false,
 		"update.showReleaseNotes": false,
 		"extensions.ignoreRecommendations": true,

--- a/apps/playwright-e2e/tests/playwright-base-test.ts
+++ b/apps/playwright-e2e/tests/playwright-base-test.ts
@@ -191,9 +191,16 @@ export const test = base.extend<TestFixtures>({
 		}
 	},
 
-	takeScreenshot: async ({ workbox }, use) => {
+	takeScreenshot: async ({ workbox: page }, use) => {
 		await use(async (name?: string) => {
-			await closeAllTabs(workbox)
+			await closeAllTabs(page)
+
+			const activatingStatus = page.locator("text=Activating Extensions")
+			const activatingStatusCount = await activatingStatus.count()
+			if (activatingStatusCount > 0) {
+				console.log("⌛️ Waiting for `Activating Extensions` to go away...")
+				await activatingStatus.waitFor({ state: "hidden", timeout: 10000 })
+			}
 
 			const testInfo = test.info()
 			// Extract test suite from the test file name or use a default
@@ -209,7 +216,7 @@ export const test = base.extend<TestFixtures>({
 				.replace(/^-|-$/g, "") // Remove leading/trailing dashes
 
 			const screenshotPath = test.info().outputPath(`${hierarchicalName}.png`)
-			await workbox.screenshot({ path: screenshotPath, fullPage: true })
+			await page.screenshot({ path: screenshotPath, fullPage: true })
 			console.log(`📸 Screenshot captured: ${hierarchicalName}`)
 		})
 	},

--- a/apps/playwright-e2e/tests/sanity.test.ts
+++ b/apps/playwright-e2e/tests/sanity.test.ts
@@ -10,16 +10,6 @@ test.describe("Sanity Tests", () => {
 		await expect(page.locator(".activitybar")).toBeVisible()
 		console.log("✅ Activity bar visible")
 
-		const modifier = process.platform === "darwin" ? "Meta" : "Control"
-		const shortcut = `${modifier}+Shift+P`
-		await page.keyboard.press(shortcut)
-		const commandPalette = page.locator(".quick-input-widget")
-		await expect(commandPalette).toBeVisible()
-
-		await page.keyboard.press("Escape")
-		await expect(commandPalette).not.toBeVisible()
-		console.log("✅ Command palette working")
-
 		await setupTestEnvironment(page)
 	})
 })

--- a/apps/playwright-e2e/tests/settings-screenshots.test.ts
+++ b/apps/playwright-e2e/tests/settings-screenshots.test.ts
@@ -1,8 +1,8 @@
 import { test, expect, type TestFixtures } from "./playwright-base-test"
 import { verifyExtensionInstalled, findWebview, upsertApiConfiguration } from "../helpers/webview-helpers"
 
-test.describe("Settings Screenshots", () => {
-	test("should take screenshots of all settings tabs", async ({ workbox: page, takeScreenshot }: TestFixtures) => {
+test.describe("Settings", () => {
+	test("settings tab screenshot", async ({ workbox: page, takeScreenshot }: TestFixtures) => {
 		await verifyExtensionInstalled(page)
 		await upsertApiConfiguration(page)
 
@@ -36,7 +36,7 @@ test.describe("Settings Screenshots", () => {
 			const sectionId = testId?.replace("tab-", "") || `section-${i}`
 
 			console.log(`📸 Taking screenshot of tab: ${tabName} (${sectionId})`)
-			await takeScreenshot(`settings-${sectionId}-${tabName.toLowerCase().replace(/\s+/g, "-")}`)
+			await takeScreenshot(`${i}-settings-${sectionId}-${tabName.toLowerCase().replace(/\s+/g, "-")}`)
 		}
 
 		console.log("✅ All settings tabs screenshots completed")

--- a/apps/playwright-e2e/tests/settings-screenshots.test.ts
+++ b/apps/playwright-e2e/tests/settings-screenshots.test.ts
@@ -4,12 +4,12 @@ import { verifyExtensionInstalled, findWebview, upsertApiConfiguration } from ".
 test.describe("Settings Screenshots", () => {
 	test("should take screenshots of all settings tabs", async ({ workbox: page, takeScreenshot }: TestFixtures) => {
 		await verifyExtensionInstalled(page)
-
 		await upsertApiConfiguration(page)
 
-		// Open the settings
+		// Open the settings then move the mouse to avoid triggering the tooltip
 		page.locator('[aria-label*="Settings"], [title*="Settings"]').first().click()
-		await page.mouse.move(0, 0) // Move the mouse to (0, 0) to avoid triggering the tooltip!
+		await page.mouse.move(0, 0)
+		await page.mouse.click(0, 0)
 
 		const webviewFrame = await findWebview(page)
 		await expect(webviewFrame.locator('[role="tablist"]')).toBeVisible({ timeout: 10000 })


### PR DESCRIPTION
* close all open tabs before taking screenshots
* setup userSettings to set some flags before start
* move the cursor to prevent triggering the settings tooltip