### PR TITLE
Feature/kilo remove todo warning when disabled

### DIFF
--- a/.changeset/cuddly-days-chew.md
+++ b/.changeset/cuddly-days-chew.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Todo reminders are no longer included in the prompt when todo lists are disabled

--- a/src/core/environment/__tests__/getEnvironmentDetails.spec.ts
+++ b/src/core/environment/__tests__/getEnvironmentDetails.spec.ts
@@ -361,4 +361,33 @@ describe("getEnvironmentDetails", () => {
 
 		await expect(getEnvironmentDetails(mockCline as Task)).resolves.not.toThrow()
 	})
+	it("should include REMINDERS section when todoListEnabled is true", async () => {
+		mockProvider.getState.mockResolvedValue({
+			...mockState,
+			apiConfiguration: { todoListEnabled: true },
+		})
+		const cline = { ...mockCline, todoList: [{ content: "test", status: "pending" }] }
+		const result = await getEnvironmentDetails(cline as Task)
+		expect(result).toContain("REMINDERS")
+	})
+
+	it("should NOT include REMINDERS section when todoListEnabled is false", async () => {
+		mockProvider.getState.mockResolvedValue({
+			...mockState,
+			apiConfiguration: { todoListEnabled: false },
+		})
+		const cline = { ...mockCline, todoList: [{ content: "test", status: "pending" }] }
+		const result = await getEnvironmentDetails(cline as Task)
+		expect(result).not.toContain("REMINDERS")
+	})
+
+	it("should include REMINDERS section when todoListEnabled is undefined", async () => {
+		mockProvider.getState.mockResolvedValue({
+			...mockState,
+			apiConfiguration: {},
+		})
+		const cline = { ...mockCline, todoList: [{ content: "test", status: "pending" }] }
+		const result = await getEnvironmentDetails(cline as Task)
+		expect(result).toContain("REMINDERS")
+	})
 })

--- a/src/core/environment/getEnvironmentDetails.ts
+++ b/src/core/environment/getEnvironmentDetails.ts
@@ -292,6 +292,10 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 		}
 	}
 
-	const reminderSection = formatReminderSection(cline.todoList)
+	const todoListEnabled =
+		state && typeof state.apiConfiguration?.todoListEnabled === "boolean"
+			? state.apiConfiguration.todoListEnabled
+			: true
+	const reminderSection = todoListEnabled ? formatReminderSection(cline.todoList) : ""
 	return `<environment_details>\n${details.trim()}\n${reminderSection}\n</environment_details>`
 }


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->
When disabling the todo feature, warnings about todo lists will still be issued

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->
Add relevant checks before generating outgoing messages

## Screenshots

| before | after |
| ------ | ----- |
|    Always issue todo warnings, regardless of whether the todo feature is enabled    |   When the todo function is turned off, no todo related information will be carried    |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->
Check if there is a todo warning message at the end of the issued API request

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
