### PR TITLE
Replace input on autocomplete

### DIFF
--- a/.changeset/olive-ads-cover.md
+++ b/.changeset/olive-ads-cover.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+improves autocomplete behavior

--- a/cli/src/state/atoms/__tests__/keyboard.test.ts
+++ b/cli/src/state/atoms/__tests__/keyboard.test.ts
@@ -359,7 +359,7 @@ describe("keypress atoms", () => {
 			expect(text).toBe("/mode")
 		})
 
-		it("should complete argument by appending only missing part", () => {
+		it("should complete argument by replacing partial text", () => {
 			// Type '/mode tes' - this will automatically trigger autocomplete
 			const input = "/mode tes"
 			for (const char of input) {
@@ -398,9 +398,94 @@ describe("keypress atoms", () => {
 			}
 			store.set(keyboardHandlerAtom, tabKey)
 
-			// Should append only 't' to complete '/mode test'
+			// Should replace 'tes' with 'test' to complete '/mode test'
 			const text = store.get(textBufferStringAtom)
 			expect(text).toBe("/mode test")
+		})
+
+		it("should replace partial argument with full suggestion", () => {
+			// Bug fix: Type '/model info gpt' with suggestion 'openai/gpt-5'
+			// This test verifies the fix where Tab was incorrectly appending instead of replacing
+			const input = "/model info gpt"
+			for (const char of input) {
+				const key: Key = {
+					name: char,
+					sequence: char,
+					ctrl: false,
+					meta: false,
+					shift: false,
+					paste: false,
+				}
+				store.set(keyboardHandlerAtom, key)
+			}
+
+			// Set up argument suggestions
+			const mockArgumentSuggestion: ArgumentSuggestion = {
+				value: "openai/gpt-5",
+				description: "OpenAI GPT-5 model",
+				matchScore: 90,
+				highlightedValue: "openai/gpt-5",
+			}
+			store.set(argumentSuggestionsAtom, [mockArgumentSuggestion])
+			store.set(suggestionsAtom, []) // No command suggestions
+			store.set(selectedIndexAtom, 0)
+
+			// Press Tab
+			const tabKey: Key = {
+				name: "tab",
+				sequence: "\t",
+				ctrl: false,
+				meta: false,
+				shift: false,
+				paste: false,
+			}
+			store.set(keyboardHandlerAtom, tabKey)
+
+			// Should replace 'gpt' with 'openai/gpt-5' (not append to get 'gptopenai/gpt-5')
+			const text = store.get(textBufferStringAtom)
+			expect(text).toBe("/model info openai/gpt-5")
+		})
+
+		it("should complete argument from empty with trailing space", () => {
+			// Type '/model info ' (with trailing space)
+			const input = "/model info "
+			for (const char of input) {
+				const key: Key = {
+					name: char,
+					sequence: char,
+					ctrl: false,
+					meta: false,
+					shift: false,
+					paste: false,
+				}
+				store.set(keyboardHandlerAtom, key)
+			}
+
+			// Set up argument suggestions
+			const mockArgumentSuggestion: ArgumentSuggestion = {
+				value: "openai/gpt-4",
+				description: "OpenAI GPT-4 model",
+				matchScore: 100,
+				highlightedValue: "openai/gpt-4",
+			}
+			store.set(argumentSuggestionsAtom, [mockArgumentSuggestion])
+			store.set(suggestionsAtom, [])
+			store.set(selectedIndexAtom, 0)
+
+			// Press Tab
+			const tabKey: Key = {
+				name: "tab",
+				sequence: "\t",
+				ctrl: false,
+				meta: false,
+				shift: false,
+				paste: false,
+			}
+			store.set(keyboardHandlerAtom, tabKey)
+
+			// Should add the full suggestion value
+			const text = store.get(textBufferStringAtom)
+			expect(text).toBe("/model info openai/gpt-4")
 		})
 
 		it("should handle exact match completion", () => {

--- a/cli/src/state/atoms/keyboard.ts
+++ b/cli/src/state/atoms/keyboard.ts
@@ -308,38 +308,6 @@ export const submitInputAtom = atom(null, (get, set, text: string | Buffer) => {
 // ============================================================================
 
 /**
- * Helper function to get the completion text (only the missing part to append)
- */
-function getCompletionText(currentInput: string, suggestion: CommandSuggestion | ArgumentSuggestion): string {
-	if ("command" in suggestion) {
-		// CommandSuggestion - complete the command name
-		const commandName = suggestion.command.name
-		const currentText = currentInput.startsWith("/") ? currentInput.slice(1) : currentInput
-
-		// If the command name starts with what user typed, return only the missing part
-		if (commandName.toLowerCase().startsWith(currentText.toLowerCase())) {
-			return commandName.slice(currentText.length)
-		}
-
-		// Otherwise return the full command (shouldn't happen in normal flow)
-		return commandName
-	} else {
-		// ArgumentSuggestion - complete the last argument
-		const parts = currentInput.split(" ")
-		const lastPart = parts[parts.length - 1] || ""
-		const suggestionValue = suggestion.value
-
-		// If suggestion starts with what user typed, return only the missing part
-		if (suggestionValue.toLowerCase().startsWith(lastPart.toLowerCase())) {
-			return suggestionValue.slice(lastPart.length)
-		}
-
-		// Otherwise return the full value
-		return suggestionValue
-	}
-}
-
-/**
  * Helper function to format autocomplete suggestions for display/submission
  */
 function formatSuggestion(suggestion: CommandSuggestion | ArgumentSuggestion, currentInput: string): string {
@@ -487,17 +455,10 @@ function handleAutocompleteKeys(get: any, set: any, key: Key): void {
 				const suggestion = allSuggestions[selectedIndex]
 				const currentText = get(textBufferStringAtom)
 
-				// For argument suggestions, replace the entire input with formatted suggestion
-				// For command suggestions, append the completion text
-				if ("command" in suggestion) {
-					// CommandSuggestion - append only the missing part
-					const completionText = getCompletionText(currentText, suggestion)
-					set(insertTextAtom, completionText)
-				} else {
-					// ArgumentSuggestion - replace entire input to avoid duplication
-					const newText = formatSuggestion(suggestion, currentText)
-					set(setTextAtom, newText)
-				}
+				// Always replace the entire input with formatted suggestion
+				// This handles both commands and arguments correctly
+				const newText = formatSuggestion(suggestion, currentText)
+				set(setTextAtom, newText)
 			}
 			return
 

--- a/cli/src/state/atoms/keyboard.ts
+++ b/cli/src/state/atoms/keyboard.ts
@@ -487,11 +487,17 @@ function handleAutocompleteKeys(get: any, set: any, key: Key): void {
 				const suggestion = allSuggestions[selectedIndex]
 				const currentText = get(textBufferStringAtom)
 
-				// Get only the missing part to append
-				const completionText = getCompletionText(currentText, suggestion)
-
-				// Insert the completion text
-				set(insertTextAtom, completionText)
+				// For argument suggestions, replace the entire input with formatted suggestion
+				// For command suggestions, append the completion text
+				if ("command" in suggestion) {
+					// CommandSuggestion - append only the missing part
+					const completionText = getCompletionText(currentText, suggestion)
+					set(insertTextAtom, completionText)
+				} else {
+					// ArgumentSuggestion - replace entire input to avoid duplication
+					const newText = formatSuggestion(suggestion, currentText)
+					set(setTextAtom, newText)
+				}
 			}
 			return
 


### PR DESCRIPTION
## Context

Fix autocomplete appending the suggestion instead of replacing the current "word".

## Implementation

Utilizes the existing `formatSuggestion` fn.

## Screenshots

N/A

## How to Test

- enter `/modl`, hit tab
- enter `/model info gpt`, hit tab

## Get in Touch

N/A

Closes https://github.com/Kilo-Org/kilocode/issues/3113
