### PR TITLE
fix: remove private package from changeset

### DIFF
--- a/.changeset/agent-manager-model-selection.md
+++ b/.changeset/agent-manager-model-selection.md
@@ -1,6 +1,5 @@
 ---
 "kilo-code": minor
-"@roo-code/vscode-webview": minor
 ---
 
 Agent Manager now lets you choose which AI model to use when starting a new session. Your model selection is remembered across panel reopens, and active sessions display the model being used.


### PR DESCRIPTION
Removes `@roo-code/vscode-webview` from the `agent-manager-model-selection` changeset.

The changeset action was failing because it contained both `kilo-code` (a publishable package) and `@roo-code/vscode-webview` (a private package). Changesets doesn't allow mixing ignored and non-ignored packages in the same changeset file.

Since `@roo-code/vscode-webview` is a private internal package that shouldn't be versioned independently, it should not be included in changesets.