### PR TITLE
Fix OpenRouter ZDR option, allow fallbacks

### DIFF
--- a/.changeset/upset-glasses-begin.md
+++ b/.changeset/upset-glasses-begin.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fallbacks are now allowed when selecting a specific OpenRouter provider

--- a/apps/kilocode-docs/docs/providers/kilocode.md
+++ b/apps/kilocode-docs/docs/providers/kilocode.md
@@ -49,11 +49,11 @@ Kilo Code can route to many different inference providers. For personal accounts
 
 #### Provider Sorting
 
-- Default provider sorting: at time of writing equivalent to prefer providers with lower latency
+- Default provider sorting: at time of writing equivalent to prefer providers with lower price
 - Prefer providers with lower price
 - Prefer providers with higher throughput (i.e. more tokens per seconds)
 - Prefer providers with lower latency (i.e. shorter time to first token)
-- A specific provider can also be chosen. This is not recommended, because it will result in errors when the provider is facing downtime or enforcing rate limits.
+- A specific provider preference can also be chosen.
 
 #### Data Policy
 

--- a/apps/kilocode-docs/docs/providers/openrouter.md
+++ b/apps/kilocode-docs/docs/providers/openrouter.md
@@ -40,7 +40,7 @@ OpenRouter can route to many different inference providers and this can be contr
 - Prefer providers with lower price
 - Prefer providers with higher throughput (i.e. more tokens per seconds)
 - Prefer providers with lower latency (i.e. shorter time to first token)
-- A specific provider can also be chosen. This is not recommended, because it will result in errors when the provider is facing downtime or enforcing rate limits.
+- A specific provider preference can also be chosen.
 
 ### Data Policy
 

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -37,7 +37,6 @@ import { verifyFinishReason } from "./kilocode/verifyFinishReason"
 // kilocode_change start
 type OpenRouterProviderParams = {
 	order?: string[]
-	only?: string[]
 	allow_fallbacks?: boolean
 	data_collection?: "allow" | "deny"
 	sort?: "price" | "throughput" | "latency"
@@ -223,9 +222,8 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 			return {
 				provider: {
 					order: [this.options.openRouterSpecificProvider],
-					only: [this.options.openRouterSpecificProvider],
-					allow_fallbacks: false,
 					data_collection: this.options.openRouterProviderDataCollection,
+					sort: this.options.openRouterProviderSort,
 					zdr: this.options.openRouterZdr,
 				},
 			}
@@ -394,16 +392,6 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 			stream: true,
 			stream_options: { include_usage: true },
 			...this.getProviderParams(), // kilocode_change: original expression was moved into function
-			parallel_tool_calls: false, // Ensure only one tool call at a time
-			// Only include provider if openRouterSpecificProvider is not "[default]".
-			...(this.options.openRouterSpecificProvider &&
-				this.options.openRouterSpecificProvider !== OPENROUTER_DEFAULT_PROVIDER_NAME && {
-					provider: {
-						order: [this.options.openRouterSpecificProvider],
-						only: [this.options.openRouterSpecificProvider],
-						allow_fallbacks: false,
-					},
-				}),
 			...(reasoning && { reasoning }),
 			...(metadata?.tools && { tools: this.convertToolsForOpenAI(metadata.tools) }),
 			...(metadata?.tool_choice && { tool_choice: metadata.tool_choice }),


### PR DESCRIPTION
No fallbacks are a terrible UX, especially when we start routing more to Vercel, which has fewer providers currently