### PR TITLE
CLI: Support bun installs

### DIFF
--- a/src/services/ripgrep/__tests__/index.spec.ts
+++ b/src/services/ripgrep/__tests__/index.spec.ts
@@ -2,7 +2,7 @@
 
 import * as path from "path" // kilocode_change
 import { getBinPath, truncateLine } from "../index" // kilocode_change
-import { fileExistsAtPath } from "../../../utils/fs"
+import { fileExistsAtPath } from "../../../utils/fs" // kilocode_change
 
 vi.mock("../../../utils/fs", () => ({
 	fileExistsAtPath: vi.fn(),

--- a/src/services/ripgrep/__tests__/index.spec.ts
+++ b/src/services/ripgrep/__tests__/index.spec.ts
@@ -54,7 +54,7 @@ describe("Ripgrep line truncation", () => {
 		expect(truncated).toContain("[truncated...]")
 	})
 })
-
+// kilocode_change start
 describe("getBinPath", () => {
 	const mockFileExists = fileExistsAtPath as ReturnType<typeof vi.fn>
 	const isWindows = process.platform.startsWith("win")

--- a/src/services/ripgrep/__tests__/index.spec.ts
+++ b/src/services/ripgrep/__tests__/index.spec.ts
@@ -140,3 +140,4 @@ describe("getBinPath", () => {
 		expect(result).toBe(traditionalPath)
 	})
 })
+// kilocode_change end

--- a/src/services/ripgrep/__tests__/index.spec.ts
+++ b/src/services/ripgrep/__tests__/index.spec.ts
@@ -3,7 +3,7 @@
 import * as path from "path" // kilocode_change
 import { getBinPath, truncateLine } from "../index" // kilocode_change
 import { fileExistsAtPath } from "../../../utils/fs" // kilocode_change
-
+// kilocode_change start
 vi.mock("../../../utils/fs", () => ({
 	fileExistsAtPath: vi.fn(),
 }))

--- a/src/services/ripgrep/__tests__/index.spec.ts
+++ b/src/services/ripgrep/__tests__/index.spec.ts
@@ -7,7 +7,7 @@ import { fileExistsAtPath } from "../../../utils/fs" // kilocode_change
 vi.mock("../../../utils/fs", () => ({
 	fileExistsAtPath: vi.fn(),
 }))
-
+// kilocode_change end
 describe("Ripgrep line truncation", () => {
 	// The default MAX_LINE_LENGTH is 500 in the implementation
 	const MAX_LINE_LENGTH = 500

--- a/src/services/ripgrep/__tests__/index.spec.ts
+++ b/src/services/ripgrep/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 // npx vitest run src/services/ripgrep/__tests__/index.spec.ts
 
-import * as path from "path"
+import * as path from "path" // kilocode_change
 import { getBinPath, truncateLine } from "../index"
 import { fileExistsAtPath } from "../../../utils/fs"
 

--- a/src/services/ripgrep/__tests__/index.spec.ts
+++ b/src/services/ripgrep/__tests__/index.spec.ts
@@ -1,7 +1,7 @@
 // npx vitest run src/services/ripgrep/__tests__/index.spec.ts
 
 import * as path from "path" // kilocode_change
-import { getBinPath, truncateLine } from "../index"
+import { getBinPath, truncateLine } from "../index" // kilocode_change
 import { fileExistsAtPath } from "../../../utils/fs"
 
 vi.mock("../../../utils/fs", () => ({

--- a/src/services/ripgrep/index.kilocode.ts
+++ b/src/services/ripgrep/index.kilocode.ts
@@ -1,0 +1,18 @@
+import path from "path"
+import { fileExistsAtPath } from "../../utils/fs"
+
+export async function checkBunPath(vscodeAppRoot: string, binName: string) {
+	// For bun: resolve package and find binary (bun uses symlinks to global cache)
+	try {
+		const ripgrepPkg = require.resolve("@vscode/ripgrep/package.json", { paths: [vscodeAppRoot] })
+		const ripgrepRoot = path.dirname(ripgrepPkg)
+		const bunPath = path.join(ripgrepRoot, "bin", binName)
+		if (await fileExistsAtPath(bunPath)) {
+			return bunPath
+		}
+	} catch (error) {
+		// Package not found via require.resolve
+	}
+
+	return undefined
+}

--- a/src/services/ripgrep/index.ts
+++ b/src/services/ripgrep/index.ts
@@ -82,7 +82,6 @@ export function truncateLine(line: string, maxLength: number = MAX_LINE_LENGTH):
 }
 /**
  * Get the path to the ripgrep binary within the VSCode installation
- * Supports npm, pnpm, yarn, and bun package managers
  */
 export async function getBinPath(vscodeAppRoot: string): Promise<string | undefined> {
 	const checkPath = async (pkgFolder: string) => {


### PR DESCRIPTION
Resolve: #3448 

This is an alternative approach to #3440 that should merge more cleanly with Roo.

The problem is that when you install the CLI with bun (`bun install -g @kilocode/cli`) that bun doesn't package the `node_modules` relative to the CLIs install directory. There's a chance that `require.resolve` works for all cases, but I decided to just implement it as a fallback to not mess with the Roo merge and just fix this specific case.

