### PR TITLE
feat(cli): add update command for CLI self-update

### DIFF
--- a/.changeset/cli-update-command.md
+++ b/.changeset/cli-update-command.md
@@ -1,0 +1,10 @@
+---
+"@kilocode/cli": minor
+---
+
+feat(cli): add `kilocode update` command for CLI self-update
+
+- Detects installation method (npm, pnpm, yarn, bun, npx, docker, local)
+- Executes appropriate update command based on detected method
+- Supports `--check` flag to only check for updates without installing
+- Updates auto-update notification to use `kilocode update`

--- a/cli/README.md
+++ b/cli/README.md
@@ -290,6 +290,26 @@ This instructs the AI to proceed without user input.
       echo "Implement the new feature" | kilocode --auto --timeout 600
 ```
 
+## Updating
+
+Check for and install updates:
+
+```bash
+# Check and update to latest version
+kilocode update
+
+# Only check for updates (don't install)
+kilocode update --check
+```
+
+The update command automatically detects your installation method (npm, pnpm, yarn, bun) and runs the appropriate update command.
+
+For Docker users, pull the latest image manually:
+
+```bash
+docker pull kiloai/cli:latest
+```
+
 ## Local Development
 
 See [Development Guide](cli/docs/DEVELOPMENT.md) for setup instructions.

--- a/cli/src/commands/__tests__/update.test.ts
+++ b/cli/src/commands/__tests__/update.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Tests for the update command
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest"
+import { detectInstallMethod, fetchLatestVersion, checkForUpdates, executeUpdate } from "../update.js"
+import * as fs from "fs"
+import * as childProcess from "child_process"
+import { EventEmitter } from "events"
+import packageJson from "package-json"
+
+// Mock fs
+vi.mock("fs", () => ({
+	existsSync: vi.fn(),
+	realpathSync: vi.fn((p: string) => p), // Default: return path as-is
+}))
+
+// Mock child_process
+vi.mock("child_process", () => ({
+	spawn: vi.fn(),
+}))
+
+// Mock Package
+vi.mock("../../constants/package.js", () => ({
+	Package: { version: "1.0.0", name: "@kilocode/cli" },
+}))
+
+// Mock package-json
+vi.mock("package-json")
+
+afterAll(() => {
+	vi.unstubAllGlobals()
+})
+
+describe("update command", () => {
+	const originalArgv1 = process.argv[1]
+	const originalCwd = process.cwd
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		// Reset argv[1] after each test
+		process.argv[1] = originalArgv1
+		// Default cwd mock
+		process.cwd = () => "/home/user/projects/myapp"
+	})
+
+	afterAll(() => {
+		process.cwd = originalCwd
+	})
+
+	describe("detectInstallMethod", () => {
+		it("should detect local node_modules install", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "/home/user/projects/myapp/node_modules/.bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("unknown")
+			expect(result.canUpdate).toBe(false)
+			expect(result.message).toContain("local node_modules")
+			expect(result.message).toContain("/home/user/projects/myapp")
+		})
+
+		it("should detect local install from @kilocode/cli path", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "/home/user/projects/myapp/node_modules/@kilocode/cli/bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("unknown")
+			expect(result.canUpdate).toBe(false)
+			expect(result.message).toContain("local node_modules")
+		})
+
+		it("should detect local install when running from subdirectory", () => {
+			// User is in subdirectory but runs local node_modules binary
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.cwd = () => "/home/user/projects/myapp/src/components"
+			process.argv[1] = "/home/user/projects/myapp/node_modules/.bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("unknown")
+			expect(result.canUpdate).toBe(false)
+			expect(result.message).toContain("local node_modules")
+		})
+
+		it("should not misdetect global as local when cwd has local @kilocode/cli", () => {
+			// Global pnpm install, project also has local @kilocode/cli
+			// Original path is global, should detect as global
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.cwd = () => "/home/user/projects/myapp"
+			process.argv[1] = "/home/user/.local/share/pnpm/global/5/node_modules/@kilocode/cli/bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("pnpm")
+			expect(result.canUpdate).toBe(true)
+		})
+
+		it("should detect Yarn PnP cache as local install", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] =
+				"/home/user/projects/myapp/.yarn/cache/@kilocode-cli-npm-1.0.0-abc123.zip/node_modules/@kilocode/cli/bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("unknown")
+			expect(result.canUpdate).toBe(false)
+			expect(result.message).toContain("Yarn PnP")
+			expect(result.message).toContain("/home/user/projects/myapp")
+		})
+
+		it("should detect Yarn PnP unplugged as local install", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] =
+				"/home/user/projects/myapp/.yarn/unplugged/@kilocode-cli-npm-1.0.0/node_modules/@kilocode/cli/bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("unknown")
+			expect(result.canUpdate).toBe(false)
+			expect(result.message).toContain("Yarn PnP")
+		})
+
+		it("should detect Docker environment", () => {
+			vi.mocked(fs.existsSync).mockImplementation((path) => path === "/.dockerenv")
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("docker")
+			expect(result.canUpdate).toBe(false)
+			expect(result.message).toContain("docker pull")
+		})
+
+		it("should detect npx execution", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "/home/user/.npm/_npx/abc123/node_modules/.bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("npx")
+			expect(result.canUpdate).toBe(false)
+		})
+
+		it("should detect pnpm global install", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "/home/user/.local/share/pnpm/global/5/node_modules/.bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("pnpm")
+			expect(result.canUpdate).toBe(true)
+			expect(result.updateCommand).toBe("pnpm add -g @kilocode/cli@latest")
+		})
+
+		it("should detect pnpm global install on macOS", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "/Users/user/Library/pnpm/global/5/node_modules/.bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("pnpm")
+			expect(result.canUpdate).toBe(true)
+		})
+
+		it("should detect pnpm global install on Windows", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "C:\\Users\\user\\AppData\\Local\\pnpm\\kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("pnpm")
+			expect(result.canUpdate).toBe(true)
+		})
+
+		it("should detect yarn global install", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "/home/user/.config/yarn/global/node_modules/.bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("yarn")
+			expect(result.canUpdate).toBe(true)
+			expect(result.updateCommand).toBe("yarn global add @kilocode/cli@latest")
+		})
+
+		it("should detect yarn global install on Windows", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "C:\\Users\\user\\AppData\\Roaming\\Yarn\\bin\\kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("yarn")
+			expect(result.canUpdate).toBe(true)
+		})
+
+		it("should detect bun global install", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "/home/user/.bun/bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("bun")
+			expect(result.canUpdate).toBe(true)
+			expect(result.updateCommand).toBe("bun add -g @kilocode/cli@latest")
+		})
+
+		it("should return unknown for unrecognized paths", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "/some/custom/path/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("unknown")
+			expect(result.canUpdate).toBe(false)
+			expect(result.message).toContain("Could not detect installation method")
+		})
+
+		it("should detect npm global install", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "/usr/local/lib/node_modules/@kilocode/cli/bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("npm")
+			expect(result.canUpdate).toBe(true)
+			expect(result.updateCommand).toBe("npm install -g @kilocode/cli@latest")
+		})
+
+		it("should detect npm global install via symlink", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			// Symlink at /usr/local/bin/kilocode resolves to real path
+			vi.mocked(fs.realpathSync).mockReturnValue("/usr/local/lib/node_modules/@kilocode/cli/bin/kilocode")
+			process.argv[1] = "/usr/local/bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("npm")
+			expect(result.canUpdate).toBe(true)
+
+			// Reset mock
+			vi.mocked(fs.realpathSync).mockImplementation((p: string) => p as string)
+		})
+
+		it("should detect npm global install via nvm", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "/home/user/.nvm/versions/node/v20.0.0/lib/node_modules/@kilocode/cli/bin/kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("npm")
+			expect(result.canUpdate).toBe(true)
+		})
+
+		it("should detect npm global install on Windows", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false)
+			process.argv[1] = "C:\\Users\\user\\AppData\\Roaming\\npm\\node_modules\\@kilocode\\cli\\bin\\kilocode"
+
+			const result = detectInstallMethod()
+
+			expect(result.method).toBe("npm")
+			expect(result.canUpdate).toBe(true)
+		})
+	})
+
+	describe("fetchLatestVersion", () => {
+		it("should fetch and return latest version from npm registry", async () => {
+			vi.mocked(packageJson).mockResolvedValue({ version: "2.0.0" } as packageJson.AbbreviatedMetadata)
+
+			const version = await fetchLatestVersion()
+
+			expect(version).toBe("2.0.0")
+			expect(packageJson).toHaveBeenCalledWith("@kilocode/cli")
+		})
+
+		it("should throw error on fetch failure", async () => {
+			vi.mocked(packageJson).mockRejectedValue(new Error("Package not found"))
+
+			await expect(fetchLatestVersion()).rejects.toThrow()
+		})
+	})
+
+	describe("checkForUpdates", () => {
+		it("should return updateAvailable true when newer version exists", async () => {
+			vi.mocked(packageJson).mockResolvedValue({ version: "2.0.0" } as packageJson.AbbreviatedMetadata)
+
+			const result = await checkForUpdates()
+
+			expect(result.current).toBe("1.0.0")
+			expect(result.latest).toBe("2.0.0")
+			expect(result.updateAvailable).toBe(true)
+		})
+
+		it("should return updateAvailable false when on latest version", async () => {
+			vi.mocked(packageJson).mockResolvedValue({ version: "1.0.0" } as packageJson.AbbreviatedMetadata)
+
+			const result = await checkForUpdates()
+
+			expect(result.current).toBe("1.0.0")
+			expect(result.latest).toBe("1.0.0")
+			expect(result.updateAvailable).toBe(false)
+		})
+
+		it("should handle semver comparison correctly", async () => {
+			vi.mocked(packageJson).mockResolvedValue({ version: "1.0.1-beta.1" } as packageJson.AbbreviatedMetadata)
+
+			const result = await checkForUpdates()
+
+			// 1.0.1-beta.1 > 1.0.0
+			expect(result.updateAvailable).toBe(true)
+		})
+	})
+
+	describe("executeUpdate", () => {
+		it("should spawn update command and resolve on success", async () => {
+			const mockProcess = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter }
+			mockProcess.stdout = new EventEmitter()
+			mockProcess.stderr = new EventEmitter()
+			vi.mocked(childProcess.spawn).mockReturnValue(mockProcess as ReturnType<typeof childProcess.spawn>)
+
+			const promise = executeUpdate("npm install -g @kilocode/cli@latest")
+
+			// Simulate successful exit
+			mockProcess.emit("close", 0)
+
+			const result = await promise
+			expect(result.success).toBe(true)
+			expect(childProcess.spawn).toHaveBeenCalledWith(
+				"npm install -g @kilocode/cli@latest",
+				expect.objectContaining({ shell: true, stdio: "inherit" }),
+			)
+		})
+
+		it("should return error on non-zero exit code", async () => {
+			const mockProcess = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter }
+			mockProcess.stdout = new EventEmitter()
+			mockProcess.stderr = new EventEmitter()
+			vi.mocked(childProcess.spawn).mockReturnValue(mockProcess as ReturnType<typeof childProcess.spawn>)
+
+			const promise = executeUpdate("npm install -g @kilocode/cli@latest")
+
+			mockProcess.emit("close", 1)
+
+			const result = await promise
+			expect(result.success).toBe(false)
+			expect(result.error).toContain("1")
+		})
+
+		it("should return error on spawn error", async () => {
+			const mockProcess = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter }
+			mockProcess.stdout = new EventEmitter()
+			mockProcess.stderr = new EventEmitter()
+			vi.mocked(childProcess.spawn).mockReturnValue(mockProcess as ReturnType<typeof childProcess.spawn>)
+
+			const promise = executeUpdate("npm install -g @kilocode/cli@latest")
+
+			mockProcess.emit("error", new Error("spawn ENOENT"))
+
+			const result = await promise
+			expect(result.success).toBe(false)
+			expect(result.error).toContain("ENOENT")
+		})
+	})
+})

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,0 +1,309 @@
+/**
+ * Update command - Check for and install CLI updates
+ *
+ * Usage:
+ *   kilocode update           # Check and update to latest version
+ *   kilocode update --check   # Only check, don't update
+ */
+
+import { spawn } from "child_process"
+import { existsSync, realpathSync } from "fs"
+import packageJson from "package-json"
+import semver from "semver"
+import { Package } from "../constants/package.js"
+
+export type InstallMethod = "npm" | "pnpm" | "yarn" | "bun" | "npx" | "docker" | "unknown"
+
+export interface InstallationInfo {
+	method: InstallMethod
+	canUpdate: boolean
+	updateCommand?: string
+	message?: string
+}
+
+export interface VersionInfo {
+	current: string
+	latest: string
+	updateAvailable: boolean
+}
+
+/**
+ * Detect how the CLI was installed based on the CLI script location
+ */
+export function detectInstallMethod(): InstallationInfo {
+	// Use the CLI script path, not the Node executable path
+	// process.argv[1] points to the actual kilocode script location
+	// Use original path (before realpath) to detect local vs global
+	// This avoids false positives when pnpm store is shared between local and global
+	const originalPath = (process.argv[1] || "").toLowerCase().replace(/\\/g, "/")
+
+	// Resolve symlinks to get the real path for global install detection
+	// If realpath fails (broken symlink, permission denied), fall back to original path
+	let scriptPath = process.argv[1] || ""
+	try {
+		scriptPath = realpathSync(scriptPath)
+	} catch (error: unknown) {
+		// Fall back to original path - detection will still work for most cases
+		const message = error instanceof Error ? error.message : String(error)
+		console.error(`Warning: Could not resolve symlink for ${scriptPath}: ${message}`)
+	}
+	scriptPath = scriptPath.toLowerCase().replace(/\\/g, "/")
+
+	// Docker detection (check first as it's environment-based)
+	if (existsSync("/.dockerenv")) {
+		return {
+			method: "docker",
+			canUpdate: false,
+			message: "Running in Docker. To update, pull the latest image:\n  docker pull kiloai/cli:latest",
+		}
+	}
+
+	// npx/pnpx/bunx detection (temporary execution) - check before local node_modules
+	if (originalPath.includes("/_npx/") || originalPath.includes("/npm/_npx")) {
+		return {
+			method: "npx",
+			canUpdate: false,
+			message: "Running via npx. Each run uses the latest version automatically.",
+		}
+	}
+	if (
+		originalPath.includes("/_pnpx/") ||
+		originalPath.includes("/pnpm/dlx") ||
+		originalPath.includes("/.cache/pnpm/dlx")
+	) {
+		return {
+			method: "npx",
+			canUpdate: false,
+			message: "Running via pnpx. Each run uses the latest version automatically.",
+		}
+	}
+	if (originalPath.includes("/.bun/install/cache/")) {
+		return {
+			method: "npx",
+			canUpdate: false,
+			message: "Running via bunx. Each run uses the latest version automatically.",
+		}
+	}
+
+	// Yarn PnP: .yarn/cache or .yarn/unplugged are local project dependencies
+	// Check this BEFORE node_modules since PnP paths may contain node_modules
+	const yarnPnpMatch = originalPath.match(/^(.+)\/\.yarn\/(cache|unplugged)\/.+/)
+	if (yarnPnpMatch) {
+		const projectRoot = yarnPnpMatch[1]
+		return {
+			method: "unknown",
+			canUpdate: false,
+			message:
+				`Running from Yarn PnP (project dependency).\n` +
+				`Project: ${projectRoot}\n` +
+				"To update, modify your package.json or run:\n" +
+				"  yarn up @kilocode/cli",
+		}
+	}
+
+	// Check if running from local dependency (project dependency, not global)
+	// Exclude global paths: /usr/lib/node_modules, ~/.nvm, pnpm/global, yarn/global, etc.
+	const globalPathPatterns = [
+		/^\/usr\/(local\/)?lib\/node_modules\//,
+		/\/\.nvm\//,
+		/\/pnpm\/global\//,
+		/\/\.local\/share\/pnpm\/global\//,
+		/\/yarn\/global\//,
+		/\/\.config\/yarn\/global\//,
+		/\/appdata\/(local|roaming)\/(npm|pnpm|yarn)\//,
+		/\/library\/pnpm\//,
+		/\/\.bun\/install\/global\//,
+	]
+	const isGlobalPath = globalPathPatterns.some((pattern) => pattern.test(originalPath))
+
+	// Match local node_modules pattern but not global paths
+	const nodeModulesMatch = originalPath.match(/^(.+)\/node_modules\/.+/)
+	if (nodeModulesMatch && !isGlobalPath) {
+		const projectRoot = nodeModulesMatch[1]
+		return {
+			method: "unknown",
+			canUpdate: false,
+			message:
+				`Running from local node_modules (project dependency).\n` +
+				`Project: ${projectRoot}\n` +
+				"To update, modify your package.json or run:\n" +
+				"  npm update @kilocode/cli\n" +
+				"  pnpm update @kilocode/cli\n" +
+				"  yarn upgrade @kilocode/cli",
+		}
+	}
+
+	// pnpm global - check for pnpm global store paths
+	// Linux: ~/.local/share/pnpm, macOS: ~/Library/pnpm, Windows: %LOCALAPPDATA%\pnpm
+	if (
+		scriptPath.includes("/.pnpm/") ||
+		scriptPath.includes("/pnpm/global/") ||
+		scriptPath.includes("/.local/share/pnpm") ||
+		scriptPath.includes("/library/pnpm") ||
+		scriptPath.includes("/appdata/local/pnpm")
+	) {
+		return {
+			method: "pnpm",
+			canUpdate: true,
+			updateCommand: "pnpm add -g @kilocode/cli@latest",
+		}
+	}
+
+	// yarn global (Yarn 1.x only - Yarn 2+ doesn't support global)
+	// Only match actual global paths, not project .yarn directories
+	// Linux/macOS: ~/.yarn/bin, Windows: %APPDATA%\Yarn or %LOCALAPPDATA%\Yarn
+	if (
+		scriptPath.includes("/yarn/global/") ||
+		scriptPath.includes("/appdata/roaming/yarn") ||
+		scriptPath.includes("/appdata/local/yarn")
+	) {
+		return {
+			method: "yarn",
+			canUpdate: true,
+			updateCommand: "yarn global add @kilocode/cli@latest",
+		}
+	}
+
+	// bun global
+	if (scriptPath.includes("/.bun/bin") || scriptPath.includes("/.bun/install/global")) {
+		return {
+			method: "bun",
+			canUpdate: true,
+			updateCommand: "bun add -g @kilocode/cli@latest",
+		}
+	}
+
+	// npm global - common paths for npm global installs
+	// Linux/macOS: /usr/local/lib/node_modules, /usr/lib/node_modules, ~/.npm-global
+	// Windows: %APPDATA%\npm, %ProgramFiles%\nodejs
+	// nvm: ~/.nvm/versions/node/*/lib/node_modules
+	if (
+		scriptPath.includes("/node_modules/@kilocode/cli") ||
+		scriptPath.includes("/node_modules/kilocode") ||
+		scriptPath.includes("/npm/node_modules/") ||
+		scriptPath.includes("/.npm-global/") ||
+		scriptPath.includes("/.nvm/") ||
+		scriptPath.includes("/appdata/roaming/npm") ||
+		scriptPath.includes("/program files/nodejs")
+	) {
+		return {
+			method: "npm",
+			canUpdate: true,
+			updateCommand: "npm install -g @kilocode/cli@latest",
+		}
+	}
+
+	// Unknown installation method - don't assume to avoid installing a duplicate
+	return {
+		method: "unknown",
+		canUpdate: false,
+		message:
+			"Could not detect installation method. Please update manually using your package manager:\n" +
+			"  npm install -g @kilocode/cli@latest\n" +
+			"  pnpm add -g @kilocode/cli@latest\n" +
+			"  yarn global add @kilocode/cli@latest\n" +
+			"  bun add -g @kilocode/cli@latest",
+	}
+}
+
+/**
+ * Fetch the latest version from npm registry
+ * Uses package-json which respects npm registry configuration
+ */
+export async function fetchLatestVersion(): Promise<string> {
+	const data = await packageJson(Package.name)
+	return data.version
+}
+
+/**
+ * Check for available updates
+ */
+export async function checkForUpdates(): Promise<VersionInfo> {
+	const current = Package.version
+	const latest = await fetchLatestVersion()
+	const updateAvailable = semver.gt(latest, current)
+
+	return { current, latest, updateAvailable }
+}
+
+/**
+ * Execute the update command
+ */
+export function executeUpdate(command: string): Promise<{ success: boolean; error?: string }> {
+	return new Promise((resolve) => {
+		// shell: true is required for Windows where npm/pnpm/yarn are .cmd files
+		// We pass the full command string to spawn when using shell: true to avoid
+		// issues with argument parsing (e.g. spaces in paths)
+		const child = spawn(command, {
+			stdio: "inherit",
+			shell: true,
+		})
+
+		child.on("close", (code) => {
+			if (code === 0) {
+				resolve({ success: true })
+			} else {
+				resolve({ success: false, error: `Update command exited with code ${code}` })
+			}
+		})
+
+		child.on("error", (err) => {
+			resolve({ success: false, error: err.message })
+		})
+	})
+}
+
+/**
+ * Main update command handler
+ */
+export async function updateCommand(options: { check?: boolean } = {}): Promise<void> {
+	const installInfo = detectInstallMethod()
+
+	// Check for updates
+	console.log("Checking for updates...")
+	let versionInfo: VersionInfo
+	try {
+		versionInfo = await checkForUpdates()
+	} catch (error) {
+		console.error(`Failed to check for updates: ${error instanceof Error ? error.message : error}`)
+		process.exit(1)
+	}
+
+	console.log(`Current version: ${versionInfo.current}`)
+	console.log(`Latest version:  ${versionInfo.latest}`)
+
+	if (!versionInfo.updateAvailable) {
+		console.log("\n✓ You are already on the latest version.")
+		process.exit(0)
+	}
+
+	console.log("\n⬆ Update available!")
+
+	// If can't update automatically, show message
+	if (!installInfo.canUpdate) {
+		if (installInfo.message) {
+			console.log(`\n${installInfo.message}`)
+		}
+		process.exit(0)
+	}
+
+	// Check-only mode
+	if (options.check) {
+		console.log(`\nTo update, run:\n  ${installInfo.updateCommand}`)
+		process.exit(0)
+	}
+
+	// Execute update
+	console.log(`\nUpdating via ${installInfo.method}...`)
+	console.log(`Running: ${installInfo.updateCommand}\n`)
+
+	const result = await executeUpdate(installInfo.updateCommand!)
+	if (result.success) {
+		console.log("\n✓ Update complete! Restart the CLI to use the new version.")
+		process.exit(0)
+	} else {
+		console.error(`\n✗ Update failed: ${result.error}`)
+		console.error(`\nYou can try updating manually:\n  ${installInfo.updateCommand}`)
+		process.exit(1)
+	}
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -67,7 +67,7 @@ program
 		// Subcommand names - if prompt matches one, Commander.js should handle it via subcommand
 		// This is a defensive check for cases where Commander.js routing might not work as expected
 		// (e.g., when spawned as a child process with stdin disconnected)
-		const SUBCOMMANDS = ["auth", "config", "debug", "models"]
+		const SUBCOMMANDS = ["auth", "config", "debug", "models", "update"]
 		if (SUBCOMMANDS.includes(prompt)) {
 			return
 		}
@@ -402,6 +402,16 @@ program
 	.action(async (options: { provider?: string; json?: boolean }) => {
 		const { modelsApiCommand } = await import("./commands/models-api.js")
 		await modelsApiCommand(options)
+	})
+
+// Update command - check for and install CLI updates
+program
+	.command("update")
+	.description("Check for and install CLI updates")
+	.option("--check", "Only check for updates, don't install")
+	.action(async (options: { check?: boolean }) => {
+		const { updateCommand } = await import("./commands/update.js")
+		await updateCommand(options)
 	})
 
 // Handle process termination signals

--- a/cli/src/utils/__tests__/auto-update.test.ts
+++ b/cli/src/utils/__tests__/auto-update.test.ts
@@ -83,10 +83,10 @@ describe("auto-update", () => {
 			expect(message.content).toContain("A new version of Kilo CLI is available!")
 			expect(message.content).toContain("v1.0.0")
 			expect(message.content).toContain("v2.0.0")
-			expect(message.content).toContain("npm install -g @kilocode/cli")
+			expect(message.content).toContain("kilocode update")
 		})
 
-		it("should include package name in install command", () => {
+		it("should include update command", () => {
 			const status = {
 				name: "@kilocode/cli",
 				isOutdated: true,
@@ -96,7 +96,7 @@ describe("auto-update", () => {
 
 			const message = generateUpdateAvailableMessage(status)
 
-			expect(message.content).toContain("@kilocode/cli")
+			expect(message.content).toContain("kilocode update")
 		})
 	})
 

--- a/cli/src/utils/auto-update.ts
+++ b/cli/src/utils/auto-update.ts
@@ -39,7 +39,7 @@ export const generateUpdateAvailableMessage = (status: AutoUpdateStatus): CliMes
 You are using v${status.currentVersion}, the latest version is v${status.latestVersion}.
 Please run the following command to update:
 \`\`\`bash
-npm install -g ${status.name}
+kilocode update
 \`\`\``,
 	}
 }


