### PR TITLE
Prevents using deprecated max_tokens with GPT5 using LiteLLM.

### DIFF
--- a/src/api/providers/lite-llm.ts
+++ b/src/api/providers/lite-llm.ts
@@ -109,7 +109,7 @@ export class LiteLLMHandler extends RouterProvider implements SingleCompletionHa
 
 		const requestOptions: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
 			model: modelId,
-			max_tokens: maxTokens,
+			max_completion_tokens: maxTokens,
 			messages: [systemMessage, ...enhancedMessages],
 			stream: true,
 			stream_options: {
@@ -189,7 +189,7 @@ export class LiteLLMHandler extends RouterProvider implements SingleCompletionHa
 				requestOptions.temperature = this.options.modelTemperature ?? 0
 			}
 
-			requestOptions.max_tokens = info.maxTokens
+			requestOptions.max_completion_tokens = info.maxTokens
 
 			const response = await this.client.chat.completions.create(requestOptions)
 			return response.choices[0]?.message.content || ""


### PR DESCRIPTION
* Changes deprecated max_tokens to max_completion_tokens.

## Context

When trying to use GPT5 variants through LiteLLM, I get the following error:

> (x) API Request Failed
> LiteLLM streaming error: 400 litellm.BadRequestError: AzureException BadRequestError - Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.. Received Model Group=gpt-5
> Available Model Group Fallbacks=None

(See [issue 2143](https://github.com/Kilo-Org/kilocode/issues/2143))

`max_tokens` is a deprecated parameter for chat completions and not supported by the more recent OpenAI models - see (the OpenAI API Reference)[https://platform.openai.com/docs/api-reference/chat/create#chat_create-max_tokens].

## Implementation

Simply changes the place where we pass `max_tokens` to pass `max_completion_tokens` instead.

## Screenshots

## How to Test

- Set up a LiteLLM instance that provides GPT-5 models as a provider
- Select a GPT5 model
- Go to ask mode, and say something like "Hello? is this thing on?"
- Observe that you do not get an API Request Failed message that mentions max_tokens.

Note that you will also need [https://github.com/Kilo-Org/kilocode/pull/2174](https://github.com/Kilo-Org/kilocode/pull/2174) in order to use GPT-5 as it no longer supports temperature. I made two separate PRs as this PR can only affect LiteLLM, whereas the other could affect other providers.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. --> Tim A (captainxap)
