### PR TITLE
Adds documentation explaining how to configure MCP servers for the Kilo Code CLI

### DIFF
--- a/apps/kilocode-docs/docs/features/mcp/using-mcp-in-cli.md
+++ b/apps/kilocode-docs/docs/features/mcp/using-mcp-in-cli.md
@@ -1,0 +1,109 @@
+---
+title: Using MCP in the CLI
+sidebar_label: Using MCP in CLI
+---
+
+# Using MCP in the CLI
+
+The Kilo Code CLI supports MCP servers, but uses a **different configuration path** than the VS Code extension.
+
+## Configuration Location
+
+| Environment | MCP Settings Path |
+|-------------|-------------------|
+| **CLI** | `~/.kilocode/cli/global/settings/mcp_settings.json` |
+| **VS Code** | VS Code's global storage directory |
+
+MCP servers configured in VS Code are **not** automatically available in the CLI. You must configure them separately.
+
+## Configuration Format
+
+Edit `~/.kilocode/cli/global/settings/mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "server-name": {
+      "command": "node",
+      "args": ["/path/to/server.js"],
+      "env": {
+        "API_KEY": "your_api_key"
+      },
+      "alwaysAllow": ["tool1", "tool2"],
+      "disabled": false
+    }
+  }
+}
+```
+
+## Transport Types
+
+### STDIO (Local Servers)
+
+```json
+{
+  "mcpServers": {
+    "local-server": {
+      "command": "node",
+      "args": ["/path/to/server.js"],
+      "env": {}
+    }
+  }
+}
+```
+
+### Streamable HTTP (Remote Servers)
+
+```json
+{
+  "mcpServers": {
+    "remote-server": {
+      "type": "streamable-http",
+      "url": "https://your-server.com/mcp",
+      "headers": {
+        "Authorization": "Bearer token"
+      }
+    }
+  }
+}
+```
+
+## Project-Level Configuration
+
+You can define MCP servers per-project by creating `.kilocode/mcp.json` in your project root. Project-level servers take precedence over global settings.
+
+## Configuration Options
+
+| Option | Description |
+|--------|-------------|
+| `command` | Executable to run (STDIO) |
+| `args` | Command arguments (STDIO) |
+| `env` | Environment variables |
+| `type` | Transport type: `stdio` (default), `streamable-http`, `sse` |
+| `url` | Server URL (HTTP transports) |
+| `headers` | HTTP headers (HTTP transports) |
+| `alwaysAllow` | Array of tool names to auto-approve |
+| `disabled` | Set `true` to disable without removing |
+| `timeout` | Request timeout in seconds (default: 60) |
+
+## Auto-Approval
+
+MCP auto-approval is controlled via CLI config (`kilocode config`):
+
+```json
+{
+  "autoApproval": {
+    "mcp": {
+      "enabled": true
+    }
+  }
+}
+```
+
+Or via environment variable:
+
+```bash
+export KILO_AUTO_APPROVAL_MCP_ENABLED=true
+```
+
+Per-tool auto-approval uses the `alwaysAllow` array in the server configuration.

--- a/apps/kilocode-docs/sidebars.ts
+++ b/apps/kilocode-docs/sidebars.ts
@@ -194,6 +194,7 @@ const sidebars: SidebarsConfig = {
 					items: [
 						"features/mcp/overview",
 						"features/mcp/using-mcp-in-kilo-code",
+						"features/mcp/using-mcp-in-cli",
 						"features/mcp/what-is-mcp",
 						"features/mcp/server-transports",
 						"features/mcp/mcp-vs-api",


### PR DESCRIPTION
The CLI uses a separate configuration path (`~/.kilocode/cli/global/settings/mcp_settings.json`) from the VS Code extension, which wasn't previously documented.
## Changes

- Add `using-mcp-in-cli.md` to the MCP docs section
- Add sidebar entry for the new page

## Documentation includes

- CLI vs VS Code configuration paths
- Configuration format and options
- Transport types (STDIO, Streamable HTTP)
- Project-level configuration
- Auto-approval settings