### PR TITLE
fix(webview): remove double scrollbar in model selector

### DIFF
--- a/.changeset/fix-model-selector-scrollbar.md
+++ b/.changeset/fix-model-selector-scrollbar.md
@@ -1,0 +1,7 @@
+---
+"@roo-code/vscode-webview": patch
+---
+
+fix: remove double scrollbar in model selector
+
+Removed nested overflow-y-auto divs that were creating duplicate scrollable containers. The contentClassName prop now has complete control over scroll behavior.

--- a/webview-ui/src/components/ui/select-dropdown.tsx
+++ b/webview-ui/src/components/ui/select-dropdown.tsx
@@ -272,7 +272,7 @@ export const SelectDropdown = React.memo(
 						align={align}
 						sideOffset={sideOffset}
 						container={portalContainer}
-						className={cn("p-0 overflow-hidden", contentClassName)}>
+						className={cn("p-0", contentClassName)}>
 						<div className="flex flex-col w-full">
 							{/* Search input */}
 							{!disableSearch && (
@@ -296,9 +296,8 @@ export const SelectDropdown = React.memo(
 								</div>
 							)}
 
-							{/* Dropdown items - Use windowing for large lists */}
-							{/* kilocode_change: different max height: max-h-82 */}
-							<div className="max-h-82 overflow-y-auto">
+							{/* Dropdown items */}
+							<div>
 								{groupedOptions.length === 0 && searchValue ? (
 									<div className="py-2 px-3 text-sm text-vscode-foreground/70">No results found</div>
 								) : (


### PR DESCRIPTION
- Removed overflow-hidden from PopoverContent className
- Removed nested max-h-82 overflow-y-auto div
- contentClassName prop now controls all scroll behavior

Fixes #5033

## Context

The model selector dropdown was displaying two scrollbars when many models were configured. This created unpredictable scrolling behavior where:

- The search input would become hidden when scrolling the model list
- Edit controls were hidden at the bottom of one scrollbar
- Users had to manage two independent scroll positions

## Implementation

Root Cause: Two nested divs both had overflow-y-auto, creating duplicate scrollable containers:
1. PopoverContent (line 275) with overflow-hidden combined with contentClassName="max-h-[300px] overflow-y-auto"
2. Inner div (line 301) with hardcoded max-h-82 overflow-y-auto

Solution:
- Removed overflow-hidden from PopoverContent className to allow contentClassName to control overflow
- Removed the hardcoded max-h-82 overflow-y-auto from the inner div
- Now only the contentClassName prop (passed from ModelSelector.tsx) controls all scroll behavior

## Screenshots

Before:
<img width="934" height="709" alt="image" src="https://github.com/user-attachments/assets/a6da24e0-4d40-4b38-af05-e17099e54e4a" />

After:
<img width="500" height="390" alt="image" src="https://github.com/user-attachments/assets/865a0c8e-8aad-4d1d-95a7-fdeb07bb9e32" />

Video:


https://github.com/user-attachments/assets/6e96537d-7daa-41a9-afbc-d1b0423a1f12



## How to Test

1. Configure multiple models (10+) in the extension settings to enable scrolling
2. Open the model selector dropdown in the chat interface
3. Verify that only one scrollbar appears
4. Scroll through the model list
5. Confirm the search input remains visible at the top while scrolling
6. Verify all models are accessible and selectable


## Get in Touch
Discord: therajusah