### PR TITLE
Create a clearer pipeline of parsing LLM changes towards file changes

### DIFF
--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -423,8 +423,7 @@ export class GhostStreamingParser {
 
 		// Generate diff between original and modified content
 		const relativePath = vscode.workspace.asRelativePath(document.uri, false)
-		const patch = structuredPatch(relativePath, relativePath, currentContent, modifiedContent, "", "")
-		return patch
+		return structuredPatch(relativePath, relativePath, currentContent, modifiedContent, "", "")
 	}
 
 	private convertToSuggestions(patch: ParsedDiff | undefined, document: vscode.TextDocument): GhostSuggestionsState {

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -318,9 +318,6 @@ export class GhostStreamingParser {
 		return newChanges
 	}
 
-	/**
-	 * Generate suggestions from completed changes
-	 */
 	private generatePatch(changes: ParsedChange[]): ParsedDiff | undefined {
 		if (!this.context?.document || changes.length === 0) {
 			return undefined

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -321,10 +321,8 @@ export class GhostStreamingParser {
 	 * Generate suggestions from completed changes
 	 */
 	private generateSuggestions(changes: ParsedChange[]): GhostSuggestionsState {
-		const suggestions = new GhostSuggestionsState()
-
 		if (!this.context?.document || changes.length === 0) {
-			return suggestions
+			return new GhostSuggestionsState()
 		}
 
 		const document = this.context.document
@@ -430,6 +428,7 @@ export class GhostStreamingParser {
 		const patch = structuredPatch(relativePath, relativePath, currentContent, modifiedContent, "", "")
 
 		// Create a suggestion file
+		const suggestions = new GhostSuggestionsState()
 		const suggestionFile = suggestions.addFile(document.uri)
 
 		// Process each hunk in the patch

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -437,7 +437,7 @@ export class GhostStreamingParser {
 			let currentNewLineNumber = hunk.newStart
 
 			for (const line of hunk.lines) {
-				const operationType = line.charAt(0) as GhostSuggestionEditOperationType
+				const operationType = line.charAt(0)
 				const content = line.substring(1)
 
 				switch (operationType) {

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode"
-import { structuredPatch } from "diff"
+import { ParsedDiff, structuredPatch } from "diff"
 import { GhostSuggestionContext, GhostSuggestionEditOperationType } from "./types"
 import { GhostSuggestionsState } from "./GhostSuggestions"
 import { CURSOR_MARKER } from "./ghostConstants"
@@ -426,17 +426,17 @@ export class GhostStreamingParser {
 		// Generate diff between original and modified content
 		const relativePath = vscode.workspace.asRelativePath(document.uri, false)
 		const patch = structuredPatch(relativePath, relativePath, currentContent, modifiedContent, "", "")
+		return this.convertToSuggestions(patch, document)
+	}
 
-		// Create a suggestion file
+	private convertToSuggestions(patch: ParsedDiff, document: vscode.TextDocument): GhostSuggestionsState {
 		const suggestions = new GhostSuggestionsState()
 		const suggestionFile = suggestions.addFile(document.uri)
 
-		// Process each hunk in the patch
 		for (const hunk of patch.hunks) {
 			let currentOldLineNumber = hunk.oldStart
 			let currentNewLineNumber = hunk.newStart
 
-			// Iterate over each line within the hunk
 			for (const line of hunk.lines) {
 				const operationType = line.charAt(0) as GhostSuggestionEditOperationType
 				const content = line.substring(1)

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -28,7 +28,7 @@ function removeCursorMarker(content: string): string {
 /**
  * Conservative XML sanitization - only fixes the specific case from user feedback
  */
-function sanitizeXMLConservative(buffer: string): string {
+export function sanitizeXMLConservative(buffer: string): string {
 	let sanitized = buffer
 
 	// Fix malformed CDATA sections first - this is the main bug from user logs

--- a/src/services/ghost/GhostStreamingParser.ts
+++ b/src/services/ghost/GhostStreamingParser.ts
@@ -481,6 +481,7 @@ export class GhostStreamingParser {
 
 	/**
 	 * Get completed changes (for debugging)
+	 * @deprecated This method is obsolete and should not be used
 	 */
 	public getCompletedChanges(): ParsedChange[] {
 		return [...this.completedChanges]

--- a/src/services/ghost/__tests__/GhostStreamingIntegration.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingIntegration.test.ts
@@ -147,7 +147,6 @@ describe("Ghost Streaming Integration", () => {
 			// Should have processed both suggestions
 			expect(parseResult.hasNewSuggestions).toBe(true)
 			expect(parseResult.suggestions.hasSuggestions()).toBe(true)
-			expect(streamingParser.getCompletedChanges()).toHaveLength(2)
 		})
 
 		it("should handle cancellation during streaming", async () => {
@@ -184,10 +183,6 @@ describe("Ghost Streaming Integration", () => {
 
 			// Should have no complete suggestions due to cancellation
 			expect(parseResult.hasNewSuggestions).toBe(false)
-
-			// Reset should clear state
-			streamingParser.reset()
-			expect(streamingParser.getCompletedChanges()).toHaveLength(0)
 		})
 
 		it("should handle malformed streaming data gracefully", async () => {
@@ -217,18 +212,8 @@ describe("Ghost Streaming Integration", () => {
 
 			await model.generateResponse("system", "user", onChunk)
 
-			// Process complete response
-			try {
-				const parseResult = streamingParser.parseResponse(fullResponse)
-				// Should only process the valid suggestion
-				if (parseResult.hasNewSuggestions) {
-					expect(streamingParser.getCompletedChanges()).toHaveLength(1)
-				}
-			} catch (error) {
-				errors++
-			}
-
-			// Should handle malformed data without crashing
+			const parseResult = streamingParser.parseResponse(fullResponse)
+			expect(parseResult.hasNewSuggestions).toBe(true)
 			expect(errors).toBe(0) // No errors thrown
 		})
 	})

--- a/src/services/ghost/__tests__/GhostStreamingIntegration.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingIntegration.test.ts
@@ -187,7 +187,6 @@ describe("Ghost Streaming Integration", () => {
 
 			// Reset should clear state
 			streamingParser.reset()
-			expect(streamingParser.buffer).toBe("")
 			expect(streamingParser.getCompletedChanges()).toHaveLength(0)
 		})
 

--- a/src/services/ghost/__tests__/GhostStreamingParser.sanitization.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingParser.sanitization.test.ts
@@ -50,7 +50,6 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 
 			expect(result.hasNewSuggestions).toBe(true)
 			expect(result.suggestions.hasSuggestions()).toBe(true)
-			expect(parser.getCompletedChanges()).toHaveLength(1)
 
 			const change = parser.getCompletedChanges()[0]
 			expect(change.search).toBe("function mutliply(<<<AUTOCOMPLETE_HERE>>>>\n")

--- a/src/services/ghost/__tests__/GhostStreamingParser.sanitization.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingParser.sanitization.test.ts
@@ -1,4 +1,4 @@
-import { GhostStreamingParser } from "../GhostStreamingParser"
+import { GhostStreamingParser, sanitizeXMLConservative } from "../GhostStreamingParser"
 import { GhostSuggestionContext } from "../types"
 import * as vscode from "vscode"
 
@@ -45,15 +45,13 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></replace></change`
 
-			// Simulate stream completion by calling finishStream with full response
-			const result = parser.parseResponse(incompleteXML)
-
-			expect(result.hasNewSuggestions).toBe(true)
-			expect(result.suggestions.hasSuggestions()).toBe(true)
-
-			const change = parser.getCompletedChanges()[0]
-			expect(change.search).toBe("function mutliply(<<<AUTOCOMPLETE_HERE>>>>\n")
-			expect(change.replace).toBe("function mutliply(a, b) {\n")
+			// Test sanitization directly
+			const sanitized = sanitizeXMLConservative(incompleteXML)
+			expect(sanitized).toContain("</change>")
+			expect(sanitized).toBe(incompleteXML.replace("</change", "</change>"))
+			// Verify the incomplete tag was fixed
+			expect(incompleteXML).toMatch(/\/change$/)
+			expect(sanitized).toMatch(/\/change>$/)
 		})
 
 		it("should add missing </change> tag entirely when stream is complete", () => {
@@ -61,16 +59,10 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></replace>`
 
-			// Simulate stream completion
-			const result = parser.parseResponse(incompleteXML)
-
-			expect(result.hasNewSuggestions).toBe(true)
-			expect(result.suggestions.hasSuggestions()).toBe(true)
-			expect(parser.getCompletedChanges()).toHaveLength(1)
-
-			const change = parser.getCompletedChanges()[0]
-			expect(change.search).toBe("function mutliply(<<<AUTOCOMPLETE_HERE>>>>\n")
-			expect(change.replace).toBe("function mutliply(a, b) {\n")
+			// Test sanitization directly
+			const sanitized = sanitizeXMLConservative(incompleteXML)
+			expect(sanitized).toContain("</change>")
+			expect(sanitized).toBe(incompleteXML + "</change>")
 		})
 
 		it("should not fix when search/replace pairs are incomplete", () => {
@@ -78,21 +70,17 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></change`
 
-			const result = parser.parseResponse(incompleteXML)
-
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.suggestions.hasSuggestions()).toBe(false)
-			expect(parser.getCompletedChanges()).toHaveLength(0)
+			// Test sanitization directly - should NOT modify when replace is incomplete
+			const sanitized = sanitizeXMLConservative(incompleteXML)
+			expect(sanitized).toBe(incompleteXML)
 		})
 
 		it("should not fix when multiple change blocks are present", () => {
 			const incompleteXML = `<change><search><![CDATA[test1]]></search><replace><![CDATA[test1]]></replace></change><change><search><![CDATA[test2]]></search><replace><![CDATA[test2]]></replace></change`
 
-			const result = parser.parseResponse(incompleteXML)
-
-			// Should process the first complete change but not fix the incomplete second one
-			expect(result.hasNewSuggestions).toBe(true)
-			expect(parser.getCompletedChanges()).toHaveLength(1)
+			// Test sanitization directly - should NOT modify when multiple changes present
+			const sanitized = sanitizeXMLConservative(incompleteXML)
+			expect(sanitized).toBe(incompleteXML)
 		})
 
 		it("should not fix when buffer ends with incomplete tag marker", () => {
@@ -100,22 +88,19 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></replace><`
 
-			const result = parser.parseResponse(incompleteXML)
-
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.isComplete).toBe(false)
-			expect(parser.getCompletedChanges()).toHaveLength(0)
+			// Test sanitization directly - should NOT modify when ending with incomplete tag
+			const sanitized = sanitizeXMLConservative(incompleteXML)
+			expect(sanitized).toBe(incompleteXML)
 		})
 
-		it("should not apply sanitization during active streaming", () => {
+		it("should apply sanitization when stream is complete", () => {
 			// Build up the full response from chunks
 			const fullResponse = `<change><search><![CDATA[function mutliply(<<<AUTOCOMPLETE_HERE>>>>]]></search><replace><![CDATA[function mutliply(a, b) {]]></replace></change`
 
-			// Only when stream completes should sanitization be applied
-			const result = parser.parseResponse(fullResponse)
-			expect(result.hasNewSuggestions).toBe(true)
-			expect(result.isComplete).toBe(true)
-			expect(parser.getCompletedChanges()).toHaveLength(1)
+			// Test sanitization directly
+			const sanitized = sanitizeXMLConservative(fullResponse)
+			expect(sanitized).toContain("</change>")
+			expect(sanitized).toBe(fullResponse.replace("</change", "</change>"))
 		})
 
 		it("should handle already complete XML without modification", () => {
@@ -123,53 +108,30 @@ describe("GhostStreamingParser - XML Sanitization", () => {
 ]]></search><replace><![CDATA[function mutliply(a, b) {
 ]]></replace></change>`
 
-			const result = parser.parseResponse(completeXML)
-
-			expect(result.hasNewSuggestions).toBe(true)
-			expect(result.suggestions.hasSuggestions()).toBe(true)
-			expect(parser.getCompletedChanges()).toHaveLength(1)
+			// Test sanitization directly - should NOT modify already complete XML
+			const sanitized = sanitizeXMLConservative(completeXML)
+			expect(sanitized).toBe(completeXML)
 		})
 
 		it("should handle malformed CDATA sections - the actual bug from user logs", () => {
 			// This reproduces the EXACT malformed CDATA issue from user logs
 			const malformedCDataXML = `<change><search><![CDATA[function getRedirectUrl(txn: CreditTransaction | undefined) {
-	 <<<AUTOCOMPLETE_HERE>>>
+		<<<AUTOCOMPLETE_HERE>>>
 
-	 const params = new URLSearchParams();</![CDATA[</search><replace><![CDATA[function getRedirectUrl(txn: CreditTransaction | undefined) {
-	 if (!txn) {
-	   return '/organizations';
-	 }
+		const params = new URLSearchParams();</![CDATA[</search><replace><![CDATA[function getRedirectUrl(txn: CreditTransaction | undefined) {
+		if (!txn) {
+		  return '/organizations';
+		}
 
-	 const params = new URLSearchParams();</![CDATA[</replace></change>`
+		const params = new URLSearchParams();</![CDATA[</replace></change>`
 
-			// Update mock document to match the search content exactly
-			const mockDocument = {
-				getText: vi.fn().mockReturnValue(`function getRedirectUrl(txn: CreditTransaction | undefined) {
-	 <<<AUTOCOMPLETE_HERE>>>
-
-	 const params = new URLSearchParams();`),
-				uri: { fsPath: "/test/file.tsx", toString: () => "file:///test/file.tsx" } as vscode.Uri,
-				offsetAt: vi.fn().mockReturnValue(60),
-			} as unknown as vscode.TextDocument
-
-			const testContext = {
-				document: mockDocument,
-				range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } } as vscode.Range,
-			}
-
-			parser.initialize(testContext)
-
-			// Simulate stream completion - this should trigger sanitization and fix the CDATA issue
-			const result = parser.parseResponse(malformedCDataXML)
-
-			// After sanitization, it should work
-			expect(result.hasNewSuggestions).toBe(true)
-			expect(result.suggestions.hasSuggestions()).toBe(true)
-			expect(parser.getCompletedChanges()).toHaveLength(1)
-
-			const change = parser.getCompletedChanges()[0]
-			expect(change.search).toContain("function getRedirectUrl")
-			expect(change.replace).toContain("if (!txn)")
+			// Test sanitization directly - should fix malformed CDATA
+			const sanitized = sanitizeXMLConservative(malformedCDataXML)
+			expect(sanitized).not.toContain("</![CDATA[")
+			expect(sanitized).toContain("]]>")
+			// Verify the malformed CDATA closures are replaced
+			const expectedSanitized = malformedCDataXML.replace(/<\/!\[CDATA\[/g, "]]>")
+			expect(sanitized).toBe(expectedSanitized)
 		})
 	})
 })

--- a/src/services/ghost/__tests__/GhostStreamingParser.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingParser.test.ts
@@ -237,11 +237,9 @@ function fibonacci(n: number): number {
 			const change = `<change><search><![CDATA[test]]></search><replace><![CDATA[replacement]]></replace></change>`
 
 			parser.parseResponse(change)
-			expect(parser.buffer).not.toBe("")
 			expect(parser.getCompletedChanges()).toHaveLength(1)
 
 			parser.reset()
-			expect(parser.buffer).toBe("")
 			expect(parser.getCompletedChanges()).toHaveLength(0)
 		})
 	})

--- a/src/services/ghost/__tests__/GhostStreamingParser.test.ts
+++ b/src/services/ghost/__tests__/GhostStreamingParser.test.ts
@@ -84,7 +84,6 @@ describe("GhostStreamingParser", () => {
 			const result = parser.parseResponse(fullResponse)
 
 			expect(result.hasNewSuggestions).toBe(true)
-			expect(parser.getCompletedChanges()).toHaveLength(2)
 		})
 
 		it("should detect when response is complete", () => {
@@ -109,35 +108,6 @@ describe("GhostStreamingParser", () => {
 			const result = parser.parseResponse(incompleteResponse)
 
 			expect(result.isComplete).toBe(false)
-		})
-
-		it("should handle cursor marker correctly", () => {
-			const changeWithCursor = `<change><search><![CDATA[function test() {
-	<<<AUTOCOMPLETE_HERE>>>return true;
-}]]></search><replace><![CDATA[function test() {
-	// Added comment<<<AUTOCOMPLETE_HERE>>>
-	return true;
-}]]></replace></change>`
-
-			const result = parser.parseResponse(changeWithCursor)
-
-			expect(result.hasNewSuggestions).toBe(true)
-			// Verify cursor marker is preserved in search content for matching
-			const changes = parser.getCompletedChanges()
-			expect(changes[0].search).toContain("<<<AUTOCOMPLETE_HERE>>>") // Should preserve in search for matching
-			expect(changes[0].replace).toContain("<<<AUTOCOMPLETE_HERE>>>") // Should preserve in replace
-			expect(changes[0].cursorPosition).toBeDefined() // Should have cursor position info
-		})
-
-		it("should extract cursor position correctly", () => {
-			const changeWithCursor = `<change><search><![CDATA[return true;]]></search><replace><![CDATA[// Comment here<<<AUTOCOMPLETE_HERE>>>
-	return false;]]></replace></change>`
-
-			const result = parser.parseResponse(changeWithCursor)
-
-			expect(result.hasNewSuggestions).toBe(true)
-			const changes = parser.getCompletedChanges()
-			expect(changes[0].cursorPosition).toBe(15) // Position after "// Comment here"
 		})
 
 		it("should handle cursor marker in search content for matching", () => {
@@ -229,18 +199,6 @@ function fibonacci(n: number): number {
 			expect(result.hasNewSuggestions).toBe(false)
 			expect(result.isComplete).toBe(true)
 			expect(result.suggestions.hasSuggestions()).toBe(false)
-		})
-	})
-
-	describe("reset", () => {
-		it("should clear all state when reset", () => {
-			const change = `<change><search><![CDATA[test]]></search><replace><![CDATA[replacement]]></replace></change>`
-
-			parser.parseResponse(change)
-			expect(parser.getCompletedChanges()).toHaveLength(1)
-
-			parser.reset()
-			expect(parser.getCompletedChanges()).toHaveLength(0)
 		})
 	})
 


### PR DESCRIPTION
Including removing most of getCompletedChanges; unfortunately this gets used by the evals, which means they do not test the full pipeline. I'll look into rewriting that logic tomorrow, this should all be simple to review as it's only refactors.

Code changes were done by hand, some test changes were done with the LLM