### PR TITLE
Use consistent naming for model identifiers

### DIFF
--- a/src/services/ghost/new-auto-complete/NewAutocompleteModel.ts
+++ b/src/services/ghost/new-auto-complete/NewAutocompleteModel.ts
@@ -18,7 +18,7 @@ import KiloCode from "../../continuedev/core/llm/llms/KiloCode"
 
 export const AUTOCOMPLETE_PROVIDER_MODELS = {
 	mistral: "codestral-2501",
-	kilocode: "codestral-2501",
+	kilocode: "mistralai/codestral-2501",
 	openrouter: "mistralai/codestral-2501",
 	bedrock: "mistral.codestral-2501-v1:0",
 } as const

--- a/src/services/ghost/new-auto-complete/__tests__/NewAutocompleteModel.spec.ts
+++ b/src/services/ghost/new-auto-complete/__tests__/NewAutocompleteModel.spec.ts
@@ -78,7 +78,7 @@ describe("NewAutocompleteModel", () => {
 				expect(result).toBeDefined()
 				expect(OpenAI).toHaveBeenCalledWith(
 					expect.objectContaining({
-						model: "codestral-2501",
+						model: "mistralai/codestral-2501",
 						apiKey: "test-kilocode-token",
 					}),
 				)


### PR DESCRIPTION
For consistency, we'll add the provider id in the model id like we do elsewhere and optionally make the translation on the backend