### PR TITLE
fix(cli): Windows CLI auth provider list empty & crashes with 'Provider not found'

### DIFF
--- a/.changeset/fix-cli-interactive-prompts-windows.md
+++ b/.changeset/fix-cli-interactive-prompts-windows.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix CLI interactive prompts (arrow key navigation) not working on Windows
+
+The inquirer v13+ upgrade introduced stricter TTY raw mode requirements. This fix ensures raw mode is properly enabled before inquirer prompts, restoring arrow key navigation in list selections like provider choice during `kilocode auth`.

--- a/cli/src/auth/index.ts
+++ b/cli/src/auth/index.ts
@@ -1,6 +1,7 @@
 import inquirer from "inquirer"
 import { loadConfig, saveConfig, CLIConfig } from "../config/index.js"
 import { authProviders } from "./providers/index.js"
+import { withRawMode } from "./utils/terminal.js"
 
 /**
  * Main authentication wizard
@@ -17,15 +18,19 @@ export default async function authWizard(): Promise<void> {
 		}))
 
 		// Prompt user to select a provider
-		const { selectedProvider } = await inquirer.prompt<{ selectedProvider: string }>([
-			{
-				type: "list",
-				name: "selectedProvider",
-				message: "Please select which provider you would like to use:",
-				choices: providerChoices,
-				loop: false,
-			},
-		])
+		// Use withRawMode to ensure arrow key navigation works in list prompts
+		// (required for inquirer v13+ which uses @inquirer/prompts internally)
+		const { selectedProvider } = await withRawMode(() =>
+			inquirer.prompt<{ selectedProvider: string }>([
+				{
+					type: "list",
+					name: "selectedProvider",
+					message: "Please select which provider you would like to use:",
+					choices: providerChoices,
+					loop: false,
+				},
+			]),
+		)
 
 		// Find the selected provider
 		const provider = authProviders.find((p) => p.value === selectedProvider)

--- a/cli/src/auth/providers/factory.ts
+++ b/cli/src/auth/providers/factory.ts
@@ -4,6 +4,7 @@ import { PROVIDER_REQUIRED_FIELDS } from "../../constants/providers/validation.j
 import { FIELD_REGISTRY, isOptionalField, getProviderDefaultModel } from "../../constants/providers/settings.js"
 import { PROVIDER_LABELS } from "../../constants/providers/labels.js"
 import inquirer from "inquirer"
+import { withRawMode } from "../utils/terminal.js"
 
 /**
  * Creates a generic authentication function for a provider
@@ -69,7 +70,9 @@ function createGenericAuthFunction(providerName: ProviderName) {
 		}
 
 		// Prompt user for all fields
-		const answers = await inquirer.prompt(prompts)
+		// Use withRawMode to ensure arrow key navigation works in list prompts
+		// (required for inquirer v13+ which uses @inquirer/prompts internally)
+		const answers = await withRawMode(() => inquirer.prompt(prompts))
 
 		// Build provider config
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cli/src/auth/providers/kilocode/shared.ts
+++ b/cli/src/auth/providers/kilocode/shared.ts
@@ -4,6 +4,7 @@ import { z } from "zod"
 import inquirer from "inquirer"
 import { logs } from "../../../services/logs.js"
 import type { KilocodeOrganization, KilocodeProfileData } from "../../types.js"
+import { withRawMode } from "../../utils/terminal.js"
 
 const API_TIMEOUT_MS = 5000
 
@@ -132,14 +133,18 @@ export async function promptOrganizationSelection(organizations: KilocodeOrganiz
 		})),
 	]
 
-	const { accountType } = await inquirer.prompt<{ accountType: string }>([
-		{
-			type: "list",
-			name: "accountType",
-			message: "Select account type:",
-			choices: accountChoices,
-		},
-	])
+	// Use withRawMode to ensure arrow key navigation works in list prompts
+	// (required for inquirer v13+ which uses @inquirer/prompts internally)
+	const { accountType } = await withRawMode(() =>
+		inquirer.prompt<{ accountType: string }>([
+			{
+				type: "list",
+				name: "accountType",
+				message: "Select account type:",
+				choices: accountChoices,
+			},
+		]),
+	)
 
 	// Return organization ID if not personal
 	return accountType !== "personal" ? accountType : undefined

--- a/cli/src/auth/providers/kilocode/token-auth.ts
+++ b/cli/src/auth/providers/kilocode/token-auth.ts
@@ -6,6 +6,7 @@ import {
 	promptOrganizationSelection,
 	INVALID_TOKEN_ERROR,
 } from "./shared.js"
+import { withRawMode } from "../../utils/terminal.js"
 
 /**
  * Execute the manual token authentication flow
@@ -22,14 +23,18 @@ export async function authenticateWithToken(): Promise<AuthResult> {
 
 	// Loop until we get a valid token
 	while (!isValidToken) {
-		const { token } = await inquirer.prompt<{ token: string }>([
-			{
-				type: "password",
-				name: "token",
-				message: "API Key:",
-				mask: true,
-			},
-		])
+		// Use withRawMode to ensure interactive prompts work correctly
+		// (required for inquirer v13+ which uses @inquirer/prompts internally)
+		const { token } = await withRawMode(() =>
+			inquirer.prompt<{ token: string }>([
+				{
+					type: "password",
+					name: "token",
+					message: "API Key:",
+					mask: true,
+				},
+			]),
+		)
 
 		kilocodeToken = token
 

--- a/cli/src/auth/utils/__tests__/terminal.test.ts
+++ b/cli/src/auth/utils/__tests__/terminal.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { ensureRawMode, withRawMode } from "../terminal.js"
+
+describe("terminal utilities", () => {
+	let originalIsTTY: boolean | undefined
+	let originalIsRaw: boolean | undefined
+	let originalSetRawMode: typeof process.stdin.setRawMode | undefined
+
+	beforeEach(() => {
+		// Store original values
+		originalIsTTY = process.stdin.isTTY
+		originalIsRaw = process.stdin.isRaw
+		originalSetRawMode = process.stdin.setRawMode
+	})
+
+	afterEach(() => {
+		// Restore original values
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: originalIsTTY,
+			writable: true,
+			configurable: true,
+		})
+		Object.defineProperty(process.stdin, "isRaw", {
+			value: originalIsRaw,
+			writable: true,
+			configurable: true,
+		})
+		if (originalSetRawMode) {
+			process.stdin.setRawMode = originalSetRawMode
+		}
+		vi.restoreAllMocks()
+	})
+
+	describe("ensureRawMode", () => {
+		it("should return noop cleanup when stdin is not a TTY", () => {
+			Object.defineProperty(process.stdin, "isTTY", {
+				value: false,
+				writable: true,
+				configurable: true,
+			})
+
+			const cleanup = ensureRawMode()
+
+			// Should return a function that does nothing
+			expect(typeof cleanup).toBe("function")
+			cleanup() // Should not throw
+		})
+
+		it("should return noop cleanup when setRawMode is not available", () => {
+			Object.defineProperty(process.stdin, "isTTY", {
+				value: true,
+				writable: true,
+				configurable: true,
+			})
+			// @ts-expect-error - intentionally setting to undefined for test
+			process.stdin.setRawMode = undefined
+
+			const cleanup = ensureRawMode()
+
+			expect(typeof cleanup).toBe("function")
+			cleanup() // Should not throw
+		})
+
+		it("should enable raw mode when not already enabled", () => {
+			const mockSetRawMode = vi.fn()
+
+			Object.defineProperty(process.stdin, "isTTY", {
+				value: true,
+				writable: true,
+				configurable: true,
+			})
+			Object.defineProperty(process.stdin, "isRaw", {
+				value: false,
+				writable: true,
+				configurable: true,
+			})
+			process.stdin.setRawMode = mockSetRawMode
+
+			const cleanup = ensureRawMode()
+
+			expect(mockSetRawMode).toHaveBeenCalledWith(true)
+			expect(typeof cleanup).toBe("function")
+		})
+
+		it("should not enable raw mode when already enabled", () => {
+			const mockSetRawMode = vi.fn()
+
+			Object.defineProperty(process.stdin, "isTTY", {
+				value: true,
+				writable: true,
+				configurable: true,
+			})
+			Object.defineProperty(process.stdin, "isRaw", {
+				value: true,
+				writable: true,
+				configurable: true,
+			})
+			process.stdin.setRawMode = mockSetRawMode
+
+			const cleanup = ensureRawMode()
+
+			expect(mockSetRawMode).not.toHaveBeenCalled()
+			expect(typeof cleanup).toBe("function")
+		})
+
+		it("should restore raw mode to false on cleanup when it was originally false", () => {
+			const mockSetRawMode = vi.fn()
+
+			Object.defineProperty(process.stdin, "isTTY", {
+				value: true,
+				writable: true,
+				configurable: true,
+			})
+			Object.defineProperty(process.stdin, "isRaw", {
+				value: false,
+				writable: true,
+				configurable: true,
+			})
+			process.stdin.setRawMode = mockSetRawMode
+
+			const cleanup = ensureRawMode()
+			cleanup()
+
+			expect(mockSetRawMode).toHaveBeenCalledTimes(2)
+			expect(mockSetRawMode).toHaveBeenNthCalledWith(1, true)
+			expect(mockSetRawMode).toHaveBeenNthCalledWith(2, false)
+		})
+
+		it("should not restore raw mode on cleanup when it was originally true", () => {
+			const mockSetRawMode = vi.fn()
+
+			Object.defineProperty(process.stdin, "isTTY", {
+				value: true,
+				writable: true,
+				configurable: true,
+			})
+			Object.defineProperty(process.stdin, "isRaw", {
+				value: true,
+				writable: true,
+				configurable: true,
+			})
+			process.stdin.setRawMode = mockSetRawMode
+
+			const cleanup = ensureRawMode()
+			cleanup()
+
+			// Should not have been called at all since raw mode was already enabled
+			expect(mockSetRawMode).not.toHaveBeenCalled()
+		})
+
+		it("should handle setRawMode throwing an error gracefully", () => {
+			const mockSetRawMode = vi.fn().mockImplementation(() => {
+				throw new Error("Cannot set raw mode")
+			})
+
+			Object.defineProperty(process.stdin, "isTTY", {
+				value: true,
+				writable: true,
+				configurable: true,
+			})
+			Object.defineProperty(process.stdin, "isRaw", {
+				value: false,
+				writable: true,
+				configurable: true,
+			})
+			process.stdin.setRawMode = mockSetRawMode
+
+			// Should not throw
+			const cleanup = ensureRawMode()
+			expect(typeof cleanup).toBe("function")
+			cleanup() // Should not throw
+		})
+	})
+
+	describe("withRawMode", () => {
+		it("should call the provided function and return its result", async () => {
+			Object.defineProperty(process.stdin, "isTTY", {
+				value: false,
+				writable: true,
+				configurable: true,
+			})
+
+			const mockFn = vi.fn().mockResolvedValue("test result")
+
+			const result = await withRawMode(mockFn)
+
+			expect(mockFn).toHaveBeenCalled()
+			expect(result).toBe("test result")
+		})
+
+		it("should enable raw mode before calling the function", async () => {
+			const mockSetRawMode = vi.fn()
+			const callOrder: string[] = []
+
+			Object.defineProperty(process.stdin, "isTTY", {
+				value: true,
+				writable: true,
+				configurable: true,
+			})
+			Object.defineProperty(process.stdin, "isRaw", {
+				value: false,
+				writable: true,
+				configurable: true,
+			})
+			process.stdin.setRawMode = mockSetRawMode.mockImplementation(() => {
+				callOrder.push("setRawMode")
+			})
+
+			const mockFn = vi.fn().mockImplementation(async () => {
+				callOrder.push("fn")
+				return "result"
+			})
+
+			await withRawMode(mockFn)
+
+			expect(callOrder).toEqual(["setRawMode", "fn", "setRawMode"])
+		})
+
+		it("should restore raw mode even if the function throws", async () => {
+			const mockSetRawMode = vi.fn()
+
+			Object.defineProperty(process.stdin, "isTTY", {
+				value: true,
+				writable: true,
+				configurable: true,
+			})
+			Object.defineProperty(process.stdin, "isRaw", {
+				value: false,
+				writable: true,
+				configurable: true,
+			})
+			process.stdin.setRawMode = mockSetRawMode
+
+			const mockFn = vi.fn().mockRejectedValue(new Error("Test error"))
+
+			await expect(withRawMode(mockFn)).rejects.toThrow("Test error")
+
+			// Should have called setRawMode twice: once to enable, once to restore
+			expect(mockSetRawMode).toHaveBeenCalledTimes(2)
+			expect(mockSetRawMode).toHaveBeenNthCalledWith(1, true)
+			expect(mockSetRawMode).toHaveBeenNthCalledWith(2, false)
+		})
+	})
+})

--- a/cli/src/auth/utils/terminal.ts
+++ b/cli/src/auth/utils/terminal.ts
@@ -1,0 +1,72 @@
+/**
+ * Terminal utilities for interactive prompts
+ *
+ * The newer versions of inquirer (v13+) use @inquirer/prompts internally,
+ * which requires raw mode to be enabled for interactive features like
+ * arrow key navigation in list prompts to work correctly.
+ *
+ * When stdin is not a TTY or when Node.js loses track of the raw mode state,
+ * the prompts fall back to a non-interactive mode where users must type
+ * their selection instead of using arrow keys.
+ *
+ * This module provides utilities to ensure raw mode is properly enabled
+ * before running inquirer prompts.
+ */
+
+/**
+ * Ensures stdin is in raw mode for interactive prompts.
+ * Returns a cleanup function to restore the original state.
+ *
+ * @returns A cleanup function that restores the original raw mode state
+ */
+export function ensureRawMode(): () => void {
+	// Only attempt to set raw mode if stdin is a TTY
+	if (!process.stdin.isTTY) {
+		return () => {}
+	}
+
+	// Check if setRawMode is available (it should be for TTY streams)
+	if (typeof process.stdin.setRawMode !== "function") {
+		return () => {}
+	}
+
+	// Store the original raw mode state
+	const wasRawMode = process.stdin.isRaw
+
+	// Enable raw mode if not already enabled
+	if (!wasRawMode) {
+		try {
+			process.stdin.setRawMode(true)
+		} catch (_error) {
+			// If setting raw mode fails, just continue without it
+			return () => {}
+		}
+	}
+
+	// Return cleanup function
+	return () => {
+		if (!wasRawMode && process.stdin.isTTY && typeof process.stdin.setRawMode === "function") {
+			try {
+				process.stdin.setRawMode(false)
+			} catch (_cleanupError) {
+				// Ignore errors during cleanup - terminal state restoration is best-effort
+			}
+		}
+	}
+}
+
+/**
+ * Wraps an async function to ensure raw mode is enabled during its execution.
+ * This is useful for wrapping inquirer prompt calls.
+ *
+ * @param fn - The async function to wrap
+ * @returns The result of the wrapped function
+ */
+export async function withRawMode<T>(fn: () => Promise<T>): Promise<T> {
+	const cleanup = ensureRawMode()
+	try {
+		return await fn()
+	} finally {
+		cleanup()
+	}
+}

