### PR TITLE
feat: Add ability to use Codestral from huggingface, litellm, lmstudio, and ollama

### DIFF
--- a/.changeset/spotty-cobras-knock.md
+++ b/.changeset/spotty-cobras-knock.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Added ability to use Codestral for autocomplete from HuggingFace, LiteLLM, LM Studio and Ollama

--- a/src/services/ghost/types.ts
+++ b/src/services/ghost/types.ts
@@ -17,6 +17,10 @@ export const AUTOCOMPLETE_PROVIDER_MODELS = new Map([
 	["openrouter", "mistralai/codestral-2508"],
 	["requesty", "mistral/codestral-latest"],
 	["bedrock", "mistral.codestral-2508-v1:0"],
+	["huggingface", "mistralai/Codestral-22B-v0.1"],
+	["litellm", "codestral/codestral-latest"],
+	["lmstudio", "mistralai/codestral-22b-v0.1"],
+	["ollama", "codestral:latest"],
 ] as const)
 
 export type AutocompleteProviderKey = typeof AUTOCOMPLETE_PROVIDER_MODELS extends Map<infer K, any> ? K : never


### PR DESCRIPTION
## Context

As a follow-up to #4693, there are more providers we can configure for the autocomplete feature.

## Get in Touch

I'm `keet_retol` on Discord.