### PR TITLE
Show console logging in vitests when the `--no-silent` flag is set

### DIFF
--- a/.kilocode/rules/tests.md
+++ b/.kilocode/rules/tests.md
@@ -1,0 +1,32 @@
+# Test Running Guidelines
+
+## Critical Rules
+
+- **NEVER use `--watch`** (causes system hang)
+- **All tests use Vitest** (Jest not installed)
+
+## Command Templates
+
+```bash
+cd $WORKSPACE_ROOT/src && npx vitest run <relative-path-no-src-prefix>
+# Example: cd $WORKSPACE_ROOT/src && npx vitest run api/providers/__tests__/anthropic.spec.ts
+```
+
+```bash
+cd $WORKSPACE_ROOT/webview-ui && npx vitest run <relative-path-with-src-prefix>
+# Example: cd $WORKSPACE_ROOT/webview-ui && npx vitest run src/utils/__tests__/context-mentions.spec.ts
+```
+
+### Verbose Debugging
+
+To see console output during tests, use the native vitest `--no-silent` flag:
+
+```bash
+cd $WORKSPACE_ROOT/src && npx vitest run <relative-path-no-src-prefix> --no-silent
+# Example: cd $WORKSPACE_ROOT/src && npx vitest run api/providers/__tests__/anthropic.spec.ts --no-silent
+```
+
+```bash
+cd $WORKSPACE_ROOT/webview-ui && npx vitest run <relative-path-with-src-prefix> --no-silent
+# Example: cd $WORKSPACE_ROOT/webview-ui && npx vitest run src/utils/__tests__/context-mentions.spec.ts --no-silent
+```

--- a/src/utils/vitest-verbosity.ts
+++ b/src/utils/vitest-verbosity.ts
@@ -1,0 +1,22 @@
+export function resolveVerbosity(argv = process.argv, env = process.env) {
+	// Check if --no-silent flag is used (native vitest flag)
+	const cliNoSilent = argv.includes("--no-silent") || argv.includes("--silent=false")
+	const silent = !cliNoSilent // Silent by default
+
+	// Check if verbose reporter is requested
+	const wantsVerboseReporter = argv.some(
+		(a) => a === "--reporter=verbose" || a === "-r=verbose" || a === "--reporter",
+	)
+
+	return {
+		silent,
+		reporters: ["dot", ...(wantsVerboseReporter ? ["verbose"] : [])],
+		onConsoleLog: (_log: string, type: string) => {
+			// When verbose, show everything
+			// When silent, allow errors/warnings and drop info/log/warn noise
+			if (!silent || type === "stderr") return
+
+			return false // Drop info/log/warn noise
+		},
+	}
+}

--- a/src/vitest.config.ts
+++ b/src/vitest.config.ts
@@ -1,15 +1,19 @@
 import { defineConfig } from "vitest/config"
 import path from "path"
+import { resolveVerbosity } from "./utils/vitest-verbosity"
+
+const { silent, reporters, onConsoleLog } = resolveVerbosity()
 
 export default defineConfig({
 	test: {
 		globals: true,
 		setupFiles: ["./vitest.setup.ts"],
 		watch: false,
-		reporters: ["dot"],
-		silent: true,
+		reporters,
+		silent,
 		testTimeout: 20_000,
 		hookTimeout: 20_000,
+		onConsoleLog,
 	},
 	resolve: {
 		alias: {

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -15,19 +15,3 @@ export function allowNetConnect(host?: string | RegExp) {
 
 // Global mocks that many tests expect.
 global.structuredClone = global.structuredClone || ((obj: any) => JSON.parse(JSON.stringify(obj)))
-
-// Suppress console.log during tests to reduce noise.
-// Keep console.error for actual errors.
-const originalConsoleLog = console.log
-const originalConsoleWarn = console.warn
-const originalConsoleInfo = console.info
-
-console.log = () => {}
-console.warn = () => {}
-console.info = () => {}
-
-afterAll(() => {
-	console.log = originalConsoleLog
-	console.warn = originalConsoleWarn
-	console.info = originalConsoleInfo
-})

--- a/webview-ui/vitest.config.ts
+++ b/webview-ui/vitest.config.ts
@@ -1,15 +1,19 @@
 import { defineConfig } from "vitest/config"
 import path from "path"
+import { resolveVerbosity } from "../src/utils/vitest-verbosity"
+
+const { silent, reporters, onConsoleLog } = resolveVerbosity()
 
 export default defineConfig({
 	test: {
 		globals: true,
 		setupFiles: ["./vitest.setup.ts"],
 		watch: false,
-		reporters: ["dot"],
-		silent: true,
+		reporters,
+		silent,
 		environment: "jsdom",
 		include: ["src/**/*.spec.ts", "src/**/*.spec.tsx"],
+		onConsoleLog,
 	},
 	resolve: {
 		alias: {

--- a/webview-ui/vitest.setup.ts
+++ b/webview-ui/vitest.setup.ts
@@ -50,19 +50,3 @@ Object.defineProperty(window, "matchMedia", {
 
 // Mock scrollIntoView which is not available in jsdom
 Element.prototype.scrollIntoView = vi.fn()
-
-// Suppress console.log during tests to reduce noise.
-// Keep console.error for actual errors.
-const originalConsoleLog = console.log
-const originalConsoleWarn = console.warn
-const originalConsoleInfo = console.info
-
-console.log = () => {}
-console.warn = () => {}
-console.info = () => {}
-
-afterAll(() => {
-	console.log = originalConsoleLog
-	console.warn = originalConsoleWarn
-	console.info = originalConsoleInfo
-})


### PR DESCRIPTION
By default, all of our tests run in silent mode, and we monkey patched the console logging so no console logging will ever appear in test output. This confuses the agent- sometimes it will add console logging to help it debug things, and it won't see the logs that it expects. I added a workspace rule file that helps the agent understand how to properly run the tests.  

With this, you can tell the agent to use the `--no-silent` flag instead of manually hacking the vite.config to see the output.

- Adds `src/utils/vitest-verbosity.ts` to handle verbosity resolution and console logging.
- Modifies `src/vitest.config.ts` and `webview-ui/vitest.config.ts` to integrate the new verbosity control.
- Removes manual console suppression from `src/vitest.setup.ts` and `webview-ui/vitest.setup.ts` as it's now handled dynamically.
- Adds `.kilocode/rules/tests.md` to document test running guidelines, including the new verbose mode.

Roo PR: https://github.com/RooCodeInc/Roo-Code/pull/7467
