### PR TITLE
use ipv4 get models

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -553,7 +553,9 @@ export async function getOpenAiModels(baseUrl?: string, apiKey?: string, openAiH
 			return []
 		}
 
-		const config: Record<string, any> = {}
+		const config: Record<string, any> = {
+			family: 4, // try ipv4 first, or use `dns.setDefaultResultOrder('ipv4first');` global config
+		}
 		const headers: Record<string, string> = {
 			...DEFAULT_HEADERS,
 			...(openAiHeaders || {}),


### PR DESCRIPTION
## Context

Use IPv4 in the function getOpenAiModels to retrieve all models.
If the API site uses CDN acceleration, it will resolve multiple IPs. Axios will prioritize IPv6. If the network conditions are not good, it will directly throw an exception. In fact, using curl can call the interface normally to get all models.

## Implementation

```
const config: Record<string, any> = {
	family: 4, // try ipv4 first, or use `dns.setDefaultResultOrder('ipv4first');` global config
}
```

Avoid using global DNS settings.

Alternatively, using fetch mayavoid setting IPv4/IPv6 request priorities?

## Screenshots

<img width="272" height="213" alt="image" src="https://github.com/user-attachments/assets/5317efa8-1e51-473e-859b-ab89da9395aa" />


