### PR TITLE
feat(cli): detect non-interactive mode to prevent auth wizard blocking

### DIFF
--- a/.changeset/cli-non-interactive-mode.md
+++ b/.changeset/cli-non-interactive-mode.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Detect non-interactive mode to prevent CLI auth wizard from blocking in CI/automated environments

--- a/cli/docs/ENVIRONMENT_VARIABLES.md
+++ b/cli/docs/ENVIRONMENT_VARIABLES.md
@@ -2,6 +2,56 @@
 
 The Kilo Code CLI can be fully configured using environment variables, allowing you to run it in ephemeral environments without a `config.json` file.
 
+## CI / Non-Interactive Mode
+
+When running in non-interactive mode (CI/CD pipelines, automated scripts, piped input), the CLI **cannot** launch the interactive authentication wizard. You must configure the CLI via environment variables or a config file before running.
+
+### Non-Interactive Mode Detection
+
+The CLI automatically detects non-interactive mode when any of the following conditions are true:
+
+| Condition                      | Example                                |
+| ------------------------------ | -------------------------------------- |
+| `--auto` flag is set           | `kilocode --auto "task"`               |
+| `--json` flag is set           | `kilocode --auto --json "task"`        |
+| `--json-io` flag is set        | `kilocode --json-io`                   |
+| stdin is not a TTY             | `echo "task" \| kilocode --auto`       |
+| CI environment variable is set | `CI=true`, `GITHUB_ACTIONS=true`, etc. |
+
+### Supported CI Environments
+
+The following CI environment variables are automatically detected:
+
+- `CI` (Generic)
+- `GITHUB_ACTIONS`
+- `GITLAB_CI`
+- `JENKINS_URL`
+- `CIRCLECI`
+- `TRAVIS`
+- `BUILDKITE`
+- `CODEBUILD_BUILD_ID` (AWS CodeBuild)
+- `TF_BUILD` (Azure Pipelines)
+- `TEAMCITY_VERSION`
+
+### CI Setup Example
+
+```yaml
+# GitHub Actions example
+jobs:
+    kilocode:
+        runs-on: ubuntu-latest
+        env:
+            KILO_PROVIDER_TYPE: anthropic
+            KILO_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            KILO_API_MODEL_ID: claude-sonnet-4-20250514
+        steps:
+            - uses: actions/checkout@v4
+            - name: Run Kilo Code
+              run: kilocode --auto "Analyze this codebase"
+```
+
+If configuration is missing in non-interactive mode, the CLI will exit with a clear error message explaining how to configure it.
+
 ## Core Configuration
 
 | Variable         | Description                                                      | Default | Required |

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -20,6 +20,7 @@ import { getParallelModeParams } from "./parallel/parallel.js"
 import { DEBUG_MODES, DEBUG_FUNCTIONS } from "./debug/index.js"
 import { logs } from "./services/logs.js"
 import { validateAttachments, validateAttachRequiresAuto, accumulateAttachments } from "./validation/attachments.js"
+import { isNonInteractiveMode, getNonInteractiveReason, emitConfigRequiredError } from "./utils/interactive.js"
 
 // Log CLI location for debugging (visible in VS Code "Kilo-Code" output channel)
 logs.info(`CLI started from: ${import.meta.url}`)
@@ -267,6 +268,24 @@ program
 					},
 				}
 				console.log(JSON.stringify(welcomeMessage))
+				process.exit(1)
+			}
+
+			// Check if we're in non-interactive mode before attempting auth wizard
+			const nonInteractiveOptions = {
+				auto: options.auto,
+				json: options.json,
+				jsonIo: options.jsonIo,
+			}
+
+			if (isNonInteractiveMode(nonInteractiveOptions)) {
+				// Cannot run auth wizard in non-interactive mode
+				const reason = getNonInteractiveReason(nonInteractiveOptions)
+				emitConfigRequiredError({
+					json: options.json,
+					jsonIo: options.jsonIo,
+					reason,
+				})
 				process.exit(1)
 			}
 

