### PR TITLE
feat(mistral): add FIM support for codestral models

### DIFF
--- a/.changeset/crisp-rabbits-lick.md
+++ b/.changeset/crisp-rabbits-lick.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Faster autocomplete when using the Mistral provider

--- a/src/api/providers/__tests__/kilocode-openrouter.spec.ts
+++ b/src/api/providers/__tests__/kilocode-openrouter.spec.ts
@@ -259,26 +259,6 @@ describe("KilocodeOpenrouterHandler", () => {
 			expect(handler.supportsFim()).toBe(false)
 		})
 
-		it("completeFim handles errors correctly", async () => {
-			const handler = new KilocodeOpenrouterHandler({
-				...mockOptions,
-				kilocodeModel: "mistral/codestral-latest",
-			})
-
-			const mockResponse = {
-				ok: false,
-				status: 500,
-				statusText: "Internal Server Error",
-				text: vitest.fn().mockResolvedValue("Error details"),
-			}
-
-			global.fetch = vitest.fn().mockResolvedValue(mockResponse)
-
-			await expect(handler.completeFim("prefix", "suffix")).rejects.toThrow(
-				"FIM streaming failed: 500 Internal Server Error - Error details",
-			)
-		})
-
 		it("streamFim yields chunks correctly", async () => {
 			const handler = new KilocodeOpenrouterHandler({
 				...mockOptions,

--- a/src/api/providers/__tests__/mistral-fim.spec.ts
+++ b/src/api/providers/__tests__/mistral-fim.spec.ts
@@ -1,0 +1,228 @@
+// kilocode_change - new file
+// npx vitest run src/api/providers/__tests__/mistral-fim.spec.ts
+
+// Mock vscode first to avoid import errors
+vitest.mock("vscode", () => ({}))
+
+import { MistralHandler } from "../mistral"
+import { ApiHandlerOptions } from "../../../shared/api"
+import { streamSse } from "../../../services/continuedev/core/fetch/stream"
+
+// Mock the stream module
+vitest.mock("../../../services/continuedev/core/fetch/stream", () => ({
+	streamSse: vitest.fn(),
+}))
+
+// Mock delay
+vitest.mock("delay", () => ({ default: vitest.fn(() => Promise.resolve()) }))
+
+describe("MistralHandler FIM support", () => {
+	const mockOptions: ApiHandlerOptions = {
+		mistralApiKey: "test-api-key",
+		apiModelId: "codestral-latest",
+	}
+
+	beforeEach(() => vitest.clearAllMocks())
+
+	describe("supportsFim", () => {
+		it("returns true for codestral models", () => {
+			const handler = new MistralHandler({
+				...mockOptions,
+				apiModelId: "codestral-latest",
+			})
+
+			expect(handler.supportsFim()).toBe(true)
+		})
+
+		it("returns true for codestral-2405", () => {
+			const handler = new MistralHandler({
+				...mockOptions,
+				apiModelId: "codestral-2405",
+			})
+
+			expect(handler.supportsFim()).toBe(true)
+		})
+
+		it("returns false for non-codestral models", () => {
+			const handler = new MistralHandler({
+				...mockOptions,
+				apiModelId: "mistral-large-latest",
+			})
+
+			expect(handler.supportsFim()).toBe(false)
+		})
+
+		it("returns true when no model is specified (defaults to codestral-latest)", () => {
+			const handler = new MistralHandler({
+				mistralApiKey: "test-api-key",
+			})
+
+			// Default model is codestral-latest, which supports FIM
+			expect(handler.supportsFim()).toBe(true)
+		})
+	})
+
+	describe("completeFim", () => {
+		it("handles errors correctly", async () => {
+			const handler = new MistralHandler({
+				...mockOptions,
+				apiModelId: "codestral-latest",
+			})
+
+			const mockResponse = {
+				ok: false,
+				status: 500,
+				statusText: "Internal Server Error",
+				text: vitest.fn().mockResolvedValue("Error details"),
+			}
+
+			global.fetch = vitest.fn().mockResolvedValue(mockResponse)
+
+			await expect(handler.completeFim("prefix", "suffix")).rejects.toThrow(
+				"FIM streaming failed: 500 Internal Server Error - Error details",
+			)
+		})
+
+		it("aggregates all chunks", async () => {
+			const handler = new MistralHandler({
+				...mockOptions,
+				apiModelId: "codestral-latest",
+			})
+
+			// Mock streamSse to return the expected data
+			;(streamSse as any).mockImplementation(async function* () {
+				yield { choices: [{ delta: { content: "Hello" } }] }
+				yield { choices: [{ delta: { content: " " } }] }
+				yield { choices: [{ delta: { content: "World" } }] }
+			})
+
+			const mockResponse = {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+			} as Response
+
+			global.fetch = vitest.fn().mockResolvedValue(mockResponse)
+
+			const result = await handler.completeFim("prefix", "suffix")
+
+			expect(result).toBe("Hello World")
+		})
+	})
+
+	describe("streamFim", () => {
+		it("yields chunks correctly", async () => {
+			const handler = new MistralHandler({
+				...mockOptions,
+				apiModelId: "codestral-latest",
+			})
+
+			// Mock streamSse to return the expected data
+			;(streamSse as any).mockImplementation(async function* () {
+				yield { choices: [{ delta: { content: "chunk1" } }] }
+				yield { choices: [{ delta: { content: "chunk2" } }] }
+				yield { choices: [{ delta: { content: "chunk3" } }] }
+			})
+
+			const mockResponse = {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+			} as Response
+
+			global.fetch = vitest.fn().mockResolvedValue(mockResponse)
+
+			const chunks: string[] = []
+
+			for await (const chunk of handler.streamFim("prefix", "suffix")) {
+				chunks.push(chunk)
+			}
+
+			expect(chunks).toEqual(["chunk1", "chunk2", "chunk3"])
+			expect(streamSse).toHaveBeenCalledWith(mockResponse)
+		})
+
+		it("handles errors correctly", async () => {
+			const handler = new MistralHandler({
+				...mockOptions,
+				apiModelId: "codestral-latest",
+			})
+
+			const mockResponse = {
+				ok: false,
+				status: 400,
+				statusText: "Bad Request",
+				text: vitest.fn().mockResolvedValue("Invalid request"),
+			}
+
+			global.fetch = vitest.fn().mockResolvedValue(mockResponse)
+
+			const generator = handler.streamFim("prefix", "suffix")
+			await expect(generator.next()).rejects.toThrow("FIM streaming failed: 400 Bad Request - Invalid request")
+		})
+
+		it("uses correct endpoint for codestral models", async () => {
+			const handler = new MistralHandler({
+				...mockOptions,
+				apiModelId: "codestral-latest",
+			})
+
+			;(streamSse as any).mockImplementation(async function* () {
+				yield { choices: [{ delta: { content: "test" } }] }
+			})
+
+			const mockResponse = {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+			} as Response
+
+			global.fetch = vitest.fn().mockResolvedValue(mockResponse)
+
+			const generator = handler.streamFim("prefix", "suffix")
+			await generator.next()
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					href: "https://codestral.mistral.ai/v1/fim/completions",
+				}),
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-api-key",
+					}),
+				}),
+			)
+		})
+
+		it("uses custom codestral URL when provided", async () => {
+			const handler = new MistralHandler({
+				...mockOptions,
+				apiModelId: "codestral-latest",
+				mistralCodestralUrl: "https://custom.codestral.url",
+			})
+
+			;(streamSse as any).mockImplementation(async function* () {
+				yield { choices: [{ delta: { content: "test" } }] }
+			})
+
+			const mockResponse = {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+			} as Response
+
+			global.fetch = vitest.fn().mockResolvedValue(mockResponse)
+
+			const generator = handler.streamFim("prefix", "suffix")
+			await generator.next()
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					href: "https://custom.codestral.url/v1/fim/completions",
+				}),
+				expect.any(Object),
+			)
+		})
+	})
+})

