### PR TITLE
WIP: One-Click Emergency Rollback Workflow

### DIFF
--- a/.github/workflows/_build-and-publish.yml
+++ b/.github/workflows/_build-and-publish.yml
@@ -1,0 +1,240 @@
+name: Build and Publish (Reusable)
+
+on:
+    workflow_call:
+        inputs:
+            version:
+                required: true
+                type: string
+                description: "Version to publish"
+            git_ref:
+                required: true
+                type: string
+                description: "Git reference to build from"
+        secrets:
+            POSTHOG_API_KEY:
+                required: true
+            VSCE_TOKEN:
+                required: true
+            OVSX_TOKEN:
+                required: true
+            JETBRAINS_MARKETPLACE_TOKEN:
+                required: true
+            GITHUB_TOKEN:
+                required: true
+            TURBO_TOKEN:
+                required: false
+            TURBO_TEAM:
+                required: false
+
+env:
+    NODE_VERSION: 20.19.2
+    PNPM_VERSION: 10.8.1
+    TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+    TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+jobs:
+    build-and-release:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        outputs:
+            version: ${{ inputs.version }}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ inputs.git_ref }}
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: ${{ env.PNPM_VERSION }}
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: "pnpm"
+            - name: Install dependencies
+              run: pnpm install
+            - name: Configure Git
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+            - name: Create .env file
+              run: echo "KILOCODE_POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" >> .env
+            - name: Package Extension
+              run: |
+                  pnpm vsix:production
+
+                  # Save VSIX contents to a temporary file to avoid broken pipe issues.
+                  unzip -l bin/kilo-code-${{ inputs.version }}.vsix > /tmp/kilo-code-vsix-contents.txt
+
+                  # Check for required files.
+                  grep -q "extension/package.json" /tmp/kilo-code-vsix-contents.txt || exit 1
+                  grep -q "extension/package.nls.json" /tmp/kilo-code-vsix-contents.txt || exit 1
+                  grep -q "extension/dist/extension.js" /tmp/kilo-code-vsix-contents.txt || exit 1
+                  grep -q "extension/webview-ui/audio/celebration.wav" /tmp/kilo-code-vsix-contents.txt || exit 1
+                  grep -q "extension/webview-ui/build/assets/index.js" /tmp/kilo-code-vsix-contents.txt || exit 1
+                  grep -q "extension/assets/codicons/codicon.ttf" /tmp/kilo-code-vsix-contents.txt || exit 1
+                  grep -q "extension/assets/vscode-material-icons/icons/3d.svg" /tmp/kilo-code-vsix-contents.txt || exit 1
+                  grep -q ".env" /tmp/kilo-code-vsix-contents.txt || exit 1
+
+                  # Clean up temporary file.
+                  rm /tmp/kilo-code-vsix-contents.txt
+            - name: Create and Push Git Tag
+              run: |
+                  # Check if tag already exists remotely
+                  if git ls-remote --tags origin | grep -q "refs/tags/v${{ inputs.version }}$"; then
+                    echo "Tag v${{ inputs.version }} already exists remotely, skipping tag creation"
+                  else
+                    git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
+                    git push origin "v${{ inputs.version }}" --no-verify
+                    echo "Successfully created and pushed git tag v${{ inputs.version }}"
+                  fi
+            - name: Create GitHub Release
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  # Check if release already exists
+                  if gh release view "v${{ inputs.version }}" >/dev/null 2>&1; then
+                    echo "Release v${{ inputs.version }} already exists, skipping release creation"
+                  else
+                    # Extract changelog for current version
+                    echo "Extracting changelog for version ${{ inputs.version }}"
+                    # Try with 'v' prefix first (newer format), then without (older format)
+                    changelog_content=$(sed -n "/## \\[v${{ inputs.version }}\\]/,/## \\[/p" CHANGELOG.md | sed '$d')
+                    if [ -z "$changelog_content" ]; then
+                      changelog_content=$(sed -n "/## \\[${{ inputs.version }}\\]/,/## \\[/p" CHANGELOG.md | sed '$d')
+                    fi
+
+                    # If changelog extraction failed, use a default message
+                    if [ -z "$changelog_content" ]; then
+                      echo "Warning: No changelog section found for version ${{ inputs.version }}"
+                      changelog_content="Release v${{ inputs.version }}"
+                    else
+                      echo "Found changelog section for version ${{ inputs.version }}"
+                    fi
+
+                    # Create release with changelog content
+                    gh release create "v${{ inputs.version }}" \
+                      --title "Release v${{ inputs.version }}" \
+                      --notes "$changelog_content" \
+                      --target ${{ inputs.git_ref }} \
+                      bin/kilo-code-${{ inputs.version }}.vsix
+                    echo "Successfully created GitHub Release v${{ inputs.version }}"
+                  fi
+            - name: Upload VSIX artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: kilo-code-vsix
+                  path: bin/kilo-code-${{ inputs.version }}.vsix
+
+    publish-vscode:
+        needs: build-and-release
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ inputs.git_ref }}
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: ${{ env.PNPM_VERSION }}
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: "pnpm"
+            - name: Install dependencies
+              run: pnpm install
+            - name: Download VSIX artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: kilo-code-vsix
+                  path: bin/
+            - name: Publish to VS Code Marketplace
+              continue-on-error: true
+              env:
+                  VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
+                  OVSX_PAT: ${{ secrets.OVSX_TOKEN }}
+              run: |
+                  pnpm --filter kilo-code publish:marketplace
+                  echo "Successfully published version ${{ inputs.version }} to VS Code Marketplace"
+
+    publish-jetbrains:
+        needs: build-and-release
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ inputs.git_ref }}
+                  submodules: recursive
+                  lfs: true
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: ${{ env.PNPM_VERSION }}
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: "pnpm"
+            - uses: actions/setup-java@v4
+              with:
+                  distribution: "jetbrains"
+                  java-version: "21"
+                  check-latest: false
+                  token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Install system dependencies
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y \
+                    libx11-dev \
+                    libxkbfile-dev \
+                    pkg-config \
+                    build-essential \
+                    python3
+            - name: Turbo cache setup
+              uses: actions/cache@v4
+              with:
+                  path: .turbo
+                  key: ${{ runner.os }}-turbo-${{ github.sha }}
+                  restore-keys: |
+                      ${{ runner.os }}-turbo-
+            - name: Install dependencies
+              run: pnpm install
+            - name: Create .env file
+              run: echo "KILOCODE_POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" >> .env
+            - name: Build JetBrains Plugin
+              run: pnpm run jetbrains:bundle
+              shell: bash
+            - name: Get bundle name
+              id: get_bundle_name
+              run: echo "BUNDLE_NAME=$(node jetbrains/plugin/scripts/get_bundle_name.js)" >> $GITHUB_ENV
+            - name: Attach to GitHub Release
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh release upload "v${{ inputs.version }}" \
+                    "jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}#JetBrains Plugin" \
+                    --clobber
+                  echo "Successfully attached JetBrains plugin to GitHub Release v${{ inputs.version }}"
+            - name: Upload artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ env.BUNDLE_NAME }}
+                  path: jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}
+            - name: Publish to JetBrains Marketplace
+              continue-on-error: true
+              run: |
+                  curl \
+                  -X POST \
+                  -H "Authorization: Bearer ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}" \
+                  -F "file=@jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}" \
+                  -F "pluginId=28350" \
+                  -F "channel=stable" \
+                  -F "isHidden=false" \
+                  https://plugins.jetbrains.com/plugin/uploadPlugin
+                  echo "Successfully published to JetBrains Marketplace"

