### PR TITLE
CLI - Support terminal resize

### DIFF
--- a/.changeset/tough-sloths-stare.md
+++ b/.changeset/tough-sloths-stare.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Terminal resize support

--- a/cli/src/state/hooks/__tests__/useTerminalResize.test.ts
+++ b/cli/src/state/hooks/__tests__/useTerminalResize.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for useTerminalResize hook
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { createStore } from "jotai"
+import { messageResetCounterAtom } from "../../atoms/ui.js"
+
+describe("useTerminalResize", () => {
+	let store: ReturnType<typeof createStore>
+	let originalIsTTY: boolean
+	let resizeListeners: Array<() => void> = []
+
+	beforeEach(() => {
+		store = createStore()
+		originalIsTTY = process.stdout.isTTY
+		resizeListeners = []
+
+		// Mock process.stdout
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: true,
+			writable: true,
+			configurable: true,
+		})
+
+		// Mock process.stdout.on and off
+		vi.spyOn(process.stdout, "on").mockImplementation((event: string, listener: any) => {
+			if (event === "resize") {
+				resizeListeners.push(listener)
+			}
+			return process.stdout
+		})
+
+		vi.spyOn(process.stdout, "off").mockImplementation((event: string | symbol, listener: any) => {
+			if (event === "resize") {
+				const index = resizeListeners.indexOf(listener)
+				if (index > -1) {
+					resizeListeners.splice(index, 1)
+				}
+			}
+			return process.stdout
+		})
+
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: originalIsTTY,
+			writable: true,
+			configurable: true,
+		})
+	})
+
+	describe("Terminal Resize Detection", () => {
+		it("should initialize messageResetCounterAtom with 0", () => {
+			const counter = store.get(messageResetCounterAtom)
+			expect(counter).toBe(0)
+		})
+
+		it("should increment reset counter when manually triggered", () => {
+			const initialCounter = store.get(messageResetCounterAtom)
+
+			// Manually increment the counter (simulating what the hook does)
+			store.set(messageResetCounterAtom, (prev) => prev + 1)
+
+			const newCounter = store.get(messageResetCounterAtom)
+			expect(newCounter).toBe(initialCounter + 1)
+		})
+
+		it("should handle multiple increments", () => {
+			const initialCounter = store.get(messageResetCounterAtom)
+
+			// Simulate multiple resize events
+			store.set(messageResetCounterAtom, (prev) => prev + 1)
+			store.set(messageResetCounterAtom, (prev) => prev + 1)
+			store.set(messageResetCounterAtom, (prev) => prev + 1)
+
+			const newCounter = store.get(messageResetCounterAtom)
+			expect(newCounter).toBe(initialCounter + 3)
+		})
+	})
+
+	describe("Terminal Clear Functionality", () => {
+		it("should verify ANSI clear codes are correct", () => {
+			const clearCode = "\x1b[2J\x1b[H"
+
+			// Verify the clear code format
+			expect(clearCode).toContain("\x1b[2J") // Clear entire screen
+			expect(clearCode).toContain("\x1b[H") // Move cursor to home
+		})
+
+		it("should verify stdout.write can be called with clear codes", () => {
+			const clearCode = "\x1b[2J\x1b[H"
+
+			process.stdout.write(clearCode)
+
+			expect(process.stdout.write).toHaveBeenCalledWith(clearCode)
+		})
+	})
+
+	describe("Hook Export", () => {
+		it("should export useTerminalResize hook", async () => {
+			const hooks = await import("../index.js")
+
+			expect(hooks.useTerminalResize).toBeDefined()
+			expect(typeof hooks.useTerminalResize).toBe("function")
+		})
+	})
+})

--- a/cli/src/state/hooks/index.ts
+++ b/cli/src/state/hooks/index.ts
@@ -71,4 +71,5 @@ export { useFollowupSuggestions } from "./useFollowupSuggestions.js"
 export type { UseFollowupSuggestionsReturn } from "./useFollowupSuggestions.js"
 
 export { useFollowupCIResponse } from "./useFollowupCIResponse.js"
+export { useTerminalResize } from "./useTerminalResize.js"
 export { useFollowupHandler } from "./useFollowupHandler.js"

