### PR TITLE
massage autocomplete types

### DIFF
--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -7,6 +7,7 @@ import { ApiStreamChunk } from "../../api/transform/stream"
 import { AUTOCOMPLETE_PROVIDER_MODELS, checkKilocodeBalance } from "./utils/kilocode-utils"
 import { KilocodeOpenrouterHandler } from "../../api/providers/kilocode-openrouter"
 import { PROVIDERS } from "../../../webview-ui/src/components/settings/constants"
+import { ResponseMetaData } from "./types"
 
 // Convert PROVIDERS array to a lookup map for display names
 const PROVIDER_DISPLAY_NAMES = Object.fromEntries(PROVIDERS.map(({ value, label }) => [value, label])) as Record<
@@ -99,13 +100,7 @@ export class GhostModel {
 		suffix: string,
 		onChunk: (text: string) => void,
 		taskId?: string,
-	): Promise<{
-		cost: number
-		inputTokens: number
-		outputTokens: number
-		cacheWriteTokens: number
-		cacheReadTokens: number
-	}> {
+	): Promise<ResponseMetaData> {
 		if (!this.apiHandler) {
 			console.error("API handler is not initialized")
 			throw new Error("API handler is not initialized. Please check your configuration.")
@@ -150,13 +145,7 @@ export class GhostModel {
 		systemPrompt: string,
 		userPrompt: string,
 		onChunk: (chunk: ApiStreamChunk) => void,
-	): Promise<{
-		cost: number
-		inputTokens: number
-		outputTokens: number
-		cacheWriteTokens: number
-		cacheReadTokens: number
-	}> {
+	): Promise<ResponseMetaData> {
 		if (!this.apiHandler) {
 			console.error("API handler is not initialized")
 			throw new Error("API handler is not initialized. Please check your configuration.")

--- a/src/services/ghost/GhostStatusBar.ts
+++ b/src/services/ghost/GhostStatusBar.ts
@@ -1,16 +1,6 @@
 import * as vscode from "vscode"
 import { t } from "../../i18n"
-
-interface GhostStatusBarStateProps {
-	enabled?: boolean
-	model?: string
-	provider?: string
-	profileName?: string | null
-	hasValidToken: boolean
-	totalSessionCost: number
-	completionCount: number
-	sessionStartTime: number
-}
+import type { GhostStatusBarStateProps } from "./types"
 
 export class GhostStatusBar {
 	statusBar: vscode.StatusBarItem

--- a/src/services/ghost/classic-auto-complete/AutocompleteTelemetry.ts
+++ b/src/services/ghost/classic-auto-complete/AutocompleteTelemetry.ts
@@ -1,5 +1,8 @@
 import { TelemetryService } from "@roo-code/telemetry"
 import { TelemetryEventName } from "@roo-code/types"
+import type { AutocompleteContext, CacheMatchType } from "../types"
+
+export type { AutocompleteContext, CacheMatchType }
 
 function captureAutocompleteTelemetry(event: TelemetryEventName, properties?: Record<string, unknown>): void {
 	// also log to console:
@@ -12,20 +15,6 @@ function captureAutocompleteTelemetry(event: TelemetryEventName, properties?: Re
 			console.log(`Autocomplete Telemetry event: ${event}`)
 		}
 	}
-}
-
-/**
- * Common context properties for autocomplete telemetry events
- */
-export interface AutocompleteContext {
-	/** The programming language of the file being edited */
-	languageId: string
-	/** The model ID used for completion (e.g., "codestral", "qwen-coder") */
-	modelId?: string
-	/** The provider name (e.g., "kilocode", "openrouter") */
-	provider?: string
-	/** The completion strategy used */
-	strategy?: "fim" | "hole_filler"
 }
 
 /**
@@ -60,11 +49,6 @@ export function captureSuggestionFiltered(
 		...context,
 	})
 }
-
-/**
- * Cache match type indicating how the suggestion was matched from history
- */
-export type CacheMatchType = "exact" | "partial_typing" | "backward_deletion"
 
 /**
  * Capture when a suggestion is found in cache/history

--- a/src/services/ghost/classic-auto-complete/FillInTheMiddle.ts
+++ b/src/services/ghost/classic-auto-complete/FillInTheMiddle.ts
@@ -1,5 +1,5 @@
-import { AutocompleteInput, GhostContextProvider } from "../types"
-import { getProcessedSnippets } from "./getProcessedSnippets"
+import { AutocompleteInput, ResponseMetaData } from "../types"
+import { GhostContextProvider } from "./GhostContextProvider"
 import { getTemplateForModel } from "../../continuedev/core/autocomplete/templating/AutocompleteTemplate"
 import { GhostModel } from "../GhostModel"
 import { FillInAtCursorSuggestion } from "./HoleFiller"
@@ -11,13 +11,8 @@ export interface FimGhostPrompt {
 	prunedSuffix: string
 }
 
-export interface FimCompletionResult {
+export interface FimCompletionResult extends ResponseMetaData {
 	suggestion: FillInAtCursorSuggestion
-	cost: number
-	inputTokens: number
-	outputTokens: number
-	cacheWriteTokens: number
-	cacheReadTokens: number
 }
 
 export class FimPromptBuilder {
@@ -27,14 +22,8 @@ export class FimPromptBuilder {
 	 * Build complete FIM prompt with all necessary data
 	 */
 	async getFimPrompts(autocompleteInput: AutocompleteInput, modelName: string): Promise<FimGhostPrompt> {
-		const { filepathUri, helper, snippetsWithUris, workspaceDirs } = await getProcessedSnippets(
-			autocompleteInput,
-			autocompleteInput.filepath,
-			this.contextProvider.contextService,
-			this.contextProvider.model,
-			this.contextProvider.ide,
-			this.contextProvider.ignoreController,
-		)
+		const { filepathUri, helper, snippetsWithUris, workspaceDirs } =
+			await this.contextProvider.getProcessedSnippets(autocompleteInput, autocompleteInput.filepath)
 
 		// Use pruned prefix/suffix from HelperVars (token-limited based on DEFAULT_AUTOCOMPLETE_OPTS)
 		const prunedPrefixRaw = helper.prunedPrefix

--- a/src/services/ghost/classic-auto-complete/FillInTheMiddle.ts
+++ b/src/services/ghost/classic-auto-complete/FillInTheMiddle.ts
@@ -1,19 +1,15 @@
-import { AutocompleteInput, ResponseMetaData } from "../types"
-import { GhostContextProvider } from "./GhostContextProvider"
+import {
+	AutocompleteInput,
+	GhostContextProvider,
+	FimGhostPrompt,
+	FimCompletionResult,
+	FillInAtCursorSuggestion,
+} from "../types"
+import { getProcessedSnippets } from "./getProcessedSnippets"
 import { getTemplateForModel } from "../../continuedev/core/autocomplete/templating/AutocompleteTemplate"
 import { GhostModel } from "../GhostModel"
-import { FillInAtCursorSuggestion } from "./HoleFiller"
 
-export interface FimGhostPrompt {
-	strategy: "fim"
-	autocompleteInput: AutocompleteInput
-	formattedPrefix: string
-	prunedSuffix: string
-}
-
-export interface FimCompletionResult extends ResponseMetaData {
-	suggestion: FillInAtCursorSuggestion
-}
+export type { FimGhostPrompt, FimCompletionResult }
 
 export class FimPromptBuilder {
 	constructor(private contextProvider: GhostContextProvider) {}
@@ -22,8 +18,14 @@ export class FimPromptBuilder {
 	 * Build complete FIM prompt with all necessary data
 	 */
 	async getFimPrompts(autocompleteInput: AutocompleteInput, modelName: string): Promise<FimGhostPrompt> {
-		const { filepathUri, helper, snippetsWithUris, workspaceDirs } =
-			await this.contextProvider.getProcessedSnippets(autocompleteInput, autocompleteInput.filepath)
+		const { filepathUri, helper, snippetsWithUris, workspaceDirs } = await getProcessedSnippets(
+			autocompleteInput,
+			autocompleteInput.filepath,
+			this.contextProvider.contextService,
+			this.contextProvider.model,
+			this.contextProvider.ide,
+			this.contextProvider.ignoreController,
+		)
 
 		// Use pruned prefix/suffix from HelperVars (token-limited based on DEFAULT_AUTOCOMPLETE_OPTS)
 		const prunedPrefixRaw = helper.prunedPrefix

--- a/src/services/ghost/classic-auto-complete/HoleFiller.ts
+++ b/src/services/ghost/classic-auto-complete/HoleFiller.ts
@@ -1,25 +1,16 @@
-import { AutocompleteInput, ResponseMetaData } from "../types"
-import { GhostContextProvider } from "./GhostContextProvider"
+import {
+	AutocompleteInput,
+	GhostContextProvider,
+	HoleFillerGhostPrompt,
+	FillInAtCursorSuggestion,
+	ChatCompletionResult,
+} from "../types"
+import { getProcessedSnippets } from "./getProcessedSnippets"
 import { formatSnippets } from "../../continuedev/core/autocomplete/templating/formatting"
 import { GhostModel } from "../GhostModel"
 import { ApiStreamChunk } from "../../../api/transform/stream"
 
-export interface HoleFillerGhostPrompt {
-	strategy: "hole_filler"
-	autocompleteInput: AutocompleteInput
-	systemPrompt: string
-	userPrompt: string
-}
-
-export interface FillInAtCursorSuggestion {
-	text: string
-	prefix: string
-	suffix: string
-}
-
-export interface ChatCompletionResult extends ResponseMetaData {
-	suggestion: FillInAtCursorSuggestion
-}
+export type { HoleFillerGhostPrompt, FillInAtCursorSuggestion, ChatCompletionResult }
 
 /**
  * Parse the response - only handles responses with <COMPLETION> tags
@@ -163,9 +154,13 @@ Provide a subtle, non-intrusive completion after a typing pause.
 	 * Build minimal prompt for auto-trigger with optional context
 	 */
 	async getUserPrompt(autocompleteInput: AutocompleteInput, languageId: string): Promise<string> {
-		const { helper, snippetsWithUris, workspaceDirs } = await this.contextProvider.getProcessedSnippets(
+		const { helper, snippetsWithUris, workspaceDirs } = await getProcessedSnippets(
 			autocompleteInput,
 			autocompleteInput.filepath,
+			this.contextProvider.contextService,
+			this.contextProvider.model,
+			this.contextProvider.ide,
+			this.contextProvider.ignoreController,
 		)
 		const formattedContext = formatSnippets(helper, snippetsWithUris, workspaceDirs)
 		// Use pruned prefix/suffix from HelperVars (token-limited based on DEFAULT_AUTOCOMPLETE_OPTS)

--- a/src/services/ghost/classic-auto-complete/HoleFiller.ts
+++ b/src/services/ghost/classic-auto-complete/HoleFiller.ts
@@ -1,5 +1,5 @@
-import { AutocompleteInput, GhostContextProvider } from "../types"
-import { getProcessedSnippets } from "./getProcessedSnippets"
+import { AutocompleteInput, ResponseMetaData } from "../types"
+import { GhostContextProvider } from "./GhostContextProvider"
 import { formatSnippets } from "../../continuedev/core/autocomplete/templating/formatting"
 import { GhostModel } from "../GhostModel"
 import { ApiStreamChunk } from "../../../api/transform/stream"
@@ -17,13 +17,8 @@ export interface FillInAtCursorSuggestion {
 	suffix: string
 }
 
-export interface ChatCompletionResult {
+export interface ChatCompletionResult extends ResponseMetaData {
 	suggestion: FillInAtCursorSuggestion
-	cost: number
-	inputTokens: number
-	outputTokens: number
-	cacheWriteTokens: number
-	cacheReadTokens: number
 }
 
 /**
@@ -168,13 +163,9 @@ Provide a subtle, non-intrusive completion after a typing pause.
 	 * Build minimal prompt for auto-trigger with optional context
 	 */
 	async getUserPrompt(autocompleteInput: AutocompleteInput, languageId: string): Promise<string> {
-		const { helper, snippetsWithUris, workspaceDirs } = await getProcessedSnippets(
+		const { helper, snippetsWithUris, workspaceDirs } = await this.contextProvider.getProcessedSnippets(
 			autocompleteInput,
 			autocompleteInput.filepath,
-			this.contextProvider.contextService,
-			this.contextProvider.model,
-			this.contextProvider.ide,
-			this.contextProvider.ignoreController,
 		)
 		const formattedContext = formatSnippets(helper, snippetsWithUris, workspaceDirs)
 		// Use pruned prefix/suffix from HelperVars (token-limited based on DEFAULT_AUTOCOMPLETE_OPTS)

--- a/src/services/ghost/types.ts
+++ b/src/services/ghost/types.ts
@@ -11,6 +11,17 @@ import { ContextRetrievalService } from "../continuedev/core/autocomplete/contex
 import { VsCodeIde } from "../continuedev/core/vscode-test-harness/src/VSCodeIde"
 import { GhostModel } from "./GhostModel"
 
+/**
+ * Metadata returned from LLM API responses including cost and token usage
+ */
+export interface ResponseMetaData {
+	cost: number
+	inputTokens: number
+	outputTokens: number
+	cacheWriteTokens: number
+	cacheReadTokens: number
+}
+
 export interface GhostSuggestionContext {
 	document: vscode.TextDocument
 	range?: vscode.Range | vscode.Selection

--- a/src/services/ghost/utils/kilocode-utils.ts
+++ b/src/services/ghost/utils/kilocode-utils.ts
@@ -1,5 +1,8 @@
 import { getKiloBaseUriFromToken } from "@roo-code/types"
-import { ProviderSettingsManager } from "../../../core/config/ProviderSettingsManager"
+import { AUTOCOMPLETE_PROVIDER_MODELS, AutocompleteProviderKey } from "../types"
+
+export { AUTOCOMPLETE_PROVIDER_MODELS }
+export type { AutocompleteProviderKey }
 
 /**
  * Check if the Kilocode account has a positive balance
@@ -35,11 +38,3 @@ export async function checkKilocodeBalance(kilocodeToken: string, kilocodeOrgani
 		return false
 	}
 }
-
-export const AUTOCOMPLETE_PROVIDER_MODELS = new Map([
-	["mistral", "codestral-latest"],
-	["kilocode", "mistralai/codestral-2508"],
-	["openrouter", "mistralai/codestral-2508"],
-	["bedrock", "mistral.codestral-2508-v1:0"],
-] as const)
-export type AutocompleteProviderKey = typeof AUTOCOMPLETE_PROVIDER_MODELS extends Map<infer K, any> ? K : never


### PR DESCRIPTION
Extract `ResponseMetaData` type for LLM response metadata (cost, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens) to reduce duplication across ghost service files.