### PR TITLE
feat(agent-manager): Add worktree setup script support

### DIFF
--- a/src/core/kilocode/agent-manager/SetupScriptRunner.ts
+++ b/src/core/kilocode/agent-manager/SetupScriptRunner.ts
@@ -1,0 +1,115 @@
+/**
+ * SetupScriptRunner - Executes worktree setup scripts
+ *
+ * Runs setup scripts in VS Code integrated terminal before agent starts.
+ * Script output is visible to the user in the terminal.
+ * Script failures don't block session start (non-blocking).
+ */
+
+import * as vscode from "vscode"
+import * as path from "node:path"
+import { SetupScriptService } from "./SetupScriptService"
+
+export interface SetupScriptEnvironment {
+	/** Absolute path to the worktree directory */
+	worktreePath: string
+	/** Absolute path to the main repository */
+	repoPath: string
+}
+
+export class SetupScriptRunner {
+	constructor(
+		private readonly outputChannel: vscode.OutputChannel,
+		private readonly setupScriptService: SetupScriptService,
+	) {}
+
+	/**
+	 * Execute setup script in a worktree if script exists.
+	 * Only runs for NEW sessions, not when resuming an existing session.
+	 * Script runs in VS Code integrated terminal - output visible to user.
+	 * Script failures don't block session start.
+	 *
+	 * @param env Environment variables for the script
+	 * @returns true if script was executed, false if skipped (no script configured)
+	 */
+	async runIfConfigured(env: SetupScriptEnvironment): Promise<boolean> {
+		// Check if script exists
+		if (!this.setupScriptService.hasScript()) {
+			this.log("No setup script configured, skipping")
+			return false
+		}
+
+		const scriptPath = this.setupScriptService.getScriptPath()
+		this.log(`Running setup script: ${scriptPath}`)
+
+		try {
+			await this.executeInTerminal(scriptPath, env)
+			return true
+		} catch (error) {
+			const errorMsg = error instanceof Error ? error.message : String(error)
+			this.log(`Setup script execution failed: ${errorMsg}`)
+			// Non-blocking - we don't throw, just log the error
+			return true // Script was attempted
+		}
+	}
+
+	/**
+	 * Execute the setup script in a VS Code terminal.
+	 * The terminal shows output to the user.
+	 */
+	private async executeInTerminal(scriptPath: string, env: SetupScriptEnvironment): Promise<void> {
+		const shellPath = process.platform === "win32" ? undefined : process.env.SHELL
+		const shellName = shellPath ? path.basename(shellPath) : undefined
+		const shellArgs = process.platform === "win32" ? undefined : shellName === "zsh" ? ["-l", "-i"] : ["-l"]
+
+		// Create terminal with environment variables
+		const terminal = vscode.window.createTerminal({
+			name: "Worktree Setup",
+			cwd: env.worktreePath,
+			shellPath,
+			shellArgs,
+			env: {
+				WORKTREE_PATH: env.worktreePath,
+				REPO_PATH: env.repoPath,
+			},
+			iconPath: new vscode.ThemeIcon("gear"),
+		})
+
+		// Build the command to execute
+		const command = this.buildCommand(scriptPath, env)
+
+		// Show terminal and execute
+		terminal.show(true) // true = preserve focus on editor
+		terminal.sendText(command)
+
+		this.log(`Setup script started in terminal`)
+	}
+
+	/**
+	 * Build the shell command to execute the setup script.
+	 * Cross-platform: uses sh on Unix, cmd on Windows.
+	 */
+	private buildCommand(scriptPath: string, env: SetupScriptEnvironment): string {
+		// Export environment variables and run the script
+		if (process.platform === "win32") {
+			// Windows: set environment variables and run script
+			return [
+				`set "WORKTREE_PATH=${env.worktreePath}"`,
+				`set "REPO_PATH=${env.repoPath}"`,
+				`"${scriptPath}"`,
+			].join(" && ")
+		} else {
+			// Unix: export environment variables and run script with sh
+			// We use sh explicitly to ensure the script runs even if it doesn't have execute permission
+			return [
+				`export WORKTREE_PATH="${env.worktreePath}"`,
+				`export REPO_PATH="${env.repoPath}"`,
+				`sh "${scriptPath}"`,
+			].join(" && ")
+		}
+	}
+
+	private log(message: string): void {
+		this.outputChannel.appendLine(`[SetupScriptRunner] ${message}`)
+	}
+}

