### PR TITLE
Fix agent-manager chat input padding for scroll

### DIFF
--- a/.changeset/witty-books-taste.md
+++ b/.changeset/witty-books-taste.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Agent-Manager - Fix Chat Input scroll

--- a/webview-ui/src/kilocode/agent-manager/components/ChatInput.tsx
+++ b/webview-ui/src/kilocode/agent-manager/components/ChatInput.tsx
@@ -87,7 +87,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ sessionId, sessionLabel, i
 						"text-vscode-editor-font-size",
 						"leading-vscode-editor-line-height",
 						"cursor-text",
-						"!py-3 !pl-3 pr-9", // Increased padding to fix "no distance" issue
+						"!pt-3 !pl-3 pr-9", // Top and left padding
 						isFocused
 							? "border border-vscode-focusBorder outline outline-vscode-focusBorder"
 							: "border border-vscode-input-border", // Default border
@@ -100,7 +100,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ sessionId, sessionLabel, i
 						"resize-none",
 						"overflow-x-hidden",
 						"overflow-y-auto",
-						"pb-10", // Bottom padding for floating buttons
+						"!pb-10", // Bottom padding for floating buttons
 						"flex-none flex-grow",
 						"z-[2]",
 						"scrollbar-none",


### PR DESCRIPTION
## Context

Text input box doesn’t allow for scroll if you add too much text 

## Implementation

- The scroll works however the padding don't allow to see the last part of the content

## Screenshots

https://github.com/user-attachments/assets/468a37dc-30b7-4c79-b5e6-83b920a10c82

