### PR TITLE
Fix workflows by disabling Roo command parsing

### DIFF
--- a/.changeset/red-coats-see.md
+++ b/.changeset/red-coats-see.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix workflows don't work

--- a/src/__tests__/command-mentions.spec.ts
+++ b/src/__tests__/command-mentions.spec.ts
@@ -10,7 +10,7 @@ vi.mock("../services/browser/UrlContentFetcher")
 const MockedUrlContentFetcher = vi.mocked(UrlContentFetcher)
 const mockGetCommand = vi.mocked(getCommand)
 
-describe("Command Mentions", () => {
+describe.skip("Command Mentions", () => {
 	let mockUrlContentFetcher: any
 
 	beforeEach(() => {

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -88,11 +88,14 @@ export async function parseMentions(
 	const mentions: Set<string> = new Set()
 	const commandMentions: Set<string> = new Set()
 
+	// kilocode_change start - disable commands
+	let parsedText = text
 	// First pass: extract command mentions (starting with /)
-	let parsedText = text.replace(commandRegexGlobal, (match, commandName) => {
-		commandMentions.add(commandName)
-		return `Command '${commandName}' (see below for command content)`
-	})
+	// let parsedText = text.replace(commandRegexGlobal, (match, commandName) => {
+	// 	commandMentions.add(commandName)
+	// 	return `Command '${commandName}' (see below for command content)`
+	// })
+	// kilocode_change end - disable commands
 
 	// Second pass: handle regular mentions
 	parsedText = parsedText.replace(mentionRegexGlobal, (match, mention) => {


### PR DESCRIPTION
The command parsing logic in `parseMentions` has been temporarily disabled to address an issue. This change is marked with `kilocode_change` comments.

Fixes #1733
