### PR TITLE
fix: remove duplicate upsertApiConfiguration call causing profile state sharing

### DIFF
--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -586,12 +586,6 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 			// Update cachedState to match the current state to prevent isChangeDetected from being set back to true
 			setCachedState((prevState) => ({ ...prevState, ...extensionState }))
 
-			// These have more complex logic so they aren't (yet) handled
-			// by the `updateSettings` message.
-			vscode.postMessage({ type: "updateCondensingPrompt", text: customCondensingPrompt || "" })
-			vscode.postMessage({ type: "upsertApiConfiguration", text: currentApiConfigName, apiConfiguration })
-			vscode.postMessage({ type: "telemetrySetting", text: telemetrySetting })
-
 			// kilocode_change: When editing a different profile, don't overwrite apiConfiguration
 			if (editingApiConfigName !== currentApiConfigName) {
 				// Only sync non-apiConfiguration fields from extensionState


### PR DESCRIPTION
## Problem

When editing profile B while profile A is active, the `handleSubmit` function in `SettingsView.tsx` was sending `upsertApiConfiguration` to **BOTH** profiles:

- **Line 563**: correctly saves to `editingApiConfigName` (profile B) ✅
- **Line 592**: incorrectly saves to `currentApiConfigName` (profile A) ❌

This caused both profiles to receive identical configuration when saving, explaining the bug where "change B, then A gets the same changes".

## Root Cause

The duplicate code block appears to be leftover from before PR #3732's profile isolation changes, likely kept during the merge in PR #3895 (Include changes from Roo Code v3.30.1-v3.32.0).

## Fix

Remove the duplicate `upsertApiConfiguration` call that was incorrectly saving to `currentApiConfigName` instead of `editingApiConfigName`.

## Related

- Fixes the profile state sharing bug reported after PR #3895 merge
- Related to PR #3732 (profile isolation changes)