### PR TITLE
fix(cli): Fix commander.js update regression

### DIFF
--- a/cli/src/__tests__/commander-flags.test.ts
+++ b/cli/src/__tests__/commander-flags.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest"
+import { Command } from "commander"
+
+describe("Commander.js Short Flag Validation", () => {
+	describe("short flags must be single characters", () => {
+		it("should reject multi-character short flags", () => {
+			const program = new Command()
+			program.exitOverride() // Throw instead of calling process.exit
+
+			// This should throw because -eb is not a valid single-character short flag
+			expect(() => {
+				program.option("-eb, --existing-branch <branch>", "Test option with invalid short flag")
+			}).toThrow()
+		})
+
+		it("should accept single-character short flags", () => {
+			const program = new Command()
+			program.exitOverride()
+
+			// Single character short flags should work
+			expect(() => {
+				program.option("-e, --existing-branch <branch>", "Test option with valid short flag")
+				program.option("-P, --provider <id>", "Test option with valid short flag")
+				program.option("-M, --model <model>", "Test option with valid short flag")
+			}).not.toThrow()
+		})
+
+		it("should validate all CLI options have single-character short flags", () => {
+			// This test documents the expected short flags for the CLI
+			// If any of these fail, it means Commander.js v14 will reject them
+			const program = new Command()
+			program.exitOverride()
+
+			// All the short flags used in the CLI should be single characters
+			const validOptions = [
+				["-m, --mode <mode>", "Set mode"],
+				["-w, --workspace <path>", "Workspace path"],
+				["-a, --auto", "Auto mode"],
+				["-j, --json", "JSON output"],
+				["-i, --json-io", "JSON IO mode"],
+				["-c, --continue", "Continue conversation"],
+				["-t, --timeout <seconds>", "Timeout"],
+				["-p, --parallel", "Parallel mode"],
+				["-e, --existing-branch <branch>", "Existing branch (fixed from -eb)"],
+				["-P, --provider <id>", "Provider (fixed from -pv)"],
+				["-M, --model <model>", "Model (fixed from -mo)"],
+				["-s, --session <sessionId>", "Session ID"],
+				["-f, --fork <shareId>", "Fork session"],
+			]
+
+			expect(() => {
+				validOptions.forEach(([flags, description]) => {
+					program.option(flags, description)
+				})
+			}).not.toThrow()
+		})
+
+		it("should fail with the original invalid flags from the CLI", () => {
+			const program = new Command()
+			program.exitOverride()
+
+			// These are the original invalid flags that need to be fixed
+			// Commander.js v14 should reject these
+			const invalidOptions = [
+				["-eb, --existing-branch <branch>", "Invalid: -eb is multi-character"],
+				["-pv, --provider <id>", "Invalid: -pv is multi-character"],
+				["-mo, --model <model>", "Invalid: -mo is multi-character"],
+			]
+
+			invalidOptions.forEach(([flags, description]) => {
+				const testProgram = new Command()
+				testProgram.exitOverride()
+
+				expect(
+					() => {
+						testProgram.option(flags, description)
+					},
+					`Expected "${flags}" to throw because short flag is multi-character`,
+				).toThrow()
+			})
+		})
+	})
+})

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -46,9 +46,9 @@ program
 		"-p, --parallel",
 		"Run in parallel mode - the agent will create a separate git branch, unless you provide the --existing-branch option",
 	)
-	.option("-eb, --existing-branch <branch>", "(Parallel mode only) Instructs the agent to work on an existing branch")
-	.option("-pv, --provider <id>", "Select provider by ID (e.g., 'kilocode-1')")
-	.option("-mo, --model <model>", "Override model for the selected provider")
+	.option("-e, --existing-branch <branch>", "(Parallel mode only) Instructs the agent to work on an existing branch")
+	.option("-P, --provider <id>", "Select provider by ID (e.g., 'kilocode-1')")
+	.option("-M, --model <model>", "Override model for the selected provider")
 	.option("-s, --session <sessionId>", "Restore a session by ID")
 	.option("-f, --fork <shareId>", "Fork a session by ID")
 	.option("--nosplash", "Disable the welcome message and update notifications", false)


### PR DESCRIPTION
Summary                                                                                                                               
                                                                                                                                        
- Fix CLI crash on startup caused by invalid multi-character short flags (-eb, -pv, -mo)                                              
- Commander.js v14 enforces single-character short flags, which broke the CLI after the v12→v14 upgrade                               
- Add test coverage for Commander.js flag validation                                                                                  
                                                                                                                                        
  Problem                                                                                                                               
                                                                                                                                        
  The CLI crashes immediately on startup with:                                                                                          
  error: option short flag is invalid: -eb, --existing-branch <branch>                                                                  
                                                                                                                                        
  Root cause: Two separate commits created this incompatibility:                                                                        
  1. e366e4ce61 (Oct 30, 2025) introduced multi-character short flags -eb, -pv, -mo                                                     
  2. f0c79d27c4 (Jan 17, 2026) upgraded Commander.js from v12.1.0 to v14.0.2                                                            
                                                                                                                                        
  Commander.js v14 is stricter and requires short flags to be exactly one character.                                                    
                                                                                                                                        
  Solution                                                                                                                              
                                                                                                                                        
  Changed the short flags to single characters:                                                                                         
  ┌────────┬───────┬───────────────────┐                                                                                                
  │ Before │ After │      Option       │                                                                                                
  ├────────┼───────┼───────────────────┤                                                                                                
  │ -eb    │ -e    │ --existing-branch │                                                                                                
  ├────────┼───────┼───────────────────┤                                                                                                
  │ -pv    │ -P    │ --provider        │                                                                                                
  ├────────┼───────┼───────────────────┤                                                                                                
  │ -mo    │ -M    │ --model           │                                                                                                
  └────────┴───────┴───────────────────┘                                                                                                
  Uppercase -P and -M avoid conflicts with existing -p (parallel) and -m (mode) flags.
  
  
  
  Before the fix, you would have seen this error:            
```                                                                           
 cd cli && pnpm build && node dist/index.js --help                                                              
  # error: option short flag is invalid: -eb, --existing-branch <branch> 
  ```