### PR TITLE
Revert PR #3533 and fix SQLite bundling

### DIFF
--- a/src/.vscodeignore
+++ b/src/.vscodeignore
@@ -13,6 +13,10 @@
 # Include the built extension
 !dist
 
+# Include sqlite3 and sqlite native bindings
+!dist/node_modules/sqlite3/**
+!dist/node_modules/sqlite/**
+
 # Include the built webview
 !**/*.map
 !webview-ui/audio

--- a/src/.vscodeignore
+++ b/src/.vscodeignore
@@ -13,10 +13,6 @@
 # Include the built extension
 !dist
 
-# Include sqlite3 and sqlite native bindings
-!dist/node_modules/sqlite3/**
-!dist/node_modules/sqlite/**
-
 # Include the built webview
 !**/*.map
 !webview-ui/audio

--- a/src/esbuild.mjs
+++ b/src/esbuild.mjs
@@ -70,47 +70,8 @@ async function main() {
 					// Copy tree-sitter files to dist directory
 					copyPaths([["services/continuedev/tree-sitter", "tree-sitter"]], srcDir, distDir)
 
-					// Copy sqlite3 and sqlite native bindings to dist directory
-					// This is necessary because they are marked as external in esbuild
-					// and contain platform-specific .node binaries that must be included
-					const sqlite3Source = path.join(
-						srcDir,
-						"../node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3",
-					)
-					const sqlite3Dest = path.join(distDir, "node_modules/sqlite3")
-
-					const sqliteSource = path.join(
-						srcDir,
-						"../node_modules/.pnpm/sqlite@5.1.1/node_modules/sqlite",
-					)
-					const sqliteDest = path.join(distDir, "node_modules/sqlite")
-
-					if (fs.existsSync(sqlite3Source)) {
-						try {
-							// Copy the entire sqlite3 module to preserve directory structure
-							// This includes build/Release/node_sqlite3.node and package.json
-							fs.cpSync(sqlite3Source, sqlite3Dest, { recursive: true })
-							console.log(`[${name}] Copied sqlite3 bindings to dist/node_modules/sqlite3`)
-						} catch (err) {
-							console.error(`[${name}] Failed to copy sqlite3 bindings:`, err)
-						}
-					} else {
-						console.warn(`[${name}] sqlite3 source not found at: ${sqlite3Source}`)
-					}
-
-					if (fs.existsSync(sqliteSource)) {
-						try {
-							// Copy the sqlite wrapper module
-							fs.cpSync(sqliteSource, sqliteDest, { recursive: true })
-							console.log(`[${name}] Copied sqlite wrapper to dist/node_modules/sqlite`)
-						} catch (err) {
-							console.error(`[${name}] Failed to copy sqlite wrapper:`, err)
-						}
-					} else {
-						console.warn(`[${name}] sqlite source not found at: ${sqliteSource}`)
-					}
-
 					// Helper function to find and copy a package
+					// This dynamically resolves package locations to avoid hardcoded version numbers
 					const copyPackage = (packageName) => {
 						let packageSource = null
 						try {
@@ -150,6 +111,12 @@ async function main() {
 						}
 					}
 
+					// Copy sqlite3 and sqlite native bindings to dist directory
+					// This is necessary because they are marked as external in esbuild
+					// and contain platform-specific .node binaries that must be included
+					copyPackage("sqlite3")
+					copyPackage("sqlite")
+					
 					// Copy bindings package (required by sqlite3)
 					copyPackage("bindings")
 

--- a/src/services/ghost/GhostServiceManager.ts
+++ b/src/services/ghost/GhostServiceManager.ts
@@ -6,7 +6,7 @@ import { GhostModel } from "./GhostModel"
 import { GhostStatusBar } from "./GhostStatusBar"
 import { GhostCodeActionProvider } from "./GhostCodeActionProvider"
 import { GhostInlineCompletionProvider } from "./classic-auto-complete/GhostInlineCompletionProvider"
-//import { NewAutocompleteProvider } from "./new-auto-complete/NewAutocompleteProvider"
+import { NewAutocompleteProvider } from "./new-auto-complete/NewAutocompleteProvider"
 import { GhostServiceSettings, TelemetryEventName } from "@roo-code/types"
 import { ContextProxy } from "../../core/config/ContextProxy"
 import { ProviderSettingsManager } from "../../core/config/ProviderSettingsManager"
@@ -36,7 +36,7 @@ export class GhostServiceManager {
 	// VSCode Providers
 	public codeActionProvider: GhostCodeActionProvider
 	public inlineCompletionProvider: GhostInlineCompletionProvider
-	//private newAutocompleteProvider: NewAutocompleteProvider | null = null
+	private newAutocompleteProvider: NewAutocompleteProvider | null = null
 	private inlineCompletionProviderDisposable: vscode.Disposable | null = null
 
 	private ignoreController?: Promise<RooIgnoreController>
@@ -126,18 +126,18 @@ export class GhostServiceManager {
 		}
 
 		// Dispose new autocomplete provider if switching away from it
-		//if (!useNewAutocomplete && this.newAutocompleteProvider) {
-		//	this.newAutocompleteProvider.dispose()
-		//	this.newAutocompleteProvider = null
-		//}
+		if (!useNewAutocomplete && this.newAutocompleteProvider) {
+			this.newAutocompleteProvider.dispose()
+			this.newAutocompleteProvider = null
+		}
 
 		if (shouldBeRegistered) {
 			if (useNewAutocomplete) {
 				// Initialize new autocomplete provider if not already created
-				//if (!this.newAutocompleteProvider) {
-				//	this.newAutocompleteProvider = new NewAutocompleteProvider(this.context, this.cline)
-				//	await this.newAutocompleteProvider.load()
-				//}
+				if (!this.newAutocompleteProvider) {
+					this.newAutocompleteProvider = new NewAutocompleteProvider(this.context, this.cline)
+					await this.newAutocompleteProvider.load()
+				}
 				// New autocomplete provider registers itself internally
 			} else {
 				// Register classic provider
@@ -458,10 +458,10 @@ export class GhostServiceManager {
 		}
 
 		// Dispose new autocomplete provider if it exists
-		//if (this.newAutocompleteProvider) {
-		//	this.newAutocompleteProvider.dispose()
-		//	this.newAutocompleteProvider = null
-		//}
+		if (this.newAutocompleteProvider) {
+			this.newAutocompleteProvider.dispose()
+			this.newAutocompleteProvider = null
+		}
 
 		this.disposeIgnoreController()
 

--- a/webview-ui/src/components/kilocode/settings/GhostServiceSettings.tsx
+++ b/webview-ui/src/components/kilocode/settings/GhostServiceSettings.tsx
@@ -75,7 +75,7 @@ export const GhostServiceSettingsView = ({
 					<Bot className="w-4" />
 					<div>{t("kilocode:ghost.title")}</div>
 				</div>
-				IK BEN MARK
+				IK BEN MARK 2
 			</SectionHeader>
 
 			<Section className="flex flex-col gap-5">

--- a/webview-ui/src/components/kilocode/settings/GhostServiceSettings.tsx
+++ b/webview-ui/src/components/kilocode/settings/GhostServiceSettings.tsx
@@ -75,6 +75,7 @@ export const GhostServiceSettingsView = ({
 					<Bot className="w-4" />
 					<div>{t("kilocode:ghost.title")}</div>
 				</div>
+				IK BEN MARK
 			</SectionHeader>
 
 			<Section className="flex flex-col gap-5">

--- a/webview-ui/src/components/kilocode/settings/GhostServiceSettings.tsx
+++ b/webview-ui/src/components/kilocode/settings/GhostServiceSettings.tsx
@@ -75,7 +75,7 @@ export const GhostServiceSettingsView = ({
 					<Bot className="w-4" />
 					<div>{t("kilocode:ghost.title")}</div>
 				</div>
-				IK BEN MARK 2
+				IK BEN MARK 3
 			</SectionHeader>
 
 			<Section className="flex flex-col gap-5">


### PR DESCRIPTION
This commit reverts PR #3533 which disabled NewAutocompleteProvider due to SQLite bundling issues. The proper fix is to bundle SQLite native binaries following Continue's approach.

Changes:
- Restored NewAutocompleteProvider in GhostServiceManager.ts
- Added .node loader to esbuild.mjs to handle native binary modules
- Added build step to copy sqlite3 and sqlite modules to dist/node_modules/
- Updated .vscodeignore to include SQLite modules in VSIX package
- Fixed sqlite3 mock in AutocompleteLruCache.spec.ts to include default export

The extension will now properly load SQLite at runtime from the bundled node_modules, allowing NewAutocompleteProvider to work in production.

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
