### PR TITLE
fix(ui): prevent TypeError when trimming input during model switching (#5614)

### DIFF
--- a/.changeset/famous-tomatoes-join.md
+++ b/.changeset/famous-tomatoes-join.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix(ui): prevent TypeError when trimming input during model switching (#5614)

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -451,7 +451,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		}, [selectedType, searchQuery])
 
 		const handleEnhancePrompt = useCallback(() => {
-			const trimmedInput = inputValue.trim()
+			const trimmedInput = inputValue?.trim() ?? ""
 
 			if (trimmedInput) {
 				setIsEnhancingPrompt(true)


### PR DESCRIPTION
Fixes #5614.

Prevents a TypeError caused by calling `.trim()` on an undefined value
during model switching in ChatTextArea.

Change:
- Replace `inputValue.trim()` with `inputValue?.trim() ?? ""`

Why safe:
- Only affects undefined/null cases that previously crashed.
- Preserves behavior for valid strings.
- Minimal and localized diff.
