### PR TITLE
docs(cli): improve development setup instructions

### DIFF
--- a/cli/docs/DEVELOPMENT.md
+++ b/cli/docs/DEVELOPMENT.md
@@ -6,13 +6,40 @@ We use `pnpm` for package management. Please make sure `pnpm` is installed.
 
 The CLI is currently built by bundling the extension core and replacing the vscode rendering parts with a cli rendering engine. To _develop_ on the CLI you need to follow a few steps:
 
-1. Build the extension core from the root workspace folder by running `pnpm cli:bundle`
+1. Install dependencies from the root workspace folder:
+   ```bash
+   pnpm install
+   ```
 
-2. Change into the cli folder `cd ./cli`
+2. Set up your environment file. Copy the sample and configure your API keys:
+   ```bash
+   cp .env.sample cli/dist/.env
+   # Edit cli/dist/.env with your API keys
+   ```
 
-3. Build & run the extension by running `pnpm start:dev`. If you want to use the CLI to work on its own code, you can run `pnpm start:dev -w ../` which will start it within the root workspace folder.
+3. Build the extension core from the root workspace folder:
+   ```bash
+   pnpm cli:bundle
+   ```
 
-4. While not required, it's pretty helpful to view log output of the cli in a separate terminal while you're developing. To do this, open a new terminal window and run `pnpm logs`. You can also run `pnpm logs:clear` to truncate any on-disk logs during development.
+4. Change into the cli folder:
+   ```bash
+   cd ./cli
+   ```
+
+5. Build & run the extension by running `pnpm start:dev`. If you want to use the CLI to work on its own code, you can run `pnpm start:dev -w ../` which will start it within the root workspace folder.
+
+6. While not required, it's pretty helpful to view log output of the cli in a separate terminal while you're developing. To do this, open a new terminal window and run `pnpm logs`. You can also run `pnpm logs:clear` to truncate any on-disk logs during development.
+
+### Quick Start (Testing Changes)
+
+If you just want to quickly test your changes without the dev server, you can run the bundled CLI directly:
+
+```bash
+# From the root workspace folder
+pnpm install && pnpm cli:bundle
+node cli/dist/index.js
+```
 
 ## Code Hygiene
 


### PR DESCRIPTION
Improves the CLI development documentation to make it easier for contributors to test their changes.

Changes:
- Add explicit `pnpm install` step
- Add environment file setup instructions (copy `.env.sample` to `cli/dist/.env`)
- Reformat steps with code blocks for better readability
- Add "Quick Start (Testing Changes)" section with one-liner command

Fixes an issue where contributors were missing required setup steps.