### PR TITLE
Add cli config overrides using env vars

### DIFF
--- a/.changeset/silly-guests-wonder.md
+++ b/.changeset/silly-guests-wonder.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+adds support for overriding config with env vars

--- a/cli/src/config/__tests__/env-overrides.test.ts
+++ b/cli/src/config/__tests__/env-overrides.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { applyEnvOverrides, ENV_OVERRIDES } from "../env-overrides.js"
+import type { CLIConfig } from "../types.js"
+
+describe("env-overrides", () => {
+	const originalEnv = process.env
+	let testConfig: CLIConfig
+
+	beforeEach(() => {
+		// Reset environment variables before each test
+		process.env = { ...originalEnv }
+
+		// Create a test config
+		testConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "default",
+			providers: [
+				{
+					id: "default",
+					provider: "kilocode",
+					kilocodeToken: "test-token",
+					kilocodeModel: "anthropic/claude-sonnet-4.5",
+					kilocodeOrganizationId: "original-org-id",
+				},
+				{
+					id: "anthropic-provider",
+					provider: "anthropic",
+					apiKey: "test-key",
+					apiModelId: "claude-3-5-sonnet-20241022",
+				},
+			],
+			autoApproval: {
+				enabled: true,
+			},
+			theme: "dark",
+			customThemes: {},
+		}
+	})
+
+	afterEach(() => {
+		// Restore original environment
+		process.env = originalEnv
+	})
+
+	describe("KILO_PROVIDER override", () => {
+		it("should override provider when KILO_PROVIDER is set and provider exists", () => {
+			process.env[ENV_OVERRIDES.PROVIDER] = "anthropic-provider"
+
+			const result = applyEnvOverrides(testConfig)
+
+			expect(result.provider).toBe("anthropic-provider")
+		})
+
+		it("should not override provider when KILO_PROVIDER provider does not exist", () => {
+			process.env[ENV_OVERRIDES.PROVIDER] = "nonexistent-provider"
+
+			const result = applyEnvOverrides(testConfig)
+
+			expect(result.provider).toBe("default")
+		})
+
+		it("should not override provider when KILO_PROVIDER is not set", () => {
+			const result = applyEnvOverrides(testConfig)
+
+			expect(result.provider).toBe("default")
+		})
+	})
+
+	describe("KILO_MODEL override", () => {
+		it("should override kilocodeModel for kilocode provider", () => {
+			process.env[ENV_OVERRIDES.MODEL] = "anthropic/claude-opus-4.0"
+
+			const result = applyEnvOverrides(testConfig)
+
+			const provider = result.providers.find((p) => p.id === "default")
+			expect(provider?.kilocodeModel).toBe("anthropic/claude-opus-4.0")
+		})
+
+		it("should override apiModelId for anthropic provider", () => {
+			testConfig.provider = "anthropic-provider"
+			process.env[ENV_OVERRIDES.MODEL] = "claude-3-opus-20240229"
+
+			const result = applyEnvOverrides(testConfig)
+
+			const provider = result.providers.find((p) => p.id === "anthropic-provider")
+			expect(provider?.apiModelId).toBe("claude-3-opus-20240229")
+		})
+
+		it("should not modify original config object", () => {
+			process.env[ENV_OVERRIDES.MODEL] = "new-model"
+
+			const result = applyEnvOverrides(testConfig)
+
+			const originalProvider = testConfig.providers.find((p) => p.id === "default")
+			const resultProvider = result.providers.find((p) => p.id === "default")
+
+			expect(originalProvider?.kilocodeModel).toBe("anthropic/claude-sonnet-4.5")
+			expect(resultProvider?.kilocodeModel).toBe("new-model")
+		})
+	})
+
+	describe("KILO_ORG_ID override", () => {
+		it("should override kilocodeOrganizationId for kilocode provider", () => {
+			process.env[ENV_OVERRIDES.ORG_ID] = "new-org-id"
+
+			const result = applyEnvOverrides(testConfig)
+
+			const provider = result.providers.find((p) => p.id === "default")
+			expect(provider?.kilocodeOrganizationId).toBe("new-org-id")
+		})
+
+		it("should not override organizationId for non-kilocode provider", () => {
+			testConfig.provider = "anthropic-provider"
+			process.env[ENV_OVERRIDES.ORG_ID] = "new-org-id"
+
+			const result = applyEnvOverrides(testConfig)
+
+			const provider = result.providers.find((p) => p.id === "anthropic-provider")
+			expect(provider?.kilocodeOrganizationId).toBeUndefined()
+		})
+
+		it("should add kilocodeOrganizationId if not present in config", () => {
+			// Remove organizationId from config
+			const providerIndex = testConfig.providers.findIndex((p) => p.id === "default")
+			delete (testConfig.providers[providerIndex] as any).kilocodeOrganizationId
+
+			process.env[ENV_OVERRIDES.ORG_ID] = "new-org-id"
+
+			const result = applyEnvOverrides(testConfig)
+
+			const provider = result.providers.find((p) => p.id === "default")
+			expect(provider?.kilocodeOrganizationId).toBe("new-org-id")
+		})
+	})
+
+	describe("Multiple overrides", () => {
+		it("should apply all overrides when multiple env vars are set", () => {
+			process.env[ENV_OVERRIDES.PROVIDER] = "default"
+			process.env[ENV_OVERRIDES.MODEL] = "anthropic/claude-opus-4.0"
+			process.env[ENV_OVERRIDES.ORG_ID] = "new-org-id"
+
+			const result = applyEnvOverrides(testConfig)
+
+			expect(result.provider).toBe("default")
+			const provider = result.providers.find((p) => p.id === "default")
+			expect(provider?.kilocodeModel).toBe("anthropic/claude-opus-4.0")
+			expect(provider?.kilocodeOrganizationId).toBe("new-org-id")
+		})
+
+		it("should handle provider switch with model override", () => {
+			process.env[ENV_OVERRIDES.PROVIDER] = "anthropic-provider"
+			process.env[ENV_OVERRIDES.MODEL] = "claude-3-opus-20240229"
+
+			const result = applyEnvOverrides(testConfig)
+
+			expect(result.provider).toBe("anthropic-provider")
+			const provider = result.providers.find((p) => p.id === "anthropic-provider")
+			expect(provider?.apiModelId).toBe("claude-3-opus-20240229")
+		})
+	})
+
+	describe("Edge cases", () => {
+		it("should handle empty config providers array", () => {
+			testConfig.providers = []
+
+			const result = applyEnvOverrides(testConfig)
+
+			expect(result.providers).toEqual([])
+		})
+
+		it("should handle config with no current provider", () => {
+			testConfig.provider = "nonexistent"
+
+			const result = applyEnvOverrides(testConfig)
+
+			expect(result).toEqual(testConfig)
+		})
+
+		it("should handle empty string env variables", () => {
+			process.env[ENV_OVERRIDES.PROVIDER] = ""
+			process.env[ENV_OVERRIDES.MODEL] = ""
+			process.env[ENV_OVERRIDES.ORG_ID] = ""
+
+			const result = applyEnvOverrides(testConfig)
+
+			// Empty strings should not trigger overrides
+			expect(result.provider).toBe("default")
+		})
+	})
+
+	describe("Provider-specific model fields", () => {
+		it("should use correct model field for different providers", () => {
+			const providers = [
+				{ id: "ollama-test", provider: "ollama" as const, ollamaModelId: "llama2" },
+				{ id: "openrouter-test", provider: "openrouter" as const, openRouterModelId: "anthropic/claude" },
+				{ id: "lmstudio-test", provider: "lmstudio" as const, lmStudioModelId: "local-model" },
+			]
+
+			testConfig.providers = [...testConfig.providers, ...providers]
+
+			// Test ollama
+			testConfig.provider = "ollama-test"
+			process.env[ENV_OVERRIDES.MODEL] = "llama3"
+			let result = applyEnvOverrides(testConfig)
+			let provider = result.providers.find((p) => p.id === "ollama-test")
+			expect(provider?.ollamaModelId).toBe("llama3")
+
+			// Test openrouter
+			testConfig.provider = "openrouter-test"
+			process.env[ENV_OVERRIDES.MODEL] = "openai/gpt-4"
+			result = applyEnvOverrides(testConfig)
+			provider = result.providers.find((p) => p.id === "openrouter-test")
+			expect(provider?.openRouterModelId).toBe("openai/gpt-4")
+
+			// Test lmstudio
+			testConfig.provider = "lmstudio-test"
+			process.env[ENV_OVERRIDES.MODEL] = "codellama"
+			result = applyEnvOverrides(testConfig)
+			provider = result.providers.find((p) => p.id === "lmstudio-test")
+			expect(provider?.lmStudioModelId).toBe("codellama")
+		})
+	})
+})

