### PR TITLE
Fix wrapping for organization provider routing button

### DIFF
--- a/webview-ui/src/components/settings/providers/KiloProviderRouting.tsx
+++ b/webview-ui/src/components/settings/providers/KiloProviderRouting.tsx
@@ -58,7 +58,7 @@ export const KiloProviderRoutingManagedByOrganization = (props: { organizationId
 				<VSCodeButtonLink
 					href={getAppUrl(`/organizations/${props.organizationId}`)}
 					appearance="secondary"
-					className="text-sm w-full">
+					className="text-sm w-full whitespace-normal h-auto py-3">
 					{t("kilocode:settings.provider.providerRouting.managedByOrganization")}
 				</VSCodeButtonLink>
 			</div>
@@ -169,7 +169,7 @@ export const KiloProviderRouting = ({ apiConfiguration, setApiConfigurationField
 					}}
 					href={getAppUrl("/organizations/new")}
 					appearance="primary"
-					className="text-sm w-full">
+					className="text-sm w-full whitespace-normal h-auto py-3">
 					{t("kilocode:settings.provider.providerRouting.createOrganization")}
 				</VSCodeButtonLink>
 			)}


### PR DESCRIPTION
Before:

<img width="480" height="349" alt="image" src="https://github.com/user-attachments/assets/2d7dae8b-d43d-4104-b290-2b64fcb8f3c8" />

After:

<img width="300" height="106" alt="image" src="https://github.com/user-attachments/assets/fe70ab47-8e13-4924-a31c-21eed8a11afc" />
