### PR TITLE
fix(ovhcloud): Remove OVHcloud max_tokens and edit webview text

### DIFF
--- a/src/api/providers/__tests__/ovhcloud.spec.ts
+++ b/src/api/providers/__tests__/ovhcloud.spec.ts
@@ -212,7 +212,6 @@ describe("OVHcloudAIEndpointsHandler", () => {
 
 			expect(mockCreate).toHaveBeenCalledWith({
 				model: modelId,
-				max_tokens: modelInfo.maxTokens,
 				messages: [{ role: "system", content: systemPrompt }, userMessages[0]],
 				stream: true,
 				stream_options: { include_usage: true },

--- a/webview-ui/src/components/settings/providers/OvhCloud.tsx
+++ b/webview-ui/src/components/settings/providers/OvhCloud.tsx
@@ -68,7 +68,7 @@ export const OvhCloudAiEndpoints = ({
 
 					setCustomUrlEnabled(isChecked)
 				}}>
-				{t("settings:providers.ovhCloudAiEndpointsBaseUrl")}
+				{t("settings:providers.getOvhCloudAiEndpointsBaseUrl")}
 			</VSCodeCheckbox>
 			{customUrlEnabled && (
 				<VSCodeTextField
@@ -79,7 +79,7 @@ export const OvhCloudAiEndpoints = ({
 					className="w-full">
 					<div className="flex justify-between items-center mb-1">
 						<label className="block font-medium">
-							{t("settings:providers.getOvhCloudAiEndpointsBaseUrl")}
+							{t("settings:providers.ovhCloudAiEndpointsBaseUrl")}
 						</label>
 					</div>
 				</VSCodeTextField>


### PR DESCRIPTION
## Context

- Switch translation key in the OVHcloud webview because they were incorrect
- Remove max_tokens from OVHcloud that causes models to not give any response.

## How to Test

You need first a OVHCloud AI Endpoints API Key.

1.  **Sign Up/Sign In:** Go to the [OVHCloud manager](https://www.ovh.com/manager). Create an account or sign in.
2.  **Navigate to Public Cloud:** Go to the Public Cloud section, and create a new project. Navigate to AI Endpoints in the _AI & Machine Learning_ section.
3.  **Create a Key:** Click to _API keys_ and create a new key.

Then in Kilo Code:
1.  **Open Kilo Code Settings:** Click the gear icon (<Codicon name="gear" />) in the Kilo Code panel.
2.  **Select Provider:** Choose "OVHCloud AI Endpoints" from the "API Provider" dropdown.
3.  **Enter API Key:** Paste your AI Endpoints API key into the "OVHCloud AI Endpoints API Key" field.
4.  **Select Model:** Choose your desired model from the "Model" dropdown.

You can then try a model, for example `Qwen2.5-Coder-32B-Instruct`. It wasn't working before.

## Get in Touch

You can contact me on Kilo Code Discord! My username is `eliqsx`! 😄 

Thank you very much for taking your time to review my PR!
