### PR TITLE
fix(types): fix URL building to handle query parameters in sign-in links

### DIFF
--- a/.changeset/hip-lands-search.md
+++ b/.changeset/hip-lands-search.md
@@ -1,0 +1,5 @@
+---
+"@roo-code/types": patch
+---
+
+Fix broken sign-in links

--- a/.changeset/hip-lands-search.md
+++ b/.changeset/hip-lands-search.md
@@ -1,5 +1,5 @@
 ---
-"@roo-code/types": patch
+"kilo-code": patch
 ---
 
 Fix broken sign-in links

--- a/packages/types/src/__tests__/kilocode.test.ts
+++ b/packages/types/src/__tests__/kilocode.test.ts
@@ -282,6 +282,9 @@ describe("URL functions", () => {
 			expect(getAppUrl("/profile")).toBe("https://kilocode.ai/profile")
 			expect(getAppUrl("/support")).toBe("https://kilocode.ai/support")
 			expect(getAppUrl("/sign-in-to-editor")).toBe("https://kilocode.ai/sign-in-to-editor")
+			expect(getAppUrl("/sign-in-to-editor?source=vscode")).toBe(
+				"https://kilocode.ai/sign-in-to-editor?source=vscode",
+			)
 		})
 
 		it("should handle development environment", () => {

--- a/packages/types/src/kilocode/kilocode.ts
+++ b/packages/types/src/kilocode/kilocode.ts
@@ -106,7 +106,13 @@ function buildUrl(path: string = ""): string {
 	try {
 		const backend = new URL(getGlobalKilocodeBackendUrl())
 		const result = new URL(backend)
-		result.pathname = path ? ensureLeadingSlash(path) : ""
+
+		// Separate pathname and search parameters
+		const [pathname, search] = path.split("?")
+		result.pathname = pathname ? ensureLeadingSlash(pathname) : ""
+		if (search) {
+			result.search = `?${search}`
+		}
 
 		return removeTrailingSlash(result.toString(), result.pathname)
 	} catch (error) {


### PR DESCRIPTION
The buildUrl function was incorrectly concatenating query parameters as part of the pathname, causing malformed URLs for sign-in links with parameters like "?source=vscode". This change separates pathname and search parameters properly, ensuring correct URL construction. Added corresponding test case to verify the fix.

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
