### PR TITLE
docs: add kilocodeignore documentation

### DIFF
--- a/apps/kilocode-docs/lib/nav/customize.ts
+++ b/apps/kilocode-docs/lib/nav/customize.ts
@@ -33,6 +33,10 @@ export const CustomizeNav: NavSection[] = [
 				href: "/customize/context/codebase-indexing",
 				children: "Codebase Indexing",
 			},
+			{
+				href: "/customize/context/kilocodeignore",
+				children: ".kilocodeignore",
+			},
 			{ href: "/customize/context/memory-bank", children: "Memory Bank" },
 			{
 				href: "/customize/context/large-projects",

--- a/apps/kilocode-docs/pages/customize/context/codebase-indexing.md
+++ b/apps/kilocode-docs/pages/customize/context/codebase-indexing.md
@@ -148,7 +148,7 @@ The indexer automatically excludes:
 - Large files (&gt;1MB)
 - Git repositories (`.git` folders)
 - Dependencies (`node_modules`, `vendor`, etc.)
-- Files matching `.gitignore` and `.kilocodeignore` patterns
+- Files matching `.gitignore` and [`.kilocodeignore`](/docs/customize/context/kilocodeignore) patterns
 
 ### Incremental Updates
 

--- a/apps/kilocode-docs/pages/customize/context/kilocodeignore.md
+++ b/apps/kilocode-docs/pages/customize/context/kilocodeignore.md
@@ -1,0 +1,74 @@
+---
+title: ".kilocodeignore"
+description: "Control which files Kilo Code can access"
+---
+
+# .kilocodeignore
+
+## Overview
+
+`.kilocodeignore` is a root-level file that tells Kilo Code which files and folders it should not access. It uses standard `.gitignore` pattern syntax, but it only affects Kilo Code's file access, not Git.
+
+If no `.kilocodeignore` file exists, Kilo Code can access all files in the workspace.
+
+## Quick Start
+
+1. Create a `.kilocodeignore` file at the root of your project.
+2. Add patterns for files or folders you want Kilo Code to avoid.
+3. Save the file. Kilo Code will pick up the changes automatically.
+
+Example:
+
+```txt
+# Secrets
+.env
+secrets/
+**/*.pem
+**/*.key
+
+# Build output
+dist/
+coverage/
+
+# Allow a specific file inside a blocked folder
+!secrets/README.md
+```
+
+## Pattern Rules
+
+`.kilocodeignore` follows the same rules as `.gitignore`:
+
+- `#` starts a comment
+- `*` and `**` match wildcards
+- Trailing `/` matches directories only
+- `!` negates a previous rule
+
+Patterns are evaluated relative to the workspace root.
+
+## What It Affects
+
+Kilo Code checks `.kilocodeignore` before accessing files in tools like:
+
+- [`read_file`](/docs/automate/tools/read-file)
+- [`write_to_file`](/docs/automate/tools/write-to-file)
+- [`apply_diff`](/docs/automate/tools/apply-diff)
+- [`delete_file`](/docs/automate/tools/delete-file)
+- [`execute_command`](/docs/automate/tools/execute-command)
+- [`list_files`](/docs/automate/tools/list-files)
+
+If a file is blocked, Kilo Code will return an "access denied" message and suggest updating your `.kilocodeignore` rules.
+
+## Visibility in Lists
+
+By default, ignored files are hidden from file lists. You can show them with a lock icon by enabling:
+
+Settings -> Context -> **Show .kilocodeignore'd files in lists and searches**
+
+## Checkpoints vs .kilocodeignore
+
+Checkpoint tracking is separate from file access rules. Files blocked by `.kilocodeignore` can still be checkpointed if they are not excluded by `.gitignore`. See the [Checkpoints](/docs/code-with-ai/features/checkpoints) documentation for details.
+
+## Troubleshooting
+
+- **Kilo can't access a file you want:** Remove or narrow the matching rule in `.kilocodeignore`.
+- **A file still appears in lists:** Check the setting that shows ignored files in lists and searches.


### PR DESCRIPTION
﻿## Context

Closes #2150.

Add a dedicated .kilocodeignore docs page and make it discoverable from the Context & Indexing nav.

## Implementation

- Added `/docs/customize/context/kilocodeignore` with overview, syntax, examples, and troubleshooting
- Linked to the new page from Codebase Indexing
- Added the page to the Customize navigation

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

- Open `/docs/customize/context/kilocodeignore`
- Verify the page renders and links resolve
- Confirm the page appears under Customize -> Context & Indexing

## Get in Touch

Discord: not on Discord
