### PR TITLE
fix: include LM Studio in requestRouterModels candidates

### DIFF
--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -956,6 +956,7 @@ export const webviewMessageHandler = async (
 					},
 				},
 				{ key: "ollama", options: { provider: "ollama", baseUrl: apiConfiguration.ollamaBaseUrl } },
+				{ key: "lmstudio", options: { provider: "lmstudio", baseUrl: apiConfiguration.lmStudioBaseUrl } },
 				{ key: "vercel-ai-gateway", options: { provider: "vercel-ai-gateway" } },
 				{
 					key: "deepinfra",
@@ -1058,7 +1059,7 @@ export const webviewMessageHandler = async (
 				if (result.status === "fulfilled") {
 					routerModels[routerName] = result.value.models
 
-					// Ollama and LM Studio settings pages still need these events. They are not fetched here.
+					// Ollama and LM Studio settings pages still need these dedicated events (requestOllamaModels, requestLmStudioModels).
 				} else {
 					// Handle rejection: Post a specific error message for this provider.
 					const errorMessage = result.reason instanceof Error ? result.reason.message : String(result.reason)


### PR DESCRIPTION
## Summary

- **Add LM Studio to the `candidates` array** in `requestRouterModels` handler (`webviewMessageHandler.ts:959`), passing `apiConfiguration.lmStudioBaseUrl` so models are fetched dynamically from the user's configured LM Studio instance
- This matches how Ollama is already handled (line 958) — both are local providers but only Ollama was included in the candidates
- Update misleading comment that said "They are not fetched here" (LM Studio now is)

## Problem

When the CLI sends `requestRouterModels`, the response includes `lmstudio: {}` as an empty placeholder because LM Studio was deliberately excluded from the candidates array. The only way to get LM Studio models was via the separate `requestLmStudioModels` message, which the CLI never sends.

This meant `kilo models lmstudio` would only show stale cached models (from a background refresh that defaults to `localhost:1234`) instead of dynamically fetching from the user's actual configured LM Studio server.

All the infrastructure for dynamic fetching already exists (`fetchModelsFromProvider` handles `"lmstudio"` at line 130, `getLMStudioModels()` accepts a `baseUrl` parameter) — it just was never wired up in the aggregate router models request.

## Test plan

- [ ] Run `kilo models lmstudio` and verify it shows all models from the configured LM Studio instance (not just a hardcoded subset)
- [ ] Verify models are fetched from the user-configured `lmStudioBaseUrl` (not just `localhost:1234`)
- [ ] Verify `kilo run -m lmstudio/<model-id>` works with any model loaded in LM Studio
- [ ] Verify no regression for other providers in `requestRouterModels`
- [ ] Verify the dedicated `requestLmStudioModels` handler still works for the VS Code extension settings page