### PR TITLE
feat: integrate Jaccard similarity ranking into autocomplete snippet selection

### DIFF
--- a/src/services/continuedev/core/autocomplete/context/ranking/index.ts
+++ b/src/services/continuedev/core/autocomplete/context/ranking/index.ts
@@ -15,7 +15,7 @@ export function getSymbolsForSnippet(snippet: string): Set<string> {
 /**
  * Calculate similarity as number of shared symbols divided by total number of unique symbols between both.
  */
-function jaccardSimilarity(a: string, b: string): number {
+export function jaccardSimilarity(a: string, b: string): number {
 	const aSet = getSymbolsForSnippet(a)
 	const bSet = getSymbolsForSnippet(b)
 	const union = new Set([...aSet, ...bSet]).size

--- a/src/services/continuedev/core/autocomplete/templating/__tests__/filtering.spec.ts
+++ b/src/services/continuedev/core/autocomplete/templating/__tests__/filtering.spec.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from "vitest"
+import { getSnippets } from "../filtering"
+import { SnippetPayload } from "../../snippets"
+import { AutocompleteSnippetType, AutocompleteCodeSnippet, AutocompleteClipboardSnippet } from "../../snippets/types"
+import { HelperVars } from "../../util/HelperVars"
+
+// Mock countTokens to return a simple token count based on content length
+vi.mock("../../../llm/countTokens", () => ({
+	countTokens: (content: string) => Math.ceil(content.length / 4),
+}))
+
+describe("getSnippets", () => {
+	const createMockHelper = (overrides: Partial<HelperVars> = {}): HelperVars => {
+		return {
+			fullPrefix: "function calculateSum(a, b) {\n  return a + b;\n}\n\nconst result = calculateSum(",
+			fullSuffix: ");\nconsole.log(result);",
+			prunedCaretWindow:
+				"function calculateSum(a, b) {\n  return a + b;\n}\n\nconst result = calculateSum();\nconsole.log(result);",
+			modelName: "codestral",
+			options: {
+				slidingWindowSize: 500,
+				slidingWindowPrefixPercentage: 0.75,
+				maxPromptTokens: 1000,
+				maxSnippetPercentage: 0.5,
+				experimental_includeClipboard: false,
+				useRecentlyOpened: false,
+				experimental_includeRecentlyVisitedRanges: false,
+				experimental_includeRecentlyEditedRanges: false,
+				experimental_includeDiff: false,
+			},
+			...overrides,
+		} as unknown as HelperVars
+	}
+
+	const createEmptyPayload = (): SnippetPayload => ({
+		rootPathSnippets: [],
+		importDefinitionSnippets: [],
+		ideSnippets: [],
+		recentlyEditedRangeSnippets: [],
+		recentlyVisitedRangesSnippets: [],
+		diffSnippets: [],
+		clipboardSnippets: [],
+		recentlyOpenedFileSnippets: [],
+		staticSnippet: [],
+	})
+
+	describe("Jaccard similarity ranking", () => {
+		it("should rank snippets by similarity to cursor context (most similar first)", () => {
+			const helper = createMockHelper()
+			const payload = createEmptyPayload()
+
+			// Create snippets with varying similarity to the cursor context
+			// The cursor context contains "calculateSum", "return", "a", "b", etc.
+			// The high similarity snippet shares the exact function name "calculateSum"
+			const highSimilaritySnippet: AutocompleteCodeSnippet = {
+				type: AutocompleteSnippetType.Code,
+				filepath: "file:///high.ts",
+				content: "const calculateSum = (x, y) => x + y; const result = calculateSum(1, 2);",
+			}
+
+			const mediumSimilaritySnippet: AutocompleteCodeSnippet = {
+				type: AutocompleteSnippetType.Code,
+				filepath: "file:///medium.ts",
+				content: "function add(x, y) { return x + y; }",
+			}
+
+			const lowSimilaritySnippet: AutocompleteCodeSnippet = {
+				type: AutocompleteSnippetType.Code,
+				filepath: "file:///low.ts",
+				content: "class DatabaseConnection { connect() {} disconnect() {} query() {} }",
+			}
+
+			// Add snippets in reverse order of similarity
+			payload.rootPathSnippets = [lowSimilaritySnippet, mediumSimilaritySnippet, highSimilaritySnippet]
+
+			const result = getSnippets(helper, payload)
+
+			// The high similarity snippet should come first (shares "calculateSum" and "result")
+			expect(result.length).toBeGreaterThan(0)
+			expect(result[0].content).toBe(highSimilaritySnippet.content)
+		})
+
+		it("should rank clipboard snippets by similarity when enabled", () => {
+			const helper = createMockHelper({
+				options: {
+					slidingWindowSize: 500,
+					slidingWindowPrefixPercentage: 0.75,
+					maxPromptTokens: 1000,
+					maxSnippetPercentage: 0.5,
+					experimental_includeClipboard: true,
+					useRecentlyOpened: false,
+					experimental_includeRecentlyVisitedRanges: false,
+					experimental_includeRecentlyEditedRanges: false,
+					experimental_includeDiff: false,
+				},
+			} as Partial<HelperVars>)
+
+			const payload = createEmptyPayload()
+
+			const highSimilarityClipboard: AutocompleteClipboardSnippet = {
+				type: AutocompleteSnippetType.Clipboard,
+				content: "calculateSum(1, 2)",
+				copiedAt: new Date().toISOString(),
+			}
+
+			const lowSimilarityClipboard: AutocompleteClipboardSnippet = {
+				type: AutocompleteSnippetType.Clipboard,
+				content: "unrelated database query",
+				copiedAt: new Date().toISOString(),
+			}
+
+			// Add in reverse order
+			payload.clipboardSnippets = [lowSimilarityClipboard, highSimilarityClipboard]
+
+			const result = getSnippets(helper, payload)
+
+			// Clipboard snippets should be ranked by similarity
+			expect(result.length).toBeGreaterThan(0)
+			expect(result[0].content).toBe(highSimilarityClipboard.content)
+		})
+
+		it("should filter out snippets already in caret window", () => {
+			const helper = createMockHelper()
+			const payload = createEmptyPayload()
+
+			// This snippet's content is already in the caret window
+			const duplicateSnippet: AutocompleteCodeSnippet = {
+				type: AutocompleteSnippetType.Code,
+				filepath: "file:///duplicate.ts",
+				content: "return a + b",
+			}
+
+			const uniqueSnippet: AutocompleteCodeSnippet = {
+				type: AutocompleteSnippetType.Code,
+				filepath: "file:///unique.ts",
+				content: "function subtract(x, y) { return x - y; }",
+			}
+
+			payload.rootPathSnippets = [duplicateSnippet, uniqueSnippet]
+
+			const result = getSnippets(helper, payload)
+
+			// Only the unique snippet should be included
+			expect(result.length).toBe(1)
+			expect(result[0].content).toBe(uniqueSnippet.content)
+		})
+
+		it("should handle empty snippet arrays", () => {
+			const helper = createMockHelper()
+			const payload = createEmptyPayload()
+
+			const result = getSnippets(helper, payload)
+
+			expect(result).toEqual([])
+		})
+
+		it("should handle single snippet without ranking", () => {
+			const helper = createMockHelper()
+			const payload = createEmptyPayload()
+
+			const singleSnippet: AutocompleteCodeSnippet = {
+				type: AutocompleteSnippetType.Code,
+				filepath: "file:///single.ts",
+				content: "const x = 1;",
+			}
+
+			payload.rootPathSnippets = [singleSnippet]
+
+			const result = getSnippets(helper, payload)
+
+			expect(result.length).toBe(1)
+			expect(result[0].content).toBe(singleSnippet.content)
+		})
+
+		it("should respect token limits while selecting most similar snippets first", () => {
+			const helper = createMockHelper({
+				options: {
+					slidingWindowSize: 500,
+					slidingWindowPrefixPercentage: 0.75,
+					maxPromptTokens: 100, // Very limited tokens
+					maxSnippetPercentage: 0.5, // Only 50 tokens for snippets
+					experimental_includeClipboard: false,
+					useRecentlyOpened: false,
+					experimental_includeRecentlyVisitedRanges: false,
+					experimental_includeRecentlyEditedRanges: false,
+					experimental_includeDiff: false,
+				},
+			} as Partial<HelperVars>)
+
+			const payload = createEmptyPayload()
+
+			// Create multiple snippets - the most similar ones should be selected first
+			const snippets: AutocompleteCodeSnippet[] = [
+				{
+					type: AutocompleteSnippetType.Code,
+					filepath: "file:///1.ts",
+					content: "unrelated content about databases and queries",
+				},
+				{
+					type: AutocompleteSnippetType.Code,
+					filepath: "file:///2.ts",
+					content: "function calculateSum(x, y) { return x + y; }",
+				},
+				{
+					type: AutocompleteSnippetType.Code,
+					filepath: "file:///3.ts",
+					content: "another unrelated piece of code",
+				},
+			]
+
+			payload.rootPathSnippets = snippets
+
+			const result = getSnippets(helper, payload)
+
+			// Due to token limits, not all snippets may be included
+			// But the most similar one should be prioritized
+			if (result.length > 0) {
+				expect(result[0].content).toContain("calculateSum")
+			}
+		})
+	})
+})

--- a/src/services/continuedev/core/autocomplete/templating/filtering.ts
+++ b/src/services/continuedev/core/autocomplete/templating/filtering.ts
@@ -1,3 +1,4 @@
+import { jaccardSimilarity } from "../context/ranking"
 import { countTokens } from "../../llm/countTokens"
 import { SnippetPayload } from "../snippets"
 import {
@@ -19,19 +20,6 @@ const getRemainingTokenCount = (helper: HelperVars): number => {
 
 const TOKEN_BUFFER = 10 // We may need extra tokens for snippet description etc.
 
-/**
- * Shuffles an array in place using the Fisher-Yates algorithm.
- * @param array The array to shuffle.
- * @returns The shuffled array.
- */
-const shuffleArray = <T>(array: T[]): T[] => {
-	for (let i = array.length - 1; i > 0; i--) {
-		const j = Math.floor(Math.random() * (i + 1))
-		;[array[i], array[j]] = [array[j], array[i]]
-	}
-	return array
-}
-
 function filterSnippetsAlreadyInCaretWindow(
 	snippets: (AutocompleteCodeSnippet | AutocompleteStaticSnippet)[],
 	caretWindow: string,
@@ -39,19 +27,51 @@ function filterSnippetsAlreadyInCaretWindow(
 	return snippets.filter((s) => s.content.trim() !== "" && !caretWindow.includes(s.content.trim()))
 }
 
+/**
+ * Ranks snippets by their Jaccard similarity to the cursor context.
+ * Higher similarity snippets are placed first.
+ * @param snippets The snippets to rank.
+ * @param cursorContext The text around the cursor to compare against.
+ * @returns A new array of snippets sorted by similarity (highest first).
+ */
+function rankSnippetsBySimilarity<T extends AutocompleteSnippet>(snippets: T[], cursorContext: string): T[] {
+	if (snippets.length <= 1) {
+		return snippets
+	}
+
+	// Calculate similarity scores and sort by them (descending - highest similarity first)
+	return [...snippets]
+		.map((snippet) => ({
+			snippet,
+			score: jaccardSimilarity(snippet.content, cursorContext),
+		}))
+		.sort((a, b) => b.score - a.score)
+		.map(({ snippet }) => snippet)
+}
+
 export const getSnippets = (helper: HelperVars, payload: SnippetPayload): AutocompleteSnippet[] => {
-	const snippets = {
-		clipboard: payload.clipboardSnippets,
-		recentlyVisitedRanges: payload.recentlyVisitedRangesSnippets,
-		recentlyEditedRanges: payload.recentlyEditedRangeSnippets,
-		diff: payload.diffSnippets,
-		recentlyOpenedFiles: payload.recentlyOpenedFileSnippets,
-		base: shuffleArray(
-			filterSnippetsAlreadyInCaretWindow(
-				[...payload.rootPathSnippets, ...payload.importDefinitionSnippets, ...payload.staticSnippet],
-				helper.prunedCaretWindow,
-			),
+	// Compute the cursor context window for similarity ranking
+	// This is the text around the cursor that we compare snippets against
+	const cursorContext =
+		helper.fullPrefix.slice(-helper.options.slidingWindowSize * helper.options.slidingWindowPrefixPercentage) +
+		helper.fullSuffix.slice(helper.options.slidingWindowSize * (1 - helper.options.slidingWindowPrefixPercentage))
+
+	// Filter and rank base snippets by similarity to cursor context
+	const baseSnippets = rankSnippetsBySimilarity(
+		filterSnippetsAlreadyInCaretWindow(
+			[...payload.rootPathSnippets, ...payload.importDefinitionSnippets, ...payload.staticSnippet],
+			helper.prunedCaretWindow,
 		),
+		cursorContext,
+	)
+
+	const snippets = {
+		clipboard: rankSnippetsBySimilarity(payload.clipboardSnippets, cursorContext),
+		recentlyVisitedRanges: rankSnippetsBySimilarity(payload.recentlyVisitedRangesSnippets, cursorContext),
+		recentlyEditedRanges: rankSnippetsBySimilarity(payload.recentlyEditedRangeSnippets, cursorContext),
+		diff: rankSnippetsBySimilarity(payload.diffSnippets, cursorContext),
+		recentlyOpenedFiles: rankSnippetsBySimilarity(payload.recentlyOpenedFileSnippets, cursorContext),
+		base: baseSnippets,
 	}
 
 	// Define snippets with their priorities
@@ -65,19 +85,19 @@ export const getSnippets = (helper: HelperVars, payload: SnippetPayload): Autoco
 			key: "clipboard",
 			enabledOrPriority: helper.options.experimental_includeClipboard,
 			defaultPriority: 1,
-			snippets: payload.clipboardSnippets,
+			snippets: snippets.clipboard,
 		},
 		{
 			key: "recentlyOpenedFiles",
 			enabledOrPriority: helper.options.useRecentlyOpened,
 			defaultPriority: 2,
-			snippets: payload.recentlyOpenedFileSnippets,
+			snippets: snippets.recentlyOpenedFiles,
 		},
 		{
 			key: "recentlyVisitedRanges",
 			enabledOrPriority: helper.options.experimental_includeRecentlyVisitedRanges,
 			defaultPriority: 3,
-			snippets: payload.recentlyVisitedRangesSnippets,
+			snippets: snippets.recentlyVisitedRanges,
 			/* TODO: recentlyVisitedRanges also contain contents from other windows like terminal or output
       if they are visible. We should handle them separately so that we can control their priority
       and whether they should be included or not. */
@@ -86,25 +106,20 @@ export const getSnippets = (helper: HelperVars, payload: SnippetPayload): Autoco
 			key: "recentlyEditedRanges",
 			enabledOrPriority: helper.options.experimental_includeRecentlyEditedRanges,
 			defaultPriority: 4,
-			snippets: payload.recentlyEditedRangeSnippets,
+			snippets: snippets.recentlyEditedRanges,
 		},
 		{
 			key: "diff",
 			enabledOrPriority: helper.options.experimental_includeDiff,
 			defaultPriority: 5,
-			snippets: payload.diffSnippets,
+			snippets: snippets.diff,
 			// TODO: diff is commonly too large, thus anything lower in priority is not included.
 		},
 		{
 			key: "base",
 			enabledOrPriority: true,
 			defaultPriority: 99, // make sure it's the last one to be processed, but still possible to override
-			snippets: shuffleArray(
-				filterSnippetsAlreadyInCaretWindow(
-					[...payload.rootPathSnippets, ...payload.importDefinitionSnippets, ...payload.staticSnippet],
-					helper.prunedCaretWindow,
-				),
-			),
+			snippets: baseSnippets,
 			// TODO: Add this too to experimental config, maybe move upper in the order, since it's almost
 			// always not inlucded due to diff being commonly large
 		},


### PR DESCRIPTION
## Summary

This PR integrates the existing `jaccardSimilarity` function into the autocomplete snippet selection process to improve context quality by prioritizing snippets that share more symbols with the code around the cursor position.

## Problem

The `jaccardSimilarity` function existed in `src/services/continuedev/core/autocomplete/context/ranking/index.ts` but was not being used in the actual snippet gathering flow. The `getSnippets()` function in `filtering.ts` was using random shuffling for base snippets instead of similarity-based ranking.

## Solution

1. **Exported `jaccardSimilarity`** from the ranking module to make it available for use elsewhere
2. **Created `rankSnippetsBySimilarity()`** function that ranks snippets by their Jaccard similarity to the cursor context
3. **Replaced random shuffling** with similarity-based ranking for all snippet categories:
   - Clipboard snippets
   - Recently visited ranges
   - Recently edited ranges
   - Diff snippets
   - Recently opened files
   - Base snippets (root path, import definitions, static)

The cursor context is computed using the sliding window around the cursor position (same approach used in the original `rankAndOrderSnippets` function).

## Changes

- `src/services/continuedev/core/autocomplete/context/ranking/index.ts`: Export `jaccardSimilarity` function
- `src/services/continuedev/core/autocomplete/templating/filtering.ts`: 
  - Import and use `jaccardSimilarity`
  - Add `rankSnippetsBySimilarity()` helper function
  - Replace `shuffleArray` with similarity-based ranking
- `src/services/continuedev/core/autocomplete/templating/__tests__/filtering.spec.ts`: New test file with comprehensive tests

## Testing

- Added 6 new tests for the ranking behavior
- All existing ranking tests continue to pass
- Tests verify:
  - Snippets are ranked by similarity to cursor context
  - Clipboard snippets are ranked when enabled
  - Snippets already in caret window are filtered out
  - Empty and single snippet arrays are handled correctly
  - Token limits are respected while prioritizing similar snippets