### PR TITLE
Enhance createMessage with error handling and retries

### DIFF
--- a/src/api/providers/virtual-quota-fallback.ts
+++ b/src/api/providers/virtual-quota-fallback.ts
@@ -122,6 +122,7 @@ export class VirtualQuotaFallbackHandler implements ApiHandler {
 				if (this.autoRetryProfileId) {
 					// Auto-retry already attempted and failed, throwing error
 					// No cooldown needed; manual retry will trigger auto-retry logic
+					this.autoRetryProfileId = undefined
 					throw error
 				} else {
 					// First-time failure: perform auto-retry after setting cooldown

--- a/src/api/providers/virtual-quota-fallback.ts
+++ b/src/api/providers/virtual-quota-fallback.ts
@@ -99,8 +99,9 @@ export class VirtualQuotaFallbackHandler implements ApiHandler {
 				}
 
 				// On successful current request, extend cooldown for the previous (errored) profile
+				// A 5-minute cooldown is enough due to auto-retry handling fallback logic
 				if (previousProfileId) {
-					await this.usage.setCooldown(previousProfileId, 10 * 60 * 1000)
+					await this.usage.setCooldown(previousProfileId, 5 * 60 * 1000)
 				}
 			} catch (error) {
 				// Check if this is a retryable


### PR DESCRIPTION
Added logic to handle previous profile cooldowns and auto-retry on errors.

## Context

The current implementation in VirtualQuotaFallbackProvider sets a 10-minute cooldown for all errors (excluding 429).

However, this behavior is not always correct — some errors may not originate from the provider itself.

## Implementation

### Problem

- Cooldown is applied too aggressively on the first failure.

- Not all errors should result in a long cooldown.

- There is no retry logic to test whether a provider actually fails consistently.

### Solution

- Introduce auto-retry mechanism for non-retryable errors.

- On first failure, apply a shorter cooldown (3 minutes).

- If the retry with a different provider succeeds, the original (errored) provider gets a longer cooldown (5 minutes).

- Prevents unnecessary cooldowns while still penalizing confirmed failing providers.
