### PR TITLE
fix(cli): include exitCode in JSON-IO command output

### DIFF
--- a/cli/src/state/atoms/effects.ts
+++ b/cli/src/state/atoms/effects.ts
@@ -560,12 +560,17 @@ export const messageHandlerEffectAtom = atom(null, (get, set, message: Extension
 
 						if (messageIndex !== -1) {
 							const pendingUpdate = newPendingUpdates.get(statusData.executionId)
+							const exitCode =
+								statusData.status === "exited" && "exitCode" in statusData
+									? statusData.exitCode
+									: undefined
 							const updatedAsk: ExtensionChatMessage = {
 								...currentMessages[messageIndex]!,
 								text: JSON.stringify({
 									executionId: statusData.executionId,
 									command: pendingUpdate?.command || "",
 									output: pendingUpdate?.output || "",
+									...(exitCode !== undefined && { exitCode }),
 								}),
 								partial: false, // Command completed
 								isAnswered: false, // Still needs user response


### PR DESCRIPTION
## Summary
When the CLI runs in `--json-io` mode, command execution results now include the exit code so consumers can determine if commands succeeded or failed.

## Changes
- Add `exitCode` to the JSON output when command exits (status 'exited')
- `exitCode` is only included when available (not for timeout status)
- Add test cases for exitCode in command output

## Context
This enables the Agent Manager (and other JSON-IO consumers) to show proper success/error indicators for command execution based on exit code.

## Testing
- All existing tests pass
- Added 3 new test cases:
  - `should include exitCode in JSON output when command exits with non-zero code`
  - `should include exitCode 0 in JSON output when command exits successfully`
  - `should NOT include exitCode in JSON output when command times out`