### PR TITLE
feat(cli): usage report

### DIFF
--- a/.changeset/clean-cli-cleanup-command.md
+++ b/.changeset/clean-cli-cleanup-command.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Add a cleanup command to delete CLI logs, history, and task data.

--- a/.changeset/usage-reports-cli.md
+++ b/.changeset/usage-reports-cli.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Add CLI usage reports for historical spend and token usage.

--- a/cli/README.md
+++ b/cli/README.md
@@ -50,6 +50,17 @@ kilocode -c
 kilocode --continue
 ```
 
+### Usage Reports
+
+In interactive mode, you can inspect historical spend and token usage:
+
+```bash
+/usage
+/usage --since 7d --workspace all --top 10
+```
+
+The report includes totals, top tasks by cost, provider/model breakdown, and a daily spend trend.
+
 ### Parallel mode
 
 Parallel mode allows multiple Kilo Code instances to work in parallel on the same directory, without conflicts. You can spawn as many Kilo Code instances as you need! Once finished, changes will be available on a separate git branch.

--- a/cli/README.md
+++ b/cli/README.md
@@ -101,6 +101,21 @@ echo "Fix the bug in app.ts" | kilocode --auto
 kilocode --auto "Run tests" --timeout 300
 ```
 
+### Cleanup
+
+Clean up local CLI data like logs, task history, and command history:
+
+```bash
+# Default cleanup (logs, tasks, command history)
+kilocode cleanup
+
+# Show what would be deleted
+kilocode cleanup --dry-run
+
+# Remove everything including config and identity
+kilocode cleanup --all --yes
+```
+
 #### Task Completion Hook
 
 Use `--on-task-completed` to send a follow-up prompt to the agent when the main task completes. This is useful for automating post-task actions like creating pull requests.

--- a/cli/docs/DISK_SPACE_MANAGEMENT.md
+++ b/cli/docs/DISK_SPACE_MANAGEMENT.md
@@ -2,6 +2,21 @@
 
 The Kilo Code CLI stores task history in `~/.kilocode/cli/` (or `%USERPROFILE%\.kilocode\cli\` on Windows). With heavy usage, this directory can grow significantly.
 
+## Cleanup Command
+
+Use the CLI to clean up stored data without manual deletion:
+
+```bash
+# Default cleanup (logs, tasks, command history)
+kilocode cleanup
+
+# Show what would be deleted
+kilocode cleanup --dry-run
+
+# Remove everything including config and identity
+kilocode cleanup --all --yes
+```
+
 ## Manual Cleanup
 
 Delete the CLI data directory to free disk space:

--- a/cli/src/commands/__tests__/cleanup.test.ts
+++ b/cli/src/commands/__tests__/cleanup.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { mkdirSync, rmSync, writeFileSync, existsSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+import { runCleanup, type CleanupPaths } from "../cleanup.js"
+
+function createTempDir(): string {
+	const dir = join(tmpdir(), `kilocode-cleanup-test-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+	mkdirSync(dir, { recursive: true })
+	return dir
+}
+
+function buildPaths(baseDir: string): CleanupPaths {
+	return {
+		logsDir: join(baseDir, "logs"),
+		tasksDir: join(baseDir, "tasks"),
+		historyFile: join(baseDir, "history.json"),
+		configFile: join(baseDir, "config.json"),
+		identityFile: join(baseDir, "identity.json"),
+	}
+}
+
+function seedPaths(paths: CleanupPaths): void {
+	mkdirSync(paths.logsDir, { recursive: true })
+	mkdirSync(paths.tasksDir, { recursive: true })
+	writeFileSync(paths.historyFile, "[]")
+	writeFileSync(paths.configFile, "{}")
+	writeFileSync(paths.identityFile, "{}")
+}
+
+describe("cleanup command", () => {
+	let baseDir: string
+	let paths: CleanupPaths
+	const io = { log: vi.fn(), error: vi.fn() }
+
+	beforeEach(() => {
+		baseDir = createTempDir()
+		paths = buildPaths(baseDir)
+		seedPaths(paths)
+		io.log.mockClear()
+		io.error.mockClear()
+	})
+
+	afterEach(() => {
+		if (existsSync(baseDir)) {
+			rmSync(baseDir, { recursive: true, force: true })
+		}
+	})
+
+	it("defaults to logs, tasks, and history", async () => {
+		const result = await runCleanup({ yes: true }, { paths, io, isInteractive: true })
+
+		expect(result.exitCode).toBe(0)
+		expect(existsSync(paths.logsDir)).toBe(false)
+		expect(existsSync(paths.tasksDir)).toBe(false)
+		expect(existsSync(paths.historyFile)).toBe(false)
+		expect(existsSync(paths.configFile)).toBe(true)
+		expect(existsSync(paths.identityFile)).toBe(true)
+	})
+
+	it("removes everything with --all", async () => {
+		const result = await runCleanup({ all: true, yes: true }, { paths, io, isInteractive: true })
+
+		expect(result.exitCode).toBe(0)
+		expect(existsSync(paths.logsDir)).toBe(false)
+		expect(existsSync(paths.tasksDir)).toBe(false)
+		expect(existsSync(paths.historyFile)).toBe(false)
+		expect(existsSync(paths.configFile)).toBe(false)
+		expect(existsSync(paths.identityFile)).toBe(false)
+	})
+
+	it("does not delete anything on dry run", async () => {
+		const result = await runCleanup({ dryRun: true }, { paths, io, isInteractive: true })
+
+		expect(result.exitCode).toBe(0)
+		expect(result.dryRun).toBe(true)
+		expect(existsSync(paths.logsDir)).toBe(true)
+		expect(existsSync(paths.tasksDir)).toBe(true)
+		expect(existsSync(paths.historyFile)).toBe(true)
+		expect(existsSync(paths.configFile)).toBe(true)
+		expect(existsSync(paths.identityFile)).toBe(true)
+	})
+
+	it("requires --yes or --dry-run in non-interactive mode", async () => {
+		const result = await runCleanup({}, { paths, io, isInteractive: false })
+
+		expect(result.exitCode).toBe(1)
+		expect(existsSync(paths.logsDir)).toBe(true)
+		expect(existsSync(paths.tasksDir)).toBe(true)
+		expect(existsSync(paths.historyFile)).toBe(true)
+	})
+})

