### PR TITLE
Fix cancellation/abort API requests immediately when hung

### DIFF
--- a/.changeset/petite-pianos-mix.md
+++ b/.changeset/petite-pianos-mix.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix immediate cancellation for KiloCode tasks - cancel button now responds within 500ms instead of hanging for minutes


### PR DESCRIPTION
## Context

Fixed immediate cancellation for KiloCode tasks. Previously, when users pressed the cancel button, the extension would hang for minutes before showing "terminate task". The main issue was API requests getting stuck during cancellation, requiring users to wait for long timeouts instead of getting immediate response.

## Implementation

Added AbortController integration to immediately terminate stuck API requests during cancellation. Enhanced streaming loop to check both existing abort flag and new AbortController signal for instant termination. Reduced graceful cancellation timeout from 3 seconds to 500ms in ClineProvider. Implemented comprehensive AbortController cleanup in all exit paths including success, error, and cancellation scenarios to prevent memory leaks. Modified terminal process abortion to be immediate rather than waiting for graceful shutdown timeouts.


## How to Test

Start a new KiloCode task with a complex request that would normally take time to process. Wait for the API request to begin streaming when you see the assistant starting to type. Click the "Cancel" button in the KiloCode interface. Expected result is task should stop immediately within 500ms instead of hanging for minutes. Verify no "terminate task" dialog appears after long delays. Test API request cancellation by starting a task that makes API calls to a slow provider, press cancel while the API request is in progress, and confirm API request aborts immediately with no hanging HTTP requests. Test terminal process cancellation by starting a task involving running terminal commands, press cancel while a command is executing, and verify terminal process terminates immediately along with the task.

## Get in Touch

danilofs83
