### PR TITLE
fix: auto-enable chat autocomplete by default in the settings, not the ui layer

### DIFF
--- a/.changeset/slimy-pens-check.md
+++ b/.changeset/slimy-pens-check.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep config screen in sync with whether chat autocomplete is enabled

--- a/src/services/ghost/GhostServiceManager.ts
+++ b/src/services/ghost/GhostServiceManager.ts
@@ -82,6 +82,13 @@ export class GhostServiceManager {
 			this.settings.enableAutoTrigger = !kiloCodeWrapperJetbrains
 		}
 
+		// Auto-enable chat autocomplete by default, but disable for JetBrains IDEs
+		// JetBrains users can manually enable it if they want to test the feature
+		if (this.settings.enableChatAutocomplete == undefined) {
+			const { kiloCodeWrapperJetbrains } = getKiloCodeWrapperProperties()
+			this.settings.enableChatAutocomplete = !kiloCodeWrapperJetbrains
+		}
+
 		await this.updateGlobalContext()
 		this.updateStatusBar()
 		await this.updateInlineCompletionProviderRegistration()

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -410,7 +410,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			handleInputChange: handleGhostTextInputChange,
 		} = useChatGhostText({
 			textAreaRef,
-			enableChatAutocomplete: ghostServiceSettings?.enableChatAutocomplete ?? true,
+			enableChatAutocomplete: ghostServiceSettings?.enableChatAutocomplete ?? false,
 		})
 		// kilocode_change end: FIM autocomplete ghost text
 		const [imageWarning, setImageWarning] = useState<string | null>(null) // kilocode_change


### PR DESCRIPTION
## Summary

Auto-enable chat autocomplete by default for non-JetBrains IDEs, matching the behavior of inline autocomplete (`enableAutoTrigger`).

## Changes

1. **`src/services/ghost/GhostServiceManager.ts`** - Added auto-enable logic for `enableChatAutocomplete`:
   - Defaults to `true` for VSCode users
   - Defaults to `false` for JetBrains IDE users (they can manually enable it if they want to test)

2. **`webview-ui/src/components/chat/ChatTextArea.tsx`** - Changed the fallback from `true` to `false` since the backend now properly initializes the value

## Testing

All related tests pass:
- GhostServiceManager tests (10 tests)
- useChatGhostText tests (11 tests)
- GhostServiceSettings tests (14 tests)