### PR TITLE
Managed indexing should be disabled by default

### DIFF
--- a/.changeset/all-cycles-flash.md
+++ b/.changeset/all-cycles-flash.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Managed codebase indexing is a new experimental feature that should be disabled by default. It is disabled on the backend, but the extension defaults to true. This change disables the feature by default.

--- a/src/services/kilocode/OrganizationService.ts
+++ b/src/services/kilocode/OrganizationService.ts
@@ -76,10 +76,10 @@ export class OrganizationService {
 	/**
 	 * Checks if code indexing is enabled for an organization
 	 * @param organization - The organization object
-	 * @returns true if code indexing is enabled (defaults to true if not specified)
+	 * @returns true if code indexing is enabled (defaults to false if not specified)
 	 */
 	public static isCodeIndexingEnabled(organization: KiloOrganization | null): boolean {
 		// Default to true if organization is null or setting is not specified
-		return organization?.settings?.code_indexing_enabled ?? true
+		return organization?.settings?.code_indexing_enabled ?? false
 	}
 }


### PR DESCRIPTION
We accidentally enabled managed indexing in the extension for all organization users. This results in the extension attempting to index projects even though the backend says the feature isn't available. We've mitigated the issue on the backend, but this gets the extension code fixed.