### PR TITLE
feat(cli): add custom commands support

### DIFF
--- a/.changeset/metal-sheep-fry.md
+++ b/.changeset/metal-sheep-fry.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+add custom commands support

--- a/apps/kilocode-docs/docs/cli.md
+++ b/apps/kilocode-docs/docs/cli.md
@@ -141,6 +141,142 @@ There are community efforts to build and share agent skills. Some resources incl
 - [Skills Marketplace](https://skillsmp.com/) - Community marketplace of skills
 - [Skill Specification](https://agentskills.io/home) - Agent Skills specification
 
+## Custom Commands
+
+Custom commands allow you to create reusable slash commands that execute predefined prompts with argument substitution. They provide a convenient way to streamline repetitive tasks and standardize workflows.
+
+Custom commands are discovered from:
+
+- **Global commands**: `~/.kilocode/commands/` (available in all projects)
+- **Project commands**: `.kilocode/commands/` (project-specific)
+
+Commands are simple markdown files with YAML frontmatter for configuration.
+
+### Creating a Custom Command
+
+1. Create the commands directory:
+
+    ```bash
+    mkdir -p ~/.kilocode/commands # mkdir %USERPROFILE%\.kilocode\commands on windows
+    ```
+
+2. Create a markdown file (e.g., `component.md`):
+
+    ```markdown
+    ---
+    description: Create a new React component
+    arguments:
+        - ComponentName
+    ---
+
+    Create a new React component named $1.
+    Include:
+
+    - Proper TypeScript typing
+    - Basic component structure
+    - Export statement
+    - A simple props interface if appropriate
+
+    Place it in the appropriate directory based on the project structure.
+    ```
+
+3. Use the command in your CLI session:
+
+    ```bash
+    /component Button
+    ```
+
+### Frontmatter Options
+
+Custom commands support the following frontmatter fields:
+
+- **`description`** (optional): Short description shown in `/help`
+- **`arguments`** (optional): List of argument names for documentation
+- **`mode`** (optional): Automatically switch to this mode when running the command
+- **`model`** (optional): Automatically switch to this model when running the command
+
+### Argument Substitution
+
+Commands support powerful argument substitution:
+
+- **`$ARGUMENTS`**: All arguments joined with spaces
+- **`$1`, `$2`, `$3`, etc.**: Individual positional arguments
+
+**Example:**
+
+```markdown
+---
+description: Create a file with content
+arguments:
+    - filename
+    - content
+---
+
+Create a new file named $1 with the following content:
+
+$2
+```
+
+Usage: `/createfile app.ts "console.log('Hello')"`
+
+### Mode and Model Switching
+
+Commands can automatically switch modes and models:
+
+```markdown
+---
+description: Run tests with coverage
+mode: code
+model: anthropic/claude-3-5-sonnet-20241022
+---
+
+Run the full test suite with coverage report and show any failures.
+Focus on the failing tests and suggest fixes.
+```
+
+When you run `/test`, it will automatically switch to code mode and use the specified model.
+
+### Example Commands
+
+**Initialize project documentation:**
+
+```markdown
+---
+description: Analyze codebase and create AGENTS.md
+mode: code
+---
+
+Please analyze this codebase and create an AGENTS.md file containing:
+
+1. Build/lint/test commands - especially for running a single test
+2. Code style guidelines including imports, formatting, types, naming conventions
+
+Focus on project-specific, non-obvious information discovered by reading files.
+```
+
+**Refactor code:**
+
+```markdown
+---
+description: Refactor code for better quality
+arguments:
+    - filepath
+---
+
+Refactor $1 to improve:
+
+- Code readability
+- Performance
+- Maintainability
+- Type safety
+
+Explain the changes you make and why they improve the code.
+```
+
+### Command Priority
+
+Project-specific commands override global commands with the same name, allowing you to customize behavior per project while maintaining sensible defaults globally.
+
 ## Checkpoint Management
 
 Kilo Code automatically creates checkpoints as you work, allowing you to revert to previous states in your project's history.

--- a/cli/src/commands/__tests__/custom.test.ts
+++ b/cli/src/commands/__tests__/custom.test.ts
@@ -1,0 +1,667 @@
+/**
+ * Tests for custom commands
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { substituteArguments, getCustomCommands, initializeCustomCommands } from "../custom.js"
+import * as path from "path"
+import { createMockContext } from "./helpers/mockContext.js"
+import type { Command } from "../core/types.js"
+import type { Dirent } from "fs"
+
+/** Minimal mock for fs.Dirent used in readdir results */
+type MockDirent = Pick<Dirent, "name" | "isFile" | "isDirectory">
+
+// Hoist mock functions so they're available during module mocking
+const { mockReaddir, mockReadFile, mockHomedir, mockRegister } = vi.hoisted(() => ({
+	mockReaddir: vi.fn<(path: string) => Promise<MockDirent[]>>(),
+	mockReadFile: vi.fn<(path: string) => Promise<string>>(),
+	mockHomedir: vi.fn<() => string>(),
+	mockRegister: vi.fn(),
+}))
+
+vi.mock("fs/promises", () => ({
+	default: {
+		readdir: mockReaddir,
+		readFile: mockReadFile,
+	},
+	readdir: mockReaddir,
+	readFile: mockReadFile,
+}))
+
+vi.mock("os", () => ({
+	default: {
+		homedir: mockHomedir,
+	},
+	homedir: mockHomedir,
+}))
+
+vi.mock("../core/registry.js", () => ({
+	commandRegistry: {
+		register: mockRegister,
+		get: vi.fn(() => undefined), // Return undefined to indicate command doesn't exist
+	},
+}))
+
+vi.mock("../services/logs.js", () => ({
+	logs: {
+		debug: vi.fn(),
+		warn: vi.fn(),
+	},
+}))
+
+describe("Custom Commands", () => {
+	describe("substituteArguments", () => {
+		it("should replace $ARGUMENTS with all arguments", () => {
+			const content = "Process $ARGUMENTS"
+			const args = ["file1.txt", "file2.txt", "file3.txt"]
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("Process file1.txt file2.txt file3.txt")
+		})
+
+		it("should replace positional arguments $1, $2, $3", () => {
+			const content = "Copy $1 to $2 with mode $3"
+			const args = ["source.txt", "dest.txt", "overwrite"]
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("Copy source.txt to dest.txt with mode overwrite")
+		})
+
+		it("should handle both $ARGUMENTS and positional arguments", () => {
+			const content = "First arg is $1, all args are: $ARGUMENTS"
+			const args = ["alpha", "beta", "gamma"]
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("First arg is alpha, all args are: alpha beta gamma")
+		})
+
+		it("should handle empty arguments", () => {
+			const content = "No args: $ARGUMENTS and $1"
+			const args: string[] = []
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("No args:  and $1")
+		})
+
+		it("should not replace undefined positional arguments", () => {
+			const content = "Args: $1 $2 $3"
+			const args = ["first"]
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("Args: first $2 $3")
+		})
+
+		it("should handle content with no placeholders", () => {
+			const content = "Plain text content"
+			const args = ["arg1", "arg2"]
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("Plain text content")
+		})
+
+		it("should not replace currency amounts with decimals like $1.50", () => {
+			const content = "The price is $1.50 for item $1"
+			const args = ["widget"]
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("The price is $1.50 for item widget")
+		})
+
+		it("should not replace $1 when it's part of $100", () => {
+			const content = "Price is $100 and description is $1"
+			const args = ["expensive item"]
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("Price is $100 and description is expensive item")
+		})
+
+		it("should not replace $2 when it's part of $25.99", () => {
+			const content = "Cost: $25.99, item: $2, quantity: $1"
+			const args = ["5", "hammer"]
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("Cost: $25.99, item: hammer, quantity: 5")
+		})
+
+		it("should replace $1 at end of sentence with period", () => {
+			const content = "Process file $1."
+			const args = ["test.txt"]
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("Process file test.txt.")
+		})
+
+		it("should handle multiple currency amounts and placeholders", () => {
+			const content = "Budget is $1000.50, allocate $1 to $2 with $3 priority"
+			const args = ["$500", "project-a", "high"]
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("Budget is $1000.50, allocate $500 to project-a with high priority")
+		})
+
+		it("should not replace positional args in larger numbers", () => {
+			const content = "Total: $123.45, items: $1, $2, $3"
+			const args = ["apple", "banana", "cherry"]
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("Total: $123.45, items: apple, banana, cherry")
+		})
+
+		it("should handle edge case with $10 when args has one element", () => {
+			const content = "Price is $10 and name is $1"
+			const args = ["product"]
+
+			const result = substituteArguments(content, args)
+
+			expect(result).toBe("Price is $10 and name is product")
+		})
+	})
+
+	describe("getCustomCommands", () => {
+		const mockCwd = "/mock/project"
+		const mockHomeDir = "/mock/home"
+
+		beforeEach(() => {
+			vi.clearAllMocks()
+			mockHomedir.mockReturnValue(mockHomeDir)
+		})
+
+		it("should load commands from global directory", async () => {
+			const mockFiles: MockDirent[] = [
+				{
+					name: "test-command.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockImplementation(async (dirPath: string) => {
+				if (dirPath === path.join(mockHomeDir, ".kilocode", "commands")) {
+					return mockFiles
+				}
+				throw new Error("ENOENT")
+			})
+
+			mockReadFile.mockResolvedValue(`---
+description: Test command
+arguments: [arg1, arg2]
+---
+Test content with $1 and $2`)
+
+			const commands = await getCustomCommands(mockCwd)
+
+			expect(commands).toHaveLength(1)
+			expect(commands[0].name).toBe("test-command")
+			expect(commands[0].description).toBe("Test command")
+			expect(commands[0].arguments).toEqual(["arg1", "arg2"])
+			expect(commands[0].content).toBe("Test content with $1 and $2")
+		})
+
+		it("should load commands from project directory with priority", async () => {
+			const globalFiles: MockDirent[] = [
+				{
+					name: "shared-command.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			const projectFiles: MockDirent[] = [
+				{
+					name: "shared-command.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+				{
+					name: "project-command.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockImplementation(async (dirPath: string) => {
+				if (dirPath === path.join(mockHomeDir, ".kilocode", "commands")) {
+					return globalFiles
+				}
+				if (dirPath === path.join(mockCwd, ".kilocode", "commands")) {
+					return projectFiles
+				}
+				throw new Error("ENOENT")
+			})
+
+			mockReadFile.mockImplementation(async (filePath: string) => {
+				if (filePath.includes("project")) {
+					return `---
+description: Project version
+---
+Project content`
+				}
+				return `---
+description: Global version
+---
+Global content`
+			})
+
+			const commands = await getCustomCommands(mockCwd)
+
+			// Should have 2 commands total (shared-command from project overrides global)
+			expect(commands).toHaveLength(2)
+
+			const sharedCommand = commands.find((c) => c.name === "shared-command")
+			expect(sharedCommand?.description).toBe("Project version")
+			expect(sharedCommand?.content).toBe("Project content")
+		})
+
+		it("should skip non-markdown files", async () => {
+			const mockFiles: MockDirent[] = [
+				{
+					name: "command.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+				{
+					name: "readme.txt",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+				{
+					name: "config.json",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockResolvedValue(mockFiles)
+			mockReadFile.mockResolvedValue(`---
+description: Valid command
+---
+Content`)
+
+			const commands = await getCustomCommands(mockCwd)
+
+			expect(commands).toHaveLength(1)
+			expect(commands[0].name).toBe("command")
+		})
+
+		it("should handle missing directories gracefully", async () => {
+			mockReaddir.mockRejectedValue(new Error("ENOENT"))
+
+			const commands = await getCustomCommands(mockCwd)
+
+			expect(commands).toHaveLength(0)
+		})
+
+		it("should parse mode and model from frontmatter", async () => {
+			const mockFiles: MockDirent[] = [
+				{
+					name: "test.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockResolvedValue(mockFiles)
+			mockReadFile.mockResolvedValue(`---
+description: Test command
+mode: plan
+model: opus
+---
+Content`)
+
+			const commands = await getCustomCommands(mockCwd)
+
+			expect(commands[0].mode).toBe("plan")
+			expect(commands[0].model).toBe("opus")
+		})
+
+		it("should skip files with invalid command names starting with --", async () => {
+			const mockFiles: MockDirent[] = [
+				{
+					name: "--test.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+				{
+					name: "valid.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockResolvedValue(mockFiles)
+			mockReadFile.mockResolvedValue(`---
+description: Test
+---
+Content`)
+
+			const commands = await getCustomCommands(mockCwd)
+
+			expect(commands).toHaveLength(1)
+			expect(commands[0].name).toBe("valid")
+		})
+
+		it("should skip files with invalid command names starting with -", async () => {
+			const mockFiles: MockDirent[] = [
+				{
+					name: "-test.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+				{
+					name: "valid-name.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockResolvedValue(mockFiles)
+			mockReadFile.mockResolvedValue(`---
+description: Test
+---
+Content`)
+
+			const commands = await getCustomCommands(mockCwd)
+
+			expect(commands).toHaveLength(1)
+			expect(commands[0].name).toBe("valid-name")
+		})
+
+		it("should skip files with special characters in names", async () => {
+			const mockFiles: MockDirent[] = [
+				{
+					name: "test!.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+				{
+					name: "test@command.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+				{
+					name: "test$var.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+				{
+					name: "valid123.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockResolvedValue(mockFiles)
+			mockReadFile.mockResolvedValue(`---
+description: Test
+---
+Content`)
+
+			const commands = await getCustomCommands(mockCwd)
+
+			expect(commands).toHaveLength(1)
+			expect(commands[0].name).toBe("valid123")
+		})
+
+		it("should accept valid command names with alphanumeric and hyphens", async () => {
+			const mockFiles: MockDirent[] = [
+				{
+					name: "test-command.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+				{
+					name: "my-command-123.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+				{
+					name: "ABC-xyz-999.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockResolvedValue(mockFiles)
+			mockReadFile.mockResolvedValue(`---
+description: Test
+---
+Content`)
+
+			const commands = await getCustomCommands(mockCwd)
+
+			expect(commands).toHaveLength(3)
+			expect(commands.map((c) => c.name).sort()).toEqual(["ABC-xyz-999", "my-command-123", "test-command"])
+		})
+	})
+
+	describe("initializeCustomCommands", () => {
+		const mockCwd = "/mock/project"
+
+		beforeEach(() => {
+			vi.clearAllMocks()
+			mockHomedir.mockReturnValue("/mock/home")
+		})
+
+		it("should register custom commands", async () => {
+			const mockFiles: MockDirent[] = [
+				{
+					name: "test.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockResolvedValue(mockFiles)
+			mockReadFile.mockResolvedValue(`---
+description: Test command
+---
+Test content`)
+
+			await initializeCustomCommands(mockCwd)
+
+			expect(mockRegister).toHaveBeenCalledTimes(1)
+			expect(mockRegister).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: "test",
+					description: "Test command",
+					category: "chat",
+					priority: 3,
+				}),
+			)
+		})
+
+		it("should handle errors gracefully", async () => {
+			mockReaddir.mockRejectedValue(new Error("Permission denied"))
+
+			// Should not throw
+			await expect(initializeCustomCommands(mockCwd)).resolves.not.toThrow()
+		})
+
+		it("should not register commands if none found", async () => {
+			mockReaddir.mockRejectedValue(new Error("ENOENT"))
+
+			await initializeCustomCommands(mockCwd)
+
+			expect(mockRegister).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("custom command handler", () => {
+		const mockCwd = "/mock/project"
+
+		beforeEach(() => {
+			vi.clearAllMocks()
+			mockHomedir.mockReturnValue("/mock/home")
+		})
+
+		async function getRegisteredHandler(): Promise<Command["handler"]> {
+			const mockFiles: MockDirent[] = [
+				{
+					name: "test-cmd.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockResolvedValue(mockFiles)
+			mockReadFile.mockResolvedValue(`---
+description: Test command
+mode: architect
+model: opus
+arguments: [file, destination]
+---
+Process $1 to $2 with $ARGUMENTS`)
+
+			await initializeCustomCommands(mockCwd)
+
+			expect(mockRegister).toHaveBeenCalledTimes(1)
+			const registeredCommand = mockRegister.mock.calls[0][0] as Command
+			return registeredCommand.handler
+		}
+
+		it("should call setMode when custom command has mode", async () => {
+			const handler = await getRegisteredHandler()
+			const mockContext = createMockContext({
+				args: ["input.txt", "output.txt"],
+			})
+
+			await handler(mockContext)
+
+			expect(mockContext.setMode).toHaveBeenCalledWith("architect")
+		})
+
+		it("should call updateProviderModel when custom command has model", async () => {
+			const handler = await getRegisteredHandler()
+			const mockContext = createMockContext({
+				args: ["input.txt", "output.txt"],
+			})
+
+			await handler(mockContext)
+
+			expect(mockContext.updateProviderModel).toHaveBeenCalledWith("opus")
+		})
+
+		it("should handle updateProviderModel errors gracefully", async () => {
+			const handler = await getRegisteredHandler()
+			const mockUpdateProviderModel = vi.fn().mockRejectedValue(new Error("Model not available"))
+			const mockContext = createMockContext({
+				args: ["input.txt", "output.txt"],
+				updateProviderModel: mockUpdateProviderModel,
+			})
+
+			// Should not throw
+			await expect(handler(mockContext)).resolves.not.toThrow()
+
+			expect(mockUpdateProviderModel).toHaveBeenCalledWith("opus")
+			// Should still send the message even if model switch fails
+			expect(mockContext.sendWebviewMessage).toHaveBeenCalled()
+		})
+
+		it("should call sendWebviewMessage with processed content", async () => {
+			const handler = await getRegisteredHandler()
+			const mockContext = createMockContext({
+				args: ["input.txt", "output.txt"],
+			})
+
+			await handler(mockContext)
+
+			expect(mockContext.sendWebviewMessage).toHaveBeenCalledWith({
+				type: "newTask",
+				text: "Process input.txt to output.txt with input.txt output.txt",
+			})
+		})
+
+		it("should not call setMode when custom command has no mode", async () => {
+			const mockFiles: MockDirent[] = [
+				{
+					name: "no-mode.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockResolvedValue(mockFiles)
+			mockReadFile.mockResolvedValue(`---
+description: Command without mode
+---
+Simple content`)
+
+			await initializeCustomCommands(mockCwd)
+
+			const registeredCommand = mockRegister.mock.calls[0][0] as Command
+			const mockContext = createMockContext({ args: [] })
+
+			await registeredCommand.handler(mockContext)
+
+			expect(mockContext.setMode).not.toHaveBeenCalled()
+		})
+
+		it("should not call updateProviderModel when custom command has no model", async () => {
+			const mockFiles: MockDirent[] = [
+				{
+					name: "no-model.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockResolvedValue(mockFiles)
+			mockReadFile.mockResolvedValue(`---
+description: Command without model
+---
+Simple content`)
+
+			await initializeCustomCommands(mockCwd)
+
+			const registeredCommand = mockRegister.mock.calls[0][0] as Command
+			const mockContext = createMockContext({ args: [] })
+
+			await registeredCommand.handler(mockContext)
+
+			expect(mockContext.updateProviderModel).not.toHaveBeenCalled()
+		})
+
+		it("should substitute arguments in content before sending", async () => {
+			const mockFiles: MockDirent[] = [
+				{
+					name: "substitute.md",
+					isFile: () => true,
+					isDirectory: () => false,
+				},
+			]
+
+			mockReaddir.mockResolvedValue(mockFiles)
+			mockReadFile.mockResolvedValue(`---
+description: Substitution test
+---
+First: $1, Second: $2, All: $ARGUMENTS`)
+
+			await initializeCustomCommands(mockCwd)
+
+			const registeredCommand = mockRegister.mock.calls[0][0] as Command
+			const mockContext = createMockContext({
+				args: ["alpha", "beta", "gamma"],
+			})
+
+			await registeredCommand.handler(mockContext)
+
+			expect(mockContext.sendWebviewMessage).toHaveBeenCalledWith({
+				type: "newTask",
+				text: "First: alpha, Second: beta, All: alpha beta gamma",
+			})
+		})
+	})
+})

--- a/cli/src/commands/custom.ts
+++ b/cli/src/commands/custom.ts
@@ -1,0 +1,189 @@
+/**
+ * Custom commands - loads markdown-based commands from ~/.kilocode/commands/ and .kilocode/commands/
+ */
+
+import fs from "fs/promises"
+import * as path from "path"
+import matter from "gray-matter"
+import * as os from "os"
+import { commandRegistry } from "./core/registry.js"
+import type { Command, CommandHandler } from "./core/types.js"
+import { logs } from "../services/logs.js"
+
+/**
+ * Custom command definition loaded from markdown files
+ */
+export interface CustomCommand {
+	name: string
+	content: string
+	filePath: string
+	description?: string
+	arguments?: string[]
+	mode?: string
+	model?: string
+}
+
+/**
+ * Validates that a command name contains only alphanumeric characters and hyphens,
+ * and starts with an alphanumeric character
+ */
+function isValidCommandName(name: string): boolean {
+	return /^[a-zA-Z0-9][a-zA-Z0-9-]*$/.test(name)
+}
+
+async function scanCommandDirectory(dirPath: string, commands: Map<string, CustomCommand>): Promise<void> {
+	try {
+		const entries = await fs.readdir(dirPath, { withFileTypes: true })
+
+		for (const entry of entries) {
+			if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".md")) continue
+
+			const commandName = entry.name.slice(0, -3)
+			const filePath = path.join(dirPath, entry.name)
+
+			// Validate command name format.
+			if (!isValidCommandName(commandName)) {
+				logs.warn(
+					`Skipping invalid command name "${commandName}" - must start with alphanumeric and contain only alphanumeric characters and hyphens`,
+					"CustomCommand",
+				)
+				continue
+			}
+
+			try {
+				const content = await fs.readFile(filePath, "utf-8")
+				const parsed = matter(content)
+
+				const description = typeof parsed.data.description === "string" ? parsed.data.description.trim() : ""
+				const mode = typeof parsed.data.mode === "string" ? parsed.data.mode.trim() : ""
+				const model = typeof parsed.data.model === "string" ? parsed.data.model.trim() : ""
+
+				// Parse arguments list
+				let args: string[] | undefined
+				if (Array.isArray(parsed.data.arguments)) {
+					args = parsed.data.arguments
+						.filter((arg) => typeof arg === "string" && arg.trim())
+						.map((arg) => arg.trim())
+				}
+
+				const command: CustomCommand = {
+					name: commandName,
+					content: parsed.content.trim(),
+					filePath,
+				}
+
+				if (description) command.description = description
+				if (args && args.length > 0) command.arguments = args
+				if (mode) command.mode = mode
+				if (model) command.model = model
+
+				commands.set(commandName, command)
+			} catch (error) {
+				logs.warn(`Failed to parse custom command file: ${filePath}`, "CustomCommand", { error })
+			}
+		}
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException)?.code
+		if (code !== "ENOENT") {
+			logs.warn(`Failed to scan command directory: ${dirPath}`, "CustomCommand", { error })
+		}
+	}
+}
+
+/**
+ * Substitute arguments in command content
+ * Supports: $ARGUMENTS (all args), $1, $2, $3, etc. (positional args)
+ */
+export function substituteArguments(content: string, args: string[]): string {
+	return content.replace(/\$ARGUMENTS\b/g, args.join(" ")).replace(/\$(\d+)\b(?!\.?\d)/g, (match, num): string => {
+		const index = parseInt(num, 10) - 1
+		return index >= 0 && index < args.length ? args[index]! : match
+	})
+}
+
+function createCustomCommandHandler(customCommand: CustomCommand): CommandHandler {
+	return async (context) => {
+		const { args, setMode, updateProviderModel, sendWebviewMessage } = context
+
+		if (customCommand.mode) {
+			setMode(customCommand.mode)
+		}
+
+		if (customCommand.model) {
+			try {
+				await updateProviderModel(customCommand.model)
+			} catch (error) {
+				logs.warn(`Failed to switch to model ${customCommand.model}`, "CustomCommand", { error })
+			}
+		}
+
+		const processedContent = substituteArguments(customCommand.content, args)
+
+		await sendWebviewMessage({
+			type: "newTask",
+			text: processedContent,
+		})
+	}
+}
+
+function customCommandToCliCommand(customCommand: CustomCommand): Command {
+	return {
+		name: customCommand.name,
+		aliases: [],
+		description: customCommand.description || `Custom command: ${customCommand.name}`,
+		usage: customCommand.arguments
+			? `/${customCommand.name} ${customCommand.arguments.map((arg) => `<${arg}>`).join(" ")}`
+			: `/${customCommand.name}`,
+		examples: [`/${customCommand.name}`],
+		category: "chat",
+		handler: createCustomCommandHandler(customCommand),
+		priority: 3,
+		...(customCommand.arguments && {
+			arguments: customCommand.arguments.map((argument) => ({
+				name: argument,
+				description: "",
+				required: false,
+			})),
+		}),
+	}
+}
+
+/**
+ * Load custom commands from ~/.kilocode/commands/ and .kilocode/commands/
+ * Priority: project > global
+ */
+export async function getCustomCommands(cwd: string): Promise<CustomCommand[]> {
+	const commands = new Map<string, CustomCommand>()
+
+	const globalDir = path.join(os.homedir(), ".kilocode", "commands")
+	await scanCommandDirectory(globalDir, commands)
+
+	const projectDir = path.join(cwd, ".kilocode", "commands")
+	await scanCommandDirectory(projectDir, commands)
+
+	return Array.from(commands.values())
+}
+
+/**
+ * Initialize custom commands from markdown files
+ * Call this after built-in commands are initialized
+ */
+export async function initializeCustomCommands(cwd: string): Promise<void> {
+	try {
+		const customCommands = await getCustomCommands(cwd)
+
+		for (const customCommand of customCommands) {
+			if (commandRegistry.get(customCommand.name)) {
+				logs.warn(`Custom command "${customCommand.name}" conflicts with an existing command`, "CustomCommand")
+				continue
+			}
+			commandRegistry.register(customCommandToCliCommand(customCommand))
+		}
+
+		if (customCommands.length > 0) {
+			logs.debug(`Loaded ${customCommands.length} custom command(s)`, "CustomCommand")
+		}
+	} catch (error) {
+		logs.warn("Failed to load custom commands", "CustomCommand", { error })
+	}
+}

--- a/cli/src/commands/index.ts
+++ b/cli/src/commands/index.ts
@@ -24,7 +24,7 @@ import { sessionCommand } from "./session.js"
 import { condenseCommand } from "./condense.js"
 
 /**
- * Initialize all commands
+ * Initialize all built-in commands
  */
 export function initializeCommands(): void {
 	// Register all commands

--- a/cli/src/ui/UI.tsx
+++ b/cli/src/ui/UI.tsx
@@ -20,6 +20,7 @@ import { CommandInput } from "./components/CommandInput.js"
 import { StatusBar } from "./components/StatusBar.js"
 import { StatusIndicator } from "./components/StatusIndicator.js"
 import { initializeCommands } from "../commands/index.js"
+import { initializeCustomCommands } from "../commands/custom.js"
 import { isCommandInput } from "../services/autocomplete.js"
 import { useCommandHandler } from "../state/hooks/useCommandHandler.js"
 import { useMessageHandler } from "../state/hooks/useMessageHandler.js"
@@ -40,7 +41,7 @@ import { useTerminal } from "../state/hooks/useTerminal.js"
 import { exitRequestCounterAtom } from "../state/atoms/keyboard.js"
 import { useWebviewMessage } from "../state/hooks/useWebviewMessage.js"
 
-// Initialize commands on module load
+// Initialize built-in commands on module load
 initializeCommands()
 
 interface UIAppProps {
@@ -143,11 +144,14 @@ export const UI: React.FC<UIAppProps> = ({ options, onExit }) => {
 		}
 	}, [options.parallel, setIsParallelMode])
 
-	// Initialize workspace path for shell commands
+	// Initialize workspace path for shell commands and load custom commands
 	useEffect(() => {
+		const workspace = options.workspace || process.cwd()
 		if (options.workspace) {
 			setWorkspacePath(options.workspace)
 		}
+		// Load custom commands from ~/.kilocode/commands/ and .kilocode/commands/
+		void initializeCustomCommands(workspace)
 	}, [options.workspace, setWorkspacePath])
 
 	// Handle CI mode exit


### PR DESCRIPTION

## Context

Implement custom commands feature allowing users to create reusable slash commands from markdown files stored in global (~/.kilocode/commands/) or project-specific (.kilocode/commands/) directories. Commands support argument substitution, automatic mode/model switching, and YAML frontmatter configuration.

## Implementation

Users drop markdown files in ~/.kilocode/commands/ or .kilocode/commands/, and those become slash commands. That's it.

### Commands loading steps:
  - On startup, I scan both directories for .md files
  - Parse each file with gray-matter to extract YAML frontmatter
  - Project-level commands override global ones (so you can customize per-project)

### The markdown format:
```md
---
description: What the command does
arguments: [arg1, arg2]
mode: code
model: opus
---

Your prompt template here with $1 and $2 for arguments
```

### When you run the command:
  1. Replace $1, $2, etc. with the actual arguments you passed
  2. Switch to the specified mode/model if provided
  3. Send the processed text as a new chat message

### Decisions

**Mardown**: Same as opencode, claude code, simple to write.

**Directories**: We already have this pattern for skills (~/.kilocode/skills/ and .kilocode/skills/), so just reused the same convention. Users already understand it.

**Arguments substitution**: Tried to keep it dumb - just replace $1 with the first arg, $ARGUMENTS with all args. No fancy templating engine needed.

**Error handling:** If a directory doesn't exist, fine. If model switching fails, warn but keep going. Don't break the whole feature because of one bad file.

## Screenshots

Here is an example with the following custom command:

```md
---
description: Example command that switches mode, model and parses arguments.
mode: ask
model: x-ai/grok-code-fast-1
arguments:
  - what
---

Only say "$1"
```

https://github.com/user-attachments/assets/c0de1f02-0227-4102-9315-6f3362076df6

## How to Test

Create custom commands in `~/.kilocode/commands/`or `.kilocode/commands/` and run `kilo`.
You can use them and show commands help

## Get in Touch

Discord: `alexandrevilain.`
