### PR TITLE
feat: cache failed Ghost autocomplete lookups to prevent redundant LL…

### DIFF
--- a/.changeset/good-horses-rush.md
+++ b/.changeset/good-horses-rush.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Do less requests for autocomplete when no completion could be found


### PR DESCRIPTION
…M calls

- Add failedLookupsCache to store prefix/suffix combinations that returned no suggestions
- Implement FIFO eviction with MAX_FAILED_CACHE_SIZE of 50 entries
- Check failed cache before making LLM API calls in getFromLLM()
- Add failed lookups to cache when parseGhostResponse returns no suggestions
- Only track costs when result.cost > 0 to avoid tracking cached lookups
- Add comprehensive test coverage for failed lookups cache functionality

Benefits:
- Reduces unnecessary LLM API calls for contexts that don't generate suggestions
- Improves performance and reduces costs
- Maintains separate caches for successful and failed lookups

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
