### PR TITLE
Reapply multi-line git commit message support in auto-approve (attempt 2)

### DIFF
--- a/src/shared/__tests__/parse-command.spec.ts
+++ b/src/shared/__tests__/parse-command.spec.ts
@@ -1,0 +1,95 @@
+// kilocode_change new file
+
+import { parseCommand } from "../parse-command"
+
+describe("parseCommand", () => {
+	describe("basic command parsing", () => {
+		it("parses a simple command", () => {
+			expect(parseCommand("git status")).toEqual(["git status"])
+		})
+
+		it("parses chained commands with &&", () => {
+			expect(parseCommand("git add . && git commit")).toEqual(["git add .", "git commit"])
+		})
+
+		it("parses chained commands with ||", () => {
+			expect(parseCommand("git pull || git fetch")).toEqual(["git pull", "git fetch"])
+		})
+
+		it("parses commands separated by newlines", () => {
+			expect(parseCommand("git status\ngit log")).toEqual(["git status", "git log"])
+		})
+
+		it("handles empty input", () => {
+			expect(parseCommand("")).toEqual([])
+			expect(parseCommand("   ")).toEqual([])
+		})
+	})
+
+	describe("quoted strings", () => {
+		it("preserves double-quoted strings", () => {
+			expect(parseCommand('echo "hello world"')).toEqual(['echo "hello world"'])
+		})
+
+		// Note: shell-quote library strips single quotes, so we test that the content is preserved
+		it("preserves content of single-quoted strings", () => {
+			expect(parseCommand("echo 'hello world'")).toEqual(["echo hello world"])
+		})
+	})
+
+	// kilocode_change start - tests for multi-line quoted strings
+	describe("multi-line quoted strings", () => {
+		it("preserves newlines within double quotes", () => {
+			const command = `echo "Hello\nWorld"`
+			const result = parseCommand(command)
+			expect(result).toHaveLength(1)
+			expect(result[0]).toContain("\n")
+			expect(result[0]).toBe('echo "Hello\nWorld"')
+		})
+
+		// Note: shell-quote library strips single quotes, but newlines are still preserved
+		it("preserves newlines within single quotes", () => {
+			const command = `echo 'Hello\nWorld'`
+			const result = parseCommand(command)
+			expect(result).toHaveLength(1)
+			expect(result[0]).toContain("\n")
+			// Single quotes are stripped by shell-quote, but newline is preserved
+			expect(result[0]).toBe("echo Hello\nWorld")
+		})
+
+		it("splits on newlines outside quotes but preserves newlines inside quotes", () => {
+			const command = `echo "Hello\nWorld"\ngit status`
+			const result = parseCommand(command)
+			expect(result).toHaveLength(2)
+			expect(result[0]).toBe('echo "Hello\nWorld"')
+			expect(result[1]).toBe("git status")
+		})
+
+		it("handles git commit with multi-line message", () => {
+			const command = `git commit -m "feat: title\n\n- point a\n- point b"`
+			const result = parseCommand(command)
+			expect(result).toHaveLength(1)
+			expect(result[0]).toContain("\n")
+			expect(result[0]).toContain("- point a")
+			expect(result[0]).toContain("- point b")
+		})
+
+		it("handles complex git command chain with multi-line commit message", () => {
+			const command = `cd /repo && git add . && git commit -m "feat: title\n\n- point a\n- point b"`
+			const result = parseCommand(command)
+			expect(result).toHaveLength(3)
+			expect(result[0]).toBe("cd /repo")
+			expect(result[1]).toBe("git add .")
+			expect(result[2]).toContain("git commit -m")
+			expect(result[2]).toContain("\n")
+		})
+
+		it("handles CRLF line endings in quotes", () => {
+			const command = `echo "Hello\r\nWorld"`
+			const result = parseCommand(command)
+			expect(result).toHaveLength(1)
+			expect(result[0]).toContain("\r\n")
+		})
+	})
+	// kilocode_change end
+})

