### PR TITLE
Extract KiloProfileSelector component and fix missing padding

### DIFF
--- a/.changeset/silly-mangos-lose.md
+++ b/.changeset/silly-mangos-lose.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix missing padding in the Profile selector

--- a/apps/storybook/stories/KiloProfileSelector.stories.tsx
+++ b/apps/storybook/stories/KiloProfileSelector.stories.tsx
@@ -1,3 +1,4 @@
+// kilocode_change - new file
 import React, { useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { KiloProfileSelector } from "../../../webview-ui/src/components/kilocode/chat/KiloProfileSelector"

--- a/apps/storybook/stories/KiloProfileSelector.stories.tsx
+++ b/apps/storybook/stories/KiloProfileSelector.stories.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from "react"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { KiloProfileSelector } from "../../../webview-ui/src/components/kilocode/chat/KiloProfileSelector"
+import { withI18n } from "../src/decorators/withI18n"
+import { withTheme } from "../src/decorators/withTheme"
+import { withTooltipProvider } from "../src/decorators/withTooltipProvider"
+import { withLimitedWidth } from "../src/decorators/withLimitedWidth"
+
+interface KiloProfileSelectorStoryProps {
+	initiallyOpen?: boolean
+}
+
+const KiloProfileSelectorStory = ({ initiallyOpen }: KiloProfileSelectorStoryProps) => {
+	const [pinnedConfigs, setPinnedConfigs] = useState<Record<string, boolean>>({
+		"anthropic-1": true,
+		"openai-2": false,
+	})
+
+	const mockApiConfigs = [
+		{ id: "anthropic-1", name: "Anthropic Claude" },
+		{ id: "gemini-3", name: "Google Gemini" },
+		{ id: "local-4", name: "Local Ollama" },
+	]
+
+	const togglePinnedApiConfig = (configId: string) => {
+		setPinnedConfigs((prev) => ({
+			...prev,
+			[configId]: !prev[configId],
+		}))
+		console.log("Toggled pin for config:", configId)
+	}
+
+	return (
+		<div style={{ maxWidth: `600px`, margin: "0 auto", height: 200 }}>
+			<KiloProfileSelector
+				currentConfigId="anthropic-1"
+				currentApiConfigName="Anthropic Claude"
+				displayName="Anthropic Claude"
+				listApiConfigMeta={mockApiConfigs}
+				pinnedApiConfigs={pinnedConfigs}
+				togglePinnedApiConfig={togglePinnedApiConfig}
+				selectApiConfigDisabled={false}
+				initiallyOpen={initiallyOpen}
+			/>
+		</div>
+	)
+}
+
+const meta: Meta<typeof KiloProfileSelectorStory> = {
+	title: "Components/KiloProfileSelector",
+	component: KiloProfileSelectorStory,
+	decorators: [withI18n, withTheme, withTooltipProvider, withLimitedWidth(400)],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: {},
+}
+
+export const Open: Story = {
+	args: {
+		initiallyOpen: true,
+	},
+}

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -19,12 +19,12 @@ import {
 	SearchResult,
 } from "@src/utils/context-mentions"
 import { convertToMentionPath } from "@/utils/path-mentions"
-import { DropdownOptionType, Button, StandardTooltip } from "@/components/ui"
+import { DropdownOptionType, Button, StandardTooltip } from "@/components/ui" // kilocode_change
 
 import Thumbnails from "../common/Thumbnails"
 import ModeSelector from "./ModeSelector"
 import KiloModeSelector from "./KiloModeSelector"
-import { KiloProfileSelector } from "../kilocode/chat/KiloProfileSelector"
+import { KiloProfileSelector } from "../kilocode/chat/KiloProfileSelector" // kilocode_change
 import { MAX_IMAGES_PER_MESSAGE } from "./ChatView"
 import ContextMenu from "./ContextMenu"
 import {

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -19,11 +19,12 @@ import {
 	SearchResult,
 } from "@src/utils/context-mentions"
 import { convertToMentionPath } from "@/utils/path-mentions"
-import { SelectDropdown, DropdownOptionType, Button, StandardTooltip } from "@/components/ui"
+import { DropdownOptionType, Button, StandardTooltip } from "@/components/ui"
 
 import Thumbnails from "../common/Thumbnails"
 import ModeSelector from "./ModeSelector"
 import KiloModeSelector from "./KiloModeSelector"
+import { KiloProfileSelector } from "../kilocode/chat/KiloProfileSelector"
 import { MAX_IMAGES_PER_MESSAGE } from "./ChatView"
 import ContextMenu from "./ContextMenu"
 import {
@@ -1198,132 +1199,15 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						{/* kilocode_change end */}
 					</div>
 
-					{/* kilocode_change start - hide if there is only one profile */}
-					<div
-						className={cn("flex-1", "min-w-0", "overflow-hidden", {
-							hidden: (listApiConfigMeta?.length ?? 0) < 2,
-						})}>
-						{/* kilocode_change end */}
-						<SelectDropdown
-							value={currentConfigId}
-							disabled={selectApiConfigDisabled}
-							title={t("chat:selectApiConfig")}
-							disableSearch={false}
-							placeholder={displayName}
-							options={[
-								// Pinned items first.
-								...(listApiConfigMeta || [])
-									.filter((config) => pinnedApiConfigs && pinnedApiConfigs[config.id])
-									.map((config) => ({
-										value: config.id,
-										label: config.name,
-										name: config.name, // Keep name for comparison with currentApiConfigName.
-										type: DropdownOptionType.ITEM,
-										pinned: true,
-									}))
-									.sort((a, b) => a.label.localeCompare(b.label)),
-								// If we have pinned items and unpinned items, add a separator.
-								...(pinnedApiConfigs &&
-								Object.keys(pinnedApiConfigs).length > 0 &&
-								(listApiConfigMeta || []).some((config) => !pinnedApiConfigs[config.id])
-									? [
-											{
-												value: "sep-pinned",
-												label: t("chat:separator"),
-												type: DropdownOptionType.SEPARATOR,
-											},
-										]
-									: []),
-								// Unpinned items sorted alphabetically.
-								...(listApiConfigMeta || [])
-									.filter((config) => !pinnedApiConfigs || !pinnedApiConfigs[config.id])
-									.map((config) => ({
-										value: config.id,
-										label: config.name,
-										name: config.name, // Keep name for comparison with currentApiConfigName.
-										type: DropdownOptionType.ITEM,
-										pinned: false,
-									}))
-									.sort((a, b) => a.label.localeCompare(b.label)),
-								{
-									value: "sep-2",
-									label: t("chat:separator"),
-									type: DropdownOptionType.SEPARATOR,
-								},
-								{
-									value: "settingsButtonClicked",
-									label: t("chat:edit"),
-									type: DropdownOptionType.ACTION,
-								},
-							]}
-							onChange={(value) => {
-								if (value === "settingsButtonClicked") {
-									vscode.postMessage({
-										type: "loadApiConfiguration",
-										text: value,
-										values: { section: "providers" },
-									})
-								} else {
-									vscode.postMessage({ type: "loadApiConfigurationById", text: value })
-								}
-							}}
-							contentClassName="max-h-[300px] overflow-y-auto"
-							// kilocode_change start - VSC Theme
-							triggerClassName={cn(
-								"w-full text-ellipsis overflow-hidden",
-								"bg-[var(--background)] border-[var(--vscode-input-border)] hover:bg-[var(--color-vscode-list-hoverBackground)]",
-							)}
-							// kilocode_change end
-							itemClassName="group"
-							renderItem={({ type, value, label, pinned }) => {
-								if (type !== DropdownOptionType.ITEM) {
-									return label
-								}
-
-								const config = listApiConfigMeta?.find((c) => c.id === value)
-								const isCurrentConfig = config?.name === currentApiConfigName
-
-								return (
-									<div className="flex justify-between gap-2 w-full h-5">
-										<div
-											className={cn("truncate min-w-0 overflow-hidden", {
-												"font-medium": isCurrentConfig,
-											})}>
-											{label}
-										</div>
-										<div className="flex justify-end w-10 flex-shrink-0">
-											<div
-												className={cn("size-5 p-1", {
-													"block group-hover:hidden": !pinned,
-													hidden: !isCurrentConfig,
-												})}>
-												<Check className="size-3" />
-											</div>
-											<StandardTooltip content={pinned ? t("chat:unpin") : t("chat:pin")}>
-												<Button
-													variant="ghost"
-													size="icon"
-													onClick={(e) => {
-														e.stopPropagation()
-														togglePinnedApiConfig(value)
-														vscode.postMessage({
-															type: "toggleApiConfigPin",
-															text: value,
-														})
-													}}
-													className={cn("size-5", {
-														"hidden group-hover:flex": !pinned,
-														"bg-accent": pinned,
-													})}>
-													<Pin className="size-3 p-0.5 opacity-50" />
-												</Button>
-											</StandardTooltip>
-										</div>
-									</div>
-								)
-							}}
-						/>
-					</div>
+					<KiloProfileSelector
+						currentConfigId={currentConfigId}
+						currentApiConfigName={currentApiConfigName}
+						displayName={displayName}
+						listApiConfigMeta={listApiConfigMeta}
+						pinnedApiConfigs={pinnedApiConfigs}
+						togglePinnedApiConfig={togglePinnedApiConfig}
+						selectApiConfigDisabled={selectApiConfigDisabled}
+					/>
 				</div>
 
 				{/* kilocode_change: hidden on small containerWidth

--- a/webview-ui/src/components/kilocode/chat/KiloProfileSelector.tsx
+++ b/webview-ui/src/components/kilocode/chat/KiloProfileSelector.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+// kilocode_change - new file
 import { SelectDropdown, DropdownOptionType, Button, StandardTooltip } from "@/components/ui"
 import { vscode } from "@/utils/vscode"
 import { useAppTranslation } from "@/i18n/TranslationContext"

--- a/webview-ui/src/components/kilocode/chat/KiloProfileSelector.tsx
+++ b/webview-ui/src/components/kilocode/chat/KiloProfileSelector.tsx
@@ -1,0 +1,165 @@
+import React from "react"
+import { SelectDropdown, DropdownOptionType, Button, StandardTooltip } from "@/components/ui"
+import { vscode } from "@/utils/vscode"
+import { useAppTranslation } from "@/i18n/TranslationContext"
+import { cn } from "@/lib/utils"
+import { Check, Pin } from "lucide-react"
+
+interface ApiConfigMeta {
+	id: string
+	name: string
+}
+
+interface KiloProfileSelectorProps {
+	currentConfigId: string
+	currentApiConfigName?: string
+	displayName: string
+	listApiConfigMeta?: ApiConfigMeta[]
+	pinnedApiConfigs?: Record<string, boolean>
+	togglePinnedApiConfig: (configId: string) => void
+	selectApiConfigDisabled?: boolean
+	initiallyOpen?: boolean
+}
+
+export const KiloProfileSelector = ({
+	currentConfigId,
+	currentApiConfigName,
+	displayName,
+	listApiConfigMeta,
+	pinnedApiConfigs,
+	togglePinnedApiConfig,
+	selectApiConfigDisabled = false,
+	initiallyOpen = false,
+}: KiloProfileSelectorProps) => {
+	const { t } = useAppTranslation()
+
+	// Hide if there is only one profile
+	if ((listApiConfigMeta?.length ?? 0) < 2) {
+		return null
+	}
+
+	return (
+		<div className={cn("flex-1", "min-w-0", "overflow-hidden")}>
+			<SelectDropdown
+				value={currentConfigId}
+				disabled={selectApiConfigDisabled}
+				title={t("chat:selectApiConfig")}
+				disableSearch={false}
+				placeholder={displayName}
+				initiallyOpen={initiallyOpen}
+				options={[
+					// Pinned items first.
+					...(listApiConfigMeta || [])
+						.filter((config) => pinnedApiConfigs && pinnedApiConfigs[config.id])
+						.map((config) => ({
+							value: config.id,
+							label: config.name,
+							name: config.name, // Keep name for comparison with currentApiConfigName.
+							type: DropdownOptionType.ITEM,
+							pinned: true,
+						}))
+						.sort((a, b) => a.label.localeCompare(b.label)),
+					// If we have pinned items and unpinned items, add a separator.
+					...(pinnedApiConfigs &&
+					Object.keys(pinnedApiConfigs).length > 0 &&
+					(listApiConfigMeta || []).some((config) => !pinnedApiConfigs[config.id])
+						? [
+								{
+									value: "sep-pinned",
+									label: t("chat:separator"),
+									type: DropdownOptionType.SEPARATOR,
+								},
+							]
+						: []),
+					// Unpinned items sorted alphabetically.
+					...(listApiConfigMeta || [])
+						.filter((config) => !pinnedApiConfigs || !pinnedApiConfigs[config.id])
+						.map((config) => ({
+							value: config.id,
+							label: config.name,
+							name: config.name, // Keep name for comparison with currentApiConfigName.
+							type: DropdownOptionType.ITEM,
+							pinned: false,
+						}))
+						.sort((a, b) => a.label.localeCompare(b.label)),
+					{
+						value: "sep-2",
+						label: t("chat:separator"),
+						type: DropdownOptionType.SEPARATOR,
+					},
+					{
+						value: "settingsButtonClicked",
+						label: t("chat:edit"),
+						type: DropdownOptionType.ACTION,
+					},
+				]}
+				onChange={(value) => {
+					if (value === "settingsButtonClicked") {
+						vscode.postMessage({
+							type: "loadApiConfiguration",
+							text: value,
+							values: { section: "providers" },
+						})
+					} else {
+						vscode.postMessage({ type: "loadApiConfigurationById", text: value })
+					}
+				}}
+				contentClassName="max-h-[300px] overflow-y-auto"
+				// kilocode_change start - VSC Theme
+				triggerClassName={cn(
+					"w-full text-ellipsis overflow-hidden",
+					"bg-[var(--background)] border-[var(--vscode-input-border)] hover:bg-[var(--color-vscode-list-hoverBackground)]",
+				)}
+				// kilocode_change end
+				itemClassName="group"
+				renderItem={({ type, value, label, pinned }) => {
+					if (type !== DropdownOptionType.ITEM) {
+						return <div className="py-1.5 px-3">{label}</div>
+					}
+
+					const config = listApiConfigMeta?.find((c) => c.id === value)
+					const isCurrentConfig = config?.name === currentApiConfigName
+
+					return (
+						<div className="flex justify-between gap-2 w-full py-1.5 px-3">
+							<div
+								className={cn("truncate min-w-0 overflow-hidden", {
+									"font-medium": isCurrentConfig,
+								})}>
+								{label}
+							</div>
+							<div className="flex justify-end w-10 flex-shrink-0">
+								<div
+									className={cn("size-5 p-1", {
+										"block group-hover:hidden": !pinned,
+										hidden: !isCurrentConfig,
+									})}>
+									<Check className="size-3" />
+								</div>
+								<StandardTooltip content={pinned ? t("chat:unpin") : t("chat:pin")}>
+									<Button
+										variant="ghost"
+										size="icon"
+										onClick={(e) => {
+											e.stopPropagation()
+											togglePinnedApiConfig(value)
+											vscode.postMessage({
+												type: "toggleApiConfigPin",
+												text: value,
+											})
+										}}
+										className={cn("size-5", {
+											"hidden group-hover:flex": !pinned,
+											"bg-accent": pinned,
+										})}>
+										<Pin className="size-3 p-0.5 opacity-50" />
+									</Button>
+								</StandardTooltip>
+							</div>
+						</div>
+					)
+				}}
+			/>
+		</div>
+	)
+}


### PR DESCRIPTION
The API configuration dropdown logic has been extracted into a new `KiloProfileSelector` component. This refactoring improves modularity and readability by moving complex UI logic out of `ChatTextArea.tsx`.

Test plan: Added story

Fixes this: 
<img width="822" height="812" alt="image" src="https://github.com/user-attachments/assets/4c3804b8-af52-448f-8d6c-491380141332" />

To This:
<img width="810" height="724" alt="CleanShot 2025-08-03 at 14 52 18@2x" src="https://github.com/user-attachments/assets/c23a09f7-17c5-4a49-911f-cc4801e9d6f7" />

