### PR TITLE
Optimize Docker image build for CLI

### DIFF
--- a/cli/.dockerignore
+++ b/cli/.dockerignore
@@ -1,0 +1,32 @@
+# Dependencies
+node_modules/
+
+# Build cache
+.turbo/
+
+# Local data
+.kilocode-cli/
+
+# Source (not needed, we use pre-built tgz)
+src/
+docs/
+integration-tests/
+scripts/
+
+# Config files
+*.config.*
+tsconfig.json
+vitest.config.ts
+eslint.config.mjs
+turbo.json
+
+# Git
+.git/
+.gitignore
+
+# Docs (keep README for reference)
+*.md
+!README.md
+
+# Logs
+*.log

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -35,7 +35,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
 FROM node:20.20.0-bookworm-slim AS debian_base
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     make \
     g++ \
@@ -97,7 +97,9 @@ LABEL org.opencontainers.image.created="${BUILD_DATE}" \
 
 # Install App
 COPY dist/kilocode-cli-${VERSION}.tgz /tmp/kilocode-cli.tgz
-RUN npm install -g /tmp/kilocode-cli.tgz && rm /tmp/kilocode-cli.tgz
+RUN npm install -g /tmp/kilocode-cli.tgz \
+    && rm /tmp/kilocode-cli.tgz \
+    && npm cache clean --force
 
 USER kilocode
 WORKDIR /workspace
@@ -126,7 +128,9 @@ LABEL org.opencontainers.image.created="${BUILD_DATE}" \
 
 # Install App
 COPY dist/kilocode-cli-${VERSION}.tgz /tmp/kilocode-cli.tgz
-RUN npm install -g /tmp/kilocode-cli.tgz && rm /tmp/kilocode-cli.tgz
+RUN npm install -g /tmp/kilocode-cli.tgz \
+    && rm /tmp/kilocode-cli.tgz \
+    && npm cache clean --force
 
 USER kilocode
 WORKDIR /workspace

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -85,6 +85,9 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
 
+# Validate VERSION is provided
+RUN test -n "$VERSION" || (echo "ERROR: VERSION build arg is required" && exit 1)
+
 # Apply Labels
 LABEL org.opencontainers.image.created="${BUILD_DATE}" \
     org.opencontainers.image.revision="${VCS_REF}" \
@@ -115,6 +118,9 @@ FROM debian_base AS debian
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
+
+# Validate VERSION is provided
+RUN test -n "$VERSION" || (echo "ERROR: VERSION build arg is required" && exit 1)
 
 # Apply Labels
 LABEL org.opencontainers.image.created="${BUILD_DATE}" \


### PR DESCRIPTION
## Context

Optimize the CLI Docker images by reducing build context size, trimming Debian
install recommendations, and failing early when VERSION is missing.

## Implementation

- Add `.dockerignore` to keep build context minimal while retaining `dist/`.
- Use `--no-install-recommends` for Debian dependencies.
- Clean npm cache after global install to reduce image size.
- Validate `VERSION` build arg in both final stages to provide a clear error.

## How to Test

- From repo root:

```bash
pnpm install
pnpm cli:bundle
(cd cli/dist && npm pack)

cd cli
VERSION=$(node -p "require('./package.json').version")
BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
VCS_REF=$(git rev-parse HEAD)

docker build --target alpine \
  --build-arg VERSION=$VERSION \
  --build-arg BUILD_DATE=$BUILD_DATE \
  --build-arg VCS_REF=$VCS_REF \
  -t kilocode-cli:alpine .

docker build --target debian \
  --build-arg VERSION=$VERSION \
  --build-arg BUILD_DATE=$BUILD_DATE \
  --build-arg VCS_REF=$VCS_REF \
  -t kilocode-cli:debian .
```

## GitHub Copilot summary

> This pull request improves the Docker build for the CLI by cleaning up the build context, enforcing best practices, and optimizing image size. The most important changes include adding a `.dockerignore` file to exclude unnecessary files, validating required build arguments, and cleaning up the npm cache after installation.
> 
> **Docker build context and image optimization:**
> 
> * Added a new `.dockerignore` file to exclude dependencies, build cache, local data, source files, documentation, config files, git files, logs, and all markdown files except `README.md`, reducing build context size and improving build performance.
> * Updated `cli/Dockerfile` to use `--no-install-recommends` when installing system dependencies, minimizing unnecessary packages and reducing image size.
> 
> **Build reliability and correctness:**
> 
> * Added a check in `cli/Dockerfile` to ensure the `VERSION` build argument is provided, failing the build with a clear error message if missing. [[1]](diffhunk://#diff-53fad39439c11209d1fd09c9c8dc733647e91161167f7daf14df477b78f06472R88-R90) [[2]](diffhunk://#diff-53fad39439c11209d1fd09c9c8dc733647e91161167f7daf14df477b78f06472R122-R124)
> 
> **Post-installation cleanup:**
> 
> * Modified the npm installation step in `cli/Dockerfile` to clean the npm cache after installing the CLI package, further reducing image size. [[1]](diffhunk://#diff-53fad39439c11209d1fd09c9c8dc733647e91161167f7daf14df477b78f06472L100-R105) [[2]](diffhunk://#diff-53fad39439c11209d1fd09c9c8dc733647e91161167f7daf14df477b78f06472L129-R139)

## Get in Touch

@PeterDaveHello 