### PR TITLE
fix(providers): fix duplicate tool use in anthropic

### DIFF
--- a/.changeset/olive-carpets-swim.md
+++ b/.changeset/olive-carpets-swim.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix duplicate tool use in Anthropic

--- a/src/api/providers/__tests__/anthropic.spec.ts
+++ b/src/api/providers/__tests__/anthropic.spec.ts
@@ -676,9 +676,6 @@ describe("AnthropicHandler", () => {
 				chunks.push(chunk)
 			}
 
-			// Ensure we don't emit complete tool_call events alongside partials
-			expect(chunks.filter((chunk) => chunk.type === "tool_call")).toHaveLength(0)
-
 			// Find the tool_call_partial chunk
 			const toolCallChunk = chunks.find((chunk) => chunk.type === "tool_call_partial")
 			expect(toolCallChunk).toBeDefined()
@@ -745,9 +742,6 @@ describe("AnthropicHandler", () => {
 			for await (const chunk of stream) {
 				chunks.push(chunk)
 			}
-
-			// Ensure we don't emit complete tool_call events alongside partials
-			expect(chunks.filter((chunk) => chunk.type === "tool_call")).toHaveLength(0)
 
 			// Find the tool_call_partial chunks
 			const toolCallChunks = chunks.filter((chunk) => chunk.type === "tool_call_partial")

--- a/src/api/providers/__tests__/anthropic.spec.ts
+++ b/src/api/providers/__tests__/anthropic.spec.ts
@@ -676,6 +676,9 @@ describe("AnthropicHandler", () => {
 				chunks.push(chunk)
 			}
 
+			// Ensure we don't emit complete tool_call events alongside partials
+			expect(chunks.filter((chunk) => chunk.type === "tool_call")).toHaveLength(0)
+
 			// Find the tool_call_partial chunk
 			const toolCallChunk = chunks.find((chunk) => chunk.type === "tool_call_partial")
 			expect(toolCallChunk).toBeDefined()
@@ -742,6 +745,9 @@ describe("AnthropicHandler", () => {
 			for await (const chunk of stream) {
 				chunks.push(chunk)
 			}
+
+			// Ensure we don't emit complete tool_call events alongside partials
+			expect(chunks.filter((chunk) => chunk.type === "tool_call")).toHaveLength(0)
 
 			// Find the tool_call_partial chunks
 			const toolCallChunks = chunks.filter((chunk) => chunk.type === "tool_call_partial")

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -20,7 +20,7 @@ import { filterNonAnthropicBlocks } from "../transform/anthropic-filter"
 import { BaseProvider } from "./base-provider"
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
 import { calculateApiCostAnthropic } from "../../shared/cost"
-import { convertOpenAIToolsToAnthropic, ToolCallAccumulatorAnthropic } from "./kilocode/nativeToolCallHelpers"
+import { convertOpenAIToolsToAnthropic } from "./kilocode/nativeToolCallHelpers"
 
 export class AnthropicHandler extends BaseProvider implements SingleCompletionHandler {
 	private options: ApiHandlerOptions
@@ -204,12 +204,9 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 		let thinkingDeltaAccumulator = ""
 		let thinkText = ""
 		let thinkSignature = ""
-		const toolCallAccumulator = new ToolCallAccumulatorAnthropic()
 		// kilocode_change end
 
 		for await (const chunk of stream) {
-			yield* toolCallAccumulator.processChunk(chunk) // kilocode_change
-
 			switch (chunk.type) {
 				case "message_start": {
 					// Tells us cache reads/writes/input/output.


### PR DESCRIPTION
## Context

Fixes duplicate tool_use emissions in Anthropic tool streaming. The current flow produces both `tool_call_partial` and a full `tool_call`, which results in the same id being emitted twice and API provider rejecting the request with "`tool_use` ids must be unique". This shows up easily with tools like `ask_followup_question`.

## Implementation

Removed the Anthropic `ToolCallAccumulatorAnthropic` output so we rely solely on `tool_call_partial`, letting `NativeToolCallParser` handle streaming assembly and completion. 

## Screenshots

| before | after |
| ------ | ----- |
| <img width="555" height="399" alt="image" src="https://github.com/user-attachments/assets/0dd35a04-61d1-4cee-acea-2185bdd1b0aa" /> | <img width="563" height="455" alt="image" src="https://github.com/user-attachments/assets/f418c4b2-bdbe-46a8-9d9b-db03c1586ef7" /> |

## How to Test

Configure the provider without changing nothing, then start a new chat, let AI ask your some question, 100% repeation.

## Get in Touch

username `hank9999` in the server
