### PR TITLE
refactor: introduce postprocessGhostSuggestion API for Ghost autocomp…

### DIFF
--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -192,31 +192,20 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 		// Process the suggestion through the postprocessing pipeline
 		let fillInAtCursorSuggestion: FillInAtCursorSuggestion
 		if (parsedSuggestion.text) {
-			// Get model name, defaulting to empty string if not available
-			let modelName = ""
-			try {
-				modelName = model.getModelName() || ""
-			} catch (error) {
-				// If getModelName is not available or throws, use empty string
-				console.debug("Could not get model name for postprocessing:", error)
-			}
-
 			const processedText = postprocessGhostSuggestion({
 				suggestion: parsedSuggestion.text,
 				prefix,
 				suffix,
-				model: modelName,
+				model: model.getModelName() || "",
 			})
 
 			if (processedText) {
 				fillInAtCursorSuggestion = { text: processedText, prefix, suffix }
 				console.info("Final suggestion:", fillInAtCursorSuggestion)
 			} else {
-				// Suggestion was filtered out
 				fillInAtCursorSuggestion = { text: "", prefix, suffix }
 			}
 		} else {
-			// No suggestion from parsing
 			fillInAtCursorSuggestion = { text: "", prefix, suffix }
 		}
 

--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -7,7 +7,7 @@ import { ApiStreamChunk } from "../../../api/transform/stream"
 import { RecentlyVisitedRangesService } from "../../continuedev/core/vscode-test-harness/src/autocomplete/RecentlyVisitedRangesService"
 import { RecentlyEditedTracker } from "../../continuedev/core/vscode-test-harness/src/autocomplete/recentlyEdited"
 import type { GhostServiceSettings } from "@roo-code/types"
-import { refuseUselessSuggestion } from "./uselessSuggestionFilter"
+import { postprocessGhostSuggestion } from "./uselessSuggestionFilter"
 
 const MAX_SUGGESTIONS_HISTORY = 20
 const DEBOUNCE_DELAY_MS = 300
@@ -187,13 +187,37 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 		console.log("response", response)
 
 		// Parse the response using the standalone function
-		let fillInAtCursorSuggestion = parseGhostResponse(response, prefix, suffix)
+		const parsedSuggestion = parseGhostResponse(response, prefix, suffix)
 
-		// Check if the suggestion is useless and clear it if so
-		if (fillInAtCursorSuggestion.text && refuseUselessSuggestion(fillInAtCursorSuggestion.text, prefix, suffix)) {
+		// Process the suggestion through the postprocessing pipeline
+		let fillInAtCursorSuggestion: FillInAtCursorSuggestion
+		if (parsedSuggestion.text) {
+			// Get model name, defaulting to empty string if not available
+			let modelName = ""
+			try {
+				modelName = model.getModelName() || ""
+			} catch (error) {
+				// If getModelName is not available or throws, use empty string
+				console.debug("Could not get model name for postprocessing:", error)
+			}
+
+			const processedText = postprocessGhostSuggestion({
+				suggestion: parsedSuggestion.text,
+				prefix,
+				suffix,
+				model: modelName,
+			})
+
+			if (processedText) {
+				fillInAtCursorSuggestion = { text: processedText, prefix, suffix }
+				console.info("Final suggestion:", fillInAtCursorSuggestion)
+			} else {
+				// Suggestion was filtered out
+				fillInAtCursorSuggestion = { text: "", prefix, suffix }
+			}
+		} else {
+			// No suggestion from parsing
 			fillInAtCursorSuggestion = { text: "", prefix, suffix }
-		} else if (fillInAtCursorSuggestion.text) {
-			console.info("Final suggestion:", fillInAtCursorSuggestion)
 		}
 
 		// Always return a FillInAtCursorSuggestion, even if text is empty

--- a/src/services/ghost/classic-auto-complete/__tests__/GhostInlineCompletionProvider.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/GhostInlineCompletionProvider.test.ts
@@ -379,6 +379,7 @@ describe("GhostInlineCompletionProvider", () => {
 				cacheWriteTokens: 0,
 				cacheReadTokens: 0,
 			}),
+			getModelName: vi.fn().mockReturnValue("test-model"),
 		} as unknown as GhostModel
 		mockCostTrackingCallback = vi.fn() as CostTrackingCallback
 

