### PR TITLE
fix(docs): update codebase indexing settings access instructions

### DIFF
--- a/.changeset/docs-update-indexing-instructions.md
+++ b/.changeset/docs-update-indexing-instructions.md
@@ -1,0 +1,5 @@
+---
+"kilocode-docs": patch
+---
+
+docs: update indexing instructions (#5126)

--- a/apps/kilocode-docs/docs/features/codebase-indexing.md
+++ b/apps/kilocode-docs/docs/features/codebase-indexing.md
@@ -98,8 +98,10 @@ For team or production use:
 
 ## Configuration
 
-1. Open Kilo Code settings (<Codicon name="gear" /> icon)
-2. Navigate to **Codebase Indexing** section
+Access codebase indexing settings directly from the chat interface:
+
+1. Look for the **Database icon** in the top-right of the Kilo Code chat panel
+2. Click the icon to open the **Codebase Indexing** popover
 3. Enable **"Enable Codebase Indexing"** using the toggle switch
 4. Configure your embedding provider:
     - **OpenAI**: Enter API key and select model


### PR DESCRIPTION
## Summary
Fixes #2146

The documentation previously instructed users to access codebase indexing settings via a settings tab, but the current version uses a Database icon button in the chat panel instead.

## Changes
- Updated instructions in `apps/kilocode-docs/docs/features/codebase-indexing.md`
- Changed from "Open Kilo Code settings > Codebase Indexing section" to "Click Database icon in chat panel"
- Clarified that the Database icon opens a popover with indexing configuration options

## Explanation
The UI was updated to use a more accessible Database icon button in the chat interface rather than a separate settings tab. Users can now:
1. Look for the Database icon in the top-right of the Kilo Code chat panel
2. Click the icon to open the Codebase Indexing popover
3. Configure indexing settings directly from the chat interface

## Test plan
- [x] Verified the IndexingStatusBadge component shows the Database icon
- [x] Confirmed the icon opens CodeIndexPopover/ManagedCodeIndexPopover on click
- [x] Updated documentation to reflect the new access pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)