### PR TITLE
feat: add Kilo organization ID to all PostHog telemetry events

### DIFF
--- a/packages/telemetry/src/BaseTelemetryClient.ts
+++ b/packages/telemetry/src/BaseTelemetryClient.ts
@@ -54,6 +54,14 @@ export abstract class BaseTelemetryClient implements TelemetryClient {
 		// Event properties take precedence in case of conflicts.
 		const mergedProperties = { ...providerProperties, ...(event.properties || {}) }
 
+		// kilocode_change start
+		// Add organization ID if available from provider properties
+		// This ensures all events include the organization ID when present
+		if (providerProperties.kilocodeOrganizationId && !mergedProperties.kilocodeOrganizationId) {
+			mergedProperties.kilocodeOrganizationId = providerProperties.kilocodeOrganizationId
+		}
+		// kilocode_change end
+
 		// Filter out properties that shouldn't be captured by this client
 		return Object.fromEntries(Object.entries(mergedProperties).filter(([key]) => this.isPropertyCapturable(key)))
 	}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -3441,6 +3441,10 @@ ${prompt}
 			...getFastApply(),
 			...getOpenRouter(),
 			...getAutoApproveSettings(),
+			// Add organization ID if available
+			...(apiConfiguration.kilocodeOrganizationId && {
+				kilocodeOrganizationId: apiConfiguration.kilocodeOrganizationId,
+			}),
 			// kilocode_change end
 			...(await this.getTaskProperties()),
 			...(await this.getGitProperties()),


### PR DESCRIPTION
- Modified BaseTelemetryClient.getEventProperties() to include organization ID from provider properties
- Updated ClineProvider.getTelemetryProperties() to include kilocodeOrganizationId from API configuration
- Added comprehensive test coverage for organization ID functionality
- Organization ID is automatically included in all telemetry events when present in configuration
