### PR TITLE
Prevent writing to files outside workspace by default to enhance security

### DIFF
--- a/.changeset/chatty-poems-own.md
+++ b/.changeset/chatty-poems-own.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": patch
+---
+
+Prevent writing to files outside the workspace by default
+
+This should mitigate supply chain compromise attacks via prompt injection. Thank you, Evan Harris from MCP Security Research for finding this!

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1860,7 +1860,7 @@ export class ClineProvider
 			alwaysAllowReadOnly: alwaysAllowReadOnly ?? true,
 			alwaysAllowReadOnlyOutsideWorkspace: alwaysAllowReadOnlyOutsideWorkspace ?? true,
 			alwaysAllowWrite: alwaysAllowWrite ?? true,
-			alwaysAllowWriteOutsideWorkspace: alwaysAllowWriteOutsideWorkspace ?? false, // kilocode_change
+			alwaysAllowWriteOutsideWorkspace: alwaysAllowWriteOutsideWorkspace ?? false,
 			alwaysAllowWriteProtected: alwaysAllowWriteProtected ?? false,
 			alwaysAllowExecute: alwaysAllowExecute ?? true,
 			alwaysAllowBrowser: alwaysAllowBrowser ?? true,
@@ -2068,7 +2068,7 @@ export class ClineProvider
 			alwaysAllowReadOnly: stateValues.alwaysAllowReadOnly ?? true,
 			alwaysAllowReadOnlyOutsideWorkspace: stateValues.alwaysAllowReadOnlyOutsideWorkspace ?? true,
 			alwaysAllowWrite: stateValues.alwaysAllowWrite ?? true,
-			alwaysAllowWriteOutsideWorkspace: stateValues.alwaysAllowWriteOutsideWorkspace ?? false, // kilocode_change
+			alwaysAllowWriteOutsideWorkspace: stateValues.alwaysAllowWriteOutsideWorkspace ?? false,
 			alwaysAllowWriteProtected: stateValues.alwaysAllowWriteProtected ?? false,
 			alwaysAllowExecute: stateValues.alwaysAllowExecute ?? true,
 			alwaysAllowBrowser: stateValues.alwaysAllowBrowser ?? true,

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1860,7 +1860,7 @@ export class ClineProvider
 			alwaysAllowReadOnly: alwaysAllowReadOnly ?? true,
 			alwaysAllowReadOnlyOutsideWorkspace: alwaysAllowReadOnlyOutsideWorkspace ?? true,
 			alwaysAllowWrite: alwaysAllowWrite ?? true,
-			alwaysAllowWriteOutsideWorkspace: alwaysAllowWriteOutsideWorkspace ?? true,
+			alwaysAllowWriteOutsideWorkspace: alwaysAllowWriteOutsideWorkspace ?? false, // kilocode_change
 			alwaysAllowWriteProtected: alwaysAllowWriteProtected ?? false,
 			alwaysAllowExecute: alwaysAllowExecute ?? true,
 			alwaysAllowBrowser: alwaysAllowBrowser ?? true,
@@ -2068,7 +2068,7 @@ export class ClineProvider
 			alwaysAllowReadOnly: stateValues.alwaysAllowReadOnly ?? true,
 			alwaysAllowReadOnlyOutsideWorkspace: stateValues.alwaysAllowReadOnlyOutsideWorkspace ?? true,
 			alwaysAllowWrite: stateValues.alwaysAllowWrite ?? true,
-			alwaysAllowWriteOutsideWorkspace: stateValues.alwaysAllowWriteOutsideWorkspace ?? true,
+			alwaysAllowWriteOutsideWorkspace: stateValues.alwaysAllowWriteOutsideWorkspace ?? false, // kilocode_change
 			alwaysAllowWriteProtected: stateValues.alwaysAllowWriteProtected ?? false,
 			alwaysAllowExecute: stateValues.alwaysAllowExecute ?? true,
 			alwaysAllowBrowser: stateValues.alwaysAllowBrowser ?? true,


### PR DESCRIPTION
The `alwaysAllowWriteOutsideWorkspace` flag in `ClineProvider` was set to `true` by default, allowing Kilo Code to write to arbitrary files outside the workspace. This change sets it to `false` by default, enhancing security and preventing unintended file modifications.

VULNERABILITY:
- AI could be manipulated via prompt injection to write to VSCode settings.json
- This bypassed command approval by whitelisting git commands
- Enabled supply chain attacks through automatic git operations

ROOT CAUSE:
- alwaysAllowWriteOutsideWorkspace defaulted to true
- No user approval required for outside-workspace file writes
- VSCode settings could be modified to bypass security controls

FIXES:
1. Change alwaysAllowWriteOutsideWorkspace default to false
   - Prevents unauthorized writes outside workspace
   - Users can still enable explicitly if needed
   - Primary mitigation for the attack vector

This addresses the reported prompt injection attack where malicious prompts could modify ~/.config/Code/User/settings.json to whitelist git commands, then automatically execute git add/commit/push operations without approval.

Evan Harris from MCP Security Research <security@mcpsec.dev> let us know about this via email. Thanks, Evan!
