### PR TITLE
feat(cli): Add default autocomplete suggestions for select commands

### DIFF
--- a/.changeset/cli-model-autocomplete.md
+++ b/.changeset/cli-model-autocomplete.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Add default autocomplete suggestions for select commands (`/model select`, `/provider select`, `/tasks select`, `/session select`)

--- a/cli/src/commands/model.ts
+++ b/cli/src/commands/model.ts
@@ -928,6 +928,7 @@ export const modelCommand: Command = {
 			name: "model-or-list-subcommand",
 			description: "Model name (for info/select) or list subcommand (page, next, prev, sort, filter)",
 			required: false,
+			provider: modelAutocompleteProvider,
 			conditionalProviders: [
 				{
 					condition: (context) => {

--- a/cli/src/commands/provider.ts
+++ b/cli/src/commands/provider.ts
@@ -199,6 +199,7 @@ export const providerCommand: Command = {
 			name: "provider-id",
 			description: "Provider ID (for select)",
 			required: false,
+			provider: providerAutocompleteProvider,
 			conditionalProviders: [
 				{
 					condition: (context) => {

--- a/cli/src/commands/session.ts
+++ b/cli/src/commands/session.ts
@@ -412,6 +412,7 @@ export const sessionCommand: Command = {
 			name: "argument",
 			description: "Argument for the subcommand",
 			required: false,
+			provider: sessionIdAutocompleteProvider,
 			conditionalProviders: [
 				{
 					condition: (context) => {

--- a/cli/src/commands/tasks.ts
+++ b/cli/src/commands/tasks.ts
@@ -515,6 +515,7 @@ export const tasksCommand: Command = {
 			name: "argument",
 			description: "Argument for the subcommand",
 			required: false,
+			provider: taskIdAutocompleteProvider,
 			conditionalProviders: [
 				{
 					condition: (context) => context.getArgument("subcommand") === "select",


### PR DESCRIPTION
## Summary

Add default autocomplete suggestions for select commands in the CLI, similar to the recently implemented teams autocomplete feature.

## Changes

- **`/model select`** - Shows model suggestions immediately when typing the command
- **`/provider select`** - Shows provider suggestions immediately when typing the command  
- **`/tasks select`** - Shows task suggestions (requires task history to be loaded first)
- **`/session select`** - Shows session suggestions (requires typing to search, as sessions are fetched on-demand)

## Technical Details

Added `provider` property to argument definitions alongside existing `conditionalProviders`. The `provider` acts as a default fallback when no conditional provider matches, ensuring suggestions appear immediately when the autocomplete system can't determine the subcommand context.

## Testing

- Added comprehensive tests for model autocomplete default provider behavior
- All 1866 existing tests pass