### PR TITLE
Actually run some of the tests we have on the CI, too

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -100,7 +100,16 @@ jobs:
             - name: Build (to build and copy WASM files)
               run: pnpm run vsix
               shell: bash
-            - name: Run unit tests
+            - name: Run packages/types tests
+              working-directory: packages/types
+              run: pnpm test
+            - name: Run packages/cloud tests
+              working-directory: packages/cloud
+              run: pnpm test
+            - name: Run packages/telemetry tests
+              working-directory: packages/telemetry
+              run: pnpm test
+            - name: Run extension unit tests
               working-directory: src
               run: pnpm test
 


### PR DESCRIPTION
 - Would have prevented https://github.com/Kilo-Org/kilocode/pull/3880 from being necessary
 - build should FAIL on the first commit, since the tests fail, and then pass after 3880 is merged.