### PR TITLE
CLI - provider command & provider/model arguments

### DIFF
--- a/.changeset/breezy-garlics-rule.md
+++ b/.changeset/breezy-garlics-rule.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+New '/provider' command to switch beteen configured providers

--- a/.changeset/early-sides-wait.md
+++ b/.changeset/early-sides-wait.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+provider (-pv/--provider) and model (-mo/--model) command arguments

--- a/cli/src/__tests__/cli-provider-model.test.ts
+++ b/cli/src/__tests__/cli-provider-model.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest"
+import type { CLIConfig, ProviderConfig } from "../config/types.js"
+import { getModelFieldForProvider, getModelIdKey } from "../constants/providers/models.js"
+import type { ProviderName } from "../types/messages.js"
+
+describe("Provider and Model CLI Options", () => {
+	describe("getModelIdKey", () => {
+		it("should return correct model field for kilocode provider", () => {
+			const field = getModelIdKey("kilocode")
+			expect(field).toBe("kilocodeModel")
+		})
+
+		it("should return correct model field for anthropic provider", () => {
+			const field = getModelIdKey("anthropic")
+			expect(field).toBe("apiModelId")
+		})
+
+		it("should return correct model field for openai provider", () => {
+			const field = getModelIdKey("openai")
+			expect(field).toBe("openAiModelId")
+		})
+
+		it("should return correct model field for openai-native provider", () => {
+			const field = getModelIdKey("openai-native")
+			expect(field).toBe("apiModelId")
+		})
+
+		it("should return apiModelId as default for unknown providers", () => {
+			const field = getModelIdKey("human-relay")
+			expect(field).toBe("apiModelId")
+		})
+	})
+
+	describe("getModelFieldForProvider (router support)", () => {
+		it("should return model field for router-supported providers", () => {
+			expect(getModelFieldForProvider("kilocode")).toBe("kilocodeModel")
+			expect(getModelFieldForProvider("openrouter")).toBe("openRouterModelId")
+			expect(getModelFieldForProvider("ollama")).toBe("ollamaModelId")
+		})
+
+		it("should return null for providers without router support", () => {
+			expect(getModelFieldForProvider("anthropic")).toBeNull()
+			expect(getModelFieldForProvider("openai")).toBeNull()
+			expect(getModelFieldForProvider("human-relay")).toBeNull()
+		})
+	})
+
+	describe("Provider Override Logic", () => {
+		const mockConfig: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: false,
+			provider: "kilocode-1",
+			providers: [
+				{
+					id: "kilocode-1",
+					provider: "kilocode",
+					kilocodeModel: "claude-sonnet-3.5",
+					kilocodeToken: "test-token",
+				},
+				{
+					id: "anthropic-main",
+					provider: "anthropic",
+					apiModelId: "claude-3-5-sonnet-20241022",
+					apiKey: "test-key",
+				},
+				{
+					id: "openai-1",
+					provider: "openai",
+					openAiModelId: "gpt-4",
+					openAiApiKey: "test-key",
+				},
+			],
+		}
+
+		it("should find provider by ID", () => {
+			const provider = mockConfig.providers.find((p) => p.id === "anthropic-main")
+			expect(provider).toBeDefined()
+			expect(provider?.provider).toBe("anthropic")
+		})
+
+		it("should update provider selection", () => {
+			const updatedConfig = {
+				...mockConfig,
+				provider: "anthropic-main",
+			}
+			expect(updatedConfig.provider).toBe("anthropic-main")
+			expect(mockConfig.provider).toBe("kilocode-1") // Original unchanged
+		})
+
+		it("should update model for kilocode provider", () => {
+			const providerIndex = mockConfig.providers.findIndex((p) => p.id === "kilocode-1")
+			const provider = mockConfig.providers[providerIndex]
+			const modelField = getModelIdKey("kilocode")
+
+			expect(modelField).toBe("kilocodeModel")
+			expect(provider).toBeDefined()
+
+			if (provider && modelField) {
+				const updatedProvider = {
+					...provider,
+					[modelField]: "claude-opus-4",
+				}
+				expect(updatedProvider.kilocodeModel).toBe("claude-opus-4")
+			}
+		})
+
+		it("should update model for anthropic provider", () => {
+			const providerIndex = mockConfig.providers.findIndex((p) => p.id === "anthropic-main")
+			const provider = mockConfig.providers[providerIndex]
+			const modelField = getModelIdKey("anthropic")
+
+			expect(modelField).toBe("apiModelId")
+			expect(provider).toBeDefined()
+
+			if (provider && modelField && "apiModelId" in provider) {
+				const updatedProvider = {
+					...provider,
+					[modelField]: "claude-opus-4",
+				} as ProviderConfig
+				if ("apiModelId" in updatedProvider) {
+					expect(updatedProvider.apiModelId).toBe("claude-opus-4")
+				}
+			}
+		})
+
+		it("should update model for openai provider", () => {
+			const providerIndex = mockConfig.providers.findIndex((p) => p.id === "openai-1")
+			const provider = mockConfig.providers[providerIndex]
+			const modelField = getModelIdKey("openai")
+
+			expect(modelField).toBe("openAiModelId")
+			expect(provider).toBeDefined()
+
+			if (provider && modelField && "openAiModelId" in provider) {
+				const updatedProvider = {
+					...provider,
+					[modelField]: "gpt-4-turbo",
+				} as ProviderConfig
+				if ("openAiModelId" in updatedProvider) {
+					expect(updatedProvider.openAiModelId).toBe("gpt-4-turbo")
+				}
+			}
+		})
+	})
+
+	describe("Config Validation", () => {
+		it("should validate provider exists in config", () => {
+			const providers = [
+				{ id: "kilocode-1", provider: "kilocode" },
+				{ id: "anthropic-main", provider: "anthropic" },
+			]
+
+			const validProvider = providers.some((p) => p.id === "kilocode-1")
+			expect(validProvider).toBe(true)
+
+			const invalidProvider = providers.some((p) => p.id === "nonexistent")
+			expect(invalidProvider).toBe(false)
+		})
+
+		it("should get list of available provider IDs", () => {
+			const providers = [
+				{ id: "kilocode-1", provider: "kilocode" },
+				{ id: "anthropic-main", provider: "anthropic" },
+				{ id: "openai-1", provider: "openai" },
+			]
+
+			const availableIds = providers.map((p) => p.id)
+			expect(availableIds).toEqual(["kilocode-1", "anthropic-main", "openai-1"])
+		})
+	})
+
+	describe("Model Field Mapping", () => {
+		it("should handle all major providers with getModelIdKey", () => {
+			const providers: Array<{ name: ProviderName; expectedField: string }> = [
+				{ name: "kilocode", expectedField: "kilocodeModel" },
+				{ name: "anthropic", expectedField: "apiModelId" },
+				{ name: "openai", expectedField: "openAiModelId" },
+				{ name: "openai-native", expectedField: "apiModelId" },
+				{ name: "openrouter", expectedField: "openRouterModelId" },
+				{ name: "ollama", expectedField: "ollamaModelId" },
+				{ name: "gemini", expectedField: "apiModelId" },
+				{ name: "bedrock", expectedField: "apiModelId" },
+			]
+
+			providers.forEach(({ name, expectedField }) => {
+				const field = getModelIdKey(name)
+				expect(field).toBe(expectedField)
+			})
+		})
+	})
+})

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -7,7 +7,7 @@ import { App } from "./ui/App.js"
 import { logs } from "./services/logs.js"
 import { extensionServiceAtom } from "./state/atoms/service.js"
 import { initializeServiceEffectAtom } from "./state/atoms/effects.js"
