### PR TITLE
Fix flaky CLI tests (ThinkingAnimation + fetch mock leakage)

### DIFF
--- a/cli/src/auth/__tests__/device-auth.test.ts
+++ b/cli/src/auth/__tests__/device-auth.test.ts
@@ -72,7 +72,7 @@ describe("Device Auth Flow", () => {
 			userEmail: "test@example.com",
 		}
 
-		global.fetch = vi.fn((url: string) => {
+		vi.spyOn(globalThis, "fetch").mockImplementation(((url: string) => {
 			if (url.includes("/api/device-auth/codes") && !url.match(/\/codes\/[^/]+$/)) {
 				return Promise.resolve({
 					ok: true,
@@ -87,7 +87,7 @@ describe("Device Auth Flow", () => {
 				} as Response)
 			}
 			return Promise.reject(new Error("Unexpected URL"))
-		}) as unknown as typeof fetch
+		}) as unknown as typeof fetch)
 
 		// Mock poll to immediately return success
 		vi.mocked(poll).mockResolvedValueOnce(mockPollResponse)
@@ -103,23 +103,23 @@ describe("Device Auth Flow", () => {
 	})
 
 	it("should handle initiation failure", async () => {
-		global.fetch = vi.fn(() =>
+		vi.spyOn(globalThis, "fetch").mockImplementation((() =>
 			Promise.resolve({
 				ok: false,
 				status: 500,
 			} as Response),
-		) as unknown as typeof fetch
+		) as unknown as typeof fetch)
 
 		await expect(authenticateWithDeviceAuth()).rejects.toThrow("Failed to start authentication")
 	})
 
 	it("should handle rate limiting", async () => {
-		global.fetch = vi.fn(() =>
+		vi.spyOn(globalThis, "fetch").mockImplementation((() =>
 			Promise.resolve({
 				ok: false,
 				status: 429,
 			} as Response),
-		) as unknown as typeof fetch
+		) as unknown as typeof fetch)
 
 		await expect(authenticateWithDeviceAuth()).rejects.toThrow(
 			"Too many pending authorization requests. Please try again later.",
@@ -133,7 +133,7 @@ describe("Device Auth Flow", () => {
 			expiresIn: 600,
 		}
 
-		global.fetch = vi.fn((url: string) => {
+		vi.spyOn(globalThis, "fetch").mockImplementation(((url: string) => {
 			if (url.includes("/api/device-auth/codes") && !url.match(/\/codes\/[^/]+$/)) {
 				return Promise.resolve({
 					ok: true,
@@ -148,7 +148,7 @@ describe("Device Auth Flow", () => {
 				} as Response)
 			}
 			return Promise.reject(new Error("Unexpected URL"))
-		}) as unknown as typeof fetch
+		}) as unknown as typeof fetch)
 
 		// Mock poll to immediately return the error
 		vi.mocked(poll).mockRejectedValueOnce(new Error("Authorization denied by user"))
@@ -163,7 +163,7 @@ describe("Device Auth Flow", () => {
 			expiresIn: 600,
 		}
 
-		global.fetch = vi.fn((url: string) => {
+		vi.spyOn(globalThis, "fetch").mockImplementation(((url: string) => {
 			if (url.includes("/api/device-auth/codes") && !url.match(/\/codes\/[^/]+$/)) {
 				return Promise.resolve({
 					ok: true,
@@ -178,7 +178,7 @@ describe("Device Auth Flow", () => {
 				} as Response)
 			}
 			return Promise.reject(new Error("Unexpected URL"))
-		}) as unknown as typeof fetch
+		}) as unknown as typeof fetch)
 
 		// Mock poll to immediately return the error
 		vi.mocked(poll).mockRejectedValueOnce(new Error("Authorization code expired"))

--- a/cli/src/auth/__tests__/device-auth.test.ts
+++ b/cli/src/auth/__tests__/device-auth.test.ts
@@ -103,23 +103,19 @@ describe("Device Auth Flow", () => {
 	})
 
 	it("should handle initiation failure", async () => {
-		vi.spyOn(globalThis, "fetch").mockImplementation((() =>
-			Promise.resolve({
-				ok: false,
-				status: 500,
-			} as Response),
-		) as unknown as typeof fetch)
+		vi.spyOn(globalThis, "fetch").mockResolvedValue({
+			ok: false,
+			status: 500,
+		} as Response)
 
 		await expect(authenticateWithDeviceAuth()).rejects.toThrow("Failed to start authentication")
 	})
 
 	it("should handle rate limiting", async () => {
-		vi.spyOn(globalThis, "fetch").mockImplementation((() =>
-			Promise.resolve({
-				ok: false,
-				status: 429,
-			} as Response),
-		) as unknown as typeof fetch)
+		vi.spyOn(globalThis, "fetch").mockResolvedValue({
+			ok: false,
+			status: 429,
+		} as Response)
 
 		await expect(authenticateWithDeviceAuth()).rejects.toThrow(
 			"Too many pending authorization requests. Please try again later.",

--- a/cli/src/config/__tests__/persistence-provider-merge.test.ts
+++ b/cli/src/config/__tests__/persistence-provider-merge.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import * as fs from "fs/promises"
 import * as path from "path"
-import { loadConfig, setConfigPaths, resetConfigPaths } from "../persistence.js"
 import type { CLIConfig } from "../types.js"
+
+type PersistenceModule = typeof import("../persistence.js")
+let loadConfig: PersistenceModule["loadConfig"]
+let setConfigPaths: PersistenceModule["setConfigPaths"]
+let resetConfigPaths: PersistenceModule["resetConfigPaths"]
 
 // Mock the validation module
 vi.mock("../validation.js", () => ({
@@ -14,6 +18,12 @@ describe("Provider Merging", () => {
 	const testFile = path.join(testDir, "config.json")
 
 	beforeEach(async () => {
+		// Some other test files mock `../persistence.js`; ensure we always test the real implementation here.
+		const persistence = await vi.importActual<PersistenceModule>("../persistence.js")
+		loadConfig = persistence.loadConfig
+		setConfigPaths = persistence.setConfigPaths
+		resetConfigPaths = persistence.resetConfigPaths
+
 		await fs.mkdir(testDir, { recursive: true })
 		setConfigPaths(testDir, testFile)
 	})

--- a/cli/src/ui/components/__tests__/ThinkingAnimation.test.tsx
+++ b/cli/src/ui/components/__tests__/ThinkingAnimation.test.tsx
@@ -19,6 +19,23 @@ vi.mock("../../../state/hooks/useTheme.js", () => ({
 // Animation frames used by the component
 const ANIMATION_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 const FRAME_INTERVAL = 80
+const TIMER_STEP = FRAME_INTERVAL + 1
+
+const getDisplayedFrame = (frameText: string | undefined) =>
+	ANIMATION_FRAMES.find((frame) => frameText?.includes(frame))
+
+const advanceUntilFrame = async (
+	lastFrame: () => string | undefined,
+	expectedFrame: string,
+	maxSteps: number = ANIMATION_FRAMES.length + 2
+) => {
+	for (let i = 0; i < maxSteps; i++) {
+		await vi.advanceTimersByTimeAsync(TIMER_STEP)
+		if (lastFrame()?.includes(expectedFrame)) return
+	}
+
+	expect(lastFrame()).toContain(expectedFrame)
+}
 
 describe("ThinkingAnimation", () => {
 	beforeEach(() => {
@@ -51,27 +68,20 @@ describe("ThinkingAnimation", () => {
 		// Initial frame
 		expect(lastFrame()).toContain(ANIMATION_FRAMES[0])
 
-		// Advance to next frame - use slightly more than interval to ensure timer fires
-		await vi.advanceTimersByTimeAsync(FRAME_INTERVAL + 1)
-		expect(lastFrame()).toContain(ANIMATION_FRAMES[1])
-
-		// Advance to third frame
-		await vi.advanceTimersByTimeAsync(FRAME_INTERVAL + 1)
-		expect(lastFrame()).toContain(ANIMATION_FRAMES[2])
-
-		// Advance to fourth frame
-		await vi.advanceTimersByTimeAsync(FRAME_INTERVAL + 1)
-		expect(lastFrame()).toContain(ANIMATION_FRAMES[3])
+		// useEffect can schedule the interval after a short delay, so don't assume tick 1 starts at t=0
+		await advanceUntilFrame(lastFrame, ANIMATION_FRAMES[1])
+		await advanceUntilFrame(lastFrame, ANIMATION_FRAMES[2])
+		await advanceUntilFrame(lastFrame, ANIMATION_FRAMES[3])
 	})
 
 	it("should loop back to first frame after completing cycle", async () => {
 		const { lastFrame } = render(<ThinkingAnimation />)
 
-		// Advance through all 10 frames plus a small buffer
-		// Using runOnlyPendingTimers in a loop is more deterministic than advancing by exact time
-		for (let i = 0; i < ANIMATION_FRAMES.length; i++) {
-			await vi.advanceTimersByTimeAsync(FRAME_INTERVAL + 1)
-		}
+		// Ensure the interval has started ticking before asserting about looping
+		await advanceUntilFrame(lastFrame, ANIMATION_FRAMES[1])
+
+		// After reaching frame[1], it should loop back to frame[0] within one cycle
+		await advanceUntilFrame(lastFrame, ANIMATION_FRAMES[0], ANIMATION_FRAMES.length)
 
 		// Should be back at first frame
 		expect(lastFrame()).toContain(ANIMATION_FRAMES[0])
@@ -89,17 +99,17 @@ describe("ThinkingAnimation", () => {
 	it("should continue animating after multiple cycles", async () => {
 		const { lastFrame } = render(<ThinkingAnimation />)
 
-		// Complete two full cycles using deterministic timer advancement
-		const totalFrames = ANIMATION_FRAMES.length * 2
-		for (let i = 0; i < totalFrames; i++) {
-			await vi.advanceTimersByTimeAsync(FRAME_INTERVAL + 1)
+		// Wait for at least one tick so we know the interval is active
+		await advanceUntilFrame(lastFrame, ANIMATION_FRAMES[1])
+
+		const seenFrames = new Set<string>()
+		for (let i = 0; i < ANIMATION_FRAMES.length * 2; i++) {
+			await vi.advanceTimersByTimeAsync(TIMER_STEP)
+			const frame = getDisplayedFrame(lastFrame())
+			if (frame) seenFrames.add(frame)
 		}
 
-		// Should be back at first frame after completing full cycles
-		expect(lastFrame()).toContain(ANIMATION_FRAMES[0])
-
-		// Advance one more frame
-		await vi.advanceTimersByTimeAsync(FRAME_INTERVAL + 1)
-		expect(lastFrame()).toContain(ANIMATION_FRAMES[1])
+		// If it keeps animating, we should observe multiple distinct frames over time
+		expect(seenFrames.size).toBeGreaterThan(3)
 	})
 })

--- a/cli/src/ui/components/__tests__/ThinkingAnimation.test.tsx
+++ b/cli/src/ui/components/__tests__/ThinkingAnimation.test.tsx
@@ -17,20 +17,20 @@ vi.mock("../../../state/hooks/useTheme.js", () => ({
 }))
 
 // Animation frames used by the component
-const ANIMATION_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+const ANIMATION_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const
 const FRAME_INTERVAL = 80
 const TIMER_STEP = FRAME_INTERVAL + 1
 
-const getDisplayedFrame = (frameText: string | undefined) =>
+type AnimationFrame = (typeof ANIMATION_FRAMES)[number]
+
+const getDisplayedFrame = (frameText: string | undefined): AnimationFrame | undefined =>
 	ANIMATION_FRAMES.find((frame) => frameText?.includes(frame))
 
 const advanceUntilFrame = async (
 	lastFrame: () => string | undefined,
-	expectedFrame: string | undefined,
+	expectedFrame: AnimationFrame,
 	maxSteps: number = ANIMATION_FRAMES.length + 2
 ) => {
-	if (!expectedFrame) throw new Error("Expected frame is undefined")
-
 	for (let i = 0; i < maxSteps; i++) {
 		await vi.advanceTimersByTimeAsync(TIMER_STEP)
 		if (lastFrame()?.includes(expectedFrame)) return

--- a/cli/src/ui/components/__tests__/ThinkingAnimation.test.tsx
+++ b/cli/src/ui/components/__tests__/ThinkingAnimation.test.tsx
@@ -26,9 +26,11 @@ const getDisplayedFrame = (frameText: string | undefined) =>
 
 const advanceUntilFrame = async (
 	lastFrame: () => string | undefined,
-	expectedFrame: string,
+	expectedFrame: string | undefined,
 	maxSteps: number = ANIMATION_FRAMES.length + 2
 ) => {
+	if (!expectedFrame) throw new Error("Expected frame is undefined")
+
 	for (let i = 0; i < maxSteps; i++) {
 		await vi.advanceTimersByTimeAsync(TIMER_STEP)
 		if (lastFrame()?.includes(expectedFrame)) return

--- a/cli/src/utils/__tests__/getKilocodeDefaultModel.test.ts
+++ b/cli/src/utils/__tests__/getKilocodeDefaultModel.test.ts
@@ -14,10 +14,10 @@ vi.mock("../../services/logs.js", () => ({
 
 // Mock fetch globally
 const mockFetch = vi.fn()
-global.fetch = mockFetch as typeof fetch
 
 describe("getKilocodeDefaultModel", () => {
 	beforeEach(() => {
+		vi.spyOn(globalThis, "fetch").mockImplementation((...args: unknown[]) => mockFetch(...(args as never[])))
 		vi.clearAllMocks()
 	})
 

--- a/cli/src/utils/__tests__/getKilocodeProfile.test.ts
+++ b/cli/src/utils/__tests__/getKilocodeProfile.test.ts
@@ -4,10 +4,10 @@ import type { KilocodeProfileData } from "../../auth/types.js"
 
 // Mock fetch globally
 const mockFetch = vi.fn()
-global.fetch = mockFetch as typeof fetch
 
 describe("getKilocodeProfile", () => {
 	beforeEach(() => {
+		vi.spyOn(globalThis, "fetch").mockImplementation((...args: unknown[]) => mockFetch(...(args as never[])))
 		vi.clearAllMocks()
 	})
 


### PR DESCRIPTION
The CI failure was flaky for two independent reasons:

1) `ThinkingAnimation` test assumed the first `setInterval` tick happens exactly at `t=80ms`. In reality, the interval is started from `useEffect`, which may run after a short delay depending on scheduling, so advancing timers by a fixed amount could still leave the component on the previous frame.

2) Some tests were overwriting `fetch` globally and not restoring it, which intermittently broke Ink's Yoga WASM loader (`Cannot read properties of undefined (reading 'then')`) depending on test ordering/worker reuse.

## What changed

- Made `ThinkingAnimation` assertions robust by advancing timers *until* the expected frame appears (instead of assuming a precise tick start time).
- Switched `fetch` mocking to `vi.spyOn(globalThis, 'fetch')` so it is automatically restored via `vi.restoreAllMocks()` and cannot leak across files.
- Made `persistence-provider-merge` import the real `persistence` module via `vi.importActual()` to avoid being affected by unrelated module mocks in other test files.