### PR TITLE
Enabled Claude Haiku 4.5 support for Claude Code

### DIFF
--- a/packages/types/src/providers/claude-code.ts
+++ b/packages/types/src/providers/claude-code.ts
@@ -48,6 +48,14 @@ export const claudeCodeModels = {
 		supportsReasoningBudget: false,
 		requiredReasoningBudget: false,
 	},
+	"claude-haiku-4-5": {
+		...anthropicModels["claude-haiku-4-5"],
+		supportsImages: false,
+		supportsPromptCache: true, // Claude Code does report cache tokens
+		supportsReasoningEffort: false,
+		supportsReasoningBudget: false,
+		requiredReasoningBudget: false,
+	},
 	"claude-sonnet-4-20250514": {
 		...anthropicModels["claude-sonnet-4-20250514"],
 		supportsImages: false,


### PR DESCRIPTION
Added Claude Haiku 4.5 to the list of models supported by Claude Code. Used the no-date model name to match the Sonnet 4.5 configuration.

## Get in Touch

@spiffytech in the Kilo discord