### PR TITLE
feat: added inception provider to default json tool calling list

### DIFF
--- a/packages/types/src/kilocode/native-function-calling.ts
+++ b/packages/types/src/kilocode/native-function-calling.ts
@@ -38,6 +38,7 @@ const modelsDefaultingToJsonKeywords = [
 //Specific providers that default to JSON tool use, regardless of model.
 const providersDefaultingToJsonKeywords = [
 	"synthetic", //All synthetic models support JSON tools, and their pricing model strongly encourages their use
+	"inception",
 ]
 
 export function getActiveToolUseStyle(settings: ProviderSettings | undefined): ToolUseStyle {


### PR DESCRIPTION
This pull request makes a minor update to the list of providers that default to JSON tool use. The provider `"inception"` has been added to the `providersDefaultingToJsonKeywords` array in `kilocode/native-function-calling.ts`. 

* Added `"inception"` to the `providersDefaultingToJsonKeywords` array to ensure it defaults to JSON tool use.