--- a/cli/src/commands/__tests__/usage.test.ts
+++ b/cli/src/commands/__tests__/usage.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the /usage command
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { usageCommand } from "../usage.js"
+import { createMockContext } from "./helpers/mockContext.js"
+import type { CommandContext } from "../core/types.js"
+import type { HistoryItem } from "../../types/messages.js"
+
+function createHistoryItem(overrides: Record<string, unknown> = {}): HistoryItem {
+	return {
+		id: "task-1",
+		number: 1,
+		ts: Date.now(),
+		task: "Test task",
+		tokensIn: 100,
+		tokensOut: 200,
+		totalCost: 0.01,
+		...overrides,
+	} as HistoryItem
+}
+
+describe("/usage command", () => {
+	let mockContext: CommandContext
+	let addMessageMock: ReturnType<typeof vi.fn>
+
+	beforeEach(() => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date("2026-01-31T12:00:00Z"))
+		addMessageMock = vi.fn()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it("summarizes usage with top tasks, breakdown, and daily trend", async () => {
+		const page1 = {
+			historyItems: [
+				createHistoryItem({
+					id: "task-1",
+					ts: Date.parse("2026-01-30T08:00:00Z"),
+					task: "Fix billing bug",
+					tokensIn: 1000,
+					tokensOut: 2000,
+					totalCost: 2.5,
+					provider: "openrouter",
+					model: "gpt-4.1",
+				}),
+				createHistoryItem({
+					id: "task-2",
+					ts: Date.parse("2026-01-25T10:00:00Z"),
+					task: "Add onboarding flow",
+					tokensIn: 500,
+					tokensOut: 800,
+					totalCost: 1.0,
+					provider: "kilocode",
+					model: "gpt-5.2-codex",
+				}),
+			],
+			pageIndex: 0,
+			pageCount: 2,
+		}
+
+		const page2 = {
+			historyItems: [
+				createHistoryItem({
+					id: "task-3",
+					ts: Date.parse("2026-01-10T10:00:00Z"),
+					task: "Old task",
+					tokensIn: 300,
+					tokensOut: 400,
+					totalCost: 0.5,
+					provider: "openrouter",
+					model: "gpt-4.1",
+				}),
+			],
+			pageIndex: 1,
+			pageCount: 2,
+		}
+
+		const updateTaskHistoryFilters = vi.fn().mockResolvedValue(page1)
+		const changeTaskHistoryPage = vi.fn().mockResolvedValue(page2)
+
+		mockContext = createMockContext({
+			input: "/usage --since 7d --workspace all --top 5",
+			args: [],
+			options: { since: "7d", workspace: "all", top: 5 },
+			addMessage: addMessageMock,
+			updateTaskHistoryFilters,
+			changeTaskHistoryPage,
+		})
+
+		await usageCommand.handler(mockContext)
+
+		expect(addMessageMock).toHaveBeenCalled()
+		const lastMessage = addMessageMock.mock.calls[addMessageMock.mock.calls.length - 1][0]
+		expect(lastMessage.type).toBe("system")
+		expect(lastMessage.content).toContain("Usage Summary")
+		expect(lastMessage.content).toContain("Total tasks: 2")
+		expect(lastMessage.content).toContain("$3.50")
+		expect(lastMessage.content).toContain("openrouter / gpt-4.1")
+		expect(lastMessage.content).toContain("kilocode / gpt-5.2-codex")
+		expect(lastMessage.content).toContain("Daily spend")
+
+		const indexTask1 = lastMessage.content.indexOf("task-1")
+		const indexTask2 = lastMessage.content.indexOf("task-2")
+		expect(indexTask1).toBeGreaterThan(-1)
+		expect(indexTask2).toBeGreaterThan(-1)
+		expect(indexTask1).toBeLessThan(indexTask2)
+	})
+
+	it("shows an error for invalid since value", async () => {
+		mockContext = createMockContext({
+			input: "/usage --since banana",
+			args: [],
+			options: { since: "banana" },
+			addMessage: addMessageMock,
+		})
+
+		await usageCommand.handler(mockContext)
+
+		expect(addMessageMock).toHaveBeenCalledTimes(1)
+		const message = addMessageMock.mock.calls[0][0]
+		expect(message.type).toBe("error")
+		expect(message.content).toContain("--since")
+	})
+
+	it("shows an error for invalid workspace", async () => {
+		mockContext = createMockContext({
+			input: "/usage --workspace foo",
+			args: [],
+			options: { workspace: "foo" },
+			addMessage: addMessageMock,
+		})
+
+		await usageCommand.handler(mockContext)
+
+		expect(addMessageMock).toHaveBeenCalledTimes(1)
+		const message = addMessageMock.mock.calls[0][0]
+		expect(message.type).toBe("error")
+		expect(message.content).toContain("--workspace")
+	})
+
+	it("reports when no tasks are in range", async () => {
+		const updateTaskHistoryFilters = vi.fn().mockResolvedValue({
+			historyItems: [],
+			pageIndex: 0,
+			pageCount: 0,
+		})
+
+		mockContext = createMockContext({
+			input: "/usage --since 7d",
+			args: [],
+			options: { since: "7d" },
+			addMessage: addMessageMock,
+			updateTaskHistoryFilters,
+		})
+
+		await usageCommand.handler(mockContext)
+
+		const lastMessage = addMessageMock.mock.calls[addMessageMock.mock.calls.length - 1][0]
+		expect(lastMessage.type).toBe("system")
+		expect(lastMessage.content).toContain("No tasks found")
+	})
+})

