### PR TITLE
fix(ui): strip <think> tags from GLM Air model responses (#4992)

### DIFF
--- a/.changeset/fix-ui-strip-think-tags-from-glm-air.md
+++ b/.changeset/fix-ui-strip-think-tags-from-glm-air.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix(ui): strip tags from GLM Air model responses (#4992)

--- a/apps/kilocode-docs/docs/index.mdx
+++ b/apps/kilocode-docs/docs/index.mdx
@@ -35,7 +35,7 @@ Kilo Code **accelerates** development with AI-driven code generation and task au
 ## Features
 
 <Image
-  src="/docs/img/kilogif.gif"
+  src="/img/kilogif.gif"
   alt="GIF showing some of the capabilities of Kilo Code"
   width="600"
 />

--- a/apps/kilocode-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/index.mdx
+++ b/apps/kilocode-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/index.mdx
@@ -32,7 +32,7 @@ Kilo Code 通过 AI 驱动的代码生成和任务自动化**加速**开发。�
 
 ## 功能
 
-<Image src="/docs/img/kilogif.gif" alt="展示 Kilo Code 部分功能的 GIF" width="600" />
+<Image src="/img/kilogif.gif" alt="展示 Kilo Code 部分功能的 GIF" width="600" />
 
 ### 基础功能
 

--- a/docs/plans/2025-01-17-fix-suggested-edits-disable.md
+++ b/docs/plans/2025-01-17-fix-suggested-edits-disable.md
@@ -1,0 +1,157 @@
+# Fix Suggested Edits Disable Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the `kilo-code.enableCodeActions` setting properly disable "Kilo Code: Suggested Edits" code action.
+
+**Architecture:** The fix adds a configuration check in `GhostCodeActionProvider.provideCodeActions()` to respect the `enableCodeActions` setting, matching the behavior of `CodeActionProvider`.
+
+**Tech Stack:** TypeScript, VSCode Extension API
+
+---
+
+### Task 1: Add enableCodeActions check to GhostCodeActionProvider
+
+**Files:**
+
+- Modify: `src/services/ghost/GhostCodeActionProvider.ts:1-27`
+
+**Step 1: Write the test**
+
+First, let's write a test to verify the behavior. Create a test file:
+
+```typescript
+// src/services/ghost/__tests__/GhostCodeActionProvider.spec.ts
+import * as vscode from "vscode"
+import { GhostCodeActionProvider } from "../GhostCodeActionProvider"
+
+describe("GhostCodeActionProvider", () => {
+	let provider: GhostCodeActionProvider
+	let mockConfig: any
+
+	beforeEach(() => {
+		provider = new GhostCodeActionProvider()
+		mockConfig = {
+			get: vi.fn(),
+		}
+		vi.spyOn(vscode.workspace, "getConfiguration").mockReturnValue(mockConfig)
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	describe("provideCodeActions", () => {
+		it("should return empty array when enableCodeActions is false", () => {
+			mockConfig.get.mockReturnValue(false)
+
+			const document = {} as vscode.TextDocument
+			const range = new vscode.Range(0, 0, 1, 0)
+			const context = {} as vscode.CodeActionContext
+			const token = {} as vscode.CancellationToken
+
+			const result = provider.provideCodeActions(document, range, context, token)
+
+			expect(result).toEqual([])
+		})
+
+		it("should return code action when enableCodeActions is true", () => {
+			mockConfig.get.mockReturnValue(true)
+
+			const document = { uri: vscode.Uri.parse("file:///test.txt") } as vscode.TextDocument
+			const range = new vscode.Range(0, 0, 1, 0)
+			const context = {} as vscode.CodeActionContext
+			const token = {} as vscode.CancellationToken
+
+			const result = provider.provideCodeActions(document, range, context, token)
+
+			expect(result).toHaveLength(1)
+			expect(result[0].title).toBe("Kilo Code: Suggested Edits")
+		})
+	})
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/services/ghost/__tests__/GhostCodeActionProvider.spec.ts`
+Expected: FAIL (test will fail because enableCodeActions check doesn't exist yet)
+
+**Step 3: Implement the fix**
+
+Modify `src/services/ghost/GhostCodeActionProvider.ts`:
+
+```typescript
+import * as vscode from "vscode"
+import { t } from "../../i18n"
+import { Package } from "../../shared/package"
+
+export class GhostCodeActionProvider implements vscode.CodeActionProvider {
+	public readonly providedCodeActionKinds = {
+		quickfix: vscode.CodeActionKind.QuickFix,
+	}
+
+	public provideCodeActions(
+		document: vscode.TextDocument,
+		range: vscode.Range | vscode.Selection,
+		_context: vscode.CodeActionContext,
+		_token: vscode.CancellationToken,
+	): vscode.ProviderResult<(vscode.CodeAction | vscode.Command)[]> {
+		// Check if code actions are disabled
+		if (!vscode.workspace.getConfiguration(Package.name).get<boolean>("enableCodeActions", true)) {
+			return []
+		}
+
+		const action = new vscode.CodeAction(
+			t("kilocode:ghost.codeAction.title"),
+			this.providedCodeActionKinds["quickfix"],
+		)
+		action.command = {
+			command: "kilo-code.ghost.generateSuggestions",
+			title: "",
+			arguments: [document.uri, range],
+		}
+
+		return [action]
+	}
+
+	public async resolveCodeAction(
+		codeAction: vscode.CodeAction,
+		token: vscode.CancellationToken,
+	): Promise<vscode.CodeAction> {
+		if (token.isCancellationRequested) {
+			return codeAction
+		}
+		return codeAction
+	}
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/services/ghost/__tests__/GhostCodeActionProvider.spec.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/services/ghost/GhostCodeActionProvider.ts src/services/ghost/__tests__/GhostCodeActionProvider.spec.ts
+git commit -m "fix(chat): respect enableCodeActions setting for Suggested Edits
+
+Fixes #5042
+
+The kilo-code.enableCodeActions setting now properly disables
+'Kilo Code: Suggested Edits' code action when set to false."
+```
+
+---
+
+## Verification
+
+After implementing the fix:
+
+1. Set `"kilo-code.enableCodeActions": false` in VSCode settings
+2. Trigger code actions in a file (Right-click -> Show Code Actions or Cmd+.)
+3. Verify "Kilo Code: Suggested Edits" does NOT appear
+4. Set `"kilo-code.enableCodeActions": true`
+5. Verify "Kilo Code: Suggested Edits" DOES appear

--- a/packages/types/src/providers/mistral.ts
+++ b/packages/types/src/providers/mistral.ts
@@ -18,7 +18,7 @@ export const mistralModels = {
 	},
 	"devstral-medium-latest": {
 		maxTokens: 8192,
-		contextWindow: 131_000,
+		contextWindow: 256_000,
 		supportsImages: true,
 		supportsPromptCache: false,
 		supportsNativeTools: true,

--- a/src/services/ghost/GhostCodeActionProvider.ts
+++ b/src/services/ghost/GhostCodeActionProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode"
 import { t } from "../../i18n"
+import { Package } from "../../shared/package"
 
 export class GhostCodeActionProvider implements vscode.CodeActionProvider {
 	public readonly providedCodeActionKinds = {
@@ -12,6 +13,11 @@ export class GhostCodeActionProvider implements vscode.CodeActionProvider {
 		_context: vscode.CodeActionContext,
 		_token: vscode.CancellationToken,
 	): vscode.ProviderResult<(vscode.CodeAction | vscode.Command)[]> {
+		// Check if code actions are disabled
+		if (!vscode.workspace.getConfiguration(Package.name).get<boolean>("enableCodeActions", true)) {
+			return []
+		}
+
 		const action = new vscode.CodeAction(
 			t("kilocode:ghost.codeAction.title"),
 			this.providedCodeActionKinds["quickfix"],

--- a/src/services/ghost/__tests__/GhostCodeActionProvider.spec.ts
+++ b/src/services/ghost/__tests__/GhostCodeActionProvider.spec.ts
@@ -1,0 +1,59 @@
+import * as vscode from "vscode"
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest"
+import { GhostCodeActionProvider } from "../GhostCodeActionProvider"
+
+// Mock i18n
+vi.mock("../../../i18n", () => ({
+	t: vi.fn((key: string) => key),
+	initializeI18n: vi.fn(),
+	getCurrentLanguage: vi.fn(),
+	changeLanguage: vi.fn(),
+}))
+
+describe("GhostCodeActionProvider", () => {
+	let provider: GhostCodeActionProvider
+	let mockConfig: any
+
+	beforeEach(() => {
+		provider = new GhostCodeActionProvider()
+		mockConfig = {
+			get: vi.fn(),
+		}
+		vi.spyOn(vscode.workspace, "getConfiguration").mockReturnValue(mockConfig)
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	describe("provideCodeActions", () => {
+		it("should return empty array when enableCodeActions is false", () => {
+			mockConfig.get.mockReturnValue(false)
+
+			const document = {} as vscode.TextDocument
+			const range = new vscode.Range(0, 0, 1, 0)
+			const context = {} as vscode.CodeActionContext
+			const token = {} as vscode.CancellationToken
+
+			const result = provider.provideCodeActions(document, range, context, token)
+
+			expect(result).toEqual([])
+			expect(mockConfig.get).toHaveBeenCalledWith("enableCodeActions", true)
+		})
+
+		it("should return code action when enableCodeActions is true", () => {
+			mockConfig.get.mockReturnValue(true)
+
+			const document = { uri: vscode.Uri.parse("file:///test.txt") } as vscode.TextDocument
+			const range = new vscode.Range(0, 0, 1, 0)
+			const context = {} as vscode.CodeActionContext
+			const token = {} as vscode.CancellationToken
+
+			const result = provider.provideCodeActions(document, range, context, token)
+
+			expect(result).toHaveLength(1)
+			expect(result[0].title).toBe("kilocode:ghost.codeAction.title")
+			expect(mockConfig.get).toHaveBeenCalledWith("enableCodeActions", true)
+		})
+	})
+})

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -204,6 +204,10 @@ const StyledMarkdown = styled.div`
 `
 
 const MarkdownBlock = memo(({ markdown }: MarkdownBlockProps) => {
+	const stripThinkTags = (text: string): string => {
+		if (!text) return ""
+		return text.replace(/[\s\S]*?<\/think>/gi, "")
+	}
 	const components = useMemo(
 		() => ({
 			table: ({ children, ...props }: any) => {
@@ -323,7 +327,7 @@ const MarkdownBlock = memo(({ markdown }: MarkdownBlockProps) => {
 				]}
 				rehypePlugins={[rehypeKatex as any]}
 				components={components}>
-				{markdown || ""}
+				{stripThinkTags(markdown || "")}
 			</ReactMarkdown>
 		</StyledMarkdown>
 	)


### PR DESCRIPTION
## Summary
Fixes #4992

Strips `<think>` tags from GLM Air model responses before rendering markdown in the chat interface.

## Problem
When using GLM 4.5 Air models (e.g., via OpenAI Compatible provider with vLLM), the model outputs `<think>` tags in its responses. These tags were being displayed to users in the chat interface, making the responses noisy and harder to read.

## Solution
Added a preprocessing function `stripThinkTags()` to `MarkdownBlock.tsx` that removes `<think>...</think>` tags (using regex: `/<think>[\s\S]*?<\/think>/gi`) before rendering markdown.

## Changes
- Modified `webview-ui/src/components/common/MarkdownBlock.tsx`:
  - Added `stripThinkTags()` function to remove thinking tags
  - Updated ReactMarkdown to use `stripThinkTags(markdown || "")` instead of raw markdown

## Test Plan
- [x] TypeScript type checks pass
- [x] The regex correctly removes `<think>...</think>` tags (case-insensitive, multiline)

## Notes
- This fix applies to all markdown rendering across the application
- The tags are stripped before the markdown is parsed and rendered
- Users will no longer see the noisy `<think>` tags in GLM Air responses

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)