### PR TITLE
fix lost text input race condition

### DIFF
--- a/.changeset/grumpy-trains-own.md
+++ b/.changeset/grumpy-trains-own.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+fixes an intermittent async race that discards user-chat-input during structured approve/reject

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -862,9 +862,12 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	}
 
 	handleWebviewAskResponse(askResponse: ClineAskResponse, text?: string, images?: string[]) {
-		this.askResponse = askResponse
 		this.askResponseText = text
 		this.askResponseImages = images
+
+		// the askResponse assignment needs to happen last to avoid the async
+		// callbacks triggering before we assign the data above
+		this.askResponse = askResponse // this triggers async callbacks
 	}
 
 	public approveAsk({ text, images }: { text?: string; images?: string[] } = {}) {

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -862,12 +862,15 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	}
 
 	handleWebviewAskResponse(askResponse: ClineAskResponse, text?: string, images?: string[]) {
+		// this.askResponse = askResponse kilocode_change
 		this.askResponseText = text
 		this.askResponseImages = images
 
+		// kilocode_change start
 		// the askResponse assignment needs to happen last to avoid the async
 		// callbacks triggering before we assign the data above
 		this.askResponse = askResponse // this triggers async callbacks
+		// kilocode_change end
 	}
 
 	public approveAsk({ text, images }: { text?: string; images?: string[] } = {}) {


### PR DESCRIPTION
## Context

I am fixing a subtle async race-condition bug where chat-text input is intermittently lost when submitting it by clicking on a structured question button (for example, approve/reject of a file edit). 

The 1-line code-re-ordering in this diff is necessary to avoid a race-condition where the async code awaited Task.askResponse can trigger due to writing Task.askResponse before the text/image data is assigned to be sent with the response. 

NOTE: this does *not* fix a similar but non-race condition bug, where search-and-replace seems to consistenly discard user-text typed when approving it. I will look at that soon.

## Implementation

In short, you can see from the tiny patch, I merely moved the assignment of Task.askResponse to below the assignment of Task.askResponseText and Task.askResponseImages, so these to "state" variables are assigned correctly before the "async triggers" waiting on the assignment of "Task.askResponse".  This is the entirety of the patch:

```
handleWebviewAskResponse(askResponse: ClineAskResponse, text?: string, images?: string[]) {
		this.askResponseText = text
		this.askResponseImages = images

		// the askResponse assignment needs to happen last to avoid the async
		// callbacks triggering before we assign the data above
		this.askResponse = askResponse // this triggers async callbacks
	}
```

The awaited task is holding because of this code, near line 830, the assignment of this.askResponse will trigger the async reactivation of this awaited task. If this happens before this.askResponseText/Image is assigned, then the text/imager data is NOT sent to the LLM, and ends up over-written the next time this codepath occurs.

```
// Wait for askResponse to be set
  await pWaitFor(() => this.askResponse !== undefined || this.lastMessageTs !== askTs, { interval: 100 })

```

This is not the only source of losing user-typed-data, but in 24 hours of testing I have not witnessed chat-text being eaten during apply-diff, something i normally experience regularly, so it seems to have solved at least once source of this problem... and at any rate, because of the asyncwait on Task.askResponse, this *IS* the correct and required ordering of this code.

## Screenshots

There are no altered visuals. This is fixing a race condition.

## How to Test

The bug is intermittent, based on an async race, so it's hard to force trigger it, but it does occur to me regularly through these actions:

1. set to manual approval of writes
2. llm performs a write file or apply diff
3. I type chat into the box before clicking approve
4. when I click approve, some percentage of the time it discards my text input. (i'd say 3-10% of the time, but it seems to get into fits where it is stuck discarding, and then if I restart everything it will stop doing it, suggesting some connection to the async await trigger ordering inside V8's async scheduler)

## Get in Touch

Discord username is "kuroparkcity", I'm on the Kilo Discord as "David Jeske", and you can also reach me at my email address "davidj@gmail.com". 