### PR TITLE
Don't clobber KILOCODE_BACKEND_BASE_URL by assuming it must be localhost

### DIFF
--- a/.changeset/fluffy-roses-behave.md
+++ b/.changeset/fluffy-roses-behave.md
@@ -1,5 +1,0 @@
----
-"@roo-code/types": patch
----
-
-Fix: don't clobber KILOCODE_BACKEND_BASE_URL by assuming it must be localhost

--- a/.changeset/fluffy-roses-behave.md
+++ b/.changeset/fluffy-roses-behave.md
@@ -1,0 +1,5 @@
+---
+"@roo-code/types": patch
+---
+
+Fix: don't clobber KILOCODE_BACKEND_BASE_URL by assuming it must be localhost

--- a/packages/types/src/__tests__/kilocode.test.ts
+++ b/packages/types/src/__tests__/kilocode.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, afterEach } from "vitest"
 import {
 	ghostServiceSettingsSchema,
 	getAppUrl,
+	getApiUrl,
 	getKiloUrlFromToken,
 	getExtensionConfigUrl,
 } from "../kilocode/kilocode.js"
@@ -65,6 +66,34 @@ describe("URL functions", () => {
 		})
 		it("should use subdomain structure for production", () => {
 			expect(getExtensionConfigUrl()).toBe("https://api.kilo.ai/extension-config.json")
+		})
+		it("should use path structure for custom backend URLs", () => {
+			process.env.KILOCODE_BACKEND_BASE_URL = "http://192.168.200.70:3000"
+			expect(getExtensionConfigUrl()).toBe("http://192.168.200.70:3000/extension-config.json")
+		})
+	})
+
+	describe("getApiUrl", () => {
+		it("should handle production URLs with api subdomain", () => {
+			expect(getApiUrl()).toBe("https://api.kilo.ai/")
+			expect(getApiUrl("/trpc/cliSessions.get")).toBe("https://api.kilo.ai/trpc/cliSessions.get")
+			expect(getApiUrl("/api/profile")).toBe("https://api.kilo.ai/api/profile")
+		})
+
+		it("should handle localhost development URLs", () => {
+			process.env.KILOCODE_BACKEND_BASE_URL = "http://localhost:3000"
+
+			expect(getApiUrl()).toBe("http://localhost:3000/")
+			expect(getApiUrl("/api/trpc/cliSessions.get")).toBe("http://localhost:3000/api/trpc/cliSessions.get")
+			expect(getApiUrl("/api/profile")).toBe("http://localhost:3000/api/profile")
+		})
+
+		it("should handle custom backend URLs (non-localhost)", () => {
+			process.env.KILOCODE_BACKEND_BASE_URL = "http://192.168.200.70:3000"
+
+			expect(getApiUrl()).toBe("http://192.168.200.70:3000/")
+			expect(getApiUrl("/api/trpc/cliSessions.get")).toBe("http://192.168.200.70:3000/api/trpc/cliSessions.get")
+			expect(getApiUrl("/api/profile")).toBe("http://192.168.200.70:3000/api/profile")
 		})
 	})
 

--- a/packages/types/src/kilocode/kilocode.ts
+++ b/packages/types/src/kilocode/kilocode.ts
@@ -119,8 +119,8 @@ export function getAppUrl(path: string = ""): string {
 export function getApiUrl(path: string = ""): string {
 	const backend = getGlobalKilocodeBackendUrl()
 
-	// In development (localhost), API is served from the same origin (no /api prefix needed)
-	if (backend.includes("localhost")) {
+	// If using a custom backend (not the default production URL), use it directly
+	if (backend !== DEFAULT_KILOCODE_BACKEND_URL) {
 		return new URL(path, backend).toString()
 	}
 
@@ -136,7 +136,7 @@ export function getApiUrl(path: string = ""): string {
 export function getExtensionConfigUrl(): string {
 	try {
 		const backend = getGlobalKilocodeBackendUrl()
-		if (backend.includes("localhost")) {
+		if (backend !== DEFAULT_KILOCODE_BACKEND_URL) {
 			return getAppUrl("/extension-config.json")
 		} else {
 			return "https://api.kilo.ai/extension-config.json"


### PR DESCRIPTION
## Context


Don't clobber KILOCODE_BACKEND_BASE_URL by assuming it must be localhost when generating api and extension config url's.


## Implementation

Instead of checking if backend URL is localhost, instead check if backend is not DEFAULT_KILOCODE_BACKEND_URL (which is the only scenario where we should rewrite). 

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test


## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