--- a/.github/workflows/emergency-rollback.yml
+++ b/.github/workflows/emergency-rollback.yml
@@ -1,0 +1,148 @@
+name: Emergency Rollback
+
+on:
+    workflow_dispatch:
+        inputs:
+            source_tag:
+                description: "🔄 Source tag to rollback to (e.g., v4.115.0)"
+                required: true
+                type: string
+
+jobs:
+    prepare-rollback:
+        runs-on: ubuntu-latest
+        outputs:
+            rollback_version: ${{ steps.calculate.outputs.rollback_version }}
+            validated_tag: ${{ steps.validate.outputs.validated_tag }}
+        steps:
+            - name: Validate source tag
+              id: validate
+              run: |
+                  TAG="${{ inputs.source_tag }}"
+
+                  # Auto-fix: add 'v' prefix if missing
+                  if [[ ! "$TAG" =~ ^v ]]; then
+                    TAG="v$TAG"
+                    echo "Auto-fixed tag: $TAG (added v prefix)"
+                  fi
+
+                  # Fetch tags to ensure we have the latest
+                  git fetch --tags
+
+                  # Verify tag exists
+                  if ! git tag -l | grep -q "^${TAG}$"; then
+                    echo "Error: Tag '$TAG' does not exist"
+                    echo ""
+                    echo "Available recent tags:"
+                    git tag -l 'v*' | sort -V | tail -10
+                    exit 1
+                  fi
+
+                  echo "Tag '$TAG' exists"
+                  echo "validated_tag=$TAG" >> $GITHUB_OUTPUT
+
+            - name: Checkout code at tag
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ steps.validate.outputs.validated_tag }}
+
+            - name: Calculate rollback version
+              id: calculate
+              run: |
+                  echo "Calculating rollback version..."
+
+                  # Get current version from main branch
+                  MAIN_VERSION=$(git show origin/main:src/package.json | jq -r '.version')
+                  echo "Current version on main: $MAIN_VERSION"
+
+                  # Parse version components
+                  IFS='.' read -r MAJOR MINOR PATCH <<< "$MAIN_VERSION"
+
+                  # Increment patch and add -rollback suffix
+                  NEW_PATCH=$((PATCH + 1))
+                  ROLLBACK_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}-rollback"
+
+                  echo ""
+                  echo "Rollback version: $ROLLBACK_VERSION"
+                  echo "Version ordering: $MAIN_VERSION < $ROLLBACK_VERSION < ${MAJOR}.${MINOR}.${NEW_PATCH}"
+                  echo ""
+
+                  # Update package.json
+                  jq ".version = \"$ROLLBACK_VERSION\"" src/package.json > src/package.json.tmp
+                  mv src/package.json.tmp src/package.json
+
+                  echo "Updated src/package.json to version $ROLLBACK_VERSION"
+
+                  # Commit the version change
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add src/package.json
+                  git commit -m "chore: bump version to $ROLLBACK_VERSION for rollback"
+                  git push origin HEAD:refs/heads/rollback-temp-${{ github.run_id }}
+
+                  echo "rollback_version=$ROLLBACK_VERSION" >> $GITHUB_OUTPUT
+
+    publish:
+        needs: prepare-rollback
+        uses: ./.github/workflows/_build-and-publish.yml
+        with:
+            version: ${{ needs.prepare-rollback.outputs.rollback_version }}
+            git_ref: rollback-temp-${{ github.run_id }}
+        secrets:
+            POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+            VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+            OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
+            JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+            TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+    sync-main:
+        needs: [prepare-rollback, publish]
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  ref: rollback-temp-${{ github.run_id }}
+
+            - name: Create sync PR
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  echo "Creating PR to sync main branch with rollback version..."
+
+                  BRANCH_NAME="rollback-sync-${{ needs.prepare-rollback.outputs.rollback_version }}"
+                  SOURCE_TAG="${{ needs.prepare-rollback.outputs.validated_tag }}"
+                  VERSION="${{ needs.prepare-rollback.outputs.rollback_version }}"
+
+                  # Create permanent branch
+                  git checkout -b "$BRANCH_NAME"
+                  git push origin "$BRANCH_NAME"
+
+                  # Update CHANGELOG
+                  TODAY=$(date +%Y-%m-%d)
+                  echo "## [v${VERSION}] - ${TODAY}" > CHANGELOG.tmp
+                  echo "" >> CHANGELOG.tmp
+                  echo "🔄 **Rollback Release**: Restored stable functionality from \`${SOURCE_TAG}\`" >> CHANGELOG.tmp
+                  echo "" >> CHANGELOG.tmp
+                  cat CHANGELOG.md >> CHANGELOG.tmp
+                  mv CHANGELOG.tmp CHANGELOG.md
+
+                  git add CHANGELOG.md
+                  git commit -m "docs: add rollback entry to changelog"
+                  git push origin "$BRANCH_NAME"
+
+                  # Create PR
+                  gh pr create \
+                    --title "chore: sync rollback version $VERSION" \
+                    --body "Rollback sync from ${SOURCE_TAG} to version ${VERSION}" \
+                    --base main \
+                    --head "$BRANCH_NAME"
+
+                  echo "Created rollback sync PR"
+
+            - name: Cleanup temp branch
+              if: always()
+              run: |
+                  git push origin --delete rollback-temp-${{ github.run_id }} || true

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -6,16 +6,10 @@ on:
 
 env:
     GIT_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || 'main' }}
