### PR TITLE
Agent Manager - Local cli install for immutable enviroments

### DIFF
--- a/.changeset/thick-waves-argue.md
+++ b/.changeset/thick-waves-argue.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Agent Manager - Local CLI install for inmutable enviroments

--- a/.changeset/thick-waves-argue.md
+++ b/.changeset/thick-waves-argue.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Agent Manager - Local CLI install for inmutable enviroments
+Agent Manager - Local CLI install for immutable environments

--- a/src/core/kilocode/agent-manager/AgentManagerProvider.ts
+++ b/src/core/kilocode/agent-manager/AgentManagerProvider.ts
@@ -30,7 +30,6 @@ import {
 	captureAgentManagerSessionError,
 } from "./telemetry"
 import { SessionManager } from "../../../shared/kilocode/cli-sessions/core/SessionManager"
-import { auth } from "@modelcontextprotocol/sdk/client/auth.js"
 
 /**
  * AgentManagerProvider

--- a/src/core/kilocode/agent-manager/AgentManagerProvider.ts
+++ b/src/core/kilocode/agent-manager/AgentManagerProvider.ts
@@ -10,7 +10,7 @@ import {
 	parseParallelModeCompletionBranch,
 } from "./parallelModeParser"
 import { findKilocodeCli } from "./CliPathResolver"
-import { canInstallCli, getCliInstallCommand } from "./CliInstaller"
+import { canInstallCli, getCliInstallCommand, getLocalCliInstallCommand, getLocalCliBinDir } from "./CliInstaller"
 import { CliProcessHandler, type CliProcessHandlerCallbacks } from "./CliProcessHandler"
 import type { StreamEvent, KilocodeStreamEvent, KilocodePayload, WelcomeStreamEvent } from "./CliOutputParser"
 import { RemoteSessionService } from "./RemoteSessionService"
@@ -30,6 +30,7 @@ import {
 	captureAgentManagerSessionError,
 } from "./telemetry"
 import { SessionManager } from "../../../shared/kilocode/cli-sessions/core/SessionManager"
+import { auth } from "@modelcontextprotocol/sdk/client/auth.js"
 
 /**
  * AgentManagerProvider
@@ -789,7 +790,7 @@ export class AgentManagerProvider implements vscode.Disposable {
 	}
 
 	/**
-	 * Open a terminal and run the CLI install command.
+	 * Open a terminal and run the CLI install command (global installation).
 	 * Uses the terminal to ensure the user's shell environment (nvm, fnm, volta, etc.) is respected.
 	 */
 	private runInstallInTerminal(): void {
@@ -815,24 +816,129 @@ export class AgentManagerProvider implements vscode.Disposable {
 			})
 	}
 
