### PR TITLE
(inception) fix: added supportsNativeTools to default inception provider config

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -647,6 +647,7 @@ export const providerSettingsSchema = z.object({
 	...vercelAiGatewaySchema.shape,
 	...sapAiCoreSchema.shape, // kilocode_change
 	...codebaseIndexProviderSchema.shape,
+	...inceptionSchema.shape,
 })
 
 export type ProviderSettings = z.infer<typeof providerSettingsSchema>

--- a/packages/types/src/providers/inception.ts
+++ b/packages/types/src/providers/inception.ts
@@ -15,4 +15,5 @@ export const inceptionDefaultModelInfo: ModelInfo = {
 	outputPrice: 0.000001,
 	cacheReadsPrice: 0,
 	cacheWritesPrice: 0,
+	supportsNativeTools: true,
 }


### PR DESCRIPTION
## Context

The default config for inception models lacked `useNativeToolCalls: true`, causing custom models to break.

## Implementation

Added `useNativeToolCalls: true` to the default config.