### PR TITLE
fix(cli): filter partial SEARCH/REPLACE markers from diff display

### DIFF
--- a/.changeset/fix-cli-diff-partial-markers.md
+++ b/.changeset/fix-cli-diff-partial-markers.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix CLI diff display showing partial SEARCH/REPLACE markers and git merge conflict markers during streaming

--- a/cli/src/ui/messages/extension/__tests__/diff.test.ts
+++ b/cli/src/ui/messages/extension/__tests__/diff.test.ts
@@ -509,3 +509,454 @@ line 3`
 		expect(result.length).toBeGreaterThan(0)
 	})
 })
+
+describe("parseDiffContent - partial/streaming markers", () => {
+	describe("should filter out partial SEARCH/REPLACE markers from streaming", () => {
+		it("should filter partial start marker '<<<<'", () => {
+			const searchMarker = "<<<<<<< SEARCH"
+			const replaceMarker = ">>>>>>> REPLACE"
+			const separator = "======="
+			const diff = `${searchMarker}
+-------
+old content
+${separator}
+new content
+${replaceMarker}
+<<<<`
+
+			const result = parseDiffContent(diff)
+
+			// Should not contain the partial marker '<<<<'
+			const hasPartialMarker = result.some((l) => l.content.includes("<<<<"))
+			expect(hasPartialMarker).toBe(false)
+
+			// Should still have the actual diff content
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+			expect(deletions).toHaveLength(1)
+			expect(additions).toHaveLength(1)
+		})
+
+		it("should filter incomplete start marker '<<<<<<< S'", () => {
+			const searchMarker = "<<<<<<< SEARCH"
+			const replaceMarker = ">>>>>>> REPLACE"
+			const separator = "======="
+			const diff = `${searchMarker}
+-------
+old content
+${separator}
+new content
+${replaceMarker}
+<<<<<<< S`
+
+			const result = parseDiffContent(diff)
+
+			// Should not contain the incomplete marker
+			const hasIncompleteMarker = result.some((l) => l.content === "<<<<<<< S")
+			expect(hasIncompleteMarker).toBe(false)
+		})
+
+		it("should filter partial end marker '>>>>>>'", () => {
+			const searchMarker = "<<<<<<< SEARCH"
+			const separator = "======="
+			const diff = `${searchMarker}
+-------
+old content
+${separator}
+new content
+>>>>>>`
+
+			const result = parseDiffContent(diff)
+
+			// Should not contain the partial marker '>>>>>>'
+			const hasPartialMarker = result.some((l) => l.content === ">>>>>>")
+			expect(hasPartialMarker).toBe(false)
+
+			// Should still have the actual diff content
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+			expect(deletions).toHaveLength(1)
+			expect(additions).toHaveLength(1)
+		})
+
+		it("should filter content that is only partial markers", () => {
+			// This simulates streaming where only partial content has arrived
+			const diff = `<<<<<<< S`
+
+			const result = parseDiffContent(diff)
+
+			// Should return empty or filter out the partial marker
+			const hasPartialMarker = result.some((l) => l.content.startsWith("<<<<"))
+			expect(hasPartialMarker).toBe(false)
+		})
+
+		it("should handle multiple partial markers in streaming content", () => {
+			const searchMarker = "<<<<<<< SEARCH"
+			const replaceMarker = ">>>>>>> REPLACE"
+			const separator = "======="
+			const diff = `${searchMarker}
+-------
+old line 1
+old line 2
+${separator}
+new line 1
+${replaceMarker}
+<<<<
+<<<<<<< S
+>>>>>>`
+
+			const result = parseDiffContent(diff)
+
+			// Should not contain any partial markers
+			const hasPartialStartMarker = result.some(
+				(l) => l.content.startsWith("<<<<") && !l.content.startsWith("<<<<<<< SEARCH"),
+			)
+			const hasPartialEndMarker = result.some(
+				(l) => l.content.startsWith(">>>>") && !l.content.startsWith(">>>>>>> REPLACE"),
+			)
+			expect(hasPartialStartMarker).toBe(false)
+			expect(hasPartialEndMarker).toBe(false)
+
+			// Should still have the actual diff content
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+			expect(deletions).toHaveLength(2)
+			expect(additions).toHaveLength(1)
+		})
+
+		it("should handle trailing partial marker after valid diff", () => {
+			// Real-world case from the bug report
+			const searchMarker = "<<<<<<< SEARCH"
+			const separator = "======="
+			const diff = `${searchMarker}
+-------
+"hint": "Prem Enter per enviar, Shift+Enter per nova línia",
+"addImage": "Add image",
+"removeImage": "Remove image"
+${separator}
+"hint": "Prem Enter per enviar, Shift+Enter per nova línia",
+"addImage": "Afegir imatge",
+"removeImage": "Eliminar imatge"
+>>>>>>`
+
+			const result = parseDiffContent(diff)
+
+			// Should not contain the partial marker
+			const hasPartialMarker = result.some((l) => l.content === ">>>>>>")
+			expect(hasPartialMarker).toBe(false)
+
+			// Should have the correct number of changes
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+			expect(deletions).toHaveLength(3)
+			expect(additions).toHaveLength(3)
+		})
+
+		it("should handle content with only '<<<<' (no complete SEARCH marker)", () => {
+			// When streaming starts and only partial marker has arrived
+			const diff = `<<<<`
+
+			const result = parseDiffContent(diff)
+
+			// Should filter out the partial marker
+			expect(result.every((l) => !l.content.includes("<<<<"))).toBe(true)
+		})
+
+		it("should not filter legitimate content that happens to start with < or >", () => {
+			const searchMarker = "<<<<<<< SEARCH"
+			const replaceMarker = ">>>>>>> REPLACE"
+			const separator = "======="
+			const diff = `${searchMarker}
+-------
+<div>old content</div>
+${separator}
+<div>new content</div>
+${replaceMarker}`
+
+			const result = parseDiffContent(diff)
+
+			// Should preserve the HTML content
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+			expect(deletions).toHaveLength(1)
+			expect(additions).toHaveLength(1)
+			expect(deletions[0].content).toBe("<div>old content</div>")
+			expect(additions[0].content).toBe("<div>new content</div>")
+		})
+
+		it("should handle partial equals marker", () => {
+			const searchMarker = "<<<<<<< SEARCH"
+			const diff = `${searchMarker}
+-------
+old content
+===`
+
+			const result = parseDiffContent(diff)
+
+			// Partial equals should be filtered if it looks like a marker
+			// But actual content with === should be preserved
+			const deletions = result.filter((l) => l.type === "deletion")
+			expect(deletions).toHaveLength(1)
+			expect(deletions[0].content).toBe("old content")
+		})
+
+		it("should filter git merge conflict start marker '<<<<<<< Updated upstream'", () => {
+			const searchMarker = "<<<<<<< SEARCH"
+			const replaceMarker = ">>>>>>> REPLACE"
+			const separator = "======="
+			const diff = `${searchMarker}
+-------
+old content
+${separator}
+new content
+${replaceMarker}
+<<<<<<< Updated upstream`
+
+			const result = parseDiffContent(diff)
+
+			// Should not contain the git conflict marker
+			const hasGitMarker = result.some((l) => l.content.includes("<<<<<<< Updated upstream"))
+			expect(hasGitMarker).toBe(false)
+
+			// Should still have the actual diff content
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+			expect(deletions).toHaveLength(1)
+			expect(additions).toHaveLength(1)
+		})
+
+		it("should filter git merge conflict end marker '>>>>>>> Stashed changes'", () => {
+			const searchMarker = "<<<<<<< SEARCH"
+			const replaceMarker = ">>>>>>> REPLACE"
+			const separator = "======="
+			const diff = `${searchMarker}
+-------
+old content
+${separator}
+new content
+${replaceMarker}
+>>>>>>> Stashed changes`
+
+			const result = parseDiffContent(diff)
+
+			// Should not contain the git conflict marker
+			const hasGitMarker = result.some((l) => l.content.includes(">>>>>>> Stashed changes"))
+			expect(hasGitMarker).toBe(false)
+
+			// Should still have the actual diff content
+			const deletions = result.filter((l) => l.type === "deletion")
+			const additions = result.filter((l) => l.type === "addition")
+			expect(deletions).toHaveLength(1)
+			expect(additions).toHaveLength(1)
+		})
+
+		it("should filter git merge conflict marker '<<<<<<< HEAD'", () => {
+			const diff = `<<<<<<< HEAD`
+
+			const result = parseDiffContent(diff)
+
+			// Should filter out the git conflict marker
+			const hasGitMarker = result.some((l) => l.content.includes("<<<<<<< HEAD"))
+			expect(hasGitMarker).toBe(false)
+		})
+
+		it("should filter git merge conflict marker with branch name '>>>>>>> feature/branch-name'", () => {
+			const searchMarker = "<<<<<<< SEARCH"
+			const replaceMarker = ">>>>>>> REPLACE"
+			const separator = "======="
+			const diff = `${searchMarker}
+-------
+old content
+${separator}
+new content
+${replaceMarker}
+>>>>>>> feature/branch-name`
+
+			const result = parseDiffContent(diff)
+
+			// Should not contain the git conflict marker
+			const hasGitMarker = result.some((l) => l.content.includes(">>>>>>> feature/branch-name"))
+			expect(hasGitMarker).toBe(false)
+		})
+	})
+})
+
+describe("parseDiffContent - unified diff format with git conflict markers", () => {
+	it("should filter git conflict markers from unified diff deletions", () => {
+		const diff = `@@ -10,7 +10,3 @@
+ import { logs } from "../../services/logs.js"
+-<<<<<<< Updated upstream
+-=======
+-import { convertImagesToDataUrls } from "../../media/image-utils.js"
+->>>>>>> Stashed changes
+ 
+ export interface StdinMessage {`
+
+		const result = parseDiffContent(diff)
+
+		// Should not contain any git conflict markers
+		const hasGitMarker = result.some(
+			(l) =>
+				l.content.includes("<<<<<<< Updated upstream") ||
+				l.content.includes(">>>>>>> Stashed changes") ||
+				l.content === "=======",
+		)
+		expect(hasGitMarker).toBe(false)
+
+		// Should still have the legitimate content
+		const hasLegitimateContent = result.some((l) => l.content.includes("import { logs }"))
+		expect(hasLegitimateContent).toBe(true)
+	})
+
+	it("should filter git conflict markers from unified diff additions", () => {
+		const diff = `@@ -1,3 +1,7 @@
+ line 1
++<<<<<<< HEAD
++new content from HEAD
++=======
++new content from branch
++>>>>>>> feature-branch
+ line 2`
+
+		const result = parseDiffContent(diff)
+
+		// Should not contain any git conflict markers
+		const hasGitMarker = result.some(
+			(l) =>
+				l.content.includes("<<<<<<< HEAD") ||
+				l.content.includes(">>>>>>> feature-branch") ||
+				l.content === "=======",
+		)
+		expect(hasGitMarker).toBe(false)
+	})
+
+	it("should filter ======= separator from unified diff", () => {
+		const diff = `@@ -1,3 +1,3 @@
+ line 1
+-=======
++new line
+ line 2`
+
+		const result = parseDiffContent(diff)
+
+		// Should not contain the separator as content
+		const hasSeparator = result.some((l) => l.content === "=======")
+		expect(hasSeparator).toBe(false)
+
+		// Should have the new line
+		const hasNewLine = result.some((l) => l.content === "new line" && l.type === "addition")
+		expect(hasNewLine).toBe(true)
+	})
+
+	it("should filter escaped git conflict markers (with backslash prefix)", () => {
+		const diff = `@@ -1,7 +1,3 @@
+ import { logs } from "../../services/logs.js"
+-\\<<<<<<< Updated upstream
+-\\=======
+-import { convertImagesToDataUrls } from "../../media/image-utils.js"
+-\\>>>>>>> Stashed changes
+ 
+ export interface StdinMessage {`
+
+		const result = parseDiffContent(diff)
+
+		// Should not contain any escaped git conflict markers
+		const hasEscapedMarker = result.some(
+			(l) =>
+				l.content.includes("\\<<<<<<< Updated upstream") ||
+				l.content.includes("\\=======") ||
+				l.content.includes("\\>>>>>>> Stashed changes"),
+		)
+		expect(hasEscapedMarker).toBe(false)
+
+		// Should still have the legitimate content
+		const hasLegitimateContent = result.some((l) => l.content.includes("import { logs }"))
+		expect(hasLegitimateContent).toBe(true)
+	})
+
+	it("should filter escaped partial markers", () => {
+		const diff = `@@ -1,3 +1,1 @@
+	line 1
+-\\<<<<
+-\\>>>>>>`
+
+		const result = parseDiffContent(diff)
+
+		// Should not contain escaped partial markers
+		const hasEscapedPartialMarker = result.some((l) => l.content === "\\<<<<" || l.content === "\\>>>>>>")
+		expect(hasEscapedPartialMarker).toBe(false)
+	})
+
+	it("should filter partial markers with leading whitespace (bug report case)", () => {
+		// This is the exact case from the bug report where markers appear with indentation
+		// e.g., "               <<<<" or "               <<<<<<< S"
+		const diff = `@@ -1,3 +1,1 @@
+	line 1
+-               <<<<
+-               <<<<<<< S`
+
+		const result = parseDiffContent(diff)
+
+		// Should not contain partial markers even with leading whitespace
+		const hasPartialMarker = result.some((l) => l.content.includes("<<<<") || l.content.includes("<<<<<<< S"))
+		expect(hasPartialMarker).toBe(false)
+	})
+
+	it("should filter markers with tabs and spaces", () => {
+		const diff = `@@ -1,2 +1,1 @@
+	line 1
+-		<<<<`
+
+		const result = parseDiffContent(diff)
+
+		// Should not contain partial markers with tab indentation
+		const hasPartialMarker = result.some((l) => l.content.includes("<<<<"))
+		expect(hasPartialMarker).toBe(false)
+	})
+
+	it("should filter partial markers appearing as additions (exact bug report case)", () => {
+		// This reproduces the exact bug from the report where >>>>>> appears as an addition
+		// The output showed: "      92 + >>>>>>"
+		const diff = `@@ -89,3 +89,4 @@
+	"hint": "Prem Enter per enviar, Shift+Enter per nova línia",
+-"addImage": "Add image",
+-"removeImage": "Remove image"
++"hint": "Prem Enter per enviar, Shift+Enter per nova línia",
++"addImage": "Afegir imatge",
++"removeImage": "Eliminar imatge"
++>>>>>>`
+
+		const result = parseDiffContent(diff)
+
+		// Should not contain the partial marker as an addition
+		const hasPartialMarker = result.some((l) => l.type === "addition" && l.content === ">>>>>>")
+		expect(hasPartialMarker).toBe(false)
+
+		// Should still have the legitimate additions
+		const hasLegitimateAddition = result.some((l) => l.type === "addition" && l.content.includes("Afegir imatge"))
+		expect(hasLegitimateAddition).toBe(true)
+	})
+
+	it("should filter partial markers appearing as only content (empty diff case)", () => {
+		// This reproduces the case where the entire diff content is just a partial marker
+		// The output showed: "⏺︎ Update( webview-ui/src/i18n/locales/es/agentManager.json)\n           <<<<"
+		const diff = `           <<<<`
+
+		const result = parseDiffContent(diff)
+
+		// Should return empty or no partial markers
+		const hasPartialMarker = result.some((l) => l.content.includes("<<<<"))
+		expect(hasPartialMarker).toBe(false)
+	})
+
+	it("should filter <<<<<<< S partial marker appearing as only content", () => {
+		// This reproduces: "⏺︎ Update( webview-ui/src/i18n/locales/pt-BR/agentManager.json)\n           <<<<<<< S"
+		const diff = `           <<<<<<< S`
+
+		const result = parseDiffContent(diff)
+
+		// Should return empty or no partial markers
+		const hasPartialMarker = result.some((l) => l.content.includes("<<<<"))
+		expect(hasPartialMarker).toBe(false)
+	})
+})

--- a/cli/src/ui/messages/extension/diff.ts
+++ b/cli/src/ui/messages/extension/diff.ts
@@ -19,6 +19,85 @@ export function isUnifiedDiffFormat(content: string): boolean {
 	return content.includes("@@") || content.startsWith("---")
 }
 
+/**
+ * Check if a line is a partial/incomplete SEARCH/REPLACE marker from streaming,
+ * or a git merge conflict marker that should be filtered out.
+ *
+ * These markers appear when content is being streamed and should be filtered out.
+ *
+ * Examples of partial markers:
+ * - "<<<<" (partial start of "<<<<<<< SEARCH")
+ * - "<<<<<<< S" (incomplete "<<<<<<< SEARCH")
+ * - ">>>>>>" (partial ">>>>>>> REPLACE")
+ * - "===" (partial "=======")
+ *
+ * Git merge conflict markers (also filtered):
+ * - "<<<<<<< Updated upstream"
+ * - "<<<<<<< HEAD"
+ * - ">>>>>>> Stashed changes"
+ * - ">>>>>>> branch-name"
+ * - "=======" (conflict separator)
+ *
+ * Also handles escaped markers (with backslash prefix):
+ * - "\<<<<<<< Updated upstream"
+ * - "\======="
+ * - "\>>>>>>> Stashed changes"
+ */
+function isPartialSearchReplaceMarker(line: string): boolean {
+	// Strip leading backslash if present (escaped markers)
+	const normalizedLine = line.startsWith("\\") ? line.slice(1) : line
+
+	// Also strip leading/trailing whitespace for detection purposes
+	// This handles cases like "               <<<<" from the bug report
+	const trimmedLine = normalizedLine.trim()
+
+	// Complete SEARCH/REPLACE markers - these are handled by the main parser in parseSearchReplaceFormat
+	// Note: We don't return false for "=======" here because it could be a git conflict separator
+	// that should be filtered when it appears as content in unified diff format
+	if (trimmedLine.startsWith("<<<<<<< SEARCH") || trimmedLine.startsWith(">>>>>>> REPLACE")) {
+		return false
+	}
+
+	// Git merge conflict markers - filter these out completely
+	// They look like "<<<<<<< Updated upstream", "<<<<<<< HEAD", ">>>>>>> Stashed changes", etc.
+	if (/^<{7}\s+\S/.test(trimmedLine)) {
+		// "<<<<<<< " followed by any text (git conflict start marker)
+		return true
+	}
+	if (/^>{7}\s+\S/.test(trimmedLine)) {
+		// ">>>>>>> " followed by any text (git conflict end marker)
+		return true
+	}
+
+	// Partial start marker: lines that are only < characters (1-7) or start with < and look like incomplete marker
+	// But NOT legitimate content like HTML tags "<div>" or comparison operators
+	if (/^<{1,7}$/.test(trimmedLine)) {
+		return true // Just angle brackets like "<<<<" or "<<<<<<<"
+	}
+	if (/^<{4,7}\s*\S*$/.test(trimmedLine) && !trimmedLine.includes(">")) {
+		// Looks like "<<<<<<< S" or "<<<<<<< SE" but not complete "<<<<<<< SEARCH"
+		return true
+	}
+
+	// Partial end marker: lines that are only > characters (1-7) or start with > and look like incomplete marker
+	// But NOT legitimate content like HTML closing tags or shell redirects
+	if (/^>{1,7}$/.test(trimmedLine)) {
+		return true // Just angle brackets like ">>>>>>" or ">>>>>>>"
+	}
+	if (/^>{4,7}\s*\S*$/.test(trimmedLine) && !trimmedLine.includes("<")) {
+		// Looks like ">>>>>>> R" or ">>>>>>> RE" but not complete ">>>>>>> REPLACE"
+		return true
+	}
+
+	// Separator: lines that are only = characters (3-7)
+	// This includes both partial separators and the complete "=======" git conflict separator
+	if (/^={3,7}$/.test(trimmedLine)) {
+		return true
+	}
+
+	return false
+}
+
 function parseSearchReplaceFormat(lines: string[]): ParsedDiffLine[] {
 	const result: ParsedDiffLine[] = []
 	let inSearch = false
@@ -27,28 +106,46 @@ function parseSearchReplaceFormat(lines: string[]): ParsedDiffLine[] {
 	let newLineNum = 1
 
 	for (const line of lines) {
+		// Handle SEARCH/REPLACE format markers first (before filtering)
 		if (line.startsWith("<<<<<<< SEARCH")) {
 			// Skip marker - don't add to result
 			inSearch = true
 			inReplace = false
-		} else if (line.startsWith(":start_line:")) {
+			continue
+		}
+		if (line.startsWith(":start_line:")) {
 			const match = line.match(/:start_line:(\d+)/)
 			if (match && match[1]) {
 				oldLineNum = parseInt(match[1], 10)
 				newLineNum = oldLineNum
 			}
 			// Skip marker - don't add to result
-		} else if (line === "-------") {
+			continue
+		}
+		if (line === "-------") {
 			// Skip marker - don't add to result
-		} else if (line === "=======") {
+			continue
+		}
+		if (line === "=======" && (inSearch || !inReplace)) {
+			// This is the SEARCH/REPLACE separator, not a git conflict marker
 			// Skip marker - don't add to result
 			inSearch = false
 			inReplace = true
-		} else if (line.startsWith(">>>>>>> REPLACE")) {
+			continue
+		}
+		if (line.startsWith(">>>>>>> REPLACE")) {
 			// Skip marker - don't add to result
 			inSearch = false
 			inReplace = false
-		} else if (inSearch) {
+			continue
+		}
+
+		// Filter out partial/incomplete markers from streaming
+		if (isPartialSearchReplaceMarker(line)) {
+			continue
+		}
+
+		if (inSearch) {
 			result.push({ type: "deletion", content: line, oldLineNum: oldLineNum++ })
 		} else if (inReplace) {
 			result.push({ type: "addition", content: line, newLineNum: newLineNum++ })
@@ -76,12 +173,31 @@ function parseUnifiedDiffFormat(lines: string[]): ParsedDiffLine[] {
 		} else if (line.startsWith("---") || line.startsWith("+++")) {
 			result.push({ type: "header", content: line })
 		} else if (line.startsWith("+")) {
-			result.push({ type: "addition", content: line.slice(1), newLineNum: newLineNum++ })
+			const content = line.slice(1)
+			// Filter out partial/incomplete markers and git conflict markers from additions
+			if (isPartialSearchReplaceMarker(content)) {
+				continue
+			}
+			result.push({ type: "addition", content, newLineNum: newLineNum++ })
 		} else if (line.startsWith("-")) {
-			result.push({ type: "deletion", content: line.slice(1), oldLineNum: oldLineNum++ })
+			const content = line.slice(1)
+			// Filter out partial/incomplete markers and git conflict markers from deletions
+			if (isPartialSearchReplaceMarker(content)) {
+				continue
+			}
+			result.push({ type: "deletion", content, oldLineNum: oldLineNum++ })
 		} else if (line.startsWith(" ")) {
-			result.push({ type: "context", content: line.slice(1), oldLineNum: oldLineNum++, newLineNum: newLineNum++ })
+			const content = line.slice(1)
+			// Filter out partial/incomplete markers and git conflict markers from context
+			if (isPartialSearchReplaceMarker(content)) {
+				continue
+			}
+			result.push({ type: "context", content, oldLineNum: oldLineNum++, newLineNum: newLineNum++ })
 		} else {
+			// Filter out partial/incomplete markers and git conflict markers
+			if (isPartialSearchReplaceMarker(line)) {
+				continue
+			}
 			result.push({ type: "context", content: line })
 		}
 	}
@@ -89,11 +205,30 @@ function parseUnifiedDiffFormat(lines: string[]): ParsedDiffLine[] {
 	return result
 }
 
+/**
+ * Check if content looks like SEARCH/REPLACE format (complete or partial).
+ * This helps route streaming content to the correct parser.
+ */
+function isSearchReplaceFormat(content: string): boolean {
+	// Complete marker
+	if (content.includes("<<<<<<< SEARCH")) {
+		return true
+	}
+
+	// Partial markers that indicate SEARCH/REPLACE format during streaming
+	// Look for 4+ consecutive < or > characters at the start of a line
+	if (/^<{4,}/m.test(content) || /^>{4,}/m.test(content)) {
+		return true
+	}
+
+	return false
+}
+
 export function parseDiffContent(diffContent: string): ParsedDiffLine[] {
 	if (!diffContent) return []
 
 	const lines = diffContent.split("\n")
-	const isSearchReplace = diffContent.includes("<<<<<<< SEARCH")
+	const isSearchReplace = isSearchReplaceFormat(diffContent)
 
 	return isSearchReplace ? parseSearchReplaceFormat(lines) : parseUnifiedDiffFormat(lines)
 }


### PR DESCRIPTION
## Summary

During streaming, incomplete diff markers like `<<<<`, `<<<<<<< S`, `>>>>>>`, and `=======` were appearing in the CLI diff output. This fix adds comprehensive filtering for all partial/incomplete markers.

## Problem

When the CLI displayed diffs during streaming, partial SEARCH/REPLACE markers would appear in the output:

```
⏺︎ Update( webview-ui/src/i18n/locales/ca/agentManager.json) ⎿ +4, -3
      92 + >>>>>>

⏺︎ Update( webview-ui/src/i18n/locales/es/agentManager.json)
           <<<<

⏺︎ Update( webview-ui/src/i18n/locales/pt-BR/agentManager.json)
           <<<<<<< S
```

## Solution

Added `isPartialSearchReplaceMarker()` function in `cli/src/ui/messages/extension/diff.ts` that detects and filters:

- **Partial start markers**: `<<<<`, `<<<<<`, `<<<<<<`, `<<<<<<< S`, etc.
- **Partial end markers**: `>>>>`, `>>>>>`, `>>>>>>`, etc.
- **Separator markers**: `===`, `====`, `=====`, `======`, `=======`
- **Git merge conflict markers**: `<<<<<<< HEAD`, `>>>>>>> branch-name`, etc.
- **Escaped markers** with backslash prefix: `\<<<<`, `\>>>>>>`, etc.
- **Markers with leading whitespace**: `           <<<<`, `           <<<<<<< S`

The fix applies to both SEARCH/REPLACE format and unified diff format parsing.

## Testing

Added comprehensive tests covering:
- Partial markers in SEARCH/REPLACE format
- Partial markers in unified diff format (as additions, deletions, and context)
- Git merge conflict markers
- Escaped markers with backslash prefix
- Markers with leading whitespace (exact bug report case)
- Markers with tabs and spaces

All 2047 CLI tests pass.