### PR TITLE
CLI: Rename -ci flag to -a

### DIFF
--- a/.changeset/beige-insects-fetch.md
+++ b/.changeset/beige-insects-fetch.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Rename -ci flag to -a (longform --auto)

--- a/cli/README.md
+++ b/cli/README.md
@@ -45,24 +45,24 @@ kilocode --mode architect
 kilocode --workspace /path/to/project
 ```
 
-### CI Mode (Non-Interactive)
+### Autonomous mode (Non-Interactive)
 
-CI mode allows Kilo Code to run in automated environments like CI/CD pipelines without requiring user interaction.
+Autonomous mode allows Kilo Code to run in automated environments like CI/CD pipelines without requiring user interaction.
 
 ```bash
-# Run in CI mode with a prompt
-kilocode --ci "Implement feature X"
+# Run in autonomous mode with a prompt
+kilocode --auto "Implement feature X"
 
-# Run in CI mode with piped input
-echo "Fix the bug in app.ts" | kilocode --ci
+# Run in autonomous mode with piped input
+echo "Fix the bug in app.ts" | kilocode --auto
 
-# Run in CI mode with timeout (in seconds)
-kilocode --ci "Run tests" --timeout 300
+# Run in autonomous mode with timeout (in seconds)
+kilocode --auto "Run tests" --timeout 300
 ```
 
-#### CI Mode Behavior
+#### Autonomous mode Behavior
 
-When running in CI mode (`--ci` flag):
+When running in Autonomous mode (`--auto` flag):
 
 1. **No User Interaction**: All approval requests are handled automatically based on configuration
 2. **Auto-Approval/Rejection**: Operations are approved or rejected based on your auto-approval settings
@@ -71,7 +71,7 @@ When running in CI mode (`--ci` flag):
 
 #### Auto-Approval Configuration
 
-CI mode respects your auto-approval configuration. Edit your config file with `kilocode config` to customize:
+Autonomous mode respects your auto-approval configuration. Edit your config file with `kilocode config` to customize:
 
 ```json
 {
@@ -136,11 +136,11 @@ CI mode respects your auto-approval configuration. Edit your config file with `k
 - `retry`: Auto-approve API retry requests
 - `todo`: Auto-approve todo list updates
 
-#### CI Mode Follow-up Questions
+#### Autonomous mode Follow-up Questions
 
-In CI mode, when the AI asks a follow-up question, it receives this response:
+In Autonomous mode, when the AI asks a follow-up question, it receives this response:
 
-> "This process is running in non-interactive CI mode. The user cannot make decisions, so you should make the decision autonomously."
+> "This process is running in non-interactive Autonomous mode. The user cannot make decisions, so you should make the decision autonomously."
 
 This instructs the AI to proceed without user input.
 
@@ -156,7 +156,7 @@ This instructs the AI to proceed without user input.
 # GitHub Actions example
 - name: Run Kilo Code
   run: |
-      echo "Implement the new feature" | kilocode --ci --timeout 600
+      echo "Implement the new feature" | kilocode --auto --timeout 600
 ```
 
 ## Local Development

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -27,8 +27,8 @@ program
 	.version(Package.version)
 	.option("-m, --mode <mode>", `Set the mode of operation (${validModes.join(", ")})`)
 	.option("-w, --workspace <path>", "Path to the workspace directory", process.cwd())
-	.option("-ci, --auto", "Run in CI mode (non-interactive)", false)
-	.option("-t, --timeout <seconds>", "Timeout in seconds for CI mode (requires --ci)", parseInt)
+	.option("-a, --auto", "Run in autonomous mode (non-interactive)", false)
+	.option("-t, --timeout <seconds>", "Timeout in seconds for autonomous mode (requires --auto)", parseInt)
 	.argument("[prompt]", "The prompt or command to execute")
 	.action(async (prompt, options) => {
 		// Validate mode if provided
@@ -43,9 +43,9 @@ program
 			process.exit(1)
 		}
 
-		// Validate that piped stdin requires CI mode
+		// Validate that piped stdin requires autonomous mode
 		if (!process.stdin.isTTY && !options.auto) {
-			console.error("Error: Piped input requires --ci flag to be enabled")
+			console.error("Error: Piped input requires --auto flag to be enabled")
 			process.exit(1)
 		}
 
@@ -60,15 +60,15 @@ program
 			finalPrompt = Buffer.concat(chunks).toString("utf-8").trim()
 		}
 
-		// Validate that CI mode requires a prompt
+		// Validate that autonomous mode requires a prompt
 		if (options.auto && !finalPrompt) {
-			console.error("Error: CI mode (--ci) requires a prompt argument or piped input")
+			console.error("Error: autonomous mode (--auto) requires a prompt argument or piped input")
 			process.exit(1)
 		}
 
-		// Validate that timeout requires CI mode
+		// Validate that timeout requires autonomous mode
 		if (options.timeout && !options.auto) {
-			console.error("Error: --timeout option requires --ci flag to be enabled")
+			console.error("Error: --timeout option requires --auto flag to be enabled")
 			process.exit(1)
 		}
 
@@ -78,7 +78,7 @@ program
 			process.exit(1)
 		}
 
-		// Track CI mode start if applicable
+		// Track autonomous mode start if applicable
 		if (options.auto && finalPrompt) {
 			getTelemetryService().trackCIModeStarted(finalPrompt.length, options.timeout)
 		}


### PR DESCRIPTION
Which is a better fit for calling it "autonomous mode" and the longform `--auto` flag.
