### PR TITLE
Add .gitignore exclusion for conport MCP directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ logs
 
 # Nix / Direnv
 .direnv
+
+# Exclude Conport Directory (MCP server)
+context_portal/


### PR DESCRIPTION
## Context

exclude conport directory to avoid polluting git repo.

## Implementation

simple .gitignore update

## Screenshots

NA
## How to Test

NA


## Get in Touch

 mcowger on discord