### PR TITLE
fix: use .git/info/exclude instead of .gitignore for worktree exclusion

### DIFF
--- a/.changeset/use-git-exclude-for-worktrees.md
+++ b/.changeset/use-git-exclude-for-worktrees.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": patch
+---
+
+Agent Manager: Parallel mode no longer modifies .gitignore
+
+Worktree exclusion rules are now written to `.git/info/exclude` instead, avoiding changes to tracked files in your repository.

--- a/apps/kilocode-docs/docs/advanced-usage/agent-manager.md
+++ b/apps/kilocode-docs/docs/advanced-usage/agent-manager.md
@@ -48,14 +48,16 @@ Parallel Mode runs the agent in an isolated Git worktree branch, keeping your ma
 
 ### Worktree Location
 
-Worktrees are created in `.kilocode/worktrees/` within your project directory. This folder is automatically added to `.gitignore` to prevent accidental commits.
+Worktrees are created in `.kilocode/worktrees/` within your project directory. This folder is automatically excluded from git via `.git/info/exclude` (a local-only ignore file that doesn't require a commit).
 
 ```
 your-project/
+├── .git/
+│   └── info/
+│       └── exclude   # local ignore rules (includes .kilocode/worktrees/)
 ├── .kilocode/
 │   └── worktrees/
 │       └── feature-branch-1234567890/   # isolated working directory
-├── .gitignore                           # auto-updated with .kilocode/worktrees/
 └── ...
 ```
 

--- a/src/core/kilocode/agent-manager/__tests__/AgentManagerProvider.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/AgentManagerProvider.spec.ts
@@ -93,7 +93,7 @@ describe("AgentManagerProvider CLI spawning", () => {
 				commitChanges: vi.fn().mockResolvedValue({ success: true }),
 				removeWorktree: vi.fn().mockResolvedValue(undefined),
 				discoverWorktrees: vi.fn().mockResolvedValue([]),
-				ensureGitignore: vi.fn().mockResolvedValue(undefined),
+				ensureGitExclude: vi.fn().mockResolvedValue(undefined),
 			})),
 			WorktreeError: class WorktreeError extends Error {
 				constructor(


### PR DESCRIPTION
## Summary
  - Changed WorktreeManager to write worktree exclusion rules to `.git/info/exclude` instead of `.gitignore`
  - This avoids modifying tracked files, eliminating the need for a commit
  - Added `resolveGitDir()` to handle nested worktree scenarios (finds main repo's .git directory)