### PR TITLE
fix(ollama): improve context window detection and parameter parsing

### DIFF
--- a/packages/types/src/providers/ollama.ts
+++ b/packages/types/src/providers/ollama.ts
@@ -5,7 +5,8 @@ import type { ModelInfo } from "../model.js"
 export const ollamaDefaultModelId = "devstral:24b"
 export const ollamaDefaultModelInfo: ModelInfo = {
 	maxTokens: 4096,
-	contextWindow: 200_000,
+	contextWindow: 128_000, //kilocode_change
+	// kilocode_change the most common models on https://ollama.com/library are all 128K, except for the qwen3 family, which are either 40K or 256K
 	supportsImages: true,
 	supportsComputerUse: true,
 	supportsPromptCache: true,


### PR DESCRIPTION
- Add parseOllamaParametersToJSON function to properly parse model parameters
- Enhance context window detection by checking model_info keys ending with '.context_length'
- Prioritize environment variable OLLAMA_CONTEXT_LENGTH over model defaults
- Update default context window from 200K to 128K to match common Ollama models
- Fix maxTokens assignment to use defined context window

This change ensures more accurate context window detection for Ollama models and provides better handling of model parameters.

## Context

Previous effort didn't quite work with models that had a large default context (like qwen3:8b) of 256K.  

## Implementation

New method does more careful parsing of the parameters field returned by Ollama.   If thats set, it uses that.  
Other wise, it uses the default context that is set in the model architecture section (`qwen3.context_window` or `gemma3._context_window`).  
If the env var is sat, that overrides all.
Lastly, it uses the default hardcoded, which is changed to be 128K, matching the top 3 models on ollama library.



## Get in Touch

mcowger
