### PR TITLE
feat(agent-manager): add YOLO mode toggle and session rename

### DIFF
--- a/.changeset/agent-manager-yolo-toggle.md
+++ b/.changeset/agent-manager-yolo-toggle.md
@@ -1,0 +1,16 @@
+---
+"kilo-code": minor
+---
+
+feat(agent-manager): add YOLO mode toggle and session rename
+
+**New Features:**
+
+- Add YOLO mode toggle button in new agent form to enable/disable auto-approval of tools
+- Add YOLO mode indicator (⚡) in session header and sidebar for sessions running in YOLO mode
+- Add inline session rename - click on session title to edit
+
+**Technical Details:**
+
+- `yoloMode` maps to `autoApprove` config in agent-runtime
+- Added translations for all 22 supported locales

--- a/packages/core-schemas/src/agent-manager/types.ts
+++ b/packages/core-schemas/src/agent-manager/types.ts
@@ -47,6 +47,7 @@ export const agentSessionSchema = z.object({
 	gitUrl: z.string().optional(),
 	model: z.string().optional(), // Model ID used for this session
 	mode: z.string().optional(), // Mode slug used for this session (e.g., "code", "architect")
+	yoloMode: z.boolean().optional(), // True if session was started with auto-approval enabled
 })
 
 /**
@@ -58,6 +59,7 @@ export const pendingSessionSchema = z.object({
 	startTime: z.number(),
 	parallelMode: z.boolean().optional(),
 	gitUrl: z.string().optional(),
+	yoloMode: z.boolean().optional(), // True if session will be started with auto-approval enabled
 })
 
 /**
@@ -84,6 +86,7 @@ export const startSessionMessageSchema = z.object({
 	versions: z.number().optional(), // Number of versions for multi-version mode
 	labels: z.array(z.string()).optional(), // Labels for multi-version sessions
 	images: z.array(z.string()).optional(), // Image data URLs to include with the prompt
+	yoloMode: z.boolean().optional(), // True to enable auto-approval (default: true)
 })
 
 export const agentManagerMessageSchema = z.discriminatedUnion("type", [

--- a/src/core/kilocode/agent-manager/AgentRegistry.ts
+++ b/src/core/kilocode/agent-manager/AgentRegistry.ts
@@ -5,6 +5,7 @@ export interface CreateSessionOptions {
 	parallelMode?: boolean
 	model?: string
 	mode?: string
+	yoloMode?: boolean
 }
 
 const MAX_SESSIONS = 10
@@ -38,6 +39,7 @@ export class AgentRegistry {
 			startTime: Date.now(),
 			parallelMode: options?.parallelMode,
 			gitUrl: options?.gitUrl,
+			yoloMode: options?.yoloMode,
 		}
 		return this._pendingSession
 	}
@@ -72,6 +74,7 @@ export class AgentRegistry {
 			gitUrl: options?.gitUrl,
 			model: options?.model,
 			mode: options?.mode ?? DEFAULT_MODE_SLUG,
+			yoloMode: options?.yoloMode,
 		}
 
 		this.sessions.set(sessionId, session)
@@ -158,6 +161,18 @@ export class AgentRegistry {
 			return undefined
 		}
 		session.mode = mode
+		return session
+	}
+
+	/**
+	 * Update the label for a session (inline rename).
+	 */
+	public updateSessionLabel(sessionId: string, label: string): AgentSession | undefined {
+		const session = this.sessions.get(sessionId)
+		if (!session) {
+			return undefined
+		}
+		session.label = label
 		return session
 	}
 

