### PR TITLE
fix(cerebras): ensure all tools have consistent strict mode values (#…

### DIFF
--- a/src/api/providers/cerebras.ts
+++ b/src/api/providers/cerebras.ts
@@ -162,6 +162,33 @@ export class CerebrasHandler extends BaseProvider implements SingleCompletionHan
 		return result
 	}
 
+	/**
+	 * Override convertToolsForOpenAI to ensure all tools have consistent strict values.
+	 * Cerebras API requires all tools to have the same strict mode setting.
+	 * We use strict: false for all tools since MCP tools cannot use strict mode
+	 * (they have optional parameters from the MCP server schema).
+	 */
+	protected override convertToolsForOpenAI(tools: any[] | undefined): any[] | undefined {
+		if (!tools) {
+			return undefined
+		}
+
+		return tools.map((tool) => {
+			if (tool.type !== "function") {
+				return tool
+			}
+
+			return {
+				...tool,
+				function: {
+					...tool.function,
+					strict: false,
+					parameters: this.convertToolSchemaForOpenAI(tool.function.parameters),
+				},
+			}
+		})
+	}
+
 	async *createMessage(
 		systemPrompt: string,
 		messages: Anthropic.Messages.MessageParam[],


### PR DESCRIPTION
## Context

This PR attempts to address Issue [#5189 ](https://github.com/RooCodeInc/Roo-Code/issues/5189).

## Implementation

Override convertToolsForOpenAI in CerebrasHandler to ensure all tools have consistent strict: false values:

* MCP tools cannot use strict mode because they have optional parameters from the MCP server schema
* Setting all tools to strict: false ensures consistency with the Cerebras API requirement
* The Cerebras handler already has a custom convertToolSchemaForOpenAI that strips unsupported fields, so non-strict mode is appropriate

## Screenshots

<img width="781" height="198" alt="image" src="https://github.com/user-attachments/assets/9b15ef40-3239-491d-9e71-d54b2af22342" />

## How to Test

Run the Cerebras provider tests:

`cd src && npm test api/providers/__tests__/cerebras.spec.ts -t "convertToolsForOpenAI"`
