### PR TITLE
Disable streaming parsing

### DIFF
--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -203,7 +203,6 @@ function mapNormalizedToOriginalIndex(
 export class GhostStreamingParser {
 	public buffer: string = ""
 	private completedChanges: ParsedChange[] = []
-	private lastProcessedIndex: number = 0
 	private context: GhostSuggestionContext | null = null
 	private streamFinished: boolean = false
 
@@ -223,7 +222,6 @@ export class GhostStreamingParser {
 	public reset(): void {
 		this.buffer = ""
 		this.completedChanges = []
-		this.lastProcessedIndex = 0
 		this.streamFinished = false
 	}
 
@@ -300,7 +298,7 @@ export class GhostStreamingParser {
 		const newChanges: ParsedChange[] = []
 
 		// Look for complete <change> blocks starting from where we left off
-		const searchText = this.buffer.substring(this.lastProcessedIndex)
+		const searchText = this.buffer
 
 		// Updated regex to handle both single-line XML format and traditional format with whitespace
 		const changeRegex =
@@ -323,11 +321,6 @@ export class GhostStreamingParser {
 			})
 
 			lastMatchEnd = match.index + match[0].length
-		}
-
-		// Update our processed index to avoid re-processing the same content
-		if (lastMatchEnd > 0) {
-			this.lastProcessedIndex += lastMatchEnd
 		}
 
 		return newChanges

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -238,6 +238,11 @@ export class GhostStreamingParser {
 		// Add chunk to buffer
 		this.buffer += chunk
 
+		if (!this.streamFinished) {
+			// do not stream
+			this.generateSuggestions(new Array<ParsedChange>())
+		}
+
 		// Extract any newly completed changes from the current buffer
 		const newChanges = this.extractCompletedChanges()
 

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -237,10 +237,15 @@ export class GhostStreamingParser {
 
 		// Add chunk to buffer
 		this.buffer += chunk
+		this.generateSuggestions(new Array<ParsedChange>())
+	}
 
-		if (!this.streamFinished) {
-			// do not stream
-			this.generateSuggestions(new Array<ParsedChange>())
+	/**
+	 * Process a new chunk of text and return any newly completed suggestions
+	 */
+	public processResult(): StreamingParseResult {
+		if (!this.context) {
+			throw new Error("Parser not initialized. Call initialize() first.")
 		}
 
 		// Extract any newly completed changes from the current buffer
@@ -285,7 +290,7 @@ export class GhostStreamingParser {
 	 */
 	public finishStream(): StreamingParseResult {
 		this.streamFinished = true
-		return this.processChunk("")
+		return this.processResult()
 	}
 
 	/**


### PR DESCRIPTION
The time spent is mostly in the LLM, and this makes it impossible to decide whether we have one result or multipel, and we want to decide based on that how to show the changes. We would want inline ghost completions if there is only one at least
