### PR TITLE
fix: styling button

### DIFF
--- a/.changeset/quiet-years-chew.md
+++ b/.changeset/quiet-years-chew.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix button styling on Let's Go CTA

--- a/webview-ui/src/components/kilocode/common/ButtonPrimary.tsx
+++ b/webview-ui/src/components/kilocode/common/ButtonPrimary.tsx
@@ -14,6 +14,7 @@ const StyledButton = styled.button`
 	padding: 14px;
 	transition: all 0.2s;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+	cursor: pointer;
 
 	/* Theme-specific styles */
 	body.vscode-dark & {


### PR DESCRIPTION
## Context

One particular CTA does not change the cursor style on hover. This is a small issue but it'd make a better DX to have consistent UI behaviour 

## Implementation

This is a straight forward change -- adds a single styling line.

## Screenshots

Before:
![Screen Recording Oct 17 2025 (3)](https://github.com/user-attachments/assets/e09dae04-7dfc-45aa-85f9-58daa62eaa13)


After:
![Screen Recording Oct 17 2025 (2)](https://github.com/user-attachments/assets/1d0bf930-ac88-462b-a80e-471e15cc2e29)


## How to Test

You have to start from the welcome page. If you already have plugin configured, you may need to reset your settings:

-  Settings -> About Kilo Code -> `Reset `

Then you should be in the welcome page, that looks like this:

<img width="505" height="481" alt="image" src="https://github.com/user-attachments/assets/cf6a88f7-a663-4321-b192-211ee175c6a9" />

From here:

- Click `Use your own API Key`
- Insert any text in `Kilo Code API Key`
- You should see the CTA in question - `Let's go!`. 


## Get in Touch

Sorry, I am not on Discord yet
