### PR TITLE
feat: add llms.txt support to docs site

### DIFF
--- a/.changeset/add-llms-txt-support.md
+++ b/.changeset/add-llms-txt-support.md
@@ -1,5 +1,0 @@
----
-"kilocode-docs": patch
----
-
-Add llms.txt support to docs site using docusaurus-plugin-llms

--- a/.changeset/add-llms-txt-support.md
+++ b/.changeset/add-llms-txt-support.md
@@ -1,0 +1,5 @@
+---
+"kilocode-docs": patch
+---
+
+Add llms.txt support to docs site using docusaurus-plugin-llms

--- a/apps/kilocode-docs/docusaurus.config.ts
+++ b/apps/kilocode-docs/docusaurus.config.ts
@@ -260,6 +260,16 @@ const config: Config = {
 				],
 			},
 		],
+		[
+			"docusaurus-plugin-llms",
+			{
+				id: "llms-txt",
+				name: "Kilo Code Documentation",
+				description: "Comprehensive documentation for Kilo Code, an AI-powered coding assistant for VS Code",
+				url: "https://kilocode.ai/docs",
+				email: "support@kilocode.ai",
+			},
+		],
 	],
 
 	themeConfig: {

--- a/apps/kilocode-docs/docusaurus.config.ts
+++ b/apps/kilocode-docs/docusaurus.config.ts
@@ -265,9 +265,9 @@ const config: Config = {
 			{
 				id: "llms-txt",
 				name: "Kilo Code Documentation",
-				description: "Comprehensive documentation for Kilo Code, an AI-powered coding assistant for VS Code",
-				url: "https://kilocode.ai/docs",
-				email: "support@kilocode.ai",
+				description: "Comprehensive documentation for Kilo Code, an AI-powered coding assistant for VS Code, Jetbrains, CLI & Cloud",
+				url: "https://kilo.ai/docs",
+				email: "hi@kilocode.ai",
 			},
 		],
 	],

--- a/apps/kilocode-docs/package.json
+++ b/apps/kilocode-docs/package.json
@@ -23,6 +23,7 @@
 		"@mdx-js/react": "^3.0.0",
 		"@vscode/codicons": "^0.0.36",
 		"clsx": "^2.0.0",
+		"docusaurus-plugin-llms": "^0.2.2",
 		"posthog-docusaurus": "^2.0.4",
 		"prism-react-renderer": "^2.3.0",
 		"react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
+      docusaurus-plugin-llms:
+        specifier: ^0.2.2
+        version: 0.2.2(@docusaurus/core@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.8)(react@19.2.0))(esbuild@0.25.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.6.3))
       posthog-docusaurus:
         specifier: ^2.0.4
         version: 2.0.5
@@ -11571,6 +11574,12 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  docusaurus-plugin-llms@0.2.2:
+    resolution: {integrity: sha512-DZlZ6cv9p5poFE00Qg78aurBNWhLa4o0VhH4kI33DUT0y4ydlFEJJbf8Bks9BuuGPFbY/Guebn+hRc2QymMImg==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/core': ^3.0.0
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -33058,6 +33067,13 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  docusaurus-plugin-llms@0.2.2(@docusaurus/core@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.8)(react@19.2.0))(esbuild@0.25.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.6.3)):
+    dependencies:
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.8)(react@19.2.0))(debug@4.4.3)(esbuild@0.25.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.6.3)
+      gray-matter: 4.0.3
+      minimatch: 9.0.5
+      yaml: 2.8.2
 
   dom-accessibility-api@0.5.16: {}
 


### PR DESCRIPTION
This PR adds llms.txt support to the Kilo Code documentation site, following the llmstxt.org standard for LLM-friendly documentation.

## Changes Made

- **Added docusaurus-plugin-llms dependency** to package.json
- **Configured the plugin** in docusaurus.config.ts with appropriate site metadata

## What This Enables

- **llms.txt file**: Index of all documentation pages with links
- **llms-full.txt file**: Complete documentation content in Markdown format
- **Multi-language support**: Generated for both English and Chinese locales
- **LLM-friendly format**: Follows llmstxt.org standard for easy consumption by AI models

This will help AI models and tools better understand and navigate the Kilo Code documentation.

---

Based on https://github.com/Kilo-Org/kilocode/pull/3425 (without the markdown formatting changes)