### PR TITLE
fix: detect and correct text-based tool call hallucinations (MODEL_NO_TOOLS_USED loop)

### DIFF
--- a/.changeset/fix-model-no-tools-used.md
+++ b/.changeset/fix-model-no-tools-used.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix recurring MODEL_NO_TOOLS_USED error loop by detecting text-based tool call hallucinations and instructing the model to use the native API.

--- a/src/core/prompts/sections/__tests__/tool-use-guidelines.spec.ts
+++ b/src/core/prompts/sections/__tests__/tool-use-guidelines.spec.ts
@@ -54,9 +54,8 @@ describe("getToolUseGuidelinesSection", () => {
 				expect(guidelines).toContain("1. Assess what information")
 				expect(guidelines).toContain("2. Choose the most appropriate tool")
 				expect(guidelines).toContain("3. If multiple actions are needed")
-				expect(guidelines).toContain("4. After each tool use")
+				expect(guidelines).toContain("5. After each tool use")
 			})
-
 			it("should include single-tool-per-message guidance when experiment disabled", () => {
 				const guidelines = getToolUseGuidelinesSection(TOOL_PROTOCOL.NATIVE, {})
 

--- a/src/core/prompts/sections/tool-use-guidelines.ts
+++ b/src/core/prompts/sections/tool-use-guidelines.ts
@@ -37,6 +37,10 @@ export function getToolUseGuidelinesSection(
 				`${itemNumber++}. If multiple actions are needed, use one tool at a time per message to accomplish the task iteratively, with each tool use being informed by the result of the previous tool use. Do not assume the outcome of any tool use. Each step must be informed by the previous step's result.`,
 			)
 		}
+
+		guidelinesList.push(
+			`${itemNumber++}. CRITICAL: You must use the API's native tool format. Do NOT simply write text describing the tool use (e.g., "[Tool Use: ...]" or JSON blocks in text). The system will strictly reject any text that mimics a tool call. You must use the proper API structure for function calling.`,
+		)
 	} else {
 		guidelinesList.push(
 			`${itemNumber++}. If multiple actions are needed, use one tool at a time per message to accomplish the task iteratively, with each tool use being informed by the result of the previous tool use. Do not assume the outcome of any tool use. Each step must be informed by the previous step's result.`,

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -3607,6 +3607,11 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 					)
 
 					if (!didToolUse) {
+						// Check for hallucinated tool use pattern
+						const hallucinatedTool = this.assistantMessageContent.find(
+							(block) => block.type === "text" && block.content.trim().match(/^\[Tool Use: .+\]/i),
+						)
+
 						// Increment consecutive no-tool-use counter
 						this.consecutiveNoToolUseCount++
 
@@ -3617,10 +3622,17 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 							this.consecutiveMistakeCount++
 						}
 
+						let responseText = formatResponse.noToolsUsed(this._taskToolProtocol ?? "xml")
+
+						if (hallucinatedTool) {
+							responseText +=
+								"\n\n[ERROR] You are outputting tool calls as text (e.g. '[Tool Use: ...]'). This is invalid. You MUST use the native tool calling capability provided by the API. Do not write the tool use in the text response."
+						}
+
 						// Use the task's locked protocol for consistent behavior
 						this.userMessageContent.push({
 							type: "text",
-							text: formatResponse.noToolsUsed(this._taskToolProtocol ?? "xml"),
+							text: responseText,
 						})
 					} else {
 						// Reset counter when tools are used successfully


### PR DESCRIPTION
This PR addresses the recurring `MODEL_NO_TOOLS_USED` error where models output tool calls as text (e.g., `[Tool Use: ...]`) instead of using the native API format.

Fixes #5256
Fixes #5280

### Changes
1. **Smart Error Handling**: Modified `src/core/task/Task.ts` to detect text blocks matching the `[Tool Use: ...]` pattern. When detected, the system now provides a specific error message instructing the model to use the native tool calling capability. This immediate feedback breaks the retry loop.
2. **System Prompt Hardening**: Updated `src/core/prompts/sections/tool-use-guidelines.ts` to include a critical guideline for native protocol sessions, explicitly forbidding text-based tool call mimicry.

This resolves the "mimicry loop" issues reported by users, particularly with Gemini and OpenRouter models.