### PR TITLE
feat(i18n): implement JetBrains i18n system and add translations

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,7 +21,19 @@
 			"label": "watch:pnpm",
 			"type": "shell",
 			"command": "npx",
-			"args": ["nodemon", "--watch", "\"**/package.json\"", "--exec", "pnpm install"],
+			"args": [
+				"nodemon",
+				"--watch",
+				"package.json",
+				"--watch",
+				"src/package.json",
+				"--watch",
+				"webview-ui/package.json",
+				"--watch",
+				"pnpm-workspace.yaml",
+				"--exec",
+				"pnpm install"
+			],
 			"group": "none",
 			"isBackground": true,
 			"presentation": {

--- a/jetbrains/.gitignore
+++ b/jetbrains/.gitignore
@@ -1,2 +1,5 @@
 ### Debug resources
 resources/*
+
+### i18n strings converted from our normal json files during gradle build
+plugin/src/main/resources/messages

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/actors/MainThreadMessageServiceShape.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/actors/MainThreadMessageServiceShape.kt
@@ -4,6 +4,7 @@
 
 package ai.kilocode.jetbrains.actors
 
+import ai.kilocode.jetbrains.i18n.I18n
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.Disposable
@@ -53,7 +54,7 @@ class MainThreadMessageService : MainThreadMessageServiceShape {
         // If no cancel button, automatically add a "Cancel" button at the end
         val commandsWithCancel = if (cancelIdx < 0) {
             val cancelHandle = commands.size
-            commands + mapOf("title" to "Cancel", "handle" to cancelHandle, "isCloseAffordance" to true)
+            commands + mapOf("title" to I18n.t("jetbrains:dialog.cancel"), "handle" to cancelHandle, "isCloseAffordance" to true)
         } else {
             commands
         }

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/core/ExtensionProcessManager.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/core/ExtensionProcessManager.kt
@@ -19,6 +19,7 @@ import ai.kilocode.jetbrains.util.PluginConstants
 import ai.kilocode.jetbrains.util.NotificationUtil
 import ai.kilocode.jetbrains.util.NodeVersionUtil
 import ai.kilocode.jetbrains.util.NodeVersion
+import ai.kilocode.jetbrains.i18n.I18n
 
 /**
  * Extension process manager
@@ -81,8 +82,9 @@ class ExtensionProcessManager : Disposable {
                 
                 // Show notification to prompt user to install Node.js
                 NotificationUtil.showError(
-                    "Node.js environment missing",
-                    "Node.js environment not detected, please install Node.js and try again. Recommended version: $MIN_REQUIRED_NODE_VERSION or higher."
+                    I18n.t("jetbrains:errors.nodejsMissing.title"),
+                    I18n.t("jetbrains:errors.nodejsMissing.message",
+                        mapOf("minVersion" to MIN_REQUIRED_NODE_VERSION))
                 )
                 
                 return false
@@ -94,8 +96,12 @@ class ExtensionProcessManager : Disposable {
                 LOG.error("Node.js version is not supported: $nodeVersion, required: $MIN_REQUIRED_NODE_VERSION")
 
                 NotificationUtil.showError(
-                    "Node.js version too low",
-                    "Current Node.js($nodePath) version is $nodeVersion, please upgrade to $MIN_REQUIRED_NODE_VERSION or higher for better compatibility."
+                    I18n.t("jetbrains:errors.nodejsVersionLow.title"),
+                    I18n.t("jetbrains:errors.nodejsVersionLow.message", mapOf(
+                        "nodePath" to nodePath,
+                        "nodeVersion" to (nodeVersion?.toString() ?: "unknown"),
+                        "minVersion" to MIN_REQUIRED_NODE_VERSION
+                    ))
                 )
                 
                 return false

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/i18n/I18nUtils.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/i18n/I18nUtils.kt
@@ -1,0 +1,18 @@
+package ai.kilocode.jetbrains.i18n
+
+/**
+ * Convenience function for translations using I18n with named parameters
+ * @param key Translation key using namespace:path format (e.g., "jetbrains:errors.nodejsMissing.title")
+ * @param params Named parameters for interpolation (e.g., mapOf("minVersion" to "18.0.0"))
+ * @return Translated string
+ */
+fun t(key: String, params: Map<String, Any> = emptyMap()): String {
+    return I18n.t(key, params)
+}
+
+/**
+ * Convenience function with vararg parameters
+ */
+fun t(key: String, vararg params: Pair<String, Any>): String {
+    return I18n.t(key, *params)
+}

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/i18n/KiloBundle.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/i18n/KiloBundle.kt
@@ -1,0 +1,88 @@
+package ai.kilocode.jetbrains.i18n
+
+import com.intellij.DynamicBundle
+import com.intellij.openapi.diagnostic.Logger
+
+/**
+ * Dynamic translation system for Kilo Code JetBrains plugin
+ *
+ * Supports named parameter substitution and auto-discovery of translation bundles.
+ * Maintains API compatibility with the TypeScript i18n system.
+ */
+object I18n {
+    private val logger = Logger.getInstance(I18n::class.java)
+    private val bundleCache = mutableMapOf<String, DynamicBundle>()
+    
+    /**
+     * Main translation function with named parameter support
+     * @param fullKey Translation key in "namespace:key.path" format (e.g., "jetbrains:errors.nodejsMissing.title")
+     * @param params Named parameters as map for substitution (e.g., mapOf("minVersion" to "18.0.0"))
+     * @return Translated string with parameters substituted
+     */
+    @JvmStatic
+    fun t(fullKey: String, params: Map<String, Any> = emptyMap()): String {
+        val parts = fullKey.split(":", limit = 2)
+        if (parts.size != 2) {
+            logger.warn("Invalid translation key format: $fullKey (expected 'namespace:key')")
+            return fullKey
+        }
+        
+        val namespace = parts[0]
+        val key = parts[1]
+        
+        return try {
+            val bundle = getOrCreateBundle(namespace)
+            val template = bundle.getMessage(key)
+            substituteNamedParams(template, params)
+        } catch (e: Exception) {
+            logger.warn("Translation failed for key: $fullKey", e)
+            fullKey // Fallback to key name
+        }
+    }
+    
+    /**
+     * Convenience method for vararg parameters (matches TypeScript pattern)
+     */
+    @JvmStatic
+    fun t(fullKey: String, vararg params: Pair<String, Any>): String {
+        return t(fullKey, params.toMap())
+    }
+    
+    /**
+     * Get or create bundle dynamically based on namespace
+     */
+    private fun getOrCreateBundle(namespace: String): DynamicBundle {
+        return bundleCache.getOrPut(namespace) {
+            val bundleName = "messages.${namespace.replaceFirstChar { it.uppercase() }}Bundle"
+            try {
+                object : DynamicBundle(bundleName) {}
+            } catch (e: Exception) {
+                logger.error("Failed to create bundle for namespace: $namespace", e)
+                throw e
+            }
+        }
+    }
+    
+    /**
+     * Substitute named parameters in template string
+     * Supports {{paramName}} placeholders with named parameter map
+     */
+    private fun substituteNamedParams(template: String, params: Map<String, Any>): String {
+        if (params.isEmpty()) return template
+        
+        var result = template
+        val placeholderPattern = """\{\{(\w+)\}\}""".toRegex()
+        
+        placeholderPattern.findAll(template).forEach { match ->
+            val paramName = match.groupValues[1]
+            val paramValue = params[paramName]?.toString()
+            if (paramValue != null) {
+                result = result.replace(match.value, paramValue)
+            } else {
+                logger.warn("Parameter not provided: $paramName in template: $template")
+            }
+        }
+        
+        return result
+    }
+}

--- a/jetbrains/plugin/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains/plugin/src/main/resources/META-INF/plugin.xml
@@ -16,6 +16,10 @@ SPDX-License-Identifier: Apache-2.0
     <!-- A displayed Vendor name or Organization ID displayed on the Plugins Page. -->
     <vendor url="https://kilocode.ai">Kilo Code</vendor>
 
+    <!-- Resource bundles for internationalization -->
+    <resource-bundle>messages.JetbrainsBundle</resource-bundle>
+    <resource-bundle>messages.KilocodeBundle</resource-bundle>
+
     <!-- Description of the plugin displayed on the Plugin Page and IDE Plugin Manager.
          Simple HTML elements (text formatting, paragraphs, and lists) can be added inside of <![CDATA[ ]]> tag.
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-description -->

--- a/jetbrains/plugin/src/test/kotlin/ai/kilocode/jetbrains/i18n/I18nTest.kt
+++ b/jetbrains/plugin/src/test/kotlin/ai/kilocode/jetbrains/i18n/I18nTest.kt
@@ -1,0 +1,152 @@
+package ai.kilocode.jetbrains.i18n
+
+import org.junit.Test
+import org.junit.Assert.*
+import org.junit.Before
+
+/**
+ * Comprehensive tests for the I18n system including named parameter substitution
+ */
+class I18nTest {
+    
+    @Before
+    fun setUp() {
+        // Ensure clean state for each test
+    }
+    
+    @Test
+    fun testBasicTranslationWithoutParameters() {
+        val result = I18n.t("jetbrains:dialog.cancel")
+        assertEquals("Cancel", result)
+        
+        val title = I18n.t("jetbrains:errors.nodejsMissing.title")
+        assertEquals("Node.js environment missing", title)
+    }
+    
+    @Test
+    fun testNamedParameterSubstitution() {
+        val result = I18n.t("jetbrains:errors.nodejsMissing.message", 
+            mapOf("minVersion" to "18.0.0"))
+        
+        // Should contain the substituted value
+        assertTrue("Result should contain substituted minVersion", 
+            result.contains("18.0.0"))
+        
+        // Should not contain the placeholder anymore
+        assertFalse("Result should not contain placeholder", 
+            result.contains("{{minVersion}}"))
+        
+        // Check exact expected content
+        assertEquals("Node.js environment not detected, please install Node.js and try again. Recommended version: 18.0.0 or higher.", 
+            result)
+    }
+    
+    @Test
+    fun testMultipleNamedParameters() {
+        val result = I18n.t("jetbrains:errors.nodejsVersionLow.message", mapOf(
+            "nodePath" to "/usr/bin/node",
+            "nodeVersion" to "16.14.0",
+            "minVersion" to "18.0.0"
+        ))
+        
+        // All parameters should be substituted
+        assertTrue("Should contain nodePath", result.contains("/usr/bin/node"))
+        assertTrue("Should contain nodeVersion", result.contains("16.14.0"))
+        assertTrue("Should contain minVersion", result.contains("18.0.0"))
+        
+        // No placeholders should remain
+        assertFalse("Should not contain nodePath placeholder", result.contains("{{nodePath}}"))
+        assertFalse("Should not contain nodeVersion placeholder", result.contains("{{nodeVersion}}"))
+        assertFalse("Should not contain minVersion placeholder", result.contains("{{minVersion}}"))
+        
+        // Check exact expected content
+        assertEquals("Current Node.js (/usr/bin/node) version is 16.14.0, please upgrade to 18.0.0 or higher for better compatibility.",
+            result)
+    }
+    
+    @Test
+    fun testVarargParameterOverload() {
+        val result = I18n.t("jetbrains:errors.nodejsVersionLow.message",
+            "nodePath" to "/usr/local/bin/node",
+            "nodeVersion" to "17.9.0",
+            "minVersion" to "18.0.0"
+        )
+        
+        assertTrue("Should contain nodePath", result.contains("/usr/local/bin/node"))
+        assertTrue("Should contain nodeVersion", result.contains("17.9.0"))
+        assertTrue("Should contain minVersion", result.contains("18.0.0"))
+    }
+    
+    @Test
+    fun testMissingParameterHandling() {
+        // Test with missing required parameter
+        val result = I18n.t("jetbrains:errors.nodejsMissing.message", 
+            mapOf("wrongParam" to "value"))
+        
+        // Should still contain the placeholder since parameter wasn't provided
+        assertTrue("Should still contain placeholder for missing param", 
+            result.contains("{{minVersion}}"))
+    }
+    
+    @Test
+    fun testInvalidKeyFormat() {
+        // Test key without namespace
+        val result1 = I18n.t("invalidkey")
+        assertEquals("invalidkey", result1) // Should fallback to key
+        
+        // Test key with multiple colons
+        val result2 = I18n.t("namespace:subspace:key")
+        // Should still work, taking first part as namespace
+        assertEquals("namespace:subspace:key", result2) // Fallback if not found
+    }
+    
+    @Test
+    fun testNonExistentKey() {
+        val result = I18n.t("jetbrains:nonexistent.key")
+        // JetBrains ResourceBundle wraps missing keys in exclamation marks
+        assertEquals("!nonexistent.key!", result)
+    }
+    
+    @Test
+    fun testNonExistentNamespace() {
+        val result = I18n.t("nonexistent:some.key")
+        assertEquals("nonexistent:some.key", result) // Should fallback to key
+    }
+    
+    @Test
+    fun testEmptyParameterMap() {
+        val result = I18n.t("jetbrains:dialog.cancel", emptyMap())
+        assertEquals("Cancel", result)
+        
+        // Test with template that has parameters but empty map provided
+        val result2 = I18n.t("jetbrains:errors.nodejsMissing.message", emptyMap())
+        // Should preserve placeholders
+        assertTrue("Should preserve placeholder", result2.contains("{{minVersion}}"))
+    }
+    
+    @Test
+    fun testParameterTypesHandling() {
+        // Test different parameter types (Int, String, Boolean, etc.)
+        val result = I18n.t("jetbrains:errors.nodejsVersionLow.message", mapOf(
+            "nodePath" to "/usr/bin/node",
+            "nodeVersion" to 16, // Int instead of String
+            "minVersion" to 18.0 // Double instead of String
+        ))
+        
+        assertTrue("Should handle Int parameter", result.contains("16"))
+        assertTrue("Should handle Double parameter", result.contains("18.0"))
+    }
+    
+    @Test 
+    fun testSpecialCharactersInParameters() {
+        val result = I18n.t("jetbrains:errors.nodejsVersionLow.message", mapOf(
+            "nodePath" to "/usr/bin/node with spaces",
+            "nodeVersion" to "16.14.0-special",
+            "minVersion" to ">=18.0.0"
+        ))
+        
+        assertTrue("Should handle spaces", result.contains("with spaces"))
+        assertTrue("Should handle dashes", result.contains("16.14.0-special"))
+        assertTrue("Should handle special chars", result.contains(">=18.0.0"))
+    }
+}

--- a/src/i18n/locales/ar/jetbrains.json
+++ b/src/i18n/locales/ar/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "بيئة Node.js مفقودة",
+			"message": "لم يتم اكتشاف بيئة Node.js، يرجى تثبيت Node.js والمحاولة مرة أخرى. الإصدار الموصى به: {{minVersion}} أو أعلى."
+		},
+		"nodejsVersionLow": {
+			"title": "إصدار Node.js منخفض جداً",
+			"message": "إصدار Node.js الحالي ({{nodePath}}) هو {{nodeVersion}}، يرجى الترقية إلى {{minVersion}} أو أعلى للحصول على توافق أفضل."
+		}
+	},
+	"dialog": {
+		"cancel": "إلغاء"
+	},
+	"ui": {
+		"initializing": "Kilo Code يتم تهيئته...",
+		"systemInformation": "معلومات النظام"
+	}
+}

