### PR TITLE
Change default permissions of CLI `reading outside of workspace` to false

### DIFF
--- a/.changeset/every-knives-dig.md
+++ b/.changeset/every-knives-dig.md
@@ -1,5 +1,5 @@
 ---
-"@kilocode/cli": minor
+"@kilocode/cli": patch
 ---
 
 Default read permissions now require approval for read operations outside the workspace

--- a/.changeset/every-knives-dig.md
+++ b/.changeset/every-knives-dig.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Default read permissions now require approval for read operations outside the workspace

--- a/apps/kilocode-docs/docs/cli.md
+++ b/apps/kilocode-docs/docs/cli.md
@@ -218,57 +218,11 @@ kilocode --parallel --auto "improve xyz"
 kilocode --parallel --auto "improve abc"
 ```
 
-## Autonomous mode (Non-Interactive)
+## Auto-approval settings
 
-Autonomous mode allows Kilo Code to run in automated environments like CI/CD pipelines without requiring user interaction.
+Auto-approval allows the Kilo Code CLI to perform operations without first requiring user confirmation. These settings can either be built up over time in interactive mode, or by editing your config file using `kilocode config` or editing the file directly at `~/.kilocode/config.json`.
 
-```bash
-# Run in autonomous mode with a prompt
-kilocode --auto "Implement feature X"
-
-# Run in autonomous mode with piped input
-echo "Fix the bug in app.ts" | kilocode --auto
-
-# Run in autonomous mode with timeout (in seconds)
-kilocode --auto "Run tests" --timeout 300
-
-# Run in autonomous mode with JSON output for structured parsing
-kilocode --auto --json "Implement feature X"
-```
-
-### Autonomous Mode Behavior
-
-When running in Autonomous mode (`--auto` flag):
-
-1. **No User Interaction**: All approval requests are handled automatically based on configuration
-2. **Auto-Approval/Rejection**: Operations are approved or rejected based on your auto-approval settings
-3. **Follow-up Questions**: Automatically responded with a message instructing the AI to make autonomous decisions
-4. **Automatic Exit**: The CLI exits automatically when the task completes or times out
-
-### JSON Output Mode
-
-Use the `--json` flag with `--auto` to get structured JSON output instead of the default terminal UI. This is useful for programmatic integration and parsing of Kilo Code responses.
-
-```bash
-# Standard autonomous mode with terminal UI
-kilocode --auto "Fix the bug"
-
-# Autonomous mode with JSON output
-kilocode --auto --json "Fix the bug"
-
-# With piped input
-echo "Implement feature X" | kilocode --auto --json
-```
-
-**Requirements:**
-
-- The `--json` flag requires `--auto` mode to be enabled
-- Output is sent to stdout as structured JSON for easy parsing
-- Ideal for CI/CD pipelines and automated workflows
-
-### Auto-Approval Configuration
-
-Autonomous mode respects your auto-approval configuration. Edit your config file with `kilocode config` to customize:
+### Default auto-approval settings
 
 ```json
 {
@@ -276,7 +230,7 @@ Autonomous mode respects your auto-approval configuration. Edit your config file
 		"enabled": true,
 		"read": {
 			"enabled": true,
-			"outside": true
+			"outside": false
 		},
 		"write": {
 			"enabled": true,
@@ -359,6 +313,12 @@ The `execute.allowed` and `execute.denied` lists support hierarchical pattern ma
 }
 ```
 
+## Interactive Mode
+
+Interactive mode is the default mode when running Kilo Code without the `--auto` flag, designed to work interactively with a user through the console.
+
+In interactive mode Kilo Code will request approval for operations which have not been auto-approved, allowing the user to review and approve operations before they are executed, and optionally add them to the auto-approval list.
+
 ### Interactive Command Approval
 
 When running in interactive mode, command approval requests now show hierarchical options:
@@ -379,6 +339,58 @@ Selecting an "Always run" option will:
 3. Auto-approve matching commands in the future
 
 This allows you to progressively build your auto-approval rules without manually editing the config file.
+
+## Autonomous mode (Non-Interactive)
+
+Autonomous mode allows Kilo Code to run in automated environments like CI/CD pipelines without requiring user interaction.
+
+```bash
+# Run in autonomous mode with a prompt
+kilocode --auto "Implement feature X"
+
+# Run in autonomous mode with piped input
+echo "Fix the bug in app.ts" | kilocode --auto
+
+# Run in autonomous mode with timeout (in seconds)
+kilocode --auto "Run tests" --timeout 300
+
+# Run in autonomous mode with JSON output for structured parsing
+kilocode --auto --json "Implement feature X"
+```
+
+### Autonomous Mode Behavior
+
+When running in Autonomous mode (`--auto` flag):
+
+1. **No User Interaction**: All approval requests are handled automatically based on configuration
+2. **Auto-Approval/Rejection**: Operations are approved or rejected based on your auto-approval settings
+3. **Follow-up Questions**: Automatically responded with a message instructing the AI to make autonomous decisions
+4. **Automatic Exit**: The CLI exits automatically when the task completes or times out
+
+### JSON Output Mode
+
+Use the `--json` flag with `--auto` to get structured JSON output instead of the default terminal UI. This is useful for programmatic integration and parsing of Kilo Code responses.
+
+```bash
+# Standard autonomous mode with terminal UI
+kilocode --auto "Fix the bug"
+
+# Autonomous mode with JSON output
+kilocode --auto --json "Fix the bug"
+
+# With piped input
+echo "Implement feature X" | kilocode --auto --json
+```
+
+**Requirements:**
+
+- The `--json` flag requires `--auto` mode to be enabled
+- Output is sent to stdout as structured JSON for easy parsing
+- Ideal for CI/CD pipelines and automated workflows
+
+### Auto-Approval in Autonomous Mode
+
+Autonomous mode respects your [auto-approval configuration](#auto-approval-settings). Operations which are not auto-approved will not be allowed.
 
 ### Autonomous Mode Follow-up Questions
 

--- a/cli/src/config/__tests__/auto-approval.test.ts
+++ b/cli/src/config/__tests__/auto-approval.test.ts
@@ -9,7 +9,7 @@ describe("Auto Approval Configuration", () => {
 				enabled: true,
 				read: {
 					enabled: true,
-					outside: true,
+					outside: false,
 				},
 				write: {
 					enabled: true,

--- a/cli/src/config/defaults.ts
+++ b/cli/src/config/defaults.ts
@@ -8,7 +8,7 @@ export const DEFAULT_AUTO_APPROVAL: AutoApprovalConfig = {
 	enabled: true,
 	read: {
 		enabled: true,
-		outside: true,
+		outside: false,
 	},
 	write: {
 		enabled: true,


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

Changes default configuration file parameter for automatic approval of read operations across the full computer when using the CLI.

The reason is that I don't think most users understand when they install and try the CLI that it arrives with defaults that could cause more data than expected on the users drive to be sent to an LLM and potentially saved or exposed to third parties (like the LLM provider). I personally found this default disconcerting and surprising, and I imagine it could erode user trust in Kilo Code lead to unfortunate accidents. (For both Kilo and the user, as a result of trying to clean up)

###  Significant behavior change / change management

We need to be careful in rolling out this change, in whether it will impact users who have already been using the CLI for some time and may like the current behavior. It could be construed as a breaking change.

The ideal scenario would be that we change the default moving forward, while leaving current users with the behavior they have likely already gotten used to.

## How to Test

Ask Kilo Code CLI to perform an action that would require reading a file outside of it's current directory it was called in. See if it prompts for approval first, if so, this change worked.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
