### PR TITLE
add context bar with button to remove files, @ menu option to add all…

### DIFF
--- a/packages/build/src/__tests__/index.test.ts
+++ b/packages/build/src/__tests__/index.test.ts
@@ -148,7 +148,7 @@ describe("generatePackageJson", () => {
 					{
 						command: "roo-code-nightly.plusButtonClicked",
 						title: "%command.newTask.title%",
-						icon: "$(edit)",
+						icon: "$(add)",
 					},
 					{
 						command: "roo-code-nightly.openInNewTab",

--- a/packages/types/src/vscode.ts
+++ b/packages/types/src/vscode.ts
@@ -63,6 +63,7 @@ export const commandIds = [
 	"handleExternalUri", // kilocode_change - for JetBrains plugin URL forwarding
 	"focusPanel",
 	"toggleAutoApprove",
+	"addFileToContext", // kilocode_change
 ] as const
 
 export type CommandId = (typeof commandIds)[number]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2942,10 +2942,6 @@ packages:
     resolution: {integrity: sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.28.3':
-    resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
@@ -20055,8 +20051,6 @@ snapshots:
 
   '@babel/runtime@7.27.4': {}
 
-  '@babel/runtime@7.28.3': {}
-
   '@babel/runtime@7.28.4': {}
 
   '@babel/template@7.27.2':
@@ -20630,7 +20624,7 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/preset-react': 7.27.1(@babel/core@7.28.3)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.3
       '@babel/traverse': 7.28.3
       '@docusaurus/logger': 3.8.1
@@ -35456,7 +35450,7 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.1.1))(webpack@5.101.3(esbuild@0.25.9)):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.1.1)'
       webpack: 5.101.3(esbuild@0.25.9)
 
@@ -35511,13 +35505,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.1.1))(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       react: 19.1.1
       react-router: 5.3.4(react@19.1.1)
 
   react-router-dom@5.3.4(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -35528,7 +35522,7 @@ snapshots:
 
   react-router@5.3.4(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -170,6 +170,13 @@ export async function activate(context: vscode.ExtensionContext) {
 					`[authStateChangedHandler] remoteControlEnabled(false) failed: ${error instanceof Error ? error.message : String(error)}`,
 				)
 			}
+			try {
+				await BridgeOrchestrator.disconnect()
+			} catch (error) {
+				cloudLogger(
+					`[authStateChangedHandler] BridgeOrchestrator.disconnect() failed: ${error instanceof Error ? error.message : String(error)}`,
+				)
+			}
 		}
 	}
 

--- a/src/package.json
+++ b/src/package.json
@@ -3,7 +3,7 @@
 	"displayName": "%extension.displayName%",
 	"description": "%extension.description%",
 	"publisher": "kilocode",
