### PR TITLE
fix: handle hyphens in fzf word boundary matching

### DIFF
--- a/webview-ui/src/lib/__tests__/word-boundary-fzf.spec.ts
+++ b/webview-ui/src/lib/__tests__/word-boundary-fzf.spec.ts
@@ -235,6 +235,21 @@ describe("Fzf - Word Boundary Matching", () => {
 			expect(results[0].item.id).toBe(1)
 		})
 
+		it("should find model names when query has trailing hyphen", () => {
+			const items = [
+				{ id: 1, name: "OpenAI: gpt-5 mini" },
+				{ id: 2, name: "OpenAI: gpt-4" },
+				{ id: 3, name: "Anthropic: claude-3" },
+			]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			const results = fzf.find("gpt-")
+			// Should match all gpt models
+			expect(results).toHaveLength(2)
+			expect(results.map((r) => r.item.id)).toContain(1)
+			expect(results.map((r) => r.item.id)).toContain(2)
+		})
+
 		it("should work with file paths", () => {
 			const items = [
 				{ path: "src/components/ui/select-dropdown.tsx" },

--- a/webview-ui/src/lib/__tests__/word-boundary-fzf.spec.ts
+++ b/webview-ui/src/lib/__tests__/word-boundary-fzf.spec.ts
@@ -207,6 +207,34 @@ describe("Fzf - Word Boundary Matching", () => {
 			expect(results[0].item.value).toBe("code")
 		})
 
+		it("should find model names with hyphens when query contains hyphen", () => {
+			const items = [
+				{ id: 1, name: "OpenAI: gpt-5 mini" },
+				{ id: 2, name: "OpenAI: gpt-4" },
+				{ id: 3, name: "Anthropic: claude-3" },
+			]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			const results = fzf.find("gpt-5")
+			// Should match "OpenAI: gpt-5 mini"
+			expect(results).toHaveLength(1)
+			expect(results[0].item.id).toBe(1)
+		})
+
+		it("should find model names with hyphens when query omits hyphen", () => {
+			const items = [
+				{ id: 1, name: "OpenAI: gpt-5 mini" },
+				{ id: 2, name: "OpenAI: gpt-4" },
+				{ id: 3, name: "Anthropic: claude-3" },
+			]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			const results = fzf.find("gpt5")
+			// Should match "OpenAI: gpt-5 mini" (gpt + 5)
+			expect(results).toHaveLength(1)
+			expect(results[0].item.id).toBe(1)
+		})
+
 		it("should work with file paths", () => {
 			const items = [
 				{ path: "src/components/ui/select-dropdown.tsx" },

--- a/webview-ui/src/lib/word-boundary-fzf.ts
+++ b/webview-ui/src/lib/word-boundary-fzf.ts
@@ -47,8 +47,10 @@ export class Fzf<T> {
 
 		const normalizedQuery = query.toLowerCase().trim()
 
-		// Split query into words for multi-word matching
-		const queryWords = normalizedQuery.split(/\s+/).filter((word) => word.length > 0)
+		// Split query into words using the same word boundary regex as text
+		// This ensures "gpt-5" becomes ["gpt", "5"] just like in the text
+		const wordBoundaryRegex = /[\s\-_./\\:]+/
+		const queryWords = normalizedQuery.split(wordBoundaryRegex).filter((word) => word.length > 0)
 
 		const results: FzfResult<T>[] = []
 
@@ -79,7 +81,7 @@ export class Fzf<T> {
 	 * Each character in the query should match the start of a word in the text.
 	 */
 	private matchAcronym(text: string, query: string): boolean {
-		const wordBoundaryRegex = /[\s\-_./\\]+/
+		const wordBoundaryRegex = /[\s\-_./\\:]+/
 		const words = text.split(wordBoundaryRegex).filter((w) => w.length > 0)
 
 		// Build word start positions in the original text

--- a/webview-ui/src/lib/word-boundary-fzf.ts
+++ b/webview-ui/src/lib/word-boundary-fzf.ts
@@ -17,6 +17,9 @@ interface FzfResult<T> {
 	item: T
 }
 
+// Single source of truth for word boundary characters
+const WORD_BOUNDARY_REGEX = /[\s\-_./\\:]+/
+
 export class Fzf<T> {
 	private items: T[]
 	private selector: (item: T) => string
@@ -49,8 +52,7 @@ export class Fzf<T> {
 
 		// Split query into words using the same word boundary regex as text
 		// This ensures "gpt-5" becomes ["gpt", "5"] just like in the text
-		const wordBoundaryRegex = /[\s\-_./\\:]+/
-		const queryWords = normalizedQuery.split(wordBoundaryRegex).filter((word) => word.length > 0)
+		const queryWords = normalizedQuery.split(WORD_BOUNDARY_REGEX).filter((word) => word.length > 0)
 
 		const results: FzfResult<T>[] = []
 
@@ -87,8 +89,7 @@ export class Fzf<T> {
 	 * Each character in the query should match the start of a word in the text.
 	 */
 	private matchAcronym(text: string, query: string): boolean {
-		const wordBoundaryRegex = /[\s\-_./\\:]+/
-		const words = text.split(wordBoundaryRegex).filter((w) => w.length > 0)
+		const words = text.split(WORD_BOUNDARY_REGEX).filter((w) => w.length > 0)
 
 		// Build word start positions in the original text
 		const wordStartPositions: number[] = []

--- a/webview-ui/src/lib/word-boundary-fzf.ts
+++ b/webview-ui/src/lib/word-boundary-fzf.ts
@@ -54,6 +54,11 @@ export class Fzf<T> {
 
 		const results: FzfResult<T>[] = []
 
+		// If no words after splitting (e.g., query was just punctuation), return all items
+		if (queryWords.length === 0) {
+			return this.items.map((item) => ({ item }))
+		}
+
 		for (const item of this.items) {
 			const text = this.selector(item).toLowerCase()
 
@@ -65,8 +70,9 @@ export class Fzf<T> {
 					results.push({ item })
 				}
 			} else {
-				// Single word query - use acronym matching
-				if (this.matchAcronym(text, normalizedQuery)) {
+				// Single word query - use the filtered word, not the original query
+				// This handles cases like "gpt-" which becomes ["gpt"]
+				if (this.matchAcronym(text, queryWords[0])) {
 					results.push({ item })
 				}
 			}


### PR DESCRIPTION
## Summary
Fix word boundary matching to properly handle queries containing hyphens like "gpt-5".

## Changes
- Split query using same word boundary regex as text (`/[\s\-_./\\:]+/`)
- Add colon to word boundary characters
- Add tests for model names with hyphens (e.g., gpt-5)

## Testing
- Added test: searching for "gpt-5" finds "OpenAI: gpt-5 mini"
- Added test: searching for "gpt5" (without hyphen) also finds "OpenAI: gpt-5 mini"
- All 38 tests pass