### PR TITLE
Fix Save button sometimes erroneously being active

### DIFF
--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -151,10 +151,6 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 	useEffect(() => {
 		ensureBodyPointerEventsRestored()
 	}, [isDiscardDialogShow])
-
-	useEffect(() => {
-		setChangeDetected(JSON.stringify(cachedState) !== JSON.stringify(extensionState))
-	}, [cachedState, extensionState])
 	// kilocode_change end
 
 	const {


### PR DESCRIPTION
This reverts PR #218, and surprisingly enough fixes the same problem as when originally making that PR.

The behaviour becomes especially egregrious in PR #3732 so this is a prerequisite for that
