### PR TITLE
refactor: unify HoleFiller and FIM as separate strategy implementations

### DIFF
--- a/src/services/ghost/classic-auto-complete/strategies/FimStrategy.ts
+++ b/src/services/ghost/classic-auto-complete/strategies/FimStrategy.ts
@@ -1,0 +1,69 @@
+import { AutocompleteInput } from "../../types"
+import { FillInAtCursorSuggestion } from "../HoleFiller"
+import { GhostContextProvider } from "../GhostContextProvider"
+import { ICompletionStrategy, CompletionPrompts, UsageInfo } from "./ICompletionStrategy"
+import { GhostModel } from "../../GhostModel"
+import { getTemplateForModel } from "../../../continuedev/core/autocomplete/templating/AutocompleteTemplate"
+
+/**
+ * FIM (Fill-In-the-Middle) strategy - uses model-specific template formatting
+ */
+export class FimStrategy implements ICompletionStrategy {
+	constructor(private contextProvider: GhostContextProvider) {}
+
+	async getPrompts(
+		autocompleteInput: AutocompleteInput,
+		prefix: string,
+		suffix: string,
+		_languageId: string,
+		modelName?: string,
+	): Promise<CompletionPrompts> {
+		const { filepathUri, snippetsWithUris, workspaceDirs } = await this.contextProvider.getProcessedSnippets(
+			autocompleteInput,
+			autocompleteInput.filepath,
+		)
+
+		const template = getTemplateForModel(modelName ?? "codestral")
+
+		let formattedPrefix = prefix
+		let formattedSuffix = suffix
+
+		if (template.compilePrefixSuffix) {
+			;[formattedPrefix, formattedSuffix] = template.compilePrefixSuffix(
+				prefix,
+				suffix,
+				filepathUri,
+				"", // reponame not used in our context
+				snippetsWithUris,
+				workspaceDirs,
+			)
+		}
+
+		console.log("[FIM] formattedPrefix:", formattedPrefix)
+
+		return {
+			formattedPrefix,
+			formattedSuffix,
+			// No system/user prompts for FIM - it uses the formatted prefix/suffix directly
+		}
+	}
+
+	parseResponse(response: string, prefix: string, suffix: string): FillInAtCursorSuggestion {
+		// FIM responses are direct - no XML parsing needed
+		return { text: response, prefix, suffix }
+	}
+
+	async generateResponse(
+		model: GhostModel,
+		prompts: CompletionPrompts,
+		onChunk: (chunk: string) => void,
+		taskId?: string,
+	): Promise<UsageInfo> {
+		// FIM uses string format for chunks
+		const chunkHandler = (text: string) => {
+			onChunk(text)
+		}
+
+		return model.generateFimResponse(prompts.formattedPrefix, prompts.formattedSuffix, chunkHandler, taskId)
+	}
+}

--- a/src/services/ghost/classic-auto-complete/strategies/HoleFillerStrategy.ts
+++ b/src/services/ghost/classic-auto-complete/strategies/HoleFillerStrategy.ts
@@ -1,0 +1,91 @@
+import { AutocompleteInput } from "../../types"
+import { FillInAtCursorSuggestion, parseGhostResponse, getBaseSystemInstructions } from "../HoleFiller"
+import { GhostContextProvider } from "../GhostContextProvider"
+import { ICompletionStrategy, CompletionPrompts, UsageInfo } from "./ICompletionStrategy"
+import { GhostModel } from "../../GhostModel"
+import { ApiStreamChunk } from "../../../../api/transform/stream"
+import { formatSnippets } from "../../../continuedev/core/autocomplete/templating/formatting"
+
+/**
+ * HoleFiller strategy - uses XML-based prompts with {{FILL_HERE}} placeholder
+ */
+export class HoleFillerStrategy implements ICompletionStrategy {
+	constructor(private contextProvider?: GhostContextProvider) {}
+
+	async getPrompts(
+		autocompleteInput: AutocompleteInput,
+		prefix: string,
+		suffix: string,
+		languageId: string,
+		_modelName?: string,
+	): Promise<CompletionPrompts> {
+		const userPrompt = await this.getUserPrompt(autocompleteInput, prefix, suffix, languageId)
+		return {
+			systemPrompt: this.getSystemInstructions(),
+			userPrompt,
+			formattedPrefix: prefix,
+			formattedSuffix: suffix,
+		}
+	}
+
+	parseResponse(response: string, prefix: string, suffix: string): FillInAtCursorSuggestion {
+		return parseGhostResponse(response, prefix, suffix)
+	}
+
+	async generateResponse(
+		model: GhostModel,
+		prompts: CompletionPrompts,
+		onChunk: (chunk: ApiStreamChunk | string) => void,
+	): Promise<UsageInfo> {
+		// HoleFiller uses ApiStreamChunk format
+		const chunkHandler = (chunk: ApiStreamChunk) => {
+			onChunk(chunk)
+		}
+
+		return model.generateResponse(prompts.systemPrompt!, prompts.userPrompt!, chunkHandler)
+	}
+
+	private getSystemInstructions(): string {
+		return (
+			getBaseSystemInstructions() +
+			`Task: Auto-Completion
+Provide a subtle, non-intrusive completion after a typing pause.
+
+`
+		)
+	}
+
+	/**
+	 * Build minimal prompt for auto-trigger with optional context
+	 */
+	private async getUserPrompt(
+		autocompleteInput: AutocompleteInput,
+		prefix: string,
+		suffix: string,
+		languageId: string,
+	): Promise<string> {
+		let prompt = `<LANGUAGE>${languageId}</LANGUAGE>\n\n`
+
+		let formattedContext = ""
+		if (this.contextProvider && autocompleteInput.filepath) {
+			try {
+				const { helper, snippetsWithUris, workspaceDirs } = await this.contextProvider.getProcessedSnippets(
+					autocompleteInput,
+					autocompleteInput.filepath,
+				)
+				formattedContext = formatSnippets(helper, snippetsWithUris, workspaceDirs)
+			} catch (error) {
+				console.warn("Failed to get formatted context:", error)
+			}
+		}
+
+		prompt += `<QUERY>
+${formattedContext}${formattedContext ? "\n" : ""}${prefix}{{FILL_HERE}}${suffix}
+</QUERY>
+
+TASK: Fill the {{FILL_HERE}} hole. Answer only with the CORRECT completion, and NOTHING ELSE. Do it now.
+Return the COMPLETION tags`
+
+		return prompt
+	}
+}

