### PR TITLE
fix(storage): add error logging to getStorageBasePathSync catch block

### DIFF
--- a/.changeset/fix-storage-add-error-logging.md
+++ b/.changeset/fix-storage-add-error-logging.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix(storage): add error logging (#5124)

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -68,6 +68,8 @@ export function getStorageBasePathSync(defaultPath: string): string {
 		fsSync.rmSync(testFile)
 		return customStoragePath
 	} catch (error) {
+		// Log error and fall back to default path (matches async version behavior)
+		console.error(`Custom storage path is unusable: ${error instanceof Error ? error.message : String(error)}`)
 		return defaultPath
 	}
 }


### PR DESCRIPTION
## Summary

Added proper error logging to the catch block in `getStorageBasePathSync` function to match the behavior of the async version (`getStorageBasePath`).

## Changes

- `src/utils/storage.ts`: Added `console.error` logging to the catch block in `getStorageBasePathSync`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvement (non-breaking change that improves code quality)

## Test Plan

This is a simple logging improvement to ensure consistency with the async version of the same function. The existing code behavior is unchanged - errors are still caught and handled, but now they are logged to the error stream for debugging purposes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)