### PR TITLE
refactor: use GhostInlineCompletionProvider directly in GhostProviderTester

### DIFF
--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -126,8 +126,8 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 	private model: GhostModel
 	private costTrackingCallback: CostTrackingCallback
 	private getSettings: () => GhostServiceSettings | null
-	private recentlyVisitedRangesService: RecentlyVisitedRangesService | null
-	private recentlyEditedTracker: RecentlyEditedTracker | null
+	private recentlyVisitedRangesService: RecentlyVisitedRangesService
+	private recentlyEditedTracker: RecentlyEditedTracker
 	private debounceTimer: NodeJS.Timeout | null = null
 	private isFirstCall: boolean = true
 	private ignoreController?: Promise<RooIgnoreController>
@@ -198,8 +198,8 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 		position: vscode.Position,
 	): Promise<{ prompt: GhostPrompt; prefix: string; suffix: string }> {
 		// Build complete context with all tracking data
-		const recentlyVisitedRanges = this.recentlyVisitedRangesService?.getSnippets() ?? []
-		const recentlyEditedRanges = (await this.recentlyEditedTracker?.getRecentlyEditedRanges()) ?? []
+		const recentlyVisitedRanges = this.recentlyVisitedRangesService.getSnippets()
+		const recentlyEditedRanges = await this.recentlyEditedTracker.getRecentlyEditedRanges()
 
 		const context: GhostSuggestionContext = {
 			document,
@@ -283,8 +283,8 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 			clearTimeout(this.debounceTimer)
 			this.debounceTimer = null
 		}
-		this.recentlyVisitedRangesService?.dispose()
-		this.recentlyEditedTracker?.dispose()
+		this.recentlyVisitedRangesService.dispose()
+		this.recentlyEditedTracker.dispose()
 		void this.disposeIgnoreController()
 		if (this.acceptedCommand) {
 			this.acceptedCommand.dispose()

--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -482,10 +482,6 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 		return requestPromise
 	}
 
-	/**
-	 * Fetch a suggestion from the LLM and cache it.
-	 * This method is public to allow direct testing without going through the debounce logic.
-	 */
 	public async fetchAndCacheSuggestion(
 		prompt: GhostPrompt,
 		prefix: string,

--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -193,7 +193,7 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 		}
 	}
 
