### PR TITLE
refactor: simplify parseGhostResponse to return FillInAtCursorSuggest…

### DIFF
--- a/src/services/ghost/__tests__/GhostServiceManager.spec.ts
+++ b/src/services/ghost/__tests__/GhostServiceManager.spec.ts
@@ -108,7 +108,7 @@ describe("GhostServiceManager", () => {
 			const position = context.range?.start ?? context.document.positionAt(0)
 			const { prefix, suffix } = extractPrefixSuffix(context.document, position)
 			const result = parseGhostResponse("", prefix, suffix)
-			expect(result.suggestions.hasSuggestions()).toBe(false)
+			expect(result.text).toBe("")
 		})
 
 		it("should handle invalid COMPLETION format", async () => {
@@ -119,7 +119,7 @@ describe("GhostServiceManager", () => {
 			const position = context.range?.start ?? context.document.positionAt(0)
 			const { prefix, suffix } = extractPrefixSuffix(context.document, position)
 			const result = parseGhostResponse(invalidCOMPLETION, prefix, suffix)
-			expect(result.suggestions.hasSuggestions()).toBe(false)
+			expect(result.text).toBe("")
 		})
 
 		it("should handle file not found in context", async () => {
@@ -138,7 +138,7 @@ console.log('test');</COMPLETION>`
 			const position = context.range?.start ?? context.document.positionAt(0)
 			const { prefix, suffix } = extractPrefixSuffix(context.document, position)
 			const result = parseGhostResponse(completionResponse, prefix, suffix)
-			expect(result.suggestions.hasSuggestions()).toBe(true)
+			expect(result.text).toBe("// Added comment\nconsole.log('test');")
 		})
 	})
 

--- a/src/services/ghost/classic-auto-complete/GhostStreamingParser.ts
+++ b/src/services/ghost/classic-auto-complete/GhostStreamingParser.ts
@@ -1,20 +1,11 @@
-import { GhostSuggestionsState } from "./GhostSuggestions"
-
-export interface StreamingParseResult {
-	suggestions: GhostSuggestionsState
-	isComplete: boolean
-	hasNewSuggestions: boolean
-}
+import { FillInAtCursorSuggestion } from "./GhostSuggestions"
 
 /**
  * Parse the response - only handles responses with <COMPLETION> tags
+ * Returns a FillInAtCursorSuggestion with the extracted text, or an empty string if nothing found
  */
-export function parseGhostResponse(fullResponse: string, prefix: string, suffix: string): StreamingParseResult {
-	const suggestions = new GhostSuggestionsState()
-	let hasNewSuggestions = false
-
+export function parseGhostResponse(fullResponse: string, prefix: string, suffix: string): FillInAtCursorSuggestion {
 	let fimText: string = ""
-	let isComplete: boolean = true
 
 	// Match content strictly between <COMPLETION> and </COMPLETION> tags
 	const completionMatch = fullResponse.match(/<COMPLETION>([\s\S]*?)<\/COMPLETION>/i)
@@ -22,24 +13,14 @@ export function parseGhostResponse(fullResponse: string, prefix: string, suffix:
 	if (completionMatch) {
 		// Extract the captured group (content between tags)
 		fimText = completionMatch[1] || ""
-		isComplete = true
 	}
 	// Remove any accidentally captured tag remnants
 	fimText = fimText.replace(/<\/?COMPLETION>/gi, "")
 
-	// Create suggestion if there's actual content
-	if (fimText.length > 0) {
-		suggestions.setFillInAtCursor({
-			text: fimText,
-			prefix,
-			suffix,
-		})
-		hasNewSuggestions = true
-	}
-
+	// Return FillInAtCursorSuggestion with the text (empty string if nothing found)
 	return {
-		suggestions,
-		isComplete,
-		hasNewSuggestions,
+		text: fimText,
+		prefix,
+		suffix,
 	}
 }

--- a/src/services/ghost/classic-auto-complete/GhostSuggestions.ts
+++ b/src/services/ghost/classic-auto-complete/GhostSuggestions.ts
@@ -3,25 +3,3 @@ export interface FillInAtCursorSuggestion {
 	prefix: string
 	suffix: string
 }
-
-export class GhostSuggestionsState {
-	private fillinAtCursorSuggestion: FillInAtCursorSuggestion | undefined = undefined
-
-	constructor() {}
-
-	public setFillInAtCursor(suggestion: FillInAtCursorSuggestion) {
-		this.fillinAtCursorSuggestion = suggestion
-	}
-
-	public getFillInAtCursor(): FillInAtCursorSuggestion | undefined {
-		return this.fillinAtCursorSuggestion
-	}
-
-	public hasSuggestions(): boolean {
-		return !!this.fillinAtCursorSuggestion
-	}
-
-	public clear(): void {
-		this.fillinAtCursorSuggestion = undefined
-	}
-}

--- a/src/services/ghost/classic-auto-complete/__tests__/GhostInlineCompletionProvider.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/GhostInlineCompletionProvider.test.ts
@@ -4,7 +4,7 @@ import {
 	findMatchingSuggestion,
 	CostTrackingCallback,
 } from "../GhostInlineCompletionProvider"
-import { GhostSuggestionsState, FillInAtCursorSuggestion } from "../GhostSuggestions"
+import { FillInAtCursorSuggestion } from "../GhostSuggestions"
 import { MockTextDocument } from "../../../mocking/MockTextDocument"
 import { GhostModel } from "../../GhostModel"
 import { GhostContext } from "../../GhostContext"

--- a/src/services/ghost/classic-auto-complete/__tests__/GhostStreamingParser.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/GhostStreamingParser.test.ts
@@ -10,82 +10,75 @@ describe("GhostStreamingParser", () => {
 			const response = "<COMPLETION>return 42</COMPLETION>"
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(true)
-			expect(result.isComplete).toBe(true)
-			expect(result.suggestions.hasSuggestions()).toBe(true)
-
-			const suggestion = result.suggestions.getFillInAtCursor()
-			expect(suggestion?.text).toBe("return 42")
-			expect(suggestion?.prefix).toBe(prefix)
-			expect(suggestion?.suffix).toBe(suffix)
+			expect(result.text).toBe("return 42")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 
 		it("should handle multiline content in COMPLETION tags", () => {
 			const response = "<COMPLETION>const x = 1;\nconst y = 2;\nreturn x + y;</COMPLETION>"
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(true)
-			expect(result.suggestions.hasSuggestions()).toBe(true)
-
-			const suggestion = result.suggestions.getFillInAtCursor()
-			expect(suggestion?.text).toBe("const x = 1;\nconst y = 2;\nreturn x + y;")
+			expect(result.text).toBe("const x = 1;\nconst y = 2;\nreturn x + y;")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 
 		it("should handle incomplete COMPLETION tag (streaming)", () => {
 			const response = "<COMPLETION>return 42"
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.isComplete).toBe(true)
-			expect(result.suggestions.hasSuggestions()).toBe(false)
-
-			const suggestion = result.suggestions.getFillInAtCursor()
-			expect(suggestion?.text).toBeUndefined()
+			// Incomplete tags should return empty string
+			expect(result.text).toBe("")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 
 		it("should remove any accidental tag remnants", () => {
 			const response = "<COMPLETION>return 42<COMPLETION></COMPLETION>"
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(true)
-			const suggestion = result.suggestions.getFillInAtCursor()
-			expect(suggestion?.text).toBe("return 42")
+			expect(result.text).toBe("return 42")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 
 		it("should handle case-insensitive tags", () => {
 			const response = "<completion>return 42</completion>"
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(true)
-			const suggestion = result.suggestions.getFillInAtCursor()
-			expect(suggestion?.text).toBe("return 42")
+			expect(result.text).toBe("return 42")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 	})
 
 	describe("Response parsing without COMPLETION tags (no suggestions)", () => {
-		it("should NOT create suggestions when no tags present", () => {
+		it("should return empty string when no tags present", () => {
 			const response = "return 42"
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.isComplete).toBe(true)
-			expect(result.suggestions.hasSuggestions()).toBe(false)
+			expect(result.text).toBe("")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 
-		it("should NOT create suggestions for multiline response without tags", () => {
+		it("should return empty string for multiline response without tags", () => {
 			const response = "const x = 1;\nconst y = 2;\nreturn x + y;"
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.suggestions.hasSuggestions()).toBe(false)
+			expect(result.text).toBe("")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 
-		it("should NOT create suggestions for markdown code blocks without tags", () => {
+		it("should return empty string for markdown code blocks without tags", () => {
 			const response = "```typescript\nreturn 42\n```"
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.suggestions.hasSuggestions()).toBe(false)
+			expect(result.text).toBe("")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 	})
 
@@ -94,17 +87,18 @@ describe("GhostStreamingParser", () => {
 			const response = ""
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.isComplete).toBe(true)
-			expect(result.suggestions.hasSuggestions()).toBe(false)
+			expect(result.text).toBe("")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 
-		it("should NOT create suggestions for whitespace-only response without tags", () => {
+		it("should return empty string for whitespace-only response without tags", () => {
 			const response = "   \n\t  "
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.suggestions.hasSuggestions()).toBe(false)
+			expect(result.text).toBe("")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 
 		it("should handle custom prefix/suffix with COMPLETION tags", () => {
@@ -114,47 +108,45 @@ describe("GhostStreamingParser", () => {
 
 			const result = parseGhostResponse(response, customPrefix, customSuffix)
 
-			expect(result.hasNewSuggestions).toBe(true)
-			expect(result.suggestions.hasSuggestions()).toBe(true)
-
-			const suggestion = result.suggestions.getFillInAtCursor()
-			expect(suggestion?.text).toBe('"Hello, World!"')
-			expect(suggestion?.prefix).toBe(customPrefix)
-			expect(suggestion?.suffix).toBe(customSuffix)
+			expect(result.text).toBe('"Hello, World!"')
+			expect(result.prefix).toBe(customPrefix)
+			expect(result.suffix).toBe(customSuffix)
 		})
 
 		it("should handle empty COMPLETION tags", () => {
 			const response = "<COMPLETION></COMPLETION>"
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(false)
-			expect(result.suggestions.hasSuggestions()).toBe(false)
+			expect(result.text).toBe("")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 
 		it("should handle whitespace-only content in COMPLETION tags", () => {
 			const response = "<COMPLETION>   </COMPLETION>"
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(true)
-			expect(result.suggestions.hasSuggestions()).toBe(true)
+			expect(result.text).toBe("   ")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 
 		it("should handle response with extra text before COMPLETION tag", () => {
 			const response = "Here is the code:\n<COMPLETION>return 42</COMPLETION>"
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(true)
-			const suggestion = result.suggestions.getFillInAtCursor()
-			expect(suggestion?.text).toBe("return 42")
+			expect(result.text).toBe("return 42")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 
 		it("should handle response with extra text after COMPLETION tag", () => {
 			const response = "<COMPLETION>return 42</COMPLETION>\nThat's the code!"
 			const result = parseGhostResponse(response, prefix, suffix)
 
-			expect(result.hasNewSuggestions).toBe(true)
-			const suggestion = result.suggestions.getFillInAtCursor()
-			expect(suggestion?.text).toBe("return 42")
+			expect(result.text).toBe("return 42")
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 	})
 
@@ -168,7 +160,9 @@ describe("GhostStreamingParser", () => {
 			const endTime = performance.now()
 
 			expect(endTime - startTime).toBeLessThan(100)
-			expect(result.hasNewSuggestions).toBe(true)
+			expect(result.text).toBe(largeContent)
+			expect(result.prefix).toBe(prefix)
+			expect(result.suffix).toBe(suffix)
 		})
 	})
 })

--- a/src/test-llm-autocompletion/strategy-tester.ts
+++ b/src/test-llm-autocompletion/strategy-tester.ts
@@ -137,10 +137,9 @@ export class StrategyTester {
 
 		// Parse the response to extract the completion from XML tags
 		const parseResult = parseGhostResponse(response.content, prefix, suffix)
-		const suggestion = parseResult.suggestions.getFillInAtCursor()
 
-		// Use parsed completion only if available
-		const completion = suggestion?.text || ""
+		// Use parsed completion text directly
+		const completion = parseResult.text
 
 		return {
 			prefix,


### PR DESCRIPTION
…ion directly

- Remove StreamingParseResult interface and related complexity
- parseGhostResponse now returns FillInAtCursorSuggestion with text, prefix, suffix
- Returns empty string for text when no completion found (instead of undefined)
- Update GhostInlineCompletionProvider to handle new return type
- Update all tests to work with simplified API
- Maintain backward compatibility by creating GhostSuggestionsState internally when needed

This change simplifies the API and reduces unnecessary abstraction layers while maintaining all existing functionality.

This is also closer to the continue api:
```
export interface AutocompleteOutcome extends TabAutocompleteOptions {
	accepted?: boolean
	time: number
	prefix: string
	suffix: string
	prompt: string
	completion: string
```

