### PR TITLE
fix(core-schemas): upgrade to Zod v4 for CLI compatibility

### DIFF
--- a/.changeset/fix-cli-zod-commander-compat.md
+++ b/.changeset/fix-cli-zod-commander-compat.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/core-schemas": patch
+---
+
+Upgrade to Zod v4 for consistency with CLI package

--- a/packages/core-schemas/package.json
+++ b/packages/core-schemas/package.json
@@ -21,7 +21,7 @@
 		"clean": "rimraf dist .turbo"
 	},
 	"dependencies": {
-		"zod": "^3.25.61"
+		"zod": "^4.3.5"
 	},
 	"peerDependencies": {
 		"@roo-code/types": "workspace:^"

--- a/packages/core-schemas/src/auth/kilocode.ts
+++ b/packages/core-schemas/src/auth/kilocode.ts
@@ -33,9 +33,9 @@ export const pollingOptionsSchema = z.object({
 	/** Maximum number of attempts before timeout */
 	maxAttempts: z.number(),
 	/** Function to execute on each poll */
-	pollFn: z.function().args().returns(z.promise(z.unknown())),
+	pollFn: z.function({ input: z.tuple([]), output: z.promise(z.unknown()) }),
 	/** Optional callback for progress updates */
-	onProgress: z.function().args(z.number(), z.number()).returns(z.void()).optional(),
+	onProgress: z.function({ input: z.tuple([z.number(), z.number()]), output: z.void() }).optional(),
 })
 
 /**

--- a/packages/core-schemas/src/config/cli-config.ts
+++ b/packages/core-schemas/src/config/cli-config.ts
@@ -20,7 +20,7 @@ export const cliConfigSchema = z.object({
 	providers: z.array(providerConfigSchema),
 	autoApproval: autoApprovalConfigSchema.optional(),
 	theme: themeIdSchema.optional(),
-	customThemes: z.record(themeSchema).optional(),
+	customThemes: z.record(z.string(), themeSchema).optional(),
 	maxConcurrentFileReads: z.number().min(1).default(DEFAULT_MAX_CONCURRENT_FILE_READS).optional(),
 })
 

--- a/packages/core-schemas/src/config/provider.ts
+++ b/packages/core-schemas/src/config/provider.ts
@@ -48,7 +48,7 @@ export const openAIProviderSchema = baseProviderSchema.extend({
 	openAiUseAzure: z.boolean().optional(),
 	azureApiVersion: z.string().optional(),
 	openAiStreamingEnabled: z.boolean().optional(),
-	openAiHeaders: z.record(z.string()).optional(),
+	openAiHeaders: z.record(z.string(), z.string()).optional(),
 })
 
 // OpenRouter provider

--- a/packages/core-schemas/src/mcp/server.ts
+++ b/packages/core-schemas/src/mcp/server.ts
@@ -6,7 +6,7 @@ import { z } from "zod"
 export const mcpToolSchema = z.object({
 	name: z.string(),
 	description: z.string().optional(),
-	inputSchema: z.record(z.unknown()).optional(),
+	inputSchema: z.record(z.string(), z.unknown()).optional(),
 })
 
 /**
@@ -29,7 +29,7 @@ export const mcpServerStatusSchema = z.enum(["connected", "connecting", "disconn
  */
 export const mcpServerSchema = z.object({
 	name: z.string(),
-	config: z.record(z.unknown()),
+	config: z.record(z.string(), z.unknown()),
 	status: mcpServerStatusSchema,
 	tools: z.array(mcpToolSchema).optional(),
 	resources: z.array(mcpResourceSchema).optional(),

--- a/packages/core-schemas/src/messages/extension.ts
+++ b/packages/core-schemas/src/messages/extension.ts
@@ -6,6 +6,7 @@ import { z } from "zod"
 export const organizationAllowListSchema = z.object({
 	allowAll: z.boolean(),
 	providers: z.record(
+		z.string(),
 		z.object({
 			allowAll: z.boolean(),
 			models: z.array(z.string()).optional(),
@@ -23,7 +24,7 @@ export const extensionMessageSchema = z.object({
 	state: z.unknown().optional(), // ExtensionState
 	images: z.array(z.string()).optional(),
 	chatMessages: z.array(z.unknown()).optional(), // ExtensionChatMessage[]
-	values: z.record(z.unknown()).optional(),
+	values: z.record(z.string(), z.unknown()).optional(),
 })
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1545,8 +1545,8 @@ importers:
   packages/core-schemas:
     dependencies:
       zod:
-        specifier: ^3.25.61
-        version: 3.25.76
+        specifier: ^4.3.5
+        version: 4.3.5
     devDependencies:
       '@roo-code/config-eslint':
         specifier: workspace:^


### PR DESCRIPTION
## Summary

Upgrades `@kilocode/core-schemas` from Zod v3 to Zod v4 to ensure compatibility with the CLI package.

## Problem

The CLI package uses Zod v4 (`^4.3.5`) while `@kilocode/core-schemas` was using Zod v3 (`^3.25.61`). This version mismatch caused schema validation failures because Zod v3 and v4 have incompatible APIs:

- **Zod v3**: `z.function().args().returns()` (chained builder pattern)
- **Zod v4**: `z.function({ input, output })` (options object pattern)

- **Zod v3**: `z.record(valueSchema)` (single argument)
- **Zod v4**: `z.record(keySchema, valueSchema)` (two arguments required)

When the CLI imported schemas from `@kilocode/core-schemas`, the Zod v3 syntax would fail at runtime because the CLI's Zod v4 doesn't have the `.args()` and `.returns()` methods.

## Solution

Upgraded `@kilocode/core-schemas` to Zod v4 and updated all schema definitions to use the new API:

1. **Function schemas**: Changed from `z.function().args(...).returns(...)` to `z.function({ input: z.tuple([...]), output: ... })`

2. **Record schemas**: Changed from `z.record(valueSchema)` to `z.record(z.string(), valueSchema)`

## Files Changed

- `packages/core-schemas/package.json` - Updated zod dependency to `^4.3.5`
- `packages/core-schemas/src/auth/kilocode.ts` - Updated function schema syntax
- `packages/core-schemas/src/config/cli-config.ts` - Updated record schema syntax
- `packages/core-schemas/src/config/provider.ts` - Updated record schema syntax
- `packages/core-schemas/src/mcp/server.ts` - Updated record schema syntax
- `packages/core-schemas/src/messages/extension.ts` - Updated record schema syntax

## Testing

- ✅ `@kilocode/core-schemas` type checking passes
- ✅ CLI builds successfully
- ✅ All 1949 CLI tests pass