### PR TITLE
refactor: update AutoTriggerStrategy.getPrompts API to accept AutocompleteInput

### DIFF
--- a/src/services/ghost/GhostProvider.ts
+++ b/src/services/ghost/GhostProvider.ts
@@ -303,7 +303,6 @@ export class GhostProvider {
 			prefix,
 			suffix,
 			languageId,
-			context,
 		)
 		if (this.isRequestCancelled) {
 			return

--- a/src/services/ghost/GhostProvider.ts
+++ b/src/services/ghost/GhostProvider.ts
@@ -268,10 +268,8 @@ export class GhostProvider {
 
 		const context = await this.ghostContext.generate(initialContext)
 
-		// Convert context to AutocompleteInput using helper
 		const autocompleteInput = contextToAutocompleteInput(context)
 
-		// Extract prefix, suffix, and languageId for the new API
 		const position = context.range?.start ?? context.document.positionAt(0)
 		const { prefix, suffix } = extractPrefixSuffix(context.document, position)
 		const languageId = context.document.languageId

--- a/src/services/ghost/GhostProvider.ts
+++ b/src/services/ghost/GhostProvider.ts
@@ -7,7 +7,7 @@ import { AutoTriggerStrategy } from "./strategies/AutoTriggerStrategy"
 import { GhostModel } from "./GhostModel"
 import { GhostWorkspaceEdit } from "./GhostWorkspaceEdit"
 import { GhostDecorations } from "./GhostDecorations"
-import { GhostSuggestionContext } from "./types"
+import { GhostSuggestionContext, contextToAutocompleteInput, extractPrefixSuffix } from "./types"
 import { GhostStatusBar } from "./GhostStatusBar"
 import { GhostSuggestionsState } from "./GhostSuggestions"
 import { GhostCodeActionProvider } from "./GhostCodeActionProvider"
@@ -268,35 +268,13 @@ export class GhostProvider {
 
 		const context = await this.ghostContext.generate(initialContext)
 
+		// Convert context to AutocompleteInput using helper
+		const autocompleteInput = contextToAutocompleteInput(context)
+
 		// Extract prefix, suffix, and languageId for the new API
 		const position = context.range?.start ?? context.document.positionAt(0)
-		const offset = context.document.offsetAt(position)
-		const text = context.document.getText()
-		const prefix = text.substring(0, offset)
-		const suffix = text.substring(offset)
+		const { prefix, suffix } = extractPrefixSuffix(context.document, position)
 		const languageId = context.document.languageId
-
-		// Convert context to AutocompleteInput
-		const autocompleteInput = {
-			isUntitledFile: context.document.isUntitled,
-			completionId: crypto.randomUUID(),
-			filepath: context.document.uri.fsPath,
-			pos: { line: position.line, character: position.character },
-			recentlyVisitedRanges: [],
-			recentlyEditedRanges:
-				context.recentOperations?.map((op) => ({
-					filepath: context.document.uri.fsPath,
-					range: op.lineRange
-						? {
-								start: { line: op.lineRange.start, character: 0 },
-								end: { line: op.lineRange.end, character: 0 },
-							}
-						: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
-					timestamp: op.timestamp ?? Date.now(),
-					lines: op.content ? op.content.split("\n") : [],
-					symbols: new Set(op.affectedSymbol ? [op.affectedSymbol] : []),
-				})) ?? [],
-		}
 
 		const { systemPrompt, userPrompt } = this.autoTriggerStrategy.getPrompts(
 			autocompleteInput,

--- a/src/services/ghost/__tests__/GhostModelPerformance.spec.ts
+++ b/src/services/ghost/__tests__/GhostModelPerformance.spec.ts
@@ -44,7 +44,6 @@ describe("GhostModelPerformance", () => {
 			prefix,
 			suffix,
 			languageId,
-			context,
 		)
 
 		return { systemPrompt, suggestionPrompt: userPrompt }

--- a/src/services/ghost/__tests__/GhostModelPerformance.spec.ts
+++ b/src/services/ghost/__tests__/GhostModelPerformance.spec.ts
@@ -5,6 +5,8 @@ import { MockWorkspace } from "./MockWorkspace"
 import { ApiHandler, buildApiHandler } from "../../../api"
 import { GhostModel } from "../GhostModel"
 import { allowNetConnect } from "../../../vitest.setup"
+import { AutocompleteInput } from "../types"
+import crypto from "crypto"
 
 const KEYS = {
 	KILOCODE: null,
@@ -25,7 +27,25 @@ describe("GhostModelPerformance", () => {
 			document: document,
 		}
 
-		const { systemPrompt, userPrompt } = autoTriggerStrategy.getPrompts(context)
+		const prefix = ""
+		const suffix = ""
+		const languageId = "typescript"
+		const autocompleteInput: AutocompleteInput = {
+			isUntitledFile: false,
+			completionId: crypto.randomUUID(),
+			filepath: testUri.fsPath,
+			pos: { line: 0, character: 0 },
+			recentlyVisitedRanges: [],
+			recentlyEditedRanges: [],
+		}
+
+		const { systemPrompt, userPrompt } = autoTriggerStrategy.getPrompts(
+			autocompleteInput,
+			prefix,
+			suffix,
+			languageId,
+			context,
+		)
 
 		return { systemPrompt, suggestionPrompt: userPrompt }
 	}

--- a/src/services/ghost/__tests__/GhostModelPerformance.spec.ts
+++ b/src/services/ghost/__tests__/GhostModelPerformance.spec.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode"
 import { describe, it, expect } from "vitest"
 import { AutoTriggerStrategy } from "../strategies/AutoTriggerStrategy"
-import { MockWorkspace } from "./MockWorkspace"
 import { ApiHandler, buildApiHandler } from "../../../api"
 import { GhostModel } from "../GhostModel"
 import { allowNetConnect } from "../../../vitest.setup"
@@ -17,19 +16,9 @@ const KEYS = {
 describe("GhostModelPerformance", () => {
 	const generatePrompt = (userInput: string) => {
 		const autoTriggerStrategy = new AutoTriggerStrategy()
-		const mockWorkspace = new MockWorkspace()
 
 		const testUri = vscode.Uri.parse("file:///example.ts")
-		const document = mockWorkspace.addDocument(testUri, "")
 
-		const context = {
-			userInput,
-			document: document,
-		}
-
-		const prefix = ""
-		const suffix = ""
-		const languageId = "typescript"
 		const autocompleteInput: AutocompleteInput = {
 			isUntitledFile: false,
 			completionId: crypto.randomUUID(),
@@ -39,12 +28,7 @@ describe("GhostModelPerformance", () => {
 			recentlyEditedRanges: [],
 		}
 
-		const { systemPrompt, userPrompt } = autoTriggerStrategy.getPrompts(
-			autocompleteInput,
-			prefix,
-			suffix,
-			languageId,
-		)
+		const { systemPrompt, userPrompt } = autoTriggerStrategy.getPrompts(autocompleteInput, "", "", "typescript")
 
 		return { systemPrompt, suggestionPrompt: userPrompt }
 	}

--- a/src/services/ghost/__tests__/GhostRecentOperations.spec.ts
+++ b/src/services/ghost/__tests__/GhostRecentOperations.spec.ts
@@ -120,13 +120,29 @@ describe("GhostRecentOperations", () => {
 		const prefix = enrichedContext.document.getText()
 		const suffix = ""
 		const languageId = enrichedContext.document.languageId
+
+		// Convert recent operations to recentlyEditedRanges
+		const recentlyEditedRanges =
+			enrichedContext.recentOperations?.map((op) => ({
+				filepath: enrichedContext.document.uri.fsPath,
+				range: op.lineRange
+					? {
+							start: { line: op.lineRange.start, character: 0 },
+							end: { line: op.lineRange.end, character: 0 },
+						}
+					: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+				timestamp: op.timestamp ?? Date.now(),
+				lines: op.content ? op.content.split("\n") : [],
+				symbols: new Set(op.affectedSymbol ? [op.affectedSymbol] : []),
+			})) ?? []
+
 		const autocompleteInput: AutocompleteInput = {
 			isUntitledFile: false,
 			completionId: crypto.randomUUID(),
 			filepath: enrichedContext.document.uri.fsPath,
 			pos: { line: 0, character: 0 },
 			recentlyVisitedRanges: [],
-			recentlyEditedRanges: [],
+			recentlyEditedRanges,
 		}
 		const { userPrompt } = autoTriggerStrategy.getPrompts(
 			autocompleteInput,

--- a/src/services/ghost/__tests__/GhostRecentOperations.spec.ts
+++ b/src/services/ghost/__tests__/GhostRecentOperations.spec.ts
@@ -3,8 +3,9 @@ import * as vscode from "vscode"
 import { GhostContext } from "../GhostContext"
 import { GhostDocumentStore } from "../GhostDocumentStore"
 import { AutoTriggerStrategy } from "../strategies/AutoTriggerStrategy"
-import { GhostSuggestionContext } from "../types"
+import { GhostSuggestionContext, AutocompleteInput } from "../types"
 import { MockTextDocument } from "../../mocking/MockTextDocument"
+import crypto from "crypto"
 
 // Mock vscode
 vi.mock("vscode", () => ({
@@ -116,7 +117,24 @@ describe("GhostRecentOperations", () => {
 		expect(enrichedContext.recentOperations?.length).toBeGreaterThan(0)
 
 		// Generate prompt
-		const { userPrompt } = autoTriggerStrategy.getPrompts(enrichedContext)
+		const prefix = enrichedContext.document.getText()
+		const suffix = ""
+		const languageId = enrichedContext.document.languageId
+		const autocompleteInput: AutocompleteInput = {
+			isUntitledFile: false,
+			completionId: crypto.randomUUID(),
+			filepath: enrichedContext.document.uri.fsPath,
+			pos: { line: 0, character: 0 },
+			recentlyVisitedRanges: [],
+			recentlyEditedRanges: [],
+		}
+		const { userPrompt } = autoTriggerStrategy.getPrompts(
+			autocompleteInput,
+			prefix,
+			suffix,
+			languageId,
+			enrichedContext,
+		)
 
 		// Verify that the prompt includes the recent operations section
 		// The new strategy system uses "## Recent Typing" format
@@ -133,7 +151,24 @@ describe("GhostRecentOperations", () => {
 		const enrichedContext = await context.generate(suggestionContext)
 
 		// Generate prompt
-		const { userPrompt } = autoTriggerStrategy.getPrompts(enrichedContext)
+		const prefix = enrichedContext.document.getText()
+		const suffix = ""
+		const languageId = enrichedContext.document.languageId
+		const autocompleteInput: AutocompleteInput = {
+			isUntitledFile: false,
+			completionId: crypto.randomUUID(),
+			filepath: enrichedContext.document.uri.fsPath,
+			pos: { line: 0, character: 0 },
+			recentlyVisitedRanges: [],
+			recentlyEditedRanges: [],
+		}
+		const { userPrompt } = autoTriggerStrategy.getPrompts(
+			autocompleteInput,
+			prefix,
+			suffix,
+			languageId,
+			enrichedContext,
+		)
 
 		// Verify that the prompt does not include recent operations section
 		// The current document content will still be in the prompt, so we should only check

--- a/src/services/ghost/__tests__/GhostRecentOperations.spec.ts
+++ b/src/services/ghost/__tests__/GhostRecentOperations.spec.ts
@@ -144,13 +144,7 @@ describe("GhostRecentOperations", () => {
 			recentlyVisitedRanges: [],
 			recentlyEditedRanges,
 		}
-		const { userPrompt } = autoTriggerStrategy.getPrompts(
-			autocompleteInput,
-			prefix,
-			suffix,
-			languageId,
-			enrichedContext,
-		)
+		const { userPrompt } = autoTriggerStrategy.getPrompts(autocompleteInput, prefix, suffix, languageId)
 
 		// Verify that the prompt includes the recent operations section
 		// The new strategy system uses "## Recent Typing" format
@@ -178,13 +172,7 @@ describe("GhostRecentOperations", () => {
 			recentlyVisitedRanges: [],
 			recentlyEditedRanges: [],
 		}
-		const { userPrompt } = autoTriggerStrategy.getPrompts(
-			autocompleteInput,
-			prefix,
-			suffix,
-			languageId,
-			enrichedContext,
-		)
+		const { userPrompt } = autoTriggerStrategy.getPrompts(autocompleteInput, prefix, suffix, languageId)
 
 		// Verify that the prompt does not include recent operations section
 		// The current document content will still be in the prompt, so we should only check

--- a/src/services/ghost/__tests__/GhostRecentOperations.spec.ts
+++ b/src/services/ghost/__tests__/GhostRecentOperations.spec.ts
@@ -115,7 +115,6 @@ describe("GhostRecentOperations", () => {
 		expect(enrichedContext.recentOperations).toBeDefined()
 		expect(enrichedContext.recentOperations?.length).toBeGreaterThan(0)
 
-		// Convert context to AutocompleteInput using helper
 		const autocompleteInput = contextToAutocompleteInput(enrichedContext)
 
 		// Generate prompt
@@ -138,7 +137,6 @@ describe("GhostRecentOperations", () => {
 		// Generate context
 		const enrichedContext = await context.generate(suggestionContext)
 
-		// Convert context to AutocompleteInput using helper
 		const autocompleteInput = contextToAutocompleteInput(enrichedContext)
 
 		// Generate prompt

--- a/src/services/ghost/strategies/AutoTriggerStrategy.ts
+++ b/src/services/ghost/strategies/AutoTriggerStrategy.ts
@@ -82,7 +82,7 @@ export class AutoTriggerStrategy {
 		if (this.shouldTreatAsComment(prefix, languageId)) {
 			return {
 				systemPrompt: this.getCommentsSystemInstructions(),
-				userPrompt: this.getCommentsUserPrompt(autocompleteInput, prefix, suffix, languageId),
+				userPrompt: this.getCommentsUserPrompt(prefix, suffix, languageId),
 			}
 		} else {
 			return {
@@ -179,12 +179,7 @@ Provide non-intrusive completions after a typing pause. Be conservative and help
 		)
 	}
 
-	getCommentsUserPrompt(
-		autocompleteInput: AutocompleteInput,
-		prefix: string,
-		suffix: string,
-		languageId: string,
-	): string {
+	getCommentsUserPrompt(prefix: string, suffix: string, languageId: string): string {
 		// Extract the comment from the prefix
 		const lines = prefix.split("\n")
 		const lastLine = lines[lines.length - 1]

--- a/src/services/ghost/strategies/AutoTriggerStrategy.ts
+++ b/src/services/ghost/strategies/AutoTriggerStrategy.ts
@@ -1,4 +1,4 @@
-import { GhostSuggestionContext, extractPrefix, AutocompleteInput } from "../types"
+import { GhostSuggestionContext, AutocompleteInput } from "../types"
 import { CURSOR_MARKER } from "../ghostConstants"
 import { isCommentLine, extractComment, cleanComment } from "./CommentHelpers"
 import type { TextDocument, Range } from "vscode"

--- a/src/services/ghost/strategies/AutoTriggerStrategy.ts
+++ b/src/services/ghost/strategies/AutoTriggerStrategy.ts
@@ -1,4 +1,4 @@
-import { GhostSuggestionContext, AutocompleteInput } from "../types"
+import { AutocompleteInput } from "../types"
 import { CURSOR_MARKER } from "../ghostConstants"
 import { isCommentLine, cleanComment } from "./CommentHelpers"
 import type { TextDocument, Range } from "vscode"

--- a/src/services/ghost/strategies/AutoTriggerStrategy.ts
+++ b/src/services/ghost/strategies/AutoTriggerStrategy.ts
@@ -55,15 +55,6 @@ export function addCursorMarker(document: TextDocument, range?: Range): string {
 	return `${beforeCursor}${CURSOR_MARKER}${afterCursor}`
 }
 
-export function formatDocumentWithCursor(document: TextDocument, range?: Range, languageId?: string): string {
-	const lang = languageId || document.languageId
-	const codeWithCursor = addCursorMarker(document, range)
-
-	return `\`\`\`${lang}
-${codeWithCursor}
-\`\`\``
-}
-
 export class AutoTriggerStrategy {
 	shouldTreatAsComment(prefix: string, languageId: string): boolean {
 		const lines = prefix.split("\n")

--- a/src/services/ghost/strategies/AutoTriggerStrategy.ts
+++ b/src/services/ghost/strategies/AutoTriggerStrategy.ts
@@ -92,12 +92,12 @@ export class AutoTriggerStrategy {
 		if (this.shouldTreatAsComment(prefix, languageId)) {
 			return {
 				systemPrompt: this.getCommentsSystemInstructions(),
-				userPrompt: this.getCommentsUserPrompt(context, prefix, languageId),
+				userPrompt: this.getCommentsUserPrompt(autocompleteInput, prefix, suffix, languageId),
 			}
 		} else {
 			return {
 				systemPrompt: this.getSystemInstructions(),
-				userPrompt: this.getUserPrompt(context, prefix, suffix),
+				userPrompt: this.getUserPrompt(autocompleteInput, prefix, suffix, languageId),
 			}
 		}
 	}
@@ -115,32 +115,29 @@ Provide non-intrusive completions after a typing pause. Be conservative and help
 	/**
 	 * Build minimal prompt for auto-trigger
 	 */
-	getUserPrompt(context: GhostSuggestionContext | undefined, prefix: string, suffix: string): string {
+	getUserPrompt(autocompleteInput: AutocompleteInput, prefix: string, suffix: string, languageId: string): string {
 		let prompt = ""
 
-		// Start with recent typing context
-		if (context?.recentOperations && context.recentOperations.length > 0) {
+		// Start with recent typing context from autocompleteInput
+		if (autocompleteInput.recentlyEditedRanges && autocompleteInput.recentlyEditedRanges.length > 0) {
 			prompt += "## Recent Typing\n"
-			context.recentOperations.forEach((op, index) => {
-				prompt += `${index + 1}. ${op.description}\n`
+			autocompleteInput.recentlyEditedRanges.forEach((range, index) => {
+				const description = `Edited ${range.filepath} at line ${range.range.start.line}`
+				prompt += `${index + 1}. ${description}\n`
 			})
 			prompt += "\n"
 		}
 
-		// Add current position
-		if (context?.range && context.document) {
-			const line = context.range.start.line + 1
-			const char = context.range.start.character + 1
-			prompt += `## Current Position\n`
-			prompt += `Line ${line}, Character ${char}\n\n`
-		}
+		// Add current position from autocompleteInput
+		const line = autocompleteInput.pos.line + 1
+		const char = autocompleteInput.pos.character + 1
+		prompt += `## Current Position\n`
+		prompt += `Line ${line}, Character ${char}\n\n`
 
 		// Add the full document with cursor marker
-		if (context?.document) {
-			prompt += "## Full Code\n"
-			prompt += formatDocumentWithCursor(context.document, context.range)
-			prompt += "\n\n"
-		}
+		const codeWithCursor = `${prefix}${CURSOR_MARKER}${suffix}`
+		prompt += "## Full Code\n"
+		prompt += `\`\`\`${languageId}\n${codeWithCursor}\n\`\`\`\n\n`
 
 		// Add specific instructions
 		prompt += "## Instructions\n"
@@ -192,23 +189,34 @@ Provide non-intrusive completions after a typing pause. Be conservative and help
 		)
 	}
 
-	getCommentsUserPrompt(context: GhostSuggestionContext | undefined, prefix: string, languageId: string): string {
-		if (!context?.document || !context.range) {
-			return "No context available for comment-driven generation."
-		}
+	getCommentsUserPrompt(
+		autocompleteInput: AutocompleteInput,
+		prefix: string,
+		suffix: string,
+		languageId: string,
+	): string {
+		// Extract the comment from the prefix
+		const lines = prefix.split("\n")
+		const lastLine = lines[lines.length - 1]
+		const previousLine = lines.length > 1 ? lines[lines.length - 2] : ""
 
-		const language = languageId || context.document.languageId
-		const comment = cleanComment(extractComment(context.document, context.range.start.line), language)
+		// Determine which line contains the comment
+		const commentLine = isCommentLine(lastLine, languageId) ? lastLine : previousLine
+		const comment = cleanComment(commentLine, languageId)
+
+		const codeWithCursor = `${prefix}${CURSOR_MARKER}${suffix}`
 
 		let prompt = `## Comment-Driven Development
-- Language: ${language}
+- Language: ${languageId}
 - Comment to Implement:
 \`\`\`
 ${comment}
 \`\`\`
 
 ## Full Code
-${formatDocumentWithCursor(context.document, context.range)}
+\`\`\`${languageId}
+${codeWithCursor}
+\`\`\`
 
 ## Instructions
 Generate code that implements the functionality described in the comment.

--- a/src/services/ghost/strategies/AutoTriggerStrategy.ts
+++ b/src/services/ghost/strategies/AutoTriggerStrategy.ts
@@ -84,7 +84,6 @@ export class AutoTriggerStrategy {
 		prefix: string,
 		suffix: string,
 		languageId: string,
-		context?: GhostSuggestionContext,
 	): {
 		systemPrompt: string
 		userPrompt: string

--- a/src/services/ghost/strategies/AutoTriggerStrategy.ts
+++ b/src/services/ghost/strategies/AutoTriggerStrategy.ts
@@ -1,6 +1,6 @@
 import { GhostSuggestionContext, AutocompleteInput } from "../types"
 import { CURSOR_MARKER } from "../ghostConstants"
-import { isCommentLine, extractComment, cleanComment } from "./CommentHelpers"
+import { isCommentLine, cleanComment } from "./CommentHelpers"
 import type { TextDocument, Range } from "vscode"
 
 export function getBaseSystemInstructions(): string {

--- a/src/services/ghost/strategies/CommentHelpers.ts
+++ b/src/services/ghost/strategies/CommentHelpers.ts
@@ -38,56 +38,6 @@ export function isCommentLine(line: string, languageId: string): boolean {
 	return false
 }
 
-export function extractComment(document: TextDocument, currentLine: number): string {
-	let comment = ""
-
-	// Get the comment (could be multi-line)
-	let commentStartLine = currentLine
-	let commentEndLine = currentLine
-
-	// Check if current line is a comment
-	const currentLineText = document.lineAt(currentLine).text
-	if (isCommentLine(currentLineText.trim(), document.languageId)) {
-		comment = currentLineText.trim()
-
-		// Check for multi-line comments above
-		let line = currentLine - 1
-		while (line >= 0) {
-			const lineText = document.lineAt(line).text.trim()
-			if (isCommentLine(lineText, document.languageId)) {
-				comment = lineText + "\n" + comment
-				commentStartLine = line
-				line--
-			} else {
-				break
-			}
-		}
-
-		// Check for multi-line comments below
-		line = currentLine + 1
-		while (line < document.lineCount) {
-			const lineText = document.lineAt(line).text.trim()
-			if (isCommentLine(lineText, document.languageId)) {
-				comment = comment + "\n" + lineText
-				commentEndLine = line
-				line++
-			} else {
-				break
-			}
-		}
-	} else if (currentLine > 0) {
-		// Check previous line for comment
-		const prevLineText = document.lineAt(currentLine - 1).text
-		if (isCommentLine(prevLineText.trim(), document.languageId)) {
-			comment = prevLineText.trim()
-			commentStartLine = currentLine - 1
-			commentEndLine = currentLine - 1
-		}
-	}
-
-	return comment
-}
-
 /**
  * Cleans comment text by removing comment syntax
  */

--- a/src/services/ghost/strategies/__tests__/AutoTriggerStrategy.test.ts
+++ b/src/services/ghost/strategies/__tests__/AutoTriggerStrategy.test.ts
@@ -1,7 +1,6 @@
-import * as vscode from "vscode"
 import { describe, it, expect, beforeEach } from "vitest"
 import { AutoTriggerStrategy } from "../AutoTriggerStrategy"
-import { GhostSuggestionContext, AutocompleteInput } from "../../types"
+import { AutocompleteInput } from "../../types"
 import crypto from "crypto"
 
 function createAutocompleteInput(
@@ -84,24 +83,6 @@ describe("AutoTriggerStrategy", () => {
 
 	describe("getPrompts - comment-driven behavior", () => {
 		it("should use comment-specific prompts when cursor is on empty line after comment", () => {
-			const mockDocument = {
-				languageId: "typescript",
-				getText: () => "// TODO: implement sum function\n",
-				lineAt: (line: number) => ({
-					text: line === 0 ? "// TODO: implement sum function" : "",
-					lineNumber: line,
-				}),
-				lineCount: 2,
-				uri: { toString: () => "file:///test.ts" },
-				offsetAt: (position: vscode.Position) => (position.line === 1 ? 32 : 0),
-			} as vscode.TextDocument
-
-			const mockRange = {
-				start: { line: 1, character: 0 } as vscode.Position,
-				end: { line: 1, character: 0 } as vscode.Position,
-				isEmpty: true,
-			} as vscode.Range
-
 			const { systemPrompt, userPrompt } = strategy.getPrompts(
 				createAutocompleteInput("/test.ts", 1, 0),
 				"// TODO: implement sum function\n",
@@ -120,24 +101,6 @@ describe("AutoTriggerStrategy", () => {
 		})
 
 		it("should use comment-specific prompts when cursor is on comment line", () => {
-			const mockDocument = {
-				languageId: "typescript",
-				getText: () => "// FIXME: handle edge case\n",
-				lineAt: (line: number) => ({
-					text: "// FIXME: handle edge case",
-					lineNumber: line,
-				}),
-				lineCount: 1,
-				uri: { toString: () => "file:///test.ts" },
-				offsetAt: (position: vscode.Position) => 0,
-			} as vscode.TextDocument
-
-			const mockRange = {
-				start: { line: 0, character: 26 } as vscode.Position,
-				end: { line: 0, character: 26 } as vscode.Position,
-				isEmpty: true,
-			} as vscode.Range
-
 			const { systemPrompt, userPrompt } = strategy.getPrompts(
 				createAutocompleteInput("/test.ts", 0, 26),
 				"// FIXME: handle edge case",
@@ -157,21 +120,6 @@ describe("AutoTriggerStrategy", () => {
 
 	describe("getPrompts - auto-trigger behavior", () => {
 		it("should use auto-trigger prompts for regular code completion", () => {
-			const mockDocument = {
-				languageId: "typescript",
-				getText: () => "const x = 1;\n",
-				lineAt: (line: number) => ({
-					text: "const x = 1;",
-				}),
-				uri: { toString: () => "file:///test.ts" },
-				offsetAt: (position: vscode.Position) => 13,
-			} as vscode.TextDocument
-
-			const mockRange = {
-				start: { line: 0, character: 13 } as vscode.Position,
-				end: { line: 0, character: 13 } as vscode.Position,
-			} as vscode.Range
-
 			const { systemPrompt, userPrompt } = strategy.getPrompts(
 				createAutocompleteInput("/test.ts", 0, 13),
 				"const x = 1;\n",
@@ -189,24 +137,6 @@ describe("AutoTriggerStrategy", () => {
 		})
 
 		it("should not treat empty line without preceding comment as comment-driven", () => {
-			const mockDocument = {
-				languageId: "typescript",
-				getText: () => "const x = 1;\n\n",
-				lineAt: (line: number) => ({
-					text: line === 0 ? "const x = 1;" : "",
-					lineNumber: line,
-				}),
-				lineCount: 3,
-				uri: { toString: () => "file:///test.ts" },
-				offsetAt: (position: vscode.Position) => (position.line === 1 ? 13 : 0),
-			} as vscode.TextDocument
-
-			const mockRange = {
-				start: { line: 1, character: 0 } as vscode.Position,
-				end: { line: 1, character: 0 } as vscode.Position,
-				isEmpty: true,
-			} as vscode.Range
-
 			const { systemPrompt } = strategy.getPrompts(
 				createAutocompleteInput("/test.ts", 1, 0),
 				"const x = 1;\n",

--- a/src/services/ghost/strategies/__tests__/AutoTriggerStrategy.test.ts
+++ b/src/services/ghost/strategies/__tests__/AutoTriggerStrategy.test.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode"
 import { describe, it, expect, beforeEach } from "vitest"
 import { AutoTriggerStrategy } from "../AutoTriggerStrategy"
-import { GhostSuggestionContext } from "../../types"
+import { GhostSuggestionContext, AutocompleteInput } from "../../types"
+import crypto from "crypto"
 
 describe("AutoTriggerStrategy", () => {
 	let strategy: AutoTriggerStrategy
@@ -91,7 +92,25 @@ describe("AutoTriggerStrategy", () => {
 				range: mockRange,
 			}
 
-			const { systemPrompt, userPrompt } = strategy.getPrompts(context)
+			const prefix = "// TODO: implement sum function\n"
+			const suffix = ""
+			const languageId = "typescript"
+			const autocompleteInput: AutocompleteInput = {
+				isUntitledFile: false,
+				completionId: crypto.randomUUID(),
+				filepath: "/test.ts",
+				pos: { line: 1, character: 0 },
+				recentlyVisitedRanges: [],
+				recentlyEditedRanges: [],
+			}
+
+			const { systemPrompt, userPrompt } = strategy.getPrompts(
+				autocompleteInput,
+				prefix,
+				suffix,
+				languageId,
+				context,
+			)
 
 			// Verify system prompt contains comment-specific keywords
 			expect(systemPrompt.toLowerCase()).toContain("comment")
@@ -127,7 +146,25 @@ describe("AutoTriggerStrategy", () => {
 				range: mockRange,
 			}
 
-			const { systemPrompt, userPrompt } = strategy.getPrompts(context)
+			const prefix = "// FIXME: handle edge case"
+			const suffix = "\n"
+			const languageId = "typescript"
+			const autocompleteInput: AutocompleteInput = {
+				isUntitledFile: false,
+				completionId: crypto.randomUUID(),
+				filepath: "/test.ts",
+				pos: { line: 0, character: 26 },
+				recentlyVisitedRanges: [],
+				recentlyEditedRanges: [],
+			}
+
+			const { systemPrompt, userPrompt } = strategy.getPrompts(
+				autocompleteInput,
+				prefix,
+				suffix,
+				languageId,
+				context,
+			)
 
 			// Verify system prompt contains comment-specific keywords
 			expect(systemPrompt.toLowerCase()).toContain("comment")
@@ -161,7 +198,25 @@ describe("AutoTriggerStrategy", () => {
 				range: mockRange,
 			}
 
-			const { systemPrompt, userPrompt } = strategy.getPrompts(context)
+			const prefix = "const x = 1;\n"
+			const suffix = ""
+			const languageId = "typescript"
+			const autocompleteInput: AutocompleteInput = {
+				isUntitledFile: false,
+				completionId: crypto.randomUUID(),
+				filepath: "/test.ts",
+				pos: { line: 0, character: 13 },
+				recentlyVisitedRanges: [],
+				recentlyEditedRanges: [],
+			}
+
+			const { systemPrompt, userPrompt } = strategy.getPrompts(
+				autocompleteInput,
+				prefix,
+				suffix,
+				languageId,
+				context,
+			)
 
 			// Verify system prompt contains auto-trigger keywords
 			expect(systemPrompt).toContain("Auto-Completion")
@@ -196,7 +251,19 @@ describe("AutoTriggerStrategy", () => {
 				range: mockRange,
 			}
 
-			const { systemPrompt } = strategy.getPrompts(context)
+			const prefix = "const x = 1;\n"
+			const suffix = "\n"
+			const languageId = "typescript"
+			const autocompleteInput: AutocompleteInput = {
+				isUntitledFile: false,
+				completionId: crypto.randomUUID(),
+				filepath: "/test.ts",
+				pos: { line: 1, character: 0 },
+				recentlyVisitedRanges: [],
+				recentlyEditedRanges: [],
+			}
+
+			const { systemPrompt } = strategy.getPrompts(autocompleteInput, prefix, suffix, languageId, context)
 
 			// Should use auto-trigger, not comment-driven
 			expect(systemPrompt).toContain("Auto-Completion")

--- a/src/services/ghost/strategies/__tests__/AutoTriggerStrategy.test.ts
+++ b/src/services/ghost/strategies/__tests__/AutoTriggerStrategy.test.ts
@@ -104,13 +104,7 @@ describe("AutoTriggerStrategy", () => {
 				recentlyEditedRanges: [],
 			}
 
-			const { systemPrompt, userPrompt } = strategy.getPrompts(
-				autocompleteInput,
-				prefix,
-				suffix,
-				languageId,
-				context,
-			)
+			const { systemPrompt, userPrompt } = strategy.getPrompts(autocompleteInput, prefix, suffix, languageId)
 
 			// Verify system prompt contains comment-specific keywords
 			expect(systemPrompt.toLowerCase()).toContain("comment")
@@ -158,13 +152,7 @@ describe("AutoTriggerStrategy", () => {
 				recentlyEditedRanges: [],
 			}
 
-			const { systemPrompt, userPrompt } = strategy.getPrompts(
-				autocompleteInput,
-				prefix,
-				suffix,
-				languageId,
-				context,
-			)
+			const { systemPrompt, userPrompt } = strategy.getPrompts(autocompleteInput, prefix, suffix, languageId)
 
 			// Verify system prompt contains comment-specific keywords
 			expect(systemPrompt.toLowerCase()).toContain("comment")
@@ -210,13 +198,7 @@ describe("AutoTriggerStrategy", () => {
 				recentlyEditedRanges: [],
 			}
 
-			const { systemPrompt, userPrompt } = strategy.getPrompts(
-				autocompleteInput,
-				prefix,
-				suffix,
-				languageId,
-				context,
-			)
+			const { systemPrompt, userPrompt } = strategy.getPrompts(autocompleteInput, prefix, suffix, languageId)
 
 			// Verify system prompt contains auto-trigger keywords
 			expect(systemPrompt).toContain("Auto-Completion")
@@ -263,7 +245,7 @@ describe("AutoTriggerStrategy", () => {
 				recentlyEditedRanges: [],
 			}
 
-			const { systemPrompt } = strategy.getPrompts(autocompleteInput, prefix, suffix, languageId, context)
+			const { systemPrompt } = strategy.getPrompts(autocompleteInput, prefix, suffix, languageId)
 
 			// Should use auto-trigger, not comment-driven
 			expect(systemPrompt).toContain("Auto-Completion")

--- a/src/services/ghost/strategies/__tests__/AutoTriggerStrategy.test.ts
+++ b/src/services/ghost/strategies/__tests__/AutoTriggerStrategy.test.ts
@@ -4,6 +4,21 @@ import { AutoTriggerStrategy } from "../AutoTriggerStrategy"
 import { GhostSuggestionContext, AutocompleteInput } from "../../types"
 import crypto from "crypto"
 
+function createAutocompleteInput(
+	filepath: string = "/test.ts",
+	line: number = 0,
+	character: number = 0,
+): AutocompleteInput {
+	return {
+		isUntitledFile: false,
+		completionId: crypto.randomUUID(),
+		filepath,
+		pos: { line, character },
+		recentlyVisitedRanges: [],
+		recentlyEditedRanges: [],
+	}
+}
+
 describe("AutoTriggerStrategy", () => {
 	let strategy: AutoTriggerStrategy
 
@@ -87,24 +102,12 @@ describe("AutoTriggerStrategy", () => {
 				isEmpty: true,
 			} as vscode.Range
 
-			const context: GhostSuggestionContext = {
-				document: mockDocument,
-				range: mockRange,
-			}
-
-			const prefix = "// TODO: implement sum function\n"
-			const suffix = ""
-			const languageId = "typescript"
-			const autocompleteInput: AutocompleteInput = {
-				isUntitledFile: false,
-				completionId: crypto.randomUUID(),
-				filepath: "/test.ts",
-				pos: { line: 1, character: 0 },
-				recentlyVisitedRanges: [],
-				recentlyEditedRanges: [],
-			}
-
-			const { systemPrompt, userPrompt } = strategy.getPrompts(autocompleteInput, prefix, suffix, languageId)
+			const { systemPrompt, userPrompt } = strategy.getPrompts(
+				createAutocompleteInput("/test.ts", 1, 0),
+				"// TODO: implement sum function\n",
+				"",
+				"typescript",
+			)
 
 			// Verify system prompt contains comment-specific keywords
 			expect(systemPrompt.toLowerCase()).toContain("comment")
@@ -135,24 +138,12 @@ describe("AutoTriggerStrategy", () => {
 				isEmpty: true,
 			} as vscode.Range
 
-			const context: GhostSuggestionContext = {
-				document: mockDocument,
-				range: mockRange,
-			}
-
-			const prefix = "// FIXME: handle edge case"
-			const suffix = "\n"
-			const languageId = "typescript"
-			const autocompleteInput: AutocompleteInput = {
-				isUntitledFile: false,
-				completionId: crypto.randomUUID(),
-				filepath: "/test.ts",
-				pos: { line: 0, character: 26 },
-				recentlyVisitedRanges: [],
-				recentlyEditedRanges: [],
-			}
-
-			const { systemPrompt, userPrompt } = strategy.getPrompts(autocompleteInput, prefix, suffix, languageId)
+			const { systemPrompt, userPrompt } = strategy.getPrompts(
+				createAutocompleteInput("/test.ts", 0, 26),
+				"// FIXME: handle edge case",
+				"\n",
+				"typescript",
+			)
 
 			// Verify system prompt contains comment-specific keywords
 			expect(systemPrompt.toLowerCase()).toContain("comment")
@@ -181,24 +172,12 @@ describe("AutoTriggerStrategy", () => {
 				end: { line: 0, character: 13 } as vscode.Position,
 			} as vscode.Range
 
-			const context: GhostSuggestionContext = {
-				document: mockDocument,
-				range: mockRange,
-			}
-
-			const prefix = "const x = 1;\n"
-			const suffix = ""
-			const languageId = "typescript"
-			const autocompleteInput: AutocompleteInput = {
-				isUntitledFile: false,
-				completionId: crypto.randomUUID(),
-				filepath: "/test.ts",
-				pos: { line: 0, character: 13 },
-				recentlyVisitedRanges: [],
-				recentlyEditedRanges: [],
-			}
-
-			const { systemPrompt, userPrompt } = strategy.getPrompts(autocompleteInput, prefix, suffix, languageId)
+			const { systemPrompt, userPrompt } = strategy.getPrompts(
+				createAutocompleteInput("/test.ts", 0, 13),
+				"const x = 1;\n",
+				"",
+				"typescript",
+			)
 
 			// Verify system prompt contains auto-trigger keywords
 			expect(systemPrompt).toContain("Auto-Completion")
@@ -228,24 +207,12 @@ describe("AutoTriggerStrategy", () => {
 				isEmpty: true,
 			} as vscode.Range
 
-			const context: GhostSuggestionContext = {
-				document: mockDocument,
-				range: mockRange,
-			}
-
-			const prefix = "const x = 1;\n"
-			const suffix = "\n"
-			const languageId = "typescript"
-			const autocompleteInput: AutocompleteInput = {
-				isUntitledFile: false,
-				completionId: crypto.randomUUID(),
-				filepath: "/test.ts",
-				pos: { line: 1, character: 0 },
-				recentlyVisitedRanges: [],
-				recentlyEditedRanges: [],
-			}
-
-			const { systemPrompt } = strategy.getPrompts(autocompleteInput, prefix, suffix, languageId)
+			const { systemPrompt } = strategy.getPrompts(
+				createAutocompleteInput("/test.ts", 1, 0),
+				"const x = 1;\n",
+				"\n",
+				"typescript",
+			)
 
 			// Should use auto-trigger, not comment-driven
 			expect(systemPrompt).toContain("Auto-Completion")

--- a/src/services/ghost/strategies/__tests__/CommentHelpers.test.ts
+++ b/src/services/ghost/strategies/__tests__/CommentHelpers.test.ts
@@ -1,6 +1,4 @@
-import * as vscode from "vscode"
-import { isCommentLine, extractComment, cleanComment } from "../CommentHelpers"
-import { MockTextDocument } from "../../../mocking/MockTextDocument"
+import { isCommentLine, cleanComment } from "../CommentHelpers"
 
 describe("CommentHelpers", () => {
 	describe("isCommentLine", () => {
@@ -133,98 +131,6 @@ describe("CommentHelpers", () => {
 			test("should handle unknown language IDs", () => {
 				expect(isCommentLine("// comment", "unknown")).toBe(true)
 				expect(isCommentLine("# comment", "unknown")).toBe(true)
-			})
-		})
-	})
-
-	describe("extractComment", () => {
-		function createDocument(content: string, languageId: string = "javascript"): MockTextDocument {
-			const uri = vscode.Uri.file("/test.js")
-			const doc = new MockTextDocument(uri, content)
-			doc.languageId = languageId
-			return doc
-		}
-
-		describe("single line comments", () => {
-			test("should extract comment from current line", () => {
-				const doc = createDocument("// comment\nconst x = 1")
-				expect(extractComment(doc, 0)).toBe("// comment")
-			})
-
-			test("should extract comment from previous line if current is not a comment", () => {
-				const doc = createDocument("// comment\nconst x = 1")
-				expect(extractComment(doc, 1)).toBe("// comment")
-			})
-
-			test("should return empty string if no comment found", () => {
-				const doc = createDocument("const x = 1\nconst y = 2")
-				expect(extractComment(doc, 1)).toBe("")
-			})
-
-			test("should not look at previous line if current line is first line", () => {
-				const doc = createDocument("const x = 1")
-				expect(extractComment(doc, 0)).toBe("")
-			})
-		})
-
-		describe("multi-line comments", () => {
-			test("should extract multi-line comment above current line", () => {
-				const doc = createDocument("// line 1\n// line 2\n// line 3\nconst x = 1")
-				const result = extractComment(doc, 2)
-				expect(result).toBe("// line 1\n// line 2\n// line 3")
-			})
-
-			test("should extract multi-line comment below current line", () => {
-				const doc = createDocument("// line 1\n// line 2\n// line 3\nconst x = 1")
-				const result = extractComment(doc, 0)
-				expect(result).toBe("// line 1\n// line 2\n// line 3")
-			})
-
-			test("should extract multi-line comment with cursor in middle", () => {
-				const doc = createDocument("// line 1\n// line 2\n// line 3\nconst x = 1")
-				const result = extractComment(doc, 1)
-				expect(result).toBe("// line 1\n// line 2\n// line 3")
-			})
-
-			test("should handle block comment style", () => {
-				const doc = createDocument("/*\n * line 1\n * line 2\n */\nconst x = 1")
-				const result = extractComment(doc, 1)
-				expect(result).toBe("* line 1\n* line 2\n*/")
-			})
-		})
-
-		describe("Python docstrings", () => {
-			test("should not extract empty Python docstring markers", () => {
-				const doc = createDocument('"""\n"""\n"""\ndef foo():', "python")
-				const result = extractComment(doc, 0)
-				expect(result).toBe("")
-			})
-		})
-
-		describe("edge cases", () => {
-			test("should handle document with only one line", () => {
-				const doc = createDocument("// comment")
-				expect(extractComment(doc, 0)).toBe("// comment")
-			})
-
-			test("should handle comment at end of document", () => {
-				const doc = createDocument("const x = 1\n// comment")
-				expect(extractComment(doc, 1)).toBe("// comment")
-			})
-
-			test("should stop at non-comment line", () => {
-				const doc = createDocument("// comment 1\nconst x = 1\n// comment 2")
-				expect(extractComment(doc, 0)).toBe("// comment 1")
-			})
-
-			test("should handle whitespace-only lines between comments", () => {
-				const doc = createDocument("// comment 1\n   \n// comment 2")
-				expect(extractComment(doc, 0)).toBe("// comment 1")
-			})
-
-			test("should preserve trimmed line content", () => {
-				const doc = createDocument("  // indented comment  \nconst x = 1")
-				expect(extractComment(doc, 0)).toBe("// indented comment")
 			})
 		})
 	})

--- a/src/services/ghost/types.ts
+++ b/src/services/ghost/types.ts
@@ -214,21 +214,6 @@ export function extractPrefixSuffix(
 }
 
 /**
- * Extract prefix (all lines up to cursor) from context
- */
-export function extractPrefix(context: GhostSuggestionContext): string {
-	if (!context.document || !context.range) {
-		return ""
-	}
-
-	const lines: string[] = []
-	for (let i = 0; i <= context.range.start.line; i++) {
-		lines.push(context.document.lineAt(i).text)
-	}
-	return lines.join("\n")
-}
-
-/**
  * Convert VSCode Position to our Position type
  */
 export function vscodePositionToPosition(pos: vscode.Position): Position {

--- a/src/test-llm-autocompletion/strategy-tester.ts
+++ b/src/test-llm-autocompletion/strategy-tester.ts
@@ -80,7 +80,6 @@ export class StrategyTester {
 			prefix,
 			suffix,
 			languageId,
-			context,
 		)
 
 		const response = await this.llmClient.sendPrompt(systemPrompt, userPrompt)

--- a/src/test-llm-autocompletion/strategy-tester.ts
+++ b/src/test-llm-autocompletion/strategy-tester.ts
@@ -36,7 +36,7 @@ export class StrategyTester {
 		}
 
 		// Remove the cursor marker from the code before creating the document
-		// formatDocumentWithCursor will add it back at the correct position
+		// the code will add it back at the correct position
 		const codeWithoutMarker = code.replace(CURSOR_MARKER, "")
 
 		const uri = vscode.Uri.parse("file:///test.js")

--- a/src/test-llm-autocompletion/strategy-tester.ts
+++ b/src/test-llm-autocompletion/strategy-tester.ts
@@ -1,10 +1,11 @@
 import { LLMClient } from "./llm-client.js"
 import { AutoTriggerStrategy } from "../services/ghost/strategies/AutoTriggerStrategy.js"
-import { GhostSuggestionContext } from "../services/ghost/types.js"
+import { GhostSuggestionContext, AutocompleteInput } from "../services/ghost/types.js"
 import { MockTextDocument } from "../services/mocking/MockTextDocument.js"
 import { CURSOR_MARKER } from "../services/ghost/ghostConstants.js"
 import { GhostStreamingParser } from "../services/ghost/GhostStreamingParser.js"
 import * as vscode from "vscode"
+import crypto from "crypto"
 
 export class StrategyTester {
 	private llmClient: LLMClient
@@ -55,7 +56,32 @@ export class StrategyTester {
 
 	async getCompletion(code: string): Promise<string> {
 		const context = this.createContext(code)
-		const { systemPrompt, userPrompt } = this.autoTriggerStrategy.getPrompts(context)
+
+		// Extract prefix, suffix, and languageId
+		const position = context.range?.start ?? new vscode.Position(0, 0)
+		const offset = context.document.offsetAt(position)
+		const text = context.document.getText()
+		const prefix = text.substring(0, offset)
+		const suffix = text.substring(offset)
+		const languageId = context.document.languageId || "javascript"
+
+		// Create AutocompleteInput
+		const autocompleteInput: AutocompleteInput = {
+			isUntitledFile: false,
+			completionId: crypto.randomUUID(),
+			filepath: context.document.uri.fsPath,
+			pos: { line: position.line, character: position.character },
+			recentlyVisitedRanges: [],
+			recentlyEditedRanges: [],
+		}
+
+		const { systemPrompt, userPrompt } = this.autoTriggerStrategy.getPrompts(
+			autocompleteInput,
+			prefix,
+			suffix,
+			languageId,
+			context,
+		)
 
 		const response = await this.llmClient.sendPrompt(systemPrompt, userPrompt)
 		return response.content


### PR DESCRIPTION


Changed the getPrompts method signature to align with autocomplete system architecture:
- Now accepts AutocompleteInput, prefix, suffix, and languageId as separate parameters
- Made GhostSuggestionContext optional since data is provided through other params
- Updated all callers in GhostProvider, tests, and utilities

This change extracts parts from PR #3102 to make the API more flexible and better aligned with the autocomplete input structure used throughout the system.
