### PR TITLE
docs: add marketplace contribution sections to modes, skills, and MCP pages

### DIFF
--- a/apps/kilocode-docs/docs/agent-behavior/custom-modes.md
+++ b/apps/kilocode-docs/docs/agent-behavior/custom-modes.md
@@ -489,6 +489,27 @@ customModes:
 - **Hyphens for List Items:** List items start with a hyphen and a space (e.g., `- read`)
 - **Validate Your YAML:** Use online YAML validators or your editor's built-in validation
 
+## Contributing to the Marketplace
+
+Have you created a custom mode that others might find useful? Share it with the community by contributing to the [Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace)!
+
+### How to Submit Your Mode
+
+1. **Export your mode**: Use the Export Mode button (download icon) in the Modes view to save your mode as a YAML file
+2. **Test thoroughly**: Ensure your mode works correctly across different scenarios
+3. **Fork the marketplace repository**: Visit [github.com/Kilo-Org/kilo-marketplace](https://github.com/Kilo-Org/kilo-marketplace) and create a fork
+4. **Add your mode**: Place your mode YAML file in the appropriate directory following the repository's structure
+5. **Submit a pull request**: Create a PR with a clear description of what your mode does and when it's useful
+
+### Submission Guidelines
+
+- Include a clear, descriptive name and description
+- Document any specific use cases or requirements
+- Test your mode with different AI models if possible
+- Follow the [contribution guidelines](https://github.com/Kilo-Org/kilo-marketplace/blob/main/CONTRIBUTING.md) in the marketplace repository
+
+For more details on contributing to Kilo Code, see the [Contributing Guide](/contributing).
+
 ## Community Gallery
 
 Ready to explore more? Check out the [Show and Tell](https://github.com/Kilo-Org/kilocode/discussions/categories/show-and-tell) to discover and share custom modes created by the community!

--- a/apps/kilocode-docs/docs/agent-behavior/skills.md
+++ b/apps/kilocode-docs/docs/agent-behavior/skills.md
@@ -34,9 +34,10 @@ Skills are loaded from multiple locations, allowing both personal skills and pro
 
 ### Global Skills (User-Level)
 
-Global skills are located in the `.kilocode` directory within your Home directory. 
-* Mac and Linux: `~/.kilocode/skills/`
-* Windows: `\Users\<yourUser>\.kilocode\`
+Global skills are located in the `.kilocode` directory within your Home directory.
+
+- Mac and Linux: `~/.kilocode/skills/`
+- Windows: `\Users\<yourUser>\.kilocode\`
 
 ```
 ~/.kilocode/
@@ -246,10 +247,10 @@ These additional files can be referenced from your skill's instructions, allowin
 
 ## Finding Skills
 
-There are community efforts to build and share agent skills. Some resources include:
+You can discover and install community-created skills through:
 
-- [Skills Marketplace](https://skillsmp.com/) - Community marketplace of skills
-- [Skill Specification](https://agentskills.io/home) - Agent Skills specification
+- **Kilo Marketplace** - Browse skills directly in the Kilo Code extension via the Marketplace tab, or explore the [Kilo Marketplace repository](https://github.com/Kilo-Org/kilo-marketplace) on GitHub
+- [Agent Skills Specification](https://agentskills.io/home) - The open specification that skills follow, enabling interoperability across different AI agents
 
 ## Troubleshooting
 
@@ -282,6 +283,28 @@ If the agent confirms the skill is available, you're ready to use it. If not, ch
 | "missing required 'name' field" | No `name` in frontmatter                     | Add `name: your-skill-name`                      |
 | "name doesn't match directory"  | Mismatch between frontmatter and folder name | Make `name` match exactly                        |
 | Skill not appearing             | Wrong directory structure                    | Verify path follows `skills/skill-name/SKILL.md` |
+
+## Contributing to the Marketplace
+
+Have you created a skill that others might find useful? Share it with the community by contributing to the [Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace)!
+
+### How to Submit Your Skill
+
+1. **Prepare your skill**: Ensure your skill directory contains a valid `SKILL.md` file with proper frontmatter
+2. **Test thoroughly**: Verify your skill works correctly across different scenarios and modes
+3. **Fork the marketplace repository**: Visit [github.com/Kilo-Org/kilo-marketplace](https://github.com/Kilo-Org/kilo-marketplace) and create a fork
+4. **Add your skill**: Place your skill directory in the appropriate location following the repository's structure
+5. **Submit a pull request**: Create a PR with a clear description of what your skill does and when it's useful
+
+### Submission Guidelines
+
+- Follow the [Agent Skills specification](https://agentskills.io/specification) for your `SKILL.md` file
+- Include a clear `name` and `description` in the frontmatter
+- Document any dependencies or requirements (scripts, external tools, etc.)
+- If your skill includes bundled resources (scripts, templates), ensure they are well-documented
+- Follow the [contribution guidelines](https://github.com/Kilo-Org/kilo-marketplace/blob/main/CONTRIBUTING.md) in the marketplace repository
+
+For more details on contributing to Kilo Code, see the [Contributing Guide](/contributing).
 
 ## Related
 

--- a/apps/kilocode-docs/docs/features/mcp/overview.md
+++ b/apps/kilocode-docs/docs/features/mcp/overview.md
@@ -18,3 +18,25 @@ This documentation is organized into several sections:
 - [**STDIO & SSE Transports**](/features/mcp/server-transports) - Detailed comparison of local (STDIO) and remote (SSE) transport mechanisms with deployment considerations for each approach.
 
 - [**MCP vs API**](/features/mcp/mcp-vs-api) - Analysis of the fundamental distinction between MCP and REST APIs, explaining how they operate at different layers of abstraction for AI systems.
+
+## Contributing to the Marketplace
+
+Have you created an MCP server that others might find useful? Share it with the community by contributing to the [Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace)!
+
+### How to Submit Your MCP Server
+
+1. **Develop your server**: Create an MCP server following the [MCP specification](https://github.com/modelcontextprotocol/)
+2. **Test thoroughly**: Ensure your server works correctly with Kilo Code and handles edge cases gracefully
+3. **Fork the marketplace repository**: Visit [github.com/Kilo-Org/kilo-marketplace](https://github.com/Kilo-Org/kilo-marketplace) and create a fork
+4. **Add your server**: Include your server configuration and documentation following the repository's structure
+5. **Submit a pull request**: Create a PR with a clear description of what your server does and its requirements
+
+### Submission Guidelines
+
+- Document all available tools and resources your server provides
+- Include example configurations for both STDIO and SSE transports if applicable
+- Specify any required environment variables or API keys
+- Note any platform-specific requirements (Windows, macOS, Linux)
+- Follow the [contribution guidelines](https://github.com/Kilo-Org/kilo-marketplace/blob/main/CONTRIBUTING.md) in the marketplace repository
+
+For more details on contributing to Kilo Code, see the [Contributing Guide](/contributing).


### PR DESCRIPTION
Adds 'Contributing to the Marketplace' sections to the documentation pages for Custom Modes, Skills, and MCP Servers.

Each section includes:
- A link to the Kilo Marketplace repository
- Step-by-step submission instructions specific to that resource type
- Submission guidelines with relevant considerations
- A link back to the main Contributing Guide

Also updates the 'Finding Skills' section to reference the Kilo Marketplace (both in-extension and GitHub) instead of the external skillsmp.com site.