### PR TITLE
feat(cli): add JSON schema contract (v1.0.0) for --json/--json-io modes

### DIFF
--- a/.changeset/cli-json-schema-contract.md
+++ b/.changeset/cli-json-schema-contract.md
@@ -1,0 +1,15 @@
+---
+"@kilocode/cli": minor
+"@kilocode/core-schemas": minor
+---
+
+Add JSON schema contract (v1.0.0) for CLI --json/--json-io modes
+
+Output messages now include:
+
+- schemaVersion: Version identifier for automation compatibility
+- messageId: Unique identifier for message tracking
+- event: Unified event type for semantic categorization
+- status: Message completion status (partial/complete)
+
+Input messages support both versioned (v1.0.0) and legacy formats for backward compatibility.

--- a/cli/src/ui/utils/__tests__/eventMapper.test.ts
+++ b/cli/src/ui/utils/__tests__/eventMapper.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest"
+import { getCliMessageEvent, getExtensionMessageEvent } from "../eventMapper.js"
+import type { CliMessage } from "../../../types/cli.js"
+import type { ExtensionChatMessage } from "../../../types/messages.js"
+
+function createCliMessage(overrides: Partial<CliMessage>): CliMessage {
+	return {
+		id: "test-id",
+		type: "assistant",
+		content: "test content",
+		ts: Date.now(),
+		...overrides,
+	}
+}
+
+function createExtensionMessage(overrides: Partial<ExtensionChatMessage>): ExtensionChatMessage {
+	return {
+		ts: Date.now(),
+		type: "say",
+		...overrides,
+	}
+}
+
+describe("getCliMessageEvent", () => {
+	it("maps welcome type to system.welcome", () => {
+		const message = createCliMessage({ type: "welcome" })
+		expect(getCliMessageEvent(message)).toBe("system.welcome")
+	})
+
+	it("maps error type to system.error", () => {
+		const message = createCliMessage({ type: "error" })
+		expect(getCliMessageEvent(message)).toBe("system.error")
+	})
+
+	it("maps system type to system.info", () => {
+		const message = createCliMessage({ type: "system" })
+		expect(getCliMessageEvent(message)).toBe("system.info")
+	})
+
+	it("maps empty type to system.empty", () => {
+		const message = createCliMessage({ type: "empty" })
+		expect(getCliMessageEvent(message)).toBe("system.empty")
+	})
+
+	it("maps user type to user.message", () => {
+		const message = createCliMessage({ type: "user" })
+		expect(getCliMessageEvent(message)).toBe("user.message")
+	})
+
+	it("maps assistant type to assistant.message", () => {
+		const message = createCliMessage({ type: "assistant" })
+		expect(getCliMessageEvent(message)).toBe("assistant.message")
+	})
+
+	it("maps requestCheckpointRestoreApproval to task.checkpoint", () => {
+		const message = createCliMessage({ type: "requestCheckpointRestoreApproval" })
+		expect(getCliMessageEvent(message)).toBe("task.checkpoint")
+	})
+})
+
+describe("getExtensionMessageEvent", () => {
+	describe("ask messages", () => {
+		it("maps tool ask to tool.request", () => {
+			const message = createExtensionMessage({ type: "ask", ask: "tool" })
+			expect(getExtensionMessageEvent(message)).toBe("tool.request")
+		})
+
+		it("maps command ask to tool.request", () => {
+			const message = createExtensionMessage({ type: "ask", ask: "command" })
+			expect(getExtensionMessageEvent(message)).toBe("tool.request")
+		})
+
+		it("maps followup ask to user.approval", () => {
+			const message = createExtensionMessage({ type: "ask", ask: "followup" })
+			expect(getExtensionMessageEvent(message)).toBe("user.approval")
+		})
+
+		it("maps api_req_failed ask to api.request_failed", () => {
+			const message = createExtensionMessage({ type: "ask", ask: "api_req_failed" })
+			expect(getExtensionMessageEvent(message)).toBe("api.request_failed")
+		})
+
+		it("maps completion_result ask to task.completed", () => {
+			const message = createExtensionMessage({ type: "ask", ask: "completion_result" })
+			expect(getExtensionMessageEvent(message)).toBe("task.completed")
+		})
+
+		it("maps resume_task ask to task.resumed", () => {
+			const message = createExtensionMessage({ type: "ask", ask: "resume_task" })
+			expect(getExtensionMessageEvent(message)).toBe("task.resumed")
+		})
+
+		it("maps command_output ask to tool.request", () => {
+			const message = createExtensionMessage({ type: "ask", ask: "command_output" })
+			expect(getExtensionMessageEvent(message)).toBe("tool.request")
+		})
+
+		it("maps unknown ask to unknown", () => {
+			const message = createExtensionMessage({ type: "ask", ask: "some_unknown_type" })
+			expect(getExtensionMessageEvent(message)).toBe("unknown")
+		})
+	})
+
+	describe("say messages", () => {
+		it("maps text say to assistant.message", () => {
+			const message = createExtensionMessage({ type: "say", say: "text" })
+			expect(getExtensionMessageEvent(message)).toBe("assistant.message")
+		})
+
+		it("maps user_feedback say to user.message", () => {
+			const message = createExtensionMessage({ type: "say", say: "user_feedback" })
+			expect(getExtensionMessageEvent(message)).toBe("user.message")
+		})
+
+		it("maps user_feedback_diff say to user.message", () => {
+			const message = createExtensionMessage({ type: "say", say: "user_feedback_diff" })
+			expect(getExtensionMessageEvent(message)).toBe("user.message")
+		})
+
+		it("maps reasoning say to assistant.reasoning", () => {
+			const message = createExtensionMessage({ type: "say", say: "reasoning" })
+			expect(getExtensionMessageEvent(message)).toBe("assistant.reasoning")
+		})
+
+		it("maps completion_result say to assistant.completion", () => {
+			const message = createExtensionMessage({ type: "say", say: "completion_result" })
+			expect(getExtensionMessageEvent(message)).toBe("assistant.completion")
+		})
+
+		it("maps api_req_started say to api.request_started", () => {
+			const message = createExtensionMessage({ type: "say", say: "api_req_started" })
+			expect(getExtensionMessageEvent(message)).toBe("api.request_started")
+		})
+
+		it("maps api_req_finished say to api.request_completed", () => {
+			const message = createExtensionMessage({ type: "say", say: "api_req_finished" })
+			expect(getExtensionMessageEvent(message)).toBe("api.request_completed")
+		})
+
+		it("maps command_output say to tool.output", () => {
+			const message = createExtensionMessage({ type: "say", say: "command_output" })
+			expect(getExtensionMessageEvent(message)).toBe("tool.output")
+		})
+
+		it("maps condense_context say to context.condensed", () => {
+			const message = createExtensionMessage({ type: "say", say: "condense_context" })
+			expect(getExtensionMessageEvent(message)).toBe("context.condensed")
+		})
+
+		it("maps sliding_window_truncation say to context.truncated", () => {
+			const message = createExtensionMessage({ type: "say", say: "sliding_window_truncation" })
+			expect(getExtensionMessageEvent(message)).toBe("context.truncated")
+		})
+
+		it("maps error say to system.error", () => {
+			const message = createExtensionMessage({ type: "say", say: "error" })
+			expect(getExtensionMessageEvent(message)).toBe("system.error")
+		})
+
+		it("maps unknown say to unknown", () => {
+			const message = createExtensionMessage({ type: "say", say: "some_unknown_type" })
+			expect(getExtensionMessageEvent(message)).toBe("unknown")
+		})
+	})
+
+	it("returns unknown for message without ask or say", () => {
+		const message = createExtensionMessage({ type: "ask" })
+		expect(getExtensionMessageEvent(message)).toBe("unknown")
+	})
+})

