### PR TITLE
Fix number key hotkeys (1, 2, 3) not working in command approval menu

### DIFF
--- a/.changeset/fix-approval-number-hotkeys.md
+++ b/.changeset/fix-approval-number-hotkeys.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix number key hotkeys (1, 2, 3) not working in command approval menu

--- a/cli/src/state/atoms/keyboard.ts
+++ b/cli/src/state/atoms/keyboard.ts
@@ -511,6 +511,14 @@ function handleApprovalKeys(get: Getter, set: Setter, key: Key) {
 	// Guard against empty options array to prevent NaN from modulo 0
 	if (options.length === 0) return
 
+	// Check if the key matches any option's hotkey (for number keys 1, 2, 3, etc.)
+	const hotkeyIndex = options.findIndex((opt) => opt.hotkey === key.name)
+	if (hotkeyIndex !== -1) {
+		set(selectedIndexAtom, hotkeyIndex)
+		set(executeSelectedAtom)
+		return
+	}
+
 	switch (key.name) {
 		case "down":
 			set(selectedIndexAtom, (selectedIndex + 1) % options.length)


### PR DESCRIPTION
## Summary

Fixes a bug where pressing number keys (1, 2, 3) to select "Always Run" options in the CLI command approval menu didn't work.

## Problem

When the approval menu displayed options like:
- Run Command (y)
- Always Run "mkdir" (1)
- Always Run "mkdir test-dir" (2)
- Always Run full command (3)
- Reject (n)

Pressing 'y' and 'n' worked correctly, but pressing '1', '2', or '3' did nothing.

## Root Cause

The `handleApprovalKeys` function in `cli/src/state/atoms/keyboard.ts` only handled `down`, `up`, `y`, `n`, `return`, and `escape` keys. Number keys were never checked against the approval options' hotkeys.

## Solution

Added hotkey matching logic at the beginning of `handleApprovalKeys` to find options by their hotkey and execute them when a matching number key is pressed.

<img width="655" height="186" alt="image" src="https://github.com/user-attachments/assets/3d10742a-8f63-4a08-949f-f31fd9d0ef92" />