### PR TITLE
fix(tree-sitter): use console.error for error logging

### DIFF
--- a/.changeset/fix-tree-sitter-error-logging.md
+++ b/.changeset/fix-tree-sitter-error-logging.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix(tree-sitter): error logging (#5121)

--- a/src/services/tree-sitter/index.ts
+++ b/src/services/tree-sitter/index.ts
@@ -336,7 +336,7 @@ async function parseFile(
 		// Process the captures
 		return processCaptures(captures, lines, extLang)
 	} catch (error) {
-		console.log(`Error parsing file: ${error}\n`)
+		console.error(`Error parsing file: ${error}\n`)
 		// Return null on parsing error to avoid showing error messages in the output
 		return null
 	}


### PR DESCRIPTION
## Summary

Changes `console.log` to `console.error` in the tree-sitter parser's error handling to ensure errors are properly logged to the error stream.

## Changes

- `src/services/tree-sitter/index.ts`: Changed `console.log` to `console.error` for error message in catch block

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvement (non-breaking change that improves code quality)

## Test Plan

This is a simple logging fix. The existing code behavior is unchanged - errors are still caught and logged, just to the proper stream (`console.error` instead of `console.log`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)