### PR TITLE
refactor: use production code in ghost provider tester

### DIFF
--- a/src/services/ghost/classic-auto-complete/FillInTheMiddle.ts
+++ b/src/services/ghost/classic-auto-complete/FillInTheMiddle.ts
@@ -1,7 +1,6 @@
-import { AutocompleteInput, GhostContextProvider } from "../types"
-import { getProcessedSnippets } from "./getProcessedSnippets"
+import { AutocompleteInput } from "../types"
 import { getTemplateForModel } from "../../continuedev/core/autocomplete/templating/AutocompleteTemplate"
-import { FillInAtCursorSuggestion } from "./HoleFiller"
+import { FillInAtCursorSuggestion, ProcessedSnippetsResult } from "./HoleFiller"
 
 /**
  * Interface for models that can generate FIM (Fill-In-Middle) completions.
@@ -39,20 +38,18 @@ export interface FimCompletionResult {
 }
 
 export class FimPromptBuilder {
-	constructor(private contextProvider: GhostContextProvider) {}
-
 	/**
 	 * Build complete FIM prompt with all necessary data
+	 * @param snippetsResult - Pre-computed snippets from getProcessedSnippets
+	 * @param autocompleteInput - The autocomplete input context
+	 * @param modelName - The model name for template selection
 	 */
