### PR TITLE
Add Kimi K2 Thinking + Turbo to Moonshot provider and make non-turbo variant the default.

### DIFF
--- a/.changeset/large-birds-admire.md
+++ b/.changeset/large-birds-admire.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Add Kimi K2 Thinking to Moonshot.ai provider.

--- a/packages/types/src/providers/moonshot.ts
+++ b/packages/types/src/providers/moonshot.ts
@@ -3,9 +3,31 @@ import type { ModelInfo } from "../model.js"
 // https://platform.moonshot.ai/
 export type MoonshotModelId = keyof typeof moonshotModels
 
-export const moonshotDefaultModelId: MoonshotModelId = "kimi-k2-0905-preview"
+export const moonshotDefaultModelId: MoonshotModelId = "kimi-k2-thinking"
 
 export const moonshotModels = {
+	"kimi-k2-thinking-turbo": {
+		maxTokens: 32_000,
+		contextWindow: 262144,
+		supportsImages: false,
+		supportsPromptCache: true,
+		inputPrice: 1.15, // $1.15 per million tokens (cache miss)
+		outputPrice: 8.0, // $8.00 per million tokens
+		cacheWritesPrice: 0, // $0 per million tokens (cache miss)
+		cacheReadsPrice: 0.15, // $0.15 per million tokens (cache hit)
+		description: `High-speed version of kimi-k2-thinking, suitable for scenarios requiring both deep reasoning and extremely fast responses`,
+	},
+	"kimi-k2-thinking": {
+		maxTokens: 32_000,
+		contextWindow: 262144,
+		supportsImages: false,
+		supportsPromptCache: true,
+		inputPrice: 0.6, // $0.6 per million tokens (cache miss)
+		outputPrice: 2.5, // $2.50 per million tokens
+		cacheWritesPrice: 0, // $0 per million tokens (cache miss)
+		cacheReadsPrice: 0.15, // $0.15 per million tokens (cache hit)
+		description: `A thinking model with general agentic and reasoning capabilities, specializing in deep reasoning tasks`,
+	},
 	"kimi-k2-0711-preview": {
 		maxTokens: 32_000,
 		contextWindow: 131_072,

--- a/packages/types/src/providers/moonshot.ts
+++ b/packages/types/src/providers/moonshot.ts
@@ -6,28 +6,6 @@ export type MoonshotModelId = keyof typeof moonshotModels
 export const moonshotDefaultModelId: MoonshotModelId = "kimi-k2-thinking"
 
 export const moonshotModels = {
-	"kimi-k2-thinking-turbo": {
-		maxTokens: 32_000,
-		contextWindow: 262144,
-		supportsImages: false,
-		supportsPromptCache: true,
-		inputPrice: 1.15, // $1.15 per million tokens (cache miss)
-		outputPrice: 8.0, // $8.00 per million tokens
-		cacheWritesPrice: 0, // $0 per million tokens (cache miss)
-		cacheReadsPrice: 0.15, // $0.15 per million tokens (cache hit)
-		description: `High-speed version of kimi-k2-thinking, suitable for scenarios requiring both deep reasoning and extremely fast responses`,
-	},
-	"kimi-k2-thinking": {
-		maxTokens: 32_000,
-		contextWindow: 262144,
-		supportsImages: false,
-		supportsPromptCache: true,
-		inputPrice: 0.6, // $0.6 per million tokens (cache miss)
-		outputPrice: 2.5, // $2.50 per million tokens
-		cacheWritesPrice: 0, // $0 per million tokens (cache miss)
-		cacheReadsPrice: 0.15, // $0.15 per million tokens (cache hit)
-		description: `A thinking model with general agentic and reasoning capabilities, specializing in deep reasoning tasks`,
-	},
 	"kimi-k2-0711-preview": {
 		maxTokens: 32_000,
 		contextWindow: 131_072,
@@ -60,6 +38,29 @@ export const moonshotModels = {
 		cacheWritesPrice: 0, // $0 per million tokens (cache miss)
 		cacheReadsPrice: 0.6, // $0.60 per million tokens (cache hit)
 		description: `Kimi K2 Turbo is a high-speed version of the state-of-the-art Kimi K2 mixture-of-experts (MoE) language model, with the same 32 billion activated parameters and 1 trillion total parameters, optimized for output speeds of up to 60 tokens per second, peaking at 100 tokens per second.`,
+	},
+
+	"kimi-k2-thinking-turbo": {
+		maxTokens: 32_000,
+		contextWindow: 262144,
+		supportsImages: false,
+		supportsPromptCache: true,
+		inputPrice: 1.15, // $1.15 per million tokens (cache miss)
+		outputPrice: 8.0, // $8.00 per million tokens
+		cacheWritesPrice: 0, // $0 per million tokens (cache miss)
+		cacheReadsPrice: 0.15, // $0.15 per million tokens (cache hit)
+		description: `High-speed version of kimi-k2-thinking, suitable for scenarios requiring both deep reasoning and extremely fast responses`,
+	},
+	"kimi-k2-thinking": {
+		maxTokens: 32_000,
+		contextWindow: 262144,
+		supportsImages: false,
+		supportsPromptCache: true,
+		inputPrice: 0.6, // $0.6 per million tokens (cache miss)
+		outputPrice: 2.5, // $2.50 per million tokens
+		cacheWritesPrice: 0, // $0 per million tokens (cache miss)
+		cacheReadsPrice: 0.15, // $0.15 per million tokens (cache hit)
+		description: `A thinking model with general agentic and reasoning capabilities, specializing in deep reasoning tasks`,
 	},
 } as const satisfies Record<string, ModelInfo>
 

--- a/src/api/providers/__tests__/moonshot.spec.ts
+++ b/src/api/providers/__tests__/moonshot.spec.ts
@@ -148,7 +148,7 @@ describe("MoonshotHandler", () => {
 			const model = handler.getModel()
 			expect(model.id).toBe(mockOptions.apiModelId)
 			expect(model.info).toBeDefined()
-			expect(model.info.maxTokens).toBe(16384)
+			expect(model.info.maxTokens).toBe(32000)
 			expect(model.info.contextWindow).toBe(262144)
 			expect(model.info.supportsImages).toBe(false)
 			expect(model.info.supportsPromptCache).toBe(true) // Should be true now


### PR DESCRIPTION
Add Kimi K2 Thinking + Turbo to Moonshot provider and make non-turbo variant the default.