### PR TITLE
cleanups in autocomplete loading

### DIFF
--- a/packages/types/src/__tests__/kilocode.test.ts
+++ b/packages/types/src/__tests__/kilocode.test.ts
@@ -1,9 +1,8 @@
 // npx vitest run src/__tests__/kilocode.test.ts
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { describe, it, expect, vi, afterEach } from "vitest"
 import {
 	ghostServiceSettingsSchema,
-	checkKilocodeBalance,
 	getAppUrl,
 	getKiloUrlFromToken,
 	getExtensionConfigUrl,
@@ -33,118 +32,6 @@ describe("ghostServiceSettingsSchema", () => {
 			enableAutoTrigger: true,
 		})
 		expect(result.success).toBe(true)
-	})
-})
-
-describe("checkKilocodeBalance", () => {
-	const mockToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbnYiOiJwcm9kdWN0aW9uIn0.test"
-	const mockOrgId = "org-123"
-
-	beforeEach(() => {
-		global.fetch = vi.fn()
-	})
-
-	afterEach(() => {
-		vi.restoreAllMocks()
-	})
-
-	it("should return true when balance is positive", async () => {
-		vi.mocked(global.fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ balance: 100 }),
-		} as Response)
-
-		const result = await checkKilocodeBalance(mockToken)
-		expect(result).toBe(true)
-		expect(global.fetch).toHaveBeenCalledWith(
-			"https://api.kilocode.ai/api/profile/balance",
-			expect.objectContaining({
-				headers: expect.objectContaining({
-					Authorization: `Bearer ${mockToken}`,
-				}),
-			}),
-		)
-	})
-
-	it("should return false when balance is zero", async () => {
-		vi.mocked(global.fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ balance: 0 }),
-		} as Response)
-
-		const result = await checkKilocodeBalance(mockToken)
-		expect(result).toBe(false)
-	})
-
-	it("should return false when balance is negative", async () => {
-		vi.mocked(global.fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ balance: -10 }),
-		} as Response)
-
-		const result = await checkKilocodeBalance(mockToken)
-		expect(result).toBe(false)
-	})
-
-	it("should include organization ID in headers when provided", async () => {
-		vi.mocked(global.fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ balance: 100 }),
-		} as Response)
-
-		const result = await checkKilocodeBalance(mockToken, mockOrgId)
-		expect(result).toBe(true)
-		expect(global.fetch).toHaveBeenCalledWith(
-			"https://api.kilocode.ai/api/profile/balance",
-			expect.objectContaining({
-				headers: expect.objectContaining({
-					Authorization: `Bearer ${mockToken}`,
-					"X-KiloCode-OrganizationId": mockOrgId,
-				}),
-			}),
-		)
-	})
-
-	it("should not include organization ID in headers when not provided", async () => {
-		vi.mocked(global.fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ balance: 100 }),
-		} as Response)
-
-		await checkKilocodeBalance(mockToken)
-
-		const fetchCall = vi.mocked(global.fetch).mock.calls[0]
-		expect(fetchCall).toBeDefined()
-		const headers = (fetchCall![1] as RequestInit)?.headers as Record<string, string>
-
-		expect(headers).toHaveProperty("Authorization")
-		expect(headers).not.toHaveProperty("X-KiloCode-OrganizationId")
-	})
-
-	it("should return false when API request fails", async () => {
-		vi.mocked(global.fetch).mockResolvedValueOnce({
-			ok: false,
-		} as Response)
-
-		const result = await checkKilocodeBalance(mockToken)
-		expect(result).toBe(false)
-	})
-
-	it("should return false when fetch throws an error", async () => {
-		vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Network error"))
-
-		const result = await checkKilocodeBalance(mockToken)
-		expect(result).toBe(false)
-	})
-
-	it("should handle missing balance field in response", async () => {
-		vi.mocked(global.fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({}),
-		} as Response)
-
-		const result = await checkKilocodeBalance(mockToken)
-		expect(result).toBe(false)
 	})
 })
 

--- a/packages/types/src/kilocode/kilocode.ts
+++ b/packages/types/src/kilocode/kilocode.ts
@@ -1,5 +1,4 @@
 import { z } from "zod"
