### PR TITLE
Separate recommended models from rest to make it more clear

### DIFF
--- a/.changeset/model-picker-sections.md
+++ b/.changeset/model-picker-sections.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add section headers to model selection dropdowns for "Recommended models" and "All models"

--- a/webview-ui/src/components/kilocode/chat/ModelSelector.tsx
+++ b/webview-ui/src/components/kilocode/chat/ModelSelector.tsx
@@ -32,7 +32,7 @@ export const ModelSelector = ({
 	const modelIdKey = getModelIdKey({ provider })
 	const isAutocomplete = apiConfiguration.profileType === "autocomplete"
 
-	const { preferredModelIds, restModelIds, hasPreferred } = useGroupedModelIds(providerModels)
+	const { preferredModelIds, restModelIds } = useGroupedModelIds(providerModels)
 	const options = useMemo(() => {
 		const result: DropdownOption[] = []
 
@@ -41,7 +41,7 @@ export const ModelSelector = ({
 		const isMissingSelectedModel = selectedModelId && !allModelIds.includes(selectedModelId)
 
 		// Add "Recommended models" section if there are preferred models
-		if (hasPreferred && preferredModelIds.length > 0) {
+		if (preferredModelIds.length > 0) {
 			result.push({
 				value: "__label_recommended__",
 				label: t("settings:modelPicker.recommendedModels"),
@@ -91,7 +91,7 @@ export const ModelSelector = ({
 		}
 
 		return result
-	}, [preferredModelIds, restModelIds, hasPreferred, providerModels, selectedModelId, t])
+	}, [preferredModelIds, restModelIds, providerModels, selectedModelId, t])
 
 	const disabled = isLoading || isError || isAutocomplete
 

--- a/webview-ui/src/components/kilocode/chat/ModelSelector.tsx
+++ b/webview-ui/src/components/kilocode/chat/ModelSelector.tsx
@@ -48,9 +48,6 @@ export const ModelSelector = ({
 				type: DropdownOptionType.LABEL,
 			})
 
-			// Add the missing selected model at the top if it was a preferred model
-			// (unlikely, but handle the edge case)
-
 			preferredModelIds.forEach((modelId) => {
 				result.push({
 					value: modelId,
@@ -121,6 +118,7 @@ export const ModelSelector = ({
 		return null
 	}
 
+	// kilocode_change start: Display active model for virtual quota fallback
 	if (provider === "virtual-quota-fallback" && virtualQuotaActiveModel) {
 		return (
 			<span className="text-xs text-vscode-descriptionForeground opacity-70 truncate">
@@ -128,6 +126,7 @@ export const ModelSelector = ({
 			</span>
 		)
 	}
+	// kilocode_change end
 
 	if (isError || isAutocomplete || options.length <= 0) {
 		return <span className="text-xs text-vscode-descriptionForeground opacity-70 truncate">{fallbackText}</span>

--- a/webview-ui/src/components/kilocode/chat/__tests__/ModelSelector.spec.tsx
+++ b/webview-ui/src/components/kilocode/chat/__tests__/ModelSelector.spec.tsx
@@ -15,7 +15,11 @@ vi.mock("@/i18n/TranslationContext", () => ({
 }))
 
 vi.mock("@/components/ui/hooks/kilocode/usePreferredModels", () => ({
-	usePreferredModels: () => ["model-1", "model-2"],
+	useGroupedModelIds: () => ({
+		preferredModelIds: [],
+		restModelIds: ["model-1", "model-2"],
+		hasPreferred: false,
+	}),
 }))
 
 // Create a mock function that can be controlled per test

--- a/webview-ui/src/components/kilocode/chat/__tests__/ModelSelector.spec.tsx
+++ b/webview-ui/src/components/kilocode/chat/__tests__/ModelSelector.spec.tsx
@@ -14,12 +14,11 @@ vi.mock("@/i18n/TranslationContext", () => ({
 	}),
 }))
 
+// Create a mock function that can be controlled per test
+const mockUseGroupedModelIds = vi.fn()
+
 vi.mock("@/components/ui/hooks/kilocode/usePreferredModels", () => ({
-	useGroupedModelIds: () => ({
-		preferredModelIds: [],
-		restModelIds: ["model-1", "model-2"],
-		hasPreferred: false,
-	}),
+	useGroupedModelIds: () => mockUseGroupedModelIds(),
 }))
 
 // Create a mock function that can be controlled per test
@@ -41,9 +40,18 @@ describe("ModelSelector", () => {
 	}
 
 	beforeEach(() => {
-		// Reset mock before each test
+		// Reset mocks before each test
 		mockUseProviderModels.mockReset()
-		// Default mock implementation
+		mockUseGroupedModelIds.mockReset()
+
+		// Default mock implementation for useGroupedModelIds (no preferred models)
+		mockUseGroupedModelIds.mockReturnValue({
+			preferredModelIds: [],
+			restModelIds: ["model-1", "model-2"],
+			hasPreferred: false,
+		})
+
+		// Default mock implementation for useProviderModels
 		mockUseProviderModels.mockReturnValue({
 			provider: "openai",
 			providerModels: {
@@ -191,5 +199,102 @@ describe("ModelSelector", () => {
 
 		const dropdownTrigger = screen.queryByTestId("dropdown-trigger")
 		expect(dropdownTrigger).not.toBeInTheDocument()
+	})
+
+	describe("preferred models sections", () => {
+		test("builds options with section headers when preferred models exist", () => {
+			// Setup mock to return preferred models
+			mockUseGroupedModelIds.mockReturnValue({
+				preferredModelIds: ["preferred-1", "preferred-2"],
+				restModelIds: ["model-1", "model-2"],
+				hasPreferred: true,
+			})
+
+			mockUseProviderModels.mockReturnValue({
+				provider: "openai",
+				providerModels: {
+					"preferred-1": { displayName: "Preferred Model 1", preferredIndex: 0 },
+					"preferred-2": { displayName: "Preferred Model 2", preferredIndex: 1 },
+					"model-1": { displayName: "Model 1" },
+					"model-2": { displayName: "Model 2" },
+				},
+				providerDefaultModel: "model-1",
+				isLoading: false,
+				isError: false,
+			})
+
+			render(
+				<ModelSelector
+					currentApiConfigName="test-profile"
+					apiConfiguration={{
+						apiProvider: "openai",
+						apiModelId: "model-1",
+					}}
+					fallbackText="Select a model"
+				/>,
+			)
+
+			// Should render the dropdown
+			const dropdownTrigger = screen.getByTestId("dropdown-trigger")
+			expect(dropdownTrigger).toBeInTheDocument()
+		})
+
+		test("does not add section headers when no preferred models exist", () => {
+			// Setup mock with no preferred models
+			mockUseGroupedModelIds.mockReturnValue({
+				preferredModelIds: [],
+				restModelIds: ["model-1", "model-2"],
+				hasPreferred: false,
+			})
+
+			render(
+				<ModelSelector
+					currentApiConfigName="test-profile"
+					apiConfiguration={{
+						apiProvider: "openai",
+						apiModelId: "model-1",
+					}}
+					fallbackText="Select a model"
+				/>,
+			)
+
+			// Should render the dropdown
+			const dropdownTrigger = screen.getByTestId("dropdown-trigger")
+			expect(dropdownTrigger).toBeInTheDocument()
+		})
+
+		test("handles only preferred models without rest models", () => {
+			// Setup mock with only preferred models (edge case)
+			mockUseGroupedModelIds.mockReturnValue({
+				preferredModelIds: ["preferred-1"],
+				restModelIds: [],
+				hasPreferred: true,
+			})
+
+			mockUseProviderModels.mockReturnValue({
+				provider: "openai",
+				providerModels: {
+					"preferred-1": { displayName: "Preferred Model 1", preferredIndex: 0 },
+				},
+				providerDefaultModel: "preferred-1",
+				isLoading: false,
+				isError: false,
+			})
+
+			render(
+				<ModelSelector
+					currentApiConfigName="test-profile"
+					apiConfiguration={{
+						apiProvider: "openai",
+						apiModelId: "preferred-1",
+					}}
+					fallbackText="Select a model"
+				/>,
+			)
+
+			// Should render the dropdown with only preferred models section
+			const dropdownTrigger = screen.getByTestId("dropdown-trigger")
+			expect(dropdownTrigger).toBeInTheDocument()
+		})
 	})
 })

--- a/webview-ui/src/components/kilocode/chat/__tests__/ModelSelector.spec.tsx
+++ b/webview-ui/src/components/kilocode/chat/__tests__/ModelSelector.spec.tsx
@@ -48,7 +48,6 @@ describe("ModelSelector", () => {
 		mockUseGroupedModelIds.mockReturnValue({
 			preferredModelIds: [],
 			restModelIds: ["model-1", "model-2"],
-			hasPreferred: false,
 		})
 
 		// Default mock implementation for useProviderModels
@@ -207,7 +206,6 @@ describe("ModelSelector", () => {
 			mockUseGroupedModelIds.mockReturnValue({
 				preferredModelIds: ["preferred-1", "preferred-2"],
 				restModelIds: ["model-1", "model-2"],
-				hasPreferred: true,
 			})
 
 			mockUseProviderModels.mockReturnValue({
@@ -244,7 +242,6 @@ describe("ModelSelector", () => {
 			mockUseGroupedModelIds.mockReturnValue({
 				preferredModelIds: [],
 				restModelIds: ["model-1", "model-2"],
-				hasPreferred: false,
 			})
 
 			render(
@@ -268,7 +265,6 @@ describe("ModelSelector", () => {
 			mockUseGroupedModelIds.mockReturnValue({
 				preferredModelIds: ["preferred-1"],
 				restModelIds: [],
-				hasPreferred: true,
 			})
 
 			mockUseProviderModels.mockReturnValue({

--- a/webview-ui/src/components/settings/ModelPicker.tsx
+++ b/webview-ui/src/components/settings/ModelPicker.tsx
@@ -139,7 +139,7 @@ export const ModelPicker = ({
 
 	useEffect(() => {
 		if (!selectedModelId && !isInitialized.current) {
-			const initialValue = allModelIds.includes(selectedModelId) ? selectedModelId : defaultModelId
+			const initialValue = allModelIds.includes(selectedModelId) ? selectedModelId : defaultModelId // kilocode_change
 			setApiConfigurationField(modelIdKey, initialValue, false) // false = automatic initialization
 		}
 

--- a/webview-ui/src/components/settings/ModelPicker.tsx
+++ b/webview-ui/src/components/settings/ModelPicker.tsx
@@ -251,13 +251,17 @@ export const ModelPicker = ({
 								)}
 								{/* kilocode_change end */}
 							</CommandList>
-							{searchValue && !allModelIds.includes(searchValue) && (
-								<div className="p-1 border-t border-vscode-input-border">
-									<CommandItem data-testid="use-custom-model" value={searchValue} onSelect={onSelect}>
-										{t("settings:modelPicker.useCustomModel", { modelId: searchValue })}
-									</CommandItem>
-								</div>
-							)}
+							{searchValue &&
+								!allModelIds.includes(searchValue) && ( // kilocode_change: allModelIds replaces modelIds
+									<div className="p-1 border-t border-vscode-input-border">
+										<CommandItem
+											data-testid="use-custom-model"
+											value={searchValue}
+											onSelect={onSelect}>
+											{t("settings:modelPicker.useCustomModel", { modelId: searchValue })}
+										</CommandItem>
+									</div>
+								)}
 						</Command>
 					</PopoverContent>
 				</Popover>

--- a/webview-ui/src/components/settings/ModelPicker.tsx
+++ b/webview-ui/src/components/settings/ModelPicker.tsx
@@ -7,7 +7,7 @@ import type { ProviderSettings, ModelInfo, OrganizationAllowList } from "@roo-co
 
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { useSelectedModel } from "@/components/ui/hooks/useSelectedModel"
-import { useGroupedModelIds } from "@/components/ui/hooks/kilocode/usePreferredModels" // kilocode_change: use grouped hook
+import { useGroupedModelIds } from "@/components/ui/hooks/kilocode/usePreferredModels" // kilocode_change
 // import { filterModels } from "./utils/organizationFilters" // kilocode_change: not doing this
 import { cn } from "@src/lib/utils"
 import {
@@ -89,7 +89,7 @@ export const ModelPicker = ({
 
 	// kilocode_change start: Use grouped model IDs for section headers
 	const { preferredModelIds, restModelIds, hasPreferred } = useGroupedModelIds(models)
-	const allModelIds = useMemo(() => [...preferredModelIds, ...restModelIds], [preferredModelIds, restModelIds])
+	const modelIds = useMemo(() => [...preferredModelIds, ...restModelIds], [preferredModelIds, restModelIds])
 	const [isPricingExpanded, setIsPricingExpanded] = useState(false)
 	// kilocode_change end
 
@@ -139,12 +139,12 @@ export const ModelPicker = ({
 
 	useEffect(() => {
 		if (!selectedModelId && !isInitialized.current) {
-			const initialValue = allModelIds.includes(selectedModelId) ? selectedModelId : defaultModelId // kilocode_change
+			const initialValue = modelIds.includes(selectedModelId) ? selectedModelId : defaultModelId
 			setApiConfigurationField(modelIdKey, initialValue, false) // false = automatic initialization
 		}
 
 		isInitialized.current = true
-	}, [allModelIds, setApiConfigurationField, modelIdKey, selectedModelId, defaultModelId]) // kilocode_change: allModelIds replaces modelIds
+	}, [modelIds, setApiConfigurationField, modelIdKey, selectedModelId, defaultModelId])
 
 	// Cleanup timeouts on unmount to prevent test flakiness
 	useEffect(() => {
@@ -251,17 +251,13 @@ export const ModelPicker = ({
 								)}
 								{/* kilocode_change end */}
 							</CommandList>
-							{searchValue &&
-								!allModelIds.includes(searchValue) && ( // kilocode_change: allModelIds replaces modelIds
-									<div className="p-1 border-t border-vscode-input-border">
-										<CommandItem
-											data-testid="use-custom-model"
-											value={searchValue}
-											onSelect={onSelect}>
-											{t("settings:modelPicker.useCustomModel", { modelId: searchValue })}
-										</CommandItem>
-									</div>
-								)}
+							{searchValue && !modelIds.includes(searchValue) && (
+								<div className="p-1 border-t border-vscode-input-border">
+									<CommandItem data-testid="use-custom-model" value={searchValue} onSelect={onSelect}>
+										{t("settings:modelPicker.useCustomModel", { modelId: searchValue })}
+									</CommandItem>
+								</div>
+							)}
 						</Command>
 					</PopoverContent>
 				</Popover>

--- a/webview-ui/src/components/settings/ModelPicker.tsx
+++ b/webview-ui/src/components/settings/ModelPicker.tsx
@@ -88,7 +88,7 @@ export const ModelPicker = ({
 	const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
 	// kilocode_change start: Use grouped model IDs for section headers
-	const { preferredModelIds, restModelIds, hasPreferred } = useGroupedModelIds(models)
+	const { preferredModelIds, restModelIds } = useGroupedModelIds(models)
 	const modelIds = useMemo(() => [...preferredModelIds, ...restModelIds], [preferredModelIds, restModelIds])
 	const [isPricingExpanded, setIsPricingExpanded] = useState(false)
 	// kilocode_change end
@@ -206,7 +206,7 @@ export const ModelPicker = ({
 									)}
 								</CommandEmpty>
 								{/* kilocode_change start: Section headers for recommended and all models */}
-								{hasPreferred && preferredModelIds.length > 0 && (
+								{preferredModelIds.length > 0 && (
 									<CommandGroup heading={t("settings:modelPicker.recommendedModels")}>
 										{preferredModelIds.map((model) => (
 											<CommandItem

--- a/webview-ui/src/components/ui/__tests__/select-dropdown.spec.tsx
+++ b/webview-ui/src/components/ui/__tests__/select-dropdown.spec.tsx
@@ -254,6 +254,51 @@ describe("SelectDropdown", () => {
 			expect(content).toBeInTheDocument()
 		})
 
+		// kilocode_change start: Tests for LABEL type (section headers)
+		it("renders label options as section headers", () => {
+			const optionsWithLabel = [
+				{ value: "__label_recommended__", label: "Recommended models", type: DropdownOptionType.LABEL },
+				{ value: "model1", label: "Model 1" },
+				{ value: "__label_all__", label: "All models", type: DropdownOptionType.LABEL },
+				{ value: "model2", label: "Model 2" },
+			]
+
+			render(<SelectDropdown value="model1" options={optionsWithLabel} onChange={onChangeMock} />)
+
+			// Click the trigger to open the dropdown
+			const trigger = screen.getByTestId("dropdown-trigger")
+			fireEvent.click(trigger)
+
+			// Now we can check for dropdown content
+			const content = screen.getByTestId("dropdown-content")
+			expect(content).toBeInTheDocument()
+
+			// For this test, we'll just verify the content is rendered
+			// In a real scenario, we'd need to update the mock to properly handle label rendering
+			expect(content).toBeInTheDocument()
+		})
+
+		it("LABEL options are non-selectable", () => {
+			const optionsWithLabel = [
+				{ value: "__label_section__", label: "Section Header", type: DropdownOptionType.LABEL },
+				{ value: "option1", label: "Option 1" },
+			]
+
+			render(<SelectDropdown value="option1" options={optionsWithLabel} onChange={onChangeMock} />)
+
+			// Click the trigger to open the dropdown
+			const trigger = screen.getByTestId("dropdown-trigger")
+			fireEvent.click(trigger)
+
+			// The content should be rendered
+			const content = screen.getByTestId("dropdown-content")
+			expect(content).toBeInTheDocument()
+
+			// LABEL items should not trigger onChange when interacted with
+			// The actual behavior is tested via integration since our mock doesn't fully simulate this
+		})
+		// kilocode_change end
+
 		it("calls onChange for regular menu items", () => {
 			render(<SelectDropdown value="option1" options={options} onChange={onChangeMock} />)
 

--- a/webview-ui/src/components/ui/__tests__/select-dropdown.spec.tsx
+++ b/webview-ui/src/components/ui/__tests__/select-dropdown.spec.tsx
@@ -272,10 +272,6 @@ describe("SelectDropdown", () => {
 			// Now we can check for dropdown content
 			const content = screen.getByTestId("dropdown-content")
 			expect(content).toBeInTheDocument()
-
-			// For this test, we'll just verify the content is rendered
-			// In a real scenario, we'd need to update the mock to properly handle label rendering
-			expect(content).toBeInTheDocument()
 		})
 
 		it("LABEL options are non-selectable", () => {
@@ -294,8 +290,10 @@ describe("SelectDropdown", () => {
 			const content = screen.getByTestId("dropdown-content")
 			expect(content).toBeInTheDocument()
 
-			// LABEL items should not trigger onChange when interacted with
-			// The actual behavior is tested via integration since our mock doesn't fully simulate this
+			// Note: The actual component renders LABEL items as static divs without onClick handlers
+			// (with data-testid="dropdown-label"), making them inherently non-selectable.
+			// This test uses mocks, so we just verify the component renders correctly.
+			// The non-selectability behavior is ensured by the component's implementation.
 		})
 		// kilocode_change end
 

--- a/webview-ui/src/components/ui/__tests__/select-dropdown.spec.tsx
+++ b/webview-ui/src/components/ui/__tests__/select-dropdown.spec.tsx
@@ -254,49 +254,6 @@ describe("SelectDropdown", () => {
 			expect(content).toBeInTheDocument()
 		})
 
-		// kilocode_change start: Tests for LABEL type (section headers)
-		it("renders label options as section headers", () => {
-			const optionsWithLabel = [
-				{ value: "__label_recommended__", label: "Recommended models", type: DropdownOptionType.LABEL },
-				{ value: "model1", label: "Model 1" },
-				{ value: "__label_all__", label: "All models", type: DropdownOptionType.LABEL },
-				{ value: "model2", label: "Model 2" },
-			]
-
-			render(<SelectDropdown value="model1" options={optionsWithLabel} onChange={onChangeMock} />)
-
-			// Click the trigger to open the dropdown
-			const trigger = screen.getByTestId("dropdown-trigger")
-			fireEvent.click(trigger)
-
-			// Now we can check for dropdown content
-			const content = screen.getByTestId("dropdown-content")
-			expect(content).toBeInTheDocument()
-		})
-
-		it("LABEL options are non-selectable", () => {
-			const optionsWithLabel = [
-				{ value: "__label_section__", label: "Section Header", type: DropdownOptionType.LABEL },
-				{ value: "option1", label: "Option 1" },
-			]
-
-			render(<SelectDropdown value="option1" options={optionsWithLabel} onChange={onChangeMock} />)
-
-			// Click the trigger to open the dropdown
-			const trigger = screen.getByTestId("dropdown-trigger")
-			fireEvent.click(trigger)
-
-			// The content should be rendered
-			const content = screen.getByTestId("dropdown-content")
-			expect(content).toBeInTheDocument()
-
-			// Note: The actual component renders LABEL items as static divs without onClick handlers
-			// (with data-testid="dropdown-label"), making them inherently non-selectable.
-			// This test uses mocks, so we just verify the component renders correctly.
-			// The non-selectability behavior is ensured by the component's implementation.
-		})
-		// kilocode_change end
-
 		it("calls onChange for regular menu items", () => {
 			render(<SelectDropdown value="option1" options={options} onChange={onChangeMock} />)
 

--- a/webview-ui/src/components/ui/hooks/kilocode/__tests__/usePreferredModels.spec.ts
+++ b/webview-ui/src/components/ui/hooks/kilocode/__tests__/usePreferredModels.spec.ts
@@ -20,7 +20,6 @@ describe("getGroupedModelIds", () => {
 		expect(result).toEqual({
 			preferredModelIds: [],
 			restModelIds: [],
-			hasPreferred: false,
 		})
 	})
 
@@ -30,7 +29,6 @@ describe("getGroupedModelIds", () => {
 		expect(result).toEqual({
 			preferredModelIds: [],
 			restModelIds: [],
-			hasPreferred: false,
 		})
 	})
 
@@ -46,7 +44,6 @@ describe("getGroupedModelIds", () => {
 
 		expect(result.preferredModelIds).toEqual(["model-c", "model-a"])
 		expect(result.restModelIds).toEqual(["model-b", "model-d"])
-		expect(result.hasPreferred).toBe(true)
 	})
 
 	it("sorts preferred models by preferredIndex", () => {
@@ -59,7 +56,6 @@ describe("getGroupedModelIds", () => {
 		const result = getGroupedModelIds(models)
 
 		expect(result.preferredModelIds).toEqual(["model-a", "model-m", "model-z"])
-		expect(result.hasPreferred).toBe(true)
 	})
 
 	it("sorts rest models alphabetically", () => {
@@ -72,7 +68,6 @@ describe("getGroupedModelIds", () => {
 		const result = getGroupedModelIds(models)
 
 		expect(result.restModelIds).toEqual(["alpha-model", "beta-model", "zebra-model"])
-		expect(result.hasPreferred).toBe(false)
 	})
 
 	it("handles case where all models are preferred", () => {
@@ -85,7 +80,6 @@ describe("getGroupedModelIds", () => {
 
 		expect(result.preferredModelIds).toEqual(["model-a", "model-b"])
 		expect(result.restModelIds).toEqual([])
-		expect(result.hasPreferred).toBe(true)
 	})
 
 	it("handles case where no models are preferred", () => {
@@ -98,12 +92,11 @@ describe("getGroupedModelIds", () => {
 
 		expect(result.preferredModelIds).toEqual([])
 		expect(result.restModelIds).toEqual(["model-a", "model-b"])
-		expect(result.hasPreferred).toBe(false)
 	})
 })
 
 describe("useGroupedModelIds", () => {
-	it("returns grouped model IDs with hasPreferred flag", () => {
+	it("returns grouped model IDs", () => {
 		const models: Record<string, ModelInfo> = {
 			"pref-model": createModelInfo({ preferredIndex: 0 }),
 			"rest-model": createModelInfo(),
@@ -113,7 +106,6 @@ describe("useGroupedModelIds", () => {
 
 		expect(result.current.preferredModelIds).toEqual(["pref-model"])
 		expect(result.current.restModelIds).toEqual(["rest-model"])
-		expect(result.current.hasPreferred).toBe(true)
 	})
 
 	it("memoizes result when models don't change", () => {

--- a/webview-ui/src/components/ui/hooks/kilocode/__tests__/usePreferredModels.spec.ts
+++ b/webview-ui/src/components/ui/hooks/kilocode/__tests__/usePreferredModels.spec.ts
@@ -1,0 +1,132 @@
+// kilocode_change - new file
+// npx vitest run src/components/ui/hooks/kilocode/__tests__/usePreferredModels.spec.ts
+
+import { renderHook } from "@testing-library/react"
+import { useGroupedModelIds, getGroupedModelIds } from "../usePreferredModels"
+import type { ModelInfo } from "@roo-code/types"
+
+// Helper to create minimal ModelInfo objects for testing
+const createModelInfo = (overrides: Partial<ModelInfo> = {}): ModelInfo => ({
+	contextWindow: 100000,
+	supportsPromptCache: false,
+	maxTokens: 4096,
+	...overrides,
+})
+
+describe("getGroupedModelIds", () => {
+	it("returns empty arrays when models is null", () => {
+		const result = getGroupedModelIds(null)
+
+		expect(result).toEqual({
+			preferredModelIds: [],
+			restModelIds: [],
+			hasPreferred: false,
+		})
+	})
+
+	it("returns empty arrays when models is empty", () => {
+		const result = getGroupedModelIds({})
+
+		expect(result).toEqual({
+			preferredModelIds: [],
+			restModelIds: [],
+			hasPreferred: false,
+		})
+	})
+
+	it("separates preferred models from rest models", () => {
+		const models: Record<string, ModelInfo> = {
+			"model-a": createModelInfo({ preferredIndex: 1 }),
+			"model-b": createModelInfo(),
+			"model-c": createModelInfo({ preferredIndex: 0 }),
+			"model-d": createModelInfo(),
+		}
+
+		const result = getGroupedModelIds(models)
+
+		expect(result.preferredModelIds).toEqual(["model-c", "model-a"])
+		expect(result.restModelIds).toEqual(["model-b", "model-d"])
+		expect(result.hasPreferred).toBe(true)
+	})
+
+	it("sorts preferred models by preferredIndex", () => {
+		const models: Record<string, ModelInfo> = {
+			"model-z": createModelInfo({ preferredIndex: 2 }),
+			"model-a": createModelInfo({ preferredIndex: 0 }),
+			"model-m": createModelInfo({ preferredIndex: 1 }),
+		}
+
+		const result = getGroupedModelIds(models)
+
+		expect(result.preferredModelIds).toEqual(["model-a", "model-m", "model-z"])
+		expect(result.hasPreferred).toBe(true)
+	})
+
+	it("sorts rest models alphabetically", () => {
+		const models: Record<string, ModelInfo> = {
+			"zebra-model": createModelInfo(),
+			"alpha-model": createModelInfo(),
+			"beta-model": createModelInfo(),
+		}
+
+		const result = getGroupedModelIds(models)
+
+		expect(result.restModelIds).toEqual(["alpha-model", "beta-model", "zebra-model"])
+		expect(result.hasPreferred).toBe(false)
+	})
+
+	it("handles case where all models are preferred", () => {
+		const models: Record<string, ModelInfo> = {
+			"model-a": createModelInfo({ preferredIndex: 0 }),
+			"model-b": createModelInfo({ preferredIndex: 1 }),
+		}
+
+		const result = getGroupedModelIds(models)
+
+		expect(result.preferredModelIds).toEqual(["model-a", "model-b"])
+		expect(result.restModelIds).toEqual([])
+		expect(result.hasPreferred).toBe(true)
+	})
+
+	it("handles case where no models are preferred", () => {
+		const models: Record<string, ModelInfo> = {
+			"model-a": createModelInfo(),
+			"model-b": createModelInfo(),
+		}
+
+		const result = getGroupedModelIds(models)
+
+		expect(result.preferredModelIds).toEqual([])
+		expect(result.restModelIds).toEqual(["model-a", "model-b"])
+		expect(result.hasPreferred).toBe(false)
+	})
+})
+
+describe("useGroupedModelIds", () => {
+	it("returns grouped model IDs with hasPreferred flag", () => {
+		const models: Record<string, ModelInfo> = {
+			"pref-model": createModelInfo({ preferredIndex: 0 }),
+			"rest-model": createModelInfo(),
+		}
+
+		const { result } = renderHook(() => useGroupedModelIds(models))
+
+		expect(result.current.preferredModelIds).toEqual(["pref-model"])
+		expect(result.current.restModelIds).toEqual(["rest-model"])
+		expect(result.current.hasPreferred).toBe(true)
+	})
+
+	it("memoizes result when models don't change", () => {
+		const models: Record<string, ModelInfo> = {
+			"model-a": createModelInfo(),
+		}
+
+		const { result, rerender } = renderHook(() => useGroupedModelIds(models))
+		const firstResult = result.current
+
+		rerender()
+		const secondResult = result.current
+
+		expect(firstResult).toBe(secondResult)
+	})
+})

--- a/webview-ui/src/components/ui/hooks/kilocode/usePreferredModels.ts
+++ b/webview-ui/src/components/ui/hooks/kilocode/usePreferredModels.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import { useMemo } from "react"
 import type { ModelInfo } from "@roo-code/types"
 

--- a/webview-ui/src/components/ui/hooks/kilocode/usePreferredModels.ts
+++ b/webview-ui/src/components/ui/hooks/kilocode/usePreferredModels.ts
@@ -1,18 +1,14 @@
 import { useMemo } from "react"
 import type { ModelInfo } from "@roo-code/types"
 
-/**
- * Result containing preferred and rest model IDs, plus a flag indicating if there are preferred models
- */
+// Result containing preferred and rest model IDs, plus a flag indicating if there are preferred models
 export interface GroupedModelIds {
 	preferredModelIds: string[]
 	restModelIds: string[]
 	hasPreferred: boolean
 }
 
-/**
- * Extracts and groups model IDs into preferred and rest categories
- */
+// Extracts and groups model IDs into preferred and rest categories
 export const getGroupedModelIds = (models: Record<string, ModelInfo> | null): GroupedModelIds => {
 	if (!models) {
 		return { preferredModelIds: [], restModelIds: [], hasPreferred: false }
@@ -49,9 +45,7 @@ export const getGroupedModelIds = (models: Record<string, ModelInfo> | null): Gr
 	}
 }
 
-/**
- * Hook to get grouped model IDs with section metadata for sectioned dropdowns
- */
+// Hook to get grouped model IDs with section metadata for sectioned dropdowns
 export const useGroupedModelIds = (models: Record<string, ModelInfo> | null): GroupedModelIds => {
 	return useMemo(() => getGroupedModelIds(models), [models])
 }

--- a/webview-ui/src/components/ui/hooks/kilocode/usePreferredModels.ts
+++ b/webview-ui/src/components/ui/hooks/kilocode/usePreferredModels.ts
@@ -1,33 +1,58 @@
+// kilocode_change - new file
 import { useMemo } from "react"
 import type { ModelInfo } from "@roo-code/types"
 
-export const usePreferredModels = (models: Record<string, ModelInfo> | null) => {
-	return useMemo(() => {
-		if (!models) return []
+/**
+ * Result containing preferred and rest model IDs, plus a flag indicating if there are preferred models
+ */
+export interface GroupedModelIds {
+	preferredModelIds: string[]
+	restModelIds: string[]
+	hasPreferred: boolean
+}
 
-		const preferredModelIds = []
-		const restModelIds = []
-		// first add the preferred models
-		for (const [key, model] of Object.entries(models)) {
-			if (Number.isInteger(model.preferredIndex)) {
-				preferredModelIds.push(key)
-			}
+/**
+ * Extracts and groups model IDs into preferred and rest categories
+ */
+export const getGroupedModelIds = (models: Record<string, ModelInfo> | null): GroupedModelIds => {
+	if (!models) {
+		return { preferredModelIds: [], restModelIds: [], hasPreferred: false }
+	}
+
+	const preferredModelIds: string[] = []
+	const restModelIds: string[] = []
+
+	// First add the preferred models
+	for (const [key, model] of Object.entries(models)) {
+		if (Number.isInteger(model.preferredIndex)) {
+			preferredModelIds.push(key)
 		}
+	}
 
-		preferredModelIds.sort((a, b) => {
-			const modelA = models[a]
-			const modelB = models[b]
-			return (modelA.preferredIndex ?? 0) - (modelB.preferredIndex ?? 0)
-		})
+	preferredModelIds.sort((a, b) => {
+		const modelA = models[a]
+		const modelB = models[b]
+		return (modelA.preferredIndex ?? 0) - (modelB.preferredIndex ?? 0)
+	})
 
-		// then add the rest
-		for (const [key] of Object.entries(models)) {
-			if (!preferredModelIds.includes(key)) {
-				restModelIds.push(key)
-			}
+	// Then add the rest
+	for (const [key] of Object.entries(models)) {
+		if (!preferredModelIds.includes(key)) {
+			restModelIds.push(key)
 		}
-		restModelIds.sort((a, b) => a.localeCompare(b))
+	}
+	restModelIds.sort((a, b) => a.localeCompare(b))
 
-		return [...preferredModelIds, ...restModelIds]
-	}, [models])
+	return {
+		preferredModelIds,
+		restModelIds,
+		hasPreferred: preferredModelIds.length > 0,
+	}
+}
+
+/**
+ * Hook to get grouped model IDs with section metadata for sectioned dropdowns
+ */
+export const useGroupedModelIds = (models: Record<string, ModelInfo> | null): GroupedModelIds => {
+	return useMemo(() => getGroupedModelIds(models), [models])
 }

--- a/webview-ui/src/components/ui/hooks/kilocode/usePreferredModels.ts
+++ b/webview-ui/src/components/ui/hooks/kilocode/usePreferredModels.ts
@@ -1,17 +1,16 @@
 import { useMemo } from "react"
 import type { ModelInfo } from "@roo-code/types"
 
-// Result containing preferred and rest model IDs, plus a flag indicating if there are preferred models
+// Result containing preferred and rest model IDs
 export interface GroupedModelIds {
 	preferredModelIds: string[]
 	restModelIds: string[]
-	hasPreferred: boolean
 }
 
 // Extracts and groups model IDs into preferred and rest categories
 export const getGroupedModelIds = (models: Record<string, ModelInfo> | null): GroupedModelIds => {
 	if (!models) {
-		return { preferredModelIds: [], restModelIds: [], hasPreferred: false }
+		return { preferredModelIds: [], restModelIds: [] }
 	}
 
 	const preferredModelIds: string[] = []
@@ -41,7 +40,6 @@ export const getGroupedModelIds = (models: Record<string, ModelInfo> | null): Gr
 	return {
 		preferredModelIds,
 		restModelIds,
-		hasPreferred: preferredModelIds.length > 0,
 	}
 }
 

--- a/webview-ui/src/components/ui/select-dropdown.tsx
+++ b/webview-ui/src/components/ui/select-dropdown.tsx
@@ -315,9 +315,7 @@ export const SelectDropdown = React.memo(
 												)
 											}
 
-											{
-												/* kilocode_change start: render LABEL type as section header */
-											}
+											// kilocode_change start: render LABEL type as section header
 											if (option.type === DropdownOptionType.LABEL) {
 												return (
 													<div
@@ -328,9 +326,7 @@ export const SelectDropdown = React.memo(
 													</div>
 												)
 											}
-											{
-												/* kilocode_change end */
-											}
+											// kilocode_change end
 
 											if (
 												option.type === DropdownOptionType.SHORTCUT ||

--- a/webview-ui/src/components/ui/select-dropdown.tsx
+++ b/webview-ui/src/components/ui/select-dropdown.tsx
@@ -319,7 +319,7 @@ export const SelectDropdown = React.memo(
 											if (option.type === DropdownOptionType.LABEL) {
 												return (
 													<div
-														key={`section-${index}`}
+														key={`label-${index}`}
 														className="px-3 py-1.5 text-xs font-medium text-vscode-descriptionForeground uppercase tracking-wide"
 														data-testid="dropdown-label">
 														{option.label}

--- a/webview-ui/src/components/ui/select-dropdown.tsx
+++ b/webview-ui/src/components/ui/select-dropdown.tsx
@@ -15,6 +15,7 @@ export enum DropdownOptionType {
 	SEPARATOR = "separator",
 	SHORTCUT = "shortcut",
 	ACTION = "action",
+	LABEL = "label", // kilocode_change: Section header for grouped options
 }
 
 export interface DropdownOption {
@@ -114,7 +115,9 @@ export const SelectDropdown = React.memo(
 				return options
 					.filter(
 						(option) =>
-							option.type !== DropdownOptionType.SEPARATOR && option.type !== DropdownOptionType.SHORTCUT,
+							option.type !== DropdownOptionType.SEPARATOR &&
+							option.type !== DropdownOptionType.SHORTCUT &&
+							option.type !== DropdownOptionType.LABEL, // kilocode_change: exclude LABEL from search
 					)
 					.map((option) => ({
 						original: option,
@@ -137,9 +140,13 @@ export const SelectDropdown = React.memo(
 				// Get fuzzy matching items - only perform search if we have a search value
 				const matchingItems = fzfInstance.find(searchValue).map((result) => result.item.original)
 
-				// Always include separators and shortcuts
+				// Always include separators, shortcuts, and labels
 				return options.filter((option) => {
-					if (option.type === DropdownOptionType.SEPARATOR || option.type === DropdownOptionType.SHORTCUT) {
+					if (
+						option.type === DropdownOptionType.SEPARATOR ||
+						option.type === DropdownOptionType.SHORTCUT ||
+						option.type === DropdownOptionType.LABEL // kilocode_change: include LABEL in filtered results
+					) {
 						return true
 					}
 
@@ -148,31 +155,61 @@ export const SelectDropdown = React.memo(
 				})
 			}, [options, searchValue, fzfInstance, disableSearch])
 
-			// Group options by type and handle separators
+			// Group options by type and handle separators and labels
+			// kilocode_change start: improved handling for section labels
 			const groupedOptions = React.useMemo(() => {
 				const result: DropdownOption[] = []
-				let lastWasSeparator = false
+				let lastWasSeparatorOrLabel = false
 
 				filteredOptions.forEach((option) => {
 					if (option.type === DropdownOptionType.SEPARATOR) {
 						// Only add separator if we have items before and after it
-						if (result.length > 0 && !lastWasSeparator) {
+						if (result.length > 0 && !lastWasSeparatorOrLabel) {
 							result.push(option)
-							lastWasSeparator = true
+							lastWasSeparatorOrLabel = true
 						}
+					} else if (option.type === DropdownOptionType.LABEL) {
+						// Track label position - we'll only keep it if it has items after it
+						result.push(option)
+						lastWasSeparatorOrLabel = true
 					} else {
 						result.push(option)
-						lastWasSeparator = false
+						lastWasSeparatorOrLabel = false
 					}
 				})
 
-				// Remove trailing separator if present
-				if (result.length > 0 && result[result.length - 1].type === DropdownOptionType.SEPARATOR) {
+				// Remove trailing separator or label if present
+				while (
+					result.length > 0 &&
+					(result[result.length - 1].type === DropdownOptionType.SEPARATOR ||
+						result[result.length - 1].type === DropdownOptionType.LABEL)
+				) {
 					result.pop()
 				}
 
-				return result
+				// Also remove any labels that ended up with no items after them
+				// (can happen when filtering removes all items in a section)
+				const finalResult: DropdownOption[] = []
+				for (let i = 0; i < result.length; i++) {
+					const option = result[i]
+					if (option.type === DropdownOptionType.LABEL) {
+						// Check if next item is also a label or separator (meaning this label has no items)
+						const nextItem = result[i + 1]
+						if (
+							nextItem &&
+							nextItem.type !== DropdownOptionType.LABEL &&
+							nextItem.type !== DropdownOptionType.SEPARATOR
+						) {
+							finalResult.push(option)
+						}
+					} else {
+						finalResult.push(option)
+					}
+				}
+
+				return finalResult
 			}, [filteredOptions])
+			// kilocode_change end
 
 			const handleSelect = React.useCallback(
 				(optionValue: string) => {
@@ -278,13 +315,30 @@ export const SelectDropdown = React.memo(
 												)
 											}
 
+											{
+												/* kilocode_change start: render LABEL type as section header */
+											}
+											if (option.type === DropdownOptionType.LABEL) {
+												return (
+													<div
+														key={`section-${index}`}
+														className="px-3 py-1.5 text-xs font-medium text-vscode-descriptionForeground uppercase tracking-wide"
+														data-testid="dropdown-label">
+														{option.label}
+													</div>
+												)
+											}
+											{
+												/* kilocode_change end */
+											}
+
 											if (
 												option.type === DropdownOptionType.SHORTCUT ||
 												(option.disabled && shortcutText && option.label.includes(shortcutText))
 											) {
 												return (
 													<div
-														key={`label-${index}`}
+														key={`shortcut-${index}`}
 														className="px-3 py-1.5 text-sm opacity-50">
 														{option.label}
 													</div>

--- a/webview-ui/src/i18n/locales/ar/settings.json
+++ b/webview-ui/src/i18n/locales/ar/settings.json
@@ -1134,7 +1134,9 @@
 		"searchPlaceholder": "بحث",
 		"noMatchFound": "ما فيه تطابق",
 		"useCustomModel": "استخدام مخصص: {{modelId}}",
-		"simplifiedExplanation": "يمكنك ضبط إعدادات النموذج التفصيلية لاحقًا."
+		"simplifiedExplanation": "يمكنك ضبط إعدادات النموذج التفصيلية لاحقًا.",
+		"recommendedModels": "Recommended models",
+		"allModels": "All models"
 	},
 	"footer": {
 		"feedback": "عندك سؤال أو ملاحظة؟ افتح تذكرة في <githubLink>github.com/Kilo-Org/kilocode</githubLink> أو انضم لـ <redditLink>r/kilocode</redditLink> أو <discordLink>kilo.ai/discord</discordLink>.",

--- a/webview-ui/src/i18n/locales/ar/settings.json
+++ b/webview-ui/src/i18n/locales/ar/settings.json
@@ -1135,8 +1135,8 @@
 		"noMatchFound": "ما فيه تطابق",
 		"useCustomModel": "استخدام مخصص: {{modelId}}",
 		"simplifiedExplanation": "يمكنك ضبط إعدادات النموذج التفصيلية لاحقًا.",
-		"recommendedModels": "Recommended models",
-		"allModels": "All models"
+		"recommendedModels": "النماذج الموصى بها",
+		"allModels": "جميع النماذج"
 	},
 	"footer": {
 		"feedback": "عندك سؤال أو ملاحظة؟ افتح تذكرة في <githubLink>github.com/Kilo-Org/kilocode</githubLink> أو انضم لـ <redditLink>r/kilocode</redditLink> أو <discordLink>kilo.ai/discord</discordLink>.",

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -1025,7 +1025,9 @@
 		"searchPlaceholder": "Cerca",
 		"noMatchFound": "No s'ha trobat cap coincidència",
 		"useCustomModel": "Utilitzar personalitzat: {{modelId}}",
-		"simplifiedExplanation": "Pots ajustar la configuració detallada del model més tard."
+		"simplifiedExplanation": "Pots ajustar la configuració detallada del model més tard.",
+		"recommendedModels": "Models recomanats",
+		"allModels": "Tots els models"
 	},
 	"footer": {
 		"feedback": "Si teniu qualsevol pregunta o comentari, no dubteu a obrir un issue a <githubLink>github.com/Kilo-Org/kilocode</githubLink> o unir-vos a <redditLink>reddit.com/r/kilocode</redditLink> o <discordLink>kilo.ai/discord</discordLink>",

--- a/webview-ui/src/i18n/locales/cs/settings.json
+++ b/webview-ui/src/i18n/locales/cs/settings.json
@@ -1110,7 +1110,9 @@
 		"searchPlaceholder": "Hledat",
 		"noMatchFound": "Nebyla nalezena žádná shoda",
 		"useCustomModel": "Použít vlastní: {{modelId}}",
-		"simplifiedExplanation": "Podrobná nastavení modelu můžete upravit později."
+		"simplifiedExplanation": "Podrobná nastavení modelu můžete upravit později.",
+		"recommendedModels": "Doporučené modely",
+		"allModels": "Všechny modely"
 	},
 	"footer": {
 		"feedback": "Pokud máte nějaké dotazy nebo zpětnou vazbu, neváhejte otevřít problém na <githubLink>github.com/Kilo-Org/kilocode</githubLink> nebo se připojte k <redditLink>reddit.com/r/kilocode</redditLink> nebo <discordLink>kilo.ai/discord</discordLink>.",

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -1022,8 +1022,8 @@
 		"noMatchFound": "Keine Übereinstimmung gefunden",
 		"useCustomModel": "Benutzerdefiniert verwenden: {{modelId}}",
 		"simplifiedExplanation": "Du kannst detaillierte Modelleinstellungen später anpassen.",
-		"recommendedModels": "Recommended models",
-		"allModels": "All models"
+		"recommendedModels": "Empfohlene Modelle",
+		"allModels": "Alle Modelle"
 	},
 	"footer": {
 		"feedback": "Wenn du Fragen oder Feedback hast, kannst du gerne ein Issue auf <githubLink>github.com/Kilo-Org/kilocode</githubLink> öffnen oder <redditLink>reddit.com/r/kilocode</redditLink> oder <discordLink>kilo.ai/discord</discordLink> beitreten",

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -1021,7 +1021,9 @@
 		"searchPlaceholder": "Suchen",
 		"noMatchFound": "Keine Übereinstimmung gefunden",
 		"useCustomModel": "Benutzerdefiniert verwenden: {{modelId}}",
-		"simplifiedExplanation": "Du kannst detaillierte Modelleinstellungen später anpassen."
+		"simplifiedExplanation": "Du kannst detaillierte Modelleinstellungen später anpassen.",
+		"recommendedModels": "Recommended models",
+		"allModels": "All models"
 	},
 	"footer": {
 		"feedback": "Wenn du Fragen oder Feedback hast, kannst du gerne ein Issue auf <githubLink>github.com/Kilo-Org/kilocode</githubLink> öffnen oder <redditLink>reddit.com/r/kilocode</redditLink> oder <discordLink>kilo.ai/discord</discordLink> beitreten",

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -1058,7 +1058,9 @@
 		"searchPlaceholder": "Search",
 		"noMatchFound": "No match found",
 		"useCustomModel": "Use custom: {{modelId}}",
-		"simplifiedExplanation": "You can adjust detailed model settings later."
+		"simplifiedExplanation": "You can adjust detailed model settings later.",
+		"recommendedModels": "Recommended models",
+		"allModels": "All models"
 	},
 	"footer": {
 		"feedback": "If you have any questions or feedback, feel free to open an issue at <githubLink>github.com/Kilo-Org/kilocode</githubLink> or join <redditLink>reddit.com/r/kilocode</redditLink> or <discordLink>kilo.ai/discord</discordLink>.",

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -1025,7 +1025,9 @@
 		"searchPlaceholder": "Buscar",
 		"noMatchFound": "No se encontraron coincidencias",
 		"useCustomModel": "Usar personalizado: {{modelId}}",
-		"simplifiedExplanation": "Puedes ajustar la configuración detallada del modelo más tarde."
+		"simplifiedExplanation": "Puedes ajustar la configuración detallada del modelo más tarde.",
+		"recommendedModels": "Modelos recomendados",
+		"allModels": "Todos los modelos"
 	},
 	"footer": {
 		"feedback": "Si tiene alguna pregunta o comentario, no dude en abrir un issue en <githubLink>github.com/Kilo-Org/kilocode</githubLink> o unirse a <redditLink>reddit.com/r/kilocode</redditLink> o <discordLink>kilo.ai/discord</discordLink>",

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -1025,7 +1025,9 @@
 		"searchPlaceholder": "Rechercher",
 		"noMatchFound": "Aucune correspondance trouvée",
 		"useCustomModel": "Utiliser personnalisé : {{modelId}}",
-		"simplifiedExplanation": "Tu peux ajuster les paramètres détaillés du modèle ultérieurement."
+		"simplifiedExplanation": "Tu peux ajuster les paramètres détaillés du modèle ultérieurement.",
+		"recommendedModels": "Modèles recommandés",
+		"allModels": "Tous les modèles"
 	},
 	"footer": {
 		"feedback": "Si vous avez des questions ou des commentaires, n'hésitez pas à ouvrir un problème sur <githubLink>github.com/Kilo-Org/kilocode</githubLink> ou à rejoindre <redditLink>reddit.com/r/kilocode</redditLink> ou <discordLink>kilo.ai/discord</discordLink>",

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -1026,7 +1026,9 @@
 		"searchPlaceholder": "खोजें",
 		"noMatchFound": "कोई मिलान नहीं मिला",
 		"useCustomModel": "कस्टम उपयोग करें: {{modelId}}",
-		"simplifiedExplanation": "आप बाद में विस्तृत मॉडल सेटिंग्स समायोजित कर सकते हैं।"
+		"simplifiedExplanation": "आप बाद में विस्तृत मॉडल सेटिंग्स समायोजित कर सकते हैं।",
+		"recommendedModels": "अनुशंसित मॉडल",
+		"allModels": "सभी मॉडल"
 	},
 	"footer": {
 		"feedback": "यदि आपके कोई प्रश्न या प्रतिक्रिया है, तो <githubLink>github.com/Kilo-Org/kilocode</githubLink> पर एक मुद्दा खोलने या <redditLink>reddit.com/r/kilocode</redditLink> या <discordLink>kilo.ai/discord</discordLink> में शामिल होने में संकोच न करें",

--- a/webview-ui/src/i18n/locales/id/settings.json
+++ b/webview-ui/src/i18n/locales/id/settings.json
@@ -1047,7 +1047,9 @@
 		"searchPlaceholder": "Cari",
 		"noMatchFound": "Tidak ada yang cocok ditemukan",
 		"useCustomModel": "Gunakan kustom: {{modelId}}",
-		"simplifiedExplanation": "Anda dapat menyesuaikan pengaturan model terperinci nanti."
+		"simplifiedExplanation": "Anda dapat menyesuaikan pengaturan model terperinci nanti.",
+		"recommendedModels": "Model yang direkomendasikan",
+		"allModels": "Semua model"
 	},
 	"footer": {
 		"feedback": "Jika kamu punya pertanyaan atau feedback, jangan ragu untuk membuka issue di <githubLink>github.com/Kilo-Org/kilocode</githubLink> atau bergabung <redditLink>reddit.com/r/kilocode</redditLink> atau <discordLink>kilo.ai/discord</discordLink>",

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -1027,7 +1027,9 @@
 		"searchPlaceholder": "Cerca",
 		"noMatchFound": "Nessuna corrispondenza trovata",
 		"useCustomModel": "Usa personalizzato: {{modelId}}",
-		"simplifiedExplanation": "Puoi modificare le impostazioni dettagliate del modello in seguito."
+		"simplifiedExplanation": "Puoi modificare le impostazioni dettagliate del modello in seguito.",
+		"recommendedModels": "Modelli consigliati",
+		"allModels": "Tutti i modelli"
 	},
 	"footer": {
 		"feedback": "Se hai domande o feedback, sentiti libero di aprire un issue su <githubLink>github.com/Kilo-Org/kilocode</githubLink> o unirti a <redditLink>reddit.com/r/kilocode</redditLink> o <discordLink>kilo.ai/discord</discordLink>",

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -1027,7 +1027,9 @@
 		"searchPlaceholder": "検索",
 		"noMatchFound": "一致するものが見つかりません",
 		"useCustomModel": "カスタムを使用: {{modelId}}",
-		"simplifiedExplanation": "詳細なモデル設定は後で調整できます。"
+		"simplifiedExplanation": "詳細なモデル設定は後で調整できます。",
+		"recommendedModels": "おすすめのモデル",
+		"allModels": "すべてのモデル"
 	},
 	"footer": {
 		"feedback": "質問やフィードバックがある場合は、<githubLink>github.com/Kilo-Org/kilocode</githubLink>で問題を開くか、<redditLink>reddit.com/r/kilocode</redditLink>や<discordLink>kilo.ai/discord</discordLink>に参加してください",

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -1026,7 +1026,9 @@
 		"searchPlaceholder": "검색",
 		"noMatchFound": "일치하는 항목 없음",
 		"useCustomModel": "사용자 정의 사용: {{modelId}}",
-		"simplifiedExplanation": "나중에 자세한 모델 설정을 조정할 수 있습니다."
+		"simplifiedExplanation": "나중에 자세한 모델 설정을 조정할 수 있습니다.",
+		"recommendedModels": "추천 모델",
+		"allModels": "모든 모델"
 	},
 	"footer": {
 		"feedback": "질문이나 피드백이 있으시면 <githubLink>github.com/Kilo-Org/kilocode</githubLink>에서 이슈를 열거나 <redditLink>reddit.com/r/kilocode</redditLink> 또는 <discordLink>kilo.ai/discord</discordLink>에 가입하세요",

--- a/webview-ui/src/i18n/locales/nl/settings.json
+++ b/webview-ui/src/i18n/locales/nl/settings.json
@@ -1026,7 +1026,9 @@
 		"searchPlaceholder": "Zoeken",
 		"noMatchFound": "Geen overeenkomsten gevonden",
 		"useCustomModel": "Aangepast gebruiken: {{modelId}}",
-		"simplifiedExplanation": "Je kunt later gedetailleerde modelinstellingen aanpassen."
+		"simplifiedExplanation": "Je kunt later gedetailleerde modelinstellingen aanpassen.",
+		"recommendedModels": "Aanbevolen modellen",
+		"allModels": "Alle modellen"
 	},
 	"footer": {
 		"feedback": "Heb je vragen of feedback? Open gerust een issue op <githubLink>github.com/Kilo-Org/kilocode</githubLink> of sluit je aan bij <redditLink>reddit.com/r/kilocode</redditLink> of <discordLink>kilo.ai/discord</discordLink>",

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -1026,7 +1026,9 @@
 		"searchPlaceholder": "Wyszukaj",
 		"noMatchFound": "Nie znaleziono dopasowań",
 		"useCustomModel": "Użyj niestandardowy: {{modelId}}",
-		"simplifiedExplanation": "Można dostosować szczegółowe ustawienia modelu później."
+		"simplifiedExplanation": "Można dostosować szczegółowe ustawienia modelu później.",
+		"recommendedModels": "Polecane modele",
+		"allModels": "Wszystkie modele"
 	},
 	"footer": {
 		"feedback": "Jeśli masz jakiekolwiek pytania lub opinie, śmiało otwórz zgłoszenie na <githubLink>github.com/Kilo-Org/kilocode</githubLink> lub dołącz do <redditLink>reddit.com/r/kilocode</redditLink> lub <discordLink>kilo.ai/discord</discordLink>",

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -1026,7 +1026,9 @@
 		"searchPlaceholder": "Pesquisar",
 		"noMatchFound": "Nenhuma correspondência encontrada",
 		"useCustomModel": "Usar personalizado: {{modelId}}",
-		"simplifiedExplanation": "Você pode ajustar as configurações detalhadas do modelo mais tarde."
+		"simplifiedExplanation": "Você pode ajustar as configurações detalhadas do modelo mais tarde.",
+		"recommendedModels": "Modelos recomendados",
+		"allModels": "Todos os modelos"
 	},
 	"footer": {
 		"feedback": "Se tiver alguma dúvida ou feedback, sinta-se à vontade para abrir um problema em <githubLink>github.com/Kilo-Org/kilocode</githubLink> ou juntar-se a <redditLink>reddit.com/r/kilocode</redditLink> ou <discordLink>kilo.ai/discord</discordLink>",

--- a/webview-ui/src/i18n/locales/ru/settings.json
+++ b/webview-ui/src/i18n/locales/ru/settings.json
@@ -1026,7 +1026,9 @@
 		"searchPlaceholder": "Поиск",
 		"noMatchFound": "Совпадений не найдено",
 		"useCustomModel": "Использовать пользовательскую: {{modelId}}",
-		"simplifiedExplanation": "Ты сможешь настроить подробные параметры модели позже."
+		"simplifiedExplanation": "Ты сможешь настроить подробные параметры модели позже.",
+		"recommendedModels": "Рекомендуемые модели",
+		"allModels": "Все модели"
 	},
 	"footer": {
 		"feedback": "Если у вас есть вопросы или предложения, откройте issue на <githubLink>github.com/Kilo-Org/kilocode</githubLink> или присоединяйтесь к <redditLink>reddit.com/r/kilocode</redditLink> или <discordLink>kilo.ai/discord</discordLink>",

--- a/webview-ui/src/i18n/locales/th/settings.json
+++ b/webview-ui/src/i18n/locales/th/settings.json
@@ -1121,7 +1121,9 @@
 		"searchPlaceholder": "ค้นหา",
 		"noMatchFound": "ไม่พบรายการที่ตรงกัน",
 		"useCustomModel": "ใช้แบบกำหนดเอง: {{modelId}}",
-		"simplifiedExplanation": "คุณสามารถปรับการตั้งค่าโมเดลโดยละเอียดได้ภายหลัง"
+		"simplifiedExplanation": "คุณสามารถปรับการตั้งค่าโมเดลโดยละเอียดได้ภายหลัง",
+		"recommendedModels": "โมเดลที่แนะนำ",
+		"allModels": "โมเดลทั้งหมด"
 	},
 	"footer": {
 		"feedback": "หากคุณมีคำถามหรือข้อเสนอแนะ โปรดเปิด issue ที่ <githubLink>github.com/Kilo-Org/kilocode</githubLink> หรือเข้าร่วม <redditLink>reddit.com/r/kilocode</redditLink> หรือ <discordLink>kilo.ai/discord</discordLink>",

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -1027,7 +1027,9 @@
 		"searchPlaceholder": "Ara",
 		"noMatchFound": "Eşleşme bulunamadı",
 		"useCustomModel": "Özel kullan: {{modelId}}",
-		"simplifiedExplanation": "Ayrıntılı model ayarlarını daha sonra ayarlayabilirsiniz."
+		"simplifiedExplanation": "Ayrıntılı model ayarlarını daha sonra ayarlayabilirsiniz.",
+		"recommendedModels": "Önerilen modeller",
+		"allModels": "Tüm modeller"
 	},
 	"footer": {
 		"feedback": "Herhangi bir sorunuz veya geri bildiriminiz varsa, <githubLink>github.com/Kilo-Org/kilocode</githubLink> adresinde bir konu açmaktan veya <redditLink>reddit.com/r/kilocode</redditLink> ya da <discordLink>kilo.ai/discord</discordLink>'a katılmaktan çekinmeyin",

--- a/webview-ui/src/i18n/locales/uk/settings.json
+++ b/webview-ui/src/i18n/locales/uk/settings.json
@@ -1135,7 +1135,9 @@
 		"searchPlaceholder": "Пошук",
 		"noMatchFound": "Збігів не знайдено",
 		"useCustomModel": "Використовувати власну: {{modelId}}",
-		"simplifiedExplanation": "Ви можете налаштувати детальні параметри моделі пізніше."
+		"simplifiedExplanation": "Ви можете налаштувати детальні параметри моделі пізніше.",
+		"recommendedModels": "Рекомендовані моделі",
+		"allModels": "Усі моделі"
 	},
 	"footer": {
 		"feedback": "Якщо у тебе є питання або відгуки, не соромся відкрити issue на <githubLink>github.com/Kilo-Org/kilocode</githubLink> або приєднатися до <redditLink>reddit.com/r/kilocode</redditLink> або <discordLink>kilo.ai/discord</discordLink>.",

--- a/webview-ui/src/i18n/locales/vi/settings.json
+++ b/webview-ui/src/i18n/locales/vi/settings.json
@@ -1026,7 +1026,9 @@
 		"searchPlaceholder": "Tìm kiếm",
 		"noMatchFound": "Không tìm thấy kết quả",
 		"useCustomModel": "Sử dụng tùy chỉnh: {{modelId}}",
-		"simplifiedExplanation": "Bạn có thể điều chỉnh cài đặt mô hình chi tiết sau."
+		"simplifiedExplanation": "Bạn có thể điều chỉnh cài đặt mô hình chi tiết sau.",
+		"recommendedModels": "Mô hình được đề xuất",
+		"allModels": "Tất cả mô hình"
 	},
 	"footer": {
 		"feedback": "Nếu bạn có bất kỳ câu hỏi hoặc phản hồi nào, vui lòng mở một vấn đề tại <githubLink>github.com/Kilo-Org/kilocode</githubLink> hoặc tham gia <redditLink>reddit.com/r/kilocode</redditLink> hoặc <discordLink>kilo.ai/discord</discordLink>",

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -1030,7 +1030,9 @@
 		"searchPlaceholder": "搜索",
 		"noMatchFound": "未找到匹配项",
 		"useCustomModel": "使用自定义：{{modelId}}",
-		"simplifiedExplanation": "你可以稍后调整详细的模型设置。"
+		"simplifiedExplanation": "你可以稍后调整详细的模型设置。",
+		"recommendedModels": "推荐模型",
+		"allModels": "全部模型"
 	},
 	"footer": {
 		"feedback": "如果您有任何问题或反馈，请随时在 <githubLink>github.com/Kilo-Org/kilocode</githubLink> 上提出问题或加入 <redditLink>reddit.com/r/kilocode</redditLink> 或 <discordLink>kilo.ai/discord</discordLink>",

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -1027,7 +1027,9 @@
 		"searchPlaceholder": "搜尋",
 		"noMatchFound": "找不到符合的項目",
 		"useCustomModel": "使用自訂模型：{{modelId}}",
-		"simplifiedExplanation": "你可以稍後調整詳細的模型設定。"
+		"simplifiedExplanation": "你可以稍後調整詳細的模型設定。",
+		"recommendedModels": "推薦模型",
+		"allModels": "所有模型"
 	},
 	"footer": {
 		"feedback": "若您有任何問題或建議，歡迎至 <githubLink>github.com/Kilo-Org/kilocode</githubLink> 提出 issue，或加入 <redditLink>reddit.com/r/kilocode</redditLink> 或 <discordLink>kilo.ai/discord</discordLink> 討論。",


### PR DESCRIPTION
This PR splits out the model list into two sections, a recommended section and the rest. We already sorted this so that recommended models appeared at the top, but other than the ordering there was no hint. This makes it more clear what we recommend folks to use and what should work well.