### PR TITLE
Kilo Icon on editor actions

### DIFF
--- a/.changeset/cold-sheep-feel.md
+++ b/.changeset/cold-sheep-feel.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add Kilo icon to editor toolbar for quick access to open Kilo from any context

--- a/packages/types/src/vscode.ts
+++ b/packages/types/src/vscode.ts
@@ -41,6 +41,7 @@ export const commandIds = [
 	"settingsButtonClicked",
 
 	"openInNewTab",
+	"open", // kilocode_change
 	"agentManagerOpen", // kilocode_change
 
 	"showHumanRelayDialog",

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -129,6 +129,7 @@ const getCommandsMap = ({ context, outputChannel }: RegisterCommandOptions): Rec
 
 		return openClineInNewTab({ context, outputChannel })
 	},
+	open: () => openClineInNewTab({ context, outputChannel }), // kilocode_change
 	openInNewTab: () => openClineInNewTab({ context, outputChannel }),
 	settingsButtonClicked: () => {
 		const visibleProvider = getVisibleProviderOrLog(outputChannel)

--- a/src/package.json
+++ b/src/package.json
@@ -293,6 +293,19 @@
 				"title": "Open Agent Manager",
 				"icon": "$(circuit-board)",
 				"category": "%configuration.title%"
+			},
+			{
+				"command": "kilo-code.popoutButtonClicked",
+				"title": "%command.openInEditor.title%",
+				"icon": "$(link-external)"
+			},
+			{
+				"command": "kilo-code.open",
+				"title": "%views.activitybar.title%",
+				"icon": {
+					"light": "assets/icons/kilo-light.svg",
+					"dark": "assets/icons/kilo-dark.svg"
+				}
 			}
 		],
 		"menus": {
@@ -404,11 +417,6 @@
 					"when": "activeWebviewPanelId == kilo-code.TabPanelProvider"
 				},
 				{
-					"command": "kilo-code.popoutButtonClicked",
-					"group": "navigation@4",
-					"when": "activeWebviewPanelId == kilo-code.TabPanelProvider"
-				},
-				{
 					"command": "kilo-code.settingsButtonClicked",
 					"group": "navigation@5",
 					"when": "activeWebviewPanelId == kilo-code.TabPanelProvider"
@@ -417,6 +425,11 @@
 					"command": "kilo-code.helpButtonClicked",
 					"group": "navigation@6",
 					"when": "activeWebviewPanelId == kilo-code.TabPanelProvider"
+				},
+				{
+					"command": "kilo-code.open",
+					"group": "navigation",
+					"when": "true"
 				}
 			],
 			"scm/input": [


### PR DESCRIPTION
## Context

This PR adds a Kilo Code icon button to the editor toolbar that provides quick access to open Kilo Code from any editor context. This improves discoverability and accessibility by making it easier for users to launch Kilo Code without needing to navigate to the sidebar or use keyboard shortcuts.

## Implementation

The implementation involves three main changes:

1. **Command Registration** ([`packages/types/src/vscode.ts`](packages/types/src/vscode.ts:44)): Added a new `"open"` command ID to the command registry to enable the new toolbar action.

2. **Command Handler** ([`src/activate/registerCommands.ts`](src/activate/registerCommands.ts:132)): Registered the `open` command handler that reuses the existing `openClineInNewTab` functionality, ensuring consistent behavior with other "open" actions.

3. **UI Integration** ([`src/package.json`](src/package.json:298-308)):
    - Added a new command definition with the Kilo Code icon (using light/dark variants from `assets/icons/`)
    - Registered the command in the editor toolbar menu with `"when": "true"` to make it always visible
    - Moved the popout button definition to maintain proper command grouping

The implementation follows the existing pattern used by other editor actions and properly marks Kilo Code-specific changes with `kilocode_change` comments to facilitate future upstream merges.

## Screenshots

<img width="2913" height="1918" alt="image" src="https://github.com/user-attachments/assets/fe4799f2-9acd-4e99-bb5f-9784b7e0f0b2" />
<img width="2913" height="1918" alt="image" src="https://github.com/user-attachments/assets/3ec2f123-8a0e-413f-808d-5368585b9a63" />
<img width="2913" height="1918" alt="image" src="https://github.com/user-attachments/assets/4ebeffcb-b6b4-461d-bb61-164bed22794f" />
<img width="2913" height="1918" alt="image" src="https://github.com/user-attachments/assets/11104993-ba6f-4836-a2dd-0e7aef07ac1e" />

## How to Test

1. Open any file in the VS Code editor
2. Look at the editor toolbar (top-right corner of the editor)
3. You should see a Kilo Code icon button (the icon will be light or dark depending on your theme)
4. Click the Kilo Code icon button
5. Verify that Kilo Code opens in a new editor tab
6. Test in both light and dark themes to ensure the icon displays correctly