### PR TITLE
fix(cli): keep API request cost updates visible without flicker

### DIFF
--- a/.changeset/cli-api-request-cost-updates.md
+++ b/.changeset/cli-api-request-cost-updates.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix API request cost updates in the CLI when using static message rendering
+

--- a/cli/src/state/atoms/__tests__/extension-message-updates.test.ts
+++ b/cli/src/state/atoms/__tests__/extension-message-updates.test.ts
@@ -177,6 +177,34 @@ describe("updateChatMessageByTsAtom", () => {
 		expect(messages[0]?.text).toBe("This is a long message")
 	})
 
+	it("should update non-partial messages when content changes but length stays the same", () => {
+		// Setup: Add initial message and initialize version tracking
+		const initialMessage: ExtensionChatMessage = {
+			ts: 1000,
+			type: "say",
+			say: "api_req_started",
+			text: '{"cost":0.0010}',
+			partial: false,
+		}
+		store.set(updateChatMessagesAtom, [initialMessage])
+		store.set(updateChatMessageByTsAtom, initialMessage)
+
+		// Update with different content but identical length (cost changed, same number of digits)
+		const updatedMessage: ExtensionChatMessage = {
+			ts: 1000,
+			type: "say",
+			say: "api_req_started",
+			text: '{"cost":0.0020}',
+			partial: false,
+		}
+		expect(updatedMessage.text?.length).toBe(initialMessage.text?.length)
+		store.set(updateChatMessageByTsAtom, updatedMessage)
+
+		const messages = store.get(chatMessagesAtom)
+		expect(messages).toHaveLength(1)
+		expect(messages[0]?.text).toBe('{"cost":0.0020}')
+	})
+
 	it("should handle ask messages correctly", () => {
 		// Setup: Add partial ask message
 		const partialAsk: ExtensionChatMessage = {

--- a/cli/src/ui/messages/MessageDisplay.tsx
+++ b/cli/src/ui/messages/MessageDisplay.tsx
@@ -34,7 +34,7 @@
 import React from "react"
 import { Box, Static } from "ink"
 import { useAtomValue } from "jotai"
-import { type UnifiedMessage, staticMessagesAtom } from "../../state/atoms/ui.js"
+import { type UnifiedMessage, dynamicMessagesAtom, staticMessagesAtom } from "../../state/atoms/ui.js"
 import { MessageRow } from "./MessageRow.js"
 
 /**
@@ -68,20 +68,33 @@ function getMessageKey(msg: UnifiedMessage, index: number): string {
 
 export const MessageDisplay: React.FC = () => {
 	const staticMessages = useAtomValue(staticMessagesAtom)
+	const dynamicMessages = useAtomValue(dynamicMessagesAtom)
 
-	if (staticMessages.length === 0) {
+	if (staticMessages.length === 0 && dynamicMessages.length === 0) {
 		return null
 	}
 
 	return (
 		<Box flexDirection="column">
-			<Static items={staticMessages}>
-				{(message, index) => (
-					<Box key={getMessageKey(message, index)} paddingX={1}>
-						<MessageRow unifiedMessage={message} />
-					</Box>
-				)}
-			</Static>
+			{staticMessages.length > 0 && (
+				<Static items={staticMessages}>
+					{(message, index) => (
+						<Box key={getMessageKey(message, index)} paddingX={1}>
+							<MessageRow unifiedMessage={message} />
+						</Box>
+					)}
+				</Static>
+			)}
+
+			{dynamicMessages.length > 0 && (
+				<Box flexDirection="column">
+					{dynamicMessages.map((message, index) => (
+						<Box key={`dyn-${getMessageKey(message, index)}`} paddingX={1}>
+							<MessageRow unifiedMessage={message} />
+						</Box>
+					))}
+				</Box>
+			)}
 		</Box>
 	)
 }

--- a/cli/src/ui/messages/extension/say/SayApiReqStartedMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayApiReqStartedMessage.tsx
@@ -11,8 +11,10 @@ export const SayApiReqStartedMessage: React.FC<MessageComponentProps> = ({ messa
 	const theme = useTheme()
 	const apiInfo = parseApiReqInfo(message)
 
-	// Streaming state
-	if (message.partial) {
+	// In-progress state
+	// NOTE: api_req_started is often sent as a non-partial placeholder before cost/usage is known.
+	// In the CLI we treat "no completion indicators" as still in progress.
+	if (message.partial || (!apiInfo?.streamingFailedMessage && !apiInfo?.cancelReason && apiInfo?.cost === undefined)) {
 		return (
 			<Box marginY={1}>
 				<Text color={theme.semantic.info}>⟳ API Request in progress...</Text>

--- a/cli/src/ui/messages/utils/__tests__/messageCompletion.test.ts
+++ b/cli/src/ui/messages/utils/__tests__/messageCompletion.test.ts
@@ -463,5 +463,27 @@ describe("messageCompletion", () => {
 			expect((result.staticMessages[0]?.message as CliMessage).id).toBe("1")
 			expect((result.staticMessages[1]?.message as CliMessage).id).toBe("3")
 		})
+
+		it("should hide api_req_started placeholders until cost/cancel/failure is present", () => {
+			const messages: UnifiedMessage[] = [
+				{
+					source: "extension",
+					message: { ts: 1, type: "say", say: "api_req_started", text: JSON.stringify({ apiProtocol: "openai" }) },
+				},
+				{
+					source: "extension",
+					message: { ts: 2, type: "say", say: "api_req_started", text: JSON.stringify({ cost: 0.001 }) },
+				},
+			]
+
+			const result = splitMessages(messages, { hidePartialMessages: true })
+
+			// Since the first api_req_started lacks completion indicators, it blocks sequential completion.
+			// In the CLI we render only the dynamic tail in-place until it completes.
+			expect(result.staticMessages).toHaveLength(0)
+			expect(result.dynamicMessages).toHaveLength(2)
+			expect(result.dynamicMessages[0]?.source).toBe("extension")
+			expect(result.dynamicMessages[1]?.source).toBe("extension")
+		})
 	})
 })

--- a/cli/src/ui/messages/utils/messageCompletion.ts
+++ b/cli/src/ui/messages/utils/messageCompletion.ts
@@ -136,10 +136,11 @@ export function splitMessages(
 		const filteredMessages = deduplicatedMessages.filter(
 			(msg) => (msg.message as { partial?: boolean }).partial !== true,
 		)
-		return {
-			staticMessages: filteredMessages,
-			dynamicMessages: [],
-		}
+
+		// After filtering out streaming messages, fall back to the normal split logic.
+		// This keeps ordering stable: incomplete messages (e.g. api_req_started without cost)
+		// stay in the dynamic section until they receive completion indicators.
+		return splitMessages(filteredMessages)
 	}
 
 	let lastCompleteIndex = -1


### PR DESCRIPTION
Fixes a #4718 side-effect where `api_req_started` (non-partial placeholders) could be frozen into Ink `<Static>` without costs, and later cost updates would either never appear or show up out-of-order/duplicated.

Changes:
- Keep `api_req_started` without completion indicators in the dynamic tail so it can update in-place once cost/cancel/failure arrives.
- Render a small dynamic tail below the static history to preserve native scrollback without re-render flicker.
- Fix CLI incremental message reconciliation to apply same-length content changes (e.g. JSON cost updates).

Includes tests and a changeset.

During requests API requests will now show like this in the CLI:
<img width="852" height="320" alt="image" src="https://github.com/user-attachments/assets/87dae4ac-a3c7-4de7-bf0a-5bf078350f24" />

Once the cost info is available we update the static UI component in place to look like this:

<img width="624" height="172" alt="image" src="https://github.com/user-attachments/assets/1cf8d1a4-657a-4c05-90be-0e89112f6e16" />
