### PR TITLE
Improve jetbrains docs

### DIFF
--- a/apps/kilocode-docs/docs/getting-started/installing.md
+++ b/apps/kilocode-docs/docs/getting-started/installing.md
@@ -4,12 +4,13 @@ sidebar_label: Installing Kilo Code
 
 # Installing Kilo Code
 
-Kilo Code is a VS Code extension that brings AI-powered coding assistance directly to your editor. Install using one of these methods:
+Kilo Code brings AI-powered coding assistance directly to your editor. Install using one of these methods:
 
 - [**VS Code Marketplace (Recommended)**](#vs-code-marketplace) - fastest method for standard VS Code users
 - [**Cursor Marketplace**](#cursor-marketplace) - recommended way for Cursor users
 - [**Open VSX Registry**](#open-vsx-registry) - for VS Code-compatible editors like VSCodium or Windsurf
 - [**Manually install the .vsix file**](#manual-installation-from-vsix) - direct installation from the GitHub Release
+- [**JetBrains IDEs**](#jetbrains-ides) - for IntelliJ IDEA, WebStorm, PyCharm, Android Studio, and other JetBrains IDEs
 
 ## VS Code Marketplace
 
@@ -85,6 +86,55 @@ If you prefer to download and install the VSIX file directly:
 
 <img src="/docs/img/installing/installing-2.png" alt="VS Code's Install from VSIX dialog" width="400" />
 *Installing Kilo Code using VS Code's "Install from VSIX" dialog*
+
+## JetBrains IDEs
+
+Kilo Code is also available as a plugin for JetBrains IDEs including IntelliJ IDEA, WebStorm, PyCharm, Android Studio, PhpStorm, RubyMine, CLion, GoLand, DataGrip, and Rider.
+
+### Prerequisites
+
+Before installing the Kilo Code plugin, ensure you have:
+
+1. **JetBrains Toolbox (Recommended):**
+
+    - Download from [https://www.jetbrains.com/toolbox-app/](https://www.jetbrains.com/toolbox-app/)
+    - Toolbox is required for authentication callbacks to work properly
+    - Without Toolbox, you'll need to manually configure API keys
+
+2. **Node.js:**
+    - Download LTS version from [https://nodejs.org/](https://nodejs.org/)
+    - Required for the extension's backend services
+
+### Installation Steps
+
+1. **Open your JetBrains IDE**
+
+2. **Access Plugin Settings:**
+
+    - **Windows/Linux:** File → Settings → Plugins
+    - **macOS:** [IDE Name] → Settings → Plugins
+
+3. **Search for Kilo Code:**
+
+    - Click the "Marketplace" tab
+    - Search for "Kilo Code"
+
+4. **Install the Plugin:**
+
+    - Click **Install** on the Kilo Code plugin
+    - Accept any required permissions
+
+5. **Restart your IDE:**
+
+    - Restart when prompted to complete the installation, if needed
+
+6. **Find Kilo Code:**
+    - Look for the Kilo Code icon in the right sidebar
+    - Click to open the Kilo Code panel
+
+### Troubleshooting JetBrains Installation
+
+For JetBrains-specific issues such as JCEF problems, authentication failures, or Node.js configuration, see the [JetBrains Troubleshooting Guide](/docs/jetbrains-troubleshooting).
 
 ## Troubleshooting
 

--- a/apps/kilocode-docs/docs/jetbrains-troubleshooting.md
+++ b/apps/kilocode-docs/docs/jetbrains-troubleshooting.md
@@ -111,4 +111,52 @@ For WebStorm, PyCharm, PhpStorm, RubyMine, CLion, GoLand, DataGrip, and Rider:
     - Navigate to Advanced Settings
     - Enable any JCEF-related options
 
+## Authentication Issues
+
+### Incomplete Kilo Code authentication
+
+**Important:** The Kilo Code authentication callback requires [JetBrains Toolbox](https://www.jetbrains.com/toolbox-app/) to be installed on your system.
+
+#### Why Toolbox is Required
+
+When you authenticate with Kilo Code, the browser redirects back to your IDE using a special URL scheme (`jetbrains://`). This URL scheme is **only registered on your system when JetBrains Toolbox is installed**. Without Toolbox:
+
+- The authentication redirect will fail silently
+- Your browser may show an error like "Cannot open link" or "No application is set to open this link"
+- The token will not be passed back to your IDE
+
+#### Symptoms of Missing Toolbox
+
+If you're experiencing authentication issues, you may notice:
+
+1. **Browser doesn't redirect after login** - After entering your credentials, the browser stays on the authentication page or shows an error
+2. **"Open in IDE" prompts don't work** - Links that should open in your JetBrains IDE do nothing
+3. **No logs in the IDE** - The authentication handler never fires because the URL scheme isn't registered
+
+#### Installing JetBrains Toolbox
+
+1. **Download JetBrains Toolbox:**
+
+    - Visit [https://www.jetbrains.com/toolbox-app/](https://www.jetbrains.com/toolbox-app/)
+    - Download the installer for your operating system
+
+2. **Install and Launch:**
+
+    - Run the installer
+    - Launch JetBrains Toolbox
+
+3. **Retry Authentication:**
+    - Return to Kilo Code in your JetBrains IDE
+    - Attempt the authentication flow again
+    - The `jetbrains://` URL should now work correctly
+
+#### Alternative: Manual Token Entry
+
+If you cannot install JetBrains Toolbox, you can manually configure your API provider:
+
+1. Go to Kilo Code Settings
+2. Select your API provider
+3. Manually enter your API key or authentication token
+4. Save your settings
+
 _For general Kilo Code support and documentation, visit [kilo.ai/docs](https://kilo.ai/docs)_


### PR DESCRIPTION
## Context

Documentation change which adds Jet Brains extension to the getting started page, and an additional troubleshooting entry for auth failures if you don't have the toolbox installed.

## Implementation

Docs-only change.
