### PR TITLE
feat(cli): add GitHub Copilot auth flow and dynamic models support

### DIFF
--- a/.changeset/github-copilot-provider.md
+++ b/.changeset/github-copilot-provider.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+---
+
+Add GitHub Copilot provider support for CLI with OAuth Device Flow authentication

--- a/cli/src/auth/__tests__/github-copilot.test.ts
+++ b/cli/src/auth/__tests__/github-copilot.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { githubCopilotDefaultModelId } from "@roo-code/types"
+
+import { authenticateWithGitHubCopilot } from "../providers/github-copilot/index.js"
+import { poll } from "../utils/polling.js"
+
+vi.mock("../utils/browser.js", () => ({
+	openBrowser: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock("../utils/polling.js", async () => {
+	const actual = await vi.importActual<typeof import("../utils/polling.js")>("../utils/polling.js")
+	return {
+		...actual,
+		poll: vi.fn(),
+		formatTimeRemaining: actual.formatTimeRemaining,
+	}
+})
+
+describe("GitHub Copilot device auth", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, "log").mockImplementation(() => {})
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("continues polling when authorization is pending", async () => {
+		const deviceResponse = {
+			device_code: "device-code",
+			user_code: "user-code",
+			verification_uri: "https://github.com/login/device",
+			expires_in: 600,
+			interval: 5,
+		}
+		let pollCount = 0
+
+		vi.spyOn(globalThis, "fetch").mockImplementation(((url: string) => {
+			if (url.includes("/login/device/code")) {
+				return Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve(deviceResponse),
+				} as Response)
+			}
+
+			if (url.includes("/login/oauth/access_token")) {
+				pollCount += 1
+				if (pollCount === 1) {
+					return Promise.resolve({
+						ok: false,
+						status: 400,
+						json: () => Promise.resolve({ error: "authorization_pending" }),
+					} as Response)
+				}
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					json: () => Promise.resolve({ access_token: "token-123" }),
+				} as Response)
+			}
+
+			return Promise.reject(new Error("Unexpected URL"))
+		}) as unknown as typeof fetch)
+
+		vi.mocked(poll).mockImplementation(async ({ pollFn }) => {
+			const first = await pollFn()
+			if (first.error) {
+				throw first.error
+			}
+			if (!first.continue) {
+				return first.data
+			}
+
+			const second = await pollFn()
+			if (second.error) {
+				throw second.error
+			}
+			return second.data
+		})
+
+		const result = await authenticateWithGitHubCopilot()
+
+		expect(result.providerConfig).toEqual({
+			id: "default",
+			provider: "github-copilot",
+			githubCopilotToken: "token-123",
+			githubCopilotModelId: githubCopilotDefaultModelId,
+		})
+	})
+})

--- a/cli/src/auth/__tests__/polling.test.ts
+++ b/cli/src/auth/__tests__/polling.test.ts
@@ -69,6 +69,8 @@ describe("Polling Utility", () => {
 					pollFn,
 				}),
 			).rejects.toThrow("Test error")
