### PR TITLE
feat(providers): add claude-sonnet-4-5-20250929 as claude code primary mode

### DIFF
--- a/.changeset/cold-foxes-go.md
+++ b/.changeset/cold-foxes-go.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Update claude code model names for Sonnet 4.5

--- a/packages/types/src/providers/anthropic.ts
+++ b/packages/types/src/providers/anthropic.ts
@@ -6,7 +6,7 @@ export type AnthropicModelId = keyof typeof anthropicModels
 export const anthropicDefaultModelId: AnthropicModelId = "claude-sonnet-4-20250514"
 
 export const anthropicModels = {
-	"claude-4.5-sonnet": {
+	"claude-sonnet-4-5-20250929": {
 		maxTokens: 64_000, // Overridden to 8k if `enableReasoningEffort` is false.
 		contextWindow: 200_000, // Default 200K, extendable to 1M with beta flag 'context-1m-2025-08-07'
 		supportsImages: true,

--- a/packages/types/src/providers/claude-code.ts
+++ b/packages/types/src/providers/claude-code.ts
@@ -21,7 +21,7 @@ export function convertModelNameForVertex(modelName: string): string {
 
 // Claude Code
 export type ClaudeCodeModelId = keyof typeof claudeCodeModels
-export const claudeCodeDefaultModelId: ClaudeCodeModelId = "claude-sonnet-4-20250514"
+export const claudeCodeDefaultModelId: ClaudeCodeModelId = "claude-sonnet-4-5-20250929"
 export const CLAUDE_CODE_DEFAULT_MAX_OUTPUT_TOKENS = 16000
 
 /**
@@ -40,8 +40,9 @@ export function getClaudeCodeModelId(baseModelId: ClaudeCodeModelId, useVertex =
 }
 
 export const claudeCodeModels = {
-	"claude-4.5-sonnet": {
-		...anthropicModels["claude-4.5-sonnet"],
+	"claude-sonnet-4-5-20250929": {
+		...anthropicModels["claude-sonnet-4-5-20250929"],
+		maxTokens: 16_000, //Limited based on CLAUDE_CODE_DEFAULT_MAX_OUTPUT_TOKENS
 		supportsImages: false,
 		supportsPromptCache: true, // Claude Code does report cache tokens
 		supportsReasoningEffort: false,


### PR DESCRIPTION
added support for the  claude-sonnet-4-5-20250929 model with updated token limits and pricing tiers. also updated claude-code default model to claude-sonnet-4-5-20250929 and limited its maxtokens to 16k based on output constraints.  claude-4.5-sonnet is not a valid name in claude code.
