### PR TITLE
Correct error in use of headers in fetchWithTimeout().

### DIFF
--- a/.changeset/eager-lamps-refuse.md
+++ b/.changeset/eager-lamps-refuse.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed "'messages' field is required" error in LMStudio


### PR DESCRIPTION
Undefined headers values were being expanded and overwriting existing ones.  Caused headers to be sent with invalid default values (like text/plain) which confused LM Studio.
