### PR TITLE
Tell Copilot not to bother with cli/jetbrains

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,7 +53,8 @@ let j = 3
 
 ### Kilocode specific file
 
-if the filename or directory name contains kilocode no marking with comments is required
+- if the filename or directory name contains kilocode no marking with comments is required
+- if the file lives inside of the jetbrains/ or cli/ root folder, no marking with comments is required
 
 ### New Files
 


### PR DESCRIPTION
I noticed that Copilot kept suggesting we add kilocode_change comments to the CLI folder.
