### PR TITLE
stop prompt logging

### DIFF
--- a/src/services/ghost/GhostProvider.ts
+++ b/src/services/ghost/GhostProvider.ts
@@ -313,9 +313,6 @@ export class GhostProvider {
 			await this.load()
 		}
 
-		console.log("system", systemPrompt)
-		console.log("userprompt", userPrompt)
-
 		// Initialize the streaming parser
 		this.streamingParser.initialize(context)
 


### PR DESCRIPTION
makes debugging harder to read

Maybe we added this when we had more complex prompt switching? But because it is really long it makes debugging harder atm, and it isnt worthwhile imo