### PR TITLE
OpenRouter routing settings are no longer randomly reset

### DIFF
--- a/.changeset/free-brooms-strive.md
+++ b/.changeset/free-brooms-strive.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+OpenRouter routing settings are no longer randomly reset

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -285,6 +285,9 @@ const kilocodeSchema = baseProviderSettingsSchema.extend({
 	kilocodeToken: z.string().optional(),
 	kilocodeOrganizationId: z.string().optional(),
 	kilocodeModel: z.string().optional(),
+	openRouterSpecificProvider: z.string().optional(),
+	openRouterProviderDataCollection: openRouterProviderDataCollectionSchema.optional(),
+	openRouterProviderSort: openRouterProviderSortSchema.optional(),
 })
 
 export const virtualQuotaFallbackProfileDataSchema = z.object({


### PR DESCRIPTION
Fixes https://github.com/Kilo-Org/kilocode/issues/1963

Not sure why it is necessary to duplicate these settings, but it seems to improve things.