### PR TITLE
feat: add zai-org/GLM-4.6-turbo model to chutes provider

### DIFF
--- a/.changeset/hungry-glasses-applaud.md
+++ b/.changeset/hungry-glasses-applaud.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add zai-org/GLM-4.6-turbo model to Chutes provider

--- a/packages/types/src/providers/chutes.ts
+++ b/packages/types/src/providers/chutes.ts
@@ -38,9 +38,10 @@ export type ChutesModelId =
 	| "zai-org/GLM-4.6-FP8" // kilocode_change
 	// kilocode_change start
 	| "zai-org/GLM-4.5V"
-	// kilocode_change end
 	| "zai-org/GLM-4.5-turbo"
+	// kilocode_change end
 	| "moonshotai/Kimi-K2-Instruct-75k"
+	| "zai-org/GLM-4.6-turbo"
 	| "moonshotai/Kimi-K2-Instruct-0905"
 	// kilocode_change start
 	| "moonshotai/Kimi-Dev-72B"
@@ -351,6 +352,15 @@ export const chutesModels = {
 		description: "GLM-4.5-turbo model with 128K token context window, optimized for fast inference.",
 	},
 	// kilocode_change start
+	"zai-org/GLM-4.6-turbo": {
+		maxTokens: 131072,
+		contextWindow: 204800,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 1.15,
+		outputPrice: 3.25,
+		description: "GLM-4.6-turbo model with 204.8K token context window, optimized for fast inference.",
+	},
 	"zai-org/GLM-4.5V": {
 		maxTokens: 32768,
 		contextWindow: 131072,

--- a/packages/types/src/providers/chutes.ts
+++ b/packages/types/src/providers/chutes.ts
@@ -38,10 +38,10 @@ export type ChutesModelId =
 	| "zai-org/GLM-4.6-FP8" // kilocode_change
 	// kilocode_change start
 	| "zai-org/GLM-4.5V"
-	| "zai-org/GLM-4.5-turbo"
-	// kilocode_change end
-	| "moonshotai/Kimi-K2-Instruct-75k"
 	| "zai-org/GLM-4.6-turbo"
+	// kilocode_change end
+	| "zai-org/GLM-4.5-turbo"
+	| "moonshotai/Kimi-K2-Instruct-75k"
 	| "moonshotai/Kimi-K2-Instruct-0905"
 	// kilocode_change start
 	| "moonshotai/Kimi-Dev-72B"


### PR DESCRIPTION
- Add GLM-4.6-turbo model with 204.8K context window
- Set max tokens to 131,072 for output
- Set pricing to .15/M input tokens and .25/M output tokens
- Model optimized for fast inference
