### PR TITLE
CLI - Fix welcome msg

### DIFF
--- a/.changeset/thirty-kings-tickle.md
+++ b/.changeset/thirty-kings-tickle.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix Wellcome Message regression

--- a/cli/src/ui/utils/welcomeMessage.ts
+++ b/cli/src/ui/utils/welcomeMessage.ts
@@ -1,9 +1,7 @@
 import type { CliMessage, WelcomeMessageOptions } from "../../types/cli.js"
 import type { ValidationResult } from "../../config/validation.js"
 import { getConfigPath } from "../../config/persistence.js"
-
-// Counter to ensure unique IDs even when created in the same millisecond
-let messageCounter = 0
+import { generateMessage } from "./messages.js"
 
 /**
  * Converts validation errors into user-friendly instructions
@@ -42,14 +40,11 @@ export function createConfigErrorInstructions(validation: ValidationResult): str
  * @returns A CliMessage of type "welcome"
  */
 export function createWelcomeMessage(options?: WelcomeMessageOptions): CliMessage {
-	const timestamp = Date.now()
-	const id = `welcome-${timestamp}-${messageCounter++}`
-
 	return {
-		id,
+		...generateMessage(),
 		type: "welcome",
 		content: "", // Content is rendered by WelcomeMessageContent component
-		ts: 0, // Welcome message should show at the top
+		ts: 1, // Welcome message should show at the top
 		metadata: {
 			welcomeOptions: options,
 		},

--- a/cli/src/utils/auto-update.ts
+++ b/cli/src/utils/auto-update.ts
@@ -2,6 +2,7 @@ import packageJson from "package-json"
 import { Package } from "../constants/package.js"
 import { CliMessage } from "../types/cli.js"
 import semver from "semver"
+import { generateMessage } from "../ui/utils/messages.js"
 
 type AutoUpdateStatus = {
 	name: string
@@ -31,11 +32,8 @@ export const getAutoUpdateStatus = async () => {
 }
 
 export const generateUpdateAvailableMessage = (status: AutoUpdateStatus): CliMessage => {
-	const timestamp = Date.now()
-
 	return {
-		id: `update-notification-${timestamp}`,
-		ts: timestamp,
+		...generateMessage(),
 		type: "system",
 		content: `## A new version of Kilo CLI is available!
 You are using v${status.currentVersion}, the latest version is v${status.latestVersion}.

--- a/cli/src/utils/notifications.ts
+++ b/cli/src/utils/notifications.ts
@@ -2,6 +2,7 @@ import { getKiloUrlFromToken } from "@roo-code/types"
 import { logs } from "../services/logs.js"
 import type { KilocodeNotification } from "../state/atoms/notifications.js"
 import type { ProviderConfig } from "../config/types.js"
+import { generateMessage } from "../ui/utils/messages.js"
 
 /**
  * Response from the Kilocode notifications API
@@ -72,8 +73,6 @@ export function supportsNotifications(provider: ProviderConfig): boolean {
  * @returns A CLI message object
  */
 export function generateNotificationMessage(notification: KilocodeNotification) {
-	const timestamp = Date.now()
-
 	let content = `## ${notification.title}\n\n${notification.message}`
 
 	if (notification.action) {
@@ -81,8 +80,7 @@ export function generateNotificationMessage(notification: KilocodeNotification) 
 	}
 
 	return {
-		id: `notification-${notification.id}-${timestamp}`,
-		ts: timestamp,
+		...generateMessage(),
 		type: "system" as const,
 		content,
 	}


### PR DESCRIPTION
## Context

- Regression with the cutoff timestamp 0

## Implementation

- Set the welcome message always on the TS 1
- use generateMessage on Update and Kilo Notifications

## Screenshots

<img width="926" height="586" alt="Screenshot 2025-11-04 at 1 44 54 PM" src="https://github.com/user-attachments/assets/f0811a0c-24b8-4e89-907b-e6f099106512" />