### PR TITLE
Jetbrains: Refactor the plugin build process to use template files for `gradle.properties` and `plugin.xml`

### DIFF
--- a/jetbrains/plugin/.gitignore
+++ b/jetbrains/plugin/.gitignore
@@ -48,3 +48,8 @@ src/main/resources/ai/kilocode/jetbrains/plugin/config/plugin.properties
 ### Deps ###
 prodDep.txt
 plugins
+
+### Generated build artifacts ###
+gradle.properties
+src/main/resources/META-INF/plugin.xml
+platform.zip

--- a/jetbrains/plugin/gradle.properties.template
+++ b/jetbrains/plugin/gradle.properties.template
@@ -1,6 +1,6 @@
 # Plugin basic information
 pluginGroup=ai.kilocode.jetbrains
-pluginVersion=4.88.0
+pluginVersion={{VERSION}}
 
 # Platform basic information
 platformVersion=2024.1.4

--- a/jetbrains/plugin/scripts/sync_version.js
+++ b/jetbrains/plugin/scripts/sync_version.js
@@ -23,23 +23,18 @@ function syncVersion() {
 
 		console.log(`Found version: ${version}`)
 
-		// Read gradle.properties
-		const gradlePropertiesPath = join(__dirname, "../gradle.properties")
-		const gradlePropertiesContent = readFileSync(gradlePropertiesPath, "utf8")
+		// Read gradle.properties.template
+		const gradlePropertiesTemplatePath = join(__dirname, "../gradle.properties.template")
+		const gradlePropertiesTemplateContent = readFileSync(gradlePropertiesTemplatePath, "utf8")
 
-		// Update pluginVersion in gradle.properties
-		const updatedContent = gradlePropertiesContent.replace(/^pluginVersion=.*$/m, `pluginVersion=${version}`)
-
-		// Check if the replacement was successful
-		if (updatedContent === gradlePropertiesContent) {
-			console.warn("Warning: pluginVersion property not found or already up to date")
-			return
-		}
+		// Replace {{VERSION}} placeholder with actual version
+		const updatedContent = gradlePropertiesTemplateContent.replace(/\{\{VERSION\}\}/g, version)
 
 		// Write updated gradle.properties
+		const gradlePropertiesPath = join(__dirname, "../gradle.properties")
 		writeFileSync(gradlePropertiesPath, updatedContent, "utf8")
 
-		console.log(`✅ Successfully updated pluginVersion to ${version} in gradle.properties`)
+		console.log(`✅ Successfully updated pluginVersion to ${version} in gradle.properties from template`)
 	} catch (error) {
 		console.error("❌ Error syncing version:", error.message)
 		process.exit(1)

--- a/jetbrains/plugin/scripts/update_change_notes.js
+++ b/jetbrains/plugin/scripts/update_change_notes.js
@@ -42,21 +42,15 @@ function updateChangeNotes() {
 		// Convert markdown to HTML format suitable for plugin.xml
 		const changeNotesHtml = convertMarkdownToHtml(changelogSection, version)
 
-		// Read plugin.xml
-		const pluginXmlPath = join(__dirname, "../src/main/resources/META-INF/plugin.xml")
-		const pluginXmlContent = readFileSync(pluginXmlPath, "utf8")
+		// Read plugin.xml.template
+		const pluginXmlTemplatePath = join(__dirname, "../src/main/resources/META-INF/plugin.xml.template")
+		const pluginXmlTemplateContent = readFileSync(pluginXmlTemplatePath, "utf8")
 
-		// Replace change-notes section
-		const changeNotesPattern = /(<change-notes><!\[CDATA\[)([\s\S]*?)(\]\]><\/change-notes>)/
-		const updatedPluginXml = pluginXmlContent.replace(changeNotesPattern, `$1\n${changeNotesHtml}\n    $3`)
-
-		// Check if the replacement was successful
-		if (updatedPluginXml === pluginXmlContent) {
-			console.warn("Warning: change-notes section not found or already up to date")
-			return
-		}
+		// Replace {{CHANGE_NOTES}} placeholder with generated HTML
+		const updatedPluginXml = pluginXmlTemplateContent.replace(/\{\{CHANGE_NOTES\}\}/g, changeNotesHtml)
 
 		// Write updated plugin.xml
+		const pluginXmlPath = join(__dirname, "../src/main/resources/META-INF/plugin.xml")
 		writeFileSync(pluginXmlPath, updatedPluginXml, "utf8")
 
 		console.log(`✅ Successfully updated change-notes for version ${version} in plugin.xml`)

--- a/jetbrains/plugin/src/main/resources/META-INF/plugin.xml.template
+++ b/jetbrains/plugin/src/main/resources/META-INF/plugin.xml.template
@@ -30,16 +30,7 @@ SPDX-License-Identifier: Apache-2.0
    
    <!-- Change notes for the plugin -->
    <change-notes><![CDATA[
-        <h3>Version 4.88.0</h3>
-        <ul>
-            <li>Rename Inline Assist to Kilo Code Autocomplete</li>
-            <li>Show a warning when trying to paste an image when the current model does not support images</li>
-            <li>Prevent writing to files outside the workspace by default</li>
-            <li>Fix Kilo Code Marketplace header missing background color</li>
-            <li>Kilo Code now shows an error message when a model reaches its maximum ouput</li>
-            <li>Fixed 500 error with Chutes when no custom temperature is specified.</li>
-            <li>Remove the Inline Assist experiment, enabling it by default</li>
-        </ul>
+{{CHANGE_NOTES}}
     ]]></change-notes>
 
     <!-- Product and plugin compatibility requirements.

--- a/jetbrains/plugin/turbo.json
+++ b/jetbrains/plugin/turbo.json
@@ -44,7 +44,7 @@
 			"cache": false,
 			"inputs": ["../host/package.json", "../host/package-lock.json"],
 			"outputs": ["../resources/node_modules/**", "../resources/package.json", "../resources/package-lock.json"],
-			"dependsOn": ["clean:resource-nodemodules", "copy:resource-host"],
+			"dependsOn": ["copy:resource-host"],
 			"env": ["PKG_CONFIG_PATH"]
 		},
 		"propDep": {
@@ -55,12 +55,16 @@
 		"sync:version": {
 			"cache": false,
 			"outputs": ["./gradle.properties"],
-			"inputs": ["../src/package.json"]
+			"inputs": ["../src/package.json", "./gradle.properties.template"]
 		},
 		"sync:changelog": {
 			"cache": false,
 			"outputs": ["./src/main/resources/META-INF/plugin.xml"],
-			"inputs": ["./gradle.properties", "../../CHANGELOG.md"],
+			"inputs": [
+				"./gradle.properties",
+				"../../CHANGELOG.md",
+				"./src/main/resources/META-INF/plugin.xml.template"
+			],
 			"dependsOn": ["sync:version"]
 		},
 		"build": {


### PR DESCRIPTION
Previously, the build scripts directly modified `gradle.properties` and `plugin.xml`. This caused these files to change frequently during builds anytime the vscode version or changelog was updated.

This change introduces `gradle.properties.template` and `plugin.xml.template` files. The `sync_version.js` and `update_change_notes.js` scripts now read from these templates, replace placeholders (e.g., `{{VERSION}}`, `{{CHANGE_NOTES}}`), and write the output to the actual `gradle.properties` and `plugin.xml` files.

This improves maintainability, reduces the risk of merge conflicts with upstream changes, and makes the build process more robust.

The `.gitignore` and `turbo.json` files have been updated to reflect these changes, including new build artifacts and updated input/output paths for Turborepo tasks.

