### PR TITLE
Update 'runCommand' title from '命令' to '运行'

### DIFF
--- a/.changeset/chatty-toes-develop.md
+++ b/.changeset/chatty-toes-develop.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": "patch"
+---
+
+Improved the Chinese translation of "run" from '命令' to '运行'

--- a/webview-ui/src/i18n/locales/zh-CN/chat.json
+++ b/webview-ui/src/i18n/locales/zh-CN/chat.json
@@ -67,7 +67,7 @@
 		"tooltip": "批准此操作"
 	},
 	"runCommand": {
-		"title": "命令",
+		"title": "运行",
 		"tooltip": "执行此命令"
 	},
 	"proceedWhileRunning": {


### PR DESCRIPTION
## Context

This is a minor but frequently encountered issue: when executing an instruction, the current Simplified Chinese option displays “命令” (which corresponds to “command” in English), but the original English term here is actually “run.” Therefore, the corresponding Simplified Chinese term should be changed to “运行.”

## Implementation

Changed the Chinese translation of "run" in the chat file to "运行."