### PR TITLE
Only use manged indexing for blessed orgs for now

### DIFF
--- a/webview-ui/src/components/chat/IndexingStatusBadge.tsx
+++ b/webview-ui/src/components/chat/IndexingStatusBadge.tsx
@@ -12,6 +12,7 @@ import { PopoverTrigger, StandardTooltip, Button } from "@src/components/ui"
 
 import { CodeIndexPopover } from "./CodeIndexPopover"
 import { ManagedCodeIndexPopover } from "./kilocode/ManagedCodeIndexPopover"
+import { useManagedCodeIndexingEnabled } from "./hooks/useManagedCodeIndexingEnabled"
 
 interface IndexingStatusBadgeProps {
 	className?: string
@@ -19,10 +20,10 @@ interface IndexingStatusBadgeProps {
 
 export const IndexingStatusBadge: React.FC<IndexingStatusBadgeProps> = ({ className }) => {
 	const { t } = useAppTranslation()
-	const { cwd, apiConfiguration } = useExtensionState()
+	const { cwd } = useExtensionState()
 
 	// Check if organization indexing is available
-	const hasOrganization = !!apiConfiguration?.kilocodeOrganizationId
+	const useManagedIndex = useManagedCodeIndexingEnabled() // kilocode_change
 
 	const [indexingStatus, setIndexingStatus] = useState<IndexingStatus>({
 		systemStatus: "Standby",
@@ -87,7 +88,7 @@ export const IndexingStatusBadge: React.FC<IndexingStatusBadgeProps> = ({ classN
 	}, [indexingStatus.systemStatus])
 
 	// Use ManagedCodeIndexPopover when organization is available, otherwise use regular CodeIndexPopover
-	const PopoverComponent = hasOrganization ? ManagedCodeIndexPopover : CodeIndexPopover
+	const PopoverComponent = useManagedIndex ? ManagedCodeIndexPopover : CodeIndexPopover
 
 	return (
 		<PopoverComponent indexingStatus={indexingStatus}>

--- a/webview-ui/src/components/chat/hooks/useManagedCodeIndexingEnabled.ts
+++ b/webview-ui/src/components/chat/hooks/useManagedCodeIndexingEnabled.ts
@@ -1,0 +1,16 @@
+import { useExtensionState } from "../../../context/ExtensionStateContext"
+
+const enabledCodeIndexOrgs = [
+	// kilo local (bmc)
+	"0e4c8216-9a79-4f25-a196-84bd58dec6ed",
+	// kilo prod
+	"9d278969-5453-4ae3-a51f-a8d2274a7b56",
+]
+
+export function useManagedCodeIndexingEnabled() {
+	const { apiConfiguration } = useExtensionState()
+
+	// Check if organization indexing is available
+	const orgId = String(apiConfiguration?.kilocodeOrganizationId || "")
+	return enabledCodeIndexOrgs.includes(orgId)
+}


### PR DESCRIPTION
## Context

Bug where any user switching to an org cannot use local code indexing and the managed version is not ready for outside orgs atm.  There are backend settings, but waiting on larger refactor to land before wiring them back through. For now this will fix users' workflows.  Just hard-coding some IDs for local testing & internal deployment testing.