### PR TITLE
Fix vscode webview

### DIFF
--- a/.changeset/tasty-insects-arrive.md
+++ b/.changeset/tasty-insects-arrive.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix VSCode webview assets

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/webview/WebViewManager.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/webview/WebViewManager.kt
@@ -314,9 +314,6 @@ class WebViewManager(var project: Project) : Disposable, ThemeChangeListener {
     fun updateWebViewHtml(data: WebviewHtmlUpdateData) {
         data.htmlContent = data.htmlContent.replace("/jetbrains/resources/kilocode/", "./")
         data.htmlContent = data.htmlContent.replace("<html lang=\"en\">", "<html lang=\"en\" style=\"background: var(--vscode-sideBar-background);\">")
-        // Replace index.css/index.js with main.css/main.js to match actual build output
-        data.htmlContent = data.htmlContent.replace("assets/index.css", "assets/main.css")
-        data.htmlContent = data.htmlContent.replace("assets/index.js", "assets/main.js")
         val encodedState = getLatestWebView()?.state.toString().replace("\"", "\\\"")
         val mRst = """<script\s+nonce="([A-Za-z0-9]{32})">""".toRegex().find(data.htmlContent)
         val str = mRst?.value ?: ""

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -121,7 +121,7 @@ export default defineConfig(({ mode }) => {
 			cssCodeSplit: true, // kilocode_change: enable CSS code splitting so CSS files are generated
 			rollupOptions: {
 				input: {
-					main: resolve(__dirname, "index.html"),
+					index: resolve(__dirname, "index.html"),
 					"agent-manager": resolve(__dirname, "agent-manager.html"), // kilocode_change
 				},
 				external: ["vscode"], // kilocode_change: we inadvertently import vscode into the webview: @roo/modes => src/shared/modes => ../core/prompts/sections/custom-instructions


### PR DESCRIPTION
## Context

The VSCode extension's webview loader (ClineProvider.ts) has hardcoded references to these specific asset filenames (lines 1294-1301). This is necessary because:

VSCode Webview Architecture: Unlike web applications, VSCode webviews cannot dynamically discover assets. The extension must know the exact file paths at compile time to generate proper webview URIs.

Vite Build Contract: The Vite configuration (vite.config.ts lines 129-150) uses [name] placeholders that resolve to the entry point names. Since our entry point is named index (line 124), Vite generates index.js and index.css.

Security Requirements: VSCode's Content Security Policy requires explicit URI references. The extension converts file paths to secure webview URIs using webview.asWebviewUri(), which requires knowing the exact filenames beforehand.

Multi-Entry Support: The build supports multiple entry points (index and agent-manager), each generating their own JS/CSS bundles. The main webview uses the index entry point, hence requiring index.js and index.css.

Any changes to the Vite build configuration that modify these output filenames would break the webview loading mechanism and require corresponding updates to ClineProvider.ts.

## Implementation

- Fix the name of the webview input

## Screenshots

<img width="3828" height="2160" alt="image" src="https://github.com/user-attachments/assets/16068358-3ddf-4bc9-b575-fd5ff3deb402" />


- Tested VSIX on Cursor
- Tested Zip on Jetbrains


