### PR TITLE
docs: fix missing how-tools-work image

### DIFF
--- a/apps/kilocode-docs/pages/automate/how-tools-work.md
+++ b/apps/kilocode-docs/pages/automate/how-tools-work.md
@@ -30,9 +30,9 @@ Describe what you want to accomplish in natural language, and Kilo Code will:
 
 Here's how a typical tool interaction works:
 
-<img src="/docs/img/how-tools-work/how-tools-work.png" alt="Tool approval interface showing Save and Reject buttons along with Auto-approve checkbox" width="600" />
-
-_The tool approval interface shows Save/Reject buttons and Auto-approve options._
+{% callout type="info" title="Tool Approval UI" %}
+When a tool is proposed, you'll see Save and Reject buttons along with an optional Auto-approve checkbox for trusted operations.
+{% /callout %}
 
 **User:** Create a file named `greeting.js` that logs a greeting message
 


### PR DESCRIPTION
﻿## Context

Closes #2152.

Fix the broken image on the How Tools Work page by replacing it with a Markdoc callout that describes the tool approval UI.

## Implementation

- Removed the missing image reference
- Added an info callout describing the Save/Reject/Auto-approve UI

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

- Open `/docs/automate/how-tools-work`
- Confirm the broken image no longer appears
- Verify the callout renders and reads correctly

## Get in Touch

Discord: not on Discord