--- a/src/i18n/locales/ca/jetbrains.json
+++ b/src/i18n/locales/ca/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Entorn Node.js absent",
+			"message": "No s'ha detectat l'entorn Node.js, si us plau instal·la Node.js i torna-ho a intentar. Versió recomanada: {{minVersion}} o superior."
+		},
+		"nodejsVersionLow": {
+			"title": "Versió de Node.js massa baixa",
+			"message": "La versió actual de Node.js ({{nodePath}}) és {{nodeVersion}}, si us plau actualitza a {{minVersion}} o superior per a una millor compatibilitat."
+		}
+	},
+	"dialog": {
+		"cancel": "Cancel·la"
+	},
+	"ui": {
+		"initializing": "Kilo Code s'està inicialitzant...",
+		"systemInformation": "Informació del sistema"
+	}
+}

--- a/src/i18n/locales/cs/jetbrains.json
+++ b/src/i18n/locales/cs/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Prostředí Node.js chybí",
+			"message": "Prostředí Node.js nebylo detekováno, nainstalujte prosím Node.js a zkuste to znovu. Doporučená verze: {{minVersion}} nebo vyšší."
+		},
+		"nodejsVersionLow": {
+			"title": "Verze Node.js je příliš nízká",
+			"message": "Aktuální verze Node.js ({{nodePath}}) je {{nodeVersion}}, aktualizujte prosím na {{minVersion}} nebo vyšší pro lepší kompatibilitu."
+		}
+	},
+	"dialog": {
+		"cancel": "Zrušit"
+	},
+	"ui": {
+		"initializing": "Kilo Code se inicializuje...",
+		"systemInformation": "Informace o systému"
+	}
+}

