### PR TITLE
docs: update custom instruction path guidance (#5664)

### DIFF
--- a/apps/kilocode-docs/pages/customize/index.md
+++ b/apps/kilocode-docs/pages/customize/index.md
@@ -32,7 +32,7 @@ Help Kilo understand your codebase better:
 
 New to customization? Here's where to start:
 
-1. **Start with Custom Instructions** — Add a simple `.kilocode/instructions.md` file to your project
+1. **Start with Custom Instructions** — Set up instructions in the [Custom Instructions](/docs/customize/custom-instructions) section to guide Kilo Code's behavior
 2. **Explore Custom Modes** — Try the built-in modes first, then create your own
 3. **Enable Codebase Indexing** — Help Kilo understand your project structure
 


### PR DESCRIPTION
Fixes #5664.

The customize index page referenced a non-existent `.kilocode/instructions.md` path.
Custom Instructions are configured via the UI, so this updates the entry point to point
to the Custom Instructions documentation page.

Docs-only change, minimal diff.
