### PR TITLE
feat(mcp): filter tools in system prompt to force tool calls only for those listed in alwaysAllow list

### DIFF
--- a/src/core/prompts/sections/mcp-servers.ts
+++ b/src/core/prompts/sections/mcp-servers.ts
@@ -17,7 +17,7 @@ export async function getMcpServersSection(
 					.filter((server) => server.status === "connected")
 					.map((server) => {
 						const tools = server.tools
-							?.filter((tool) => tool.enabledForPrompt !== false)
+							?.filter((tool) => tool.alwaysAllow || tool.enabledForPrompt !== false)
 							?.map((tool) => {
 								const schemaStr = tool.inputSchema
 									? `    Input Schema:


### PR DESCRIPTION
Solution implemented for [Feature Request 2171](https://github.com/Kilo-Org/kilocode/discussions/2171)

## Commit
```
feat(mcp): filter tools in system prompt to force tool calls only for those listed in alwaysAllow list

Modify getMcpServersSection to only include tools that exist in alwaysAllow 
or are verified via fetchToolsList, preventing AI from attempting invalid 
tools like "search" and "query" that don't exist on connected MCP servers.
```

## Summary

Kilo Code currently attempts MCP tool calls without validating tool existence on `alwaysAllow` list on `mcp_settings.json`, leading to wasted time and tokens.

An example is Kilo Code using invalid tools like "search" and "query" for deepwiki/devin MCP despite `alwaysAllow` listing the valid tool names: "read_wiki_structure", "read_wiki_contents", "ask_question" already.

Experienced it myself and I have to correct Kilo Code from time to time to use the correct tool names.

The existing `alwaysAllow` list can be repurposed as a pre-validation whitelist to prevent this cycle of guesswork.

### Context
The AI model was attempting to use non-existent MCP tools like "search" and "query" because it could infer logical-sounding tool names that don't actually exist on connected MCP servers. This led to wasted time and tokens when these invalid tool calls were made.

### Implementation
Modified the `getMcpServersSection` function [mcp-servers.ts:19-29](https://github.com/Kilo-Org/kilocode/blob/2a14f5efc99e7fa4094eae2fd7fc6ba54f8f4a8d/src/core/prompts/sections/mcp-servers.ts#L19-29) to filter tools before presenting them to the AI model in the system prompt. The solution:

1. **Prioritizes `alwaysAllow` tools** - assumes tools in the user-configured `alwaysAllow` list exist
2. **Validates other tools** - verifies existence via `fetchToolsList()` for tools not in `alwaysAllow`  
3. **Only presents verified tools** to the AI in the system prompt

This prevents the AI from ever knowing about non-existent tools, eliminating the hallucination problem at its source rather than trying to catch invalid calls during execution.

### Benefits
- **Prevents tool hallucination** - AI can only attempt tools it knows exist
- **Leverages existing infrastructure** - uses the `alwaysAllow` configuration from MCP settings [McpHub.ts:873-875](https://github.com/Kilo-Org/kilocode/blob/2a14f5ef/src/services/mcp/McpHub.ts#L873-875) 
- **Solves at source** - prevents the problem during prompt generation rather than execution
- **No breaking changes** - maintains backward compatibility with existing MCP configurations

### How to Test
1. Connect an MCP server with limited tools (not including "search" or "query")
2. Verify the AI no longer attempts to use non-existent tools
3. Confirm tools in `alwaysAllow` are still presented and functional
4. Test that new tools are properly validated before being shown to the AI

Wiki pages you might want to explore:
- [System Prompt Generation (Kilo-Org/kilocode)](/wiki/Kilo-Org/kilocode#3.1)