### PR TITLE
fix(cli-sessions): skip restore for empty sessions

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1950,12 +1950,14 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			} else {
 				throw new Error("Unexpected: Last message is not a user or assistant message")
 			}
+			// kilocode_change start: Handle empty API conversation history for CLI session restoration
 		} else {
 			// Empty API conversation history - this can happen when restoring an empty session
-			// (e.g., a session created but never used). Treat it like a fresh start.
+			// (e.g., a session created but not yet used). Treat it like a fresh start.
 			modifiedApiConversationHistory = []
 			modifiedOldUserContent = []
 		}
+		// kilocode_change end
 
 		let newUserContent: Anthropic.Messages.ContentBlockParam[] = [...modifiedOldUserContent]
 

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1951,7 +1951,10 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				throw new Error("Unexpected: Last message is not a user or assistant message")
 			}
 		} else {
-			throw new Error("Unexpected: No existing API conversation history")
+			// Empty API conversation history - this can happen when restoring an empty session
+			// (e.g., a session created but never used). Treat it like a fresh start.
+			modifiedApiConversationHistory = []
+			modifiedOldUserContent = []
 		}
 
 		let newUserContent: Anthropic.Messages.ContentBlockParam[] = [...modifiedOldUserContent]

--- a/src/core/task/__tests__/task-tool-history.spec.ts
+++ b/src/core/task/__tests__/task-tool-history.spec.ts
@@ -318,4 +318,59 @@ describe("Task Tool History Handling", () => {
 			})
 		})
 	})
+
+	describe("empty API conversation history handling", () => {
+		it("should handle empty API conversation history gracefully", () => {
+			// Simulate empty API conversation history (e.g., from an empty session)
+			const apiHistory: any[] = []
+
+			// The logic in Task.resumeTaskFromHistory should handle this case
+			// by initializing empty arrays instead of throwing
+			let modifiedApiConversationHistory: any[]
+			let modifiedOldUserContent: any[]
+
+			if (apiHistory.length === 0) {
+				// Empty API conversation history - treat it like a fresh start
+				modifiedApiConversationHistory = []
+				modifiedOldUserContent = []
+			} else {
+				// Normal case - would process the history
+				modifiedApiConversationHistory = [...apiHistory]
+				modifiedOldUserContent = []
+			}
+
+			// Verify we get empty arrays, not an error
+			expect(modifiedApiConversationHistory).toEqual([])
+			expect(modifiedOldUserContent).toEqual([])
+		})
+
+		it("should not throw when API conversation history is empty", () => {
+			const apiHistory: any[] = []
+
+			// This should NOT throw - it should handle empty history gracefully
+			expect(() => {
+				if (apiHistory.length === 0) {
+					// Empty history is valid - just return empty arrays
+					return { history: [], userContent: [] }
+				}
+				// Normal processing would happen here
+				return { history: apiHistory, userContent: [] }
+			}).not.toThrow()
+		})
+
+		it("should handle single-message API conversation history", () => {
+			// A session with just one user message (no assistant response yet)
+			const apiHistory: any[] = [
+				{
+					role: "user",
+					content: "Hello",
+					ts: Date.now(),
+				},
+			]
+
+			// This is a valid case - the session was started but no response was received
+			expect(apiHistory.length).toBe(1)
+			expect(apiHistory[0].role).toBe("user")
+		})
+	})
 })

