### PR TITLE
chore(cli): simplify --yolo option description

### DIFF
--- a/.changeset/yolo-option-description.md
+++ b/.changeset/yolo-option-description.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Simplify --yolo option description

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -33,7 +33,7 @@ program
 	.option("-m, --mode <mode>", `Set the mode of operation (${validModes.join(", ")})`)
 	.option("-w, --workspace <path>", "Path to the workspace directory", process.cwd())
 	.option("-a, --auto", "Run in autonomous mode (non-interactive)", false)
-	.option("--yolo", "Auto-approve all tool permissions while keeping interactive input", false)
+	.option("--yolo", "Auto-approve all tool permissions", false)
 	.option("-j, --json", "Output messages as JSON (requires --auto)", false)
 	.option("-i, --json-io", "Bidirectional JSON mode (no TUI, stdin/stdout enabled)", false)
 	.option("-c, --continue", "Resume the last conversation from this workspace", false)


### PR DESCRIPTION
Simplify the --yolo option description from 'Auto-approve all tool permissions while keeping interactive input' to 'Auto-approve all tool permissions'.