### PR TITLE
fix: Adjust handling of thinking blocks in message filtering

### DIFF
--- a/src/api/providers/anthropic-vertex.ts
+++ b/src/api/providers/anthropic-vertex.ts
@@ -74,7 +74,9 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 		} = this.getModel()
 
 		// Filter out non-Anthropic blocks (reasoning, thoughtSignature, etc.) before sending to the API
-		const sanitizedMessages = filterNonAnthropicBlocks(messages)
+		// kilocode_change start
+		const sanitizedMessages = filterNonAnthropicBlocks(messages, thinking)
+		// kilocode_change end
 
 		/**
 		 * Vertex API has specific limitations for prompt caching:

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -55,8 +55,12 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 			verbosity, // kilocode_change
 		} = this.getModel()
 
+		// kilocode_change start
 		// Filter out non-Anthropic blocks (reasoning, thoughtSignature, etc.) before sending to the API
-		const sanitizedMessages = filterNonAnthropicBlocks(messages)
+		// When thinking is disabled (undefined), also strip thinking/redacted_thinking blocks from history
+		// to prevent the error: "When thinking is disabled, an 'assistant' message cannot contain 'thinking'"
+		const sanitizedMessages = filterNonAnthropicBlocks(messages, thinking)
+		// kilocode_change end
 		const apiModelId = this.options.anthropicDeploymentName?.trim() || modelId // kilocode_change
 
 		// Add 1M context beta flag if enabled for Claude Sonnet 4 and 4.5

--- a/src/api/transform/anthropic-filter.ts
+++ b/src/api/transform/anthropic-filter.ts
@@ -15,6 +15,7 @@ export const VALID_ANTHROPIC_BLOCK_TYPES = new Set([
 	"document",
 ])
 
+// kilocode_change start
 /**
  * Filters out non-Anthropic content blocks from messages before sending to Anthropic/Vertex API.
  * Uses an allowlist approach - only blocks with types in VALID_ANTHROPIC_BLOCK_TYPES are kept.
@@ -22,10 +23,26 @@ export const VALID_ANTHROPIC_BLOCK_TYPES = new Set([
  * - Internal "reasoning" blocks (Roo Code's internal representation)
  * - Gemini's "thoughtSignature" blocks (encrypted reasoning continuity tokens)
  * - Any other unknown block types
+ *
+ * @param messages - The messages to filter
+ * @param thinking - The Anthropic thinking config. When undefined (thinking disabled),
+ *                   thinking/redacted_thinking blocks are stripped from history to prevent
+ *                   the API error: "When thinking is disabled, an 'assistant' message cannot contain 'thinking'"
  */
 export function filterNonAnthropicBlocks(
 	messages: Anthropic.Messages.MessageParam[],
+	thinking?: Anthropic.Messages.ThinkingConfigParam,
 ): Anthropic.Messages.MessageParam[] {
+	// Build the set of allowed block types based on whether thinking is enabled
+	const allowedTypes = new Set(VALID_ANTHROPIC_BLOCK_TYPES)
+
+	// When thinking is undefined (disabled), remove thinking blocks from the allowlist
+	if (thinking === undefined) {
+		allowedTypes.delete("thinking")
+		allowedTypes.delete("redacted_thinking")
+	}
+	// kilocode_change end
+
 	return messages
 		.map((message) => {
 			if (typeof message.content === "string") {
@@ -35,7 +52,9 @@ export function filterNonAnthropicBlocks(
 			const filteredContent = message.content.filter((block) => {
 				const blockType = (block as { type: string }).type
 				// Only keep block types that Anthropic recognizes
-				return VALID_ANTHROPIC_BLOCK_TYPES.has(blockType)
+				// kilocode_change start
+				return allowedTypes.has(blockType)
+				// kilocode_change end
 			})
 
 			// If all content was filtered out, return undefined to filter the message later


### PR DESCRIPTION
## Context

Occasionally when using the anthropic provider, users report running into the error:

> "When thinking is disabled, an 'assistant' message in the final position cannot contain 'thinking'. To use thinking blocks, enable 'thinking' in your request."
> ... repeats...

## Implementation

- Updated filterNonAnthropicBlocks to conditionally strip thinking and redacted_thinking blocks based on the thinking parameter.
- Added tests to verify behavior when thinking is enabled and disabled.

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
