### PR TITLE
feat: add model selection support below prompt for z.ai

### DIFF
--- a/.changeset/tricky-glasses-yell.md
+++ b/.changeset/tricky-glasses-yell.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Added model selection support below prompt for Z.ai

--- a/webview-ui/src/components/kilocode/hooks/__tests__/getModelsByProvider.spec.ts
+++ b/webview-ui/src/components/kilocode/hooks/__tests__/getModelsByProvider.spec.ts
@@ -1,51 +1,58 @@
-import { ModelInfo, ProviderName, providerNames } from "@roo-code/types"
+import {
+	ModelInfo,
+	ProviderName,
+	providerNames,
+	internationalZAiModels,
+	internationalZAiDefaultModelId,
+	mainlandZAiModels,
+	mainlandZAiDefaultModelId,
+} from "@roo-code/types"
 import { RouterModels } from "@roo/api"
-import { getModelsByProvider } from "../useProviderModels"
+import { getModelsByProvider, getOptionsForProvider } from "../useProviderModels"
 
 describe("getModelsByProvider", () => {
+	const testModel: ModelInfo = {
+		maxTokens: 4096,
+		contextWindow: 8192,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.1,
+		outputPrice: 0.2,
+		description: "Test model",
+	}
+
+	const routerModels: RouterModels = {
+		openrouter: { "test-model": testModel },
+		requesty: { "test-model": testModel },
+		glama: { "test-model": testModel },
+		unbound: { "test-model": testModel },
+		litellm: { "test-model": testModel },
+		kilocode: { "test-model": testModel },
+		"nano-gpt": { "test-model": testModel },
+		ollama: { "test-model": testModel },
+		lmstudio: { "test-model": testModel },
+		"io-intelligence": { "test-model": testModel },
+		deepinfra: { "test-model": testModel },
+		"vercel-ai-gateway": { "test-model": testModel },
+		huggingface: { "test-model": testModel },
+		gemini: { "test-model": testModel },
+		ovhcloud: { "test-model": testModel },
+		chutes: { "test-model": testModel },
+		"sap-ai-core": { "test-model": testModel },
+		synthetic: { "test-model": testModel },
+		inception: { "test-model": testModel },
+		roo: { "test-model": testModel },
+	}
+
 	it("returns models for all providers", () => {
-		const testModel: ModelInfo = {
-			maxTokens: 4096,
-			contextWindow: 8192,
-			supportsImages: false,
-			supportsPromptCache: false,
-			inputPrice: 0.1,
-			outputPrice: 0.2,
-			description: "Test model",
-		}
-
-		const routerModels: RouterModels = {
-			openrouter: { "test-model": testModel },
-			requesty: { "test-model": testModel },
-			glama: { "test-model": testModel },
-			unbound: { "test-model": testModel },
-			litellm: { "test-model": testModel },
-			kilocode: { "test-model": testModel },
-			"nano-gpt": { "test-model": testModel }, //kilocode_change
-			ollama: { "test-model": testModel },
-			lmstudio: { "test-model": testModel },
-			"io-intelligence": { "test-model": testModel },
-			deepinfra: { "test-model": testModel },
-			"vercel-ai-gateway": { "test-model": testModel },
-			huggingface: { "test-model": testModel },
-			gemini: { "test-model": testModel },
-			ovhcloud: { "test-model": testModel },
-			chutes: { "test-model": testModel },
-			"sap-ai-core": { "test-model": testModel }, // kilocode_change
-			synthetic: { "test-model": testModel }, // kilocode_change
-			inception: { "test-model": testModel },
-			roo: { "test-model": testModel },
-		}
-
 		const exceptions = [
 			"fake-ai", // don't know what this is
 			"huggingface", // don't know what this is
 			"human-relay", // no models
-			"nano-gpt", // dynamic provider - models fetched from API //kilocode_change
+			"nano-gpt", // dynamic provider - models fetched from API
 			"openai", // not implemented
 			"roo", // don't care
 			"virtual-quota-fallback", // no models
-			"zai", // has weird mainland/international distiction
 			"vercel-ai-gateway", // different structure
 		]
 
@@ -58,6 +65,7 @@ describe("getModelsByProvider", () => {
 							provider,
 							routerModels,
 							kilocodeDefaultModel: "test-default-model",
+							options: {},
 						}),
 					] satisfies [ProviderName, ReturnType<typeof getModelsByProvider>],
 			)
@@ -65,5 +73,46 @@ describe("getModelsByProvider", () => {
 			.map((provider) => provider[0])
 
 		expect(providersWithoutModels).toStrictEqual([])
+	})
+
+	it("returns international Z.AI models when isChina is false", () => {
+		const result = getModelsByProvider({
+			provider: "zai",
+			routerModels,
+			kilocodeDefaultModel: "test-default-model",
+			options: { isChina: false },
+		})
+
+		expect(result.models).toEqual(internationalZAiModels)
+		expect(result.defaultModel).toEqual(internationalZAiDefaultModelId)
+	})
+
+	it("returns mainland Z.AI models when isChina is true", () => {
+		const result = getModelsByProvider({
+			provider: "zai",
+			routerModels,
+			kilocodeDefaultModel: "test-default-model",
+			options: { isChina: true },
+		})
+
+		expect(result.models).toEqual(mainlandZAiModels)
+		expect(result.defaultModel).toEqual(mainlandZAiDefaultModelId)
+	})
+})
+
+describe("getOptionsForProvider", () => {
+	it("returns default options for non-zai providers", () => {
+		const result = getOptionsForProvider("openrouter")
+		expect(result).toEqual({})
+	})
+
+	it("returns isChina: false for zai provider with default apiConfiguration", () => {
+		const result = getOptionsForProvider("zai", { zaiApiLine: "international_coding" })
+		expect(result).toEqual({ isChina: false })
+	})
+
+	it("returns isChina: true for zai provider with china_coding apiConfiguration", () => {
+		const result = getOptionsForProvider("zai", { zaiApiLine: "china_coding" })
+		expect(result).toEqual({ isChina: true })
 	})
 })

