### PR TITLE
feat: add context file support to autocomplete benchmark

### DIFF
--- a/src/test-llm-autocompletion/ghost-provider-tester.ts
+++ b/src/test-llm-autocompletion/ghost-provider-tester.ts
@@ -12,6 +12,7 @@ import {
 	findMatchingSuggestion,
 } from "../services/ghost/classic-auto-complete/GhostInlineCompletionProvider.js"
 import { GhostModel } from "../services/ghost/GhostModel.js"
+import type { ContextFile } from "./test-cases.js"
 
 export class GhostProviderTester {
 	private llmClient: LLMClient
@@ -27,6 +28,7 @@ export class GhostProviderTester {
 	async getCompletion(
 		code: string,
 		testCaseName: string = "test",
+		contextFiles: ContextFile[] = [],
 	): Promise<{ prefix: string; completion: string; suffix: string }> {
 		const context = createContext(code, testCaseName)
 		const position = context.range?.start ?? context.document.positionAt(0)
@@ -34,7 +36,13 @@ export class GhostProviderTester {
 		const languageId = context.document.languageId || "javascript"
 
 		// Create context provider with the actual content for prompt building
-		const contextProvider = createMockContextProvider(prefix, suffix, context.document.fileName, this.ghostModel)
+		const contextProvider = createMockContextProvider(
+			prefix,
+			suffix,
+			context.document.fileName,
+			this.ghostModel,
+			contextFiles,
+		)
 
 		// Create a fresh provider instance for this completion
 		const provider = createProviderForTesting(contextProvider)

--- a/src/test-llm-autocompletion/mock-context-provider.ts
+++ b/src/test-llm-autocompletion/mock-context-provider.ts
@@ -8,8 +8,13 @@ import {
 import { HoleFiller } from "../services/ghost/classic-auto-complete/HoleFiller.js"
 import { FimPromptBuilder } from "../services/ghost/classic-auto-complete/FillInTheMiddle.js"
 import type { GhostServiceSettings } from "@roo-code/types"
-import type { AutocompleteCodeSnippet } from "../services/continuedev/core/autocomplete/snippets/types.js"
+import {
+	AutocompleteSnippetType,
+	type AutocompleteCodeSnippet,
+	type AutocompleteStaticSnippet,
+} from "../services/continuedev/core/autocomplete/snippets/types.js"
 import type { RecentlyEditedRange } from "../services/continuedev/core/autocomplete/util/types.js"
+import type { ContextFile } from "./test-cases.js"
 
 /**
  * Check if a model supports FIM (Fill-In-Middle) completions.
@@ -79,7 +84,15 @@ export function createMockContextProvider(
 	suffix: string,
 	filepath: string,
 	ghostModel: GhostModel,
+	contextFiles: ContextFile[] = [],
 ): GhostContextProvider {
+	// Convert context files to AutocompleteStaticSnippet format
+	const staticSnippets: AutocompleteStaticSnippet[] = contextFiles.map((file) => ({
+		type: AutocompleteSnippetType.Static,
+		filepath: file.filepath,
+		content: file.content,
+	}))
+
 	return {
 		ide: {
 			readFile: async () => prefix + suffix,
@@ -90,7 +103,7 @@ export function createMockContextProvider(
 			initializeForFile: async () => {},
 			getRootPathSnippets: async () => [],
 			getSnippetsFromImportDefinitions: async () => [],
-			getStaticContextSnippets: async () => [],
+			getStaticContextSnippets: async () => staticSnippets,
 		},
 		model: ghostModel,
 	} as unknown as GhostContextProvider

--- a/src/test-llm-autocompletion/runner.ts
+++ b/src/test-llm-autocompletion/runner.ts
@@ -34,7 +34,11 @@ export class TestRunner {
 	async runTest(testCase: TestCase): Promise<TestResult> {
 		try {
 			const startTime = performance.now()
-			const { prefix, completion, suffix } = await this.tester.getCompletion(testCase.input, testCase.name)
+			const { prefix, completion, suffix } = await this.tester.getCompletion(
+				testCase.input,
+				testCase.name,
+				testCase.contextFiles,
+			)
 			const llmRequestDuration = performance.now() - startTime
 			let actualValue: string = prefix + completion + suffix
 

--- a/src/test-llm-autocompletion/test-cases.ts
+++ b/src/test-llm-autocompletion/test-cases.ts
@@ -65,10 +65,10 @@ function parseHeaders(
 function parseContextFiles(content: string): { mainContent: string; contextFiles: ContextFile[] } {
 	const contextFiles: ContextFile[] = []
 
-	// Split by #### headers to find context files
-	const sections = content.split(/^#### /m)
+	// Split by ##### headers to find context files (5 hashes for context, 4 for metadata)
+	const sections = content.split(/^##### /m)
 
-	// First section is the main file content (before any #### headers)
+	// First section is the main file content (before any ##### headers)
 	const mainContent = sections[0]
 
 	// Remaining sections are context files

--- a/src/test-llm-autocompletion/test-cases.ts
+++ b/src/test-llm-autocompletion/test-cases.ts
@@ -94,15 +94,15 @@ const CONTEXT_FILE_HEADER_PATTERN = /^##### ([^:]+):\s*(.*)$/
 function parseContextFiles(lines: string[], startIndex: number): { mainContent: string; contextFiles: ContextFile[] } {
 	const contextFiles: ContextFile[] = []
 
-	// Read main content until we hit a context file header (##### filepath: value)
+	// Read main content until we hit a context file header (##### Filename: value)
 	const { content: mainContent, nextHeaderIndex } = readUntilHeaders(lines, startIndex, CONTEXT_FILE_HEADER_PATTERN)
 
 	// Parse remaining context files
 	let currentIndex = nextHeaderIndex
 	while (currentIndex < lines.length) {
-		// Parse the context file header (##### filepath: path/to/file)
+		// Parse the context file header (##### Filename: path/to/file)
 		const { headers, contentStartIndex } = parseHeaders(lines, currentIndex, CONTEXT_FILE_HEADER_PATTERN, [
-			"filepath",
+			"filename",
 		])
 
 		// Read content until next context file header or end of file
@@ -113,7 +113,7 @@ function parseContextFiles(lines: string[], startIndex: number): { mainContent: 
 		)
 
 		contextFiles.push({
-			filepath: headers.filepath,
+			filepath: headers.filename,
 			content: fileContent,
 		})
 

--- a/src/test-llm-autocompletion/test-cases/context-aware/config-object-property.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/config-object-property.txt
@@ -10,7 +10,7 @@ const config: ServerConfig = {
     methods: ['GET', 'POST'],
   },
   logging: {
-    level: '<<<CURSOR>>>',
+    level: '<<<AUTOCOMPLETE_HERE>>>',
   },
 };
 

--- a/src/test-llm-autocompletion/test-cases/context-aware/config-object-property.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/config-object-property.txt
@@ -17,7 +17,7 @@ const config: ServerConfig = {
 const server = createServer(config);
 server.start();
 
-##### config/server-config.ts
+##### filepath: config/server-config.ts
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
 export interface CorsConfig {

--- a/src/test-llm-autocompletion/test-cases/context-aware/config-object-property.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/config-object-property.txt
@@ -1,0 +1,51 @@
+# Description: Should autocomplete config object property based on type from another file
+# Filename: server.ts
+import { ServerConfig, createServer } from './config/server-config';
+
+const config: ServerConfig = {
+  port: 3000,
+  host: 'localhost',
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST'],
+  },
+  logging: {
+    level: '<<<CURSOR>>>',
+  },
+};
+
+const server = createServer(config);
+server.start();
+
+#### config/server-config.ts
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+export interface CorsConfig {
+  origin: string | string[];
+  methods: string[];
+  credentials?: boolean;
+  maxAge?: number;
+}
+
+export interface LoggingConfig {
+  level: LogLevel;
+  format?: 'json' | 'pretty';
+  destination?: string;
+}
+
+export interface ServerConfig {
+  port: number;
+  host: string;
+  cors?: CorsConfig;
+  logging?: LoggingConfig;
+  timeout?: number;
+  maxConnections?: number;
+}
+
+export function createServer(config: ServerConfig) {
+  return {
+    config,
+    start: () => console.log(`Server starting on ${config.host}:${config.port}`),
+    stop: () => console.log('Server stopping'),
+  };
+}

--- a/src/test-llm-autocompletion/test-cases/context-aware/config-object-property.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/config-object-property.txt
@@ -17,7 +17,7 @@ const config: ServerConfig = {
 const server = createServer(config);
 server.start();
 
-##### filepath: config/server-config.ts
+##### Filename: config/server-config.ts
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
 export interface CorsConfig {

--- a/src/test-llm-autocompletion/test-cases/context-aware/config-object-property.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/config-object-property.txt
@@ -1,5 +1,5 @@
-# Description: Should autocomplete config object property based on type from another file
-# Filename: server.ts
+#### Description: Should autocomplete config object property based on type from another file
+#### Filename: server.ts
 import { ServerConfig, createServer } from './config/server-config';
 
 const config: ServerConfig = {
@@ -17,7 +17,7 @@ const config: ServerConfig = {
 const server = createServer(config);
 server.start();
 
-#### config/server-config.ts
+##### config/server-config.ts
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
 export interface CorsConfig {

--- a/src/test-llm-autocompletion/test-cases/context-aware/config-object-property.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/config-object-property.txt
@@ -17,7 +17,7 @@ const config: ServerConfig = {
 const server = createServer(config);
 server.start();
 
-##### Filename: config/server-config.ts
+#### Filename: config/server-config.ts
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
 export interface CorsConfig {

--- a/src/test-llm-autocompletion/test-cases/context-aware/interface-implementation.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/interface-implementation.txt
@@ -1,0 +1,34 @@
+# Description: Should autocomplete interface property based on type definition
+# Filename: handlers/order-handler.ts
+import { Order, OrderStatus } from '../types/order';
+
+function processOrder(order: Order): void {
+  if (order.status === OrderStatus.<<<CURSOR>>>) {
+    // Process pending order
+  }
+}
+
+#### types/order.ts
+export interface Order {
+  id: string;
+  customerId: string;
+  items: OrderItem[];
+  status: OrderStatus;
+  totalAmount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface OrderItem {
+  productId: string;
+  quantity: number;
+  price: number;
+}
+
+export enum OrderStatus {
+  Pending = 'pending',
+  Processing = 'processing',
+  Shipped = 'shipped',
+  Delivered = 'delivered',
+  Cancelled = 'cancelled',
+}

--- a/src/test-llm-autocompletion/test-cases/context-aware/interface-implementation.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/interface-implementation.txt
@@ -8,7 +8,7 @@ function processOrder(order: Order): void {
   }
 }
 
-##### types/order.ts
+##### filepath: types/order.ts
 export interface Order {
   id: string;
   customerId: string;

--- a/src/test-llm-autocompletion/test-cases/context-aware/interface-implementation.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/interface-implementation.txt
@@ -1,5 +1,5 @@
-# Description: Should autocomplete interface property based on type definition
-# Filename: handlers/order-handler.ts
+#### Description: Should autocomplete interface property based on type definition
+#### Filename: handlers/order-handler.ts
 import { Order, OrderStatus } from '../types/order';
 
 function processOrder(order: Order): void {
@@ -8,7 +8,7 @@ function processOrder(order: Order): void {
   }
 }
 
-#### types/order.ts
+##### types/order.ts
 export interface Order {
   id: string;
   customerId: string;

--- a/src/test-llm-autocompletion/test-cases/context-aware/interface-implementation.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/interface-implementation.txt
@@ -8,7 +8,7 @@ function processOrder(order: Order): void {
   }
 }
 
-##### Filename: types/order.ts
+#### Filename: types/order.ts
 export interface Order {
   id: string;
   customerId: string;

--- a/src/test-llm-autocompletion/test-cases/context-aware/interface-implementation.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/interface-implementation.txt
@@ -3,7 +3,7 @@
 import { Order, OrderStatus } from '../types/order';
 
 function processOrder(order: Order): void {
-  if (order.status === OrderStatus.<<<CURSOR>>>) {
+  if (order.status === OrderStatus.<<<AUTOCOMPLETE_HERE>>>) {
     // Process pending order
   }
 }

--- a/src/test-llm-autocompletion/test-cases/context-aware/interface-implementation.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/interface-implementation.txt
@@ -8,7 +8,7 @@ function processOrder(order: Order): void {
   }
 }
 
-##### filepath: types/order.ts
+##### Filename: types/order.ts
 export interface Order {
   id: string;
   customerId: string;

--- a/src/test-llm-autocompletion/test-cases/context-aware/method-invocation.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/method-invocation.txt
@@ -5,7 +5,7 @@ import { UserService } from './services/user-service';
 const userService = new UserService();
 const user = userService.<<<AUTOCOMPLETE_HERE>>>
 
-##### filepath: services/user-service.ts
+##### Filename: services/user-service.ts
 export class UserService {
   async findById(id: string): Promise<User | null> {
     // Find user by ID

--- a/src/test-llm-autocompletion/test-cases/context-aware/method-invocation.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/method-invocation.txt
@@ -1,11 +1,11 @@
-# Description: Should autocomplete method invocation from imported class
-# Filename: app.ts
+#### Description: Should autocomplete method invocation from imported class
+#### Filename: app.ts
 import { UserService } from './services/user-service';
 
 const userService = new UserService();
 const user = userService.<<<CURSOR>>>
 
-#### services/user-service.ts
+##### services/user-service.ts
 export class UserService {
   async findById(id: string): Promise<User | null> {
     // Find user by ID

--- a/src/test-llm-autocompletion/test-cases/context-aware/method-invocation.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/method-invocation.txt
@@ -5,7 +5,7 @@ import { UserService } from './services/user-service';
 const userService = new UserService();
 const user = userService.<<<AUTOCOMPLETE_HERE>>>
 
-##### services/user-service.ts
+##### filepath: services/user-service.ts
 export class UserService {
   async findById(id: string): Promise<User | null> {
     // Find user by ID

--- a/src/test-llm-autocompletion/test-cases/context-aware/method-invocation.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/method-invocation.txt
@@ -3,7 +3,7 @@
 import { UserService } from './services/user-service';
 
 const userService = new UserService();
-const user = userService.<<<CURSOR>>>
+const user = userService.<<<AUTOCOMPLETE_HERE>>>
 
 ##### services/user-service.ts
 export class UserService {

--- a/src/test-llm-autocompletion/test-cases/context-aware/method-invocation.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/method-invocation.txt
@@ -5,7 +5,7 @@ import { UserService } from './services/user-service';
 const userService = new UserService();
 const user = userService.<<<AUTOCOMPLETE_HERE>>>
 
-##### Filename: services/user-service.ts
+#### Filename: services/user-service.ts
 export class UserService {
   async findById(id: string): Promise<User | null> {
     // Find user by ID

--- a/src/test-llm-autocompletion/test-cases/context-aware/method-invocation.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/method-invocation.txt
@@ -1,0 +1,39 @@
+# Description: Should autocomplete method invocation from imported class
+# Filename: app.ts
+import { UserService } from './services/user-service';
+
+const userService = new UserService();
+const user = userService.<<<CURSOR>>>
+
+#### services/user-service.ts
+export class UserService {
+  async findById(id: string): Promise<User | null> {
+    // Find user by ID
+    return null;
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    // Find user by email
+    return null;
+  }
+
+  async createUser(data: CreateUserDto): Promise<User> {
+    // Create a new user
+    return {} as User;
+  }
+
+  async deleteUser(id: string): Promise<void> {
+    // Delete user
+  }
+}
+
+interface User {
+  id: string;
+  email: string;
+  name: string;
+}
+
+interface CreateUserDto {
+  email: string;
+  name: string;
+}

--- a/src/test-llm-autocompletion/test-cases/context-aware/utility-function-call.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/utility-function-call.txt
@@ -18,7 +18,7 @@ export function ProductCard({ name, price, releaseDate }: ProductCardProps) {
   );
 }
 
-##### filepath: utils/formatters.ts
+##### Filename: utils/formatters.ts
 /**
  * Format a price value to a currency string
  * @param amount - The price amount in cents

--- a/src/test-llm-autocompletion/test-cases/context-aware/utility-function-call.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/utility-function-call.txt
@@ -12,7 +12,7 @@ export function ProductCard({ name, price, releaseDate }: ProductCardProps) {
   return (
     <div className="product-card">
       <h2>{name}</h2>
-      <p className="price">{formatPrice(<<<CURSOR>>>)}</p>
+      <p className="price">{formatPrice(<<<AUTOCOMPLETE_HERE>>>)}</p>
       <p className="date">Released: {formatDate(releaseDate)}</p>
     </div>
   );

--- a/src/test-llm-autocompletion/test-cases/context-aware/utility-function-call.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/utility-function-call.txt
@@ -18,7 +18,7 @@ export function ProductCard({ name, price, releaseDate }: ProductCardProps) {
   );
 }
 
-##### Filename: utils/formatters.ts
+#### Filename: utils/formatters.ts
 /**
  * Format a price value to a currency string
  * @param amount - The price amount in cents

--- a/src/test-llm-autocompletion/test-cases/context-aware/utility-function-call.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/utility-function-call.txt
@@ -1,0 +1,56 @@
+# Description: Should autocomplete utility function call with correct parameters
+# Filename: components/ProductCard.tsx
+import { formatPrice, formatDate } from '../utils/formatters';
+
+interface ProductCardProps {
+  name: string;
+  price: number;
+  releaseDate: Date;
+}
+
+export function ProductCard({ name, price, releaseDate }: ProductCardProps) {
+  return (
+    <div className="product-card">
+      <h2>{name}</h2>
+      <p className="price">{formatPrice(<<<CURSOR>>>)}</p>
+      <p className="date">Released: {formatDate(releaseDate)}</p>
+    </div>
+  );
+}
+
+#### utils/formatters.ts
+/**
+ * Format a price value to a currency string
+ * @param amount - The price amount in cents
+ * @param currency - The currency code (default: 'USD')
+ * @param locale - The locale for formatting (default: 'en-US')
+ */
+export function formatPrice(
+  amount: number,
+  currency: string = 'USD',
+  locale: string = 'en-US'
+): string {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+  }).format(amount / 100);
+}
+
+/**
+ * Format a date to a human-readable string
+ * @param date - The date to format
+ * @param options - Intl.DateTimeFormat options
+ */
+export function formatDate(
+  date: Date,
+  options: Intl.DateTimeFormatOptions = { dateStyle: 'medium' }
+): string {
+  return new Intl.DateTimeFormat('en-US', options).format(date);
+}
+
+/**
+ * Format a number with thousand separators
+ */
+export function formatNumber(value: number, locale: string = 'en-US'): string {
+  return new Intl.NumberFormat(locale).format(value);
+}

--- a/src/test-llm-autocompletion/test-cases/context-aware/utility-function-call.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/utility-function-call.txt
@@ -18,7 +18,7 @@ export function ProductCard({ name, price, releaseDate }: ProductCardProps) {
   );
 }
 
-##### utils/formatters.ts
+##### filepath: utils/formatters.ts
 /**
  * Format a price value to a currency string
  * @param amount - The price amount in cents

--- a/src/test-llm-autocompletion/test-cases/context-aware/utility-function-call.txt
+++ b/src/test-llm-autocompletion/test-cases/context-aware/utility-function-call.txt
@@ -1,5 +1,5 @@
-# Description: Should autocomplete utility function call with correct parameters
-# Filename: components/ProductCard.tsx
+#### Description: Should autocomplete utility function call with correct parameters
+#### Filename: components/ProductCard.tsx
 import { formatPrice, formatDate } from '../utils/formatters';
 
 interface ProductCardProps {
@@ -18,7 +18,7 @@ export function ProductCard({ name, price, releaseDate }: ProductCardProps) {
   );
 }
 
-#### utils/formatters.ts
+##### utils/formatters.ts
 /**
  * Format a price value to a currency string
  * @param amount - The price amount in cents


### PR DESCRIPTION
## Summary

Adds support for context files in the autocomplete benchmark/eval system. This allows test cases to include additional files that provide context for the autocomplete, enabling testing of cross-file completions.

## Changes

### Test Case Format
Test cases can now include context files using `#### filename` headers:

```
# Description: Test description
# Filename: main-file.ts
// Main file content with <<<CURSOR>>> marker

#### path/to/context-file.ts
// Context file content that will be provided to the autocomplete
```

### Code Changes
- **test-cases.ts**: Added `ContextFile` interface and parsing for `#### filename` headers
- **mock-context-provider.ts**: Updated to return context files as static snippets via `getStaticContextSnippets()`
- **ghost-provider-tester.ts**: Updated to pass context files to the provider
- **runner.ts**: Updated to pass `testCase.contextFiles` to `getCompletion()`

### New Test Cases
Added 4 new context-aware test cases in `test-cases/context-aware/`:
1. **method-invocation**: Autocomplete method from imported class
2. **interface-implementation**: Autocomplete enum value from type definition
3. **utility-function-call**: Autocomplete function parameters from utility file
4. **config-object-property**: Autocomplete string literal type from config

## Testing
The existing test cases continue to work unchanged (they have empty `contextFiles` arrays).