### PR TITLE
show yolo mode settings

### DIFF
--- a/.changeset/flat-turkeys-travel.md
+++ b/.changeset/flat-turkeys-travel.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+show yolo mode setting

--- a/webview-ui/src/components/settings/AutoApproveSettings.tsx
+++ b/webview-ui/src/components/settings/AutoApproveSettings.tsx
@@ -135,7 +135,7 @@ export const AutoApproveSettings = ({
 					<div className="bg-yellow-500/10 border border-yellow-500/30 rounded p-3 flex items-center gap-2">
 						<span className="text-lg">⚡</span>
 						<span className="text-sm font-medium text-yellow-500">
-							YOLO Mode is active - all auto-approval settings above are overridden
+							YOLO Mode is active - all auto-approval settings below are overridden
 						</span>
 					</div>
 				</Section>

--- a/webview-ui/src/components/settings/AutoApproveSettings.tsx
+++ b/webview-ui/src/components/settings/AutoApproveSettings.tsx
@@ -130,6 +130,18 @@ export const AutoApproveSettings = ({
 			</SectionHeader>
 
 			{/* kilocode_change start */}
+			{yoloMode && (
+				<Section>
+					<div className="bg-yellow-500/10 border border-yellow-500/30 rounded p-3 flex items-center gap-2">
+						<span className="text-lg">⚡</span>
+						<span className="text-sm font-medium text-yellow-500">
+							YOLO Mode is active - all auto-approval settings above are overridden
+						</span>
+					</div>
+				</Section>
+			)}
+			{/* kilocode_change end */}
+
 			<Section>
 				<div>
 					<VSCodeCheckbox
@@ -143,46 +155,6 @@ export const AutoApproveSettings = ({
 					</div>
 				</div>
 			</Section>
-
-			{/* YOLO MODE SECTION */}
-			{process.env.NODE_ENV === "development" && (
-				<Section>
-					<div className="border-2 border-yellow-500 rounded-md p-4 bg-yellow-500/10">
-						<div className="flex items-center gap-2 mb-3">
-							<span className="text-2xl">⚠️</span>
-							<h3 className="text-lg font-bold text-yellow-500">YOLO Mode</h3>
-						</div>
-						<VSCodeCheckbox
-							checked={yoloMode ?? false}
-							onChange={(e: any) => setCachedStateField("yoloMode", e.target.checked)}
-							data-testid="yolo-mode-checkbox">
-							<span className="font-bold text-base">Enable YOLO Mode - Auto-approve EVERYTHING</span>
-						</VSCodeCheckbox>
-						<div className="text-vscode-descriptionForeground text-sm mt-2 pl-6">
-							<p className="mb-2">
-								When enabled,{" "}
-								<strong>all operations will be automatically approved without confirmation</strong>.
-							</p>
-							<p className="text-yellow-500 font-medium">
-								⚡ This includes file modifications, command execution, MCP tools, browser actions, and
-								all other operations. Use with extreme caution!
-							</p>
-						</div>
-					</div>
-				</Section>
-			)}
-
-			{process.env.NODE_ENV === "development" && yoloMode && (
-				<Section>
-					<div className="bg-yellow-500/10 border border-yellow-500/30 rounded p-3 flex items-center gap-2">
-						<span className="text-lg">⚡</span>
-						<span className="text-sm font-medium text-yellow-500">
-							YOLO Mode is active - all auto-approval settings below are overridden
-						</span>
-					</div>
-				</Section>
-			)}
-			{/* kilocode_change end */}
 
 			<Section>
 				<div className="space-y-4">
@@ -465,6 +437,33 @@ export const AutoApproveSettings = ({
 					</div>
 				)}
 			</Section>
+
+			{/* kilocode_change start */}
+			<Section>
+				<div className="border-2 border-yellow-500 rounded-md p-4 bg-yellow-500/10">
+					<div className="flex items-center gap-2 mb-3">
+						<span className="text-2xl">⚠️</span>
+						<h3 className="text-lg font-bold text-yellow-500">YOLO Mode</h3>
+					</div>
+					<VSCodeCheckbox
+						checked={yoloMode ?? false}
+						onChange={(e: any) => setCachedStateField("yoloMode", e.target.checked)}
+						data-testid="yolo-mode-checkbox">
+						<span className="font-bold text-base">Enable YOLO Mode - Auto-approve EVERYTHING</span>
+					</VSCodeCheckbox>
+					<div className="text-vscode-descriptionForeground text-sm mt-2 pl-6">
+						<p className="mb-2">
+							When enabled,{" "}
+							<strong>all operations will be automatically approved without confirmation</strong>.
+						</p>
+						<p className="text-yellow-500 font-medium">
+							⚡ This includes file modifications, command execution, MCP tools, browser actions, and all
+							other operations. Use with extreme caution!
+						</p>
+					</div>
+				</div>
+			</Section>
+			{/* kilocode_change end */}
 		</div>
 	)
 }


### PR DESCRIPTION
## Context

Shows the yolo mode setting toggle to all users. Yolo mode is useful for users who trust the agent to make correct decisions and not destroy something.

## Implementation

This was already implemented, I've just enabled showing it to all users.

## Screenshots

<img width="500" height="845" alt="image" src="https://github.com/user-attachments/assets/f817d74d-7433-48fd-a659-99b38247cd68" />
<img width="496" height="1407" alt="image" src="https://github.com/user-attachments/assets/40350a24-0f95-4e6d-be4d-e57b05c99bb0" />

## How to Test

Enable yolo mode and ask the agent to do anything which would normally prompt for approval.

## Get in Touch

N/A
