### PR TITLE
docs: clarify Mistral autocomplete setup instructions

### DIFF
--- a/apps/kilocode-docs/docs/basic-usage/autocomplete/mistral-setup.md
+++ b/apps/kilocode-docs/docs/basic-usage/autocomplete/mistral-setup.md
@@ -28,13 +28,21 @@ Navigate to **Settings → Providers** and click **Add Profile** to create a new
 
 ## Step 3: Name Your Profile
 
-In the "New Configuration Profile" dialog, enter a name like "Mistral profile" and click **Create Profile**.
+In the "New Configuration Profile" dialog, enter a name like "Mistral profile" (the name can be anything you prefer) and click **Create Profile**.
+
+:::note
+The profile name is just a label for your reference—it doesn't affect functionality. Choose any name that helps you identify this configuration.
+:::
 
 ![Create Mistral Profile](./mistral-setup/03-name-your-profile.png)
 
 ## Step 4: Select Mistral as Provider
 
 In the **API Provider** dropdown, search for and select **Mistral**.
+
+:::note
+When creating an autocomplete profile, you don't need to select a specific model—Kilo Code will automatically use the appropriate Codestral model optimized for code completions.
+:::
 
 ![Select Mistral Provider](./mistral-setup/04-select-mistral-provider.png)
 

--- a/apps/kilocode-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/basic-usage/autocomplete/mistral-setup.md
+++ b/apps/kilocode-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/basic-usage/autocomplete/mistral-setup.md
@@ -28,13 +28,21 @@ sidebar_position: 1
 
 ## 步骤 3：命名您的配置文件
 
-在"新建配置文件"对话框中，输入名称如"Mistral profile"，然后点击**创建配置文件**。
+在"新建配置文件"对话框中，输入名称如"Mistral profile"（名称可以是您喜欢的任何内容），然后点击**创建配置文件**。
+
+:::note
+配置文件名称只是供您参考的标签——它不会影响功能。选择任何有助于您识别此配置的名称。
+:::
 
 ![创建 Mistral 配置文件](./mistral-setup/03-name-your-profile.png)
 
 ## 步骤 4：选择 Mistral 作为提供商
 
 在 **API 提供商**下拉菜单中，搜索并选择 **Mistral**。
+
+:::note
+创建自动补全配置文件时，您无需选择特定模型——Kilo Code 将自动使用为代码补全优化的适当 Codestral 模型。
+:::
 
 ![选择 Mistral 提供商](./mistral-setup/04-select-mistral-provider.png)
 


### PR DESCRIPTION
- Clarify that profile name is arbitrary and can be anything
- Add note that model selection is not required for autocomplete profiles
- Update both English and Chinese (zh-CN) documentation
