### PR TITLE
feat(terminal): convert cd commands to use cwd parameter

### DIFF
--- a/.changeset/sixty-windows-notice.md
+++ b/.changeset/sixty-windows-notice.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Improve terminal command execution with direcory changes by automatically converting `cd` and `chdir` command patterns to use `cwd` parameter

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -131,7 +131,7 @@
 		{
 			"label": "install-dev-extension",
 			"type": "shell",
-			"command": "pnpm i && npm run build && code --install-extension \"$(ls -1v bin/kilo-code-*.vsix | tail -n1)\"",
+			"command": "pnpm i && npm run build && code --force --install-extension \"$(ls -1v bin/kilo-code-*.vsix | tail -n1)\"",
 			"group": "build",
 			"presentation": {
 				"echo": true,

--- a/src/core/prompts/tools/execute-command.ts
+++ b/src/core/prompts/tools/execute-command.ts
@@ -2,19 +2,21 @@ import { ToolArgs } from "./types"
 
 export function getExecuteCommandDescription(args: ToolArgs): string | undefined {
 	return `## execute_command
-Description: Request to execute a CLI command on the system. Use this when you need to perform system operations or run specific commands to accomplish any step in the user's task. You must tailor your command to the user's system and provide a clear explanation of what the command does. For command chaining, use the appropriate chaining syntax for the user's shell. Prefer to execute complex CLI commands over creating executable scripts, as they are more flexible and easier to run. Prefer relative commands and paths that avoid location sensitivity for terminal consistency, e.g: \`touch ./testdata/example.file\`, \`dir ./examples/model1/data/yaml\`, or \`go test ./cmd/front --config ./cmd/front/config.yml\`. If directed by the user, you may open a terminal in a different directory by using the \`cwd\` parameter.
+Description: Request to execute a CLI command on the system. Use this when you need to perform system operations or run specific commands to accomplish any step in the user's task. You must tailor your command to the user's system and provide a clear explanation of what the command does. For command chaining, use the appropriate chaining syntax for the user's shell. Prefer to execute complex CLI commands over creating executable scripts, as they are more flexible and easier to run. Prefer relative commands and paths that avoid location sensitivity for terminal consistency, e.g: \`touch ./testdata/example.file\`, \`dir ./examples/model1/data/yaml\`, or \`go test ./cmd/front --config ./cmd/front/config.yml\`. Critically, use the 'cwd' parameter instead of 'cd directory && command'.**
+
 Parameters:
-- command: (required) The CLI command to execute. This should be valid for the current operating system. Ensure the command is properly formatted and does not contain any harmful instructions.
-- cwd: (optional) The working directory to execute the command in (default: ${args.cwd})
+- cwd: (optional) Working directory to execute the command in (default: ${args.cwd})
+- command: (required) The CLI command to execute a valid for the current operating system. Ensure the command is properly formatted and does not contain any harmful instructions. Use cwd param instead of starting w/ 'cd' or 'chdir'
 Usage:
 <execute_command>
 <command>Your command here</command>
 <cwd>Working directory path (optional)</cwd>
 </execute_command>
 
-Example: Requesting to execute npm run dev
+Example: Request to execute npm run dev in a subdirectory
 <execute_command>
 <command>npm run dev</command>
+<cwd>./frontend</cwd>
 </execute_command>
 
 Example: Requesting to execute ls in a specific directory if directed

--- a/src/integrations/terminal/__tests__/commandUtils.spec.ts
+++ b/src/integrations/terminal/__tests__/commandUtils.spec.ts
@@ -1,0 +1,504 @@
+import { describe, it, expect } from "vitest"
+import * as path from "path"
+import { detectAndConvertCdPattern } from "../commandUtils"
+
+describe("detectAndConvertCdPattern", () => {
+	const baseCwd = "/project/root"
+
+	describe("Basic && patterns (should convert)", () => {
+		it("should convert cd with && - simple case", () => {
+			const result = detectAndConvertCdPattern("cd frontend && npm install", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm install",
+				finalCwd: path.resolve(baseCwd, "frontend"),
+				wasConverted: true,
+			})
+		})
+
+		it("should convert chdir with &&", () => {
+			const result = detectAndConvertCdPattern("chdir backend && npm test", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm test",
+				finalCwd: path.resolve(baseCwd, "backend"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle relative paths with ../", () => {
+			const result = detectAndConvertCdPattern("cd ../parent && ls -la", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "ls -la",
+				finalCwd: path.resolve(baseCwd, "../parent"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle case insensitive cd/chdir", () => {
+			const result = detectAndConvertCdPattern("CD frontend && npm install", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm install",
+				finalCwd: path.resolve(baseCwd, "frontend"),
+				wasConverted: true,
+			})
+		})
+	})
+
+	describe("Quoted paths", () => {
+		it("should handle double-quoted paths", () => {
+			const result = detectAndConvertCdPattern('cd "path with spaces" && npm install', baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm install",
+				finalCwd: path.resolve(baseCwd, "path with spaces"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle single-quoted paths", () => {
+			const result = detectAndConvertCdPattern("cd 'another path' && npm install", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm install",
+				finalCwd: path.resolve(baseCwd, "another path"),
+				wasConverted: true,
+			})
+		})
+	})
+
+	describe("Windows-specific patterns", () => {
+		it("should handle cd /d with && (Windows drive change)", () => {
+			const winBaseCwd = "C:\\project"
+			const result = detectAndConvertCdPattern("cd /d D:\\work && dir", winBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "dir",
+				finalCwd: path.resolve(winBaseCwd, "D:\\work"),
+				wasConverted: true,
+			})
+		})
+	})
+
+	describe("Complex command patterns", () => {
+		it("should handle commands with multiple arguments", () => {
+			const result = detectAndConvertCdPattern("cd frontend && npm run build --prod", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm run build --prod",
+				finalCwd: path.resolve(baseCwd, "frontend"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle commands with pipes and redirects", () => {
+			const result = detectAndConvertCdPattern('cd logs && grep "error" *.log | head -10', baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: 'grep "error" *.log | head -10',
+				finalCwd: path.resolve(baseCwd, "logs"),
+				wasConverted: true,
+			})
+		})
+	})
+
+	describe("Semicolon separator support", () => {
+		it("should convert cd with semicolon separator", () => {
+			const result = detectAndConvertCdPattern("cd frontend; npm install", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm install",
+				finalCwd: path.resolve(baseCwd, "frontend"),
+				wasConverted: true,
+			})
+		})
+
+		it("should convert cd with semicolon and quoted path", () => {
+			const result = detectAndConvertCdPattern('cd "path with spaces"; npm test', baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm test",
+				finalCwd: path.resolve(baseCwd, "path with spaces"),
+				wasConverted: true,
+			})
+		})
+
+		it("should convert cd with semicolon and complex command", () => {
+			const result = detectAndConvertCdPattern("cd logs; tail -f app.log | grep ERROR", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "tail -f app.log | grep ERROR",
+				finalCwd: path.resolve(baseCwd, "logs"),
+				wasConverted: true,
+			})
+		})
+
+		it("should NOT convert single & (background execution)", () => {
+			const result = detectAndConvertCdPattern("cd frontend & npm install", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "cd frontend & npm install",
+				finalCwd: baseCwd,
+				wasConverted: false,
+			})
+		})
+
+		it("should NOT convert cd without subsequent command", () => {
+			const result = detectAndConvertCdPattern("cd frontend", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "cd frontend",
+				finalCwd: baseCwd,
+				wasConverted: false,
+			})
+		})
+
+		it("should NOT convert commands with variables", () => {
+			const result = detectAndConvertCdPattern("cd $WORKSPACE_ROOT/src && npm install", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "cd $WORKSPACE_ROOT/src && npm install",
+				finalCwd: baseCwd,
+				wasConverted: false,
+			})
+		})
+
+		it("should NOT convert commands with Windows variables", () => {
+			const result = detectAndConvertCdPattern("cd %USERPROFILE%\\Documents && dir", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "cd %USERPROFILE%\\Documents && dir",
+				finalCwd: baseCwd,
+				wasConverted: false,
+			})
+		})
+	})
+
+	describe("Cross-platform Windows scenarios", () => {
+		const winBaseCwd = "C:\\Users\\dev\\project"
+
+		it("should handle Windows backslash paths", () => {
+			const result = detectAndConvertCdPattern("cd src\\components && npm test", winBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm test",
+				finalCwd: path.resolve(winBaseCwd, "src\\components"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle Windows UNC paths", () => {
+			const result = detectAndConvertCdPattern('cd "\\\\server\\share\\folder" && dir', winBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "dir",
+				finalCwd: path.resolve(winBaseCwd, "\\\\server\\share\\folder"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle Windows drive letters", () => {
+			const result = detectAndConvertCdPattern("cd D:\\projects\\app && npm start", winBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm start",
+				finalCwd: path.resolve(winBaseCwd, "D:\\projects\\app"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle Windows cmd.exe commands", () => {
+			const result = detectAndConvertCdPattern("cd temp && del *.tmp", winBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "del *.tmp",
+				finalCwd: path.resolve(winBaseCwd, "temp"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle PowerShell commands", () => {
+			const result = detectAndConvertCdPattern("cd scripts && Get-ChildItem *.ps1", winBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "Get-ChildItem *.ps1",
+				finalCwd: path.resolve(winBaseCwd, "scripts"),
+				wasConverted: true,
+			})
+		})
+	})
+
+	describe("Cross-platform Unix/Linux scenarios", () => {
+		const unixBaseCwd = "/home/dev/project"
+
+		it("should handle Unix forward slash paths", () => {
+			const result = detectAndConvertCdPattern("cd src/components && npm test", unixBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm test",
+				finalCwd: path.resolve(unixBaseCwd, "src/components"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle Unix hidden directories", () => {
+			const result = detectAndConvertCdPattern("cd .config && ls -la", unixBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "ls -la",
+				finalCwd: path.resolve(unixBaseCwd, ".config"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle Unix root paths", () => {
+			const result = detectAndConvertCdPattern("cd /etc && cat hosts", unixBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "cat hosts",
+				finalCwd: "/etc",
+				wasConverted: true,
+			})
+		})
+
+		it("should handle Unix home directory shortcuts", () => {
+			const result = detectAndConvertCdPattern("cd ~/Documents && find . -name '*.txt'", unixBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "find . -name '*.txt'",
+				finalCwd: path.resolve(unixBaseCwd, "~/Documents"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle complex Unix commands with pipes", () => {
+			const result = detectAndConvertCdPattern("cd logs && tail -f app.log | grep ERROR", unixBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "tail -f app.log | grep ERROR",
+				finalCwd: path.resolve(unixBaseCwd, "logs"),
+				wasConverted: true,
+			})
+		})
+	})
+
+	describe("macOS-specific scenarios", () => {
+		const macBaseCwd = "/Users/dev/project"
+
+		it("should handle macOS Applications folder", () => {
+			const result = detectAndConvertCdPattern('cd "/Applications/Xcode.app" && ls -la', macBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "ls -la",
+				finalCwd: "/Applications/Xcode.app",
+				wasConverted: true,
+			})
+		})
+
+		it("should handle macOS user directories", () => {
+			const result = detectAndConvertCdPattern("cd ~/Library/Preferences && ls", macBaseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "ls",
+				finalCwd: path.resolve(macBaseCwd, "~/Library/Preferences"),
+				wasConverted: true,
+			})
+		})
+	})
+
+	describe("Shell-specific command variations", () => {
+		it("should handle bash-style commands", () => {
+			const result = detectAndConvertCdPattern("cd build && make clean && make", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "make clean && make",
+				finalCwd: path.resolve(baseCwd, "build"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle zsh-style commands", () => {
+			const result = detectAndConvertCdPattern("cd src && find . -name '*.ts' -exec echo {} \\;", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "find . -name '*.ts' -exec echo {} \\;",
+				finalCwd: path.resolve(baseCwd, "src"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle fish shell commands", () => {
+			const result = detectAndConvertCdPattern("cd tests && python -m pytest --verbose", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "python -m pytest --verbose",
+				finalCwd: path.resolve(baseCwd, "tests"),
+				wasConverted: true,
+			})
+		})
+	})
+
+	describe("Development workflow scenarios", () => {
+		it("should handle Node.js workflows", () => {
+			const result = detectAndConvertCdPattern("cd frontend && npm ci && npm run build", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm ci && npm run build",
+				finalCwd: path.resolve(baseCwd, "frontend"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle Python workflows", () => {
+			const result = detectAndConvertCdPattern(
+				"cd backend && python -m venv venv && source venv/bin/activate",
+				baseCwd,
+			)
+
+			expect(result).toEqual({
+				finalCommand: "python -m venv venv && source venv/bin/activate",
+				finalCwd: path.resolve(baseCwd, "backend"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle Docker workflows", () => {
+			const result = detectAndConvertCdPattern("cd docker && docker build -t myapp .", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "docker build -t myapp .",
+				finalCwd: path.resolve(baseCwd, "docker"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle Git workflows", () => {
+			const result = detectAndConvertCdPattern("cd .git && git log --oneline -10", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "git log --oneline -10",
+				finalCwd: path.resolve(baseCwd, ".git"),
+				wasConverted: true,
+			})
+		})
+	})
+
+	describe("Advanced quote and escape scenarios", () => {
+		it("should handle mixed quotes", () => {
+			const result = detectAndConvertCdPattern(`cd 'path with "nested" quotes' && ls`, baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "ls",
+				finalCwd: path.resolve(baseCwd, 'path with "nested" quotes'),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle paths with special characters", () => {
+			const result = detectAndConvertCdPattern("cd 'folder (with) [brackets] & symbols' && npm test", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm test",
+				finalCwd: path.resolve(baseCwd, "folder (with) [brackets] & symbols"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle very long paths", () => {
+			const longPath = "very/long/nested/path/structure/that/goes/deep/into/subdirectories"
+			const result = detectAndConvertCdPattern(`cd ${longPath} && ls -la`, baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "ls -la",
+				finalCwd: path.resolve(baseCwd, longPath),
+				wasConverted: true,
+			})
+		})
+	})
+
+	describe("Error and edge case scenarios", () => {
+		it("should handle empty input", () => {
+			const result = detectAndConvertCdPattern("", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "",
+				finalCwd: baseCwd,
+				wasConverted: false,
+			})
+		})
+
+		it("should handle whitespace variations", () => {
+			const result = detectAndConvertCdPattern("cd   frontend   &&   npm install", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm install",
+				finalCwd: path.resolve(baseCwd, "frontend"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle absolute paths", () => {
+			const result = detectAndConvertCdPattern("cd /usr/local/bin && ls", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "ls",
+				finalCwd: "/usr/local/bin",
+				wasConverted: true,
+			})
+		})
+
+		it("should handle malformed quotes", () => {
+			const result = detectAndConvertCdPattern('cd "unclosed quote && npm install', baseCwd)
+
+			// Our custom tokenizer handles this case by treating the unclosed quote as part of the path
+			expect(result).toEqual({
+				finalCommand: "npm install",
+				finalCwd: path.resolve(baseCwd, "unclosed quote"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle cd with no path argument", () => {
+			const result = detectAndConvertCdPattern("cd && npm install", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "cd && npm install",
+				finalCwd: baseCwd,
+				wasConverted: false,
+			})
+		})
+
+		it("should handle multiple && operators", () => {
+			const result = detectAndConvertCdPattern("cd src && npm test && npm run lint", baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: "npm test && npm run lint",
+				finalCwd: path.resolve(baseCwd, "src"),
+				wasConverted: true,
+			})
+		})
+
+		// Additional tests for the custom tokenizer robustness
+		it("should preserve complex quoted commands exactly", () => {
+			const result = detectAndConvertCdPattern('cd src && echo "Hello && World" | grep "&&"', baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: 'echo "Hello && World" | grep "&&"',
+				finalCwd: path.resolve(baseCwd, "src"),
+				wasConverted: true,
+			})
+		})
+
+		it("should handle mixed quote types in command", () => {
+			const result = detectAndConvertCdPattern(`cd 'test dir' && echo "mixed 'quotes'" && ls`, baseCwd)
+
+			expect(result).toEqual({
+				finalCommand: `echo "mixed 'quotes'" && ls`,
+				finalCwd: path.resolve(baseCwd, "test dir"),
+				wasConverted: true,
+			})
+		})
+	})
+})

--- a/src/integrations/terminal/commandUtils.ts
+++ b/src/integrations/terminal/commandUtils.ts
@@ -1,0 +1,114 @@
+import * as path from "path"
+
+export interface CommandConversionResult {
+	finalCommand: string
+	finalCwd: string
+	wasConverted: boolean
+}
+
+/**
+ * Extracts tokens from cd command, respecting quotes.
+ * Stops at && or ; separator. Strips quotes during tokenization.
+ */
+function extractCdTokens(command: string): string[] {
+	const tokens: string[] = []
+	let current = ""
+	let inQuotes = false
+	let quoteChar = ""
+
+	for (let i = 0; i < command.length; i++) {
+		const char = command[i]
+		const next = command[i + 1]
+
+		// Handle quote boundaries
+		if (!inQuotes && (char === '"' || char === "'")) {
+			inQuotes = true
+			quoteChar = char
+			continue // Skip the quote character
+		}
+		if (inQuotes && char === quoteChar) {
+			inQuotes = false
+			quoteChar = ""
+			continue // Skip the quote character
+		}
+
+		// Stop at separators (outside quotes)
+		if (!inQuotes) {
+			if ((char === "&" && next === "&") || char === ";") {
+				if (current) tokens.push(current)
+				break
+			}
+			if (char === " ") {
+				if (current) tokens.push(current)
+				current = ""
+				continue
+			}
+		}
+
+		current += char
+	}
+
+	if (current) tokens.push(current)
+	return tokens
+}
+
+/**
+ * Converts `cd path && command` or `cd path; command` to {cwd, command}.
+ * Only converts if safe to do so, otherwise returns original command.
+ */
+export function detectAndConvertCdPattern(command: string, baseCwd: string): CommandConversionResult {
+	command = command.trim()
+	if (!command) {
+		return { finalCommand: command, finalCwd: baseCwd, wasConverted: false }
+	}
+
+	// Find separator (prefer && over ;)
+	let sepIndex = command.indexOf(" && ")
+	let sepLength = 4
+	if (sepIndex === -1) {
+		sepIndex = command.indexOf(";")
+		sepLength = 1
+	}
+	if (sepIndex === -1) {
+		return { finalCommand: command, finalCwd: baseCwd, wasConverted: false }
+	}
+
+	// Extract parts
+	const beforeSep = command.slice(0, sepIndex)
+	const afterSep = command.slice(sepIndex + sepLength).trim()
+
+	// Parse cd command
+	const tokens = extractCdTokens(beforeSep)
+	if (tokens.length < 2) {
+		return { finalCommand: command, finalCwd: baseCwd, wasConverted: false }
+	}
+
+	// Check for cd/chdir
+	const verb = tokens[0].toLowerCase()
+	if (verb !== "cd" && verb !== "chdir") {
+		return { finalCommand: command, finalCwd: baseCwd, wasConverted: false }
+	}
+
+	// Handle Windows /d flag
+	let pathIndex = 1
+	if (tokens[1]?.toLowerCase() === "/d") {
+		pathIndex = 2
+	}
+
+	const targetPath = tokens[pathIndex]
+	if (!targetPath) {
+		return { finalCommand: command, finalCwd: baseCwd, wasConverted: false }
+	}
+
+	// Don't convert paths with variables
+	if (targetPath.includes("$") || targetPath.includes("%")) {
+		return { finalCommand: command, finalCwd: baseCwd, wasConverted: false }
+	}
+
+	try {
+		const resolvedPath = path.resolve(baseCwd, targetPath)
+		return { finalCommand: afterSep, finalCwd: resolvedPath, wasConverted: true }
+	} catch {
+		return { finalCommand: command, finalCwd: baseCwd, wasConverted: false }
+	}
+}

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -14,7 +14,7 @@ import { ExtensionStateContextProvider, useExtensionState } from "./context/Exte
 import ChatView, { ChatViewRef } from "./components/chat/ChatView"
 import HistoryView from "./components/history/HistoryView"
 import SettingsView, { SettingsViewRef } from "./components/settings/SettingsView"
-import WelcomeView from "./components/kilocode/Welcome/WelcomeView" // kilocode_change
+import WelcomeView from "./components/kilocode/welcome/WelcomeView" // kilocode_change
 import ProfileView from "./components/kilocode/profile/ProfileView" // kilocode_change
 import McpView from "./components/mcp/McpView"
 import { MarketplaceView } from "./components/marketplace/MarketplaceView"


### PR DESCRIPTION
The `execute_command` tool now automatically detects and converts commands starting with `cd` or `chdir` followed by `&&` or `;` into the `cwd` parameter. This simplifies command execution by allowing the model to directly specify the target directory without needing to chain `cd` commands.

This change includes:
- A new `detectAndConvertCdPattern` utility function in `src/integrations/terminal/commandUtils.ts`.
- Integration of this utility into `executeCommandTool.ts` to process commands before approval.
- Updates to the `execute_command` tool description to reflect this new behavior.
- Comprehensive unit tests for the `detectAndConvertCdPattern` function in `src/integrations/terminal/__tests__/commandUtils.spec.ts`.

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
