### PR TITLE
Add focus to chat input in E2E test

### DIFF
--- a/apps/playwright-e2e/tests/chat-with-response.test.ts
+++ b/apps/playwright-e2e/tests/chat-with-response.test.ts
@@ -1,6 +1,12 @@
 // kilocode_change - new file
 import { test, type TestFixtures } from "./playwright-base-test"
-import { sendMessage, waitForWebviewText, verifyExtensionInstalled, configureApiKeyThroughUI } from "../helpers"
+import {
+	sendMessage,
+	waitForWebviewText,
+	verifyExtensionInstalled,
+	configureApiKeyThroughUI,
+	getChatInput,
+} from "../helpers"
 
 test.describe("E2E Chat Test", () => {
 	test("should configure credentials and send a message", async ({ workbox: page, takeScreenshot }: TestFixtures) => {
@@ -13,6 +19,7 @@ test.describe("E2E Chat Test", () => {
 		await configureApiKeyThroughUI(page)
 		await waitForWebviewText(page, "Generate, refactor, and debug code with AI assistance")
 
+		await (await getChatInput(page)).focus()
 		await page.waitForTimeout(1000) // Let the page settle to avoid flakes
 		await takeScreenshot("ready-to-chat")
 


### PR DESCRIPTION
Fix this flake

<img width="726" height="496" alt="CleanShot 2025-07-31 at 16 02 28@2x" src="https://github.com/user-attachments/assets/64511549-da86-4b11-b25b-117762b54e99" />
https://www.chromatic.com/test?appId=6851bcda14fd1c48ae0e387c&id=688b7017868380fd91c07290