### PR TITLE
feat(agent-manager): use local CLI build in debug mode

### DIFF
--- a/.changeset/dev-cli-path.md
+++ b/.changeset/dev-cli-path.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+---
+
+Add KILOCODE_DEV_CLI_PATH support for easier extension + CLI development workflow

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,8 @@
 			"preLaunchTask": "${defaultBuildTask}",
 			"env": {
 				"NODE_ENV": "development",
-				"VSCODE_DEBUG_MODE": "true"
+				"VSCODE_DEBUG_MODE": "true",
+				"KILOCODE_DEV_CLI_PATH": "${workspaceFolder}/cli/dist/index.js"
 			},
 			"resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
 			"presentation": {
@@ -40,7 +41,8 @@
 			"preLaunchTask": "${defaultBuildTask}",
 			"env": {
 				"NODE_ENV": "development",
-				"VSCODE_DEBUG_MODE": "true"
+				"VSCODE_DEBUG_MODE": "true",
+				"KILOCODE_DEV_CLI_PATH": "${workspaceFolder}/cli/dist/index.js"
 			},
 			"resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
 			"presentation": { "hidden": false, "group": "tasks", "order": 1 }
@@ -57,6 +59,7 @@
 			"env": {
 				"NODE_ENV": "development",
 				"VSCODE_DEBUG_MODE": "true",
+				"KILOCODE_DEV_CLI_PATH": "${workspaceFolder}/cli/dist/index.js",
 				"KILOCODE_BACKEND_BASE_URL": "${input:kilocodeBackendBaseUrl}"
 			},
 			"resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
 	"tasks": [
 		{
 			"label": "watch",
-			"dependsOn": ["watch:pnpm", "watch:webview", "watch:bundle", "watch:tsc"],
+			"dependsOn": ["watch:pnpm", "watch:webview", "watch:bundle", "watch:tsc", "watch:cli"],
 			"presentation": {
 				"reveal": "never"
 			},
@@ -103,6 +103,29 @@
 			"isBackground": true,
 			"presentation": {
 				"group": "none",
+				"reveal": "always"
+			}
+		},
+		{
+			"label": "watch:cli",
+			"dependsOn": ["watch:pnpm"],
+			"type": "shell",
+			"command": "pnpm --filter @kilocode/cli dev",
+			"group": "build",
+			"problemMatcher": {
+				"owner": "esbuild",
+				"pattern": {
+					"regexp": "^$"
+				},
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": "esbuild-problem-matcher#onStart",
+					"endsPattern": "esbuild-problem-matcher#onEnd"
+				}
+			},
+			"isBackground": true,
+			"presentation": {
+				"group": "watch",
 				"reveal": "always"
 			}
 		},

--- a/cli/esbuild.config.mjs
+++ b/cli/esbuild.config.mjs
@@ -56,6 +56,23 @@ const afterBuildPlugin = {
 	},
 }
 
+// Problem matcher plugin for VS Code task integration
+const esbuildProblemMatcherPlugin = {
+	name: "esbuild-problem-matcher",
+	setup(build) {
+		build.onStart(() => console.log("[esbuild-problem-matcher#onStart]"))
+		build.onEnd((result) => {
+			result.errors.forEach(({ text, location }) => {
+				console.error(`✘ [ERROR] ${text}`)
+				if (location && location.file) {
+					console.error(`    ${location.file}:${location.line}:${location.column}:`)
+				}
+			})
+			console.log("[esbuild-problem-matcher#onEnd]")
+		})
+	},
+}
+
 const config = {
 	entryPoints: ["src/index.ts"],
 	bundle: true,
@@ -169,7 +186,7 @@ const __dirname = __dirname__(__filename);
 	minify: false,
 	treeShaking: true,
 	logLevel: "info",
-	plugins: [afterBuildPlugin],
+	plugins: [esbuildProblemMatcherPlugin, afterBuildPlugin],
 	alias: {
 		'is-in-ci': path.resolve(__dirname, 'src/patches/is-in-ci.ts'),
 	}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -19,6 +19,9 @@ import { getParallelModeParams } from "./parallel/parallel.js"
 import { DEBUG_MODES, DEBUG_FUNCTIONS } from "./debug/index.js"
 import { logs } from "./services/logs.js"
 
+// Log CLI location for debugging (visible in VS Code "Kilo-Code" output channel)
+logs.info(`CLI started from: ${import.meta.url}`)
+
 const program = new Command()
 let cli: CLI | null = null
 

--- a/src/core/kilocode/agent-manager/CliPathResolver.ts
+++ b/src/core/kilocode/agent-manager/CliPathResolver.ts
@@ -155,6 +155,14 @@ export async function findKilocodeCli(log?: (msg: string) => void): Promise<CliD
 	// when finding it, even when the editor is launched from Finder/Spotlight
 	const shellEnv = process.platform !== "win32" ? getLoginShellPath(log) : undefined
 
+	// 0) Development mode: use CLI from launch.json env variable
+	// This allows F5 debugging to use the locally built CLI from the source workspace
+	const devCliPath = process.env.KILOCODE_DEV_CLI_PATH
+	if (devCliPath && (await fileExistsAtPath(devCliPath))) {
+		log?.(`Using dev CLI from KILOCODE_DEV_CLI_PATH: ${devCliPath}`)
+		return { cliPath: devCliPath, shellPath: shellEnv }
+	}
+
 	// 1) Explicit override from settings
 	try {
 		// Lazy import avoids hard dep when running in non-extension contexts


### PR DESCRIPTION
## Summary
- Add `KILOCODE_DEV_CLI_PATH` environment variable in launch.json to automatically use the locally built CLI when debugging with F5
- Add `watch:cli` task to auto-build CLI in watch mode during development
- Add esbuild problem matcher to CLI build for proper VS Code task integration
- Add startup log to display CLI location for easier debugging

## Problem
When developing both the extension and CLI together, developers had to use workarounds (like two separate checkouts) to test their CLI changes with the extension.

## Solution
The extension now checks for `KILOCODE_DEV_CLI_PATH` env variable first when resolving CLI path. This variable is set automatically in launch.json, pointing to `${workspaceFolder}/cli/dist/index.js`.

## Test plan
- [x] F5 launches extension with local CLI build
- [x] CLI watch mode rebuilds on file changes
- [x] VS Code tasks show proper completion status (no perpetual loading spinner)
- [x] Log confirms correct CLI path: `[AgentManager] Using dev CLI from KILOCODE_DEV_CLI_PATH: .../cli/dist/index.js`