### PR TITLE
fix: hide chat autocomplete when unfocused and discard stale suggestions

### DIFF
--- a/.changeset/fix-chat-autocomplete-focus.md
+++ b/.changeset/fix-chat-autocomplete-focus.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Fix chat autocomplete to only suggestions when textarea has focus, and text hasn't changed
+Fix chat autocomplete to only show suggestions when textarea has focus, text hasn't changed, and clear suggestions on paste

--- a/.changeset/fix-chat-autocomplete-focus.md
+++ b/.changeset/fix-chat-autocomplete-focus.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix chat autocomplete to hide suggestions when textarea loses focus and discard suggestions when text prefix no longer matches (e.g., after paste or external text changes)

--- a/.changeset/fix-chat-autocomplete-focus.md
+++ b/.changeset/fix-chat-autocomplete-focus.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Fix chat autocomplete to hide suggestions when textarea loses focus and discard suggestions when text prefix no longer matches (e.g., after paste or external text changes)
+Fix chat autocomplete to only suggestions when textarea has focus, and text hasn't changed

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1039,7 +1039,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				const urlRegex = /^\S+:\/\/\S+$/
 				if (urlRegex.test(pastedText.trim())) {
 					e.preventDefault()
-					clearGhostText() // kilocode_change: Clear ghost text on paste
+					clearGhostText() // kilocode_change: Clear ghost text on paste of URL as well
 					const trimmedUrl = pastedText.trim()
 					const newValue =
 						inputValue.slice(0, cursorPosition) + trimmedUrl + " " + inputValue.slice(cursorPosition)

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -419,6 +419,9 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			ghostText,
 			handleKeyDown: handleGhostTextKeyDown,
 			handleInputChange: handleGhostTextInputChange,
+			handleFocus: handleGhostTextFocus,
+			handleBlur: handleGhostTextBlur,
+			handleSelect: handleGhostTextSelect,
 		} = useChatGhostText({
 			textAreaRef,
 			enableChatAutocomplete: ghostServiceSettings?.enableChatAutocomplete ?? false,
@@ -1013,7 +1016,14 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			} // kilocode_change
 
 			// setIsFocused(false) // kilocode_change - not needed
-		}, [isMouseDownOnMenu])
+			handleGhostTextBlur() // kilocode_change: Clear ghost text on blur
+		}, [isMouseDownOnMenu, handleGhostTextBlur])
+
+		// kilocode_change start: FIM autocomplete - track focus for ghost text
+		const handleFocus = useCallback(() => {
+			handleGhostTextFocus()
+		}, [handleGhostTextFocus])
+		// kilocode_change end: FIM autocomplete
 
 		const handlePaste = useCallback(
 			async (e: React.ClipboardEvent) => {
@@ -1207,7 +1217,8 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			if (textAreaRef.current) {
 				setCursorPosition(textAreaRef.current.selectionStart)
 			}
-		}, [])
+			handleGhostTextSelect() // kilocode_change: Clear ghost text if cursor moved away from end
+		}, [handleGhostTextSelect])
 
 		const handleKeyUp = useCallback(
 			(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -1548,7 +1559,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							updateHighlights()
 						}
 					}}
-					// onFocus={() => setIsFocused(true)} // kilocode_change - not needed
+					onFocus={handleFocus} // kilocode_change: FIM autocomplete - track focus for ghost text
 					onKeyDown={(e) => {
 						// Handle ESC to cancel in edit mode
 						if (isEditMode && e.key === "Escape" && !e.nativeEvent?.isComposing) {

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -413,7 +413,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const [intendedCursorPosition, setIntendedCursorPosition] = useState<number | null>(null)
 		const contextMenuContainerRef = useRef<HTMLDivElement>(null)
 		const [isEnhancingPrompt, setIsEnhancingPrompt] = useState(false)
-		// const [isFocused, setIsFocused] = useState(false) // kilocode_change - not needed
+		const [isFocused, setIsFocused] = useState(false)
 		// kilocode_change start: FIM autocomplete ghost text
 		const {
 			ghostText,
@@ -1015,14 +1015,17 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				setShowSlashCommandsMenu(false)
 			} // kilocode_change
 
-			// setIsFocused(false) // kilocode_change - not needed
-			handleGhostTextBlur() // kilocode_change: Clear ghost text on blur
-		}, [isMouseDownOnMenu, handleGhostTextBlur])
+			setIsFocused(false)
+		}, [isMouseDownOnMenu])
 
 		// kilocode_change start: FIM autocomplete - track focus for ghost text
