### PR TITLE
fix(litellm): add dedicated handler for LiteLLM models refresh

### DIFF
--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -99,6 +99,7 @@ export interface ExtensionMessage {
 		| "openAiModels"
 		| "ollamaModels"
 		| "lmStudioModels"
+		| "litellmModels"
 		| "vsCodeLmModels"
 		| "huggingFaceModels"
 		| "sapAiCoreModels" // kilocode_change
@@ -244,6 +245,7 @@ export interface ExtensionMessage {
 	openAiModels?: string[]
 	ollamaModels?: ModelRecord
 	lmStudioModels?: ModelRecord
+	litellmModels?: ModelRecord
 	vsCodeLmModels?: { vendor?: string; family?: string; version?: string; id?: string }[]
 	huggingFaceModels?: Array<{
 		id: string

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -85,6 +85,7 @@ export interface WebviewMessage {
 		| "requestOpenAiModels"
 		| "requestOllamaModels"
 		| "requestLmStudioModels"
+		| "requestLiteLLMModels"
 		| "requestRooModels"
 		| "requestRooCreditBalance"
 		| "requestVsCodeLmModels"


### PR DESCRIPTION
Fixes #4790

## Summary

Previously, LiteLLM models were fetched through the generic `requestRouterModels` handler, which only flushed the cache when API credentials changed. This meant that clicking "Refresh Models" without changing credentials would return cached models instead of fetching fresh ones from the server.

## Changes

- Added `requestLiteLLMModels` message type to `WebviewMessage.ts`
- Added `litellmModels` response type to `ExtensionMessage.ts`
- Added dedicated handler in `webviewMessageHandler.ts` that:
  - Always flushes the cache before fetching (consistent with Ollama and LM Studio handlers)
  - Fetches fresh models from the LiteLLM server
  - Sends the updated model list to the webview
- Added tests for the new handler

## Test Plan

- Added 2 new tests for `requestLiteLLMModels` handler
- All existing tests pass (7390 passed)
- Verified the implementation follows the same pattern as Ollama and LM Studio handlers

Co-Authored-By: Claude <noreply@anthropic.com>