### PR TITLE
Ignore exceptions in partial editFileTool processing

### DIFF
--- a/src/core/tools/editFileTool.ts
+++ b/src/core/tools/editFileTool.ts
@@ -66,11 +66,9 @@ export async function editFileTool(
 				instructions: removeClosingTag("instructions", instructions),
 				codeEdit: removeClosingTag("code_edit", code_edit),
 			}
-			try {
-				await cline.ask("tool", JSON.stringify(partialMessageProps), block.partial)
-			} catch (error) {
-				TelemetryService.instance.captureException(error, { context: "editFileTool" })
-			}
+			await cline.ask("tool", JSON.stringify(partialMessageProps), block.partial).catch(() => {
+				// Roo tools ignore exceptions as well here
+			})
 			return
 		}
 


### PR DESCRIPTION
This currently reports an avalanche of exceptions.

Compare: https://github.com/Kilo-Org/kilocode/blob/ebf2e3f882ad546f744a0c3a5e05f1fd21ff027e/src/core/tools/applyDiffTool.ts#L53