-	async getFimPrompts(autocompleteInput: AutocompleteInput, modelName: string): Promise<FimGhostPrompt> {
-		const { filepathUri, helper, snippetsWithUris, workspaceDirs } = await getProcessedSnippets(
-			autocompleteInput,
-			autocompleteInput.filepath,
-			this.contextProvider.contextService,
-			this.contextProvider.model,
-			this.contextProvider.ide,
-			this.contextProvider.ignoreController,
-		)
+	getFimPrompts(
+		snippetsResult: ProcessedSnippetsResult,
+		autocompleteInput: AutocompleteInput,
+		modelName: string,
+	): FimGhostPrompt {
+		const { filepathUri, helper, snippetsWithUris, workspaceDirs } = snippetsResult
 
 		// Use pruned prefix/suffix from HelperVars (token-limited based on DEFAULT_AUTOCOMPLETE_OPTS)
 		const prunedPrefixRaw = helper.prunedPrefix

--- a/src/services/ghost/classic-auto-complete/FillInTheMiddle.ts
+++ b/src/services/ghost/classic-auto-complete/FillInTheMiddle.ts
@@ -1,8 +1,26 @@
 import { AutocompleteInput, GhostContextProvider } from "../types"
 import { getProcessedSnippets } from "./getProcessedSnippets"
 import { getTemplateForModel } from "../../continuedev/core/autocomplete/templating/AutocompleteTemplate"
-import { GhostModel } from "../GhostModel"
 import { FillInAtCursorSuggestion } from "./HoleFiller"
+
+/**
+ * Interface for models that can generate FIM (Fill-In-Middle) completions.
+ * This allows both GhostModel and test implementations to be used.
+ */
+export interface FimCompletionModel {
+	generateFimResponse(
+		prefix: string,
+		suffix: string,
+		onChunk: (text: string) => void,
+		taskId?: string,
+	): Promise<{
+		cost: number
+		inputTokens: number
+		outputTokens: number
+		cacheWriteTokens: number
+		cacheReadTokens: number
+	}>
+}
 
 export interface FimGhostPrompt {
 	strategy: "fim"
@@ -67,7 +85,7 @@ export class FimPromptBuilder {
 	 * Execute FIM-based completion using the model
 	 */
 	async getFromFIM(
-		model: GhostModel,
+		model: FimCompletionModel,
 		prompt: FimGhostPrompt,
 		processSuggestion: (text: string) => FillInAtCursorSuggestion,
 	): Promise<FimCompletionResult> {

--- a/src/services/ghost/classic-auto-complete/HoleFiller.ts
+++ b/src/services/ghost/classic-auto-complete/HoleFiller.ts
@@ -1,8 +1,25 @@
 import { AutocompleteInput, GhostContextProvider } from "../types"
 import { getProcessedSnippets } from "./getProcessedSnippets"
 import { formatSnippets } from "../../continuedev/core/autocomplete/templating/formatting"
-import { GhostModel } from "../GhostModel"
 import { ApiStreamChunk } from "../../../api/transform/stream"
+
+/**
+ * Interface for models that can generate chat-based completions.
+ * This allows both GhostModel and test implementations to be used.
+ */
+export interface ChatCompletionModel {
+	generateResponse(
+		systemPrompt: string,
+		userPrompt: string,
+		onChunk: (chunk: ApiStreamChunk) => void,
+	): Promise<{
+		cost: number
+		inputTokens: number
+		outputTokens: number
+		cacheWriteTokens: number
+		cacheReadTokens: number
+	}>
+}
 
 export interface HoleFillerGhostPrompt {
 	strategy: "hole_filler"
@@ -193,7 +210,7 @@ Return the COMPLETION tags`
 	 * Execute chat-based completion using the model
 	 */
 	async getFromChat(
-		model: GhostModel,
+		model: ChatCompletionModel,
 		prompt: HoleFillerGhostPrompt,
 		processSuggestion: (text: string) => FillInAtCursorSuggestion,
 	): Promise<ChatCompletionResult> {

--- a/src/test-llm-autocompletion/mock-context-provider.ts
+++ b/src/test-llm-autocompletion/mock-context-provider.ts
@@ -1,21 +1,46 @@
-import { GhostContextProvider } from "../services/ghost/classic-auto-complete/GhostContextProvider.js"
+import { GhostContextProvider } from "../services/ghost/types.js"
 
 /**
  * Creates a mock context provider for standalone testing.
  * This provides minimal context without requiring a full VS Code environment.
+ *
+ * Note: This mock bypasses the real context retrieval and returns pre-computed
+ * prefix/suffix values. The contextService, ide, and model are mocked to provide
+ * the expected data structure.
  */
-export function createMockContextProvider(prefix: string, suffix: string, filepath: string): GhostContextProvider {
-	return {
-		getProcessedSnippets: async () => ({
-			filepathUri: `file://${filepath}`,
-			helper: {
-				filepath: `file://${filepath}`,
-				lang: { name: "typescript", singleLineComment: "//" },
-				prunedPrefix: prefix,
-				prunedSuffix: suffix,
-			},
-			snippetsWithUris: [],
-			workspaceDirs: [],
-		}),
-	} as unknown as GhostContextProvider
+export function createMockContextProvider(
+	prefix: string,
+	suffix: string,
+	filepath: string,
+): { contextProvider: GhostContextProvider; mockHelper: any } {
+	// Create a mock helper that will be returned by getProcessedSnippets
+	const mockHelper = {
+		filepath: `file://${filepath}`,
+		lang: { name: "typescript", singleLineComment: "//" },
+		prunedPrefix: prefix,
+		prunedSuffix: suffix,
+	}
+
+	// Create mock services that satisfy the GhostContextProvider interface
+	const mockContextService = {
+		initializeForFile: async () => {},
+	} as any
+
+	const mockIde = {
+		getWorkspaceDirs: async () => [],
+	} as any
+
+	const mockModel = {
+		getModelName: () => "test-model",
+		supportsFim: () => false,
+	} as any
+
+	const contextProvider: GhostContextProvider = {
+		contextService: mockContextService,
+		ide: mockIde,
+		model: mockModel,
+		ignoreController: undefined,
+	}
+
+	return { contextProvider, mockHelper }
 }

--- a/src/test-llm-autocompletion/mock-context-provider.ts
+++ b/src/test-llm-autocompletion/mock-context-provider.ts
@@ -1,0 +1,21 @@
+import { GhostContextProvider } from "../services/ghost/classic-auto-complete/GhostContextProvider.js"
+
+/**
+ * Creates a mock context provider for standalone testing.
+ * This provides minimal context without requiring a full VS Code environment.
+ */
+export function createMockContextProvider(prefix: string, suffix: string, filepath: string): GhostContextProvider {
+	return {
+		getProcessedSnippets: async () => ({
+			filepathUri: `file://${filepath}`,
+			helper: {
+				filepath: `file://${filepath}`,
+				lang: { name: "typescript", singleLineComment: "//" },
+				prunedPrefix: prefix,
+				prunedSuffix: suffix,
+			},
+			snippetsWithUris: [],
+			workspaceDirs: [],
+		}),
+	} as unknown as GhostContextProvider
+}

--- a/src/test-llm-autocompletion/prompt-builder.ts
+++ b/src/test-llm-autocompletion/prompt-builder.ts
@@ -1,0 +1,71 @@
+import {
+	HoleFiller,
+	HoleFillerGhostPrompt,
+	ProcessedSnippetsResult,
+} from "../services/ghost/classic-auto-complete/HoleFiller.js"
+import { FimPromptBuilder, FimGhostPrompt } from "../services/ghost/classic-auto-complete/FillInTheMiddle.js"
+import { AutocompleteInput } from "../services/ghost/types.js"
+import { HelperVars } from "../services/continuedev/core/autocomplete/util/HelperVars.js"
+import { Typescript } from "../services/continuedev/core/autocomplete/constants/AutocompleteLanguageInfo.js"
+import { DEFAULT_AUTOCOMPLETE_OPTS } from "../services/continuedev/core/util/parameters.js"
+
+/**
+ * Creates a mock ProcessedSnippetsResult for testing.
+ * This provides minimal context without requiring a full VS Code environment.
+ */
+export function createMockSnippetsResult(
+	prefix: string,
+	suffix: string,
+	filepath: string,
+	autocompleteInput: AutocompleteInput,
+): ProcessedSnippetsResult {
+	const filepathUri = filepath.startsWith("file://") ? filepath : `file://${filepath}`
+
+	// Create a mock HelperVars that satisfies the interface
+	const mockHelper: HelperVars = {
+		lang: Typescript, // Use the TypeScript language info which has all required fields
+		treePath: undefined,
+		workspaceUris: [],
+		fileContents: prefix + suffix,
+		fileLines: (prefix + suffix).split("\n"),
+		fullPrefix: prefix,
+		fullSuffix: suffix,
+		prunedPrefix: prefix,
+		prunedSuffix: suffix,
+		input: autocompleteInput,
+		options: DEFAULT_AUTOCOMPLETE_OPTS,
+		modelName: "test-model",
+		filepath: filepathUri,
+		pos: autocompleteInput.pos,
+		prunedCaretWindow: prefix + suffix,
+	}
+
+	return {
+		filepathUri,
+		helper: mockHelper,
+		snippetsWithUris: [],
+		workspaceDirs: [],
+	}
+}
+
+/**
+ * Build prompts for both FIM and HoleFiller strategies.
+ * Uses the production HoleFiller and FimPromptBuilder classes with mock data.
+ */
+export function buildTestPrompts(
+	prefix: string,
+	suffix: string,
+	languageId: string,
+	autocompleteInput: AutocompleteInput,
+	modelName: string,
+): { fim: FimGhostPrompt; holeFiller: HoleFillerGhostPrompt } {
+	const snippetsResult = createMockSnippetsResult(prefix, suffix, autocompleteInput.filepath, autocompleteInput)
+
+	const holeFiller = new HoleFiller()
+	const fimPromptBuilder = new FimPromptBuilder()
+
+	return {
+		fim: fimPromptBuilder.getFimPrompts(snippetsResult, autocompleteInput, modelName),
+		holeFiller: holeFiller.getPrompts(snippetsResult, autocompleteInput, languageId),
+	}
+}

--- a/src/test-llm-autocompletion/test-ghost-model.ts
+++ b/src/test-llm-autocompletion/test-ghost-model.ts
@@ -1,0 +1,100 @@
+import { LLMClient } from "./llm-client.js"
+import { ApiStreamChunk } from "../api/transform/stream.js"
+import { ChatCompletionModel } from "../services/ghost/classic-auto-complete/HoleFiller.js"
+import { FimCompletionModel } from "../services/ghost/classic-auto-complete/FillInTheMiddle.js"
+
+/**
+ * Check if a model supports FIM (Fill-In-Middle) completions.
+ * This mirrors the logic in KilocodeOpenrouterHandler.supportsFim()
+ */
+function modelSupportsFim(modelId: string): boolean {
+	return modelId.includes("codestral")
+}
+
+/**
+ * A test adapter that implements the ChatCompletionModel and FimCompletionModel interfaces using LLMClient.
+ * This allows the test harness to use the same production code paths
+ * (HoleFiller.getFromChat, FimPromptBuilder.getFromFIM) as the real provider.
+ */
+export class TestGhostModel implements ChatCompletionModel, FimCompletionModel {
+	private llmClient: LLMClient
+	private modelName: string
+
+	constructor() {
+		this.modelName = process.env.LLM_MODEL || "mistralai/codestral-2508"
+		this.llmClient = new LLMClient()
+	}
+
+	supportsFim(): boolean {
+		return modelSupportsFim(this.modelName)
+	}
+
+	getModelName(): string | undefined {
+		return this.modelName
+	}
+
+	getProviderDisplayName(): string | undefined {
+		return "kilocode-test"
+	}
+
+	hasValidCredentials(): boolean {
+		return true
+	}
+
+	/**
+	 * Generate FIM completion - matches GhostModel.generateFimResponse signature
+	 */
+	async generateFimResponse(
+		prefix: string,
+		suffix: string,
+		onChunk: (text: string) => void,
+		_taskId?: string,
+	): Promise<{
+		cost: number
+		inputTokens: number
+		outputTokens: number
+		cacheWriteTokens: number
+		cacheReadTokens: number
+	}> {
+		const response = await this.llmClient.sendFimCompletion(prefix, suffix)
+
+		// Call onChunk with the full completion (LLMClient doesn't stream)
+		onChunk(response.completion)
+
+		return {
+			cost: 0,
+			inputTokens: response.tokensUsed ?? 0,
+			outputTokens: 0,
+			cacheWriteTokens: 0,
+			cacheReadTokens: 0,
+		}
+	}
+
+	/**
+	 * Generate chat response - matches GhostModel.generateResponse signature
+	 */
+	async generateResponse(
+		systemPrompt: string,
+		userPrompt: string,
+		onChunk: (chunk: ApiStreamChunk) => void,
+	): Promise<{
+		cost: number
+		inputTokens: number
+		outputTokens: number
+		cacheWriteTokens: number
+		cacheReadTokens: number
+	}> {
+		const response = await this.llmClient.sendPrompt(systemPrompt, userPrompt)
+
+		// Call onChunk with the full response as a text chunk
+		onChunk({ type: "text", text: response.content })
+
+		return {
+			cost: 0,
+			inputTokens: response.tokensUsed ?? 0,
+			outputTokens: 0,
+			cacheWriteTokens: 0,
+			cacheReadTokens: 0,
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Refactored the ghost provider tester to use more production code, reducing duplication and ensuring the tester exercises the same code paths as production.

## Changes

1. **Extracted interfaces from production code**:
   - `ChatCompletionModel` - interface for chat-based completions (HoleFiller)
   - `FimCompletionModel` - interface for FIM completions (FillInTheMiddle)

2. **Created `TestGhostModel`** - an adapter that implements both interfaces using `LLMClient`, allowing the test harness to use the same code paths as production.

3. **Created `createMockContextProvider`** - extracted the mock context provider to a separate file.

4. **Simplified `GhostProviderTester`** - now uses:
   - Production `HoleFiller.getFromChat()` and `FimPromptBuilder.getFromFIM()` methods
   - `TestGhostModel.supportsFim()` for strategy detection (mirrors production logic)
   - Removed duplicated FIM detection logic and manual prompt/response handling

## Benefits

- Tester now exercises the same prompt building and response parsing code as production
- Changes to `HoleFiller` or `FimPromptBuilder` will automatically be tested
- Reduced code duplication from ~100 lines to ~70 lines
- Interfaces allow easy mocking in unit tests

## Testing

- All existing tests pass (`HoleFiller.test.ts`, `GhostInlineCompletionProvider.test.ts`)
- TypeScript compilation passes