### PR TITLE
Fix issue where some models used incorrect param format for file/directory handling tools

### DIFF
--- a/.changeset/ripe-sloths-cover.md
+++ b/.changeset/ripe-sloths-cover.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix an issue where some models use an incorrect param format for file/directory handling tools (i.e. "Kilo Code tried to use <tool> without value for required parameter 'path'")

--- a/src/core/tools/ApplyDiffTool.ts
+++ b/src/core/tools/ApplyDiffTool.ts
@@ -6,12 +6,12 @@ import { DEFAULT_WRITE_DELAY_MS } from "@roo-code/types"
 
 import { ClineSayTool } from "../../shared/ExtensionMessage"
 import { getReadablePath } from "../../utils/path"
+import { parseParamsFromArgs } from "../../utils/pathUtils"
 import { Task } from "../task/Task"
 import { formatResponse } from "../prompts/responses"
 import { fileExistsAtPath } from "../../utils/fs"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { unescapeHtmlEntities } from "../../utils/text-normalization"
-import { parsePathFromArgsParam } from "../../utils/xml"
 import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
 import { computeDiffStats, sanitizeUnifiedDiff } from "../diff/stats"
 import { BaseTool, ToolCallbacks } from "./BaseTool"
@@ -26,11 +26,13 @@ export class ApplyDiffTool extends BaseTool<"apply_diff"> {
 	readonly name = "apply_diff" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): ApplyDiffParams {
-		const relPath = params.path || parsePathFromArgsParam(params) || ""
+		const args = parseParamsFromArgs(params.args, ["path", "diff"])
+		const relPath = params.path || args.path || ""
+		const diff = params.diff || args.diff || ""
 
 		return {
 			path: relPath,
-			diff: params.diff || "",
+			diff: diff,
 		}
 	}
 

--- a/src/core/tools/ApplyDiffTool.ts
+++ b/src/core/tools/ApplyDiffTool.ts
@@ -11,6 +11,7 @@ import { formatResponse } from "../prompts/responses"
 import { fileExistsAtPath } from "../../utils/fs"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { unescapeHtmlEntities } from "../../utils/text-normalization"
+import { parsePathFromArgsParam } from "../../utils/xml"
 import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
 import { computeDiffStats, sanitizeUnifiedDiff } from "../diff/stats"
 import { BaseTool, ToolCallbacks } from "./BaseTool"
@@ -25,8 +26,10 @@ export class ApplyDiffTool extends BaseTool<"apply_diff"> {
 	readonly name = "apply_diff" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): ApplyDiffParams {
+		const relPath = params.path || parsePathFromArgsParam(params) || ""
+
 		return {
-			path: params.path || "",
+			path: relPath,
 			diff: params.diff || "",
 		}
 	}

--- a/src/core/tools/CodebaseSearchTool.ts
+++ b/src/core/tools/CodebaseSearchTool.ts
@@ -4,7 +4,7 @@ import path from "path"
 import { Task } from "../task/Task"
 import { CodeIndexManager } from "../../services/code-index/manager"
 import { getWorkspacePath } from "../../utils/path"
-import { parsePathFromArgsParam } from "../../utils/xml"
+import { parseParamsFromArgs } from "../../utils/pathUtils"
 import { formatResponse } from "../prompts/responses"
 import { VectorStoreSearchResult } from "../../services/code-index/interfaces"
 import { BaseTool, ToolCallbacks } from "./BaseTool"
@@ -23,15 +23,16 @@ export class CodebaseSearchTool extends BaseTool<"codebase_search"> {
 	readonly name = "codebase_search" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): CodebaseSearchParams {
-		let query = params.query
-		let directoryPrefix = params.path || parsePathFromArgsParam(params)
+		const args = parseParamsFromArgs(params.args, ["query", "path"])
+		let query = params.query || args.query || ""
+		let directoryPrefix = params.path || args.path
 
 		if (directoryPrefix) {
 			directoryPrefix = path.normalize(directoryPrefix)
 		}
 
 		return {
-			query: query || "",
+			query: query,
 			path: directoryPrefix,
 		}
 	}

--- a/src/core/tools/CodebaseSearchTool.ts
+++ b/src/core/tools/CodebaseSearchTool.ts
@@ -4,6 +4,7 @@ import path from "path"
 import { Task } from "../task/Task"
 import { CodeIndexManager } from "../../services/code-index/manager"
 import { getWorkspacePath } from "../../utils/path"
+import { parsePathFromArgsParam } from "../../utils/xml"
 import { formatResponse } from "../prompts/responses"
 import { VectorStoreSearchResult } from "../../services/code-index/interfaces"
 import { BaseTool, ToolCallbacks } from "./BaseTool"
