### PR TITLE
fix: prevent error when autocomplete runs without configured API

### DIFF
--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -296,8 +296,9 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 
 		telemetry.captureSuggestionRequested(telemetryContext)
 
-		if (!this.model) {
-			// bail if no model is available, because if there is none, we also have no cache
+		if (!this.model || !this.model.hasValidCredentials()) {
+			// bail if no model is available or no valid API credentials configured
+			// this prevents errors when autocomplete is enabled but no provider is set up
 			return []
 		}
 


### PR DESCRIPTION
## Summary
Check `hasValidCredentials()` early in the inline completion provider to avoid throwing 'API handler is not initialized' error when autocomplete is enabled but no API provider is configured.

## Changes
- Add early return in `provideInlineCompletionItems_Internal` when model has no valid credentials
- Add `hasValidCredentials` mock to test file
- Add test cases for credentials validation behavior

## Problem
When autocomplete is enabled but no API provider is configured, the inline completion provider would throw an error:
```
Error: API handler is not initialized. Please check your configuration.
```

## Solution
The `GhostModel.hasValidCredentials()` method already exists and returns `true` only when both `apiHandler !== null` and `loaded === true`. The provider now checks this before attempting any completion work, silently returning an empty array instead of throwing an error.