-		const handleFocus = useCallback(() => {
-			handleGhostTextFocus()
-		}, [handleGhostTextFocus])
+		useEffect(() => {
+			if (isFocused) {
+				handleGhostTextFocus()
+			} else {
+				handleGhostTextBlur()
+			}
+		}, [isFocused, handleGhostTextFocus, handleGhostTextBlur])
 		// kilocode_change end: FIM autocomplete
 
 		const handlePaste = useCallback(
@@ -1559,7 +1562,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							updateHighlights()
 						}
 					}}
-					onFocus={handleFocus} // kilocode_change: FIM autocomplete - track focus for ghost text
+					onFocus={() => setIsFocused(true)}
 					onKeyDown={(e) => {
 						// Handle ESC to cancel in edit mode
 						if (isEditMode && e.key === "Escape" && !e.nativeEvent?.isComposing) {

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -422,6 +422,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			handleFocus: handleGhostTextFocus,
 			handleBlur: handleGhostTextBlur,
 			handleSelect: handleGhostTextSelect,
+			clearGhostText,
 		} = useChatGhostText({
 			textAreaRef,
 			enableChatAutocomplete: ghostServiceSettings?.enableChatAutocomplete ?? false,
@@ -1038,6 +1039,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				const urlRegex = /^\S+:\/\/\S+$/
 				if (urlRegex.test(pastedText.trim())) {
 					e.preventDefault()
+					clearGhostText() // kilocode_change: Clear ghost text on paste
 					const trimmedUrl = pastedText.trim()
 					const newValue =
 						inputValue.slice(0, cursorPosition) + trimmedUrl + " " + inputValue.slice(cursorPosition)
@@ -1122,6 +1124,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				t,
 				selectedImages.length,
 				showImageWarning, // kilocode_change
+				clearGhostText, // kilocode_change: Clear ghost text on paste
 			],
 		)
 

--- a/webview-ui/src/components/chat/hooks/__tests__/useChatGhostText.spec.tsx
+++ b/webview-ui/src/components/chat/hooks/__tests__/useChatGhostText.spec.tsx
@@ -710,5 +710,76 @@ describe("useChatGhostText", () => {
 			// Ghost text should be cleared because there's a selection
 			expect(result.current.ghostText).toBe("")
 		})
+
+		it("should restore ghost text when cursor returns to end via handleSelect", () => {
+			const { result } = renderHook(() =>
+				useChatGhostText({
+					textAreaRef,
+					enableChatAutocomplete: true,
+				}),
+			)
+
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Hello world", " completion")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" completion")
+
+			// Move cursor to middle
+			mockTextArea.selectionStart = 5
+			mockTextArea.selectionEnd = 5
+
+			// Call handleSelect - ghost text should be cleared
+			act(() => {
+				result.current.handleSelect()
+			})
+			expect(result.current.ghostText).toBe("")
+
+			// Move cursor back to end
+			mockTextArea.selectionStart = 11
+			mockTextArea.selectionEnd = 11
+
+			// Call handleSelect again - ghost text should be restored
+			act(() => {
+				result.current.handleSelect()
+			})
+			expect(result.current.ghostText).toBe(" completion")
+		})
+
+		it("should not restore ghost text when cursor returns to end if text changed", () => {
+			const { result } = renderHook(() =>
+				useChatGhostText({
+					textAreaRef,
+					enableChatAutocomplete: true,
+				}),
+			)
+
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Hello world", " completion")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" completion")
+
+			// Move cursor to middle
+			mockTextArea.selectionStart = 5
+			mockTextArea.selectionEnd = 5
+
+			// Call handleSelect - ghost text should be cleared
+			act(() => {
+				result.current.handleSelect()
+			})
+			expect(result.current.ghostText).toBe("")
+
+			// Change the text
+			mockTextArea.value = "Different text"
+			mockTextArea.selectionStart = 14
+			mockTextArea.selectionEnd = 14
+
+			// Call handleSelect again - ghost text should NOT be restored because text changed
+			act(() => {
+				result.current.handleSelect()
+			})
+			expect(result.current.ghostText).toBe("")
+		})
 	})
 })