--- a/cli/src/utils/__tests__/interactive.test.ts
+++ b/cli/src/utils/__tests__/interactive.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Tests for interactive mode detection utilities
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import {
+	isCI,
+	isStdinTTY,
+	isNonInteractiveMode,
+	getNonInteractiveReason,
+	getConfigRequiredError,
+	emitConfigRequiredError,
+} from "../interactive.js"
+
+describe("interactive utilities", () => {
+	// Save original values
+	const originalEnv = { ...process.env }
+	const originalStdinIsTTY = process.stdin.isTTY
+
+	beforeEach(() => {
+		// Clear CI environment variables
+		delete process.env.CI
+		delete process.env.GITHUB_ACTIONS
+		delete process.env.GITLAB_CI
+		delete process.env.JENKINS_URL
+		delete process.env.CIRCLECI
+		delete process.env.TRAVIS
+		delete process.env.BUILDKITE
+		delete process.env.CODEBUILD_BUILD_ID
+		delete process.env.TF_BUILD
+		delete process.env.TEAMCITY_VERSION
+	})
+
+	afterEach(() => {
+		// Restore original environment properly
+		// Clear all current env vars and reassign original ones
+		Object.keys(process.env).forEach((key) => delete process.env[key])
+		Object.assign(process.env, originalEnv)
+		// Note: isTTY is read-only in real Node.js, but we mock it in tests
+		Object.defineProperty(process.stdin, "isTTY", { value: originalStdinIsTTY, writable: true })
+	})
+
+	describe("isCI", () => {
+		it("should return false when no CI environment variables are set", () => {
+			expect(isCI()).toBe(false)
+		})
+
+		it("should return true when CI=true is set", () => {
+			process.env.CI = "true"
+			expect(isCI()).toBe(true)
+		})
+
+		it("should return true when CI=1 is set", () => {
+			process.env.CI = "1"
+			expect(isCI()).toBe(true)
+		})
+
+		it("should return false when CI=false is set", () => {
+			process.env.CI = "false"
+			expect(isCI()).toBe(false)
+		})
+
+		it("should return false when CI=FALSE is set (case insensitive)", () => {
+			process.env.CI = "FALSE"
+			expect(isCI()).toBe(false)
+		})
+
+		it("should return false when CI=False is set (case insensitive)", () => {
+			process.env.CI = "False"
+			expect(isCI()).toBe(false)
+		})
+
+		it("should return false when CI=0 is set", () => {
+			process.env.CI = "0"
+			expect(isCI()).toBe(false)
+		})
+
+		it("should return false when CI is empty string", () => {
+			process.env.CI = ""
+			expect(isCI()).toBe(false)
+		})
+
+		it("should return true when GITHUB_ACTIONS is set", () => {
+			process.env.GITHUB_ACTIONS = "true"
+			expect(isCI()).toBe(true)
+		})
+
+		it("should return true when GITLAB_CI is set", () => {
+			process.env.GITLAB_CI = "true"
+			expect(isCI()).toBe(true)
+		})
+
+		it("should return true when JENKINS_URL is set", () => {
+			process.env.JENKINS_URL = "http://jenkins.example.com"
+			expect(isCI()).toBe(true)
+		})
+
+		it("should return true when CIRCLECI is set", () => {
+			process.env.CIRCLECI = "true"
+			expect(isCI()).toBe(true)
+		})
+
+		it("should return true when TRAVIS is set", () => {
+			process.env.TRAVIS = "true"
+			expect(isCI()).toBe(true)
+		})
+
+		it("should return true when BUILDKITE is set", () => {
+			process.env.BUILDKITE = "true"
+			expect(isCI()).toBe(true)
+		})
+
+		it("should return true when CODEBUILD_BUILD_ID is set", () => {
+			process.env.CODEBUILD_BUILD_ID = "build-123"
+			expect(isCI()).toBe(true)
+		})
+
+		it("should return true when TF_BUILD is set (Azure Pipelines)", () => {
+			process.env.TF_BUILD = "True"
+			expect(isCI()).toBe(true)
+		})
+
+		it("should return true when TEAMCITY_VERSION is set", () => {
+			process.env.TEAMCITY_VERSION = "2023.1"
+			expect(isCI()).toBe(true)
+		})
+	})
+
+	describe("isStdinTTY", () => {
+		it("should return true when stdin is a TTY", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true })
+			expect(isStdinTTY()).toBe(true)
+		})
+
+		it("should return false when stdin is not a TTY", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: false, writable: true })
+			expect(isStdinTTY()).toBe(false)
+		})
+
+		it("should return false when stdin.isTTY is undefined", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: undefined, writable: true })
+			expect(isStdinTTY()).toBe(false)
+		})
+	})
+
+	describe("isNonInteractiveMode", () => {
+		it("should return false with no options and TTY stdin in non-CI environment", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true })
+			expect(isNonInteractiveMode()).toBe(false)
+		})
+
+		it("should return true when auto option is set", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true })
+			expect(isNonInteractiveMode({ auto: true })).toBe(true)
+		})
+
+		it("should return true when json option is set", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true })
+			expect(isNonInteractiveMode({ json: true })).toBe(true)
+		})
+
+		it("should return true when jsonIo option is set", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true })
+			expect(isNonInteractiveMode({ jsonIo: true })).toBe(true)
+		})
+
+		it("should return true when stdin is not a TTY", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: false, writable: true })
+			expect(isNonInteractiveMode()).toBe(true)
+		})
+
+		it("should return true when in CI environment", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true })
+			process.env.CI = "true"
+			expect(isNonInteractiveMode()).toBe(true)
+		})
+
+		it("should return true when multiple non-interactive conditions are met", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: false, writable: true })
+			process.env.CI = "true"
+			expect(isNonInteractiveMode({ auto: true, json: true })).toBe(true)
+		})
+	})
+
+	describe("getNonInteractiveReason", () => {
+		it("should return null when in interactive mode", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true })
+			expect(getNonInteractiveReason()).toBeNull()
+		})
+
+		it("should identify --auto flag as reason", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true })
+			expect(getNonInteractiveReason({ auto: true })).toBe("--auto flag is set")
+		})
+
+		it("should identify --json flag as reason", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true })
+			expect(getNonInteractiveReason({ json: true })).toBe("--json flag is set")
+		})
+
+		it("should identify --json-io flag as reason", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true })
+			expect(getNonInteractiveReason({ jsonIo: true })).toBe("--json-io flag is set")
+		})
+
+		it("should identify non-TTY stdin as reason", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: false, writable: true })
+			expect(getNonInteractiveReason()).toBe("stdin is not a TTY (input may be piped)")
+		})
+
+		it("should identify CI environment as reason", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true })
+			process.env.GITHUB_ACTIONS = "true"
+			const reason = getNonInteractiveReason()
+			expect(reason).toContain("CI environment detected")
+			expect(reason).toContain("GITHUB_ACTIONS is set")
+		})
+
+		it("should prioritize explicit flags over environment detection", () => {
+			Object.defineProperty(process.stdin, "isTTY", { value: false, writable: true })
+			process.env.CI = "true"
+			// --auto should be reported first even if other conditions are met
+			expect(getNonInteractiveReason({ auto: true })).toBe("--auto flag is set")
+		})
+	})
+
+	describe("getConfigRequiredError", () => {
+		it("should include the reason in error message", () => {
+			const error = getConfigRequiredError("--auto flag is set")
+			expect(error).toContain("--auto flag is set")
+		})
+
+		it("should include environment variable configuration instructions", () => {
+			const error = getConfigRequiredError("CI environment detected")
+			expect(error).toContain("KILO_PROVIDER_TYPE")
+			expect(error).toContain("KILO_API_KEY")
+			expect(error).toContain("KILO_API_MODEL_ID")
+			expect(error).toContain("your-model-id")
+		})
+
+		it("should include auth wizard instructions", () => {
+			const error = getConfigRequiredError(null)
+			expect(error).toContain("kilocode auth")
+		})
+
+		it("should include config file instructions", () => {
+			const error = getConfigRequiredError(null)
+			expect(error).toContain("config.json")
+		})
+
+		it("should include documentation link", () => {
+			const error = getConfigRequiredError(null)
+			expect(error).toContain("ENVIRONMENT_VARIABLES.md")
+		})
+
+		it("should handle null reason gracefully", () => {
+			const error = getConfigRequiredError(null)
+			expect(error).toContain("Running in non-interactive mode")
+		})
+	})
+
+	describe("emitConfigRequiredError", () => {
+		it("should write JSON to stdout when json flag is set", () => {
+			const stdout = vi.fn()
+			const stderr = vi.fn()
+			const reason = "--json flag is set"
+
+			emitConfigRequiredError({ json: true, reason, stdout, stderr })
+
+			expect(stdout).toHaveBeenCalledWith(
+				JSON.stringify({
+					type: "error",
+					error: "configuration_required",
+					message: getConfigRequiredError(reason),
+					reason,
+				}),
+			)
+			expect(stderr).not.toHaveBeenCalled()
+		})
+
+		it("should write JSON to stdout when jsonIo flag is set", () => {
+			const stdout = vi.fn()
+			const stderr = vi.fn()
+			const reason = "--json-io flag is set"
+
+			emitConfigRequiredError({ jsonIo: true, reason, stdout, stderr })
+
+			expect(stdout).toHaveBeenCalledWith(
+				JSON.stringify({
+					type: "error",
+					error: "configuration_required",
+					message: getConfigRequiredError(reason),
+					reason,
+				}),
+			)
+			expect(stderr).not.toHaveBeenCalled()
+		})
+
+		it("should write plain error to stderr when json flags are not set", () => {
+			const stdout = vi.fn()
+			const stderr = vi.fn()
+			const reason = "--auto flag is set"
+
+			emitConfigRequiredError({ reason, stdout, stderr })
+
+			expect(stdout).not.toHaveBeenCalled()
+			expect(stderr).toHaveBeenCalledWith(getConfigRequiredError(reason))
+		})
+	})
+})

