### PR TITLE
feat(cli): Add custom slash commands

### DIFF
--- a/.changeset/custom-slash-commands-cli.md
+++ b/.changeset/custom-slash-commands-cli.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Add custom slash commands to the CLI for reusable prompts.

--- a/cli/README.md
+++ b/cli/README.md
@@ -50,6 +50,44 @@ kilocode -c
 kilocode --continue
 ```
 
+### Custom Slash Commands
+
+You can define reusable prompts as custom slash commands. Commands are Markdown files where the filename
+becomes the command name (e.g., `audit.md` → `/audit`).
+
+- Project commands: `.kilocode/commands/`
+- User commands: `~/.kilocode/cli/commands/`
+Legacy user commands in `~/.kilocode/commands/` are still loaded for backwards compatibility.
+
+Example command file:
+
+```md
+---
+description: Audit code for security issues
+argument-hint: "<path> [level]"
+allowed-tools:
+    - Read(src/**)
+    - Bash(git diff)
+model: anthropic/claude-sonnet-4.5
+disable-model-invocation: false
+---
+
+Review $1 for security issues at level $2. Use $ARGUMENTS for all args.
+```
+
+Usage:
+
+```bash
+/audit src high
+```
+
+Notes:
+
+- `$ARGUMENTS` expands to all arguments as a single string.
+- `$1`, `$2`, ... expand to positional arguments.
+- `allowed-tools` restricts which tool actions the command can trigger.
+- Use `/commands` to list or reload custom commands.
+
 ### Parallel mode
 
 Parallel mode allows multiple Kilo Code instances to work in parallel on the same directory, without conflicts. You can spawn as many Kilo Code instances as you need! Once finished, changes will be available on a separate git branch.

--- a/cli/src/commands/__tests__/customCommands.test.ts
+++ b/cli/src/commands/__tests__/customCommands.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest"
+import { executeCustomSlashCommand } from "../../services/customSlashCommands.js"
+import type { CustomSlashCommandDefinition } from "../../services/customSlashCommands.js"
+import { createMockContext } from "./helpers/mockContext.js"
+import type { ExtensionChatMessage } from "../../types/messages.js"
+import type { ProviderConfig } from "../../config/types.js"
+
+const buildDefinition = (overrides: Partial<CustomSlashCommandDefinition> = {}): CustomSlashCommandDefinition => ({
+	name: "audit",
+	description: "Audit command",
+	body: "Review $ARGUMENTS",
+	metadata: {
+		scope: "project",
+		sourcePath: "/tmp/audit.md",
+		argumentHint: "<path>",
+		allowedTools: [{ type: "read", raw: "Read" }],
+		model: undefined,
+		disableModelInvocation: undefined,
+	},
+	...overrides,
+})
+
+describe("custom slash command execution", () => {
+	it("sends newTask when no active chat messages", async () => {
+		const sendWebviewMessage = vi.fn().mockResolvedValue(undefined)
+		const setSlashCommandPolicy = vi.fn()
+
+		const context = createMockContext({
+			args: ["src"],
+			chatMessages: [],
+			sendWebviewMessage,
+			setSlashCommandPolicy,
+		})
+
+		await executeCustomSlashCommand(buildDefinition(), context)
+
+		expect(setSlashCommandPolicy).toHaveBeenCalled()
+		expect(sendWebviewMessage).toHaveBeenCalledWith({
+			type: "newTask",
+			text: "Review src",
+		})
+	})
+
+	it("sends askResponse when chat messages exist", async () => {
+		const sendWebviewMessage = vi.fn().mockResolvedValue(undefined)
+
+		const context = createMockContext({
+			args: ["src", "utils"],
+			chatMessages: [{ type: "say", ts: Date.now() } as ExtensionChatMessage],
+			sendWebviewMessage,
+		})
+
+		await executeCustomSlashCommand(buildDefinition(), context)
+
+		expect(sendWebviewMessage).toHaveBeenCalledWith({
+			type: "askResponse",
+			askResponse: "messageResponse",
+			text: "Review src utils",
+		})
+	})
+
+	it("applies model override and queues restore", async () => {
+		const sendWebviewMessage = vi.fn().mockResolvedValue(undefined)
+		const updateProviderModel = vi.fn().mockResolvedValue(undefined)
+		const setPendingModelOverride = vi.fn()
+
+		const currentProvider = {
+			id: "provider-1",
+			provider: "kilocode",
+			kilocodeModel: "old-model",
+		} as ProviderConfig
+
+		const context = createMockContext({
+			args: [],
+			chatMessages: [],
+			sendWebviewMessage,
+			updateProviderModel,
+			setPendingModelOverride,
+			currentProvider,
+		})
+
+		await executeCustomSlashCommand(
+			buildDefinition({
+				metadata: {
+					...buildDefinition().metadata,
+					model: "new-model",
+				},
+			}),
+			context,
+		)
+
+		expect(setPendingModelOverride).toHaveBeenCalled()
+		expect(updateProviderModel).toHaveBeenCalledWith("new-model")
+	})
+})

--- a/cli/src/commands/__tests__/helpers/mockContext.ts
+++ b/cli/src/commands/__tests__/helpers/mockContext.ts
@@ -31,6 +31,7 @@ export function createMockContext(overrides: Partial<CommandContext> = {}): Comm
 		input: "",
 		args: [],
 		options: {},
+		workspacePath: "/workspace",
 		config: {} as CLIConfig,
 		sendMessage: vi.fn().mockResolvedValue(undefined),
 		addMessage: vi.fn(),
@@ -73,6 +74,9 @@ export function createMockContext(overrides: Partial<CommandContext> = {}): Comm
 		chatMessages: [],
 		// Current task context
 		currentTask: null,
+		setSlashCommandPolicy: vi.fn(),
+		clearSlashCommandPolicy: vi.fn(),
+		setPendingModelOverride: vi.fn(),
 		modelListPageIndex: 0,
 		modelListFilters: {
 			sort: "preferred",

--- a/cli/src/commands/commands.ts
+++ b/cli/src/commands/commands.ts
@@ -1,0 +1,77 @@
+/**
+ * /commands command - Manage custom slash commands
+ */
+
+import type { Command } from "./core/types.js"
+import { getCustomSlashCommands, registerCustomSlashCommands } from "../services/customSlashCommands.js"
+
+export const commandsCommand: Command = {
+	name: "commands",
+	aliases: ["cmds"],
+	description: "List or reload custom slash commands",
+	usage: "/commands [list|reload]",
+	examples: ["/commands", "/commands list", "/commands reload"],
+	category: "system",
+	priority: 6,
+	handler: async (context) => {
+		const { args, addMessage, workspacePath } = context
+		const subcommand = (args[0] || "list").toLowerCase()
+
+		if (subcommand === "reload" || subcommand === "refresh") {
+			const commands = await registerCustomSlashCommands(workspacePath)
+			addMessage({
+				id: Date.now().toString(),
+				type: "system",
+				content: `Reloaded ${commands.length} custom command${commands.length === 1 ? "" : "s"}.`,
+				ts: Date.now(),
+			})
+			return
+		}
+
+		const commands = getCustomSlashCommands()
+		if (commands.length === 0) {
+			addMessage({
+				id: Date.now().toString(),
+				type: "system",
+				content:
+					"No custom commands found. Add Markdown files to .kilocode/commands or ~/.kilocode/cli/commands.",
+				ts: Date.now(),
+			})
+			return
+		}
+
+		const grouped = {
+			project: commands.filter((cmd) => cmd.metadata.scope === "project"),
+			user: commands.filter((cmd) => cmd.metadata.scope === "user"),
+		}
+
+		const lines: string[] = ["**Custom Commands**", ""]
+
+		if (grouped.project.length > 0) {
+			lines.push("**Project:**")
+			grouped.project.forEach((cmd) => {
+				const hint = cmd.metadata.argumentHint ? ` ${cmd.metadata.argumentHint}` : ""
+				lines.push(`  /${cmd.name}${hint} - ${cmd.description}`)
+			})
+			lines.push("")
+		}
+
+		if (grouped.user.length > 0) {
+			lines.push("**User:**")
+			grouped.user.forEach((cmd) => {
+				const hint = cmd.metadata.argumentHint ? ` ${cmd.metadata.argumentHint}` : ""
+				lines.push(`  /${cmd.name}${hint} - ${cmd.description}`)
+			})
+			lines.push("")
+		}
+
+		lines.push("Use /commands reload to rescan custom commands.")
+
+		addMessage({
+			id: Date.now().toString(),
+			type: "system",
+			content: lines.join("\n"),
+			ts: Date.now(),
+		})
+	},
+}

--- a/cli/src/commands/core/registry.ts
+++ b/cli/src/commands/core/registry.ts
@@ -81,6 +81,21 @@ class CommandRegistry {
 		this.commands.clear()
 		this.aliases.clear()
 	}
+
+	/**
+	 * Unregister a command by name or alias
+	 */
+	unregister(nameOrAlias: string): void {
+		const command = this.get(nameOrAlias)
+		if (!command) {
+			return
+		}
+
+		this.commands.delete(command.name)
+		for (const alias of command.aliases) {
+			this.aliases.delete(alias)
+		}
+	}
 }
 
 // Export singleton instance