--- a/webview-ui/src/components/chat/hooks/__tests__/useChatGhostText.spec.tsx
+++ b/webview-ui/src/components/chat/hooks/__tests__/useChatGhostText.spec.tsx
@@ -1,4 +1,4 @@
-import { renderHook, act, waitFor } from "@testing-library/react"
+import { renderHook, act } from "@testing-library/react"
 import { vi } from "vitest"
 import { useChatGhostText } from "../useChatGhostText"
 
@@ -9,13 +9,64 @@ vi.mock("@/utils/vscode", () => ({
 	},
 }))
 
+// Mock generateRequestId to return a predictable value
+const MOCK_REQUEST_ID = "test-request-id"
+vi.mock("@roo/id", () => ({
+	generateRequestId: () => MOCK_REQUEST_ID,
+}))
+
+// Helper to simulate the full flow: focus -> input change -> completion result
+function simulateCompletionFlow(
+	result: ReturnType<typeof useChatGhostText>,
+	mockTextArea: HTMLTextAreaElement,
+	text: string,
+	ghostText: string,
+) {
+	// First, focus the textarea
+	act(() => {
+		result.handleFocus()
+	})
+
+	// Then simulate input change (this sets the prefix and triggers completion request)
+	act(() => {
+		mockTextArea.value = text
+		mockTextArea.selectionStart = text.length
+		mockTextArea.selectionEnd = text.length
+		const changeEvent = {
+			target: mockTextArea,
+		} as React.ChangeEvent<HTMLTextAreaElement>
+		result.handleInputChange(changeEvent)
+	})
+
+	// Advance timers to trigger the debounced completion request
+	act(() => {
+		vi.advanceTimersByTime(300)
+	})
+
+	// Finally, simulate receiving the completion result
+	// The requestId should match what was set during handleInputChange
+	act(() => {
+		const messageEvent = new MessageEvent("message", {
+			data: {
+				type: "chatCompletionResult",
+				text: ghostText,
+				requestId: MOCK_REQUEST_ID,
+			},
+		})
+		window.dispatchEvent(messageEvent)
+	})
+}
+
 describe("useChatGhostText", () => {
 	let mockTextArea: HTMLTextAreaElement
 	let textAreaRef: React.RefObject<HTMLTextAreaElement>
 
 	beforeEach(() => {
+		vi.useFakeTimers()
 		mockTextArea = document.createElement("textarea")
 		mockTextArea.value = "Hello world"
+		mockTextArea.selectionStart = 11
+		mockTextArea.selectionEnd = 11
 		document.body.appendChild(mockTextArea)
 		textAreaRef = { current: mockTextArea }
 		document.execCommand = vi.fn(() => true)
@@ -24,6 +75,7 @@ describe("useChatGhostText", () => {
 	afterEach(() => {
 		document.body.removeChild(mockTextArea)
 		vi.clearAllMocks()
+		vi.useRealTimers()
 	})
 
 	describe("Tab key acceptance", () => {
@@ -35,22 +87,11 @@ describe("useChatGhostText", () => {
 				}),
 			)
 
-			// Simulate receiving ghost text
-			act(() => {
-				const messageEvent = new MessageEvent("message", {
-					data: {
-						type: "chatCompletionResult",
-						text: " completion text",
-						requestId: "",
-					},
-				})
-				window.dispatchEvent(messageEvent)
-			})
+			// Simulate the full flow: focus -> input -> completion result
+			simulateCompletionFlow(result.current, mockTextArea, "Hello world", " completion text")
 
-			// Wait for ghost text to be set
-			waitFor(() => {
-				expect(result.current.ghostText).toBe(" completion text")
-			})
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" completion text")
 
 			// Simulate Tab key press
 			const tabEvent = {
@@ -71,10 +112,6 @@ describe("useChatGhostText", () => {
 
 	describe("Right Arrow key - word-by-word acceptance", () => {
 		it("should accept next word when cursor is at end", () => {
-			mockTextArea.value = "Hello world"
-			mockTextArea.selectionStart = 11 // At end
-			mockTextArea.selectionEnd = 11
-
 			const { result } = renderHook(() =>
 				useChatGhostText({
 					textAreaRef,
@@ -82,17 +119,11 @@ describe("useChatGhostText", () => {
 				}),
 			)
 
-			// Set ghost text manually for test
-			act(() => {
-				const messageEvent = new MessageEvent("message", {
-					data: {
-						type: "chatCompletionResult",
-						text: " this is more text",
-						requestId: "",
-					},
-				})
-				window.dispatchEvent(messageEvent)
-			})
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Hello world", " this is more text")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" this is more text")
 
 			// Simulate Right Arrow key press
 			const arrowEvent = {
@@ -124,17 +155,11 @@ describe("useChatGhostText", () => {
 				}),
 			)
 
-			// Set ghost text
-			act(() => {
-				const messageEvent = new MessageEvent("message", {
-					data: {
-						type: "chatCompletionResult",
-						text: " word1 word2 word3",
-						requestId: "",
-					},
-				})
-				window.dispatchEvent(messageEvent)
-			})
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Start", " word1 word2 word3")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" word1 word2 word3")
 
 			const arrowEvent = {
 				key: "ArrowRight",
@@ -164,10 +189,6 @@ describe("useChatGhostText", () => {
 		})
 
 		it("should NOT accept word when cursor is not at end", () => {
-			mockTextArea.value = "Hello world"
-			mockTextArea.selectionStart = 5 // In middle
-			mockTextArea.selectionEnd = 5
-
 			const { result } = renderHook(() =>
 				useChatGhostText({
 					textAreaRef,
@@ -175,17 +196,15 @@ describe("useChatGhostText", () => {
 				}),
 			)
 
-			// Set ghost text
-			act(() => {
-				const messageEvent = new MessageEvent("message", {
-					data: {
-						type: "chatCompletionResult",
-						text: " more text",
-						requestId: "",
-					},
-				})
-				window.dispatchEvent(messageEvent)
-			})
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Hello world", " more text")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" more text")
+
+			// Move cursor to middle
+			mockTextArea.selectionStart = 5
+			mockTextArea.selectionEnd = 5
 
 			const arrowEvent = {
 				key: "ArrowRight",
@@ -203,9 +222,9 @@ describe("useChatGhostText", () => {
 		})
 
 		it("should NOT accept word with Shift modifier", () => {
-			mockTextArea.value = "Test"
-			mockTextArea.selectionStart = 4
-			mockTextArea.selectionEnd = 4
+			mockTextArea.value = "Test1"
+			mockTextArea.selectionStart = 5
+			mockTextArea.selectionEnd = 5
 
 			const { result } = renderHook(() =>
 				useChatGhostText({
@@ -214,17 +233,11 @@ describe("useChatGhostText", () => {
 				}),
 			)
 
-			// Set ghost text
-			act(() => {
-				const messageEvent = new MessageEvent("message", {
-					data: {
-						type: "chatCompletionResult",
-						text: " text",
-						requestId: "",
-					},
-				})
-				window.dispatchEvent(messageEvent)
-			})
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Test1", " text")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" text")
 
 			const arrowEvent = {
 				key: "ArrowRight",
@@ -241,9 +254,9 @@ describe("useChatGhostText", () => {
 		})
 
 		it("should NOT accept word with Ctrl modifier", () => {
-			mockTextArea.value = "Test"
-			mockTextArea.selectionStart = 4
-			mockTextArea.selectionEnd = 4
+			mockTextArea.value = "Test2"
+			mockTextArea.selectionStart = 5
+			mockTextArea.selectionEnd = 5
 
 			const { result } = renderHook(() =>
 				useChatGhostText({
@@ -252,17 +265,11 @@ describe("useChatGhostText", () => {
 				}),
 			)
 
-			// Set ghost text
-			act(() => {
-				const messageEvent = new MessageEvent("message", {
-					data: {
-						type: "chatCompletionResult",
-						text: " text",
-						requestId: "",
-					},
-				})
-				window.dispatchEvent(messageEvent)
-			})
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Test2", " text")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" text")
 
 			const arrowEvent = {
 				key: "ArrowRight",
@@ -288,18 +295,10 @@ describe("useChatGhostText", () => {
 				}),
 			)
 
-			// Set ghost text
-			act(() => {
-				const messageEvent = new MessageEvent("message", {
-					data: {
-						type: "chatCompletionResult",
-						text: " world",
-						requestId: "",
-					},
-				})
-				window.dispatchEvent(messageEvent)
-			})
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Hello world", " world")
 
+			// Verify ghost text is set
 			expect(result.current.ghostText).toBe(" world")
 
 			// Simulate Escape key
@@ -317,9 +316,9 @@ describe("useChatGhostText", () => {
 
 	describe("Edge cases", () => {
 		it("should handle ghost text with only whitespace", () => {
-			mockTextArea.value = "Test"
-			mockTextArea.selectionStart = 4
-			mockTextArea.selectionEnd = 4
+			mockTextArea.value = "Test3"
+			mockTextArea.selectionStart = 5
+			mockTextArea.selectionEnd = 5
 
 			const { result } = renderHook(() =>
 				useChatGhostText({
@@ -328,17 +327,11 @@ describe("useChatGhostText", () => {
 				}),
 			)
 
-			// Set ghost text with only whitespace
-			act(() => {
-				const messageEvent = new MessageEvent("message", {
-					data: {
-						type: "chatCompletionResult",
-						text: "   ",
-						requestId: "",
-					},
-				})
-				window.dispatchEvent(messageEvent)
-			})
+			// Simulate the full flow with whitespace-only ghost text
+			simulateCompletionFlow(result.current, mockTextArea, "Test3", "   ")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe("   ")
 
 			const arrowEvent = {
 				key: "ArrowRight",
@@ -357,9 +350,9 @@ describe("useChatGhostText", () => {
 		})
 
 		it("should handle single word ghost text", () => {
-			mockTextArea.value = "Test"
-			mockTextArea.selectionStart = 4
-			mockTextArea.selectionEnd = 4
+			mockTextArea.value = "Test4"
+			mockTextArea.selectionStart = 5
+			mockTextArea.selectionEnd = 5
 
 			const { result } = renderHook(() =>
 				useChatGhostText({
@@ -368,17 +361,11 @@ describe("useChatGhostText", () => {
 				}),
 			)
 
-			// Set single word ghost text
-			act(() => {
-				const messageEvent = new MessageEvent("message", {
-					data: {
-						type: "chatCompletionResult",
-						text: "word",
-						requestId: "",
-					},
-				})
-				window.dispatchEvent(messageEvent)
-			})
+			// Simulate the full flow with single word ghost text
+			simulateCompletionFlow(result.current, mockTextArea, "Test4", "word")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe("word")
 
 			const arrowEvent = {
 				key: "ArrowRight",
@@ -397,9 +384,9 @@ describe("useChatGhostText", () => {
 		})
 
 		it("should handle empty ghost text gracefully", () => {
-			mockTextArea.value = "Test"
-			mockTextArea.selectionStart = 4
-			mockTextArea.selectionEnd = 4
+			mockTextArea.value = "Test5"
+			mockTextArea.selectionStart = 5
+			mockTextArea.selectionEnd = 5
 
 			const { result } = renderHook(() =>
 				useChatGhostText({
@@ -432,7 +419,107 @@ describe("useChatGhostText", () => {
 				}),
 			)
 
-			// Set ghost text
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Hello world", " completion")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" completion")
+
+			act(() => {
+				result.current.clearGhostText()
+			})
+
+			expect(result.current.ghostText).toBe("")
+		})
+	})
+
+	describe("Focus and blur behavior", () => {
+		it("should clear ghost text on blur and restore on focus", () => {
+			const { result } = renderHook(() =>
+				useChatGhostText({
+					textAreaRef,
+					enableChatAutocomplete: true,
+				}),
+			)
+
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Hello world", " completion")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" completion")
+
+			// Blur the textarea
+			act(() => {
+				result.current.handleBlur()
+			})
+
+			expect(result.current.ghostText).toBe("")
+
+			// Focus the textarea again - ghost text should be restored
+			act(() => {
+				result.current.handleFocus()
+			})
+
+			expect(result.current.ghostText).toBe(" completion")
+		})
+
+		it("should not restore ghost text if text changed while unfocused", () => {
+			const { result } = renderHook(() =>
+				useChatGhostText({
+					textAreaRef,
+					enableChatAutocomplete: true,
+				}),
+			)
+
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Hello world", " completion")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" completion")
+
+			// Blur the textarea
+			act(() => {
+				result.current.handleBlur()
+			})
+
+			expect(result.current.ghostText).toBe("")
+
+			// Change the text while unfocused (simulating external change)
+			mockTextArea.value = "Different text"
+			mockTextArea.selectionStart = 14
+			mockTextArea.selectionEnd = 14
+
+			// Focus the textarea again - ghost text should NOT be restored
+			act(() => {
+				result.current.handleFocus()
+			})
+
+			expect(result.current.ghostText).toBe("")
+		})
+
+		it("should not request completion when not focused", () => {
+			const { result } = renderHook(() =>
+				useChatGhostText({
+					textAreaRef,
+					enableChatAutocomplete: true,
+				}),
+			)
+
+			// Don't call handleFocus - simulate typing without focus
+			act(() => {
+				mockTextArea.value = "Hello world"
+				const changeEvent = {
+					target: mockTextArea,
+				} as React.ChangeEvent<HTMLTextAreaElement>
+				result.current.handleInputChange(changeEvent)
+			})
+
+			// Advance timers
+			act(() => {
+				vi.advanceTimersByTime(300)
+			})
+
+			// Simulate receiving completion result
 			act(() => {
 				const messageEvent = new MessageEvent("message", {
 					data: {
@@ -444,12 +531,102 @@ describe("useChatGhostText", () => {
 				window.dispatchEvent(messageEvent)
 			})
 
-			expect(result.current.ghostText).toBe(" completion")
+			// Ghost text should not be set because we weren't focused
+			expect(result.current.ghostText).toBe("")
+		})
 
+		it("should discard completion result if text changed", () => {
+			const { result } = renderHook(() =>
+				useChatGhostText({
+					textAreaRef,
+					enableChatAutocomplete: true,
+				}),
+			)
+
+			// Focus and type
 			act(() => {
-				result.current.clearGhostText()
+				result.current.handleFocus()
 			})
 
+			act(() => {
+				mockTextArea.value = "Hello world"
+				mockTextArea.selectionStart = 11
+				mockTextArea.selectionEnd = 11
+				const changeEvent = {
+					target: mockTextArea,
+				} as React.ChangeEvent<HTMLTextAreaElement>
+				result.current.handleInputChange(changeEvent)
+			})
+
+			// Advance timers to trigger completion request
+			act(() => {
+				vi.advanceTimersByTime(300)
+			})
+
+			// Change the text before completion arrives (simulating paste or external change)
+			mockTextArea.value = "Different text"
+
+			// Simulate receiving completion result for the old text
+			act(() => {
+				const messageEvent = new MessageEvent("message", {
+					data: {
+						type: "chatCompletionResult",
+						text: " completion",
+						requestId: "",
+					},
+				})
+				window.dispatchEvent(messageEvent)
+			})
+
+			// Ghost text should not be set because the text changed
+			expect(result.current.ghostText).toBe("")
+		})
+
+		it("should discard completion result if cursor is not at end", () => {
+			const { result } = renderHook(() =>
+				useChatGhostText({
+					textAreaRef,
+					enableChatAutocomplete: true,
+				}),
+			)
+
+			// Focus and type
+			act(() => {
+				result.current.handleFocus()
+			})
+
+			act(() => {
+				mockTextArea.value = "Hello world"
+				mockTextArea.selectionStart = 11
+				mockTextArea.selectionEnd = 11
+				const changeEvent = {
+					target: mockTextArea,
+				} as React.ChangeEvent<HTMLTextAreaElement>
+				result.current.handleInputChange(changeEvent)
+			})
+
+			// Advance timers to trigger completion request
+			act(() => {
+				vi.advanceTimersByTime(300)
+			})
+
+			// Move cursor to middle before completion arrives
+			mockTextArea.selectionStart = 5
+			mockTextArea.selectionEnd = 5
+
+			// Simulate receiving completion result
+			act(() => {
+				const messageEvent = new MessageEvent("message", {
+					data: {
+						type: "chatCompletionResult",
+						text: " completion",
+						requestId: MOCK_REQUEST_ID,
+					},
+				})
+				window.dispatchEvent(messageEvent)
+			})
+
+			// Ghost text should not be set because cursor is not at end
 			expect(result.current.ghostText).toBe("")
 		})
 	})

--- a/webview-ui/src/components/chat/hooks/__tests__/useChatGhostText.spec.tsx
+++ b/webview-ui/src/components/chat/hooks/__tests__/useChatGhostText.spec.tsx
@@ -629,5 +629,86 @@ describe("useChatGhostText", () => {
 			// Ghost text should not be set because cursor is not at end
 			expect(result.current.ghostText).toBe("")
 		})
+
+		it("should clear ghost text when cursor moves away from end via handleSelect", () => {
+			const { result } = renderHook(() =>
+				useChatGhostText({
+					textAreaRef,
+					enableChatAutocomplete: true,
+				}),
+			)
+
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Hello world", " completion")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" completion")
+
+			// Move cursor to middle (simulating user clicking or using arrow keys)
+			mockTextArea.selectionStart = 5
+			mockTextArea.selectionEnd = 5
+
+			// Call handleSelect (this is called on selection change events)
+			act(() => {
+				result.current.handleSelect()
+			})
+
+			// Ghost text should be cleared because cursor is no longer at end
+			expect(result.current.ghostText).toBe("")
+		})
+
+		it("should not clear ghost text when cursor is still at end via handleSelect", () => {
+			const { result } = renderHook(() =>
+				useChatGhostText({
+					textAreaRef,
+					enableChatAutocomplete: true,
+				}),
+			)
+
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Hello world", " completion")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" completion")
+
+			// Cursor is still at end
+			mockTextArea.selectionStart = 11
+			mockTextArea.selectionEnd = 11
+
+			// Call handleSelect
+			act(() => {
+				result.current.handleSelect()
+			})
+
+			// Ghost text should still be there
+			expect(result.current.ghostText).toBe(" completion")
+		})
+
+		it("should clear ghost text when there is a selection via handleSelect", () => {
+			const { result } = renderHook(() =>
+				useChatGhostText({
+					textAreaRef,
+					enableChatAutocomplete: true,
+				}),
+			)
+
+			// Simulate the full flow
+			simulateCompletionFlow(result.current, mockTextArea, "Hello world", " completion")
+
+			// Verify ghost text is set
+			expect(result.current.ghostText).toBe(" completion")
+
+			// Create a selection (not just cursor position)
+			mockTextArea.selectionStart = 5
+			mockTextArea.selectionEnd = 11
+
+			// Call handleSelect
+			act(() => {
+				result.current.handleSelect()
+			})
+
+			// Ghost text should be cleared because there's a selection
+			expect(result.current.ghostText).toBe("")
+		})
 	})
 })

--- a/webview-ui/src/components/chat/hooks/useChatGhostText.ts
+++ b/webview-ui/src/components/chat/hooks/useChatGhostText.ts
@@ -206,14 +206,27 @@ export function useChatGhostText({
 	}, [ghostText, textAreaRef])
 
 	const handleSelect = useCallback(() => {
-		// Clear ghost text if cursor is no longer at the end
 		const textArea = textAreaRef.current
-		if (textArea && ghostText) {
-			const isCursorAtEnd =
-				textArea.selectionStart === textArea.value.length && textArea.selectionEnd === textArea.value.length
+		if (!textArea) return
+
+		const isCursorAtEnd =
+			textArea.selectionStart === textArea.value.length && textArea.selectionEnd === textArea.value.length
+
+		if (ghostText) {
+			// Clear ghost text if cursor is no longer at the end
 			if (!isCursorAtEnd) {
+				// Save ghost text before clearing so we can restore it when cursor returns to end
+				savedGhostTextRef.current = ghostText
+				savedPrefixRef.current = textArea.value
 				setGhostText("")
-				// Also clear saved ghost text since cursor position changed
+			}
+		} else if (isCursorAtEnd && savedGhostTextRef.current) {
+			// Restore ghost text if cursor returned to end and text hasn't changed
+			const currentText = textArea.value
+			if (currentText === savedPrefixRef.current) {
+				setGhostText(savedGhostTextRef.current)
+			} else {
+				// Text changed, clear saved ghost text
 				savedGhostTextRef.current = ""
 				savedPrefixRef.current = ""
 			}

--- a/webview-ui/src/components/chat/hooks/useChatGhostText.ts
+++ b/webview-ui/src/components/chat/hooks/useChatGhostText.ts
@@ -15,6 +15,7 @@ interface UseChatGhostTextReturn {
 	handleInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
 	handleFocus: () => void
 	handleBlur: () => void
+	handleSelect: () => void
 	clearGhostText: () => void
 }
 
@@ -204,6 +205,21 @@ export function useChatGhostText({
 		}
 	}, [ghostText, textAreaRef])
 
+	const handleSelect = useCallback(() => {
+		// Clear ghost text if cursor is no longer at the end
+		const textArea = textAreaRef.current
+		if (textArea && ghostText) {
+			const isCursorAtEnd =
+				textArea.selectionStart === textArea.value.length && textArea.selectionEnd === textArea.value.length
+			if (!isCursorAtEnd) {
+				setGhostText("")
+				// Also clear saved ghost text since cursor position changed
+				savedGhostTextRef.current = ""
+				savedPrefixRef.current = ""
+			}
+		}
+	}, [ghostText, textAreaRef])
+
 	useEffect(() => {
 		return () => {
 			if (completionDebounceRef.current) {
@@ -218,6 +234,7 @@ export function useChatGhostText({
 		handleInputChange,
 		handleFocus,
 		handleBlur,
+		handleSelect,
 		clearGhostText,
 	}
 }


### PR DESCRIPTION
## Summary

Fixes two issues with the chat autocomplete feature added in #3999:

1. **Hide suggestions when textarea loses focus**: Suggestions are now cleared when the textarea loses focus, and completion results are ignored if the textarea is not focused when they arrive.

2. **Discard suggestions when prefix doesn't match**: When a completion result arrives, we now verify that the current textarea value still matches the prefix that was used for the request. If the text has changed (e.g., from paste or 'add to context from kilo'), the suggestion is silently discarded.

3. **Do not show suggestion when we aren't at the end of the chatbox
![CleanShot 2026-01-13 at 13 57 52](https://github.com/user-attachments/assets/0f2c6c1e-0521-451b-a8ff-a747792d82b9)
