### PR TITLE
docs(readme): add JetBrains Marketplace badge to README

### DIFF
--- a/.changeset/docs-add-jetbrains-badge.md
+++ b/.changeset/docs-add-jetbrains-badge.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+docs: add JetBrains badge (#5129)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://img.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace"></a>
+  <a href="https://plugins.jetbrains.com/plugin/24558-kilo-code"><img src="https://img.shields.io/badge/JetBrains_Marketplace-000000?style=flat&logo=jetbrains&logoColor=white" alt="JetBrains Marketplace"></a>
   <a href="https://x.com/kilocode"><img src="https://img.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)"></a>
   <a href="https://blog.kilo.ai"><img src="https://img.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Substack Blog"></a>
   <a href="https://kilo.ai/discord"><img src="https://img.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord"></a>


### PR DESCRIPTION
## Summary
This change adds a JetBrains Marketplace badge to the README alongside the VS Code Marketplace badge, providing visibility for both supported platforms.

## Changes
- Added JetBrains Marketplace badge linking to https://plugins.jetbrains.com/plugin/24558-kilo-code
- Positioned between VS Code and X (Twitter) badges for logical platform grouping
- Uses consistent badge styling with other links

## Benefits
- Better visibility for JetBrains IDE users
- Clear indication of multi-platform support
- Consistent with existing README badge style

## Test plan
- [x] Verified badge link points to correct marketplace page
- [x] Badge styling matches other badges
- [x] Linting passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)