### PR TITLE
Make autocomplete LLM parser non streaming

### DIFF
--- a/.changeset/eager-cloths-return.md
+++ b/.changeset/eager-cloths-return.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Fix bug: autocomplete no longer suggests strange XML

--- a/src/services/ghost/GhostProvider.ts
+++ b/src/services/ghost/GhostProvider.ts
@@ -311,32 +311,6 @@ export class GhostProvider {
 
 			if (chunk.type === "text") {
 				response += chunk.text
-
-				// Process the text chunk through our streaming parser
-				const parseResult = this.streamingParser.processChunk(chunk.text)
-
-				if (parseResult.hasNewSuggestions) {
-					// Update our suggestions with the new parsed results
-					this.suggestions = parseResult.suggestions
-
-					// If this is the first suggestion, show it immediately
-					if (!hasShownFirstSuggestion && this.suggestions.hasSuggestions()) {
-						hasShownFirstSuggestion = true
-						this.stopProcessing() // Stop the loading animation
-						this.selectClosestSuggestion()
-						void this.render() // Render asynchronously to not block streaming
-					} else if (hasShownFirstSuggestion) {
-						// Update existing suggestions
-						this.selectClosestSuggestion()
-						void this.render() // Update UI asynchronously
-					}
-				}
-
-				// If the response appears complete, finalize
-				if (parseResult.isComplete && hasShownFirstSuggestion) {
-					this.selectClosestSuggestion()
-					void this.render()
-				}
 			}
 		}
 
@@ -373,7 +347,7 @@ export class GhostProvider {
 			}
 
 			// Finish the streaming parser to apply sanitization if needed
