### PR TITLE
Add slash config command to cli

### DIFF
--- a/apps/kilocode-docs/docs/cli.md
+++ b/apps/kilocode-docs/docs/cli.md
@@ -42,6 +42,7 @@ to start the CLI and begin a new task with your preferred model and relevant mod
 | `/model list`   | List available models                                            |                             |
 | `/model info`   | Prints description for a specific model by name                  | `/model info z-ai/glm-4.5v` |
 | `/model select` | Select and switch to a new model                                 |                             |
+| `/config`       | Open configuration editor (same as `kilocode config`)            |                             |
 | `/new`          | Start a new task with the agent with a clean slate               |                             |
 | `/help`         | List available commands and how to use them                      |                             |
 | `/exit`         | Exit the CLI                                                     |                             |
@@ -55,6 +56,10 @@ You can reference the [Provider Configuration Guide](https://github.com/Kilo-Org
 `kilocode config`
 
 to complete configuration with an interactive workflow on the command line.
+
+:::tip
+You can also use the `/config` slash command during an interactive session, which is equivalent to running `kilocode config`.
+:::
 
 ## Autonomous mode (Non-Interactive)
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -45,6 +45,17 @@ kilocode --mode architect
 kilocode --workspace /path/to/project
 ```
 
+#### Slash Commands
+
+While in the interactive CLI, you can use slash commands:
+
+- `/help` - Display available commands
+- `/mode` - Switch between different modes
+- `/config` - Open the CLI configuration file in your editor
+- `/exit` - Exit the CLI
+
+Type `/help` for a full list of available commands.
+
 ### Autonomous mode (Non-Interactive)
 
 Autonomous mode allows Kilo Code to run in automated environments like CI/CD pipelines without requiring user interaction.

--- a/cli/README.md
+++ b/cli/README.md
@@ -45,17 +45,6 @@ kilocode --mode architect
 kilocode --workspace /path/to/project
 ```
 
-#### Slash Commands
-
-While in the interactive CLI, you can use slash commands:
-
-- `/help` - Display available commands
-- `/mode` - Switch between different modes
-- `/config` - Open the CLI configuration file in your editor
-- `/exit` - Exit the CLI
-
-Type `/help` for a full list of available commands.
-
 ### Autonomous mode (Non-Interactive)
 
 Autonomous mode allows Kilo Code to run in automated environments like CI/CD pipelines without requiring user interaction.

--- a/cli/src/commands/__tests__/config.test.ts
+++ b/cli/src/commands/__tests__/config.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { configCommand } from "../config.js"
+import type { CommandContext } from "../core/types.js"
+import openConfigFile from "../../config/openConfig.js"
+
+// Mock the openConfigFile function
+vi.mock("../../config/openConfig.js", () => ({
+	default: vi.fn(),
+}))
+
+describe("configCommand", () => {
+	let mockContext: CommandContext
+	let addMessageSpy: ReturnType<typeof vi.fn>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		addMessageSpy = vi.fn()
+
+		mockContext = {
+			input: "/config",
+			args: [],
+			options: {},
+			sendMessage: vi.fn(),
+			addMessage: addMessageSpy,
+			clearMessages: vi.fn(),
+			replaceMessages: vi.fn(),
+			clearTask: vi.fn(),
+			setMode: vi.fn(),
+			exit: vi.fn(),
+			routerModels: null,
+			currentProvider: null,
+			kilocodeDefaultModel: "",
+			updateProviderModel: vi.fn(),
+			refreshRouterModels: vi.fn(),
+			updateProvider: vi.fn(),
+			profileData: null,
+			balanceData: null,
+			profileLoading: false,
+			balanceLoading: false,
+		}
+	})
+
+	it("should have correct metadata", () => {
+		expect(configCommand.name).toBe("config")
+		expect(configCommand.aliases).toContain("c")
+		expect(configCommand.aliases).toContain("settings")
+		expect(configCommand.category).toBe("settings")
+		expect(configCommand.priority).toBe(8)
+	})
+
+	it("should open config file successfully", async () => {
+		vi.mocked(openConfigFile).mockResolvedValue(undefined)
+
+		await configCommand.handler(mockContext)
+
+		expect(addMessageSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "system",
+				content: "Opening configuration file...",
+			}),
+		)
+		expect(openConfigFile).toHaveBeenCalled()
+	})
+
+	it("should handle errors when opening config file", async () => {
+		const error = new Error("Failed to open editor")
+		vi.mocked(openConfigFile).mockRejectedValue(error)
+
+		await configCommand.handler(mockContext)
+
+		expect(addMessageSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "system",
+				content: "Opening configuration file...",
+			}),
+		)
+		expect(addMessageSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "error",
+				content: "Failed to open config file: Failed to open editor",
+			}),
+		)
+	})
+
+	it("should handle non-Error exceptions", async () => {
+		vi.mocked(openConfigFile).mockRejectedValue("String error")
+
+		await configCommand.handler(mockContext)
+
+		expect(addMessageSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "error",
+				content: "Failed to open config file: String error",
+			}),
+		)
+	})
+})

