### PR TITLE
Fix workflows not working except as the initial prompt of a task

### DIFF
--- a/.changeset/poor-months-build.md
+++ b/.changeset/poor-months-build.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix an issue where workflows are not working except as the initial prompt of a task

--- a/src/core/slash-commands/kilo.ts
+++ b/src/core/slash-commands/kilo.ts
@@ -38,9 +38,9 @@ export async function parseKiloSlashCommands(
 	// this currently allows matching prepended whitespace prior to /slash-command
 	const tagPatterns = [
 		{ tag: "task", regex: /<task>(\s*\/([a-zA-Z0-9_.-]+))(\s+.+?)?\s*<\/task>/is },
-		{ tag: "feedback", regex: /<feedback>(\s*\/([a-zA-Z0-9_-]+))(\s+.+?)?\s*<\/feedback>/is },
-		{ tag: "answer", regex: /<answer>(\s*\/([a-zA-Z0-9_-]+))(\s+.+?)?\s*<\/answer>/is },
-		{ tag: "user_message", regex: /<user_message>(\s*\/([a-zA-Z0-9_-]+))(\s+.+?)?\s*<\/user_message>/is },
+		{ tag: "feedback", regex: /<feedback>(\s*\/([a-zA-Z0-9_.-]+))(\s+.+?)?\s*<\/feedback>/is },
+		{ tag: "answer", regex: /<answer>(\s*\/([a-zA-Z0-9_.-]+))(\s+.+?)?\s*<\/answer>/is },
+		{ tag: "user_message", regex: /<user_message>(\s*\/([a-zA-Z0-9_.-]+))(\s+.+?)?\s*<\/user_message>/is },
 	]
 
 	// if we find a valid match, we will return inside that block


### PR DESCRIPTION
## Context

Workflows are not triggering when sent using slash commands: (e.g. `/workflow.md`) except when sent as the initial prompt.
**Issue**: #1320

## Implementation

Added the missing `.` character to the regex patterns for `feedback`, `answer`, and `user_message` tags in `kilo.ts`. This ensures proper pattern matching for these slash command tags.

## Screenshots

| before | after |
| ------ | ----- |
| <img width="708" height="878" alt="image" src="https://github.com/user-attachments/assets/027abbec-905a-41ab-b0ca-f7a7e2b29611" /> | <img width="703" height="789" alt="Image" src="https://github.com/user-attachments/assets/7da6131d-77d7-45f1-bb60-8f73dc0bb1a0" /> |

## How to Test

- Create a workflow inside Kilo Code (either global or local would yield the same behavior)
- Start a task and say anything
- Execute the workflow using slash commands anytime AFTER the initial prompt
- Observe if the workflow is properly being executed