### PR TITLE
feat(cli): show total session cost in status bar instead of per-request costs

### DIFF
--- a/.changeset/cli-session-cost-display.md
+++ b/.changeset/cli-session-cost-display.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Show total session cost in status bar instead of per-request costs. Remove "API Request in progress" messages for cleaner UI.

--- a/cli/src/state/hooks/__tests__/useSessionCost.test.ts
+++ b/cli/src/state/hooks/__tests__/useSessionCost.test.ts
@@ -128,33 +128,6 @@ describe("useSessionCost", () => {
 			expect(result.hasCostData).toBe(true)
 		})
 
-		it("should handle invalid JSON gracefully", () => {
-			const messages: ExtensionChatMessage[] = [
-				{
-					ts: 1000,
-					type: "say",
-					say: "api_req_started",
-					text: JSON.stringify({ cost: 0.01 }),
-				},
-				{
-					ts: 2000,
-					type: "say",
-					say: "api_req_started",
-					text: "invalid json",
-				},
-				{
-					ts: 3000,
-					type: "say",
-					say: "api_req_started",
-					text: JSON.stringify({ cost: 0.02 }),
-				},
-			]
-			store.set(chatMessagesAtom, messages)
-			const result = calculateSessionCost(store.get(chatMessagesAtom))
-			expect(result.totalCost).toBeCloseTo(0.03, 4)
-			expect(result.requestCount).toBe(2)
-			expect(result.hasCostData).toBe(true)
-		})
 
 		it("should handle messages with empty text", () => {
 			const messages: ExtensionChatMessage[] = [
@@ -196,14 +169,10 @@ function calculateSessionCost(messages: ExtensionChatMessage[]) {
 
 	for (const message of messages) {
 		if (message.say === "api_req_started" && message.text) {
-			try {
-				const data = JSON.parse(message.text)
-				if (typeof data.cost === "number") {
-					totalCost += data.cost
-					requestCount++
-				}
-			} catch {
-				// Ignore parse errors
+			const data = JSON.parse(message.text)
+			if (typeof data.cost === "number") {
+				totalCost += data.cost
+				requestCount++
 			}
 		}
 	}

--- a/cli/src/state/hooks/__tests__/useSessionCost.test.ts
+++ b/cli/src/state/hooks/__tests__/useSessionCost.test.ts
@@ -20,13 +20,10 @@ describe("useSessionCost", () => {
 			expect(formatSessionCost(0)).toBe("$0.00")
 		})
 
-		it("should format small costs with 4 decimal places", () => {
-			expect(formatSessionCost(0.0001)).toBe("$0.0001")
-			expect(formatSessionCost(0.0012)).toBe("$0.0012")
-			expect(formatSessionCost(0.0099)).toBe("$0.0099")
-		})
-
-		it("should format larger costs with 2 decimal places", () => {
+		it("should format costs with 2 decimal places", () => {
+			expect(formatSessionCost(0.0001)).toBe("$0.00")
+			expect(formatSessionCost(0.0012)).toBe("$0.00")
+			expect(formatSessionCost(0.0099)).toBe("$0.01")
 			expect(formatSessionCost(0.01)).toBe("$0.01")
 			expect(formatSessionCost(0.12)).toBe("$0.12")
 			expect(formatSessionCost(1.23)).toBe("$1.23")

--- a/cli/src/state/hooks/__tests__/useSessionCost.test.ts
+++ b/cli/src/state/hooks/__tests__/useSessionCost.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for useSessionCost hook
+ */
+
+import { describe, it, expect, beforeEach } from "vitest"
+import { createStore } from "jotai"
+import { chatMessagesAtom } from "../../atoms/extension.js"
+import type { ExtensionChatMessage } from "../../../types/messages.js"
+import { formatSessionCost } from "../useSessionCost.js"
+
+describe("useSessionCost", () => {
+	let store: ReturnType<typeof createStore>
+
+	beforeEach(() => {
+		store = createStore()
+	})
+
+	describe("formatSessionCost", () => {
+		it("should format zero cost", () => {
+			expect(formatSessionCost(0)).toBe("$0.00")
+		})
+
+		it("should format small costs with 4 decimal places", () => {
+			expect(formatSessionCost(0.0001)).toBe("$0.0001")
+			expect(formatSessionCost(0.0012)).toBe("$0.0012")
+			expect(formatSessionCost(0.0099)).toBe("$0.0099")
+		})
+
+		it("should format larger costs with 2 decimal places", () => {
+			expect(formatSessionCost(0.01)).toBe("$0.01")
+			expect(formatSessionCost(0.12)).toBe("$0.12")
+			expect(formatSessionCost(1.23)).toBe("$1.23")
+			expect(formatSessionCost(10.5)).toBe("$10.50")
+		})
+	})
+
+	describe("cost calculation from messages", () => {
+		it("should return zero when no messages", () => {
+			store.set(chatMessagesAtom, [])
+			const messages = store.get(chatMessagesAtom)
+			const result = calculateSessionCost(messages)
+			expect(result.totalCost).toBe(0)
+			expect(result.requestCount).toBe(0)
+			expect(result.hasCostData).toBe(false)
+		})
+
+		it("should calculate total cost from api_req_started messages", () => {
+			const messages: ExtensionChatMessage[] = [
+				{
+					ts: 1000,
+					type: "say",
+					say: "api_req_started",
+					text: JSON.stringify({ cost: 0.01 }),
+				},
+				{
+					ts: 2000,
+					type: "say",
+					say: "api_req_started",
+					text: JSON.stringify({ cost: 0.02 }),
+				},
+				{
+					ts: 3000,
+					type: "say",
+					say: "api_req_started",
+					text: JSON.stringify({ cost: 0.005 }),
+				},
+			]
+			store.set(chatMessagesAtom, messages)
+			const result = calculateSessionCost(store.get(chatMessagesAtom))
+			expect(result.totalCost).toBeCloseTo(0.035, 4)
+			expect(result.requestCount).toBe(3)
+			expect(result.hasCostData).toBe(true)
+		})
+
+		it("should ignore api_req_started messages without cost", () => {
+			const messages: ExtensionChatMessage[] = [
+				{
+					ts: 1000,
+					type: "say",
+					say: "api_req_started",
+					text: JSON.stringify({ cost: 0.01 }),
+				},
+				{
+					ts: 2000,
+					type: "say",
+					say: "api_req_started",
+					text: JSON.stringify({ request: "test" }), // No cost field
+				},
+				{
+					ts: 3000,
+					type: "say",
+					say: "api_req_started",
+					text: JSON.stringify({ cost: 0.02 }),
+				},
+			]
+			store.set(chatMessagesAtom, messages)
+			const result = calculateSessionCost(store.get(chatMessagesAtom))
+			expect(result.totalCost).toBeCloseTo(0.03, 4)
+			expect(result.requestCount).toBe(2)
+			expect(result.hasCostData).toBe(true)
+		})
+
+		it("should ignore non-api_req_started messages", () => {
+			const messages: ExtensionChatMessage[] = [
+				{
+					ts: 1000,
+					type: "say",
+					say: "api_req_started",
+					text: JSON.stringify({ cost: 0.01 }),
+				},
+				{
+					ts: 2000,
+					type: "say",
+					say: "text",
+					text: "Hello world",
+				},
+				{
+					ts: 3000,
+					type: "ask",
+					ask: "tool",
+					text: JSON.stringify({ tool: "readFile" }),
+				},
+			]
+			store.set(chatMessagesAtom, messages)
+			const result = calculateSessionCost(store.get(chatMessagesAtom))
+			expect(result.totalCost).toBeCloseTo(0.01, 4)
+			expect(result.requestCount).toBe(1)
+			expect(result.hasCostData).toBe(true)
+		})
+
+		it("should handle invalid JSON gracefully", () => {
+			const messages: ExtensionChatMessage[] = [
+				{
+					ts: 1000,
+					type: "say",
+					say: "api_req_started",
+					text: JSON.stringify({ cost: 0.01 }),
+				},
+				{
+					ts: 2000,
+					type: "say",
+					say: "api_req_started",
+					text: "invalid json",
+				},
+				{
+					ts: 3000,
+					type: "say",
+					say: "api_req_started",
+					text: JSON.stringify({ cost: 0.02 }),
+				},
+			]
+			store.set(chatMessagesAtom, messages)
+			const result = calculateSessionCost(store.get(chatMessagesAtom))
+			expect(result.totalCost).toBeCloseTo(0.03, 4)
+			expect(result.requestCount).toBe(2)
+			expect(result.hasCostData).toBe(true)
+		})
+
+		it("should handle messages with empty text", () => {
+			const messages: ExtensionChatMessage[] = [
+				{
+					ts: 1000,
+					type: "say",
+					say: "api_req_started",
+					text: JSON.stringify({ cost: 0.01 }),
+				},
+				{
+					ts: 2000,
+					type: "say",
+					say: "api_req_started",
+					text: "",
+				},
+				{
+					ts: 3000,
+					type: "say",
+					say: "api_req_started",
+					// text is undefined
+				},
+			]
+			store.set(chatMessagesAtom, messages)
+			const result = calculateSessionCost(store.get(chatMessagesAtom))
+			expect(result.totalCost).toBeCloseTo(0.01, 4)
+			expect(result.requestCount).toBe(1)
+			expect(result.hasCostData).toBe(true)
+		})
+	})
+})
+
+/**
+ * Helper function to calculate session cost from messages
+ * This mirrors the logic in useSessionCost hook for testing
+ */
+function calculateSessionCost(messages: ExtensionChatMessage[]) {
+	let totalCost = 0
+	let requestCount = 0
+
+	for (const message of messages) {
+		if (message.say === "api_req_started" && message.text) {
+			try {
+				const data = JSON.parse(message.text)
+				if (typeof data.cost === "number") {
+					totalCost += data.cost
+					requestCount++
+				}
+			} catch {
+				// Ignore parse errors
+			}
+		}
+	}
+
+	return {
+		totalCost,
+		requestCount,
+		hasCostData: requestCount > 0,
+	}
+}

--- a/cli/src/state/hooks/index.ts
+++ b/cli/src/state/hooks/index.ts
@@ -69,3 +69,7 @@ export type { UseFollowupSuggestionsReturn } from "./useFollowupSuggestions.js"
 export { useFollowupCIResponse } from "./useFollowupCIResponse.js"
 export { useTerminal } from "./useTerminal.js"
 export { useFollowupHandler } from "./useFollowupHandler.js"
+
+// Session cost hooks
+export { useSessionCost, formatSessionCost } from "./useSessionCost.js"
+export type { SessionCostInfo } from "./useSessionCost.js"

--- a/cli/src/state/hooks/useSessionCost.ts
+++ b/cli/src/state/hooks/useSessionCost.ts
@@ -1,0 +1,66 @@
+/**
+ * Hook to calculate total session cost from api_req_started messages
+ * Aggregates all API request costs into a single session total
+ */
+
+import { useMemo } from "react"
+import { useAtomValue } from "jotai"
+import { chatMessagesAtom } from "../atoms/extension.js"
+
+export interface SessionCostInfo {
+	/** Total cost of all API requests in the session */
+	totalCost: number
+	/** Number of completed API requests */
+	requestCount: number
+	/** Whether any cost data is available */
+	hasCostData: boolean
+}
+
+/**
+ * Calculate total session cost from all api_req_started messages
+ * Only counts completed requests (those with a cost field)
+ */
+export function useSessionCost(): SessionCostInfo {
+	const messages = useAtomValue(chatMessagesAtom)
+
+	return useMemo(() => {
+		let totalCost = 0
+		let requestCount = 0
+
+		for (const message of messages) {
+			if (message.say === "api_req_started" && message.text) {
+				try {
+					const data = JSON.parse(message.text)
+					if (typeof data.cost === "number") {
+						totalCost += data.cost
+						requestCount++
+					}
+				} catch {
+					// Ignore parse errors
+				}
+			}
+		}
+
+		return {
+			totalCost,
+			requestCount,
+			hasCostData: requestCount > 0,
+		}
+	}, [messages])
+}
+
+/**
+ * Format cost for display
+ * @param cost - Cost in dollars
+ * @returns Formatted cost string (e.g., "$0.0123")
+ */
+export function formatSessionCost(cost: number): string {
+	if (cost === 0) {
+		return "$0.00"
+	}
+	// Show 4 decimal places for small costs, 2 for larger
+	if (cost < 0.01) {
+		return `$${cost.toFixed(4)}`
+	}
+	return `$${cost.toFixed(2)}`
+}

--- a/cli/src/state/hooks/useSessionCost.ts
+++ b/cli/src/state/hooks/useSessionCost.ts
@@ -48,15 +48,8 @@ export function useSessionCost(): SessionCostInfo {
 /**
  * Format cost for display
  * @param cost - Cost in dollars
- * @returns Formatted cost string (e.g., "$0.0123")
+ * @returns Formatted cost string (e.g., "$1.23")
  */
 export function formatSessionCost(cost: number): string {
-	if (cost === 0) {
-		return "$0.00"
-	}
-	// Show 4 decimal places for small costs, 2 for larger
-	if (cost < 0.01) {
-		return `$${cost.toFixed(4)}`
-	}
 	return `$${cost.toFixed(2)}`
 }

--- a/cli/src/state/hooks/useSessionCost.ts
+++ b/cli/src/state/hooks/useSessionCost.ts
@@ -29,14 +29,10 @@ export function useSessionCost(): SessionCostInfo {
 
 		for (const message of messages) {
 			if (message.say === "api_req_started" && message.text) {
-				try {
-					const data = JSON.parse(message.text)
-					if (typeof data.cost === "number") {
-						totalCost += data.cost
-						requestCount++
-					}
-				} catch {
-					// Ignore parse errors
+				const data = JSON.parse(message.text)
+				if (typeof data.cost === "number") {
+					totalCost += data.cost
+					requestCount++
 				}
 			}
 		}

--- a/cli/src/ui/components/StatusBar.tsx
+++ b/cli/src/ui/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 /**
- * StatusBar component - displays project info, git branch, mode, model, and context usage
+ * StatusBar component - displays project info, git branch, mode, model, context usage, and session cost
  */
 
 import React, { useEffect, useMemo, useState } from "react"
@@ -16,6 +16,7 @@ import {
 } from "../../state/atoms/index.js"
 import { useGitInfo } from "../../state/hooks/useGitInfo.js"
 import { useContextUsage } from "../../state/hooks/useContextUsage.js"
+import { useSessionCost, formatSessionCost } from "../../state/hooks/useSessionCost.js"
 import { useTheme } from "../../state/hooks/useTheme.js"
 import { formatContextUsage } from "../../utils/context.js"
 import {
@@ -110,6 +111,9 @@ export const StatusBar: React.FC = () => {
 
 	// Calculate context usage
 	const contextUsage = useContextUsage(messages, apiConfig)
+
+	// Calculate session cost
+	const sessionCost = useSessionCost()
 
 	const [isWorktree, setIsWorktree] = useState(false)
 
@@ -217,6 +221,16 @@ export const StatusBar: React.FC = () => {
 				<Text color={contextColor} bold>
 					{contextText}
 				</Text>
+
+				{/* Session Cost */}
+				{sessionCost.hasCostData && (
+					<>
+						<Text color={theme.ui.text.dimmed} dimColor>
+							{" | "}
+						</Text>
+						<Text color={theme.semantic.info}>{formatSessionCost(sessionCost.totalCost)}</Text>
+					</>
+				)}
 			</Box>
 		</Box>
 	)

--- a/cli/src/ui/components/__tests__/StatusBar.test.tsx
+++ b/cli/src/ui/components/__tests__/StatusBar.test.tsx
@@ -16,6 +16,14 @@ vi.mock("jotai")
 
 vi.mock("../../../state/hooks/useGitInfo.js")
 vi.mock("../../../state/hooks/useContextUsage.js")
+vi.mock("../../../state/hooks/useSessionCost.js", () => ({
+	useSessionCost: vi.fn(() => ({
+		totalCost: 0,
+		requestCount: 0,
+		hasCostData: false,
+	})),
+	formatSessionCost: vi.fn((cost: number) => `$${cost.toFixed(2)}`),
+}))
 vi.mock("../../../utils/git.js", () => ({
 	isGitWorktree: vi.fn(),
 }))

--- a/cli/src/ui/messages/extension/say/SayApiReqStartedMessage.tsx
+++ b/cli/src/ui/messages/extension/say/SayApiReqStartedMessage.tsx
@@ -5,27 +5,25 @@ import { parseApiReqInfo } from "../utils.js"
 import { useTheme } from "../../../../state/hooks/useTheme.js"
 
 /**
- * Display API request status (streaming/completed/failed/cancelled)
+ * Display API request status (only for failed/cancelled states)
+ *
+ * In-progress and completed states are no longer shown individually.
+ * The total session cost is displayed in the StatusBar instead.
+ * This reduces visual noise and provides a cleaner user experience.
  */
 export const SayApiReqStartedMessage: React.FC<MessageComponentProps> = ({ message }) => {
 	const theme = useTheme()
 	const apiInfo = parseApiReqInfo(message)
 
-	// In-progress state
-	// NOTE: api_req_started is often sent as a non-partial placeholder before cost/usage is known.
-	// In the CLI we treat "no completion indicators" as still in progress.
+	// In-progress state - don't show anything (thinking spinner is enough)
 	if (
 		message.partial ||
 		(!apiInfo?.streamingFailedMessage && !apiInfo?.cancelReason && apiInfo?.cost === undefined)
 	) {
-		return (
-			<Box marginY={1}>
-				<Text color={theme.semantic.info}>⟳ API Request in progress...</Text>
-			</Box>
-		)
+		return null
 	}
 
-	// Failed state
+	// Failed state - show error message
 	if (apiInfo?.streamingFailedMessage) {
 		return (
 			<Box flexDirection="column" marginY={1}>
@@ -41,7 +39,7 @@ export const SayApiReqStartedMessage: React.FC<MessageComponentProps> = ({ messa
 		)
 	}
 
-	// Cancelled state
+	// Cancelled state - show cancellation message
 	if (apiInfo?.cancelReason) {
 		return (
 			<Box flexDirection="column" marginY={1}>
@@ -59,23 +57,6 @@ export const SayApiReqStartedMessage: React.FC<MessageComponentProps> = ({ messa
 		)
 	}
 
-	// Completed state
-	return (
-		<Box marginY={1}>
-			<Text color={theme.semantic.success} bold>
-				✓ API Request
-			</Text>
-			{apiInfo?.cost !== undefined && (
-				<>
-					<Text color={theme.semantic.info}> - Cost: ${apiInfo.cost.toFixed(4)}</Text>
-					{apiInfo.usageMissing && (
-						<Text color={theme.ui.text.dimmed} dimColor>
-							{" "}
-							(estimated)
-						</Text>
-					)}
-				</>
-			)}
-		</Box>
-	)
+	// Completed state - don't show anything (total cost shown in StatusBar)
+	return null
 }


### PR DESCRIPTION
## Summary

Improves the CLI UI by showing total session cost in the status bar instead of per-request costs, and removes the "API Request  in progress" messages for a cleaner user experience.

<img width="161" height="133" alt="image" src="https://github.com/user-attachments/assets/24ffcd3e-e854-428c-90b7-d2ce786f249d" />


## Changes

### New Features
- **Session cost display in StatusBar**: Shows the total accumulated cost of all API requests in the current session
- **New `useSessionCost` hook**: Calculates total session cost from `api_req_started` messages

### Removed
- **"API Request in progress" messages**: The thinking spinner is sufficient feedback for the user
- **Per-request cost display**: Individual request costs are no longer shown; only the session total is displayed

 ### Files Changed
 - `.changeset/cli-session-cost-display.md` - Changeset for the patch
 - `cli/src/state/hooks/useSessionCost.ts` - New hook to calculate session cost
 - `cli/src/state/hooks/__tests__/useSessionCost.test.ts` - Tests for the new hook
 - `cli/src/state/hooks/index.ts` - Export the new hook
 - `cli/src/ui/components/StatusBar.tsx` - Display session cost
 - `cli/src/ui/components/__tests__/StatusBar.test.tsx` - Mock the new hook
 - `cli/src/ui/messages/extension/say/SayApiReqStartedMessage.tsx` - Return null for in-progress/completed states
