### PR TITLE
Add more fuzzy search separators, fix free search

### DIFF
--- a/.changeset/silver-rivers-smile.md
+++ b/.changeset/silver-rivers-smile.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix model search matching for free tags.

--- a/webview-ui/src/lib/__tests__/word-boundary-fzf.spec.ts
+++ b/webview-ui/src/lib/__tests__/word-boundary-fzf.spec.ts
@@ -105,6 +105,14 @@ describe("Fzf - Word Boundary Matching", () => {
 
 			expect(results).toHaveLength(1)
 		})
+
+		it("should recognize parentheses as word separators", () => {
+			const items = [{ id: 1, name: "xAI: Grok Code Fast 1 (free)" }]
+			const fzf = new Fzf(items, { selector: (item) => item.name })
+			const results = fzf.find("free")
+
+			expect(results).toHaveLength(1)
+		})
 	})
 
 	describe("Empty and whitespace queries", () => {

--- a/webview-ui/src/lib/word-boundary-fzf.ts
+++ b/webview-ui/src/lib/word-boundary-fzf.ts
@@ -19,8 +19,8 @@ interface FzfResult<T> {
 
 // Single source of truth for word boundary characters
 // - Split at positions before uppercase letters (camelCase/PascalCase: gitRebase → git, Rebase)
-// - Split at existing delimiters: hyphen, underscore, dot, colon, whitespace, forward/back slash
-const WORD_BOUNDARY_REGEX = /(?=[A-Z])|[-_.:\s/\\]+/
+// - Split at existing delimiters: hyphen, underscore, dot, colon, whitespace, forward/back slash, brackets/parentheses
+const WORD_BOUNDARY_REGEX = /(?=[A-Z])|[[\]_.:\s/\\(){}-]+/
 
 export class Fzf<T> {
 	private items: T[]


### PR DESCRIPTION
Adds additional separators for fuzzy search:
* Square brackets `[ ]`
* Parenthesis `( )`
* Curly braces `{ }`

This fixes searching for `free` in the model search, as now `free` is detected as its own word. (Before it was `(free)`).

Mistral worked prior, because the public id was had `:free` at the end. Grok Code did not.
* Mistral: https://github.com/Kilo-Org/kilocode-backend/blob/e65ac57e15c5917cad6d9522eea40cfc683a460a/src/lib/providers/mistral.ts#L6
* Grok Code: https://github.com/Kilo-Org/kilocode-backend/blob/e65ac57e15c5917cad6d9522eea40cfc683a460a/src/lib/providers/xai.ts#L5