### PR TITLE
Simplified enable/disable

### DIFF
--- a/src/services/ghost/GhostServiceManager.ts
+++ b/src/services/ghost/GhostServiceManager.ts
@@ -155,17 +155,6 @@ export class GhostServiceManager {
 		await this.load()
 	}
 
-	public async enable() {
-		this.settings = {
-			...this.settings,
-			enableAutoTrigger: true,
-			enableSmartInlineTaskKeybinding: true,
-			enableQuickInlineTaskKeybinding: true,
-		}
-		await this.saveSettings()
-		await this.load()
-	}
-
 	// VsCode Event Handlers
 	private onDidCloseTextDocument(document: vscode.TextDocument): void {
 		if (document.uri.scheme !== "file") {

--- a/src/services/ghost/GhostServiceManager.ts
+++ b/src/services/ghost/GhostServiceManager.ts
@@ -145,13 +145,16 @@ export class GhostServiceManager {
 	}
 
 	public async disable() {
-		this.settings = {
-			...this.settings,
-			enableAutoTrigger: false,
-			enableSmartInlineTaskKeybinding: false,
-			enableQuickInlineTaskKeybinding: false,
-		}
-		await this.saveSettings()
+		const settings = ContextProxy.instance.getGlobalState("ghostServiceSettings") ?? {}
+		await ContextProxy.instance.setValues({
+			ghostServiceSettings: {
+				...settings,
+				enableAutoTrigger: false,
+				enableSmartInlineTaskKeybinding: false,
+				enableQuickInlineTaskKeybinding: false,
+			},
+		})
+
 		await this.load()
 	}
 

--- a/src/services/ghost/GhostServiceManager.ts
+++ b/src/services/ghost/GhostServiceManager.ts
@@ -87,16 +87,6 @@ export class GhostServiceManager {
 		return GhostServiceManager.instance
 	}
 
-	private async saveSettings() {
-		const settingsWithModelInfo = {
-			...this.settings,
-			provider: this.getCurrentProviderName(),
-			model: this.getCurrentModelName(),
-		}
-		await ContextProxy.instance.setValues({ ghostServiceSettings: settingsWithModelInfo })
-		await this.cline.postStateToWebview()
-	}
-
 	public async load() {
 		this.settings = ContextProxy.instance.getGlobalState("ghostServiceSettings") ?? {
 			enableQuickInlineTaskKeybinding: true,
@@ -106,7 +96,13 @@ export class GhostServiceManager {
 		await this.updateGlobalContext()
 		this.updateStatusBar()
 		await this.updateInlineCompletionProviderRegistration()
-		await this.saveSettings()
+		const settingsWithModelInfo = {
+			...this.settings,
+			provider: this.getCurrentProviderName(),
+			model: this.getCurrentModelName(),
+		}
+		await ContextProxy.instance.setValues({ ghostServiceSettings: settingsWithModelInfo })
+		await this.cline.postStateToWebview()
 	}
 
 	private async updateInlineCompletionProviderRegistration() {

--- a/src/services/ghost/index.ts
+++ b/src/services/ghost/index.ts
@@ -34,11 +34,6 @@ export const registerGhostProvider = (context: vscode.ExtensionContext, cline: C
 		}),
 	)
 	context.subscriptions.push(
-		vscode.commands.registerCommand("kilo-code.ghost.enable", async () => {
-			await ghost.enable()
-		}),
-	)
-	context.subscriptions.push(
 		vscode.commands.registerCommand("kilo-code.ghost.disable", async () => {
 			await ghost.disable()
 		}),


### PR DESCRIPTION
and inline saveSettings. Goal is mostly to make clear in code what we learned today, that load + saveSettings is always executed as one