### PR TITLE
feat: show login button for KiloCode auth errors in chat

### DIFF
--- a/src/api/providers/kilocode-openrouter.ts
+++ b/src/api/providers/kilocode-openrouter.ts
@@ -14,6 +14,7 @@ import {
 	X_KILOCODE_PROJECTID,
 	X_KILOCODE_TESTER,
 } from "../../shared/kilocode/headers"
+import { KILOCODE_TOKEN_REQUIRED_ERROR } from "../../shared/kilocode/errorUtils"
 import { DEFAULT_HEADERS } from "./constants"
 import { streamSse } from "../../services/continuedev/core/fetch/stream"
 
@@ -114,7 +115,7 @@ export class KilocodeOpenrouterHandler extends OpenRouterHandler {
 
 	public override async fetchModel() {
 		if (!this.options.kilocodeToken || !this.options.openRouterBaseUrl) {
-			throw new Error("KiloCode token + baseUrl is required to fetch models")
+			throw new Error(KILOCODE_TOKEN_REQUIRED_ERROR)
 		}
 
 		const [models, endpoints, defaultModel] = await Promise.all([

--- a/src/shared/kilocode/errorUtils.ts
+++ b/src/shared/kilocode/errorUtils.ts
@@ -2,6 +2,11 @@ export function stringifyError(error: unknown) {
 	return error instanceof Error ? error.stack || error.message : String(error)
 }
 
+/**
+ * Error message thrown when the KiloCode token is missing or invalid.
+ */
+export const KILOCODE_TOKEN_REQUIRED_ERROR = "KiloCode token + baseUrl is required to fetch models"
+
 export function isPaymentRequiredError(error: any) {
 	return !!(error && error.status === 402)
 }

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1361,7 +1361,28 @@ export const ChatRowContent = ({
 						</div>
 					)
 				case "error":
-					return <ErrorRow type="error" message={message.text || ""} />
+					// kilocode_change start: Show login button for KiloCode auth errors
+					const isKiloCodeAuthError =
+						apiConfiguration?.apiProvider === "kilocode" && message.text?.includes("KiloCode token")
+					return (
+						<ErrorRow
+							type="error"
+							message={message.text || ""}
+							showLoginButton={isKiloCodeAuthError}
+							onLoginClick={
+								isKiloCodeAuthError
+									? () => {
+											vscode.postMessage({
+												type: "switchTab",
+												tab: "auth",
+												values: { returnTo: "chat" },
+											})
+										}
+									: undefined
+							}
+						/>
+					)
+				// kilocode_change end
 				case "completion_result":
 					const commitRange = message.metadata?.kiloCode?.commitRange
 					return (

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -76,6 +76,7 @@ import { InvalidModelWarning } from "../kilocode/chat/InvalidModelWarning"
 import { formatFileSize } from "@/lib/formatting-utils"
 import ChatTimestamps from "./ChatTimestamps"
 import { removeLeadingNonAlphanumeric } from "@/utils/removeLeadingNonAlphanumeric"
+import { KILOCODE_TOKEN_REQUIRED_ERROR } from "@roo/kilocode/errorUtils"
 // kilocode_change end
 
 // Helper function to get previous todos before a specific message
@@ -1363,7 +1364,8 @@ export const ChatRowContent = ({
 				case "error":
 					// kilocode_change start: Show login button for KiloCode auth errors
 					const isKiloCodeAuthError =
-						apiConfiguration?.apiProvider === "kilocode" && message.text?.includes("KiloCode token")
+						apiConfiguration?.apiProvider === "kilocode" &&
+						message.text?.includes(KILOCODE_TOKEN_REQUIRED_ERROR)
 					return (
 						<ErrorRow
 							type="error"

--- a/webview-ui/src/components/chat/ErrorRow.tsx
+++ b/webview-ui/src/components/chat/ErrorRow.tsx
@@ -4,6 +4,7 @@ import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { MessageCircleWarning } from "lucide-react"
 import { useCopyToClipboard } from "@src/utils/clipboard"
 import CodeBlock from "../kilocode/common/CodeBlock" // kilocode_change
+import { Button } from "@src/components/ui" // kilocode_change
 
 export interface ErrorRowProps {
 	type: "error" | "mistake_limit" | "api_failure" | "diff_error" | "streaming_failed" | "cancelled"
@@ -15,6 +16,8 @@ export interface ErrorRowProps {
 	additionalContent?: React.ReactNode
 	headerClassName?: string
 	messageClassName?: string
+	showLoginButton?: boolean // kilocode_change
+	onLoginClick?: () => void // kilocode_change
 }
 
 /**
@@ -31,6 +34,8 @@ export const ErrorRow = memo(
 		additionalContent,
 		headerClassName,
 		messageClassName,
+		showLoginButton = false, // kilocode_change
+		onLoginClick, // kilocode_change
 	}: ErrorRowProps) => {
 		const { t } = useTranslation()
 		const [isExpanded, setIsExpanded] = useState(defaultExpanded)
@@ -130,6 +135,15 @@ export const ErrorRow = memo(
 					}>
 					{message}
 				</p>
+				{/* kilocode_change start */}
+				{showLoginButton && onLoginClick && (
+					<div className="ml-6 mt-3">
+						<Button variant="secondary" onClick={onLoginClick}>
+							{t("kilocode:settings.provider.login")}
+						</Button>
+					</div>
+				)}
+				{/* kilocode_change end */}
 				{additionalContent}
 			</>
 		)

--- a/webview-ui/src/components/chat/__tests__/ChatRow.kilocode-auth-error.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatRow.kilocode-auth-error.spec.tsx
@@ -1,0 +1,142 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { ChatRowContent } from "../ChatRow"
+import { vscode } from "@src/utils/vscode"
+
+// Create a variable to hold the mock state
+let mockExtensionState: any = {}
+
+// Mock ExtensionStateContext
+vi.mock("@src/context/ExtensionStateContext", () => ({
+	useExtensionState: () => mockExtensionState,
+}))
+
+// Mock i18n
+vi.mock("react-i18next", () => ({
+	useTranslation: () => ({
+		t: (key: string) => {
+			const map: Record<string, string> = {
+				"chat:error": "Error",
+				"kilocode:settings.provider.login": "Login",
+			}
+			return map[key] || key
+		},
+	}),
+	Trans: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+	initReactI18next: { type: "3rdParty", init: () => {} },
+}))
+
+// Mock vscode postMessage
+vi.mock("@src/utils/vscode", () => ({
+	vscode: {
+		postMessage: vi.fn(),
+	},
+}))
+
+// Mock CodeBlock (avoid ESM/highlighter costs)
+vi.mock("@src/components/common/CodeBlock", () => ({
+	default: () => null,
+}))
+
+// Mock useSelectedModel hook
+vi.mock("@src/components/ui/hooks/useSelectedModel", () => ({
+	useSelectedModel: () => ({ info: undefined }),
+}))
+
+const queryClient = new QueryClient()
+
+function renderChatRow(message: any, apiConfiguration: any = {}) {
+	// Update the mock state before rendering
+	mockExtensionState = {
+		apiConfiguration,
+		mcpServers: [],
+		alwaysAllowMcp: false,
+		currentCheckpoint: undefined,
+		mode: "code",
+		clineMessages: [],
+		showTimestamps: false,
+		hideCostBelowThreshold: 0,
+	}
+
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<ChatRowContent
+				message={message}
+				isExpanded={false}
+				isLast={false}
+				isStreaming={false}
+				onToggleExpand={() => {}}
+				onSuggestionClick={() => {}}
+				onBatchFileResponse={() => {}}
+				onFollowUpUnmount={() => {}}
+				isFollowUpAnswered={false}
+			/>
+		</QueryClientProvider>,
+	)
+}
+
+describe("ChatRow - KiloCode auth error login button", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("shows login button for KiloCode auth error", () => {
+		const message: any = {
+			type: "say",
+			say: "error",
+			ts: Date.now(),
+			text: "Cannot complete request, make sure you are connected and logged in with the selected provider.\n\nKiloCode token + baseUrl is required to fetch models",
+		}
+
+		renderChatRow(message, { apiProvider: "kilocode" })
+
+		expect(screen.getByText("Login")).toBeInTheDocument()
+	})
+
+	it("does not show login button for non-KiloCode provider", () => {
+		const message: any = {
+			type: "say",
+			say: "error",
+			ts: Date.now(),
+			text: "Cannot complete request, make sure you are connected and logged in with the selected provider.\n\nKiloCode token + baseUrl is required to fetch models",
+		}
+
+		renderChatRow(message, { apiProvider: "openai" })
+
+		expect(screen.queryByText("Login")).not.toBeInTheDocument()
+	})
+
+	it("does not show login button for non-auth errors", () => {
+		const message: any = {
+			type: "say",
+			say: "error",
+			ts: Date.now(),
+			text: "Some other error message",
+		}
+
+		renderChatRow(message, { apiProvider: "kilocode" })
+
+		expect(screen.queryByText("Login")).not.toBeInTheDocument()
+	})
+
+	it("navigates to auth tab when login button is clicked", () => {
+		const message: any = {
+			type: "say",
+			say: "error",
+			ts: Date.now(),
+			text: "Cannot complete request, make sure you are connected and logged in with the selected provider.\n\nKiloCode token + baseUrl is required to fetch models",
+		}
+
+		renderChatRow(message, { apiProvider: "kilocode" })
+
+		const loginButton = screen.getByText("Login")
+		fireEvent.click(loginButton)
+
+		expect(vscode.postMessage).toHaveBeenCalledWith({
+			type: "switchTab",
+			tab: "auth",
+			values: { returnTo: "chat" },
+		})
+	})
+})

--- a/webview-ui/src/components/chat/__tests__/ErrorRow.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ErrorRow.spec.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+import { ErrorRow } from "../ErrorRow"
+
+// Mock react-i18next with initReactI18next for i18n setup
+vi.mock("react-i18next", () => ({
+	useTranslation: () => ({
+		t: (key: string) => {
+			const translations: Record<string, string> = {
+				"chat:error": "Error",
+				"chat:troubleMessage": "Trouble",
+				"chat:apiRequest.failed": "API Request Failed",
+				"chat:apiRequest.streamingFailed": "Streaming Failed",
+				"chat:apiRequest.cancelled": "Cancelled",
+				"chat:diffError.title": "Diff Error",
+				"kilocode:settings.provider.login": "Login",
+			}
+			return translations[key] || key
+		},
+	}),
+	initReactI18next: {
+		type: "3rdParty",
+		init: () => {},
+	},
+}))
+
+// Mock clipboard hook
+vi.mock("@src/utils/clipboard", () => ({
+	useCopyToClipboard: () => ({
+		copyWithFeedback: vi.fn().mockResolvedValue(true),
+	}),
+}))
+
+describe("ErrorRow", () => {
+	describe("basic rendering", () => {
+		it("renders error message", () => {
+			render(<ErrorRow type="error" message="Test error message" />)
+			expect(screen.getByText("Error")).toBeInTheDocument()
+			expect(screen.getByText("Test error message")).toBeInTheDocument()
+		})
+
+		it("renders custom title when provided", () => {
+			render(<ErrorRow type="error" title="Custom Title" message="Test message" />)
+			expect(screen.getByText("Custom Title")).toBeInTheDocument()
+		})
+
+		it("renders additional content when provided", () => {
+			render(
+				<ErrorRow
+					type="error"
+					message="Test message"
+					additionalContent={<div data-testid="additional">Additional content</div>}
+				/>,
+			)
+			expect(screen.getByTestId("additional")).toBeInTheDocument()
+		})
+	})
+
+	describe("login button", () => {
+		it("does not show login button by default", () => {
+			render(<ErrorRow type="error" message="Test error message" />)
+			expect(screen.queryByText("Login")).not.toBeInTheDocument()
+		})
+
+		it("shows login button when showLoginButton is true and onLoginClick is provided", () => {
+			const onLoginClick = vi.fn()
+			render(<ErrorRow type="error" message="Test error message" showLoginButton={true} onLoginClick={onLoginClick} />)
+			expect(screen.getByText("Login")).toBeInTheDocument()
+		})
+
+		it("does not show login button when showLoginButton is true but onLoginClick is not provided", () => {
+			render(<ErrorRow type="error" message="Test error message" showLoginButton={true} />)
+			expect(screen.queryByText("Login")).not.toBeInTheDocument()
+		})
+
+		it("calls onLoginClick when login button is clicked", () => {
+			const onLoginClick = vi.fn()
+			render(<ErrorRow type="error" message="Test error message" showLoginButton={true} onLoginClick={onLoginClick} />)
+
+			const loginButton = screen.getByText("Login")
+			fireEvent.click(loginButton)
+
+			expect(onLoginClick).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe("error types", () => {
+		it("renders mistake_limit type with correct title", () => {
+			render(<ErrorRow type="mistake_limit" message="Test message" />)
+			expect(screen.getByText("Trouble")).toBeInTheDocument()
+		})
+
+		it("renders api_failure type with correct title", () => {
+			render(<ErrorRow type="api_failure" message="Test message" />)
+			expect(screen.getByText("API Request Failed")).toBeInTheDocument()
+		})
+
+		it("renders streaming_failed type with correct title", () => {
+			render(<ErrorRow type="streaming_failed" message="Test message" />)
+			expect(screen.getByText("Streaming Failed")).toBeInTheDocument()
+		})
+
+		it("renders cancelled type with correct title", () => {
+			render(<ErrorRow type="cancelled" message="Test message" />)
+			expect(screen.getByText("Cancelled")).toBeInTheDocument()
+		})
+	})
+})


### PR DESCRIPTION
## Summary
When a user is logged out and starts a chat with the KiloCode provider, they now see a helpful login button instead of just an error message.

![CleanShot 2025-12-10 at 13 29 23](https://github.com/user-attachments/assets/d0384c62-45a5-4a7d-9bed-42430239dfda)
