### PR TITLE
Add posthog api key on jetbrains build

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -146,6 +146,8 @@ jobs:
                       ${{ runner.os }}-turbo-
             - name: Install dependencies
               run: pnpm install
+            - name: Create .env file
+              run: echo "KILOCODE_POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" >> .env
             - name: Build
               run: pnpm run jetbrains:bundle
               shell: bash


### PR DESCRIPTION
This PR adds PostHog API key configuration to the JetBrains marketplace publishing workflow by creating a .env file with the API key from GitHub secrets.

Adds environment variable setup for PostHog analytics integration in the JetBrains build process