### PR TITLE
docs: remove broken image reference from how-tools-work page

### DIFF
--- a/.changeset/docs-remove-broken-image.md
+++ b/.changeset/docs-remove-broken-image.md
@@ -1,0 +1,5 @@
+---
+"kilocode-docs": patch
+---
+
+docs: remove broken image (#5137)

--- a/apps/kilocode-docs/docs/basic-usage/how-tools-work.md
+++ b/apps/kilocode-docs/docs/basic-usage/how-tools-work.md
@@ -25,13 +25,9 @@ Describe what you want to accomplish in natural language, and Kilo Code will:
 
 Here's how a typical tool interaction works:
 
-<img src="/docs/img/how-tools-work/how-tools-work.png" alt="Tool approval interface showing Save and Reject buttons along with Auto-approve checkbox" width="600" />
-
-_The tool approval interface shows Save/Reject buttons and Auto-approve options._
-
 **User:** Create a file named `greeting.js` that logs a greeting message
 
-**Kilo Code:** (Proposes the `write_to_file` tool as shown in the image above)
+**Kilo Code:** (Proposes the `write_to_file` tool)
 
 ```xml
 <write_to_file>


### PR DESCRIPTION
## Summary
- Fixes #2152

## Changes
- Removed broken image reference to `/docs/img/how-tools-work/how-tools-work.png`
- The image file doesn't exist in the repository
- Updated text to remove reference to "as shown in the image above"
- The tool approval workflow is well-documented in the "Tool Safety and Approval" section below

## Before
Documentation referenced a non-existent image, causing a broken image icon on the documentation website.

## After
Removed the broken image reference. The functionality is clearly explained in the text documentation.

Co-Authored-By: Claude <noreply@anthropic.com>