--- a/cli/src/ui/utils/__tests__/messageId.test.ts
+++ b/cli/src/ui/utils/__tests__/messageId.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest"
+import { generateCliMessageId, generateExtensionMessageId } from "../messageId.js"
+import type { CliMessage } from "../../../types/cli.js"
+import type { ExtensionChatMessage } from "../../../types/messages.js"
+
+function createCliMessage(overrides: Partial<CliMessage>): CliMessage {
+	return {
+		id: "test-id",
+		type: "assistant",
+		content: "test content",
+		ts: 1704067200000,
+		...overrides,
+	}
+}
+
+function createExtensionMessage(overrides: Partial<ExtensionChatMessage>): ExtensionChatMessage {
+	return {
+		ts: 1704067200000,
+		type: "say",
+		...overrides,
+	}
+}
+
+describe("generateCliMessageId", () => {
+	it("generates ID with cli prefix", () => {
+		const message = createCliMessage({})
+		const id = generateCliMessageId(message)
+		expect(id).toMatch(/^cli-/)
+	})
+
+	it("includes timestamp in ID", () => {
+		const message = createCliMessage({ ts: 1704067200000 })
+		const id = generateCliMessageId(message)
+		expect(id).toContain("1704067200000")
+	})
+
+	it("generates deterministic IDs for same input", () => {
+		const message = createCliMessage({ id: "unique-id", ts: 1704067200000 })
+		const id1 = generateCliMessageId(message)
+		const id2 = generateCliMessageId(message)
+		expect(id1).toBe(id2)
+	})
+
+	it("generates different IDs for different messages", () => {
+		const message1 = createCliMessage({ id: "id-1", ts: 1704067200000 })
+		const message2 = createCliMessage({ id: "id-2", ts: 1704067200000 })
+		const id1 = generateCliMessageId(message1)
+		const id2 = generateCliMessageId(message2)
+		expect(id1).not.toBe(id2)
+	})
+
+	it("handles messages without id by using content", () => {
+		const message = createCliMessage({ id: "", content: "some content", ts: 1704067200000 })
+		const id = generateCliMessageId(message)
+		expect(id).toMatch(/^cli-1704067200000-/)
+	})
+
+	it("handles messages without content by using type", () => {
+		const message = createCliMessage({ id: "", content: "", type: "error", ts: 1704067200000 })
+		const id = generateCliMessageId(message)
+		expect(id).toMatch(/^cli-1704067200000-/)
+	})
+})
+
+describe("generateExtensionMessageId", () => {
+	it("generates ID with ext prefix", () => {
+		const message = createExtensionMessage({})
+		const id = generateExtensionMessageId(message)
+		expect(id).toMatch(/^ext-/)
+	})
+
+	it("includes timestamp in ID", () => {
+		const message = createExtensionMessage({ ts: 1704067200000 })
+		const id = generateExtensionMessageId(message)
+		expect(id).toContain("1704067200000")
+	})
+
+	it("generates deterministic IDs for same input", () => {
+		const message = createExtensionMessage({ type: "say", say: "text", text: "hello", ts: 1704067200000 })
+		const id1 = generateExtensionMessageId(message)
+		const id2 = generateExtensionMessageId(message)
+		expect(id1).toBe(id2)
+	})
+
+	it("generates different IDs for different message types", () => {
+		const message1 = createExtensionMessage({ type: "ask", ask: "tool", ts: 1704067200000 })
+		const message2 = createExtensionMessage({ type: "say", say: "text", ts: 1704067200000 })
+		const id1 = generateExtensionMessageId(message1)
+		const id2 = generateExtensionMessageId(message2)
+		expect(id1).not.toBe(id2)
+	})
+
+	it("includes ask type in hash calculation", () => {
+		const message1 = createExtensionMessage({ type: "ask", ask: "tool", ts: 1704067200000 })
+		const message2 = createExtensionMessage({ type: "ask", ask: "command", ts: 1704067200000 })
+		const id1 = generateExtensionMessageId(message1)
+		const id2 = generateExtensionMessageId(message2)
+		expect(id1).not.toBe(id2)
+	})
+
+	it("includes say type in hash calculation", () => {
+		const message1 = createExtensionMessage({ type: "say", say: "text", ts: 1704067200000 })
+		const message2 = createExtensionMessage({ type: "say", say: "error", ts: 1704067200000 })
+		const id1 = generateExtensionMessageId(message1)
+		const id2 = generateExtensionMessageId(message2)
+		expect(id1).not.toBe(id2)
+	})
+
+	it("generates same ID for messages with different text (streaming stability)", () => {
+		// During streaming, text changes but messageId should remain stable
+		const partialMessage = createExtensionMessage({
+			type: "say",
+			say: "text",
+			text: "Hello",
+			partial: true,
+			ts: 1704067200000,
+		})
+		const completeMessage = createExtensionMessage({
+			type: "say",
+			say: "text",
+			text: "Hello, world!",
+			partial: false,
+			ts: 1704067200000,
+		})
+		const id1 = generateExtensionMessageId(partialMessage)
+		const id2 = generateExtensionMessageId(completeMessage)
+		expect(id1).toBe(id2) // Same ID for streaming updates
+	})
+})

