### PR TITLE
Disable JetBrains publish

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -110,10 +110,11 @@ jobs:
     publish-jetbrains:
         runs-on: ubuntu-latest
         if: >
+            false && (
             ( github.event_name == 'pull_request' &&
             github.event.pull_request.base.ref == 'main' &&
             contains(github.event.pull_request.title, 'Changeset version bump') ) ||
-            github.event_name == 'workflow_dispatch'
+            github.event_name == 'workflow_dispatch' )
         steps:
             - name: Checkout code
               uses: actions/checkout@v4


### PR DESCRIPTION
Disable JetBrains publish while we figure out why we have versions stuck in the approval pipeline.