### PR TITLE
Tweak prompts for image reading

### DIFF
--- a/.changeset/brown-walls-shout.md
+++ b/.changeset/brown-walls-shout.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+The description of the read_file tool was tweaked to make it more likely a vision-capable model will use it for image reading.

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -20,6 +20,7 @@ import { RooIgnoreController } from "../ignore/RooIgnoreController"
 import { getCommand, type Command } from "../../services/command/commands"
 
 import { t } from "../../i18n"
+import { isSupportedImageFormat } from "../tools/helpers/imageHelpers" // kilocode_change
 
 function getUrlErrorMessage(error: unknown): string {
 	const errorMessage = error instanceof Error ? error.message : String(error)
@@ -277,6 +278,11 @@ async function getFileOrFolderContent(
 			if (rooIgnoreController && !rooIgnoreController.validateAccess(absPath)) {
 				return `(File ${mentionPath} is ignored by .kilocodeignore)`
 			}
+			// kilocode_change start
+			if (isSupportedImageFormat(path.extname(absPath))) {
+				return `(Image of size ${stats.size} bytes, the read_file tool may be able to read it)`
+			}
+			// kilocode_change end
 			try {
 				const content = await extractTextFromFile(absPath, maxReadFileLine)
 				return content

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/architect-mode-prompt.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/architect-mode-prompt.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from .pdf and .docx and .ipynb and .xlsx files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/ask-mode-prompt.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/ask-mode-prompt.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from .pdf and .docx and .ipynb and .xlsx files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/mcp-server-creation-disabled.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/mcp-server-creation-disabled.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from .pdf and .docx and .ipynb and .xlsx files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/mcp-server-creation-enabled.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/mcp-server-creation-enabled.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from .pdf and .docx and .ipynb and .xlsx files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/partial-reads-enabled.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/partial-reads-enabled.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Use line ranges to efficiently read specific portions of large files. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Use line ranges to efficiently read specific portions of large files. Supports text extraction from .pdf and .docx and .ipynb and .xlsx files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/consistent-system-prompt.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/consistent-system-prompt.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from .pdf and .docx and .ipynb and .xlsx files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-computer-use-support.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-computer-use-support.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from .pdf and .docx and .ipynb and .xlsx and .png and .jpg and .jpeg and .gif and .webp and .svg and .bmp and .ico and .tiff and .tif and .avif files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-false.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-false.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from .pdf and .docx and .ipynb and .xlsx files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-true.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-true.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from .pdf and .docx and .ipynb and .xlsx files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-undefined.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-undefined.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from .pdf and .docx and .ipynb and .xlsx files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-different-viewport-size.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-different-viewport-size.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from .pdf and .docx and .ipynb and .xlsx and .png and .jpg and .jpeg and .gif and .webp and .svg and .bmp and .ico and .tiff and .tif and .avif files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-mcp-hub-provided.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-mcp-hub-provided.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from .pdf and .docx and .ipynb and .xlsx files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-undefined-mcp-hub.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-undefined-mcp-hub.snap
@@ -27,7 +27,7 @@ Always use the actual tool name as the XML tag name for proper parsing and execu
 # Tools
 
 ## read_file
-Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of one or more files. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code. Supports text extraction from .pdf and .docx and .ipynb and .xlsx files, but may not handle other binary files properly.
 
 **IMPORTANT: You can read a maximum of 5 files in a single request.** If you need to read more files, use multiple sequential read_file requests.
 

--- a/src/core/prompts/tools/read-file.ts
+++ b/src/core/prompts/tools/read-file.ts
@@ -1,11 +1,21 @@
+// kilocode_change start
+import { getSupportedBinaryFormats } from "../../../integrations/misc/extract-text"
+import { SUPPORTED_IMAGE_FORMATS } from "../../tools/helpers/imageHelpers"
+// kilocode_change end
+
 import { ToolArgs } from "./types"
 
 export function getReadFileDescription(args: ToolArgs): string {
 	const maxConcurrentReads = args.settings?.maxConcurrentFileReads ?? 5
 	const isMultipleReadsEnabled = maxConcurrentReads > 1
+	const supportsImages = args.supportsComputerUse // kilocode_change: supportsComputerUse==supportsImages in kilo
 
 	return `## read_file
-Description: Request to read the contents of ${isMultipleReadsEnabled ? "one or more files" : "a file"}. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code.${args.partialReadsEnabled ? " Use line ranges to efficiently read specific portions of large files." : ""} Supports text extraction from PDF and DOCX files, but may not handle other binary files properly.
+Description: Request to read the contents of ${isMultipleReadsEnabled ? "one or more files" : "a file"}. The tool outputs line-numbered content (e.g. "1 | const x = 1") for easy reference when creating diffs or discussing code.${args.partialReadsEnabled ? " Use line ranges to efficiently read specific portions of large files." : ""} Supports text extraction from ${
+		getSupportedBinaryFormats()
+			.concat(supportsImages ? SUPPORTED_IMAGE_FORMATS : [])
+			.join(" and ") /*kilocode_change*/
+	} files, but may not handle other binary files properly.
 
 ${isMultipleReadsEnabled ? `**IMPORTANT: You can read a maximum of ${maxConcurrentReads} files in a single request.** If you need to read more files, use multiple sequential read_file requests.` : "**IMPORTANT: Multiple file reads are currently disabled. You can only read one file at a time.**"}
 


### PR DESCRIPTION
Trying to make it more likely Supernova will use the read_file tool to read images. It is still somewhat reluctant, but these changes look reasonable to me at least.