### PR TITLE
Support multiple changelog version formats in JetBrains build

### DIFF
--- a/jetbrains/plugin/scripts/update_change_notes.js
+++ b/jetbrains/plugin/scripts/update_change_notes.js
@@ -29,7 +29,9 @@ function updateChangeNotes() {
 		const changelogContent = readFileSync(changelogPath, "utf8")
 
 		// Find the version section in changelog
-		const versionPattern = new RegExp(`## \\[v${version.replace(/\./g, "\\.")}\\]([\\s\\S]*?)(?=## \\[v|$)`)
+		// Support multiple formats: ## [vX.X.X], ## [X.X.X], ## X.X.X
+		const escapedVersion = version.replaceAll(".", "\\.")
+		const versionPattern = new RegExp(`## \\[?v?${escapedVersion}\\]?([\\s\\S]*?)(?=## \\[?v?\\d|$)`)
 		const changelogVersionMatch = changelogContent.match(versionPattern)
 
 		if (!changelogVersionMatch) {


### PR DESCRIPTION
The JetBrains plugin build script now accepts multiple version header formats in CHANGELOG.md:
- ## [vX.X.X] (old custom format)
- ## [X.X.X] (bracketed without v)
- ## X.X.X (default changeset format)

This makes the build compatible with the default changeset changelog output, which uses '## X.X.X' without brackets or 'v' prefix.
