### PR TITLE
Improve the duplication-prevention filter in autocomplete

### DIFF
--- a/.changeset/neat-ghosts-argue.md
+++ b/.changeset/neat-ghosts-argue.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent autocomplete from showing suggestions duplicating the previous or next line

--- a/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
@@ -195,4 +195,48 @@ describe("suggestionConsideredDuplication", () => {
 		expect(isDuplication("const greeting = 你好<<<你好>>>")).toBe(true)
 		expect(isDuplication("launch<<<🚀>>>🌟")).toBe(false)
 	})
+
+	it("treats as duplication when completed line equals the last complete line in prefix", () => {
+		// The suggestion completes the current line to match the previous line
+		expect(
+			isDuplication(`
+doStuff()
+
+console.info('logging some stuff')
+console.info<<<('logging some stuff')>>>
+
+if (foo) {`),
+		).toBe(true)
+
+		expect(
+			isDuplication(`
+doStuff()
+
+console.info<<<('logging some stuff')>>>
+console.info('logging some stuff')
+
+if (foo) {`),
+		).toBe(true)
+
+		// Different variations - exact match with same spacing
+		expect(
+			isDuplication(`const x = 1
+const x <<<= 1>>>
+`),
+		).toBe(true)
+
+		// Should NOT be duplication when the completed line is different
+		expect(
+			isDuplication(`
+doStuff()
+
+console.info('logging some stuff')
+console.info<<<('logging different stuff')>>>
+
+if (foo) {`),
+		).toBe(false)
+
+		// Should NOT be duplication when there's no previous complete line
+		expect(isDuplication(`console.info<<<('logging some stuff')>>>`)).toBe(false)
+	})
 })

--- a/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
@@ -105,19 +105,19 @@ describe("suggestionConsideredDuplication", () => {
 		}
 
 		const prefix = input.slice(0, startIdx)
-		const processed = input.slice(startIdx + startMarker.length, endIdx)
+		const suggestion = input.slice(startIdx + startMarker.length, endIdx)
 		const suffix = input.slice(endIdx + endMarker.length)
 
-		return suggestionConsideredDuplication({ processed, prefix, suffix })
+		return suggestionConsideredDuplication({ suggestion, prefix, suffix })
 	}
 
