### PR TITLE
fix: correct kilogif.gif path in documentation (#4273)

### DIFF
--- a/.changeset/fix-docs-correct-gif-path.md
+++ b/.changeset/fix-docs-correct-gif-path.md
@@ -1,0 +1,5 @@
+---
+"kilocode-docs": patch
+---
+
+fix(docs): correct gif path (#5143)

--- a/apps/kilocode-docs/docs/index.mdx
+++ b/apps/kilocode-docs/docs/index.mdx
@@ -35,7 +35,7 @@ Kilo Code **accelerates** development with AI-driven code generation and task au
 ## Features
 
 <Image
-  src="/docs/img/kilogif.gif"
+  src="/img/kilogif.gif"
   alt="GIF showing some of the capabilities of Kilo Code"
   width="600"
 />

--- a/apps/kilocode-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/index.mdx
+++ b/apps/kilocode-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/index.mdx
@@ -32,7 +32,7 @@ Kilo Code 通过 AI 驱动的代码生成和任务自动化**加速**开发。�
 
 ## 功能
 
-<Image src="/docs/img/kilogif.gif" alt="展示 Kilo Code 部分功能的 GIF" width="600" />
+<Image src="/img/kilogif.gif" alt="展示 Kilo Code 部分功能的 GIF" width="600" />
 
 ### 基础功能
 


### PR DESCRIPTION
## Summary
- Fixes broken GIF image in documentation homepage
- Updates image path from `/docs/img/kilogif.gif` to `/img/kilogif.gif`

## Changes
- Fixed image path in `apps/kilocode-docs/docs/index.mdx` (English)
- Fixed image path in `apps/kilocode-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/index.mdx` (Chinese)

## Context
The `kilogif.gif` file is located in `static/img/`, but the documentation was incorrectly referencing `/docs/img/kilogif.gif`. In Docusaurus, static files are served directly from `/img/` for the `static/img/` directory.

Fixes #4273

## Test plan
- [x] Verified the file exists at `static/img/kilogif.gif`
- [x] Updated both English and Chinese documentation
- [x] Used correct Docusaurus static file path convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)