### PR TITLE
Update image in model-access documentation

### DIFF
--- a/apps/kilocode-docs/docs/plans/enterprise/model-access.md
+++ b/apps/kilocode-docs/docs/plans/enterprise/model-access.md
@@ -13,7 +13,7 @@ Admins can **enable or disable** specific models, filter by attributes, and enfo
 2. Toggle the checkbox beside any model or provider to enable or disable access.
 3. Click "Save Changes" to apply
 
-<img width="800" height="877" alt="Model-Access-Select" src="https://github.com/user-attachments/assets/af71353d-facc-4d4b-a0cd-c7f2cea73e97" />
+<img width="800" alt="Model-Access-Select" src="https://github.com/user-attachments/assets/af71353d-facc-4d4b-a0cd-c7f2cea73e97" />
 
 ## Filtering Models
 


### PR DESCRIPTION
Screenshot on Model Limiting page was stretched; removed height limit so it renders properly

<img width="829" height="743" alt="Screenshot 2025-11-12 at 10 15 54 AM" src="https://github.com/user-attachments/assets/007b533a-e402-4e8c-b316-0e0975726984" />