### PR TITLE
Fix chat autocomplete to properly handle incomplete words and trailing whitespace

### DIFF
--- a/src/services/continuedev/core/autocomplete/postprocessing/__tests__/removePrefixOverlap.test.ts
+++ b/src/services/continuedev/core/autocomplete/postprocessing/__tests__/removePrefixOverlap.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest"
+import { removePrefixOverlap } from "../removePrefixOverlap.js"
+
+describe("removePrefixOverlap", () => {
+	it("should remove full prefix match", () => {
+		expect(removePrefixOverlap("hello world", "hello ")).toBe("world")
+	})
+
+	it("should remove trimmed prefix when prefix has extra whitespace", () => {
+		expect(removePrefixOverlap("hello world", "  hello  ")).toBe(" world")
+	})
+
+	it("should remove partial word overlap", () => {
+		expect(removePrefixOverlap("hello world", "hel")).toBe("lo world")
+	})
+
+	it("should return completion as-is when no overlap", () => {
+		expect(removePrefixOverlap("world", "hello")).toBe("world")
+	})
+
+	it("should use last line of multi-line prefix", () => {
+		expect(removePrefixOverlap("hello world", "line 1\nline 2\nhello ")).toBe("world")
+	})
+
+	it("should handle empty strings", () => {
+		expect(removePrefixOverlap("hello world", "")).toBe("hello world")
+		expect(removePrefixOverlap("", "hello")).toBe("")
+	})
+
+	it("should be case-sensitive", () => {
+		expect(removePrefixOverlap("hello world", "HELLO ")).toBe("hello world")
+	})
+})

--- a/src/services/continuedev/core/autocomplete/postprocessing/index.ts
+++ b/src/services/continuedev/core/autocomplete/postprocessing/index.ts
@@ -1,5 +1,6 @@
 import { longestCommonSubsequence } from "../../util/lcs.js"
 import { lineIsRepeated } from "../util/textSimilarity.js"
+import { removePrefixOverlap } from "./removePrefixOverlap.js"
 
 function rewritesLineAbove(completion: string, prefix: string): boolean {
 	const lineAbove = prefix
@@ -143,21 +144,7 @@ export function postprocessCompletion({
 	}
 
 	if (llm.model.includes("mercury") || llm.model.includes("granite")) {
-		// Granite tends to repeat the start of the line in the completion output
-		const prefixEnd = prefix.split("\n").pop()
-		if (prefixEnd) {
-			if (completion.startsWith(prefixEnd)) {
-				completion = completion.slice(prefixEnd.length)
-			} else {
-				const trimmedPrefix = prefixEnd.trim()
-				const lastWord = trimmedPrefix.split(/\s+/).pop()
-				if (lastWord && completion.startsWith(lastWord)) {
-					completion = completion.slice(lastWord.length)
-				} else if (completion.startsWith(trimmedPrefix)) {
-					completion = completion.slice(trimmedPrefix.length)
-				}
-			}
-		}
+		completion = removePrefixOverlap(completion, prefix)
 	}
 
 	// // If completion starts with multiple whitespaces, but the cursor is at the end of the line

--- a/src/services/continuedev/core/autocomplete/postprocessing/removePrefixOverlap.ts
+++ b/src/services/continuedev/core/autocomplete/postprocessing/removePrefixOverlap.ts
@@ -1,0 +1,17 @@
+export function removePrefixOverlap(completion: string, prefix: string): string {
+	const prefixEnd = prefix.split("\n").pop()
+	if (prefixEnd) {
+		if (completion.startsWith(prefixEnd)) {
+			completion = completion.slice(prefixEnd.length)
+		} else {
+			const trimmedPrefix = prefixEnd.trim()
+			const lastWord = trimmedPrefix.split(/\s+/).pop()
+			if (lastWord && completion.startsWith(lastWord)) {
+				completion = completion.slice(lastWord.length)
+			} else if (completion.startsWith(trimmedPrefix)) {
+				completion = completion.slice(trimmedPrefix.length)
+			}
+		}
+	}
+	return completion
+}


### PR DESCRIPTION
The main bug fix was we were calling .trim() on the autocomplete result, which would remove leading whitespace, preventing us from properly spacing out words in the completion. Now we do not trim the autocomplete result and just do simple prefix matching before appending it onto the user's chat text

![2025-12-17 17 56 51](https://github.com/user-attachments/assets/8381bb0e-ea25-451a-88b8-1fd01516e0b4)