--- a/src/core/kilocode/agent-manager/SetupScriptService.ts
+++ b/src/core/kilocode/agent-manager/SetupScriptService.ts
@@ -1,0 +1,129 @@
+/**
+ * SetupScriptService - Manages worktree setup scripts
+ *
+ * Handles reading, creating, and checking for setup scripts stored in .kilocode/setup-script.
+ * Setup scripts run before an agent starts in a worktree (new sessions only).
+ */
+
+import * as vscode from "vscode"
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+const SETUP_SCRIPT_FILENAME = "setup-script"
+const KILOCODE_DIR = ".kilocode"
+
+/**
+ * Default template for the setup script with helpful comments
+ */
+const DEFAULT_SCRIPT_TEMPLATE = `#!/bin/bash
+# Kilo Code Worktree Setup Script
+# This script runs before the agent starts in a worktree (new sessions only).
+#
+# Available environment variables:
+#   WORKTREE_PATH  - Absolute path to the worktree directory
+#   REPO_PATH      - Absolute path to the main repository
+#
+# Example tasks:
+#   - Copy .env files from main repo
+#   - Install dependencies
+#   - Run database migrations
+#   - Set up local configuration
+
+set -e  # Exit on error
+
+echo "Setting up worktree: $WORKTREE_PATH"
+
+# Uncomment and modify as needed:
+
+# Copy environment files
+# if [ -f "$REPO_PATH/.env" ]; then
+#     cp "$REPO_PATH/.env" "$WORKTREE_PATH/.env"
+#     echo "Copied .env"
+# fi
+
+# Install dependencies (Node.js)
+# if [ -f "$WORKTREE_PATH/package.json" ]; then
+#     cd "$WORKTREE_PATH"
+#     npm install
+# fi
+
+# Install dependencies (Python)
+# if [ -f "$WORKTREE_PATH/requirements.txt" ]; then
+#     cd "$WORKTREE_PATH"
+#     pip install -r requirements.txt
+# fi
+
+echo "Setup complete!"
+`
+
+export class SetupScriptService {
+	private readonly projectRoot: string
+	private readonly scriptPath: string
+
+	constructor(projectRoot: string) {
+		this.projectRoot = projectRoot
+		this.scriptPath = path.join(projectRoot, KILOCODE_DIR, SETUP_SCRIPT_FILENAME)
+	}
+
+	/**
+	 * Get the path to the setup script
+	 */
+	getScriptPath(): string {
+		return this.scriptPath
+	}
+
+	/**
+	 * Check if a setup script exists
+	 */
+	hasScript(): boolean {
+		return fs.existsSync(this.scriptPath)
+	}
+
+	/**
+	 * Read the setup script content
+	 * @returns Script content if exists, null otherwise
+	 */
+	async getScript(): Promise<string | null> {
+		if (!this.hasScript()) {
+			return null
+		}
+
+		try {
+			return await fs.promises.readFile(this.scriptPath, "utf-8")
+		} catch {
+			return null
+		}
+	}
+
+	/**
+	 * Create a default setup script with helpful comments and open it in VS Code
+	 */
+	async createDefaultScript(): Promise<void> {
+		// Ensure .kilocode directory exists
+		const kilocodeDir = path.join(this.projectRoot, KILOCODE_DIR)
+		if (!fs.existsSync(kilocodeDir)) {
+			await fs.promises.mkdir(kilocodeDir, { recursive: true })
+		}
+
+		// Write the default template
+		await fs.promises.writeFile(this.scriptPath, DEFAULT_SCRIPT_TEMPLATE, "utf-8")
+
+		// Make executable on Unix systems
+		if (process.platform !== "win32") {
+			await fs.promises.chmod(this.scriptPath, 0o755)
+		}
+	}
+
+	/**
+	 * Open the setup script in VS Code editor
+	 * Creates the default script if it doesn't exist
+	 */
+	async openInEditor(): Promise<void> {
+		if (!this.hasScript()) {
+			await this.createDefaultScript()
+		}
+
+		const document = await vscode.workspace.openTextDocument(this.scriptPath)
+		await vscode.window.showTextDocument(document)
+	}
+}

