### PR TITLE
Enable autocomplete by default in JetBrains extension

### DIFF
--- a/.changeset/enable-jetbrains-autocomplete.md
+++ b/.changeset/enable-jetbrains-autocomplete.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Enable autocomplete by default in the JetBrains extension

--- a/src/services/ghost/GhostServiceManager.ts
+++ b/src/services/ghost/GhostServiceManager.ts
@@ -9,7 +9,6 @@ import { GhostServiceSettings, TelemetryEventName } from "@roo-code/types"
 import { ContextProxy } from "../../core/config/ContextProxy"
 import { TelemetryService } from "@roo-code/telemetry"
 import { ClineProvider } from "../../core/webview/ClineProvider"
-import { getKiloCodeWrapperProperties } from "../../core/kilocode/wrapper"
 import { AutocompleteTelemetry } from "./classic-auto-complete/AutocompleteTelemetry"
 
 export class GhostServiceManager {
@@ -75,18 +74,14 @@ export class GhostServiceManager {
 		this.settings = ContextProxy.instance.getGlobalState("ghostServiceSettings") ?? {
 			enableSmartInlineTaskKeybinding: true,
 		}
-		// Auto-enable autocomplete by default, but disable for JetBrains IDEs
-		// JetBrains users can manually enable it if they want to test the feature
+		// Auto-enable autocomplete by default
 		if (this.settings.enableAutoTrigger == undefined) {
-			const { kiloCodeWrapperJetbrains } = getKiloCodeWrapperProperties()
-			this.settings.enableAutoTrigger = !kiloCodeWrapperJetbrains
+			this.settings.enableAutoTrigger = true
 		}
 
-		// Auto-enable chat autocomplete by default, but disable for JetBrains IDEs
-		// JetBrains users can manually enable it if they want to test the feature
+		// Auto-enable chat autocomplete by default
 		if (this.settings.enableChatAutocomplete == undefined) {
-			const { kiloCodeWrapperJetbrains } = getKiloCodeWrapperProperties()
-			this.settings.enableChatAutocomplete = !kiloCodeWrapperJetbrains
+			this.settings.enableChatAutocomplete = true
 		}
 
 		await this.updateGlobalContext()

--- a/src/services/ghost/__tests__/GhostServiceManager.spec.ts
+++ b/src/services/ghost/__tests__/GhostServiceManager.spec.ts
@@ -123,10 +123,6 @@ vi.mock("@roo-code/telemetry", () => ({
 	},
 }))
 
-vi.mock("../../../core/kilocode/wrapper", () => ({
-	getKiloCodeWrapperProperties: () => ({ kiloCodeWrapperJetbrains: false }),
-}))
-
 vi.mock("../../../core/config/ContextProxy", () => {
 	const state: Record<string, any> = {}
 


### PR DESCRIPTION
This PR removes the JetBrains-specific gate that was disabling autocomplete by default. Now autocomplete will be enabled by default for JetBrains users as well.

## Changes
- Removed the `kiloCodeWrapperJetbrains` check that was disabling `enableAutoTrigger` and `enableChatAutocomplete` by default for JetBrains IDEs
- Removed the unused `getKiloCodeWrapperProperties` import
- Removed the corresponding mock from the test file