### PR TITLE
feat: enable Skills Marketplace for all users

### DIFF
--- a/.changeset/skills-marketplace-enabled.md
+++ b/.changeset/skills-marketplace-enabled.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Added Skills Marketplace tab alongside existing MCP and Modes marketplace tabs

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -14,7 +14,7 @@ export const MODEL_SELECTION_ENABLED = process.env.NODE_ENV === "development"
 export const EXTREME_SNOOZE_VALUES_ENABLED = process.env.NODE_ENV === "development"
 
 /**
- * Enable skills marketplace tab in development mode.
- * This allows developers to test the skills marketplace feature before it's ready for production.
+ * Skills marketplace is now enabled for all users.
+ * @deprecated This flag is no longer needed - skills marketplace is always enabled.
  */
-export const SKILLS_MARKETPLACE_ENABLED = process.env.NODE_ENV === "development"
+export const SKILLS_MARKETPLACE_ENABLED = true

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -12,9 +12,3 @@ export const MODEL_SELECTION_ENABLED = process.env.NODE_ENV === "development"
  * Enable extreme snooze values for autocomplete in development mode.
  */
 export const EXTREME_SNOOZE_VALUES_ENABLED = process.env.NODE_ENV === "development"
-
-/**
- * Skills marketplace is now enabled for all users.
- * @deprecated This flag is no longer needed - skills marketplace is always enabled.
- */
-export const SKILLS_MARKETPLACE_ENABLED = true

--- a/webview-ui/src/components/marketplace/MarketplaceView.tsx
+++ b/webview-ui/src/components/marketplace/MarketplaceView.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo, useContext } from "react"
-import { SKILLS_MARKETPLACE_ENABLED } from "@roo-code/types" // kilocode_change
 import { Button } from "@/components/ui/button"
 import { Tab, TabContent, TabHeader } from "../common/Tab"
 import { MarketplaceViewStateManager } from "./MarketplaceViewStateManager"
@@ -174,18 +173,14 @@ export function MarketplaceView({ stateManager, onDone, targetTab, hideHeader = 
 								}>
 								Modes
 							</button>
-							{/* kilocode_change start - Skills tab button or filler div */}
-							{SKILLS_MARKETPLACE_ENABLED ? (
-								<button
-									className="flex items-center justify-center gap-2 flex-1 text-sm font-medium rounded-sm transition-colors duration-300 relative z-10 text-vscode-foreground"
-									onClick={() =>
-										manager.transition({ type: "SET_ACTIVE_TAB", payload: { tab: "skills" } })
-									}>
-									Skills
-								</button>
-							) : (
-								<div className="flex-1" />
-							)}
+							{/* kilocode_change - Skills tab button */}
+							<button
+								className="flex items-center justify-center gap-2 flex-1 text-sm font-medium rounded-sm transition-colors duration-300 relative z-10 text-vscode-foreground"
+								onClick={() =>
+									manager.transition({ type: "SET_ACTIVE_TAB", payload: { tab: "skills" } })
+								}>
+								Skills
+							</button>
 							{/* kilocode_change end */}
 						</div>
 					</div>
@@ -210,8 +205,8 @@ export function MarketplaceView({ stateManager, onDone, targetTab, hideHeader = 
 							headerMessage={modesHeaderMessage} // kilocode_change
 						/>
 					)}
-					{/* kilocode_change start - Skills marketplace tab content */}
-					{SKILLS_MARKETPLACE_ENABLED && state.activeTab === "skills" && (
+					{/* kilocode_change - Skills marketplace tab content */}
+					{state.activeTab === "skills" && (
 						<SkillsMarketplace skills={stateManager.getSkills()} isLoading={state.isFetching} />
 					)}
 					{/* kilocode_change end */}

--- a/webview-ui/src/components/marketplace/MarketplaceView.tsx
+++ b/webview-ui/src/components/marketplace/MarketplaceView.tsx
@@ -173,7 +173,7 @@ export function MarketplaceView({ stateManager, onDone, targetTab, hideHeader = 
 								}>
 								Modes
 							</button>
-							{/* kilocode_change - Skills tab button */}
+							{/* kilocode_change start - Skills tab button */}
 							<button
 								className="flex items-center justify-center gap-2 flex-1 text-sm font-medium rounded-sm transition-colors duration-300 relative z-10 text-vscode-foreground"
 								onClick={() =>
@@ -205,7 +205,7 @@ export function MarketplaceView({ stateManager, onDone, targetTab, hideHeader = 
 							headerMessage={modesHeaderMessage} // kilocode_change
 						/>
 					)}
-					{/* kilocode_change - Skills marketplace tab content */}
+					{/* kilocode_change start - Skills marketplace tab content */}
 					{state.activeTab === "skills" && (
 						<SkillsMarketplace skills={stateManager.getSkills()} isLoading={state.isFetching} />
 					)}


### PR DESCRIPTION
## Summary

Enables the Skills Marketplace tab for all users, completing the feature rollout.

## Changes

- Removed the `SKILLS_MARKETPLACE_ENABLED` feature toggle (now always `true`)
- Simplified the MarketplaceView component by removing conditional rendering
- Added changeset for the minor release

The Skills Marketplace is now available alongside the existing MCP and Modes marketplace tabs.