### PR TITLE
Remove parseDoubleEncodedParams

### DIFF
--- a/.changeset/shiny-scissors-camp.md
+++ b/.changeset/shiny-scissors-camp.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix hang when model wants to write JSON file with native tool calls enabled

--- a/src/core/assistant-message/AssistantMessageParser.ts
+++ b/src/core/assistant-message/AssistantMessageParser.ts
@@ -1,7 +1,7 @@
 import { type ToolName, toolNames } from "@roo-code/types"
 import { TextContent, ToolUse, ToolParamName, toolParamNames } from "../../shared/tools"
 import { AssistantMessageContent } from "./parseAssistantMessage"
-import { extractMcpToolInfo, NativeToolCall, parseDoubleEncodedParams } from "./kilocode/native-tool-call"
+import { extractMcpToolInfo, NativeToolCall } from "./kilocode/native-tool-call"
 import Anthropic from "@anthropic-ai/sdk" // kilocode_change
 
 /**
@@ -165,10 +165,6 @@ export class AssistantMessageParser {
 			try {
 				if (accumulatedCall.function!.arguments.trim()) {
 					parsedArgs = JSON.parse(accumulatedCall.function!.arguments)
-
-					// Fix any double-encoded parameters
-					parsedArgs = parseDoubleEncodedParams(parsedArgs)
-
 					isComplete = true
 				}
 			} catch (error) {

--- a/src/core/assistant-message/kilocode/native-tool-call.ts
+++ b/src/core/assistant-message/kilocode/native-tool-call.ts
@@ -14,53 +14,6 @@ export interface NativeToolCall {
 	}
 }
 
-/**
- * Recursively parse any string values that appear to be JSON-encoded.
- * This handles cases where the model double-encodes parameters.
- *
- * @param obj - The object to process
- * @returns The object with any double-encoded strings parsed
- */
-export function parseDoubleEncodedParams(obj: any): any {
-	if (obj === null || obj === undefined) {
-		return obj
-	}
-
-	// If it's a string that looks like JSON, try to parse it
-	if (typeof obj === "string") {
-		const trimmed = obj.trim()
-		if ((trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]"))) {
-			try {
-				const parsed = JSON.parse(obj)
-				// Recursively process the parsed value in case it has more double-encoding
-				// console.debug("[AssistantMessageParser] Parsed double-encoded JSON:", JSON.stringify(parsed))
-				return parseDoubleEncodedParams(parsed)
-			} catch {
-				// Not valid JSON, return as-is
-				return obj
-			}
-		}
-		return obj
-	}
-
-	// If it's an array, recursively process each element
-	if (Array.isArray(obj)) {
-		return obj.map((item) => parseDoubleEncodedParams(item))
-	}
-
-	// If it's an object, recursively process each property
-	if (typeof obj === "object") {
-		const result: Record<string, any> = {}
-		for (const [key, value] of Object.entries(obj)) {
-			result[key] = parseDoubleEncodedParams(value)
-		}
-		return result
-	}
-
-	// Primitive types (number, boolean, etc.) return as-is
-	return obj
-}
-
 const NATIVE_MCP_TOOL_PREFIX = "use_mcp_tool___"
 const NATIVE_MCP_TOOL_SEPARATOR = "___"
 


### PR DESCRIPTION
This causes a crash when a string just happens to be valid JSON.