### PR TITLE
Test-only: Fix trailing slashes after hostname

### DIFF
--- a/packages/types/src/__tests__/kilocode.test.ts
+++ b/packages/types/src/__tests__/kilocode.test.ts
@@ -70,7 +70,7 @@ describe("URL functions", () => {
 
 	describe("getAppUrl", () => {
 		it("should handle production URLs correctly", () => {
-			expect(getAppUrl()).toBe("https://kilocode.ai")
+			expect(getAppUrl()).toBe("https://kilocode.ai/")
 			expect(getAppUrl("/profile")).toBe("https://kilocode.ai/profile")
 			expect(getAppUrl("/support")).toBe("https://kilocode.ai/support")
 			expect(getAppUrl("/sign-in-to-editor")).toBe("https://kilocode.ai/sign-in-to-editor")
@@ -82,7 +82,7 @@ describe("URL functions", () => {
 		it("should handle development environment", () => {
 			process.env.KILOCODE_BACKEND_BASE_URL = "http://localhost:3000"
 
-			expect(getAppUrl()).toBe("http://localhost:3000")
+			expect(getAppUrl()).toBe("http://localhost:3000/")
 			expect(getAppUrl("/profile")).toBe("http://localhost:3000/profile")
 			expect(getAppUrl("/support")).toBe("http://localhost:3000/support")
 		})
@@ -93,8 +93,8 @@ describe("URL functions", () => {
 		})
 
 		it("should handle empty and root paths", () => {
-			expect(getAppUrl("")).toBe("https://kilocode.ai")
-			expect(getAppUrl("/")).toBe("https://kilocode.ai")
+			expect(getAppUrl("")).toBe("https://kilocode.ai/")
+			expect(getAppUrl("/")).toBe("https://kilocode.ai/")
 		})
 	})
 
@@ -197,7 +197,7 @@ describe("URL functions", () => {
 		it("should handle custom backend URLs", () => {
 			process.env.KILOCODE_BACKEND_BASE_URL = "https://staging.example.com"
 
-			expect(getAppUrl()).toBe("https://staging.example.com")
+			expect(getAppUrl()).toBe("https://staging.example.com/")
 			expect(getAppUrl("/api/test")).toBe("https://staging.example.com/api/test")
 			expect(getAppUrl("/dashboard")).toBe("https://staging.example.com/dashboard")
 		})


### PR DESCRIPTION
These tests are broken for me locally, and if I look at the spec, they _should_ be broken.  I don't understand why this works anywhere else.  Something wrong with our test runner?

If I do `pnpm test` these tests fail locally too, but on @chrarnoldus 's machine they don't (wtf?)  We tried lots of corepack and nvm stuff and couldn't find any nodejs version problems that explain the difference (but might not be looking in the right place?)

It's faster to do `pnpm i; pushd packages/types; pnpx vitest run src/__tests__; popd` but that to shows failing tests for me.


curious what the CI says...
