### PR TITLE
fix(native-tools): Make read_file_multi pattern JSON Schema compliant

### DIFF
--- a/.changeset/shy-bags-admire.md
+++ b/.changeset/shy-bags-admire.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix(native-tools): Make read_file_multi pattern JSON Schema compliant

--- a/src/core/prompts/tools/native-tools/read_file.ts
+++ b/src/core/prompts/tools/native-tools/read_file.ts
@@ -26,7 +26,7 @@ export const read_file_multi = {
 									"Optional 1-based inclusive ranges to read (format: start-end). Use multiple ranges for non-contiguous sections and keep ranges tight to the needed context.",
 								items: {
 									type: "string",
-									pattern: "^\\d+-\\d+$",
+									pattern: "^[0-9]+-[0-9]+$",
 								},
 							},
 						},


### PR DESCRIPTION
Closes #3610

## Context

The `pattern` for `line_ranges` in the `read_file_multi` native tool schema used the `\d` shorthand. This is not compliant with the ECMA 262 dialect required by the JSON Schema standard.

This non-compliance causes API calls to fail with backends that use strict schema validators, such as the GBNF grammar parser in `llama.cpp`, effectively blocking the use of this tool with certain setups. This PR fixes the schema to ensure compatibility and reliable tool execution.

## Implementation

The fix is a straightforward, one-line change in `src/core/prompts/tools/native-tools/read_file.ts`.

I replaced the non-standard `\d` shorthand in the regular expression with the standard-compliant character class `[0-9]`. This aligns the schema with the ECMA 262 specification without changing the validation logic. No refactoring was necessary.

## Screenshots

| before | after |
| ------ | ----- |
|   N/A  |  N/A  |

This is a schema change with no UI impact.

## How to Test

You can verify the fix by testing against a `llama.cpp` server, which enforces strict schema compliance.

1.  Set up a `llama.cpp` server (version `b6970` or later).
2.  Load a function-calling model like `unsloth/Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf`.
3.  Configure `kilocode` to use this local server endpoint.
4.  Check out the `main` branch (before this change). In `code` mode, ask the model to read multiple files, for example: *"Read lines 1-5 of `file1.ts` and lines 10-15 of `file2.ts`."* **The request should fail.**
5.  Build kilocode with this branch. Repeat the same request. **The request should now be processed successfully**, and the tool call should execute as expected.