### PR DESCRIPTION
## Context

Add `kilocode update` command for CLI self-update functionality. Users can check for updates and install the latest version directly from the terminal without manually running package manager commands.

## Implementation

- **Installation detection**: Detects how the CLI was installed (npm, pnpm, yarn, bun, npx, docker, or local project dependency) by analyzing `process.argv[1]` path patterns
  - Uses original path (before symlink resolution) to distinguish local vs global installs
  - Handles Yarn PnP projects (`.yarn/cache`, `.yarn/unplugged`)
  - Excludes global path patterns to avoid misdetecting global installs as local
- **Version checking**: Fetches latest version from npm registry with 10s timeout using `AbortController`
- **Update execution**: Spawns appropriate package manager command with `shell: true` for Windows compatibility
- **Subcommand registration**: Added to `SUBCOMMANDS` array in `index.ts` for fallback handling

Key design decisions:
- Returns `canUpdate: false` for local installs, npx, and docker with manual update instructions
- Uses `semver.gt()` for version comparison (consistent with auto-update.ts style)
- Original argv path used for local detection to avoid pnpm store path conflicts
- Updated auto-update notification to suggest `kilocode update` instead of hardcoded `npm install -g`

## Screenshots

N/A (CLI command)

## How to Test

```bash
# Build CLI
cd cli && pnpm build

# Test update check
pnpm start update --check

# Test with different install scenarios (mock by setting process.argv[1])
pnpm vitest run src/commands/__tests__/update.test.ts
```

Expected behaviors:
- Global npm/pnpm/yarn/bun install → shows update command and executes it
- Local node_modules install → shows "Running from local node_modules" with manual instructions
- Yarn PnP project → shows "Running from Yarn PnP" with `yarn up` instruction
- npx/pnpx/bunx → shows "Each run uses the latest version automatically"
- Docker → shows `docker pull` instruction

## Get in Touch

@PeterDaveHello 