### PR TITLE
feat(config): allow user to specify launch directory for dev extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,7 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}/src",
 				"--disable-extensions",
-				"${workspaceFolder}/launch"
+				"${input:extensionLaunchDir}"
 			],
 			"sourceMaps": true,
 			"outFiles": ["${workspaceFolder}/dist/**/*.js"],
@@ -44,6 +44,14 @@
 			},
 			"resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
 			"presentation": { "hidden": false, "group": "tasks", "order": 1 }
+		}
+	],
+	"inputs": [
+		{
+			"id": "extensionLaunchDir",
+			"description": "Directory the dev extension will open in",
+			"default": "${workspaceFolder}/launch",
+			"type": "promptString"
 		}
 	]
 }


### PR DESCRIPTION
Adds an input prompt to the `.vscode/launch.json` configuration, allowing the user to specify the directory the development extension will open in. This provides more flexibility for testing and development workflows.

![2025-08-28 12 58 19](https://github.com/user-attachments/assets/58e1294f-964e-4bc8-b717-75d4dc393ff6)