-    NODE_VERSION: 20.19.2
-    PNPM_VERSION: 10.8.1
-    TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-    TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
-    create-release:
+    get-version:
         runs-on: ubuntu-latest
-        permissions:
-            contents: write # Required for pushing tags and creating releases
         if: >
             ( github.event_name == 'pull_request' &&
             github.event.pull_request.base.ref == 'main' &&
@@ -28,218 +22,24 @@ jobs:
               uses: actions/checkout@v4
               with:
                   ref: ${{ env.GIT_REF }}
-            - name: Install pnpm
-              uses: pnpm/action-setup@v4
-              with:
-                  version: ${{ env.PNPM_VERSION }}
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ env.NODE_VERSION }}
-                  cache: "pnpm"
-            - name: Install dependencies
-              run: pnpm install
-            - name: Configure Git
-              run: |
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
-            - name: Create .env file
-              run: echo "KILOCODE_POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" >> .env
             - name: Get version
               id: get-version
               run: |
                   current_package_version=$(node -p "require('./src/package.json').version")
                   echo "version=${current_package_version}" >> $GITHUB_OUTPUT
                   echo "Version: ${current_package_version}"
-            - name: Package Extension
-              run: |
-                  current_package_version=$(node -p "require('./src/package.json').version")
-                  pnpm vsix:production
 
