### PR TITLE
 Agent Manager Permission-Aware Mode

### DIFF
--- a/cli/src/commands/__tests__/theme.test.ts
+++ b/cli/src/commands/__tests__/theme.test.ts
@@ -97,162 +97,20 @@ describe("/theme command", () => {
 		refreshTerminalMock = vi.fn().mockResolvedValue(undefined)
 
 		// Create mock config
-		mockConfig = {
-			version: "1.0.0",
-			mode: "code",
-			telemetry: true,
-			provider: "test-provider",
-			providers: [],
-			customThemes: {
-				"custom-theme": mockTheme,
-			},
-		}
-
-		// Mock config loading
-		vi.doMock("../../config/persistence.js", () => ({
-			loadConfig: vi.fn().mockResolvedValue({
-				config: {
-					customThemes: {
-						"custom-theme": mockTheme,
-					},
-				},
-			}),
-		}))
-
-		// Mock the constants/themes/index.js functions
-		vi.doMock("../../constants/themes/index.js", () => ({
-			getAvailableThemes: vi.fn(() => [
-				"alpha",
-				"dark",
-				"dracula",
-				"github-dark",
-				"light",
-				"github-light",
-				"custom-theme",
-			]),
-			getThemeById: vi.fn((id: string) => {
-				const themes: Record<string, Theme> = {
-					dark: {
-						id: "dark",
-						name: "Dark",
-						type: "dark",
-						brand: { primary: "#3b82f6", secondary: "#1d4ed8" },
-						semantic: {
-							success: "#4ade80",
-							error: "#f87171",
-							warning: "#fbbf24",
-							info: "#60a5fa",
-							neutral: "#6b7280",
-						},
-						interactive: {
-							prompt: "#3b82f6",
-							selection: "#1e40af",
-							hover: "#2563eb",
-							disabled: "#9ca3af",
-							focus: "#1d4ed8",
-						},
-						messages: { user: "#10b981", assistant: "#8b5cf6", system: "#f59e0b", error: "#ef4444" },
-						actions: { approve: "#10b981", reject: "#ef4444", cancel: "#6b7280", pending: "#f59e0b" },
-						code: {
-							addition: "#10b981",
-							deletion: "#ef4444",
-							modification: "#f59e0b",
-							context: "#6b7280",
-							lineNumber: "#9ca3af",
-						},
-						ui: {
-							border: { default: "#374151", active: "#3b82f6", warning: "#f59e0b", error: "#ef4444" },
-							text: { primary: "#f9fafb", secondary: "#d1d5db", dimmed: "#9ca3af", highlight: "#fbbf24" },
-							background: { default: "#111827", elevated: "#1f2937" },
-						},
-						status: { online: "#10b981", offline: "#6b7280", busy: "#f59e0b", idle: "#94a3b8" },
-					},
-					light: {
-						id: "light",
-						name: "Light",
-						type: "light",
-						brand: { primary: "#3b82f6", secondary: "#1d4ed8" },
-						semantic: {
-							success: "#4ade80",
-							error: "#f87171",
-							warning: "#fbbf24",
-							info: "#60a5fa",
-							neutral: "#6b7280",
-						},
-						interactive: {
-							prompt: "#3b82f6",
-							selection: "#1e40af",
-							hover: "#2563eb",
-							disabled: "#9ca3af",
-							focus: "#1d4ed8",
-						},
-						messages: { user: "#10b981", assistant: "#8b5cf6", system: "#f59e0b", error: "#ef4444" },
-						actions: { approve: "#10b981", reject: "#ef4444", cancel: "#6b7280", pending: "#f59e0b" },
-						code: {
-							addition: "#10b981",
-							deletion: "#ef4444",
-							modification: "#f59e0b",
-							context: "#6b7280",
-							lineNumber: "#9ca3af",
-						},
-						ui: {
-							border: { default: "#e5e7eb", active: "#3b82f6", warning: "#f59e0b", error: "#ef4444" },
-							text: { primary: "#111827", secondary: "#6b7280", dimmed: "#9ca3af", highlight: "#fbbf24" },
-							background: { default: "#ffffff", elevated: "#f9fafb" },
-						},
-						status: { online: "#10b981", offline: "#6b7280", busy: "#f59e0b", idle: "#94a3b8" },
-					},
+			mockConfig = {
+				version: "1.0.0",
+				mode: "code",
+				telemetry: true,
+				provider: "test-provider",
+				providers: [],
+				customThemes: {
 					"custom-theme": mockTheme,
-				}
-				return (
-					themes[id] || {
-						id: "unknown",
-						name: "Unknown Theme",
-						type: "dark",
-						brand: { primary: "#000000", secondary: "#000000" },
-						semantic: {
-							success: "#000000",
-							error: "#000000",
-							warning: "#000000",
-							info: "#000000",
-							neutral: "#000000",
-						},
-						interactive: {
-							prompt: "#000000",
-							selection: "#000000",
-							hover: "#000000",
-							disabled: "#000000",
-							focus: "#000000",
-						},
-						messages: { user: "#000000", assistant: "#000000", system: "#000000", error: "#000000" },
-						actions: { approve: "#000000", reject: "#000000", cancel: "#000000", pending: "#000000" },
-						code: {
-							addition: "#000000",
-							deletion: "#000000",
-							modification: "#000000",
-							context: "#000000",
-							lineNumber: "#000000",
-						},
-						ui: {
-							border: { default: "#000000", active: "#000000", warning: "#000000", error: "#000000" },
-							text: { primary: "#000000", secondary: "#000000", dimmed: "#000000", highlight: "#000000" },
-							background: { default: "#000000", elevated: "#000000" },
-						},
-						status: { online: "#000000", offline: "#000000", busy: "#000000", idle: "#000000" },
-					}
-				)
-			}),
-			isValidThemeId: vi.fn(() => true),
-		}))
+				},
+			}
 
-		// Mock getBuiltinThemeIds
-		vi.doMock("../../constants/themes/custom.js", () => ({
-			getBuiltinThemeIds: vi.fn(() => ["alpha", "dark", "dracula", "github-dark", "light", "github-light"]),
-		}))
-
-		mockContext = createMockContext({
-			input: "/theme",
-			config: mockConfig,
+			mockContext = createMockContext({
+				input: "/theme",
+				config: mockConfig,
 			addMessage: addMessageMock,
 			setTheme: setThemeMock,
 			refreshTerminal: refreshTerminalMock,

--- a/cli/src/config/__tests__/auto-approval.test.ts
+++ b/cli/src/config/__tests__/auto-approval.test.ts
@@ -6,7 +6,7 @@ describe("Auto Approval Configuration", () => {
 	describe("DEFAULT_AUTO_APPROVAL", () => {
 		it("should have correct default values", () => {
 			expect(DEFAULT_AUTO_APPROVAL).toEqual({
-				enabled: true,
+				enabled: false, // Safe default: auto-approval disabled until explicitly enabled
 				read: {
 					enabled: true,
 					outside: false,
@@ -47,8 +47,10 @@ describe("Auto Approval Configuration", () => {
 			})
 		})
 
-		it("should have global enabled set to true by default", () => {
-			expect(DEFAULT_AUTO_APPROVAL.enabled).toBe(true)
+		it("should have global enabled set to false by default for safety", () => {
+			// Safe default: auto-approval is disabled until explicitly enabled
+			// This prevents accidental auto-approval when config isn't loaded yet
+			expect(DEFAULT_AUTO_APPROVAL.enabled).toBe(false)
 		})
 
 		it("should have safe defaults for write operations", () => {

--- a/cli/src/config/__tests__/env-config-json.test.ts
+++ b/cli/src/config/__tests__/env-config-json.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { buildConfigFromEnv, applyEnvOverrides } from "../env-config.js"
+import { ENV_VARS } from "../env-utils.js"
+import type { CLIConfig, AutoApprovalConfig } from "../types.js"
+
+describe("env-config JSON auto-approval", () => {
+	const originalEnv = process.env
+
+	beforeEach(() => {
+		// Reset environment for each test
+		process.env = { ...originalEnv }
+	})
+
+	afterEach(() => {
+		process.env = originalEnv
+	})
+
+	describe("KILO_AUTO_APPROVAL_JSON parsing", () => {
+		const baseConfig: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "kilocode",
+			providers: [{ id: "kilocode", provider: "kilocode" }],
+			autoApproval: {
+				enabled: false,
+				read: { enabled: false },
+				write: { enabled: false },
+			},
+		}
+
+		it("parses valid JSON from KILO_AUTO_APPROVAL_JSON", () => {
+			const jsonConfig: AutoApprovalConfig = {
+				enabled: true,
+				read: { enabled: true, outside: true },
+				write: { enabled: true, outside: false, protected: true },
+				browser: { enabled: true },
+				mcp: { enabled: false },
+				execute: { enabled: true, allowed: ["npm test"], denied: ["rm"] },
+			}
+
+			process.env[ENV_VARS.AUTO_APPROVAL_JSON] = JSON.stringify(jsonConfig)
+
+			const result = applyEnvOverrides(baseConfig)
+
+			expect(result.autoApproval).toEqual(jsonConfig)
+		})
+
+		it("ignores individual env vars when JSON is set", () => {
+			const jsonConfig: AutoApprovalConfig = {
+				enabled: true,
+				read: { enabled: true },
+			}
+
+			process.env[ENV_VARS.AUTO_APPROVAL_JSON] = JSON.stringify(jsonConfig)
+			// These should be ignored
+			process.env[ENV_VARS.AUTO_APPROVAL_ENABLED] = "false"
+			process.env[ENV_VARS.AUTO_APPROVAL_READ_ENABLED] = "false"
+
+			const result = applyEnvOverrides(baseConfig)
+
+			// Should use JSON config, not individual env vars
+			expect(result.autoApproval?.enabled).toBe(true)
+			expect(result.autoApproval?.read?.enabled).toBe(true)
+		})
+
+		it("falls back to individual env vars when JSON is not set", () => {
+			process.env[ENV_VARS.AUTO_APPROVAL_ENABLED] = "true"
+			process.env[ENV_VARS.AUTO_APPROVAL_READ_ENABLED] = "true"
+
+			const result = applyEnvOverrides(baseConfig)
+
+			expect(result.autoApproval?.enabled).toBe(true)
+			expect(result.autoApproval?.read?.enabled).toBe(true)
+		})
+
+		it("falls back to individual env vars when JSON is invalid", () => {
+			process.env[ENV_VARS.AUTO_APPROVAL_JSON] = "not valid json"
+			process.env[ENV_VARS.AUTO_APPROVAL_ENABLED] = "true"
+
+			const result = applyEnvOverrides(baseConfig)
+
+			// Should fall back to individual env vars
+			expect(result.autoApproval?.enabled).toBe(true)
+		})
+
+		it("handles empty JSON string gracefully", () => {
+			process.env[ENV_VARS.AUTO_APPROVAL_JSON] = ""
+			process.env[ENV_VARS.AUTO_APPROVAL_ENABLED] = "true"
+
+			const result = applyEnvOverrides(baseConfig)
+
+			// Empty string should fall back to individual env vars
+			expect(result.autoApproval?.enabled).toBe(true)
+		})
+
+		it("preserves all auto-approval fields from JSON", () => {
+			const fullConfig: AutoApprovalConfig = {
+				enabled: true,
+				read: { enabled: true, outside: true },
+				write: { enabled: true, outside: true, protected: true },
+				browser: { enabled: true },
+				retry: { enabled: true, delay: 15 },
+				mcp: { enabled: true },
+				mode: { enabled: true },
+				subtasks: { enabled: true },
+				execute: { enabled: true, allowed: ["npm", "pnpm"], denied: ["rm -rf"] },
+				question: { enabled: false, timeout: 30000 },
+				todo: { enabled: true },
+			}
+
+			process.env[ENV_VARS.AUTO_APPROVAL_JSON] = JSON.stringify(fullConfig)
+
+			const result = applyEnvOverrides(baseConfig)
+
+			expect(result.autoApproval).toEqual(fullConfig)
+		})
+	})
+
+	describe("buildConfigFromEnv with JSON", () => {
+		it("uses JSON config when building from env", () => {
+			const jsonConfig: AutoApprovalConfig = {
+				enabled: true,
+				read: { enabled: true },
+				write: { enabled: false },
+			}
+
+			// Set up minimal required env vars for buildConfigFromEnv to work
+			process.env[ENV_VARS.PROVIDER_TYPE] = "kilocode"
+			process.env["KILOCODE_TOKEN"] = "test-token"
+			process.env[ENV_VARS.AUTO_APPROVAL_JSON] = JSON.stringify(jsonConfig)
+
+			const result = buildConfigFromEnv()
+
+			expect(result).not.toBeNull()
+			expect(result?.autoApproval).toEqual(jsonConfig)
+		})
+	})
+})

--- a/cli/src/config/defaults.ts
+++ b/cli/src/config/defaults.ts
@@ -2,10 +2,12 @@ import type { CLIConfig, AutoApprovalConfig } from "./types.js"
 
 /**
  * Default auto approval configuration
- * Matches the defaults from the webview settings
+ * Safe defaults: auto-approval is disabled by default.
+ * When running via Agent Manager, the extension passes its config via KILO_AUTO_APPROVAL_JSON env var.
+ * When running standalone CLI, user must explicitly enable auto-approval in config.
  */
 export const DEFAULT_AUTO_APPROVAL: AutoApprovalConfig = {
-	enabled: true,
+	enabled: false,
 	read: {
 		enabled: true,
 		outside: false,

--- a/cli/src/config/env-utils.ts
+++ b/cli/src/config/env-utils.ts
@@ -15,6 +15,9 @@ export const ENV_VARS = {
 	PROVIDER_TYPE: "KILO_PROVIDER_TYPE",
 
 	// Auto-approval settings
+	// JSON format for complete config (takes precedence when set)
+	AUTO_APPROVAL_JSON: "KILO_AUTO_APPROVAL_JSON",
+	// Individual settings (used when JSON not set)
 	AUTO_APPROVAL_ENABLED: "KILO_AUTO_APPROVAL_ENABLED",
 	AUTO_APPROVAL_READ_ENABLED: "KILO_AUTO_APPROVAL_READ_ENABLED",
 	AUTO_APPROVAL_READ_OUTSIDE: "KILO_AUTO_APPROVAL_READ_OUTSIDE",
@@ -59,6 +62,11 @@ export const SPECIFIC_ENV_VARS = new Set([
 	ENV_VARS.MODE,
 	ENV_VARS.TELEMETRY,
 	ENV_VARS.THEME,
+	// Internal flags (not provider fields)
+	"KILO_CLI_MODE",
+	"KILO_EPHEMERAL_MODE",
+	"KILO_PLATFORM",
+	"KILO_TELEMETRY_DEBUG",
 ])
 
 /**

--- a/cli/src/state/atoms/__tests__/config.test.ts
+++ b/cli/src/state/atoms/__tests__/config.test.ts
@@ -4,10 +4,14 @@ import { loadConfigAtom, configAtom, configValidationAtom } from "../config.js"
 import * as persistence from "../../../config/persistence.js"
 
 // Mock the persistence module
-vi.mock("../../../config/persistence.js", () => ({
-	loadConfig: vi.fn(),
-	saveConfig: vi.fn(),
-}))
+vi.mock("../../../config/persistence.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../../config/persistence.js")>()
+	return {
+		...actual,
+		loadConfig: vi.fn(),
+		saveConfig: vi.fn(),
+	}
+})
 
 describe("loadConfigAtom", () => {
 	beforeEach(() => {

--- a/cli/src/state/atoms/__tests__/modelValidation.test.ts
+++ b/cli/src/state/atoms/__tests__/modelValidation.test.ts
@@ -21,9 +21,13 @@ vi.mock("../../../services/logs.js", () => ({
 	},
 }))
 
-vi.mock("../../../config/persistence.js", () => ({
-	saveConfig: vi.fn().mockResolvedValue(undefined),
-}))
+vi.mock("../../../config/persistence.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../../config/persistence.js")>()
+	return {
+		...actual,
+		saveConfig: vi.fn().mockResolvedValue(undefined),
+	}
+})
 
 vi.mock("../../../ui/utils/messages.js", () => ({
 	generateModelFallbackMessage: vi.fn().mockReturnValue({

--- a/cli/src/state/atoms/config.ts
+++ b/cli/src/state/atoms/config.ts
@@ -473,6 +473,29 @@ export const updateAutoApprovalAtom = atom(
 )
 
 /**
+ * Replace the auto approval configuration (used by Agent Manager permission sync).
+ */
+export const setAutoApprovalConfigAtom = atom(null, async (get, set, autoApproval: AutoApprovalConfig) => {
+	const config = get(configAtom)
+
+	const updatedConfig = {
+		...config,
+		autoApproval,
+	}
+
+	set(configAtom, updatedConfig)
+	await set(saveConfigAtom, updatedConfig)
+
+	logs.info("Auto approval configuration replaced", "ConfigAtoms")
+
+	// Import from config-sync to avoid circular dependency
+	const { syncConfigToExtensionEffectAtom } = await import("./config-sync.js")
+
+	// Trigger sync to extension after permission update
+	await set(syncConfigToExtensionEffectAtom)
+})
+
+/**
  * Action atom to update a specific auto approval setting
  */
 export const updateAutoApprovalSettingAtom = atom(

--- a/src/core/kilocode/agent-manager/CliArgsBuilder.ts
+++ b/src/core/kilocode/agent-manager/CliArgsBuilder.ts
@@ -2,18 +2,29 @@ export interface BuildCliArgsOptions {
 	parallelMode?: boolean
 	sessionId?: string
 	existingBranch?: string
+	/**
+	 * When true, adds --yolo flag for auto-approval of all tool operations.
+	 * By default (when undefined/false), the CLI runs in permission-aware mode,
+	 * respecting the extension's auto-approval settings.
+	 */
+	yolo?: boolean
 }
 
 /**
  * Builds CLI arguments for spawning kilocode agent processes.
  * Uses --json-io for bidirectional communication via stdin/stdout.
- * Runs in interactive mode - approvals are handled via the JSON-IO protocol.
+ * Runs in permission-aware mode by default - approvals are handled via the JSON-IO protocol.
  */
 export function buildCliArgs(workspace: string, prompt: string, options?: BuildCliArgsOptions): string[] {
 	// --json-io: enables bidirectional JSON communication via stdin/stdout
 	// Note: --json (without -io) exists for CI/CD read-only mode but isn't used here
-	// --yolo: auto-approve tool uses (file reads, writes, commands, etc.)
-	const args = ["--json-io", "--yolo", `--workspace=${workspace}`]
+	const args = ["--json-io", `--workspace=${workspace}`]
+
+	// Only add --yolo when explicitly requested
+	// By default, the CLI runs in permission-aware mode, respecting extension settings
+	if (options?.yolo) {
+		args.push("--yolo")
+	}
 
 	if (options?.parallelMode) {
 		args.push("--parallel")

--- a/src/core/kilocode/agent-manager/CliSessionLauncher.ts
+++ b/src/core/kilocode/agent-manager/CliSessionLauncher.ts
@@ -6,6 +6,7 @@ import { getRemoteUrl } from "../../../services/code-index/managed/git-utils"
 import { normalizeGitUrl } from "./normalizeGitUrl"
 import { buildProviderEnvOverrides } from "./providerEnvMapper"
 import type { ProviderSettings } from "@roo-code/types"
+import type { AutoApprovalEnvConfig } from "./autoApprovalEnv"
 
 /**
  * Options for spawning a CLI session
@@ -16,6 +17,17 @@ export interface SpawnOptions {
 	gitUrl?: string
 	existingBranch?: string
 	sessionId?: string
+	/**
+	 * Auto-approval configuration to pass to CLI.
+	 * When provided, the CLI runs in permission-aware mode.
+	 * When omitted, the CLI uses its default behavior.
+	 */
+	autoApprovalConfig?: AutoApprovalEnvConfig
+	/**
+	 * When true, adds --yolo flag for auto-approval of ALL tool operations.
+	 * This corresponds to the extension's "YOLO Mode" setting.
+	 */
+	yolo?: boolean
 }
 
 /**

--- a/src/core/kilocode/agent-manager/__tests__/CliArgsBuilder.test.ts
+++ b/src/core/kilocode/agent-manager/__tests__/CliArgsBuilder.test.ts
@@ -13,6 +13,32 @@ describe("CliArgsBuilder", () => {
 		expect(args).toContain(prompt)
 	})
 
+	describe("yolo mode", () => {
+		it("does NOT include --yolo by default (permission-aware mode)", () => {
+			const args = buildCliArgs(workspace, prompt)
+
+			expect(args).not.toContain("--yolo")
+		})
+
+		it("includes --yolo only when explicitly requested via options", () => {
+			const args = buildCliArgs(workspace, prompt, { yolo: true })
+
+			expect(args).toContain("--yolo")
+		})
+
+		it("does not include --yolo when yolo option is false", () => {
+			const args = buildCliArgs(workspace, prompt, { yolo: false })
+
+			expect(args).not.toContain("--yolo")
+		})
+
+		it("does not include --yolo when yolo option is undefined", () => {
+			const args = buildCliArgs(workspace, prompt, { parallelMode: true })
+
+			expect(args).not.toContain("--yolo")
+		})
+	})
+
 	it("adds --parallel flag when parallelMode is true", () => {
 		const args = buildCliArgs(workspace, prompt, { parallelMode: true })
 

--- a/src/core/kilocode/agent-manager/__tests__/CliProcessHandler.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/CliProcessHandler.spec.ts
@@ -90,13 +90,14 @@ describe("CliProcessHandler", () => {
 	})
 
 	describe("spawnProcess", () => {
-		it("spawns a CLI process with correct arguments (yolo mode for testing)", () => {
+		it("spawns a CLI process with correct arguments (permission-aware mode by default)", () => {
 			const onCliEvent = vi.fn()
 			handler.spawnProcess("/path/to/kilocode", "/workspace", "test prompt", undefined, onCliEvent)
 
+			// By default, --yolo is NOT included - runs in permission-aware mode
 			expect(spawnMock).toHaveBeenCalledWith(
 				"/path/to/kilocode",
-				["--json-io", "--yolo", "--workspace=/workspace", "test prompt"],
+				["--json-io", "--workspace=/workspace", "test prompt"],
 				expect.objectContaining({
 					cwd: "/workspace",
 					stdio: ["pipe", "pipe", "pipe"],

--- a/src/core/kilocode/agent-manager/__tests__/autoApprovalEnv.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/autoApprovalEnv.spec.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from "vitest"
+import {
+	extractAutoApprovalConfig,
+	buildAutoApprovalEnv,
+	KILO_AUTO_APPROVAL_ENV_KEY,
+	type AutoApprovalEnvConfig,
+} from "../autoApprovalEnv"
+
+describe("autoApprovalEnv", () => {
+	describe("extractAutoApprovalConfig", () => {
+		it("extracts enabled state from autoApprovalEnabled", () => {
+			const config = extractAutoApprovalConfig({
+				autoApprovalEnabled: true,
+				alwaysAllowReadOnly: false,
+				alwaysAllowReadOnlyOutsideWorkspace: false,
+				alwaysAllowWrite: false,
+				alwaysAllowWriteOutsideWorkspace: false,
+				alwaysAllowWriteProtected: false,
+				alwaysAllowBrowser: false,
+				alwaysApproveResubmit: false,
+				requestDelaySeconds: 10,
+				alwaysAllowMcp: false,
+				alwaysAllowModeSwitch: false,
+				alwaysAllowSubtasks: false,
+				alwaysAllowExecute: false,
+				allowedCommands: [],
+				deniedCommands: [],
+				alwaysAllowFollowupQuestions: false,
+				followupAutoApproveTimeoutMs: 60000,
+				alwaysAllowUpdateTodoList: false,
+			})
+
+			expect(config.enabled).toBe(true)
+		})
+
+		it("maps read permissions correctly", () => {
+			const config = extractAutoApprovalConfig({
+				autoApprovalEnabled: true,
+				alwaysAllowReadOnly: true,
+				alwaysAllowReadOnlyOutsideWorkspace: true,
+				alwaysAllowWrite: false,
+				alwaysAllowWriteOutsideWorkspace: false,
+				alwaysAllowWriteProtected: false,
+				alwaysAllowBrowser: false,
+				alwaysApproveResubmit: false,
+				requestDelaySeconds: 10,
+				alwaysAllowMcp: false,
+				alwaysAllowModeSwitch: false,
+				alwaysAllowSubtasks: false,
+				alwaysAllowExecute: false,
+				allowedCommands: [],
+				deniedCommands: [],
+				alwaysAllowFollowupQuestions: false,
+				followupAutoApproveTimeoutMs: 60000,
+				alwaysAllowUpdateTodoList: false,
+			})
+
+			expect(config.read).toEqual({
+				enabled: true,
+				outside: true,
+			})
+		})
+
+		it("maps write permissions correctly", () => {
+			const config = extractAutoApprovalConfig({
+				autoApprovalEnabled: true,
+				alwaysAllowReadOnly: false,
+				alwaysAllowReadOnlyOutsideWorkspace: false,
+				alwaysAllowWrite: true,
+				alwaysAllowWriteOutsideWorkspace: true,
+				alwaysAllowWriteProtected: true,
+				alwaysAllowBrowser: false,
+				alwaysApproveResubmit: false,
+				requestDelaySeconds: 10,
+				alwaysAllowMcp: false,
+				alwaysAllowModeSwitch: false,
+				alwaysAllowSubtasks: false,
+				alwaysAllowExecute: false,
+				allowedCommands: [],
+				deniedCommands: [],
+				alwaysAllowFollowupQuestions: false,
+				followupAutoApproveTimeoutMs: 60000,
+				alwaysAllowUpdateTodoList: false,
+			})
+
+			expect(config.write).toEqual({
+				enabled: true,
+				outside: true,
+				protected: true,
+			})
+		})
+
+		it("maps execute permissions with allowed/denied commands", () => {
+			const config = extractAutoApprovalConfig({
+				autoApprovalEnabled: true,
+				alwaysAllowReadOnly: false,
+				alwaysAllowReadOnlyOutsideWorkspace: false,
+				alwaysAllowWrite: false,
+				alwaysAllowWriteOutsideWorkspace: false,
+				alwaysAllowWriteProtected: false,
+				alwaysAllowBrowser: false,
+				alwaysApproveResubmit: false,
+				requestDelaySeconds: 10,
+				alwaysAllowMcp: false,
+				alwaysAllowModeSwitch: false,
+				alwaysAllowSubtasks: false,
+				alwaysAllowExecute: true,
+				allowedCommands: ["npm test", "npm run build"],
+				deniedCommands: ["rm -rf"],
+				alwaysAllowFollowupQuestions: false,
+				followupAutoApproveTimeoutMs: 60000,
+				alwaysAllowUpdateTodoList: false,
+			})
+
+			expect(config.execute).toEqual({
+				enabled: true,
+				allowed: ["npm test", "npm run build"],
+				denied: ["rm -rf"],
+			})
+		})
+
+		it("maps retry settings correctly", () => {
+			const config = extractAutoApprovalConfig({
+				autoApprovalEnabled: true,
+				alwaysAllowReadOnly: false,
+				alwaysAllowReadOnlyOutsideWorkspace: false,
+				alwaysAllowWrite: false,
+				alwaysAllowWriteOutsideWorkspace: false,
+				alwaysAllowWriteProtected: false,
+				alwaysAllowBrowser: false,
+				alwaysApproveResubmit: true,
+				requestDelaySeconds: 30,
+				alwaysAllowMcp: false,
+				alwaysAllowModeSwitch: false,
+				alwaysAllowSubtasks: false,
+				alwaysAllowExecute: false,
+				allowedCommands: [],
+				deniedCommands: [],
+				alwaysAllowFollowupQuestions: false,
+				followupAutoApproveTimeoutMs: 60000,
+				alwaysAllowUpdateTodoList: false,
+			})
+
+			expect(config.retry).toEqual({
+				enabled: true,
+				delay: 30,
+			})
+		})
+
+		it("defaults undefined values to false/empty", () => {
+			const config = extractAutoApprovalConfig({
+				autoApprovalEnabled: undefined as unknown as boolean,
+				alwaysAllowReadOnly: undefined as unknown as boolean,
+				alwaysAllowReadOnlyOutsideWorkspace: undefined as unknown as boolean,
+				alwaysAllowWrite: undefined as unknown as boolean,
+				alwaysAllowWriteOutsideWorkspace: undefined as unknown as boolean,
+				alwaysAllowWriteProtected: undefined as unknown as boolean,
+				alwaysAllowBrowser: undefined as unknown as boolean,
+				alwaysApproveResubmit: undefined as unknown as boolean,
+				requestDelaySeconds: undefined as unknown as number,
+				alwaysAllowMcp: undefined as unknown as boolean,
+				alwaysAllowModeSwitch: undefined as unknown as boolean,
+				alwaysAllowSubtasks: undefined as unknown as boolean,
+				alwaysAllowExecute: undefined as unknown as boolean,
+				allowedCommands: undefined as unknown as string[],
+				deniedCommands: undefined as unknown as string[],
+				alwaysAllowFollowupQuestions: undefined as unknown as boolean,
+				followupAutoApproveTimeoutMs: undefined as unknown as number,
+				alwaysAllowUpdateTodoList: undefined as unknown as boolean,
+			})
+
+			expect(config.enabled).toBe(false)
+			expect(config.read?.enabled).toBe(false)
+			expect(config.write?.enabled).toBe(false)
+			expect(config.execute?.allowed).toEqual([])
+			expect(config.execute?.denied).toEqual([])
+		})
+	})
+
+	describe("buildAutoApprovalEnv", () => {
+		it("returns object with KILO_AUTO_APPROVAL_JSON key", () => {
+			const config: AutoApprovalEnvConfig = {
+				enabled: true,
+				read: { enabled: true },
+			}
+
+			const env = buildAutoApprovalEnv(config)
+
+			expect(env).toHaveProperty(KILO_AUTO_APPROVAL_ENV_KEY)
+		})
+
+		it("serializes config as JSON", () => {
+			const config: AutoApprovalEnvConfig = {
+				enabled: true,
+				read: { enabled: true, outside: false },
+				write: { enabled: false },
+			}
+
+			const env = buildAutoApprovalEnv(config)
+			const parsed = JSON.parse(env[KILO_AUTO_APPROVAL_ENV_KEY])
+
+			expect(parsed).toEqual(config)
+		})
+
+		it("handles complete config with all options", () => {
+			const config: AutoApprovalEnvConfig = {
+				enabled: true,
+				read: { enabled: true, outside: true },
+				write: { enabled: true, outside: true, protected: false },
+				browser: { enabled: true },
+				retry: { enabled: true, delay: 15 },
+				mcp: { enabled: true },
+				mode: { enabled: true },
+				subtasks: { enabled: true },
+				execute: { enabled: true, allowed: ["npm"], denied: ["rm"] },
+				question: { enabled: false, timeout: 30000 },
+				todo: { enabled: true },
+			}
+
+			const env = buildAutoApprovalEnv(config)
+			const parsed = JSON.parse(env[KILO_AUTO_APPROVAL_ENV_KEY])
+
+			expect(parsed).toEqual(config)
+		})
+	})
+
+	describe("KILO_AUTO_APPROVAL_ENV_KEY", () => {
+		it("has correct value", () => {
+			expect(KILO_AUTO_APPROVAL_ENV_KEY).toBe("KILO_AUTO_APPROVAL_JSON")
+		})
+	})
+})

--- a/src/core/kilocode/agent-manager/autoApprovalEnv.ts
+++ b/src/core/kilocode/agent-manager/autoApprovalEnv.ts
@@ -1,0 +1,110 @@
+/**
+ * Helper functions for passing auto-approval configuration to CLI processes
+ * via environment variables.
+ *
+ * This enables Agent Manager sessions to respect the same permission settings
+ * as the main sidebar, rather than always running in YOLO mode.
+ */
+
+import type { ExtensionState } from "../../../shared/ExtensionMessage"
+
+/**
+ * Environment variable name for passing auto-approval config to CLI
+ */
+export const KILO_AUTO_APPROVAL_ENV_KEY = "KILO_AUTO_APPROVAL_JSON"
+
+/**
+ * Auto-approval configuration structure that matches CLI's AutoApprovalConfig type
+ */
+export interface AutoApprovalEnvConfig {
+	enabled: boolean
+	read?: { enabled?: boolean; outside?: boolean }
+	write?: { enabled?: boolean; outside?: boolean; protected?: boolean }
+	browser?: { enabled?: boolean }
+	retry?: { enabled?: boolean; delay?: number }
+	mcp?: { enabled?: boolean }
+	mode?: { enabled?: boolean }
+	subtasks?: { enabled?: boolean }
+	execute?: { enabled?: boolean; allowed?: string[]; denied?: string[] }
+	question?: { enabled?: boolean; timeout?: number }
+	todo?: { enabled?: boolean }
+}
+
+/**
+ * Extract auto-approval configuration from extension state.
+ * This maps the extension's state properties to the CLI's config format.
+ */
+export function extractAutoApprovalConfig(
+	state: Pick<
+		ExtensionState,
+		| "autoApprovalEnabled"
+		| "alwaysAllowReadOnly"
+		| "alwaysAllowReadOnlyOutsideWorkspace"
+		| "alwaysAllowWrite"
+		| "alwaysAllowWriteOutsideWorkspace"
+		| "alwaysAllowWriteProtected"
+		| "alwaysAllowBrowser"
+		| "alwaysApproveResubmit"
+		| "requestDelaySeconds"
+		| "alwaysAllowMcp"
+		| "alwaysAllowModeSwitch"
+		| "alwaysAllowSubtasks"
+		| "alwaysAllowExecute"
+		| "allowedCommands"
+		| "deniedCommands"
+		| "alwaysAllowFollowupQuestions"
+		| "followupAutoApproveTimeoutMs"
+		| "alwaysAllowUpdateTodoList"
+	>,
+): AutoApprovalEnvConfig {
+	return {
+		enabled: state.autoApprovalEnabled ?? false,
+		read: {
+			enabled: state.alwaysAllowReadOnly ?? false,
+			outside: state.alwaysAllowReadOnlyOutsideWorkspace ?? false,
+		},
+		write: {
+			enabled: state.alwaysAllowWrite ?? false,
+			outside: state.alwaysAllowWriteOutsideWorkspace ?? false,
+			protected: state.alwaysAllowWriteProtected ?? false,
+		},
+		browser: {
+			enabled: state.alwaysAllowBrowser ?? false,
+		},
+		retry: {
+			enabled: state.alwaysApproveResubmit ?? false,
+			delay: state.requestDelaySeconds ?? 10,
+		},
+		mcp: {
+			enabled: state.alwaysAllowMcp ?? false,
+		},
+		mode: {
+			enabled: state.alwaysAllowModeSwitch ?? false,
+		},
+		subtasks: {
+			enabled: state.alwaysAllowSubtasks ?? false,
+		},
+		execute: {
+			enabled: state.alwaysAllowExecute ?? false,
+			allowed: state.allowedCommands ?? [],
+			denied: state.deniedCommands ?? [],
+		},
+		question: {
+			enabled: state.alwaysAllowFollowupQuestions ?? false,
+			timeout: state.followupAutoApproveTimeoutMs ?? 60000,
+		},
+		todo: {
+			enabled: state.alwaysAllowUpdateTodoList ?? false,
+		},
+	}
+}
+
+/**
+ * Build environment variables for passing auto-approval config to CLI.
+ * Returns an object with KILO_AUTO_APPROVAL_JSON set to the JSON-encoded config.
+ */
+export function buildAutoApprovalEnv(config: AutoApprovalEnvConfig): Record<string, string> {
+	return {
+		[KILO_AUTO_APPROVAL_ENV_KEY]: JSON.stringify(config),
+	}
+}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2339,7 +2339,7 @@ ${prompt}
 			enhancementApiConfigId,
 			commitMessageApiConfigId, // kilocode_change
 			terminalCommandApiConfigId, // kilocode_change
-			autoApprovalEnabled: autoApprovalEnabled ?? true,
+			autoApprovalEnabled: autoApprovalEnabled ?? (process.env.KILO_CLI_MODE === "true" ? false : true),
 			customModes,
 			experiments: experiments ?? experimentDefault,
 			mcpServers: this.mcpHub?.getAllServers() ?? [],
@@ -2641,7 +2641,7 @@ ${prompt}
 			autoPurgeLastRunTimestamp: stateValues.autoPurgeLastRunTimestamp,
 			// kilocode_change end
 			experiments: stateValues.experiments ?? experimentDefault,
-			autoApprovalEnabled: stateValues.autoApprovalEnabled ?? true,
+			autoApprovalEnabled: stateValues.autoApprovalEnabled ?? (process.env.KILO_CLI_MODE === "true" ? false : true),
 			customModes,
 			maxOpenTabsContext: stateValues.maxOpenTabsContext ?? 20,
 			maxWorkspaceFiles: stateValues.maxWorkspaceFiles ?? 200,

--- a/webview-ui/src/i18n/locales/en/agentManager.json
+++ b/webview-ui/src/i18n/locales/en/agentManager.json
@@ -70,7 +70,9 @@
 		"usingTool": "Using tool: **{{tool}}** {{details}}",
 		"expandOutput": "Expand output",
 		"collapseOutput": "Collapse output",
-		"copyCommand": "Copy command"
+		"copyCommand": "Copy command",
+		"approve": "Approve",
+		"reject": "Reject"
 	},
 	"chatInput": {
 		"autoMode": "Agent running in full-auto mode - no input allowed",


### PR DESCRIPTION
Summary

  This PR enables Agent Manager sessions to respect the same permission settings as the main sidebar, rather than always running in YOLO mode (auto-approving everything).

  Problem

  Previously, Agent Manager always spawned CLI processes with --yolo flag, causing all tool operations (file reads, writes, command execution, etc.) to be auto-approved without user consent. This was inconsistent with the sidebar behavior where users could configure granular auto-approval settings.

  A Discord user reported: "The agent manager ignores my permission settings - it just runs commands without asking for approval even though I have auto-approval disabled."

  Solution

  Extension Side:
  - Created autoApprovalEnv.ts with helper functions to extract auto-approval configuration from extension state and serialize it to JSON
  - Modified AgentManagerProvider.ts to read permission settings from extension state before spawning CLI
  - Modified CliProcessHandler.ts to pass autoApprovalConfig via KILO_AUTO_APPROVAL_JSON environment variable
  - Modified CliArgsBuilder.ts to NOT include --yolo by default - it's now only added when explicitly requested (YOLO mode enabled in extension)

  CLI Side:
  - Added KILO_AUTO_APPROVAL_JSON to env-utils.ts ENV_VARS
  - Added parseAutoApprovalFromJsonEnv() in env-config.ts to parse the JSON config
  - Modified applyAutoApprovalOverrides() to check for JSON config first (from Agent Manager) before falling back to individual env vars
  - Changed DEFAULT_AUTO_APPROVAL.enabled to false for safety - if config isn't loaded before first approval request, defaults to requiring approval

  How It Works

  1. Extension extracts config from state (autoApprovalEnabled, alwaysAllowReadOnly, alwaysAllowExecute, etc.)
  2. Config is serialized to JSON and passed via KILO_AUTO_APPROVAL_JSON env var
  3. CLI reads env var during config loading via applyEnvOverrides()
  4. CLI uses config in useApprovalMonitor hook to determine approval decisions
  5. If auto-approval disabled, CLI shows approval UI and waits for user input via JSON-IO bidirectional communication