--- a/src/core/kilocode/agent-manager/__tests__/SetupScriptRunner.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/SetupScriptRunner.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as vscode from "vscode"
+import { SetupScriptRunner, type SetupScriptEnvironment } from "../SetupScriptRunner"
+import { SetupScriptService } from "../SetupScriptService"
+
+// Mock terminal object
+const mockTerminal = {
+	show: vi.fn(),
+	sendText: vi.fn(),
+}
+
+// Mock vscode
+vi.mock("vscode", () => ({
+	window: {
+		createTerminal: vi.fn(() => mockTerminal),
+	},
+	ThemeIcon: vi.fn().mockImplementation((id: string) => ({ id })),
+}))
+
+describe("SetupScriptRunner", () => {
+	const testEnv: SetupScriptEnvironment = {
+		worktreePath: "/test/project/.kilocode/worktrees/feature-branch",
+		repoPath: "/test/project",
+	}
+
+	let mockOutputChannel: { appendLine: ReturnType<typeof vi.fn> }
+	let mockSetupScriptService: {
+		hasScript: ReturnType<typeof vi.fn>
+		getScriptPath: ReturnType<typeof vi.fn>
+	}
+	let runner: SetupScriptRunner
+
+	beforeEach(() => {
+		mockOutputChannel = {
+			appendLine: vi.fn(),
+		}
+		mockSetupScriptService = {
+			hasScript: vi.fn(),
+			getScriptPath: vi.fn().mockReturnValue("/test/project/.kilocode/setup-script"),
+		}
+		runner = new SetupScriptRunner(
+			mockOutputChannel as unknown as vscode.OutputChannel,
+			mockSetupScriptService as unknown as SetupScriptService,
+		)
+		vi.clearAllMocks()
+		// Reset mock terminal functions after clearAllMocks
+		mockTerminal.show = vi.fn()
+		mockTerminal.sendText = vi.fn()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	describe("runIfConfigured", () => {
+		it("returns false and skips when no script is configured", async () => {
+			mockSetupScriptService.hasScript.mockReturnValue(false)
+
+			const result = await runner.runIfConfigured(testEnv)
+
+			expect(result).toBe(false)
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+				expect.stringContaining("No setup script configured"),
+			)
+		})
+
+		it("returns true and executes script when configured", async () => {
+			const vscode = await import("vscode")
+			mockSetupScriptService.hasScript.mockReturnValue(true)
+
+			const result = await runner.runIfConfigured(testEnv)
+
+			expect(result).toBe(true)
+			expect(vscode.window.createTerminal).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: "Worktree Setup",
+					cwd: testEnv.worktreePath,
+					env: {
+						WORKTREE_PATH: testEnv.worktreePath,
+						REPO_PATH: testEnv.repoPath,
+					},
+				}),
+			)
+			expect(mockTerminal.show).toHaveBeenCalledWith(true)
+			expect(mockTerminal.sendText).toHaveBeenCalled()
+		})
+
+		it("logs script path when running", async () => {
+			mockSetupScriptService.hasScript.mockReturnValue(true)
+
+			await runner.runIfConfigured(testEnv)
+
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringContaining("Running setup script"))
+		})
+
+		it("returns true even when execution fails (non-blocking)", async () => {
+			const vscode = await import("vscode")
+			mockSetupScriptService.hasScript.mockReturnValue(true)
+			vi.mocked(vscode.window.createTerminal).mockImplementation(() => {
+				throw new Error("Terminal creation failed")
+			})
+
+			const result = await runner.runIfConfigured(testEnv)
+
+			expect(result).toBe(true) // Non-blocking - still returns true
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+				expect.stringContaining("Setup script execution failed"),
+			)
+		})
+	})
+
+	describe("buildCommand (via terminal sendText)", () => {
+		it("builds Unix command with sh", async () => {
+			const originalPlatform = process.platform
+			Object.defineProperty(process, "platform", { value: "linux" })
+
+			mockSetupScriptService.hasScript.mockReturnValue(true)
+
+			await runner.runIfConfigured(testEnv)
+
+			expect(mockTerminal.sendText).toHaveBeenCalledWith(expect.stringContaining("sh "))
+
+			Object.defineProperty(process, "platform", { value: originalPlatform })
+		})
+
+		it("builds Windows command with set statements", async () => {
+			const originalPlatform = process.platform
+			Object.defineProperty(process, "platform", { value: "win32" })
+
+			mockSetupScriptService.hasScript.mockReturnValue(true)
+
+			await runner.runIfConfigured(testEnv)
+
+			// Windows uses set commands to set environment variables
+			expect(mockTerminal.sendText).toHaveBeenCalledWith(expect.stringContaining("set "))
+
+			Object.defineProperty(process, "platform", { value: originalPlatform })
+		})
+	})
+})

