### PR TITLE
feat(cli): add cleanup command

### DIFF
--- a/.changeset/clean-cli-cleanup-command.md
+++ b/.changeset/clean-cli-cleanup-command.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Add a cleanup command to delete CLI logs, history, and task data.

--- a/cli/README.md
+++ b/cli/README.md
@@ -101,6 +101,21 @@ echo "Fix the bug in app.ts" | kilocode --auto
 kilocode --auto "Run tests" --timeout 300
 ```
 
+### Cleanup
+
+Clean up local CLI data like logs, task history, and command history:
+
+```bash
+# Default cleanup (logs, tasks, command history)
+kilocode cleanup
+
+# Show what would be deleted
+kilocode cleanup --dry-run
+
+# Remove everything including config and identity
+kilocode cleanup --all --yes
+```
+
 #### Task Completion Hook
 
 Use `--on-task-completed` to send a follow-up prompt to the agent when the main task completes. This is useful for automating post-task actions like creating pull requests.

--- a/cli/docs/DISK_SPACE_MANAGEMENT.md
+++ b/cli/docs/DISK_SPACE_MANAGEMENT.md
@@ -2,6 +2,21 @@
 
 The Kilo Code CLI stores task history in `~/.kilocode/cli/` (or `%USERPROFILE%\.kilocode\cli\` on Windows). With heavy usage, this directory can grow significantly.
 
+## Cleanup Command
+
+Use the CLI to clean up stored data without manual deletion:
+
+```bash
+# Default cleanup (logs, tasks, command history)
+kilocode cleanup
+
+# Show what would be deleted
+kilocode cleanup --dry-run
+
+# Remove everything including config and identity
+kilocode cleanup --all --yes
+```
+
 ## Manual Cleanup
 
 Delete the CLI data directory to free disk space:

--- a/cli/src/commands/__tests__/cleanup.test.ts
+++ b/cli/src/commands/__tests__/cleanup.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { mkdirSync, rmSync, writeFileSync, existsSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+import { runCleanup, type CleanupPaths } from "../cleanup.js"
+
+function createTempDir(): string {
+	const dir = join(tmpdir(), `kilocode-cleanup-test-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+	mkdirSync(dir, { recursive: true })
+	return dir
+}
+
+function buildPaths(baseDir: string): CleanupPaths {
+	return {
+		logsDir: join(baseDir, "logs"),
+		tasksDir: join(baseDir, "tasks"),
+		historyFile: join(baseDir, "history.json"),
+		configFile: join(baseDir, "config.json"),
+		identityFile: join(baseDir, "identity.json"),
+	}
+}
+
+function seedPaths(paths: CleanupPaths): void {
+	mkdirSync(paths.logsDir, { recursive: true })
+	mkdirSync(paths.tasksDir, { recursive: true })
+	writeFileSync(paths.historyFile, "[]")
+	writeFileSync(paths.configFile, "{}")
+	writeFileSync(paths.identityFile, "{}")
+}
+
+describe("cleanup command", () => {
+	let baseDir: string
+	let paths: CleanupPaths
+	const io = { log: vi.fn(), error: vi.fn() }
+
+	beforeEach(() => {
+		baseDir = createTempDir()
+		paths = buildPaths(baseDir)
+		seedPaths(paths)
+		io.log.mockClear()
+		io.error.mockClear()
+	})
+
+	afterEach(() => {
+		if (existsSync(baseDir)) {
+			rmSync(baseDir, { recursive: true, force: true })
+		}
+	})
+
+	it("defaults to logs, tasks, and history", async () => {
+		const result = await runCleanup({ yes: true }, { paths, io, isInteractive: true })
+
+		expect(result.exitCode).toBe(0)
+		expect(existsSync(paths.logsDir)).toBe(false)
+		expect(existsSync(paths.tasksDir)).toBe(false)
+		expect(existsSync(paths.historyFile)).toBe(false)
+		expect(existsSync(paths.configFile)).toBe(true)
+		expect(existsSync(paths.identityFile)).toBe(true)
+	})
+
+	it("removes everything with --all", async () => {
+		const result = await runCleanup({ all: true, yes: true }, { paths, io, isInteractive: true })
+
+		expect(result.exitCode).toBe(0)
+		expect(existsSync(paths.logsDir)).toBe(false)
+		expect(existsSync(paths.tasksDir)).toBe(false)
+		expect(existsSync(paths.historyFile)).toBe(false)
+		expect(existsSync(paths.configFile)).toBe(false)
+		expect(existsSync(paths.identityFile)).toBe(false)
+	})
+
+	it("does not delete anything on dry run", async () => {
+		const result = await runCleanup({ dryRun: true }, { paths, io, isInteractive: true })
+
+		expect(result.exitCode).toBe(0)
+		expect(result.dryRun).toBe(true)
+		expect(existsSync(paths.logsDir)).toBe(true)
+		expect(existsSync(paths.tasksDir)).toBe(true)
+		expect(existsSync(paths.historyFile)).toBe(true)
+		expect(existsSync(paths.configFile)).toBe(true)
+		expect(existsSync(paths.identityFile)).toBe(true)
+	})
+
+	it("requires --yes or --dry-run in non-interactive mode", async () => {
+		const result = await runCleanup({}, { paths, io, isInteractive: false })
+
+		expect(result.exitCode).toBe(1)
+		expect(existsSync(paths.logsDir)).toBe(true)
+		expect(existsSync(paths.tasksDir)).toBe(true)
+		expect(existsSync(paths.historyFile)).toBe(true)
+	})
+})

