### PR TITLE
fix(playwright): Fix Playwright tests

### DIFF
--- a/apps/playwright-e2e/playwright.config.ts
+++ b/apps/playwright-e2e/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig<void, TestOptions>({
 	timeout: 120_000,
 	expect: { timeout: 30_000 },
 	reporter: process.env.CI ? "html" : "list",
-	workers: process.env.CI ? 2 : 1,
+	workers: 1,
 	retries: process.env.CI ? 2 : 0, // Retry in CI, never locally
 	globalSetup: "./playwright.globalSetup",
 	testDir: "./tests",

--- a/apps/playwright-e2e/tests/chat-with-response.test.ts
+++ b/apps/playwright-e2e/tests/chat-with-response.test.ts
@@ -6,6 +6,7 @@ import {
 	verifyExtensionInstalled,
 	configureApiKeyThroughUI,
 	getChatInput,
+	closeAllToastNotifications,
 } from "../helpers"
 
 test.describe("E2E Chat Test", () => {
@@ -14,6 +15,8 @@ test.describe("E2E Chat Test", () => {
 		await waitForWebviewText(page, "Welcome to Kilo Code!")
 
 		await page.waitForTimeout(1000) // Let the page settle to avoid flakes
+
+		await closeAllToastNotifications(page)
 		await takeScreenshot("welcome")
 
 		await configureApiKeyThroughUI(page)

--- a/apps/playwright-e2e/tests/playwright-base-test.ts
+++ b/apps/playwright-e2e/tests/playwright-base-test.ts
@@ -7,7 +7,7 @@ import * as fs from "fs"
 import { fileURLToPath } from "url"
 import { camelCase } from "change-case"
 import { setupConsoleLogging, cleanLogMessage } from "../helpers/console-logging"
-import { closeAllTabs, closeAllToastNotifications, waitForAllExtensionActivation } from "../helpers"
+import { waitForAllExtensionActivation, closeAllTabs } from "../helpers"
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url)
@@ -195,7 +195,6 @@ export const test = base.extend<TestFixtures>({
 		await use(async (name?: string) => {
 			await waitForAllExtensionActivation(page)
 			await closeAllTabs(page)
-			await closeAllToastNotifications(page)
 
 			// Extract test suite from the test file name or use a default
 			const testInfo = test.info()

--- a/apps/playwright-e2e/tests/settings-screenshots.test.ts
+++ b/apps/playwright-e2e/tests/settings-screenshots.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, type TestFixtures } from "./playwright-base-test"
 import { verifyExtensionInstalled, findWebview, upsertApiConfiguration } from "../helpers/webview-helpers"
+import { closeAllToastNotifications } from "../helpers"
 
 test.describe("Settings", () => {
 	test("settings tab screenshot", async ({ workbox: page, takeScreenshot }: TestFixtures) => {
@@ -35,7 +36,7 @@ test.describe("Settings", () => {
 			const testId = await tabButton.getAttribute("data-testid")
 			const sectionId = testId?.replace("tab-", "") || `section-${i}`
 
-			console.log(`📸 Taking screenshot of tab: ${tabName} (${sectionId})`)
+			await closeAllToastNotifications(page)
 			await takeScreenshot(`${i}-settings-${sectionId}-${tabName.toLowerCase().replace(/\s+/g, "-")}`)
 		}
 


### PR DESCRIPTION
Fix the playwright test errors that started after I added the notification closing before taking screenshots

I suspect something in the settings was causing the notification clicking to go wrong. I updated the selectors and added more bail-outs and it seems to be working better now 🤷 😄 