### PR TITLE
chore: remove redundant TODO comment from NextEditWindowManager

### DIFF
--- a/src/services/continuedev/core/vscode-test-harness/src/activation/NextEditWindowManager.ts
+++ b/src/services/continuedev/core/vscode-test-harness/src/activation/NextEditWindowManager.ts
@@ -760,7 +760,7 @@ export class NextEditWindowManager {
 		}
 
 		// Store the decoration and editor.
-		this.currentDecoration = decoration // TODO: This might be redundant.
+		this.currentDecoration = decoration
 		this.disposables.push(decoration)
 
 		// Calculate how far off to the right of the cursor the decoration should be.


### PR DESCRIPTION
Removes an unnecessary TODO comment that said "This might be redundant" without providing actionable information. The code simply stores a decoration reference, which is a standard pattern.