### PR TITLE
feat(autocomplete): filter out useless suggestions

### DIFF
--- a/.changeset/new-horses-mix.md
+++ b/.changeset/new-horses-mix.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent autocomplete from suggesting duplicating the previous or next line

--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -8,6 +8,7 @@ import { GhostContext } from "../GhostContext"
 import { ApiStreamChunk } from "../../../api/transform/stream"
 import { GhostGutterAnimation } from "../GhostGutterAnimation"
 import type { GhostServiceSettings } from "@roo-code/types"
+import { refuseUselessSuggestion } from "./uselessSuggestionFilter"
 
 const MAX_SUGGESTIONS_HISTORY = 20
 
@@ -193,9 +194,12 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 		}
 
 		// Parse the response using the standalone function
-		const fillInAtCursorSuggestion = parseGhostResponse(response, prefix, suffix)
+		let fillInAtCursorSuggestion = parseGhostResponse(response, prefix, suffix)
 
-		if (fillInAtCursorSuggestion.text) {
+		// Check if the suggestion is useless and clear it if so
+		if (fillInAtCursorSuggestion.text && refuseUselessSuggestion(fillInAtCursorSuggestion.text, prefix, suffix)) {
+			fillInAtCursorSuggestion = { text: "", prefix, suffix }
+		} else if (fillInAtCursorSuggestion.text) {
 			console.info("Final suggestion:", fillInAtCursorSuggestion)
 		}
 

--- a/src/services/ghost/classic-auto-complete/__tests__/GhostInlineCompletionProvider.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/GhostInlineCompletionProvider.test.ts
@@ -1163,4 +1163,135 @@ describe("GhostInlineCompletionProvider", () => {
 			expect(mockCostTrackingCallback).not.toHaveBeenCalled()
 		})
 	})
+
+	describe("useless suggestion filtering", () => {
+		it("should refuse suggestions that match the end of prefix", async () => {
+			// Mock the model to return a suggestion that matches the end of prefix
+			vi.mocked(mockModel.generateResponse).mockImplementation(async (_sys, _user, onChunk) => {
+				if (onChunk) {
+					onChunk({ type: "text", text: "<COMPLETION>" })
+					onChunk({ type: "text", text: "= 1" }) // This matches the end of "const x = 1"
+					onChunk({ type: "text", text: "</COMPLETION>" })
+				}
+				return {
+					cost: 0.01,
+					inputTokens: 100,
+					outputTokens: 50,
+					cacheWriteTokens: 0,
+					cacheReadTokens: 0,
+				}
+			})
+
+			const result = (await provider.provideInlineCompletionItems(
+				mockDocument,
+				mockPosition,
+				mockContext,
+				mockToken,
+			)) as vscode.InlineCompletionItem[]
+
+			// Should return empty array because the suggestion is useless
+			expect(result).toHaveLength(0)
+			expect(mockModel.generateResponse).toHaveBeenCalledTimes(1)
+		})
+
+		it("should refuse suggestions that match the start of suffix", async () => {
+			// Mock the model to return a suggestion that matches the start of suffix
+			vi.mocked(mockModel.generateResponse).mockImplementation(async (_sys, _user, onChunk) => {
+				if (onChunk) {
+					onChunk({ type: "text", text: "<COMPLETION>" })
+					onChunk({ type: "text", text: "\nconst" }) // This matches the start of "\nconst y = 2"
+					onChunk({ type: "text", text: "</COMPLETION>" })
+				}
+				return {
+					cost: 0.01,
+					inputTokens: 100,
+					outputTokens: 50,
+					cacheWriteTokens: 0,
+					cacheReadTokens: 0,
+				}
+			})
+
+			const result = (await provider.provideInlineCompletionItems(
+				mockDocument,
+				mockPosition,
+				mockContext,
+				mockToken,
+			)) as vscode.InlineCompletionItem[]
+
+			// Should return empty array because the suggestion is useless
+			expect(result).toHaveLength(0)
+			expect(mockModel.generateResponse).toHaveBeenCalledTimes(1)
+		})
+
+		it("should accept useful suggestions that don't match prefix end or suffix start", async () => {
+			// Mock the model to return a useful suggestion
+			vi.mocked(mockModel.generateResponse).mockImplementation(async (_sys, _user, onChunk) => {
+				if (onChunk) {
+					onChunk({ type: "text", text: "<COMPLETION>" })
+					onChunk({ type: "text", text: "\nconsole.log('useful');" }) // Useful suggestion
+					onChunk({ type: "text", text: "</COMPLETION>" })
+				}
+				return {
+					cost: 0.01,
+					inputTokens: 100,
+					outputTokens: 50,
+					cacheWriteTokens: 0,
+					cacheReadTokens: 0,
+				}
+			})
+
+			const result = (await provider.provideInlineCompletionItems(
+				mockDocument,
+				mockPosition,
+				mockContext,
+				mockToken,
+			)) as vscode.InlineCompletionItem[]
+
+			// Should return the suggestion because it's useful
+			expect(result).toHaveLength(1)
+			expect(result[0].insertText).toBe("\nconsole.log('useful');")
+			expect(mockModel.generateResponse).toHaveBeenCalledTimes(1)
+		})
+
+		it("should cache refused suggestions as empty to avoid repeated LLM calls", async () => {
+			// Mock the model to return a useless suggestion
+			vi.mocked(mockModel.generateResponse).mockImplementation(async (_sys, _user, onChunk) => {
+				if (onChunk) {
+					onChunk({ type: "text", text: "<COMPLETION>" })
+					onChunk({ type: "text", text: "= 1" }) // Matches end of prefix
+					onChunk({ type: "text", text: "</COMPLETION>" })
+				}
+				return {
+					cost: 0.01,
+					inputTokens: 100,
+					outputTokens: 50,
+					cacheWriteTokens: 0,
+					cacheReadTokens: 0,
+				}
+			})
+
+			// First call - should invoke LLM and refuse the suggestion
+			const result1 = (await provider.provideInlineCompletionItems(
+				mockDocument,
+				mockPosition,
+				mockContext,
+				mockToken,
+			)) as vscode.InlineCompletionItem[]
+
+			expect(result1).toHaveLength(0)
+			expect(mockModel.generateResponse).toHaveBeenCalledTimes(1)
+
+			// Second call with same prefix/suffix - should use cache, not call LLM
+			vi.mocked(mockModel.generateResponse).mockClear()
+			const result2 = (await provider.provideInlineCompletionItems(
+				mockDocument,
+				mockPosition,
+				mockContext,
+				mockToken,
+			)) as vscode.InlineCompletionItem[]
+
+			expect(result2).toHaveLength(0)
+			expect(mockModel.generateResponse).not.toHaveBeenCalled()
+		})
+	})
 })

