### PR TITLE
feat(cli): improve file update display with compact format and colored diffs

### DIFF
--- a/.changeset/improve-file-update-display.md
+++ b/.changeset/improve-file-update-display.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Improved file update display in CLI with compact format and colored diffs

--- a/cli/src/ui/messages/extension/__tests__/diff.test.ts
+++ b/cli/src/ui/messages/extension/__tests__/diff.test.ts
@@ -1,0 +1,511 @@
+import { describe, it, expect } from "vitest"
+import {
+	parseDiffContent,
+	calculateDiffStats,
+	parseInsertContent,
+	isUnifiedDiffFormat,
+	parseNewFileContent,
+	formatDiffSummary,
+	type ParsedDiffLine,
+	type DiffStats,
+} from "../diff.js"
+
+describe("parseDiffContent", () => {
+	describe("unified diff format", () => {
+		it("should parse a simple unified diff", () => {
+			const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+ line 1
+-old line 2
++new line 2
+ line 3`
+
+			const result = parseDiffContent(diff)
+
+			expect(result).toHaveLength(7)
+			expect(result[0]).toEqual({ type: "header", content: "--- a/file.txt" })
+			expect(result[1]).toEqual({ type: "header", content: "+++ b/file.txt" })
+			expect(result[2]).toEqual({ type: "header", content: "@@ -1,3 +1,3 @@" })
+			expect(result[3]).toEqual({ type: "context", content: "line 1", oldLineNum: 1, newLineNum: 1 })
+			expect(result[4]).toEqual({ type: "deletion", content: "old line 2", oldLineNum: 2 })
+			expect(result[5]).toEqual({ type: "addition", content: "new line 2", newLineNum: 2 })
+			expect(result[6]).toEqual({ type: "context", content: "line 3", oldLineNum: 3, newLineNum: 3 })
+		})
+
+		it("should handle multiple hunks", () => {
+			const diff = `@@ -1,2 +1,2 @@
+-old1
++new1
+@@ -10,2 +10,2 @@
+-old10
++new10`
+
+			const result = parseDiffContent(diff)
+
+			// First hunk
+			expect(result[0]).toEqual({ type: "header", content: "@@ -1,2 +1,2 @@" })
+			expect(result[1]).toEqual({ type: "deletion", content: "old1", oldLineNum: 1 })
+			expect(result[2]).toEqual({ type: "addition", content: "new1", newLineNum: 1 })
+
+			// Second hunk
+			expect(result[3]).toEqual({ type: "header", content: "@@ -10,2 +10,2 @@" })
+			expect(result[4]).toEqual({ type: "deletion", content: "old10", oldLineNum: 10 })
+			expect(result[5]).toEqual({ type: "addition", content: "new10", newLineNum: 10 })
+		})
+
+		it("should return empty array for empty input", () => {
+			expect(parseDiffContent("")).toEqual([])
+		})
+	})
+
+	describe("SEARCH/REPLACE format", () => {
+		it("should parse a simple SEARCH/REPLACE block", () => {
+			const startLineMarker = ":start" + "_line:5"
+			const diff = `<<<<<<< SEARCH
+${startLineMarker}
+-------
+old content
+=======
+new content
+>>>>>>> REPLACE`
+
+			const result = parseDiffContent(diff)
+
+			expect(result).toHaveLength(7)
+			expect(result[0]).toEqual({ type: "marker", content: "<<<<<<< SEARCH" })
+			expect(result[1]).toEqual({ type: "marker", content: startLineMarker })
+			expect(result[2]).toEqual({ type: "marker", content: "-------" })
+			expect(result[3]).toEqual({ type: "deletion", content: "old content", oldLineNum: 5 })
+			expect(result[4]).toEqual({ type: "marker", content: "=======" })
+			expect(result[5]).toEqual({ type: "addition", content: "new content", newLineNum: 5 })
+			expect(result[6]).toEqual({ type: "marker", content: ">>>>>>> REPLACE" })
+		})
+
+		it("should handle multi-line SEARCH/REPLACE", () => {
+			const startLineMarker = ":start" + "_line:1"
+			const diff = `<<<<<<< SEARCH
+${startLineMarker}
+-------
+line 1
+line 2
+=======
+new line 1
+new line 2
+new line 3
+>>>>>>> REPLACE`
+
+			const result = parseDiffContent(diff)
+
+			// Count deletions and additions
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+
+			expect(deletions).toHaveLength(2)
+			expect(additions).toHaveLength(3)
+
+			// Check line numbers
+			expect(deletions[0].oldLineNum).toBe(1)
+			expect(deletions[1].oldLineNum).toBe(2)
+			expect(additions[0].newLineNum).toBe(1)
+			expect(additions[1].newLineNum).toBe(2)
+			expect(additions[2].newLineNum).toBe(3)
+		})
+
+		it("should handle SEARCH/REPLACE without start_line", () => {
+			const diff = `<<<<<<< SEARCH
+-------
+old
+=======
+new
+>>>>>>> REPLACE`
+
+			const result = parseDiffContent(diff)
+
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+
+			expect(deletions).toHaveLength(1)
+			expect(additions).toHaveLength(1)
+			expect(deletions[0].oldLineNum).toBe(1) // Default to line 1
+			expect(additions[0].newLineNum).toBe(1)
+		})
+	})
+
+	describe("edge cases", () => {
+		it("should handle hunk header without count (e.g., @@ -5 +5 @@)", () => {
+			const diff = `@@ -5 +5 @@
+-old line
++new line`
+
+			const result = parseDiffContent(diff)
+
+			expect(result[0]).toEqual({ type: "header", content: "@@ -5 +5 @@" })
+			expect(result[1]).toEqual({ type: "deletion", content: "old line", oldLineNum: 5 })
+			expect(result[2]).toEqual({ type: "addition", content: "new line", newLineNum: 5 })
+		})
+
+		it("should handle lines without standard prefix as context", () => {
+			const diff = `@@ -1,2 +1,2 @@
+no prefix line
+-deleted
++added`
+
+			const result = parseDiffContent(diff)
+
+			// Line without prefix should be treated as context
+			expect(result[1]).toEqual({ type: "context", content: "no prefix line" })
+			expect(result[2]).toEqual({ type: "deletion", content: "deleted", oldLineNum: 1 })
+			expect(result[3]).toEqual({ type: "addition", content: "added", newLineNum: 1 })
+		})
+
+		it("should handle consecutive deletions followed by consecutive additions", () => {
+			const diff = `@@ -1,4 +1,4 @@
+-old1
+-old2
+-old3
++new1
++new2
++new3`
+
+			const result = parseDiffContent(diff)
+
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+
+			expect(deletions).toHaveLength(3)
+			expect(additions).toHaveLength(3)
+			expect(deletions[0].oldLineNum).toBe(1)
+			expect(deletions[1].oldLineNum).toBe(2)
+			expect(deletions[2].oldLineNum).toBe(3)
+			expect(additions[0].newLineNum).toBe(1)
+			expect(additions[1].newLineNum).toBe(2)
+			expect(additions[2].newLineNum).toBe(3)
+		})
+
+		it("should handle empty SEARCH block (addition only)", () => {
+			const startLineMarker = ":start" + "_line:10"
+			const diff = `<<<<<<< SEARCH
+${startLineMarker}
+-------
+=======
+new content line 1
+new content line 2
+>>>>>>> REPLACE`
+
+			const result = parseDiffContent(diff)
+
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+
+			expect(deletions).toHaveLength(0)
+			expect(additions).toHaveLength(2)
+			expect(additions[0].newLineNum).toBe(10)
+			expect(additions[1].newLineNum).toBe(11)
+		})
+
+		it("should handle empty REPLACE block (deletion only)", () => {
+			const startLineMarker = ":start" + "_line:5"
+			const diff = `<<<<<<< SEARCH
+${startLineMarker}
+-------
+line to delete 1
+line to delete 2
+=======
+>>>>>>> REPLACE`
+
+			const result = parseDiffContent(diff)
+
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+
+			expect(deletions).toHaveLength(2)
+			expect(additions).toHaveLength(0)
+			expect(deletions[0].oldLineNum).toBe(5)
+			expect(deletions[1].oldLineNum).toBe(6)
+		})
+
+		it("should handle content before SEARCH/REPLACE blocks as context", () => {
+			const startLineMarker = ":start" + "_line:1"
+			const diff = `Some preamble text
+<<<<<<< SEARCH
+${startLineMarker}
+-------
+old
+=======
+new
+>>>>>>> REPLACE
+Some trailing text`
+
+			const result = parseDiffContent(diff)
+
+			// First line should be context
+			expect(result[0]).toEqual({ type: "context", content: "Some preamble text" })
+			// Last line should be context
+			expect(result[result.length - 1]).toEqual({ type: "context", content: "Some trailing text" })
+		})
+
+		it("should handle malformed start_line directive gracefully", () => {
+			const startLineMarker = ":start" + "_line:abc"
+			const diff = `<<<<<<< SEARCH
+${startLineMarker}
+-------
+old content
+=======
+new content
+>>>>>>> REPLACE`
+
+			const result = parseDiffContent(diff)
+
+			// Should still parse, defaulting to line 1 when parsing fails
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+
+			expect(deletions).toHaveLength(1)
+			expect(additions).toHaveLength(1)
+			// NaN from parseInt should result in default behavior
+			expect(deletions[0].oldLineNum).toBe(1)
+		})
+	})
+})
+
+describe("calculateDiffStats", () => {
+	it("should count additions and deletions", () => {
+		const lines: ParsedDiffLine[] = [
+			{ type: "header", content: "@@ -1,3 +1,4 @@" },
+			{ type: "context", content: "unchanged" },
+			{ type: "deletion", content: "removed 1" },
+			{ type: "deletion", content: "removed 2" },
+			{ type: "addition", content: "added 1" },
+			{ type: "addition", content: "added 2" },
+			{ type: "addition", content: "added 3" },
+		]
+
+		const stats = calculateDiffStats(lines)
+
+		expect(stats.added).toBe(3)
+		expect(stats.removed).toBe(2)
+	})
+
+	it("should return zeros for empty input", () => {
+		const stats = calculateDiffStats([])
+
+		expect(stats.added).toBe(0)
+		expect(stats.removed).toBe(0)
+	})
+
+	it("should handle only additions", () => {
+		const lines: ParsedDiffLine[] = [
+			{ type: "addition", content: "new 1" },
+			{ type: "addition", content: "new 2" },
+		]
+
+		const stats = calculateDiffStats(lines)
+
+		expect(stats.added).toBe(2)
+		expect(stats.removed).toBe(0)
+	})
+
+	it("should handle only deletions", () => {
+		const lines: ParsedDiffLine[] = [
+			{ type: "deletion", content: "old 1" },
+			{ type: "deletion", content: "old 2" },
+		]
+
+		const stats = calculateDiffStats(lines)
+
+		expect(stats.added).toBe(0)
+		expect(stats.removed).toBe(2)
+	})
+
+	it("should ignore markers and headers", () => {
+		const lines: ParsedDiffLine[] = [
+			{ type: "marker", content: "<<<<<<< SEARCH" },
+			{ type: "header", content: "@@ -1,1 +1,1 @@" },
+			{ type: "context", content: "unchanged" },
+		]
+
+		const stats = calculateDiffStats(lines)
+
+		expect(stats.added).toBe(0)
+		expect(stats.removed).toBe(0)
+	})
+})
+
+describe("formatDiffSummary", () => {
+	describe("full format (default)", () => {
+		it("should format additions and removals", () => {
+			const stats: DiffStats = { added: 5, removed: 3 }
+			expect(formatDiffSummary(stats)).toBe("⎿ +5, -3")
+		})
+
+		it("should format additions only", () => {
+			const stats: DiffStats = { added: 5, removed: 0 }
+			expect(formatDiffSummary(stats)).toBe("⎿ +5")
+		})
+
+		it("should format removals only", () => {
+			const stats: DiffStats = { added: 0, removed: 3 }
+			expect(formatDiffSummary(stats)).toBe("⎿ -3")
+		})
+
+		it("should return empty string for no changes", () => {
+			const stats: DiffStats = { added: 0, removed: 0 }
+			expect(formatDiffSummary(stats)).toBe("")
+		})
+	})
+
+	describe("additions-only format", () => {
+		it("should format additions with 'lines' suffix", () => {
+			const stats: DiffStats = { added: 5, removed: 0 }
+			expect(formatDiffSummary(stats, "additions-only")).toBe("⎿ +5 lines")
+		})
+
+		it("should ignore removals in additions-only format", () => {
+			const stats: DiffStats = { added: 5, removed: 3 }
+			expect(formatDiffSummary(stats, "additions-only")).toBe("⎿ +5 lines")
+		})
+
+		it("should return empty string for no additions", () => {
+			const stats: DiffStats = { added: 0, removed: 3 }
+			expect(formatDiffSummary(stats, "additions-only")).toBe("")
+		})
+	})
+})
+
+describe("parseInsertContent", () => {
+	it("should parse raw content as additions starting at specified line", () => {
+		const content = `line 1
+line 2
+line 3`
+
+		const result = parseInsertContent(content, 10)
+
+		expect(result).toHaveLength(3)
+		expect(result[0]).toEqual({ type: "addition", content: "line 1", newLineNum: 10 })
+		expect(result[1]).toEqual({ type: "addition", content: "line 2", newLineNum: 11 })
+		expect(result[2]).toEqual({ type: "addition", content: "line 3", newLineNum: 12 })
+	})
+
+	it("should default to line 1 when no start line specified", () => {
+		const content = "single line"
+
+		const result = parseInsertContent(content)
+
+		expect(result).toHaveLength(1)
+		expect(result[0]).toEqual({ type: "addition", content: "single line", newLineNum: 1 })
+	})
+
+	it("should return empty array for empty content", () => {
+		expect(parseInsertContent("")).toEqual([])
+	})
+
+	it("should handle content with empty lines", () => {
+		const content = `first
+
+third`
+
+		const result = parseInsertContent(content, 5)
+
+		expect(result).toHaveLength(3)
+		expect(result[0]).toEqual({ type: "addition", content: "first", newLineNum: 5 })
+		expect(result[1]).toEqual({ type: "addition", content: "", newLineNum: 6 })
+		expect(result[2]).toEqual({ type: "addition", content: "third", newLineNum: 7 })
+	})
+
+	it("should handle single line content", () => {
+		const result = parseInsertContent("only one line", 42)
+
+		expect(result).toHaveLength(1)
+		expect(result[0]).toEqual({ type: "addition", content: "only one line", newLineNum: 42 })
+	})
+
+	it("should handle line number 0 (end of file indicator)", () => {
+		const result = parseInsertContent("appended line", 0)
+
+		expect(result).toHaveLength(1)
+		// Line 0 should be treated as-is (caller handles "end" display)
+		expect(result[0]).toEqual({ type: "addition", content: "appended line", newLineNum: 0 })
+	})
+})
+
+describe("isUnifiedDiffFormat", () => {
+	it("should return true for content with hunk headers (@@)", () => {
+		expect(isUnifiedDiffFormat("@@ -1,3 +1,3 @@\n-old\n+new")).toBe(true)
+		expect(isUnifiedDiffFormat("some text\n@@ -5 +5 @@")).toBe(true)
+	})
+
+	it("should return true for content starting with file header (---)", () => {
+		expect(isUnifiedDiffFormat("--- a/file.txt\n+++ b/file.txt")).toBe(true)
+	})
+
+	it("should return false for raw content without diff markers", () => {
+		expect(isUnifiedDiffFormat("just some text")).toBe(false)
+		expect(isUnifiedDiffFormat("line 1\nline 2\nline 3")).toBe(false)
+	})
+
+	it("should return false for SEARCH/REPLACE format", () => {
+		expect(isUnifiedDiffFormat("<<<<<<< SEARCH\nold\n=======\nnew\n>>>>>>> REPLACE")).toBe(false)
+	})
+
+	it("should return false for empty string", () => {
+		expect(isUnifiedDiffFormat("")).toBe(false)
+	})
+
+	it("should handle --- in middle of content (not at start)", () => {
+		// --- must be at start to be considered a file header
+		expect(isUnifiedDiffFormat("some text\n--- not a header")).toBe(false)
+	})
+})
+
+describe("parseNewFileContent", () => {
+	it("should parse unified diff format when detected", () => {
+		const diff = `--- a/file.txt
++++ b/file.txt
+@@ -0,0 +1,2 @@
++line 1
++line 2`
+
+		const result = parseNewFileContent(diff)
+
+		// Should use parseDiffContent for unified diff
+		expect(result.some((l) => l.type === "header")).toBe(true)
+		const additions = result.filter((l) => l.type === "addition")
+		expect(additions).toHaveLength(2)
+	})
+
+	it("should parse raw content as additions when not unified diff", () => {
+		const content = `line 1
+line 2
+line 3`
+
+		const result = parseNewFileContent(content)
+
+		expect(result).toHaveLength(3)
+		expect(result[0]).toEqual({ type: "addition", content: "line 1", newLineNum: 1 })
+		expect(result[1]).toEqual({ type: "addition", content: "line 2", newLineNum: 2 })
+		expect(result[2]).toEqual({ type: "addition", content: "line 3", newLineNum: 3 })
+	})
+
+	it("should return empty array for empty content", () => {
+		expect(parseNewFileContent("")).toEqual([])
+	})
+
+	it("should start line numbers at 1 for raw content", () => {
+		const result = parseNewFileContent("single line")
+
+		expect(result).toHaveLength(1)
+		expect(result[0].newLineNum).toBe(1)
+	})
+
+	it("should handle content with @@ in middle (not a hunk header)", () => {
+		// @@ anywhere in content triggers unified diff detection
+		const content = "email@@domain.com"
+
+		const result = parseNewFileContent(content)
+
+		// This will be detected as unified diff format due to @@
+		// but parseDiffContent will handle it gracefully
+		expect(result.length).toBeGreaterThan(0)
+	})
+})

--- a/cli/src/ui/messages/extension/diff.ts
+++ b/cli/src/ui/messages/extension/diff.ts
@@ -1,0 +1,222 @@
+/**
+ * Diff parsing and formatting utilities for CLI tool messages
+ *
+ * Supports two diff formats:
+ * 1. Unified diff format (standard git diff with @@ hunk headers)
+ * 2. SEARCH/REPLACE format (used by apply_diff tool)
+ */
+
+/**
+ * Parsed diff line with type and content
+ */
+export interface ParsedDiffLine {
+	type: "addition" | "deletion" | "context" | "header" | "marker"
+	content: string
+	oldLineNum?: number
+	newLineNum?: number
+}
+
+/**
+ * Diff stats interface
+ */
+export interface DiffStats {
+	added: number
+	removed: number
+}
+
+/**
+ * Check if content is in unified diff format
+ * Detects hunk headers (@@) or file headers (---)
+ */
+export function isUnifiedDiffFormat(content: string): boolean {
+	return content.includes("@@") || content.startsWith("---")
+}
+
+/**
+ * Parse diff content (supports both unified diff and SEARCH/REPLACE format)
+ * Returns an array of parsed lines with type information for coloring
+ */
+export function parseDiffContent(diffContent: string): ParsedDiffLine[] {
+	if (!diffContent) return []
+
+	const lines = diffContent.split("\n")
+	const result: ParsedDiffLine[] = []
+
+	// Detect format: SEARCH/REPLACE uses <<<<<<< SEARCH markers
+	const isSearchReplace = diffContent.includes("<<<<<<< SEARCH")
+
+	if (isSearchReplace) {
+		// Parse SEARCH/REPLACE format
+		let inSearch = false
+		let inReplace = false
+		let oldLineNum = 1
+		let newLineNum = 1
+
+		for (const line of lines) {
+			if (line.startsWith("<<<<<<< SEARCH")) {
+				result.push({ type: "marker", content: line })
+				inSearch = true
+				inReplace = false
+			} else if (line.startsWith(":start_line:")) {
+				// Extract starting line number
+				const match = line.match(/:start_line:(\d+)/)
+				if (match && match[1]) {
+					oldLineNum = parseInt(match[1], 10)
+					newLineNum = oldLineNum
+				}
+				result.push({ type: "marker", content: line })
+			} else if (line === "-------") {
+				result.push({ type: "marker", content: line })
+			} else if (line === "=======") {
+				result.push({ type: "marker", content: line })
+				inSearch = false
+				inReplace = true
+			} else if (line.startsWith(">>>>>>> REPLACE")) {
+				result.push({ type: "marker", content: line })
+				inSearch = false
+				inReplace = false
+			} else if (inSearch) {
+				result.push({
+					type: "deletion",
+					content: line,
+					oldLineNum: oldLineNum++,
+				})
+			} else if (inReplace) {
+				result.push({
+					type: "addition",
+					content: line,
+					newLineNum: newLineNum++,
+				})
+			} else {
+				result.push({ type: "context", content: line })
+			}
+		}
+	} else {
+		// Parse unified diff format
+		let oldLineNum = 1
+		let newLineNum = 1
+
+		for (const line of lines) {
+			if (line.startsWith("@@")) {
+				// Parse hunk header: @@ -oldStart,oldCount +newStart,newCount @@
+				const match = line.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+				if (match && match[1] && match[2]) {
+					oldLineNum = parseInt(match[1], 10)
+					newLineNum = parseInt(match[2], 10)
+				}
+				result.push({ type: "header", content: line })
+			} else if (line.startsWith("---") || line.startsWith("+++")) {
+				result.push({ type: "header", content: line })
+			} else if (line.startsWith("+")) {
+				result.push({
+					type: "addition",
+					content: line.slice(1),
+					newLineNum: newLineNum++,
+				})
+			} else if (line.startsWith("-")) {
+				result.push({
+					type: "deletion",
+					content: line.slice(1),
+					oldLineNum: oldLineNum++,
+				})
+			} else if (line.startsWith(" ")) {
+				result.push({
+					type: "context",
+					content: line.slice(1),
+					oldLineNum: oldLineNum++,
+					newLineNum: newLineNum++,
+				})
+			} else {
+				// Lines without prefix (could be context or other)
+				result.push({ type: "context", content: line })
+			}
+		}
+	}
+
+	return result
+}
+
+/**
+ * Calculate diff stats from parsed diff lines
+ */
+export function calculateDiffStats(lines: ParsedDiffLine[]): DiffStats {
+	let added = 0
+	let removed = 0
+
+	for (const line of lines) {
+		if (line.type === "addition") added++
+		if (line.type === "deletion") removed++
+	}
+
+	return { added, removed }
+}
+
+/**
+ * Format diff stats as a summary string for display
+ *
+ * Two formats supported:
+ * - "additions-only": For new files/inserts, shows "⎿ +X lines"
+ * - "full": For edits, shows "⎿ +X, -Y" (only non-zero values)
+ *
+ * @param stats - The diff stats to format
+ * @param format - The format style: "additions-only" or "full" (default: "full")
+ * @returns Formatted summary string, or empty string if no changes
+ */
+export function formatDiffSummary(stats: DiffStats, format: "additions-only" | "full" = "full"): string {
+	if (format === "additions-only") {
+		if (stats.added > 0) {
+			return `⎿ +${stats.added} lines`
+		}
+		return ""
+	}
+
+	// Full format: show both additions and removals
+	const parts: string[] = []
+	if (stats.added > 0) {
+		parts.push(`+${stats.added}`)
+	}
+	if (stats.removed > 0) {
+		parts.push(`-${stats.removed}`)
+	}
+	return parts.length > 0 ? `⎿ ${parts.join(", ")}` : ""
+}
+
+/**
+ * Parse raw content as insertion lines (all additions)
+ * Used for insert_content tool where all lines are new additions
+ *
+ * @param content - The raw content to parse
+ * @param startLine - The starting line number (defaults to 1)
+ * @returns Array of parsed diff lines, all marked as additions
+ */
+export function parseInsertContent(content: string, startLine: number = 1): ParsedDiffLine[] {
+	if (!content) return []
+
+	const lines = content.split("\n")
+	return lines.map(
+		(lineContent, index): ParsedDiffLine => ({
+			type: "addition",
+			content: lineContent,
+			newLineNum: startLine + index,
+		}),
+	)
+}
+
+/**
+ * Parse new file content - handles both unified diff and raw content
+ * Used for new file creation where all content is additions
+ *
+ * @param content - The content to parse (unified diff or raw)
+ * @returns Array of parsed diff lines
+ */
+export function parseNewFileContent(content: string): ParsedDiffLine[] {
+	if (!content) return []
+
+	// Check if it's a unified diff format
+	if (isUnifiedDiffFormat(content)) {
+		return parseDiffContent(content)
+	}
+
+	// Otherwise, treat as raw file content - all lines are additions starting at line 1
+	return parseInsertContent(content, 1)
+}

--- a/cli/src/ui/messages/extension/diff.ts
+++ b/cli/src/ui/messages/extension/diff.ts
@@ -1,14 +1,8 @@
 /**
- * Diff parsing and formatting utilities for CLI tool messages
- *
- * Supports two diff formats:
- * 1. Unified diff format (standard git diff with @@ hunk headers)
- * 2. SEARCH/REPLACE format (used by apply_diff tool)
+ * Diff parsing and formatting utilities for CLI tool messages.
+ * Supports unified diff format (@@ hunk headers) and SEARCH/REPLACE format.
  */
 
-/**
- * Parsed diff line with type and content
- */
 export interface ParsedDiffLine {
 	type: "addition" | "deletion" | "context" | "header" | "marker"
 	content: string
@@ -16,129 +10,94 @@ export interface ParsedDiffLine {
 	newLineNum?: number
 }
 
-/**
- * Diff stats interface
- */
 export interface DiffStats {
 	added: number
 	removed: number
 }
 
-/**
- * Check if content is in unified diff format
- * Detects hunk headers (@@) or file headers (---)
- */
 export function isUnifiedDiffFormat(content: string): boolean {
 	return content.includes("@@") || content.startsWith("---")
 }
 
-/**
- * Parse diff content (supports both unified diff and SEARCH/REPLACE format)
- * Returns an array of parsed lines with type information for coloring
- */
-export function parseDiffContent(diffContent: string): ParsedDiffLine[] {
-	if (!diffContent) return []
-
-	const lines = diffContent.split("\n")
+function parseSearchReplaceFormat(lines: string[]): ParsedDiffLine[] {
 	const result: ParsedDiffLine[] = []
+	let inSearch = false
+	let inReplace = false
+	let oldLineNum = 1
+	let newLineNum = 1
 
-	// Detect format: SEARCH/REPLACE uses <<<<<<< SEARCH markers
-	const isSearchReplace = diffContent.includes("<<<<<<< SEARCH")
-
-	if (isSearchReplace) {
-		// Parse SEARCH/REPLACE format
-		let inSearch = false
-		let inReplace = false
-		let oldLineNum = 1
-		let newLineNum = 1
-
-		for (const line of lines) {
-			if (line.startsWith("<<<<<<< SEARCH")) {
-				result.push({ type: "marker", content: line })
-				inSearch = true
-				inReplace = false
-			} else if (line.startsWith(":start_line:")) {
-				// Extract starting line number
-				const match = line.match(/:start_line:(\d+)/)
-				if (match && match[1]) {
-					oldLineNum = parseInt(match[1], 10)
-					newLineNum = oldLineNum
-				}
-				result.push({ type: "marker", content: line })
-			} else if (line === "-------") {
-				result.push({ type: "marker", content: line })
-			} else if (line === "=======") {
-				result.push({ type: "marker", content: line })
-				inSearch = false
-				inReplace = true
-			} else if (line.startsWith(">>>>>>> REPLACE")) {
-				result.push({ type: "marker", content: line })
-				inSearch = false
-				inReplace = false
-			} else if (inSearch) {
-				result.push({
-					type: "deletion",
-					content: line,
-					oldLineNum: oldLineNum++,
-				})
-			} else if (inReplace) {
-				result.push({
-					type: "addition",
-					content: line,
-					newLineNum: newLineNum++,
-				})
-			} else {
-				result.push({ type: "context", content: line })
+	for (const line of lines) {
+		if (line.startsWith("<<<<<<< SEARCH")) {
+			result.push({ type: "marker", content: line })
+			inSearch = true
+			inReplace = false
+		} else if (line.startsWith(":start_line:")) {
+			const match = line.match(/:start_line:(\d+)/)
+			if (match && match[1]) {
+				oldLineNum = parseInt(match[1], 10)
+				newLineNum = oldLineNum
 			}
-		}
-	} else {
-		// Parse unified diff format
-		let oldLineNum = 1
-		let newLineNum = 1
-
-		for (const line of lines) {
-			if (line.startsWith("@@")) {
-				// Parse hunk header: @@ -oldStart,oldCount +newStart,newCount @@
-				const match = line.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
-				if (match && match[1] && match[2]) {
-					oldLineNum = parseInt(match[1], 10)
-					newLineNum = parseInt(match[2], 10)
-				}
-				result.push({ type: "header", content: line })
-			} else if (line.startsWith("---") || line.startsWith("+++")) {
-				result.push({ type: "header", content: line })
-			} else if (line.startsWith("+")) {
-				result.push({
-					type: "addition",
-					content: line.slice(1),
-					newLineNum: newLineNum++,
-				})
-			} else if (line.startsWith("-")) {
-				result.push({
-					type: "deletion",
-					content: line.slice(1),
-					oldLineNum: oldLineNum++,
-				})
-			} else if (line.startsWith(" ")) {
-				result.push({
-					type: "context",
-					content: line.slice(1),
-					oldLineNum: oldLineNum++,
-					newLineNum: newLineNum++,
-				})
-			} else {
-				// Lines without prefix (could be context or other)
-				result.push({ type: "context", content: line })
-			}
+			result.push({ type: "marker", content: line })
+		} else if (line === "-------") {
+			result.push({ type: "marker", content: line })
+		} else if (line === "=======") {
+			result.push({ type: "marker", content: line })
+			inSearch = false
+			inReplace = true
+		} else if (line.startsWith(">>>>>>> REPLACE")) {
+			result.push({ type: "marker", content: line })
+			inSearch = false
+			inReplace = false
+		} else if (inSearch) {
+			result.push({ type: "deletion", content: line, oldLineNum: oldLineNum++ })
+		} else if (inReplace) {
+			result.push({ type: "addition", content: line, newLineNum: newLineNum++ })
+		} else {
+			result.push({ type: "context", content: line })
 		}
 	}
 
 	return result
 }
 
-/**
- * Calculate diff stats from parsed diff lines
- */
+function parseUnifiedDiffFormat(lines: string[]): ParsedDiffLine[] {
+	const result: ParsedDiffLine[] = []
+	let oldLineNum = 1
+	let newLineNum = 1
+
+	for (const line of lines) {
+		if (line.startsWith("@@")) {
+			const match = line.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+			if (match && match[1] && match[2]) {
+				oldLineNum = parseInt(match[1], 10)
+				newLineNum = parseInt(match[2], 10)
+			}
+			result.push({ type: "header", content: line })
+		} else if (line.startsWith("---") || line.startsWith("+++")) {
+			result.push({ type: "header", content: line })
+		} else if (line.startsWith("+")) {
+			result.push({ type: "addition", content: line.slice(1), newLineNum: newLineNum++ })
+		} else if (line.startsWith("-")) {
+			result.push({ type: "deletion", content: line.slice(1), oldLineNum: oldLineNum++ })
+		} else if (line.startsWith(" ")) {
+			result.push({ type: "context", content: line.slice(1), oldLineNum: oldLineNum++, newLineNum: newLineNum++ })
+		} else {
+			result.push({ type: "context", content: line })
+		}
+	}
+
+	return result
+}
+
+export function parseDiffContent(diffContent: string): ParsedDiffLine[] {
+	if (!diffContent) return []
+
+	const lines = diffContent.split("\n")
+	const isSearchReplace = diffContent.includes("<<<<<<< SEARCH")
+
+	return isSearchReplace ? parseSearchReplaceFormat(lines) : parseUnifiedDiffFormat(lines)
+}
+
 export function calculateDiffStats(lines: ParsedDiffLine[]): DiffStats {
 	let added = 0
 	let removed = 0
@@ -151,49 +110,21 @@ export function calculateDiffStats(lines: ParsedDiffLine[]): DiffStats {
 	return { added, removed }
 }
 
-/**
- * Format diff stats as a summary string for display
- *
- * Two formats supported:
- * - "additions-only": For new files/inserts, shows "⎿ +X lines"
- * - "full": For edits, shows "⎿ +X, -Y" (only non-zero values)
- *
- * @param stats - The diff stats to format
- * @param format - The format style: "additions-only" or "full" (default: "full")
- * @returns Formatted summary string, or empty string if no changes
- */
 export function formatDiffSummary(stats: DiffStats, format: "additions-only" | "full" = "full"): string {
 	if (format === "additions-only") {
-		if (stats.added > 0) {
-			return `⎿ +${stats.added} lines`
-		}
-		return ""
+		return stats.added > 0 ? `⎿ +${stats.added} lines` : ""
 	}
 
-	// Full format: show both additions and removals
 	const parts: string[] = []
-	if (stats.added > 0) {
-		parts.push(`+${stats.added}`)
-	}
-	if (stats.removed > 0) {
-		parts.push(`-${stats.removed}`)
-	}
+	if (stats.added > 0) parts.push(`+${stats.added}`)
+	if (stats.removed > 0) parts.push(`-${stats.removed}`)
 	return parts.length > 0 ? `⎿ ${parts.join(", ")}` : ""
 }
 
-/**
- * Parse raw content as insertion lines (all additions)
- * Used for insert_content tool where all lines are new additions
- *
- * @param content - The raw content to parse
- * @param startLine - The starting line number (defaults to 1)
- * @returns Array of parsed diff lines, all marked as additions
- */
 export function parseInsertContent(content: string, startLine: number = 1): ParsedDiffLine[] {
 	if (!content) return []
 
-	const lines = content.split("\n")
-	return lines.map(
+	return content.split("\n").map(
 		(lineContent, index): ParsedDiffLine => ({
 			type: "addition",
 			content: lineContent,
@@ -202,21 +133,12 @@ export function parseInsertContent(content: string, startLine: number = 1): Pars
 	)
 }
 
-/**
- * Parse new file content - handles both unified diff and raw content
- * Used for new file creation where all content is additions
- *
- * @param content - The content to parse (unified diff or raw)
- * @returns Array of parsed diff lines
- */
 export function parseNewFileContent(content: string): ParsedDiffLine[] {
 	if (!content) return []
 
-	// Check if it's a unified diff format
 	if (isUnifiedDiffFormat(content)) {
 		return parseDiffContent(content)
 	}
 
-	// Otherwise, treat as raw file content - all lines are additions starting at line 1
 	return parseInsertContent(content, 1)
 }

--- a/cli/src/ui/messages/extension/tools/DiffLine.tsx
+++ b/cli/src/ui/messages/extension/tools/DiffLine.tsx
@@ -1,0 +1,52 @@
+import React from "react"
+import { Box, Text } from "ink"
+import type { ParsedDiffLine } from "../diff.js"
+import type { useTheme } from "../../../../state/hooks/useTheme.js"
+
+/**
+ * Render a single diff line with appropriate coloring
+ */
+export const DiffLine: React.FC<{
+	line: ParsedDiffLine
+	theme: ReturnType<typeof useTheme>
+	showLineNumbers?: boolean
+}> = ({ line, theme, showLineNumbers = true }) => {
+	// Determine color based on line type
+	const color =
+		line.type === "addition"
+			? theme.code.addition
+			: line.type === "deletion"
+				? theme.code.deletion
+				: line.type === "header" || line.type === "marker"
+					? theme.semantic.info
+					: theme.code.context
+
+	// Format line number display
+	const oldNum = line.oldLineNum?.toString().padStart(4, " ") ?? "    "
+	const newNum = line.newLineNum?.toString().padStart(4, " ") ?? "    "
+
+	// Determine sign prefix
+	const sign = line.type === "addition" ? "+" : line.type === "deletion" ? "-" : " "
+
+	// Skip line numbers for markers and headers
+	if (line.type === "marker" || line.type === "header") {
+		return (
+			<Text color={color} dimColor>
+				{line.content}
+			</Text>
+		)
+	}
+
+	return (
+		<Box>
+			{showLineNumbers && (
+				<Text color={theme.ui.text.dimmed} dimColor>
+					{oldNum} {newNum}{" "}
+				</Text>
+			)}
+			<Text color={color}>
+				{sign} {line.content}
+			</Text>
+		</Box>
+	)
+}

--- a/cli/src/ui/messages/extension/tools/ToolInsertContentMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolInsertContentMessage.tsx
@@ -1,67 +1,97 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
-import { getToolIcon, formatFilePath, truncateText } from "../utils.js"
+import { formatFilePath } from "../utils.js"
+import { parseDiffContent, calculateDiffStats, parseInsertContent, isUnifiedDiffFormat } from "../diff.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
 import { getBoxWidth } from "../../../utils/width.js"
+import { DiffLine } from "./DiffLine.js"
 
 /**
  * Display content insertion at specific line
+ * Uses compact format: + Insert(filename:line) ⎿ +X lines
  */
 export const ToolInsertContentMessage: React.FC<ToolMessageProps> = ({ toolData }) => {
 	const theme = useTheme()
-	const icon = getToolIcon("insertContent")
-	const lineText = toolData.lineNumber === 0 ? "end of file" : `line ${toolData.lineNumber}`
+	const lineText = toolData.lineNumber === 0 ? "end" : toolData.lineNumber?.toString() || ""
+
+	// Use content (unified diff) if available, otherwise fall back to diff
+	const diffContent = toolData.content || toolData.diff || ""
+
+	// Parse diff content or create simple line list
+	const parsedLines = useMemo(() => {
+		if (!diffContent) return []
+
+		// Check if it's a unified diff format
+		if (isUnifiedDiffFormat(diffContent)) {
+			return parseDiffContent(diffContent)
+		}
+
+		// Otherwise, treat as raw content - all lines are additions
+		return parseInsertContent(diffContent, toolData.lineNumber || 1)
+	}, [diffContent, toolData.lineNumber])
+
+	// Calculate stats
+	const stats = useMemo(() => {
+		if (toolData.diffStats) return toolData.diffStats
+		return calculateDiffStats(parsedLines)
+	}, [toolData.diffStats, parsedLines])
+
+	// Generate diff summary text
+	const diffSummary = useMemo(() => {
+		if (stats.added > 0) {
+			return `⎿ +${stats.added} lines`
+		}
+		return ""
+	}, [stats])
 
 	return (
 		<Box flexDirection="column" marginY={1}>
+			{/* Compact header: + Insert(filename:line) ⎿ +X lines */}
 			<Box>
 				<Text color={theme.semantic.success} bold>
-					{icon} Insert Content: {formatFilePath(toolData.path || "")}
+					+ Insert(
+				</Text>
+				<Text color={theme.semantic.success} bold>
+					{formatFilePath(toolData.path || "")}
+				</Text>
+				{lineText && (
+					<Text color={theme.semantic.success} bold>
+						:{lineText}
+					</Text>
+				)}
+				<Text color={theme.semantic.success} bold>
+					)
 				</Text>
 				{toolData.isProtected && (
 					<Text color={theme.semantic.warning} dimColor>
 						{" "}
-						🔒 Protected
+						🔒
 					</Text>
 				)}
 				{toolData.isOutsideWorkspace && (
 					<Text color={theme.semantic.warning} dimColor>
 						{" "}
-						⚠ Outside workspace
+						⚠
+					</Text>
+				)}
+				{diffSummary && (
+					<Text color={theme.ui.text.dimmed} dimColor>
+						{" "}
+						{diffSummary}
 					</Text>
 				)}
 			</Box>
 
-			<Box marginLeft={2}>
-				<Text color={theme.ui.text.dimmed} dimColor>
-					At {lineText}
-				</Text>
-			</Box>
-
-			{toolData.diff && (
-				<Box
-					width={getBoxWidth(3)}
-					flexDirection="column"
-					borderStyle="single"
-					borderColor={theme.ui.border.default}
-					paddingX={1}
-					marginTop={1}
-					marginLeft={2}>
-					{toolData.diff
-						.split("\n")
-						.slice(0, 10)
-						.map((line, index) => {
-							const color = line.startsWith("+") ? theme.code.addition : theme.code.context
-							return (
-								<Text key={index} color={color}>
-									{truncateText(line, 80)}
-								</Text>
-							)
-						})}
-					{toolData.diff.split("\n").length > 10 && (
+			{/* Content preview with colored lines */}
+			{parsedLines.length > 0 && (
+				<Box width={getBoxWidth(3)} flexDirection="column" marginTop={1} marginLeft={2}>
+					{parsedLines.slice(0, 20).map((line, index) => (
+						<DiffLine key={index} line={line} theme={theme} showLineNumbers={true} />
+					))}
+					{parsedLines.length > 20 && (
 						<Text color={theme.ui.text.dimmed} dimColor>
-							... ({toolData.diff.split("\n").length - 10} more lines)
+							... ({parsedLines.length - 20} more lines)
 						</Text>
 					)}
 				</Box>

--- a/cli/src/ui/messages/extension/tools/ToolNewFileCreatedMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolNewFileCreatedMessage.tsx
@@ -1,62 +1,88 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
-import { getToolIcon, formatFilePath, truncateText } from "../utils.js"
+import { formatFilePath } from "../utils.js"
+import { calculateDiffStats, parseNewFileContent } from "../diff.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
 import { getBoxWidth } from "../../../utils/width.js"
+import { DiffLine } from "./DiffLine.js"
 
 /**
  * Display new file creation with content preview
+ * Uses compact format: Create(filename) ⎿ +X lines
  */
 export const ToolNewFileCreatedMessage: React.FC<ToolMessageProps> = ({ toolData }) => {
 	const theme = useTheme()
-	const icon = getToolIcon("newFileCreated")
-	const lines = toolData.content ? toolData.content.split("\n") : []
+
+	// Use content (unified diff) if available, otherwise use raw content
+	const diffContent = toolData.content || ""
+
+	// Parse diff content or create simple line list
+	const parsedLines = useMemo(() => parseNewFileContent(diffContent), [diffContent])
+
+	// Calculate stats
+	const stats = useMemo(() => {
+		if (toolData.diffStats) return toolData.diffStats
+		return calculateDiffStats(parsedLines)
+	}, [toolData.diffStats, parsedLines])
+
+	// Generate diff summary text
+	const diffSummary = useMemo(() => {
+		if (stats.added > 0) {
+			return `⎿ +${stats.added} lines`
+		}
+		return ""
+	}, [stats])
 
 	return (
 		<Box flexDirection="column" marginY={1}>
+			{/* Compact header: 📄 Create(filename) ⎿ +X lines */}
 			<Box>
 				<Text color={theme.semantic.success} bold>
-					{icon} New File: {formatFilePath(toolData.path || "")}
+					📄 Create(
+				</Text>
+				<Text color={theme.semantic.success} bold>
+					{formatFilePath(toolData.path || "")}
+				</Text>
+				<Text color={theme.semantic.success} bold>
+					)
 				</Text>
 				{toolData.isProtected && (
 					<Text color={theme.semantic.warning} dimColor>
 						{" "}
-						🔒 Protected
+						🔒
+					</Text>
+				)}
+				{toolData.isOutsideWorkspace && (
+					<Text color={theme.semantic.warning} dimColor>
+						{" "}
+						⚠
+					</Text>
+				)}
+				{diffSummary && (
+					<Text color={theme.ui.text.dimmed} dimColor>
+						{" "}
+						{diffSummary}
 					</Text>
 				)}
 			</Box>
 
-			{toolData.content && (
-				<Box
-					width={getBoxWidth(3)}
-					flexDirection="column"
-					borderStyle="single"
-					borderColor={theme.ui.border.default}
-					paddingX={1}
-					marginTop={1}
-					marginLeft={2}>
-					{lines.slice(0, 10).map((line, index) => (
-						<Text key={index} color={theme.ui.text.dimmed}>
-							{truncateText(line, 80)}
-						</Text>
+			{/* Content preview with colored lines */}
+			{parsedLines.length > 0 && (
+				<Box width={getBoxWidth(3)} flexDirection="column" marginTop={1} marginLeft={2}>
+					{parsedLines.slice(0, 20).map((line, index) => (
+						<DiffLine key={index} line={line} theme={theme} showLineNumbers={true} />
 					))}
-					{lines.length > 10 && (
+					{parsedLines.length > 20 && (
 						<Text color={theme.ui.text.dimmed} dimColor>
-							... ({lines.length - 10} more lines)
+							... ({parsedLines.length - 20} more lines)
 						</Text>
 					)}
 				</Box>
 			)}
 
-			<Box marginLeft={2} marginTop={1}>
-				<Text color={theme.ui.text.dimmed} dimColor>
-					Lines: {lines.length}
-				</Text>
-			</Box>
-
 			{toolData.fastApplyResult && typeof toolData.fastApplyResult === "object" ? (
-				<Box marginLeft={2}>
+				<Box marginLeft={2} marginTop={1}>
 					<Text color={theme.semantic.success} dimColor>
 						✓ Fast apply
 					</Text>

--- a/cli/src/ui/messages/extension/tools/ToolSearchAndReplaceMessage.tsx
+++ b/cli/src/ui/messages/extension/tools/ToolSearchAndReplaceMessage.tsx
@@ -1,60 +1,85 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { Box, Text } from "ink"
 import type { ToolMessageProps } from "../types.js"
-import { getToolIcon, formatFilePath, truncateText } from "../utils.js"
+import { formatFilePath } from "../utils.js"
+import { parseDiffContent, calculateDiffStats } from "../diff.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
 import { getBoxWidth } from "../../../utils/width.js"
+import { DiffLine } from "./DiffLine.js"
 
 /**
  * Display search and replace operations
+ * Uses compact format: ⇄ Replace(filename) ⎿ +X, -Y
  */
 export const ToolSearchAndReplaceMessage: React.FC<ToolMessageProps> = ({ toolData }) => {
 	const theme = useTheme()
-	const icon = getToolIcon("searchAndReplace")
+
+	// Use content (unified diff) if available, otherwise fall back to diff
+	const diffContent = toolData.content || toolData.diff || ""
+
+	// Parse diff content
+	const parsedLines = useMemo(() => parseDiffContent(diffContent), [diffContent])
+
+	// Calculate stats from parsed lines if not provided
+	const stats = useMemo(() => {
+		if (toolData.diffStats) return toolData.diffStats
+		return calculateDiffStats(parsedLines)
+	}, [toolData.diffStats, parsedLines])
+
+	// Generate diff summary text
+	const diffSummary = useMemo(() => {
+		const parts: string[] = []
+		if (stats.added > 0) {
+			parts.push(`+${stats.added}`)
+		}
+		if (stats.removed > 0) {
+			parts.push(`-${stats.removed}`)
+		}
+		return parts.length > 0 ? `⎿ ${parts.join(", ")}` : ""
+	}, [stats])
 
 	return (
 		<Box flexDirection="column" marginY={1}>
+			{/* Compact header: ⇄ Replace(filename) ⎿ +X, -Y */}
 			<Box>
 				<Text color={theme.ui.text.highlight} bold>
-					{icon} Search & Replace: {formatFilePath(toolData.path || "")}
+					⇄ Replace(
+				</Text>
+				<Text color={theme.ui.text.highlight} bold>
+					{formatFilePath(toolData.path || "")}
+				</Text>
+				<Text color={theme.ui.text.highlight} bold>
+					)
 				</Text>
 				{toolData.isProtected && (
 					<Text color={theme.semantic.warning} dimColor>
 						{" "}
-						🔒 Protected
+						🔒
+					</Text>
+				)}
+				{toolData.isOutsideWorkspace && (
+					<Text color={theme.semantic.warning} dimColor>
+						{" "}
+						⚠
+					</Text>
+				)}
+				{diffSummary && (
+					<Text color={theme.ui.text.dimmed} dimColor>
+						{" "}
+						{diffSummary}
 					</Text>
 				)}
 			</Box>
 
-			{toolData.diff && (
-				<Box
-					width={getBoxWidth(3)}
-					flexDirection="column"
-					borderStyle="single"
-					borderColor={theme.ui.border.default}
-					paddingX={1}
-					marginTop={1}
-					marginLeft={2}>
-					{toolData.diff
-						.split("\n")
-						.slice(0, 10)
-						.map((line, index) => {
-							const color = line.startsWith("+")
-								? theme.code.addition
-								: line.startsWith("-")
-									? theme.code.deletion
-									: line.startsWith("@@")
-										? theme.semantic.info
-										: theme.code.context
-							return (
-								<Text key={index} color={color}>
-									{truncateText(line, 80)}
-								</Text>
-							)
-						})}
-					{toolData.diff.split("\n").length > 10 && (
+			{/* Diff content with colored lines */}
+			{parsedLines.length > 0 && (
+				<Box width={getBoxWidth(3)} flexDirection="column" marginTop={1} marginLeft={2}>
+					{parsedLines.slice(0, 20).map((line, index) => (
+						<DiffLine key={index} line={line} theme={theme} showLineNumbers={true} />
+					))}
+					{parsedLines.length > 20 && (
 						<Text color={theme.ui.text.dimmed} dimColor>
-							... ({toolData.diff.split("\n").length - 10} more lines)
+							... ({parsedLines.length - 20} more lines)
 						</Text>
 					)}
 				</Box>

--- a/cli/src/ui/messages/extension/types.ts
+++ b/cli/src/ui/messages/extension/types.ts
@@ -48,6 +48,7 @@ export interface ToolData {
 	source?: string
 	additionalFileCount?: number
 	fastApplyResult?: unknown
+	diffStats?: { added: number; removed: number }
 }
 
 /**

--- a/cli/src/ui/messages/extension/utils.ts
+++ b/cli/src/ui/messages/extension/utils.ts
@@ -217,8 +217,8 @@ export function truncateText(text: string, maxLength: number = 100): string {
  * Format file path for display
  */
 export function formatFilePath(path: string): string {
-	// Remove leading ./ if present
-	return path.replace(/^\.\//, "")
+	// Trim whitespace and remove leading ./ if present
+	return path.trim().replace(/^\.\//, "")
 }
 
 /**


### PR DESCRIPTION
Improves the CLI display for file operations with a modern, compact format and proper diff coloring.

## Changes

### New Features
- **Compact headers**: `⏺ Update(filename) ⎿ +5, -3` instead of verbose multi-line format
- **Colored diff output**: Additions in green, deletions in red, with line numbers
- **Unified diff parsing**: Supports both unified diff (`@@`) and SEARCH/REPLACE formats
- **Diff stats**: Shows `+X, -Y` summary for edits, `+X lines` for new files/inserts

### Why?

As a CLI user I would like to see the changes the CLI did directly

### Before
<img width="1802" height="558" alt="image" src="https://github.com/user-attachments/assets/13e9ba26-7bf1-4e7d-9671-fa200b4b7d7f" />

### After

<img width="522" height="178" alt="image" src="https://github.com/user-attachments/assets/f942dd41-fdf8-40f9-928a-154e97e92d3f" />
<img width="836" height="396" alt="image" src="https://github.com/user-attachments/assets/65f9e44d-31e6-4e89-b4fa-281c47963a2e" />
<img width="379" height="184" alt="image" src="https://github.com/user-attachments/assets/b250acda-82b6-441a-963a-c7ea5f000e99" />
<img width="716" height="367" alt="image" src="https://github.com/user-attachments/assets/d398d1d6-6d6c-4f8d-a804-9edb7ac8bd5e" />

