### PR TITLE
only use tab for autocomplete, not shift-tab or ctrl-tab

### DIFF
--- a/.changeset/cute-states-stop.md
+++ b/.changeset/cute-states-stop.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Do not accept an autocomplete suggestion with shift-tab or ctrl-tab (only plain tab)

--- a/src/package.json
+++ b/src/package.json
@@ -437,7 +437,7 @@
 			{
 				"command": "editor.action.inlineSuggest.commit",
 				"key": "tab",
-				"when": "inlineSuggestionVisible && editorTextFocus && !editorTabMovesFocus && !inSnippetMode && !suggestWidgetVisible && editorLangId != 'markdown'"
+				"when": "inlineSuggestionVisible && editorTextFocus && !editorTabMovesFocus && !inSnippetMode && !suggestWidgetVisible && editorLangId != 'markdown' && !shiftKey && !ctrlKey && !altKey && !metaKey"
 			},
 			{
 				"command": "kilo-code.ghost.applyAllSuggestions",


### PR DESCRIPTION
also added alt + meta; I do not think you can use those on a Mac, but I am not fully sure it is never possible on another OS

Issue found internally:

> I just selected a block of code that I pasted into a yaml file, and hit shift + tab to decrease the indentation, and instead it pasted in an autocomplete suggestion that I guess showed up a millisecond before I hit the keystrokes (because I didn't see a suggestion).  I don't think we should count shift+tab as a completion request