### PR TITLE
refactor(ghost): remove singleton pattern from GhostServiceManager

### DIFF
--- a/src/services/ghost/GhostServiceManager.ts
+++ b/src/services/ghost/GhostServiceManager.ts
@@ -12,7 +12,6 @@ import { TelemetryService } from "@roo-code/telemetry"
 import { ClineProvider } from "../../core/webview/ClineProvider"
 
 export class GhostServiceManager {
-	private static instance: GhostServiceManager | null = null
 	private readonly model: GhostModel
 	private readonly cline: ClineProvider
 	private readonly context: vscode.ExtensionContext
@@ -32,7 +31,7 @@ export class GhostServiceManager {
 	private newAutocompleteProvider: NewAutocompleteProvider | null = null
 	private inlineCompletionProviderDisposable: vscode.Disposable | null = null
 
-	private constructor(context: vscode.ExtensionContext, cline: ClineProvider) {
+	constructor(context: vscode.ExtensionContext, cline: ClineProvider) {
 		this.context = context
 		this.cline = cline
 
@@ -50,17 +49,6 @@ export class GhostServiceManager {
 		)
 
 		void this.load()
-	}
-
-	// Singleton Management
-	public static initialize(context: vscode.ExtensionContext, cline: ClineProvider): GhostServiceManager {
-		if (GhostServiceManager.instance) {
-			throw new Error(
-				"GhostServiceManager is already initialized. Restart VS code, or change this to return the cached instance.",
-			)
-		}
-		GhostServiceManager.instance = new GhostServiceManager(context, cline)
-		return GhostServiceManager.instance
 	}
 
 	public async load() {
@@ -318,7 +306,5 @@ export class GhostServiceManager {
 			this.newAutocompleteProvider.dispose()
 			this.newAutocompleteProvider = null
 		}
-
-		GhostServiceManager.instance = null // Reset singleton
 	}
 }

--- a/src/services/ghost/index.ts
+++ b/src/services/ghost/index.ts
@@ -4,7 +4,7 @@ import { GhostServiceManager } from "./GhostServiceManager"
 import { ClineProvider } from "../../core/webview/ClineProvider"
 
 export const registerGhostProvider = (context: vscode.ExtensionContext, cline: ClineProvider) => {
-	const ghost = GhostServiceManager.initialize(context, cline)
+	const ghost = new GhostServiceManager(context, cline)
 	context.subscriptions.push(ghost)
 
 	// Register GhostServiceManager Commands


### PR DESCRIPTION
## Summary

Removes the unnecessary singleton pattern from `GhostServiceManager`.

## Why this is safe

The singleton pattern was redundant because:

1. `registerGhostProvider()` is only called once from `activate()` in extension.ts, which VS Code guarantees runs only once per extension lifecycle

2. All command registrations and provider registrations inside `registerGhostProvider()` also only run once as part of the same activation flow

3. The error-throwing behavior on double-initialization was defensive but redundant - the call site already provides this guarantee

## Changes

- Remove static `instance` field and `initialize()` method
- Make constructor public instead of private  
- Remove singleton reset in `dispose()`
- Update call site to use `new GhostServiceManager()` directly

## Testing

All 9 existing tests pass.