### PR TITLE
feat: add vertical to horizontal scrolling translator for task timeline

### DIFF
--- a/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useEffect, useCallback, useMemo } from "react"
+import { memo, useRef, forwardRef, useEffect, useCallback, useMemo } from "react"
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import type { ClineMessage } from "@roo-code/types"
 import { TaskTimelineMessage } from "./TaskTimelineMessage"
@@ -19,6 +19,25 @@ interface TaskTimelineProps {
 	onMessageClick?: (index: number) => void
 	isTaskActive?: boolean
 }
+
+const HorizontalScroller = forwardRef<HTMLDivElement, any>(({ style, children, ...props }, ref) => (
+	<div
+		{...props}
+		ref={ref}
+		style={{
+			...style,
+			overflowX: "auto",
+			overflowY: "hidden",
+			willChange: "transform",
+		}}
+		onWheel={(e) => {
+			e.preventDefault() // stop the default vertical scroll
+			// scrollLeft by the vertical wheel amount:
+			;(ref as React.MutableRefObject<HTMLDivElement>).current!.scrollLeft += e.deltaY
+		}}>
+		{children}
+	</div>
+))
 
 export const TaskTimeline = memo<TaskTimelineProps>(({ groupedMessages, onMessageClick, isTaskActive = false }) => {
 	const { setHoveringTaskTimeline } = useExtensionState()
@@ -90,6 +109,7 @@ export const TaskTimeline = memo<TaskTimelineProps>(({ groupedMessages, onMessag
 				<Virtuoso
 					ref={virtuosoRef}
 					data={timelineMessagesData}
+					components={{ Scroller: HorizontalScroller }}
 					itemContent={itemContent}
 					horizontalDirection={true}
 					initialTopMostItemIndex={timelineMessagesData.length - 1}


### PR DESCRIPTION
## Context

Following issue #1785, a user asked to be able to scroll on the tasks time line using the mouse wheel, without the need for the pressing the shift key at the same time, which results in a better user experience to mouse users comparable to touchpads.

## Implementation

Implemented a customer scroller component that works with Virtuoso, for it to translate vertical mouse scrolls into horizontal scroll events which gives a better overall user experience for mouse users.

## How to Test

A "How To Test" section can look something like this:

- Get the task timeline to overflow
- Using a mouse, scroll vertically (Without using the shift key)
- You should be able to scroll left and right on the time line

## Get in Touch

On Discord its: abodftw