### PR TITLE
docs: remove broken image reference from browser-use page

### DIFF
--- a/.changeset/docs-remove-broken-image.md
+++ b/.changeset/docs-remove-broken-image.md
@@ -1,0 +1,5 @@
+---
+"kilocode-docs": patch
+---
+
+docs: remove broken image (#5133)

--- a/apps/kilocode-docs/docs/features/browser-use.md
+++ b/apps/kilocode-docs/docs/features/browser-use.md
@@ -40,8 +40,6 @@ Can you check if my website at https://kilo.ai is displaying correctly?
 Browse http://localhost:3000, scroll down to the bottom of the page and check if the footer information is displaying correctly.
 ```
 
-<img src="/docs/features/KiloCodeBrowser.png" alt="Browser use example" width="300" />
-
 ## How Browser Actions Work
 
 The browser_action tool controls a browser instance that returns screenshots and console logs after each action, allowing you to see the results of interactions.


### PR DESCRIPTION
## Summary
- Fixes #2153

## Changes
- Removed broken image reference (`/docs/features/KiloCodeBrowser.png`) from browser-use documentation
- The referenced file does not exist in the repository
- The image was causing a broken image icon on the documentation page

## Verification
- All other images on the page are correctly referenced and exist
- No functional changes to the documentation content

Co-Authored-By: Claude <noreply@anthropic.com>