### PR TITLE
feat(cli): add word-by-word cursor navigation

### DIFF
--- a/cli/src/state/atoms/keyboard.ts
+++ b/cli/src/state/atoms/keyboard.ts
@@ -30,6 +30,8 @@ import {
 	moveToLineStartAtom,
 	moveToLineEndAtom,
 	moveToAtom,
+	moveToPreviousWordAtom,
+	moveToNextWordAtom,
 	insertCharAtom,
 	insertTextAtom,
 	insertNewlineAtom,
@@ -768,6 +770,21 @@ function handleTextInputKeys(get: Getter, set: Setter, key: Key) {
 		case "u":
 			if (key.ctrl) {
 				set(killLineLeftAtom)
+				return
+			}
+			break
+
+		// Word navigation (Meta/Alt key)
+		case "b":
+			if (key.meta) {
+				set(moveToPreviousWordAtom)
+				return
+			}
+			break
+
+		case "f":
+			if (key.meta) {
+				set(moveToNextWordAtom)
 				return
 			}
 			break


### PR DESCRIPTION
## Context

Implement word-by-word cursor navigation in the CLI text input to enhance the editing experience.

## Implementation

- Adds support for Emacs-style keybindings:
  - `Meta-b` to move to the beginning of the previous word.
  - `Meta-f` to move to the beginning of the next word.
- Includes logic and tests to handle various edge cases, including word boundaries and navigating across multiple lines.

## How to Test

- Run kilocode in CLI mode
- Type a number of words and lines in the prompt
- Use Meta+b and Meta+f keyboard shortcuts to see that you can easily move one word forward and one ward backward. 

## Get in Touch

I don't use Discord much yet, but feel free to contact me using my email address christian.couder@gmail.com.