### PR TITLE
Try to use exact provider-model profile for autocompletion if such exists

### DIFF
--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -61,9 +61,15 @@ export class GhostModel {
 		}
 
 		for (const [provider, model] of AUTOCOMPLETE_PROVIDER_MODELS) {
-			const selectedProfile = profiles.find(
-				(x) => x?.apiProvider === provider && !(x.profileType === "autocomplete"),
+			let selectedProfile = profiles.find(
+				(x) => x.apiProvider === provider && x.modelId === model && !(x.profileType === "autocomplete"),
 			)
+			if (!selectedProfile) {
+				// If failed to find exact provider-model pair, try to use any profile with looked-up provider
+				selectedProfile = profiles.find(
+					(x) => x.apiProvider === provider && !(x.profileType === "autocomplete"),
+				)
+			}
 			if (!selectedProfile) continue
 			const profile = await providerSettingsManager.getProfile({ id: selectedProfile.id })
 


### PR DESCRIPTION
## Context

I've created two profiles: Mistral's devstral and Mistral's codestral (for autocompletion).
And autocompletion stopped working.
Logs revealed `401 Unauthorized` error.

It turned out that KiloCode selected the devstral profile for autocompletion (the first Mistral's profile)
and used the API key from the profile (for `api.mistral.ai` endpoint) with the `codestral.mistral.ai` endpoint.

`codestral.mistral.ai` endpoint is default endpoint for autocompletion with Mistral provider if the user does not set another
endpoint in profile settings. But, as the profile is related to devstral (not codestral) model, user does not have such option.

Of course `codestral.mistral.ai` endpoint with API key for `api.mistral.ai` simply does not work.

## Implementation

I've added a lookup for profile with exact provider-model match before falling back to "any profile of looked-up provider".

## Screenshots

## How to Test

1. Create profile for Mistral / devstral
2. Create profile for Mistral / codestral
3. Autocompletion should work.

## Get in Touch

My discord handle is `wkordalski`