### PR TITLE
fix(chat): add right margin to message content area for code blocks

### DIFF
--- a/.changeset/common-parts-argue.md
+++ b/.changeset/common-parts-argue.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+add right margin to message content area for code blocks

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1135,6 +1135,7 @@ export const ChatRowContent = ({
 								<MessageCircle className="w-4 shrink-0" aria-label="Speech bubble icon" />
 								<span style={{ fontWeight: "bold" }}>{t("chat:text.rooSaid")}</span>
 							</div>
+							{/* kilocode_change: mr */}
 							<div className="pl-6 mr-6">
 								<Markdown markdown={message.text} partial={message.partial} />
 								{message.images && message.images.length > 0 && (

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1135,7 +1135,7 @@ export const ChatRowContent = ({
 								<MessageCircle className="w-4 shrink-0" aria-label="Speech bubble icon" />
 								<span style={{ fontWeight: "bold" }}>{t("chat:text.rooSaid")}</span>
 							</div>
-							<div className="pl-6">
+							<div className="pl-6 mr-6">
 								<Markdown markdown={message.text} partial={message.partial} />
 								{message.images && message.images.length > 0 && (
 									<div style={{ marginTop: "10px" }}>


### PR DESCRIPTION
fix(chat): add right margin to message content area for code blocks to create more distance between the scroll bars.

## Context

Scroll bars for code blocks are too close to the main scroll bars.

## Implementation

Minor tailwind adjustments


## Screenshots
<img width="552" height="528" alt="Screenshot 2025-10-13 at 3 02 53 PM" src="https://github.com/user-attachments/assets/c990f4d8-2bee-4d63-aacc-8f8dafa56aff" />



## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
