### PR TITLE
Stop ManagedIndexer from stealing focus with the sidebar

### DIFF
--- a/.changeset/five-carpets-tell.md
+++ b/.changeset/five-carpets-tell.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Kilo Code sidebar no longer steals focus on startup when managed codebase indexing is active

--- a/src/services/code-index/managed/ManagedIndexer.ts
+++ b/src/services/code-index/managed/ManagedIndexer.ts
@@ -158,14 +158,13 @@ export class ManagedIndexer implements vscode.Disposable {
 
 	sendEnabledStateToWebview() {
 		const isEnabled = this.isEnabled()
-		ClineProvider.getInstance().then((provider) => {
-			if (provider) {
-				provider.postMessageToWebview({
-					type: "managedIndexerEnabled",
-					managedIndexerEnabled: isEnabled,
-				})
-			}
-		})
+		const provider = ClineProvider.getVisibleInstance()
+		if (provider) {
+			provider.postMessageToWebview({
+				type: "managedIndexerEnabled",
+				managedIndexerEnabled: isEnabled,
+			})
+		}
 	}
 
 	async start() {


### PR DESCRIPTION
No idea whether this will break something