### PR TITLE
fix: make MCP transport close fire-and-forget to speed up CLI exit

### DIFF
--- a/.changeset/fix-cli-slow-termination.md
+++ b/.changeset/fix-cli-slow-termination.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": patch
+---
+
+Fix slow CLI termination when pressing Ctrl+C during prompt selection
+
+MCP server connection cleanup now uses fire-and-forget pattern for transport.close() and client.close() calls, which could previously block for 2+ seconds if MCP servers were unresponsive. This ensures fast exit behavior when the user wants to quit quickly.

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -1129,8 +1129,19 @@ export class McpHub {
 		for (const connection of connections) {
 			try {
 				if (connection.type === "connected") {
-					await connection.transport.close()
-					await connection.client.close()
+					// kilocode_change start
+					// Fire-and-forget: don't await close() calls as they can block
+					// waiting for the subprocess to exit. The MCP SDK's transport.close()
+					// waits up to 2 seconds for the process to exit gracefully before
+					// sending SIGTERM, then another 2 seconds before SIGKILL.
+					// This 4+ second delay is unacceptable during CLI shutdown.
+					connection.transport.close().catch((err) => {
+						console.error(`Error closing transport for ${name}:`, err)
+					})
+					connection.client.close().catch((err) => {
+						console.error(`Error closing client for ${name}:`, err)
+					})
+					// kilocode_change end
 				}
 			} catch (error) {
 				console.error(`Failed to close transport for ${name}:`, error)


### PR DESCRIPTION
## Summary

Fixes #5094 - Kilo CLI slow termination when exiting via Ctrl+C while MCP servers are connected.

## Problem

When a user presses Ctrl+C to exit the CLI, the shutdown process was taking 10+ seconds. The root cause was in `McpHub.deleteConnection()` which awaited `transport.close()` and `client.close()` calls.

### MCP SDK's `transport.close()` Implementation

Looking at the MCP SDK source code, `StdioClientTransport.close()` does the following:

```javascript
async close() {
    if (this._process) {
        // Wait up to 2 seconds for graceful exit after stdin.end()
        await Promise.race([closePromise, new Promise(resolve => setTimeout(resolve, 2000))]);
        
        if (processToClose.exitCode === null) {
            processToClose.kill('SIGTERM');
            // Wait another 2 seconds after SIGTERM
            await Promise.race([closePromise, new Promise(resolve => setTimeout(resolve, 2000))]);
        }
        
        if (processToClose.exitCode === null) {
            processToClose.kill('SIGKILL');
        }
    }
}
```

**The SDK waits up to 4 seconds total per MCP server** - 2 seconds for graceful exit, then 2 more seconds after SIGTERM before SIGKILL.

## Solution

Make the `transport.close()` and `client.close()` calls fire-and-forget (don't await them). This is safe because:

1. **The OS will clean up anyway** - When the parent process (Kilo CLI) exits, the OS terminates any orphaned child processes
2. **MCP servers are stateless** - They don't hold critical state that requires graceful shutdown
3. **The close() still runs** - It just runs in the background without blocking the exit

## Changes

- **`src/services/mcp/McpHub.ts`**: Changed `deleteConnection()` to not await the close() calls
- Added changeset for the fix

## Testing

- All 44 MCP-related tests pass
- Manual testing confirms CLI now exits immediately on Ctrl+C