### PR TITLE
Changelog extraction fix for github releases

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -92,28 +92,29 @@ jobs:
                   # Check if release already exists
                   if gh release view "v${current_package_version}" >/dev/null 2>&1; then
                     echo "Release v${current_package_version} already exists, skipping release creation"
-                  else
-                    # Extract changelog for current version
-                    echo "Extracting changelog for version ${current_package_version}"
-                    # Match version headers: ## [vX.X.X], ## [X.X.X], ## X.X.X (brackets and v are optional)
-                    changelog_content=$(sed -E -n "/^## \\[?v?${current_package_version}\\]?/,/^## /p" CHANGELOG.md | sed '$d')
-
-                    if [ -z "$changelog_content" ]; then
-                      echo "Error: No changelog section found for version ${current_package_version}"
-                      echo "Please add a changelog entry in CHANGELOG.md for version ${current_package_version}"
-                      exit 1
-                    fi
-                    
-                    echo "Found changelog section for version ${current_package_version}"
-
-                    # Create release with changelog content
-                    gh release create "v${current_package_version}" \
-                      --title "Release v${current_package_version}" \
-                      --notes "$changelog_content" \
-                      --target ${{ env.GIT_REF }} \
-                      bin/kilo-code-${current_package_version}.vsix
-                    echo "Successfully created GitHub Release v${current_package_version}"
+                    exit 0
                   fi
+                  
+                  # Extract changelog for current version
+                  echo "Extracting changelog for version ${current_package_version}"
+                  # Match version headers: ## [vX.X.X], ## [X.X.X], ## X.X.X (brackets and v are optional)
+                  changelog_content=$(sed -E -n "/^## \\[?v?${current_package_version}\\]?/,/^## /p" CHANGELOG.md | sed '$d')
+
+                  if [ -z "$changelog_content" ]; then
+                    echo "Error: No changelog section found for version ${current_package_version}"
+                    echo "Please add a changelog entry in CHANGELOG.md for version ${current_package_version}"
+                    exit 1
+                  fi
+                  
+                  echo "Found changelog section for version ${current_package_version}"
+
+                  # Create release with changelog content
+                  gh release create "v${current_package_version}" \
+                    --title "Release v${current_package_version}" \
+                    --notes "$changelog_content" \
+                    --target ${{ env.GIT_REF }} \
+                    bin/kilo-code-${current_package_version}.vsix
+                  echo "Successfully created GitHub Release v${current_package_version}"
             - name: Upload VSIX artifact
               uses: actions/upload-artifact@v4
               with:

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -96,7 +96,7 @@ jobs:
                     # Extract changelog for current version
                     echo "Extracting changelog for version ${current_package_version}"
                     # Match version headers: ## [vX.X.X], ## [X.X.X], ## X.X.X (brackets and v are optional)
-                    changelog_content=$(sed -E -n "/## \\[?v?${current_package_version}\\]?/,/## /p" CHANGELOG.md | sed '$d')
+                    changelog_content=$(sed -E -n "/^## \\[?v?${current_package_version}\\]?/,/^## /p" CHANGELOG.md | sed '$d')
 
                     # If changelog extraction failed, use a default message
                     if [ -z "$changelog_content" ]; then

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -98,13 +98,13 @@ jobs:
                     # Match version headers: ## [vX.X.X], ## [X.X.X], ## X.X.X (brackets and v are optional)
                     changelog_content=$(sed -E -n "/^## \\[?v?${current_package_version}\\]?/,/^## /p" CHANGELOG.md | sed '$d')
 
-                    # If changelog extraction failed, use a default message
                     if [ -z "$changelog_content" ]; then
-                      echo "Warning: No changelog section found for version ${current_package_version}"
-                      changelog_content="Release v${current_package_version}"
-                    else
-                      echo "Found changelog section for version ${current_package_version}"
+                      echo "Error: No changelog section found for version ${current_package_version}"
+                      echo "Please add a changelog entry in CHANGELOG.md for version ${current_package_version}"
+                      exit 1
                     fi
+                    
+                    echo "Found changelog section for version ${current_package_version}"
 
                     # Create release with changelog content
                     gh release create "v${current_package_version}" \

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -89,13 +89,11 @@ jobs:
               run: |
                   current_package_version=$(node -p "require('./src/package.json').version")
 
-                  # Check if release already exists
                   if gh release view "v${current_package_version}" >/dev/null 2>&1; then
                     echo "Release v${current_package_version} already exists, skipping release creation"
                     exit 0
                   fi
                   
-                  # Extract changelog for current version
                   echo "Extracting changelog for version ${current_package_version}"
                   # Match version headers: ## [vX.X.X], ## [X.X.X], ## X.X.X (brackets and v are optional)
                   changelog_content=$(sed -E -n "/^## \\[?v?${current_package_version}\\]?/,/^## /p" CHANGELOG.md | sed '$d')


### PR DESCRIPTION
I mean, it's a little concerning that we have this code in three places, but enough of the rabbit holes.

best reviewed by commit hiding whitespace changes, i.e. starting here: https://github.com/Kilo-Org/kilocode/pull/4007/commits/2f9d1f4c7d528146d19a721684f98095a69aff3e?w=1