--- a/cli/src/commands/cleanup.ts
+++ b/cli/src/commands/cleanup.ts
@@ -1,0 +1,254 @@
+import { rm, stat } from "fs/promises"
+import path from "path"
+import { confirm } from "@inquirer/prompts"
+import { KiloCodePaths } from "@kilocode/agent-runtime"
+import { getHistoryPath } from "../config/history.js"
+import { getConfigPath } from "../config/persistence.js"
+import { logs } from "../services/logs.js"
+
+type CleanupKey = "logs" | "tasks" | "history" | "config" | "identity"
+
+export interface CleanupOptions {
+	all?: boolean
+	logs?: boolean
+	tasks?: boolean
+	history?: boolean
+	config?: boolean
+	identity?: boolean
+	dryRun?: boolean
+	yes?: boolean
+}
+
+export interface CleanupPaths {
+	logsDir: string
+	tasksDir: string
+	historyFile: string
+	configFile: string
+	identityFile: string
+}
+
+interface CleanupTarget {
+	key: CleanupKey
+	label: string
+	path: string
+	kind: "file" | "dir"
+}
+
+interface CleanupTargetStatus extends CleanupTarget {
+	exists: boolean
+}
+
+interface CleanupIo {
+	log: (message: string) => void
+	error: (message: string) => void
+}
+
+export interface CleanupResult {
+	exitCode: number
+	planned: CleanupTargetStatus[]
+	removed: CleanupTargetStatus[]
+	skipped: CleanupTargetStatus[]
+	errors: Array<{ target: CleanupTargetStatus; message: string }>
+	dryRun: boolean
+	cancelled: boolean
+}
+
+interface CleanupDependencies {
+	paths?: CleanupPaths
+	io?: CleanupIo
+	confirm?: (message: string) => Promise<boolean>
+	isInteractive?: boolean
+}
+
+export function getCleanupPaths(): CleanupPaths {
+	return {
+		logsDir: KiloCodePaths.getLogsDir(),
+		tasksDir: KiloCodePaths.getTasksDir(),
+		historyFile: getHistoryPath(),
+		configFile: getConfigPath(),
+		identityFile: path.join(KiloCodePaths.getKiloCodeDir(), "identity.json"),
+	}
+}
+
+function resolveSelection(options: CleanupOptions): Set<CleanupKey> {
+	const selection = new Set<CleanupKey>()
+
+	const flags = {
+		logs: options.logs === true,
+		tasks: options.tasks === true,
+		history: options.history === true,
+		config: options.config === true,
+		identity: options.identity === true,
+	}
+
+	const anyExplicit = Object.values(flags).some(Boolean)
+
+	if (options.all) {
+		Object.keys(flags).forEach((key) => {
+			selection.add(key as CleanupKey)
+		})
+		return selection
+	}
+
+	if (!anyExplicit) {
+		selection.add("logs")
+		selection.add("tasks")
+		selection.add("history")
+		return selection
+	}
+
+	if (flags.logs) selection.add("logs")
+	if (flags.tasks) selection.add("tasks")
+	if (flags.history) selection.add("history")
+	if (flags.config) selection.add("config")
+	if (flags.identity) selection.add("identity")
+
+	return selection
+}
+
+function buildTargets(paths: CleanupPaths): CleanupTarget[] {
+	return [
+		{ key: "logs", label: "Logs", path: paths.logsDir, kind: "dir" },
+		{ key: "tasks", label: "Tasks", path: paths.tasksDir, kind: "dir" },
+		{ key: "history", label: "Command history", path: paths.historyFile, kind: "file" },
+		{ key: "config", label: "Config", path: paths.configFile, kind: "file" },
+		{ key: "identity", label: "Identity", path: paths.identityFile, kind: "file" },
+	]
+}
+
+async function checkTarget(target: CleanupTarget): Promise<CleanupTargetStatus> {
+	try {
+		await stat(target.path)
+		return { ...target, exists: true }
+	} catch {
+		return { ...target, exists: false }
+	}
+}
+
+function formatTarget(target: CleanupTargetStatus): string {
+	const suffix = target.exists ? "" : " (not found)"
+	return `- ${target.label}: ${target.path}${suffix}`
+}
+
+function getConfirmMessage(targets: CleanupTargetStatus[]): string {
+	const labelList = targets.map((target) => target.label).join(", ")
+	return `Delete ${targets.length} item${targets.length === 1 ? "" : "s"} (${labelList})?`
+}
+
+export async function runCleanup(options: CleanupOptions, deps: CleanupDependencies = {}): Promise<CleanupResult> {
+	const io = deps.io ?? console
+	const paths = deps.paths ?? getCleanupPaths()
+	const selection = resolveSelection(options)
+
+	if (selection.size === 0) {
+		io.error("Error: No cleanup targets selected. Use --logs, --tasks, --history, --config, --identity, or --all.")
+		return {
+			exitCode: 1,
+			planned: [],
+			removed: [],
+			skipped: [],
+			errors: [],
+			dryRun: Boolean(options.dryRun),
+			cancelled: false,
+		}
+	}
+
+	const targets = buildTargets(paths).filter((target) => selection.has(target.key))
+	const planned = await Promise.all(targets.map((target) => checkTarget(target)))
+
+	io.log("Cleanup targets:")
+	planned.forEach((target) => io.log(formatTarget(target)))
+
+	if (options.dryRun) {
+		io.log("Dry run: no files were deleted.")
+		return {
+			exitCode: 0,
+			planned,
+			removed: [],
+			skipped: planned.filter((target) => !target.exists),
+			errors: [],
+			dryRun: true,
+			cancelled: false,
+		}
+	}
+
+	if (!options.yes) {
+		const isInteractive = deps.isInteractive ?? process.stdin.isTTY
+		if (!isInteractive) {
+			io.error("Error: Non-interactive mode requires --yes or --dry-run.")
+			return {
+				exitCode: 1,
+				planned,
+				removed: [],
+				skipped: [],
+				errors: [],
+				dryRun: false,
+				cancelled: false,
+			}
+		}
+
+		const confirmFn = deps.confirm ?? (async (message: string) => confirm({ message, default: false }))
+		const confirmed = await confirmFn(getConfirmMessage(planned))
+		if (!confirmed) {
+			io.log("Cleanup cancelled.")
+			return {
+				exitCode: 0,
+				planned,
+				removed: [],
+				skipped: [],
+				errors: [],
+				dryRun: false,
+				cancelled: true,
+			}
+		}
+	}
+
+	logs.info("Running cleanup command", "Cleanup", { targets: planned.map((target) => target.key) })
+
+	const removed: CleanupTargetStatus[] = []
+	const skipped: CleanupTargetStatus[] = []
+	const errors: Array<{ target: CleanupTargetStatus; message: string }> = []
+
+	for (const target of planned) {
+		if (!target.exists) {
+			skipped.push(target)
+			continue
+		}
+
+		try {
+			await rm(target.path, { recursive: true, force: true })
+			removed.push(target)
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			errors.push({ target, message })
+			io.error(`Failed to delete ${target.label.toLowerCase()}: ${message}`)
+		}
+	}
+
+	if (removed.length > 0) {
+		io.log(`Removed ${removed.length} item${removed.length === 1 ? "" : "s"}.`)
+	}
+
+	if (skipped.length > 0) {
+		io.log(`Skipped ${skipped.length} item${skipped.length === 1 ? "" : "s"} (not found).`)
+	}
+
+	if (errors.length > 0) {
+		io.error(`Cleanup finished with ${errors.length} error${errors.length === 1 ? "" : "s"}.`)
+	}
+
+	return {
+		exitCode: errors.length > 0 ? 1 : 0,
+		planned,
+		removed,
+		skipped,
+		errors,
+		dryRun: false,
+		cancelled: false,
+	}
+}
+
+export async function cleanupCommand(options: CleanupOptions): Promise<void> {
+	const result = await runCleanup(options)
+	process.exit(result.exitCode)
+}

