### PR TITLE
Emit session_synced event with api reported updated_at

### DIFF
--- a/.changeset/tame-rivers-appear.md
+++ b/.changeset/tame-rivers-appear.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Begin emitting session_synced event

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -158,6 +158,11 @@ export class CLI {
 							this.store.set(taskResumedViaContinueOrSessionAtom, true)
 						}
 					},
+					onSessionSynced: (message) => {
+						if (this.options.json) {
+							console.log(JSON.stringify(message))
+						}
+					},
 					platform: "cli",
 				})
 				logs.debug("SessionManager initialized with dependencies", "CLI")

--- a/src/shared/kilocode/cli-sessions/core/__tests__/SessionClient.spec.ts
+++ b/src/shared/kilocode/cli-sessions/core/__tests__/SessionClient.spec.ts
@@ -27,20 +27,22 @@ describe("SessionClient", () => {
 
 		it("should get signed URL and upload blob successfully", async () => {
 			const signedUrl = "https://storage.example.com/signed-upload-url"
+			const updatedAt = "2024-01-01T00:00:00.000Z"
 			const blobBody = JSON.stringify(blobData)
 			const contentLength = new TextEncoder().encode(blobBody).length
 
 			mockFetch
 				.mockResolvedValueOnce({
 					ok: true,
-					json: () => Promise.resolve({ signed_url: signedUrl }),
+					json: () => Promise.resolve({ signed_url: signedUrl, updated_at: updatedAt }),
 				})
 				.mockResolvedValueOnce({
 					ok: true,
 				})
 
-			await sessionClient.uploadBlob(sessionId, blobType, blobData)
+			const result = await sessionClient.uploadBlob(sessionId, blobType, blobData)
 
+			expect(result).toEqual({ updated_at: updatedAt })
 			expect(mockFetch).toHaveBeenCalledTimes(2)
 
 			expect(mockFetch).toHaveBeenNthCalledWith(1, "https://api.example.com/api/upload-cli-session-blob-v2", {
@@ -80,11 +82,12 @@ describe("SessionClient", () => {
 
 		it("should throw error when upload to signed URL fails", async () => {
 			const signedUrl = "https://storage.example.com/signed-upload-url"
+			const updatedAt = "2024-01-01T00:00:00.000Z"
 
 			mockFetch
 				.mockResolvedValueOnce({
 					ok: true,
-					json: () => Promise.resolve({ signed_url: signedUrl }),
+					json: () => Promise.resolve({ signed_url: signedUrl, updated_at: updatedAt }),
 				})
 				.mockResolvedValueOnce({
 					ok: false,
@@ -100,13 +103,14 @@ describe("SessionClient", () => {
 
 		it("should work with different blob types", async () => {
 			const signedUrl = "https://storage.example.com/signed-upload-url"
+			const updatedAt = "2024-01-01T00:00:00.000Z"
 			const blobBody = JSON.stringify(blobData)
 			const contentLength = new TextEncoder().encode(blobBody).length
 
 			mockFetch
 				.mockResolvedValueOnce({
 					ok: true,
-					json: () => Promise.resolve({ signed_url: signedUrl }),
+					json: () => Promise.resolve({ signed_url: signedUrl, updated_at: updatedAt }),
 				})
 				.mockResolvedValueOnce({
 					ok: true,
@@ -130,6 +134,7 @@ describe("SessionClient", () => {
 
 		it("should work with task_metadata blob type", async () => {
 			const signedUrl = "https://storage.example.com/signed-upload-url"
+			const updatedAt = "2024-01-01T00:00:00.000Z"
 			const taskData = { task: "test" }
 			const blobBody = JSON.stringify(taskData)
 			const contentLength = new TextEncoder().encode(blobBody).length
@@ -137,7 +142,7 @@ describe("SessionClient", () => {
 			mockFetch
 				.mockResolvedValueOnce({
 					ok: true,
-					json: () => Promise.resolve({ signed_url: signedUrl }),
+					json: () => Promise.resolve({ signed_url: signedUrl, updated_at: updatedAt }),
 				})
 				.mockResolvedValueOnce({
 					ok: true,
@@ -161,6 +166,7 @@ describe("SessionClient", () => {
 
 		it("should work with git_state blob type", async () => {
 			const signedUrl = "https://storage.example.com/signed-upload-url"
+			const updatedAt = "2024-01-01T00:00:00.000Z"
 			const gitData = { head: "abc123" }
 			const blobBody = JSON.stringify(gitData)
 			const contentLength = new TextEncoder().encode(blobBody).length
@@ -168,7 +174,7 @@ describe("SessionClient", () => {
 			mockFetch
 				.mockResolvedValueOnce({
 					ok: true,
-					json: () => Promise.resolve({ signed_url: signedUrl }),
+					json: () => Promise.resolve({ signed_url: signedUrl, updated_at: updatedAt }),
 				})
 				.mockResolvedValueOnce({
 					ok: true,

--- a/src/shared/kilocode/cli-sessions/core/__tests__/SessionManager.spec.ts
+++ b/src/shared/kilocode/cli-sessions/core/__tests__/SessionManager.spec.ts
@@ -588,7 +588,7 @@ describe("SessionManager", () => {
 				created_at: new Date().toISOString(),
 				updated_at: new Date().toISOString(),
 			})
-			vi.mocked(manager.sessionClient!.uploadBlob).mockResolvedValue()
+			vi.mocked(manager.sessionClient!.uploadBlob).mockResolvedValue({ updated_at: new Date().toISOString() })
 
 			const result = await manager.getSessionFromTask("task-123", mockTaskDataProvider)
 
@@ -612,7 +612,7 @@ describe("SessionManager", () => {
 				created_at: new Date().toISOString(),
 				updated_at: new Date().toISOString(),
 			})
-			vi.mocked(manager.sessionClient!.uploadBlob).mockResolvedValue()
+			vi.mocked(manager.sessionClient!.uploadBlob).mockResolvedValue({ updated_at: new Date().toISOString() })
 
 			await manager.getSessionFromTask("task-123", mockTaskDataProvider)
 


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

Starting to emit `session_synced` events that include the API returned `updated_at` timestamp - which can be used as a high water mark or  quasi confirmation id as a session progresses. 

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

The API already returned updated_at fields in the cli session endpoints, we now just capture these and emit `session_synced` events that contain these as we make calls to the backend to sync the session. 

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test


Just invoke with --json and grep for `session_synced`, the events will look like:

```
{"sessionId":"e1ba1aed-4d7c-4a5c-901d-4e4d31256f00","updatedAt":1765240603602,"timestamp":1765240604600,"event":"session_synced"}
```
## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
