### PR TITLE
feat(agent-manager): display reasoning as collapsible block

### DIFF
--- a/.changeset/reasoning-block-agent-manager.md
+++ b/.changeset/reasoning-block-agent-manager.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Display reasoning as collapsible block in Agent Manager instead of plain text

--- a/webview-ui/src/i18n/locales/ar/agentManager.json
+++ b/webview-ui/src/i18n/locales/ar/agentManager.json
@@ -79,7 +79,9 @@
 		"usingTool": "استخدام الأداة: **{{tool}}** {{details}}",
 		"expandOutput": "توسيع المخرجات",
 		"collapseOutput": "طي المخرجات",
-		"copyCommand": "نسخ الأمر"
+		"copyCommand": "نسخ الأمر",
+		"thinking": "يفكّر",
+		"thinkingSeconds": "{{count}}ث"
 	},
 	"chatInput": {
 		"autoMode": "الوكيل يعمل في وضع الأتمتة الكاملة - لا يُسمح بالإدخال",

--- a/webview-ui/src/i18n/locales/ca/agentManager.json
+++ b/webview-ui/src/i18n/locales/ca/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "Utilitzant eina: **{{tool}}** {{details}}",
 		"expandOutput": "Expandir sortida",
 		"collapseOutput": "Replegar sortida",
-		"copyCommand": "Copiar comanda"
+		"copyCommand": "Copiar comanda",
+		"thinking": "Pensant",
+		"thinkingSeconds": "{{count}}s"
 	},
 	"chatInput": {
 		"autoMode": "Agent en mode automàtic complet - no es permet entrada",

--- a/webview-ui/src/i18n/locales/cs/agentManager.json
+++ b/webview-ui/src/i18n/locales/cs/agentManager.json
@@ -76,7 +76,9 @@
 		"usingTool": "Používání nástroje: **{{tool}}** {{details}}",
 		"expandOutput": "Rozbalit výstup",
 		"collapseOutput": "Sbalit výstup",
-		"copyCommand": "Kopírovat příkaz"
+		"copyCommand": "Kopírovat příkaz",
+		"thinking": "Přemýšlení",
+		"thinkingSeconds": "{{count}}s"
 	},
 	"chatInput": {
 		"autoMode": "Agent běží v plně automatickém režimu - vstup není povolen",

--- a/webview-ui/src/i18n/locales/de/agentManager.json
+++ b/webview-ui/src/i18n/locales/de/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "Verwende Werkzeug: **{{tool}}** {{details}}",
 		"expandOutput": "Ausgabe erweitern",
 		"collapseOutput": "Ausgabe einklappen",
-		"copyCommand": "Befehl kopieren"
+		"copyCommand": "Befehl kopieren",
+		"thinking": "Denke nach",
+		"thinkingSeconds": "{{count}}s"
 	},
 	"chatInput": {
 		"autoMode": "Agent läuft im Vollautomatik-Modus - keine Eingabe möglich",

--- a/webview-ui/src/i18n/locales/en/agentManager.json
+++ b/webview-ui/src/i18n/locales/en/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "Using tool: **{{tool}}** {{details}}",
 		"expandOutput": "Expand output",
 		"collapseOutput": "Collapse output",
-		"copyCommand": "Copy command"
+		"copyCommand": "Copy command",
+		"thinking": "Thinking",
+		"thinkingSeconds": "{{count}}s"
 	},
 	"chatInput": {
 		"autoMode": "Agent running in full-auto mode - no input allowed",

--- a/webview-ui/src/i18n/locales/es/agentManager.json
+++ b/webview-ui/src/i18n/locales/es/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "Usando herramienta: **{{tool}}** {{details}}",
 		"expandOutput": "Expandir salida",
 		"collapseOutput": "Colapsar salida",
-		"copyCommand": "Copiar comando"
+		"copyCommand": "Copiar comando",
+		"thinking": "Pensando",
+		"thinkingSeconds": "{{count}}s"
 	},
 	"chatInput": {
 		"autoMode": "Agente ejecutándose en modo totalmente automático - no se permite entrada",

--- a/webview-ui/src/i18n/locales/fr/agentManager.json
+++ b/webview-ui/src/i18n/locales/fr/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "Utilisation de l'outil : **{{tool}}** {{details}}",
 		"expandOutput": "Développer la sortie",
 		"collapseOutput": "Réduire la sortie",
-		"copyCommand": "Copier la commande"
+		"copyCommand": "Copier la commande",
+		"thinking": "Réflexion",
+		"thinkingSeconds": "{{count}}s"
 	},
 	"chatInput": {
 		"autoMode": "Agent en mode entièrement automatique - aucune entrée autorisée",

--- a/webview-ui/src/i18n/locales/hi/agentManager.json
+++ b/webview-ui/src/i18n/locales/hi/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "टूल का उपयोग: **{{tool}}** {{details}}",
 		"expandOutput": "आउटपुट विस्तार करें",
 		"collapseOutput": "आउटपुट संक्षिप्त करें",
-		"copyCommand": "कमांड कॉपी करें"
+		"copyCommand": "कमांड कॉपी करें",
+		"thinking": "विचार कर रहा है",
+		"thinkingSeconds": "{{count}} सेकंड"
 	},
 	"chatInput": {
 		"autoMode": "एजेंट पूर्ण-स्वचालित मोड में चल रहा है - इनपुट की अनुमति नहीं है",

--- a/webview-ui/src/i18n/locales/id/agentManager.json
+++ b/webview-ui/src/i18n/locales/id/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "Menggunakan alat: **{{tool}}** {{details}}",
 		"expandOutput": "Perluas output",
 		"collapseOutput": "Ciutkan output",
-		"copyCommand": "Salin perintah"
+		"copyCommand": "Salin perintah",
+		"thinking": "Berpikir",
+		"thinkingSeconds": "{{count}}d"
 	},
 	"chatInput": {
 		"autoMode": "Agen berjalan dalam mode otomatis penuh - input tidak diizinkan",

--- a/webview-ui/src/i18n/locales/it/agentManager.json
+++ b/webview-ui/src/i18n/locales/it/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "Utilizzo strumento: **{{tool}}** {{details}}",
 		"expandOutput": "Espandi output",
 		"collapseOutput": "Comprimi output",
-		"copyCommand": "Copia comando"
+		"copyCommand": "Copia comando",
+		"thinking": "Pensando",
+		"thinkingSeconds": "{{count}}s"
 	},
 	"chatInput": {
 		"autoMode": "Agent in esecuzione in modalità completamente automatica - input non consentito",

--- a/webview-ui/src/i18n/locales/ja/agentManager.json
+++ b/webview-ui/src/i18n/locales/ja/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "ツールを使用中: **{{tool}}** {{details}}",
 		"expandOutput": "出力を展開",
 		"collapseOutput": "出力を折りたたむ",
-		"copyCommand": "コマンドをコピー"
+		"copyCommand": "コマンドをコピー",
+		"thinking": "思考中",
+		"thinkingSeconds": "{{count}}秒"
 	},
 	"chatInput": {
 		"autoMode": "エージェントが完全自動モードで実行中 - 入力はできません",

--- a/webview-ui/src/i18n/locales/ko/agentManager.json
+++ b/webview-ui/src/i18n/locales/ko/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "도구 사용 중: **{{tool}}** {{details}}",
 		"expandOutput": "출력 펼치기",
 		"collapseOutput": "출력 접기",
-		"copyCommand": "명령 복사"
+		"copyCommand": "명령 복사",
+		"thinking": "생각 중",
+		"thinkingSeconds": "{{count}}초"
 	},
 	"chatInput": {
 		"autoMode": "에이전트가 완전 자동 모드로 실행 중 - 입력이 허용되지 않습니다",

--- a/webview-ui/src/i18n/locales/nl/agentManager.json
+++ b/webview-ui/src/i18n/locales/nl/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "Tool gebruiken: **{{tool}}** {{details}}",
 		"expandOutput": "Uitvoer uitvouwen",
 		"collapseOutput": "Uitvoer invouwen",
-		"copyCommand": "Opdracht kopiëren"
+		"copyCommand": "Opdracht kopiëren",
+		"thinking": "Denkt na",
+		"thinkingSeconds": "{{count}}s"
 	},
 	"chatInput": {
 		"autoMode": "Agent draait in volledig automatische modus - geen invoer toegestaan",

--- a/webview-ui/src/i18n/locales/pl/agentManager.json
+++ b/webview-ui/src/i18n/locales/pl/agentManager.json
@@ -77,7 +77,9 @@
 		"usingTool": "Używanie narzędzia: **{{tool}}** {{details}}",
 		"expandOutput": "Rozwiń wyjście",
 		"collapseOutput": "Zwiń wyjście",
-		"copyCommand": "Kopiuj polecenie"
+		"copyCommand": "Kopiuj polecenie",
+		"thinking": "Myślenie",
+		"thinkingSeconds": "{{count}}s"
 	},
 	"chatInput": {
 		"autoMode": "Agent działa w trybie w pełni automatycznym - wprowadzanie danych niemożliwe",

--- a/webview-ui/src/i18n/locales/pt-BR/agentManager.json
+++ b/webview-ui/src/i18n/locales/pt-BR/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "Usando ferramenta: **{{tool}}** {{details}}",
 		"expandOutput": "Expandir saída",
 		"collapseOutput": "Recolher saída",
-		"copyCommand": "Copiar comando"
+		"copyCommand": "Copiar comando",
+		"thinking": "Pensando",
+		"thinkingSeconds": "{{count}}s"
 	},
 	"chatInput": {
 		"autoMode": "Agente executando em modo totalmente automático - entrada não permitida",

--- a/webview-ui/src/i18n/locales/ru/agentManager.json
+++ b/webview-ui/src/i18n/locales/ru/agentManager.json
@@ -77,7 +77,9 @@
 		"usingTool": "Использование инструмента: **{{tool}}** {{details}}",
 		"expandOutput": "Развернуть вывод",
 		"collapseOutput": "Свернуть вывод",
-		"copyCommand": "Копировать команду"
+		"copyCommand": "Копировать команду",
+		"thinking": "Обдумывание",
+		"thinkingSeconds": "{{count}}с"
 	},
 	"chatInput": {
 		"autoMode": "Агент работает в полностью автоматическом режиме - ввод запрещён",

--- a/webview-ui/src/i18n/locales/th/agentManager.json
+++ b/webview-ui/src/i18n/locales/th/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "กำลังใช้เครื่องมือ: **{{tool}}** {{details}}",
 		"expandOutput": "ขยายผลลัพธ์",
 		"collapseOutput": "ยุบผลลัพธ์",
-		"copyCommand": "คัดลอกคำสั่ง"
+		"copyCommand": "คัดลอกคำสั่ง",
+		"thinking": "กำลังคิด",
+		"thinkingSeconds": "{{count}} วินาที"
 	},
 	"chatInput": {
 		"autoMode": "เอเจนต์กำลังทำงานในโหมดอัตโนมัติเต็มรูปแบบ - ไม่อนุญาตให้ป้อนข้อมูล",

--- a/webview-ui/src/i18n/locales/tr/agentManager.json
+++ b/webview-ui/src/i18n/locales/tr/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "Araç kullanılıyor: **{{tool}}** {{details}}",
 		"expandOutput": "Çıktıyı genişlet",
 		"collapseOutput": "Çıktıyı daralt",
-		"copyCommand": "Komutu kopyala"
+		"copyCommand": "Komutu kopyala",
+		"thinking": "Düşünüyor",
+		"thinkingSeconds": "{{count}}sn"
 	},
 	"chatInput": {
 		"autoMode": "Agent tam otomatik modda çalışıyor - girişe izin verilmiyor",

--- a/webview-ui/src/i18n/locales/uk/agentManager.json
+++ b/webview-ui/src/i18n/locales/uk/agentManager.json
@@ -77,7 +77,9 @@
 		"usingTool": "Використання інструменту: **{{tool}}** {{details}}",
 		"expandOutput": "Розгорнути вивід",
 		"collapseOutput": "Згорнути вивід",
-		"copyCommand": "Копіювати команду"
+		"copyCommand": "Копіювати команду",
+		"thinking": "Думаю",
+		"thinkingSeconds": "{{count}}с"
 	},
 	"chatInput": {
 		"autoMode": "Агент працює в повністю автоматичному режимі - введення заборонено",

--- a/webview-ui/src/i18n/locales/vi/agentManager.json
+++ b/webview-ui/src/i18n/locales/vi/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "Đang sử dụng công cụ: **{{tool}}** {{details}}",
 		"expandOutput": "Mở rộng đầu ra",
 		"collapseOutput": "Thu gọn đầu ra",
-		"copyCommand": "Sao chép lệnh"
+		"copyCommand": "Sao chép lệnh",
+		"thinking": "Đang suy nghĩ",
+		"thinkingSeconds": "{{count}}s"
 	},
 	"chatInput": {
 		"autoMode": "Agent đang chạy ở chế độ tự động hoàn toàn - không cho phép nhập",

--- a/webview-ui/src/i18n/locales/zh-CN/agentManager.json
+++ b/webview-ui/src/i18n/locales/zh-CN/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "正在使用工具：**{{tool}}** {{details}}",
 		"expandOutput": "展开输出",
 		"collapseOutput": "收起输出",
-		"copyCommand": "复制命令"
+		"copyCommand": "复制命令",
+		"thinking": "思考中",
+		"thinkingSeconds": "{{count}}秒"
 	},
 	"chatInput": {
 		"autoMode": "Agent 正在全自动模式下运行 - 不允许输入",

--- a/webview-ui/src/i18n/locales/zh-TW/agentManager.json
+++ b/webview-ui/src/i18n/locales/zh-TW/agentManager.json
@@ -75,7 +75,9 @@
 		"usingTool": "正在使用工具：**{{tool}}** {{details}}",
 		"expandOutput": "展開輸出",
 		"collapseOutput": "收合輸出",
-		"copyCommand": "複製指令"
+		"copyCommand": "複製指令",
+		"thinking": "思考中",
+		"thinkingSeconds": "{{count}} 秒"
 	},
 	"chatInput": {
 		"autoMode": "Agent 正在全自動模式下執行 - 不允許輸入",

--- a/webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css
+++ b/webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css
@@ -495,6 +495,61 @@
 	border-radius: 3px;
 }
 