--- a/cli/src/ui/utils/eventMapper.ts
+++ b/cli/src/ui/utils/eventMapper.ts
@@ -1,0 +1,32 @@
+/**
+ * Event mapping utilities for JSON schema contract
+ *
+ * Maps various message formats to unified event types for consistent
+ * automation integration.
+ */
+
+import { type OutputEvent, mapCliTypeToEvent, mapAskToEvent, mapSayToEvent } from "@kilocode/core-schemas"
+import type { CliMessage } from "../../types/cli.js"
+import type { ExtensionChatMessage } from "../../types/messages.js"
+
+/**
+ * Get unified event type from a CLI message
+ */
+export function getCliMessageEvent(message: CliMessage): OutputEvent {
+	return mapCliTypeToEvent(message.type)
+}
+
+/**
+ * Get unified event type from an extension message
+ */
+export function getExtensionMessageEvent(message: ExtensionChatMessage): OutputEvent {
+	if (message.type === "ask" && message.ask) {
+		return mapAskToEvent(message.ask)
+	}
+
+	if (message.type === "say" && message.say) {
+		return mapSayToEvent(message.say)
+	}
+
+	return "unknown"
+}

--- a/cli/src/ui/utils/jsonOutput.ts
+++ b/cli/src/ui/utils/jsonOutput.ts
@@ -1,37 +1,57 @@
 /**
  * JSON output utilities for CI mode
  * Converts messages to JSON format for non-interactive output
+ *
+ * Schema v1.0.0 adds:
+ * - schemaVersion: Version identifier for automation compatibility
+ * - event: Unified event type for semantic categorization
+ * - messageId: Unique identifier for message tracking
+ * - status: Message completion status (partial/complete)
  */
 
