### PR TITLE
fix: use local agent-runtime build in F5 debug mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,8 @@
 			"preLaunchTask": "${defaultBuildTask}",
 			"env": {
 				"NODE_ENV": "development",
-				"VSCODE_DEBUG_MODE": "true"
+				"VSCODE_DEBUG_MODE": "true",
+				"KILOCODE_DEV_AGENT_RUNTIME_PATH": "${workspaceFolder}/dist/agent-runtime-process.js"
 			},
 			"resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
 			"presentation": {
@@ -40,7 +41,8 @@
 			"preLaunchTask": "${defaultBuildTask}",
 			"env": {
 				"NODE_ENV": "development",
-				"VSCODE_DEBUG_MODE": "true"
+				"VSCODE_DEBUG_MODE": "true",
+				"KILOCODE_DEV_AGENT_RUNTIME_PATH": "${workspaceFolder}/dist/agent-runtime-process.js"
 			},
 			"resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
 			"presentation": { "hidden": false, "group": "tasks", "order": 1 }
@@ -57,7 +59,8 @@
 			"env": {
 				"NODE_ENV": "development",
 				"VSCODE_DEBUG_MODE": "true",
-				"KILOCODE_BACKEND_BASE_URL": "${input:kilocodeBackendBaseUrl}"
+				"KILOCODE_BACKEND_BASE_URL": "${input:kilocodeBackendBaseUrl}",
+				"KILOCODE_DEV_AGENT_RUNTIME_PATH": "${workspaceFolder}/dist/agent-runtime-process.js"
 			},
 			"resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
 			"presentation": { "hidden": false, "group": "tasks", "order": 2 }

--- a/src/core/kilocode/agent-manager/RuntimeProcessHandler.ts
+++ b/src/core/kilocode/agent-manager/RuntimeProcessHandler.ts
@@ -165,6 +165,14 @@ export class RuntimeProcessHandler {
 	private getProcessEntryPath(): string {
 		const fs = require("fs")
 
+		// Development: Check for explicit dev path override (set in launch.json)
+		// This ensures F5 debugging uses the locally built agent-runtime from the current workspace
+		const devPath = process.env.KILOCODE_DEV_AGENT_RUNTIME_PATH
+		if (devPath && fs.existsSync(devPath)) {
+			this.callbacks.onLog(`Using dev agent-runtime process: ${devPath}`)
+			return devPath
+		}
+
 		// Production: Check for bundled file in extension's dist directory
 		// The esbuild config bundles agent-runtime/src/process.ts to dist/agent-runtime-process.js
 		if (this.extensionPath) {
@@ -516,8 +524,7 @@ export class RuntimeProcessHandler {
 		this.callbacks.onPendingSessionChanged(null)
 
 		// Pass resume info if this is a resumed session with history
-		const resumeInfo =
-			isResume && sessionData ? { prompt: capturedPrompt, images: images } : undefined
+		const resumeInfo = isResume && sessionData ? { prompt: capturedPrompt, images: images } : undefined
 		this.callbacks.onSessionCreated(false, resumeInfo)
 
 		// Send session_created event


### PR DESCRIPTION
## Problem

When running the extension via F5 debugging in a worktree, the `RuntimeProcessHandler.getProcessEntryPath()` method would find and use a potentially stale `dist/agent-runtime-process.js` from another worktree instead of the locally built one. This caused the error:

```
Failed to start agent session: Failed to load extension: Class extends value undefined is not a constructor or null
```

## Solution

Implemented the same pattern as `KILOCODE_DEV_CLI_PATH` (from commit `9809864ce5`):

1. **Added `KILOCODE_DEV_AGENT_RUNTIME_PATH` to `.vscode/launch.json`**
   - All three launch configurations now include this env var pointing to `${workspaceFolder}/dist/agent-runtime-process.js`

2. **Modified `RuntimeProcessHandler.getProcessEntryPath()`**
   - Added a check at the beginning of the method to use the dev path if the env var is set
   - This ensures F5 debugging uses the locally built agent-runtime from the current workspace

## How It Works

- When debugging via F5, the `preLaunchTask` runs `watch:bundle` which builds `dist/agent-runtime-process.js` in the current workspace
- The `KILOCODE_DEV_AGENT_RUNTIME_PATH` env var points to this locally built file
- `RuntimeProcessHandler` now checks this env var first, ensuring it uses the fresh local build
- Production users are unaffected (env var is not set, falls back to existing logic)

## Testing

- Type check passes
- Lint passes
- This is a development-only fix that doesn't affect production builds