### PR TITLE
Emit signal specific exit code

### DIFF
--- a/.changeset/twenty-trams-fetch.md
+++ b/.changeset/twenty-trams-fetch.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Support emitting Unix exit codes for signal interruption (SIGINT/SIGTERM).

--- a/cli/README.md
+++ b/cli/README.md
@@ -220,6 +220,8 @@ This instructs the AI to proceed without user input.
 
 - `0`: Success (task completed)
 - `124`: Timeout (task exceeded time limit)
+- `130`: SIGINT interruption (Ctrl+C)
+- `143`: SIGTERM interruption (system termination)
 - `1`: Error (initialization or execution failure)
 
 #### Example CI/CD Integration

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -252,7 +252,7 @@ export class CLI {
 	 * - Disposes service
 	 * - Cleans up store
 	 */
-	async dispose(): Promise<void> {
+	async dispose(signal?: string): Promise<void> {
 		if (this.isDisposing) {
 			logs.info("Already disposing, ignoring duplicate dispose call", "CLI")
 
@@ -261,7 +261,7 @@ export class CLI {
 
 		this.isDisposing = true
 
-		// Determine exit code based on CI mode and exit reason
+		// Determine exit code based on signal type and CI mode
 		let exitCode = 0
 
 		let beforeExit = () => {}
@@ -269,8 +269,15 @@ export class CLI {
 		try {
 			logs.info("Disposing Kilo Code CLI...", "CLI")
 
-			if (this.options.ci && this.store) {
-				// Check exit reason from CI atoms
+			// Signal codes take precedence over CI logic
+			if (signal === "SIGINT") {
+				exitCode = 130
+				logs.info("Exiting with SIGINT code (130)", "CLI")
+			} else if (signal === "SIGTERM") {
+				exitCode = 143
+				logs.info("Exiting with SIGTERM code (143)", "CLI")
+			} else if (this.options.ci && this.store) {
+				// CI mode logic only when not interrupted by signal
 				const exitReason = this.store.get(ciExitReasonAtom)
 
 				// Set exit code based on the actual exit reason

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -247,12 +247,16 @@ program
 process.on("SIGINT", async () => {
 	if (cli) {
 		await cli.dispose("SIGINT")
+	} else {
+		process.exit(130)
 	}
 })
 
 process.on("SIGTERM", async () => {
 	if (cli) {
 		await cli.dispose("SIGTERM")
+	} else {
+		process.exit(143)
 	}
 })
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -246,16 +246,14 @@ program
 // Handle process termination signals
 process.on("SIGINT", async () => {
 	if (cli) {
-		await cli.dispose()
+		await cli.dispose("SIGINT")
 	}
-	process.exit(0)
 })
 
 process.on("SIGTERM", async () => {
 	if (cli) {
-		await cli.dispose()
+		await cli.dispose("SIGTERM")
 	}
-	process.exit(0)
 })
 
 // Parse command line arguments


### PR DESCRIPTION
## Context

What: Implement Unix exit codes for signal interruption (SIGINT/SIGTERM) instead of generic error code 1.

Why: Signal interruption was indistinguishable from actual failures, causing issues for automation systems and CI/CD pipelines that need to differentiate between user interruption, system termination, and task failures.

## Implementation

Modified the CLI's dispose() method to accept an optional signal parameter and prioritize signal-specific exit codes (130 for SIGINT, 143 for SIGTERM) over CI completion logic. Updated signal handlers to pass signal types or exit directly with expected code. 

Tradeoffs: Signal codes now take precedence over CI completion logic

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

```
kilocode --auto "do something that takes a while"
# either SIGTERM or INT  the process
# observe that exit code is either 143 or 130
```

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilocode.ai/discord), please share your handle here. -->
