### PR TITLE
Fixed an HTTP 500 error with OpenAI-compatible providers when no custom temperature is set

### DIFF
--- a/.changeset/polite-glasses-warn.md
+++ b/.changeset/polite-glasses-warn.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed an HTTP 500 error with OpenAI-compatible providers when no custom temperature is set

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -164,7 +164,10 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 			}
 
 			// Only include temperature if explicitly set
-			if (this.options.modelTemperature !== undefined) {
+			if (
+				this.options.modelTemperature !== undefined &&
+				this.options.modelTemperature !== null // kilocode_change: some providers like Chutes don't like this
+			) {
 				requestOptions.temperature = this.options.modelTemperature
 			} else if (deepseekReasoner) {
 				// DeepSeek Reasoner has a specific default temperature


### PR DESCRIPTION
same as https://github.com/Kilo-Org/kilocode/pull/2238

https://discord.com/channels/1349288496988160052/1414258635303030784/1414258635303030784