### PR TITLE
fix: restrict inline completion provider to file scheme only

### DIFF
--- a/src/services/ghost/GhostServiceManager.ts
+++ b/src/services/ghost/GhostServiceManager.ts
@@ -110,7 +110,7 @@ export class GhostServiceManager {
 		} else {
 			// Register classic provider
 			this.inlineCompletionProviderDisposable = vscode.languages.registerInlineCompletionItemProvider(
-				"*",
+				{ scheme: "file" },
 				this.inlineCompletionProvider,
 			)
 			this.context.subscriptions.push(this.inlineCompletionProviderDisposable)


### PR DESCRIPTION
Changed document selector from '*' to { scheme: 'file' } in GhostServiceManager to exclude inline completions from git commit message editors and other non-file document types. This ensures ghost completions only appear in regular file editors where they are most useful and appropriate.

  - Related to https://github.com/Kilo-Org/kilocode/issues/3689