--- a/src/shared/__tests__/quote-protection.spec.ts
+++ b/src/shared/__tests__/quote-protection.spec.ts
@@ -1,0 +1,152 @@
+// kilocode_change new file
+
+import {
+	protectNewlinesInQuotes,
+	restoreNewlinesFromPlaceholders,
+	NEWLINE_PLACEHOLDER,
+	CARRIAGE_RETURN_PLACEHOLDER,
+} from "../quote-protection"
+
+describe("protectNewlinesInQuotes", () => {
+	const newlinePlaceholder = NEWLINE_PLACEHOLDER
+	const crPlaceholder = CARRIAGE_RETURN_PLACEHOLDER
+
+	describe("basic quote handling", () => {
+		it("protects newlines in double quotes", () => {
+			const input = 'echo "hello\nworld"'
+			const expected = `echo "hello${newlinePlaceholder}world"`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+
+		it("protects newlines in single quotes", () => {
+			const input = "echo 'hello\nworld'"
+			const expected = `echo 'hello${newlinePlaceholder}world'`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+
+		it("does not protect newlines outside quotes", () => {
+			const input = "echo hello\necho world"
+			const expected = "echo hello\necho world"
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+	})
+
+	describe("quote concatenation", () => {
+		it("handles quote concatenation where content between quotes is NOT quoted", () => {
+			// In bash: echo '"'A'"' prints "A" (A is not quoted)
+			const input = `echo '"'A\n'"'`
+			// The newline after A is NOT inside quotes, so it should NOT be protected
+			const expected = `echo '"'A\n'"'`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+
+		it("handles alternating quotes correctly", () => {
+			// echo "hello"world"test" -> hello is quoted, world is not, test is quoted
+			const input = `echo "hello\n"world\n"test\n"`
+			const expected = `echo "hello${newlinePlaceholder}"world\n"test${newlinePlaceholder}"`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+
+		it("handles single quote after double quote", () => {
+			const input = `echo "hello"'world\n'`
+			const expected = `echo "hello"'world${newlinePlaceholder}'`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+
+		it("handles double quote after single quote", () => {
+			const input = `echo 'hello'"world\n"`
+			const expected = `echo 'hello'"world${newlinePlaceholder}"`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+	})
+
+	describe("escaped quotes", () => {
+		it("handles escaped double quotes in double-quoted strings", () => {
+			const input = 'echo "hello\\"world\n"'
+			const expected = `echo "hello\\"world${newlinePlaceholder}"`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+
+		it("does not treat backslash as escape in single quotes", () => {
+			// In single quotes, backslash is literal (except for \' in some shells)
+			const input = "echo 'hello\\'world\n'"
+			// The \\ is literal, the ' ends the quote, so world\n is outside quotes
+			const expected = "echo 'hello\\'world\n'"
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+	})
+
+	describe("edge cases", () => {
+		it("handles unclosed quotes", () => {
+			const input = 'echo "unclosed\n'
+			const expected = `echo "unclosed${newlinePlaceholder}`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+
+		it("handles empty string", () => {
+			expect(protectNewlinesInQuotes("", newlinePlaceholder, crPlaceholder)).toBe("")
+		})
+
+		it("handles string with no quotes", () => {
+			const input = "echo hello\nworld"
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(input)
+		})
+
+		it("handles multiple newlines in quotes", () => {
+			const input = 'echo "line1\nline2\nline3"'
+			const expected = `echo "line1${newlinePlaceholder}line2${newlinePlaceholder}line3"`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+
+		it("handles carriage returns", () => {
+			const input = 'echo "hello\rworld"'
+			const expected = `echo "hello${crPlaceholder}world"`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+
+		it("handles CRLF", () => {
+			const input = 'echo "hello\r\nworld"'
+			const expected = `echo "hello${crPlaceholder}${newlinePlaceholder}world"`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+	})
+
+	describe("real-world git commit examples", () => {
+		it("protects newlines in git commit message", () => {
+			const input = `git commit -m "feat: title\n\n- point a\n- point b"`
+			const expected = `git commit -m "feat: title${newlinePlaceholder}${newlinePlaceholder}- point a${newlinePlaceholder}- point b"`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+
+		it("handles complex git command with multiple quoted sections", () => {
+			const input = `git add . && git commit -m "feat: title\n\n- point a" && echo "done\n"`
+			const expected = `git add . && git commit -m "feat: title${newlinePlaceholder}${newlinePlaceholder}- point a" && echo "done${newlinePlaceholder}"`
+			expect(protectNewlinesInQuotes(input, newlinePlaceholder, crPlaceholder)).toBe(expected)
+		})
+	})
+})
+
+describe("restoreNewlinesFromPlaceholders", () => {
+	it("restores newlines from placeholders", () => {
+		const input = `echo "hello${NEWLINE_PLACEHOLDER}world"`
+		const expected = 'echo "hello\nworld"'
+		expect(restoreNewlinesFromPlaceholders(input, NEWLINE_PLACEHOLDER, CARRIAGE_RETURN_PLACEHOLDER)).toBe(expected)
+	})
+
+	it("restores carriage returns from placeholders", () => {
+		const input = `echo "hello${CARRIAGE_RETURN_PLACEHOLDER}world"`
+		const expected = 'echo "hello\rworld"'
+		expect(restoreNewlinesFromPlaceholders(input, NEWLINE_PLACEHOLDER, CARRIAGE_RETURN_PLACEHOLDER)).toBe(expected)
+	})
+
+	it("restores both newlines and carriage returns", () => {
+		const input = `echo "hello${CARRIAGE_RETURN_PLACEHOLDER}${NEWLINE_PLACEHOLDER}world"`
+		const expected = 'echo "hello\r\nworld"'
+		expect(restoreNewlinesFromPlaceholders(input, NEWLINE_PLACEHOLDER, CARRIAGE_RETURN_PLACEHOLDER)).toBe(expected)
+	})
+
+	it("handles string with no placeholders", () => {
+		const input = 'echo "hello world"'
+		expect(restoreNewlinesFromPlaceholders(input, NEWLINE_PLACEHOLDER, CARRIAGE_RETURN_PLACEHOLDER)).toBe(input)
+	})
+})

--- a/src/shared/quote-protection.ts
+++ b/src/shared/quote-protection.ts
@@ -1,0 +1,121 @@
+// kilocode_change new file
+
+/**
+ * Placeholders used to protect newlines within quoted strings during command parsing.
+ * These constants are used by the protectNewlinesInQuotes function to temporarily replace
+ * newlines that appear inside quotes, preventing them from being treated as command separators.
+ * We use separate placeholders for \n and \r to preserve the original line ending type.
+ */
+export const NEWLINE_PLACEHOLDER = "___NEWLINE___"
+export const CARRIAGE_RETURN_PLACEHOLDER = "___CARRIAGE_RETURN___"
+
+/**
+ * Protect newlines inside quoted strings by replacing them with placeholders.
+ * This handles proper shell quoting rules where quotes can be concatenated.
+ * Uses separate placeholders for \n and \r to preserve the original line ending type.
+ *
+ * Examples:
+ * - "hello\nworld" -> newline is protected (inside double quotes)
+ * - 'hello\nworld' -> newline is protected (inside single quotes)
+ * - echo '"'A'"' -> A is NOT quoted (quote concatenation)
+ * - "hello"world -> world is NOT quoted
+ *
+ * @param command - The command string to process
+ * @param newlinePlaceholder - The placeholder string to use for \n characters
+ * @param carriageReturnPlaceholder - The placeholder string to use for \r characters
+ * @returns The command with newlines in quotes replaced by placeholders
+ */
+export function protectNewlinesInQuotes(
+	command: string,
+	newlinePlaceholder: string,
+	carriageReturnPlaceholder: string,
+): string {
+	let result = ""
+	let i = 0
+
+	while (i < command.length) {
+		const char = command[i]
+
+		if (char === '"') {
+			// Start of double-quoted string
+			result += char
+			i++
+
+			// Process until we find the closing unescaped quote
+			while (i < command.length) {
+				const quoteChar = command[i]
+				const prevChar = i > 0 ? command[i - 1] : ""
+
+				if (quoteChar === '"' && prevChar !== "\\") {
+					// Found closing quote
+					result += quoteChar
+					i++
+					break
+				} else if (quoteChar === "\n") {
+					// Replace \n inside double quotes
+					result += newlinePlaceholder
+					i++
+				} else if (quoteChar === "\r") {
+					// Replace \r inside double quotes
+					result += carriageReturnPlaceholder
+					i++
+				} else {
+					result += quoteChar
+					i++
+				}
+			}
+		} else if (char === "'") {
+			// Start of single-quoted string
+			result += char
+			i++
+
+			// Process until we find the closing quote
+			// Note: In single quotes, backslash does NOT escape (except for \' in some shells)
+			while (i < command.length) {
+				const quoteChar = command[i]
+
+				if (quoteChar === "'") {
+					// Found closing quote
+					result += quoteChar
+					i++
+					break
+				} else if (quoteChar === "\n") {
+					// Replace \n inside single quotes
+					result += newlinePlaceholder
+					i++
+				} else if (quoteChar === "\r") {
+					// Replace \r inside single quotes
+					result += carriageReturnPlaceholder
+					i++
+				} else {
+					result += quoteChar
+					i++
+				}
+			}
+		} else {
+			// Not in quotes, keep character as-is
+			result += char
+			i++
+		}
+	}
+
+	return result
+}
+
+/**
+ * Restore newlines from placeholders in a command string.
+ *
+ * @param command - The command string with placeholders
+ * @param newlinePlaceholder - The placeholder string used for \n characters
+ * @param carriageReturnPlaceholder - The placeholder string used for \r characters
+ * @returns The command with placeholders restored to actual newlines
+ */
+export function restoreNewlinesFromPlaceholders(
+	command: string,
+	newlinePlaceholder: string,
+	carriageReturnPlaceholder: string,
+): string {
+	return command
+		.replace(new RegExp(newlinePlaceholder, "g"), "\n")
+		.replace(new RegExp(carriageReturnPlaceholder, "g"), "\r")
+}


### PR DESCRIPTION
## Summary

This PR reapplies the changes from PR #3104 that were reverted during the Roo v3.32.0 merge (PR #3895).

The Roo PR #9157 moved auto-approval logic from `ChatView` to `Task`, and in the process, the command parsing was moved to `src/shared/parse-command.ts`. However, this new implementation doesn't preserve newlines within quoted strings, which breaks multi-line git commit messages.

## Problem

When using auto-approve with a multi-line git commit message like:
```bash
git commit -m "feat: title

- point a
- point b"
```

The command was being split on newlines, treating each line as a separate command, which caused the auto-approval to fail.

## Solution

- Added `src/shared/quote-protection.ts` with `protectNewlinesInQuotes` function that temporarily replaces newlines inside quoted strings with placeholders
- Updated `src/shared/parse-command.ts` to use quote protection before splitting by newlines, then restore the newlines after parsing
- Added comprehensive tests for both the quote protection and parse-command functionality

## Testing

- All existing tests pass
- Added new tests for:
  - Quote protection functionality
  - Multi-line quoted strings in parseCommand
  - Git commit with multi-line message scenario

## Related PRs

- Original fix: #3104
- Roo merge that reverted it: #3895
- Roo PR that changed auto-approval: https://github.com/RooCodeInc/Roo-Code/pull/9157