### PR TITLE
CLI - Fix follow up suggestion auto selection

### DIFF
--- a/.changeset/wicked-seas-stand.md
+++ b/.changeset/wicked-seas-stand.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Allow the user to type any custom follow up suggestion

--- a/cli/src/state/atoms/keyboard.ts
+++ b/cli/src/state/atoms/keyboard.ts
@@ -903,12 +903,9 @@ const isKeyModifyBuffer = (key: Key): boolean => {
 	return (
 		!key.ctrl &&
 		!key.meta &&
-		!key.shift &&
 		!key.paste &&
 		key.name !== "return" &&
 		key.name !== "escape" &&
-		key.name !== "backspace" &&
-		key.name !== "delete" &&
 		key.sequence.length === 1
 	)
 }

--- a/cli/src/state/atoms/keyboard.ts
+++ b/cli/src/state/atoms/keyboard.ts
@@ -488,6 +488,11 @@ function handleFollowupKeys(get: Getter, set: Setter, key: Key): void {
 			break
 	}
 
+	if (isKeyModifyBuffer(key)) {
+		// If modifying buffer, unselect any suggestion
+		set(selectedIndexAtom, -1)
+	}
+
 	// Fall through to normal text handling
 	handleTextInputKeys(get, set, key)
 }
@@ -889,3 +894,21 @@ export const setupKeyboardAtom = atom(null, (get, set) => {
 
 	return unsubscribe
 })
+
+/**
+ * Utility Keys Functions
+ */
+
+const isKeyModifyBuffer = (key: Key): boolean => {
+	return (
+		!key.ctrl &&
+		!key.meta &&
+		!key.shift &&
+		!key.paste &&
+		key.name !== "return" &&
+		key.name !== "escape" &&
+		key.name !== "backspace" &&
+		key.name !== "delete" &&
+		key.sequence.length === 1
+	)
+}

--- a/cli/src/state/atoms/ui.ts
+++ b/cli/src/state/atoms/ui.ts
@@ -397,7 +397,11 @@ export const clearTextBufferAtom = atom(null, (get, set) => {
  */
 export const setSuggestionsAtom = atom(null, (get, set, suggestions: CommandSuggestion[]) => {
 	set(suggestionsAtom, suggestions)
-	set(selectedIndexAtom, 0)
+	if (suggestions.length === 0) {
+		set(selectedIndexAtom, -1)
+	} else {
+		set(selectedIndexAtom, 0)
+	}
 })
 
 /**
@@ -405,7 +409,11 @@ export const setSuggestionsAtom = atom(null, (get, set, suggestions: CommandSugg
  */
 export const setArgumentSuggestionsAtom = atom(null, (get, set, suggestions: ArgumentSuggestion[]) => {
 	set(argumentSuggestionsAtom, suggestions)
-	set(selectedIndexAtom, 0)
+	if (suggestions.length === 0) {
+		set(selectedIndexAtom, -1)
+	} else {
+		set(selectedIndexAtom, 0)
+	}
 })
 
 /**
@@ -413,7 +421,11 @@ export const setArgumentSuggestionsAtom = atom(null, (get, set, suggestions: Arg
  */
 export const setFileMentionSuggestionsAtom = atom(null, (get, set, suggestions: FileMentionSuggestion[]) => {
 	set(fileMentionSuggestionsAtom, suggestions)
-	set(selectedIndexAtom, 0)
+	if (suggestions.length === 0) {
+		set(selectedIndexAtom, -1)
+	} else {
+		set(selectedIndexAtom, 0)
+	}
 })
 
 /**


### PR DESCRIPTION
## Context

Resolve: #3811 

## Implementation

- Unselect the suggestion if the user press any key that modify the buffer
- Don't auto select the first option when no suggestion are available

## Screenshots

<img width="2298" height="1436" alt="image" src="https://github.com/user-attachments/assets/20b30b30-65de-4016-b6a1-46e6a05b2feb" />
<img width="2298" height="1436" alt="image" src="https://github.com/user-attachments/assets/4a7f7550-851b-4020-a2b5-33c86c1db7f4" />


## How to Test

- Prompt "ask me my name a give me options"
- Select any suggestion with Down/Up Keys
- Type any custom input

