### PR TITLE
CLI: Continue / Abort command execution

### DIFF
--- a/.changeset/brown-pans-kneel.md
+++ b/.changeset/brown-pans-kneel.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Continue and abort commands

--- a/cli/src/services/approvalDecision.ts
+++ b/cli/src/services/approvalDecision.ts
@@ -334,6 +334,11 @@ export function getApprovalDecision(
 		case "command":
 			return getCommandApprovalDecision(message, config, isCIMode)
 
+		case "command_output":
+			// Command output always requires manual approval
+			// User must choose to continue (proceed with conversation) or abort (kill command)
+			return { action: "manual" }
+
 		case "followup":
 			return getFollowupApprovalDecision(message, config, isCIMode)
 

--- a/cli/src/state/atoms/__tests__/effects-command-output-duplicate.test.ts
+++ b/cli/src/state/atoms/__tests__/effects-command-output-duplicate.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for command_output ask deduplication
+ * Verifies that duplicate asks from the backend are properly filtered
+ * when the CLI has already created a synthetic ask
+ */
+
+import { describe, it, expect, beforeEach } from "vitest"
+import { createStore } from "jotai"
+import { messageHandlerEffectAtom, commandOutputAskShownAtom } from "../effects.js"
+import { chatMessagesAtom } from "../extension.js"
+import { extensionServiceAtom } from "../service.js"
+import type { ExtensionService } from "../../../services/extension.js"
+import type { ExtensionMessage, ExtensionChatMessage, ExtensionState } from "../../../types/messages.js"
+
+describe("Command Output Ask Deduplication", () => {
+	let store: ReturnType<typeof createStore>
+
+	beforeEach(() => {
+		store = createStore()
+
+		// Mock the extension service
+		const mockService: Partial<ExtensionService> = {
+			initialize: async () => {},
+			on: () => mockService as ExtensionService,
+			getState: () => null,
+		}
+		store.set(extensionServiceAtom, mockService as ExtensionService)
+	})
+
+	it("should filter duplicate command_output ask from state when synthetic ask exists", () => {
+		const executionId = "test-exec-123"
+
+		// Step 1: Simulate commandExecutionStatus "started" which creates synthetic ask
+		const startedMessage: ExtensionMessage = {
+			type: "commandExecutionStatus",
+			text: JSON.stringify({
+				executionId,
+				status: "started",
+				command: "sleep 30",
+			}),
+		}
+		store.set(messageHandlerEffectAtom, startedMessage)
+
+		// Verify synthetic ask was created
+		const messagesAfterStart = store.get(chatMessagesAtom)
+		expect(messagesAfterStart).toHaveLength(1)
+		expect(messagesAfterStart[0]?.ask).toBe("command_output")
+
+		// Step 2: Simulate backend sending its own command_output ask via state
+		const backendAsk: ExtensionChatMessage = {
+			ts: Date.now() + 100,
+			type: "ask",
+			ask: "command_output",
+			text: JSON.stringify({
+				executionId,
+				command: "sleep 30",
+				output: "",
+			}),
+			partial: true,
+			isAnswered: false,
+		}
+
+		const stateMessage: ExtensionMessage = {
+			type: "state",
+			state: {
+				chatMessages: [messagesAfterStart[0]!, backendAsk],
+			} as unknown as ExtensionState,
+		}
+		store.set(messageHandlerEffectAtom, stateMessage)
+
+		// Verify duplicate was filtered - should still have only 1 message
+		const messagesAfterState = store.get(chatMessagesAtom)
+		expect(messagesAfterState).toHaveLength(1)
+		expect(messagesAfterState[0]?.ts).toBe(messagesAfterStart[0]?.ts)
+	})
+
+	it("should filter duplicate command_output ask from messageUpdated when synthetic ask exists", () => {
+		const executionId = "test-exec-456"
+
+		// Step 1: Create synthetic ask
+		const startedMessage: ExtensionMessage = {
+			type: "commandExecutionStatus",
+			text: JSON.stringify({
+				executionId,
+				status: "started",
+				command: "sleep 30",
+			}),
+		}
+		store.set(messageHandlerEffectAtom, startedMessage)
+
+		const messagesAfterStart = store.get(chatMessagesAtom)
+		expect(messagesAfterStart).toHaveLength(1)
+
+		// Step 2: Simulate backend sending its own ask via messageUpdated
+		const backendAsk: ExtensionChatMessage = {
+			ts: Date.now() + 100,
+			type: "ask",
+			ask: "command_output",
+			text: JSON.stringify({
+				executionId,
+				command: "sleep 30",
+				output: "",
+			}),
+			partial: true,
+			isAnswered: false,
+		}
+
+		const messageUpdatedMessage: ExtensionMessage = {
+			type: "messageUpdated",
+			chatMessage: backendAsk,
+		}
+		store.set(messageHandlerEffectAtom, messageUpdatedMessage)
+
+		// Verify duplicate was ignored - should still have only 1 message
+		const messagesAfterUpdate = store.get(chatMessagesAtom)
+		expect(messagesAfterUpdate).toHaveLength(1)
+		expect(messagesAfterUpdate[0]?.ts).toBe(messagesAfterStart[0]?.ts)
+	})
+
+	it("should allow backend ask when no synthetic ask exists", () => {
+		const executionId = "test-exec-789"
+
+		// This test verifies that our filtering logic doesn't break normal scenarios
+		// where the backend creates a command_output ask without a prior synthetic one
+
+		// In this case, we DON'T create a synthetic ask first
+		// Instead, we simulate the backend creating its own ask
+		// This would happen if the command produces output immediately (before our synthetic ask is created)
+
+		// Since we can't easily test the full state update flow in a unit test,
+		// we'll just verify that the tracking map doesn't have this executionId
+		// which means our filter won't block it
+
+		const askShownMap = store.get(commandOutputAskShownAtom)
+		expect(askShownMap.has(executionId)).toBe(false)
+
+		// This means when a backend ask with this executionId comes through,
+		// it won't be filtered out by our duplicate detection logic
+	})
+
+	it("should update synthetic ask with output when command produces output", () => {
+		const executionId = "test-exec-output"
+
+		// Step 1: Create synthetic ask
+		const startedMessage: ExtensionMessage = {
+			type: "commandExecutionStatus",
+			text: JSON.stringify({
+				executionId,
+				status: "started",
+				command: "echo test",
+			}),
+		}
+		store.set(messageHandlerEffectAtom, startedMessage)
+
+		// Step 2: Send output
+		const outputMessage: ExtensionMessage = {
+			type: "commandExecutionStatus",
+			text: JSON.stringify({
+				executionId,
+				status: "output",
+				output: "test\n",
+			}),
+		}
+		store.set(messageHandlerEffectAtom, outputMessage)
+
+		// Verify synthetic ask was updated with output
+		const messages = store.get(chatMessagesAtom)
+		expect(messages).toHaveLength(1)
+
+		const askData = JSON.parse(messages[0]?.text || "{}")
+		expect(askData.output).toBe("test\n")
+		expect(askData.command).toBe("echo test")
+	})
+
+	it("should mark synthetic ask as complete when command exits", () => {
+		const executionId = "test-exec-complete"
+
+		// Step 1: Create synthetic ask
+		store.set(messageHandlerEffectAtom, {
+			type: "commandExecutionStatus",
+			text: JSON.stringify({
+				executionId,
+				status: "started",
+				command: "sleep 1",
+			}),
+		})
+
+		// Step 2: Command exits
+		store.set(messageHandlerEffectAtom, {
+			type: "commandExecutionStatus",
+			text: JSON.stringify({
+				executionId,
+				status: "exited",
+				exitCode: 0,
+			}),
+		})
+
+		// Verify synthetic ask is marked as complete
+		const messages = store.get(chatMessagesAtom)
+		expect(messages).toHaveLength(1)
+		expect(messages[0]?.partial).toBe(false)
+	})
+})

--- a/cli/src/state/atoms/__tests__/effects-command-output.test.ts
+++ b/cli/src/state/atoms/__tests__/effects-command-output.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for command execution status handling in effects.ts
+ * Specifically tests the CLI-only workaround for commands that produce no output (like `sleep 10`)
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { createStore } from "jotai"
+import { messageHandlerEffectAtom, pendingOutputUpdatesAtom } from "../effects.js"
+import { extensionServiceAtom } from "../service.js"
+import { chatMessagesAtom } from "../extension.js"
+import type { ExtensionMessage } from "../../../types/messages.js"
+import type { CommandExecutionStatus } from "@roo-code/types"
+import type { ExtensionService } from "../../../services/extension.js"
+
+describe("Command Execution Status - CLI-Only Workaround", () => {
+	let store: ReturnType<typeof createStore>
+
+	beforeEach(() => {
+		store = createStore()
+
+		// Mock the extension service to prevent buffering
+		const mockService: Partial<ExtensionService> = {
+			initialize: vi.fn(),
+			dispose: vi.fn(),
+			on: vi.fn(),
+			off: vi.fn(),
+		}
+		store.set(extensionServiceAtom, mockService as ExtensionService)
+	})
+
+	it("should synthesize command_output ask immediately on start and update on exit", () => {
+		const executionId = "test-exec-123"
+		const command = "sleep 10"
+
+		// Simulate command started
+		const startedStatus: CommandExecutionStatus = {
+			status: "started",
+			executionId,
+			command,
+		}
+
+		const startedMessage: ExtensionMessage = {
+			type: "commandExecutionStatus",
+			text: JSON.stringify(startedStatus),
+		}
+
+		store.set(messageHandlerEffectAtom, startedMessage)
+
+		// Verify pending updates were created with command info
+		let pendingUpdates = store.get(pendingOutputUpdatesAtom)
+		expect(pendingUpdates.has(executionId)).toBe(true)
+		expect(pendingUpdates.get(executionId)).toEqual({
+			output: "",
+			command: "sleep 10",
+		})
+
+		// Verify synthetic command_output ask was created IMMEDIATELY
+		let messages = store.get(chatMessagesAtom)
+		expect(messages.length).toBe(1)
+		expect(messages[0]).toMatchObject({
+			type: "ask",
+			ask: "command_output",
+			partial: true, // Still running
+			isAnswered: false,
+		})
+
+		// Verify the synthetic ask has the correct initial data
+		const askData = JSON.parse(messages[0]!.text || "{}")
+		expect(askData).toEqual({
+			executionId: "test-exec-123",
+			command: "sleep 10",
+			output: "",
+		})
+
+		// Simulate command exited without any output
+		const exitedStatus: CommandExecutionStatus = {
+			status: "exited",
+			executionId,
+			exitCode: 0,
+		}
+
+		const exitedMessage: ExtensionMessage = {
+			type: "commandExecutionStatus",
+			text: JSON.stringify(exitedStatus),
+		}
+
+		store.set(messageHandlerEffectAtom, exitedMessage)
+
+		// Verify command info is preserved and marked as completed
+		pendingUpdates = store.get(pendingOutputUpdatesAtom)
+		expect(pendingUpdates.has(executionId)).toBe(true)
+		expect(pendingUpdates.get(executionId)).toEqual({
+			output: "",
+			command: "sleep 10",
+			completed: true,
+		})
+
+		// Verify the ask was updated to mark as complete (not partial)
+		messages = store.get(chatMessagesAtom)
+		expect(messages.length).toBe(1) // Still just one message
+		expect(messages[0]).toMatchObject({
+			type: "ask",
+			ask: "command_output",
+			partial: false, // Now complete
+			isAnswered: false,
+		})
+	})
+
+	it("should handle commands with output (started -> output -> exited)", () => {
+		const executionId = "test-exec-456"
+		const command = "echo hello"
+
+		// Simulate command started
+		const startedStatus: CommandExecutionStatus = {
+			status: "started",
+			executionId,
+			command,
+		}
+
+		const startedMessage: ExtensionMessage = {
+			type: "commandExecutionStatus",
+			text: JSON.stringify(startedStatus),
+		}
+
+		store.set(messageHandlerEffectAtom, startedMessage)
+
+		// Verify initial state
+		let pendingUpdates = store.get(pendingOutputUpdatesAtom)
+		expect(pendingUpdates.get(executionId)).toEqual({
+			output: "",
+			command: "echo hello",
+		})
+
+		// Verify synthetic ask was created on start
+		let messages = store.get(chatMessagesAtom)
+		expect(messages.length).toBe(1)
+		expect(messages[0]?.partial).toBe(true)
+
+		// Simulate output received
+		const outputStatus: CommandExecutionStatus = {
+			status: "output",
+			executionId,
+			output: "hello\n",
+		}
+
+		const outputMessage: ExtensionMessage = {
+			type: "commandExecutionStatus",
+			text: JSON.stringify(outputStatus),
+		}
+
+		store.set(messageHandlerEffectAtom, outputMessage)
+
+		// Verify output was updated
+		pendingUpdates = store.get(pendingOutputUpdatesAtom)
+		expect(pendingUpdates.get(executionId)).toEqual({
+			output: "hello\n",
+			command: "echo hello",
+		})
+
+		// Verify the synthetic ask was updated with output
+		messages = store.get(chatMessagesAtom)
+		expect(messages.length).toBe(1)
+		const askData = JSON.parse(messages[0]!.text || "{}")
+		expect(askData.output).toBe("hello\n")
+		expect(messages[0]?.partial).toBe(true) // Still running
+
+		// Simulate command exited
+		const exitedStatus: CommandExecutionStatus = {
+			status: "exited",
+			executionId,
+			exitCode: 0,
+		}
+
+		const exitedMessage: ExtensionMessage = {
+			type: "commandExecutionStatus",
+			text: JSON.stringify(exitedStatus),
+		}
+
+		store.set(messageHandlerEffectAtom, exitedMessage)
+
+		// Verify final state
+		pendingUpdates = store.get(pendingOutputUpdatesAtom)
+		expect(pendingUpdates.get(executionId)).toEqual({
+			output: "hello\n",
+			command: "echo hello",
+			completed: true,
+		})
+
+		// Verify the ask was marked as complete
+		messages = store.get(chatMessagesAtom)
+		expect(messages.length).toBe(1)
+		expect(messages[0]?.partial).toBe(false) // Now complete
+	})
+
+	it("should handle timeout status", () => {
+		const executionId = "test-exec-789"
+		const command = "sleep 1000"
+
+		// Simulate command started
+		const startedStatus: CommandExecutionStatus = {
+			status: "started",
+			executionId,
+			command,
+		}
+
+		store.set(messageHandlerEffectAtom, {
+			type: "commandExecutionStatus",
+			text: JSON.stringify(startedStatus),
+		})
+
+		// Simulate timeout
+		const timeoutStatus: CommandExecutionStatus = {
+			status: "timeout",
+			executionId,
+		}
+
+		store.set(messageHandlerEffectAtom, {
+			type: "commandExecutionStatus",
+			text: JSON.stringify(timeoutStatus),
+		})
+
+		// Verify command info is preserved and marked as completed
+		const pendingUpdates = store.get(pendingOutputUpdatesAtom)
+		expect(pendingUpdates.get(executionId)).toEqual({
+			output: "",
+			command: "sleep 1000",
+			completed: true,
+		})
+	})
+
+	it("should handle empty command in started status", () => {
+		const executionId = "test-exec-no-cmd"
+
+		// Simulate command started with empty command field
+		const startedStatus: CommandExecutionStatus = {
+			status: "started",
+			executionId,
+			command: "",
+		}
+
+		store.set(messageHandlerEffectAtom, {
+			type: "commandExecutionStatus",
+			text: JSON.stringify(startedStatus),
+		})
+
+		// Verify it still creates an entry with empty command
+		const pendingUpdates = store.get(pendingOutputUpdatesAtom)
+		expect(pendingUpdates.get(executionId)).toEqual({
+			output: "",
+			command: "",
+		})
+	})
+})

--- a/cli/src/state/atoms/extension.ts
+++ b/cli/src/state/atoms/extension.ts
@@ -12,6 +12,7 @@ import type {
 	ProviderSettings,
 	McpServer,
 } from "../../types/messages.js"
+import { pendingOutputUpdatesAtom } from "./effects.js"
 
 /**
  * Atom to hold the complete ExtensionState
@@ -201,6 +202,7 @@ export const updateExtensionStateAtom = atom(null, (get, set, state: ExtensionSt
 	const currentMessages = get(chatMessagesAtom)
 	const versionMap = get(messageVersionMapAtom)
 	const streamingSet = get(streamingMessagesSetAtom)
+	const pendingUpdates = get(pendingOutputUpdatesAtom)
 
 	set(extensionStateAtom, state)
 
@@ -209,7 +211,14 @@ export const updateExtensionStateAtom = atom(null, (get, set, state: ExtensionSt
 		const incomingMessages = state.clineMessages || state.chatMessages || []
 
 		// Reconcile with current messages to preserve streaming state
-		let reconciledMessages = reconcileMessages(currentMessages, incomingMessages, versionMap, streamingSet)
+		// Pass pending updates to apply them to new command_output asks
+		let reconciledMessages = reconcileMessages(
+			currentMessages,
+			incomingMessages,
+			versionMap,
+			streamingSet,
+			pendingUpdates,
+		)
 
 		// Auto-complete orphaned partial ask messages (CLI-only workaround for extension bug)
 		reconciledMessages = autoCompleteOrphanedPartialAsks(reconciledMessages)
@@ -528,12 +537,14 @@ function autoCompleteOrphanedPartialAsks(messages: ExtensionChatMessage[]): Exte
  * - State is the source of truth for WHICH messages exist (count/list)
  * - Real-time updates are the source of truth for CONTENT of partial messages
  * - Only preserve content of actively streaming messages if they have more data
+ * - Merge duplicate command_output asks with the same executionId
  */
 function reconcileMessages(
 	current: ExtensionChatMessage[],
 	incoming: ExtensionChatMessage[],
 	versionMap: Map<number, number>,
 	streamingSet: Set<number>,
+	pendingUpdates?: Map<string, { output: string; command?: string; completed?: boolean }>,
 ): ExtensionChatMessage[] {
 	// Create lookup map for current messages
 	const currentMap = new Map<number, ExtensionChatMessage>()
@@ -541,8 +552,12 @@ function reconcileMessages(
 		currentMap.set(msg.ts, msg)
 	})
 
+	// First, deduplicate command_output asks
+	// Since extension creates asks with empty text, we keep only the first unanswered one
+	const deduplicatedIncoming = deduplicateCommandOutputAsks(incoming, pendingUpdates)
+
 	// Process ALL incoming messages - state determines which messages exist
-	const resultMessages: ExtensionChatMessage[] = incoming.map((incomingMsg) => {
+	const resultMessages: ExtensionChatMessage[] = deduplicatedIncoming.map((incomingMsg) => {
 		const existingMsg = currentMap.get(incomingMsg.ts)
 
 		// PRIORITY 1: Prevent completed messages from being overwritten by stale partial updates
@@ -588,4 +603,85 @@ function reconcileMessages(
 
 	// Return sorted array by timestamp
 	return resultMessages.sort((a, b) => a.ts - b.ts)
+}
+
+/**
+ * Deduplicate command_output asks
+ * Since the extension creates asks with empty text (no executionId), we can't match by executionId
+ * Instead, keep only the MOST RECENT unanswered command_output ask and discard older ones
+ * This allows multiple sequential commands to work correctly
+ * The component will read from pendingOutputUpdatesAtom for real-time output
+ */
+function deduplicateCommandOutputAsks(
+	messages: ExtensionChatMessage[],
+	pendingUpdates?: Map<string, { output: string; command?: string; completed?: boolean }>,
+): ExtensionChatMessage[] {
+	const result: ExtensionChatMessage[] = []
+	let mostRecentUnansweredAsk: ExtensionChatMessage | null = null
+	let mostRecentUnansweredAskIndex = -1
+
+	// First pass: find the most recent unanswered command_output ask
+	for (let i = 0; i < messages.length; i++) {
+		const msg = messages[i]
+		if (msg && msg.type === "ask" && msg.ask === "command_output" && !msg.isAnswered) {
+			if (!mostRecentUnansweredAsk || msg.ts > mostRecentUnansweredAsk.ts) {
+				mostRecentUnansweredAsk = msg
+				mostRecentUnansweredAskIndex = i
+			}
+		}
+	}
+
+	// Second pass: build result, keeping only the most recent unanswered ask
+	for (let i = 0; i < messages.length; i++) {
+		const msg = messages[i]
+
+		if (msg && msg.type === "ask" && msg.ask === "command_output" && !msg.isAnswered) {
+			if (i === mostRecentUnansweredAskIndex) {
+				// This is the most recent unanswered ask - keep it with pending updates
+				let processedMsg = msg
+
+				// If we have pending updates, find the one that's NOT completed (the active command)
+				if (pendingUpdates && pendingUpdates.size > 0) {
+					// Find the active (non-completed) pending update
+					let activeExecutionId: string | null = null
+					let activeUpdate: { output: string; command?: string; completed?: boolean } | null = null
+
+					for (const [execId, update] of pendingUpdates.entries()) {
+						if (!update.completed) {
+							activeExecutionId = execId
+							activeUpdate = update
+							break
+						}
+					}
+
+					// If no active update found, use the most recent one (fallback)
+					if (!activeExecutionId && pendingUpdates.size > 0) {
+						const entries = Array.from(pendingUpdates.entries())
+						;[activeExecutionId, activeUpdate] = entries[entries.length - 1]!
+					}
+
+					if (activeExecutionId && activeUpdate) {
+						processedMsg = {
+							...msg,
+							text: JSON.stringify({
+								executionId: activeExecutionId,
+								command: activeUpdate.command || "",
+								output: activeUpdate.output || "",
+							}),
+							partial: !activeUpdate.completed,
+							isAnswered: activeUpdate.completed || false,
+						}
+					}
+				}
+
+				result.push(processedMsg)
+			}
+			// Discard older unanswered command_output asks (no logging needed)
+		} else if (msg) {
+			// Not an unanswered command_output ask, keep as-is
+			result.push(msg)
+		}
+	}
+
+	return result
 }

--- a/cli/src/state/atoms/ui.ts
+++ b/cli/src/state/atoms/ui.ts
@@ -290,6 +290,7 @@ export const lastAskMessageAtom = atom<ExtensionChatMessage | null>((get) => {
 	const approvalAskTypes = [
 		"tool",
 		"command",
+		"command_output",
 		"browser_action_launch",
 		"use_mcp_server",
 		"payment_required_prompt",
@@ -302,10 +303,13 @@ export const lastAskMessageAtom = atom<ExtensionChatMessage | null>((get) => {
 		lastMessage.type === "ask" &&
 		!lastMessage.isAnswered &&
 		lastMessage.ask &&
-		approvalAskTypes.includes(lastMessage.ask) &&
-		!lastMessage.partial
+		approvalAskTypes.includes(lastMessage.ask)
 	) {
-		return lastMessage
+		// command_output asks can be partial (while command is running)
+		// All other asks must be complete (not partial) to show approval
+		if (lastMessage.ask === "command_output" || !lastMessage.partial) {
+			return lastMessage
+		}
 	}
 	return null
 })

--- a/cli/src/state/atoms/ui.ts
+++ b/cli/src/state/atoms/ui.ts
@@ -298,6 +298,7 @@ export const lastAskMessageAtom = atom<ExtensionChatMessage | null>((get) => {
 	]
 
 	const lastMessage = messages[messages.length - 1]
+
 	if (
 		lastMessage &&
 		lastMessage.type === "ask" &&

--- a/cli/src/state/hooks/useApprovalHandler.ts
+++ b/cli/src/state/hooks/useApprovalHandler.ts
@@ -15,6 +15,7 @@ import {
 	approveCallbackAtom,
 	rejectCallbackAtom,
 	executeSelectedCallbackAtom,
+	sendTerminalOperationCallbackAtom,
 	type ApprovalOption,
 } from "../atoms/approval.js"
 import { addAllowedCommandAtom, autoApproveExecuteAllowedAtom } from "../atoms/config.js"
@@ -25,6 +26,10 @@ import { logs } from "../../services/logs.js"
 import { useApprovalTelemetry } from "./useApprovalTelemetry.js"
 
 const APPROVAL_MENU_DELAY_MS = 500
+
+// command_output asks should show immediately without delay
+// since they represent running commands that users need to be able to abort
+const COMMAND_OUTPUT_DELAY_MS = 0
 
 /**
  * Options for useApprovalHandler hook
@@ -58,6 +63,8 @@ export interface UseApprovalHandlerReturn {
 	reject: (text?: string, images?: string[]) => Promise<void>
 	/** Execute the currently selected option */
 	executeSelected: (text?: string, images?: string[]) => Promise<void>
+	/** Send terminal operation (continue or abort) */
+	sendTerminalOperation: (operation: "continue" | "abort") => Promise<void>
 }
 
 /**
@@ -106,6 +113,7 @@ export function useApprovalHandler(): UseApprovalHandlerReturn {
 	const setApproveCallback = useSetAtom(approveCallbackAtom)
 	const setRejectCallback = useSetAtom(rejectCallbackAtom)
 	const setExecuteSelectedCallback = useSetAtom(executeSelectedCallbackAtom)
+	const setSendTerminalOperationCallback = useSetAtom(sendTerminalOperationCallbackAtom)
 
 	const { sendAskResponse, sendMessage } = useWebviewMessage()
 	const approvalTelemetry = useApprovalTelemetry()
@@ -284,10 +292,120 @@ export function useApprovalHandler(): UseApprovalHandlerReturn {
 		[store, sendAskResponse, approvalTelemetry],
 	)
 
+	const sendTerminalOperation = useCallback(
+		async (operation: "continue" | "abort") => {
+			// Read the current state directly from the store at call time
+			const currentPendingApproval = store.get(pendingApprovalAtom)
+			const processingState = store.get(approvalProcessingAtom)
+
+			if (!currentPendingApproval) {
+				logs.warn("No pending approval for terminal operation", "useApprovalHandler", {
+					operation,
+				})
+				return
+			}
+
+			// Verify this is a command_output ask
+			if (currentPendingApproval.ask !== "command_output") {
+				logs.warn("Terminal operation called for non-command_output ask", "useApprovalHandler", {
+					ask: currentPendingApproval.ask,
+					operation,
+				})
+				return
+			}
+
+			// Check if already processing
+			if (processingState.isProcessing) {
+				logs.warn("Approval already being processed, skipping duplicate", "useApprovalHandler", {
+					processingTs: processingState.processingTs,
+					currentTs: currentPendingApproval.ts,
+				})
+				return
+			}
+
+			// Start processing atomically
+			const started = store.set(startApprovalProcessingAtom, operation === "continue" ? "approve" : "reject")
+			if (!started) {
+				logs.warn("Failed to start terminal operation processing", "useApprovalHandler")
+				return
+			}
+
+			try {
+				logs.debug(`Sending terminal operation: ${operation}`, "useApprovalHandler", {
+					ts: currentPendingApproval.ts,
+				})
+
+				// Mark message as answered locally BEFORE sending operation
+				const answeredMessage: ExtensionChatMessage = {
+					...currentPendingApproval,
+					isAnswered: true,
+				}
+				store.set(updateChatMessageByTsAtom, answeredMessage)
+
+				// For continue operation, we need to send BOTH:
+				// 1. The terminal operation message (to call handleTerminalOperation)
+				// 2. An ask response with "messageResponse" (to unblock the task.ask() call)
+				if (operation === "continue") {
+					// Send terminal operation first
+					await sendMessage({
+						type: "terminalOperation",
+						terminalOperation: "continue",
+					})
+
+					// Then send ask response to unblock the waiting ask() call
+					await sendAskResponse({
+						response: "messageResponse",
+					})
+				} else {
+					// For abort, just send the terminal operation
+					// The task will handle the abortion and won't wait for a response
+					await sendMessage({
+						type: "terminalOperation",
+						terminalOperation: "abort",
+					})
+				}
+
+				logs.debug("Terminal operation sent successfully", "useApprovalHandler", {
+					operation,
+					ts: currentPendingApproval.ts,
+				})
+
+				// Track the operation as manual approval/rejection
+				if (operation === "continue") {
+					approvalTelemetry.trackManualApproval(currentPendingApproval)
+				} else {
+					approvalTelemetry.trackManualRejection(currentPendingApproval)
+				}
+
+				// Complete processing atomically
+				store.set(completeApprovalProcessingAtom)
+			} catch (error) {
+				logs.error("Failed to send terminal operation", "useApprovalHandler", { error, operation })
+				// Reset processing state on error so user can retry
+				store.set(completeApprovalProcessingAtom)
+				throw error
+			}
+		},
+		[store, sendMessage, sendAskResponse, approvalTelemetry],
+	)
+
 	const executeSelected = useCallback(
 		async (text?: string, images?: string[]) => {
+			// Read the current state to check if this is a command_output
+			const currentPendingApproval = store.get(pendingApprovalAtom)
+
 			if (!selectedOption) {
 				logs.warn("No option selected", "useApprovalHandler")
+				return
+			}
+
+			// Special handling for command_output - use terminal operations instead
+			if (currentPendingApproval?.ask === "command_output") {
+				if (selectedOption.action === "approve") {
+					await sendTerminalOperation("continue")
+				} else {
+					await sendTerminalOperation("abort")
+				}
 				return
 			}
 
@@ -318,7 +436,7 @@ export function useApprovalHandler(): UseApprovalHandlerReturn {
 				await reject(text, images)
 			}
 		},
-		[selectedOption, approve, reject, store],
+		[selectedOption, approve, reject, sendTerminalOperation, store],
 	)
 
 	// Set callbacks for keyboard handler to use
@@ -326,7 +444,17 @@ export function useApprovalHandler(): UseApprovalHandlerReturn {
 		setApproveCallback(() => approve)
 		setRejectCallback(() => reject)
 		setExecuteSelectedCallback(() => executeSelected)
-	}, [approve, reject, executeSelected, setApproveCallback, setRejectCallback, setExecuteSelectedCallback])
+		setSendTerminalOperationCallback(() => sendTerminalOperation)
+	}, [
+		approve,
+		reject,
+		executeSelected,
+		sendTerminalOperation,
+		setApproveCallback,
+		setRejectCallback,
+		setExecuteSelectedCallback,
+		setSendTerminalOperationCallback,
+	])
 
 	// Manage delayed visibility of approval menu
 	useEffect(() => {
@@ -336,9 +464,13 @@ export function useApprovalHandler(): UseApprovalHandlerReturn {
 			return
 		}
 
+		// Determine delay based on ask type
+		// command_output asks should show immediately so users can abort running commands
+		const delay = pendingApproval?.ask === "command_output" ? COMMAND_OUTPUT_DELAY_MS : APPROVAL_MENU_DELAY_MS
+
 		// Calculate remaining time for delay
 		const elapsed = Date.now() - approvalSetTimestamp
-		const remaining = Math.max(0, APPROVAL_MENU_DELAY_MS - elapsed)
+		const remaining = Math.max(0, delay - elapsed)
 
 		// Set timeout to show menu after delay
 		const timeoutId = setTimeout(() => {
@@ -348,7 +480,7 @@ export function useApprovalHandler(): UseApprovalHandlerReturn {
 		return () => {
 			clearTimeout(timeoutId)
 		}
-	}, [approvalSetTimestamp, isApprovalPendingImmediate])
+	}, [approvalSetTimestamp, isApprovalPendingImmediate, pendingApproval?.ask])
 
 	return {
 		pendingApproval,
@@ -361,5 +493,6 @@ export function useApprovalHandler(): UseApprovalHandlerReturn {
 		approve,
 		reject,
 		executeSelected,
+		sendTerminalOperation,
 	}
 }

--- a/cli/src/state/hooks/useApprovalHandler.ts
+++ b/cli/src/state/hooks/useApprovalHandler.ts
@@ -342,28 +342,13 @@ export function useApprovalHandler(): UseApprovalHandlerReturn {
 				}
 				store.set(updateChatMessageByTsAtom, answeredMessage)
 
-				// For continue operation, we need to send BOTH:
-				// 1. The terminal operation message (to call handleTerminalOperation)
-				// 2. An ask response with "messageResponse" (to unblock the task.ask() call)
-				if (operation === "continue") {
-					// Send terminal operation first
-					await sendMessage({
-						type: "terminalOperation",
-						terminalOperation: "continue",
-					})
-
-					// Then send ask response to unblock the waiting ask() call
-					await sendAskResponse({
-						response: "messageResponse",
-					})
-				} else {
-					// For abort, just send the terminal operation
-					// The task will handle the abortion and won't wait for a response
-					await sendMessage({
-						type: "terminalOperation",
-						terminalOperation: "abort",
-					})
-				}
+				// For terminal operations, we only need to send the terminal operation message
+				// DO NOT send askResponse - that would resolve the wrong ask (completion_result instead of command_output)
+				// The backend's onLine callback handles the command_output ask internally
+				await sendMessage({
+					type: "terminalOperation",
+					terminalOperation: operation,
+				})
 
 				logs.debug("Terminal operation sent successfully", "useApprovalHandler", {
 					operation,

--- a/cli/src/ui/components/ApprovalMenu.tsx
+++ b/cli/src/ui/components/ApprovalMenu.tsx
@@ -24,7 +24,7 @@ export const ApprovalMenu: React.FC<ApprovalMenuProps> = ({ options, selectedInd
 	return (
 		<Box flexDirection="column" borderStyle="round" borderColor={theme.actions.pending} paddingX={1}>
 			<Text bold color={theme.actions.pending}>
-				[!] Action Required:
+				[!] Actions:
 			</Text>
 			{options.map((option, index) => (
 				<ApprovalOptionRow
@@ -52,7 +52,8 @@ const ApprovalOptionRow: React.FC<ApprovalOptionRowProps> = ({ option, isSelecte
 
 	const themeColor = getThemeColor(option.color)
 	const color = isSelected ? themeColor : theme.ui.text.primary
-	const icon = option.action === "approve" ? "✓" : "✗"
+	// Use appropriate icon based on action type
+	const icon = option.action === "approve" || option.action === "approve-and-remember" ? "✓" : "✗"
 
 	return (
 		<Box>

--- a/cli/src/ui/components/ApprovalMenu.tsx
+++ b/cli/src/ui/components/ApprovalMenu.tsx
@@ -23,9 +23,6 @@ export const ApprovalMenu: React.FC<ApprovalMenuProps> = ({ options, selectedInd
 
 	return (
 		<Box flexDirection="column" borderStyle="round" borderColor={theme.actions.pending} paddingX={1}>
-			<Text bold color={theme.actions.pending}>
-				[!] Actions:
-			</Text>
 			{options.map((option, index) => (
 				<ApprovalOptionRow
 					key={option.key || `${option.action}-${index}`}

--- a/cli/src/ui/components/CommandInput.tsx
+++ b/cli/src/ui/components/CommandInput.tsx
@@ -136,7 +136,7 @@ export const CommandInput: React.FC<CommandInputProps> = ({
 		: isShellMode
 			? "Type shell command..."
 			: isApprovalPending
-				? "Awaiting approval..."
+				? "Actions available:"
 				: placeholder
 
 	return (

--- a/cli/src/ui/messages/extension/AskMessageRouter.tsx
+++ b/cli/src/ui/messages/extension/AskMessageRouter.tsx
@@ -8,6 +8,7 @@ import {
 	AskToolMessage,
 	AskMistakeLimitMessage,
 	AskCommandMessage,
+	AskCommandOutputMessage,
 	AskUseMcpServerMessage,
 	AskFollowupMessage,
 	AskCondenseMessage,
@@ -52,7 +53,7 @@ export const AskMessageRouter: React.FC<MessageComponentProps> = ({ message }) =
 			return <AskCommandMessage message={message} />
 
 		case "command_output":
-			return null
+			return <AskCommandOutputMessage message={message} />
 
 		case "browser_action_launch":
 			return <AskBrowserActionLaunchMessage message={message} />

--- a/cli/src/ui/messages/extension/SayMessageRouter.tsx
+++ b/cli/src/ui/messages/extension/SayMessageRouter.tsx
@@ -24,7 +24,6 @@ import {
 	SayMcpServerResponseMessage,
 	SayApiReqFinishedMessage,
 	SayApiReqRetryDelayedMessage,
-	SayCommandOutputMessage,
 } from "./say/index.js"
 
 /**
@@ -108,7 +107,7 @@ export const SayMessageRouter: React.FC<MessageComponentProps> = ({ message }) =
 			return <SayApiReqRetryDelayedMessage message={message} />
 
 		case "command_output":
-			return <SayCommandOutputMessage message={message} />
+			return null // Handled in AskMessageRouter
 
 		default:
 			return <DefaultSayMessage message={message} />

--- a/cli/src/ui/messages/extension/__tests__/ExtensionMessageRow.test.tsx
+++ b/cli/src/ui/messages/extension/__tests__/ExtensionMessageRow.test.tsx
@@ -183,21 +183,6 @@ describe("ExtensionMessageRow", () => {
 			expect(lastFrame()).not.toContain("Unknown message type")
 		})
 
-		it("should route 'say' message with type 'command_output' to SayCommandOutputMessage", () => {
-			const message: ExtensionChatMessage = {
-				ts: Date.now(),
-				type: "say",
-				say: "command_output",
-				text: "Command executed successfully",
-			}
-
-			const { lastFrame } = render(<ExtensionMessageRow message={message} />)
-
-			expect(lastFrame()).toBeDefined()
-			expect(lastFrame()).toContain("Command executed successfully")
-			expect(lastFrame()).not.toContain("Unknown say type")
-		})
-
 		it("should show default message for unknown 'say' type", () => {
 			const message: ExtensionChatMessage = {
 				ts: Date.now(),

--- a/cli/src/ui/messages/extension/ask/AskCommandOutputMessage.tsx
+++ b/cli/src/ui/messages/extension/ask/AskCommandOutputMessage.tsx
@@ -1,0 +1,74 @@
+import React from "react"
+import { Box, Text } from "ink"
+import { useAtomValue } from "jotai"
+import type { MessageComponentProps } from "../types.js"
+import { getMessageIcon } from "../utils.js"
+import { useTheme } from "../../../../state/hooks/useTheme.js"
+import { getBoxWidth } from "../../../utils/width.js"
+import { pendingOutputUpdatesAtom } from "../../../../state/atoms/effects.js"
+
+export const AskCommandOutputMessage: React.FC<MessageComponentProps> = ({ message }) => {
+	const theme = useTheme()
+	const pendingUpdates = useAtomValue(pendingOutputUpdatesAtom)
+
+	const icon = getMessageIcon("ask", "command_output")
+
+	// Parse the message text to get initial command and executionId
+	let executionId = ""
+	let initialCommand = ""
+	try {
+		const data = JSON.parse(message.text || "{}")
+		executionId = data.executionId || ""
+		initialCommand = data.command || ""
+	} catch {
+		// If parsing fails, use text directly
+		initialCommand = message.text || ""
+	}
+
+	// Get real-time output from pending updates (similar to webview's streamingOutput)
+	const pendingUpdate = executionId ? pendingUpdates.get(executionId) : undefined
+	const command = pendingUpdate?.command || initialCommand
+	const output = pendingUpdate?.output || ""
+
+	return (
+		<Box flexDirection="column" marginY={1}>
+			<Box>
+				<Text color={theme.semantic.info} bold>
+					{icon} Command Running
+				</Text>
+			</Box>
+
+			{command && (
+				<Box
+					width={getBoxWidth(3)}
+					marginLeft={2}
+					marginTop={1}
+					borderStyle="single"
+					borderColor={theme.semantic.info}
+					paddingX={1}>
+					<Text color={theme.ui.text.primary}>{command}</Text>
+				</Box>
+			)}
+
+			{output.trim() ? (
+				<Box
+					width={getBoxWidth(3)}
+					marginLeft={2}
+					marginTop={1}
+					borderStyle="single"
+					borderColor={theme.ui.text.dimmed}
+					paddingX={1}>
+					<Text color={theme.ui.text.primary}>
+						{output.trim().length > 500 ? output.trim().slice(0, 500) + "\n..." : output.trim()}
+					</Text>
+				</Box>
+			) : (
+				<Box marginLeft={2} marginTop={1}>
+					<Text color={theme.ui.text.dimmed} dimColor>
+						Waiting for output...
+					</Text>
+				</Box>
+			)}
+		</Box>
+	)
+}

--- a/cli/src/ui/messages/extension/ask/AskCommandOutputMessage.tsx
+++ b/cli/src/ui/messages/extension/ask/AskCommandOutputMessage.tsx
@@ -62,13 +62,7 @@ export const AskCommandOutputMessage: React.FC<MessageComponentProps> = ({ messa
 						{output.trim().length > 500 ? output.trim().slice(0, 500) + "\n..." : output.trim()}
 					</Text>
 				</Box>
-			) : (
-				<Box marginLeft={2} marginTop={1}>
-					<Text color={theme.ui.text.dimmed} dimColor>
-						Waiting for output...
-					</Text>
-				</Box>
-			)}
+			) : null}
 		</Box>
 	)
 }

--- a/cli/src/ui/messages/extension/ask/index.ts
+++ b/cli/src/ui/messages/extension/ask/index.ts
@@ -1,6 +1,7 @@
 export { AskToolMessage } from "./AskToolMessage.js"
 export { AskMistakeLimitMessage } from "./AskMistakeLimitMessage.js"
 export { AskCommandMessage } from "./AskCommandMessage.js"
+export { AskCommandOutputMessage } from "./AskCommandOutputMessage.js"
 export { AskUseMcpServerMessage } from "./AskUseMcpServerMessage.js"
 export { AskFollowupMessage } from "./AskFollowupMessage.js"
 export { AskCondenseMessage } from "./AskCondenseMessage.js"

--- a/cli/src/ui/messages/utils/__tests__/messageCompletion.test.ts
+++ b/cli/src/ui/messages/utils/__tests__/messageCompletion.test.ts
@@ -232,17 +232,30 @@ describe("messageCompletion", () => {
 				expect(isMessageComplete(message)).toBe(true)
 			})
 
-			it("should return true for non-rendering ask types (command_output)", () => {
-				const message: UnifiedMessage = {
+			it("should return false for command_output ask type until not partial", () => {
+				const partialMessage: UnifiedMessage = {
 					source: "extension",
 					message: {
 						ts: Date.now(),
 						type: "ask",
 						ask: "command_output",
 						text: "",
+						partial: true,
 					},
 				}
-				expect(isMessageComplete(message)).toBe(true)
+				expect(isMessageComplete(partialMessage)).toBe(false)
+
+				const completeMessage: UnifiedMessage = {
+					source: "extension",
+					message: {
+						ts: Date.now(),
+						type: "ask",
+						ask: "command_output",
+						text: "",
+						partial: false,
+					},
+				}
+				expect(isMessageComplete(completeMessage)).toBe(true)
 			})
 		})
 	})

--- a/cli/src/ui/messages/utils/messageCompletion.ts
+++ b/cli/src/ui/messages/utils/messageCompletion.ts
@@ -45,7 +45,7 @@ function isExtensionMessageComplete(message: ExtensionChatMessage): boolean {
 	// Ask messages completion logic
 	if (message.type === "ask") {
 		// These ask types don't render, so they're immediately complete
-		const nonRenderingAskTypes = ["completion_result", "command_output"]
+		const nonRenderingAskTypes = ["completion_result"]
 		if (message.ask && nonRenderingAskTypes.includes(message.ask)) {
 			return true
 		}


### PR DESCRIPTION
## Context

Resolve [#3815](https://github.com/Kilo-Org/kilocode/issues/3815)

## Implementation

- Command execution realtime updates (Output stream)
- Action menu (Continue / Abort)
- Synthetic ask command msg to workaround the inconsistencies of the extension messages

## Screenshots

https://github.com/user-attachments/assets/37b0f066-36fd-4b68-8726-b06501973b7d


## How to Test

Execute
```
for i in {1..5}; do echo "HI" && sleep 2; done
```
To check if the stream of the command works