--- a/src/i18n/locales/de/jetbrains.json
+++ b/src/i18n/locales/de/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Node.js-Umgebung fehlt",
+			"message": "Node.js-Umgebung wurde nicht erkannt, bitte installiere Node.js und versuche es erneut. Empfohlene Version: {{minVersion}} oder höher."
+		},
+		"nodejsVersionLow": {
+			"title": "Node.js-Version zu niedrig",
+			"message": "Die aktuelle Node.js-Version ({{nodePath}}) ist {{nodeVersion}}, bitte aktualisiere auf {{minVersion}} oder höher für bessere Kompatibilität."
+		}
+	},
+	"dialog": {
+		"cancel": "Abbrechen"
+	},
+	"ui": {
+		"initializing": "Kilo Code wird initialisiert...",
+		"systemInformation": "Systeminformationen"
+	}
+}

--- a/src/i18n/locales/en/jetbrains.json
+++ b/src/i18n/locales/en/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Node.js environment missing",
+			"message": "Node.js environment not detected, please install Node.js and try again. Recommended version: {{minVersion}} or higher."
+		},
+		"nodejsVersionLow": {
+			"title": "Node.js version too low",
+			"message": "Current Node.js ({{nodePath}}) version is {{nodeVersion}}, please upgrade to {{minVersion}} or higher for better compatibility."
+		}
+	},
+	"dialog": {
+		"cancel": "Cancel"
+	},
+	"ui": {
+		"initializing": "Kilo Code is initializing...",
+		"systemInformation": "System Information"
+	}
+}

