### PR TITLE
log version on boot

### DIFF
--- a/.changeset/loose-jars-obey.md
+++ b/.changeset/loose-jars-obey.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+logs version on boot

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -16,6 +16,7 @@ import { notificationsAtom, notificationsErrorAtom, notificationsLoadingAtom } f
 import { fetchKilocodeNotifications } from "./utils/notifications.js"
 import { finishParallelMode } from "./parallel/parallel.js"
 import { isGitWorktree } from "./utils/git.js"
+import { Package } from "./constants/package.js"
 
 export interface CLIOptions {
 	mode?: string
@@ -56,6 +57,7 @@ export class CLI {
 
 		try {
 			logs.info("Initializing Kilo Code CLI...", "CLI")
+			logs.info(`Version: ${Package.version}`, "CLI")
 
 			// Set terminal title - use process.cwd() in parallel mode to show original directory
 			const titleWorkspace = this.options.parallel ? process.cwd() : this.options.workspace || process.cwd()


### PR DESCRIPTION
## Context

Logs CLI version on boot - useful when looking at logs.

## Implementation

N/A

## Screenshots

N/A

## How to Test

After starting the cli, look at logs - there should be a version there.

## Get in Touch

N/A
