### PR TITLE
Fix ChatGPT provider support for commit message generation, and other Kilo specific features

### DIFF
--- a/.changeset/fair-geckos-compare.md
+++ b/.changeset/fair-geckos-compare.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix OpenAI Codex commit message generation, prompt enhancement, and terminal command generation by sending required instructions and streaming responses.

--- a/src/api/providers/openai-codex.ts
+++ b/src/api/providers/openai-codex.ts
@@ -1053,7 +1053,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 				],
 				stream: true, // kilocode_change
 				store: false,
-				instructions: this.resolveInstructions(), // kilocode_change
+				instructions: this.ensureInstructions(), // kilocode_change
 				...(reasoningEffort ? { include: ["reasoning.encrypted_content"] } : {}),
 			}
 

--- a/src/api/providers/openai-codex.ts
+++ b/src/api/providers/openai-codex.ts
@@ -339,7 +339,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 	}
 
 	// kilocode_change start
-	private resolveInstructions(systemPrompt?: string): string {
+	private ensureInstructions(systemPrompt?: string): string {
 		if (systemPrompt && systemPrompt.trim().length > 0) {
 			return systemPrompt
 		}


### PR DESCRIPTION
The ChatGPT backend does not seem to support non-streaming requests, and it also requires at least some prompt.

This PR makes two changes:
1. Always sends a prompt even if instructions is blank.
2. Enables streaming in completePrompt, which is used by Commit Message generation, Terminal Command creation, and Prompt enhancements.

From what I can tell, these are the only places in the code base that call completePrompt, and are also Kilo-specific features. (Not available in upstream Roo, where this provider was cherry picked from)

These features are currently broken, returning one one of two errors:

A lack of instructions:
<img width="958" height="302" alt="image" src="https://github.com/user-attachments/assets/4323ce00-3c62-4b5f-b10e-adb8614f5912" />

If you fix that, you end up with: 
<img width="944" height="302" alt="image" src="https://github.com/user-attachments/assets/c2c4f5f7-8dd6-44ac-aea8-4e96510173e1" />
