### PR TITLE
Improve instructions in LLM prompt to use only one tool per message

### DIFF
--- a/.changeset/one-tool-per-message.md
+++ b/.changeset/one-tool-per-message.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Improve instructions in LLM prompt to use only one tool per message.

--- a/src/core/prompts/sections/tool-use.ts
+++ b/src/core/prompts/sections/tool-use.ts
@@ -3,6 +3,8 @@ export function getSharedToolUseSection(): string {
 
 TOOL USE
 
+You have access to a set of tools that are executed upon the user's approval.
+
 **IMPORTANT:** You can use ONLY ONE tool per message. If you need to use multiple tools, use only the first tool. For example: when you need to update the todo list AND you need to build the project, you send your message with only the update_todo_list command.
 **END MESSAGE RULE:** Every message containing a tool use MUST end immediately after the closing tool tag. No exceptions. For example: when you need to update the todo list AND you need to provide a summary, you will only use the update_todo_list command and then end the message.
 **REMEMBER:** You use tools step-by-step to accomplish a given task, with each tool use informed by the result of the previous tool use.

--- a/src/core/prompts/sections/tool-use.ts
+++ b/src/core/prompts/sections/tool-use.ts
@@ -3,7 +3,9 @@ export function getSharedToolUseSection(): string {
 
 TOOL USE
 
-You have access to a set of tools that are executed upon the user's approval. You can use one tool per message, and will receive the result of that tool use in the user's response. You use tools step-by-step to accomplish a given task, with each tool use informed by the result of the previous tool use.
+**IMPORTANT:** You can use ONLY ONE tool per message. If you need to use multiple tools, use only the first tool. For example: when you need to update the todo list AND you need to build the project, you send your message with only the update_todo_list command.
+**END MESSAGE RULE:** Every message containing a tool use MUST end immediately after the closing tool tag. No exceptions. For example: when you need to update the todo list AND you need to provide a summary, you will only use the update_todo_list command and then end the message.
+**REMEMBER:** You use tools step-by-step to accomplish a given task, with each tool use informed by the result of the previous tool use.
 
 # Tool Use Formatting
 


### PR DESCRIPTION
fixes #1478

## Context

When the LLM responds with multiple tool-calls in one answer, the chat-log would show "Response interrupted by a tool use result." The costs of the LLM would not be added and processing the response would be interrupted. The part of the costs not being calculated was already fixed in release 4.64

## Implementation

This current commit modifies the prompt-instructions for tool-usage, so the LLM will do a better job in obeying the rules for tool-usage. I also noticed that Kilo-code and the LLM were able to generate correct code faster and cheaper, because it didn't lose track of tool-usage.

## How to Test

I have Custom Instructions in Kilo-Code saying:

- After every change-set an explicit recompile and analyse the output.
- Include compile-evidence in your response.

This would trigger the LLM (Claude Sonnet 4) to have <update_todo_list> and <execute_command> in the same response. The change in this commit gives clear instructions about tool-usage. After having this prompt changed, I was not able to reproduce the problem.

## Get in Touch

renelergner@live.nl