### PR TITLE
feat: allow kilocode provider to work without token

### DIFF
--- a/.changeset/kilocode-anonymous-access.md
+++ b/.changeset/kilocode-anonymous-access.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Allow kilocode provider to work without token (anonymous access)

--- a/src/api/providers/kilocode-openrouter.ts
+++ b/src/api/providers/kilocode-openrouter.ts
@@ -120,8 +120,9 @@ export class KilocodeOpenrouterHandler extends OpenRouterHandler {
 	}
 
 	public override async fetchModel() {
-		if (!this.options.kilocodeToken || !this.options.openRouterBaseUrl) {
-			throw new Error(KILOCODE_TOKEN_REQUIRED_ERROR)
+		// kilocode_change: Allow anonymous access - only require openRouterBaseUrl
+		if (!this.options.openRouterBaseUrl) {
+			throw new Error("OpenRouter base URL is required")
 		}
 
 		const [models, endpoints, defaultModel] = await Promise.all([

--- a/src/api/providers/kilocode/getKilocodeDefaultModel.ts
+++ b/src/api/providers/kilocode/getKilocodeDefaultModel.ts
@@ -15,17 +15,20 @@ const defaultsSchema = z.object({
 })
 
 async function fetchKilocodeDefaultModel(
-	kilocodeToken: KilocodeToken,
+	kilocodeToken?: KilocodeToken,
 	organizationId?: OrganizationId,
 	providerSettings?: ProviderSettings,
 ): Promise<string> {
 	try {
 		const path = organizationId ? `/organizations/${organizationId}/defaults` : `/defaults`
-		const url = getKiloUrlFromToken(`https://api.kilo.ai/api${path}`, kilocodeToken)
+		const url = getKiloUrlFromToken(`https://api.kilo.ai/api${path}`, kilocodeToken ?? "")
 
+		// kilocode_change: Make Authorization header optional for anonymous access
 		const headers: Record<string, string> = {
 			...DEFAULT_HEADERS,
-			Authorization: `Bearer ${kilocodeToken}`,
+		}
+		if (kilocodeToken) {
+			headers.Authorization = `Bearer ${kilocodeToken}`
 		}
 
 		// Add X-KILOCODE-TESTER: SUPPRESS header if the setting is enabled
@@ -61,11 +64,9 @@ export async function getKilocodeDefaultModel(
 	organizationId?: OrganizationId,
 	providerSettings?: ProviderSettings,
 ): Promise<string> {
-	if (!kilocodeToken) {
-		return openRouterDefaultModelId
-	}
+	// kilocode_change: Remove early return - allow fetching default model without token for anonymous access
 	const key = JSON.stringify({
-		kilocodeToken,
+		kilocodeToken: kilocodeToken ?? "anonymous",
 		organizationId,
 		testerSuppressed: providerSettings?.kilocodeTesterWarningsDisabledUntil,
 	})


### PR DESCRIPTION
## Summary

This PR removes the token requirement from the kilocode provider, allowing anonymous access to the Kilo Code Gateway.

## Changes

### File 1: `src/api/providers/kilocode-openrouter.ts`
- Changed the `fetchModel()` check to only require `openRouterBaseUrl` instead of both token and URL
- Removed the `KILOCODE_TOKEN_REQUIRED_ERROR` throw when no token is present

### File 2: `src/api/providers/kilocode/getKilocodeDefaultModel.ts`
- Made the `kilocodeToken` parameter optional in `fetchKilocodeDefaultModel()`
- Made the Authorization header conditional (only added when token is present)
- Removed the early return that blocked fetching default model without a token
- Updated cache key to use "anonymous" when no token is provided

## Testing

- [ ] Verify anonymous users can use the kilocode provider
- [ ] Verify authenticated users still work correctly