### PR TITLE
For docs only changes, request a docs/ branch name

### DIFF
--- a/apps/kilocode-docs/AGENTS.md
+++ b/apps/kilocode-docs/AGENTS.md
@@ -6,6 +6,16 @@ This is the Kilo Code documentation site. Kilo Code is the leading open source a
 
 The dev server is run with `bun dev` and runs on `http://localhost:3002`. Typically the user will be running it themselves, so always check if it is running FIRST before deciding to run it yourself to test something.
 
+## Branch Naming Convention
+
+When making changes _only_ to the documentation, create branches with the `docs/` prefix:
+
+```bash
+git checkout -b docs/description-of-change
+```
+
+This convention helps identify documentation-only PRs and keeps them organized.
+
 ## Markdoc Custom Tags
 
 This project uses [Markdoc](https://markdoc.dev/) for rendering markdown with custom components. Custom tags allow you to embed React components directly in markdown files.

--- a/apps/kilocode-docs/README.md
+++ b/apps/kilocode-docs/README.md
@@ -37,3 +37,19 @@ The quickest way to deploy your own version of this boilerplate is by deploying 
 ### Deploy to Netlify
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/markdoc/next.js-starter)
+
+## Contributing
+
+When making documentation _only_ changes, use branch names prefixed with `docs/`:
+
+```bash
+git checkout -b docs/your-change-description
+```
+
+Examples:
+
+- `docs/add-mcp-tutorial`
+- `docs/fix-installation-steps`
+- `docs/update-api-reference`
+
+For full contribution guidelines, see the [Contributing Guide](https://kilo.ai/docs/contributing).

--- a/apps/kilocode-docs/pages/contributing/index.md
+++ b/apps/kilocode-docs/pages/contributing/index.md
@@ -32,9 +32,13 @@ Before diving into the code, we recommend reviewing the [Architecture Overview](
 
 - Create a new branch for each feature or bugfix
 - Use descriptive branch names (e.g., `feature/new-tool-support` or `fix/browser-action-bug`)
+- **For documentation only changes**: Use the `docs/` prefix (e.g., `docs/improve-mcp-guide`)
 
 ```bash
 git checkout -b your-branch-name
+
+# For documentation changes:
+git checkout -b docs/your-change-description
 ```
 
 ### Coding Standards


### PR DESCRIPTION
The idea here is to *try* and organize docs-only changes to `docs/` branches