### PR TITLE
Ignore continue temp files

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -3,3 +3,4 @@ CHANGELOG.md
 LICENSE
 webview-ui
 assets/vscode-material-icons
+services/continuedev/core/test/.continue-test


### PR DESCRIPTION
For #3095, so that long-lived branch doesn't leave messy temp files behind when switching to `main`