### PR TITLE
docs(contributing): add changeset reminder for contributors

### DIFF
--- a/.changeset/docs-add-changeset-reminder.md
+++ b/.changeset/docs-add-changeset-reminder.md
@@ -1,0 +1,5 @@
+---
+"kilocode-docs": patch
+---
+
+docs: add changeset reminder (#5128)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,4 +13,14 @@ There are lots of ways to contribute to the project
 - **Feature Requests:** Suggest new features or improvements
 - **Community Support:** Help other users in the community
 
+## Important: Changesets
+
+When making code changes that affect user-facing behavior, please create a changeset:
+
+```bash
+pnpm changeset
+```
+
+This helps us automatically generate a changelog for releases.
+
 The Kilocode Community is [on Discord](https://kilo.ai/discord)


### PR DESCRIPTION
## Summary
This change adds a reminder about creating changesets when making code changes that affect user-facing behavior. This helps maintain an accurate changelog for releases.

## Changes
- Added "Important: Changesets" section to CONTRIBUTING.md
- Included command example (`pnpm changeset`)
- Explained the purpose of changesets for automatic changelog generation

## Benefits
- Helps new contributors remember to create changesets
- Maintains accurate changelog for releases
- Reduces manual work for maintainers

## Test plan
- [x] Verified markdown formatting is correct
- [x] Linting passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)