### PR TITLE
refactor(cli): improve maintainability with code quality cleanup

### DIFF
--- a/cli/src/commands/core/registry.ts
+++ b/cli/src/commands/core/registry.ts
@@ -4,7 +4,7 @@
 
 import type { Command } from "./types.js"
 
-class CommandRegistry {
+export class CommandRegistry {
 	private commands: Map<string, Command> = new Map()
 	private aliases: Map<string, string> = new Map()
 
@@ -85,6 +85,3 @@ class CommandRegistry {
 
 // Export singleton instance
 export const commandRegistry = new CommandRegistry()
-
-// Export class for testing
-export { CommandRegistry }

--- a/cli/src/commands/model.ts
+++ b/cli/src/commands/model.ts
@@ -3,10 +3,10 @@
  */
 
 import type { Command, ArgumentProviderContext, CommandContext } from "./core/types.js"
-import type { ModelRecord } from "../constants/providers/models.js"
 import type { ProviderConfig } from "../config/types.js"
 import type { RouterModels } from "../types/messages.js"
 import {
+	type ModelRecord,
 	getModelsByProvider,
 	getCurrentModelId,
 	sortModelsByPreference,

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -1,9 +1,7 @@
 import React from "react"
-import { Provider as JotaiProvider } from "jotai"
+import { Provider as JotaiProvider, type createStore } from "jotai"
 import { UI } from "./UI.js"
 import { KeyboardProvider } from "./providers/KeyboardProvider.js"
-
-import type { createStore } from "jotai"
 
 type JotaiStore = ReturnType<typeof createStore>
 

--- a/cli/src/ui/messages/MessageRow.tsx
+++ b/cli/src/ui/messages/MessageRow.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { type UnifiedMessage } from "../../state/atoms/ui.js"
 import { CliMessageRow } from "./cli/CliMessageRow.js"
 import { ExtensionMessageRow } from "./extension/ExtensionMessageRow.js"
-//import { logs } from "../../services/logs.js"
 
 interface MessageRowProps {
 	unifiedMessage: UnifiedMessage

--- a/cli/src/utils/context.ts
+++ b/cli/src/utils/context.ts
@@ -3,9 +3,8 @@
  */
 
 import type { ExtensionChatMessage, ProviderSettings } from "../types/messages.js"
-import type { RouterModels } from "../constants/providers/models.js"
 import type { ProviderConfig } from "../config/types.js"
-import { getCurrentModelId, getModelsByProvider } from "../constants/providers/models.js"
+import { type RouterModels, getCurrentModelId, getModelsByProvider } from "../constants/providers/models.js"
 import { logs } from "../services/logs.js"
 
 // Default max tokens reserved for model output (matches Anthropic's default)


### PR DESCRIPTION
## Context

Consolidate duplicate imports and remove unnecessary code in CLI package for improved code quality.

## Implementation

- Removed commented-out debug import in `MessageRow.tsx`
- Inlined `CommandRegistry` export at class declaration instead of separate export statement
- Consolidated duplicate imports from same modules in `model.ts`, `App.tsx`, and `context.ts`

## Screenshots

N/A - Code refactoring only, no UI changes.

## How to Test

- Run `cd cli && pnpm build` to verify no build errors
- Run `cd cli && pnpm test` to verify tests pass

## GitHub Copilot Summary

> This pull request mainly focuses on improving type imports, streamlining exports, and cleaning up unused code in the CLI codebase. The most important changes are grouped below by theme:
> 
> **Type Import and Export Improvements:**
> 
> * Changed the import of `ModelRecord` in `cli/src/commands/model.ts` to use a type-only import for better type safety and consistency.
> * Updated the import in `cli/src/utils/context.ts` to use a type-only import for `RouterModels`, and grouped related imports together for clarity.
> * Combined the import of `Provider` and `createStore` from `jotai` in `cli/src/ui/App.tsx`, removing a redundant type-only import line.
> 
> **Export and Class Structure Updates:**
> 
> * Changed `CommandRegistry` to be exported directly as a class in `cli/src/commands/core/registry.ts`, rather than exporting it separately for testing; also removed the redundant export statement at the end of the file. [[1]](diffhunk://#diff-70c01136144acb20fd87336b676b0c7a596ce89982d25ecd636e9b0a4e436b9aL7-R7) [[2]](diffhunk://#diff-70c01136144acb20fd87336b676b0c7a596ce89982d25ecd636e9b0a4e436b9aL88-L90)
> 
> **Code Cleanup:**
> 
> * Removed a commented-out import for `logs` in `cli/src/ui/messages/MessageRow.tsx` to clean up unused code.

## Get in Touch

@PeterDaveHello