--- a/cli/src/auth/utils/terminal.ts
+++ b/cli/src/auth/utils/terminal.ts
@@ -37,8 +37,10 @@ export function ensureRawMode(): () => void {
 	if (!wasRawMode) {
 		try {
 			process.stdin.setRawMode(true)
-		} catch (_error) {
-			// If setting raw mode fails, just continue without it
+		} catch (error) {
+			// If setting raw mode fails, log and continue without it
+			// The CLI will fall back to non-interactive mode
+			console.debug("Failed to enable terminal raw mode:", error)
 			return () => {}
 		}
 	}
@@ -48,8 +50,9 @@ export function ensureRawMode(): () => void {
 		if (!wasRawMode && process.stdin.isTTY && typeof process.stdin.setRawMode === "function") {
 			try {
 				process.stdin.setRawMode(false)
-			} catch (_cleanupError) {
-				// Ignore errors during cleanup - terminal state restoration is best-effort
+			} catch (error) {
+				// Log but don't throw - terminal state restoration is best-effort
+				console.debug("Failed to restore terminal raw mode:", error)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes the Windows CLI authentication issue where `kilocode auth` shows an empty/invisible provider selection list and crashes with "Provider not found" when pressing Enter.

## Root Cause

The inquirer v13+ upgrade introduced stricter TTY raw mode requirements. Without raw mode enabled, the list choices are not rendered properly and users cannot navigate with arrow keys. This affects both Windows and Linux terminals.

## Solution

- Add `cli/src/auth/utils/terminal.ts` with `ensureRawMode()` and `withRawMode()` utilities
- Wrap all inquirer prompts with `withRawMode()` to ensure raw mode is properly enabled before interactive prompts
- Add comprehensive test coverage for the terminal utilities

## Testing

- All 1959 CLI tests pass
- Manual testing on Windows PowerShell and CMD should show provider list correctly

Fixes #5097