### PR TITLE
Fix model selection not showing in resumed sessions in Agent Manager

### DIFF
--- a/.changeset/fix-model-selection-resumed-sessions.md
+++ b/.changeset/fix-model-selection-resumed-sessions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix model selection not showing in resumed sessions in Agent Manager

--- a/src/core/kilocode/agent-manager/AgentManagerProvider.ts
+++ b/src/core/kilocode/agent-manager/AgentManagerProvider.ts
@@ -1334,6 +1334,7 @@ export class AgentManagerProvider implements vscode.Disposable {
 					effectiveWorkspace: worktreeInfo.path,
 					images,
 					sessionData,
+					model: session.model,
 				})
 				return
 			}
@@ -1349,6 +1350,7 @@ export class AgentManagerProvider implements vscode.Disposable {
 			gitUrl: session?.gitUrl,
 			images,
 			sessionData,
+			model: session?.model,
 		})
 	}
 

--- a/webview-ui/src/kilocode/agent-manager/state/atoms/sessions.ts
+++ b/webview-ui/src/kilocode/agent-manager/state/atoms/sessions.ts
@@ -47,6 +47,7 @@ export interface RemoteSession {
 	created_at: string
 	updated_at: string
 	git_url?: string
+	last_model?: string | null
 }
 
 // Core atoms
@@ -114,6 +115,7 @@ function toAgentSession(remote: RemoteSession): AgentSession {
 		endTime: Number.isNaN(updatedTime) ? 0 : updatedTime,
 		source: "remote",
 		gitUrl: remote.git_url,
+		model: remote.last_model ?? undefined,
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the issue where the model selection dropdown was not showing in resumed sessions in the Agent Manager.

## Root Causes

### Issue 1: Backend - Model not passed when resuming sessions
The `resumeSession` method in `AgentManagerProvider.ts` wasn't passing the `model` to `spawnAgentWithCommonSetup`, so when a session was resumed, the model information was lost.

### Issue 2: Frontend - Remote sessions missing model field
The webview's `RemoteSession` interface was missing the `last_model` field that comes from the API. When selecting a remote session (before resuming), the model selector couldn't display the model because the field wasn't being mapped.

## Changes

### `src/core/kilocode/agent-manager/AgentManagerProvider.ts`
- Added `model: session.model` to the parallel mode (worktree) resume path
- Added `model: session?.model` to the non-parallel mode resume path

### `webview-ui/src/kilocode/agent-manager/state/atoms/sessions.ts`
- Added `last_model?: string | null` to the `RemoteSession` interface
- Updated `toAgentSession` to map `remote.last_model` to `model`

## Testing

- All 51 backend tests pass
- All 10 webview session atom tests pass
- Manually verified that the model selector now shows correctly for resumed sessions