### PR TITLE
Fix link to Development Guide in cli readme

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -292,4 +292,4 @@ This instructs the AI to proceed without user input.
 
 ## Local Development
 
-See [Development Guide](cli/docs/DEVELOPMENT.md) for setup instructions.
+See [Development Guide](docs/DEVELOPMENT.md) for setup instructions.


### PR DESCRIPTION
## Context

Fix link in readme

## Implementation

updated markdown

## How to Test

click the link. you can try it on my fork: https://github.com/justingray0/kilocode/blob/patch-1/cli/README.md#local-development
whereas it's broken here: https://github.com/Kilo-Org/kilocode/tree/main/cli#local-development
