### PR TITLE
feat: add release notes modal with build-time generation

### DIFF
--- a/.changeset/nine-moments-rule.md
+++ b/.changeset/nine-moments-rule.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Add a button to view the latest release notes to the extension

--- a/apps/storybook/stories/MarkdownBlock.stories.tsx
+++ b/apps/storybook/stories/MarkdownBlock.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import MarkdownBlock from "@/components/common/MarkdownBlock"
+
+const meta = {
+	title: "Components/MarkdownBlock",
+	component: MarkdownBlock,
+	argTypes: {
+		markdown: {
+			control: { type: "text" },
+		},
+	},
+	args: {
+		markdown: `# Markdown Example
+
+This is a **markdown** example with various formatting.
+
+## Features
+
+- **Bold text**
+- *Italic text*
+- \`Inline code\`
+- [Links](https://example.com)
+
+## Code Block
+
+\`\`\`typescript
+function example() {
+  return "Hello, World!"
+}
+\`\`\`
+
+## Lists
+
+1. First item
+2. Second item
+3. Third item
+
+> This is a blockquote`,
+	},
+} satisfies Meta<typeof MarkdownBlock>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/storybook/stories/ReleaseNotesDialog.stories.tsx
+++ b/apps/storybook/stories/ReleaseNotesDialog.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { ReleaseNotesDialog } from "@/components/release-notes/ReleaseNotesDialog"
+
+const mockChangelog = `## [v4.106.0]
+
+- [#2833](https://github.com/Kilo-Org/kilocode/pull/2833) [\`0b8ef46\`](https://github.com/Kilo-Org/kilocode/commit/0b8ef46) Thanks [@mcowger](https://github.com/mcowger)! - Preliminary support for native tool calling (a.k.a native function calling) was added
+
+- [#3050](https://github.com/Kilo-Org/kilocode/pull/3050) [\`357d438\`](https://github.com/Kilo-Org/kilocode/commit/357d438) Thanks [@markijbema](https://github.com/markijbema)! - CMD-I now invokes the agent so you can give it more complex prompts
+
+## [v4.105.0]
+
+- [#3005](https://github.com/Kilo-Org/kilocode/pull/3005) [\`b87ae9c\`](https://github.com/Kilo-Org/kilocode/commit/b87ae9c) Thanks [@kevinvandijk](https://github.com/kevinvandijk)! - Improve the edit chat area to allow context and file drag and drop when editing messages
+`
+
+const meta = {
+	title: "Views/Release Notes/ReleaseNotesDialog",
+	component: ReleaseNotesDialog,
+	argTypes: {
+		isOpen: {
+			control: { type: "boolean" },
+		},
+	},
+	parameters: {
+		disableChromaticDualThemeSnapshot: true,
+	},
+	args: {
+		isOpen: true,
+		onClose: () => console.log("Dialog closed"),
+		markdown: mockChangelog,
+	},
+} satisfies Meta<typeof ReleaseNotesDialog>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/storybook/stories/ShowReleaseNotesButton.stories.tsx
+++ b/apps/storybook/stories/ShowReleaseNotesButton.stories.tsx
@@ -1,0 +1,46 @@
+// kilocode_change - new file: Storybook story for Show Release Notes Button Inner component
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { fn } from "storybook/test"
+import { ShowReleaseNotesButtonInner } from "@/components/release-notes/ShowReleaseNotesButton"
+
+const meta = {
+	title: "Views/Release Notes/ShowReleaseNotesButton",
+	component: ShowReleaseNotesButtonInner,
+	parameters: {
+		layout: "centered",
+	},
+	decorators: [
+		(Story) => (
+			<div className="p-4">
+				<Story />
+			</div>
+		),
+	],
+	argTypes: {
+		buttonText: {
+			control: { type: "text" },
+		},
+		showBadge: {
+			control: { type: "boolean" },
+		},
+		className: {
+			control: { type: "text" },
+		},
+	},
+	args: {
+		onClick: fn(),
+		buttonText: "View Release Notes",
+		showBadge: false,
+	},
+} satisfies Meta<typeof ShowReleaseNotesButtonInner>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithBadge: Story = {
+	args: {
+		showBadge: true,
+	},
+}

