### PR TITLE
feat: add /condense and /compact slash command aliases

### DIFF
--- a/.changeset/sharp-pears-invent.md
+++ b/.changeset/sharp-pears-invent.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+add /condense and /compact commands

--- a/src/core/slash-commands/__tests__/kilo.spec.ts
+++ b/src/core/slash-commands/__tests__/kilo.spec.ts
@@ -110,6 +110,35 @@ describe("parseKiloSlashCommands", () => {
 				expect(result.needsRulesFileCheck).toBe(false)
 			})
 		})
+
+		describe("/condense command", () => {
+			it("should process /condense command", async () => {
+				const text = "<task>/condense</task>"
+				const result = await parseKiloSlashCommands(text, emptyToggles, emptyToggles)
+
+				expect(result.processedText).toContain('<explicit_instructions type="condense">')
+				expect(result.needsRulesFileCheck).toBe(false)
+			})
+
+			it("should process /condense with additional instructions", async () => {
+				const text = "<user_message>/condense Focus on the API changes</user_message>"
+				const result = await parseKiloSlashCommands(text, emptyToggles, emptyToggles)
+
+				expect(result.processedText).toContain('<explicit_instructions type="condense">')
+				expect(result.processedText).toContain("Focus on the API changes")
+				expect(result.needsRulesFileCheck).toBe(false)
+			})
+		})
+
+		describe("/compact command", () => {
+			it("should process /compact command", async () => {
+				const text = "<task>/compact</task>"
+				const result = await parseKiloSlashCommands(text, emptyToggles, emptyToggles)
+
+				expect(result.processedText).toContain('<explicit_instructions type="condense">')
+				expect(result.needsRulesFileCheck).toBe(false)
+			})
+		})
 	})
 
 	describe("tag patterns", () => {

--- a/src/core/slash-commands/kilo.ts
+++ b/src/core/slash-commands/kilo.ts
@@ -28,11 +28,19 @@ export async function parseKiloSlashCommands(
 	localWorkflowToggles: ClineRulesToggles,
 	globalWorkflowToggles: ClineRulesToggles,
 ): Promise<{ processedText: string; needsRulesFileCheck: boolean }> {
+	// kilocode_change start - /smol and /condense are aliases
+	const condenseAliases = condenseToolResponse
+	// kilocode_change end
+
 	const commandReplacements: Record<string, ((userInput: string) => string) | undefined> = {
 		newtask: newTaskToolResponse,
 		newrule: newRuleToolResponse,
 		reportbug: reportBugToolResponse,
-		smol: condenseToolResponse,
+		// kilocode_change start - /smol and /condense are aliases
+		smol: condenseAliases,
+		condense: condenseAliases,
+		compact: condenseAliases,
+		// kilocode_change end
 	}
 
 	// this currently allows matching prepended whitespace prior to /slash-command

--- a/src/core/slash-commands/kilo.ts
+++ b/src/core/slash-commands/kilo.ts
@@ -28,19 +28,15 @@ export async function parseKiloSlashCommands(
 	localWorkflowToggles: ClineRulesToggles,
 	globalWorkflowToggles: ClineRulesToggles,
 ): Promise<{ processedText: string; needsRulesFileCheck: boolean }> {
-	// kilocode_change start - /smol and /condense are aliases
 	const condenseAliases = condenseToolResponse
-	// kilocode_change end
 
 	const commandReplacements: Record<string, ((userInput: string) => string) | undefined> = {
 		newtask: newTaskToolResponse,
 		newrule: newRuleToolResponse,
 		reportbug: reportBugToolResponse,
-		// kilocode_change start - /smol and /condense are aliases
 		smol: condenseAliases,
 		condense: condenseAliases,
 		compact: condenseAliases,
-		// kilocode_change end
 	}
 
 	// this currently allows matching prepended whitespace prior to /slash-command

--- a/webview-ui/src/utils/__tests__/slash-commands.spec.ts
+++ b/webview-ui/src/utils/__tests__/slash-commands.spec.ts
@@ -30,6 +30,11 @@ describe("Slash Command Matching", () => {
 			const results = getMatchingSlashCommands("")
 			expect(results.length).toBeGreaterThan(0)
 		})
+
+		it("should include condense aliases in results", () => {
+			const results = getMatchingSlashCommands("cond")
+			expect(results.some((r) => r.name === "condense")).toBe(true)
+		})
 	})
 
 	describe("validateSlashCommand - case insensitivity", () => {
@@ -37,6 +42,12 @@ describe("Slash Command Matching", () => {
 			expect(validateSlashCommand("newtask")).toBe("full")
 			expect(validateSlashCommand("NEWTASK")).toBe("full")
 			expect(validateSlashCommand("NewTask")).toBe("full")
+		})
+
+		it("should validate condense aliases", () => {
+			expect(validateSlashCommand("smol")).toBe("full")
+			expect(validateSlashCommand("condense")).toBe("full")
+			expect(validateSlashCommand("compact")).toBe("full")
 		})
 
 		it("should validate partial matches regardless of case", () => {

--- a/webview-ui/src/utils/slash-commands.ts
+++ b/webview-ui/src/utils/slash-commands.ts
@@ -29,8 +29,12 @@ export function getSupportedSlashCommands(
 			description: "Create a new Kilo rule with context from your conversation",
 		},
 		{ name: "reportbug", description: "Create a KiloCode GitHub issue" },
+		// kilocode_change start
 		{ name: "smol", description: "Condenses your current context window" },
-		{ name: "session", description: "Session management <fork|share|show>" }, // kilocode_change
+		{ name: "condense", description: "Condenses your current context window" },
+		{ name: "compact", description: "Condenses your current context window" },
+		{ name: "session", description: "Session management <fork|share|show>" },
+		// kilocode_change end
 	]
 
 	// Add mode-switching commands dynamically


### PR DESCRIPTION
Adds `/condense` and `/compact` as aliases for the existing condense workflow prompt (also wired `/smol`).

Tests:
- `cd src && pnpm test core/slash-commands/__tests__/kilo.spec.ts`