### PR TITLE
Fix windows spawning cmd.exe windows

### DIFF
--- a/.changeset/busy-tables-enjoy.md
+++ b/.changeset/busy-tables-enjoy.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixes issue on Windows where kilo code would spawn many cmd.exe windows.

--- a/src/shared/utils/exec.ts
+++ b/src/shared/utils/exec.ts
@@ -42,6 +42,7 @@ export async function execWithStdin({ cmd, cwd, uid, env }: ExecOptions): Promis
 		cwd,
 		uid,
 		shell: true,
+		windowsHide: true,
 		stdio: ["pipe", 1, 2],
 		env,
 	})
@@ -56,6 +57,7 @@ export async function exec({ cmd, cwd, context, uid, env }: ExecOptions): Promis
 		cwd,
 		uid,
 		shell: true,
+		windowsHide: true,
 		stdio: ["inherit", "inherit", "inherit"],
 		env,
 	})
@@ -77,6 +79,7 @@ export async function* execGetLines({
 		cwd,
 		uid,
 		shell: true,
+		windowsHide: true,
 		stdio: ["ignore", "pipe", "inherit"],
 		env,
 	})
@@ -111,6 +114,7 @@ export async function* execGetLinesStdoutStderr({
 		cwd,
 		uid,
 		shell: true,
+		windowsHide: true,
 		stdio: ["ignore", "pipe", "pipe"],
 		env,
 	})


### PR DESCRIPTION
Fixes issue on Windows where kilo code would spawn many cmd.exe windows.