### PR TITLE
fix: resolve z.ai provider setup failure (#3828)

### DIFF
--- a/.changeset/zai-provider-fix.md
+++ b/.changeset/zai-provider-fix.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": patch
+---
+
+Fixes z.ai provider setup failure by collecting all required configuration fields. The authentication wizard now prompts for API line selection (international_coding or china_coding) and sets the default model to gpt-4o.
+
+Fixes #3828

--- a/cli/src/utils/authWizard.ts
+++ b/cli/src/utils/authWizard.ts
@@ -4,6 +4,7 @@ import openConfigFile from "../config/openConfig"
 import wait from "../utils/wait"
 import { getKilocodeDefaultModel } from "./getKilocodeDefaultModel.js"
 import { getKilocodeProfile, INVALID_TOKEN_ERROR, type KilocodeProfileData } from "./getKilocodeProfile.js"
+import { getProviderDefaultModel } from "../constants/providers/settings.js"
 
 export default async function authWizard() {
 	const config = await loadConfig()
@@ -103,14 +104,35 @@ export default async function authWizard() {
 			break
 		}
 		case "zai": {
-			const { zaiApiKey } = await inquirer.prompt<{ zaiApiKey: string }>([
+			const { zaiApiKey, zaiApiLine } = await inquirer.prompt<{
+				zaiApiKey: string
+				zaiApiLine: "international_coding" | "china_coding"
+			}>([
 				{
 					type: "password",
 					name: "zaiApiKey",
 					message: "Please enter your zAI token:",
 				},
+				{
+					type: "list",
+					name: "zaiApiLine",
+					message: "Select your zAI API line:",
+					choices: [
+						{ name: "International Coding", value: "international_coding" },
+						{ name: "China Coding", value: "china_coding" },
+					],
+					default: "international_coding",
+				},
 			])
-			providerSpecificConfig = { zaiApiKey }
+
+			// Get the default model for zai provider
+			const defaultModel = getProviderDefaultModel("zai")
+
+			providerSpecificConfig = {
+				zaiApiKey,
+				zaiApiLine,
+				apiModelId: defaultModel,
+			}
 			break
 		}
 		case "other": {


### PR DESCRIPTION
## Summary
Fixes the issue where users cannot configure z.ai as their AI provider due to missing required fields in the authentication wizard.

## Problem
When users try to configure z.ai provider, they encounter this error:
```
zaiApiLine is required and cannot be empty for selected provider, apiModelId is required and cannot be empty for selected provider
```

## Root Cause
The authentication wizard (`cli/src/utils/authWizard.ts`) was only collecting the `zaiApiKey` but the validation requires three fields:
- `zaiApiKey` ✓ (already collected)
- `zaiApiLine` ✗ (missing)
- `apiModelId` ✗ (missing)

## Solution
Updated the auth wizard to collect all required fields:
1. Added a prompt for selecting API line (international_coding or china_coding)
2. Set default model to gpt-4o from PROVIDER_DEFAULT_MODELS
3. Imported `getProviderDefaultModel` function from settings

## Changes Made
- Modified `cli/src/utils/authWizard.ts`:
  - Added import for `getProviderDefaultModel`
  - Added inquirer prompt for `zaiApiLine` selection
  - Added logic to set `apiModelId` with default value

## Testing
- ✅ All linting checks pass
- ✅ All type checks pass  
- ✅ All existing tests pass (1062 tests)
- ✅ Interactive test confirms API line selection prompt appears
- ✅ Configuration saves with all required fields:
  ```json
  {
    "provider": "zai",
    "zaiApiKey": "...",
    "zaiApiLine": "international_coding",
    "apiModelId": "gpt-4o"
  }
  ```
- ✅ No validation errors occur during setup

## Verification Steps
1. Run `kilocode auth`
2. Select "zAI" as provider
3. Enter your zAI API token
4. Select API line (International/China Coding)
5. Configuration is saved successfully with all required fields

Fixes: #3828