--- a/src/core/kilocode/agent-manager/__tests__/SetupScriptService.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/SetupScriptService.spec.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as path from "node:path"
+
+// Mock fs module
+vi.mock("node:fs", () => ({
+	existsSync: vi.fn(),
+	promises: {
+		readFile: vi.fn(),
+		writeFile: vi.fn(),
+		mkdir: vi.fn(),
+		chmod: vi.fn(),
+	},
+}))
+
+// Mock vscode
+vi.mock("vscode", () => ({
+	Uri: {
+		file: vi.fn().mockImplementation((p: string) => ({ fsPath: p, scheme: "file" })),
+	},
+	workspace: {
+		openTextDocument: vi.fn().mockResolvedValue({}),
+	},
+	window: {
+		showTextDocument: vi.fn().mockResolvedValue(undefined),
+	},
+}))
+
+import * as fs from "node:fs"
+import { SetupScriptService } from "../SetupScriptService"
+
+describe("SetupScriptService", () => {
+	const testWorkspacePath = "/test/project"
+	let service: SetupScriptService
+
+	beforeEach(() => {
+		service = new SetupScriptService(testWorkspacePath)
+		vi.clearAllMocks()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	describe("getScriptPath", () => {
+		it("returns correct path to setup-script file", () => {
+			const expectedPath = path.join(testWorkspacePath, ".kilocode", "setup-script")
+			expect(service.getScriptPath()).toBe(expectedPath)
+		})
+	})
+
+	describe("hasScript", () => {
+		it("returns true when script exists", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(true)
+
+			expect(service.hasScript()).toBe(true)
+			expect(fs.existsSync).toHaveBeenCalledWith(service.getScriptPath())
+		})
+
+		it("returns false when script does not exist", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+
+			expect(service.hasScript()).toBe(false)
+		})
+	})
+
+	describe("getScript", () => {
+		it("returns script content when script exists", async () => {
+			const scriptContent = "#!/bin/bash\necho 'Hello'"
+			vi.mocked(fs.existsSync).mockReturnValue(true)
+			vi.mocked(fs.promises.readFile).mockResolvedValue(scriptContent)
+
+			const result = await service.getScript()
+
+			expect(result).toBe(scriptContent)
+			expect(fs.promises.readFile).toHaveBeenCalledWith(service.getScriptPath(), "utf-8")
+		})
+
+		it("returns null when script does not exist", async () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+
+			const result = await service.getScript()
+
+			expect(result).toBeNull()
+		})
+
+		it("returns null when read fails", async () => {
+			vi.mocked(fs.existsSync).mockReturnValue(true)
+			vi.mocked(fs.promises.readFile).mockRejectedValue(new Error("Read failed"))
+
+			const result = await service.getScript()
+
+			expect(result).toBeNull()
+		})
+	})
+
+	describe("createDefaultScript", () => {
+		it("creates .kilocode directory if it does not exist", async () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			vi.mocked(fs.promises.mkdir).mockResolvedValue(undefined)
+			vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined)
+			vi.mocked(fs.promises.chmod).mockResolvedValue(undefined)
+
+			await service.createDefaultScript()
+
+			expect(fs.promises.mkdir).toHaveBeenCalledWith(
+				path.join(testWorkspacePath, ".kilocode"),
+				expect.objectContaining({ recursive: true }),
+			)
+		})
+
+		it("writes default template to script file", async () => {
+			vi.mocked(fs.existsSync).mockReturnValue(true)
+			vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined)
+			vi.mocked(fs.promises.chmod).mockResolvedValue(undefined)
+
+			await service.createDefaultScript()
+
+			expect(fs.promises.writeFile).toHaveBeenCalledWith(
+				service.getScriptPath(),
+				expect.stringContaining("#!/bin/bash"),
+				"utf-8",
+			)
+		})
+
+		it("includes helpful comments in default template", async () => {
+			vi.mocked(fs.existsSync).mockReturnValue(true)
+			vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined)
+			vi.mocked(fs.promises.chmod).mockResolvedValue(undefined)
+
+			await service.createDefaultScript()
+
+			const writeCall = vi.mocked(fs.promises.writeFile).mock.calls[0]
+			const content = writeCall[1] as string
+
+			expect(content).toContain("WORKTREE_PATH")
+			expect(content).toContain("REPO_PATH")
+		})
+
+		it("makes script executable on Unix", async () => {
+			const originalPlatform = process.platform
+			Object.defineProperty(process, "platform", { value: "linux" })
+
+			vi.mocked(fs.existsSync).mockReturnValue(true)
+			vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined)
+			vi.mocked(fs.promises.chmod).mockResolvedValue(undefined)
+
+			await service.createDefaultScript()
+
+			expect(fs.promises.chmod).toHaveBeenCalledWith(service.getScriptPath(), 0o755)
+
+			Object.defineProperty(process, "platform", { value: originalPlatform })
+		})
+
+		it("does not chmod on Windows", async () => {
+			const originalPlatform = process.platform
+			Object.defineProperty(process, "platform", { value: "win32" })
+
+			vi.mocked(fs.existsSync).mockReturnValue(true)
+			vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined)
+			vi.mocked(fs.promises.chmod).mockResolvedValue(undefined)
+
+			await service.createDefaultScript()
+
+			expect(fs.promises.chmod).not.toHaveBeenCalled()
+
+			Object.defineProperty(process, "platform", { value: originalPlatform })
+		})
+	})
+
+	describe("openInEditor", () => {
+		it("creates default script if it does not exist", async () => {
+			const vscode = await import("vscode")
+			vi.mocked(fs.existsSync).mockReturnValueOnce(false).mockReturnValue(true)
+			vi.mocked(fs.promises.mkdir).mockResolvedValue(undefined)
+			vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined)
+			vi.mocked(fs.promises.chmod).mockResolvedValue(undefined)
+
+			await service.openInEditor()
+
+			expect(fs.promises.writeFile).toHaveBeenCalled()
+			expect(vscode.workspace.openTextDocument).toHaveBeenCalled()
+			expect(vscode.window.showTextDocument).toHaveBeenCalled()
+		})
+
+		it("opens existing script without creating", async () => {
+			const vscode = await import("vscode")
+			vi.mocked(fs.existsSync).mockReturnValue(true)
+
+			await service.openInEditor()
+
+			expect(fs.promises.writeFile).not.toHaveBeenCalled()
+			expect(vscode.workspace.openTextDocument).toHaveBeenCalled()
+			expect(vscode.window.showTextDocument).toHaveBeenCalled()
+		})
+	})
+})

