### PR TITLE
refactor: use unique ID for autocomplete telemetry tracking

### DIFF
--- a/src/services/ghost/classic-auto-complete/AutocompleteTelemetry.ts
+++ b/src/services/ghost/classic-auto-complete/AutocompleteTelemetry.ts
@@ -5,11 +5,11 @@ import type { AutocompleteContext, CacheMatchType, FillInAtCursorSuggestion } fr
 export type { AutocompleteContext, CacheMatchType, FillInAtCursorSuggestion }
 
 /**
- * Generate a unique key for a suggestion based on its content and context.
+ * Get the unique key for a suggestion.
  * This key is used to track whether the same suggestion is still being displayed.
  */
 export function getSuggestionKey(suggestion: FillInAtCursorSuggestion): string {
-	return `${suggestion.prefix}|${suggestion.suffix}|${suggestion.text}`
+	return suggestion.id
 }
 
 /**

--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -368,7 +368,7 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 	): FillInAtCursorSuggestion {
 		if (!suggestionText) {
 			this.telemetry?.captureSuggestionFiltered("empty_response", telemetryContext)
-			return { text: "", prefix, suffix }
+			return { id: crypto.randomUUID(), text: "", prefix, suffix }
 		}
 
 		const processedText = postprocessGhostSuggestion({
@@ -379,11 +379,11 @@ export class GhostInlineCompletionProvider implements vscode.InlineCompletionIte
 		})
 
 		if (processedText) {
-			return { text: processedText, prefix, suffix }
+			return { id: crypto.randomUUID(), text: processedText, prefix, suffix }
 		}
 
 		this.telemetry?.captureSuggestionFiltered("filtered_by_postprocessing", telemetryContext)
-		return { text: "", prefix, suffix }
+		return { id: crypto.randomUUID(), text: "", prefix, suffix }
 	}
 
 	private async disposeIgnoreController(): Promise<void> {

--- a/src/services/ghost/classic-auto-complete/HoleFiller.ts
+++ b/src/services/ghost/classic-auto-complete/HoleFiller.ts
@@ -31,6 +31,7 @@ export function parseGhostResponse(fullResponse: string, prefix: string, suffix:
 
 	// Return FillInAtCursorSuggestion with the text (empty string if nothing found)
 	return {
+		id: crypto.randomUUID(),
 		text: fimText,
 		prefix,
 		suffix,

--- a/src/services/ghost/classic-auto-complete/__tests__/AutocompleteTelemetry.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/AutocompleteTelemetry.test.ts
@@ -12,10 +12,11 @@ describe("AutocompleteTelemetry", () => {
 	})
 
 	/**
-	 * Helper to create a FillInAtCursorSuggestion with a unique key
+	 * Helper to create a FillInAtCursorSuggestion with a unique id
 	 */
 	function createSuggestion(index: number): FillInAtCursorSuggestion {
 		return {
+			id: `suggestion-${index}`,
 			text: `text-${index}`,
 			prefix: `prefix-${index}`,
 			suffix: `suffix-${index}`,

--- a/src/services/ghost/types.ts
+++ b/src/services/ghost/types.ts
@@ -93,6 +93,8 @@ export interface PromptResult {
 // ============================================================================
 
 export interface FillInAtCursorSuggestion {
+	/** Unique identifier for this suggestion, used for telemetry tracking */
+	id: string
 	text: string
 	prefix: string
 	suffix: string


### PR DESCRIPTION
## Summary

Instead of tracking the tuple prefix/suffix/text as identity for autocomplete telemetry, this PR uses a unique identifier stored in the suggestion cache.

## Changes

- Added `id` field to `FillInAtCursorSuggestion` interface
- Updated `getSuggestionKey()` to use the ID instead of concatenating prefix|suffix|text
- Updated `processSuggestion()` and `parseGhostResponse()` to generate unique IDs using `crypto.randomUUID()`
- Updated tests to use the new ID-based approach

## Benefits

- Simpler key generation (just the UUID)
- Consistent tracking regardless of how suggestions are displayed (e.g., truncated to first line)
- Better privacy (telemetry key no longer contains actual suggestion text)

Related to #4383