### PR TITLE
fix(chat): improve autocomplete layering and request tracking

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1710,7 +1710,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							// kilocode_change start
 							style={{
 								marginTop: "-38px",
-								zIndex: 2,
+								zIndex: 10,
 								paddingLeft: "8px",
 								paddingRight: "8px",
 								paddingBottom: isEditMode ? "10px" : "0",

--- a/webview-ui/src/components/chat/hooks/useChatGhostText.ts
+++ b/webview-ui/src/components/chat/hooks/useChatGhostText.ts
@@ -117,9 +117,9 @@ export function useChatGhostText({
 				!newValue.includes("@")
 			) {
 				// Request new completion after debounce (only if feature is enabled)
+				const requestId = generateRequestId()
+				completionRequestIdRef.current = requestId
 				completionDebounceRef.current = setTimeout(() => {
-					const requestId = generateRequestId()
-					completionRequestIdRef.current = requestId
 					vscode.postMessage({
 						type: "requestChatCompletion",
 						text: newValue,


### PR DESCRIPTION
I just added this autocomplete ghost text, but noticed a case where it appears and looks pretty bad. This should fix it!

- Increase autocomplete z-index to 10 so the buttons float over any autocomplete text overlap
- Move request ID generation outside setTimeout to avoid race conditions applying the result after the input changes

**Fixes this**
<img width="974" height="410" alt="CleanShot 2025-12-09 at 22 04 12@2x" src="https://github.com/user-attachments/assets/4d0ce9cc-d37a-4e41-9347-b4b6b446ea01" />