--- a/cli/src/config/__tests__/env-overrides.test.ts
+++ b/cli/src/config/__tests__/env-overrides.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest"
-import { applyEnvOverrides, ENV_OVERRIDES } from "../env-overrides.js"
+import { applyEnvOverrides, PROVIDER_ENV_VAR, PROVIDER_OVERRIDE_PREFIX } from "../env-overrides.js"
 import type { CLIConfig } from "../types.js"
 
 describe("env-overrides", () => {
@@ -46,7 +46,7 @@ describe("env-overrides", () => {
 
 	describe("KILO_PROVIDER override", () => {
 		it("should override provider when KILO_PROVIDER is set and provider exists", () => {
-			process.env[ENV_OVERRIDES.PROVIDER] = "anthropic-provider"
+			process.env[PROVIDER_ENV_VAR] = "anthropic-provider"
 
 			const result = applyEnvOverrides(testConfig)
 
@@ -54,110 +54,47 @@ describe("env-overrides", () => {
 		})
 
 		it("should not override provider when KILO_PROVIDER provider does not exist", () => {
-			process.env[ENV_OVERRIDES.PROVIDER] = "nonexistent-provider"
+			process.env[PROVIDER_ENV_VAR] = "nonexistent-provider"
 
 			const result = applyEnvOverrides(testConfig)
 
 			expect(result.provider).toBe("default")
 		})
 
-		it("should not override provider when KILO_PROVIDER is not set", () => {
+		it("should not override provider when KILO_PROVIDER is empty", () => {
+			process.env[PROVIDER_ENV_VAR] = ""
+
 			const result = applyEnvOverrides(testConfig)
 
 			expect(result.provider).toBe("default")
 		})
 	})
 
-	describe("KILO_MODEL override", () => {
-		it("should override kilocodeModel for kilocode provider", () => {
-			process.env[ENV_OVERRIDES.MODEL] = "anthropic/claude-opus-4.0"
+	describe("KILO_PROVIDER_OVERRIDE_* overrides", () => {
+		it("should override any field in current provider", () => {
+			process.env[`${PROVIDER_OVERRIDE_PREFIX}kilocodeModel`] = "anthropic/claude-opus-4.0"
+			process.env[`${PROVIDER_OVERRIDE_PREFIX}kilocodeOrganizationId`] = "new-org-id"
 
 			const result = applyEnvOverrides(testConfig)
 
 			const provider = result.providers.find((p) => p.id === "default")
 			expect(provider?.kilocodeModel).toBe("anthropic/claude-opus-4.0")
-		})
-
-		it("should override apiModelId for anthropic provider", () => {
-			testConfig.provider = "anthropic-provider"
-			process.env[ENV_OVERRIDES.MODEL] = "claude-3-opus-20240229"
-
-			const result = applyEnvOverrides(testConfig)
-
-			const provider = result.providers.find((p) => p.id === "anthropic-provider")
-			expect(provider?.apiModelId).toBe("claude-3-opus-20240229")
-		})
-
-		it("should not modify original config object", () => {
-			process.env[ENV_OVERRIDES.MODEL] = "new-model"
-
-			const result = applyEnvOverrides(testConfig)
-
-			const originalProvider = testConfig.providers.find((p) => p.id === "default")
-			const resultProvider = result.providers.find((p) => p.id === "default")
-
-			expect(originalProvider?.kilocodeModel).toBe("anthropic/claude-sonnet-4.5")
-			expect(resultProvider?.kilocodeModel).toBe("new-model")
-		})
-	})
-
-	describe("KILO_ORG_ID override", () => {
-		it("should override kilocodeOrganizationId for kilocode provider", () => {
-			process.env[ENV_OVERRIDES.ORG_ID] = "new-org-id"
-
-			const result = applyEnvOverrides(testConfig)
-
-			const provider = result.providers.find((p) => p.id === "default")
-			expect(provider?.kilocodeOrganizationId).toBe("new-org-id")
-		})
-
-		it("should not override organizationId for non-kilocode provider", () => {
-			testConfig.provider = "anthropic-provider"
-			process.env[ENV_OVERRIDES.ORG_ID] = "new-org-id"
-
-			const result = applyEnvOverrides(testConfig)
-
-			const provider = result.providers.find((p) => p.id === "anthropic-provider")
-			expect(provider?.kilocodeOrganizationId).toBeUndefined()
-		})
-
-		it("should add kilocodeOrganizationId if not present in config", () => {
-			// Remove organizationId from config
-			const providerIndex = testConfig.providers.findIndex((p) => p.id === "default")
-			delete (testConfig.providers[providerIndex] as any).kilocodeOrganizationId
-
-			process.env[ENV_OVERRIDES.ORG_ID] = "new-org-id"
-
-			const result = applyEnvOverrides(testConfig)
-
-			const provider = result.providers.find((p) => p.id === "default")
 			expect(provider?.kilocodeOrganizationId).toBe("new-org-id")
 		})
 	})
 
-	describe("Multiple overrides", () => {
-		it("should apply all overrides when multiple env vars are set", () => {
-			process.env[ENV_OVERRIDES.PROVIDER] = "default"
-			process.env[ENV_OVERRIDES.MODEL] = "anthropic/claude-opus-4.0"
-			process.env[ENV_OVERRIDES.ORG_ID] = "new-org-id"
-
-			const result = applyEnvOverrides(testConfig)
-
-			expect(result.provider).toBe("default")
-			const provider = result.providers.find((p) => p.id === "default")
-			expect(provider?.kilocodeModel).toBe("anthropic/claude-opus-4.0")
-			expect(provider?.kilocodeOrganizationId).toBe("new-org-id")
-		})
-
-		it("should handle provider switch with model override", () => {
-			process.env[ENV_OVERRIDES.PROVIDER] = "anthropic-provider"
-			process.env[ENV_OVERRIDES.MODEL] = "claude-3-opus-20240229"
+	describe("Combined overrides", () => {
+		it("should apply both provider and field overrides together", () => {
+			process.env[PROVIDER_ENV_VAR] = "anthropic-provider"
+			process.env[`${PROVIDER_OVERRIDE_PREFIX}apiModelId`] = "claude-3-opus-20240229"
+			process.env[`${PROVIDER_OVERRIDE_PREFIX}apiKey`] = "new-key"
 
 			const result = applyEnvOverrides(testConfig)
 
 			expect(result.provider).toBe("anthropic-provider")
 			const provider = result.providers.find((p) => p.id === "anthropic-provider")
 			expect(provider?.apiModelId).toBe("claude-3-opus-20240229")
+			expect(provider?.apiKey).toBe("new-key")
 		})
 	})
 
@@ -178,48 +115,23 @@ describe("env-overrides", () => {
 			expect(result).toEqual(testConfig)
 		})
 
-		it("should handle empty string env variables", () => {
-			process.env[ENV_OVERRIDES.PROVIDER] = ""
-			process.env[ENV_OVERRIDES.MODEL] = ""
-			process.env[ENV_OVERRIDES.ORG_ID] = ""
+		it("should handle empty string override values", () => {
+			process.env[`${PROVIDER_OVERRIDE_PREFIX}apiModelId`] = ""
 
 			const result = applyEnvOverrides(testConfig)
 
 			// Empty strings should not trigger overrides
-			expect(result.provider).toBe("default")
+			const provider = result.providers.find((p) => p.id === "default")
+			expect(provider?.kilocodeModel).toBe("anthropic/claude-sonnet-4.5")
 		})
-	})
 
-	describe("Provider-specific model fields", () => {
-		it("should use correct model field for different providers", () => {
-			const providers = [
-				{ id: "ollama-test", provider: "ollama" as const, ollamaModelId: "llama2" },
-				{ id: "openrouter-test", provider: "openrouter" as const, openRouterModelId: "anthropic/claude" },
-				{ id: "lmstudio-test", provider: "lmstudio" as const, lmStudioModelId: "local-model" },
-			]
+		it("should ignore KILO_PROVIDER_OVERRIDE_ with no field name", () => {
+			process.env[PROVIDER_OVERRIDE_PREFIX] = "value"
 
-			testConfig.providers = [...testConfig.providers, ...providers]
+			const result = applyEnvOverrides(testConfig)
 
-			// Test ollama
-			testConfig.provider = "ollama-test"
-			process.env[ENV_OVERRIDES.MODEL] = "llama3"
-			let result = applyEnvOverrides(testConfig)
-			let provider = result.providers.find((p) => p.id === "ollama-test")
-			expect(provider?.ollamaModelId).toBe("llama3")
-
-			// Test openrouter
-			testConfig.provider = "openrouter-test"
-			process.env[ENV_OVERRIDES.MODEL] = "openai/gpt-4"
-			result = applyEnvOverrides(testConfig)
-			provider = result.providers.find((p) => p.id === "openrouter-test")
-			expect(provider?.openRouterModelId).toBe("openai/gpt-4")
-
-			// Test lmstudio
-			testConfig.provider = "lmstudio-test"
-			process.env[ENV_OVERRIDES.MODEL] = "codellama"
-			result = applyEnvOverrides(testConfig)
-			provider = result.providers.find((p) => p.id === "lmstudio-test")
-			expect(provider?.lmStudioModelId).toBe("codellama")
+			// Should not modify anything
+			expect(result).toEqual(testConfig)
 		})
 	})
 })

--- a/cli/src/config/env-overrides.ts
+++ b/cli/src/config/env-overrides.ts
@@ -1,0 +1,170 @@
+import type { CLIConfig } from "./types.js"
+import { logs } from "../services/logs.js"
+
+/**
+ * Environment variable names for config overrides
+ */
+export const ENV_OVERRIDES = {
+	PROVIDER: "KILO_PROVIDER",
+	MODEL: "KILO_MODEL",
+	ORG_ID: "KILO_ORG_ID",
+} as const
+
+/**
+ * Apply environment variable overrides to the config
+ * Overrides the current provider's settings based on environment variables
+ *
+ * Environment variables:
+ * - KILO_PROVIDER: Override the active provider ID
+ * - KILO_MODEL: Override the model for the current provider
+ * - KILO_ORG_ID: Override the organization ID (for kilocode provider)
+ *
+ * @param config The config to apply overrides to
+ * @returns The config with environment variable overrides applied
+ */
+export function applyEnvOverrides(config: CLIConfig): CLIConfig {
+	const overriddenConfig = { ...config }
+
+	// Override provider if KILO_PROVIDER is set
+	const envProvider = process.env[ENV_OVERRIDES.PROVIDER]
+
+	if (envProvider) {
+		// Check if the provider exists in the config
+		const providerExists = config.providers.some((p) => p.id === envProvider)
+
+		if (providerExists) {
+			overriddenConfig.provider = envProvider
+
+			logs.info(
+				`Config override: provider set to "${envProvider}" from ${ENV_OVERRIDES.PROVIDER}`,
+				"EnvOverrides",
+			)
+		} else {
+			logs.warn(
+				`Config override ignored: provider "${envProvider}" from ${ENV_OVERRIDES.PROVIDER} not found in config`,
+				"EnvOverrides",
+			)
+		}
+	}
+
+	// Get the current provider (after potential provider override)
+	const currentProvider = overriddenConfig.providers.find((p) => p.id === overriddenConfig.provider)
+
+	if (!currentProvider) {
+		// No valid provider, return config as-is
+		return overriddenConfig
+	}
+
+	// Override model if KILO_MODEL is set
+	const envModel = process.env[ENV_OVERRIDES.MODEL]
+
+	if (envModel) {
+		// Apply model override based on provider type
+		const modelField = getModelFieldForProvider(currentProvider.provider)
+
+		if (modelField) {
+			// Create a new providers array with the updated provider
+			overriddenConfig.providers = overriddenConfig.providers.map((p) => {
+				if (p.id === currentProvider.id) {
+					return {
+						...p,
+						[modelField]: envModel,
+					}
+				}
+
+				return p
+			})
+
+			logs.info(
+				`Config override: ${modelField} set to "${envModel}" from ${ENV_OVERRIDES.MODEL} for provider "${currentProvider.id}"`,
+				"EnvOverrides",
+			)
+		}
+	}
+
+	// Override organization ID if KILO_ORG_ID is set (only for kilocode provider)
+	const envOrgId = process.env[ENV_OVERRIDES.ORG_ID]
+
+	if (envOrgId && currentProvider.provider === "kilocode") {
+		// Create a new providers array with the updated provider
+		overriddenConfig.providers = overriddenConfig.providers.map((p) => {
+			if (p.id === currentProvider.id) {
+				return {
+					...p,
+					kilocodeOrganizationId: envOrgId,
+				}
+			}
+
+			return p
+		})
+
+		logs.info(
+			`Config override: kilocodeOrganizationId set to "${envOrgId}" from ${ENV_OVERRIDES.ORG_ID} for provider "${currentProvider.id}"`,
+			"EnvOverrides",
+		)
+	} else if (envOrgId && currentProvider.provider !== "kilocode") {
+		logs.warn(
+			`Config override ignored: ${ENV_OVERRIDES.ORG_ID} is only applicable for kilocode provider, current provider is "${currentProvider.provider}"`,
+			"EnvOverrides",
+		)
+	}
+
+	return overriddenConfig
+}
+
+/**
+ * Get the model field name for a given provider
+ * Different providers use different field names for their model ID
+ */
+function getModelFieldForProvider(provider: string): string | null {
+	switch (provider) {
+		case "kilocode":
+			return "kilocodeModel"
+
+		case "anthropic":
+			return "apiModelId"
+
+		case "openai-native":
+			return "apiModelId"
+
+		case "openrouter":
+			return "openRouterModelId"
+
+		case "ollama":
+			return "ollamaModelId"
+
+		case "lmstudio":
+			return "lmStudioModelId"
+
+		case "openai":
+			return "apiModelId"
+
+		case "glama":
+			return "glamaModelId"
+
+		case "litellm":
+			return "litellmModelId"
+
+		case "deepinfra":
+			return "deepInfraModelId"
+
+		case "unbound":
+			return "unboundModelId"
+
+		case "requesty":
+			return "requestyModelId"
+
+		case "vercel-ai-gateway":
+			return "vercelAiGatewayModelId"
+
+		case "io-intelligence":
+			return "ioIntelligenceModelId"
+
+		case "huggingface":
+			return "huggingFaceModelId"
+
+		default:
+			// For most other providers, use apiModelId as fallback
+			return "apiModelId"
+	}
+}

--- a/cli/src/state/atoms/config.ts
+++ b/cli/src/state/atoms/config.ts
@@ -8,6 +8,7 @@ import { addCustomTheme, removeCustomTheme, updateCustomTheme } from "../../cons
 import type { Theme } from "../../types/theme.js"
 import { logs } from "../../services/logs.js"
 import { getTelemetryService } from "../../services/telemetry/index.js"
+import { applyEnvOverrides } from "../../config/env-overrides.js"
 
 // Core config atom - holds the current configuration
 export const configAtom = atom<CLIConfig>(DEFAULT_CONFIG)
@@ -55,7 +56,11 @@ export const loadConfigAtom = atom(null, async (get, set, mode?: string) => {
 		set(configValidationAtom, result.validation)
 
 		// Override mode if provided (e.g., from CLI options)
-		const finalConfig = mode ? { ...result.config, mode } : result.config
+		let finalConfig = mode ? { ...result.config, mode } : result.config
+
+		// Apply environment variable overrides
+		finalConfig = applyEnvOverrides(finalConfig)
+
 		set(configAtom, finalConfig)
 
 		if (result.validation.valid) {


### PR DESCRIPTION
## Context

Added support for overriding CLI configuration values using environment variables. This enables users to temporarily override their saved config without modifying the config file, which is particularly useful for testing different providers/models, CI/CD environments, or switching contexts quickly. Any override value is treated as a string.

Closes https://github.com/Kilo-Org/kilocode/issues/3461

## Implementation

**Supported Environment Variables:**

```
 * - KILO_PROVIDER: Override the active provider ID
 * - For Kilocode provider: KILOCODE_<FIELD_NAME> (e.g., KILOCODE_MODEL → kilocodeModel)
 *   Examples:
 *   - KILOCODE_MODEL → kilocodeModel
 *   - KILOCODE_ORGANIZATION_ID → kilocodeOrganizationId
 * - For other providers: KILO_<FIELD_NAME> (e.g., KILO_API_KEY → apiKey)
 *   Examples:
 *   - KILO_API_KEY → apiKey
 *   - KILO_BASE_URL → baseUrl
 *   - KILO_API_MODEL_ID → apiModelId
```

## Screenshots

N/A

## How to Test

Run the CLI with any of the env vars listed above.

## Get in Touch

N/A