### PR TITLE
Depend less on vscode in autocompletion strategies

### DIFF
--- a/src/services/ghost/strategies/AutoTriggerStrategy.ts
+++ b/src/services/ghost/strategies/AutoTriggerStrategy.ts
@@ -1,4 +1,3 @@
-import * as vscode from "vscode"
 import { GhostSuggestionContext } from "../types"
 import { UseCaseType } from "../types/PromptStrategy"
 import { BasePromptStrategy } from "./BasePromptStrategy"

--- a/src/services/ghost/strategies/BasePromptStrategy.ts
+++ b/src/services/ghost/strategies/BasePromptStrategy.ts
@@ -1,7 +1,15 @@
-import { TextDocument, Range, Diagnostic, DiagnosticSeverity } from "vscode"
+import type { TextDocument, Range, Diagnostic } from "vscode"
 import { GhostSuggestionContext } from "../types"
 import { PromptStrategy, UseCaseType } from "../types/PromptStrategy"
 import { CURSOR_MARKER } from "../ghostConstants"
+
+// Local mapping for DiagnosticSeverity since we're using type-only imports
+const DiagnosticSeverityNames: Record<number, string> = {
+	0: "Error",
+	1: "Warning",
+	2: "Information",
+	3: "Hint",
+}
 
 /**
  * Abstract base class for all prompt strategies
@@ -126,7 +134,7 @@ EXAMPLE:
 		const sorted = [...diagnostics].sort((a, b) => a.severity - b.severity)
 
 		sorted.forEach((d) => {
-			const severity = DiagnosticSeverity[d.severity]
+			const severity = DiagnosticSeverityNames[d.severity] || "Unknown"
 			const line = d.range.start.line + 1
 			result += `- **${severity}** at line ${line}: ${d.message}\n`
 		})

--- a/src/services/ghost/strategies/BasePromptStrategy.ts
+++ b/src/services/ghost/strategies/BasePromptStrategy.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode"
+import { TextDocument, Range, Diagnostic, DiagnosticSeverity } from "vscode"
 import { GhostSuggestionContext } from "../types"
 import { PromptStrategy, UseCaseType } from "../types/PromptStrategy"
 import { CURSOR_MARKER } from "../ghostConstants"
@@ -103,7 +103,7 @@ EXAMPLE:
 	/**
 	 * Adds the cursor marker to the document text at the specified position
 	 */
