### PR TITLE
feat(cli): add mode cycling via tab key and show mode name in prompt

### DIFF
--- a/cli/src/state/atoms/keyboard.ts
+++ b/cli/src/state/atoms/keyboard.ts
@@ -648,6 +648,9 @@ function handleFollowupKeys(get: Getter, set: Setter, key: Key): void {
 					set(setTextAtom, suggestion.answer)
 					set(selectedIndexAtom, -1)
 				}
+			} else {
+				// No suggestion selected, cycle modes
+				set(cycleNextModeAtom)
 			}
 			return
 
@@ -724,6 +727,9 @@ function handleAutocompleteKeys(get: Getter, set: Setter, key: Key): void {
 					const { row, column } = calculateRowColumnFromPosition(newText, cursorPosition)
 					set(moveToAtom, { row, column })
 				}
+			} else {
+				// No suggestion selected, cycle modes
+				set(cycleNextModeAtom)
 			}
 			return
 
@@ -924,6 +930,11 @@ function handleTextInputKeys(get: Getter, set: Setter, key: Key) {
 		// Delete
 		case "delete":
 			set(deleteCharAtom)
+			return
+
+		// Tab (cycle modes)
+		case "tab":
+			set(cycleNextModeAtom)
 			return
 
 		// Escape

--- a/cli/src/ui/components/CommandInput.tsx
+++ b/cli/src/ui/components/CommandInput.tsx
@@ -14,6 +14,8 @@ import {
 	commitCountdownSecondsAtom,
 } from "../../state/atoms/ui.js"
 import { shellModeActiveAtom, executeShellCommandAtom } from "../../state/atoms/keyboard.js"
+import { extensionModeAtom, customModesAtom } from "../../state/atoms/extension.js"
+import { getModeBySlug } from "../../constants/modes/defaults.js"
 import { MultilineTextInput } from "./MultilineTextInput.js"
 import { useCommandInput } from "../../state/hooks/useCommandInput.js"
 import { useApprovalHandler } from "../../state/hooks/useApprovalHandler.js"
@@ -42,6 +44,12 @@ export const CommandInput: React.FC<CommandInputProps> = ({
 	const isShellModeActive = useAtomValue(shellModeActiveAtom)
 	const inputMode = useAtomValue(inputModeAtom)
 	const executeShellCommand = useSetAtom(executeShellCommandAtom)
+
+	// Get current mode
+	const extensionMode = useAtomValue(extensionModeAtom)
+	const customModes = useAtomValue(customModesAtom)
+	const currentModeConfig = getModeBySlug(extensionMode, customModes)
+	const modeName = currentModeConfig?.name?.toLowerCase() || extensionMode.toLowerCase()
 
 	// Use the command input hook for autocomplete functionality
 	const { isAutocompleteVisible, commandSuggestions, argumentSuggestions, fileMentionSuggestions } = useCommandInput()
@@ -145,9 +153,9 @@ export const CommandInput: React.FC<CommandInputProps> = ({
 			<Box borderStyle="round" borderColor={borderColor} paddingX={1}>
 				<Box flexDirection="row" alignItems="center">
 					<Text color={promptColor} bold>
-						{isShellMode && !isCommittingParallelMode && (
+						{!isCommittingParallelMode && (
 							<>
-								<Text color={promptColor}>shell</Text>
+								<Text color={promptColor}>{isShellMode ? "shell" : modeName}</Text>
 								<Text> </Text>
 							</>
 						)}


### PR DESCRIPTION
## Summary

Added mode cycling via Tab key and displays the current mode name in the CLI prompt.

## Changes

- **Tab key support**: Pressing Tab now cycles through available modes when no autocomplete suggestion is selected
- **Mode display**: The CLI prompt now shows the current mode name (e.g., "ask", "architect", "code") instead of just "shell" when in non-shell modes

## Motivation

Makes it easier for users to:
1. Quickly switch between modes using Tab
2. See which mode is currently active in the command prompt

## Testing

Tested manually:
- Tab cycles through modes when no suggestion is selected
- Mode name correctly displays in the prompt for all modes
- Shell mode still shows "shell" as before

## Screenshots

<img width="1891" height="916" alt="Screenshot from 2026-01-17 20-01-31" src="https://github.com/user-attachments/assets/c2b4ce34-95aa-41c2-82a8-3fe174298a04" />
<img width="1891" height="916" alt="Screenshot from 2026-01-17 20-01-16" src="https://github.com/user-attachments/assets/800bc16c-5c4f-4d00-9f6a-6a8be09a041e" />
<img width="1891" height="916" alt="Screenshot from 2026-01-17 20-01-13" src="https://github.com/user-attachments/assets/344b6dcb-0680-4c07-be23-11c7683a1d17" />