-import { loadConfigAtom, mappedExtensionStateAtom, providersAtom } from "./state/atoms/config.js"
+import { loadConfigAtom, mappedExtensionStateAtom, providersAtom, saveConfigAtom } from "./state/atoms/config.js"
 import { ciExitReasonAtom } from "./state/atoms/ci.js"
 import { requestRouterModelsAtom } from "./state/atoms/actions.js"
 import { loadHistoryAtom } from "./state/atoms/history.js"
@@ -20,18 +20,10 @@ import { fetchKilocodeNotifications } from "./utils/notifications.js"
 import { finishParallelMode } from "./parallel/parallel.js"
 import { isGitWorktree } from "./utils/git.js"
 import { Package } from "./constants/package.js"
-
-export interface CLIOptions {
-	mode?: string
-	workspace?: string
-	ci?: boolean
-	json?: boolean
-	prompt?: string
-	timeout?: number
-	parallel?: boolean
-	worktreeBranch?: string | undefined
-	continue?: boolean
-}
+import type { CLIOptions } from "./types/cli.js"
+import type { CLIConfig, ProviderConfig } from "./config/types.js"
+import { getModelIdKey } from "./constants/providers/models.js"
+import type { ProviderName } from "./types/messages.js"
 
 /**
  * Main application class that orchestrates the CLI lifecycle
@@ -73,8 +65,16 @@ export class CLI {
 			logs.debug("Jotai store created", "CLI")
 
 			// Initialize telemetry service first to get identity
-			const config = await this.store.set(loadConfigAtom, this.options.mode)
+			let config = await this.store.set(loadConfigAtom, this.options.mode)
 			logs.debug("CLI configuration loaded", "CLI", { mode: this.options.mode })
+
+			// Apply provider and model overrides from CLI
+			if (this.options.provider || this.options.model) {
+				config = await this.applyProviderModelOverrides(config)
+				// Save the updated config to persist changes
+				await this.store.set(saveConfigAtom, config)
+				logs.info("Provider/model overrides applied and saved", "CLI")
+			}
 
 			const telemetryService = getTelemetryService()
 			await telemetryService.initialize(config, {
@@ -203,6 +203,44 @@ export class CLI {
 
 		// Wait for UI to exit
 		await this.ui.waitUntilExit()
+	}
+
+	/**
+	 * Apply provider and model overrides from CLI options
+	 */
+	private async applyProviderModelOverrides(config: CLIConfig): Promise<CLIConfig> {
+		const updatedConfig = { ...config }
+
+		// Apply provider override
+		if (this.options.provider) {
+			const provider = config.providers.find((p) => p.id === this.options.provider)
+			if (provider) {
+				updatedConfig.provider = this.options.provider
+				logs.info(`Provider overridden to: ${this.options.provider}`, "CLI")
+			}
+		}
+
+		// Apply model override
+		if (this.options.model) {
+			const activeProviderId = updatedConfig.provider
+			const providerIndex = updatedConfig.providers.findIndex((p) => p.id === activeProviderId)
+
+			if (providerIndex !== -1) {
+				const provider = updatedConfig.providers[providerIndex]
+				if (provider && "provider" in provider) {
+					const modelField = getModelIdKey(provider.provider as ProviderName)
+
+					// Update the provider's model field
+					updatedConfig.providers[providerIndex] = {
+						...provider,
+						[modelField]: this.options.model,
+					} as ProviderConfig
+					logs.info(`Model overridden to: ${this.options.model} for provider ${activeProviderId}`, "CLI")
+				}
+			}
+		}
+
+		return updatedConfig
 	}
 
 	private isDisposing = false

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -227,7 +227,7 @@ export class CLI {
 
 			if (providerIndex !== -1) {
 				const provider = updatedConfig.providers[providerIndex]
-				if (provider && "provider" in provider) {
+				if (provider) {
 					const modelField = getModelIdKey(provider.provider as ProviderName)
 
 					// Update the provider's model field

--- a/cli/src/commands/__tests__/helpers/mockContext.ts
+++ b/cli/src/commands/__tests__/helpers/mockContext.ts
@@ -49,6 +49,7 @@ export function createMockContext(overrides: Partial<CommandContext> = {}): Comm
 		updateProviderModel: vi.fn().mockResolvedValue(undefined),
 		refreshRouterModels: vi.fn().mockResolvedValue(undefined),
 		updateProvider: vi.fn().mockResolvedValue(undefined),
+		selectProvider: vi.fn().mockResolvedValue(undefined),
 		profileData: null,
 		balanceData: null,
 		profileLoading: false,

--- a/cli/src/commands/__tests__/provider.test.ts
+++ b/cli/src/commands/__tests__/provider.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { providerCommand } from "../provider.js"
+import { createMockContext } from "./helpers/mockContext.js"
+import type { CommandContext } from "../core/types.js"
+import type { ProviderConfig } from "../../config/types.js"
+
+describe("provider command", () => {
+	let mockContext: CommandContext
+	let addMessageMock: ReturnType<typeof vi.fn>
+	let selectProviderMock: ReturnType<typeof vi.fn>
+
+	const mockProviders: ProviderConfig[] = [
+		{
+			id: "anthropic-main",
+			provider: "anthropic",
+			apiModelId: "claude-sonnet-4",
+		},
+		{
+			id: "openai-backup",
+			provider: "openai-native",
+			apiModelId: "gpt-4",
+		},
+		{
+			id: "kilocode-test",
+			provider: "kilocode",
+			kilocodeModel: "claude-sonnet-4.5",
+		},
+	]
+
+	beforeEach(() => {
+		addMessageMock = vi.fn()
+		selectProviderMock = vi.fn().mockResolvedValue(undefined)
+
+		mockContext = createMockContext({
+			config: {
+				version: "1.0.0",
+				mode: "code",
+				telemetry: true,
+				provider: "anthropic-main",
+				providers: mockProviders,
+			},
+			currentProvider: mockProviders[0],
+			addMessage: addMessageMock,
+			selectProvider: selectProviderMock,
+		})
+	})
+
+	describe("command metadata", () => {
+		it("should have correct name and aliases", () => {
+			expect(providerCommand.name).toBe("provider")
+			expect(providerCommand.aliases).toContain("prov")
+		})
+
+		it("should have correct category and priority", () => {
+			expect(providerCommand.category).toBe("settings")
+			expect(providerCommand.priority).toBe(8)
+		})
+
+		it("should have proper usage and examples", () => {
+			expect(providerCommand.usage).toBe("/provider [subcommand] [args]")
+			expect(providerCommand.examples).toContain("/provider")
+			expect(providerCommand.examples).toContain("/provider list")
+			expect(providerCommand.examples).toContain("/provider select my-anthropic")
+		})
+	})
+
+	describe("showing current provider", () => {
+		it("should show current provider information when no arguments provided", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				args: [],
+			})
+
+			expect(addMessageMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "system",
+					content: expect.stringContaining("Current Provider:"),
+				}),
+			)
+
+			const message = addMessageMock.mock.calls[0][0]
+			expect(message.content).toContain("ID: anthropic-main")
+			expect(message.content).toContain("Type: Anthropic")
+			expect(message.content).toContain("Model: claude-sonnet-4")
+			expect(message.content).toContain("Total Configured: 3")
+		})
+
+		it("should show error when no provider is configured", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				currentProvider: null,
+				args: [],
+			})
+
+			expect(addMessageMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "error",
+					content: expect.stringContaining("No provider configured"),
+				}),
+			)
+		})
+
+		it("should show commands help in current provider view", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				args: [],
+			})
+
+			const message = addMessageMock.mock.calls[0][0]
+			expect(message.content).toContain("/provider list")
+			expect(message.content).toContain("/provider select")
+		})
+	})
+
+	describe("listing providers", () => {
+		it("should list all configured providers", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				args: ["list"],
+			})
+
+			expect(addMessageMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "system",
+					content: expect.stringContaining("Configured Providers:"),
+				}),
+			)
+
+			const message = addMessageMock.mock.calls[0][0]
+			expect(message.content).toContain("anthropic-main")
+			expect(message.content).toContain("openai-backup")
+			expect(message.content).toContain("kilocode-test")
+			expect(message.content).toContain("**Total:** 3 providers")
+		})
+
+		it("should mark current provider with star", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				args: ["list"],
+			})
+
+			const message = addMessageMock.mock.calls[0][0]
+			expect(message.content).toContain("⭐ **anthropic-main** (current)")
+		})
+
+		it("should show provider types", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				args: ["list"],
+			})
+
+			const message = addMessageMock.mock.calls[0][0]
+			expect(message.content).toContain("Type: Anthropic")
+			expect(message.content).toContain("Type: OpenAI")
+			expect(message.content).toContain("Type: Kilo Code")
+		})
+
+		it("should show model information when available", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				args: ["list"],
+			})
+
+			const message = addMessageMock.mock.calls[0][0]
+			expect(message.content).toContain("Model: claude-sonnet-4")
+			expect(message.content).toContain("Model: gpt-4")
+			expect(message.content).toContain("Model: claude-sonnet-4.5")
+		})
+
+		it("should show message when no providers configured", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				config: {
+					...mockContext.config,
+					providers: [],
+				},
+				args: ["list"],
+			})
+
+			expect(addMessageMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "system",
+					content: expect.stringContaining("No providers configured"),
+				}),
+			)
+		})
+
+		it("should show usage hint at the end", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				args: ["list"],
+			})
+
+			const message = addMessageMock.mock.calls[0][0]
+			expect(message.content).toContain("/provider select <provider-id>")
+		})
+	})
+
+	describe("selecting provider", () => {
+		it("should show error when provider ID is missing", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				args: ["select"],
+			})
+
+			expect(addMessageMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "error",
+					content: expect.stringContaining("Usage: /provider select <provider-id>"),
+				}),
+			)
+		})
+
+		it("should show error when provider not found", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				args: ["select", "non-existent"],
+			})
+
+			expect(addMessageMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "error",
+					content: expect.stringContaining('Provider "non-existent" not found'),
+				}),
+			)
+		})
+
+		it("should show success message when provider is selected", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				args: ["select", "openai-backup"],
+			})
+
+			// Should call selectProvider
+			expect(selectProviderMock).toHaveBeenCalledWith("openai-backup")
+
+			// Should show success message
+			const successCall = addMessageMock.mock.calls.find((call) => call[0].type === "system")
+			expect(successCall).toBeDefined()
+			if (successCall) {
+				expect(successCall[0].content).toContain("Switched to **openai-backup**")
+				expect(successCall[0].content).toContain("Type: OpenAI")
+				expect(successCall[0].content).toContain("Model: gpt-4")
+			}
+		})
+	})
+
+	describe("unknown subcommand", () => {
+		it("should show error for unknown subcommand", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				args: ["unknown"],
+			})
+
+			expect(addMessageMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "error",
+					content: expect.stringContaining('Unknown subcommand "unknown"'),
+				}),
+			)
+		})
+
+		it("should list available subcommands in error", async () => {
+			await providerCommand.handler({
+				...mockContext,
+				args: ["invalid"],
+			})
+
+			const message = addMessageMock.mock.calls[0][0]
+			expect(message.content).toContain("Available: list, select")
+		})
+	})
+
+	describe("argument definitions", () => {
+		it("should have subcommand argument with correct values", () => {
+			const subcommandArg = providerCommand.arguments?.find((arg) => arg.name === "subcommand")
+			expect(subcommandArg).toBeDefined()
+			expect(subcommandArg?.required).toBe(false)
+			expect(subcommandArg?.values).toContainEqual(
+				expect.objectContaining({
+					value: "list",
+					description: "List all configured providers",
+				}),
+			)
+			expect(subcommandArg?.values).toContainEqual(
+				expect.objectContaining({
+					value: "select",
+					description: "Switch to a different provider",
+				}),
+			)
+		})
+
+		it("should have provider-id argument with conditional provider", () => {
+			const providerIdArg = providerCommand.arguments?.find((arg) => arg.name === "provider-id")
+			expect(providerIdArg).toBeDefined()
+			expect(providerIdArg?.required).toBe(false)
+			expect(providerIdArg?.conditionalProviders).toBeDefined()
+			expect(providerIdArg?.conditionalProviders?.length).toBeGreaterThan(0)
+		})
+	})
+})