--- a/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
@@ -1,0 +1,89 @@
+import { refuseUselessSuggestion } from "../uselessSuggestionFilter"
+
+describe("refuseUselessSuggestion", () => {
+	describe("should refuse useless suggestions", () => {
+		it("should refuse empty suggestions", () => {
+			expect(refuseUselessSuggestion("", "const x = ", " + 1")).toBe(true)
+			expect(refuseUselessSuggestion("   ", "const x = ", " + 1")).toBe(true)
+			expect(refuseUselessSuggestion("\t\n", "const x = ", " + 1")).toBe(true)
+		})
+
+		it("should refuse suggestions that match the end of prefix", () => {
+			// Exact match at the end
+			expect(refuseUselessSuggestion("hello", "const x = hello", "")).toBe(true)
+			expect(refuseUselessSuggestion("world", "hello world", " + 1")).toBe(true)
+
+			// With whitespace variations
+			expect(refuseUselessSuggestion("test", "const test ", "")).toBe(true)
+			expect(refuseUselessSuggestion("foo", "bar foo  ", "")).toBe(true)
+		})
+
+		it("should refuse suggestions that match the start of suffix", () => {
+			// Exact match at the start
+			expect(refuseUselessSuggestion("hello", "const x = ", "hello world")).toBe(true)
+			expect(refuseUselessSuggestion("const", "", "const y = 2")).toBe(true)
+
+			// With whitespace variations
+			expect(refuseUselessSuggestion("test", "const x = ", "  test()")).toBe(true)
+			expect(refuseUselessSuggestion("foo", "", " foo bar")).toBe(true)
+
+			// Trimmed match
+			expect(refuseUselessSuggestion("bar", "const x = ", "  bar  baz")).toBe(true)
+		})
+
+		it("should refuse suggestions when trimmed version matches", () => {
+			expect(refuseUselessSuggestion("  hello  ", "const x = ", "hello world")).toBe(true)
+			expect(refuseUselessSuggestion("\nhello\t", "test hello", "")).toBe(true)
+		})
+	})
+
+	describe("should accept useful suggestions", () => {
+		it("should accept suggestions that add new content", () => {
+			expect(refuseUselessSuggestion("newValue", "const x = ", "")).toBe(false)
+			expect(refuseUselessSuggestion("42", "const x = ", " + y")).toBe(false)
+			expect(refuseUselessSuggestion("middle", "const x = ", " + y")).toBe(false)
+		})
+
+		it("should accept suggestions that don't match prefix end or suffix start", () => {
+			expect(refuseUselessSuggestion("hello", "const x = ", "world")).toBe(false)
+			expect(refuseUselessSuggestion("test", "const x = ", "const y = 2")).toBe(false)
+			expect(refuseUselessSuggestion("foo", "bar", "baz")).toBe(false)
+		})
+
+		it("should accept partial matches that are still useful", () => {
+			// Suggestion contains but doesn't exactly match
+			expect(refuseUselessSuggestion("hello world", "const x = hello", "")).toBe(false)
+			expect(refuseUselessSuggestion("test123", "test", "456")).toBe(false)
+		})
+
+		it("should accept suggestions with meaningful content between prefix and suffix", () => {
+			expect(refuseUselessSuggestion("= 42", "const x ", " + y")).toBe(false)
+			expect(refuseUselessSuggestion("()", "myFunction", ".then()")).toBe(false)
+		})
+	})
+
+	describe("edge cases", () => {
+		it("should handle empty prefix and suffix", () => {
+			expect(refuseUselessSuggestion("hello", "", "")).toBe(false)
+			expect(refuseUselessSuggestion("", "", "")).toBe(true)
+		})
+
+		it("should handle very long strings", () => {
+			const longString = "a".repeat(1000)
+			expect(refuseUselessSuggestion("different", longString, longString)).toBe(false)
+			expect(refuseUselessSuggestion("different", longString + "different", "")).toBe(true)
+		})
+
+		it("should handle special characters", () => {
+			expect(refuseUselessSuggestion("${}", "const template = `", "${}`")).toBe(true)
+			expect(refuseUselessSuggestion("\\n", "const x = ", "\\n")).toBe(true)
+			expect(refuseUselessSuggestion("/**/", "const x = /**/", "")).toBe(true)
+		})
+
+		it("should handle unicode characters", () => {
+			expect(refuseUselessSuggestion("😀", "const emoji = ", "😀")).toBe(true)
+			expect(refuseUselessSuggestion("你好", "const greeting = 你好", "")).toBe(true)
+			expect(refuseUselessSuggestion("🚀", "launch", "🌟")).toBe(false)
+		})
+	})
+})

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -1,0 +1,28 @@
+/**
+ * Filters out useless autocomplete suggestions that don't provide value to the user
+ *
+ * @param suggestion - The suggested text to insert
+ * @param prefix - The text before the cursor position
+ * @param suffix - The text after the cursor position
+ * @returns true if the suggestion should be refused (is useless), false if it should be kept
+ */
+export function refuseUselessSuggestion(suggestion: string, prefix: string, suffix: string): boolean {
+	const trimmedSuggestion = suggestion.trim()
+
+	if (!trimmedSuggestion) {
+		return true
+	}
+
+	const trimmedPrefixEnd = prefix.trimEnd()
+	if (trimmedPrefixEnd.endsWith(trimmedSuggestion)) {
+		return true
+	}
+
+	const trimmedSuffix = suffix.trimStart()
+	if (trimmedSuffix.startsWith(trimmedSuggestion)) {
+		return true
+	}
+
+	// The suggestion appears to be useful
+	return false
+}


### PR DESCRIPTION
- Add refuseUselessSuggestion function to detect and filter suggestions that:
  - Are empty or whitespace-only
  - Match the end of the prefix (already typed)
  - Match the start of the suffix (already coming next)
- Integrate filtering into GhostInlineCompletionProvider
- Add comprehensive test coverage for the filtering logic
- Cache refused suggestions to avoid repeated LLM calls

This improves the autocomplete experience by only showing meaningful completions that actually add value to the user's code.

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
