### PR TITLE
feat(cli): Add Shift+Tab keyboard shortcut to cycle through modes

### DIFF
--- a/.changeset/shift-tab-mode-cycling.md
+++ b/.changeset/shift-tab-mode-cycling.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Add Shift+Tab keyboard shortcut to cycle through modes in the CLI

--- a/apps/kilocode-docs/docs/cli.md
+++ b/apps/kilocode-docs/docs/cli.md
@@ -42,6 +42,19 @@ Upgrade the Kilo CLI package:
 
 ## CLI reference
 
+### Keyboard shortcuts
+
+| Shortcut    | Description                                                      |
+| ----------- | ---------------------------------------------------------------- |
+| `Shift+Tab` | Cycle through modes (architect → code → ask → debug → orchestrator → custom modes) |
+| `Ctrl+C`    | Exit (press twice to confirm)                                    |
+| `Ctrl+X`    | Cancel current task                                              |
+| `Esc`       | Cancel current task (while streaming) or clear input             |
+| `Ctrl+Y`    | Toggle YOLO mode (auto-approve all operations)                   |
+| `Ctrl+R`    | Resume task (when a task is ready to resume)                     |
+| `!`         | Enter shell mode (when input is empty)                           |
+| `↑/↓`       | Navigate command history (when input is empty)                   |
+
 ### CLI commands
 
 | Command               | Description                                                      | Example                        |

--- a/cli/src/state/atoms/__tests__/keyboard.test.ts
+++ b/cli/src/state/atoms/__tests__/keyboard.test.ts
@@ -20,7 +20,7 @@ import {
 } from "../keyboard.js"
 import { pendingApprovalAtom } from "../approval.js"
 import { historyDataAtom, historyModeAtom, historyIndexAtom as _historyIndexAtom } from "../history.js"
-import { chatMessagesAtom } from "../extension.js"
+import { chatMessagesAtom, extensionModeAtom, customModesAtom } from "../extension.js"
 import { extensionServiceAtom, isServiceReadyAtom } from "../service.js"
 import type { Key } from "../../../types/keyboard.js"
 import type { CommandSuggestion, ArgumentSuggestion, FileMentionSuggestion } from "../../../services/autocomplete.js"
@@ -1151,6 +1151,125 @@ describe("keypress atoms", () => {
 
 			// Exit prompt should be visible
 			expect(store.get(exitPromptVisibleAtom)).toBe(true)
+		})
+
+		it("should cycle to next mode when Shift+Tab is pressed", async () => {
+			// Set initial mode to "code"
+			store.set(extensionModeAtom, "code")
+			store.set(customModesAtom, [])
+
+			// Press Shift+Tab
+			const shiftTabKey: Key = {
+				name: "tab",
+				sequence: "\t",
+				ctrl: false,
+				meta: false,
+				shift: true,
+				paste: false,
+			}
+			await store.set(keyboardHandlerAtom, shiftTabKey)
+
+			// Wait for async operations to complete
+			await new Promise((resolve) => setTimeout(resolve, 10))
+
+			// Should have cycled to the next mode
+			// DEFAULT_MODES order: architect, code, ask, debug, orchestrator
+			// code is at index 1, so next is ask at index 2
+			const newMode = store.get(extensionModeAtom)
+			expect(newMode).toBe("ask")
+		})
+
+		it("should wrap around to first mode when at the last mode", async () => {
+			// Set initial mode to the last default mode
+			// DEFAULT_MODES order: architect, code, ask, debug, orchestrator
+			store.set(extensionModeAtom, "orchestrator")
+			store.set(customModesAtom, [])
+
+			// Press Shift+Tab
+			const shiftTabKey: Key = {
+				name: "tab",
+				sequence: "\t",
+				ctrl: false,
+				meta: false,
+				shift: true,
+				paste: false,
+			}
+			await store.set(keyboardHandlerAtom, shiftTabKey)
+
+			// Wait for async operations to complete
+			await new Promise((resolve) => setTimeout(resolve, 10))
+
+			// Should have wrapped around to the first mode (architect)
+			const newMode = store.get(extensionModeAtom)
+			expect(newMode).toBe("architect")
+		})
+
+		it("should include custom modes in the cycle", async () => {
+			// Set initial mode to "orchestrator" (last default mode)
+			store.set(extensionModeAtom, "orchestrator")
+			// Add a custom mode
+			store.set(customModesAtom, [
+				{
+					slug: "custom-mode",
+					name: "Custom Mode",
+					description: "A custom mode for testing",
+					roleDefinition: "You are a custom assistant",
+					groups: [],
+				},
+			])
+
+			// Press Shift+Tab
+			const shiftTabKey: Key = {
+				name: "tab",
+				sequence: "\t",
+				ctrl: false,
+				meta: false,
+				shift: true,
+				paste: false,
+			}
+			await store.set(keyboardHandlerAtom, shiftTabKey)
+
+			// Wait for async operations to complete
+			await new Promise((resolve) => setTimeout(resolve, 10))
+
+			// Should have cycled to the custom mode (after orchestrator)
+			const newMode = store.get(extensionModeAtom)
+			expect(newMode).toBe("custom-mode")
+		})
+
+		it("should not cycle mode when Tab is pressed without Shift", async () => {
+			// Set initial mode
+			store.set(extensionModeAtom, "code")
+			store.set(customModesAtom, [])
+
+			// Type some text first to avoid history mode
+			const chars = ["h", "i"]
+			for (const char of chars) {
+				const key: Key = {
+					name: char,
+					sequence: char,
+					ctrl: false,
+					meta: false,
+					shift: false,
+					paste: false,
+				}
+				store.set(keyboardHandlerAtom, key)
+			}
+
+			// Press Tab without Shift
+			const tabKey: Key = {
+				name: "tab",
+				sequence: "\t",
+				ctrl: false,
+				meta: false,
+				shift: false,
+				paste: false,
+			}
+			await store.set(keyboardHandlerAtom, tabKey)
+
+			// Mode should remain unchanged
+			const mode = store.get(extensionModeAtom)
+			expect(mode).toBe("code")
 		})
 	})
 