-                  # Save VSIX contents to a temporary file to avoid broken pipe issues.
-                  unzip -l bin/kilo-code-${current_package_version}.vsix > /tmp/kilo-code-vsix-contents.txt
-
-                  # Check for required files.
-                  grep -q "extension/package.json" /tmp/kilo-code-vsix-contents.txt || exit 1
-                  grep -q "extension/package.nls.json" /tmp/kilo-code-vsix-contents.txt || exit 1
-                  grep -q "extension/dist/extension.js" /tmp/kilo-code-vsix-contents.txt || exit 1
-                  grep -q "extension/webview-ui/audio/celebration.wav" /tmp/kilo-code-vsix-contents.txt || exit 1
-                  grep -q "extension/webview-ui/build/assets/index.js" /tmp/kilo-code-vsix-contents.txt || exit 1
-                  grep -q "extension/assets/codicons/codicon.ttf" /tmp/kilo-code-vsix-contents.txt || exit 1
-                  grep -q "extension/assets/vscode-material-icons/icons/3d.svg" /tmp/kilo-code-vsix-contents.txt || exit 1
-                  grep -q ".env" /tmp/kilo-code-vsix-contents.txt || exit 1
-
-                  # Clean up temporary file.
-                  rm /tmp/kilo-code-vsix-contents.txt
-            - name: Create and Push Git Tag
-              run: |
-                  current_package_version=$(node -p "require('./src/package.json').version")
-
-                  # Check if tag already exists remotely
-                  if git ls-remote --tags origin | grep -q "refs/tags/v${current_package_version}$"; then
-                    echo "Tag v${current_package_version} already exists remotely, skipping tag creation"
-                  else
-                    git tag -a "v${current_package_version}" -m "Release v${current_package_version}"
-                    git push origin "v${current_package_version}" --no-verify
-                    echo "Successfully created and pushed git tag v${current_package_version}"
-                  fi
-            - name: Create GitHub Release
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  current_package_version=$(node -p "require('./src/package.json').version")
-
-                  # Check if release already exists
-                  if gh release view "v${current_package_version}" >/dev/null 2>&1; then
-                    echo "Release v${current_package_version} already exists, skipping release creation"
-                  else
-                    # Extract changelog for current version
-                    echo "Extracting changelog for version ${current_package_version}"
-                    # Try with 'v' prefix first (newer format), then without (older format)
-                    changelog_content=$(sed -n "/## \\[v${current_package_version}\\]/,/## \\[/p" CHANGELOG.md | sed '$d')
-                    if [ -z "$changelog_content" ]; then
-                      changelog_content=$(sed -n "/## \\[${current_package_version}\\]/,/## \\[/p" CHANGELOG.md | sed '$d')
-                    fi
-
-                    # If changelog extraction failed, use a default message
-                    if [ -z "$changelog_content" ]; then
-                      echo "Warning: No changelog section found for version ${current_package_version}"
-                      changelog_content="Release v${current_package_version}"
-                    else
-                      echo "Found changelog section for version ${current_package_version}"
-                    fi
-
-                    # Create release with changelog content
-                    gh release create "v${current_package_version}" \
-                      --title "Release v${current_package_version}" \
-                      --notes "$changelog_content" \
-                      --target ${{ env.GIT_REF }} \
-                      bin/kilo-code-${current_package_version}.vsix
-                    echo "Successfully created GitHub Release v${current_package_version}"
-                  fi
-            - name: Upload VSIX artifact
-              uses: actions/upload-artifact@v4
-              with:
-                  name: kilo-code-vsix
-                  path: bin/kilo-code-${{ steps.get-version.outputs.version }}.vsix
-
-    publish-vscode:
-        needs: create-release
-        runs-on: ubuntu-latest
-        if: >
-            ( github.event_name == 'pull_request' &&
-            github.event.pull_request.base.ref == 'main' &&
-            contains(github.event.pull_request.title, 'Changeset version bump') ) ||
-            github.event_name == 'workflow_dispatch'
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
-              with:
-                  ref: ${{ env.GIT_REF }}
-            - name: Install pnpm
-              uses: pnpm/action-setup@v4
-              with:
-                  version: ${{ env.PNPM_VERSION }}
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ env.NODE_VERSION }}
-                  cache: "pnpm"
-            - name: Install dependencies
-              run: pnpm install
-            - name: Download VSIX artifact
-              uses: actions/download-artifact@v4
-              with:
-                  name: kilo-code-vsix
-                  path: bin/
-            - name: Publish to VS Code Marketplace
-              continue-on-error: true
-              env:
-                  VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
-                  OVSX_PAT: ${{ secrets.OVSX_TOKEN }}
-              run: |
-                  current_package_version="${{ needs.create-release.outputs.version }}"
-                  pnpm --filter kilo-code publish:marketplace
-                  echo "Successfully published version $current_package_version to VS Code Marketplace"
-
-    publish-jetbrains:
-        needs: create-release
-        runs-on: ubuntu-latest
-        if: >
-            ( github.event_name == 'pull_request' &&
-            github.event.pull_request.base.ref == 'main' &&
-            contains(github.event.pull_request.title, 'Changeset version bump') ) ||
-            github.event_name == 'workflow_dispatch'
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
-              with:
-                  submodules: recursive
-                  lfs: true
-            - name: Install pnpm
-              uses: pnpm/action-setup@v4
-              with:
-                  version: ${{ env.PNPM_VERSION }}
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ env.NODE_VERSION }}
-                  cache: "pnpm"
-            - uses: actions/setup-java@v4
-              with:
-                  distribution: "jetbrains"
-                  java-version: "21"
-                  check-latest: false
-                  token: ${{ secrets.GITHUB_TOKEN }}
-            - name: Install system dependencies
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install -y \
-                    libx11-dev \
-                    libxkbfile-dev \
-                    pkg-config \
-                    build-essential \
-                    python3
-            - name: Turbo cache setup
-              uses: actions/cache@v4
-              with:
-                  path: .turbo
-                  key: ${{ runner.os }}-turbo-${{ github.sha }}
-                  restore-keys: |
-                      ${{ runner.os }}-turbo-
-            - name: Install dependencies
-              run: pnpm install
-            - name: Create .env file
-              run: echo "KILOCODE_POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" >> .env
-            - name: Build JetBrains Plugin
-              run: pnpm run jetbrains:bundle
-              shell: bash
-            - name: Get bundle name
-              id: get_bundle_name
-              run: echo "BUNDLE_NAME=$(node jetbrains/plugin/scripts/get_bundle_name.js)" >> $GITHUB_ENV
-            - name: Attach to GitHub Release
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  current_package_version="${{ needs.create-release.outputs.version }}"
-                  gh release upload "v${current_package_version}" \
-                    "jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}#JetBrains Plugin" \
-                    --clobber
-                  echo "Successfully attached JetBrains plugin to GitHub Release v${current_package_version}"
-            - name: Upload artifact
-              uses: actions/upload-artifact@v4
-              with:
-                  name: ${{ env.BUNDLE_NAME }}
-                  path: jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}
-            - name: Publish to JetBrains Marketplace
-              continue-on-error: true
-              run: |
-                  curl \
-                  -X POST \
-                  -H "Authorization: Bearer ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}" \
-                  -F "file=@jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}" \
-                  -F "pluginId=28350" \
-                  -F "channel=stable" \
-                  -F "isHidden=false" \
-                  https://plugins.jetbrains.com/plugin/uploadPlugin
-                  echo "Successfully published to JetBrains Marketplace"
+    publish:
+        needs: get-version
+        uses: ./.github/workflows/_build-and-publish.yml
+        with:
+            version: ${{ needs.get-version.outputs.version }}
+            git_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || 'main' }}
+        secrets:
+            POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+            VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+            OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
+            JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+            TURBO_TEAM: ${{ secrets.TURBO_TEAM }}


