### PR TITLE
never show unknown, instead show friendly warning provider wasnt found

### DIFF
--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -109,20 +109,20 @@ export class GhostModel {
 		}
 	}
 
-	public getModelName(): string | null {
-		if (!this.apiHandler) return null
+	public getModelName(): string | undefined {
+		if (!this.apiHandler) return undefined
 
-		return this.apiHandler.getModel().id ?? "unknown"
+		return this.apiHandler.getModel().id ?? undefined
 	}
 
-	public getProviderDisplayName(): string | null {
-		if (!this.apiHandler) return null
+	public getProviderDisplayName(): string | undefined {
+		if (!this.apiHandler) return undefined
 
 		const handler = this.apiHandler as any
 		if (handler.providerName && typeof handler.providerName === "string") {
 			return handler.providerName
 		} else {
-			return "unknown"
+			return undefined
 		}
 	}
 

--- a/src/services/ghost/GhostServiceManager.ts
+++ b/src/services/ghost/GhostServiceManager.ts
@@ -333,18 +333,18 @@ export class GhostServiceManager {
 		})
 	}
 
-	private getCurrentModelName(): string {
+	private getCurrentModelName(): string | undefined {
 		if (!this.model.loaded) {
-			return "loading..."
+			return
 		}
-		return this.model.getModelName() ?? "unknown"
+		return this.model.getModelName()
 	}
 
-	private getCurrentProviderName(): string {
+	private getCurrentProviderName(): string | undefined {
 		if (!this.model.loaded) {
-			return "loading..."
+			return
 		}
-		return this.model.getProviderDisplayName() ?? "unknown"
+		return this.model.getProviderDisplayName()
 	}
 
 	private hasValidApiToken(): boolean {

--- a/src/services/ghost/__tests__/GhostModel.spec.ts
+++ b/src/services/ghost/__tests__/GhostModel.spec.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { GhostModel } from "../GhostModel"
 import { ProviderSettingsManager } from "../../../core/config/ProviderSettingsManager"
 import { AUTOCOMPLETE_PROVIDER_MODELS } from "../utils/kilocode-utils"
+import * as apiIndex from "../../../api"
 
 describe("GhostModel", () => {
 	let mockProviderSettingsManager: ProviderSettingsManager
@@ -314,12 +315,25 @@ describe("GhostModel", () => {
 				mistralApiKey: "test-key",
 			} as any)
 
+			// Mock buildApiHandler to return a handler with providerName
+			const mockApiHandler = {
+				providerName: "Test Provider",
+				getModel: vi.fn().mockReturnValue({ id: "test-model", info: {} }),
+				createMessage: vi.fn(),
+				countTokens: vi.fn(),
+			}
+			vi.spyOn(apiIndex, "buildApiHandler").mockReturnValue(mockApiHandler as any)
+
 			const model = new GhostModel()
 			await model.reload(mockProviderSettingsManager)
 
 			const providerName = model.getProviderDisplayName()
 			expect(providerName).toBeTruthy()
 			expect(typeof providerName).toBe("string")
+			expect(providerName).toBe("Test Provider")
+
+			// Restore the spy
+			vi.restoreAllMocks()
 		})
 	})
 })

--- a/src/services/ghost/__tests__/GhostModel.spec.ts
+++ b/src/services/ghost/__tests__/GhostModel.spec.ts
@@ -297,9 +297,9 @@ describe("GhostModel", () => {
 	})
 
 	describe("getProviderDisplayName", () => {
-		it("returns null when no provider is loaded", () => {
+		it("returns undefined when no provider is loaded", () => {
 			const model = new GhostModel()
-			expect(model.getProviderDisplayName()).toBeNull()
+			expect(model.getProviderDisplayName()).toBeUndefined()
 		})
 
 		it("returns provider name from API handler when provider is loaded", async () => {


### PR DESCRIPTION
I don't want to have two 'empty' states as it is utterly confusing

switch to always showing this if model / provider isnt found:
<img width="710" height="200" alt="CleanShot 2025-11-07 at 13 36 50@2x" src="https://github.com/user-attachments/assets/95bfd439-e5ac-401d-9eca-537723832930" />