--- a/cli/src/commands/index.ts
+++ b/cli/src/commands/index.ts
@@ -22,6 +22,7 @@ import { themeCommand } from "./theme.js"
 import { checkpointCommand } from "./checkpoint.js"
 import { sessionCommand } from "./session.js"
 import { condenseCommand } from "./condense.js"
+import { usageCommand } from "./usage.js"
 
 /**
  * Initialize all built-in commands
@@ -43,4 +44,5 @@ export function initializeCommands(): void {
 	commandRegistry.register(checkpointCommand)
 	commandRegistry.register(sessionCommand)
 	commandRegistry.register(condenseCommand)
+	commandRegistry.register(usageCommand)
 }

--- a/cli/src/commands/usage.ts
+++ b/cli/src/commands/usage.ts
@@ -1,0 +1,551 @@
+/**
+ * /usage command - Summarize historical cost and token usage
+ */
+
+import { generateMessage } from "../ui/utils/messages.js"
+import type { Command, CommandContext } from "./core/types.js"
+import type { TaskHistoryData, TaskHistoryFilters } from "../state/atoms/taskHistory.js"
+import type { HistoryItem, ProviderName } from "../types/messages.js"
+import { getModelFieldForProvider } from "../constants/providers/models.js"
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+const DEFAULT_SINCE_DAYS = 30
+const DEFAULT_TOP_COUNT = 5
+const DEFAULT_BREAKDOWN_LIMIT = 10
+
+interface UsageRange {
+	startTimestamp: number
+	label: string
+}
+
+interface BucketStats {
+	cost: number
+	tokensIn: number
+	tokensOut: number
+	tasks: number
+}
+
+interface UsageOptions {
+	workspace: "current" | "all"
+	range: UsageRange
+	topCount: number
+}
+
+function formatCost(cost: number): string {
+	if (cost === 0) return "$0.00"
+	if (cost < 0.01) return "<$0.01"
+	return `$${cost.toFixed(2)}`
+}
+
+function formatTokens(tokens: number): string {
+	if (tokens >= 1000000) {
+		return `${(tokens / 1000000).toFixed(1)}M`
+	}
+	if (tokens >= 1000) {
+		return `${(tokens / 1000).toFixed(1)}K`
+	}
+	return tokens.toString()
+}
+
+function truncate(text: string, maxLength: number): string {
+	if (text.length <= maxLength) return text
+	return text.substring(0, maxLength - 3) + "..."
+}
+
+function toNumber(value: unknown): number {
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return value
+	}
+	if (typeof value === "string") {
+		const parsed = Number(value)
+		if (Number.isFinite(parsed)) {
+			return parsed
+		}
+	}
+	return 0
+}
+
+function toStringValue(value: unknown): string | null {
+	if (typeof value === "string") {
+		const trimmed = value.trim()
+		return trimmed.length > 0 ? trimmed : null
+	}
+	return null
+}
+
+function formatDateUtc(timestamp: number): string {
+	return new Date(timestamp).toISOString().slice(0, 10)
+}
+
+function startOfDayUtc(timestamp: number): number {
+	const date = new Date(timestamp)
+	return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+}
+
+function parseSinceOption(value: string | undefined, now: number): UsageRange | { error: string } {
+	if (!value) {
+		const start = startOfDayUtc(now - (DEFAULT_SINCE_DAYS - 1) * MS_PER_DAY)
+		return { startTimestamp: start, label: `${DEFAULT_SINCE_DAYS}d` }
+	}
+
+	const trimmed = value.trim()
+	const rangeMatch = trimmed.match(/^(\d+)(d|w)$/)
+	if (rangeMatch) {
+		const count = Number.parseInt(rangeMatch[1] || "", 10)
+		if (!Number.isFinite(count) || count < 1) {
+			return { error: "--since expects a positive duration like 7d or 2w." }
+		}
+		const unit = rangeMatch[2]
+		const days = unit === "w" ? count * 7 : count
+		const start = startOfDayUtc(now - (days - 1) * MS_PER_DAY)
+		return { startTimestamp: start, label: `${count}${unit}` }
+	}
+
+	const dateMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+	if (dateMatch) {
+		const year = Number.parseInt(dateMatch[1] || "", 10)
+		const month = Number.parseInt(dateMatch[2] || "", 10)
+		const day = Number.parseInt(dateMatch[3] || "", 10)
+		const date = Date.UTC(year, month - 1, day)
+		if (!Number.isFinite(date)) {
+			return { error: "--since must be a valid date (YYYY-MM-DD)." }
+		}
+		const normalized = formatDateUtc(date)
+		if (normalized !== trimmed) {
+			return { error: "--since must be a valid date (YYYY-MM-DD)." }
+		}
+		return { startTimestamp: date, label: trimmed }
+	}
+
+	return { error: "--since must be a duration like 7d/2w or a date like 2026-01-31." }
+}
+
+function parseWorkspaceOption(
+	value: string | undefined,
+	fallback: "current" | "all",
+): "current" | "all" | { error: string } {
+	if (!value) {
+		return fallback
+	}
+
+	const normalized = value.toLowerCase()
+	if (normalized === "current" || normalized === "all") {
+		return normalized
+	}
+
+	return { error: "--workspace must be either current or all." }
+}
+
+function parseTopOption(value: string | number | boolean | undefined): number | { error: string } {
+	if (value === undefined) {
+		return DEFAULT_TOP_COUNT
+	}
+
+	if (typeof value === "boolean") {
+		return { error: "--top requires a number (for example: --top 5)." }
+	}
+
+	const parsed = typeof value === "number" ? value : Number.parseInt(value, 10)
+	if (!Number.isFinite(parsed) || parsed < 1) {
+		return { error: "--top must be a positive number." }
+	}
+
+	return Math.floor(parsed)
+}
+
+function getHistoryItemCost(item: HistoryItem): number {
+	return toNumber((item as Record<string, unknown>).totalCost)
+}
+
+function getHistoryItemTokensIn(item: HistoryItem): number {
+	return toNumber((item as Record<string, unknown>).tokensIn)
+}
+
+function getHistoryItemTokensOut(item: HistoryItem): number {
+	return toNumber((item as Record<string, unknown>).tokensOut)
+}
+
+function getHistoryItemTimestamp(item: HistoryItem): number {
+	return toNumber((item as Record<string, unknown>).ts)
+}
+
+function getHistoryItemTask(item: HistoryItem): string {
+	const value = (item as Record<string, unknown>).task
+	const task = toStringValue(value)
+	return task || "Untitled task"
+}
+
+function getHistoryItemProvider(item: HistoryItem): string {
+	const record = item as Record<string, unknown>
+	const provider =
+		toStringValue(record.provider) ||
+		toStringValue(record.apiProvider) ||
+		toStringValue(record.providerName) ||
+		toStringValue(record.providerId)
+	return provider || "unknown"
+}
+
+function getHistoryItemModel(item: HistoryItem, provider: string): string {
+	const record = item as Record<string, unknown>
+	const direct =
+		toStringValue(record.model) ||
+		toStringValue(record.modelId) ||
+		toStringValue(record.apiModelId) ||
+		toStringValue(record.modelName)
+
+	if (direct) {
+		return direct
+	}
+
+	if (provider && provider !== "unknown") {
+		const modelField = getModelFieldForProvider(provider as ProviderName)
+		if (modelField) {
+			if (modelField === "vsCodeLmModelSelector") {
+				const selector = record[modelField]
+				if (selector && typeof selector === "object") {
+					const vendor = toStringValue((selector as Record<string, unknown>).vendor)
+					const family = toStringValue((selector as Record<string, unknown>).family)
+					if (vendor && family) {
+						return `${vendor}/${family}`
+					}
+				}
+			} else {
+				const providerValue = toStringValue(record[modelField])
+				if (providerValue) {
+					return providerValue
+				}
+			}
+		}
+	}
+
+	return "unknown"
+}
+
+function formatProviderModel(provider: string, model: string): string {
+	if (provider === "unknown" && model === "unknown") {
+		return "unknown"
+	}
+	if (provider === "unknown") {
+		return model
+	}
+	if (model === "unknown") {
+		return provider
+	}
+	return `${provider} / ${model}`
+}
+
+function accumulateBucket(buckets: Map<string, BucketStats>, key: string, item: HistoryItem): void {
+	const existing = buckets.get(key) || { cost: 0, tokensIn: 0, tokensOut: 0, tasks: 0 }
+	const updated = {
+		cost: existing.cost + getHistoryItemCost(item),
+		tokensIn: existing.tokensIn + getHistoryItemTokensIn(item),
+		tokensOut: existing.tokensOut + getHistoryItemTokensOut(item),
+		tasks: existing.tasks + 1,
+	}
+	buckets.set(key, updated)
+}
+
+function buildDailyBuckets(
+	items: HistoryItem[],
+	rangeStart: number,
+	rangeEnd: number,
+): Array<{ date: string; stats: BucketStats }> {
+	const buckets = new Map<string, BucketStats>()
+	items.forEach((item) => {
+		const ts = getHistoryItemTimestamp(item)
+		if (!ts) {
+			return
+		}
+		if (ts < rangeStart || ts > rangeEnd) {
+			return
+		}
+		const dateKey = formatDateUtc(startOfDayUtc(ts))
+		accumulateBucket(buckets, dateKey, item)
+	})
+
+	const startDate = new Date(rangeStart)
+	const endDate = new Date(rangeEnd)
+	const days: Array<{ date: string; stats: BucketStats }> = []
+
+	const cursor = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), startDate.getUTCDate()))
+	const endCursor = Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate())
+
+	while (cursor.getTime() <= endCursor) {
+		const dateKey = formatDateUtc(cursor.getTime())
+		const stats = buckets.get(dateKey) || { cost: 0, tokensIn: 0, tokensOut: 0, tasks: 0 }
+		days.push({ date: dateKey, stats })
+		cursor.setUTCDate(cursor.getUTCDate() + 1)
+	}
+
+	return days
+}
+
+function median(values: number[]): number {
+	if (values.length === 0) {
+		return 0
+	}
+	const sorted = [...values].sort((a, b) => a - b)
+	const mid = Math.floor(sorted.length / 2)
+	if (sorted.length % 2 === 0) {
+		return (sorted[mid - 1]! + sorted[mid]!) / 2
+	}
+	return sorted[mid]!
+}
+
+function buildUsageOptions(context: CommandContext): UsageOptions | { error: string } {
+	const rawWorkspace = context.options.workspace ?? context.options.w
+	const rawSinceOption = context.options.since ?? context.options.s
+	const rawSinceArg = context.args[0]
+	const rawTop = context.options.top ?? context.options.t
+
+	if (rawWorkspace !== undefined && typeof rawWorkspace !== "string") {
+		return { error: "--workspace must be either current or all." }
+	}
+
+	if (rawSinceOption !== undefined && typeof rawSinceOption !== "string") {
+		return { error: "--since requires a value like 7d or 2026-01-31." }
+	}
+
+	const now = Date.now()
+	const rawSince = typeof rawSinceOption === "string" ? rawSinceOption : rawSinceArg
+	const range = parseSinceOption(typeof rawSince === "string" ? rawSince : undefined, now)
+	if ("error" in range) {
+		return { error: range.error }
+	}
+
+	const workspaceResult = parseWorkspaceOption(
+		typeof rawWorkspace === "string" ? rawWorkspace : undefined,
+		context.taskHistoryFilters.workspace,
+	)
+	if (typeof workspaceResult !== "string") {
+		return { error: workspaceResult.error }
+	}
+
+	const topCount = parseTopOption(rawTop)
+	if (typeof topCount !== "number") {
+		return { error: topCount.error }
+	}
+
+	return {
+		workspace: workspaceResult,
+		range,
+		topCount,
+	}
+}
+
+async function fetchUsageHistory(context: CommandContext, options: UsageOptions): Promise<HistoryItem[]> {
+	const previousFilters = context.taskHistoryFilters
+	const previousPageIndex = context.taskHistoryData?.pageIndex ?? 0
+
+	const restoreFilters: Partial<TaskHistoryFilters> = {
+		workspace: previousFilters.workspace,
+		sort: previousFilters.sort,
+		favoritesOnly: previousFilters.favoritesOnly,
+	}
+	if (typeof previousFilters.search === "string") {
+		restoreFilters.search = previousFilters.search
+	}
+
+	try {
+		const firstPage = await context.updateTaskHistoryFilters({
+			workspace: options.workspace,
+			sort: "newest",
+			favoritesOnly: false,
+			search: "",
+		})
+
+		const allItems: HistoryItem[] = []
+		const since = options.range.startTimestamp
+		const hasRecentItems = (items: HistoryItem[]) => items.some((item) => getHistoryItemTimestamp(item) >= since)
+		const collectItems = (data: TaskHistoryData) => {
+			data.historyItems.forEach((item) => {
+				if (getHistoryItemTimestamp(item) >= since) {
+					allItems.push(item)
+				}
+			})
+		}
+
+		collectItems(firstPage)
+		if (!hasRecentItems(firstPage.historyItems)) {
+			return allItems
+		}
+
+		for (let pageIndex = 1; pageIndex < firstPage.pageCount; pageIndex += 1) {
+			const page = await context.changeTaskHistoryPage(pageIndex)
+			collectItems(page)
+			if (!hasRecentItems(page.historyItems)) {
+				break
+			}
+		}
+
+		return allItems
+	} finally {
+		try {
+			await context.updateTaskHistoryFilters(restoreFilters)
+			if (previousPageIndex !== 0) {
+				await context.changeTaskHistoryPage(previousPageIndex)
+			}
+		} catch {
+			// Ignore restore failures
+		}
+	}
+}
+
+function buildUsageReport(items: HistoryItem[], options: UsageOptions): string {
+	const totalTasks = items.length
+	if (totalTasks === 0) {
+		return `No tasks found for the last ${options.range.label} in the ${options.workspace} workspace.`
+	}
+
+	const totalCost = items.reduce((sum, item) => sum + getHistoryItemCost(item), 0)
+	const tokensIn = items.reduce((sum, item) => sum + getHistoryItemTokensIn(item), 0)
+	const tokensOut = items.reduce((sum, item) => sum + getHistoryItemTokensOut(item), 0)
+	const totalTokens = tokensIn + tokensOut
+	const avgCost = totalCost / totalTasks
+	const medianCost = median(items.map((item) => getHistoryItemCost(item)))
+
+	const topTasks = [...items].sort((a, b) => getHistoryItemCost(b) - getHistoryItemCost(a)).slice(0, options.topCount)
+
+	const providerModelBuckets = new Map<string, BucketStats>()
+	items.forEach((item) => {
+		const provider = getHistoryItemProvider(item)
+		const model = getHistoryItemModel(item, provider)
+		const key = formatProviderModel(provider, model)
+		accumulateBucket(providerModelBuckets, key, item)
+	})
+
+	const providerModelBreakdown = [...providerModelBuckets.entries()]
+		.map(([key, stats]) => ({ key, stats }))
+		.sort((a, b) => b.stats.cost - a.stats.cost)
+		.slice(0, DEFAULT_BREAKDOWN_LIMIT)
+
+	const rangeStart = options.range.startTimestamp
+	const rangeEnd = Date.now()
+	const dailyBuckets = buildDailyBuckets(items, rangeStart, rangeEnd)
+
+	const lines: string[] = []
+	lines.push(`**Usage Summary** (last ${options.range.label}, workspace: ${options.workspace})`)
+	lines.push("")
+	lines.push(`Total tasks: ${totalTasks}`)
+	lines.push(`Total cost: ${formatCost(totalCost)}`)
+	lines.push(
+		`Total tokens: ${formatTokens(totalTokens)} (${formatTokens(tokensIn)} in / ${formatTokens(tokensOut)} out)`,
+	)
+	lines.push(`Avg cost per task: ${formatCost(avgCost)}`)
+	lines.push(`Median cost per task: ${formatCost(medianCost)}`)
+	lines.push("")
+
+	lines.push("**Top tasks by cost:**")
+	if (topTasks.length === 0) {
+		lines.push("No tasks with cost data.")
+	} else {
+		topTasks.forEach((item, index) => {
+			const taskId = (item as Record<string, unknown>).id
+			const label = typeof taskId === "string" ? taskId : "unknown"
+			const cost = formatCost(getHistoryItemCost(item))
+			const tokens = formatTokens(getHistoryItemTokensIn(item) + getHistoryItemTokensOut(item))
+			const timestamp = getHistoryItemTimestamp(item)
+			const date = timestamp ? formatDateUtc(timestamp) : "unknown"
+			const provider = getHistoryItemProvider(item)
+			const model = getHistoryItemModel(item, provider)
+			const providerModel = formatProviderModel(provider, model)
+			const taskText = truncate(getHistoryItemTask(item), 60)
+			lines.push(`${index + 1}. ${cost} | ${tokens} tokens | ${date} | ${providerModel} | ${label}`)
+			lines.push(`   ${taskText}`)
+		})
+	}
+	lines.push("")
+
+	lines.push("**Provider / model breakdown:**")
+	if (providerModelBreakdown.length === 0) {
+		lines.push("No provider or model data available.")
+	} else {
+		providerModelBreakdown.forEach(({ key, stats }) => {
+			const tokens = formatTokens(stats.tokensIn + stats.tokensOut)
+			lines.push(`- ${key}: ${formatCost(stats.cost)} | ${tokens} tokens | ${stats.tasks} tasks`)
+		})
+		if (providerModelBuckets.size > DEFAULT_BREAKDOWN_LIMIT) {
+			lines.push(`(Showing top ${DEFAULT_BREAKDOWN_LIMIT} by cost)`)
+		}
+	}
+	lines.push("")
+
+	lines.push("**Daily spend:**")
+	if (dailyBuckets.length === 0) {
+		lines.push("No daily data available.")
+	} else {
+		dailyBuckets.forEach((entry) => {
+			const tokens = formatTokens(entry.stats.tokensIn + entry.stats.tokensOut)
+			lines.push(`${entry.date}: ${formatCost(entry.stats.cost)} | ${tokens} tokens | ${entry.stats.tasks} tasks`)
+		})
+	}
+
+	return lines.join("\n")
+}
+
+export const usageCommand: Command = {
+	name: "usage",
+	aliases: ["spend", "cost"],
+	description: "Summarize historical cost and token usage",
+	usage: "/usage [--since 7d|2026-01-31] [--workspace current|all] [--top 5]",
+	examples: ["/usage", "/usage --since 7d", "/usage --workspace all", "/usage --top 10"],
+	category: "system",
+	priority: 8,
+	options: [
+		{
+			name: "since",
+			alias: "s",
+			description: "Time range (e.g., 7d, 2w, 2026-01-31)",
+			required: false,
+			type: "string",
+		},
+		{
+			name: "workspace",
+			alias: "w",
+			description: "Scope: current or all workspaces",
+			required: false,
+			type: "string",
+		},
+		{
+			name: "top",
+			alias: "t",
+			description: "Number of top tasks to show",
+			required: false,
+			type: "number",
+		},
+	],
+	handler: async (context) => {
+		const { addMessage } = context
+		const options = buildUsageOptions(context)
+		if ("error" in options) {
+			addMessage({
+				...generateMessage(),
+				type: "error",
+				content: `${options.error}\nUsage: /usage --since 7d --workspace current --top 5`,
+			})
+			return
+		}
+
+		addMessage({
+			...generateMessage(),
+			type: "system",
+			content: `Building usage report (last ${options.range.label}, workspace: ${options.workspace})...`,
+		})
+
+		try {
+			const items = await fetchUsageHistory(context, options)
+			const report = buildUsageReport(items, options)
+			addMessage({
+				...generateMessage(),
+				type: "system",
+				content: report,
+			})
+		} catch (error) {
+			addMessage({
+				...generateMessage(),
+				type: "error",
+				content: `Failed to build usage report: ${error instanceof Error ? error.message : String(error)}`,
+			})
+		}
+	},
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -20,6 +20,7 @@ import { getParallelModeParams } from "./parallel/parallel.js"
 import { DEBUG_MODES, DEBUG_FUNCTIONS } from "./debug/index.js"
 import { logs } from "./services/logs.js"
 import { validateAttachments, validateAttachRequiresAuto, accumulateAttachments } from "./validation/attachments.js"
+import { cleanupCommand } from "./commands/cleanup.js"
 
 // Log CLI location for debugging (visible in VS Code "Kilo-Code" output channel)
 logs.info(`CLI started from: ${import.meta.url}`)
@@ -67,7 +68,7 @@ program
 		// Subcommand names - if prompt matches one, Commander.js should handle it via subcommand
 		// This is a defensive check for cases where Commander.js routing might not work as expected
 		// (e.g., when spawned as a child process with stdin disconnected)
-		const SUBCOMMANDS = ["auth", "config", "debug", "models"]
+		const SUBCOMMANDS = ["auth", "config", "debug", "models", "cleanup"]
 		if (SUBCOMMANDS.includes(prompt)) {
 			return
 		}
@@ -402,6 +403,21 @@ program
 	.action(async (options: { provider?: string; json?: boolean }) => {
 		const { modelsApiCommand } = await import("./commands/models-api.js")
 		await modelsApiCommand(options)
+	})
+
+program
+	.command("cleanup")
+	.description("Clean up local Kilo Code CLI data")
+	.option("--logs", "Remove CLI logs")
+	.option("--tasks", "Remove task history and checkpoints")
+	.option("--history", "Remove command history")
+	.option("--config", "Remove CLI config.json")
+	.option("--identity", "Remove CLI identity file")
+	.option("--all", "Remove all CLI data, including config and identity")
+	.option("--dry-run", "Show what would be deleted without removing anything")
+	.option("-y, --yes", "Skip confirmation prompt")
+	.action(async (options) => {
+		await cleanupCommand(options)
 	})
 
 // Handle process termination signals


### PR DESCRIPTION
## Context

Add a CLI `/usage` report to give users actionable visibility into historical spend beyond the live session cost (totals, top tasks by cost, provider/model breakdown, daily trend).

## Implementation

- Introduced `/usage` in `cli/src/commands/usage.ts`, pulling from task history and aggregating cost + token usage.
- Computes totals, top tasks by cost, provider/model breakdown, and a daily spend trend over the requested range.
- Registered the command and documented usage.

## Screenshots

| before | after |
| ------ | ----- |
| n/a    | n/a   |

## How to Test

- `cd cli && npm test`
- Run in interactive mode:
  - `/usage`
  - `/usage --since 7d --workspace all --top 10`
- Verify output includes totals, top tasks, provider/model breakdown, and daily spend lines.

## Get in Touch

Discord: aravhawk