--- a/cli/src/state/hooks/useTerminalResize.ts
+++ b/cli/src/state/hooks/useTerminalResize.ts
@@ -1,0 +1,51 @@
+/**
+ * useTerminalResize - Hook to handle terminal resize events
+ *
+ * This hook listens for terminal resize events and triggers a full UI re-render
+ * by clearing the terminal and incrementing the message reset counter.
+ * This is necessary because Ink's Static component doesn't re-render on resize.
+ */
+
+import { useEffect, useRef } from "react"
+import { useSetAtom } from "jotai"
+import { messageResetCounterAtom } from "../atoms/ui.js"
+
+/**
+ * Hook to handle terminal resize events
+ * Clears the terminal and forces a full re-render when terminal size changes
+ */
+export function useTerminalResize(): void {
+	const incrementResetCounter = useSetAtom(messageResetCounterAtom)
+	const width = useRef(process.stdout.columns)
+
+	useEffect(() => {
+		// Only set up resize listener if stdout is a TTY
+		if (!process.stdout.isTTY) {
+			return
+		}
+
+		const handleResize = () => {
+			if (process.stdout.columns === width.current) {
+				return
+			}
+			width.current = process.stdout.columns
+
+			// Clear the terminal screen and reset cursor position
+			// \x1b[2J - Clear entire screen
+			// \x1b[3J - Clear scrollback buffer (needed for gnome-terminal)
+			// \x1b[H - Move cursor to home position (0,0)
+			process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
+
+			// Increment reset counter to force Static component remount
+			incrementResetCounter((prev) => prev + 1)
+		}
+
+		// Listen for resize events
+		process.stdout.on("resize", handleResize)
+
+		// Cleanup listener on unmount
+		return () => {
+			process.stdout.off("resize", handleResize)
+		}
+	}, [incrementResetCounter])
+}

--- a/cli/src/ui/UI.tsx
+++ b/cli/src/ui/UI.tsx
@@ -23,6 +23,7 @@ import { useApprovalMonitor } from "../state/hooks/useApprovalMonitor.js"
 import { useProfile } from "../state/hooks/useProfile.js"
 import { useCIMode } from "../state/hooks/useCIMode.js"
 import { useTheme } from "../state/hooks/useTheme.js"
+import { useTerminalResize } from "../state/hooks/useTerminalResize.js"
 import { AppOptions } from "./App.js"
 import { logs } from "../services/logs.js"
 import { createConfigErrorInstructions, createWelcomeMessage } from "./utils/welcomeMessage.js"
@@ -70,6 +71,10 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 		...(options.timeout !== undefined && { timeout: options.timeout }),
 		onExit: onExit,
 	})
+
+	// Terminal resize hook for handling terminal size changes
+	// This clears the terminal and forces re-render of static components
+	useTerminalResize()
 
 	// Track if prompt has been executed and welcome message shown
 	const promptExecutedRef = useRef(false)

--- a/cli/src/ui/messages/extension/ExtensionMessageRow.tsx
+++ b/cli/src/ui/messages/extension/ExtensionMessageRow.tsx
@@ -5,7 +5,7 @@ import { ErrorBoundary } from "react-error-boundary"
 import { AskMessageRouter } from "./AskMessageRouter.js"
 import { SayMessageRouter } from "./SayMessageRouter.js"
 import { useTheme } from "../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../utils/width.js"