-	private async getPrompt(
+	public async getPrompt(
 		document: vscode.TextDocument,
 		position: vscode.Position,
 	): Promise<{ prompt: GhostPrompt; prefix: string; suffix: string }> {

--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -118,7 +118,7 @@ export function stringToInlineCompletions(text: string, position: vscode.Positio
 }
 
 export class GhostInlineCompletionProvider implements vscode.InlineCompletionItemProvider {
-	private suggestionsHistory: FillInAtCursorSuggestion[] = []
+	public suggestionsHistory: FillInAtCursorSuggestion[] = []
 	/** Tracks all pending/in-flight requests */
 	private pendingRequests: PendingRequest[] = []
 	private holeFiller: HoleFiller
@@ -170,43 +170,6 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 		this.acceptedCommand = vscode.commands.registerCommand(INLINE_COMPLETION_ACCEPTED_COMMAND, () =>
 			telemetry.captureAcceptSuggestion(),
 		)
-	}
-
-	/**
-	 * Create a GhostInlineCompletionProvider for testing purposes.
-	 * This factory method allows creating an instance with a custom GhostContextProvider
-	 * without requiring VSCode extension context or ClineProvider.
-	 */
-	static createForTesting(
-		contextProvider: GhostContextProvider,
-		costTrackingCallback: CostTrackingCallback = () => {},
-		getSettings: () => GhostServiceSettings | null = () => null,
-	): GhostInlineCompletionProvider {
-		const instance = Object.create(GhostInlineCompletionProvider.prototype) as GhostInlineCompletionProvider
-		instance.suggestionsHistory = []
-		instance.pendingRequests = []
-		instance.model = contextProvider.model
-		instance.costTrackingCallback = costTrackingCallback
-		instance.getSettings = getSettings
-		instance.holeFiller = new HoleFiller(contextProvider)
-		instance.fimPromptBuilder = new FimPromptBuilder(contextProvider)
-		instance.recentlyVisitedRangesService = null
-		instance.recentlyEditedTracker = null
-		instance.debounceTimer = null
-		instance.isFirstCall = true
-		instance.ignoreController = contextProvider.ignoreController
-		instance.acceptedCommand = null
-		instance.debounceDelayMs = INITIAL_DEBOUNCE_DELAY_MS
-		instance.latencyHistory = []
-		return instance
-	}
-
-	/**
-	 * Get the suggestions history for testing purposes.
-	 * Use with findMatchingSuggestion() to retrieve cached suggestions.
-	 */
-	public getSuggestionsHistory(): FillInAtCursorSuggestion[] {
-		return this.suggestionsHistory
 	}
 
 	public updateSuggestions(fillInAtCursor: FillInAtCursorSuggestion): void {

--- a/src/test-llm-autocompletion/ghost-provider-tester.ts
+++ b/src/test-llm-autocompletion/ghost-provider-tester.ts
@@ -5,7 +5,7 @@ import { extractPrefixSuffix, contextToAutocompleteInput } from "../services/gho
 import { createContext } from "./utils.js"
 import {
 	createTestGhostModel,
-	createMockContextProviderWithContent,
+	createMockContextProvider,
 	modelSupportsFim,
 	createProviderForTesting,
 } from "./mock-context-provider.js"
@@ -27,7 +27,7 @@ export class GhostProviderTester {
 		this.ghostModel = createTestGhostModel(this.llmClient, this.modelId)
 
 		// Create a base context provider for the provider instance
-		const baseContextProvider = createMockContextProviderWithContent("", "", "/test/file.ts", this.ghostModel)
+		const baseContextProvider = createMockContextProvider("", "", "/test/file.ts", this.ghostModel)
 		this.provider = createProviderForTesting(baseContextProvider)
 	}
 
@@ -44,12 +44,7 @@ export class GhostProviderTester {
 		const languageId = context.document.languageId || "javascript"
 
 		// Create context provider with the actual content for prompt building
-		const contextProvider = createMockContextProviderWithContent(
-			prefix,
-			suffix,
-			autocompleteInput.filepath,
-			this.ghostModel,
-		)
+		const contextProvider = createMockContextProvider(prefix, suffix, autocompleteInput.filepath, this.ghostModel)
 
 		// Build the prompt using the appropriate strategy
 		const supportsFim = modelSupportsFim(this.modelId)

--- a/src/test-llm-autocompletion/ghost-provider-tester.ts
+++ b/src/test-llm-autocompletion/ghost-provider-tester.ts
@@ -15,6 +15,36 @@ import {
 } from "../services/ghost/classic-auto-complete/GhostInlineCompletionProvider.js"
 import { GhostModel } from "../services/ghost/GhostModel.js"
 import type { GhostServiceSettings } from "@roo-code/types"
+import type { AutocompleteCodeSnippet } from "../services/continuedev/core/autocomplete/snippets/types.js"
+import type { RecentlyEditedRange } from "../services/continuedev/core/autocomplete/util/types.js"
+
+/**
+ * Stub implementation of RecentlyVisitedRangesService for testing.
+ * Always returns an empty array since we don't need this context in tests.
+ */
+class StubRecentlyVisitedRangesService {
+	public getSnippets(): AutocompleteCodeSnippet[] {
+		return []
+	}
+
+	public dispose(): void {
+		// No-op
+	}
+}
+
+/**
+ * Stub implementation of RecentlyEditedTracker for testing.
+ * Always returns an empty array since we don't need this context in tests.
+ */
+class StubRecentlyEditedTracker {
+	public async getRecentlyEditedRanges(): Promise<RecentlyEditedRange[]> {
+		return []
+	}
+
+	public dispose(): void {
+		// No-op
+	}
+}
 
 /**
  * Create a GhostInlineCompletionProvider for testing purposes.
@@ -36,8 +66,8 @@ function createProviderForTesting(
 		getSettings,
 		holeFiller: new HoleFiller(contextProvider),
 		fimPromptBuilder: new FimPromptBuilder(contextProvider),
-		recentlyVisitedRangesService: null,
-		recentlyEditedTracker: null,
+		recentlyVisitedRangesService: new StubRecentlyVisitedRangesService(),
+		recentlyEditedTracker: new StubRecentlyEditedTracker(),
 		debounceTimer: null,
 		isFirstCall: true,
 		ignoreController: contextProvider.ignoreController,

--- a/src/test-llm-autocompletion/ghost-provider-tester.ts
+++ b/src/test-llm-autocompletion/ghost-provider-tester.ts
@@ -1,82 +1,19 @@
 import { LLMClient } from "./llm-client.js"
 import { HoleFiller } from "../services/ghost/classic-auto-complete/HoleFiller.js"
 import { FimPromptBuilder } from "../services/ghost/classic-auto-complete/FillInTheMiddle.js"
-import { extractPrefixSuffix, contextToAutocompleteInput, GhostContextProvider } from "../services/ghost/types.js"
+import { extractPrefixSuffix, contextToAutocompleteInput } from "../services/ghost/types.js"
 import { createContext } from "./utils.js"
 import {
 	createTestGhostModel,
 	createMockContextProviderWithContent,
 	modelSupportsFim,
+	createProviderForTesting,
 } from "./mock-context-provider.js"
 import {
 	GhostInlineCompletionProvider,
 	findMatchingSuggestion,
-	CostTrackingCallback,
 } from "../services/ghost/classic-auto-complete/GhostInlineCompletionProvider.js"
 import { GhostModel } from "../services/ghost/GhostModel.js"
-import type { GhostServiceSettings } from "@roo-code/types"
-import type { AutocompleteCodeSnippet } from "../services/continuedev/core/autocomplete/snippets/types.js"
-import type { RecentlyEditedRange } from "../services/continuedev/core/autocomplete/util/types.js"
-
-/**
- * Stub implementation of RecentlyVisitedRangesService for testing.
- * Always returns an empty array since we don't need this context in tests.
- */
-class StubRecentlyVisitedRangesService {
-	public getSnippets(): AutocompleteCodeSnippet[] {
-		return []
-	}
-
-	public dispose(): void {
-		// No-op
-	}
-}
-
-/**
- * Stub implementation of RecentlyEditedTracker for testing.
- * Always returns an empty array since we don't need this context in tests.
- */
-class StubRecentlyEditedTracker {
-	public async getRecentlyEditedRanges(): Promise<RecentlyEditedRange[]> {
-		return []
-	}
-
-	public dispose(): void {
-		// No-op
-	}
-}
-
-/**
- * Create a GhostInlineCompletionProvider for testing purposes.
- * This factory function creates an instance with a custom GhostContextProvider
- * without requiring VSCode extension context or ClineProvider.
- */
-function createProviderForTesting(
-	contextProvider: GhostContextProvider,
-	costTrackingCallback: CostTrackingCallback = () => {},
-	getSettings: () => GhostServiceSettings | null = () => null,
-): GhostInlineCompletionProvider {
-	const instance = Object.create(GhostInlineCompletionProvider.prototype) as GhostInlineCompletionProvider
-	// Initialize private fields using Object.assign to bypass TypeScript private access
-	Object.assign(instance, {
-		suggestionsHistory: [],
-		pendingRequests: [],
-		model: contextProvider.model,
-		costTrackingCallback,
-		getSettings,
-		holeFiller: new HoleFiller(contextProvider),
-		fimPromptBuilder: new FimPromptBuilder(contextProvider),
-		recentlyVisitedRangesService: new StubRecentlyVisitedRangesService(),
-		recentlyEditedTracker: new StubRecentlyEditedTracker(),
-		debounceTimer: null,
-		isFirstCall: true,
-		ignoreController: contextProvider.ignoreController,
-		acceptedCommand: null,
-		debounceDelayMs: 300, // INITIAL_DEBOUNCE_DELAY_MS
-		latencyHistory: [],
-	})
-	return instance
-}
 
 export class GhostProviderTester {
 	private llmClient: LLMClient

--- a/src/test-llm-autocompletion/mock-context-provider.ts
+++ b/src/test-llm-autocompletion/mock-context-provider.ts
@@ -74,23 +74,6 @@ export function createTestGhostModel(llmClient: LLMClient, modelId: string): Gho
 	return mockModel
 }
 
-export function createMockContextProvider(ghostModel: GhostModel): GhostContextProvider {
-	return {
-		ide: {
-			readFile: async () => "",
-			getWorkspaceDirs: async () => [],
-			getClipboardContent: async () => ({ text: "", copiedAt: new Date().toISOString() }),
-		},
-		contextService: {
-			initializeForFile: async () => {},
-			getRootPathSnippets: async () => [],
-			getSnippetsFromImportDefinitions: async () => [],
-			getStaticContextSnippets: async () => [],
-		},
-		model: ghostModel,
-	} as unknown as GhostContextProvider
-}
-
 export function createMockContextProviderWithContent(
 	prefix: string,
 	suffix: string,

--- a/src/test-llm-autocompletion/mock-context-provider.ts
+++ b/src/test-llm-autocompletion/mock-context-provider.ts
@@ -74,7 +74,7 @@ export function createTestGhostModel(llmClient: LLMClient, modelId: string): Gho
 	return mockModel
 }
 
-export function createMockContextProviderWithContent(
+export function createMockContextProvider(
 	prefix: string,
 	suffix: string,
 	filepath: string,

--- a/src/test-llm-autocompletion/mock-context-provider.ts
+++ b/src/test-llm-autocompletion/mock-context-provider.ts
@@ -1,4 +1,6 @@
 import { GhostContextProvider } from "../services/ghost/types.js"
+import { GhostModel } from "../services/ghost/GhostModel.js"
+import { LLMClient } from "./llm-client.js"
 
 /**
  * Check if a model supports FIM (Fill-In-Middle) completions.
@@ -9,10 +11,95 @@ export function modelSupportsFim(modelId: string): boolean {
 }
 
 /**
+ * Create a mock GhostModel that wraps an LLMClient for testing.
+ * This allows testing the GhostInlineCompletionProvider without VSCode dependencies.
+ */
+export function createTestGhostModel(llmClient: LLMClient, modelId: string): GhostModel {
+	const supportsFim = modelSupportsFim(modelId)
+
+	// Create a mock GhostModel that delegates to LLMClient
+	const mockModel = {
+		loaded: true,
+		profileName: "test-profile",
+		profileType: "autocomplete",
+
+		supportsFim: () => supportsFim,
+		getModelName: () => modelId,
+		getProviderDisplayName: () => "kilocode",
+		hasValidCredentials: () => true,
+		getRolloutHash_IfLoggedInToKilo: () => undefined,
+
+		generateFimResponse: async (
+			prefix: string,
+			suffix: string,
+			onChunk: (text: string) => void,
+			_taskId?: string,
+		) => {
+			const response = await llmClient.sendFimCompletion(prefix, suffix)
+			onChunk(response.completion)
+			return {
+				cost: 0,
+				inputTokens: response.tokensUsed ?? 0,
+				outputTokens: 0,
+				cacheWriteTokens: 0,
+				cacheReadTokens: 0,
+			}
+		},
+
+		generateResponse: async (
+			systemPrompt: string,
+			userPrompt: string,
+			onChunk: (chunk: { type: string; text?: string }) => void,
+		) => {
+			const response = await llmClient.sendPrompt(systemPrompt, userPrompt)
+			onChunk({ type: "text", text: response.content })
+			return {
+				cost: 0,
+				inputTokens: response.tokensUsed ?? 0,
+				outputTokens: 0,
+				cacheWriteTokens: 0,
+				cacheReadTokens: 0,
+			}
+		},
+
+		reload: async () => true,
+		dispose: () => {},
+	} as unknown as GhostModel
+
+	return mockModel
+}
+
+/**
  * Create a mock GhostContextProvider for standalone testing.
  * This provider simulates the context retrieval without requiring VSCode services.
  */
-export function createMockContextProvider(prefix: string, suffix: string, filepath: string): GhostContextProvider {
+export function createMockContextProvider(ghostModel: GhostModel): GhostContextProvider {
+	return {
+		ide: {
+			readFile: async () => "",
+			getWorkspaceDirs: async () => [],
+			getClipboardContent: async () => ({ text: "", copiedAt: new Date().toISOString() }),
+		},
+		contextService: {
+			initializeForFile: async () => {},
+			getRootPathSnippets: async () => [],
+			getSnippetsFromImportDefinitions: async () => [],
+			getStaticContextSnippets: async () => [],
+		},
+		model: ghostModel,
+	} as unknown as GhostContextProvider
+}
+
+/**
+ * Create a mock GhostContextProvider with prefix/suffix for prompt building.
+ * This is used by the prompt builders to get context.
+ */
+export function createMockContextProviderWithContent(
+	prefix: string,
+	suffix: string,
+	filepath: string,
+	ghostModel: GhostModel,
+): GhostContextProvider {
 	return {
 		ide: {
 			readFile: async () => prefix + suffix,
@@ -25,9 +112,6 @@ export function createMockContextProvider(prefix: string, suffix: string, filepa
 			getSnippetsFromImportDefinitions: async () => [],
 			getStaticContextSnippets: async () => [],
 		},
-		model: {
-			supportsFim: () => modelSupportsFim(process.env.LLM_MODEL || "mistralai/codestral-2508"),
-			getModelName: () => process.env.LLM_MODEL || "mistralai/codestral-2508",
-		},
+		model: ghostModel,
 	} as unknown as GhostContextProvider
 }

--- a/src/test-llm-autocompletion/mock-context-provider.ts
+++ b/src/test-llm-autocompletion/mock-context-provider.ts
@@ -19,10 +19,6 @@ export function modelSupportsFim(modelId: string): boolean {
 	return modelId.includes("codestral")
 }
 
-/**
- * Create a mock GhostModel that wraps an LLMClient for testing.
- * This allows testing the GhostInlineCompletionProvider without VSCode dependencies.
- */
 export function createTestGhostModel(llmClient: LLMClient, modelId: string): GhostModel {
 	const supportsFim = modelSupportsFim(modelId)
 
@@ -78,10 +74,6 @@ export function createTestGhostModel(llmClient: LLMClient, modelId: string): Gho
 	return mockModel
 }
 
-/**
- * Create a mock GhostContextProvider for standalone testing.
- * This provider simulates the context retrieval without requiring VSCode services.
- */
 export function createMockContextProvider(ghostModel: GhostModel): GhostContextProvider {
 	return {
 		ide: {
@@ -99,10 +91,6 @@ export function createMockContextProvider(ghostModel: GhostModel): GhostContextP
 	} as unknown as GhostContextProvider
 }
 
-/**
- * Create a mock GhostContextProvider with prefix/suffix for prompt building.
- * This is used by the prompt builders to get context.
- */
 export function createMockContextProviderWithContent(
 	prefix: string,
 	suffix: string,
@@ -125,39 +113,22 @@ export function createMockContextProviderWithContent(
 	} as unknown as GhostContextProvider
 }
 
-/**
- * Stub implementation of RecentlyVisitedRangesService for testing.
- * Always returns an empty array since we don't need this context in tests.
- */
 export class StubRecentlyVisitedRangesService {
 	public getSnippets(): AutocompleteCodeSnippet[] {
 		return []
 	}
 
-	public dispose(): void {
-		// No-op
-	}
+	public dispose(): void {}
 }
 
-/**
- * Stub implementation of RecentlyEditedTracker for testing.
- * Always returns an empty array since we don't need this context in tests.
- */
 export class StubRecentlyEditedTracker {
 	public async getRecentlyEditedRanges(): Promise<RecentlyEditedRange[]> {
 		return []
 	}
 
-	public dispose(): void {
-		// No-op
-	}
+	public dispose(): void {}
 }
 
-/**
- * Create a GhostInlineCompletionProvider for testing purposes.
- * This factory function creates an instance with a custom GhostContextProvider
- * without requiring VSCode extension context or ClineProvider.
- */
 export function createProviderForTesting(
 	contextProvider: GhostContextProvider,
 	costTrackingCallback: CostTrackingCallback = () => {},


### PR DESCRIPTION
Goal:
* minimal changes in production code
* use a bigger part of the autocomplete code in the benchmark
* make the whole vscode context the input