### PR TITLE
MacOs / Terminal Notifier Support

### DIFF
--- a/.changeset/spicy-animals-nail.md
+++ b/.changeset/spicy-animals-nail.md
@@ -1,5 +1,4 @@
 ---
-"kilocode-docs": minor
 "kilo-code": minor
 ---
 

--- a/.changeset/spicy-animals-nail.md
+++ b/.changeset/spicy-animals-nail.md
@@ -1,0 +1,6 @@
+---
+"kilocode-docs": minor
+"kilo-code": minor
+---
+
+MacOS - System Terminal Notifier Support

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,7 +21,19 @@
 			"label": "watch:pnpm",
 			"type": "shell",
 			"command": "npx",
-			"args": ["nodemon", "--watch", "\"**/package.json\"", "--exec", "pnpm install"],
+			"args": [
+				"nodemon",
+				"--watch",
+				"package.json",
+				"--watch",
+				"src/package.json",
+				"--watch",
+				"webview-ui/package.json",
+				"--watch",
+				"pnpm-workspace.yaml",
+				"--exec",
+				"pnpm install"
+			],
 			"group": "none",
 			"isBackground": true,
 			"presentation": {

--- a/apps/kilocode-docs/docs/features/system-notifications.md
+++ b/apps/kilocode-docs/docs/features/system-notifications.md
@@ -1,0 +1,251 @@
+# System Notifications
+
+System notifications are native operating system notifications that appear in your system's notification center or tray. Unlike VSCode's built-in notifications that only appear within the editor, system notifications are visible even when:
+
+- VSCode is minimized or in the background
+- You're working in other applications
+- Your screen is locked (depending on OS settings)
+- You're away from your computer
+
+Kilo Code uses system notifications to inform you about:
+
+- Task completion status
+- Important errors or warnings
+- Long-running operation updates
+- Critical system events
+
+## Supported Operating Systems
+
+Kilo Code's system notifications work on all major operating systems with different underlying technologies:
+
+| Operating System | Technology                      | Requirements                                 |
+| ---------------- | ------------------------------- | -------------------------------------------- |
+| **macOS**        | AppleScript + terminal-notifier | Built-in support, optional enhanced features |
+| **Windows**      | PowerShell + Windows Runtime    | PowerShell execution policy configuration    |
+| **Linux**        | notify-send                     | libnotify package installation               |
+
+## Platform-Specific Setup
+
+### macOS Setup
+
+macOS has the best built-in support for system notifications with two available methods:
+
+#### Method 1: Built-in AppleScript (Fallback)
+
+No additional setup required. Kilo Code uses macOS's built-in command to display notifications.
+
+#### Method 2: Enhanced with terminal-notifier (Recommended)
+
+For enhanced notifications with custom icons, install terminal-notifier:
+
+```bash
+# Install via Homebrew
+brew install terminal-notifier
+
+# Or install via npm
+npm install -g terminal-notifier
+```
+
+**How it works:** Kilo Code first attempts to use `terminal-notifier` and automatically falls back to AppleScript if it's not installed.
+
+### Windows Setup
+
+Windows notifications require PowerShell execution policy configuration to work properly.
+
+#### Step 1: Configure PowerShell Execution Policy
+
+Open PowerShell as Administrator and run:
+
+```powershell
+# Check current execution policy
+Get-ExecutionPolicy
+
+# Set execution policy to allow local scripts
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
+#### Step 2: Verify Windows Runtime Access
+
+Windows notifications use the `Windows.UI.Notifications` API through PowerShell. This is available on:
+
+- ✅ Windows 10 (all versions)
+- ✅ Windows 11 (all versions)
+- ✅ Windows Server 2016 and later
+- ❌ Windows 8.1 and earlier (limited support)
+
+#### Execution Policy Options
+
+| Policy         | Description                                | Security Level | Recommended             |
+| -------------- | ------------------------------------------ | -------------- | ----------------------- |
+| `Restricted`   | No scripts allowed (default)               | Highest        | ❌ Blocks notifications |
+| `RemoteSigned` | Local scripts run, downloaded need signing | High           | ✅ **Recommended**      |
+| `Unrestricted` | All scripts run with warnings              | Medium         | ⚠️ Use with caution     |
+| `AllSigned`    | All scripts must be signed                 | Highest        | ❌ Too restrictive      |
+
+### Linux Setup
+
+Linux notifications require the `libnotify` package and `notify-send` command.
+
+#### Ubuntu/Debian Installation
+
+```bash
+# Install libnotify
+sudo apt update
+sudo apt install libnotify-bin
+
+# Verify installation
+which notify-send
+```
+
+#### Red Hat/CentOS/Fedora Installation
+
+```bash
+# RHEL/CentOS
+sudo yum install libnotify
+
+# Fedora
+sudo dnf install libnotify
+
+# Verify installation
+which notify-send
+```
+
+#### Arch Linux Installation
+
+```bash
+# Install libnotify
+sudo pacman -S libnotify
+
+# Verify installation
+which notify-send
+```
+
+#### Desktop Environment Requirements
+
+System notifications work best with these desktop environments:
+
+| Desktop Environment | Support Level   | Notes                                     |
+| ------------------- | --------------- | ----------------------------------------- |
+| **GNOME**           | ✅ Full support | Native notification center                |
+| **KDE Plasma**      | ✅ Full support | Native notification system                |
+| **XFCE**            | ✅ Good support | Requires notification daemon              |
+| **Unity**           | ✅ Full support | Ubuntu's notification system              |
+| **i3/Sway**         | ⚠️ Limited      | Requires manual notification daemon setup |
+| **Headless**        | ❌ No support   | No display server available               |
+
+#### Notification Daemon Setup (Advanced)
+
+For minimal window managers, you may need to start a notification daemon:
+
+```bash
+# Install and start dunst (lightweight notification daemon)
+sudo apt install dunst  # Ubuntu/Debian
+sudo pacman -S dunst    # Arch Linux
+
+# Start dunst manually
+dunst &
+
+# Or add to your window manager startup script
+echo "dunst &" >> ~/.xinitrc
+```
+
+## Verifying System Notifications
+
+### Test Commands by Platform
+
+#### macOS Test
+
+```bash
+# Test AppleScript method
+osascript -e 'display notification "Test message" with title "Test Title" sound name "Tink"'
+
+# Test terminal-notifier (if installed)
+terminal-notifier -message "Test message" -title "Test Title" -sound Tink
+```
+
+#### Windows Test
+
+```powershell
+# Test PowerShell notification
+$template = @"
+<toast>
+    <visual>
+        <binding template="ToastText02">
+            <text id="1">Test Title</text>
+            <text id="2">Test message</text>
+        </binding>
+    </visual>
+</toast>
+"@
+
+[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] | Out-Null
+$xml = New-Object Windows.Data.Xml.Dom.XmlDocument
+$xml.LoadXml($template)
+$toast = [Windows.UI.Notifications.ToastNotification]::new($xml)
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("Test App").Show($toast)
+```
+
+#### Linux Test
+
+```bash
+# Test notify-send
+notify-send "Test Title" "Test message"
+
+# Test with icon (optional)
+notify-send -i dialog-information "Test Title" "Test message"
+```
+
+## Troubleshooting
+
+### Common Issues and Solutions
+
+#### macOS Issues
+
+**Problem:** Notifications not appearing
+
+- **Solution 1:** Check System Preferences → Notifications → Terminal (or VSCode) → Allow notifications
+- **Solution 2:** Verify Do Not Disturb is disabled
+- **Solution 3:** Test with the manual commands above
+
+**Problem:** Notifications not appearing
+
+- **Solution:** Ensure terminal-notifier is properly installed: `brew install terminal-notifier`
+
+#### Windows Issues
+
+**Problem:** "Execution of scripts is disabled" error
+
+- **Solution:** Configure PowerShell execution policy as described in setup
+- **Command:** `Set-ExecutionPolicy RemoteSigned -Scope CurrentUser`
+
+**Problem:** Notifications not appearing in Windows 11
+
+- **Solution 1:** Check Settings → System → Notifications → Allow notifications
+- **Solution 2:** Ensure Focus Assist is not blocking notifications
+- **Solution 3:** Verify Windows notification service is running
+
+**Problem:** PowerShell script errors
+
+- **Solution:** Update PowerShell to version 5.1 or later
+- **Check version:** `$PSVersionTable.PSVersion`
+
+#### Linux Issues
+
+**Problem:** `notify-send: command not found`
+
+- **Solution:** Install libnotify package for your distribution
+- **Ubuntu/Debian:** `sudo apt install libnotify-bin`
+- **RHEL/CentOS:** `sudo yum install libnotify`
+- **Arch:** `sudo pacman -S libnotify`
+
+**Problem:** Notifications not appearing in minimal window managers
+
+- **Solution:** Install and configure a notification daemon like dunst
+- **Install:** `sudo apt install dunst` (Ubuntu/Debian)
+- **Start:** `dunst &`
+
+**Problem:** Permission denied errors
+
+- **Solution:** Ensure your user has access to the display server
+- **Check:** `echo $DISPLAY` should return something like `:0`

--- a/apps/kilocode-docs/sidebars.ts
+++ b/apps/kilocode-docs/sidebars.ts
@@ -34,6 +34,7 @@ const sidebars: SidebarsConfig = {
 						"basic-usage/git-commit-generation",
 						"features/browser-use",
 						"features/code-actions",
+						"features/system-notifications",
 						"features/more-features",
 					],
 				},

--- a/jetbrains/host/package.json
+++ b/jetbrains/host/package.json
@@ -12,8 +12,6 @@
 		"build:clean": "npm run clean && npm run build",
 		"start": "node ./dist/src/main.js",
 		"dev": "tsc && node ./dist/src/main.js",
-		"watch:tsc": "tsc --watch",
-		"watch": "tsc --watch",
 		"bundle:package": "cp ./package.json ./dist/package.json",
 		"bundle:build": "tsc --noEmit && tsup",
 		"lint": "eslint . --ext=ts --max-warnings=0"

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1005,7 +1005,7 @@ export const webviewMessageHandler = async (
 			break
 		case "showSystemNotification":
 			const isSystemNotificationsEnabled = getGlobalState("systemNotificationsEnabled") ?? true
-			if (!isSystemNotificationsEnabled) {
+			if (!isSystemNotificationsEnabled && !message.alwaysAllow) {
 				break
 			}
 			if (message.notificationOptions) {

--- a/src/integrations/notifications/__tests__/index.spec.ts
+++ b/src/integrations/notifications/__tests__/index.spec.ts
@@ -1,19 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { execa } from "execa"
-import { platform } from "os"
 import * as path from "path"
-import { showSystemNotification } from "../index"
 
 // Mock execa
 vi.mock("execa")
 
-// Mock os platform
+// Mock os module
 vi.mock("os", () => ({
 	platform: vi.fn(),
 }))
 
+// Mock vscode module
+vi.mock("vscode", () => ({
+	extensions: {
+		getExtension: vi.fn(() => ({
+			extensionUri: {
+				fsPath: "/mock/extension/path",
+			},
+		})),
+	},
+	Uri: {
+		joinPath: vi.fn((extensionUri, ...pathSegments) => ({
+			fsPath: path.join(__dirname, "..", "..", "..", ...pathSegments),
+		})),
+	},
+}))
+
+// Import after mocking
+import { showSystemNotification } from "../index"
+import * as os from "os"
+
 const mockedExeca = vi.mocked(execa)
-const mockedPlatform = vi.mocked(platform)
+const mockedPlatform = vi.mocked(os.platform)
 
 describe("showSystemNotification", () => {
 	beforeEach(() => {

--- a/src/integrations/notifications/__tests__/index.spec.ts
+++ b/src/integrations/notifications/__tests__/index.spec.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { execa } from "execa"
+import { platform } from "os"
+import * as path from "path"
+import { showSystemNotification } from "../index"
+
+// Mock execa
+vi.mock("execa")
+
+// Mock os platform
+vi.mock("os", () => ({
+	platform: vi.fn(),
+}))
+
+const mockedExeca = vi.mocked(execa)
+const mockedPlatform = vi.mocked(platform)
+
+describe("showSystemNotification", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		// Suppress console.error for tests
+		vi.spyOn(console, "error").mockImplementation(() => {})
+	})
+
+	describe("macOS notifications", () => {
+		beforeEach(() => {
+			mockedPlatform.mockReturnValue("darwin")
+		})
+
+		it("should use terminal-notifier when available", async () => {
+			mockedExeca.mockResolvedValueOnce({} as any)
+
+			await showSystemNotification({
+				title: "Test Title",
+				subtitle: "Test Subtitle",
+				message: "Test Message",
+			})
+
+			const expectedIconPath = path.join(__dirname, "..", "..", "..", "assets", "icons", "kilo.png")
+			expect(mockedExeca).toHaveBeenCalledWith("terminal-notifier", [
+				"-message",
+				"Test Message",
+				"-title",
+				"Test Title",
+				"-subtitle",
+				"Test Subtitle",
+				"-sound",
+				"Tink",
+				"-appIcon",
+				expectedIconPath,
+			])
+			expect(mockedExeca).toHaveBeenCalledTimes(1)
+		})
+
+		it("should fall back to osascript when terminal-notifier fails", async () => {
+			// First call (terminal-notifier) fails
+			mockedExeca.mockRejectedValueOnce(new Error("terminal-notifier not found"))
+			// Second call (osascript) succeeds
+			mockedExeca.mockResolvedValueOnce({} as any)
+
+			await showSystemNotification({
+				title: "Test Title",
+				subtitle: "Test Subtitle",
+				message: "Test Message",
+			})
+
+			const expectedIconPath = path.join(__dirname, "..", "..", "..", "assets", "icons", "kilo.png")
+			expect(mockedExeca).toHaveBeenCalledTimes(2)
+			expect(mockedExeca).toHaveBeenNthCalledWith(1, "terminal-notifier", [
+				"-message",
+				"Test Message",
+				"-title",
+				"Test Title",
+				"-subtitle",
+				"Test Subtitle",
+				"-sound",
+				"Tink",
+				"-appIcon",
+				expectedIconPath,
+			])
+			expect(mockedExeca).toHaveBeenNthCalledWith(2, "osascript", [
+				"-e",
+				'display notification "Test Message" with title "Test Title" subtitle "Test Subtitle" sound name "Tink"',
+			])
+		})
+
+		it("should handle terminal-notifier with minimal options", async () => {
+			mockedExeca.mockResolvedValueOnce({} as any)
+
+			await showSystemNotification({
+				message: "Test Message",
+			})
+
+			const expectedIconPath = path.join(__dirname, "..", "..", "..", "assets", "icons", "kilo.png")
+			expect(mockedExeca).toHaveBeenCalledWith("terminal-notifier", [
+				"-message",
+				"Test Message",
+				"-title",
+				"Kilo Code",
+				"-sound",
+				"Tink",
+				"-appIcon",
+				expectedIconPath,
+			])
+		})
+
+		it("should handle terminal-notifier without subtitle", async () => {
+			mockedExeca.mockResolvedValueOnce({} as any)
+
+			await showSystemNotification({
+				title: "Test Title",
+				message: "Test Message",
+			})
+
+			const expectedIconPath = path.join(__dirname, "..", "..", "..", "assets", "icons", "kilo.png")
+			expect(mockedExeca).toHaveBeenCalledWith("terminal-notifier", [
+				"-message",
+				"Test Message",
+				"-title",
+				"Test Title",
+				"-sound",
+				"Tink",
+				"-appIcon",
+				expectedIconPath,
+			])
+		})
+
+		it("should escape quotes in terminal-notifier arguments", async () => {
+			mockedExeca.mockResolvedValueOnce({} as any)
+
+			await showSystemNotification({
+				title: 'Title with "quotes"',
+				subtitle: 'Subtitle with "quotes"',
+				message: 'Message with "quotes"',
+			})
+
+			const expectedIconPath = path.join(__dirname, "..", "..", "..", "assets", "icons", "kilo.png")
+			expect(mockedExeca).toHaveBeenCalledWith("terminal-notifier", [
+				"-message",
+				'Message with \\"quotes\\"',
+				"-title",
+				'Title with \\"quotes\\"',
+				"-subtitle",
+				'Subtitle with \\"quotes\\"',
+				"-sound",
+				"Tink",
+				"-appIcon",
+				expectedIconPath,
+			])
+		})
+
+		it("should fall back to osascript and escape quotes properly", async () => {
+			// terminal-notifier fails
+			mockedExeca.mockRejectedValueOnce(new Error("not found"))
+			// osascript succeeds
+			mockedExeca.mockResolvedValueOnce({} as any)
+
+			await showSystemNotification({
+				title: 'Title with "quotes"',
+				subtitle: 'Subtitle with "quotes"',
+				message: 'Message with "quotes"',
+			})
+
+			expect(mockedExeca).toHaveBeenNthCalledWith(2, "osascript", [
+				"-e",
+				'display notification "Message with \\"quotes\\"" with title "Title with \\"quotes\\"" subtitle "Subtitle with \\"quotes\\"" sound name "Tink"',
+			])
+		})
+
+		it("should throw error when both terminal-notifier and osascript fail", async () => {
+			// Both calls fail
+			mockedExeca.mockRejectedValue(new Error("Command failed"))
+
+			await showSystemNotification({
+				message: "Test Message",
+			})
+
+			// Should not throw but log error to console
+			expect(console.error).toHaveBeenCalledWith("Could not show system notification", expect.any(Error))
+		})
+	})
+
+	describe("Windows notifications", () => {
+		beforeEach(() => {
+			mockedPlatform.mockReturnValue("win32")
+		})
+
+		it("should use PowerShell for Windows notifications", async () => {
+			mockedExeca.mockResolvedValueOnce({} as any)
+
+			await showSystemNotification({
+				title: "Test Title",
+				subtitle: "Test Subtitle",
+				message: "Test Message",
+			})
+
+			expect(mockedExeca).toHaveBeenCalledWith("powershell", [
+				"-Command",
+				expect.stringContaining("ToastNotificationManager"),
+			])
+		})
+	})
+
+	describe("Linux notifications", () => {
+		beforeEach(() => {
+			mockedPlatform.mockReturnValue("linux")
+		})
+
+		it("should use notify-send for Linux notifications", async () => {
+			mockedExeca.mockResolvedValueOnce({} as any)
+
+			await showSystemNotification({
+				title: "Test Title",
+				subtitle: "Test Subtitle",
+				message: "Test Message",
+			})
+
+			expect(mockedExeca).toHaveBeenCalledWith("notify-send", ["Test Title", "Test Subtitle\nTest Message"])
+		})
+	})
+
+	describe("Unsupported platforms", () => {
+		it("should handle unsupported platforms gracefully", async () => {
+			mockedPlatform.mockReturnValue("freebsd")
+
+			await showSystemNotification({
+				message: "Test Message",
+			})
+
+			expect(console.error).toHaveBeenCalledWith("Could not show system notification", expect.any(Error))
+		})
+	})
+
+	describe("Input validation", () => {
+		beforeEach(() => {
+			mockedPlatform.mockReturnValue("darwin")
+		})
+
+		it("should handle missing message gracefully", async () => {
+			await showSystemNotification({
+				title: "Test Title",
+			} as any)
+
+			expect(console.error).toHaveBeenCalledWith("Could not show system notification", expect.any(Error))
+		})
+
+		it("should use default title when not provided", async () => {
+			mockedExeca.mockResolvedValueOnce({} as any)
+
+			await showSystemNotification({
+				message: "Test Message",
+			})
+
+			const expectedIconPath = path.join(__dirname, "..", "..", "..", "assets", "icons", "kilo.png")
+			expect(mockedExeca).toHaveBeenCalledWith("terminal-notifier", [
+				"-message",
+				"Test Message",
+				"-title",
+				"Kilo Code",
+				"-sound",
+				"Tink",
+				"-appIcon",
+				expectedIconPath,
+			])
+		})
+	})
+})

--- a/src/integrations/notifications/index.ts
+++ b/src/integrations/notifications/index.ts
@@ -1,5 +1,6 @@
 import { execa } from "execa"
 import { platform } from "os"
+import * as vscode from "vscode"
 
 interface NotificationOptions {
 	title?: string
@@ -10,6 +11,30 @@ interface NotificationOptions {
 async function showMacOSNotification(options: NotificationOptions): Promise<void> {
 	const { title, subtitle = "", message } = options
 
+	// Try terminal-notifier first if available
+	try {
+		const args = ["-message", message]
+		if (title) {
+			args.push("-title", title)
+		}
+		if (subtitle) {
+			args.push("-subtitle", subtitle)
+		}
+		args.push("-sound", "Tink")
+
+		// Add Kilo Code logo
+		const extensionUri = vscode.extensions.getExtension(`kilocode.kilo-code`)!.extensionUri
+		const iconPath = vscode.Uri.joinPath(extensionUri, "assets", "icons", "kilo.png").fsPath
+		args.push("-appIcon", iconPath)
+
+		await execa("terminal-notifier", args)
+		return
+	} catch (error) {
+		// If terminal-notifier fails, fall back to osascript
+		// This could be because terminal-notifier is not installed or other error
+	}
+
+	// Fallback to osascript
 	const script = `display notification "${message}" with title "${title}" subtitle "${subtitle}" sound name "Tink"`
 
 	try {

--- a/src/integrations/notifications/index.ts
+++ b/src/integrations/notifications/index.ts
@@ -1,5 +1,5 @@
 import { execa } from "execa"
-import { platform } from "os"
+import * as os from "os"
 import * as vscode from "vscode"
 
 interface NotificationOptions {
@@ -103,7 +103,7 @@ export async function showSystemNotification(options: NotificationOptions): Prom
 			subtitle: options.subtitle?.replace(/"/g, '\\"') || "",
 		}
 
-		switch (platform()) {
+		switch (os.platform()) {
 			case "darwin":
 				await showMacOSNotification(escapedOptions)
 				break

--- a/webview-ui/src/components/settings/NotificationSettings.tsx
+++ b/webview-ui/src/components/settings/NotificationSettings.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, useMemo } from "react" // kilocode_change
+import { HTMLAttributes } from "react" // kilocode_change
 import { useAppTranslation } from "@/i18n/TranslationContext"
 import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import { Bell } from "lucide-react"
@@ -42,11 +42,9 @@ export const NotificationSettings = ({
 				title: t("kilocode:settings.systemNotifications.testTitle"),
 				message: t("kilocode:settings.systemNotifications.testMessage"),
 			},
+			alwaysAllow: true,
 		})
 	}
-	const showTestSystemNotification = useMemo(() => {
-		return systemNotificationsEnabled && areSettingsCommitted
-	}, [systemNotificationsEnabled, areSettingsCommitted])
 	// kilocode_change end
 
 	return (
@@ -137,10 +135,9 @@ export const NotificationSettings = ({
 						{t("kilocode:settings.systemNotifications.description")}
 					</div>
 				</div>
-				{showTestSystemNotification && (
+				{systemNotificationsEnabled && (
 					<div className="flex flex-col gap-3 pl-3 border-l-2 border-vscode-button-background">
 						<Button
-							disabled={!areSettingsCommitted}
 							className="w-fit text-vscode-button-background hover:text-vscode-button-hoverBackground"
 							onClick={onTestNotificationClick}>
 							{t("kilocode:settings.systemNotifications.testButton")}


### PR DESCRIPTION
## Context

This PR adds enhanced macOS notification support with terminal-notifier integration while maintaining backward compatibility. The implementation prioritizes terminal-notifier for richer notifications and automatically falls back to AppleScript when it's unavailable.


## Implementation

- Adds terminal-notifier support for macOS notifications with custom icons and enhanced features
- Implements comprehensive fallback mechanism from terminal-notifier to osascript
- Includes extensive test coverage and detailed documentation for cross-platform system notifications

## Screenshots

<img width="1512" height="556" alt="Screenshot 2025-09-05 at 5 40 45 PM" src="https://github.com/user-attachments/assets/33f6e52f-0f3c-45db-b1d4-7772fb5ea6d7" />