--- a/src/i18n/locales/es/jetbrains.json
+++ b/src/i18n/locales/es/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Entorno Node.js faltante",
+			"message": "No se detectó el entorno Node.js, por favor instala Node.js e inténtalo de nuevo. Versión recomendada: {{minVersion}} o superior."
+		},
+		"nodejsVersionLow": {
+			"title": "Versión de Node.js demasiado baja",
+			"message": "La versión actual de Node.js ({{nodePath}}) es {{nodeVersion}}, por favor actualiza a {{minVersion}} o superior para mejor compatibilidad."
+		}
+	},
+	"dialog": {
+		"cancel": "Cancelar"
+	},
+	"ui": {
+		"initializing": "Kilo Code se está inicializando...",
+		"systemInformation": "Información del sistema"
+	}
+}

--- a/src/i18n/locales/fr/jetbrains.json
+++ b/src/i18n/locales/fr/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Environnement Node.js manquant",
+			"message": "L'environnement Node.js n'a pas été détecté, veuillez installer Node.js et réessayer. Version recommandée : {{minVersion}} ou supérieure."
+		},
+		"nodejsVersionLow": {
+			"title": "Version de Node.js trop ancienne",
+			"message": "La version actuelle de Node.js ({{nodePath}}) est {{nodeVersion}}, veuillez mettre à jour vers {{minVersion}} ou supérieure pour une meilleure compatibilité."
+		}
+	},
+	"dialog": {
+		"cancel": "Annuler"
+	},
+	"ui": {
+		"initializing": "Kilo Code s'initialise...",
+		"systemInformation": "Informations système"
+	}
+}

