### PR TITLE
show mcp tool name instead of servername as header

### DIFF
--- a/.changeset/long-foxes-win.md
+++ b/.changeset/long-foxes-win.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Show MCP tool instead of server name when asked to approve a tool

--- a/webview-ui/src/components/chat/McpExecution.tsx
+++ b/webview-ui/src/components/chat/McpExecution.tsx
@@ -186,7 +186,8 @@ export const McpExecution = ({
 				<div className="flex flex-row items-center gap-1 flex-wrap">
 					<Server size={16} className="text-vscode-descriptionForeground" />
 					<div className="flex items-center gap-1 flex-wrap">
-						{serverName && <span className="font-bold text-vscode-foreground">{serverName}</span>}
+						{/* kilocode_change: Show tool name instead of server name since server is already shown above */}
+						{toolName && <span className="font-bold text-vscode-foreground">{toolName}</span>}
 					</div>
 				</div>
 				<div className="flex flex-row items-center justify-between gap-2 px-1">


### PR DESCRIPTION
The server name is already shown above the component, so is redundant. And the user is asked to approve the tool but cannot see the toolname without expanding the component

Before:
<img width="278" height="114" alt="CleanShot 2025-11-04 at 10 01 26" src="https://github.com/user-attachments/assets/d6a5c039-16b5-4756-ac78-dd4c7d197c02" />


After:
<img width="1186" height="182" alt="CleanShot 2025-11-04 at 09 58 10@2x" src="https://github.com/user-attachments/assets/3874b3b5-663f-42ff-b244-97154171f3d5" />
