### PR TITLE
Fix extension and webview using different provider names, don't ask for a specific provider if the setting is corrupt

### DIFF
--- a/src/api/providers/fetchers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/fetchers/__tests__/openrouter.spec.ts
@@ -230,7 +230,8 @@ describe("OpenRouter API", () => {
 			const endpoints = await getOpenRouterModelEndpoints("google/gemini-2.5-pro-preview")
 
 			expect(endpoints).toEqual({
-				Google: {
+				"google-vertex": {
+					// kilocode_change: Updated to match actual endpoint tag
 					maxTokens: 65535,
 					contextWindow: 1048576,
 					supportsImages: true,
@@ -244,7 +245,8 @@ describe("OpenRouter API", () => {
 					supportsReasoningEffort: undefined,
 					supportedParameters: undefined,
 				},
-				"Google AI Studio": {
+				"google-ai-studio": {
+					// kilocode_change: Updated to match actual endpoint tag
 					maxTokens: 65536,
 					contextWindow: 1048576,
 					supportsImages: true,

--- a/src/api/providers/fetchers/openrouter.ts
+++ b/src/api/providers/fetchers/openrouter.ts
@@ -59,6 +59,7 @@ export type OpenRouterModel = z.infer<typeof openRouterModelSchema>
 
 export const openRouterModelEndpointSchema = modelRouterBaseModelSchema.extend({
 	provider_name: z.string(),
+	tag: z.string().optional(), // kilocode_change
 })
 
 export type OpenRouterModelEndpoint = z.infer<typeof openRouterModelEndpointSchema>
@@ -155,7 +156,7 @@ export async function getOpenRouterModelEndpoints(
 		const { id, architecture, endpoints } = data
 
 		for (const endpoint of endpoints) {
-			models[endpoint.provider_name] = parseOpenRouterModel({
+			models[endpoint.tag /*kilocode_change*/ ?? endpoint.provider_name] = parseOpenRouterModel({
 				id,
 				model: endpoint,
 				modality: architecture?.modality,

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -95,10 +95,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 	}
 
 	getProviderParams(): { provider?: OpenRouterProviderParams } {
-		if (
-			this.options.openRouterSpecificProvider &&
-			this.options.openRouterSpecificProvider !== OPENROUTER_DEFAULT_PROVIDER_NAME
-		) {
+		if (this.options.openRouterSpecificProvider && this.endpoints[this.options.openRouterSpecificProvider]) {
 			return {
 				provider: {
 					order: [this.options.openRouterSpecificProvider],

--- a/webview-ui/src/components/ui/hooks/useOpenRouterModelProviders.ts
+++ b/webview-ui/src/components/ui/hooks/useOpenRouterModelProviders.ts
@@ -22,7 +22,10 @@ const openRouterEndpointsSchema = z.object({
 		endpoints: z.array(
 			z.object({
 				name: z.string(),
-				tag: z.string().optional(), // kilocode_change
+				// kilocode_change start
+				provider_name: z.string(),
+				tag: z.string().optional(),
+				// kilocode_change end
 				context_length: z.number(),
 				max_completion_tokens: z.number().nullish(),
 				pricing: z
@@ -65,7 +68,7 @@ async function getOpenRouterProvidersForModel(modelId: string, baseUrl?: string,
 		const { id, description, architecture, endpoints } = result.data.data
 
 		for (const endpoint of endpoints) {
-			const providerName = endpoint.tag /*kilocode_change*/ || endpoint.name.split("|")[0].trim()
+			const providerName = endpoint.tag ?? endpoint.provider_name // kilocode_change
 			const inputPrice = parseApiPrice(endpoint.pricing?.prompt)
 			const outputPrice = parseApiPrice(endpoint.pricing?.completion)
 


### PR DESCRIPTION
There are currently various ways you can change the model without resetting the endpoint, so try to avoid failing the request in that case.

As for the provider name, I *think* `tag` is the correct one, although it is not documented:
https://openrouter.ai/docs/api-reference/list-endpoints-for-a-model
https://openrouter.ai/api/v1/models/anthropic/claude-sonnet-4/endpoints

The docs only say:

<img width="656" height="116" alt="CleanShot 2025-08-14 at 11 35 16" src="https://github.com/user-attachments/assets/9f1ec6a0-6788-4598-a640-c8d6e1c70151" />

https://openrouter.ai/docs/features/provider-routing#ordering-specific-providers

`provider_name` and `endpoint.name.split("|")[0].trim()` are clearly not correct; they are not even unique.