### PR TITLE
fix(cli): add Model ID field to OpenAI Compatible provider

### DIFF
--- a/.changeset/cli-openai-model-id.md
+++ b/.changeset/cli-openai-model-id.md
@@ -1,0 +1,13 @@
+---
+"@kilocode/cli": patch
+---
+
+Add Model ID field to OpenAI Compatible provider in CLI settings
+
+Fixes #5236. The OpenAI Compatible provider was missing a Model ID input field in the CLI setup wizard, preventing users from specifying custom models when using VLLM or other OpenAI-compatible endpoints.
+
+Changes:
+
+- Added `openAiModelId` to required fields in `validation.ts`
+- Added Model ID field metadata in `FIELD_REGISTRY` in `settings.ts`
+- Added Model ID input field to the OpenAI Compatible provider settings UI

--- a/cli/src/constants/providers/settings.ts
+++ b/cli/src/constants/providers/settings.ts
@@ -354,6 +354,11 @@ export const FIELD_REGISTRY: Record<string, FieldMetadata> = {
 		placeholder: "Enter base URL (or leave empty for default)...",
 		isOptional: true,
 	},
+	openAiModelId: {
+		label: "Model ID",
+		type: "text",
+		placeholder: "Enter model ID (e.g., gpt-4, llama-3.1-70b)...",
+	},
 
 	// Glama fields
 	glamaApiKey: {
@@ -876,7 +881,11 @@ export const getProviderSettings = (provider: ProviderName, config: ProviderSett
 			]
 
 		case "openai":
-			return [createFieldConfig("openAiApiKey", config), createFieldConfig("openAiBaseUrl", config, "Default")]
+			return [
+				createFieldConfig("openAiApiKey", config),
+				createFieldConfig("openAiModelId", config),
+				createFieldConfig("openAiBaseUrl", config, "Default"),
+			]
 
 		case "glama":
 			return [

--- a/cli/src/constants/providers/validation.ts
+++ b/cli/src/constants/providers/validation.ts
@@ -19,7 +19,7 @@ export const PROVIDER_REQUIRED_FIELDS: Record<ProviderName, string[]> = {
 	groq: ["groqApiKey", "apiModelId"],
 	deepseek: ["deepSeekApiKey", "apiModelId"],
 	xai: ["xaiApiKey", "apiModelId"],
-	openai: ["openAiApiKey"],
+	openai: ["openAiApiKey", "openAiModelId"],
 	"openai-responses": ["openAiApiKey"],
 	cerebras: ["cerebrasApiKey", "apiModelId"],
 	glama: ["glamaApiKey", "glamaModelId"],


### PR DESCRIPTION
## Context

Fixes #5236. The OpenAI Compatible provider in the CLI setup wizard was missing a Model ID input field.

## Implementation

Added `openAiModelId` field to match the existing environment variable validation:

1. **validation.ts**: Added `openAiModelId` to required fields for `openai` provider
2. **settings.ts**: Added field metadata and included Model ID input in settings UI

## How to Test

1. Run the CLI and select "OpenAI Compatible" provider during setup
2. Verify "Model ID" field appears and is required
3. Complete setup and check `~/.kilocode-cli/config.json` contains `openAiModelId`
