### PR TITLE
fix: mode create dialog text fields clearing while typing

### DIFF
--- a/.changeset/fix-mode-create-role-definition.md
+++ b/.changeset/fix-mode-create-role-definition.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix mode create dialog text fields clearing while typing

--- a/webview-ui/src/components/modes/ModesView.tsx
+++ b/webview-ui/src/components/modes/ModesView.tsx
@@ -1572,7 +1572,10 @@ const ModesView = ({ hideHeader = false }: { hideHeader?: boolean }) => {
 									resize="vertical"
 									value={newModeRoleDefinition}
 									onChange={(e) => {
-										setNewModeRoleDefinition((e.target as HTMLTextAreaElement).value)
+										const value =
+											(e as unknown as CustomEvent)?.detail?.target?.value ??
+											((e as any).target as HTMLTextAreaElement).value
+										setNewModeRoleDefinition(value)
 									}}
 									rows={4}
 									className="w-full"
@@ -1610,7 +1613,10 @@ const ModesView = ({ hideHeader = false }: { hideHeader?: boolean }) => {
 									resize="vertical"
 									value={newModeWhenToUse}
 									onChange={(e) => {
-										setNewModeWhenToUse((e.target as HTMLTextAreaElement).value)
+										const value =
+											(e as unknown as CustomEvent)?.detail?.target?.value ??
+											((e as any).target as HTMLTextAreaElement).value
+										setNewModeWhenToUse(value)
 									}}
 									rows={3}
 									className="w-full"
@@ -1657,7 +1663,10 @@ const ModesView = ({ hideHeader = false }: { hideHeader?: boolean }) => {
 									resize="vertical"
 									value={newModeCustomInstructions}
 									onChange={(e) => {
-										setNewModeCustomInstructions((e.target as HTMLTextAreaElement).value)
+										const value =
+											(e as unknown as CustomEvent)?.detail?.target?.value ??
+											((e as any).target as HTMLTextAreaElement).value
+										setNewModeCustomInstructions(value)
 									}}
 									rows={4}
 									className="w-full"


### PR DESCRIPTION
The VSCodeTextArea components in the create mode dialog were using incorrect event value extraction. VSCode webview toolkit components fire CustomEvents where the value is in e.detail.target.value, not e.target.value directly.

Updated the onChange handlers for Role Definition, When To Use, and Custom Instructions fields to use the correct pattern that's already used elsewhere in the codebase.


Warning: vibed & untested as of yet