### PR TITLE
docs: add Kilo Marketplace reference to contributing guide

### DIFF
--- a/apps/kilocode-docs/docs/contributing/index.md
+++ b/apps/kilocode-docs/docs/contributing/index.md
@@ -13,7 +13,7 @@ There are many ways to contribute to Kilo Code:
 
 1. **Code Contributions**: Implement new features or fix bugs
 2. **Documentation**: Improve existing docs or create new guides
-3. **Custom Modes**: Create and share specialized modes
+3. **Marketplace Contributions**: Create and share custom modes, skills, and MCP servers via the [Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace)
 4. **Bug Reports**: Report issues you encounter
 5. **Feature Requests**: Suggest new features or improvements
 6. **Community Support**: Help other users in the community
@@ -78,15 +78,21 @@ git checkout -b your-branch-name
     - Testing steps
     - Screenshots (if applicable)
 
-## Creating Custom Modes
+## Contributing to the Kilo Marketplace
 
-Custom modes are a powerful way to extend Kilo Code's capabilities. To create and share a custom mode:
+The [Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace) is a community-driven repository of agent tooling that extends Kilo Code's capabilities. You can contribute:
 
-1. Follow the [Custom Modes documentation](/agent-behavior/custom-modes) to create your mode
+- **Skills**: Modular workflows and domain expertise that teach agents how to perform specific tasks
+- **MCP Servers**: Standardized integrations that connect agents to external tools and services
+- **Modes**: Custom agent personalities and behaviors with tailored tool access
 
-2. Test your mode thoroughly
+To contribute:
 
-3. Share your mode with the community by submitting a [GitHub Discussion](https://github.com/Kilo-Org/kilocode/discussions)
+1. Follow the documentation for [Custom Modes](/agent-behavior/custom-modes), [Skills](/agent-behavior/skills), or [MCP Servers](/features/mcp/overview) to create your resource
+
+2. Test your contribution thoroughly
+
+3. Submit a pull request to the [Kilo Marketplace repository](https://github.com/Kilo-Org/kilo-marketplace)
 
 ## Engineering Specs
 

--- a/apps/kilocode-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/extending/contributing-to-kilo.md
+++ b/apps/kilocode-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/extending/contributing-to-kilo.md
@@ -8,7 +8,7 @@ Kilo Code 是一个开源项目，欢迎所有技能水平的开发者贡献代�
 
 1. **代码贡献**：实现新功能或修复错误
 2. **文档**：改进现有文档或创建新指南
-3. **自定义模式**：创建并分享专用模式
+3. **市场贡献**：通过 [Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace) 创建并分享自定义模式、技能和 MCP 服务器
 4. **错误报告**：报告你遇到的问题
 5. **功能请求**：建议新功能或改进
 6. **社区支持**：在社区中帮助其他用户
@@ -69,15 +69,21 @@ git checkout -b your-branch-name
     - 测试步骤
     - 截图（如适用）
 
-## 创建自定义模式
+## 为 Kilo Marketplace 做贡献
 
-自定义模式是扩展 Kilo Code 功能的强大方式。要创建并分享自定义模式：
+[Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace) 是一个社区驱动的代理工具仓库，用于扩展 Kilo Code 的功能。你可以贡献：
 
-1. 按照 [自定义模式文档](/agent-behavior/custom-modes) 创建你的模式
+- **技能（Skills）**：模块化的工作流程和领域专业知识，教代理如何执行特定任务
+- **MCP 服务器**：标准化的集成，将代理连接到外部工具和服务
+- **模式（Modes）**：具有定制工具访问权限的自定义代理个性和行为
 
-2. 彻底测试你的模式
+贡献方式：
 
-3. 通过提交 [GitHub Discussion](https://github.com/Kilo-Org/kilocode/discussions) 与社区分享你的模式
+1. 按照 [自定义模式](/agent-behavior/custom-modes)、[技能](/agent-behavior/skills) 或 [MCP 服务器](/features/mcp/overview) 的文档创建你的资源
+
+2. 彻底测试你的贡献
+
+3. 向 [Kilo Marketplace 仓库](https://github.com/Kilo-Org/kilo-marketplace) 提交拉取请求
 
 ## 文档贡献
 


### PR DESCRIPTION
Updates the contributing documentation to reference the [Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace) repository.

## Changes

- Updated "Ways to Contribute" section to mention marketplace contributions (modes, skills, MCP servers)
- Renamed "Creating Custom Modes" section to "Contributing to the Kilo Marketplace"
- Added links to relevant documentation for each resource type
- Synced changes to Chinese translation

## Related

- https://github.com/Kilo-Org/kilo-marketplace