--- a/src/i18n/locales/hi/jetbrains.json
+++ b/src/i18n/locales/hi/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Node.js वातावरण गुम है",
+			"message": "Node.js वातावरण का पता नहीं चला, कृपया Node.js इंस्टॉल करें और पुनः प्रयास करें। अनुशंसित संस्करण: {{minVersion}} या उससे अधिक।"
+		},
+		"nodejsVersionLow": {
+			"title": "Node.js संस्करण बहुत कम है",
+			"message": "वर्तमान Node.js ({{nodePath}}) संस्करण {{nodeVersion}} है, बेहतर संगतता के लिए कृपया {{minVersion}} या उससे अधिक में अपग्रेड करें।"
+		}
+	},
+	"dialog": {
+		"cancel": "रद्द करें"
+	},
+	"ui": {
+		"initializing": "Kilo Code प्रारंभ हो रहा है...",
+		"systemInformation": "सिस्टम की जानकारी"
+	}
+}

--- a/src/i18n/locales/id/jetbrains.json
+++ b/src/i18n/locales/id/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Lingkungan Node.js tidak ada",
+			"message": "Lingkungan Node.js tidak terdeteksi, harap instal Node.js dan coba lagi. Versi yang disarankan: {{minVersion}} atau lebih tinggi."
+		},
+		"nodejsVersionLow": {
+			"title": "Versi Node.js terlalu rendah",
+			"message": "Versi Node.js saat ini ({{nodePath}}) adalah {{nodeVersion}}, harap perbarui ke {{minVersion}} atau lebih tinggi untuk kompatibilitas yang lebih baik."
+		}
+	},
+	"dialog": {
+		"cancel": "Batal"
+	},
+	"ui": {
+		"initializing": "Kilo Code sedang menginisialisasi...",
+		"systemInformation": "Informasi Sistem"
+	}
+}

