### PR TITLE
fix(skills): use actual home directory path instead of tilde on Windows

### DIFF
--- a/src/core/prompts/sections/skills.ts
+++ b/src/core/prompts/sections/skills.ts
@@ -16,7 +16,7 @@ function getDisplayPath(skill: SkillMetadata): string {
 	const skillsDir = skill.mode ? `skills-${skill.mode}` : "skills"
 
 	if (skill.source === "project") {
-		return `.kilocode/${skillsDir}/${skill.name}/SKILL.md`
+		return path.join('.kilocode', skillsDir, skill.name, 'SKILL.md')
 	}
 
 	// For global skills, use the actual home directory path instead of ~

--- a/src/core/prompts/sections/skills.ts
+++ b/src/core/prompts/sections/skills.ts
@@ -24,7 +24,7 @@ function getDisplayPath(skill: SkillMetadata): string {
 	// on all platforms, especially Windows where ~ is not automatically expanded
 	const homeDir = os.homedir()
 	const basePath = path.join(homeDir, ".kilocode")
-	return `${basePath}/${skillsDir}/${skill.name}/SKILL.md`
+	return path.join(basePath, skillsDir, skill.name, 'SKILL.md')
 }
 
 /**

--- a/src/core/prompts/sections/skills.ts
+++ b/src/core/prompts/sections/skills.ts
@@ -1,15 +1,29 @@
+import * as os from "os"
+import * as path from "path"
 import { SkillsManager, SkillMetadata } from "../../../services/skills/SkillsManager"
 
 /**
- * Get a display-friendly relative path for a skill.
+ * Get a display-friendly path for a skill.
  * Converts absolute paths to relative paths to avoid leaking sensitive filesystem info.
  *
+ * For global skills, uses the actual home directory path (not ~) to ensure
+ * the path works correctly when the AI model tries to read the file on all platforms.
+ *
  * @param skill - The skill metadata
- * @returns A relative path like ".kilocode/skills/name/SKILL.md" or "~/.kilocode/skills/name/SKILL.md"
+ * @returns A path like ".kilocode/skills/name/SKILL.md" or "C:/Users/john/.kilocode/skills/name/SKILL.md"
  */
 function getDisplayPath(skill: SkillMetadata): string {
-	const basePath = skill.source === "project" ? ".kilocode" : "~/.kilocode"
 	const skillsDir = skill.mode ? `skills-${skill.mode}` : "skills"
+
+	if (skill.source === "project") {
+		return `.kilocode/${skillsDir}/${skill.name}/SKILL.md`
+	}
+
+	// For global skills, use the actual home directory path instead of ~
+	// This ensures the path works correctly when the AI model tries to read the file
+	// on all platforms, especially Windows where ~ is not automatically expanded
+	const homeDir = os.homedir()
+	const basePath = path.join(homeDir, ".kilocode")
 	return `${basePath}/${skillsDir}/${skill.name}/SKILL.md`
 }
 


### PR DESCRIPTION
Fixes #4779

## Summary

Previously, the display path for global skills used "~/.kilocode" which caused issues on Windows when the AI model tried to read the skill file. The tilde (~) is not automatically expanded to the home directory on Windows, resulting in malformed paths like:
```
e:\Projects\Temp\test_skill\\~\\.kilocode\skills\skill-creator\SKILL.md
```

## Changes

- Modified `getDisplayPath()` in `skills.ts` to use `os.homedir()` for global skills instead of `~/.kilocode`
- Added imports for `os` and `path` modules
- Updated JSDoc comments to reflect the new behavior

This ensures the path works correctly when the AI model tries to read the file on all platforms, especially Windows.

## Test Plan

- All existing tests pass (7386 passed)
- The fix follows the same pattern used in `kilo.ts` for rules (using `os.homedir()`)

Co-Authored-By: Claude <noreply@anthropic.com>