--- a/cli/src/commands/core/types.ts
+++ b/cli/src/commands/core/types.ts
@@ -54,6 +54,8 @@ export interface CommandContext {
 	refreshRouterModels: () => Promise<void>
 	// Provider update function for teams command
 	updateProvider: (providerId: string, updates: Partial<ProviderConfig>) => Promise<void>
+	// Provider selection function
+	selectProvider: (providerId: string) => Promise<void>
 	// Profile data context
 	profileData: ProfileData | null
 	balanceData: BalanceData | null

--- a/cli/src/commands/index.ts
+++ b/cli/src/commands/index.ts
@@ -13,6 +13,7 @@ import { clearCommand } from "./clear.js"
 import { exitCommand } from "./exit.js"
 import { modeCommand } from "./mode.js"
 import { modelCommand } from "./model.js"
+import { providerCommand } from "./provider.js"
 import { profileCommand } from "./profile.js"
 import { teamsCommand } from "./teams.js"
 import { configCommand } from "./config.js"
@@ -31,6 +32,7 @@ export function initializeCommands(): void {
 	commandRegistry.register(exitCommand)
 	commandRegistry.register(modeCommand)
 	commandRegistry.register(modelCommand)
+	commandRegistry.register(providerCommand)
 	commandRegistry.register(profileCommand)
 	commandRegistry.register(teamsCommand)
 	commandRegistry.register(configCommand)

--- a/cli/src/commands/provider.ts
+++ b/cli/src/commands/provider.ts
@@ -1,0 +1,256 @@
+/**
+ * /provider command - View and manage providers
+ */
+
+import type { Command, ArgumentProviderContext, CommandContext } from "./core/types.js"
+import { getProviderLabel } from "../constants/providers/labels.js"
+import { getCurrentModelId } from "../constants/providers/models.js"
+import { getModelIdForProvider } from "../config/mapper.js"
+
+/**
+ * Show current provider information
+ */
+async function showCurrentProvider(context: CommandContext): Promise<void> {
+	const { config, currentProvider, routerModels, kilocodeDefaultModel, addMessage } = context
+
+	if (!currentProvider) {
+		addMessage({
+			id: Date.now().toString(),
+			type: "error",
+			content: "No provider configured. Please configure a provider first.",
+			ts: Date.now(),
+		})
+		return
+	}
+
+	const providerLabel = getProviderLabel(currentProvider.provider)
+	const totalProviders = config.providers.length
+
+	let content = `**Current Provider:**\n`
+	content += `  ID: ${currentProvider.id}\n`
+	content += `  Type: ${providerLabel}\n`
+
+	// Show model information if available
+	const currentModelId = getCurrentModelId({
+		providerConfig: currentProvider,
+		routerModels,
+		kilocodeDefaultModel,
+	})
+
+	if (currentModelId) {
+		content += `  Model: ${currentModelId}\n`
+	}
+
+	content += `  Total Configured: ${totalProviders}\n`
+
+	content += `\n**Commands:**\n`
+	content += `  /provider list - List all configured providers\n`
+	content += `  /provider select <provider-id> - Switch to a different provider\n`
+
+	addMessage({
+		id: Date.now().toString(),
+		type: "system",
+		content,
+		ts: Date.now(),
+	})
+}
+
+/**
+ * List all configured providers
+ */
+async function listProviders(context: CommandContext): Promise<void> {
+	const { config, currentProvider, addMessage } = context
+
+	if (config.providers.length === 0) {
+		addMessage({
+			id: Date.now().toString(),
+			type: "system",
+			content: "No providers configured. Please configure a provider first.",
+			ts: Date.now(),
+		})
+		return
+	}
+
+	let content = `**Configured Providers:**\n\n`
+
+	for (const provider of config.providers) {
+		const isCurrent = currentProvider?.id === provider.id
+		const prefix = isCurrent ? "⭐ " : "  "
+		const suffix = isCurrent ? " (current)" : ""
+		const providerLabel = getProviderLabel(provider.provider)
+
+		content += `${prefix}**${provider.id}**${suffix}\n`
+		content += `   Type: ${providerLabel}\n`
+
+		// Show model information if available
+		const modelInfo = getModelIdForProvider(provider)
+		if (modelInfo) {
+			content += `   Model: ${modelInfo}\n`
+		}
+
+		content += `\n`
+	}
+
+	content += `**Total:** ${config.providers.length} provider${config.providers.length !== 1 ? "s" : ""}\n`
+	content += `\nUse \`/provider select <provider-id>\` to switch providers\n`
+
+	addMessage({
+		id: Date.now().toString(),
+		type: "system",
+		content,
+		ts: Date.now(),
+	})
+}
+
+/**
+ * Select a different provider
+ */
+async function selectProvider(context: CommandContext, providerId: string): Promise<void> {
+	const { config, addMessage, selectProvider: selectProviderFn } = context
+
+	const provider = config.providers.find((p) => p.id === providerId)
+
+	if (!provider) {
+		addMessage({
+			id: Date.now().toString(),
+			type: "error",
+			content: `Provider "${providerId}" not found. Use \`/provider list\` to see available providers.`,
+			ts: Date.now(),
+		})
+		return
+	}
+
+	try {
+		await selectProviderFn(providerId)
+
+		const providerLabel = getProviderLabel(provider.provider)
+		const modelInfo = getModelIdForProvider(provider)
+
+		let content = `✓ Switched to **${providerId}**\n`
+		content += `  Type: ${providerLabel}\n`
+
+		if (modelInfo) {
+			content += `  Model: ${modelInfo}\n`
+		}
+
+		addMessage({
+			id: Date.now().toString(),
+			type: "system",
+			content,
+			ts: Date.now(),
+		})
+	} catch (error) {
+		addMessage({
+			id: Date.now().toString(),
+			type: "error",
+			content: `Failed to switch provider: ${error instanceof Error ? error.message : String(error)}`,
+			ts: Date.now(),
+		})
+	}
+}
+
+/**
+ * Autocomplete provider for provider IDs
+ */
+async function providerAutocompleteProvider(context: ArgumentProviderContext) {
+	// Check if commandContext is available
+	if (!context.commandContext) {
+		return []
+	}
+
+	const { config } = context.commandContext
+
+	return config.providers.map((provider) => {
+		const providerLabel = getProviderLabel(provider.provider)
+
+		// Get model info if available
+		const modelInfo = getModelIdForProvider(provider)
+		const description = modelInfo ? `${providerLabel} - ${modelInfo}` : providerLabel
+
+		return {
+			value: provider.id,
+			title: provider.id,
+			description,
+			matchScore: 1.0,
+			highlightedValue: provider.id,
+		}
+	})
+}
+
+export const providerCommand: Command = {
+	name: "provider",
+	aliases: ["prov"],
+	description: "View and manage providers",
+	usage: "/provider [subcommand] [args]",
+	examples: ["/provider", "/provider list", "/provider select my-anthropic"],
+	category: "settings",
+	priority: 8,
+	arguments: [
+		{
+			name: "subcommand",
+			description: "Subcommand: list, select",
+			required: false,
+			values: [
+				{ value: "list", description: "List all configured providers" },
+				{ value: "select", description: "Switch to a different provider" },
+			],
+		},
+		{
+			name: "provider-id",
+			description: "Provider ID (for select)",
+			required: false,
+			conditionalProviders: [
+				{
+					condition: (context) => {
+						const subcommand = context.getArgument("subcommand")
+						return subcommand === "select"
+					},
+					provider: providerAutocompleteProvider,
+				},
+			],
+		},
+	],
+	handler: async (context) => {
+		const { args } = context
+
+		// No arguments - show current provider
+		if (args.length === 0) {
+			await showCurrentProvider(context)
+			return
+		}
+
+		const subcommand = args[0]?.toLowerCase()
+		if (!subcommand) {
+			await showCurrentProvider(context)
+			return
+		}
+
+		// Handle subcommands
+		switch (subcommand) {
+			case "list":
+				await listProviders(context)
+				break
+
+			case "select":
+				if (args.length < 2 || !args[1]) {
+					context.addMessage({
+						id: Date.now().toString(),
+						type: "error",
+						content: "Usage: /provider select <provider-id>",
+						ts: Date.now(),
+					})
+					return
+				}
+				await selectProvider(context, args[1])
+				break
+
+			default:
+				context.addMessage({
+					id: Date.now().toString(),
+					type: "error",
+					content: `Unknown subcommand "${subcommand}". Available: list, select`,
+					ts: Date.now(),
+				})
+		}
+	},
+}

--- a/cli/src/config/mapper.ts
+++ b/cli/src/config/mapper.ts
@@ -59,7 +59,7 @@ function mapProviderToApiConfig(provider: ProviderConfig): ProviderSettings {
 	return config
 }
 
-function getModelIdForProvider(provider: ProviderConfig): string {
+export function getModelIdForProvider(provider: ProviderConfig): string {
 	switch (provider.provider) {
 		case "kilocode":
 			return provider.kilocodeModel || ""

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -37,6 +37,8 @@ program
 		"Run in parallel mode - the agent will create a separate git branch, unless you provide the --existing-branch option",
 	)
 	.option("-eb, --existing-branch <branch>", "(Parallel mode only) Instructs the agent to work on an existing branch")
+	.option("-pv, --provider <id>", "Select provider by ID (e.g., 'kilocode-1')")
+	.option("-mo, --model <model>", "Override model for the selected provider")
 	.argument("[prompt]", "The prompt or command to execute")
 	.action(async (prompt, options) => {
 		// Validate mode if provided
@@ -112,6 +114,19 @@ program
 			process.exit(1)
 		}
 
+		// Validate provider if specified
+		if (options.provider) {
+			// Load config to check if provider exists
+			const { loadConfig } = await import("./config/persistence.js")
+			const { config } = await loadConfig()
+			const providerExists = config.providers.some((p) => p.id === options.provider)
+			if (!providerExists) {
+				const availableIds = config.providers.map((p) => p.id).join(", ")
+				console.error(`Error: Provider "${options.provider}" not found. Available providers: ${availableIds}`)
+				process.exit(1)
+			}
+		}
+
 		// Track autonomous mode start if applicable
 		if (options.auto && finalPrompt) {
 			getTelemetryService().trackCIModeStarted(finalPrompt.length, options.timeout)
@@ -154,6 +169,8 @@ program
 			parallel: options.parallel,
 			worktreeBranch,
 			continue: options.continue,
+			provider: options.provider,
+			model: options.model,
 		})
 		await cli.start()
 		await cli.dispose()

--- a/cli/src/state/atoms/config.ts
+++ b/cli/src/state/atoms/config.ts
@@ -125,6 +125,12 @@ export const selectProviderAtom = atom(null, async (get, set, providerId: string
 	set(configAtom, updatedConfig)
 	await set(saveConfigAtom, updatedConfig)
 
+	// Import from config-sync to avoid circular dependency
+	const { syncConfigToExtensionEffectAtom } = await import("./config-sync.js")
+
+	// Trigger sync to extension after provider update
+	await set(syncConfigToExtensionEffectAtom)
+
 	// Track provider change
 	getTelemetryService().trackProviderChanged(
 		previousProvider,

--- a/cli/src/state/hooks/useCommandContext.ts
+++ b/cli/src/state/hooks/useCommandContext.ts
@@ -17,7 +17,14 @@ import {
 	isCommittingParallelModeAtom,
 	refreshTerminalAtom,
 } from "../atoms/ui.js"
-import { setModeAtom, setThemeAtom, providerAtom, updateProviderAtom, configAtom } from "../atoms/config.js"
+import {
+	setModeAtom,
+	setThemeAtom,
+	providerAtom,
+	updateProviderAtom,
+	selectProviderAtom,
+	configAtom,
+} from "../atoms/config.js"
 import { routerModelsAtom, extensionStateAtom, isParallelModeAtom, chatMessagesAtom } from "../atoms/extension.js"
 import { requestRouterModelsAtom } from "../atoms/actions.js"
 import { profileDataAtom, balanceDataAtom, profileLoadingAtom, balanceLoadingAtom } from "../atoms/profile.js"
@@ -77,6 +84,7 @@ export function useCommandContext(): UseCommandContextReturn {
 	const setMode = useSetAtom(setModeAtom)
 	const setTheme = useSetAtom(setThemeAtom)
 	const updateProvider = useSetAtom(updateProviderAtom)
+	const selectProvider = useSetAtom(selectProviderAtom)
 	const refreshRouterModels = useSetAtom(requestRouterModelsAtom)
 	const setMessageCutoffTimestamp = useSetAtom(setMessageCutoffTimestampAtom)
 	const setCommittingParallelMode = useSetAtom(isCommittingParallelModeAtom)
@@ -184,6 +192,10 @@ export function useCommandContext(): UseCommandContextReturn {
 				updateProvider: async (providerId: string, updates: Partial<ProviderConfig>) => {
 					await updateProvider(providerId, updates)
 				},
+				// Provider selection function
+				selectProvider: async (providerId: string) => {
+					await selectProvider(providerId)
+				},
 				// Profile data context
 				profileData,
 				balanceData,
@@ -216,6 +228,7 @@ export function useCommandContext(): UseCommandContextReturn {
 			currentProvider,
 			kilocodeDefaultModel,
 			updateProvider,
+			selectProvider,
 			refreshRouterModels,
 			replaceMessages,
 			setMessageCutoffTimestamp,

--- a/cli/src/types/cli.ts
+++ b/cli/src/types/cli.ts
@@ -22,3 +22,17 @@ export interface CliMessage {
 	}
 	payload?: unknown
 }
+
+export interface CLIOptions {
+	mode?: string
+	workspace?: string
+	ci?: boolean
+	json?: boolean
+	prompt?: string
+	timeout?: number
+	parallel?: boolean
+	worktreeBranch?: string | undefined
+	continue?: boolean
+	provider?: string
+	model?: string
+}


### PR DESCRIPTION
## Context

Resolve: #3682 

This PR adds CLI provider management capabilities with a /provider command and command-line arguments for provider/model selection. The implementation enables users to switch providers and override models directly from the command line or through interactive commands.

## Implementation

- Adds /provider command with list and select subcommands for managing providers interactively
- Adds -pv, --provider <id> and -mo, --model <model> CLI arguments for non-interactive provider/model overrides
- Integrates provider/model overrides into CLI initialization workflow with config persistence

## Screenshots

<img width="2246" height="2088" alt="image" src="https://github.com/user-attachments/assets/db278e0b-7408-4f27-aa24-9826c0154eab" />
<img width="2246" height="2088" alt="image" src="https://github.com/user-attachments/assets/8850231c-d410-49a7-8109-b8f883d1f932" />
<img width="2246" height="2088" alt="image" src="https://github.com/user-attachments/assets/1bdb4b02-62fe-44fb-9a61-2e10e22b3b8a" />
<img width="2235" height="356" alt="image" src="https://github.com/user-attachments/assets/4a034e98-3fd8-4b75-b19f-af7b3c3f7615" />


## How to Test

```
kilocode --auto -pv kilocode -mo x-ai/grok-code-fast-1 -m ask "What is your model name?"
```
<img width="2235" height="2084" alt="image" src="https://github.com/user-attachments/assets/e35a1be5-7167-4f45-b048-f156e1c80bc3" />

```
kilocode --auto -mo openai/gpt-5.1 -m ask "What is your model name?"
```
<img width="2235" height="2084" alt="image" src="https://github.com/user-attachments/assets/d3450273-89db-4288-9a9e-e8386affea68" />

```
kilocode --auto -mo minimax/minimax-m2 -m ask "What is your model name?"
```
<img width="2235" height="2084" alt="image" src="https://github.com/user-attachments/assets/ebea9cef-a36b-467d-9b7d-4994404685b2" />

```
kilocode --auto -pv default -m ask "What is your model name?"
```
<img width="2235" height="2084" alt="image" src="https://github.com/user-attachments/assets/ca6d63ae-481d-444d-af22-d8867bd85769" />