--- a/src/i18n/locales/it/jetbrains.json
+++ b/src/i18n/locales/it/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Ambiente Node.js mancante",
+			"message": "Ambiente Node.js non rilevato, si prega di installare Node.js e riprovare. Versione consigliata: {{minVersion}} o superiore."
+		},
+		"nodejsVersionLow": {
+			"title": "Versione Node.js troppo bassa",
+			"message": "La versione corrente di Node.js ({{nodePath}}) è {{nodeVersion}}, si prega di aggiornare a {{minVersion}} o superiore per una migliore compatibilità."
+		}
+	},
+	"dialog": {
+		"cancel": "Annulla"
+	},
+	"ui": {
+		"initializing": "Kilo Code si sta inizializzando...",
+		"systemInformation": "Informazioni del sistema"
+	}
+}

--- a/src/i18n/locales/ja/jetbrains.json
+++ b/src/i18n/locales/ja/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Node.js環境が見つかりません",
+			"message": "Node.js環境が検出されませんでした。Node.jsをインストールして再度お試しください。推奨バージョン：{{minVersion}}以上。"
+		},
+		"nodejsVersionLow": {
+			"title": "Node.jsバージョンが古すぎます",
+			"message": "現在のNode.js（{{nodePath}}）バージョンは{{nodeVersion}}です。互換性を向上させるため、{{minVersion}}以上にアップグレードしてください。"
+		}
+	},
+	"dialog": {
+		"cancel": "キャンセル"
+	},
+	"ui": {
+		"initializing": "Kilo Codeを初期化しています...",
+		"systemInformation": "システム情報"
+	}
+}

--- a/src/i18n/locales/ko/jetbrains.json
+++ b/src/i18n/locales/ko/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Node.js 환경이 없습니다",
+			"message": "Node.js 환경이 감지되지 않았습니다. Node.js를 설치한 후 다시 시도해주세요. 권장 버전: {{minVersion}} 이상."
+		},
+		"nodejsVersionLow": {
+			"title": "Node.js 버전이 너무 낮습니다",
+			"message": "현재 Node.js({{nodePath}}) 버전은 {{nodeVersion}}입니다. 더 나은 호환성을 위해 {{minVersion}} 이상으로 업그레이드해주세요."
+		}
+	},
+	"dialog": {
+		"cancel": "취소"
+	},
+	"ui": {
+		"initializing": "Kilo Code를 초기화하는 중...",
+		"systemInformation": "시스템 정보"
+	}
+}

--- a/src/i18n/locales/nl/jetbrains.json
+++ b/src/i18n/locales/nl/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Node.js omgeving ontbreekt",
+			"message": "Node.js omgeving niet gedetecteerd, installeer Node.js en probeer opnieuw. Aanbevolen versie: {{minVersion}} of hoger."
+		},
+		"nodejsVersionLow": {
+			"title": "Node.js versie te laag",
+			"message": "Huidige Node.js ({{nodePath}}) versie is {{nodeVersion}}, upgrade naar {{minVersion}} of hoger voor betere compatibiliteit."
+		}
+	},
+	"dialog": {
+		"cancel": "Annuleren"
+	},
+	"ui": {
+		"initializing": "Kilo Code wordt geïnitialiseerd...",
+		"systemInformation": "Systeeminformatie"
+	}
+}

--- a/src/i18n/locales/pl/jetbrains.json
+++ b/src/i18n/locales/pl/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Brak środowiska Node.js",
+			"message": "Nie wykryto środowiska Node.js, zainstaluj Node.js i spróbuj ponownie. Zalecana wersja: {{minVersion}} lub wyższa."
+		},
+		"nodejsVersionLow": {
+			"title": "Wersja Node.js zbyt niska",
+			"message": "Aktualna wersja Node.js ({{nodePath}}) to {{nodeVersion}}, zaktualizuj do {{minVersion}} lub wyższej dla lepszej kompatybilności."
+		}
+	},
+	"dialog": {
+		"cancel": "Anuluj"
+	},
+	"ui": {
+		"initializing": "Kilo Code się inicjalizuje...",
+		"systemInformation": "Informacje systemowe"
+	}
+}

