### PR TITLE
Fix page shift screenshot flake

### DIFF
--- a/apps/playwright-e2e/tests/chat.test.ts
+++ b/apps/playwright-e2e/tests/chat.test.ts
@@ -16,12 +16,12 @@ test.describe("E2E Chat Test", () => {
 		await configureApiKeyThroughUI(page)
 		await waitForWebviewText(page, "Generate, refactor, and debug code with AI assistance")
 
-		await (await getChatInput(page)).focus()
-		await page.waitForTimeout(3000) // Let the page settle to avoid flakes
+		await page.waitForTimeout(5000) // Let the page settle to avoid flakes
 		await takeScreenshot("ready-to-chat")
 
 		// Don't take any more screenshots after the reponse starts-
 		// llm responses aren't deterministic any capturing the reponse would cause screenshot flakes
+		await (await getChatInput(page)).focus()
 		await sendMessage(page, "Fill in the blanks for this phrase: 'hello w_r_d'")
 		await waitForWebviewText(page, "hello world", 30_000)
 	})


### PR DESCRIPTION
The flake seems to be caused by focusing the chat text area. By taking the screenshot before focusing the chat text, I didn't seem to get any flaky screenshot tests after running the test 20+ times. 

https://kilo-code.slack.com/archives/C08HC5A2EDT/p1762190944121769