### PR TITLE
fix(ghost): respect enableCodeActions setting for code actions

### DIFF
--- a/.changeset/fix-ghost-respect-setting.md
+++ b/.changeset/fix-ghost-respect-setting.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix(ghost): respect setting (#5120)

--- a/src/services/ghost/GhostCodeActionProvider.ts
+++ b/src/services/ghost/GhostCodeActionProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode"
 import { t } from "../../i18n"
+import { Package } from "../../shared/package"
 
 export class GhostCodeActionProvider implements vscode.CodeActionProvider {
 	public readonly providedCodeActionKinds = {
@@ -12,6 +13,11 @@ export class GhostCodeActionProvider implements vscode.CodeActionProvider {
 		_context: vscode.CodeActionContext,
 		_token: vscode.CancellationToken,
 	): vscode.ProviderResult<(vscode.CodeAction | vscode.Command)[]> {
+		// Check if code actions are disabled in settings
+		if (!vscode.workspace.getConfiguration(Package.name).get<boolean>("enableCodeActions", true)) {
+			return []
+		}
+
 		const action = new vscode.CodeAction(
 			t("kilocode:ghost.codeAction.title"),
 			this.providedCodeActionKinds["quickfix"],


### PR DESCRIPTION
## Summary

Fixes #5042 - The GhostCodeActionProvider was not respecting the enableCodeActions setting.

## Problem

When users disabled code actions in settings, the "Suggested Edits" action (provided by GhostCodeActionProvider for autocomplete) was still appearing in the VS Code lightbulb menu.

## Solution

Added a check at the start of `provideCodeActions` to return an empty array when code actions are disabled, matching the behavior of the main CodeActionProvider.

## Changes

- Added import for `Package` from `../../shared/package`
- Added setting check using `vscode.workspace.getConfiguration(Package.name).get<boolean>("enableCodeActions", true)`
- Returns empty array when disabled

## Testing

1. Disable code actions in Kilo Code settings
2. The "Suggested Edits" action should no longer appear in the lightbulb menu
3. Re-enable code actions
4. The "Suggested Edits" action should appear again

Co-Authored-By: Claude <noreply@anthropic.com>