### PR TITLE
fix(editor): prevent file editing issues when git diff views are open

### DIFF
--- a/.changeset/easy-masks-show.md
+++ b/.changeset/easy-masks-show.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix bug preventing the agent from editing files properly when git diff views are open

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -54,8 +54,8 @@ export class DiffViewProvider {
 		// If the file is already open, ensure it's not dirty before getting its
 		// contents.
 		if (fileExists) {
-			const existingDocument = vscode.workspace.textDocuments.find((doc) =>
-				arePathsEqual(doc.uri.fsPath, absolutePath),
+			const existingDocument = vscode.workspace.textDocuments.find(
+				(doc) => doc.uri.scheme === "file" && arePathsEqual(doc.uri.fsPath, absolutePath),
 			)
 
 			if (existingDocument && existingDocument.isDirty) {
@@ -91,7 +91,10 @@ export class DiffViewProvider {
 			.map((tg) => tg.tabs)
 			.flat()
 			.filter(
-				(tab) => tab.input instanceof vscode.TabInputText && arePathsEqual(tab.input.uri.fsPath, absolutePath),
+				(tab) =>
+					tab.input instanceof vscode.TabInputText &&
+					tab.input.uri.scheme === "file" &&
+					arePathsEqual(tab.input.uri.fsPath, absolutePath),
 			)
 
 		for (const tab of tabs) {

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -522,8 +522,6 @@ export class DiffViewProvider {
 						if (editor) {
 							cleanup()
 							resolve(editor)
-						} else {
-							console.error(`[DiffViewProvider] Failed to find valid editor for ${fileName}`)
 						}
 					}
 				}),
@@ -540,8 +538,6 @@ export class DiffViewProvider {
 					if (editor) {
 						cleanup()
 						resolve(editor)
-					} else {
-						console.error(`[DiffViewProvider] Failed to find valid editor for ${fileName}`)
 					}
 				}),
 			)

--- a/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
@@ -187,7 +187,7 @@ describe("DiffViewProvider", () => {
 			// Setup
 			const mockEditor = {
 				document: {
-					uri: { fsPath: `${mockCwd}/test.md` },
+					uri: { fsPath: `${mockCwd}/test.md`, scheme: "file" },
 					getText: vi.fn().mockReturnValue(""),
 					lineCount: 0,
 				},
@@ -220,7 +220,7 @@ describe("DiffViewProvider", () => {
 			vi.mocked(vscode.workspace.onDidOpenTextDocument).mockImplementation((callback) => {
 				// Trigger the callback immediately with the document
 				setTimeout(() => {
-					callback({ uri: { fsPath: `${mockCwd}/test.md` } } as any)
+					callback({ uri: { fsPath: `${mockCwd}/test.md`, scheme: "file" } } as any)
 				}, 0)
 				return { dispose: vi.fn() }
 			})


### PR DESCRIPTION
Fix bug where the agent couldn't edit files properly when git diff views were open by ensuring only file:// scheme documents are matched in editor detection.

I'll open this fix for Roo too so the `// kilocode_change` markers are pending:
https://github.com/RooCodeInc/Roo-Code/pull/8676