### PR TITLE
Check token validity before syncing session

### DIFF
--- a/.changeset/empty-berries-warn.md
+++ b/.changeset/empty-berries-warn.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+check token before syncing session

--- a/src/shared/kilocode/cli-sessions/core/SessionClient.ts
+++ b/src/shared/kilocode/cli-sessions/core/SessionClient.ts
@@ -251,4 +251,20 @@ export class SessionClient {
 			updated_at: signedUrlResponse.updated_at,
 		}
 	}
+
+	async tokenValid() {
+		const { endpoint, getToken } = this.trpcClient
+
+		const url = new URL("/api/user", endpoint)
+
+		const response = await fetch(url.toString(), {
+			method: "GET",
+			headers: {
+				Authorization: `Bearer ${await getToken()}`,
+				"Content-Type": "application/json",
+			},
+		})
+
+		return response.ok
+	}
 }

--- a/src/shared/kilocode/cli-sessions/core/SessionClient.ts
+++ b/src/shared/kilocode/cli-sessions/core/SessionClient.ts
@@ -283,6 +283,11 @@ export class SessionClient {
 			}
 
 			const payloadBase64 = parts[1]
+
+			if (!payloadBase64) {
+				return false
+			}
+
 			const payloadJson = Buffer.from(payloadBase64, "base64").toString("utf-8")
 			const payload = JSON.parse(payloadJson) as {
 				kiloUserId?: string

--- a/src/shared/kilocode/cli-sessions/core/SessionManager.ts
+++ b/src/shared/kilocode/cli-sessions/core/SessionManager.ts
@@ -62,6 +62,7 @@ export class SessionManager {
 	private taskGitHashes: Record<string, string> = {}
 	private sessionTitles: Record<string, string> = {}
 	private sessionUpdatedAt: Record<string, string> = {}
+	private tokenValid: Record<string, boolean | undefined> = {}
 
 	public get sessionId() {
 		return this.lastActiveSessionId || this.sessionPersistenceManager?.getLastSession()?.sessionId
@@ -80,6 +81,7 @@ export class SessionManager {
 	private onSessionRestored: (() => void) | undefined
 	private onSessionSynced: ((message: SessionSyncedMessage) => void) | undefined
 	private platform: string | undefined
+	private getToken: (() => Promise<string>) | undefined
 
 	private constructor() {}
 
@@ -91,6 +93,7 @@ export class SessionManager {
 		this.onSessionRestored = dependencies.onSessionRestored ?? (() => {})
 		this.onSessionSynced = dependencies.onSessionSynced ?? (() => {})
 		this.platform = dependencies.platform
+		this.getToken = dependencies.getToken
 
 		const trpcClient = new TrpcClient({
 			getToken: dependencies.getToken,
@@ -453,6 +456,27 @@ export class SessionManager {
 		try {
 			this.isSyncing = true
 
+			const token = await this.getToken?.()
+
+			if (!token) {
+				throw new Error("No token available for session sync")
+			}
+
+			if (this.tokenValid[token] === undefined) {
+				this.logger?.debug("Checking token validity", "SessionManager")
+
+				const tokenValid = await this.sessionClient.tokenValid()
+
+				this.tokenValid[token] = tokenValid
+
+				this.logger?.debug("Token validity checked", "SessionManager", { tokenValid })
+			}
+
+			if (!this.tokenValid[token]) {
+				this.logger?.debug("Token is invalid, skipping sync", "SessionManager")
+				return
+			}
+
 			const taskIds = new Set<string>(this.queue.map((item) => item.taskId))
 			const lastItem = this.queue[this.queue.length - 1]
 
@@ -724,6 +748,12 @@ export class SessionManager {
 						taskId,
 						error: error instanceof Error ? error.message : String(error),
 					})
+
+					const token = await this.getToken?.()
+
+					if (token) {
+						this.tokenValid[token] = undefined
+					}
 				}
 			}
 

--- a/src/shared/kilocode/cli-sessions/core/SessionManager.ts
+++ b/src/shared/kilocode/cli-sessions/core/SessionManager.ts
@@ -459,7 +459,8 @@ export class SessionManager {
 			const token = await this.getToken?.()
 
 			if (!token) {
-				throw new Error("No token available for session sync")
+				this.logger?.debug("No token available for session sync, skipping", "SessionManager")
+				return
 			}
 
 			if (this.tokenValid[token] === undefined) {


### PR DESCRIPTION
## Context

We assumed a truthy `kilocodeToken` was valid - turns out users put all sorts of non-valid stuff in there. This change introduces a token check before syncing the session.