--- a/webview-ui/.gitignore
+++ b/webview-ui/.gitignore
@@ -11,6 +11,9 @@
 # production
 /build
 
+# copied files
+public/changelog.md
+
 # misc
 .DS_Store
 .env.local

--- a/webview-ui/src/__mocks__/changelog.md
+++ b/webview-ui/src/__mocks__/changelog.md
@@ -1,0 +1,9 @@
+# kilo-code
+
+## [v4.106.0]
+
+- [#2833](https://github.com/Kilo-Org/kilocode/pull/2833) [`0b8ef46`](https://github.com/Kilo-Org/kilocode/commit/0b8ef46) Thanks [@mcowger](https://github.com/mcowger)! - Preliminary support for native tool calling (a.k.a native function calling) was added
+
+## [v4.105.0]
+
+- [#3005](https://github.com/Kilo-Org/kilocode/pull/3005) [`b87ae9c`](https://github.com/Kilo-Org/kilocode/commit/b87ae9c) Thanks [@kevinvandijk](https://github.com/kevinvandijk)! - Improve the edit chat area to allow context and file drag and drop when editing messages

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -16,6 +16,8 @@ interface MarkdownBlockProps {
 }
 
 const StyledMarkdown = styled.div`
+	color: var(--vscode-editor-foreground);
+
 	* {
 		font-weight: 400;
 	}

--- a/webview-ui/src/components/release-notes/ReleaseNotesDialog.tsx
+++ b/webview-ui/src/components/release-notes/ReleaseNotesDialog.tsx
@@ -1,0 +1,62 @@
+// kilocode_change - simplified: Self-contained dialog that fetches changelog itself
+import React, { useEffect, useRef } from "react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog"
+import MarkdownBlock from "../common/MarkdownBlock"
+import { useAppTranslation } from "@/i18n/TranslationContext"
+import { useReleaseNotes } from "../../hooks/useReleaseNotes"
+
+interface ReleaseNotesDialogProps {
+	isOpen: boolean
+	onClose: () => void
+	markdown?: string // Optional: if provided, use this instead of fetching
+}
+
+export const ReleaseNotesDialog: React.FC<ReleaseNotesDialogProps> = ({
+	isOpen,
+	onClose,
+	markdown: providedMarkdown,
+}) => {
+	const { t } = useAppTranslation()
+	const { markdown: fetchedMarkdown, loading, loadReleases } = useReleaseNotes()
+	const hasLoadedRef = useRef(false)
+
+	// Use provided markdown if available (Storybook), otherwise use fetched
+	const markdown = providedMarkdown || fetchedMarkdown
+
+	useEffect(() => {
+		if (isOpen && !hasLoadedRef.current && !providedMarkdown) {
+			hasLoadedRef.current = true
+			loadReleases()
+		}
+		if (!isOpen) {
+			hasLoadedRef.current = false
+		}
+	}, [isOpen, loadReleases, providedMarkdown])
+
+	return (
+		<Dialog open={isOpen} onOpenChange={onClose}>
+			<DialogContent className="flex flex-col max-w-[calc(100%-3rem)] max-h-[50vh]">
+				<DialogHeader>
+					<DialogTitle className="text-xl font-medium text-vscode-editor-foreground">
+						{t("kilocode:releaseNotes.modalTitle")}
+					</DialogTitle>
+				</DialogHeader>
+				<div className="overflow-y-auto pr-2">
+					{loading ? (
+						<div className="text-center py-8 text-vscode-descriptionForeground">
+							{t("kilocode:releaseNotes.loading")}
+						</div>
+					) : !markdown ? (
+						<div className="text-center py-8 text-vscode-descriptionForeground">
+							{t("kilocode:releaseNotes.noReleases")}
+						</div>
+					) : (
+						<div className="release-notes-content">
+							<MarkdownBlock markdown={markdown} />
+						</div>
+					)}
+				</div>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/webview-ui/src/components/release-notes/ShowReleaseNotesButton.tsx
+++ b/webview-ui/src/components/release-notes/ShowReleaseNotesButton.tsx
@@ -1,0 +1,56 @@
+// kilocode_change - simplified: Button that opens self-contained dialog
+import React, { useState } from "react"
+import { FileText, Bell } from "lucide-react"
+import { Button } from "../ui"
+import { ReleaseNotesDialog } from "./ReleaseNotesDialog"
+import { useAppTranslation } from "@/i18n/TranslationContext"
+
+interface ShowReleaseNotesButtonProps {
+	buttonText?: string
+	className?: string
+}
+
+interface ShowReleaseNotesButtonInnerProps {
+	buttonText: string
+	className?: string
+	showBadge: boolean
+	onClick: () => void
+}
+
+export const ShowReleaseNotesButtonInner: React.FC<ShowReleaseNotesButtonInnerProps> = ({
+	buttonText,
+	className,
+	showBadge,
+	onClick,
+}) => {
+	return (
+		<Button onClick={onClick} className={`relative ${className}`}>
+			<FileText className="p-0.5" />
+			{buttonText}
+			{showBadge && (
+				<div className="absolute -top-2 -right-2 size-4 bg-yellow-500 rounded-full flex items-center justify-center">
+					<Bell size={24} fill="currentColor" className="p-0.5" />
+				</div>
+			)}
+		</Button>
+	)
+}
+
+export const ShowReleaseNotesButton: React.FC<ShowReleaseNotesButtonProps> = ({ buttonText, className = "w-40" }) => {
+	const { t } = useAppTranslation()
+	const [showDialog, setShowDialog] = useState(false)
+	const displayText = buttonText || t("kilocode:releaseNotes.viewReleaseNotes")
+
+	return (
+		<>
+			<ShowReleaseNotesButtonInner
+				buttonText={displayText}
+				className={className}
+				showBadge={false}
+				onClick={() => setShowDialog(true)}
+			/>
+
+			<ReleaseNotesDialog isOpen={showDialog} onClose={() => setShowDialog(false)} />
+		</>
+	)
+}

--- a/webview-ui/src/components/release-notes/index.ts
+++ b/webview-ui/src/components/release-notes/index.ts
@@ -1,0 +1,3 @@
+// kilocode_change - simplified: Export only the components we still use
+export { ReleaseNotesDialog } from "./ReleaseNotesDialog"
+export { ShowReleaseNotesButton as ManualReleaseNotesButton } from "./ShowReleaseNotesButton"

--- a/webview-ui/src/components/settings/About.tsx
+++ b/webview-ui/src/components/settings/About.tsx
@@ -14,6 +14,7 @@ import { Package } from "@roo/package"
 import { vscode } from "@/utils/vscode"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui"
+import { ManualReleaseNotesButton } from "@/components/release-notes" // kilocode_change
 
 import { SectionHeader } from "./SectionHeader"
 import { Section } from "./Section"
@@ -84,7 +85,6 @@ export const About = ({ telemetrySetting, setTelemetrySetting, className, ...pro
 					/>
 				</div>
 				{/* kilocode_change end */}
-
 				<div className="flex flex-wrap items-center gap-2 mt-2">
 					<Button onClick={() => vscode.postMessage({ type: "exportSettings" })} className="w-28">
 						<Upload className="p-0.5" />
@@ -102,6 +102,12 @@ export const About = ({ telemetrySetting, setTelemetrySetting, className, ...pro
 						{t("settings:footer.settings.reset")}
 					</Button>
 				</div>
+
+				{/* kilocode_change start */}
+				<div className="flex flex-wrap items-center gap-2 mt-2">
+					<ManualReleaseNotesButton />
+				</div>
+				{/* kilocode_change end */}
 
 				{
 					// kilocode_change start

--- a/webview-ui/src/components/ui/dialog.tsx
+++ b/webview-ui/src/components/ui/dialog.tsx
@@ -45,7 +45,7 @@ function DialogContent({ className, children, ...props }: React.ComponentProps<t
 				)}
 				{...props}>
 				{children}
-				<DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+				<DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none cursor-pointer [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
 					<XIcon />
 					<span className="sr-only">Close</span>
 				</DialogPrimitive.Close>

--- a/webview-ui/src/hooks/useReleaseNotes.ts
+++ b/webview-ui/src/hooks/useReleaseNotes.ts
@@ -1,0 +1,48 @@
+// kilocode_change - simplified: Load and parse changelog markdown directly
+import { useState } from "react"
+import { loadChangelog } from "../utils/changelogLoader"
+
+// Global cache
+let changelogCache: string | null = null
+let currentVersionCache: string | null = null
+
+const NULL_VERSION = "0.0.0"
+
+// Parse version from markdown by finding first version header
+function parseVersionFromMarkdown(markdown: string): string {
+	const versionHeaderRegex = /^## \[v(\d+\.\d+\.\d+)\]/m
+	const match = markdown.match(versionHeaderRegex)
+	return match ? match[1] : NULL_VERSION
+}
+
+export const useReleaseNotes = () => {
+	const [loading, setLoading] = useState(false)
+
+	const loadReleases = async () => {
+		if (changelogCache && currentVersionCache) {
+			return { markdown: changelogCache, currentVersion: currentVersionCache }
+		}
+
+		setLoading(true)
+		try {
+			changelogCache = await loadChangelog()
+			currentVersionCache = parseVersionFromMarkdown(changelogCache)
+
+			return { markdown: changelogCache, currentVersion: currentVersionCache }
+		} catch (error) {
+			console.error("Failed to load release notes:", error)
+			changelogCache = ""
+			currentVersionCache = NULL_VERSION
+			return { markdown: "", currentVersion: NULL_VERSION }
+		} finally {
+			setLoading(false)
+		}
+	}
+
+	return {
+		markdown: changelogCache || "",
+		currentVersion: currentVersionCache || NULL_VERSION,
+		loading,
+		loadReleases,
+	}
+}

--- a/webview-ui/src/i18n/locales/ar/kilocode.json
+++ b/webview-ui/src/i18n/locales/ar/kilocode.json
@@ -280,5 +280,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "جديد: مشاركة الأوضاع عن طريق إنشاء منظمة"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "عرض ملاحظات الإصدار",
+		"noReleases": "لا تتوفر ملاحظات الإصدار",
+		"loading": "جاري تحميل ملاحظات الإصدار...",
+		"latestBadge": "الأحدث",
+		"modalTitle": "ما الجديد في كيلو كود",
+		"byAuthor": "بواسطة"
 	}
 }

--- a/webview-ui/src/i18n/locales/ca/kilocode.json
+++ b/webview-ui/src/i18n/locales/ca/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Nou: Comparteix modes creant una organització"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Veure notes de la versió",
+		"modalTitle": "Novetats a Kilo Code",
+		"loading": "S'estan carregant les notes de la versió...",
+		"latestBadge": "Últim",
+		"noReleases": "No hi ha notes de llançament disponibles",
+		"byAuthor": "per"
 	}
 }

--- a/webview-ui/src/i18n/locales/cs/kilocode.json
+++ b/webview-ui/src/i18n/locales/cs/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Novinka: Sdílejte režimy vytvořením organizace"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Zobrazit poznámky k vydání",
+		"loading": "Načítání poznámek k vydání...",
+		"noReleases": "Poznámky k vydání nejsou k dispozici",
+		"latestBadge": "Nejnovější",
+		"modalTitle": "Co je nového v Kilo Code",
+		"byAuthor": "od"
 	}
 }

--- a/webview-ui/src/i18n/locales/de/kilocode.json
+++ b/webview-ui/src/i18n/locales/de/kilocode.json
@@ -280,5 +280,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Neu: Modi teilen durch Erstellen einer Organisation"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Release Notes ansehen",
+		"modalTitle": "Was gibt es Neues in Kilo Code",
+		"loading": "Versionshinweise werden geladen...",
+		"noReleases": "Keine Release Notes verfügbar",
+		"latestBadge": "Neueste",
+		"byAuthor": "von"
 	}
 }

--- a/webview-ui/src/i18n/locales/en/kilocode.json
+++ b/webview-ui/src/i18n/locales/en/kilocode.json
@@ -279,5 +279,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "New: Share modes by creating an organization"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "View Release Notes",
+		"modalTitle": "What's New in Kilo Code",
+		"loading": "Loading release notes...",
+		"noReleases": "No release notes available",
+		"latestBadge": "Latest",
+		"byAuthor": "by"
 	}
 }

--- a/webview-ui/src/i18n/locales/es/kilocode.json
+++ b/webview-ui/src/i18n/locales/es/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Nuevo: Comparte modos creando una organización"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Ver notas de la versión",
+		"modalTitle": "Novedades en Kilo Code",
+		"loading": "Cargando notas de la versión...",
+		"noReleases": "No hay notas de lanzamiento disponibles",
+		"byAuthor": "por",
+		"latestBadge": "Último"
 	}
 }

--- a/webview-ui/src/i18n/locales/fr/kilocode.json
+++ b/webview-ui/src/i18n/locales/fr/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Nouveau : Partagez des modes en créant une organisation"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Voir les notes de version",
+		"loading": "Chargement des notes de version...",
+		"modalTitle": "Quoi de neuf dans Kilo Code",
+		"noReleases": "Aucune note de version disponible",
+		"byAuthor": "par",
+		"latestBadge": "Plus récent"
 	}
 }

--- a/webview-ui/src/i18n/locales/hi/kilocode.json
+++ b/webview-ui/src/i18n/locales/hi/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "नया: एक संगठन बनाकर मोड साझा करें"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "रिलीज़ नोट्स देखें",
+		"loading": "रिलीज़ नोट्स लोड हो रहे हैं...",
+		"modalTitle": "किलो कोड में नया क्या है",
+		"latestBadge": "नवीनतम",
+		"noReleases": "कोई रिलीज़ नोट्स उपलब्ध नहीं",
+		"byAuthor": "द्वारा"
 	}
 }

--- a/webview-ui/src/i18n/locales/id/kilocode.json
+++ b/webview-ui/src/i18n/locales/id/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Baru: Bagikan mode dengan membuat organisasi"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Lihat Catatan Rilis",
+		"modalTitle": "Apa yang Baru di Kilo Code",
+		"loading": "Memuat catatan rilis...",
+		"noReleases": "Tidak ada catatan rilis yang tersedia",
+		"byAuthor": "oleh",
+		"latestBadge": "Terbaru"
 	}
 }

--- a/webview-ui/src/i18n/locales/it/kilocode.json
+++ b/webview-ui/src/i18n/locales/it/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Novità: Condividi le modalità creando un'organizzazione"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Visualizza note di rilascio",
+		"modalTitle": "Novità in Kilo Code",
+		"loading": "Caricamento delle note di rilascio...",
+		"noReleases": "Nessuna nota di rilascio disponibile",
+		"latestBadge": "Più recenti",
+		"byAuthor": "di"
 	}
 }

--- a/webview-ui/src/i18n/locales/ja/kilocode.json
+++ b/webview-ui/src/i18n/locales/ja/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "新機能: 組織を作成してモードを共有"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "リリースノートを表示",
+		"modalTitle": "Kilo Codeの新機能",
+		"loading": "リリースノートを読み込んでいます...",
+		"latestBadge": "最新",
+		"noReleases": "リリースノートはありません",
+		"byAuthor": "によって"
 	}
 }

--- a/webview-ui/src/i18n/locales/ko/kilocode.json
+++ b/webview-ui/src/i18n/locales/ko/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "신규: 조직을 생성하여 모드 공유하기"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "릴리스 노트 보기",
+		"loading": "릴리스 노트 로딩 중...",
+		"noReleases": "릴리스 노트 없음",
+		"modalTitle": "Kilo Code의 새로운 기능",
+		"latestBadge": "최신",
+		"byAuthor": "작성자:"
 	}
 }

--- a/webview-ui/src/i18n/locales/nl/kilocode.json
+++ b/webview-ui/src/i18n/locales/nl/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Nieuw: Deel modi door een organisatie aan te maken"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Bekijk Release Notes",
+		"modalTitle": "Wat is er nieuw in Kilo Code",
+		"loading": "Releaseopmerkingen laden...",
+		"byAuthor": "door",
+		"noReleases": "Geen release notes beschikbaar",
+		"latestBadge": "Nieuwste"
 	}
 }

--- a/webview-ui/src/i18n/locales/pl/kilocode.json
+++ b/webview-ui/src/i18n/locales/pl/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Nowość: Udostępniaj tryby tworząc organizację"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Zobacz informacje o wydaniu",
+		"modalTitle": "Co nowego w Kilo Code",
+		"loading": "Ładowanie informacji o wydaniu...",
+		"latestBadge": "Najnowsze",
+		"noReleases": "Brak dostępnych informacji o wydaniu",
+		"byAuthor": "przez"
 	}
 }

--- a/webview-ui/src/i18n/locales/pt-BR/kilocode.json
+++ b/webview-ui/src/i18n/locales/pt-BR/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Novo: Compartilhe modos criando uma organização"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Ver Notas da Versão",
+		"loading": "Carregando notas de atualização...",
+		"modalTitle": "O Que Há de Novo no Kilo Code",
+		"noReleases": "Sem notas de lançamento disponíveis",
+		"latestBadge": "Mais recentes",
+		"byAuthor": "por"
 	}
 }

--- a/webview-ui/src/i18n/locales/ru/kilocode.json
+++ b/webview-ui/src/i18n/locales/ru/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Новое: Делитесь режимами путем создания организации"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Посмотреть примечания к выпуску",
+		"loading": "Загрузка примечаний к выпуску...",
+		"latestBadge": "Последние",
+		"noReleases": "Примечания к выпуску отсутствуют",
+		"modalTitle": "Что нового в Kilo Code",
+		"byAuthor": "от"
 	}
 }

--- a/webview-ui/src/i18n/locales/th/kilocode.json
+++ b/webview-ui/src/i18n/locales/th/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "ใหม่: แชร์โหมดโดยการสร้างองค์กร"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "ดูบันทึกการเปิดตัว",
+		"latestBadge": "ล่าสุด",
+		"modalTitle": "มีอะไรใหม่ใน Kilo Code",
+		"loading": "กำลังโหลดบันทึกการอัปเดต...",
+		"noReleases": "ไม่มีบันทึกประจำรุ่นที่เผยแพร่",
+		"byAuthor": "โดย"
 	}
 }

--- a/webview-ui/src/i18n/locales/tr/kilocode.json
+++ b/webview-ui/src/i18n/locales/tr/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Yeni: Bir organizasyon oluşturarak modları paylaşın"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Sürüm Notlarını Görüntüle",
+		"modalTitle": "Kilo Code'da Yeni Neler Var",
+		"noReleases": "Hiçbir sürüm notu bulunmuyor",
+		"loading": "Sürüm notları yükleniyor...",
+		"byAuthor": "tarafından",
+		"latestBadge": "En Son"
 	}
 }

--- a/webview-ui/src/i18n/locales/uk/kilocode.json
+++ b/webview-ui/src/i18n/locales/uk/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Нове: Діліться режимами, створивши організацію"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Переглянути примітки до випуску",
+		"loading": "Завантаження приміток до випуску...",
+		"modalTitle": "Що нового у Kilo Code",
+		"latestBadge": "Останні",
+		"noReleases": "Примітки до випуску відсутні",
+		"byAuthor": "від"
 	}
 }

--- a/webview-ui/src/i18n/locales/vi/kilocode.json
+++ b/webview-ui/src/i18n/locales/vi/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "Mới: Chia sẻ chế độ bằng cách tạo một tổ chức"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "Xem Ghi Chú Phát Hành",
+		"modalTitle": "Có gì mới trong Kilo Code",
+		"latestBadge": "Mới nhất",
+		"loading": "Đang tải ghi chú phát hành...",
+		"noReleases": "Không có ghi chú phát hành",
+		"byAuthor": "bởi"
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-CN/kilocode.json
+++ b/webview-ui/src/i18n/locales/zh-CN/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "新功能：通过创建组织来共享模式"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "查看发布说明",
+		"noReleases": "没有可用的发布说明",
+		"modalTitle": "Kilo Code 的新特性",
+		"latestBadge": "最新",
+		"byAuthor": "由",
+		"loading": "加载发行说明..."
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-TW/kilocode.json
+++ b/webview-ui/src/i18n/locales/zh-TW/kilocode.json
@@ -281,5 +281,13 @@
 	},
 	"modes": {
 		"shareModesNewBanner": "新功能：通过创建组织共享模式"
+	},
+	"releaseNotes": {
+		"viewReleaseNotes": "查看发布说明",
+		"modalTitle": "Kilo Code 新功能一览",
+		"loading": "正在加载发行说明...",
+		"noReleases": "没有可用的发布说明",
+		"byAuthor": "由",
+		"latestBadge": "最新"
 	}
 }

--- a/webview-ui/src/utils/changelogLoader.ts
+++ b/webview-ui/src/utils/changelogLoader.ts
@@ -1,0 +1,12 @@
+// kilocode_change - Extract changelog loading logic for easier testing
+/**
+ * Loads the changelog markdown from the public directory
+ * @returns Promise resolving to the changelog markdown content
+ */
+export async function loadChangelog(): Promise<string> {
+	const response = await fetch("/changelog.md")
+	if (!response.ok) {
+		throw new Error(`Failed to fetch changelog: ${response.statusText}`)
+	}
+	return response.text()
+}

--- a/webview-ui/src/vite-plugins/sourcemapPlugin.ts
+++ b/webview-ui/src/vite-plugins/sourcemapPlugin.ts
@@ -1,6 +1,8 @@
 import { Plugin } from "vite"
 import fs from "fs"
 import path from "path"
+import { fileURLToPath } from "url"
+import { dirname } from "path"
 
 /**
  * Custom Vite plugin to ensure source maps are properly included in the build
@@ -17,14 +19,19 @@ export function sourcemapPlugin(): Plugin {
 			handler: async () => {
 				console.log("Ensuring source maps are included in build...")
 
+				// Get the plugin file's directory for consistent path resolution
+				const pluginDir = dirname(fileURLToPath(import.meta.url))
+				// Get webview-ui directory (parent of src/vite-plugins)
+				const webviewUiDir = path.resolve(pluginDir, "../..")
+
 				// Determine the correct output directory based on the build mode
 				const mode = process.env.NODE_ENV
 				let outDir
 
 				if (mode === "nightly") {
-					outDir = path.resolve("../apps/vscode-nightly/build/webview-ui/build")
+					outDir = path.resolve(webviewUiDir, "../apps/vscode-nightly/build/webview-ui/build")
 				} else {
-					outDir = path.resolve("../src/webview-ui/build")
+					outDir = path.resolve(webviewUiDir, "../src/webview-ui/build")
 				}
 
 				const assetsDir = path.join(outDir, "assets")

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -1,12 +1,18 @@
 import path, { resolve } from "path"
 import fs from "fs"
 import { execSync } from "child_process"
+import { fileURLToPath } from "url"
+import { dirname } from "path"
 
 import { defineConfig, type PluginOption, type Plugin } from "vite"
 import react from "@vitejs/plugin-react"
 import tailwindcss from "@tailwindcss/vite"
 
 import { sourcemapPlugin } from "./src/vite-plugins/sourcemapPlugin"
+
+// Get __dirname equivalent for ES modules
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 function getGitSha() {
 	let gitSha: string | undefined = undefined
@@ -51,6 +57,19 @@ const persistPortPlugin = (): Plugin => ({
 	},
 })
 
+const copyChangelogPlugin = (): Plugin => ({
+	name: "copy-changelog",
+	buildStart() {
+		try {
+			const publicDir = path.resolve(__dirname, "./public")
+			fs.mkdirSync(publicDir, { recursive: true })
+			fs.copyFileSync(path.resolve(__dirname, "../../CHANGELOG.md"), path.join(publicDir, "changelog.md"))
+		} catch (_error) {
+			// Ignore errors - build can continue without changelog
+		}
+	},
+})
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
 	let outDir = "../src/webview-ui/build"
@@ -91,7 +110,14 @@ export default defineConfig(({ mode }) => {
 		define["process.env.PKG_OUTPUT_CHANNEL"] = JSON.stringify("Kilo-Code-Nightly")
 	}
 
-	const plugins: PluginOption[] = [react(), tailwindcss(), persistPortPlugin(), wasmPlugin(), sourcemapPlugin()]
+	const plugins: PluginOption[] = [
+		react(),
+		tailwindcss(),
+		persistPortPlugin(),
+		wasmPlugin(),
+		sourcemapPlugin(),
+		copyChangelogPlugin(), // kilocode_change: Generate release notes at build time
+	]
 
 	return {
 		plugins,

--- a/webview-ui/vitest.setup.ts
+++ b/webview-ui/vitest.setup.ts
@@ -50,3 +50,17 @@ Object.defineProperty(window, "matchMedia", {
 
 // Mock scrollIntoView which is not available in jsdom
 Element.prototype.scrollIntoView = vi.fn()
+
+// Mock changelog loader for tests
+vi.mock("@src/utils/changelogLoader", async () => {
+	const fs = await import("fs")
+	const path = await import("path")
+	const mockChangelogPath = path.resolve(__dirname, "./src/__mocks__/changelog.md")
+	const mockContent = fs.existsSync(mockChangelogPath)
+		? fs.readFileSync(mockChangelogPath, "utf-8")
+		: "## [v0.0.0]\n\n- Initial mock release notes."
+
+	return {
+		loadChangelog: vi.fn(() => Promise.resolve(mockContent)),
+	}
+})


### PR DESCRIPTION
- Add ReleaseNotesModal component and related UI components
- Implement build-time script to parse CHANGELOG.md and generate releases.json
- Add useReleaseNotes hook for loading pre-generated release data
- Update settings page with manual release notes button

**Dev Notes**
This pull request adds support to our build system to parse our changelog markdown file and turn it into a set of JSON files for displaying in the extension in release note components.

Eventually, we'll automatically pop up the release notes if there's any unviewed versions, but for now, users will have to manually open them using the button in the info page in the settings. 

![2025-11-04 11 21 28](https://github.com/user-attachments/assets/c364ca1b-fb89-4290-be3b-1ab89ed2cba7)