+import { JSON_SCHEMA_VERSION, type MessageStatus } from "@kilocode/core-schemas"
 import type { UnifiedMessage } from "../../state/atoms/ui.js"
 import type { ExtensionChatMessage } from "../../types/messages.js"
 import type { CliMessage } from "../../types/cli.js"
+import { getCliMessageEvent, getExtensionMessageEvent } from "./eventMapper.js"
+import { generateCliMessageId, generateExtensionMessageId } from "./messageId.js"
 
 /**
- * Convert a CLI message to JSON output format
+ * Convert a CLI message to JSON output format (v1.0.0)
  */
 function formatCliMessage(message: CliMessage) {
 	const { ts, ...restOfMessage } = message
+	const status: MessageStatus = message.partial ? "partial" : "complete"
+
 	return {
+		schemaVersion: JSON_SCHEMA_VERSION,
+		messageId: generateCliMessageId(message),
 		timestamp: ts,
-		source: "cli",
-		...restOfMessage,
+		source: "cli" as const,
+		event: getCliMessageEvent(message),
+		status,
+		...restOfMessage, // preserves partial for backward compatibility
 	}
 }
 
 /**
- * Convert an extension message to JSON output format
+ * Convert an extension message to JSON output format (v1.0.0)
  *
  * If text is valid JSON (object/array), it's placed in 'metadata' field.
  * If text is plain text or malformed JSON, it's placed in 'content' field.
  */
 function formatExtensionMessage(message: ExtensionChatMessage) {
 	const { ts, text, ...restOfMessage } = message
+	const status: MessageStatus = message.partial ? "partial" : "complete"
 
 	const output: Record<string, unknown> = {
+		schemaVersion: JSON_SCHEMA_VERSION,
+		messageId: generateExtensionMessageId(message),
 		timestamp: ts,
-		source: "extension",
-		...restOfMessage,
+		source: "extension" as const,
+		event: getExtensionMessageEvent(message),
+		status,
+		...restOfMessage, // preserves partial for backward compatibility
 	}
 
 	if (text) {

--- a/cli/src/ui/utils/messageId.ts
+++ b/cli/src/ui/utils/messageId.ts
@@ -1,0 +1,55 @@
+/**
+ * Message ID generation utilities for JSON schema contract
+ *
+ * Generates unique, deterministic message IDs for tracking messages
+ * in automation workflows.
+ */
+
+import type { CliMessage } from "../../types/cli.js"
+import type { ExtensionChatMessage } from "../../types/messages.js"
+
+/**
+ * Generate a short hash from string content
+ */
+function shortHash(str: string): string {
+	let hash = 0
+	for (let i = 0; i < str.length; i++) {
+		const char = str.charCodeAt(i)
+		hash = (hash << 5) - hash + char
+		hash = hash & hash // Convert to 32-bit integer
+	}
+	// Convert to base36 and take last 6 characters for brevity
+	return Math.abs(hash).toString(36).slice(-6).padStart(6, "0")
+}
+
+/**
+ * Generate a unique message ID for a CLI message
+ *
+ * Format: cli-{timestamp}-{hash}
+ * Uses existing id if available, otherwise generates from content
+ */
+export function generateCliMessageId(message: CliMessage): string {
+	// Use existing id if present
+	if (message.id) {
+		return `cli-${message.ts}-${shortHash(message.id)}`
+	}
+
+	// Generate hash from content
+	const contentHash = shortHash(message.content || message.type)
+	return `cli-${message.ts}-${contentHash}`
+}
+
+/**
+ * Generate a unique message ID for an extension message
+ *
+ * Format: ext-{timestamp}-{hash}
+ * Uses stable message properties (not text) to create deterministic hash
+ * that remains consistent across partial/complete streaming updates.
+ */
+export function generateExtensionMessageId(message: ExtensionChatMessage): string {
+	// Create hash from stable message properties only (not text, which changes during streaming)
+	const hashSource = [message.type, message.ask || "", message.say || ""].join("|")
+
+	const contentHash = shortHash(hashSource)
+	return `ext-${message.ts}-${contentHash}`
+}

--- a/packages/core-schemas/src/messages/events.ts
+++ b/packages/core-schemas/src/messages/events.ts
@@ -1,0 +1,191 @@
+import { z } from "zod"
+
+/**
+ * Current JSON schema version for CLI output/input
+ */
+export const JSON_SCHEMA_VERSION = "1.0.0"
+
+/**
+ * Unified event types for CLI JSON output
+ *
+ * These provide semantic categorization of all message types,
+ * making it easier for automation tools to handle different events.
+ */
+export const outputEventSchema = z.enum([
+	// System events
+	"system.welcome",
+	"system.error",
+	"system.info",
+	"system.ready",
+	"system.empty",
+
+	// User interaction
+	"user.message",
+	"user.approval",
+
+	// Assistant events
+	"assistant.message",
+	"assistant.reasoning",
+	"assistant.completion",
+
+	// Tool events
+	"tool.request",
+	"tool.approved",
+	"tool.rejected",
+	"tool.output",
+
+	// API events
+	"api.request_started",
+	"api.request_completed",
+	"api.request_failed",
+	"api.request_retried",
+
+	// Task lifecycle
+	"task.resumed",
+	"task.completed",
+	"task.checkpoint",
+
+	// Context management
+	"context.condensed",
+	"context.truncated",
+
+	// Unknown/unmapped events
+	"unknown",
+])
+
+export type OutputEvent = z.infer<typeof outputEventSchema>
+
+/**
+ * Message status for streaming support
+ */
+export const messageStatusSchema = z.enum(["partial", "complete"])
+
+export type MessageStatus = z.infer<typeof messageStatusSchema>
+
+/**
+ * CLI message types
+ */
+export const cliMessageTypeSchema = z.enum([
+	"user",
+	"assistant",
+	"system",
+	"error",
+	"welcome",
+	"empty",
+	"requestCheckpointRestoreApproval",
+])
+
+export type CliMessageType = z.infer<typeof cliMessageTypeSchema>
+
+/**
+ * Map CLI message type to unified event
+ */
+export function mapCliTypeToEvent(type: string): OutputEvent {
+	switch (type) {
+		case "welcome":
+			return "system.welcome"
+		case "error":
+			return "system.error"
+		case "system":
+			return "system.info"
+		case "empty":
+			return "system.empty"
+		case "user":
+			return "user.message"
+		case "assistant":
+			return "assistant.message"
+		case "requestCheckpointRestoreApproval":
+			return "task.checkpoint"
+		default:
+			return "unknown"
+	}
+}
+
+/**
+ * Map extension "ask" type to unified event
+ */
+export function mapAskToEvent(ask: string): OutputEvent {
+	switch (ask) {
+		case "followup":
+			return "user.approval"
+		case "tool":
+		case "command":
+		case "browser_action_launch":
+		case "use_mcp_server":
+			return "tool.request"
+		case "api_req_failed":
+			return "api.request_failed"
+		case "resume_task":
+		case "resume_completed_task":
+			return "task.resumed"
+		case "completion_result":
+			return "task.completed"
+		case "checkpoint_restore":
+			return "task.checkpoint"
+		case "command_output":
+			return "tool.request"
+		case "mistake_limit_reached":
+		case "auto_approval_max_req_reached":
+		case "payment_required_prompt":
+		case "invalid_model":
+		case "report_bug":
+		case "condense":
+			return "user.approval"
+		default:
+			return "unknown"
+	}
+}
+
+/**
+ * Map extension "say" type to unified event
+ */
+export function mapSayToEvent(say: string): OutputEvent {
+	switch (say) {
+		case "text":
+			return "assistant.message"
+		case "user_feedback":
+		case "user_feedback_diff":
+			return "user.message"
+		case "reasoning":
+			return "assistant.reasoning"
+		case "completion_result":
+			return "assistant.completion"
+		case "api_req_started":
+			return "api.request_started"
+		case "api_req_finished":
+			return "api.request_completed"
+		case "api_req_retried":
+		case "api_req_retry_delayed":
+		case "api_req_rate_limit_wait":
+			return "api.request_retried"
+		case "api_req_deleted":
+			return "api.request_failed"
+		case "command_output":
+		case "browser_action":
+		case "browser_action_result":
+		case "mcp_server_request_started":
+		case "mcp_server_response":
+		case "subtask_result":
+			return "tool.output"
+		case "checkpoint_saved":
+			return "task.checkpoint"
+		case "condense_context":
+			return "context.condensed"
+		case "condense_context_error":
+			return "system.error"
+		case "sliding_window_truncation":
+			return "context.truncated"
+		case "error":
+		case "rooignore_error":
+		case "diff_error":
+		case "shell_integration_warning":
+			return "system.error"
+		case "image":
+		case "codebase_search_result":
+		case "user_edit_todos":
+		case "browser_session_status":
+			return "assistant.message"
+		default:
+			return "unknown"
+	}
+}

--- a/packages/core-schemas/src/messages/index.ts
+++ b/packages/core-schemas/src/messages/index.ts
@@ -3,3 +3,8 @@ export * from "./cli.js"
 
 // Extension message types
 export * from "./extension.js"
+
+// JSON schema contract (v1.0.0)
+export * from "./events.js"
+export * from "./output.js"
+export * from "./input.js"

--- a/packages/core-schemas/src/messages/input.ts
+++ b/packages/core-schemas/src/messages/input.ts
@@ -1,0 +1,168 @@
+import { z } from "zod"
+import { JSON_SCHEMA_VERSION } from "./events.js"
+
+/**
+ * Input message schema for --json-io mode
+ *
+ * Supports both versioned (v1.0.0) and legacy formats for backward compatibility.
+ */
+
+/**
+ * Versioned input message schema (v1.0.0)
+ *
+ * Use discriminated union to enforce response field when type="response"
+ */
+const baseVersionedInputSchema = z.object({
+	schemaVersion: z.literal(JSON_SCHEMA_VERSION),
+	content: z.string().optional(),
+	images: z.array(z.string()).optional(),
+	metadata: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const versionedInputMessageSchema = z.discriminatedUnion("type", [
+	// User input
+	baseVersionedInputSchema.extend({
+		type: z.literal("user_input"),
+	}),
+	// Tool approval
+	baseVersionedInputSchema.extend({
+		type: z.literal("approval"),
+	}),
+	// Tool rejection
+	baseVersionedInputSchema.extend({
+		type: z.literal("rejection"),
+	}),
+	// Abort task
+	baseVersionedInputSchema.extend({
+		type: z.literal("abort"),
+	}),
+	// Special askResponse (retry_clicked, objectResponse, messageResponse)
+	baseVersionedInputSchema.extend({
+		type: z.literal("response"),
+		response: z.enum(["messageResponse", "retry_clicked", "objectResponse"]), // Required for type="response"
+	}),
+])
+
+/**
+ * Legacy input message schema (pre-v1.0.0)
+ *
+ * Matches the actual format accepted by useStdinJsonHandler.
+ * Examples:
+ *   {"type": "askResponse", "text": "hello"}
+ *   {"type": "askResponse", "askResponse": "yesButtonClicked"}
+ *   {"type": "respondToApproval", "approved": true}
+ *   {"type": "cancelTask"}
+ */
+export const legacyInputMessageSchema = z.object({
+	// Message type determines how to handle
+	type: z.enum(["askResponse", "respondToApproval", "cancelTask"]),
+
+	// For askResponse: the response type or defaults to messageResponse
+	askResponse: z.string().optional(),
+
+	// User text input
+	text: z.string().optional(),
+
+	// Image attachments
+	images: z.array(z.string()).optional(),
+
+	// For respondToApproval: approval decision
+	approved: z.boolean().optional(),
+})
+
+/**
+ * Combined input message schema
+ *
+ * Accepts both versioned and legacy formats.
+ * Consumers should check for schemaVersion to determine format.
+ */
+export const inputMessageSchema = z.union([versionedInputMessageSchema, legacyInputMessageSchema])
+
+// Inferred types
+export type VersionedInputMessage = z.infer<typeof versionedInputMessageSchema>
+export type LegacyInputMessage = z.infer<typeof legacyInputMessageSchema>
+export type InputMessage = z.infer<typeof inputMessageSchema>
+
+/**
+ * Check if an input message is versioned (v1.0.0)
+ */
+export function isVersionedInput(input: InputMessage): input is VersionedInputMessage {
+	return "schemaVersion" in input && input.schemaVersion === JSON_SCHEMA_VERSION
+}
+
+/**
+ * Normalize legacy input to versioned format
+ */
+export function normalizeInput(input: InputMessage): VersionedInputMessage {
+	if (isVersionedInput(input)) {
+		return input
+	}
+
+	// Convert legacy format to versioned format
+	const legacy = input as LegacyInputMessage
+
+	switch (legacy.type) {
+		case "cancelTask":
+			return {
+				schemaVersion: JSON_SCHEMA_VERSION,
+				type: "abort",
+				images: legacy.images,
+			}
+
+		case "respondToApproval":
+			return {
+				schemaVersion: JSON_SCHEMA_VERSION,
+				type: legacy.approved ? "approval" : "rejection",
+				content: legacy.text,
+				images: legacy.images,
+			}
+
+		case "askResponse":
+			// Map common responses to semantic types
+			if (legacy.askResponse === "yesButtonClicked") {
+				return {
+					schemaVersion: JSON_SCHEMA_VERSION,
+					type: "approval",
+					content: legacy.text,
+					images: legacy.images,
+				}
+			}
+			if (legacy.askResponse === "noButtonClicked") {
+				return {
+					schemaVersion: JSON_SCHEMA_VERSION,
+					type: "rejection",
+					content: legacy.text,
+					images: legacy.images,
+				}
+			}
+			// Special response types (retry_clicked, objectResponse) use response field
+			if (
+				legacy.askResponse === "retry_clicked" ||
+				legacy.askResponse === "objectResponse" ||
+				legacy.askResponse === "messageResponse"
+			) {
+				return {
+					schemaVersion: JSON_SCHEMA_VERSION,
+					type: "response",
+					response: legacy.askResponse as "retry_clicked" | "objectResponse" | "messageResponse",
+					content: legacy.text,
+					images: legacy.images,
+				}
+			}
+			// Unknown askResponse: treat as user input
+			return {
+				schemaVersion: JSON_SCHEMA_VERSION,
+				type: "user_input",
+				content: legacy.text ?? "",
+				images: legacy.images,
+			}
+
+		default:
+			return {
+				schemaVersion: JSON_SCHEMA_VERSION,
+				type: "user_input",
+				content: "",
+				images: legacy.images,
+			}
+	}
+}

--- a/packages/core-schemas/src/messages/output.ts
+++ b/packages/core-schemas/src/messages/output.ts
@@ -1,0 +1,74 @@
+import { z } from "zod"
+import { JSON_SCHEMA_VERSION, outputEventSchema, messageStatusSchema } from "./events.js"
+
+/**
+ * Base fields for all JSON output messages
+ */
+const outputMessageBaseSchema = z.object({
+	schemaVersion: z.literal(JSON_SCHEMA_VERSION),
+	messageId: z.string(),
+	timestamp: z.number(),
+	source: z.enum(["cli", "extension"]),
+	event: outputEventSchema,
+	status: messageStatusSchema,
+})
+
+/**
+ * CLI-sourced output message schema
+ *
+ * Uses passthrough() to allow additional fields for backward compatibility.
+ */
+export const cliOutputMessageSchema = outputMessageBaseSchema
+	.extend({
+		source: z.literal("cli"),
+		type: z.enum(["user", "assistant", "system", "error", "welcome", "empty", "requestCheckpointRestoreApproval"]),
+		id: z.string(),
+		content: z.string(),
+		partial: z.boolean().optional(),
+		metadata: z.union([z.record(z.string(), z.unknown()), z.array(z.unknown())]).optional(),
+		payload: z.unknown().optional(),
+	})
+	.passthrough()
+
+/**
+ * Extension-sourced output message schema
+ *
+ * Uses passthrough() to allow additional fields for backward compatibility.
+ * Explicitly declares common fields for better documentation.
+ */
+export const extensionOutputMessageSchema = outputMessageBaseSchema
+	.extend({
+		source: z.literal("extension"),
+		type: z.enum(["ask", "say"]),
+		ask: z.string().optional(),
+		say: z.string().optional(),
+		content: z.string().optional(),
+		metadata: z.union([z.record(z.string(), z.unknown()), z.array(z.unknown())]).optional(),
+		// Common extension fields for backward compatibility
+		partial: z.boolean().optional(),
+		images: z.array(z.string()).optional(),
+		reasoning: z.string().optional(),
+		conversationHistoryIndex: z.number().optional(),
+		checkpoint: z.record(z.string(), z.unknown()).optional(),
+		isProtected: z.boolean().optional(),
+		apiProtocol: z.enum(["openai", "anthropic"]).optional(),
+		isAnswered: z.boolean().optional(),
+		progressStatus: z.unknown().optional(),
+		contextCondense: z.unknown().optional(),
+		contextTruncation: z.unknown().optional(),
+	})
+	.passthrough()
+
+/**
+ * Union of all output message types
+ */
+export const outputMessageSchema = z.discriminatedUnion("source", [
+	cliOutputMessageSchema,
+	extensionOutputMessageSchema,
+])
+
+// Inferred types
+export type OutputMessageBase = z.infer<typeof outputMessageBaseSchema>
+export type CliOutputMessage = z.infer<typeof cliOutputMessageSchema>
+export type ExtensionOutputMessage = z.infer<typeof extensionOutputMessageSchema>
+export type OutputMessage = z.infer<typeof outputMessageSchema>


### PR DESCRIPTION
## Summary
- Add explicit schema versioning and unified event types for CLI JSON output
- Improve automation integration stability with --json/--json-io modes

## Schema v1.0.0 Features

### Output Messages
All JSON output messages now include:
- **schemaVersion**: Version identifier (`"1.0.0"`) for automation compatibility
- **messageId**: Unique identifier for message tracking (format: `cli-{ts}-{hash}` or `ext-{ts}-{hash}`)
- **event**: Unified event type for semantic categorization
  - `system.*` - System events (welcome, error, ready, empty)
  - `user.*` - User events (message, approval)
  - `assistant.*` - Assistant events (message, reasoning, completion)
  - `tool.*` - Tool events (request, output)
  - `api.*` - API events (request_started, request_completed, request_failed)
  - `task.*` - Task events (resumed, completed, checkpoint)
  - `context.*` - Context events (condensed, truncated)
- **status**: Message completion status (`partial` | `complete`)

### Input Messages
Supports both **versioned (v1.0.0)** and **legacy** formats:

**Versioned format:**
```json
{"schemaVersion": "1.0.0", "type": "user_input", "content": "hello"}
{"schemaVersion": "1.0.0", "type": "approval"}
{"schemaVersion": "1.0.0", "type": "rejection", "content": "reason"}
{"schemaVersion": "1.0.0", "type": "abort"}
{"schemaVersion": "1.0.0", "type": "response", "response": "retry_clicked"}
```

**Legacy format** (still supported):
```json
{"type": "askResponse", "text": "hello"}
{"type": "respondToApproval", "approved": true}
{"type": "cancelTask"}
```

## Implementation

### New Files
- `packages/core-schemas/src/messages/events.ts` - Event types and mapping functions
- `packages/core-schemas/src/messages/output.ts` - Output message schemas
- `packages/core-schemas/src/messages/input.ts` - Input message schemas (discriminated union)
- `cli/src/ui/utils/eventMapper.ts` - CLI event mapping utilities
- `cli/src/ui/utils/messageId.ts` - Message ID generation (streaming-stable)

### Key Design Decisions

1. **Backward Compatibility**
   - Output: `.passthrough()` preserves all original fields
   - Input: Dual handler for versioned + legacy formats
   - Legacy messages log deprecation warning but work normally

2. **Event Mapping Correctness**
   - `user_feedback` → `user.message` (not assistant)
   - `command_output` ask → `tool.request` (not output)
   - `command_output` say → `tool.output`

3. **Streaming Stability**
   - `messageId` uses stable properties (type, ask/say, timestamp)
   - Does NOT use text content (which changes during streaming)
   - Same messageId for partial/complete updates

4. **Special Response Types**
   - `retry_clicked` - Payment/model error retry
   - `objectResponse` - Multi-file diff selection
   - Handled via discriminated union with required `response` field

## Test Coverage
- ✅ 2025+ tests pass
- ✅ Event mapper tests (170 lines) - All event mappings
- ✅ Message ID tests (129 lines) - Streaming stability
- ✅ JSON output tests (updated) - v1.0.0 fields validation
- ✅ Stdin handler tests (256 lines) - Versioned + legacy formats, images, response types

## Test Plan
- [x] Type check passes
- [x] All CLI tests pass (2025 tests)
- [x] Build succeeds
- [x] Backward compatibility verified (legacy format works)
- [x] Event mappings tested (user_feedback, command_output)
- [x] Special responses tested (retry_clicked, objectResponse)