### PR TITLE
Fix #3551 - Refreshing models with LiteLLM provider returned 400 with Kilocode Cli

### DIFF
--- a/.changeset/fifty-parts-pick.md
+++ b/.changeset/fifty-parts-pick.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+fix #3551 for KiloCode to be able to refresh model lists from LiteLLM provider

--- a/cli/src/services/models/fetcher.ts
+++ b/cli/src/services/models/fetcher.ts
@@ -82,6 +82,19 @@ export async function fetchRouterModels(
 		})
 
 		// Send requestRouterModels message
+		// For litellm provider, pass credentials in message values to ensure they're available
+		// even if the injected configuration hasn't been fully processed yet.
+		// This matches the pattern used by the webview UI when refreshing models.
+		const messageValues: Record<string, unknown> = {}
+		if (provider.provider === "litellm") {
+			if (provider.litellmApiKey) {
+				messageValues.litellmApiKey = provider.litellmApiKey
+			}
+			if (provider.litellmBaseUrl) {
+				messageValues.litellmBaseUrl = provider.litellmBaseUrl
+			}
+		}
+
 		await service.sendWebviewMessage({
 			type: "requestRouterModels",
 		})


### PR DESCRIPTION

## Context

Based on the large fix from PR #4793, this fixes the litellm provider model refresh for Kilocode Cli.  


## Implementation

Pass litellm credentials directly in the requestRouterModels message to ensure availability before config processing completes.

## How to Test

- Configure a litellm proxy backend with a working api key 
- Set litellm as the current providers 

- Run: kilocode models 

```
kilocode models
{
  "error": "No models available for provider \"litellm\". The provider may require authentication or the model list could not be fetched.",
  "code": "NO_MODELS_AVAILABLE"
}

```

After the fix, kilocode models will return all available models provided by the litellm backend. 


## Get in Touch

dan-and 

Fixes #3551 