-	it("treats empty/whitespace-only processed suggestions as duplication", () => {
+	it("treats empty/whitespace-only suggestions as duplication", () => {
 		expect(isDuplication("const x = <<<>>> + 1")).toBe(true)
 		expect(isDuplication("const x = <<<   >>> + 1")).toBe(true)
 		expect(isDuplication("const x = <<<\t\n>>> + 1")).toBe(true)
 	})
 
-	it("treats processed suggestion as duplication when it matches the end of the prefix (trim-aware)", () => {
+	it("treats suggestion as duplication when it matches the end of the prefix (trim-aware)", () => {
 		// Exact match at the end
 		expect(isDuplication("const x = hello<<<hello>>>")).toBe(true)
 		expect(isDuplication("hello world<<<world>>> + 1")).toBe(true)
@@ -127,7 +127,7 @@ describe("suggestionConsideredDuplication", () => {
 		expect(isDuplication("bar foo  <<<foo>>>")).toBe(true)
 	})
 
-	it("treats processed suggestion as duplication when it matches the start of the suffix (trim-aware)", () => {
+	it("treats suggestion as duplication when it matches the start of the suffix (trim-aware)", () => {
 		// Exact match at the start
 		expect(isDuplication("const x = <<<hello>>>hello world")).toBe(true)
 		expect(isDuplication("<<<const>>>const y = 2")).toBe(true)
@@ -140,7 +140,7 @@ describe("suggestionConsideredDuplication", () => {
 		expect(isDuplication("const x = <<<bar>>>  bar  baz")).toBe(true)
 	})
 
-	it("trims processed before comparing to prefix/suffix", () => {
+	it("trims suggestion before comparing to prefix/suffix", () => {
 		expect(isDuplication("const x = <<<  hello  >>>hello world")).toBe(true)
 		expect(isDuplication("test hello<<<\nhello\t>>>")).toBe(true)
 	})

--- a/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
@@ -1,27 +1,15 @@
 import { postprocessGhostSuggestion, suggestionConsideredDuplication } from "../uselessSuggestionFilter"
 
 describe("postprocessGhostSuggestion", () => {
-	it("calls suggestionConsideredDuplication", () => {
-		let calls = 0
-		;(globalThis as any).__kiloTestHooks = {
-			onSuggestionConsideredDuplication: () => {
-				calls++
-			},
-		}
+	it("filters suggestions that are considered duplication (prefix/suffix match)", () => {
+		const result = postprocessGhostSuggestion({
+			suggestion: "hello",
+			prefix: "hello",
+			suffix: "",
+			model: "",
+		})
 
-		try {
-			const result = postprocessGhostSuggestion({
-				suggestion: "hello",
-				prefix: "",
-				suffix: "",
-				model: "",
-			})
-
-			expect(result).toBe("hello")
-			expect(calls).toBe(1)
-		} finally {
-			;(globalThis as any).__kiloTestHooks = undefined
-		}
+		expect(result).toBeUndefined()
 	})
 
 	it("filters suggestions that rewrite the line above (continuedev postprocessCompletion behavior)", () => {

--- a/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/uselessSuggestionFilter.test.ts
@@ -227,4 +227,27 @@ if (foo) {`),
 		// Should NOT be duplication when there's no previous complete line
 		expect(isDuplication(`console.info<<<('logging some stuff')>>>`)).toBe(false)
 	})
+
+	it("treats as duplication when a multiline suggestion duplicates the last line in prefix on its first line", () => {
+		expect(
+			isDuplication(`doStuff()
+console.info('logging some stuff')
+<<<console.info('logging some stuff')
+if (foo) {
+	 bar()
+}>>>`),
+		).toBe(true)
+	})
+
+	it("treats as duplication when a multiline suggestion duplicates the first line in suffix on its last line", () => {
+		expect(
+			isDuplication(`doStuff()
+<<<if (foo) {
+	 bar()
+}
+console.info('logging some stuff')>>>console.info('logging some stuff')
+return 1
+`),
+		).toBe(true)
+	})
 })

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -35,32 +35,22 @@ function checkDuplication(params: AutocompleteSuggestion): boolean {
  */
 function normalizeToCompleteLine(params: AutocompleteSuggestion): AutocompleteSuggestion | null {
 	const prefixNewlineIndex = params.prefix.lastIndexOf("\n")
+	const prefix = prefixNewlineIndex === -1 ? "" : params.prefix.slice(0, prefixNewlineIndex + 1)
+	const prefixLineTail = prefixNewlineIndex === -1 ? params.prefix : params.prefix.slice(prefixNewlineIndex + 1)
+
 	const suffixNewlineIndex = params.suffix.indexOf("\n")
-
-	let prefixLineTail: string, prefix: string, suffixLineHead: string, suffix: string
-	if (prefixNewlineIndex === -1) {
-		prefixLineTail = params.prefix
-		prefix = ""
-	} else {
-		prefixLineTail = params.prefix.slice(prefixNewlineIndex + 1)
-		prefix = params.prefix.slice(0, prefixNewlineIndex + 1)
-	}
-
-	if (suffixNewlineIndex === -1) {
-		suffixLineHead = params.suffix
-		suffix = ""
-	} else {
-		suffixLineHead = params.suffix.slice(0, suffixNewlineIndex)
-		suffix = params.suffix.slice(suffixNewlineIndex)
-	}
+	const suffixLineHead = suffixNewlineIndex === -1 ? params.suffix : params.suffix.slice(0, suffixNewlineIndex)
+	const suffix = suffixNewlineIndex === -1 ? "" : params.suffix.slice(suffixNewlineIndex)
 
 	if (prefixLineTail.length === 0 && suffixLineHead.length === 0) {
 		return null
 	}
 
-	const suggestion = prefixLineTail + params.suggestion + suffixLineHead
-
-	return { prefix, suggestion, suffix }
+	return {
+		prefix,
+		suggestion: prefixLineTail + params.suggestion + suffixLineHead,
+		suffix,
+	}
 }
 
 /**

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -13,7 +13,7 @@ export function suggestionConsideredDuplication(params: AutocompleteSuggestion):
 
 	// When the suggestion isn't a full line or set of lines, normalize by including
 	// the rest of the line in the prefix/suffix and check with the completed line(s)
-	const normalized = normalizeToCompleteLine(params.prefix, params.suggestion, params.suffix)
+	const normalized = normalizeToCompleteLine(params)
 	if (normalized) {
 		return checkDuplication(normalized)
 	}
@@ -47,25 +47,25 @@ function checkDuplication(params: AutocompleteSuggestion): boolean {
  *
  * Returns null when the suggestion already starts/ends on line boundaries.
  */
-function normalizeToCompleteLine(prefix: string, suggestion: string, suffix: string): AutocompleteSuggestion | null {
-	const prefixNewlineIndex = prefix.lastIndexOf("\n")
-	const suffixNewlineIndex = suffix.indexOf("\n")
+function normalizeToCompleteLine(params: AutocompleteSuggestion): AutocompleteSuggestion | null {
+	const prefixNewlineIndex = params.prefix.lastIndexOf("\n")
+	const suffixNewlineIndex = params.suffix.indexOf("\n")
 
 	let prefixLineTail: string, normalizedPrefix: string, suffixLineHead: string, normalizedSuffix: string
 	if (prefixNewlineIndex === -1) {
-		prefixLineTail = prefix
+		prefixLineTail = params.prefix
 		normalizedPrefix = ""
 	} else {
-		prefixLineTail = prefix.slice(prefixNewlineIndex + 1)
-		normalizedPrefix = prefix.slice(0, prefixNewlineIndex + 1)
+		prefixLineTail = params.prefix.slice(prefixNewlineIndex + 1)
+		normalizedPrefix = params.prefix.slice(0, prefixNewlineIndex + 1)
 	}
 
 	if (suffixNewlineIndex === -1) {
-		suffixLineHead = suffix
+		suffixLineHead = params.suffix
 		normalizedSuffix = ""
 	} else {
-		suffixLineHead = suffix.slice(0, suffixNewlineIndex)
-		normalizedSuffix = suffix.slice(suffixNewlineIndex)
+		suffixLineHead = params.suffix.slice(0, suffixNewlineIndex)
+		normalizedSuffix = params.suffix.slice(suffixNewlineIndex)
 	}
 
 	if (prefixLineTail.length === 0 && suffixLineHead.length === 0) {
@@ -74,7 +74,7 @@ function normalizeToCompleteLine(prefix: string, suggestion: string, suffix: str
 
 	return {
 		prefix: normalizedPrefix,
-		suggestion: prefixLineTail + suggestion + suffixLineHead,
+		suggestion: prefixLineTail + params.suggestion + suffixLineHead,
 		suffix: normalizedSuffix,
 	}
 }

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -7,17 +7,17 @@ export type AutocompleteSuggestion = {
 }
 
 export function suggestionConsideredDuplication(params: AutocompleteSuggestion): boolean {
-	if (checkDuplication(params)) {
+	if (DuplicatesFromPrefixOrSuffix(params)) {
 		return true
 	}
 
 	// When the suggestion isn't a full line or set of lines, normalize by including
 	// the rest of the line in the prefix/suffix and check with the completed line(s)
 	const normalized = normalizeToCompleteLine(params)
-	return !!normalized && checkDuplication(normalized)
+	return !!normalized && DuplicatesFromPrefixOrSuffix(normalized)
 }
 
-function checkDuplication(params: AutocompleteSuggestion): boolean {
+function DuplicatesFromPrefixOrSuffix(params: AutocompleteSuggestion): boolean {
 	const trimmed = params.suggestion.trim()
 
 	return (

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -14,11 +14,7 @@ export function suggestionConsideredDuplication(params: AutocompleteSuggestion):
 	// When the suggestion isn't a full line or set of lines, normalize by including
 	// the rest of the line in the prefix/suffix and check with the completed line(s)
 	const normalized = normalizeToCompleteLine(params)
-	if (normalized) {
-		return checkDuplication(normalized)
-	}
-
-	return false
+	return !!normalized && checkDuplication(normalized)
 }
 
 function checkDuplication(params: AutocompleteSuggestion): boolean {

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -7,8 +7,6 @@ export type SuggestionConsideredDuplicationParams = {
 }
 
 export function suggestionConsideredDuplication(params: SuggestionConsideredDuplicationParams): boolean {
-	;(globalThis as any).__kiloTestHooks?.onSuggestionConsideredDuplication?.(params)
-
 	const { processed, prefix, suffix } = params
 
 	// First check with original params

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -27,7 +27,66 @@ export function suggestionConsideredDuplication(params: SuggestionConsideredDupl
 		return true
 	}
 
+	// When the suggestion isn't a full line or set of lines, normalize by including
+	// the rest of the line in the prefix/suffix and check recursively with the completed line(s)
+	const normalized = normalizeToCompleteLine(prefix, processed, suffix)
+	if (normalized) {
+		return suggestionConsideredDuplication({
+			processed: normalized.completedLine,
+			prefix: normalized.normalizedPrefix,
+			suffix: normalized.normalizedSuffix,
+		})
+	}
+
 	return false
+}
+
+/**
+ * When the suggestion doesn't start and end at line boundaries, normalize by including
+ * the rest of the line in the prefix and/or suffix.
+ *
+ * Returns the normalized prefix/suffix and the completed first line, or null if already normalized.
+ *
+ * For example:
+ * - prefix: "console.info('foo')\nconsole.info", suggestion: "('foo')"
+ *   -> normalizedPrefix: "console.info('foo')\n", completedLine: "console.info('foo')"
+ * - prefix: "console.info", suggestion: "('foo')", suffix: "\nconsole.info('foo')"
+ *   -> normalizedSuffix: "\nconsole.info('foo')", completedLine: "console.info('foo')"
+ */
+function normalizeToCompleteLine(
+	prefix: string,
+	suggestion: string,
+	suffix: string,
+): { normalizedPrefix: string; completedLine: string; normalizedSuffix: string } | null {
+	// Get the partial line before the suggestion (from the last newline in prefix)
+	const lastPrefixNewline = prefix.lastIndexOf("\n")
+	const lineStartInPrefix = lastPrefixNewline === -1 ? prefix : prefix.slice(lastPrefixNewline + 1)
+
+	// Get the partial line after the suggestion (up to the first newline in suffix)
+	const firstSuffixNewline = suffix.indexOf("\n")
+	const lineEndInSuffix = firstSuffixNewline === -1 ? suffix : suffix.slice(0, firstSuffixNewline)
+
+	// If the suggestion already starts and ends at line boundaries, no normalization needed
+	if (lineStartInPrefix.length === 0 && lineEndInSuffix.length === 0) {
+		return null
+	}
+
+	// Build the complete line by combining: lineStartInPrefix + suggestion's first line + lineEndInSuffix
+	const suggestionLines = suggestion.split("\n")
+	const suggestionFirstLine = suggestionLines[0]
+	const completedFirstLine = lineStartInPrefix + suggestionFirstLine + lineEndInSuffix
+
+	// Get the prefix content before the current line (complete lines only, including trailing newline)
+	const normalizedPrefix = lastPrefixNewline === -1 ? "" : prefix.slice(0, lastPrefixNewline + 1)
+
+	// Get the suffix content after the current line (complete lines only, including leading newline)
+	const normalizedSuffix = firstSuffixNewline === -1 ? "" : suffix.slice(firstSuffixNewline)
+
+	return {
+		normalizedPrefix,
+		completedLine: completedFirstLine,
+		normalizedSuffix,
+	}
 }
 
 /**

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -51,32 +51,30 @@ function normalizeToCompleteLine(params: AutocompleteSuggestion): AutocompleteSu
 	const prefixNewlineIndex = params.prefix.lastIndexOf("\n")
 	const suffixNewlineIndex = params.suffix.indexOf("\n")
 
-	let prefixLineTail: string, normalizedPrefix: string, suffixLineHead: string, normalizedSuffix: string
+	let prefixLineTail: string, prefix: string, suffixLineHead: string, suffix: string
 	if (prefixNewlineIndex === -1) {
 		prefixLineTail = params.prefix
-		normalizedPrefix = ""
+		prefix = ""
 	} else {
 		prefixLineTail = params.prefix.slice(prefixNewlineIndex + 1)
-		normalizedPrefix = params.prefix.slice(0, prefixNewlineIndex + 1)
+		prefix = params.prefix.slice(0, prefixNewlineIndex + 1)
 	}
 
 	if (suffixNewlineIndex === -1) {
 		suffixLineHead = params.suffix
-		normalizedSuffix = ""
+		suffix = ""
 	} else {
 		suffixLineHead = params.suffix.slice(0, suffixNewlineIndex)
-		normalizedSuffix = params.suffix.slice(suffixNewlineIndex)
+		suffix = params.suffix.slice(suffixNewlineIndex)
 	}
 
 	if (prefixLineTail.length === 0 && suffixLineHead.length === 0) {
 		return null
 	}
 
-	return {
-		prefix: normalizedPrefix,
-		suggestion: prefixLineTail + params.suggestion + suffixLineHead,
-		suffix: normalizedSuffix,
-	}
+	const suggestion = prefixLineTail + params.suggestion + suffixLineHead
+
+	return { prefix, suggestion, suffix }
 }
 
 /**

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -24,21 +24,11 @@ export function suggestionConsideredDuplication(params: AutocompleteSuggestion):
 function checkDuplication(params: AutocompleteSuggestion): boolean {
 	const trimmed = params.suggestion.trim()
 
-	if (trimmed.length === 0) {
-		return true
-	}
-
-	const trimmedPrefixEnd = params.prefix.trimEnd()
-	if (trimmedPrefixEnd.endsWith(trimmed)) {
-		return true
-	}
-
-	const trimmedSuffix = params.suffix.trimStart()
-	if (trimmedSuffix.startsWith(trimmed)) {
-		return true
-	}
-
-	return false
+	return (
+		trimmed.length === 0 ||
+		params.prefix.trimEnd().endsWith(trimmed) ||
+		params.suffix.trimStart().startsWith(trimmed)
+	)
 }
 
 /**

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -11,6 +11,26 @@ export function suggestionConsideredDuplication(params: SuggestionConsideredDupl
 
 	const { processed, prefix, suffix } = params
 
+	// First check with original params
+	if (checkDuplication(processed, prefix, suffix)) {
+		return true
+	}
+
+	// When the suggestion isn't a full line or set of lines, normalize by including
+	// the rest of the line in the prefix/suffix and check with the completed line(s)
+	const normalized = normalizeToCompleteLine(prefix, processed, suffix)
+	if (normalized) {
+		return checkDuplication(normalized.completedLine, normalized.normalizedPrefix, normalized.normalizedSuffix)
+	}
+
+	return false
+}
+
+/**
+ * Core duplication check logic - checks if the processed suggestion is a duplication
+ * based on prefix/suffix matching.
+ */
+function checkDuplication(processed: string, prefix: string, suffix: string): boolean {
 	const trimmed = processed.trim()
 
 	if (trimmed.length === 0) {
@@ -25,17 +45,6 @@ export function suggestionConsideredDuplication(params: SuggestionConsideredDupl
 	const trimmedSuffix = suffix.trimStart()
 	if (trimmedSuffix.startsWith(trimmed)) {
 		return true
-	}
-
-	// When the suggestion isn't a full line or set of lines, normalize by including
-	// the rest of the line in the prefix/suffix and check recursively with the completed line(s)
-	const normalized = normalizeToCompleteLine(prefix, processed, suffix)
-	if (normalized) {
-		return suggestionConsideredDuplication({
-			processed: normalized.completedLine,
-			prefix: normalized.normalizedPrefix,
-			suffix: normalized.normalizedSuffix,
-		})
 	}
 
 	return false

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -1,5 +1,35 @@
 import { postprocessCompletion } from "../../continuedev/core/autocomplete/postprocessing/index.js"
 
+export type SuggestionConsideredDuplicationParams = {
+	processed: string
+	prefix: string
+	suffix: string
+}
+
+export function suggestionConsideredDuplication(params: SuggestionConsideredDuplicationParams): boolean {
+	;(globalThis as any).__kiloTestHooks?.onSuggestionConsideredDuplication?.(params)
+
+	const { processed, prefix, suffix } = params
+
+	const trimmed = processed.trim()
+
+	if (trimmed.length === 0) {
+		return true
+	}
+
+	const trimmedPrefixEnd = prefix.trimEnd()
+	if (trimmedPrefixEnd.endsWith(trimmed)) {
+		return true
+	}
+
+	const trimmedSuffix = suffix.trimStart()
+	if (trimmedSuffix.startsWith(trimmed)) {
+		return true
+	}
+
+	return false
+}
+
 /**
  * Postprocesses a Ghost autocomplete suggestion using the continuedev postprocessing pipeline
  * and applies some of our own duplicate checks.
@@ -31,19 +61,7 @@ export function postprocessGhostSuggestion(params: {
 		return undefined
 	}
 
-	const trimmed = processed.trim()
-
-	if (trimmed.length === 0) {
-		return undefined
-	}
-
-	const trimmedPrefixEnd = prefix.trimEnd()
-	if (trimmedPrefixEnd.endsWith(trimmed)) {
-		return undefined
-	}
-
-	const trimmedSuffix = suffix.trimStart()
-	if (trimmedSuffix.startsWith(trimmed)) {
+	if (suggestionConsideredDuplication({ processed, prefix, suffix })) {
 		return undefined
 	}
 

--- a/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
+++ b/src/services/ghost/classic-auto-complete/uselessSuggestionFilter.ts
@@ -61,24 +61,34 @@ function normalizeToCompleteLine(
 	suggestion: string,
 	suffix: string,
 ): { normalizedPrefix: string; completedLine: string; normalizedSuffix: string } | null {
-	const prefixNewline = prefix.lastIndexOf("\n")
-	const suffixNewline = suffix.indexOf("\n")
+	const prefixNewlineIndex = prefix.lastIndexOf("\n")
+	const suffixNewlineIndex = suffix.indexOf("\n")
 
-	const prefixLineTail = prefixNewline === -1 ? prefix : prefix.slice(prefixNewline + 1)
-	const suffixLineHead = suffixNewline === -1 ? suffix : suffix.slice(0, suffixNewline)
+	let prefixLineTail: string, normalizedPrefix: string, suffixLineHead: string, normalizedSuffix: string
+	if (prefixNewlineIndex === -1) {
+		prefixLineTail = prefix
+		normalizedPrefix = ""
+	} else {
+		prefixLineTail = prefix.slice(prefixNewlineIndex + 1)
+		normalizedPrefix = prefix.slice(0, prefixNewlineIndex + 1)
+	}
 
-	// Already aligned to line boundaries.
+	if (suffixNewlineIndex === -1) {
+		suffixLineHead = suffix
+		normalizedSuffix = ""
+	} else {
+		suffixLineHead = suffix.slice(0, suffixNewlineIndex)
+		normalizedSuffix = suffix.slice(suffixNewlineIndex)
+	}
+
 	if (prefixLineTail.length === 0 && suffixLineHead.length === 0) {
 		return null
 	}
 
-	const suggestionNewline = suggestion.indexOf("\n")
-	const suggestionFirstLine = suggestionNewline === -1 ? suggestion : suggestion.slice(0, suggestionNewline)
-
 	return {
-		normalizedPrefix: prefixNewline === -1 ? "" : prefix.slice(0, prefixNewline + 1),
-		completedLine: prefixLineTail + suggestionFirstLine + suffixLineHead,
-		normalizedSuffix: suffixNewline === -1 ? "" : suffix.slice(suffixNewline),
+		normalizedPrefix,
+		completedLine: prefixLineTail + suggestion + suffixLineHead,
+		normalizedSuffix,
 	}
 }
 


### PR DESCRIPTION
Prevent cases like this (<<< ...  >>> is the suggestion)

```typescript
		expect(
			isDuplication(`
doStuff()

console.info('logging some stuff')
console.info<<<('logging some stuff')>>>

if (foo) {`),
		).toBe(true)

		expect(
			isDuplication(`
doStuff()

console.info<<<('logging some stuff')>>>
console.info('logging some stuff')

if (foo) {`),
		).toBe(true)

```