### PR TITLE
Fully revert tests after https://github.com/Kilo-Org/kilocode/pull/4210

### DIFF
--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -111,7 +111,7 @@ describe("OpenAiHandler", () => {
 				baseURL: expect.any(String),
 				apiKey: expect.any(String),
 				defaultHeaders: {
-					"HTTP-Referer": "https://kilo.ai",
+					"HTTP-Referer": "https://kilocode.ai",
 					"X-Title": "Kilo Code",
 					"X-KiloCode-Version": Package.version,
 					"User-Agent": `Kilo-Code/${Package.version}`,

--- a/src/api/providers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/__tests__/openrouter.spec.ts
@@ -72,7 +72,7 @@ describe("OpenRouterHandler", () => {
 			baseURL: "https://openrouter.ai/api/v1",
 			apiKey: mockOptions.openRouterApiKey,
 			defaultHeaders: {
-				"HTTP-Referer": "https://kilo.ai",
+				"HTTP-Referer": "https://kilocode.ai",
 				"X-Title": "Kilo Code",
 				"X-KiloCode-Version": Package.version,
 				"User-Agent": `Kilo-Code/${Package.version}`,

--- a/src/api/providers/__tests__/requesty.spec.ts
+++ b/src/api/providers/__tests__/requesty.spec.ts
@@ -57,7 +57,7 @@ describe("RequestyHandler", () => {
 			baseURL: "https://router.requesty.ai/v1",
 			apiKey: mockOptions.requestyApiKey,
 			defaultHeaders: {
-				"HTTP-Referer": "https://kilo.ai",
+				"HTTP-Referer": "https://kilocode.ai",
 				"X-Title": "Kilo Code",
 				"X-KiloCode-Version": Package.version,
 				"User-Agent": `Kilo-Code/${Package.version}`,
@@ -73,7 +73,7 @@ describe("RequestyHandler", () => {
 			baseURL: "https://custom.requesty.ai/v1",
 			apiKey: mockOptions.requestyApiKey,
 			defaultHeaders: {
-				"HTTP-Referer": "https://kilo.ai",
+				"HTTP-Referer": "https://kilocode.ai",
 				"X-Title": "Kilo Code",
 				"X-KiloCode-Version": Package.version,
 				"User-Agent": `Kilo-Code/${Package.version}`,

--- a/src/api/providers/__tests__/vercel-ai-gateway.spec.ts
+++ b/src/api/providers/__tests__/vercel-ai-gateway.spec.ts
@@ -96,7 +96,7 @@ describe("VercelAiGatewayHandler", () => {
 			apiKey: mockOptions.vercelAiGatewayApiKey,
 			// kilocode_change start
 			defaultHeaders: expect.objectContaining({
-				"HTTP-Referer": "https://kilo.ai",
+				"HTTP-Referer": "https://kilocode.ai",
 				"X-Title": "Kilo Code",
 				"User-Agent": expect.stringContaining("Kilo-Code/"),
 			}),


### PR DESCRIPTION
## Context

https://github.com/Kilo-Org/kilocode/pull/4210 reverted the HTTP Referrer used in constants.ts, which was originally changed as part of https://github.com/Kilo-Org/kilocode/pull/4195 , this finishes reverting the remaining test expectations.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
