### PR TITLE
speech-to-text: skip availability check when experiment disabled

### DIFF
--- a/.changeset/tricky-jokes-deny.md
+++ b/.changeset/tricky-jokes-deny.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remove check for ffmpeg if the STT experiment is disabled

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -95,6 +95,7 @@ import { Task } from "../task/Task"
 import { getSystemPromptFilePath } from "../prompts/sections/custom-system-prompt"
 
 import { webviewMessageHandler } from "./webviewMessageHandler"
+import { checkSpeechToTextAvailable } from "./speechToTextCheck" // kilocode_change
 import type { ClineMessage, TodoItem } from "@roo-code/types"
 import { readApiMessages, saveApiMessages, saveTaskMessages } from "../task-persistence"
 import { readTaskMessages } from "../task-persistence/taskMessages"
@@ -2211,11 +2212,9 @@ ${prompt}
 				: undefined
 		// kilocode_change end
 
-		// kilocode_change start - checkSpeechToTextAvailable (backend prerequisites only, experiment flag checked in frontend)
-		console.log("🎙️ [ClineProvider] Checking speech-to-text availability for webview state update...")
-		const { checkSpeechToTextAvailable } = await import("./speechToTextCheck")
-		const speechToTextAvailable = await checkSpeechToTextAvailable(this.providerSettingsManager)
-		console.log(`🎙️ [ClineProvider] Speech-to-text available: ${speechToTextAvailable}`)
+		// kilocode_change start - checkSpeechToTextAvailable (only when experiment enabled)
+		let speechToTextAvailable =
+			experiments?.speechToText && (await checkSpeechToTextAvailable(this.providerSettingsManager))
 		// kilocode_change end - checkSpeechToTextAvailable
 
 		let cloudOrganizations: CloudOrganizationMembership[] = []

--- a/src/core/webview/speechToTextCheck.ts
+++ b/src/core/webview/speechToTextCheck.ts
@@ -35,41 +35,24 @@ export async function checkSpeechToTextAvailable(
 		}
 	}
 
-	console.log("🎙️ [STT Availability Check] Starting speech-to-text prerequisite check...")
-
 	try {
 		// Check 1: OpenAI API key
 		const apiKey = await getOpenAiApiKey(providerSettingsManager)
-		const hasApiKey = !!apiKey
-		console.log(`🎙️ [STT Availability Check] OpenAI API key configured: ${hasApiKey}`)
-
-		if (!hasApiKey) {
-			console.log("🎙️ [STT Availability Check] ❌ FAILED: No OpenAI API key found")
-			console.log("🎙️ [STT Availability Check] → Add an OpenAI API provider in Settings")
+		if (!apiKey) {
 			cachedResult = { available: false, timestamp: Date.now() }
 			return false
 		}
 
 		// Check 2: FFmpeg installed
-		console.log("🎙️ [STT Availability Check] Checking FFmpeg installation...")
 		const ffmpegResult = FFmpegCaptureService.findFFmpeg()
-		console.log(`🎙️ [STT Availability Check] FFmpeg available: ${ffmpegResult.available}`)
-
 		if (!ffmpegResult.available) {
-			console.log("🎙️ [STT Availability Check] ❌ FAILED: FFmpeg is not installed or not in PATH")
-			console.log("🎙️ [STT Availability Check] → Install FFmpeg: https://ffmpeg.org/download.html")
-			if (ffmpegResult.error) {
-				console.log(`🎙️ [STT Availability Check] → Error: ${ffmpegResult.error}`)
-			}
 			cachedResult = { available: false, timestamp: Date.now() }
 			return false
 		}
 
-		console.log("🎙️ [STT Availability Check] ✅ SUCCESS: Speech-to-text prerequisites are met!")
 		cachedResult = { available: true, timestamp: Date.now() }
 		return true
 	} catch (error) {
-		console.error("🎙️ [STT Availability Check] ❌ FAILED: Unexpected error during check", error)
 		cachedResult = { available: false, timestamp: Date.now() }
 		return false
 	}

--- a/src/services/stt/FFmpegCaptureService.ts
+++ b/src/services/stt/FFmpegCaptureService.ts
@@ -236,7 +236,6 @@ export class FFmpegCaptureService extends EventEmitter {
 		const platform = os.platform()
 		try {
 			execSync("ffmpeg -version", { stdio: "ignore" })
-			console.log(`🎙️ [FFmpeg] ✅ Found 'ffmpeg' in PATH`)
 			cachedFFmpegPath = "ffmpeg"
 			return { available: true, path: "ffmpeg" }
 		} catch {
@@ -247,7 +246,6 @@ export class FFmpegCaptureService extends EventEmitter {
 		for (const fallbackPath of platformPaths) {
 			try {
 				execSync(`"${fallbackPath}" -version`, { stdio: "ignore" })
-				console.log(`🎙️ [FFmpeg] ✅ Found at: ${fallbackPath}`)
 				cachedFFmpegPath = fallbackPath
 				return { available: true, path: fallbackPath }
 			} catch {


### PR DESCRIPTION
Only run speech-to-text availability check when experiments.speechToText flag is enabled. Move checkSpeechToTextAvailable import to module level for better performance.

Remove excessive debug logging from availability check and FFmpeg detection to reduce noise in production logs.