+import { getBoxWidth } from "../../utils/width.js"
 
 interface ExtensionMessageRowProps {
 	message: ExtensionChatMessage
@@ -14,7 +14,7 @@ interface ExtensionMessageRowProps {
 function ErrorFallback({ error }: { error: Error }) {
 	const theme = useTheme()
 	return (
-		<Box width={BOX_L1} borderColor={theme.semantic.error} borderStyle="round" padding={1} marginY={1}>
+		<Box width={getBoxWidth(1)} borderColor={theme.semantic.error} borderStyle="round" padding={1} marginY={1}>
 			<Text color={theme.semantic.error}>Error rendering message: {error.message}</Text>
 		</Box>
 	)

--- a/cli/src/ui/messages/extension/ask/AskAutoApprovalMaxReachedMessage.tsx
+++ b/cli/src/ui/messages/extension/ask/AskAutoApprovalMaxReachedMessage.tsx
@@ -4,7 +4,7 @@ import type { MessageComponentProps } from "../types.js"
 import { getMessageIcon } from "../utils.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display auto-approval limit reached warning
@@ -15,7 +15,7 @@ export const AskAutoApprovalMaxReachedMessage: React.FC<MessageComponentProps> =
 
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="single"
 			borderColor={theme.semantic.warning}

--- a/cli/src/ui/messages/extension/ask/AskCommandMessage.tsx
+++ b/cli/src/ui/messages/extension/ask/AskCommandMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { MessageComponentProps } from "../types.js"
 import { getMessageIcon, parseToolData } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display command execution request with terminal icon and command in a bordered box
@@ -29,7 +29,7 @@ export const AskCommandMessage: React.FC<MessageComponentProps> = ({ message }) 
 
 			{command && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					marginLeft={2}
 					marginTop={1}
 					borderStyle="single"

--- a/cli/src/ui/messages/extension/ask/AskInvalidModelMessage.tsx
+++ b/cli/src/ui/messages/extension/ask/AskInvalidModelMessage.tsx
@@ -4,7 +4,7 @@ import type { MessageComponentProps } from "../types.js"
 import { getMessageIcon } from "../utils.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display invalid model selection warning
@@ -15,7 +15,7 @@ export const AskInvalidModelMessage: React.FC<MessageComponentProps> = ({ messag
 
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="single"
 			borderColor={theme.semantic.warning}

--- a/cli/src/ui/messages/extension/ask/AskMistakeLimitMessage.tsx
+++ b/cli/src/ui/messages/extension/ask/AskMistakeLimitMessage.tsx
@@ -4,7 +4,7 @@ import type { MessageComponentProps } from "../types.js"
 import { getMessageIcon } from "../utils.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display mistake limit reached error with red error styling
@@ -15,7 +15,7 @@ export const AskMistakeLimitMessage: React.FC<MessageComponentProps> = ({ messag
 
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="single"
 			borderColor={theme.semantic.error}

--- a/cli/src/ui/messages/extension/ask/AskPaymentRequiredMessage.tsx
+++ b/cli/src/ui/messages/extension/ask/AskPaymentRequiredMessage.tsx
@@ -4,7 +4,7 @@ import type { MessageComponentProps } from "../types.js"
 import { getMessageIcon } from "../utils.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display low credit warning with payment icon
@@ -15,7 +15,7 @@ export const AskPaymentRequiredMessage: React.FC<MessageComponentProps> = ({ mes
 
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="single"
 			borderColor={theme.semantic.warning}

--- a/cli/src/ui/messages/extension/ask/AskToolMessage.tsx
+++ b/cli/src/ui/messages/extension/ask/AskToolMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { MessageComponentProps } from "../types.js"
 import { parseToolData, getToolIcon } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display tool usage requests requiring approval
@@ -51,7 +51,7 @@ export const AskToolMessage: React.FC<MessageComponentProps> = ({ message }) => 
 
 			{toolData.content && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					marginLeft={2}
 					marginTop={1}
 					borderStyle="single"

--- a/cli/src/ui/messages/extension/ask/AskUseMcpServerMessage.tsx
+++ b/cli/src/ui/messages/extension/ask/AskUseMcpServerMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { MessageComponentProps } from "../types.js"
 import { getMessageIcon, parseMcpServerData } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display MCP server usage request (tool or resource access)
@@ -54,7 +54,7 @@ export const AskUseMcpServerMessage: React.FC<MessageComponentProps> = ({ messag
 
 			{mcpData.arguments && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					marginLeft={2}
 					marginTop={1}
 					borderStyle="single"

--- a/cli/src/ui/messages/extension/say/SayCodebaseSearchResultMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayCodebaseSearchResultMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { MessageComponentProps, CodebaseSearchResult } from "../types.js"
 import { getMessageIcon, parseMessageJson } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display codebase search results with scores
@@ -25,7 +25,7 @@ export const SayCodebaseSearchResultMessage: React.FC<MessageComponentProps> = (
 
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="single"
 			borderColor={theme.semantic.info}

--- a/cli/src/ui/messages/extension/say/SayCommandOutputMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayCommandOutputMessage.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { Box, Text } from "ink"
 import type { MessageComponentProps } from "../types.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display command output messages
@@ -18,7 +18,7 @@ export const SayCommandOutputMessage: React.FC<MessageComponentProps> = ({ messa
 
 	return (
 		<Box flexDirection="column" marginBottom={1}>
-			<Box width={BOX_L1} borderStyle="round" borderColor={theme.ui.border.default} paddingX={1}>
+			<Box width={getBoxWidth(1)} borderStyle="round" borderColor={theme.ui.border.default} paddingX={1}>
 				<Text color={theme.ui.text.dimmed} dimColor>
 					{text}
 				</Text>

--- a/cli/src/ui/messages/extension/say/SayCondenseContextErrorMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayCondenseContextErrorMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { MessageComponentProps } from "../types.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display context condensing errors
@@ -12,7 +12,7 @@ export const SayCondenseContextErrorMessage: React.FC<MessageComponentProps> = (
 	const theme = useTheme()
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="single"
 			borderColor={theme.semantic.error}

--- a/cli/src/ui/messages/extension/say/SayDiffErrorMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayDiffErrorMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { MessageComponentProps } from "../types.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display diff application errors with warning icon
@@ -12,7 +12,7 @@ export const SayDiffErrorMessage: React.FC<MessageComponentProps> = ({ message }
 	const theme = useTheme()
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="single"
 			borderColor={theme.semantic.warning}

--- a/cli/src/ui/messages/extension/say/SayErrorMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayErrorMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { MessageComponentProps } from "../types.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display error messages with red bordered box
@@ -12,7 +12,7 @@ export const SayErrorMessage: React.FC<MessageComponentProps> = ({ message }) =>
 	const theme = useTheme()
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="round"
 			borderColor={theme.semantic.error}

--- a/cli/src/ui/messages/extension/say/SayReasoningMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayReasoningMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { MessageComponentProps } from "../types.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display AI reasoning/thinking process in a bordered box
@@ -12,7 +12,7 @@ export const SayReasoningMessage: React.FC<MessageComponentProps> = ({ message }
 	const theme = useTheme()
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="single"
 			borderColor={theme.ui.text.highlight}

--- a/cli/src/ui/messages/extension/say/SayShellIntegrationWarningMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayShellIntegrationWarningMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { MessageComponentProps } from "../types.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display shell integration warnings
@@ -12,7 +12,7 @@ export const SayShellIntegrationWarningMessage: React.FC<MessageComponentProps> 
 	const theme = useTheme()
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="single"
 			borderColor={theme.semantic.warning}

--- a/cli/src/ui/messages/extension/say/SaySubtaskResultMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SaySubtaskResultMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { MessageComponentProps } from "../types.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display subtask results in a badge-styled box
@@ -12,7 +12,7 @@ export const SaySubtaskResultMessage: React.FC<MessageComponentProps> = ({ messa
 	const theme = useTheme()
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="round"
 			borderColor={theme.semantic.info}

--- a/cli/src/ui/messages/extension/say/SayToolMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayToolMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { MessageComponentProps } from "../types.js"
 import { parseToolData, getToolIcon } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display tool execution results
@@ -38,7 +38,7 @@ export const SayToolMessage: React.FC<MessageComponentProps> = ({ message }) => 
 
 			{toolData.content && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					marginLeft={2}
 					marginTop={1}
 					borderStyle="single"

--- a/cli/src/ui/messages/extension/say/SayUserEditTodosMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayUserEditTodosMessage.tsx
@@ -4,7 +4,7 @@ import type { MessageComponentProps } from "../types.js"
 import { parseToolData } from "../utils.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display user manually edited todos
@@ -15,7 +15,7 @@ export const SayUserEditTodosMessage: React.FC<MessageComponentProps> = ({ messa
 
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="single"
 			borderColor={theme.semantic.info}

--- a/cli/src/ui/messages/extension/say/SayUserFeedbackDiffMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayUserFeedbackDiffMessage.tsx
@@ -4,7 +4,7 @@ import type { MessageComponentProps } from "../types.js"
 import { parseToolData, truncateText } from "../utils.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display user feedback with diff content
@@ -15,7 +15,7 @@ export const SayUserFeedbackDiffMessage: React.FC<MessageComponentProps> = ({ me
 
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="round"
 			borderColor={theme.messages.user}
@@ -35,7 +35,7 @@ export const SayUserFeedbackDiffMessage: React.FC<MessageComponentProps> = ({ me
 
 			{toolData?.diff && (
 				<Box
-					width={BOX_L1}
+					width={getBoxWidth(1)}
 					marginTop={1}
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/messages/extension/say/SayUserFeedbackMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayUserFeedbackMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { MessageComponentProps } from "../types.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display user feedback messages
@@ -12,7 +12,7 @@ export const SayUserFeedbackMessage: React.FC<MessageComponentProps> = ({ messag
 	const theme = useTheme()
 	return (
 		<Box
-			width={BOX_L1}
+			width={getBoxWidth(1)}
 			flexDirection="column"
 			borderStyle="round"
 			borderColor={theme.messages.user}

--- a/cli/src/ui/messages/extension/tools/ToolEditedExistingFileMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolEditedExistingFileMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
 import { getToolIcon, formatFilePath, truncateText } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1, BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display file edits with diff (handles both editedExistingFile and appliedDiff tool types)
@@ -16,7 +16,7 @@ export const ToolEditedExistingFileMessage: React.FC<ToolMessageProps> = ({ tool
 	if (isBatch) {
 		return (
 			<Box
-				width={BOX_L1}
+				width={getBoxWidth(1)}
 				flexDirection="column"
 				borderStyle="single"
 				borderColor={theme.semantic.info}
@@ -66,7 +66,7 @@ export const ToolEditedExistingFileMessage: React.FC<ToolMessageProps> = ({ tool
 
 			{toolData.diff && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					flexDirection="column"
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/messages/extension/tools/ToolFetchInstructionsMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolFetchInstructionsMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
 import { getToolIcon, truncateText } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display fetched instructions
@@ -23,7 +23,7 @@ export const ToolFetchInstructionsMessage: React.FC<ToolMessageProps> = ({ toolD
 
 			{toolData.content && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					flexDirection="column"
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/messages/extension/tools/ToolGenerateImageMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolGenerateImageMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
 import { getToolIcon, formatFilePath, truncateText } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display image generation request
@@ -34,7 +34,7 @@ export const ToolGenerateImageMessage: React.FC<ToolMessageProps> = ({ toolData 
 
 			{toolData.content && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					flexDirection="column"
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/messages/extension/tools/ToolInsertContentMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolInsertContentMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
 import { getToolIcon, formatFilePath, truncateText } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display content insertion at specific line
@@ -41,7 +41,7 @@ export const ToolInsertContentMessage: React.FC<ToolMessageProps> = ({ toolData 
 
 			{toolData.diff && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					flexDirection="column"
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/messages/extension/tools/ToolListCodeDefinitionNamesMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolListCodeDefinitionNamesMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
 import { getToolIcon, formatFilePath, truncateText } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display code definitions listing
@@ -29,7 +29,7 @@ export const ToolListCodeDefinitionNamesMessage: React.FC<ToolMessageProps> = ({
 
 			{definitions.length > 0 && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					flexDirection="column"
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/messages/extension/tools/ToolListFilesRecursiveMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolListFilesRecursiveMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
 import { getToolIcon, formatFilePath, truncateText } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display recursive file listing
@@ -29,7 +29,7 @@ export const ToolListFilesRecursiveMessage: React.FC<ToolMessageProps> = ({ tool
 
 			{files.length > 0 && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					flexDirection="column"
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/messages/extension/tools/ToolListFilesTopLevelMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolListFilesTopLevelMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
 import { getToolIcon, formatFilePath, truncateText } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display top-level file listing
@@ -29,7 +29,7 @@ export const ToolListFilesTopLevelMessage: React.FC<ToolMessageProps> = ({ toolD
 
 			{files.length > 0 && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					flexDirection="column"
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/messages/extension/tools/ToolNewFileCreatedMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolNewFileCreatedMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
 import { getToolIcon, formatFilePath, truncateText } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display new file creation with content preview
@@ -29,7 +29,7 @@ export const ToolNewFileCreatedMessage: React.FC<ToolMessageProps> = ({ toolData
 
 			{toolData.content && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					flexDirection="column"
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/messages/extension/tools/ToolNewTaskMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolNewTaskMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
 import { getToolIcon, truncateText } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display new subtask creation
@@ -33,7 +33,7 @@ export const ToolNewTaskMessage: React.FC<ToolMessageProps> = ({ toolData }) => 
 
 			{toolData.content && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					flexDirection="column"
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/messages/extension/tools/ToolReadFileMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolReadFileMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
 import { getToolIcon, formatFilePath } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L1 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display file reading (single or batch)
@@ -17,7 +17,7 @@ export const ToolReadFileMessage: React.FC<ToolMessageProps> = ({ toolData }) =>
 		const totalFiles = toolData.batchFiles!.length + (toolData.additionalFileCount || 0)
 		return (
 			<Box
-				width={BOX_L1}
+				width={getBoxWidth(1)}
 				flexDirection="column"
 				borderStyle="round"
 				borderColor={theme.messages.user}

--- a/cli/src/ui/messages/extension/tools/ToolSearchAndReplaceMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolSearchAndReplaceMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
 import { getToolIcon, formatFilePath, truncateText } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display search and replace operations
@@ -28,7 +28,7 @@ export const ToolSearchAndReplaceMessage: React.FC<ToolMessageProps> = ({ toolDa
 
 			{toolData.diff && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					flexDirection="column"
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/messages/extension/tools/ToolSearchFilesMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolSearchFilesMessage.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
 import { getToolIcon, formatFilePath, truncateText } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display regex file search results
@@ -48,7 +48,7 @@ export const ToolSearchFilesMessage: React.FC<ToolMessageProps> = ({ toolData })
 
 			{results.length > 0 && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					flexDirection="column"
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/messages/extension/tools/ToolUpdateTodoListMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolUpdateTodoListMessage.tsx
@@ -5,7 +5,7 @@ import { getToolIcon } from "../utils.js"
 import { MarkdownText } from "../../../components/MarkdownText.js"
 import { logs } from "../../../../services/logs.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
-import { BOX_L3 } from "../../../utils/width.js"
+import { getBoxWidth } from "../../../utils/width.js"
 
 /**
  * Display todo list updates with status indicators
@@ -48,7 +48,7 @@ export const ToolUpdateTodoListMessage: React.FC<ToolMessageProps> = ({ toolData
 
 			{toolData.todos && toolData.todos.length > 0 && (
 				<Box
-					width={BOX_L3}
+					width={getBoxWidth(3)}
 					flexDirection="column"
 					borderStyle="single"
 					borderColor={theme.ui.border.default}

--- a/cli/src/ui/utils/width.ts
+++ b/cli/src/ui/utils/width.ts
@@ -1,4 +1,13 @@
-export const BOX_FULL_WIDTH = process.stdout.columns || 80
-export const BOX_L1 = BOX_FULL_WIDTH - 2
-export const BOX_L2 = BOX_FULL_WIDTH - 4
-export const BOX_L3 = BOX_FULL_WIDTH - 6
+export const getBoxWidth = (level: 1 | 2 | 3): number => {
+	const width = process.stdout.columns || 80
+	switch (level) {
+		case 1:
+			return width - 2
+		case 2:
+			return width - 4
+		case 3:
+			return width - 6
+		default:
+			return width
+	}
+}


### PR DESCRIPTION
## Context

Resolve: #3023 

## Implementation

useTerminalResize Hook to:
- Detect width change
- `\x1b[2J` - Clear entire screen
- `\x1b[3J` - Clear scrollback buffer (needed for gnome-terminal)
- `\x1b[H` - Move cursor to home position (0,0)
- force the redraw of the static components

Update the all BOX definitions for a dynamic function

## Screenshots

https://github.com/user-attachments/assets/2f37cd16-c16d-4f5f-b89b-66730f90f50b

## How to Test

- Resize your TTY