### PR TITLE
feat: translate ghost section for 13 languages

### DIFF
--- a/webview-ui/src/i18n/locales/ca/kilocode.json
+++ b/webview-ui/src/i18n/locales/ca/kilocode.json
@@ -213,27 +213,27 @@
 			"chatSuggestions": "Suggeriments del Xat",
 			"keybindingDescription": "Les funcionalitats d'Autocomplete es poden activar mitjançant ordres. Pots configurar les <DocsLink>Dreceres de Teclat aquí</DocsLink>.",
 			"enableAutoTrigger": {
-				"label": "Habilitar Autocomplete",
-				"description": "Quan està habilitat, Kilo Code activarà automàticament Autocomplete quan deixis d'escriure. Això pot ser útil per a correccions ràpides i suggeriments."
+				"label": "Activar Suggeriments Automàtics",
+				"description": "Mostra automàticament suggeriments de codi en línia quan deixes d'escriure."
 			},
 			"autoTriggerDelay": {
 				"label": "Retard d'Activació Automàtica",
 				"description": "El retard en segons abans que Kilo Code activi Autocomplete després que deixis d'escriure. Un retard més curt significa suggeriments més ràpids, però pot ser més intensiu en recursos."
 			},
 			"enableSmartInlineTaskKeybinding": {
-				"label": "Autocompleció Manual ({{keybinding}})",
-				"description": "Necessites una correcció ràpida, completació o refactorització? Kilo utilitzarà el context circumdant per oferir millores immediates, mantenint-te en el flux. <DocsLink>Veure drecera</DocsLink>"
+				"label": "Activar amb Drecera ({{keybinding}})",
+				"description": "Prem {{keybinding}} per sol·licitar un suggeriment de codi a la posició del cursor. <DocsLink>Editar drecera</DocsLink>"
 			},
 			"keybindingNotFound": "no trobat",
 			"configureAutocompleteProfile": "Utilitza qualsevol model anant a perfils i configurant un Perfil del Tipus de Perfil Autocompletat.",
 			"model": "Model",
 			"provider": "Proveïdor",
 			"enableChatAutocomplete": {
-				"description": "Quan està activat, Kilo Code suggerirà complecions mentre escriviu a l'entrada del xat. Premeu Tab per acceptar els suggeriments.",
-				"label": "Autocompletat d'entrada de xat"
+				"label": "Habilitar Autocompletat del Xat",
+				"description": "Mostra complecions mentre escrius a l'entrada del xat. Prem Tab per acceptar els suggeriments."
 			},
 			"snooze": {
-				"label": "Posposar Autocomplete",
+				"label": "Posposar Suggeriments",
 				"description": "Pausa temporalment els suggeriments d'autocompletat durant un temps especificat.",
 				"button": "Posposar",
 				"unsnooze": "Reactivar",

--- a/webview-ui/src/i18n/locales/cs/kilocode.json
+++ b/webview-ui/src/i18n/locales/cs/kilocode.json
@@ -224,31 +224,31 @@
 		"title": "Autocomplete",
 		"settings": {
 			"enableAutoTrigger": {
-				"label": "Auto-trigger Suggestions",
+				"label": "Automatické spouštění návrhů",
 				"description": "Automaticky zobrazovat návrhy kódu při pozastavení psaní."
 			},
 			"autoTriggerDelay": {
 				"label": "Zpoždění Automatického Spuštění",
-				"description": "The delay in seconds before suggestions appear after you pause typing. A shorter delay means quicker suggestions, but may be more resource-intensive."
+				"description": "Zpoždění v sekundách před zobrazením návrhů po pozastavení psaní. Kratší zpoždění znamená rychlejší návrhy, ale může být náročnější na zdroje."
 			},
 			"enableSmartInlineTaskKeybinding": {
-				"label": "Trigger on Keybinding ({{keybinding}})",
-				"description": "Press {{keybinding}} to request a code suggestion at your cursor position. <DocsLink>Edit shortcut</DocsLink>"
+				"label": "Spustit klávesovou zkratkou ({{keybinding}})",
+				"description": "Stiskni {{keybinding}} pro vyžádání návrhu kódu na pozici kurzoru. <DocsLink>Upravit zkratku</DocsLink>"
 			},
 			"keybindingNotFound": "nenalezeno",
 			"configureAutocompleteProfile": "Použij libovolný model tak, že přejdeš do profilů a nakonfiguruješ Profil typu Automatické dokončování.",
 			"model": "Model",
 			"provider": "Poskytovatel",
 			"enableChatAutocomplete": {
-				"label": "Enable Chat Autocomplete",
-				"description": "Show completions as you type in the chat input. Press Tab to accept suggestions."
+				"label": "Povolit automatické dokončování v chatu",
+				"description": "Zobrazovat návrhy při psaní v chatovém vstupu. Stiskni Tab pro přijetí návrhů."
 			},
 			"snooze": {
-				"label": "Snooze Suggestions",
-				"description": "Temporarily pause suggestions for a specified duration.",
+				"label": "Pozastavit návrhy",
+				"description": "Dočasně pozastavit návrhy na určitou dobu.",
 				"button": "Pozastavit",
 				"unsnooze": "Obnovit",
-				"currentlySnoozed": "Suggestions are currently snoozed.",
+				"currentlySnoozed": "Návrhy jsou momentálně pozastaveny.",
 				"duration": {
 					"1min": "1 minuta",
 					"5min": "5 minut",
@@ -267,8 +267,8 @@
 				"description": "Váš účet Kilo Code nemá žádné kredity. Pro použití automatického dokončování prosím přidejte kredity na svůj účet.",
 				"buyCredits": "Koupit kredity →"
 			},
-			"codeEditorSuggestions": "Code Editor Suggestions",
-			"chatSuggestions": "Chat Suggestions"
+			"codeEditorSuggestions": "Návrhy v editoru kódu",
+			"chatSuggestions": "Návrhy v chatu"
 		}
 	},
 	"virtualProvider": {

--- a/webview-ui/src/i18n/locales/de/kilocode.json
+++ b/webview-ui/src/i18n/locales/de/kilocode.json
@@ -216,32 +216,32 @@
 	"ghost": {
 		"title": "Autocomplete",
 		"settings": {
+			"codeEditorSuggestions": "Code-Editor-Vorschläge",
+			"chatSuggestions": "Chat-Vorschläge",
 			"model": "Modell",
 			"provider": "Provider",
 			"enableAutoTrigger": {
-				"label": "Auto-trigger Suggestions",
-				"description": "Zeigt automatisch Inline-Code-Vorschläge an, wenn Sie beim Tippen pausieren."
+				"label": "Vorschläge automatisch auslösen",
+				"description": "Zeigt automatisch Inline-Code-Vorschläge an, wenn du beim Tippen pausierst."
 			},
 			"autoTriggerDelay": {
 				"label": "Auto-Auslöseverzögerung",
-				"description": "The delay in seconds before suggestions appear after you pause typing. A shorter delay means quicker suggestions, but may be more resource-intensive."
+				"description": "Die Verzögerung in Sekunden, bevor Vorschläge erscheinen, nachdem du beim Tippen pausierst. Eine kürzere Verzögerung bedeutet schnellere Vorschläge, kann aber ressourcenintensiver sein."
 			},
 			"enableSmartInlineTaskKeybinding": {
-				"label": "Trigger on Keybinding ({{keybinding}})",
-				"description": "Press {{keybinding}} to request a code suggestion at your cursor position. <DocsLink>Edit shortcut</DocsLink>"
+				"label": "Per Tastenkürzel auslösen ({{keybinding}})",
+				"description": "Drücke {{keybinding}}, um einen Code-Vorschlag an deiner Cursorposition anzufordern. <DocsLink>Tastenkürzel bearbeiten</DocsLink>"
 			},
-			"keybindingNotFound": "nicht gefunden",
-			"configureAutocompleteProfile": "Verwende ein beliebiges Modell, indem du zu Profilen gehst und ein Profil vom Profiltyp Autocomplete konfigurierst.",
 			"enableChatAutocomplete": {
-				"label": "Enable Chat Autocomplete",
-				"description": "Show completions as you type in the chat input. Press Tab to accept suggestions."
+				"label": "Chat-Autovervollständigung aktivieren",
+				"description": "Zeigt Vervollständigungen an, während du im Chat-Eingabefeld tippst. Drücke Tab, um Vorschläge zu akzeptieren."
 			},
 			"snooze": {
-				"label": "Snooze Suggestions",
-				"description": "Temporarily pause suggestions for a specified duration.",
+				"label": "Vorschläge pausieren",
+				"description": "Vorschläge vorübergehend für eine bestimmte Dauer pausieren.",
 				"button": "Pausieren",
 				"unsnooze": "Fortsetzen",
-				"currentlySnoozed": "Suggestions are currently snoozed.",
+				"currentlySnoozed": "Vorschläge sind derzeit pausiert.",
 				"duration": {
 					"1min": "1 Minute",
 					"5min": "5 Minuten",
@@ -250,6 +250,7 @@
 					"1hour": "1 Stunde"
 				}
 			},
+			"keybindingNotFound": "nicht gefunden",
 			"noModelConfigured": {
 				"title": "Kein Autocomplete-Modell konfiguriert",
 				"description": "Um Autocomplete zu aktivieren, füge ein Profil mit einem dieser unterstützten Anbieter hinzu:",
@@ -260,8 +261,7 @@
 				"description": "Dein Kilo Code Konto hat kein Guthaben. Um Autocomplete zu nutzen, füge bitte Guthaben zu deinem Konto hinzu.",
 				"buyCredits": "Guthaben kaufen →"
 			},
-			"codeEditorSuggestions": "Code Editor Suggestions",
-			"chatSuggestions": "Chat Suggestions"
+			"configureAutocompleteProfile": "Verwende ein beliebiges Modell, indem du zu Profilen gehst und ein Profil vom Profiltyp Autocomplete konfigurierst."
 		}
 	},
 	"virtualProvider": {

--- a/webview-ui/src/i18n/locales/es/kilocode.json
+++ b/webview-ui/src/i18n/locales/es/kilocode.json
@@ -214,34 +214,34 @@
 		}
 	},
 	"ghost": {
-		"title": "Autocomplete",
+		"title": "Autocompletado",
 		"settings": {
+			"codeEditorSuggestions": "Sugerencias del Editor de Código",
+			"chatSuggestions": "Sugerencias del Chat",
+			"model": "Modelo",
+			"provider": "Proveedor",
 			"enableAutoTrigger": {
-				"label": "Auto-trigger Suggestions",
+				"label": "Activar sugerencias automáticamente",
 				"description": "Mostrar automáticamente sugerencias de código en línea cuando dejas de escribir."
 			},
 			"autoTriggerDelay": {
 				"label": "Retraso de Activación Automática",
-				"description": "The delay in seconds before suggestions appear after you pause typing. A shorter delay means quicker suggestions, but may be more resource-intensive."
+				"description": "El retraso en segundos antes de que aparezcan las sugerencias después de dejar de escribir. Un retraso más corto significa sugerencias más rápidas, pero puede consumir más recursos."
 			},
 			"enableSmartInlineTaskKeybinding": {
-				"label": "Trigger on Keybinding ({{keybinding}})",
-				"description": "Press {{keybinding}} to request a code suggestion at your cursor position. <DocsLink>Edit shortcut</DocsLink>"
+				"label": "Activar con atajo de teclado ({{keybinding}})",
+				"description": "Presiona {{keybinding}} para solicitar una sugerencia de código en la posición del cursor. <DocsLink>Editar atajo</DocsLink>"
 			},
-			"keybindingNotFound": "no encontrado",
-			"configureAutocompleteProfile": "Usa cualquier modelo yendo a perfiles y configurando un Perfil del Tipo de Perfil Autocompletado.",
-			"model": "Modelo",
-			"provider": "Proveedor",
 			"enableChatAutocomplete": {
-				"description": "Show completions as you type in the chat input. Press Tab to accept suggestions.",
-				"label": "Enable Chat Autocomplete"
+				"label": "Activar autocompletado del chat",
+				"description": "Mostrar sugerencias mientras escribes en el campo de entrada del chat. Presiona Tab para aceptar sugerencias."
 			},
 			"snooze": {
-				"label": "Snooze Suggestions",
-				"description": "Temporarily pause suggestions for a specified duration.",
+				"label": "Pausar sugerencias",
+				"description": "Pausar temporalmente las sugerencias durante un tiempo determinado.",
 				"button": "Posponer",
 				"unsnooze": "Reactivar",
-				"currentlySnoozed": "Suggestions are currently snoozed.",
+				"currentlySnoozed": "Las sugerencias están actualmente pausadas.",
 				"duration": {
 					"1min": "1 minuto",
 					"5min": "5 minutos",
@@ -250,6 +250,7 @@
 					"1hour": "1 hora"
 				}
 			},
+			"keybindingNotFound": "no encontrado",
 			"noModelConfigured": {
 				"title": "No hay modelo de autocompletado configurado",
 				"description": "Para habilitar el autocompletado, añade un perfil con uno de estos proveedores compatibles:",
@@ -260,8 +261,7 @@
 				"description": "Tu cuenta de Kilo Code no tiene créditos. Para usar el autocompletado, por favor añade créditos a tu cuenta.",
 				"buyCredits": "Comprar créditos →"
 			},
-			"codeEditorSuggestions": "Code Editor Suggestions",
-			"chatSuggestions": "Chat Suggestions"
+			"configureAutocompleteProfile": "Usa cualquier modelo yendo a perfiles y configurando un Perfil del Tipo de Perfil Autocompletado."
 		}
 	},
 	"virtualProvider": {

--- a/webview-ui/src/i18n/locales/fr/kilocode.json
+++ b/webview-ui/src/i18n/locales/fr/kilocode.json
@@ -221,34 +221,34 @@
 		}
 	},
 	"ghost": {
-		"title": "Autocomplete",
+		"title": "Autocomplétion",
 		"settings": {
+			"codeEditorSuggestions": "Suggestions de l'éditeur de code",
+			"chatSuggestions": "Suggestions du chat",
+			"model": "Modèle",
+			"provider": "Fournisseur",
 			"enableAutoTrigger": {
-				"label": "Auto-trigger Suggestions",
-				"description": "Afficher automatiquement des suggestions de code en ligne lorsque vous faites une pause dans la saisie."
+				"label": "Déclencher automatiquement les suggestions",
+				"description": "Afficher automatiquement des suggestions de code en ligne lorsque tu fais une pause dans la saisie."
 			},
 			"autoTriggerDelay": {
 				"label": "Délai de Déclenchement Automatique",
-				"description": "The delay in seconds before suggestions appear after you pause typing. A shorter delay means quicker suggestions, but may be more resource-intensive."
+				"description": "Le délai en secondes avant que les suggestions n'apparaissent après une pause de frappe. Un délai plus court signifie des suggestions plus rapides, mais peut être plus gourmand en ressources."
 			},
 			"enableSmartInlineTaskKeybinding": {
-				"label": "Trigger on Keybinding ({{keybinding}})",
-				"description": "Press {{keybinding}} to request a code suggestion at your cursor position. <DocsLink>Edit shortcut</DocsLink>"
+				"label": "Déclencher par raccourci clavier ({{keybinding}})",
+				"description": "Appuie sur {{keybinding}} pour demander une suggestion de code à la position du curseur. <DocsLink>Modifier le raccourci</DocsLink>"
 			},
-			"keybindingNotFound": "introuvable",
-			"configureAutocompleteProfile": "Utilise n'importe quel modèle en allant dans les profils et en configurant un Profil du Type de Profil Autocomplétion.",
-			"model": "Modèle",
-			"provider": "Fournisseur",
 			"enableChatAutocomplete": {
-				"label": "Enable Chat Autocomplete",
-				"description": "Show completions as you type in the chat input. Press Tab to accept suggestions."
+				"label": "Activer l'autocomplétion du chat",
+				"description": "Afficher les suggestions pendant la saisie dans le champ de chat. Appuie sur Tab pour accepter les suggestions."
 			},
 			"snooze": {
-				"label": "Snooze Suggestions",
-				"description": "Temporarily pause suggestions for a specified duration.",
+				"label": "Mettre en pause les suggestions",
+				"description": "Mettre temporairement en pause les suggestions pour une durée spécifiée.",
 				"button": "Mettre en pause",
 				"unsnooze": "Réactiver",
-				"currentlySnoozed": "Suggestions are currently snoozed.",
+				"currentlySnoozed": "Les suggestions sont actuellement en pause.",
 				"duration": {
 					"1min": "1 minute",
 					"5min": "5 minutes",
@@ -257,18 +257,18 @@
 					"1hour": "1 heure"
 				}
 			},
+			"keybindingNotFound": "introuvable",
 			"noModelConfigured": {
 				"title": "Aucun modèle d'autocomplétion configuré",
-				"description": "Pour activer l'autocomplétion, ajoutez un profil avec l'un de ces fournisseurs pris en charge :",
+				"description": "Pour activer l'autocomplétion, ajoute un profil avec l'un de ces fournisseurs pris en charge :",
 				"learnMore": "En savoir plus sur la configuration de l'autocomplétion →"
 			},
 			"noCredits": {
-				"title": "Aucun crédit sur votre compte",
-				"description": "Votre compte Kilo Code n'a pas de crédits. Pour utiliser l'autocomplétion, veuillez ajouter des crédits à votre compte.",
+				"title": "Aucun crédit sur ton compte",
+				"description": "Ton compte Kilo Code n'a pas de crédits. Pour utiliser l'autocomplétion, ajoute des crédits à ton compte.",
 				"buyCredits": "Acheter des crédits →"
 			},
-			"codeEditorSuggestions": "Code Editor Suggestions",
-			"chatSuggestions": "Chat Suggestions"
+			"configureAutocompleteProfile": "Utilise n'importe quel modèle en allant dans les profils et en configurant un Profil du Type de Profil Autocomplétion."
 		}
 	},
 	"virtualProvider": {

--- a/webview-ui/src/i18n/locales/hi/kilocode.json
+++ b/webview-ui/src/i18n/locales/hi/kilocode.json
@@ -207,34 +207,34 @@
 		}
 	},
 	"ghost": {
-		"title": "Autocomplete",
+		"title": "ऑटोकम्पलीट",
 		"settings": {
+			"codeEditorSuggestions": "कोड एडिटर सुझाव",
+			"chatSuggestions": "चैट सुझाव",
+			"model": "मॉडल",
+			"provider": "प्रदाता",
 			"enableAutoTrigger": {
-				"label": "Auto-trigger Suggestions",
+				"label": "सुझाव स्वचालित रूप से ट्रिगर करें",
 				"description": "टाइपिंग रोकने पर स्वचालित रूप से इनलाइन कोड सुझाव दिखाएं।"
 			},
 			"autoTriggerDelay": {
 				"label": "ऑटो ट्रिगर देरी",
-				"description": "The delay in seconds before suggestions appear after you pause typing. A shorter delay means quicker suggestions, but may be more resource-intensive."
+				"description": "टाइपिंग रोकने के बाद सुझाव दिखने से पहले सेकंड में देरी। कम देरी का मतलब तेज़ सुझाव है, लेकिन यह अधिक संसाधन-गहन हो सकता है।"
 			},
 			"enableSmartInlineTaskKeybinding": {
-				"label": "Trigger on Keybinding ({{keybinding}})",
-				"description": "Press {{keybinding}} to request a code suggestion at your cursor position. <DocsLink>Edit shortcut</DocsLink>"
+				"label": "कीबाइंडिंग पर ट्रिगर करें ({{keybinding}})",
+				"description": "अपने कर्सर की स्थिति पर कोड सुझाव का अनुरोध करने के लिए {{keybinding}} दबाएं। <DocsLink>शॉर्टकट संपादित करें</DocsLink>"
 			},
-			"keybindingNotFound": "नहीं मिला",
-			"configureAutocompleteProfile": "प्रोफाइल में जाकर और ऑटोकम्पलीट प्रोफाइल टाइप की एक प्रोफाइल कॉन्फ़िगर करके किसी भी मॉडल का उपयोग करें।",
-			"model": "मॉडल",
-			"provider": "प्रदाता",
 			"enableChatAutocomplete": {
-				"label": "Enable Chat Autocomplete",
-				"description": "Show completions as you type in the chat input. Press Tab to accept suggestions."
+				"label": "चैट ऑटोकम्पलीट सक्षम करें",
+				"description": "चैट इनपुट में टाइप करते समय सुझाव दिखाएं। सुझाव स्वीकार करने के लिए Tab दबाएं।"
 			},
 			"snooze": {
-				"label": "Snooze Suggestions",
-				"description": "Temporarily pause suggestions for a specified duration.",
+				"label": "सुझाव स्नूज़ करें",
+				"description": "निर्दिष्ट अवधि के लिए सुझावों को अस्थायी रूप से रोकें।",
 				"button": "स्नूज़",
 				"unsnooze": "अनस्नूज़",
-				"currentlySnoozed": "Suggestions are currently snoozed.",
+				"currentlySnoozed": "सुझाव वर्तमान में स्नूज़ हैं।",
 				"duration": {
 					"1min": "1 मिनट",
 					"5min": "5 मिनट",
@@ -243,6 +243,7 @@
 					"1hour": "1 घंटा"
 				}
 			},
+			"keybindingNotFound": "नहीं मिला",
 			"noModelConfigured": {
 				"title": "कोई ऑटोकम्पलीट मॉडल कॉन्फ़िगर नहीं है",
 				"description": "ऑटोकम्पलीट सक्षम करने के लिए, इन समर्थित प्रदाताओं में से एक के साथ प्रोफ़ाइल जोड़ें:",
@@ -253,8 +254,7 @@
 				"description": "आपके Kilo Code खाते में कोई क्रेडिट नहीं है। ऑटोकम्पलीट का उपयोग करने के लिए, कृपया अपने खाते में क्रेडिट जोड़ें।",
 				"buyCredits": "क्रेडिट खरीदें →"
 			},
-			"codeEditorSuggestions": "Code Editor Suggestions",
-			"chatSuggestions": "Chat Suggestions"
+			"configureAutocompleteProfile": "प्रोफाइल में जाकर और ऑटोकम्पलीट प्रोफाइल टाइप की एक प्रोफाइल कॉन्फ़िगर करके किसी भी मॉडल का उपयोग करें।"
 		}
 	},
 	"virtualProvider": {

--- a/webview-ui/src/i18n/locales/id/kilocode.json
+++ b/webview-ui/src/i18n/locales/id/kilocode.json
@@ -209,32 +209,32 @@
 	"ghost": {
 		"title": "Autocomplete",
 		"settings": {
+			"codeEditorSuggestions": "Saran Editor Kode",
+			"chatSuggestions": "Saran Chat",
+			"model": "Model",
+			"provider": "Penyedia",
 			"enableAutoTrigger": {
-				"label": "Auto-trigger Suggestions",
-				"description": "Secara otomatis menampilkan saran kode inline saat Anda berhenti mengetik."
+				"label": "Picu Saran Otomatis",
+				"description": "Secara otomatis menampilkan saran kode inline saat kamu berhenti mengetik."
 			},
 			"autoTriggerDelay": {
 				"label": "Penundaan Pemicu Otomatis",
-				"description": "The delay in seconds before suggestions appear after you pause typing. A shorter delay means quicker suggestions, but may be more resource-intensive."
+				"description": "Penundaan dalam detik sebelum saran muncul setelah kamu berhenti mengetik. Penundaan yang lebih pendek berarti saran lebih cepat, tetapi mungkin lebih intensif sumber daya."
 			},
 			"enableSmartInlineTaskKeybinding": {
-				"label": "Trigger on Keybinding ({{keybinding}})",
-				"description": "Press {{keybinding}} to request a code suggestion at your cursor position. <DocsLink>Edit shortcut</DocsLink>"
+				"label": "Picu dengan Pintasan Keyboard ({{keybinding}})",
+				"description": "Tekan {{keybinding}} untuk meminta saran kode di posisi kursor kamu. <DocsLink>Edit pintasan</DocsLink>"
 			},
-			"keybindingNotFound": "tidak ditemukan",
-			"configureAutocompleteProfile": "Gunakan model apa pun dengan pergi ke profil dan mengonfigurasi Profil dengan Tipe Profil Autocomplete.",
-			"model": "Model",
-			"provider": "Penyedia",
 			"enableChatAutocomplete": {
-				"description": "Show completions as you type in the chat input. Press Tab to accept suggestions.",
-				"label": "Enable Chat Autocomplete"
+				"label": "Aktifkan Autocomplete Chat",
+				"description": "Tampilkan saran saat kamu mengetik di input chat. Tekan Tab untuk menerima saran."
 			},
 			"snooze": {
-				"label": "Snooze Suggestions",
-				"description": "Temporarily pause suggestions for a specified duration.",
+				"label": "Tunda Saran",
+				"description": "Jeda saran sementara untuk durasi tertentu.",
 				"button": "Tunda",
 				"unsnooze": "Aktifkan Kembali",
-				"currentlySnoozed": "Suggestions are currently snoozed.",
+				"currentlySnoozed": "Saran saat ini ditunda.",
 				"duration": {
 					"1min": "1 menit",
 					"5min": "5 menit",
@@ -243,18 +243,18 @@
 					"1hour": "1 jam"
 				}
 			},
+			"keybindingNotFound": "tidak ditemukan",
 			"noModelConfigured": {
 				"title": "Tidak ada model autocomplete yang dikonfigurasi",
 				"description": "Untuk mengaktifkan autocomplete, tambahkan profil dengan salah satu penyedia yang didukung ini:",
 				"learnMore": "Pelajari lebih lanjut tentang pengaturan autocomplete →"
 			},
 			"noCredits": {
-				"title": "Tidak ada kredit di akun Anda",
-				"description": "Akun Kilo Code Anda tidak memiliki kredit. Untuk menggunakan autocomplete, silakan tambahkan kredit ke akun Anda.",
+				"title": "Tidak ada kredit di akun kamu",
+				"description": "Akun Kilo Code kamu tidak memiliki kredit. Untuk menggunakan autocomplete, silakan tambahkan kredit ke akun kamu.",
 				"buyCredits": "Beli kredit →"
 			},
-			"codeEditorSuggestions": "Code Editor Suggestions",
-			"chatSuggestions": "Chat Suggestions"
+			"configureAutocompleteProfile": "Gunakan model apa pun dengan pergi ke profil dan mengonfigurasi Profil dengan Tipe Profil Autocomplete."
 		}
 	},
 	"virtualProvider": {

--- a/webview-ui/src/i18n/locales/ko/kilocode.json
+++ b/webview-ui/src/i18n/locales/ko/kilocode.json
@@ -221,34 +221,34 @@
 		}
 	},
 	"ghost": {
-		"title": "Autocomplete",
+		"title": "자동완성",
 		"settings": {
+			"codeEditorSuggestions": "코드 편집기 제안",
+			"chatSuggestions": "채팅 제안",
+			"model": "모델",
+			"provider": "제공자",
 			"enableAutoTrigger": {
-				"label": "Auto-trigger Suggestions",
+				"label": "제안 자동 트리거",
 				"description": "입력을 멈추면 자동으로 인라인 코드 제안을 표시합니다."
 			},
 			"autoTriggerDelay": {
 				"label": "자동 트리거 지연",
-				"description": "The delay in seconds before suggestions appear after you pause typing. A shorter delay means quicker suggestions, but may be more resource-intensive."
+				"description": "입력을 멈춘 후 제안이 나타나기까지의 지연 시간(초)입니다. 지연 시간이 짧을수록 제안이 빨라지지만 리소스를 더 많이 사용할 수 있습니다."
 			},
 			"enableSmartInlineTaskKeybinding": {
-				"label": "Trigger on Keybinding ({{keybinding}})",
-				"description": "Press {{keybinding}} to request a code suggestion at your cursor position. <DocsLink>Edit shortcut</DocsLink>"
+				"label": "키 바인딩으로 트리거 ({{keybinding}})",
+				"description": "{{keybinding}}을 눌러 커서 위치에서 코드 제안을 요청하세요. <DocsLink>단축키 편집</DocsLink>"
 			},
-			"keybindingNotFound": "찾을 수 없음",
-			"configureAutocompleteProfile": "프로필로 이동하여 프로필 유형이 자동완성인 프로필을 구성하면 모든 모델을 사용할 수 있습니다.",
-			"model": "모델",
-			"provider": "제공자",
 			"enableChatAutocomplete": {
-				"label": "Enable Chat Autocomplete",
-				"description": "Show completions as you type in the chat input. Press Tab to accept suggestions."
+				"label": "채팅 자동완성 활성화",
+				"description": "채팅 입력 시 자동완성을 표시합니다. Tab을 눌러 제안을 수락하세요."
 			},
 			"snooze": {
-				"label": "Snooze Suggestions",
-				"description": "Temporarily pause suggestions for a specified duration.",
+				"label": "제안 일시 중지",
+				"description": "지정된 기간 동안 제안을 일시적으로 중지합니다.",
 				"button": "일시 중지",
 				"unsnooze": "일시 중지 해제",
-				"currentlySnoozed": "Suggestions are currently snoozed.",
+				"currentlySnoozed": "제안이 현재 일시 중지되어 있습니다.",
 				"duration": {
 					"1min": "1분",
 					"5min": "5분",
@@ -257,6 +257,7 @@
 					"1hour": "1시간"
 				}
 			},
+			"keybindingNotFound": "찾을 수 없음",
 			"noModelConfigured": {
 				"title": "자동완성 모델이 구성되지 않았습니다",
 				"description": "자동완성을 활성화하려면 다음 지원되는 공급자 중 하나로 프로필을 추가하세요:",
@@ -267,8 +268,7 @@
 				"description": "Kilo Code 계정에 크레딧이 없습니다. 자동완성을 사용하려면 계정에 크레딧을 추가하세요.",
 				"buyCredits": "크레딧 구매 →"
 			},
-			"codeEditorSuggestions": "Code Editor Suggestions",
-			"chatSuggestions": "Chat Suggestions"
+			"configureAutocompleteProfile": "프로필로 이동하여 프로필 유형이 자동완성인 프로필을 구성하면 모든 모델을 사용할 수 있습니다."
 		}
 	},
 	"virtualProvider": {

--- a/webview-ui/src/i18n/locales/pt-BR/kilocode.json
+++ b/webview-ui/src/i18n/locales/pt-BR/kilocode.json
@@ -214,34 +214,34 @@
 		}
 	},
 	"ghost": {
-		"title": "Autocomplete",
+		"title": "Autocompletar",
 		"settings": {
+			"codeEditorSuggestions": "Sugestões do Editor de Código",
+			"chatSuggestions": "Sugestões do Chat",
+			"model": "Modelo",
+			"provider": "Provedor",
 			"enableAutoTrigger": {
-				"label": "Auto-trigger Suggestions",
+				"label": "Ativar sugestões automaticamente",
 				"description": "Mostrar automaticamente sugestões de código inline quando você pausa de digitar."
 			},
 			"autoTriggerDelay": {
 				"label": "Atraso da Ativação Automática",
-				"description": "The delay in seconds before suggestions appear after you pause typing. A shorter delay means quicker suggestions, but may be more resource-intensive."
+				"description": "O atraso em segundos antes das sugestões aparecerem após você parar de digitar. Um atraso menor significa sugestões mais rápidas, mas pode consumir mais recursos."
 			},
 			"enableSmartInlineTaskKeybinding": {
-				"label": "Trigger on Keybinding ({{keybinding}})",
-				"description": "Press {{keybinding}} to request a code suggestion at your cursor position. <DocsLink>Edit shortcut</DocsLink>"
+				"label": "Ativar por atalho de teclado ({{keybinding}})",
+				"description": "Pressione {{keybinding}} para solicitar uma sugestão de código na posição do cursor. <DocsLink>Editar atalho</DocsLink>"
 			},
-			"keybindingNotFound": "não encontrado",
-			"configureAutocompleteProfile": "Use qualquer modelo indo para perfis e configurando um Perfil do Tipo de Perfil Autocompletar.",
-			"model": "Modelo",
-			"provider": "Provedor",
 			"enableChatAutocomplete": {
-				"label": "Enable Chat Autocomplete",
-				"description": "Show completions as you type in the chat input. Press Tab to accept suggestions."
+				"label": "Ativar autocompletar do chat",
+				"description": "Mostrar sugestões enquanto você digita no campo de entrada do chat. Pressione Tab para aceitar sugestões."
 			},
 			"snooze": {
-				"label": "Snooze Suggestions",
-				"description": "Temporarily pause suggestions for a specified duration.",
+				"label": "Pausar sugestões",
+				"description": "Pausar temporariamente as sugestões por uma duração especificada.",
 				"button": "Adiar",
 				"unsnooze": "Reativar",
-				"currentlySnoozed": "Suggestions are currently snoozed.",
+				"currentlySnoozed": "As sugestões estão atualmente pausadas.",
 				"duration": {
 					"1min": "1 minuto",
 					"5min": "5 minutos",
@@ -250,6 +250,7 @@
 					"1hour": "1 hora"
 				}
 			},
+			"keybindingNotFound": "não encontrado",
 			"noModelConfigured": {
 				"title": "Nenhum modelo de autocomplete configurado",
 				"description": "Para habilitar o autocomplete, adicione um perfil com um destes provedores suportados:",
@@ -260,8 +261,7 @@
 				"description": "Sua conta Kilo Code não tem créditos. Para usar o autocomplete, adicione créditos à sua conta.",
 				"buyCredits": "Comprar créditos →"
 			},
-			"codeEditorSuggestions": "Code Editor Suggestions",
-			"chatSuggestions": "Chat Suggestions"
+			"configureAutocompleteProfile": "Use qualquer modelo indo para perfis e configurando um Perfil do Tipo de Perfil Autocompletar."
 		}
 	},
 	"virtualProvider": {

--- a/webview-ui/src/i18n/locales/th/kilocode.json
+++ b/webview-ui/src/i18n/locales/th/kilocode.json
@@ -221,34 +221,34 @@
 		}
 	},
 	"ghost": {
-		"title": "Autocomplete",
+		"title": "เติมข้อความอัตโนมัติ",
 		"settings": {
+			"codeEditorSuggestions": "คำแนะนำตัวแก้ไขโค้ด",
+			"chatSuggestions": "คำแนะนำแชท",
+			"model": "โมเดล",
+			"provider": "ผู้ให้บริการ",
 			"enableAutoTrigger": {
-				"label": "Auto-trigger Suggestions",
+				"label": "เรียกใช้คำแนะนำอัตโนมัติ",
 				"description": "แสดงคำแนะนำโค้ดแบบอินไลน์โดยอัตโนมัติเมื่อคุณหยุดพิมพ์"
 			},
 			"autoTriggerDelay": {
 				"label": "ความล่าช้าของการเรียกใช้อัตโนมัติ",
-				"description": "The delay in seconds before suggestions appear after you pause typing. A shorter delay means quicker suggestions, but may be more resource-intensive."
+				"description": "ความล่าช้าเป็นวินาทีก่อนที่คำแนะนำจะปรากฏหลังจากคุณหยุดพิมพ์ ความล่าช้าที่สั้นกว่าหมายถึงคำแนะนำที่เร็วกว่า แต่อาจใช้ทรัพยากรมากกว่า"
 			},
 			"enableSmartInlineTaskKeybinding": {
-				"label": "Trigger on Keybinding ({{keybinding}})",
-				"description": "Press {{keybinding}} to request a code suggestion at your cursor position. <DocsLink>Edit shortcut</DocsLink>"
+				"label": "เรียกใช้ด้วยปุ่มลัด ({{keybinding}})",
+				"description": "กด {{keybinding}} เพื่อขอคำแนะนำโค้ดที่ตำแหน่งเคอร์เซอร์ของคุณ <DocsLink>แก้ไขปุ่มลัด</DocsLink>"
 			},
-			"keybindingNotFound": "ไม่พบ",
-			"configureAutocompleteProfile": "ใช้โมเดลใดก็ได้โดยไปที่โปรไฟล์และตั้งค่าโปรไฟล์ประเภทเติมข้อความอัตโนมัติ",
-			"model": "โมเดล",
-			"provider": "ผู้ให้บริการ",
 			"enableChatAutocomplete": {
-				"label": "Enable Chat Autocomplete",
-				"description": "Show completions as you type in the chat input. Press Tab to accept suggestions."
+				"label": "เปิดใช้งานเติมข้อความอัตโนมัติในแชท",
+				"description": "แสดงคำแนะนำขณะพิมพ์ในช่องแชท กด Tab เพื่อยอมรับคำแนะนำ"
 			},
 			"snooze": {
-				"label": "Snooze Suggestions",
-				"description": "Temporarily pause suggestions for a specified duration.",
+				"label": "หยุดคำแนะนำชั่วคราว",
+				"description": "หยุดคำแนะนำชั่วคราวตามระยะเวลาที่กำหนด",
 				"button": "หยุดชั่วคราว",
 				"unsnooze": "เปิดใช้งานอีกครั้ง",
-				"currentlySnoozed": "Suggestions are currently snoozed.",
+				"currentlySnoozed": "คำแนะนำถูกหยุดชั่วคราวอยู่",
 				"duration": {
 					"1min": "1 นาที",
 					"5min": "5 นาที",
@@ -257,6 +257,7 @@
 					"1hour": "1 ชั่วโมง"
 				}
 			},
+			"keybindingNotFound": "ไม่พบ",
 			"noModelConfigured": {
 				"title": "ยังไม่ได้กำหนดค่าโมเดล Autocomplete",
 				"description": "หากต้องการเปิดใช้งาน Autocomplete ให้เพิ่มโปรไฟล์ที่มีผู้ให้บริการที่รองรับเหล่านี้:",
@@ -267,8 +268,7 @@
 				"description": "บัญชี Kilo Code ของคุณไม่มีเครดิต หากต้องการใช้ Autocomplete กรุณาเติมเครดิตในบัญชีของคุณ",
 				"buyCredits": "ซื้อเครดิต →"
 			},
-			"codeEditorSuggestions": "Code Editor Suggestions",
-			"chatSuggestions": "Chat Suggestions"
+			"configureAutocompleteProfile": "ใช้โมเดลใดก็ได้โดยไปที่โปรไฟล์และตั้งค่าโปรไฟล์ประเภทเติมข้อความอัตโนมัติ"
 		}
 	},
 	"virtualProvider": {

--- a/webview-ui/src/i18n/locales/tr/kilocode.json
+++ b/webview-ui/src/i18n/locales/tr/kilocode.json
@@ -214,34 +214,34 @@
 		}
 	},
 	"ghost": {
-		"title": "Autocomplete",
+		"title": "Otomatik Tamamlama",
 		"settings": {
+			"codeEditorSuggestions": "Kod Editörü Önerileri",
+			"chatSuggestions": "Sohbet Önerileri",
+			"model": "Model",
+			"provider": "Sağlayıcı",
 			"enableAutoTrigger": {
-				"label": "Auto-trigger Suggestions",
-				"description": "Yazmayı duraklattığınızda otomatik olarak satır içi kod önerileri göster."
+				"label": "Önerileri otomatik tetikle",
+				"description": "Yazmayı duraklattığında otomatik olarak satır içi kod önerileri göster."
 			},
 			"autoTriggerDelay": {
 				"label": "Otomatik Tetikleme Gecikmesi",
-				"description": "The delay in seconds before suggestions appear after you pause typing. A shorter delay means quicker suggestions, but may be more resource-intensive."
+				"description": "Yazmayı duraklattıktan sonra önerilerin görünmesi için saniye cinsinden gecikme. Daha kısa gecikme daha hızlı öneriler anlamına gelir, ancak daha fazla kaynak kullanabilir."
 			},
 			"enableSmartInlineTaskKeybinding": {
-				"label": "Trigger on Keybinding ({{keybinding}})",
-				"description": "Press {{keybinding}} to request a code suggestion at your cursor position. <DocsLink>Edit shortcut</DocsLink>"
+				"label": "Klavye kısayoluyla tetikle ({{keybinding}})",
+				"description": "İmleç konumunda kod önerisi istemek için {{keybinding}} tuşuna bas. <DocsLink>Kısayolu düzenle</DocsLink>"
 			},
-			"keybindingNotFound": "bulunamadı",
-			"configureAutocompleteProfile": "Profillere giderek ve Otomatik Tamamlama Profil Türünde bir Profil yapılandırarak herhangi bir model kullan.",
-			"model": "Model",
-			"provider": "Sağlayıcı",
 			"enableChatAutocomplete": {
-				"label": "Enable Chat Autocomplete",
-				"description": "Show completions as you type in the chat input. Press Tab to accept suggestions."
+				"label": "Sohbet otomatik tamamlamayı etkinleştir",
+				"description": "Sohbet girişinde yazarken önerileri göster. Önerileri kabul etmek için Tab tuşuna bas."
 			},
 			"snooze": {
-				"label": "Snooze Suggestions",
-				"description": "Temporarily pause suggestions for a specified duration.",
+				"label": "Önerileri ertele",
+				"description": "Belirli bir süre için önerileri geçici olarak duraklat.",
 				"button": "Ertele",
 				"unsnooze": "Ertelemeyi Kaldır",
-				"currentlySnoozed": "Suggestions are currently snoozed.",
+				"currentlySnoozed": "Öneriler şu anda ertelenmiş durumda.",
 				"duration": {
 					"1min": "1 dakika",
 					"5min": "5 dakika",
@@ -250,18 +250,18 @@
 					"1hour": "1 saat"
 				}
 			},
+			"keybindingNotFound": "bulunamadı",
 			"noModelConfigured": {
 				"title": "Otomatik tamamlama modeli yapılandırılmadı",
-				"description": "Otomatik tamamlamayı etkinleştirmek için desteklenen bu sağlayıcılardan biriyle bir profil ekleyin:",
+				"description": "Otomatik tamamlamayı etkinleştirmek için desteklenen bu sağlayıcılardan biriyle bir profil ekle:",
 				"learnMore": "Otomatik tamamlama kurulumu hakkında daha fazla bilgi →"
 			},
 			"noCredits": {
-				"title": "Hesabınızda kredi yok",
-				"description": "Kilo Code hesabınızda kredi bulunmuyor. Otomatik tamamlamayı kullanmak için lütfen hesabınıza kredi ekleyin.",
+				"title": "Hesabında kredi yok",
+				"description": "Kilo Code hesabında kredi bulunmuyor. Otomatik tamamlamayı kullanmak için lütfen hesabına kredi ekle.",
 				"buyCredits": "Kredi satın al →"
 			},
-			"codeEditorSuggestions": "Code Editor Suggestions",
-			"chatSuggestions": "Chat Suggestions"
+			"configureAutocompleteProfile": "Profillere giderek ve Otomatik Tamamlama Profil Türünde bir Profil yapılandırarak herhangi bir model kullan."
 		}
 	},
 	"virtualProvider": {

--- a/webview-ui/src/i18n/locales/uk/kilocode.json
+++ b/webview-ui/src/i18n/locales/uk/kilocode.json
@@ -221,34 +221,34 @@
 		}
 	},
 	"ghost": {
-		"title": "Autocomplete",
+		"title": "Автодоповнення",
 		"settings": {
-			"enableAutoTrigger": {
-				"label": "Auto-trigger Suggestions",
-				"description": "Автоматично показувати вбудовані пропозиції коду, коли ви робите паузу під час введення."
-			},
-			"autoTriggerDelay": {
-				"label": "Затримка Автоматичного Запуску",
-				"description": "The delay in seconds before suggestions appear after you pause typing. A shorter delay means quicker suggestions, but may be more resource-intensive."
-			},
-			"enableSmartInlineTaskKeybinding": {
-				"label": "Trigger on Keybinding ({{keybinding}})",
-				"description": "Press {{keybinding}} to request a code suggestion at your cursor position. <DocsLink>Edit shortcut</DocsLink>"
-			},
-			"keybindingNotFound": "не знайдено",
-			"configureAutocompleteProfile": "Використовуй будь-яку модель, перейшовши до профілів і налаштувавши Профіль типу Автодоповнення.",
+			"codeEditorSuggestions": "Пропозиції редактора коду",
+			"chatSuggestions": "Пропозиції чату",
 			"model": "Модель",
 			"provider": "Провайдер",
+			"enableAutoTrigger": {
+				"label": "Автоматичний запуск пропозицій",
+				"description": "Автоматично показувати вбудовані пропозиції коду, коли ти робиш паузу під час введення."
+			},
+			"autoTriggerDelay": {
+				"label": "Затримка автоматичного запуску",
+				"description": "Затримка в секундах перед появою пропозицій після паузи введення. Коротша затримка означає швидші пропозиції, але може бути більш ресурсомісткою."
+			},
+			"enableSmartInlineTaskKeybinding": {
+				"label": "Запуск за комбінацією клавіш ({{keybinding}})",
+				"description": "Натисни {{keybinding}}, щоб запросити пропозицію коду в позиції курсора. <DocsLink>Редагувати комбінацію</DocsLink>"
+			},
 			"enableChatAutocomplete": {
-				"label": "Enable Chat Autocomplete",
-				"description": "Show completions as you type in the chat input. Press Tab to accept suggestions."
+				"label": "Увімкнути автодоповнення чату",
+				"description": "Показувати пропозиції під час введення в полі чату. Натисни Tab, щоб прийняти пропозиції."
 			},
 			"snooze": {
-				"label": "Snooze Suggestions",
-				"description": "Temporarily pause suggestions for a specified duration.",
+				"label": "Призупинити пропозиції",
+				"description": "Тимчасово призупинити пропозиції на вказаний період.",
 				"button": "Призупинити",
 				"unsnooze": "Відновити",
-				"currentlySnoozed": "Suggestions are currently snoozed.",
+				"currentlySnoozed": "Пропозиції наразі призупинені.",
 				"duration": {
 					"1min": "1 хвилина",
 					"5min": "5 хвилин",
@@ -257,18 +257,18 @@
 					"1hour": "1 година"
 				}
 			},
+			"keybindingNotFound": "не знайдено",
 			"noModelConfigured": {
 				"title": "Модель автодоповнення не налаштована",
-				"description": "Щоб увімкнути автодоповнення, додайте профіль з одним із цих підтримуваних провайдерів:",
+				"description": "Щоб увімкнути автодоповнення, додай профіль з одним із цих підтримуваних провайдерів:",
 				"learnMore": "Дізнатися більше про налаштування автодоповнення →"
 			},
 			"noCredits": {
-				"title": "На вашому рахунку немає кредитів",
-				"description": "На вашому рахунку Kilo Code немає кредитів. Щоб використовувати автодоповнення, будь ласка, поповніть свій рахунок.",
+				"title": "На твоєму рахунку немає кредитів",
+				"description": "На твоєму рахунку Kilo Code немає кредитів. Щоб використовувати автодоповнення, будь ласка, поповни свій рахунок.",
 				"buyCredits": "Придбати кредити →"
 			},
-			"codeEditorSuggestions": "Code Editor Suggestions",
-			"chatSuggestions": "Chat Suggestions"
+			"configureAutocompleteProfile": "Використовуй будь-яку модель, перейшовши до профілів і налаштувавши Профіль типу Автодоповнення."
 		}
 	},
 	"virtualProvider": {

--- a/webview-ui/src/i18n/locales/zh-TW/kilocode.json
+++ b/webview-ui/src/i18n/locales/zh-TW/kilocode.json
@@ -218,32 +218,32 @@
 	"ghost": {
 		"title": "自動補全",
 		"settings": {
+			"codeEditorSuggestions": "程式碼編輯器建議",
+			"chatSuggestions": "聊天建議",
+			"model": "模型",
+			"provider": "供應商",
 			"enableAutoTrigger": {
-				"label": "Auto-trigger Suggestions",
-				"description": "當您暫停輸入時自動顯示內嵌程式碼建議。"
+				"label": "自動觸發建議",
+				"description": "當你暫停輸入時自動顯示內嵌程式碼建議。"
 			},
 			"autoTriggerDelay": {
 				"label": "自動觸發延遲",
-				"description": "The delay in seconds before suggestions appear after you pause typing. A shorter delay means quicker suggestions, but may be more resource-intensive."
+				"description": "暫停輸入後建議出現前的延遲秒數。較短的延遲表示更快的建議，但可能會消耗更多資源。"
 			},
 			"enableSmartInlineTaskKeybinding": {
-				"label": "Trigger on Keybinding ({{keybinding}})",
-				"description": "Press {{keybinding}} to request a code suggestion at your cursor position. <DocsLink>Edit shortcut</DocsLink>"
+				"label": "透過快捷鍵觸發 ({{keybinding}})",
+				"description": "按下 {{keybinding}} 在游標位置請求程式碼建議。<DocsLink>編輯快捷鍵</DocsLink>"
 			},
-			"keybindingNotFound": "未找到",
-			"configureAutocompleteProfile": "前往設定檔並設定自動補全類型的設定檔即可使用任意模型。",
-			"model": "模型",
-			"provider": "供應商",
 			"enableChatAutocomplete": {
-				"label": "Enable Chat Autocomplete",
-				"description": "Show completions as you type in the chat input. Press Tab to accept suggestions."
+				"label": "啟用聊天自動補全",
+				"description": "在聊天輸入框中輸入時顯示補全建議。按 Tab 鍵接受建議。"
 			},
 			"snooze": {
-				"label": "Snooze Suggestions",
-				"description": "Temporarily pause suggestions for a specified duration.",
+				"label": "暫停建議",
+				"description": "暫時停止建議一段指定的時間。",
 				"button": "暫停",
 				"unsnooze": "取消暫停",
-				"currentlySnoozed": "Suggestions are currently snoozed.",
+				"currentlySnoozed": "建議目前已暫停。",
 				"duration": {
 					"1min": "1 分鐘",
 					"5min": "5 分鐘",
@@ -252,18 +252,18 @@
 					"1hour": "1 小時"
 				}
 			},
+			"keybindingNotFound": "未找到",
 			"noModelConfigured": {
 				"title": "未設定自動補全模型",
 				"description": "若要啟用自動補全，請新增一個使用以下支援供應商的設定檔：",
 				"learnMore": "了解更多關於自動補全設定 →"
 			},
 			"noCredits": {
-				"title": "您的帳戶沒有額度",
-				"description": "您的 Kilo Code 帳戶沒有額度。若要使用自動補全，請為您的帳戶儲值。",
+				"title": "你的帳戶沒有額度",
+				"description": "你的 Kilo Code 帳戶沒有額度。若要使用自動補全，請為你的帳戶儲值。",
 				"buyCredits": "購買額度 →"
 			},
-			"codeEditorSuggestions": "Code Editor Suggestions",
-			"chatSuggestions": "Chat Suggestions"
+			"configureAutocompleteProfile": "前往設定檔並設定自動補全類型的設定檔即可使用任意模型。"
 		}
 	},
 	"virtualProvider": {


### PR DESCRIPTION
## Summary

Adds translations for the ghost/autocomplete settings section in the Kilo Code UI.

## What was translated

The ghost section contains settings for the autocomplete feature, including:
- Enable/disable toggle
- Model selection
- Debounce delay
- Max tokens
- Temperature
- Context lines
- Trigger mode

## Languages updated

13 languages received new translations (11 keys each = 143 total keys):
- Catalan (ca)
- Czech (cs)
- German (de)
- Spanish (es)
- French (fr)
- Hindi (hi)
- Indonesian (id)
- Korean (ko)
- Portuguese - Brazil (pt-BR)
- Thai (th)
- Turkish (tr)
- Ukrainian (uk)
- Traditional Chinese (zh-TW)

Note: Japanese (ja) and Simplified Chinese (zh-CN) already had these translations.