### PR TITLE
Remove mcpButtonClicked from JetBrains plugin

### DIFF
--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/actions/VSCodeCommandActions.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/actions/VSCodeCommandActions.kt
@@ -62,25 +62,6 @@ class PromptsButtonClickAction : AnAction() {
 }
 
 /**
- * Action that handles clicks on the MCP button in the UI.
- * Executes the corresponding VSCode command when triggered.
- */
-class MCPButtonClickAction : AnAction() {
-    private val logger: Logger = Logger.getInstance(MCPButtonClickAction::class.java)
-    private val commandId: String = "kilo-code.mcpButtonClicked"
-
-    /**
-     * Performs the action when the MCP button is clicked.
-     *
-     * @param e The action event containing context information
-     */
-    override fun actionPerformed(e: AnActionEvent) {
-        logger.info("MCP button clicked")
-        executeCommand(commandId, e.project)
-    }
-}
-
-/**
  * Action that handles clicks on the History button in the UI.
  * Executes the corresponding VSCode command when triggered.
  */

--- a/jetbrains/plugin/src/main/resources/META-INF/plugin.xml.template
+++ b/jetbrains/plugin/src/main/resources/META-INF/plugin.xml.template
@@ -72,14 +72,6 @@ SPDX-License-Identifier: Apache-2.0
             <override-text place="GoToAction" text="New Task" />
         </action>
 
-        <action id="kilocode.mcpButtonClicked"
-                icon="AllIcons.Webreferences.Server"
-                class="ai.kilocode.jetbrains.actions.MCPButtonClickAction"
-                text="MCP Server"
-                description="MCP server">
-            <override-text place="GoToAction" text="MCP Server" />
-        </action>
-
         <action id="kilocode.historyButtonClicked"
                 icon="AllIcons.Vcs.History"
                 class="ai.kilocode.jetbrains.actions.HistoryButtonClickAction"
@@ -114,7 +106,6 @@ SPDX-License-Identifier: Apache-2.0
 
         <group id="WecoderToolbarGroup">
             <reference ref="kilocode.plusButtonClicked" />
-            <reference ref="kilocode.mcpButtonClicked" />
             <reference ref="kilocode.historyButtonClicked" />
             <reference ref="kilocode.profileButtonClicked" />
             <reference ref="kilocode.settingsButtonClicked" />


### PR DESCRIPTION
The mcpButtonClicked command was removed from VSCode in PR #5264. This removes the corresponding action from the JetBrains plugin to maintain consistency between the two platforms.

## Changes
- Removed `MCPButtonClickAction` class from VSCodeCommandActions.kt
- Removed the `kilocode.mcpButtonClicked` action definition from plugin.xml.template
- Removed the reference to `kilocode.mcpButtonClicked` from the WecoderToolbarGroup

Spotted by @kevinvandijk ; I think this should be the fix but I currently don't have the setup to test this, can you verify @catrielmuller ?