### PR TITLE
Ignore providers whose context window is smaller than the "top provider" context window

### DIFF
--- a/.changeset/eleven-cougars-tap.md
+++ b/.changeset/eleven-cougars-tap.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-OpenRouter inference providers that don't support the advertised context window are now automatically ignored.
+OpenRouter inference providers whose context window is smaller than that of the top provider for a particular model are now automatically ignored. They can still be used by selecting them specifically in the Provider Routing settings.

--- a/.changeset/eleven-cougars-tap.md
+++ b/.changeset/eleven-cougars-tap.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+OpenRouter inference providers that don't support the advertised context window are now automatically ignored.

--- a/.changeset/eleven-cougars-tap.md
+++ b/.changeset/eleven-cougars-tap.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-OpenRouter inference providers whose context window is smaller than that of the top provider for a particular model are now automatically ignored. They can still be used by selecting them specifically in the Provider Routing settings.
+OpenRouter inference providers whose context window is smaller than that of the top provider for a particular model are now automatically ignored by default. They can still be used by selecting them specifically in the Provider Routing settings.

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -98,7 +98,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 
 	getIgnoredProviders(model: ModelInfo): string[] | undefined {
 		const endpoints = Object.entries(this.endpoints)
-		const ignoredProviders = Object.entries(this.endpoints)
+		const ignoredProviders = endpoints
 			.filter((endpoint) => endpoint[1].contextWindow < model.contextWindow)
 			.map((endpoint) => endpoint[0])
 		if (ignoredProviders.length > 0 && ignoredProviders.length < endpoints.length) {

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -7,6 +7,7 @@ import {
 	OPENROUTER_DEFAULT_PROVIDER_NAME,
 	OPEN_ROUTER_PROMPT_CACHING_MODELS,
 	DEEP_SEEK_DEFAULT_TEMPERATURE,
+	ModelInfo, // kilocode_change
 } from "@roo-code/types"
 
 import type { ApiHandlerOptions, ModelRecord } from "../../shared/api"
@@ -33,6 +34,7 @@ import type {
 type OpenRouterProviderParams = {
 	order?: string[]
 	only?: string[]
+	ignore?: string[] // kilocode_change
 	allow_fallbacks?: boolean
 	data_collection?: "allow" | "deny"
 	sort?: "price" | "throughput" | "latency"
@@ -94,7 +96,18 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 		return (lastUsage.cost_details?.upstream_inference_cost || 0) + (lastUsage.cost || 0)
 	}
 
-	getProviderParams(): { provider?: OpenRouterProviderParams } {
+	getIgnoredProviders(model: ModelInfo): string[] | undefined {
+		const endpoints = Object.entries(this.endpoints)
+		const ignoredProviders = Object.entries(this.endpoints)
+			.filter((endpoint) => endpoint[1].contextWindow < model.contextWindow)
+			.map((endpoint) => endpoint[0])
+		if (ignoredProviders.length > 0 && ignoredProviders.length < endpoints.length) {
+			return ignoredProviders
+		}
+		return undefined
+	}
+
+	getProviderParams(model: ModelInfo): { provider?: OpenRouterProviderParams } {
 		if (this.options.openRouterSpecificProvider && this.endpoints[this.options.openRouterSpecificProvider]) {
 			return {
 				provider: {
@@ -104,9 +117,15 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 				},
 			}
 		}
-		if (this.options.openRouterProviderDataCollection || this.options.openRouterProviderSort) {
+		const ignoredProviders = this.getIgnoredProviders(model)
+		if (
+			(ignoredProviders?.length ?? 0) > 0 ||
+			this.options.openRouterProviderDataCollection ||
+			this.options.openRouterProviderSort
+		) {
 			return {
 				provider: {
+					ignore: ignoredProviders,
 					data_collection: this.options.openRouterProviderDataCollection,
 					sort: this.options.openRouterProviderSort,
 				},
@@ -169,7 +188,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 			messages: openAiMessages,
 			stream: true,
 			stream_options: { include_usage: true },
-			...this.getProviderParams(), // kilocode_change: original expression was moved into function
+			...this.getProviderParams(model.info), // kilocode_change: original expression was moved into function
 			...(transforms && { transforms }),
 			...(reasoning && { reasoning }),
 		}
@@ -260,7 +279,13 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 	}
 
 	async completePrompt(prompt: string) {
-		let { id: modelId, maxTokens, temperature, reasoning } = await this.fetchModel()
+		let {
+			id: modelId,
+			maxTokens,
+			temperature,
+			reasoning,
+			info: modelInfo, // kilocode_change
+		} = await this.fetchModel()
 
 		const completionParams: OpenRouterChatCompletionParams = {
 			model: modelId,
@@ -268,7 +293,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 			temperature,
 			messages: [{ role: "user", content: prompt }],
 			stream: false,
-			...this.getProviderParams(), // kilocode_change: original expression was moved into function
+			...this.getProviderParams(modelInfo), // kilocode_change: original expression was moved into function
 			...(reasoning && { reasoning }),
 		}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2335,6 +2335,22 @@ export class ClineProvider
 			}
 		}
 
+		function getOpenRouter() {
+			if (
+				apiConfiguration &&
+				(apiConfiguration.apiProvider === "openrouter" || apiConfiguration.apiProvider === "kilocode")
+			) {
+				return {
+					openRouter: {
+						sort: apiConfiguration.openRouterProviderSort,
+						dataCollection: apiConfiguration.openRouterProviderDataCollection,
+						specificProvider: apiConfiguration.openRouterSpecificProvider,
+					},
+				}
+			}
+			return {}
+		}
+
 		function getMemory() {
 			try {
 				return { memory: { ...process.memoryUsage() } }
@@ -2388,6 +2404,7 @@ export class ClineProvider
 			...(await getModelId()),
 			...getMemory(),
 			...getFastApply(),
+			...getOpenRouter(),
 			// kilocode_change end
 			diffStrategy: task?.diffStrategy?.getName(),
 			isSubtask: task ? !!task.parentTask : undefined,


### PR DESCRIPTION
For example, here Cerebras has a smaller context window than the others: https://openrouter.ai/qwen/qwen3-coder

I don't trust this is handled well automatically. For example, here someone has weird things happening while just being over Cerebras' context window: https://app.frontapp.com/open/cnv_1ijj98ri?key=uuVJWDzoYBqaUdeq91e_vxSi6aek7Dzd