### PR TITLE
CLI: Make sure we disable Kitty protocol on exit

### DIFF
--- a/cli/src/ui/providers/KeyboardProvider.tsx
+++ b/cli/src/ui/providers/KeyboardProvider.tsx
@@ -39,7 +39,7 @@ import {
 	createPasteKey,
 	createSpecialKey,
 } from "../utils/keyParsing.js"
-import { autoEnableKittyProtocol, disableKittyProtocol } from "../utils/terminalCapabilities.js"
+import { autoEnableKittyProtocol } from "../utils/terminalCapabilities.js"
 import {
 	ESC,
 	PASTE_MODE_PREFIX,
@@ -445,12 +445,6 @@ export function KeyboardProvider({ children, config = {} }: KeyboardProviderProp
 
 			// Disable bracketed paste mode
 			process.stdout.write("\x1b[?2004l")
-
-			// Disable Kitty keyboard protocol if it was enabled
-			const currentKittyState = isKittyEnabled
-			if (currentKittyState) {
-				disableKittyProtocol()
-			}
 
 			// Restore original raw mode
 			if (!wasRaw) {

--- a/cli/src/ui/utils/terminalCapabilities.ts
+++ b/cli/src/ui/utils/terminalCapabilities.ts
@@ -47,6 +47,9 @@ export function autoEnableKittyProtocol(): boolean {
 		process.stdout.write("\x1b[>1u")
 		// CSI = 1 ; 1 u - Push keyboard flags, enable disambiguate
 		process.stdout.write("\x1b[=1;1u")
+
+		process.on("exit", disableKittyProtocol)
+		process.on("SIGTERM", disableKittyProtocol)
 		return true
 	}
 

--- a/cli/src/ui/utils/terminalCapabilities.ts
+++ b/cli/src/ui/utils/terminalCapabilities.ts
@@ -59,7 +59,10 @@ export async function autoEnableKittyProtocol(): Promise<boolean> {
 /**
  * Disable Kitty keyboard protocol
  */
+let kittyDisabled = false
 export function disableKittyProtocol(): void {
-	// CSI < 1 u - Pop keyboard flags (disable)
-	process.stdout.write("\x1b[<u")
+	if (!kittyDisabled) {
+		process.stdout.write("\x1b[<u")
+		kittyDisabled = true
+	}
 }

--- a/cli/src/ui/utils/terminalCapabilities.ts
+++ b/cli/src/ui/utils/terminalCapabilities.ts
@@ -37,9 +37,9 @@ export function detectKittyProtocolSupport(): boolean {
  * Auto-detect and enable Kitty protocol if supported
  * Returns true if enabled, false otherwise
  */
-export function autoEnableKittyProtocol(): boolean {
+export async function autoEnableKittyProtocol(): Promise<boolean> {
 	// Query terminal for actual support
-	const isSupported = detectKittyProtocolSupport()
+	const isSupported = await detectKittyProtocolSupport()
 
 	if (isSupported) {
 		// Enable Kitty keyboard protocol
@@ -61,5 +61,5 @@ export function autoEnableKittyProtocol(): boolean {
  */
 export function disableKittyProtocol(): void {
 	// CSI < 1 u - Pop keyboard flags (disable)
-	process.stdout.write("\x1b[<1u")
+	process.stdout.write("\x1b[<u")
 }

--- a/cli/src/ui/utils/terminalCapabilities.ts
+++ b/cli/src/ui/utils/terminalCapabilities.ts
@@ -37,9 +37,9 @@ export function detectKittyProtocolSupport(): boolean {
  * Auto-detect and enable Kitty protocol if supported
  * Returns true if enabled, false otherwise
  */
-export async function autoEnableKittyProtocol(): Promise<boolean> {
+export function autoEnableKittyProtocol(): boolean {
 	// Query terminal for actual support
-	const isSupported = await detectKittyProtocolSupport()
+	const isSupported = detectKittyProtocolSupport()
 
 	if (isSupported) {
 		// Enable Kitty keyboard protocol


### PR DESCRIPTION
## Context

I noticed that when exitting the CLI through CTRL-C, the Kitty protocol wasn't properly reset, which meant that CTRL-C wouldn't work anymore (see video). This PR makes sure that we always disable the Kitty protocol shenanigans when the CLI exits.

## Screenshots


https://github.com/user-attachments/assets/63300396-acbe-4111-899f-3b47610fa5b2


