### PR TITLE
fix: agent manager session disappears due to gitUrl race condition

### DIFF
--- a/.changeset/fix-agent-manager-session-disappears.md
+++ b/.changeset/fix-agent-manager-session-disappears.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Agent Manager session disappearing immediately after starting due to gitUrl race condition

--- a/src/core/kilocode/agent-manager/AgentManagerProvider.ts
+++ b/src/core/kilocode/agent-manager/AgentManagerProvider.ts
@@ -473,6 +473,12 @@ export class AgentManagerProvider implements vscode.Disposable {
 		if (workspaceFolder) {
 			try {
 				gitUrl = normalizeGitUrl(await getRemoteUrl(workspaceFolder))
+				// Update currentGitUrl to ensure consistency between session gitUrl and filter
+				// This fixes a race condition where initializeCurrentGitUrl() hasn't completed yet
+				if (gitUrl && !this.currentGitUrl) {
+					this.currentGitUrl = gitUrl
+					this.outputChannel.appendLine(`[AgentManager] Updated current git URL: ${gitUrl}`)
+				}
 			} catch (error) {
 				this.outputChannel.appendLine(
 					`[AgentManager] Could not get git URL: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/core/kilocode/agent-manager/__tests__/AgentManagerProvider.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/AgentManagerProvider.spec.ts
@@ -842,6 +842,28 @@ describe("AgentManagerProvider gitUrl filtering", () => {
 		expect(state.sessions[0].sessionId).toBe("session-2")
 	})
 
+	it("updates currentGitUrl when starting a session if not already set (race condition fix)", async () => {
+		// Simulate the race condition: currentGitUrl is undefined because initializeCurrentGitUrl hasn't completed
+		;(provider as any).currentGitUrl = undefined
+
+		// Start a session - this should update currentGitUrl
+		await (provider as any).startAgentSession("test prompt")
+
+		// currentGitUrl should now be set from the session's gitUrl
+		expect((provider as any).currentGitUrl).toBe("https://github.com/org/repo.git")
+	})
+
+	it("does not overwrite currentGitUrl if already set", async () => {
+		// Set a different currentGitUrl
+		;(provider as any).currentGitUrl = "https://github.com/org/other-repo.git"
+
+		// Start a session
+		await (provider as any).startAgentSession("test prompt")
+
+		// currentGitUrl should NOT be overwritten
+		expect((provider as any).currentGitUrl).toBe("https://github.com/org/other-repo.git")
+	})
+
 	describe("filterRemoteSessionsByGitUrl", () => {
 		it("returns only sessions with matching git_url when currentGitUrl is set", () => {
 			const remoteSessions = [


### PR DESCRIPTION
# Fix: Agent Manager sessions disappearing immediately after starting

Fixes an issue where Agent Manager sessions would disappear immediately after starting, particularly when there's already a session running in the right sidebar.

## Root Cause

A race condition in `currentGitUrl` initialization caused Agent Manager sessions to be filtered out immediately after creation:

1. In `AgentManagerProvider` constructor, `initializeCurrentGitUrl()` is called asynchronously but **not awaited**
2. `currentGitUrl` starts as `undefined`
3. When `startAgentSession()` is called, it fetches `gitUrl` from the workspace and creates the session with this `gitUrl`
4. `postStateToWebview()` is called, which uses `getFilteredState()` with `this.currentGitUrl`
5. If `currentGitUrl` is still `undefined` (because `initializeCurrentGitUrl()` hasn't completed), but the session has a `gitUrl`, the session is filtered out by `getSessionsForGitUrl()`
6. The webview receives state without the session and removes it

## Fix

Modified `startAgentSession()` to update `currentGitUrl` when fetching the git URL for a new session, ensuring the filter matches the session's `gitUrl`:

```typescript
if (gitUrl && !this.currentGitUrl) {
    this.currentGitUrl = gitUrl
    this.outputChannel.appendLine(`[AgentManager] Updated current git URL: ${gitUrl}`)
}
```