### PR TITLE
Prevent webview crash when browser tool is used with native tool calling enabled

### DIFF
--- a/.changeset/shaggy-hotels-remain.md
+++ b/.changeset/shaggy-hotels-remain.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed crash when browser tool is used with native tool calling enabled

--- a/packages/types/src/kilocode/native-function-calling.ts
+++ b/packages/types/src/kilocode/native-function-calling.ts
@@ -17,6 +17,7 @@ export const nativeFunctionCallingProviders = [
 	"deepinfra",
 	"xai",
 	"zai",
+	"human-relay",
 ] satisfies ProviderName[] as ProviderName[]
 
 const modelsDefaultingToNativeFunctionCalls = ["anthropic/claude-haiku-4.5"]

--- a/src/core/tools/browserActionTool.ts
+++ b/src/core/tools/browserActionTool.ts
@@ -8,6 +8,32 @@ import {
 } from "../../shared/ExtensionMessage"
 import { formatResponse } from "../prompts/responses"
 
+function toStringlyTyped_kilocode(value: string | number[] | object | null | undefined): string | undefined {
+	if (typeof value === "string") {
+		console.debug("toStringlyTyped: returning string as-is", value)
+		return value
+	}
+	if (Array.isArray(value)) {
+		console.debug(
+			"toStringlyTyped: model returned an array, this is not allowed by either the XML or JSON tool.",
+			value,
+		)
+		return value.join(",")
+	}
+	if (value && typeof value === "object") {
+		if ("x" in value && "y" in value) {
+			console.debug("toStringlyTyped: x,y object", value)
+			return `${value.x},${value.y}`
+		}
+		if ("width" in value && "height" in value) {
+			console.debug("toStringlyTyped: width,height object", value)
+			return `${value.width},${value.height}`
+		}
+	}
+	console.debug("toStringlyTyped: returning undefined", value)
+	return undefined
+}
+
 export async function browserActionTool(
 	cline: Task,
 	block: ToolUse,
@@ -18,9 +44,9 @@ export async function browserActionTool(
 ) {
 	const action: BrowserAction | undefined = block.params.action as BrowserAction
 	const url: string | undefined = block.params.url
-	const coordinate: string | undefined = block.params.coordinate
+	const coordinate: string | undefined = toStringlyTyped_kilocode(block.params.coordinate)
 	const text: string | undefined = block.params.text
-	const size: string | undefined = block.params.size
+	const size: string | undefined = toStringlyTyped_kilocode(block.params.size)
 
 	if (!action || !browserActions.includes(action)) {
 		// checking for action to ensure it is complete and valid


### PR DESCRIPTION
Fixes https://github.com/Kilo-Org/kilocode/issues/3081

more of a workaround than a fix, we'll have to find a way to make the params properly typed.