### PR TITLE
Revert "fix(webview): improve conditional model loading logic"

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1969,13 +1969,10 @@ export class ClineProvider
 			uriScheme: vscode.env.uriScheme,
 			uiKind: vscode.UIKind[vscode.env.uiKind], // kilocode_change
 			kiloCodeWrapperProperties, // kilocode_change wrapper information
-			kilocodeDefaultModel:
-				apiConfiguration.apiProvider === "kilocode"
-					? await getKilocodeDefaultModel(
-							apiConfiguration.kilocodeToken,
-							apiConfiguration.kilocodeOrganizationId,
-						)
-					: openRouterDefaultModelId,
+			kilocodeDefaultModel: await getKilocodeDefaultModel(
+				apiConfiguration.kilocodeToken,
+				apiConfiguration.kilocodeOrganizationId,
+			),
 			currentTaskItem: this.getCurrentTask()?.taskId
 				? (taskHistory || []).find((item: HistoryItem) => item.id === this.getCurrentTask()?.taskId)
 				: undefined,
@@ -2203,13 +2200,10 @@ export class ClineProvider
 		// Return the same structure as before.
 		return {
 			apiConfiguration: providerSettings,
-			kilocodeDefaultModel:
-				providerSettings.apiProvider === "kilocode"
-					? await getKilocodeDefaultModel(
-							providerSettings.kilocodeToken,
-							providerSettings.kilocodeOrganizationId,
-						)
-					: openRouterDefaultModelId, // kilocode_change
+			kilocodeDefaultModel: await getKilocodeDefaultModel(
+				providerSettings.kilocodeToken,
+				providerSettings.kilocodeOrganizationId,
+			), // kilocode_change
 			lastShownAnnouncementId: stateValues.lastShownAnnouncementId,
 			customInstructions: stateValues.customInstructions,
 			apiModelId: stateValues.apiModelId,


### PR DESCRIPTION
Reverts Kilo-Org/kilocode#2537

Since this change I notice the Kilo Code model being reset to Sonnet 4 occasionally, which is not what we want. I also don't think the original reasoning is accurate, because no connection will be made when there's no Kilo Code token: https://github.com/Kilo-Org/kilocode/blob/10efb386c676b5254c0638e0e726489fdb12a4bd/src/api/providers/kilocode/getKilocodeDefaultModel.ts#L65