### PR TITLE
Exclude vscode deps files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,11 +2,19 @@
 {
 	"files.exclude": {
 		"out": false, // set this to true to hide the "out" folder with the compiled JS files
-		"dist": false // set this to true to hide the "dist" folder with the compiled JS files
+		"dist": false, // set this to true to hide the "dist" folder with the compiled JS files
+		"deps/vscode/**": true,
+		"jetbrains/host/deps/**": true
 	},
 	"search.exclude": {
 		"out": true, // set this to false to include "out" folder in search results
-		"dist": true // set this to false to include "dist" folder in search results
+		"dist": true, // set this to false to include "dist" folder in search results
+		"deps/vscode/**": true,
+		"jetbrains/host/deps/**": true
+	},
+	"files.watcherExclude": {
+		"deps/vscode/**": true,
+		"jetbrains/host/deps/**": true
 	},
 	// Turn off tsc task auto detection since we have the necessary tasks as npm scripts
 	"typescript.tsc.autoDetect": "off",


### PR DESCRIPTION
## Context

This PR configures VS Code to exclude specific dependency directories from file browsing, search, and file watching operations. The changes help improve VS Code performance by preventing it from indexing and monitoring files in dependency directories that don't need to be actively searched or watched.

## Implementation

- Adds exclusion patterns for deps/vscode/** and jetbrains/host/deps/** directories
- Applies exclusions to file explorer, search functionality, and file watcher
- Fixes missing commas in the JSON configuration
