### PR TITLE
Add loading spinner to agent manager API request messages

### DIFF
--- a/.changeset/agent-manager-api-request-spinner.md
+++ b/.changeset/agent-manager-api-request-spinner.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add loading spinner to agent manager API request messages

--- a/webview-ui/src/kilocode/agent-manager/components/MessageList.tsx
+++ b/webview-ui/src/kilocode/agent-manager/components/MessageList.tsx
@@ -17,6 +17,7 @@ import { combineCommandSequences } from "@roo/combineCommandSequences"
 import { SimpleMarkdown } from "./SimpleMarkdown"
 import { FollowUpSuggestions } from "./FollowUpSuggestions"
 import { CommandExecutionBlock } from "./CommandExecutionBlock"
+import { ProgressIndicator } from "./ProgressIndicator"
 import { vscode } from "../utils/vscode"
 import {
 	MessageCircle,
@@ -249,11 +250,17 @@ function MessageItem({ message, isLast, commandExecutionByTs, onSuggestionClick,
 	if (message.type === "say") {
 		switch (message.say) {
 			case "api_req_started": {
-				icon = <ArrowRightLeft size={16} className="opacity-70" />
 				title = t("messages.apiRequest")
 				const info = safeJsonParse<{ cost?: number }>(messageText)
-				if (info?.cost !== undefined) {
-					extraInfo = <span className="am-message-cost">${info.cost.toFixed(4)}</span>
+				const hasCost = info?.cost !== undefined && info.cost !== null
+				// Show spinner when this is the last message and no cost yet (API request in progress)
+				if (hasCost) {
+					icon = <ArrowRightLeft size={16} className="opacity-70" />
+					extraInfo = <span className="am-message-cost">${info.cost!.toFixed(4)}</span>
+				} else if (isLast) {
+					icon = <ProgressIndicator />
+				} else {
+					icon = <ArrowRightLeft size={16} className="opacity-70" />
 				}
 				// Don't show content for API req started, just header
 				content = null

--- a/webview-ui/src/kilocode/agent-manager/components/ProgressIndicator.tsx
+++ b/webview-ui/src/kilocode/agent-manager/components/ProgressIndicator.tsx
@@ -1,0 +1,16 @@
+import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react"
+
+export const ProgressIndicator = () => (
+	<div
+		style={{
+			width: "16px",
+			height: "16px",
+			display: "flex",
+			alignItems: "center",
+			justifyContent: "center",
+		}}>
+		<div style={{ transform: "scale(0.55)", transformOrigin: "center" }}>
+			<VSCodeProgressRing />
+		</div>
+	</div>
+)


### PR DESCRIPTION
## Summary

Adds a loading spinner to the agent manager's API request messages, matching the behavior of the sidebar extension.

## Changes

1. **Created `webview-ui/src/kilocode/agent-manager/components/ProgressIndicator.tsx`** - A local copy of the sidebar's `ProgressIndicator` component using `VSCodeProgressRing`. This keeps the agent-manager self-contained and avoids cross-directory dependencies with upstream code.

2. **Modified `webview-ui/src/kilocode/agent-manager/components/MessageList.tsx`** - Updated the `api_req_started` case to show `<ProgressIndicator />` when the message is the last one and has no cost yet (API request in progress), matching the sidebar's behavior.

## Why a local copy?

The `ProgressIndicator` component is copied locally rather than imported from `../../../components/chat/` because:
- The agent-manager is Kilo-specific code that won't be merged upstream
- Avoids creating dependencies from Kilo-specific code to shared/upstream code
- The component is only 16 lines, so duplication is minimal
- Allows independent evolution if needed

<img width="556" height="196" alt="image" src="https://github.com/user-attachments/assets/fe52aad8-878d-4d60-986e-dd275cca4669" />