### PR TITLE
Sample memory usage telemetry to reduce events

### DIFF
--- a/webview-ui/src/utils/__tests__/sampling.spec.ts
+++ b/webview-ui/src/utils/__tests__/sampling.spec.ts
@@ -1,0 +1,28 @@
+import { createSampledFunction } from "../sampling"
+import { vi } from "vitest"
+
+describe("createSampledFunction", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("should call the wrapped function when random value is less than sample rate", () => {
+		vi.spyOn(Math, "random").mockReturnValue(0.005) // 0.5%
+		const mockFn = vi.fn()
+		const sampledFn = createSampledFunction(mockFn, 0.01) // 1%
+
+		sampledFn("test", 123)
+
+		expect(mockFn).toHaveBeenCalledWith("test", 123)
+	})
+
+	it("should not call the wrapped function when random value is greater than sample rate", () => {
+		vi.spyOn(Math, "random").mockReturnValue(0.015) // 1.5%
+		const mockFn = vi.fn()
+		const sampledFn = createSampledFunction(mockFn, 0.01) // 1%
+
+		sampledFn("test", 123)
+
+		expect(mockFn).not.toHaveBeenCalled()
+	})
+})

--- a/webview-ui/src/utils/sampling.ts
+++ b/webview-ui/src/utils/sampling.ts
@@ -1,0 +1,16 @@
+/**
+ * Creates a sampled version of a function that only executes based on the provided sample rate.
+ *
+ * @param fn - The function to wrap with sampling
+ * @param sampleRate - The sampling rate as a decimal (e.g., 0.01 for 1%, 0.1 for 10%)
+ * @returns A new function that only executes the original function based on the sample rate
+ */
+export function createSampledFunction<T extends (...args: any[]) => any>(fn: T, sampleRate: number): T {
+	const clampedRate = Math.max(0, Math.min(1, sampleRate))
+
+	return ((...args: Parameters<T>) => {
+		if (Math.random() < clampedRate) {
+			return fn(...args)
+		}
+	}) as T
+}


### PR DESCRIPTION
Adjusts the memory usage telemetry capture to a 1% sampling rate to reduce data volume. Increases the interval for memory capture from 1 minute to 10 minutes.

