### PR TITLE
feat: add new Chutes AI models and update pricing (#2530)

### DIFF
--- a/.changeset/seven-seals-judge.md
+++ b/.changeset/seven-seals-judge.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+New Chutes AI models added and pricing updated

--- a/packages/types/src/providers/chutes.ts
+++ b/packages/types/src/providers/chutes.ts
@@ -18,6 +18,9 @@ export type ChutesModelId =
 	| "deepseek-ai/DeepSeek-V3-Base"
 	| "deepseek-ai/DeepSeek-R1-Zero"
 	| "deepseek-ai/DeepSeek-V3-0324"
+	| "deepseek-ai/DeepSeek-V3.1-Terminus"
+	| "deepseek-ai/DeepSeek-V3.1-turbo"
+	| "deepseek-ai/DeepSeek-V3-0324-turbo"
 	| "Qwen/Qwen3-235B-A22B"
 	| "Qwen/Qwen3-235B-A22B-Instruct-2507"
 	| "Qwen/Qwen3-32B"
@@ -29,8 +32,12 @@ export type ChutesModelId =
 	| "tngtech/DeepSeek-R1T-Chimera"
 	| "zai-org/GLM-4.5-Air"
 	| "zai-org/GLM-4.5-FP8"
+	| "zai-org/GLM-4.5-turbo"
+	| "zai-org/GLM-4.5V"
 	| "moonshotai/Kimi-K2-Instruct-75k"
 	| "moonshotai/Kimi-K2-Instruct-0905"
+	| "moonshotai/Kimi-Dev-72B"
+	| "moonshotai/Kimi-VL-A3B-Thinking"
 	| "Qwen/Qwen3-235B-A22B-Thinking-2507"
 	| "Qwen/Qwen3-Next-80B-A3B-Instruct"
 	| "Qwen/Qwen3-Next-80B-A3B-Thinking"
@@ -182,6 +189,33 @@ export const chutesModels = {
 		outputPrice: 0,
 		description: "DeepSeek V3 (0324) model.",
 	},
+	"deepseek-ai/DeepSeek-V3.1-Terminus": {
+		maxTokens: 32768,
+		contextWindow: 163840,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.25,
+		outputPrice: 1.0,
+		description: "DeepSeek V3.1 Terminus model.",
+	},
+	"deepseek-ai/DeepSeek-V3.1-turbo": {
+		maxTokens: 32768,
+		contextWindow: 163840,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 1.0,
+		outputPrice: 3.0,
+		description: "DeepSeek V3.1 Turbo model.",
+	},
+	"deepseek-ai/DeepSeek-V3-0324-turbo": {
+		maxTokens: 32768,
+		contextWindow: 163840,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 1.0,
+		outputPrice: 3.0,
+		description: "DeepSeek V3 (0324) Turbo model.",
+	},
 	"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 		maxTokens: 32768,
 		contextWindow: 262144,
@@ -274,6 +308,24 @@ export const chutesModels = {
 		description:
 			"GLM-4.5-FP8 model with 128k token context window, optimized for agent-based applications with MoE architecture.",
 	},
+	"zai-org/GLM-4.5-turbo": {
+		maxTokens: 32768,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 1.0,
+		outputPrice: 3.0,
+		description: "GLM-4.5-Turbo model.",
+	},
+	"zai-org/GLM-4.5V": {
+		maxTokens: 32768,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.08,
+		outputPrice: 0.33,
+		description: "GLM-4.5V model.",
+	},
 	"Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
 		maxTokens: 32768,
 		contextWindow: 262144,
@@ -300,6 +352,24 @@ export const chutesModels = {
 		inputPrice: 0.1999,
 		outputPrice: 0.8001,
 		description: "Moonshot AI Kimi K2 Instruct 0905 model with 256k context window.",
+	},
+	"moonshotai/Kimi-Dev-72B": {
+		maxTokens: 32768,
+		contextWindow: 262144,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.07,
+		outputPrice: 0.26,
+		description: "Moonshot AI Kimi Dev 72B model.",
+	},
+	"moonshotai/Kimi-VL-A3B-Thinking": {
+		maxTokens: 32768,
+		contextWindow: 262144,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.02,
+		outputPrice: 0.07,
+		description: "Moonshot AI Kimi VL A3B Thinking model.",
 	},
 	"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 		maxTokens: 32768,

--- a/packages/types/src/providers/chutes.ts
+++ b/packages/types/src/providers/chutes.ts
@@ -18,9 +18,11 @@ export type ChutesModelId =
 	| "deepseek-ai/DeepSeek-V3-Base"
 	| "deepseek-ai/DeepSeek-R1-Zero"
 	| "deepseek-ai/DeepSeek-V3-0324"
+	// kilocode_change start
 	| "deepseek-ai/DeepSeek-V3.1-Terminus"
 	| "deepseek-ai/DeepSeek-V3.1-turbo"
 	| "deepseek-ai/DeepSeek-V3-0324-turbo"
+	// kilocode_change end
 	| "Qwen/Qwen3-235B-A22B"
 	| "Qwen/Qwen3-235B-A22B-Instruct-2507"
 	| "Qwen/Qwen3-32B"
@@ -32,12 +34,16 @@ export type ChutesModelId =
 	| "tngtech/DeepSeek-R1T-Chimera"
 	| "zai-org/GLM-4.5-Air"
 	| "zai-org/GLM-4.5-FP8"
+	// kilocode_change start
 	| "zai-org/GLM-4.5-turbo"
 	| "zai-org/GLM-4.5V"
+	// kilocode_change end
 	| "moonshotai/Kimi-K2-Instruct-75k"
 	| "moonshotai/Kimi-K2-Instruct-0905"
+	// kilocode_change start
 	| "moonshotai/Kimi-Dev-72B"
 	| "moonshotai/Kimi-VL-A3B-Thinking"
+	// kilocode_change end
 	| "Qwen/Qwen3-235B-A22B-Thinking-2507"
 	| "Qwen/Qwen3-Next-80B-A3B-Instruct"
 	| "Qwen/Qwen3-Next-80B-A3B-Thinking"
@@ -189,6 +195,7 @@ export const chutesModels = {
 		outputPrice: 0,
 		description: "DeepSeek V3 (0324) model.",
 	},
+	// kilocode_change start
 	"deepseek-ai/DeepSeek-V3.1-Terminus": {
 		maxTokens: 32768,
 		contextWindow: 163840,
@@ -216,6 +223,7 @@ export const chutesModels = {
 		outputPrice: 3.0,
 		description: "DeepSeek V3 (0324) Turbo model.",
 	},
+	// kilocode_change end
 	"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 		maxTokens: 32768,
 		contextWindow: 262144,
@@ -308,6 +316,7 @@ export const chutesModels = {
 		description:
 			"GLM-4.5-FP8 model with 128k token context window, optimized for agent-based applications with MoE architecture.",
 	},
+	// kilocode_change start
 	"zai-org/GLM-4.5-turbo": {
 		maxTokens: 32768,
 		contextWindow: 131072,
@@ -326,6 +335,7 @@ export const chutesModels = {
 		outputPrice: 0.33,
 		description: "GLM-4.5V model.",
 	},
+	// kilocode_change end
 	"Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
 		maxTokens: 32768,
 		contextWindow: 262144,
@@ -353,6 +363,7 @@ export const chutesModels = {
 		outputPrice: 0.8001,
 		description: "Moonshot AI Kimi K2 Instruct 0905 model with 256k context window.",
 	},
+	// kilocode_change start
 	"moonshotai/Kimi-Dev-72B": {
 		maxTokens: 32768,
 		contextWindow: 262144,
@@ -371,6 +382,7 @@ export const chutesModels = {
 		outputPrice: 0.07,
 		description: "Moonshot AI Kimi VL A3B Thinking model.",
 	},
+	// kilocode_change end
 	"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 		maxTokens: 32768,
 		contextWindow: 262144,


### PR DESCRIPTION
- Add 7 new models from Chutes AI API:
  * deepseek-ai/DeepSeek-V3.1-Terminus
  * deepseek-ai/DeepSeek-V3.1-turbo
  * deepseek-ai/DeepSeek-V3-0324-turbo
  * zai-org/GLM-4.5-turbo
  * zai-org/GLM-4.5V
  * moonshotai/Kimi-Dev-72B
  * moonshotai/Kimi-VL-A3B-Thinking

- Update pricing to match current API values
- Set appropriate context windows based on model families

addresses #2530
