### PR TITLE
docs: add /teams commands to CLI reference table

### DIFF
--- a/apps/kilocode-docs/docs/cli.md
+++ b/apps/kilocode-docs/docs/cli.md
@@ -42,6 +42,8 @@ to start the CLI and begin a new task with your preferred model and relevant mod
 | `/model list`   | List available models                                            |                             |
 | `/model info`   | Prints description for a specific model by name                  | `/model info z-ai/glm-4.5v` |
 | `/model select` | Select and switch to a new model                                 |                             |
+| `/teams`        | List all organizations you can switch into                       |                             |
+| `/teams select` | Switch to a different organization                               |                             |
 | `/config`       | Open configuration editor (same as `kilocode config`)            |                             |
 | `/new`          | Start a new task with the agent with a clean slate               |                             |
 | `/help`         | List available commands and how to use them                      |                             |
@@ -255,3 +257,7 @@ Use the `/teams` command to see a list of all organizations you can switch into.
 Use `/teams select` and start typing the team name to switch teams.
 
 The process is the same when switching into a Team or Enterprise organization.
+The process is the same when switching into a Team or Enterprise organization.
+
+
+


### PR DESCRIPTION
## Summary
Add /teams and /teams select commands to the CLI commands reference table at the top of the CLI documentation page.

## Changes
- Added `/teams` command to list all organizations you can switch into
- Added `/teams select` command to switch to a different organization

## Context
These commands were already documented in the 'Switching into an Organization from the CLI' section at the bottom of the page but were missing from the quick reference table at the top. This PR ensures consistency and makes these commands easier to discover for users.