### PR TITLE
Disable web extension support to prevent broken installations in vscode.dev

### DIFF
--- a/.changeset/yellow-drinks-run.md
+++ b/.changeset/yellow-drinks-run.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Explicitly disable the web version of the extension since it is not compatible (vscode.dev)

--- a/src/package.json
+++ b/src/package.json
@@ -13,6 +13,9 @@
 		"vscode": "^1.84.0",
 		"node": "20.19.2"
 	},
+	"extensionKind": [
+		"workspace"
+	],
 	"author": {
 		"name": "Kilo Code"
 	},


### PR DESCRIPTION
Users reported that Kilo Code appears to install in VSCode web (vscode.dev) but shows broken CSS/JavaScript and non-functional behavior. This occurred because the extension manifest didn't explicitly restrict web support, causing VSCode to treat it as web-compatible despite extensive native dependencies.

Currently it looks like it works, but is missing CSS and JS and doesn't work at all:
<img width="3200" height="2400" alt="image" src="https://github.com/user-attachments/assets/7ef9766a-82da-4c87-b5c6-4e4956974288" />

The extension fundamentally requires Node.js APIs unavailable in browsers:
- Puppeteer for browser automation and web scraping
- Node IPC for inter-process communication
- Process management (ps-tree) for terminal operations
- Shell integration (default-shell) for command execution
- Text-to-speech (say) and sound playback (sound-play)
- Native file system operations and terminal spawning

Added `extensionKind: ["workspace"]` to package.json to explicitly restrict the extension to desktop environments only. This prevents installation in vscode.dev and eliminates user confusion from broken web installations.

Resolves: Users experiencing broken extension behavior in VSCode web

Fixes: https://github.com/Kilo-Org/kilocode/issues/2103
