### PR TITLE
Add a global ignore list for read operations

### DIFF
--- a/.changeset/pretty-pants-end.md
+++ b/.changeset/pretty-pants-end.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": minor
+"@roo-code/types": patch
+---
+
+Adds the concept of a global list of ignored file types for privacy and security

--- a/.changeset/pretty-pants-end.md
+++ b/.changeset/pretty-pants-end.md
@@ -1,6 +1,5 @@
 ---
 "kilo-code": minor
-"@roo-code/types": patch
 ---
 
 Adds the concept of a global list of ignored file types for privacy and security

--- a/apps/kilocode-docs/docs/features/auto-approving-actions.md
+++ b/apps/kilocode-docs/docs/features/auto-approving-actions.md
@@ -87,7 +87,7 @@ When auto-approve read is enabled, you can configure a list of file patterns tha
 
 **Default patterns include:**
 
-- Environment files: `.env`, `.env.*`
+- Environment files: `.env*` (matches .env, .env.local, .env.production, etc.)
 - Keys and certificates: `*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.jks`
 - SSH keys: `id_rsa`, `id_dsa`, `id_ecdsa`, `id_ed25519`, `*.ppk`
 - Encryption files: `*.gpg`, `*.asc`, `*.sig`
@@ -103,7 +103,7 @@ When auto-approve read is enabled, you can configure a list of file patterns tha
 
 1. Enable "Always approve read-only operations"
 2. Scroll down to the "Globally ignored files" section
-3. Add custom patterns using glob syntax (e.g., `*.key`, `.env.*`)
+3. Add custom patterns using glob syntax (e.g., `*.key`, `.env*`)
 4. Click "Add Pattern" to save each pattern
 5. Remove patterns by clicking the X on pattern chips
    :::
@@ -127,6 +127,23 @@ This setting allows Kilo Code to modify your files without confirmation. The del
 - Default (1000ms): Suitable for most projects
 - Lower values: Use only when speed is critical and you're in a controlled environment
 - Zero: No delay for diagnostics (not recommended for critical code)
+
+#### Protected Files
+
+Kilo Code has **two levels of file protection**:
+
+1. **Globally Ignored Files** (configured in Read settings above):
+
+    - Completely blocked from all operations (read AND write)
+    - Examples: `.env`, `*.key`, SSH keys, credentials
+    - These files cannot be accessed at all, regardless of any other settings
+
+2. **Write-Protected Configuration Files**:
+    - Can be read but require approval to modify by default
+    - Examples: `.kilocodeignore`, `.kilocode/`, `.vscode/`
+    - Can be auto-approved if you enable "Include protected files" checkbox below
+
+This layered protection ensures sensitive data files are completely inaccessible while configuration files remain readable. You can choose whether to auto-approve writes to configuration files based on your trust level.
 
 #### Write Delay & Problems Pane Integration
 

--- a/apps/kilocode-docs/docs/features/auto-approving-actions.md
+++ b/apps/kilocode-docs/docs/features/auto-approving-actions.md
@@ -80,7 +80,33 @@ _Complete settings panel view_
 **Risk level:** Medium
 
 While this setting only allows reading files (not modifying them), it could potentially expose sensitive data. Still recommended as a starting point for most users, but be mindful of what files Kilo Code can access.
-:::
+
+#### Globally Ignored Files
+
+When auto-approve read is enabled, you can configure a list of file patterns that are **always ignored**, even without a `.kilocodeignore` file. This provides an extra layer of protection for sensitive files.
+
+**Default patterns include:**
+
+- Environment files: `.env`, `.env.*`
+- Keys and certificates: `*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.jks`
+- SSH keys: `id_rsa`, `id_dsa`, `id_ecdsa`, `id_ed25519`, `*.ppk`
+- Encryption files: `*.gpg`, `*.asc`, `*.sig`
+
+**Key features:**
+
+- Works even without a `.kilocodeignore` file
+- Takes priority over `.kilocodeignore` patterns
+- Fully customizable - add or remove patterns as needed
+- Includes sensible defaults for common sensitive files
+
+**How to configure:**
+
+1. Enable "Always approve read-only operations"
+2. Scroll down to the "Globally ignored files" section
+3. Add custom patterns using glob syntax (e.g., `*.key`, `.env.*`)
+4. Click "Add Pattern" to save each pattern
+5. Remove patterns by clicking the X on pattern chips
+   :::
 
 ### Write Operations
 

--- a/apps/kilocode-docs/docs/features/auto-approving-actions.md
+++ b/apps/kilocode-docs/docs/features/auto-approving-actions.md
@@ -83,7 +83,7 @@ While this setting only allows reading files (not modifying them), it could pote
 
 #### Globally Ignored Files
 
