### PR TITLE
Revert HTTP-Referer from kilo.ai back to kilocode.ai

### DIFF
--- a/src/api/providers/__tests__/constants.spec.ts
+++ b/src/api/providers/__tests__/constants.spec.ts
@@ -11,7 +11,7 @@ describe("DEFAULT_HEADERS", () => {
 	})
 
 	it("should have correct HTTP-Referer value", () => {
-		expect(DEFAULT_HEADERS["HTTP-Referer"]).toBe("https://kilo.ai")
+		expect(DEFAULT_HEADERS["HTTP-Referer"]).toBe("https://kilocode.ai")
 	})
 
 	it("should have correct X-Title value", () => {

--- a/src/api/providers/constants.ts
+++ b/src/api/providers/constants.ts
@@ -2,7 +2,7 @@ import { X_KILOCODE_VERSION } from "../../shared/kilocode/headers"
 import { Package } from "../../shared/package"
 
 export const DEFAULT_HEADERS = {
-	"HTTP-Referer": "https://kilo.ai",
+	"HTTP-Referer": "https://kilocode.ai",
 	"X-Title": "Kilo Code",
 	[X_KILOCODE_VERSION]: Package.version,
 	"User-Agent": `Kilo-Code/${Package.version}`,


### PR DESCRIPTION
HTTP-Referer is used by Openrouter to identify our application, so use kilocode.ai for now.
