### PR TITLE
CLI: Default to publishing to latest tag

### DIFF
--- a/cli/package.dist.json
+++ b/cli/package.dist.json
@@ -141,7 +141,6 @@
 	},
 	"license": "Apache-2.0",
 	"publishConfig": {
-		"access": "public",
-		"tag": "alpha"
+		"access": "public"
 	}
 }


### PR DESCRIPTION
## Context

We've recently started using changesets to track the CLI's changelog. This has the added caveat that we now publish patch release instead of alpha. So in order to make `npm publish` work as expected we need to remove the `alpha` tag, otherwise new installs will install the latest non-alpha release.