--- a/src/i18n/locales/pt-BR/jetbrains.json
+++ b/src/i18n/locales/pt-BR/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Ambiente Node.js ausente",
+			"message": "Ambiente Node.js não detectado, instale o Node.js e tente novamente. Versão recomendada: {{minVersion}} ou superior."
+		},
+		"nodejsVersionLow": {
+			"title": "Versão do Node.js muito baixa",
+			"message": "A versão atual do Node.js ({{nodePath}}) é {{nodeVersion}}, atualize para {{minVersion}} ou superior para melhor compatibilidade."
+		}
+	},
+	"dialog": {
+		"cancel": "Cancelar"
+	},
+	"ui": {
+		"initializing": "Kilo Code está inicializando...",
+		"systemInformation": "Informações do Sistema"
+	}
+}

--- a/src/i18n/locales/ru/jetbrains.json
+++ b/src/i18n/locales/ru/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Отсутствует среда Node.js",
+			"message": "Среда Node.js не обнаружена, установите Node.js и попробуйте снова. Рекомендуемая версия: {{minVersion}} или выше."
+		},
+		"nodejsVersionLow": {
+			"title": "Версия Node.js слишком низкая",
+			"message": "Текущая версия Node.js ({{nodePath}}) {{nodeVersion}}, обновите до {{minVersion}} или выше для лучшей совместимости."
+		}
+	},
+	"dialog": {
+		"cancel": "Отмена"
+	},
+	"ui": {
+		"initializing": "Kilo Code инициализируется...",
+		"systemInformation": "Информация о системе"
+	}
+}

--- a/src/i18n/locales/th/jetbrains.json
+++ b/src/i18n/locales/th/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "ไม่พบสภาพแวดล้อม Node.js",
+			"message": "ไม่พบสภาพแวดล้อม Node.js โปรดติดตั้ง Node.js และลองอีกครั้ง เวอร์ชันที่แนะนำ: {{minVersion}} หรือสูงกว่า"
+		},
+		"nodejsVersionLow": {
+			"title": "เวอร์ชัน Node.js ต่ำเกินไป",
+			"message": "เวอร์ชัน Node.js ปัจจุบัน ({{nodePath}}) คือ {{nodeVersion}} โปรดอัปเกรดเป็น {{minVersion}} หรือสูงกว่าเพื่อความเข้ากันได้ที่ดีขึ้น"
+		}
+	},
+	"dialog": {
+		"cancel": "ยกเลิก"
+	},
+	"ui": {
+		"initializing": "Kilo Code กำลังเริ่มต้น...",
+		"systemInformation": "ข้อมูลระบบ"
+	}
+}

--- a/src/i18n/locales/tr/jetbrains.json
+++ b/src/i18n/locales/tr/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Node.js ortamı eksik",
+			"message": "Node.js ortamı algılanmadı, lütfen Node.js'yi yükleyin ve tekrar deneyin. Önerilen sürüm: {{minVersion}} veya üzeri."
+		},
+		"nodejsVersionLow": {
+			"title": "Node.js sürümü çok düşük",
+			"message": "Mevcut Node.js ({{nodePath}}) sürümü {{nodeVersion}}, daha iyi uyumluluk için lütfen {{minVersion}} veya üzerine yükseltin."
+		}
+	},
+	"dialog": {
+		"cancel": "İptal"
+	},
+	"ui": {
+		"initializing": "Kilo Code başlatılıyor...",
+		"systemInformation": "Sistem Bilgileri"
+	}
+}

--- a/src/i18n/locales/uk/jetbrains.json
+++ b/src/i18n/locales/uk/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Відсутнє середовище Node.js",
+			"message": "Середовище Node.js не виявлено, встановіть Node.js і спробуйте знову. Рекомендована версія: {{minVersion}} або вища."
+		},
+		"nodejsVersionLow": {
+			"title": "Версія Node.js занадто низька",
+			"message": "Поточна версія Node.js ({{nodePath}}) {{nodeVersion}}, оновіть до {{minVersion}} або вищої для кращої сумісності."
+		}
+	},
+	"dialog": {
+		"cancel": "Скасувати"
+	},
+	"ui": {
+		"initializing": "Kilo Code ініціалізується...",
+		"systemInformation": "Інформація про систему"
+	}
+}

