### PR TITLE
fix: add Gradle caching and Maven mirrors for JetBrains CI builds

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -174,6 +174,10 @@ jobs:
                   check-latest: false
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v4
+              with:
+                  cache-read-only: ${{ github.ref != 'refs/heads/main' }}
             - name: Install system dependencies
               run: |
                   sudo apt-get update

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -189,6 +189,10 @@ jobs:
                   java-version: "21"
                   check-latest: false
                   token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v4
+              with:
+                  cache-read-only: false
             - name: Install system dependencies
               run: |
                   sudo apt-get update

--- a/jetbrains/plugin/build.gradle.kts
+++ b/jetbrains/plugin/build.gradle.kts
@@ -66,6 +66,21 @@ version = properties("pluginVersion").get()
 
 repositories {
     mavenCentral()
+    // Fallback mirrors for when Maven Central returns 403 (common in CI environments)
+    maven {
+        url = uri("https://repo1.maven.org/maven2/")
+        content {
+            includeGroupByRegex("com\\.squareup.*")
+            includeGroupByRegex("com\\.google.*")
+        }
+    }
+    maven {
+        url = uri("https://maven-central.storage.googleapis.com/maven2/")
+        content {
+            includeGroupByRegex("com\\.squareup.*")
+            includeGroupByRegex("com\\.google.*")
+        }
+    }
 
     intellijPlatform {
         defaultRepositories()


### PR DESCRIPTION
## Problem
JetBrains builds are failing in CI with 403 Forbidden errors from Maven Central when trying to download dependencies like `okhttp:4.10.0` and `gson:2.10.1`.

## Solution
1. **Added Gradle caching** via `gradle/actions/setup-gradle@v4` to both `code-qa.yml` and `marketplace-publish.yml` workflows
2. **Added fallback Maven mirrors** in `build.gradle.kts`:
   - `repo1.maven.org/maven2/` - Direct Maven Central mirror
   - `maven-central.storage.googleapis.com/maven2/` - Google Cloud mirror

The Gradle caching will cache downloaded dependencies between builds, reducing the likelihood of hitting Maven Central rate limits. The fallback mirrors provide redundancy when the primary Maven Central endpoint returns 403 errors.

## Testing
The fix will be validated when the CI runs on this PR.