### PR TITLE
fix: update Cerebras maxTokens to 16384

### DIFF
--- a/.changeset/cerebras-16k-max-tokens.md
+++ b/.changeset/cerebras-16k-max-tokens.md
@@ -1,5 +1,5 @@
 ---
-"@roo-code/types": patch
+"kilo-code": patch
 ---
 
 Update Cerebras maxTokens from 8192 to 16384 for all models

--- a/.changeset/cerebras-16k-max-tokens.md
+++ b/.changeset/cerebras-16k-max-tokens.md
@@ -1,0 +1,5 @@
+---
+"@roo-code/types": patch
+---
+
+Update Cerebras maxTokens from 8192 to 16384 for all models

--- a/packages/types/src/providers/cerebras.ts
+++ b/packages/types/src/providers/cerebras.ts
@@ -7,7 +7,7 @@ export const cerebrasDefaultModelId: CerebrasModelId = "gpt-oss-120b"
 
 export const cerebrasModels = {
 	"zai-glm-4.6": {
-		maxTokens: 8192, // Conservative default to avoid premature rate limiting (Cerebras reserves quota upfront)
+		maxTokens: 16384, // Conservative default to avoid premature rate limiting (Cerebras reserves quota upfront)
 		contextWindow: 131072,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -17,7 +17,7 @@ export const cerebrasModels = {
 		description: "Highly intelligent general purpose model with up to 1,000 tokens/s",
 	},
 	"qwen-3-235b-a22b-instruct-2507": {
-		maxTokens: 8192, // Conservative default to avoid premature rate limiting
+		maxTokens: 16384, // Conservative default to avoid premature rate limiting
 		contextWindow: 64000,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -27,7 +27,7 @@ export const cerebrasModels = {
 		description: "Intelligent model with ~1400 tokens/s",
 	},
 	"llama-3.3-70b": {
-		maxTokens: 8192, // Conservative default to avoid premature rate limiting
+		maxTokens: 16384, // Conservative default to avoid premature rate limiting
 		contextWindow: 64000,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -37,7 +37,7 @@ export const cerebrasModels = {
 		description: "Powerful model with ~2600 tokens/s",
 	},
 	"qwen-3-32b": {
-		maxTokens: 8192, // Conservative default to avoid premature rate limiting
+		maxTokens: 16384, // Conservative default to avoid premature rate limiting
 		contextWindow: 64000,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -47,7 +47,7 @@ export const cerebrasModels = {
 		description: "SOTA coding performance with ~2500 tokens/s",
 	},
 	"gpt-oss-120b": {
-		maxTokens: 8192, // Conservative default to avoid premature rate limiting
+		maxTokens: 16384, // Conservative default to avoid premature rate limiting
 		contextWindow: 64000,
 		supportsImages: false,
 		supportsPromptCache: false,


### PR DESCRIPTION
Update all Cerebras models maxTokens from 8192 to 16384.

16k is sufficient for most agentic tool use while preserving rate limit headroom. Cerebras rate limiter estimates token consumption using max_completion_tokens upfront, so this conservative default avoids premature rate limiting.