### PR TITLE
fix: resolve GitHub API rate limit in code-qa workflow

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -160,10 +160,8 @@ jobs:
                   cache: "pnpm"
             - uses: actions/setup-java@v4
               with:
-                  distribution: 'jetbrains'
+                  distribution: 'temurin'
                   java-version: '21'
-                  check-latest: false
-                  token: ${{ secrets.GITHUB_TOKEN }}
             - name: Install system dependencies
               run: |
                 sudo apt-get update


### PR DESCRIPTION
Changed Java distribution from 'jetbrains' to 'temurin' to avoid API rate limit errors when resolving Java versions. Temurin is more reliable for CI/CD environments and doesn't require remote API calls.
