### PR TITLE
Add temperature=0.9 and top_p=0.95 to zai-glm-4.7 model

### DIFF
--- a/.changeset/glm-47-temperature.md
+++ b/.changeset/glm-47-temperature.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Set default temperature to 1.0 for Cerebras zai-glm-4.7 model

--- a/packages/types/src/providers/cerebras.ts
+++ b/packages/types/src/providers/cerebras.ts
@@ -12,6 +12,8 @@ export const cerebrasModels = {
 		supportsImages: false,
 		supportsPromptCache: false,
 		supportsNativeTools: true,
+		supportsTemperature: true,
+		defaultTemperature: 0.9,
 		inputPrice: 0,
 		outputPrice: 0,
 		description:


### PR DESCRIPTION
Added supportsTemperature: true, defaultTemperature: 0.9 to zai-glm-4.7 model + changeset

Similar to packages/types/src/providers/moonshot.ts:

```typescript
supportsTemperature: true, // Default temperature: 1.0
preserveReasoning: true,
defaultTemperature: 1.0,
```