-			const finalParseResult = this.streamingParser.finishStream()
+			const finalParseResult = this.streamingParser.finishStream(response)
 			if (finalParseResult.hasNewSuggestions && !hasShownFirstSuggestion) {
 				// Handle case where sanitization produced suggestions
 				this.suggestions = finalParseResult.suggestions

--- a/src/services/ghost/GhostProvider.ts
+++ b/src/services/ghost/GhostProvider.ts
@@ -347,7 +347,7 @@ export class GhostProvider {
 			}
 
 			// Finish the streaming parser to apply sanitization if needed
-			const finalParseResult = this.streamingParser.finishStream(response)
+			const finalParseResult = this.streamingParser.parseResponse(response)
 			if (finalParseResult.hasNewSuggestions && !hasShownFirstSuggestion) {
 				// Handle case where sanitization produced suggestions
 				this.suggestions = finalParseResult.suggestions

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -227,7 +227,7 @@ export class GhostStreamingParser {
 	/**
 	 * Mark the stream as finished and process any remaining content with sanitization
 	 */
-	public finishStream(fullResponse: string): StreamingParseResult {
+	public parseResponse(fullResponse: string): StreamingParseResult {
 		this.buffer = fullResponse
 
 		// Extract any newly completed changes from the current buffer

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -232,7 +232,7 @@ export class GhostStreamingParser {
 		this.buffer = fullResponse
 
 		// Extract any newly completed changes from the current buffer
-		const newChanges = this.extractCompletedChanges()
+		const newChanges = this.extractCompletedChanges(this.buffer)
 
 		let hasNewSuggestions = newChanges.length > 0
 
@@ -249,7 +249,7 @@ export class GhostStreamingParser {
 			if (sanitizedBuffer !== this.buffer) {
 				// Re-process with sanitized buffer
 				this.buffer = sanitizedBuffer
-				const sanitizedChanges = this.extractCompletedChanges()
+				const sanitizedChanges = this.extractCompletedChanges(this.buffer)
 				if (sanitizedChanges.length > 0) {
 					this.completedChanges.push(...sanitizedChanges)
 					hasNewSuggestions = true
@@ -271,11 +271,8 @@ export class GhostStreamingParser {
 	/**
 	 * Extract completed <change> blocks from the buffer
 	 */
-	private extractCompletedChanges(): ParsedChange[] {
+	private extractCompletedChanges(searchText: string): ParsedChange[] {
 		const newChanges: ParsedChange[] = []
-
-		// Look for complete <change> blocks starting from where we left off
-		const searchText = this.buffer
 
 		// Updated regex to handle both single-line XML format and traditional format with whitespace
 		const changeRegex =

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -230,7 +230,7 @@ export class GhostStreamingParser {
 	 */
 	public finishStream(fullResponse: string): StreamingParseResult {
 		// Add chunk to buffer
-		this.buffer += fullResponse
+		this.buffer = fullResponse
 
 		// Extract any newly completed changes from the current buffer
 		const newChanges = this.extractCompletedChanges()

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -235,6 +235,14 @@ export class GhostStreamingParser {
 			throw new Error("Parser not initialized. Call initialize() first.")
 		}
 
+		if (!this.streamFinished) {
+			return {
+				suggestions: new GhostSuggestionsState(),
+				isComplete: false,
+				hasNewSuggestions: false,
+			}
+		}
+
 		// Add chunk to buffer
 		this.buffer += chunk
 
@@ -278,9 +286,9 @@ export class GhostStreamingParser {
 	/**
 	 * Mark the stream as finished and process any remaining content with sanitization
 	 */
-	public finishStream(): StreamingParseResult {
+	public finishStream(fullResponse: string): StreamingParseResult {
 		this.streamFinished = true
-		return this.processChunk("")
+		return this.processChunk(fullResponse)
 	}
 
 	/**

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -205,7 +205,6 @@ export class GhostStreamingParser {
 	private completedChanges: ParsedChange[] = []
 	private lastProcessedIndex: number = 0
 	private context: GhostSuggestionContext | null = null
-	private streamFinished: boolean = false
 
 	constructor() {}
 
@@ -224,15 +223,12 @@ export class GhostStreamingParser {
 		this.buffer = ""
 		this.completedChanges = []
 		this.lastProcessedIndex = 0
-		this.streamFinished = false
 	}
 
 	/**
 	 * Mark the stream as finished and process any remaining content with sanitization
 	 */
 	public finishStream(fullResponse: string): StreamingParseResult {
-		this.streamFinished = true
-
 		// Add chunk to buffer
 		this.buffer += fullResponse
 
@@ -249,7 +245,7 @@ export class GhostStreamingParser {
 
 		// Apply very conservative sanitization only when the stream is finished
 		// and we still have no completed changes but have content in the buffer
-		if (this.completedChanges.length === 0 && this.buffer.trim().length > 0 && this.streamFinished) {
+		if (this.completedChanges.length === 0 && this.buffer.trim().length > 0) {
 			const sanitizedBuffer = sanitizeXMLConservative(this.buffer)
 			if (sanitizedBuffer !== this.buffer) {
 				// Re-process with sanitized buffer

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -228,7 +228,6 @@ export class GhostStreamingParser {
 	 * Mark the stream as finished and process any remaining content with sanitization
 	 */
 	public finishStream(fullResponse: string): StreamingParseResult {
-		// Add chunk to buffer
 		this.buffer = fullResponse
 
 		// Extract any newly completed changes from the current buffer

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -203,7 +203,7 @@ function mapNormalizedToOriginalIndex(
 export class GhostStreamingParser {
 	public buffer: string = ""
 	private completedChanges: ParsedChange[] = []
-	private lastProcessedIndex: number = 0
+
 	private context: GhostSuggestionContext | null = null
 
 	constructor() {}
@@ -222,7 +222,6 @@ export class GhostStreamingParser {
 	public reset(): void {
 		this.buffer = ""
 		this.completedChanges = []
-		this.lastProcessedIndex = 0
 	}
 
 	/**
@@ -276,7 +275,7 @@ export class GhostStreamingParser {
 		const newChanges: ParsedChange[] = []
 
 		// Look for complete <change> blocks starting from where we left off
-		const searchText = this.buffer.substring(this.lastProcessedIndex)
+		const searchText = this.buffer
 
 		// Updated regex to handle both single-line XML format and traditional format with whitespace
 		const changeRegex =
@@ -299,11 +298,6 @@ export class GhostStreamingParser {
 			})
 
 			lastMatchEnd = match.index + match[0].length
-		}
-
-		// Update our processed index to avoid re-processing the same content
-		if (lastMatchEnd > 0) {
-			this.lastProcessedIndex += lastMatchEnd
 		}
 
 		return newChanges

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -228,23 +228,13 @@ export class GhostStreamingParser {
 	}
 
 	/**
-	 * Process a new chunk of text and return any newly completed suggestions
+	 * Mark the stream as finished and process any remaining content with sanitization
 	 */
-	public processChunk(chunk: string): StreamingParseResult {
-		if (!this.context) {
-			throw new Error("Parser not initialized. Call initialize() first.")
-		}
-
-		if (!this.streamFinished) {
-			return {
-				suggestions: new GhostSuggestionsState(),
-				isComplete: false,
-				hasNewSuggestions: false,
-			}
-		}
+	public finishStream(fullResponse: string): StreamingParseResult {
+		this.streamFinished = true
 
 		// Add chunk to buffer
-		this.buffer += chunk
+		this.buffer += fullResponse
 
 		// Extract any newly completed changes from the current buffer
 		const newChanges = this.extractCompletedChanges()
@@ -281,14 +271,6 @@ export class GhostStreamingParser {
 			isComplete,
 			hasNewSuggestions,
 		}
-	}
-
-	/**
-	 * Mark the stream as finished and process any remaining content with sanitization
-	 */
-	public finishStream(fullResponse: string): StreamingParseResult {
-		this.streamFinished = true
-		return this.processChunk(fullResponse)
 	}
 
 	/**

--- a/src/services/ghost/__tests__/GhostProvider.spec.ts
+++ b/src/services/ghost/__tests__/GhostProvider.spec.ts
@@ -130,8 +130,8 @@ describe("GhostProvider", () => {
 		// Initialize streaming parser
 		streamingParser.initialize(context)
 
-		// Process the response as a single chunk (simulating complete response)
-		const result = streamingParser.processChunk(response)
+		// Process the complete response
+		const result = streamingParser.finishStream(response)
 
 		// Apply the suggestions
 		await workspaceEdit.applySuggestions(result.suggestions)
@@ -232,7 +232,7 @@ describe("GhostProvider", () => {
 
 			// Test empty response
 			streamingParser.initialize(context)
-			const result = streamingParser.processChunk("")
+			const result = streamingParser.finishStream("")
 			expect(result.suggestions.hasSuggestions()).toBe(false)
 		})
 
@@ -243,7 +243,7 @@ describe("GhostProvider", () => {
 			// Test invalid diff format
 			const invalidDiff = "This is not a valid diff format"
 			streamingParser.initialize(context)
-			const result = streamingParser.processChunk(invalidDiff)
+			const result = streamingParser.finishStream(invalidDiff)
 			expect(result.suggestions.hasSuggestions()).toBe(false)
 		})
 
@@ -262,7 +262,7 @@ describe("GhostProvider", () => {
 console.log('test');]]></replace></change>`
 
 			streamingParser.initialize(context)
-			const result = streamingParser.processChunk(xmlResponse)
+			const result = streamingParser.finishStream(xmlResponse)
 			// Should work with the XML format
 			expect(result.suggestions.hasSuggestions()).toBe(true)
 		})

--- a/src/services/ghost/__tests__/GhostProvider.spec.ts
+++ b/src/services/ghost/__tests__/GhostProvider.spec.ts
@@ -131,7 +131,7 @@ describe("GhostProvider", () => {
 		streamingParser.initialize(context)
 
 		// Process the complete response
-		const result = streamingParser.finishStream(response)
+		const result = streamingParser.parseResponse(response)
 
 		// Apply the suggestions
 		await workspaceEdit.applySuggestions(result.suggestions)
@@ -232,7 +232,7 @@ describe("GhostProvider", () => {
 
 			// Test empty response
 			streamingParser.initialize(context)
-			const result = streamingParser.finishStream("")
+			const result = streamingParser.parseResponse("")
 			expect(result.suggestions.hasSuggestions()).toBe(false)
 		})
 
@@ -243,7 +243,7 @@ describe("GhostProvider", () => {
 			// Test invalid diff format
 			const invalidDiff = "This is not a valid diff format"
 			streamingParser.initialize(context)
-			const result = streamingParser.finishStream(invalidDiff)
+			const result = streamingParser.parseResponse(invalidDiff)
 			expect(result.suggestions.hasSuggestions()).toBe(false)
 		})
 
@@ -262,7 +262,7 @@ describe("GhostProvider", () => {
 console.log('test');]]></replace></change>`
 
 			streamingParser.initialize(context)
-			const result = streamingParser.finishStream(xmlResponse)
+			const result = streamingParser.parseResponse(xmlResponse)
 			// Should work with the XML format
 			expect(result.suggestions.hasSuggestions()).toBe(true)
 		})

--- a/src/services/ghost/__tests__/GhostStreamingIntegration.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingIntegration.test.ts
@@ -92,7 +92,7 @@ describe("Ghost Streaming Integration", () => {
 			const usageInfo = await model.generateResponse("system prompt", "user prompt", onChunk)
 
 			// Process complete response
-			const parseResult = streamingParser.finishStream(fullResponse)
+			const parseResult = streamingParser.parseResponse(fullResponse)
 			finalSuggestionTime = performance.now()
 
 			const endTime = performance.now()
@@ -142,7 +142,7 @@ describe("Ghost Streaming Integration", () => {
 			await model.generateResponse("system", "user", onChunk)
 
 			// Process complete response
-			const parseResult = streamingParser.finishStream(fullResponse)
+			const parseResult = streamingParser.parseResponse(fullResponse)
 
 			// Should have processed both suggestions
 			expect(parseResult.hasNewSuggestions).toBe(true)
@@ -180,7 +180,7 @@ describe("Ghost Streaming Integration", () => {
 			await model.generateResponse("system", "user", onChunk)
 
 			// Try to process incomplete response
-			const parseResult = streamingParser.finishStream(fullResponse)
+			const parseResult = streamingParser.parseResponse(fullResponse)
 
 			// Should have no complete suggestions due to cancellation
 			expect(parseResult.hasNewSuggestions).toBe(false)
@@ -220,7 +220,7 @@ describe("Ghost Streaming Integration", () => {
 
 			// Process complete response
 			try {
-				const parseResult = streamingParser.finishStream(fullResponse)
+				const parseResult = streamingParser.parseResponse(fullResponse)
 				// Should only process the valid suggestion
 				if (parseResult.hasNewSuggestions) {
 					expect(streamingParser.getCompletedChanges()).toHaveLength(1)
@@ -260,7 +260,7 @@ describe("Ghost Streaming Integration", () => {
 
 			await model.generateResponse("system", "user", onChunk)
 
-			const parseResult = streamingParser.finishStream(fullResponse)
+			const parseResult = streamingParser.parseResponse(fullResponse)
 			const totalTime = performance.now() - startTime
 
 			// Should process successfully

--- a/src/services/ghost/__tests__/GhostStreamingIntegration.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingIntegration.test.ts
@@ -57,7 +57,7 @@ describe("Ghost Streaming Integration", () => {
 	})
 
 	describe("end-to-end streaming workflow", () => {
-		it("should process streaming chunks and show suggestions incrementally", async () => {
+		it("should process streaming chunks and show suggestions when complete", async () => {
 			// Simulate streaming chunks that build up to a complete suggestion
 			const streamingChunks: ApiStreamChunk[] = [
 				{ type: "text", text: "<change><search><![CDATA[function test() {" },
@@ -76,50 +76,39 @@ describe("Ghost Streaming Integration", () => {
 			// Initialize streaming parser
 			streamingParser.initialize(context)
 
-			let firstSuggestionTime: number | null = null
+			let fullResponse = ""
 			let finalSuggestionTime: number | null = null
-			let suggestionCount = 0
 
 			const startTime = performance.now()
 
-			// Simulate the streaming callback workflow
+			// Simulate the streaming callback workflow - accumulate chunks
 			const onChunk = (chunk: ApiStreamChunk) => {
 				if (chunk.type === "text") {
-					const parseResult = streamingParser.processChunk(chunk.text)
-
-					if (parseResult.hasNewSuggestions && parseResult.suggestions.hasSuggestions()) {
-						suggestionCount++
-
-						if (firstSuggestionTime === null) {
-							firstSuggestionTime = performance.now()
-						}
-
-						if (parseResult.isComplete) {
-							finalSuggestionTime = performance.now()
-						}
-					}
+					fullResponse += chunk.text
 				}
 			}
 
 			// Run the streaming generation
 			const usageInfo = await model.generateResponse("system prompt", "user prompt", onChunk)
 
+			// Process complete response
+			const parseResult = streamingParser.finishStream(fullResponse)
+			finalSuggestionTime = performance.now()
+
 			const endTime = performance.now()
 
 			// Verify streaming behavior
-			expect(firstSuggestionTime).not.toBeNull()
 			expect(finalSuggestionTime).not.toBeNull()
-			expect(suggestionCount).toBeGreaterThan(0)
+			expect(parseResult.hasNewSuggestions).toBe(true)
+			expect(parseResult.suggestions.hasSuggestions()).toBe(true)
 
-			// Verify timing - first suggestion should come before final
-			expect(firstSuggestionTime!).toBeLessThan(finalSuggestionTime!)
+			// Verify timing
 			expect(finalSuggestionTime!).toBeLessThan(endTime)
 
 			// Verify usage info
 			expect(usageInfo.inputTokens).toBe(10)
 			expect(usageInfo.outputTokens).toBe(20)
 
-			console.log(`First suggestion after: ${(firstSuggestionTime! - startTime).toFixed(2)}ms`)
 			console.log(`Final suggestion after: ${(finalSuggestionTime! - startTime).toFixed(2)}ms`)
 			console.log(`Total time: ${(endTime - startTime).toFixed(2)}ms`)
 		})
@@ -142,26 +131,23 @@ describe("Ghost Streaming Integration", () => {
 
 			streamingParser.initialize(context)
 
-			let suggestionUpdates = 0
-			let finalSuggestions: any = null
+			let fullResponse = ""
 
 			const onChunk = (chunk: ApiStreamChunk) => {
 				if (chunk.type === "text") {
-					const parseResult = streamingParser.processChunk(chunk.text)
-
-					if (parseResult.hasNewSuggestions) {
-						suggestionUpdates++
-						finalSuggestions = parseResult.suggestions
-					}
+					fullResponse += chunk.text
 				}
 			}
 
 			await model.generateResponse("system", "user", onChunk)
 
-			// Should have received multiple suggestion updates
-			expect(suggestionUpdates).toBe(2)
-			expect(finalSuggestions).not.toBeNull()
-			expect(finalSuggestions.hasSuggestions()).toBe(true)
+			// Process complete response
+			const parseResult = streamingParser.finishStream(fullResponse)
+
+			// Should have processed both suggestions
+			expect(parseResult.hasNewSuggestions).toBe(true)
+			expect(parseResult.suggestions.hasSuggestions()).toBe(true)
+			expect(streamingParser.getCompletedChanges()).toHaveLength(2)
 		})
 
 		it("should handle cancellation during streaming", async () => {
@@ -177,7 +163,7 @@ describe("Ghost Streaming Integration", () => {
 			streamingParser.initialize(context)
 
 			let isRequestCancelled = false
-			let suggestionCount = 0
+			let fullResponse = ""
 
 			const onChunk = (chunk: ApiStreamChunk) => {
 				if (isRequestCancelled) {
@@ -185,25 +171,24 @@ describe("Ghost Streaming Integration", () => {
 				}
 
 				if (chunk.type === "text") {
-					const parseResult = streamingParser.processChunk(chunk.text)
-
-					if (parseResult.hasNewSuggestions) {
-						suggestionCount++
-						// Simulate cancellation after first chunk
-						isRequestCancelled = true
-					}
+					fullResponse += chunk.text
+					// Simulate cancellation after first chunk
+					isRequestCancelled = true
 				}
 			}
 
 			await model.generateResponse("system", "user", onChunk)
 
-			// Should have processed some chunks but stopped due to cancellation
-			expect(suggestionCount).toBe(0) // No complete suggestions due to cancellation
+			// Try to process incomplete response
+			const parseResult = streamingParser.finishStream(fullResponse)
+
+			// Should have no complete suggestions due to cancellation
+			expect(parseResult.hasNewSuggestions).toBe(false)
 
 			// Reset should clear state
 			streamingParser.reset()
 			expect(streamingParser.buffer).toBe("")
-			expect((streamingParser as any).getCompletedChanges()).toHaveLength(0)
+			expect(streamingParser.getCompletedChanges()).toHaveLength(0)
 		})
 
 		it("should handle malformed streaming data gracefully", async () => {
@@ -222,33 +207,35 @@ describe("Ghost Streaming Integration", () => {
 
 			streamingParser.initialize(context)
 
-			let validSuggestions = 0
+			let fullResponse = ""
 			let errors = 0
 
 			const onChunk = (chunk: ApiStreamChunk) => {
 				if (chunk.type === "text") {
-					try {
-						const parseResult = streamingParser.processChunk(chunk.text)
-
-						if (parseResult.hasNewSuggestions) {
-							validSuggestions++
-						}
-					} catch (error) {
-						errors++
-					}
+					fullResponse += chunk.text
 				}
 			}
 
 			await model.generateResponse("system", "user", onChunk)
 
+			// Process complete response
+			try {
+				const parseResult = streamingParser.finishStream(fullResponse)
+				// Should only process the valid suggestion
+				if (parseResult.hasNewSuggestions) {
+					expect(streamingParser.getCompletedChanges()).toHaveLength(1)
+				}
+			} catch (error) {
+				errors++
+			}
+
 			// Should handle malformed data without crashing
 			expect(errors).toBe(0) // No errors thrown
-			expect(validSuggestions).toBe(1) // Only the valid suggestion processed
 		})
 	})
 
 	describe("performance characteristics", () => {
-		it("should show first suggestion quickly in streaming mode", async () => {
+		it("should process complete response quickly", async () => {
 			const streamingChunks: ApiStreamChunk[] = [
 				{
 					type: "text",
@@ -263,28 +250,23 @@ describe("Ghost Streaming Integration", () => {
 			streamingParser.initialize(context)
 
 			const startTime = performance.now()
-			let firstSuggestionTime: number | null = null
+			let fullResponse = ""
 
 			const onChunk = (chunk: ApiStreamChunk) => {
 				if (chunk.type === "text") {
-					const parseResult = streamingParser.processChunk(chunk.text)
-
-					if (parseResult.hasNewSuggestions && firstSuggestionTime === null) {
-						firstSuggestionTime = performance.now()
-					}
+					fullResponse += chunk.text
 				}
 			}
 
 			await model.generateResponse("system", "user", onChunk)
 
+			const parseResult = streamingParser.finishStream(fullResponse)
 			const totalTime = performance.now() - startTime
-			const timeToFirstSuggestion = firstSuggestionTime! - startTime
 
-			// First suggestion should come quickly (within reasonable bounds for test)
-			expect(timeToFirstSuggestion).toBeLessThan(totalTime)
-			expect(timeToFirstSuggestion).toBeGreaterThan(0)
+			// Should process successfully
+			expect(parseResult.hasNewSuggestions).toBe(true)
+			expect(totalTime).toBeGreaterThan(0)
 
-			console.log(`Time to first suggestion: ${timeToFirstSuggestion.toFixed(2)}ms`)
 			console.log(`Total time: ${totalTime.toFixed(2)}ms`)
 		})
 	})

--- a/src/services/ghost/__tests__/GhostStreamingParser.sanitization.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingParser.sanitization.test.ts
@@ -45,13 +45,8 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></replace></change`
 
-			// First chunk - should not sanitize yet (stream not complete)
-			let result = parser.processChunk(incompleteXML)
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.isComplete).toBe(false)
-
-			// Simulate stream completion by calling finishStream
-			result = parser.finishStream()
+			// Simulate stream completion by calling finishStream with full response
+			const result = parser.finishStream(incompleteXML)
 
 			expect(result.hasNewSuggestions).toBe(true)
 			expect(result.suggestions.hasSuggestions()).toBe(true)
@@ -67,13 +62,8 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></replace>`
 
-			// First chunk - should not sanitize yet (stream not complete)
-			let result = parser.processChunk(incompleteXML)
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.isComplete).toBe(false)
-
 			// Simulate stream completion
-			result = parser.finishStream()
+			const result = parser.finishStream(incompleteXML)
 
 			expect(result.hasNewSuggestions).toBe(true)
 			expect(result.suggestions.hasSuggestions()).toBe(true)
@@ -89,7 +79,7 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></change`
 
-			const result = parser.processChunk(incompleteXML)
+			const result = parser.finishStream(incompleteXML)
 
 			expect(result.hasNewSuggestions).toBe(false)
 			expect(result.suggestions.hasSuggestions()).toBe(false)
@@ -99,7 +89,7 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 		it("should not fix when multiple change blocks are present", () => {
 			const incompleteXML = `<change><search><![CDATA[test1]]></search><replace><![CDATA[test1]]></replace></change><change><search><![CDATA[test2]]></search><replace><![CDATA[test2]]></replace></change`
 
-			const result = parser.processChunk(incompleteXML)
+			const result = parser.finishStream(incompleteXML)
 
 			// Should process the first complete change but not fix the incomplete second one
 			expect(result.hasNewSuggestions).toBe(true)
@@ -111,7 +101,7 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></replace><`
 
-			const result = parser.processChunk(incompleteXML)
+			const result = parser.finishStream(incompleteXML)
 
 			expect(result.hasNewSuggestions).toBe(false)
 			expect(result.isComplete).toBe(false)
@@ -119,21 +109,11 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 		})
 
 		it("should not apply sanitization during active streaming", () => {
-			// Simulate streaming chunks
-			let result = parser.processChunk(`<change><search><![CDATA[function mutliply(<<<AUTOCOMPLETE_HERE>>>>`)
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.isComplete).toBe(false)
-
-			result = parser.processChunk(`]]></search><replace><![CDATA[function mutliply(a, b) {`)
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.isComplete).toBe(false)
-
-			result = parser.processChunk(`]]></replace></change`)
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.isComplete).toBe(false)
+			// Build up the full response from chunks
+			const fullResponse = `<change><search><![CDATA[function mutliply(<<<AUTOCOMPLETE_HERE>>>>]]></search><replace><![CDATA[function mutliply(a, b) {]]></replace></change`
 
 			// Only when stream completes should sanitization be applied
-			result = parser.finishStream()
+			const result = parser.finishStream(fullResponse)
 			expect(result.hasNewSuggestions).toBe(true)
 			expect(result.isComplete).toBe(true)
 			expect(parser.getCompletedChanges()).toHaveLength(1)
@@ -144,7 +124,7 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></replace></change>`
 
-			const result = parser.processChunk(completeXML)
+			const result = parser.finishStream(completeXML)
 
 			expect(result.hasNewSuggestions).toBe(true)
 			expect(result.suggestions.hasSuggestions()).toBe(true)
@@ -154,21 +134,21 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 		it("should handle malformed CDATA sections - the actual bug from user logs", () => {
 			// This reproduces the EXACT malformed CDATA issue from user logs
 			const malformedCDataXML = `<change><search><![CDATA[function getRedirectUrl(txn: CreditTransaction | undefined) {
-  <<<AUTOCOMPLETE_HERE>>>
+	 <<<AUTOCOMPLETE_HERE>>>
 
-  const params = new URLSearchParams();</![CDATA[</search><replace><![CDATA[function getRedirectUrl(txn: CreditTransaction | undefined) {
-  if (!txn) {
-    return '/organizations';
-  }
+	 const params = new URLSearchParams();</![CDATA[</search><replace><![CDATA[function getRedirectUrl(txn: CreditTransaction | undefined) {
+	 if (!txn) {
+	   return '/organizations';
+	 }
 
-  const params = new URLSearchParams();</![CDATA[</replace></change>`
+	 const params = new URLSearchParams();</![CDATA[</replace></change>`
 
 			// Update mock document to match the search content exactly
 			const mockDocument = {
 				getText: vi.fn().mockReturnValue(`function getRedirectUrl(txn: CreditTransaction | undefined) {
-  <<<AUTOCOMPLETE_HERE>>>
+	 <<<AUTOCOMPLETE_HERE>>>
 
-  const params = new URLSearchParams();`),
+	 const params = new URLSearchParams();`),
 				uri: { fsPath: "/test/file.tsx", toString: () => "file:///test/file.tsx" } as vscode.Uri,
 				offsetAt: vi.fn().mockReturnValue(60),
 			} as unknown as vscode.TextDocument
@@ -180,16 +160,8 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 
 			parser.initialize(testContext)
 
-			// Process the malformed XML - this should initially fail
-			let result = parser.processChunk(malformedCDataXML)
-
-			// Should fail to parse initially due to malformed CDATA
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.isComplete).toBe(false)
-			expect(parser.getCompletedChanges()).toHaveLength(0)
-
 			// Simulate stream completion - this should trigger sanitization and fix the CDATA issue
-			result = parser.finishStream()
+			const result = parser.finishStream(malformedCDataXML)
 
 			// After sanitization, it should work
 			expect(result.hasNewSuggestions).toBe(true)

--- a/src/services/ghost/__tests__/GhostStreamingParser.sanitization.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingParser.sanitization.test.ts
@@ -46,7 +46,7 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></replace></change`
 
 			// Simulate stream completion by calling finishStream with full response
-			const result = parser.finishStream(incompleteXML)
+			const result = parser.parseResponse(incompleteXML)
 
 			expect(result.hasNewSuggestions).toBe(true)
 			expect(result.suggestions.hasSuggestions()).toBe(true)
@@ -63,7 +63,7 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></replace>`
 
 			// Simulate stream completion
-			const result = parser.finishStream(incompleteXML)
+			const result = parser.parseResponse(incompleteXML)
 
 			expect(result.hasNewSuggestions).toBe(true)
 			expect(result.suggestions.hasSuggestions()).toBe(true)
@@ -79,7 +79,7 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></change`
 
-			const result = parser.finishStream(incompleteXML)
+			const result = parser.parseResponse(incompleteXML)
 
 			expect(result.hasNewSuggestions).toBe(false)
 			expect(result.suggestions.hasSuggestions()).toBe(false)
@@ -89,7 +89,7 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 		it("should not fix when multiple change blocks are present", () => {
 			const incompleteXML = `<change><search><![CDATA[test1]]></search><replace><![CDATA[test1]]></replace></change><change><search><![CDATA[test2]]></search><replace><![CDATA[test2]]></replace></change`
 
-			const result = parser.finishStream(incompleteXML)
+			const result = parser.parseResponse(incompleteXML)
 
 			// Should process the first complete change but not fix the incomplete second one
 			expect(result.hasNewSuggestions).toBe(true)
@@ -101,7 +101,7 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></replace><`
 
-			const result = parser.finishStream(incompleteXML)
+			const result = parser.parseResponse(incompleteXML)
 
 			expect(result.hasNewSuggestions).toBe(false)
 			expect(result.isComplete).toBe(false)
@@ -113,7 +113,7 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 			const fullResponse = `<change><search><![CDATA[function mutliply(<<<AUTOCOMPLETE_HERE>>>>]]></search><replace><![CDATA[function mutliply(a, b) {]]></replace></change`
 
 			// Only when stream completes should sanitization be applied
-			const result = parser.finishStream(fullResponse)
+			const result = parser.parseResponse(fullResponse)
 			expect(result.hasNewSuggestions).toBe(true)
 			expect(result.isComplete).toBe(true)
 			expect(parser.getCompletedChanges()).toHaveLength(1)
@@ -124,7 +124,7 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></replace></change>`
 
-			const result = parser.finishStream(completeXML)
+			const result = parser.parseResponse(completeXML)
 
 			expect(result.hasNewSuggestions).toBe(true)
 			expect(result.suggestions.hasSuggestions()).toBe(true)
@@ -161,7 +161,7 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 			parser.initialize(testContext)
 
 			// Simulate stream completion - this should trigger sanitization and fix the CDATA issue
-			const result = parser.finishStream(malformedCDataXML)
+			const result = parser.parseResponse(malformedCDataXML)
 
 			// After sanitization, it should work
 			expect(result.hasNewSuggestions).toBe(true)

--- a/src/services/ghost/__tests__/GhostStreamingParser.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingParser.test.ts
@@ -39,14 +39,14 @@ describe("GhostStreamingParser", () => {
 		parser.reset()
 	})
 
-	describe("processChunk", () => {
-		it("should handle incomplete XML chunks", () => {
-			const chunk1 = "<change><search><![CDATA["
-			const result1 = parser.processChunk(chunk1)
+	describe("finishStream", () => {
+		it("should handle incomplete XML", () => {
+			const incompleteXml = "<change><search><![CDATA["
+			const result = parser.finishStream(incompleteXml)
 
-			expect(result1.hasNewSuggestions).toBe(false)
-			expect(result1.isComplete).toBe(false)
-			expect(result1.suggestions.hasSuggestions()).toBe(false)
+			expect(result.hasNewSuggestions).toBe(false)
+			expect(result.isComplete).toBe(false)
+			expect(result.suggestions.hasSuggestions()).toBe(false)
 		})
 
 		it("should parse complete change blocks", () => {
@@ -57,42 +57,33 @@ describe("GhostStreamingParser", () => {
 	return true;
 }]]></replace></change>`
 
-			const result = parser.processChunk(completeChange)
+			const result = parser.finishStream(completeChange)
 
 			expect(result.hasNewSuggestions).toBe(true)
 			expect(result.suggestions.hasSuggestions()).toBe(true)
 		})
 
-		it("should handle multiple chunks building up to complete change", () => {
-			const chunks = [
-				"<change><search><![CDATA[function test() {",
-				"\n\treturn true;",
-				"\n}]]></search><replace><![CDATA[function test() {",
-				"\n\t// Added comment",
-				"\n\treturn true;",
-				"\n}]]></replace></change>",
-			]
+		it("should handle complete response built from multiple chunks", () => {
+			const fullResponse = `<change><search><![CDATA[function test() {
+	return true;
+}]]></search><replace><![CDATA[function test() {
+	// Added comment
+	return true;
+}]]></replace></change>`
 
-			let finalResult
-			for (const chunk of chunks) {
-				finalResult = parser.processChunk(chunk)
-			}
+			const result = parser.finishStream(fullResponse)
 
-			expect(finalResult!.hasNewSuggestions).toBe(true)
-			expect(finalResult!.suggestions.hasSuggestions()).toBe(true)
+			expect(result.hasNewSuggestions).toBe(true)
+			expect(result.suggestions.hasSuggestions()).toBe(true)
 		})
 
-		it("should handle multiple complete changes in sequence", () => {
-			const change1 = `<change><search><![CDATA[function test() {]]></search><replace><![CDATA[function test() {
-	// First change]]></replace></change>`
+		it("should handle multiple complete changes", () => {
+			const fullResponse = `<change><search><![CDATA[function test() {]]></search><replace><![CDATA[function test() {
+	// First change]]></replace></change><change><search><![CDATA[return true;]]></search><replace><![CDATA[return false; // Second change]]></replace></change>`
 
-			const change2 = `<change><search><![CDATA[return true;]]></search><replace><![CDATA[return false; // Second change]]></replace></change>`
+			const result = parser.finishStream(fullResponse)
 
-			const result1 = parser.processChunk(change1)
-			const result2 = parser.processChunk(change2)
-
-			expect(result1.hasNewSuggestions).toBe(true)
-			expect(result2.hasNewSuggestions).toBe(true)
+			expect(result.hasNewSuggestions).toBe(true)
 			expect(parser.getCompletedChanges()).toHaveLength(2)
 		})
 
@@ -104,7 +95,7 @@ describe("GhostStreamingParser", () => {
 	return true;
 }]]></replace></change>`
 
-			const result = parser.processChunk(completeResponse)
+			const result = parser.finishStream(completeResponse)
 
 			expect(result.isComplete).toBe(true)
 		})
@@ -115,7 +106,7 @@ describe("GhostStreamingParser", () => {
 }]]></search><replace><![CDATA[function test() {
 	// Added comment`
 
-			const result = parser.processChunk(incompleteResponse)
+			const result = parser.finishStream(incompleteResponse)
 
 			expect(result.isComplete).toBe(false)
 		})
@@ -128,7 +119,7 @@ describe("GhostStreamingParser", () => {
 	return true;
 }]]></replace></change>`
 
-			const result = parser.processChunk(changeWithCursor)
+			const result = parser.finishStream(changeWithCursor)
 
 			expect(result.hasNewSuggestions).toBe(true)
 			// Verify cursor marker is preserved in search content for matching
@@ -142,7 +133,7 @@ describe("GhostStreamingParser", () => {
 			const changeWithCursor = `<change><search><![CDATA[return true;]]></search><replace><![CDATA[// Comment here<<<AUTOCOMPLETE_HERE>>>
 	return false;]]></replace></change>`
 
-			const result = parser.processChunk(changeWithCursor)
+			const result = parser.finishStream(changeWithCursor)
 
 			expect(result.hasNewSuggestions).toBe(true)
 			const changes = parser.getCompletedChanges()
@@ -180,7 +171,7 @@ function fibonacci(n: number): number {
 		return fibonacci(n - 1) + fibonacci(n - 2);
 }]]></replace></change>`
 
-			const result = parser.processChunk(changeWithCursor)
+			const result = parser.finishStream(changeWithCursor)
 
 			expect(result.hasNewSuggestions).toBe(true)
 			expect(result.suggestions.hasSuggestions()).toBe(true)
@@ -208,7 +199,7 @@ function fibonacci(n: number): number {
 		return fibonacci(n - 1) + fibonacci(n - 2);
 }]]></replace></change>`
 
-			const result = parser.processChunk(changeWithCursor)
+			const result = parser.finishStream(changeWithCursor)
 
 			expect(result.hasNewSuggestions).toBe(true)
 			expect(result.suggestions.hasSuggestions()).toBe(true)
@@ -217,23 +208,23 @@ function fibonacci(n: number): number {
 		it("should handle malformed XML gracefully", () => {
 			const malformedXml = `<change><search><![CDATA[test]]><replace><![CDATA[replacement]]></replace></change>`
 
-			const result = parser.processChunk(malformedXml)
+			const result = parser.finishStream(malformedXml)
 
 			// Should not crash and should not produce suggestions
 			expect(result.hasNewSuggestions).toBe(false)
 			expect(result.suggestions.hasSuggestions()).toBe(false)
 		})
 
-		it("should handle empty chunks", () => {
-			const result = parser.processChunk("")
+		it("should handle empty response", () => {
+			const result = parser.finishStream("")
 
 			expect(result.hasNewSuggestions).toBe(false)
 			expect(result.isComplete).toBe(true) // Empty is considered complete
 			expect(result.suggestions.hasSuggestions()).toBe(false)
 		})
 
-		it("should handle whitespace-only chunks", () => {
-			const result = parser.processChunk("   \n\t  ")
+		it("should handle whitespace-only response", () => {
+			const result = parser.finishStream("   \n\t  ")
 
 			expect(result.hasNewSuggestions).toBe(false)
 			expect(result.isComplete).toBe(true)
@@ -245,7 +236,7 @@ function fibonacci(n: number): number {
 		it("should clear all state when reset", () => {
 			const change = `<change><search><![CDATA[test]]></search><replace><![CDATA[replacement]]></replace></change>`
 
-			parser.processChunk(change)
+			parser.finishStream(change)
 			expect(parser.buffer).not.toBe("")
 			expect(parser.getCompletedChanges()).toHaveLength(1)
 
@@ -286,7 +277,7 @@ function fibonacci(n: number): number {
 			const uninitializedParser = new GhostStreamingParser()
 
 			expect(() => {
-				uninitializedParser.processChunk("test")
+				uninitializedParser.finishStream("test")
 			}).toThrow("Parser not initialized")
 		})
 
@@ -295,31 +286,29 @@ function fibonacci(n: number): number {
 			parser.initialize(contextWithoutDoc)
 
 			const change = `<change><search><![CDATA[test]]></search><replace><![CDATA[replacement]]></replace></change>`
-			const result = parser.processChunk(change)
+			const result = parser.finishStream(change)
 
 			expect(result.suggestions.hasSuggestions()).toBe(false)
 		})
 	})
 
 	describe("performance", () => {
-		it("should handle large chunks efficiently", () => {
+		it("should handle large responses efficiently", () => {
 			const largeChange = `<change><search><![CDATA[${"x".repeat(10000)}]]></search><replace><![CDATA[${"y".repeat(10000)}]]></replace></change>`
 
 			const startTime = performance.now()
-			const result = parser.processChunk(largeChange)
+			const result = parser.finishStream(largeChange)
 			const endTime = performance.now()
 
 			expect(endTime - startTime).toBeLessThan(100) // Should complete in under 100ms
 			expect(result.hasNewSuggestions).toBe(true)
 		})
 
-		it("should handle many small chunks efficiently", () => {
-			const chunks = Array(1000).fill("x")
+		it("should handle large concatenated responses efficiently", () => {
+			const largeResponse = Array(1000).fill("x").join("")
 			const startTime = performance.now()
 
-			for (const chunk of chunks) {
-				parser.processChunk(chunk)
-			}
+			parser.finishStream(largeResponse)
 			const endTime = performance.now()
 
 			expect(endTime - startTime).toBeLessThan(200) // Should complete in under 200ms

--- a/src/services/ghost/__tests__/GhostStreamingParser.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingParser.test.ts
@@ -273,14 +273,6 @@ function fibonacci(n: number): number {
 	})
 
 	describe("error handling", () => {
-		it("should throw error if not initialized", () => {
-			const uninitializedParser = new GhostStreamingParser()
-
-			expect(() => {
-				uninitializedParser.parseResponse("test")
-			}).toThrow("Parser not initialized")
-		})
-
 		it("should handle context without document", () => {
 			const contextWithoutDoc = {} as GhostSuggestionContext
 			parser.initialize(contextWithoutDoc)

--- a/src/services/ghost/__tests__/GhostStreamingParser.user-issue.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingParser.user-issue.test.ts
@@ -45,13 +45,8 @@ describe("GhostStreamingParser - User Issue Fix", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></replace></change`
 
-		// First chunk - should not sanitize yet (stream not complete)
-		let result = parser.processChunk(userIssueXML)
-		expect(result.hasNewSuggestions).toBe(false)
-		expect(result.isComplete).toBe(false)
-
-		// Simulate stream completion
-		result = parser.finishStream()
+		// Simulate stream completion with full response
+		const result = parser.finishStream(userIssueXML)
 
 		// Verify that the sanitization worked and we got suggestions
 		expect(result.hasNewSuggestions).toBe(true)
@@ -72,13 +67,8 @@ describe("GhostStreamingParser - User Issue Fix", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></replace></change`
 
-		// First chunk - should not sanitize yet
-		let result = parser.processChunk(brokenXML)
-		expect(result.hasNewSuggestions).toBe(false)
-		expect(result.isComplete).toBe(false)
-
 		// Simulate stream completion
-		result = parser.finishStream()
+		const result = parser.finishStream(brokenXML)
 
 		expect(result.hasNewSuggestions).toBe(true)
 		expect(result.suggestions.hasSuggestions()).toBe(true)

--- a/src/services/ghost/__tests__/GhostStreamingParser.user-issue.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingParser.user-issue.test.ts
@@ -46,7 +46,7 @@ describe("GhostStreamingParser - User Issue Fix", () => {
 ]]></replace></change`
 
 		// Simulate stream completion with full response
-		const result = parser.finishStream(userIssueXML)
+		const result = parser.parseResponse(userIssueXML)
 
 		// Verify that the sanitization worked and we got suggestions
 		expect(result.hasNewSuggestions).toBe(true)
@@ -68,7 +68,7 @@ describe("GhostStreamingParser - User Issue Fix", () => {
 ]]></replace></change`
 
 		// Simulate stream completion
-		const result = parser.finishStream(brokenXML)
+		const result = parser.parseResponse(brokenXML)
 
 		expect(result.hasNewSuggestions).toBe(true)
 		expect(result.suggestions.hasSuggestions()).toBe(true)

--- a/src/test-llm-autocompletion/strategy-tester.ts
+++ b/src/test-llm-autocompletion/strategy-tester.ts
@@ -95,8 +95,7 @@ export class StrategyTester {
 		}
 
 		parser.initialize(dummyContext)
-		parser.processChunk(xmlResponse)
-		parser.finishStream()
+		parser.finishStream(xmlResponse)
 
 		return parser.getCompletedChanges()
 	}

--- a/src/test-llm-autocompletion/strategy-tester.ts
+++ b/src/test-llm-autocompletion/strategy-tester.ts
@@ -95,7 +95,7 @@ export class StrategyTester {
 		}
 
 		parser.initialize(dummyContext)
-		parser.finishStream(xmlResponse)
+		parser.parseResponse(xmlResponse)
 
 		return parser.getCompletedChanges()
 	}


### PR DESCRIPTION
the streaming parser mixed up the order of the chunks, which caused the parsing to fail and the autocomplete to suggest XML search/replace content

Context: i noticed the local variable (response) was out of sync with the buffer:
<img width="679" height="766" alt="image" src="https://github.com/user-attachments/assets/207735b8-c12c-427f-a5b2-0d03357da09b" />

<img width="720" height="88" alt="image" src="https://github.com/user-attachments/assets/ae5c39f6-4f9d-487a-b1b3-e27b5d053563" />


As it doesn't seem to add speed/reponsiveness to our current provider removed the streaming altogether