### PR TITLE
Don't set access token for model list request

### DIFF
--- a/src/api/providers/fetchers/modelCache.ts
+++ b/src/api/providers/fetchers/modelCache.ts
@@ -87,7 +87,6 @@ export const getModels = async (options: GetModelsOptions): Promise<ModelRecord>
 			case "kilocode-openrouter":
 				models = await getOpenRouterModels({
 					openRouterBaseUrl: getKiloBaseUriFromToken(options.kilocodeToken ?? "") + "/api/openrouter",
-					headers: { Authorization: `Bearer ${options.kilocodeToken}` },
 				})
 				break
 			case "cerebras":


### PR DESCRIPTION
I heard this disables Vercel caching