-When auto-approve read is enabled, you can configure a list of file patterns that are **always ignored**, even without a `.kilocodeignore` file. This provides an extra layer of protection for sensitive files.
+When auto-approve read is enabled, you can configure a list of file patterns that are **always ignored**, even without a `.kilocodeignore` file. This provides an initial layer of protection for sensitive files.
 
 **Default patterns include:**
 

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -50,21 +50,20 @@ export const DEFAULT_CHECKPOINT_TIMEOUT_SECONDS = 15
  * These are common sensitive files that should be ignored even without a .kilocodeignore file
  */
 export const DEFAULT_GLOBALLY_IGNORED_FILES = [
-	".env",
-	".env.*",
-	"*.pem",
-	"*.key",
-	"*.p12",
-	"*.pfx",
-	"*.jks",
-	"id_rsa",
-	"id_dsa",
-	"id_ecdsa",
-	"id_ed25519",
-	"*.ppk",
-	"*.gpg",
-	"*.asc",
-	"*.sig",
+	".env*", // Matches .env, .env.local, .env.production, etc.
+	"*.pem", // SSL certificates
+	"*.key", // Private keys
+	"*.p12", // PKCS#12 certificates
+	"*.pfx", // Windows certificates
+	"*.jks", // Java keystores
+	"id_rsa", // SSH private key (RSA)
+	"id_dsa", // SSH private key (DSA)
+	"id_ecdsa", // SSH private key (ECDSA)
+	"id_ed25519", // SSH private key (ED25519)
+	"*.ppk", // PuTTY private keys
+	"*.gpg", // GPG encrypted files
+	"*.asc", // ASCII-armored GPG files
+	"*.sig", // Signature files
 ]
 
 /**

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -45,6 +45,7 @@ export const MAX_CHECKPOINT_TIMEOUT_SECONDS = 60
  */
 export const DEFAULT_CHECKPOINT_TIMEOUT_SECONDS = 15
 
+// kilocode_change start
 /**
  * Default globally ignored file patterns
  * These are common sensitive files that should be ignored even without a .kilocodeignore file
@@ -65,7 +66,7 @@ export const DEFAULT_GLOBALLY_IGNORED_FILES = [
 	"*.asc", // ASCII-armored GPG files
 	"*.sig", // Signature files
 ]
-
+// kilocode_change end
 /**
  * GlobalSettings
  */

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -45,8 +45,7 @@ export const MAX_CHECKPOINT_TIMEOUT_SECONDS = 60
  */
 export const DEFAULT_CHECKPOINT_TIMEOUT_SECONDS = 15
 
-// kilocode_change start
-/**
+/** kilocode_change start
  * Default globally ignored file patterns
  * These are common sensitive files that should be ignored even without a .kilocodeignore file
  */
@@ -65,8 +64,8 @@ export const DEFAULT_GLOBALLY_IGNORED_FILES = [
 	"*.gpg", // GPG encrypted files
 	"*.asc", // ASCII-armored GPG files
 	"*.sig", // Signature files
-]
-// kilocode_change end
+] // kilocode_change end
+
 /**
  * GlobalSettings
  */

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -46,6 +46,28 @@ export const MAX_CHECKPOINT_TIMEOUT_SECONDS = 60
 export const DEFAULT_CHECKPOINT_TIMEOUT_SECONDS = 15
 
 /**
+ * Default globally ignored file patterns
+ * These are common sensitive files that should be ignored even without a .kilocodeignore file
+ */
+export const DEFAULT_GLOBALLY_IGNORED_FILES = [
+	".env",
+	".env.*",
+	"*.pem",
+	"*.key",
+	"*.p12",
+	"*.pfx",
+	"*.jks",
+	"id_rsa",
+	"id_dsa",
+	"id_ecdsa",
+	"id_ed25519",
+	"*.ppk",
+	"*.gpg",
+	"*.asc",
+	"*.sig",
+]
+
+/**
  * GlobalSettings
  */
 
