### PR TITLE
fix: memoize keybinding command IDs to prevent infinite re-render loop

### DIFF
--- a/webview-ui/src/components/kilocode/settings/GhostServiceSettings.tsx
+++ b/webview-ui/src/components/kilocode/settings/GhostServiceSettings.tsx
@@ -28,6 +28,7 @@ type GhostServiceSettingsViewProps = HTMLAttributes<HTMLDivElement> & {
 
 // Get the list of supported provider keys from AUTOCOMPLETE_PROVIDER_MODELS
 const SUPPORTED_AUTOCOMPLETE_PROVIDER_KEYS = Array.from(AUTOCOMPLETE_PROVIDER_MODELS.keys())
+const GHOST_SERVICE_KEYBINDING_COMMAND_IDS = ["kilo-code.ghost.generateSuggestions"]
 
 export const GhostServiceSettingsView = ({
 	ghostServiceSettings,
@@ -45,8 +46,7 @@ export const GhostServiceSettingsView = ({
 		model,
 		hasKilocodeProfileWithNoBalance,
 	} = ghostServiceSettings || {}
-	const keybindingCommandIds = useMemo(() => ["kilo-code.ghost.generateSuggestions"], [])
-	const keybindings = useKeybindings(keybindingCommandIds)
+	const keybindings = useKeybindings(GHOST_SERVICE_KEYBINDING_COMMAND_IDS)
 	const [snoozeDuration, setSnoozeDuration] = useState<number>(300)
 	const [currentTime, setCurrentTime] = useState<number>(Date.now())
 

--- a/webview-ui/src/components/kilocode/settings/GhostServiceSettings.tsx
+++ b/webview-ui/src/components/kilocode/settings/GhostServiceSettings.tsx
@@ -45,7 +45,8 @@ export const GhostServiceSettingsView = ({
 		model,
 		hasKilocodeProfileWithNoBalance,
 	} = ghostServiceSettings || {}
-	const keybindings = useKeybindings(["kilo-code.ghost.generateSuggestions"])
+	const keybindingCommandIds = useMemo(() => ["kilo-code.ghost.generateSuggestions"], [])
+	const keybindings = useKeybindings(keybindingCommandIds)
 	const [snoozeDuration, setSnoozeDuration] = useState<number>(300)
 	const [currentTime, setCurrentTime] = useState<number>(Date.now())
 


### PR DESCRIPTION
## Summary

Fixes #5268 - High CPU usage on Autocomplete Tab

## Problem

When switching to the Autocomplete settings tab, CPU usage spiked to 100% (single core) due to an infinite re-render loop.

The `useKeybindings` hook was called with an inline array literal:
```typescript
const keybindings = useKeybindings(["kilo-code.ghost.generateSuggestions"])
```

Since arrays are compared by reference in JavaScript, a new array was created on every render. The `useKeybindings` hook uses `commandIds` as a `useEffect` dependency, causing it to fire on every render:

1. Component renders
2. `useEffect` fires (new array reference)
3. `postMessage` sent to extension host
4. Response received, `setState` called
5. Component re-renders → goto 1

## Solution

Memoize the command IDs array so it maintains a stable reference across renders:

```typescript
const keybindingCommandIds = useMemo(() => ["kilo-code.ghost.generateSuggestions"], [])
const keybindings = useKeybindings(keybindingCommandIds)
```

## Testing

- All 15 existing GhostServiceSettings tests pass
- Lint and type checks pass