### PR TITLE
fix: add backtracking to word boundary search to fix Gemini search issue

### DIFF
--- a/webview-ui/src/lib/__tests__/word-boundary-fzf.spec.ts
+++ b/webview-ui/src/lib/__tests__/word-boundary-fzf.spec.ts
@@ -141,10 +141,11 @@ describe("Fzf - Word Boundary Matching", () => {
 			const fzf = new Fzf(items, { selector: (item) => item.name })
 			const results = fzf.find("test")
 
-			// Should match "test" and "testing" at word start, and "the test" at word boundary
-			expect(results).toHaveLength(2)
+			// Should match all three: "test" and "testing" at word start, and "the test" at word boundary
+			expect(results).toHaveLength(3)
 			expect(results[0].item.id).toBe(1)
 			expect(results[1].item.id).toBe(2)
+			expect(results[2].item.id).toBe(3)
 		})
 
 		it("should preserve original order", () => {
@@ -293,6 +294,106 @@ describe("Fzf - Word Boundary Matching", () => {
 			const results = fzf.find("clso")
 			// Should not match because 'cl' and 'so' are not at word boundaries
 			expect(results).toHaveLength(0)
+		})
+	})
+
+	describe("Trimming and space handling", () => {
+		it("should trim leading and trailing spaces from query", () => {
+			const items = [
+				{ id: 1, name: "foo bar" },
+				{ id: 2, name: "foo" },
+			]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			// Query with leading space should match same as without
+			const resultsWithSpace = fzf.find(" foo")
+			const resultsWithoutSpace = fzf.find("foo")
+
+			expect(resultsWithSpace).toHaveLength(2)
+			expect(resultsWithoutSpace).toHaveLength(2)
+			expect(resultsWithSpace.map((r) => r.item.id)).toEqual(resultsWithoutSpace.map((r) => r.item.id))
+		})
+
+		it("should trim trailing spaces from query", () => {
+			const items = [
+				{ id: 1, name: "foo bar" },
+				{ id: 2, name: "foo" },
+			]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			// Query with trailing space should match same as without
+			const resultsWithSpace = fzf.find("foo ")
+			const resultsWithoutSpace = fzf.find("foo")
+
+			expect(resultsWithSpace).toHaveLength(2)
+			expect(resultsWithoutSpace).toHaveLength(2)
+			expect(resultsWithSpace.map((r) => r.item.id)).toEqual(resultsWithoutSpace.map((r) => r.item.id))
+		})
+
+		it("should handle query with spaces on both sides", () => {
+			const items = [{ id: 1, name: "foo bar" }]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			const results = fzf.find("  foo  ")
+			expect(results).toHaveLength(1)
+			expect(results[0].item.id).toBe(1)
+		})
+	})
+
+	describe("Backtracking for word matches", () => {
+		it("should match word that appears later in text", () => {
+			const items = [
+				{ id: 1, name: "google gemini" },
+				{ id: 2, name: "gemini pro" },
+			]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			const results = fzf.find("gemini")
+			// Should match both items
+			expect(results).toHaveLength(2)
+			expect(results.map((r) => r.item.id)).toContain(1)
+			expect(results.map((r) => r.item.id)).toContain(2)
+		})
+
+		it("should match partial word that appears later", () => {
+			const items = [
+				{ id: 1, name: "Microsoft Copilot" },
+				{ id: 2, name: "GitHub Copilot" },
+				{ id: 3, name: "Copilot Pro" },
+			]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			const results = fzf.find("copilot")
+			// Should match all three items
+			expect(results).toHaveLength(3)
+		})
+
+		it("should match when query word is not the first word", () => {
+			const items = [
+				{ id: 1, name: "The Quick Brown Fox" },
+				{ id: 2, name: "Brown Bear" },
+				{ id: 3, name: "Quick Start Guide" },
+			]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			const results = fzf.find("brown")
+			// Should match items 1 and 2
+			expect(results).toHaveLength(2)
+			expect(results.map((r) => r.item.id)).toContain(1)
+			expect(results.map((r) => r.item.id)).toContain(2)
+		})
+
+		it("should still respect word boundaries with backtracking", () => {
+			const items = [
+				{ id: 1, name: "google gemini" },
+				{ id: 2, name: "googlegemini" }, // no space, not a word boundary
+			]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			const results = fzf.find("gemini")
+			// Should only match item 1 where gemini is a separate word
+			expect(results).toHaveLength(1)
+			expect(results[0].item.id).toBe(1)
 		})
 	})
 


### PR DESCRIPTION
## Summary

This PR fixes the word boundary search functionality that was introduced in #3778, addressing the issue where searching for "gemini" wouldn't match "google gemini".

## Problem

The previous implementation only matched from the beginning of words forward, without backtracking. This meant:
- ❌ Searching for "gemini" wouldn't match "google gemini" 
- ❌ The search was too restrictive for multi-word model names

## Solution

Implemented backtracking in the `matchAcronym` method to:
- ✅ Try matching from each word position in the text
- ✅ Find matches that don't necessarily start at the beginning
- ✅ Still respect word boundaries (e.g., "gemini" won't match "googlegemini" without spaces)

## Changes

1. **Updated `webview-ui/src/lib/word-boundary-fzf.ts`**:
   - Rewrote the `matchAcronym` method to support backtracking
   - The algorithm now tries to match starting from each word position
   - Maintains word boundary respect while allowing matches to start from any word

2. **Added comprehensive test coverage**:
   - Tests for trimming spaces from queries
   - Tests for backtracking to find words that appear later in text
   - Tests to ensure word boundaries are still respected with backtracking
   - Fixed an existing test that had incorrect expectations

## Testing

- ✅ All 37 tests in the word-boundary-fzf test suite pass
- ✅ All 1,150 tests in the webview-ui test suite pass
- ✅ Manual verification confirms both bugs are fixed

## Examples

Before:
- `" foo"` (with space) → wouldn't match "foo" ❌
- `"gemini"` → wouldn't match "google gemini" ❌

After:
- `" foo"` (with space) → matches "foo" ✅
- `"gemini"` → matches "google gemini" ✅
- `"gemini"` → doesn't match "googlegemini" (respects boundaries) ✅

Fixes #3896