### PR TITLE
fix(ui): prevent accidental hover selections in context menu

### DIFF
--- a/.changeset/dirty-plants-sort.md
+++ b/.changeset/dirty-plants-sort.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Now items in the Chat context menu will not be auto selected if your cursor is already on the row when the items change


### PR DESCRIPTION
Add logic to temporarily disable hover-based selection when context menu items change, preventing unintended selections while the menu is open

Also introduce stable empty array references- Previously, the empty arrays were causing the props to change, causing a continuous render loop while the `ContextMenu.tsx` was open

Fixes: https://github.com/Kilo-Org/kilocode/issues/2104

![2025-11-07 10 56 30](https://github.com/user-attachments/assets/04b8fde0-f9cb-452e-8e8f-2ef45d170713)