--- a/src/shared/kilocode/cli-sessions/core/SessionLifecycleService.ts
+++ b/src/shared/kilocode/cli-sessions/core/SessionLifecycleService.ts
@@ -143,6 +143,22 @@ export class SessionLifecycleService {
 
 			this.logger.debug("Obtained session", LOG_SOURCES.SESSION_LIFECYCLE, { sessionId, session })
 
+			// Check if session has any content to restore
+			const hasContent =
+				session.api_conversation_history_blob_url ||
+				session.ui_messages_blob_url ||
+				session.task_metadata_blob_url ||
+				session.git_state_blob_url
+
+			if (!hasContent) {
+				this.logger.info(
+					"Session has no content to restore - skipping restore. This can happen with sessions created but never used (e.g., from cloud-agent).",
+					LOG_SOURCES.SESSION_LIFECYCLE,
+					{ sessionId },
+				)
+				throw new Error("Session has no content to restore")
+			}
+
 			const sessionDirectoryPath = path.join(this.pathProvider.getTasksDir(), sessionId)
 
 			mkdirSync(sessionDirectoryPath, { recursive: true })

--- a/src/shared/kilocode/cli-sessions/core/SessionLifecycleService.ts
+++ b/src/shared/kilocode/cli-sessions/core/SessionLifecycleService.ts
@@ -143,22 +143,6 @@ export class SessionLifecycleService {
 
 			this.logger.debug("Obtained session", LOG_SOURCES.SESSION_LIFECYCLE, { sessionId, session })
 
-			// Check if session has any content to restore
-			const hasContent =
-				session.api_conversation_history_blob_url ||
-				session.ui_messages_blob_url ||
-				session.task_metadata_blob_url ||
-				session.git_state_blob_url
-
-			if (!hasContent) {
-				this.logger.info(
-					"Session has no content to restore - skipping restore. This can happen with sessions created but never used (e.g., from cloud-agent).",
-					LOG_SOURCES.SESSION_LIFECYCLE,
-					{ sessionId },
-				)
-				throw new Error("Session has no content to restore")
-			}
-
 			const sessionDirectoryPath = path.join(this.pathProvider.getTasksDir(), sessionId)
 
 			mkdirSync(sessionDirectoryPath, { recursive: true })
@@ -228,6 +212,28 @@ export class SessionLifecycleService {
 						})
 					}
 				}
