### PR TITLE
add tests for autocomplete xml parsing

### DIFF
--- a/src/services/ghost/__tests__/GhostStreamingParser.xml-metadata.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingParser.xml-metadata.test.ts
@@ -1,0 +1,579 @@
+import { GhostStreamingParser } from "../GhostStreamingParser"
+import { GhostSuggestionContext } from "../types"
+
+// Mock vscode module
+vi.mock("vscode", () => ({
+	Uri: {
+		file: (path: string) => ({ toString: () => path, fsPath: path }),
+	},
+	workspace: {
+		asRelativePath: (uri: any) => uri.toString(),
+	},
+}))
+
+/**
+ * Test suite to reproduce and verify the fix for XML metadata leakage issue.
+ *
+ * User reported issue: When the LLM response contains malformed or nested XML/CDATA,
+ * the parser was including XML metadata tags in the actual suggestion content, resulting in:
+ *
+ *   end<change><search><
+ *   <<<AUTOCOMPLETE_HERE>>![CDATA[
+ *   private]]
+ *   private
+ *   ]]></search><replace></replace></change><![CDATA>[
+ *
+ * Root cause: The regex pattern `<!\[CDATA\[([\s\S]*?)\]\]>` uses non-greedy matching
+ * which can incorrectly capture nested CDATA tags or malformed XML as part of the content.
+ */
+describe("GhostStreamingParser - XML Metadata Leakage (User Issue Reproduction)", () => {
+	let parser: GhostStreamingParser
+	let mockDocument: any
+	let context: GhostSuggestionContext
+
+	beforeEach(() => {
+		parser = new GhostStreamingParser()
+
+		// Create mock document with Ruby code
+		mockDocument = {
+			uri: { toString: () => "/test/file.rb", fsPath: "/test/file.rb" },
+			getText: () => `  <<<AUTOCOMPLETE_HERE>>>
+
+  private`,
+			languageId: "ruby",
+			offsetAt: (position: any) => 2, // Mock cursor position at start
+		}
+
+		const mockRange: any = {
+			start: { line: 0, character: 2 },
+			end: { line: 0, character: 2 },
+			isEmpty: true,
+			isSingleLine: true,
+		}
+
+		context = {
+			document: mockDocument,
+			range: mockRange,
+		}
+
+		parser.initialize(context)
+	})
+
+	afterEach(() => {
+		parser.reset()
+	})
+
+	it("should handle the EXACT user-provided string correctly", () => {
+		// This is the EXACT string the user provided - testing if it works correctly
+		const exactUserString = `<change><search><![CDATA[  <<<AUTOCOMPLETE_HERE>>>
+
+	 private]]></search><replace><![CDATA[  def readonly_ranges
+	   config[:readonly_ranges]
+	 end
+
+	 <<<AUTOCOMPLETE_HERE>>>
+
+	 private]]></replace></change>`
+
+		const result = parser.processChunk(exactUserString)
+
+		// Log the results for inspection
+		console.log("Has new suggestions:", result.hasNewSuggestions)
+		console.log("Has suggestions:", result.suggestions.hasSuggestions())
+
+		const changes = parser.getCompletedChanges()
+		console.log("Number of changes:", changes.length)
+
+		if (changes.length > 0) {
+			console.log("Search content:", JSON.stringify(changes[0].search))
+			console.log("Replace content:", JSON.stringify(changes[0].replace))
+
+			// Verify no XML metadata leaked
+			expect(changes[0].search).not.toContain("<![CDATA[")
+			expect(changes[0].search).not.toContain("]]>")
+			expect(changes[0].search).not.toContain("<change>")
+			expect(changes[0].search).not.toContain("</change>")
+			expect(changes[0].search).not.toContain("<search>")
+			expect(changes[0].search).not.toContain("</search>")
+			expect(changes[0].search).not.toContain("<replace>")
+			expect(changes[0].search).not.toContain("</replace>")
+
+			expect(changes[0].replace).not.toContain("<![CDATA[")
+			expect(changes[0].replace).not.toContain("]]>")
+			expect(changes[0].replace).not.toContain("<change>")
+			expect(changes[0].replace).not.toContain("</change>")
+			expect(changes[0].replace).not.toContain("<search>")
+			expect(changes[0].replace).not.toContain("</search>")
+			expect(changes[0].replace).not.toContain("<replace>")
+			expect(changes[0].replace).not.toContain("</replace>")
+
+			// Verify the actual content is correct
+			expect(changes[0].search).toContain("<<<AUTOCOMPLETE_HERE>>>")
+			expect(changes[0].search).toContain("private")
+			expect(changes[0].replace).toContain("def readonly_ranges")
+			expect(changes[0].replace).toContain("config[:readonly_ranges]")
+			expect(changes[0].replace).toContain("end")
+		}
+	})
+
+	it("should handle the EXACT user string with finishStream() call", () => {
+		// This simulates the exact flow in GhostProvider where finishStream() is called
+		// after all chunks are processed. The sanitization in finishStream() might be
+		// causing the XML metadata leakage.
+
+		const exactUserString = `<change><search><![CDATA[  <<<AUTOCOMPLETE_HERE>>>
+
+	 private]]></search><replace><![CDATA[  def readonly_ranges
+	   config[:readonly_ranges]
+	 end
+
+	 <<<AUTOCOMPLETE_HERE>>>
+
+	 private]]></replace></change>`
+
+		// Process the chunk
+		const result = parser.processChunk(exactUserString)
+
+		// Now call finishStream() like GhostProvider does at line 364
+		const finalResult = parser.finishStream()
+
+		console.log("After finishStream - Has new suggestions:", finalResult.hasNewSuggestions)
+		console.log("After finishStream - Has suggestions:", finalResult.suggestions.hasSuggestions())
+
+		const changes = parser.getCompletedChanges()
+		console.log("After finishStream - Number of changes:", changes.length)
+
+		if (changes.length > 0) {
+			console.log("After finishStream - Search content:", JSON.stringify(changes[0].search))
+			console.log("After finishStream - Replace content:", JSON.stringify(changes[0].replace))
+
+			// Verify no XML metadata leaked after finishStream
+			expect(changes[0].search).not.toContain("<![CDATA[")
+			expect(changes[0].search).not.toContain("]]>")
+			expect(changes[0].search).not.toContain("<change>")
+			expect(changes[0].search).not.toContain("</change>")
+
+			expect(changes[0].replace).not.toContain("<![CDATA[")
+			expect(changes[0].replace).not.toContain("]]>")
+			expect(changes[0].replace).not.toContain("<change>")
+			expect(changes[0].replace).not.toContain("</change>")
+		}
+	})
+
+	it("should handle user string and verify actual suggestion content - WORKS CORRECTLY", () => {
+		// This test verifies that the exact user string works correctly
+		// The issue must be triggered by a different scenario (chunking, timing, etc.)
+
+		const exactUserString = `<change><search><![CDATA[  <<<AUTOCOMPLETE_HERE>>>
+
+	 private]]></search><replace><![CDATA[  def readonly_ranges
+	   config[:readonly_ranges]
+	 end
+
+	 <<<AUTOCOMPLETE_HERE>>>
+
+	 private]]></replace></change>`
+
+		const result = parser.processChunk(exactUserString)
+		const finalResult = parser.finishStream()
+
+		// Get the actual suggestions that would be displayed
+		const suggestions = finalResult.suggestions
+
+		console.log("Has suggestions:", suggestions.hasSuggestions())
+		console.log("Suggestions:", JSON.stringify(suggestions, null, 2))
+
+		// Check if suggestions contain XML metadata
+		if (suggestions.hasSuggestions()) {
+			const file = suggestions.getFile(mockDocument.uri)
+			if (file) {
+				const groups = file.getGroupsOperations()
+				for (const group of groups) {
+					for (const op of group) {
+						console.log("Operation type:", op.type)
+						console.log("Operation content:", JSON.stringify(op.content))
+
+						// The actual displayed content should NOT contain XML metadata
+						expect(op.content).not.toContain("<![CDATA[")
+						expect(op.content).not.toContain("]]>")
+						expect(op.content).not.toContain("<change>")
+						expect(op.content).not.toContain("</change>")
+						expect(op.content).not.toContain("<search>")
+						expect(op.content).not.toContain("</search>")
+						expect(op.content).not.toContain("<replace>")
+						expect(op.content).not.toContain("</replace>")
+					}
+				}
+			}
+		}
+	})
+
+	it("should not leak XML metadata tags in the response - exact user issue", () => {
+		// This reproduces the EXACT issue where XML metadata appears in suggestions
+		// The user reported seeing output like:
+		//   end<change><search><
+		//   <<<AUTOCOMPLETE_HERE>>![CDATA[
+		//   private]]
+		//   private
+		//   ]]></search><replace></replace></change><![CDATA>[
+
+		// This suggests the XML is being included in the actual suggestion content
+		const malformedResponse = `<change><search><![CDATA[  <<<AUTOCOMPLETE_HERE>>>
+
+	 private]]></search><replace><![CDATA[  def readonly_ranges
+	   config[:readonly_ranges]
+	 end<change><search><
+
+	 <<<AUTOCOMPLETE_HERE>>![CDATA[
+>
+
+	 private]]
+	 private
+]]></search><replace></replace></change><![CDATA>[
+]]></replace></change>`
+
+		const result = parser.processChunk(malformedResponse)
+
+		// The parser should handle this gracefully
+		const changes = parser.getCompletedChanges()
+
+		// Log what we got for debugging
+		console.log("Number of changes:", changes.length)
+		if (changes.length > 0) {
+			console.log("First change search:", JSON.stringify(changes[0].search))
+			console.log("First change replace:", JSON.stringify(changes[0].replace))
+		}
+
+		// If suggestions are generated, they should NOT contain XML metadata
+		if (result.suggestions.hasSuggestions()) {
+			for (const change of changes) {
+				// The replace content should not contain XML tags
+				expect(change.replace).not.toContain("<change>")
+				expect(change.replace).not.toContain("</change>")
+				expect(change.replace).not.toContain("<search>")
+				expect(change.replace).not.toContain("</search>")
+				expect(change.replace).not.toContain("<replace>")
+				expect(change.replace).not.toContain("</replace>")
+				expect(change.replace).not.toContain("<![CDATA[")
+				expect(change.replace).not.toContain("]]>")
+
+				// Search content should also be clean
+				expect(change.search).not.toContain("<change>")
+				expect(change.search).not.toContain("</change>")
+				expect(change.search).not.toContain("<replace>")
+				expect(change.search).not.toContain("</replace>")
+			}
+		}
+	})
+
+	it.fails("should handle nested CDATA tags without leaking metadata - KNOWN BUG", () => {
+		// This test documents the current bug: nested CDATA causes metadata leakage
+		// When there's nested CDATA like: <![CDATA[test<![CDATA[nested]]>]]>
+		// The regex captures: test<![CDATA[nested]]>
+		// Instead of just: test (or handling it as malformed XML)
+		//
+		// This is the root cause of the user's reported issue where XML metadata
+		// appears in the suggestion content.
+
+		const nestedCDATA = `<change><search><![CDATA[test<![CDATA[nested]]>]]></search><replace><![CDATA[replacement]]></replace></change>`
+
+		parser.reset()
+		parser.initialize(context)
+
+		const result = parser.processChunk(nestedCDATA)
+		const changes = parser.getCompletedChanges()
+
+		if (changes.length > 0) {
+			console.log("Nested CDATA - Search content:", JSON.stringify(changes[0].search))
+			console.log("Nested CDATA - Replace content:", JSON.stringify(changes[0].replace))
+
+			// EXPECTED BEHAVIOR: The search content should NOT include the nested CDATA tags
+			// This test will FAIL until the bug is fixed
+			expect(changes[0].search).not.toMatch(/<!\[CDATA\[/)
+			expect(changes[0].search).not.toMatch(/\]\]>/)
+			expect(changes[0].replace).not.toMatch(/<!\[CDATA\[/)
+			expect(changes[0].replace).not.toMatch(/\]\]>/)
+		}
+	})
+
+	it.fails("should handle extra closing CDATA tags without leaking metadata - KNOWN BUG", () => {
+		// This test documents another manifestation of the bug: extra ]]> tags leak through
+		// When there are extra closing tags like: <![CDATA[test]]>]]>
+		// The regex captures: test]]>
+		// Instead of just: test
+
+		const extraClosingTags = `<change><search><![CDATA[test]]>]]></search><replace><![CDATA[replacement]]>]]></replace></change>`
+
+		parser.reset()
+		parser.initialize(context)
+
+		const result = parser.processChunk(extraClosingTags)
+		const changes = parser.getCompletedChanges()
+
+		if (changes.length > 0) {
+			console.log("Extra closing tags - Search content:", JSON.stringify(changes[0].search))
+			console.log("Extra closing tags - Replace content:", JSON.stringify(changes[0].replace))
+
+			// EXPECTED BEHAVIOR: Should not include the extra ]]>
+			expect(changes[0].search).not.toMatch(/\]\]>/)
+			expect(changes[0].replace).not.toMatch(/\]\]>/)
+		}
+	})
+
+	it("should handle other malformed XML scenarios", () => {
+		// Test malformed XML scenarios that don't trigger the known bugs
+		const scenarios = [
+			{
+				name: "Unclosed CDATA in replace",
+				xml: `<change><search><![CDATA[test]]></search><replace><![CDATA[replacement</replace></change>`,
+			},
+			{
+				name: "Mixed up tags",
+				xml: `<change><search><![CDATA[test]]></replace><replace><![CDATA[replacement]]></search></change>`,
+			},
+		]
+
+		for (const scenario of scenarios) {
+			parser.reset()
+			parser.initialize(context)
+
+			const result = parser.processChunk(scenario.xml)
+			const changes = parser.getCompletedChanges()
+
+			console.log(`\nScenario: ${scenario.name}`)
+			console.log(`Changes found: ${changes.length}`)
+
+			// If any changes were parsed, they should not contain XML metadata
+			for (const change of changes) {
+				console.log(`  Search: ${JSON.stringify(change.search)}`)
+				console.log(`  Replace: ${JSON.stringify(change.replace)}`)
+
+				// These should not contain XML metadata
+				expect(change.search).not.toMatch(/<!\[CDATA\[/)
+				expect(change.search).not.toMatch(/\]\]>/)
+				expect(change.replace).not.toMatch(/<!\[CDATA\[/)
+				expect(change.replace).not.toMatch(/\]\]>/)
+			}
+		}
+	})
+
+	it("should handle multiple changes without XML metadata leakage", () => {
+		const multipleChanges = `<change><search><![CDATA[  <<<AUTOCOMPLETE_HERE>>>
+
+  private]]></search><replace><![CDATA[  def readonly_ranges
+    config[:readonly_ranges]
+  end
+
+  <<<AUTOCOMPLETE_HERE>>>
+
+  private]]></replace></change><change><search><![CDATA[private]]></search><replace><![CDATA[protected]]></replace></change>`
+
+		const result = parser.processChunk(multipleChanges)
+
+		expect(result.hasNewSuggestions).toBe(true)
+		const changes = parser.getCompletedChanges()
+		expect(changes).toHaveLength(2)
+
+		// Check both changes for XML metadata
+		for (const change of changes) {
+			expect(change.search).not.toContain("<![CDATA[")
+			expect(change.search).not.toContain("]]>")
+			expect(change.replace).not.toContain("<![CDATA[")
+			expect(change.replace).not.toContain("]]>")
+		}
+	})
+
+	it("should handle streaming chunks without XML metadata leakage", () => {
+		// Simulate streaming where XML tags come in chunks
+		const chunks = [
+			"<change><search><![CDATA[  <<<AUTOCOMPLETE_HERE>>>",
+			"\n\n  private]]></search><replace><![CDATA[  def readonly_ranges",
+			"\n    config[:readonly_ranges]",
+			"\n  end",
+			"\n\n  <<<AUTOCOMPLETE_HERE>>>",
+			"\n\n  private]]></replace></change>",
+		]
+
+		let finalResult
+		for (const chunk of chunks) {
+			finalResult = parser.processChunk(chunk)
+		}
+
+		expect(finalResult!.hasNewSuggestions).toBe(true)
+		const changes = parser.getCompletedChanges()
+		expect(changes).toHaveLength(1)
+
+		// Verify no XML metadata in the parsed content
+		expect(changes[0].search).not.toContain("<![CDATA[")
+		expect(changes[0].search).not.toContain("]]>")
+		expect(changes[0].replace).not.toContain("<![CDATA[")
+		expect(changes[0].replace).not.toContain("]]>")
+	})
+
+	it("should handle malformed CDATA sections without leaking metadata", () => {
+		// Test the case where CDATA might be malformed
+		const malformedCDATA = `<change><search><![CDATA[test</![CDATA[]]></search><replace><![CDATA[replacement]]></replace></change>`
+
+		const result = parser.processChunk(malformedCDATA)
+
+		// Even with malformed CDATA, we shouldn't leak XML tags
+		const changes = parser.getCompletedChanges()
+		if (changes.length > 0) {
+			expect(changes[0].search).not.toContain("<![CDATA[")
+			expect(changes[0].replace).not.toContain("<![CDATA[")
+		}
+	})
+
+	it("should preserve actual code content that looks like XML", () => {
+		// Edge case: what if the actual code contains strings that look like XML?
+		mockDocument.getText = () => `const xml = "<![CDATA[data]]>"`
+
+		const changeWithXMLLikeContent = `<change><search><![CDATA[const xml = "<![CDATA[data]]>"]]></search><replace><![CDATA[const xml = "<![CDATA[newdata]]>"]]></replace></change>`
+
+		const result = parser.processChunk(changeWithXMLLikeContent)
+
+		expect(result.hasNewSuggestions).toBe(true)
+		const changes = parser.getCompletedChanges()
+		expect(changes).toHaveLength(1)
+
+		// The actual code content should be preserved
+		expect(changes[0].replace).toContain('const xml = "<![CDATA[newdata]]>"')
+	})
+
+	describe("Chunking scenarios with exact user string", () => {
+		const exactUserString = `<change><search><![CDATA[  <<<AUTOCOMPLETE_HERE>>>
+
+	 private]]></search><replace><![CDATA[  def readonly_ranges
+	   config[:readonly_ranges]
+	 end
+
+	 <<<AUTOCOMPLETE_HERE>>>
+
+	 private]]></replace></change>`
+
+		it("should handle chunking at tag boundaries", () => {
+			parser.reset()
+			parser.initialize(context)
+
+			const chunks = [
+				"<change><search><![CDATA[  <<<AUTOCOMPLETE_HERE>>>",
+				"\n\n  private]]></search><replace><![CDATA[  def readonly_ranges",
+				"\n    config[:readonly_ranges]",
+				"\n  end",
+				"\n\n  <<<AUTOCOMPLETE_HERE>>>",
+				"\n\n  private]]></replace></change>",
+			]
+
+			for (const chunk of chunks) {
+				parser.processChunk(chunk)
+			}
+			const finalResult = parser.finishStream()
+
+			const changes = parser.getCompletedChanges()
+			if (changes.length > 0) {
+				expect(changes[0].search).not.toContain("<![CDATA[")
+				expect(changes[0].search).not.toContain("]]>")
+				expect(changes[0].replace).not.toContain("<![CDATA[")
+				expect(changes[0].replace).not.toContain("]]>")
+			}
+		})
+
+		it("should handle chunking mid-tag", () => {
+			parser.reset()
+			parser.initialize(context)
+
+			const chunks = [
+				"<change><search><![CDA",
+				"TA[  <<<AUTOCOMPLETE_HERE>>>\n\n  private]]></search><replace><![CDATA[  def readonly_ranges\n    config[:readonly_ranges]\n  end\n\n  <<<AUTOCOMPLETE_HERE>>>\n\n  private]]></replace></change>",
+			]
+
+			for (const chunk of chunks) {
+				parser.processChunk(chunk)
+			}
+			const finalResult = parser.finishStream()
+
+			const changes = parser.getCompletedChanges()
+			if (changes.length > 0) {
+				expect(changes[0].search).not.toContain("<![CDATA[")
+				expect(changes[0].replace).not.toContain("<![CDATA[")
+			}
+		})
+
+		it("should handle chunking at CDATA boundaries", () => {
+			parser.reset()
+			parser.initialize(context)
+
+			const chunks = [
+				"<change><search><![CDATA[  <<<AUTOCOMPLETE_HERE>>>\n\n  private]]>",
+				"</search><replace><![CDATA[  def readonly_ranges\n    config[:readonly_ranges]\n  end\n\n  <<<AUTOCOMPLETE_HERE>>>\n\n  private]]>",
+				"</replace></change>",
+			]
+
+			for (const chunk of chunks) {
+				parser.processChunk(chunk)
+			}
+			const finalResult = parser.finishStream()
+
+			const changes = parser.getCompletedChanges()
+			if (changes.length > 0) {
+				expect(changes[0].search).not.toContain("<![CDATA[")
+				expect(changes[0].replace).not.toContain("<![CDATA[")
+			}
+		})
+
+		it("should handle single character chunks", () => {
+			parser.reset()
+			parser.initialize(context)
+
+			const chunks = exactUserString.split("")
+
+			for (const chunk of chunks) {
+				parser.processChunk(chunk)
+			}
+			const finalResult = parser.finishStream()
+
+			const changes = parser.getCompletedChanges()
+			if (changes.length > 0) {
+				expect(changes[0].search).not.toContain("<![CDATA[")
+				expect(changes[0].replace).not.toContain("<![CDATA[")
+			}
+		})
+
+		it("should handle random chunk sizes", () => {
+			parser.reset()
+			parser.initialize(context)
+
+			// Split at random positions
+			const chunkSizes = [15, 30, 20, 40, 25, 50]
+			const chunks: string[] = []
+			let pos = 0
+
+			for (const size of chunkSizes) {
+				if (pos >= exactUserString.length) break
+				chunks.push(exactUserString.substring(pos, pos + size))
+				pos += size
+			}
+			if (pos < exactUserString.length) {
+				chunks.push(exactUserString.substring(pos))
+			}
+
+			console.log(
+				"Random chunks:",
+				chunks.map((c) => c.length),
+			)
+
+			for (const chunk of chunks) {
+				parser.processChunk(chunk)
+			}
+			const finalResult = parser.finishStream()
+
+			const changes = parser.getCompletedChanges()
+			if (changes.length > 0) {
+				console.log("Search:", JSON.stringify(changes[0].search))
+				console.log("Replace:", JSON.stringify(changes[0].replace))
+				expect(changes[0].search).not.toContain("<![CDATA[")
+				expect(changes[0].replace).not.toContain("<![CDATA[")
+			}
+		})
+	})
+})


### PR DESCRIPTION
to reproduce autocomplete bugs like:
<img width="2170" height="262" alt="image" src="https://github.com/user-attachments/assets/26d73ea1-df01-444a-9a1f-dda8650fbcb0" />

However I/Sonnet don't seem to be able to do so

for context, I have seen this response go wrong:
```
<change><search><![CDATA[  <<<AUTOCOMPLETE_HERE>>>

  private]]></search><replace><![CDATA[  def readonly_ranges
    config[:readonly_ranges]
  end

  <<<AUTOCOMPLETE_HERE>>>

  private]]></replace></change>
```