### PR TITLE
Update model selection docs to stay more current

### DIFF
--- a/apps/kilocode-docs/docs/basic-usage/model-selection-guide.md
+++ b/apps/kilocode-docs/docs/basic-usage/model-selection-guide.md
@@ -35,7 +35,7 @@ One thing that doesn't change: context window size matters for your workflow.
 - **Large codebases**: 256K+ tokens helps with cross-system understanding
 - **Massive systems**: 1M+ token models exist but effectiveness degrades at the extremes
 
-Check [our provider docs](/docs/providers/) for specific context limits on each model.
+Check [our provider docs](/docs/providers/openrouter) for specific context limits on each model.
 
 ## Stay Current
 

--- a/apps/kilocode-docs/docs/basic-usage/model-selection-guide.md
+++ b/apps/kilocode-docs/docs/basic-usage/model-selection-guide.md
@@ -2,83 +2,41 @@
 sidebar_label: "Model Selection Guide"
 ---
 
-# Kilo Code Model Selection Guide
+# Model Selection Guide
 
-Last updated: September 3, 2025.
+Here's the honest truth about AI model recommendations: by the time I write them down, they're probably already outdated. New models drop every few weeks, existing ones get updated, prices shift, and yesterday's champion becomes today's budget option.
 
-The AI model landscape evolves rapidly, so this guide focuses on what's delivering excellent results with Kilo Code right now. We update this regularly as new models emerge and performance shifts.
+Instead of maintaining a static list that's perpetually behind, we built something better — a real-time leaderboard showing which models Kilo Code users are actually having success with right now.
 
-## Kilo Code Top Performers
+## Check the Live Models List
 
