### PR TITLE
base token limits for autocomplete prefix, suffix and context off continue's code.

### DIFF
--- a/src/services/continuedev/core/autocomplete/templating/filtering.ts
+++ b/src/services/continuedev/core/autocomplete/templating/filtering.ts
@@ -13,8 +13,8 @@ import { isValidSnippet } from "./validation"
 
 const getRemainingTokenCount = (helper: HelperVars): number => {
 	const tokenCount = countTokens(helper.prunedCaretWindow, helper.modelName)
-
-	return helper.options.maxPromptTokens - tokenCount
+	const remainingTokens = helper.options.maxPromptTokens - tokenCount
+	return Math.min(remainingTokens, Math.floor(helper.options.maxPromptTokens * helper.options.maxSnippetPercentage))
 }
 
 const TOKEN_BUFFER = 10 // We may need extra tokens for snippet description etc.

--- a/src/services/continuedev/core/index.d.ts
+++ b/src/services/continuedev/core/index.d.ts
@@ -551,6 +551,7 @@ export interface TabAutocompleteOptions {
 	modelTimeout: number
 	maxSuffixPercentage: number
 	prefixPercentage: number
+	maxSnippetPercentage: number
 	transform?: boolean
 	multilineCompletions: "always" | "never" | "auto"
 	slidingWindowPrefixPercentage: number

--- a/src/services/continuedev/core/util/parameters.ts
+++ b/src/services/continuedev/core/util/parameters.ts
@@ -2,9 +2,10 @@ import { TabAutocompleteOptions } from "../index.js"
 
 export const DEFAULT_AUTOCOMPLETE_OPTS: TabAutocompleteOptions = {
 	disable: false,
-	maxPromptTokens: 1024,
+	maxPromptTokens: 2048,
 	prefixPercentage: 0.3,
 	maxSuffixPercentage: 0.2,
+	maxSnippetPercentage: 0.6,
 	debounceDelay: 350,
 	modelTimeout: 150,
 	multilineCompletions: "auto",

--- a/src/services/continuedev/core/vscode-test-harness/test/JumpManager.test.ts
+++ b/src/services/continuedev/core/vscode-test-harness/test/JumpManager.test.ts
@@ -121,6 +121,7 @@ const createMockNextEditOutcome = (overrides: Partial<NextEditOutcome> = {}): Ne
 		modelTimeout: 5000,
 		maxSuffixPercentage: 0.5,
 		prefixPercentage: 0.8,
+		maxSnippetPercentage: 0.5,
 		transform: true,
 		multilineCompletions: "auto",
 		slidingWindowPrefixPercentage: 0.5,

--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -244,7 +244,7 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 		const { filepathUri, helper, snippetsWithUris, workspaceDirs } =
 			await this.contextProvider.getProcessedSnippets(autocompleteInput, autocompleteInput.filepath)
 
-		// Use pruned prefix/suffix from HelperVars (token-limited based on GHOST_AUTOCOMPLETE_OPTS)
+		// Use pruned prefix/suffix from HelperVars (token-limited based on DEFAULT_AUTOCOMPLETE_OPTS)
 		const prunedPrefix = helper.prunedPrefix
 		const prunedSuffix = helper.prunedSuffix
 

--- a/src/services/ghost/classic-auto-complete/HoleFiller.ts
+++ b/src/services/ghost/classic-auto-complete/HoleFiller.ts
@@ -181,7 +181,7 @@ Provide a subtle, non-intrusive completion after a typing pause.
 					autocompleteInput.filepath,
 				)
 				formattedContext = formatSnippets(helper, snippetsWithUris, workspaceDirs)
-				// Use pruned prefix/suffix from HelperVars (token-limited based on GHOST_AUTOCOMPLETE_OPTS)
+				// Use pruned prefix/suffix from HelperVars (token-limited based on DEFAULT_AUTOCOMPLETE_OPTS)
 				prunedPrefix = helper.prunedPrefix
 				prunedSuffix = helper.prunedSuffix
 			} catch (error) {

--- a/src/services/ghost/classic-auto-complete/HoleFiller.ts
+++ b/src/services/ghost/classic-auto-complete/HoleFiller.ts
@@ -172,6 +172,8 @@ Provide a subtle, non-intrusive completion after a typing pause.
 		let prompt = `<LANGUAGE>${languageId}</LANGUAGE>\n\n`
 
 		let formattedContext = ""
+		let prunedPrefix = prefix
+		let prunedSuffix = suffix
 		if (this.contextProvider && autocompleteInput.filepath) {
 			try {
 				const { helper, snippetsWithUris, workspaceDirs } = await this.contextProvider.getProcessedSnippets(
@@ -179,13 +181,16 @@ Provide a subtle, non-intrusive completion after a typing pause.
 					autocompleteInput.filepath,
 				)
 				formattedContext = formatSnippets(helper, snippetsWithUris, workspaceDirs)
+				// Use pruned prefix/suffix from HelperVars (token-limited based on GHOST_AUTOCOMPLETE_OPTS)
+				prunedPrefix = helper.prunedPrefix
+				prunedSuffix = helper.prunedSuffix
 			} catch (error) {
 				console.warn("Failed to get formatted context:", error)
 			}
 		}
 
 		prompt += `<QUERY>
-${formattedContext}${formattedContext ? "\n" : ""}${prefix}{{FILL_HERE}}${suffix}
+${formattedContext}${formattedContext ? "\n" : ""}${prunedPrefix}{{FILL_HERE}}${prunedSuffix}
 </QUERY>
 
 TASK: Fill the {{FILL_HERE}} hole. Answer only with the CORRECT completion, and NOTHING ELSE. Do it now.

--- a/src/services/ghost/classic-auto-complete/__tests__/HoleFiller.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/HoleFiller.test.ts
@@ -59,6 +59,8 @@ Return the COMPLETION tags`
 					helper: {
 						filepath: "file:///app.ts",
 						lang: { name: "typescript", singleLineComment: "//" },
+						prunedPrefix: "function calculate() {\n  ",
+						prunedSuffix: "\n}",
 					},
 					snippetsWithUris: [
 						{


### PR DESCRIPTION
Because it looks like they might be doing something smart there.

Also slightly tune the context window size.

 - basically: tune #3882