### PR TITLE
feat(native-function-calling): add provider-level JSON tool use defaults

### DIFF
--- a/.changeset/tidy-rockets-reflect.md
+++ b/.changeset/tidy-rockets-reflect.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Synthetic provider now uses JSON tool calls by default

--- a/packages/types/src/kilocode/native-function-calling.ts
+++ b/packages/types/src/kilocode/native-function-calling.ts
@@ -26,13 +26,7 @@ export const nativeFunctionCallingProviders = [
 	"moonshot",
 ] satisfies ProviderName[] as ProviderName[]
 
-//Specific models, regardless of provider, that need JSON tool use.
-const modelsDefaultingToJsonKeywords = [
-	"claude-haiku-4.5",
-	"claude-haiku-4-5", //Haiku struggles with XML
-	"minimax-m2", // minimax needs the JSON calls to maintain reasoning coherance.
-]
-
+const modelsDefaultingToJsonKeywords = ["claude-haiku-4.5", "claude-haiku-4-5", "minimax-m2"]
 //Specific providers that default to JSON tool use, regardless of model.
 const providersDefaultingToJsonKeywords = [
 	"synthetic", //All synthetic models support JSON tools, and their pricing model strongly encourages their use
@@ -43,23 +37,19 @@ export function getActiveToolUseStyle(settings: ProviderSettings | undefined): T
 		console.error("getActiveToolUseStyle: settings missing, returning xml")
 		return "xml"
 	}
-
-	const provider = settings.apiProvider as ProviderName
-
-	if (!nativeFunctionCallingProviders.includes(provider)) {
-		return "xml" //default to xml for providers that don't support native function calling
+	if (settings.apiProvider && !nativeFunctionCallingProviders.includes(settings.apiProvider as ProviderName)) {
+		return "xml"
 	}
 	if (settings.toolStyle) {
-		return settings.toolStyle //use explicitly set style if available.
+		return settings.toolStyle
 	}
 	const model = getModelId(settings)?.toLowerCase()
 	if (!model) {
 		console.error("getActiveToolUseStyle: model missing, returning xml")
-		return "xml" //default to xml if model is missing
+		return "xml"
 	}
-	if (providersDefaultingToJsonKeywords.includes(provider)) {
+	if (providersDefaultingToJsonKeywords.includes(settings.apiProvider as ProviderName)) {
 		return "json" //providers that always use json
 	}
-	// models that specifically need json, otherwise default to XML.
 	return modelsDefaultingToJsonKeywords.some((keyword) => model.includes(keyword)) ? "json" : "xml"
 }


### PR DESCRIPTION


## Context

Some providers work best with JSON.  We should default them on.   Discussed with @reissbaker and he is in agreement this is good choice for Synthetic.

## Implementation

- Introduce providersDefaultingToJsonKeywords for providers preferring JSON tool use
- Add synthetic provider to default to JSON
- Detailed inline comments explaining model and provider defaults



## Get in Touch

mcowger
