### PR TITLE
feat: show only first line of completion when adding to current line

### DIFF
--- a/.changeset/pretty-memes-lose.md
+++ b/.changeset/pretty-memes-lose.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Split autocomplete suggestion in current line and next lines in most cases

--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -147,16 +147,24 @@ export const INLINE_COMPLETION_ACCEPTED_COMMAND = "kilocode.ghost.inline-complet
 /**
  * Counts the number of lines in a text string.
  *
+ * Notes:
+ * - Returns 0 for an empty string
+ * - A single trailing newline (or CRLF) does not count as an additional line
+ *
  * @param text - The text to count lines in
- * @returns The number of lines (1 for empty string or no newlines)
+ * @returns The number of lines
  */
 export function countLines(text: string): number {
 	if (text === "") {
 		return 0
 	}
-	// Count newlines and add 1 for the first line
-	const newlineCount = (text.match(/\r?\n/g) || []).length
-	return newlineCount + 1
+
+	// Count line breaks and add 1 for the first line.
+	// If the text ends with a line break, don't count the implicit trailing empty line.
+	const lineBreakCount = (text.match(/\r?\n/g) || []).length
+	const endsWithLineBreak = text.endsWith("\n")
+
+	return lineBreakCount + 1 - (endsWithLineBreak ? 1 : 0)
 }
 
 /**

--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -208,15 +208,7 @@ export function shouldShowOnlyFirstLine(prefix: string, suggestion: string): boo
  * @returns The first line of the completion (without the newline)
  */
 export function getFirstLine(text: string): string {
-	const newlineIndex = text.indexOf("\n")
-	if (newlineIndex === -1) {
-		return text
-	}
-	// Handle \r\n line endings
-	if (newlineIndex > 0 && text[newlineIndex - 1] === "\r") {
-		return text.substring(0, newlineIndex - 1)
-	}
-	return text.substring(0, newlineIndex)
+	return text.split(/\r?\n/, 1)[0]
 }
 
 export function stringToInlineCompletions(text: string, position: vscode.Position): vscode.InlineCompletionItem[] {

--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -188,7 +188,7 @@ export function shouldShowOnlyFirstLine(prefix: string, suggestion: string): boo
 
 	// Check if the current line (before cursor) has non-whitespace text
 	const lastNewlineIndex = prefix.lastIndexOf("\n")
-	const currentLinePrefix = lastNewlineIndex === -1 ? prefix : prefix.substring(lastNewlineIndex + 1)
+	const currentLinePrefix = prefix.slice(lastNewlineIndex + 1)
 
 	// If the current line prefix contains non-whitespace, only show the first line
 	if (currentLinePrefix.trim().length > 0) {

--- a/src/services/ghost/classic-auto-complete/__tests__/GhostInlineCompletionProvider.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/GhostInlineCompletionProvider.test.ts
@@ -502,8 +502,8 @@ describe("countLines", () => {
 		expect(countLines("l1\nl2\r\nl3")).toBe(3)
 	})
 
-	it("counts trailing newline as an additional line", () => {
-		expect(countLines("l1\n")).toBe(2)
+	it("does not count trailing newline as an additional line", () => {
+		expect(countLines("l1\nl2\n")).toBe(2)
 	})
 })
 


### PR DESCRIPTION
## Summary

When the inline completion provider suggests text that adds to the current line (suggestion doesn't start with newline), only show the first line. VSCode will request the rest on subsequent completions.

## Changes

- Added `shouldShowOnlyFirstLine(prefix, suggestion)` function that determines when to show only the first line
- Added `getFirstLine(text)` helper to extract the first line from completion text
- Updated `stringToInlineCompletions()` to apply the first-line-only logic

## Logic

The full suggestion is shown when:
- The suggestion starts with a newline (inserting a new line)
- The current line is only whitespace (cursor on empty/indented line)

Only the first line is shown when:
- The suggestion adds to existing content on the current line

## Why

This improves the UX by not overwhelming users with multi-line suggestions when they're typing in the middle of existing code. VSCode will automatically request more completions as the user continues typing.