### PR TITLE
feat(mcp): re-enable oauth resource parameter and add discovery logging

### DIFF
--- a/src/services/mcp/oauth/McpAuthorizationDiscovery.ts
+++ b/src/services/mcp/oauth/McpAuthorizationDiscovery.ts
@@ -158,6 +158,7 @@ export class McpAuthorizationDiscovery {
 			}
 		} catch (e) {
 			// Ignore and try next
+			console.warn(`Failed to fetch RFC 8414 metadata:`, e)
 		}
 
 		// Try OIDC Discovery
@@ -174,6 +175,7 @@ export class McpAuthorizationDiscovery {
 			}
 		} catch (e) {
 			// Ignore fetch errors
+			console.warn(`Failed to fetch OIDC metadata:`, e)
 		}
 
 		throw new Error(`Failed to discover authorization server metadata for ${issuerUrl}`)

--- a/src/services/mcp/oauth/McpOAuthService.ts
+++ b/src/services/mcp/oauth/McpOAuthService.ts
@@ -194,7 +194,7 @@ export class McpOAuthService {
 			state,
 			codeChallenge,
 			codeChallengeMethod: "S256",
-			// resource: serverUrl, // Disabled: Cloudflare doesn't support RFC 8707 resource parameter
+			resource: serverUrl,
 		})
 
 		// 5. Verify State


### PR DESCRIPTION
Addresses feedback in #5297 

- Re-enable the RFC 8707 resource parameter in the authorization URL
- Add warning logs to capture specific failures during RFC 8414 and OIDC metadata discovery to improve observability