--- a/src/i18n/locales/vi/jetbrains.json
+++ b/src/i18n/locales/vi/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Thiếu môi trường Node.js",
+			"message": "Không phát hiện môi trường Node.js, vui lòng cài đặt Node.js và thử lại. Phiên bản được đề xuất: {{minVersion}} trở lên."
+		},
+		"nodejsVersionLow": {
+			"title": "Phiên bản Node.js quá thấp",
+			"message": "Phiên bản Node.js hiện tại ({{nodePath}}) là {{nodeVersion}}, vui lòng nâng cấp lên {{minVersion}} trở lên để có khả năng tương thích tốt hơn."
+		}
+	},
+	"dialog": {
+		"cancel": "Hủy"
+	},
+	"ui": {
+		"initializing": "Kilo Code đang khởi tạo...",
+		"systemInformation": "Thông tin hệ thống"
+	}
+}

--- a/src/i18n/locales/zh-CN/jetbrains.json
+++ b/src/i18n/locales/zh-CN/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Node.js 环境缺失",
+			"message": "未检测到 Node.js 环境，请安装 Node.js 并重试。推荐版本：{{minVersion}} 或更高。"
+		},
+		"nodejsVersionLow": {
+			"title": "Node.js 版本过低",
+			"message": "当前 Node.js ({{nodePath}}) 版本为 {{nodeVersion}}，请升级到 {{minVersion}} 或更高版本以获得更好的兼容性。"
+		}
+	},
+	"dialog": {
+		"cancel": "取消"
+	},
+	"ui": {
+		"initializing": "Kilo Code 正在初始化...",
+		"systemInformation": "系统信息"
+	}
+}

--- a/src/i18n/locales/zh-TW/jetbrains.json
+++ b/src/i18n/locales/zh-TW/jetbrains.json
@@ -1,0 +1,19 @@
+{
+	"errors": {
+		"nodejsMissing": {
+			"title": "Node.js 環境遺失",
+			"message": "未偵測到 Node.js 環境，請安裝 Node.js 並重新嘗試。建議版本：{{minVersion}} 或更高。"
+		},
+		"nodejsVersionLow": {
+			"title": "Node.js 版本過低",
+			"message": "目前 Node.js ({{nodePath}}) 版本為 {{nodeVersion}}，請升級至 {{minVersion}} 或更高版本以獲得更好的相容性。"
+		}
+	},
+	"dialog": {
+		"cancel": "取消"
+	},
+	"ui": {
+		"initializing": "Kilo Code 正在初始化...",
+		"systemInformation": "系統資訊"
+	}
+}


### PR DESCRIPTION
Introduces a comprehensive internationalization (i18n) system for the JetBrains plugin, mirroring the existing TypeScript i18n. It simulates what we already have for our extension inside Kotlin, so we continue to use the same `t` fn() translation conventions. 

I decided to add the translations into our existing JSON files instead of putting them directly into Kotlin bundles, just to keep everything centralized and easy to understand. The JSON files are turned into Kotlin bundles as part of the Gradle build. 

This includes:

- **New `I18n` object:** Provides `t()` function for translations with named parameter substitution.
- **Gradle task `convertTranslations`:** Automates conversion of JSON translation files from `src/i18n/locales` into JetBrains ResourceBundle `.properties` format.
- **Integration:** Updates `MainThreadMessageService` and `ExtensionProcessManager` to use the new i18n system for user-facing messages.
- **Test suite:** Adds `I18nTest.kt` for comprehensive testing of the i18n functionality.
- **Multilingual support:** Adds `jetbrains.json` translation files for 15 languages (Arabic, Catalan, Czech, German, English, Spanish, French, Hindi, Indonesian, Italian, Japanese, Korean, Dutch, Polish, Brazilian Portuguese, Russian, Thai, Turkish, Ukrainian, Vietnamese, Simplified Chinese, Traditional Chinese).
- **VSCode tasks.json update:** Expands `watch:pnpm` to monitor `package.json` files in subdirectories for better dependency management.
- **Gradle properties update:** Bumps `pluginVersion` to 4.91.0.
- **Gitignore update:** Adds `plugin/src/main/resources/messages` to `.gitignore` to exclude generated translation files.

