### PR TITLE
Add grok-4-1-fast-reasoning and grok-4-1-fast-reasoning models; fixes #3921

### DIFF
--- a/.changeset/tender-sides-sink.md
+++ b/.changeset/tender-sides-sink.md
@@ -1,5 +1,5 @@
 ---
-"@roo-code/types": patch
+"kilo-code": patch
 ---
 
 Add grok-4-1-fast-reasoning and grok-4-1-fast-reasoning models

--- a/.changeset/tender-sides-sink.md
+++ b/.changeset/tender-sides-sink.md
@@ -1,0 +1,5 @@
+---
+"@roo-code/types": patch
+---
+
+Add grok-4-1-fast-reasoning and grok-4-1-fast-reasoning models

--- a/packages/types/src/providers/xai.ts
+++ b/packages/types/src/providers/xai.ts
@@ -17,6 +17,54 @@ export const xaiModels = {
 		cacheReadsPrice: 0.02,
 		description: "xAI's Grok Code Fast model with 256K context window",
 	},
+	"grok-4-1-fast-reasoning": {
+		maxTokens: 30_000,
+		contextWindow: 2_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.4, // This is the pricing for prompts above 128K context
+		outputPrice: 1.0,
+		cacheReadsPrice: 0.05,
+		description: "xAI's Grok-4-1-Fast model with reasonning and a 2M context window",
+		tiers: [
+			{
+				contextWindow: 128_000,
+				inputPrice: 0.2,
+				outputPrice: 0.5,
+				cacheReadsPrice: 0.05,
+			},
+			{
+				contextWindow: Infinity,
+				inputPrice: 0.4,
+				outputPrice: 1,
+				cacheReadsPrice: 0.05,
+			},
+		],
+	},
+	"grok-4-1-fast-non-reasoning": {
+		maxTokens: 30_000,
+		contextWindow: 2_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.4, // This is the pricing for prompts above 128K context
+		outputPrice: 1.0,
+		cacheReadsPrice: 0.05,
+		description: "xAI's Grok-4-1-Fast model without reasonning and with a 2M context window",
+		tiers: [
+			{
+				contextWindow: 128_000,
+				inputPrice: 0.2,
+				outputPrice: 0.5,
+				cacheReadsPrice: 0.05,
+			},
+			{
+				contextWindow: Infinity,
+				inputPrice: 0.4,
+				outputPrice: 1,
+				cacheReadsPrice: 0.05,
+			},
+		],
+	},
 	"grok-4": {
 		maxTokens: 8192,
 		contextWindow: 256000,

--- a/packages/types/src/providers/xai.ts
+++ b/packages/types/src/providers/xai.ts
@@ -17,6 +17,7 @@ export const xaiModels = {
 		cacheReadsPrice: 0.02,
 		description: "xAI's Grok Code Fast model with 256K context window",
 	},
+    // kilocode_change start
 	"grok-4-1-fast-reasoning": {
 		maxTokens: 30_000,
 		contextWindow: 2_000_000,
@@ -65,6 +66,7 @@ export const xaiModels = {
 			},
 		],
 	},
+	// kilocode_change end
 	"grok-4": {
 		maxTokens: 8192,
 		contextWindow: 256000,


### PR DESCRIPTION
## Context

x.ai launched grok-4-1-fast-reasoning and grok-4-1-fast-non-reasoning. I added them to the list for the xAI endpoint.
Fixes #3921 


## Implementation

Updated packages/types/src/providers/xai.ts



## Screenshots

Before:
<img width="398" height="363" alt="image" src="https://github.com/user-attachments/assets/5f42689a-2986-4504-a53f-53ac40a22c92" />


After:
<img width="410" height="385" alt="image" src="https://github.com/user-attachments/assets/aa8e6c9c-8890-42ac-b340-c75f1e9dc89d" />


## How to Test

- Set up a configuration profile with an x.ai API key
- Look for Grok 4 1 Fast Reasoning and Grok 4 1 Fast Non Reasoning in the dropdown