--- a/cli/src/utils/interactive.ts
+++ b/cli/src/utils/interactive.ts
@@ -1,0 +1,182 @@
+/**
+ * Utilities for detecting interactive vs non-interactive mode
+ * Used to prevent blocking on user input in CI/automated environments
+ */
+
+/**
+ * Common CI environment variables that indicate a non-interactive environment
+ */
+const CI_ENV_VARS = [
+	"CI", // Generic CI (GitHub Actions, GitLab CI, etc.)
+	"GITHUB_ACTIONS", // GitHub Actions
+	"GITLAB_CI", // GitLab CI
+	"JENKINS_URL", // Jenkins
+	"CIRCLECI", // CircleCI
+	"TRAVIS", // Travis CI
+	"BUILDKITE", // Buildkite
+	"CODEBUILD_BUILD_ID", // AWS CodeBuild
+	"TF_BUILD", // Azure Pipelines
+	"TEAMCITY_VERSION", // TeamCity
+] as const
+
+/**
+ * Options that can indicate non-interactive mode
+ */
+export interface NonInteractiveOptions {
+	auto?: boolean
+	json?: boolean
+	jsonIo?: boolean
+}
+
+/**
+ * Check if running in a CI environment based on environment variables
+ */
+export function isCI(): boolean {
+	return CI_ENV_VARS.some((envVar) => {
+		const value = process.env[envVar]
+		// Check if the variable exists and is truthy (not empty, not "false"/"FALSE", not "0")
+		if (value === undefined || value === "") {
+			return false
+		}
+		const lowerValue = value.toLowerCase()
+		return lowerValue !== "false" && lowerValue !== "0"
+	})
+}
+
+/**
+ * Check if stdin is connected to an interactive terminal (TTY)
+ */
+export function isStdinTTY(): boolean {
+	return process.stdin.isTTY === true
+}
+
+/**
+ * Determine if the CLI is running in a non-interactive mode
+ *
+ * Non-interactive mode is detected when any of the following is true:
+ * - --auto flag is set
+ * - --json flag is set (implies non-interactive output)
+ * - --json-io flag is set (bidirectional JSON mode)
+ * - stdin is not a TTY (e.g., piped input)
+ * - Running in a CI environment
+ *
+ * @param options - CLI options that can force non-interactive mode
+ * @returns true if running in non-interactive mode
+ */
+export function isNonInteractiveMode(options: NonInteractiveOptions = {}): boolean {
+	// Explicit flags that indicate non-interactive mode
+	if (options.auto || options.json || options.jsonIo) {
+		return true
+	}
+
+	// stdin not connected to terminal
+	if (!isStdinTTY()) {
+		return true
+	}
+
+	// CI environment detected
+	if (isCI()) {
+		return true
+	}
+
+	return false
+}
+
+/**
+ * Get a detailed reason why non-interactive mode was detected
+ * Useful for debugging and error messages
+ *
+ * @param options - CLI options to check
+ * @returns Human-readable reason string or null if interactive
+ */
+export function getNonInteractiveReason(options: NonInteractiveOptions = {}): string | null {
+	if (options.auto) {
+		return "--auto flag is set"
+	}
+	if (options.json) {
+		return "--json flag is set"
+	}
+	if (options.jsonIo) {
+		return "--json-io flag is set"
+	}
+	if (!isStdinTTY()) {
+		return "stdin is not a TTY (input may be piped)"
+	}
+	if (isCI()) {
+		const detectedVar = CI_ENV_VARS.find((v) => {
+			const val = process.env[v]
+			if (val === undefined || val === "") {
+				return false
+			}
+			const lowerVal = val.toLowerCase()
+			return lowerVal !== "false" && lowerVal !== "0"
+		})
+		// Only output variable name, not value (may contain sensitive tokens)
+		return `CI environment detected (${detectedVar} is set)`
+	}
+	return null
+}
+
+/**
+ * Generate a helpful error message for when auth is required in non-interactive mode
+ *
+ * @param reason - The reason non-interactive mode was detected
+ * @returns Formatted error message with configuration instructions
+ */
+export function getConfigRequiredError(reason: string | null): string {
+	const lines = [
+		"Error: No configuration found and cannot run authentication wizard.",
+		"",
+		`Reason: ${reason || "Running in non-interactive mode"}`,
+		"",
+		"To use Kilo Code CLI in non-interactive/CI mode, you must configure it first.",
+		"",
+		"Option 1: Set environment variables (recommended for CI)",
+		"  export KILO_PROVIDER_TYPE=anthropic",
+		"  export KILO_API_KEY=your-api-key",
+		"  export KILO_API_MODEL_ID=your-model-id",
+		"",
+		"Option 2: Run the auth wizard interactively first",
+		"  kilocode auth",
+		"",
+		"Option 3: Use a config file",
+		"  Provide a config file at ~/.kilocode/cli/config.json",
+		"",
+		"For more details, see:",
+		"  https://github.com/Kilo-Org/kilocode/blob/main/cli/docs/ENVIRONMENT_VARIABLES.md",
+	]
+
+	return lines.join("\n")
+}
+
+export interface ConfigRequiredErrorOutputOptions {
+	json?: boolean
+	jsonIo?: boolean
+	reason: string | null
+	stdout?: (message: string) => void
+	stderr?: (message: string) => void
+}
+
+export function emitConfigRequiredError({
+	json,
+	jsonIo,
+	reason,
+	stdout = console.log,
+	stderr = console.error,
+}: ConfigRequiredErrorOutputOptions): void {
+	const errorMessage = getConfigRequiredError(reason)
+
+	if (json || jsonIo) {
+		stdout(
+			JSON.stringify({
+				type: "error",
+				error: "configuration_required",
+				message: errorMessage,
+				reason,
+			}),
+		)
+		return
+	}
+
+	stderr(errorMessage)
+}


