### PR TITLE
fix(cli): make .env file optional for CLI startup

### DIFF
--- a/.changeset/cli-optional-env-file.md
+++ b/.changeset/cli-optional-env-file.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Make .env file optional in CLI - users can configure via KILO\_\* environment variables instead

--- a/cli/src/utils/__tests__/env-loader.test.ts
+++ b/cli/src/utils/__tests__/env-loader.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for env-loader utilities
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { existsSync } from "fs"
+import { config } from "dotenv"
+
+// Mock fs and dotenv modules
+vi.mock("fs", () => ({
+	existsSync: vi.fn(),
+}))
+
+vi.mock("dotenv", () => ({
+	config: vi.fn(),
+}))
+
+describe("loadEnvFile", () => {
+	const mockExistsSync = vi.mocked(existsSync)
+	const mockConfig = vi.mocked(config)
+	let loadEnvFile: typeof import("../env-loader.js").loadEnvFile
+
+	beforeEach(async () => {
+		vi.clearAllMocks()
+		vi.resetModules() // Reset module cache to ensure fresh import with mocks
+		// Use vi.spyOn for safer mocking that auto-restores
+		vi.spyOn(process, "exit").mockImplementation(() => undefined as never)
+		vi.spyOn(console, "error").mockImplementation(() => {})
+		// Import module after mocks are set up
+		const module = await import("../env-loader.js")
+		loadEnvFile = module.loadEnvFile
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("should return early without logging when .env file does not exist", () => {
+		mockExistsSync.mockReturnValue(false)
+
+		loadEnvFile()
+
+		expect(mockExistsSync).toHaveBeenCalledWith(expect.stringContaining(".env"))
+		expect(mockConfig).not.toHaveBeenCalled()
+		expect(console.error).not.toHaveBeenCalled()
+		expect(process.exit).not.toHaveBeenCalled()
+	})
+
+	it("should load .env file when it exists", () => {
+		mockExistsSync.mockReturnValue(true)
+		mockConfig.mockReturnValue({ parsed: { TEST_VAR: "value" } })
+
+		loadEnvFile()
+
+		expect(mockExistsSync).toHaveBeenCalledWith(expect.stringContaining(".env"))
+		expect(mockConfig).toHaveBeenCalledWith({ path: expect.stringContaining(".env") })
+		expect(process.exit).not.toHaveBeenCalled()
+	})
+
+	it("should exit with error when .env file exists but has parsing errors", () => {
+		mockExistsSync.mockReturnValue(true)
+		mockConfig.mockReturnValue({ error: new Error("Parse error") })
+
+		loadEnvFile()
+
+		expect(mockExistsSync).toHaveBeenCalledWith(expect.stringContaining(".env"))
+		expect(mockConfig).toHaveBeenCalledWith({ path: expect.stringContaining(".env") })
+		expect(console.error).toHaveBeenCalledWith("Error loading .env file: Parse error")
+		expect(process.exit).toHaveBeenCalledWith(1)
+	})
+})

--- a/cli/src/utils/env-loader.ts
+++ b/cli/src/utils/env-loader.ts
@@ -7,22 +7,22 @@ declare const __dirname: string
 
 /**
  * Loads the .env file from the dist directory (where binaries are located)
- * Throws an error if the .env file doesn't exist
+ * The .env file is optional - users can configure via KILO_* environment variables instead
  */
 export function loadEnvFile(): void {
 	// In bundled output, __dirname points to the dist directory where index.js is located
 	// The .env file should be in the same directory
 	const envPath = join(__dirname, ".env")
 
-	// Check if .env file exists
+	// .env is optional - users can configure via KILO_* environment variables instead
 	if (!existsSync(envPath)) {
-		console.error(`Error: Required .env file not found at: ${envPath}`)
-		process.exit(1)
+		return
 	}
 
 	// Load the .env file
 	const result = config({ path: envPath })
 
+	// If .env exists but has parsing errors, report the error
 	if (result.error) {
 		console.error(`Error loading .env file: ${result.error.message}`)
 		process.exit(1)


### PR DESCRIPTION
## Summary
- Make `.env` file optional in CLI - users can configure via `KILO_*` environment variables instead
- Previously, CLI would exit with error if `.env` file was not found
- Now it simply returns early and continues execution

## Test plan
- [x] Added unit tests for `loadEnvFile()` function
- [x] Tests pass locally (`pnpm test cli/src/utils/__tests__/env-loader.test.ts`)