--- a/cli/src/state/atoms/keyboard.ts
+++ b/cli/src/state/atoms/keyboard.ts
@@ -43,7 +43,7 @@ import {
 } from "./textBuffer.js"
 import { isApprovalPendingAtom, approvalOptionsAtom, approveAtom, rejectAtom, executeSelectedAtom } from "./approval.js"
 import { hasResumeTaskAtom } from "./extension.js"
-import { cancelTaskAtom, resumeTaskAtom, toggleYoloModeAtom } from "./actions.js"
+import { cancelTaskAtom, resumeTaskAtom, toggleYoloModeAtom, cycleNextModeAtom } from "./actions.js"
 import {
 	historyModeAtom,
 	historyEntriesAtom,
@@ -974,6 +974,13 @@ function handleGlobalHotkeys(get: Getter, set: Setter, key: Key): boolean {
 			// Toggle YOLO mode with Ctrl+Y
 			if (key.ctrl) {
 				set(toggleYoloModeAtom)
+				return true
+			}
+			break
+		case "tab":
+			// Cycle through modes with Shift+Tab
+			if (key.shift) {
+				set(cycleNextModeAtom)
 				return true
 			}
 			break

--- a/cli/src/state/hooks/useHotkeys.ts
+++ b/cli/src/state/hooks/useHotkeys.ts
@@ -95,7 +95,7 @@ export function useHotkeys(): UseHotkeysReturn {
 		// Default: General command hints
 		return [
 			{ keys: "/help", description: "for commands" },
-			{ keys: "/mode", description: "to switch mode" },
+			{ keys: "Shift+Tab", description: "to cycle mode" },
 			{ keys: "!", description: "for shell mode", primary: true },
 		]
 	}, [hasResumeTask, isApprovalPending, isStreaming, isFollowupVisible, isShellModeActive, modifierKey])


### PR DESCRIPTION
## Summary

Adds a new keyboard shortcut `Shift+Tab` to the CLI that allows users to quickly cycle through all available modes (default + custom) without using the `/mode` command.

## Changes

- **`cli/src/state/atoms/actions.ts`** - Added `cycleNextModeAtom` that cycles through all available modes with wrap-around
- **`cli/src/state/atoms/keyboard.ts`** - Added Shift+Tab handler in `handleGlobalHotkeys` to trigger mode cycling
- **`cli/src/state/hooks/useHotkeys.ts`** - Updated hotkey hints to show `Shift+Tab` for mode cycling
- **`cli/src/state/atoms/__tests__/keyboard.test.ts`** - Added 4 tests for mode cycling functionality
- **`apps/kilocode-docs/docs/cli.md`** - Added new "Keyboard shortcuts" section documenting all CLI keyboard shortcuts

## Usage

Press **Shift+Tab** at any time to cycle through modes:
`architect → code → ask → debug → orchestrator → custom modes → back to architect`

The mode change is reflected in the status bar - no feedback message is shown since users can see the mode change themselves.

## Testing

All 4 new tests pass:
- `should cycle to next mode when Shift+Tab is pressed`
- `should wrap around to first mode when at the last mode`
- `should include custom modes in the cycle`
- `should not cycle mode when Tab is pressed without Shift`