### PR TITLE
CLI: Make Logo responsive

### DIFF
--- a/.changeset/fresh-points-dance.md
+++ b/.changeset/fresh-points-dance.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Made Logo responsive so that it better fits smaller screens

--- a/cli/src/ui/components/Logo.tsx
+++ b/cli/src/ui/components/Logo.tsx
@@ -1,6 +1,7 @@
 import React from "react"
-import { Box, Text } from "ink"
+import { Box, Text, useStdout } from "ink"
 import { useTheme } from "../../state/hooks/useTheme.js"
+import { logs } from "../../services/logs.js"
 
 export const ASCII_LOGO = `⣿⡿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⢿⣿
 ⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿
@@ -22,34 +23,45 @@ export const BIG_TEXT = ` █████   ████  ███  ███�
  █████ ░░████ █████ █████░░██████     ░░█████████ ░░██████ ░░████████░░██████
 ░░░░░   ░░░░ ░░░░░ ░░░░░  ░░░░░░       ░░░░░░░░░   ░░░░░░   ░░░░░░░░  ░░░░░░ `
 
-interface LogoProps {
-	color?: string
-	showBigText?: boolean
-	alignment?: "left" | "center" | "right"
-}
-
-export const Logo: React.FC<LogoProps> = ({ color, showBigText = true, alignment = "left" }) => {
+export const Logo: React.FC = () => {
 	const theme = useTheme()
-	const logoColor = color ?? theme.brand.primary
-	const justifyContent = alignment === "center" ? "center" : alignment === "right" ? "flex-end" : "flex-start"
+	const {
+		stdout: { columns },
+	} = useStdout()
+	const logoColor = theme.brand.primary
+	const justifyContent = "flex-start"
+
+	const LogoIcon = (
+		<Box flexDirection="column">
+			{ASCII_LOGO.split("\n").map((line, index) => (
+				<Text key={index} color={logoColor}>
+					{line}
+				</Text>
+			))}
+		</Box>
+	)
+
+	const LogoBigText = (
+		<Box flexDirection="column">
+			{BIG_TEXT.split("\n").map((line, index) => (
+				<Text key={index} color={logoColor}>
+					{line}
+				</Text>
+			))}
+		</Box>
+	)
 
 	return (
 		<Box flexDirection="row" alignItems="center" gap={4} justifyContent={justifyContent}>
-			<Box flexDirection="column">
-				{ASCII_LOGO.split("\n").map((line, index) => (
-					<Text key={index} color={logoColor}>
-						{line}
-					</Text>
-				))}
-			</Box>
-			{showBigText && (
-				<Box flexDirection="column">
-					{BIG_TEXT.split("\n").map((line, index) => (
-						<Text key={index} color={logoColor}>
-							{line}
-						</Text>
-					))}
-				</Box>
+			{columns < 80 ? (
+				LogoIcon
+			) : columns < 104 ? (
+				LogoBigText
+			) : (
+				<>
+					{LogoIcon}
+					{LogoBigText}
+				</>
 			)}
 		</Box>
 	)

--- a/cli/src/ui/components/Logo.tsx
+++ b/cli/src/ui/components/Logo.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { Box, Text, useStdout } from "ink"
 import { useTheme } from "../../state/hooks/useTheme.js"
-import { logs } from "../../services/logs.js"
 
 export const ASCII_LOGO = `⣿⡿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⢿⣿
 ⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿


### PR DESCRIPTION


https://github.com/user-attachments/assets/b85ccadc-4a0d-49d6-bf39-ed9266ebf155

## Context

On smaller windows the Logo didn't look great, so with this change I decided to add a little more support for smaller screens. Please note that this does not repaint on resize, though I think we should definitely do that in the future!