### PR TITLE
docs: add provider and model selection documentation for autocomplete

### DIFF
--- a/apps/kilocode-docs/docs/basic-usage/autocomplete.md
+++ b/apps/kilocode-docs/docs/basic-usage/autocomplete.md
@@ -16,8 +16,6 @@ Autocomplete analyzes your code context and provides:
 - **Contextual suggestions** based on your surrounding code
 - **Multi-line completions** for complex code structures
 
-The feature uses your selected AI provider to generate intelligent suggestions that match your coding style and project context.
-
 ## Triggering Options
 
 ### Pause to Complete
@@ -63,6 +61,29 @@ This is ideal for:
 - Keeping you in the flow without interruptions
 
 You can customize this keyboard shortcut as well in your VS Code settings.
+
+## Provider and Model Selection
+
+Autocomplete currently uses **Codestral** (by Mistral AI) as the underlying model. This model is specifically optimized for code completion tasks and provides fast, high-quality suggestions.
+
+### How the Provider is Chosen
+
+Kilo Code automatically selects a provider for autocomplete in the following priority order:
+
+- **Mistral** (using `codestral-latest`)
+- **Kilo Code** (using `mistralai/codestral-2508`)
+- **OpenRouter** (using `mistralai/codestral-2508`)
+- **Requesty** (using `mistral/codestral-latest`)
+- **Bedrock** (using `mistral.codestral-2508-v1:0`)
+- **Hugging Face** (using `mistralai/Codestral-22B-v0.1`)
+- **LiteLLM** (using `codestral/codestral-latest`)
+- **LM Studio** (using `mistralai/codestral-22b-v0.1`)
+- **Ollama** (using `codestral:latest`)
+  `
+
+:::note
+**Model Selection is Currently Fixed**: At this time, you cannot freely choose a different model for autocomplete. The feature is designed to work specifically with Codestral, which is optimized for Fill-in-the-Middle (FIM) completions. Support for additional models may be added in future releases.
+:::
 
 ## Disable Rival Autocomplete
 

--- a/apps/kilocode-docs/docs/basic-usage/autocomplete.md
+++ b/apps/kilocode-docs/docs/basic-usage/autocomplete.md
@@ -79,7 +79,7 @@ Kilo Code automatically selects a provider for autocomplete in the following pri
 - **LiteLLM** (using `codestral/codestral-latest`)
 - **LM Studio** (using `mistralai/codestral-22b-v0.1`)
 - **Ollama** (using `codestral:latest`)
-  `
+
 
 :::note
 **Model Selection is Currently Fixed**: At this time, you cannot freely choose a different model for autocomplete. The feature is designed to work specifically with Codestral, which is optimized for Fill-in-the-Middle (FIM) completions. Support for additional models may be added in future releases.


### PR DESCRIPTION
## Summary

Adds documentation explaining how the provider and model are chosen for the autocomplete feature.

## Changes

- Added a new "Provider and Model Selection" section to the autocomplete documentation
- Documents that Codestral (by Mistral AI) is the underlying model used for autocomplete
- Explains the priority order for automatic provider detection:
  1. Dedicated Autocomplete Profile (if configured)
  2. Automatic detection from supported providers (Mistral, Kilo Code, OpenRouter, Requesty, Bedrock, Hugging Face, LiteLLM, LM Studio, Ollama)
- Clearly states that users cannot currently choose a different model than Codestral
- Notes that Kilo Code provider requires positive balance verification

## Why

Users need to understand how the autocomplete provider/model is selected and that they cannot freely choose a different model at this time.