--- a/src/services/ghost/classic-auto-complete/strategies/ICompletionStrategy.ts
+++ b/src/services/ghost/classic-auto-complete/strategies/ICompletionStrategy.ts
@@ -1,0 +1,50 @@
+import { AutocompleteInput } from "../../types"
+import { FillInAtCursorSuggestion } from "../HoleFiller"
+import { GhostModel } from "../../GhostModel"
+import { ApiStreamChunk } from "../../../../api/transform/stream"
+
+export interface CompletionPrompts {
+	systemPrompt?: string
+	userPrompt?: string
+	formattedPrefix: string
+	formattedSuffix: string
+}
+
+export interface UsageInfo {
+	cost: number
+	inputTokens: number
+	outputTokens: number
+	cacheWriteTokens: number
+	cacheReadTokens: number
+}
+
+/**
+ * Strategy interface for different autocomplete approaches (HoleFiller, FIM, etc.)
+ */
+export interface ICompletionStrategy {
+	/**
+	 * Generate prompts for the completion request
+	 */
+	getPrompts(
+		autocompleteInput: AutocompleteInput,
+		prefix: string,
+		suffix: string,
+		languageId: string,
+		modelName?: string,
+	): Promise<CompletionPrompts>
+
+	/**
+	 * Parse the raw response from the model into a suggestion
+	 */
+	parseResponse(response: string, prefix: string, suffix: string): FillInAtCursorSuggestion
+
+	/**
+	 * Generate response using the model
+	 */
+	generateResponse(
+		model: GhostModel,
+		prompts: CompletionPrompts,
+		onChunk: (chunk: ApiStreamChunk | string) => void,
+		taskId?: string,
+	): Promise<UsageInfo>
+}

--- a/src/services/ghost/classic-auto-complete/strategies/StrategyFactory.ts
+++ b/src/services/ghost/classic-auto-complete/strategies/StrategyFactory.ts
@@ -1,0 +1,20 @@
+import { GhostModel } from "../../GhostModel"
+import { GhostContextProvider } from "../GhostContextProvider"
+import { ICompletionStrategy } from "./ICompletionStrategy"
+import { HoleFillerStrategy } from "./HoleFillerStrategy"
+import { FimStrategy } from "./FimStrategy"
+
+/**
+ * Factory for creating the appropriate completion strategy based on model capabilities
+ */
+export class StrategyFactory {
+	/**
+	 * Create a completion strategy based on whether the model supports FIM
+	 */
+	static createStrategy(model: GhostModel, contextProvider: GhostContextProvider): ICompletionStrategy {
+		if (model.supportsFim()) {
+			return new FimStrategy(contextProvider)
+		}
+		return new HoleFillerStrategy(contextProvider)
+	}
+}

--- a/src/services/ghost/classic-auto-complete/strategies/__tests__/StrategyFactory.test.ts
+++ b/src/services/ghost/classic-auto-complete/strategies/__tests__/StrategyFactory.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest"
+import { StrategyFactory } from "../StrategyFactory"
+import { HoleFillerStrategy } from "../HoleFillerStrategy"
+import { FimStrategy } from "../FimStrategy"
+import { GhostModel } from "../../../GhostModel"
+import { GhostContextProvider } from "../../GhostContextProvider"
+
+describe("StrategyFactory", () => {
+	it("should create HoleFillerStrategy when model does not support FIM", () => {
+		const mockModel = {
+			supportsFim: vi.fn().mockReturnValue(false),
+		} as unknown as GhostModel
+
+		const mockContextProvider = {} as GhostContextProvider
+
+		const strategy = StrategyFactory.createStrategy(mockModel, mockContextProvider)
+
+		expect(strategy).toBeInstanceOf(HoleFillerStrategy)
+		expect(mockModel.supportsFim).toHaveBeenCalled()
+	})
+
+	it("should create FimStrategy when model supports FIM", () => {
+		const mockModel = {
+			supportsFim: vi.fn().mockReturnValue(true),
+		} as unknown as GhostModel
+
+		const mockContextProvider = {} as GhostContextProvider
+
+		const strategy = StrategyFactory.createStrategy(mockModel, mockContextProvider)
+
+		expect(strategy).toBeInstanceOf(FimStrategy)
+		expect(mockModel.supportsFim).toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
- Create ICompletionStrategy interface for autocomplete strategies
- Implement HoleFillerStrategy for XML-based hole filling approach
- Implement FimStrategy for Fill-In-the-Middle template-based approach
- Add StrategyFactory to select strategy based on model capabilities
- Refactor GhostInlineCompletionProvider to use strategy pattern
- Strategy selection now happens at construction time, not runtime
- Unified code path for both strategies in getFromLLM()
- Add tests for StrategyFactory
- All existing tests pass

Benefits:
- HoleFiller and FIM are now equal peer strategies
- Strategy decision made before prompt creation (like CompletionProvider)
- Single unified code path reduces duplication
- Easier to add new strategies in the future
- Better separation of concerns

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