--- a/cli/src/commands/core/types.ts
+++ b/cli/src/commands/core/types.ts
@@ -10,6 +10,51 @@ import type { TaskHistoryData, TaskHistoryFilters } from "../../state/atoms/task
 import type { ModelListFilters } from "../../state/atoms/modelList.js"
 import type { HistoryItem } from "@roo-code/types"
 
+export type CustomCommandScope = "project" | "user"
+
+export type AllowedToolType =
+	| "read"
+	| "write"
+	| "bash"
+	| "browser"
+	| "mcp"
+	| "mode"
+	| "subtask"
+	| "todo"
+	| "slashCommand"
+
+export interface AllowedToolRule {
+	type: AllowedToolType
+	patterns?: string[]
+	raw: string
+}
+
+export interface CustomCommandMetadata {
+	scope: CustomCommandScope
+	sourcePath: string
+	argumentHint?: string
+	allowedTools?: AllowedToolRule[] | null
+	model?: string
+	disableModelInvocation?: boolean
+}
+
+export interface SlashCommandPolicy {
+	commandName: string
+	scope: CustomCommandScope
+	sourcePath: string
+	allowedTools: AllowedToolRule[] | null
+	model?: string
+	disableModelInvocation?: boolean
+}
+
+export interface PendingModelOverride {
+	commandName: string
+	providerId: string
+	providerName: string
+	previousModelId: string
+	overrideModelId: string
+}
+
 export interface Command {
 	name: string
 	aliases: string[]
@@ -21,6 +66,7 @@ export interface Command {
 	options?: CommandOption[]
 	arguments?: ArgumentDefinition[]
 	priority?: number // 1-10 scale, default 5. Higher = appears first in suggestions
+	custom?: CustomCommandMetadata
 }
 
 export interface CommandOption {
@@ -36,6 +82,7 @@ export interface CommandContext {
 	input: string
 	args: string[]
 	options: Record<string, string | number | boolean>
+	workspacePath: string
 	config: CLIConfig
 	sendMessage: (message: CliMessage) => Promise<void>
 	addMessage: (message: CliMessage) => void
@@ -80,6 +127,9 @@ export interface CommandContext {
 	chatMessages: ExtensionMessage[]
 	// Current task context
 	currentTask: HistoryItem | null
+	setSlashCommandPolicy: (policy: SlashCommandPolicy | null) => void
+	clearSlashCommandPolicy: () => void
+	setPendingModelOverride: (override: PendingModelOverride | null) => void
 	// Model list context
 	modelListPageIndex: number
 	modelListFilters: ModelListFilters

--- a/cli/src/commands/help.ts
+++ b/cli/src/commands/help.ts
@@ -34,6 +34,17 @@ export const helpCommand: Command = {
 			// Show detailed help for specific command
 			const helpText = [`**${command.name}** - ${command.description}`, "", `**Usage:** ${command.usage}`, ""]
 
+			if (command.custom?.argumentHint) {
+				helpText.push(`**Argument Hint:** ${command.custom.argumentHint}`)
+				helpText.push("")
+			}
+
+			if (command.custom) {
+				const scopeLabel = command.custom.scope === "project" ? "Project" : "User"
+				helpText.push(`**Source:** ${scopeLabel}`)
+				helpText.push("")
+			}
+
 			if (command.aliases.length > 0) {
 				helpText.push(`**Aliases:** ${command.aliases.join(", ")}`)
 				helpText.push("")
@@ -86,7 +97,8 @@ export const helpCommand: Command = {
 		if (categories.chat && categories.chat.length > 0) {
 			helpText.push("**Chat:**")
 			categories.chat.forEach((cmd) => {
-				helpText.push(`  /${cmd.name} - ${cmd.description}`)
+				const scopeLabel = cmd.custom ? ` [${cmd.custom.scope}]` : ""
+				helpText.push(`  /${cmd.name}${scopeLabel} - ${cmd.description}`)
 			})
 			helpText.push("")
 		}
@@ -95,7 +107,8 @@ export const helpCommand: Command = {
 		if (categories.settings && categories.settings.length > 0) {
 			helpText.push("**Settings:**")
 			categories.settings.forEach((cmd) => {
-				helpText.push(`  /${cmd.name} - ${cmd.description}`)
+				const scopeLabel = cmd.custom ? ` [${cmd.custom.scope}]` : ""
+				helpText.push(`  /${cmd.name}${scopeLabel} - ${cmd.description}`)
 			})
 			helpText.push("")
 		}
@@ -104,7 +117,8 @@ export const helpCommand: Command = {
 		if (categories.navigation && categories.navigation.length > 0) {
 			helpText.push("**Navigation:**")
 			categories.navigation.forEach((cmd) => {
-				helpText.push(`  /${cmd.name} - ${cmd.description}`)
+				const scopeLabel = cmd.custom ? ` [${cmd.custom.scope}]` : ""
+				helpText.push(`  /${cmd.name}${scopeLabel} - ${cmd.description}`)
 			})
 			helpText.push("")
 		}
@@ -113,7 +127,8 @@ export const helpCommand: Command = {
 		if (categories.system && categories.system.length > 0) {
 			helpText.push("**System:**")
 			categories.system.forEach((cmd) => {
-				helpText.push(`  /${cmd.name} - ${cmd.description}`)
+				const scopeLabel = cmd.custom ? ` [${cmd.custom.scope}]` : ""
+				helpText.push(`  /${cmd.name}${scopeLabel} - ${cmd.description}`)
 			})
 			helpText.push("")
 		}

--- a/cli/src/commands/index.ts
+++ b/cli/src/commands/index.ts
@@ -22,6 +22,8 @@ import { themeCommand } from "./theme.js"
 import { checkpointCommand } from "./checkpoint.js"
 import { sessionCommand } from "./session.js"
 import { condenseCommand } from "./condense.js"
+import { commandsCommand } from "./commands.js"
+import { registerCustomSlashCommands } from "../services/customSlashCommands.js"
 
 /**
  * Initialize all built-in commands
@@ -43,4 +45,12 @@ export function initializeCommands(): void {
 	commandRegistry.register(checkpointCommand)
 	commandRegistry.register(sessionCommand)
 	commandRegistry.register(condenseCommand)
+	commandRegistry.register(commandsCommand)
+}
+
+/**
+ * Initialize custom slash commands from disk.
+ */
+export async function initializeCustomCommands(workspacePath: string | null): Promise<void> {
+	await registerCustomSlashCommands(workspacePath)
 }

--- a/cli/src/commands/new.ts
+++ b/cli/src/commands/new.ts
@@ -14,7 +14,8 @@ export const newCommand: Command = {
 	category: "system",
 	priority: 9,
 	handler: async (context) => {
-		const { clearTask, replaceMessages, refreshTerminal } = context
+		const { clearTask, replaceMessages, refreshTerminal, clearSlashCommandPolicy, setPendingModelOverride } =
+			context
 
 		// Clear the extension task state (this also clears extension messages)
 		await clearTask()
@@ -35,5 +36,8 @@ export const newCommand: Command = {
 
 		// Force terminal refresh to clear screen
 		await refreshTerminal()
+
+		clearSlashCommandPolicy()
+		setPendingModelOverride(null)
 	},
 }

--- a/cli/src/host/ExtensionHost.ts
+++ b/cli/src/host/ExtensionHost.ts
@@ -785,7 +785,7 @@ export class ExtensionHost extends EventEmitter {
 				multiFileApplyDiff: false,
 				powerSteering: false,
 				imageGeneration: false,
-				runSlashCommand: false,
+				runSlashCommand: true,
 			},
 			// Add appendSystemPrompt from CLI options
 			...(this.options.appendSystemPrompt && { appendSystemPrompt: this.options.appendSystemPrompt }),

--- a/cli/src/services/__tests__/customSlashCommands.test.ts
+++ b/cli/src/services/__tests__/customSlashCommands.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { mkdtemp, writeFile, mkdir } from "node:fs/promises"
+import { join } from "node:path"
+import os from "node:os"
+import { loadCustomSlashCommands } from "../customSlashCommands.js"
+import { expandSlashCommandTemplate } from "../slashCommandTemplate.js"
+
+const originalHome = process.env.HOME
+
+describe("customSlashCommands", () => {
+	beforeEach(async () => {
+		const tempHome = await mkdtemp(join(os.tmpdir(), "kc-home-"))
+		process.env.HOME = tempHome
+	})
+
+	afterEach(() => {
+		process.env.HOME = originalHome
+	})
+
+	it("expands slash command templates with arguments", () => {
+		expect(expandSlashCommandTemplate("Hello $ARGUMENTS", ["foo", "bar"])).toBe("Hello foo bar")
+		expect(expandSlashCommandTemplate("First $1, second $2", ["alpha", "beta"])).toBe("First alpha, second beta")
+		expect(expandSlashCommandTemplate("Missing $3", ["alpha"])).toBe("Missing ")
+		expect(expandSlashCommandTemplate("Cost \\$5", [])).toBe("Cost $5")
+	})
+
+	it("loads project commands with precedence over user commands", async () => {
+		const workspace = await mkdtemp(join(os.tmpdir(), "kc-workspace-"))
+		const userCommandsDir = join(process.env.HOME || "", ".kilocode", "cli", "commands")
+		const projectCommandsDir = join(workspace, ".kilocode", "commands")
+
+		await mkdir(userCommandsDir, { recursive: true })
+		await mkdir(projectCommandsDir, { recursive: true })
+
+		await writeFile(
+			join(userCommandsDir, "audit.md"),
+			`---\ndescription: User audit\nargument-hint: "<path>"\n---\nUser body`,
+			"utf-8",
+		)
+		await writeFile(
+			join(projectCommandsDir, "audit.md"),
+			`---\ndescription: Project audit\nallowed-tools:\n  - Read(src/**)\n---\nProject body`,
+			"utf-8",
+		)
+
+		const commands = await loadCustomSlashCommands(workspace)
+		const audit = commands.find((cmd) => cmd.name === "audit")
+
+		expect(audit).toBeDefined()
+		expect(audit?.description).toBe("Project audit")
+		expect(audit?.metadata.scope).toBe("project")
+		expect(audit?.metadata.allowedTools?.[0]?.type).toBe("read")
+	})
+})

--- a/cli/src/services/customSlashCommands.ts
+++ b/cli/src/services/customSlashCommands.ts
@@ -1,0 +1,371 @@
+import { basename, extname, join } from "node:path"
+import { promises as fs } from "node:fs"
+import { existsSync } from "node:fs"
+import fg from "fast-glob"
+import matter from "gray-matter"
+import { commandRegistry } from "../commands/core/registry.js"
+import type {
+	Command,
+	CommandContext,
+	CustomCommandMetadata,
+	CustomCommandScope,
+	SlashCommandPolicy,
+} from "../commands/core/types.js"
+import { KiloCodePaths } from "../utils/paths.js"
+import { logs } from "./logs.js"
+import { parseAllowedTools } from "./slashCommandTools.js"
+import { expandSlashCommandTemplate } from "./slashCommandTemplate.js"
+import { processMessageImages } from "../media/processMessageImages.js"
+import { getCurrentModelId } from "../constants/providers/models.js"
+
+export interface CustomSlashCommandDefinition {
+	name: string
+	description: string
+	body: string
+	metadata: CustomCommandMetadata
+}
+
+const PROJECT_COMMANDS_DIRNAME = ".kilocode/commands"
+const COMMAND_GLOB = "**/*.md"
+
+let cachedCustomCommands: CustomSlashCommandDefinition[] = []
+let registeredCustomCommandNames: string[] = []
+
+export function getCustomSlashCommands(): CustomSlashCommandDefinition[] {
+	return cachedCustomCommands
+}
+
+export async function registerCustomSlashCommands(
+	workspacePath: string | null,
+): Promise<CustomSlashCommandDefinition[]> {
+	unregisterCustomSlashCommands()
+
+	const definitions = await loadCustomSlashCommands(workspacePath)
+	cachedCustomCommands = definitions
+
+	for (const definition of definitions) {
+		const existing = commandRegistry.get(definition.name)
+		if (existing && !existing.custom) {
+			logs.warn(
+				`Skipping custom command "/${definition.name}" because it conflicts with a built-in command`,
+				"SlashCommands",
+			)
+			continue
+		}
+
+		const usageSuffix = definition.metadata.argumentHint ? ` ${definition.metadata.argumentHint}` : ""
+		const command: Command = {
+			name: definition.name,
+			aliases: [],
+			description: definition.description,
+			usage: `/${definition.name}${usageSuffix}`,
+			examples: [`/${definition.name}${usageSuffix}`],
+			category: "chat",
+			priority: 4,
+			custom: definition.metadata,
+			handler: async (context) => {
+				await executeCustomSlashCommand(definition, context)
+			},
+		}
+
+		commandRegistry.register(command)
+		registeredCustomCommandNames.push(command.name)
+	}
+
+	return definitions
+}
+
+export function unregisterCustomSlashCommands(): void {
+	for (const name of registeredCustomCommandNames) {
+		commandRegistry.unregister(name)
+	}
+	registeredCustomCommandNames = []
+}
+
+export async function loadCustomSlashCommands(workspacePath: string | null): Promise<CustomSlashCommandDefinition[]> {
+	const userDir = KiloCodePaths.getUserCommandsDir()
+	const legacyUserDir = KiloCodePaths.getLegacyUserCommandsDir()
+	const projectDir = workspacePath ? join(workspacePath, PROJECT_COMMANDS_DIRNAME) : null
+
+	const legacyUserCommands = await loadCommandsFromDir(legacyUserDir, "user")
+	const userCommands = await loadCommandsFromDir(userDir, "user")
+	const projectCommands = projectDir ? await loadCommandsFromDir(projectDir, "project") : []
+
+	const merged = new Map<string, CustomSlashCommandDefinition>()
+	for (const command of legacyUserCommands) {
+		merged.set(command.name, command)
+	}
+	for (const command of userCommands) {
+		merged.set(command.name, command)
+	}
+	for (const command of projectCommands) {
+		merged.set(command.name, command)
+	}
+
+	return Array.from(merged.values())
+}
+
+async function loadCommandsFromDir(
+	directory: string,
+	scope: CustomCommandScope,
+): Promise<CustomSlashCommandDefinition[]> {
+	if (!existsSync(directory)) {
+		return []
+	}
+
+	const files = await fg(COMMAND_GLOB, {
+		cwd: directory,
+		onlyFiles: true,
+		absolute: true,
+		dot: true,
+		unique: true,
+	})
+
+	const definitions: CustomSlashCommandDefinition[] = []
+	const seenNames = new Set<string>()
+
+	for (const filePath of files) {
+		const definition = await loadCommandFromFile(filePath, scope)
+		if (!definition) {
+			continue
+		}
+
+		if (seenNames.has(definition.name)) {
+			logs.warn(
+				`Duplicate custom command "${definition.name}" found in ${directory}. Using last occurrence.`,
+				"SlashCommands",
+			)
+		}
+
+		seenNames.add(definition.name)
+		definitions.push(definition)
+	}
+
+	return definitions
+}
+
+async function loadCommandFromFile(
+	filePath: string,
+	scope: CustomCommandScope,
+): Promise<CustomSlashCommandDefinition | null> {
+	try {
+		const raw = await fs.readFile(filePath, "utf-8")
+		const parsed = matter(raw)
+		const body = parsed.content.trim()
+
+		if (!body) {
+			logs.warn(`Custom command file "${filePath}" is empty`, "SlashCommands")
+			return null
+		}
+
+		const name = normalizeCommandName(basename(filePath, extname(filePath)))
+		if (!name || /\s/.test(name)) {
+			logs.warn(`Custom command file "${filePath}" has invalid name`, "SlashCommands")
+			return null
+		}
+
+		const description = parseDescription(parsed.data, body, scope)
+		const argumentHint = parseStringValue(parsed.data, ["argument-hint", "argumentHint"])
+		const allowedTools = parseAllowedTools(parsed.data["allowed-tools"] ?? parsed.data.allowedTools)
+		const model = parseStringValue(parsed.data, ["model"])
+		const disableModelInvocation = parseBooleanValue(parsed.data, [
+			"disable-model-invocation",
+			"disableModelInvocation",
+		])
+
+		const metadata: CustomCommandMetadata = {
+			scope,
+			sourcePath: filePath,
+			allowedTools,
+		}
+
+		if (argumentHint !== undefined) {
+			metadata.argumentHint = argumentHint
+		}
+
+		if (model !== undefined) {
+			metadata.model = model
+		}
+
+		if (disableModelInvocation !== undefined) {
+			metadata.disableModelInvocation = disableModelInvocation
+		}
+
+		return {
+			name,
+			description,
+			body,
+			metadata,
+		}
+	} catch (error) {
+		logs.error(`Failed to load custom command "${filePath}"`, "SlashCommands", { error })
+		return null
+	}
+}
+
+export async function executeCustomSlashCommand(
+	definition: CustomSlashCommandDefinition,
+	context: CommandContext,
+): Promise<void> {
+	const { args, addMessage, sendWebviewMessage, chatMessages } = context
+
+	const expanded = expandSlashCommandTemplate(definition.body, args)
+
+	const processed = await processMessageImages(expanded)
+
+	if (processed.errors.length > 0) {
+		for (const error of processed.errors) {
+			addMessage({
+				id: `slash-cmd-img-error-${Date.now()}-${Math.random()}`,
+				type: "error",
+				content: error,
+				ts: Date.now(),
+			})
+		}
+	}
+
+	const policy: SlashCommandPolicy = {
+		commandName: definition.name,
+		scope: definition.metadata.scope,
+		sourcePath: definition.metadata.sourcePath,
+		allowedTools: definition.metadata.allowedTools ?? null,
+	}
+
+	if (definition.metadata.model !== undefined) {
+		policy.model = definition.metadata.model
+	}
+
+	if (definition.metadata.disableModelInvocation !== undefined) {
+		policy.disableModelInvocation = definition.metadata.disableModelInvocation
+	}
+
+	context.setSlashCommandPolicy(policy)
+
+	await applyModelOverride(definition, context)
+
+	const payload = {
+		text: processed.text,
+		...(processed.hasImages && { images: processed.images }),
+	}
+
+	try {
+		if (chatMessages.length > 0) {
+			await sendWebviewMessage({
+				type: "askResponse",
+				askResponse: "messageResponse",
+				...payload,
+			})
+		} else {
+			await sendWebviewMessage({
+				type: "newTask",
+				...payload,
+			})
+		}
+	} catch (error) {
+		addMessage({
+			id: `slash-cmd-send-error-${Date.now()}`,
+			type: "error",
+			content: `Failed to run /${definition.name}: ${error instanceof Error ? error.message : String(error)}`,
+			ts: Date.now(),
+		})
+		context.clearSlashCommandPolicy()
+		context.setPendingModelOverride(null)
+	}
+}
+
+async function applyModelOverride(definition: CustomSlashCommandDefinition, context: CommandContext): Promise<void> {
+	const modelOverride = definition.metadata.model
+	if (!modelOverride) return
+
+	const { currentProvider, routerModels, kilocodeDefaultModel, updateProviderModel, addMessage } = context
+
+	if (!currentProvider) {
+		addMessage({
+			id: `slash-cmd-model-error-${Date.now()}`,
+			type: "error",
+			content: `Cannot apply model override for /${definition.name}: no provider configured.`,
+			ts: Date.now(),
+		})
+		return
+	}
+
+	const currentModelId = getCurrentModelId({
+		providerConfig: currentProvider,
+		routerModels,
+		kilocodeDefaultModel,
+	})
+
+	if (currentModelId === modelOverride) {
+		return
+	}
+
+	try {
+		context.setPendingModelOverride({
+			commandName: definition.name,
+			providerId: currentProvider.id,
+			providerName: currentProvider.provider,
+			previousModelId: currentModelId,
+			overrideModelId: modelOverride,
+		})
+		await updateProviderModel(modelOverride)
+	} catch (error) {
+		context.setPendingModelOverride(null)
+		addMessage({
+			id: `slash-cmd-model-error-${Date.now()}`,
+			type: "error",
+			content: `Failed to switch model to "${modelOverride}" for /${definition.name}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+			ts: Date.now(),
+		})
+	}
+}
+
+function normalizeCommandName(name: string): string {
+	return name.trim().toLowerCase()
+}
+
+function parseDescription(data: Record<string, unknown>, body: string, scope: CustomCommandScope): string {
+	const description = parseStringValue(data, ["description"])
+	if (description) {
+		return description
+	}
+
+	const fallback = extractFirstLine(body)
+	if (fallback) {
+		return fallback
+	}
+
+	return scope === "project" ? "Project custom command" : "User custom command"
+}
+
+function parseStringValue(data: Record<string, unknown>, keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = data[key]
+		if (typeof value === "string" && value.trim()) {
+			return value.trim()
+		}
+	}
+	return undefined
+}
+
+function parseBooleanValue(data: Record<string, unknown>, keys: string[]): boolean | undefined {
+	for (const key of keys) {
+		const value = data[key]
+		if (typeof value === "boolean") {
+			return value
+		}
+	}
+	return undefined
+}
+
+function extractFirstLine(body: string): string | undefined {
+	const lines = body.split("\n")
+	for (const line of lines) {
+		const trimmed = line.trim()
+		if (trimmed) {
+			return trimmed.length > 120 ? `${trimmed.slice(0, 117)}...` : trimmed
+		}
+	}
+	return undefined
+}

--- a/cli/src/services/slashCommandTemplate.ts
+++ b/cli/src/services/slashCommandTemplate.ts
@@ -1,0 +1,15 @@
+const ESCAPED_DOLLAR_TOKEN = "__KC_ESCAPED_DOLLAR__"
+
+export function expandSlashCommandTemplate(template: string, args: string[]): string {
+	const escaped = template.replace(/\\\$/g, ESCAPED_DOLLAR_TOKEN)
+	const withArguments = escaped.replace(/\$ARGUMENTS\b/g, args.join(" "))
+	const withPositionals = withArguments.replace(/\$(\d+)/g, (_match, index) => {
+		const position = Number(index) - 1
+		if (Number.isNaN(position) || position < 0) {
+			return ""
+		}
+		return args[position] ?? ""
+	})
+
+	return withPositionals.replace(new RegExp(ESCAPED_DOLLAR_TOKEN, "g"), "$")
+}

--- a/cli/src/services/slashCommandTools.ts
+++ b/cli/src/services/slashCommandTools.ts
@@ -1,0 +1,392 @@
+import path from "node:path"
+import type { AllowedToolRule, AllowedToolType, SlashCommandPolicy } from "../commands/core/types.js"
+import type { ExtensionChatMessage } from "../types/messages.js"
+
+interface ToolData {
+	tool: string
+	path?: string
+	filePattern?: string
+	command?: string
+	args?: string
+}
+
+export interface AllowedToolsDecision {
+	allowed: boolean
+	reason?: string
+}
+
+const TOOL_TYPE_ALIASES: Record<string, AllowedToolType> = {
+	read: "read",
+	readfile: "read",
+	listfiles: "read",
+	listfilestoplevel: "read",
+	listfilesrecursive: "read",
+	searchfiles: "read",
+	codebasesearch: "read",
+	listcodedefinitionnames: "read",
+	write: "write",
+	writefile: "write",
+	editedexistingfile: "write",
+	applieddiff: "write",
+	newfilecreated: "write",
+	insertcontent: "write",
+	searchandreplace: "write",
+	delete: "write",
+	deletefile: "write",
+	generateimage: "write",
+	bash: "bash",
+	command: "bash",
+	execute: "bash",
+	browser: "browser",
+	mcp: "mcp",
+	mode: "mode",
+	switchmode: "mode",
+	subtask: "subtask",
+	subtasks: "subtask",
+	newtask: "subtask",
+	todo: "todo",
+	updatetodolist: "todo",
+	slashcommand: "slashCommand",
+	runslashcommand: "slashCommand",
+}
+
+const TOOL_NAME_TO_TYPE: Record<string, AllowedToolType> = {
+	readfile: "read",
+	listfiles: "read",
+	listfilestoplevel: "read",
+	listfilesrecursive: "read",
+	searchfiles: "read",
+	codebasesearch: "read",
+	listcodedefinitionnames: "read",
+	editedexistingfile: "write",
+	applieddiff: "write",
+	newfilecreated: "write",
+	insertcontent: "write",
+	searchandreplace: "write",
+	deletefile: "write",
+	generateimage: "write",
+	browser_action: "browser",
+	use_mcp_tool: "mcp",
+	access_mcp_resource: "mcp",
+	use_mcp_server: "mcp",
+	switchmode: "mode",
+	newtask: "subtask",
+	updatetodolist: "todo",
+	runslashcommand: "slashCommand",
+}
+
+export function parseAllowedTools(raw: unknown): AllowedToolRule[] | null {
+	if (raw === undefined || raw === null) {
+		return null
+	}
+
+	const entries = normalizeAllowedToolEntries(raw)
+	const rules: AllowedToolRule[] = []
+
+	for (const entry of entries) {
+		const trimmed = entry.trim()
+		if (!trimmed) continue
+
+		const parsed = parseAllowedToolEntry(trimmed)
+		if (!parsed) continue
+
+		rules.push(parsed)
+	}
+
+	return rules
+}
+
+export function checkAllowedTools(
+	message: ExtensionChatMessage,
+	policy: SlashCommandPolicy | null | undefined,
+): AllowedToolsDecision {
+	if (!policy || policy.allowedTools === null) {
+		return { allowed: true }
+	}
+
+	if (policy.allowedTools.length === 0) {
+		return {
+			allowed: false,
+			reason: `Slash command "/${policy.commandName}" does not allow any tools.`,
+		}
+	}
+
+	switch (message.ask) {
+		case "command": {
+			const commandText = extractCommandFromMessage(message)
+			return checkCommandAllowed(commandText, policy)
+		}
+		case "tool": {
+			const toolData = parseToolData(message)
+			if (!toolData) {
+				return {
+					allowed: false,
+					reason: `Slash command "/${policy.commandName}" blocked an unrecognized tool request.`,
+				}
+			}
+			return checkToolAllowed(toolData, policy)
+		}
+		case "browser_action_launch":
+			return checkSimpleToolType("browser", policy)
+		case "use_mcp_server":
+			return checkSimpleToolType("mcp", policy)
+		default:
+			return { allowed: true }
+	}
+}
+
+function normalizeAllowedToolEntries(raw: unknown): string[] {
+	if (Array.isArray(raw)) {
+		return raw.filter((entry): entry is string => typeof entry === "string")
+	}
+	if (typeof raw === "string") {
+		return splitCommaSeparated(raw)
+	}
+	return []
+}
+
+function splitCommaSeparated(value: string): string[] {
+	const result: string[] = []
+	let current = ""
+	let depth = 0
+
+	for (const char of value) {
+		if (char === "(") depth += 1
+		if (char === ")") depth = Math.max(0, depth - 1)
+
+		if (char === "," && depth === 0) {
+			if (current.trim()) {
+				result.push(current.trim())
+			}
+			current = ""
+			continue
+		}
+
+		current += char
+	}
+
+	if (current.trim()) {
+		result.push(current.trim())
+	}
+
+	return result
+}
+
+function parseAllowedToolEntry(entry: string): AllowedToolRule | null {
+	const match = entry.match(/^([A-Za-z][\w-]*)(?:\((.+)\))?$/)
+	if (!match) {
+		return null
+	}
+
+	const name = normalizeToolName(match[1] || "")
+	const type = TOOL_TYPE_ALIASES[name]
+	if (!type) {
+		return null
+	}
+
+	const patternSource = match[2]?.trim()
+	const patterns = patternSource ? splitCommaSeparated(patternSource) : undefined
+
+	const rule: AllowedToolRule = {
+		type,
+		raw: entry,
+	}
+
+	if (patterns && patterns.length > 0) {
+		rule.patterns = patterns
+	}
+
+	return rule
+}
+
+function parseToolData(message: ExtensionChatMessage): ToolData | null {
+	if (!message.text) return null
+	try {
+		return JSON.parse(message.text) as ToolData
+	} catch {
+		return null
+	}
+}
+
+function extractCommandFromMessage(message: ExtensionChatMessage): string {
+	if (!message.text) return ""
+	try {
+		const parsed = JSON.parse(message.text) as { command?: string }
+		return parsed.command || ""
+	} catch {
+		return message.text
+	}
+}
+
+function checkCommandAllowed(commandText: string, policy: SlashCommandPolicy): AllowedToolsDecision {
+	const rules = policy.allowedTools?.filter((rule) => rule.type === "bash") ?? []
+	if (rules.length === 0) {
+		return {
+			allowed: false,
+			reason: `Slash command "/${policy.commandName}" does not allow command execution.`,
+		}
+	}
+
+	if (!commandText) {
+		return {
+			allowed: false,
+			reason: `Slash command "/${policy.commandName}" blocked an empty command request.`,
+		}
+	}
+
+	const allowed = rules.some((rule) => matchesCommandRule(commandText, rule))
+	if (!allowed) {
+		return {
+			allowed: false,
+			reason: `Slash command "/${policy.commandName}" does not allow command "${commandText}".`,
+		}
+	}
+
+	return { allowed: true }
+}
+
+function checkToolAllowed(toolData: ToolData, policy: SlashCommandPolicy): AllowedToolsDecision {
+	const toolName = normalizeToolName(toolData.tool || "")
+	const toolType = TOOL_NAME_TO_TYPE[toolName]
+
+	if (!toolType) {
+		return {
+			allowed: false,
+			reason: `Slash command "/${policy.commandName}" does not allow tool "${toolData.tool}".`,
+		}
+	}
+
+	if (toolType === "read" || toolType === "write") {
+		return checkPathToolAllowed(toolType, toolData, policy)
+	}
+
+	if (toolType === "bash") {
+		const commandText = toolData.command || toolData.args || ""
+		return checkCommandAllowed(commandText, policy)
+	}
+
+	return checkSimpleToolType(toolType, policy, toolData.tool)
+}
+
+function checkPathToolAllowed(
+	toolType: "read" | "write",
+	toolData: ToolData,
+	policy: SlashCommandPolicy,
+): AllowedToolsDecision {
+	const rules = policy.allowedTools?.filter((rule) => rule.type === toolType) ?? []
+	if (rules.length === 0) {
+		return {
+			allowed: false,
+			reason: `Slash command "/${policy.commandName}" does not allow ${toolType} operations.`,
+		}
+	}
+
+	const targetPath = toolData.path || toolData.filePattern || ""
+	const allowed = rules.some((rule) => matchesPathRule(targetPath, rule))
+
+	if (!allowed) {
+		return {
+			allowed: false,
+			reason: targetPath
+				? `Slash command "/${policy.commandName}" does not allow ${toolType} on "${targetPath}".`
+				: `Slash command "/${policy.commandName}" blocked a ${toolType} operation without a path.`,
+		}
+	}
+
+	return { allowed: true }
+}
+
+function checkSimpleToolType(
+	toolType: AllowedToolType,
+	policy: SlashCommandPolicy,
+	toolName?: string,
+): AllowedToolsDecision {
+	const rules = policy.allowedTools?.filter((rule) => rule.type === toolType) ?? []
+	if (rules.length === 0) {
+		return {
+			allowed: false,
+			reason: toolName
+				? `Slash command "/${policy.commandName}" does not allow tool "${toolName}".`
+				: `Slash command "/${policy.commandName}" does not allow ${toolType} operations.`,
+		}
+	}
+	return { allowed: true }
+}
+
+function normalizeToolName(value: string): string {
+	return value.toLowerCase().replace(/[^a-z0-9_]/g, "")
+}
+
+function matchesPathRule(targetPath: string, rule: AllowedToolRule): boolean {
+	if (!rule.patterns || rule.patterns.length === 0) {
+		return true
+	}
+
+	if (!targetPath) {
+		return false
+	}
+
+	return rule.patterns.some((pattern) => matchesGlobPattern(pattern, targetPath))
+}
+
+function matchesCommandRule(command: string, rule: AllowedToolRule): boolean {
+	if (!rule.patterns || rule.patterns.length === 0) {
+		return true
+	}
+
+	return rule.patterns.some((pattern) => matchesCommandPattern(command, pattern))
+}
+
+function matchesCommandPattern(command: string, pattern: string): boolean {
+	const normalizedCommand = command.trim()
+	const normalizedPattern = pattern.trim()
+	if (!normalizedPattern) return false
+
+	if (normalizedPattern === "*") return true
+
+	if (normalizedPattern.includes("*") || normalizedPattern.includes("?")) {
+		const regex = globToRegex(normalizedPattern, true)
+		return regex.test(normalizedCommand)
+	}
+
+	if (normalizedPattern === normalizedCommand) {
+		return true
+	}
+
+	if (normalizedCommand.startsWith(normalizedPattern)) {
+		const nextChar = normalizedCommand[normalizedPattern.length]
+		return nextChar === undefined || nextChar === " " || nextChar === "\t"
+	}
+
+	return false
+}
+
+function matchesGlobPattern(pattern: string, targetPath: string): boolean {
+	const normalizedPattern = normalizePath(pattern)
+	const normalizedTarget = normalizePath(targetPath)
+
+	const candidates = [normalizedTarget]
+	if (normalizedTarget.startsWith("/")) {
+		candidates.push(normalizedTarget.slice(1))
+	}
+
+	const regex = globToRegex(normalizedPattern, false)
+	return candidates.some((candidate) => regex.test(candidate))
+}
+
+function normalizePath(value: string): string {
+	const normalized = value.replace(/\\/g, "/")
+	const trimmed = normalized.replace(/^\.\/+/, "")
+	return path.posix.normalize(trimmed)
+}
+
+function globToRegex(pattern: string, allowSpaces: boolean): RegExp {
+	const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&")
+	const withGlob = escaped
+		.replace(/\*\*/g, ".*")
+		.replace(/\*/g, "[^/]*")
+		.replace(/\?/g, allowSpaces ? "." : "[^/]")
+
+	const finalPattern = `^${withGlob}${allowSpaces ? "" : "$"}`
+	return new RegExp(finalPattern)
+}

--- a/cli/src/state/atoms/slashCommands.ts
+++ b/cli/src/state/atoms/slashCommands.ts
@@ -1,0 +1,28 @@
+import { atom } from "jotai"
+import type { SlashCommandPolicy, PendingModelOverride } from "../../commands/core/types.js"
+
+/**
+ * Active slash command policy (used to gate tool approvals).
+ */
+export const activeSlashCommandPolicyAtom = atom<SlashCommandPolicy | null>(null)
+
+export const setActiveSlashCommandPolicyAtom = atom(null, (_get, set, policy: SlashCommandPolicy | null) => {
+	set(activeSlashCommandPolicyAtom, policy)
+})
+
+export const clearActiveSlashCommandPolicyAtom = atom(null, (_get, set) => {
+	set(activeSlashCommandPolicyAtom, null)
+})
+
+/**
+ * Pending model override (restored on completion_result).
+ */
+export const pendingModelOverrideAtom = atom<PendingModelOverride | null>(null)
+
+export const setPendingModelOverrideAtom = atom(null, (_get, set, override: PendingModelOverride | null) => {
+	set(pendingModelOverrideAtom, override)
+})
+
+export const clearPendingModelOverrideAtom = atom(null, (_get, set) => {
+	set(pendingModelOverrideAtom, null)
+})

--- a/cli/src/state/hooks/useCommandContext.ts
+++ b/cli/src/state/hooks/useCommandContext.ts
@@ -31,6 +31,7 @@ import {
 	isParallelModeAtom,
 	chatMessagesAtom,
 	currentTaskAtom,
+	cwdAtom,
 } from "../atoms/extension.js"
 import { requestRouterModelsAtom } from "../atoms/actions.js"
 import { profileDataAtom, balanceDataAtom, profileLoadingAtom, balanceLoadingAtom } from "../atoms/profile.js"
@@ -47,6 +48,11 @@ import {
 	changeModelListPageAtom,
 	resetModelListStateAtom,
 } from "../atoms/modelList.js"
+import {
+	setActiveSlashCommandPolicyAtom,
+	clearActiveSlashCommandPolicyAtom,
+	setPendingModelOverrideAtom,
+} from "../atoms/slashCommands.js"
 import { useWebviewMessage } from "./useWebviewMessage.js"
 import { useTaskHistory } from "./useTaskHistory.js"
 import { useCondense } from "./useCondense.js"
@@ -109,6 +115,7 @@ export function useCommandContext(): UseCommandContextReturn {
 	const routerModels = useAtomValue(routerModelsAtom)
 	const currentProvider = useAtomValue(providerAtom)
 	const extensionState = useAtomValue(extensionStateAtom)
+	const workspacePath = useAtomValue(cwdAtom) || process.cwd()
 	const kilocodeDefaultModel = (extensionState?.kilocodeDefaultModel as string) || ""
 	const customModes = extensionState?.customModes || []
 	const isParallelMode = useAtomValue(isParallelModeAtom)
@@ -141,6 +148,9 @@ export function useCommandContext(): UseCommandContextReturn {
 	const updateModelListFilters = useSetAtom(updateModelListFiltersAtom)
 	const changeModelListPage = useSetAtom(changeModelListPageAtom)
 	const resetModelListState = useSetAtom(resetModelListStateAtom)
+	const setSlashCommandPolicy = useSetAtom(setActiveSlashCommandPolicyAtom)
+	const clearSlashCommandPolicy = useSetAtom(clearActiveSlashCommandPolicyAtom)
+	const setPendingModelOverride = useSetAtom(setPendingModelOverrideAtom)
 
 	// Get condense function
 	const { condenseAndWait } = useCondense()
@@ -157,6 +167,7 @@ export function useCommandContext(): UseCommandContextReturn {
 				input,
 				args,
 				options,
+				workspacePath,
 				config,
 				sendMessage: async (message: unknown) => {
 					await sendMessage(message as Parameters<typeof sendMessage>[0])
@@ -243,6 +254,15 @@ export function useCommandContext(): UseCommandContextReturn {
 				chatMessages: chatMessages as unknown as ExtensionMessage[],
 				// Current task context
 				currentTask,
+				setSlashCommandPolicy: (policy) => {
+					setSlashCommandPolicy(policy)
+				},
+				clearSlashCommandPolicy: () => {
+					clearSlashCommandPolicy()
+				},
+				setPendingModelOverride: (override) => {
+					setPendingModelOverride(override)
+				},
 				// Model list context
 				modelListPageIndex,
 				modelListFilters,
@@ -288,6 +308,10 @@ export function useCommandContext(): UseCommandContextReturn {
 			previousTaskHistoryPage,
 			chatMessages,
 			currentTask,
+			workspacePath,
+			setSlashCommandPolicy,
+			clearSlashCommandPolicy,
+			setPendingModelOverride,
 			modelListPageIndex,
 			modelListFilters,
 			updateModelListFilters,

--- a/cli/src/state/hooks/useSlashCommandCleanup.ts
+++ b/cli/src/state/hooks/useSlashCommandCleanup.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef } from "react"
+import { useAtomValue, useSetAtom } from "jotai"
+import { lastChatMessageAtom, chatMessagesAtom } from "../atoms/extension.js"
+import {
+	clearActiveSlashCommandPolicyAtom,
+	clearPendingModelOverrideAtom,
+	pendingModelOverrideAtom,
+} from "../atoms/slashCommands.js"
+import { updateProviderAtom, providerAtom } from "../atoms/config.js"
+import { getModelIdKey } from "../../constants/providers/models.js"
+import { logs } from "../../services/logs.js"
+
+/**
+ * Clears active slash command policy and restores model overrides
+ * when a completion_result message is received.
+ */
+export function useSlashCommandCleanup(): void {
+	const lastMessage = useAtomValue(lastChatMessageAtom)
+	const pendingOverride = useAtomValue(pendingModelOverrideAtom)
+	const currentProvider = useAtomValue(providerAtom)
+	const chatMessages = useAtomValue(chatMessagesAtom)
+	const clearPolicy = useSetAtom(clearActiveSlashCommandPolicyAtom)
+	const clearOverride = useSetAtom(clearPendingModelOverrideAtom)
+	const updateProvider = useSetAtom(updateProviderAtom)
+	const handledCompletionRef = useRef<Set<number>>(new Set())
+
+	const restorePendingOverride = useCallback(() => {
+		if (pendingOverride && currentProvider && currentProvider.id === pendingOverride.providerId) {
+			const modelKey = getModelIdKey(currentProvider.provider)
+			const currentModel = currentProvider[modelKey] as string | undefined
+
+			if (currentModel === pendingOverride.overrideModelId) {
+				void updateProvider(currentProvider.id, {
+					[modelKey]: pendingOverride.previousModelId,
+				}).catch((error) => {
+					logs.warn("Failed to restore model after slash command", "SlashCommands", { error })
+				})
+			}
+		}
+
+		clearOverride()
+	}, [pendingOverride, currentProvider, updateProvider, clearOverride])
+
+	useEffect(() => {
+		if (!lastMessage || lastMessage.type !== "ask" || lastMessage.ask !== "completion_result") {
+			return
+		}
+
+		if (handledCompletionRef.current.has(lastMessage.ts)) {
+			return
+		}
+
+		handledCompletionRef.current.add(lastMessage.ts)
+		clearPolicy()
+		restorePendingOverride()
+	}, [lastMessage, clearPolicy, restorePendingOverride])
+
+	useEffect(() => {
+		if (chatMessages.length > 0) {
+			return
+		}
+
+		if (!pendingOverride) {
+			return
+		}
+
+		clearPolicy()
+		restorePendingOverride()
+	}, [chatMessages.length, pendingOverride, clearPolicy, restorePendingOverride])
+}

--- a/cli/src/utils/paths.ts
+++ b/cli/src/utils/paths.ts
@@ -40,6 +40,20 @@ export class KiloCodePaths {
 	}
 
 	/**
+	 * Get user-level custom command directory
+	 */
+	static getUserCommandsDir(): string {
+		return path.join(this.getKiloCodeDir(), "commands")
+	}
+
+	/**
+	 * Get legacy user-level custom command directory (~/.kilocode/commands)
+	 */
+	static getLegacyUserCommandsDir(): string {
+		return path.join(this.getHomeDir(), this.BASE_DIR_NAME, "commands")
+	}
+
+	/**
 	 * Get tasks base directory
 	 */
 	static getTasksDir(): string {


### PR DESCRIPTION
## Context

Add custom slash commands to the CLI with project + user scopes, mirroring Claude Code’s custom commands so users can create reusable workflows in Markdown.

## Implementation

- Discover Markdown commands from `.kilocode/commands` (project) and `~/.kilocode/cli/commands` (user); keep legacy `~/.kilocode/commands` for backward compatibility.
- Parse frontmatter (`description`, `argument-hint`, `allowed-tools`, `model`, `disable-model-invocation`) and expand templates (`$ARGUMENTS`, `$1`, `@file`, `!` bash).
- Register commands in the CLI registry with `/help` visibility + autocomplete priority and add `/commands list` + `/commands reload`.
- Enforce `allowed-tools` via approval policy and clean up policy/model overrides after task completion.
- Add tests + documentation + changeset.

## Screenshots

| before | after |
| ------ | ----- |
| N/A (CLI) | N/A (CLI) |

## How to Test

1. Build extension + CLI:
   - `cd src && pnpm bundle`
   - `cd ../cli && pnpm build`
2. Run CLI with dev extension:
   - `KILOCODE_DEV_CLI_PATH="<repo>/cli/dist/index.js" pnpm start`
3. Create a project command in `.kilocode/commands/hello.md` (or user command in `~/.kilocode/cli/commands/hello.md`) with frontmatter and body using `$ARGUMENTS`, `$1`, and `@file`.
4. In the CLI:
   - `/commands list` shows it.
   - `/help` lists it with the argument hint.
   - `/hello world` sends the expanded prompt.
   - `/commands reload` picks up edits.
5. Add `allowed-tools` to a command and verify blocked tools are denied during approval.

Tests run:
- `cd cli && pnpm test src/services/__tests__/customSlashCommands.test.ts src/services/__tests__/approvalDecision.test.ts src/commands/__tests__/customCommands.test.ts`

## Get in Touch

Discord: aravhawk