### PR TITLE
fix: don't show browser screenshot when closing browser

### DIFF
--- a/.changeset/six-ghosts-cough.md
+++ b/.changeset/six-ghosts-cough.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Do not show browser window when closing the browser

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26967,7 +26967,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.17.57)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
 
   '@vitest/utils@2.0.5':
     dependencies:

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1375,19 +1375,21 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 				}
 
 				if (isBrowserSessionMessage(message)) {
-					currentGroup.push(message)
-
 					// kilocode_change start: upstream pr https://github.com/RooCodeInc/Roo-Code/pull/5452
+					// Check if this is a browser_action_result for a close action
 					if (message.say === "browser_action_result") {
-						// Check if the previous browser_action was a close action
 						const lastBrowserAction = [...currentGroup].reverse().find((m) => m.say === "browser_action")
 						if (lastBrowserAction) {
 							const browserAction = JSON.parse(lastBrowserAction.text || "{}") as ClineSayBrowserAction
 							if (browserAction.action === "close") {
+								// Don't add the browser_action_result for close action to the group
+								// End the session immediately
 								endBrowserSession()
+								return
 							}
 						}
 					}
+					currentGroup.push(message)
 					// kilocode_change end
 				} else {
 					// complete existing browser session if any


### PR DESCRIPTION
Before:
<img width="1542" height="1598" alt="CleanShot 2025-11-20 at 11 04 43@2x" src="https://github.com/user-attachments/assets/cda70f34-013a-49ee-a968-d998919203db" />


After:
<img width="1172" height="430" alt="CleanShot 2025-11-20 at 11 03 49@2x" src="https://github.com/user-attachments/assets/93712dfc-ae04-4e89-9d31-fe63354816f1" />