### PR DESCRIPTION
## Context

The CLI's `authWizard` is interactive and blocks when running in CI/automated environments (e.g., `--auto` mode, piped input, GitHub Actions). This causes the CLI to hang or fail in non-interactive scenarios.

This PR adds detection for non-interactive mode and provides clear error messages with configuration instructions instead of blocking.

## Implementation

- Added `cli/src/utils/interactive.ts` with utilities:
  - `isCI()` - detects CI environment variables (CI, GITHUB_ACTIONS, GITLAB_CI, etc.)
  - `isStdinTTY()` - checks if stdin is connected to a terminal
  - `isNonInteractiveMode()` - combines all detection methods
  - `getNonInteractiveReason()` - provides human-readable reason for debugging
  - `getConfigRequiredError()` - generates helpful error message with setup instructions

- Modified `cli/src/index.ts` to check non-interactive mode before launching `authWizard`
  - In non-interactive mode: exit with clear error and configuration instructions
  - In interactive mode: show auth wizard as before

- Updated `cli/docs/ENVIRONMENT_VARIABLES.md` with CI setup documentation

## Screenshots

N/A - CLI change, no UI screenshots

## How to Test

1. **Test CI detection:**
   ```bash
   CI=true kilocode --auto "test"
   # Should show error with configuration instructions
   ```

2. **Test piped input detection:**
   ```bash
   echo "test" | kilocode --auto
   # Should show error with configuration instructions
   ```

3. **Test with proper configuration:**
   ```bash
   export KILO_PROVIDER_TYPE=anthropic
   export KILO_API_KEY=your-key
   export KILO_API_MODEL_ID=claude-sonnet-4-20250514
   CI=true kilocode --auto "test"
   # Should work normally
   ```

4. **Run tests:**
   ```bash
   cd cli && pnpm test src/utils/__tests__/interactive.test.ts
   ```

## Get in Touch

@PeterDaveHello on Discord