### PR TITLE
add --force to install-dev-extension task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -131,7 +131,7 @@
 		{
 			"label": "install-dev-extension",
 			"type": "shell",
-			"command": "pnpm i && npm run build && code --install-extension \"$(ls -1v bin/kilo-code-*.vsix | tail -n1)\"",
+			"command": "pnpm i && npm run build && code --force --install-extension \"$(ls -1v bin/kilo-code-*.vsix | tail -n1)\"",
 			"group": "build",
 			"presentation": {
 				"echo": true,


### PR DESCRIPTION
without `--force` it'll subtly error if the versions are the same, this takes care of that
this is for development only- no risk
