### PR TITLE
feat(cli): add /shortcuts command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -50,6 +50,8 @@ kilocode -c
 kilocode --continue
 ```
 
+Tip: In interactive mode, type `/shortcuts` to view keyboard shortcuts.
+
 ### Parallel mode
 
 Parallel mode allows multiple Kilo Code instances to work in parallel on the same directory, without conflicts. You can spawn as many Kilo Code instances as you need! Once finished, changes will be available on a separate git branch.

--- a/cli/src/commands/__tests__/shortcuts.test.ts
+++ b/cli/src/commands/__tests__/shortcuts.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the /shortcuts command
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import { shortcutsCommand } from "../shortcuts.js"
+import { createMockContext } from "./helpers/mockContext.js"
+
+describe("shortcutsCommand", () => {
+	describe("command metadata", () => {
+		it("should have correct name", () => {
+			expect(shortcutsCommand.name).toBe("shortcuts")
+		})
+
+		it("should have correct aliases", () => {
+			expect(shortcutsCommand.aliases).toEqual(["keys", "hotkeys"])
+		})
+
+		it("should have correct description", () => {
+			expect(shortcutsCommand.description).toBe("Show keyboard shortcuts")
+		})
+
+		it("should have correct usage", () => {
+			expect(shortcutsCommand.usage).toBe("/shortcuts")
+		})
+
+		it("should have correct category", () => {
+			expect(shortcutsCommand.category).toBe("system")
+		})
+
+		it("should have examples", () => {
+			expect(shortcutsCommand.examples).toEqual(["/shortcuts", "/keys", "/hotkeys"])
+		})
+	})
+
+	describe("handler", () => {
+		it("should output shortcut help", async () => {
+			const addMessage = vi.fn()
+			const context = createMockContext({
+				input: "/shortcuts",
+				addMessage,
+			})
+
+			await shortcutsCommand.handler(context)
+
+			expect(addMessage).toHaveBeenCalledTimes(1)
+			const message = addMessage.mock.calls[0]![0]
+			expect(message.type).toBe("system")
+			expect(message.content).toContain("**Keyboard Shortcuts**")
+			expect(message.content).toContain("Shift+Tab")
+			expect(message.content).toContain("!")
+			expect(message.content).toMatch(/(Cmd\+C|Ctrl\+C)/)
+		})
+	})
+})

--- a/cli/src/commands/index.ts
+++ b/cli/src/commands/index.ts
@@ -8,6 +8,7 @@ export * from "./core/registry.js"
 import { commandRegistry } from "./core/registry.js"
 
 import { helpCommand } from "./help.js"
+import { shortcutsCommand } from "./shortcuts.js"
 import { newCommand } from "./new.js"
 import { clearCommand } from "./clear.js"
 import { exitCommand } from "./exit.js"
@@ -29,6 +30,7 @@ import { condenseCommand } from "./condense.js"
 export function initializeCommands(): void {
 	// Register all commands
 	commandRegistry.register(helpCommand)
+	commandRegistry.register(shortcutsCommand)
 	commandRegistry.register(newCommand)
 	commandRegistry.register(clearCommand)
 	commandRegistry.register(exitCommand)

--- a/cli/src/commands/shortcuts.ts
+++ b/cli/src/commands/shortcuts.ts
@@ -1,0 +1,113 @@
+/**
+ * /shortcuts command - Display keyboard shortcuts
+ */
+
+import type { Command } from "./core/types.js"
+import { generateMessage } from "../ui/utils/messages.js"
+
+type ShortcutItem = {
+	keys: string
+	description: string
+}
+
+type ShortcutSection = {
+	title: string
+	items: ShortcutItem[]
+}
+
+function getModifierKey(): "Cmd" | "Ctrl" {
+	return process.platform === "darwin" ? "Cmd" : "Ctrl"
+}
+
+function buildShortcutSections(modifierKey: "Cmd" | "Ctrl"): ShortcutSection[] {
+	return [
+		{
+			title: "Global",
+			items: [
+				{ keys: `${modifierKey}+C`, description: "Exit (press twice to confirm)" },
+				{ keys: `${modifierKey}+Y`, description: "Toggle YOLO mode (auto-approve all operations)" },
+				{ keys: `${modifierKey}+R`, description: "Resume task (when a task is ready to resume)" },
+				{ keys: "Shift+Tab", description: "Cycle through modes" },
+				{ keys: "!", description: "Enter shell mode (when input is empty)" },
+				{ keys: "Up/Down", description: "Navigate command history (when input is empty)" },
+				{ keys: `${modifierKey}+V`, description: "Paste image from clipboard (if available)" },
+			],
+		},
+		{
+			title: "Streaming/Task",
+			items: [
+				{ keys: "Esc", description: "Cancel current task (while streaming) or clear input" },
+				{ keys: `${modifierKey}+X`, description: "Cancel current task (while streaming)" },
+			],
+		},
+		{
+			title: "Input",
+			items: [
+				{ keys: "Enter", description: "Submit message" },
+				{ keys: "Shift+Enter", description: "Insert newline" },
+			],
+		},
+		{
+			title: "Approvals",
+			items: [
+				{ keys: "Y", description: "Approve" },
+				{ keys: "N", description: "Reject" },
+				{ keys: "1-9", description: "Select an approval scope (when shown)" },
+				{ keys: "Esc", description: "Cancel approval prompt" },
+			],
+		},
+		{
+			title: "Followup Suggestions",
+			items: [
+				{ keys: "Up/Down", description: "Navigate suggestions" },
+				{ keys: "Tab", description: "Fill suggestion" },
+				{ keys: "Enter", description: "Submit suggestion" },
+			],
+		},
+		{
+			title: "Shell Mode",
+			items: [
+				{ keys: "Up/Down", description: "History" },
+				{ keys: "Enter", description: "Execute command" },
+				{ keys: "Esc", description: "Exit shell mode" },
+				{ keys: "!", description: "Exit shell mode" },
+			],
+		},
+	]
+}
+
+function formatShortcutSections(sections: ShortcutSection[]): string {
+	const lines: string[] = ["**Keyboard Shortcuts**", ""]
+
+	sections.forEach((section) => {
+		lines.push(`**${section.title}**`)
+		section.items.forEach((item) => {
+			lines.push(`- \`${item.keys}\` - ${item.description}`)
+		})
+		lines.push("")
+	})
+
+	return lines.join("\n").trim()
+}
+
+export const shortcutsCommand: Command = {
+	name: "shortcuts",
+	aliases: ["keys", "hotkeys"],
+	description: "Show keyboard shortcuts",
+	usage: "/shortcuts",
+	examples: ["/shortcuts", "/keys", "/hotkeys"],
+	category: "system",
+	priority: 7,
+	handler: async (context) => {
+		const { addMessage } = context
+		const modifierKey = getModifierKey()
+		const sections = buildShortcutSections(modifierKey)
+		const content = formatShortcutSections(sections)
+
+		addMessage({
+			...generateMessage(),
+			type: "system",
+			content,
+		})
+	},
+}


### PR DESCRIPTION
## Context

Add a /shortcuts command to surface keyboard shortcuts inside the CLI so users don’t need to leave the terminal to find keybindings. This addresses a current gap where shortcuts are documented but not discoverable in‑app.

## Implementation

- Added a new /shortcuts command (aliases: /keys, /hotkeys) that formats and prints shortcut sections with a platform‑appropriate modifier key (Cmd/Ctrl).
- Registered the command with the command registry and documented it in the CLI README.
- Added unit tests for command metadata and output format.

## Screenshots

N/A — CLI output is self‑descriptive.

## How to Test

- Run the CLI interactively: `pnpm start:dev` (or `pnpm start:dev -w ../` from `cli/`).
- Type `/shortcuts`.
- Verify the shortcut list renders with sections and the correct modifier key (Cmd on macOS, Ctrl on other platforms).

## Get in Touch

Discord: aravhawk