-	protected addCursorMarker(document: vscode.TextDocument, range?: vscode.Range): string {
+	protected addCursorMarker(document: TextDocument, range?: Range): string {
 		if (!range) return document.getText()
 
 		const fullText = document.getText()
@@ -117,7 +117,7 @@ EXAMPLE:
 	/**
 	 * Formats diagnostics for inclusion in prompts
 	 */
-	protected formatDiagnostics(diagnostics: vscode.Diagnostic[]): string {
+	protected formatDiagnostics(diagnostics: Diagnostic[]): string {
 		if (!diagnostics || diagnostics.length === 0) return ""
 
 		let result = "## Active Issues\n"
@@ -126,7 +126,7 @@ EXAMPLE:
 		const sorted = [...diagnostics].sort((a, b) => a.severity - b.severity)
 
 		sorted.forEach((d) => {
-			const severity = vscode.DiagnosticSeverity[d.severity]
+			const severity = DiagnosticSeverity[d.severity]
 			const line = d.range.start.line + 1
 			result += `- **${severity}** at line ${line}: ${d.message}\n`
 		})
@@ -138,8 +138,8 @@ EXAMPLE:
 	 * Gets surrounding code context (lines before and after cursor)
 	 */
 	protected getSurroundingCode(
-		document: vscode.TextDocument,
-		range: vscode.Range,
+		document: TextDocument,
+		range: Range,
 		linesBefore: number = 10,
 		linesAfter: number = 10,
 	): { before: string; after: string; currentLine: string } {
@@ -167,11 +167,7 @@ EXAMPLE:
 	/**
 	 * Formats the document with cursor marker for the prompt
 	 */
-	protected formatDocumentWithCursor(
-		document: vscode.TextDocument,
-		range?: vscode.Range,
-		languageId?: string,
-	): string {
+	protected formatDocumentWithCursor(document: TextDocument, range?: Range, languageId?: string): string {
 		const lang = languageId || document.languageId
 		const codeWithCursor = this.addCursorMarker(document, range)
 
@@ -183,14 +179,14 @@ ${codeWithCursor}
 	/**
 	 * Gets the file path from the document
 	 */
-	protected getFilePath(document: vscode.TextDocument): string {
+	protected getFilePath(document: TextDocument): string {
 		return document.uri.toString()
 	}
 
 	/**
 	 * Formats selected text for inclusion in prompts
 	 */
-	protected formatSelectedText(document: vscode.TextDocument, range: vscode.Range): string {
+	protected formatSelectedText(document: TextDocument, range: Range): string {
 		if (range.isEmpty) return ""
 
 		const selectedText = document.getText(range)

--- a/src/services/ghost/strategies/BasePromptStrategy.ts
+++ b/src/services/ghost/strategies/BasePromptStrategy.ts
@@ -2,14 +2,7 @@ import type { TextDocument, Range, Diagnostic } from "vscode"
 import { GhostSuggestionContext } from "../types"
 import { PromptStrategy, UseCaseType } from "../types/PromptStrategy"
 import { CURSOR_MARKER } from "../ghostConstants"
-
-// Local mapping for DiagnosticSeverity since we're using type-only imports
-const DiagnosticSeverityNames: Record<number, string> = {
-	0: "Error",
-	1: "Warning",
-	2: "Information",
-	3: "Hint",
-}
+import { DiagnosticSeverityNames } from "./diagnostics"
 
 /**
  * Abstract base class for all prompt strategies

--- a/src/services/ghost/strategies/ErrorFixStrategy.ts
+++ b/src/services/ghost/strategies/ErrorFixStrategy.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode"
+import { Diagnostic, DiagnosticSeverity, TextDocument } from "vscode"
 import { GhostSuggestionContext } from "../types"
 import { UseCaseType } from "../types/PromptStrategy"
 import { BasePromptStrategy } from "./BasePromptStrategy"
@@ -84,7 +84,7 @@ Important:
 			})
 
 			// Group diagnostics by line for better context
-			const diagnosticsByLine = new Map<number, vscode.Diagnostic[]>()
+			const diagnosticsByLine = new Map<number, Diagnostic[]>()
 			sorted.forEach((d) => {
 				const line = d.range.start.line
 				if (!diagnosticsByLine.has(line)) {
@@ -106,7 +106,7 @@ Important:
 
 				// List all diagnostics for this line
 				diagnostics.forEach((d) => {
-					const severity = vscode.DiagnosticSeverity[d.severity]
+					const severity = DiagnosticSeverity[d.severity]
 					prompt += `- **${severity}**: ${d.message}`
 
 					// Add diagnostic code if available (helps identify the type of error)
@@ -151,10 +151,8 @@ Important:
 		}
 
 		// Count errors vs warnings
-		const errorCount =
-			context.diagnostics?.filter((d) => d.severity === vscode.DiagnosticSeverity.Error).length || 0
-		const warningCount =
-			context.diagnostics?.filter((d) => d.severity === vscode.DiagnosticSeverity.Warning).length || 0
+		const errorCount = context.diagnostics?.filter((d) => d.severity === DiagnosticSeverity.Error).length || 0
+		const warningCount = context.diagnostics?.filter((d) => d.severity === DiagnosticSeverity.Warning).length || 0
 
 		if (errorCount > 0) {
 			prompt += `\nYou have ${errorCount} error${errorCount > 1 ? "s" : ""} that must be fixed.\n`
@@ -185,8 +183,8 @@ Important:
 	/**
 	 * Helper to check if all diagnostics are just warnings
 	 */
-	private hasOnlyWarnings(diagnostics: vscode.Diagnostic[]): boolean {
-		return diagnostics.every((d) => d.severity === vscode.DiagnosticSeverity.Warning)
+	private hasOnlyWarnings(diagnostics: Diagnostic[]): boolean {
+		return diagnostics.every((d) => d.severity === DiagnosticSeverity.Warning)
 	}
 
 	/**
@@ -194,7 +192,7 @@ Important:
 	 */
 	canHandle(context: GhostSuggestionContext): boolean {
 		// Primary: handle if there are errors
-		const hasErrors = context.diagnostics?.some((d) => d.severity === vscode.DiagnosticSeverity.Error) || false
+		const hasErrors = context.diagnostics?.some((d) => d.severity === DiagnosticSeverity.Error) || false
 
 		if (hasErrors) {
 			return true

--- a/src/services/ghost/strategies/ErrorFixStrategy.ts
+++ b/src/services/ghost/strategies/ErrorFixStrategy.ts
@@ -3,22 +3,7 @@ import { GhostSuggestionContext } from "../types"
 import { UseCaseType } from "../types/PromptStrategy"
 import { BasePromptStrategy } from "./BasePromptStrategy"
 import { CURSOR_MARKER } from "../ghostConstants"
-
-// Local constants for DiagnosticSeverity values since we're using type-only imports
-const DiagnosticSeverityValues = {
-	Error: 0,
-	Warning: 1,
-	Information: 2,
-	Hint: 3,
-} as const
-
-// Mapping for getting severity names from values
-const DiagnosticSeverityNames: Record<number, string> = {
-	0: "Error",
-	1: "Warning",
-	2: "Information",
-	3: "Hint",
-}
+import { DiagnosticSeverityValues, DiagnosticSeverityNames } from "./diagnostics"
 
 /**
  * Strategy for fixing compilation errors and warnings

--- a/src/services/ghost/strategies/NewLineCompletionStrategy.ts
+++ b/src/services/ghost/strategies/NewLineCompletionStrategy.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode"
+import { TextDocument, Range } from "vscode"
 import { GhostSuggestionContext } from "../types"
 import { UseCaseType } from "../types/PromptStrategy"
 import { BasePromptStrategy } from "./BasePromptStrategy"
@@ -201,7 +201,7 @@ Important:
 	/**
 	 * Get contextual hints based on surrounding code
 	 */
-	private getContextualHints(document: vscode.TextDocument, range: vscode.Range): string {
+	private getContextualHints(document: TextDocument, range: Range): string {
 		const lineNum = range.start.line
 		let hints = "### Hints:\n"
 
@@ -249,7 +249,7 @@ Important:
 	/**
 	 * Get the indentation level of a line
 	 */
-	private getIndentationLevel(document: vscode.TextDocument, lineNum: number): number {
+	private getIndentationLevel(document: TextDocument, lineNum: number): number {
 		if (lineNum >= document.lineCount) return 0
 
 		const line = document.lineAt(lineNum).text
@@ -260,7 +260,7 @@ Important:
 	/**
 	 * Check if we're near the end of a function
 	 */
-	private isNearFunctionEnd(document: vscode.TextDocument, lineNum: number): boolean {
+	private isNearFunctionEnd(document: TextDocument, lineNum: number): boolean {
 		// Simple heuristic: check if there's a closing brace within 3 lines
 		for (let i = lineNum + 1; i < Math.min(lineNum + 4, document.lineCount); i++) {
 			const line = document.lineAt(i).text

--- a/src/services/ghost/strategies/NewLineCompletionStrategy.ts
+++ b/src/services/ghost/strategies/NewLineCompletionStrategy.ts
@@ -1,4 +1,4 @@
-import { TextDocument, Range } from "vscode"
+import type { TextDocument, Range } from "vscode"
 import { GhostSuggestionContext } from "../types"
 import { UseCaseType } from "../types/PromptStrategy"
 import { BasePromptStrategy } from "./BasePromptStrategy"

--- a/src/services/ghost/strategies/UserRequestStrategy.ts
+++ b/src/services/ghost/strategies/UserRequestStrategy.ts
@@ -1,4 +1,3 @@
-import * as vscode from "vscode"
 import { GhostSuggestionContext } from "../types"
 import { UseCaseType } from "../types/PromptStrategy"
 import { BasePromptStrategy } from "./BasePromptStrategy"

--- a/src/services/ghost/strategies/diagnostics.ts
+++ b/src/services/ghost/strategies/diagnostics.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared diagnostic severity constants for VSCode diagnostics
+ * These are used when working with type-only imports of vscode.Diagnostic
+ */
+
+export const DiagnosticSeverityValues = {
+	Error: 0,
+	Warning: 1,
+	Information: 2,
+	Hint: 3,
+} as const
+
+export const DiagnosticSeverityNames: Record<number, string> = {
+	0: "Error",
+	1: "Warning",
+	2: "Information",
+	3: "Hint",
+}


### PR DESCRIPTION
And make clear where we are, to make it easier to invoke without vscode for testing/benchmarking ( https://github.com/Kilo-Org/kilocode/pull/2644 )