### PR TITLE
fix: Use Ctrl+C for exit message on all platforms

### DIFF
--- a/.changeset/fix-mac-exit-message.md
+++ b/.changeset/fix-mac-exit-message.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed exit prompt showing "Cmd+C" instead of "Ctrl+C" on Mac. Ctrl+C is the universal terminal interrupt signal on all platforms.

--- a/cli/src/ui/components/StatusIndicator.tsx
+++ b/cli/src/ui/components/StatusIndicator.tsx
@@ -36,7 +36,7 @@ export const StatusIndicator: React.FC<StatusIndicatorProps> = ({ disabled = fal
 	const isStreaming = useAtomValue(isStreamingAtom)
 	const hasResumeTask = useAtomValue(hasResumeTaskAtom)
 	const exitPromptVisible = useAtomValue(exitPromptVisibleAtom)
-	const exitModifierKey = process.platform === "darwin" ? "Cmd" : "Ctrl"
+	const exitModifierKey = "Ctrl" // Ctrl+C is the universal terminal interrupt signal on all platforms
 
 	// Don't render if no hotkeys to show or disabled
 	if (!shouldShow || disabled) {


### PR DESCRIPTION
## Context

On Mac, the exit prompt incorrectly shows "Press Cmd+C again to exit." but Cmd+C is the copy shortcut, not the terminal interrupt. Users actually need to press Ctrl+C to exit, which is the universal terminal interrupt signal (SIGINT) on all platforms.

## Implementation

Simple one-line fix in `cli/src/ui/components/StatusIndicator.tsx`:
- Changed `exitModifierKey` from `process.platform === "darwin" ? "Cmd" : "Ctrl"` to just `"Ctrl"`
- Ctrl+C is the standard terminal interrupt on Mac, Windows, and Linux

## How to Test

- Run KiloCode CLI on Mac
- Press Ctrl+C once to trigger the exit prompt
- Verify the message shows "Press Ctrl+C again to exit." (not "Cmd+C")
- Press Ctrl+C again to confirm exit works

