### PR TITLE
Improved the error message when an unsupported reasoning effort value is chosen

### DIFF
--- a/.changeset/public-bees-fall.md
+++ b/.changeset/public-bees-fall.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Improved the error message when an unsupported reasoning effort value is chosen

--- a/src/api/providers/kilocode-openrouter.ts
+++ b/src/api/providers/kilocode-openrouter.ts
@@ -18,7 +18,7 @@ export class KilocodeOpenrouterHandler extends OpenRouterHandler {
 	defaultModel: string = openRouterDefaultModelId
 
 	protected override get providerName() {
-		return "KiloCode"
+		return "KiloCode" as const
 	}
 
 	constructor(options: ApiHandlerOptions) {

--- a/src/api/providers/utils/openai-error-handler.ts
+++ b/src/api/providers/utils/openai-error-handler.ts
@@ -13,12 +13,6 @@ import { isAnyRecognizedKiloCodeError } from "../../../shared/kilocode/errorUtil
  * @returns The original error or a transformed user-friendly error
  */
 export function handleOpenAIError(error: unknown, providerName: string): Error {
-	// kilocode_change start
-	if (providerName === "KiloCode" && isAnyRecognizedKiloCodeError(error)) {
-		throw error
-	}
-	// kilocode_change end
-
 	if (error instanceof Error) {
 		const msg = error.message || ""
 


### PR DESCRIPTION
<img width="500" src="https://github.com/user-attachments/assets/17498c1f-ce4a-4540-bb69-b92ff90baa97" />

Annoying that it doesn't show the parameter name in the error message.
