### PR TITLE
feat(o11y): track per-session metrics

### DIFF
--- a/.changeset/session-metrics-o11y.md
+++ b/.changeset/session-metrics-o11y.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": patch
+"@roo-code/telemetry": patch
+"@roo-code/types": patch
+---
+
+Add per-session metrics telemetry (duration, turns, tool calls, errors, tokens, termination reason) emitted on task completion/abort.

--- a/packages/telemetry/src/TelemetryService.ts
+++ b/packages/telemetry/src/TelemetryService.ts
@@ -89,6 +89,12 @@ export class TelemetryService {
 		this.captureEvent(TelemetryEventName.TASK_COMPLETED, { taskId })
 	}
 
+	// kilocode_change start
+	public captureSessionMetrics(taskId: string, properties: Record<string, unknown>): void {
+		this.captureEvent(TelemetryEventName.SESSION_METRICS, { taskId, ...properties })
+	}
+	// kilocode_change end
+
 	public captureConversationMessage(taskId: string, source: "user" | "assistant"): void {
 		this.captureEvent(TelemetryEventName.TASK_CONVERSATION_MESSAGE, { taskId, source })
 	}

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -62,6 +62,7 @@ export enum TelemetryEventName {
 	TASK_CREATED = "Task Created",
 	TASK_RESTARTED = "Task Reopened",
 	TASK_COMPLETED = "Task Completed",
+	SESSION_METRICS = "Session Metrics", // kilocode_change
 	TASK_MESSAGE = "Task Message",
 	TASK_CONVERSATION_MESSAGE = "Conversation Message",
 	LLM_COMPLETION = "LLM Completion",
@@ -285,6 +286,23 @@ export const rooCodeTelemetryEventSchema = z.discriminatedUnion("type", [
 			TelemetryEventName.CUSTOM_MODE_CREATED,
 		]),
 		properties: telemetryPropertiesSchema,
+	}),
+	z.object({
+		// kilocode_change start
+		type: z.literal(TelemetryEventName.SESSION_METRICS),
+		properties: z.object({
+			...telemetryPropertiesSchema.shape,
+			taskId: z.string(),
+			sessionDurationMs: z.number(),
+			totalTurns: z.number(),
+			toolCallsByType: z.record(z.number()),
+			errorsByType: z.record(z.number()),
+			totalTokensConsumed: z.number(),
+			totalTokensIn: z.number(),
+			totalTokensOut: z.number(),
+			terminationReason: z.enum(["user_closed", "timeout", "explicit_completion", "error"]),
+		}),
+		// kilocode_change end
 	}),
 	z.object({
 		type: z.literal(TelemetryEventName.TELEMETRY_SETTINGS_CHANGED),

--- a/src/core/task/sessionMetrics.ts
+++ b/src/core/task/sessionMetrics.ts
@@ -1,0 +1,83 @@
+// kilocode_change - new file
+
+import type { ClineMessage, TokenUsage, ToolName, ToolUsage } from "@roo-code/types"
+import type { ClineApiReqCancelReason } from "../../shared/ExtensionMessage"
+
+export type SessionTerminationReason = "user_closed" | "timeout" | "explicit_completion" | "error"
+
+export type SessionToolCallsByType = Record<string, number>
+export type SessionErrorsByType = Record<string, number>
+
+export interface SessionMetrics {
+	sessionDurationMs: number
+	totalTurns: number
+	toolCallsByType: SessionToolCallsByType
+	errorsByType: SessionErrorsByType
+	totalTokensConsumed: number
+	totalTokensIn: number
+	totalTokensOut: number
+	terminationReason: SessionTerminationReason
+}
+
+export interface ComputeSessionMetricsInput {
+	startedAtMs: number
+	endedAtMs: number
+	clineMessages: ClineMessage[]
+	toolUsage: ToolUsage
+	tokenUsage: TokenUsage
+	abortReason?: ClineApiReqCancelReason
+	terminationReason: SessionTerminationReason
+}
+
+function getTotalTurnsFromMessages(messages: ClineMessage[]): number {
+	return messages.filter((m) => m.type === "say" && m.say === "api_req_started").length
+}
+
+function getToolCallsByType(toolUsage: ToolUsage): SessionToolCallsByType {
+	const result: SessionToolCallsByType = {}
+
+	for (const [tool, stats] of Object.entries(toolUsage) as Array<[ToolName, ToolUsage[ToolName]]>) {
+		if (!stats) continue
+		if (typeof stats.attempts === "number" && stats.attempts > 0) {
+			result[tool] = stats.attempts
+		}
+	}
+
+	return result
+}
+
+function getErrorsByType(toolUsage: ToolUsage, abortReason?: ClineApiReqCancelReason): SessionErrorsByType {
+	const result: SessionErrorsByType = {}
+
+	for (const [tool, stats] of Object.entries(toolUsage) as Array<[ToolName, ToolUsage[ToolName]]>) {
+		if (!stats) continue
+		if (typeof stats.failures === "number" && stats.failures > 0) {
+			result[`tool:${tool}`] = stats.failures
+		}
+	}
+
+	// Capture a single top-level API/stream failure reason for session-level rollups.
+	if (abortReason === "streaming_failed") {
+		result["api:streaming_failed"] = (result["api:streaming_failed"] ?? 0) + 1
+	}
+
+	return result
+}
+
+export function computeSessionMetrics(input: ComputeSessionMetricsInput): SessionMetrics {
+	const durationMs = Math.max(0, input.endedAtMs - input.startedAtMs)
+
+	const totalTokensIn = input.tokenUsage.totalTokensIn ?? 0
+	const totalTokensOut = input.tokenUsage.totalTokensOut ?? 0
+
+	return {
+		sessionDurationMs: durationMs,
+		totalTurns: getTotalTurnsFromMessages(input.clineMessages),
+		toolCallsByType: getToolCallsByType(input.toolUsage),
+		errorsByType: getErrorsByType(input.toolUsage, input.abortReason),
+		totalTokensConsumed: totalTokensIn + totalTokensOut,
+		totalTokensIn,
+		totalTokensOut,
+		terminationReason: input.terminationReason,
+	}
+}

--- a/src/core/tools/AttemptCompletionTool.ts
+++ b/src/core/tools/AttemptCompletionTool.ts
@@ -120,6 +120,9 @@ export class AttemptCompletionTool extends BaseTool<"attempt_completion"> {
 			// and properly updates the snapshot to prevent redundant emissions
 			task.emitFinalTokenUsageUpdate()
 
+			// kilocode_change: session metrics (Phase 1b)
+			task.captureSessionMetricsOnce("explicit_completion")
+
 			TelemetryService.instance.captureTaskCompleted(task.taskId)
 			task.emit(RooCodeEventName.TaskCompleted, task.taskId, task.getTokenUsage(), task.toolUsage)
 
@@ -240,6 +243,9 @@ export class AttemptCompletionTool extends BaseTool<"attempt_completion"> {
 
 				// Force final token usage update before emitting TaskCompleted for consistency
 				task.emitFinalTokenUsageUpdate()
+
+				// kilocode_change: session metrics (Phase 1b)
+				task.captureSessionMetricsOnce("explicit_completion")
 
 				TelemetryService.instance.captureTaskCompleted(task.taskId)
 				task.emit(RooCodeEventName.TaskCompleted, task.taskId, task.getTokenUsage(), task.toolUsage)


### PR DESCRIPTION
Implements Phase 1b session metrics from apps/kilocode-docs/docs/contributing/architecture/model-o11y.md.\n\nCaptures (per chat session/task, aggregated on completion/abort):\n- session duration\n- total turns (api_req_started count)\n- tool calls by tool type\n- errors by error type\n- total tokens in/out + total consumed\n- termination reason (explicit_completion / user_closed / timeout / error)\n\nKey implementation:\n- New telemetry event: SESSION_METRICS\n- Emitted once per task at session close (completion or abort)\n- Includes heuristic timeout detection for streaming failures\n\nTests:\n- Updated attempt_completion tool unit tests to assert metrics capture on completion.