### PR TITLE
fix(core-schemas): use z.custom() with validator for function types in Zod v4

### DIFF
--- a/.changeset/fix-zod-function-api.md
+++ b/.changeset/fix-zod-function-api.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/core-schemas": patch
+---
+
+Fix Zod function API usage in pollingOptionsSchema

--- a/packages/core-schemas/src/auth/kilocode.ts
+++ b/packages/core-schemas/src/auth/kilocode.ts
@@ -33,9 +33,9 @@ export const pollingOptionsSchema = z.object({
 	/** Maximum number of attempts before timeout */
 	maxAttempts: z.number(),
 	/** Function to execute on each poll */
-	pollFn: z.function({ input: z.tuple([]), output: z.promise(z.unknown()) }),
+	pollFn: z.custom<() => Promise<unknown>>((val) => typeof val === "function"),
 	/** Optional callback for progress updates */
-	onProgress: z.function({ input: z.tuple([z.number(), z.number()]), output: z.void() }).optional(),
+	onProgress: z.custom<(current: number, total: number) => void>((val) => typeof val === "function").optional(),
 })
 
 /**


### PR DESCRIPTION
## Summary
- Fix DTS build errors in core-schemas introduced by PR #5107
- Replace incorrect `z.function({ input, output })` with `z.custom<T>()` + validator

## Problem

PR #5107 upgraded core-schemas to Zod v4 and attempted to use:
```typescript
z.function({ input: z.tuple([]), output: z.promise(...) })
```

This syntax is **incorrect for Zod v4** because:
- In Zod v4, `z.function()` is a function factory, **not a schema**
- It cannot be used inside `z.object()`
- Causes DTS build errors: `"Object literal may only specify known properties, but 'input' does not exist"`

References:
- Zod v4 changelog: https://zod.dev/v4/changelog#zfunction
- Official workaround: https://github.com/colinhacks/zod/issues/4143
- Zod custom API: https://zod.dev/api#custom

## Solution

Use `z.custom<T>()` with runtime validator:
```typescript
pollFn: z.custom<() => Promise<unknown>>((val) => typeof val === "function")
onProgress: z.custom<(current: number, total: number) => void>((val) => typeof val === "function")
```

This approach:
- ✅ Fixes DTS build errors
- ✅ Preserves TypeScript type inference  
- ✅ Adds runtime function validation (Zod best practice)

## Why CI Didn't Catch This

CI runs `pnpm check-types` which executes `tsc --noEmit` and **does detect the error**.

However, Turbo's remote cache caused the check to be skipped:
1. PR #5107 only changed `package.json` (dependency version)
2. Turbo cached the type check results from before the breaking change
3. Subsequent PRs didn't modify core-schemas files
4. Cache kept being reused, CI never actually ran type check

## Verification

**Before (main branch):**
```bash
$ pnpm build
# DTS Build error
src/auth/kilocode.ts(36,23): error TS2561: Object literal may only specify known properties, 
but 'input' does not exist
```

**After (this PR):**
```bash
$ pnpm build
# DTS ⚡️ Build success
```

## Test Plan
- [x] Type check passes: `pnpm check-types`
- [x] Build succeeds: `pnpm build` (ESM, CJS, DTS all pass)
- [x] Type inference verified: `PollingOptions` type still correct
- [x] Runtime validation added: `typeof val === "function"`

cc #5107