### PR TITLE
fix(ui): support camelCase and PascalCase in slash command fuzzy matching

### DIFF
--- a/webview-ui/src/lib/__tests__/word-boundary-fzf.spec.ts
+++ b/webview-ui/src/lib/__tests__/word-boundary-fzf.spec.ts
@@ -1,4 +1,4 @@
-//kilocode_change new file
+// kilocode_change - new file
 import { describe, it, expect } from "vitest"
 import { Fzf } from "../word-boundary-fzf"
 
@@ -465,6 +465,49 @@ describe("Fzf - Word Boundary Matching", () => {
 
 			// Should match "foo-bar" with "foob" (foo + b from bar)
 			expect(results).toHaveLength(1)
+		})
+	})
+
+	describe("camelCase and PascalCase support", () => {
+		it("should recognize camelCase as word boundary", () => {
+			const items = [{ name: "gitRebase" }, { name: "newFile" }, { name: "httpRequest" }]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			const results = fzf.find("gr")
+			// Should match "gitRebase" (gr at word boundary)
+			expect(results).toHaveLength(1)
+			expect(results[0].item.name).toBe("gitRebase")
+		})
+
+		it("should match PascalCase acronyms", () => {
+			const items = [{ name: "NewFileCreation" }, { name: "HttpRequest" }, { name: "APIClient" }]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			const results = fzf.find("NFC")
+			// Should match "NewFileCreation" (N + F + C)
+			expect(results.length).toBeGreaterThan(0)
+			expect(results.some((r) => r.item.name === "NewFileCreation")).toBe(true)
+		})
+
+		it("should handle mixed case scenarios", () => {
+			const items = [{ name: "gitRebase" }, { name: "newFile" }, { name: "GitRebase" }, { name: "NewFile" }]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			const results = fzf.find("GitR")
+			// Should match both gitRebase and GitRebase
+			expect(results.length).toBeGreaterThanOrEqual(2)
+			expect(results.some((r) => r.item.name === "gitRebase")).toBe(true)
+			expect(results.some((r) => r.item.name === "GitRebase")).toBe(true)
+		})
+
+		it("should split camelCase at uppercase transitions", () => {
+			const items = [{ name: "parseMarkdownContent" }, { name: "renderHtmlTemplate" }]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+
+			const results = fzf.find("pmc")
+			// Should match "parseMarkdownContent" (P + M + C)
+			expect(results.length).toBeGreaterThan(0)
+			expect(results.some((r) => r.item.name === "parseMarkdownContent")).toBe(true)
 		})
 	})
 

--- a/webview-ui/src/lib/word-boundary-fzf.ts
+++ b/webview-ui/src/lib/word-boundary-fzf.ts
@@ -1,4 +1,4 @@
-//kilocode_change - new file
+// kilocode_change - new file
 
 /**
  * Drop-in replacement for Fzf library that uses word boundary matching

--- a/webview-ui/src/lib/word-boundary-fzf.ts
+++ b/webview-ui/src/lib/word-boundary-fzf.ts
@@ -1,4 +1,4 @@
-//kilocode_change new file
+//kilocode_change - new file
 
 /**
  * Drop-in replacement for Fzf library that uses word boundary matching
@@ -18,7 +18,9 @@ interface FzfResult<T> {
 }
 
 // Single source of truth for word boundary characters
-const WORD_BOUNDARY_REGEX = /[\s\-_./\\:]+/
+// - Split at positions before uppercase letters (camelCase/PascalCase: gitRebase → git, Rebase)
+// - Split at existing delimiters: hyphen, underscore, dot, colon, whitespace, forward/back slash
+const WORD_BOUNDARY_REGEX = /(?=[A-Z])|[-_.:\s/\\]+/
 
 export class Fzf<T> {
 	private items: T[]
@@ -62,7 +64,7 @@ export class Fzf<T> {
 		}
 
 		for (const item of this.items) {
-			const text = this.selector(item).toLowerCase()
+			const text = this.selector(item)
 
 			// For multi-word queries, all words must match
 			if (queryWords.length > 1) {
@@ -89,16 +91,12 @@ export class Fzf<T> {
 	 * Each character in the query should match the start of a word in the text.
 	 */
 	private matchAcronym(text: string, query: string): boolean {
-		const words = text.split(WORD_BOUNDARY_REGEX).filter((w) => w.length > 0)
-
-		// Build word start positions in the original text
-		const wordStartPositions: number[] = []
-		let searchPos = 0
-		for (const word of words) {
-			const wordPos = text.indexOf(word, searchPos)
-			wordStartPositions.push(wordPos)
-			searchPos = wordPos + word.length
-		}
+		// Split original text to find word boundaries (including camelCase transitions)
+		// Then lowercase the words for case-insensitive matching
+		const words = text
+			.split(WORD_BOUNDARY_REGEX)
+			.filter((w) => w.length > 0)
+			.map((w) => w.toLowerCase())
 
 		// Recursive helper function to try matching from a given word index
 		const tryMatch = (wordIdx: number, queryIdx: number): boolean => {

--- a/webview-ui/src/utils/__tests__/slash-commands.spec.ts
+++ b/webview-ui/src/utils/__tests__/slash-commands.spec.ts
@@ -70,4 +70,26 @@ describe("Slash Command Matching", () => {
 			expect(result.commandIndex).toBe(0)
 		})
 	})
+
+	describe("getMatchingSlashCommands - underscore and camelCase", () => {
+		it("should match underscore delimited commands with acronym query", () => {
+			const results = getMatchingSlashCommands("nf", [], { new_file_creation: true }, {})
+			expect(results.some((r) => r.name === "new_file_creation")).toBe(true)
+		})
+
+		it("should match camelCase commands with acronym query", () => {
+			const results = getMatchingSlashCommands("gr", [], { gitRebase: true }, {})
+			expect(results.some((r) => r.name === "gitRebase")).toBe(true)
+		})
+
+		it("should match camelCase commands with mixed case query", () => {
+			const results = getMatchingSlashCommands("GitR", [], { gitRebase: true }, {})
+			expect(results.some((r) => r.name === "gitRebase")).toBe(true)
+		})
+
+		it("should match PascalCase commands with acronym query", () => {
+			const results = getMatchingSlashCommands("NFC", [], { NewFileCreation: true }, {})
+			expect(results.some((r) => r.name === "NewFileCreation")).toBe(true)
+		})
+	})
 })


### PR DESCRIPTION
This updates the slash command fuzzy matching to handle camel case, underscores, and other delimiters