### PR TITLE
Add Windows troubleshooting blurb

### DIFF
--- a/apps/kilocode-docs/docs/getting-started/installing.md
+++ b/apps/kilocode-docs/docs/getting-started/installing.md
@@ -100,8 +100,7 @@ If you prefer to download and install the VSIX file directly:
 * If VS Code Marketplace is inaccessible, try the Open VSX Registry method
 
 **Windows Users**  
-* Support for Windows is currently limited  
-* If you encounter errors, ensure **`PowerShell` is added to your `PATH`**:  
+* Ensure that **`PowerShell` is added to your `PATH`**:  
   1. Open **Edit system environment variables** → **Environment Variables**  
   2. Under **System variables**, select **Path** → **Edit** → **New**  
   3. Add: `C:\Windows\System32\WindowsPowerShell\v1.0\`  

--- a/apps/kilocode-docs/docs/getting-started/installing.md
+++ b/apps/kilocode-docs/docs/getting-started/installing.md
@@ -99,6 +99,14 @@ If you prefer to download and install the VSIX file directly:
 * Verify VS Code version 1.84.0 or later
 * If VS Code Marketplace is inaccessible, try the Open VSX Registry method
 
+**Windows Users**  
+* Support for Windows is currently limited  
+* If you encounter errors, ensure **`PowerShell` is added to your `PATH`**:  
+  1. Open **Edit system environment variables** → **Environment Variables**  
+  2. Under **System variables**, select **Path** → **Edit** → **New**  
+  3. Add: `C:\Windows\System32\WindowsPowerShell\v1.0\`  
+  4. Click **OK** and restart VS Code
+
 ## Getting Support
 
 If you encounter issues not covered here:


### PR DESCRIPTION
Adding instructions for Windows users regarding PowerShell path requirement

## Context

Windows users occasionally face errors if `powershell` is not added to `PATH`. Adding documentation blurb to address this