### PR TITLE
fix(jetbrains): apply patch for @vscode/policy-watcher macOS compilation

### DIFF
--- a/deps/patches/policy-watcher/README.md
+++ b/deps/patches/policy-watcher/README.md
@@ -1,0 +1,13 @@
+# Policy Watcher Patches
+
+This directory contains patches for `@vscode/policy-watcher` package.
+
+## macos-optional-fix.patch
+
+**Issue**: macOS compilation fails with `std::optional` errors because the `<optional>` header is not included in `PreferencesPolicy.hh`.
+
+**Fix**: Added `#include <optional>` to `src/macos/PreferencesPolicy.hh` after the CoreFoundation include.
+
+**Application**: The patch is automatically applied via `scripts/apply-policy-watcher-patch.js` during `copy:resource-nodemodules` in `jetbrains/plugin/package.json`.
+
+**Note**: This follows the same pattern as `deps/patches/vscode/jetbrains.patch` for consistency.

--- a/deps/patches/policy-watcher/macos-optional-fix.patch
+++ b/deps/patches/policy-watcher/macos-optional-fix.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/@vscode/policy-watcher/src/macos/PreferencesPolicy.hh b/node_modules/@vscode/policy-watcher/src/macos/PreferencesPolicy.hh
+index 0000000..1111111 100644
+--- a/node_modules/@vscode/policy-watcher/src/macos/PreferencesPolicy.hh
++++ b/node_modules/@vscode/policy-watcher/src/macos/PreferencesPolicy.hh
+@@ -7,6 +7,7 @@
+ #ifndef PREFERENCES_POLICY_H
+ #define PREFERENCES_POLICY_H
+ 
+ #include <napi.h>
+ #include <CoreFoundation/CoreFoundation.h>
++#include <optional>
+ #include "../Policy.hh"
+ 
+ using namespace Napi;

--- a/jetbrains/plugin/package.json
+++ b/jetbrains/plugin/package.json
@@ -23,7 +23,7 @@
 		"clean:resource-logs": "npx del-cli ../resources/logs --force",
 		"copy:resource-logs": "npx mkdirp ../resources/logs",
 		"clean:resource-nodemodules": "npx del-cli ../resources/node_modules --force && npx del-cli ../resources/package.json --force",
-		"copy:resource-nodemodules": "cp ../host/package.json ../resources/package.json && npm install --prefix ../resources",
+		"copy:resource-nodemodules": "cp ../host/package.json ../resources/package.json && npm install --prefix ../resources --ignore-scripts && node ../../scripts/apply-policy-watcher-patch.js --target ../resources && npm rebuild @vscode/policy-watcher --prefix ../resources",
 		"propDep": "npx del-cli ./propDep.txt --force && npm ls --omit=dev --all --parseable --prefix ../resources > ./prodDep.txt",
 		"sync:version": "node scripts/sync_version.js",
 		"sync:changelog": "node scripts/update_change_notes.js"

