### PR TITLE
Jetbrains - Fix Terminal Shell Integration

### DIFF
--- a/.changeset/five-snakes-scream.md
+++ b/.changeset/five-snakes-scream.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Jetbrains - Fix Terminal Integration ZSH/Bash

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/actors/MainThreadTerminalServiceShape.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/actors/MainThreadTerminalServiceShape.kt
@@ -196,8 +196,6 @@ class MainThreadTerminalService(private val project: Project) : MainThreadTermin
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     override suspend fun createTerminal(extHostTerminalId: String, config: Map<String, Any?>) {
-        logger.info("🚀 Creating terminal: $extHostTerminalId, config: $config")
-
         try {
             // Check if terminal already exists
             if (terminalManager.containsTerminal(extHostTerminalId)) {
@@ -209,14 +207,12 @@ class MainThreadTerminalService(private val project: Project) : MainThreadTermin
             val pluginContext = PluginContext.getInstance(project)
             val rpcProtocol = pluginContext.getRPCProtocol()
             if (rpcProtocol == null) {
-                logger.error("❌ Unable to get RPC protocol instance, terminal creation failed: $extHostTerminalId")
+                logger.error("Unable to get RPC protocol instance, terminal creation failed: $extHostTerminalId")
                 throw IllegalStateException("RPC protocol not initialized")
             }
-            logger.info("✅ Got RPC protocol instance: ${rpcProtocol.javaClass.simpleName}")
 
             // Allocate numeric ID
             val numericId = terminalManager.allocateNumericId()
-            logger.info("🔢 Allocated terminal numeric ID: $numericId")
 
             // Create terminal instance
             val terminalConfig = TerminalConfig.fromMap(config)
@@ -230,7 +226,7 @@ class MainThreadTerminalService(private val project: Project) : MainThreadTermin
 
             logger.info("✅ Terminal created successfully: $extHostTerminalId (numericId: $numericId)")
         } catch (e: Exception) {
-            logger.error("❌ Failed to create terminal: $extHostTerminalId", e)
+            logger.error("Failed to create terminal: $extHostTerminalId", e)
             // Clean up possibly created resources
             terminalManager.unregisterTerminal(extHostTerminalId)
             throw e

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/TerminalShellIntegration.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/TerminalShellIntegration.kt
@@ -129,7 +129,7 @@ class TerminalShellIntegration(
     private inner class TerminalShellEventListener : ShellEventListener {
 
         override fun onShellExecutionStart(commandLine: String, cwd: String) {
-            logger.info("$LOG_PREFIX_START Command execution started: '$commandLine' in directory '$cwd' (terminal: $extHostTerminalId)")
+            logger.info("$LOG_PREFIX_START Command execution started: '$commandLine' in directory '$cwd' (terminal: $extHostTerminalId, numericId: $numericId)")
 
             safeRpcCall("Notify ExtHost command start") {
                 extHostProxy.shellExecutionStart(
@@ -144,7 +144,7 @@ class TerminalShellIntegration(
 
         override fun onShellExecutionEnd(commandLine: String, exitCode: Int?) {
             val actualExitCode = exitCode ?: DEFAULT_EXIT_CODE
-            logger.info("$LOG_PREFIX_END Command execution finished: '$commandLine' (exit code: $actualExitCode) (terminal: $extHostTerminalId)")
+            logger.info("$LOG_PREFIX_END Command execution finished: '$commandLine' (exit code: $actualExitCode) (terminal: $extHostTerminalId, numericId: $numericId)")
 
             safeRpcCall("Notify ExtHost command end") {
                 extHostProxy.shellExecutionEnd(
@@ -158,8 +158,6 @@ class TerminalShellIntegration(
         }
 
         override fun onShellExecutionData(data: String) {
-            logger.debug("$LOG_PREFIX_DATA Clean output data: ${data.length} chars (terminal: $extHostTerminalId)")
-
             safeRpcCall("Send shellExecutionData") {
                 extHostProxy.shellExecutionData(
                     instanceId = numericId,
@@ -169,7 +167,7 @@ class TerminalShellIntegration(
         }
 
         override fun onCwdChange(cwd: String) {
-            logger.info("$LOG_PREFIX_CWD Working directory changed to: '$cwd' (terminal: $extHostTerminalId)")
+            logger.info("$LOG_PREFIX_CWD Working directory changed to: '$cwd' (terminal: $extHostTerminalId, numericId: $numericId)")
 
             safeRpcCall("Notify ExtHost directory change") {
                 extHostProxy.cwdChange(


### PR DESCRIPTION
- Fix #2846

## Context

The JetBrains terminal integration was not working correctly - shell execution events (command start/end) were not being captured and sent to the extension via RPC. This prevented features like command history tracking and shell integration from functioning in the JetBrains IDE.

Through systematic debugging, we discovered a complex chain of issues:

1. **JetBrains Integration Conflict**: The `WeCoderTerminalCustomizer` detected JetBrains' own shell integration (`JETBRAINS_INTELLIJ_ZSH_DIR` environment variable) and skipped VSCode shell integration injection to avoid conflicts.

2. **Incorrect USER_ZDOTDIR**: The `USER_ZDOTDIR` environment variable was pointing to JetBrains' shell integration directory, causing VSCode's `.zshenv` to source JetBrains' integration scripts.

3. **OSC 133 Protocol Not Supported**: Users with Powerlevel10k or similar shell themes emit OSC 133 (FinalTerm) markers, but the parser only recognized OSC 633 (VSCode) markers.

4. **Command Line Not Captured**: The OSC 133 protocol doesn't have an explicit command line marker - the command text appears between the B (COMMAND_START) and C (COMMAND_EXECUTED) markers, which wasn't being captured.

## Implementation

### 1. Extension Terminal Detection

Added a `KILOCODE_EXTENSION_TERMINAL=true` environment variable marker to identify terminals created by the extension (vs. regular JetBrains terminals):

- **[`TerminalInstance.createStartupOptions()`](jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/TerminalInstance.kt:242)**: Adds marker to environment before terminal creation
- **[`WeCoderTerminalCustomizer.injectZshScript()`](jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/WeCoderTerminalCustomizer.kt:190)**: Detects marker and forces VSCode shell integration even when JetBrains integration is present

### 2. Correct USER_ZDOTDIR Configuration

Modified [`WeCoderTerminalCustomizer.injectZshScript()`](jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/WeCoderTerminalCustomizer.kt:231) to set `USER_ZDOTDIR` to the user's home directory (instead of JetBrains' integration directory) for extension terminals. This prevents VSCode's `.zshenv` from loading JetBrains' shell integration.

### 3. Dual Protocol Support (OSC 633 + OSC 133)

Enhanced [`ShellIntegrationOutputState.appendRawOutput()`](jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/ShellIntegrationOutputState.kt:206) to recognize both shell integration protocols:

**OSC 633 (VSCode)**:

```
OSC 633;E;command - Explicit command line
OSC 633;C - Command execution starts
OSC 633;D;exitcode - Command finishes
```

**OSC 133 (FinalTerm/JetBrains/Powerlevel10k)**:

```
OSC 133;A - Prompt start
OSC 133;B - Command input start
[command text with ANSI codes]
OSC 133;C - Command execution starts
[command output]
OSC 133;D;exitcode - Command finishes
```

### 4. Command Line Capture for OSC 133

Implemented command line capture logic in [`ShellIntegrationOutputState`](jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/ShellIntegrationOutputState.kt:73):

- Added `commandLineBuffer` and `isCapturingCommandLine` state variables
- Start capturing when OSC 133;B (COMMAND_START) is detected
- Capture all text between B and C markers (including text in subsequent chunks)
- Clean ANSI escape sequences and use as command when OSC 133;C (COMMAND_EXECUTED) is detected
- Notify listeners with `ShellExecutionStart` event containing the captured command

### 5. Code Cleanup

Removed all debug logging added during the debugging process from:

- [`ProxyPtyProcess.kt`](jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/ProxyPtyProcess.kt)
- [`TerminalInstance.kt`](jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/TerminalInstance.kt)
- [`WeCoderTerminalCustomizer.kt`](jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/WeCoderTerminalCustomizer.kt)
- [`ShellIntegrationOutputState.kt`](jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/ShellIntegrationOutputState.kt)
- [`TerminalShellIntegration.kt`](jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/TerminalShellIntegration.kt)
- [`MainThreadTerminalServiceShape.kt`](jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/actors/MainThreadTerminalServiceShape.kt)

## Screenshots

### Bash Support
<img width="3741" height="1992" alt="image" src="https://github.com/user-attachments/assets/d5bb6f0a-c120-4755-8ba6-9780f07cf86b" />

### ZSH Support
<img width="3741" height="1992" alt="image" src="https://github.com/user-attachments/assets/1926d18f-4530-4975-9430-93976d9afd1a" />

## How to Test

### Prerequisites

- JetBrains IDE (IntelliJ IDEA, WebStorm, etc.)
- Zsh shell with Powerlevel10k or similar theme (or any shell with OSC 133 support)

### Test Steps

1. **Build and run the JetBrains plugin**:

    ```bash
    pnpm run jetbrains:bundle
    pnpm run jetbrains:run
    ```

2. **Create a terminal from the extension**:

    - Open the Kilo Code extension in the JetBrains IDE
    - Use the extension to create a terminal (e.g., `execute "echo $0" and explain the output`)

4. **Verify shell integration is working**:

    - You should see a new terminal (Kilo Code)
    - The command should be executed correctly
    - The extension should receive the output of the command and sent to the agent

5. **Test with different shells** (optional):
    - Test with bash: Should work with OSC 633 markers
    - Test with zsh + Powerlevel10k: Should work with OSC 133 markers
    - Test with plain zsh: Should work with VSCode's injected OSC 633 markers