### PR TITLE
feat(cli): add session_created event for Agent Manager integration

### DIFF
--- a/.changeset/cli-session-tracking.md
+++ b/.changeset/cli-session-tracking.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": patch
+---
+
+Add session_created event emission for Agent Manager integration
+
+Emit session_created event when a task is first started in JSON mode, allowing Agent Manager to track CLI sessions.


### PR DESCRIPTION
## Summary
Add `session_created` event emission in CLI for Agent Manager integration.

> **⚠️ Investigation needed**: This PR is opened for discussion. There may be conflicts with backend `session_created` events as noted by @marius-kilocode in #4941.

## Problem
When Agent Manager spawns the CLI, it waits for a `session_created` event to associate the CLI session with the spawned process. Without this event, the session times out after 30s:

```
[AgentManager] Pending session created, waiting for CLI session_created event
[AgentManager] Created provisional session: provisional-xxxxx
[AgentManager] Captured api_req_started before session_created
[AgentManager] Pending session timed out after 30s - no session_created event received
```

## Solution
Emit `session_created` event when a task is first started in JSON mode, using the local task ID.

## Known Issue
As noted by @marius-kilocode, this creates two different `session_created` events:
1. Local taskId (this PR): `{"event":"session_created","sessionId":"1736745600000"}`
2. Cloud sessionId (SessionSyncService): `{"event":"session_created","sessionId":"sess_abc123xyz"}`

This may cause Agent Manager and backend to use different session IDs.

## Questions
- Should the CLI wait for the backend `session_created` and forward it?
- Or should Agent Manager handle the provisional session differently?
- Is this specific to certain providers (e.g., Claude Code)?

## Test plan
- [ ] Investigate session ID conflicts
- [ ] Test with different providers
- [ ] Coordinate with Agent Manager session handling