### PR TITLE
Fix autocomplete status bar appearing when autocomplete is disabled

### DIFF
--- a/.changeset/floppy-falcons-unite.md
+++ b/.changeset/floppy-falcons-unite.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix the autocomplete status bar appearing when autocomplete is not enabled

--- a/src/services/commit-message/index.ts
+++ b/src/services/commit-message/index.ts
@@ -12,6 +12,7 @@ export function registerCommitMessageProvider(
 	outputChannel: vscode.OutputChannel,
 ): void {
 	const commitProvider = new CommitMessageProvider(context, outputChannel)
+	context.subscriptions.push(commitProvider)
 
 	commitProvider.activate().catch((error) => {
 		outputChannel.appendLine(t("kilocode:commitMessage.activationFailed", { error: error.message }))

--- a/src/services/ghost/GhostCursorAnimation.ts
+++ b/src/services/ghost/GhostCursorAnimation.ts
@@ -59,4 +59,12 @@ export class GhostCursorAnimation {
 		this.state = "hide"
 		this.update()
 	}
+
+	public dispose() {
+		const editor = vscode.window.activeTextEditor
+		editor?.setDecorations(this.decorationActive, [])
+		editor?.setDecorations(this.decorationWait, [])
+		this.decorationWait.dispose()
+		this.decorationActive.dispose()
+	}
 }

--- a/src/services/ghost/GhostGutterAnimation.ts
+++ b/src/services/ghost/GhostGutterAnimation.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode"
 
-export class GhostCursorAnimation {
+export class GhostGutterAnimation {
 	private state: "hide" | "wait" | "active" = "hide"
 	private decorationWait: vscode.TextEditorDecorationType
 	private decorationActive: vscode.TextEditorDecorationType

--- a/src/services/ghost/GhostProvider.ts
+++ b/src/services/ghost/GhostProvider.ts
@@ -18,7 +18,7 @@ import { ProviderSettingsManager } from "../../core/config/ProviderSettingsManag
 import { GhostContext } from "./GhostContext"
 import { TelemetryService } from "@roo-code/telemetry"
 import { ClineProvider } from "../../core/webview/ClineProvider"
-import { GhostCursorAnimation } from "./GhostCursorAnimation"
+import { GhostGutterAnimation } from "./GhostGutterAnimation"
 import { GhostCursor } from "./GhostCursor"
 
 export class GhostProvider {
@@ -35,7 +35,7 @@ export class GhostProvider {
 	private settings: GhostServiceSettings | null = null
 	private ghostContext: GhostContext
 	private cursor: GhostCursor
-	private cursorAnimation: GhostCursorAnimation
+	private cursorAnimation: GhostGutterAnimation
 
 	private enabled: boolean = true
 	private taskId: string | null = null
@@ -68,7 +68,7 @@ export class GhostProvider {
 		this.model = new GhostModel()
 		this.ghostContext = new GhostContext(this.documentStore)
 		this.cursor = new GhostCursor()
-		this.cursorAnimation = new GhostCursorAnimation(context)
+		this.cursorAnimation = new GhostGutterAnimation(context)
 
 		// Register the providers
 		this.codeActionProvider = new GhostCodeActionProvider()

--- a/src/services/ghost/GhostProvider.ts
+++ b/src/services/ghost/GhostProvider.ts
@@ -111,7 +111,7 @@ export class GhostProvider {
 			return
 		}
 		await ContextProxy.instance?.setValues?.({ ghostServiceSettings: this.settings })
-		await this.cline.postStateToWebview
+		await this.cline.postStateToWebview()
 	}
 
 	public async load() {
@@ -599,17 +599,12 @@ export class GhostProvider {
 		}
 
 		this.statusBar?.update({
-			enabled: true,
+			enabled: this.settings?.enableAutoTrigger,
 			model: this.getCurrentModelName(),
 			hasValidToken: this.hasValidApiToken(),
 			totalSessionCost: this.sessionCost,
 			lastCompletionCost: this.lastCompletionCost,
 		})
-	}
-
-	private disposeStatusBar() {
-		this.statusBar?.dispose()
-		this.statusBar = null
 	}
 
 	public async showIncompatibilityExtensionPopup() {
@@ -716,5 +711,21 @@ export class GhostProvider {
 
 		// Trigger code suggestion automatically
 		await this.codeSuggestion()
+	}
+
+	/**
+	 * Dispose of all resources used by the GhostProvider
+	 */
+	public dispose(): void {
+		this.clearAutoTriggerTimer()
+		this.cancelRequest()
+
+		this.suggestions.clear()
+		this.decorations.clearAll()
+
+		this.statusBar?.dispose()
+		this.cursorAnimation.dispose()
+
+		GhostProvider.instance = null // Reset singleton
 	}
 }

--- a/src/services/ghost/GhostStatusBar.ts
+++ b/src/services/ghost/GhostStatusBar.ts
@@ -31,15 +31,15 @@ export class GhostStatusBar {
 	private init() {
 		this.statusBar.text = t("kilocode:ghost.statusBar.enabled")
 		this.statusBar.tooltip = t("kilocode:ghost.statusBar.tooltip.basic")
-		this.show()
-	}
-
-	public show() {
 		this.statusBar.show()
 	}
 
-	public hide() {
-		this.statusBar.hide()
+	public updateVisible(enabled: boolean) {
+		if (enabled) {
+			this.statusBar.show()
+		} else {
+			this.statusBar.hide()
+		}
 	}
 
 	public dispose() {
@@ -59,13 +59,16 @@ export class GhostStatusBar {
 		this.totalSessionCost = params.totalSessionCost !== undefined ? params.totalSessionCost : this.totalSessionCost
 		this.lastCompletionCost =
 			params.lastCompletionCost !== undefined ? params.lastCompletionCost : this.lastCompletionCost
-		this.render()
+
+		this.updateVisible(this.enabled)
+		if (this.enabled) this.render()
 	}
 
-	private renderDisabled() {
-		this.statusBar.text = t("kilocode:ghost.statusBar.disabled")
-		this.statusBar.tooltip = t("kilocode:ghost.statusBar.tooltip.disabled")
-	}
+	// TODO: Bring back paused state in the future
+	// private renderPaused() {
+	// 	this.statusBar.text = t("kilocode:ghost.statusBar.disabled")
+	// 	this.statusBar.tooltip = t("kilocode:ghost.statusBar.tooltip.disabled")
+	// }
 
 	private renderTokenError() {
 		this.statusBar.text = t("kilocode:ghost.statusBar.warning")
@@ -85,9 +88,6 @@ ${t("kilocode:ghost.statusBar.tooltip.basic")}
 	}
 
 	public render() {
-		if (!this.enabled) {
-			return this.renderDisabled()
-		}
 		if (!this.hasValidToken) {
 			return this.renderTokenError()
 		}

--- a/src/services/ghost/index.ts
+++ b/src/services/ghost/index.ts
@@ -5,6 +5,7 @@ import { ClineProvider } from "../../core/webview/ClineProvider"
 
 export const registerGhostProvider = (context: vscode.ExtensionContext, cline: ClineProvider) => {
 	const ghost = GhostProvider.initialize(context, cline)
+	context.subscriptions.push(ghost)
 
 	// Register GhostProvider Commands
 	context.subscriptions.push(


### PR DESCRIPTION
The status bar's visibility is now dynamically controlled by the `enableAutoTrigger` setting.
Additionally, the `GhostProvider`'s `dispose` method has been updated to ensure proper cleanup of `GhostCursorAnimation` and `GhostStatusBar` resources. A minor fix was also applied to correctly invoke `postStateToWebview`.

When we removed the autocomplete experiment, it got disconnected from the enabled flag. Now we'll just check whether or not the `enableAutoTrigger` is set, and use that to control the status bar. 