### PR TITLE
fix: remove duplicate upsertApiConfiguration call that overwrites wrong profile

### DIFF
--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -557,11 +557,8 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 			vscode.postMessage({ type: "sendMessageOnEnter", bool: sendMessageOnEnter }) // kilocode_change
 			vscode.postMessage({ type: "showTimestamps", bool: showTimestamps }) // kilocode_change
 			vscode.postMessage({ type: "hideCostBelowThreshold", value: hideCostBelowThreshold }) // kilocode_change
-			vscode.postMessage({ type: "updateCondensingPrompt", text: customCondensingPrompt || "" })
 			vscode.postMessage({ type: "yoloGatekeeperApiConfigId", text: yoloGatekeeperApiConfigId || "" }) // kilocode_change: AI gatekeeper for YOLO mode
 			vscode.postMessage({ type: "setReasoningBlockCollapsed", bool: reasoningBlockCollapsed ?? true })
-			vscode.postMessage({ type: "upsertApiConfiguration", text: editingApiConfigName, apiConfiguration }) // kilocode_change: Save to editing profile instead of current active profile
-			vscode.postMessage({ type: "telemetrySetting", text: telemetrySetting })
 			vscode.postMessage({ type: "systemNotificationsEnabled", bool: systemNotificationsEnabled }) // kilocode_change
 			vscode.postMessage({ type: "ghostServiceSettings", values: ghostServiceSettings }) // kilocode_change
 			vscode.postMessage({ type: "morphApiKey", text: morphApiKey }) // kilocode_change
@@ -589,7 +586,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 			// These have more complex logic so they aren't (yet) handled
 			// by the `updateSettings` message.
 			vscode.postMessage({ type: "updateCondensingPrompt", text: customCondensingPrompt || "" })
-			vscode.postMessage({ type: "upsertApiConfiguration", text: currentApiConfigName, apiConfiguration })
+			vscode.postMessage({ type: "upsertApiConfiguration", text: editingApiConfigName, apiConfiguration }) // kilocode_change: Save to editing profile instead of current active profile
 			vscode.postMessage({ type: "telemetrySetting", text: telemetrySetting })
 
 			// kilocode_change: When editing a different profile, don't overwrite apiConfiguration


### PR DESCRIPTION
## Problem

When editing profile B while profile A is active, the `handleSubmit` function in SettingsView was calling `upsertApiConfiguration` twice:

1. **Line 563** (correct): `upsertApiConfiguration` with `editingApiConfigName` - saves to profile B
2. **Line 592** (bug): `upsertApiConfiguration` with `currentApiConfigName` - overwrites profile A with B's config

This caused the symptom where changing profile B would also change profile A.

## Root Cause

This appears to be leftover code from the merge of PR #3732 in PR #3895. The duplicate calls at lines 591-593 were meant to replace the earlier calls, but both sets remained in the code.

## Solution

- Remove the early duplicate calls for `updateCondensingPrompt`, `upsertApiConfiguration`, and `telemetrySetting` (lines 560, 563-564)
- Keep only the later calls (lines 591-593)
- Change line 592 to use `editingApiConfigName` instead of `currentApiConfigName`

## Testing

- [x] Existing tests pass (`SettingsView.change-detection.spec.tsx`, `ApiConfigManager.spec.tsx`)
- [ ] Manual testing: Create profile B, edit it while A is active, verify A is not modified

Fixes the profile isolation issue introduced in PR #3732 merge (#3895).