### PR TITLE
fix: prevent RangeError invalid array length in vector stores

### DIFF
--- a/src/services/code-index/service-factory.ts
+++ b/src/services/code-index/service-factory.ts
@@ -152,7 +152,10 @@ export class CodeIndexServiceFactory {
 			vectorSize = config.modelDimension
 		}
 
-		if (vectorSize === undefined || vectorSize <= 0) {
+		if (vectorSize === undefined || vectorSize <= 0 || !Number.isFinite(vectorSize) || vectorSize > 100000) {
+			// kilocode_change start - Enhanced validation for issue #5325
+			console.error(`[CodeIndexServiceFactory] Invalid vectorSize: ${vectorSize} (type: ${typeof vectorSize}) for provider: ${provider}, modelId: ${modelId}`)
+			// kilocode_change end
 			if (provider === "openai-compatible") {
 				throw new Error(
 					t("embeddings:serviceFactory.vectorDimensionNotDeterminedOpenAiCompatible", { modelId, provider }),

--- a/src/services/code-index/vector-store/__tests__/lancedb-vector-store.spec.ts
+++ b/src/services/code-index/vector-store/__tests__/lancedb-vector-store.spec.ts
@@ -103,6 +103,36 @@ describe("LocalVectorStore", () => {
 			expect(store["workspacePath"]).toBe(workspacePath)
 			expect(store["dbPath"]).toContain("mock")
 		})
+
+		// kilocode_change start - Test for issue #5325
+		it("should reject invalid vectorSize values", () => {
+			// Test negative values
+			expect(() => new LanceDBVectorStore(workspacePath, -1, dbDirectory, mockLanceDBManager as unknown as LanceDBManager)).toThrow(RangeError)
+
+			// Test zero
+			expect(() => new LanceDBVectorStore(workspacePath, 0, dbDirectory, mockLanceDBManager as unknown as LanceDBManager)).toThrow(RangeError)
+
+			// Test NaN
+			expect(() => new LanceDBVectorStore(workspacePath, NaN, dbDirectory, mockLanceDBManager as unknown as LanceDBManager)).toThrow(RangeError)
+
+			// Test Infinity
+			expect(() => new LanceDBVectorStore(workspacePath, Infinity, dbDirectory, mockLanceDBManager as unknown as LanceDBManager)).toThrow(RangeError)
+
+			// Test extremely large values
+			expect(() => new LanceDBVectorStore(workspacePath, 200000, dbDirectory, mockLanceDBManager as unknown as LanceDBManager)).toThrow(RangeError)
+
+			// Test non-number types (should be caught by typeof check)
+			expect(() => new LanceDBVectorStore(workspacePath, "768" as any, dbDirectory, mockLanceDBManager as unknown as LanceDBManager)).toThrow(RangeError)
+			expect(() => new LanceDBVectorStore(workspacePath, null as any, dbDirectory, mockLanceDBManager as unknown as LanceDBManager)).toThrow(RangeError)
+			expect(() => new LanceDBVectorStore(workspacePath, undefined as any, dbDirectory, mockLanceDBManager as unknown as LanceDBManager)).toThrow(RangeError)
+		})
+
+		it("should accept valid vectorSize values", () => {
+			expect(() => new LanceDBVectorStore(workspacePath, 1, dbDirectory, mockLanceDBManager as unknown as LanceDBManager)).not.toThrow()
+			expect(() => new LanceDBVectorStore(workspacePath, 768, dbDirectory, mockLanceDBManager as unknown as LanceDBManager)).not.toThrow()
+			expect(() => new LanceDBVectorStore(workspacePath, 100000, dbDirectory, mockLanceDBManager as unknown as LanceDBManager)).not.toThrow()
+		})
+		// kilocode_change end
 	})
 
 	describe("initialize", () => {

--- a/src/services/code-index/vector-store/lancedb-vector-store.ts
+++ b/src/services/code-index/vector-store/lancedb-vector-store.ts
@@ -25,6 +25,13 @@ export class LanceDBVectorStore implements IVectorStore {
 	private lancedbModule: any = null
 
 	constructor(workspacePath: string, vectorSize: number, dbDirectory: string, lancedbManager: LanceDBManager) {
+		// kilocode_change start - Validate vectorSize to prevent RangeError (issue #5325)
+		if (typeof vectorSize !== 'number' || !Number.isFinite(vectorSize) || vectorSize <= 0 || vectorSize > 100000) {
+			console.error(`[LanceDBVectorStore] Invalid vectorSize: ${vectorSize} (type: ${typeof vectorSize}). Expected positive finite number <= 100000.`)
+			throw new RangeError(`Invalid vector size: ${vectorSize}. Expected a positive finite number <= 100000.`)
+		}
+		// kilocode_change end
+
 		this.vectorSize = vectorSize
 		this.workspacePath = workspacePath
 		const basename = path.basename(workspacePath)
@@ -113,6 +120,13 @@ export class LanceDBVectorStore implements IVectorStore {
 	 * @returns An array containing sample data.
 	 */
 	private _createSampleData() {
+		// kilocode_change start - Debug logging for issue #5325
+		console.log(`[LanceDBVectorStore] _createSampleData called with vectorSize: ${this.vectorSize}, type: ${typeof this.vectorSize}`)
+		if (this.vectorSize <= 0 || !Number.isFinite(this.vectorSize) || this.vectorSize > 100000) {
+			console.error(`[LanceDBVectorStore] Invalid vectorSize detected: ${this.vectorSize}. This will cause RangeError.`)
+			throw new RangeError(`Invalid vector size: ${this.vectorSize}. Expected a positive finite number <= 100000.`)
+		}
+		// kilocode_change end
 		return [
 			{
 				id: "sample",

--- a/src/services/code-index/vector-store/qdrant-client.ts
+++ b/src/services/code-index/vector-store/qdrant-client.ts
@@ -25,6 +25,13 @@ export class QdrantVectorStore implements IVectorStore {
 	 * @param url Optional URL to the Qdrant server
 	 */
 	constructor(workspacePath: string, url: string, vectorSize: number, apiKey?: string) {
+		// kilocode_change start - Validate vectorSize to prevent RangeError (issue #5325)
+		if (typeof vectorSize !== 'number' || !Number.isFinite(vectorSize) || vectorSize <= 0 || vectorSize > 100000) {
+			console.error(`[QdrantVectorStore] Invalid vectorSize: ${vectorSize} (type: ${typeof vectorSize}). Expected positive finite number <= 100000.`)
+			throw new RangeError(`Invalid vector size: ${vectorSize}. Expected a positive finite number <= 100000.`)
+		}
+		// kilocode_change end
+
 		// Parse the URL to determine the appropriate QdrantClient configuration
 		const parsedUrl = this.parseQdrantUrl(url)
 
@@ -630,6 +637,14 @@ export class QdrantVectorStore implements IVectorStore {
 			// Use uuidv5 to generate a consistent UUID from a constant string
 			const metadataId = uuidv5("__indexing_metadata__", QDRANT_CODE_BLOCK_NAMESPACE)
 
+			// kilocode_change start - Debug logging for issue #5325
+			console.log(`[QdrantVectorStore] markIndexingComplete called with vectorSize: ${this.vectorSize}, type: ${typeof this.vectorSize}`)
+			if (this.vectorSize <= 0 || !Number.isFinite(this.vectorSize) || this.vectorSize > 100000) {
+				console.error(`[QdrantVectorStore] Invalid vectorSize detected in markIndexingComplete: ${this.vectorSize}. This will cause RangeError.`)
+				throw new RangeError(`Invalid vector size: ${this.vectorSize}. Expected a positive finite number <= 100000.`)
+			}
+			// kilocode_change end
+
 			await this.client.upsert(this.collectionName, {
 				points: [
 					{
@@ -660,6 +675,14 @@ export class QdrantVectorStore implements IVectorStore {
 			// Create a metadata point with a deterministic UUID to mark indexing as incomplete
 			// Use uuidv5 to generate a consistent UUID from a constant string
 			const metadataId = uuidv5("__indexing_metadata__", QDRANT_CODE_BLOCK_NAMESPACE)
+
+			// kilocode_change start - Debug logging for issue #5325
+			console.log(`[QdrantVectorStore] markIndexingIncomplete called with vectorSize: ${this.vectorSize}, type: ${typeof this.vectorSize}`)
+			if (this.vectorSize <= 0 || !Number.isFinite(this.vectorSize) || this.vectorSize > 100000) {
+				console.error(`[QdrantVectorStore] Invalid vectorSize detected in markIndexingIncomplete: ${this.vectorSize}. This will cause RangeError.`)
+				throw new RangeError(`Invalid vector size: ${this.vectorSize}. Expected a positive finite number <= 100000.`)
+			}
+			// kilocode_change end
 
 			await this.client.upsert(this.collectionName, {
 				points: [


### PR DESCRIPTION
Fixes issue #5325 where the extension becomes unresponsive after permission prompts due to invalid vectorSize causing RangeError when creating arrays.