### PR TITLE
Validate config.json on init

### DIFF
--- a/cli/src/config/__tests__/persistence-merge.test.ts
+++ b/cli/src/config/__tests__/persistence-merge.test.ts
@@ -64,10 +64,11 @@ describe("Config Persistence - Merge with Defaults", () => {
 
 		await fs.writeFile(testFile, JSON.stringify(partialConfig, null, 2))
 
-		const loaded = await loadConfig()
+		const result = await loadConfig()
 
-		expect(loaded.autoApproval).toBeDefined()
-		expect(loaded.autoApproval).toEqual(DEFAULT_AUTO_APPROVAL)
+		expect(result.config.autoApproval).toBeDefined()
+		expect(result.config.autoApproval).toEqual(DEFAULT_AUTO_APPROVAL)
+		expect(result.validation.valid).toBe(true)
 	})
 
 	it("should fill missing autoApproval nested keys with defaults", async () => {
@@ -96,16 +97,17 @@ describe("Config Persistence - Merge with Defaults", () => {
 
 		await fs.writeFile(testFile, JSON.stringify(partialConfig, null, 2))
 
-		const loaded = await loadConfig()
+		const result = await loadConfig()
 
-		expect(loaded.autoApproval?.enabled).toBe(true)
-		expect(loaded.autoApproval?.read?.enabled).toBe(false)
-		expect(loaded.autoApproval?.read?.outside).toBe(DEFAULT_AUTO_APPROVAL.read?.outside)
-		expect(loaded.autoApproval?.write).toEqual(DEFAULT_AUTO_APPROVAL.write)
-		expect(loaded.autoApproval?.browser).toEqual(DEFAULT_AUTO_APPROVAL.browser)
-		expect(loaded.autoApproval?.retry).toEqual(DEFAULT_AUTO_APPROVAL.retry)
-		expect(loaded.autoApproval?.execute).toEqual(DEFAULT_AUTO_APPROVAL.execute)
-		expect(loaded.autoApproval?.question).toEqual(DEFAULT_AUTO_APPROVAL.question)
+		expect(result.config.autoApproval?.enabled).toBe(true)
+		expect(result.config.autoApproval?.read?.enabled).toBe(false)
+		expect(result.config.autoApproval?.read?.outside).toBe(DEFAULT_AUTO_APPROVAL.read?.outside)
+		expect(result.config.autoApproval?.write).toEqual(DEFAULT_AUTO_APPROVAL.write)
+		expect(result.config.autoApproval?.browser).toEqual(DEFAULT_AUTO_APPROVAL.browser)
+		expect(result.config.autoApproval?.retry).toEqual(DEFAULT_AUTO_APPROVAL.retry)
+		expect(result.config.autoApproval?.execute).toEqual(DEFAULT_AUTO_APPROVAL.execute)
+		expect(result.config.autoApproval?.question).toEqual(DEFAULT_AUTO_APPROVAL.question)
+		expect(result.validation.valid).toBe(true)
 	})
 
 	it("should preserve existing values while filling missing ones", async () => {
@@ -135,20 +137,21 @@ describe("Config Persistence - Merge with Defaults", () => {
 
 		await fs.writeFile(testFile, JSON.stringify(partialConfig, null, 2))
 
-		const loaded = await loadConfig()
+		const result = await loadConfig()
 
 		// Custom values should be preserved
-		expect(loaded.mode).toBe("architect")
-		expect(loaded.telemetry).toBe(false)
-		expect(loaded.autoApproval?.enabled).toBe(true)
-		expect(loaded.autoApproval?.execute?.enabled).toBe(true)
-		expect(loaded.autoApproval?.execute?.allowed).toEqual(["npm", "git"])
-		expect(loaded.autoApproval?.execute?.denied).toEqual(["rm -rf"])
+		expect(result.config.mode).toBe("architect")
+		expect(result.config.telemetry).toBe(false)
+		expect(result.config.autoApproval?.enabled).toBe(true)
+		expect(result.config.autoApproval?.execute?.enabled).toBe(true)
+		expect(result.config.autoApproval?.execute?.allowed).toEqual(["npm", "git"])
+		expect(result.config.autoApproval?.execute?.denied).toEqual(["rm -rf"])
 
 		// Missing values should be filled with defaults
-		expect(loaded.autoApproval?.read).toEqual(DEFAULT_AUTO_APPROVAL.read)
-		expect(loaded.autoApproval?.write).toEqual(DEFAULT_AUTO_APPROVAL.write)
-		expect(loaded.autoApproval?.retry).toEqual(DEFAULT_AUTO_APPROVAL.retry)
+		expect(result.config.autoApproval?.read).toEqual(DEFAULT_AUTO_APPROVAL.read)
+		expect(result.config.autoApproval?.write).toEqual(DEFAULT_AUTO_APPROVAL.write)
+		expect(result.config.autoApproval?.retry).toEqual(DEFAULT_AUTO_APPROVAL.retry)
+		expect(result.validation.valid).toBe(true)
 	})
 
 	it("should save merged config back to file", async () => {
@@ -211,11 +214,12 @@ describe("Config Persistence - Merge with Defaults", () => {
 
 		await fs.writeFile(testFile, JSON.stringify(partialConfig, null, 2))
 
-		const loaded = await loadConfig()
+		const result = await loadConfig()
 
-		expect(loaded.autoApproval?.retry?.enabled).toBe(true)
-		expect(loaded.autoApproval?.retry?.delay).toBe(DEFAULT_AUTO_APPROVAL.retry?.delay)
-		expect(loaded.autoApproval?.question?.enabled).toBe(DEFAULT_AUTO_APPROVAL.question?.enabled)
-		expect(loaded.autoApproval?.question?.timeout).toBe(DEFAULT_AUTO_APPROVAL.question?.timeout)
+		expect(result.config.autoApproval?.retry?.enabled).toBe(true)
+		expect(result.config.autoApproval?.retry?.delay).toBe(DEFAULT_AUTO_APPROVAL.retry?.delay)
+		expect(result.config.autoApproval?.question?.enabled).toBe(DEFAULT_AUTO_APPROVAL.question?.enabled)
+		expect(result.config.autoApproval?.question?.timeout).toBe(DEFAULT_AUTO_APPROVAL.question?.timeout)
+		expect(result.validation.valid).toBe(true)
 	})
 })

--- a/cli/src/config/__tests__/persistence-merge.test.ts
+++ b/cli/src/config/__tests__/persistence-merge.test.ts
@@ -56,7 +56,7 @@ describe("Config Persistence - Merge with Defaults", () => {
 				{
 					id: "default",
 					provider: "kilocode",
-					kilocodeToken: "",
+					kilocodeToken: "valid-token-1234567890",
 					kilocodeModel: "anthropic/claude-sonnet-4",
 				},
 			],
@@ -81,7 +81,7 @@ describe("Config Persistence - Merge with Defaults", () => {
 				{
 					id: "default",
 					provider: "kilocode",
-					kilocodeToken: "",
+					kilocodeToken: "valid-token-1234567890",
 					kilocodeModel: "anthropic/claude-sonnet-4",
 				},
 			],
@@ -119,7 +119,7 @@ describe("Config Persistence - Merge with Defaults", () => {
 				{
 					id: "default",
 					provider: "kilocode",
-					kilocodeToken: "test-token",
+					kilocodeToken: "test-token-1234567890",
 					kilocodeModel: "anthropic/claude-sonnet-4",
 				},
 			],
@@ -162,7 +162,7 @@ describe("Config Persistence - Merge with Defaults", () => {
 				{
 					id: "default",
 					provider: "kilocode",
-					kilocodeToken: "",
+					kilocodeToken: "valid-token-1234567890",
 					kilocodeModel: "anthropic/claude-sonnet-4",
 				},
 			],
@@ -193,7 +193,7 @@ describe("Config Persistence - Merge with Defaults", () => {
 				{
 					id: "default",
 					provider: "kilocode",
-					kilocodeToken: "",
+					kilocodeToken: "valid-token-1234567890",
 					kilocodeModel: "anthropic/claude-sonnet-4",
 				},
 			],

--- a/cli/src/config/__tests__/persistence-provider-merge.test.ts
+++ b/cli/src/config/__tests__/persistence-provider-merge.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import * as fs from "fs/promises"
+import * as path from "path"
+import { loadConfig, setConfigPaths, resetConfigPaths } from "../persistence.js"
+import type { CLIConfig } from "../types.js"
+
+// Mock the validation module
+vi.mock("../validation.js", () => ({
+	validateConfig: vi.fn().mockResolvedValue({ valid: true }),
+}))
+
+describe("Provider Merging", () => {
+	const testDir = path.join(process.cwd(), "test-config-provider-merge")
+	const testFile = path.join(testDir, "config.json")
+
+	beforeEach(async () => {
+		await fs.mkdir(testDir, { recursive: true })
+		setConfigPaths(testDir, testFile)
+	})
+
+	afterEach(async () => {
+		resetConfigPaths()
+		await fs.rm(testDir, { recursive: true, force: true })
+	})
+
+	it("should merge provider field from defaults when missing in loaded config", async () => {
+		// Create a config file without the provider field in the provider object
+		const configWithoutProviderField = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "default",
+			providers: [
+				{
+					id: "default",
+					// Missing 'provider' field
+					kilocodeToken: "test-token-1234567890",
+					kilocodeModel: "anthropic/claude-sonnet-4.5",
+				},
+			],
+			theme: "dark",
+		}
+
+		await fs.writeFile(testFile, JSON.stringify(configWithoutProviderField, null, 2))
+
+		// Load the config - it should merge with defaults
+		const result = await loadConfig()
+
+		// Check that the provider field was added from defaults
+		expect(result.config.providers[0]).toHaveProperty("provider")
+		expect(result.config.providers[0].provider).toBe("kilocode")
+		expect(result.config.providers[0].id).toBe("default")
+		expect(result.config.providers[0].kilocodeToken).toBe("test-token-1234567890")
+		expect(result.config.providers[0].kilocodeModel).toBe("anthropic/claude-sonnet-4.5")
+		expect(result.validation.valid).toBe(true)
+	})
+
+	it("should preserve provider field when present in loaded config", async () => {
+		// Create a config file with the provider field
+		const configWithProviderField: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "default",
+			providers: [
+				{
+					id: "default",
+					provider: "kilocode",
+					kilocodeToken: "test-token-1234567890",
+					kilocodeModel: "anthropic/claude-sonnet-4.5",
+				},
+			],
+			theme: "dark",
+		}
+
+		await fs.writeFile(testFile, JSON.stringify(configWithProviderField, null, 2))
+
+		// Load the config
+		const result = await loadConfig()
+
+		// Check that the provider field is preserved
+		expect(result.config.providers[0].provider).toBe("kilocode")
+		expect(result.config.providers[0].id).toBe("default")
+		expect(result.config.providers[0].kilocodeToken).toBe("test-token-1234567890")
+		expect(result.validation.valid).toBe(true)
+	})
+
+	it("should handle providers with different ids", async () => {
+		// Create a config with a provider that doesn't match default id
+		const configWithDifferentId = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "custom",
+			providers: [
+				{
+					id: "custom",
+					// Missing 'provider' field
+					kilocodeToken: "test-token-1234567890",
+					kilocodeModel: "anthropic/claude-sonnet-4.5",
+				},
+			],
+			theme: "dark",
+		}
+
+		await fs.writeFile(testFile, JSON.stringify(configWithDifferentId, null, 2))
+
+		// Load the config
+		const result = await loadConfig()
+
+		// Since there's no matching default provider with id "custom",
+		// the provider field won't be added automatically
+		// This will be caught by validation
+		expect(result.config.providers[0].id).toBe("custom")
+	})
+})

--- a/cli/src/config/__tests__/persistence.test.ts
+++ b/cli/src/config/__tests__/persistence.test.ts
@@ -87,8 +87,11 @@ describe("Config Persistence", () => {
 
 	describe("loadConfig", () => {
 		it("should create default config if file doesn't exist", async () => {
-			const config = await loadConfig()
-			expect(config).toEqual(DEFAULT_CONFIG)
+			const result = await loadConfig()
+			expect(result.config).toEqual(DEFAULT_CONFIG)
+			// Default config has empty credentials, so validation should fail
+			expect(result.validation.valid).toBe(false)
+			expect(result.validation.errors).toBeDefined()
 		})
 
 		it("should load existing config from file", async () => {
@@ -110,8 +113,33 @@ describe("Config Persistence", () => {
 			}
 
 			await saveConfig(testConfig)
-			const loaded = await loadConfig()
-			expect(loaded).toEqual(testConfig)
+			const result = await loadConfig()
+			expect(result.config).toEqual(testConfig)
+			expect(result.validation.valid).toBe(true)
+		})
+
+		it("should return validation errors for invalid config", async () => {
+			const invalidConfig = {
+				...DEFAULT_CONFIG,
+				provider: "test-provider",
+				providers: [
+					{
+						id: "test-provider",
+						provider: "anthropic",
+						apiKey: "", // Empty API key should fail validation
+						apiModelId: "claude-3-5-sonnet-20241022",
+					},
+				],
+			}
+
+			// Write invalid config directly to file (bypassing saveConfig validation)
+			await ensureConfigDir()
+			await fs.writeFile(TEST_CONFIG_FILE, JSON.stringify(invalidConfig, null, 2))
+
+			const result = await loadConfig()
+			expect(result.validation.valid).toBe(false)
+			expect(result.validation.errors).toBeDefined()
+			expect(result.validation.errors!.length).toBeGreaterThan(0)
 		})
 	})
 

--- a/cli/src/config/__tests__/persistence.test.ts
+++ b/cli/src/config/__tests__/persistence.test.ts
@@ -102,7 +102,7 @@ describe("Config Persistence", () => {
 					{
 						id: "test-provider",
 						provider: "anthropic",
-						apiKey: "test-key",
+						apiKey: "test-key-1234567890",
 						apiModelId: "claude-3-5-sonnet-20241022",
 					},
 				],
@@ -126,7 +126,7 @@ describe("Config Persistence", () => {
 					{
 						id: "test",
 						provider: "kilocode",
-						kilocodeToken: "test-token",
+						kilocodeToken: "test-token-1234567890",
 						kilocodeModel: "test-model",
 					},
 				],
@@ -139,7 +139,18 @@ describe("Config Persistence", () => {
 		})
 
 		it("should format JSON with proper indentation", async () => {
-			await saveConfig(DEFAULT_CONFIG)
+			const validConfig: CLIConfig = {
+				...DEFAULT_CONFIG,
+				providers: [
+					{
+						id: "default",
+						provider: "kilocode",
+						kilocodeToken: "valid-token-1234567890",
+						kilocodeModel: "anthropic/claude-sonnet-4.5",
+					},
+				],
+			}
+			await saveConfig(validConfig)
 			const content = await fs.readFile(TEST_CONFIG_FILE, "utf-8")
 			expect(content).toContain("\n")
 			expect(content).toContain("  ")
@@ -153,7 +164,18 @@ describe("Config Persistence", () => {
 		})
 
 		it("should return true if config exists", async () => {
-			await saveConfig(DEFAULT_CONFIG)
+			const validConfig: CLIConfig = {
+				...DEFAULT_CONFIG,
+				providers: [
+					{
+						id: "default",
+						provider: "kilocode",
+						kilocodeToken: "valid-token-1234567890",
+						kilocodeModel: "anthropic/claude-sonnet-4.5",
+					},
+				],
+			}
+			await saveConfig(validConfig)
 			const exists = await configExists()
 			expect(exists).toBe(true)
 		})

--- a/cli/src/config/__tests__/validation.test.ts
+++ b/cli/src/config/__tests__/validation.test.ts
@@ -1,0 +1,463 @@
+import { describe, it, expect, vi } from "vitest"
+import { validateConfig, validateProviderConfig, validateSelectedProvider } from "../validation.js"
+import type { CLIConfig, ProviderConfig } from "../types.js"
+
+// Mock fs/promises
+vi.mock("fs/promises", () => ({
+	readFile: vi.fn().mockResolvedValue(
+		JSON.stringify({
+			type: "object",
+			properties: {
+				version: { type: "string" },
+				mode: { type: "string" },
+				telemetry: { type: "boolean" },
+				provider: { type: "string" },
+				providers: { type: "array" },
+			},
+			required: ["version", "mode", "telemetry", "provider", "providers"],
+		}),
+	),
+}))
+
+describe("validateProviderConfig", () => {
+	it("should return error when provider type is missing", () => {
+		const provider = { id: "test" } as ProviderConfig
+		const result = validateProviderConfig(provider)
+		expect(result.valid).toBe(false)
+		expect(result.errors).toContain("Provider type is required")
+	})
+
+	describe("kilocode provider", () => {
+		it("should validate valid kilocode provider (not selected)", () => {
+			const provider: ProviderConfig = {
+				id: "test-kilocode",
+				provider: "kilocode",
+				kilocodeToken: "valid-token-123",
+				kilocodeModel: "claude-3-5-sonnet",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(true)
+		})
+
+		it("should allow empty credentials for non-selected provider", () => {
+			const provider: ProviderConfig = {
+				id: "test-kilocode",
+				provider: "kilocode",
+				kilocodeToken: "",
+				kilocodeModel: "claude-3-5-sonnet",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(true)
+		})
+
+		it("should reject empty credentials for selected provider", () => {
+			const provider: ProviderConfig = {
+				id: "test-kilocode",
+				provider: "kilocode",
+				kilocodeToken: "",
+				kilocodeModel: "claude-3-5-sonnet",
+			}
+			const result = validateProviderConfig(provider, true)
+			expect(result.valid).toBe(false)
+			expect(result.errors?.[0]).toContain("kilocodeToken is required and cannot be empty")
+		})
+
+		it("should return error for missing kilocodeToken", () => {
+			const provider: ProviderConfig = {
+				id: "test-kilocode",
+				provider: "kilocode",
+				kilocodeModel: "claude-3-5-sonnet",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(false)
+			expect(result.errors).toContain("kilocodeToken must be a string")
+		})
+
+		it("should return error for short kilocodeToken", () => {
+			const provider: ProviderConfig = {
+				id: "test-kilocode",
+				provider: "kilocode",
+				kilocodeToken: "short",
+				kilocodeModel: "claude-3-5-sonnet",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(false)
+			expect(result.errors?.[0]).toContain("kilocodeToken must be at least 10 characters long")
+		})
+
+		it("should return error for missing kilocodeModel", () => {
+			const provider: ProviderConfig = {
+				id: "test-kilocode",
+				provider: "kilocode",
+				kilocodeToken: "valid-token-123",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(false)
+			expect(result.errors).toContain("kilocodeModel must be a string")
+		})
+	})
+
+	describe("anthropic provider", () => {
+		it("should validate valid anthropic provider", () => {
+			const provider: ProviderConfig = {
+				id: "test-anthropic",
+				provider: "anthropic",
+				apiKey: "sk-ant-valid-key-123",
+				apiModelId: "claude-3-5-sonnet-20241022",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(true)
+		})
+
+		it("should allow empty credentials for non-selected provider", () => {
+			const provider: ProviderConfig = {
+				id: "test-anthropic",
+				provider: "anthropic",
+				apiKey: "",
+				apiModelId: "claude-3-5-sonnet-20241022",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(true)
+		})
+
+		it("should reject empty credentials for selected provider", () => {
+			const provider: ProviderConfig = {
+				id: "test-anthropic",
+				provider: "anthropic",
+				apiKey: "",
+				apiModelId: "claude-3-5-sonnet-20241022",
+			}
+			const result = validateProviderConfig(provider, true)
+			expect(result.valid).toBe(false)
+			expect(result.errors?.[0]).toContain("apiKey is required and cannot be empty")
+		})
+
+		it("should return error for missing apiKey", () => {
+			const provider: ProviderConfig = {
+				id: "test-anthropic",
+				provider: "anthropic",
+				apiModelId: "claude-3-5-sonnet-20241022",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(false)
+			expect(result.errors).toContain("apiKey must be a string")
+		})
+
+		it("should return error for short apiKey", () => {
+			const provider: ProviderConfig = {
+				id: "test-anthropic",
+				provider: "anthropic",
+				apiKey: "short",
+				apiModelId: "claude-3-5-sonnet-20241022",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(false)
+			expect(result.errors?.[0]).toContain("apiKey must be at least 10 characters long")
+		})
+	})
+
+	describe("openai-native provider", () => {
+		it("should validate valid openai-native provider", () => {
+			const provider: ProviderConfig = {
+				id: "test-openai",
+				provider: "openai-native",
+				openAiNativeApiKey: "sk-valid-key-123",
+				apiModelId: "gpt-4",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(true)
+		})
+
+		it("should return error for missing openAiNativeApiKey", () => {
+			const provider: ProviderConfig = {
+				id: "test-openai",
+				provider: "openai-native",
+				apiModelId: "gpt-4",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(false)
+			expect(result.errors).toContain("openAiNativeApiKey must be a string")
+		})
+	})
+
+	describe("ollama provider", () => {
+		it("should validate valid ollama provider", () => {
+			const provider: ProviderConfig = {
+				id: "test-ollama",
+				provider: "ollama",
+				ollamaBaseUrl: "http://localhost:11434",
+				ollamaModelId: "llama2",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(true)
+		})
+
+		it("should return error for missing ollamaBaseUrl", () => {
+			const provider: ProviderConfig = {
+				id: "test-ollama",
+				provider: "ollama",
+				ollamaModelId: "llama2",
+			}
+			const result = validateProviderConfig(provider, false)
+			expect(result.valid).toBe(false)
+			expect(result.errors).toContain("ollamaBaseUrl must be a string")
+		})
+	})
+})
+
+describe("validateConfig", () => {
+	it("should validate a valid config", async () => {
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "test-provider",
+			providers: [
+				{
+					id: "test-provider",
+					provider: "anthropic",
+					apiKey: "sk-ant-valid-key-123",
+					apiModelId: "claude-3-5-sonnet-20241022",
+				},
+			],
+		}
+		const result = await validateConfig(config)
+		expect(result.valid).toBe(true)
+	})
+
+	it("should return error for invalid provider config", async () => {
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "test-provider",
+			providers: [
+				{
+					id: "test-provider",
+					provider: "anthropic",
+					apiKey: "short", // Too short
+					apiModelId: "claude-3-5-sonnet-20241022",
+				},
+			],
+		}
+		const result = await validateConfig(config)
+		expect(result.valid).toBe(false)
+		expect(result.errors?.[0]).toContain("Provider 'test-provider'")
+		expect(result.errors?.[0]).toContain("apiKey must be at least 10 characters long")
+	})
+
+	it("should validate multiple providers with empty credentials for non-selected", async () => {
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "provider1",
+			providers: [
+				{
+					id: "provider1",
+					provider: "anthropic",
+					apiKey: "sk-ant-valid-key-123",
+					apiModelId: "claude-3-5-sonnet-20241022",
+				},
+				{
+					id: "provider2",
+					provider: "kilocode",
+					kilocodeToken: "", // Empty is OK for non-selected provider
+					kilocodeModel: "claude-3-5-sonnet",
+				},
+			],
+		}
+		const result = await validateConfig(config)
+		expect(result.valid).toBe(true)
+	})
+
+	it("should reject config when selected provider has empty credentials", async () => {
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "provider1",
+			providers: [
+				{
+					id: "provider1",
+					provider: "kilocode",
+					kilocodeToken: "", // Empty is NOT OK for selected provider
+					kilocodeModel: "claude-3-5-sonnet",
+				},
+			],
+		}
+		const result = await validateConfig(config)
+		expect(result.valid).toBe(false)
+		expect(result.errors?.[0]).toContain("Provider 'provider1'")
+		expect(result.errors?.[0]).toContain("kilocodeToken is required and cannot be empty")
+	})
+
+	it("should return errors for multiple invalid providers", async () => {
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "provider1",
+			providers: [
+				{
+					id: "provider1",
+					provider: "anthropic",
+					apiKey: "short", // Invalid
+					apiModelId: "claude-3-5-sonnet-20241022",
+				},
+				{
+					id: "provider2",
+					provider: "kilocode",
+					kilocodeToken: "short", // Invalid
+					kilocodeModel: "claude-3-5-sonnet",
+				},
+			],
+		}
+		const result = await validateConfig(config)
+		expect(result.valid).toBe(false)
+		expect(result.errors?.length).toBeGreaterThan(0)
+		expect(result.errors?.some((e) => e.includes("provider1"))).toBe(true)
+		expect(result.errors?.some((e) => e.includes("provider2"))).toBe(true)
+	})
+
+	it("should validate selected provider exists", async () => {
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "non-existent",
+			providers: [
+				{
+					id: "provider1",
+					provider: "anthropic",
+					apiKey: "sk-ant-valid-key-123",
+					apiModelId: "claude-3-5-sonnet-20241022",
+				},
+			],
+		}
+		const result = await validateConfig(config)
+		expect(result.valid).toBe(false)
+		expect(result.errors?.[0]).toContain("Selected provider 'non-existent' not found")
+	})
+
+	it("should validate selected provider configuration", async () => {
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "provider1",
+			providers: [
+				{
+					id: "provider1",
+					provider: "anthropic",
+					apiKey: "short", // Invalid
+					apiModelId: "claude-3-5-sonnet-20241022",
+				},
+				{
+					id: "provider2",
+					provider: "kilocode",
+					kilocodeToken: "valid-token-123",
+					kilocodeModel: "claude-3-5-sonnet",
+				},
+			],
+		}
+		const result = await validateConfig(config)
+		expect(result.valid).toBe(false)
+		// Should catch the error during provider validation
+		expect(result.errors?.some((e) => e.includes("provider1"))).toBe(true)
+	})
+
+	it("should return error when no provider is selected", async () => {
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "",
+			providers: [
+				{
+					id: "provider1",
+					provider: "anthropic",
+					apiKey: "sk-ant-valid-key-123",
+					apiModelId: "claude-3-5-sonnet-20241022",
+				},
+			],
+		}
+		const result = await validateConfig(config)
+		expect(result.valid).toBe(false)
+		expect(result.errors).toContain("No provider selected in configuration")
+	})
+})
+
+describe("validateSelectedProvider", () => {
+	it("should validate when selected provider exists and is valid", () => {
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "test-provider",
+			providers: [
+				{
+					id: "test-provider",
+					provider: "anthropic",
+					apiKey: "sk-ant-valid-key-123",
+					apiModelId: "claude-3-5-sonnet-20241022",
+				},
+			],
+		}
+		const result = validateSelectedProvider(config)
+		expect(result.valid).toBe(true)
+	})
+
+	it("should return error when no provider is selected", () => {
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "",
+			providers: [],
+		}
+		const result = validateSelectedProvider(config)
+		expect(result.valid).toBe(false)
+		expect(result.errors).toContain("No provider selected in configuration")
+	})
+
+	it("should return error when selected provider is not found", () => {
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "non-existent",
+			providers: [
+				{
+					id: "test-provider",
+					provider: "anthropic",
+					apiKey: "sk-ant-valid-key-123",
+					apiModelId: "claude-3-5-sonnet-20241022",
+				},
+			],
+		}
+		const result = validateSelectedProvider(config)
+		expect(result.valid).toBe(false)
+		expect(result.errors?.[0]).toContain("Selected provider 'non-existent' not found")
+	})
+
+	it("should return error when selected provider config is invalid", () => {
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "test-provider",
+			providers: [
+				{
+					id: "test-provider",
+					provider: "anthropic",
+					apiKey: "short", // Invalid
+					apiModelId: "claude-3-5-sonnet-20241022",
+				},
+			],
+		}
+		const result = validateSelectedProvider(config)
+		expect(result.valid).toBe(false)
+		expect(result.errors?.[0]).toContain("apiKey must be at least 10 characters long")
+	})
+})

--- a/cli/src/config/__tests__/validation.test.ts
+++ b/cli/src/config/__tests__/validation.test.ts
@@ -1,207 +1,53 @@
 import { describe, it, expect, vi } from "vitest"
 import { validateConfig, validateProviderConfig, validateSelectedProvider } from "../validation.js"
 import type { CLIConfig, ProviderConfig } from "../types.js"
+import * as fs from "fs/promises"
+import * as path from "path"
+import { fileURLToPath } from "url"
 
-// Mock fs/promises
-vi.mock("fs/promises", () => ({
-	readFile: vi.fn().mockResolvedValue(
-		JSON.stringify({
-			type: "object",
-			properties: {
-				version: { type: "string" },
-				mode: { type: "string" },
-				telemetry: { type: "boolean" },
-				provider: { type: "string" },
-				providers: { type: "array" },
-			},
-			required: ["version", "mode", "telemetry", "provider", "providers"],
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// Mock fs/promises to return the actual schema
+vi.mock("fs/promises", async () => {
+	const actual = await vi.importActual<typeof fs>("fs/promises")
+	return {
+		...actual,
+		readFile: vi.fn(async (filePath: string) => {
+			// If it's the schema file, read the actual schema
+			if (filePath.includes("schema.json")) {
+				const schemaPath = path.join(__dirname, "..", "schema.json")
+				return actual.readFile(schemaPath, "utf-8")
+			}
+			return actual.readFile(filePath, "utf-8")
 		}),
-	),
-}))
+	}
+})
 
 describe("validateProviderConfig", () => {
-	it("should return error when provider type is missing", () => {
-		const provider = { id: "test" } as ProviderConfig
-		const result = validateProviderConfig(provider)
-		expect(result.valid).toBe(false)
-		expect(result.errors).toContain("Provider type is required")
+	it("should always return valid since schema handles all validations", () => {
+		// validateProviderConfig is now a stub that always returns valid
+		// All validations are handled by the JSON schema
+		const provider: ProviderConfig = {
+			id: "test-kilocode",
+			provider: "kilocode",
+			kilocodeToken: "valid-token-123",
+			kilocodeModel: "claude-3-5-sonnet",
+		}
+		const result = validateProviderConfig(provider, false)
+		expect(result.valid).toBe(true)
 	})
 
-	describe("kilocode provider", () => {
-		it("should validate valid kilocode provider (not selected)", () => {
-			const provider: ProviderConfig = {
-				id: "test-kilocode",
-				provider: "kilocode",
-				kilocodeToken: "valid-token-123",
-				kilocodeModel: "claude-3-5-sonnet",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(true)
-		})
-
-		it("should allow empty credentials for non-selected provider", () => {
-			const provider: ProviderConfig = {
-				id: "test-kilocode",
-				provider: "kilocode",
-				kilocodeToken: "",
-				kilocodeModel: "claude-3-5-sonnet",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(true)
-		})
-
-		it("should reject empty credentials for selected provider", () => {
-			const provider: ProviderConfig = {
-				id: "test-kilocode",
-				provider: "kilocode",
-				kilocodeToken: "",
-				kilocodeModel: "claude-3-5-sonnet",
-			}
-			const result = validateProviderConfig(provider, true)
-			expect(result.valid).toBe(false)
-			expect(result.errors?.[0]).toContain("kilocodeToken is required and cannot be empty")
-		})
-
-		it("should return error for missing kilocodeToken", () => {
-			const provider: ProviderConfig = {
-				id: "test-kilocode",
-				provider: "kilocode",
-				kilocodeModel: "claude-3-5-sonnet",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(false)
-			expect(result.errors).toContain("kilocodeToken must be a string")
-		})
-
-		it("should return error for short kilocodeToken", () => {
-			const provider: ProviderConfig = {
-				id: "test-kilocode",
-				provider: "kilocode",
-				kilocodeToken: "short",
-				kilocodeModel: "claude-3-5-sonnet",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(false)
-			expect(result.errors?.[0]).toContain("kilocodeToken must be at least 10 characters long")
-		})
-
-		it("should return error for missing kilocodeModel", () => {
-			const provider: ProviderConfig = {
-				id: "test-kilocode",
-				provider: "kilocode",
-				kilocodeToken: "valid-token-123",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(false)
-			expect(result.errors).toContain("kilocodeModel must be a string")
-		})
-	})
-
-	describe("anthropic provider", () => {
-		it("should validate valid anthropic provider", () => {
-			const provider: ProviderConfig = {
-				id: "test-anthropic",
-				provider: "anthropic",
-				apiKey: "sk-ant-valid-key-123",
-				apiModelId: "claude-3-5-sonnet-20241022",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(true)
-		})
-
-		it("should allow empty credentials for non-selected provider", () => {
-			const provider: ProviderConfig = {
-				id: "test-anthropic",
-				provider: "anthropic",
-				apiKey: "",
-				apiModelId: "claude-3-5-sonnet-20241022",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(true)
-		})
-
-		it("should reject empty credentials for selected provider", () => {
-			const provider: ProviderConfig = {
-				id: "test-anthropic",
-				provider: "anthropic",
-				apiKey: "",
-				apiModelId: "claude-3-5-sonnet-20241022",
-			}
-			const result = validateProviderConfig(provider, true)
-			expect(result.valid).toBe(false)
-			expect(result.errors?.[0]).toContain("apiKey is required and cannot be empty")
-		})
-
-		it("should return error for missing apiKey", () => {
-			const provider: ProviderConfig = {
-				id: "test-anthropic",
-				provider: "anthropic",
-				apiModelId: "claude-3-5-sonnet-20241022",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(false)
-			expect(result.errors).toContain("apiKey must be a string")
-		})
-
-		it("should return error for short apiKey", () => {
-			const provider: ProviderConfig = {
-				id: "test-anthropic",
-				provider: "anthropic",
-				apiKey: "short",
-				apiModelId: "claude-3-5-sonnet-20241022",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(false)
-			expect(result.errors?.[0]).toContain("apiKey must be at least 10 characters long")
-		})
-	})
-
-	describe("openai-native provider", () => {
-		it("should validate valid openai-native provider", () => {
-			const provider: ProviderConfig = {
-				id: "test-openai",
-				provider: "openai-native",
-				openAiNativeApiKey: "sk-valid-key-123",
-				apiModelId: "gpt-4",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(true)
-		})
-
-		it("should return error for missing openAiNativeApiKey", () => {
-			const provider: ProviderConfig = {
-				id: "test-openai",
-				provider: "openai-native",
-				apiModelId: "gpt-4",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(false)
-			expect(result.errors).toContain("openAiNativeApiKey must be a string")
-		})
-	})
-
-	describe("ollama provider", () => {
-		it("should validate valid ollama provider", () => {
-			const provider: ProviderConfig = {
-				id: "test-ollama",
-				provider: "ollama",
-				ollamaBaseUrl: "http://localhost:11434",
-				ollamaModelId: "llama2",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(true)
-		})
-
-		it("should return error for missing ollamaBaseUrl", () => {
-			const provider: ProviderConfig = {
-				id: "test-ollama",
-				provider: "ollama",
-				ollamaModelId: "llama2",
-			}
-			const result = validateProviderConfig(provider, false)
-			expect(result.valid).toBe(false)
-			expect(result.errors).toContain("ollamaBaseUrl must be a string")
-		})
+	it("should return valid even for invalid data (schema validates this)", () => {
+		// This function no longer validates - schema does it
+		const provider: ProviderConfig = {
+			id: "test-kilocode",
+			provider: "kilocode",
+			kilocodeToken: "short",
+			kilocodeModel: "claude-3-5-sonnet",
+		}
+		const result = validateProviderConfig(provider, false)
+		expect(result.valid).toBe(true)
 	})
 })
 
@@ -225,7 +71,7 @@ describe("validateConfig", () => {
 		expect(result.valid).toBe(true)
 	})
 
-	it("should return error for invalid provider config", async () => {
+	it("should return error for invalid provider config (schema validation)", async () => {
 		const config: CLIConfig = {
 			version: "1.0.0",
 			mode: "code",
@@ -235,15 +81,15 @@ describe("validateConfig", () => {
 				{
 					id: "test-provider",
 					provider: "anthropic",
-					apiKey: "short", // Too short
+					apiKey: "short", // Too short - schema will catch this
 					apiModelId: "claude-3-5-sonnet-20241022",
 				},
 			],
 		}
 		const result = await validateConfig(config)
 		expect(result.valid).toBe(false)
-		expect(result.errors?.[0]).toContain("Provider 'test-provider'")
-		expect(result.errors?.[0]).toContain("apiKey must be at least 10 characters long")
+		// Schema validation error format
+		expect(result.errors?.some((e) => e.includes("apiKey"))).toBe(true)
 	})
 
 	it("should validate multiple providers with empty credentials for non-selected", async () => {
@@ -271,7 +117,7 @@ describe("validateConfig", () => {
 		expect(result.valid).toBe(true)
 	})
 
-	it("should reject config when selected provider has empty credentials", async () => {
+	it("should reject config when selected provider has empty credentials (schema validation)", async () => {
 		const config: CLIConfig = {
 			version: "1.0.0",
 			mode: "code",
@@ -281,18 +127,18 @@ describe("validateConfig", () => {
 				{
 					id: "provider1",
 					provider: "kilocode",
-					kilocodeToken: "", // Empty is NOT OK for selected provider
+					kilocodeToken: "", // Empty is NOT OK - schema minLength will catch this
 					kilocodeModel: "claude-3-5-sonnet",
 				},
 			],
 		}
 		const result = await validateConfig(config)
 		expect(result.valid).toBe(false)
-		expect(result.errors?.[0]).toContain("Provider 'provider1'")
-		expect(result.errors?.[0]).toContain("kilocodeToken is required and cannot be empty")
+		// Schema validation error
+		expect(result.errors?.some((e) => e.includes("kilocodeToken"))).toBe(true)
 	})
 
-	it("should return errors for multiple invalid providers", async () => {
+	it("should return errors for multiple invalid providers (schema validation)", async () => {
 		const config: CLIConfig = {
 			version: "1.0.0",
 			mode: "code",
@@ -302,13 +148,13 @@ describe("validateConfig", () => {
 				{
 					id: "provider1",
 					provider: "anthropic",
-					apiKey: "short", // Invalid
+					apiKey: "short", // Invalid - schema will catch
 					apiModelId: "claude-3-5-sonnet-20241022",
 				},
 				{
 					id: "provider2",
 					provider: "kilocode",
-					kilocodeToken: "short", // Invalid
+					kilocodeToken: "short", // Invalid - schema will catch
 					kilocodeModel: "claude-3-5-sonnet",
 				},
 			],
@@ -316,8 +162,8 @@ describe("validateConfig", () => {
 		const result = await validateConfig(config)
 		expect(result.valid).toBe(false)
 		expect(result.errors?.length).toBeGreaterThan(0)
-		expect(result.errors?.some((e) => e.includes("provider1"))).toBe(true)
-		expect(result.errors?.some((e) => e.includes("provider2"))).toBe(true)
+		// Schema will report errors for the invalid fields
+		expect(result.errors?.some((e) => e.includes("apiKey") || e.includes("kilocodeToken"))).toBe(true)
 	})
 
 	it("should validate selected provider exists", async () => {
@@ -340,7 +186,7 @@ describe("validateConfig", () => {
 		expect(result.errors?.[0]).toContain("Selected provider 'non-existent' not found")
 	})
 
-	it("should validate selected provider configuration", async () => {
+	it("should validate selected provider configuration (schema validation)", async () => {
 		const config: CLIConfig = {
 			version: "1.0.0",
 			mode: "code",
@@ -350,7 +196,7 @@ describe("validateConfig", () => {
 				{
 					id: "provider1",
 					provider: "anthropic",
-					apiKey: "short", // Invalid
+					apiKey: "short", // Invalid - schema will catch
 					apiModelId: "claude-3-5-sonnet-20241022",
 				},
 				{
@@ -363,8 +209,8 @@ describe("validateConfig", () => {
 		}
 		const result = await validateConfig(config)
 		expect(result.valid).toBe(false)
-		// Should catch the error during provider validation
-		expect(result.errors?.some((e) => e.includes("provider1"))).toBe(true)
+		// Schema validation error
+		expect(result.errors?.some((e) => e.includes("apiKey"))).toBe(true)
 	})
 
 	it("should return error when no provider is selected", async () => {
@@ -441,7 +287,7 @@ describe("validateSelectedProvider", () => {
 		expect(result.errors?.[0]).toContain("Selected provider 'non-existent' not found")
 	})
 
-	it("should return error when selected provider config is invalid", () => {
+	it("should return valid even for invalid config (schema validates this)", () => {
 		const config: CLIConfig = {
 			version: "1.0.0",
 			mode: "code",
@@ -451,13 +297,13 @@ describe("validateSelectedProvider", () => {
 				{
 					id: "test-provider",
 					provider: "anthropic",
-					apiKey: "short", // Invalid
+					apiKey: "short", // Invalid but validateProviderConfig no longer checks
 					apiModelId: "claude-3-5-sonnet-20241022",
 				},
 			],
 		}
 		const result = validateSelectedProvider(config)
-		expect(result.valid).toBe(false)
-		expect(result.errors?.[0]).toContain("apiKey must be at least 10 characters long")
+		// validateProviderConfig always returns valid now
+		expect(result.valid).toBe(true)
 	})
 })

--- a/cli/src/config/schema.json
+++ b/cli/src/config/schema.json
@@ -274,11 +274,44 @@
 					},
 					"then": {
 						"properties": {
-							"kilocodeToken": { "type": "string" },
-							"kilocodeModel": { "type": "string" },
+							"kilocodeToken": {
+								"type": "string",
+								"description": "Kilocode API token"
+							},
+							"kilocodeModel": {
+								"type": "string",
+								"description": "Kilocode model ID"
+							},
 							"kilocodeOrganizationId": { "type": "string" }
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"provider": { "const": "kilocode" },
+							"kilocodeToken": { "type": "string", "minLength": 1 }
 						},
-						"required": ["kilocodeToken", "kilocodeModel"]
+						"required": ["kilocodeToken"]
+					},
+					"then": {
+						"properties": {
+							"kilocodeToken": { "minLength": 10 }
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"provider": { "const": "kilocode" },
+							"kilocodeModel": { "type": "string", "minLength": 1 }
+						},
+						"required": ["kilocodeModel"]
+					},
+					"then": {
+						"properties": {
+							"kilocodeModel": { "minLength": 1 }
+						}
 					}
 				},
 				{
@@ -287,11 +320,44 @@
 					},
 					"then": {
 						"properties": {
-							"apiKey": { "type": "string" },
-							"apiModelId": { "type": "string" },
+							"apiKey": {
+								"type": "string",
+								"description": "Anthropic API key"
+							},
+							"apiModelId": {
+								"type": "string",
+								"description": "Anthropic model ID"
+							},
 							"anthropicBaseUrl": { "type": "string" }
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"provider": { "const": "anthropic" },
+							"apiKey": { "type": "string", "minLength": 1 }
 						},
-						"required": ["apiKey", "apiModelId"]
+						"required": ["apiKey"]
+					},
+					"then": {
+						"properties": {
+							"apiKey": { "minLength": 10 }
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"provider": { "const": "anthropic" },
+							"apiModelId": { "type": "string", "minLength": 1 }
+						},
+						"required": ["apiModelId"]
+					},
+					"then": {
+						"properties": {
+							"apiModelId": { "minLength": 1 }
+						}
 					}
 				},
 				{
@@ -300,11 +366,30 @@
 					},
 					"then": {
 						"properties": {
-							"openAiNativeApiKey": { "type": "string" },
-							"apiModelId": { "type": "string" },
+							"openAiNativeApiKey": {
+								"type": "string",
+								"description": "OpenAI Native API key"
+							},
+							"apiModelId": {
+								"type": "string",
+								"description": "OpenAI model ID"
+							},
 							"openAiNativeBaseUrl": { "type": "string" }
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"provider": { "const": "openai-native" },
+							"openAiNativeApiKey": { "type": "string", "minLength": 1 }
 						},
-						"required": ["openAiNativeApiKey", "apiModelId"]
+						"required": ["openAiNativeApiKey"]
+					},
+					"then": {
+						"properties": {
+							"openAiNativeApiKey": { "minLength": 10 }
+						}
 					}
 				},
 				{
@@ -313,11 +398,44 @@
 					},
 					"then": {
 						"properties": {
-							"openRouterApiKey": { "type": "string" },
-							"openRouterModelId": { "type": "string" },
+							"openRouterApiKey": {
+								"type": "string",
+								"description": "OpenRouter API key"
+							},
+							"openRouterModelId": {
+								"type": "string",
+								"description": "OpenRouter model ID"
+							},
 							"openRouterBaseUrl": { "type": "string" }
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"provider": { "const": "openrouter" },
+							"openRouterApiKey": { "type": "string", "minLength": 1 }
 						},
-						"required": ["openRouterApiKey", "openRouterModelId"]
+						"required": ["openRouterApiKey"]
+					},
+					"then": {
+						"properties": {
+							"openRouterApiKey": { "minLength": 10 }
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"provider": { "const": "openrouter" },
+							"openRouterModelId": { "type": "string", "minLength": 1 }
+						},
+						"required": ["openRouterModelId"]
+					},
+					"then": {
+						"properties": {
+							"openRouterModelId": { "minLength": 1 }
+						}
 					}
 				},
 				{
@@ -326,11 +444,44 @@
 					},
 					"then": {
 						"properties": {
-							"ollamaBaseUrl": { "type": "string" },
-							"ollamaModelId": { "type": "string" },
+							"ollamaBaseUrl": {
+								"type": "string",
+								"description": "Ollama base URL"
+							},
+							"ollamaModelId": {
+								"type": "string",
+								"description": "Ollama model ID"
+							},
 							"ollamaApiKey": { "type": "string" }
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"provider": { "const": "ollama" },
+							"ollamaBaseUrl": { "type": "string", "minLength": 1 }
 						},
-						"required": ["ollamaBaseUrl", "ollamaModelId"]
+						"required": ["ollamaBaseUrl"]
+					},
+					"then": {
+						"properties": {
+							"ollamaBaseUrl": { "minLength": 1 }
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"provider": { "const": "ollama" },
+							"ollamaModelId": { "type": "string", "minLength": 1 }
+						},
+						"required": ["ollamaModelId"]
+					},
+					"then": {
+						"properties": {
+							"ollamaModelId": { "minLength": 1 }
+						}
 					}
 				},
 				{
@@ -339,11 +490,27 @@
 					},
 					"then": {
 						"properties": {
-							"openAiApiKey": { "type": "string" },
+							"openAiApiKey": {
+								"type": "string",
+								"description": "OpenAI API key"
+							},
 							"openAiBaseUrl": { "type": "string" },
 							"apiModelId": { "type": "string" }
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"provider": { "const": "openai" },
+							"openAiApiKey": { "type": "string", "minLength": 1 }
 						},
 						"required": ["openAiApiKey"]
+					},
+					"then": {
+						"properties": {
+							"openAiApiKey": { "minLength": 10 }
+						}
 					}
 				}
 			]

--- a/cli/src/config/validation.ts
+++ b/cli/src/config/validation.ts
@@ -1,12 +1,13 @@
 import Ajv from "ajv"
 import * as fs from "fs/promises"
 import * as path from "path"
+import type { CLIConfig, ProviderConfig } from "./types.js"
 
 // __dirname is provided by the banner in the bundled output
 declare const __dirname: string
 
 let ajv: Ajv | null = null
-let validateFunction: any = null
+let validateFunction: ReturnType<Ajv["compile"]> | null = null
 
 async function getValidator() {
 	if (!validateFunction) {
@@ -30,11 +31,37 @@ export async function validateConfig(config: unknown): Promise<ValidationResult>
 		const valid = validate(config)
 
 		if (!valid) {
-			const errors = validate.errors?.map((err: any) => {
-				const path = err.instancePath || "root"
-				return `${path}: ${err.message}`
-			})
+			const errors =
+				validate.errors?.map((err) => {
+					const path = err.instancePath || "root"
+					return `${path}: ${err.message}`
+				}) || []
 			return { valid: false, errors }
+		}
+
+		// After schema validation, validate provider configurations
+		if (config && typeof config === "object" && "providers" in config) {
+			const cliConfig = config as CLIConfig
+			const providerErrors: string[] = []
+
+			// Validate each provider configuration (allow empty for non-selected providers)
+			for (const provider of cliConfig.providers) {
+				const isSelected = provider.id === cliConfig.provider
+				const providerResult = validateProviderConfig(provider, isSelected)
+				if (!providerResult.valid && providerResult.errors) {
+					providerErrors.push(...providerResult.errors.map((err) => `Provider '${provider.id}': ${err}`))
+				}
+			}
+
+			if (providerErrors.length > 0) {
+				return { valid: false, errors: providerErrors }
+			}
+
+			// Validate the selected provider exists
+			const selectedProviderResult = validateSelectedProvider(cliConfig)
+			if (!selectedProviderResult.valid) {
+				return selectedProviderResult
+			}
 		}
 
 		return { valid: true }
@@ -44,4 +71,166 @@ export async function validateConfig(config: unknown): Promise<ValidationResult>
 			errors: [`Validation error: ${error instanceof Error ? error.message : String(error)}`],
 		}
 	}
+}
+
+/**
+ * Minimum length for API keys and tokens
+ */
+const MIN_API_KEY_LENGTH = 10
+
+/**
+ * Validates that a string field is non-empty and meets minimum length requirements
+ * @param value - The value to validate
+ * @param fieldName - The name of the field for error messages
+ * @param minLength - Minimum length requirement
+ * @param allowEmpty - Whether to allow empty strings (for unconfigured providers)
+ */
+function validateStringField(
+	value: unknown,
+	fieldName: string,
+	minLength: number = 1,
+	allowEmpty: boolean = true,
+): string | null {
+	if (typeof value !== "string") {
+		return `${fieldName} must be a string`
+	}
+	// Check if empty strings are allowed
+	if (value.length === 0) {
+		return allowEmpty ? null : `${fieldName} is required and cannot be empty`
+	}
+	// If not empty, check minimum length
+	if (value.length < minLength) {
+		return `${fieldName} must be at least ${minLength} characters long`
+	}
+	return null
+}
+
+/**
+ * Validates provider-specific configuration based on provider type
+ * @param provider - The provider configuration to validate
+ * @param isSelected - Whether this is the currently selected provider (requires non-empty credentials)
+ */
+export function validateProviderConfig(provider: ProviderConfig, isSelected: boolean = false): ValidationResult {
+	const errors: string[] = []
+
+	// Check provider type exists
+	if (!provider.provider) {
+		return {
+			valid: false,
+			errors: ["Provider type is required"],
+		}
+	}
+
+	// Validate based on provider type
+	// For selected providers, empty credentials are not allowed
+	const allowEmpty = !isSelected
+
+	switch (provider.provider) {
+		case "kilocode": {
+			const tokenError = validateStringField(
+				provider.kilocodeToken,
+				"kilocodeToken",
+				MIN_API_KEY_LENGTH,
+				allowEmpty,
+			)
+			if (tokenError) errors.push(tokenError)
+
+			const modelError = validateStringField(provider.kilocodeModel, "kilocodeModel", 1, allowEmpty)
+			if (modelError) errors.push(modelError)
+			break
+		}
+
+		case "anthropic": {
+			const keyError = validateStringField(provider.apiKey, "apiKey", MIN_API_KEY_LENGTH, allowEmpty)
+			if (keyError) errors.push(keyError)
+
+			const modelError = validateStringField(provider.apiModelId, "apiModelId", 1, allowEmpty)
+			if (modelError) errors.push(modelError)
+			break
+		}
+
+		case "openai-native": {
+			const keyError = validateStringField(
+				provider.openAiNativeApiKey,
+				"openAiNativeApiKey",
+				MIN_API_KEY_LENGTH,
+				allowEmpty,
+			)
+			if (keyError) errors.push(keyError)
+
+			const modelError = validateStringField(provider.apiModelId, "apiModelId", 1, allowEmpty)
+			if (modelError) errors.push(modelError)
+			break
+		}
+
+		case "openrouter": {
+			const keyError = validateStringField(
+				provider.openRouterApiKey,
+				"openRouterApiKey",
+				MIN_API_KEY_LENGTH,
+				allowEmpty,
+			)
+			if (keyError) errors.push(keyError)
+
+			const modelError = validateStringField(provider.openRouterModelId, "openRouterModelId", 1, allowEmpty)
+			if (modelError) errors.push(modelError)
+			break
+		}
+
+		case "ollama": {
+			const urlError = validateStringField(provider.ollamaBaseUrl, "ollamaBaseUrl", 1, allowEmpty)
+			if (urlError) errors.push(urlError)
+
+			const modelError = validateStringField(provider.ollamaModelId, "ollamaModelId", 1, allowEmpty)
+			if (modelError) errors.push(modelError)
+			break
+		}
+
+		case "openai": {
+			const keyError = validateStringField(provider.openAiApiKey, "openAiApiKey", MIN_API_KEY_LENGTH, allowEmpty)
+			if (keyError) errors.push(keyError)
+			break
+		}
+
+		// Add more provider validations as needed
+		default:
+			// For other providers, just check if they have basic configuration
+			break
+	}
+
+	if (errors.length > 0) {
+		return {
+			valid: false,
+			errors,
+		}
+	}
+
+	return {
+		valid: true,
+	}
+}
+
+/**
+ * Validates the selected provider in the config
+ */
+export function validateSelectedProvider(config: CLIConfig): ValidationResult {
+	// Check if provider ID is set
+	if (!config.provider) {
+		return {
+			valid: false,
+			errors: ["No provider selected in configuration"],
+		}
+	}
+
+	// Find the selected provider
+	const selectedProvider = config.providers.find((p) => p.id === config.provider)
+	if (!selectedProvider) {
+		return {
+			valid: false,
+			errors: [`Selected provider '${config.provider}' not found in providers list`],
+		}
+	}
+
+	// Validate the provider configuration (must have non-empty credentials)
+	return validateProviderConfig(selectedProvider, true)
 }

--- a/cli/src/state/atoms/__tests__/config.test.ts
+++ b/cli/src/state/atoms/__tests__/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import { createStore } from "jotai"
-import { loadConfigAtom, configAtom } from "../config.js"
+import { loadConfigAtom, configAtom, configValidationAtom } from "../config.js"
 import * as persistence from "../../../config/persistence.js"
 
 // Mock the persistence module
@@ -23,13 +23,19 @@ describe("loadConfigAtom", () => {
 			telemetry: true,
 		}
 
-		vi.mocked(persistence.loadConfig).mockResolvedValue(mockConfig)
+		vi.mocked(persistence.loadConfig).mockResolvedValue({
+			config: mockConfig,
+			validation: { valid: true },
+		})
 
 		const store = createStore()
 		await store.set(loadConfigAtom)
 
 		const config = store.get(configAtom)
 		expect(config.mode).toBe("ask")
+
+		const validation = store.get(configValidationAtom)
+		expect(validation.valid).toBe(true)
 	})
 
 	it("should override mode when provided", async () => {
@@ -41,13 +47,19 @@ describe("loadConfigAtom", () => {
 			telemetry: true,
 		}
 
-		vi.mocked(persistence.loadConfig).mockResolvedValue(mockConfig)
+		vi.mocked(persistence.loadConfig).mockResolvedValue({
+			config: mockConfig,
+			validation: { valid: true },
+		})
 
 		const store = createStore()
 		await store.set(loadConfigAtom, "debug")
 
 		const config = store.get(configAtom)
 		expect(config.mode).toBe("debug")
+
+		const validation = store.get(configValidationAtom)
+		expect(validation.valid).toBe(true)
 	})
 
 	it("should not override mode when not provided", async () => {
@@ -59,12 +71,47 @@ describe("loadConfigAtom", () => {
 			telemetry: true,
 		}
 
-		vi.mocked(persistence.loadConfig).mockResolvedValue(mockConfig)
+		vi.mocked(persistence.loadConfig).mockResolvedValue({
+			config: mockConfig,
+			validation: { valid: true },
+		})
 
 		const store = createStore()
 		await store.set(loadConfigAtom, undefined)
 
 		const config = store.get(configAtom)
 		expect(config.mode).toBe("code")
+
+		const validation = store.get(configValidationAtom)
+		expect(validation.valid).toBe(true)
+	})
+
+	it("should store validation errors when config is invalid", async () => {
+		const mockConfig = {
+			version: "1.0.0" as const,
+			mode: "code",
+			provider: "test",
+			providers: [],
+			telemetry: true,
+		}
+
+		vi.mocked(persistence.loadConfig).mockResolvedValue({
+			config: mockConfig,
+			validation: {
+				valid: false,
+				errors: ["Provider 'test': apiKey is required and cannot be empty"],
+			},
+		})
+
+		const store = createStore()
+		await store.set(loadConfigAtom)
+
+		const config = store.get(configAtom)
+		expect(config).toEqual(mockConfig)
+
+		const validation = store.get(configValidationAtom)
+		expect(validation.valid).toBe(false)
+		expect(validation.errors).toHaveLength(1)
+		expect(validation.errors![0]).toContain("apiKey is required")
 	})
 })

--- a/cli/src/state/atoms/config.ts
+++ b/cli/src/state/atoms/config.ts
@@ -3,12 +3,15 @@ import type { CLIConfig, ProviderConfig } from "../../config/types.js"
 import { DEFAULT_CONFIG } from "../../config/defaults.js"
 import { loadConfig, saveConfig } from "../../config/persistence.js"
 import { mapConfigToExtensionState } from "../../config/mapper.js"
-import { validateConfig } from "../../config/validation.js"
+import type { ValidationResult } from "../../config/validation.js"
 import { logs } from "../../services/logs.js"
 import { getTelemetryService } from "../../services/telemetry/index.js"
 
 // Core config atom - holds the current configuration
 export const configAtom = atom<CLIConfig>(DEFAULT_CONFIG)
+
+// Validation result atom - holds the validation status of the current config
+export const configValidationAtom = atom<ValidationResult>({ valid: true })
 
 // Loading state atom
 export const configLoadingAtom = atom<boolean>(false)
@@ -37,12 +40,6 @@ export const themeAtom = atom((get) => {
 	return config.theme || "dark"
 })
 
-// Derived atom for general configuration validation
-export const configValidAtom = atom(async (get) => {
-	const config = get(configAtom)
-	return await validateConfig(config)
-})
-
 // Action atom to load config from disk
 // Accepts optional mode parameter to override the loaded config's mode
 export const loadConfigAtom = atom(null, async (get, set, mode?: string) => {
@@ -50,16 +47,25 @@ export const loadConfigAtom = atom(null, async (get, set, mode?: string) => {
 		set(configLoadingAtom, true)
 		set(configErrorAtom, null)
 
-		const config = await loadConfig()
+		const result = await loadConfig()
+
+		// Store validation result
+		set(configValidationAtom, result.validation)
 
 		// Override mode if provided (e.g., from CLI options)
-		const finalConfig = mode ? { ...config, mode } : config
+		const finalConfig = mode ? { ...result.config, mode } : result.config
 		set(configAtom, finalConfig)
 
-		logs.info("Config loaded successfully", "ConfigAtoms", { mode: finalConfig.mode })
-
-		// Track config loaded
-		getTelemetryService().trackConfigLoaded(finalConfig)
+		if (result.validation.valid) {
+			logs.info("Config loaded successfully", "ConfigAtoms", { mode: finalConfig.mode })
+			// Track config loaded
+			getTelemetryService().trackConfigLoaded(finalConfig)
+		} else {
+			logs.warn("Config loaded with validation errors", "ConfigAtoms", {
+				errors: result.validation.errors,
+				mode: finalConfig.mode,
+			})
+		}
 
 		return finalConfig
 	} catch (error) {

--- a/cli/src/state/atoms/config.ts
+++ b/cli/src/state/atoms/config.ts
@@ -3,6 +3,7 @@ import type { CLIConfig, ProviderConfig } from "../../config/types.js"
 import { DEFAULT_CONFIG } from "../../config/defaults.js"
 import { loadConfig, saveConfig } from "../../config/persistence.js"
 import { mapConfigToExtensionState } from "../../config/mapper.js"
+import { validateConfig } from "../../config/validation.js"
 import { logs } from "../../services/logs.js"
 import { getTelemetryService } from "../../services/telemetry/index.js"
 
@@ -34,6 +35,12 @@ export const modeAtom = atom((get) => {
 export const themeAtom = atom((get) => {
 	const config = get(configAtom)
 	return config.theme || "dark"
+})
+
+// Derived atom for general configuration validation
+export const configValidAtom = atom(async (get) => {
+	const config = get(configAtom)
+	return await validateConfig(config)
 })
 
 // Action atom to load config from disk

--- a/cli/src/ui/UI.tsx
+++ b/cli/src/ui/UI.tsx
@@ -8,7 +8,7 @@ import { Box, Text, useInput } from "ink"
 import { useAtomValue, useSetAtom } from "jotai"
 import { isStreamingAtom, errorAtom, addMessageAtom } from "../state/atoms/ui.js"
 import { setCIModeAtom } from "../state/atoms/ci.js"
-import { configValidAtom } from "../state/atoms/config.js"
+import { configValidationAtom } from "../state/atoms/config.js"
 import { MessageDisplay } from "./messages/MessageDisplay.js"
 import { CommandInput } from "./components/CommandInput.js"
 import { StatusBar } from "./components/StatusBar.js"
@@ -36,7 +36,7 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 	const isStreaming = useAtomValue(isStreamingAtom)
 	const error = useAtomValue(errorAtom)
 	const theme = useTheme()
-	const configValidation = useAtomValue(configValidAtom)
+	const configValidation = useAtomValue(configValidationAtom)
 
 	// Initialize CI mode configuration
 	const setCIMode = useSetAtom(setCIModeAtom)
@@ -139,7 +139,7 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 			welcomeShownRef.current = true
 			addMessage(
 				createWelcomeMessage({
-					clearScreen: !options.ci || !configValidation.valid,
+					clearScreen: !options.ci && configValidation.valid,
 					showInstructions: !options.ci || !options.prompt,
 					instructions: createConfigErrorInstructions(configValidation),
 				}),

--- a/cli/src/ui/UI.tsx
+++ b/cli/src/ui/UI.tsx
@@ -80,7 +80,7 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 			// Small delay for cleanup and final message display
 			setTimeout(() => {
 				onExit()
-			}, 100)
+			}, 500)
 		}
 	}, [shouldExit, exitReason, options.ci, onExit])
 
@@ -139,7 +139,7 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 			welcomeShownRef.current = true
 			addMessage(
 				createWelcomeMessage({
-					clearScreen: !options.ci,
+					clearScreen: !options.ci || !configValidation.valid,
 					showInstructions: !options.ci || !options.prompt,
 					instructions: createConfigErrorInstructions(configValidation),
 				}),
@@ -153,8 +153,8 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 			logs.error("Invalid configuration", "UI", { errors: configValidation.errors })
 			// Give time for the welcome message to render
 			setTimeout(() => {
-				process.exit(1)
-			}, 100)
+				onExit()
+			}, 500)
 		}
 	}, [configValidation])
 

--- a/cli/src/ui/UI.tsx
+++ b/cli/src/ui/UI.tsx
@@ -8,6 +8,7 @@ import { Box, Text, useInput } from "ink"
 import { useAtomValue, useSetAtom } from "jotai"
 import { isStreamingAtom, errorAtom, addMessageAtom } from "../state/atoms/ui.js"
 import { setCIModeAtom } from "../state/atoms/ci.js"
+import { configValidAtom } from "../state/atoms/config.js"
 import { MessageDisplay } from "./messages/MessageDisplay.js"
 import { CommandInput } from "./components/CommandInput.js"
 import { StatusBar } from "./components/StatusBar.js"
@@ -21,7 +22,7 @@ import { useCIMode } from "../state/hooks/useCIMode.js"
 import { useTheme } from "../state/hooks/useTheme.js"
 import { AppOptions } from "./App.js"
 import { logs } from "../services/logs.js"
-import { createWelcomeMessage } from "./utils/welcomeMessage.js"
+import { createConfigErrorInstructions, createWelcomeMessage } from "./utils/welcomeMessage.js"
 
 // Initialize commands on module load
 initializeCommands()
@@ -35,6 +36,7 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 	const isStreaming = useAtomValue(isStreamingAtom)
 	const error = useAtomValue(errorAtom)
 	const theme = useTheme()
+	const configValidation = useAtomValue(configValidAtom)
 
 	// Initialize CI mode configuration
 	const setCIMode = useSetAtom(setCIModeAtom)
@@ -93,7 +95,7 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 
 	// Execute prompt automatically on mount if provided
 	useEffect(() => {
-		if (options.prompt && !promptExecutedRef.current) {
+		if (options.prompt && !promptExecutedRef.current && configValidation.valid) {
 			promptExecutedRef.current = true
 			const trimmedPrompt = options.prompt.trim()
 
@@ -108,7 +110,7 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 				}
 			}
 		}
-	}, [options.prompt, executeCommand, sendUserMessage, onExit])
+	}, [options.prompt, executeCommand, sendUserMessage, onExit, configValidation])
 
 	// Simplified submit handler that delegates to appropriate hook
 	const handleSubmit = useCallback(
@@ -135,15 +137,26 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 	useEffect(() => {
 		if (!welcomeShownRef.current) {
 			welcomeShownRef.current = true
-
 			addMessage(
 				createWelcomeMessage({
 					clearScreen: !options.ci,
 					showInstructions: !options.ci || !options.prompt,
+					instructions: createConfigErrorInstructions(configValidation),
 				}),
 			)
 		}
-	}, [options.ci, options.prompt, addMessage])
+	}, [options.ci, options.prompt, addMessage, configValidation])
+
+	// Exit if provider configuration is invalid
+	useEffect(() => {
+		if (!configValidation.valid) {
+			logs.error("Invalid configuration", "UI", { errors: configValidation.errors })
+			// Give time for the welcome message to render
+			setTimeout(() => {
+				process.exit(1)
+			}, 100)
+		}
+	}, [configValidation])
 
 	return (
 		// Using stdout.rows causes layout shift during renders
@@ -158,7 +171,7 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 				</Box>
 			)}
 
-			{!options.ci && (
+			{!options.ci && configValidation.valid && (
 				<>
 					<StatusIndicator disabled={false} />
 					<CommandInput onSubmit={handleSubmit} disabled={isAnyOperationInProgress} />

--- a/cli/src/ui/messages/cli/WelcomeMessage.tsx
+++ b/cli/src/ui/messages/cli/WelcomeMessage.tsx
@@ -17,7 +17,8 @@ const DEFAULT_INSTRUCTIONS = [
 export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({ options = {} }) => {
 	const theme = useTheme()
 	const showInstructions = options.showInstructions !== false
-	const instructions = options.instructions || DEFAULT_INSTRUCTIONS
+	const instructions =
+		options.instructions && options.instructions.length > 0 ? options.instructions : DEFAULT_INSTRUCTIONS
 	const contentHeight = 12 + (showInstructions ? instructions.length : 0)
 	const marginTop = options.clearScreen ? Math.max(0, (stdout?.rows || 0) - contentHeight) : 0
 

--- a/cli/src/ui/utils/welcomeMessage.ts
+++ b/cli/src/ui/utils/welcomeMessage.ts
@@ -1,7 +1,40 @@
 import type { CliMessage, WelcomeMessageOptions } from "../../types/cli.js"
+import type { ValidationResult } from "../../config/validation.js"
+import { getConfigPath } from "../../config/persistence.js"
 
 // Counter to ensure unique IDs even when created in the same millisecond
 let messageCounter = 0
+
+/**
+ * Converts validation errors into user-friendly instructions
+ * @param validation - The validation result
+ * @returns Array of instruction strings
+ */
+export function createConfigErrorInstructions(validation: ValidationResult): string[] {
+	if (validation.valid) {
+		return []
+	}
+
+	const configPath = getConfigPath()
+	const instructions: string[] = ["Configuration Error: config.json is incomplete or invalid.\n", "Errors found:"]
+
+	// Add each validation error
+	if (validation.errors) {
+		validation.errors.forEach((error) => {
+			instructions.push(`  • ${error}`)
+		})
+	}
+
+	instructions.push(
+		"\nTo fix this issue:",
+		`  1. Run: kilocode config`,
+		`  2. Or edit: ${configPath}`,
+		"\n",
+		"The CLI will exit now. Please configure your Kilo Code and try again.",
+	)
+
+	return instructions
+}
 
 /**
  * Creates a welcome message with customizable options


### PR DESCRIPTION
## Context

Resolve: #3000 

## Implementation

- Enforce validation on the config.json
- Show the error as instructions
- Exit the cli when the config is invalid

## Screenshots

<img width="2330" height="996" alt="image" src="https://github.com/user-attachments/assets/de8b531b-0576-4016-8d79-959c8154e62f" />
<img width="2334" height="855" alt="image" src="https://github.com/user-attachments/assets/04bdd77e-54bb-4efe-9c85-1eb604bd0f5d" />



## How to Test

1. Remove your kilocodeToken from kilocode config
2. Run `kilocode "tell me more about this project"
