### PR TITLE
fix(cli): pass auto-approval settings from CLI config to extension

### DIFF
--- a/cli/src/config/__tests__/mapper.test.ts
+++ b/cli/src/config/__tests__/mapper.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect } from "vitest"
+import { mapConfigToExtensionState } from "../mapper.js"
+import type { CLIConfig } from "../types.js"
+
+describe("mapConfigToExtensionState", () => {
+	const baseConfig: CLIConfig = {
+		version: "1.0.0",
+		mode: "code",
+		telemetry: true,
+		provider: "test-provider",
+		providers: [
+			{
+				id: "test-provider",
+				provider: "anthropic",
+				apiKey: "test-key",
+				apiModelId: "claude-3-5-sonnet-20241022",
+			},
+		],
+	}
+
+	describe("auto-approval settings mapping", () => {
+		it("should set all auto-approval settings to false when autoApproval.enabled is false", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: false,
+					read: { enabled: true, outside: true },
+					write: { enabled: true, outside: true, protected: true },
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.autoApprovalEnabled).toBe(false)
+			expect(state.alwaysAllowReadOnly).toBe(false)
+			expect(state.alwaysAllowReadOnlyOutsideWorkspace).toBe(false)
+			expect(state.alwaysAllowWrite).toBe(false)
+			expect(state.alwaysAllowWriteOutsideWorkspace).toBe(false)
+			expect(state.alwaysAllowWriteProtected).toBe(false)
+		})
+
+		it("should set read settings correctly when autoApproval is enabled", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: true,
+					read: { enabled: true, outside: false },
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.autoApprovalEnabled).toBe(true)
+			expect(state.alwaysAllowReadOnly).toBe(true)
+			expect(state.alwaysAllowReadOnlyOutsideWorkspace).toBe(false)
+		})
+
+		it("should set alwaysAllowReadOnlyOutsideWorkspace to true only when all conditions are met", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: true,
+					read: { enabled: true, outside: true },
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.alwaysAllowReadOnlyOutsideWorkspace).toBe(true)
+		})
+
+		it("should set alwaysAllowReadOnlyOutsideWorkspace to false when read.enabled is false", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: true,
+					read: { enabled: false, outside: true },
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.alwaysAllowReadOnly).toBe(false)
+			expect(state.alwaysAllowReadOnlyOutsideWorkspace).toBe(false)
+		})
+
+		it("should set write settings correctly", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: true,
+					write: { enabled: true, outside: true, protected: false },
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.alwaysAllowWrite).toBe(true)
+			expect(state.alwaysAllowWriteOutsideWorkspace).toBe(true)
+			expect(state.alwaysAllowWriteProtected).toBe(false)
+		})
+
+		it("should set browser settings correctly", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: true,
+					browser: { enabled: true },
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.alwaysAllowBrowser).toBe(true)
+		})
+
+		it("should set execute settings correctly", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: true,
+					execute: {
+						enabled: true,
+						allowed: ["npm", "git"],
+						denied: ["rm -rf"],
+					},
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.alwaysAllowExecute).toBe(true)
+			expect(state.allowedCommands).toEqual(["npm", "git"])
+			expect(state.deniedCommands).toEqual(["rm -rf"])
+		})
+
+		it("should set MCP settings correctly", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: true,
+					mcp: { enabled: true },
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.alwaysAllowMcp).toBe(true)
+		})
+
+		it("should set mode switch settings correctly", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: true,
+					mode: { enabled: true },
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.alwaysAllowModeSwitch).toBe(true)
+		})
+
+		it("should set subtasks settings correctly", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: true,
+					subtasks: { enabled: true },
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.alwaysAllowSubtasks).toBe(true)
+		})
+
+		it("should set retry settings correctly", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: true,
+					retry: { enabled: true, delay: 15 },
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.alwaysApproveResubmit).toBe(true)
+			expect(state.requestDelaySeconds).toBe(15)
+		})
+
+		it("should set question settings correctly", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: true,
+					question: { enabled: true, timeout: 30 },
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.alwaysAllowFollowupQuestions).toBe(true)
+			expect(state.followupAutoApproveTimeoutMs).toBe(30000) // 30 seconds in ms
+		})
+
+		it("should set todo settings correctly", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				autoApproval: {
+					enabled: true,
+					todo: { enabled: true },
+				},
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.alwaysAllowUpdateTodoList).toBe(true)
+		})
+
+		it("should use default values when autoApproval is not provided", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.autoApprovalEnabled).toBe(false)
+			expect(state.alwaysAllowReadOnly).toBe(false)
+			expect(state.alwaysAllowReadOnlyOutsideWorkspace).toBe(false)
+			expect(state.alwaysAllowWrite).toBe(false)
+			expect(state.alwaysAllowWriteOutsideWorkspace).toBe(false)
+			expect(state.alwaysAllowWriteProtected).toBe(false)
+			expect(state.alwaysAllowBrowser).toBe(false)
+			expect(state.alwaysAllowMcp).toBe(false)
+			expect(state.alwaysAllowModeSwitch).toBe(false)
+			expect(state.alwaysAllowSubtasks).toBe(false)
+			expect(state.alwaysAllowExecute).toBe(false)
+			expect(state.allowedCommands).toEqual([])
+			expect(state.deniedCommands).toEqual([])
+			expect(state.alwaysAllowFollowupQuestions).toBe(false)
+			expect(state.alwaysAllowUpdateTodoList).toBe(false)
+		})
+	})
+
+	describe("provider mapping", () => {
+		it("should map provider configuration correctly", () => {
+			const state = mapConfigToExtensionState(baseConfig)
+
+			expect(state.apiConfiguration).toBeDefined()
+			expect(state.apiConfiguration?.apiProvider).toBe("anthropic")
+			expect(state.currentApiConfigName).toBe("test-provider")
+		})
+
+		it("should create listApiConfigMeta from providers", () => {
+			const state = mapConfigToExtensionState(baseConfig)
+
+			expect(state.listApiConfigMeta).toHaveLength(1)
+			expect(state.listApiConfigMeta?.[0]).toEqual({
+				id: "test-provider",
+				name: "test-provider",
+				apiProvider: "anthropic",
+				modelId: "claude-3-5-sonnet-20241022",
+			})
+		})
+	})
+
+	describe("telemetry mapping", () => {
+		it("should map telemetry enabled correctly", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				telemetry: true,
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.telemetrySetting).toBe("enabled")
+		})
+
+		it("should map telemetry disabled correctly", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				telemetry: false,
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.telemetrySetting).toBe("disabled")
+		})
+	})
+
+	describe("mode mapping", () => {
+		it("should map mode correctly", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				mode: "architect",
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.mode).toBe("architect")
+		})
+	})
+})

