### PR TITLE
feat(cli): Add maxConcurrentFileReads configuration support

### DIFF
--- a/.changeset/cli-max-concurrent-file-reads.md
+++ b/.changeset/cli-max-concurrent-file-reads.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Add maxConcurrentFileReads configuration support to CLI with documentation

--- a/cli/README.md
+++ b/cli/README.md
@@ -161,6 +161,20 @@ Autonomous mode respects your auto-approval configuration. Edit your config file
 - `retry`: Auto-approve API retry requests
 - `todo`: Auto-approve todo list updates
 
+#### Context Management Configuration
+
+You can also configure context management settings:
+
+```json
+{
+	"maxConcurrentFileReads": 5
+}
+```
+
+**Configuration Options:**
+
+- `maxConcurrentFileReads`: Maximum number of files that can be read in a single `read_file` request (default: 5, minimum: 1). The AI will be instructed about this limit and requests exceeding it will be rejected. Set to `1` to disable multi-file reads.
+
 #### Command Approval Patterns
 
 The `execute.allowed` and `execute.denied` lists support hierarchical pattern matching:

--- a/cli/src/config/__tests__/mapper.test.ts
+++ b/cli/src/config/__tests__/mapper.test.ts
@@ -303,4 +303,38 @@ describe("mapConfigToExtensionState", () => {
 			expect(state.mode).toBe("architect")
 		})
 	})
+
+	describe("context management settings mapping", () => {
+		it("should use default maxConcurrentFileReads of 5 when not specified", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.maxConcurrentFileReads).toBe(5)
+		})
+
+		it("should map custom maxConcurrentFileReads value", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				maxConcurrentFileReads: 10,
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.maxConcurrentFileReads).toBe(10)
+		})
+
+		it("should map maxConcurrentFileReads of 1 for single file reads only", () => {
+			const config: CLIConfig = {
+				...baseConfig,
+				maxConcurrentFileReads: 1,
+			}
+
+			const state = mapConfigToExtensionState(config)
+
+			expect(state.maxConcurrentFileReads).toBe(1)
+		})
+	})
 })

--- a/cli/src/config/mapper.ts
+++ b/cli/src/config/mapper.ts
@@ -1,6 +1,7 @@
 import type { CLIConfig, ProviderConfig } from "./types.js"
 import type { ExtensionState, ProviderSettings, ProviderSettingsEntry } from "../types/messages.js"
 import { logs } from "../services/logs.js"
+import { DEFAULT_MAX_CONCURRENT_FILE_READS } from "@kilocode/core-schemas"
 
 export function mapConfigToExtensionState(
 	config: CLIConfig,
@@ -69,6 +70,8 @@ export function mapConfigToExtensionState(
 			alwaysAllowFollowupQuestions: autoApprovalEnabled && (autoApproval?.question?.enabled ?? false),
 			followupAutoApproveTimeoutMs: (autoApproval?.question?.timeout ?? 60) * 1000,
 			alwaysAllowUpdateTodoList: autoApprovalEnabled && (autoApproval?.todo?.enabled ?? false),
+			// Context management settings
+			maxConcurrentFileReads: config.maxConcurrentFileReads ?? DEFAULT_MAX_CONCURRENT_FILE_READS,
 		}
 	} catch (error) {
 		logs.error("Failed to map config to extension state", "ConfigMapper", { error })

--- a/cli/src/config/schema.json
+++ b/cli/src/config/schema.json
@@ -212,6 +212,12 @@
 					}
 				}
 			}
+		},
+		"maxConcurrentFileReads": {
+			"type": "number",
+			"minimum": 1,
+			"default": 5,
+			"description": "Maximum number of files that can be read in a single read_file request. The AI will be instructed about this limit and requests exceeding it will be rejected."
 		}
 	},
 	"definitions": {

--- a/cli/src/host/ExtensionHost.ts
+++ b/cli/src/host/ExtensionHost.ts
@@ -1030,6 +1030,23 @@ export class ExtensionHost extends EventEmitter {
 			autoApprovalSettings.alwaysAllowUpdateTodoList = configState.alwaysAllowUpdateTodoList
 		}
 
+		// Context management settings
+		const contextSettings: Record<string, unknown> = {}
+		if (configState.maxConcurrentFileReads !== undefined) {
+			contextSettings.maxConcurrentFileReads = configState.maxConcurrentFileReads
+		}
+
+		// Send context management settings if any are present
+		if (Object.keys(contextSettings).length > 0) {
+			await this.sendWebviewMessage({
+				type: "updateSettings",
+				updatedSettings: contextSettings,
+			})
+			logs.debug("Context management settings synchronized to extension", "ExtensionHost", {
+				settings: Object.keys(contextSettings),
+			})
+		}
+
 		// Send auto-approval settings if any are present
 		if (Object.keys(autoApprovalSettings).length > 0) {
 			await this.sendWebviewMessage({

--- a/packages/core-schemas/src/config/cli-config.ts
+++ b/packages/core-schemas/src/config/cli-config.ts
@@ -4,6 +4,12 @@ import { autoApprovalConfigSchema } from "./auto-approval.js"
 import { themeSchema, themeIdSchema } from "../theme/theme.js"
 
 /**
+ * Default maximum number of files that can be read in a single read_file request.
+ * This is a CLI-specific constant that matches the extension's default value.
+ */
+export const DEFAULT_MAX_CONCURRENT_FILE_READS = 5
+
+/**
  * CLI configuration schema
  */
 export const cliConfigSchema = z.object({
@@ -15,6 +21,7 @@ export const cliConfigSchema = z.object({
 	autoApproval: autoApprovalConfigSchema.optional(),
 	theme: themeIdSchema.optional(),
 	customThemes: z.record(themeSchema).optional(),
+	maxConcurrentFileReads: z.number().min(1).default(DEFAULT_MAX_CONCURRENT_FILE_READS).optional(),
 })
 
 // Inferred type


### PR DESCRIPTION
## Summary

Adds support for `maxConcurrentFileReads` configuration in the CLI, matching the extension's behavior from the recent Roo merge.

<img width="966" height="238" alt="image" src="https://github.com/user-attachments/assets/9ecd57d0-0f73-43e0-bb2e-6380c540ac63" />


## Changes

### Core Implementation
- **packages/core-schemas/src/config/cli-config.ts**: Added `DEFAULT_MAX_CONCURRENT_FILE_READS = 5` constant and updated Zod schema to use it
- **cli/src/config/mapper.ts**: Import constant from `@kilocode/core-schemas` and use it for default value mapping
- **cli/src/host/ExtensionHost.ts**: Syncs the setting to the extension via `updateSettings` message
- **cli/src/config/schema.json**: JSON schema with `default: 5`, `minimum: 1`

### Documentation
- **cli/README.md**: Added "Context Management Configuration" section explaining the option

### Testing
- All 1725 CLI tests pass
- Existing tests in `cli/src/config/__tests__/mapper.test.ts` cover the mapping behavior

## Configuration

```json
{
  "maxConcurrentFileReads": 5
}
```

- **Default**: 5 (matches extension)
- **Minimum**: 1 (effectively disables multi-file reads)
- **Effect**: Limits files per `read_file` tool request; AI is informed of this limit in its system prompt

## Architecture Notes

The constant is defined in `@kilocode/core-schemas` which is a CLI-specific package, keeping the implementation CLI-specific while maintaining a single source of truth for the default value.