### PR TITLE
fix(cli): show loader and block input during paste operations

### DIFF
--- a/.changeset/cli-image-text-paste-loader.md
+++ b/.changeset/cli-image-text-paste-loader.md
@@ -1,0 +1,10 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix missing visual feedback and input blocking during paste operations
+
+- Display "Pasting image..." loader when pasting images via Cmd+V/Ctrl+V
+- Display "Pasting text..." loader when pasting large text (10+ lines)
+- Block keyboard input during paste operations to prevent concurrent writes
+- Support multiple concurrent paste operations with counter-based tracking

--- a/cli/src/state/atoms/__tests__/keyboard.test.ts
+++ b/cli/src/state/atoms/__tests__/keyboard.test.ts
@@ -1394,7 +1394,7 @@ describe("keypress atoms", () => {
 			expect(text).toBe(smallPaste)
 		})
 
-		it("should abbreviate large pastes as references", () => {
+		it("should abbreviate large pastes as references", async () => {
 			// Large paste (10+ lines to trigger abbreviation)
 			const lines = Array.from({ length: 15 }, (_, i) => `line ${i + 1}`)
 			const largePaste = lines.join("\n")
@@ -1409,13 +1409,18 @@ describe("keypress atoms", () => {
 
 			store.set(keyboardHandlerAtom, pasteKey)
 
+			// Wait for async paste operation to complete
+			await vi.waitFor(() => {
+				const text = store.get(textBufferStringAtom)
+				expect(text).toContain("[Pasted text #1 +15 lines]")
+			})
+
 			// Should insert abbreviated reference
 			const text = store.get(textBufferStringAtom)
-			expect(text).toContain("[Pasted text #1 +15 lines]")
 			expect(text).not.toContain("line 1")
 		})
 
-		it("should store full text in references map for large pastes", () => {
+		it("should store full text in references map for large pastes", async () => {
 			const lines = Array.from({ length: 12 }, (_, i) => `content line ${i + 1}`)
 			const largePaste = lines.join("\n")
 			const pasteKey: Key = {
@@ -1429,12 +1434,14 @@ describe("keypress atoms", () => {
 
 			store.set(keyboardHandlerAtom, pasteKey)
 
-			// Full text should be in references map
-			const refs = store.get(pastedTextReferencesAtom)
-			expect(refs.get(1)).toBe(largePaste)
+			// Wait for async paste operation to complete
+			await vi.waitFor(() => {
+				const refs = store.get(pastedTextReferencesAtom)
+				expect(refs.get(1)).toBe(largePaste)
+			})
 		})
 
-		it("should increment reference numbers for multiple large pastes", () => {
+		it("should increment reference numbers for multiple large pastes", async () => {
 			const createLargePaste = (id: number) => {
 				const lines = Array.from({ length: 11 }, (_, i) => `paste${id} line ${i + 1}`)
 				return lines.join("\n")
@@ -1448,6 +1455,12 @@ describe("keypress atoms", () => {
 				meta: false,
 				shift: false,
 				paste: true,
+			})
+
+			// Wait for first paste to complete
+			await vi.waitFor(() => {
+				const text = store.get(textBufferStringAtom)
+				expect(text).toContain("[Pasted text #1 +11 lines]")
 			})
 
 			// Add a space
@@ -1470,12 +1483,14 @@ describe("keypress atoms", () => {
 				paste: true,
 			})
 
-			const text = store.get(textBufferStringAtom)
-			expect(text).toContain("[Pasted text #1 +11 lines]")
-			expect(text).toContain("[Pasted text #2 +11 lines]")
+			// Wait for second paste to complete
+			await vi.waitFor(() => {
+				const text = store.get(textBufferStringAtom)
+				expect(text).toContain("[Pasted text #2 +11 lines]")
+			})
 		})
 
-		it("should handle paste at exactly threshold boundary", () => {
+		it("should handle paste at exactly threshold boundary", async () => {
 			// Exactly 10 lines (threshold)
 			const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`)
 			const boundaryPaste = lines.join("\n")
@@ -1490,9 +1505,11 @@ describe("keypress atoms", () => {
 
 			store.set(keyboardHandlerAtom, pasteKey)
 
-			// Should abbreviate (>= threshold)
-			const text = store.get(textBufferStringAtom)
-			expect(text).toContain("[Pasted text #1 +10 lines]")
+			// Wait for async paste operation to complete
+			await vi.waitFor(() => {
+				const text = store.get(textBufferStringAtom)
+				expect(text).toContain("[Pasted text #1 +10 lines]")
+			})
 		})
 
 		it("should not abbreviate paste just below threshold", () => {

--- a/cli/src/ui/components/StatusIndicator.tsx
+++ b/cli/src/ui/components/StatusIndicator.tsx
@@ -12,7 +12,7 @@ import { ThinkingAnimation } from "./ThinkingAnimation.js"
 import { useAtomValue, useSetAtom } from "jotai"
 import { isStreamingAtom, isCancellingAtom } from "../../state/atoms/ui.js"
 import { hasResumeTaskAtom } from "../../state/atoms/extension.js"
-import { exitPromptVisibleAtom } from "../../state/atoms/keyboard.js"
+import { exitPromptVisibleAtom, pendingImagePastesAtom, pendingTextPastesAtom } from "../../state/atoms/keyboard.js"
 import { useEffect } from "react"
 
 /** Safety timeout to auto-reset cancelling state if extension doesn't respond */
@@ -42,6 +42,10 @@ export const StatusIndicator: React.FC<StatusIndicatorProps> = ({ disabled = fal
 	const setIsCancelling = useSetAtom(isCancellingAtom)
 	const hasResumeTask = useAtomValue(hasResumeTaskAtom)
 	const exitPromptVisible = useAtomValue(exitPromptVisibleAtom)
+	const pendingImagePastes = useAtomValue(pendingImagePastesAtom)
+	const pendingTextPastes = useAtomValue(pendingTextPastesAtom)
+	const isPastingImage = pendingImagePastes > 0
+	const isPastingText = pendingTextPastes > 0
 	const exitModifierKey = "Ctrl" // Ctrl+C is the universal terminal interrupt signal on all platforms
 
 	// Reset cancelling state when streaming stops
@@ -75,9 +79,15 @@ export const StatusIndicator: React.FC<StatusIndicatorProps> = ({ disabled = fal
 					<Text color={theme.semantic.warning}>Press {exitModifierKey}+C again to exit.</Text>
 				) : (
 					<>
-						{isCancelling && <ThinkingAnimation text="Cancelling..." />}
-						{isStreaming && !isCancelling && <ThinkingAnimation />}
-						{hasResumeTask && <Text color={theme.ui.text.dimmed}>Task ready to resume</Text>}
+						{isPastingImage && <ThinkingAnimation text="Pasting image..." />}
+						{isPastingText && !isPastingImage && <ThinkingAnimation text="Pasting text..." />}
+						{isCancelling && !isPastingImage && !isPastingText && (
+							<ThinkingAnimation text="Cancelling..." />
+						)}
+						{isStreaming && !isCancelling && !isPastingImage && !isPastingText && <ThinkingAnimation />}
+						{hasResumeTask && !isPastingImage && !isPastingText && (
+							<Text color={theme.ui.text.dimmed}>Task ready to resume</Text>
+						)}
 					</>
 				)}
 			</Box>


### PR DESCRIPTION
## Summary

- Fix UX issue where users had no visual feedback when pasting images or large text
- Display "Pasting image..." loader when pasting images via Cmd+V/Ctrl+V
- Display "Pasting text..." loader when pasting large text (10+ lines that generate `[Pasted text #N]` references)
- Block keyboard input during paste operations to prevent interference and concurrent writes
- Support multiple concurrent paste operations with counter-based tracking (loader only disappears when all pastes complete)

## Test plan

- [ ] Paste an image with Cmd+V/Ctrl+V → should see "Pasting image..." loader
- [ ] Paste a large text (10+ lines) → should see "Pasting text..." loader
- [ ] Spam Cmd+V multiple times with images → loader should remain until all pastes complete
- [ ] Try typing during paste → input should be blocked
- [ ] Paste small text (<10 lines) → should insert directly without loader