@@ -72,6 +94,7 @@ export const globalSettingsSchema = z.object({
 	yoloGatekeeperApiConfigId: z.string().optional(), // kilocode_change: AI gatekeeper for YOLO mode
 	alwaysAllowReadOnly: z.boolean().optional(),
 	alwaysAllowReadOnlyOutsideWorkspace: z.boolean().optional(),
+	globallyIgnoredFiles: z.array(z.string()).optional(), // kilocode_change: Global ignore patterns
 	alwaysAllowWrite: z.boolean().optional(),
 	alwaysAllowWriteOutsideWorkspace: z.boolean().optional(),
 	alwaysAllowWriteProtected: z.boolean().optional(),
@@ -334,6 +357,7 @@ export const EVALS_SETTINGS: RooCodeSettings = {
 	autoApprovalEnabled: true,
 	alwaysAllowReadOnly: true,
 	alwaysAllowReadOnlyOutsideWorkspace: false,
+	globallyIgnoredFiles: DEFAULT_GLOBALLY_IGNORED_FILES, // kilocode_change
 	alwaysAllowWrite: true,
 	alwaysAllowWriteOutsideWorkspace: false,
 	alwaysAllowWriteProtected: false,

--- a/src/core/ignore/RooIgnoreController.ts
+++ b/src/core/ignore/RooIgnoreController.ts
@@ -111,7 +111,7 @@ export class RooIgnoreController {
 			// Convert real path to relative for .rooignore checking
 			const relativePath = path.relative(this.cwd, realPath).toPosix()
 
-			// First check global ignore patterns (always active) // kilocode_change start
+			// kilocode_change start: First check global ignore patterns (always active)
 			if (this.globallyIgnoredFiles.length > 0 && this.globalIgnoreInstance.ignores(relativePath)) {
 				return false
 			}

--- a/src/core/ignore/RooIgnoreController.ts
+++ b/src/core/ignore/RooIgnoreController.ts
@@ -20,7 +20,7 @@ export class RooIgnoreController {
 	private disposables: vscode.Disposable[] = []
 	rooIgnoreContent: string | undefined
 
-	constructor(cwd: string, globallyIgnoredFiles: string[] = []) {
+	constructor(cwd: string, globallyIgnoredFiles: string[] = []) { // kilocode_change
 		// kilocode_change
 		this.cwd = cwd
 		this.ignoreInstance = ignore()

--- a/src/core/ignore/RooIgnoreController.ts
+++ b/src/core/ignore/RooIgnoreController.ts
@@ -21,7 +21,6 @@ export class RooIgnoreController {
 	rooIgnoreContent: string | undefined
 
 	constructor(cwd: string, globallyIgnoredFiles: string[] = []) { // kilocode_change
-		// kilocode_change
 		this.cwd = cwd
 		this.ignoreInstance = ignore()
 		this.globalIgnoreInstance = ignore() // kilocode_change

--- a/src/core/ignore/RooIgnoreController.ts
+++ b/src/core/ignore/RooIgnoreController.ts
@@ -129,7 +129,7 @@ export class RooIgnoreController {
 		}
 	}
 
-	/**
+	/** kilocode_change start
 	 * Update the global ignore patterns
 	 * @param patterns - Array of glob patterns to ignore globally
 	 */
@@ -139,7 +139,7 @@ export class RooIgnoreController {
 		if (patterns.length > 0) {
 			this.globalIgnoreInstance.add(patterns)
 		}
-	}
+	} // kilocode_change end
 
 	/**
 	 * Check if a terminal command should be allowed to execute based on file access patterns

--- a/src/core/ignore/RooIgnoreController.ts
+++ b/src/core/ignore/RooIgnoreController.ts
@@ -15,21 +15,22 @@ export const LOCK_TEXT_SYMBOL = "\u{1F512}"
 export class RooIgnoreController {
 	private cwd: string
 	private ignoreInstance: Ignore
-	private globalIgnoreInstance: Ignore
+	private globalIgnoreInstance: Ignore // kilocode_change
+	private globallyIgnoredFiles: string[] // kilocode_change
 	private disposables: vscode.Disposable[] = []
 	rooIgnoreContent: string | undefined
-	private globallyIgnoredFiles: string[]
 
 	constructor(cwd: string, globallyIgnoredFiles: string[] = []) {
+		// kilocode_change
 		this.cwd = cwd
 		this.ignoreInstance = ignore()
-		this.globalIgnoreInstance = ignore()
+		this.globalIgnoreInstance = ignore() // kilocode_change
 		this.rooIgnoreContent = undefined
-		this.globallyIgnoredFiles = globallyIgnoredFiles
+		this.globallyIgnoredFiles = globallyIgnoredFiles // kilocode_change start
 		// Initialize global ignore patterns
 		if (globallyIgnoredFiles.length > 0) {
 			this.globalIgnoreInstance.add(globallyIgnoredFiles)
-		}
+		} // kilocode_change end
 		// Set up file watcher for .kilocodeignore
 		this.setupFileWatcher()
 	}
@@ -108,10 +109,10 @@ export class RooIgnoreController {
 				realPath = absolutePath
 			}
 
-			// Convert real path to relative for checking
+			// Convert real path to relative for .rooignore checking
 			const relativePath = path.relative(this.cwd, realPath).toPosix()
 
-			// First check global ignore patterns (always active)
+			// First check global ignore patterns (always active) // kilocode_change start
 			if (this.globallyIgnoredFiles.length > 0 && this.globalIgnoreInstance.ignores(relativePath)) {
 				return false
 			}
@@ -121,7 +122,7 @@ export class RooIgnoreController {
 				return false
 			}
 
-			return true
+			return true // kilocode_change end
 		} catch (error) {
 			// Allow access to files outside cwd or on errors (backward compatibility)
 			return true

--- a/src/core/ignore/__tests__/RooIgnoreController.spec.ts
+++ b/src/core/ignore/__tests__/RooIgnoreController.spec.ts
@@ -528,6 +528,7 @@ describe("RooIgnoreController", () => {
 	})
 
 	describe("global ignore patterns", () => {
+		// kilocode_change start
 		/**
 		 * Tests that global patterns work without .kilocodeignore
 		 */
@@ -717,4 +718,4 @@ describe("RooIgnoreController", () => {
 			expect(controllerWithDefaults.validateAccess("README.md")).toBe(true)
 		})
 	})
-})
+}) // kilocode_change end

--- a/src/core/ignore/__tests__/RooIgnoreController.spec.ts
+++ b/src/core/ignore/__tests__/RooIgnoreController.spec.ts
@@ -528,7 +528,6 @@ describe("RooIgnoreController", () => {
 	})
 
 	describe("global ignore patterns", () => {
-		// kilocode_change start
 		/**
 		 * Tests that global patterns work without .kilocodeignore
 		 */

--- a/src/core/ignore/__tests__/RooIgnoreController.spec.ts
+++ b/src/core/ignore/__tests__/RooIgnoreController.spec.ts
@@ -527,7 +527,7 @@ describe("RooIgnoreController", () => {
 		})
 	})
 
-	describe("global ignore patterns", () => {
+	describe("global ignore patterns", () => {  // kilocode_change start
 		/**
 		 * Tests that global patterns work without .kilocodeignore
 		 */

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -43,7 +43,7 @@ import {
 	ORGANIZATION_ALLOW_ALL,
 	DEFAULT_MODES,
 	DEFAULT_CHECKPOINT_TIMEOUT_SECONDS,
-	DEFAULT_GLOBALLY_IGNORED_FILES,
+	DEFAULT_GLOBALLY_IGNORED_FILES, // kilocode_change
 	getModelId,
 } from "@roo-code/types"
 import { TelemetryService } from "@roo-code/telemetry"

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -43,6 +43,7 @@ import {
 	ORGANIZATION_ALLOW_ALL,
 	DEFAULT_MODES,
 	DEFAULT_CHECKPOINT_TIMEOUT_SECONDS,
+	DEFAULT_GLOBALLY_IGNORED_FILES,
 	getModelId,
 } from "@roo-code/types"
 import { TelemetryService } from "@roo-code/telemetry"
@@ -2056,6 +2057,7 @@ ${prompt}
 			customInstructions,
 			alwaysAllowReadOnly,
 			alwaysAllowReadOnlyOutsideWorkspace,
+			globallyIgnoredFiles, // kilocode_change
 			alwaysAllowWrite,
 			alwaysAllowWriteOutsideWorkspace,
 			alwaysAllowWriteProtected,
@@ -2218,6 +2220,7 @@ ${prompt}
 			customInstructions,
 			alwaysAllowReadOnly: alwaysAllowReadOnly ?? true,
 			alwaysAllowReadOnlyOutsideWorkspace: alwaysAllowReadOnlyOutsideWorkspace ?? true,
+			globallyIgnoredFiles: globallyIgnoredFiles ?? DEFAULT_GLOBALLY_IGNORED_FILES, // kilocode_change
 			alwaysAllowWrite: alwaysAllowWrite ?? true,
 			alwaysAllowWriteOutsideWorkspace: alwaysAllowWriteOutsideWorkspace ?? false,
 			alwaysAllowWriteProtected: alwaysAllowWriteProtected ?? false,
@@ -2498,6 +2501,7 @@ ${prompt}
 			apiModelId: stateValues.apiModelId,
 			alwaysAllowReadOnly: stateValues.alwaysAllowReadOnly ?? true,
 			alwaysAllowReadOnlyOutsideWorkspace: stateValues.alwaysAllowReadOnlyOutsideWorkspace ?? true,
+			globallyIgnoredFiles: stateValues.globallyIgnoredFiles ?? DEFAULT_GLOBALLY_IGNORED_FILES, // kilocode_change
 			alwaysAllowWrite: stateValues.alwaysAllowWrite ?? true,
 			alwaysAllowWriteOutsideWorkspace: stateValues.alwaysAllowWriteOutsideWorkspace ?? false,
 			alwaysAllowWriteProtected: stateValues.alwaysAllowWriteProtected ?? false,

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -340,7 +340,7 @@ export type ExtensionState = Pick<
 	| "yoloMode" // kilocode_change
 	| "alwaysAllowReadOnly"
 	| "alwaysAllowReadOnlyOutsideWorkspace"
-	| "globallyIgnoredFiles"
+	| "globallyIgnoredFiles" // kilocode_change
 	| "alwaysAllowWrite"
 	| "alwaysAllowWriteOutsideWorkspace"
 	| "alwaysAllowWriteProtected"

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -340,6 +340,7 @@ export type ExtensionState = Pick<
 	| "yoloMode" // kilocode_change
 	| "alwaysAllowReadOnly"
 	| "alwaysAllowReadOnlyOutsideWorkspace"
+	| "globallyIgnoredFiles"
 	| "alwaysAllowWrite"
 	| "alwaysAllowWriteOutsideWorkspace"
 	| "alwaysAllowWriteProtected"

--- a/webview-ui/src/components/settings/AutoApproveSettings.tsx
+++ b/webview-ui/src/components/settings/AutoApproveSettings.tsx
@@ -13,6 +13,7 @@ import { SectionHeader } from "./SectionHeader"
 import { Section } from "./Section"
 import { AutoApproveToggle } from "./AutoApproveToggle"
 import { MaxLimitInputs } from "./MaxLimitInputs"
+import { GlobalIgnoreSettings } from "./GlobalIgnoreSettings"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useAutoApprovalState } from "@/hooks/useAutoApprovalState"
 import { useAutoApprovalToggles } from "@/hooks/useAutoApprovalToggles"
@@ -99,7 +100,6 @@ export const AutoApproveSettings = ({
 	const { t } = useAppTranslation()
 	const [commandInput, setCommandInput] = useState("")
 	const [deniedCommandInput, setDeniedCommandInput] = useState("")
-	const [globalIgnoreInput, setGlobalIgnoreInput] = useState("")
 	const { autoApprovalEnabled, setAutoApprovalEnabled, listApiConfigMeta } = useExtensionState() // kilocode_change: Add listApiConfigMeta for gatekeeper
 
 	const toggles = useAutoApprovalToggles()
@@ -125,17 +125,6 @@ export const AutoApproveSettings = ({
 			setCachedStateField("deniedCommands", newCommands)
 			setDeniedCommandInput("")
 			vscode.postMessage({ type: "updateSettings", updatedSettings: { deniedCommands: newCommands } })
-		}
-	}
-
-	const handleAddGlobalIgnorePattern = () => {
-		const currentPatterns = globallyIgnoredFiles ?? []
-
-		if (globalIgnoreInput && !currentPatterns.includes(globalIgnoreInput)) {
-			const newPatterns = [...currentPatterns, globalIgnoreInput]
-			setCachedStateField("globallyIgnoredFiles", newPatterns)
-			setGlobalIgnoreInput("")
-			vscode.postMessage({ type: "updateSettings", updatedSettings: { globallyIgnoredFiles: newPatterns } })
 		}
 	}
 
@@ -237,80 +226,11 @@ export const AutoApproveSettings = ({
 				{/* ADDITIONAL SETTINGS */}
 
 				{alwaysAllowReadOnly && (
-					<div className="flex flex-col gap-3 pl-3 border-l-2 border-vscode-button-background">
-						<div className="flex items-center gap-4 font-bold">
-							<span className="codicon codicon-eye" />
-							<div>{t("settings:autoApprove.readOnly.label")}</div>
-						</div>
-						<div>
-							<VSCodeCheckbox
-								checked={alwaysAllowReadOnlyOutsideWorkspace}
-								onChange={(e: any) =>
-									setCachedStateField("alwaysAllowReadOnlyOutsideWorkspace", e.target.checked)
-								}
-								data-testid="always-allow-readonly-outside-workspace-checkbox">
-								<span className="font-medium">
-									{t("settings:autoApprove.readOnly.outsideWorkspace.label")}
-								</span>
-							</VSCodeCheckbox>
-							<div className="text-vscode-descriptionForeground text-sm mt-1">
-								{t("settings:autoApprove.readOnly.outsideWorkspace.description")}
-							</div>
-						</div>
-						<div>
-							<label className="block font-medium mb-1" data-testid="global-ignore-heading">
-								{t("settings:autoApprove.readOnly.globalIgnore.label")}
-							</label>
-							<div className="text-vscode-descriptionForeground text-sm mt-1">
-								{t("settings:autoApprove.readOnly.globalIgnore.description")}
-							</div>
-						</div>
-
-						<div className="flex gap-2">
-							<Input
-								value={globalIgnoreInput}
-								onChange={(e: any) => setGlobalIgnoreInput(e.target.value)}
-								onKeyDown={(e: any) => {
-									if (e.key === "Enter") {
-										e.preventDefault()
-										handleAddGlobalIgnorePattern()
-									}
-								}}
-								placeholder={t("settings:autoApprove.readOnly.globalIgnore.patternPlaceholder")}
-								className="grow"
-								data-testid="global-ignore-input"
-							/>
-							<Button
-								className="h-8"
-								onClick={handleAddGlobalIgnorePattern}
-								data-testid="add-global-ignore-button">
-								{t("settings:autoApprove.readOnly.globalIgnore.addButton")}
-							</Button>
-						</div>
-
-						<div className="flex flex-wrap gap-2">
-							{(globallyIgnoredFiles ?? []).map((pattern, index) => (
-								<Button
-									key={index}
-									variant="secondary"
-									data-testid={`remove-global-ignore-${index}`}
-									onClick={() => {
-										const newPatterns = (globallyIgnoredFiles ?? []).filter((_, i) => i !== index)
-										setCachedStateField("globallyIgnoredFiles", newPatterns)
-
-										vscode.postMessage({
-											type: "updateSettings",
-											updatedSettings: { globallyIgnoredFiles: newPatterns },
-										})
-									}}>
-									<div className="flex flex-row items-center gap-1">
-										<div>{pattern}</div>
-										<X className="text-foreground scale-75" />
-									</div>
-								</Button>
-							))}
-						</div>
-					</div>
+					<GlobalIgnoreSettings
+						globallyIgnoredFiles={globallyIgnoredFiles}
+						alwaysAllowReadOnlyOutsideWorkspace={alwaysAllowReadOnlyOutsideWorkspace}
+						setCachedStateField={setCachedStateField}
+					/>
 				)}
 
 				{alwaysAllowWrite && (

--- a/webview-ui/src/components/settings/GlobalIgnoreSettings.tsx
+++ b/webview-ui/src/components/settings/GlobalIgnoreSettings.tsx
@@ -1,0 +1,103 @@
+import { X } from "lucide-react"
+import { useAppTranslation } from "@/i18n/TranslationContext"
+import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
+import { vscode } from "@/utils/vscode"
+import { Button, Input } from "@/components/ui"
+import { useState } from "react"
+import { SetCachedStateField } from "./types"
+
+interface GlobalIgnoreSettingsProps {
+	globallyIgnoredFiles?: string[]
+	alwaysAllowReadOnlyOutsideWorkspace?: boolean
+	setCachedStateField: SetCachedStateField<"globallyIgnoredFiles" | "alwaysAllowReadOnlyOutsideWorkspace">
+}
+
+export const GlobalIgnoreSettings = ({
+	globallyIgnoredFiles,
+	alwaysAllowReadOnlyOutsideWorkspace,
+	setCachedStateField,
+}: GlobalIgnoreSettingsProps) => {
+	const { t } = useAppTranslation()
+	const [globalIgnoreInput, setGlobalIgnoreInput] = useState("")
+
+	const handleAddGlobalIgnorePattern = () => {
+		const currentPatterns = globallyIgnoredFiles ?? []
+
+		if (globalIgnoreInput && !currentPatterns.includes(globalIgnoreInput)) {
+			const newPatterns = [...currentPatterns, globalIgnoreInput]
+			setCachedStateField("globallyIgnoredFiles", newPatterns)
+			setGlobalIgnoreInput("")
+			vscode.postMessage({ type: "updateSettings", updatedSettings: { globallyIgnoredFiles: newPatterns } })
+		}
+	}
+
+	return (
+		<div className="flex flex-col gap-3 pl-3 border-l-2 border-vscode-button-background">
+			<div className="flex items-center gap-4 font-bold">
+				<span className="codicon codicon-eye" />
+				<div>{t("settings:autoApprove.readOnly.label")}</div>
+			</div>
+			<div>
+				<VSCodeCheckbox
+					checked={alwaysAllowReadOnlyOutsideWorkspace}
+					onChange={(e: any) => setCachedStateField("alwaysAllowReadOnlyOutsideWorkspace", e.target.checked)}
+					data-testid="always-allow-readonly-outside-workspace-checkbox">
+					<span className="font-medium">{t("settings:autoApprove.readOnly.outsideWorkspace.label")}</span>
+				</VSCodeCheckbox>
+				<div className="text-vscode-descriptionForeground text-sm mt-1">
+					{t("settings:autoApprove.readOnly.outsideWorkspace.description")}
+				</div>
+			</div>
+			<div>
+				<label className="block font-medium mb-1" data-testid="global-ignore-heading">
+					{t("settings:autoApprove.readOnly.globalIgnore.label")}
+				</label>
+				<div className="text-vscode-descriptionForeground text-sm mt-1">
+					{t("settings:autoApprove.readOnly.globalIgnore.description")}
+				</div>
+			</div>
+
+			<div className="flex gap-2">
+				<Input
+					value={globalIgnoreInput}
+					onChange={(e: any) => setGlobalIgnoreInput(e.target.value)}
+					onKeyDown={(e: any) => {
+						if (e.key === "Enter") {
+							e.preventDefault()
+							handleAddGlobalIgnorePattern()
+						}
+					}}
+					placeholder={t("settings:autoApprove.readOnly.globalIgnore.patternPlaceholder")}
+					className="grow"
+					data-testid="global-ignore-input"
+				/>
+				<Button className="h-8" onClick={handleAddGlobalIgnorePattern} data-testid="add-global-ignore-button">
+					{t("settings:autoApprove.readOnly.globalIgnore.addButton")}
+				</Button>
+			</div>
+
+			<div className="flex flex-wrap gap-2">
+				{(globallyIgnoredFiles ?? []).map((pattern, index) => (
+					<Button
+						key={index}
+						variant="secondary"
+						data-testid={`remove-global-ignore-${index}`}
+						onClick={() => {
+							const newPatterns = (globallyIgnoredFiles ?? []).filter((_, i) => i !== index)
+							setCachedStateField("globallyIgnoredFiles", newPatterns)
+
+							vscode.postMessage({
+								type: "updateSettings",
+								updatedSettings: { globallyIgnoredFiles: newPatterns },
+							})
+						}}>
+						<div className="flex flex-row items-center gap-1">
+							<div>{pattern}</div>
+							<X className="text-foreground scale-75" />
+						</div>
+					</Button>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -9,7 +9,7 @@ import React, {
 	useRef,
 	useState,
 } from "react"
-import { DEFAULT_GLOBALLY_IGNORED_FILES } from "@roo-code/types"
+import { DEFAULT_GLOBALLY_IGNORED_FILES } from "@roo-code/types" // kilocode_change
 import {
 	CheckCheck,
 	SquareMousePointer,

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -9,6 +9,7 @@ import React, {
 	useRef,
 	useState,
 } from "react"
+import { DEFAULT_GLOBALLY_IGNORED_FILES } from "@roo-code/types"
 import {
 	CheckCheck,
 	SquareMousePointer,
@@ -159,6 +160,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 	const {
 		alwaysAllowReadOnly,
 		alwaysAllowReadOnlyOutsideWorkspace,
+		globallyIgnoredFiles, // kilocode_change
 		allowedCommands,
 		deniedCommands,
 		allowedMaxRequests,
@@ -476,6 +478,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 					language,
 					alwaysAllowReadOnly: alwaysAllowReadOnly ?? undefined,
 					alwaysAllowReadOnlyOutsideWorkspace: alwaysAllowReadOnlyOutsideWorkspace ?? undefined,
+					globallyIgnoredFiles: globallyIgnoredFiles ?? DEFAULT_GLOBALLY_IGNORED_FILES, // kilocode_change
 					alwaysAllowWrite: alwaysAllowWrite ?? undefined,
 					alwaysAllowWriteOutsideWorkspace: alwaysAllowWriteOutsideWorkspace ?? undefined,
 					alwaysAllowWriteProtected: alwaysAllowWriteProtected ?? undefined,
@@ -952,6 +955,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 							yoloGatekeeperApiConfigId={yoloGatekeeperApiConfigId} // kilocode_change: AI gatekeeper for YOLO mode
 							alwaysAllowReadOnly={alwaysAllowReadOnly}
 							alwaysAllowReadOnlyOutsideWorkspace={alwaysAllowReadOnlyOutsideWorkspace}
+							globallyIgnoredFiles={globallyIgnoredFiles ?? DEFAULT_GLOBALLY_IGNORED_FILES} // kilocode_change
 							alwaysAllowWrite={alwaysAllowWrite}
 							alwaysAllowWriteOutsideWorkspace={alwaysAllowWriteOutsideWorkspace}
 							alwaysAllowWriteProtected={alwaysAllowWriteProtected}

--- a/webview-ui/src/components/settings/__tests__/GlobalIgnoreSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/GlobalIgnoreSettings.spec.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent } from "@/utils/test-utils"
+import { GlobalIgnoreSettings } from "../GlobalIgnoreSettings"
+import { vscode } from "@/utils/vscode"
+
+// Mock vscode
+vi.mock("@/utils/vscode", () => ({
+	vscode: {
+		postMessage: vi.fn(),
+	},
+}))
+
+describe("GlobalIgnoreSettings", () => {
+	const mockSetCachedStateField = vi.fn()
+	const defaultProps = {
+		globallyIgnoredFiles: [".env", "*.secret"],
+		alwaysAllowReadOnlyOutsideWorkspace: false,
+		setCachedStateField: mockSetCachedStateField,
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("renders correctly", () => {
+		render(<GlobalIgnoreSettings {...defaultProps} />)
+		expect(screen.getByText("settings:autoApprove.readOnly.label")).toBeInTheDocument()
+		expect(screen.getByTestId("global-ignore-input")).toBeInTheDocument()
+		expect(screen.getByText(".env")).toBeInTheDocument()
+		expect(screen.getByText("*.secret")).toBeInTheDocument()
+	})
+
+	it("adds a new global ignore pattern", () => {
+		render(<GlobalIgnoreSettings {...defaultProps} />)
+
+		const input = screen.getByTestId("global-ignore-input")
+		fireEvent.change(input, { target: { value: "*.pem" } })
+
+		const addButton = screen.getByTestId("add-global-ignore-button")
+		fireEvent.click(addButton)
+
+		// Check if state update was called
+		expect(mockSetCachedStateField).toHaveBeenCalledWith("globallyIgnoredFiles", [".env", "*.secret", "*.pem"])
+
+		// Check if vscode message was sent
+		expect(vscode.postMessage).toHaveBeenCalledWith({
+			type: "updateSettings",
+			updatedSettings: {
+				globallyIgnoredFiles: [".env", "*.secret", "*.pem"],
+			},
+		})
+	})
+
+	it("does not add duplicate patterns", () => {
+		render(<GlobalIgnoreSettings {...defaultProps} />)
+
+		const input = screen.getByTestId("global-ignore-input")
+		fireEvent.change(input, { target: { value: ".env" } }) // Already exists
+
+		const addButton = screen.getByTestId("add-global-ignore-button")
+		fireEvent.click(addButton)
+
+		expect(mockSetCachedStateField).not.toHaveBeenCalled()
+		expect(vscode.postMessage).not.toHaveBeenCalled()
+	})
+
+	it("removes a global ignore pattern", () => {
+		render(<GlobalIgnoreSettings {...defaultProps} />)
+
+		const removeButton = screen.getByTestId("remove-global-ignore-0") // Remove first item (.env)
+		fireEvent.click(removeButton)
+
+		expect(mockSetCachedStateField).toHaveBeenCalledWith("globallyIgnoredFiles", ["*.secret"])
+
+		expect(vscode.postMessage).toHaveBeenCalledWith({
+			type: "updateSettings",
+			updatedSettings: {
+				globallyIgnoredFiles: ["*.secret"],
+			},
+		})
+	})
+
+	it("toggles alwaysAllowReadOnlyOutsideWorkspace", () => {
+		render(<GlobalIgnoreSettings {...defaultProps} />)
+
+		const checkbox = screen.getByTestId("always-allow-readonly-outside-workspace-checkbox")
+		fireEvent.click(checkbox)
+
+		expect(mockSetCachedStateField).toHaveBeenCalledWith("alwaysAllowReadOnlyOutsideWorkspace", true)
+	})
+})

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -165,7 +165,7 @@
 			},
 			"globalIgnore": {
 				"label": "Globally ignored files",
-				"description": "File patterns that are always ignored, even without a .kilocodeignore file. Common sensitive files like .env, keys, and credentials are included by default.",
+				"description": "File patterns that are always ignored, even without a .kilocodeignore file.",
 				"addButton": "Add Pattern",
 				"patternPlaceholder": "Enter glob pattern (e.g., '*.key', '.env.*')"
 			}

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -162,6 +162,12 @@
 			"outsideWorkspace": {
 				"label": "Include files outside workspace",
 				"description": "Allow Kilo Code to read files outside the current workspace without requiring approval."
+			},
+			"globalIgnore": {
+				"label": "Globally ignored files",
+				"description": "File patterns that are always ignored, even without a .kilocodeignore file. Common sensitive files like .env, keys, and credentials are included by default.",
+				"addButton": "Add Pattern",
+				"patternPlaceholder": "Enter glob pattern (e.g., '*.key', '.env.*')"
 			}
 		},
 		"write": {


### PR DESCRIPTION
## Context

Kilo Code supports a .kilocodeignore file, to prevent secrets and other sensitive content from being read and exposed to an LLM. However this must be created specifically for each project, and in the event it doesn't exist, read operations are allowed for all file types.

.gitignore can help in these situations, but it is not comprehensive as it does not get applied (per our documentation) for [read operations](https://kilo.ai/docs/features/tools/read-file), only for certain directory [list](https://kilo.ai/docs/features/tools/list-files) operations.

This introduces a new concept to add a global ignore list which works even without the presence of a .kilocodeignore file, so that common secrets and other sensitive file types are ignored by default.

## Implementation

Adds a new option to the auto-approve list, which shows when read is enabled, and has supports a list of glob syntax similar to other settings. This is then checked to prevent auto-approved read or write operations.

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
