### PR TITLE
feat: add Skills tab to Agent Behaviour settings

### DIFF
--- a/.changeset/skills-tab-agent-behaviour.md
+++ b/.changeset/skills-tab-agent-behaviour.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Add Skills tab to Agent Behaviour settings showing installed skills with delete functionality

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -35,6 +35,7 @@ import { ClineRulesToggles } from "./cline-rules"
 import { KiloCodeWrapperProperties } from "./kilocode/wrapper"
 import { DeploymentRecord } from "../api/providers/fetchers/sap-ai-core"
 import { STTSegment, MicrophoneDevice } from "./sttContract" // kilocode_change: STT segment type and microphone device
+import { SkillMetadata } from "./skills" // kilocode_change: Skills tab data
 // kilocode_change end
 
 // Command interface for frontend/backend communication
@@ -202,6 +203,7 @@ export interface ExtensionMessage {
 		| "chatCompletionResult" // kilocode_change: FIM completion result for chat text area
 		| "claudeCodeRateLimits"
 		| "customToolsResult"
+		| "skillsData" // kilocode_change: Skills tab data
 	text?: string
 	// kilocode_change start
 	completionRequestId?: string // Correlation ID from request
@@ -309,6 +311,9 @@ export interface ExtensionMessage {
 	localRules?: ClineRulesToggles
 	globalWorkflows?: ClineRulesToggles
 	localWorkflows?: ClineRulesToggles
+	// kilocode_change: Skills tab data
+	globalSkills?: SkillMetadata[]
+	projectSkills?: SkillMetadata[]
 	marketplaceItems?: MarketplaceItem[]
 	organizationMcps?: MarketplaceItem[]
 	marketplaceInstalledMetadata?: MarketplaceInstalledMetadata

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -298,6 +298,10 @@ export interface WebviewMessage {
 		| "downloadErrorDiagnostics"
 		| "requestClaudeCodeRateLimits"
 		| "refreshCustomTools"
+		// kilocode_change start - Skills tab messages
+		| "refreshSkills"
+		| "deleteSkill"
+	// kilocode_change end
 	text?: string
 	suggestionLength?: number // kilocode_change: Length of accepted suggestion for telemetry
 	completionRequestId?: string // kilocode_change
@@ -334,6 +338,7 @@ export interface WebviewMessage {
 	filename?: string // kilocode_change
 	ruleType?: string // kilocode_change
 	notificationId?: string // kilocode_change
+	skillName?: string // kilocode_change: For deleteSkill
 	commandIds?: string[] // kilocode_change: For getKeybindings
 	// kilocode_change end
 	serverName?: string

--- a/webview-ui/src/components/kilocode/rules/KiloRulesWorkflowsView.tsx
+++ b/webview-ui/src/components/kilocode/rules/KiloRulesWorkflowsView.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react"
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { useTranslation } from "react-i18next"
+
+import { vscode } from "@/utils/vscode"
+
+import RulesWorkflowsSection from "./RulesWorkflowsSection"
+
+const sortedRules = (data: Record<string, unknown> | undefined) =>
+	Object.entries(data || {})
+		.map(([path, enabled]): [string, boolean] => [path, enabled as boolean])
+		.sort(([a], [b]) => a.localeCompare(b))
+
+interface DescriptionWithLinkProps {
+	children: React.ReactNode
+	href: string
+	linkText: string
+}
+
+const DescriptionWithLink: React.FC<DescriptionWithLinkProps> = ({ children, href, linkText }) => (
+	<p>
+		{children}{" "}
+		<VSCodeLink href={href} style={{ display: "inline" }} className="text-xs">
+			{linkText}
+		</VSCodeLink>
+	</p>
+)
+
+type KiloRulesWorkflowsViewProps = {
+	type: "rule" | "workflow"
+}
+
+const KiloRulesWorkflowsView = ({ type }: KiloRulesWorkflowsViewProps) => {
+	const { t } = useTranslation()
+
+	const [localRules, setLocalRules] = useState<[string, boolean][]>([])
+	const [globalRules, setGlobalRules] = useState<[string, boolean][]>([])
+	const [localWorkflows, setLocalWorkflows] = useState<[string, boolean][]>([])
+	const [globalWorkflows, setGlobalWorkflows] = useState<[string, boolean][]>([])
+
+	useEffect(() => {
+		vscode.postMessage({ type: "refreshRules" })
+	}, [])
+
+	useEffect(() => {
+		const handleMessage = (event: MessageEvent) => {
+			const message = event.data
+			if (message.type === "rulesData") {
+				setLocalRules(sortedRules(message.localRules))
+				setGlobalRules(sortedRules(message.globalRules))
+				setLocalWorkflows(sortedRules(message.localWorkflows))
+				setGlobalWorkflows(sortedRules(message.globalWorkflows))
+			}
+		}
+
+		window.addEventListener("message", handleMessage)
+		return () => window.removeEventListener("message", handleMessage)
+	}, [])
+
+	const toggleRule = (isGlobal: boolean, rulePath: string, enabled: boolean) => {
+		vscode.postMessage({
+			type: "toggleRule",
+			rulePath,
+			enabled,
+			isGlobal,
+		})
+	}
+
+	const toggleWorkflow = (isGlobal: boolean, workflowPath: string, enabled: boolean) => {
+		vscode.postMessage({
+			type: "toggleWorkflow",
+			workflowPath,
+			enabled,
+			isGlobal,
+		})
+	}
+
+	const isRules = type === "rule"
+
+	return (
+		<div className="px-5">
+			<div className="text-xs text-[var(--vscode-descriptionForeground)] mb-4">
+				{isRules ? (
+					<DescriptionWithLink
+						href="https://kilo.ai/docs/advanced-usage/custom-rules"
+						linkText={t("kilocode:docs")}>
+						{t("kilocode:rules.description.rules")}
+					</DescriptionWithLink>
+				) : (
+					<DescriptionWithLink
+						href="https://kilo.ai/docs/features/slash-commands/workflows"
+						linkText={t("kilocode:docs")}>
+						{t("kilocode:rules.description.workflows")}{" "}
+						<span className="text-[var(--vscode-foreground)] font-bold">/workflow-name</span>{" "}
+						{t("kilocode:rules.description.workflowsInChat")}
+					</DescriptionWithLink>
+				)}
+			</div>
+
+			<RulesWorkflowsSection
+				type={type}
+				globalItems={isRules ? globalRules : globalWorkflows}
+				localItems={isRules ? localRules : localWorkflows}
+				toggleGlobal={(path: string, enabled: boolean) =>
+					isRules ? toggleRule(true, path, enabled) : toggleWorkflow(true, path, enabled)
+				}
+				toggleLocal={(path: string, enabled: boolean) =>
+					isRules ? toggleRule(false, path, enabled) : toggleWorkflow(false, path, enabled)
+				}
+			/>
+		</div>
+	)
+}
+
+export default KiloRulesWorkflowsView

--- a/webview-ui/src/components/kilocode/settings/AgentBehaviourView.tsx
+++ b/webview-ui/src/components/kilocode/settings/AgentBehaviourView.tsx
@@ -1,0 +1,95 @@
+// kilocode_change - new file
+import { useState } from "react"
+import styled from "styled-components"
+import { Users2 } from "lucide-react"
+import { useAppTranslation } from "@src/i18n/TranslationContext"
+import { SectionHeader } from "@src/components/settings/SectionHeader"
+import { Section } from "@src/components/settings/Section"
+import ModesView from "@src/components/modes/ModesView"
+import McpView from "@src/components/mcp/McpView"
+import KiloRulesWorkflowsView from "@src/components/kilocode/rules/KiloRulesWorkflowsView"
+import InstalledSkillsView from "@src/components/kilocode/skills/InstalledSkillsView"
+
+const StyledTabButton = styled.button<{ isActive: boolean }>`
+	background: none;
+	border: none;
+	border-bottom: 2px solid ${(props) => (props.isActive ? "var(--vscode-foreground)" : "transparent")};
+	color: ${(props) => (props.isActive ? "var(--vscode-foreground)" : "var(--vscode-descriptionForeground)")};
+	padding: 8px 16px;
+	cursor: pointer;
+	font-size: 13px;
+	margin-bottom: -1px;
+	font-family: inherit;
+
+	&:hover {
+		color: var(--vscode-foreground);
+	}
+`
+
+const TabButton = ({
+	children,
+	isActive,
+	onClick,
+}: {
+	children: React.ReactNode
+	isActive: boolean
+	onClick: () => void
+}) => (
+	<StyledTabButton isActive={isActive} onClick={onClick}>
+		{children}
+	</StyledTabButton>
+)
+
+const AgentBehaviourView = () => {
+	const [activeTab, setActiveTab] = useState<"modes" | "mcp" | "rules" | "workflows" | "skills">("modes")
+	const { t } = useAppTranslation()
+
+	return (
+		<div>
+			<SectionHeader>
+				<div className="flex items-center gap-2">
+					<Users2 className="w-4" />
+					<div>{t("kilocode:settings.sections.agentBehaviour")}</div>
+				</div>
+			</SectionHeader>
+
+			<Section>
+				{/* Tab buttons */}
+				<div
+					style={{
+						display: "flex",
+						gap: "1px",
+						padding: "0 20px 0 20px",
+						borderBottom: "1px solid var(--vscode-panel-border)",
+					}}>
+					<TabButton isActive={activeTab === "modes"} onClick={() => setActiveTab("modes")}>
+						{t("settings:sections.modes")}
+					</TabButton>
+					<TabButton isActive={activeTab === "mcp"} onClick={() => setActiveTab("mcp")}>
+						{t("kilocode:settings.sections.mcp")}
+					</TabButton>
+					<TabButton isActive={activeTab === "rules"} onClick={() => setActiveTab("rules")}>
+						{t("kilocode:rules.tabs.rules")}
+					</TabButton>
+					<TabButton isActive={activeTab === "workflows"} onClick={() => setActiveTab("workflows")}>
+						{t("kilocode:rules.tabs.workflows")}
+					</TabButton>
+					<TabButton isActive={activeTab === "skills"} onClick={() => setActiveTab("skills")}>
+						{t("kilocode:skills.title")}
+					</TabButton>
+				</div>
+
+				{/* Content */}
+				<div style={{ width: "100%" }}>
+					{activeTab === "modes" && <ModesView hideHeader />}
+					{activeTab === "mcp" && <McpView hideHeader onDone={() => {}} />}
+					{activeTab === "rules" && <KiloRulesWorkflowsView type="rule" />}
+					{activeTab === "workflows" && <KiloRulesWorkflowsView type="workflow" />}
+					{activeTab === "skills" && <InstalledSkillsView />}
+				</div>
+			</Section>
+		</div>
+	)
+}
+
+export default AgentBehaviourView

--- a/webview-ui/src/components/kilocode/skills/InstalledSkillsView.tsx
+++ b/webview-ui/src/components/kilocode/skills/InstalledSkillsView.tsx
@@ -1,0 +1,168 @@
+// kilocode_change - new file
+import { useEffect, useState } from "react"
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { useTranslation } from "react-i18next"
+import { Trash2 } from "lucide-react"
+
+import { vscode } from "@/utils/vscode"
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogDescription,
+	DialogFooter,
+} from "@/components/ui"
+
+interface SkillMetadata {
+	name: string
+	description: string
+	path: string
+	source: "global" | "project"
+	mode?: string
+}
+
+const InstalledSkillsView = () => {
+	const { t } = useTranslation()
+	const [globalSkills, setGlobalSkills] = useState<SkillMetadata[]>([])
+	const [projectSkills, setProjectSkills] = useState<SkillMetadata[]>([])
+	const [skillToDelete, setSkillToDelete] = useState<SkillMetadata | null>(null)
+
+	useEffect(() => {
+		vscode.postMessage({ type: "refreshSkills" })
+	}, [])
+
+	useEffect(() => {
+		const handleMessage = (event: MessageEvent) => {
+			const message = event.data
+			if (message.type === "skillsData") {
+				setGlobalSkills(message.globalSkills || [])
+				setProjectSkills(message.projectSkills || [])
+			}
+		}
+		window.addEventListener("message", handleMessage)
+		return () => window.removeEventListener("message", handleMessage)
+	}, [])
+
+	const handleDelete = () => {
+		if (skillToDelete) {
+			vscode.postMessage({
+				type: "deleteSkill",
+				skillName: skillToDelete.name,
+				source: skillToDelete.source,
+				mode: skillToDelete.mode,
+			})
+			setSkillToDelete(null)
+		}
+	}
+
+	return (
+		<div className="px-5">
+			{/* Description */}
+			<div className="text-xs text-[var(--vscode-descriptionForeground)] mb-4">
+				<p>
+					{t("kilocode:skills.description")}{" "}
+					<VSCodeLink
+						href="https://kilo.ai/docs/features/skills"
+						style={{ display: "inline" }}
+						className="text-xs">
+						{t("kilocode:docs")}
+					</VSCodeLink>
+				</p>
+			</div>
+
+			{/* Global Skills Section */}
+			<div className="mb-3">
+				<div className="text-sm font-normal mb-2">{t("kilocode:skills.sections.globalSkills")}</div>
+				<SkillsList
+					skills={globalSkills}
+					onDelete={setSkillToDelete}
+					emptyMessage={t("kilocode:skills.emptyState")}
+				/>
+			</div>
+
+			{/* Project Skills Section */}
+			<div style={{ marginBottom: -10 }}>
+				<div className="text-sm font-normal mb-2">{t("kilocode:skills.sections.projectSkills")}</div>
+				<SkillsList
+					skills={projectSkills}
+					onDelete={setSkillToDelete}
+					emptyMessage={t("kilocode:skills.emptyState")}
+				/>
+			</div>
+
+			{/* Delete Confirmation Dialog */}
+			<Dialog open={!!skillToDelete} onOpenChange={(open) => !open && setSkillToDelete(null)}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>{t("kilocode:skills.deleteDialog.title")}</DialogTitle>
+						<DialogDescription>
+							{t("kilocode:skills.deleteDialog.description", { skillName: skillToDelete?.name })}
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button variant="secondary" onClick={() => setSkillToDelete(null)}>
+							{t("kilocode:skills.deleteDialog.cancel")}
+						</Button>
+						<Button variant="destructive" onClick={handleDelete}>
+							{t("kilocode:skills.deleteDialog.delete")}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	)
+}
+
+interface SkillsListProps {
+	skills: SkillMetadata[]
+	onDelete: (skill: SkillMetadata) => void
+	emptyMessage: string
+}
+
+const SkillsList = ({ skills, onDelete, emptyMessage }: SkillsListProps) => {
+	if (skills.length === 0) {
+		return <div className="text-xs text-[var(--vscode-descriptionForeground)] py-2">{emptyMessage}</div>
+	}
+
+	return (
+		<div className="flex flex-col gap-2">
+			{skills.map((skill) => (
+				<SkillRow
+					key={`${skill.source}-${skill.mode || "generic"}-${skill.name}`}
+					skill={skill}
+					onDelete={onDelete}
+				/>
+			))}
+		</div>
+	)
+}
+
+interface SkillRowProps {
+	skill: SkillMetadata
+	onDelete: (skill: SkillMetadata) => void
+}
+
+const SkillRow = ({ skill, onDelete }: SkillRowProps) => {
+	return (
+		<div className="flex items-center p-2 bg-[var(--vscode-textCodeBlock-background)] rounded">
+			<div className="flex-1 min-w-0">
+				<div className="flex items-center gap-2">
+					<span className="font-medium text-sm">{skill.name}</span>
+					{skill.mode && (
+						<span className="px-1.5 py-0.5 text-[10px] rounded bg-[var(--vscode-badge-background)] text-[var(--vscode-badge-foreground)]">
+							{skill.mode}
+						</span>
+					)}
+				</div>
+				<div className="text-xs text-[var(--vscode-descriptionForeground)] truncate">{skill.description}</div>
+			</div>
+			<Button variant="ghost" size="icon" onClick={() => onDelete(skill)} className="ml-2 flex-shrink-0">
+				<Trash2 className="w-4 h-4" />
+			</Button>
+		</div>
+	)
+}
+
+export default InstalledSkillsView

--- a/webview-ui/src/components/modes/ModesView.tsx
+++ b/webview-ui/src/components/modes/ModesView.tsx
@@ -66,7 +66,9 @@ function getGroupName(group: GroupEntry): ToolGroup {
 	return Array.isArray(group) ? group[0] : group
 }
 
-const ModesView = () => {
+// kilocode_change start - add hideHeader prop
+const ModesView = ({ hideHeader = false }: { hideHeader?: boolean }) => {
+	// kilocode_change end
 	const { t } = useAppTranslation()
 
 	const {
@@ -601,12 +603,16 @@ const ModesView = () => {
 
 	return (
 		<div>
-			<SectionHeader>
-				<div className="flex items-center gap-2">
-					<MessageSquare className="w-4" />
-					<div>{t("prompts:title")}</div>
-				</div>
-			</SectionHeader>
+			{/* kilocode_change start - conditionally hide header */}
+			{!hideHeader && (
+				<SectionHeader>
+					<div className="flex items-center gap-2">
+						<MessageSquare className="w-4" />
+						<div>{t("prompts:title")}</div>
+					</div>
+				</SectionHeader>
+			)}
+			{/* kilocode_change end */}
 
 			<Section>
 				<div>

--- a/webview-ui/src/i18n/locales/en/kilocode.json
+++ b/webview-ui/src/i18n/locales/en/kilocode.json
@@ -46,7 +46,8 @@
 	},
 	"settings": {
 		"sections": {
-			"mcp": "MCP Servers"
+			"mcp": "MCP Servers",
+			"agentBehaviour": "Agent Behaviour"
 		},
 		"provider": {
 			"account": "Kilo Code Account",
@@ -176,6 +177,21 @@
 		"newFile": {
 			"newWorkflowFile": "New workflow file...",
 			"newRuleFile": "New rule file..."
+		}
+	},
+	"skills": {
+		"title": "Skills",
+		"description": "Skills provide specialized instructions for specific tasks. They can be scoped to specific modes or available globally.",
+		"sections": {
+			"globalSkills": "Global Skills",
+			"projectSkills": "Project Skills"
+		},
+		"emptyState": "No skills installed",
+		"deleteDialog": {
+			"title": "Delete Skill",
+			"description": "Are you sure you want to delete the skill \"{{skillName}}\"? This action cannot be undone.",
+			"cancel": "Cancel",
+			"delete": "Delete"
 		}
 	},
 	"taskTimeline": {


### PR DESCRIPTION
## Summary

This PR adds a Skills tab to the Agent Behaviour settings view, showing installed skills from both global and project directories with delete functionality.

## Changes

### Backend
- Added `refreshSkills` and `deleteSkill` message types to WebviewMessage.ts
- Added `skillsData` message type to ExtensionMessage.ts
- Added handlers in webviewMessageHandler.ts for skill listing and deletion

### Frontend
- Created `InstalledSkillsView.tsx` component showing global and project skills
- Created `AgentBehaviourView.tsx` with tabs for Modes, MCP Servers, Rules, Workflows, and Skills
- Added translations for Skills tab UI

## Screenshots
(Add screenshots after testing)

## Testing
- [ ] Skills tab appears in Agent Behaviour settings
- [ ] Global skills are listed correctly
- [ ] Project skills are listed correctly
- [ ] Delete button shows confirmation dialog
- [ ] Deleting a skill removes it from the list