### PR TITLE
Fix API request errors with MCP functions incompatible with OpenAI strict mode

### DIFF
--- a/.changeset/stale-lines-care.md
+++ b/.changeset/stale-lines-care.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix API request errors with MCP functions incompatible with OpenAI strict mode

--- a/src/api/providers/__tests__/openai-strict-schema.spec.ts
+++ b/src/api/providers/__tests__/openai-strict-schema.spec.ts
@@ -1,0 +1,62 @@
+import { BaseProvider } from "../base-provider"
+import { normalizeObjectAdditionalPropertiesFalse } from "../kilocode/openai-strict-schema"
+
+class TestProvider extends BaseProvider {
+	// Minimal implementations for abstract base class
+	createMessage(): any {
+		throw new Error("not used")
+	}
+
+	getModel(): any {
+		return { id: "test", info: {} }
+	}
+
+	public convertTools(tools: any[]): any[] | undefined {
+		return this.convertToolsForOpenAI(tools)
+	}
+
+	public convertSchema(schema: any): any {
+		return this.convertToolSchemaForOpenAI(schema)
+	}
+}
+
+describe("OpenAI strict schema helpers", () => {
+	test("normalizeObjectAdditionalPropertiesFalse adds additionalProperties:false for nested objects with properties", () => {
+		const schema = {
+			type: "object",
+			additionalProperties: false,
+			properties: {
+				inputs: {
+					type: "object",
+					properties: {
+						ref: { type: "string" },
+					},
+					// additionalProperties intentionally missing
+				},
+			},
+		}
+
+		const normalized = normalizeObjectAdditionalPropertiesFalse(schema)
+		expect(normalized.properties.inputs.additionalProperties).toBe(false)
+	})
+})
+
+describe("BaseProvider.convertToolsForOpenAI", () => {
+	test("adds additionalProperties:false during schema conversion", () => {
+		const provider = new TestProvider()
+		const schema = {
+			type: "object",
+			properties: {
+				inputs: {
+					type: "object",
+					properties: {
+						ref: { type: "string" },
+					},
+				},
+			},
+		}
+
+		const converted = provider.convertSchema(schema)
+		expect(converted.properties.inputs.additionalProperties).toBe(false)
+	})
+})

--- a/src/api/providers/base-provider.ts
+++ b/src/api/providers/base-provider.ts
@@ -6,6 +6,8 @@ import type { ApiHandler, ApiHandlerCreateMessageMetadata } from "../index"
 import { ApiStream } from "../transform/stream"
 import { countTokens } from "../../utils/countTokens"
 
+import { normalizeObjectAdditionalPropertiesFalse } from "./kilocode/openai-strict-schema" // kilocode_change
+
 /**
  * Base class for API providers that implements common functionality.
  */
@@ -86,7 +88,7 @@ export abstract class BaseProvider implements ApiHandler {
 			result.properties = newProps
 		}
 
-		return result
+		return normalizeObjectAdditionalPropertiesFalse(result) // kilocode_change: normalize invalid schemes for strict mode
 	}
 
 	/**

--- a/src/api/providers/kilocode/openai-strict-schema.ts
+++ b/src/api/providers/kilocode/openai-strict-schema.ts
@@ -1,0 +1,73 @@
+// kilocode_change - new file
+type JsonSchema = any
+
+const isObjectLike = (value: unknown): value is Record<string, any> =>
+	!!value && typeof value === "object" && !Array.isArray(value)
+
+const isSchemaObjectNode = (schema: JsonSchema): boolean => {
+	if (!isObjectLike(schema)) return false
+	return schema.type === "object" || isObjectLike(schema.properties)
+}
+
+/**
+ * Recursively ensures `additionalProperties` is present (default false) for object schemas that declare `properties`.
+ *
+ * OpenAI strict tool schemas require `additionalProperties` to be explicitly provided and `false`
+ * for objects using `properties`.
+ */
+export const normalizeObjectAdditionalPropertiesFalse = (schema: JsonSchema): JsonSchema => {
+	if (!schema || typeof schema !== "object") return schema
+
+	if (Array.isArray(schema)) {
+		return schema.map((item) => normalizeObjectAdditionalPropertiesFalse(item))
+	}
+
+	const result: Record<string, any> = { ...(schema as any) }
+
+	// Normalize this node
+	if (isSchemaObjectNode(result) && isObjectLike(result.properties)) {
+		// Only add when missing/undefined; do not override dictionary semantics.
+		if (result.additionalProperties === undefined) {
+			result.additionalProperties = false
+		}
+	}
+
+	// Recurse into common schema composition keywords
+	for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+		if (Array.isArray(result[key])) {
+			result[key] = result[key].map((s: any) => normalizeObjectAdditionalPropertiesFalse(s))
+		}
+	}
+
+	// Recurse into items
+	if (result.items) {
+		result.items = normalizeObjectAdditionalPropertiesFalse(result.items)
+	}
+
+	// Recurse into properties
+	if (isObjectLike(result.properties)) {
+		const nextProps: Record<string, any> = { ...result.properties }
+		for (const [propKey, propSchema] of Object.entries(nextProps)) {
+			nextProps[propKey] = normalizeObjectAdditionalPropertiesFalse(propSchema)
+		}
+		result.properties = nextProps
+	}
+
+	// Recurse into additionalProperties *schema* if present (doesn't change semantics)
+	if (isObjectLike(result.additionalProperties)) {
+		result.additionalProperties = normalizeObjectAdditionalPropertiesFalse(result.additionalProperties)
+	}
+
+	// Recurse into definitions containers when present
+	for (const defsKey of ["$defs", "definitions"] as const) {
+		if (isObjectLike(result[defsKey])) {
+			const nextDefs: Record<string, any> = { ...result[defsKey] }
+			for (const [defKey, defSchema] of Object.entries(nextDefs)) {
+				nextDefs[defKey] = normalizeObjectAdditionalPropertiesFalse(defSchema)
+			}
+			result[defsKey] = nextDefs
+		}
+	}
+
+	return result
+}

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -22,6 +22,7 @@ import { getModelParams } from "../transform/model-params"
 
 import { BaseProvider } from "./base-provider"
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import { normalizeObjectAdditionalPropertiesFalse } from "./kilocode/openai-strict-schema" // kilocode_change
 
 export type OpenAiNativeModel = ReturnType<OpenAiNativeHandler["getModel"]>
 
@@ -292,7 +293,11 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 						type: "function",
 						name: tool.function.name,
 						description: tool.function.description,
-						parameters: ensureAllRequired(tool.function.parameters),
+						// kilocode_change start: normalize invalid schemes for strict mode
+						parameters: normalizeObjectAdditionalPropertiesFalse(
+							ensureAllRequired(tool.function.parameters),
+						),
+						// kilocode_chang end
 						strict: true,
 					})),
 			}),


### PR DESCRIPTION
Some MCP servers, like the Github one have tools that are not defining the `additionalProperties` param. This is required with native tools in strict mode. This PR adds the param when it's missing.