### PR TITLE
Fix broken links

### DIFF
--- a/apps/kilocode-docs/pages/automate/mcp/overview.md
+++ b/apps/kilocode-docs/pages/automate/mcp/overview.md
@@ -11,13 +11,13 @@ The Model Context Protocol (MCP) is a standard for extending Kilo Code's capabil
 
 This documentation is organized into several sections:
 
-- [**Using MCP in Kilo Code**](/features/mcp/using-mcp-in-kilo-code) - Comprehensive guide to configuring, enabling, and managing MCP servers with Kilo Code. Includes server settings, tool approval, and troubleshooting.
+- [**Using MCP in Kilo Code**](using-in-kilo-code) - Comprehensive guide to configuring, enabling, and managing MCP servers with Kilo Code. Includes server settings, tool approval, and troubleshooting.
 
-- [**What is MCP?**](/features/mcp/what-is-mcp) - Clear explanation of the Model Context Protocol, its client-server architecture, and how it enables AI systems to interact with external tools.
+- [**What is MCP?**](what-is-mcp) - Clear explanation of the Model Context Protocol, its client-server architecture, and how it enables AI systems to interact with external tools.
 
-- [**STDIO & SSE Transports**](/features/mcp/server-transports) - Detailed comparison of local (STDIO) and remote (SSE) transport mechanisms with deployment considerations for each approach.
+- [**STDIO & SSE Transports**](server-transports) - Detailed comparison of local (STDIO) and remote (SSE) transport mechanisms with deployment considerations for each approach.
 
-- [**MCP vs API**](/features/mcp/mcp-vs-api) - Analysis of the fundamental distinction between MCP and REST APIs, explaining how they operate at different layers of abstraction for AI systems.
+- [**MCP vs API**](mcp-vs-api) - Analysis of the fundamental distinction between MCP and REST APIs, explaining how they operate at different layers of abstraction for AI systems.
 
 ## Contributing to the Marketplace
 

--- a/apps/kilocode-docs/pages/automate/mcp/server-transports.md
+++ b/apps/kilocode-docs/pages/automate/mcp/server-transports.md
@@ -196,4 +196,4 @@ Some scenarios benefit from a hybrid approach:
 
 ## Configuring Transports in Kilo Code
 
