### PR TITLE
Tracking kilo.gif in lfs now

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,6 @@ src/assets/docs/demo.gif filter=lfs diff=lfs merge=lfs -text
 src/package.nls.*.json linguist-generated=true
 # Exclude the base English file from being marked as generated
 src/package.nls.json linguist-generated=false
-
 # Root locales directory (contains only non-English translations)
 locales/** linguist-generated=true
 # Mark all locale directories as generated first
@@ -19,3 +18,4 @@ src/i18n/locales/en/** linguist-generated=false
 webview-ui/src/i18n/locales/en/** linguist-generated=false
 # This approach uses gitattributes' last-match-wins rule to exclude English while including all other locales
 jetbrains/plugin/platform.zip filter=lfs diff=lfs merge=lfs -text
+kilo.gif filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - 💡 **Get $20 in bonus credits when you top-up for the first time** Credits can be used with 400+ models like Gemini 3 Pro, Claude 4 Sonnet & Opus, and GPT-5
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/Kilo-Org/kilocode/refs/heads/main/kilo.gif" width="100%" />
+  <img src="https://media.githubusercontent.com/media/Kilo-Org/kilocode/main/kilo.gif" width="100%" />
 </p>
 
 - [VS Code Marketplace](https://kilocode.ai/vscode-marketplace?utm_source=Readme) (download)


### PR DESCRIPTION
Trying to fix slow readme loading with kilo.gif in VSCode marketplace details page.

Kilo.gif wasn't added to LFS, which is required to use as media link.
