### PR TITLE
Fix Agent Manager CLI detection/spawn on Windows and macOS

### DIFF
--- a/.changeset/quick-otters-sleep.md
+++ b/.changeset/quick-otters-sleep.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Agent Manager CLI detection and Windows spawn by sanitizing shell output and running .cmd via cmd.exe.

--- a/src/core/kilocode/agent-manager/CliPathResolver.ts
+++ b/src/core/kilocode/agent-manager/CliPathResolver.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path"
 import * as fs from "node:fs"
 import { execSync, spawnSync } from "node:child_process"
+import stripAnsi from "strip-ansi"
 import { fileExistsAtPath } from "../../../utils/fs"
 import { getLocalCliPath } from "./CliInstaller"
 
@@ -24,6 +25,33 @@ function getCaseInsensitive(target: NodeJS.ProcessEnv, key: string): string | un
 	const lowercaseKey = key.toLowerCase()
 	const equivalentKey = Object.keys(target).find((k) => k.toLowerCase() === lowercaseKey)
 	return equivalentKey ? target[equivalentKey] : target[key]
+}
+
+function stripShellControlCodes(value: string): string {
+	const withoutOsc = value.replace(/\x1b\][^\x07]*\x07/gs, "").replace(/\x1b\].*?\x1b\\/gs, "")
+	return stripAnsi(withoutOsc)
+}
+
+function extractAbsolutePath(line: string): string | null {
+	const trimmed = line.trim()
+	if (!trimmed) {
+		return null
+	}
+	if (path.isAbsolute(trimmed)) {
+		return trimmed
+	}
+	const parts = trimmed.split(/\s+/)
+	const last = parts[parts.length - 1]
+	return path.isAbsolute(last) ? last : null
+}
+
+function isExecutablePath(candidate: string): boolean {
+	try {
+		const stat = fs.statSync(candidate)
+		return stat.isFile()
+	} catch {
+		return false
+	}
 }
 
 /**
@@ -276,17 +304,25 @@ function findViaLoginShell(log?: (msg: string) => void): string | null {
 
 	try {
 		log?.(`Trying login shell lookup: ${cmd}`)
-		const result = execSync(cmd, {
+		const rawOutput = execSync(cmd, {
 			encoding: "utf-8",
 			timeout: 10000,
 			env: { ...process.env, HOME: process.env.HOME },
 		})
-			.split(/\r?\n/)[0]
-			?.trim()
+		const lines = stripShellControlCodes(rawOutput)
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter(Boolean)
 
-		if (result && !result.includes("not found")) {
-			log?.(`Found CLI via login shell: ${result}`)
-			return result
+		for (const line of lines) {
+			if (line.includes("not found")) {
+				continue
+			}
+			const candidate = extractAbsolutePath(line)
+			if (candidate && isExecutablePath(candidate)) {
+				log?.(`Found CLI via login shell: ${candidate}`)
+				return candidate
+			}
 		}
 	} catch (error) {
 		log?.(`Login shell lookup failed (this is normal if CLI not installed via version manager): ${error}`)
@@ -304,11 +340,10 @@ function getNpmPaths(log?: (msg: string) => void): string[] {
 	if (process.platform === "win32") {
 		const appData = process.env.APPDATA || ""
 		const localAppData = process.env.LOCALAPPDATA || ""
-		return [
-			appData ? path.join(appData, "npm", "kilocode.cmd") : "",
-			appData ? path.join(appData, "npm", "kilocode") : "",
-			localAppData ? path.join(localAppData, "npm", "kilocode.cmd") : "",
-		].filter(Boolean)
+		const basePaths = [appData, localAppData].filter(Boolean).map((base) => path.join(base, "npm", "kilocode"))
+		const pathExt = getCaseInsensitive(process.env, "PATHEXT") || ".COM;.EXE;.BAT;.CMD"
+		const extensions = pathExt.split(";").filter(Boolean)
+		return basePaths.flatMap((basePath) => extensions.map((ext) => `${basePath}${ext}`))
 	}
 
 	const paths = [

--- a/src/core/kilocode/agent-manager/CliPathResolver.ts
+++ b/src/core/kilocode/agent-manager/CliPathResolver.ts
@@ -1,9 +1,9 @@
 import * as path from "node:path"
 import * as fs from "node:fs"
 import { execSync, spawnSync } from "node:child_process"
-import stripAnsi from "strip-ansi"
 import { fileExistsAtPath } from "../../../utils/fs"
 import { getLocalCliPath } from "./CliInstaller"
+import { stripShellControlCodes } from "./ShellOutput"
 
 /**
  * Result of CLI discovery including optional shell environment.
@@ -25,11 +25,6 @@ function getCaseInsensitive(target: NodeJS.ProcessEnv, key: string): string | un
 	const lowercaseKey = key.toLowerCase()
 	const equivalentKey = Object.keys(target).find((k) => k.toLowerCase() === lowercaseKey)
 	return equivalentKey ? target[equivalentKey] : target[key]
-}
-
-function stripShellControlCodes(value: string): string {
-	const withoutOsc = value.replace(/\x1b\][^\x07]*\x07/gs, "").replace(/\x1b\].*?\x1b\\/gs, "")
-	return stripAnsi(withoutOsc)
 }
 
 function extractAbsolutePath(line: string): string | null {

--- a/src/core/kilocode/agent-manager/ShellOutput.ts
+++ b/src/core/kilocode/agent-manager/ShellOutput.ts
@@ -1,0 +1,33 @@
+import stripAnsi from "strip-ansi"
+
+export function stripOscSequences(value: string): string {
+	let result = ""
+	let index = 0
+
+	while (index < value.length) {
+		if (value[index] === "\x1b" && value[index + 1] === "]") {
+			index += 2
+			while (index < value.length) {
+				const ch = value[index]
+				if (ch === "\x07") {
+					index += 1
+					break
+				}
+				if (ch === "\x1b" && value[index + 1] === "\\") {
+					index += 2
+					break
+				}
+				index += 1
+			}
+			continue
+		}
+		result += value[index]
+		index += 1
+	}
+
+	return result
+}
+
+export function stripShellControlCodes(value: string): string {
+	return stripAnsi(stripOscSequences(value))
+}

--- a/src/core/kilocode/agent-manager/ShellOutput.ts
+++ b/src/core/kilocode/agent-manager/ShellOutput.ts
@@ -1,5 +1,6 @@
 import stripAnsi from "strip-ansi"
 
+// this strips any form os OSC sequences from a value coming from a terminal command execution
 export function stripOscSequences(value: string): string {
 	let result = ""
 	let index = 0

--- a/src/core/kilocode/agent-manager/__tests__/CliPathResolver.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/CliPathResolver.spec.ts
@@ -17,11 +17,18 @@ describe("findKilocodeCli", () => {
 			.fn()
 			.mockReturnValue({ stdout: `__KILO_PATH_START__${testShellPath}__KILO_PATH_END__\n` })
 		const execSyncMock = vi.fn().mockReturnValue("/Users/test/.nvm/versions/node/v20/bin/kilocode\n")
+		const statSyncMock = vi.fn().mockImplementation((filePath: string) => {
+			if (filePath === "/Users/test/.nvm/versions/node/v20/bin/kilocode") {
+				return { isFile: () => true }
+			}
+			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+		})
 
 		vi.doMock("node:child_process", () => ({ execSync: execSyncMock, spawnSync: spawnSyncMock }))
 		vi.doMock("../../../../utils/fs", () => ({ fileExistsAtPath: vi.fn().mockResolvedValue(false) }))
 		vi.doMock("node:fs", () => ({
 			existsSync: vi.fn().mockReturnValue(false),
+			statSync: statSyncMock,
 			promises: { stat: vi.fn().mockRejectedValue(new Error("ENOENT")) },
 		}))
 
@@ -53,6 +60,9 @@ describe("findKilocodeCli", () => {
 		vi.doMock("../../../../utils/fs", () => ({ fileExistsAtPath: vi.fn().mockResolvedValue(false) }))
 		vi.doMock("node:fs", () => ({
 			existsSync: vi.fn().mockReturnValue(false),
+			statSync: vi.fn().mockImplementation(() => {
+				throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+			}),
 			promises: { stat: statMock },
 		}))
 
@@ -60,6 +70,75 @@ describe("findKilocodeCli", () => {
 		const result = await findKilocodeCli()
 
 		expect(result?.cliPath).toBe("/usr/local/bin/kilocode")
+	})
+
+	loginShellTests("ignores alias output from login shell", async () => {
+		const originalEnv = { ...process.env }
+		const testShellPath = "/custom/path:/usr/bin"
+		const spawnSyncMock = vi
+			.fn()
+			.mockReturnValue({ stdout: `__KILO_PATH_START__${testShellPath}__KILO_PATH_END__\n` })
+		const execSyncMock = vi.fn().mockReturnValue("alias kilocode='npx kilo'\n")
+		const statMock = vi.fn().mockImplementation((filePath: string) => {
+			if (filePath === "/usr/local/bin/kilocode") {
+				return Promise.resolve({ isFile: () => true })
+			}
+			return Promise.reject(new Error("ENOENT"))
+		})
+		const statSyncMock = vi.fn().mockImplementation((filePath: string) => {
+			if (filePath === "/usr/local/bin/kilocode") {
+				return { isFile: () => true }
+			}
+			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+		})
+
+		process.env.PATH = "/usr/local/bin"
+
+		try {
+			vi.doMock("node:child_process", () => ({ execSync: execSyncMock, spawnSync: spawnSyncMock }))
+			vi.doMock("../../../../utils/fs", () => ({ fileExistsAtPath: vi.fn().mockResolvedValue(false) }))
+			vi.doMock("node:fs", () => ({
+				existsSync: vi.fn().mockReturnValue(false),
+				statSync: statSyncMock,
+				promises: { stat: statMock },
+			}))
+
+			const { findKilocodeCli } = await import("../CliPathResolver")
+			const result = await findKilocodeCli()
+
+			expect(result?.cliPath).toBe("/usr/local/bin/kilocode")
+		} finally {
+			Object.assign(process.env, originalEnv)
+		}
+	})
+
+	loginShellTests("strips shell control codes from login shell output", async () => {
+		const testShellPath = "/custom/path:/usr/bin"
+		const spawnSyncMock = vi
+			.fn()
+			.mockReturnValue({ stdout: `__KILO_PATH_START__${testShellPath}__KILO_PATH_END__\n` })
+		const execSyncMock = vi
+			.fn()
+			.mockReturnValue("\x1b]1337;RemoteHost=host.local\x07/opt/homebrew/bin/kilocode\n")
+		const statSyncMock = vi.fn().mockImplementation((filePath: string) => {
+			if (filePath === "/opt/homebrew/bin/kilocode") {
+				return { isFile: () => true }
+			}
+			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+		})
+
+		vi.doMock("node:child_process", () => ({ execSync: execSyncMock, spawnSync: spawnSyncMock }))
+		vi.doMock("../../../../utils/fs", () => ({ fileExistsAtPath: vi.fn().mockResolvedValue(false) }))
+		vi.doMock("node:fs", () => ({
+			existsSync: vi.fn().mockReturnValue(false),
+			statSync: statSyncMock,
+			promises: { stat: vi.fn().mockRejectedValue(new Error("ENOENT")) },
+		}))
+
+		const { findKilocodeCli } = await import("../CliPathResolver")
+		const result = await findKilocodeCli()
+
+		expect(result?.cliPath).toBe("/opt/homebrew/bin/kilocode")
 	})
 
 	it("falls back to npm paths when all PATH lookups fail", async () => {
@@ -85,6 +164,50 @@ describe("findKilocodeCli", () => {
 		expect(result).not.toBeNull()
 		expect(result?.cliPath).toBeDefined()
 		expect(fileExistsMock).toHaveBeenCalled()
+	})
+
+	it("prefers PATHEXT executables when scanning npm paths on Windows", async () => {
+		const originalPlatform = process.platform
+		const originalEnv = { ...process.env }
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true })
+		process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming"
+		process.env.LOCALAPPDATA = ""
+		process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD"
+
+		try {
+			const spawnSyncMock = vi.fn().mockImplementation(() => {
+				throw new Error("not found")
+			})
+			const execSyncMock = vi.fn().mockImplementation(() => {
+				throw new Error("not found")
+			})
+			const fileExistsMock = vi.fn().mockImplementation((filePath: string) => {
+				return Promise.resolve(filePath.endsWith("kilocode.CMD"))
+			})
+
+			vi.doMock("node:child_process", () => ({ execSync: execSyncMock, spawnSync: spawnSyncMock }))
+			vi.doMock("../../../../utils/fs", () => ({ fileExistsAtPath: fileExistsMock }))
+			vi.doMock("node:fs", () => ({
+				existsSync: vi.fn().mockReturnValue(false),
+				promises: { stat: vi.fn().mockRejectedValue(new Error("ENOENT")) },
+			}))
+
+			const { findKilocodeCli } = await import("../CliPathResolver")
+			const result = await findKilocodeCli()
+
+			const expectedCmdPath = path.join("C:\\Users\\test\\AppData\\Roaming", "npm", "kilocode.CMD")
+			const expectedBasePath = path.join("C:\\Users\\test\\AppData\\Roaming", "npm", "kilocode")
+			expect(result?.cliPath).toBe(expectedCmdPath)
+			expect(fileExistsMock).not.toHaveBeenCalledWith(expectedBasePath)
+		} finally {
+			Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
+			for (const key of Object.keys(process.env)) {
+				if (!(key in originalEnv)) {
+					delete process.env[key]
+				}
+			}
+			Object.assign(process.env, originalEnv)
+		}
 	})
 
 	it("returns null when CLI is not found anywhere", async () => {
@@ -296,9 +419,20 @@ describe("findExecutable", () => {
 			.fn()
 			.mockReturnValue({ stdout: `some banner\n__KILO_PATH_START__${testPath}__KILO_PATH_END__\n` })
 		const execSyncMock = vi.fn().mockReturnValue("/opt/homebrew/bin/kilocode\n")
+		const statSyncMock = vi.fn().mockImplementation((filePath: string) => {
+			if (filePath === "/opt/homebrew/bin/kilocode") {
+				return { isFile: () => true }
+			}
+			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+		})
 
 		vi.doMock("node:child_process", () => ({ execSync: execSyncMock, spawnSync: spawnSyncMock }))
 		vi.doMock("../../../../utils/fs", () => ({ fileExistsAtPath: vi.fn().mockResolvedValue(false) }))
+		vi.doMock("node:fs", () => ({
+			existsSync: vi.fn().mockReturnValue(false),
+			statSync: statSyncMock,
+			promises: { stat: vi.fn().mockRejectedValue(new Error("ENOENT")) },
+		}))
 
 		const { findKilocodeCli } = await import("../CliPathResolver")
 		const result = await findKilocodeCli()

--- a/src/core/kilocode/agent-manager/__tests__/CliProcessHandler.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/CliProcessHandler.spec.ts
@@ -325,8 +325,9 @@ describe("CliProcessHandler", () => {
 		})
 
 		describe("Windows .cmd file handling", () => {
-			it("uses shell: true for .cmd files on Windows", () => {
+			it("uses cmd.exe for .cmd files on Windows", () => {
 				const originalPlatform = process.platform
+				const expectedCommand = process.env.ComSpec ?? "cmd.exe"
 				Object.defineProperty(process, "platform", { value: "win32", configurable: true })
 
 				try {
@@ -340,17 +341,20 @@ describe("CliProcessHandler", () => {
 					)
 
 					expect(spawnMock).toHaveBeenCalledWith(
-						"C:\\Users\\test\\.kilocode\\cli\\pkg\\node_modules\\.bin\\kilocode.cmd",
-						expect.any(Array),
-						expect.objectContaining({ shell: true }),
+						expectedCommand,
+						expect.arrayContaining(["/c", "C:\\Users\\test\\.kilocode\\cli\\pkg\\node_modules\\.bin\\kilocode.cmd"]),
+						expect.objectContaining({ shell: false }),
 					)
+					const args = spawnMock.mock.calls[0]?.[1] as string[]
+					expect(args.slice(0, 3)).toEqual(["/d", "/s", "/c"])
 				} finally {
 					Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
 				}
 			})
 
-			it("uses shell: true for .CMD files (case insensitive) on Windows", () => {
+			it("uses cmd.exe for .CMD files (case insensitive) on Windows", () => {
 				const originalPlatform = process.platform
+				const expectedCommand = process.env.ComSpec ?? "cmd.exe"
 				Object.defineProperty(process, "platform", { value: "win32", configurable: true })
 
 				try {
@@ -364,10 +368,12 @@ describe("CliProcessHandler", () => {
 					)
 
 					expect(spawnMock).toHaveBeenCalledWith(
-						"C:\\Users\\test\\kilocode.CMD",
-						expect.any(Array),
-						expect.objectContaining({ shell: true }),
+						expectedCommand,
+						expect.arrayContaining(["/c", "C:\\Users\\test\\kilocode.CMD"]),
+						expect.objectContaining({ shell: false }),
 					)
+					const args = spawnMock.mock.calls[0]?.[1] as string[]
+					expect(args.slice(0, 3)).toEqual(["/d", "/s", "/c"])
 				} finally {
 					Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
 				}

--- a/src/core/kilocode/agent-manager/__tests__/ShellOutput.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/ShellOutput.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest"
+import { stripOscSequences, stripShellControlCodes } from "../ShellOutput"
+
+describe("ShellOutput", () => {
+	it("strips OSC sequences terminated by BEL", () => {
+		const input = "\x1b]1337;RemoteHost=host.local\x07/opt/homebrew/bin/kilocode\n"
+		expect(stripOscSequences(input)).toBe("/opt/homebrew/bin/kilocode\n")
+	})
+
+	it("strips OSC sequences terminated by ST", () => {
+		const input = "\x1b]0;title\x1b\\usr/local/bin/kilocode"
+		expect(stripOscSequences(input)).toBe("usr/local/bin/kilocode")
+	})
+
+	it("strips multiple OSC sequences in one line", () => {
+		const input = "a\x1b]0;title\x07b\x1b]1337;RemoteHost=host.local\x07c"
+		expect(stripOscSequences(input)).toBe("abc")
+	})
+
+	it("strips OSC sequences that appear mid-string", () => {
+		const input = "/opt\x1b]0;title\x07/homebrew/bin/kilocode"
+		expect(stripOscSequences(input)).toBe("/opt/homebrew/bin/kilocode")
+	})
+
+	it("drops unterminated OSC sequences", () => {
+		const input = "prefix\x1b]1337;RemoteHost=host.local"
+		expect(stripOscSequences(input)).toBe("prefix")
+	})
+
+	it("strips ANSI codes after removing OSC sequences", () => {
+		const input = "\x1b]1337;RemoteHost=host.local\x07\x1b[32m/path\x1b[0m"
+		expect(stripShellControlCodes(input)).toBe("/path")
+	})
+})


### PR DESCRIPTION
Fix related to #4625

Root cause: we sometimes resolved a non-runnable CLI path (Windows .cmd batch shim spawned directly, or login-shell output polluted with ANSI/OSC/alias text), so spawn failed with ENOENT and the UI kept showing “Install CLI.”
  
Fix: 
- spawn .cmd/.bat via cmd.exe
- respect PATHEXT when scanning npm paths
- sanitize login-shell output to only accept existing absolute paths.
  