-For detailed information on configuring STDIO and SSE transports in Kilo Code, including example configurations, see the [Understanding Transport Types](/features/mcp/using-mcp-in-kilo-code#understanding-transport-types) section in the Using MCP in Kilo Code guide.
+For detailed information on configuring STDIO and SSE transports in Kilo Code, including example configurations, see the [Understanding Transport Types](using-in-kilo-code#understanding-transport-types) section in the Using MCP in Kilo Code guide.

--- a/apps/kilocode-docs/pages/automate/mcp/using-in-kilo-code.md
+++ b/apps/kilocode-docs/pages/automate/mcp/using-in-kilo-code.md
@@ -65,7 +65,7 @@ Used for local servers running on your machine:
 - Simpler setup (no HTTP server needed)
 - Runs as a child process on your machine
 
-For more in-depth information about how STDIO transport works, see [STDIO Transport](/features/mcp/server-transports#stdio-transport).
+For more in-depth information about how STDIO transport works, see [STDIO Transport](server-transports#stdio-transport).
 
 STDIO configuration example:
 
@@ -124,7 +124,7 @@ Used for remote servers accessed over HTTP/HTTPS:
 - Requires network access
 - Allows centralized deployment and management
 
-For more in-depth information about how SSE transport works, see [SSE Transport](/features/mcp/server-transports#sse-transport).
+For more in-depth information about how SSE transport works, see [SSE Transport](server-transports#sse-transport).
 
 SSE configuration example:
 

--- a/apps/kilocode-docs/pages/automate/mcp/what-is-mcp.md
+++ b/apps/kilocode-docs/pages/automate/mcp/what-is-mcp.md
@@ -43,7 +43,7 @@ MCP provides a standardized way for AI systems to interact with external tools a
 
 Ready to dig deeper? Check out these guides:
 
-- [MCP Overview](/features/mcp/overview) - A quick glance at the MCP documentation structure
-- [Using MCP in Kilo Code](/features/mcp/using-mcp-in-kilo-code) - Get started with MCP in Kilo Code, including creating simple servers
-- [MCP vs API](/features/mcp/mcp-vs-api) - Technical advantages compared to traditional APIs
-- [STDIO & SSE Transports](/features/mcp/server-transports) - Local vs. hosted deployment models
+- [MCP Overview](overview) - A quick glance at the MCP documentation structure
+- [Using MCP in Kilo Code](using-in-kilo-code) - Get started with MCP in Kilo Code, including creating simple servers
+- [MCP vs API](mcp-vs-api) - Technical advantages compared to traditional APIs
+- [STDIO & SSE Transports](server-transports) - Local vs. hosted deployment models

--- a/apps/kilocode-docs/pages/code-with-ai/agents/free-and-budget-models.md
+++ b/apps/kilocode-docs/pages/code-with-ai/agents/free-and-budget-models.md
@@ -221,7 +221,7 @@ When you need more capability than free models provide, these options deliver ex
 
 **Reduce system prompt size:**
 
-- [Disable MCP](/features/mcp/using-mcp-in-kilo-code) if not using external tools
+- [Disable MCP](/docs/automate/mcp/using-in-kilo-code) if not using external tools
 - Use focused custom modes
 - Minimize unnecessary context
 

--- a/apps/kilocode-docs/pages/contributing/index.md
+++ b/apps/kilocode-docs/pages/contributing/index.md
@@ -88,7 +88,7 @@ The [Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace) is a commun
 
 To contribute:
 
-1. Follow the documentation for [Custom Modes](/agent-behavior/custom-modes), [Skills](/agent-behavior/skills), or [MCP Servers](/features/mcp/overview) to create your resource
+1. Follow the documentation for [Custom Modes](/agent-behavior/custom-modes), [Skills](/agent-behavior/skills), or [MCP Servers](/docs/automate/mcp/overview) to create your resource
 
 2. Test your contribution thoroughly
 

--- a/apps/kilocode-docs/pages/customize/workflows.md
+++ b/apps/kilocode-docs/pages/customize/workflows.md
@@ -28,7 +28,7 @@ Workflows can leverage:
 
 - [Built-in tools](/features/tools/tool-use-overview): [`read_file()`](/features/tools/read-file), [`search_files()`](/features/tools/search-files), [`execute_command()`](/features/tools/execute-command)
 - CLI tools: `gh`, `docker`, `npm`, custom scripts
-- [MCP integrations](/features/mcp/overview): Slack, databases, APIs
+- [MCP integrations](/docs/automate/mcp/overview): Slack, databases, APIs
 - [Mode switching](/basic-usage/using-modes): [`new_task()`](/features/tools/new-task) for specialized contexts
 
 ## Common Workflow Patterns

--- a/apps/kilocode-docs/pages/getting-started/faq.md
+++ b/apps/kilocode-docs/pages/getting-started/faq.md
@@ -177,7 +177,7 @@ Yes, if you use a [local model](/advanced-usage/local-models).
 
 ### What is MCP (Model Context Protocol)?
 
-[MCP](/features/mcp/overview) is a protocol that allows Kilo Code to communicate with external servers, extending its capabilities with custom tools and resources.
+[MCP](/docs/automate/mcp/overview) is a protocol that allows Kilo Code to communicate with external servers, extending its capabilities with custom tools and resources.
 
 ### Can I create my own MCP servers?
 


### PR DESCRIPTION
Just correcting some orphaned links from #5401:

- `/features/mcp/overview` -> `/docs/automate/mcp/overview`
- `/features/mcp/using-mcp-in-kilo-code` -> `/docs/automate/mcp/using-in-kilo-code`
- `/features/mcp/what-is-mcp` -> `/docs/automate/mcp/what-is-mcp`
- `/features/mcp/server-transports` -> `/docs/automate/mcp/server-transports`
- `/features/mcp/mcp-vs-api` -> `/docs/automate/mcp/mcp-vs-api`