### PR TITLE
Add grok-4-fast and grok-4-fast-non-reasoning models to xAI list

### DIFF
--- a/.changeset/hungry-clouds-cut.md
+++ b/.changeset/hungry-clouds-cut.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add Grok 4 Fast model to xAI provider

--- a/packages/types/src/providers/xai.ts
+++ b/packages/types/src/providers/xai.ts
@@ -28,14 +28,14 @@ export const xaiModels = {
 		cacheReadsPrice: 0.75,
 		description: "xAI's Grok-4 model with 256K context window",
 	},
+	// kilocode_change start
 	"grok-4-fast": {
-		maxTokens: 8_192,
+		maxTokens: 30_000,
 		contextWindow: 2_000_000,
 		supportsImages: true,
 		supportsPromptCache: true,
 		inputPrice: 0.4, // This is the pricing for prompts above 128K context
 		outputPrice: 1.0,
-		cacheWritesPrice: 0.05,
 		cacheReadsPrice: 0.05,
 		description: "xAI's Grok-4-Fast model with reasonning and a 2M context window",
 		tiers: [
@@ -54,13 +54,12 @@ export const xaiModels = {
 		],
 	},
 	"grok-4-fast-non-reasoning": {
-		maxTokens: 8_192,
+		maxTokens: 30_000,
 		contextWindow: 2_000_000,
 		supportsImages: true,
 		supportsPromptCache: true,
 		inputPrice: 0.4, // This is the pricing for prompts above 128K context
 		outputPrice: 1.0,
-		cacheWritesPrice: 0.05,
 		cacheReadsPrice: 0.05,
 		description: "xAI's Grok-4-Fast model without reasonning and with a 2M context window",
 		tiers: [
@@ -78,6 +77,7 @@ export const xaiModels = {
 			},
 		],
 	},
+	// kilocode_change end
 	"grok-3": {
 		maxTokens: 8192,
 		contextWindow: 131072,

--- a/packages/types/src/providers/xai.ts
+++ b/packages/types/src/providers/xai.ts
@@ -28,6 +28,56 @@ export const xaiModels = {
 		cacheReadsPrice: 0.75,
 		description: "xAI's Grok-4 model with 256K context window",
 	},
+	"grok-4-fast": {
+		maxTokens: 8_192,
+		contextWindow: 2_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.4, // This is the pricing for prompts above 128K context
+		outputPrice: 1.0,
+		cacheWritesPrice: 0.05,
+		cacheReadsPrice: 0.05,
+		description: "xAI's Grok-4-Fast model with reasonning and a 2M context window",
+		tiers: [
+			{
+				contextWindow: 128_000,
+				inputPrice: 0.2,
+				outputPrice: 0.5,
+				cacheReadsPrice: 0.05,
+			},
+			{
+				contextWindow: Infinity,
+				inputPrice: 0.4,
+				outputPrice: 1,
+				cacheReadsPrice: 0.05,
+			},
+		],
+	},
+	"grok-4-fast-non-reasoning": {
+		maxTokens: 8_192,
+		contextWindow: 2_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.4, // This is the pricing for prompts above 128K context
+		outputPrice: 1.0,
+		cacheWritesPrice: 0.05,
+		cacheReadsPrice: 0.05,
+		description: "xAI's Grok-4-Fast model without reasonning and with a 2M context window",
+		tiers: [
+			{
+				contextWindow: 128_000,
+				inputPrice: 0.2,
+				outputPrice: 0.5,
+				cacheReadsPrice: 0.05,
+			},
+			{
+				contextWindow: Infinity,
+				inputPrice: 0.4,
+				outputPrice: 1,
+				cacheReadsPrice: 0.05,
+			},
+		],
+	},
 	"grok-3": {
 		maxTokens: 8192,
 		contextWindow: 131072,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2933,10 +2933,6 @@ packages:
     resolution: {integrity: sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.28.3':
-    resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
@@ -19988,8 +19984,6 @@ snapshots:
 
   '@babel/runtime@7.27.4': {}
 
-  '@babel/runtime@7.28.3': {}
-
   '@babel/runtime@7.28.4': {}
 
   '@babel/template@7.27.2':
@@ -20563,7 +20557,7 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/preset-react': 7.27.1(@babel/core@7.28.3)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.3
       '@babel/traverse': 7.28.3
       '@docusaurus/logger': 3.8.1
@@ -35390,7 +35384,7 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.1.1))(webpack@5.101.3(esbuild@0.25.9)):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.1.1)'
       webpack: 5.101.3(esbuild@0.25.9)
 
@@ -35445,13 +35439,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.1.1))(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       react: 19.1.1
       react-router: 5.3.4(react@19.1.1)
 
   react-router-dom@5.3.4(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -35462,7 +35456,7 @@ snapshots:
 
   react-router@5.3.4(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2933,6 +2933,10 @@ packages:
     resolution: {integrity: sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.28.3':
+    resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
@@ -19984,6 +19988,8 @@ snapshots:
 
   '@babel/runtime@7.27.4': {}
 
+  '@babel/runtime@7.28.3': {}
+
   '@babel/runtime@7.28.4': {}
 
   '@babel/template@7.27.2':
@@ -20557,7 +20563,7 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/preset-react': 7.27.1(@babel/core@7.28.3)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.3
       '@babel/runtime-corejs3': 7.28.3
       '@babel/traverse': 7.28.3
       '@docusaurus/logger': 3.8.1
@@ -35384,7 +35390,7 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.1.1))(webpack@5.101.3(esbuild@0.25.9)):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.3
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.1.1)'
       webpack: 5.101.3(esbuild@0.25.9)
 
@@ -35439,13 +35445,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.1.1))(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.3
       react: 19.1.1
       react-router: 5.3.4(react@19.1.1)
 
   react-router-dom@5.3.4(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.3
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -35456,7 +35462,7 @@ snapshots:
 
   react-router@5.3.4(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.3
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0


### PR DESCRIPTION
## Context

xAI released their grok-4-fast models (reasoning and non-reasoning variants) through their API. I added them to the list for the xAI endpoint.

## Implementation

Updated `packages/types/src/providers/xai.ts`

## Screenshots

<img width="1012" height="1236" alt="image" src="https://github.com/user-attachments/assets/e8ac7ad9-fb38-4bf8-9a80-b5b51db8977f" />

## How to Test

Just run the building process

## Get in Touch

You can message me on your discord @technoascender