### PR DESCRIPTION
This is a proposal after today's scramble to publish a working version of the extension:
https://kilo-code.slack.com/archives/C090U1NLQUC/p1762375603554519

When we publish a broken extension, we have no fast recovery path. Our changeset-based release process requires reverting PRs, code reviews, and manual version coordination—all while users are experiencing issues in production.

**The pain:** Emergency rollbacks require:
1. Reverting multiple PRs
2. Creating changeset PRs
3. Manual version number calculations
4. Code reviews during an emergency
# 🔄 Emergency Rollback System

## Overview

A **zero-dependency emergency rollback system** that republishes old stable versions with new semver-compatible version numbers (e.g., `v4.10.5` → `4.10.6-rollback`).

## Architecture

### Three-Workflow Design

```
.github/workflows/
├── _build-and-publish.yml      # Reusable: Core build & publish logic
├── marketplace-publish.yml      # Normal: Triggered by version bump PRs
└── emergency-rollback.yml       # Emergency: Manual rollback trigger
```

### Trigger Emergency Rollback

1. Go to **Actions → Emergency Rollback**
2. Click **Run workflow**
3. Enter source tag: `v4.115.0`
4. Click **Run**

**What happens:**

1. Validates tag exists
2. Checks out old code from that tag
3. Calculates new version: `4.10.6-rollback`
4. Builds & publishes to VSCode + JetBrains marketplaces
5. Creates PR to sync main branch