--- a/webview-ui/src/components/kilocode/hooks/useProviderModels.ts
+++ b/webview-ui/src/components/kilocode/hooks/useProviderModels.ts
@@ -54,6 +54,10 @@ import {
 	inceptionDefaultModelId,
 	minimaxModels,
 	minimaxDefaultModelId,
+	internationalZAiModels,
+	internationalZAiDefaultModelId,
+	mainlandZAiModels,
+	mainlandZAiDefaultModelId,
 } from "@roo-code/types"
 import type { ModelRecord, RouterModels } from "@roo/api"
 import { useRouterModels } from "../../ui/hooks/useRouterModels"
@@ -68,10 +72,12 @@ export const getModelsByProvider = ({
 	provider,
 	routerModels,
 	kilocodeDefaultModel,
+	options = { isChina: false },
 }: {
 	provider: ProviderName
 	routerModels: RouterModels
 	kilocodeDefaultModel: string
+	options: { isChina?: boolean }
 }): { models: ModelRecord; defaultModel: string } => {
 	switch (provider) {
 		case "openrouter": {
@@ -310,11 +316,34 @@ export const getModelsByProvider = ({
 				defaultModel: basetenDefaultModelId,
 			}
 		}
+		case "zai": {
+			if (options.isChina) {
+				return {
+					models: mainlandZAiModels,
+					defaultModel: mainlandZAiDefaultModelId,
+				}
+			} else {
+				return {
+					models: internationalZAiModels,
+					defaultModel: internationalZAiDefaultModelId,
+				}
+			}
+		}
 		default:
 			return {
 				models: {},
 				defaultModel: "",
 			}
+	}
+}
+
+export const getOptionsForProvider = (provider: ProviderName, apiConfiguration?: ProviderSettings) => {
+	switch (provider) {
+		case "zai":
+			// Determine which Z.AI model set to use based on the API line configuration
+			return { isChina: apiConfiguration?.zaiApiLine === "china_coding" }
+		default:
+			return {}
 	}
 }
 
@@ -337,12 +366,15 @@ export const useProviderModels = (apiConfiguration?: ProviderSettings) => {
 		syntheticApiKey: apiConfiguration?.syntheticApiKey, // kilocode_change
 	})
 
