### PR TITLE
Add Requesty Codestral to autocomplete provider models

### DIFF
--- a/.changeset/chatty-carpets-turn.md
+++ b/.changeset/chatty-carpets-turn.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add Requesty Codestral to autocomplete provider models

--- a/src/services/ghost/types.ts
+++ b/src/services/ghost/types.ts
@@ -15,6 +15,7 @@ export const AUTOCOMPLETE_PROVIDER_MODELS = new Map([
 	["mistral", "codestral-latest"],
 	["kilocode", "mistralai/codestral-2508"],
 	["openrouter", "mistralai/codestral-2508"],
+	["requesty", "mistral/codestral-latest"],
 	["bedrock", "mistral.codestral-2508-v1:0"],
 ] as const)
 


### PR DESCRIPTION
## Context

There are a number of [open issues](https://github.com/Kilo-Org/kilocode/issues?q=is%3Aissue%20state%3Aopen%20autocomplete%20model) relating to using models for the autocomplete feature. In my case, as a [Requesty](https://www.requesty.ai/) user, I think this patch would solve the issue for me.

## How to Test

1. Configure Requesty as a provider
2. Create a profile with `mistral/codestral-latest` as the model
3. Confirm Kilo has recognized the configured model as valid for autocompletion.

## Get in Touch

I'm `keet_retol` on Discord.
