### PR TITLE
Disable question tool in yolo mode

### DIFF
--- a/.changeset/disable-questions-yolo-mode.md
+++ b/.changeset/disable-questions-yolo-mode.md
@@ -1,0 +1,8 @@
+---
+"kilo-code": patch
+---
+
+Disable ask_followup_question tool when yolo mode is enabled to prevent the agent from asking itself questions and auto-answering them. Applied to:
+- XML tool descriptions (system prompt)
+- Native tool filtering
+- Tool execution (returns error message if model still tries to use the tool from conversation history)

--- a/src/core/prompts/tools/filter-tools-for-mode.ts
+++ b/src/core/prompts/tools/filter-tools-for-mode.ts
@@ -328,6 +328,14 @@ export function filterNativeToolsForMode(
 		allowedToolNames.delete("apply_diff")
 	}
 
+	// kilocode_change start
+	// Conditionally exclude ask_followup_question in yolo mode
+	// This prevents the agent from asking itself questions and auto-answering them
+	if (state?.yoloMode) {
+		allowedToolNames.delete("ask_followup_question")
+	}
+	// kilocode_change end
+
 	// Conditionally exclude access_mcp_resource if MCP is not enabled or there are no resources
 	if (!mcpHub || !hasAnyMcpResources(mcpHub)) {
 		allowedToolNames.delete("access_mcp_resource")

--- a/src/core/prompts/tools/index.ts
+++ b/src/core/prompts/tools/index.ts
@@ -125,6 +125,14 @@ export function getToolDescriptionsForMode(
 	// Add always available tools
 	ALWAYS_AVAILABLE_TOOLS.forEach((tool) => tools.add(tool))
 
+	// kilocode_change start
+	// Conditionally exclude ask_followup_question in yolo mode
+	// This prevents the agent from asking itself questions and auto-answering them
+	if (clineProviderState?.yoloMode) {
+		tools.delete("ask_followup_question")
+	}
+	// kilocode_change end
+
 	// Conditionally exclude codebase_search if feature is disabled or not configured
 	// kilocode_change start
 	const isCodebaseSearchAvailable =


### PR DESCRIPTION
## Summary
  - Prevents the `ask_followup_question` tool from being used when yolo mode is enabled (via CLI `--yolo` flag or sidebar toggle)
  - Previously, the agent would ask itself questions and auto-answer them, which is unintuitive

  ## Changes
  - Filter out `ask_followup_question` from XML tool descriptions in system prompt
  - Filter out `ask_followup_question` from native tools list
  - Return helpful error at tool execution if model tries to use it from conversation history (handles mid-session yolo toggle)
  - Skip showing question UI during streaming in yolo mode