--- a/cli/src/config/mapper.ts
+++ b/cli/src/config/mapper.ts
@@ -29,6 +29,12 @@ export function mapConfigToExtensionState(
 			modelId: getModelIdForProvider(p),
 		}))
 
+		// Map auto-approval settings from CLI config to extension state
+		// These settings control whether the extension auto-approves operations
+		// or asks the CLI for approval (which then prompts the user)
+		const autoApproval = config.autoApproval
+		const autoApprovalEnabled = autoApproval?.enabled ?? false
+
 		return {
 			...currentState,
 			apiConfiguration,
@@ -36,6 +42,33 @@ export function mapConfigToExtensionState(
 			listApiConfigMeta,
 			telemetrySetting: config.telemetry ? "enabled" : "disabled",
 			mode: config.mode,
+			// Auto-approval settings - these control whether the extension auto-approves
+			// or defers to the CLI's approval flow
+			autoApprovalEnabled,
+			alwaysAllowReadOnly: autoApprovalEnabled && (autoApproval?.read?.enabled ?? false),
+			alwaysAllowReadOnlyOutsideWorkspace:
+				autoApprovalEnabled && (autoApproval?.read?.enabled ?? false) && (autoApproval?.read?.outside ?? false),
+			alwaysAllowWrite: autoApprovalEnabled && (autoApproval?.write?.enabled ?? false),
+			alwaysAllowWriteOutsideWorkspace:
+				autoApprovalEnabled &&
+				(autoApproval?.write?.enabled ?? false) &&
+				(autoApproval?.write?.outside ?? false),
+			alwaysAllowWriteProtected:
+				autoApprovalEnabled &&
+				(autoApproval?.write?.enabled ?? false) &&
+				(autoApproval?.write?.protected ?? false),
+			alwaysAllowBrowser: autoApprovalEnabled && (autoApproval?.browser?.enabled ?? false),
+			alwaysApproveResubmit: autoApprovalEnabled && (autoApproval?.retry?.enabled ?? false),
+			requestDelaySeconds: autoApproval?.retry?.delay ?? 10,
+			alwaysAllowMcp: autoApprovalEnabled && (autoApproval?.mcp?.enabled ?? false),
+			alwaysAllowModeSwitch: autoApprovalEnabled && (autoApproval?.mode?.enabled ?? false),
+			alwaysAllowSubtasks: autoApprovalEnabled && (autoApproval?.subtasks?.enabled ?? false),
+			alwaysAllowExecute: autoApprovalEnabled && (autoApproval?.execute?.enabled ?? false),
+			allowedCommands: autoApproval?.execute?.allowed ?? [],
+			deniedCommands: autoApproval?.execute?.denied ?? [],
+			alwaysAllowFollowupQuestions: autoApprovalEnabled && (autoApproval?.question?.enabled ?? false),
+			followupAutoApproveTimeoutMs: (autoApproval?.question?.timeout ?? 60) * 1000,
+			alwaysAllowUpdateTodoList: autoApprovalEnabled && (autoApproval?.todo?.enabled ?? false),
 		}
 	} catch (error) {
 		logs.error("Failed to map config to extension state", "ConfigMapper", { error })

--- a/cli/src/host/ExtensionHost.ts
+++ b/cli/src/host/ExtensionHost.ts
@@ -965,6 +965,78 @@ export class ExtensionHost extends EventEmitter {
 				updatedSettings: { experiments },
 			})
 		}
