### PR TITLE
CLI - /teams list command

### DIFF
--- a/.changeset/public-rocks-yawn.md
+++ b/.changeset/public-rocks-yawn.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix "/teams list" command

--- a/cli/src/commands/teams.ts
+++ b/cli/src/commands/teams.ts
@@ -255,15 +255,18 @@ export const teamsCommand: Command = {
 	aliases: ["team", "org", "orgs"],
 	description: "Manage team/organization selection",
 	usage: "/teams [subcommand] [args]",
-	examples: ["/teams", "/teams select personal", "/teams select kilo-code", "/teams select my-team"],
+	examples: ["/teams", "/teams list", "/teams select personal", "/teams select kilo-code", "/teams select my-team"],
 	category: "settings",
 	priority: 10,
 	arguments: [
 		{
 			name: "subcommand",
-			description: "Subcommand: select",
+			description: "Subcommand: list, select",
 			required: false,
-			values: [{ value: "select", description: "Switch to a different team" }],
+			values: [
+				{ value: "list", description: "List all available teams" },
+				{ value: "select", description: "Switch to a different team" },
+			],
 		},
 		{
 			name: "team-name",
@@ -298,6 +301,10 @@ export const teamsCommand: Command = {
 
 		// Handle subcommands
 		switch (subcommand) {
+			case "list":
+				await listTeams(context)
+				break
+
 			case "select":
 				if (args.length < 2 || !args[1]) {
 					context.addMessage({


### PR DESCRIPTION
## Context


Resolve: #3526 

## Implementation

This PR adds an explicit /teams list subcommand to the CLI teams command. Previously, listing teams was only available when calling /teams with no arguments, and now it can be called explicitly via /teams list.

- Added list as an explicit subcommand alongside select
- Updated command examples, argument descriptions, and values to include the new list subcommand
- Implementation reuses the existing listTeams function

## Screenshots

<img width="2352" height="965" alt="image" src="https://github.com/user-attachments/assets/186929d8-03a1-4b69-b692-2c68eb029f96" />
