### PR TITLE
feat(cli): add session export command with Markdown, HTML, and JSONL

### DIFF
--- a/.changeset/session-export.md
+++ b/.changeset/session-export.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Add session export feature to CLI with support for Markdown, HTML, and JSONL formats

--- a/cli/README.md
+++ b/cli/README.md
@@ -290,6 +290,42 @@ This instructs the AI to proceed without user input.
       echo "Implement the new feature" | kilocode --auto --timeout 600
 ```
 
+### Session Export
+
+Export your conversation sessions to shareable file formats for documentation, PR descriptions, or auditing.
+
+```bash
+# Inside the CLI, use the /session export command:
+
+# Export to Markdown (default) - great for PRs and documentation
+/session export markdown
+
+# Export to HTML - styled, self-contained report
+/session export html
+
+# Export to JSONL - machine-readable, one message per line
+/session export jsonl
+
+# Specify custom output path
+/session export html ./my-session-report.html
+```
+
+**Supported Formats:**
+
+- `markdown` - README-friendly format with metadata and conversation history
+- `html` - Single-file styled report with dark theme
+- `jsonl` - JSON Lines format for programmatic processing
+
+**Exported Metadata:**
+
+- Session ID
+- Mode, provider, and model used
+- Workspace directory
+- Export timestamp
+- Message count
+
+Files are saved to `./kilo-exports/` by default, or to your specified path.
+
 ## Local Development
 
 See [Development Guide](cli/docs/DEVELOPMENT.md) for setup instructions.

--- a/cli/src/commands/__tests__/helpers/mockContext.ts
+++ b/cli/src/commands/__tests__/helpers/mockContext.ts
@@ -73,6 +73,9 @@ export function createMockContext(overrides: Partial<CommandContext> = {}): Comm
 		chatMessages: [],
 		// Current task context
 		currentTask: null,
+		// Session export context
+		getMessages: vi.fn().mockReturnValue([]),
+		getExtensionState: vi.fn().mockReturnValue(null),
 		modelListPageIndex: 0,
 		modelListFilters: {
 			sort: "preferred",

--- a/cli/src/commands/__tests__/session.test.ts
+++ b/cli/src/commands/__tests__/session.test.ts
@@ -100,7 +100,7 @@ describe("sessionCommand", () => {
 		})
 
 		it("should have usage examples", () => {
-			expect(sessionCommand.examples).toHaveLength(8)
+			expect(sessionCommand.examples).toHaveLength(10)
 			expect(sessionCommand.examples).toContain("/session show")
 			expect(sessionCommand.examples).toContain("/session list")
 			expect(sessionCommand.examples).toContain("/session search <query>")
@@ -109,6 +109,8 @@ describe("sessionCommand", () => {
 			expect(sessionCommand.examples).toContain("/session fork <id>")
 			expect(sessionCommand.examples).toContain("/session delete <sessionId>")
 			expect(sessionCommand.examples).toContain("/session rename <new name>")
+			expect(sessionCommand.examples).toContain("/session export markdown")
+			expect(sessionCommand.examples).toContain("/session export html ./output.html")
 		})
 
 		it("should have subcommand argument defined", () => {
@@ -121,7 +123,7 @@ describe("sessionCommand", () => {
 		it("should have all subcommand values defined", () => {
 			const subcommandArg = sessionCommand.arguments![0]
 			expect(subcommandArg.values).toBeDefined()
-			expect(subcommandArg.values).toHaveLength(8)
+			expect(subcommandArg.values).toHaveLength(9)
 			expect(subcommandArg.values!.map((v) => v.value)).toEqual([
 				"show",
 				"list",
@@ -131,6 +133,7 @@ describe("sessionCommand", () => {
 				"fork",
 				"delete",
 				"rename",
+				"export",
 			])
 		})
 

--- a/cli/src/commands/core/types.ts
+++ b/cli/src/commands/core/types.ts
@@ -2,13 +2,20 @@
  * Command system type definitions
  */
 
-import type { ExtensionMessage, RouterModels, WebviewMessage, ModeConfig } from "../../types/messages.js"
+import type {
+	ExtensionMessage,
+	ExtensionState,
+	RouterModels,
+	WebviewMessage,
+	ModeConfig,
+} from "../../types/messages.js"
 import type { CliMessage } from "../../types/cli.js"
 import type { CLIConfig, ProviderConfig } from "../../config/types.js"
 import type { ProfileData, BalanceData } from "../../state/atoms/profile.js"
 import type { TaskHistoryData, TaskHistoryFilters } from "../../state/atoms/taskHistory.js"
 import type { ModelListFilters } from "../../state/atoms/modelList.js"
 import type { HistoryItem } from "@roo-code/types"
+import type { UnifiedMessage } from "../../state/atoms/ui.js"
 
 export interface Command {
 	name: string
@@ -80,6 +87,9 @@ export interface CommandContext {
 	chatMessages: ExtensionMessage[]
 	// Current task context
 	currentTask: HistoryItem | null
+	// Session export context
+	getMessages: () => UnifiedMessage[]
+	getExtensionState: () => ExtensionState | null
 	// Model list context
 	modelListPageIndex: number
 	modelListFilters: ModelListFilters

--- a/cli/src/state/hooks/useCommandContext.ts
+++ b/cli/src/state/hooks/useCommandContext.ts
@@ -16,6 +16,7 @@ import {
 	setMessageCutoffTimestampAtom,
 	isCommittingParallelModeAtom,
 	refreshTerminalAtom,
+	mergedMessagesAtom,
 } from "../atoms/ui.js"
 import {
 	setModeAtom,
@@ -115,6 +116,7 @@ export function useCommandContext(): UseCommandContextReturn {
 	const config = useAtomValue(configAtom)
 	const chatMessages = useAtomValue(chatMessagesAtom)
 	const currentTask = useAtomValue(currentTaskAtom)
+	const mergedMessages = useAtomValue(mergedMessagesAtom)
 
 	// Get profile state
 	const profileData = useAtomValue(profileDataAtom)
@@ -243,6 +245,9 @@ export function useCommandContext(): UseCommandContextReturn {
 				chatMessages: chatMessages as unknown as ExtensionMessage[],
 				// Current task context
 				currentTask,
+				// Session export context
+				getMessages: () => mergedMessages,
+				getExtensionState: () => extensionState,
 				// Model list context
 				modelListPageIndex,
 				modelListFilters,
@@ -288,6 +293,8 @@ export function useCommandContext(): UseCommandContextReturn {
 			previousTaskHistoryPage,
 			chatMessages,
 			currentTask,
+			mergedMessages,
+			extensionState,
 			modelListPageIndex,
 			modelListFilters,
 			updateModelListFilters,

--- a/cli/src/utils/__tests__/export.test.ts
+++ b/cli/src/utils/__tests__/export.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { renderToMarkdown, renderToHtml, renderToJsonl, exportSession } from "../export.js"
+import type { UnifiedMessage } from "../../state/atoms/ui.js"
+import type { CliMessage } from "../../types/cli.js"
+import type { ExtensionChatMessage } from "../../types/messages.js"
+import { rm } from "node:fs/promises"
+import { join } from "node:path"
+import { existsSync } from "node:fs"
+
+const mockCliMessage = (content: string, type: CliMessage["type"] = "user"): UnifiedMessage => ({
+	source: "cli",
+	message: {
+		id: `cli-${Date.now()}`,
+		type,
+		content,
+		ts: Date.now(),
+	},
+})
+
+const mockExtensionMessage = (
+	text: string,
+	sayType: "user_feedback" | "text" | "error" | "completion_result" = "text",
+): UnifiedMessage => ({
+	source: "extension",
+	message: {
+		ts: Date.now(),
+		type: "say",
+		say: sayType,
+		text,
+	} as ExtensionChatMessage,
+})
+
+const mockMetadata = {
+	sessionId: "test-session-123",
+	title: "Test Session",
+	mode: "code",
+	provider: "anthropic",
+	model: "claude-3-5-sonnet",
+	workspace: "/test/workspace",
+	exportedAt: new Date().toISOString(),
+	messageCount: 3,
+}
+
+describe("export utilities", () => {
+	describe("renderToMarkdown", () => {
+		it("should render messages to markdown format", () => {
+			const messages: UnifiedMessage[] = [
+				mockCliMessage("Hello, can you help me?", "user"),
+				mockExtensionMessage("Of course! How can I assist you?", "text"),
+			]
+
+			const result = renderToMarkdown(messages, mockMetadata)
+
+			expect(result).toContain("# Test Session")
+			expect(result).toContain("## Metadata")
+			expect(result).toContain("**Session ID:** `test-session-123`")
+			expect(result).toContain("**Mode:** code")
+			expect(result).toContain("## Conversation")
+			expect(result).toContain("### User")
+			expect(result).toContain("Hello, can you help me?")
+			expect(result).toContain("### Assistant")
+			expect(result).toContain("Of course! How can I assist you?")
+		})
+
+		it("should handle empty messages", () => {
+			const result = renderToMarkdown([], mockMetadata)
+
+			expect(result).toContain("# Test Session")
+			expect(result).toContain("## Conversation")
+		})
+
+		it("should include all metadata fields", () => {
+			const result = renderToMarkdown([], mockMetadata)
+
+			expect(result).toContain("**Provider:** anthropic")
+			expect(result).toContain("**Model:** claude-3-5-sonnet")
+			expect(result).toContain("**Workspace:** `/test/workspace`")
+		})
+	})
+
+	describe("renderToHtml", () => {
+		it("should render messages to HTML format", () => {
+			const messages: UnifiedMessage[] = [
+				mockCliMessage("Hello", "user"),
+				mockExtensionMessage("Hi there!", "text"),
+			]
+
+			const result = renderToHtml(messages, mockMetadata)
+
+			expect(result).toContain("<!DOCTYPE html>")
+			expect(result).toContain("<title>Test Session</title>")
+			expect(result).toContain("<h1>Test Session</h1>")
+			expect(result).toContain('class="message user"')
+			expect(result).toContain('class="message assistant"')
+			expect(result).toContain("Hello")
+			expect(result).toContain("Hi there!")
+		})
+
+		it("should include proper styling", () => {
+			const result = renderToHtml([], mockMetadata)
+
+			expect(result).toContain("<style>")
+			expect(result).toContain("--bg-color")
+			expect(result).toContain("--user-bg")
+			expect(result).toContain("--assistant-bg")
+		})
+
+		it("should escape HTML in content", () => {
+			const messages: UnifiedMessage[] = [mockCliMessage("<script>alert('xss')</script>", "user")]
+
+			const result = renderToHtml(messages, mockMetadata)
+
+			expect(result).not.toContain("<script>")
+			expect(result).toContain("&lt;script&gt;")
+		})
+	})
+
+	describe("renderToJsonl", () => {
+		it("should render messages to JSONL format", () => {
+			const messages: UnifiedMessage[] = [mockCliMessage("Hello", "user"), mockExtensionMessage("Hi!", "text")]
+
+			const result = renderToJsonl(messages, mockMetadata)
+			const lines = result.split("\n")
+
+			expect(lines).toHaveLength(3)
+
+			const metadataLine = JSON.parse(lines[0]!)
+			expect(metadataLine.type).toBe("metadata")
+			expect(metadataLine.sessionId).toBe("test-session-123")
+
+			const messageLine1 = JSON.parse(lines[1]!)
+			expect(messageLine1.type).toBe("message")
+			expect(messageLine1.role).toBe("User")
+			expect(messageLine1.content).toBe("Hello")
+
+			const messageLine2 = JSON.parse(lines[2]!)
+			expect(messageLine2.type).toBe("message")
+			expect(messageLine2.role).toBe("Assistant")
+		})
+
+		it("should include source in message lines", () => {
+			const messages: UnifiedMessage[] = [mockCliMessage("Hello", "user")]
+
+			const result = renderToJsonl(messages, mockMetadata)
+			const lines = result.split("\n")
+			const messageLine = JSON.parse(lines[1]!)
+
+			expect(messageLine.source).toBe("cli")
+		})
+	})
+
+	describe("exportSession", () => {
+		const testDir = join(process.cwd(), "test-exports")
+
+		beforeEach(async () => {
+			if (existsSync(testDir)) {
+				await rm(testDir, { recursive: true })
+			}
+		})
+
+		afterEach(async () => {
+			if (existsSync(testDir)) {
+				await rm(testDir, { recursive: true })
+			}
+		})
+
+		it("should export session to markdown file", async () => {
+			const messages: UnifiedMessage[] = [mockCliMessage("Test message", "user")]
+			const outputPath = join(testDir, "test-export.md")
+
+			const result = await exportSession(messages, {
+				format: "markdown",
+				outputPath,
+				metadata: { sessionId: "export-test" },
+			})
+
+			expect(result.success).toBe(true)
+			expect(result.format).toBe("markdown")
+			expect(result.outputPath).toBe(outputPath)
+			expect(existsSync(outputPath)).toBe(true)
+		})
+
+		it("should export session to HTML file", async () => {
+			const messages: UnifiedMessage[] = [mockCliMessage("Test message", "user")]
+			const outputPath = join(testDir, "test-export.html")
+
+			const result = await exportSession(messages, {
+				format: "html",
+				outputPath,
+				metadata: { sessionId: "export-test" },
+			})
+
+			expect(result.success).toBe(true)
+			expect(result.format).toBe("html")
+			expect(existsSync(outputPath)).toBe(true)
+		})
+
+		it("should export session to JSONL file", async () => {
+			const messages: UnifiedMessage[] = [mockCliMessage("Test message", "user")]
+			const outputPath = join(testDir, "test-export.jsonl")
+
+			const result = await exportSession(messages, {
+				format: "jsonl",
+				outputPath,
+				metadata: { sessionId: "export-test" },
+			})
+
+			expect(result.success).toBe(true)
+			expect(result.format).toBe("jsonl")
+			expect(existsSync(outputPath)).toBe(true)
+		})
+
+		it("should create directory if it doesn't exist", async () => {
+			const messages: UnifiedMessage[] = [mockCliMessage("Test", "user")]
+			const nestedPath = join(testDir, "nested", "deep", "export.md")
+
+			const result = await exportSession(messages, {
+				format: "markdown",
+				outputPath: nestedPath,
+			})
+
+			expect(result.success).toBe(true)
+			expect(existsSync(nestedPath)).toBe(true)
+		})
+
+		it("should return error on failure", async () => {
+			const messages: UnifiedMessage[] = [mockCliMessage("Test", "user")]
+			const invalidPath = "/root/no-permission/export.md"
+
+			const result = await exportSession(messages, {
+				format: "markdown",
+				outputPath: invalidPath,
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toBeDefined()
+		})
+	})
+})

--- a/cli/src/utils/export.ts
+++ b/cli/src/utils/export.ts
@@ -1,0 +1,396 @@
+/**
+ * Session export utilities
+ * Converts session messages to Markdown, HTML, and JSONL formats
+ */
+
+import { writeFile, mkdir } from "node:fs/promises"
+import { dirname, join, resolve } from "node:path"
+import { existsSync } from "node:fs"
+import type { UnifiedMessage } from "../state/atoms/ui.js"
+import type { ExtensionChatMessage } from "../types/messages.js"
+import type { CliMessage } from "../types/cli.js"
+
+export type ExportFormat = "markdown" | "html" | "jsonl"
+
+export interface ExportMetadata {
+	sessionId?: string | undefined
+	title?: string | undefined
+	mode?: string | undefined
+	provider?: string | undefined
+	model?: string | undefined
+	workspace?: string | undefined
+	exportedAt: string
+	messageCount: number
+}
+
+export interface ExportOptions {
+	format: ExportFormat
+	outputPath?: string | undefined
+	metadata?: Partial<ExportMetadata>
+}
+
+export interface ExportResult {
+	success: boolean
+	outputPath: string
+	format: ExportFormat
+	messageCount: number
+	error?: string
+}
+
+function formatTimestamp(ts: number): string {
+	return new Date(ts).toISOString()
+}
+
+function formatRelativeTimestamp(ts: number): string {
+	const date = new Date(ts)
+	return date.toLocaleString()
+}
+
+function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#039;")
+}
+
+function extractTextContent(message: ExtensionChatMessage): string {
+	if (!message.text) return ""
+
+	try {
+		const parsed = JSON.parse(message.text)
+		if (typeof parsed === "object" && parsed !== null) {
+			if (parsed.content) return parsed.content
+			if (parsed.command) return `Command: ${parsed.command}\n${parsed.output || ""}`
+			if (parsed.diff) return parsed.diff
+			return JSON.stringify(parsed, null, 2)
+		}
+		return message.text
+	} catch {
+		return message.text
+	}
+}
+
+function getMessageRole(message: UnifiedMessage): string {
+	if (message.source === "cli") {
+		const cliMsg = message.message as CliMessage
+		switch (cliMsg.type) {
+			case "user":
+				return "User"
+			case "assistant":
+				return "Assistant"
+			case "system":
+				return "System"
+			case "error":
+				return "Error"
+			case "welcome":
+				return "Welcome"
+			default:
+				return "System"
+		}
+	} else {
+		const extMsg = message.message as ExtensionChatMessage
+		if (extMsg.type === "say") {
+			const sayType = extMsg.say
+			if (sayType === "user_feedback" || sayType === "user_feedback_diff") {
+				return "User"
+			}
+			if (sayType === "text" || sayType === "reasoning") {
+				return "Assistant"
+			}
+			if (sayType === "error") {
+				return "Error"
+			}
+			if (sayType === "completion_result") {
+				return "Result"
+			}
+			return "Assistant"
+		} else if (extMsg.type === "ask") {
+			if (extMsg.ask === "tool") {
+				return "Tool"
+			}
+			return "Assistant"
+		}
+		return "System"
+	}
+}
+
+function getMessageContent(message: UnifiedMessage): string {
+	if (message.source === "cli") {
+		return (message.message as CliMessage).content
+	} else {
+		return extractTextContent(message.message as ExtensionChatMessage)
+	}
+}
+
+function shouldIncludeMessage(message: UnifiedMessage): boolean {
+	if (message.source === "cli") {
+		const cliMsg = message.message as CliMessage
+		return cliMsg.type !== "empty"
+	} else {
+		const extMsg = message.message as ExtensionChatMessage
+		if (extMsg.say === "api_req_started" || extMsg.say === "api_req_finished") {
+			return false
+		}
+		if (extMsg.say === "checkpoint_saved") {
+			return false
+		}
+		const content = extractTextContent(extMsg)
+		return content.trim().length > 0
+	}
+}
+
+export function renderToMarkdown(messages: UnifiedMessage[], metadata: ExportMetadata): string {
+	const lines: string[] = []
+
+	lines.push(`# ${metadata.title || "Session Export"}`)
+	lines.push("")
+	lines.push("## Metadata")
+	lines.push("")
+	if (metadata.sessionId) lines.push(`- **Session ID:** \`${metadata.sessionId}\``)
+	if (metadata.mode) lines.push(`- **Mode:** ${metadata.mode}`)
+	if (metadata.provider) lines.push(`- **Provider:** ${metadata.provider}`)
+	if (metadata.model) lines.push(`- **Model:** ${metadata.model}`)
+	if (metadata.workspace) lines.push(`- **Workspace:** \`${metadata.workspace}\``)
+	lines.push(`- **Exported:** ${metadata.exportedAt}`)
+	lines.push(`- **Messages:** ${metadata.messageCount}`)
+	lines.push("")
+	lines.push("---")
+	lines.push("")
+	lines.push("## Conversation")
+	lines.push("")
+
+	const filteredMessages = messages.filter(shouldIncludeMessage)
+
+	for (const message of filteredMessages) {
+		const role = getMessageRole(message)
+		const content = getMessageContent(message)
+		const timestamp = formatRelativeTimestamp(message.message.ts)
+
+		lines.push(`### ${role}`)
+		lines.push(`*${timestamp}*`)
+		lines.push("")
+
+		if (content.includes("```") || content.includes("\n")) {
+			lines.push(content)
+		} else {
+			lines.push(content)
+		}
+		lines.push("")
+	}
+
+	return lines.join("\n")
+}
+
+export function renderToHtml(messages: UnifiedMessage[], metadata: ExportMetadata): string {
+	const filteredMessages = messages.filter(shouldIncludeMessage)
+
+	const messageRows = filteredMessages
+		.map((message) => {
+			const role = getMessageRole(message)
+			const content = getMessageContent(message)
+			const timestamp = formatRelativeTimestamp(message.message.ts)
+			const roleClass = role.toLowerCase().replace(/\s+/g, "-")
+
+			return `
+		<div class="message ${roleClass}">
+			<div class="message-header">
+				<span class="role">${escapeHtml(role)}</span>
+				<span class="timestamp">${escapeHtml(timestamp)}</span>
+			</div>
+			<div class="message-content">
+				<pre>${escapeHtml(content)}</pre>
+			</div>
+		</div>`
+		})
+		.join("\n")
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>${escapeHtml(metadata.title || "Session Export")}</title>
+	<style>
+		:root {
+			--bg-color: #1a1a2e;
+			--text-color: #e0e0e0;
+			--border-color: #333;
+			--user-bg: #2d4a3e;
+			--assistant-bg: #2d3a4a;
+			--system-bg: #3a3a3a;
+			--error-bg: #4a2d2d;
+			--tool-bg: #4a3a2d;
+		}
+		body {
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+			background-color: var(--bg-color);
+			color: var(--text-color);
+			max-width: 900px;
+			margin: 0 auto;
+			padding: 2rem;
+			line-height: 1.6;
+		}
+		h1 { color: #00d9ff; border-bottom: 2px solid #00d9ff; padding-bottom: 0.5rem; }
+		h2 { color: #a0a0a0; margin-top: 2rem; }
+		.metadata {
+			background: #252540;
+			padding: 1rem;
+			border-radius: 8px;
+			margin-bottom: 2rem;
+		}
+		.metadata p { margin: 0.25rem 0; }
+		.metadata code { background: #333; padding: 0.2rem 0.4rem; border-radius: 4px; }
+		hr { border: none; border-top: 1px solid var(--border-color); margin: 2rem 0; }
+		.message {
+			margin-bottom: 1.5rem;
+			border-radius: 8px;
+			overflow: hidden;
+		}
+		.message-header {
+			padding: 0.5rem 1rem;
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+		}
+		.role { font-weight: bold; }
+		.timestamp { font-size: 0.85rem; opacity: 0.7; }
+		.message-content {
+			padding: 1rem;
+			background: rgba(0,0,0,0.2);
+		}
+		.message-content pre {
+			margin: 0;
+			white-space: pre-wrap;
+			word-wrap: break-word;
+			font-family: 'Fira Code', 'Consolas', monospace;
+			font-size: 0.9rem;
+		}
+		.user .message-header { background: var(--user-bg); }
+		.assistant .message-header { background: var(--assistant-bg); }
+		.system .message-header { background: var(--system-bg); }
+		.error .message-header { background: var(--error-bg); }
+		.tool .message-header { background: var(--tool-bg); }
+		.result .message-header { background: #2d4a4a; }
+	</style>
+</head>
+<body>
+	<h1>${escapeHtml(metadata.title || "Session Export")}</h1>
+	
+	<div class="metadata">
+		<h2>Metadata</h2>
+		${metadata.sessionId ? `<p><strong>Session ID:</strong> <code>${escapeHtml(metadata.sessionId)}</code></p>` : ""}
+		${metadata.mode ? `<p><strong>Mode:</strong> ${escapeHtml(metadata.mode)}</p>` : ""}
+		${metadata.provider ? `<p><strong>Provider:</strong> ${escapeHtml(metadata.provider)}</p>` : ""}
+		${metadata.model ? `<p><strong>Model:</strong> ${escapeHtml(metadata.model)}</p>` : ""}
+		${metadata.workspace ? `<p><strong>Workspace:</strong> <code>${escapeHtml(metadata.workspace)}</code></p>` : ""}
+		<p><strong>Exported:</strong> ${escapeHtml(metadata.exportedAt)}</p>
+		<p><strong>Messages:</strong> ${metadata.messageCount}</p>
+	</div>
+
+	<hr>
+
+	<h2>Conversation</h2>
+
+	${messageRows}
+
+</body>
+</html>`
+}
+
+export function renderToJsonl(messages: UnifiedMessage[], metadata: ExportMetadata): string {
+	const lines: string[] = []
+
+	lines.push(JSON.stringify({ type: "metadata", ...metadata }))
+
+	const filteredMessages = messages.filter(shouldIncludeMessage)
+
+	for (const message of filteredMessages) {
+		const role = getMessageRole(message)
+		const content = getMessageContent(message)
+		const timestamp = formatTimestamp(message.message.ts)
+
+		lines.push(
+			JSON.stringify({
+				type: "message",
+				role,
+				content,
+				timestamp,
+				ts: message.message.ts,
+				source: message.source,
+			}),
+		)
+	}
+
+	return lines.join("\n")
+}
+
+export function renderSession(messages: UnifiedMessage[], format: ExportFormat, metadata: ExportMetadata): string {
+	switch (format) {
+		case "markdown":
+			return renderToMarkdown(messages, metadata)
+		case "html":
+			return renderToHtml(messages, metadata)
+		case "jsonl":
+			return renderToJsonl(messages, metadata)
+		default:
+			throw new Error(`Unsupported export format: ${format}`)
+	}
+}
+
+function getFileExtension(format: ExportFormat): string {
+	switch (format) {
+		case "markdown":
+			return "md"
+		case "html":
+			return "html"
+		case "jsonl":
+			return "jsonl"
+		default:
+			return "txt"
+	}
+}
+
+export async function exportSession(messages: UnifiedMessage[], options: ExportOptions): Promise<ExportResult> {
+	const { format, outputPath, metadata = {} } = options
+
+	const exportMetadata: ExportMetadata = {
+		exportedAt: new Date().toISOString(),
+		messageCount: messages.filter(shouldIncludeMessage).length,
+		...metadata,
+	}
+
+	try {
+		const content = renderSession(messages, format, exportMetadata)
+
+		const extension = getFileExtension(format)
+		const filename = metadata.sessionId
+			? `session-${metadata.sessionId}.${extension}`
+			: `session-${Date.now()}.${extension}`
+
+		const finalPath = outputPath ? resolve(outputPath) : join(process.cwd(), "kilo-exports", filename)
+
+		const dir = dirname(finalPath)
+		if (!existsSync(dir)) {
+			await mkdir(dir, { recursive: true })
+		}
+
+		await writeFile(finalPath, content, "utf-8")
+
+		return {
+			success: true,
+			outputPath: finalPath,
+			format,
+			messageCount: exportMetadata.messageCount,
+		}
+	} catch (error) {
+		return {
+			success: false,
+			outputPath: outputPath || "",
+			format,
+			messageCount: 0,
+			error: error instanceof Error ? error.message : String(error),
+		}
+	}
+}


### PR DESCRIPTION
## Context

Adds a `/session export` command to the Kilo Code CLI that allows users to export their conversation sessions to shareable file formats (Markdown, HTML, JSONL). This enables users to save sessions for documentation, PR descriptions, bug reports, and auditing purposes.

## Implementation

- Created `cli/src/utils/export.ts` with rendering functions for each format:
  - `renderToMarkdown()` - Generates README-friendly Markdown with metadata header
  - `renderToHtml()` - Produces a self-contained HTML file with dark theme styling
  - `renderToJsonl()` - Outputs one JSON object per line for programmatic processing
- Extended `CommandContext` with `getMessages()` and `getExtensionState()` to provide access to unified messages and session metadata
- Added `export` subcommand to the existing `/session` command, following the pattern of other subcommands (show, list, share, etc.)
- Messages are filtered to exclude internal types (api_req_started, checkpoints) and empty content
- Export files default to `./kilo-exports/` with auto-directory creation

## Screenshots

| before | after |
| ------ | ----- |
| <img width="1470" height="923" alt="image" src="https://github.com/user-attachments/assets/c3c07554-46d4-4e3b-ac51-8b4b18d4db08" /> | <img width="1470" height="923" alt="image" src="https://github.com/user-attachments/assets/31d0d5aa-178b-480e-98b6-17d3f1dc328d" /> |

**Example Markdown output:**
```markdown
# Kilo Code Session

## Metadata
- **Session ID:** `abc123`
- **Mode:** code
- **Provider:** anthropic
- **Model:** claude-sonnet-4-5-20250929

## Conversation

### User
Hello, can you help me?

### Assistant
Of course! How can I assist you?
```

## How to Test

1. Build and start the CLI:
   ```bash
   pnpm cli:bundle
   cd cli && pnpm start
   ```
2. Send a message to start a conversation (e.g., "Hello")
3. Test the export commands:
   - `/session export markdown` - exports to `./kilo-exports/session-<id>.md`
   - `/session export html` - exports to `./kilo-exports/session-<id>.html`
   - `/session export jsonl ./test.jsonl` - exports to custom path
4. Open the exported files to verify content and formatting

## Get in Touch

Discord: aravhawk