--- a/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
@@ -1,6 +1,118 @@
-import { refuseUselessSuggestion } from "../uselessSuggestionFilter"
+import { refuseUselessSuggestion, postprocessGhostSuggestion } from "../uselessSuggestionFilter"
 
-describe("refuseUselessSuggestion", () => {
+describe("postprocessGhostSuggestion", () => {
+	// Helper function to test filtering (returns undefined)
+	const shouldFilter = (suggestion: string, prefix: string, suffix: string, model = "") => {
+		return postprocessGhostSuggestion({ suggestion, prefix, suffix, model }) === undefined
+	}
+
+	// Helper function to test acceptance (returns processed string)
+	const shouldAccept = (suggestion: string, prefix: string, suffix: string, model = "") => {
+		const result = postprocessGhostSuggestion({ suggestion, prefix, suffix, model })
+		return result !== undefined
+	}
+
+	describe("should filter out useless suggestions", () => {
+		it("should filter empty suggestions", () => {
+			expect(shouldFilter("", "const x = ", " + 1")).toBe(true)
+			expect(shouldFilter("   ", "const x = ", " + 1")).toBe(true)
+			expect(shouldFilter("\t\n", "const x = ", " + 1")).toBe(true)
+		})
+
+		it("should filter suggestions that match the end of prefix", () => {
+			// Exact match at the end
+			expect(shouldFilter("hello", "const x = hello", "")).toBe(true)
+			expect(shouldFilter("world", "hello world", " + 1")).toBe(true)
+
+			// With whitespace variations
+			expect(shouldFilter("test", "const test ", "")).toBe(true)
+			expect(shouldFilter("foo", "bar foo  ", "")).toBe(true)
+		})
+
+		it("should filter suggestions that match the start of suffix", () => {
+			// Exact match at the start
+			expect(shouldFilter("hello", "const x = ", "hello world")).toBe(true)
+			expect(shouldFilter("const", "", "const y = 2")).toBe(true)
+
+			// With whitespace variations
+			expect(shouldFilter("test", "const x = ", "  test()")).toBe(true)
+			expect(shouldFilter("foo", "", " foo bar")).toBe(true)
+
+			// Trimmed match
+			expect(shouldFilter("bar", "const x = ", "  bar  baz")).toBe(true)
+		})
+
+		it("should filter suggestions when trimmed version matches", () => {
+			expect(shouldFilter("  hello  ", "const x = ", "hello world")).toBe(true)
+			expect(shouldFilter("\nhello\t", "test hello", "")).toBe(true)
+		})
+	})
+
+	describe("should accept useful suggestions", () => {
+		it("should accept suggestions that add new content", () => {
+			expect(shouldAccept("newValue", "const x = ", "")).toBe(true)
+			expect(shouldAccept("42", "const x = ", " + y")).toBe(true)
+			expect(shouldAccept("middle", "const x = ", " + y")).toBe(true)
+		})
+
+		it("should accept suggestions that don't match prefix end or suffix start", () => {
+			expect(shouldAccept("hello", "const x = ", "world")).toBe(true)
+			expect(shouldAccept("test", "const x = ", "const y = 2")).toBe(true)
+			expect(shouldAccept("foo", "bar", "baz")).toBe(true)
+		})
+
+		it("should accept partial matches that are still useful", () => {
+			// Suggestion "hello world" with prefix ending in "hello" should be accepted
+			// because the full suggestion doesn't match what's at the end of the prefix
+			expect(shouldAccept("hello world", "const x = hello", "")).toBe(true)
+			expect(shouldAccept("test123", "test", "456")).toBe(true)
+		})
+
+		it("should accept suggestions with meaningful content between prefix and suffix", () => {
+			expect(shouldAccept("= 42", "const x ", " + y")).toBe(true)
+			expect(shouldAccept("()", "myFunction", ".then()")).toBe(true)
+		})
+	})
+
+	describe("edge cases", () => {
+		it("should handle empty prefix and suffix", () => {
+			expect(shouldAccept("hello", "", "")).toBe(true)
+			expect(shouldFilter("", "", "")).toBe(true)
+		})
+
+		it("should handle very long strings", () => {
+			const longString = "a".repeat(1000)
+			expect(shouldAccept("different", longString, longString)).toBe(true)
+			expect(shouldFilter("different", longString + "different", "")).toBe(true)
+		})
+
+		it("should handle special characters", () => {
+			expect(shouldFilter("${}", "const template = `", "${}`")).toBe(true)
+			expect(shouldFilter("\\n", "const x = ", "\\n")).toBe(true)
+			expect(shouldFilter("/**/", "const x = /**/", "")).toBe(true)
+		})
+
+		it("should handle unicode characters", () => {
+			expect(shouldFilter("😀", "const emoji = ", "😀")).toBe(true)
+			expect(shouldFilter("你好", "const greeting = 你好", "")).toBe(true)
+			expect(shouldAccept("🚀", "launch", "🌟")).toBe(true)
+		})
+	})
+
+	describe("returns the original suggestion when accepted", () => {
+		it("should return the original suggestion, not the trimmed version", () => {
+			const result = postprocessGhostSuggestion({
+				suggestion: "  hello world  ",
+				prefix: "const x = ",
+				suffix: "",
+				model: "",
+			})
+			expect(result).toBe("  hello world  ")
+		})
+	})
+})
+
+describe("refuseUselessSuggestion (deprecated)", () => {
 	describe("should refuse useless suggestions", () => {
 		it("should refuse empty suggestions", () => {
 			expect(refuseUselessSuggestion("", "const x = ", " + 1")).toBe(true)
@@ -51,7 +163,8 @@ describe("refuseUselessSuggestion", () => {
 		})
 
 		it("should accept partial matches that are still useful", () => {
-			// Suggestion contains but doesn't exactly match
+			// Suggestion "hello world" with prefix ending in "hello" should be accepted
+			// because the full suggestion doesn't match what's at the end of the prefix
 			expect(refuseUselessSuggestion("hello world", "const x = hello", "")).toBe(false)
 			expect(refuseUselessSuggestion("test123", "test", "456")).toBe(false)
 		})

--- a/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
@@ -1,4 +1,4 @@
-import { refuseUselessSuggestion, postprocessGhostSuggestion } from "../uselessSuggestionFilter"
+import { postprocessGhostSuggestion } from "../uselessSuggestionFilter"
 
 describe("postprocessGhostSuggestion", () => {
 	// Helper function to test filtering (returns undefined)
@@ -108,95 +108,6 @@ describe("postprocessGhostSuggestion", () => {
 				model: "",
 			})
 			expect(result).toBe("  hello world  ")
-		})
-	})
-})
-
-describe("refuseUselessSuggestion (deprecated)", () => {
-	describe("should refuse useless suggestions", () => {
-		it("should refuse empty suggestions", () => {
-			expect(refuseUselessSuggestion("", "const x = ", " + 1")).toBe(true)
-			expect(refuseUselessSuggestion("   ", "const x = ", " + 1")).toBe(true)
-			expect(refuseUselessSuggestion("\t\n", "const x = ", " + 1")).toBe(true)
-		})
-
-		it("should refuse suggestions that match the end of prefix", () => {
-			// Exact match at the end
-			expect(refuseUselessSuggestion("hello", "const x = hello", "")).toBe(true)
-			expect(refuseUselessSuggestion("world", "hello world", " + 1")).toBe(true)
-
-			// With whitespace variations
-			expect(refuseUselessSuggestion("test", "const test ", "")).toBe(true)
-			expect(refuseUselessSuggestion("foo", "bar foo  ", "")).toBe(true)
-		})
-
-		it("should refuse suggestions that match the start of suffix", () => {
-			// Exact match at the start
-			expect(refuseUselessSuggestion("hello", "const x = ", "hello world")).toBe(true)
-			expect(refuseUselessSuggestion("const", "", "const y = 2")).toBe(true)
-
-			// With whitespace variations
-			expect(refuseUselessSuggestion("test", "const x = ", "  test()")).toBe(true)
-			expect(refuseUselessSuggestion("foo", "", " foo bar")).toBe(true)
-
-			// Trimmed match
-			expect(refuseUselessSuggestion("bar", "const x = ", "  bar  baz")).toBe(true)
-		})
-
-		it("should refuse suggestions when trimmed version matches", () => {
-			expect(refuseUselessSuggestion("  hello  ", "const x = ", "hello world")).toBe(true)
-			expect(refuseUselessSuggestion("\nhello\t", "test hello", "")).toBe(true)
-		})
-	})
-
-	describe("should accept useful suggestions", () => {
-		it("should accept suggestions that add new content", () => {
-			expect(refuseUselessSuggestion("newValue", "const x = ", "")).toBe(false)
-			expect(refuseUselessSuggestion("42", "const x = ", " + y")).toBe(false)
-			expect(refuseUselessSuggestion("middle", "const x = ", " + y")).toBe(false)
-		})
-
-		it("should accept suggestions that don't match prefix end or suffix start", () => {
-			expect(refuseUselessSuggestion("hello", "const x = ", "world")).toBe(false)
-			expect(refuseUselessSuggestion("test", "const x = ", "const y = 2")).toBe(false)
-			expect(refuseUselessSuggestion("foo", "bar", "baz")).toBe(false)
-		})
-
-		it("should accept partial matches that are still useful", () => {
-			// Suggestion "hello world" with prefix ending in "hello" should be accepted
-			// because the full suggestion doesn't match what's at the end of the prefix
-			expect(refuseUselessSuggestion("hello world", "const x = hello", "")).toBe(false)
-			expect(refuseUselessSuggestion("test123", "test", "456")).toBe(false)
-		})
-
-		it("should accept suggestions with meaningful content between prefix and suffix", () => {
-			expect(refuseUselessSuggestion("= 42", "const x ", " + y")).toBe(false)
-			expect(refuseUselessSuggestion("()", "myFunction", ".then()")).toBe(false)
-		})
-	})
-
-	describe("edge cases", () => {
-		it("should handle empty prefix and suffix", () => {
-			expect(refuseUselessSuggestion("hello", "", "")).toBe(false)
-			expect(refuseUselessSuggestion("", "", "")).toBe(true)
-		})
-
-		it("should handle very long strings", () => {
-			const longString = "a".repeat(1000)
-			expect(refuseUselessSuggestion("different", longString, longString)).toBe(false)
-			expect(refuseUselessSuggestion("different", longString + "different", "")).toBe(true)
-		})
-
-		it("should handle special characters", () => {
-			expect(refuseUselessSuggestion("${}", "const template = `", "${}`")).toBe(true)
-			expect(refuseUselessSuggestion("\\n", "const x = ", "\\n")).toBe(true)
-			expect(refuseUselessSuggestion("/**/", "const x = /**/", "")).toBe(true)
-		})
-
-		it("should handle unicode characters", () => {
-			expect(refuseUselessSuggestion("😀", "const emoji = ", "😀")).toBe(true)
-			expect(refuseUselessSuggestion("你好", "const greeting = 你好", "")).toBe(true)
-			expect(refuseUselessSuggestion("🚀", "launch", "🌟")).toBe(false)
 		})
 	})
 })

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -39,18 +39,3 @@ export function postprocessGhostSuggestion(params: {
 	// The suggestion appears to be useful - return the original (not trimmed) suggestion
 	return suggestion
 }
-
-/**
- * @deprecated Use postprocessGhostSuggestion instead
- * Filters out useless autocomplete suggestions that don't provide value to the user
- *
- * @param suggestion - The suggested text to insert
- * @param prefix - The text before the cursor position
- * @param suffix - The text after the cursor position
- * @returns true if the suggestion should be refused (is useless), false if it should be kept
- */
-export function refuseUselessSuggestion(suggestion: string, prefix: string, suffix: string): boolean {
-	// Delegate to the new API for backward compatibility
-	const result = postprocessGhostSuggestion({ suggestion, prefix, suffix, model: "" })
-	return result === undefined
-}

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -1,4 +1,47 @@
 /**
+ * Postprocesses a Ghost autocomplete suggestion.
+ * This will eventually use the continuedev postprocessing pipeline,
+ * but for now reimplements the existing Ghost-specific checks.
+ *
+ * @param params - Object containing suggestion parameters
+ * @param params.suggestion - The suggested text to insert
+ * @param params.prefix - The text before the cursor position
+ * @param params.suffix - The text after the cursor position
+ * @param params.model - The model string (e.g., "codestral", "qwen3", etc.)
+ * @returns The processed suggestion text, or undefined if it should be filtered out
+ */
+export function postprocessGhostSuggestion(params: {
+	suggestion: string
+	prefix: string
+	suffix: string
+	model: string
+}): string | undefined {
+	const { suggestion, prefix, suffix } = params
+	// Note: model parameter will be used when we integrate with postprocessCompletion
+
+	// For now, reimplement the existing logic with the new API shape
+	const trimmedSuggestion = suggestion.trim()
+
+	if (!trimmedSuggestion) {
+		return undefined
+	}
+
+	const trimmedPrefixEnd = prefix.trimEnd()
+	if (trimmedPrefixEnd.endsWith(trimmedSuggestion)) {
+		return undefined
+	}
+
+	const trimmedSuffix = suffix.trimStart()
+	if (trimmedSuffix.startsWith(trimmedSuggestion)) {
+		return undefined
+	}
+
+	// The suggestion appears to be useful - return the original (not trimmed) suggestion
+	return suggestion
+}
+
+/**
+ * @deprecated Use postprocessGhostSuggestion instead
  * Filters out useless autocomplete suggestions that don't provide value to the user
  *
  * @param suggestion - The suggested text to insert
@@ -7,22 +50,7 @@
  * @returns true if the suggestion should be refused (is useless), false if it should be kept
  */
 export function refuseUselessSuggestion(suggestion: string, prefix: string, suffix: string): boolean {
-	const trimmedSuggestion = suggestion.trim()
-
-	if (!trimmedSuggestion) {
-		return true
-	}
-
-	const trimmedPrefixEnd = prefix.trimEnd()
-	if (trimmedPrefixEnd.endsWith(trimmedSuggestion)) {
-		return true
-	}
-
-	const trimmedSuffix = suffix.trimStart()
-	if (trimmedSuffix.startsWith(trimmedSuggestion)) {
-		return true
-	}
-
-	// The suggestion appears to be useful
-	return false
+	// Delegate to the new API for backward compatibility
+	const result = postprocessGhostSuggestion({ suggestion, prefix, suffix, model: "" })
+	return result === undefined
 }


### PR DESCRIPTION
…lete

- Add new postprocessGhostSuggestion function with structured params (suggestion, prefix, suffix, model)
- Update GhostInlineCompletionProvider to use new API and pass model name
- Keep refuseUselessSuggestion as deprecated wrapper for backward compatibility
- Update tests to cover both new and deprecated APIs
- This prepares for integration with continuedev postprocessing pipeline (PR #3680)
