### PR TITLE
refactor(cli): simplify keyboard simulation in tests with type and press helpers

### DIFF
--- a/cli/src/media/processPastedText.ts
+++ b/cli/src/media/processPastedText.ts
@@ -22,7 +22,6 @@ export function expandPastedTextReferences(text: string, pastedTextReferences: R
 	return text.replace(PASTED_TEXT_REFERENCE_REGEX, (match, refNum) => {
 		const content = pastedTextReferences[parseInt(refNum, 10)]
 		if (content === undefined) return match
-		// Normalize tabs to spaces when expanding
-		return content.replace(/\t/g, "  ")
+		return content
 	})
 }

--- a/cli/src/state/atoms/keyboard.ts
+++ b/cli/src/state/atoms/keyboard.ts
@@ -1008,10 +1008,13 @@ function handleTextInputKeys(get: Getter, set: Setter, key: Key): void {
 }
 
 async function handlePaste(set: Setter, text: string): Promise<void> {
+	// Normalize tabs to spaces to prevent border corruption and ensure consistent display
+	const normalizedText = text.replace(/\t/g, "  ")
+
 	// Quick line count check - avoid processing large text unnecessarily
 	let lineCount = 0
-	for (let i = 0; i < text.length; i++) {
-		if (text[i] === "\n") lineCount++
+	for (let i = 0; i < normalizedText.length; i++) {
+		if (normalizedText[i] === "\n") lineCount++
 		if (lineCount >= PASTE_LINE_THRESHOLD) break
 	}
 	lineCount++ // Account for last line (no trailing newline)
@@ -1027,14 +1030,13 @@ async function handlePaste(set: Setter, text: string): Promise<void> {
 
 	try {
 		if (isLargePaste) {
-			// Store original text - normalize tabs only when expanding
-			const actualLineCount = text.split("\n").length
-			const refNumber = set(addPastedTextReferenceAtom, text)
+			// Store normalized text - tabs are already normalized above
+			const actualLineCount = normalizedText.split("\n").length
+			const refNumber = set(addPastedTextReferenceAtom, normalizedText)
 			const reference = formatPastedTextReference(refNumber, actualLineCount)
 			set(insertTextAtom, reference + " ")
 		} else {
-			// Small paste - normalize tabs to prevent border corruption
-			const normalizedText = text.replace(/\t/g, "  ")
+			// Small paste - insert normalized text
 			set(insertTextAtom, normalizedText)
 		}
 	} finally {


### PR DESCRIPTION
## Context

Keyboard tests (in `cli/src/state/atoms/__tests__/keyboard.test.ts`) have a lot of boilerplate code that can be simplified with a few helper functions.

Also in `cli/src/state/atoms/keyboard.ts` normalizing tabs in all pasted text makes thing more coherent.

This is a follow up from https://github.com/Kilo-Org/kilocode/pull/4959

@marius-kilocode and @RSO please take a look.

## Implementation

- Apply tab-to-space normalization to large pastes too
- Add type() and press() helper functions to reduce boilerplate in keyboard tests
- Add support for Meta-modified arrow keys in the press helper
- Update all relevant test cases to use the new helpers

## Screenshots

```bash
$ git diff --stat HEAD^
 cli/src/state/atoms/__tests__/keyboard.test.ts | 1149 +++++++++++++++++++++-----------------------------------------------------------------------------------------------------------------------------------------
 1 file changed, 151 insertions(+), 998 deletions(-)
 ```

## How to Test

Just run the keyboard tests and see that they behave the same.

## Get in Touch

Sorry but I am not in the Kilocode Discord.
