### PR TITLE
feat: change free model onboarding to opt-in with button

### DIFF
--- a/.changeset/opt-in-free-models.md
+++ b/.changeset/opt-in-free-models.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Changed free model onboarding from automatic to opt-in: new users must click "Start with free models" button to enable free models instead of having them configured by default

--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -948,6 +948,7 @@ export interface WebviewMessage {
 		| "openDebugUiHistory"
 		| "startDeviceAuth" // kilocode_change: Start device auth flow
 		| "cancelDeviceAuth" // kilocode_change: Cancel device auth flow
+		| "startWithFreeModels" // kilocode_change: Start with free models without auth
 		| "deviceAuthCompleteWithProfile" // kilocode_change: Device auth complete with specific profile
 		| "requestChatCompletion" // kilocode_change: Request FIM completion for chat text area
 		| "chatCompletionAccepted" // kilocode_change: User accepted a chat completion suggestion

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -66,16 +66,9 @@ export class ProviderSettingsManager {
 		modes.map((mode) => [mode.slug, this.defaultConfigId]),
 	)
 
-	// kilocode_change start: Anonymous kilocode onboarding - set default provider for new users
 	private readonly defaultProviderProfiles: ProviderProfiles = {
 		currentApiConfigName: "default",
-		apiConfigs: {
-			default: {
-				id: this.defaultConfigId,
-				apiProvider: "kilocode",
-				kilocodeModel: "minimax/minimax-m2.1:free",
-			},
-		},
+		apiConfigs: { default: { id: this.defaultConfigId } },
 		modeApiConfigs: this.defaultModeApiConfigs,
 		migrations: {
 			rateLimitSecondsMigrated: true, // Mark as migrated on fresh installs
@@ -86,7 +79,6 @@ export class ProviderSettingsManager {
 			claudeCodeLegacySettingsMigrated: true, // Mark as migrated on fresh installs
 		},
 	}
-	// kilocode_change end
 
 	// kilocode_change start
 	private pendingDuplicateIdRepairReport: Record<string, string[]> | null = null
@@ -148,15 +140,10 @@ export class ProviderSettingsManager {
 	async init_runMigrations() {
 		try {
 			return await this.lock(async () => {
-				// kilocode_change start: Check if this is a new user (no stored config)
-				const storedContent = await this.context.secrets.get(this.secretsKey)
-				const isNewUser = !storedContent
-				// kilocode_change end
+				const providerProfiles = await this.load()
 
-				const providerProfiles = await this.loadFromContent(storedContent)
-
-				if (isNewUser) {
-					await this.store(providerProfiles)
+				if (!providerProfiles) {
+					await this.store(this.defaultProviderProfiles)
 					return
 				}
 
@@ -774,13 +761,9 @@ export class ProviderSettingsManager {
 	}
 
 	private async load(): Promise<ProviderProfiles> {
-		const content = await this.context.secrets.get(this.secretsKey)
-		return this.loadFromContent(content)
-	}
-
-	// kilocode_change start: Extract content parsing to avoid double-fetching in init_runMigrations
-	private loadFromContent(content: string | undefined): ProviderProfiles {
 		try {
+			const content = await this.context.secrets.get(this.secretsKey)
+
 			if (!content) {
 				return this.defaultProviderProfiles
 			}
@@ -819,7 +802,6 @@ export class ProviderSettingsManager {
 			throw new Error(`Failed to read provider profiles from secrets: ${error}`)
 		}
 	}
-	// kilocode_change end
 
 	/**
 	 * Sanitizes a provider config by resetting invalid/removed apiProvider values.

--- a/src/core/kilocode/webview/__tests__/webviewMessageHandlerUtils.spec.ts
+++ b/src/core/kilocode/webview/__tests__/webviewMessageHandlerUtils.spec.ts
@@ -1,0 +1,84 @@
+import { deviceAuthMessageHandler } from "../webviewMessageHandlerUtils"
+import { ClineProvider } from "../../../webview/ClineProvider"
+import { WebviewMessage } from "../../../../shared/WebviewMessage"
+
+// Mock the buildApiHandler
+vi.mock("../../../../api", () => ({
+	buildApiHandler: vi.fn().mockReturnValue({}),
+}))
+
+describe("deviceAuthMessageHandler", () => {
+	let mockProvider: Partial<ClineProvider>
+
+	beforeEach(() => {
+		mockProvider = {
+			getState: vi.fn().mockResolvedValue({
+				apiConfiguration: {},
+				currentApiConfigName: "default",
+			}),
+			upsertProviderProfile: vi.fn().mockResolvedValue(undefined),
+			getCurrentTask: vi.fn().mockReturnValue(null),
+			postMessageToWebview: vi.fn(),
+			log: vi.fn(),
+		}
+	})
+
+	describe("startWithFreeModels", () => {
+		it("should set up the profile with kilocode provider and free model", async () => {
+			const message: WebviewMessage = { type: "startWithFreeModels" }
+
+			const result = await deviceAuthMessageHandler(mockProvider as ClineProvider, message)
+
+			expect(result).toBe(true)
+			expect(mockProvider.upsertProviderProfile).toHaveBeenCalledWith("default", {
+				apiProvider: "kilocode",
+				kilocodeModel: "minimax/minimax-m2.1:free",
+			})
+		})
+
+		it("should navigate to chat tab after setting up free models", async () => {
+			const message: WebviewMessage = { type: "startWithFreeModels" }
+
+			await deviceAuthMessageHandler(mockProvider as ClineProvider, message)
+
+			expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
+				type: "action",
+				action: "switchTab",
+				tab: "chat",
+			})
+		})
+
+		it("should preserve existing apiConfiguration when setting up free models", async () => {
+			mockProvider.getState = vi.fn().mockResolvedValue({
+				apiConfiguration: {
+					existingSetting: "value",
+					anotherSetting: 123,
+				},
+				currentApiConfigName: "my-profile",
+			})
+
+			const message: WebviewMessage = { type: "startWithFreeModels" }
+
+			await deviceAuthMessageHandler(mockProvider as ClineProvider, message)
+
+			expect(mockProvider.upsertProviderProfile).toHaveBeenCalledWith("my-profile", {
+				existingSetting: "value",
+				anotherSetting: 123,
+				apiProvider: "kilocode",
+				kilocodeModel: "minimax/minimax-m2.1:free",
+			})
+		})
+
+		it("should log error if setup fails", async () => {
+			const error = new Error("Test error")
+			mockProvider.upsertProviderProfile = vi.fn().mockRejectedValue(error)
+
+			const message: WebviewMessage = { type: "startWithFreeModels" }
+
+			const result = await deviceAuthMessageHandler(mockProvider as ClineProvider, message)
+
+			expect(result).toBe(true) // Still returns true even on error
+			expect(mockProvider.log).toHaveBeenCalledWith("Error setting up free models: Test error")
+		})
+	})
+})

--- a/src/core/kilocode/webview/webviewMessageHandlerUtils.ts
+++ b/src/core/kilocode/webview/webviewMessageHandlerUtils.ts
@@ -354,6 +354,28 @@ export const deviceAuthMessageHandler = async (provider: ClineProvider, message:
 			provider.cancelDeviceAuth()
 			return true
 		}
+		case "startWithFreeModels": {
+			// Set up kilocode provider with free model (no token required)
+			try {
+				const { currentApiConfigName = "default", apiConfiguration } = await provider.getState()
+				await provider.upsertProviderProfile(currentApiConfigName, {
+					...apiConfiguration,
+					apiProvider: "kilocode",
+					kilocodeModel: "minimax/minimax-m2.1:free",
+				})
+
+				// Navigate to chat tab after setup using action message
+				await provider.postMessageToWebview({
+					type: "action",
+					action: "switchTab",
+					tab: "chat",
+				})
+			} catch (error) {
+				provider.log(`Error setting up free models: ${error instanceof Error ? error.message : String(error)}`)
+				vscode.window.showErrorMessage("Failed to set up free models")
+			}
+			return true
+		}
 		case "deviceAuthCompleteWithProfile": {
 			// Save token to specific profile or current profile if no profile name provided
 			if (message.values?.token) {

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -4605,6 +4605,7 @@ export const webviewMessageHandler = async (
 		// kilocode_change start - Device Auth handlers
 		case "startDeviceAuth":
 		case "cancelDeviceAuth":
+		case "startWithFreeModels":
 		case "deviceAuthCompleteWithProfile": {
 			await deviceAuthMessageHandler(provider, message)
 			break

--- a/webview-ui/src/components/kilocode/common/KiloCodeAuth.tsx
+++ b/webview-ui/src/components/kilocode/common/KiloCodeAuth.tsx
@@ -138,6 +138,13 @@ const KiloCodeAuth: React.FC<KiloCodeAuthProps> = ({ onManualConfigClick, onLogi
 			<div className="w-full flex flex-col gap-5">
 				<ButtonPrimary onClick={handleStartDeviceAuth}>{t("kilocode:welcome.ctaButton")}</ButtonPrimary>
 
+				<ButtonSecondary
+					onClick={() => {
+						vscode.postMessage({ type: "startWithFreeModels" })
+					}}>
+					{t("kilocode:welcome.startWithFreeModels")}
+				</ButtonSecondary>
+
 				{!!onManualConfigClick && (
 					<ButtonSecondary onClick={() => onManualConfigClick && onManualConfigClick()}>
 						{t("kilocode:welcome.manualModeButton")}

--- a/webview-ui/src/i18n/locales/en/kilocode.json
+++ b/webview-ui/src/i18n/locales/en/kilocode.json
@@ -5,6 +5,7 @@
 		"introText2": "It works with the latest AI models like Claude Opus 4.5, Gemini 3 Pro, GPT-5.2, and 450+ more.",
 		"introText3": "Create a free account and get $20 in bonus credits when you top-up for the first time.",
 		"ctaButton": "Get Started",
+		"startWithFreeModels": "Start with free models",
 		"manualModeButton": "Use your own API key",
 		"alreadySignedUp": "Already signed up?",
 		"loginText": "Log in here"


### PR DESCRIPTION
## Changes

- Reverts automatic kilocode profile creation for new users from PR #5415
- Adds 'Start with free models' button to WelcomeView 
- Implements `startWithFreeModels` message handler
- Updates tests to reflect opt-in behavior

## Behavior

**Before (PR #5415):**
- New users automatically got a kilocode profile with free model configured
- No user action required

**After (this PR):**
- New users see empty default profile
- Must click 'Start with free models' button to enable free models
- Provides explicit opt-in user experience

## Related
- Addresses feedback on PR #5415
- Maintains anonymous access support for kilocode provider