### PR TITLE
Add ChatGPT Plus/Pro provider documentation

### DIFF
--- a/apps/kilocode-docs/docs/getting-started/setting-up.mdx
+++ b/apps/kilocode-docs/docs/getting-started/setting-up.mdx
@@ -29,6 +29,11 @@ Kilo Code provides a simple registration process that gives you access to the la
 
 That's it - you're all set! Now you can start with [your first task](/getting-started/your-first-task)
 
+## Already have a subscription to another AI provider?
+
+If you subscribe to ChatGPT, use the [OpenAI ChatGPT provider](../providers/openai-chatgpt-plus-pro) to utilize your subscription with Kilo Code.
+
+You can also [bring your own key](../basic-usage/byok) to use your account or subscription for other providers, including: Anthropic, OpenAI, Mistral, Z.AI, and Minimax. 
 :::tip Need Help?
 If you have any questions about pricing or tokens, please reach out to our [support team](mailto:hi@kilo.ai) or ask in our <a href={DISCORD_URL} target='_blank'>Discord community</a>.
 :::

--- a/apps/kilocode-docs/docs/getting-started/setting-up.mdx
+++ b/apps/kilocode-docs/docs/getting-started/setting-up.mdx
@@ -34,6 +34,7 @@ That's it - you're all set! Now you can start with [your first task](/getting-st
 If you subscribe to ChatGPT, use the [OpenAI ChatGPT provider](../providers/openai-chatgpt-plus-pro) to utilize your subscription with Kilo Code.
 
 You can also [bring your own key](../basic-usage/byok) to use your account or subscription for other providers, including: Anthropic, OpenAI, Mistral, Z.AI, and Minimax. 
+
 :::tip Need Help?
 If you have any questions about pricing or tokens, please reach out to our [support team](mailto:hi@kilo.ai) or ask in our <a href={DISCORD_URL} target='_blank'>Discord community</a>.
 :::

--- a/apps/kilocode-docs/docs/providers/openai-chatgpt-plus-pro.md
+++ b/apps/kilocode-docs/docs/providers/openai-chatgpt-plus-pro.md
@@ -2,7 +2,7 @@
 sidebar_label: ChatGPT Plus/Pro
 ---
 
-## Quickstart: Connect your ChatGPT subscription to Kilo Code
+# Connect your ChatGPT subscription to Kilo Code
 
 1. Open Kilo Code settings (click the gear icon <Codicon name="gear" /> in the Kilo Code panel).
 2. In **API Provider**, select **OpenAI – ChatGPT Plus/Pro**.

--- a/apps/kilocode-docs/docs/providers/openai-chatgpt-plus-pro.md
+++ b/apps/kilocode-docs/docs/providers/openai-chatgpt-plus-pro.md
@@ -2,7 +2,7 @@
 sidebar_label: ChatGPT Plus/Pro
 ---
 
-# Connect your ChatGPT subscription to Kilo Code
+# Using ChatGPT Subscriptions With Kilo Code
 
 1. Open Kilo Code settings (click the gear icon <Codicon name="gear" /> in the Kilo Code panel).
 2. In **API Provider**, select **OpenAI – ChatGPT Plus/Pro**.

--- a/apps/kilocode-docs/docs/providers/openai-chatgpt-plus-pro.md
+++ b/apps/kilocode-docs/docs/providers/openai-chatgpt-plus-pro.md
@@ -1,37 +1,8 @@
 ---
 sidebar_label: ChatGPT Plus/Pro
-title: ChatGPT Plus/Pro
-description: Use OpenAI models in Kilo Code with your ChatGPT Plus/Pro subscription (OAuth sign-in, no API key).
-keywords:
-  - OpenAI Codex
-  - ChatGPT Plus
-  - ChatGPT Pro
-  - Kilo Code
-  - OAuth
-  - no api key
-  - subscription
 ---
 
-<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden' }}>
-  <iframe
-    src="https://www.youtube.com/embed/c1IXRMl5i0g?rel=0&modestbranding=1"
-    title="OpenAI – ChatGPT Plus/Pro provider setup"
-    style={{
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      width: '100%',
-      height: '100%',
-    }}
-    frameBorder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-    allowFullScreen
-  ></iframe>
-</div>
-
----
-
-## Quickstart: Connect your subscription to Kilo Code
+## Quickstart: Connect your ChatGPT subscription to Kilo Code
 
 1. Open Kilo Code settings (click the gear icon <Codicon name="gear" /> in the Kilo Code panel).
 2. In **API Provider**, select **OpenAI – ChatGPT Plus/Pro**.
@@ -42,11 +13,11 @@ keywords:
 
 ## Tips and Notes
 
-- **Subscription Required:** You need an active ChatGPT Plus or Pro subscription. This provider won't work with free ChatGPT accounts. See [OpenAI's ChatGPT plans](https://openai.com/chatgpt/pricing) for more info.
+- **Subscription Required:** You need an active ChatGPT Plus or Pro subscription. This provider won't work with free ChatGPT accounts. See [OpenAI's ChatGPT plans](https://openai.com/chatgpt/pricing) for more information.
 - **No API Costs:** Usage through this provider counts against your ChatGPT subscription, not separately billed API usage.
 - **Sign Out:** To disconnect, use the "Sign Out" button in the provider settings.
 
-## What you can't do (and why)
+## Limitations
 
 - **You can't use arbitrary OpenAI API models.** This provider only exposes the models listed in Kilo Code's Codex model catalog.
 - **You can't export/migrate your sign-in state with settings export.** OAuth tokens are stored in VS Code SecretStorage, which isn't included in Kilo Code's settings export.

--- a/apps/kilocode-docs/docs/providers/openai-chatgpt-plus-pro.md
+++ b/apps/kilocode-docs/docs/providers/openai-chatgpt-plus-pro.md
@@ -1,0 +1,52 @@
+---
+sidebar_label: ChatGPT Plus/Pro
+title: ChatGPT Plus/Pro
+description: Use OpenAI models in Kilo Code with your ChatGPT Plus/Pro subscription (OAuth sign-in, no API key).
+keywords:
+  - OpenAI Codex
+  - ChatGPT Plus
+  - ChatGPT Pro
+  - Kilo Code
+  - OAuth
+  - no api key
+  - subscription
+---
+
+<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden' }}>
+  <iframe
+    src="https://www.youtube.com/embed/c1IXRMl5i0g?rel=0&modestbranding=1"
+    title="OpenAI – ChatGPT Plus/Pro provider setup"
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+    }}
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  ></iframe>
+</div>
+
+---
+
+## Quickstart: Connect your subscription to Kilo Code
+
+1. Open Kilo Code settings (click the gear icon <Codicon name="gear" /> in the Kilo Code panel).
+2. In **API Provider**, select **OpenAI – ChatGPT Plus/Pro**.
+3. Click **Sign in to OpenAI Codex**.
+4. Finish the sign-in flow in your browser.
+5. Back in Kilo Code settings, pick a model from the dropdown.
+6. Save.
+
+## Tips and Notes
+
+- **Subscription Required:** You need an active ChatGPT Plus or Pro subscription. This provider won't work with free ChatGPT accounts. See [OpenAI's ChatGPT plans](https://openai.com/chatgpt/pricing) for more info.
+- **No API Costs:** Usage through this provider counts against your ChatGPT subscription, not separately billed API usage.
+- **Sign Out:** To disconnect, use the "Sign Out" button in the provider settings.
+
+## What you can't do (and why)
+
+- **You can't use arbitrary OpenAI API models.** This provider only exposes the models listed in Kilo Code's Codex model catalog.
+- **You can't export/migrate your sign-in state with settings export.** OAuth tokens are stored in VS Code SecretStorage, which isn't included in Kilo Code's settings export.

--- a/apps/kilocode-docs/sidebars.ts
+++ b/apps/kilocode-docs/sidebars.ts
@@ -62,6 +62,7 @@ const sidebars: SidebarsConfig = {
 								"providers/anthropic",
 								"providers/bedrock",
 								"providers/cerebras", // kilocode_change
+								"providers/openai-chatgpt-plus-pro", // kilocode_change
 								"providers/chutes-ai",
 								"providers/claude-code",
 								"providers/deepseek",


### PR DESCRIPTION
Adds initial ChatGPT provider documentation, based on: https://docs.roocode.com/providers/openai-chatgpt-plus-pro