--- a/webview-ui/src/i18n/locales/ar/agentManager.json
+++ b/webview-ui/src/i18n/locales/ar/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "مشاركة الجلسة",
 		"shareConfirmMessage": "هل ترغب في مشاركة لقطة من هذه الجلسة علنًا؟",
 		"shareConfirmYes": "نعم",
-		"shareConfirmNo": "لا"
+		"shareConfirmNo": "لا",
+		"options": "خيارات",
+		"configureSetupScript": "سكريبت إعداد Worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "بدء وكيل جديد",

--- a/webview-ui/src/i18n/locales/ca/agentManager.json
+++ b/webview-ui/src/i18n/locales/ca/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Compartir sessió",
 		"shareConfirmMessage": "Vols compartir públicament una instantània d'aquesta sessió?",
 		"shareConfirmYes": "Sí",
-		"shareConfirmNo": "No"
+		"shareConfirmNo": "No",
+		"options": "Opcions",
+		"configureSetupScript": "Script de setup del worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Iniciar un agent nou",

--- a/webview-ui/src/i18n/locales/cs/agentManager.json
+++ b/webview-ui/src/i18n/locales/cs/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Sdílet relaci",
 		"shareConfirmMessage": "Chcete veřejně sdílet snímek této relace?",
 		"shareConfirmYes": "Ano",
-		"shareConfirmNo": "Ne"
+		"shareConfirmNo": "Ne",
+		"options": "Možnosti",
+		"configureSetupScript": "Setup skript worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Spustit nového agenta",

--- a/webview-ui/src/i18n/locales/de/agentManager.json
+++ b/webview-ui/src/i18n/locales/de/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Sitzung teilen",
 		"shareConfirmMessage": "Möchtest du einen Schnappschuss dieser Sitzung öffentlich teilen?",
 		"shareConfirmYes": "Ja",
-		"shareConfirmNo": "Nein"
+		"shareConfirmNo": "Nein",
+		"options": "Optionen",
+		"configureSetupScript": "Worktree-Setup-Skript"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Einen neuen Agenten starten",

--- a/webview-ui/src/i18n/locales/en/agentManager.json
+++ b/webview-ui/src/i18n/locales/en/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Share session",
 		"shareConfirmMessage": "Would you like to publicly share a snapshot of this session?",
 		"shareConfirmYes": "Yes",
-		"shareConfirmNo": "No"
+		"shareConfirmNo": "No",
+		"options": "Options",
+		"configureSetupScript": "Worktree Setup Script"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Start a new agent",

--- a/webview-ui/src/i18n/locales/es/agentManager.json
+++ b/webview-ui/src/i18n/locales/es/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Compartir sesión",
 		"shareConfirmMessage": "¿Te gustaría compartir públicamente una instantánea de esta sesión?",
 		"shareConfirmYes": "Sí",
-		"shareConfirmNo": "No"
+		"shareConfirmNo": "No",
+		"options": "Opciones",
+		"configureSetupScript": "Script de setup de worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Iniciar un nuevo agente",

--- a/webview-ui/src/i18n/locales/fr/agentManager.json
+++ b/webview-ui/src/i18n/locales/fr/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Partager la session",
 		"shareConfirmMessage": "Souhaites-tu partager publiquement un instantané de cette session ?",
 		"shareConfirmYes": "Oui",
-		"shareConfirmNo": "Non"
+		"shareConfirmNo": "Non",
+		"options": "Options",
+		"configureSetupScript": "Script de setup worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Démarrer un nouvel agent",

--- a/webview-ui/src/i18n/locales/hi/agentManager.json
+++ b/webview-ui/src/i18n/locales/hi/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "सत्र साझा करें",
 		"shareConfirmMessage": "क्या आप इस सत्र का एक स्नैपशॉट सार्वजनिक रूप से साझा करना चाहेंगे?",
 		"shareConfirmYes": "हाँ",