+
+			expect(pollFn).toHaveBeenCalledTimes(1)
 		})
 
 		it("should call onProgress callback", async () => {

--- a/cli/src/auth/providers/config.ts
+++ b/cli/src/auth/providers/config.ts
@@ -4,6 +4,7 @@
  */
 export const CUSTOM_AUTH_PROVIDERS: Set<string> = new Set([
 	"kilocode", // Has device auth and token auth variants
+	"github-copilot", // kilocode_change: Has OAuth device flow
 	"other", // Opens config file manually (not a ProviderName, but an auth provider value)
 	"vscode-lm", // Uses VSCode's built-in auth
 	"fake-ai", // No auth needed - testing only

--- a/cli/src/auth/providers/github-copilot/index.ts
+++ b/cli/src/auth/providers/github-copilot/index.ts
@@ -1,0 +1,224 @@
+// kilocode_change - new file
+import { githubCopilotDefaultModelId } from "@roo-code/types"
+import * as readline from "readline"
+
+import type { AuthProvider, AuthResult } from "../../types.js"
+import { poll, formatTimeRemaining } from "../../utils/polling.js"
+import { openBrowser } from "../../utils/browser.js"
+
+// GitHub OAuth App Client ID for Kilo Code
+// You can register your own at: https://github.com/settings/developers
+const GITHUB_CLIENT_ID = "" // TODO: Replace with Kilo Code's own client ID
+
+const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
+
+interface DeviceCodeResponse {
+	device_code: string
+	user_code: string
+	verification_uri: string
+	expires_in: number
+	interval: number
+}
+
+interface AccessTokenResponse {
+	access_token?: string
+	error?: string
+	interval?: number
+}
+
+function renderWaitingMessage(message: string): void {
+	if (!process.stdout.isTTY) {
+		return
+	}
+
+	readline.clearLine(process.stdout, 0)
+	readline.cursorTo(process.stdout, 0)
+	process.stdout.write(message)
+}
+
+function clearWaitingMessage(): void {
+	if (!process.stdout.isTTY) {
+		return
+	}
+
+	readline.clearLine(process.stdout, 0)
+	readline.cursorTo(process.stdout, 0)
+}
+
+function startWaitingCountdown(startTime: number, expiresIn: number): () => void {
+	const update = () => {
+		const timeRemaining = formatTimeRemaining(startTime, expiresIn)
+		renderWaitingMessage(`Waiting for authorization... ⏳ (${timeRemaining} remaining)`)
+	}
+
+	update()
+	const timer = setInterval(update, 1000)
+
+	return () => clearInterval(timer)
+}
+
+/**
+ * Initiate GitHub OAuth Device Flow
+ */
+async function initiateDeviceAuth(): Promise<DeviceCodeResponse> {
+	const response = await fetch("https://github.com/login/device/code", {
+		method: "POST",
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/x-www-form-urlencoded",
+		},
+		body: new URLSearchParams({
+			client_id: GITHUB_CLIENT_ID,
+			scope: "read:user",
+		}),
+	})
+
+	if (!response.ok) {
+		throw new Error(`Failed to initiate device authorization: ${response.status}`)
+	}
+
+	return (await response.json()) as DeviceCodeResponse
+}
+
+/**
+ * Poll for access token
+ */
+async function pollAccessToken(deviceCode: string): Promise<AccessTokenResponse> {
+	const response = await fetch("https://github.com/login/oauth/access_token", {
+		method: "POST",
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/x-www-form-urlencoded",
+		},
+		body: new URLSearchParams({
+			client_id: GITHUB_CLIENT_ID,
+			device_code: deviceCode,
+			grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+		}),
+	})
+
+	let payload: AccessTokenResponse
+	try {
+		payload = (await response.json()) as AccessTokenResponse
+	} catch (error) {
+		if (!response.ok) {
+			throw new Error(`Failed to poll for access token: ${response.status}`)
+		}
+		const message = error instanceof Error ? error.message : String(error)
+		throw new Error(`Failed to parse access token response: ${message}`)
+	}
+
+	if (!response.ok) {
+		return payload
+	}
+
+	return payload
+}
+
+/**
+ * Execute GitHub Copilot OAuth Device Flow authentication
+ */
+export async function authenticateWithGitHubCopilot(): Promise<AuthResult> {
+	console.log("🔐 Starting GitHub Copilot authentication...")
+
+	// Step 1: Get device code
+	let deviceData: DeviceCodeResponse
+	try {
+		deviceData = await initiateDeviceAuth()
+	} catch (error) {
+		throw new Error(`Failed to start authentication: ${error instanceof Error ? error.message : String(error)}`)
+	}
+
+	const { device_code, user_code, verification_uri, expires_in, interval } = deviceData
+
+	// Step 2: Display instructions and open browser
+	console.log("Opening browser for GitHub authentication...")
+	console.log(`Visit: ${verification_uri}`)
+	console.log("")
+	console.log(`Enter code: ${user_code}`)
+
+	const browserOpened = await openBrowser(verification_uri)
+	if (!browserOpened) {
+		console.log("⚠️ Could not open browser automatically. Please open the URL manually.")
+	}
+
+	// Step 3: Poll for access token
+	const startTime = Date.now()
+	const pollInterval = (interval || 5) * 1000 + OAUTH_POLLING_SAFETY_MARGIN_MS
+	const maxAttempts = Math.ceil((expires_in * 1000) / pollInterval)
+
+	let accessToken: string
+	let stopWaitingCountdown: (() => void) | null = null
+
+	try {
+		stopWaitingCountdown = startWaitingCountdown(startTime, expires_in)
+		const result = await poll<AccessTokenResponse>({
+			interval: pollInterval,
+			maxAttempts,
+			pollFn: async () => {
+				const pollResult = await pollAccessToken(device_code)
+
+				if (pollResult.access_token) {
+					return { continue: false, data: pollResult }
+				}
+
+				if (pollResult.error === "authorization_pending") {
+					return { continue: true }
+				}
+
+				if (pollResult.error === "slow_down") {
+					// Wait extra time as requested
+					await new Promise((resolve) => setTimeout(resolve, 5000))
+					return { continue: true }
+				}
+
+				if (pollResult.error === "expired_token") {
+					return { continue: false, error: new Error("Authorization code expired") }
+				}
+
+				if (pollResult.error === "access_denied") {
+					return { continue: false, error: new Error("Authorization denied by user") }
+				}
+
+				if (pollResult.error) {
+					return { continue: false, error: new Error(`GitHub OAuth error: ${pollResult.error}`) }
+				}
+
+				return { continue: true }
+			},
+		})
+
+		if (!result.access_token) {
+			throw new Error("No access token received")
+		}
+
+		accessToken = result.access_token
+		clearWaitingMessage()
+		process.stdout.write("\n")
+		console.log("✓ GitHub Copilot authentication successful!")
+	} catch (error) {
+		clearWaitingMessage()
+		console.log("")
+		throw new Error(`Authentication failed: ${error instanceof Error ? error.message : String(error)}`)
+	} finally {
+		stopWaitingCountdown?.()
+	}
+
+	return {
+		providerConfig: {
+			id: "default",
+			provider: "github-copilot",
+			githubCopilotToken: accessToken,
+			githubCopilotModelId: githubCopilotDefaultModelId,
+		},
+	}
+}
+
+/**
+ * GitHub Copilot authentication provider
+ */
+export const githubCopilotAuthProvider: AuthProvider = {
+	name: "GitHub Copilot (OAuth)",
+	value: "github-copilot",
+	authenticate: authenticateWithGitHubCopilot,
+}

--- a/cli/src/auth/providers/index.ts
+++ b/cli/src/auth/providers/index.ts
@@ -1,6 +1,7 @@
 import type { AuthProvider } from "../types.js"
 import type { ProviderName } from "../../types/messages.js"
 import { kilocodeDeviceAuthProvider, kilocodeTokenAuthProvider } from "./kilocode/index.js"
+import { githubCopilotAuthProvider } from "./github-copilot/index.js" // kilocode_change
 import { otherProvider } from "./other/index.js"
 import { createGenericAuthProvider } from "./factory.js"
 import { shouldUseGenericAuth } from "./config.js"
@@ -14,6 +15,7 @@ export const authProviders: AuthProvider[] = [
 	// Special providers with custom authentication flows
 	kilocodeDeviceAuthProvider, // Recommended: Browser-based device auth
 	kilocodeTokenAuthProvider, // Advanced: Manual token entry
+	githubCopilotAuthProvider, // kilocode_change: GitHub Copilot OAuth
 
 	// Auto-generate providers for all others that support generic auth
 	...Object.keys(PROVIDER_LABELS)

--- a/cli/src/auth/utils/polling.ts
+++ b/cli/src/auth/utils/polling.ts
@@ -20,22 +20,24 @@ export async function poll<T>(options: PollingOptions): Promise<T> {
 			onProgress(attempt, maxAttempts)
 		}
 
+		let result: PollResult
 		try {
-			const result: PollResult = await pollFn()
-
-			// If polling should stop
-			if (!result.continue) {
-				if (result.error) {
-					throw result.error
-				}
-				return result.data as T
-			}
+			result = await pollFn()
 		} catch (error) {
 			// If this is the last attempt, throw the error
 			if (attempt === maxAttempts) {
 				throw error
 			}
 			// Otherwise, continue polling (network errors might be transient)
+			continue
+		}
+
+		// If polling should stop
+		if (!result.continue) {
+			if (result.error) {
+				throw result.error
+			}
+			return result.data as T
 		}
 	}
 

--- a/cli/src/commands/model.ts
+++ b/cli/src/commands/model.ts
@@ -58,6 +58,7 @@ async function ensureRouterModels(context: CommandContext): Promise<boolean> {
 		"vercel-ai-gateway",
 		"ovhcloud",
 		"nano-gpt",
+		"github-copilot",
 	].includes(routerName)
 
 	if (!needsRouterModels) {

--- a/cli/src/config/__tests__/validation.test.ts
+++ b/cli/src/config/__tests__/validation.test.ts
@@ -254,6 +254,43 @@ describe("validateSelectedProvider", () => {
 		expect(result.valid).toBe(true)
 	})
 
+	it("should require github-copilot token even when GH_TOKEN is set", () => {
+		const originalGhToken = process.env.GH_TOKEN
+		const originalGithubToken = process.env.GITHUB_TOKEN
+
+		process.env.GH_TOKEN = "env-token"
+		delete process.env.GITHUB_TOKEN
+
+		const config: CLIConfig = {
+			version: "1.0.0",
+			mode: "code",
+			telemetry: true,
+			provider: "copilot",
+			providers: [
+				{
+					id: "copilot",
+					provider: "github-copilot",
+				},
+			],
+		}
+
+		const result = validateSelectedProvider(config)
+		expect(result.valid).toBe(false)
+		expect(result.errors).toContain("githubCopilotToken is required and cannot be empty for selected provider")
+
+		if (originalGhToken === undefined) {
+			delete process.env.GH_TOKEN
+		} else {
+			process.env.GH_TOKEN = originalGhToken
+		}
+
+		if (originalGithubToken === undefined) {
+			delete process.env.GITHUB_TOKEN
+		} else {
+			process.env.GITHUB_TOKEN = originalGithubToken
+		}
+	})
+
 	it("should return error when no provider is selected", () => {
 		const config: CLIConfig = {
 			version: "1.0.0",

--- a/cli/src/config/mapper.ts
+++ b/cli/src/config/mapper.ts
@@ -104,6 +104,8 @@ export function getModelIdForProvider(provider: ProviderConfig): string {
 		case "openai-native":
 		case "openai-codex":
 			return provider.apiModelId || ""
+		case "github-copilot": // kilocode_change
+			return provider.githubCopilotModelId || "" // kilocode_change
 		case "openrouter":
 			return provider.openRouterModelId || ""
 		case "ollama":

--- a/cli/src/config/schema.json
+++ b/cli/src/config/schema.json
@@ -236,6 +236,7 @@
 						"anthropic",
 						"openai-native",
 						"openai-codex",
+						"github-copilot",
 						"openai-responses",
 						"openrouter",
 						"bedrock",
@@ -453,6 +454,23 @@
 							"apiModelId": {
 								"type": "string",
 								"description": "OpenAI model ID"
+							}
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": { "provider": { "const": "github-copilot" } }
+					},
+					"then": {
+						"properties": {
+							"githubCopilotToken": {
+								"type": "string",
+								"description": "GitHub Copilot OAuth token"
+							},
+							"githubCopilotModelId": {
+								"type": "string",
+								"description": "GitHub Copilot model ID"
 							}
 						}
 					}

--- a/cli/src/constants/providers/__tests__/models.test.ts
+++ b/cli/src/constants/providers/__tests__/models.test.ts
@@ -229,6 +229,12 @@ describe("Static Provider Models", () => {
 					outputPrice: 10,
 				},
 			},
+			"github-copilot": {
+				"gpt-4o": {
+					contextWindow: 128000,
+					supportsPromptCache: false,
+				},
+			},
 		}
 
 		it("should return router models for openrouter provider", () => {
@@ -309,6 +315,17 @@ describe("Static Provider Models", () => {
 				expect(result.defaultModel).toBeDefined()
 			})
 		})
+
+		it("should return router models for github-copilot provider", () => {
+			const result = getModelsByProvider({
+				provider: "github-copilot",
+				routerModels: mockRouterModels,
+				kilocodeDefaultModel: "",
+			})
+
+			expect(result.models).toBe(mockRouterModels["github-copilot"])
+			expect(Object.keys(result.models)).toContain("gpt-4o")
+		})
 	})
 
 	describe("getModelsByProvider - Edge Cases", () => {
@@ -385,6 +402,7 @@ describe("Static Provider Models", () => {
 			expect(PROVIDER_TO_ROUTER_NAME.openrouter).toBe("openrouter")
 			expect(PROVIDER_TO_ROUTER_NAME.ollama).toBe("ollama")
 			expect(PROVIDER_TO_ROUTER_NAME.litellm).toBe("litellm")
+			expect(PROVIDER_TO_ROUTER_NAME["github-copilot"]).toBe("github-copilot")
 		})
 
 		it("should map nano-gpt to nano-gpt router name", () => {
@@ -405,6 +423,7 @@ describe("Static Provider Models", () => {
 			expect(providerSupportsModelList("openrouter")).toBe(true)
 			expect(providerSupportsModelList("ollama")).toBe(true)
 			expect(providerSupportsModelList("litellm")).toBe(true)
+			expect(providerSupportsModelList("github-copilot")).toBe(true)
 		})
 
 		it("should return true for nano-gpt provider", () => {
@@ -423,6 +442,7 @@ describe("Static Provider Models", () => {
 		it("should return router name for router-based providers", () => {
 			expect(getRouterNameForProvider("openrouter")).toBe("openrouter")
 			expect(getRouterNameForProvider("ollama")).toBe("ollama")
+			expect(getRouterNameForProvider("github-copilot")).toBe("github-copilot")
 		})
 
 		it("should return nano-gpt for nano-gpt provider", () => {
@@ -439,6 +459,7 @@ describe("Static Provider Models", () => {
 		it("should return correct field names for router providers", () => {
 			expect(getModelFieldForProvider("openrouter")).toBe("openRouterModelId")
 			expect(getModelFieldForProvider("ollama")).toBe("ollamaModelId")
+			expect(getModelFieldForProvider("github-copilot")).toBe("githubCopilotModelId")
 		})
 
 		it("should return nanoGptModelId for nano-gpt provider", () => {

--- a/cli/src/constants/providers/labels.ts
+++ b/cli/src/constants/providers/labels.ts
@@ -9,6 +9,7 @@ export const PROVIDER_LABELS: Record<ProviderName, string> = {
 	anthropic: "Anthropic",
 	"openai-native": "OpenAI",
 	"openai-codex": "OpenAI - ChatGPT Plus/Pro",
+	"github-copilot": "GitHub Copilot", // kilocode_change
 	"openai-responses": "OpenAI Compatible (Responses)",
 	openrouter: "OpenRouter",
 	bedrock: "Amazon Bedrock",

--- a/cli/src/constants/providers/models.ts
+++ b/cli/src/constants/providers/models.ts
@@ -46,6 +46,8 @@ import {
 	minimaxModels,
 	minimaxDefaultModelId,
 	ovhCloudAiEndpointsDefaultModelId,
+	githubCopilotModels, // kilocode_change
+	githubCopilotDefaultModelId, // kilocode_change
 } from "@roo-code/types"
 
 /**
@@ -65,6 +67,7 @@ export type RouterName =
 	| "vercel-ai-gateway"
 	| "ovhcloud"
 	| "nano-gpt"
+	| "github-copilot" // kilocode_change
 
 /**
  * ModelInfo interface - mirrors the one from packages/types/src/model.ts
@@ -141,6 +144,7 @@ export const PROVIDER_TO_ROUTER_NAME: Record<ProviderName, RouterName | null> = 
 	gemini: null,
 	"openai-native": null,
 	"openai-codex": null,
+	"github-copilot": "github-copilot", // kilocode_change
 	mistral: null,
 	moonshot: null,
 	deepseek: null,
@@ -194,6 +198,7 @@ export const PROVIDER_MODEL_FIELD: Record<ProviderName, string | null> = {
 	gemini: null,
 	"openai-native": null,
 	"openai-codex": null,
+	"github-copilot": "githubCopilotModelId", // kilocode_change
 	mistral: null,
 	moonshot: null,
 	deepseek: null,
@@ -283,6 +288,7 @@ export const DEFAULT_MODEL_IDS: Partial<Record<ProviderName, string>> = {
 	zai: internationalZAiDefaultModelId,
 	roo: rooDefaultModelId,
 	ovhcloud: ovhCloudAiEndpointsDefaultModelId,
+	"github-copilot": githubCopilotDefaultModelId, // kilocode_change
 }
 
 /**
@@ -413,6 +419,11 @@ export function getModelsByProvider(params: {
 				models: claudeCodeModels as ModelRecord,
 				defaultModel: claudeCodeDefaultModelId,
 			}
+		case "github-copilot": // kilocode_change
+			return {
+				models: githubCopilotModels as ModelRecord,
+				defaultModel: githubCopilotDefaultModelId,
+			}
 		default:
 			// For providers without static models (e.g., vscode-lm, fake-ai, virtual-quota-fallback)
 			return {
@@ -460,6 +471,8 @@ export function getModelIdKey(provider: ProviderName): string {
 			return "ovhCloudAiEndpointsModelId"
 		case "nano-gpt":
 			return "nanoGptModelId"
+		case "github-copilot": // kilocode_change
+			return "githubCopilotModelId" // kilocode_change
 		default:
 			return "apiModelId"
 	}

--- a/cli/src/constants/providers/settings.ts
+++ b/cli/src/constants/providers/settings.ts
@@ -1,3 +1,5 @@
+import { githubCopilotDefaultModelId } from "@roo-code/types"
+
 import type { ProviderName, ProviderSettings } from "../../types/messages.js"
 
 /**
@@ -157,6 +159,22 @@ export const FIELD_REGISTRY: Record<string, FieldMetadata> = {
 		placeholder: "Enter base URL (or leave empty for default)...",
 		isOptional: true,
 	},
+
+	// kilocode_change start
+	// GitHub Copilot fields
+	githubCopilotToken: {
+		label: "Access Token",
+		type: "password",
+		placeholder: "Run 'kilocode auth copilot' to authenticate...",
+	},
+	githubCopilotModelId: {
+		label: "Model",
+		type: "text",
+		placeholder: "Enter model name (e.g., gpt-4o)...",
+		isOptional: true,
+	},
+	// kilocode_change end
+
 	openAiNativeServiceTier: {
 		label: "Service Tier",
 		type: "select",
@@ -801,6 +819,14 @@ export const getProviderSettings = (provider: ProviderName, config: ProviderSett
 		case "openai-codex":
 			return [createFieldConfig("apiModelId", config, "gpt-4o")]
 
+		// kilocode_change start
+		case "github-copilot":
+			return [
+				createFieldConfig("githubCopilotToken", config),
+				createFieldConfig("githubCopilotModelId", config, githubCopilotDefaultModelId),
+			]
+		// kilocode_change end
+
 		case "bedrock":
 			return [
 				createFieldConfig("awsAccessKey", config),
@@ -1041,6 +1067,7 @@ export const PROVIDER_DEFAULT_MODELS: Record<ProviderName, string> = {
 	anthropic: "claude-3-5-sonnet-20241022",
 	"openai-native": "gpt-4o",
 	"openai-codex": "gpt-4o",
+	"github-copilot": "gpt-4o", // kilocode_change
 	"openai-responses": "gpt-4o",
 	openrouter: "anthropic/claude-3-5-sonnet",
 	bedrock: "anthropic.claude-3-5-sonnet-20241022-v2:0",

--- a/cli/src/constants/providers/validation.ts
+++ b/cli/src/constants/providers/validation.ts
@@ -9,6 +9,7 @@ export const PROVIDER_REQUIRED_FIELDS: Record<ProviderName, string[]> = {
 	anthropic: ["apiKey", "apiModelId"],
 	"openai-native": ["openAiNativeApiKey", "apiModelId"],
 	"openai-codex": ["apiModelId"],
+	"github-copilot": ["githubCopilotToken"], // kilocode_change
 	openrouter: ["openRouterApiKey", "openRouterModelId"],
 	ollama: ["ollamaBaseUrl", "ollamaModelId"],
 	lmstudio: ["lmStudioBaseUrl", "lmStudioModelId"],

--- a/cli/src/services/models/fetcher.ts
+++ b/cli/src/services/models/fetcher.ts
@@ -81,9 +81,16 @@ export async function fetchRouterModels(
 			service!.on("message", messageHandler)
 		})
 
+		const shouldRefresh = provider.provider === "github-copilot"
+		const providerKey = provider.provider
+
 		// Send requestRouterModels message
 		await service.sendWebviewMessage({
 			type: "requestRouterModels",
+			values: {
+				provider: providerKey,
+				refresh: shouldRefresh,
+			},
 		})
 		logs.debug("Sent requestRouterModels message", "ModelFetcher")
 

--- a/packages/core-schemas/src/config/provider.ts
+++ b/packages/core-schemas/src/config/provider.ts
@@ -43,6 +43,13 @@ export const openAICodexProviderSchema = baseProviderSchema.extend({
 	provider: z.literal("openai-codex"),
 	apiModelId: z.string().optional(),
 })
+
+// GitHub Copilot provider
+export const githubCopilotProviderSchema = baseProviderSchema.extend({
+	provider: z.literal("github-copilot"),
+	githubCopilotToken: z.string().optional(),
+	githubCopilotModelId: z.string().optional(),
+})
 // kilocode_change end
 
 // OpenAI provider
@@ -404,6 +411,7 @@ export const providerConfigSchema = z.discriminatedUnion("provider", [
 	anthropicProviderSchema,
 	openAINativeProviderSchema,
 	openAICodexProviderSchema, // kilocode_change
+	githubCopilotProviderSchema, // kilocode_change
 	openAIProviderSchema,
 	openAIResponsesProviderSchema, // kilocode_change
 	openRouterProviderSchema,
@@ -450,6 +458,7 @@ export type KilocodeProviderConfig = z.infer<typeof kilocodeProviderSchema>
 export type AnthropicProviderConfig = z.infer<typeof anthropicProviderSchema>
 export type OpenAINativeProviderConfig = z.infer<typeof openAINativeProviderSchema>
 export type OpenAICodexProviderConfig = z.infer<typeof openAICodexProviderSchema> // kilocode_change
+export type GitHubCopilotProviderConfig = z.infer<typeof githubCopilotProviderSchema> // kilocode_change
 export type OpenAIProviderConfig = z.infer<typeof openAIProviderSchema>
 export type OpenAIResponsesProviderConfig = z.infer<typeof openAIResponsesProviderSchema> // kilocode_change
 export type OpenRouterProviderConfig = z.infer<typeof openRouterProviderSchema>

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -309,6 +309,7 @@ export const SECRET_STATE_KEYS = [
 	"vercelAiGatewayApiKey",
 	"sapAiCoreServiceKey", // kilocode_change
 	"basetenApiKey",
+	"githubCopilotToken", // kilocode_change
 ] as const
 
 // Global secrets that are part of GlobalSettings (not ProviderSettings)

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -14,6 +14,7 @@ import {
 	featherlessModels,
 	fireworksModels,
 	// kilocode_change start
+	githubCopilotModels,
 	syntheticModels,
 	// geminiModels,
 	// kilocode_change end
@@ -56,6 +57,7 @@ export const dynamicProviders = [
 	"inception",
 	"synthetic",
 	"sap-ai-core",
+	"github-copilot",
 	// kilocode_change end
 	"deepinfra",
 	"io-intelligence",
@@ -153,6 +155,7 @@ export const providerNames = [
 	"openai-codex",
 	"openai-native",
 	"openai-responses", // kilocode_change
+	"github-copilot", // kilocode_change
 	"qwen-code",
 	"roo",
 	// kilocode_change start
@@ -356,6 +359,13 @@ const geminiSchema = apiModelIdProviderModelSchema.extend({
 const openAiCodexSchema = apiModelIdProviderModelSchema.extend({
 	// No additional settings needed - uses OAuth authentication
 })
+
+// kilocode_change start
+const githubCopilotSchema = baseProviderSettingsSchema.extend({
+	githubCopilotToken: z.string().optional(),
+	githubCopilotModelId: z.string().optional(),
+})
+// kilocode_change end
 
 const openAiNativeSchema = apiModelIdProviderModelSchema.extend({
 	openAiNativeApiKey: z.string().optional(),
@@ -574,6 +584,7 @@ export const providerSettingsSchemaDiscriminated = z.discriminatedUnion("apiProv
 	lmStudioSchema.merge(z.object({ apiProvider: z.literal("lmstudio") })),
 	geminiSchema.merge(z.object({ apiProvider: z.literal("gemini") })),
 	openAiCodexSchema.merge(z.object({ apiProvider: z.literal("openai-codex") })),
+	githubCopilotSchema.merge(z.object({ apiProvider: z.literal("github-copilot") })), // kilocode_change
 	openAiNativeSchema.merge(z.object({ apiProvider: z.literal("openai-native") })),
 	ovhcloudSchema.merge(z.object({ apiProvider: z.literal("ovhcloud") })), // kilocode_change
 	mistralSchema.merge(z.object({ apiProvider: z.literal("mistral") })),
@@ -634,6 +645,7 @@ export const providerSettingsSchema = z.object({
 	...inceptionSchema.shape,
 	// kilocode_change end
 	...openAiCodexSchema.shape,
+	...githubCopilotSchema.shape, // kilocode_change
 	...openAiNativeSchema.shape,
 	...mistralSchema.shape,
 	...deepSeekSchema.shape,
@@ -701,6 +713,7 @@ export const modelIdKeys = [
 	"ovhCloudAiEndpointsModelId", // kilocode_change
 	"inceptionLabsModelId", // kilocode_change
 	"sapAiCoreModelId", // kilocode_change
+	"githubCopilotModelId", // kilocode_change
 ] as const satisfies readonly (keyof ProviderSettings)[]
 
 export type ModelIdKey = (typeof modelIdKeys)[number]
@@ -729,6 +742,7 @@ export const modelIdKeysByProvider: Record<TypicalProvider, ModelIdKey> = {
 	bedrock: "apiModelId",
 	vertex: "apiModelId",
 	"openai-codex": "apiModelId",
+	"github-copilot": "githubCopilotModelId", // kilocode_change
 	"openai-native": "openAiModelId",
 	ollama: "ollamaModelId",
 	lmstudio: "lmStudioModelId",
@@ -879,6 +893,13 @@ export const MODELS_BY_PROVIDER: Record<
 		label: "OpenAI - ChatGPT Plus/Pro",
 		models: Object.keys(openAiCodexModels),
 	},
+	// kilocode_change start
+	"github-copilot": {
+		id: "github-copilot",
+		label: "GitHub Copilot",
+		models: Object.keys(githubCopilotModels),
+	},
+	// kilocode_change end
 	"openai-native": {
 		id: "openai-native",
 		label: "OpenAI",

--- a/packages/types/src/providers/github-copilot.ts
+++ b/packages/types/src/providers/github-copilot.ts
@@ -1,0 +1,65 @@
+// kilocode_change - new file
+import type { ModelInfo } from "../model.js"
+
+// GitHub Copilot available models
+// These are the models available through GitHub Copilot subscription
+// NOTE: Copilot is subscription-based - pricing fields are 0
+export const githubCopilotModels = {
+	"gpt-4o": {
+		maxTokens: 16384,
+		contextWindow: 128_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		description: "GPT-4o - Latest multimodal model",
+	},
+	"gpt-4o-mini": {
+		maxTokens: 16384,
+		contextWindow: 128_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		description: "GPT-4o Mini - Fast and efficient",
+	},
+	"gpt-4.1": {
+		maxTokens: 32768,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		description: "GPT-4.1 - Extended context",
+	},
+	"claude-sonnet-4.5": {
+		maxTokens: 32768,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		description: "Claude Sonnet 4.5 via Copilot",
+	},
+	"claude-opus-4.5": {
+		maxTokens: 32768,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		description: "Claude Opus 4.5 via Copilot",
+	},
+	"claude-haiku-4.5": {
+		maxTokens: 32768,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		description: "Claude Haiku 4.5 via Copilot - Fast",
+	},
+} as const satisfies Record<string, ModelInfo>
+
+export type GitHubCopilotModelId = keyof typeof githubCopilotModels
+export const githubCopilotDefaultModelId: GitHubCopilotModelId = "claude-sonnet-4.5"

--- a/packages/types/src/providers/index.ts
+++ b/packages/types/src/providers/index.ts
@@ -10,6 +10,7 @@ export * from "./featherless.js"
 export * from "./fireworks.js"
 export * from "./gemini.js"
 // kilocode_change start
+export * from "./github-copilot.js"
 export * from "./ovhcloud.js"
 export * from "./synthetic.js"
 export * from "./inception.js"
@@ -53,6 +54,7 @@ import { doubaoDefaultModelId } from "./doubao.js"
 import { featherlessDefaultModelId } from "./featherless.js"
 import { fireworksDefaultModelId } from "./fireworks.js"
 import { geminiDefaultModelId } from "./gemini.js"
+import { githubCopilotDefaultModelId } from "./github-copilot.js" // kilocode_change
 import { glamaDefaultModelId } from "./glama.js" // kilocode_change
 import { groqDefaultModelId } from "./groq.js"
 import { ioIntelligenceDefaultModelId } from "./io-intelligence.js"
@@ -94,6 +96,10 @@ export function getProviderDefaultModelId(
 		// kilocode_change start
 		case "glama":
 			return glamaDefaultModelId
+		// kilocode_change end
+		// kilocode_change start
+		case "github-copilot":
+			return githubCopilotDefaultModelId
 		// kilocode_change end
 		case "unbound":
 			return unboundDefaultModelId

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -15,6 +15,7 @@ import {
 	AnthropicVertexHandler,
 	OpenAiHandler,
 	OpenAiCodexHandler,
+	GitHubCopilotHandler, // kilocode_change
 	LmStudioHandler,
 	GeminiHandler,
 	OpenAiNativeHandler,
@@ -196,6 +197,8 @@ export function buildApiHandler(configuration: ProviderSettings): ApiHandler {
 			return new GeminiHandler(options)
 		case "openai-codex":
 			return new OpenAiCodexHandler(options)
+		case "github-copilot": // kilocode_change
+			return new GitHubCopilotHandler(options) // kilocode_change
 		case "openai-native":
 			return new OpenAiNativeHandler(options)
 		case "openai-responses": // kilocode_change

--- a/src/api/providers/fetchers/__tests__/github-copilot.spec.ts
+++ b/src/api/providers/fetchers/__tests__/github-copilot.spec.ts
@@ -1,0 +1,56 @@
+// kilocode_change - new file
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+import { getGitHubCopilotModels } from "../github-copilot"
+import { fetchCopilotToken } from "../../utils/github-copilot-auth"
+
+vi.mock("../../utils/github-copilot-auth", () => ({
+	fetchCopilotToken: vi.fn(),
+	resolveGitHubCopilotToken: (token?: string) => token ?? "",
+}))
+
+global.fetch = vi.fn()
+
+describe("getGitHubCopilotModels", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("returns empty models when api key is missing", async () => {
+		const models = await getGitHubCopilotModels()
+		expect(models).toEqual({})
+	})
+
+	it("fetches models using exchanged Copilot token", async () => {
+		vi.mocked(fetchCopilotToken).mockResolvedValue({
+			token: "copilot-token",
+		})
+
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: true,
+			json: vi.fn().mockResolvedValue({
+				data: [
+					{ id: "gpt-4o", object: "model", created: 0, owned_by: "copilot" },
+					{ id: "gpt-4o", object: "model", created: 0, owned_by: "copilot" },
+				],
+			}),
+		} as any)
+
+		const models = await getGitHubCopilotModels("oauth-token")
+
+		expect(fetchCopilotToken).toHaveBeenCalledWith("oauth-token")
+		expect(global.fetch).toHaveBeenCalledWith(
+			"https://api.githubcopilot.com/models",
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Authorization: "Bearer copilot-token",
+				}),
+			}),
+		)
+		expect(models["gpt-4o"]).toBeDefined()
+	})
+})

--- a/src/api/providers/fetchers/github-copilot.ts
+++ b/src/api/providers/fetchers/github-copilot.ts
@@ -1,0 +1,133 @@
+// kilocode_change - new file
+import type { ModelRecord } from "@roo-code/types"
+
+import { githubCopilotModels } from "@roo-code/types"
+
+import { fetchCopilotToken, resolveGitHubCopilotToken } from "../utils/github-copilot-auth"
+
+const GITHUB_COPILOT_MODELS_URLS = [
+	"https://api.githubcopilot.com/models",
+	"https://api.githubcopilot.com/v1/models",
+] as const
+const COPILOT_USER_AGENT = process.env.KILOCODE_COPILOT_USER_AGENT ?? "KiloCode/1.0"
+const COPILOT_EDITOR_VERSION = process.env.KILOCODE_COPILOT_EDITOR_VERSION ?? "KiloCode/1.0"
+const COPILOT_EDITOR_PLUGIN_VERSION = process.env.KILOCODE_COPILOT_EDITOR_PLUGIN_VERSION ?? "KiloCode/1.0"
+const COPILOT_INTEGRATION_ID = process.env.KILOCODE_COPILOT_INTEGRATION_ID ?? "vscode-chat"
+const COPILOT_INITIATOR = process.env.KILOCODE_COPILOT_INITIATOR
+const COPILOT_API_HEADERS: Record<string, string> = {
+	Accept: "application/json",
+	"Openai-Intent": "conversation-edits",
+	"User-Agent": COPILOT_USER_AGENT,
+	"Editor-Version": COPILOT_EDITOR_VERSION,
+	"Editor-Plugin-Version": COPILOT_EDITOR_PLUGIN_VERSION,
+	"Copilot-Integration-Id": COPILOT_INTEGRATION_ID,
+}
+if (COPILOT_INITIATOR) {
+	COPILOT_API_HEADERS["x-initiator"] = COPILOT_INITIATOR
+}
+const DEBUG_COPILOT_MODELS =
+	process.env.KILOCODE_DEBUG_COPILOT_MODELS === "1" || process.env.KILOCODE_DEBUG_COPILOT_MODELS === "true"
+
+interface CopilotModel {
+	id: string
+	object: string
+	created: number
+	owned_by: string | null
+}
+
+interface CopilotModelsResponse {
+	data: CopilotModel[]
+}
+
+/**
+ * Fetch available models from GitHub Copilot API
+ */
+export async function getGitHubCopilotModels(apiKey?: string): Promise<ModelRecord> {
+	const resolvedToken = resolveGitHubCopilotToken(apiKey)
+	if (!resolvedToken) {
+		return {}
+	}
+
+	let token: string
+	try {
+		;({ token } = await fetchCopilotToken(resolvedToken))
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn("[GitHubCopilotModels] Copilot token exchange failed, using static models:", message)
+		return { ...githubCopilotModels }
+	}
+	let lastError: Error | undefined
+	let data: CopilotModelsResponse | undefined
+
+	for (const url of GITHUB_COPILOT_MODELS_URLS) {
+		const response = await fetch(url, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				...COPILOT_API_HEADERS,
+			},
+		})
+
+		if (!response.ok) {
+			// 404 indicates the endpoint is not available; try the next URL.
+			if (response.status === 404) {
+				lastError = new Error(`GitHub Copilot models endpoint not found: ${url}`)
+				continue
+			}
+
+			const errorText = await response.text().catch(() => "")
+			const detail = errorText ? `: ${errorText}` : ""
+			lastError = new Error(`Failed to fetch GitHub Copilot models (${url}): ${response.status}${detail}`)
+			// For auth errors, don't fall back to static list.
+			if (response.status === 401 || response.status === 403) {
+				throw lastError
+			}
+
+			continue
+		}
+
+		data = (await response.json()) as CopilotModelsResponse
+		if (DEBUG_COPILOT_MODELS) {
+			const ids = data.data?.map((model) => model.id) ?? []
+			console.info(`[GitHubCopilotModels] Raw models (${ids.length}): ${ids.join(", ")}`)
+		}
+		break
+	}
+
+	if (!data) {
+		if (lastError) {
+			console.warn("[GitHubCopilotModels] Falling back to static model list:", lastError.message)
+		}
+		return { ...githubCopilotModels }
+	}
+
+	const models: ModelRecord = {}
+	const seen = new Set<string>()
+
+	for (const model of data.data) {
+		// Skip duplicates and embedding models
+		if (seen.has(model.id) || model.id.includes("embedding")) {
+			continue
+		}
+		seen.add(model.id)
+
+		const staticInfo = (githubCopilotModels as ModelRecord)[model.id]
+		if (staticInfo) {
+			models[model.id] = { ...staticInfo }
+			continue
+		}
+
+		// Determine model capabilities based on name
+		const isClaudeModel = model.id.includes("claude")
+		const isGptModel = model.id.includes("gpt")
+
+		models[model.id] = {
+			contextWindow: isClaudeModel ? 200_000 : isGptModel ? 128_000 : 32_000,
+			supportsPromptCache: false,
+			supportsImages: isClaudeModel || model.id.includes("4o") || model.id.includes("4.1"),
+			supportsNativeTools: true,
+			description: `${model.id} via GitHub Copilot`,
+		}
+	}
+
+	return models
+}

--- a/src/api/providers/fetchers/modelCache.ts
+++ b/src/api/providers/fetchers/modelCache.ts
@@ -40,6 +40,7 @@ import { getHuggingFaceModels } from "./huggingface"
 import { getRooModels } from "./roo"
 import { getChutesModels } from "./chutes"
 import { getNanoGptModels } from "./nano-gpt" //kilocode_change
+import { getGitHubCopilotModels } from "./github-copilot" // kilocode_change
 
 const memoryCache = new NodeCache({ stdTTL: 5 * 60, checkperiod: 5 * 60 })
 
@@ -172,6 +173,9 @@ async function fetchModelsFromProvider(options: GetModelsOptions): Promise<Model
 				nanoGptModelList: options.nanoGptModelList,
 				apiKey: options.apiKey,
 			})
+			break
+		case "github-copilot":
+			models = await getGitHubCopilotModels(options.apiKey)
 			break
 		//kilocode_change end
 		default: {

--- a/src/api/providers/github-copilot.ts
+++ b/src/api/providers/github-copilot.ts
@@ -1,0 +1,177 @@
+// kilocode_change - new file
+import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
+
+import {
+	githubCopilotDefaultModelId,
+	githubCopilotModels,
+	openAiModelInfoSaneDefaults,
+	type ModelInfo,
+	NATIVE_TOOL_DEFAULTS,
+} from "@roo-code/types"
+
+import type { ApiHandlerOptions } from "../../shared/api"
+
+import { getModelParams } from "../transform/model-params"
+import type { ApiStream } from "../transform/stream"
+
+import { OpenAiHandler } from "./openai"
+import type { ApiHandlerCreateMessageMetadata } from "../index"
+import { fetchCopilotToken, resolveGitHubCopilotToken } from "./utils/github-copilot-auth"
+import { getApiRequestTimeout } from "./utils/timeout-config"
+
+const GITHUB_COPILOT_BASE_URL = "https://api.githubcopilot.com"
+const COPILOT_TOKEN_REFRESH_BUFFER_MS = 60_000
+const COPILOT_USER_AGENT = process.env.KILOCODE_COPILOT_USER_AGENT ?? "KiloCode/1.0"
+const COPILOT_EDITOR_VERSION = process.env.KILOCODE_COPILOT_EDITOR_VERSION ?? "KiloCode/1.0"
+const COPILOT_EDITOR_PLUGIN_VERSION = process.env.KILOCODE_COPILOT_EDITOR_PLUGIN_VERSION ?? "KiloCode/1.0"
+const COPILOT_INTEGRATION_ID = process.env.KILOCODE_COPILOT_INTEGRATION_ID ?? "vscode-chat"
+const COPILOT_INITIATOR = process.env.KILOCODE_COPILOT_INITIATOR
+const COPILOT_API_HEADERS: Record<string, string> = {
+	"Openai-Intent": "conversation-edits",
+	"User-Agent": COPILOT_USER_AGENT,
+	"Editor-Version": COPILOT_EDITOR_VERSION,
+	"Editor-Plugin-Version": COPILOT_EDITOR_PLUGIN_VERSION,
+	"Copilot-Integration-Id": COPILOT_INTEGRATION_ID,
+}
+if (COPILOT_INITIATOR) {
+	COPILOT_API_HEADERS["x-initiator"] = COPILOT_INITIATOR
+}
+
+/**
+ * GitHub Copilot provider handler.
+ * Uses OAuth token from GitHub Copilot subscription to access the API.
+ * API is OpenAI-compatible, so we extend OpenAiHandler.
+ */
+export class GitHubCopilotHandler extends OpenAiHandler {
+	private copilotToken?: string
+	private copilotTokenExpiresAt?: number
+	private copilotTokenRefreshAt?: number
+	private copilotTokenRequest?: Promise<string>
+
+	constructor(options: ApiHandlerOptions) {
+		// Set openAiModelId from githubCopilotModelId so parent class uses correct model
+		const defaultModelId = options.githubCopilotModelId ?? githubCopilotDefaultModelId
+		const mergedOptions = {
+			...options,
+			openAiModelId: defaultModelId,
+			openAiBaseUrl: GITHUB_COPILOT_BASE_URL,
+		}
+		super(mergedOptions)
+
+		this.client = new OpenAI({
+			baseURL: GITHUB_COPILOT_BASE_URL,
+			apiKey: "not-provided",
+			timeout: getApiRequestTimeout(),
+			defaultHeaders: COPILOT_API_HEADERS,
+		})
+	}
+
+	override async *createMessage(
+		systemPrompt: string,
+		messages: Anthropic.Messages.MessageParam[],
+		metadata?: ApiHandlerCreateMessageMetadata,
+	): ApiStream {
+		await this.ensureCopilotToken()
+
+		try {
+			yield* super.createMessage(systemPrompt, messages, metadata)
+		} catch (error) {
+			if (this.isAuthError(error)) {
+				await this.ensureCopilotToken(true)
+				yield* super.createMessage(systemPrompt, messages, metadata)
+				return
+			}
+
+			throw error
+		}
+	}
+
+	override async completePrompt(prompt: string): Promise<string> {
+		await this.ensureCopilotToken()
+
+		try {
+			return await super.completePrompt(prompt)
+		} catch (error) {
+			if (this.isAuthError(error)) {
+				await this.ensureCopilotToken(true)
+				return await super.completePrompt(prompt)
+			}
+
+			throw error
+		}
+	}
+
+	override getModel() {
+		const id = this.options.githubCopilotModelId ?? githubCopilotDefaultModelId
+		const copilotInfo = (githubCopilotModels as Record<string, ModelInfo>)[id]
+		const info: ModelInfo = {
+			...openAiModelInfoSaneDefaults,
+			...NATIVE_TOOL_DEFAULTS,
+			...(copilotInfo ?? {}),
+		}
+		const params = getModelParams({ format: "openai", modelId: id, model: info, settings: this.options })
+		return { id, info, ...params }
+	}
+
+	private async ensureCopilotToken(forceRefresh = false): Promise<string> {
+		if (!forceRefresh && !this.shouldRefreshToken()) {
+			return this.copilotToken ?? ""
+		}
+
+		if (this.copilotTokenRequest) {
+			return this.copilotTokenRequest
+		}
+
+		const githubToken = resolveGitHubCopilotToken(this.options.githubCopilotToken)
+		if (!githubToken) {
+			throw new Error("Missing GitHub Copilot token. Run `kilocode auth` to authenticate.")
+		}
+
+		this.copilotTokenRequest = (async () => {
+			const result = await fetchCopilotToken(githubToken)
+			this.copilotToken = result.token
+			this.copilotTokenExpiresAt = result.expiresAt
+			this.copilotTokenRefreshAt = result.refreshAt
+			this.client.apiKey = result.token
+			return result.token
+		})()
+
+		try {
+			return await this.copilotTokenRequest
+		} finally {
+			this.copilotTokenRequest = undefined
+		}
+	}
+
+	private shouldRefreshToken(): boolean {
+		if (!this.copilotToken) {
+			return true
+		}
+
+		const now = Date.now()
+		if (this.copilotTokenRefreshAt) {
+			return now >= this.copilotTokenRefreshAt - COPILOT_TOKEN_REFRESH_BUFFER_MS
+		}
+
+		if (this.copilotTokenExpiresAt) {
+			return now >= this.copilotTokenExpiresAt - COPILOT_TOKEN_REFRESH_BUFFER_MS
+		}
+
+		return false
+	}
+
+	private isAuthError(error: unknown): boolean {
+		if (!error || typeof error !== "object") {
+			return false
+		}
+
+		const status = "status" in error ? Number((error as { status?: number }).status) : undefined
+		if (status === 401 || status === 403) {
+			return true
+		}
+
+		const message = error instanceof Error ? error.message : ""
+		return /unauthorized|invalid token|not authenticated|authentication|401|403/i.test(message)
+	}
+}

--- a/src/api/providers/index.ts
+++ b/src/api/providers/index.ts
@@ -9,6 +9,7 @@ export { DoubaoHandler } from "./doubao"
 export { MoonshotHandler } from "./moonshot"
 export { FakeAIHandler } from "./fake-ai"
 export { GeminiHandler } from "./gemini"
+export { GitHubCopilotHandler } from "./github-copilot" // kilocode_change
 export { GlamaHandler } from "./glama" // kilocode_change
 export { GroqHandler } from "./groq"
 export { HuggingFaceHandler } from "./huggingface"

--- a/src/api/providers/utils/__tests__/github-copilot-auth.spec.ts
+++ b/src/api/providers/utils/__tests__/github-copilot-auth.spec.ts
@@ -1,0 +1,122 @@
+// kilocode_change - new file
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { fetchCopilotToken, resolveGitHubCopilotToken } from "../github-copilot-auth"
+
+global.fetch = vi.fn()
+
+describe("fetchCopilotToken", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"))
+		vi.clearAllMocks()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.clearAllMocks()
+	})
+
+	it("returns token and expiry from expires_in", async () => {
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: true,
+			json: vi.fn().mockResolvedValue({
+				token: "copilot-token",
+				expires_in: 3600,
+				refresh_in: 600,
+			}),
+		} as any)
+
+		const result = await fetchCopilotToken("oauth-token")
+
+		expect(result.token).toBe("copilot-token")
+		expect(result.expiresAt).toBe(Date.now() + 3600 * 1000)
+		expect(result.refreshAt).toBe(Date.now() + 600 * 1000)
+	})
+
+	it("falls back to access_token and parses expires_at string", async () => {
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: true,
+			json: vi.fn().mockResolvedValue({
+				access_token: "copilot-access",
+				expires_at: "2025-01-01T01:00:00.000Z",
+			}),
+		} as any)
+
+		const result = await fetchCopilotToken("oauth-token")
+
+		expect(result.token).toBe("copilot-access")
+		expect(result.expiresAt).toBe(Date.parse("2025-01-01T01:00:00.000Z"))
+	})
+
+	it("retries with Bearer scheme after unauthorized response", async () => {
+		vi.mocked(global.fetch)
+			.mockResolvedValueOnce({
+				ok: false,
+				status: 401,
+				statusText: "Unauthorized",
+			} as any)
+			.mockResolvedValueOnce({
+				ok: true,
+				json: vi.fn().mockResolvedValue({
+					copilot_token: "copilot-fallback",
+				}),
+			} as any)
+
+		const result = await fetchCopilotToken("oauth-token")
+
+		expect(result.token).toBe("copilot-fallback")
+		expect(global.fetch).toHaveBeenCalledTimes(2)
+		expect(global.fetch).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Authorization: "Bearer oauth-token",
+				}),
+			}),
+		)
+	})
+
+	it("throws when token is missing", async () => {
+		vi.mocked(global.fetch).mockResolvedValue({
+			ok: true,
+			json: vi.fn().mockResolvedValue({}),
+		} as any)
+
+		await expect(fetchCopilotToken("oauth-token")).rejects.toThrow("token response")
+	})
+
+	it("falls back to OAuth token when all endpoints are unavailable", async () => {
+		vi.mocked(global.fetch).mockResolvedValue({
+			ok: false,
+			status: 404,
+			statusText: "Not Found",
+			text: vi.fn().mockResolvedValue(""),
+		} as any)
+
+		const result = await fetchCopilotToken("oauth-token")
+
+		expect(result.token).toBe("oauth-token")
+	})
+
+	it("ignores GH_TOKEN when configured token is present", () => {
+		const originalGhToken = process.env.GH_TOKEN
+		const originalGithubToken = process.env.GITHUB_TOKEN
+
+		process.env.GH_TOKEN = "env-token"
+		delete process.env.GITHUB_TOKEN
+
+		expect(resolveGitHubCopilotToken("config-token")).toBe("config-token")
+
+		if (originalGhToken === undefined) {
+			delete process.env.GH_TOKEN
+		} else {
+			process.env.GH_TOKEN = originalGhToken
+		}
+
+		if (originalGithubToken === undefined) {
+			delete process.env.GITHUB_TOKEN
+		} else {
+			process.env.GITHUB_TOKEN = originalGithubToken
+		}
+	})
+})

--- a/src/api/providers/utils/github-copilot-auth.ts
+++ b/src/api/providers/utils/github-copilot-auth.ts
@@ -1,0 +1,226 @@
+// kilocode_change - new file
+const COPILOT_TOKEN_PRIMARY_URLS = ["https://api.github.com/copilot_internal/v2/token"] as const
+const COPILOT_TOKEN_FALLBACK_URLS = [
+	"https://api.githubcopilot.com/v2/token",
+	"https://api.githubcopilot.com/token",
+	"https://api.githubcopilot.com/v1/token",
+] as const
+const COPILOT_USER_AGENT = process.env.KILOCODE_COPILOT_USER_AGENT ?? "KiloCode/1.0"
+const COPILOT_TOKEN_HEADERS = {
+	Accept: "application/json",
+	"Content-Type": "application/json",
+	"Openai-Intent": "conversation-edits",
+	"User-Agent": COPILOT_USER_AGENT,
+}
+const AUTH_SCHEMES = ["token", "Bearer"] as const
+const TOKEN_HTTP_METHODS = ["GET", "POST"] as const
+const DEBUG_COPILOT_AUTH =
+	process.env.KILOCODE_DEBUG_COPILOT_AUTH === "1" || process.env.KILOCODE_DEBUG_COPILOT_AUTH === "true"
+
+export interface CopilotTokenResult {
+	token: string
+	expiresAt?: number
+	refreshAt?: number
+}
+
+type CopilotTokenResponse = {
+	token?: string
+	access_token?: string
+	copilot_token?: string
+	expires_at?: number | string
+	expires_in?: number
+	refresh_in?: number
+}
+
+const parseEpochMs = (value: number): number => (value > 1e12 ? value : value * 1000)
+
+const getCopilotRequestHeaders = (url: string, githubToken: string, scheme: (typeof AUTH_SCHEMES)[number]) => {
+	const isGitHubApi = url.includes("api.github.com")
+	return {
+		...COPILOT_TOKEN_HEADERS,
+		Authorization: `${scheme} ${githubToken}`,
+		...(isGitHubApi ? { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" } : {}),
+	}
+}
+
+const extractErrorBody = async (response: Response): Promise<string> => {
+	try {
+		const text = await response.text()
+		if (!text) {
+			return ""
+		}
+
+		const contentType = response.headers.get("content-type") ?? ""
+		if (contentType.includes("application/json")) {
+			try {
+				const data = JSON.parse(text) as { error?: string; error_description?: string; message?: string }
+				const safeParts = [data.error, data.error_description, data.message].filter(Boolean).join(": ")
+				return (safeParts || text).slice(0, 200)
+			} catch {
+				return text.slice(0, 200)
+			}
+		}
+
+		return text.slice(0, 200)
+	} catch {
+		return ""
+	}
+}
+
+const parseExpiresAt = (value?: number | string): number | undefined => {
+	if (typeof value === "number") {
+		return parseEpochMs(value)
+	}
+	if (typeof value === "string") {
+		const parsed = Date.parse(value)
+		return Number.isNaN(parsed) ? undefined : parsed
+	}
+	return undefined
+}
+
+const extractToken = (data: CopilotTokenResponse): string | undefined =>
+	data.token ?? data.copilot_token ?? data.access_token
+
+export const resolveGitHubCopilotToken = (configuredToken?: string): string => {
+	return configuredToken ?? ""
+}
+
+async function requestCopilotToken(
+	url: string,
+	githubToken: string,
+	scheme: (typeof AUTH_SCHEMES)[number],
+	method: string,
+) {
+	return fetch(url, {
+		method,
+		headers: getCopilotRequestHeaders(url, githubToken, scheme),
+	})
+}
+
+type CopilotTokenAttempt = {
+	result?: CopilotTokenResult
+	lastError?: Error
+	meaningfulError?: Error
+	allNotFound?: boolean
+}
+
+async function attemptCopilotTokenExchange(urls: readonly string[], githubToken: string): Promise<CopilotTokenAttempt> {
+	let lastError: Error | undefined
+	let meaningfulError: Error | undefined
+	let sawNotFound = false
+	let sawNonNotFound = false
+
+	for (const url of urls) {
+		for (const scheme of AUTH_SCHEMES) {
+			let response: Response
+			try {
+				response = await requestCopilotToken(url, githubToken, scheme, TOKEN_HTTP_METHODS[0])
+
+				if (!response.ok && (response.status === 404 || response.status === 405)) {
+					response = await requestCopilotToken(url, githubToken, scheme, TOKEN_HTTP_METHODS[1])
+				}
+			} catch (error) {
+				const errorMessage = error instanceof Error ? error.message : String(error)
+				const requestError = new Error(
+					`Failed to exchange GitHub Copilot token (${url}, ${scheme}): ${errorMessage}`,
+				)
+				lastError = requestError
+				meaningfulError ??= requestError
+				sawNonNotFound = true
+				if (DEBUG_COPILOT_AUTH) {
+					console.info(
+						`[GitHubCopilotAuth] Token exchange request failed (${url}, ${scheme}): ${errorMessage}`,
+					)
+				}
+				continue
+			}
+
+			if (!response.ok) {
+				if (response.status === 404 || response.status === 405) {
+					sawNotFound = true
+				} else {
+					sawNonNotFound = true
+				}
+				if (DEBUG_COPILOT_AUTH) {
+					console.info(
+						`[GitHubCopilotAuth] Token exchange failed ${response.status} ${response.statusText} (${url}, ${scheme})`,
+					)
+				}
+				const errorBody = await extractErrorBody(response)
+				const detail = errorBody ? `: ${errorBody}` : ""
+				const error = new Error(
+					`Failed to exchange GitHub Copilot token (${url}): ${response.status} ${response.statusText}${detail}`,
+				)
+				lastError = error
+
+				if (response.status !== 404 && response.status !== 405) {
+					meaningfulError ??= error
+				}
+
+				// 404/405 likely means endpoint not available for this host.
+				if (response.status === 404 || response.status === 405) {
+					break
+				}
+
+				// Try the next auth scheme if unauthorized with "token".
+				if ((response.status === 401 || response.status === 403) && scheme === "token") {
+					continue
+				}
+
+				// Try next host for other errors.
+				continue
+			}
+
+			const data = (await response.json()) as CopilotTokenResponse
+			const token = extractToken(data)
+
+			if (!token) {
+				const error = new Error("GitHub Copilot token response did not include a token.")
+				lastError = error
+				meaningfulError ??= error
+				sawNonNotFound = true
+				continue
+			}
+
+			const now = Date.now()
+			const expiresAt =
+				parseExpiresAt(data.expires_at) ?? (data.expires_in ? now + data.expires_in * 1000 : undefined)
+			const refreshAt = data.refresh_in ? now + data.refresh_in * 1000 : undefined
+
+			return { result: { token, expiresAt, refreshAt }, lastError, meaningfulError }
+		}
+	}
+
+	return { lastError, meaningfulError, allNotFound: sawNotFound && !sawNonNotFound }
+}
+
+export async function fetchCopilotToken(githubToken: string): Promise<CopilotTokenResult> {
+	if (!githubToken) {
+		throw new Error("Missing GitHub OAuth token for Copilot exchange.")
+	}
+
+	const primaryAttempt = await attemptCopilotTokenExchange(COPILOT_TOKEN_PRIMARY_URLS, githubToken)
+	if (primaryAttempt.result) {
+		return primaryAttempt.result
+	}
+
+	const fallbackAttempt = await attemptCopilotTokenExchange(COPILOT_TOKEN_FALLBACK_URLS, githubToken)
+	if (fallbackAttempt.result) {
+		return fallbackAttempt.result
+	}
+
+	if (primaryAttempt.allNotFound && fallbackAttempt.allNotFound) {
+		if (DEBUG_COPILOT_AUTH) {
+			console.info("[GitHubCopilotAuth] Token exchange endpoints unavailable; using OAuth token directly.")
+		}
+		return { token: githubToken }
+	}
+
+	throw (
+		primaryAttempt.meaningfulError ??
+		fallbackAttempt.meaningfulError ??
+		primaryAttempt.lastError ??
+		fallbackAttempt.lastError ??
+		new Error("Failed to exchange GitHub Copilot token.")
+	)
+}

--- a/src/core/config/ContextProxy.ts
+++ b/src/core/config/ContextProxy.ts
@@ -119,7 +119,8 @@ export class ContextProxy {
 	private async migrateInvalidApiProvider() {
 		try {
 			const apiProvider = this.stateCache.apiProvider
-			if (apiProvider !== undefined && !isProviderName(apiProvider)) {
+			// kilocode_change: github-copilot is CLI-only, treat as invalid in VS Code
+			if (apiProvider !== undefined && (!isProviderName(apiProvider) || apiProvider === "github-copilot")) {
 				logger.info(`[ContextProxy] Found invalid provider "${apiProvider}" in storage - clearing it`)
 				// Clear the invalid provider from both cache and storage
 				this.stateCache.apiProvider = undefined

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -2778,6 +2778,7 @@ describe("ClineProvider - Router Models", () => {
 				baseUrl: expect.any(String),
 			}),
 		)
+		expect(getModels).toHaveBeenCalledWith({ provider: "github-copilot", apiKey: undefined }) // kilocode_change
 		expect(getModels).toHaveBeenCalledWith({
 			provider: "litellm",
 			apiKey: "litellm-key",
@@ -2809,6 +2810,7 @@ describe("ClineProvider - Router Models", () => {
 				"sap-ai-core": {}, // kilocode_change
 				huggingface: {},
 				"io-intelligence": {},
+				"github-copilot": mockModels, // kilocode_change
 			},
 			values: undefined,
 		})
@@ -2861,6 +2863,7 @@ describe("ClineProvider - Router Models", () => {
 			.mockResolvedValueOnce(mockModels) // kilocode_change: synthetic success
 			.mockResolvedValueOnce(mockModels) // roo success
 			.mockRejectedValueOnce(new Error("Chutes API error")) // chutes fail
+			.mockResolvedValueOnce(mockModels) // github-copilot success // kilocode_change
 			.mockRejectedValueOnce(new Error("LiteLLM connection failed")) // litellm fail
 
 		await messageHandler({ type: "requestRouterModels" })
@@ -2889,6 +2892,7 @@ describe("ClineProvider - Router Models", () => {
 				"sap-ai-core": {}, // kilocode_change
 				huggingface: {},
 				"io-intelligence": {},
+				"github-copilot": mockModels, // kilocode_change
 			},
 			values: undefined,
 		})
@@ -3045,6 +3049,7 @@ describe("ClineProvider - Router Models", () => {
 				"sap-ai-core": {}, // kilocode_change
 				huggingface: {},
 				"io-intelligence": {},
+				"github-copilot": mockModels, // kilocode_change
 			},
 			values: undefined,
 		})

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -336,6 +336,7 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 				baseUrl: expect.any(String),
 			}),
 		)
+		expect(mockGetModels).toHaveBeenCalledWith({ provider: "github-copilot", apiKey: undefined }) // kilocode_change
 		expect(mockGetModels).toHaveBeenCalledWith({
 			provider: "litellm",
 			apiKey: "litellm-key",
@@ -368,6 +369,7 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 				ovhcloud: mockModels, // kilocode_change
 				inception: mockModels, // kilocode_change
 				"sap-ai-core": {}, // kilocode_change
+				"github-copilot": mockModels, // kilocode_change
 			},
 			values: undefined,
 		})
@@ -474,6 +476,7 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 				ovhcloud: mockModels, // kilocode_change
 				inception: mockModels, // kilocode_change
 				"sap-ai-core": {}, // kilocode_change
+				"github-copilot": mockModels, // kilocode_change
 			},
 			values: undefined,
 		})
@@ -506,6 +509,7 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 			.mockRejectedValueOnce(new Error("Synthetic API error")) // kilocode_change
 			.mockResolvedValueOnce(mockModels) // roo
 			.mockRejectedValueOnce(new Error("Chutes API error")) // chutes
+			.mockResolvedValueOnce(mockModels) // github-copilot // kilocode_change
 			.mockRejectedValueOnce(new Error("LiteLLM connection failed")) // litellm
 
 		await webviewMessageHandler(mockClineProvider, {
@@ -582,6 +586,7 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 				gemini: mockModels,
 				ovhcloud: mockModels,
 				"sap-ai-core": {},
+				"github-copilot": mockModels, // kilocode_change
 				// kilocode_change end
 			},
 			values: undefined,
@@ -606,6 +611,7 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 			.mockRejectedValueOnce(new Error("Synthetic API error")) // kilocode_change synthetic
 			.mockRejectedValueOnce(new Error("Roo API error")) // roo
 			.mockRejectedValueOnce(new Error("Chutes API error")) // chutes
+			.mockRejectedValueOnce(new Error("GitHub Copilot API error")) // github-copilot // kilocode_change
 			.mockRejectedValueOnce(new Error("LiteLLM connection failed")) // litellm
 
 		await webviewMessageHandler(mockClineProvider, {
@@ -711,6 +717,15 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 			error: "Chutes API error",
 			values: { provider: "chutes" },
 		})
+
+		// kilocode_change start
+		expect(mockClineProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "singleRouterModelFetchResponse",
+			success: false,
+			error: "GitHub Copilot API error",
+			values: { provider: "github-copilot" },
+		})
+		// kilocode_change end
 
 		expect(mockClineProvider.postMessageToWebview).toHaveBeenCalledWith({
 			type: "singleRouterModelFetchResponse",

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -912,6 +912,7 @@ export const webviewMessageHandler = async (
 						inception: {},
 						kilocode: {},
 						gemini: {},
+						"github-copilot": {},
 						// kilocode_change end
 						openrouter: {},
 						"vercel-ai-gateway": {},
@@ -1030,6 +1031,10 @@ export const webviewMessageHandler = async (
 				{
 					key: "chutes",
 					options: { provider: "chutes", apiKey: apiConfiguration.chutesApiKey },
+				},
+				{
+					key: "github-copilot",
+					options: { provider: "github-copilot", apiKey: apiConfiguration.githubCopilotToken },
 				},
 			]
 			// kilocode_change end

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -193,6 +193,9 @@ const dynamicProviderExtras = {
 	glama: {} as {}, // eslint-disable-line @typescript-eslint/no-empty-object-type
 	// kilocode_change end
 	"nano-gpt": {} as { nanoGptModelList?: "all" | "personalized" | "subscription" }, // kilocode_change
+	// kilocode_change start
+	"github-copilot": {} as {}, // eslint-disable-line @typescript-eslint/no-empty-object-type
+	// kilocode_change end
 	ollama: {} as { numCtx?: number }, // kilocode_change
 	lmstudio: {} as {}, // eslint-disable-line @typescript-eslint/no-empty-object-type
 	ovhcloud: {} as { apiKey?: string }, // kilocode_change

--- a/webview-ui/src/components/kilocode/hooks/__tests__/getModelsByProvider.spec.ts
+++ b/webview-ui/src/components/kilocode/hooks/__tests__/getModelsByProvider.spec.ts
@@ -36,6 +36,7 @@ describe("getModelsByProvider", () => {
 		"vercel-ai-gateway": { "test-model": testModel },
 		huggingface: { "test-model": testModel },
 		gemini: { "test-model": testModel },
+		"github-copilot": { "test-model": testModel },
 		ovhcloud: { "test-model": testModel },
 		chutes: { "test-model": testModel },
 		"sap-ai-core": { "test-model": testModel },
@@ -49,6 +50,7 @@ describe("getModelsByProvider", () => {
 			"fake-ai", // don't know what this is
 			"huggingface", // don't know what this is
 			"human-relay", // no models
+			"github-copilot", // OAuth-only provider (CLI only)
 			"nano-gpt", // dynamic provider - models fetched from API
 			"openai", // not implemented
 			"openai-responses", // not implemented

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -13,6 +13,7 @@ import {
 	geminiModels,
 	geminiDefaultModelId,
 	// kilocode_change start
+	githubCopilotModels,
 	syntheticDefaultModelId,
 	ovhCloudAiEndpointsDefaultModelId,
 	inceptionDefaultModelId,
@@ -522,6 +523,18 @@ function getSelectedModel({
 			const info = openAiCodexModels[id as keyof typeof openAiCodexModels]
 			return { id, info }
 		}
+		// kilocode_change start
+		case "github-copilot": {
+			const id = getValidatedModelId(
+				apiConfiguration.githubCopilotModelId,
+				routerModels["github-copilot"],
+				defaultModelId,
+			)
+			const info =
+				routerModels["github-copilot"]?.[id] ?? githubCopilotModels[id as keyof typeof githubCopilotModels]
+			return { id, info }
+		}
+		// kilocode_change end
 		case "vercel-ai-gateway": {
 			const id = getValidatedModelId(
 				apiConfiguration.vercelAiGatewayModelId,

--- a/webview-ui/src/utils/__tests__/validate.spec.ts
+++ b/webview-ui/src/utils/__tests__/validate.spec.ts
@@ -78,6 +78,7 @@ describe("Model Validation Functions", () => {
 		"io-intelligence": {},
 		"vercel-ai-gateway": {},
 		huggingface: {},
+		"github-copilot": {},
 		// kilocode_change start
 		ovhcloud: {},
 		gemini: {},


### PR DESCRIPTION
## Context

Add GitHub Copilot as a new API provider for the **CLI**, allowing users to leverage their existing GitHub Copilot subscription to access models via the Kilo Code CLI.

This enables users who already have GitHub Copilot to use it directly without needing separate API keys from other providers.

## Implementation

### Architecture

1. **Types & Schemas** (`packages/types`, `packages/core-schemas`)
   - Added GitHub Copilot provider fields (OAuth token + model ID) to provider schemas/types
   - Added `github-copilot` to provider enums and validation schemas

2. **CLI** (`cli/src/`)
   - OAuth device flow authentication (`cli/src/auth/providers/github-copilot/`)
   - Dynamic model listing via `kilo models` command
   - Config schema updates for storing GitHub OAuth tokens

3. **Extension Core** (`src/api/providers/`) - Provider backend, no UI
   - `github-copilot.ts` - Provider class extending OpenAI-compatible base, with automatic Copilot token refresh
   - `github-copilot-auth.ts` - Token exchange utilities
   - `fetchers/github-copilot.ts` - Dynamic model fetching from Copilot API

### Token Flow

```
GitHub OAuth access token (stored as secret)
         ↓
   Token Exchange API
         ↓
Copilot API token (short-lived, cached in memory)
         ↓
   Copilot Chat API
```

The Copilot API token is refreshed on demand when it is missing or nearing expiration (1-minute buffer).

### Key Design Decisions

- **Extends OpenAI-compatible provider**: GitHub Copilot API is OpenAI-compatible, so we extend the existing OpenAI router provider to reuse streaming/message handling logic
- **Lazy token refresh**: Copilot tokens are refreshed on-demand, not proactively, to avoid unnecessary API calls

## Screenshots
```
? Select an AI provider:
❯ Kilo Gateway
  Kilo Gateway (Manual)
  GitHub Copilot (OAuth)
  Anthropic
  OpenAI
  OpenAI - ChatGPT Plus/Pro
  OpenAI Compatible (Responses)
  OpenRouter
```

```
✔ Select an AI provider: GitHub Copilot (OAuth)                                
🔐 Starting GitHub Copilot authentication...
Opening browser for GitHub authentication...                                   
Visit: https://github.com/login/device                                                                                                                        
                                                                               
Enter code: D371-55A0                                        
⚠️  Could not open browser automatically. Please open the URL manually.                                                                                        
Waiting for authorization... ⏳ (14:32 remaining)
```

## How to Test

### CLI Authentication

```bash
# Authenticate with GitHub
kilo auth
# Choose "GitHub Copilot" in the prompt

# Verify models are fetched
kilo models --provider github-copilot
```

### Unit Tests

```bash
# CLI tests
cd cli && pnpm test src/auth/__tests__/github-copilot.test.ts

# Extension provider tests
cd src && pnpm test api/providers/utils/__tests__/github-copilot-auth.spec.ts
cd src && pnpm test api/providers/fetchers/__tests__/github-copilot.spec.ts
```

## Get in Touch

@PeterDaveHello 