--- a/scripts/apply-policy-watcher-patch.js
+++ b/scripts/apply-policy-watcher-patch.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+/**
+ * Apply patch for @vscode/policy-watcher to fix macOS compilation issues.
+ * This script patches the PreferencesPolicy.hh file to include <optional> header.
+ * 
+ * The patch file is located at deps/patches/policy-watcher/macos-optional-fix.patch
+ * This follows the same pattern as deps/patches/vscode/jetbrains.patch
+ * 
+ * Usage:
+ *   node scripts/apply-policy-watcher-patch.js                    # Patch root node_modules
+ *   node scripts/apply-policy-watcher-patch.js --target <dir>    # Patch specific directory
+ * 
+ * For pnpm, we need to patch files in the .pnpm store directly.
+ * For regular npm installs (like in jetbrains/resources), we patch the direct node_modules structure.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const PATCH_FILE = path.join(__dirname, '../deps/patches/policy-watcher/macos-optional-fix.patch');
+const OPTIONAL_INCLUDE = '#include <optional>';
+
+function findPolicyWatcherFiles(targetDir) {
+  const baseDir = targetDir || path.join(__dirname, '..');
+  const nodeModulesPath = path.join(baseDir, 'node_modules');
+  
+  const files = [];
+  
+  // Check if it's a pnpm structure (.pnpm store)
+  const pnpmStorePath = path.join(nodeModulesPath, '.pnpm');
+  if (fs.existsSync(pnpmStorePath)) {
+    // Find all PreferencesPolicy.hh files in @vscode+policy-watcher@1.3.2 directories
+    function searchDir(dir) {
+      try {
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          const fullPath = path.join(dir, entry.name);
+          if (entry.isDirectory()) {
+            if (entry.name.includes('@vscode+policy-watcher@1.3.2')) {
+              const policyFile = path.join(fullPath, 'node_modules/@vscode/policy-watcher/src/macos/PreferencesPolicy.hh');
+              if (fs.existsSync(policyFile)) {
+                files.push(policyFile);
+              }
+            } else {
+              searchDir(fullPath);
+            }
+          }
+        }
+      } catch (err) {
+        // Ignore permission errors
+      }
+    }
+    searchDir(pnpmStorePath);
+  }
+  
+  // Also check for regular npm/node_modules structure (for jetbrains/resources)
+  const directPath = path.join(nodeModulesPath, '@vscode/policy-watcher/src/macos/PreferencesPolicy.hh');
+  if (fs.existsSync(directPath)) {
+    files.push(directPath);
+  }
+  
+  return files;
+}
+
+function applyPatch(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    
+    // Check if patch is already applied
+    if (content.includes(OPTIONAL_INCLUDE)) {
+      return false; // Already patched
+    }
+    
+    // Check if std::optional is used (which requires the include)
+    if (!content.includes('std::optional')) {
+      return false; // No need to patch if optional is not used
+    }
+    
+    // Find the insertion point (after CoreFoundation include, before Policy.hh)
+    const lines = content.split('\n');
+    let insertIndex = -1;
+    
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].includes('#include <CoreFoundation/CoreFoundation.h>')) {
+        insertIndex = i + 1;
+        // Skip empty lines
+        while (insertIndex < lines.length && lines[insertIndex].trim() === '') {
+          insertIndex++;
+        }
+        break;
+      }
+    }
+    
+    if (insertIndex === -1) {
+      console.warn(`Could not find insertion point in ${filePath}`);
+      return false;
+    }
+    
+    // Insert the optional include
+    lines.splice(insertIndex, 0, OPTIONAL_INCLUDE);
+    const newContent = lines.join('\n');
+    
+    fs.writeFileSync(filePath, newContent, 'utf8');
+    console.log(`✓ Patched ${filePath}`);
+    return true;
+  } catch (err) {
+    console.error(`Error patching ${filePath}:`, err.message);
+    return false;
+  }
+}
+
+function main() {
+  // Parse command line arguments
+  const args = process.argv.slice(2);
+  let targetDir = null;
+  
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--target' && i + 1 < args.length) {
+      targetDir = path.resolve(args[i + 1]);
+      break;
+    }
+  }
+  
+  console.log('Applying @vscode/policy-watcher patch for macOS...');
+  if (targetDir) {
+    console.log(`Target directory: ${targetDir}`);
+  }
+  
+  const files = findPolicyWatcherFiles(targetDir);
+  
+  if (files.length === 0) {
+    console.warn('No @vscode/policy-watcher@1.3.2 files found to patch');
+    return;
+  }
+  
+  let patched = 0;
+  for (const file of files) {
+    if (applyPatch(file)) {
+      patched++;
+    }
+  }
+  
+  if (patched > 0) {
+    console.log(`✓ Successfully patched ${patched} file(s)`);
+  } else {
+    console.log('All files already patched or no changes needed');
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { applyPatch, findPolicyWatcherFiles };


### PR DESCRIPTION
## Context


The JetBrains plugin build fails on macOS due to a compilation error in `@vscode/policy-watcher`. The package uses `std::optional` in `PreferencesPolicy.hh` but doesn't include the `<optional>` header, causing the build to fail during native module compilation.

This fix adds an automated patch application system that:
1. Patches the `PreferencesPolicy.hh` file to include `<optional>` header
2. Integrates seamlessly into the existing build process
3. Follows the same pattern as other patches in the codebase (e.g., `deps/patches/vscode/jetbrains.patch`)

## Implementation


### Changes Made

1. **Created patch file** (`deps/patches/policy-watcher/macos-optional-fix.patch`)
   - Adds `#include <optional>` to `PreferencesPolicy.hh` after the CoreFoundation include

2. **Created patch application script** (`scripts/apply-policy-watcher-patch.js`)
   - Automatically finds and patches `@vscode/policy-watcher` files in both pnpm and npm node_modules structures
   - Handles both the pnpm store format and regular npm installs
   - Includes safety checks to avoid duplicate patching

3. **Updated build script** (`jetbrains/plugin/package.json`)
   - Modified `copy:resource-nodemodules` to:
     - Install dependencies with `--ignore-scripts` to skip native compilation
     - Apply the patch before compilation
     - Rebuild `@vscode/policy-watcher` after patching

4. **Added documentation** (`deps/patches/policy-watcher/README.md`)
   - Documents the issue and fix
   - Explains the patch application process



### Technical Details

The patch script:
- Searches for `PreferencesPolicy.hh` files in both pnpm and npm structures
- Checks if the patch is already applied to avoid duplicates
- Inserts `#include <optional>` after `#include <CoreFoundation/CoreFoundation.h>`
- Works with the existing build pipeline without requiring manual intervention

The build process now:
1. Installs packages without running build scripts (`--ignore-scripts`)
2. Applies the patch to fix the missing header
3. Rebuilds the native module with the patch in place

## Screenshots

| before | after |
| ------ | ----- |
| Build fails with `std::optional` compilation errors | Build completes successfully |

## How to Test

1. **Clean build test:**
   ```bash
   cd jetbrains/plugin
   pnpm run clean:resource-nodemodules
   pnpm run copy:resource-nodemodules
   ```
   Verify that the build completes without errors.

2. **Full build test:**
   ```bash
   cd jetbrains/plugin
   pnpm run bundle
   ```
   Verify that the complete plugin bundle builds successfully.

3. **Patch verification:**
   After running `copy:resource-nodemodules`, check that the patch was applied:
   ```bash
   grep -A 2 "CoreFoundation" ../resources/node_modules/@vscode/policy-watcher/src/macos/PreferencesPolicy.hh
   ```
   Should show `#include <optional>` after the CoreFoundation include.

4. **Multiple runs test:**
   Run `copy:resource-nodemodules` multiple times to ensure the patch script handles already-patched files correctly.