### PR TITLE
feat: use shared COMPLETION tag format in chat textarea autocomplete

### DIFF
--- a/.changeset/chat-autocomplete-completion-tags.md
+++ b/.changeset/chat-autocomplete-completion-tags.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Use shared COMPLETION tag format in chat textarea autocomplete for consistency with HoleFiller


### PR DESCRIPTION
## Summary
Use shared `<COMPLETION>` tag response format from HoleFiller in ChatTextAreaAutocomplete for consistency.

## Changes
- Updated `getChatSystemPrompt()` to instruct model to use `<COMPLETION></COMPLETION>` tags (same format as HoleFiller)
- Updated `getChatUserPrompt()` to reinforce COMPLETION tag requirement  
- Added `parseCompletionResponse()` to extract text from tags (same regex as HoleFiller)
- Updated `getCompletion()` to parse COMPLETION tags for chat-based completion (non-FIM models)
- Added test for COMPLETION tag parsing with fallback behavior

## Benefits
- Consistent response parsing between code completion (HoleFiller) and chat completion
- Better model instruction following with explicit output format
- Fallback support for models that don't follow the tag format

## Testing
- All existing tests pass
- Added new test for COMPLETION tag parsing