### PR TITLE
feat(cli): add providers/modes/profile subcommands for discoverability

### DIFF
--- a/.changeset/cli-subcommands-discoverability.md
+++ b/.changeset/cli-subcommands-discoverability.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Add CLI subcommands to list providers, modes, and profile details.

--- a/cli/README.md
+++ b/cli/README.md
@@ -50,6 +50,96 @@ kilocode -c
 kilocode --continue
 ```
 
+### Scriptable Subcommands
+
+These subcommands run without the TUI and return JSON for scripting.
+
+```bash
+# List configured providers
+kilocode providers [list]
+
+# List available modes (default workspace is the current directory)
+kilocode modes [list] [--workspace <path>]
+
+# Show Kilocode profile information
+kilocode profile
+```
+
+Successful responses are returned as JSON:
+
+Providers example:
+
+```json
+{
+	"current": "kilocode-1",
+	"providers": [
+		{
+			"id": "kilocode-1",
+			"type": "kilocode",
+			"label": "Kilo Code",
+			"model": "claude-sonnet-4",
+			"isCurrent": true
+		},
+		{
+			"id": "anthropic-1",
+			"type": "anthropic",
+			"label": "Anthropic",
+			"model": null,
+			"isCurrent": false
+		}
+	]
+}
+```
+
+Modes example:
+
+```json
+{
+	"current": "code",
+	"workspace": "/path/to/workspace",
+	"modes": [
+		{
+			"slug": "code",
+			"name": "Code",
+			"description": "Write and update code",
+			"source": "built-in",
+			"isCurrent": true
+		}
+	]
+}
+```
+
+Note: `description` can be `null` when a mode does not define one.
+
+Profile example:
+
+```json
+{
+	"authenticated": true,
+	"provider": "kilocode",
+	"user": {
+		"name": "Jane Doe",
+		"email": "jane@example.com"
+	},
+	"organization": {
+		"id": "org_123",
+		"name": "Example Org",
+		"role": "admin"
+	}
+}
+```
+
+Errors are returned as JSON:
+
+```json
+{
+	"error": "Message",
+	"code": "ERROR_CODE"
+}
+```
+
+Exit codes: 0 = success, 1 = failure.
+
 ### Parallel mode
 
 Parallel mode allows multiple Kilo Code instances to work in parallel on the same directory, without conflicts. You can spawn as many Kilo Code instances as you need! Once finished, changes will be available on a separate git branch.

--- a/cli/src/commands/__tests__/modes-api.test.ts
+++ b/cli/src/commands/__tests__/modes-api.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { mkdtemp, writeFile, rm, readFile } from "fs/promises"
+import { tmpdir } from "os"
+import { join, resolve } from "path"
+import type { ModeConfig } from "../../types/messages.js"
+import type { ModesApiOutput } from "../modes-api.js"
+import { buildModesOutput, resolveModeSource, modesApiCommand } from "../modes-api.js"
+import { loadCustomModes, getSearchedPaths } from "../../config/customModes.js"
+import { loadConfigAtom } from "../../state/atoms/config.js"
+
+const storeSetMock = vi.hoisted(() => vi.fn())
+
+vi.mock("jotai", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("jotai")>()
+	return {
+		...actual,
+		createStore: () => ({
+			set: storeSetMock,
+		}),
+	}
+})
+
+vi.mock("fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("fs/promises")>()
+	return {
+		...actual,
+		readFile: vi.fn(actual.readFile),
+	}
+})
+
+vi.mock("../../config/customModes.js", () => ({
+	loadCustomModes: vi.fn(),
+	getSearchedPaths: vi.fn(),
+}))
+
+describe("modes-api command", () => {
+	it("should resolve built-in mode source", () => {
+		const mode = { slug: "code", name: "Code" } as ModeConfig
+		expect(resolveModeSource(mode)).toBe("built-in")
+	})
+
+	it("should resolve explicit custom mode source", () => {
+		const mode = { slug: "custom", name: "Custom", source: "project" } as ModeConfig
+		expect(resolveModeSource(mode)).toBe("project")
+	})
+
+	it("should default custom mode source to global when missing", () => {
+		const mode = { slug: "legacy", name: "Legacy" } as ModeConfig
+		expect(resolveModeSource(mode, new Set())).toBe("global")
+	})
+
+	it("should build modes output with current mode and workspace", () => {
+		const builtIn = { slug: "code", name: "Code" } as ModeConfig
+		const custom = { slug: "custom", name: "Custom", source: "project" } as ModeConfig
+
+		const output = buildModesOutput({
+			currentMode: "code",
+			workspace: "/tmp/workspace",
+			modes: [builtIn, custom],
+		})
+
+		expect(output.current).toBe("code")
+		expect(output.workspace).toBe("/tmp/workspace")
+		expect(output.modes).toHaveLength(2)
+		expect(output.modes[0]?.isCurrent).toBe(true)
+		expect(output.modes[0]?.source).toBe("built-in")
+		expect(output.modes[0]?.description).toBeNull()
+		expect(output.modes[1]?.isCurrent).toBe(false)
+		expect(output.modes[1]?.source).toBe("project")
+	})
+})
+
+describe("modesApiCommand", () => {
+	let configForTest: { mode: string } | Error
+	let consoleLogSpy: ReturnType<typeof vi.spyOn>
+	let processExitSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+		processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("process.exit called")
+		})
+		storeSetMock.mockImplementation(async () => {
+			if (configForTest instanceof Error) {
+				throw configForTest
+			}
+			return configForTest
+		})
+	})
+
+	afterEach(() => {
+		consoleLogSpy.mockRestore()
+		processExitSpy.mockRestore()
+		storeSetMock.mockReset()
+		vi.clearAllMocks()
+	})
+
+	it("should respect the --workspace option", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "kilocode-modes-"))
+		try {
+			configForTest = { mode: "code" }
+			vi.mocked(loadCustomModes).mockResolvedValue([])
+			vi.mocked(getSearchedPaths).mockReturnValue([])
+
+			await expect(modesApiCommand({ workspace })).rejects.toThrow("process.exit called")
+
+			expect(storeSetMock).toHaveBeenCalledWith(loadConfigAtom)
+			expect(processExitSpy).toHaveBeenCalledWith(0)
+			const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string) as { workspace: string }
+			expect(output.workspace).toBe(resolve(workspace))
+		} finally {
+			await rm(workspace, { recursive: true, force: true })
+		}
+	})
+
+	it("should prefer custom mode when slug overrides built-in", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "kilocode-modes-"))
+		try {
+			configForTest = { mode: "code" }
+			vi.mocked(loadCustomModes).mockResolvedValue([
+				{ slug: "code", name: "Custom Code", source: "project" } as ModeConfig,
+			])
+			vi.mocked(getSearchedPaths).mockReturnValue([])
+
+			await expect(modesApiCommand({ workspace })).rejects.toThrow("process.exit called")
+
+			const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string) as ModesApiOutput
+			const codeModes = output.modes.filter((mode) => mode.slug === "code")
+			expect(codeModes).toHaveLength(1)
+			expect(codeModes[0]?.name).toBe("Custom Code")
+			expect(codeModes[0]?.source).toBe("project")
+			expect(codeModes[0]?.isCurrent).toBe(true)
+		} finally {
+			await rm(workspace, { recursive: true, force: true })
+		}
+	})
+
+	it("should accept empty customModes (null)", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "kilocode-modes-"))
+		const emptyConfigPath = join(workspace, ".kilocodemodes")
+		try {
+			await writeFile(emptyConfigPath, "customModes: null")
+
+			configForTest = { mode: "code" }
+			vi.mocked(loadCustomModes).mockResolvedValue([])
+			vi.mocked(getSearchedPaths).mockReturnValue([
+				{
+					type: "project",
+					path: emptyConfigPath,
+					found: true,
+					modesCount: 0,
+				},
+			])
+
+			await expect(modesApiCommand({ workspace })).rejects.toThrow("process.exit called")
+
+			expect(processExitSpy).toHaveBeenCalledWith(0) // Should succeed
+		} finally {
+			await rm(workspace, { recursive: true, force: true })
+		}
+	})
+
+	it("should accept empty customModes (undefined)", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "kilocode-modes-"))
+		const emptyConfigPath = join(workspace, ".kilocodemodes")
+		try {
+			await writeFile(emptyConfigPath, "customModes:")
+
+			configForTest = { mode: "code" }
+			vi.mocked(loadCustomModes).mockResolvedValue([])
+			vi.mocked(getSearchedPaths).mockReturnValue([
+				{
+					type: "project",
+					path: emptyConfigPath,
+					found: true,
+					modesCount: 0,
+				},
+			])
+
+			await expect(modesApiCommand({ workspace })).rejects.toThrow("process.exit called")
+
+			expect(processExitSpy).toHaveBeenCalledWith(0) // Should succeed
+		} finally {
+			await rm(workspace, { recursive: true, force: true })
+		}
+	})
+
+	it("should return INVALID_MODES_CONFIG for invalid custom modes config", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "kilocode-modes-"))
+		const invalidConfigPath = join(workspace, ".kilocodemodes")
+		try {
+			await writeFile(invalidConfigPath, "customModes: [")
+
+			configForTest = { mode: "code" }
+			vi.mocked(loadCustomModes).mockResolvedValue([])
+			vi.mocked(getSearchedPaths).mockReturnValue([
+				{
+					type: "project",
+					path: invalidConfigPath,
+					found: true,
+					modesCount: 0,
+				},
+			])
+
+			await expect(modesApiCommand({ workspace })).rejects.toThrow("process.exit called")
+
+			expect(processExitSpy).toHaveBeenCalledWith(1)
+			const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string) as { code: string }
+			expect(output.code).toBe("INVALID_MODES_CONFIG")
+		} finally {
+			await rm(workspace, { recursive: true, force: true })
+		}
+	})
+
+	it("should return INVALID_MODES_CONFIG when custom modes file is unreadable", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "kilocode-modes-"))
+		const unreadableConfigPath = join(workspace, ".kilocodemodes")
+		try {
+			await writeFile(unreadableConfigPath, "customModes: []")
+
+			configForTest = { mode: "code" }
+			vi.mocked(loadCustomModes).mockResolvedValue([])
+			vi.mocked(getSearchedPaths).mockReturnValue([
+				{
+					type: "project",
+					path: unreadableConfigPath,
+					found: true,
+					modesCount: 0,
+				},
+			])
+
+			vi.mocked(readFile).mockRejectedValueOnce(new Error("permission denied"))
+
+			await expect(modesApiCommand({ workspace })).rejects.toThrow("process.exit called")
+
+			expect(processExitSpy).toHaveBeenCalledWith(1)
+			const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string) as { code: string }
+			expect(output.code).toBe("INVALID_MODES_CONFIG")
+		} finally {
+			await rm(workspace, { recursive: true, force: true })
+		}
+	})
+})

--- a/cli/src/commands/__tests__/profile-api.test.ts
+++ b/cli/src/commands/__tests__/profile-api.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import type { KilocodeProfileData } from "../../auth/types.js"
+import type { CLIConfig, ProviderConfig } from "../../config/types.js"
+import { getKilocodeProfile, INVALID_TOKEN_ERROR } from "../../auth/providers/kilocode/shared.js"
+import { buildProfileOutput, classifyProfileFetchError, profileApiCommand } from "../profile-api.js"
+import { loadConfigAtom } from "../../state/atoms/config.js"
+
+const storeSetMock = vi.hoisted(() => vi.fn())
+
+vi.mock("jotai", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("jotai")>()
+	return {
+		...actual,
+		createStore: () => ({
+			set: storeSetMock,
+		}),
+	}
+})
+
+vi.mock("../../auth/providers/kilocode/shared.js", async () => {
+	const actual = await vi.importActual<typeof import("../../auth/providers/kilocode/shared.js")>(
+		"../../auth/providers/kilocode/shared.js",
+	)
+	return {
+		...actual,
+		getKilocodeProfile: vi.fn(),
+	}
+})
+
+describe("profile-api command", () => {
+	it("should classify invalid token errors", () => {
+		const error = new Error(INVALID_TOKEN_ERROR)
+		const result = classifyProfileFetchError(error)
+		expect(result.code).toBe("NOT_AUTHENTICATED")
+	})
+
+	it("should classify network errors by message", () => {
+		const error = new Error("Failed to fetch profile: fetch failed")
+		const result = classifyProfileFetchError(error)
+		expect(result.code).toBe("NETWORK_ERROR")
+	})
+
+	it("should classify network errors by error code (ETIMEDOUT)", () => {
+		const error = Object.assign(new Error("Connection timeout"), { code: "ETIMEDOUT" })
+		const result = classifyProfileFetchError(error)
+		expect(result.code).toBe("NETWORK_ERROR")
+	})
+
+	it("should classify network errors by error code (ECONNREFUSED)", () => {
+		const error = Object.assign(new Error("Connection refused"), { code: "ECONNREFUSED" })
+		const result = classifyProfileFetchError(error)
+		expect(result.code).toBe("NETWORK_ERROR")
+	})
+
+	it("should classify abort errors as network errors", () => {
+		const error = new Error("Failed to fetch profile: The operation was aborted")
+		const result = classifyProfileFetchError(error)
+		expect(result.code).toBe("NETWORK_ERROR")
+	})
+
+	it("should classify API errors with status", () => {
+		const error = new Error("Failed to fetch profile: 500")
+		const result = classifyProfileFetchError(error)
+		expect(result.code).toBe("API_ERROR")
+	})
+
+	it("should build profile output with user and organization", () => {
+		const profile: KilocodeProfileData = {
+			user: {
+				name: "Jane Doe",
+				email: undefined,
+			},
+			organizations: [
+				{
+					id: "org_123",
+					name: "Example Org",
+					role: "admin",
+				},
+			],
+		}
+
+		const provider = {
+			id: "kilocode-1",
+			provider: "kilocode",
+			kilocodeOrganizationId: "org_123",
+		} as ProviderConfig
+
+		const output = buildProfileOutput(profile, provider)
+		expect(output.authenticated).toBe(true)
+		expect(output.provider).toBe("kilocode")
+		expect(output.user?.name).toBe("Jane Doe")
+		expect(output.user?.email).toBeNull()
+		expect(output.organization?.id).toBe("org_123")
+	})
+})
+
+describe("profileApiCommand", () => {
+	let configForTest: CLIConfig | Error
+	let consoleLogSpy: ReturnType<typeof vi.spyOn>
+	let processExitSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+		processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("process.exit called")
+		})
+		storeSetMock.mockImplementation(async () => {
+			if (configForTest instanceof Error) {
+				throw configForTest
+			}
+			return configForTest
+		})
+	})
+
+	afterEach(() => {
+		consoleLogSpy.mockRestore()
+		processExitSpy.mockRestore()
+		storeSetMock.mockReset()
+		vi.clearAllMocks()
+	})
+
+	it("should output profile JSON for authenticated Kilocode provider", async () => {
+		configForTest = {
+			provider: "kilocode-1",
+			providers: [
+				{
+					id: "kilocode-1",
+					provider: "kilocode",
+					kilocodeToken: "test-token",
+					kilocodeOrganizationId: "org_123",
+				},
+			],
+		} as CLIConfig
+
+		vi.mocked(getKilocodeProfile).mockResolvedValue({
+			user: { name: "Jane Doe", email: "jane@example.com" },
+			organizations: [{ id: "org_123", name: "Example Org", role: "admin" }],
+		})
+
+		await expect(profileApiCommand()).rejects.toThrow("process.exit called")
+
+		expect(storeSetMock).toHaveBeenCalledWith(loadConfigAtom)
+		expect(processExitSpy).toHaveBeenCalledWith(0)
+		const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string) as {
+			authenticated: boolean
+			provider: string
+			user?: { name: string | null; email: string | null }
+			organization?: { id: string; name: string; role: string }
+		}
+		expect(output.authenticated).toBe(true)
+		expect(output.provider).toBe("kilocode")
+		expect(output.user?.name).toBe("Jane Doe")
+		expect(output.organization?.id).toBe("org_123")
+	})
+
+	it("should return PROVIDER_NOT_FOUND when provider ID is missing", async () => {
+		configForTest = {
+			provider: "missing-provider",
+			providers: [],
+		} as CLIConfig
+
+		await expect(profileApiCommand()).rejects.toThrow("process.exit called")
+
+		expect(processExitSpy).toHaveBeenCalledWith(1)
+		const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string) as { code: string }
+		expect(output.code).toBe("PROVIDER_NOT_FOUND")
+		expect(getKilocodeProfile).not.toHaveBeenCalled()
+	})
+
+	it("should return NOT_KILOCODE_PROVIDER when provider is not Kilocode", async () => {
+		configForTest = {
+			provider: "openai-1",
+			providers: [
+				{
+					id: "openai-1",
+					provider: "openai",
+					apiKey: "test-key",
+				},
+			],
+		} as CLIConfig
+
+		await expect(profileApiCommand()).rejects.toThrow("process.exit called")
+
+		expect(processExitSpy).toHaveBeenCalledWith(1)
+		const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string) as { code: string }
+		expect(output.code).toBe("NOT_KILOCODE_PROVIDER")
+	})
+
+	it("should return NOT_AUTHENTICATED when token is missing", async () => {
+		configForTest = {
+			provider: "kilocode-1",
+			providers: [
+				{
+					id: "kilocode-1",
+					provider: "kilocode",
+				},
+			],
+		} as CLIConfig
+
+		await expect(profileApiCommand()).rejects.toThrow("process.exit called")
+
+		expect(processExitSpy).toHaveBeenCalledWith(1)
+		const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string) as { code: string }
+		expect(output.code).toBe("NOT_AUTHENTICATED")
+	})
+
+	it("should return NETWORK_ERROR when profile fetch fails with network error code", async () => {
+		configForTest = {
+			provider: "kilocode-1",
+			providers: [
+				{
+					id: "kilocode-1",
+					provider: "kilocode",
+					kilocodeToken: "test-token",
+				},
+			],
+		} as CLIConfig
+
+		const networkError = Object.assign(new Error("Connection timeout"), { code: "ETIMEDOUT" })
+		vi.mocked(getKilocodeProfile).mockRejectedValue(networkError)
+
+		await expect(profileApiCommand()).rejects.toThrow("process.exit called")
+
+		expect(processExitSpy).toHaveBeenCalledWith(1)
+		const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string) as { code: string }
+		expect(output.code).toBe("NETWORK_ERROR")
+	})
+})

--- a/cli/src/commands/__tests__/providers-api.test.ts
+++ b/cli/src/commands/__tests__/providers-api.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import type { CLIConfig } from "../../config/types.js"
+import { buildProvidersOutput, providersApiCommand } from "../providers-api.js"
+import { loadConfigAtom } from "../../state/atoms/config.js"
+
+const storeSetMock = vi.hoisted(() => vi.fn())
+
+vi.mock("jotai", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("jotai")>()
+	return {
+		...actual,
+		createStore: () => ({
+			set: storeSetMock,
+		}),
+	}
+})
+
+describe("providers-api command", () => {
+	it("should build providers output with current provider and labels", () => {
+		const config = {
+			provider: "kilocode-1",
+			providers: [
+				{
+					id: "kilocode-1",
+					provider: "kilocode",
+					kilocodeToken: "test-token",
+					kilocodeModel: "claude-sonnet-4",
+				},
+				{
+					id: "anthropic-1",
+					provider: "anthropic",
+					apiKey: "test-key",
+					apiModelId: "",
+				},
+			],
+		} as CLIConfig
+
+		const output = buildProvidersOutput(config)
+
+		expect(output.current).toBe("kilocode-1")
+		expect(output.providers).toHaveLength(2)
+		expect(output.providers[0]?.id).toBe("kilocode-1")
+		expect(output.providers[0]?.isCurrent).toBe(true)
+		expect(output.providers[0]?.label).toBe("Kilo Code")
+		expect(output.providers[1]?.id).toBe("anthropic-1")
+		expect(output.providers[1]?.isCurrent).toBe(false)
+		expect(output.providers[1]?.label).toBe("Anthropic")
+		expect(output.providers[1]?.model).toBeNull()
+	})
+
+	it("should not expose tokens or API keys", () => {
+		const config = {
+			provider: "kilocode-1",
+			providers: [
+				{
+					id: "kilocode-1",
+					provider: "kilocode",
+					kilocodeToken: "test-token",
+					kilocodeModel: "claude-sonnet-4",
+				},
+				{
+					id: "anthropic-1",
+					provider: "anthropic",
+					apiKey: "test-key",
+					apiModelId: "claude-3-opus",
+				},
+			],
+		} as CLIConfig
+
+		const output = buildProvidersOutput(config)
+		const serialized = JSON.stringify(output)
+
+		expect(serialized).not.toContain("test-token")
+		expect(serialized).not.toContain("test-key")
+	})
+
+	it("should set current to null when configured provider is missing", () => {
+		const config = {
+			provider: "missing-provider",
+			providers: [
+				{
+					id: "kilocode-1",
+					provider: "kilocode",
+					kilocodeToken: "test-token",
+					kilocodeModel: "claude-sonnet-4",
+				},
+			],
+		} as CLIConfig
+
+		const output = buildProvidersOutput(config)
+
+		expect(output.current).toBeNull()
+		expect(output.providers[0]?.isCurrent).toBe(false)
+	})
+
+	it("should include model values for supported providers with custom model fields", () => {
+		const config = {
+			provider: "nano-gpt-1",
+			providers: [
+				{
+					id: "nano-gpt-1",
+					provider: "nano-gpt",
+					nanoGptModelId: "nano-model",
+				},
+				{
+					id: "sap-ai-core-1",
+					provider: "sap-ai-core",
+					sapAiCoreModelId: "sap-model",
+				},
+				{
+					id: "baseten-1",
+					provider: "baseten",
+					apiModelId: "baseten-model",
+				},
+			],
+		} as CLIConfig
+
+		const output = buildProvidersOutput(config)
+
+		const nanoProvider = output.providers.find((provider) => provider.id === "nano-gpt-1")
+		const sapProvider = output.providers.find((provider) => provider.id === "sap-ai-core-1")
+		const basetenProvider = output.providers.find((provider) => provider.id === "baseten-1")
+
+		expect(nanoProvider?.model).toBe("nano-model")
+		expect(sapProvider?.model).toBe("sap-model")
+		expect(basetenProvider?.model).toBe("baseten-model")
+	})
+
+	it("should include model field for openai-codex provider", () => {
+		const config = {
+			provider: "openai-codex-1",
+			providers: [
+				{
+					id: "openai-codex-1",
+					provider: "openai-codex",
+					apiModelId: "gpt-4o",
+				},
+				{
+					id: "openai-codex-2",
+					provider: "openai-codex",
+					apiModelId: "",
+				},
+			],
+		} as CLIConfig
+
+		const output = buildProvidersOutput(config)
+		const serialized = JSON.stringify(output)
+
+		const provider1 = output.providers.find((p) => p.id === "openai-codex-1")
+		const provider2 = output.providers.find((p) => p.id === "openai-codex-2")
+
+		// Model field should exist (not undefined)
+		expect(provider1?.model).toBe("gpt-4o")
+		expect(provider2?.model).toBeNull()
+
+		// Model field should be present in JSON output
+		expect(serialized).toContain('"model":"gpt-4o"')
+		expect(serialized).toContain('"model":null')
+	})
+})
+
+describe("providersApiCommand", () => {
+	let configForTest: CLIConfig | Error
+	let consoleLogSpy: ReturnType<typeof vi.spyOn>
+	let processExitSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+		processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("process.exit called")
+		})
+		storeSetMock.mockImplementation(async () => {
+			if (configForTest instanceof Error) {
+				throw configForTest
+			}
+			return configForTest
+		})
+	})
+
+	afterEach(() => {
+		consoleLogSpy.mockRestore()
+		processExitSpy.mockRestore()
+		storeSetMock.mockReset()
+		vi.clearAllMocks()
+	})
+
+	it("should output providers JSON and exit 0", async () => {
+		configForTest = {
+			provider: "kilocode-1",
+			providers: [
+				{
+					id: "kilocode-1",
+					provider: "kilocode",
+					kilocodeToken: "test-token",
+					kilocodeModel: "claude-sonnet-4",
+				},
+			],
+		} as CLIConfig
+
+		await expect(providersApiCommand()).rejects.toThrow("process.exit called")
+
+		expect(storeSetMock).toHaveBeenCalledWith(loadConfigAtom)
+		expect(processExitSpy).toHaveBeenCalledWith(0)
+		const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string) as {
+			current: string | null
+			providers: Array<{ id: string; isCurrent: boolean }>
+		}
+		expect(output.current).toBe("kilocode-1")
+		expect(output.providers[0]?.isCurrent).toBe(true)
+	})
+
+	it("should output error JSON and exit 1 on failure", async () => {
+		configForTest = new Error("Load config failed")
+
+		await expect(providersApiCommand()).rejects.toThrow("process.exit called")
+
+		expect(processExitSpy).toHaveBeenCalledWith(1)
+		const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string) as { code: string; error: string }
+		expect(output.code).toBe("INTERNAL_ERROR")
+		expect(output.error).toBe("Load config failed")
+	})
+})

--- a/cli/src/commands/modes-api.ts
+++ b/cli/src/commands/modes-api.ts
@@ -1,0 +1,199 @@
+/**
+ * Modes API command - Exposes available modes as JSON for programmatic use
+ *
+ * Usage:
+ *   kilocode modes [list] [--workspace <path>]
+ *
+ * Output format:
+ *   {
+ *     "current": "code",
+ *     "workspace": "/path/to/workspace",
+ *     "modes": [
+ *       {
+ *         "slug": "code",
+ *         "name": "Code",
+ *         "description": "Write and update code",
+ *         "source": "built-in",
+ *         "isCurrent": true
+ *       }
+ *     ]
+ *   }
+ */
+
+import { createStore } from "jotai"
+import { existsSync } from "fs"
+import { readFile } from "fs/promises"
+import { resolve } from "path"
+import { parse } from "yaml"
+import { loadConfigAtom } from "../state/atoms/config.js"
+import { logs } from "../services/logs.js"
+import { DEFAULT_MODES, getAllModes } from "../constants/modes/defaults.js"
+import { loadCustomModes, getSearchedPaths, type SearchedPath } from "../config/customModes.js"
+import type { ModeConfig } from "../types/messages.js"
+
+/**
+ * Output format for the modes API command
+ */
+export interface ModesApiOutput {
+	current: string
+	workspace: string
+	modes: Array<{
+		slug: string
+		name: string
+		description: string | null
+		source: "built-in" | "global" | "project" | "organization"
+		isCurrent: boolean
+	}>
+}
+
+/**
+ * Error output format
+ */
+export interface ModesApiError {
+	error: string
+	code: string
+}
+
+/**
+ * Options for the modes API command
+ */
+export interface ModesApiOptions {
+	workspace?: string
+}
+
+const DEFAULT_MODE_SLUGS = new Set(DEFAULT_MODES.map((mode) => mode.slug))
+
+function hasNonCommentContent(content: string): boolean {
+	return content.split("\n").some((line) => {
+		const trimmed = line.trim()
+		return trimmed !== "" && !trimmed.startsWith("#")
+	})
+}
+
+export function resolveModeSource(
+	mode: ModeConfig,
+	defaultModeSlugs: Set<string> = DEFAULT_MODE_SLUGS,
+): "built-in" | "global" | "project" | "organization" {
+	if (defaultModeSlugs.has(mode.slug) && !mode.source) {
+		return "built-in"
+	}
+	if (!mode.source) {
+		return "global"
+	}
+	return mode.source
+}
+
+export function buildModesOutput(params: {
+	currentMode: string
+	workspace: string
+	modes: ModeConfig[]
+}): ModesApiOutput {
+	return {
+		current: params.currentMode,
+		workspace: params.workspace,
+		modes: params.modes.map((mode) => ({
+			slug: mode.slug,
+			name: mode.name,
+			description: mode.description ?? null,
+			source: resolveModeSource(mode),
+			isCurrent: mode.slug === params.currentMode,
+		})),
+	}
+}
+
+async function validateCustomModesConfig(searchedPaths: SearchedPath[]): Promise<string | null> {
+	for (const searched of searchedPaths) {
+		if (!searched.found) {
+			continue
+		}
+
+		let content: string
+		try {
+			content = await readFile(searched.path, "utf-8")
+		} catch (error) {
+			logs.debug("Failed to read custom modes file", "ModesAPI", { path: searched.path, error })
+			return `Unable to read custom modes configuration at ${searched.path}`
+		}
+
+		if (!hasNonCommentContent(content)) {
+			continue
+		}
+
+		let parsed: unknown
+		try {
+			parsed = parse(content)
+		} catch (error) {
+			logs.debug("Failed to parse custom modes file", "ModesAPI", { path: searched.path, error })
+			return `Invalid custom modes configuration at ${searched.path}`
+		}
+
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return `Invalid custom modes configuration at ${searched.path}`
+		}
+
+		const { customModes } = parsed as { customModes?: unknown }
+		// Allow null/undefined (treated as empty array by parseCustomModes)
+		if (customModes !== null && customModes !== undefined && !Array.isArray(customModes)) {
+			return `Invalid custom modes configuration at ${searched.path}`
+		}
+	}
+
+	return null
+}
+
+/**
+ * Output result as JSON to stdout
+ */
+function outputJson(data: ModesApiOutput | ModesApiError): void {
+	console.log(JSON.stringify(data, null, 2))
+}
+
+/**
+ * Output error and exit
+ */
+function outputError(message: string, code: string): never {
+	outputJson({ error: message, code })
+	process.exit(1)
+}
+
+/**
+ * Main modes API command handler
+ */
+export async function modesApiCommand(options: ModesApiOptions = {}): Promise<void> {
+	try {
+		const workspace = resolve(options.workspace || process.cwd())
+
+		if (!existsSync(workspace)) {
+			outputError(`Workspace path does not exist: ${workspace}`, "WORKSPACE_NOT_FOUND")
+		}
+
+		logs.info("Starting modes API command", "ModesAPI", { workspace })
+
+		const store = createStore()
+		const config = await store.set(loadConfigAtom)
+
+		const customModes = await loadCustomModes(workspace)
+		const validationError = await validateCustomModesConfig(getSearchedPaths())
+		if (validationError) {
+			outputError(validationError, "INVALID_MODES_CONFIG")
+		}
+
+		const allModes = getAllModes(customModes)
+		const output = buildModesOutput({
+			currentMode: config.mode,
+			workspace,
+			modes: allModes,
+		})
+
+		outputJson(output)
+
+		logs.info("Modes API command completed successfully", "ModesAPI", {
+			modeCount: output.modes.length,
+		})
+	} catch (error) {
+		logs.error("Modes API command failed", "ModesAPI", { error })
+		outputError(error instanceof Error ? error.message : "An unexpected error occurred", "INTERNAL_ERROR")
+	}
+
+	process.exit(0)
+}

--- a/cli/src/commands/profile-api.ts
+++ b/cli/src/commands/profile-api.ts
@@ -1,0 +1,209 @@
+/**
+ * Profile API command - Exposes Kilocode profile data as JSON for programmatic use
+ *
+ * Usage:
+ *   kilocode profile
+ *
+ * Output format:
+ *   {
+ *     "authenticated": true,
+ *     "provider": "kilocode",
+ *     "user": {
+ *       "name": "Jane Doe",
+ *       "email": "jane@example.com"
+ *     },
+ *     "organization": {
+ *       "id": "org_123",
+ *       "name": "Example Org",
+ *       "role": "admin"
+ *     }
+ *   }
+ */
+
+import { createStore } from "jotai"
+import { loadConfigAtom } from "../state/atoms/config.js"
+import { logs } from "../services/logs.js"
+import { getKilocodeProfile, INVALID_TOKEN_ERROR } from "../auth/providers/kilocode/shared.js"
+import type { CLIConfig, ProviderConfig } from "../config/types.js"
+import type { KilocodeProfileData } from "../auth/types.js"
+
+/**
+ * Output format for the profile API command
+ */
+export interface ProfileApiOutput {
+	authenticated: boolean
+	provider: string | null
+	user?: {
+		name: string | null
+		email: string | null
+	}
+	organization?: {
+		id: string
+		name: string
+		role: string
+	}
+}
+
+/**
+ * Error output format
+ */
+export interface ProfileApiError {
+	error: string
+	code: string
+}
+
+function isNetworkErrorMessage(message: string): boolean {
+	const lowerMessage = message.toLowerCase()
+	return (
+		lowerMessage.includes("fetch failed") ||
+		lowerMessage.includes("network") ||
+		lowerMessage.includes("timeout") ||
+		lowerMessage.includes("timed out") ||
+		lowerMessage.includes("abort") ||
+		lowerMessage.includes("econn") ||
+		lowerMessage.includes("enotfound") ||
+		lowerMessage.includes("eai_again")
+	)
+}
+
+export function classifyProfileFetchError(error: Error): { code: string; message: string } {
+	if (error.message === INVALID_TOKEN_ERROR) {
+		return {
+			code: "NOT_AUTHENTICATED",
+			message: "Not authenticated. Run 'kilocode auth' to configure.",
+		}
+	}
+
+	// Check error.code for Node.js network errors (ETIMEDOUT, ECONNREFUSED, etc.)
+	const errorCode = (error as Error & { code?: string }).code
+	if (typeof errorCode === "string") {
+		const networkErrorCodes = ["ETIMEDOUT", "ECONNREFUSED", "ENOTFOUND", "EAI_AGAIN", "ECONNRESET", "ABORT_ERR"]
+		if (networkErrorCodes.includes(errorCode)) {
+			return {
+				code: "NETWORK_ERROR",
+				message: "Network error while fetching profile. Check your network connection and try again.",
+			}
+		}
+	}
+
+	const prefix = "Failed to fetch profile:"
+	if (error.message.startsWith(prefix)) {
+		const detail = error.message.slice(prefix.length).trim()
+
+		if (isNetworkErrorMessage(detail)) {
+			return {
+				code: "NETWORK_ERROR",
+				message: "Network error while fetching profile. Check your network connection and try again.",
+			}
+		}
+
+		if (/\b\d{3}\b/.test(detail)) {
+			return {
+				code: "API_ERROR",
+				message: error.message,
+			}
+		}
+	}
+
+	if (isNetworkErrorMessage(error.message)) {
+		return {
+			code: "NETWORK_ERROR",
+			message: "Network error while fetching profile. Check your network connection and try again.",
+		}
+	}
+
+	return {
+		code: "API_ERROR",
+		message: error.message,
+	}
+}
+
+export function buildProfileOutput(profile: KilocodeProfileData, provider: ProviderConfig): ProfileApiOutput {
+	const output: ProfileApiOutput = {
+		authenticated: true,
+		provider: provider.provider,
+	}
+
+	if (profile.user) {
+		output.user = {
+			name: profile.user.name ?? null,
+			email: profile.user.email ?? null,
+		}
+	}
+
+	if (provider.kilocodeOrganizationId && profile.organizations) {
+		const organization = profile.organizations.find((org) => org.id === provider.kilocodeOrganizationId)
+		if (organization) {
+			output.organization = {
+				id: organization.id,
+				name: organization.name,
+				role: organization.role,
+			}
+		}
+	}
+
+	return output
+}
+
+/**
+ * Output result as JSON to stdout
+ */
+function outputJson(data: ProfileApiOutput | ProfileApiError): void {
+	console.log(JSON.stringify(data, null, 2))
+}
+
+/**
+ * Output error and exit
+ */
+function outputError(message: string, code: string): never {
+	outputJson({ error: message, code })
+	process.exit(1)
+}
+
+function getCurrentProvider(config: CLIConfig): ProviderConfig | null {
+	return config.providers.find((provider) => provider.id === config.provider) || null
+}
+
+/**
+ * Main profile API command handler
+ */
+export async function profileApiCommand(): Promise<void> {
+	try {
+		logs.info("Starting profile API command", "ProfileAPI")
+
+		const store = createStore()
+		const config = await store.set(loadConfigAtom)
+
+		const currentProvider = getCurrentProvider(config)
+		if (!currentProvider) {
+			outputError(`Provider "${config.provider}" not found. Check your CLI configuration.`, "PROVIDER_NOT_FOUND")
+		}
+
+		if (currentProvider.provider !== "kilocode") {
+			outputError("Profile command requires Kilocode provider. Please switch providers.", "NOT_KILOCODE_PROVIDER")
+		}
+
+		const kilocodeToken = typeof currentProvider.kilocodeToken === "string" ? currentProvider.kilocodeToken : null
+		if (!kilocodeToken) {
+			outputError("Not authenticated. Run 'kilocode auth' to configure.", "NOT_AUTHENTICATED")
+		}
+
+		let profileData: KilocodeProfileData
+		try {
+			profileData = await getKilocodeProfile(kilocodeToken)
+		} catch (error) {
+			const errorInfo = classifyProfileFetchError(error as Error)
+			outputError(errorInfo.message, errorInfo.code)
+		}
+
+		const output = buildProfileOutput(profileData, currentProvider)
+		outputJson(output)
+
+		logs.info("Profile API command completed successfully", "ProfileAPI")
+	} catch (error) {
+		logs.error("Profile API command failed", "ProfileAPI", { error })
+		outputError(error instanceof Error ? error.message : "An unexpected error occurred", "INTERNAL_ERROR")
+	}
+
+	process.exit(0)
+}

--- a/cli/src/commands/providers-api.ts
+++ b/cli/src/commands/providers-api.ts
@@ -1,0 +1,110 @@
+/**
+ * Providers API command - Exposes configured providers as JSON for programmatic use
+ *
+ * Usage:
+ *   kilocode providers [list]
+ *
+ * Output format:
+ *   {
+ *     "current": "kilocode-1",
+ *     "providers": [
+ *       {
+ *         "id": "kilocode-1",
+ *         "type": "kilocode",
+ *         "label": "Kilo Code",
+ *         "model": "claude-sonnet-4",
+ *         "isCurrent": true
+ *       }
+ *     ]
+ *   }
+ */
+
+import { createStore } from "jotai"
+import { loadConfigAtom } from "../state/atoms/config.js"
+import { logs } from "../services/logs.js"
+import { getProviderLabel } from "../constants/providers/labels.js"
+import { getModelIdForProvider } from "../config/mapper.js"
+import type { CLIConfig } from "../config/types.js"
+
+/**
+ * Output format for the providers API command
+ */
+export interface ProvidersApiOutput {
+	current: string | null
+	providers: Array<{
+		id: string
+		type: string
+		label: string
+		model: string | null
+		isCurrent: boolean
+	}>
+}
+
+/**
+ * Error output format
+ */
+export interface ProvidersApiError {
+	error: string
+	code: string
+}
+
+function normalizeModelId(modelId: string): string | null {
+	return modelId === "" ? null : modelId
+}
+
+export function buildProvidersOutput(config: CLIConfig): ProvidersApiOutput {
+	const currentProvider = config.providers.find((provider) => provider.id === config.provider) || null
+
+	return {
+		current: currentProvider?.id ?? null,
+		providers: config.providers.map((provider) => {
+			const modelId = getModelIdForProvider(provider)
+			return {
+				id: provider.id,
+				type: provider.provider,
+				label: getProviderLabel(provider.provider),
+				model: normalizeModelId(modelId),
+				isCurrent: provider.id === currentProvider?.id,
+			}
+		}),
+	}
+}
+
+/**
+ * Output result as JSON to stdout
+ */
+function outputJson(data: ProvidersApiOutput | ProvidersApiError): void {
+	console.log(JSON.stringify(data, null, 2))
+}
+
+/**
+ * Output error and exit
+ */
+function outputError(message: string, code: string): never {
+	outputJson({ error: message, code })
+	process.exit(1)
+}
+
+/**
+ * Main providers API command handler
+ */
+export async function providersApiCommand(): Promise<void> {
+	try {
+		logs.info("Starting providers API command", "ProvidersAPI")
+
+		const store = createStore()
+		const config = await store.set(loadConfigAtom)
+
+		const output = buildProvidersOutput(config)
+		outputJson(output)
+
+		logs.info("Providers API command completed successfully", "ProvidersAPI", {
+			providerCount: output.providers.length,
+		})
+	} catch (error) {
+		logs.error("Providers API command failed", "ProvidersAPI", { error })
+		outputError(error instanceof Error ? error.message : "An unexpected error occurred", "INTERNAL_ERROR")
+	}
+
+	process.exit(0)
+}

--- a/cli/src/config/customModes.ts
+++ b/cli/src/config/customModes.ts
@@ -156,15 +156,18 @@ async function loadGlobalCustomModes(): Promise<{ modes: ModeConfig[]; pathInfo:
 		return { modes: [], pathInfo }
 	}
 
+	pathInfo.found = true
+
 	try {
 		const content = await readFile(globalPath, "utf-8")
 		const modes = parseCustomModes(content, "global")
-		pathInfo.found = true
 		pathInfo.modesCount = modes.length
 		logs.debug(`Loaded ${modes.length} global custom mode(s) from: ${globalPath}`, "CustomModes")
 		return { modes, pathInfo }
 	} catch (error) {
-		logs.debug(`Failed to read global custom modes file: ${globalPath}`, "CustomModes", { error })
+		logs.warn(`Custom modes file exists but cannot be read: ${globalPath}. File will be skipped.`, "CustomModes", {
+			error: error instanceof Error ? error.message : String(error),
+		})
 		return { modes: [], pathInfo }
 	}
 }
@@ -188,15 +191,18 @@ async function loadProjectCustomModes(workspace: string): Promise<{ modes: ModeC
 		return { modes: [], pathInfo }
 	}
 
+	pathInfo.found = true
+
 	try {
 		const content = await readFile(projectPath, "utf-8")
 		const modes = parseCustomModes(content, "project")
-		pathInfo.found = true
 		pathInfo.modesCount = modes.length
 		logs.debug(`Loaded ${modes.length} project custom mode(s) from: ${projectPath}`, "CustomModes")
 		return { modes, pathInfo }
 	} catch (error) {
-		logs.debug(`Failed to read project custom modes file: ${projectPath}`, "CustomModes", { error })
+		logs.warn(`Custom modes file exists but cannot be read: ${projectPath}. File will be skipped.`, "CustomModes", {
+			error: error instanceof Error ? error.message : String(error),
+		})
 		return { modes: [], pathInfo }
 	}
 }

--- a/cli/src/config/mapper.ts
+++ b/cli/src/config/mapper.ts
@@ -96,11 +96,25 @@ export function mapProviderToApiConfig(provider: ProviderConfig): ProviderSettin
 }
 
 export function getModelIdForProvider(provider: ProviderConfig): string {
+	// Handle providers not in core-schemas union via dynamic property access
+	// These are defined in @roo-code/types but not yet in @kilocode/core-schemas
+	const providerType = provider.provider as string
+	const providerWithDynamicProps = provider as Record<string, unknown>
+
+	if (providerType === "nano-gpt") {
+		return (providerWithDynamicProps.nanoGptModelId as string) || ""
+	}
+	if (providerType === "sap-ai-core") {
+		return (providerWithDynamicProps.sapAiCoreModelId as string) || ""
+	}
+	if (providerType === "baseten") {
+		return (providerWithDynamicProps.apiModelId as string) || ""
+	}
+
 	switch (provider.provider) {
 		case "kilocode":
 			return provider.kilocodeModel || ""
 		case "anthropic":
-			return provider.apiModelId || ""
 		case "openai-native":
 		case "openai-codex":
 			return provider.apiModelId || ""

--- a/cli/src/constants/modes/defaults.ts
+++ b/cli/src/constants/modes/defaults.ts
@@ -19,12 +19,27 @@ export const getModeBySlug = (slug: string, customModes: ModeConfig[] = []): Mod
 }
 
 /**
- * Get all available modes (default + custom)
+ * Get all available modes, with custom modes overriding built-in modes
  * @param customModes - Array of custom modes
  * @returns Array of all mode configurations
  */
 export const getAllModes = (customModes: ModeConfig[] = []): ModeConfig[] => {
-	return [...DEFAULT_MODES, ...customModes]
+	if (!customModes?.length) {
+		return [...DEFAULT_MODES]
+	}
+
+	const allModes = [...DEFAULT_MODES]
+
+	customModes.forEach((customMode) => {
+		const index = allModes.findIndex((mode) => mode.slug === customMode.slug)
+		if (index !== -1) {
+			allModes[index] = customMode
+		} else {
+			allModes.push(customMode)
+		}
+	})
+
+	return allModes
 }
 
 /**

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -67,7 +67,7 @@ program
 		// Subcommand names - if prompt matches one, Commander.js should handle it via subcommand
 		// This is a defensive check for cases where Commander.js routing might not work as expected
 		// (e.g., when spawned as a child process with stdin disconnected)
-		const SUBCOMMANDS = ["auth", "config", "debug", "models"]
+		const SUBCOMMANDS = ["auth", "config", "debug", "models", "providers", "modes", "profile"]
 		if (SUBCOMMANDS.includes(prompt)) {
 			return
 		}
@@ -402,6 +402,58 @@ program
 	.action(async (options: { provider?: string; json?: boolean }) => {
 		const { modelsApiCommand } = await import("./commands/models-api.js")
 		await modelsApiCommand(options)
+	})
+
+function validateListSubcommand(subcommand: string): void {
+	if (subcommand && subcommand !== "list") {
+		console.log(
+			JSON.stringify(
+				{
+					error: 'Unknown subcommand. Available: "list"',
+					code: "INVALID_SUBCOMMAND",
+				},
+				null,
+				2,
+			),
+		)
+		process.exit(1)
+	}
+}
+
+// Providers command - list configured providers as JSON
+program
+	.command("providers")
+	.description("List configured providers as JSON")
+	.argument("[subcommand]", "Subcommand: list", "list")
+	.action(async (subcommand: string) => {
+		validateListSubcommand(subcommand)
+
+		const { providersApiCommand } = await import("./commands/providers-api.js")
+		await providersApiCommand()
+	})
+
+// Modes command - list available modes as JSON
+program
+	.command("modes")
+	.description("List available modes as JSON")
+	.argument("[subcommand]", "Subcommand: list", "list")
+	.option("--workspace <path>", "Path to the workspace directory", process.cwd())
+	.action(async (subcommand: string, options: { workspace?: string }) => {
+		validateListSubcommand(subcommand)
+
+		const { modesApiCommand } = await import("./commands/modes-api.js")
+		// Normalize workspace to string (Commander.js default already ensures it's defined)
+		const workspace = options.workspace || process.cwd()
+		await modesApiCommand({ workspace })
+	})
+
+// Profile command - show current Kilocode profile as JSON
+program
+	.command("profile")
+	.description("Show profile information for the current Kilocode user as JSON")
+	.action(async () => {
+		const { profileApiCommand } = await import("./commands/profile-api.js")
+		await profileApiCommand()
 	})
 
 // Handle process termination signals

--- a/cli/src/utils/__tests__/getKilocodeProfile.test.ts
+++ b/cli/src/utils/__tests__/getKilocodeProfile.test.ts
@@ -127,6 +127,35 @@ describe("getKilocodeProfile", () => {
 		await expect(getKilocodeProfile("test-token")).rejects.toThrow("Failed to fetch profile: Invalid JSON")
 	})
 
+	it("should reject invalid profile schema", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				user: { name: 123 },
+				organizations: [],
+			}),
+		})
+
+		await expect(getKilocodeProfile("test-token")).rejects.toThrow("Failed to fetch profile:")
+	})
+
+	it("should normalize null profile fields", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				user: { name: null, email: null, image: null },
+				organizations: null,
+			}),
+		})
+
+		const result = await getKilocodeProfile("test-token")
+
+		expect(result.user?.name).toBeUndefined()
+		expect(result.user?.email).toBeUndefined()
+		expect(result.user?.image).toBeUndefined()
+		expect(result.organizations).toBeUndefined()
+	})
+
 	it("should handle empty token gracefully", async () => {
 		mockFetch.mockResolvedValueOnce({
 			ok: true,


### PR DESCRIPTION
## Context

Adds three new CLI subcommands that expose TUI features as standalone JSON APIs for CI/scripting use.

## Implementation

### New Subcommands

**`kilocode providers [list]`**
- List configured providers with model information
- JSON output: `{current, providers: [{id, type, label, model, isCurrent}]}`
- Secure: redacts tokens/API keys

**`kilocode modes [list] [--workspace <path>]`**
- List available modes (built-in + custom)
- JSON output: `{current, workspace, modes: [{slug, name, description, source, isCurrent}]}`
- Validates custom modes configuration

**`kilocode profile`**
- Show Kilocode user profile and organization
- JSON output: `{authenticated, provider, user?, organization?}`
- Error codes: PROVIDER_NOT_FOUND, NOT_KILOCODE_PROVIDER, NOT_AUTHENTICATED, NETWORK_ERROR, API_ERROR

### Design

- Consistent JSON output format (no schemaVersion, matching models command)
- Standardized error handling: `{"error": "...", "code": "ERROR_CODE"}` for all commands
- Exit codes: 0 = success, 1 = error
- Reuses existing modules: `loadConfigAtom`, `getProviderLabel`, `loadCustomModes`, `getKilocodeProfile`
- Comprehensive tests: 27 test cases (630+ lines) covering functionality, error paths, and security

### Additional Improvements

- README documentation with usage examples and JSON output formats
- Profile error classification: detect abort/timeout and use error.code
- Custom modes: warn when files exist but cannot be read
- Provider model mapping: fix nano-gpt, sap-ai-core, baseten for complete output
- Profile validation: add schema validation and null normalization for reliability

## Screenshots

N/A (CLI commands)

## How to Test

```bash
# Run tests
pnpm test src/commands/__tests__/providers-api.test.ts  # 7 tests
pnpm test src/commands/__tests__/modes-api.test.ts      # 8 tests
pnpm test src/commands/__tests__/profile-api.test.ts    # 12 tests

# Manual testing (requires configured CLI)
kilocode providers
kilocode modes
kilocode profile
```

## Get in Touch

@PeterDaveHello