### PR TITLE
fix(cli): Add error handling to prevent silent failures

### DIFF
--- a/.changeset/cli-error-handling.md
+++ b/.changeset/cli-error-handling.md
@@ -1,0 +1,8 @@
+---
+"@kilocode/cli": patch
+---
+
+Add error handling to prevent silent CLI failures
+
+Added uncaught exception and unhandled rejection handlers to ensure
+errors are displayed to users instead of exiting silently.


### PR DESCRIPTION
Fixes #5683

## Problem
The CLI was exiting silently without any output when errors occurred during startup. This happened because there were no error handlers for uncaught exceptions or unhandled promise rejections.

## Solution
Added comprehensive error handling:

1. **Global error handlers:**
   - `uncaughtException` - catches synchronous errors
   - `unhandledRejection` - catches async promise rejections

2. **Program parsing:**
   - Changed `program.parse()` to `program.parseAsync().catch()` to catch Commander.js errors

3. **Subcommand wrappers:**
   - Added try-catch blocks to auth, debug, and models commands

## Testing Completed ✅

### Manual CLI Testing:
- [x] `--help` displays correctly: Shows full help output
- [x] `--version` works: Returns `0.26.1`
- [x] Invalid flags show errors: Displays `error: unknown option '--invalid-flag'`
- [x] Debug command works: Shows available modes
- [x] Models command shows proper error: JSON error response instead of silent exit
- [x] No config shows error message: Proper error instead of silent failure

### Unit Tests:
- [x] All 2078 tests passed
- [x] 120 test files passed
- [x] Duration: 49.53s

## Checklist
- [x] Changeset created
- [x] Follows contribution guidelines
- [x] Commit message follows conventions
- [x] All tests passing