@@ -23,7 +24,7 @@ export class CodebaseSearchTool extends BaseTool<"codebase_search"> {
 
 	parseLegacy(params: Partial<Record<string, string>>): CodebaseSearchParams {
 		let query = params.query
-		let directoryPrefix = params.path
+		let directoryPrefix = params.path || parsePathFromArgsParam(params)
 
 		if (directoryPrefix) {
 			directoryPrefix = path.normalize(directoryPrefix)

--- a/src/core/tools/InsertContentTool.ts
+++ b/src/core/tools/InsertContentTool.ts
@@ -2,12 +2,12 @@ import fs from "fs/promises"
 import path from "path"
 
 import { getReadablePath } from "../../utils/path"
+import { parseParamsFromArgs } from "../../utils/pathUtils"
 import { Task } from "../task/Task"
 import { formatResponse } from "../prompts/responses"
 import { ClineSayTool } from "../../shared/ExtensionMessage"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { fileExistsAtPath } from "../../utils/fs"
-import { parsePathFromArgsParam } from "../../utils/xml"
 import { insertGroups } from "../diff/insert-groups"
 import { DEFAULT_WRITE_DELAY_MS } from "@roo-code/types"
 import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
@@ -25,9 +25,10 @@ export class InsertContentTool extends BaseTool<"insert_content"> {
 	readonly name = "insert_content" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): InsertContentParams {
-		const relPath = params.path || parsePathFromArgsParam(params) || ""
-		const lineStr = params.line || ""
-		const content = params.content || ""
+		const args = parseParamsFromArgs(params.args, ["path", "line", "content"])
+		const relPath = params.path || args.path || ""
+		const lineStr = params.line || args.line || ""
+		const content = params.content || args.content || ""
 
 		const lineNumber = parseInt(lineStr, 10)
 

--- a/src/core/tools/InsertContentTool.ts
+++ b/src/core/tools/InsertContentTool.ts
@@ -7,6 +7,7 @@ import { formatResponse } from "../prompts/responses"
 import { ClineSayTool } from "../../shared/ExtensionMessage"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { fileExistsAtPath } from "../../utils/fs"
+import { parsePathFromArgsParam } from "../../utils/xml"
 import { insertGroups } from "../diff/insert-groups"
 import { DEFAULT_WRITE_DELAY_MS } from "@roo-code/types"
 import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
@@ -24,7 +25,7 @@ export class InsertContentTool extends BaseTool<"insert_content"> {
 	readonly name = "insert_content" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): InsertContentParams {
-		const relPath = params.path || ""
+		const relPath = params.path || parsePathFromArgsParam(params) || ""
 		const lineStr = params.line || ""
 		const content = params.content || ""
 

--- a/src/core/tools/ListCodeDefinitionNamesTool.ts
+++ b/src/core/tools/ListCodeDefinitionNamesTool.ts
@@ -4,8 +4,7 @@ import fs from "fs/promises"
 import { Task } from "../task/Task"
 import { ClineSayTool } from "../../shared/ExtensionMessage"
 import { getReadablePath } from "../../utils/path"
-import { isPathOutsideWorkspace } from "../../utils/pathUtils"
-import { parsePathFromArgsParam } from "../../utils/xml"
+import { isPathOutsideWorkspace, parseParamsFromArgs } from "../../utils/pathUtils"
 import { parseSourceCodeForDefinitionsTopLevel, parseSourceCodeDefinitionsForFile } from "../../services/tree-sitter"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { truncateDefinitionsToLineLimit } from "./helpers/truncateDefinitions"
@@ -20,7 +19,8 @@ export class ListCodeDefinitionNamesTool extends BaseTool<"list_code_definition_
 	readonly name = "list_code_definition_names" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): ListCodeDefinitionNamesParams {
-		const relPath = params.path || parsePathFromArgsParam(params) || ""
+		const args = parseParamsFromArgs(params.args, ["path"])
+		const relPath = params.path || args.path || ""
 
 		return {
 			path: relPath,

--- a/src/core/tools/ListCodeDefinitionNamesTool.ts
+++ b/src/core/tools/ListCodeDefinitionNamesTool.ts
@@ -5,6 +5,7 @@ import { Task } from "../task/Task"
 import { ClineSayTool } from "../../shared/ExtensionMessage"
 import { getReadablePath } from "../../utils/path"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
+import { parsePathFromArgsParam } from "../../utils/xml"
 import { parseSourceCodeForDefinitionsTopLevel, parseSourceCodeDefinitionsForFile } from "../../services/tree-sitter"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { truncateDefinitionsToLineLimit } from "./helpers/truncateDefinitions"
@@ -19,8 +20,10 @@ export class ListCodeDefinitionNamesTool extends BaseTool<"list_code_definition_
 	readonly name = "list_code_definition_names" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): ListCodeDefinitionNamesParams {
+		const relPath = params.path || parsePathFromArgsParam(params) || ""
+
 		return {
-			path: params.path || "",
+			path: relPath,
 		}
 	}
 

--- a/src/core/tools/ListFilesTool.ts
+++ b/src/core/tools/ListFilesTool.ts
@@ -5,8 +5,7 @@ import { ClineSayTool } from "../../shared/ExtensionMessage"
 import { formatResponse } from "../prompts/responses"
 import { listFiles } from "../../services/glob/list-files"
 import { getReadablePath } from "../../utils/path"
-import { isPathOutsideWorkspace } from "../../utils/pathUtils"
-import { parsePathFromArgsParam } from "../../utils/xml"
+import { isPathOutsideWorkspace, parseParamsFromArgs } from "../../utils/pathUtils"
 import { BaseTool, ToolCallbacks } from "./BaseTool"
 import type { ToolUse } from "../../shared/tools"
 
@@ -19,8 +18,9 @@ export class ListFilesTool extends BaseTool<"list_files"> {
 	readonly name = "list_files" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): ListFilesParams {
-		const relPath = params.path || parsePathFromArgsParam(params) || ""
-		const recursiveRaw: string | undefined = params.recursive
+		const args = parseParamsFromArgs(params.args, ["path", "recursive"])
+		const relPath = params.path || args.path || ""
+		const recursiveRaw: string | undefined = params.recursive || args.recursive
 		const recursive = recursiveRaw?.toLowerCase() === "true"
 
 		return {

--- a/src/core/tools/ListFilesTool.ts
+++ b/src/core/tools/ListFilesTool.ts
@@ -6,6 +6,7 @@ import { formatResponse } from "../prompts/responses"
 import { listFiles } from "../../services/glob/list-files"
 import { getReadablePath } from "../../utils/path"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
+import { parsePathFromArgsParam } from "../../utils/xml"
 import { BaseTool, ToolCallbacks } from "./BaseTool"
 import type { ToolUse } from "../../shared/tools"
 
@@ -18,11 +19,12 @@ export class ListFilesTool extends BaseTool<"list_files"> {
 	readonly name = "list_files" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): ListFilesParams {
+		const relPath = params.path || parsePathFromArgsParam(params) || ""
 		const recursiveRaw: string | undefined = params.recursive
 		const recursive = recursiveRaw?.toLowerCase() === "true"
 
 		return {
-			path: params.path || "",
+			path: relPath,
 			recursive,
 		}
 	}

--- a/src/core/tools/SearchFilesTool.ts
+++ b/src/core/tools/SearchFilesTool.ts
@@ -3,8 +3,7 @@ import path from "path"
 import { Task } from "../task/Task"
 import { ClineSayTool } from "../../shared/ExtensionMessage"
 import { getReadablePath } from "../../utils/path"
-import { isPathOutsideWorkspace } from "../../utils/pathUtils"
-import { parsePathFromArgsParam } from "../../utils/xml"
+import { isPathOutsideWorkspace, parseParamsFromArgs } from "../../utils/pathUtils"
 import { regexSearchFiles } from "../../services/ripgrep"
 import { BaseTool, ToolCallbacks } from "./BaseTool"
 import type { ToolUse } from "../../shared/tools"
@@ -19,12 +18,15 @@ export class SearchFilesTool extends BaseTool<"search_files"> {
 	readonly name = "search_files" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): SearchFilesParams {
-		const relPath = params.path || parsePathFromArgsParam(params) || ""
+		const args = parseParamsFromArgs(params.args, ["path", "regex", "file_pattern"])
+		const relPath = params.path || args.path || ""
+		const regex = params.regex || args.regex || ""
+		const filePattern = params.file_pattern || args.file_pattern
 
 		return {
 			path: relPath,
-			regex: params.regex || "",
-			file_pattern: params.file_pattern || undefined,
+			regex: regex,
+			file_pattern: filePattern,
 		}
 	}
 

--- a/src/core/tools/SearchFilesTool.ts
+++ b/src/core/tools/SearchFilesTool.ts
@@ -4,6 +4,7 @@ import { Task } from "../task/Task"
 import { ClineSayTool } from "../../shared/ExtensionMessage"
 import { getReadablePath } from "../../utils/path"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
+import { parsePathFromArgsParam } from "../../utils/xml"
 import { regexSearchFiles } from "../../services/ripgrep"
 import { BaseTool, ToolCallbacks } from "./BaseTool"
 import type { ToolUse } from "../../shared/tools"
@@ -18,8 +19,10 @@ export class SearchFilesTool extends BaseTool<"search_files"> {
 	readonly name = "search_files" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): SearchFilesParams {
+		const relPath = params.path || parsePathFromArgsParam(params) || ""
+
 		return {
-			path: params.path || "",
+			path: relPath,
 			regex: params.regex || "",
 			file_pattern: params.file_pattern || undefined,
 		}

--- a/src/core/tools/WriteToFileTool.ts
+++ b/src/core/tools/WriteToFileTool.ts
@@ -13,6 +13,7 @@ import { getReadablePath } from "../../utils/path"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
 import { detectCodeOmission } from "../../integrations/editor/detect-omission"
 import { unescapeHtmlEntities } from "../../utils/text-normalization"
+import { parsePathFromArgsParam } from "../../utils/xml"
 import { DEFAULT_WRITE_DELAY_MS } from "@roo-code/types"
 import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
 import { convertNewFileToUnifiedDiff, computeDiffStats, sanitizeUnifiedDiff } from "../diff/stats"
@@ -29,8 +30,10 @@ export class WriteToFileTool extends BaseTool<"write_to_file"> {
 	readonly name = "write_to_file" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): WriteToFileParams {
+		const relPath = params.path || parsePathFromArgsParam(params) || ""
+
 		return {
-			path: params.path || "",
+			path: relPath,
 			content: params.content || "",
 			line_count: parseInt(params.line_count ?? "0", 10),
 		}

--- a/src/core/tools/WriteToFileTool.ts
+++ b/src/core/tools/WriteToFileTool.ts
@@ -10,10 +10,9 @@ import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { fileExistsAtPath } from "../../utils/fs"
 import { stripLineNumbers, everyLineHasLineNumbers } from "../../integrations/misc/extract-text"
 import { getReadablePath } from "../../utils/path"
-import { isPathOutsideWorkspace } from "../../utils/pathUtils"
+import { isPathOutsideWorkspace, parseParamsFromArgs } from "../../utils/pathUtils"
 import { detectCodeOmission } from "../../integrations/editor/detect-omission"
 import { unescapeHtmlEntities } from "../../utils/text-normalization"
-import { parsePathFromArgsParam } from "../../utils/xml"
 import { DEFAULT_WRITE_DELAY_MS } from "@roo-code/types"
 import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
 import { convertNewFileToUnifiedDiff, computeDiffStats, sanitizeUnifiedDiff } from "../diff/stats"
@@ -30,12 +29,15 @@ export class WriteToFileTool extends BaseTool<"write_to_file"> {
 	readonly name = "write_to_file" as const
 
 	parseLegacy(params: Partial<Record<string, string>>): WriteToFileParams {
-		const relPath = params.path || parsePathFromArgsParam(params) || ""
+		const args = parseParamsFromArgs(params.args, ["path", "content", "line_count"])
+		const relPath = params.path || args.path || ""
+		const content = params.content || args.content || ""
+		const lineCount = parseInt(params.line_count || args.line_count || "0", 10)
 
 		return {
 			path: relPath,
-			content: params.content || "",
-			line_count: parseInt(params.line_count ?? "0", 10),
+			content: content,
+			line_count: lineCount,
 		}
 	}
 

--- a/src/core/tools/__tests__/deleteFileTool.spec.ts
+++ b/src/core/tools/__tests__/deleteFileTool.spec.ts
@@ -23,6 +23,7 @@ vi.mock("fs/promises", () => ({
 
 vi.mock("../../../utils/pathUtils", () => ({
 	isPathOutsideWorkspace: vi.fn().mockReturnValue(false),
+	parseParamsFromArgs: vi.fn().mockReturnValue({}),
 }))
 
 vi.mock("../../prompts/responses", () => ({

--- a/src/core/tools/__tests__/writeToFileTool.spec.ts
+++ b/src/core/tools/__tests__/writeToFileTool.spec.ts
@@ -48,6 +48,7 @@ vi.mock("../../../integrations/editor/detect-omission", () => ({
 
 vi.mock("../../../utils/pathUtils", () => ({
 	isPathOutsideWorkspace: vi.fn().mockReturnValue(false),
+	parseParamsFromArgs: vi.fn().mockReturnValue({}),
 }))
 
 vi.mock("../../../utils/path", () => ({

--- a/src/core/tools/kilocode/deleteFileTool.ts
+++ b/src/core/tools/kilocode/deleteFileTool.ts
@@ -6,6 +6,7 @@ import { ClineSayTool } from "../../../shared/ExtensionMessage"
 import { formatResponse } from "../../prompts/responses"
 import { getReadablePath } from "../../../utils/path"
 import { isPathOutsideWorkspace } from "../../../utils/pathUtils"
+import { parsePathFromArgsParam } from "../../../utils/xml"
 import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../../shared/tools"
 
 interface DirectoryStats {
@@ -99,7 +100,7 @@ export async function deleteFileTool(
 		return
 	}
 
-	const relPath: string | undefined = block.params.path
+	const relPath: string | undefined = block.params.path || parsePathFromArgsParam(block.params)
 
 	try {
 		if (!relPath) {

--- a/src/core/tools/kilocode/deleteFileTool.ts
+++ b/src/core/tools/kilocode/deleteFileTool.ts
@@ -5,8 +5,7 @@ import { Task } from "../../task/Task"
 import { ClineSayTool } from "../../../shared/ExtensionMessage"
 import { formatResponse } from "../../prompts/responses"
 import { getReadablePath } from "../../../utils/path"
-import { isPathOutsideWorkspace } from "../../../utils/pathUtils"
-import { parsePathFromArgsParam } from "../../../utils/xml"
+import { isPathOutsideWorkspace, parseParamsFromArgs } from "../../../utils/pathUtils"
 import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../../shared/tools"
 
 interface DirectoryStats {
@@ -100,7 +99,8 @@ export async function deleteFileTool(
 		return
 	}
 
-	const relPath: string | undefined = block.params.path || parsePathFromArgsParam(block.params)
+	const args = parseParamsFromArgs(block.params.args, ["path"])
+	const relPath: string | undefined = block.params.path || args.path
 
 	try {
 		if (!relPath) {

--- a/src/core/tools/kilocode/editFileTool.ts
+++ b/src/core/tools/kilocode/editFileTool.ts
@@ -7,7 +7,7 @@ import { formatResponse } from "../../prompts/responses"
 import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../../shared/tools"
 import { fileExistsAtPath } from "../../../utils/fs"
 import { getReadablePath } from "../../../utils/path"
-import { parsePathFromArgsParam } from "../../../utils/xml"
+import { parseParamsFromArgs } from "../../../utils/pathUtils"
 import { FastApplyApiProvider, fastApplyApiProviderSchema, getKiloUrlFromToken } from "@roo-code/types"
 import { DEFAULT_HEADERS } from "../../../api/providers/constants"
 import { TelemetryService } from "@roo-code/telemetry"
@@ -85,9 +85,10 @@ export async function editFileTool(
 	pushToolResult: PushToolResult,
 	removeClosingTag: RemoveClosingTag,
 ): Promise<void> {
-	const target_file: string | undefined = block.params.target_file || parsePathFromArgsParam(block.params)
-	const instructions: string | undefined = block.params.instructions
-	const code_edit: string | undefined = block.params.code_edit
+	const args = parseParamsFromArgs(block.params.args, ["target_file", "instructions", "code_edit"])
+	const target_file: string | undefined = block.params.target_file || args.target_file
+	const instructions: string | undefined = block.params.instructions || args.instructions
+	const code_edit: string | undefined = block.params.code_edit || args.code_edit
 
 	let fileExists = true
 	try {

--- a/src/core/tools/kilocode/editFileTool.ts
+++ b/src/core/tools/kilocode/editFileTool.ts
@@ -7,6 +7,7 @@ import { formatResponse } from "../../prompts/responses"
 import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../../shared/tools"
 import { fileExistsAtPath } from "../../../utils/fs"
 import { getReadablePath } from "../../../utils/path"
+import { parsePathFromArgsParam } from "../../../utils/xml"
 import { FastApplyApiProvider, fastApplyApiProviderSchema, getKiloUrlFromToken } from "@roo-code/types"
 import { DEFAULT_HEADERS } from "../../../api/providers/constants"
 import { TelemetryService } from "@roo-code/telemetry"
@@ -84,7 +85,7 @@ export async function editFileTool(
 	pushToolResult: PushToolResult,
 	removeClosingTag: RemoveClosingTag,
 ): Promise<void> {
-	const target_file: string | undefined = block.params.target_file
+	const target_file: string | undefined = block.params.target_file || parsePathFromArgsParam(block.params)
 	const instructions: string | undefined = block.params.instructions
 	const code_edit: string | undefined = block.params.code_edit
 

--- a/src/core/tools/kilocode/searchAndReplaceTool.ts
+++ b/src/core/tools/kilocode/searchAndReplaceTool.ts
@@ -9,8 +9,8 @@ import { AskApproval, HandleError, PushToolResult, ToolUse } from "../../../shar
 import { formatResponse } from "../../prompts/responses"
 import { ClineSayTool } from "../../../shared/ExtensionMessage"
 import { getReadablePath } from "../../../utils/path"
+import { parseParamsFromArgs } from "../../../utils/pathUtils"
 import { fileExistsAtPath } from "../../../utils/fs"
-import { parsePathFromArgsParam } from "../../../utils/xml"
 import { RecordSource } from "../../context-tracking/FileContextTrackerTypes"
 import { DEFAULT_WRITE_DELAY_MS } from "@roo-code/types"
 import { EXPERIMENT_IDS, experiments } from "../../../shared/experiments"
@@ -71,9 +71,12 @@ export async function searchAndReplaceTool(
 			return
 		}
 
-		// Fix `path` param first to prevent `validateParams` from
-		// failing if `path` exists in `args`
-		block.params.path ||= parsePathFromArgsParam(block.params)
+		// Fix params first to prevent `validateParams` from
+		// failing if they exist in `args`
+		const args = parseParamsFromArgs(block.params.args, ["path", "old_str", "new_str"])
+		block.params.path ||= args.path
+		block.params.old_str ||= args.old_str
+		block.params.new_str ||= args.new_str
 
 		// Validate required parameters
 		const params = await validateParams(cline, block, pushToolResult)

--- a/src/core/tools/kilocode/searchAndReplaceTool.ts
+++ b/src/core/tools/kilocode/searchAndReplaceTool.ts
@@ -10,6 +10,7 @@ import { formatResponse } from "../../prompts/responses"
 import { ClineSayTool } from "../../../shared/ExtensionMessage"
 import { getReadablePath } from "../../../utils/path"
 import { fileExistsAtPath } from "../../../utils/fs"
+import { parsePathFromArgsParam } from "../../../utils/xml"
 import { RecordSource } from "../../context-tracking/FileContextTrackerTypes"
 import { DEFAULT_WRITE_DELAY_MS } from "@roo-code/types"
 import { EXPERIMENT_IDS, experiments } from "../../../shared/experiments"
@@ -69,6 +70,10 @@ export async function searchAndReplaceTool(
 		if (block.partial) {
 			return
 		}
+
+		// Fix `path` param first to prevent `validateParams` from
+		// failing if `path` exists in `args`
+		block.params.path ||= parsePathFromArgsParam(block.params)
 
 		// Validate required parameters
 		const params = await validateParams(cline, block, pushToolResult)

--- a/src/core/tools/simpleReadFileTool.ts
+++ b/src/core/tools/simpleReadFileTool.ts
@@ -7,9 +7,8 @@ import { formatResponse } from "../prompts/responses"
 import { t } from "../../i18n"
 import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../shared/tools"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
-import { isPathOutsideWorkspace } from "../../utils/pathUtils"
+import { isPathOutsideWorkspace, parseParamsFromArgs } from "../../utils/pathUtils"
 import { getReadablePath } from "../../utils/path"
-import { parsePathFromArgsParam } from "../../utils/xml"
 import { countFileLines } from "../../integrations/misc/line-counter"
 import { readLines } from "../../integrations/misc/read-lines"
 import { extractTextFromFile, addLineNumbers, getSupportedBinaryFormats } from "../../integrations/misc/extract-text"
@@ -40,7 +39,8 @@ export async function simpleReadFileTool(
 	pushToolResult: PushToolResult,
 	_removeClosingTag: RemoveClosingTag,
 ) {
-	const filePath: string | undefined = block.params.path || parsePathFromArgsParam(block.params)
+	const args = parseParamsFromArgs(block.params.args, ["path"])
+	const filePath: string | undefined = block.params.path || args.path
 
 	// Check if the current model supports images
 	const modelInfo = cline.api.getModel().info

--- a/src/core/tools/simpleReadFileTool.ts
+++ b/src/core/tools/simpleReadFileTool.ts
@@ -9,6 +9,7 @@ import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } f
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
 import { getReadablePath } from "../../utils/path"
+import { parsePathFromArgsParam } from "../../utils/xml"
 import { countFileLines } from "../../integrations/misc/line-counter"
 import { readLines } from "../../integrations/misc/read-lines"
 import { extractTextFromFile, addLineNumbers, getSupportedBinaryFormats } from "../../integrations/misc/extract-text"
@@ -39,7 +40,7 @@ export async function simpleReadFileTool(
 	pushToolResult: PushToolResult,
 	_removeClosingTag: RemoveClosingTag,
 ) {
-	const filePath: string | undefined = block.params.path
+	const filePath: string | undefined = block.params.path || parsePathFromArgsParam(block.params)
 
 	// Check if the current model supports images
 	const modelInfo = cline.api.getModel().info

--- a/src/utils/__tests__/pathUtils.spec.ts
+++ b/src/utils/__tests__/pathUtils.spec.ts
@@ -1,0 +1,123 @@
+// kilocode_change - new file
+// npx vitest utils/__tests__/pathUtils.spec.ts
+
+import { parseParamsFromArgs } from "../pathUtils"
+
+describe("parseParamsFromArgs", () => {
+	describe("parameter extraction", () => {
+		it("should extract parameters from XML file tag", () => {
+			const args = `
+				<args>
+					<file>
+						<path>src/main.ts</path>
+						<content>console.log('hello')</content>
+					</file>
+				</args>
+			`
+
+			const result = parseParamsFromArgs(args, ["path", "content"])
+			expect(result).toEqual({
+				path: "src/main.ts",
+				content: "console.log('hello')",
+			})
+		})
+
+		it("should handle XML with multiple file tags", () => {
+			const args = `
+				<args>
+					<file>
+						<path>src/file1.ts</path>
+						<content>first file</content>
+					</file>
+					<file>
+						<path>src/file2.ts</path>
+						<content>second file</content>
+					</file>
+				</args>
+			`
+
+			const result = parseParamsFromArgs(args, ["path", "content"])
+			expect(result).toEqual({
+				path: "src/file1.ts",
+				content: "first file",
+			})
+		})
+
+		it("should handle XML with root-level parameters", () => {
+			const args = `
+				<args>
+					<path>src/main.ts</path>
+					<content>console.log('hello')</content>
+				</args>
+			`
+
+			const result = parseParamsFromArgs(args, ["path", "content"])
+			expect(result).toEqual({
+				path: "src/main.ts",
+				content: "console.log('hello')",
+			})
+		})
+
+		it("should handle missing parameters gracefully", () => {
+			const args = `
+				<args>
+					<file>
+						<path>src/main.ts</path>
+					</file>
+				</args>
+			`
+
+			const result = parseParamsFromArgs(args, ["path", "content"])
+			expect(result).toEqual({
+				path: "src/main.ts",
+				content: undefined,
+			})
+		})
+
+		it("should return empty object when no args provided", () => {
+			const result = parseParamsFromArgs(undefined, ["path"])
+			expect(result).toEqual({})
+		})
+
+		it("should return empty object when empty args provided", () => {
+			const result = parseParamsFromArgs("", ["path"])
+			expect(result).toEqual({})
+		})
+
+		it("should extract only specified parameters", () => {
+			const args = `
+				<args>
+					<file>
+						<path>src/main.ts</path>
+						<content>console.log('hello')</content>
+						<line>10</line>
+					</file>
+				</args>
+			`
+
+			const result = parseParamsFromArgs(args, ["path"])
+			expect(result).toEqual({
+				path: "src/main.ts",
+			})
+		})
+
+		it("should handle complex parameter names", () => {
+			const args = `
+				<args>
+					<file>
+						<target_file>src/main.ts</target_file>
+						<old_str>old code</old_str>
+						<new_str>new code</new_str>
+					</file>
+				</args>
+			`
+
+			const result = parseParamsFromArgs(args, ["target_file", "old_str", "new_str"])
+			expect(result).toEqual({
+				target_file: "src/main.ts",
+				old_str: "old code",
+				new_str: "new code",
+			})
+		})
+	})
+})

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -22,3 +22,36 @@ export function isPathOutsideWorkspace(filePath: string): boolean {
 		return absolutePath === folderPath || absolutePath.startsWith(folderPath + path.sep)
 	})
 }
+
+// kilocode_change
+/**
+ * Parses parameters from an XML-like string by extracting content between matching tags.
+ * This function searches for opening and closing tags (e.g., `<path>...</path>`) and extracts
+ * the content between them for each specified parameter name.
+ *
+ * @param args The XML-like string containing parameter tags to extract
+ * @param paramNames An array of parameter names to search for and extract
+ * @returns A record mapping parameter names to their extracted values, or undefined if not found
+ */
+export function parseParamsFromArgs(
+	args: string | undefined,
+	paramNames: string[],
+): Record<string, string | undefined> {
+	const parsedParams: Record<string, string | undefined> = {}
+
+	if (args) {
+		for (const name of paramNames) {
+			const tagOpen = `<${name}>`
+			const tagClose = `</${name}>`
+
+			const startIndex = args.indexOf(tagOpen)
+			const endIndex = args.indexOf(tagClose)
+
+			if (startIndex !== -1 && endIndex !== -1) {
+				parsedParams[name] = args.substring(startIndex + tagOpen.length, endIndex)
+			}
+		}
+	}
+
+	return parsedParams
+}

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -61,29 +61,3 @@ export function parseXmlForDiff(xmlString: string, stopNodes?: string[]): unknow
 	// Delegate to parseXml with processEntities disabled
 	return parseXml(xmlString, stopNodes, { processEntities: false })
 }
-
-/**
- * Extracts the file path from XML arguments parameter
- * @param params The parameters object that may contain an 'args' XML string
- * @returns The first file path found in the XML, or undefined if not found
- */
-export function parsePathFromArgsParam(params: Partial<Record<string, string>>): string | undefined {
-	const argsXmlTag = params.args
-
-	if (argsXmlTag) {
-		const parsed = parseXml(argsXmlTag) as any
-		const files = Array.isArray(parsed.file) ? parsed.file : [parsed.file].filter(Boolean)
-
-		for (const file of files) {
-			if (!file?.path) continue
-
-			return file.path
-		}
-
-		if (parsed.path) {
-			return parsed.path
-		}
-	}
-
-	return undefined
-}

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -61,3 +61,25 @@ export function parseXmlForDiff(xmlString: string, stopNodes?: string[]): unknow
 	// Delegate to parseXml with processEntities disabled
 	return parseXml(xmlString, stopNodes, { processEntities: false })
 }
+
+/**
+ * Extracts the file path from XML arguments parameter
+ * @param params The parameters object that may contain an 'args' XML string
+ * @returns The first file path found in the XML, or undefined if not found
+ */
+export function parsePathFromArgsParam(params: Partial<Record<string, string>>): string | undefined {
+	const argsXmlTag = params.args
+
+	if (argsXmlTag) {
+		const parsed = parseXml(argsXmlTag) as any
+		const files = Array.isArray(parsed.file) ? parsed.file : [parsed.file].filter(Boolean)
+
+		for (const file of files) {
+			if (!file?.path) continue
+
+			return file.path
+		}
+	}
+
+	return undefined
+}

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -79,6 +79,10 @@ export function parsePathFromArgsParam(params: Partial<Record<string, string>>):
 
 			return file.path
 		}
+
+		if (parsed.path) {
+			return parsed.path
+		}
 	}
 
 	return undefined


### PR DESCRIPTION
## Context

Some models incorrectly use the wrong XML format for their tool usage.
This behavior is very inconsistent and sometimes they do use the correct format.
This is most commonly experience with the dreaded error: **"Kilo Code tried to use `<tool>` without value for required parameter 'path'"**

**Issues**: #2273, #2347, #2855

## Implementation

I found that the issue is due to some models using this format:
```xml
<[tool_name]>
  <args>
    <file>
      <path>.</path>
    </file>
  </args>
</[tool_name]>
```
This is the correct format for the `read_file` tool, but for some reason, some models keep trying to use it for other tools as well.

To fix this, I added a parser that specifically checks for the `path` parameter inside the `args` tag.
~~The parser logic was partly taken from the existing implementation of the `read_file` tool.~~
This would let Kilo Code parse any model's tool usage format no matter if it's correct or not.

~~**Bonus**: In case some models use an even further incorrect XML format, I also added handling for the missing `<file>` tag inside `<args>`:~~
~~```xml~~
~~<[tool_name]>~~
~~  <args>~~
~~    <path>.</path>~~
~~  </args>~~
~~</[tool_name]>~~
~~```~~

To ensure that existing working functionality is not affected, all tool calls use the default `path` parameter first.
Only if it doesn't exist, which would normally result in the tool use error, would the parser be called.
~~`const relPath = params.path || parsePathFromArgsParam(params) || ""`~~

I updated the implementation to be able to parse any parameter, not just `path`.
```ts
export function parseParamsFromArgs(
	args: string | undefined,
	paramNames: string[],
): Record<string, string | undefined> {
```
**Usage**
```ts
const args = parseParamsFromArgs(params.args, ["path", "diff"])
const relPath = params.path || args.path || ""
const diff = params.diff || args.diff || ""
```

But to make it work, I had to use regular string parsing to find the relevant tags instead of XML parsing.
Using a proper XML parser fails due to some params, like diff, that have symbols that XML is not happy with (e.g. `<<<`, `>>>`)

**Note**: I made the parser output `undefined` instead of an empty string (`""`) when no `path` params are actually found because some tool implementation checks for both `undefined` and `""`. Instead of trying to change their logic, I just made the parser output `undefined` and just used `|| ""` for the tools that need an empty string.

### Affected tools

- `apply_diff`
- `codebase_search`
- `delete_file`
- `edit_file`
- `insert_content`
- `list_code_definition_names`
- `list_files`
- `read_file`
- `search_files`
- `write_to_file`

## Screenshots

| before | after |
| ------ | ----- |
| <img width="522" height="146" alt="image" src="https://github.com/user-attachments/assets/7d8fd195-b257-4999-a590-31b32a582b1e" /> | <img width="575" height="189" alt="image" src="https://github.com/user-attachments/assets/4d311642-3c05-4f58-a64f-fc340c2d8153" /> |

## How to Test

Due to the inconsistency of LLMs, this might be difficult to test.
But here's a basic test anyway:
- Ask Kilo Code to use any file/directory handling tool
- Check if the tool usage failed or not

To actually test that my implementation worked, I heavily utilized VSCode's breakpoints feature.
This let me actually know with certainty that the LLM used the "wrong" XML format, and that my fix indeed worked.
<img width="407" height="90" alt="image" src="https://github.com/user-attachments/assets/d18ada07-b8ef-4d10-9d38-d99c0907b7ed" />
