### PR TITLE
fix(docs): remove self-referencing redirects causing redirect loops

### DIFF
--- a/.changeset/fix-docs-redirect-loop.md
+++ b/.changeset/fix-docs-redirect-loop.md
@@ -1,0 +1,5 @@
+---
+"kilocode-docs": patch
+---
+
+Fix redirect loops in docs by removing self-referencing redirects

--- a/apps/kilocode-docs/previous-docs-redirects.js
+++ b/apps/kilocode-docs/previous-docs-redirects.js
@@ -3,12 +3,6 @@ module.exports = [
 	// GET STARTED
 	// ============================================
 	{
-		source: "/docs/getting-started/quickstart",
-		destination: "/docs/getting-started/quickstart",
-		basePath: false,
-		permanent: true,
-	},
-	{
 		source: "/docs/getting-started/setting-up",
 		destination: "/docs/getting-started/setup-authentication",
 		basePath: false,
@@ -555,20 +549,8 @@ module.exports = [
 	// CONTRIBUTING
 	// ============================================
 	{
-		source: "/docs/contributing",
-		destination: "/docs/contributing",
-		basePath: false,
-		permanent: true,
-	},
-	{
 		source: "/docs/contributing/index",
 		destination: "/docs/contributing",
-		basePath: false,
-		permanent: true,
-	},
-	{
-		source: "/docs/contributing/development-environment",
-		destination: "/docs/contributing/development-environment",
 		basePath: false,
 		permanent: true,
 	},
@@ -577,56 +559,14 @@ module.exports = [
 	// CONTRIBUTING - Architecture
 	// ============================================
 	{
-		source: "/docs/contributing/architecture",
-		destination: "/docs/contributing/architecture",
-		basePath: false,
-		permanent: true,
-	},
-	{
 		source: "/docs/contributing/architecture/index",
 		destination: "/docs/contributing/architecture",
 		basePath: false,
 		permanent: true,
 	},
 	{
-		source: "/docs/contributing/architecture/annual-billing",
-		destination: "/docs/contributing/architecture/annual-billing",
-		basePath: false,
-		permanent: true,
-	},
-	{
-		source: "/docs/contributing/architecture/enterprise-mcp-controls",
-		destination: "/docs/contributing/architecture/enterprise-mcp-controls",
-		basePath: false,
-		permanent: true,
-	},
-	{
 		source: "/docs/contributing/architecture/onboarding-engagement-improvements",
 		destination: "/docs/contributing/architecture/onboarding-improvements",
-		basePath: false,
-		permanent: true,
-	},
-	{
-		source: "/docs/contributing/architecture/organization-modes-library",
-		destination: "/docs/contributing/architecture/organization-modes-library",
-		basePath: false,
-		permanent: true,
-	},
-	{
-		source: "/docs/contributing/architecture/track-repo-url",
-		destination: "/docs/contributing/architecture/track-repo-url",
-		basePath: false,
-		permanent: true,
-	},
-	{
-		source: "/docs/contributing/architecture/vercel-ai-gateway",
-		destination: "/docs/contributing/architecture/vercel-ai-gateway",
-		basePath: false,
-		permanent: true,
-	},
-	{
-		source: "/docs/contributing/architecture/voice-transcription",
-		destination: "/docs/contributing/architecture/voice-transcription",
 		basePath: false,
 		permanent: true,
 	},


### PR DESCRIPTION
## Summary

Fixes redirect loops in the docs site by removing 10 self-referencing redirects where `source` equals `destination`.

## Problem

The following redirects were causing infinite redirect loops because they redirect to themselves:

- `/docs/getting-started/quickstart`
- `/docs/contributing`
- `/docs/contributing/development-environment`
- `/docs/contributing/architecture`
- `/docs/contributing/architecture/annual-billing`
- `/docs/contributing/architecture/enterprise-mcp-controls`
- `/docs/contributing/architecture/organization-modes-library`
- `/docs/contributing/architecture/track-repo-url`
- `/docs/contributing/architecture/vercel-ai-gateway`
- `/docs/contributing/architecture/voice-transcription`

## Solution

Removed these self-referencing redirects entirely. Useful redirects (like `/docs/contributing/index` → `/docs/contributing`) were preserved.