### PR TITLE
Fix loss of synthetic auto model refresh which was lost in the Roo merge.

### DIFF
--- a/.changeset/sixty-teachers-begin.md
+++ b/.changeset/sixty-teachers-begin.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix loss of kilocode auto model refresh

--- a/src/api/providers/fetchers/modelCache.ts
+++ b/src/api/providers/fetchers/modelCache.ts
@@ -321,6 +321,7 @@ export async function initializeModelCacheRefresh(): Promise<void> {
 			{ provider: "glama", options: { provider: "glama" } }, // kilocode_change
 			{ provider: "vercel-ai-gateway", options: { provider: "vercel-ai-gateway" } },
 			{ provider: "chutes", options: { provider: "chutes" } },
+			{ provider: "synthetic", options: { provider: "synthetic" } }, // kilocode_change: Add synthetic to background refresh
 		]
 
 		// Refresh each provider in background (fire and forget)


### PR DESCRIPTION
 ## Context

The synthetic provider's dynamic model fetcher was not being called during extension startup, causing synthetic models to never be cached. This meant that the synthetic provider would not have any models available until manually refreshed, and the dynamic fetcher would appear to not work at all.

## Implementation

Added the synthetic provider to the `publicProviders` array in the [`initializeModelCacheRefresh()`](src/api/providers/fetchers/modelCache.ts:315) function. This ensures that synthetic models are pre-fetched and cached in the background when the extension starts, just like other public providers (openrouter, glama, vercel-ai-gateway, chutes).

The change is minimal and follows the existing pattern for other providers. The synthetic provider works without API keys, making it eligible for background refresh. The fix ensures that:

1. Synthetic models are fetched and cached during extension startup (after 2 second delay)
2. Subsequent calls to `getModels({ provider: "synthetic" })` return cached models immediately
3. The synthetic fetcher behaves consistently with other dynamic providers

## Screenshots

Not applicable - this is a backend caching change with no UI impact.

## How to Test

1. Start the extension with the synthetic provider configured
2. Check the model cache directory (`~/.kilo-code/cache/`) - a `synthetic_models.json` file should appear after ~2 seconds
3. Verify that synthetic models are available in the provider dropdown
4. Confirm that calling `getModels({ provider: "synthetic" })` returns cached models without making a new API call
5. Check the logs for `[MODEL_CACHE]` entries related to synthetic provider

## Get in Touch

mcowger