### PR TITLE
feat: show whole block when current line has no word characters

### DIFF
--- a/.changeset/brown-rules-watch.md
+++ b/.changeset/brown-rules-watch.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Autocomplete: Show entire suggestion when first line has no word characters

--- a/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
+++ b/src/services/ghost/classic-auto-complete/GhostInlineCompletionProvider.ts
@@ -217,6 +217,11 @@ export function shouldShowOnlyFirstLine(prefix: string, suggestion: string): boo
 	const lastNewlineIndex = prefix.lastIndexOf("\n")
 	const currentLinePrefix = prefix.slice(lastNewlineIndex + 1)
 
+	// if the first line contains no word characters, show the whole block
+	if (!currentLinePrefix.match(/\w/)) {
+		return false
+	}
+
 	// If the current line prefix contains non-whitespace, only show the first line
 	if (currentLinePrefix.trim().length > 0) {
 		return true

--- a/src/services/ghost/classic-auto-complete/__tests__/GhostInlineCompletionProvider.test.ts
+++ b/src/services/ghost/classic-auto-complete/__tests__/GhostInlineCompletionProvider.test.ts
@@ -572,12 +572,26 @@ describe("shouldShowOnlyFirstLine", () => {
 		expect(shouldShowOnlyFirstLine("const x = 1\nconst y = foo", "bar\nbaz")).toBe(true)
 	})
 
-	it("returns true at start of line when suggestion is 3+ lines", () => {
-		expect(shouldShowOnlyFirstLine("const x = 1\n    ", "l1\nl2\nl3")).toBe(true)
+	it("returns false at start of line when suggestion is 3+ lines but current line has no word characters", () => {
+		// When current line has only whitespace (no word characters), show the whole block
+		expect(shouldShowOnlyFirstLine("const x = 1\n    ", "l1\nl2\nl3")).toBe(false)
+	})
+
+	it("returns true at start of line when suggestion is 3+ lines and current line has word characters", () => {
+		// When current line has word characters (e.g., partial code), show only first line
+		expect(shouldShowOnlyFirstLine("const x = 1\n    const", "l1\nl2\nl3")).toBe(true)
 	})
 
 	it("returns false at start of line when suggestion is 2 lines", () => {
 		expect(shouldShowOnlyFirstLine("const x = 1\n", "l1\nl2")).toBe(false)
+	})
+
+	it("returns false when current line has only non-word characters (e.g., indentation after comma)", () => {
+		// Simulates typing comma + Enter in an array of objects, then getting a multi-line suggestion
+		// The prefix ends with whitespace-only line (indentation), suggestion is the next object block
+		const prefix = "const items = [\n\t{ name: 'first' },\n\t"
+		const suggestion = "{ name: 'second' },\n\t{ name: 'third' },"
+		expect(shouldShowOnlyFirstLine(prefix, suggestion)).toBe(false)
 	})
 })
 


### PR DESCRIPTION
## Summary

When the current line prefix contains no word characters (e.g., only whitespace/indentation after typing comma and Enter in an array of objects), show the whole multi-line suggestion instead of truncating to the first line.

## Problem

When editing an array of objects and typing `,` then `Enter`, the cursor is on a new line with only whitespace/indentation. Previously, multi-line suggestions would be truncated to just the first line (e.g., showing only `{` instead of the complete object block).

## Solution

Add a check in `shouldShowOnlyFirstLine` to return `false` (show whole block) when the current line prefix contains no word characters (`\w`).

| Before | After|
|---|---|
|<img width="956" height="352" alt="CleanShot 2026-01-12 at 10 14 36@2x" src="https://github.com/user-attachments/assets/bacfe966-ff80-477c-8476-24f2f29130fd" />|<img width="892" height="450" alt="CleanShot 2026-01-12 at 10 13 24@2x" src="https://github.com/user-attachments/assets/c116dce7-8d16-4677-917f-825d65c2f289" /> |