### PR TITLE
Make publishing of the extension a manual action

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -1,7 +1,5 @@
 name: Publish Extension
 on:
-    pull_request:
-        types: [closed]
     workflow_dispatch:
 
 env:
@@ -16,11 +14,6 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: write # Required for pushing tags.
-        if: >
-            ( github.event_name == 'pull_request' &&
-            github.event.pull_request.base.ref == 'main' &&
-            contains(github.event.pull_request.title, 'Changeset version bump') ) ||
-            github.event_name == 'workflow_dispatch'
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -110,11 +103,6 @@ jobs:
     publish-jetbrains:
         needs: publish-extension
         runs-on: ubuntu-latest
-        if: >
-            ( github.event_name == 'pull_request' &&
-            github.event.pull_request.base.ref == 'main' &&
-            contains(github.event.pull_request.title, 'Changeset version bump') ) ||
-            github.event_name == 'workflow_dispatch'
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -177,11 +165,11 @@ jobs:
                   path: jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}
             - name: JetBrains Marketplace Publisher
               run: |
-                 curl \
-                 -X POST \
-                 -H "Authorization: Bearer ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}" \
-                 -F "file=@jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}" \
-                 -F "pluginId=28350" \
-                 -F "channel=stable" \
-                 -F "isHidden=false" \
-                 https://plugins.jetbrains.com/plugin/uploadPlugin
+                  curl \
+                  -X POST \
+                  -H "Authorization: Bearer ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}" \
+                  -F "file=@jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}" \
+                  -F "pluginId=28350" \
+                  -F "channel=stable" \
+                  -F "isHidden=false" \
+                  https://plugins.jetbrains.com/plugin/uploadPlugin


### PR DESCRIPTION
Previously we automatically published the extension when the Changeset PR got merged, but now that we also bump the CLI version through changeset that means that we have to publish the extension whenever we want to release the CLI, which is not great, especially because we want to limit the number of releases of the extension.

This PR removes the PR-closed trigger, which means that to release the extension we have to manually trigger this workflow.