--- a/cli/src/commands/__tests__/config.test.ts
+++ b/cli/src/commands/__tests__/config.test.ts
@@ -61,37 +61,4 @@ describe("configCommand", () => {
 		)
 		expect(openConfigFile).toHaveBeenCalled()
 	})
-
-	it("should handle errors when opening config file", async () => {
-		const error = new Error("Failed to open editor")
-		vi.mocked(openConfigFile).mockRejectedValue(error)
-
-		await configCommand.handler(mockContext)
-
-		expect(addMessageSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				type: "system",
-				content: "Opening configuration file...",
-			}),
-		)
-		expect(addMessageSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				type: "error",
-				content: "Failed to open config file: Failed to open editor",
-			}),
-		)
-	})
-
-	it("should handle non-Error exceptions", async () => {
-		vi.mocked(openConfigFile).mockRejectedValue("String error")
-
-		await configCommand.handler(mockContext)
-
-		expect(addMessageSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				type: "error",
-				content: "Failed to open config file: String error",
-			}),
-		)
-	})
 })

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -16,22 +16,13 @@ export const configCommand: Command = {
 	handler: async (context) => {
 		const { addMessage } = context
 
-		try {
-			addMessage({
-				id: Date.now().toString(),
-				type: "system",
-				content: "Opening configuration file...",
-				ts: Date.now(),
-			})
+		addMessage({
+			id: Date.now().toString(),
+			type: "system",
+			content: "Opening configuration file...",
+			ts: Date.now(),
+		})
 
-			await openConfigFile()
-		} catch (error) {
-			addMessage({
-				id: Date.now().toString(),
-				type: "error",
-				content: `Failed to open config file: ${error instanceof Error ? error.message : String(error)}`,
-				ts: Date.now(),
-			})
-		}
+		await openConfigFile()
 	},
 }

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,0 +1,37 @@
+/**
+ * /config command - Open the CLI configuration file
+ */
+
+import type { Command } from "./core/types.js"
+import openConfigFile from "../config/openConfig.js"
+
+export const configCommand: Command = {
+	name: "config",
+	aliases: ["c", "settings"],
+	description: "Open the CLI configuration file in your default editor",
+	usage: "/config",
+	examples: ["/config"],
+	category: "settings",
+	priority: 8,
+	handler: async (context) => {
+		const { addMessage } = context
+
+		try {
+			addMessage({
+				id: Date.now().toString(),
+				type: "system",
+				content: "Opening configuration file...",
+				ts: Date.now(),
+			})
+
+			await openConfigFile()
+		} catch (error) {
+			addMessage({
+				id: Date.now().toString(),
+				type: "error",
+				content: `Failed to open config file: ${error instanceof Error ? error.message : String(error)}`,
+				ts: Date.now(),
+			})
+		}
+	},
+}

--- a/cli/src/commands/index.ts
+++ b/cli/src/commands/index.ts
@@ -14,6 +14,7 @@ import { modeCommand } from "./mode.js"
 import { modelCommand } from "./model.js"
 import { profileCommand } from "./profile.js"
 import { teamsCommand } from "./teams.js"
+import { configCommand } from "./config.js"
 
 /**
  * Initialize all commands
@@ -27,4 +28,5 @@ export function initializeCommands(): void {
 	commandRegistry.register(modelCommand)
 	commandRegistry.register(profileCommand)
 	commandRegistry.register(teamsCommand)
+	commandRegistry.register(configCommand)
 }


### PR DESCRIPTION
## Context

Adding a `/config` command to open the config for the CLI while running the CLI

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
