### PR TITLE
style(ui): add default "link" style to <a> tags and adjust welcome message spacing

### DIFF
--- a/.changeset/loud-rocks-flash.md
+++ b/.changeset/loud-rocks-flash.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Make all text-based links the same visual style

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -2009,7 +2009,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						)}
 						<div className="flex flex-grow flex-col justify-center gap-4">
 							{/* kilocode_change end */}
-							<p className="text-vscode-editor-foreground leading-tight font-vscode-font-family text-center text-balance max-w-[380px] mx-auto my-0">
+							<p className="text-vscode-editor-foreground leading-normal font-vscode-font-family text-center text-balance max-w-[380px] mx-auto my-0">
 								<Trans
 									i18nKey="chat:about"
 									components={{

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -183,9 +183,11 @@
 		--vscode-input-border: var(--border);
 	}
 
+	/* kilocode_change start */
 	a {
 		color: var(--vscode-textLink-foreground);
 	}
+	/* kilocode_change end */
 }
 
 @layer components {

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -182,6 +182,10 @@
 	body {
 		--vscode-input-border: var(--border);
 	}
+
+	a {
+		color: var(--vscode-textLink-foreground);
+	}
 }
 
 @layer components {


### PR DESCRIPTION
Before:
<img width="413" height="173" alt="CleanShot 2025-10-08 at 10 41 46" src="https://github.com/user-attachments/assets/38ba2307-3959-40bf-a9e8-8b1029c0021b" />

After:
<img width="408" height="172" alt="CleanShot 2025-10-08 at 10 41 12" src="https://github.com/user-attachments/assets/16bd01aa-4781-4118-90f4-8cee7ac79399" />
