### PR TITLE
ci: fix marketplace publish vsix path

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -159,7 +159,9 @@ jobs:
                   OVSX_PAT: ${{ secrets.OVSX_TOKEN }}
               run: |
                   current_package_version="${{ needs.create-release.outputs.version }}"
-                  pnpm --filter kilo-code publish:marketplace
+                  cd src
+                  npx vsce publish --packagePath ../bin/kilo-code-${current_package_version}.vsix
+                  npx ovsx publish ../bin/kilo-code-${current_package_version}.vsix
                   echo "Successfully published version $current_package_version to VS Code Marketplace"
 
     publish-jetbrains:


### PR DESCRIPTION
Fix the marketplace publish workflow:
https://github.com/Kilo-Org/kilocode/actions/runs/19307816623/job/55220143615

The vsce command was triggering a new build, even though we already have the VSIX, so instead just point to the already built VSIX file(s)

Dev Notes: Yes, I know the `publish:marketplace` script target still exists. We can clean that up once we know this works