### PR TITLE
refactor: standardize on AUTOCOMPLETE_HERE marker in test cases

### DIFF
--- a/src/test-llm-autocompletion/test-cases.ts
+++ b/src/test-llm-autocompletion/test-cases.ts
@@ -126,12 +126,10 @@ function parseTestCaseFile(filePath: string): {
 		currentIndex = nextIndex
 	}
 
-	const input = mainContent
-
 	return {
 		description: headers.description,
 		filename: headers.filename,
-		input,
+		input: mainContent,
 		contextFiles,
 	}
 }

--- a/src/test-llm-autocompletion/test-cases.ts
+++ b/src/test-llm-autocompletion/test-cases.ts
@@ -126,7 +126,7 @@ function parseTestCaseFile(filePath: string): {
 		currentIndex = nextIndex
 	}
 
-	const input = mainContent.replace(/<<<CURSOR>>>/g, CURSOR_MARKER)
+	const input = mainContent
 
 	return {
 		description: headers.description,

--- a/src/test-llm-autocompletion/test-cases/comment-driven/fixme-bug.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/fixme-bug.txt
@@ -1,6 +1,6 @@
 #### Description: Should fix bug described in FIXME comment
 #### Filename: math-utils.js
 function divide(a, b) {
-  // FIXME: Handle division by zero<<<CURSOR>>>
+  // FIXME: Handle division by zero<<<AUTOCOMPLETE_HERE>>>
   return a / b;
 }

--- a/src/test-llm-autocompletion/test-cases/comment-driven/implement-function-add-numbers.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/implement-function-add-numbers.txt
@@ -1,3 +1,3 @@
 #### Description: Should fix bug described in FIXME comment
 #### Filename: calculator.js
-// Implement functino to add two numbers<<<CURSOR>>>
+// Implement functino to add two numbers<<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/comment-driven/implement-function-combine-functions.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/implement-function-combine-functions.txt
@@ -9,4 +9,4 @@ function multiplyBy5(a) {
     return a * 5
 }
 
-// Implement function to combine above functions<<<CURSOR>>>
+// Implement function to combine above functions<<<AUTOCOMPLETE_HERE>>>

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-caching.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-caching.txt
@@ -1,7 +1,7 @@
 #### Description: Should implement caching mechanism after TODO
 #### Filename: data-service.js
 class DataService {
-  // TODO: Implement caching mechanism to reduce API calls<<<CURSOR>>>
+  // TODO: Implement caching mechanism to reduce API calls<<<AUTOCOMPLETE_HERE>>>
   async fetchData(id) {
     return await api.get(`/data/${id}`);
   }

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-debounce.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-debounce.txt
@@ -1,6 +1,6 @@
 #### Description: Should implement debounce function
 #### Filename: search-handler.js
 function handleSearch(query) {
-  // TODO: Add debounce to prevent excessive API calls<<<CURSOR>>>
+  // TODO: Add debounce to prevent excessive API calls<<<AUTOCOMPLETE_HERE>>>
   searchAPI(query);
 }

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-error-handling.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-error-handling.txt
@@ -1,6 +1,6 @@
 #### Description: Should implement error handling after TODO comment
 #### Filename: data-processor.js
 function processData(data) {
-  // TODO: Implement error handling<<<CURSOR>>>
+  // TODO: Implement error handling<<<AUTOCOMPLETE_HERE>>>
   return processedData;
 }

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-logging.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-logging.txt
@@ -1,7 +1,7 @@
 #### Description: Should add logging functionality after TODO
 #### Filename: order-processor.js
 function processOrder(order) {
-  // TODO: Add comprehensive logging for order processing<<<CURSOR>>>
+  // TODO: Add comprehensive logging for order processing<<<AUTOCOMPLETE_HERE>>>
   const result = validateOrder(order);
   return result;
 }

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-pagination.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-pagination.txt
@@ -1,6 +1,6 @@
 #### Description: Should implement pagination logic
 #### Filename: user-repository.js
 function fetchUsers(page, limit) {
-  // TODO: Implement pagination with offset and limit<<<CURSOR>>>
+  // TODO: Implement pagination with offset and limit<<<AUTOCOMPLETE_HERE>>>
   return db.query('SELECT * FROM users');
 }

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-rate-limiting.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-rate-limiting.txt
@@ -1,6 +1,6 @@
 #### Description: Should implement rate limiting for API endpoints
 #### Filename: api-middleware.js
 function handleAPIRequest(req, res) {
-  // TODO: Implement rate limiting to prevent abuse<<<CURSOR>>>
+  // TODO: Implement rate limiting to prevent abuse<<<AUTOCOMPLETE_HERE>>>
   processRequest(req, res);
 }

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-retry-logic.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-retry-logic.txt
@@ -1,7 +1,7 @@
 #### Description: Should implement retry logic with exponential backoff
 #### Filename: http-client.js
 async function fetchWithRetry(url) {
-  // TODO: Implement retry logic with exponential backoff<<<CURSOR>>>
+  // TODO: Implement retry logic with exponential backoff<<<AUTOCOMPLETE_HERE>>>
   const response = await fetch(url);
   return response.json();
 }

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-sanitize-input.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-sanitize-input.txt
@@ -1,6 +1,6 @@
 #### Description: Should sanitize user input to prevent XSS attacks
 #### Filename: comment-renderer.js
 function renderUserComment(comment) {
-  // TODO: Sanitize input to prevent XSS attacks<<<CURSOR>>>
+  // TODO: Sanitize input to prevent XSS attacks<<<AUTOCOMPLETE_HERE>>>
   document.getElementById('comments').innerHTML = comment;
 }

--- a/src/test-llm-autocompletion/test-cases/comment-driven/todo-validation.txt
+++ b/src/test-llm-autocompletion/test-cases/comment-driven/todo-validation.txt
@@ -1,6 +1,6 @@
 #### Description: Should add input validation after TODO comment
 #### Filename: auth-service.js
 function registerUser(email, password) {
-  // TODO: Add input validation for email and password<<<CURSOR>>>
+  // TODO: Add input validation for email and password<<<AUTOCOMPLETE_HERE>>>
   return createUser(email, password);
 }

--- a/src/test-llm-autocompletion/test-cases/inline-completion/conditional-expression.txt
+++ b/src/test-llm-autocompletion/test-cases/inline-completion/conditional-expression.txt
@@ -1,5 +1,5 @@
 #### Description: Should complete conditional expression
 #### Filename: validator.js
 function isValid(value) {
-  return value !== null && <<<CURSOR>>>;
+  return value !== null && <<<AUTOCOMPLETE_HERE>>>;
 }

--- a/src/test-llm-autocompletion/test-cases/inline-completion/function-parameter.txt
+++ b/src/test-llm-autocompletion/test-cases/inline-completion/function-parameter.txt
@@ -1,5 +1,5 @@
 #### Description: Should complete function call parameters
 #### Filename: greeter.js
-function greet(name, <<<CURSOR>>>) {
+function greet(name, <<<AUTOCOMPLETE_HERE>>>) {
   console.log(`Hello ${name}!`);
 }

--- a/src/test-llm-autocompletion/test-cases/inline-completion/property-access.txt
+++ b/src/test-llm-autocompletion/test-cases/inline-completion/property-access.txt
@@ -1,4 +1,4 @@
 #### Description: Should complete property access after dot
 #### Filename: user-display.js
 const user = { name: 'John', age: 30 };
-console.log(user.<<<CURSOR>>>);
+console.log(user.<<<AUTOCOMPLETE_HERE>>>);

--- a/src/test-llm-autocompletion/test-cases/inline-completion/variable-assignment-value.txt
+++ b/src/test-llm-autocompletion/test-cases/inline-completion/variable-assignment-value.txt
@@ -1,4 +1,4 @@
 #### Description: Should complete variable assignment value
 #### Filename: totals.js
-const total = <<<CURSOR>>>;
+const total = <<<AUTOCOMPLETE_HERE>>>;
 const items = [1, 2, 3, 4, 5];

--- a/src/test-llm-autocompletion/test-cases/new-line/after-for-loop.txt
+++ b/src/test-llm-autocompletion/test-cases/new-line/after-for-loop.txt
@@ -3,7 +3,7 @@
 function sumArray(arr) {
   let sum = 0;
   for (let i = 0; i < arr.length; i++) {
-<<<CURSOR>>>
+<<<AUTOCOMPLETE_HERE>>>
   }
   return sum;
 }

--- a/src/test-llm-autocompletion/test-cases/new-line/after-if-statement.txt
+++ b/src/test-llm-autocompletion/test-cases/new-line/after-if-statement.txt
@@ -2,7 +2,7 @@
 #### Filename: value-checker.js
 function checkValue(value) {
   if (value > 0) {
-<<<CURSOR>>>
+<<<AUTOCOMPLETE_HERE>>>
   }
   return false;
 }

--- a/src/test-llm-autocompletion/test-cases/new-line/before-closing-brace.txt
+++ b/src/test-llm-autocompletion/test-cases/new-line/before-closing-brace.txt
@@ -2,5 +2,5 @@
 #### Filename: total-calculator.js
 function calculateTotal(items) {
   const sum = items.reduce((a, b) => a + b, 0);
-<<<CURSOR>>>
+<<<AUTOCOMPLETE_HERE>>>
 }


### PR DESCRIPTION
## Summary

- Remove `<<<CURSOR>>>` to `AUTOCOMPLETE_HERE` replacement in test-cases.ts
- Update all test case files to use `<<<AUTOCOMPLETE_HERE>>>` directly
- Simplifies the code by removing unnecessary transformation

## Changes

1. Modified `src/test-llm-autocompletion/test-cases.ts` to remove the `.replace(/<<<CURSOR>>>/g, CURSOR_MARKER)` call
2. Updated 19 test case files to use `<<<AUTOCOMPLETE_HERE>>>` instead of `<<<CURSOR>>>`

## Testing

All tests pass (`pnpm test test-llm-autocompletion/test-cases.spec.ts`)