### PR TITLE
perf(cli): Skip VSCode-specific operations in CLI mode

### DIFF
--- a/.changeset/cli-diagnostic-delay-skip.md
+++ b/.changeset/cli-diagnostic-delay-skip.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Skip VSCode-specific diagnostic operations in CLI mode for improved performance

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -687,6 +687,10 @@ export class DiffViewProvider {
 	}> {
 		const absolutePath = path.resolve(this.cwd, relPath)
 
+		// kilocode_change start: In CLI mode, skip VSCode-specific operations (diagnostics are mocked)
+		const skipVscodeOps = process.env.KILO_CLI_MODE === "true"
+		// kilocode_change end
+
 		// Get diagnostics before editing the file
 		this.preDiagnostics = vscode.languages.getDiagnostics()
 
@@ -696,28 +700,34 @@ export class DiffViewProvider {
 
 		// Open the document to ensure diagnostics are loaded
 		// When openFile is false (PREVENT_FOCUS_DISRUPTION enabled), we only open in memory
-		if (openFile) {
-			// Show the document in the editor
-			await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), {
-				preview: false,
-				preserveFocus: true,
-			})
-		} else {
-			// Just open the document in memory to trigger diagnostics without showing it
-			const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(absolutePath))
+		// kilocode_change start: Skip document opening in CLI mode
+		if (!skipVscodeOps) {
+			// kilocode_change end
+			if (openFile) {
+				// Show the document in the editor
+				await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), {
+					preview: false,
+					preserveFocus: true,
+				})
+			} else {
+				// Just open the document in memory to trigger diagnostics without showing it
+				const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(absolutePath))
 
-			// Save the document to ensure VSCode recognizes it as saved and triggers diagnostics
-			if (doc.isDirty) {
-				await doc.save()
+				// Save the document to ensure VSCode recognizes it as saved and triggers diagnostics
+				if (doc.isDirty) {
+					await doc.save()
+				}
+
+				// Force a small delay to ensure diagnostics are triggered
+				await new Promise((resolve) => setTimeout(resolve, 100))
 			}
-
-			// Force a small delay to ensure diagnostics are triggered
-			await new Promise((resolve) => setTimeout(resolve, 100))
 		}
 
 		let newProblemsMessage = ""
 
-		if (diagnosticsEnabled) {
+		// kilocode_change start: Skip diagnostic delay in CLI mode
+		if (diagnosticsEnabled && !skipVscodeOps) {
+			// kilocode_change end
 			// Add configurable delay to allow linters time to process
 			const safeDelayMs = Math.max(0, writeDelayMs)
 


### PR DESCRIPTION
## Summary

Improves CLI performance by skipping VSCode-specific operations that are unnecessary in CLI mode.

## Changes

- Skip document opening operations in CLI mode (document opening is used to trigger VSCode diagnostics, which are mocked in CLI mode)
- Skip diagnostic delay in CLI mode (the delay waits for linters to process, but diagnostics are mocked in CLI mode)
- Add tests for CLI mode optimization behavior

## Impact

When running in CLI mode (`KILO_CLI_MODE=true`), file write operations via `saveDirectly()` will skip:
- Opening documents in VSCode (saves ~100ms per file)
- Waiting for diagnostic delay (saves up to 400ms per file, depending on configuration)

This has no effect on the VSCode extension behavior.