### PR TITLE
feat: add click-to-show for Ghost status bar tooltip

### DIFF
--- a/.changeset/ghost-statusbar-click.md
+++ b/.changeset/ghost-statusbar-click.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add click-to-show functionality for Ghost status bar tooltip

--- a/src/services/ghost/GhostStatusBar.ts
+++ b/src/services/ghost/GhostStatusBar.ts
@@ -65,10 +65,10 @@ export class GhostStatusBar {
 		this.statusBar.dispose()
 	}
 
-	// kilocode_change start - Show status message on click
+	// kilocode_change start - Show status dialog on click
 	private showStatusMessage() {
 		if (this.props.hasKilocodeProfileWithNoBalance) {
-			vscode.window.showWarningMessage(t("kilocode:ghost.statusBar.tooltip.noCredits"))
+			vscode.window.showWarningMessage(t("kilocode:ghost.statusBar.tooltip.noCredits"), { modal: true })
 			return
 		}
 		if (this.props.hasNoUsableProvider) {
@@ -76,6 +76,7 @@ export class GhostStatusBar {
 			const providerList = providers.join(", ")
 			vscode.window.showWarningMessage(
 				t("kilocode:ghost.statusBar.tooltip.noUsableProvider", { providers: providerList }),
+				{ modal: true },
 			)
 			return
 		}
@@ -83,7 +84,7 @@ export class GhostStatusBar {
 		const sessionStartTime = this.formatTime(this.props.sessionStartTime)
 		const now = this.formatTime(Date.now())
 
-		const message = [
+		const details = [
 			t("kilocode:ghost.statusBar.tooltip.completionSummary", {
 				count: this.props.completionCount,
 				startTime: sessionStartTime,
@@ -98,9 +99,9 @@ export class GhostStatusBar {
 				: undefined,
 		]
 			.filter(Boolean)
-			.join(" | ")
+			.join("\n\n")
 
-		vscode.window.showInformationMessage(message)
+		vscode.window.showInformationMessage(details, { modal: true })
 	}
 	// kilocode_change end
 

--- a/src/services/ghost/GhostStatusBar.ts
+++ b/src/services/ghost/GhostStatusBar.ts
@@ -10,6 +10,9 @@ const PROVIDER_DISPLAY_NAMES = Object.fromEntries(PROVIDERS.map(({ value, label 
 	string
 >
 
+// kilocode_change - Command ID for showing ghost status tooltip on click
+const GHOST_STATUS_COMMAND_ID = "kilocode.ghost.showStatus"
+
 /**
  * Get the display names of all supported autocomplete providers
  */
@@ -21,6 +24,7 @@ function getSupportedProviderDisplayNames(): string[] {
 export class GhostStatusBar {
 	statusBar: vscode.StatusBarItem
 	private props: GhostStatusBarStateProps
+	private commandDisposable: vscode.Disposable | undefined // kilocode_change
 
 	constructor(params: GhostStatusBarStateProps) {
 		this.statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100)
@@ -30,6 +34,13 @@ export class GhostStatusBar {
 	}
 
 	private init() {
+		// kilocode_change start - Register command to show status on click
+		this.commandDisposable = vscode.commands.registerCommand(GHOST_STATUS_COMMAND_ID, () => {
+			this.showStatusMessage()
+		})
+		this.statusBar.command = GHOST_STATUS_COMMAND_ID
+		// kilocode_change end
+
 		this.statusBar.text = t("kilocode:ghost.statusBar.enabled")
 		this.statusBar.tooltip = this.createMarkdownTooltip(t("kilocode:ghost.statusBar.tooltip.basic"))
 		this.statusBar.show()
@@ -50,8 +61,48 @@ export class GhostStatusBar {
 	}
 
 	public dispose() {
+		this.commandDisposable?.dispose() // kilocode_change
 		this.statusBar.dispose()
 	}
+
+	// kilocode_change start - Show status message on click
+	private showStatusMessage() {
+		if (this.props.hasKilocodeProfileWithNoBalance) {
+			vscode.window.showWarningMessage(t("kilocode:ghost.statusBar.tooltip.noCredits"))
+			return
+		}
+		if (this.props.hasNoUsableProvider) {
+			const providers = getSupportedProviderDisplayNames()
+			const providerList = providers.join(", ")
+			vscode.window.showWarningMessage(
+				t("kilocode:ghost.statusBar.tooltip.noUsableProvider", { providers: providerList }),
+			)
+			return
+		}
+
+		const sessionStartTime = this.formatTime(this.props.sessionStartTime)
+		const now = this.formatTime(Date.now())
+
+		const message = [
+			t("kilocode:ghost.statusBar.tooltip.completionSummary", {
+				count: this.props.completionCount,
+				startTime: sessionStartTime,
+				endTime: now,
+				cost: this.humanFormatSessionCost(),
+			}),
+			this.props.model && this.props.provider
+				? t("kilocode:ghost.statusBar.tooltip.providerInfo", {
+						model: this.props.model,
+						provider: this.props.provider,
+					})
+				: undefined,
+		]
+			.filter(Boolean)
+			.join(" | ")
+
+		vscode.window.showInformationMessage(message)
+	}
+	// kilocode_change end
 
 	private humanFormatSessionCost(): string {
 		const cost = this.props.totalSessionCost

--- a/src/services/ghost/__tests__/GhostStatusBar.spec.ts
+++ b/src/services/ghost/__tests__/GhostStatusBar.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as vscode from "vscode"
+import { GhostStatusBar } from "../GhostStatusBar"
+import type { GhostStatusBarStateProps } from "../types"
+
+// Mock vscode
+vi.mock("vscode", () => ({
+	window: {
+		createStatusBarItem: vi.fn(() => ({
+			text: "",
+			tooltip: "",
+			command: undefined,
+			show: vi.fn(),
+			hide: vi.fn(),
+			dispose: vi.fn(),
+		})),
+		showInformationMessage: vi.fn(),
+		showWarningMessage: vi.fn(),
+	},
+	commands: {
+		registerCommand: vi.fn(() => ({
+			dispose: vi.fn(),
+		})),
+	},
+	StatusBarAlignment: {
+		Right: 1,
+	},
+	MarkdownString: vi.fn().mockImplementation((text: string) => ({
+		value: text,
+		isTrusted: false,
+	})),
+}))
+
+// Mock i18n
+vi.mock("../../../i18n", () => ({
+	t: vi.fn((key: string, params?: Record<string, unknown>) => {
+		if (params) {
+			return `${key}: ${JSON.stringify(params)}`
+		}
+		return key
+	}),
+}))
+
+// Mock PROVIDERS
+vi.mock("../../../../webview-ui/src/components/settings/constants", () => ({
+	PROVIDERS: [
+		{ value: "openai", label: "OpenAI" },
+		{ value: "anthropic", label: "Anthropic" },
+	],
+}))
+
+describe("GhostStatusBar", () => {
+	let statusBar: GhostStatusBar
+	let defaultProps: GhostStatusBarStateProps
+	let registeredCommandCallback: () => void
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		// Capture the command callback when registerCommand is called
+		vi.mocked(vscode.commands.registerCommand).mockImplementation((commandId, callback) => {
+			registeredCommandCallback = callback as () => void
+			return { dispose: vi.fn() }
+		})
+
+		defaultProps = {
+			enabled: true,
+			completionCount: 5,
+			totalSessionCost: 0.05,
+			sessionStartTime: Date.now() - 3600000, // 1 hour ago
+			snoozed: false,
+			model: "gpt-4",
+			provider: "openai",
+			hasKilocodeProfileWithNoBalance: false,
+			hasNoUsableProvider: false,
+		}
+
+		statusBar = new GhostStatusBar(defaultProps)
+	})
+
+	afterEach(() => {
+		statusBar.dispose()
+	})
+
+	describe("initialization", () => {
+		it("should create a status bar item", () => {
+			expect(vscode.window.createStatusBarItem).toHaveBeenCalledWith(vscode.StatusBarAlignment.Right, 100)
+		})
+
+		it("should register a command for click handling", () => {
+			expect(vscode.commands.registerCommand).toHaveBeenCalledWith(
+				"kilocode.ghost.showStatus",
+				expect.any(Function),
+			)
+		})
+
+		it("should set the command on the status bar item", () => {
+			expect(statusBar.statusBar.command).toBe("kilocode.ghost.showStatus")
+		})
+
+		it("should show the status bar", () => {
+			expect(statusBar.statusBar.show).toHaveBeenCalled()
+		})
+	})
+
+	describe("click behavior", () => {
+		it("should show information message with completion summary when clicked", () => {
+			statusBar.update(defaultProps)
+			registeredCommandCallback()
+
+			expect(vscode.window.showInformationMessage).toHaveBeenCalled()
+		})
+
+		it("should show warning message when no credits", () => {
+			statusBar.update({ ...defaultProps, hasKilocodeProfileWithNoBalance: true })
+			registeredCommandCallback()
+
+			expect(vscode.window.showWarningMessage).toHaveBeenCalledWith("kilocode:ghost.statusBar.tooltip.noCredits")
+		})
+
+		it("should show warning message when no usable provider", () => {
+			statusBar.update({ ...defaultProps, hasNoUsableProvider: true })
+			registeredCommandCallback()
+
+			expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("kilocode:ghost.statusBar.tooltip.noUsableProvider"),
+			)
+		})
+	})
+
+	describe("dispose", () => {
+		it("should dispose the command registration", () => {
+			const commandDisposable = { dispose: vi.fn() }
+			vi.mocked(vscode.commands.registerCommand).mockReturnValue(commandDisposable)
+
+			const newStatusBar = new GhostStatusBar(defaultProps)
+			newStatusBar.dispose()
+
+			expect(commandDisposable.dispose).toHaveBeenCalled()
+		})
+
+		it("should dispose the status bar item", () => {
+			statusBar.dispose()
+			expect(statusBar.statusBar.dispose).toHaveBeenCalled()
+		})
+	})
+})

--- a/src/services/ghost/__tests__/GhostStatusBar.spec.ts
+++ b/src/services/ghost/__tests__/GhostStatusBar.spec.ts
@@ -104,26 +104,30 @@ describe("GhostStatusBar", () => {
 	})
 
 	describe("click behavior", () => {
-		it("should show information message with completion summary when clicked", () => {
+		it("should show modal information dialog with completion summary when clicked", () => {
 			statusBar.update(defaultProps)
 			registeredCommandCallback()
 
-			expect(vscode.window.showInformationMessage).toHaveBeenCalled()
+			expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(expect.any(String), { modal: true })
 		})
 
-		it("should show warning message when no credits", () => {
+		it("should show modal warning dialog when no credits", () => {
 			statusBar.update({ ...defaultProps, hasKilocodeProfileWithNoBalance: true })
 			registeredCommandCallback()
 
-			expect(vscode.window.showWarningMessage).toHaveBeenCalledWith("kilocode:ghost.statusBar.tooltip.noCredits")
+			expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+				"kilocode:ghost.statusBar.tooltip.noCredits",
+				{ modal: true },
+			)
 		})
 
-		it("should show warning message when no usable provider", () => {
+		it("should show modal warning dialog when no usable provider", () => {
 			statusBar.update({ ...defaultProps, hasNoUsableProvider: true })
 			registeredCommandCallback()
 
 			expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
 				expect.stringContaining("kilocode:ghost.statusBar.tooltip.noUsableProvider"),
+				{ modal: true },
 			)
 		})
 	})


### PR DESCRIPTION
## Summary
Adds click-to-show functionality for the Ghost status bar tooltip. Now when you click on the status bar item, it immediately shows the tooltip information as a VSCode notification message, without having to wait for the hover timeout.

## Changes
- Register command `kilocode.ghost.showStatus` to show status on click
- Display same information as tooltip via VSCode notification
- Show warning messages for error states (no credits, no provider)
- Add comprehensive tests for click behavior
- Properly dispose command registration on cleanup

## Testing
- All 9 new tests pass
- Type checking passes
- Linting passes