### PR TITLE
Disable/fix storybook snapshot workflow condition

### DIFF
--- a/.github/workflows/storybook-playwright-snapshot.yml
+++ b/.github/workflows/storybook-playwright-snapshot.yml
@@ -31,13 +31,7 @@ jobs:
     storybook-playwright-snapshot:
         runs-on: ubuntu-latest
         timeout-minutes: 45
-        if: |
-            ${{
-              inputs.should_run == true ||
-              contains(github.event.head_commit.message, '[storybook]') ||
-              contains(github.event.head_commit.message, '[chromatic]') ||
-              contains(github.event.head_commit.message, '[screnshot')
-            }}
+        if: ${{ inputs.should_run == true }}
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
This commit-based trigger code was making Chromatic run on every commit for some reason, so just remove it and use should_run for manual triggering until we resolve the screenshot flakes.
