### PR TITLE
set KILO_PLATFORM env variable for CLI process

### DIFF
--- a/src/core/kilocode/agent-manager/CliProcessHandler.ts
+++ b/src/core/kilocode/agent-manager/CliProcessHandler.ts
@@ -120,7 +120,7 @@ export class CliProcessHandler {
 		const proc = spawn(cliPath, cliArgs, {
 			cwd: workspace,
 			stdio: ["pipe", "pipe", "pipe"],
-			env: { ...process.env, NO_COLOR: "1", FORCE_COLOR: "0" },
+			env: { ...process.env, NO_COLOR: "1", FORCE_COLOR: "0", KILO_PLATFORM: "agent-manager" },
 			shell: false,
 		})
 

--- a/src/core/kilocode/agent-manager/__tests__/CliProcessHandler.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/CliProcessHandler.spec.ts
@@ -152,6 +152,21 @@ describe("CliProcessHandler", () => {
 				}),
 			)
 		})
+
+		it("sets KILO_PLATFORM environment variable to agent-manager", () => {
+			const onCliEvent = vi.fn()
+			handler.spawnProcess("/path/to/kilocode", "/workspace", "test prompt", undefined, onCliEvent)
+
+			expect(spawnMock).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.any(Array),
+				expect.objectContaining({
+					env: expect.objectContaining({
+						KILO_PLATFORM: "agent-manager",
+					}),
+				}),
+			)
+		})
 	})
 
 	describe("session_created event handling", () => {


### PR DESCRIPTION
## Context

When the agent manager starts a CLI process, it now sets the KILO_PLATFORM environment variable to 'agent-manager' so the CLI can identify the platform it's running on.
