### PR TITLE
kilo -> kilocode in url handler

### DIFF
--- a/.changeset/easy-turtles-post.md
+++ b/.changeset/easy-turtles-post.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix share url handling

--- a/src/activate/handleUri.ts
+++ b/src/activate/handleUri.ts
@@ -46,7 +46,7 @@ export const handleUri = async (uri: vscode.Uri) => {
 			})
 			break
 		}
-		case "/kilo/fork": {
+		case "/kilocode/fork": {
 			const id = query.get("id")
 			if (id) {
 				await visibleProvider.postMessageToWebview({


### PR DESCRIPTION
## Context

Fix share url handling. It's `/kilocode`, not `/kilo`.