### PR TITLE
feat(cli/ovhcloud): Add OVHcloud AI Endpoints to CLI

### DIFF
--- a/.changeset/bitter-donkeys-tease.md
+++ b/.changeset/bitter-donkeys-tease.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Add OVHcloud AI Endpoints provider to Kilocode CLI

--- a/cli/docs/PROVIDER_CONFIGURATION.md
+++ b/cli/docs/PROVIDER_CONFIGURATION.md
@@ -45,6 +45,7 @@ This guide provides detailed information on how to configure each provider in Ki
     - [Virtual Quota Fallback](#virtual-quota-fallback)
     - [Human Relay](#human-relay)
     - [Fake AI](#fake-ai)
+    - [OVHcloud AI Endpoints](#ovhcloud-ai-endpoints)
 
 ## Introduction
 
@@ -1319,6 +1320,41 @@ Fake AI provider for testing and development.
 - Used for testing and development
 - Returns mock responses without calling any actual AI service
 - Useful for integration testing
+
+---
+
+### OVHcloud AI Endpoints
+
+OVHcloud AI Endpoints inference provider.
+
+**Description**: Use OVHcloud leading cloud computing for accessing various open-source models, with GDPR compliance and data sovreignty.
+
+**Required Field**:
+
+- `ovhCloudAiEndpointsModelId` (text): Model identifier (default: `gpt-oss-120b`)
+
+**Optional Field**:
+
+- `ovhCloudAiEndpointsApiKey` (password): Your OVHcloud AI Endpoints API key
+  If you do not provide the API key, you can use our service for free with a rate limit.
+
+**Example Configuration**:
+
+```json
+{
+	"id": "default",
+	"provider": "ovhcloud",
+	"ovhCloudAiEndpointsApiKey": "your-api-key", // optional
+	"ovhCloudAiEndpointsModelId": "gpt-oss-120b"
+}
+```
+
+**Default Model**: `gpt-oss-120b`
+
+**Notes**:
+
+- Get your API key from https://ovh.com/manager in `Public Cloud > AI & Machine Learning` section, then in `AI Endpoints`.
+- You can browse our [catalog](https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/) to discover all of our models.
 
 ---
 

--- a/cli/src/commands/__tests__/model.test.ts
+++ b/cli/src/commands/__tests__/model.test.ts
@@ -41,6 +41,7 @@ describe("/model command", () => {
 		"io-intelligence": {},
 		deepinfra: {},
 		"vercel-ai-gateway": {},
+		ovhcloud: {},
 	}
 
 	const mockProvider: ProviderConfig = {
@@ -404,6 +405,7 @@ describe("/model command", () => {
 				"io-intelligence": {},
 				deepinfra: {},
 				"vercel-ai-gateway": {},
+				ovhcloud: {},
 			}
 			mockContext.args = ["list"]
 

--- a/cli/src/commands/model.ts
+++ b/cli/src/commands/model.ts
@@ -37,6 +37,7 @@ async function ensureRouterModels(context: any): Promise<boolean> {
 		"deepinfra",
 		"io-intelligence",
 		"vercel-ai-gateway",
+		"ovhcloud",
 	].includes(routerName)
 
 	if (!needsRouterModels) {

--- a/cli/src/config/mapper.ts
+++ b/cli/src/config/mapper.ts
@@ -88,6 +88,8 @@ function getModelIdForProvider(provider: ProviderConfig): string {
 			return provider.vercelAiGatewayModelId || ""
 		case "io-intelligence":
 			return provider.ioIntelligenceModelId || ""
+		case "ovhcloud":
+			return provider.ovhCloudAiEndpointsModelId || ""
 		default:
 			return provider.apiModelId || provider.modelId || ""
 	}

--- a/cli/src/config/schema.json
+++ b/cli/src/config/schema.json
@@ -264,7 +264,8 @@
 						"vercel-ai-gateway",
 						"virtual-quota-fallback",
 						"human-relay",
-						"fake-ai"
+						"fake-ai",
+						"ovhcloud"
 					]
 				}
 			},
@@ -2127,6 +2128,48 @@
 									"family": { "minLength": 1 }
 								}
 							}
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": { "provider": { "const": "ovhcloud" } }
+					},
+					"then": {
+						"properties": {
+							"ovhCloudAiEndpointsApiKey": {
+								"type": "string",
+								"description": "OVHcloud AI Endpoints API key"
+							},
+							"ovhCloudAiEndpointsModelId": {
+								"type": "string",
+								"description": "OVHcloud AI Endpoints model ID"
+							}
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": { "provider": { "const": "ovhcloud" } }
+					},
+					"then": {
+						"properties": {
+							"ovhCloudAiEndpointsApiKey": { "type": "string" }
+						},
+						"required": []
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"provider": { "const": "ovhcloud" },
+							"ovhCloudAiEndpointsModelId": { "type": "string", "minLength": 1 }
+						},
+						"required": ["ovhCloudAiEndpointsModelId"]
+					},
+					"then": {
+						"properties": {
+							"ovhCloudAiEndpointsModelId": { "minLength": 1 }
 						}
 					}
 				}

--- a/cli/src/constants/providers/__tests__/models.test.ts
+++ b/cli/src/constants/providers/__tests__/models.test.ts
@@ -215,6 +215,7 @@ describe("Static Provider Models", () => {
 			"io-intelligence": {},
 			deepinfra: {},
 			"vercel-ai-gateway": {},
+			ovhcloud: {},
 		}
 
 		it("should return router models for openrouter provider", () => {

--- a/cli/src/constants/providers/labels.ts
+++ b/cli/src/constants/providers/labels.ts
@@ -44,6 +44,7 @@ export const PROVIDER_LABELS: Record<ProviderName, string> = {
 	"virtual-quota-fallback": "Virtual Quota Fallback",
 	"human-relay": "Human Relay",
 	"fake-ai": "Fake AI",
+	ovhcloud: "OVHcloud AI Endpoints",
 }
 
 /**

--- a/cli/src/constants/providers/models.ts
+++ b/cli/src/constants/providers/models.ts
@@ -47,6 +47,7 @@ import {
 	geminiCliDefaultModelId,
 	minimaxModels,
 	minimaxDefaultModelId,
+	ovhCloudAiEndpointsDefaultModelId,
 } from "@roo-code/types"
 
 /**
@@ -64,6 +65,7 @@ export type RouterName =
 	| "io-intelligence"
 	| "deepinfra"
 	| "vercel-ai-gateway"
+	| "ovhcloud"
 
 /**
  * ModelInfo interface - mirrors the one from packages/types/src/model.ts
@@ -107,6 +109,7 @@ export const PROVIDER_TO_ROUTER_NAME: Record<ProviderName, RouterName | null> = 
 	deepinfra: "deepinfra",
 	"io-intelligence": "io-intelligence",
 	"vercel-ai-gateway": "vercel-ai-gateway",
+	ovhcloud: "ovhcloud",
 	// Providers without dynamic model support
 	anthropic: null,
 	bedrock: null,
@@ -153,6 +156,7 @@ export const PROVIDER_MODEL_FIELD: Record<ProviderName, string | null> = {
 	deepinfra: "deepInfraModelId",
 	"io-intelligence": "ioIntelligenceModelId",
 	"vercel-ai-gateway": "vercelAiGatewayModelId",
+	ovhcloud: "ovhCloudAiEndpointsModelId",
 	// Providers without dynamic model support
 	anthropic: null,
 	bedrock: null,
@@ -247,6 +251,7 @@ export const DEFAULT_MODEL_IDS: Partial<Record<ProviderName, string>> = {
 	zai: internationalZAiDefaultModelId,
 	roo: rooDefaultModelId,
 	"gemini-cli": geminiCliDefaultModelId,
+	ovhcloud: ovhCloudAiEndpointsDefaultModelId,
 }
 
 /**
@@ -423,6 +428,8 @@ export function getModelIdKey(provider: ProviderName): string {
 			return "ioIntelligenceModelId"
 		case "vercel-ai-gateway":
 			return "vercelAiGatewayModelId"
+		case "ovhcloud":
+			return "ovhCloudAiEndpointsModelId"
 		default:
 			return "apiModelId"
 	}

--- a/cli/src/constants/providers/settings.ts
+++ b/cli/src/constants/providers/settings.ts
@@ -464,6 +464,18 @@ export const FIELD_REGISTRY: Record<string, FieldMetadata> = {
 		placeholder: "Enter model ID...",
 	},
 
+	// OVHcloud AI Endpoints fields
+	ovhCloudAiEndpointsApiKey: {
+		label: "API Key",
+		type: "password",
+		placeholder: "Enter OVHcloud AI Endpoints API key...",
+	},
+	ovhCloudAiEndpointsModelId: {
+		label: "Model ID",
+		type: "text",
+		placeholder: "Enter model ID...",
+	},
+
 	// Virtual Quota Fallback fields
 	profiles: {
 		label: "Profiles Configuration",
@@ -795,6 +807,12 @@ export const getProviderSettings = (provider: ProviderName, config: ProviderSett
 				},
 			]
 
+		case "ovhcloud":
+			return [
+				createFieldConfig("ovhCloudAiEndpointsApiKey", config),
+				createFieldConfig("ovhCloudAiEndpointsModelId", config, "gpt-oss-120b"),
+			]
+
 		default:
 			return []
 	}
@@ -843,6 +861,7 @@ export const PROVIDER_DEFAULT_MODELS: Record<ProviderName, string> = {
 	"human-relay": "human",
 	minimax: "MiniMax-M2",
 	"fake-ai": "fake-model",
+	ovhcloud: "gpt-oss-120b",
 }
 
 /**

--- a/cli/src/constants/providers/validation.ts
+++ b/cli/src/constants/providers/validation.ts
@@ -40,6 +40,7 @@ export const PROVIDER_REQUIRED_FIELDS: Record<ProviderName, string[]> = {
 	"vercel-ai-gateway": ["vercelAiGatewayApiKey", "vercelAiGatewayModelId"],
 	"human-relay": ["apiModelId"],
 	"fake-ai": ["apiModelId"],
+	ovhcloud: ["ovhCloudAiEndpointsModelId"],
 	// Special cases handled separately in handleSpecialValidations
 	vertex: [], // Has special validation logic (either/or fields)
 	"vscode-lm": [], // Has nested object validation

--- a/cli/src/types/messages.ts
+++ b/cli/src/types/messages.ts
@@ -104,6 +104,7 @@ export type ProviderName =
 	| "roo"
 	| "vercel-ai-gateway"
 	| "minimax"
+	| "ovhcloud"
 
 // Provider Settings Entry for profile metadata
 export interface ProviderSettingsEntry {
@@ -324,6 +325,10 @@ export interface ProviderSettings {
 	// MiniMax AI
 	minimaxBaseUrl?: "https://api.minimax.io/anthropic" | "https://api.minimaxi.com/anthropic"
 	minimaxApiKey?: string
+
+	// OVHcloud AI Endpoints
+	ovhCloudAiEndpointsApiKey?: string
+	ovhCloudAiEndpointsModelId?: string
 
 	// Allow additional fields for extensibility
 	[key: string]: any

--- a/cli/src/utils/__tests__/providers.test.ts
+++ b/cli/src/utils/__tests__/providers.test.ts
@@ -65,6 +65,12 @@ describe("getSelectedModelId", () => {
 		expect(result).toBe("litellm-model-1")
 	})
 
+	it("should return correct model for OVHcloud AI Endpoints provider", () => {
+		const apiConfig = { ovhCloudAiEndpointsModelId: "ovhcloud-model" }
+		const result = getSelectedModelId("ovhcloud", apiConfig)
+		expect(result).toBe("ovhcloud-model")
+	})
+
 	it("should return 'unknown' when model field is not set", () => {
 		const apiConfig = { someOtherField: "value" }
 		const result = getSelectedModelId("kilocode", apiConfig)


### PR DESCRIPTION
## Context

Implementation of OVHcloud AI Endpoints in Kilo Code CLI, since it's already in Kilo Code

## How to Test

Run kilo code config, and add this config:
```
{
	"id": "default",
	"provider": "ovhcloud",
	"ovhCloudAiEndpointsModelId": "gpt-oss-120b"
}

```
You can let the api key empty for using it for free (with a rate limit)

## Get in Touch

I'm on the Discord server as @eliqsx :)
