### PR TITLE
remove red background in task when task could not be found

### DIFF
--- a/.changeset/clever-moments-melt.md
+++ b/.changeset/clever-moments-melt.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed that some tasks in task history were red

--- a/packages/types/src/history.ts
+++ b/packages/types/src/history.ts
@@ -19,7 +19,6 @@ export const historyItemSchema = z.object({
 	size: z.number().optional(),
 	workspace: z.string().optional(),
 	isFavorited: z.boolean().optional(), // kilocode_change
-	fileNotfound: z.boolean().optional(), // kilocode_change
 	mode: z.string().optional(),
 	status: z.enum(["active", "completed", "delegated"]).optional(),
 	delegatedToId: z.string().optional(), // Last child this parent delegated to

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1816,7 +1816,13 @@ export class ClineProvider
 
 		// if we tried to get a task that doesn't exist, remove it from state
 		// FIXME: this seems to happen sometimes when the json file doesnt save to disk for some reason
-		await this.deleteTaskFromState(id)
+		// kilocode_change start
+		// commented out deleting the task, because in the previous version we made this task red
+		// instead of deleting, and people were confused because the task was actually working fine
+		// which leads us to believe that this is triggered to often somehow, or that the task will turn up later
+		// via some sync ( context https://github.com/Kilo-Org/kilocode/pull/4880 )
+		// await this.deleteTaskFromState(id)
+		// kilocode_change end
 		throw new Error("Task not found")
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1816,8 +1816,7 @@ export class ClineProvider
 
 		// if we tried to get a task that doesn't exist, remove it from state
 		// FIXME: this seems to happen sometimes when the json file doesnt save to disk for some reason
-		// await this.deleteTaskFromState(id) // kilocode_change disable confusing behaviour
-		await this.setTaskFileNotFound(id) // kilocode_change
+		await this.deleteTaskFromState(id)
 		throw new Error("Task not found")
 	}
 
@@ -3665,19 +3664,6 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 		for (const id of taskIds) {
 			await this.deleteTaskWithId(id)
 		}
-	}
-
-	async setTaskFileNotFound(id: string) {
-		const history = this.getGlobalState("taskHistory") ?? []
-		const updatedHistory = history.map((item) => {
-			if (item.id === id) {
-				return { ...item, fileNotfound: true }
-			}
-			return item
-		})
-		await this.updateGlobalState("taskHistory", updatedHistory)
-		this.kiloCodeTaskHistoryVersion++
-		await this.postStateToWebview()
 	}
 
 	private kiloCodeTaskHistoryVersion = 0

--- a/webview-ui/src/components/history/TaskItem.tsx
+++ b/webview-ui/src/components/history/TaskItem.tsx
@@ -48,10 +48,6 @@ const TaskItem = ({
 			data-testid={`task-item-${item.id}`}
 			className={cn(
 				"cursor-pointer group bg-vscode-editor-background rounded relative overflow-hidden border border-transparent hover:bg-vscode-list-hoverBackground transition-colors", // kilocode_change: no rounded borders
-				{
-					"bg-red-900 text-white": item.fileNotfound, // kilocode_change added this state instead of removing
-					"bg-vscode-editor-background": !item.fileNotfound, //kilocode_change this is the default normally in the regular classname list
-				},
 				className,
 			)}
 			onClick={handleClick}>


### PR DESCRIPTION
we had multiple people give us feedback that this triggers when the task is actually there, so this does more harm than good now
