### PR TITLE
docs: update teams pricing to $15 per user per month

### DIFF
--- a/apps/kilocode-docs/docs/plans/about.md
+++ b/apps/kilocode-docs/docs/plans/about.md
@@ -26,7 +26,7 @@ No credits are included with a Teams or Enterprise plan purchase.
 - **Complete transparency** - see every request, cost, and usage pattern
 - **Team management** - roles, permissions, and usage controls
 
-**Cost:** $29 per user per month
+**Cost:** $15 per user per month
 
 ## What You Get from Kilo Enterprise
 

--- a/apps/kilocode-docs/docs/plans/dashboard.md
+++ b/apps/kilocode-docs/docs/plans/dashboard.md
@@ -113,7 +113,7 @@ Manage your Kilo Teams plan and seat allocation.
 ### Current Plan Details
 
 - **Plan type** (Kilo Teams)
-- **Monthly cost** per seat ($29/user/month)
+- **Monthly cost** per seat ($15/user/month)
 - **Billing cycle** dates and next charge
 - **Plan benefits** and included features
 

--- a/apps/kilocode-docs/docs/plans/migration.md
+++ b/apps/kilocode-docs/docs/plans/migration.md
@@ -57,7 +57,7 @@ Switch to **Kilo Teams** or **Kilo Enterprise** from other AI coding tools and e
 **Step 2: Kilo Setup**
 
 1. **Create organization** at [app.kilocode.com](https://app.kilocode.com)
-2. **Subscribe to Teams ($29/month)** or **Enterprise ($299/month)**
+2. **Subscribe to Teams ($15/month)** or **Enterprise ($299/month)**
 3. **Configure team settings** and usage policies
 4. **Purchase initial AI credits** based on usage estimates
 


### PR DESCRIPTION
Update pricing information across documentation files to reflect the new $15 per user per month cost for Kilo Teams plan.

**Issue**: https://github.com/Kilo-Org/kilocode-backend/issues/3143

**Other PRs**:
https://github.com/Kilo-Org/kilocode-landing/pull/367
https://github.com/Kilo-Org/kilocode-backend/pull/3154