### PR TITLE
Make Marketplace Publishing workflows idempotent

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -74,38 +74,49 @@ jobs:
             - name: Create and Push Git Tag
               run: |
                   current_package_version=$(node -p "require('./src/package.json').version")
-                  git tag -a "v${current_package_version}" -m "Release v${current_package_version}"
-                  git push origin "v${current_package_version}" --no-verify
-                  echo "Successfully created and pushed git tag v${current_package_version}"
+
+                  # Check if tag already exists remotely
+                  if git ls-remote --tags origin | grep -q "refs/tags/v${current_package_version}$"; then
+                    echo "Tag v${current_package_version} already exists remotely, skipping tag creation"
+                  else
+                    git tag -a "v${current_package_version}" -m "Release v${current_package_version}"
+                    git push origin "v${current_package_version}" --no-verify
+                    echo "Successfully created and pushed git tag v${current_package_version}"
+                  fi
             - name: Create GitHub Release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   current_package_version=$(node -p "require('./src/package.json').version")
 
-                  # Extract changelog for current version
-                  echo "Extracting changelog for version ${current_package_version}"
-                  # Try with 'v' prefix first (newer format), then without (older format)
-                  changelog_content=$(sed -n "/## \\[v${current_package_version}\\]/,/## \\[/p" CHANGELOG.md | sed '$d')
-                  if [ -z "$changelog_content" ]; then
-                    changelog_content=$(sed -n "/## \\[${current_package_version}\\]/,/## \\[/p" CHANGELOG.md | sed '$d')
-                  fi
-
-                  # If changelog extraction failed, use a default message
-                  if [ -z "$changelog_content" ]; then
-                    echo "Warning: No changelog section found for version ${current_package_version}"
-                    changelog_content="Release v${current_package_version}"
+                  # Check if release already exists
+                  if gh release view "v${current_package_version}" >/dev/null 2>&1; then
+                    echo "Release v${current_package_version} already exists, skipping release creation"
                   else
-                    echo "Found changelog section for version ${current_package_version}"
-                  fi
+                    # Extract changelog for current version
+                    echo "Extracting changelog for version ${current_package_version}"
+                    # Try with 'v' prefix first (newer format), then without (older format)
+                    changelog_content=$(sed -n "/## \\[v${current_package_version}\\]/,/## \\[/p" CHANGELOG.md | sed '$d')
+                    if [ -z "$changelog_content" ]; then
+                      changelog_content=$(sed -n "/## \\[${current_package_version}\\]/,/## \\[/p" CHANGELOG.md | sed '$d')
+                    fi
 
-                  # Create release with changelog content
-                  gh release create "v${current_package_version}" \
-                    --title "Release v${current_package_version}" \
-                    --notes "$changelog_content" \
-                    --target ${{ env.GIT_REF }} \
-                    bin/kilo-code-${current_package_version}.vsix
-                  echo "Successfully created GitHub Release v${current_package_version}"
+                    # If changelog extraction failed, use a default message
+                    if [ -z "$changelog_content" ]; then
+                      echo "Warning: No changelog section found for version ${current_package_version}"
+                      changelog_content="Release v${current_package_version}"
+                    else
+                      echo "Found changelog section for version ${current_package_version}"
+                    fi
+
+                    # Create release with changelog content
+                    gh release create "v${current_package_version}" \
+                      --title "Release v${current_package_version}" \
+                      --notes "$changelog_content" \
+                      --target ${{ env.GIT_REF }} \
+                      bin/kilo-code-${current_package_version}.vsix
+                    echo "Successfully created GitHub Release v${current_package_version}"
+                  fi
             - name: Upload VSIX artifact
               uses: actions/upload-artifact@v4
               with:
@@ -142,6 +153,7 @@ jobs:
                   name: kilo-code-vsix
                   path: bin/
             - name: Publish to VS Code Marketplace
+              continue-on-error: true
               env:
                   VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
                   OVSX_PAT: ${{ secrets.OVSX_TOKEN }}
@@ -199,7 +211,7 @@ jobs:
               run: pnpm install
             - name: Create .env file
               run: echo "KILOCODE_POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" >> .env
-            - name: Build
+            - name: Build JetBrains Plugin
               run: pnpm run jetbrains:bundle
               shell: bash
             - name: Get bundle name
@@ -209,16 +221,18 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  current_package_version=$(node -p "require('./src/package.json').version")
+                  current_package_version="${{ needs.create-release.outputs.version }}"
                   gh release upload "v${current_package_version}" \
-                    "jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}#JetBrains Plugin"
+                    "jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}#JetBrains Plugin" \
+                    --clobber
                   echo "Successfully attached JetBrains plugin to GitHub Release v${current_package_version}"
             - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
                   name: ${{ env.BUNDLE_NAME }}
                   path: jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}
-            - name: JetBrains Marketplace Publisher
+            - name: Publish to JetBrains Marketplace
+              continue-on-error: true
               run: |
                   curl \
                   -X POST \
@@ -228,3 +242,4 @@ jobs:
                   -F "channel=stable" \
                   -F "isHidden=false" \
                   https://plugins.jetbrains.com/plugin/uploadPlugin