-	"version": "4.101.0",
+	"version": "4.102.0",
 	"icon": "assets/icons/logo-outline-black.png",
 	"galleryBanner": {
 		"color": "#FFFFFF",

--- a/src/package.json
+++ b/src/package.json
@@ -3,7 +3,7 @@
 	"displayName": "%extension.displayName%",
 	"description": "%extension.description%",
 	"publisher": "kilocode",
-	"version": "4.102.0",
+	"version": "4.101.0",
 	"icon": "assets/icons/logo-outline-black.png",
 	"galleryBanner": {
 		"color": "#FFFFFF",
@@ -292,9 +292,20 @@
 				"command": "kilo-code.ghost.goToPreviousSuggestion",
 				"title": "%ghost.commands.goToPreviousSuggestion%",
 				"category": "%configuration.title%"
+			},
+			{
+				"command": "kilo-code.addFileToContext",
+				"title": "%command.addFileToContext.title%",
+				"category": "%configuration.title%"
 			}
 		],
 		"menus": {
+			"explorer/context": [
+				{
+					"command": "kilo-code.addFileToContext",
+					"group": "navigation@9"
+				}
+			],
 			"editor/context": [
 				{
 					"submenu": "kilo-code.contextMenu",

--- a/src/package.nls.json
+++ b/src/package.nls.json
@@ -19,6 +19,7 @@
 	"command.fixCode.title": "Fix Code",
 	"command.improveCode.title": "Improve Code",
 	"command.addToContext.title": "Add To Context",
+	"command.addFileToContext.title": "Add File(s) to Context",
 	"command.focusInput.title": "Focus Input Field",
 	"command.setCustomStoragePath.title": "Set Custom Storage Path",
 	"command.importSettings.title": "Import Settings",

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -174,6 +174,7 @@ export interface ExtensionMessage {
 		| "focusInput"
 		| "switchTab"
 		| "focusChatInput" // kilocode_change
+		| "addContextMentions" // kilocode_change: add mentions directly to pills bar
 		| "toggleAutoApprove"
 	invoke?: "newChat" | "sendMessage" | "primaryButtonClick" | "secondaryButtonClick" | "setChatBoxMessage"
 	state?: ExtensionState

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -955,7 +955,13 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			setIsMouseDownOnMenu(true)
 		}, [])
 
-		// Highlight overlay removed - mentions are now shown in ContextPillsBar instead
+		// The visual highlight overlay for mentions within the textarea was removed.
+		// Previously, mentions were visually highlighted directly in the textarea as users typed.
+		// This functionality was removed to simplify the input UI and improve maintainability.
+		// Mentions are now visually represented in the ContextPillsBar component above the textarea,
+		// providing a clearer and more accessible way to view and manage mentions in the message.
+		// If visual highlighting in the textarea is needed in the future, refer to previous implementations
+		// prior to this change for guidance.
 
 		const updateCursorPosition = useCallback(() => {
 			if (textAreaRef.current) {

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -330,7 +330,11 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						};
 					}),
 				...filePaths
-					.filter((file) => file && file.trim() !== "" && file.trim() !== "/")
+					.filter((file) => {
+						if (!file) return false;
+						const trimmed = file.trim();
+						return trimmed !== "" && trimmed !== "/";
+					})
 					.map((file) => `@/${file}`)
 					.filter((mentionPath) => mentionPath !== "@/") // Exclude root
 					.filter((mentionPath) => {

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -312,7 +312,11 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				{ type: ContextMenuOptionType.Terminal, value: "terminal" },
 				...gitCommits,
 				...openedTabs
-					.filter((tab) => tab.path && tab.path.trim() !== "" && tab.path.trim() !== "/")
+					.filter((tab) => {
+						if (!tab.path) return false;
+						const trimmedPath = tab.path.trim();
+						return trimmedPath !== "" && trimmedPath !== "/";
+					})
 					.map((tab) => {
 						// tab.path is already a relative path (e.g., "src/file.ts")
 						// Format it directly as a mention path with @/ prefix

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -406,7 +406,8 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					if (openedTabs && openedTabs.length > 0) {
 						for (const tab of openedTabs) {
 							// Skip tabs with invalid paths
-							if (!tab.path || tab.path.trim() === "" || tab.path.trim() === "/") {
+							const trimmedPath = tab.path ? tab.path.trim() : "";
+							if (!tab.path || trimmedPath === "" || trimmedPath === "/") {
 								continue;
 							}
 

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -622,11 +622,15 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		disableAutoScrollRef.current = false
 	}, [])
 
+	// Utility function to validate mentions
+	const isValidMention = (mention: string): boolean => {
+		const trimmed = mention?.trim() || "";
+		return !!trimmed && trimmed !== "@" && trimmed !== "@/";
+	};
+
 	const handleAddMention = useCallback((mention: string) => {
 		// Validate mention before adding - skip empty or invalid mentions
-		const trimmed = mention?.trim() || "";
-		if (!trimmed || trimmed === "@" || trimmed === "@/") {
-			return;
+		if (!isValidMention(mention)) {
 		}
 		// Check for duplicates before adding
 		setContextMentions((prev) => {
@@ -651,11 +655,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			text = text.trim()
 
 			// Inject context mentions into the text
-			// Filter out invalid mentions and ensure proper formatting
+			// Use isValidMention to filter out invalid mentions and ensure proper formatting
 			const validMentions = contextMentions
-				.filter((m) => m && m.trim() !== "" && m.trim() !== "@" && m.trim() !== "@/")
-				.map((m) => m.trim())
-				.map((m) => m.startsWith("@") ? m : `@${m}`);
+								.filter(isValidMention)
+								.map((m) => m.trim())
+								.map((m) => m.startsWith("@") ? m : `@${m}`);
 
 			const mentionsText = validMentions.join(" ");
 			const fullText = mentionsText ? `${mentionsText} ${text}` : text;

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -631,6 +631,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	const handleAddMention = useCallback((mention: string) => {
 		// Validate mention before adding - skip empty or invalid mentions
 		if (!isValidMention(mention)) {
+			return; // kilocode_change: return early if mention is invalid
 		}
 		// Check for duplicates before adding
 		setContextMentions((prev) => {

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -875,6 +875,15 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						case "focusInput":
 							textAreaRef.current?.focus()
 							break
+						// kilocode_change start: support adding mentions directly to the pills bar
+						case "addContextMentions":
+							if (Array.isArray(message.values?.mentions)) {
+								const mentions: string[] = message.values?.mentions as string[];
+								// Add each mention via the existing handler to ensure validation/deduping
+								mentions.forEach((m) => handleAddMention(m));
+							}
+							break;
+						// kilocode_change end
 					}
 					break
 				case "selectedImages":
@@ -929,6 +938,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			handleSetChatBoxMessage,
 			handlePrimaryButtonClick,
 			handleSecondaryButtonClick,
+			handleAddMention, // kilocode_change
 		],
 	)
 

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -83,6 +83,13 @@ export const MAX_IMAGES_PER_MESSAGE = 20 // This is the Anthropic limit.
 
 const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0
 
+
+// Utility function to validate mentions
+const isValidMention = (mention: string): boolean => {
+	const trimmed = mention?.trim() || "";
+	return !!trimmed && trimmed !== "@" && trimmed !== "@/";
+};
+
 const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewProps> = (
 	{ isHidden, showAnnouncement, hideAnnouncement },
 	ref,
@@ -621,12 +628,6 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		// setSecondaryButtonText(undefined)
 		disableAutoScrollRef.current = false
 	}, [])
-
-	// Utility function to validate mentions
-	const isValidMention = (mention: string): boolean => {
-		const trimmed = mention?.trim() || "";
-		return !!trimmed && trimmed !== "@" && trimmed !== "@/";
-	};
 
 	const handleAddMention = useCallback((mention: string) => {
 		// Validate mention before adding - skip empty or invalid mentions

--- a/webview-ui/src/components/chat/ContextMenu.tsx
+++ b/webview-ui/src/components/chat/ContextMenu.tsx
@@ -150,6 +150,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 			case ContextMenuOptionType.Image:
 				return <span>Add Image</span>
 			// kilocode_change end
+			case ContextMenuOptionType.AllOpenEditors:
+				return <span>All Open Editors</span>
 			case ContextMenuOptionType.Git:
 				if (option.value) {
 					return (
@@ -236,6 +238,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 			case ContextMenuOptionType.Image:
 				return "device-camera"
 			// kilocode_change end
+			case ContextMenuOptionType.AllOpenEditors:
+				return "window"
 			case ContextMenuOptionType.Git:
 				return "git-commit"
 			case ContextMenuOptionType.NoResults:

--- a/webview-ui/src/components/chat/ContextPillsBar.tsx
+++ b/webview-ui/src/components/chat/ContextPillsBar.tsx
@@ -1,0 +1,67 @@
+import { X } from "lucide-react"
+import { StandardTooltip } from "@/components/ui"
+
+interface ContextPillsBarProps {
+	mentions: string[]
+	onRemove: (mention: string) => void
+}
+
+export const ContextPillsBar = ({ mentions, onRemove }: ContextPillsBarProps) => {
+	if (mentions.length === 0) return null
+
+	const getDisplayName = (path: string) => {
+		// Remove @ prefix if present
+		const cleanPath = path.startsWith("@") ? path.slice(1) : path
+
+		// Handle special mentions
+		if (["problems", "terminal", "git-changes"].includes(cleanPath)) {
+			return cleanPath
+		}
+
+		// Handle git commit hashes
+		if (/^[a-f0-9]{7,40}$/i.test(cleanPath)) {
+			return cleanPath.substring(0, 7)
+		}
+
+		// Handle URLs
+		if (cleanPath.startsWith("http://") || cleanPath.startsWith("https://")) {
+			try {
+				const url = new URL(cleanPath)
+				return url.hostname
+			} catch {
+				return cleanPath
+			}
+		}
+
+		// Get basename for file paths
+		const parts = cleanPath.split("/")
+		return parts[parts.length - 1] || cleanPath
+	}
+
+	return (
+		<div className="context-pills-bar">
+			{mentions.map((mention, index) => {
+				const displayName = getDisplayName(mention)
+				// For hover text, show the path without the @ prefix and with proper formatting
+				const cleanPath = mention.startsWith("@") ? mention.slice(1) : mention
+				// Ensure the path starts with / for display, but don't add an extra one
+				const displayPath = cleanPath.startsWith("/") ? cleanPath : `/${cleanPath}`
+
+				return (
+					<StandardTooltip key={`${mention}-${index}`} content={displayPath} side="top">
+						<div className="context-pill">
+							<span className="context-pill-name">{displayName}</span>
+							<button
+								className="context-pill-remove"
+								onClick={() => onRemove(mention)}
+								aria-label={`Remove ${displayName}`}
+								type="button">
+								<X className="h-3 w-3" />
+							</button>
+						</div>
+					</StandardTooltip>
+				)
+			})}
+		</div>
+	)
+}

--- a/webview-ui/src/components/chat/ContextPillsBar.tsx
+++ b/webview-ui/src/components/chat/ContextPillsBar.tsx
@@ -50,7 +50,6 @@ export const ContextPillsBar = ({ mentions, onRemove }: ContextPillsBarProps) =>
 				return (
 					<StandardTooltip key={`${mention}-${index}`} content={displayPath} side="top">
 						<div className="context-pill">
-							<span className="context-pill-name">{displayName}</span>
 							<button
 								className="context-pill-remove"
 								onClick={() => onRemove(mention)}
@@ -58,6 +57,7 @@ export const ContextPillsBar = ({ mentions, onRemove }: ContextPillsBarProps) =>
 								type="button">
 								<X className="h-3 w-3" />
 							</button>
+							<span className="context-pill-name">{displayName}</span>
 						</div>
 					</StandardTooltip>
 				)

--- a/webview-ui/src/components/chat/__tests__/ContextPillsBar.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ContextPillsBar.spec.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { ContextPillsBar } from "../ContextPillsBar"
+
+// Mock StandardTooltip to simplify testing
+vi.mock("@/components/ui", () => ({
+	StandardTooltip: ({ children }: any) => <>{children}</>,
+}))
+
+describe("ContextPillsBar", () => {
+	it("should render nothing when mentions array is empty", () => {
+		const { container } = render(<ContextPillsBar mentions={[]} onRemove={vi.fn()} />)
+		expect(container.firstChild).toBeNull()
+	})
+
+	it("should render pills for each mention", () => {
+		const mentions = ["/src/App.tsx", "/src/utils/helper.ts", "/README.md"]
+		render(<ContextPillsBar mentions={mentions} onRemove={vi.fn()} />)
+
+		expect(screen.getByText("App.tsx")).toBeInTheDocument()
+		expect(screen.getByText("helper.ts")).toBeInTheDocument()
+		expect(screen.getByText("README.md")).toBeInTheDocument()
+	})
+
+	it("should display only filename for file paths", () => {
+		const mentions = ["/path/to/deeply/nested/file.tsx"]
+		render(<ContextPillsBar mentions={mentions} onRemove={vi.fn()} />)
+
+		expect(screen.getByText("file.tsx")).toBeInTheDocument()
+		expect(screen.queryByText("/path/to/deeply/nested/file.tsx")).not.toBeInTheDocument()
+	})
+
+	it("should display special mentions correctly", () => {
+		const mentions = ["problems", "terminal", "git-changes"]
+		render(<ContextPillsBar mentions={mentions} onRemove={vi.fn()} />)
+
+		expect(screen.getByText("problems")).toBeInTheDocument()
+		expect(screen.getByText("terminal")).toBeInTheDocument()
+		expect(screen.getByText("git-changes")).toBeInTheDocument()
+	})
+
+	it("should display shortened git commit hash", () => {
+		const mentions = ["a1b2c3d4e5f6789"]
+		render(<ContextPillsBar mentions={mentions} onRemove={vi.fn()} />)
+
+		expect(screen.getByText("a1b2c3d")).toBeInTheDocument()
+	})
+
+	it("should display hostname for URLs", () => {
+		const mentions = ["https://example.com/path/to/page"]
+		render(<ContextPillsBar mentions={mentions} onRemove={vi.fn()} />)
+
+		expect(screen.getByText("example.com")).toBeInTheDocument()
+	})
+
+	it("should call onRemove when remove button is clicked", async () => {
+		const onRemove = vi.fn()
+		const mentions = ["/src/App.tsx", "/src/utils/helper.ts"]
+		const user = userEvent.setup()
+
+		render(<ContextPillsBar mentions={mentions} onRemove={onRemove} />)
+
+		const removeButtons = screen.getAllByRole("button")
+		await user.click(removeButtons[0])
+
+		expect(onRemove).toHaveBeenCalledWith("/src/App.tsx")
+	})
+
+	it("should render remove button for each pill", () => {
+		const mentions = ["/src/App.tsx", "/src/utils/helper.ts", "/README.md"]
+		render(<ContextPillsBar mentions={mentions} onRemove={vi.fn()} />)
+
+		const removeButtons = screen.getAllByRole("button")
+		expect(removeButtons).toHaveLength(3)
+	})
+
+	it("should have correct aria-label for remove buttons", () => {
+		const mentions = ["/src/App.tsx"]
+		render(<ContextPillsBar mentions={mentions} onRemove={vi.fn()} />)
+
+		const removeButton = screen.getByLabelText("Remove App.tsx")
+		expect(removeButton).toBeInTheDocument()
+	})
+
+	it("should handle mentions with @ prefix", () => {
+		const mentions = ["@/src/App.tsx"]
+		render(<ContextPillsBar mentions={mentions} onRemove={vi.fn()} />)
+
+		expect(screen.getByText("App.tsx")).toBeInTheDocument()
+	})
+
+	it("should handle multiple pills with same filename", () => {
+		const mentions = ["/src/components/App.tsx", "/tests/App.tsx"]
+		render(<ContextPillsBar mentions={mentions} onRemove={vi.fn()} />)
+
+		const pills = screen.getAllByText("App.tsx")
+		expect(pills).toHaveLength(2)
+	})
+})

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -398,6 +398,66 @@ vscode-dropdown::part(listbox) {
 	border-radius: 3px;
 	box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--vscode-badge-foreground) 30%, transparent);
 }
+/* Context Pills Bar */
+.context-pills-bar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	padding: 8px 12px;
+	background-color: var(--vscode-editor-background);
+	border-bottom: 1px solid color-mix(in srgb, var(--vscode-panel-border) 50%, transparent);
+	min-height: 40px;
+	align-items: center;
+}
+
+.context-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 4px 4px 8px;
+	background-color: color-mix(in srgb, var(--vscode-badge-background) 85%, transparent);
+	border: 1px solid color-mix(in srgb, var(--vscode-badge-background) 40%, transparent);
+	border-radius: 4px;
+	font-size: calc(var(--vscode-font-size) * 0.9);
+	color: var(--vscode-badge-foreground);
+	transition: all 0.15s ease;
+}
+
+.context-pill:hover {
+	background-color: var(--vscode-badge-background);
+	border-color: color-mix(in srgb, var(--vscode-badge-background) 60%, transparent);
+}
+
+.context-pill-name {
+	white-space: nowrap;
+	max-width: 200px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.context-pill-remove {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 2px;
+	background: transparent;
+	border: none;
+	border-radius: 2px;
+	cursor: pointer;
+	opacity: 0.6;
+	transition: all 0.1s ease;
+	color: currentColor;
+}
+
+.context-pill-remove:hover {
+	opacity: 1;
+	background-color: color-mix(in srgb, var(--vscode-badge-foreground) 15%, transparent);
+}
+
+.context-pill-remove:active {
+	transform: scale(0.9);
+}
+
 
 /**
  * vscrui Overrides / Hacks

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -414,7 +414,7 @@ vscode-dropdown::part(listbox) {
 	display: inline-flex;
 	align-items: center;
 	gap: 4px;
-	padding: 4px 4px 4px 8px;
+	padding: 4px 8px 4px 4px;
 	background-color: color-mix(in srgb, var(--vscode-badge-background) 85%, transparent);
 	border: 1px solid color-mix(in srgb, var(--vscode-badge-background) 40%, transparent);
 	border-radius: 4px;

--- a/webview-ui/src/utils/__tests__/context-mentions.spec.ts
+++ b/webview-ui/src/utils/__tests__/context-mentions.spec.ts
@@ -238,11 +238,12 @@ describe("getContextMenuOptions", () => {
 
 	it("should return all option types for empty query", () => {
 		const result = getContextMenuOptions("", null, [])
-		expect(result).toHaveLength(7) // kilocode_change: added image option
+		expect(result).toHaveLength(8) // kilocode_change: added image and allOpenEditors options
 		expect(result.map((item) => item.type)).toEqual([
 			ContextMenuOptionType.Problems,
 			ContextMenuOptionType.Terminal,
 			ContextMenuOptionType.URL,
+			ContextMenuOptionType.AllOpenEditors,
 			ContextMenuOptionType.Folder,
 			ContextMenuOptionType.File,
 			ContextMenuOptionType.Image, // kilocode_change

--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -110,6 +110,7 @@ export enum ContextMenuOptionType {
 	Image = "image", // kilocode_change
 	Command = "command", // Add command type
 	SectionHeader = "sectionHeader", // Add section header type
+	AllOpenEditors = "allOpenEditors", // Add all open editors type
 }
 
 export interface ContextMenuQueryItem {
@@ -254,6 +255,7 @@ export function getContextMenuOptions(
 			{ type: ContextMenuOptionType.Problems },
 			{ type: ContextMenuOptionType.Terminal },
 			{ type: ContextMenuOptionType.URL },
+			{ type: ContextMenuOptionType.AllOpenEditors },
 			{ type: ContextMenuOptionType.Folder },
 			{ type: ContextMenuOptionType.File },
 			{ type: ContextMenuOptionType.Image }, // kilocode_change
@@ -283,6 +285,13 @@ export function getContextMenuOptions(
 	}
 	if (query.startsWith("http")) {
 		suggestions.push({ type: ContextMenuOptionType.URL, value: query })
+	}
+	if ("all open editors".startsWith(lowerQuery) || "opened".startsWith(lowerQuery)) {
+		suggestions.push({
+			type: ContextMenuOptionType.AllOpenEditors,
+			label: "All Open Editors",
+			description: "Add all open files to context",
+		})
 	}
 
 	// Add exact SHA matches to suggestions


### PR DESCRIPTION
… open files/editors

## Context

This adds a context bar above the chat, in the style of Github Copilot and Augment Code. Files get a "pill" with an X button to remove it. It works for @ Add File/Folder/Commit, multiple file shift+drag-and-drop, as well as a new @ menu option `All Open Editors` which adds all currently-open files/editors to the context. 


## Implementation

Uploading Code_5r58SV28iJ.mp4

I dont even have a clue - pure vibe coded/debugged as I dont know typescript etc... Should be self-explanatory from the diffs. 

I had issues with full vs workspace-relative path being shown in the tooltip and, especially with being included in the actual api request. In the end, i seemed to get it all working by ensuring that it had the format `@/workspace/relative/path/to/file.js`. The leading `/` was necessary for Kilo to actually attach the file rather than just provide the file name/path. 

This is the extent of my capabilities here - if anything needs to be further tested/changed, i'll have to leave it up to more knowledgeable people.

## Screenshots
https://github.com/user-attachments/assets/82082621-0227-4ef8-8bd6-f193fedf96b6


## How to Test

Try the various methods for adding files to context:


@ Add Files/Folders
@ All Open Editors
Shift + Drag-and-drop multiple files

## Get in Touch
Here, or in discord with the same username
