### PR TITLE
fix(cli): ensure custom commands prompt for input in YOLO mode

### DIFF
--- a/.changeset/fix-yolo-custom-command-input.md
+++ b/.changeset/fix-yolo-custom-command-input.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix: Ensure custom commands in YOLO mode prompt for input instead of auto-executing

--- a/cli/src/commands/__tests__/helpers/mockContext.ts
+++ b/cli/src/commands/__tests__/helpers/mockContext.ts
@@ -83,6 +83,9 @@ export function createMockContext(overrides: Partial<CommandContext> = {}): Comm
 		resetModelListState: vi.fn(),
 		// Condense context
 		condenseAndWait: vi.fn().mockResolvedValue(undefined),
+		// Input control
+		setInput: vi.fn(),
+		yoloMode: false,
 	}
 
 	return {

--- a/cli/src/commands/core/types.ts
+++ b/cli/src/commands/core/types.ts
@@ -88,6 +88,9 @@ export interface CommandContext {
 	resetModelListState: () => void
 	// Condense context
 	condenseAndWait: (taskId: string) => Promise<void>
+	// Input control
+	setInput: (value: string) => void
+	yoloMode: boolean
 }
 
 export type CommandHandler = (context: CommandContext) => Promise<void> | void

--- a/cli/src/commands/custom.ts
+++ b/cli/src/commands/custom.ts
@@ -119,10 +119,14 @@ function createCustomCommandHandler(customCommand: CustomCommand): CommandHandle
 
 		const processedContent = substituteArguments(customCommand.content, args)
 
-		await sendWebviewMessage({
-			type: "newTask",
-			text: processedContent,
-		})
+		if (context.yoloMode) {
+			context.setInput(processedContent)
+		} else {
+			await sendWebviewMessage({
+				type: "newTask",
+				text: processedContent,
+			})
+		}
 	}
 }
 

--- a/cli/src/state/hooks/useCommandContext.ts
+++ b/cli/src/state/hooks/useCommandContext.ts
@@ -16,6 +16,7 @@ import {
 	setMessageCutoffTimestampAtom,
 	isCommittingParallelModeAtom,
 	refreshTerminalAtom,
+	yoloModeAtom,
 } from "../atoms/ui.js"
 import {
 	setModeAtom,
@@ -51,6 +52,7 @@ import { useWebviewMessage } from "./useWebviewMessage.js"
 import { useTaskHistory } from "./useTaskHistory.js"
 import { useCondense } from "./useCondense.js"
 import { getModelIdKey } from "../../constants/providers/models.js"
+import { setTextAtom } from "../atoms/textBuffer.js"
 
 const TERMINAL_CLEAR_DELAY_MS = 500
 
@@ -104,6 +106,7 @@ export function useCommandContext(): UseCommandContextReturn {
 	const setCommittingParallelMode = useSetAtom(isCommittingParallelModeAtom)
 	const refreshTerminal = useSetAtom(refreshTerminalAtom)
 	const { sendMessage, clearTask } = useWebviewMessage()
+	const setTextBuffer = useSetAtom(setTextAtom)
 
 	// Get read-only state
 	const routerModels = useAtomValue(routerModelsAtom)
@@ -115,6 +118,7 @@ export function useCommandContext(): UseCommandContextReturn {
 	const config = useAtomValue(configAtom)
 	const chatMessages = useAtomValue(chatMessagesAtom)
 	const currentTask = useAtomValue(currentTaskAtom)
+	const yoloMode = useAtomValue(yoloModeAtom)
 
 	// Get profile state
 	const profileData = useAtomValue(profileDataAtom)
@@ -144,6 +148,13 @@ export function useCommandContext(): UseCommandContextReturn {
 
 	// Get condense function
 	const { condenseAndWait } = useCondense()
+
+	const setInput = useCallback(
+		(text: string) => {
+			setTextBuffer(text)
+		},
+		[setTextBuffer],
+	)
 
 	// Create the factory function
 	const createContext = useCallback<CommandContextFactory>(
@@ -251,6 +262,9 @@ export function useCommandContext(): UseCommandContextReturn {
 				resetModelListState,
 				// Condense context
 				condenseAndWait,
+				// Input control
+				setInput,
+				yoloMode,
 			}
 		},
 		[
@@ -294,6 +308,8 @@ export function useCommandContext(): UseCommandContextReturn {
 			changeModelListPage,
 			resetModelListState,
 			condenseAndWait,
+			setInput,
+			yoloMode,
 		],
 	)
 


### PR DESCRIPTION
Fixes an issue where custom commands would auto-execute in YOLO mode without giving the user a chance to edit the input.