### PR TITLE
fix(docs): correct kilogif.gif path in index page

### DIFF
--- a/.changeset/docs-correct-gif-path.md
+++ b/.changeset/docs-correct-gif-path.md
@@ -1,0 +1,5 @@
+---
+"kilocode-docs": patch
+---
+
+docs: correct gif path (#5125)

--- a/apps/kilocode-docs/docs/index.mdx
+++ b/apps/kilocode-docs/docs/index.mdx
@@ -35,7 +35,7 @@ Kilo Code **accelerates** development with AI-driven code generation and task au
 ## Features
 
 <Image
-  src="/docs/img/kilogif.gif"
+  src="/img/kilogif.gif"
   alt="GIF showing some of the capabilities of Kilo Code"
   width="600"
 />

--- a/apps/kilocode-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/index.mdx
+++ b/apps/kilocode-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/index.mdx
@@ -32,7 +32,7 @@ Kilo Code 通过 AI 驱动的代码生成和任务自动化**加速**开发。�
 
 ## 功能
 
-<Image src="/docs/img/kilogif.gif" alt="展示 Kilo Code 部分功能的 GIF" width="600" />
+<Image src="/img/kilogif.gif" alt="展示 Kilo Code 部分功能的 GIF" width="600" />
 
 ### 基础功能
 


### PR DESCRIPTION
## Summary
Fixes #4273

The `kilogif.gif` file is located in `static/img/kilogif.gif` but was being referenced with `/docs/img/kilogif.gif` which caused a broken image on the documentation homepage.

## Changes
- Updated `src` path in `apps/kilocode-docs/docs/index.mdx` from `/docs/img/kilogif.gif` to `/img/kilogif.gif`
- Updated `src` path in `apps/kilocode-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/index.mdx` (Chinese translation)

## Explanation
In Docusaurus, static files are served from the root path (`/`), so files in `static/img/` should be referenced as `/img/` rather than `/docs/img/`.

## Test plan
- [x] Verified the file exists at `apps/kilocode-docs/static/img/kilogif.gif`
- [x] Updated paths in both English and Chinese documentation
- [x] Changes follow Docusaurus static file path conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)