### PR TITLE
feat(ui): implement fuzzy matching for slash commands

### DIFF
--- a/.changeset/thirty-rocks-shave.md
+++ b/.changeset/thirty-rocks-shave.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add fuzzy matching to / commands

--- a/webview-ui/src/utils/__tests__/slash-commands.spec.ts
+++ b/webview-ui/src/utils/__tests__/slash-commands.spec.ts
@@ -1,0 +1,73 @@
+// kilocode-change - new file
+import { describe, it, expect } from "vitest"
+import {
+	getMatchingSlashCommands,
+	validateSlashCommand,
+	shouldShowSlashCommandsMenu,
+	insertSlashCommand,
+} from "../slash-commands"
+
+describe("Slash Command Matching", () => {
+	describe("getMatchingSlashCommands - case insensitivity", () => {
+		it("should match commands regardless of case", () => {
+			const results = getMatchingSlashCommands("newtask")
+			expect(results.some((r) => r.name === "newtask")).toBe(true)
+
+			const resultsUpper = getMatchingSlashCommands("NEWTASK")
+			expect(resultsUpper.some((r) => r.name === "newtask")).toBe(true)
+
+			const resultsMixed = getMatchingSlashCommands("NewTask")
+			expect(resultsMixed.some((r) => r.name === "newtask")).toBe(true)
+		})
+
+		it("should match commands with partial queries", () => {
+			const results = getMatchingSlashCommands("new")
+			expect(results.some((r) => r.name === "newtask")).toBe(true)
+			expect(results.some((r) => r.name === "newrule")).toBe(true)
+		})
+
+		it("should return all commands for empty query", () => {
+			const results = getMatchingSlashCommands("")
+			expect(results.length).toBeGreaterThan(0)
+		})
+	})
+
+	describe("validateSlashCommand - case insensitivity", () => {
+		it("should validate exact matches regardless of case", () => {
+			expect(validateSlashCommand("newtask")).toBe("full")
+			expect(validateSlashCommand("NEWTASK")).toBe("full")
+			expect(validateSlashCommand("NewTask")).toBe("full")
+		})
+
+		it("should validate partial matches regardless of case", () => {
+			expect(validateSlashCommand("new")).toBe("partial")
+			expect(validateSlashCommand("NEW")).toBe("partial")
+		})
+
+		it("should return null for non-matching commands", () => {
+			expect(validateSlashCommand("nonexistent")).toBe(null)
+		})
+	})
+
+	describe("shouldShowSlashCommandsMenu", () => {
+		it("should show menu when typing after slash", () => {
+			expect(shouldShowSlashCommandsMenu("/new", 4)).toBe(true)
+		})
+
+		it("should hide menu when there's whitespace after slash", () => {
+			expect(shouldShowSlashCommandsMenu("/ new", 5)).toBe(false)
+		})
+
+		it("should hide menu when no slash present", () => {
+			expect(shouldShowSlashCommandsMenu("newtask", 8)).toBe(false)
+		})
+	})
+
+	describe("insertSlashCommand", () => {
+		it("should insert command and add trailing space", () => {
+			const result = insertSlashCommand("/new", "newtask")
+			expect(result.newValue).toBe("/newtask ")
+			expect(result.commandIndex).toBe(0)
+		})
+	})
+})

--- a/webview-ui/src/utils/slash-commands.ts
+++ b/webview-ui/src/utils/slash-commands.ts
@@ -3,6 +3,7 @@
 
 import { getAllModes } from "@roo/modes"
 import { getBasename } from "./kilocode/path-webview"
+import { Fzf } from "@/lib/word-boundary-fzf" // kilocode_change
 import { ClineRulesToggles } from "@roo/cline-rules"
 
 export interface SlashCommand {
@@ -111,8 +112,12 @@ export function getMatchingSlashCommands(
 		return [...commands]
 	}
 
-	// filter commands that start with the query (case sensitive)
-	return commands.filter((cmd) => cmd.name.startsWith(query))
+	// kilocode_change start: Use Fzf for case-insensitive word-boundary fuzzy matching
+	const fzf = new Fzf(commands, {
+		selector: (cmd: SlashCommand) => cmd.name,
+	})
+	return fzf.find(query).map((result) => result.item)
+	// kilocode_change end: Use Fzf for case-insensitive word-boundary fuzzy matching
 }
 
 /**
@@ -133,7 +138,7 @@ export function insertSlashCommand(text: string, commandName: string): { newValu
 
 /**
  * Determines the validation state of a slash command
- * Returns partial if we have a partial match against valid commands, or full for full match
+ * Returns partial if we have a fuzzy match against valid commands, or full for exact match
  */
 export function validateSlashCommand(
 	command: string,
@@ -145,20 +150,24 @@ export function validateSlashCommand(
 		return null
 	}
 
-	// case sensitive matching
 	const commands = getSupportedSlashCommands(customModes, localWorkflowToggles, globalWorkflowToggles)
 
-	const exactMatch = commands.some((cmd) => cmd.name === command)
-
+	// Check for exact match (command name equals query, case-insensitive via FZF)
+	const lowerCommand = command.toLowerCase()
+	const exactMatch = commands.some((cmd) => cmd.name.toLowerCase() === lowerCommand)
 	if (exactMatch) {
 		return "full"
 	}
 
-	const partialMatch = commands.some((cmd) => cmd.name.startsWith(command))
-
-	if (partialMatch) {
+	// kilocode_change start: Use FZF for consistent fuzzy matching with getMatchingSlashCommands
+	const fzf = new Fzf(commands, {
+		selector: (cmd: SlashCommand) => cmd.name,
+	})
+	const results = fzf.find(command)
+	if (results.length > 0) {
 		return "partial"
 	}
+	// kilocode_change end: Use FZF for consistent fuzzy matching with getMatchingSlashCommands
 
 	return null // no match
 }


### PR DESCRIPTION
Replace simple prefix matching with Fzf-based fuzzy matching for slash command completion and validation. This enables case-insensitive word-boundary matching, improving discoverability and user experience when searching for commands.


**Before**
![2026-01-05 12 31 18](https://github.com/user-attachments/assets/81229102-2ccc-474b-a3af-6c59fe6e6b16)


**After**
![2026-01-05 12 31 45](https://github.com/user-attachments/assets/4fb6c947-cf75-41c2-adc6-7f6d731ca6a6)

