### PR TITLE
fix(cli): correct appRoot path to find ripgrep binary

### DIFF
--- a/cli/src/host/VSCode.ts
+++ b/cli/src/host/VSCode.ts
@@ -2320,9 +2320,11 @@ export function createVSCodeAPIMock(extensionRootPath: string, workspacePath: st
 	window.setWorkspace(workspace)
 
 	// Environment mock with identity values
+	// appRoot should point to CLI root (parent of dist) so ripgrep and other binaries can be found in node_modules
+	const appRoot = path.resolve(import.meta.dirname, "..")
 	const env = {
 		appName: `wrapper|cli|cli|${Package.version}`,
-		appRoot: import.meta.dirname,
+		appRoot,
 		language: "en",
 		machineId: identity?.machineId || machineIdSync(),
 		sessionId: identity?.sessionId || "cli-session-id",


### PR DESCRIPTION
## Summary

Fixes the "Could not find ripgrep binary" error in the CLI by correcting the `appRoot` path in the VSCode mock.

## Problem

The CLI's `vscode.env.appRoot` was pointing to the `dist` folder (`import.meta.dirname`), but the ripgrep binary and other node_modules are in the parent CLI folder. This caused the `getBinPath()` function in `src/services/ripgrep/index.ts` to fail finding `node_modules/@vscode/ripgrep/bin/rg`.

## Solution

Changed `appRoot` to resolve to the parent of `import.meta.dirname`:

```typescript
const appRoot = path.resolve(import.meta.dirname, "..")
```

This allows the ripgrep path resolution to correctly find binaries at:
- `node_modules/@vscode/ripgrep/bin/rg`
- `node_modules/vscode-ripgrep/bin/rg`
- etc.

## Testing

1. Build the CLI: `pnpm build`
2. Run a task that requires ripgrep (e.g., `kilocode --auto --yolo "say hello"`)
3. Verify no "Could not find ripgrep binary" error appears

## Files Changed

- `cli/src/host/VSCode.ts` - Updated `appRoot` to point to CLI root instead of dist folder