### PR TITLE
fix: prevent multiline commands from showing auto-approve options

### DIFF
--- a/webview-ui/src/components/chat/CommandExecution.tsx
+++ b/webview-ui/src/components/chat/CommandExecution.tsx
@@ -55,8 +55,18 @@ export const CommandExecution = ({ executionId, text, icon, title }: CommandExec
 
 	// Extract command patterns from the actual command that was executed
 	const commandPatterns = useMemo<CommandPattern[]>(() => {
-		// First get all individual commands (including subshell commands) using parseCommand
+		// Check if this is a true multiline command (contains newlines not within quotes)
+		// We can detect this by checking if the original command contains newlines
+		// and if parseCommand splits it into multiple commands
+		const hasActualNewlines = /\r\n|\r|\n/.test(command)
 		const allCommands = parseCommand(command)
+		const isMultilineCommand = hasActualNewlines && allCommands.length > 1
+
+		// For multiline commands, don't show pattern options as they would be confusing
+		// Users shouldn't auto-approve multiline commands as individual patterns
+		if (isMultilineCommand) {
+			return []
+		}
 
 		// Then extract patterns from each command using the existing pattern extraction logic
 		const allPatterns = new Set<string>()

--- a/webview-ui/src/components/chat/CommandPatternSelector.tsx
+++ b/webview-ui/src/components/chat/CommandPatternSelector.tsx
@@ -62,6 +62,11 @@ export const CommandPatternSelector: React.FC<CommandPatternSelectorProps> = ({
 		}))
 	}
 
+	// Don't render anything if there are no patterns (e.g., for multiline commands)
+	if (allPatterns.length === 0) {
+		return null
+	}
+
 	return (
 		<div className="border-t border-vscode-panel-border/50 bg-vscode-sideBar-background/30">
 			<button

--- a/webview-ui/src/components/chat/__tests__/CommandExecution.multiline.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/CommandExecution.multiline.spec.tsx
@@ -1,0 +1,200 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { CommandExecution } from "../CommandExecution"
+import { ExtensionStateContext } from "../../../context/ExtensionStateContext"
+
+// Mock dependencies - must be hoisted before imports
+vi.mock("react-use", () => ({
+	useEvent: vi.fn(),
+}))
+
+// Mock the vscode API
+vi.mock("../../../utils/vscode", () => ({
+	vscode: {
+		postMessage: vi.fn(),
+	},
+}))
+
+// Mock CodeBlock component
+vi.mock("../../kilocode/common/CodeBlock", () => {
+	return {
+		default: ({ source }: { source: string }) => {
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			const React = require("react")
+			return React.createElement("div", { "data-testid": "code-block" }, source)
+		},
+	}
+})
+
+// Mock CommandPatternSelector to check if it's rendered
+vi.mock("../CommandPatternSelector", () => {
+	return {
+		CommandPatternSelector: ({ patterns }: any) => {
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			const React = require("react")
+			if (!patterns || patterns.length === 0) return null
+			return React.createElement(
+				"div",
+				{ "data-testid": "command-pattern-selector" },
+				React.createElement("span", null, "chat:commandExecution.manageCommands"),
+				patterns.map((pattern: any, index: number) =>
+					React.createElement("span", { key: index }, pattern.pattern),
+				),
+			)
+		},
+	}
+})
+
+describe("CommandExecution - Multiline Commands", () => {
+	// Mock ExtensionStateContext
+	const mockExtensionState = {
+		terminalShellIntegrationDisabled: true,
+		allowedCommands: ["git", "npm"],
+		deniedCommands: ["rm"],
+		setAllowedCommands: vi.fn(),
+		setDeniedCommands: vi.fn(),
+	}
+
+	const ExtensionStateWrapper = ({ children }: { children: React.ReactNode }) => (
+		<ExtensionStateContext.Provider value={mockExtensionState as any}>{children}</ExtensionStateContext.Provider>
+	)
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("should not show pattern selector for multiline commands", () => {
+		// A multiline command with actual newlines (not in quotes)
+		const multilineCommand = `git add .
+git commit -m "feat: update"
+git push`
+
+		render(
+			<ExtensionStateWrapper>
+				<CommandExecution executionId="test-1" text={multilineCommand} />
+			</ExtensionStateWrapper>,
+		)
+
+		// The command should be displayed
+		expect(screen.getByText(/git add/)).toBeInTheDocument()
+
+		// But the pattern selector should not be shown
+		// (The "Manage Commands" button should not exist)
+		expect(screen.queryByTestId("command-pattern-selector")).not.toBeInTheDocument()
+	})
+
+	it("should show pattern selector for single-line commands", () => {
+		// A single-line command
+		const singleLineCommand = `git status`
+
+		render(
+			<ExtensionStateWrapper>
+				<CommandExecution executionId="test-2" text={singleLineCommand} />
+			</ExtensionStateWrapper>,
+		)
+
+		// The command should be displayed
+		expect(screen.getByTestId("code-block")).toHaveTextContent("git status")
+
+		// The pattern selector should be shown
+		expect(screen.getByTestId("command-pattern-selector")).toBeInTheDocument()
+		expect(screen.getByText("chat:commandExecution.manageCommands")).toBeInTheDocument()
+	})
+
+	it("should show pattern selector for commands with quoted newlines", () => {
+		// A command with newlines inside quotes (should be treated as single-line)
+		const quotedNewlineCommand = `git commit -m "feat: update\n\n- Added feature A\n- Fixed bug B"`
+
+		render(
+			<ExtensionStateWrapper>
+				<CommandExecution executionId="test-3" text={quotedNewlineCommand} />
+			</ExtensionStateWrapper>,
+		)
+
+		// The command should be displayed
+		expect(screen.getByTestId("code-block")).toHaveTextContent("git commit")
+
+		// The pattern selector should be shown (because newlines are within quotes)
+		expect(screen.getByTestId("command-pattern-selector")).toBeInTheDocument()
+		expect(screen.getByText("chat:commandExecution.manageCommands")).toBeInTheDocument()
+	})
+
+	it("should not show pattern selector for commands chained with && on multiple lines", () => {
+		// Commands chained with && across multiple lines
+		const chainedMultilineCommand = `npm install &&
+npm run build &&
+npm test`
+
+		render(
+			<ExtensionStateWrapper>
+				<CommandExecution executionId="test-4" text={chainedMultilineCommand} />
+			</ExtensionStateWrapper>,
+		)
+
+		// The command should be displayed
+		expect(screen.getByText(/npm install/)).toBeInTheDocument()
+
+		// The pattern selector should not be shown for multiline commands
+		expect(screen.queryByTestId("command-pattern-selector")).not.toBeInTheDocument()
+	})
+
+	it("should show pattern selector for commands chained with && on single line", () => {
+		// Commands chained with && on a single line
+		const chainedSingleLineCommand = `npm install && npm run build && npm test`
+
+		render(
+			<ExtensionStateWrapper>
+				<CommandExecution executionId="test-5" text={chainedSingleLineCommand} />
+			</ExtensionStateWrapper>,
+		)
+
+		// The command should be displayed
+		expect(screen.getByTestId("code-block")).toHaveTextContent("npm install && npm run build && npm test")
+
+		// The pattern selector should be shown for single-line chained commands
+		expect(screen.getByTestId("command-pattern-selector")).toBeInTheDocument()
+		expect(screen.getByText("chat:commandExecution.manageCommands")).toBeInTheDocument()
+	})
+
+	it("should not show pattern selector for shell scripts with multiple lines", () => {
+		// A shell script with multiple lines
+		const shellScript = `for file in *.txt; do
+	 echo "Processing $file"
+	 cat "$file"
+done`
+
+		render(
+			<ExtensionStateWrapper>
+				<CommandExecution executionId="test-6" text={shellScript} />
+			</ExtensionStateWrapper>,
+		)
+
+		// The command should be displayed
+		expect(screen.getByText(/for file in/)).toBeInTheDocument()
+
+		// The pattern selector should not be shown
+		expect(screen.queryByTestId("command-pattern-selector")).not.toBeInTheDocument()
+	})
+
+	it("should not show pattern selector for heredoc commands", () => {
+		// A heredoc command
+		const heredocCommand = `cat << EOF > config.txt
+line1
+line2
+line3
+EOF`
+
+		render(
+			<ExtensionStateWrapper>
+				<CommandExecution executionId="test-7" text={heredocCommand} />
+			</ExtensionStateWrapper>,
+		)
+
+		// The command should be displayed
+		expect(screen.getByText(/cat << EOF/)).toBeInTheDocument()
+
+		// The pattern selector should not be shown
+		expect(screen.queryByTestId("command-pattern-selector")).not.toBeInTheDocument()
+	})
+})


### PR DESCRIPTION
## Summary

This PR prevents multiline commands from showing auto-approve options in the UI, ensuring users don't accidentally auto-approve complex multiline scripts.

## Changes

- **CommandExecution.tsx**: Added detection for true multiline commands (commands with actual newlines, not within quotes) and returns an empty pattern list for such commands
- **CommandPatternSelector.tsx**: Updated to gracefully handle empty pattern lists by not rendering anything when there are no patterns
- **Test Coverage**: Added comprehensive tests in `CommandExecution.multiline.spec.tsx` with 7 test cases

## How It Works

The solution intelligently distinguishes between:
- **True multiline commands** (multiple lines with actual newlines) → NO auto-approve options shown
- **Single-line commands with quoted newlines** (like `git commit -m "line1\nline2"`) → auto-approve options ARE shown  
- **Single-line chained commands** (like `cmd1 && cmd2`) → auto-approve options ARE shown

## Examples

### Commands that SHOULD show auto-approve options:
- `git status`
- `git commit -m "feat: update\n\n- Added feature A"`
- `npm install && npm run build && npm test`

### Commands that should NOT show auto-approve options:
```bash
git add .
git commit -m "feat: update"
git push
```

```bash
npm install &&
npm run build &&
npm test
```

## Testing

All tests are passing:
- New multiline command tests: 7/7 ✅
- Existing CommandExecution tests: 29/29 ✅
- Command validation tests: 17/17 ✅

Run tests with:
```bash
cd webview-ui && npx vitest run src/components/chat/__tests__/CommandExecution.multiline.spec.tsx
```