### PR TITLE
expose autocomplete profile selection in settings

### DIFF
--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -3,12 +3,6 @@
  */
 
 /**
- * Enable model selection for autocomplete in development mode.
- * This allows developers to test different models for autocomplete functionality.
- */
-export const MODEL_SELECTION_ENABLED = process.env.NODE_ENV === "development"
-
-/**
- * Enable extreme snooze values for autocomplete in development mode.
+ * Enable extreme snooze values for ghost autocomplete in development mode.
  */
 export const EXTREME_SNOOZE_VALUES_ENABLED = process.env.NODE_ENV === "development"

--- a/webview-ui/src/components/kilocode/settings/GhostServiceSettings.tsx
+++ b/webview-ui/src/components/kilocode/settings/GhostServiceSettings.tsx
@@ -6,12 +6,7 @@ import { Bot, Zap, Clock } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { SectionHeader } from "../../settings/SectionHeader"
 import { Section } from "../../settings/Section"
-import {
-	AUTOCOMPLETE_PROVIDER_MODELS,
-	EXTREME_SNOOZE_VALUES_ENABLED,
-	GhostServiceSettings,
-	MODEL_SELECTION_ENABLED,
-} from "@roo-code/types"
+import { AUTOCOMPLETE_PROVIDER_MODELS, EXTREME_SNOOZE_VALUES_ENABLED, GhostServiceSettings } from "@roo-code/types"
 import { vscode } from "@/utils/vscode"
 import { VSCodeCheckbox, VSCodeButton, VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
 import { useKeybindings } from "@/hooks/useKeybindings"
@@ -285,11 +280,9 @@ export const GhostServiceSettingsView = ({
 									</div>
 								</div>
 							)}
-							{MODEL_SELECTION_ENABLED && (
-								<div className="text-vscode-descriptionForeground mt-2">
-									{t("kilocode:ghost.settings.configureAutocompleteProfile")}
-								</div>
-							)}
+							<div className="text-vscode-descriptionForeground mt-2">
+								{t("kilocode:ghost.settings.configureAutocompleteProfile")}
+							</div>
 						</div>
 					</div>
 				</div>

--- a/webview-ui/src/components/settings/ApiConfigManager.tsx
+++ b/webview-ui/src/components/settings/ApiConfigManager.tsx
@@ -3,7 +3,6 @@ import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import { AlertTriangle } from "lucide-react"
 
 import type { ProviderSettingsEntry, OrganizationAllowList, ProfileType } from "@roo-code/types" // kilocode_change - autocomplete profile type system
-import { MODEL_SELECTION_ENABLED } from "@roo-code/types"
 
 import { useAppTranslation } from "@/i18n/TranslationContext"
 import {
@@ -376,29 +375,27 @@ const ApiConfigManager = ({
 								}}
 							/>
 						</div>
-						{MODEL_SELECTION_ENABLED && (
-							<div>
-								<label className="block text-sm font-medium mb-1">
-									{t("settings:providers.profileType")}
-								</label>
-								<Select
-									value={newProfileType}
-									onValueChange={(value) => setNewProfileType(value as ProfileType)}>
-									<SelectTrigger className="w-full">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="chat">{t("settings:providers.profileTypeChat")}</SelectItem>
-										<SelectItem value="autocomplete">
-											{t("settings:providers.profileTypeAutocomplete")}
-										</SelectItem>
-									</SelectContent>
-								</Select>
-								<p className="text-vscode-descriptionForeground text-xs mt-1">
-									{t("settings:providers.profileTypeDescription")}
-								</p>
-							</div>
-						)}
+						<div>
+							<label className="block text-sm font-medium mb-1">
+								{t("settings:providers.profileType")}
+							</label>
+							<Select
+								value={newProfileType}
+								onValueChange={(value) => setNewProfileType(value as ProfileType)}>
+								<SelectTrigger className="w-full">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="chat">{t("settings:providers.profileTypeChat")}</SelectItem>
+									<SelectItem value="autocomplete">
+										{t("settings:providers.profileTypeAutocomplete")}
+									</SelectItem>
+								</SelectContent>
+							</Select>
+							<p className="text-vscode-descriptionForeground text-xs mt-1">
+								{t("settings:providers.profileTypeDescription")}
+							</p>
+						</div>
 					</div>
 					{/* kilocode_change end */}
 					{error && (

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -27,7 +27,6 @@ import {
 	syntheticDefaultModelId,
 	ovhCloudAiEndpointsDefaultModelId,
 	inceptionDefaultModelId,
-	MODEL_SELECTION_ENABLED,
 	// kilocode_change end
 	mistralDefaultModelId,
 	xaiDefaultModelId,
@@ -531,24 +530,22 @@ const ApiOptions = ({
 		<div className="flex flex-col gap-3">
 			{/* kilocode_change start - autocomplete profile type system */}
 			{/* Profile Type Display (read-only for existing profiles) */}
-			{MODEL_SELECTION_ENABLED && (
-				<div className="flex flex-col gap-1">
-					<label className="block font-medium mb-1">{t("settings:providers.profileType")}</label>
-					<div className="px-3 py-2 bg-vscode-input-background border border-vscode-input-border rounded text-vscode-input-foreground">
-						{apiConfiguration.profileType === "autocomplete"
-							? t("settings:providers.profileTypeAutocomplete")
-							: t("settings:providers.profileTypeChat")}
-						{apiConfiguration.profileType === "autocomplete" && (
-							<span className="ml-2 text-vscode-descriptionForeground">
-								{t("settings:providers.autocompleteLabel")}
-							</span>
-						)}
-					</div>
-					<div className="text-vscode-descriptionForeground text-sm mt-1">
-						{t("settings:providers.profileTypeDescription")}
-					</div>
+			<div className="flex flex-col gap-1">
+				<label className="block font-medium mb-1">{t("settings:providers.profileType")}</label>
+				<div className="px-3 py-2 bg-vscode-input-background border border-vscode-input-border rounded text-vscode-input-foreground">
+					{apiConfiguration.profileType === "autocomplete"
+						? t("settings:providers.profileTypeAutocomplete")
+						: t("settings:providers.profileTypeChat")}
+					{apiConfiguration.profileType === "autocomplete" && (
+						<span className="ml-2 text-vscode-descriptionForeground">
+							{t("settings:providers.autocompleteLabel")}
+						</span>
+					)}
 				</div>
-			)}
+				<div className="text-vscode-descriptionForeground text-sm mt-1">
+					{t("settings:providers.profileTypeDescription")}
+				</div>
+			</div>
 			{/* kilocode_change end */}
 
 			<div className="flex flex-col gap-1 relative">


### PR DESCRIPTION
Context
Expose autocomplete profile selection in settings so users can choose a dedicated model for Ghost/autocompletions without dev-only flags.

Implementation
Removed the dev-only gate around autocomplete profile type selection and display. The Providers tab now always allows creating an “autocomplete” profile, and the profile editor always shows the profile type. Ghost settings now always surfaces the guidance to configure the autocomplete profile.