### PR TITLE
Use custom backend URL even if dev token is present

### DIFF
--- a/.changeset/better-stamps-fall.md
+++ b/.changeset/better-stamps-fall.md
@@ -1,0 +1,5 @@
+---
+"@roo-code/types": patch
+---
+
+Fix to respect KILOCODE_BACKEND_BASE_URL when dev tokens are present

--- a/packages/types/src/kilocode/kilocode.ts
+++ b/packages/types/src/kilocode/kilocode.ts
@@ -57,7 +57,16 @@ export function getKiloBaseUriFromToken(kilocodeToken?: string) {
 				typeof atob !== "undefined" ? atob(payload_string) : Buffer.from(payload_string, "base64").toString()
 			const payload = JSON.parse(payload_json)
 			//note: this is UNTRUSTED, so we need to make sure we're OK with this being manipulated by an attacker; e.g. we should not read uri's from the JWT directly.
-			if (payload.env === "development") return "http://localhost:3000"
+			// For dev tokens, check if KILOCODE_BACKEND_BASE_URL is set to a custom value
+			if (payload.env === "development") {
+				const baseUrl = getGlobalKilocodeBackendUrl()
+				// This allows pointing to custom dev backends beyond just those accessible on localhost
+				// (e.g., 192.168.x.x, staging servers)
+				if (baseUrl !== DEFAULT_KILOCODE_BACKEND_URL) {
+					return baseUrl
+				}
+				return "http://localhost:3000"
+			}
 		} catch (_error) {
 			console.warn("Failed to get base URL from Kilo Code token")
 		}


### PR DESCRIPTION
## Context

When setting KILOCODE_BACKEND_BASE_URL in a kilocode cli invocation AND using a dev token - we'd ignore KILOCODE_BACKEND_BASE_URL and always return `http://localhost:3000` as the base. 

This meant that if you were in a dev environment where kilocode was running in a sandbox or remote container, you had no way of actually overriding the URL to point at your actual kilocode-backend instance.  

## Implementation

Updated getKiloBaseUriFromToken to respect KILOCODE_BACKEND_BASE_URL when dev tokens are present.

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

- Spin up a kilocode cli instance in a container
- Set KILOCODE_BACKEND_BASE_URL to point to your backend (e.g. http://192.168.100.42:3000)

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
