### PR TITLE
feat: change test case headers from # to ####

### DIFF
--- a/src/test-llm-autocompletion/test-cases.ts
+++ b/src/test-llm-autocompletion/test-cases.ts
@@ -35,7 +35,7 @@ function parseHeaders(
 
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i]
-		const headerMatch = line.match(/^# ([^:]+):\s*(.*)$/)
+		const headerMatch = line.match(/^#### ([^:]+):\s*(.*)$/)
 
 		if (headerMatch) {
 			const [, name, value] = headerMatch

--- a/src/test-llm-autocompletion/test-cases/api-patterns/rest-api-client.txt
+++ b/src/test-llm-autocompletion/test-cases/api-patterns/rest-api-client.txt
@@ -1,5 +1,5 @@
-# Description: Should complete REST API client method
-# Filename: api-client.js
+#### Description: Should complete REST API client method
+#### Filename: api-client.js
 class ApiClient {
 	async post(endpoint, data) {
 		const response = await fetch(this.baseUrl + endpoint, {

--- a/src/test-llm-autocompletion/test-cases/api-patterns/retry-logic.txt
+++ b/src/test-llm-autocompletion/test-cases/api-patterns/retry-logic.txt
@@ -1,5 +1,5 @@
-# Description: Should complete retry logic with exponential backoff
-# Filename: fetch-utils.js
+#### Description: Should complete retry logic with exponential backoff
+#### Filename: fetch-utils.js
 async function fetchWithRetry(url, maxRetries = 3) {
 	for (let attempt = 0; attempt < maxRetries; attempt++) {
 		try {

--- a/src/test-llm-autocompletion/test-cases/class-patterns/class-constructor.rb.txt
+++ b/src/test-llm-autocompletion/test-cases/class-patterns/class-constructor.rb.txt
@@ -1,5 +1,5 @@
-# Description: Should complete Ruby initialize method with instance variables
-# Filename: user.rb
+#### Description: Should complete Ruby initialize method with instance variables
+#### Filename: user.rb
 class User
 	def initialize(username, email, role)
 		@username = username

--- a/src/test-llm-autocompletion/test-cases/class-patterns/class-constructor.txt
+++ b/src/test-llm-autocompletion/test-cases/class-patterns/class-constructor.txt
@@ -1,5 +1,5 @@
-# Description: Should complete constructor with parameter initialization
-# Filename: user.js
+#### Description: Should complete constructor with parameter initialization
+#### Filename: user.js
 class User {
 	constructor(username, email, role) {
 		this.username = username;

--- a/src/test-llm-autocompletion/test-cases/class-patterns/class-inheritance.rb.txt
+++ b/src/test-llm-autocompletion/test-cases/class-patterns/class-inheritance.rb.txt
@@ -1,5 +1,5 @@
-# Description: Should complete Ruby class inheritance with super
-# Filename: animals.rb
+#### Description: Should complete Ruby class inheritance with super
+#### Filename: animals.rb
 class Animal
 	def initialize(name)
 		@name = name

--- a/src/test-llm-autocompletion/test-cases/class-patterns/class-inheritance.txt
+++ b/src/test-llm-autocompletion/test-cases/class-patterns/class-inheritance.txt
@@ -1,5 +1,5 @@
-# Description: Should complete class inheritance with extends and super
-# Filename: animals.js
+#### Description: Should complete class inheritance with extends and super
+#### Filename: animals.js
 class Animal {
 	constructor(name) {
 		this.name = name;

--- a/src/test-llm-autocompletion/test-cases/class-patterns/class-method-override.rb.txt
+++ b/src/test-llm-autocompletion/test-cases/class-patterns/class-method-override.rb.txt
@@ -1,5 +1,5 @@
-# Description: Should complete Ruby method override in derived class
-# Filename: shapes.rb
+#### Description: Should complete Ruby method override in derived class
+#### Filename: shapes.rb
 class Shape
 	def area
 		0

--- a/src/test-llm-autocompletion/test-cases/class-patterns/class-method-override.txt
+++ b/src/test-llm-autocompletion/test-cases/class-patterns/class-method-override.txt
@@ -1,5 +1,5 @@
-# Description: Should complete method override in derived class
-# Filename: shapes.js
+#### Description: Should complete method override in derived class
+#### Filename: shapes.js
 class Shape {
 	area() {
 		return 0;

--- a/src/test-llm-autocompletion/test-cases/comment-driven/fixme-bug.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/fixme-bug.txt
@@ -1,5 +1,5 @@
-# Description: Should fix bug described in FIXME comment
-# Filename: math-utils.js
+#### Description: Should fix bug described in FIXME comment
+#### Filename: math-utils.js
 function divide(a, b) {
   // FIXME: Handle division by zero<<<CURSOR>>>
   return a / b;

--- a/src/test-llm-autocompletion/test-cases/comment-driven/implement-function-add-numbers.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/implement-function-add-numbers.txt
@@ -1,3 +1,3 @@
-# Description: Should fix bug described in FIXME comment
-# Filename: calculator.js
+#### Description: Should fix bug described in FIXME comment
+#### Filename: calculator.js
 // Implement functino to add two numbers<<<CURSOR>>>

--- a/src/test-llm-autocompletion/test-cases/comment-driven/implement-function-combine-functions.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/implement-function-combine-functions.txt
@@ -1,5 +1,5 @@
-# Description: Should fix bug described in FIXME comment
-# Filename: math-operations.js
+#### Description: Should fix bug described in FIXME comment
+#### Filename: math-operations.js
 
 function addNumbers(a, b) {
     return a + b

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-caching.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-caching.txt
@@ -1,5 +1,5 @@
-# Description: Should implement caching mechanism after TODO
-# Filename: data-service.js
+#### Description: Should implement caching mechanism after TODO
+#### Filename: data-service.js
 class DataService {
   // TODO: Implement caching mechanism to reduce API calls<<<CURSOR>>>
   async fetchData(id) {

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-debounce.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-debounce.txt
@@ -1,5 +1,5 @@
-# Description: Should implement debounce function
-# Filename: search-handler.js
+#### Description: Should implement debounce function
+#### Filename: search-handler.js
 function handleSearch(query) {
   // TODO: Add debounce to prevent excessive API calls<<<CURSOR>>>
   searchAPI(query);

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-error-handling.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-error-handling.txt
@@ -1,5 +1,5 @@
-# Description: Should implement error handling after TODO comment
-# Filename: data-processor.js
+#### Description: Should implement error handling after TODO comment
+#### Filename: data-processor.js
 function processData(data) {
   // TODO: Implement error handling<<<CURSOR>>>
   return processedData;

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-logging.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-logging.txt
@@ -1,5 +1,5 @@
-# Description: Should add logging functionality after TODO
-# Filename: order-processor.js
+#### Description: Should add logging functionality after TODO
+#### Filename: order-processor.js
 function processOrder(order) {
   // TODO: Add comprehensive logging for order processing<<<CURSOR>>>
   const result = validateOrder(order);

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-pagination.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-pagination.txt
@@ -1,5 +1,5 @@
-# Description: Should implement pagination logic
-# Filename: user-repository.js
+#### Description: Should implement pagination logic
+#### Filename: user-repository.js
 function fetchUsers(page, limit) {
   // TODO: Implement pagination with offset and limit<<<CURSOR>>>
   return db.query('SELECT * FROM users');

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-rate-limiting.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-rate-limiting.txt
@@ -1,5 +1,5 @@
-# Description: Should implement rate limiting for API endpoints
-# Filename: api-middleware.js
+#### Description: Should implement rate limiting for API endpoints
+#### Filename: api-middleware.js
 function handleAPIRequest(req, res) {
   // TODO: Implement rate limiting to prevent abuse<<<CURSOR>>>
   processRequest(req, res);

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-retry-logic.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-retry-logic.txt
@@ -1,5 +1,5 @@
-# Description: Should implement retry logic with exponential backoff
-# Filename: http-client.js
+#### Description: Should implement retry logic with exponential backoff
+#### Filename: http-client.js
 async function fetchWithRetry(url) {
   // TODO: Implement retry logic with exponential backoff<<<CURSOR>>>
   const response = await fetch(url);

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-sanitize-input.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-sanitize-input.txt
@@ -1,5 +1,5 @@
-# Description: Should sanitize user input to prevent XSS attacks
-# Filename: comment-renderer.js
+#### Description: Should sanitize user input to prevent XSS attacks
+#### Filename: comment-renderer.js
 function renderUserComment(comment) {
   // TODO: Sanitize input to prevent XSS attacks<<<CURSOR>>>
   document.getElementById('comments').innerHTML = comment;

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-validation.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-validation.txt
@@ -1,5 +1,5 @@
-# Description: Should add input validation after TODO comment
-# Filename: auth-service.js
+#### Description: Should add input validation after TODO comment
+#### Filename: auth-service.js
 function registerUser(email, password) {
   // TODO: Add input validation for email and password<<<CURSOR>>>
   return createUser(email, password);

--- a/src/test-llm-autocompletion/test-cases/complex/chained-methods.txt
+++ b/src/test-llm-autocompletion/test-cases/complex/chained-methods.txt
@@ -1,5 +1,5 @@
-# Description: Should suggest chained array methods
-# Filename: array-utils.js
+#### Description: Should suggest chained array methods
+#### Filename: array-utils.js
 const result = [1, 2, 3]
 	.map(x => x * 2)
 	.<<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/complex/nested-object.txt
+++ b/src/test-llm-autocompletion/test-cases/complex/nested-object.txt
@@ -1,5 +1,5 @@
-# Description: Should suggest nested object properties
-# Filename: config.js
+#### Description: Should suggest nested object properties
+#### Filename: config.js
 const config = {
 	server: {
 	  port: 3000,

--- a/src/test-llm-autocompletion/test-cases/control-flow/for-loop.rb.txt
+++ b/src/test-llm-autocompletion/test-cases/control-flow/for-loop.rb.txt
@@ -1,5 +1,5 @@
-# Description: Should complete Ruby loop iteration
-# Filename: loop_example.rb
+#### Description: Should complete Ruby loop iteration
+#### Filename: loop_example.rb
 arr = [1, 2, 3, 4, 5]
 arr.each do |item|
 	<<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/control-flow/for-loop.txt
+++ b/src/test-llm-autocompletion/test-cases/control-flow/for-loop.txt
@@ -1,3 +1,3 @@
-# Description: Should complete for loop body
-# Filename: loop-example.js
+#### Description: Should complete for loop body
+#### Filename: loop-example.js
 for (let i = 0; i < 10; i++) <<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/control-flow/if-statement.rb.txt
+++ b/src/test-llm-autocompletion/test-cases/control-flow/if-statement.rb.txt
@@ -1,5 +1,5 @@
-# Description: Should complete if statement body in Ruby
-# Filename: conditional.rb
+#### Description: Should complete if statement body in Ruby
+#### Filename: conditional.rb
 x = 10
 if x > 5
 	<<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/control-flow/if-statement.txt
+++ b/src/test-llm-autocompletion/test-cases/control-flow/if-statement.txt
@@ -1,4 +1,4 @@
-# Description: Should complete if statement body
-# Filename: conditional.js
+#### Description: Should complete if statement body
+#### Filename: conditional.js
 const x = 10;
 if (x > 5) <<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/control-flow/return-statement.rb.txt
+++ b/src/test-llm-autocompletion/test-cases/control-flow/return-statement.rb.txt
@@ -1,5 +1,5 @@
-# Description: Should complete Ruby return statement
-# Filename: calculator.rb
+#### Description: Should complete Ruby return statement
+#### Filename: calculator.rb
 def calculate_total(items)
 	sum = 0
 	items.each { |item| sum += item }

--- a/src/test-llm-autocompletion/test-cases/data-transformation/array-reduce-complex.txt
+++ b/src/test-llm-autocompletion/test-cases/data-transformation/array-reduce-complex.txt
@@ -1,5 +1,5 @@
-# Description: Should complete complex array reduce operation
-# Filename: order-analytics.js
+#### Description: Should complete complex array reduce operation
+#### Filename: order-analytics.js
 const orders = [{id: 1, items: [{price: 10}, {price: 20}]}, {id: 2, items: [{price: 15}]}];
 const totalRevenue = orders.reduce((acc, order) => {
 	const orderTotal = order.items.reduce((sum, item) => <<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/data-transformation/data-pipeline.txt
+++ b/src/test-llm-autocompletion/test-cases/data-transformation/data-pipeline.txt
@@ -1,5 +1,5 @@
-# Description: Should complete chained data transformation pipeline
-# Filename: data-pipeline.js
+#### Description: Should complete chained data transformation pipeline
+#### Filename: data-pipeline.js
 const data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 const result = data
 	.filter(n => n % 2 === 0)

--- a/src/test-llm-autocompletion/test-cases/data-transformation/object-mapping.txt
+++ b/src/test-llm-autocompletion/test-cases/data-transformation/object-mapping.txt
@@ -1,5 +1,5 @@
-# Description: Should complete object transformation mapping
-# Filename: user-mapper.js
+#### Description: Should complete object transformation mapping
+#### Filename: user-mapper.js
 const users = [{id: 1, firstName: 'John', lastName: 'Doe'}, {id: 2, firstName: 'Jane', lastName: 'Smith'}];
 const userDTOs = users.map(user => ({
 	id: user.id,

--- a/src/test-llm-autocompletion/test-cases/error-handling/promise-rejection.txt
+++ b/src/test-llm-autocompletion/test-cases/error-handling/promise-rejection.txt
@@ -1,5 +1,5 @@
-# Description: Should complete promise rejection handling
-# Filename: user-service.js
+#### Description: Should complete promise rejection handling
+#### Filename: user-service.js
 fetchUser(userId)
 	.then(user => {
 		return processUser(user);

--- a/src/test-llm-autocompletion/test-cases/error-handling/rescue-handling.rb.txt
+++ b/src/test-llm-autocompletion/test-cases/error-handling/rescue-handling.rb.txt
@@ -1,5 +1,5 @@
-# Description: Should complete Ruby begin-rescue-ensure error handling
-# Filename: data_processor.rb
+#### Description: Should complete Ruby begin-rescue-ensure error handling
+#### Filename: data_processor.rb
 def process_data(data)
 	begin
 		result = JSON.parse(data)

--- a/src/test-llm-autocompletion/test-cases/error-handling/try-catch-finally.txt
+++ b/src/test-llm-autocompletion/test-cases/error-handling/try-catch-finally.txt
@@ -1,5 +1,5 @@
-# Description: Should complete try-catch-finally error handling
-# Filename: data-processor.js
+#### Description: Should complete try-catch-finally error handling
+#### Filename: data-processor.js
 function processData(data) {
 	try {
 		const result = JSON.parse(data);

--- a/src/test-llm-autocompletion/test-cases/function-call/function-call-args.txt
+++ b/src/test-llm-autocompletion/test-cases/function-call/function-call-args.txt
@@ -1,4 +1,4 @@
-# Description: Should suggest function call argument completion
-# Filename: greeting.js
+#### Description: Should suggest function call argument completion
+#### Filename: greeting.js
 function greet(name) { return 'Hello ' + name; }
 greet(<<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/function-declaration/arrow-function.txt
+++ b/src/test-llm-autocompletion/test-cases/function-declaration/arrow-function.txt
@@ -1,3 +1,3 @@
-# Description: Should complete arrow function syntax
-# Filename: math-helpers.js
+#### Description: Should complete arrow function syntax
+#### Filename: math-helpers.js
 const add = (a, b) <<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/function-declaration/function-body.rb.txt
+++ b/src/test-llm-autocompletion/test-cases/function-declaration/function-body.rb.txt
@@ -1,4 +1,4 @@
-# Description: Should complete Ruby method body
-# Filename: calculator.rb
+#### Description: Should complete Ruby method body
+#### Filename: calculator.rb
 def calculate_sum(a, b)
 	<<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/function-declaration/function-body.txt
+++ b/src/test-llm-autocompletion/test-cases/function-declaration/function-body.txt
@@ -1,3 +1,3 @@
-# Description: Should complete function body opening
-# Filename: calculator.js
+#### Description: Should complete function body opening
+#### Filename: calculator.js
 function calculateSum(a, b) <<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/import-statement/import-curly-brace.txt
+++ b/src/test-llm-autocompletion/test-cases/import-statement/import-curly-brace.txt
@@ -1,3 +1,3 @@
-# Description: Should suggest import syntax options
-# Filename: App.jsx
+#### Description: Should suggest import syntax options
+#### Filename: App.jsx
 import <<<AUTOCOMPLETE_HERE>>> from 'react'

--- a/src/test-llm-autocompletion/test-cases/inline-completion/conditional-expression.txt
+++ b/src/test-llm-autocompletion/test-cases/inline-completion/conditional-expression.txt
@@ -1,5 +1,5 @@
-# Description: Should complete conditional expression
-# Filename: validator.js
+#### Description: Should complete conditional expression
+#### Filename: validator.js
 function isValid(value) {
   return value !== null && <<<CURSOR>>>;
 }

--- a/src/test-llm-autocompletion/test-cases/inline-completion/function-parameter.txt
+++ b/src/test-llm-autocompletion/test-cases/inline-completion/function-parameter.txt
@@ -1,5 +1,5 @@
-# Description: Should complete function call parameters
-# Filename: greeter.js
+#### Description: Should complete function call parameters
+#### Filename: greeter.js
 function greet(name, <<<CURSOR>>>) {
   console.log(`Hello ${name}!`);
 }

--- a/src/test-llm-autocompletion/test-cases/inline-completion/property-access.txt
+++ b/src/test-llm-autocompletion/test-cases/inline-completion/property-access.txt
@@ -1,4 +1,4 @@
-# Description: Should complete property access after dot
-# Filename: user-display.js
+#### Description: Should complete property access after dot
+#### Filename: user-display.js
 const user = { name: 'John', age: 30 };
 console.log(user.<<<CURSOR>>>);

--- a/src/test-llm-autocompletion/test-cases/inline-completion/variable-assignment-value.txt
+++ b/src/test-llm-autocompletion/test-cases/inline-completion/variable-assignment-value.txt
@@ -1,4 +1,4 @@
-# Description: Should complete variable assignment value
-# Filename: totals.js
+#### Description: Should complete variable assignment value
+#### Filename: totals.js
 const total = <<<CURSOR>>>;
 const items = [1, 2, 3, 4, 5];

--- a/src/test-llm-autocompletion/test-cases/larger-examples/gilded-rose.ts.txt
+++ b/src/test-llm-autocompletion/test-cases/larger-examples/gilded-rose.ts.txt
@@ -1,5 +1,5 @@
-# Description: Gilded Rose Kata code with ReadStream. Should autocomplete 50
-# Filename: gilded-rose.ts
+#### Description: Gilded Rose Kata code with ReadStream. Should autocomplete 50
+#### Filename: gilded-rose.ts
 
 /* README
 

--- a/src/test-llm-autocompletion/test-cases/larger-examples/sudoku.html.txt
+++ b/src/test-llm-autocompletion/test-cases/larger-examples/sudoku.html.txt
@@ -1,5 +1,5 @@
-# Description: 1 file Sudoku game; completion should fill height same way as width
-# Filename: sudoku.html
+#### Description: 1 file Sudoku game; completion should fill height same way as width
+#### Filename: sudoku.html
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/src/test-llm-autocompletion/test-cases/new-line/after-for-loop.txt
+++ b/src/test-llm-autocompletion/test-cases/new-line/after-for-loop.txt
@@ -1,5 +1,5 @@
-# Description: Should complete for loop body
-# Filename: array-utils.js
+#### Description: Should complete for loop body
+#### Filename: array-utils.js
 function sumArray(arr) {
   let sum = 0;
   for (let i = 0; i < arr.length; i++) {

--- a/src/test-llm-autocompletion/test-cases/new-line/after-if-statement.txt
+++ b/src/test-llm-autocompletion/test-cases/new-line/after-if-statement.txt
@@ -1,5 +1,5 @@
-# Description: Should complete if statement body
-# Filename: value-checker.js
+#### Description: Should complete if statement body
+#### Filename: value-checker.js
 function checkValue(value) {
   if (value > 0) {
 <<<CURSOR>>>

--- a/src/test-llm-autocompletion/test-cases/new-line/before-closing-brace.txt
+++ b/src/test-llm-autocompletion/test-cases/new-line/before-closing-brace.txt
@@ -1,5 +1,5 @@
-# Description: Should add return statement before closing brace
-# Filename: total-calculator.js
+#### Description: Should add return statement before closing brace
+#### Filename: total-calculator.js
 function calculateTotal(items) {
   const sum = items.reduce((a, b) => a + b, 0);
 <<<CURSOR>>>

--- a/src/test-llm-autocompletion/test-cases/variable-assignment/array-declaration.rb.txt
+++ b/src/test-llm-autocompletion/test-cases/variable-assignment/array-declaration.rb.txt
@@ -1,3 +1,3 @@
-# Description: Should complete Ruby array declaration
-# Filename: data.rb
+#### Description: Should complete Ruby array declaration
+#### Filename: data.rb
 arr = [1, 2, <<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/variable-assignment/array-declaration.txt
+++ b/src/test-llm-autocompletion/test-cases/variable-assignment/array-declaration.txt
@@ -1,3 +1,3 @@
-# Description: Should suggest array initialization
-# Filename: data.js
+#### Description: Should suggest array initialization
+#### Filename: data.js
 const numbers = <<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/variable-assignment/object-declaration.rb.txt
+++ b/src/test-llm-autocompletion/test-cases/variable-assignment/object-declaration.rb.txt
@@ -1,5 +1,5 @@
-# Description: Should complete Ruby hash declaration
-# Filename: user.rb
+#### Description: Should complete Ruby hash declaration
+#### Filename: user.rb
 user = {
 	name: 'John',
 	email: <<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/variable-assignment/object-declaration.txt
+++ b/src/test-llm-autocompletion/test-cases/variable-assignment/object-declaration.txt
@@ -1,3 +1,3 @@
-# Description: Should suggest object initialization
-# Filename: config.js
+#### Description: Should suggest object initialization
+#### Filename: config.js
 const config = <<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/variable-assignment/variable-assignment.rb.txt
+++ b/src/test-llm-autocompletion/test-cases/variable-assignment/variable-assignment.rb.txt
@@ -1,4 +1,4 @@
-# Description: Should complete Ruby variable assignment
-# Filename: variables.rb
+#### Description: Should complete Ruby variable assignment
+#### Filename: variables.rb
 x = 10
 y = <<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/variable-assignment/variable-assignment.txt
+++ b/src/test-llm-autocompletion/test-cases/variable-assignment/variable-assignment.txt
@@ -1,3 +1,3 @@
-# Description: Should suggest common variable assignments
-# Filename: user-data.js
+#### Description: Should suggest common variable assignments
+#### Filename: user-data.js
 const userName = <<<AUTOCOMPLETE_HERE>>>


### PR DESCRIPTION
## Summary

Changed the header format in autocompletion test cases from single `#` to quadruple `####` for better visual distinction.

## Changes

- Updated `parseHeaders()` regex in [`test-cases.ts`](src/test-llm-autocompletion/test-cases.ts:38) from `/^# ([^:]+):\s*(.*)$/` to `/^#### ([^:]+):\s*(.*)$/`
- Updated all 53 test case files to use `####` prefix for headers

## Test Case Format

Before:
```
# Description: Should complete constructor with parameter initialization
# Filename: user.js
class User {
  constructor(username, email, role) {
```

After:
```
#### Description: Should complete constructor with parameter initialization
#### Filename: user.js
class User {
  constructor(username, email, role) {
```

## Testing

All 25 tests pass (12 in test-cases.spec.ts, 13 in approvals.spec.ts).