### PR TITLE
fix(webview-ui): improve session title contrast and readability

### DIFF
--- a/.changeset/fix-session-title-readability.md
+++ b/.changeset/fix-session-title-readability.md
@@ -1,0 +1,16 @@
+---
+"webview-ui": patch
+---
+
+Fix unreadable text and poor contrast issues in Agent Manager
+
+**Session list item (issue #5618):**
+
+- Change selected session item background from list-activeSelectionBackground to button-background for better contrast
+- Change selected session item text color from list-activeSelectionForeground to button-foreground
+
+**Session detail view:**
+
+- Change session header, messages container, and chat input backgrounds from editor-background to sideBar-background
+- Add explicit text color to session title using titleBar-activeForeground
+- Add explicit color to messages container using sideBar-foreground

--- a/webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css
+++ b/webview-ui/src/kilocode/agent-manager/components/AgentManagerApp.css
@@ -195,8 +195,8 @@
 }
 
 .am-session-item.am-selected {
-	background: var(--vscode-list-activeSelectionBackground);
-	color: var(--vscode-list-activeSelectionForeground);
+	background: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
 }
 
 .am-session-item:focus {
@@ -302,7 +302,7 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: flex-start;
-	background: var(--vscode-editor-background);
+	background: var(--vscode-sideBar-background);
 }
 
 .am-header-info {
@@ -314,6 +314,7 @@
 .am-header-title {
 	font-size: 18px;
 	font-weight: 600;
+	color: var(--vscode-titleBar-activeForeground);
 	margin-bottom: 4px;
 	white-space: nowrap;
 	overflow: hidden;
@@ -393,7 +394,9 @@
 	padding: 0;
 	display: flex;
 	flex-direction: column;
-	position: relative; /* kilocode_change */
+	position: relative;
+	background: var(--vscode-sideBar-background);
+	color: var(--vscode-sideBar-foreground);
 }
 
 .am-messages-list {
@@ -617,7 +620,7 @@
 /* Chat Input Styles */
 .am-chat-input-container {
 	padding: 12px 20px 20px 20px;
-	background: var(--vscode-editor-background);
+	background: var(--vscode-sideBar-background);
 }
 
 .am-chat-input-hint {


### PR DESCRIPTION
## Summary

Fixes poor contrast issue in Agent Manager session titles (#5618)

## Changes

- Change selected session item background from list-activeSelectionBackground to button-background for better contrast
- Change session header, messages container, and chat input backgrounds from editor-background to sideBar-background
- Add explicit text color to session title using titleBar-activeForeground

## Before vs After

Selected session (sidebar): Blue BG + Black text (unreadable) -> Dark BG + White text (readable)
Session title (inside box): Blue BG + Black text (unreadable) -> Dark BG + White text (readable)

## Testing

- Visual test on various VS Code themes (light/dark/custom)
- All changes are CSS-only, no logic changes