### PR TITLE
Only run Run Playwright E2E tests if secrets are available

### DIFF
--- a/.github/workflows/storybook-playwright-snapshot.yml
+++ b/.github/workflows/storybook-playwright-snapshot.yml
@@ -18,6 +18,7 @@ env:
     COMPOSE_DOCKER_CLI_BUILD: 1
     NODE_VERSION: 20.19.2
     PNPM_VERSION: 10.8.1
+    SECRETS_SET: ${{ secrets.OPENROUTER_API_KEY != '' }}
     TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
@@ -71,6 +72,7 @@ jobs:
                   restore-keys: ${{ runner.os }}-buildx-
 
             - name: Run Playwright E2E tests
+              if: ${{ env.SECRETS_SET }}
               run: |
                   cd apps/playwright-e2e
                   node run-docker-playwright.js


### PR DESCRIPTION
This should prevent users that don't have access to our secrets from having failing builds!

Prevent builds from external users from failing like this:
<img width="1450" height="500" alt="CleanShot 2025-07-31 at 11 07 00@2x" src="https://github.com/user-attachments/assets/62e5a3b9-61fb-48c2-82eb-29fd132e1381" />

