### PR TITLE
Fix Agent Behaviour tabs wrapping on small screens

### DIFF
--- a/.changeset/fix-agent-behaviour-tabs-wrap.md
+++ b/.changeset/fix-agent-behaviour-tabs-wrap.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Agent Behaviour tabs wrapping on small screens

--- a/.changeset/fix-agent-behaviour-tabs-wrap.md
+++ b/.changeset/fix-agent-behaviour-tabs-wrap.md
@@ -1,5 +1,0 @@
----
-"kilo-code": patch
----
-
-Fix Agent Behaviour tabs wrapping on small screens

--- a/webview-ui/src/components/kilocode/settings/AgentBehaviourView.tsx
+++ b/webview-ui/src/components/kilocode/settings/AgentBehaviourView.tsx
@@ -55,13 +55,7 @@ const AgentBehaviourView = () => {
 
 			<Section>
 				{/* Tab buttons */}
-				<div
-					style={{
-						display: "flex",
-						gap: "1px",
-						padding: "0 20px 0 20px",
-						borderBottom: "1px solid var(--vscode-panel-border)",
-					}}>
+				<div className="flex flex-wrap gap-[1px] px-5 border-b border-vscode-panel-border">
 					<TabButton isActive={activeTab === "modes"} onClick={() => setActiveTab("modes")}>
 						{t("settings:sections.modes")}
 					</TabButton>
@@ -80,7 +74,7 @@ const AgentBehaviourView = () => {
 				</div>
 
 				{/* Content */}
-				<div style={{ width: "100%" }}>
+				<div className="w-full">
 					{activeTab === "modes" && <ModesView hideHeader />}
 					{activeTab === "mcp" && <McpView hideHeader onDone={() => {}} />}
 					{activeTab === "rules" && <KiloRulesWorkflowsView type="rule" />}


### PR DESCRIPTION
The tabs in the Agent Behaviour settings view (Modes, MCP Servers, Rules, Workflows) were getting cut off on smaller screens. This change adds `flex-wrap` to allow tabs to wrap to multiple lines when the container is too narrow.