### PR TITLE
Fix env path resolution for custom gemini cli oauth path

### DIFF
--- a/.changeset/silent-spoons-give.md
+++ b/.changeset/silent-spoons-give.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix env path resolution for custom gemini cli oauth path

--- a/src/api/providers/gemini-cli.ts
+++ b/src/api/providers/gemini-cli.ts
@@ -142,7 +142,9 @@ export class GeminiCliHandler extends BaseProvider implements SingleCompletionHa
 
 		// Lookup for the project id from the env variable
 		// with a fallback to a default project ID (can be anything for personal OAuth)
-		const envPath = this.options.geminiCliOAuthPath || path.join(os.homedir(), ".gemini", ".env")
+		const envPath = this.options.geminiCliOAuthPath
+			? path.join(path.dirname(this.options.geminiCliOAuthPath), ".env")
+			: path.join(os.homedir(), ".gemini", ".env")
 
 		const { parsed, error } = dotenvx.config({ path: envPath })
 


### PR DESCRIPTION
Use path.dirname of the provided geminiCliOAuthPath to locate the .env file in the same directory, ensuring correct environment variable loading.

## Context

Some oauths need to set a value of GOOGLE_CLOUD_PROJECT id from the .env, now the .env will be taken from the same path as the oauth custom path

## Implementation

<!--

By checking the custom path for the oauth and using the path to also get the .env file. This change has no tradeoffs, just another feature to add custom path of the .env
-->

## Screenshots

| before | after |
| ------ | ----- |
| 
<img width="443" height="674" alt="Screenshot 2025-09-22 at 11 06 54" src="https://github.com/user-attachments/assets/555d200d-ad80-4dda-96f8-68cd94248a58" />
       | 
<img width="2048" height="683" alt="Screenshot 2025-09-22 at 11 07 40" src="https://github.com/user-attachments/assets/2807e0a6-6788-4d8d-990f-40488404d6d7" />
      |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Create a gemini cli profile that oauth needs to use the GOOGLE_CLOUD_PROJECT
- Set a custom path for the oauth, then move the .env to the same folder
- The .env should be used with no issues

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
555126999790780418