+	const options = getOptionsForProvider(provider, apiConfiguration)
+
 	const { models, defaultModel } =
 		apiConfiguration && typeof routerModels.data !== "undefined"
 			? getModelsByProvider({
 					provider,
 					routerModels: routerModels.data,
 					kilocodeDefaultModel,
+					options,
 				})
 			: FALLBACK_MODELS
 


### PR DESCRIPTION
## Context

Z.AI supports different models depending on which _Entrypoint_ is selected in the API _Provider_ configuration:

- International Coding (https://api.z.ai/api/coding/paas/v4)
- China Coding (https://open.bigmodel.cn/api/coding/paas/v4)

This code change allows a user to select the Z.AI model from the model selection list below the prompt / chat text area, based on the Entrypoint configured.

Currently the model selection list below the prompt / chat text area only shows the one model selected during configuration, it does not contains the full list of supported Z.AI models for the configured Entrypoint.

## Implementation

I implemented this change in a similar way to how the `getProviderDefaultModelId` function in `packages/types/src/providers/index.ts` handles the Z.AI models. It adds an `options` argument to the function:
```
options: { isChina?: boolean } = { isChina: false },
```
And then uses the options to return the correct default model:
```
case "zai":
	return options?.isChina ? mainlandZAiDefaultModelId : internationalZAiDefaultModelId
```

In my code I created a new function called `getOptionsForProvider` which returns the `options` based on the ProviderSettings of the selected Provider:
```
case "zai":
	return { isChina: apiConfiguration?.zaiApiLine === "china_coding" }

```

`useProviderModels` then calls `getModelsByProvider` passing in the `options` to determine which list of models should be returned:
```
case "zai": {
	if (options.isChina) {
		return {
			models: mainlandZAiModels,
			defaultModel: mainlandZAiDefaultModelId,
		}
	} else {
		return {
			models: internationalZAiModels,
			defaultModel: internationalZAiDefaultModelId,
		}
	}
}
```

## Screenshots

Provider configuration for the **International** _Entrypoint_ (no changes to this code)
<img width="683" height="723" alt="Z.AI International Configuration" src="https://github.com/user-attachments/assets/eb501ec6-3d02-4159-bbda-4ca40c9b6082" />

Select the **International provider** (no changes to this code)
<img width="380" height="179" alt="Z.AI International" src="https://github.com/user-attachments/assets/adde9506-3827-4883-84fa-979bc8ee3704" />

The list of models available for the **International provider** (illustrates the code changes)
<img width="373" height="474" alt="Z.AI International Models" src="https://github.com/user-attachments/assets/d432fdfa-8d3b-478b-b99f-05a2450dbd7a" />

Provider configuration for the **China** _Entrypoint_ (no changes to this code)
<img width="672" height="730" alt="Z.AI China Configuration" src="https://github.com/user-attachments/assets/321b7bc9-b2bb-4b04-9aa6-d704c111bb71" />

Select the **China provider** (no changes to this code)
<img width="375" height="180" alt="Z.AI China" src="https://github.com/user-attachments/assets/025bddaa-2a81-4436-8783-fd423987c994" />

The list of models available for the **China provider** (illustrates the code changes)
<img width="379" height="299" alt="Z.AI China Models" src="https://github.com/user-attachments/assets/72544619-620b-44e2-9f20-6dac011dfb29" />

## How to Test

- Configure two new Provider Profiles:
  - Z.AI International
    - Profile Type: Chat
    - API Provider: Z.ai
    - Z.AI Entrypoint: International Coding
  - Z.AI China
    - Profile Type: Chat
    - API Provider: Z.ai
    - Z.AI Entrypoint: China Coding
- Select the new profile below the prompt / chat text area
- Change the Model selection
- Verify that you are receiving responses from the Z.AI provider

I have verified that selecting a different model does in fact pass the new model to Z.AI
<img width="368" height="700" alt="Z.AI Testing Model Change" src="https://github.com/user-attachments/assets/b3ddde96-caad-4ea2-b0c2-940e424e10f7" />

## Get in Touch

Discord handle: alvin_50005