--- a/cli/src/commands/cleanup.ts
+++ b/cli/src/commands/cleanup.ts
@@ -1,0 +1,254 @@
+import { rm, stat } from "fs/promises"
+import path from "path"
+import { confirm } from "@inquirer/prompts"
+import { KiloCodePaths } from "@kilocode/agent-runtime"
+import { getHistoryPath } from "../config/history.js"
+import { getConfigPath } from "../config/persistence.js"
+import { logs } from "../services/logs.js"
+
+type CleanupKey = "logs" | "tasks" | "history" | "config" | "identity"
+
+export interface CleanupOptions {
+	all?: boolean
+	logs?: boolean
+	tasks?: boolean
+	history?: boolean
+	config?: boolean
+	identity?: boolean
+	dryRun?: boolean
+	yes?: boolean
+}
+
+export interface CleanupPaths {
+	logsDir: string
+	tasksDir: string
+	historyFile: string
+	configFile: string
+	identityFile: string
+}
+
+interface CleanupTarget {
+	key: CleanupKey
+	label: string
+	path: string
+	kind: "file" | "dir"
+}
+
+interface CleanupTargetStatus extends CleanupTarget {
+	exists: boolean
+}
+
+interface CleanupIo {
+	log: (message: string) => void
+	error: (message: string) => void
+}
+
+export interface CleanupResult {
+	exitCode: number
+	planned: CleanupTargetStatus[]
+	removed: CleanupTargetStatus[]
+	skipped: CleanupTargetStatus[]
+	errors: Array<{ target: CleanupTargetStatus; message: string }>
+	dryRun: boolean
+	cancelled: boolean
+}
+
+interface CleanupDependencies {
+	paths?: CleanupPaths
+	io?: CleanupIo
+	confirm?: (message: string) => Promise<boolean>
+	isInteractive?: boolean
+}
+
+export function getCleanupPaths(): CleanupPaths {
+	return {
+		logsDir: KiloCodePaths.getLogsDir(),
+		tasksDir: KiloCodePaths.getTasksDir(),
+		historyFile: getHistoryPath(),
+		configFile: getConfigPath(),
+		identityFile: path.join(KiloCodePaths.getKiloCodeDir(), "identity.json"),
+	}
+}
+
+function resolveSelection(options: CleanupOptions): Set<CleanupKey> {
+	const selection = new Set<CleanupKey>()
+
+	const flags = {
+		logs: options.logs === true,
+		tasks: options.tasks === true,
+		history: options.history === true,
+		config: options.config === true,
+		identity: options.identity === true,
+	}
+
+	const anyExplicit = Object.values(flags).some(Boolean)
+
+	if (options.all) {
+		Object.keys(flags).forEach((key) => {
+			selection.add(key as CleanupKey)
+		})
+		return selection
+	}
+
+	if (!anyExplicit) {
+		selection.add("logs")
+		selection.add("tasks")
+		selection.add("history")
+		return selection
+	}
+
+	if (flags.logs) selection.add("logs")
+	if (flags.tasks) selection.add("tasks")
+	if (flags.history) selection.add("history")
+	if (flags.config) selection.add("config")
+	if (flags.identity) selection.add("identity")
+
+	return selection
+}
+
+function buildTargets(paths: CleanupPaths): CleanupTarget[] {
+	return [
+		{ key: "logs", label: "Logs", path: paths.logsDir, kind: "dir" },
+		{ key: "tasks", label: "Tasks", path: paths.tasksDir, kind: "dir" },
+		{ key: "history", label: "Command history", path: paths.historyFile, kind: "file" },
+		{ key: "config", label: "Config", path: paths.configFile, kind: "file" },
+		{ key: "identity", label: "Identity", path: paths.identityFile, kind: "file" },
+	]
+}
+
+async function checkTarget(target: CleanupTarget): Promise<CleanupTargetStatus> {
+	try {
+		await stat(target.path)
+		return { ...target, exists: true }
+	} catch {
+		return { ...target, exists: false }
+	}
+}
+
+function formatTarget(target: CleanupTargetStatus): string {
+	const suffix = target.exists ? "" : " (not found)"
+	return `- ${target.label}: ${target.path}${suffix}`
+}
+
+function getConfirmMessage(targets: CleanupTargetStatus[]): string {
+	const labelList = targets.map((target) => target.label).join(", ")
+	return `Delete ${targets.length} item${targets.length === 1 ? "" : "s"} (${labelList})?`
+}
+
+export async function runCleanup(options: CleanupOptions, deps: CleanupDependencies = {}): Promise<CleanupResult> {
+	const io = deps.io ?? console
+	const paths = deps.paths ?? getCleanupPaths()
+	const selection = resolveSelection(options)
+
+	if (selection.size === 0) {
+		io.error("Error: No cleanup targets selected. Use --logs, --tasks, --history, --config, --identity, or --all.")
+		return {
+			exitCode: 1,
+			planned: [],
+			removed: [],
+			skipped: [],
+			errors: [],
+			dryRun: Boolean(options.dryRun),
+			cancelled: false,
+		}
+	}
+
+	const targets = buildTargets(paths).filter((target) => selection.has(target.key))
+	const planned = await Promise.all(targets.map((target) => checkTarget(target)))
+
+	io.log("Cleanup targets:")
+	planned.forEach((target) => io.log(formatTarget(target)))
+
+	if (options.dryRun) {
+		io.log("Dry run: no files were deleted.")
+		return {
+			exitCode: 0,
+			planned,
+			removed: [],
+			skipped: planned.filter((target) => !target.exists),
+			errors: [],
+			dryRun: true,
+			cancelled: false,
+		}
+	}
+
+	if (!options.yes) {
+		const isInteractive = deps.isInteractive ?? process.stdin.isTTY
+		if (!isInteractive) {
+			io.error("Error: Non-interactive mode requires --yes or --dry-run.")
+			return {
+				exitCode: 1,
+				planned,
+				removed: [],
+				skipped: [],
+				errors: [],
+				dryRun: false,
+				cancelled: false,
+			}
+		}
+
+		const confirmFn = deps.confirm ?? (async (message: string) => confirm({ message, default: false }))
+		const confirmed = await confirmFn(getConfirmMessage(planned))
+		if (!confirmed) {
+			io.log("Cleanup cancelled.")
+			return {
+				exitCode: 0,
+				planned,
+				removed: [],
+				skipped: [],
+				errors: [],
+				dryRun: false,
+				cancelled: true,
+			}
+		}
+	}
+
+	logs.info("Running cleanup command", "Cleanup", { targets: planned.map((target) => target.key) })
+
+	const removed: CleanupTargetStatus[] = []
+	const skipped: CleanupTargetStatus[] = []
+	const errors: Array<{ target: CleanupTargetStatus; message: string }> = []
+
+	for (const target of planned) {
+		if (!target.exists) {
+			skipped.push(target)
+			continue
+		}
+
+		try {
+			await rm(target.path, { recursive: true, force: true })
+			removed.push(target)
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			errors.push({ target, message })
+			io.error(`Failed to delete ${target.label.toLowerCase()}: ${message}`)
+		}
+	}
+
+	if (removed.length > 0) {
+		io.log(`Removed ${removed.length} item${removed.length === 1 ? "" : "s"}.`)
+	}
+
+	if (skipped.length > 0) {
+		io.log(`Skipped ${skipped.length} item${skipped.length === 1 ? "" : "s"} (not found).`)
+	}
+
+	if (errors.length > 0) {
+		io.error(`Cleanup finished with ${errors.length} error${errors.length === 1 ? "" : "s"}.`)
+	}
+
+	return {
+		exitCode: errors.length > 0 ? 1 : 0,
+		planned,
+		removed,
+		skipped,
+		errors,
+		dryRun: false,
+		cancelled: false,
+	}
+}
+
+export async function cleanupCommand(options: CleanupOptions): Promise<void> {
+	const result = await runCleanup(options)
+	process.exit(result.exitCode)
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -20,6 +20,7 @@ import { getParallelModeParams } from "./parallel/parallel.js"
 import { DEBUG_MODES, DEBUG_FUNCTIONS } from "./debug/index.js"
 import { logs } from "./services/logs.js"
 import { validateAttachments, validateAttachRequiresAuto, accumulateAttachments } from "./validation/attachments.js"
+import { cleanupCommand } from "./commands/cleanup.js"
 
 // Log CLI location for debugging (visible in VS Code "Kilo-Code" output channel)
 logs.info(`CLI started from: ${import.meta.url}`)
@@ -67,7 +68,7 @@ program
 		// Subcommand names - if prompt matches one, Commander.js should handle it via subcommand
 		// This is a defensive check for cases where Commander.js routing might not work as expected
 		// (e.g., when spawned as a child process with stdin disconnected)
-		const SUBCOMMANDS = ["auth", "config", "debug", "models"]
+		const SUBCOMMANDS = ["auth", "config", "debug", "models", "cleanup"]
 		if (SUBCOMMANDS.includes(prompt)) {
 			return
 		}
@@ -402,6 +403,21 @@ program
 	.action(async (options: { provider?: string; json?: boolean }) => {
 		const { modelsApiCommand } = await import("./commands/models-api.js")
 		await modelsApiCommand(options)
+	})
+
+program
+	.command("cleanup")
+	.description("Clean up local Kilo Code CLI data")
+	.option("--logs", "Remove CLI logs")
+	.option("--tasks", "Remove task history and checkpoints")
+	.option("--history", "Remove command history")
+	.option("--config", "Remove CLI config.json")
+	.option("--identity", "Remove CLI identity file")
+	.option("--all", "Remove all CLI data, including config and identity")
+	.option("--dry-run", "Show what would be deleted without removing anything")
+	.option("-y, --yes", "Skip confirmation prompt")
+	.action(async (options) => {
+		await cleanupCommand(options)
 	})
 
 // Handle process termination signals


### PR DESCRIPTION
## Context
Add a `kilocode cleanup` subcommand so users can reclaim disk space by deleting local CLI data (logs, task history, command history) without hunting through `~/.kilocode/cli`.

## Implementation
Introduced a new cleanup command module that plans targets, confirms in interactive mode, supports `--dry-run`/`--yes`, and deletes selected paths. Wired it into the CLI subcommands, added tests for default behavior and flags, and documented usage in the README + disk space guide.

## Screenshots

| before | after |
| ------ | ----- |
| N/A    | N/A   |

## How to Test
- `cd cli && npm test`
- `kilocode cleanup --dry-run` (should list logs/tasks/history without deleting)
- `kilocode cleanup --yes` (should remove logs, tasks, history)
- `kilocode cleanup --all --yes` (should also remove config + identity)

## Get in Touch
aravhawk