### PR TITLE
feat(gemini): add Gemma 3 27B

### DIFF
--- a/.changeset/fresh-beds-glow.md
+++ b/.changeset/fresh-beds-glow.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+feat(gemini): Add Gemma 3 27B to Gemini Provider

--- a/packages/types/src/providers/gemini.ts
+++ b/packages/types/src/providers/gemini.ts
@@ -295,4 +295,12 @@ export const geminiModels = {
 		supportsReasoningBudget: true,
 		maxThinkingTokens: 24_576,
 	},
+	"gemma-3-27b-it": {
+		maxTokens: 128_000,
+		contextWindow: 128_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+	},
 } as const satisfies Record<string, ModelInfo>

--- a/packages/types/src/providers/gemini.ts
+++ b/packages/types/src/providers/gemini.ts
@@ -295,6 +295,7 @@ export const geminiModels = {
 		supportsReasoningBudget: true,
 		maxThinkingTokens: 24_576,
 	},
+	// kilocode_change start
 	"gemma-3-27b-it": {
 		maxTokens: 128_000,
 		contextWindow: 128_000,
@@ -303,4 +304,5 @@ export const geminiModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 	},
+	// kilocode_change end
 } as const satisfies Record<string, ModelInfo>


### PR DESCRIPTION
## Context  
This PR closes Closes #1714  and introduces support for the **Gemma 3 27B** model in the Gemini provider configuration. The new model entry allows the system to recognize and utilize `gemma-3-27b-it`, a large multimodal model with extended context capabilities.

## Implementation  
- Added a new model entry: `gemma-3-27b-it`
- Defined key model properties:
  - `maxTokens: 128_000`
  - `contextWindow: 128_000`
  - `supportsImages: true`
  - `supportsPromptCache: false`
  - `inputPrice: 0`, `outputPrice: 0`
- Extended the `geminiModels` constant with the new model definition

## Screenshots  
<img width="307" height="435" alt="image" src="https://github.com/user-attachments/assets/69a49c98-4f4f-479d-944c-f041122db8b5" />

