### PR TITLE
fix(chat): prevent ghost text overlap when chat input is empty

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1040,7 +1040,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				}
 			}
 			// kilocode_change start - autocomplete ghost text display
-			if (ghostText) {
+			if (inputValue && ghostText) {
 				processedText += `<span class="text-vscode-editor-foreground opacity-60 pointer-events-none">${escapeHtml(ghostText)}</span>`
 			}
 			// kilocode_change end - autocomplete ghost text display
@@ -1048,7 +1048,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			highlightLayerRef.current.innerHTML = processedText
 			highlightLayerRef.current.scrollTop = textAreaRef.current.scrollTop
 			highlightLayerRef.current.scrollLeft = textAreaRef.current.scrollLeft
-		}, [customModes, ghostText])
+		}, [customModes, ghostText, inputValue]) // kilocode_change - add inputValue
 
 		useLayoutEffect(() => {
 			updateHighlights()


### PR DESCRIPTION
Fix fixes a bug where the `ghostText` in the input would overlap with the placeholder text we show when the box is empty

Add condition to only show autocomplete ghost text when inputValue exists, preventing visual overlap in the chat textarea

Prevent this:
<img width="524" height="166" alt="CleanShot 2025-12-11 at 12 16 33" src="https://github.com/user-attachments/assets/86ad7907-93fc-486b-bea6-f848251f73c9" />
