### PR TITLE
fix: handle cli configuration errors

### DIFF
--- a/.changeset/salty-shirts-guess.md
+++ b/.changeset/salty-shirts-guess.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Agent Manager not showing error when CLI is misconfigured. When the CLI exits with a configuration error (e.g., missing kilocodeToken), the extension now detects this and shows an error popup with options to run `kilocode auth` or `kilocode config`.

--- a/src/core/kilocode/agent-manager/AgentManagerProvider.ts
+++ b/src/core/kilocode/agent-manager/AgentManagerProvider.ts
@@ -1244,11 +1244,7 @@ export class AgentManagerProvider implements vscode.Disposable {
 			return
 		}
 		terminal.show()
-		// Use resolved CLI path if available, fallback to "kilocode" for PATH lookup
-		void this.sessionLauncher.getPrewarmedCliPath().then((cliPath) => {
-			const cmd = cliPath ? `"${cliPath}" auth` : "kilocode auth"
-			terminal.sendText(cmd)
-		})
+		terminal.sendText("kilocode auth")
 	}
 
 	private runConfigureInTerminal(): void {
@@ -1257,11 +1253,7 @@ export class AgentManagerProvider implements vscode.Disposable {
 			return
 		}
 		terminal.show()
-		// Use resolved CLI path if available, fallback to "kilocode" for PATH lookup
-		void this.sessionLauncher.getPrewarmedCliPath().then((cliPath) => {
-			const cmd = cliPath ? `"${cliPath}" config` : "kilocode config"
-			terminal.sendText(cmd)
-		})
+		terminal.sendText("kilocode config")
 	}
 
 	private showCliAuthReminder(message?: string): void {

--- a/src/core/kilocode/agent-manager/CliOutputParser.ts
+++ b/src/core/kilocode/agent-manager/CliOutputParser.ts
@@ -75,6 +75,8 @@ export interface WelcomeStreamEvent {
 	streamEventType: "welcome"
 	worktreeBranch?: string
 	timestamp: number
+	/** Configuration error instructions from CLI (indicates misconfigured CLI) */
+	instructions?: string[]
 }
 
 export type StreamEvent =
@@ -223,14 +225,16 @@ function toStreamEvent(parsed: Record<string, unknown>): StreamEvent | null {
 		}
 	}
 
-	// Detect welcome event from CLI (format: { type: "welcome", metadata: { welcomeOptions: { worktreeBranch: "..." } }, ... })
+	// Detect welcome event from CLI (format: { type: "welcome", metadata: { welcomeOptions: { worktreeBranch: "...", instructions: [...] } }, ... })
 	if (parsed.type === "welcome") {
 		const metadata = parsed.metadata as Record<string, unknown> | undefined
 		const welcomeOptions = metadata?.welcomeOptions as Record<string, unknown> | undefined
+		const instructions = welcomeOptions?.instructions as string[] | undefined
 		return {
 			streamEventType: "welcome",
 			worktreeBranch: welcomeOptions?.worktreeBranch as string | undefined,
 			timestamp: (parsed.timestamp as number) || Date.now(),
+			instructions: Array.isArray(instructions) && instructions.length > 0 ? instructions : undefined,
 		}
 	}
 

--- a/src/core/kilocode/agent-manager/CliProcessHandler.ts
+++ b/src/core/kilocode/agent-manager/CliProcessHandler.ts
@@ -22,6 +22,12 @@ import { captureAgentManagerLoginIssue, getPlatformDiagnostics } from "./telemet
 const PENDING_SESSION_TIMEOUT_MS = 30_000
 
 /**
+ * Maximum size for stdout buffer (bytes) - prevents memory issues when buffering output
+ * before session_created. We only need enough to detect configuration errors.
+ */
+const MAX_STDOUT_BUFFER_SIZE = 64 * 1024
+
+/**
  * Tracks a pending session while waiting for CLI's session_created event.
  * Note: This is only used for NEW sessions. Resume sessions go directly to activeSessions.
  */
