### PR TITLE
Add JSON stdin handler for bidirectional CLI communication

### DIFF
--- a/.changeset/bright-snails-flow.md
+++ b/.changeset/bright-snails-flow.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Add JSON stdin handler for bidirectional CLI communication

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -230,7 +230,7 @@ export class CLI {
 		// Render UI with store
 		// Disable stdin for Ink when in CI mode or when stdin is piped (not a TTY)
 		// This prevents the "Raw mode is not supported" error
-		const shouldDisableStdin = this.options.ci || !process.stdin.isTTY
+		const shouldDisableStdin = this.options.jsonInteractive || this.options.ci || !process.stdin.isTTY
 
 		this.ui = render(
 			React.createElement(App, {
@@ -240,6 +240,7 @@ export class CLI {
 					workspace: this.options.workspace || process.cwd(),
 					ci: this.options.ci || false,
 					json: this.options.json || false,
+					jsonInteractive: this.options.jsonInteractive || false,
 					prompt: this.options.prompt || "",
 					...(this.options.timeout !== undefined && { timeout: this.options.timeout }),
 					parallel: this.options.parallel || false,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -34,7 +34,7 @@ program
 	.option("-w, --workspace <path>", "Path to the workspace directory", process.cwd())
 	.option("-a, --auto", "Run in autonomous mode (non-interactive)", false)
 	.option("-j, --json", "Output messages as JSON (requires --auto)", false)
-	.option("--json-io", "Bidirectional JSON mode (no TUI, stdin/stdout enabled)", false)
+	.option("-i, --json-io", "Bidirectional JSON mode (no TUI, stdin/stdout enabled)", false)
 	.option("-c, --continue", "Resume the last conversation from this workspace", false)
 	.option("-t, --timeout <seconds>", "Timeout in seconds for autonomous mode (requires --auto)", parseInt)
 	.option(
@@ -212,6 +212,7 @@ program
 			mode: options.mode,
 			workspace: finalWorkspace,
 			ci: options.auto,
+			// json-io mode implies json output (both modes output JSON to stdout)
 			json: options.json || jsonIoMode,
 			jsonInteractive: jsonIoMode,
 			prompt: finalPrompt,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -34,6 +34,7 @@ program
 	.option("-w, --workspace <path>", "Path to the workspace directory", process.cwd())
 	.option("-a, --auto", "Run in autonomous mode (non-interactive)", false)
 	.option("-j, --json", "Output messages as JSON (requires --auto)", false)
+	.option("--json-io", "Bidirectional JSON mode (no TUI, stdin/stdout enabled)", false)
 	.option("-c, --continue", "Resume the last conversation from this workspace", false)
 	.option("-t, --timeout <seconds>", "Timeout in seconds for autonomous mode (requires --auto)", parseInt)
 	.option(
@@ -68,18 +69,6 @@ program
 		// Validate mode if provided
 		if (options.mode && !allValidModes.includes(options.mode)) {
 			console.error(`Error: Invalid mode "${options.mode}". Valid modes are: ${allValidModes.join(", ")}`)
-			process.exit(1)
-		}
-
-		// Validate that piped stdin requires autonomous mode
-		if (!process.stdin.isTTY && !options.auto) {
-			console.error("Error: Piped input requires --auto flag to be enabled")
-			process.exit(1)
-		}
-
-		// Validate that JSON mode requires autonomous mode
-		if (options.json && !options.auto) {
-			console.error("Error: --json option requires --auto flag to be enabled")
 			process.exit(1)
 		}
 
@@ -129,6 +118,18 @@ program
 		// Validate that --fork and --session are not used together
 		if (options.fork && options.session) {
 			console.error("Error: --fork and --session options cannot be used together")
+			process.exit(1)
+		}
+
+		// Validate that piped stdin requires autonomous mode or json-io mode
+		if (!process.stdin.isTTY && !options.auto && !options.jsonIo) {
+			console.error("Error: Piped input requires --auto or --json-io flag to be enabled")
+			process.exit(1)
+		}
+
+		// Validate that --json requires --auto (--json-io is independent)
+		if (options.json && !options.auto) {
+			console.error("Error: --json option requires --auto flag to be enabled")
 			process.exit(1)
 		}
 
@@ -205,11 +206,14 @@ program
 
 		logs.debug("Starting Kilo Code CLI", "Index", { options })
 
+		const jsonIoMode = options.jsonIo
+
 		cli = new CLI({
 			mode: options.mode,
 			workspace: finalWorkspace,
 			ci: options.auto,
-			json: options.json,
+			json: options.json || jsonIoMode,
+			jsonInteractive: jsonIoMode,
 			prompt: finalPrompt,
 			timeout: options.timeout,
 			customModes: customModes,

--- a/cli/src/state/hooks/__tests__/useStdinJsonHandler.test.ts
+++ b/cli/src/state/hooks/__tests__/useStdinJsonHandler.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for useStdinJsonHandler hook
+ *
+ * This hook handles JSON messages from stdin in jsonInteractive mode,
+ * enabling bidirectional communication.
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import { Readable } from "stream"
+import { createInterface } from "readline"
+
+// Mock the atoms
+vi.mock("../../atoms/actions.js", () => ({
+	sendAskResponseAtom: { write: vi.fn() },
+	cancelTaskAtom: { write: vi.fn() },
+	respondToToolAtom: { write: vi.fn() },
+}))
+
+// Mock the logs service
+vi.mock("../../../services/logs.js", () => ({
+	logs: {
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}))
+
+describe("useStdinJsonHandler", () => {
+	describe("Message Parsing", () => {
+		it("should parse valid JSON messages", () => {
+			const validMessages = [
+				{ type: "askResponse", askResponse: "messageResponse", text: "hello" },
+				{ type: "cancelTask" },
+				{ type: "respondToApproval", approved: true },
+				{ type: "respondToApproval", approved: false, text: "rejected" },
+			]
+
+			for (const msg of validMessages) {
+				expect(() => JSON.parse(JSON.stringify(msg))).not.toThrow()
+			}
+		})
+
+		it("should handle askResponse with yesButtonClicked", () => {
+			const message = {
+				type: "askResponse",
+				askResponse: "yesButtonClicked",
+				text: "approved",
+			}
+			const parsed = JSON.parse(JSON.stringify(message))
+			expect(parsed.type).toBe("askResponse")
+			expect(parsed.askResponse).toBe("yesButtonClicked")
+		})
+
+		it("should handle askResponse with noButtonClicked", () => {
+			const message = {
+				type: "askResponse",
+				askResponse: "noButtonClicked",
+				text: "rejected",
+			}
+			const parsed = JSON.parse(JSON.stringify(message))
+			expect(parsed.type).toBe("askResponse")
+			expect(parsed.askResponse).toBe("noButtonClicked")
+		})
+
+		it("should handle askResponse with messageResponse", () => {
+			const message = {
+				type: "askResponse",
+				askResponse: "messageResponse",
+				text: "user message",
+				images: ["image1.png"],
+			}
+			const parsed = JSON.parse(JSON.stringify(message))
+			expect(parsed.type).toBe("askResponse")
+			expect(parsed.askResponse).toBe("messageResponse")
+			expect(parsed.text).toBe("user message")
+			expect(parsed.images).toEqual(["image1.png"])
+		})
+
+		it("should handle cancelTask message", () => {
+			const message = { type: "cancelTask" }
+			const parsed = JSON.parse(JSON.stringify(message))
+			expect(parsed.type).toBe("cancelTask")
+		})
+
+		it("should handle respondToApproval with approved=true", () => {
+			const message = {
+				type: "respondToApproval",
+				approved: true,
+				text: "go ahead",
+			}
+			const parsed = JSON.parse(JSON.stringify(message))
+			expect(parsed.type).toBe("respondToApproval")
+			expect(parsed.approved).toBe(true)
+			expect(parsed.text).toBe("go ahead")
+		})
+
+		it("should handle respondToApproval with approved=false", () => {
+			const message = {
+				type: "respondToApproval",
+				approved: false,
+				text: "denied",
+			}
+			const parsed = JSON.parse(JSON.stringify(message))
+			expect(parsed.type).toBe("respondToApproval")
+			expect(parsed.approved).toBe(false)
+			expect(parsed.text).toBe("denied")
+		})
+	})
+
+	describe("Message Type Validation", () => {
+		it("should identify valid message types", () => {
+			const validTypes = ["askResponse", "cancelTask", "respondToApproval"]
+			for (const type of validTypes) {
+				expect(validTypes.includes(type)).toBe(true)
+			}
+		})
+
+		it("should identify unknown message types", () => {
+			const validTypes = ["askResponse", "cancelTask", "respondToApproval"]
+			const unknownTypes = ["unknown", "invalid", "foo", "bar"]
+			for (const type of unknownTypes) {
+				expect(validTypes.includes(type)).toBe(false)
+			}
+		})
+	})
+
+	describe("JSON Parsing Error Handling", () => {
+		it("should handle invalid JSON gracefully", () => {
+			const invalidJsonStrings = ["not json", "{invalid}", "{'single': 'quotes'}", "", "   ", "null", "undefined"]
+
+			for (const str of invalidJsonStrings) {
+				if (str.trim() === "" || str === "null" || str === "undefined") {
+					// Empty strings and null/undefined should be handled specially
+					continue
+				}
+				try {
+					JSON.parse(str)
+				} catch (e) {
+					expect(e).toBeInstanceOf(SyntaxError)
+				}
+			}
+		})
+
+		it("should handle empty lines", () => {
+			const emptyLines = ["", "   ", "\t", "\n"]
+			for (const line of emptyLines) {
+				expect(line.trim()).toBe("")
+			}
+		})
+	})
+
+	describe("Readline Interface", () => {
+		it("should create readline interface with correct options", () => {
+			const mockStdin = new Readable({
+				read() {},
+			})
+
+			const rl = createInterface({
+				input: mockStdin,
+				terminal: false,
+			})
+
+			expect(rl).toBeDefined()
+			rl.close()
+		})
+
+		it("should handle line events", async () => {
+			const mockStdin = new Readable({
+				read() {},
+			})
+
+			const rl = createInterface({
+				input: mockStdin,
+				terminal: false,
+			})
+
+			const lines: string[] = []
+			rl.on("line", (line) => {
+				lines.push(line)
+			})
+
+			// Simulate pushing data
+			mockStdin.push('{"type":"cancelTask"}\n')
+			mockStdin.push(null) // End of stream
+
+			// Wait for processing
+			await new Promise((resolve) => setTimeout(resolve, 10))
+
+			expect(lines).toContain('{"type":"cancelTask"}')
+			rl.close()
+		})
+
+		it("should handle close events", async () => {
+			const mockStdin = new Readable({
+				read() {},
+			})
+
+			const rl = createInterface({
+				input: mockStdin,
+				terminal: false,
+			})
+
+			let closed = false
+			rl.on("close", () => {
+				closed = true
+			})
+
+			rl.close()
+
+			expect(closed).toBe(true)
+		})
+	})
+
+	describe("Message Structure", () => {
+		it("should support optional text field", () => {
+			const withText = { type: "askResponse", askResponse: "messageResponse", text: "hello" }
+			const withoutText = { type: "askResponse", askResponse: "messageResponse" }
+
+			expect(withText.text).toBe("hello")
+			expect(withoutText.text).toBeUndefined()
+		})
+
+		it("should support optional images field", () => {
+			const withImages = {
+				type: "askResponse",
+				askResponse: "messageResponse",
+				images: ["img1.png", "img2.png"],
+			}
+			const withoutImages = { type: "askResponse", askResponse: "messageResponse" }
+
+			expect(withImages.images).toEqual(["img1.png", "img2.png"])
+			expect(withoutImages.images).toBeUndefined()
+		})
+
+		it("should support approved boolean field for respondToApproval", () => {
+			const approved = { type: "respondToApproval", approved: true }
+			const rejected = { type: "respondToApproval", approved: false }
+
+			expect(approved.approved).toBe(true)
+			expect(rejected.approved).toBe(false)
+		})
+	})
+})
+
+describe("StdinMessage Interface", () => {
+	interface StdinMessage {
+		type: string
+		askResponse?: string
+		text?: string
+		images?: string[]
+		approved?: boolean
+	}
+
+	it("should match expected interface structure", () => {
+		const message: StdinMessage = {
+			type: "askResponse",
+			askResponse: "messageResponse",
+			text: "test",
+			images: ["img.png"],
+		}
+
+		expect(message.type).toBe("askResponse")
+		expect(message.askResponse).toBe("messageResponse")
+		expect(message.text).toBe("test")
+		expect(message.images).toEqual(["img.png"])
+	})
+
+	it("should allow minimal message with only type", () => {
+		const message: StdinMessage = {
+			type: "cancelTask",
+		}
+
+		expect(message.type).toBe("cancelTask")
+		expect(message.askResponse).toBeUndefined()
+		expect(message.text).toBeUndefined()
+		expect(message.images).toBeUndefined()
+		expect(message.approved).toBeUndefined()
+	})
+})

--- a/cli/src/state/hooks/useStdinJsonHandler.ts
+++ b/cli/src/state/hooks/useStdinJsonHandler.ts
@@ -53,7 +53,7 @@ export function useStdinJsonHandler(enabled: boolean) {
 							})
 						} else {
 							await sendAskResponse({
-								response: (message.askResponse as "messageResponse") || "messageResponse",
+								response: (message.askResponse as "messageResponse") ?? "messageResponse",
 								...(message.text !== undefined && { text: message.text }),
 								...(message.images !== undefined && { images: message.images }),
 							})

--- a/cli/src/state/hooks/useStdinJsonHandler.ts
+++ b/cli/src/state/hooks/useStdinJsonHandler.ts
@@ -1,0 +1,110 @@
+/**
+ * Hook to handle JSON messages from stdin in jsonInteractive mode.
+ * This enables bidirectional communication with the Agent Manager.
+ */
+
+import { useEffect } from "react"
+import { useSetAtom } from "jotai"
+import { createInterface } from "readline"
+import { sendAskResponseAtom, cancelTaskAtom, respondToToolAtom } from "../atoms/actions.js"
+import { logs } from "../../services/logs.js"
+
+interface StdinMessage {
+	type: string
+	askResponse?: string
+	text?: string
+	images?: string[]
+	approved?: boolean
+}
+
+export function useStdinJsonHandler(enabled: boolean) {
+	const sendAskResponse = useSetAtom(sendAskResponseAtom)
+	const cancelTask = useSetAtom(cancelTaskAtom)
+	const respondToTool = useSetAtom(respondToToolAtom)
+
+	useEffect(() => {
+		if (!enabled) {
+			return
+		}
+
+		logs.debug("Starting stdin JSON handler", "useStdinJsonHandler")
+
+		const rl = createInterface({
+			input: process.stdin,
+			terminal: false,
+		})
+
+		const handleLine = async (line: string) => {
+			const trimmed = line.trim()
+			if (!trimmed) return
+
+			try {
+				const message: StdinMessage = JSON.parse(trimmed)
+				logs.debug("Received stdin message", "useStdinJsonHandler", { type: message.type })
+
+				switch (message.type) {
+					case "askResponse":
+						// Handle ask response (user message, approval response, etc.)
+						if (message.askResponse === "yesButtonClicked" || message.askResponse === "noButtonClicked") {
+							await respondToTool({
+								response: message.askResponse,
+								...(message.text !== undefined && { text: message.text }),
+								...(message.images !== undefined && { images: message.images }),
+							})
+						} else {
+							await sendAskResponse({
+								response: (message.askResponse as "messageResponse") || "messageResponse",
+								...(message.text !== undefined && { text: message.text }),
+								...(message.images !== undefined && { images: message.images }),
+							})
+						}
+						break
+
+					case "cancelTask":
+						logs.debug("Canceling task via stdin", "useStdinJsonHandler")
+						await cancelTask()
+						break
+
+					case "respondToApproval":
+						// Handle approval response (yes/no for tool use)
+						if (message.approved) {
+							await respondToTool({
+								response: "yesButtonClicked",
+								...(message.text !== undefined && { text: message.text }),
+							})
+						} else {
+							await respondToTool({
+								response: "noButtonClicked",
+								...(message.text !== undefined && { text: message.text }),
+							})
+						}
+						break
+
+					default:
+						logs.warn("Unknown stdin message type", "useStdinJsonHandler", { type: message.type })
+				}
+			} catch (error) {
+				logs.error("Failed to parse stdin JSON", "useStdinJsonHandler", {
+					error: error instanceof Error ? error.message : String(error),
+					line: trimmed.slice(0, 100),
+				})
+			}
+		}
+
+		rl.on("line", handleLine)
+
+		rl.on("close", () => {
+			logs.debug("Stdin closed", "useStdinJsonHandler")
+		})
+
+		rl.on("error", (error) => {
+			logs.error("Stdin error", "useStdinJsonHandler", {
+				error: error instanceof Error ? error.message : String(error),
+			})
+		})
+
+		return () => {
+			rl.close()
+		}
+	}, [enabled, sendAskResponse, cancelTask, respondToTool])
+}

--- a/cli/src/types/cli.ts
+++ b/cli/src/types/cli.ts
@@ -30,6 +30,7 @@ export interface CLIOptions {
 	workspace?: string
 	ci?: boolean
 	json?: boolean
+	jsonInteractive?: boolean
 	prompt?: string
 	timeout?: number
 	customModes?: ModeConfig[]

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -12,6 +12,7 @@ export interface AppOptions {
 	workspace?: string
 	ci?: boolean
 	json?: boolean
+	jsonInteractive?: boolean
 	prompt?: string
 	timeout?: number
 	parallel?: boolean

--- a/cli/src/ui/JsonRenderer.tsx
+++ b/cli/src/ui/JsonRenderer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react"
 import { useAtomValue } from "jotai"
 import { mergedMessagesAtom, type UnifiedMessage } from "../state/atoms/ui.js"
 import { outputJsonMessage } from "./utils/jsonOutput.js"
+import { useStdinJsonHandler } from "../state/hooks/useStdinJsonHandler.js"
 
 function getMessageKey(message: UnifiedMessage): string {
 	const baseKey = `${message.source}-${message.message.ts}`
@@ -10,9 +11,16 @@ function getMessageKey(message: UnifiedMessage): string {
 	return `${baseKey}-${content.length}-${partial}`
 }
 
-export function JsonRenderer() {
+interface JsonRendererProps {
+	jsonInteractive?: boolean
+}
+
+export function JsonRenderer({ jsonInteractive = false }: JsonRendererProps) {
 	const messages = useAtomValue(mergedMessagesAtom)
 	const lastOutputKeysRef = useRef<string[]>([])
+
+	// Enable stdin JSON handler for bidirectional communication
+	useStdinJsonHandler(jsonInteractive)
 
 	useEffect(() => {
 		const currentKeys = messages.map(getMessageKey)

--- a/cli/src/ui/UI.tsx
+++ b/cli/src/ui/UI.tsx
@@ -262,8 +262,8 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 	}, [configValidation])
 
 	// If JSON mode is enabled, use JSON renderer instead of UI components
-	if (options.json && options.ci) {
-		return <JsonRenderer />
+	if (options.json && (options.ci || options.jsonInteractive)) {
+		return <JsonRenderer jsonInteractive={options.jsonInteractive === true} />
 	}
 
 	return (


### PR DESCRIPTION
Adds useStdinJsonHandler hook to handle JSON messages from stdin in jsonInteractive mode, enabling external tools to send commands (askResponse, cancelTask, respondToApproval) to the CLI.
The standard --json api is unaffected of this change.