### PR TITLE
fix(api): add checks for null/empty stream chunks

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -191,6 +191,14 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 			let lastUsage
 
 			for await (const chunk of stream) {
+				if (!chunk) {
+					console.warn("Received a null/undefined chunk from the stream.")
+					continue
+				}
+				if (!chunk.choices || chunk.choices.length === 0) {
+					console.warn("Received a chunk without choices or empty choices array:", chunk)
+					continue
+				}
 				const delta = chunk.choices[0]?.delta ?? {}
 
 				if (delta.content) {
@@ -409,6 +417,14 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 
 	private async *handleStreamResponse(stream: AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>): ApiStream {
 		for await (const chunk of stream) {
+			if (!chunk) {
+				console.warn("Received a null/undefined chunk from the stream in handleStreamResponse.")
+				continue
+			}
+			if (!chunk.choices || chunk.choices.length === 0) {
+				console.warn("Received a chunk without choices or empty choices array in handleStreamResponse:", chunk)
+				continue
+			}
 			const delta = chunk.choices[0]?.delta
 			if (delta?.content) {
 				yield {


### PR DESCRIPTION
Introduce explicit checks for null/undefined chunks and empty choices arrays received from the OpenAI streaming API. 

This enhances robustness by preventing potential runtime errors if the API sends malformed or unexpected data during streaming like AgentRouter.org does.   They send a 'data: null' between the reasoning and completion:

```
data: {"id":"msg_01XA3sB1QMS7Kyhp5JqB54A4","object":"chat.completion.chunk","created":1760645182,"model":"claude-haiku-4-5-20251001","system_fingerprint":null,"choices":[{"delta":{"reasoning_content":"\n"},"logprobs":null,"finish_reason":null,"index":0}],"usage":null}
data: null
data: {"id":"msg_01XA3sB1QMS7Kyhp5JqB54A4","object":"chat.completion.chunk","created":1760645182,"model":"claude-haiku-4-5-20251001","system_fingerprint":null,"choices":[{"delta":{},"logprobs":null,"finish_reason":null,"index":0}],"usage":null}
```

## Context

[<!-- Brief description of WHAT you’re doing and WHY. -->](https://discord.com/channels/1349288496988160052/1427672436597588023/1428449187665674310)


## Get in Touch

mcowger
