### PR TITLE
ci(workflows): Update the Storybook Chromatic workflow to be manually triggered

### DIFF
--- a/.github/workflows/storybook-playwright-snapshot.yml
+++ b/.github/workflows/storybook-playwright-snapshot.yml
@@ -4,9 +4,6 @@ on:
     workflow_dispatch:
     push:
         branches: [main]
-    pull_request:
-        types: [opened, reopened, ready_for_review, synchronize]
-        branches: [main]
 
 # Cancel in-progress jobs when new workflow is triggered
 concurrency:


### PR DESCRIPTION
There are too many flakes right now, and until we fix them, it's causing too much unnecessary noise.

Made an issue to track fixing the flakes here:
https://github.com/Kilo-Org/kilocode/issues/2621
