### PR TITLE
docs: update codebase indexing access steps

### DIFF
--- a/apps/kilocode-docs/pages/customize/context/codebase-indexing.md
+++ b/apps/kilocode-docs/pages/customize/context/codebase-indexing.md
@@ -97,16 +97,22 @@ For team or production use:
 
 ## Configuration
 
-1. Open Kilo Code settings (<Codicon name="gear" /> icon)
-2. Navigate to **Codebase Indexing** section
-3. Enable **"Enable Codebase Indexing"** using the toggle switch
-4. Configure your embedding provider:
+### Open Codebase Indexing Settings
+
+1. In the chat header, click the database icon (indexing status)
+2. The Codebase Indexing settings panel opens
+3. If you don't see the icon, open Kilo Code settings (<Codicon name="gear" />) and search for **Codebase Indexing**
+
+### Configure Settings
+
+1. Enable **"Enable Codebase Indexing"** using the toggle switch
+2. Configure your embedding provider:
     - **OpenAI**: Enter API key and select model
     - **Gemini**: Enter Google AI API key and select embedding model
     - **Ollama**: Enter base URL and select model
-5. Set Qdrant URL and optional API key
-6. Configure **Max Search Results** (default: 20, range: 1-100)
-7. Click **Save** to start initial indexing
+3. Set Qdrant URL and optional API key
+4. Configure **Max Search Results** (default: 20, range: 1-100)
+5. Click **Save** to start initial indexing
 
 ### Enable/Disable Toggle
 


### PR DESCRIPTION
﻿## Context

Closes #2146.

Update the Codebase Indexing docs to reflect the current access path (database icon in the chat header), not a separate settings tab.

## Implementation

- Added an "Open Codebase Indexing Settings" section with the chat header entry point
- Kept the existing configuration steps but clarified where to open the panel

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

- Open `/docs/customize/context/codebase-indexing`
- Verify the configuration section references the chat header database icon
- Confirm the steps are still accurate and readable

## Get in Touch

Discord: not on Discord
