### PR TITLE
docs: expand task todo list guidance

### DIFF
--- a/apps/kilocode-docs/pages/code-with-ai/features/task-todo-list.md
+++ b/apps/kilocode-docs/pages/code-with-ai/features/task-todo-list.md
@@ -1,4 +1,4 @@
---- <!-- kilocode_change -->
+--- 
 title: "Task Todo List"
 description: "Track and manage tasks with AI-generated todo lists"
 ---

--- a/apps/kilocode-docs/pages/code-with-ai/features/task-todo-list.md
+++ b/apps/kilocode-docs/pages/code-with-ai/features/task-todo-list.md
@@ -69,19 +69,19 @@ Background "REMINDERS" table that keeps Kilo informed about current progress
 
 ## Task status decoded
 
-**Pending** â†’ Empty checkbox (not started)
+**Pending** -> Empty checkbox (not started)
 
 {% image src="/docs/img/task-todo-list/not-started.png" alt="Pending todo item with empty checkbox" width="300" /%}
 
 ---
 
-**In Progress** â†’ Yellow dot (currently working)
+**In Progress** -> Yellow dot (currently working)
 
 {% image src="/docs/img/task-todo-list/in-progress.png" alt="In progress todo item with yellow dot indicator" width="300" /%}
 
 ---
 
-**Completed** â†’ Green checkmark (finished)
+**Completed** -> Green checkmark (finished)
 
 {% image src="/docs/img/task-todo-list/complete.png" alt="Completed todo item with green checkmark" width="300" /%}
 

--- a/apps/kilocode-docs/pages/code-with-ai/features/task-todo-list.md
+++ b/apps/kilocode-docs/pages/code-with-ai/features/task-todo-list.md
@@ -1,4 +1,4 @@
-﻿---
+--- <!-- kilocode_change -->
 title: "Task Todo List"
 description: "Track and manage tasks with AI-generated todo lists"
 ---

--- a/apps/kilocode-docs/pages/code-with-ai/features/task-todo-list.md
+++ b/apps/kilocode-docs/pages/code-with-ai/features/task-todo-list.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Task Todo List"
 description: "Track and manage tasks with AI-generated todo lists"
 ---
@@ -28,6 +28,18 @@ description: "Track and manage tasks with AI-generated todo lists"
 
 ---
 
+## How todo lists are updated
+
+Todo lists are managed with the [`update_todo_list` tool](/docs/features/tools/update-todo-list). Each time Kilo updates the list, it replaces the entire checklist with the latest view of the task.
+
+Kilo updates the list when:
+
+- New steps are discovered
+- Items are completed or reprioritized
+- You explicitly ask for a todo list
+
+---
+
 ## The old way vs. the new way
 
 **Before**: You juggled task steps in your head or scattered notes, constantly wondering "what's next?"
@@ -43,6 +55,8 @@ Quick progress overview with your next important item
 
 {% image src="/docs/img/task-todo-list/task-header.png" alt="Task header summary showing todo list progress" width="500" /%}
 
+Click the task header summary to expand the full list inline and jump to the current item.
+
 **2. Interactive Tool Block**
 Full todo interface in chat where you can:
 
@@ -55,23 +69,27 @@ Background "REMINDERS" table that keeps Kilo informed about current progress
 
 ## Task status decoded
 
-**Pending** → Empty checkbox (not started)
+**Pending** â†’ Empty checkbox (not started)
 
 {% image src="/docs/img/task-todo-list/not-started.png" alt="Pending todo item with empty checkbox" width="300" /%}
 
 ---
 
-**In Progress** → Yellow dot (currently working)
+**In Progress** â†’ Yellow dot (currently working)
 
 {% image src="/docs/img/task-todo-list/in-progress.png" alt="In progress todo item with yellow dot indicator" width="300" /%}
 
 ---
 
-**Completed** → Green checkmark (finished)
+**Completed** â†’ Green checkmark (finished)
 
 {% image src="/docs/img/task-todo-list/complete.png" alt="Completed todo item with green checkmark" width="300" /%}
 
 ---
+
+## Editing todo lists
+
+When Kilo proposes a todo list update, you can edit the list before approving. Use the "Edit" button in the tool block to update item text, add or remove steps, or adjust status. Once approved, Kilo continues with the updated list.
 
 ## Common questions
 
@@ -86,6 +104,10 @@ Design choice. Kilo maintains authority over task management to ensure consisten
 
 ---
 
+## Settings
+
+You can disable todo lists in Settings -> Advanced -> **Enable todo list tool**. When disabled, Kilo won't create or update todo lists, and the REMINDERS table won't appear in Environment Details.
+
 {% callout type="tip" title="Pro tip: Auto-approval" %}
 **What it does**: Automatically approves todo list updates without confirmation prompts.
 
@@ -95,3 +117,4 @@ Design choice. Kilo maintains authority over task management to ensure consisten
 
 **The catch**: Less control, but faster execution.
 {% /callout %}
+


### PR DESCRIPTION
﻿## Context

Closes #2149.

Add missing documentation around task todo lists: how they update, where they appear, how to edit, and where to disable them.

## Implementation

Expanded the Task Todo List docs with sections on update behavior, header interaction, editing flow, and settings. No product behavior changes.

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

- Open `/docs/code-with-ai/features/task-todo-list`
- Confirm the new sections: "How todo lists are updated", "Editing todo lists", and "Settings"
- Verify links render and flow reads cleanly

## Get in Touch

Discord: not on Discord
