### PR TITLE
Fix: prevent double display of MCP marketplace section in settings view

### DIFF
--- a/.changeset/purple-pears-visit.md
+++ b/.changeset/purple-pears-visit.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix: prevent double display of MCP marketplace section in settings view

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -1215,10 +1215,6 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>((props, ref)
 						<LanguageSettings language={language || "en"} setCachedStateField={setCachedStateField} />
 					)}
 
-					{/* kilocode_change */}
-					{/* MCP Section */}
-					{activeTab === "mcp" && <McpView />}
-
 					{/* About Section */}
 					{activeTab === "about" && (
 						<About telemetrySetting={telemetrySetting} setTelemetrySetting={setTelemetrySetting} />


### PR DESCRIPTION
This was double rendered in settings