-		"shareConfirmNo": "नहीं"
+		"shareConfirmNo": "नहीं",
+		"options": "विकल्प",
+		"configureSetupScript": "Worktree सेटअप स्क्रिप्ट"
 	},
 	"sessionDetail": {
 		"startNewAgent": "नया एजेंट शुरू करें",

--- a/webview-ui/src/i18n/locales/id/agentManager.json
+++ b/webview-ui/src/i18n/locales/id/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Bagikan sesi",
 		"shareConfirmMessage": "Apakah Anda ingin membagikan snapshot sesi ini secara publik?",
 		"shareConfirmYes": "Ya",
-		"shareConfirmNo": "Tidak"
+		"shareConfirmNo": "Tidak",
+		"options": "Opsi",
+		"configureSetupScript": "Skrip setup worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Mulai agen baru",

--- a/webview-ui/src/i18n/locales/it/agentManager.json
+++ b/webview-ui/src/i18n/locales/it/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Condividi sessione",
 		"shareConfirmMessage": "Vuoi condividere pubblicamente uno snapshot di questa sessione?",
 		"shareConfirmYes": "Sì",
-		"shareConfirmNo": "No"
+		"shareConfirmNo": "No",
+		"options": "Opzioni",
+		"configureSetupScript": "Script di setup worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Avvia un nuovo agente",

--- a/webview-ui/src/i18n/locales/ja/agentManager.json
+++ b/webview-ui/src/i18n/locales/ja/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "セッションを共有",
 		"shareConfirmMessage": "このセッションのスナップショットを公開で共有しますか？",
 		"shareConfirmYes": "はい",
-		"shareConfirmNo": "いいえ"
+		"shareConfirmNo": "いいえ",
+		"options": "オプション",
+		"configureSetupScript": "Worktree セットアップスクリプト"
 	},
 	"sessionDetail": {
 		"startNewAgent": "新しいエージェントを開始",

--- a/webview-ui/src/i18n/locales/ko/agentManager.json
+++ b/webview-ui/src/i18n/locales/ko/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "세션 공유",
 		"shareConfirmMessage": "이 세션의 스냅샷을 공개적으로 공유하시겠습니까?",
 		"shareConfirmYes": "예",
-		"shareConfirmNo": "아니요"
+		"shareConfirmNo": "아니요",
+		"options": "옵션",
+		"configureSetupScript": "Worktree 설정 스크립트"
 	},
 	"sessionDetail": {
 		"startNewAgent": "새 에이전트 시작",

--- a/webview-ui/src/i18n/locales/nl/agentManager.json
+++ b/webview-ui/src/i18n/locales/nl/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Sessie delen",
 		"shareConfirmMessage": "Wil je een momentopname van deze sessie publiek delen?",
 		"shareConfirmYes": "Ja",
-		"shareConfirmNo": "Nee"
+		"shareConfirmNo": "Nee",
+		"options": "Opties",
+		"configureSetupScript": "Worktree setup-script"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Een nieuwe agent starten",

--- a/webview-ui/src/i18n/locales/pl/agentManager.json
+++ b/webview-ui/src/i18n/locales/pl/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Udostępnij sesję",
 		"shareConfirmMessage": "Czy chcesz publicznie udostępnić migawkę tej sesji?",
 		"shareConfirmYes": "Tak",
-		"shareConfirmNo": "Nie"
+		"shareConfirmNo": "Nie",
+		"options": "Opcje",
+		"configureSetupScript": "Skrypt setup worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Uruchom nowego agenta",

--- a/webview-ui/src/i18n/locales/pt-BR/agentManager.json
+++ b/webview-ui/src/i18n/locales/pt-BR/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Compartilhar sessão",
 		"shareConfirmMessage": "Gostaria de compartilhar publicamente um instantâneo desta sessão?",
 		"shareConfirmYes": "Sim",
-		"shareConfirmNo": "Não"
+		"shareConfirmNo": "Não",
+		"options": "Opções",
+		"configureSetupScript": "Script de setup do worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Iniciar um novo agente",

--- a/webview-ui/src/i18n/locales/ru/agentManager.json
+++ b/webview-ui/src/i18n/locales/ru/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Поделиться сессией",
 		"shareConfirmMessage": "Хотите опубликовать снимок этой сессии?",
 		"shareConfirmYes": "Да",
-		"shareConfirmNo": "Нет"
+		"shareConfirmNo": "Нет",
+		"options": "Параметры",
+		"configureSetupScript": "Скрипт настройки worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Запустить нового агента",

--- a/webview-ui/src/i18n/locales/th/agentManager.json
+++ b/webview-ui/src/i18n/locales/th/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "แชร์เซสชัน",
 		"shareConfirmMessage": "คุณต้องการแชร์สแนปช็อตของเซสชันนี้แบบสาธารณะหรือไม่?",
 		"shareConfirmYes": "ใช่",
-		"shareConfirmNo": "ไม่"
+		"shareConfirmNo": "ไม่",
+		"options": "ตัวเลือก",
+		"configureSetupScript": "สคริปต์ตั้งค่า Worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "เริ่มเอเจนต์ใหม่",

--- a/webview-ui/src/i18n/locales/tr/agentManager.json
+++ b/webview-ui/src/i18n/locales/tr/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Oturumu paylaş",
 		"shareConfirmMessage": "Bu oturumun bir anlık görüntüsünü herkese açık olarak paylaşmak istiyor musunuz?",
 		"shareConfirmYes": "Evet",
-		"shareConfirmNo": "Hayır"
+		"shareConfirmNo": "Hayır",
+		"options": "Seçenekler",
+		"configureSetupScript": "Worktree kurulum betiği"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Yeni bir ajan başlat",

--- a/webview-ui/src/i18n/locales/uk/agentManager.json
+++ b/webview-ui/src/i18n/locales/uk/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Поділитися сесією",
 		"shareConfirmMessage": "Хочете опублікувати знімок цієї сесії?",
 		"shareConfirmYes": "Так",
-		"shareConfirmNo": "Ні"
+		"shareConfirmNo": "Ні",
+		"options": "Параметри",
+		"configureSetupScript": "Скрипт налаштування worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Запустити нового агента",

--- a/webview-ui/src/i18n/locales/vi/agentManager.json
+++ b/webview-ui/src/i18n/locales/vi/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "Chia sẻ phiên",
 		"shareConfirmMessage": "Bạn có muốn chia sẻ công khai một ảnh chụp của phiên này không?",
 		"shareConfirmYes": "Có",
-		"shareConfirmNo": "Không"
+		"shareConfirmNo": "Không",
+		"options": "Tùy chọn",
+		"configureSetupScript": "Script thiết lập worktree"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Khởi động agent mới",

--- a/webview-ui/src/i18n/locales/zh-CN/agentManager.json
+++ b/webview-ui/src/i18n/locales/zh-CN/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "分享会话",
 		"shareConfirmMessage": "是否要公开分享此会话的快照？",
 		"shareConfirmYes": "是",
-		"shareConfirmNo": "否"
+		"shareConfirmNo": "否",
+		"options": "选项",
+		"configureSetupScript": "Worktree 设置脚本"
 	},
 	"sessionDetail": {
 		"startNewAgent": "启动新代理",

--- a/webview-ui/src/i18n/locales/zh-TW/agentManager.json
+++ b/webview-ui/src/i18n/locales/zh-TW/agentManager.json
@@ -14,7 +14,9 @@
 		"shareSession": "分享工作階段",
 		"shareConfirmMessage": "是否要公開分享此工作階段的快照？",
 		"shareConfirmYes": "是",
-		"shareConfirmNo": "否"
+		"shareConfirmNo": "否",
+		"options": "選項",
+		"configureSetupScript": "Worktree 設定腳本"
 	},
 	"sessionDetail": {
 		"startNewAgent": "啟動新代理",

--- a/webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css
+++ b/webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css
@@ -59,6 +59,64 @@
 	text-transform: uppercase;
 }
 
