### PR TITLE
ensure only available server capabilities are fetched

### DIFF
--- a/.changeset/chatty-planes-begin.md
+++ b/.changeset/chatty-planes-begin.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Now only available MCP server capabilities are fetched

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -847,7 +847,7 @@ export class McpHub {
 			this.kiloNotificationService.connect(name, connection.client)
 
 			// Initial fetch of tools and resources
-			this.fetchAvailableServerCapabilities(name, source) // kilocode_change: logic moved into method
+			await this.fetchAvailableServerCapabilities(name, source) // kilocode_change: logic moved into method
 		} catch (error) {
 			// Update status with error
 			const connection = this.findConnection(name, source)
@@ -1434,7 +1434,7 @@ export class McpHub {
 						await this.connectToServer(serverName, config, serverSource)
 					} else if (connection.server.status === "connected") {
 						// Only refresh capabilities if connected
-						this.fetchAvailableServerCapabilities(serverName, serverSource) // kilocode_change: logic moved into method
+						await this.fetchAvailableServerCapabilities(serverName, serverSource) // kilocode_change: logic moved into method
 					}
 				} catch (error) {
 					console.error(`Failed to refresh capabilities for ${serverName}:`, error)

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -847,9 +847,7 @@ export class McpHub {
 			this.kiloNotificationService.connect(name, connection.client)
 
 			// Initial fetch of tools and resources
-			connection.server.tools = await this.fetchToolsList(name, source)
-			connection.server.resources = await this.fetchResourcesList(name, source)
-			connection.server.resourceTemplates = await this.fetchResourceTemplatesList(name, source)
+			this.fetchAvailableServerCapabilities(name, source)
 		} catch (error) {
 			// Update status with error
 			const connection = this.findConnection(name, source)
@@ -913,12 +911,39 @@ export class McpHub {
 		)
 	}
 
+	/**
+	 * Helper method to set the supported server capabilities
+	 * @param serverName The name of the server to find
+	 * @param source Optional source to filter by (global or project)
+	 */
+	private async fetchAvailableServerCapabilities(serverName: string, source?: "global" | "project") {
+		// Use the helper method to find the connection
+		const connection = this.findConnection(serverName, source)
+
+		if (!connection || connection.type !== "connected") {
+			return
+		}
+
+		if (connection.client.getServerCapabilities()?.tools) {
+			connection.server.tools = await this.fetchToolsList(serverName, source)
+		}
+		if (connection.client.getServerCapabilities()?.resources) {
+			connection.server.resources = await this.fetchResourcesList(serverName, source)
+			connection.server.resourceTemplates = await this.fetchResourceTemplatesList(serverName, source)
+		}
+	}
+
 	private async fetchToolsList(serverName: string, source?: "global" | "project"): Promise<McpTool[]> {
 		try {
 			// Use the helper method to find the connection
 			const connection = this.findConnection(serverName, source)
 
 			if (!connection || connection.type !== "connected") {
+				return []
+			}
+
+			// Only proceed of the server defined the tools capability.
+			if (!connection.client.getServerCapabilities()?.tools) {
 				return []
 			}
 
@@ -976,6 +1001,12 @@ export class McpHub {
 			if (!connection || connection.type !== "connected") {
 				return []
 			}
+
+			// Only proceed of the server defined the resources capability.
+			if (!connection.client.getServerCapabilities()?.resources) {
+				return []
+			}
+
 			const response = await connection.client.request({ method: "resources/list" }, ListResourcesResultSchema)
 			return response?.resources || []
 		} catch (error) {
@@ -993,6 +1024,12 @@ export class McpHub {
 			if (!connection || connection.type !== "connected") {
 				return []
 			}
+
+			// Only proceed of the server defined the resources capability.
+			if (!connection.client.getServerCapabilities()?.resources) {
+				return []
+			}
+
 			const response = await connection.client.request(
 				{ method: "resources/templates/list" },
 				ListResourceTemplatesResultSchema,
@@ -1389,12 +1426,7 @@ export class McpHub {
 						await this.connectToServer(serverName, config, serverSource)
 					} else if (connection.server.status === "connected") {
 						// Only refresh capabilities if connected
-						connection.server.tools = await this.fetchToolsList(serverName, serverSource)
-						connection.server.resources = await this.fetchResourcesList(serverName, serverSource)
-						connection.server.resourceTemplates = await this.fetchResourceTemplatesList(
-							serverName,
-							serverSource,
-						)
+						this.fetchAvailableServerCapabilities(serverName, serverSource)
 					}
 				} catch (error) {
 					console.error(`Failed to refresh capabilities for ${serverName}:`, error)

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -847,7 +847,7 @@ export class McpHub {
 			this.kiloNotificationService.connect(name, connection.client)
 
 			// Initial fetch of tools and resources
-			this.fetchAvailableServerCapabilities(name, source)
+			this.fetchAvailableServerCapabilities(name, source) // kilocode_change: logic moved into method
 		} catch (error) {
 			// Update status with error
 			const connection = this.findConnection(name, source)
@@ -911,6 +911,7 @@ export class McpHub {
 		)
 	}
 
+	// kilocode_change start: method added
 	/**
 	 * Helper method to set the supported server capabilities
 	 * @param serverName The name of the server to find
@@ -932,6 +933,7 @@ export class McpHub {
 			connection.server.resourceTemplates = await this.fetchResourceTemplatesList(serverName, source)
 		}
 	}
+	// kilocode_change end
 
 	private async fetchToolsList(serverName: string, source?: "global" | "project"): Promise<McpTool[]> {
 		try {
@@ -942,10 +944,12 @@ export class McpHub {
 				return []
 			}
 
+			// kilocode_change start
 			// Only proceed of the server defined the tools capability.
 			if (!connection.client.getServerCapabilities()?.tools) {
 				return []
 			}
+			// kilocode_change end
 
 			const response = await connection.client.request({ method: "tools/list" }, ListToolsResultSchema)
 
@@ -1002,10 +1006,12 @@ export class McpHub {
 				return []
 			}
 
+			// kilocode_change start
 			// Only proceed of the server defined the resources capability.
 			if (!connection.client.getServerCapabilities()?.resources) {
 				return []
 			}
+			// kilocode_change end
 
 			const response = await connection.client.request({ method: "resources/list" }, ListResourcesResultSchema)
 			return response?.resources || []
@@ -1025,10 +1031,12 @@ export class McpHub {
 				return []
 			}
 
+			// kilocode_change start
 			// Only proceed of the server defined the resources capability.
 			if (!connection.client.getServerCapabilities()?.resources) {
 				return []
 			}
+			// kilocode_change end
 
 			const response = await connection.client.request(
 				{ method: "resources/templates/list" },
@@ -1426,7 +1434,7 @@ export class McpHub {
 						await this.connectToServer(serverName, config, serverSource)
 					} else if (connection.server.status === "connected") {
 						// Only refresh capabilities if connected
-						this.fetchAvailableServerCapabilities(serverName, serverSource)
+						this.fetchAvailableServerCapabilities(serverName, serverSource) // kilocode_change: logic moved into method
 					}
 				} catch (error) {
 					console.error(`Failed to refresh capabilities for ${serverName}:`, error)

--- a/src/services/mcp/__tests__/McpHub.spec.ts
+++ b/src/services/mcp/__tests__/McpHub.spec.ts
@@ -219,7 +219,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
-				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }), // kilocode_change
 			}
 
 			Client.mockImplementation(() => mockClient)
@@ -388,7 +388,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
-				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }), // kilocode_change
 			}
 
 			Client.mockImplementation(() => mockClient)
@@ -462,7 +462,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
-				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }), // kilocode_change
 			}
 
 			Client.mockImplementation(() => mockClient)
@@ -673,7 +673,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
-				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }), // kilocode_change
 			}
 
 			Client.mockImplementation(() => mockClient)
@@ -746,7 +746,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
-				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }), // kilocode_change
 			}
 
 			Client.mockImplementation(() => mockClient)
@@ -1557,7 +1557,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
-				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }), // kilocode_change
 			}
 
 			Client.mockImplementation(() => mockClient)
@@ -1678,7 +1678,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
-				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }), // kilocode_change
 			}))
 
 			// Mock provider with mcpEnabled: true
@@ -1866,7 +1866,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
-				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }), // kilocode_change
 			}))
 
 			// Create a new McpHub instance
@@ -1929,7 +1929,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
-				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }), // kilocode_change
 			}))
 
 			// Create a new McpHub instance
@@ -1992,7 +1992,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
-				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }), // kilocode_change
 			}))
 
 			// Create a new McpHub instance
@@ -2062,7 +2062,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
-				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }), // kilocode_change
 			}))
 
 			// Create a new McpHub instance
@@ -2136,7 +2136,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
-				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }), // kilocode_change
 			}))
 
 			// Create a new McpHub instance

--- a/src/services/mcp/__tests__/McpHub.spec.ts
+++ b/src/services/mcp/__tests__/McpHub.spec.ts
@@ -219,6 +219,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
 			}
 
 			Client.mockImplementation(() => mockClient)
@@ -387,6 +388,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
 			}
 
 			Client.mockImplementation(() => mockClient)
@@ -460,6 +462,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
 			}
 
 			Client.mockImplementation(() => mockClient)
@@ -670,6 +673,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
 			}
 
 			Client.mockImplementation(() => mockClient)
@@ -742,6 +746,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
 			}
 
 			Client.mockImplementation(() => mockClient)
@@ -1552,6 +1557,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
 			}
 
 			Client.mockImplementation(() => mockClient)
@@ -1672,6 +1678,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
 			}))
 
 			// Mock provider with mcpEnabled: true
@@ -1859,6 +1866,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
 			}))
 
 			// Create a new McpHub instance
@@ -1921,6 +1929,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
 			}))
 
 			// Create a new McpHub instance
@@ -1983,6 +1992,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
 			}))
 
 			// Create a new McpHub instance
@@ -2052,6 +2062,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
 			}))
 
 			// Create a new McpHub instance
@@ -2125,6 +2136,7 @@ describe("McpHub", () => {
 				close: vi.fn().mockResolvedValue(undefined),
 				getInstructions: vi.fn().mockReturnValue("test instructions"),
 				request: vi.fn().mockResolvedValue({ tools: [], resources: [], resourceTemplates: [] }),
+				getServerCapabilities: vi.fn().mockResolvedValue({ tools: {} }),
 			}))
 
 			// Create a new McpHub instance


### PR DESCRIPTION
## Context

Currently the possible [tools, resources and resources templates are fetched ](https://github.com/Kilo-Org/kilocode/blob/main/src/services/mcp/McpHub.ts#L849-L852) in the `McpHub.connectToServer` method.

Based on the [spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#initialization), during `Initialization` phase, the [capabilities](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#capability-negotiation) of both client and server must be negotiated.

So it would make sense to ensure that e.g. resources are not fetched (or give an error while trying to fetch them) if the server already defined it doesn't support them.

If Pr addresses this

(see also https://github.com/Kilo-Org/kilocode/discussions/3350)

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

* added a helper method `McpHub:fetchAvailableServerCapabilities` that checks the server capabilities before fetching hem
* added a check in all existing `fetch...List` methods to verify if the server capability is supported.

Depending on the approach, the check could also only live in the `fetch...List` methods, and `McpHub:fetchAvailableServerCapabilities` only be used as an easy helper method to fetch all capabilities, [as there are others too](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#capability-negotiation).

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|  <img width="651" height="814" alt="Screenshot 2025-10-28 at 11 48 15" src="https://github.com/user-attachments/assets/d61917e8-9c8d-470b-9831-74bced9c893c" /> | <img width="648" height="595" alt="Screenshot 2025-10-28 at 11 37 31" src="https://github.com/user-attachments/assets/84e60b74-81cc-4282-9958-79580a769b07" /> |

## How to Test

- use an MCP server that doesn't support tools or resources
- verify that there are no calls (and thus errors) for fetching those capabilities

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

 - 

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
Discord handle: mollux
GitLab profile: https://gitlab.com/mmichaux-ext
