### PR TITLE
fix(cli): prevent escape sequences from displaying as raw text on Windows cmd.exe

### DIFF
--- a/.changeset/fix-windows-cmd-escape-sequences.md
+++ b/.changeset/fix-windows-cmd-escape-sequences.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fixed escape sequences appearing as raw text on Windows cmd.exe

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,6 +6,7 @@ import { createExtensionService, ExtensionService } from "./services/extension.j
 import { App } from "./ui/App.js"
 import { logs } from "./services/logs.js"
 import { initializeSyntaxHighlighter } from "./ui/utils/syntaxHighlight.js"
+import { supportsTitleSetting } from "./ui/utils/terminalCapabilities.js"
 import { extensionServiceAtom } from "./state/atoms/service.js"
 import { initializeServiceEffectAtom } from "./state/atoms/effects.js"
 import { loadConfigAtom, mappedExtensionStateAtom, providersAtom, saveConfigAtom } from "./state/atoms/config.js"
@@ -78,7 +79,9 @@ export class CLI {
 			// Set terminal title - use process.cwd() in parallel mode to show original directory
 			const titleWorkspace = this.options.parallel ? process.cwd() : this.options.workspace || process.cwd()
 			const folderName = `${basename(titleWorkspace)}${(await isGitWorktree(this.options.workspace || "")) ? " (git worktree)" : ""}`
-			process.stdout.write(`\x1b]0;Kilo Code - ${folderName}\x07`)
+			if (supportsTitleSetting()) {
+				process.stdout.write(`\x1b]0;Kilo Code - ${folderName}\x07`)
+			}
 
 			// Create Jotai store
 			this.store = createStore()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5405,7 +5405,6 @@ packages:
   '@lancedb/lancedb@0.21.3':
     resolution: {integrity: sha512-hfzp498BfcCJ730fV1YGGoXVxRgE+W1n0D0KwanKlbt8bBPSQ6E6Tf8mPXc8rKdAXIRR3o5mTzMG3z3Fda+m3Q==}
     engines: {node: '>= 18'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -30596,7 +30595,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.17.57)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@27.4.0)(lightningcss@1.30.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.0.3)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@27.4.0)(lightningcss@1.30.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@2.0.5':
     dependencies:


### PR DESCRIPTION
## Summary

Fixes escape sequences appearing as raw text on Windows cmd.exe (legacy terminal). The issue manifested as codes like `61;4;6;7;14;21;22;23;24;28;32;42;52c` being displayed in the terminal.

## Root Cause

Two escape sequences were being sent unconditionally that legacy Windows cmd.exe doesn't support:

1. **OSC 0 title setting** (`\x1b]0;title\x07`) - Used to set the terminal window title
2. **CSI Device Attributes query** (`\x1b[c`) - Used by Kitty keyboard protocol detection, which caused cmd.exe to display the terminal's response as raw text

## Solution

Added capability detection to skip these escape sequences on legacy Windows terminals (cmd.exe) while maintaining full functionality on modern terminals:

- **Windows Terminal** - Detected via `WT_SESSION` environment variable
- **VS Code terminal** - Detected via `TERM_PROGRAM` environment variable
- **Linux/macOS** - Always supported (not Windows)

## Changes

- Added `supportsTitleSetting()` function that uses existing `supportsScrollbackClear()` detection
- Wrapped title-setting code with capability check
- Added early return in `detectKittyProtocolSupport()` to skip CSI queries on legacy Windows
- Added comprehensive tests for the new behavior

## Testing

- All 1984 tests pass
- Verified on macOS that title setting and keyboard detection still work
- The fix only affects legacy Windows cmd.exe where `WT_SESSION` and `TERM_PROGRAM` are both unset