### PR TITLE
Fix fireworks provider

### DIFF
--- a/.changeset/tricky-hairs-fetch.md
+++ b/.changeset/tricky-hairs-fetch.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix fireworks provider

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -208,6 +208,7 @@ export const SECRET_STATE_KEYS = [
 	"codebaseIndexMistralApiKey",
 	"huggingFaceApiKey",
 	"sambaNovaApiKey",
+	"fireworksApiKey",
 ] as const satisfies readonly (keyof ProviderSettings)[]
 export type SecretState = Pick<ProviderSettings, (typeof SECRET_STATE_KEYS)[number]>
 

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -287,8 +287,7 @@ const kilocodeSchema = baseProviderSettingsSchema.extend({
 	kilocodeModel: z.string().optional(),
 	openRouterSpecificProvider: z.string().optional(),
 })
-const fireworksSchema = baseProviderSettingsSchema.extend({
-	fireworksModelId: z.string().optional(),
+const fireworksSchema = apiModelIdProviderModelSchema.extend({
 	fireworksApiKey: z.string().optional(),
 })
 const cerebrasSchema = baseProviderSettingsSchema.extend({

--- a/packages/types/src/providers/fireworks.ts
+++ b/packages/types/src/providers/fireworks.ts
@@ -1,0 +1,63 @@
+import type { ModelInfo } from "../model.js"
+
+export type FireworksModelId =
+	| "accounts/fireworks/models/kimi-k2-instruct"
+	| "accounts/fireworks/models/qwen3-235b-a22b-instruct-2507"
+	| "accounts/fireworks/models/qwen3-coder-480b-a35b-instruct"
+	| "accounts/fireworks/models/deepseek-r1-0528"
+	| "accounts/fireworks/models/deepseek-v3"
+
+export const fireworksDefaultModelId: FireworksModelId = "accounts/fireworks/models/kimi-k2-instruct"
+
+export const fireworksModels = {
+	"accounts/fireworks/models/kimi-k2-instruct": {
+		maxTokens: 16384,
+		contextWindow: 128000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.6,
+		outputPrice: 2.5,
+		description:
+			"Kimi K2 is a state-of-the-art mixture-of-experts (MoE) language model with 32 billion activated parameters and 1 trillion total parameters. Trained with the Muon optimizer, Kimi K2 achieves exceptional performance across frontier knowledge, reasoning, and coding tasks while being meticulously optimized for agentic capabilities.",
+	},
+	"accounts/fireworks/models/qwen3-235b-a22b-instruct-2507": {
+		maxTokens: 32768,
+		contextWindow: 256000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.22,
+		outputPrice: 0.88,
+		description: "Latest Qwen3 thinking model, competitive against the best closed source models in Jul 2025.",
+	},
+	"accounts/fireworks/models/qwen3-coder-480b-a35b-instruct": {
+		maxTokens: 32768,
+		contextWindow: 256000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.45,
+		outputPrice: 1.8,
+		description: "Qwen3's most agentic code model to date.",
+	},
+	"accounts/fireworks/models/deepseek-r1-0528": {
+		maxTokens: 20480,
+		contextWindow: 160000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 3,
+		outputPrice: 8,
+		description:
+			"05/28 updated checkpoint of Deepseek R1. Its overall performance is now approaching that of leading models, such as O3 and Gemini 2.5 Pro. Compared to the previous version, the upgraded model shows significant improvements in handling complex reasoning tasks, and this version also offers a reduced hallucination rate, enhanced support for function calling, and better experience for vibe coding. Note that fine-tuning for this model is only available through contacting fireworks at https://fireworks.ai/company/contact-us.",
+	},
+	"accounts/fireworks/models/deepseek-v3": {
+		maxTokens: 16384,
+		contextWindow: 128000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.9,
+		outputPrice: 0.9,
+		description:
+			"A strong Mixture-of-Experts (MoE) language model with 671B total parameters with 37B activated for each token from Deepseek. Note that fine-tuning for this model is only available through contacting fireworks at https://fireworks.ai/company/contact-us.",
+	},
+} as const satisfies Record<string, ModelInfo>
+
+export const FIREWORKS_API_BASE_URL = "https://api.fireworks.ai/inference/v1"

--- a/packages/types/src/providers/index.ts
+++ b/packages/types/src/providers/index.ts
@@ -26,3 +26,4 @@ export * from "./zai.js"
 export * from "./bigmodel.js"
 // kilocode_change end
 export * from "./doubao.js"
+export * from "./fireworks.js"

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -37,9 +37,9 @@ import {
 	ClaudeCodeHandler,
 	SambaNovaHandler,
 	DoubaoHandler,
+	FireworksHandler,
 } from "./providers"
 // kilocode_change start
-import { FireworksHandler } from "./providers/fireworks"
 import { KilocodeOpenrouterHandler } from "./providers/kilocode-openrouter"
 import { KilocodeOllamaHandler } from "./providers/kilocode-ollama"
 // kilocode_change end

--- a/src/api/providers/__tests__/fireworks.test.ts
+++ b/src/api/providers/__tests__/fireworks.test.ts
@@ -1,15 +1,17 @@
-// npx jest src/api/providers/__tests__/fireworks.test.ts
+// npx vitest run api/providers/__tests__/fireworks.test.ts
 
 import { FireworksHandler } from "../fireworks"
-import { ApiHandlerOptions, fireworksDefaultModelId } from "../../../shared/api"
-import { Anthropic } from "@anthropic-ai/sdk"
-import { BaseProvider } from "../base-provider"
+import type { ApiHandlerOptions } from "../../../shared/api"
+import type { Anthropic } from "@anthropic-ai/sdk"
+import { fireworksDefaultModelId, fireworksModels } from "@roo-code/types"
 
 const mockCreate = vi.fn()
+
 vi.mock("openai", () => {
+	const mockConstructor = vi.fn()
 	return {
 		__esModule: true,
-		default: vi.fn().mockImplementation(() => ({
+		default: mockConstructor.mockImplementation(() => ({
 			chat: {
 				completions: {
 					create: mockCreate.mockImplementation(async (options) => {
@@ -18,7 +20,7 @@ vi.mock("openai", () => {
 								id: "test-completion",
 								choices: [
 									{
-										message: { role: "assistant", content: "Test response" },
+										message: { role: "assistant", content: "Test response", refusal: null },
 										finish_reason: "stop",
 										index: 0,
 									},
@@ -70,7 +72,10 @@ describe("FireworksHandler", () => {
 
 	beforeEach(() => {
 		mockOptions = {
-			fireworksApiKey: "test-api-key",
+			fireworksApiKey: "test-fireworks-api-key",
+			apiModelId: fireworksDefaultModelId,
+			includeMaxTokens: true,
+			modelTemperature: 0.5,
 		}
 		handler = new FireworksHandler(mockOptions)
 		mockCreate.mockClear()
@@ -82,29 +87,81 @@ describe("FireworksHandler", () => {
 			expect(handler.getModel().id).toBe(fireworksDefaultModelId)
 		})
 
-		it("should initialize with undefined API key", () => {
-			const handlerWithoutKey = new FireworksHandler({
+		it("should throw error if API key is missing", () => {
+			expect(() => {
+				new FireworksHandler({
+					...mockOptions,
+					fireworksApiKey: undefined,
+				})
+			}).toThrow("API key is required")
+		})
+
+		it("should use fireworks base URL", () => {
+			const handlerWithKey = new FireworksHandler({
 				...mockOptions,
-				fireworksApiKey: undefined,
+				fireworksApiKey: "test-key",
 			})
-			expect(handlerWithoutKey).toBeInstanceOf(FireworksHandler)
+			expect(handlerWithKey).toBeInstanceOf(FireworksHandler)
 		})
 
-		it("should prioritize apiModelId over fireworksModelId in constructor", () => {
-			const handler = new FireworksHandler({
-				fireworksApiKey: "test-api-key",
-				fireworksModelId: "accounts/fireworks/models/deepseek-v3",
-				apiModelId: "accounts/fireworks/models/llama-13b",
+		it("should set default temperature to 0.5", () => {
+			const handlerWithDefaults = new FireworksHandler({
+				fireworksApiKey: "test-key",
 			})
-			expect(handler.getModel().id).toBe("accounts/fireworks/models/llama-13b")
+			expect(handlerWithDefaults).toBeInstanceOf(FireworksHandler)
 		})
 
-		it("should use fireworksModelId when apiModelId is not provided", () => {
-			const handler = new FireworksHandler({
-				fireworksApiKey: "test-api-key",
-				fireworksModelId: "accounts/fireworks/models/deepseek-v3",
+		it("should override default model if provided in options", () => {
+			const customModelId = "accounts/fireworks/models/deepseek-v3"
+			const handlerWithCustomModel = new FireworksHandler({
+				...mockOptions,
+				apiModelId: customModelId,
 			})
-			expect(handler.getModel().id).toBe("accounts/fireworks/models/deepseek-v3")
+			expect(handlerWithCustomModel.getModel().id).toBe(customModelId)
+		})
+	})
+
+	describe("getModel", () => {
+		it("should return correct model info for default model", () => {
+			const model = handler.getModel()
+			expect(model.id).toBe(fireworksDefaultModelId)
+			expect(model.info).toEqual(fireworksModels[fireworksDefaultModelId])
+			expect(model.info.supportsPromptCache).toBe(false)
+			expect(model.info.supportsImages).toBe(false)
+		})
+
+		it("should return correct model info for deepseek-v3", () => {
+			const deepseekModelId = "accounts/fireworks/models/deepseek-v3"
+			const handlerWithDeepseek = new FireworksHandler({
+				...mockOptions,
+				apiModelId: deepseekModelId,
+			})
+			const model = handlerWithDeepseek.getModel()
+			expect(model.id).toBe(deepseekModelId)
+			expect(model.info).toEqual(fireworksModels[deepseekModelId])
+			expect(model.info.maxTokens).toBe(16384)
+			expect(model.info.contextWindow).toBe(128000)
+		})
+
+		it("should return correct model info for qwen3-235b", () => {
+			const qwenModelId = "accounts/fireworks/models/qwen3-235b-a22b-instruct-2507"
+			const handlerWithQwen = new FireworksHandler({
+				...mockOptions,
+				apiModelId: qwenModelId,
+			})
+			const model = handlerWithQwen.getModel()
+			expect(model.id).toBe(qwenModelId)
+			expect(model.info).toEqual(fireworksModels[qwenModelId])
+			expect(model.info.maxTokens).toBe(32768)
+			expect(model.info.contextWindow).toBe(256000)
+		})
+
+		it("should return correct pricing information", () => {
+			const model = handler.getModel()
+			expect(model.info.inputPrice).toBeDefined()
+			expect(model.info.outputPrice).toBeDefined()
+			expect(typeof model.info.inputPrice).toBe("number")
+			expect(typeof model.info.outputPrice).toBe("number")
 		})
 	})
 
@@ -113,90 +170,113 @@ describe("FireworksHandler", () => {
 		const messages: Anthropic.Messages.MessageParam[] = [
 			{
 				role: "user",
-				content: [
-					{
-						type: "text" as const,
-						text: "Hello!",
-					},
-				],
+				content: "Hello, how are you?",
 			},
 		]
 
-		it("should yield error message when API key is missing", async () => {
-			const handlerWithoutKey = new FireworksHandler({
-				...mockOptions,
-				fireworksApiKey: undefined,
-			})
+		it("should create streaming response", async () => {
+			const stream = handler.createMessage(systemPrompt, messages)
+			const chunks = []
 
-			const stream = handlerWithoutKey.createMessage(systemPrompt, messages)
-			const chunks: any[] = []
 			for await (const chunk of stream) {
 				chunks.push(chunk)
 			}
 
-			expect(chunks.length).toBe(1)
-			expect(chunks[0].type).toBe("text")
-			expect(chunks[0].text).toContain("ERROR: Fireworks API key is required")
+			expect(chunks).toHaveLength(2)
+			expect(chunks[0]).toEqual({
+				type: "text",
+				text: "Test response",
+			})
+			expect(chunks[1]).toEqual({
+				type: "usage",
+				inputTokens: 10,
+				outputTokens: 5,
+			})
 		})
 
-		it("should handle streaming responses", async () => {
+		it("should call OpenAI client with correct parameters", async () => {
 			const stream = handler.createMessage(systemPrompt, messages)
-			const chunks: any[] = []
+
+			// Consume the stream to trigger the API call
 			for await (const chunk of stream) {
-				chunks.push(chunk)
+				// Just consume the stream
 			}
 
-			expect(chunks.length).toBeGreaterThan(0)
-			const textChunks = chunks.filter((chunk) => chunk.type === "text")
-			expect(textChunks).toHaveLength(1)
-			expect(textChunks[0].text).toBe("Test response")
+			expect(mockCreate).toHaveBeenCalledWith({
+				model: fireworksDefaultModelId,
+				max_tokens: fireworksModels[fireworksDefaultModelId].maxTokens,
+				temperature: 0.5,
+				messages: [
+					{ role: "system", content: systemPrompt },
+					{ role: "user", content: "Hello, how are you?" },
+				],
+				stream: true,
+				stream_options: { include_usage: true },
+			})
+		})
+
+		it("should use custom temperature when provided", async () => {
+			const customHandler = new FireworksHandler({
+				...mockOptions,
+				modelTemperature: 0.8,
+			})
+
+			const stream = customHandler.createMessage(systemPrompt, messages)
+
+			// Consume the stream to trigger the API call
+			for await (const chunk of stream) {
+				// Just consume the stream
+			}
 
 			expect(mockCreate).toHaveBeenCalledWith(
 				expect.objectContaining({
-					model: fireworksDefaultModelId,
-					stream: true,
-					stream_options: { include_usage: true },
+					temperature: 0.8,
 				}),
 			)
-
-			const callArgs = mockCreate.mock.calls[0][0]
-			expect(callArgs.messages[0].role).toBe("system")
-			expect(callArgs.messages[0].content).toBe(systemPrompt)
 		})
 
-		it("should handle DeepSeek models differently", async () => {
-			vi.spyOn(handler, "getModel").mockReturnValueOnce({
-				id: "accounts/fireworks/models/deepseek-test" as any,
-				info: {
-					maxTokens: 4096,
-					contextWindow: 8192,
-					supportsImages: false,
-					supportsPromptCache: true,
-					inputPrice: 3.0,
-					outputPrice: 8.0,
-					cacheWritesPrice: 3.0,
-					cacheReadsPrice: 0.75,
+		it("should handle multiple messages correctly", async () => {
+			const multiMessages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "user",
+					content: "First message",
 				},
-			})
+				{
+					role: "assistant",
+					content: "First response",
+				},
+				{
+					role: "user",
+					content: "Second message",
+				},
+			]
 
-			const stream = handler.createMessage(systemPrompt, messages)
+			const stream = handler.createMessage(systemPrompt, multiMessages)
+
+			// Consume the stream to trigger the API call
 			for await (const chunk of stream) {
+				// Just consume the stream
 			}
 
-			const callArgs = mockCreate.mock.calls[0][0]
-			expect(callArgs.temperature).toBe(0.7)
-
-			const systemPromptMessage = callArgs.messages.find((msg: { role: string }) => msg.role === "system")
-			expect(systemPromptMessage).toBeDefined()
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					messages: [
+						{ role: "system", content: systemPrompt },
+						{ role: "user", content: "First message" },
+						{ role: "assistant", content: "First response" },
+						{ role: "user", content: "Second message" },
+					],
+				}),
+			)
 		})
 
-		it("should handle DeepSeek-r1 responses with <think> tags", async () => {
+		it("should handle empty content delta", async () => {
 			mockCreate.mockImplementationOnce(async () => ({
 				[Symbol.asyncIterator]: async function* () {
 					yield {
 						choices: [
 							{
-								delta: { content: "<think>\n\n</think>\n\nHello! I'm DeepSeek-R1" },
+								delta: { content: null },
 								index: 0,
 							},
 						],
@@ -210,573 +290,72 @@ describe("FireworksHandler", () => {
 							},
 						],
 						usage: {
-							prompt_tokens: 10,
-							completion_tokens: 46,
-							total_tokens: 56,
+							prompt_tokens: 5,
+							completion_tokens: 3,
+							total_tokens: 8,
 						},
 					}
 				},
 			}))
 
 			const stream = handler.createMessage(systemPrompt, messages)
-			const chunks: any[] = []
+			const chunks = []
+
 			for await (const chunk of stream) {
 				chunks.push(chunk)
 			}
 
-			const textChunks = chunks.filter((chunk) => chunk.type === "text")
-			expect(textChunks).toHaveLength(1)
-			expect(textChunks[0].text).toContain("<think>")
-			expect(textChunks[0].text).toContain("</think>")
-
-			const usageChunks = chunks.filter((chunk) => chunk.type === "usage")
-			expect(usageChunks).toHaveLength(1)
-			expect(usageChunks[0].inputTokens).toBe(10)
-			expect(usageChunks[0].outputTokens).toBe(46)
-		})
-
-		it("should correctly calculate max output tokens when prompt is near context window limit", async () => {
-			vi.spyOn(handler, "countTokens").mockResolvedValueOnce(8000)
-
-			vi.spyOn(handler, "getModel").mockReturnValueOnce({
-				id: "accounts/fireworks/models/deepseek-v3" as any,
-				info: {
-					maxTokens: 16000,
-					contextWindow: 8192,
-					supportsImages: false,
-					supportsPromptCache: true,
-					inputPrice: 3.0,
-					outputPrice: 8.0,
-					cacheWritesPrice: 3.0,
-					cacheReadsPrice: 0.75,
-				},
+			expect(chunks).toHaveLength(1)
+			expect(chunks[0]).toEqual({
+				type: "usage",
+				inputTokens: 5,
+				outputTokens: 3,
 			})
-
-			const stream = handler.createMessage(systemPrompt, messages)
-			for await (const chunk of stream) {
-			}
-
-			const callArgs = mockCreate.mock.calls[0][0]
-			expect(callArgs.max_tokens).toBe(192)
-		})
-
-		it("should use model specified in fireworksModelId option", async () => {
-			const customModelHandler = new FireworksHandler({
-				...mockOptions,
-				fireworksModelId: "accounts/fireworks/models/deepseek-v3",
-			})
-
-			const stream = customModelHandler.createMessage(systemPrompt, messages)
-			for await (const chunk of stream) {
-			}
-
-			const callArgs = mockCreate.mock.calls[0][0]
-			expect(callArgs.model).toBe("accounts/fireworks/models/deepseek-v3")
-		})
-
-		it("should prioritize apiModelId over fireworksModelId", async () => {
-			const customModelHandler = new FireworksHandler({
-				...mockOptions,
-				fireworksModelId: "accounts/fireworks/models/deepseek-v3",
-				apiModelId: "accounts/fireworks/models/llama-13b",
-			})
-
-			const stream = customModelHandler.createMessage(systemPrompt, messages)
-			for await (const chunk of stream) {
-			}
-
-			const callArgs = mockCreate.mock.calls[0][0]
-			expect(callArgs.model).toBe("accounts/fireworks/models/llama-13b")
-		})
-
-		it("should fall back to default model when invalid model ID is provided", async () => {
-			const handlerWithInvalidModel = new FireworksHandler({
-				...mockOptions,
-				fireworksModelId: "invalid-model-id" as any,
-			})
-
-			const stream = handlerWithInvalidModel.createMessage(systemPrompt, messages)
-			for await (const chunk of stream) {
-			}
-
-			const callArgs = mockCreate.mock.calls[0][0]
-			expect(callArgs.model).toBe("invalid-model-id")
-
-			expect(handlerWithInvalidModel.getModel().info).toEqual(
-				expect.objectContaining({
-					contextWindow: expect.any(Number),
-				}),
-			)
-		})
-
-		it("should handle and cap extremely large max_tokens values", async () => {
-			vi.spyOn(handler, "getModel").mockReturnValueOnce({
-				id: "accounts/fireworks/models/deepseek-v3" as any,
-				info: {
-					maxTokens: 200000,
-					contextWindow: 200000,
-					supportsImages: false,
-					supportsPromptCache: true,
-					inputPrice: 3.0,
-					outputPrice: 8.0,
-					cacheWritesPrice: 3.0,
-					cacheReadsPrice: 0.75,
-				},
-			})
-
-			const stream = handler.createMessage(systemPrompt, messages)
-			for await (const chunk of stream) {
-			}
-
-			const callArgs = mockCreate.mock.calls[0][0]
-			expect(callArgs.max_tokens).toBeLessThanOrEqual(200000)
-		})
-
-		it("should handle streaming errors gracefully", async () => {
-			mockCreate.mockImplementationOnce(async () => ({
-				// eslint-disable-next-line require-yield
-				[Symbol.asyncIterator]: async function* () {
-					throw new Error("Streaming interrupted")
-				},
-			}))
-
-			const stream = handler.createMessage(systemPrompt, messages)
-			const chunks: any[] = []
-			for await (const chunk of stream) {
-				chunks.push(chunk)
-			}
-
-			expect(chunks.length).toBe(1)
-			expect(chunks[0].type).toBe("text")
-			expect(chunks[0].text).toContain("ERROR")
-			expect(chunks[0].text).toContain("Streaming interrupted")
-		})
-
-		it("should handle excessively large prompts", async () => {
-			vi.spyOn(handler, "countTokens").mockResolvedValueOnce(100000)
-
-			const stream = handler.createMessage(systemPrompt, messages)
-			for await (const chunk of stream) {
-			}
-
-			const callArgs = mockCreate.mock.calls[0][0]
-			expect(callArgs.max_tokens).toBeGreaterThanOrEqual(100)
 		})
 	})
 
-	describe("error handling", () => {
-		const testMessages: Anthropic.Messages.MessageParam[] = [
-			{
-				role: "user",
-				content: [
-					{
-						type: "text" as const,
-						text: "Hello",
-					},
-				],
-			},
-		]
-
-		it("should handle 401 API errors (invalid key)", async () => {
-			const error = new Error("Invalid API key")
-			error.name = "Error"
-			;(error as any).status = 401
-			mockCreate.mockRejectedValueOnce(error)
-
-			const stream = handler.createMessage("system prompt", testMessages)
-			const chunks: any[] = []
-			for await (const chunk of stream) {
-				chunks.push(chunk)
-			}
-
-			expect(chunks.length).toBe(1)
-			expect(chunks[0].type).toBe("text")
-			expect(chunks[0].text).toContain("ERROR: Invalid Fireworks API key")
+	describe("provider specifics", () => {
+		it("should use Fireworks as provider name", () => {
+			expect(handler).toBeInstanceOf(FireworksHandler)
+			// The provider name is internal, but we can verify through constructor behavior
 		})
 
-		it("should handle 429 API errors (rate limit)", async () => {
-			const error = new Error("Rate limit exceeded")
-			error.name = "Error"
-			;(error as any).status = 429
-			mockCreate.mockRejectedValueOnce(error)
-
-			const stream = handler.createMessage("system prompt", testMessages)
-			const chunks: any[] = []
-			for await (const chunk of stream) {
-				chunks.push(chunk)
-			}
-
-			expect(chunks.length).toBe(1)
-			expect(chunks[0].type).toBe("text")
-			expect(chunks[0].text).toContain("ERROR: Rate limit exceeded")
+		it("should use correct API base URL", () => {
+			expect(handler).toBeInstanceOf(FireworksHandler)
+			// Base URL is set internally to https://api.fireworks.ai/inference/v1
 		})
 
-		it("should handle 400 API errors (bad request)", async () => {
-			const error = new Error("Bad request")
-			error.name = "Error"
-			;(error as any).status = 400
-			mockCreate.mockRejectedValueOnce(error)
+		it("should support all defined Fireworks models", () => {
+			const modelIds = Object.keys(fireworksModels)
 
-			const stream = handler.createMessage("system prompt", testMessages)
-			const chunks: any[] = []
-			for await (const chunk of stream) {
-				chunks.push(chunk)
-			}
-
-			expect(chunks.length).toBe(1)
-			expect(chunks[0].type).toBe("text")
-			expect(chunks[0].text).toContain("ERROR: Bad request")
-		})
-
-		it("should handle generic API errors", async () => {
-			const error = new Error("Unknown error")
-			mockCreate.mockRejectedValueOnce(error)
-
-			const stream = handler.createMessage("system prompt", testMessages)
-			const chunks: any[] = []
-			for await (const chunk of stream) {
-				chunks.push(chunk)
-			}
-
-			expect(chunks.length).toBe(1)
-			expect(chunks[0].type).toBe("text")
-			expect(chunks[0].text).toContain("ERROR: Unknown error")
-		})
-
-		it("should handle empty response content", async () => {
-			mockCreate.mockImplementationOnce(async () => ({
-				[Symbol.asyncIterator]: async function* () {
-					yield {
-						choices: [
-							{
-								delta: {},
-								index: 0,
-							},
-						],
-						usage: {
-							prompt_tokens: 10,
-							completion_tokens: 0,
-							total_tokens: 10,
-						},
-					}
-				},
-			}))
-
-			const stream = handler.createMessage("system prompt", testMessages)
-			const chunks: any[] = []
-			for await (const chunk of stream) {
-				chunks.push(chunk)
-			}
-
-			const textChunks = chunks.filter((chunk) => chunk.type === "text")
-			expect(textChunks.length).toBe(1)
-			expect(textChunks[0].text).toContain("No content was received from the model")
-		})
-
-		it("should handle context window exceedance errors", async () => {
-			const error = new Error(
-				"This model's maximum context length is 8192 tokens. However, your messages resulted in 10000 tokens",
-			)
-			error.name = "Error"
-			;(error as any).status = 400
-			mockCreate.mockRejectedValueOnce(error)
-
-			const stream = handler.createMessage("system prompt", testMessages)
-			const chunks: any[] = []
-			for await (const chunk of stream) {
-				chunks.push(chunk)
-			}
-
-			expect(chunks.length).toBe(1)
-			expect(chunks[0].type).toBe("text")
-			expect(chunks[0].text).toContain("ERROR: Bad request")
-			expect(chunks[0].text).toContain("prompt that's too large")
-		})
-
-		it("should handle network timeouts", async () => {
-			const error = new Error("Network timeout")
-			error.name = "TimeoutError"
-			mockCreate.mockRejectedValueOnce(error)
-
-			const stream = handler.createMessage("system prompt", testMessages)
-			const chunks: any[] = []
-			for await (const chunk of stream) {
-				chunks.push(chunk)
-			}
-
-			expect(chunks.length).toBe(1)
-			expect(chunks[0].type).toBe("text")
-			expect(chunks[0].text).toContain("ERROR")
-			expect(chunks[0].text).toContain("Network timeout")
-		})
-
-		it("should handle connection errors", async () => {
-			const error = new Error("Connection refused")
-			error.name = "ConnectionError"
-			mockCreate.mockRejectedValueOnce(error)
-
-			const stream = handler.createMessage("system prompt", testMessages)
-			const chunks: any[] = []
-			for await (const chunk of stream) {
-				chunks.push(chunk)
-			}
-
-			expect(chunks.length).toBe(1)
-			expect(chunks[0].type).toBe("text")
-			expect(chunks[0].text).toContain("ERROR")
-			expect(chunks[0].text).toContain("Connection refused")
-		})
-	})
-
-	describe("completePrompt", () => {
-		it("should complete prompt successfully", async () => {
-			const result = await handler.completePrompt("Test prompt")
-			expect(result).toBe("Test response")
-			expect(mockCreate).toHaveBeenCalledWith(
-				expect.objectContaining({
-					model: fireworksDefaultModelId,
-					messages: [{ role: "user", content: "Test prompt" }],
-				}),
-			)
-		})
-
-		it("should handle API errors", async () => {
-			mockCreate.mockRejectedValueOnce(new Error("API Error"))
-			await expect(handler.completePrompt("Test prompt")).rejects.toThrow("Fireworks completion error: API Error")
-		})
-
-		it("should handle missing API key", async () => {
-			const handlerWithoutKey = new FireworksHandler({
-				...mockOptions,
-				fireworksApiKey: undefined,
+			modelIds.forEach((modelId) => {
+				const testHandler = new FireworksHandler({
+					...mockOptions,
+					apiModelId: modelId as any,
+				})
+				expect(testHandler.getModel().id).toBe(modelId)
+				expect(testHandler.getModel().info).toEqual(fireworksModels[modelId as keyof typeof fireworksModels])
 			})
-			await expect(handlerWithoutKey.completePrompt("Test prompt")).rejects.toThrow(
-				"Fireworks API key is required",
-			)
 		})
 
-		it("should handle empty response", async () => {
-			mockCreate.mockImplementationOnce(() => ({
-				choices: [{ message: { content: "" } }],
-			}))
-			const result = await handler.completePrompt("Test prompt")
-			expect(result).toBe("")
-		})
-
-		it("should use correct parameters for non-streaming completion", async () => {
-			await handler.completePrompt("Test prompt with specific parameters")
-
-			expect(mockCreate).toHaveBeenCalledWith(
-				expect.objectContaining({
-					max_tokens: expect.any(Number),
-					temperature: 0.6,
-					top_p: 1,
-					presence_penalty: 0,
-					frequency_penalty: 0,
-				}),
-			)
-		})
-
-		it("should handle null or malformed API response", async () => {
-			mockCreate.mockImplementationOnce(() => ({
-				choices: [{ message: null }],
-			}))
-
-			const result = await handler.completePrompt("Test prompt")
-			expect(result).toBe("")
-		})
-
-		it("should handle multiple choices in response", async () => {
-			mockCreate.mockImplementationOnce(() => ({
-				choices: [
-					{ message: { role: "assistant", content: "Choice 1" }, index: 0 },
-					{ message: { role: "assistant", content: "Choice 2" }, index: 1 },
-				],
-			}))
-
-			const result = await handler.completePrompt("Test prompt")
-			expect(result).toBe("Choice 1")
-		})
-
-		it("should handle truncated responses", async () => {
-			mockCreate.mockImplementationOnce(() => ({
-				choices: [
-					{
-						message: { role: "assistant", content: "Truncated response" },
-						finish_reason: "length",
-					},
-				],
-			}))
-
-			const result = await handler.completePrompt("Test prompt")
-			expect(result).toBe("Truncated response")
-		})
-
-		it("should handle different finish reasons", async () => {
-			mockCreate.mockImplementationOnce(() => ({
-				choices: [
-					{
-						message: { role: "assistant", content: "Content filtered" },
-						finish_reason: "content_filter",
-					},
-				],
-			}))
-
-			const result = await handler.completePrompt("Test prompt")
-			expect(result).toBe("Content filtered")
-		})
-	})
-
-	describe("getModel", () => {
-		it("should return model info with default model", () => {
+		it("should have proper model info structure", () => {
 			const model = handler.getModel()
-			expect(model.id).toBe(fireworksDefaultModelId)
-			expect(model.info).toBeDefined()
-			expect(model.info.contextWindow).toBe(1000000)
-			expect(model.info.supportsImages).toBe(true)
-		})
 
-		it("should return info for explicitly specified model", () => {
-			const customModelHandler = new FireworksHandler({
-				...mockOptions,
-				fireworksModelId: "accounts/fireworks/models/deepseek-v3" as any,
-			})
+			expect(model.info).toHaveProperty("maxTokens")
+			expect(model.info).toHaveProperty("contextWindow")
+			expect(model.info).toHaveProperty("supportsImages")
+			expect(model.info).toHaveProperty("supportsPromptCache")
+			expect(model.info).toHaveProperty("inputPrice")
+			expect(model.info).toHaveProperty("outputPrice")
+			expect(model.info).toHaveProperty("description")
 
-			const model = customModelHandler.getModel()
-			expect(model.id).toBe("accounts/fireworks/models/deepseek-v3")
-		})
-
-		it("should fall back to default model info when invalid model is specified", () => {
-			const invalidModelHandler = new FireworksHandler({
-				...mockOptions,
-				fireworksModelId: "nonexistent-model" as any,
-			})
-
-			const model = invalidModelHandler.getModel()
-			expect(model.id).toBe("nonexistent-model")
-			expect(model.info).toBeDefined()
-		})
-
-		it("should provide correct info properties for different models", () => {
-			const deepseekHandler = new FireworksHandler({
-				...mockOptions,
-				fireworksModelId: "accounts/fireworks/models/deepseek-r1" as any,
-			})
-
-			const llama3Handler = new FireworksHandler({
-				...mockOptions,
-				fireworksModelId: "accounts/fireworks/models/llama-v3" as any,
-			})
-
-			expect(deepseekHandler.getModel().info).toBeDefined()
-			expect(llama3Handler.getModel().info).toBeDefined()
-		})
-
-		it("should handle model switching", () => {
-			const handler = new FireworksHandler({
-				...mockOptions,
-				fireworksModelId: "accounts/fireworks/models/deepseek-v3" as any,
-			})
-
-			expect(handler.getModel().id).toBe("accounts/fireworks/models/deepseek-v3")
-
-			handler["options"].apiModelId = "accounts/fireworks/models/llama-13b" as any
-
-			expect(handler.getModel().id).toBe("accounts/fireworks/models/llama-13b")
-		})
-	})
-
-	describe("countTokens", () => {
-		it("should use base provider's token counting", async () => {
-			const baseSpy = vi.spyOn(BaseProvider.prototype, "countTokens").mockResolvedValue(100)
-
-			const content = [{ type: "text" as const, text: "Hello world" }]
-			const result = await handler.countTokens(content)
-
-			expect(result).toBe(100)
-			expect(baseSpy).toHaveBeenCalledWith(content)
-
-			baseSpy.mockRestore()
-		})
-
-		it("should handle empty content for token counting", async () => {
-			const content: Anthropic.Messages.ContentBlockParam[] = []
-			const result = await handler.countTokens(content)
-
-			expect(result).toBe(0)
-		})
-
-		it("should handle image content blocks in token counting", async () => {
-			const baseCountSpy = vi.spyOn(BaseProvider.prototype, "countTokens").mockImplementation(async (content) => {
-				for (const block of content as Anthropic.Messages.ContentBlockParam[]) {
-					if (block.type === "image") {
-						return 500
-					}
-				}
-				return 10
-			})
-
-			const content = [
-				{
-					type: "image" as const,
-					source: {
-						type: "base64" as const,
-						media_type: "image/jpeg" as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
-						data: "mockBase64ImageData",
-					},
-				},
-			]
-
-			const result = await handler.countTokens(content)
-			expect(result).toBe(500)
-			expect(baseCountSpy).toHaveBeenCalledWith(content)
-
-			baseCountSpy.mockRestore()
-		})
-
-		it("should count tokens for mixed text and image content", async () => {
-			const baseCountSpy = vi.spyOn(BaseProvider.prototype, "countTokens").mockImplementation(async (content) => {
-				let totalTokens = 0
-				for (const block of content as Anthropic.Messages.ContentBlockParam[]) {
-					if (block.type === "image") {
-						totalTokens += 500
-					} else if (block.type === "text") {
-						totalTokens += 10
-					}
-				}
-				return totalTokens
-			})
-
-			const content = [
-				{ type: "text" as const, text: "Hello world" },
-				{
-					type: "image" as const,
-					source: {
-						type: "base64" as const,
-						media_type: "image/jpeg" as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
-						data: "mockBase64ImageData",
-					},
-				},
-			]
-
-			const result = await handler.countTokens(content)
-			expect(result).toBe(510)
-			expect(baseCountSpy).toHaveBeenCalledWith(content)
-
-			baseCountSpy.mockRestore()
-		})
-
-		it("should handle large text inputs", async () => {
-			const veryLongText = "A".repeat(10000)
-			const baseCountSpy = vi.spyOn(BaseProvider.prototype, "countTokens").mockResolvedValue(2500)
-
-			const content = [{ type: "text" as const, text: veryLongText }]
-			const result = await handler.countTokens(content)
-
-			expect(result).toBe(2500)
-			expect(baseCountSpy).toHaveBeenCalledWith(content)
-
-			baseCountSpy.mockRestore()
+			expect(typeof model.info.maxTokens).toBe("number")
+			expect(typeof model.info.contextWindow).toBe("number")
+			expect(typeof model.info.supportsImages).toBe("boolean")
+			expect(typeof model.info.supportsPromptCache).toBe("boolean")
+			expect(typeof model.info.inputPrice).toBe("number")
+			expect(typeof model.info.outputPrice).toBe("number")
+			expect(typeof model.info.description).toBe("string")
 		})
 	})
 })

--- a/src/api/providers/fireworks.ts
+++ b/src/api/providers/fireworks.ts
@@ -1,220 +1,24 @@
-import { Anthropic } from "@anthropic-ai/sdk"
-import OpenAI from "openai"
-import { ApiHandler, SingleCompletionHandler } from "../"
-import { ApiHandlerOptions, FireworksModelId, fireworksDefaultModelId, fireworksModels } from "../../shared/api"
-import { type ModelInfo } from "@roo-code/types"
-import { calculateApiCostOpenAI } from "../../shared/cost"
-import { convertToOpenAiMessages } from "../transform/openai-format"
-import { ApiStream } from "../transform/stream"
-import { BaseProvider } from "./base-provider"
+import {
+	type FireworksModelId,
+	fireworksDefaultModelId,
+	fireworksModels,
+	FIREWORKS_API_BASE_URL,
+} from "@roo-code/types"
 
-export class FireworksHandler extends BaseProvider implements ApiHandler, SingleCompletionHandler {
-	private options: ApiHandlerOptions
-	private client: OpenAI
-	private baseUrl: string = "https://api.fireworks.ai/inference/v1"
+import type { ApiHandlerOptions } from "../../shared/api"
 
+import { BaseOpenAiCompatibleProvider } from "./base-openai-compatible-provider"
+
+export class FireworksHandler extends BaseOpenAiCompatibleProvider<FireworksModelId> {
 	constructor(options: ApiHandlerOptions) {
-		super()
-		this.options = options
-		this.client = new OpenAI({
-			baseURL: this.baseUrl,
-			apiKey: this.options.fireworksApiKey,
+		super({
+			...options,
+			providerName: "Fireworks",
+			baseURL: FIREWORKS_API_BASE_URL,
+			apiKey: options.fireworksApiKey,
+			defaultProviderModelId: fireworksDefaultModelId,
+			providerModels: fireworksModels,
+			defaultTemperature: 0.5,
 		})
-	}
-
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
-		const model = this.getModel()
-
-		if (!this.options.fireworksApiKey) {
-			yield {
-				type: "text",
-				text:
-					"ERROR: Fireworks API key is required but was not provided.\n\n" +
-					"Please set your API key in the extension settings:\n" +
-					"1. Open the KiloCode settings panel\n" +
-					"2. Select 'Fireworks' as your provider\n" +
-					"3. Enter your API key\n\n" +
-					"You can get your API key from: https://fireworks.ai/account/api-keys",
-			}
-			return
-		}
-
-		// Format the messages according to OpenAI format, with special handling for DeepSeek models
-		let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = []
-		const isDeepSeek = model.id.includes("deepseek")
-
-		if (isDeepSeek) {
-			// DeepSeek models handle system prompts differently
-			if (systemPrompt.trim() !== "") {
-				openAiMessages.push({ role: "system", content: systemPrompt })
-			}
-			openAiMessages = [...openAiMessages, ...convertToOpenAiMessages(messages)]
-		} else {
-			// Standard OpenAI format
-			openAiMessages = [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)]
-		}
-
-		// Calculate token usage for prompt size limits
-		let estimatedTokens = 0
-		const contextWindow = model.info.contextWindow || 8191
-
-		try {
-			const contentBlocks = openAiMessages.map((msg) => ({
-				text: typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content),
-			}))
-
-			estimatedTokens = await this.countTokens(contentBlocks as any)
-		} catch (error) {
-			// Silently handle token counting errors
-		}
-
-		// Calculate max output tokens based on context window and input size
-		const maxOutputTokens = Math.min(model.info.maxTokens || 4096, Math.max(100, contextWindow - estimatedTokens))
-
-		try {
-			// Prepare request parameters
-			const requestOptions: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
-				model: model.id,
-				messages: openAiMessages,
-				max_tokens: maxOutputTokens,
-				temperature: isDeepSeek ? 0.7 : 0.6, // DeepSeek works better with slightly higher temperature
-				top_p: 1,
-				presence_penalty: 0,
-				frequency_penalty: 0,
-				stream: true,
-				stream_options: { include_usage: true },
-			}
-
-			// Send the request
-			const stream = await this.client.chat.completions.create(requestOptions)
-
-			// Process the streaming response
-			let contentStarted = false
-			let accumulatedText = ""
-
-			for await (const chunk of stream) {
-				const delta = chunk.choices[0]?.delta
-				if (delta?.content) {
-					contentStarted = true
-					accumulatedText += delta.content
-					yield {
-						type: "text",
-						text: delta.content,
-					}
-				}
-
-				// Process usage information if available
-				if (chunk.usage) {
-					yield {
-						type: "usage",
-						inputTokens: chunk.usage.prompt_tokens || 0,
-						outputTokens: chunk.usage.completion_tokens || 0,
-						totalCost: calculateApiCostOpenAI(
-							model.info,
-							chunk.usage.prompt_tokens || 0,
-							chunk.usage.completion_tokens || 0,
-						),
-					}
-				}
-			}
-
-			// Handle the case where no content was received
-			if (!contentStarted) {
-				yield {
-					type: "text",
-					text: "No content was received from the model. This could be an issue with the API or the model.",
-				}
-			}
-		} catch (error: any) {
-			// Other Providers provide these instructions in their JSON errors, but Fireworks doesn't, so we do it here
-			if (error.status === 401) {
-				yield {
-					type: "text",
-					text:
-						"ERROR: Invalid Fireworks API key.\n\n" +
-						"Please check your API key in the extension settings and make sure it is correct.\n" +
-						"You can find or create a new API key at: https://fireworks.ai/account/api-keys",
-				}
-			} else if (error.status === 429) {
-				yield {
-					type: "text",
-					text:
-						"ERROR: Rate limit exceeded.\n\n" +
-						"You have sent too many requests to the Fireworks API in a short period of time.\n" +
-						"Please try again later or consider upgrading your Fireworks AI plan at:\n" +
-						"https://fireworks.ai/pricing",
-				}
-			} else if (error.status === 400) {
-				yield {
-					type: "text",
-					text:
-						"ERROR: Bad request to Fireworks API.\n\n" +
-						"This might be due to invalid parameters or a prompt that's too large.\n" +
-						"Please try again with a shorter prompt or different parameters.",
-				}
-			} else if (error.status === 403) {
-				yield {
-					type: "text",
-					text:
-						"ERROR: Forbidden request to Fireworks API.\n\n" +
-						"The model name may be incorrect, or the model does not exist.\n" +
-						"This error is also returned to avoid leaking information about model availability.\n",
-				}
-			} else {
-				yield {
-					type: "text",
-					text:
-						`ERROR: ${error.message || "Failed to communicate with Fireworks API"}\n\n` +
-						"Please, check https://docs.fireworks.ai/troubleshooting/status_error_codes for more information.",
-				}
-			}
-		}
-	}
-
-	getModel(): { id: FireworksModelId; info: ModelInfo } {
-		const modelId =
-			((this.options.apiModelId || this.options.fireworksModelId) as FireworksModelId) || fireworksDefaultModelId
-		return {
-			id: modelId,
-			info: fireworksModels[modelId] || fireworksModels[fireworksDefaultModelId],
-		}
-	}
-
-	override async countTokens(content: Array<Anthropic.Messages.ContentBlockParam>): Promise<number> {
-		return super.countTokens(content)
-	}
-
-	async completePrompt(prompt: string): Promise<string> {
-		try {
-			const model = this.getModel()
-
-			if (!this.options.fireworksApiKey) {
-				throw new Error("Fireworks API key is required but was not provided")
-			}
-
-			// Special handling for DeepSeek models
-			const isDeepSeek = model.id.includes("deepseek")
-
-			// Prepare request parameters
-			const requestOptions: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming = {
-				model: model.id,
-				messages: [{ role: "user", content: prompt }],
-				max_tokens: model.info.maxTokens || 4096,
-				temperature: isDeepSeek ? 0.7 : 0.6, // DeepSeek works better with slightly higher temperature
-				top_p: 1,
-				presence_penalty: 0,
-				frequency_penalty: 0,
-			}
-
-			// Send the request
-			const response = await this.client.chat.completions.create(requestOptions)
-
-			return response.choices[0]?.message?.content || ""
-		} catch (error) {
-			if (error instanceof Error) {
-				throw new Error(`Fireworks completion error: ${error.message}`)
-			}
-			throw error
-		}
 	}
 }

--- a/src/api/providers/index.ts
+++ b/src/api/providers/index.ts
@@ -32,3 +32,4 @@ export { BigModelHandler } from "./bigmodel"
 // kilocode_change end
 export { VsCodeLmHandler } from "./vscode-lm"
 export { XAIHandler } from "./xai"
+export { FireworksHandler } from "./fireworks"

--- a/src/shared/ProfileValidator.ts
+++ b/src/shared/ProfileValidator.ts
@@ -70,6 +70,7 @@ export class ProfileValidator {
 			case "groq":
 			case "sambanova":
 			case "chutes":
+			case "fireworks":
 				return profile.apiModelId
 			case "litellm":
 				return profile.litellmModelId

--- a/src/shared/__tests__/ProfileValidator.spec.ts
+++ b/src/shared/__tests__/ProfileValidator.spec.ts
@@ -193,6 +193,7 @@ describe("ProfileValidator", () => {
 			"groq",
 			"chutes",
 			"sambanova",
+			"fireworks",
 		]
 
 		apiModelProviders.forEach((provider) => {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -10,53 +10,6 @@ import {
 export type ApiHandlerOptions = Omit<ProviderSettings, "apiProvider">
 
 // kilocode_change start
-// Fireworks
-// https://fireworks.ai/models
-// TODO: Add support for all Fireworks models, currently only supports DeepSeek's serverless models
-
-export const fireworksModels = {
-	"accounts/fireworks/models/deepseek-r1": {
-		maxTokens: 16384,
-		contextWindow: 160000,
-		supportsImages: false,
-		supportsPromptCache: true,
-		inputPrice: 3.0,
-		outputPrice: 8.0,
-	},
-
-	"accounts/fireworks/models/deepseek-v3": {
-		maxTokens: 16384,
-		contextWindow: 128_000,
-		supportsImages: false,
-		supportsPromptCache: true,
-		inputPrice: 0.9,
-		outputPrice: 0.9,
-	},
-
-	"accounts/fireworks/models/llama4-scout-instruct-basic": {
-		maxTokens: 16_384,
-		contextWindow: 128_000,
-		supportsImages: true,
-		supportsPromptCache: true,
-		inputPrice: 0.15,
-		outputPrice: 0.6,
-	},
-
-	"accounts/fireworks/models/llama4-maverick-instruct-basic": {
-		maxTokens: 16_384,
-		contextWindow: 1_000_000,
-		supportsImages: true,
-		supportsPromptCache: true,
-		inputPrice: 0.22,
-		outputPrice: 0.88,
-	},
-} as const satisfies Record<string, ModelInfo>
-
-export type FireworksModelId = keyof typeof fireworksModels
-export const fireworksDefaultModelId: FireworksModelId = "accounts/fireworks/models/llama4-maverick-instruct-basic"
-// kilocode_change end
-
-// kilocode_change start
 // Cerebras
 // https://inference-docs.cerebras.ai/api-reference/models
 

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, memo, useCallback, useEffect, useMemo, useState } from "react" // kilocode_change Fragment
 import { convertHeadersToObject } from "./utils/headers"
 import { useDebounce } from "react-use"
-import { VSCodeLink, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { ExternalLinkIcon } from "@radix-ui/react-icons"
 
 import {
@@ -33,6 +33,7 @@ import {
 	vertexDefaultModelId,
 	kilocodeDefaultModelId,
 	sambaNovaDefaultModelId,
+	fireworksDefaultModelId,
 } from "@roo-code/types"
 
 import { vscode } from "@src/utils/vscode"
@@ -91,6 +92,7 @@ import {
 	Cerebras,
 	VirtualQuotaFallbackProvider,
 	// kilocode_change end
+	Fireworks,
 } from "./providers"
 
 import { MODELS_BY_PROVIDER, PROVIDERS } from "./constants"
@@ -347,6 +349,7 @@ const ApiOptions = ({
 				kilocode: { field: "kilocodeModel", default: kilocodeDefaultModelId },
 				cerebras: { field: "cerebrasModelId", default: cerebrasDefaultModelId },
 				// kilocode_change end
+				fireworks: { field: "apiModelId", default: fireworksDefaultModelId },
 			}
 
 			const config = PROVIDER_MODEL_CONFIG[value]
@@ -376,7 +379,6 @@ const ApiOptions = ({
 		// kilocode_change start
 		// Providers that don't have documentation pages yet
 		const excludedProviders = [
-			"fireworks",
 			"gemini-cli",
 			"moonshot",
 			"chutes",
@@ -454,32 +456,7 @@ const ApiOptions = ({
 			{/* kilocode_change end */}
 
 			{selectedProvider === "fireworks" && (
-				<div>
-					<VSCodeTextField
-						value={apiConfiguration?.fireworksApiKey || ""}
-						style={{ width: "100%" }}
-						type="password"
-						onInput={handleInputChange("fireworksApiKey")}
-						placeholder="Enter API Key...">
-						<span style={{ fontWeight: 500 }}>Fireworks API Key</span>
-					</VSCodeTextField>
-					<p
-						style={{
-							fontSize: "12px",
-							marginTop: 3,
-							color: "var(--vscode-descriptionForeground)",
-						}}>
-						This key is stored locally and only used to make API requests from this extension.
-						{!apiConfiguration?.fireworksApiKey && (
-							<>
-								<br />
-								<br />
-								Get your API key from{" "}
-								<VSCodeLink href="https://fireworks.ai/account/api-keys">Fireworks</VSCodeLink>.
-							</>
-						)}
-					</p>
-				</div>
+				<Fireworks apiConfiguration={apiConfiguration} setApiConfigurationField={setApiConfigurationField} />
 			)}
 
 			{selectedProvider === "openrouter" && (

--- a/webview-ui/src/components/settings/constants.ts
+++ b/webview-ui/src/components/settings/constants.ts
@@ -20,9 +20,10 @@ import {
 	chutesModels,
 	sambaNovaModels,
 	doubaoModels,
+	fireworksModels,
 } from "@roo-code/types"
 
-import { fireworksModels, cerebrasModels } from "@roo/api" // kilocode_change
+import { cerebrasModels } from "@roo/api" // kilocode_change
 
 export const MODELS_BY_PROVIDER: Partial<Record<ProviderName, Record<string, ModelInfo>>> = {
 	anthropic: anthropicModels,
@@ -34,7 +35,6 @@ export const MODELS_BY_PROVIDER: Partial<Record<ProviderName, Record<string, Mod
 	gemini: geminiModels,
 	// kilocode_change start
 	"gemini-cli": geminiCliModels,
-	fireworks: fireworksModels,
 	zai: zaiModels,
 	bigmodel: bigModelModels,
 	cerebras: cerebrasModels,
@@ -46,6 +46,7 @@ export const MODELS_BY_PROVIDER: Partial<Record<ProviderName, Record<string, Mod
 	groq: groqModels,
 	chutes: chutesModels,
 	sambanova: sambaNovaModels,
+	fireworks: fireworksModels,
 }
 
 export const PROVIDERS = [
@@ -56,8 +57,8 @@ export const PROVIDERS = [
 	{ value: "gemini", label: "Google Gemini" },
 	{ value: "gemini-cli", label: "Gemini CLI" },
 	{ value: "doubao", label: "Doubao" },
+	{ value: "fireworks", label: "Fireworks AI" },
 	// kilocode_change start
-	{ value: "fireworks", label: "Fireworks" },
 	{ value: "zai", label: "Z.AI" },
 	{ value: "bigmodel", label: "BigModel" },
 	{ value: "cerebras", label: "Cerebras" },

--- a/webview-ui/src/components/settings/providers/Fireworks.tsx
+++ b/webview-ui/src/components/settings/providers/Fireworks.tsx
@@ -1,0 +1,50 @@
+import { useCallback } from "react"
+import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+
+import type { ProviderSettings } from "@roo-code/types"
+
+import { useAppTranslation } from "@src/i18n/TranslationContext"
+import { VSCodeButtonLink } from "@src/components/common/VSCodeButtonLink"
+
+import { inputEventTransform } from "../transforms"
+
+type FireworksProps = {
+	apiConfiguration: ProviderSettings
+	setApiConfigurationField: (field: keyof ProviderSettings, value: ProviderSettings[keyof ProviderSettings]) => void
+}
+
+export const Fireworks = ({ apiConfiguration, setApiConfigurationField }: FireworksProps) => {
+	const { t } = useAppTranslation()
+
+	const handleInputChange = useCallback(
+		<K extends keyof ProviderSettings, E>(
+			field: K,
+			transform: (event: E) => ProviderSettings[K] = inputEventTransform,
+		) =>
+			(event: E | Event) => {
+				setApiConfigurationField(field, transform(event as E))
+			},
+		[setApiConfigurationField],
+	)
+
+	return (
+		<>
+			<VSCodeTextField
+				value={apiConfiguration?.fireworksApiKey || ""}
+				type="password"
+				onInput={handleInputChange("fireworksApiKey")}
+				placeholder={t("settings:placeholders.apiKey")}
+				className="w-full">
+				<label className="block font-medium mb-1">{t("settings:providers.fireworksApiKey")}</label>
+			</VSCodeTextField>
+			<div className="text-sm text-vscode-descriptionForeground -mt-2">
+				{t("settings:providers.apiKeyStorageNotice")}
+			</div>
+			{!apiConfiguration?.fireworksApiKey && (
+				<VSCodeButtonLink href="https://fireworks.ai/" appearance="secondary">
+					{t("settings:providers.getFireworksApiKey")}
+				</VSCodeButtonLink>
+			)}
+		</>
+	)
+}

--- a/webview-ui/src/components/settings/providers/index.ts
+++ b/webview-ui/src/components/settings/providers/index.ts
@@ -29,3 +29,4 @@ export { VirtualQuotaFallbackProvider } from "./VirtualQuotaFallbackProvider"
 export { Cerebras } from "./Cerebras"
 // kilocode_change end
 export { LiteLLM } from "./LiteLLM"
+export { Fireworks } from "./Fireworks"

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -47,9 +47,11 @@ import {
 	sambaNovaDefaultModelId,
 	doubaoModels,
 	doubaoDefaultModelId,
+	fireworksDefaultModelId,
+	fireworksModels,
 } from "@roo-code/types"
 
-import { cerebrasModels, cerebrasDefaultModelId, fireworksDefaultModelId, fireworksModels } from "@roo/api" // kilocode_change
+import { cerebrasModels, cerebrasDefaultModelId } from "@roo/api" // kilocode_change
 
 import type { RouterModels } from "@roo/api"
 
@@ -308,12 +310,9 @@ function getSelectedModel({
 			}
 		}
 		case "fireworks": {
-			return {
-				id: apiConfiguration.fireworksModelId ?? fireworksDefaultModelId,
-				info: fireworksModels[
-					(apiConfiguration.fireworksModelId ?? fireworksDefaultModelId) as keyof typeof fireworksModels
-				],
-			}
+			const id = apiConfiguration.apiModelId ?? fireworksDefaultModelId
+			const info = fireworksModels[id as keyof typeof fireworksModels]
+			return { id, info }
 		}
 		case "virtual-quota-fallback": {
 			return {

--- a/webview-ui/src/i18n/locales/ar/settings.json
+++ b/webview-ui/src/i18n/locales/ar/settings.json
@@ -264,6 +264,8 @@
 		"getDeepSeekApiKey": "احصل على مفتاح DeepSeek",
 		"doubaoApiKey": "مفتاح Doubao",
 		"getDoubaoApiKey": "احصل على مفتاح Doubao",
+		"fireworksApiKey": "مفتاح Fireworks",
+		"getFireworksApiKey": "احصل على مفتاح Fireworks",
 		"zaiApiKey": "مفتاح Z.AI",
 		"getZaiApiKey": "احصل على مفتاح Z.AI",
 		"bigModelApiKey": "مفتاح BigModel",

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -264,6 +264,8 @@
 		"getDeepSeekApiKey": "Obtenir clau API de DeepSeek",
 		"doubaoApiKey": "Clau API de Doubao",
 		"getDoubaoApiKey": "Obtenir clau API de Doubao",
+		"fireworksApiKey": "Clau API de Fireworks",
+		"getFireworksApiKey": "Obtenir clau API de Fireworks",
 		"zaiApiKey": "Clau API de Z.AI",
 		"getZaiApiKey": "Obtenir clau API de Z.AI",
 		"bigModelApiKey": "Clau API de BigModel",

--- a/webview-ui/src/i18n/locales/cs/settings.json
+++ b/webview-ui/src/i18n/locales/cs/settings.json
@@ -264,6 +264,8 @@
 		"getDeepSeekApiKey": "Získat klíč API DeepSeek",
 		"doubaoApiKey": "Klíč API Doubao",
 		"getDoubaoApiKey": "Získat klíč API Doubao",
+		"fireworksApiKey": "Klíč API Fireworks",
+		"getFireworksApiKey": "Získat klíč API Fireworks",
 		"zaiApiKey": "Klíč API Z.AI",
 		"getZaiApiKey": "Získat klíč API Z.AI",
 		"bigModelApiKey": "Klíč API BigModel",

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -264,6 +264,8 @@
 		"getChutesApiKey": "Chutes API-Schlüssel erhalten",
 		"deepSeekApiKey": "DeepSeek API-Schlüssel",
 		"getDeepSeekApiKey": "DeepSeek API-Schlüssel erhalten",
+		"fireworksApiKey": "Fireworks API-Schlüssel",
+		"getFireworksApiKey": "Fireworks API-Schlüssel erhalten",
 		"moonshotApiKey": "Moonshot API-Schlüssel",
 		"getMoonshotApiKey": "Moonshot API-Schlüssel erhalten",
 		"moonshotBaseUrl": "Moonshot-Einstiegspunkt",

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -260,6 +260,8 @@
 		"getDeepSeekApiKey": "Get DeepSeek API Key",
 		"doubaoApiKey": "Doubao API Key",
 		"getDoubaoApiKey": "Get Doubao API Key",
+		"fireworksApiKey": "Fireworks API Key",
+		"getFireworksApiKey": "Get Fireworks API Key",
 		"zaiApiKey": "Z.AI API Key",
 		"getZaiApiKey": "Get Z.AI API Key",
 		"bigModelApiKey": "BigModel API Key",

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -260,6 +260,8 @@
 		"getDeepSeekApiKey": "Obtener clave API de DeepSeek",
 		"doubaoApiKey": "Clave API de Doubao",
 		"getDoubaoApiKey": "Obtener clave API de Doubao",
+		"fireworksApiKey": "Clave API de Fireworks",
+		"getFireworksApiKey": "Obtener clave API de Fireworks",
 		"zaiApiKey": "Clave API de Z.AI",
 		"getZaiApiKey": "Obtener clave API de Z.AI",
 		"bigModelApiKey": "Clave API de BigModel",

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -260,6 +260,8 @@
 		"getDeepSeekApiKey": "Obtenir la clé API DeepSeek",
 		"doubaoApiKey": "Clé API Doubao",
 		"getDoubaoApiKey": "Obtenir la clé API Doubao",
+		"fireworksApiKey": "Clé API Fireworks",
+		"getFireworksApiKey": "Obtenir la clé API Fireworks",
 		"zaiApiKey": "Clé API Z.AI",
 		"getZaiApiKey": "Obtenir la clé API Z.AI",
 		"bigModelApiKey": "Clé API BigModel",

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -264,6 +264,8 @@
 		"getDeepSeekApiKey": "DeepSeek API कुंजी प्राप्त करें",
 		"doubaoApiKey": "डौबाओ API कुंजी",
 		"getDoubaoApiKey": "डौबाओ API कुंजी प्राप्त करें",
+		"fireworksApiKey": "Fireworks API कुंजी",
+		"getFireworksApiKey": "Fireworks API कुंजी प्राप्त करें",
 		"zaiApiKey": "Z.AI API कुंजी",
 		"getZaiApiKey": "Z.AI API कुंजी प्राप्त करें",
 		"bigModelApiKey": "BigModel API कुंजी",

--- a/webview-ui/src/i18n/locales/id/settings.json
+++ b/webview-ui/src/i18n/locales/id/settings.json
@@ -264,6 +264,8 @@
 		"getDeepSeekApiKey": "Dapatkan DeepSeek API Key",
 		"doubaoApiKey": "Kunci API Doubao",
 		"getDoubaoApiKey": "Dapatkan Kunci API Doubao",
+		"fireworksApiKey": "Kunci API Fireworks",
+		"getFireworksApiKey": "Dapatkan Kunci API Fireworks",
 		"zaiApiKey": "Kunci API Z.AI",
 		"getZaiApiKey": "Dapatkan Kunci API Z.AI",
 		"bigModelApiKey": "Kunci API BigModel",

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -260,6 +260,8 @@
 		"getDeepSeekApiKey": "Ottieni chiave API DeepSeek",
 		"doubaoApiKey": "Chiave API Doubao",
 		"getDoubaoApiKey": "Ottieni chiave API Doubao",
+		"fireworksApiKey": "Chiave API Fireworks",
+		"getFireworksApiKey": "Ottieni chiave API Fireworks",
 		"zaiApiKey": "Chiave API Z.AI",
 		"getZaiApiKey": "Ottieni chiave API Z.AI",
 		"bigModelApiKey": "Chiave API BigModel",

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -260,6 +260,8 @@
 		"getDeepSeekApiKey": "DeepSeek APIキーを取得",
 		"doubaoApiKey": "Doubao APIキー",
 		"getDoubaoApiKey": "Doubao APIキーを取得",
+		"fireworksApiKey": "Fireworks APIキー",
+		"getFireworksApiKey": "Fireworks APIキーを取得",
 		"zaiApiKey": "Z.AI APIキー",
 		"getZaiApiKey": "Z.AI APIキーを取得",
 		"bigModelApiKey": "BigModel APIキー",

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -260,6 +260,8 @@
 		"getDeepSeekApiKey": "DeepSeek API 키 받기",
 		"doubaoApiKey": "Doubao API 키",
 		"getDoubaoApiKey": "Doubao API 키 받기",
+		"fireworksApiKey": "Fireworks API 키",
+		"getFireworksApiKey": "Fireworks API 키 받기",
 		"zaiApiKey": "Z.AI API 키",
 		"getZaiApiKey": "Z.AI API 키 받기",
 		"bigModelApiKey": "BigModel API 키",

--- a/webview-ui/src/i18n/locales/nl/settings.json
+++ b/webview-ui/src/i18n/locales/nl/settings.json
@@ -260,6 +260,8 @@
 		"getDeepSeekApiKey": "DeepSeek API-sleutel ophalen",
 		"doubaoApiKey": "Doubao API-sleutel",
 		"getDoubaoApiKey": "Doubao API-sleutel ophalen",
+		"fireworksApiKey": "Fireworks API-sleutel",
+		"getFireworksApiKey": "Fireworks API-sleutel ophalen",
 		"zaiApiKey": "Z.AI API-sleutel",
 		"getZaiApiKey": "Z.AI API-sleutel ophalen",
 		"bigModelApiKey": "BigModel API-sleutel",

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -260,6 +260,8 @@
 		"getDeepSeekApiKey": "Uzyskaj klucz API DeepSeek",
 		"doubaoApiKey": "Klucz API Doubao",
 		"getDoubaoApiKey": "Uzyskaj klucz API Doubao",
+		"fireworksApiKey": "Klucz API Fireworks",
+		"getFireworksApiKey": "Uzyskaj klucz API Fireworks",
 		"zaiApiKey": "Klucz API Z.AI",
 		"getZaiApiKey": "Uzyskaj klucz API Z.AI",
 		"bigModelApiKey": "Klucz API BigModel",

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -264,6 +264,8 @@
 		"getDeepSeekApiKey": "Obter chave de API DeepSeek",
 		"doubaoApiKey": "Chave de API Doubao",
 		"getDoubaoApiKey": "Obter chave de API Doubao",
+		"fireworksApiKey": "Chave de API Fireworks",
+		"getFireworksApiKey": "Obter chave de API Fireworks",
 		"zaiApiKey": "Chave de API Z.AI",
 		"getZaiApiKey": "Obter chave de API Z.AI",
 		"bigModelApiKey": "Chave de API BigModel",

--- a/webview-ui/src/i18n/locales/ru/settings.json
+++ b/webview-ui/src/i18n/locales/ru/settings.json
@@ -264,6 +264,8 @@
 		"getDeepSeekApiKey": "Получить DeepSeek API-ключ",
 		"doubaoApiKey": "Doubao API-ключ",
 		"getDoubaoApiKey": "Получить Doubao API-ключ",
+		"fireworksApiKey": "Fireworks API-ключ",
+		"getFireworksApiKey": "Получить Fireworks API-ключ",
 		"zaiApiKey": "Z.AI API-ключ",
 		"getZaiApiKey": "Получить Z.AI API-ключ",
 		"bigModelApiKey": "BigModel API-ключ",

--- a/webview-ui/src/i18n/locales/th/settings.json
+++ b/webview-ui/src/i18n/locales/th/settings.json
@@ -258,6 +258,8 @@
 		"getChutesApiKey": "รับคีย์ API ของ Chutes",
 		"deepSeekApiKey": "คีย์ API ของ DeepSeek",
 		"getDeepSeekApiKey": "รับคีย์ API ของ DeepSeek",
+		"fireworksApiKey": "คีย์ API ของ Fireworks",
+		"getFireworksApiKey": "รับคีย์ API ของ Fireworks",
 		"moonshotApiKey": "คีย์ API ของ Moonshot",
 		"getMoonshotApiKey": "รับคีย์ API ของ Moonshot",
 		"moonshotBaseUrl": "จุดเข้าใช้งาน Moonshot",

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -264,6 +264,8 @@
 		"getDeepSeekApiKey": "DeepSeek API Anahtarı Al",
 		"doubaoApiKey": "Doubao API Anahtarı",
 		"getDoubaoApiKey": "Doubao API Anahtarı Al",
+		"fireworksApiKey": "Fireworks API Anahtarı",
+		"getFireworksApiKey": "Fireworks API Anahtarı Al",
 		"zaiApiKey": "Z.AI API Anahtarı",
 		"getZaiApiKey": "Z.AI API Anahtarı Al",
 		"bigModelApiKey": "BigModel API Anahtarı",

--- a/webview-ui/src/i18n/locales/uk/settings.json
+++ b/webview-ui/src/i18n/locales/uk/settings.json
@@ -264,6 +264,8 @@
 		"getChutesApiKey": "Отримати ключ API Chutes",
 		"deepSeekApiKey": "Ключ API DeepSeek",
 		"getDeepSeekApiKey": "Отримати ключ API DeepSeek",
+		"fireworksApiKey": "Ключ API Fireworks",
+		"getFireworksApiKey": "Отримати ключ API Fireworks",
 		"moonshotApiKey": "Ключ API Moonshot",
 		"getMoonshotApiKey": "Отримати ключ API Moonshot",
 		"moonshotBaseUrl": "Точка входу Moonshot",

--- a/webview-ui/src/i18n/locales/vi/settings.json
+++ b/webview-ui/src/i18n/locales/vi/settings.json
@@ -264,6 +264,8 @@
 		"getDeepSeekApiKey": "Lấy khóa API DeepSeek",
 		"doubaoApiKey": "Khóa API Doubao",
 		"getDoubaoApiKey": "Lấy khóa API Doubao",
+		"fireworksApiKey": "Khóa API Fireworks",
+		"getFireworksApiKey": "Lấy khóa API Fireworks",
 		"zaiApiKey": "Khóa API Z.AI",
 		"getZaiApiKey": "Lấy khóa API Z.AI",
 		"bigModelApiKey": "Khóa API BigModel",

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -265,6 +265,8 @@
 		"getDeepSeekApiKey": "获取 DeepSeek API 密钥",
 		"doubaoApiKey": "豆包 API 密钥",
 		"getDoubaoApiKey": "获取豆包 API 密钥",
+		"fireworksApiKey": "Fireworks API 密钥",
+		"getFireworksApiKey": "获取 Fireworks API 密钥",
 		"zaiApiKey": "Z.AI API 密钥",
 		"getZaiApiKey": "获取 Z.AI API 密钥",
 		"bigModelApiKey": "BigModel API 密钥",

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -264,6 +264,8 @@
 		"getDeepSeekApiKey": "取得 DeepSeek API 金鑰",
 		"doubaoApiKey": "豆包 API 金鑰",
 		"getDoubaoApiKey": "取得豆包 API 金鑰",
+		"fireworksApiKey": "Fireworks API 金鑰",
+		"getFireworksApiKey": "取得 Fireworks API 金鑰",
 		"zaiApiKey": "Z.AI API 金鑰",
 		"getZaiApiKey": "取得 Z.AI API 金鑰",
 		"bigModelApiKey": "BigModel API 金鑰",

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -109,7 +109,7 @@ function validateModelsAndKeysProvided(apiConfiguration: ProviderSettings): stri
 			break
 		case "fireworks":
 			if (!apiConfiguration.fireworksApiKey) {
-				return "You must provide a valid API key or choose a different provider."
+				return i18next.t("settings:validation.apiKey")
 			}
 			break
 		// kilocode_change start


### PR DESCRIPTION
## Context

The models from the provider Fireworks AI were outdated, and users were unable to select Fireworks AI as the provider on the initial setup page—the “Let’s Go” button did not function properly.

This PR addresses the following issues:
1. Fixes the bug preventing users from selecting Fireworks AI as the provider on the initial setup page.
2. Updates the list of models to include the latest ones from Fireworks AI.

## Implementation

It’s fairly straightforward—I followed the implementation pattern used for the other providers and applied the same approach to Fireworks AI.



## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

- Open the KiloCode extension page in VS Code.
- Click “Use your own key” and select Fireworks AI as the LLM provider.
- Enter your API key and choose a model.
- Click “Let’s Go”—you should now be able to use KiloCode with Fireworks AI.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
----------------------
Fixes https://github.com/Kilo-Org/kilocode/issues/1570