### PR TITLE
Removed dynamic vscode marketplace version shield badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://img.shields.io/visual-studio-marketplace/v/kilocode.Kilo-Code.svg?label=VS%20Code%20Marketplace" alt="VS Code Marketplace"></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://img.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace"></a>
   <a href="https://x.com/kilocode"><img src="https://img.shields.io/twitter/follow/kilocode?style=flat&logo=x&color=555" alt="X (Twitter)"></a>
   <a href="https://blog.kilocode.ai"><img src="https://img.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Substack Blog"></a>
   <a href="https://kilocode.ai/discord"><img src="https://img.shields.io/discord/1349288496988160052?style=flat&logo=discord&logoColor=white" alt="Discord"></a>


### PR DESCRIPTION
Removed version number from vscode marketplace badge, which might cause the details page in the extensions market place to hang/freeze, because sometimes the dynamic call for the badge gets rate limited

Old badges:

<img width="679" height="51" alt="image" src="https://github.com/user-attachments/assets/424cd073-0724-4f14-9665-9b16c2094bbc" />

New badges:

<img width="642" height="63" alt="image" src="https://github.com/user-attachments/assets/ee57069e-0bca-4190-879d-0220f5f78c7d" />