@@ -37,9 +43,11 @@ interface PendingProcessInfo {
 	sawApiReqStarted?: boolean // Track if api_req_started arrived before session_created
 	gitUrl?: string
 	stderrBuffer: string[] // Capture stderr for error detection
+	stdoutBuffer: string[] // Capture raw stdout for configuration error detection when JSON is truncated
 	timeoutId?: NodeJS.Timeout // Timer for auto-failing stuck pending sessions
 	cliPath?: string // CLI path for error telemetry
 	provisionalSessionId?: string // Temporary session ID created when api_req_started arrives (before session_created)
+	configurationError?: string // Captured from welcome event instructions (indicates misconfigured CLI)
 }
 
 interface ActiveProcessInfo {
@@ -55,7 +63,7 @@ export interface CliProcessHandlerCallbacks {
 	onPendingSessionChanged: (pendingSession: { prompt: string; label: string; startTime: number } | null) => void
 	onStartSessionFailed: (
 		error?:
-			| { type: "cli_outdated" | "spawn_error" | "unknown"; message: string }
+			| { type: "cli_outdated" | "spawn_error" | "unknown" | "cli_configuration_error"; message: string }
 			| { type: "api_req_failed"; message: string; payload?: KilocodePayload; authError?: boolean }
 			| { type: "payment_required"; message: string; payload?: KilocodePayload },
 	) => void
@@ -212,6 +220,7 @@ export class CliProcessHandler {
 				desiredLabel: options?.label,
 				gitUrl: options?.gitUrl,
 				stderrBuffer: [],
+				stdoutBuffer: [],
 				timeoutId: setTimeout(() => this.handlePendingTimeout(), PENDING_SESSION_TIMEOUT_MS),
 				cliPath,
 			}
@@ -221,6 +230,13 @@ export class CliProcessHandler {
 		proc.stdout?.on("data", (chunk) => {
 			const chunkStr = chunk.toString()
 			this.debugLog(`stdout chunk (${chunkStr.length} bytes): ${chunkStr.slice(0, 200)}`)
+
+			// Capture raw stdout for configuration error detection (in case JSON is truncated)
+			// Cap buffer size to prevent memory issues
+			if (this.pendingProcess && this.pendingProcess.process === proc) {
+				this.pendingProcess.stdoutBuffer.push(chunkStr)
+				this.capStdoutBuffer()
+			}
 
 			const { events } = parser.parse(chunkStr)
 
@@ -361,12 +377,17 @@ export class CliProcessHandler {
 
 		// If this is the pending process, handle specially
 		if (this.pendingProcess && this.pendingProcess.process === proc) {
-			// Capture worktree branch from welcome event (arrives before session_created)
+			// Capture worktree branch and configuration errors from welcome event (arrives before session_created)
 			if (event.streamEventType === "welcome") {
 				const welcomeEvent = event as WelcomeStreamEvent
 				if (welcomeEvent.worktreeBranch) {
 					this.pendingProcess.worktreeBranch = welcomeEvent.worktreeBranch
 					this.debugLog(`Captured worktree branch from welcome: ${welcomeEvent.worktreeBranch}`)
+				}
+				// Capture configuration error instructions (indicates misconfigured CLI)
+				if (welcomeEvent.instructions && welcomeEvent.instructions.length > 0) {
+					this.pendingProcess.configurationError = welcomeEvent.instructions.join("\n")
+					this.debugLog(`Captured CLI configuration error: ${this.pendingProcess.configurationError}`)
 				}
 				return
 			}
@@ -601,15 +622,62 @@ export class CliProcessHandler {
 	): void {
 		if (this.pendingProcess && this.pendingProcess.process === proc) {
 			this.clearPendingTimeout()
+
+			// Flush any buffered parser output before checking for errors
+			// This is important because the welcome event JSON might be split across chunks
+			const { events } = this.pendingProcess.parser.flush()
+			for (const event of events) {
+				// Process welcome events to capture configuration errors
+				if (event.streamEventType === "welcome") {
+					const welcomeEvent = event as WelcomeStreamEvent
+					if (welcomeEvent.instructions && welcomeEvent.instructions.length > 0) {
+						this.pendingProcess.configurationError = welcomeEvent.instructions.join("\n")
+						this.debugLog(
+							`Captured CLI configuration error from flush: ${this.pendingProcess.configurationError}`,
+						)
+					}
+				}
+			}
+
+			// Fallback: Check raw stdout for configuration error patterns if JSON parsing didn't capture it
+			// This handles cases where the CLI sends truncated JSON before exiting
+			if (!this.pendingProcess.configurationError) {
+				const rawStdout = this.pendingProcess.stdoutBuffer.join("")
+				const configError = this.detectConfigurationErrorFromRawOutput(rawStdout)
+				if (configError) {
+					this.pendingProcess.configurationError = configError
+					this.debugLog(`Captured CLI configuration error from raw output: ${configError}`)
+				}
+			}
+
 			const stderrOutput = this.pendingProcess.stderrBuffer.join("\n")
+			const configurationError = this.pendingProcess.configurationError
 			this.registry.clearPendingSession()
 			this.callbacks.onPendingSessionChanged(null)
 			this.pendingProcess = null
+
+			// Check for CLI configuration error (e.g., missing kilocodeToken)
+			// CLI may exit with code 0 when showing configuration error instructions
+			if (configurationError) {
+				this.callbacks.onStartSessionFailed({
+					type: "cli_configuration_error",
+					message: configurationError,
+				})
+				this.callbacks.onStateChanged()
+				return
+			}
 
 			if (code !== 0) {
 				// Detect CLI version/compatibility issues from stderr
 				const errorInfo = this.detectCliError(stderrOutput, code)
 				this.callbacks.onStartSessionFailed(errorInfo)
+			} else {
+				// Generic fallback: CLI exited with code 0 before session_created
+				// This ensures the user never gets "nothing happened"
+				this.callbacks.onStartSessionFailed({
+					type: "unknown",
+					message: stderrOutput || "CLI exited before creating a session",
+				})
 			}
 			this.callbacks.onStateChanged()
 			return
@@ -793,5 +861,50 @@ export class CliProcessHandler {
 			type: "unknown",
 			message: stderrOutput || "Unknown error",
 		}
+	}
+
+	/**
+	 * Cap the stdout buffer size to prevent memory issues.
+	 * Keeps the most recent data up to MAX_STDOUT_BUFFER_SIZE.
+	 */
+	private capStdoutBuffer(): void {
+		if (!this.pendingProcess) {
+			return
+		}
+
+		const buffer = this.pendingProcess.stdoutBuffer
+		const totalSize = buffer.reduce((sum, chunk) => sum + chunk.length, 0)
+
+		if (totalSize > MAX_STDOUT_BUFFER_SIZE) {
+			// Join, trim from the start, and replace buffer with single trimmed string
+			const joined = buffer.join("")
+			const trimmed = joined.slice(joined.length - MAX_STDOUT_BUFFER_SIZE)
+			this.pendingProcess.stdoutBuffer = [trimmed]
+		}
+	}
+
+	/**
+	 * Detect configuration errors from raw stdout output.
+	 * This is a fallback for when the CLI sends truncated JSON that can't be parsed.
+	 * Looks for patterns like "Configuration Error" or "instructions" containing error text.
+	 */
+	private detectConfigurationErrorFromRawOutput(rawOutput: string): string | undefined {
+		// Look for "Configuration Error" pattern in the raw output
+		// The CLI outputs this when config.json is incomplete or invalid
+		if (rawOutput.includes('"instructions":') && rawOutput.includes("Configuration Error")) {
+			// Return a generic configuration error message since we can't parse the full details
+			return "CLI configuration is incomplete or invalid. Please run 'kilocode config' or 'kilocode auth' to configure."
+		}
+
+		// Also check for common configuration error indicators
+		if (
+			rawOutput.includes("kilocodeToken is required") ||
+			rawOutput.includes("config.json is incomplete") ||
+			rawOutput.includes("apiKey is required")
+		) {
+			return "CLI configuration is incomplete or invalid. Please run 'kilocode config' or 'kilocode auth' to configure."
+		}
+
+		return undefined
 	}
 }

--- a/src/core/kilocode/agent-manager/CliSessionLauncher.ts
+++ b/src/core/kilocode/agent-manager/CliSessionLauncher.ts
@@ -94,7 +94,8 @@ export class CliSessionLauncher {
 	 * This is useful for terminal commands that need the resolved CLI path.
 	 */
 	public async getPrewarmedCliPath(): Promise<string | null> {
-		return this.cliPathPromise ?? null
+		const result = await this.cliPathPromise
+		return result?.cliPath ?? null
 	}
 
 	/**

--- a/src/core/kilocode/agent-manager/CliSessionLauncher.ts
+++ b/src/core/kilocode/agent-manager/CliSessionLauncher.ts
@@ -90,6 +90,14 @@ export class CliSessionLauncher {
 	}
 
 	/**
+	 * Get the pre-warmed CLI path, or null if not available.
+	 * This is useful for terminal commands that need the resolved CLI path.
+	 */
+	public async getPrewarmedCliPath(): Promise<string | null> {
+		return this.cliPathPromise ?? null
+	}
+
+	/**
 	 * Spawn a CLI process with all the standard setup.
 	 * Handles CLI path lookup, git URL resolution, API config, and event callback wiring.
 	 * Uses pre-warmed promises when available.

--- a/src/core/kilocode/agent-manager/__tests__/CliOutputParser.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/CliOutputParser.spec.ts
@@ -82,6 +82,7 @@ describe("parseCliChunk", () => {
 			streamEventType: "welcome",
 			worktreeBranch: "feature/test-branch",
 			timestamp: 1234567890,
+			instructions: undefined,
 		})
 	})
 
@@ -92,6 +93,33 @@ describe("parseCliChunk", () => {
 			streamEventType: "welcome",
 			worktreeBranch: undefined,
 			timestamp: 1234567890,
+			instructions: undefined,
+		})
+	})
+
+	it("should parse welcome event with configuration error instructions", () => {
+		const result = parseCliChunk(
+			'{"type":"welcome","metadata":{"welcomeOptions":{"instructions":["Configuration Error: config.json is incomplete","kilocodeToken is required"]}},"timestamp":1234567890}\n',
+		)
+		expect(result.events).toHaveLength(1)
+		expect(result.events[0]).toEqual({
+			streamEventType: "welcome",
+			worktreeBranch: undefined,
+			timestamp: 1234567890,
+			instructions: ["Configuration Error: config.json is incomplete", "kilocodeToken is required"],
+		})
+	})
+
+	it("should not include instructions when array is empty", () => {
+		const result = parseCliChunk(
+			'{"type":"welcome","metadata":{"welcomeOptions":{"instructions":[]}},"timestamp":1234567890}\n',
+		)
+		expect(result.events).toHaveLength(1)
+		expect(result.events[0]).toEqual({
+			streamEventType: "welcome",
+			worktreeBranch: undefined,
+			timestamp: 1234567890,
+			instructions: undefined,
 		})
 	})
 

--- a/src/core/kilocode/agent-manager/__tests__/telemetry.test.ts
+++ b/src/core/kilocode/agent-manager/__tests__/telemetry.test.ts
@@ -231,6 +231,23 @@ describe("Agent Manager Telemetry", () => {
 			)
 		})
 
+		it("captures cli_configuration_error issue with platform diagnostics", () => {
+			vi.mocked(TelemetryService.hasInstance).mockReturnValue(true)
+
+			const props: AgentManagerLoginIssueProperties = {
+				issueType: "cli_configuration_error",
+				platform: "darwin",
+				shell: "fish",
+			}
+
+			captureAgentManagerLoginIssue(props)
+
+			expect(TelemetryService.instance.captureEvent).toHaveBeenCalledWith(
+				TelemetryEventName.AGENT_MANAGER_LOGIN_ISSUE,
+				props,
+			)
+		})
+
 		it("captures cli_not_found with platform and shell diagnostics", () => {
 			vi.mocked(TelemetryService.hasInstance).mockReturnValue(true)
 

--- a/src/core/kilocode/agent-manager/telemetry.ts
+++ b/src/core/kilocode/agent-manager/telemetry.ts
@@ -18,6 +18,7 @@ export type AgentManagerLoginIssueType =
 	| "cli_not_found"
 	| "cli_outdated"
 	| "cli_spawn_error"
+	| "cli_configuration_error"
 	| "auth_error"
 	| "payment_required"
 	| "api_error"

--- a/src/i18n/locales/ar/kilocode.json
+++ b/src/i18n/locales/ar/kilocode.json
@@ -181,6 +181,7 @@
 		"errors": {
 			"cliOutdated": "إصدار Kilocode CLI لديك قديم ولا يدعم مدير الوكلاء. يرجى التحديث إلى أحدث إصدار.",
 			"cliNotFound": "لم يتم العثور على Kilocode CLI. يرجى تثبيته لاستخدام مدير الوكلاء.",
+			"cliMisconfigured": "Kilocode CLI غير مُهيأ. قم بتشغيل 'kilocode auth' لتسجيل الدخول أو 'kilocode config' للإعداد.",
 			"sessionFailed": "فشل بدء جلسة الوكيل",
 			"sessionFailedWithMessage": "فشل بدء جلسة الوكيل: {{message}}"
 		},
@@ -190,6 +191,7 @@
 			"getHelp": "الحصول على المساعدة",
 			"runInTerminal": "تشغيل في الطرفية",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "تحديث عام",
 			"updateLocal": "تحديث محلي",
 			"installGlobal": "تثبيت عام",

--- a/src/i18n/locales/ca/kilocode.json
+++ b/src/i18n/locales/ca/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "La teva versió de Kilocode CLI està desactualitzada i no és compatible amb el Gestor d'Agents. Si us plau, actualitza a la versió més recent.",
 			"cliNotFound": "No s'ha trobat Kilocode CLI. Si us plau, instal·la'l per utilitzar el Gestor d'Agents.",
+			"cliMisconfigured": "Kilocode CLI no està configurat. Executa 'kilocode auth' per iniciar sessió o 'kilocode config' per configurar.",
 			"sessionFailed": "Error en iniciar la sessió de l'agent",
 			"sessionFailedWithMessage": "Error en iniciar la sessió de l'agent: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "Obtenir Ajuda",
 			"runInTerminal": "Executar al Terminal",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Actualitzar Global",
 			"updateLocal": "Actualitzar Local",
 			"installGlobal": "Instal·lar Global",

--- a/src/i18n/locales/cs/kilocode.json
+++ b/src/i18n/locales/cs/kilocode.json
@@ -106,6 +106,7 @@
 		"errors": {
 			"cliOutdated": "Tvoje verze Kilocode CLI je zastaralá a nepodporuje Agent Manager. Prosím aktualizuj na nejnovější verzi.",
 			"cliNotFound": "Kilocode CLI nenalezeno. Prosím nainstaluj ho pro použití Agent Manageru.",
+			"cliMisconfigured": "Kilocode CLI není nakonfigurováno. Spusť 'kilocode auth' pro přihlášení nebo 'kilocode config' pro konfiguraci.",
 			"sessionFailed": "Nepodařilo se spustit relaci agenta",
 			"sessionFailedWithMessage": "Nepodařilo se spustit relaci agenta: {{message}}"
 		},
@@ -115,6 +116,7 @@
 			"getHelp": "Získat Pomoc",
 			"runInTerminal": "Spustit v Terminálu",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Aktualizovat Globálně",
 			"updateLocal": "Aktualizovat Lokálně",
 			"installGlobal": "Instalovat Globálně",

--- a/src/i18n/locales/de/kilocode.json
+++ b/src/i18n/locales/de/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "Deine Kilocode CLI-Version ist veraltet und unterstützt den Agent Manager nicht. Bitte aktualisiere auf die neueste Version.",
 			"cliNotFound": "Kilocode CLI nicht gefunden. Bitte installiere es, um den Agent Manager zu nutzen.",
+			"cliMisconfigured": "Kilocode CLI ist nicht konfiguriert. Bitte führe 'kilocode auth' aus, um dich anzumelden, oder 'kilocode config' zum Konfigurieren.",
 			"sessionFailed": "Agent-Sitzung konnte nicht gestartet werden",
 			"sessionFailedWithMessage": "Agent-Sitzung konnte nicht gestartet werden: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "Hilfe erhalten",
 			"runInTerminal": "Im Terminal ausführen",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Global Aktualisieren",
 			"updateLocal": "Lokal Aktualisieren",
 			"installGlobal": "Global Installieren",

--- a/src/i18n/locales/en/kilocode.json
+++ b/src/i18n/locales/en/kilocode.json
@@ -162,6 +162,7 @@
 		"errors": {
 			"cliOutdated": "Your Kilocode CLI version is outdated and doesn't support the Agent Manager. Please update to the latest version.",
 			"cliNotFound": "Kilocode CLI not found. Please install it to use the Agent Manager.",
+			"cliMisconfigured": "Kilocode CLI is not configured. Please run 'kilocode auth' to sign in or 'kilocode config' to configure.",
 			"sessionFailed": "Failed to start agent session",
 			"sessionFailedWithMessage": "Failed to start agent session: {{message}}"
 		},
@@ -174,7 +175,8 @@
 			"updateLocal": "Update Local",
 			"installGlobal": "Install Global",
 			"installLocal": "Install Local",
-			"loginCli": "Run kilocode auth"
+			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config"
 		},
 		"terminal": {
 			"installMessage": "Running npm install to install the Kilocode CLI. Once complete, you can close this terminal and try starting the Agent Manager again.",

--- a/src/i18n/locales/es/kilocode.json
+++ b/src/i18n/locales/es/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "Tu versión de Kilocode CLI está desactualizada y no es compatible con el Gestor de Agentes. Por favor, actualiza a la última versión.",
 			"cliNotFound": "No se encontró Kilocode CLI. Por favor, instálalo para usar el Gestor de Agentes.",
+			"cliMisconfigured": "Kilocode CLI no está configurado. Ejecuta 'kilocode auth' para iniciar sesión o 'kilocode config' para configurar.",
 			"sessionFailed": "Error al iniciar la sesión del agente",
 			"sessionFailedWithMessage": "Error al iniciar la sesión del agente: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "Obtener Ayuda",
 			"runInTerminal": "Ejecutar en Terminal",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Actualizar Global",
 			"updateLocal": "Actualizar Local",
 			"installGlobal": "Instalar Global",

--- a/src/i18n/locales/fr/kilocode.json
+++ b/src/i18n/locales/fr/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "Ta version de Kilocode CLI est obsolète et ne prend pas en charge le Gestionnaire d'Agents. Mets-la à jour vers la dernière version.",
 			"cliNotFound": "Kilocode CLI introuvable. Installe-le pour utiliser le Gestionnaire d'Agents.",
+			"cliMisconfigured": "Kilocode CLI n'est pas configuré. Exécute 'kilocode auth' pour te connecter ou 'kilocode config' pour configurer.",
 			"sessionFailed": "Échec du démarrage de la session de l'agent",
 			"sessionFailedWithMessage": "Échec du démarrage de la session de l'agent : {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "Obtenir de l'Aide",
 			"runInTerminal": "Exécuter dans le Terminal",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Mettre à jour Global",
 			"updateLocal": "Mettre à jour Local",
 			"installGlobal": "Installer Global",

--- a/src/i18n/locales/hi/kilocode.json
+++ b/src/i18n/locales/hi/kilocode.json
@@ -106,6 +106,7 @@
 		"errors": {
 			"cliOutdated": "आपका Kilocode CLI संस्करण पुराना है और Agent Manager का समर्थन नहीं करता। कृपया नवीनतम संस्करण में अपडेट करें।",
 			"cliNotFound": "Kilocode CLI नहीं मिला। Agent Manager का उपयोग करने के लिए कृपया इसे इंस्टॉल करें।",
+			"cliMisconfigured": "Kilocode CLI कॉन्फ़िगर नहीं है। साइन इन करने के लिए 'kilocode auth' चलाएं या कॉन्फ़िगर करने के लिए 'kilocode config' चलाएं।",
 			"sessionFailed": "एजेंट सत्र प्रारंभ करने में विफल",
 			"sessionFailedWithMessage": "एजेंट सत्र प्रारंभ करने में विफल: {{message}}"
 		},
@@ -115,6 +116,7 @@
 			"getHelp": "सहायता प्राप्त करें",
 			"runInTerminal": "टर्मिनल में चलाएं",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "ग्लोबल अपडेट करें",
 			"updateLocal": "लोकल अपडेट करें",
 			"installGlobal": "ग्लोबल इंस्टॉल करें",

--- a/src/i18n/locales/id/kilocode.json
+++ b/src/i18n/locales/id/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "Versi Kilocode CLI kamu sudah usang dan tidak mendukung Agent Manager. Harap perbarui ke versi terbaru.",
 			"cliNotFound": "Kilocode CLI tidak ditemukan. Harap instal untuk menggunakan Agent Manager.",
+			"cliMisconfigured": "Kilocode CLI belum dikonfigurasi. Jalankan 'kilocode auth' untuk masuk atau 'kilocode config' untuk mengonfigurasi.",
 			"sessionFailed": "Gagal memulai sesi agen",
 			"sessionFailedWithMessage": "Gagal memulai sesi agen: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "Dapatkan Bantuan",
 			"runInTerminal": "Jalankan di Terminal",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Perbarui Global",
 			"updateLocal": "Perbarui Lokal",
 			"installGlobal": "Instal Global",

--- a/src/i18n/locales/it/kilocode.json
+++ b/src/i18n/locales/it/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "La tua versione di Kilocode CLI è obsoleta e non supporta l'Agent Manager. Aggiorna all'ultima versione.",
 			"cliNotFound": "Kilocode CLI non trovato. Installalo per utilizzare l'Agent Manager.",
+			"cliMisconfigured": "Kilocode CLI non è configurato. Esegui 'kilocode auth' per accedere o 'kilocode config' per configurare.",
 			"sessionFailed": "Impossibile avviare la sessione dell'agente",
 			"sessionFailedWithMessage": "Impossibile avviare la sessione dell'agente: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "Ottieni Aiuto",
 			"runInTerminal": "Esegui nel Terminale",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Aggiorna Globale",
 			"updateLocal": "Aggiorna Locale",
 			"installGlobal": "Installa Globale",

--- a/src/i18n/locales/ja/kilocode.json
+++ b/src/i18n/locales/ja/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "Kilocode CLIのバージョンが古く、Agent Managerをサポートしていません。最新バージョンに更新してください。",
 			"cliNotFound": "Kilocode CLIが見つかりません。Agent Managerを使用するにはインストールしてください。",
+			"cliMisconfigured": "Kilocode CLIが設定されていません。'kilocode auth'でサインインするか、'kilocode config'で設定してください。",
 			"sessionFailed": "エージェントセッションの開始に失敗しました",
 			"sessionFailedWithMessage": "エージェントセッションの開始に失敗しました: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "ヘルプを表示",
 			"runInTerminal": "ターミナルで実行",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "グローバル更新",
 			"updateLocal": "ローカル更新",
 			"installGlobal": "グローバルインストール",

--- a/src/i18n/locales/ko/kilocode.json
+++ b/src/i18n/locales/ko/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "Kilocode CLI 버전이 오래되어 Agent Manager를 지원하지 않습니다. 최신 버전으로 업데이트하세요.",
 			"cliNotFound": "Kilocode CLI를 찾을 수 없습니다. Agent Manager를 사용하려면 설치하세요.",
+			"cliMisconfigured": "Kilocode CLI가 구성되지 않았습니다. 'kilocode auth'를 실행하여 로그인하거나 'kilocode config'로 구성하세요.",
 			"sessionFailed": "에이전트 세션 시작 실패",
 			"sessionFailedWithMessage": "에이전트 세션 시작 실패: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "도움말 보기",
 			"runInTerminal": "터미널에서 실행",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "전역 업데이트",
 			"updateLocal": "로컬 업데이트",
 			"installGlobal": "전역 설치",

--- a/src/i18n/locales/nl/kilocode.json
+++ b/src/i18n/locales/nl/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "Je Kilocode CLI-versie is verouderd en ondersteunt de Agent Manager niet. Update naar de nieuwste versie.",
 			"cliNotFound": "Kilocode CLI niet gevonden. Installeer het om de Agent Manager te gebruiken.",
+			"cliMisconfigured": "Kilocode CLI is niet geconfigureerd. Voer 'kilocode auth' uit om in te loggen of 'kilocode config' om te configureren.",
 			"sessionFailed": "Kon agentsessie niet starten",
 			"sessionFailedWithMessage": "Kon agentsessie niet starten: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "Hulp krijgen",
 			"runInTerminal": "Uitvoeren in Terminal",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Globaal Bijwerken",
 			"updateLocal": "Lokaal Bijwerken",
 			"installGlobal": "Globaal Installeren",

--- a/src/i18n/locales/pl/kilocode.json
+++ b/src/i18n/locales/pl/kilocode.json
@@ -106,6 +106,7 @@
 		"errors": {
 			"cliOutdated": "Twoja wersja Kilocode CLI jest przestarzała i nie obsługuje Agent Managera. Zaktualizuj do najnowszej wersji.",
 			"cliNotFound": "Nie znaleziono Kilocode CLI. Zainstaluj go, aby korzystać z Agent Managera.",
+			"cliMisconfigured": "Kilocode CLI nie jest skonfigurowany. Uruchom 'kilocode auth', aby się zalogować lub 'kilocode config', aby skonfigurować.",
 			"sessionFailed": "Nie udało się uruchomić sesji agenta",
 			"sessionFailedWithMessage": "Nie udało się uruchomić sesji agenta: {{message}}"
 		},
@@ -115,6 +116,7 @@
 			"getHelp": "Uzyskaj Pomoc",
 			"runInTerminal": "Uruchom w Terminalu",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Aktualizuj Globalnie",
 			"updateLocal": "Aktualizuj Lokalnie",
 			"installGlobal": "Zainstaluj Globalnie",

--- a/src/i18n/locales/pt-BR/kilocode.json
+++ b/src/i18n/locales/pt-BR/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "Sua versão do Kilocode CLI está desatualizada e não suporta o Gerenciador de Agentes. Atualize para a versão mais recente.",
 			"cliNotFound": "Kilocode CLI não encontrado. Instale-o para usar o Gerenciador de Agentes.",
+			"cliMisconfigured": "Kilocode CLI não está configurado. Execute 'kilocode auth' para entrar ou 'kilocode config' para configurar.",
 			"sessionFailed": "Falha ao iniciar sessão do agente",
 			"sessionFailedWithMessage": "Falha ao iniciar sessão do agente: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "Obter Ajuda",
 			"runInTerminal": "Executar no Terminal",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Atualizar Global",
 			"updateLocal": "Atualizar Local",
 			"installGlobal": "Instalar Global",

--- a/src/i18n/locales/ru/kilocode.json
+++ b/src/i18n/locales/ru/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "Твоя версия Kilocode CLI устарела и не поддерживает Agent Manager. Обнови до последней версии.",
 			"cliNotFound": "Kilocode CLI не найден. Установи его для использования Agent Manager.",
+			"cliMisconfigured": "Kilocode CLI не настроен. Выполни 'kilocode auth' для входа или 'kilocode config' для настройки.",
 			"sessionFailed": "Не удалось запустить сессию агента",
 			"sessionFailedWithMessage": "Не удалось запустить сессию агента: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "Получить Помощь",
 			"runInTerminal": "Запустить в Терминале",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Обновить Глобально",
 			"updateLocal": "Обновить Локально",
 			"installGlobal": "Установить Глобально",

--- a/src/i18n/locales/th/kilocode.json
+++ b/src/i18n/locales/th/kilocode.json
@@ -106,6 +106,7 @@
 		"errors": {
 			"cliOutdated": "เวอร์ชัน Kilocode CLI ของคุณล้าสมัยและไม่รองรับ Agent Manager โปรดอัปเดตเป็นเวอร์ชันล่าสุด",
 			"cliNotFound": "ไม่พบ Kilocode CLI โปรดติดตั้งเพื่อใช้งาน Agent Manager",
+			"cliMisconfigured": "Kilocode CLI ยังไม่ได้ตั้งค่า เรียกใช้ 'kilocode auth' เพื่อลงชื่อเข้าใช้ หรือ 'kilocode config' เพื่อตั้งค่า",
 			"sessionFailed": "เริ่มเซสชันเอเจนต์ไม่สำเร็จ",
 			"sessionFailedWithMessage": "เริ่มเซสชันเอเจนต์ไม่สำเร็จ: {{message}}"
 		},
@@ -115,6 +116,7 @@
 			"getHelp": "รับความช่วยเหลือ",
 			"runInTerminal": "เรียกใช้ในเทอร์มินัล",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "อัปเดตแบบ Global",
 			"updateLocal": "อัปเดตแบบ Local",
 			"installGlobal": "ติดตั้งแบบ Global",

--- a/src/i18n/locales/tr/kilocode.json
+++ b/src/i18n/locales/tr/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "Kilocode CLI sürümün eski ve Agent Manager'ı desteklemiyor. Lütfen en son sürüme güncelle.",
 			"cliNotFound": "Kilocode CLI bulunamadı. Agent Manager'ı kullanmak için lütfen yükle.",
+			"cliMisconfigured": "Kilocode CLI yapılandırılmamış. Giriş yapmak için 'kilocode auth' veya yapılandırmak için 'kilocode config' çalıştır.",
 			"sessionFailed": "Ajan oturumu başlatılamadı",
 			"sessionFailedWithMessage": "Ajan oturumu başlatılamadı: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "Yardım Al",
 			"runInTerminal": "Terminalde Çalıştır",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Global Güncelle",
 			"updateLocal": "Lokal Güncelle",
 			"installGlobal": "Global Yükle",

--- a/src/i18n/locales/uk/kilocode.json
+++ b/src/i18n/locales/uk/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "Твоя версія Kilocode CLI застаріла і не підтримує Agent Manager. Будь ласка, оновись до останньої версії.",
 			"cliNotFound": "Kilocode CLI не знайдено. Будь ласка, встанови його для використання Agent Manager.",
+			"cliMisconfigured": "Kilocode CLI не налаштовано. Виконай 'kilocode auth' для входу або 'kilocode config' для налаштування.",
 			"sessionFailed": "Не вдалося запустити сесію агента",
 			"sessionFailedWithMessage": "Не вдалося запустити сесію агента: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "Отримати Допомогу",
 			"runInTerminal": "Запустити в Терміналі",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Оновити Глобально",
 			"updateLocal": "Оновити Локально",
 			"installGlobal": "Встановити Глобально",

--- a/src/i18n/locales/vi/kilocode.json
+++ b/src/i18n/locales/vi/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "Phiên bản Kilocode CLI của bạn đã cũ và không hỗ trợ Agent Manager. Vui lòng cập nhật lên phiên bản mới nhất.",
 			"cliNotFound": "Không tìm thấy Kilocode CLI. Vui lòng cài đặt để sử dụng Agent Manager.",
+			"cliMisconfigured": "Kilocode CLI chưa được cấu hình. Chạy 'kilocode auth' để đăng nhập hoặc 'kilocode config' để cấu hình.",
 			"sessionFailed": "Không thể khởi động phiên agent",
 			"sessionFailedWithMessage": "Không thể khởi động phiên agent: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "Nhận Trợ Giúp",
 			"runInTerminal": "Chạy trong Terminal",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "Cập Nhật Toàn Cục",
 			"updateLocal": "Cập Nhật Cục Bộ",
 			"installGlobal": "Cài Đặt Toàn Cục",

--- a/src/i18n/locales/zh-CN/kilocode.json
+++ b/src/i18n/locales/zh-CN/kilocode.json
@@ -106,6 +106,7 @@
 		"errors": {
 			"cliOutdated": "你的 Kilocode CLI 版本已过时，不支持 Agent Manager。请更新到最新版本。",
 			"cliNotFound": "未找到 Kilocode CLI。请安装以使用 Agent Manager。",
+			"cliMisconfigured": "Kilocode CLI 未配置。请运行 'kilocode auth' 登录或 'kilocode config' 进行配置。",
 			"sessionFailed": "启动代理会话失败",
 			"sessionFailedWithMessage": "启动代理会话失败: {{message}}"
 		},
@@ -115,6 +116,7 @@
 			"getHelp": "获取帮助",
 			"runInTerminal": "运行命令",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "全局更新",
 			"updateLocal": "本地更新",
 			"installGlobal": "全局安装",

--- a/src/i18n/locales/zh-TW/kilocode.json
+++ b/src/i18n/locales/zh-TW/kilocode.json
@@ -177,6 +177,7 @@
 		"errors": {
 			"cliOutdated": "你的 Kilocode CLI 版本已過時且不支援 Agent Manager。請更新至最新版本。",
 			"cliNotFound": "找不到 Kilocode CLI。請安裝以使用 Agent Manager。",
+			"cliMisconfigured": "Kilocode CLI 未設定。請執行 'kilocode auth' 登入或 'kilocode config' 進行設定。",
 			"sessionFailed": "啟動代理工作階段失敗",
 			"sessionFailedWithMessage": "啟動代理工作階段失敗: {{message}}"
 		},
@@ -186,6 +187,7 @@
 			"getHelp": "取得協助",
 			"runInTerminal": "在終端機執行",
 			"loginCli": "Run kilocode auth",
+			"configureCli": "Run kilocode config",
 			"updateGlobal": "更新全域",
 			"updateLocal": "更新本地",
 			"installGlobal": "安裝全域",


### PR DESCRIPTION
Fix Agent Manager not showing error when CLI is misconfigured. When the CLI exits with a configuration error (e.g., missing kilocodeToken), the extension now detects this and shows an error popup with options to run `kilocode auth` or `kilocode config`.