--- a/src/core/kilocode/agent-manager/RuntimeProcessHandler.ts
+++ b/src/core/kilocode/agent-manager/RuntimeProcessHandler.ts
@@ -81,6 +81,7 @@ interface PendingProcessInfo {
 	prompt: string
 	startTime: number
 	parallelMode?: boolean
+	yoloMode?: boolean
 	desiredSessionId?: string
 	desiredLabel?: string
 	worktreeInfo?: { branch: string; path: string; parentBranch: string }
@@ -296,6 +297,7 @@ export class RuntimeProcessHandler {
 		options:
 			| {
 					parallelMode?: boolean
+					yoloMode?: boolean
 					sessionId?: string
 					label?: string
 					gitUrl?: string
@@ -321,6 +323,7 @@ export class RuntimeProcessHandler {
 			} else {
 				this.registry.createSession(options!.sessionId!, prompt, Date.now(), {
 					parallelMode: options?.parallelMode,
+					yoloMode: options?.yoloMode,
 					labelOverride: options?.label,
 					gitUrl: options?.gitUrl,
 					model: options?.model,
@@ -342,13 +345,18 @@ export class RuntimeProcessHandler {
 		} else {
 			const pendingSession = this.registry.setPendingSession(prompt, {
 				parallelMode: options?.parallelMode,
+				yoloMode: options?.yoloMode,
 				gitUrl: options?.gitUrl,
 			})
 			this.callbacks.onPendingSessionChanged(pendingSession)
 		}
 
 		// Build agent configuration
-		const agentConfig = this.buildAgentConfig(workspace, prompt, options)
+		// Map yoloMode to autoApprove for the agent config
+		const agentConfig = this.buildAgentConfig(workspace, prompt, {
+			...options,
+			autoApprove: options?.yoloMode,
+		})
 
 		// Get process entry point path
 		const entryPath = this.getProcessEntryPath()
@@ -373,6 +381,7 @@ export class RuntimeProcessHandler {
 				prompt,
 				startTime: Date.now(),
 				parallelMode: options?.parallelMode,
+				yoloMode: options?.yoloMode,
 				desiredSessionId: options?.sessionId,
 				desiredLabel: options?.label,
 				worktreeInfo: options?.worktreeInfo,
@@ -506,6 +515,7 @@ export class RuntimeProcessHandler {
 		// Create the session in registry
 		this.registry.createSession(sessionId, prompt, Date.now(), {
 			parallelMode: this.pendingProcess.parallelMode,
+			yoloMode: this.pendingProcess.yoloMode,
 			labelOverride: this.pendingProcess.desiredLabel,
 			gitUrl: this.pendingProcess.gitUrl,
 			model: this.pendingProcess.model,

--- a/webview-ui/src/i18n/locales/ar/agentManager.json
+++ b/webview-ui/src/i18n/locales/ar/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "نعم",
 		"shareConfirmNo": "لا",
 		"options": "خيارات",
-		"configureSetupScript": "سكريبت إعداد Worktree"
+		"configureSetupScript": "سكريبت إعداد Worktree",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "بدء وكيل جديد",
@@ -66,7 +67,10 @@
 		"defaultModel": "النموذج الافتراضي",
 		"loadingModels": "جاري التحميل...",
 		"selectMode": "اختر الوضع",
-		"modeTooltip": "الوضع: {{mode}}"
+		"modeTooltip": "الوضع: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "في انتظار رد الوكيل...",

--- a/webview-ui/src/i18n/locales/ca/agentManager.json
+++ b/webview-ui/src/i18n/locales/ca/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Sí",
 		"shareConfirmNo": "No",
 		"options": "Opcions",
-		"configureSetupScript": "Script de setup del worktree"
+		"configureSetupScript": "Script de setup del worktree",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Iniciar un agent nou",
@@ -62,7 +63,10 @@
 		"defaultModel": "Model per defecte",
 		"loadingModels": "Carregant...",
 		"selectMode": "Selecciona el mode",
-		"modeTooltip": "Mode: {{mode}}"
+		"modeTooltip": "Mode: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "Esperant resposta de l'agent...",

--- a/webview-ui/src/i18n/locales/cs/agentManager.json
+++ b/webview-ui/src/i18n/locales/cs/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Ano",
 		"shareConfirmNo": "Ne",
 		"options": "Možnosti",
-		"configureSetupScript": "Setup skript worktree"
+		"configureSetupScript": "Setup skript worktree",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Spustit nového agenta",
@@ -63,7 +64,10 @@
 		"defaultModel": "Výchozí model",
 		"loadingModels": "Načítání...",
 		"selectMode": "Vybrat režim",
-		"modeTooltip": "Režim: {{mode}}"
+		"modeTooltip": "Režim: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "Čekání na odpověď agenta...",

--- a/webview-ui/src/i18n/locales/de/agentManager.json
+++ b/webview-ui/src/i18n/locales/de/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Ja",
 		"shareConfirmNo": "Nein",
 		"options": "Optionen",
-		"configureSetupScript": "Worktree-Setup-Skript"
+		"configureSetupScript": "Worktree-Setup-Skript",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Einen neuen Agenten starten",
@@ -62,7 +63,10 @@
 		"defaultModel": "Standard-Modell",
 		"loadingModels": "Wird geladen...",
 		"selectMode": "Modus auswählen",
-		"modeTooltip": "Modus: {{mode}}"
+		"modeTooltip": "Modus: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "Warte auf Antwort des Agenten...",

--- a/webview-ui/src/i18n/locales/en/agentManager.json
+++ b/webview-ui/src/i18n/locales/en/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Yes",
 		"shareConfirmNo": "No",
 		"options": "Options",
-		"configureSetupScript": "Worktree Setup Script"
+		"configureSetupScript": "Worktree Setup Script",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Start a new agent",
@@ -62,7 +63,14 @@
 		"defaultModel": "Default model",
 		"loadingModels": "Loading...",
 		"selectMode": "Select mode",
-		"modeTooltip": "Mode: {{mode}}"
+		"modeTooltip": "Mode: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval",
+		"yoloModeOn": "YOLO mode - tools auto-approved",
+		"renameSession": "Rename session",
+		"confirmRename": "Confirm rename",
+		"clickToRename": "Click to rename"
 	},
 	"messages": {
 		"waiting": "Waiting for agent response...",

--- a/webview-ui/src/i18n/locales/es/agentManager.json
+++ b/webview-ui/src/i18n/locales/es/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Sí",
 		"shareConfirmNo": "No",
 		"options": "Opciones",
-		"configureSetupScript": "Script de setup de worktree"
+		"configureSetupScript": "Script de setup de worktree",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Iniciar un nuevo agente",
@@ -62,7 +63,10 @@
 		"defaultModel": "Modelo predeterminado",
 		"loadingModels": "Cargando...",
 		"selectMode": "Seleccionar modo",
-		"modeTooltip": "Modo: {{mode}}"
+		"modeTooltip": "Modo: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "Esperando respuesta del agente...",

--- a/webview-ui/src/i18n/locales/fr/agentManager.json
+++ b/webview-ui/src/i18n/locales/fr/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Oui",
 		"shareConfirmNo": "Non",
 		"options": "Options",
-		"configureSetupScript": "Script de setup worktree"
+		"configureSetupScript": "Script de setup worktree",
+		"yoloMode": "Mode YOLO (approbation auto)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Démarrer un nouvel agent",
@@ -62,7 +63,10 @@
 		"defaultModel": "Modèle par défaut",
 		"loadingModels": "Chargement...",
 		"selectMode": "Sélectionner le mode",
-		"modeTooltip": "Mode : {{mode}}"
+		"modeTooltip": "Mode : {{mode}}",
+		"yoloModeToggle": "Activer/désactiver le mode YOLO",
+		"yoloModeEnabled": "Mode YOLO activé - outils approuvés automatiquement",
+		"yoloModeDisabled": "Mode YOLO désactivé - approbation requise"
 	},
 	"messages": {
 		"waiting": "En attente de la réponse de l'agent...",

--- a/webview-ui/src/i18n/locales/hi/agentManager.json
+++ b/webview-ui/src/i18n/locales/hi/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "हाँ",
 		"shareConfirmNo": "नहीं",
 		"options": "विकल्प",
-		"configureSetupScript": "Worktree सेटअप स्क्रिप्ट"
+		"configureSetupScript": "Worktree सेटअप स्क्रिप्ट",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "नया एजेंट शुरू करें",
@@ -62,7 +63,10 @@
 		"defaultModel": "डिफ़ॉल्ट मॉडल",
 		"loadingModels": "लोड हो रहा है...",
 		"selectMode": "मोड चुनें",
-		"modeTooltip": "मोड: {{mode}}"
+		"modeTooltip": "मोड: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "एजेंट की प्रतिक्रिया की प्रतीक्षा में...",

--- a/webview-ui/src/i18n/locales/id/agentManager.json
+++ b/webview-ui/src/i18n/locales/id/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Ya",
 		"shareConfirmNo": "Tidak",
 		"options": "Opsi",
-		"configureSetupScript": "Skrip setup worktree"
+		"configureSetupScript": "Skrip setup worktree",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Mulai agen baru",
@@ -62,7 +63,10 @@
 		"defaultModel": "Model default",
 		"loadingModels": "Memuat...",
 		"selectMode": "Pilih mode",
-		"modeTooltip": "Mode: {{mode}}"
+		"modeTooltip": "Mode: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "Menunggu respons agen...",

--- a/webview-ui/src/i18n/locales/it/agentManager.json
+++ b/webview-ui/src/i18n/locales/it/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Sì",
 		"shareConfirmNo": "No",
 		"options": "Opzioni",
-		"configureSetupScript": "Script di setup worktree"
+		"configureSetupScript": "Script di setup worktree",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Avvia un nuovo agente",
@@ -62,7 +63,10 @@
 		"defaultModel": "Modello predefinito",
 		"loadingModels": "Caricamento...",
 		"selectMode": "Seleziona modalità",
-		"modeTooltip": "Modalità: {{mode}}"
+		"modeTooltip": "Modalità: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "In attesa della risposta dell'agente...",

--- a/webview-ui/src/i18n/locales/ja/agentManager.json
+++ b/webview-ui/src/i18n/locales/ja/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "はい",
 		"shareConfirmNo": "いいえ",
 		"options": "オプション",
-		"configureSetupScript": "Worktree セットアップスクリプト"
+		"configureSetupScript": "Worktree セットアップスクリプト",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "新しいエージェントを開始",
@@ -62,7 +63,10 @@
 		"defaultModel": "デフォルトモデル",
 		"loadingModels": "読み込み中...",
 		"selectMode": "モードを選択",
-		"modeTooltip": "モード: {{mode}}"
+		"modeTooltip": "モード: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "エージェントの応答を待っています...",

--- a/webview-ui/src/i18n/locales/ko/agentManager.json
+++ b/webview-ui/src/i18n/locales/ko/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "예",
 		"shareConfirmNo": "아니요",
 		"options": "옵션",
-		"configureSetupScript": "Worktree 설정 스크립트"
+		"configureSetupScript": "Worktree 설정 스크립트",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "새 에이전트 시작",
@@ -62,7 +63,10 @@
 		"defaultModel": "기본 모델",
 		"loadingModels": "로딩 중...",
 		"selectMode": "모드 선택",
-		"modeTooltip": "모드: {{mode}}"
+		"modeTooltip": "모드: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "에이전트 응답 대기 중...",

--- a/webview-ui/src/i18n/locales/nl/agentManager.json
+++ b/webview-ui/src/i18n/locales/nl/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Ja",
 		"shareConfirmNo": "Nee",
 		"options": "Opties",
-		"configureSetupScript": "Worktree setup-script"
+		"configureSetupScript": "Worktree setup-script",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Een nieuwe agent starten",
@@ -62,7 +63,10 @@
 		"defaultModel": "Standaardmodel",
 		"loadingModels": "Laden...",
 		"selectMode": "Selecteer modus",
-		"modeTooltip": "Modus: {{mode}}"
+		"modeTooltip": "Modus: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "Wachten op antwoord van agent...",

--- a/webview-ui/src/i18n/locales/pl/agentManager.json
+++ b/webview-ui/src/i18n/locales/pl/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Tak",
 		"shareConfirmNo": "Nie",
 		"options": "Opcje",
-		"configureSetupScript": "Skrypt setup worktree"
+		"configureSetupScript": "Skrypt setup worktree",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Uruchom nowego agenta",
@@ -64,7 +65,10 @@
 		"defaultModel": "Domyślny model",
 		"loadingModels": "Ładowanie...",
 		"selectMode": "Wybierz tryb",
-		"modeTooltip": "Tryb: {{mode}}"
+		"modeTooltip": "Tryb: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "Oczekiwanie na odpowiedź agenta...",

--- a/webview-ui/src/i18n/locales/pt-BR/agentManager.json
+++ b/webview-ui/src/i18n/locales/pt-BR/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Sim",
 		"shareConfirmNo": "Não",
 		"options": "Opções",
-		"configureSetupScript": "Script de setup do worktree"
+		"configureSetupScript": "Script de setup do worktree",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Iniciar um novo agente",
@@ -62,7 +63,10 @@
 		"defaultModel": "Modelo padrão",
 		"loadingModels": "Carregando...",
 		"selectMode": "Selecionar modo",
-		"modeTooltip": "Modo: {{mode}}"
+		"modeTooltip": "Modo: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "Aguardando resposta do agente...",

--- a/webview-ui/src/i18n/locales/ru/agentManager.json
+++ b/webview-ui/src/i18n/locales/ru/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Да",
 		"shareConfirmNo": "Нет",
 		"options": "Параметры",
-		"configureSetupScript": "Скрипт настройки worktree"
+		"configureSetupScript": "Скрипт настройки worktree",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Запустить нового агента",
@@ -64,7 +65,10 @@
 		"defaultModel": "Модель по умолчанию",
 		"loadingModels": "Загрузка...",
 		"selectMode": "Выбрать режим",
-		"modeTooltip": "Режим: {{mode}}"
+		"modeTooltip": "Режим: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "Ожидание ответа агента...",

--- a/webview-ui/src/i18n/locales/th/agentManager.json
+++ b/webview-ui/src/i18n/locales/th/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "ใช่",
 		"shareConfirmNo": "ไม่",
 		"options": "ตัวเลือก",
-		"configureSetupScript": "สคริปต์ตั้งค่า Worktree"
+		"configureSetupScript": "สคริปต์ตั้งค่า Worktree",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "เริ่มเอเจนต์ใหม่",
@@ -62,7 +63,10 @@
 		"defaultModel": "โมเดลเริ่มต้น",
 		"loadingModels": "กำลังโหลด...",
 		"selectMode": "เลือกโหมด",
-		"modeTooltip": "โหมด: {{mode}}"
+		"modeTooltip": "โหมด: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "รอการตอบกลับจากเอเจนต์...",

--- a/webview-ui/src/i18n/locales/tr/agentManager.json
+++ b/webview-ui/src/i18n/locales/tr/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Evet",
 		"shareConfirmNo": "Hayır",
 		"options": "Seçenekler",
-		"configureSetupScript": "Worktree kurulum betiği"
+		"configureSetupScript": "Worktree kurulum betiği",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Yeni bir ajan başlat",
@@ -62,7 +63,10 @@
 		"defaultModel": "Varsayılan model",
 		"loadingModels": "Yükleniyor...",
 		"selectMode": "Mod seç",
-		"modeTooltip": "Mod: {{mode}}"
+		"modeTooltip": "Mod: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "Ajan yanıtı bekleniyor...",

--- a/webview-ui/src/i18n/locales/uk/agentManager.json
+++ b/webview-ui/src/i18n/locales/uk/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Так",
 		"shareConfirmNo": "Ні",
 		"options": "Параметри",
-		"configureSetupScript": "Скрипт налаштування worktree"
+		"configureSetupScript": "Скрипт налаштування worktree",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Запустити нового агента",
@@ -64,7 +65,10 @@
 		"defaultModel": "Модель за замовчуванням",
 		"loadingModels": "Завантаження...",
 		"selectMode": "Вибрати режим",
-		"modeTooltip": "Режим: {{mode}}"
+		"modeTooltip": "Режим: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "Очікування відповіді агента...",

--- a/webview-ui/src/i18n/locales/vi/agentManager.json
+++ b/webview-ui/src/i18n/locales/vi/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "Có",
 		"shareConfirmNo": "Không",
 		"options": "Tùy chọn",
-		"configureSetupScript": "Script thiết lập worktree"
+		"configureSetupScript": "Script thiết lập worktree",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "Khởi động agent mới",
@@ -62,7 +63,10 @@
 		"defaultModel": "Mô hình mặc định",
 		"loadingModels": "Đang tải...",
 		"selectMode": "Chọn chế độ",
-		"modeTooltip": "Chế độ: {{mode}}"
+		"modeTooltip": "Chế độ: {{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "Đang chờ phản hồi từ agent...",

--- a/webview-ui/src/i18n/locales/zh-CN/agentManager.json
+++ b/webview-ui/src/i18n/locales/zh-CN/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "是",
 		"shareConfirmNo": "否",
 		"options": "选项",
-		"configureSetupScript": "Worktree 设置脚本"
+		"configureSetupScript": "Worktree 设置脚本",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "启动新代理",
@@ -62,7 +63,10 @@
 		"defaultModel": "默认模型",
 		"loadingModels": "加载中...",
 		"selectMode": "选择模式",
-		"modeTooltip": "模式：{{mode}}"
+		"modeTooltip": "模式：{{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "等待代理响应...",

--- a/webview-ui/src/i18n/locales/zh-TW/agentManager.json
+++ b/webview-ui/src/i18n/locales/zh-TW/agentManager.json
@@ -16,7 +16,8 @@
 		"shareConfirmYes": "是",
 		"shareConfirmNo": "否",
 		"options": "選項",
-		"configureSetupScript": "Worktree 設定腳本"
+		"configureSetupScript": "Worktree 設定腳本",
+		"yoloMode": "YOLO mode (auto-approve)"
 	},
 	"sessionDetail": {
 		"startNewAgent": "啟動新代理",
@@ -62,7 +63,10 @@
 		"defaultModel": "預設模型",
 		"loadingModels": "載入中...",
 		"selectMode": "選擇模式",
-		"modeTooltip": "模式：{{mode}}"
+		"modeTooltip": "模式：{{mode}}",
+		"yoloModeToggle": "Toggle YOLO mode",
+		"yoloModeEnabled": "YOLO mode enabled - tools auto-approved",
+		"yoloModeDisabled": "YOLO mode disabled - tools require approval"
 	},
 	"messages": {
 		"waiting": "等待代理回應...",

--- a/webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css
+++ b/webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css
@@ -318,6 +318,89 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+/* Editable title */
+.am-title-edit-container {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex: 1;
+	min-width: 0;
+}
+
+.am-title-input {
+	flex: 1;
+	min-width: 100px;
+	padding: 2px 6px;
+	font-size: 18px;
+	font-weight: 600;
+	background: var(--vscode-input-background);
+	color: var(--vscode-input-foreground);
+	border: 1px solid var(--vscode-focusBorder);
+	border-radius: 3px;
+	outline: none;
+}
+
+.am-title-confirm-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 4px;
+	background: transparent;
+	border: none;
+	color: var(--vscode-charts-green);
+	cursor: pointer;
+	border-radius: 3px;
+}
+
+.am-title-confirm-btn:hover {
+	background: var(--vscode-toolbar-hoverBackground);
+}
+
+.am-title-text {
+	cursor: pointer;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.am-title-text:hover {
+	text-decoration: underline;
+	text-decoration-style: dotted;
+}
+
+.am-title-edit-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 4px;
+	background: transparent;
+	border: none;
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	border-radius: 3px;
+	opacity: 0;
+	transition: opacity 0.15s;
+}
+
+.am-header-title:hover .am-title-edit-btn {
+	opacity: 0.7;
+}
+
+.am-title-edit-btn:hover {
+	opacity: 1;
+	background: var(--vscode-toolbar-hoverBackground);
+}
+
+/* YOLO badge in header */
+.am-yolo-badge {
+	display: flex;
+	align-items: center;
+	color: var(--vscode-charts-yellow, #f5c518);
 }
 
 .am-header-meta {
@@ -701,6 +784,14 @@
 	text-overflow: ellipsis;
 }
 
+/* YOLO mode indicator in sidebar */
+.am-yolo-indicator {
+	display: inline-flex;
+	align-items: center;
+	color: var(--vscode-charts-yellow, #f5c518);
+	opacity: 0.9;
+}
+
 .am-ready-to-merge {
 	font-size: calc(var(--vscode-font-size) * 0.8);
 	color: var(--vscode-charts-green);
@@ -850,6 +941,16 @@
 .am-run-mode-trigger-inline.am-locked:hover {
 	background: transparent;
 	border-color: transparent;
+}
+
+/* YOLO mode toggle active state */
+.am-run-mode-trigger-inline.am-yolo-active {
+	opacity: 1;
+	color: var(--vscode-charts-yellow, #f5c518);
+}
+
+.am-run-mode-trigger-inline.am-yolo-active:hover:not(:disabled) {
+	color: var(--vscode-charts-yellow, #f5c518);
 }
 
 /* Cancel button for pending session */

--- a/webview-ui/src/kilocode/agent-manager/components/SessionSidebar.tsx
+++ b/webview-ui/src/kilocode/agent-manager/components/SessionSidebar.tsx
@@ -11,7 +11,7 @@ import {
 import { sessionMachineUiStateAtom } from "../state/atoms/stateMachine"
 import { vscode } from "../utils/vscode"
 import { formatRelativeTime, createRelativeTimeLabels } from "../utils/timeUtils"
-import { Plus, Loader2, RefreshCw, GitBranch, Folder, Share2, MoreVertical, FileCode } from "lucide-react"
+import { Plus, Loader2, RefreshCw, GitBranch, Folder, Share2, MoreVertical, FileCode, Zap } from "lucide-react"
 
 export function SessionSidebar() {
 	const { t } = useTranslation("agentManager")
@@ -243,6 +243,11 @@ function SessionItem({
 					{!isWorktree && (
 						<span className="am-workspace-indicator" title={t("sidebar.local")}>
 							<Folder size={10} />
+						</span>
+					)}
+					{session.yoloMode && (
+						<span className="am-yolo-indicator" title={t("sidebar.yoloMode")}>
+							<Zap size={10} />
 						</span>
 					)}
 				</div>

--- a/webview-ui/src/kilocode/agent-manager/state/atoms/sessions.ts
+++ b/webview-ui/src/kilocode/agent-manager/state/atoms/sessions.ts
@@ -26,6 +26,7 @@ export interface AgentSession {
 	parallelMode?: ParallelModeInfo
 	gitUrl?: string
 	autoMode?: boolean // True if session was started with --auto flag (non-interactive)
+	yoloMode?: boolean // True if session was started with auto-approval enabled
 	model?: string // Model ID used for this session
 	mode?: string // Mode slug used for this session (e.g., "code", "architect")
 }
@@ -40,6 +41,7 @@ export interface PendingSession {
 	parallelMode?: boolean
 	gitUrl?: string
 	autoMode?: boolean // True if session will be started with --auto flag
+	yoloMode?: boolean // True if session will be started with auto-approval enabled
 }
 
 export interface RemoteSession {
@@ -226,4 +228,18 @@ export const updateSessionModeAtom = atom(null, (get, set, payload: { sessionId:
 export const setRemoteSessionsAtom = atom(null, (_get, set, sessions: RemoteSession[]) => {
 	set(remoteSessionsAtom, sessions)
 	set(isRefreshingRemoteSessionsAtom, false)
+})
+
+export const renameSessionAtom = atom(null, (get, set, payload: { sessionId: string; label: string }) => {
+	const current = get(sessionsMapAtom)
+	const session = current[payload.sessionId]
+	if (!session) return
+
+	set(sessionsMapAtom, {
+		...current,
+		[payload.sessionId]: {
+			...session,
+			label: payload.label,
+		},
+	})
 })


### PR DESCRIPTION
## Summary

- Add YOLO mode toggle button in new agent form to enable/disable auto-approval of tools
- Add YOLO mode indicator (⚡) in session header and sidebar for sessions running in YOLO mode
- Add inline session rename - click on session title to edit

## Technical Details

- `yoloMode` maps to `autoApprove` config in agent-runtime
- Added translations for all 22 supported locales

## Test plan

- [ ] Start a new agent with YOLO mode enabled → verify ⚡ badge appears in header and sidebar
- [ ] Start a new agent with YOLO mode disabled → verify no ⚡ badge
- [ ] Click on session title → verify inline edit mode activates
- [ ] Rename session and press Enter → verify new name persists
- [ ] Press Escape during rename → verify edit is cancelled