### PR TITLE
Clear indexing state error when clicking clear index button

### DIFF
--- a/.changeset/tidy-nights-raise.md
+++ b/.changeset/tidy-nights-raise.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix: reset state errors when clearing indexing state

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -3374,6 +3374,16 @@ export const webviewMessageHandler = async (
 					})
 					return
 				}
+
+				// kilocode_change start
+				// Clear any prior error banner in UI even if config is still invalid.
+				manager.clearErrorState()
+				provider.postMessageToWebview({
+					type: "indexingStatusUpdate",
+					values: manager.getCurrentStatus(),
+				})
+				// kilocode_change end
+
 				await manager.clearIndexData()
 				provider.postMessageToWebview({ type: "indexCleared", values: { success: true } })
 			} catch (error) {

--- a/src/services/code-index/manager.ts
+++ b/src/services/code-index/manager.ts
@@ -293,6 +293,12 @@ export class CodeIndexManager {
 		await this._cacheManager!.clearCacheFile()
 	}
 
+	// kilocode_change start
+	public clearErrorState(): void {
+		this._stateManager.setSystemState("Standby", "")
+	}
+	// kilocode_change end
+
 	// --- Private Helpers ---
 
 	public getCurrentStatus() {


### PR DESCRIPTION
In the code indexing dialog, if an error occurs and you hit 'clear' index it would get stuck in an error state. This resolves that. 