### PR TITLE
Jetbrains make the published package available for everyone

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -165,5 +165,5 @@ jobs:
                 -F "file=@jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}" \
                 -F "pluginId=28350" \
                 -F "channel=stable" \
-                -F "isHidden=true" \
+                -F "isHidden=false" \
                 https://plugins.jetbrains.com/plugin/uploadPlugin


### PR DESCRIPTION
## Context

This affect only to the version visibility, so the Alpha Program member can get the updates automatically. 