### PR TITLE
remove up and down actions for completion

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -460,16 +460,6 @@
 				"when": "editorTextFocus && !editorTabMovesFocus && !inSnippetMode && kilocode.ghost.hasSuggestions"
 			},
 			{
-				"command": "kilo-code.ghost.goToNextSuggestion",
-				"key": "down",
-				"when": "editorTextFocus && !editorTabMovesFocus && !inSnippetMode && kilocode.ghost.hasSuggestions"
-			},
-			{
-				"command": "kilo-code.ghost.goToPreviousSuggestion",
-				"key": "up",
-				"when": "editorTextFocus && !editorTabMovesFocus && !inSnippetMode && kilocode.ghost.hasSuggestions"
-			},
-			{
 				"command": "kilo-code.ghost.promptCodeSuggestion",
 				"key": "ctrl+i",
 				"mac": "cmd+i",


### PR DESCRIPTION
without codelens it just looks like autocomplete disables arrow keys, especially when there is only one completion. we might want to turn this on when we turn on codelens for autocomplete, but disable until we show in the ui that we capture these keystrokes
