### PR TITLE
fix: normalize line endings in test case parser for Windows compatibility

### DIFF
--- a/src/test-llm-autocompletion/test-cases.ts
+++ b/src/test-llm-autocompletion/test-cases.ts
@@ -58,7 +58,9 @@ function parseHeaders(
 
 function parseTestCaseFile(filePath: string): { description: string; filename: string; input: string } {
 	const content = fs.readFileSync(filePath, "utf-8")
-	const lines = content.split("\n")
+	// Normalize line endings to handle Windows CRLF
+	const normalizedContent = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+	const lines = normalizedContent.split("\n")
 
 	const { headers, contentStartIndex } = parseHeaders(lines, filePath, ["description", "filename"])
 


### PR DESCRIPTION
## Problem

On Windows, the test case parser was failing with:
```
Error: Invalid test case file format: D:\a\***/***/src/test-llm-autocompletion/test-cases/api-patterns/rest-api-client.txt. Missing headers: description, filename
```

## Cause

The parser was splitting file content by `\n` only, but Windows uses `\r\n` (CRLF) line endings. This caused the `\r` character to remain at the end of each line, preventing the header regex pattern from matching correctly.

## Solution

Normalize line endings by replacing `\r\n` and standalone `\r` with `\n` before splitting the file content into lines.

## Testing

- All 25 tests pass locally on macOS
- Should now work correctly on Windows CI