### PR TITLE
Small tweaks to prepare for FIM usage

### DIFF
--- a/src/api/providers/kilocode-openrouter.ts
+++ b/src/api/providers/kilocode-openrouter.ts
@@ -157,14 +157,14 @@ export class KilocodeOpenrouterHandler extends OpenRouterHandler {
 			Authorization: `Bearer ${this.options.kilocodeToken}`,
 			...this.customRequestOptions(taskId ? { taskId, mode: "code" } : undefined)?.headers,
 		}
-
+		const max_max_tokens = 1000
 		const response = await fetch(endpoint, {
 			method: "POST",
 			body: JSON.stringify({
 				model: model.id,
 				prompt: prefix,
 				suffix,
-				max_tokens: model.maxTokens,
+				max_tokens: Math.min(max_max_tokens, model.maxTokens ?? max_max_tokens),
 				temperature: model.temperature,
 				top_p: model.topP,
 				stream: true,

--- a/src/services/ghost/GhostServiceManager.ts
+++ b/src/services/ghost/GhostServiceManager.ts
@@ -17,13 +17,13 @@ import { RooIgnoreController } from "../../core/ignore/RooIgnoreController"
 
 export class GhostServiceManager {
 	private static instance: GhostServiceManager | null = null
-	private documentStore: GhostDocumentStore
-	private model: GhostModel
-	private cline: ClineProvider
-	private context: vscode.ExtensionContext
+	private readonly documentStore: GhostDocumentStore
+	private readonly model: GhostModel
+	private readonly cline: ClineProvider
+	private readonly context: vscode.ExtensionContext
 	private settings: GhostServiceSettings | null = null
-	private ghostContext: GhostContext
-	private ghostContextProvider: GhostContextProvider
+	private readonly ghostContext: GhostContext
+	private readonly ghostContextProvider: GhostContextProvider
 
 	private taskId: string | null = null
 	private isProcessing: boolean = false
@@ -34,8 +34,8 @@ export class GhostServiceManager {
 	private lastCompletionCost: number = 0
 
 	// VSCode Providers
-	public codeActionProvider: GhostCodeActionProvider
-	public inlineCompletionProvider: GhostInlineCompletionProvider
+	public readonly codeActionProvider: GhostCodeActionProvider
+	public readonly inlineCompletionProvider: GhostInlineCompletionProvider
 	//private newAutocompleteProvider: NewAutocompleteProvider | null = null
 	private inlineCompletionProviderDisposable: vscode.Disposable | null = null
 


### PR DESCRIPTION
 - #2912 
  - limit max_tokens to ensure we don't just keep on streaming junk when the LLM gets dizzy
  - mark some readonly stuff thusly.