### PR TITLE
fix: skip backward deletion logic when suggestion text is empty

### DIFF
--- a/src/services/continuedev/core/autocomplete/filtering/test/util.ts
+++ b/src/services/continuedev/core/autocomplete/filtering/test/util.ts
@@ -70,5 +70,8 @@ export async function testAutocompleteFiltering(test: AutocompleteFileringTestIn
 	)
 
 	// Ensure that we return the text that is wanted to be displayed
-	expect(result?.completion).toEqual(test.expectedCompletion)
+	// Normalize line endings for cross-platform compatibility
+	const normalizeLineEndings = (str: string | null | undefined) => str?.replace(/\r\n/g, "\n")
+
+	expect(normalizeLineEndings(result?.completion)).toEqual(normalizeLineEndings(test.expectedCompletion))
 }

--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -87,7 +87,12 @@ export function findMatchingSuggestion(
 
 		// Check for backward deletion: user deleted characters from the end of the prefix
 		// The stored prefix should start with the current prefix (current is shorter)
-		if (fillInAtCursor.prefix.startsWith(prefix) && suffix === fillInAtCursor.suffix) {
+		// Only use this logic if the original suggestion is non-empty
+		if (
+			fillInAtCursor.text !== "" &&
+			fillInAtCursor.prefix.startsWith(prefix) &&
+			suffix === fillInAtCursor.suffix
+		) {
 			// Extract the deleted portion of the prefix
 			const deletedContent = fillInAtCursor.prefix.substring(prefix.length)
 

--- a/src/services/ghost/classic-auto-complete/__tests__/GhostInlineCompletionProvider.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/GhostInlineCompletionProvider.test.ts
@@ -228,7 +228,7 @@ describe("findMatchingSuggestion", () => {
 			expect(result).toBeNull()
 		})
 
-		it("should handle backward deletion with empty suggestion text", () => {
+		it("should not use backward deletion when suggestion text is empty", () => {
 			const suggestions: FillInAtCursorSuggestion[] = [
 				{
 					text: "",
@@ -237,9 +237,9 @@ describe("findMatchingSuggestion", () => {
 				},
 			]
 
-			// User backspaced - should return just the deleted portion
+			// User backspaced - should return null because the original suggestion was empty
 			const result = findMatchingSuggestion("f", "bar", suggestions)
-			expect(result).toEqual({ text: "oo", matchType: "backward_deletion" })
+			expect(result).toBeNull()
 		})
 
 		it("should prefer exact match over backward deletion match", () => {


### PR DESCRIPTION
The backward deletion matching in findMatchingSuggestion() was returning the deleted prefix portion even when the original suggestion was empty. 

So everytime you backspaced it suggested undoing the backspace which isnt very helpful