### PR TITLE
Slight simplifications

### DIFF
--- a/cli/src/services/telemetry/identity.ts
+++ b/cli/src/services/telemetry/identity.ts
@@ -9,7 +9,7 @@ import * as crypto from "crypto"
 import * as os from "os"
 import { KiloCodePaths } from "../../utils/paths.js"
 import { logs } from "../logs.js"
-import { getApiUrl } from "@roo-code/types"
+import { getAppUrl } from "@roo-code/types"
 
 /**
  * User identity structure
@@ -108,7 +108,7 @@ export class IdentityManager {
 
 		try {
 			// Fetch user profile from Kilocode API
-			const response = await fetch(getApiUrl("/profile"), {
+			const response = await fetch(getAppUrl("/api/profile"), {
 				headers: {
 					Authorization: `Bearer ${kilocodeToken}`,
 					"Content-Type": "application/json",

--- a/packages/telemetry/src/PostHogTelemetryClient.ts
+++ b/packages/telemetry/src/PostHogTelemetryClient.ts
@@ -1,7 +1,7 @@
 import { PostHog } from "posthog-node"
 import * as vscode from "vscode"
 
-import { TelemetryEventName, type TelemetryEvent } from "@roo-code/types"
+import { getKiloUrlFromToken, TelemetryEventName, type TelemetryEvent } from "@roo-code/types"
 
 import { BaseTelemetryClient } from "./BaseTelemetryClient"
 
@@ -129,7 +129,7 @@ export class PostHogTelemetryClient extends BaseTelemetryClient {
 		}
 		const id = ++this.counter
 		try {
-			const response = await fetch("https://api.kilocode.ai/api/profile", {
+			const response = await fetch(getKiloUrlFromToken("https://api.kilocode.ai/api/profile", kilocodeToken), {
 				headers: {
 					Authorization: `Bearer ${kilocodeToken}`,
 					"Content-Type": "application/json",

--- a/packages/types/src/__tests__/kilocode.test.ts
+++ b/packages/types/src/__tests__/kilocode.test.ts
@@ -4,7 +4,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import {
 	ghostServiceSettingsSchema,
 	checkKilocodeBalance,
-	getApiUrl,
 	getAppUrl,
 	getKiloUrlFromToken,
 	getExtensionConfigUrl,
@@ -184,36 +183,6 @@ describe("URL functions", () => {
 		})
 	})
 
-	describe("getApiUrl", () => {
-		it("should handle production URLs correctly", () => {
-			// API URLs using /api path structure
-			expect(getApiUrl("/extension-config.json")).toBe("https://kilocode.ai/api/extension-config.json")
-			expect(getApiUrl("/marketplace/modes")).toBe("https://kilocode.ai/api/marketplace/modes")
-			expect(getApiUrl("/marketplace/mcps")).toBe("https://kilocode.ai/api/marketplace/mcps")
-			expect(getApiUrl("/profile/balance")).toBe("https://kilocode.ai/api/profile/balance")
-			expect(getApiUrl()).toBe("https://kilocode.ai/api")
-		})
-
-		it("should handle development environment", () => {
-			process.env.KILOCODE_BACKEND_BASE_URL = "http://localhost:3000"
-
-			expect(getApiUrl("/extension-config.json")).toBe("http://localhost:3000/api/extension-config.json")
-			expect(getApiUrl("/marketplace/modes")).toBe("http://localhost:3000/api/marketplace/modes")
-			expect(getApiUrl("/marketplace/mcps")).toBe("http://localhost:3000/api/marketplace/mcps")
-			expect(getApiUrl()).toBe("http://localhost:3000/api")
-		})
-
-		it("should handle paths without leading slash", () => {
-			process.env.KILOCODE_BACKEND_BASE_URL = "http://localhost:3000"
-			expect(getApiUrl("extension-config.json")).toBe("http://localhost:3000/api/extension-config.json")
-		})
-
-		it("should handle empty and root paths", () => {
-			expect(getApiUrl("")).toBe("https://kilocode.ai/api")
-			expect(getApiUrl("/")).toBe("https://kilocode.ai/api/")
-		})
-	})
-
 	describe("getAppUrl", () => {
 		it("should handle production URLs correctly", () => {
 			expect(getAppUrl()).toBe("https://kilocode.ai")
@@ -300,8 +269,8 @@ describe("URL functions", () => {
 	describe("Real-world URL patterns from application", () => {
 		it("should correctly handle marketplace endpoints", () => {
 			// These are the actual endpoints used in RemoteConfigLoader
-			expect(getApiUrl("/marketplace/modes")).toBe("https://kilocode.ai/api/marketplace/modes")
-			expect(getApiUrl("/marketplace/mcps")).toBe("https://kilocode.ai/api/marketplace/mcps")
+			expect(getAppUrl("/api/marketplace/modes")).toBe("https://kilocode.ai/api/marketplace/modes")
+			expect(getAppUrl("/api/marketplace/mcps")).toBe("https://kilocode.ai/api/marketplace/mcps")
 		})
 
 		it("should correctly handle app navigation URLs", () => {
@@ -326,25 +295,25 @@ describe("URL functions", () => {
 
 		it("should maintain backwards compatibility for legacy endpoints", () => {
 			expect(getExtensionConfigUrl()).toBe("https://api.kilocode.ai/extension-config.json")
-			expect(getApiUrl("/extension-config.json")).toBe("https://kilocode.ai/api/extension-config.json")
-			expect(getApiUrl("/extension-config.json")).not.toBe(getExtensionConfigUrl())
+			expect(getAppUrl("/api/extension-config.json")).toBe("https://kilocode.ai/api/extension-config.json")
+			expect(getAppUrl("/api/extension-config.json")).not.toBe(getExtensionConfigUrl())
 		})
 	})
 
 	describe("Edge cases and error handling", () => {
 		it("should handle various localhost configurations", () => {
 			process.env.KILOCODE_BACKEND_BASE_URL = "http://localhost:8080"
-			expect(getApiUrl("/test")).toBe("http://localhost:8080/api/test")
+			expect(getAppUrl("/api/test")).toBe("http://localhost:8080/api/test")
 
 			process.env.KILOCODE_BACKEND_BASE_URL = "http://127.0.0.1:3000"
-			expect(getApiUrl("/test")).toBe("http://127.0.0.1:3000/api/test")
+			expect(getAppUrl("/api/test")).toBe("http://127.0.0.1:3000/api/test")
 		})
 
 		it("should handle custom backend URLs", () => {
 			process.env.KILOCODE_BACKEND_BASE_URL = "https://staging.example.com"
 
 			expect(getAppUrl()).toBe("https://staging.example.com")
-			expect(getApiUrl("/test")).toBe("https://staging.example.com/api/test")
+			expect(getAppUrl("/api/test")).toBe("https://staging.example.com/api/test")
 			expect(getAppUrl("/dashboard")).toBe("https://staging.example.com/dashboard")
 		})
 	})

--- a/packages/types/src/kilocode/kilocode.ts
+++ b/packages/types/src/kilocode/kilocode.ts
@@ -50,9 +50,7 @@ export function getKiloBaseUriFromToken(kilocodeToken?: string) {
 		try {
 			const payload_string = kilocodeToken.split(".")[1]
 			if (!payload_string) return "https://api.kilocode.ai"
-
-			const payload_json =
-				typeof atob !== "undefined" ? atob(payload_string) : Buffer.from(payload_string, "base64").toString()
+			const payload_json = Buffer.from(payload_string, "base64").toString()
 			const payload = JSON.parse(payload_json)
 			//note: this is UNTRUSTED, so we need to make sure we're OK with this being manipulated by an attacker; e.g. we should not read uri's from the JWT directly.
 			if (payload.env === "development") return "http://localhost:3000"

--- a/packages/types/src/kilocode/kilocode.ts
+++ b/packages/types/src/kilocode/kilocode.ts
@@ -105,7 +105,7 @@ function buildUrl(path: string = ""): string {
  * In production: https://kilocode.ai
  */
 export function getAppUrl(path: string = ""): string {
-	return buildUrl(path)
+	return new URL(path, getGlobalKilocodeBackendUrl()).toString()
 }
 
 /**

--- a/packages/types/src/kilocode/kilocode.ts
+++ b/packages/types/src/kilocode/kilocode.ts
@@ -93,13 +93,6 @@ function ensureLeadingSlash(path: string): string {
 }
 
 /**
- * Internal helper to build URLs for the current environment.
- */
-function buildUrl(path: string = ""): string {
-	return new URL(path, getGlobalKilocodeBackendUrl()).toString()
-}
-
-/**
  * Gets the app/web URL for the current environment.
  * In development: http://localhost:3000
  * In production: https://kilocode.ai
@@ -114,7 +107,7 @@ export function getAppUrl(path: string = ""): string {
  * In production: https://kilocode.ai/api
  */
 export function getApiUrl(path: string = ""): string {
-	return buildUrl(`/api${path ? ensureLeadingSlash(path) : ""}`)
+	return getAppUrl(`/api${path ? ensureLeadingSlash(path) : ""}`)
 }
 
 /**

--- a/packages/types/src/kilocode/kilocode.ts
+++ b/packages/types/src/kilocode/kilocode.ts
@@ -88,10 +88,6 @@ function getGlobalKilocodeBackendUrl(): string {
 	)
 }
 
-function removeTrailingSlash(url: string, pathname: string): string {
-	return url.endsWith("/") && (pathname === "/" || pathname === "") ? url.slice(0, -1) : url
-}
-
 function ensureLeadingSlash(path: string): string {
 	return path.startsWith("/") ? path : `/${path}`
 }
@@ -100,22 +96,7 @@ function ensureLeadingSlash(path: string): string {
  * Internal helper to build URLs for the current environment.
  */
 function buildUrl(path: string = ""): string {
-	try {
-		const backend = new URL(getGlobalKilocodeBackendUrl())
-		const result = new URL(backend)
-
-		// Separate pathname and search parameters
-		const [pathname, search] = path.split("?")
-		result.pathname = pathname ? ensureLeadingSlash(pathname) : ""
-		if (search) {
-			result.search = `?${search}`
-		}
-
-		return removeTrailingSlash(result.toString(), result.pathname)
-	} catch (error) {
-		console.warn("Failed to build URL:", path, error)
-		return `https://kilocode.ai${path ? ensureLeadingSlash(path) : ""}`
-	}
+	return new URL(path, getGlobalKilocodeBackendUrl()).toString()
 }
 
 /**

--- a/packages/types/src/kilocode/kilocode.ts
+++ b/packages/types/src/kilocode/kilocode.ts
@@ -88,10 +88,6 @@ function getGlobalKilocodeBackendUrl(): string {
 	)
 }
 
-function ensureLeadingSlash(path: string): string {
-	return path.startsWith("/") ? path : `/${path}`
-}
-
 /**
  * Gets the app/web URL for the current environment.
  * In development: http://localhost:3000
@@ -99,15 +95,6 @@ function ensureLeadingSlash(path: string): string {
  */
 export function getAppUrl(path: string = ""): string {
 	return new URL(path, getGlobalKilocodeBackendUrl()).toString()
-}
-
-/**
- * Gets the API base URL for the current environment.
- * In development: http://localhost:3000/api
- * In production: https://kilocode.ai/api
- */
-export function getApiUrl(path: string = ""): string {
-	return getAppUrl(`/api${path ? ensureLeadingSlash(path) : ""}`)
 }
 
 /**

--- a/packages/types/src/kilocode/kilocode.ts
+++ b/packages/types/src/kilocode/kilocode.ts
@@ -50,7 +50,9 @@ export function getKiloBaseUriFromToken(kilocodeToken?: string) {
 		try {
 			const payload_string = kilocodeToken.split(".")[1]
 			if (!payload_string) return "https://api.kilocode.ai"
-			const payload_json = Buffer.from(payload_string, "base64").toString()
+
+			const payload_json =
+				typeof atob !== "undefined" ? atob(payload_string) : Buffer.from(payload_string, "base64").toString()
 			const payload = JSON.parse(payload_json)
 			//note: this is UNTRUSTED, so we need to make sure we're OK with this being manipulated by an attacker; e.g. we should not read uri's from the JWT directly.
 			if (payload.env === "development") return "http://localhost:3000"

--- a/src/api/providers/constants.ts
+++ b/src/api/providers/constants.ts
@@ -1,9 +1,8 @@
 import { X_KILOCODE_VERSION } from "../../shared/kilocode/headers"
 import { Package } from "../../shared/package"
-import { getAppUrl } from "@roo-code/types"
 
 export const DEFAULT_HEADERS = {
-	"HTTP-Referer": getAppUrl(),
+	"HTTP-Referer": "https://kilocode.ai",
 	"X-Title": "Kilo Code",
 	[X_KILOCODE_VERSION]: Package.version,
 	"User-Agent": `Kilo-Code/${Package.version}`,

--- a/src/services/marketplace/RemoteConfigLoader.ts
+++ b/src/services/marketplace/RemoteConfigLoader.ts
@@ -1,7 +1,7 @@
 import axios from "axios"
 import * as yaml from "yaml"
 import { z } from "zod"
-import { getApiUrl } from "@roo-code/types" // kilocode_change
+import { getAppUrl } from "@roo-code/types" // kilocode_change
 import {
 	type MarketplaceItem,
 	type MarketplaceItemType,
@@ -48,7 +48,7 @@ export class RemoteConfigLoader {
 			return cached
 		}
 
-		const url = getApiUrl("/marketplace/modes") // kilocode_change
+		const url = getAppUrl("/api/marketplace/modes") // kilocode_change
 		const data = await this.fetchWithRetry<string>(url)
 
 		const yamlData = yaml.parse(data)
@@ -71,7 +71,7 @@ export class RemoteConfigLoader {
 			return cached
 		}
 
-		const url = getApiUrl("/marketplace/mcps") // kilocode_change
+		const url = getAppUrl("/api/marketplace/mcps") // kilocode_change
 		const data = await this.fetchWithRetry<string>(url)
 
 		const yamlData = yaml.parse(data)


### PR DESCRIPTION
Review by commit

Mostly stuff from https://github.com/Kilo-Org/kilocode/pull/3116; specifically we don't need both getAppUrl and getApiUrl since the latter merely prepents /api to the path.

Also simplify url construction.

I suspect we could somehow integrate getKiloUrlFromToken better into all this - feels a little clunky to sometimes have the token, and sometimes not, and to first make a full url and then only replace the host+port+protocol if and only if the token is for dev. A plain object would be nice here, but this is a step, anyhow.

Refactor: I tried not to change the url's (except getting rid of the special case to write `https://kilocode.ai` without a trailing slash), even though most of these app url's probably should now point to app.kilocode.ai and not kilocode.ai.  This works (inefficiently) because we have redirects in place.  But that's for another time, and also probably easier to fix if we have an actual object making these urls, rather than a bunch of strings.