### PR TITLE
docs(cli): fix broken link to Development Guide in CLI README

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -292,4 +292,4 @@ This instructs the AI to proceed without user input.
 
 ## Local Development
 
-See [Development Guide](cli/docs/DEVELOPMENT.md) for setup instructions.
+See [Development Guide](docs/DEVELOPMENT.md) for setup instructions.


### PR DESCRIPTION
## Context

Fixed a broken documentation link in the CLI README. The link to the Development Guide was pointing to an incorrect path (`cli/docs/DEVELOPMENT.md`) which would result in a 404 error. The correct path is `docs/DEVELOPMENT.md` relative to the CLI directory.

## Implementation

Simple path correction in the README markdown link. The file structure shows that `DEVELOPMENT.md` is located at `cli/docs/DEVELOPMENT.md` from the repository root, but since the README is already inside the `cli/` directory, the relative link should be `docs/DEVELOPMENT.md` not `cli/docs/DEVELOPMENT.md`.

## Screenshots

| before | after |
| ------ | ----- |
| `[Development Guide](cli/docs/DEVELOPMENT.md)` | `[Development Guide](docs/DEVELOPMENT.md)` |

## How to Test

- Navigate to the CLI README at `cli/README.md`
- Scroll to the "Local Development" section at the bottom
- Click on the "Development Guide" link
- Verify it correctly navigates to `cli/docs/DEVELOPMENT.md`
