### PR TITLE
Fix #5462: CLI status bar now shows current provider/model after switching

### DIFF
--- a/apps/cli/src/ui/App.tsx
+++ b/apps/cli/src/ui/App.tsx
@@ -122,6 +122,9 @@ function AppInner({
 		return getContextWindow(routerModels, apiConfiguration)
 	}, [routerModels, apiConfiguration])
 
+	const currentProvider = apiConfiguration?.apiProvider ?? provider
+	const currentModel = apiConfiguration?.apiModelId ?? model
+
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const autocompleteRef = useRef<AutocompleteInputHandle<any>>(null)
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -457,8 +460,8 @@ function AppInner({
 				<Header
 					cwd={workspacePath}
 					user={user}
-					provider={provider}
-					model={model}
+					provider={currentProvider}
+					model={currentModel}
 					mode={currentMode || mode}
 					reasoningEffort={reasoningEffort}
 					version={version}

--- a/apps/cli/src/ui/hooks/useMessageHandlers.ts
+++ b/apps/cli/src/ui/hooks/useMessageHandlers.ts
@@ -42,6 +42,7 @@ export function useMessageHandlers({ nonInteractive }: UseMessageHandlersOptions
 		setTokenUsage,
 		setRouterModels,
 		setTaskHistory,
+		setApiConfiguration,
 		currentTodos,
 		setTodos,
 	} = useCLIStore()
@@ -322,6 +323,10 @@ export function useMessageHandlers({ nonInteractive }: UseMessageHandlersOptions
 					setTaskHistory(newTaskHistory)
 				}
 
+				if (state.apiConfiguration) {
+					setApiConfiguration(state.apiConfiguration)
+				}
+
 				const clineMessages = state.clineMessages
 
 				if (clineMessages) {
@@ -398,6 +403,7 @@ export function useMessageHandlers({ nonInteractive }: UseMessageHandlersOptions
 			setTokenUsage,
 			setRouterModels,
 			setTaskHistory,
+			setApiConfiguration,
 		],
 	)
 


### PR DESCRIPTION
Fixes #5462

## Problem
CLI status bar always showed the initial provider/model even after switching to a different provider.

## Solution
- Extract "apiConfiguration" from extension state messages in "useMessageHandlers.ts"
- Derive current provider/model from store (with fallback to initial props) in "App.tsx"

## Changes
- "apps/cli/src/ui/App.tsx": Use store values for Header component
- "apps/cli/src/ui/hooks/useMessageHandlers.ts": Extract and update apiConfiguration from state

## Testing
- Build passes ✅
- Type checks pass ✅
- Lint passes ✅
- Unit tests pass ✅