### PR TITLE
Fix: bottom controls no longer overlap with create mode button

### DIFF
--- a/.changeset/humble-points-care.md
+++ b/.changeset/humble-points-care.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix: bottom controls no longer overlap with create mode button

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -438,8 +438,8 @@ const App = () => {
 				/>
 			)}
 			{/* kilocode_change */}
-			{/* Chat, modes and history view contain their own bottom controls */}
-			{!["chat", "modes", "history"].includes(tab) && (
+			{/* Chat, and history view contain their own bottom controls, settings doesn't need it */}
+			{!["chat", "settings", "history"].includes(tab) && (
 				<div className="fixed inset-0 top-auto">
 					<BottomControls />
 				</div>

--- a/webview-ui/src/components/modes/ModesView.tsx
+++ b/webview-ui/src/components/modes/ModesView.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from "react"
-import BottomControls from "../kilocode/BottomControls" // kilocode_change
 import { KiloShareModesBanner } from "../kilocode/KiloShareModesBanner" // kilocode_change
 import {
 	VSCodeCheckbox,
@@ -1779,9 +1778,6 @@ const ModesView = () => {
 					}
 				}}
 			/>
-
-			{/* kilocode_change */}
-			<BottomControls />
 		</div>
 	)
 }


### PR DESCRIPTION
Fixes #4413

Because Modes moved into the regular settings the bottom controls in settings would overlap with the save buttons for new modes. These bottom controls are irrelevant in the settings window anyway so I removed them there.