### PR TITLE
Revert "Let GhostServiceManager handle defaults"

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2158,7 +2158,10 @@ ${prompt}
 			sharingEnabled: sharingEnabled ?? false,
 			organizationAllowList,
 			// kilocode_change start
-			ghostServiceSettings: ghostServiceSettings,
+			ghostServiceSettings: ghostServiceSettings ?? {
+				enableQuickInlineTaskKeybinding: true,
+				enableSmartInlineTaskKeybinding: true,
+			},
 			// kilocode_change end
 			organizationSettingsVersion,
 			condensingApiConfigId,
@@ -2387,7 +2390,10 @@ ${prompt}
 			commitMessageApiConfigId: stateValues.commitMessageApiConfigId, // kilocode_change
 			terminalCommandApiConfigId: stateValues.terminalCommandApiConfigId, // kilocode_change
 			// kilocode_change start
-			ghostServiceSettings: stateValues.ghostServiceSettings,
+			ghostServiceSettings: stateValues.ghostServiceSettings ?? {
+				enableQuickInlineTaskKeybinding: true,
+				enableSmartInlineTaskKeybinding: true,
+			},
 			// kilocode_change end
 			// kilocode_change start - Auto-purge settings
 			autoPurgeEnabled: stateValues.autoPurgeEnabled ?? false,


### PR DESCRIPTION
Reverts Kilo-Org/kilocode#3563

this changes the default from
<img width="730" height="762" alt="CleanShot 2025-11-07 at 10 39 10@2x" src="https://github.com/user-attachments/assets/9bd197ed-dabc-448f-8d93-f2c3ad549fe9" />

to
<img width="728" height="732" alt="CleanShot 2025-11-07 at 10 39 29@2x" src="https://github.com/user-attachments/assets/a4305c57-765b-43d9-a072-6d3338a802d0" />

