### PR TITLE
Add GPT-5.1 models

### DIFF
--- a/.changeset/late-eels-remember.md
+++ b/.changeset/late-eels-remember.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add GPT-5.1 models for OpenAI provider

--- a/packages/types/src/providers/openai.ts
+++ b/packages/types/src/providers/openai.ts
@@ -3,9 +3,10 @@ import type { ModelInfo } from "../model.js"
 // https://openai.com/api/pricing/
 export type OpenAiNativeModelId = keyof typeof openAiNativeModels
 
-export const openAiNativeDefaultModelId: OpenAiNativeModelId = "gpt-5.1"
+export const openAiNativeDefaultModelId: OpenAiNativeModelId = "gpt-5.1" // kilocode_change
 
 export const openAiNativeModels = {
+	// kilocode_change start
 	"gpt-5.1": {
 		maxTokens: 128000,
 		contextWindow: 400000,
@@ -57,6 +58,7 @@ export const openAiNativeModels = {
 		description: "GPT-5.1 Chat Latest: Optimized for conversational AI and non-reasoning tasks",
 		supportsVerbosity: true,
 	},
+	// kilocode_change end
 	"gpt-5-chat-latest": {
 		maxTokens: 128000,
 		contextWindow: 400000,

--- a/packages/types/src/providers/openai.ts
+++ b/packages/types/src/providers/openai.ts
@@ -3,9 +3,60 @@ import type { ModelInfo } from "../model.js"
 // https://openai.com/api/pricing/
 export type OpenAiNativeModelId = keyof typeof openAiNativeModels
 
-export const openAiNativeDefaultModelId: OpenAiNativeModelId = "gpt-5-2025-08-07"
+export const openAiNativeDefaultModelId: OpenAiNativeModelId = "gpt-5.1"
 
 export const openAiNativeModels = {
+	"gpt-5.1": {
+		maxTokens: 128000,
+		contextWindow: 400000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoningEffort: true,
+		inputPrice: 1.25,
+		outputPrice: 10.0,
+		cacheReadsPrice: 0.125,
+		description:
+			"GPT-5.1 is our flagship model for coding and agentic tasks with configurable reasoning and non-reasoning effort.",
+		supportsVerbosity: true,
+	},
+	"gpt-5.1-codex": {
+		maxTokens: 128000,
+		contextWindow: 400000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoningEffort: true,
+		inputPrice: 1.25,
+		outputPrice: 10.0,
+		cacheReadsPrice: 0.125,
+		description:
+			"GPT-5.1-Codex is a version of GPT-5 optimized for agentic coding tasks in Codex or similar environments.",
+		supportsVerbosity: true,
+	},
+	"gpt-5.1-codex-mini": {
+		maxTokens: 128000,
+		contextWindow: 400000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoningEffort: true,
+		inputPrice: 1.25,
+		outputPrice: 10.0,
+		cacheReadsPrice: 0.125,
+		description:
+			"GPT-5.1-Codex Mini is a version of GPT-5 optimized for agentic coding tasks in Codex or similar environments.",
+		supportsVerbosity: true,
+	},
+	"gpt-5.1-chat-latest": {
+		maxTokens: 128000,
+		contextWindow: 400000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoningEffort: false,
+		inputPrice: 1.25,
+		outputPrice: 10.0,
+		cacheReadsPrice: 0.125,
+		description: "GPT-5.1 Chat Latest: Optimized for conversational AI and non-reasoning tasks",
+		supportsVerbosity: true,
+	},
 	"gpt-5-chat-latest": {
 		maxTokens: 128000,
 		contextWindow: 400000,

--- a/src/api/providers/__tests__/openai-native.spec.ts
+++ b/src/api/providers/__tests__/openai-native.spec.ts
@@ -202,7 +202,7 @@ describe("OpenAiNativeHandler", () => {
 				openAiNativeApiKey: "test-api-key",
 			})
 			const modelInfo = handlerWithoutModel.getModel()
-			expect(modelInfo.id).toBe("gpt-5-2025-08-07") // Default model
+			expect(modelInfo.id).toBe("gpt-5.1") // Default model
 			expect(modelInfo.info).toBeDefined()
 		})
 	})

--- a/src/api/providers/__tests__/openai-native.spec.ts
+++ b/src/api/providers/__tests__/openai-native.spec.ts
@@ -202,7 +202,7 @@ describe("OpenAiNativeHandler", () => {
 				openAiNativeApiKey: "test-api-key",
 			})
 			const modelInfo = handlerWithoutModel.getModel()
-			expect(modelInfo.id).toBe("gpt-5.1") // Default model
+			expect(modelInfo.id).toBe("gpt-5.1") // kilocode_change: Default model
 			expect(modelInfo.info).toBeDefined()
 		})
 	})


### PR DESCRIPTION
## Context

Adds GPT 5.1 models, and make 5.1 the default.

## Implementation

Added to types.  Adjusted tests

