### PR TITLE
fix(cli): restore Cmd+V image paste in VSCode terminal

### DIFF
--- a/.changeset/fix-cmdv-image-paste-regression.md
+++ b/.changeset/fix-cmdv-image-paste-regression.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix Cmd+V image paste regression in VSCode terminal
+
+Restores the ability to paste images using Cmd+V in VSCode terminal, which was broken in #4916. VSCode sends empty bracketed paste sequences for Cmd+V (unlike regular terminals that send key events), so we need to check the clipboard for images when receiving an empty paste.


### PR DESCRIPTION
## Summary

Fixes Cmd+V image paste regression in VSCode terminal that was introduced in #4916.

### The Problem

When pasting images with Cmd+V in VSCode terminal:
- VSCode sends empty bracketed paste sequences (`\x1b[200~\x1b[201~`) unlike regular terminals
- #4916 changed the condition to `if (wasPasting && currentBuffer)`, which skips empty pastes
- This broke the original #4832 behavior that checked clipboard for images on empty pastes

### The Fix

- Restore clipboard image check when receiving empty bracketed pastes
- Keep the optimization from #4916 for regular text pastes (no clipboard check)
- Preserves the multiline paste fix from #5011

### Test Plan

- [ ] Copy an image to clipboard (e.g., screenshot or image file from Finder)
- [ ] In VSCode terminal running Kilo CLI, press Cmd+V
- [ ] Image should be pasted as a reference
- [ ] Regular text paste (Ctrl+V / Cmd+V with text) still works
- [ ] Multiline paste still works correctly