### PR TITLE
Removed the arbitrary 8192 output limit for Anthropic models

### DIFF
--- a/.changeset/happy-tigers-cross.md
+++ b/.changeset/happy-tigers-cross.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Removed the arbitrary 8192 output limit for Anthropic models

--- a/src/api/transform/__tests__/model-params.spec.ts
+++ b/src/api/transform/__tests__/model-params.spec.ts
@@ -597,7 +597,7 @@ describe("getModelParams", () => {
 
 			// For hybrid models (supportsReasoningBudget) in Anthropic contexts,
 			// should discard model's maxTokens and use ANTHROPIC_DEFAULT_MAX_TOKENS
-			expect(result.maxTokens).toBe(ANTHROPIC_DEFAULT_MAX_TOKENS)
+			expect(result.maxTokens).toBe(3200 /*kilocode_change*/)
 			expect(result.reasoningBudget).toBeUndefined()
 		})
 

--- a/src/shared/__tests__/api.spec.ts
+++ b/src/shared/__tests__/api.spec.ts
@@ -112,7 +112,7 @@ describe("getModelMaxOutputTokens", () => {
 		}
 
 		const result = getModelMaxOutputTokens({ modelId: anthropicModelId, model, settings })
-		expect(result).toBe(ANTHROPIC_DEFAULT_MAX_TOKENS) // Should be 8192, not 64_000
+		expect(result).toBe(40_000 /*kilocode_change*/) // Should be 8192, not 64_000
 	})
 
 	test("should return model.maxTokens for non-Anthropic models that support reasoning budget but aren't using it", () => {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -110,9 +110,10 @@ export const getModelMaxOutputTokens = ({
 		(format === "openrouter" && modelId.startsWith("anthropic/"))
 
 	// For "Hybrid" reasoning models, discard the model's actual maxTokens for Anthropic contexts
+	/* kilocode_change: don't limit Anthropic model output, no idea why this was done before
 	if (model.supportsReasoningBudget && isAnthropicContext) {
 		return ANTHROPIC_DEFAULT_MAX_TOKENS
-	}
+	}*/
 
 	// For Anthropic contexts, always ensure a maxTokens value is set
 	if (isAnthropicContext && (!model.maxTokens || model.maxTokens === 0)) {


### PR DESCRIPTION
I have no idea why this was here.

I have verified using the debugger that max tokens is now correctly set for Sonnet (64k or the slider value when reasoning is enabled).

Sonnet was hitting max output for 0.86% of requests, which is IMO very high: https://us.posthog.com/project/141915/insights/qd1c13NC