+/* Reasoning Block */
+.am-reasoning-block {
+	padding: 10px 20px;
+}
+
+.am-reasoning-block:hover {
+	background-color: var(--vscode-list-hoverBackground);
+}
+
+.am-reasoning-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	cursor: pointer;
+	user-select: none;
+	padding-right: 8px;
+}
+
+.am-reasoning-title {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	color: var(--vscode-foreground);
+}
+
+.am-reasoning-elapsed {
+	font-size: calc(var(--vscode-font-size) * 0.85);
+	color: var(--vscode-descriptionForeground);
+	margin-top: 1px;
+}
+
+.am-reasoning-content {
+	border-left: 1px solid var(--vscode-descriptionForeground);
+	margin-left: 8px;
+	margin-top: 10px;
+	padding-left: 16px;
+	padding-bottom: 4px;
+	color: var(--vscode-descriptionForeground);
+	opacity: 0.8;
+}
+
+.am-reasoning-chevron {
+	transition: transform 0.2s;
+	opacity: 0;
+	color: var(--vscode-descriptionForeground);
+}
+
+.am-reasoning-block:hover .am-reasoning-chevron {
+	opacity: 1;
+}
+
+.am-reasoning-chevron.am-collapsed {
+	transform: rotate(180deg);
+}
+
 /* Forms */
 .am-center-form {
 	display: flex;

--- a/webview-ui/src/kilocode/agent-manager/components/MessageList.tsx
+++ b/webview-ui/src/kilocode/agent-manager/components/MessageList.tsx
@@ -17,6 +17,7 @@ import { combineCommandSequences } from "@roo/combineCommandSequences"
 import { SimpleMarkdown } from "./SimpleMarkdown"
 import { FollowUpSuggestions } from "./FollowUpSuggestions"
 import { CommandExecutionBlock } from "./CommandExecutionBlock"
+import { ReasoningBlock } from "./ReasoningBlock"
 import { vscode } from "../utils/vscode"
 import {
 	MessageCircle,
@@ -282,6 +283,17 @@ function MessageItem({ message, isLast, commandExecutionByTs, onSuggestionClick,
 				title = t("messages.error")
 				content = <SimpleMarkdown content={messageText} />
 				break
+			}
+			case "reasoning": {
+				// Return early - reasoning block has its own wrapper
+				return (
+					<ReasoningBlock
+						content={messageText}
+						ts={message.ts}
+						isStreaming={message.partial ?? false}
+						isLast={isLast}
+					/>
+				)
 			}
 			case "api_req_finished":
 			case "checkpoint_saved":

--- a/webview-ui/src/kilocode/agent-manager/components/ReasoningBlock.tsx
+++ b/webview-ui/src/kilocode/agent-manager/components/ReasoningBlock.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Lightbulb, ChevronUp } from "lucide-react"
+import { cn } from "../../../lib/utils"
+import { SimpleMarkdown } from "./SimpleMarkdown"
+
+interface ReasoningBlockProps {
+	content: string
+	ts: number
+	isStreaming: boolean
+	isLast: boolean
+}
+
+export const ReasoningBlock: React.FC<ReasoningBlockProps> = ({ content, ts: _ts, isStreaming, isLast }) => {
+	const { t } = useTranslation("agentManager")
+	const [isCollapsed, setIsCollapsed] = useState(true) // Default collapsed
+	const startTimeRef = useRef<number>(Date.now())
+	const [elapsed, setElapsed] = useState<number>(0)
+
+	useEffect(() => {
+		if (isLast && isStreaming) {
+			const tick = () => setElapsed(Date.now() - startTimeRef.current)
+			tick()
+			const id = setInterval(tick, 1000)
+			return () => clearInterval(id)
+		}
+	}, [isLast, isStreaming])
+
+	const seconds = Math.floor(elapsed / 1000)
+	const secondsLabel = t("messages.thinkingSeconds", { count: seconds })
+
+	const handleToggle = () => {
+		setIsCollapsed(!isCollapsed)
+	}
+
+	return (
+		<div className="am-reasoning-block group">
+			<div className="am-reasoning-header" onClick={handleToggle}>
+				<div className="am-reasoning-title">
+					<Lightbulb size={16} />
+					<span className="font-bold">{t("messages.thinking")}</span>
+					{elapsed > 0 && <span className="am-reasoning-elapsed">{secondsLabel}</span>}
+				</div>
+				<ChevronUp size={16} className={cn("am-reasoning-chevron", isCollapsed && "am-collapsed")} />
+			</div>
+			{(content?.trim()?.length ?? 0) > 0 && !isCollapsed && (
+				<div className="am-reasoning-content">
+					<SimpleMarkdown content={content} />
+				</div>
+			)}
+		</div>
+	)
+}

--- a/webview-ui/src/kilocode/agent-manager/components/__tests__/ReasoningBlock.spec.tsx
+++ b/webview-ui/src/kilocode/agent-manager/components/__tests__/ReasoningBlock.spec.tsx
@@ -1,0 +1,112 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import { ReasoningBlock } from "../ReasoningBlock"
+
+// Mock react-i18next
+vi.mock("react-i18next", () => ({
+	useTranslation: () => ({
+		t: (key: string, options?: { count?: number }) => {
+			if (key === "messages.thinking") return "Thinking"
+			if (key === "messages.thinkingSeconds") return `${options?.count}s`
+			return key
+		},
+	}),
+}))
+
+describe("ReasoningBlock", () => {
+	const defaultProps = {
+		content: "This is the reasoning content",
+		ts: Date.now(),
+		isStreaming: false,
+		isLast: false,
+	}
+
+	it("renders with thinking title", () => {
+		render(<ReasoningBlock {...defaultProps} />)
+		expect(screen.getByText("Thinking")).toBeInTheDocument()
+	})
+
+	it("is collapsed by default", () => {
+		render(<ReasoningBlock {...defaultProps} />)
+		expect(screen.queryByText("This is the reasoning content")).not.toBeInTheDocument()
+	})
+
+	it("expands when header is clicked", () => {
+		render(<ReasoningBlock {...defaultProps} />)
+
+		// Click the header to expand
+		const header = screen.getByText("Thinking").closest(".am-reasoning-header")
+		expect(header).toBeInTheDocument()
+		fireEvent.click(header!)
+
+		// Content should now be visible
+		expect(screen.getByText("This is the reasoning content")).toBeInTheDocument()
+	})
+
+	it("collapses when header is clicked again", () => {
+		render(<ReasoningBlock {...defaultProps} />)
+
+		const header = screen.getByText("Thinking").closest(".am-reasoning-header")
+
+		// Expand
+		fireEvent.click(header!)
+		expect(screen.getByText("This is the reasoning content")).toBeInTheDocument()
+
+		// Collapse
+		fireEvent.click(header!)
+		expect(screen.queryByText("This is the reasoning content")).not.toBeInTheDocument()
+	})
+
+	it("does not show elapsed time when not streaming", () => {
+		render(<ReasoningBlock {...defaultProps} isStreaming={false} isLast={true} />)
+		expect(screen.queryByText(/\d+s/)).not.toBeInTheDocument()
+	})
+
+	it("does not render content when content is empty", () => {
+		const { container } = render(<ReasoningBlock {...defaultProps} content="" />)
+
+		// Expand
+		const header = screen.getByText("Thinking").closest(".am-reasoning-header")
+		fireEvent.click(header!)
+
+		// No content div should be rendered
+		expect(container.querySelector(".am-reasoning-content")).not.toBeInTheDocument()
+	})
+
+	it("does not render content when content is whitespace only", () => {
+		const { container } = render(<ReasoningBlock {...defaultProps} content="   " />)
+
+		// Expand
+		const header = screen.getByText("Thinking").closest(".am-reasoning-header")
+		fireEvent.click(header!)
+
+		// No content div should be rendered
+		expect(container.querySelector(".am-reasoning-content")).not.toBeInTheDocument()
+	})
+
+	it("has correct CSS classes", () => {
+		const { container } = render(<ReasoningBlock {...defaultProps} />)
+
+		expect(container.querySelector(".am-reasoning-block")).toBeInTheDocument()
+		expect(container.querySelector(".am-reasoning-header")).toBeInTheDocument()
+		expect(container.querySelector(".am-reasoning-title")).toBeInTheDocument()
+		expect(container.querySelector(".am-reasoning-chevron")).toBeInTheDocument()
+	})
+
+	it("chevron has collapsed class when collapsed", () => {
+		const { container } = render(<ReasoningBlock {...defaultProps} />)
+
+		const chevron = container.querySelector(".am-reasoning-chevron")
+		expect(chevron).toHaveClass("am-collapsed")
+	})
+
+	it("chevron does not have collapsed class when expanded", () => {
+		const { container } = render(<ReasoningBlock {...defaultProps} />)
+
+		// Expand
+		const header = screen.getByText("Thinking").closest(".am-reasoning-header")
+		fireEvent.click(header!)
+
+		const chevron = container.querySelector(".am-reasoning-chevron")
+		expect(chevron).not.toHaveClass("am-collapsed")
+	})
+})


### PR DESCRIPTION
## Summary

When using reasoning models in the Agent Manager, the reasoning/thinking content was displayed as a regular message with "Kilo said" title. This PR renders it as a collapsible "Thinking" block with a lightbulb icon, matching the main extension sidebar's behavior.

## Changes

### New Files
- `webview-ui/src/kilocode/agent-manager/components/ReasoningBlock.tsx` - Collapsible reasoning block component
- `webview-ui/src/kilocode/agent-manager/components/__tests__/ReasoningBlock.spec.tsx` - Test suite (10 tests)

### Modified Files
- `webview-ui/src/kilocode/agent-manager/components/MessageList.tsx` - Added `case "reasoning":` handler
- `webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css` - Added `.am-reasoning-*` CSS styles
- 15 translation files - Added `thinking` and `thinkingSeconds` keys

## Features
- Lightbulb icon and "Thinking" title
- Collapsed by default
- Click-to-toggle functionality
- Elapsed time display during streaming
- Chevron indicator that rotates based on state
- Hover to reveal chevron

## Testing
- All 10 unit tests pass
- Type check passes
- Lint passes
- Manual testing confirmed working


<img width="679" height="279" alt="image" src="https://github.com/user-attachments/assets/8bf1523f-6762-4e0d-8711-d8f1cadf03c5" />

<img width="1454" height="254" alt="image" src="https://github.com/user-attachments/assets/1dddb045-8e2c-444a-a9bb-648e797e1ce9" />

