### PR TITLE
Optimistically enable caching for (new) Claude and Gemini models

### DIFF
--- a/packages/types/src/providers/openrouter.ts
+++ b/packages/types/src/providers/openrouter.ts
@@ -41,10 +41,6 @@ export const OPEN_ROUTER_PROMPT_CACHING_MODELS = new Set([
 	"anthropic/claude-sonnet-4.5",
 	"anthropic/claude-opus-4",
 	"anthropic/claude-opus-4.1",
-	// kilocode_change start
-	"google/gemini-2.5-pro",
-	"google/gemini-2.5-pro-preview",
-	// kilocode_change end
 	"google/gemini-2.5-flash-preview",
 	"google/gemini-2.5-flash-preview:thinking",
 	"google/gemini-2.5-flash-preview-05-20",

--- a/src/api/providers/fetchers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/fetchers/__tests__/openrouter.spec.ts
@@ -31,7 +31,6 @@ describe("OpenRouter API", () => {
 
 			// Define models that are intentionally excluded
 			const excludedModels = new Set([
-				"google/gemini-2.5-pro", // kilocode_change: not included in mock response
 				"google/gemini-2.5-pro-preview", // Excluded due to lag issue (#4487)
 				"google/gemini-2.5-flash", // OpenRouter doesn't report this as supporting prompt caching
 				"google/gemini-2.5-flash-lite-preview-06-17", // OpenRouter doesn't report this as supporting prompt caching

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -189,15 +189,13 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 			openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
 		}
 
-		// https://openrouter.ai/docs/features/prompt-caching
-		// TODO: Add a `promptCacheStratey` field to `ModelInfo`.
-		if (OPEN_ROUTER_PROMPT_CACHING_MODELS.has(modelId)) {
-			if (modelId.startsWith("google")) {
-				addGeminiCacheBreakpoints(systemPrompt, openAiMessages)
-			} else {
-				addAnthropicCacheBreakpoints(systemPrompt, openAiMessages)
-			}
+		// kilocode_change start
+		if (modelId.startsWith("google/gemini")) {
+			addGeminiCacheBreakpoints(systemPrompt, openAiMessages)
+		} else if (modelId.startsWith("anthropic/claude") || OPEN_ROUTER_PROMPT_CACHING_MODELS.has(modelId)) {
+			addAnthropicCacheBreakpoints(systemPrompt, openAiMessages)
 		}
+		// kilocode_change end
 
 		const transforms = (this.options.openRouterUseMiddleOutTransform ?? true) ? ["middle-out"] : undefined
 


### PR DESCRIPTION
Currently we have to enable caching in a new release when a new Claude model shows up (like Opus 4.1 or Sonnet 4.5), which is certainly not ideal.