### PR TITLE
Enable Moonshot for native tool calling. 

### DIFF
--- a/.changeset/cyan-dots-type.md
+++ b/.changeset/cyan-dots-type.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Enable Moonshot for native tool calling

--- a/packages/types/src/kilocode/native-function-calling.ts
+++ b/packages/types/src/kilocode/native-function-calling.ts
@@ -23,6 +23,7 @@ export const nativeFunctionCallingProviders = [
 	"inception",
 	"minimax",
 	"anthropic",
+	"moonshot",
 ] satisfies ProviderName[] as ProviderName[]
 
 const modelsDefaultingToJsonKeywords = ["claude-haiku-4.5", "claude-haiku-4-5"]


### PR DESCRIPTION
## Context

Enable Moonshot for native tool calling. 

## Implementation

Provider uses baseline OAI-Compat implementation, so only need to add to allow list.  Confirmed working on Moonshot API endpoint.


## Get in Touch

mcowger
