### PR TITLE
fix(core-schemas): add missing openai-codex provider type definition

### DIFF
--- a/.changeset/fix-openai-codex-type.md
+++ b/.changeset/fix-openai-codex-type.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/core-schemas": patch
+---
+
+Add missing openai-codex provider type definition

--- a/cli/src/config/mapper.ts
+++ b/cli/src/config/mapper.ts
@@ -102,6 +102,7 @@ export function getModelIdForProvider(provider: ProviderConfig): string {
 		case "anthropic":
 			return provider.apiModelId || ""
 		case "openai-native":
+		case "openai-codex":
 			return provider.apiModelId || ""
 		case "openrouter":
 			return provider.openRouterModelId || ""

--- a/cli/src/config/schema.json
+++ b/cli/src/config/schema.json
@@ -235,6 +235,7 @@
 						"kilocode",
 						"anthropic",
 						"openai-native",
+						"openai-codex",
 						"openrouter",
 						"bedrock",
 						"gemini",
@@ -440,6 +441,19 @@
 					"then": {
 						"properties": {
 							"openAiNativeApiKey": { "minLength": 10 }
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": { "provider": { "const": "openai-codex" } }
+					},
+					"then": {
+						"properties": {
+							"apiModelId": {
+								"type": "string",
+								"description": "OpenAI model ID"
+							}
 						}
 					}
 				},

--- a/packages/core-schemas/src/config/provider.ts
+++ b/packages/core-schemas/src/config/provider.ts
@@ -37,6 +37,14 @@ export const openAINativeProviderSchema = baseProviderSchema.extend({
 	openAiNativeServiceTier: z.enum(["auto", "default", "flex", "priority"]).optional(),
 })
 
+// kilocode_change start
+// OpenAI Codex provider (ChatGPT Plus/Pro)
+export const openAICodexProviderSchema = baseProviderSchema.extend({
+	provider: z.literal("openai-codex"),
+	apiModelId: z.string().optional(),
+})
+// kilocode_change end
+
 // OpenAI provider
 export const openAIProviderSchema = baseProviderSchema.extend({
 	provider: z.literal("openai"),
@@ -387,6 +395,7 @@ export const providerConfigSchema = z.discriminatedUnion("provider", [
 	kilocodeProviderSchema,
 	anthropicProviderSchema,
 	openAINativeProviderSchema,
+	openAICodexProviderSchema, // kilocode_change
 	openAIProviderSchema,
 	openRouterProviderSchema,
 	ollamaProviderSchema,
@@ -432,6 +441,7 @@ export const providerConfigSchema = z.discriminatedUnion("provider", [
 export type KilocodeProviderConfig = z.infer<typeof kilocodeProviderSchema>
 export type AnthropicProviderConfig = z.infer<typeof anthropicProviderSchema>
 export type OpenAINativeProviderConfig = z.infer<typeof openAINativeProviderSchema>
+export type OpenAICodexProviderConfig = z.infer<typeof openAICodexProviderSchema> // kilocode_change
 export type OpenAIProviderConfig = z.infer<typeof openAIProviderSchema>
 export type OpenRouterProviderConfig = z.infer<typeof openRouterProviderSchema>
 export type OllamaProviderConfig = z.infer<typeof ollamaProviderSchema>


### PR DESCRIPTION
## Context

PR #5270 added openai-codex provider but the implementation was incomplete - it included runtime validation and UI metadata, but missed the TypeScript type definition in `@kilocode/core-schemas` and model mapping in `cli/src/config/mapper.ts`.

This bug was discovered while developing the CLI providers API command (branch `feat/cli-subcommands-discoverability`), which needs to enumerate and display all configured providers with their model information. When attempting to add `case "openai-codex":` to the switch statement, TypeScript reported:

```
error TS2678: Type '"openai-codex"' is not comparable to type ...
```

## Implementation

**packages/core-schemas/src/config/provider.ts:**
- Created `openAICodexProviderSchema` with `apiModelId` field
- Added to `providerConfigSchema` discriminated union (line 398)
- Exported `OpenAICodexProviderConfig` type (line 444)
- Marked with `kilocode_change` (per CLAUDE.md - packages/ requires markers)

**cli/src/config/mapper.ts:**
- Added `openai-codex` case alongside `openai-native` (both use `apiModelId`)

openai-codex now matches the pattern of openai-native and can be properly handled in type-safe code.

## Screenshots

N/A (type definition fix)

## How to Test

```bash
pnpm check-types  # All 20 packages should pass
```

## Get in Touch

@PeterDaveHello