### PR TITLE
fix: translate untranslated 'Details' string in errorDetails.link

### DIFF
--- a/webview-ui/src/i18n/locales/ca/chat.json
+++ b/webview-ui/src/i18n/locales/ca/chat.json
@@ -282,7 +282,7 @@
 		"noAssistantMessagesDetails": "El model de llenguatge ha retornat una resposta buida sense text ni crides a eines. Això pot passar a causa de problemes d'API, limitació de velocitat o problemes específics del model. El model ha estat sol·licitat automàticament per tornar-ho a provar."
 	},
 	"errorDetails": {
-		"link": "Details",
+		"link": "Detalls",
 		"title": "Detalls de l'error",
 		"copyToClipboard": "Copiar al porta-retalls",
 		"copied": "Copiat!",

--- a/webview-ui/src/i18n/locales/id/chat.json
+++ b/webview-ui/src/i18n/locales/id/chat.json
@@ -312,7 +312,7 @@
 	},
 	"troubleMessage": "Kilo Code mengalami masalah...",
 	"errorDetails": {
-		"link": "Details",
+		"link": "Detail",
 		"title": "Detail Kesalahan",
 		"copyToClipboard": "Salin ke Clipboard",
 		"copied": "Disalin!",

--- a/webview-ui/src/i18n/locales/pl/chat.json
+++ b/webview-ui/src/i18n/locales/pl/chat.json
@@ -282,7 +282,7 @@
 		"noAssistantMessagesDetails": "Model językowy zwrócił pustą odpowiedź bez żadnego tekstu ani wywołań narzędzi. Może się to zdarzyć z powodu problemów z API, limitów szybkości lub problemów specyficznych dla modelu. Model został automatycznie poproszony o ponowną próbę."
 	},
 	"errorDetails": {
-		"link": "Details",
+		"link": "Szczegóły",
 		"title": "Szczegóły błędu",
 		"copyToClipboard": "Kopiuj do schowka",
 		"copied": "Skopiowano!",

--- a/webview-ui/src/i18n/locales/pt-BR/chat.json
+++ b/webview-ui/src/i18n/locales/pt-BR/chat.json
@@ -282,7 +282,7 @@
 		"noAssistantMessagesDetails": "O modelo de linguagem retornou uma resposta vazia sem texto ou chamadas de ferramentas. Isso pode acontecer devido a problemas de API, limitação de taxa ou problemas específicos do modelo. O modelo foi automaticamente solicitado a tentar novamente."
 	},
 	"errorDetails": {
-		"link": "Details",
+		"link": "Detalhes",
 		"title": "Detalhes do erro",
 		"copyToClipboard": "Copiar para área de transferência",
 		"copied": "Copiado!",

--- a/webview-ui/src/i18n/locales/tr/chat.json
+++ b/webview-ui/src/i18n/locales/tr/chat.json
@@ -283,7 +283,7 @@
 		"noAssistantMessagesDetails": "Dil modeli herhangi bir metin veya araç çağrısı olmadan boş bir yanıt döndürdü. Bu, API sorunları, hız sınırlaması veya modele özgü sorunlar nedeniyle olabilir. Model otomatik olarak yeniden denemeye yönlendirildi."
 	},
 	"errorDetails": {
-		"link": "Details",
+		"link": "Ayrıntılar",
 		"title": "Hata Detayları",
 		"copyToClipboard": "Panoya Kopyala",
 		"copied": "Kopyalandı!",


### PR DESCRIPTION
## Summary
Translated the `errorDetails.link` key from English 'Details' to the appropriate translations in the following locales:

| Locale | Translation |
|--------|-------------|
| pt-BR | Detalhes |
| tr | Ayrıntılar |
| pl | Szczegóły |
| ca | Detalls |
| id | Detail |

## Notes
- **nl (Dutch)** and **de (German)** were not changed as 'Details' is a valid word in those languages.
- This was discovered during a review of the pt-BR translation files for accidentally untranslated strings.