--- a/src/api/providers/__tests__/mistral-fim.spec.ts
+++ b/src/api/providers/__tests__/mistral-fim.spec.ts
@@ -62,54 +62,6 @@ describe("MistralHandler FIM support", () => {
 		})
 	})
 
-	describe("completeFim", () => {
-		it("handles errors correctly", async () => {
-			const handler = new MistralHandler({
-				...mockOptions,
-				apiModelId: "codestral-latest",
-			})
-
-			const mockResponse = {
-				ok: false,
-				status: 500,
-				statusText: "Internal Server Error",
-				text: vitest.fn().mockResolvedValue("Error details"),
-			}
-
-			global.fetch = vitest.fn().mockResolvedValue(mockResponse)
-
-			await expect(handler.completeFim("prefix", "suffix")).rejects.toThrow(
-				"FIM streaming failed: 500 Internal Server Error - Error details",
-			)
-		})
-
-		it("aggregates all chunks", async () => {
-			const handler = new MistralHandler({
-				...mockOptions,
-				apiModelId: "codestral-latest",
-			})
-
-			// Mock streamSse to return the expected data
-			;(streamSse as any).mockImplementation(async function* () {
-				yield { choices: [{ delta: { content: "Hello" } }] }
-				yield { choices: [{ delta: { content: " " } }] }
-				yield { choices: [{ delta: { content: "World" } }] }
-			})
-
-			const mockResponse = {
-				ok: true,
-				status: 200,
-				statusText: "OK",
-			} as Response
-
-			global.fetch = vitest.fn().mockResolvedValue(mockResponse)
-
-			const result = await handler.completeFim("prefix", "suffix")
-
-			expect(result).toBe("Hello World")
-		})
-	})
-
 	describe("streamFim", () => {
 		it("yields chunks correctly", async () => {
 			const handler = new MistralHandler({

--- a/src/api/providers/kilocode-openrouter.ts
+++ b/src/api/providers/kilocode-openrouter.ts
@@ -148,14 +148,6 @@ export class KilocodeOpenrouterHandler extends OpenRouterHandler {
 		return modelId.includes("codestral")
 	}
 
-	async completeFim(prefix: string, suffix: string, taskId?: string): Promise<string> {
-		let result = ""
-		for await (const chunk of this.streamFim(prefix, suffix, taskId)) {
-			result += chunk
-		}
-		return result
-	}
-
 	async *streamFim(
 		prefix: string,
 		suffix: string,

--- a/src/api/providers/kilocode/IFimProvider.ts
+++ b/src/api/providers/kilocode/IFimProvider.ts
@@ -14,15 +14,6 @@ export interface IFimProvider {
 	supportsFim(): boolean
 
 	/**
-	 * Complete code between a prefix and suffix (non-streaming)
-	 * @param prefix - The code before the cursor/insertion point
-	 * @param suffix - The code after the cursor/insertion point
-	 * @param taskId - Optional task ID for tracking
-	 * @returns The completed code string
-	 */
-	completeFim(prefix: string, suffix: string, taskId?: string): Promise<string>
-
-	/**
 	 * Stream code completion between a prefix and suffix
 	 * @param prefix - The code before the cursor/insertion point
 	 * @param suffix - The code after the cursor/insertion point

--- a/src/api/providers/mistral.ts
+++ b/src/api/providers/mistral.ts
@@ -11,9 +11,9 @@ import { ApiStream } from "../transform/stream"
 
 import { BaseProvider } from "./base-provider"
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
-import { DEFAULT_HEADERS } from "./constants"
-import { streamSse } from "../../services/continuedev/core/fetch/stream"
-import type { CompletionUsage } from "./openrouter"
+import { DEFAULT_HEADERS } from "./constants" // kilocode_change
+import { streamSse } from "../../services/continuedev/core/fetch/stream" // kilocode_change
+import type { CompletionUsage } from "./openrouter" // kilocode_change
 
 // Type helper to handle thinking chunks from Mistral API
 // The SDK includes ThinkChunk but TypeScript has trouble with the discriminated union

--- a/src/api/providers/mistral.ts
+++ b/src/api/providers/mistral.ts
@@ -228,6 +228,7 @@ export class MistralHandler extends BaseProvider implements SingleCompletionHand
 		const { id: model, maxTokens } = this.getModel()
 
 		// Get the base URL for the model
+		// copy pasted from constructor, be sure to keep in sync
 		const baseUrl = model.startsWith("codestral-")
 			? this.options.mistralCodestralUrl || "https://codestral.mistral.ai"
 			: "https://api.mistral.ai"

--- a/src/api/providers/mistral.ts
+++ b/src/api/providers/mistral.ts
@@ -219,14 +219,6 @@ export class MistralHandler extends BaseProvider implements SingleCompletionHand
 		return modelId.startsWith("codestral-")
 	}
 
-	async completeFim(prefix: string, suffix: string, _taskId?: string): Promise<string> {
-		let result = ""
-		for await (const chunk of this.streamFim(prefix, suffix)) {
-			result += chunk
-		}
-		return result
-	}
-
 	async *streamFim(
 		prefix: string,
 		suffix: string,

--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -1,3 +1,4 @@
+// kilocode_change new file
 import { modelIdKeysByProvider, ProviderName } from "@roo-code/types"
 import { ApiHandler, buildApiHandler } from "../../api"
 import { ProviderSettingsManager } from "../../core/config/ProviderSettingsManager"
@@ -8,7 +9,6 @@ import { KilocodeOpenrouterHandler } from "../../api/providers/kilocode-openrout
 import { PROVIDERS } from "../../../webview-ui/src/components/settings/constants"
 import { ResponseMetaData } from "./types"
 
-// kilocode_change start
 /**
  * Interface for handlers that support FIM (Fill-in-the-Middle) completions.
  * Uses duck typing - any handler implementing these methods can be used for FIM.
@@ -30,7 +30,6 @@ function isFimCapable(handler: ApiHandler): handler is ApiHandler & FimCapableHa
 		(handler as any).supportsFim() === true
 	)
 }
-// kilocode_change end
 
 // Convert PROVIDERS array to a lookup map for display names
 const PROVIDER_DISPLAY_NAMES = Object.fromEntries(PROVIDERS.map(({ value, label }) => [value, label])) as Record<
@@ -110,7 +109,6 @@ export class GhostModel {
 		}
 	}
 
-	// kilocode_change start
 	public supportsFim(): boolean {
 		if (!this.apiHandler) {
 			return false
@@ -166,7 +164,6 @@ export class GhostModel {
 			cacheReadTokens,
 		}
 	}
-	// kilocode_change end
 
 	/**
 	 * Generate response with streaming callback support


### PR DESCRIPTION
- Add supportsFim(), completeFim(), and streamFim() methods to MistralHandler
- FIM support is only enabled for codestral models (codestral-latest, codestral-2405, etc.)
