### PR TITLE
fix: docs cache input

### DIFF
--- a/apps/kilocode-docs/turbo.json
+++ b/apps/kilocode-docs/turbo.json
@@ -3,6 +3,16 @@
 	"extends": ["//"],
 	"tasks": {
 		"build": {
+			"inputs": [
+				"docs/**",
+				"blog-posts/**",
+				"src/**",
+				"static/**",
+				"i18n/**",
+				"docusaurus.config.ts",
+				"sidebars.ts",
+				"package.json"
+			],
 			"outputs": ["build/**"],
 			"env": ["POSTHOG_API_KEY", "FREE_TIER_AMOUNT"]
 		}


### PR DESCRIPTION
## Context

This PR fixes the cache input configuration for the documentation build task by adding specific input paths to the turbo.json configuration. This ensures proper cache invalidation when relevant files are modified.

- Adds comprehensive input file patterns to the docs build task including documentation content, source code, static assets, configuration files, and dependencies

