### PR TITLE
feat(slash-commands): type/source indicators, skill invocation & argument hints

### DIFF
--- a/.changeset/slash-command-enhancements.md
+++ b/.changeset/slash-command-enhancements.md
@@ -1,0 +1,12 @@
+---
+"kilo-code": minor
+---
+
+feat: Enhance slash command menu with type indicators, source badges, skill invocation, and argument hints
+
+- Add type badges (command, mode, workflow, skill) with distinct colors to the "/" slash command dropdown
+- Add source labels (project, global, organization) for non-built-in items
+- Add skills to the "/" slash command menu, allowing discovery and invocation of installed skills
+- Color-code slash command highlights in the text input to match their type
+- Support Claude Code's `argument-hint` SKILL.md frontmatter field (from the Agent Skills specification), displayed as ghost text in the input after selecting a skill command to guide usage (e.g. `[-a] [-x] <task description>`)
+- Parse and propagate `argument-hint` from skill frontmatter through the full data pipeline (SkillsManager → ExtensionStateContext → SlashCommand)

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -4047,10 +4047,14 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 							)
 
 							// when parsing slash commands, we still want to allow the user to provide their desired context
+							const currentMode = await this.getTaskMode()
+							const skillsForMode =
+								this.providerRef.deref()?.getSkillsManager()?.getSkillsForMode(currentMode) ?? []
 							const { processedText, needsRulesFileCheck: needsCheck } = await parseKiloSlashCommands(
 								parsedText.text,
 								localWorkflowToggles,
 								globalWorkflowToggles,
+								skillsForMode,
 							)
 
 							if (needsCheck) {

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -527,6 +527,7 @@ export const webviewMessageHandler = async (
 
 			provider.postStateToWebview()
 			provider.postRulesDataToWebview() // kilocode_change: send workflows and rules immediately
+			provider.postSkillsDataToWebview() // kilocode_change: send skills data for slash command dropdown
 			provider.workspaceTracker?.initializeFilePaths() // Don't await.
 
 			getTheme().then((theme) => provider.postMessageToWebview({ type: "theme", text: JSON.stringify(theme) }))

--- a/src/services/skills/SkillsManager.ts
+++ b/src/services/skills/SkillsManager.ts
@@ -165,6 +165,10 @@ export class SkillsManager {
 				return
 			}
 
+			// Extract optional argument-hint from frontmatter
+			const argumentHint =
+				typeof frontmatter["argument-hint"] === "string" ? frontmatter["argument-hint"].trim() : undefined
+
 			// Create unique key combining name, source, and mode for override resolution
 			const skillKey = this.getSkillKey(effectiveSkillName, source, mode)
 
@@ -174,6 +178,7 @@ export class SkillsManager {
 				path: skillMdPath,
 				source,
 				mode, // undefined for generic skills, string for mode-specific
+				...(argumentHint && { argumentHint }),
 			})
 		} catch (error) {
 			console.error(`Failed to load skill at ${skillDir}:`, error)

--- a/src/shared/skills.ts
+++ b/src/shared/skills.ts
@@ -8,6 +8,7 @@ export interface SkillMetadata {
 	path: string // Absolute path to SKILL.md
 	source: "global" | "project" // Where the skill was discovered
 	mode?: string // If set, skill is only available in this mode
+	argumentHint?: string // Optional: usage hint shown after command selection (from frontmatter argument-hint)
 }
 
 /**

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -84,6 +84,7 @@ export interface ExtensionStateContextType extends ExtensionState {
 	localWorkflows: ClineRulesToggles
 	// kilocode_change start
 	commands: Command[]
+	skills: Array<{ name: string; description: string; path: string; source: "global" | "project"; mode?: string }>
 	organizationAllowList: OrganizationAllowList
 	organizationSettingsVersion: number
 	cloudIsAuthenticated: boolean
@@ -372,6 +373,16 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 	const [filePaths, setFilePaths] = useState<string[]>([])
 	const [openedTabs, setOpenedTabs] = useState<Array<{ label: string; isActive: boolean; path?: string }>>([])
 	const [commands, setCommands] = useState<Command[]>([])
+	const [skills, setSkills] = useState<
+		Array<{
+			name: string
+			description: string
+			path: string
+			source: "global" | "project"
+			mode?: string
+			argumentHint?: string
+		}>
+	>([])
 	const [mcpServers, setMcpServers] = useState<McpServer[]>([])
 	const [mcpMarketplaceCatalog, setMcpMarketplaceCatalog] = useState<McpMarketplaceCatalog>({ items: [] }) // kilocode_change
 	const [currentCheckpoint, setCurrentCheckpoint] = useState<string>()
@@ -477,6 +488,10 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 					setCommands(message.commands ?? [])
 					break
 				}
+				case "skillsData": {
+					setSkills(message.skills ?? [])
+					break
+				}
 				case "messageUpdated": {
 					const clineMessage = message.clineMessage!
 					setState((prevState) => {
@@ -576,6 +591,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		localWorkflows,
 		// kilocode_change end
 		commands,
+		skills,
 		soundVolume: state.soundVolume,
 		ttsSpeed: state.ttsSpeed,
 		fuzzyMatchThreshold: state.fuzzyMatchThreshold,

--- a/webview-ui/src/kilocode.css
+++ b/webview-ui/src/kilocode.css
@@ -8,6 +8,34 @@
 	color: transparent;
 }
 
+/* Type-specific slash command highlight colors */
+.slash-command-match-textarea-highlight.slash-command-type-command {
+	background-color: rgba(58, 150, 221, 0.2);
+	box-shadow: 0 0 0 0.5px rgba(58, 150, 221, 0.3);
+}
+
+.slash-command-match-textarea-highlight.slash-command-type-mode {
+	background-color: rgba(160, 100, 230, 0.2);
+	box-shadow: 0 0 0 0.5px rgba(160, 100, 230, 0.3);
+}
+
+.slash-command-match-textarea-highlight.slash-command-type-workflow {
+	background-color: rgba(80, 180, 100, 0.2);
+	box-shadow: 0 0 0 0.5px rgba(80, 180, 100, 0.3);
+}
+
+.slash-command-match-textarea-highlight.slash-command-type-skill {
+	background-color: rgba(220, 160, 50, 0.2);
+	box-shadow: 0 0 0 0.5px rgba(220, 160, 50, 0.3);
+}
+
+/* Argument hint ghost text after slash commands */
+.slash-command-argument-hint {
+	color: var(--vscode-editorGhostText-foreground, var(--vscode-descriptionForeground));
+	opacity: 0.5;
+	pointer-events: none;
+}
+
 /* Custom slow pulse animation for task progress squares */
 @keyframes slow-pulse {
 	0%,


### PR DESCRIPTION
## Summary

Enhances the "/" slash command menu with rich visual metadata, adds skills to the command list, and introduces argument hint ghost text for skills.

## Features

### Type badges

Each command in the dropdown shows a color-coded badge indicating its type:
- 🔵 `command` — built-in commands (newtask, condense, etc.)
- 🟣 `mode` — mode switching (code, architect, etc.)
- 🟢 `workflow` — workflow rules (.kilo/rules)
- 🟡 `skill` — installed skills (SKILL.md based)

<table>
<tr><th>Command</th><th>Mode</th></tr>
<tr>
<td><img width="327" alt="command list" src="https://github.com/user-attachments/assets/5a4ece02-7abb-4796-b91c-8c70cecbfb4d" /></td>
<td><img width="335" alt="mode list" src="https://github.com/user-attachments/assets/bc36b969-40f4-43a8-9720-420c54687df9" /></td>
</tr>
<tr><th>Workflow</th><th>Skill</th></tr>
<tr>
<td><img width="336" alt="workflow list" src="https://github.com/user-attachments/assets/250cef2d-d749-4c3a-a630-5191828c8902" /></td>
<td><img width="343" alt="skill list" src="https://github.com/user-attachments/assets/d625040c-7561-4dd2-909f-1092460af942" /></td>
</tr>
</table>

### Source labels

Non-built-in items show their origin (`project`, `global`, `org`) to help disambiguate items with similar names.

### Type-colored input highlights

When a slash command is typed in the input field, the highlight color matches its type:

<table>
<tr><th>Command (blue)</th><th>Workflow (green)</th><th>Skill (amber)</th></tr>
<tr>
<td><img width="81" alt="command highlight" src="https://github.com/user-attachments/assets/9496ba90-1870-457a-8cd7-dc5987b9ed39" /></td>
<td><img width="237" alt="workflow highlight" src="https://github.com/user-attachments/assets/9df8374e-34c6-4104-8ebb-0ec931be5eb5" /></td>
<td><img width="276" alt="skill highlight" src="https://github.com/user-attachments/assets/abd852e0-dde5-479e-9153-13dea2748e63" /></td>
</tr>
</table>

### Skills in "/" menu

Installed skills are now discoverable and invocable directly from the slash command dropdown. Selecting a skill reads its SKILL.md and injects the content as `<explicit_instructions>` (same pattern as workflows).

### Argument hint ghost text

Skills with an `argument-hint` field in their SKILL.md frontmatter (from the [Agent Skills specification](https://agentskills.io/specification)) display usage hints as faded ghost text after the command. The hint disappears when the user starts typing arguments, and yields to FIM autocomplete when active.

<img width="371" alt="argument hint" src="https://github.com/user-attachments/assets/dfe50884-b995-4583-8d06-ea7bf9ae5e52" />

## Changed files

| File | Change |
|------|--------|
| `src/shared/skills.ts` | Add `argumentHint?` to `SkillMetadata` |
| `src/services/skills/SkillsManager.ts` | Parse `argument-hint` from SKILL.md frontmatter |
| `src/core/slash-commands/kilo.ts` | Add skill matching/invocation in `parseKiloSlashCommands` |
| `src/core/task/Task.ts` | Pass skills from `SkillsManager` to slash command parser |
| `src/core/webview/webviewMessageHandler.ts` | Send skills data to webview on launch |
| `webview-ui/src/context/ExtensionStateContext.tsx` | Add `skills` state + `skillsData` message handler |
| `webview-ui/src/utils/slash-commands.ts` | Add `SlashCommandType`, `SlashCommandSource`, `SkillInfo`, `findSlashCommand()`, skills parameter to all functions |
| `webview-ui/src/components/chat/SlashCommandMenu.tsx` | Type badge colors, source labels, skills in dropdown |
| `webview-ui/src/components/chat/ChatTextArea.tsx` | Type-colored highlights, argument hint rendering, skills in keyboard navigation |
| `webview-ui/src/kilocode.css` | Type-specific highlight colors + argument hint style |

## Test plan

- [x] Type "/" in the chat input and verify type badges (command/mode/workflow/skill) appear with correct colors
- [x] Verify source labels (project/global/org) appear for non-built-in items
- [x] Verify installed skills appear in the "/" dropdown list
- [x] Select a skill from the menu and verify it invokes correctly (SKILL.md content injected)
- [x] Arrow-key navigation reaches all items including skills at the bottom
- [x] Type a command and verify the input highlight matches the command type color
- [x] Select a skill with `argument-hint` frontmatter and verify ghost text appears after the command
- [x] Start typing after a skill command and verify the argument hint disappears
- [x] Verify FIM autocomplete still works and takes priority over argument hints
- [x] `pnpm run check-types` passes (22/22)
- [x] `pnpm run lint` passes (18/18, 0 warnings)
- [x] `pnpm vitest run` passes (515 files, 7831 tests)