### PR TITLE
fix: Remove @vertex suffix from model ID for Anthropic Vertex API

### DIFF
--- a/.changeset/fix-opus-4.6-vertex.md
+++ b/.changeset/fix-opus-4.6-vertex.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Opus 4.6 via Vertex AI 404 error by removing @vertex suffix from model ID

--- a/src/api/providers/anthropic-vertex.ts
+++ b/src/api/providers/anthropic-vertex.ts
@@ -272,8 +272,11 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 		// reasoning model and that reasoning is required to be enabled.
 		// The actual model ID honored by Anthropic's API does not have this
 		// suffix.
+		// The `@vertex` suffix is used to distinguish Vertex AI models but should
+		// be removed before sending to the API.
+		let cleanId = id.replace(/@vertex$/, "").replace(/:thinking$/, "")
 		return {
-			id: id.endsWith(":thinking") ? id.replace(":thinking", "") : id,
+			id: cleanId,
 			info,
 			betas: betas.length > 0 ? betas : undefined,
 			...params,


### PR DESCRIPTION
## Summary

Fixes Opus 4.6 via Vertex AI returning 404 NOT_FOUND error.

## Problem

When selecting Claude Opus 4.6 via Vertex AI provider, users get a 404 error.

## Root Cause

The @vertex suffix was being sent directly to the AnthropicVertex SDK. This suffix is only used by Kilo Code to distinguish Vertex AI models in the dropdown, but it is not a valid model identifier for Anthropic API.

## Fix

Remove both @vertex and :thinking suffixes from the model ID before sending to the API.

### Results

| Input | Output |
|-------|--------|
| claude-opus-4-6@vertex | claude-opus-4-6 |
| claude-sonnet-4@vertex:thinking | claude-sonnet-4 |

## Files Changed

- src/api/providers/anthropic-vertex.ts

## Fixes

Fixes #5693