### PR TITLE
Move captureEvent out of if

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -3008,8 +3008,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 		if (error) {
 			this.emit(RooCodeEventName.TaskToolFailed, this.taskId, toolName, error)
-			TelemetryService.instance.captureEvent(TelemetryEventName.TOOL_ERROR, { toolName, error }) // kilocode_change
 		}
+		TelemetryService.instance.captureEvent(TelemetryEventName.TOOL_ERROR, { toolName, error }) // kilocode_change
 	}
 
 	/**


### PR DESCRIPTION
I thought error would always be set, but in actuality it is rarely set