### PR TITLE
fix(docs): correct edit page URL for Docusaurus site in monorepo

### DIFF
--- a/apps/kilocode-docs/docusaurus.config.ts
+++ b/apps/kilocode-docs/docusaurus.config.ts
@@ -52,7 +52,7 @@ const config: Config = {
 				docs: {
 					sidebarPath: "./sidebars.ts",
 					routeBasePath: "/",
-					editUrl: `${GITHUB_REPO_URL}/edit/main/`,
+					editUrl: `${GITHUB_MAIN_REPO_URL}/edit/main/apps/kilocode-docs/`,
 					showLastUpdateTime: true,
 				},
 				blog: false, // Disable blog feature


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

Fixed the filepath for the "edit this page" button