+.am-sidebar-header .am-icon-btn {
+	opacity: 0.6;
+}
+
+.am-sidebar-header .am-icon-btn:hover {
+	opacity: 1;
+}
+
+/* Options Menu Container */
+.am-options-menu-container {
+	position: relative;
+}
+
+.am-options-dropdown {
+	position: absolute;
+	top: 100%;
+	left: 0;
+	margin-top: 4px;
+	white-space: nowrap;
+	background: var(--vscode-menu-background, var(--vscode-dropdown-background));
+	border: 1px solid var(--vscode-menu-border, var(--vscode-dropdown-border));
+	border-radius: 4px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+	z-index: 100;
+	overflow: hidden;
+	padding: 4px 0;
+}
+
+.am-options-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	padding: 6px 12px;
+	border: none;
+	background: transparent;
+	color: var(--vscode-menu-foreground, var(--vscode-dropdown-foreground));
+	font-size: 12px;
+	text-align: left;
+	cursor: pointer;
+	transition: background 0.1s;
+}
+
+.am-options-item:hover {
+	background: var(--vscode-menu-selectionBackground, var(--vscode-list-hoverBackground));
+	color: var(--vscode-menu-selectionForeground, var(--vscode-list-hoverForeground));
+}
+
+.am-options-item:focus {
+	outline: none;
+	background: var(--vscode-menu-selectionBackground, var(--vscode-list-hoverBackground));
+}
+
+.am-options-item svg {
+	flex-shrink: 0;
+	opacity: 0.7;
+}
+
 /* New Agent Item - Primary action at top of sidebar */
 .am-new-agent-item {
 	display: flex;

--- a/webview-ui/src/kilocode/agent-manager/components/SessionSidebar.tsx
+++ b/webview-ui/src/kilocode/agent-manager/components/SessionSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react"
+import React, { useMemo, useState, useRef, useEffect } from "react"
 import { useAtom, useAtomValue, useSetAtom } from "jotai"
 import { useTranslation } from "react-i18next"
 import {
@@ -11,7 +11,7 @@ import {
 import { sessionMachineUiStateAtom } from "../state/atoms/stateMachine"
 import { vscode } from "../utils/vscode"
 import { formatRelativeTime, createRelativeTimeLabels } from "../utils/timeUtils"
-import { Plus, Loader2, RefreshCw, GitBranch, Folder, Share2 } from "lucide-react"
+import { Plus, Loader2, RefreshCw, GitBranch, Folder, Share2, MoreVertical, FileCode } from "lucide-react"
 
 export function SessionSidebar() {
 	const { t } = useTranslation("agentManager")
@@ -21,6 +21,28 @@ export function SessionSidebar() {
 	const isRefreshing = useAtomValue(isRefreshingRemoteSessionsAtom)
 	const setIsRefreshing = useSetAtom(isRefreshingRemoteSessionsAtom)
 	const machineUiState = useAtomValue(sessionMachineUiStateAtom)
+	const [showOptionsMenu, setShowOptionsMenu] = useState(false)
+	const menuRef = useRef<HTMLDivElement>(null)
+	const buttonRef = useRef<HTMLButtonElement>(null)
+
+	// Close menu when clicking outside
+	useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (
+				menuRef.current &&
+				buttonRef.current &&
+				!menuRef.current.contains(event.target as Node) &&
+				!buttonRef.current.contains(event.target as Node)
+			) {
+				setShowOptionsMenu(false)
+			}
+		}
+
+		if (showOptionsMenu) {
+			document.addEventListener("mousedown", handleClickOutside)
+			return () => document.removeEventListener("mousedown", handleClickOutside)
+		}
+	}, [showOptionsMenu])
 
 	const handleNewSession = () => {
 		setSelectedId(null)
@@ -37,12 +59,36 @@ export function SessionSidebar() {
 		vscode.postMessage({ type: "agentManager.refreshRemoteSessions" })
 	}
 
+	const handleConfigureSetupScript = () => {
+		setShowOptionsMenu(false)
+		vscode.postMessage({ type: "agentManager.configureSetupScript" })
+	}
+
 	const isNewAgentSelected = selectedId === null && !pendingSession
 
 	return (
 		<div className="am-sidebar">
 			<div className="am-sidebar-header">
 				<span>{t("sidebar.title")}</span>
+				<div className="am-options-menu-container">
+					<button
+						ref={buttonRef}
+						className="am-icon-btn"
+						onClick={() => setShowOptionsMenu(!showOptionsMenu)}
+						title={t("sidebar.options")}
+						aria-expanded={showOptionsMenu}
+						aria-haspopup="menu">
+						<MoreVertical size={14} />
+					</button>
+					{showOptionsMenu && (
+						<div ref={menuRef} className="am-options-dropdown" role="menu">
+							<button className="am-options-item" onClick={handleConfigureSetupScript} role="menuitem">
+								<FileCode size={14} />
+								<span>{t("sidebar.configureSetupScript")}</span>
+							</button>
+						</div>
+					)}
+				</div>
 			</div>
 
 			<div


### PR DESCRIPTION
## Summary

Adds support for user-defined worktree setup scripts that run before an agent starts in parallel mode. This allows users to prepare the worktree environment (e.g., copy `.env` files, install dependencies, run custom initialization) before the agent begins working.

## Features

- **Setup Script Storage**: Scripts are stored in `.kilocode/setup-script` within the project
- **Cross-Platform Support**: Unix uses `sh`, Windows uses `cmd` with `set` commands
- **Environment Variables**: Scripts receive `WORKTREE_PATH` and `REPO_PATH`
- **Non-Blocking Execution**: Errors are visible in terminal but don't prevent agent startup
- **Multi-Version Support**: Script runs for each worktree when using multiple versions
- **UI Integration**: Dropdown menu in Agent Manager sidebar with "Worktree Setup Script" option

## Implementation

### New Files
- `src/core/kilocode/agent-manager/SetupScriptService.ts` - Manages script file operations
- `src/core/kilocode/agent-manager/SetupScriptRunner.ts` - Executes scripts in VS Code terminal
- `src/core/kilocode/agent-manager/__tests__/SetupScriptService.spec.ts` - 12 unit tests
- `src/core/kilocode/agent-manager/__tests__/SetupScriptRunner.spec.ts` - 7 unit tests
- `docs/plans/worktree-setup-script-implementation.md` - Implementation plan

### Modified Files
- `src/core/kilocode/agent-manager/AgentManagerProvider.ts` - Integration with session startup
- `webview-ui/src/kilocode/agent-manager/components/SessionSidebar.tsx` - UI dropdown menu
- `webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css` - Dropdown styles
- All 20 language files in `webview-ui/src/i18n/locales/*/agentManager.json` - Translations

## Usage

1. Click the ⋮ menu in the Agent Manager sidebar
2. Select "Worktree Setup Script"
3. Edit the script (default template provided)
4. Save - script will run before each new parallel mode session

## Example Script

```bash
#!/bin/bash
# Copy environment files
cp "$REPO_PATH/.env" "$WORKTREE_PATH/.env"

# Install dependencies
cd "$WORKTREE_PATH" && npm install
```

## Testing

- 19 unit tests covering both service and runner
- Manual testing with single and multi-version sessions
- Cross-platform testing (Unix shell commands)