+                  echo "Successfully published to JetBrains Marketplace"

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -12,10 +12,10 @@ env:
     TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
-    publish-extension:
+    create-release:
         runs-on: ubuntu-latest
         permissions:
-            contents: write # Required for pushing tags.
+            contents: write # Required for pushing tags and creating releases
         if: >
             ( github.event_name == 'pull_request' &&
             github.event.pull_request.base.ref == 'main' &&
@@ -77,14 +77,6 @@ jobs:
                   git tag -a "v${current_package_version}" -m "Release v${current_package_version}"
                   git push origin "v${current_package_version}" --no-verify
                   echo "Successfully created and pushed git tag v${current_package_version}"
-            - name: Publish Extension
-              env:
-                  VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
-                  OVSX_PAT: ${{ secrets.OVSX_TOKEN }}
-              run: |
-                  current_package_version=$(node -p "require('./src/package.json').version")
-                  pnpm --filter kilo-code publish:marketplace
-                  echo "Successfully published version $current_package_version to VS Code Marketplace"
             - name: Create GitHub Release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -120,8 +112,46 @@ jobs:
                   name: kilo-code-vsix
                   path: bin/kilo-code-${{ steps.get-version.outputs.version }}.vsix
 
+    publish-vscode:
+        needs: create-release
+        runs-on: ubuntu-latest
+        if: >
+            ( github.event_name == 'pull_request' &&
+            github.event.pull_request.base.ref == 'main' &&
+            contains(github.event.pull_request.title, 'Changeset version bump') ) ||
+            github.event_name == 'workflow_dispatch'
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ env.GIT_REF }}
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: ${{ env.PNPM_VERSION }}
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: "pnpm"
+            - name: Install dependencies
+              run: pnpm install
+            - name: Download VSIX artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: kilo-code-vsix
+                  path: bin/
+            - name: Publish to VS Code Marketplace
+              env:
+                  VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
+                  OVSX_PAT: ${{ secrets.OVSX_TOKEN }}
+              run: |
+                  current_package_version="${{ needs.create-release.outputs.version }}"
+                  pnpm --filter kilo-code publish:marketplace
+                  echo "Successfully published version $current_package_version to VS Code Marketplace"
+
     publish-jetbrains:
-        needs: publish-extension
+        needs: create-release
         runs-on: ubuntu-latest
         if: >
             ( github.event_name == 'pull_request' &&

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -21,6 +21,8 @@ jobs:
             github.event.pull_request.base.ref == 'main' &&
             contains(github.event.pull_request.title, 'Changeset version bump') ) ||
             github.event_name == 'workflow_dispatch'
+        outputs:
+            version: ${{ steps.get-version.outputs.version }}
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -43,6 +45,12 @@ jobs:
                   git config user.email "github-actions[bot]@users.noreply.github.com"
             - name: Create .env file
               run: echo "KILOCODE_POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}" >> .env
+            - name: Get version
+              id: get-version
+              run: |
+                  current_package_version=$(node -p "require('./src/package.json').version")
+                  echo "version=${current_package_version}" >> $GITHUB_OUTPUT
+                  echo "Version: ${current_package_version}"
             - name: Package Extension
               run: |
                   current_package_version=$(node -p "require('./src/package.json').version")
@@ -106,6 +114,11 @@ jobs:
                     --target ${{ env.GIT_REF }} \
                     bin/kilo-code-${current_package_version}.vsix
                   echo "Successfully created GitHub Release v${current_package_version}"
+            - name: Upload VSIX artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: kilo-code-vsix
+                  path: bin/kilo-code-${{ steps.get-version.outputs.version }}.vsix
 
     publish-jetbrains:
         needs: publish-extension
@@ -177,11 +190,11 @@ jobs:
                   path: jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}
             - name: JetBrains Marketplace Publisher
               run: |
-                 curl \
-                 -X POST \
-                 -H "Authorization: Bearer ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}" \
-                 -F "file=@jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}" \
-                 -F "pluginId=28350" \
-                 -F "channel=stable" \
-                 -F "isHidden=false" \
-                 https://plugins.jetbrains.com/plugin/uploadPlugin
+                  curl \
+                  -X POST \
+                  -H "Authorization: Bearer ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}" \
+                  -F "file=@jetbrains/plugin/build/distributions/${{ env.BUNDLE_NAME }}" \
+                  -F "pluginId=28350" \
+                  -F "channel=stable" \
+                  -F "isHidden=false" \
+                  https://plugins.jetbrains.com/plugin/uploadPlugin


### PR DESCRIPTION
We had a case where just the JetBrains side of publishing failed: https://github.com/Kilo-Org/kilocode/actions/runs/19174634471/job/54816372930 but didn't have a way of re-running just that part.

Our existing publishing workflow couldn't be re-run without issues. This PR makes the publishing workflow idempotent, so you can run it many times without anything bad happening. It splits out the tagging and release creation from the publishing steps for both the VS Code and JetBrains jobs. 

Reviewing commit by commit should be the easiest. 

