### PR TITLE
feat: Support multiple context directories for skills (.kilocode, .claude)

### DIFF
--- a/.changeset/multi-directory-skills.md
+++ b/.changeset/multi-directory-skills.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Support multiple context directories for skills discovery. Skills can now be loaded from both `.kilocode/skills/` and `.claude/skills/` directories, allowing users with existing Claude configurations to reuse their skills. The `.kilocode` directory takes precedence when the same skill exists in both locations.

--- a/src/services/marketplace/MarketplaceManager.ts
+++ b/src/services/marketplace/MarketplaceManager.ts
@@ -286,26 +286,29 @@ export class MarketplaceManager {
 				// File doesn't exist or can't be read, skip
 			}
 
-			// kilocode_change start - Check skills in .kilocode/skills/
-			const projectSkillsPath = path.join(workspaceFolder.uri.fsPath, ".kilocode", "skills")
-			try {
-				const entries = await fs.readdir(projectSkillsPath, { withFileTypes: true })
-				for (const entry of entries) {
-					if (entry.isDirectory()) {
-						// Check if SKILL.md exists in the directory
-						const skillFilePath = path.join(projectSkillsPath, entry.name, "SKILL.md")
-						try {
-							await fs.access(skillFilePath)
-							metadata[entry.name] = {
-								type: "skill",
+			// kilocode_change start - Check skills in multiple context directories
+			const projectContextDirs = [".kilocode", ".claude"]
+			for (const contextDir of projectContextDirs) {
+				const projectSkillsPath = path.join(workspaceFolder.uri.fsPath, contextDir, "skills")
+				try {
+					const entries = await fs.readdir(projectSkillsPath, { withFileTypes: true })
+					for (const entry of entries) {
+						if (entry.isDirectory()) {
+							// Check if SKILL.md exists in the directory
+							const skillFilePath = path.join(projectSkillsPath, entry.name, "SKILL.md")
+							try {
+								await fs.access(skillFilePath)
+								metadata[entry.name] = {
+									type: "skill",
+								}
+							} catch {
+								// SKILL.md doesn't exist, skip
 							}
-						} catch {
-							// SKILL.md doesn't exist, skip
 						}
 					}
+				} catch (error) {
+					// Directory doesn't exist or can't be read, skip
 				}
-			} catch (error) {
-				// Directory doesn't exist or can't be read, skip
 			}
 			// kilocode_change end
 		} catch (error) {


### PR DESCRIPTION
## Summary

This PR adds support for multiple context directories for skills retrieval. Skills can now be loaded from both `.kilocode/skills/` and `.claude/skills/` directories, allowing users with existing Claude configurations to reuse their skills.

## Changes

### SkillsManager.ts
- Added `PROJECT_CONTEXT_DIRS` constant: `[".kilocode", ".claude"]`
- Updated `getSkillsDirectories()` to iterate over all supported context directories
- Updated `setupFileWatchers()` to watch all context directories
- Added first-wins logic in `loadSkillMetadata()` to ensure `.kilocode` takes precedence over `.claude`

### MarketplaceManager.ts
- Updated `checkProjectInstallations()` to check skills in both `.kilocode` and `.claude` directories

### Tests
- Added tests for multi-directory skills support:
  - Discovering skills from `.claude` directory
  - Preferring `.kilocode` over `.claude` for same skill name
  - Merging skills from both directories

## Behavior
- `.kilocode` takes precedence over `.claude` when the same skill exists in both
- Skills from both directories are merged and available
- File watchers monitor both directories for changes
- No breaking changes - existing `.kilocode` configurations work unchanged