-| Model                | Context Window | SWE-Bench Verified | Human Eval | LiveCodeBench | Input Price\* | Output Price\* | Best For                                    |
-| -------------------- | -------------- | ------------------ | ---------- | ------------- | ------------- | -------------- | ------------------------------------------- |
-| **GPT-5**            | 400K tokens    | 74.9%              | 96.3%      | 68.2%         | $1.25         | $10            | Latest capabilities, multi-modal coding     |
-| **Claude Sonnet 4**  | 1M tokens      | 72.7%              | 94.8%      | 65.9%         | $3-6          | $15-22.50      | Enterprise code generation, complex systems |
-| **Grok Code Fast 1** | 256K tokens    | 70.8%              | 92.1%      | 63.4%         | $0.20         | $1.50          | Rapid development, cost-performance balance |
-| **Qwen3 Coder**      | 256K tokens    | 68.4%              | 91.7%      | 61.8%         | $0.20         | $0.80          | Pure coding tasks, rapid prototyping        |
-| **Gemini 2.5 Pro**   | 1M+ tokens     | 67.2%              | 89.9%      | 59.3%         | TBD           | TBD            | Massive codebases, architectural planning   |
+**[👉 See what's working today at kilo.ai/models](https://kilo.ai/models)**
 
-\*Per million tokens
+This isn't benchmarks from some lab. It's real usage data from developers like you, updated continuously. You'll see which models people are choosing for different tasks, what's delivering results, and how the landscape is shifting in real-time.
 
-## Budget-Conscious Options
+## General Guidance
 
-| Model            | Context Window | SWE-Bench Verified | Human Eval | LiveCodeBench | Input Price\* | Output Price\* | Notes                                |
-| ---------------- | -------------- | ------------------ | ---------- | ------------- | ------------- | -------------- | ------------------------------------ |
-| **DeepSeek V3**  | 128K tokens    | 64.1%              | 87.3%      | 56.7%         | $0.14         | $0.28          | Exceptional value for daily coding   |
-| **DeepSeek R1**  | 128K tokens    | 62.8%              | 85.9%      | 54.2%         | $0.55         | $2.19          | Advanced reasoning at budget prices  |
-| **Qwen3 32B**    | 128K tokens    | 60.3%              | 83.4%      | 52.1%         | Varies        | Varies         | Open source flexibility              |
-| **Z AI GLM 4.5** | 128K tokens    | 58.7%              | 81.2%      | 49.8%         | TBD           | TBD            | MIT license, hybrid reasoning system |
+While the specifics change constantly, some principles stay consistent:
 
-\*Per million tokens
+**For complex coding tasks**: Premium models (Claude Sonnet/Opus, GPT-5 class, Gemini Pro) typically handle nuanced requirements, large refactors, and architectural decisions better.
 
-## Comprehensive Evaluation Framework
+**For everyday coding**: Mid-tier models often provide the best balance of speed, cost, and quality. They're fast enough to keep your flow state intact and capable enough for most tasks.
 
-### Latency Performance
+**For budget-conscious work**: Newer efficient models keep surprising us with price-to-performance ratios. DeepSeek, Qwen, and similar models can handle more than you'd expect.
 
-Response times significantly impact development flow and productivity:
+**For local/private work**: Ollama and LM Studio let you run models locally. The tradeoff is usually speed and capability for privacy and zero API costs.
 
-- **Ultra-Fast (< 2s)**: Grok Code Fast 1, Qwen3 Coder
-- **Fast (2-4s)**: DeepSeek V3, GPT-5
-- **Moderate (4-8s)**: Claude Sonnet 4, DeepSeek R1
-- **Slower (8-15s)**: Gemini 2.5 Pro, Z AI GLM 4.5
+## Context Windows Matter
 
-**Impact on Development**: Ultra-fast models enable real-time coding assistance and immediate feedback loops. Models with 8+ second latency can disrupt flow state but may be acceptable for complex architectural decisions.
+One thing that doesn't change: context window size matters for your workflow.
 
-### Throughput Analysis
+- **Small projects** (scripts, components): 32-64K tokens works fine
+- **Standard applications**: 128K tokens handles most multi-file context
+- **Large codebases**: 256K+ tokens helps with cross-system understanding
+- **Massive systems**: 1M+ token models exist but effectiveness degrades at the extremes
 
-Token generation rates affect large codebase processing:
+Check [our provider docs](/docs/providers/) for specific context limits on each model.
 
-- **High Throughput (150+ tokens/s)**: GPT-5, Grok Code Fast 1
-- **Medium Throughput (100-150 tokens/s)**: Claude Sonnet 4, Qwen3 Coder
-- **Standard Throughput (50-100 tokens/s)**: DeepSeek models, Gemini 2.5 Pro
-- **Variable Throughput**: Open source models depend on infrastructure
+## Stay Current
 
-**Scaling Factors**: High throughput models excel when generating extensive documentation, refactoring large files, or batch processing multiple components.
-
-### Reliability & Availability
-
-Enterprise considerations for production environments:
-
-- **Enterprise Grade (99.9%+ uptime)**: Claude Sonnet 4, GPT-5, Gemini 2.5 Pro
-- **Production Ready (99%+ uptime)**: Qwen3 Coder, Grok Code Fast 1
-- **Developing Reliability**: DeepSeek models, Z AI GLM 4.5
-- **Self-Hosted**: Qwen3 32B (reliability depends on your infrastructure)
-
-**Success Rates**: Enterprise models maintain consistent output quality and handle edge cases more gracefully, while budget options may require additional validation steps.
-
-### Context Window Strategy
-
-Optimizing for different project scales:
-
-| Size             | Word Count      | Typical Use Case                      | Recommended Models                     | Strategy                                        |
-| ---------------- | --------------- | ------------------------------------- | -------------------------------------- | ----------------------------------------------- |
-| **32K tokens**   | ~24,000 words   | Individual components, scripts        | DeepSeek V3, Qwen3 Coder               | Focus on single-file optimization               |
-| **128K tokens**  | ~96,000 words   | Standard applications, most projects  | All budget models, Grok Code Fast 1    | Multi-file context, moderate complexity         |
-| **256K tokens**  | ~192,000 words  | Large applications, multiple services | Qwen3 Coder, Grok Code Fast 1          | Full feature context, service integration       |
-| **400K+ tokens** | ~300,000+ words | Enterprise systems, full stack apps   | GPT-5, Claude Sonnet 4, Gemini 2.5 Pro | Architectural overview, system-wide refactoring |
-
-**Performance Degradation**: Model effectiveness typically drops significantly beyond 400-500K tokens, regardless of advertised limits. Plan context usage accordingly.
-
-## Community Choice
-
-The AI model landscape changes quicky to stay up to date [**👉 check Kilo Code Community Favorites on OpenRouter**](https://openrouter.ai/apps?url=https%3A%2F%2Fkilocode.ai%2F)
+The AI model space moves fast. Bookmark [kilo.ai/models](https://kilo.ai/models) and check back when you're evaluating options. What's best today might not be best next month — and that's actually exciting.


### PR DESCRIPTION
## Context

Model recommendations in docs go stale fast. Replaced the static benchmark tables with a pointer to the live models list at kilo.ai/models.

## Implementation

- Rewrote [model-selection-guide.md](apps/kilocode-docs/docs/basic-usage/model-selection-guide.md) to lead with the live list
- Kept general guidance (tier categories, context window basics) that won't need constant updates
- Removed fictional benchmarks and model tables

## Screenshots

| before | after |
| ------ | ----- |
| Static model tables with benchmark data | Link to kilo.ai/models with general guidance |

## How to Test

- `cd apps/kilocode-docs && pnpm start`
- Navigate to Basic Usage → Model Selection Guide
- Verify the kilo.ai/models link works and content reads clearly

## Get in Touch

@olearycrew 