### PR TITLE
fix: use PATH to find binaries in CLI mode

### DIFF
--- a/src/services/ripgrep/index.kilocode.ts
+++ b/src/services/ripgrep/index.kilocode.ts
@@ -1,3 +1,4 @@
+import { execSync } from "child_process"
 import path from "path"
 import { fileExistsAtPath } from "../../utils/fs"
 
@@ -14,5 +15,24 @@ export async function checkBunPath(vscodeAppRoot: string, binName: string) {
 		// Package not found via require.resolve
 	}
 
+	return undefined
+}
+
+export async function checkSystemPath(binName: string): Promise<string | undefined> {
+	// Try to find rg in system PATH using which/where
+	const command = process.platform === "win32" ? "where" : "which"
+	try {
+		const result = execSync(`${command} ${binName}`, {
+			encoding: "utf8",
+			stdio: ["pipe", "pipe", "pipe"],
+		}).trim()
+		// which/where may return multiple lines on Windows, take the first
+		const firstPath = result.split("\n")[0].trim()
+		if (firstPath && (await fileExistsAtPath(firstPath))) {
+			return firstPath
+		}
+	} catch {
+		// Command failed, binary not in PATH
+	}
 	return undefined
 }

--- a/src/services/ripgrep/index.ts
+++ b/src/services/ripgrep/index.ts
@@ -6,7 +6,7 @@ import * as vscode from "vscode"
 
 import { RooIgnoreController } from "../../core/ignore/RooIgnoreController"
 import { fileExistsAtPath } from "../../utils/fs"
-import { checkBunPath } from "./index.kilocode" // kilocode_change
+import { checkBunPath, checkSystemPath } from "./index.kilocode" // kilocode_change
 /*
 This file provides functionality to perform regex searches on files using ripgrep.
 Inspired by: https://github.com/DiscreteTom/vscode-ripgrep-utils
@@ -94,7 +94,8 @@ export async function getBinPath(vscodeAppRoot: string): Promise<string | undefi
 		(await checkPath("node_modules/vscode-ripgrep/bin")) ||
 		(await checkPath("node_modules.asar.unpacked/vscode-ripgrep/bin/")) ||
 		(await checkPath("node_modules.asar.unpacked/@vscode/ripgrep/bin/")) ||
-		(await checkBunPath(vscodeAppRoot, binName)) // kilocode_change
+		(await checkBunPath(vscodeAppRoot, binName)) ||
+		(await checkSystemPath(binName)) // kilocode_change: fallback to system PATH for CLI
 	)
 }
 


### PR DESCRIPTION
## Context

Before this patch, Kilo Code in CLI mode would get stuck at "Thinking...".
Looking at the logs, the reason for the behavior was explained by this:

```
2025-12-02T22:05:18.358Z [ExtensionHost] ERROR: Unhandled promise rejection from extension {"error":{"message":"Could not find ripgrep binary","name":"Error","stack":"Error: Could not find ripgrep binary\n    at cro
```

It turns out that, before this fix, Kilo Code in CLI mode would attempt to find the ripgrep binary in its own bundle instead of relying on the system binaries.

## Implementation

> [!WARNING]
> The code was completely generated by Claude Opus 4.5 - but it was tested and I can confirm that the fix works

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

Use the CLI, send a message

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
