### PR TITLE
fix: use JetBrains URI scheme for OAuth callbacks in JetBrains plugin (#4848)

### DIFF
--- a/.changeset/fix-jetbrains-use-jetbrains-uri-scheme.md
+++ b/.changeset/fix-jetbrains-use-jetbrains-uri-scheme.md
@@ -1,0 +1,5 @@
+---
+"@kilo-code/jetbrains-plugin": patch
+---
+
+fix(jetbrains): use JetBrains URI scheme (#5145)

--- a/jetbrains/host/src/main.ts
+++ b/jetbrains/host/src/main.ts
@@ -81,7 +81,7 @@ const server = net.createServer((socket) => {
 					appName: "VSCodeAPIHook",
 					appHost: "node",
 					appLanguage: "en",
-					appUriScheme: "vscode",
+					appUriScheme: "jetbrains",
 					appRoot: URI.file(__dirname),
 					globalStorageHome: URI.file(path.join(__dirname, "globalStorage")),
 					workspaceStorageHome: URI.file(path.join(__dirname, "workspaceStorage")),

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/commands/KiloCodeOAuthCallbackCommand.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/commands/KiloCodeOAuthCallbackCommand.kt
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ai.kilocode.jetbrains.commands
+
+import ai.kilocode.jetbrains.core.PluginContext
+import com.intellij.openapi.application.JBProtocolCommand
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * JetBrains Protocol Command for handling Kilo Code OAuth callback URLs
+ *
+ * Handles OAuth callback URLs from providers like OpenRouter, Glama, Requesty
+ * Format: jetbrains://idea/ai.kilocode.jetbrains.oauth?provider=openrouter&token=HERE
+ */
+class KiloCodeOAuthCallbackCommand : JBProtocolCommand("ai.kilocode.jetbrains.oauth") {
+    private val logger = Logger.getInstance(KiloCodeOAuthCallbackCommand::class.java)
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    companion object {
+        const val COMMAND_ID = "ai.kilocode.jetbrains.oauth"
+        const val PROVIDER_PARAM = "provider"
+        const val TOKEN_PARAM = "token"
+        const val STATE_PARAM = "state"
+    }
+
+    /**
+     * Handle the protocol command
+     * @param target The target parameter from the URL
+     * @param parameters Map of URL parameters
+     * @param fragment The URL fragment
+     * @return null on success, error message on error
+     */
+    override suspend fun execute(target: String?, parameters: Map<String, String>, fragment: String?): String? {
+        val provider = parameters[PROVIDER_PARAM]
+        val token = parameters[TOKEN_PARAM]
+        val state = parameters[STATE_PARAM]
+
+        logger.info("Handling Kilo Code OAuth callback: provider=$provider, state=$state")
+
+        return try {
+            if (provider.isNullOrBlank()) {
+                val errorMsg = "No provider specified in OAuth callback: $parameters"
+                logger.warn(errorMsg)
+                return errorMsg
+            }
+
+            if (token.isNullOrBlank()) {
+                val errorMsg = "No token found in OAuth callback for provider=$provider"
+                logger.warn(errorMsg)
+                return errorMsg
+            }
+
+            logger.info("Extracted OAuth token for provider=$provider, forwarding to extension")
+
+            // Forward to the existing auth protocol command
+            forwardToken(token, provider, state)
+
+            null // Success
+        } catch (e: Exception) {
+            val errorMsg = "Error handling OAuth callback: ${e.message}"
+            logger.error(errorMsg, e)
+            errorMsg
+        }
+    }
+
+    /**
+     * Forward the OAuth token to the extension via the existing auth protocol command
+     */
+    private fun forwardToken(token: String, provider: String, state: String?) {
+        coroutineScope.launch {
+            try {
+                val projectManager = ProjectManager.getInstance()
+                val projects = projectManager.openProjects
+
+                if (projects.isEmpty()) {
+                    logger.warn("No open projects to forward OAuth token to")
+                    return@launch
+                }
+
+                // Forward to each open project
+                projects.forEach { project ->
+                    try {
+                        val pluginContext = project.getService(PluginContext::class.java)
+                        val extensionHostManager = pluginContext.getExtensionHostManager()
+
+                        logger.info("Forwarding OAuth token to extension host for project: ${project.name}")
+
+                        // Send token via RPC
+                        val authCommand = KiloCodeAuthProtocolCommand()
+                        authCommand.executeForTesting(null, mapOf(TOKEN_PARAM to token), null)
+
+                        logger.info("Successfully forwarded OAuth token for provider=$provider")
+                    } catch (e: Exception) {
+                        logger.error("Failed to forward OAuth token for project ${project.name}", e)
+                    }
+                }
+            } catch (e: Exception) {
+                logger.error("Failed to forward OAuth token", e)
+            }
+        }
+    }
+}

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/core/ExtensionHostManager.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/core/ExtensionHostManager.kt
@@ -372,7 +372,7 @@ class ExtensionHostManager : Disposable {
                 "appName" to getCurrentIDEName(),
                 "appHost" to "node",
                 "appLanguage" to "en",
-                "appUriScheme" to "vscode",
+                "appUriScheme" to "jetbrains",
                 "appRoot" to uriFromPath(pluginDir),
                 "globalStorageHome" to uriFromPath(Paths.get(System.getProperty("user.home"), ".kilocode", "globalStorage").toString()),
                 "workspaceStorageHome" to uriFromPath(Paths.get(System.getProperty("user.home"), ".kilocode", "workspaceStorage").toString()),

--- a/jetbrains/plugin/src/main/resources/META-INF/plugin.xml.template
+++ b/jetbrains/plugin/src/main/resources/META-INF/plugin.xml.template
@@ -43,6 +43,7 @@ SPDX-License-Identifier: Apache-2.0
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="ai.kilocode.jetbrains.plugin.WecoderPluginService"/>
         <jbProtocolCommand implementation="ai.kilocode.jetbrains.commands.KiloCodeAuthProtocolCommand" />
+        <jbProtocolCommand implementation="ai.kilocode.jetbrains.commands.KiloCodeOAuthCallbackCommand" />
         <postStartupActivity implementation="ai.kilocode.jetbrains.plugin.WecoderPlugin"/>
         <editorFactoryListener implementation="ai.kilocode.jetbrains.editor.EditorListener"/>
         <toolWindow factoryClass="ai.kilocode.jetbrains.ui.RooToolWindowFactory"

--- a/webview-ui/src/oauth/urls.ts
+++ b/webview-ui/src/oauth/urls.ts
@@ -1,6 +1,13 @@
 import { Package } from "@roo/package"
 
 export function getCallbackUrl(provider: string, uriScheme?: string) {
+	// JetBrains uses a different URL format for OAuth callbacks
+	// Format: jetbrains://idea/ai.kilocode.jetbrains.oauth?provider={provider}
+	if (uriScheme === "jetbrains") {
+		return encodeURIComponent(`jetbrains://idea/ai.kilocode.jetbrains.oauth?provider=${provider}`)
+	}
+	// VS Code and other IDEs use the standard format
+	// Format: vscode://kilocode/kilo-code/{provider}
 	return encodeURIComponent(`${uriScheme || "vscode"}://${Package.publisher}.${Package.name}/${provider}`)
 }
 


### PR DESCRIPTION
## Summary
- Changed `appUriScheme` from "vscode" to "jetbrains" in JetBrains plugin
- Created new `KiloCodeOAuthCallbackCommand` for handling OAuth callbacks
- Updated `getCallbackUrl()` to use JetBrains-specific URL format

## Changes
- **jetbrains/host/src/main.ts**: Changed `appUriScheme: "vscode"` → `"jetbrains"`
- **jetbrains/plugin/.../ExtensionHostManager.kt**: Changed `appUriScheme: "vscode"` → `"jetbrains"`
- **jetbrains/plugin/.../KiloCodeOAuthCallbackCommand.kt** (new): JetBrains protocol command for OAuth callbacks
- **plugin.xml.template**: Added registration for `KiloCodeOAuthCallbackCommand`
- **webview-ui/src/oauth/urls.ts**: Added JetBrains-specific callback URL format

## Context
The JetBrains plugin was using `vscode://` callback URLs for OAuth authentication (e.g., OpenRouter). JetBrains IDEs cannot handle `vscode://` URLs - they need `jetbrains://` URLs with the proper protocol command format.

**Callback URL formats:**
- VS Code: `vscode://kilocode/kilo-code/{provider}`
- JetBrains: `jetbrains://idea/ai.kilocode.jetbrains.oauth?provider={provider}`

The new `KiloCodeOAuthCallbackCommand` handles OAuth callbacks from providers like OpenRouter, Glama, and Requesty, forwarding the tokens to the extension via RPC.

Fixes #4848

## Test plan
- [x] Updated appUriScheme in JetBrains host and plugin
- [x] Created new jbProtocolCommand for OAuth callbacks
- [x] Updated getCallbackUrl() to detect JetBrains and use correct format
- [x] Added protocol command registration in plugin.xml

🤖 Generated with [Claude Code](https://claude.com/claude-code)