### PR TITLE
fix: Ensure API provider profile is activated after manual configuration in welcome flow

### DIFF
--- a/.changeset/rotten-hotels-thank.md
+++ b/.changeset/rotten-hotels-thank.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix manual configuration in welcome flow


### PR DESCRIPTION

Fixes #3871

After PR #3732 separated profile editing from activation, the manual configuration flow in the welcome view stopped working. When users clicked 'Use your own API key' and configured an alternative provider, the profile was saved but never activated, causing the 'Please provide a valid API key' error.

The issue occurred because upsertApiConfiguration now only activates profiles when they match the currently active profile. In the welcome flow (fresh install or after reset), there's no active profile yet, so the new profile was never activated.

This fix explicitly activates the profile after saving it in the welcome flow by sending a loadApiConfiguration message, ensuring the configured provider is immediately usable.