### PR TITLE
fix(anthropic-vertex): add manual baseURL configuration to fix out of date library

### DIFF
--- a/.changeset/big-fans-spend.md
+++ b/.changeset/big-fans-spend.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Update baseURL for Vertex Anthropic models to fix.

--- a/.changeset/big-fans-spend.md
+++ b/.changeset/big-fans-spend.md
@@ -2,4 +2,4 @@
 "kilo-code": minor
 ---
 
-Update baseURL for Vertex Anthropic models to fix.
+Update base URL for Vertex Anthropic models to work around outdated library.

--- a/src/api/providers/__tests__/anthropic-vertex.spec.ts
+++ b/src/api/providers/__tests__/anthropic-vertex.spec.ts
@@ -60,6 +60,7 @@ describe("VertexHandler", () => {
 			})
 
 			expect(AnthropicVertex).toHaveBeenCalledWith({
+				baseURL: "https://aiplatform.googleapis.com/v1",
 				projectId: "test-project",
 				region: "us-central1",
 			})

--- a/src/api/providers/__tests__/anthropic-vertex.spec.ts
+++ b/src/api/providers/__tests__/anthropic-vertex.spec.ts
@@ -60,7 +60,7 @@ describe("VertexHandler", () => {
 			})
 
 			expect(AnthropicVertex).toHaveBeenCalledWith({
-				baseURL: "https://aiplatform.googleapis.com/v1",
+				baseURL: "https://aiplatform.googleapis.com/v1", // kilocode_change
 				projectId: "test-project",
 				region: "us-central1",
 			})

--- a/src/api/providers/anthropic-vertex.ts
+++ b/src/api/providers/anthropic-vertex.ts
@@ -34,27 +34,30 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 		const projectId = this.options.vertexProjectId ?? "not-provided"
 		const region = this.options.vertexRegion ?? "us-east5"
 
-		if (this.options.vertexJsonCredentials) {
-			this.client = new AnthropicVertex({
-				projectId,
-				region,
-				googleAuth: new GoogleAuth({
-					scopes: ["https://www.googleapis.com/auth/cloud-platform"],
-					credentials: safeJsonParse<JWTInput>(this.options.vertexJsonCredentials, undefined),
-				}),
-			})
-		} else if (this.options.vertexKeyFile) {
-			this.client = new AnthropicVertex({
-				projectId,
-				region,
-				googleAuth: new GoogleAuth({
-					scopes: ["https://www.googleapis.com/auth/cloud-platform"],
-					keyFile: this.options.vertexKeyFile,
-				}),
-			})
-		} else {
-			this.client = new AnthropicVertex({ projectId, region })
-		}
+		//kilocode_change start
+		// Manually construct the baseURL because the format has changed (there are no longer
+		// dedicated hosts), but updating the required anthropic libraries has signidficant
+		// breaking changes for other parts of the application.
+		// TODO: Upgrade the anthropic libraries
+		const updatedBaseUrl = `https://aiplatform.googleapis.com/v1`
+
+		const googleAuthConfig =
+			this.options.vertexJsonCredentials || this.options.vertexKeyFile
+				? {
+						scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+						...(this.options.vertexJsonCredentials
+							? { credentials: safeJsonParse<JWTInput>(this.options.vertexJsonCredentials, undefined) }
+							: { keyFile: this.options.vertexKeyFile }),
+					}
+				: undefined
+
+		this.client = new AnthropicVertex({
+			baseURL: updatedBaseUrl,
+			projectId,
+			region,
+			...(googleAuthConfig && { googleAuth: new GoogleAuth(googleAuthConfig) }),
+		})
+		//kilocode_change end
 	}
 
 	override async *createMessage(

--- a/src/api/providers/anthropic-vertex.ts
+++ b/src/api/providers/anthropic-vertex.ts
@@ -36,9 +36,8 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 
 		//kilocode_change start
 		// Manually construct the baseURL because the format has changed (there are no longer
-		// dedicated hosts), but updating the required anthropic libraries has signidficant
+		// dedicated hosts), but the required updated Anthropic libraries have significant
 		// breaking changes for other parts of the application.
-		// TODO: Upgrade the anthropic libraries
 		const updatedBaseUrl = `https://aiplatform.googleapis.com/v1`
 
 		const googleAuthConfig =


### PR DESCRIPTION
## Context

The Anthropic Vertex API format has changed and no longer provides dedicated hosts. Instead of updating the required anthropic libraries (which would introduce significant breaking changes), manually construct the baseURL to maintain compatibility with the current library versions.

Refactored the authentication configuration to consolidate the three previous authentication scenarios into a single unified initialization.

https://discord.com/channels/1349288496988160052/1427950146120843346

## Get in Touch

mcowger
