### PR TITLE
feat(cli): add /version command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -50,6 +50,8 @@ kilocode -c
 kilocode --continue
 ```
 
+Tip: Type `/version` to view CLI version and environment info.
+
 ### Parallel mode
 
 Parallel mode allows multiple Kilo Code instances to work in parallel on the same directory, without conflicts. You can spawn as many Kilo Code instances as you need! Once finished, changes will be available on a separate git branch.

--- a/cli/src/commands/__tests__/version.test.ts
+++ b/cli/src/commands/__tests__/version.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the /version command
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { versionCommand } from "../version.js"
+import { createMockContext } from "./helpers/mockContext.js"
+
+const getAutoUpdateStatusMock = vi.fn()
+
+vi.mock("../../utils/auto-update.js", () => ({
+	getAutoUpdateStatus: () => getAutoUpdateStatusMock(),
+}))
+
+describe("versionCommand", () => {
+	beforeEach(() => {
+		getAutoUpdateStatusMock.mockReset()
+	})
+
+	describe("command metadata", () => {
+		it("should have correct name", () => {
+			expect(versionCommand.name).toBe("version")
+		})
+
+		it("should have correct aliases", () => {
+			expect(versionCommand.aliases).toEqual(["about", "ver"])
+		})
+
+		it("should have correct description", () => {
+			expect(versionCommand.description).toBe("Show CLI version information")
+		})
+
+		it("should have correct usage", () => {
+			expect(versionCommand.usage).toBe("/version")
+		})
+
+		it("should have correct category", () => {
+			expect(versionCommand.category).toBe("system")
+		})
+
+		it("should have examples", () => {
+			expect(versionCommand.examples).toEqual(["/version", "/about", "/ver"])
+		})
+	})
+
+	describe("handler", () => {
+		it("should show up-to-date status when current version is latest", async () => {
+			getAutoUpdateStatusMock.mockResolvedValue({
+				name: "@kilocode/cli",
+				isOutdated: false,
+				currentVersion: "1.0.0",
+				latestVersion: "1.0.0",
+			})
+
+			const addMessage = vi.fn()
+			const context = createMockContext({
+				input: "/version",
+				addMessage,
+			})
+
+			await versionCommand.handler(context)
+
+			expect(addMessage).toHaveBeenCalledTimes(1)
+			const message = addMessage.mock.calls[0]![0]
+			expect(message.type).toBe("system")
+			expect(message.content).toContain("**Version Information**")
+			expect(message.content).toContain("CLI:")
+			expect(message.content).toContain("Node:")
+			expect(message.content).toContain("OS:")
+			expect(message.content).toContain("Update: up to date")
+		})
+
+		it("should show update instructions when a newer version is available", async () => {
+			getAutoUpdateStatusMock.mockResolvedValue({
+				name: "@kilocode/cli",
+				isOutdated: true,
+				currentVersion: "1.0.0",
+				latestVersion: "1.2.0",
+			})
+
+			const addMessage = vi.fn()
+			const context = createMockContext({
+				input: "/version",
+				addMessage,
+			})
+
+			await versionCommand.handler(context)
+
+			const message = addMessage.mock.calls[0]![0]
+			expect(message.content).toContain("Update: v1.2.0 available (current v1.0.0)")
+			expect(message.content).toContain("Run: npm install -g @kilocode/cli")
+		})
+	})
+})

--- a/cli/src/commands/index.ts
+++ b/cli/src/commands/index.ts
@@ -22,6 +22,7 @@ import { themeCommand } from "./theme.js"
 import { checkpointCommand } from "./checkpoint.js"
 import { sessionCommand } from "./session.js"
 import { condenseCommand } from "./condense.js"
+import { versionCommand } from "./version.js"
 
 /**
  * Initialize all built-in commands
@@ -43,4 +44,5 @@ export function initializeCommands(): void {
 	commandRegistry.register(checkpointCommand)
 	commandRegistry.register(sessionCommand)
 	commandRegistry.register(condenseCommand)
+	commandRegistry.register(versionCommand)
 }

--- a/cli/src/commands/version.ts
+++ b/cli/src/commands/version.ts
@@ -1,0 +1,49 @@
+/**
+ * /version command - Display CLI version information
+ */
+
+import os from "os"
+import type { Command } from "./core/types.js"
+import { Package } from "../constants/package.js"
+import { getAutoUpdateStatus } from "../utils/auto-update.js"
+import { generateMessage } from "../ui/utils/messages.js"
+
+function formatUpdateLine(status: Awaited<ReturnType<typeof getAutoUpdateStatus>>): string[] {
+	if (status.isOutdated) {
+		return [
+			`Update: v${status.latestVersion} available (current v${status.currentVersion})`,
+			`Run: npm install -g ${status.name}`,
+		]
+	}
+
+	return ["Update: up to date"]
+}
+
+export const versionCommand: Command = {
+	name: "version",
+	aliases: ["about", "ver"],
+	description: "Show CLI version information",
+	usage: "/version",
+	examples: ["/version", "/about", "/ver"],
+	category: "system",
+	priority: 7,
+	handler: async (context) => {
+		const { addMessage } = context
+		const status = await getAutoUpdateStatus()
+
+		const lines = [
+			"**Version Information**",
+			"",
+			`CLI: ${Package.name} v${Package.version}`,
+			`Node: ${process.version}`,
+			`OS: ${os.platform()} ${os.release()} (${process.arch})`,
+			...formatUpdateLine(status),
+		]
+
+		addMessage({
+			...generateMessage(),
+			type: "system",
+			content: lines.join("\n"),
+		})
+	},
+}


### PR DESCRIPTION
## Context
Add a `/version` command so users can quickly see the CLI version, Node/OS info, and whether an update is available.

## Implementation
- Added a new command that calls the existing auto-update utility and formats version/environment details into a single system message.
- Registered the command and documented the new tip in the CLI README.
- Added unit tests covering both up-to-date and update-available outputs.

## Screenshots

| before | after |
| ------ | ----- |
| N/A (CLI) | N/A (CLI) |

## How to Test
- `cd cli`
- `npm test` (fails in this environment due to `uv_uptime` EPERM in `src/debug/os/__tests__/os.test.ts`, unrelated to this change)
- `pnpm start:dev` and run `/version` to verify output

## Get in Touch
Discord: aravhawk