### PR TITLE
Fix CLI deps warnings

### DIFF
--- a/.changeset/fuzzy-jeans-accept.md
+++ b/.changeset/fuzzy-jeans-accept.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+CLI - Fix deprecated dependencies

--- a/cli/esbuild.config.mjs
+++ b/cli/esbuild.config.mjs
@@ -72,7 +72,6 @@ const __dirname = __dirname__(__filename);
 		"@anthropic-ai/vertex-sdk",
 		"@aws-sdk/client-bedrock-runtime",
 		"@aws-sdk/credential-providers",
-		"@cerebras/cerebras_cloud_sdk",
 		"@google/genai",
 		"@lmstudio/sdk",
 		"@mistralai/mistralai",

--- a/cli/esbuild.config.mjs
+++ b/cli/esbuild.config.mjs
@@ -148,7 +148,6 @@ const __dirname = __dirname__(__filename);
 		"socket.io-client",
 		"sound-play",
 		"stream-json",
-		"string-similarity",
 		"strip-ansi",
 		"strip-bom",
 		"tiktoken",

--- a/cli/package.dist.json
+++ b/cli/package.dist.json
@@ -94,7 +94,6 @@
 		"socket.io-client": "^4.8.1",
 		"sound-play": "^1.1.0",
 		"stream-json": "^1.8.0",
-		"string-similarity": "^4.0.4",
 		"strip-ansi": "^7.1.0",
 		"strip-bom": "^5.0.0",
 		"tiktoken": "^1.0.21",

--- a/cli/package.dist.json
+++ b/cli/package.dist.json
@@ -79,7 +79,7 @@
 		"pretty-bytes": "^7.0.0",
 		"proper-lockfile": "^4.1.2",
 		"ps-tree": "^1.2.0",
-		"puppeteer-chromium-resolver": "^24.0.0",
+		"puppeteer-chromium-resolver": "npm:@catrielmuller/puppeteer-chromium-resolver@24.0.2",
 		"puppeteer-core": "^23.4.0",
 		"react": "^19.2.0",
 		"react-devtools-core": "^6.1.5",
