### PR TITLE
Increase Agent Manager prompt input size

### DIFF
--- a/.changeset/agent-manager-larger-prompt-input.md
+++ b/.changeset/agent-manager-larger-prompt-input.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Increased Agent Manager initial prompt input size for easier editing of longer prompts

--- a/webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css
+++ b/webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css
@@ -559,7 +559,7 @@
 	height: 100%;
 	padding: 20px;
 	width: 100%;
-	max-width: 560px;
+	max-width: 800px;
 	margin: 0 auto;
 	text-align: center;
 }

--- a/webview-ui/src/kilocode/agent-manager/components/SessionDetail.tsx
+++ b/webview-ui/src/kilocode/agent-manager/components/SessionDetail.tsx
@@ -406,8 +406,8 @@ function NewAgentForm() {
 						aria-label={t("sessionDetail.startNewAgent")}
 						disabled={isStarting}
 						placeholder={t("sessionDetail.placeholderTask")}
-						minRows={5}
-						maxRows={12}
+						minRows={8}
+						maxRows={20}
 						style={{
 							paddingTop: "12px",
 							// Add extra padding when images are present to make room for the image row


### PR DESCRIPTION
## Summary

Increased the Agent Manager initial prompt input size to make it easier to write and review longer contextualized prompts without excessive scrolling.

## Changes

- **Form width**: Increased `max-width` from 560px to 800px (~43% wider)
- **Textarea rows**: Increased `minRows` from 5 to 8 and `maxRows` from 12 to 20 (60% more visible rows)

## Files Modified

- `webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css`
- `webview-ui/src/kilocode/agent-manager/components/SessionDetail.tsx`

<img width="938" height="539" alt="image" src="https://github.com/user-attachments/assets/cacf5a09-409f-42f0-9004-27771ab2a517" />

<img width="1772" height="1186" alt="image" src="https://github.com/user-attachments/assets/0ad27101-9c22-4fb9-b394-3e6ace734080" />
