### PR TITLE
ci(code-qa): use version matrix for node

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -9,7 +9,6 @@ on:
         branches: [main]
 
 env:
-    NODE_VERSION: 20.19.2
     PNPM_VERSION: 10.8.1
     TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -17,6 +16,9 @@ env:
 jobs:
     compile:
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [20.x, 22.x]
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -24,17 +26,18 @@ jobs:
               uses: pnpm/action-setup@v4
               with:
                   version: ${{ env.PNPM_VERSION }}
-            - name: Setup Node.js
+            - name: Setup Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:
-                  node-version: ${{ env.NODE_VERSION }}
+                  node-version: ${{ matrix.node-version }}
                   cache: "pnpm"
             - name: Turbo cache setup
               uses: actions/cache@v4
               with:
                   path: .turbo
-                  key: ${{ runner.os }}-turbo-${{ github.sha }}
+                  key: ${{ runner.os }}-node-${{ matrix.node-version }}-turbo-${{ github.sha }}
                   restore-keys: |
+                      ${{ runner.os }}-node-${{ matrix.node-version }}-turbo-
                       ${{ runner.os }}-turbo-
             - name: Install dependencies
               run: pnpm install
@@ -47,6 +50,9 @@ jobs:
 
     check-translations:
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [20.x, 22.x]
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -54,17 +60,18 @@ jobs:
               uses: pnpm/action-setup@v4
               with:
                   version: ${{ env.PNPM_VERSION }}
-            - name: Setup Node.js
+            - name: Setup Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:
-                  node-version: "18"
+                  node-version: ${{ matrix.node-version }}
                   cache: "pnpm"
             - name: Turbo cache setup
               uses: actions/cache@v4
               with:
                   path: .turbo
-                  key: ${{ runner.os }}-turbo-${{ github.sha }}
+                  key: ${{ runner.os }}-node-${{ matrix.node-version }}-turbo-${{ github.sha }}
                   restore-keys: |
+                      ${{ runner.os }}-node-${{ matrix.node-version }}-turbo-
                       ${{ runner.os }}-turbo-
             - name: Install dependencies
               run: pnpm install
@@ -76,6 +83,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest]
+                node-version: [20.x, 22.x]
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -83,17 +91,18 @@ jobs:
               uses: pnpm/action-setup@v4
               with:
                   version: ${{ env.PNPM_VERSION }}
-            - name: Setup Node.js
+            - name: Setup Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:
-                  node-version: ${{ env.NODE_VERSION }}
+                  node-version: ${{ matrix.node-version }}
                   cache: "pnpm"
             - name: Turbo cache setup
               uses: actions/cache@v4
               with:
                   path: .turbo
-                  key: ${{ runner.os }}-turbo-${{ github.sha }}
+                  key: ${{ runner.os }}-node-${{ matrix.node-version }}-turbo-${{ github.sha }}
                   restore-keys: |
+                      ${{ runner.os }}-node-${{ matrix.node-version }}-turbo-
                       ${{ runner.os }}-turbo-
             - name: Install dependencies
               run: pnpm install
@@ -108,6 +117,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest]
+                node-version: [20.x, 22.x]
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -115,17 +125,18 @@ jobs:
               uses: pnpm/action-setup@v4
               with:
                   version: ${{ env.PNPM_VERSION }}
-            - name: Setup Node.js
+            - name: Setup Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:
-                  node-version: "18"
+                  node-version: ${{ matrix.node-version }}
                   cache: "pnpm"
             - name: Turbo cache setup
               uses: actions/cache@v4
               with:
                   path: .turbo
-                  key: ${{ runner.os }}-turbo-${{ github.sha }}
+                  key: ${{ runner.os }}-node-${{ matrix.node-version }}-turbo-${{ github.sha }}
                   restore-keys: |
+                      ${{ runner.os }}-node-${{ matrix.node-version }}-turbo-
                       ${{ runner.os }}-turbo-
             - name: Install dependencies
               run: pnpm install


### PR DESCRIPTION
Introduce matrix version for node compatibility

## Context

We want CI coverage across the two active Node.js LTS majors to ensure ongoing compatibility. Previously, the workflow mixed a pinned Node 20 patch and Node 18 in a couple of jobs. This change standardizes and expands coverage to Node 20.x and 22.x across the pipeline using a matrix, so we catch incompatibilities early and automatically validate new minor/patch releases in those majors.

## Implementation

- Added a node-version matrix [20.x, 22.x] to relevant jobs:
  - compile (ubuntu)
  - check-translations (ubuntu; was pinned to Node 18)
  - test-extension (ubuntu, windows)
  - test-webview (ubuntu, windows; was pinned to Node 18)
- Removed the global NODE_VERSION env and switched all jobs to use the matrix version.
- Included the Node version in the Turbo cache key to avoid cross-version cache contamination:
  - Key now includes node-${{ matrix.node-version }} so each Node major maintains its own cache.
- Kept pnpm as the package manager and preserved the existing PNPM version.
- No source changes; CI only.

Trade-offs and notes:
- Increases job fan-out (e.g., test-extension/test-webview now run 4 variants each: 2 OS x 2 Node versions). Runs longer overall but in parallel.
- Using 20.x and 22.x means we automatically test against new minors/patches as they’re released.
- If runtime becomes a concern, we can scope some jobs (e.g., check-translations or test-webview) to a single OS or a single Node version while keeping full coverage where it matters most.

## Results

| before | after |
| ------ | ----- |
| [Mixed Node versions](https://github.com/Kilo-Org/kilocode/actions/runs/17005920640) | [Consistent matrix](https://github.com/bitsnaps/kilocode/actions/runs/17006832177)|

## How to Test

- Open this PR or trigger the workflow via “Run workflow” (workflow_dispatch).
- Confirm the matrix expands as expected:
  - compile runs twice: Node 20.x and 22.x.
  - check-translations runs twice: Node 20.x and 22.x.
  - test-extension runs four times: ubuntu/windows x Node 20.x/22.x.
  - test-webview runs four times: ubuntu/windows x Node 20.x/22.x.
- In each job, check the “Set up Node.js” step logs to verify the resolved version is 20.x or 22.x.
- Verify caches include node-20.x and node-22.x in the Turbo cache key.
- Ensure all jobs pass on both Node versions.
