### PR TITLE
fix(settings): remove dublicate fireworks provider from constants

### DIFF
--- a/webview-ui/src/components/settings/constants.ts
+++ b/webview-ui/src/components/settings/constants.ts
@@ -52,7 +52,6 @@ export const PROVIDERS = [
 	{ value: "cerebras", label: "Cerebras" },
 	{ value: "gemini", label: "Google Gemini" },
 	{ value: "doubao", label: "Doubao" },
-	{ value: "fireworks", label: "Fireworks AI" },
 	// kilocode_change start
 	{ value: "gemini-cli", label: "Gemini CLI" },
 	{ value: "virtual-quota-fallback", label: "Virtual Quota Fallback" },


### PR DESCRIPTION
I wanted to add a new provider and found a duplicate
