### PR TITLE
fix: keep session interactive after "Finish to Branch" button click

### DIFF
--- a/.changeset/fix-session-interactive-after-pr.md
+++ b/.changeset/fix-session-interactive-after-pr.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix session becoming non-interactable after clicking "Finish to Branch" button. The session now remains active so users can continue working after committing changes.

--- a/src/core/kilocode/agent-manager/AgentManagerProvider.ts
+++ b/src/core/kilocode/agent-manager/AgentManagerProvider.ts
@@ -889,8 +889,9 @@ export class AgentManagerProvider implements vscode.Disposable {
 	 * 1. Stage all changes
 	 * 2. Ask agent to generate commit message and commit
 	 * 3. Fallback to programmatic commit if agent times out
-	 * 4. Terminate CLI process
-	 * 5. Clean up worktree (keep branch)
+	 *
+	 * Note: The session remains interactive after finishing. The CLI process
+	 * and worktree are kept alive so the user can continue working.
 	 */
 	private async finishWorktreeSession(sessionId: string): Promise<void> {
 		const session = this.registry.getSession(sessionId)
@@ -913,7 +914,6 @@ export class AgentManagerProvider implements vscode.Disposable {
 
 		if (!worktreePath) {
 			this.outputChannel.appendLine(`[AgentManager] No worktree path for session: ${sessionId}`)
-			this.processHandler.terminateProcess(sessionId, "SIGTERM")
 			return
 		}
 
@@ -948,20 +948,11 @@ export class AgentManagerProvider implements vscode.Disposable {
 				this.log(sessionId, "No changes to commit")
 			}
 
-			// Terminate CLI process
-			this.processHandler.terminateProcess(sessionId, "SIGTERM")
-
-			// Clean up worktree (keep the branch for later merging)
-			await manager.removeWorktree(worktreePath)
-
 			// Show completion message
 			this.showWorktreeCompletionMessage(branch)
 		} catch (error) {
 			const errorMsg = error instanceof Error ? error.message : String(error)
 			this.outputChannel.appendLine(`[AgentManager] Error finishing worktree session: ${errorMsg}`)
-
-			// Still try to terminate the process
-			this.processHandler.terminateProcess(sessionId, "SIGTERM")
 		}
 
 		this.postStateToWebview()

--- a/src/core/kilocode/agent-manager/__tests__/AgentManagerProvider.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/AgentManagerProvider.spec.ts
@@ -1106,7 +1106,7 @@ describe("AgentManagerProvider telemetry", () => {
 	})
 
 	describe("Regression Tests - finishWorktreeSession validation (P0)", () => {
-		it("should not attempt to terminate non-running worktree sessions", async () => {
+		it("should not attempt to finish non-running worktree sessions", async () => {
 			const registry = (provider as any).registry
 			const sessionId = "session-done-1"
 			registry.createSession(sessionId, "test done session", undefined, { parallelMode: true })
@@ -1118,11 +1118,11 @@ describe("AgentManagerProvider telemetry", () => {
 			// Call finishWorktreeSession on a done session
 			;(provider as any).finishWorktreeSession(sessionId)
 
-			// Should NOT call terminateProcess
+			// Should NOT call terminateProcess - session is not running
 			expect(processHandler.terminateProcess).not.toHaveBeenCalled()
 		})
 
-		it("should only allow finishing running worktree sessions", async () => {
+		it("should keep session interactive after finishing running worktree sessions", async () => {
 			const registry = (provider as any).registry
 			const sessionId = "session-running-1"
 			registry.createSession(sessionId, "test running session", undefined, { parallelMode: true })
@@ -1135,8 +1135,8 @@ describe("AgentManagerProvider telemetry", () => {
 			// Call finishWorktreeSession on a running session
 			;(provider as any).finishWorktreeSession(sessionId)
 
-			// Should call terminateProcess
-			expect(processHandler.terminateProcess).toHaveBeenCalledWith(sessionId, "SIGTERM")
+			// Should NOT call terminateProcess - session should remain interactive
+			expect(processHandler.terminateProcess).not.toHaveBeenCalled()
 		})
 	})
 })


### PR DESCRIPTION
Description:
  ## Summary
  - Removes CLI process termination and worktree cleanup from `finishWorktreeSession`
  - Sessions now remain interactive after clicking "Finish to Branch"

  ## Problem
  After clicking the "Finish to Branch" button, the session became non-interactable because the CLI process was being terminated. This was legacy logic from when branch creation required the CLI to exit.

  ## Solution
  Since branch/worktree management is now handled by the agent manager, the CLI no longer needs to be killed after committing. The session stays alive so users can continue working.