### PR TITLE
fix: prevent terminal command loop in local CLI installation for fish shell

### DIFF
--- a/src/core/kilocode/agent-manager/CliProcessHandler.ts
+++ b/src/core/kilocode/agent-manager/CliProcessHandler.ts
@@ -158,12 +158,16 @@ export class CliProcessHandler {
 
 		const env = this.buildEnvWithApiConfiguration(options?.apiConfiguration)
 
+		// On Windows, .cmd files need to be executed through cmd.exe (shell: true)
+		// Without this, spawn() fails silently because .cmd files are batch scripts
+		const needsShell = process.platform === "win32" && cliPath.toLowerCase().endsWith(".cmd")
+
 		// Spawn CLI process
 		const proc = spawn(cliPath, cliArgs, {
 			cwd: workspace,
 			stdio: ["pipe", "pipe", "pipe"],
 			env,
-			shell: false,
+			shell: needsShell,
 		})
 
 		if (proc.pid) {

--- a/src/core/kilocode/agent-manager/__tests__/AgentManagerProvider.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/AgentManagerProvider.spec.ts
@@ -89,6 +89,70 @@ describe("AgentManagerProvider CLI spawning", () => {
 		expect(options?.shell).not.toBe(true)
 	})
 
+	it("spawns with shell: true on Windows when CLI path ends with .cmd", async () => {
+		// Reset modules to set up Windows-specific mock
+		vi.resetModules()
+
+		const mockWorkspaceFolder = { uri: { fsPath: "/tmp/workspace" } }
+		const mockProvider = {
+			getState: vi.fn().mockResolvedValue({ apiConfiguration: { apiProvider: "kilocode" } }),
+		}
+
+		vi.doMock("vscode", () => ({
+			workspace: { workspaceFolders: [mockWorkspaceFolder] },
+			window: { showErrorMessage: vi.fn(), showWarningMessage: vi.fn(), ViewColumn: { One: 1 } },
+			env: { openExternal: vi.fn() },
+			Uri: { parse: vi.fn(), joinPath: vi.fn() },
+			ViewColumn: { One: 1 },
+			ExtensionMode: { Development: 1, Production: 2, Test: 3 },
+		}))
+
+		vi.doMock("../../../../utils/fs", () => ({
+			fileExistsAtPath: vi.fn().mockResolvedValue(false),
+		}))
+
+		vi.doMock("../../../../services/code-index/managed/git-utils", () => ({
+			getRemoteUrl: vi.fn().mockResolvedValue(undefined),
+		}))
+
+		class TestProc extends EventEmitter {
+			stdout = new EventEmitter()
+			stderr = new EventEmitter()
+			kill = vi.fn()
+			pid = 1234
+		}
+
+		const spawnMock = vi.fn(() => new TestProc())
+		// Return a .cmd path to simulate Windows local CLI installation
+		const execSyncMock = vi.fn(() => "C:\\Users\\test\\.kilocode\\cli\\pkg\\node_modules\\.bin\\kilocode.cmd")
+
+		vi.doMock("node:child_process", () => ({
+			spawn: spawnMock,
+			execSync: execSyncMock,
+		}))
+
+		// Mock process.platform to be win32
+		const originalPlatform = process.platform
+		Object.defineProperty(process, "platform", { value: "win32", writable: true })
+
+		try {
+			const module = await import("../AgentManagerProvider")
+			const windowsProvider = new module.AgentManagerProvider(mockContext, mockOutputChannel, mockProvider as any)
+
+			await (windowsProvider as any).startAgentSession("test windows cmd")
+
+			expect(spawnMock).toHaveBeenCalledTimes(1)
+			const [cmd, , options] = spawnMock.mock.calls[0] as unknown as [string, string[], Record<string, unknown>]
+			expect(cmd.toLowerCase()).toContain(".cmd")
+			expect(options?.shell).toBe(true)
+
+			windowsProvider.dispose()
+		} finally {
+			// Restore original platform
+			Object.defineProperty(process, "platform", { value: originalPlatform, writable: true })
+		}
+	})
+
 	it("creates pending session and waits for session_created event", async () => {
 		await (provider as any).startAgentSession("test pending")
 


### PR DESCRIPTION
### Problem

   When installing the Kilocode CLI locally via the "Install Local" option, users on fish shell experienced an
    infinite loop where the installation command would repeat endlessly. The terminal output showed the
   command being re-executed with a "🚀 Launch:" prefix:

       ...kilocode auth' to authenticate if not in PATH"
       🚀 Launch:  npm install @kilocode/cli --prefix /Users/user/.kilocode/cli/pkg ; echo "" ; echo "✓ CLI 
   installed locally" ; ...
       🚀 Launch:  npm install @kilocode/cli --prefix /Users/user/.kilocode/cli/pkg ; echo "" ; echo "✓ CLI 
   installed locally" ; ...

   ### Root Cause

   The runLocalInstallInTerminal() method had two issues:

       1. Multiple terminal.sendText() calls: The code called terminal.sendText() twice in succession, which
   could cause race conditions where the second command starts before the first completes.
       2. Command separator: Using ; as a command separator instead of && meant commands would execute
   regardless of whether previous commands succeeded.

   ### Solution

   Consolidated all commands into a single terminal.sendText() call with && chaining:

   Before:

`const commands = [getLocalCliInstallCommand(), pathCommand]
       terminal.sendText(commands.join(" ; "))
       terminal.sendText(`echo "" && echo "✓ CLI installed locally" && ...`)
`
       
   After:

 `      const fullCommand = [
           getLocalCliInstallCommand(),
           pathCommand,
           `echo ""`,
           `echo "✓ CLI installed locally"`,
           `echo "Added ${binDir} to PATH in ${configFile}"`,
           // ... more echo commands
       ].join(" && ")
`
       terminal.sendText(fullCommand)