### PR TITLE
CLI - Refactor VSCode Webview Mock initialization

### DIFF
--- a/.changeset/afraid-points-fall.md
+++ b/.changeset/afraid-points-fall.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix initialization race conditions on auto mode

--- a/cli/src/host/ExtensionHost.ts
+++ b/cli/src/host/ExtensionHost.ts
@@ -27,6 +27,9 @@ export class ExtensionHost extends EventEmitter {
 	private webviewProviders: Map<string, any> = new Map()
 	private webviewProviderReady: Promise<void> | null = null
 	private webviewProviderReadyResolve: (() => void) | null = null
+	private webviewInitialized = false
+	private pendingMessages: WebviewMessage[] = []
+	private isInitialSetup = true
 	private originalConsole: {
 		log: typeof console.log
 		error: typeof console.error
@@ -280,14 +283,11 @@ export class ExtensionHost extends EventEmitter {
 				return
 			}
 
-			// Wait for webview provider to be ready before processing messages
-			if (this.webviewProviderReady) {
-				logs.debug(
-					`Waiting for webview provider to be ready before processing: ${message.type}`,
-					"ExtensionHost",
-				)
-				await this.webviewProviderReady
-				logs.debug(`Webview provider ready, processing message: ${message.type}`, "ExtensionHost")
+			// Queue messages if webview not initialized
+			if (!this.webviewInitialized) {
+				this.pendingMessages.push(message)
+				logs.debug(`Queued message ${message.type} - webview not ready`, "ExtensionHost")
+				return
 			}
 
 			// Track extension message sent
@@ -919,6 +919,46 @@ export class ExtensionHost extends EventEmitter {
 	unregisterWebviewProvider(viewId: string): void {
 		this.webviewProviders.delete(viewId)
 		logs.debug(`Unregistered webview provider: ${viewId}`, "ExtensionHost")
+	}
+
+	/**
+	 * Mark webview as ready and flush pending messages
+	 * Called by VSCode mock after resolveWebviewView completes
+	 */
+	public markWebviewReady(): void {
+		this.webviewInitialized = true
+		this.isInitialSetup = false
+		logs.info("Webview marked as ready, flushing pending messages", "ExtensionHost")
+		this.flushPendingMessages()
+	}
+
+	/**
+	 * Flush all pending messages that were queued before webview was ready
+	 */
+	private flushPendingMessages(): void {
+		const messages = [...this.pendingMessages]
+		this.pendingMessages = []
+
+		logs.info(`Flushing ${messages.length} pending messages`, "ExtensionHost")
+		for (const message of messages) {
+			logs.debug(`Flushing pending message: ${message.type}`, "ExtensionHost")
+			// Use void to explicitly ignore the promise
+			void this.sendWebviewMessage(message)
+		}
+	}
+
+	/**
+	 * Check if webview is ready to receive messages
+	 */
+	public isWebviewReady(): boolean {
+		return this.webviewInitialized
+	}
+
+	/**
+	 * Check if this is the initial setup phase
+	 */
+	public isInInitialSetup(): boolean {
+		return this.isInitialSetup
 	}
 }
 

--- a/cli/src/host/ExtensionHost.ts
+++ b/cli/src/host/ExtensionHost.ts
@@ -52,11 +52,6 @@ export class ExtensionHost extends EventEmitter {
 		// Increase max listeners to avoid warnings in tests
 		process.setMaxListeners(20)
 		this.setupGlobalErrorHandlers()
-
-		// Create a promise that will be resolved when the webview provider is registered
-		this.webviewProviderReady = new Promise((resolve) => {
-			this.webviewProviderReadyResolve = resolve
-		})
 	}
 
 	/**
@@ -904,14 +899,6 @@ export class ExtensionHost extends EventEmitter {
 	registerWebviewProvider(viewId: string, provider: any): void {
 		this.webviewProviders.set(viewId, provider)
 		logs.info(`Webview provider registered: ${viewId}`, "ExtensionHost")
-
-		// Resolve the ready promise to unblock any waiting messages
-		if (this.webviewProviderReadyResolve) {
-			this.webviewProviderReadyResolve()
-			this.webviewProviderReadyResolve = null
-			this.webviewProviderReady = null
-			logs.info("Webview provider ready signal sent", "ExtensionHost")
-		}
 	}
 
 	unregisterWebviewProvider(viewId: string): void {

--- a/cli/src/host/ExtensionHost.ts
+++ b/cli/src/host/ExtensionHost.ts
@@ -25,8 +25,6 @@ export class ExtensionHost extends EventEmitter {
 	private extensionAPI: any = null
 	private vscodeAPI: any = null
 	private webviewProviders: Map<string, any> = new Map()
-	private webviewProviderReady: Promise<void> | null = null
-	private webviewProviderReadyResolve: (() => void) | null = null
 	private webviewInitialized = false
 	private pendingMessages: WebviewMessage[] = []
 	private isInitialSetup = true

--- a/cli/src/host/VSCode.ts
+++ b/cli/src/host/VSCode.ts
@@ -1649,25 +1649,29 @@ export class WindowAPI {
 
 				// Call resolveWebviewView immediately with initialization context
 				// No setTimeout needed - use event-based synchronization instead
-				try {
-					// Pass isInitialSetup flag in context to prevent task abortion
-					const context = {
-						preserveFocus: false,
-						isInitialSetup: extensionHost.isInInitialSetup(),
+				;(async () => {
+					try {
+						// Pass isInitialSetup flag in context to prevent task abortion
+						const context = {
+							preserveFocus: false,
+							isInitialSetup: extensionHost.isInInitialSetup(),
+						}
+
+						logs.debug(
+							`Calling resolveWebviewView with isInitialSetup=${context.isInitialSetup}`,
+							"VSCode.Window",
+						)
+
+						// Await the result to ensure webview is fully initialized before marking ready
+						await provider.resolveWebviewView(mockWebviewView, context, {})
+
+						// Mark webview as ready after resolution completes
+						extensionHost.markWebviewReady()
+						logs.debug("Webview resolution complete, marked as ready", "VSCode.Window")
+					} catch (error) {
+						logs.error("Error resolving webview view", "VSCode.Window", { error })
 					}
-
-					logs.debug(
-						`Calling resolveWebviewView with isInitialSetup=${context.isInitialSetup}`,
-						"VSCode.Window",
-					)
-					provider.resolveWebviewView(mockWebviewView, context, {})
-
-					// Mark webview as ready after resolution completes
-					extensionHost.markWebviewReady()
-					logs.debug("Webview resolution complete, marked as ready", "VSCode.Window")
-				} catch (error) {
-					logs.error("Error resolving webview view", "VSCode.Window", { error })
-				}
+				})()
 			}
 		}
 		return {

--- a/cli/src/host/__tests__/ExtensionHost.raceCondition.test.ts
+++ b/cli/src/host/__tests__/ExtensionHost.raceCondition.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { ExtensionHost } from "../ExtensionHost.js"
+import type { WebviewMessage } from "../../types/messages.js"
+
+describe("ExtensionHost Race Condition Fix", () => {
+	let extensionHost: ExtensionHost
+
+	beforeEach(() => {
+		extensionHost = new ExtensionHost({
+			workspacePath: "/test/workspace",
+			extensionBundlePath: "/test/extension.js",
+			extensionRootPath: "/test",
+		})
+
+		// Initialize state and mark as activated for testing
+		const initializeState = (extensionHost as any).initializeState.bind(extensionHost)
+		initializeState()
+		;(extensionHost as any).isActivated = true
+	})
+
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	describe("Message Queuing", () => {
+		it("should queue messages when webview is not initialized", async () => {
+			const message: WebviewMessage = {
+				type: "newTask",
+				text: "Test task",
+			}
+
+			// Webview should not be ready initially
+			expect(extensionHost.isWebviewReady()).toBe(false)
+
+			// Send message - it should be queued
+			await extensionHost.sendWebviewMessage(message)
+
+			// Verify message was queued (check internal state)
+			const pendingMessages = (extensionHost as any).pendingMessages
+			expect(pendingMessages).toHaveLength(1)
+			expect(pendingMessages[0]).toEqual(message)
+		})
+
+		it("should queue multiple messages before webview is ready", async () => {
+			const messages: WebviewMessage[] = [
+				{ type: "mode", text: "code" },
+				{ type: "newTask", text: "Test task" },
+				{ type: "telemetrySetting", text: "enabled" },
+			]
+
+			// Send all messages
+			for (const message of messages) {
+				await extensionHost.sendWebviewMessage(message)
+			}
+
+			// Verify all messages were queued
+			const pendingMessages = (extensionHost as any).pendingMessages
+			expect(pendingMessages).toHaveLength(3)
+			expect(pendingMessages).toEqual(messages)
+		})
+
+		it("should not queue messages after webview is ready", async () => {
+			// Mark webview as ready
+			extensionHost.markWebviewReady()
+
+			const message: WebviewMessage = {
+				type: "newTask",
+				text: "Test task",
+			}
+
+			// Mock the webview provider to prevent actual message sending
+			const mockProvider = {
+				handleCLIMessage: vi.fn(),
+			}
+			;(extensionHost as any).webviewProviders.set("kilo-code.SidebarProvider", mockProvider)
+
+			// Send message - it should not be queued
+			await extensionHost.sendWebviewMessage(message)
+
+			// Verify message was not queued
+			const pendingMessages = (extensionHost as any).pendingMessages
+			expect(pendingMessages).toHaveLength(0)
+
+			// Verify message was sent directly
+			expect(mockProvider.handleCLIMessage).toHaveBeenCalledWith(message)
+		})
+	})
+
+	describe("Message Flushing", () => {
+		it("should flush all pending messages when webview becomes ready", async () => {
+			const messages: WebviewMessage[] = [
+				{ type: "mode", text: "code" },
+				{ type: "newTask", text: "Test task" },
+			]
+
+			// Queue messages
+			for (const message of messages) {
+				await extensionHost.sendWebviewMessage(message)
+			}
+
+			// Verify messages are queued
+			expect((extensionHost as any).pendingMessages).toHaveLength(2)
+
+			// Mock the webview provider
+			const mockProvider = {
+				handleCLIMessage: vi.fn(),
+			}
+			;(extensionHost as any).webviewProviders.set("kilo-code.SidebarProvider", mockProvider)
+
+			// Mark webview as ready - this should flush messages
+			extensionHost.markWebviewReady()
+
+			// Wait for async flush to complete
+			await new Promise((resolve) => setTimeout(resolve, 10))
+
+			// Verify pending messages were cleared
+			expect((extensionHost as any).pendingMessages).toHaveLength(0)
+
+			// Verify all messages were sent
+			expect(mockProvider.handleCLIMessage).toHaveBeenCalledTimes(2)
+		})
+
+		it("should maintain message order when flushing", async () => {
+			const messages: WebviewMessage[] = [
+				{ type: "mode", text: "code" },
+				{ type: "telemetrySetting", text: "enabled" },
+				{ type: "newTask", text: "Test task" },
+			]
+
+			// Queue messages
+			for (const message of messages) {
+				await extensionHost.sendWebviewMessage(message)
+			}
+
+			// Mock the webview provider to track call order
+			const callOrder: string[] = []
+			const mockProvider = {
+				handleCLIMessage: vi.fn((msg: WebviewMessage) => {
+					callOrder.push(msg.type)
+				}),
+			}
+			;(extensionHost as any).webviewProviders.set("kilo-code.SidebarProvider", mockProvider)
+
+			// Mark webview as ready
+			extensionHost.markWebviewReady()
+
+			// Wait for async flush
+			await new Promise((resolve) => setTimeout(resolve, 10))
+
+			// Verify messages were sent in order
+			expect(callOrder).toEqual(["mode", "telemetrySetting", "newTask"])
+		})
+	})
+
+	describe("Initialization State", () => {
+		it("should start in initial setup mode", () => {
+			expect(extensionHost.isInInitialSetup()).toBe(true)
+		})
+
+		it("should exit initial setup mode when webview is marked ready", () => {
+			expect(extensionHost.isInInitialSetup()).toBe(true)
+
+			extensionHost.markWebviewReady()
+
+			expect(extensionHost.isInInitialSetup()).toBe(false)
+		})
+
+		it("should not be ready initially", () => {
+			expect(extensionHost.isWebviewReady()).toBe(false)
+		})
+
+		it("should be ready after markWebviewReady is called", () => {
+			extensionHost.markWebviewReady()
+
+			expect(extensionHost.isWebviewReady()).toBe(true)
+		})
+	})
+
+	describe("Race Condition Prevention", () => {
+		it("should prevent task abortion by queuing newTask messages", async () => {
+			// Simulate the race condition scenario:
+			// 1. Extension activates
+			// 2. CLI sends newTask immediately
+			// 3. Webview resolves later
+
+			const newTaskMessage: WebviewMessage = {
+				type: "newTask",
+				text: "Test task from CLI",
+			}
+
+			// Send newTask before webview is ready (simulating CLI auto mode)
+			await extensionHost.sendWebviewMessage(newTaskMessage)
+
+			// Verify message is queued, not processed
+			const pendingMessages = (extensionHost as any).pendingMessages
+			expect(pendingMessages).toHaveLength(1)
+			expect(pendingMessages[0].type).toBe("newTask")
+
+			// Mock provider
+			const mockProvider = {
+				handleCLIMessage: vi.fn(),
+			}
+			;(extensionHost as any).webviewProviders.set("kilo-code.SidebarProvider", mockProvider)
+
+			// Now mark webview as ready (simulating resolveWebviewView completion)
+			extensionHost.markWebviewReady()
+
+			// Wait for flush
+			await new Promise((resolve) => setTimeout(resolve, 10))
+
+			// Verify the newTask message was sent AFTER webview was ready
+			expect(mockProvider.handleCLIMessage).toHaveBeenCalledWith(newTaskMessage)
+			expect((extensionHost as any).pendingMessages).toHaveLength(0)
+		})
+
+		it("should handle configuration injection before task creation", async () => {
+			const configMessage: WebviewMessage = {
+				type: "mode",
+				text: "architect",
+			}
+
+			const taskMessage: WebviewMessage = {
+				type: "newTask",
+				text: "Design a system",
+			}
+
+			// Send config and task messages before webview is ready
+			await extensionHost.sendWebviewMessage(configMessage)
+			await extensionHost.sendWebviewMessage(taskMessage)
+
+			// Both should be queued
+			const pendingMessages = (extensionHost as any).pendingMessages
+			expect(pendingMessages).toHaveLength(2)
+
+			// Mock provider
+			const callOrder: string[] = []
+			const mockProvider = {
+				handleCLIMessage: vi.fn((msg: WebviewMessage) => {
+					callOrder.push(msg.type)
+				}),
+			}
+			;(extensionHost as any).webviewProviders.set("kilo-code.SidebarProvider", mockProvider)
+
+			// Mark ready
+			extensionHost.markWebviewReady()
+			await new Promise((resolve) => setTimeout(resolve, 10))
+
+			// Verify config was sent before task
+			expect(callOrder).toEqual(["mode", "newTask"])
+		})
+	})
+
+	describe("Edge Cases", () => {
+		it("should handle markWebviewReady being called multiple times", () => {
+			extensionHost.markWebviewReady()
+			expect(extensionHost.isWebviewReady()).toBe(true)
+
+			// Call again - should not cause issues
+			extensionHost.markWebviewReady()
+			expect(extensionHost.isWebviewReady()).toBe(true)
+		})
+
+		it("should handle empty pending messages queue", () => {
+			// Mark ready with no pending messages
+			expect((extensionHost as any).pendingMessages).toHaveLength(0)
+
+			// Should not throw
+			expect(() => extensionHost.markWebviewReady()).not.toThrow()
+
+			expect(extensionHost.isWebviewReady()).toBe(true)
+		})
+
+		it("should handle messages sent during flush", async () => {
+			// Queue initial message
+			await extensionHost.sendWebviewMessage({ type: "mode", text: "code" })
+
+			// Mock provider that sends another message during handling
+			const mockProvider = {
+				handleCLIMessage: vi.fn(async (msg: WebviewMessage) => {
+					if (msg.type === "mode") {
+						// Send another message during flush
+						await extensionHost.sendWebviewMessage({ type: "telemetrySetting", text: "enabled" })
+					}
+				}),
+			}
+			;(extensionHost as any).webviewProviders.set("kilo-code.SidebarProvider", mockProvider)
+
+			// Mark ready and flush
+			extensionHost.markWebviewReady()
+			await new Promise((resolve) => setTimeout(resolve, 20))
+
+			// Both messages should have been processed
+			expect(mockProvider.handleCLIMessage).toHaveBeenCalledTimes(2)
+		})
+	})
+})

--- a/cli/src/host/__tests__/webview-async-resolution.test.ts
+++ b/cli/src/host/__tests__/webview-async-resolution.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { ExtensionHost } from "../ExtensionHost.js"
+import * as path from "path"
+import * as fs from "fs"
+import { fileURLToPath } from "url"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+describe("Webview Async Resolution", () => {
+	let extensionHost: ExtensionHost
+	let tempDir: string
+
+	beforeEach(() => {
+		// Create a temporary directory for the test
+		tempDir = path.join(__dirname, "..", "..", "..", "test-temp", `test-${Date.now()}`)
+		fs.mkdirSync(tempDir, { recursive: true })
+
+		// Create a mock extension bundle
+		const mockExtensionPath = path.join(tempDir, "extension.js")
+		fs.writeFileSync(
+			mockExtensionPath,
+			`
+			module.exports = {
+				activate: function(context) {
+					return {
+						getState: () => null,
+						sendMessage: () => {},
+					}
+				},
+				deactivate: function() {}
+			}
+		`,
+		)
+
+		extensionHost = new ExtensionHost({
+			workspacePath: tempDir,
+			extensionBundlePath: mockExtensionPath,
+			extensionRootPath: tempDir,
+		})
+	})
+
+	afterEach(async () => {
+		await extensionHost.deactivate()
+		// Clean up temp directory
+		if (fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	it("should await async resolveWebviewView before marking ready", async () => {
+		const resolutionOrder: string[] = []
+		let resolvePromise: () => void
+
+		// Create a promise that we control
+		const asyncResolution = new Promise<void>((resolve) => {
+			resolvePromise = resolve
+		})
+
+		// Mock provider with async resolveWebviewView
+		const mockProvider = {
+			resolveWebviewView: vi.fn(async () => {
+				resolutionOrder.push("resolveWebviewView-start")
+				await asyncResolution
+				resolutionOrder.push("resolveWebviewView-end")
+			}),
+		}
+
+		// Activate extension
+		await extensionHost.activate()
+
+		// Register the provider (simulating what VSCode API does)
+		extensionHost.registerWebviewProvider("test-provider", mockProvider)
+
+		// Simulate the webview registration flow
+		const vscode = (global as any).vscode
+		if (vscode && vscode.window) {
+			// This will trigger resolveWebviewView
+			vscode.window.registerWebviewViewProvider("test-provider", mockProvider)
+		}
+
+		// Wait a bit to ensure resolveWebviewView is called
+		await new Promise((resolve) => setTimeout(resolve, 50))
+
+		// At this point, resolveWebviewView should be running but not complete
+		expect(resolutionOrder).toContain("resolveWebviewView-start")
+		expect(resolutionOrder).not.toContain("resolveWebviewView-end")
+
+		// Webview should NOT be ready yet
+		expect(extensionHost.isWebviewReady()).toBe(false)
+
+		// Now complete the async resolution
+		resolvePromise!()
+
+		// Wait for the resolution to complete
+		await new Promise((resolve) => setTimeout(resolve, 50))
+
+		// Now it should be complete
+		expect(resolutionOrder).toContain("resolveWebviewView-end")
+
+		// And webview should be ready
+		expect(extensionHost.isWebviewReady()).toBe(true)
+	})
+
+	it("should handle synchronous resolveWebviewView correctly", async () => {
+		const mockProvider = {
+			resolveWebviewView: vi.fn(() => {
+				// Synchronous - no promise returned
+			}),
+		}
+
+		// Activate extension
+		await extensionHost.activate()
+
+		// Register the provider
+		extensionHost.registerWebviewProvider("test-provider", mockProvider)
+
+		// Simulate the webview registration flow
+		const vscode = (global as any).vscode
+		if (vscode && vscode.window) {
+			vscode.window.registerWebviewViewProvider("test-provider", mockProvider)
+		}
+
+		// Wait for registration to complete
+		await new Promise((resolve) => setTimeout(resolve, 50))
+
+		// Webview should be ready
+		expect(extensionHost.isWebviewReady()).toBe(true)
+	})
+
+	it("should queue messages until async resolution completes", async () => {
+		let resolvePromise: () => void
+		const asyncResolution = new Promise<void>((resolve) => {
+			resolvePromise = resolve
+		})
+
+		const receivedMessages: any[] = []
+		const mockProvider = {
+			resolveWebviewView: vi.fn(async () => {
+				await asyncResolution
+			}),
+			handleCLIMessage: vi.fn((message: any) => {
+				receivedMessages.push(message)
+			}),
+		}
+
+		// Activate extension
+		await extensionHost.activate()
+
+		// Register the provider
+		extensionHost.registerWebviewProvider("kilo-code.SidebarProvider", mockProvider)
+
+		// Simulate the webview registration flow
+		const vscode = (global as any).vscode
+		if (vscode && vscode.window) {
+			vscode.window.registerWebviewViewProvider("kilo-code.SidebarProvider", mockProvider)
+		}
+
+		// Send messages before resolution completes
+		await extensionHost.sendWebviewMessage({ type: "test1" })
+		await extensionHost.sendWebviewMessage({ type: "test2" })
+
+		// Messages should be queued, not received yet
+		expect(receivedMessages).toHaveLength(0)
+		expect(extensionHost.isWebviewReady()).toBe(false)
+
+		// Complete the async resolution
+		resolvePromise!()
+		await new Promise((resolve) => setTimeout(resolve, 100))
+
+		// Now webview should be ready and messages should be flushed
+		expect(extensionHost.isWebviewReady()).toBe(true)
+		expect(receivedMessages).toHaveLength(2)
+		expect(receivedMessages[0].type).toBe("test1")
+		expect(receivedMessages[1].type).toBe("test2")
+	})
+})

--- a/cli/src/services/__tests__/ExtensionService.test.ts
+++ b/cli/src/services/__tests__/ExtensionService.test.ts
@@ -265,6 +265,9 @@ describe("ExtensionService", () => {
 		it("should emit stateChange event when state changes", async () => {
 			await service.initialize()
 
+			// Mark webview as ready to allow messages to be processed
+			service.getExtensionHost().markWebviewReady()
+
 			const stateChangeHandler = vi.fn()
 			service.on("stateChange", stateChangeHandler)
 
@@ -283,6 +286,9 @@ describe("ExtensionService", () => {
 
 		it("should emit message event for extension messages", async () => {
 			await service.initialize()
+
+			// Mark webview as ready to allow messages to be processed
+			service.getExtensionHost().markWebviewReady()
 
 			const messageHandler = vi.fn()
 			service.on("message", messageHandler)


### PR DESCRIPTION
## Context

This PR refactors the VSCode webview mock initialization to prevent race conditions when CLI sends messages before the webview is ready. The implementation replaces the previous setTimeout-based delay with an event-based synchronization system using message queuing.

## Implementation

- Introduces a message queuing system that buffers messages sent before webview initialization completes
- Replaces setTimeout delay with immediate resolveWebviewView call followed by explicit markWebviewReady() signal
- Adds comprehensive test coverage for race condition scenarios and message queuing behavior
