### PR TITLE
Add "initial response time" as a metric

### DIFF
--- a/apps/kilocode-docs/docs/contributing/architecture/model-o11y.md
+++ b/apps/kilocode-docs/docs/contributing/architecture/model-o11y.md
@@ -92,6 +92,7 @@ Paging should **only occur on Recommended Models when using the Kilo Gateway**. 
 **Per-session (aggregated at session close or timeout):**
 
 - Session duration
+- Time from user input to first model response
 - Total turns/steps
 - Total tool calls by tool type
 - Total errors by error type


### PR DESCRIPTION
We have gotten complaints that Kilo can "feel" slow, and this has been the initial response time to the user's request. We should try to track this.