## Version Strategy

### Calculation

```bash
# Main branch version: 4.10.5
# Source rollback tag: v4.10.5
# New rollback version: 4.10.6-rollback

# SemVer ordering:
# 4.10.5 < 4.10.6-rollback < 4.10.6
```

## Implementation Details

### [emergency-rollback.yml](.github/workflows/emergency-rollback.yml)

**Purpose**: Emergency rollback workflow (manual trigger only)

**Jobs:**

1. `prepare-rollback`: Validates tag, calculates version, updates package.json
2. `publish`: Calls reusable build workflow
3. `sync-main`: Creates PR to keep main in sync

### [\_build-and-publish.yml](.github/workflows/_build-and-publish.yml)

**Purpose**: Reusable build and publish workflow

**Jobs:**

1. `build-and-release`: Packages extension, creates GitHub release
2. `publish-vscode`: Publishes to VSCode & OpenVSX marketplaces
3. `publish-jetbrains`: Builds and publishes JetBrains plugin

## Why Sync PR

The emergency rollback creates a PR to main because:

1. **Prevents version conflicts**: Without the PR, main stays at `4.10.5` and we'd try to republish it
2. **Keeps history**: Documents that a rollback occurred
3. **Manual control**: Merge whenever convenient after the emergency

## Key Design Decisions

### Separate Emergency Workflow

**Decision**: Create dedicated `emergency-rollback.yml` instead of optional parameter

**Rationale:**

- Clear, obvious purpose
- No confusion with normal publish
- Easier to find and use in emergencies
- Better separation of concerns

### Reusable Workflow Architecture

**Decision**: Extract common build logic into `_build-and-publish.yml`

**Rationale:**

- Eliminates code duplication
- Single source of truth for build process
- Changes propagate automatically
- Industry best practice for GitHub Actions

### PR Creation

**Decision**: Always create sync PR to main after rollback

**Rationale:**

- Prevents accidentally republishing same version
- Documents rollback in git history
- Can be merged at convenience after emergency
- Manual changelog editing is acceptable for speed
