### PR TITLE
Sebastiand/update cerebras

### DIFF
--- a/.changeset/fifty-cars-approve.md
+++ b/.changeset/fifty-cars-approve.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Some UI text related to pricing and cost has been improved

--- a/.changeset/metal-views-build.md
+++ b/.changeset/metal-views-build.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Credits Store Improvements

--- a/src/activate/handleUri.ts
+++ b/src/activate/handleUri.ts
@@ -35,6 +35,18 @@ export const handleUri = async (uri: vscode.Uri) => {
 			}
 			break
 		}
+		// kilocode_change start
+		case "/kilocode/profile": {
+			await visibleProvider.postMessageToWebview({
+				type: "action",
+				action: "profileButtonClicked",
+			})
+			await visibleProvider.postMessageToWebview({
+				type: "updateProfileData",
+			})
+			break
+		}
+		// kilocode_change end
 		case "/requesty": {
 			const code = query.get("code")
 			if (code) {

--- a/src/api/providers/__tests__/virtual-quota-fallback-provider.spec.ts
+++ b/src/api/providers/__tests__/virtual-quota-fallback-provider.spec.ts
@@ -109,7 +109,9 @@ describe("VirtualQuotaFallbackProvider", () => {
 		})
 
 		it("should prune old events when consuming", async () => {
-			const now = Date.now()
+			const now = 1000000000000 // Fixed timestamp to avoid race conditions
+			const dateNowSpy = vitest.spyOn(Date, "now").mockReturnValue(now)
+
 			const oneDayMs = 24 * 60 * 60 * 1000
 			const oldEvent: UsageEvent = {
 				timestamp: now - oneDayMs - 1000,
@@ -125,6 +127,8 @@ describe("VirtualQuotaFallbackProvider", () => {
 			const updatedEvents = (mockContext.globalState.update as any).mock.calls[0][1]
 			expect(updatedEvents.find((e: UsageEvent) => e.timestamp === oldEvent.timestamp)).toBeUndefined()
 			expect(updatedEvents.find((e: UsageEvent) => e.timestamp === newEvent.timestamp)).toBeDefined()
+
+			dateNowSpy.mockRestore()
 		})
 
 		it("should clear all usage data", async () => {

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -2130,7 +2130,6 @@ export const webviewMessageHandler = async (
 			}
 			break
 		case "shopBuyCredits": // New handler
-			console.log("shopBuyCredits message received", message)
 			try {
 				const { apiConfiguration } = await provider.getState()
 				const kilocodeToken = apiConfiguration?.kilocodeToken
@@ -2155,27 +2154,17 @@ export const webviewMessageHandler = async (
 						validateStatus: (status) => status < 400, // Accept 3xx status codes
 					},
 				)
-
 				if (response.status !== 303 || !response.headers.location) {
 					return
 				}
 				await vscode.env.openExternal(vscode.Uri.parse(response.headers.location))
 			} catch (error: any) {
-				// Handle axios errors that might include redirect information
-				if (error.response?.status === 303 && error.response?.headers?.location) {
-					try {
-						const redirectUrl = error.response.headers.location
-						await vscode.env.openExternal(vscode.Uri.parse(redirectUrl))
-						provider.log(`Opened Stripe payment URL from error response: ${redirectUrl}`)
-						break
-					} catch (openError) {
-						provider.log(`Failed to open redirect URL from error response: ${openError}`)
-					}
-				}
-
-				const errorMessage = error.response?.data?.message || error.message || "Failed to initiate payment"
-				provider.log(`Error redirecting to payment page: ${errorMessage}`)
-				vscode.window.showErrorMessage(`Payment error: ${errorMessage}`)
+				const errorMessage = error?.message || "Unknown error";
+				const errorStack = error?.stack ? ` Stack: ${error.stack}` : "";
+				provider.log(`Error redirecting to payment page: ${errorMessage}.${errorStack}`);
+				provider.postMessageToWebview({
+					type: "updateProfileData",
+				})
 			}
 			break
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -106,6 +106,7 @@ export interface ExtensionMessage {
 		| "vsCodeSetting"
 		| "profileDataResponse" // kilocode_change
 		| "balanceDataResponse" // kilocode_change
+		| "updateProfileData" // kilocode_change
 		| "authenticatedUser"
 		| "condenseTaskContextResponse"
 		| "singleRouterModelFetchResponse"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -197,6 +197,7 @@ export interface WebviewMessage {
 		| "fetchBalanceDataRequest" // kilocode_change
 		| "shopBuyCredits" // kilocode_change
 		| "balanceDataResponse" // kilocode_change
+		| "updateProfileData" // kilocode_change
 		| "condense" // kilocode_change
 		| "toggleWorkflow" // kilocode_change
 		| "refreshRules" // kilocode_change

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -65,7 +65,7 @@ export const fireworksDefaultModelId: FireworksModelId = "accounts/fireworks/mod
 export const cerebrasModels = {
 	"zai-glm-4.6": {
 		maxTokens: 40000,
-		contextWindow: 64000,
+		contextWindow: 128000,
 		supportsImages: false,
 		supportsPromptCache: false,
 		inputPrice: 0,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -63,6 +63,24 @@ export const fireworksDefaultModelId: FireworksModelId = "accounts/fireworks/mod
 // Cerebras AI Inference Model Definitions - Updated July 2025
 
 export const cerebrasModels = {
+	"zai-glm-4.6": {
+		maxTokens: 40000,
+		contextWindow: 64000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+		description: "SOTA coding model with ~3000 tokens/s",
+	},
+	"gpt-oss-120b": {
+		maxTokens: 40000,
+		contextWindow: 64000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+		description: "SOTA coding model with ~3000 tokens/s",
+	},
 	"qwen-3-coder-480b-free": {
 		maxTokens: 40000,
 		contextWindow: 64000,
@@ -70,7 +88,7 @@ export const cerebrasModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "SOTA coding model with ~2000 tokens/s (free tier)",
+		description: "[SOON TO BE DEPRECATED] SOTA coding model with ~2000 tokens/s (free tier)",
 	},
 	"qwen-3-coder-480b": {
 		maxTokens: 40000,
@@ -79,7 +97,7 @@ export const cerebrasModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "SOTA coding model with ~2000 tokens/s",
+		description: "[SOON TO BE DEPRECATED] SOTA coding model with ~2000 tokens/s",
 	},
 	"qwen-3-235b-a22b-instruct-2507": {
 		maxTokens: 20000,
@@ -120,7 +138,7 @@ export const cerebrasModels = {
 } as const satisfies Record<string, ModelInfo>
 
 export type CerebrasModelId = keyof typeof cerebrasModels
-export const cerebrasDefaultModelId: CerebrasModelId = "qwen-3-coder-480b-free"
+export const cerebrasDefaultModelId: CerebrasModelId = "gpt-oss-120b"
 
 // kilocode_change end
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -70,7 +70,7 @@ export const cerebrasModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "SOTA coding model with ~3000 tokens/s",
+		description: "SOTA coding model with ~1000 tokens/s",
 	},
 	"gpt-oss-120b": {
 		maxTokens: 40000,

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1036,7 +1036,7 @@ export const ChatRowContent = ({
 											<StandardTooltip content="The API Provider did not provide any cost data or the request was canceled.">
 												<VSCodeBadge className="whitespace-nowrap">
 													<span className="codicon codicon-warning pr-1"></span>
-													no data
+													cost unknown
 												</VSCodeBadge>
 											</StandardTooltip>
 										)

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1033,10 +1033,10 @@ export const ChatRowContent = ({
 									{
 										// kilocode_change start
 										!cost && usageMissing && (
-											<StandardTooltip content="The API Provider did not provide any cost data or the request was canceled.">
+											<StandardTooltip content={t("kilocode:pricing.costUnknownDescription")}>
 												<VSCodeBadge className="whitespace-nowrap">
 													<span className="codicon codicon-warning pr-1"></span>
-													cost unknown
+													{t("kilocode:pricing.costUnknown")}
 												</VSCodeBadge>
 											</StandardTooltip>
 										)

--- a/webview-ui/src/components/kilocode/profile/ProfileView.tsx
+++ b/webview-ui/src/components/kilocode/profile/ProfileView.tsx
@@ -58,6 +58,13 @@ const ProfileView: React.FC<ProfileViewProps> = ({ onDone }) => {
 					setBalance(null)
 				}
 				setIsLoadingBalance(false)
+			} else if (message.type === "updateProfileData") {
+				vscode.postMessage({
+					type: "fetchProfileDataRequest",
+				})
+				vscode.postMessage({
+					type: "fetchBalanceDataRequest",
+				})
 			}
 		}
 

--- a/webview-ui/src/components/settings/ModelInfoView.tsx
+++ b/webview-ui/src/components/settings/ModelInfoView.tsx
@@ -25,6 +25,14 @@ export const ModelInfoView = ({
 }: ModelInfoViewProps) => {
 	const { t } = useAppTranslation()
 
+	// kilocode_change start
+	const kiloCodeTrustsThePricing =
+		(apiProvider !== "kilocode" && apiProvider !== "openrouter") ||
+		selectedModelId.startsWith("anthropic/") ||
+		selectedModelId.startsWith("openai/") ||
+		selectedModelId.startsWith("google/")
+	// kilocode_change end
+
 	const infoItems = [
 		<ModelInfoSupportsItem
 			isSupported={modelInfo?.supportsImages ?? false}
@@ -48,29 +56,36 @@ export const ModelInfoView = ({
 				{modelInfo.maxTokens?.toLocaleString()} tokens
 			</>
 		),
-		modelInfo?.inputPrice !== undefined && modelInfo.inputPrice > 0 && (
+		kiloCodeTrustsThePricing && modelInfo?.inputPrice !== undefined && modelInfo.inputPrice > 0 && (
 			<>
 				<span className="font-medium">{t("settings:modelInfo.inputPrice")}:</span>{" "}
 				{formatPrice(modelInfo.inputPrice)} / 1M tokens
 			</>
 		),
-		modelInfo?.outputPrice !== undefined && modelInfo.outputPrice > 0 && (
+		kiloCodeTrustsThePricing && modelInfo?.outputPrice !== undefined && modelInfo.outputPrice > 0 && (
 			<>
 				<span className="font-medium">{t("settings:modelInfo.outputPrice")}:</span>{" "}
 				{formatPrice(modelInfo.outputPrice)} / 1M tokens
 			</>
 		),
-		modelInfo?.supportsPromptCache && modelInfo.cacheReadsPrice && (
+		kiloCodeTrustsThePricing && modelInfo?.supportsPromptCache && modelInfo.cacheReadsPrice && (
 			<>
 				<span className="font-medium">{t("settings:modelInfo.cacheReadsPrice")}:</span>{" "}
 				{formatPrice(modelInfo.cacheReadsPrice || 0)} / 1M tokens
 			</>
 		),
-		modelInfo?.supportsPromptCache && modelInfo.cacheWritesPrice && (
+		kiloCodeTrustsThePricing && modelInfo?.supportsPromptCache && modelInfo.cacheWritesPrice && (
 			<>
 				<span className="font-medium">{t("settings:modelInfo.cacheWritesPrice")}:</span>{" "}
 				{formatPrice(modelInfo.cacheWritesPrice || 0)} / 1M tokens
 			</>
+		),
+		!kiloCodeTrustsThePricing && selectedModelId && (
+			<span className="font-medium">
+				<a href={`https://openrouter.ai/${selectedModelId}`} className="text-vscode-link">
+					Discover model pricing and capabilities
+				</a>
+			</span>
 		),
 		apiProvider === "gemini" && (
 			<span className="italic">

--- a/webview-ui/src/components/settings/ModelInfoView.tsx
+++ b/webview-ui/src/components/settings/ModelInfoView.tsx
@@ -83,7 +83,7 @@ export const ModelInfoView = ({
 		!kiloCodeTrustsThePricing && selectedModelId && (
 			<span className="font-medium">
 				<a href={`https://openrouter.ai/${selectedModelId}`} className="text-vscode-link">
-					Discover model pricing and capabilities
+					{t("kilocode:pricing.discoverModelPricing")}
 				</a>
 			</span>
 		),

--- a/webview-ui/src/i18n/locales/ar/kilocode.json
+++ b/webview-ui/src/i18n/locales/ar/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "شحن الرصيد",
 		"lowBalance": "رصيدك في Kilo Code منخفض"
 	},
+	"pricing": {
+		"costUnknown": "التكلفة غير معروفة",
+		"costUnknownDescription": "لم يقدم مزود واجهة برمجة التطبيقات أي بيانات تكلفة أو تم إلغاء الطلب.",
+		"discoverModelPricing": "اكتشف أسعار النماذج وقدراتها"
+	},
 	"notifications": {
 		"toolRequest": "طلب أداة بانتظار الموافقة",
 		"browserAction": "طلب استخدام المتصفح بانتظار الموافقة",

--- a/webview-ui/src/i18n/locales/ca/kilocode.json
+++ b/webview-ui/src/i18n/locales/ca/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Afegir crèdit",
 		"lowBalance": "El teu saldo de Kilo Code és baix"
 	},
+	"pricing": {
+		"costUnknown": "cost desconegut",
+		"costUnknownDescription": "El proveïdor de l'API no va proporcionar cap dada de cost o la sol·licitud va ser cancel·lada.",
+		"discoverModelPricing": "Descobreix els preus i capacitats del model"
+	},
 	"notifications": {
 		"toolRequest": "Sol·licitud d'eina pendent d'aprovació",
 		"browserAction": "Acció del navegador pendent d'aprovació",

--- a/webview-ui/src/i18n/locales/cs/kilocode.json
+++ b/webview-ui/src/i18n/locales/cs/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Přidat kredit",
 		"lowBalance": "Tvůj Kilo Code zůstatek je nízký"
 	},
+	"pricing": {
+		"costUnknown": "neznámé náklady",
+		"costUnknownDescription": "Poskytovatel API neposkytl žádné údaje o nákladech nebo byl požadavek zrušen.",
+		"discoverModelPricing": "Objevte ceny a možnosti modelů"
+	},
 	"notifications": {
 		"toolRequest": "Požadavek na nástroj čeká na schválení",
 		"browserAction": "Akce prohlížeče čeká na schválení",

--- a/webview-ui/src/i18n/locales/de/kilocode.json
+++ b/webview-ui/src/i18n/locales/de/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Guthaben hinzufügen",
 		"lowBalance": "Ihr Kilo Code Guthaben ist niedrig"
 	},
+	"pricing": {
+		"costUnknown": "Kosten unbekannt",
+		"costUnknownDescription": "Der API-Anbieter hat keine Kostendaten bereitgestellt oder die Anfrage wurde abgebrochen.",
+		"discoverModelPricing": "Modellpreise und -funktionen entdecken"
+	},
 	"notifications": {
 		"toolRequest": "Werkzeuganfrage wartet auf Genehmigung",
 		"browserAction": "Browseraktion wartet auf Genehmigung",

--- a/webview-ui/src/i18n/locales/en/kilocode.json
+++ b/webview-ui/src/i18n/locales/en/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Add Credit",
 		"lowBalance": "Your Kilo Code balance is low"
 	},
+	"pricing": {
+		"costUnknown": "cost unknown",
+		"costUnknownDescription": "The API Provider did not provide any cost data or the request was canceled.",
+		"discoverModelPricing": "Discover model pricing and capabilities"
+	},
 	"notifications": {
 		"toolRequest": "Tool request waiting for approval",
 		"browserAction": "Browser action waiting for approval",

--- a/webview-ui/src/i18n/locales/es/kilocode.json
+++ b/webview-ui/src/i18n/locales/es/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Añadir Crédito",
 		"lowBalance": "Tu saldo de Kilo Code es bajo"
 	},
+	"pricing": {
+		"costUnknown": "costo desconocido",
+		"costUnknownDescription": "El proveedor de API no proporcionó datos de costo o la solicitud fue cancelada.",
+		"discoverModelPricing": "Descubrir precios y capacidades del modelo"
+	},
 	"notifications": {
 		"toolRequest": "Solicitud de herramienta pendiente de aprobación",
 		"browserAction": "Acción del navegador pendiente de aprobación",

--- a/webview-ui/src/i18n/locales/fr/kilocode.json
+++ b/webview-ui/src/i18n/locales/fr/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Ajouter du crédit",
 		"lowBalance": "Votre solde Kilo Code est bas"
 	},
+	"pricing": {
+		"costUnknown": "coût inconnu",
+		"costUnknownDescription": "Le fournisseur d'API n'a pas fourni de données de coût ou la demande a été annulée.",
+		"discoverModelPricing": "Découvrir les tarifs et capacités du modèle"
+	},
 	"notifications": {
 		"toolRequest": "Demande d'outil en attente d'approbation",
 		"browserAction": "Action du navigateur en attente d'approbation",

--- a/webview-ui/src/i18n/locales/hi/kilocode.json
+++ b/webview-ui/src/i18n/locales/hi/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "क्रेडिट जोड़ें",
 		"lowBalance": "आपका Kilo Code बैलेंस कम है"
 	},
+	"pricing": {
+		"costUnknown": "लागत अज्ञात",
+		"costUnknownDescription": "API प्रदाता ने कोई लागत डेटा प्रदान नहीं किया या अनुरोध रद्द कर दिया गया।",
+		"discoverModelPricing": "मॉडल मूल्य निर्धारण और क्षमताओं की खोज करें"
+	},
 	"notifications": {
 		"toolRequest": "उपकरण अनुरोध अनुमोदन की प्रतीक्षा कर रहा है",
 		"browserAction": "ब्राउज़र कार्रवाई अनुमोदन की प्रतीक्षा कर रही है",

--- a/webview-ui/src/i18n/locales/id/kilocode.json
+++ b/webview-ui/src/i18n/locales/id/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Tambah Kredit",
 		"lowBalance": "Saldo Kilo Code kamu rendah"
 	},
+	"pricing": {
+		"costUnknown": "biaya tidak diketahui",
+		"costUnknownDescription": "Penyedia API tidak memberikan data biaya atau permintaan dibatalkan.",
+		"discoverModelPricing": "Temukan harga dan kemampuan model"
+	},
 	"notifications": {
 		"toolRequest": "Permintaan tool menunggu persetujuan",
 		"browserAction": "Aksi browser menunggu persetujuan",

--- a/webview-ui/src/i18n/locales/it/kilocode.json
+++ b/webview-ui/src/i18n/locales/it/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Aggiungi credito",
 		"lowBalance": "Il tuo saldo Kilo Code è basso"
 	},
+	"pricing": {
+		"costUnknown": "costo sconosciuto",
+		"costUnknownDescription": "Il Provider API non ha fornito dati sui costi o la richiesta è stata annullata.",
+		"discoverModelPricing": "Scopri prezzi e capacità del modello"
+	},
 	"notifications": {
 		"toolRequest": "Richiesta strumento in attesa di approvazione",
 		"browserAction": "Azione del browser in attesa di approvazione",

--- a/webview-ui/src/i18n/locales/ja/kilocode.json
+++ b/webview-ui/src/i18n/locales/ja/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "クレジットを追加",
 		"lowBalance": "Kilo Codeの残高が少なくなっています"
 	},
+	"pricing": {
+		"costUnknown": "コスト不明",
+		"costUnknownDescription": "APIプロバイダーがコストデータを提供しなかったか、リクエストがキャンセルされました。",
+		"discoverModelPricing": "モデルの価格と機能を確認"
+	},
 	"notifications": {
 		"toolRequest": "ツールのリクエストが承認待ちです",
 		"browserAction": "ブラウザのアクションが承認待ちです",

--- a/webview-ui/src/i18n/locales/ko/kilocode.json
+++ b/webview-ui/src/i18n/locales/ko/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "크레딧 추가",
 		"lowBalance": "Kilo Code 잔액이 부족합니다"
 	},
+	"pricing": {
+		"costUnknown": "비용 알 수 없음",
+		"costUnknownDescription": "API 제공자가 비용 데이터를 제공하지 않았거나 요청이 취소되었습니다.",
+		"discoverModelPricing": "모델 가격 및 기능 알아보기"
+	},
 	"notifications": {
 		"toolRequest": "도구 요청 승인 대기 중",
 		"browserAction": "브라우저 작업 승인 대기 중",

--- a/webview-ui/src/i18n/locales/nl/kilocode.json
+++ b/webview-ui/src/i18n/locales/nl/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Krediet toevoegen",
 		"lowBalance": "Uw Kilo Code-saldo is laag"
 	},
+	"pricing": {
+		"costUnknown": "kosten onbekend",
+		"costUnknownDescription": "De API-provider heeft geen kostengegevens verstrekt of het verzoek is geannuleerd.",
+		"discoverModelPricing": "Ontdek modelprijzen en mogelijkheden"
+	},
 	"notifications": {
 		"toolRequest": "Toolverzoek wacht op goedkeuring",
 		"browserAction": "Browseractie wacht op goedkeuring",

--- a/webview-ui/src/i18n/locales/pl/kilocode.json
+++ b/webview-ui/src/i18n/locales/pl/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Dodaj kredyt",
 		"lowBalance": "Twój stan konta Kilo Code jest niski"
 	},
+	"pricing": {
+		"costUnknown": "koszt nieznany",
+		"costUnknownDescription": "Dostawca API nie podał żadnych danych o kosztach lub żądanie zostało anulowane.",
+		"discoverModelPricing": "Odkryj ceny i możliwości modeli"
+	},
 	"notifications": {
 		"toolRequest": "Żądanie narzędzia oczekuje na zatwierdzenie",
 		"browserAction": "Akcja przeglądarki oczekuje na zatwierdzenie",

--- a/webview-ui/src/i18n/locales/pt-BR/kilocode.json
+++ b/webview-ui/src/i18n/locales/pt-BR/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Adicionar crédito",
 		"lowBalance": "Seu saldo do Kilo Code está baixo"
 	},
+	"pricing": {
+		"costUnknown": "custo desconhecido",
+		"costUnknownDescription": "O Provedor de API não forneceu dados de custo ou a solicitação foi cancelada.",
+		"discoverModelPricing": "Descobrir preços e capacidades do modelo"
+	},
 	"notifications": {
 		"toolRequest": "Solicitação de ferramenta aguardando aprovação",
 		"browserAction": "Ação do navegador aguardando aprovação",

--- a/webview-ui/src/i18n/locales/ru/kilocode.json
+++ b/webview-ui/src/i18n/locales/ru/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Добавить кредит",
 		"lowBalance": "Ваш баланс Kilo Code низкий"
 	},
+	"pricing": {
+		"costUnknown": "стоимость неизвестна",
+		"costUnknownDescription": "API-провайдер не предоставил данные о стоимости или запрос был отменен.",
+		"discoverModelPricing": "Узнать цены и возможности модели"
+	},
 	"notifications": {
 		"toolRequest": "Запрос инструмента ожидает утверждения",
 		"browserAction": "Действие браузера ожидает утверждения",

--- a/webview-ui/src/i18n/locales/th/kilocode.json
+++ b/webview-ui/src/i18n/locales/th/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "เติมเครดิต",
 		"lowBalance": "ยอดเงิน Kilo Code ของคุณเหลือน้อย"
 	},
+	"pricing": {
+		"costUnknown": "ค่าใช้จ่ายไม่ทราบ",
+		"costUnknownDescription": "ผู้ให้บริการ API ไม่ได้ให้ข้อมูลค่าใช้จ่าย หรือคำขอถูกยกเลิก",
+		"discoverModelPricing": "ค้นหาราคาและความสามารถของโมเดล"
+	},
 	"notifications": {
 		"toolRequest": "คำขอใช้เครื่องมือรอการอนุมัติ",
 		"browserAction": "การดำเนินการของเบราว์เซอร์รอการอนุมัติ",

--- a/webview-ui/src/i18n/locales/tr/kilocode.json
+++ b/webview-ui/src/i18n/locales/tr/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Kredi Ekle",
 		"lowBalance": "Kilo Code bakiyeniz düşük"
 	},
+	"pricing": {
+		"costUnknown": "maliyet bilinmiyor",
+		"costUnknownDescription": "API Sağlayıcısı herhangi bir maliyet verisi sağlamadı veya istek iptal edildi.",
+		"discoverModelPricing": "Model fiyatlandırması ve yeteneklerini keşfedin"
+	},
 	"notifications": {
 		"toolRequest": "Araç isteği onay bekliyor",
 		"browserAction": "Tarayıcı eylemi onay bekliyor",

--- a/webview-ui/src/i18n/locales/uk/kilocode.json
+++ b/webview-ui/src/i18n/locales/uk/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Додати кредит",
 		"lowBalance": "Твій баланс Kilo Code низький"
 	},
+	"pricing": {
+		"costUnknown": "вартість невідома",
+		"costUnknownDescription": "API провайдер не надав дані про вартість або запит було скасовано.",
+		"discoverModelPricing": "Дізнатися про ціни та можливості моделі"
+	},
 	"notifications": {
 		"toolRequest": "Запит інструменту очікує на схвалення",
 		"browserAction": "Дія браузера очікує на схвалення",

--- a/webview-ui/src/i18n/locales/vi/kilocode.json
+++ b/webview-ui/src/i18n/locales/vi/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "Thêm tín dụng",
 		"lowBalance": "Số dư Kilo Code của bạn thấp"
 	},
+	"pricing": {
+		"costUnknown": "chi phí không xác định",
+		"costUnknownDescription": "Nhà cung cấp API không cung cấp dữ liệu chi phí hoặc yêu cầu đã bị hủy.",
+		"discoverModelPricing": "Khám phá giá cả và khả năng của mô hình"
+	},
 	"notifications": {
 		"toolRequest": "Yêu cầu công cụ đang chờ phê duyệt",
 		"browserAction": "Hành động trình duyệt đang chờ phê duyệt",

--- a/webview-ui/src/i18n/locales/zh-CN/kilocode.json
+++ b/webview-ui/src/i18n/locales/zh-CN/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "添加额度",
 		"lowBalance": "你的 Kilo Code 余额不足"
 	},
+	"pricing": {
+		"costUnknown": "费用未知",
+		"costUnknownDescription": "API 提供商未提供任何费用数据或请求已取消。",
+		"discoverModelPricing": "了解模型定价和功能"
+	},
 	"notifications": {
 		"toolRequest": "工具请求等待批准",
 		"browserAction": "浏览器操作等待批准",

--- a/webview-ui/src/i18n/locales/zh-TW/kilocode.json
+++ b/webview-ui/src/i18n/locales/zh-TW/kilocode.json
@@ -13,6 +13,11 @@
 		"addCredit": "添加額度",
 		"lowBalance": "你的 Kilo Code 餘額不足"
 	},
+	"pricing": {
+		"costUnknown": "費用未知",
+		"costUnknownDescription": "API 提供商未提供任何費用資料或請求已取消。",
+		"discoverModelPricing": "了解模型定價和功能"
+	},
 	"notifications": {
 		"toolRequest": "工具請求等待核准",
 		"browserAction": "瀏覽器動作等待核准",


### PR DESCRIPTION
Context
Adds updates to Cerebras AI Inference as a model provider, enabling access to Cerebras's high-performance language models.

Current Models:
- zai-glm-4.6 (128K context)
- qwen-3-32b (32K context)
- llama-3.3-70b (8K context)
- llama-3.1-8b and 70b variants

How to Test
- Configure Cerebras API credentials in settings
- Select Cerebras as provider and choose a model
- Send a chat message and verify streaming responses work correctly