### PR TITLE
Fix WSL terminal not loading user's bashrc

### DIFF
--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/WeCoderTerminalCustomizer.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/terminal/WeCoderTerminalCustomizer.kt
@@ -175,6 +175,11 @@ class WeCoderTerminalCustomizer : LocalTerminalCustomizer() {
      * Falls back to manual conversion if distribution is not available.
      */
     private fun convertToWslPath(windowsPath: String, distribution: WSLDistribution?): String {
+        // If already a Linux/WSL path, return as-is
+        if (windowsPath.startsWith("/")) {
+            return windowsPath
+        }
+
         // Try using the JetBrains WSL API first
         if (distribution != null) {
             try {


### PR DESCRIPTION
Fixes #5403

## Context

When using Kilocode with JetBrains IDEs on Windows with WSL terminals, the user's `~/.bashrc` was not being loaded. This resulted in missing PATH entries, aliases, and environment setup.

The root cause: shell integration script paths were passed as Windows paths (`C:\Users\...`) which bash running in WSL cannot read. It needs Linux-style paths (`/mnt/c/Users/...`).

## Implementation

- Added `getWslDistribution()` to detect WSL terminals using JetBrains WSL API:
  - Parses UNC path from working directory via `WslPath.parseWindowsUncPath()`
  - Checks `WSL_DISTRO_NAME` environment variable
  - Falls back to first installed distribution if shell command is Linux-style path
- Added `convertToWslPath()` using `WSLDistribution.getWslPath()` for path conversion with manual fallback for edge cases
- Updated injection methods to pass `WSLDistribution?` instead of boolean flag

Uses JetBrains platform APIs (`com.intellij.execution.wsl.*`) which are already bundled - no new dependencies.

## Screenshots

| before | after |
| ------ | ----- |
| `--rcfile C:\Users\mkore\.kilocode-shell-integrations\vscode-bash\bashrc` | `--rcfile /mnt/c/Users/mkore/.kilocode-shell-integrations/vscode-bash/bashrc` |

## How to Test

1. Open a project from a WSL path in IntelliJ on Windows
2. Ensure `~/.bashrc` has visible side effects (e.g., `alias ll='ls -la'`)
3. Open terminal (Alt+F12)
4. Verify bashrc was loaded:
   ```bash
   ll  # Should work if alias is defined in bashrc
   cat /proc/$$/cmdline | tr '\0' '\n'  # Should show /mnt/c/... path
   ```

## Get in Touch

Discord: maxkoretskyi
