### PR TITLE
feat(core): support .kiloignore as alias for .kilocodeignore

### DIFF
--- a/.changeset/friendly-kilos-ignore.md
+++ b/.changeset/friendly-kilos-ignore.md
@@ -1,0 +1,9 @@
+---
+"kilo-code": minor
+---
+
+feat: add .kiloignore as an alias for .kilocodeignore (fixes #3825)
+
+Users can now use either `.kiloignore` or `.kilocodeignore` to specify files that should be blocked from LLM access. The `.kilocodeignore` file takes precedence if both exist.
+
+This addresses user confusion reported in issue #3825 where users expected `.kiloignore` to work similar to other ignore files.


### PR DESCRIPTION
## Context
Fixes #3825

Users have reported confusion regarding ignore files, expecting `.kiloignore` to work similarly to `.gitignore`. Currently, only `.kilocodeignore` is supported. This PR adds support for `.kiloignore` as an alias for `.kilocodeignore` to improve the user experience and address [Issue #3825](https://github.com/Kilo-Org/kilocode/issues/3825).

## Implementation

- Modified `RooIgnoreController` to support a list of ignore filenames (`.kilocodeignore`, `.kiloignore`).
- Implemented precedence logic: `.kilocodeignore` takes priority if both files exist.
- **Security improvement**: Both `.kilocodeignore` and `.kiloignore` are added to the ignore list regardless of which one is active, preventing either file from being read by the LLM.
- Updated file watchers to monitor both files for changes.
- Added comprehensive unit tests to verify fallback behavior, precedence rules, and correct instruction generation.

## Screenshots

| before | after |
| ------ | ----- |
| N/A    | N/A   |

## How to Test

1. **Setup**: Open a workspace in Kilo Code.
2. **Create Sensitive File**: Create a file named `secret.txt` with some content.
3. **Create Ignore File**: Create a `.kiloignore` file in the root and add `secret.txt` to it.
4. **Verify Block**: Ask Kilo to "read secret.txt". It should be blocked.
5. **Verify Precedence (Optional)**:
   - Create a `.kilocodeignore` file.
   - Add a different rule (e.g., ignore `other.txt` but not `secret.txt`).
   - Reload/Initialize. `.kilocodeignore` should now take effect.