@@ -113,7 +113,8 @@
 	"overrides": {
 		"exceljs": {
 			"archiver": "^7.0.1",
-			"unzipper": "^0.12.3"
+			"unzipper": "^0.12.3",
+			"fast-csv": "^5.0.5"
 		},
 		"event-pubsub": {
 			"copyfiles": "npm:empty-module@0.0.2"

--- a/cli/package.dist.json
+++ b/cli/package.dist.json
@@ -14,7 +14,6 @@
 		"@anthropic-ai/vertex-sdk": "^0.11.3",
 		"@aws-sdk/client-bedrock-runtime": "^3.812.0",
 		"@aws-sdk/credential-providers": "^3.806.0",
-		"@cerebras/cerebras_cloud_sdk": "^1.35.0",
 		"@google/genai": "^1.0.0",
 		"@lmstudio/sdk": "^1.1.1",
 		"@mistralai/mistralai": "^1.9.18",

--- a/cli/package.dist.json
+++ b/cli/package.dist.json
@@ -111,6 +111,15 @@
 		"yaml": "^2.6.1",
 		"zod": "^3.25.61"
 	},
+	"overrides": {
+		"exceljs": {
+			"archiver": "^7.0.1",
+			"unzipper": "^0.12.3"
+		},
+		"event-pubsub": {
+			"copyfiles": "npm:empty-module@0.0.2"
+		}
+	},
 	"engines": {
 		"node": ">=20.19.2"
 	},

--- a/cli/package.json
+++ b/cli/package.json
@@ -30,7 +30,6 @@
 		"@anthropic-ai/vertex-sdk": "^0.11.3",
 		"@aws-sdk/client-bedrock-runtime": "^3.812.0",
 		"@aws-sdk/credential-providers": "^3.806.0",
-		"@cerebras/cerebras_cloud_sdk": "^1.35.0",
 		"@google/genai": "^1.0.0",
 		"@lmstudio/sdk": "^1.1.1",
 		"@mistralai/mistralai": "^1.9.18",

--- a/cli/package.json
+++ b/cli/package.json
@@ -96,7 +96,7 @@
 		"pretty-bytes": "^7.0.0",
 		"proper-lockfile": "^4.1.2",
 		"ps-tree": "^1.2.0",
-		"puppeteer-chromium-resolver": "^24.0.0",
+		"puppeteer-chromium-resolver": "npm:@catrielmuller/puppeteer-chromium-resolver@24.0.2",
 		"puppeteer-core": "^23.4.0",
 		"react": "^19.2.0",
 		"react-devtools-core": "^6.1.5",
@@ -130,7 +130,8 @@
 	"overrides": {
 		"exceljs": {
 			"archiver": "^7.0.1",
-			"unzipper": "^0.12.3"
+			"unzipper": "^0.12.3",
+			"fast-csv": "^5.0.5"
 		},
 		"event-pubsub": {
 			"copyfiles": "npm:empty-module@0.0.2"

--- a/cli/package.json
+++ b/cli/package.json
@@ -11,7 +11,7 @@
 	"scripts": {
 		"build": "node esbuild.config.mjs",
 		"dev": "pnpm build --watch",
-		"deps:install": "npm install --prefix ./dist",
+		"deps:install": "npm install --omit=dev --prefix ./dist",
 		"start": "node dist/index.js",
 		"clean": "rimraf dist",
 		"test": "vitest run",
@@ -127,6 +127,15 @@
 		"workerpool": "^9.2.0",
 		"yaml": "^2.6.1",
 		"zod": "^3.25.61"
+	},
+	"overrides": {
+		"exceljs": {
+			"archiver": "^7.0.1",
+			"unzipper": "^0.12.3"
+		},
+		"event-pubsub": {
+			"copyfiles": "npm:empty-module@0.0.2"
+		}
 	},
 	"devDependencies": {
 		"@roo-code/config-eslint": "workspace:^",

--- a/cli/package.json
+++ b/cli/package.json
@@ -111,7 +111,6 @@
 		"socket.io-client": "^4.8.1",
 		"sound-play": "^1.1.0",
 		"stream-json": "^1.8.0",
-		"string-similarity": "^4.0.4",
 		"strip-ansi": "^7.1.0",
 		"strip-bom": "^5.0.0",
 		"tiktoken": "^1.0.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,9 +582,6 @@ importers:
       '@aws-sdk/credential-providers':
         specifier: ^3.806.0
         version: 3.848.0
-      '@cerebras/cerebras_cloud_sdk':
-        specifier: ^1.35.0
-        version: 1.46.0
       '@google/genai':
         specifier: ^1.0.0
         version: 1.3.0(@modelcontextprotocol/sdk@1.12.0)
@@ -784,8 +781,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       puppeteer-chromium-resolver:
-        specifier: ^24.0.0
-        version: 24.0.1
+        specifier: npm:@catrielmuller/puppeteer-chromium-resolver@24.0.2
+        version: '@catrielmuller/puppeteer-chromium-resolver@24.0.2'
       puppeteer-core:
         specifier: ^23.4.0
         version: 23.11.1
@@ -3331,6 +3328,9 @@ packages:
   '@c4312/eventsource-umd@3.0.5':
     resolution: {integrity: sha512-0QhLg51eFB+SS/a4Pv5tHaRSnjJBpdFsjT3WN/Vfh6qzeFXqvaE+evVIIToYvr2lRBLg1NIB635ip8ML+/84Sg==}
     engines: {node: '>=18.0.0'}
+
+  '@catrielmuller/puppeteer-chromium-resolver@24.0.2':
+    resolution: {integrity: sha512-/hvJx+9/OXSwB41AlGAXmCKAczco/3IDvSC1JtkIxvpFdf904pFBuU8cciuIWrPaVGvVs31KzPE5MngfnAuz5A==}
 
   '@cerebras/cerebras_cloud_sdk@1.46.0':
     resolution: {integrity: sha512-5IFlD9jvZr5fRsHd4pL4sFkzDPSvHxzM0dmk3mJG2/biRBl+3EV6CdXCabf7J8kr8hyQyK67N0rQLnYy6NSh9w==}
@@ -9035,6 +9035,10 @@ packages:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
+
+  cli-progress@3.12.0:
+    resolution: {integrity: sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==}
+    engines: {node: '>=4'}
 
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
@@ -20633,6 +20637,18 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.2
 
+  '@catrielmuller/puppeteer-chromium-resolver@24.0.2':
+    dependencies:
+      '@puppeteer/browsers': 2.10.5
+      cli-progress: 3.12.0
+      eight-colors: 1.3.1
+      puppeteer-core: 24.10.2
+    transitivePeerDependencies:
+      - bare-buffer
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@cerebras/cerebras_cloud_sdk@1.46.0':
     dependencies:
       '@types/node': 18.19.100
@@ -22680,7 +22696,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23316,7 +23332,7 @@ snapshots:
 
   '@puppeteer/browsers@2.10.5':
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -23329,7 +23345,7 @@ snapshots:
 
   '@puppeteer/browsers@2.6.1':
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -26291,7 +26307,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.17.57)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -27161,7 +27177,7 @@ snapshots:
 
   axios@1.12.2:
     dependencies:
-      follow-redirects: 1.15.9
+      follow-redirects: 1.15.9(debug@4.4.1)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -27399,7 +27415,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -27886,6 +27902,10 @@ snapshots:
       parse5: 5.1.1
       parse5-htmlparser2-tree-adapter: 6.0.1
       yargs: 16.2.0
+
+  cli-progress@3.12.0:
+    dependencies:
+      string-width: 4.2.3
 
   cli-spinners@2.9.2: {}
 
@@ -28793,10 +28813,6 @@ snapshots:
       ms: 2.1.3
 
   debug@4.3.7:
-    dependencies:
-      ms: 2.1.3
-
-  debug@4.4.1:
     dependencies:
       ms: 2.1.3
 
@@ -29935,7 +29951,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -29997,7 +30013,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -30162,7 +30178,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -30278,8 +30294,6 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       readable-stream: 2.3.8
-
-  follow-redirects@1.15.9: {}
 
   follow-redirects@1.15.9(debug@4.4.1):
     optionalDependencies:
@@ -31364,7 +31378,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -31408,7 +31422,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -35913,7 +35927,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -35987,7 +36001,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.6.1
       chromium-bidi: 0.11.0(devtools-protocol@0.0.1367902)
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       devtools-protocol: 0.0.1367902
       typed-query-selector: 2.12.0
       ws: 8.18.2
@@ -36001,7 +36015,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.10.5
       chromium-bidi: 5.1.0(devtools-protocol@0.0.1452169)
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       devtools-protocol: 0.0.1452169
       typed-query-selector: 2.12.0
       ws: 8.18.3
@@ -36915,7 +36929,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -37073,7 +37087,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -37306,7 +37320,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -37430,7 +37444,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -39054,7 +39068,7 @@ snapshots:
   vite-node@3.2.4(@types/node@20.17.57)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.3.6(@types/node@20.17.57)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
@@ -39250,7 +39264,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,9 +825,6 @@ importers:
       stream-json:
         specifier: ^1.8.0
         version: 1.9.1
-      string-similarity:
-        specifier: ^4.0.4
-        version: 4.0.4
       strip-ansi:
         specifier: ^7.1.0
         version: 7.1.0
@@ -19769,7 +19766,7 @@ snapshots:
       '@babel/traverse': 7.28.3
       '@babel/types': 7.28.2
       convert-source-map: 2.0.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -20614,7 +20611,7 @@ snapshots:
       '@babel/parser': 7.28.3
       '@babel/template': 7.27.2
       '@babel/types': 7.28.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -22683,7 +22680,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -23319,7 +23316,7 @@ snapshots:
 
   '@puppeteer/browsers@2.10.5':
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -23332,7 +23329,7 @@ snapshots:
 
   '@puppeteer/browsers@2.6.1':
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -26294,7 +26291,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.17.57)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -27164,7 +27161,7 @@ snapshots:
 
   axios@1.12.2:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.1)
+      follow-redirects: 1.15.9
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -27402,7 +27399,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -28799,6 +28796,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.1(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -29934,7 +29935,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -29996,7 +29997,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -30161,7 +30162,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -30277,6 +30278,8 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       readable-stream: 2.3.8
+
+  follow-redirects@1.15.9: {}
 
   follow-redirects@1.15.9(debug@4.4.1):
     optionalDependencies:
@@ -31361,7 +31364,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -31405,7 +31408,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -35910,7 +35913,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -35984,7 +35987,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.6.1
       chromium-bidi: 0.11.0(devtools-protocol@0.0.1367902)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       devtools-protocol: 0.0.1367902
       typed-query-selector: 2.12.0
       ws: 8.18.2
@@ -35998,7 +36001,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.10.5
       chromium-bidi: 5.1.0(devtools-protocol@0.0.1452169)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       devtools-protocol: 0.0.1452169
       typed-query-selector: 2.12.0
       ws: 8.18.3
@@ -36912,7 +36915,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -37070,7 +37073,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -37303,7 +37306,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -37427,7 +37430,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -39051,7 +39054,7 @@ snapshots:
   vite-node@3.2.4(@types/node@20.17.57)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.3.6(@types/node@20.17.57)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
@@ -39247,7 +39250,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3


### PR DESCRIPTION
## Context

Resolve: #3014 
Related: https://github.com/cenfun/puppeteer-chromium-resolver/pull/20

I publish a fork with this PR: https://www.npmjs.com/package/@catrielmuller/puppeteer-chromium-resolver

The `copyfiles` dependency on "event-pubsub" is a dev dependency, however was published on npm as a prod.
Ref: https://github.com/RIAEvangelist/event-pubsub/blob/master/package.json

## Implementation

- Override deprecated dependencies

## Screenshots

<img width="1495" height="382" alt="image" src="https://github.com/user-attachments/assets/f5d9ba1c-6788-4e31-b0c7-52730b752e6d" />

