### PR TITLE
docs: update discord links to canonical url

### DIFF
--- a/apps/kilocode-docs/pages/getting-started/adding-credits.md
+++ b/apps/kilocode-docs/pages/getting-started/adding-credits.md
@@ -33,5 +33,5 @@ We're continuously working to improve Kilo Code and expand our offerings:
 - More payment options and other plans are under development
 
 {% callout type="tip" title="Need Help?" %}
-If you have any questions about pricing or tokens, please reach out to our [support team](mailto:hi@kilo.ai) or ask in our <a href={DISCORD_URL} target='_blank'>Discord community</a>.
+If you have any questions about pricing or tokens, please reach out to our [support team](mailto:hi@kilo.ai) or ask in our [Discord community](https://kilo.ai/discord).
 {% /callout %}

--- a/apps/kilocode-docs/pages/getting-started/faq.md
+++ b/apps/kilocode-docs/pages/getting-started/faq.md
@@ -53,7 +53,7 @@ Model usage is metered by the providers in terms of different kinds of tokens. W
 
 You can use any models you like as long as you have credits in your account. When you run out of credits, you can add more. It's that simple!
 
-If you're looking to earn some credits, you could join our <a href={DISCORD_URL} target='_blank'>Discord</a> where we sometimes have promotional offers!
+If you're looking to earn some credits, you could join our [Discord](https://kilo.ai/discord) where we sometimes have promotional offers!
 
 ### What are the risks of using Kilo Code?
 


### PR DESCRIPTION
## Context

Documentation had inconsistent Discord links (some using DISCORD_URL) and an outdated contributing documentation URL. This change standardizes links to the canonical Discord landing page and fixes the contributing guide to point at the current docs location.

## Implementation

## Screenshots

| before | after |
| ------ | ----- |
|<img width="2560" height="1398" alt="image" src="https://github.com/user-attachments/assets/fe37aaa4-e8d1-4e88-8a06-140fe00ed538" />|<img width="2560" height="1398" alt="image" src="https://github.com/user-attachments/assets/29a216a2-2771-4307-b7fd-677b3d92e91e" />|
|<img width="2560" height="1398" alt="image" src="https://github.com/user-attachments/assets/6c0d33f2-5d67-4a90-b7b8-22e83681c8f3" />|<img width="2560" height="1398" alt="image" src="https://github.com/user-attachments/assets/78d699df-5bdf-4f29-b1f6-6043696da5a1" />|

## How to Test

## Get in Touch

Phoen1xCode