### PR TITLE
fix(cli): handle empty or corrupted config files gracefully

### DIFF
--- a/.changeset/fix-cli-empty-config-json.md
+++ b/.changeset/fix-cli-empty-config-json.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix CLI crash when config file is empty or contains invalid JSON

--- a/cli/src/config/__tests__/persistence.test.ts
+++ b/cli/src/config/__tests__/persistence.test.ts
@@ -190,6 +190,64 @@ describe("Config Persistence", () => {
 			expect(result.validation.errors).toBeDefined()
 			expect(result.validation.errors!.length).toBeGreaterThan(0)
 		})
+
+		it("should return default config when config file is empty", async () => {
+			// Create an empty config file
+			await ensureConfigDir()
+			await fs.writeFile(TEST_CONFIG_FILE, "")
+
+			// Verify file exists
+			const exists = await configExists()
+			expect(exists).toBe(true)
+
+			// Load config - should return default config instead of throwing
+			const result = await loadConfig()
+			expect(result.config).toEqual(DEFAULT_CONFIG)
+			// Default config has empty credentials, so validation should fail
+			expect(result.validation.valid).toBe(false)
+		})
+
+		it("should return default config when config file contains only whitespace", async () => {
+			// Create a config file with only whitespace
+			await ensureConfigDir()
+			await fs.writeFile(TEST_CONFIG_FILE, "   \n\t  \n  ")
+
+			// Verify file exists
+			const exists = await configExists()
+			expect(exists).toBe(true)
+
+			// Load config - should return default config instead of throwing
+			const result = await loadConfig()
+			expect(result.config).toEqual(DEFAULT_CONFIG)
+		})
+
+		it("should return default config when config file contains invalid JSON", async () => {
+			// Create a config file with invalid JSON
+			await ensureConfigDir()
+			await fs.writeFile(TEST_CONFIG_FILE, '{ "version": "1.0.0", invalid json }')
+
+			// Verify file exists
+			const exists = await configExists()
+			expect(exists).toBe(true)
+
+			// Load config - should return default config instead of throwing
+			const result = await loadConfig()
+			expect(result.config).toEqual(DEFAULT_CONFIG)
+		})
+
+		it("should return default config when config file is truncated JSON", async () => {
+			// Create a config file with truncated JSON (simulating interrupted write)
+			await ensureConfigDir()
+			await fs.writeFile(TEST_CONFIG_FILE, '{ "version": "1.0.0", "mode": "code"')
+
+			// Verify file exists
+			const exists = await configExists()
+			expect(exists).toBe(true)
+
+			// Load config - should return default config instead of throwing
+			const result = await loadConfig()
+			expect(result.config).toEqual(DEFAULT_CONFIG)
+		})
 	})
 
 	describe("saveConfig", () => {


### PR DESCRIPTION
## Summary

Fixes CLI crash when the config file (`~/.kilocode/cli/config.json`) is empty or contains invalid JSON.

## Problem

The CLI would crash with `SyntaxError: Unexpected end of JSON input` when:
- The config file was empty (0 bytes)
- The config file contained only whitespace
- The config file contained invalid/truncated JSON (e.g., from an interrupted write)

This could happen due to race conditions when multiple CLI sessions write to the shared config file, or when a CLI process was interrupted during config save.

## Solution

Added defensive checks in `loadConfig()`:
1. Check for empty/whitespace-only content before parsing
2. Wrap `JSON.parse` in try-catch to handle malformed JSON
3. Return default config instead of crashing in both cases

## User Impact

**Before:** CLI crashes, user must manually delete config file and re-authenticate

**After:** CLI logs a warning and continues with default config, prompting re-authentication if needed. No manual intervention required.

## Testing

Added 4 new test cases covering:
- Empty config file
- Whitespace-only config file
- Invalid JSON
- Truncated JSON (simulating interrupted writes)