### PR TITLE
webview-ui watches too many files to the point my OS ran out of file …

### DIFF
--- a/packages/build/src/esbuild.ts
+++ b/packages/build/src/esbuild.ts
@@ -192,12 +192,10 @@ export function setupLocaleWatcher(srcDir: string, distDir: string) {
 	}
 
 	try {
-		fs.watch(localesDir, { recursive: true }, (_eventType, filename) => {
-			if (filename && filename.endsWith(".json")) {
-				console.log(`Locale file ${filename} changed, triggering copy...`)
-				debouncedCopy()
-			}
-		})
+		// it isn't necessary to watch i18n files here because it's handled much more robustly in the vite watch, just need to configure it
+		// to actually do so
+		debouncedCopy()
+
 		console.log("Watcher for locale files is set up")
 	} catch (error) {
 		console.error(

--- a/packages/build/src/esbuild.ts
+++ b/packages/build/src/esbuild.ts
@@ -192,10 +192,12 @@ export function setupLocaleWatcher(srcDir: string, distDir: string) {
 	}
 
 	try {
-		// it isn't necessary to watch i18n files here because it's handled much more robustly in the vite watch, just need to configure it
-		// to actually do so
-		debouncedCopy()
-
+		fs.watch(localesDir, { recursive: true }, (_eventType, filename) => {
+			if (filename && filename.endsWith(".json")) {
+				console.log(`Locale file ${filename} changed, triggering copy...`)
+				debouncedCopy()
+			}
+		})
 		console.log("Watcher for locale files is set up")
 	} catch (error) {
 		console.error(

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -165,6 +165,10 @@ export default defineConfig(({ mode }) => {
 		},
 		server: {
 			host: "0.0.0.0", // kilocode_change
+			fs: {
+				// Allow serving files from parent directories for locale watching
+				allow: ["..", "../src/i18n/locales"],
+			},
 			watch: {
 				usePolling: false,
 				ignored: [
@@ -184,9 +188,8 @@ export default defineConfig(({ mode }) => {
 					"../src/__mocks__/**",
 					"src/**/__tests__/**",
 					"src/**/__mocks__/**",
-					// Exclude all non-TS/JS files
+					// Exclude all non-TS/JS files EXCEPT locale JSON files
 					"../**/*.md",
-					"../**/*.json",
 					"../**/*.yml",
 					"../**/*.yaml",
 					"../**/*.txt",
@@ -204,6 +207,8 @@ export default defineConfig(({ mode }) => {
 					"src/**/*.css",
 					"src/**/*.scss",
 					"src/**/*.less",
+					"src/i18n/locales/**",
+					"!../src/i18n/locales",
 					// Exclude packages directory (build artifacts)
 					"../packages/**/dist/**",
 					"../packages/**/build/**",

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -165,6 +165,57 @@ export default defineConfig(({ mode }) => {
 		},
 		server: {
 			host: "0.0.0.0", // kilocode_change
+			watch: {
+				// Use polling to reduce file watcher usage
+				usePolling: true,
+				interval: 1000,
+				ignored: [
+					"**/node_modules/**",
+					"**/dist/**",
+					"**/.git/**",
+					"**/logs/**",
+					"**/.turbo/**",
+					"**/coverage/**",
+					"**/.nyc_output/**",
+					// Exclude asset directories (static files don't need watching)
+					"../src/assets/**",
+					"../src/i18n/locales/**",
+					// Exclude test utilities and build artifacts
+					"../src/test-llm-autocompletion/**",
+					"../src/walkthrough/**",
+					"../src/__tests__/**",
+					"../src/__mocks__/**",
+					// Exclude all non-TS/JS files
+					"../**/*.md",
+					"../**/*.json",
+					"../**/*.yml",
+					"../**/*.yaml",
+					"../**/*.txt",
+					"../**/*.log",
+					"../**/*.png",
+					"../**/*.jpg",
+					"../**/*.jpeg",
+					"../**/*.gif",
+					"../**/*.svg",
+					"../**/*.ico",
+					"../**/*.woff",
+					"../**/*.woff2",
+					"../**/*.ttf",
+					"../**/*.eot",
+					// Exclude packages directory (build artifacts)
+					"../packages/**/dist/**",
+					"../packages/**/build/**",
+					// Exclude apps directory
+					"../apps/**",
+					// Exclude other non-essential directories
+					"../benchmark/**",
+					"../jetbrains/**",
+					"../launch/**",
+					"../releases/**",
+					"../run/**",
+					"../scripts/**",
+				],
+			},
 			hmr: {
 				// host: "localhost", kilocode_change
 				protocol: "ws",

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -166,9 +166,7 @@ export default defineConfig(({ mode }) => {
 		server: {
 			host: "0.0.0.0", // kilocode_change
 			watch: {
-				// Use polling to reduce file watcher usage
-				usePolling: true,
-				interval: 1000,
+				usePolling: false,
 				ignored: [
 					"**/node_modules/**",
 					"**/dist/**",
@@ -179,12 +177,13 @@ export default defineConfig(({ mode }) => {
 					"**/.nyc_output/**",
 					// Exclude asset directories (static files don't need watching)
 					"../src/assets/**",
-					"../src/i18n/locales/**",
 					// Exclude test utilities and build artifacts
 					"../src/test-llm-autocompletion/**",
 					"../src/walkthrough/**",
 					"../src/__tests__/**",
 					"../src/__mocks__/**",
+					"src/**/__tests__/**",
+					"src/**/__mocks__/**",
 					// Exclude all non-TS/JS files
 					"../**/*.md",
 					"../**/*.json",
@@ -202,6 +201,9 @@ export default defineConfig(({ mode }) => {
 					"../**/*.woff2",
 					"../**/*.ttf",
 					"../**/*.eot",
+					"src/**/*.css",
+					"src/**/*.scss",
+					"src/**/*.less",
 					// Exclude packages directory (build artifacts)
 					"../packages/**/dist/**",
 					"../packages/**/build/**",


### PR DESCRIPTION
The webview-ui vite server watches too many files to the point of consuming ALL os file watchers, and when it hits that limit the dev server can't start which means the ui never loads. This change restricts it to only watch files that might potentially require build steps, and switches to polling method to make it less aggressive.
