### PR TITLE
fix: correctly report sub-task results in Orchestrator mode

### DIFF
--- a/.changeset/heavy-jeans-ask.md
+++ b/.changeset/heavy-jeans-ask.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix bug preventing Orchestrator mode sub-tasks from reporting their results properly

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -148,8 +148,8 @@ export class Task extends EventEmitter<TaskEvents> {
 	private taskIsFavorited?: boolean // kilocode_change
 	readonly instanceId: string
 
-	readonly rootTask: Task | undefined = undefined
-	readonly parentTask: Task | undefined = undefined
+	readonly rootTask: Task | undefined
+	readonly parentTask: Task | undefined
 	readonly taskNumber: number
 	readonly workspacePath: string
 


### PR DESCRIPTION
The `rootTask` and `parentTask` properties in the `Task` class were incorrectly initialized, preventing sub-tasks from properly reporting their results back to the main Orchestrator task. This commit fixes the initialization to ensure correct task hierarchy and result propagation.

The issue is with how TypeScript handles `readonly` properties when they have explicit initializers. Let me demonstrate:

```typescript
readonly rootTask: Task | undefined
readonly parentTask: Task | undefined
```

```typescript
readonly rootTask: Task | undefined = undefined
readonly parentTask: Task | undefined = undefined
```

When you declare a `readonly` property with an explicit initializer like `= undefined`, TypeScript treats this as a **definitive assignment** that happens at the class field level, **before** the constructor runs.

Here's what happens:

1. Class is instantiated
2. Constructor runs
3. `this.parentTask = parentTask` successfully assigns the parent task
4. Property now contains the actual parent task reference

1. Class is instantiated
2. **TypeScript immediately sets `this.parentTask = undefined` due to the field initializer**
3. Constructor runs
4. `this.parentTask = parentTask` tries to assign, but TypeScript may optimize this away or the field initializer takes precedence
5. Property remains `undefined` even though we tried to assign it

Fixes #1742