-import { ProviderSettings, ProviderSettingsEntry } from "../provider-settings.js"
 
 declare global {
 	interface Window {
@@ -116,86 +115,4 @@ export function getExtensionConfigUrl(): string {
 		console.warn("Failed to build extension config URL:", error)
 		return "https://api.kilocode.ai/extension-config.json"
 	}
-}
-
-/**
- * Check if the Kilocode account has a positive balance
- * @param kilocodeToken - The Kilocode JWT token
- * @param kilocodeOrganizationId - Optional organization ID to include in headers
- * @returns Promise<boolean> - True if balance > 0, false otherwise
- */
-export async function checkKilocodeBalance(kilocodeToken: string, kilocodeOrganizationId?: string): Promise<boolean> {
-	try {
-		const baseUrl = getKiloBaseUriFromToken(kilocodeToken)
-
-		const headers: Record<string, string> = {
-			Authorization: `Bearer ${kilocodeToken}`,
-		}
-
-		if (kilocodeOrganizationId) {
-			headers["X-KiloCode-OrganizationId"] = kilocodeOrganizationId
-		}
-
-		const response = await fetch(`${baseUrl}/api/profile/balance`, {
-			headers,
-		})
-
-		if (!response.ok) {
-			return false
-		}
-
-		const data = await response.json()
-		const balance = data.balance ?? 0
-		return balance > 0
-	} catch (error) {
-		console.error("Error checking kilocode balance:", error)
-		return false
-	}
-}
-
-export const AUTOCOMPLETE_PROVIDER_MODELS = {
-	mistral: "codestral-latest",
-	kilocode: "mistralai/codestral-2508",
-	openrouter: "mistralai/codestral-2508",
-	bedrock: "mistral.codestral-2508-v1:0",
-} as const
-export type AutocompleteProviderKey = keyof typeof AUTOCOMPLETE_PROVIDER_MODELS
-
-interface ProviderSettingsManager {
-	listConfig(): Promise<ProviderSettingsEntry[]>
-	getProfile(params: { id: string }): Promise<ProviderSettings>
-}
-
-export type ProviderUsabilityChecker = (
-	provider: AutocompleteProviderKey,
-	providerSettingsManager: ProviderSettingsManager,
-) => Promise<boolean>
-
-export const defaultProviderUsabilityChecker: ProviderUsabilityChecker = async (provider, providerSettingsManager) => {
-	if (provider === "kilocode") {
-		try {
-			const profiles = await providerSettingsManager.listConfig()
-			const kilocodeProfile = profiles.find((p) => p.apiProvider === "kilocode")
-
-			if (!kilocodeProfile) {
-				return false
-			}
-
-			const profile = await providerSettingsManager.getProfile({ id: kilocodeProfile.id })
-			const kilocodeToken = profile.kilocodeToken
-			const kilocodeOrgId = profile.kilocodeOrganizationId
-
-			if (!kilocodeToken) {
-				return false
-			}
-
-			return await checkKilocodeBalance(kilocodeToken, kilocodeOrgId)
-		} catch (error) {
-			console.error("Error checking kilocode balance:", error)
-			return false
-		}
-	}
-
-	// For all other providers, assume they are usable
-	return true
 }

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -29,17 +29,13 @@ export class GhostModel {
 		for (const [provider, model] of AUTOCOMPLETE_PROVIDER_MAP) {
 			const selectedProfile = profiles.find((x) => x?.apiProvider === provider)
 			if (!selectedProfile) continue
+			const profile = await providerSettingsManager.getProfile({ id: selectedProfile.id })
 
 			if (provider === "kilocode") {
 				// For all other providers, assume they are usable
-				const profile = await providerSettingsManager.getProfile({ id: selectedProfile.id })
 				if (!profile.kilocodeToken) continue
 				if (!(await checkKilocodeBalance(profile.kilocodeToken, profile.kilocodeOrganizationId))) continue
 			}
-
-			const profile = await providerSettingsManager.getProfile({
-				id: selectedProfile.id,
-			})
 
 			this.apiHandler = buildApiHandler({
 				...profile,

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -1,13 +1,9 @@
-import {
-	AUTOCOMPLETE_PROVIDER_MODELS,
-	defaultProviderUsabilityChecker,
-	modelIdKeysByProvider,
-	ProviderSettingsEntry,
-} from "@roo-code/types"
+import { modelIdKeysByProvider, ProviderSettingsEntry } from "@roo-code/types"
 import { ApiHandler, buildApiHandler } from "../../api"
 import { ProviderSettingsManager } from "../../core/config/ProviderSettingsManager"
 import { OpenRouterHandler } from "../../api/providers"
 import { ApiStreamChunk } from "../../api/transform/stream"
+import { AUTOCOMPLETE_PROVIDER_MODELS, defaultProviderUsabilityChecker } from "./utils/kilocode-utils"
 
 export class GhostModel {
 	private apiHandler: ApiHandler | null = null

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -35,9 +35,6 @@ export class GhostModel {
 
 			if (provider === "kilocode") {
 				// For all other providers, assume they are usable
-
-				if (!selectedProfile) continue
-
 				const profile = await providerSettingsManager.getProfile({ id: selectedProfile.id })
 				const kilocodeToken = profile.kilocodeToken
 				const kilocodeOrgId = profile.kilocodeOrganizationId

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -3,7 +3,7 @@ import { ApiHandler, buildApiHandler } from "../../api"
 import { ProviderSettingsManager } from "../../core/config/ProviderSettingsManager"
 import { OpenRouterHandler } from "../../api/providers"
 import { ApiStreamChunk } from "../../api/transform/stream"
-import { AUTOCOMPLETE_PROVIDER_MODELS, checkKilocodeBalance } from "./utils/kilocode-utils"
+import { AUTOCOMPLETE_PROVIDER_MAP, AUTOCOMPLETE_PROVIDER_MODELS, checkKilocodeBalance } from "./utils/kilocode-utils"
 
 export class GhostModel {
 	private apiHandler: ApiHandler | null = null
@@ -22,14 +22,11 @@ export class GhostModel {
 
 	public async reload(providerSettingsManager: ProviderSettingsManager): Promise<boolean> {
 		const profiles = await providerSettingsManager.listConfig()
-		const supportedProviders = Object.keys(AUTOCOMPLETE_PROVIDER_MODELS) as Array<
-			keyof typeof AUTOCOMPLETE_PROVIDER_MODELS
-		>
 
 		this.cleanup()
 
 		// Check providers in order, but skip unusable ones (e.g., kilocode with zero balance)
-		for (const provider of supportedProviders) {
+		for (const [provider, model] of AUTOCOMPLETE_PROVIDER_MAP) {
 			const selectedProfile = profiles.find((x) => x?.apiProvider === provider)
 			if (!selectedProfile) continue
 
@@ -46,7 +43,7 @@ export class GhostModel {
 
 			this.apiHandler = buildApiHandler({
 				...profile,
-				[modelIdKeysByProvider[provider]]: AUTOCOMPLETE_PROVIDER_MODELS[provider],
+				[modelIdKeysByProvider[provider]]: model,
 			})
 
 			if (this.apiHandler instanceof OpenRouterHandler) {

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -30,9 +30,7 @@ export class GhostModel {
 
 		// Check providers in order, but skip unusable ones (e.g., kilocode with zero balance)
 		for (const provider of supportedProviders) {
-			const selectedProfile = profiles.find(
-				(x): x is typeof x & { apiProvider: string } => x?.apiProvider === provider,
-			)
+			const selectedProfile = profiles.find((x) => x?.apiProvider === provider)
 			if (selectedProfile) {
 				const isUsable = await defaultProviderUsabilityChecker(provider, providerSettingsManager)
 				if (!isUsable) continue

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -36,11 +36,8 @@ export class GhostModel {
 			if (provider === "kilocode") {
 				// For all other providers, assume they are usable
 				const profile = await providerSettingsManager.getProfile({ id: selectedProfile.id })
-				const kilocodeToken = profile.kilocodeToken
-				const kilocodeOrgId = profile.kilocodeOrganizationId
-
-				if (!kilocodeToken) continue
-				if (!(await checkKilocodeBalance(kilocodeToken, kilocodeOrgId))) continue
+				if (!profile.kilocodeToken) continue
+				if (!(await checkKilocodeBalance(profile.kilocodeToken, profile.kilocodeOrganizationId))) continue
 			}
 
 			this.loadProfile(providerSettingsManager, selectedProfile, provider)

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -31,14 +31,13 @@ export class GhostModel {
 		// Check providers in order, but skip unusable ones (e.g., kilocode with zero balance)
 		for (const provider of supportedProviders) {
 			const selectedProfile = profiles.find((x) => x?.apiProvider === provider)
-			if (selectedProfile) {
-				const isUsable = await defaultProviderUsabilityChecker(provider, providerSettingsManager)
-				if (!isUsable) continue
+			if (!selectedProfile) continue
+			const isUsable = await defaultProviderUsabilityChecker(provider, providerSettingsManager)
+			if (!isUsable) continue
 
-				this.loadProfile(providerSettingsManager, selectedProfile, provider)
-				this.loaded = true
-				return true
-			}
+			this.loadProfile(providerSettingsManager, selectedProfile, provider)
+			this.loaded = true
+			return true
 		}
 
 		this.loaded = true // we loaded, and found nothing, but we do not wish to reload

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -35,11 +35,10 @@ export class GhostModel {
 
 			if (provider === "kilocode") {
 				// For all other providers, assume they are usable
-				const kilocodeProfile = selectedProfile
 
-				if (!kilocodeProfile) continue
+				if (!selectedProfile) continue
 
-				const profile = await providerSettingsManager.getProfile({ id: kilocodeProfile.id })
+				const profile = await providerSettingsManager.getProfile({ id: selectedProfile.id })
 				const kilocodeToken = profile.kilocodeToken
 				const kilocodeOrgId = profile.kilocodeOrganizationId
 

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -35,7 +35,6 @@ export class GhostModel {
 
 			if (provider === "kilocode") {
 				// For all other providers, assume they are usable
-				const profiles = await providerSettingsManager.listConfig()
 				const kilocodeProfile = profiles.find((p) => p.apiProvider === "kilocode")
 
 				if (!kilocodeProfile) continue

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -37,10 +37,7 @@ export class GhostModel {
 				if (!(await checkKilocodeBalance(profile.kilocodeToken, profile.kilocodeOrganizationId))) continue
 			}
 
-			this.apiHandler = buildApiHandler({
-				...profile,
-				[modelIdKeysByProvider[provider]]: model,
-			})
+			this.apiHandler = buildApiHandler({ ...profile, [modelIdKeysByProvider[provider]]: model })
 
 			if (this.apiHandler instanceof OpenRouterHandler) {
 				await this.apiHandler.fetchModel()

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -3,7 +3,7 @@ import { ApiHandler, buildApiHandler } from "../../api"
 import { ProviderSettingsManager } from "../../core/config/ProviderSettingsManager"
 import { OpenRouterHandler } from "../../api/providers"
 import { ApiStreamChunk } from "../../api/transform/stream"
-import { AUTOCOMPLETE_PROVIDER_MAP, AUTOCOMPLETE_PROVIDER_MODELS, checkKilocodeBalance } from "./utils/kilocode-utils"
+import { AUTOCOMPLETE_PROVIDER_MODELS, checkKilocodeBalance } from "./utils/kilocode-utils"
 
 export class GhostModel {
 	private apiHandler: ApiHandler | null = null
@@ -26,7 +26,7 @@ export class GhostModel {
 		this.cleanup()
 
 		// Check providers in order, but skip unusable ones (e.g., kilocode with zero balance)
-		for (const [provider, model] of AUTOCOMPLETE_PROVIDER_MAP) {
+		for (const [provider, model] of AUTOCOMPLETE_PROVIDER_MODELS) {
 			const selectedProfile = profiles.find((x) => x?.apiProvider === provider)
 			if (!selectedProfile) continue
 			const profile = await providerSettingsManager.getProfile({ id: selectedProfile.id })

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -40,32 +40,24 @@ export class GhostModel {
 				if (!(await checkKilocodeBalance(profile.kilocodeToken, profile.kilocodeOrganizationId))) continue
 			}
 
-			this.loadProfile(providerSettingsManager, selectedProfile, provider)
+			const profile = await providerSettingsManager.getProfile({
+				id: selectedProfile.id,
+			})
+
+			this.apiHandler = buildApiHandler({
+				...profile,
+				[modelIdKeysByProvider[provider]]: AUTOCOMPLETE_PROVIDER_MODELS[provider],
+			})
+
+			if (this.apiHandler instanceof OpenRouterHandler) {
+				await this.apiHandler.fetchModel()
+			}
 			this.loaded = true
 			return true
 		}
 
 		this.loaded = true // we loaded, and found nothing, but we do not wish to reload
 		return false
-	}
-
-	public async loadProfile(
-		providerSettingsManager: ProviderSettingsManager,
-		selectedProfile: ProviderSettingsEntry,
-		provider: keyof typeof AUTOCOMPLETE_PROVIDER_MODELS,
-	): Promise<void> {
-		const profile = await providerSettingsManager.getProfile({
-			id: selectedProfile.id,
-		})
-
-		this.apiHandler = buildApiHandler({
-			...profile,
-			[modelIdKeysByProvider[provider]]: AUTOCOMPLETE_PROVIDER_MODELS[provider],
-		})
-
-		if (this.apiHandler instanceof OpenRouterHandler) {
-			await this.apiHandler.fetchModel()
-		}
 	}
 
 	/**

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -35,7 +35,7 @@ export class GhostModel {
 
 			if (provider === "kilocode") {
 				// For all other providers, assume they are usable
-				const kilocodeProfile = profiles.find((p) => p.apiProvider === "kilocode")
+				const kilocodeProfile = selectedProfile
 
 				if (!kilocodeProfile) continue
 

--- a/src/services/ghost/__tests__/GhostModel.spec.ts
+++ b/src/services/ghost/__tests__/GhostModel.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { GhostModel } from "../GhostModel"
 import { ProviderSettingsManager } from "../../../core/config/ProviderSettingsManager"
-import { AUTOCOMPLETE_PROVIDER_MODELS } from "@roo-code/types"
+import { AUTOCOMPLETE_PROVIDER_MODELS } from "../utils/kilocode-utils"
 
 describe("GhostModel", () => {
 	let mockProviderSettingsManager: ProviderSettingsManager

--- a/src/services/ghost/__tests__/GhostModel.spec.ts
+++ b/src/services/ghost/__tests__/GhostModel.spec.ts
@@ -15,7 +15,7 @@ describe("GhostModel", () => {
 
 	describe("reload", () => {
 		it("sorts profiles by supportedProviders index order", async () => {
-			const supportedProviders = Object.keys(AUTOCOMPLETE_PROVIDER_MODELS)
+			const supportedProviders = [...AUTOCOMPLETE_PROVIDER_MODELS.keys()]
 			const profiles = [
 				{ id: "3", name: "profile3", apiProvider: supportedProviders[2] },
 				{ id: "1", name: "profile1", apiProvider: supportedProviders[0] },
@@ -37,7 +37,7 @@ describe("GhostModel", () => {
 		})
 
 		it("filters out profiles without apiProvider", async () => {
-			const supportedProviders = Object.keys(AUTOCOMPLETE_PROVIDER_MODELS)
+			const supportedProviders = [...AUTOCOMPLETE_PROVIDER_MODELS.keys()]
 			const profiles = [
 				{ id: "1", name: "profile1", apiProvider: undefined },
 				{ id: "2", name: "profile2", apiProvider: supportedProviders[0] },
@@ -58,7 +58,7 @@ describe("GhostModel", () => {
 		})
 
 		it("filters out profiles with unsupported apiProvider", async () => {
-			const supportedProviders = Object.keys(AUTOCOMPLETE_PROVIDER_MODELS)
+			const supportedProviders = [...AUTOCOMPLETE_PROVIDER_MODELS.keys()]
 			const profiles = [
 				{ id: "1", name: "profile1", apiProvider: "unsupported" },
 				{ id: "2", name: "profile2", apiProvider: supportedProviders[0] },
@@ -90,7 +90,7 @@ describe("GhostModel", () => {
 		})
 
 		it("returns true when profile found", async () => {
-			const supportedProviders = Object.keys(AUTOCOMPLETE_PROVIDER_MODELS)
+			const supportedProviders = [...AUTOCOMPLETE_PROVIDER_MODELS.keys()]
 			const profiles = [{ id: "1", name: "profile1", apiProvider: supportedProviders[0] }] as any
 
 			vi.mocked(mockProviderSettingsManager.listConfig).mockResolvedValue(profiles)
@@ -303,7 +303,7 @@ describe("GhostModel", () => {
 		})
 
 		it("returns provider name from API handler when provider is loaded", async () => {
-			const supportedProviders = Object.keys(AUTOCOMPLETE_PROVIDER_MODELS)
+			const supportedProviders = [...AUTOCOMPLETE_PROVIDER_MODELS.keys()]
 			const profiles = [{ id: "1", name: "profile1", apiProvider: supportedProviders[0] }] as any
 
 			vi.mocked(mockProviderSettingsManager.listConfig).mockResolvedValue(profiles)

--- a/src/services/ghost/new-auto-complete/NewAutocompleteModel.ts
+++ b/src/services/ghost/new-auto-complete/NewAutocompleteModel.ts
@@ -1,7 +1,4 @@
 import {
-	AUTOCOMPLETE_PROVIDER_MODELS,
-	AutocompleteProviderKey,
-	defaultProviderUsabilityChecker,
 	getKiloBaseUriFromToken,
 	modelIdKeysByProvider,
 	ProviderSettings,
@@ -16,6 +13,11 @@ import { DEFAULT_AUTOCOMPLETE_OPTS } from "../../continuedev/core/util/parameter
 import Mistral from "../../continuedev/core/llm/llms/Mistral"
 import OpenRouter from "../../continuedev/core/llm/llms/OpenRouter"
 import KiloCode from "../../continuedev/core/llm/llms/KiloCode"
+import {
+	AUTOCOMPLETE_PROVIDER_MODELS,
+	AutocompleteProviderKey,
+	defaultProviderUsabilityChecker,
+} from "../utils/kilocode-utils"
 
 export class NewAutocompleteModel {
 	private apiHandler: ApiHandler | null = null

--- a/src/services/ghost/new-auto-complete/NewAutocompleteModel.ts
+++ b/src/services/ghost/new-auto-complete/NewAutocompleteModel.ts
@@ -46,17 +46,14 @@ export class NewAutocompleteModel {
 
 		// Check providers in order, but skip unusable ones (e.g., kilocode with zero balance)
 		for (const provider of supportedProviders) {
-			const selectedProfile = profiles.find(
-				(x): x is typeof x & { apiProvider: string } => x?.apiProvider === provider,
-			)
-			if (selectedProfile) {
-				const isUsable = await defaultProviderUsabilityChecker(provider, providerSettingsManager)
-				if (!isUsable) continue
+			const selectedProfile = profiles.find((x) => x?.apiProvider === provider)
+			if (!selectedProfile) continue
+			const isUsable = await defaultProviderUsabilityChecker(provider, providerSettingsManager)
+			if (!isUsable) continue
 
-				this.loadProfile(providerSettingsManager, selectedProfile, provider)
-				this.loaded = true
-				return true
-			}
+			this.loadProfile(providerSettingsManager, selectedProfile, provider)
+			this.loaded = true
+			return true
 		}
 
 		this.loaded = true // we loaded, and found nothing, but we do not wish to reload

--- a/src/services/ghost/new-auto-complete/NewAutocompleteModel.ts
+++ b/src/services/ghost/new-auto-complete/NewAutocompleteModel.ts
@@ -34,49 +34,32 @@ export class NewAutocompleteModel {
 
 	public async reload(providerSettingsManager: ProviderSettingsManager): Promise<boolean> {
 		const profiles = await providerSettingsManager.listConfig()
-		const supportedProviders = Object.keys(AUTOCOMPLETE_PROVIDER_MODELS) as Array<
-			keyof typeof AUTOCOMPLETE_PROVIDER_MODELS
-		>
 
 		this.cleanup()
 
 		// Check providers in order, but skip unusable ones (e.g., kilocode with zero balance)
-		for (const provider of supportedProviders) {
+		for (const [provider, model] of AUTOCOMPLETE_PROVIDER_MODELS) {
 			const selectedProfile = profiles.find((x) => x?.apiProvider === provider)
 			if (!selectedProfile) continue
+			const profile = await providerSettingsManager.getProfile({ id: selectedProfile.id })
 
 			if (provider === "kilocode") {
 				// For all other providers, assume they are usable
-				const profile = await providerSettingsManager.getProfile({ id: selectedProfile.id })
 				if (!profile.kilocodeToken) continue
 				if (!(await checkKilocodeBalance(profile.kilocodeToken, profile.kilocodeOrganizationId))) continue
 			}
 
-			this.loadProfile(providerSettingsManager, selectedProfile, provider)
+			this.apiHandler = buildApiHandler({ ...profile, [modelIdKeysByProvider[provider]]: model })
+
+			if (this.apiHandler instanceof OpenRouterHandler) {
+				await this.apiHandler.fetchModel()
+			}
 			this.loaded = true
 			return true
 		}
 
 		this.loaded = true // we loaded, and found nothing, but we do not wish to reload
 		return false
-	}
-	public async loadProfile(
-		providerSettingsManager: ProviderSettingsManager,
-		selectedProfile: ProviderSettingsEntry,
-		provider: keyof typeof AUTOCOMPLETE_PROVIDER_MODELS,
-	): Promise<void> {
-		this.profile = await providerSettingsManager.getProfile({
-			id: selectedProfile.id,
-		})
-
-		this.apiHandler = buildApiHandler({
-			...this.profile,
-			[modelIdKeysByProvider[provider]]: AUTOCOMPLETE_PROVIDER_MODELS[provider],
-		})
-
-		if (this.apiHandler instanceof OpenRouterHandler) {
-			await this.apiHandler.fetchModel()
-		}
 	}
 
 	/**
@@ -147,7 +130,11 @@ export class NewAutocompleteModel {
 		}
 
 		const provider = this.profile.apiProvider as AutocompleteProviderKey
-		const model = AUTOCOMPLETE_PROVIDER_MODELS[provider]
+		const model = AUTOCOMPLETE_PROVIDER_MODELS.get(provider)
+		if (!model) {
+			console.warn(`[NewAutocompleteModel] Unsupported provider: ${provider}`)
+			return null
+		}
 
 		switch (provider) {
 			case "mistral":

--- a/src/services/ghost/utils/kilocode-utils.test.ts
+++ b/src/services/ghost/utils/kilocode-utils.test.ts
@@ -1,0 +1,113 @@
+import { checkKilocodeBalance } from "./kilocode-utils"
+
+describe("checkKilocodeBalance", () => {
+	const mockToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbnYiOiJwcm9kdWN0aW9uIn0.test"
+	const mockOrgId = "org-123"
+
+	beforeEach(() => {
+		global.fetch = vi.fn()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("should return true when balance is positive", async () => {
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ balance: 100 }),
+		} as Response)
+
+		const result = await checkKilocodeBalance(mockToken)
+		expect(result).toBe(true)
+		expect(global.fetch).toHaveBeenCalledWith(
+			"https://api.kilocode.ai/api/profile/balance",
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Authorization: `Bearer ${mockToken}`,
+				}),
+			}),
+		)
+	})
+
+	it("should return false when balance is zero", async () => {
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ balance: 0 }),
+		} as Response)
+
+		const result = await checkKilocodeBalance(mockToken)
+		expect(result).toBe(false)
+	})
+
+	it("should return false when balance is negative", async () => {
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ balance: -10 }),
+		} as Response)
+
+		const result = await checkKilocodeBalance(mockToken)
+		expect(result).toBe(false)
+	})
+
+	it("should include organization ID in headers when provided", async () => {
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ balance: 100 }),
+		} as Response)
+
+		const result = await checkKilocodeBalance(mockToken, mockOrgId)
+		expect(result).toBe(true)
+		expect(global.fetch).toHaveBeenCalledWith(
+			"https://api.kilocode.ai/api/profile/balance",
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Authorization: `Bearer ${mockToken}`,
+					"X-KiloCode-OrganizationId": mockOrgId,
+				}),
+			}),
+		)
+	})
+
+	it("should not include organization ID in headers when not provided", async () => {
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ balance: 100 }),
+		} as Response)
+
+		await checkKilocodeBalance(mockToken)
+
+		const fetchCall = vi.mocked(global.fetch).mock.calls[0]
+		expect(fetchCall).toBeDefined()
+		const headers = (fetchCall![1] as RequestInit)?.headers as Record<string, string>
+
+		expect(headers).toHaveProperty("Authorization")
+		expect(headers).not.toHaveProperty("X-KiloCode-OrganizationId")
+	})
+
+	it("should return false when API request fails", async () => {
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: false,
+		} as Response)
+
+		const result = await checkKilocodeBalance(mockToken)
+		expect(result).toBe(false)
+	})
+
+	it("should return false when fetch throws an error", async () => {
+		vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Network error"))
+
+		const result = await checkKilocodeBalance(mockToken)
+		expect(result).toBe(false)
+	})
+
+	it("should handle missing balance field in response", async () => {
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({}),
+		} as Response)
+
+		const result = await checkKilocodeBalance(mockToken)
+		expect(result).toBe(false)
+	})
+})

--- a/src/services/ghost/utils/kilocode-utils.ts
+++ b/src/services/ghost/utils/kilocode-utils.ts
@@ -43,3 +43,10 @@ export const AUTOCOMPLETE_PROVIDER_MODELS = {
 	bedrock: "mistral.codestral-2508-v1:0",
 } as const
 export type AutocompleteProviderKey = keyof typeof AUTOCOMPLETE_PROVIDER_MODELS
+export const AUTOCOMPLETE_PROVIDER_MAP = new Map([
+	["mistral", "codestral-latest"],
+	["kilocode", "mistralai/codestral-2508"],
+	["openrouter", "mistralai/codestral-2508"],
+	["bedrock", "mistral.codestral-2508-v1:0"],
+] as const)
+export type AutocompleteProviderKey2 = typeof AUTOCOMPLETE_PROVIDER_MAP extends Map<infer K, any> ? K : never

--- a/src/services/ghost/utils/kilocode-utils.ts
+++ b/src/services/ghost/utils/kilocode-utils.ts
@@ -43,35 +43,3 @@ export const AUTOCOMPLETE_PROVIDER_MODELS = {
 	bedrock: "mistral.codestral-2508-v1:0",
 } as const
 export type AutocompleteProviderKey = keyof typeof AUTOCOMPLETE_PROVIDER_MODELS
-
-export const defaultProviderUsabilityChecker = async (
-	provider: AutocompleteProviderKey,
-	providerSettingsManager: ProviderSettingsManager,
-): Promise<boolean> => {
-	if (provider === "kilocode") {
-		try {
-			const profiles = await providerSettingsManager.listConfig()
-			const kilocodeProfile = profiles.find((p) => p.apiProvider === "kilocode")
-
-			if (!kilocodeProfile) {
-				return false
-			}
-
-			const profile = await providerSettingsManager.getProfile({ id: kilocodeProfile.id })
-			const kilocodeToken = profile.kilocodeToken
-			const kilocodeOrgId = profile.kilocodeOrganizationId
-
-			if (!kilocodeToken) {
-				return false
-			}
-
-			return await checkKilocodeBalance(kilocodeToken, kilocodeOrgId)
-		} catch (error) {
-			console.error("Error checking kilocode balance:", error)
-			return false
-		}
-	}
-
-	// For all other providers, assume they are usable
-	return true
-}

--- a/src/services/ghost/utils/kilocode-utils.ts
+++ b/src/services/ghost/utils/kilocode-utils.ts
@@ -44,12 +44,10 @@ export const AUTOCOMPLETE_PROVIDER_MODELS = {
 } as const
 export type AutocompleteProviderKey = keyof typeof AUTOCOMPLETE_PROVIDER_MODELS
 
-export type ProviderUsabilityChecker = (
+export const defaultProviderUsabilityChecker = async (
 	provider: AutocompleteProviderKey,
 	providerSettingsManager: ProviderSettingsManager,
-) => Promise<boolean>
-
-export const defaultProviderUsabilityChecker: ProviderUsabilityChecker = async (provider, providerSettingsManager) => {
+): Promise<boolean> => {
 	if (provider === "kilocode") {
 		try {
 			const profiles = await providerSettingsManager.listConfig()

--- a/src/services/ghost/utils/kilocode-utils.ts
+++ b/src/services/ghost/utils/kilocode-utils.ts
@@ -1,0 +1,79 @@
+import { getKiloBaseUriFromToken } from "@roo-code/types"
+import { ProviderSettingsManager } from "../../../core/config/ProviderSettingsManager"
+
+/**
+ * Check if the Kilocode account has a positive balance
+ * @param kilocodeToken - The Kilocode JWT token
+ * @param kilocodeOrganizationId - Optional organization ID to include in headers
+ * @returns Promise<boolean> - True if balance > 0, false otherwise
+ */
+export async function checkKilocodeBalance(kilocodeToken: string, kilocodeOrganizationId?: string): Promise<boolean> {
+	try {
+		const baseUrl = getKiloBaseUriFromToken(kilocodeToken)
+
+		const headers: Record<string, string> = {
+			Authorization: `Bearer ${kilocodeToken}`,
+		}
+
+		if (kilocodeOrganizationId) {
+			headers["X-KiloCode-OrganizationId"] = kilocodeOrganizationId
+		}
+
+		const response = await fetch(`${baseUrl}/api/profile/balance`, {
+			headers,
+		})
+
+		if (!response.ok) {
+			return false
+		}
+
+		const data = await response.json()
+		const balance = data.balance ?? 0
+		return balance > 0
+	} catch (error) {
+		console.error("Error checking kilocode balance:", error)
+		return false
+	}
+}
+
+export const AUTOCOMPLETE_PROVIDER_MODELS = {
+	mistral: "codestral-latest",
+	kilocode: "mistralai/codestral-2508",
+	openrouter: "mistralai/codestral-2508",
+	bedrock: "mistral.codestral-2508-v1:0",
+} as const
+export type AutocompleteProviderKey = keyof typeof AUTOCOMPLETE_PROVIDER_MODELS
+
+export type ProviderUsabilityChecker = (
+	provider: AutocompleteProviderKey,
+	providerSettingsManager: ProviderSettingsManager,
+) => Promise<boolean>
+
+export const defaultProviderUsabilityChecker: ProviderUsabilityChecker = async (provider, providerSettingsManager) => {
+	if (provider === "kilocode") {
+		try {
+			const profiles = await providerSettingsManager.listConfig()
+			const kilocodeProfile = profiles.find((p) => p.apiProvider === "kilocode")
+
+			if (!kilocodeProfile) {
+				return false
+			}
+
+			const profile = await providerSettingsManager.getProfile({ id: kilocodeProfile.id })
+			const kilocodeToken = profile.kilocodeToken
+			const kilocodeOrgId = profile.kilocodeOrganizationId
+
+			if (!kilocodeToken) {
+				return false
+			}
+
+			return await checkKilocodeBalance(kilocodeToken, kilocodeOrgId)
+		} catch (error) {
+			console.error("Error checking kilocode balance:", error)
+			return false
+		}
+	}
+
+	// For all other providers, assume they are usable
+	return true
+}

--- a/src/services/ghost/utils/kilocode-utils.ts
+++ b/src/services/ghost/utils/kilocode-utils.ts
@@ -36,17 +36,10 @@ export async function checkKilocodeBalance(kilocodeToken: string, kilocodeOrgani
 	}
 }
 
-export const AUTOCOMPLETE_PROVIDER_MODELS = {
-	mistral: "codestral-latest",
-	kilocode: "mistralai/codestral-2508",
-	openrouter: "mistralai/codestral-2508",
-	bedrock: "mistral.codestral-2508-v1:0",
-} as const
-export type AutocompleteProviderKey = keyof typeof AUTOCOMPLETE_PROVIDER_MODELS
-export const AUTOCOMPLETE_PROVIDER_MAP = new Map([
+export const AUTOCOMPLETE_PROVIDER_MODELS = new Map([
 	["mistral", "codestral-latest"],
 	["kilocode", "mistralai/codestral-2508"],
 	["openrouter", "mistralai/codestral-2508"],
 	["bedrock", "mistral.codestral-2508-v1:0"],
 ] as const)
-export type AutocompleteProviderKey2 = typeof AUTOCOMPLETE_PROVIDER_MAP extends Map<infer K, any> ? K : never
+export type AutocompleteProviderKey = typeof AUTOCOMPLETE_PROVIDER_MODELS extends Map<infer K, any> ? K : never


### PR DESCRIPTION
 - #2912 
 - refactor
 - move defaultProviderUsabilityChecker, AUTOCOMPLETE_PROVIDER_MODELS, checkKilocodeBalance from types package into autocomplete service
 - then inline defaultProviderUsabilityChecker into both the new and old autocomplete providers
 - also inline loadProfile
 - despite inlining the fairly hefty defaultProviderUsabilityChecker in two places, the result is still 70 lines less; there was just a lot of cruft between all the various functions.
 
 "works on my machine" proof: 
<img width="643" height="244" alt="image" src="https://github.com/user-attachments/assets/f3d36527-035a-4645-8767-226103bf8ba1" />
...also very wrong, bad LLM, but you know....