### PR TITLE
Remove `when: isMac` condition from viewsContainers to fix missing icon in windows

### DIFF
--- a/.changeset/public-emus-flow.md
+++ b/.changeset/public-emus-flow.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Potentially fix missing Kilo Code icon by removing 'when' condition from the extension's activitybar config

--- a/src/package.json
+++ b/src/package.json
@@ -111,8 +111,7 @@
 					"id": "kilo-code-ActivityBar",
 					"title": "%views.activitybar.title%",
 					"icon": "assets/icons/kilo.png",
-					"darkIcon": "assets/icons/kilo-dark.png",
-					"when": "isMac"
+					"darkIcon": "assets/icons/kilo-dark.png"
 				}
 			]
 		},
@@ -121,7 +120,9 @@
 				{
 					"type": "webview",
 					"id": "kilo-code.SidebarProvider",
-					"name": "%views.sidebar.name%"
+					"name": "%views.sidebar.name%",
+					"icon": "assets/icons/kilo.png",
+					"darkIcon": "assets/icons/kilo-dark.png"
 				}
 			]
 		},


### PR DESCRIPTION
Removed the `when: "isMac"` condition from the Kilo-Code activity bar container. This condition caused the icon to be hidden on Windows/Linux and likely triggered cache corruption that persisted across sessions.

Per user report (waewoo, last week), the visibility issue was resolved after running “View: Reset View Locations”, confirming a user cache interaction — but the `isMac` condition remained a root cause of instability across platforms.

Removing the platform gate ensures consistent icon visibility and prevents future persistence issues in the activity bar container.

Hopefully the final fix for: https://github.com/Kilo-Org/kilocode/issues/1453
