### PR TITLE
remove the waiting animation

### DIFF
--- a/src/services/ghost/GhostGutterAnimation.ts
+++ b/src/services/ghost/GhostGutterAnimation.ts
@@ -2,17 +2,11 @@ import * as vscode from "vscode"
 import type { GhostServiceSettings } from "@roo-code/types"
 
 export class GhostGutterAnimation {
-	private state: "hide" | "wait" | "active" = "hide"
-	private decorationWait: vscode.TextEditorDecorationType
+	private state: "hide" | "active" = "hide"
 	private decorationActive: vscode.TextEditorDecorationType
 	private isEnabled: boolean = true
 
 	public constructor(context: vscode.ExtensionContext) {
-		this.decorationWait = vscode.window.createTextEditorDecorationType({
-			gutterIconPath: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "logo-outline-black.gif"),
-			gutterIconSize: "30px",
-			isWholeLine: false,
-		})
 		this.decorationActive = vscode.window.createTextEditorDecorationType({
 			gutterIconPath: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "logo-outline-yellow.gif"),
 			gutterIconSize: "30px",
@@ -31,7 +25,6 @@ export class GhostGutterAnimation {
 		const editor = vscode.window.activeTextEditor
 		if (editor) {
 			editor.setDecorations(this.decorationActive, [])
-			editor.setDecorations(this.decorationWait, [])
 		}
 	}
 
@@ -54,18 +47,7 @@ export class GhostGutterAnimation {
 		}
 
 		const position = this.getPosition(editor)
-		if (this.state == "wait") {
-			editor.setDecorations(this.decorationActive, [])
-			editor.setDecorations(this.decorationWait, [position])
-			return
-		}
-		editor.setDecorations(this.decorationWait, [])
 		editor.setDecorations(this.decorationActive, [position])
-	}
-
-	public wait() {
-		this.state = "wait"
-		this.update()
 	}
 
 	public active() {
@@ -81,8 +63,6 @@ export class GhostGutterAnimation {
 	public dispose() {
 		const editor = vscode.window.activeTextEditor
 		editor?.setDecorations(this.decorationActive, [])
-		editor?.setDecorations(this.decorationWait, [])
-		this.decorationWait.dispose()
 		this.decorationActive.dispose()
 	}
 }

--- a/src/services/ghost/GhostProvider.ts
+++ b/src/services/ghost/GhostProvider.ts
@@ -671,7 +671,6 @@ export class GhostProvider {
 	}
 
 	private startProcessing() {
-		this.cursorAnimation.wait()
 		this.isProcessing = true
 		this.updateGlobalContext()
 	}


### PR DESCRIPTION
only show an animation once we kick off a LLM request, removed the animation for when we are waiting before we do so. This way the interface stays a bit cleaner and less distracting
