### PR TITLE
feat(ghost): support backward deletion in suggestion matching

### DIFF
--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -61,6 +61,16 @@ export function findMatchingSuggestion(
 				return fillInAtCursor.text.substring(typedContent.length)
 			}
 		}
+
+		// Check for backward deletion: user deleted characters from the end of the prefix
+		// The stored prefix should start with the current prefix (current is shorter)
+		if (fillInAtCursor.prefix.startsWith(prefix) && suffix === fillInAtCursor.suffix) {
+			// Extract the deleted portion of the prefix
+			const deletedContent = fillInAtCursor.prefix.substring(prefix.length)
+
+			// Return the deleted portion plus the original suggestion text
+			return deletedContent + fillInAtCursor.text
+		}
 	}
 
 	return null


### PR DESCRIPTION
Extend findMatchingSuggestion to handle cases where the user has backspaced/deleted characters from the end of the prefix. When the stored prefix starts with the current prefix, return the deleted portion plus the original suggestion text.

Example: If history has prefix='foo', suffix='bar', text='henk' and user is at prefix='f', suffix='bar', return 'oohenk'

Works especially well with https://github.com/Kilo-Org/kilocode/pull/4141