### PR TITLE
Support refreshing MCP tool, resources, etc lists and avoid prompts

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -1421,7 +1421,12 @@ export class McpHub {
 			// kilocode_change - Reset reconnect attempts on successful connection
 			this.resetReconnectAttempts(name, source)
 
-			this.kiloNotificationService.connect(name, connection.client)
+			// kilocode_change start - Pass refresh callback to handle list_changed notifications
+			this.kiloNotificationService.connect(name, connection.client, async (serverName) => {
+				await this.fetchAvailableServerCapabilities(serverName, source)
+				await this.notifyWebviewOfServerChanges()
+			})
+			// kilocode_change end
 
 			// Initial fetch of tools and resources
 			await this.fetchAvailableServerCapabilities(name, source) // kilocode_change: logic moved into method

--- a/src/services/mcp/kilocode/NotificationService.ts
+++ b/src/services/mcp/kilocode/NotificationService.ts
@@ -1,18 +1,38 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { LoggingMessageNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
+import {
+	LoggingMessageNotificationSchema,
+	ResourceListChangedNotificationSchema,
+	ToolListChangedNotificationSchema,
+	PromptListChangedNotificationSchema,
+} from "@modelcontextprotocol/sdk/types.js"
 import * as vscode from "vscode"
 
 // Define LogLevel explicitly to avoid deep type inference issues
 export type LogLevel = "debug" | "info" | "notice" | "warning" | "error" | "critical" | "alert" | "emergency"
 
+/**
+ * Callback type for refreshing server capabilities when the MCP server
+ * notifies us that tools, resources, or prompts have changed.
+ */
+export type RefreshCapabilitiesCallback = (serverName: string) => Promise<void>
+
 export class NotificationService {
-	connect(name: string, client: Client): void {
+	/**
+	 * Connect notification handlers to an MCP client.
+	 *
+	 * @param name - The name of the MCP server (for logging purposes)
+	 * @param client - The MCP client to attach handlers to
+	 * @param onRefreshCapabilities - Optional callback to refresh server capabilities
+	 *        when the server notifies us of changes to tools, resources, or prompts
+	 */
+	connect(name: string, client: Client, onRefreshCapabilities?: RefreshCapabilitiesCallback): void {
+		// Handle logging messages from the server - these are intended for users
 		client.setNotificationHandler(LoggingMessageNotificationSchema, async (notification) => {
 			const params = notification.params || {}
 			const level = params.level || "info"
 			// `LoggingMessageNotificationSchema` defines `data`, not `message`.
 			// Keep backwards/compat handling by accepting either.
-			const data = (params as any).data || (params as any).message || "" // kilocode_change
+			const data = (params as any).data || (params as any).message || ""
 			const logger = params.logger || ""
 			const dataPrefix = logger ? `[${logger}]` : ``
 			const message = `MCP ${name}: ${dataPrefix}${data}`
@@ -32,8 +52,40 @@ export class NotificationService {
 			}
 		})
 
+		// Handle resource list changes - refresh capabilities silently
+		client.setNotificationHandler(ResourceListChangedNotificationSchema, async () => {
+			console.log(`MCP ${name}: resources list changed, refreshing capabilities`)
+			try {
+				await onRefreshCapabilities?.(name)
+			} catch (error) {
+				console.error(`MCP ${name}: failed to refresh capabilities after resource list change:`, error)
+			}
+		})
+
+		// Handle tool list changes - refresh capabilities silently
+		client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
+			console.log(`MCP ${name}: tools list changed, refreshing capabilities`)
+			try {
+				await onRefreshCapabilities?.(name)
+			} catch (error) {
+				console.error(`MCP ${name}: failed to refresh capabilities after tool list change:`, error)
+			}
+		})
+
+		// Handle prompt list changes - refresh capabilities silently
+		client.setNotificationHandler(PromptListChangedNotificationSchema, async () => {
+			console.log(`MCP ${name}: prompts list changed, refreshing capabilities`)
+			try {
+				await onRefreshCapabilities?.(name)
+			} catch (error) {
+				console.error(`MCP ${name}: failed to refresh capabilities after prompt list change:`, error)
+			}
+		})
+
+		// Fallback for any other unhandled notifications - log silently, don't notify user
+		// This prevents raw JSON-RPC messages from being displayed as VS Code notifications
 		client.fallbackNotificationHandler = async (notification) => {
-			vscode.window.showInformationMessage(`MCP ${name}: ${JSON.stringify(notification)}`)
+			console.log(`MCP ${name}: unhandled notification`, notification)
 		}
 	}
 }

--- a/src/services/mcp/kilocode/__tests__/NotificationService.spec.ts
+++ b/src/services/mcp/kilocode/__tests__/NotificationService.spec.ts
@@ -1,0 +1,346 @@
+import { NotificationService, RefreshCapabilitiesCallback } from "../NotificationService"
+import {
+	LoggingMessageNotificationSchema,
+	ResourceListChangedNotificationSchema,
+	ToolListChangedNotificationSchema,
+	PromptListChangedNotificationSchema,
+} from "@modelcontextprotocol/sdk/types.js"
+
+// Mock vscode
+const mockShowInformationMessage = vi.fn()
+const mockShowWarningMessage = vi.fn()
+const mockShowErrorMessage = vi.fn()
+
+vi.mock("vscode", () => ({
+	window: {
+		showInformationMessage: (...args: any[]) => mockShowInformationMessage(...args),
+		showWarningMessage: (...args: any[]) => mockShowWarningMessage(...args),
+		showErrorMessage: (...args: any[]) => mockShowErrorMessage(...args),
+	},
+}))
+
+describe("NotificationService", () => {
+	let notificationService: NotificationService
+	let mockClient: {
+		setNotificationHandler: ReturnType<typeof vi.fn>
+		fallbackNotificationHandler: ((notification: any) => Promise<void>) | null
+	}
+	let notificationHandlers: Map<any, (notification: any) => Promise<void>>
+	let mockConsoleLog: ReturnType<typeof vi.spyOn>
+	let mockConsoleError: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		// Mock console.log and console.error to verify logging behavior
+		mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {})
+		mockConsoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+		notificationService = new NotificationService()
+		notificationHandlers = new Map()
+
+		// Create a mock client that captures notification handlers
+		mockClient = {
+			setNotificationHandler: vi.fn((schema, handler) => {
+				notificationHandlers.set(schema, handler)
+			}),
+			fallbackNotificationHandler: null,
+		}
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	describe("connect", () => {
+		it("should register handlers for all notification types", () => {
+			notificationService.connect("test-server", mockClient as any)
+
+			expect(mockClient.setNotificationHandler).toHaveBeenCalledTimes(4)
+			expect(notificationHandlers.has(LoggingMessageNotificationSchema)).toBe(true)
+			expect(notificationHandlers.has(ResourceListChangedNotificationSchema)).toBe(true)
+			expect(notificationHandlers.has(ToolListChangedNotificationSchema)).toBe(true)
+			expect(notificationHandlers.has(PromptListChangedNotificationSchema)).toBe(true)
+		})
+
+		it("should set a fallback notification handler", () => {
+			notificationService.connect("test-server", mockClient as any)
+
+			expect(mockClient.fallbackNotificationHandler).toBeDefined()
+		})
+	})
+
+	describe("LoggingMessage notifications", () => {
+		it("should show info message for info level", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const handler = notificationHandlers.get(LoggingMessageNotificationSchema)!
+
+			await handler({
+				params: {
+					level: "info",
+					data: "Test info message",
+				},
+			})
+
+			expect(mockShowInformationMessage).toHaveBeenCalledWith("MCP test-server: Test info message")
+		})
+
+		it("should show warning message for warning level", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const handler = notificationHandlers.get(LoggingMessageNotificationSchema)!
+
+			await handler({
+				params: {
+					level: "warning",
+					data: "Test warning message",
+				},
+			})
+
+			expect(mockShowWarningMessage).toHaveBeenCalledWith("MCP test-server: Test warning message")
+		})
+
+		it("should show warning message for alert level", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const handler = notificationHandlers.get(LoggingMessageNotificationSchema)!
+
+			await handler({
+				params: {
+					level: "alert",
+					data: "Test alert message",
+				},
+			})
+
+			expect(mockShowWarningMessage).toHaveBeenCalledWith("MCP test-server: Test alert message")
+		})
+
+		it("should show error message for error level", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const handler = notificationHandlers.get(LoggingMessageNotificationSchema)!
+
+			await handler({
+				params: {
+					level: "error",
+					data: "Test error message",
+				},
+			})
+
+			expect(mockShowErrorMessage).toHaveBeenCalledWith("MCP test-server: Test error message")
+		})
+
+		it("should show error message for critical level", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const handler = notificationHandlers.get(LoggingMessageNotificationSchema)!
+
+			await handler({
+				params: {
+					level: "critical",
+					data: "Test critical message",
+				},
+			})
+
+			expect(mockShowErrorMessage).toHaveBeenCalledWith("MCP test-server: Test critical message")
+		})
+
+		it("should show error message for emergency level", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const handler = notificationHandlers.get(LoggingMessageNotificationSchema)!
+
+			await handler({
+				params: {
+					level: "emergency",
+					data: "Test emergency message",
+				},
+			})
+
+			expect(mockShowErrorMessage).toHaveBeenCalledWith("MCP test-server: Test emergency message")
+		})
+
+		it("should include logger prefix when provided", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const handler = notificationHandlers.get(LoggingMessageNotificationSchema)!
+
+			await handler({
+				params: {
+					level: "info",
+					logger: "MyLogger",
+					data: "Test message",
+				},
+			})
+
+			expect(mockShowInformationMessage).toHaveBeenCalledWith("MCP test-server: [MyLogger]Test message")
+		})
+
+		it("should use message field if data is not provided", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const handler = notificationHandlers.get(LoggingMessageNotificationSchema)!
+
+			await handler({
+				params: {
+					level: "info",
+					message: "Test from message field",
+				},
+			})
+
+			expect(mockShowInformationMessage).toHaveBeenCalledWith("MCP test-server: Test from message field")
+		})
+
+		it("should default to info level when not specified", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const handler = notificationHandlers.get(LoggingMessageNotificationSchema)!
+
+			await handler({
+				params: {
+					data: "Test message without level",
+				},
+			})
+
+			expect(mockShowInformationMessage).toHaveBeenCalledWith("MCP test-server: Test message without level")
+		})
+	})
+
+	describe("ResourceListChanged notifications", () => {
+		it("should call refresh callback when resources change", async () => {
+			const mockRefreshCallback: RefreshCapabilitiesCallback = vi.fn().mockResolvedValue(undefined)
+			notificationService.connect("test-server", mockClient as any, mockRefreshCallback)
+			const handler = notificationHandlers.get(ResourceListChangedNotificationSchema)!
+
+			await handler({})
+
+			expect(mockRefreshCallback).toHaveBeenCalledWith("test-server")
+			expect(mockConsoleLog).toHaveBeenCalledWith(
+				"MCP test-server: resources list changed, refreshing capabilities",
+			)
+		})
+
+		it("should not throw when no refresh callback is provided", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const handler = notificationHandlers.get(ResourceListChangedNotificationSchema)!
+
+			await expect(handler({})).resolves.not.toThrow()
+			expect(mockConsoleLog).toHaveBeenCalledWith(
+				"MCP test-server: resources list changed, refreshing capabilities",
+			)
+		})
+
+		it("should log error when refresh callback fails", async () => {
+			const mockRefreshCallback: RefreshCapabilitiesCallback = vi
+				.fn()
+				.mockRejectedValue(new Error("Refresh failed"))
+			notificationService.connect("test-server", mockClient as any, mockRefreshCallback)
+			const handler = notificationHandlers.get(ResourceListChangedNotificationSchema)!
+
+			await handler({})
+
+			expect(mockConsoleError).toHaveBeenCalledWith(
+				"MCP test-server: failed to refresh capabilities after resource list change:",
+				expect.any(Error),
+			)
+		})
+
+		it("should not show user notification for resource changes", async () => {
+			const mockRefreshCallback: RefreshCapabilitiesCallback = vi.fn().mockResolvedValue(undefined)
+			notificationService.connect("test-server", mockClient as any, mockRefreshCallback)
+			const handler = notificationHandlers.get(ResourceListChangedNotificationSchema)!
+
+			await handler({})
+
+			expect(mockShowInformationMessage).not.toHaveBeenCalled()
+			expect(mockShowWarningMessage).not.toHaveBeenCalled()
+			expect(mockShowErrorMessage).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("ToolListChanged notifications", () => {
+		it("should call refresh callback when tools change", async () => {
+			const mockRefreshCallback: RefreshCapabilitiesCallback = vi.fn().mockResolvedValue(undefined)
+			notificationService.connect("test-server", mockClient as any, mockRefreshCallback)
+			const handler = notificationHandlers.get(ToolListChangedNotificationSchema)!
+
+			await handler({})
+
+			expect(mockRefreshCallback).toHaveBeenCalledWith("test-server")
+			expect(mockConsoleLog).toHaveBeenCalledWith("MCP test-server: tools list changed, refreshing capabilities")
+		})
+
+		it("should not throw when no refresh callback is provided", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const handler = notificationHandlers.get(ToolListChangedNotificationSchema)!
+
+			await expect(handler({})).resolves.not.toThrow()
+		})
+
+		it("should log error when refresh callback fails", async () => {
+			const mockRefreshCallback: RefreshCapabilitiesCallback = vi
+				.fn()
+				.mockRejectedValue(new Error("Refresh failed"))
+			notificationService.connect("test-server", mockClient as any, mockRefreshCallback)
+			const handler = notificationHandlers.get(ToolListChangedNotificationSchema)!
+
+			await handler({})
+
+			expect(mockConsoleError).toHaveBeenCalledWith(
+				"MCP test-server: failed to refresh capabilities after tool list change:",
+				expect.any(Error),
+			)
+		})
+	})
+
+	describe("PromptListChanged notifications", () => {
+		it("should call refresh callback when prompts change", async () => {
+			const mockRefreshCallback: RefreshCapabilitiesCallback = vi.fn().mockResolvedValue(undefined)
+			notificationService.connect("test-server", mockClient as any, mockRefreshCallback)
+			const handler = notificationHandlers.get(PromptListChangedNotificationSchema)!
+
+			await handler({})
+
+			expect(mockRefreshCallback).toHaveBeenCalledWith("test-server")
+			expect(mockConsoleLog).toHaveBeenCalledWith(
+				"MCP test-server: prompts list changed, refreshing capabilities",
+			)
+		})
+
+		it("should not throw when no refresh callback is provided", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const handler = notificationHandlers.get(PromptListChangedNotificationSchema)!
+
+			await expect(handler({})).resolves.not.toThrow()
+		})
+
+		it("should log error when refresh callback fails", async () => {
+			const mockRefreshCallback: RefreshCapabilitiesCallback = vi
+				.fn()
+				.mockRejectedValue(new Error("Refresh failed"))
+			notificationService.connect("test-server", mockClient as any, mockRefreshCallback)
+			const handler = notificationHandlers.get(PromptListChangedNotificationSchema)!
+
+			await handler({})
+
+			expect(mockConsoleError).toHaveBeenCalledWith(
+				"MCP test-server: failed to refresh capabilities after prompt list change:",
+				expect.any(Error),
+			)
+		})
+	})
+
+	describe("Fallback notification handler", () => {
+		it("should log unknown notifications without showing user notification", async () => {
+			notificationService.connect("test-server", mockClient as any)
+			const fallbackHandler = mockClient.fallbackNotificationHandler!
+
+			await fallbackHandler({
+				jsonrpc: "2.0",
+				method: "unknown/notification",
+				params: { foo: "bar" },
+			})
+
+			expect(mockConsoleLog).toHaveBeenCalledWith("MCP test-server: unhandled notification", {
+				jsonrpc: "2.0",
+				method: "unknown/notification",
+				params: { foo: "bar" },
+			})
+			expect(mockShowInformationMessage).not.toHaveBeenCalled()
+			expect(mockShowWarningMessage).not.toHaveBeenCalled()
+			expect(mockShowErrorMessage).not.toHaveBeenCalled()
+		})
+	})
+})


### PR DESCRIPTION
Vibe coded, tested but not reviewed at a code level, in draft. This PR attempts to do two things:

1. Remove the annoying MCP tool change notifications that appear on extension init and provider changes.
2. Support refreshing the MCP cache when an MCP server informs it that tools/resource/etc lists have changed. 

The primary importance IMO is hiding the notifications by properly handling them. The bonus is improvement support for MCP, as there is a risk that these tool lists could change after initial load and this better supports that. 

Here is the offending notifications: 
<img width="974" height="540" alt="image" src="https://github.com/user-attachments/assets/158f22c9-02aa-489d-9db5-847e7b32243f" />
