### PR TITLE
Fix: Broken JetBrains Powershell Integration

### DIFF
--- a/.changeset/breezy-pianos-train.md
+++ b/.changeset/breezy-pianos-train.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed JetBrains PowerShell integration

--- a/jetbrains/plugin/src/main/resources/kilocode-shell-integrations/vscode-powershell/profile.ps1
+++ b/jetbrains/plugin/src/main/resources/kilocode-shell-integrations/vscode-powershell/profile.ps1
@@ -78,20 +78,20 @@ function Global:Prompt() {
 		$Global:__VSCodeIsInExecution = $false
 		if ($LastHistoryEntry.Id -eq $Global:__LastHistoryId) {
 			# Don't provide a command line or exit code if there was no history entry (eg. ctrl+c, enter on no command)
-			$Result += $esc + "]633;D" + $bell
+			$Result += $esc + ']633;D' + $bell
 		} else {
 			# Command finished exit code
-			$Result += $esc + "]633;D;" + $FakeCode + $bell
+			$Result += $esc + ']633;D;' + $FakeCode + $bell
 		}
 	}
 
 	# Prompt started
-	$Result += $esc + "]633;A" + $bell
+	$Result += $esc + ']633;A' + $bell
 
 	# Current working directory
 	if ($pwd.Provider.Name -eq 'FileSystem') {
 		$cwdEscaped = __VSCode-Escape-Value $pwd.ProviderPath
-		$Result += $esc + "]633;P;Cwd=" + $cwdEscaped + $bell
+		$Result += $esc + ']633;P;Cwd=' + $cwdEscaped + $bell
 	}
 
 	# Before running the original prompt, put $? back to what it was:
@@ -138,10 +138,10 @@ if (Get-Module -Name PSReadLine) {
 		$Global:__VSCodeIsInExecution = $true
 
 		# Command line
-		$Result = $esc + "]633;E;" + $(__VSCode-Escape-Value $CommandLine) + ";" + $Nonce + $bell
+		$Result = $esc + ']633;E;' + $(__VSCode-Escape-Value $CommandLine) + ';' + $Nonce + $bell
 
 		# Command executed
-		$Result += $esc + "]633;C" + $bell
+		$Result += $esc + ']633;C' + $bell
 
 		# Write command executed sequence directly to Console
 		[Console]::Write($Result)


### PR DESCRIPTION
Replace expanding strings with literal strings to prevent "Unexpected token in expression or statement" issue caused by square brackets (i.e., `]`).

Fixes #2590

## Context

This PR fixes a bug where Kilo Code's Powershell integration fails in Jetbrains on Windows due to expanding strings around square brackets in `profile.ps1`. This resulted in an "Unexpected token in expression or statement" error.

## Implementation

The fix is to replace all double-quoted expanding strings (`"..."`) with single-quoted literal strings (`'...'`) where appropriate, ensuring that Powershell does not attempt to evaluate special characters such as square brackets (`]`).

## Screenshots

Using the `Reworked 2025` terminal engine and Powershell in PyCharm: 

| before | after |
| ------ | ----- |
| <img width="1500" height="911" alt="image" src="https://github.com/user-attachments/assets/acd2ea89-0709-4f4e-963f-c43ccc5017cb" /> | <img width="1500" height="486" alt="image" src="https://github.com/user-attachments/assets/bd953e93-20eb-4fd4-9d11-2455f3a1e1f2" /> |

## How to Test

- Before, opening a new the Jetbrains Terminal would always result in the error being displayed and Kilo Code's terminal integration failing. 
- Now, opening a new Jetbrains Terminal should not show any error messages and Kilo Code's terminal integration should work without issues.
