### PR TITLE
feat(experiments): enable SPEECH_TO_TEXT experiment

### DIFF
--- a/src/shared/__tests__/experiments.spec.ts
+++ b/src/shared/__tests__/experiments.spec.ts
@@ -27,7 +27,7 @@ describe("experiments", () => {
 		it("is configured correctly", () => {
 			expect(EXPERIMENT_IDS.SPEECH_TO_TEXT).toBe("speechToText")
 			expect(experimentConfigsMap.SPEECH_TO_TEXT).toMatchObject({
-				enabled: false,
+				enabled: true,
 			})
 		})
 	})

--- a/src/shared/experiments.ts
+++ b/src/shared/experiments.ts
@@ -21,7 +21,7 @@ interface ExperimentConfig {
 
 export const experimentConfigsMap: Record<ExperimentKey, ExperimentConfig> = {
 	MORPH_FAST_APPLY: { enabled: false }, // kilocode_change
-	SPEECH_TO_TEXT: { enabled: false }, // kilocode_change
+	SPEECH_TO_TEXT: { enabled: true }, // kilocode_change
 	MULTI_FILE_APPLY_DIFF: { enabled: false },
 	POWER_STEERING: { enabled: false },
 	PREVENT_FOCUS_DISRUPTION: { enabled: false },


### PR DESCRIPTION
Updated the SPEECH_TO_TEXT experiment configuration to be enabled by default