### PR TITLE
Fix UI overflow in agent manager

### DIFF
--- a/webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css
+++ b/webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css
@@ -234,6 +234,7 @@
 	flex-direction: column;
 	overflow: hidden;
 	background: var(--vscode-editor-background);
+	min-width: 280px;
 }
 
 .am-detail-header {

--- a/webview-ui/src/kilocode/agent-manager/components/ChatInput.tsx
+++ b/webview-ui/src/kilocode/agent-manager/components/ChatInput.tsx
@@ -154,7 +154,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ sessionId, sessionLabel, i
 				{/* Hint Text inside input */}
 				{!messageText && (
 					<div
-						className="absolute left-3 z-30 pr-9 flex items-center h-8"
+						className="absolute left-3 right-[70px] z-30 flex items-center h-8 overflow-hidden text-ellipsis whitespace-nowrap"
 						style={{
 							bottom: "0.25rem",
 							color: "var(--vscode-descriptionForeground)",

--- a/webview-ui/src/kilocode/agent-manager/components/SessionDetail.tsx
+++ b/webview-ui/src/kilocode/agent-manager/components/SessionDetail.tsx
@@ -333,7 +333,7 @@ function NewAgentForm() {
 					{/* Hint Text inside input */}
 					{!promptText && (
 						<div
-							className="absolute left-3 z-30 pr-9 flex items-center h-8"
+							className="absolute left-3 right-[90px] z-30 flex items-center h-8 overflow-hidden text-ellipsis whitespace-nowrap"
 							style={{
 								bottom: "0.25rem",
 								color: "var(--vscode-descriptionForeground)",


### PR DESCRIPTION
Prevent hint text from overflowing under buttons when the panel width is small.

<img width="196" height="258" alt="image" src="https://github.com/user-attachments/assets/04fd073a-0e18-41bb-b68e-1cef8ddc4c20" />

With fix:

<img width="196" height="240" alt="image" src="https://github.com/user-attachments/assets/98d839db-3139-4726-a00e-1924a619aa6e" />

