### PR TITLE
Fix: reload extension when switch project

### DIFF
--- a/.changeset/tired-pianos-dress.md
+++ b/.changeset/tired-pianos-dress.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Jetbrains - Fix reload extension when switch project

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/plugin/SystemObjectProvider.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/plugin/SystemObjectProvider.kt
@@ -5,65 +5,106 @@
 package ai.kilocode.jetbrains.plugin
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.Disposable
 import java.util.concurrent.ConcurrentHashMap
 
 /**
  * System Object Provider
  * Provides unified access to IDEA system objects
+ * Now project-scoped to prevent state sharing between projects
  */
-object SystemObjectProvider {
+@Service(Service.Level.PROJECT)
+class SystemObjectProvider(private val project: Project) : Disposable {
     private val logger = Logger.getInstance(SystemObjectProvider::class.java)
-    
-        // Mapping for storing system objects
-        private val systemObjects = ConcurrentHashMap<String, Any>()
 
-    
-        /**
-         * System object keys
-         */
+    // Mapping for storing system objects per project
+    private val systemObjects = ConcurrentHashMap<String, Any>()
+
+    /**
+     * System object keys
+     */
     object Keys {
         const val APPLICATION = "application"
-            // More system object keys can be added
+        const val PLUGIN_SERVICE = "pluginService"
+        // More system object keys can be added
     }
-    
-        /**
-         * Initialize the system object provider
-         * @param project current project
-         */
-    fun initialize(project: Project) {
-        logger.info("Initializing SystemObjectProvider with project: ${project.name}")
 
+    /**
+     * Initialize the system object provider
+     * @param project current project
+     */
+    fun initialize(project: Project) {
+        logger.info("Initializing SystemObjectProvider for project: ${project.name}")
+
+        // Register application-level objects
         register(Keys.APPLICATION, ApplicationManager.getApplication())
     }
-    
-        /**
-         * Register a system object
-         * @param key object key
-         * @param obj object instance
-         */
+
+    /**
+     * Register a system object
+     * @param key object key
+     * @param obj object instance
+     */
     fun register(key: String, obj: Any) {
         systemObjects[key] = obj
-        logger.debug("Registered system object: $key")
+        logger.debug("Registered system object for project ${project.name}: $key")
     }
-    
-        /**
-         * Get a system object
-         * @param key object key
-         * @return object instance or null
-         */
+
+    /**
+     * Get a system object
+     * @param key object key
+     * @return object instance or null
+     */
     @Suppress("UNCHECKED_CAST")
     fun <T> get(key: String): T? {
         return systemObjects[key] as? T
     }
-    
 
-        /**
-         * Clean up resources
-         */
-    fun dispose() {
-        logger.info("Disposing SystemObjectProvider")
+    /**
+     * Remove a system object
+     * @param key object key
+     */
+    fun remove(key: String) {
+        systemObjects.remove(key)
+        logger.debug("Removed system object for project ${project.name}: $key")
+    }
+
+    /**
+     * Check if a system object exists
+     * @param key object key
+     * @return true if exists, false otherwise
+     */
+    fun has(key: String): Boolean {
+        return systemObjects.containsKey(key)
+    }
+
+    /**
+     * Get all registered keys
+     * @return set of registered keys
+     */
+    fun getKeys(): Set<String> {
+        return systemObjects.keys.toSet()
+    }
+
+    /**
+     * Clean up resources for this project
+     */
+    override fun dispose() {
+        logger.info("Disposing SystemObjectProvider for project: ${project.name}")
         systemObjects.clear()
     }
-} 
+
+    companion object {
+        /**
+         * Get SystemObjectProvider instance for a project
+         * @param project the project
+         * @return SystemObjectProvider instance
+         */
+        fun getInstance(project: Project): SystemObjectProvider {
+            return project.getService(SystemObjectProvider::class.java)
+        }
+    }
+}


### PR DESCRIPTION
## Context

Resolve #2425 

Error:
```
Socket[extension-host] IO exception occurred while reading data

java.net.SocketException: Connection reset
	at java.base/sun.nio.ch.SocketChannelImpl.throwConnectionReset(SocketChannelImpl.java:401)
	at java.base/sun.nio.ch.SocketChannelImpl.blockingRead(SocketChannelImpl.java:1349)
	at java.base/sun.nio.ch.SocketInputStream.read(SocketInputStream.java:70)
	at java.base/java.io.InputStream.read(InputStream.java:220)
	at ai.kilocode.jetbrains.ipc.NodeSocket$startReceiving$1.invoke(NodeSocket.kt:83)
	at ai.kilocode.jetbrains.ipc.NodeSocket$startReceiving$1.invoke(NodeSocket.kt:78)
	at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)
```

## Implementation

This PR fixes an issue where the Kilocode extension encounters a "Connection reset" socket exception when switching between projects in JetBrains IDEs. The fix implements proper cleanup and reinitialization of resources when projects are switched.

Key Changes:

- Added project lifecycle event handling to properly clean up and reinitialize resources
- Improved socket connection management with graceful cleanup during project switches
- Converted SystemObjectProvider from singleton to project-scoped service

## How to Test

- On Any Jetbrains IDE
- Open a project and execute a task on Kilo Code
- When finish the task. Switch project on Jetbrains