### PR TITLE
Slightly more thread safe ProviderSettingsManager initialization

### DIFF
--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -80,9 +80,19 @@ export class ProviderSettingsManager {
 	constructor(context: ExtensionContext) {
 		this.context = context
 
-		// TODO: We really shouldn't have async methods in the constructor.
-		this.initialize().catch(console.error)
+		// kilocode_change start
+		// only initialize ONCE, and save the promise in case somebody needs to wait.
+		this.initialization = this.init_runMigrations()
 	}
+	private readonly initialization: Promise<void>
+	/**
+	 * Wait for initialization migrations to complete.  These were started during construction.
+	 * The odd active-verb name is retained to simplify roo-merged.
+	 */
+	public initialize(): Promise<void> {
+		return this.initialization
+	}
+	// kilocode_change end
 
 	public generateId() {
 		return Math.random().toString(36).substring(2, 15)
@@ -96,10 +106,8 @@ export class ProviderSettingsManager {
 		return next
 	}
 
-	/**
-	 * Initialize config if it doesn't exist and run migrations.
-	 */
-	public async initialize() {
+	// kilocode_change: private & renamed:
+	async init_runMigrations() {
 		try {
 			return await this.lock(async () => {
 				const providerProfiles = await this.load()

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -83,7 +83,8 @@ export class ProviderSettingsManager {
 		// TODO: We really shouldn't have async methods in the constructor.
 		// kilocode_change start
 		// only initialize ONCE, and save the promise in case somebody needs to wait.
-		this.initialization = this.init_runMigrations().catch(console.error)
+		this.initialization = this.init_runMigrations()
+		this.initialization.catch(console.error)
 		// kilocode_change end
 	}
 

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -80,6 +80,7 @@ export class ProviderSettingsManager {
 	constructor(context: ExtensionContext) {
 		this.context = context
 
+		// TODO: We really shouldn't have async methods in the constructor.
 		// kilocode_change start
 		// only initialize ONCE, and save the promise in case somebody needs to wait.
 		this.initialization = this.init_runMigrations().catch(console.error)

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -83,7 +83,10 @@ export class ProviderSettingsManager {
 		// kilocode_change start
 		// only initialize ONCE, and save the promise in case somebody needs to wait.
 		this.initialization = this.init_runMigrations()
+		// kilocode_change end
 	}
+
+	// kilocode_change start
 	private readonly initialization: Promise<void>
 	/**
 	 * Wait for initialization migrations to complete.  These were started during construction.

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -82,7 +82,7 @@ export class ProviderSettingsManager {
 
 		// kilocode_change start
 		// only initialize ONCE, and save the promise in case somebody needs to wait.
-		this.initialization = this.init_runMigrations()
+		this.initialization = this.init_runMigrations().catch(console.error)
 		// kilocode_change end
 	}
 

--- a/src/core/config/__tests__/ProviderSettingsManager.spec.ts
+++ b/src/core/config/__tests__/ProviderSettingsManager.spec.ts
@@ -28,6 +28,7 @@ describe("ProviderSettingsManager", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks()
+
 		// Reset all mock implementations to default successful behavior
 		mockSecrets.get.mockResolvedValue(null)
 		mockSecrets.store.mockResolvedValue(undefined)
@@ -36,6 +37,18 @@ describe("ProviderSettingsManager", () => {
 		mockGlobalState.update.mockResolvedValue(undefined)
 
 		providerSettingsManager = new ProviderSettingsManager(mockContext)
+
+		//kilocode_change start: this is a REAL ugly hack to keep tests running
+		// The roo tests here rely on instantiating ProviderSettingsManager in the beforeEach,
+		// then in some tests alter the mocks in ways that would have influenced initialization
+		// then reinitializing, and spying on internals of said initialization.
+		// I'm not convinced this test coverage means very much, so this fix makes a complicated puzzle happen to fall in place
+		// Also this override resets itself, but fortunately no test required triple initialization...
+		providerSettingsManager.initialize = async () => {
+			providerSettingsManager = new ProviderSettingsManager(mockContext)
+			await providerSettingsManager.initialize()
+		}
+		//kilocode_change end
 	})
 
 	describe("initialize", () => {

--- a/src/core/config/__tests__/ProviderSettingsManager.spec.ts
+++ b/src/core/config/__tests__/ProviderSettingsManager.spec.ts
@@ -28,7 +28,6 @@ describe("ProviderSettingsManager", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks()
-
 		// Reset all mock implementations to default successful behavior
 		mockSecrets.get.mockResolvedValue(null)
 		mockSecrets.store.mockResolvedValue(undefined)

--- a/src/services/ghost/GhostServiceManager.ts
+++ b/src/services/ghost/GhostServiceManager.ts
@@ -71,16 +71,11 @@ export class GhostServiceManager {
 	// Singleton Management
 	public static initialize(context: vscode.ExtensionContext, cline: ClineProvider): GhostServiceManager {
 		if (GhostServiceManager.instance) {
-			throw new Error("GhostServiceManager is already initialized. Use getInstance() instead.")
+			throw new Error(
+				"GhostServiceManager is already initialized. Restart VS code, or change this to return the cached instance.",
+			)
 		}
 		GhostServiceManager.instance = new GhostServiceManager(context, cline)
-		return GhostServiceManager.instance
-	}
-
-	public static getInstance(): GhostServiceManager {
-		if (!GhostServiceManager.instance) {
-			throw new Error("GhostServiceManager is not initialized. Call initialize() first.")
-		}
 		return GhostServiceManager.instance
 	}
 

--- a/src/services/ghost/GhostServiceManager.ts
+++ b/src/services/ghost/GhostServiceManager.ts
@@ -9,7 +9,6 @@ import { GhostInlineCompletionProvider } from "./classic-auto-complete/GhostInli
 //import { NewAutocompleteProvider } from "./new-auto-complete/NewAutocompleteProvider"
 import { GhostServiceSettings, TelemetryEventName } from "@roo-code/types"
 import { ContextProxy } from "../../core/config/ContextProxy"
-import { ProviderSettingsManager } from "../../core/config/ProviderSettingsManager"
 import { GhostContext } from "./GhostContext"
 import { TelemetryService } from "@roo-code/telemetry"
 import { ClineProvider } from "../../core/webview/ClineProvider"
@@ -21,7 +20,6 @@ export class GhostServiceManager {
 	private model: GhostModel
 	private cline: ClineProvider
 	private context: vscode.ExtensionContext
-	private providerSettingsManager: ProviderSettingsManager
 	private settings: GhostServiceSettings | null = null
 	private ghostContext: GhostContext
 
@@ -47,7 +45,6 @@ export class GhostServiceManager {
 
 		// Register Internal Components
 		this.documentStore = new GhostDocumentStore()
-		this.providerSettingsManager = cline.providerSettingsManager
 		this.model = new GhostModel()
 		this.ghostContext = new GhostContext(this.documentStore)
 
@@ -102,7 +99,8 @@ export class GhostServiceManager {
 			enableQuickInlineTaskKeybinding: true,
 			enableSmartInlineTaskKeybinding: true,
 		}
-		await this.model.reload(this.providerSettingsManager)
+		await this.cline.providerSettingsManager.initialize() // avoid race condition with settings migrations
+		await this.model.reload(this.cline.providerSettingsManager)
 		await this.updateGlobalContext()
 		this.updateStatusBar()
 		await this.updateInlineCompletionProviderRegistration()


### PR DESCRIPTION
- #2912 
- never initialize more than once, even in the terminal command generation code, and even in the git commit message generator.
- wait for that initialization in the autocomplete code.

I'm still getting autocompletes:
<img width="652" height="78" alt="image" src="https://github.com/user-attachments/assets/f2bb42d2-6612-4b25-8439-50b4cc564354" />
...and this time autocomplete models got closer to the big-O anyhow, so hey :-P