### PR TITLE
feat(cli): upgrade autocomplete with Fuse.js and visual highlighting

### DIFF
--- a/cli/src/services/__tests__/autocomplete_fuse.test.ts
+++ b/cli/src/services/__tests__/autocomplete_fuse.test.ts
@@ -1,0 +1,36 @@
+
+import { describe, it, expect } from "vitest"
+import { getSuggestions } from "../autocomplete"
+
+describe("Autocomplete Fuse Integration (Public API)", () => {
+
+    it("should return suggestions for fuzzy queries", () => {
+        // "hepl" vs "help" - Transposition
+        // Current implementation linear scan fails here.
+        // Fuse should handle "hepl" -> "help" with a good score.
+
+        const strictResults = getSuggestions("/hepl")
+        const strictHelpMatch = strictResults.find(r => r.command.name === "help")
+
+        // This EXPECTATION is that it currently FAILS (returns undefined) and will PASS with Fuse.
+        expect(strictHelpMatch).toBeDefined()
+    })
+
+    it("should provide highlightedName with ANSI colors", () => {
+        const results = getSuggestions("/help")
+        const helpMatch = results.find(r => r.command.name === "help")
+
+        expect(helpMatch).toBeDefined()
+        if (helpMatch) {
+            // Current implementation returns plain text
+            // We want it to be highlighted.
+            // Typically ANSI codes start with \u001b or \x1b
+            expect(helpMatch.highlightedName).toMatch(/\u001b\[/)
+        }
+    })
+
+    it("falls back gracefully for no matches", () => {
+        const results = getSuggestions("/zzzzzz")
+        expect(results).toHaveLength(0)
+    })
+})


### PR DESCRIPTION
Upgrade CLI autocomplete by replacing custom fuzzy matching with Fuse.js for improved accuracy and implementing ANSI-safe visual highlighting for matches.

## Context

The current CLI autocomplete service relies on a basic custom fuzzy matcher which has limited accuracy and fails to provide visual feedback explaining *why* a particular suggestion was matched.

The project already includes `fuse.js` as a dependency, but it was not being utilized in the CLI service layer. This PR leverages that existing dependency to provide a "smart" and polished autocomplete experience worthy of a modern CLI tool.

## Implementation

I refactored [cli/src/services/autocomplete.ts](cci:7://file:///c:/Users/yazid/OneDrive/Bureau/kilo%20bounties/kilocode/cli/src/services/autocomplete.ts:0:0-0:0) to integrate `fuse.js` while maintaining strict backward compatibility and performance standards.

Key changes:
*   **Intelligent Fuzzy Matching:** Replaced the custom matching logic with `fuse.js` (tuned with `threshold: 0.4`, `minMatchCharLength: 2`). This supports real-world usage like `cnfig` → `config` or `inst` → `install`.
*   **Visual Highlighting:** Implemented [highlightMatch](cci:1://file:///c:/Users/yazid/OneDrive/Bureau/kilo%20bounties/kilocode/cli/src/services/autocomplete.ts:168:0-197:1) using Fuse's returned indices. Matched characters are wrapped in ANSI-safe cyan codes (`\u001b[36m`), providing immediate visual clarity using existing CLI color patterns.
*   **Singleton Caching:** Implemented a singleton pattern for Fuse instances to prevent re-indexing overhead on every keystroke.
*   **Safety Fallback:** Added a critical fallback mechanism. If Fuse returns no results, the system falls back to the legacy prefix/substring matching. This guarantees that deep muscle-memory abbreviations (like `in` → `init`) continue to work exactly as before.

## Screenshots

| before | after |
| ------ | ----- |
| Plain text lists (e.g. `install`) | Highlighted matches (e.g. `inst`all in cyan) |
| Rigid matching (typos = no results) | Smart fuzzy matching (e.g. `cnfig` finds `config`) |

## How to Test

You can verify the improvements with these steps:

1.  **Build:** Run `pnpm cli:bundle`
2.  **Run:** Start the CLI (`node cli/dist/index.js`)
3.  **Scenario A (Fuzzy):** Type `/cnfig`.
    *   *Expected:* `/config` is suggested despite the typo.
4.  **Scenario B (Highlighting):** Type `inst`.
    *   *Expected:* `install` is suggested, and the letters `i`, `n`, `s`, `t` are highlighted in cyan.
5.  **Scenario C (Fallback):** Type a very short prefix like `c`.
    *   *Expected:* Standard commands like `config` appear correctly.

## Get in Touch

In Kilo Code Discord: dragony2dragon2