### PR TITLE
Prevent git restore from falling back to HEAD on failure

### DIFF
--- a/.changeset/odd-taxis-change.md
+++ b/.changeset/odd-taxis-change.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep session git restore resilient when checkout or patch apply fails.

--- a/src/shared/kilocode/cli-sessions/core/__tests__/GitStateService.spec.ts
+++ b/src/shared/kilocode/cli-sessions/core/__tests__/GitStateService.spec.ts
@@ -809,6 +809,12 @@ describe("GitStateService", () => {
 				LOG_SOURCES.GIT_STATE,
 				expect.any(Object),
 			)
+			expect(mockGit.applyPatch).not.toHaveBeenCalled()
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				"Skipping patch apply due to checkout failure",
+				LOG_SOURCES.GIT_STATE,
+				expect.any(Object),
+			)
 		})
 
 		it("handles patch failure gracefully", async () => {


### PR DESCRIPTION
## Summary
- skip patch apply when git checkout fails and log a warning
- log patch temp cleanup failures instead of silently ignoring them
- add changeset for resilient git restore behavior

## Testing
- `pnpm test shared/kilocode/cli-sessions/core/__tests__/GitStateService.spec.ts` (from `src`)