### PR TITLE
fix: add pretty JSON formatting option to safeWriteJson (#4532)

### DIFF
--- a/.changeset/fix-mcp-add-pretty-json-formatting.md
+++ b/.changeset/fix-mcp-add-pretty-json-formatting.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix(mcp): add pretty JSON formatting (#5147)

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1493,7 +1493,7 @@ export const webviewMessageHandler = async (
 				const exists = await fileExistsAtPath(mcpPath)
 
 				if (!exists) {
-					await safeWriteJson(mcpPath, { mcpServers: {} })
+					await safeWriteJson(mcpPath, { mcpServers: {} }, true)
 				}
 
 				openFile(mcpPath)


### PR DESCRIPTION
## Summary
- Added `pretty` parameter to `safeWriteJson()` function
- MCP JSON files now created with proper formatting (2-space indentation)

## Changes
- **src/utils/safeWriteJson.ts**:
  - Added optional `pretty` parameter to `safeWriteJson(data, pretty = false)`
  - When `pretty=true`, uses `JSON.stringify(data, null, 2)` for formatted output
  - Compact JSON (default) still uses streaming for large files

- **src/core/webview/webviewMessageHandler.ts**:
  - Updated MCP JSON creation to use `safeWriteJson(path, data, true)`

## Context
The MCP Settings UI was removing JSON formatting when creating `.kilocode/mcp.json` files. This made manual editing difficult and the files hard to read.

The fix adds a `pretty` option to `safeWriteJson()` so that MCP configuration files are created with proper 2-space indentation for better readability and easier manual editing.

Fixes #4532

## Test plan
- [x] Added `pretty` parameter to `safeWriteJson()`
- [x] Updated MCP JSON file creation to use `pretty=true`
- [x] Pretty printing uses standard `JSON.stringify(data, null, 2)`
- [x] Default behavior (compact) unchanged for other uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)