+	/**
+	 * Open a terminal and run the local CLI install command.
+	 * This installs the CLI to ~/.kilocode/cli/pkg for systems that don't support global installation (e.g., NixOS).
+	 * Also adds the local bin directory to the user's PATH in their shell configuration and sources it immediately.
+	 */
+	private runLocalInstallInTerminal(): void {
+		const shellPath = process.platform === "win32" ? undefined : process.env.SHELL
+		const shellName = shellPath ? path.basename(shellPath) : undefined
+		const shellArgs = process.platform === "win32" ? undefined : shellName === "zsh" ? ["-l", "-i"] : ["-l"]
+
+		const terminal = vscode.window.createTerminal({
+			name: "Install Kilocode CLI (Local)",
+			message: "Installing Kilocode CLI locally to ~/.kilocode/cli/pkg",
+			shellPath,
+			shellArgs,
+		})
+		terminal.show()
+
+		const binDir = getLocalCliBinDir()
+
+		// Build command as array and join with && for sequential execution
+		if (process.platform === "win32") {
+			// Windows: Chain commands with && to ensure they run sequentially
+			const psCommand = `$binDir = "${binDir.replace(/\\/g, "\\\\")}"; $currentPath = [Environment]::GetEnvironmentVariable("Path", "User"); if ($currentPath -notlike "*$binDir*") { [Environment]::SetEnvironmentVariable("Path", "$binDir;$currentPath", "User"); Write-Host "Added $binDir to user PATH"; $env:Path = "$binDir;$env:Path"; Write-Host "PATH updated in current session" } else { Write-Host "$binDir already in PATH" }`
+
+			const commands = [
+				getLocalCliInstallCommand(),
+				`powershell -Command "${psCommand}"`,
+				"echo.",
+				"echo ✓ CLI installed locally and PATH updated!",
+				"echo.",
+				"echo Next step: Run 'kilocode auth' to authenticate",
+			]
+			terminal.sendText(commands.join(" && "))
+		} else {
+			// Unix: Chain commands with && to ensure they run sequentially
+			const exportLine = `export PATH="${binDir}:$PATH"`
+
+			// Determine the shell config file based on the shell
+			let configFile = "~/.bashrc"
+			let pathCommand = `grep -qxF '${exportLine}' ${configFile} || echo '${exportLine}' >> ${configFile}`
+			let sourceCommand = `source ${configFile}`
+
+			if (shellName === "zsh") {
+				configFile = "~/.zshrc"
+				pathCommand = `grep -qxF '${exportLine}' ${configFile} || echo '${exportLine}' >> ${configFile}`
+				sourceCommand = `source ${configFile}`
+			} else if (shellName === "fish") {
+				// Fish uses a different syntax for PATH
+				configFile = "~/.config/fish/config.fish"
+				const fishPathLine = `fish_add_path ${binDir}`
+				pathCommand = `grep -qxF '${fishPathLine}' ${configFile} || echo '${fishPathLine}' >> ${configFile}`
+				sourceCommand = `source ${configFile}`
+			}
+
+			const commands = [
+				"clear",
+				getLocalCliInstallCommand(),
+				'echo ""',
+				'echo "✓ CLI installed locally"',
+				'echo ""',
+				pathCommand,
+				sourceCommand,
+				`echo "Added ${binDir} to PATH and reloaded config"`,
+				'echo ""',
+				"echo \"Next step: Run 'kilocode auth' to authenticate\"",
+				"echo \"Alternatively, run '~/.kilocode/cli/pkg/node_modules/.bin/kilocode auth' to authenticate if not in PATH\"",
+			]
+			terminal.sendText(commands.join(" ; "))
+		}
+	}
+
+	/**
+	 * Open a terminal and run the local CLI update command.
+	 * This updates the CLI in ~/.kilocode/cli/pkg for systems using local installation.
+	 */
+	private runLocalUpdateInTerminal(): void {
+		const shellPath = process.platform === "win32" ? undefined : process.env.SHELL
+		const shellName = shellPath ? path.basename(shellPath) : undefined
+		const shellArgs = process.platform === "win32" ? undefined : shellName === "zsh" ? ["-l", "-i"] : ["-l"]
+
+		const terminal = vscode.window.createTerminal({
+			name: "Update Kilocode CLI (Local)",
+			message: "Updating Kilocode CLI in ~/.kilocode/cli/pkg",
+			shellPath,
+			shellArgs,
+		})
+		terminal.show()
+
+		// Update the CLI (npm install will update if already installed)
+		const commands = [
+			"clear",
+			getLocalCliInstallCommand(),
+			'echo ""',
+			'echo "✓ CLI updated successfully!"',
+			'echo ""',
+			'echo "The updated CLI is ready to use"',
+		]
+		terminal.sendText(commands.join(" && "))
+	}
+
 	private showCliError(error?: { type: "cli_outdated" | "spawn_error" | "unknown"; message: string }): void {
 		const hasNpm = canInstallCli((msg) => this.outputChannel.appendLine(`[AgentManager] ${msg}`))
 
 		switch (error?.type) {
 			case "cli_outdated":
 				if (hasNpm) {
-					// Offer to update via terminal
-					const updateInTerminal = t("kilocode:agentManager.actions.runInTerminal")
+					// Offer to update via terminal (global or local)
+					const updateGlobal = t("kilocode:agentManager.actions.updateGlobal")
+					const updateLocal = t("kilocode:agentManager.actions.updateLocal")
 					const manualUpdate = t("kilocode:agentManager.actions.updateInstructions")
 					vscode.window
 						.showWarningMessage(
 							t("kilocode:agentManager.errors.cliOutdated"),
-							updateInTerminal,
+							updateGlobal,
+							updateLocal,
 							manualUpdate,
 						)
 						.then((selection) => {
-							if (selection === updateInTerminal) {
+							if (selection === updateGlobal) {
 								this.runInstallInTerminal()
+							} else if (selection === updateLocal) {
+								this.runLocalUpdateInTerminal()
 							} else if (selection === manualUpdate) {
 								void vscode.env.openExternal(vscode.Uri.parse("https://kilo.ai/docs/cli"))
 							}
@@ -851,18 +957,22 @@ export class AgentManagerProvider implements vscode.Disposable {
 				break
 			case "spawn_error": {
 				if (hasNpm) {
-					// Offer to install via terminal
-					const installInTerminal = t("kilocode:agentManager.actions.runInTerminal")
+					// Offer to install via terminal (global or local)
+					const installGlobal = t("kilocode:agentManager.actions.installGlobal")
+					const installLocal = t("kilocode:agentManager.actions.installLocal")
 					const manualInstall = t("kilocode:agentManager.actions.installInstructions")
 					vscode.window
 						.showErrorMessage(
 							t("kilocode:agentManager.errors.cliNotFound"),
-							installInTerminal,
+							installGlobal,
+							installLocal,
 							manualInstall,
 						)
 						.then((selection) => {
-							if (selection === installInTerminal) {
+							if (selection === installGlobal) {
 								this.runInstallInTerminal()
+							} else if (selection === installLocal) {
+								this.runLocalInstallInTerminal()
 							} else if (selection === manualInstall) {
 								void vscode.env.openExternal(vscode.Uri.parse("https://kilo.ai/docs/cli"))
 							}

--- a/src/core/kilocode/agent-manager/CliInstaller.ts
+++ b/src/core/kilocode/agent-manager/CliInstaller.ts
@@ -1,13 +1,51 @@
 import { execSync } from "node:child_process"
+import * as path from "node:path"
+import * as os from "node:os"
 
 const CLI_PACKAGE_NAME = "@kilocode/cli"
+const LOCAL_CLI_DIR = path.join(os.homedir(), ".kilocode", "cli", "pkg")
 
 /**
- * Get the npm install command for the CLI.
+ * Get the path to the local CLI installation directory.
+ * This is where the CLI will be installed for immutable systems like NixOS.
+ */
+export function getLocalCliDir(): string {
+	return LOCAL_CLI_DIR
+}
+
+/**
+ * Get the path to the local CLI bin directory.
+ * This is the directory that should be added to PATH.
+ */
+export function getLocalCliBinDir(): string {
+	return path.join(LOCAL_CLI_DIR, "node_modules", ".bin")
+}
+
+/**
+ * Get the path to the locally installed CLI executable.
+ * Returns the full path to the kilocode binary in the local installation.
+ */
+export function getLocalCliPath(): string {
+	const binDir = getLocalCliBinDir()
+	// Windows uses .cmd wrapper scripts
+	const executable = process.platform === "win32" ? "kilocode.cmd" : "kilocode"
+	return path.join(binDir, executable)
+}
+
+/**
+ * Get the npm install command for the CLI (global installation).
  * Useful for displaying to users or running in terminal.
  */
 export function getCliInstallCommand(): string {
 	return `npm install -g ${CLI_PACKAGE_NAME}`
+}
+
+/**
+ * Get the npm install command for local CLI installation.
+ * This installs the CLI to ~/.kilocode/cli/pkg for systems that don't support global installation.
+ */
+export function getLocalCliInstallCommand(): string {
+	return `npm install ${CLI_PACKAGE_NAME} --prefix ${LOCAL_CLI_DIR}`
 }
 
 /**

--- a/src/core/kilocode/agent-manager/__tests__/CliInstaller.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/CliInstaller.spec.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import * as os from "node:os"
+import * as path from "node:path"
 
 describe("CliInstaller", () => {
 	beforeEach(() => {
@@ -14,6 +16,68 @@ describe("CliInstaller", () => {
 			const { getCliInstallCommand } = await import("../CliInstaller")
 			const command = getCliInstallCommand()
 			expect(command).toBe("npm install -g @kilocode/cli")
+		})
+	})
+
+	describe("getLocalCliDir", () => {
+		it("returns the local CLI installation directory", async () => {
+			const { getLocalCliDir } = await import("../CliInstaller")
+			const dir = getLocalCliDir()
+			const expectedDir = path.join(os.homedir(), ".kilocode", "cli", "pkg")
+			expect(dir).toBe(expectedDir)
+		})
+	})
+
+	describe("getLocalCliBinDir", () => {
+		it("returns the local CLI bin directory", async () => {
+			const { getLocalCliBinDir } = await import("../CliInstaller")
+			const binDir = getLocalCliBinDir()
+			const expectedDir = path.join(os.homedir(), ".kilocode", "cli", "pkg", "node_modules", ".bin")
+			expect(binDir).toBe(expectedDir)
+		})
+	})
+
+	describe("getLocalCliPath", () => {
+		it("returns the local CLI executable path on Unix", async () => {
+			const originalPlatform = process.platform
+			Object.defineProperty(process, "platform", { value: "linux" })
+
+			const { getLocalCliPath } = await import("../CliInstaller")
+			const cliPath = getLocalCliPath()
+			const expectedPath = path.join(os.homedir(), ".kilocode", "cli", "pkg", "node_modules", ".bin", "kilocode")
+			expect(cliPath).toBe(expectedPath)
+
+			Object.defineProperty(process, "platform", { value: originalPlatform })
+		})
+
+		it("returns the local CLI executable path with .cmd extension on Windows", async () => {
+			const originalPlatform = process.platform
+			Object.defineProperty(process, "platform", { value: "win32" })
+
+			vi.resetModules()
+			const { getLocalCliPath } = await import("../CliInstaller")
+			const cliPath = getLocalCliPath()
+			const expectedPath = path.join(
+				os.homedir(),
+				".kilocode",
+				"cli",
+				"pkg",
+				"node_modules",
+				".bin",
+				"kilocode.cmd",
+			)
+			expect(cliPath).toBe(expectedPath)
+
+			Object.defineProperty(process, "platform", { value: originalPlatform })
+		})
+	})
+
+	describe("getLocalCliInstallCommand", () => {
+		it("returns the npm install command for local CLI installation", async () => {
+			const { getLocalCliInstallCommand } = await import("../CliInstaller")
+			const command = getLocalCliInstallCommand()
+			const expectedDir = path.join(os.homedir(), ".kilocode", "cli", "pkg")
+			expect(command).toBe(`npm install @kilocode/cli --prefix ${expectedDir}`)
 		})
 	})
 

--- a/src/i18n/locales/ar/kilocode.json
+++ b/src/i18n/locales/ar/kilocode.json
@@ -188,7 +188,11 @@
 			"installInstructions": "تعليمات التثبيت",
 			"getHelp": "الحصول على المساعدة",
 			"runInTerminal": "تشغيل في الطرفية",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "تحديث عام",
+			"updateLocal": "تحديث محلي",
+			"installGlobal": "تثبيت عام",
+			"installLocal": "تثبيت محلي"
 		},
 		"terminal": {
 			"installMessage": "تشغيل npm install لتثبيت Kilocode CLI. بمجرد الانتهاء، يمكنك إغلاق هذه الطرفية ومحاولة بدء Agent Manager مرة أخرى.",

--- a/src/i18n/locales/ca/kilocode.json
+++ b/src/i18n/locales/ca/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "Instruccions d'Instal·lació",
 			"getHelp": "Obtenir Ajuda",
 			"runInTerminal": "Executar al Terminal",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Actualitzar Global",
+			"updateLocal": "Actualitzar Local",
+			"installGlobal": "Instal·lar Global",
+			"installLocal": "Instal·lar Local"
 		},
 		"terminal": {
 			"installMessage": "Executant npm install per instal·lar Kilocode CLI. Un cop completat, pots tancar aquest terminal i intentar iniciar el Gestor d'Agents de nou.",

--- a/src/i18n/locales/cs/kilocode.json
+++ b/src/i18n/locales/cs/kilocode.json
@@ -114,7 +114,11 @@
 			"installInstructions": "Instrukce k Instalaci",
 			"getHelp": "Získat Pomoc",
 			"runInTerminal": "Spustit v Terminálu",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Aktualizovat Globálně",
+			"updateLocal": "Aktualizovat Lokálně",
+			"installGlobal": "Instalovat Globálně",
+			"installLocal": "Instalovat Lokálně"
 		},
 		"terminal": {
 			"installMessage": "Spouštím npm install pro instalaci Kilocode CLI. Po dokončení můžeš tento terminál zavřít a zkusit Agent Manager spustit znovu.",

--- a/src/i18n/locales/de/kilocode.json
+++ b/src/i18n/locales/de/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "Installationsanleitung",
 			"getHelp": "Hilfe erhalten",
 			"runInTerminal": "Im Terminal ausführen",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Global Aktualisieren",
+			"updateLocal": "Lokal Aktualisieren",
+			"installGlobal": "Global Installieren",
+			"installLocal": "Lokal Installieren"
 		},
 		"terminal": {
 			"installMessage": "Führe npm install aus, um die Kilocode CLI zu installieren. Sobald die Installation abgeschlossen ist, kannst du dieses Terminal schließen und versuchen, den Agent Manager erneut zu starten.",

--- a/src/i18n/locales/en/kilocode.json
+++ b/src/i18n/locales/en/kilocode.json
@@ -169,6 +169,10 @@
 			"installInstructions": "Install Instructions",
 			"getHelp": "Get Help",
 			"runInTerminal": "Run in Terminal",
+			"updateGlobal": "Update Global",
+			"updateLocal": "Update Local",
+			"installGlobal": "Install Global",
+			"installLocal": "Install Local",
 			"loginCli": "Run kilocode auth"
 		},
 		"terminal": {

--- a/src/i18n/locales/es/kilocode.json
+++ b/src/i18n/locales/es/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "Instrucciones de Instalación",
 			"getHelp": "Obtener Ayuda",
 			"runInTerminal": "Ejecutar en Terminal",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Actualizar Global",
+			"updateLocal": "Actualizar Local",
+			"installGlobal": "Instalar Global",
+			"installLocal": "Instalar Local"
 		},
 		"terminal": {
 			"installMessage": "Ejecutando npm install para instalar Kilocode CLI. Una vez completado, puedes cerrar este terminal e intentar iniciar el Gestor de Agentes nuevamente.",

--- a/src/i18n/locales/fr/kilocode.json
+++ b/src/i18n/locales/fr/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "Instructions d'Installation",
 			"getHelp": "Obtenir de l'Aide",
 			"runInTerminal": "Exécuter dans le Terminal",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Mettre à jour Global",
+			"updateLocal": "Mettre à jour Local",
+			"installGlobal": "Installer Global",
+			"installLocal": "Installer Local"
 		},
 		"terminal": {
 			"installMessage": "Exécution de npm install pour installer Kilocode CLI. Une fois terminé, tu peux fermer ce terminal et essayer de démarrer le Gestionnaire d'Agents à nouveau.",

--- a/src/i18n/locales/hi/kilocode.json
+++ b/src/i18n/locales/hi/kilocode.json
@@ -114,7 +114,11 @@
 			"installInstructions": "इंस्टॉल निर्देश",
 			"getHelp": "सहायता प्राप्त करें",
 			"runInTerminal": "टर्मिनल में चलाएं",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "ग्लोबल अपडेट करें",
+			"updateLocal": "लोकल अपडेट करें",
+			"installGlobal": "ग्लोबल इंस्टॉल करें",
+			"installLocal": "लोकल इंस्टॉल करें"
 		},
 		"terminal": {
 			"installMessage": "Kilocode CLI इंस्टॉल करने के लिए npm install चल रहा है। पूर्ण होने के बाद, आप यह टर्मिनल बंद कर सकते हैं और Agent Manager को फिर से शुरू करने का प्रयास कर सकते हैं।",

--- a/src/i18n/locales/id/kilocode.json
+++ b/src/i18n/locales/id/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "Petunjuk Instalasi",
 			"getHelp": "Dapatkan Bantuan",
 			"runInTerminal": "Jalankan di Terminal",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Perbarui Global",
+			"updateLocal": "Perbarui Lokal",
+			"installGlobal": "Instal Global",
+			"installLocal": "Instal Lokal"
 		},
 		"terminal": {
 			"installMessage": "Menjalankan npm install untuk menginstal Kilocode CLI. Setelah selesai, kamu dapat menutup terminal ini dan mencoba memulai Agent Manager lagi.",

--- a/src/i18n/locales/it/kilocode.json
+++ b/src/i18n/locales/it/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "Istruzioni di Installazione",
 			"getHelp": "Ottieni Aiuto",
 			"runInTerminal": "Esegui nel Terminale",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Aggiorna Globale",
+			"updateLocal": "Aggiorna Locale",
+			"installGlobal": "Installa Globale",
+			"installLocal": "Installa Locale"
 		},
 		"terminal": {
 			"installMessage": "Esecuzione di npm install per installare Kilocode CLI. Una volta completato, puoi chiudere questo terminale e provare ad avviare nuovamente l'Agent Manager.",

--- a/src/i18n/locales/ja/kilocode.json
+++ b/src/i18n/locales/ja/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "インストール手順",
 			"getHelp": "ヘルプを表示",
 			"runInTerminal": "ターミナルで実行",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "グローバル更新",
+			"updateLocal": "ローカル更新",
+			"installGlobal": "グローバルインストール",
+			"installLocal": "ローカルインストール"
 		},
 		"terminal": {
 			"installMessage": "Kilocode CLIをインストールするためにnpm installを実行しています。完了したら、このターミナルを閉じてAgent Managerを再度起動してみてください。",

--- a/src/i18n/locales/ko/kilocode.json
+++ b/src/i18n/locales/ko/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "설치 지침",
 			"getHelp": "도움말 보기",
 			"runInTerminal": "터미널에서 실행",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "전역 업데이트",
+			"updateLocal": "로컬 업데이트",
+			"installGlobal": "전역 설치",
+			"installLocal": "로컬 설치"
 		},
 		"terminal": {
 			"installMessage": "Kilocode CLI를 설치하기 위해 npm install을 실행합니다. 완료되면 이 터미널을 닫고 Agent Manager를 다시 시작해 보세요.",

--- a/src/i18n/locales/nl/kilocode.json
+++ b/src/i18n/locales/nl/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "Installatie-instructies",
 			"getHelp": "Hulp krijgen",
 			"runInTerminal": "Uitvoeren in Terminal",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Globaal Bijwerken",
+			"updateLocal": "Lokaal Bijwerken",
+			"installGlobal": "Globaal Installeren",
+			"installLocal": "Lokaal Installeren"
 		},
 		"terminal": {
 			"installMessage": "npm install uitvoeren om Kilocode CLI te installeren. Zodra voltooid, kun je dit terminal sluiten en proberen de Agent Manager opnieuw te starten.",

--- a/src/i18n/locales/pl/kilocode.json
+++ b/src/i18n/locales/pl/kilocode.json
@@ -114,7 +114,11 @@
 			"installInstructions": "Instrukcje Instalacji",
 			"getHelp": "Uzyskaj Pomoc",
 			"runInTerminal": "Uruchom w Terminalu",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Aktualizuj Globalnie",
+			"updateLocal": "Aktualizuj Lokalnie",
+			"installGlobal": "Zainstaluj Globalnie",
+			"installLocal": "Zainstaluj Lokalnie"
 		},
 		"terminal": {
 			"installMessage": "Uruchamianie npm install w celu zainstalowania Kilocode CLI. Po zakończeniu możesz zamknąć ten terminal i spróbować ponownie uruchomić Agent Managera.",

--- a/src/i18n/locales/pt-BR/kilocode.json
+++ b/src/i18n/locales/pt-BR/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "Instruções de Instalação",
 			"getHelp": "Obter Ajuda",
 			"runInTerminal": "Executar no Terminal",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Atualizar Global",
+			"updateLocal": "Atualizar Local",
+			"installGlobal": "Instalar Global",
+			"installLocal": "Instalar Local"
 		},
 		"terminal": {
 			"installMessage": "Executando npm install para instalar o Kilocode CLI. Após a conclusão, você pode fechar este terminal e tentar iniciar o Gerenciador de Agentes novamente.",

--- a/src/i18n/locales/ru/kilocode.json
+++ b/src/i18n/locales/ru/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "Инструкции по Установке",
 			"getHelp": "Получить Помощь",
 			"runInTerminal": "Запустить в Терминале",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Обновить Глобально",
+			"updateLocal": "Обновить Локально",
+			"installGlobal": "Установить Глобально",
+			"installLocal": "Установить Локально"
 		},
 		"terminal": {
 			"installMessage": "Выполнение npm install для установки Kilocode CLI. После завершения можешь закрыть этот терминал и попробовать запустить Agent Manager снова.",

--- a/src/i18n/locales/th/kilocode.json
+++ b/src/i18n/locales/th/kilocode.json
@@ -114,7 +114,11 @@
 			"installInstructions": "คำแนะนำการติดตั้ง",
 			"getHelp": "รับความช่วยเหลือ",
 			"runInTerminal": "เรียกใช้ในเทอร์มินัล",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "อัปเดตแบบ Global",
+			"updateLocal": "อัปเดตแบบ Local",
+			"installGlobal": "ติดตั้งแบบ Global",
+			"installLocal": "ติดตั้งแบบ Local"
 		},
 		"terminal": {
 			"installMessage": "กำลังรัน npm install เพื่อติดตั้ง Kilocode CLI เมื่อเสร็จแล้ว คุณสามารถปิดเทอร์มินัลนี้และลองเริ่ม Agent Manager อีกครั้ง",

--- a/src/i18n/locales/tr/kilocode.json
+++ b/src/i18n/locales/tr/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "Kurulum Talimatları",
 			"getHelp": "Yardım Al",
 			"runInTerminal": "Terminalde Çalıştır",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Global Güncelle",
+			"updateLocal": "Lokal Güncelle",
+			"installGlobal": "Global Yükle",
+			"installLocal": "Lokal Yükle"
 		},
 		"terminal": {
 			"installMessage": "Kilocode CLI'yi yüklemek için npm install çalıştırılıyor. Tamamlandığında, bu terminali kapatıp Agent Manager'ı tekrar başlatmayı deneyebilirsin.",

--- a/src/i18n/locales/uk/kilocode.json
+++ b/src/i18n/locales/uk/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "Інструкції з Встановлення",
 			"getHelp": "Отримати Допомогу",
 			"runInTerminal": "Запустити в Терміналі",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Оновити Глобально",
+			"updateLocal": "Оновити Локально",
+			"installGlobal": "Встановити Глобально",
+			"installLocal": "Встановити Локально"
 		},
 		"terminal": {
 			"installMessage": "Виконання npm install для встановлення Kilocode CLI. Після завершення можеш закрити цей термінал і спробувати запустити Agent Manager знову.",

--- a/src/i18n/locales/vi/kilocode.json
+++ b/src/i18n/locales/vi/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "Hướng Dẫn Cài Đặt",
 			"getHelp": "Nhận Trợ Giúp",
 			"runInTerminal": "Chạy trong Terminal",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "Cập Nhật Toàn Cục",
+			"updateLocal": "Cập Nhật Cục Bộ",
+			"installGlobal": "Cài Đặt Toàn Cục",
+			"installLocal": "Cài Đặt Cục Bộ"
 		},
 		"terminal": {
 			"installMessage": "Đang chạy npm install để cài đặt Kilocode CLI. Sau khi hoàn tất, bạn có thể đóng terminal này và thử khởi động lại Agent Manager.",

--- a/src/i18n/locales/zh-CN/kilocode.json
+++ b/src/i18n/locales/zh-CN/kilocode.json
@@ -114,7 +114,11 @@
 			"installInstructions": "安装说明",
 			"getHelp": "获取帮助",
 			"runInTerminal": "运行命令",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "全局更新",
+			"updateLocal": "本地更新",
+			"installGlobal": "全局安装",
+			"installLocal": "本地安装"
 		},
 		"terminal": {
 			"installMessage": "运行 npm install 安装 Kilocode CLI。完成后可关闭此终端，然后重新启动 Agent Manager。",

--- a/src/i18n/locales/zh-TW/kilocode.json
+++ b/src/i18n/locales/zh-TW/kilocode.json
@@ -184,7 +184,11 @@
 			"installInstructions": "安裝說明",
 			"getHelp": "取得協助",
 			"runInTerminal": "在終端機執行",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"updateGlobal": "更新全域",
+			"updateLocal": "更新本地",
+			"installGlobal": "安裝全域",
+			"installLocal": "安裝本地"
 		},
 		"terminal": {
 			"installMessage": "執行 npm install 以安裝 Kilocode CLI。完成後，您可以關閉此終端機並嘗試再次啟動 Agent Manager。",


### PR DESCRIPTION
## Context

https://github.com/Kilo-Org/kilocode/discussions/4368

The global install don't work on my NixOS immutable environment 

<img width="2016" height="511" alt="image" src="https://github.com/user-attachments/assets/d4200cbe-ae12-40a9-807e-82f9adf50f44" />

## Implementation

- Add a Alternative Local Install on `~/.kilocode/cli/pkg`
- Add the path into the shell init script if it's possible
- Use this new path to find the install there
- Handle auto update parity with the global install

## Screenshots

<img width="1959" height="1523" alt="image" src="https://github.com/user-attachments/assets/c33d62b2-9c99-4c64-9493-b082d48740f7" />
<img width="2391" height="1944" alt="image" src="https://github.com/user-attachments/assets/95fdecf2-6c82-4d37-96a4-ea29f8aab6a5" />
<img width="1334" height="481" alt="image" src="https://github.com/user-attachments/assets/686e41e8-ee27-45ff-a903-b1af4adf1a8a" />

