### PR TITLE
Fix double scroll bar in ModelSelector and KiloProfileSelector

### DIFF
--- a/.changeset/fix-model-selector-double-scroll-bar.md
+++ b/.changeset/fix-model-selector-double-scroll-bar.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix double scroll bar in ModelSelector and KiloProfileSelector by increasing max-height.

--- a/webview-ui/src/components/kilocode/chat/KiloProfileSelector.tsx
+++ b/webview-ui/src/components/kilocode/chat/KiloProfileSelector.tsx
@@ -104,7 +104,7 @@ export const KiloProfileSelector = ({
 						vscode.postMessage({ type: "loadApiConfigurationById", text: value })
 					}
 				}}
-				contentClassName="max-h-[300px] overflow-y-auto"
+				contentClassName="max-h-[400px] overflow-y-auto"
 				// kilocode_change start - VSC Theme
 				triggerClassName={cn(
 					"w-full text-ellipsis overflow-hidden",

--- a/webview-ui/src/components/kilocode/chat/ModelSelector.tsx
+++ b/webview-ui/src/components/kilocode/chat/ModelSelector.tsx
@@ -142,7 +142,7 @@ export const ModelSelector = ({
 			title={t("chat:selectApiConfig")}
 			options={options}
 			onChange={onChange}
-			contentClassName="max-h-[300px] overflow-y-auto"
+			contentClassName="max-h-[400px] overflow-y-auto"
 			triggerClassName={cn(
 				"w-full text-ellipsis overflow-hidden p-0",
 				"bg-transparent border-transparent hover:bg-transparent hover:border-transparent",


### PR DESCRIPTION
# Fix double scroll bar in ModelSelector and KiloProfileSelector

## Context

Double scroll bars were appearing in the model and profile selection dropdowns on the front page. This occurred because both the outer popover container and the inner list container had `overflow-y-auto` enabled and the outer container's `max-height` was smaller than the inner one's, causing both to trigger scrollbars when the list was long.

## Implementation

I resolved this by increasing the `max-height` of the outer container to `400px` in [`ModelSelector.tsx`](webview-ui/src/components/kilocode/chat/ModelSelector.tsx) and [`KiloProfileSelector.tsx`](webview-ui/src/components/kilocode/chat/KiloProfileSelector.tsx). This ensures the outer container is tall enough to accommodate the inner scrollable list (which has a default `max-height` of `max-h-82` or ~328px) without triggering its own scrollbar.

This change ensures that only the inner container handles scrolling, providing a cleaner and more standard user experience.

## Screenshots

| before | after |
| ------ | ----- |
| <img width="304" height="338" alt="image" src="https://github.com/user-attachments/assets/48c9f66a-c4f4-430e-8015-65869695db49" /> | <img width="301" height="414" alt="image" src="https://github.com/user-attachments/assets/502f2090-4c2f-4793-b0a5-f663ac679440" /> |

## How to Test

1.  Open the Kilo Code extension to the front page.
2.  Click on the model selector in the bottom left corner.
3.  Ensure you have enough models or profiles to require scrolling.
4.  Verify that only one scroll bar is visible and functional.
5.  Repeat the same check for the profile selector.
