### PR TITLE
fix(code-index): conditionally validate embedder based on configured provider.

### DIFF
--- a/.changeset/strange-meals-brush.md
+++ b/.changeset/strange-meals-brush.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Only validate embedders when they match the currently configured provider

--- a/src/services/code-index/manager.ts
+++ b/src/services/code-index/manager.ts
@@ -340,6 +340,7 @@ export class CodeIndexManager {
 			rooIgnoreController,
 		)
 
+		// kilocode_change start
 		// Only validate the embedder if it matches the currently configured provider
 		const config = this._configManager!.getConfig()
 		const shouldValidate = embedder.embedderInfo.name === config.embedderProvider
@@ -352,6 +353,7 @@ export class CodeIndexManager {
 				throw new Error(errorMessage)
 			}
 		}
+		// kilocode_change end
 
 		// (Re)Initialize orchestrator
 		this._orchestrator = new CodeIndexOrchestrator(

--- a/src/services/code-index/manager.ts
+++ b/src/services/code-index/manager.ts
@@ -340,12 +340,17 @@ export class CodeIndexManager {
 			rooIgnoreController,
 		)
 
-		// Validate embedder configuration before proceeding
-		const validationResult = await this._serviceFactory.validateEmbedder(embedder)
-		if (!validationResult.valid) {
-			const errorMessage = validationResult.error || "Embedder configuration validation failed"
-			this._stateManager.setSystemState("Error", errorMessage)
-			throw new Error(errorMessage)
+		// Only validate the embedder if it matches the currently configured provider
+		const config = this._configManager!.getConfig()
+		const shouldValidate = embedder.embedderInfo.name === config.embedderProvider
+
+		if (shouldValidate) {
+			const validationResult = await this._serviceFactory.validateEmbedder(embedder)
+			if (!validationResult.valid) {
+				const errorMessage = validationResult.error || "Embedder configuration validation failed"
+				this._stateManager.setSystemState("Error", errorMessage)
+				throw new Error(errorMessage)
+			}
 		}
 
 		// (Re)Initialize orchestrator


### PR DESCRIPTION
Avoids blindly attempt to make an Ollama connection via the embedder validation on startup if its not configured.

## Context

Addresses (partially): https://discordapp.com/channels/1349288496988160052/1417842697192083456/1417842697192083456
