### PR TITLE
tie session id to task id when restoring a session

### DIFF
--- a/.changeset/strong-olives-press.md
+++ b/.changeset/strong-olives-press.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix an issue where a session was duplicated instead of restored

--- a/src/shared/kilocode/cli-sessions/core/SessionManager.ts
+++ b/src/shared/kilocode/cli-sessions/core/SessionManager.ts
@@ -268,6 +268,8 @@ export class SessionManager {
 				totalCost: 0,
 			}
 
+			this.sessionPersistenceManager.setSessionForTask(historyItem.id, sessionId)
+
 			await this.extensionMessenger.sendWebviewMessage({
 				type: "addTaskToHistory",
 				historyItem,

--- a/src/shared/kilocode/cli-sessions/core/__tests__/SessionManager.spec.ts
+++ b/src/shared/kilocode/cli-sessions/core/__tests__/SessionManager.spec.ts
@@ -347,6 +347,28 @@ describe("SessionManager", () => {
 			expect(mockDependencies.onSessionRestored).toHaveBeenCalled()
 		})
 
+		it("should persist task-to-session mapping when restoring session", async () => {
+			const mockSession: SessionWithSignedUrls = {
+				session_id: "session-123",
+				title: "Test Session",
+				created_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+				api_conversation_history_blob_url: null,
+				task_metadata_blob_url: null,
+				ui_messages_blob_url: null,
+				git_state_blob_url: null,
+			}
+
+			vi.mocked(manager.sessionClient!.get).mockResolvedValue(mockSession)
+
+			await manager.restoreSession("session-123")
+
+			expect(manager.sessionPersistenceManager!.setSessionForTask).toHaveBeenCalledWith(
+				"session-123",
+				"session-123",
+			)
+		})
+
 		it("should fetch and write blobs when URLs are provided", async () => {
 			const mockSession: SessionWithSignedUrls = {
 				session_id: "session-123",


### PR DESCRIPTION
## Context

Fixes an issue where restoring a session would create a duplicate session instead.