### PR TITLE
feat: make /smol command use autocondensing feature

### DIFF
--- a/src/core/tools/kilocode/__tests__/condenseTool.spec.ts
+++ b/src/core/tools/kilocode/__tests__/condenseTool.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { condenseTool } from "../condenseTool"
+import { Task } from "../../../task/Task"
+import { ToolUse } from "../../../../shared/tools"
+
+// Mock the Task class
+vi.mock("../../../task/Task", () => ({
+	Task: vi.fn(),
+}))
+
+describe("condenseTool", () => {
+	let mockTask: Partial<Task>
+	let mockAskApproval: ReturnType<typeof vi.fn>
+	let mockHandleError: ReturnType<typeof vi.fn>
+	let mockPushToolResult: ReturnType<typeof vi.fn>
+	let mockRemoveClosingTag: ReturnType<typeof vi.fn>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		mockTask = {
+			ask: vi.fn(),
+			say: vi.fn(),
+			condenseContext: vi.fn().mockResolvedValue(undefined),
+			sayAndCreateMissingParamError: vi.fn().mockResolvedValue("Missing param error"),
+			consecutiveMistakeCount: 0,
+		}
+
+		mockAskApproval = vi.fn()
+		mockHandleError = vi.fn()
+		mockPushToolResult = vi.fn()
+		mockRemoveClosingTag = vi.fn((tag, content) => content)
+	})
+
+	it("should call condenseContext when user accepts the condensed version", async () => {
+		const block: ToolUse = {
+			type: "tool_use",
+			name: "condense",
+			params: {
+				message: "Test summary message",
+			},
+			partial: false,
+		}
+
+		// User accepts (no text or images in response)
+		;(mockTask.ask as ReturnType<typeof vi.fn>).mockResolvedValue({ text: undefined, images: undefined })
+
+		await condenseTool(
+			mockTask as Task,
+			block,
+			mockAskApproval,
+			mockHandleError,
+			mockPushToolResult,
+			mockRemoveClosingTag,
+		)
+
+		// Verify condenseContext was called
+		expect(mockTask.condenseContext).toHaveBeenCalledTimes(1)
+		expect(mockPushToolResult).toHaveBeenCalled()
+	})
+
+	it("should not call condenseContext when user provides feedback", async () => {
+		const block: ToolUse = {
+			type: "tool_use",
+			name: "condense",
+			params: {
+				message: "Test summary message",
+			},
+			partial: false,
+		}
+
+		// User provides feedback
+		;(mockTask.ask as ReturnType<typeof vi.fn>).mockResolvedValue({ text: "Some feedback", images: [] })
+
+		await condenseTool(
+			mockTask as Task,
+			block,
+			mockAskApproval,
+			mockHandleError,
+			mockPushToolResult,
+			mockRemoveClosingTag,
+		)
+
+		// Verify condenseContext was NOT called
+		expect(mockTask.condenseContext).not.toHaveBeenCalled()
+		// Verify user feedback was recorded
+		expect(mockTask.say).toHaveBeenCalledWith("user_feedback", "Some feedback", [])
+	})
+
+	it("should handle partial blocks", async () => {
+		const block: ToolUse = {
+			type: "tool_use",
+			name: "condense",
+			params: {
+				message: "Partial message",
+			},
+			partial: true,
+		}
+
+		;(mockTask.ask as ReturnType<typeof vi.fn>).mockResolvedValue({ text: undefined, images: undefined })
+
+		await condenseTool(
+			mockTask as Task,
+			block,
+			mockAskApproval,
+			mockHandleError,
+			mockPushToolResult,
+			mockRemoveClosingTag,
+		)
+
+		// Verify ask was called with partial flag
+		expect(mockTask.ask).toHaveBeenCalledWith("condense", "Partial message", true)
+		// Verify condenseContext was NOT called for partial blocks
+		expect(mockTask.condenseContext).not.toHaveBeenCalled()
+	})
+
+	it("should handle missing message parameter", async () => {
+		const block: ToolUse = {
+			type: "tool_use",
+			name: "condense",
+			params: {},
+			partial: false,
+		}
+
+		await condenseTool(
+			mockTask as Task,
+			block,
+			mockAskApproval,
+			mockHandleError,
+			mockPushToolResult,
+			mockRemoveClosingTag,
+		)
+
+		// Verify error was pushed
+		expect(mockTask.sayAndCreateMissingParamError).toHaveBeenCalledWith("condense", "context")
+		expect(mockPushToolResult).toHaveBeenCalledWith("Missing param error")
+		// Verify condenseContext was NOT called
+		expect(mockTask.condenseContext).not.toHaveBeenCalled()
+	})
+
+	it("should handle errors during condensing", async () => {
+		const block: ToolUse = {
+			type: "tool_use",
+			name: "condense",
+			params: {
+				message: "Test summary message",
+			},
+			partial: false,
+		}
+
+		const testError = new Error("Condensing failed")
+		;(mockTask.ask as ReturnType<typeof vi.fn>).mockRejectedValue(testError)
+
+		await condenseTool(
+			mockTask as Task,
+			block,
+			mockAskApproval,
+			mockHandleError,
+			mockPushToolResult,
+			mockRemoveClosingTag,
+		)
+
+		// Verify error handler was called
+		expect(mockHandleError).toHaveBeenCalledWith("condensing context window", testError)
+	})
+})

--- a/src/core/tools/kilocode/condenseTool.ts
+++ b/src/core/tools/kilocode/condenseTool.ts
@@ -1,7 +1,6 @@
 import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../../shared/tools"
 import { Task } from "../../task/Task"
 import { formatResponse } from "../../prompts/responses"
-import { summarizeConversation } from "../../condense"
 
 export const condenseTool = async (
 	cline: Task,
@@ -39,19 +38,9 @@ export const condenseTool = async (
 				// If no response, the user accepted the condensed version
 				pushToolResult(formatResponse.toolResult(formatResponse.condense()))
 
-				const { contextTokens: prevContextTokens } = cline.getTokenUsage()
-
-				// Use summarizeConversation to create a condensed version of the conversation
-				const summarizedMessages = await summarizeConversation(
-					cline.apiConversationHistory,
-					cline.api,
-					await cline.getSystemPrompt(),
-					"TaskId condenseTool",
-					prevContextTokens,
-				)
-
-				// Overwrite the apiConversationHistory with the summarized messages
-				await cline.overwriteApiConversationHistory(summarizedMessages.messages)
+				// Use the same condenseContext method that the UI button uses
+				// This ensures /smol uses the autocondensing feature with custom prompts and API handlers
+				await cline.condenseContext()
 			}
 			return
 		}


### PR DESCRIPTION
- Modified condenseTool to call cline.condenseContext() instead of directly calling summarizeConversation()
- This ensures /smol uses the same condensing logic as the UI button, including custom condensing prompts and API handlers
- Added tests for condenseTool covering various scenarios

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