+
+		// Sync auto-approval settings to the extension
+		// These settings control whether the extension auto-approves operations
+		// or defers to the CLI's approval flow (which prompts the user)
+		const autoApprovalSettings: Record<string, unknown> = {}
+
+		// Only include settings that are explicitly set in configState
+		if (configState.autoApprovalEnabled !== undefined) {
+			autoApprovalSettings.autoApprovalEnabled = configState.autoApprovalEnabled
+		}
+		if (configState.alwaysAllowReadOnly !== undefined) {
+			autoApprovalSettings.alwaysAllowReadOnly = configState.alwaysAllowReadOnly
+		}
+		if (configState.alwaysAllowReadOnlyOutsideWorkspace !== undefined) {
+			autoApprovalSettings.alwaysAllowReadOnlyOutsideWorkspace = configState.alwaysAllowReadOnlyOutsideWorkspace
+		}
+		if (configState.alwaysAllowWrite !== undefined) {
+			autoApprovalSettings.alwaysAllowWrite = configState.alwaysAllowWrite
+		}
+		if (configState.alwaysAllowWriteOutsideWorkspace !== undefined) {
+			autoApprovalSettings.alwaysAllowWriteOutsideWorkspace = configState.alwaysAllowWriteOutsideWorkspace
+		}
+		if (configState.alwaysAllowWriteProtected !== undefined) {
+			autoApprovalSettings.alwaysAllowWriteProtected = configState.alwaysAllowWriteProtected
+		}
+		if (configState.alwaysAllowBrowser !== undefined) {
+			autoApprovalSettings.alwaysAllowBrowser = configState.alwaysAllowBrowser
+		}
+		if (configState.alwaysApproveResubmit !== undefined) {
+			autoApprovalSettings.alwaysApproveResubmit = configState.alwaysApproveResubmit
+		}
+		if (configState.requestDelaySeconds !== undefined) {
+			autoApprovalSettings.requestDelaySeconds = configState.requestDelaySeconds
+		}
+		if (configState.alwaysAllowMcp !== undefined) {
+			autoApprovalSettings.alwaysAllowMcp = configState.alwaysAllowMcp
+		}
+		if (configState.alwaysAllowModeSwitch !== undefined) {
+			autoApprovalSettings.alwaysAllowModeSwitch = configState.alwaysAllowModeSwitch
+		}
+		if (configState.alwaysAllowSubtasks !== undefined) {
+			autoApprovalSettings.alwaysAllowSubtasks = configState.alwaysAllowSubtasks
+		}
+		if (configState.alwaysAllowExecute !== undefined) {
+			autoApprovalSettings.alwaysAllowExecute = configState.alwaysAllowExecute
+		}
+		if (configState.allowedCommands !== undefined) {
+			autoApprovalSettings.allowedCommands = configState.allowedCommands
+		}
+		if (configState.deniedCommands !== undefined) {
+			autoApprovalSettings.deniedCommands = configState.deniedCommands
+		}
+		if (configState.alwaysAllowFollowupQuestions !== undefined) {
+			autoApprovalSettings.alwaysAllowFollowupQuestions = configState.alwaysAllowFollowupQuestions
+		}
+		if (configState.followupAutoApproveTimeoutMs !== undefined) {
+			autoApprovalSettings.followupAutoApproveTimeoutMs = configState.followupAutoApproveTimeoutMs
+		}
+		if (configState.alwaysAllowUpdateTodoList !== undefined) {
+			autoApprovalSettings.alwaysAllowUpdateTodoList = configState.alwaysAllowUpdateTodoList
+		}
+
+		// Send auto-approval settings if any are present
+		if (Object.keys(autoApprovalSettings).length > 0) {
+			await this.sendWebviewMessage({
+				type: "updateSettings",
+				updatedSettings: autoApprovalSettings,
+			})
+			logs.debug("Auto-approval settings synchronized to extension", "ExtensionHost", {
+				settings: Object.keys(autoApprovalSettings),
+			})
+		}
 	}
 
 	/**


### PR DESCRIPTION
During testing of https://github.com/Kilo-Org/kilocode/pull/4186 , it was discovered that the CLI was not passing auto-approval settings into the embedded extension, resulting in the extension defaults taking effect.  This PR strives to fix that, and add some tests. Note, there may be other settings that are also not passed.

Changes:
- cli/src/config/mapper.ts: Map all auto-approval settings from CLI config to extension state
- cli/src/host/ExtensionHost.ts: Send auto-approval settings via updateSettings message
- cli/src/config/__tests__/mapper.test.ts: Add 19 tests for auto-approval mapping
