### PR TITLE
Hide autocomplete indicator when LLM call throws

### DIFF
--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -270,33 +270,39 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 			}
 
 			const fullContext = await this.ghostContext.generate(context)
-			const result = await this.getFromLLM(fullContext, this.model)
+			try {
+				const result = await this.getFromLLM(fullContext, this.model)
 
-			// Hide cursor animation after generation
-			this.cursorAnimation.hide()
+				// Hide cursor animation after generation
+				this.cursorAnimation.hide()
 
-			// Track costs
-			if (this.costTrackingCallback) {
-				this.costTrackingCallback(
-					result.cost,
-					result.inputTokens,
-					result.outputTokens,
-					result.cacheWriteTokens,
-					result.cacheReadTokens,
-				)
-			}
-
-			// Update suggestions history
-			this.updateSuggestions(result.suggestions)
-
-			// Return the new suggestion if available
-			const fillInAtCursor = result.suggestions.getFillInAtCursor()
-			if (fillInAtCursor) {
-				const item: vscode.InlineCompletionItem = {
-					insertText: fillInAtCursor.text,
-					range: new vscode.Range(position, position),
+				// Track costs
+				if (this.costTrackingCallback) {
+					this.costTrackingCallback(
+						result.cost,
+						result.inputTokens,
+						result.outputTokens,
+						result.cacheWriteTokens,
+						result.cacheReadTokens,
+					)
 				}
-				return [item]
+
+				// Update suggestions history
+				this.updateSuggestions(result.suggestions)
+
+				// Return the new suggestion if available
+				const fillInAtCursor = result.suggestions.getFillInAtCursor()
+				if (fillInAtCursor) {
+					const item: vscode.InlineCompletionItem = {
+						insertText: fillInAtCursor.text,
+						range: new vscode.Range(position, position),
+					}
+					return [item]
+				}
+			} catch (error) {
+				this.cursorAnimation.hide()
+				console.error("Error getting inline completion from LLM:", error)
+				return []
 			}
 		}
 


### PR DESCRIPTION
## Context

When calling LLM for autocomplete if it thows for any reason the indicator (if enabled) is never hidden. This fixes the issue by try/catch & hiding it in the catch.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

Configure a broken provider & attempt to auto-complete. It throws sometimes, and the indicator hangs out forever.  Now, it goes away on error.
