### PR TITLE
feat(cli): support Cmd+V for image paste in VSCode terminal

### DIFF
--- a/.changeset/cmdv-image-paste-macos.md
+++ b/.changeset/cmdv-image-paste-macos.md
@@ -1,0 +1,9 @@
+---
+"kilo-code": patch
+---
+
+Support Cmd+V for pasting images on macOS in VSCode terminal
+
+- Detect empty bracketed paste (when clipboard contains image instead of text)
+- Trigger clipboard image check on empty paste or paste timeout
+- Add Cmd+V (meta key) support alongside Ctrl+V for image paste


### PR DESCRIPTION
## Summary

Adds support for Cmd+V to paste images from clipboard in VSCode terminal on macOS, matching the behavior of Ctrl+V.

**Context:** Ctrl+V for images already works in all terminals. Cmd+V is the macOS-native paste shortcut and now also works for images in VSCode terminal.

## Problem

On macOS in VSCode terminal, when the clipboard contains an image and the user presses Cmd+V:
1. The terminal sends a bracketed paste (may contain filename if image file was copied from Finder)
2. The terminal cannot convert image data to text, so image data is not sent
3. Previously, this resulted in pasting the filename instead of the image

## Solution

Always check clipboard for image first when completing a paste operation. If image found, insert it. If not, use the pasted text as fallback.

### Changes

- **keyboard.ts**: 
  - Modify `triggerClipboardImagePasteAtom` to accept optional fallback text
  - If no image in clipboard and fallback text provided, broadcast it as paste event
  - Support Cmd+V (meta key) in `handleGlobalHotkeys`
- **KeyboardProvider.tsx**: 
  - Simplify `completePaste()` to always check clipboard for image first
  - Pass pasted text as fallback when no image found

## Test plan

- [x] Cmd+V with image in clipboard (VSCode terminal) - image is attached
- [x] Cmd+V with image file copied from Finder - image is attached (not filename)
- [x] Cmd+V with text in clipboard - text is pasted normally
- [x] Ctrl+V with image - still works as before
- [x] Empty clipboard Cmd+V - silent (no action)

## Related

Same behavior as Claude Code's Cmd+V image paste support in VSCode terminal.