### PR TITLE
fix: context condensing prompt not saving properly

### DIFF
--- a/.changeset/fix-condensing-prompt.md
+++ b/.changeset/fix-condensing-prompt.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix context condensing prompt not saving properly


### PR DESCRIPTION
Fixes #5629

## Problem
Context condensing prompt was clearing out and not saving properly when typing.

## Root Cause
The VSCodeTextArea was directly controlled by extension state. Every keystroke triggered a save to extension state → webview re-render → race condition caused text to clear.

## Solution
- Added local React state buffer (localCondensingPrompt)
- Update local state on input (smooth typing, no flicker)  
- Sync with extension state on blur (save when done typing)
- Initialize local state when switching to CONDENSE tab

## Changes
- Modified: webview-ui/src/components/settings/PromptsSettings.tsx

## Testing
- [x] Type in CONDENSE textarea - no longer clears while typing
- [x] Click outside (blur) - saves properly to extension state
- [x] Switch tabs and back - value persists correctly
- [x] Reset button works correctly