### PR TITLE
fix: execute shell commands in workspace directory

### DIFF
--- a/.changeset/tasty-ducks-jump.md
+++ b/.changeset/tasty-ducks-jump.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Fix workspace path resolution when using relative paths with --workspace flag. Bash commands now execute in the correct directory.

--- a/.changeset/tasty-ducks-jump.md
+++ b/.changeset/tasty-ducks-jump.md
@@ -1,5 +1,5 @@
 ---
-"@kilocode/cli": minor
+"@kilocode/cli": patch
 ---
 
 Fix workspace path resolution when using relative paths with --workspace flag. Bash commands now execute in the correct directory.

--- a/cli/src/state/atoms/shell.ts
+++ b/cli/src/state/atoms/shell.ts
@@ -8,6 +8,15 @@ import { exec } from "child_process"
 import { clearTextAtom, setTextAtom, textBufferIsEmptyAtom } from "./textBuffer.js"
 
 // ============================================================================
+// Workspace Path Atom
+// ============================================================================
+
+/**
+ * The workspace directory where shell commands should be executed
+ */
+export const workspacePathAtom = atom<string | null>(null)
+
+// ============================================================================
 // Shell Mode Atoms
 // ============================================================================
 
@@ -134,9 +143,13 @@ export const executeShellCommandAtom = atom(null, async (get, set, command: stri
 
 	// Execute the command immediately (no approval needed)
 	try {
+		// Get the workspace path for command execution
+		const workspacePath = get(workspacePathAtom)
+		const executionDir = workspacePath || process.cwd()
+
 		// Execute command and capture output
 		const childProcess = exec(command, {
-			cwd: process.cwd(),
+			cwd: executionDir,
 			timeout: 30000, // 30 second timeout
 		})
 

--- a/cli/src/ui/UI.tsx
+++ b/cli/src/ui/UI.tsx
@@ -32,6 +32,7 @@ import { createConfigErrorInstructions, createWelcomeMessage } from "./utils/wel
 import { generateUpdateAvailableMessage, getAutoUpdateStatus } from "../utils/auto-update.js"
 import { generateNotificationMessage } from "../utils/notifications.js"
 import { notificationsAtom } from "../state/atoms/notifications.js"
+import { workspacePathAtom } from "../state/atoms/shell.js"
 import { useTerminal } from "../state/hooks/useTerminal.js"
 
 // Initialize commands on module load
@@ -58,6 +59,7 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 	const resetHistoryNavigation = useSetAtom(resetHistoryNavigationAtom)
 	const exitHistoryMode = useSetAtom(exitHistoryModeAtom)
 	const setIsParallelMode = useSetAtom(isParallelModeAtom)
+	const setWorkspacePath = useSetAtom(workspacePathAtom)
 
 	// Use specialized hooks for command and message handling
 	const { executeCommand, isExecuting: isExecutingCommand } = useCommandHandler()
@@ -109,6 +111,13 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 			setIsParallelMode(true)
 		}
 	}, [options.parallel, setIsParallelMode])
+
+	// Initialize workspace path for shell commands
+	useEffect(() => {
+		if (options.workspace) {
+			setWorkspacePath(options.workspace)
+		}
+	}, [options.workspace, setWorkspacePath])
 
 	// Handle CI mode exit
 	useEffect(() => {


### PR DESCRIPTION
## Summary
- Add `workspacePathAtom` to track the working directory for shell commands.
- When `--workspace` flag is provided, shell commands now execute in the specified directory instead of always using `process.cwd()`.
- Fixes issue where relative paths with `--workspace` would execute in the wrong directory.

## Changes
- **shell.ts**: Added `workspacePathAtom` and updated `executeShellCommandAtom` to use the workspace directory.
- **UI.tsx**: Initialize `workspacePathAtom` from `options.workspace`.
- **changeset**: Documented fix for workspace path resolution with relative paths.

## Testing
Tested with:
- `--workspace ./relative-path`
- `--workspace /absolute/path`
- Default behavior (no workspace flag)

Fixes #3634


<img width="1832" height="512" alt="Screenshot 2025-11-10 at 11 40 37 PM" src="https://github.com/user-attachments/assets/63bb446f-15e0-4b43-bf0c-dbff020b165c" />
<img width="886" height="306" alt="Screenshot 2025-11-10 at 11 40 09 PM" src="https://github.com/user-attachments/assets/37734ad4-eddc-490d-baf7-feee2faac0f4" />
