### PR TITLE
Bmc/start figuring out why code indexing going bananas

### DIFF
--- a/cli/src/host/ExtensionHost.ts
+++ b/cli/src/host/ExtensionHost.ts
@@ -552,8 +552,6 @@ export class ExtensionHost extends EventEmitter {
 
 	private async activateExtension(): Promise<void> {
 		try {
-			logs.info("Calling extension activate function...", "ExtensionHost")
-
 			// Call the extension's activate function with our mocked context
 			// Use safeExecute to catch and handle any errors without crashing the CLI
 			this.extensionAPI =
@@ -562,6 +560,7 @@ export class ExtensionHost extends EventEmitter {
 						if (!this.extensionModule || !this.vscodeAPI) {
 							throw new Error("Extension module or VSCode API not initialized")
 						}
+						logs.info("Calling extension activate function...", "ExtensionHost")
 						return await this.extensionModule.activate(this.vscodeAPI.context)
 					},
 					"extension.activate",

--- a/cli/src/state/atoms/effects.ts
+++ b/cli/src/state/atoms/effects.ts
@@ -38,6 +38,22 @@ const messageBufferAtom = atom<ExtensionMessage[]>([])
  */
 const isProcessingBufferAtom = atom<boolean>(false)
 
+// Indexing status types
+export interface IndexingStatus {
+	systemStatus: string
+	message?: string
+	processedItems: number
+	totalItems: number
+	currentItemUnit?: string
+	workspacePath?: string
+	gitBranch?: string // Current git branch being indexed
+	manifest?: {
+		totalFiles: number
+		totalChunks: number
+		lastUpdated: string
+	}
+}
+
 /**
  * Effect atom to initialize the ExtensionService
  * This sets up event listeners and activates the service
@@ -229,6 +245,15 @@ export const messageHandlerEffectAtom = atom(null, (get, set, message: Extension
 			case "invoke":
 				// Invoke messages trigger specific UI actions
 				break
+
+			case "indexingStatusUpdate": {
+				// logs.debug('indexing status', 'effects', message.values)
+				// const indexingMsg: IndexingStatus = message.values as unknown as IndexingStatus
+				// Indexing status updates are handled by the code index manager
+				// const logMsg = `Indexing Status - processed: ${indexingMsg.processedItems}. total: ${indexingMsg.totalItems}. status: ${indexingMsg.systemStatus}`
+				// logs.debug(logMsg)
+				break
+			}
 
 			default:
 				logs.debug(`Unhandled message type: ${message.type}`, "effects")

--- a/cli/src/state/atoms/effects.ts
+++ b/cli/src/state/atoms/effects.ts
@@ -247,11 +247,8 @@ export const messageHandlerEffectAtom = atom(null, (get, set, message: Extension
 				break
 
 			case "indexingStatusUpdate": {
-				// logs.debug('indexing status', 'effects', message.values)
-				// const indexingMsg: IndexingStatus = message.values as unknown as IndexingStatus
-				// Indexing status updates are handled by the code index manager
-				// const logMsg = `Indexing Status - processed: ${indexingMsg.processedItems}. total: ${indexingMsg.totalItems}. status: ${indexingMsg.systemStatus}`
-				// logs.debug(logMsg)
+				// this message fires rapidly as the scanner is progressing and we don't have a UI for it in the
+				// CLI at this point, so just quietly ignore it. Eventually we can add more CLI info about indexing.
 				break
 			}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,7 +81,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	try {
 		telemetryService.register(new PostHogTelemetryClient())
 	} catch (error) {
-		console.warn("Failed to register PostHogTelemetryClient:", error)
+		console.warn("Failed to register PostHogTelemetryClient:", error.message)
 	}
 
 	// Create logger for cloud services.

--- a/src/services/code-index/managed/__tests__/error-handling.spec.ts
+++ b/src/services/code-index/managed/__tests__/error-handling.spec.ts
@@ -84,7 +84,7 @@ describe("Managed Indexing Error Handling", () => {
 		})
 
 		// Attempt to start indexing
-		await expect(startIndexing(config, mockContext)).rejects.toThrow(/Scan failed with 3 errors/)
+		await expect(startIndexing(config, mockContext, () => {})).rejects.toThrow(/Scan failed with 3 errors/)
 	})
 
 	it("should include error details in thrown error message", async () => {
@@ -99,7 +99,7 @@ describe("Managed Indexing Error Handling", () => {
 		})
 
 		try {
-			await startIndexing(config, mockContext)
+			await startIndexing(config, mockContext, () => {})
 			expect.fail("Should have thrown an error")
 		} catch (error) {
 			expect(error).toBeInstanceOf(Error)
@@ -122,7 +122,7 @@ describe("Managed Indexing Error Handling", () => {
 		})
 
 		try {
-			await startIndexing(config, mockContext)
+			await startIndexing(config, mockContext, () => {})
 			expect.fail("Should have thrown an error")
 		} catch (error) {
 			expect(error).toBeInstanceOf(Error)

--- a/src/services/code-index/managed/__tests__/error-handling.spec.ts
+++ b/src/services/code-index/managed/__tests__/error-handling.spec.ts
@@ -84,7 +84,7 @@ describe("Managed Indexing Error Handling", () => {
 		})
 
 		// Attempt to start indexing
-		await expect(startIndexing(config, mockContext, () => {})).rejects.toThrow(/Scan failed with 3 errors/)
+		await expect(startIndexing(config, () => {})).rejects.toThrow(/Scan failed with 3 errors/)
 	})
 
 	it("should include error details in thrown error message", async () => {
@@ -99,7 +99,7 @@ describe("Managed Indexing Error Handling", () => {
 		})
 
 		try {
-			await startIndexing(config, mockContext, () => {})
+			await startIndexing(config, () => {})
 			expect.fail("Should have thrown an error")
 		} catch (error) {
 			expect(error).toBeInstanceOf(Error)
@@ -122,7 +122,7 @@ describe("Managed Indexing Error Handling", () => {
 		})
 
 		try {
-			await startIndexing(config, mockContext, () => {})
+			await startIndexing(config, () => {})
 			expect.fail("Should have thrown an error")
 		} catch (error) {
 			expect(error).toBeInstanceOf(Error)
@@ -149,7 +149,7 @@ describe("Managed Indexing Error Handling", () => {
 		})
 
 		try {
-			await startIndexing(config, mockContext, onStateChange)
+			await startIndexing(config, onStateChange)
 		} catch {
 			// Expected to throw
 		}

--- a/src/services/code-index/managed/git-watcher.ts
+++ b/src/services/code-index/managed/git-watcher.ts
@@ -43,13 +43,13 @@ interface GitStateSnapshot {
  *
  * @param config Managed indexing configuration
  * @param context VSCode extension context
- * @param onStateChange Optional callback when git state changes
+ * @param onStateChange Callback when git state changes
  * @returns Disposable watcher instance
  */
 export async function createGitWatcher(
 	config: ManagedIndexingConfig,
 	context: vscode.ExtensionContext,
-	onStateChange?: (state: IndexerState) => void,
+	onStateChange: (state: IndexerState) => void,
 ): Promise<vscode.Disposable> {
 	const disposables: vscode.Disposable[] = []
 	let currentState: GitStateSnapshot | null = null
@@ -64,7 +64,7 @@ export async function createGitWatcher(
 			if (gitState) {
 				currentState = gitState
 			} else {
-				onStateChange?.({
+				onStateChange({
 					status: "idle",
 					message: "Detached HEAD state - indexing disabled",
 					gitBranch: undefined,
@@ -89,7 +89,7 @@ export async function createGitWatcher(
 			// Check for detached HEAD
 			if (await isDetachedHead(config.workspacePath)) {
 				currentState = null
-				onStateChange?.({
+				onStateChange({
 					status: "idle",
 					message: "Detached HEAD state - indexing disabled",
 					gitBranch: undefined,
@@ -142,10 +142,10 @@ export async function createGitWatcher(
 		newBranch: string,
 		config: ManagedIndexingConfig,
 		context: vscode.ExtensionContext,
-		onStateChange?: (state: IndexerState) => void,
+		onStateChange: (state: IndexerState) => void,
 	) => {
 		try {
-			onStateChange?.({
+			onStateChange({
 				status: "scanning",
 				message: `Branch changed to ${newBranch}, fetching manifest...`,
 				gitBranch: newBranch,
@@ -165,14 +165,14 @@ export async function createGitWatcher(
 			}
 
 			// Trigger re-scan with manifest
-			onStateChange?.({
+			onStateChange({
 				status: "scanning",
 				message: `Scanning branch ${newBranch}...`,
 				gitBranch: newBranch,
 			})
 
 			const result = await scanDirectory(config, context, manifest, (progress) => {
-				onStateChange?.({
+				onStateChange({
 					status: "scanning",
 					message: `Scanning: ${progress.filesProcessed}/${progress.filesTotal} files (${progress.chunksIndexed} chunks)`,
 					gitBranch: newBranch,
@@ -193,7 +193,7 @@ export async function createGitWatcher(
 					logger.warn("[GitWatcher] Failed to fetch updated manifest after scan")
 				}
 
-				onStateChange?.({
+				onStateChange({
 					status: "watching",
 					message: `Branch ${newBranch} indexed successfully`,
 					gitBranch: newBranch,
@@ -213,7 +213,7 @@ export async function createGitWatcher(
 			}
 		} catch (error) {
 			logger.error(`[GitWatcher] Failed to handle branch change:`, error)
-			onStateChange?.({
+			onStateChange({
 				status: "error",
 				message: `Failed to index branch ${newBranch}: ${error instanceof Error ? error.message : String(error)}`,
 				error: error instanceof Error ? error.message : String(error),
@@ -229,10 +229,10 @@ export async function createGitWatcher(
 		branch: string,
 		config: ManagedIndexingConfig,
 		context: vscode.ExtensionContext,
-		onStateChange?: (state: IndexerState) => void,
+		onStateChange: (state: IndexerState) => void,
 	) => {
 		try {
-			onStateChange?.({
+			onStateChange({
 				status: "scanning",
 				message: `New commit detected, updating index...`,
 				gitBranch: branch,
@@ -253,7 +253,7 @@ export async function createGitWatcher(
 
 			// Re-scan to pick up committed changes
 			const result = await scanDirectory(config, context, manifest, (progress) => {
-				onStateChange?.({
+				onStateChange({
 					status: "scanning",
 					message: `Updating: ${progress.filesProcessed}/${progress.filesTotal} files (${progress.chunksIndexed} chunks)`,
 					gitBranch: branch,
@@ -274,7 +274,7 @@ export async function createGitWatcher(
 					logger.warn("[GitWatcher] Failed to fetch updated manifest after commit")
 				}
 
-				onStateChange?.({
+				onStateChange({
 					status: "watching",
 					message: `Index updated after commit`,
 					gitBranch: branch,
@@ -294,7 +294,7 @@ export async function createGitWatcher(
 			}
 		} catch (error) {
 			logger.error(`[GitWatcher] Failed to handle commit:`, error)
-			onStateChange?.({
+			onStateChange({
 				status: "error",
 				message: `Failed to update index after commit: ${error instanceof Error ? error.message : String(error)}`,
 				error: error instanceof Error ? error.message : String(error),

--- a/src/services/code-index/managed/git-watcher.ts
+++ b/src/services/code-index/managed/git-watcher.ts
@@ -42,13 +42,11 @@ interface GitStateSnapshot {
  * - Disables indexing in detached HEAD state
  *
  * @param config Managed indexing configuration
- * @param context VSCode extension context
  * @param onStateChange Callback when git state changes
  * @returns Disposable watcher instance
  */
 export async function createGitWatcher(
 	config: ManagedIndexingConfig,
-	context: vscode.ExtensionContext,
 	onStateChange: (state: IndexerState) => void,
 ): Promise<vscode.Disposable> {
 	const disposables: vscode.Disposable[] = []
@@ -114,13 +112,13 @@ export async function createGitWatcher(
 				}
 
 				if (branchChanged) {
-					await handleBranchChange(newState.branch, config, context, onStateChange)
+					await handleBranchChange(newState.branch, config, onStateChange)
 				} else if (commitChanged) {
-					await handleCommit(newState.branch, config, context, onStateChange)
+					await handleCommit(newState.branch, config, onStateChange)
 				}
 			} else {
 				// First time seeing a valid state (recovered from detached HEAD)
-				await handleBranchChange(newState.branch, config, context, onStateChange)
+				await handleBranchChange(newState.branch, config, onStateChange)
 			}
 
 			currentState = newState
@@ -141,7 +139,6 @@ export async function createGitWatcher(
 	const handleBranchChange = async (
 		newBranch: string,
 		config: ManagedIndexingConfig,
-		context: vscode.ExtensionContext,
 		onStateChange: (state: IndexerState) => void,
 	) => {
 		try {
@@ -171,7 +168,7 @@ export async function createGitWatcher(
 				gitBranch: newBranch,
 			})
 
-			const result = await scanDirectory(config, context, manifest, (progress) => {
+			const result = await scanDirectory(config, manifest, (progress) => {
 				onStateChange({
 					status: "scanning",
 					message: `Scanning: ${progress.filesProcessed}/${progress.filesTotal} files (${progress.chunksIndexed} chunks)`,
@@ -228,7 +225,6 @@ export async function createGitWatcher(
 	const handleCommit = async (
 		branch: string,
 		config: ManagedIndexingConfig,
-		context: vscode.ExtensionContext,
 		onStateChange: (state: IndexerState) => void,
 	) => {
 		try {
@@ -252,7 +248,7 @@ export async function createGitWatcher(
 			}
 
 			// Re-scan to pick up committed changes
-			const result = await scanDirectory(config, context, manifest, (progress) => {
+			const result = await scanDirectory(config, manifest, (progress) => {
 				onStateChange({
 					status: "scanning",
 					message: `Updating: ${progress.filesProcessed}/${progress.filesTotal} files (${progress.chunksIndexed} chunks)`,

--- a/src/services/code-index/managed/index.ts
+++ b/src/services/code-index/managed/index.ts
@@ -24,7 +24,7 @@
  *   workspacePath
  * )
  *
- * // Start indexing
+ * // Start indexing with state change callback
  * const disposable = await startIndexing(config, context, (state) => {
  *   console.log('State:', state)
  * })

--- a/src/services/code-index/managed/index.ts
+++ b/src/services/code-index/managed/index.ts
@@ -41,7 +41,7 @@
 export { startIndexing, search, getIndexerState, createManagedIndexingConfig } from "./indexer"
 
 // Scanner functions (for advanced usage)
-export { scanDirectory, indexFile, handleFileDeleted } from "./scanner"
+export { scanDirectory } from "./scanner"
 
 // Watcher functions
 export { createGitWatcher } from "./git-watcher"

--- a/src/services/code-index/managed/indexer.ts
+++ b/src/services/code-index/managed/indexer.ts
@@ -30,19 +30,19 @@ import { TelemetryEventName } from "@roo-code/types"
  *
  * @param config Managed indexing configuration
  * @param context VSCode extension context
- * @param onStateChange Optional state change callback
+ * @param onStateChange State change callback
  * @returns Disposable that stops the indexer when disposed
  */
 export async function startIndexing(
 	config: ManagedIndexingConfig,
 	context: vscode.ExtensionContext,
-	onStateChange?: (state: IndexerState) => void,
+	onStateChange: (state: IndexerState) => void,
 ): Promise<vscode.Disposable> {
 	try {
 		// Validate git repository
 		if (!(await isGitRepository(config.workspacePath))) {
 			const error = new Error("Workspace is not a git repository")
-			onStateChange?.({
+			onStateChange({
 				status: "error",
 				message: "Not a git repository",
 				error: error.message,
@@ -53,7 +53,7 @@ export async function startIndexing(
 		// Check for detached HEAD state
 		if (await isDetachedHead(config.workspacePath)) {
 			const error = new Error("Repository is in detached HEAD state")
-			onStateChange?.({
+			onStateChange({
 				status: "idle",
 				message: "Detached HEAD state - indexing disabled",
 			})
@@ -94,7 +94,7 @@ export async function startIndexing(
 		}
 
 		// Update state: scanning
-		onStateChange?.({
+		onStateChange({
 			status: "scanning",
 			message: `Starting scan on branch ${gitBranch}...`,
 			gitBranch,
@@ -102,7 +102,7 @@ export async function startIndexing(
 
 		// Perform initial scan with manifest for intelligent delta indexing
 		const result = await scanDirectory(config, context, manifest, (progress) => {
-			onStateChange?.({
+			onStateChange({
 				status: "scanning",
 				message: `Scanning: ${progress.filesProcessed}/${progress.filesTotal} files (${progress.chunksIndexed} chunks)`,
 				gitBranch,
@@ -197,7 +197,7 @@ export async function startIndexing(
 
 		// Update state based on whether we have data
 		if (hasIndexedData) {
-			onStateChange?.({
+			onStateChange({
 				status: "watching",
 				message: "Index up-to-date. Watching for git commits and branch changes.",
 				gitBranch,
@@ -214,7 +214,7 @@ export async function startIndexing(
 			})
 		} else {
 			// No data indexed - set to idle state to indicate re-scan is needed
-			onStateChange?.({
+			onStateChange({
 				status: "idle",
 				message: "No files indexed. Click 'Start Indexing' to begin.",
 				gitBranch,
@@ -227,7 +227,7 @@ export async function startIndexing(
 				if (gitWatcher) {
 					gitWatcher.dispose()
 				}
-				onStateChange?.({
+				onStateChange({
 					status: "idle",
 					message: "Indexing stopped",
 					gitBranch,
@@ -244,7 +244,7 @@ export async function startIndexing(
 			location: "startIndexing",
 		})
 
-		onStateChange?.({
+		onStateChange({
 			status: "error",
 			message: `Failed to start indexing: ${err.message}`,
 			error: err.message,

--- a/src/services/code-index/managed/webview.ts
+++ b/src/services/code-index/managed/webview.ts
@@ -60,9 +60,6 @@ export async function tryStartManagedIndexing(provider: ClineProvider): Promise<
  * This should be called whenever the API configuration changes
  */
 export async function updateCodeIndexWithKiloProps(provider: ClineProvider): Promise<void> {
-	// ClineProvider is too big to log
-	//console.log("updateCodeIndexWithKiloProps", provider)
-
 	try {
 		const { apiConfiguration } = await provider.getState()
 

--- a/src/services/code-index/manager.ts
+++ b/src/services/code-index/manager.ts
@@ -504,6 +504,7 @@ export class CodeIndexManager {
 		}
 
 		// Start managed indexing automatically
+		console.info("[BMC DEBUG] - [CodeIndexManager] Starting managed indexing due to Kilo org props set")
 		this.startManagedIndexing().catch((error) => {
 			const err = error instanceof Error ? error : new Error(String(error))
 			console.error("[CodeIndexManager] Failed to start managed indexing:", err.message)
@@ -532,11 +533,7 @@ export class CodeIndexManager {
 		}
 
 		try {
-			// Stop any existing managed indexer
-			if (this._managedIndexerDisposable) {
-				this._managedIndexerDisposable.dispose()
-				this._managedIndexerDisposable = undefined
-			}
+			this.stopManagedIndexing()
 
 			// Create configuration
 			const config = createManagedIndexingConfig(
@@ -586,6 +583,7 @@ export class CodeIndexManager {
 	 */
 	public stopManagedIndexing(): void {
 		if (this._managedIndexerDisposable) {
+			console.info("[CodeIndexManager] Stopping existing managed indexer")
 			this._managedIndexerDisposable.dispose()
 			this._managedIndexerDisposable = undefined
 			this._managedIndexerState = undefined

--- a/src/services/code-index/manager.ts
+++ b/src/services/code-index/manager.ts
@@ -292,10 +292,7 @@ export class CodeIndexManager {
 			this.stopWatcher()
 		}
 		// kilocode_change start
-		if (this._managedIndexerDisposable) {
-			this._managedIndexerDisposable.dispose()
-			this._managedIndexerDisposable = undefined
-		}
+		this.stopManagedIndexing()
 		// kilocode_change end
 		this._stateManager.dispose()
 	}
@@ -587,6 +584,8 @@ export class CodeIndexManager {
 			this._managedIndexerDisposable.dispose()
 			this._managedIndexerDisposable = undefined
 			this._managedIndexerState = undefined
+		} else {
+			console.info("[CodeIndexManager] - [stopManagedIndexing] No managed indexer to stop")
 		}
 	}
 

--- a/src/services/code-index/manager.ts
+++ b/src/services/code-index/manager.ts
@@ -504,7 +504,6 @@ export class CodeIndexManager {
 		}
 
 		// Start managed indexing automatically
-		console.info("[BMC DEBUG] - [CodeIndexManager] Starting managed indexing due to Kilo org props set")
 		this.startManagedIndexing().catch((error) => {
 			const err = error instanceof Error ? error : new Error(String(error))
 			console.error("[CodeIndexManager] Failed to start managed indexing:", err.message)
@@ -528,6 +527,7 @@ export class CodeIndexManager {
 	 * This is the new standalone indexing system that uses delta-based indexing
 	 */
 	public async startManagedIndexing(): Promise<void> {
+		console.info("[BMC DEBUG] - [CodeIndexManager] Starting managed indexing due to Kilo org props set")
 		if (!this._kiloOrgCodeIndexProps) {
 			throw new Error("Managed indexing requires organization credentials")
 		}

--- a/src/services/code-index/manager.ts
+++ b/src/services/code-index/manager.ts
@@ -491,7 +491,15 @@ export class CodeIndexManager {
 	} | null = null
 
 	public setKiloOrgCodeIndexProps(props: NonNullable<typeof this._kiloOrgCodeIndexProps>) {
-		console.log("setKiloOrgCodeIndexProps", props)
+		// this gets called more often than you'd expect so only actually kick off a new manager if things change
+		if (
+			props.kilocodeToken === this._kiloOrgCodeIndexProps?.kilocodeToken &&
+			props.organizationId === this._kiloOrgCodeIndexProps?.organizationId &&
+			props.projectId === this._kiloOrgCodeIndexProps?.projectId
+		) {
+			// No change in token, no need to restart indexing
+			return
+		}
 
 		this._kiloOrgCodeIndexProps = props
 
@@ -524,7 +532,7 @@ export class CodeIndexManager {
 	 * This is the new standalone indexing system that uses delta-based indexing
 	 */
 	public async startManagedIndexing(): Promise<void> {
-		console.info("[BMC DEBUG] - [CodeIndexManager] Starting managed indexing due to Kilo org props set")
+		console.info("[CodeIndexManager] Starting managed indexing due to Kilo org props set")
 		if (!this._kiloOrgCodeIndexProps) {
 			throw new Error("Managed indexing requires organization credentials")
 		}
@@ -541,7 +549,7 @@ export class CodeIndexManager {
 			)
 
 			// Start indexing
-			this._managedIndexerDisposable = await startManagedIndexing(config, this.context, (state) => {
+			this._managedIndexerDisposable = await startManagedIndexing(config, (state) => {
 				this._managedIndexerState = state
 				// Emit state change event through state manager
 				// Map managed indexer states to system states:

--- a/src/services/kilocode/OrganizationService.ts
+++ b/src/services/kilocode/OrganizationService.ts
@@ -3,7 +3,9 @@ import axios from "axios"
 import { getKiloUrlFromToken } from "@roo-code/types"
 import { X_KILOCODE_ORGANIZATIONID, X_KILOCODE_TESTER } from "../../shared/kilocode/headers"
 import { KiloOrganization, KiloOrganizationSchema } from "../../shared/kilocode/organization"
-import { logger } from "../../utils/logging"
+import { CompactLogger } from "../../utils/logging/CompactLogger"
+
+const logger = new CompactLogger()
 
 /**
  * Service for fetching and managing Kilo Code organization settings


### PR DESCRIPTION
- clean up & add bits of logging
- do not kick off multiple indexers if the config stays the same
- remove some unused function args and code