### PR TITLE
addressing latest comments 8/20

### DIFF
--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -133,6 +133,8 @@ export const globalSettingsSchema = z.object({
 	fuzzyMatchThreshold: z.number().optional(),
 	experiments: experimentsSchema.optional(),
 
+	morphApiKey: z.string().optional(), // kilocode_change: Morph fast apply - moved from provider settings to global
+
 	codebaseIndexModels: codebaseIndexModelsSchema.optional(),
 	codebaseIndexConfig: codebaseIndexConfigSchema.optional(),
 

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -85,8 +85,6 @@ const baseProviderSettingsSchema = z.object({
 	modelMaxTokens: z.number().optional(),
 	modelMaxThinkingTokens: z.number().optional(),
 
-	morphApiKey: z.string().optional(), // kilocode_change: Morph fast apply
-
 	// Model verbosity.
 	verbosity: verbosityLevelsSchema.optional(),
 })

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2213,12 +2213,12 @@ export class ClineProvider
 			}
 		}
 
-		function getFastApply() {
+		const getFastApply = () => {
 			try {
 				return {
 					fastApply: {
 						morphFastApply: Boolean(experiments.morphFastApply),
-						morphApiKey: Boolean(apiConfiguration.morphApiKey),
+						morphApiKey: Boolean(this.contextProxy.getValue("morphApiKey")), // kilocode_change: Use global morphApiKey
 					},
 				}
 			} catch (error) {

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1092,6 +1092,10 @@ export const webviewMessageHandler = async (
 			await updateGlobalState("fuzzyMatchThreshold", message.value)
 			await provider.postStateToWebview()
 			break
+		case "morphApiKey":
+			await updateGlobalState("morphApiKey", message.text)
+			await provider.postStateToWebview()
+			break
 		case "updateVSCodeSetting": {
 			const { setting, value } = message
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -298,6 +298,7 @@ export type ExtensionState = Pick<
 	| "diagnosticsEnabled"
 	| "diffEnabled"
 	| "fuzzyMatchThreshold"
+	| "morphApiKey" // kilocode_change: Morph fast apply - global setting
 	// | "experiments" // Optional in GlobalSettings, required here.
 	| "language"
 	// | "telemetrySetting" // Optional in GlobalSettings, required here.

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -118,6 +118,7 @@ export interface WebviewMessage {
 		| "toggleMcpServer"
 		| "updateMcpTimeout"
 		| "fuzzyMatchThreshold"
+		| "morphApiKey" // kilocode_change: Morph fast apply - global setting
 		| "writeDelayMs"
 		| "diagnosticsEnabled"
 		| "enhancePrompt"

--- a/webview-ui/src/components/settings/ExperimentalSettings.tsx
+++ b/webview-ui/src/components/settings/ExperimentalSettings.tsx
@@ -1,10 +1,7 @@
 import { HTMLAttributes } from "react"
 import { FlaskConical } from "lucide-react"
 
-import type {
-	Experiments,
-	ProviderSettings, // kilocode_change
-} from "@roo-code/types"
+import type { Experiments } from "@roo-code/types"
 
 import { EXPERIMENT_IDS, experimentConfigsMap } from "@roo/experiments"
 
@@ -15,21 +12,19 @@ import { SetExperimentEnabled } from "./types"
 import { SectionHeader } from "./SectionHeader"
 import { Section } from "./Section"
 import { ExperimentalFeature } from "./ExperimentalFeature"
-import { MorphSettings } from "./MorphSettings" // kilocode_change
+import { GlobalMorphSettings } from "./GlobalMorphSettings" // kilocode_change: Use global version
 
 type ExperimentalSettingsProps = HTMLAttributes<HTMLDivElement> & {
 	experiments: Experiments
 	setExperimentEnabled: SetExperimentEnabled
-	apiConfiguration: ProviderSettings // kilocode_change
-	setApiConfigurationField: <K extends keyof ProviderSettings>(field: K, value: ProviderSettings[K]) => void // kilocode_change
+	morphApiKey?: string // kilocode_change: Use global morphApiKey
 }
 
 export const ExperimentalSettings = ({
 	experiments,
 	setExperimentEnabled,
 	className,
-	apiConfiguration, // kilocode_change
-	setApiConfigurationField, // kilocode_change
+	morphApiKey, // kilocode_change: Use global morphApiKey
 	...props
 }: ExperimentalSettingsProps) => {
 	const { t } = useAppTranslation()
@@ -77,12 +72,7 @@ export const ExperimentalSettings = ({
 											)
 										}
 									/>
-									{enabled && (
-										<MorphSettings
-											apiConfiguration={apiConfiguration}
-											setApiConfigurationField={setApiConfigurationField}
-										/>
-									)}
+									{enabled && <GlobalMorphSettings morphApiKey={morphApiKey} />}
 								</>
 							)
 						}

--- a/webview-ui/src/components/settings/GlobalMorphSettings.tsx
+++ b/webview-ui/src/components/settings/GlobalMorphSettings.tsx
@@ -1,24 +1,26 @@
-// kilocode_change: Morph fast apply - file added
+// kilocode_change: Morph fast apply - global settings version
 
 import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
-import { ProviderSettings } from "@roo-code/types"
 import { useAppTranslation } from "@/i18n/TranslationContext"
+import { vscode } from "@/utils/vscode"
 
-export const MorphSettings = ({
-	apiConfiguration,
-	setApiConfigurationField,
-}: {
-	apiConfiguration: ProviderSettings
-	setApiConfigurationField: <K extends keyof ProviderSettings>(field: K, value: ProviderSettings[K]) => void
-}) => {
+export const GlobalMorphSettings = ({ morphApiKey }: { morphApiKey?: string }) => {
 	const { t } = useAppTranslation()
+
+	const handleMorphApiKeyChange = (value: string) => {
+		vscode.postMessage({
+			type: "morphApiKey",
+			text: value || "",
+		})
+	}
+
 	return (
 		<div>
 			<VSCodeTextField
 				type="password"
-				value={apiConfiguration?.morphApiKey || ""}
+				value={morphApiKey || ""}
 				placeholder={t("settings:experimental.MORPH_FAST_APPLY.placeholder")}
-				onChange={(e) => setApiConfigurationField("morphApiKey", (e.target as any)?.value || "")}
+				onChange={(e) => handleMorphApiKeyChange((e.target as any)?.value || "")}
 				className="w-full">
 				{t("settings:experimental.MORPH_FAST_APPLY.apiKey")}
 			</VSCodeTextField>

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -165,6 +165,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 		enableCheckpoints,
 		diffEnabled,
 		experiments,
+		morphApiKey,
 		fuzzyMatchThreshold,
 		maxOpenTabsContext,
 		maxWorkspaceFiles,
@@ -846,8 +847,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 						<ExperimentalSettings
 							setExperimentEnabled={setExperimentEnabled}
 							experiments={experiments}
-							apiConfiguration={apiConfiguration /*kilocode_change*/}
-							setApiConfigurationField={setApiConfigurationField /*kilocode_change*/}
+							morphApiKey={morphApiKey} // kilocode_change: Use global morphApiKey
 						/>
 					)}
 


### PR DESCRIPTION
- Move morphApiKey from provider settings to global settings
- Update UI to use GlobalMorphSettings component instead of provider-specific one
- Add migration logic to move existing keys from provider to global settings
- Update morph configuration logic to require either global API key or OpenRouter provider
- When credentials unavailable, behave as if morph is completely disabled

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
