### PR TITLE
fix: jetbrains error logs brigde from extension

### DIFF
--- a/.changeset/seven-bats-tickle.md
+++ b/.changeset/seven-bats-tickle.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Jetbrains - Fix .gitignore error

--- a/.changeset/seven-bats-tickle.md
+++ b/.changeset/seven-bats-tickle.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Jetbrains - Fix .gitignore error
+Fix error logging behavior in JetBrains plugin by updating console bridge log levels

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/actors/MainThreadConsoleShape.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/actors/MainThreadConsoleShape.kt
@@ -66,7 +66,7 @@ class MainThreadConsole : MainThreadConsoleShape {
             when (severity) {
                 "log", "info" -> logger.info("[Extension Host] $arguments")
                 "warn" -> logger.warn("[Host] $arguments")
-                "error" -> logger.error("[ERROR]: $arguments")
+                "error" -> logger.warn("[ERROR]: $arguments")
                 "debug" -> logger.debug("[Host] $arguments")
                 else -> logger.info("[Host] $arguments")
             }


### PR DESCRIPTION
## Context

This PR fixes error logging in the JetBrains plugin by changing error-level logs to warning-level logs to prevent them from appearing in error logs. The changeset indicates this is addressing a .gitignore error issue.

## Implementation

- Changes error log level to warning in the JetBrains console bridge
- Adds a changeset documenting the fix