+			}
+
+			// Ensure required JSON files exist even if no blob URLs were provided.
+			// This prevents the UI from hanging when restoring an empty session.
+			if (!session.ui_messages_blob_url) {
+				const uiMessagesPath = path.join(sessionDirectoryPath, "ui_messages.json")
+				writeFileSync(uiMessagesPath, JSON.stringify([], null, 2))
+				this.logger.debug(
+					"Created empty ui_messages.json for session without messages",
+					LOG_SOURCES.SESSION_LIFECYCLE,
+					{ sessionId },
+				)
+			}
+
+			if (!session.api_conversation_history_blob_url) {
+				const apiHistoryPath = path.join(sessionDirectoryPath, "api_conversation_history.json")
+				writeFileSync(apiHistoryPath, JSON.stringify([], null, 2))
+				this.logger.debug(
+					"Created empty api_conversation_history.json for session without history",
+					LOG_SOURCES.SESSION_LIFECYCLE,
+					{ sessionId },
+				)
 			}
 
 			const historyItem: HistoryItem = {

--- a/src/shared/kilocode/cli-sessions/core/__tests__/SessionLifecycleService.spec.ts
+++ b/src/shared/kilocode/cli-sessions/core/__tests__/SessionLifecycleService.spec.ts
@@ -417,7 +417,7 @@ describe("SessionLifecycleService", () => {
 		})
 
 		describe("empty session handling", () => {
-			it("throws error when session has no content (no blob URLs)", async () => {
+			it("creates empty JSON files when session has no blob URLs", async () => {
 				const emptySession = {
 					session_id: "session-123",
 					title: "Empty Session",
@@ -430,20 +430,34 @@ describe("SessionLifecycleService", () => {
 				}
 				mockSessionClient.get.mockResolvedValue(emptySession)
 
-				// Should throw when rethrowError is true
-				await expect(service.restoreSession("session-123", true)).rejects.toThrow(
-					"Session has no content to restore",
+				await service.restoreSession("session-123")
+
+				// Should create empty ui_messages.json
+				expect(writeFileSync).toHaveBeenCalledWith(
+					"/mock/tasks/session-123/ui_messages.json",
+					JSON.stringify([], null, 2),
 				)
 
-				// Should log info message about empty session
-				expect(mockLogger.info).toHaveBeenCalledWith(
-					"Session has no content to restore - skipping restore. This can happen with sessions created but never used (e.g., from cloud-agent).",
+				// Should create empty api_conversation_history.json
+				expect(writeFileSync).toHaveBeenCalledWith(
+					"/mock/tasks/session-123/api_conversation_history.json",
+					JSON.stringify([], null, 2),
+				)
+
+				// Should log debug messages about creating empty files
+				expect(mockLogger.debug).toHaveBeenCalledWith(
+					"Created empty ui_messages.json for session without messages",
+					expect.any(String),
+					{ sessionId: "session-123" },
+				)
+				expect(mockLogger.debug).toHaveBeenCalledWith(
+					"Created empty api_conversation_history.json for session without history",
 					expect.any(String),
 					{ sessionId: "session-123" },
 				)
 			})
 
-			it("does not throw when rethrowError is false for empty session", async () => {
+			it("restores empty session successfully and calls onSessionRestored", async () => {
 				const emptySession = {
 					session_id: "session-123",
 					title: "Empty Session",
@@ -456,24 +470,18 @@ describe("SessionLifecycleService", () => {
 				}
 				mockSessionClient.get.mockResolvedValue(emptySession)
 
-				// Should not throw when rethrowError is false (default)
-				await expect(service.restoreSession("session-123", false)).resolves.not.toThrow()
+				await service.restoreSession("session-123")
 
-				// Should still log the error
-				expect(mockLogger.error).toHaveBeenCalledWith(
-					"Failed to restore session",
-					expect.any(String),
-					expect.objectContaining({
-						error: "Session has no content to restore",
-						sessionId: "session-123",
-					}),
-				)
+				// Should proceed with restore
+				expect(mockOnSessionRestored).toHaveBeenCalled()
+				expect(mockStateManager.setActiveSessionId).toHaveBeenCalledWith("session-123")
+				expect(mockPersistenceManager.setLastSession).toHaveBeenCalledWith("session-123")
 			})
 
-			it("restores session successfully when it has at least one blob URL", async () => {
-				const sessionWithContent = {
+			it("creates empty ui_messages.json only when ui_messages_blob_url is missing", async () => {
+				const sessionWithApiHistory = {
 					session_id: "session-123",
-					title: "Session With Content",
+					title: "Session With API History",
 					version: 1,
 					created_at: "2023-01-01T00:00:00Z",
 					api_conversation_history_blob_url: "https://api.example.com",
@@ -481,13 +489,56 @@ describe("SessionLifecycleService", () => {
 					task_metadata_blob_url: undefined,
 					git_state_blob_url: undefined,
 				}
-				mockSessionClient.get.mockResolvedValue(sessionWithContent)
+				mockSessionClient.get.mockResolvedValue(sessionWithApiHistory)
 
 				await service.restoreSession("session-123")
 
-				// Should proceed with restore
-				expect(mockOnSessionRestored).toHaveBeenCalled()
-				expect(mockStateManager.setActiveSessionId).toHaveBeenCalledWith("session-123")
+				// Should create empty ui_messages.json
+				expect(writeFileSync).toHaveBeenCalledWith(
+					"/mock/tasks/session-123/ui_messages.json",
+					JSON.stringify([], null, 2),
+				)
+
+				// Should NOT create empty api_conversation_history.json (it has a blob URL)
+				const apiHistoryCalls = vi
+					.mocked(writeFileSync)
+					.mock.calls.filter(
+						(call) =>
+							(call[0] as string).includes("api_conversation_history.json") &&
+							call[1] === JSON.stringify([], null, 2),
+					)
+				expect(apiHistoryCalls).toHaveLength(0)
+			})
+
+			it("creates empty api_conversation_history.json only when api_conversation_history_blob_url is missing", async () => {
+				const sessionWithUiMessages = {
+					session_id: "session-123",
+					title: "Session With UI Messages",
+					version: 1,
+					created_at: "2023-01-01T00:00:00Z",
+					api_conversation_history_blob_url: undefined,
+					ui_messages_blob_url: "https://ui.example.com",
+					task_metadata_blob_url: undefined,
+					git_state_blob_url: undefined,
+				}
+				mockSessionClient.get.mockResolvedValue(sessionWithUiMessages)
+
+				await service.restoreSession("session-123")
+
+				// Should create empty api_conversation_history.json
+				expect(writeFileSync).toHaveBeenCalledWith(
+					"/mock/tasks/session-123/api_conversation_history.json",
+					JSON.stringify([], null, 2),
+				)
+
+				// Should NOT create empty ui_messages.json (it has a blob URL)
+				const uiMessagesCalls = vi
+					.mocked(writeFileSync)
+					.mock.calls.filter(
+						(call) =>
+							(call[0] as string).includes("ui_messages.json") && call[1] === JSON.stringify([], null, 2),
+					)
+				expect(uiMessagesCalls).toHaveLength(0)
 			})
 		})
 	})


### PR DESCRIPTION
## Context

Pre-created sessions without blob urls triggered a hang when resuming the session.

## Implementation

- Write empty JSON files in SessionLifecycleService when blob URLs are missing
- Handle empty API conversation history gracefully in Task.resumeTaskFromHistory

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
