### PR TITLE
Restore Kimi tool calling and enforce strict thinking behavior

### DIFF
--- a/.changeset/fix-chutes-kimi-no-assistant-messages.md
+++ b/.changeset/fix-chutes-kimi-no-assistant-messages.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Improve Chutes Kimi reliability by preventing terminated-stream retry loops and handling tool/reasoning chunks more safely.

--- a/.changeset/green-geese-warn.md
+++ b/.changeset/green-geese-warn.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed Moonshot Kimi tool-calling and thinking-mode behavior for `kimi-k2.5` and `kimi-for-coding`.

--- a/packages/types/src/providers/moonshot.ts
+++ b/packages/types/src/providers/moonshot.ts
@@ -10,7 +10,7 @@ export const moonshotModels = {
 	"kimi-for-coding": {
 		maxTokens: 32_000,
 		contextWindow: 131_072,
-		supportsImages: false,
+		supportsImages: true,
 		supportsPromptCache: true,
 		supportsReasoningBinary: true,
 		supportsAdaptiveThinking: true,
@@ -100,7 +100,7 @@ export const moonshotModels = {
 	"kimi-k2.5": {
 		maxTokens: 16_384,
 		contextWindow: 262_144,
-		supportsImages: false,
+		supportsImages: true,
 		supportsPromptCache: true,
 		supportsReasoningBinary: true,
 		supportsAdaptiveThinking: true,

--- a/packages/types/src/providers/moonshot.ts
+++ b/packages/types/src/providers/moonshot.ts
@@ -6,21 +6,26 @@ export type MoonshotModelId = keyof typeof moonshotModels
 export const moonshotDefaultModelId: MoonshotModelId = "kimi-k2-thinking"
 
 export const moonshotModels = {
+	// kilocode_change start
 	"kimi-for-coding": {
 		maxTokens: 32_000,
 		contextWindow: 131_072,
 		supportsImages: false,
 		supportsPromptCache: true,
-		supportsReasoningBudget: true,
-		supportsReasoningEffort: true,
+		supportsReasoningBinary: true,
+		supportsAdaptiveThinking: true,
 		inputPrice: 0.6, // $0.60 per million tokens (cache miss)
 		outputPrice: 2.5, // $2.50 per million tokens
 		cacheWritesPrice: 0, // $0 per million tokens (cache miss)
 		cacheReadsPrice: 0.15, // $0.15 per million tokens (cache hit)
 		preserveReasoning: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		supportsTemperature: false,
+		defaultTemperature: 0.6,
 		description: `Kimi for coding`,
 	},
+	// kilocode_change end
 	"kimi-k2-0711-preview": {
 		maxTokens: 32_000,
 		contextWindow: 131_072,
@@ -91,19 +96,26 @@ export const moonshotModels = {
 		defaultTemperature: 1.0,
 		description: `The kimi-k2-thinking model is a general-purpose agentic reasoning model developed by Moonshot AI. Thanks to its strength in deep reasoning and multi-turn tool use, it can solve even the hardest problems.`,
 	},
+	// kilocode_change start
 	"kimi-k2.5": {
 		maxTokens: 16_384,
 		contextWindow: 262_144,
 		supportsImages: false,
 		supportsPromptCache: true,
+		supportsReasoningBinary: true,
+		supportsAdaptiveThinking: true,
+		preserveReasoning: true,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 0.6, // $0.60 per million tokens (cache miss)
 		outputPrice: 3.0, // $3.00 per million tokens
 		cacheReadsPrice: 0.1, // $0.10 per million tokens (cache hit)
-		supportsTemperature: true,
-		defaultTemperature: 1.0,
+		supportsTemperature: false,
+		defaultTemperature: 0.6,
 		description:
 			"Kimi K2.5 is the latest generation of Moonshot AI's Kimi series, featuring improved reasoning capabilities and enhanced performance across diverse tasks.",
 	},
+	// kilocode_change end
 } as const satisfies Record<string, ModelInfo>
 
 export const MOONSHOT_DEFAULT_TEMPERATURE = 0.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26161,7 +26161,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.0.10)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@2.0.5':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26161,7 +26161,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.0.10)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@2.0.5':
     dependencies:

--- a/src/api/providers/__tests__/moonshot.spec.ts
+++ b/src/api/providers/__tests__/moonshot.spec.ts
@@ -285,6 +285,43 @@ describe("MoonshotHandler", () => {
 			)
 		})
 
+		it("should enforce strict thinking temperature/provider options for kimi-for-coding by default", async () => {
+			const strictHandler = new MoonshotHandler({
+				...mockOptions,
+				apiModelId: "kimi-for-coding",
+				modelTemperature: 0.1,
+			})
+
+			async function* mockFullStream() {
+				yield { type: "text-delta", text: "Test response" }
+			}
+
+			mockStreamText.mockReturnValue({
+				fullStream: mockFullStream(),
+				usage: Promise.resolve({
+					inputTokens: 1,
+					outputTokens: 1,
+					details: {},
+					raw: {},
+				}),
+			})
+
+			for await (const _chunk of strictHandler.createMessage(systemPrompt, messages)) {
+				// Drain stream
+			}
+
+			expect(mockStreamText).toHaveBeenCalledWith(
+				expect.objectContaining({
+					temperature: 1.0,
+					providerOptions: {
+						moonshot: {
+							thinking: { type: "enabled" },
+						},
+					},
+				}),
+			)
+		})
+
 		it("should enforce strict non-thinking temperature/provider options when reasoning is disabled", async () => {
 			const strictHandler = new MoonshotHandler({
 				...mockOptions,

--- a/src/api/providers/__tests__/moonshot.spec.ts
+++ b/src/api/providers/__tests__/moonshot.spec.ts
@@ -129,6 +129,17 @@ describe("MoonshotHandler", () => {
 
 			expect(strictModelInfo.supportsNativeTools).toBe(true)
 			expect(strictModelInfo.defaultToolProtocol).toBe("native")
+			expect(model.info.supportsImages).toBe(true)
+		})
+
+		it("should expose image capability for kimi-for-coding", () => {
+			const strictHandler = new MoonshotHandler({
+				...mockOptions,
+				apiModelId: "kimi-for-coding",
+			})
+			const model = strictHandler.getModel()
+
+			expect(model.info.supportsImages).toBe(true)
 		})
 		// kilocode_change end
 	})

--- a/src/api/transform/__tests__/model-params.spec.ts
+++ b/src/api/transform/__tests__/model-params.spec.ts
@@ -684,6 +684,42 @@ describe("getModelParams", () => {
 		})
 	})
 
+	// kilocode_change start
+	describe("Adaptive thinking models", () => {
+		it("should default to thinking temperature when adaptive thinking is enabled and unset", () => {
+			const model: ModelInfo = {
+				...baseModel,
+				supportsAdaptiveThinking: true,
+				defaultTemperature: 0.6,
+			}
+
+			const result = getModelParams({
+				...openaiParams,
+				settings: {},
+				model,
+			})
+
+			expect(result.temperature).toBe(1.0)
+		})
+
+		it("should use default non-thinking temperature when adaptive thinking is explicitly disabled", () => {
+			const model: ModelInfo = {
+				...baseModel,
+				supportsAdaptiveThinking: true,
+				defaultTemperature: 0.6,
+			}
+
+			const result = getModelParams({
+				...openaiParams,
+				settings: { enableReasoningEffort: false },
+				model,
+			})
+
+			expect(result.temperature).toBe(0.6)
+		})
+	})
+	// kilocode_change end
+
 	describe("Hybrid reasoning models (supportsReasoningEffort)", () => {
 		const model: ModelInfo = {
 			...baseModel,

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -332,11 +332,23 @@ const ApiOptions = ({
 		if (!models) return []
 
 		const filteredModels = filterModels(models, selectedProvider, organizationAllowList)
+		// kilocode_change start
+		const modelsAllowedByEndpoint =
+			selectedProvider === "moonshot" && filteredModels
+				? Object.fromEntries(
+						Object.entries(filteredModels).filter(
+							([modelId]) =>
+								modelId !== "kimi-for-coding" ||
+								apiConfiguration.moonshotBaseUrl === "https://api.kimi.com/coding/v1",
+						),
+					)
+				: filteredModels
+		// kilocode_change end
 
 		// Include the currently selected model even if deprecated (so users can see what they have selected)
 		// But filter out other deprecated models from being newly selectable
-		const availableModels = filteredModels
-			? Object.entries(filteredModels)
+		const availableModels = modelsAllowedByEndpoint
+			? Object.entries(modelsAllowedByEndpoint)
 					.filter(([modelId, modelInfo]) => {
 						// Always include the currently selected model
 						if (modelId === selectedModelId) return true
@@ -350,7 +362,7 @@ const ApiOptions = ({
 			: []
 
 		return availableModels
-	}, [selectedProvider, organizationAllowList, selectedModelId])
+	}, [selectedProvider, organizationAllowList, selectedModelId, apiConfiguration.moonshotBaseUrl])
 
 	const onProviderChange = useCallback(
 		(value: ProviderName) => {

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -338,8 +338,9 @@ const ApiOptions = ({
 				? Object.fromEntries(
 						Object.entries(filteredModels).filter(
 							([modelId]) =>
-								modelId !== "kimi-for-coding" ||
-								apiConfiguration.moonshotBaseUrl === "https://api.kimi.com/coding/v1",
+								apiConfiguration.moonshotBaseUrl === "https://api.kimi.com/coding/v1"
+									? modelId === "kimi-for-coding"
+									: modelId !== "kimi-for-coding",
 						),
 					)
 				: filteredModels

--- a/webview-ui/src/components/settings/ThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudget.tsx
@@ -141,6 +141,8 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 	])
 
 	const enableReasoningEffort = apiConfiguration.enableReasoningEffort
+	// kilocode_change
+	const enableBinaryReasoningEffort = apiConfiguration.enableReasoningEffort ?? true
 	const customMaxOutputTokens = apiConfiguration.modelMaxTokens || DEFAULT_HYBRID_REASONING_MODEL_MAX_TOKENS
 	const customMaxThinkingTokens =
 		apiConfiguration.modelMaxThinkingTokens || DEFAULT_HYBRID_REASONING_MODEL_THINKING_TOKENS
@@ -179,7 +181,7 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 		return (
 			<div className="flex flex-col gap-1">
 				<Checkbox
-					checked={enableReasoningEffort}
+					checked={enableBinaryReasoningEffort}
 					onChange={(checked: boolean) =>
 						setApiConfigurationField("enableReasoningEffort", checked === true)
 					}>

--- a/webview-ui/src/components/settings/__tests__/ApiOptions.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiOptions.spec.tsx
@@ -339,6 +339,30 @@ describe("ApiOptions", () => {
 		expect(mockSetApiConfigurationField).toHaveBeenCalledWith("apiModelId", openAiCodexDefaultModelId, false)
 	})
 
+	it("hides kimi-for-coding from model options when Moonshot endpoint is not coding", () => {
+		renderApiOptions({
+			apiConfiguration: {
+				apiProvider: "moonshot",
+				apiModelId: "kimi-k2-thinking",
+				moonshotBaseUrl: "https://api.moonshot.ai/v1",
+			},
+		})
+
+		expect(screen.queryByRole("option", { name: "kimi-for-coding" })).not.toBeInTheDocument()
+	})
+
+	it("shows kimi-for-coding in model options when Moonshot endpoint is coding", () => {
+		renderApiOptions({
+			apiConfiguration: {
+				apiProvider: "moonshot",
+				apiModelId: "kimi-k2-thinking",
+				moonshotBaseUrl: "https://api.kimi.com/coding/v1",
+			},
+		})
+
+		expect(screen.getByRole("option", { name: "kimi-for-coding" })).toBeInTheDocument()
+	})
+
 	it("shows diff settings, temperature and rate limit controls by default", () => {
 		renderApiOptions({
 			apiConfiguration: {

--- a/webview-ui/src/components/settings/__tests__/ApiOptions.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiOptions.spec.tsx
@@ -361,6 +361,7 @@ describe("ApiOptions", () => {
 		})
 
 		expect(screen.getByRole("option", { name: "kimi-for-coding" })).toBeInTheDocument()
+		expect(screen.queryByRole("option", { name: "kimi-k2-thinking" })).not.toBeInTheDocument() // kilocode_change
 	})
 
 	it("shows diff settings, temperature and rate limit controls by default", () => {

--- a/webview-ui/src/components/settings/__tests__/ThinkingBudget.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ThinkingBudget.spec.tsx
@@ -111,6 +111,42 @@ describe("ThinkingBudget", () => {
 		expect(screen.queryByTestId("reasoning-effort")).not.toBeInTheDocument()
 	})
 
+	// kilocode_change start
+	it("should default binary reasoning toggle to enabled when setting is unset", () => {
+		render(
+			<ThinkingBudget
+				{...defaultProps}
+				apiConfiguration={{}}
+				modelInfo={{
+					...mockModelInfo,
+					supportsReasoningBinary: true,
+					supportsReasoningBudget: false,
+					supportsReasoningEffort: false,
+				}}
+			/>,
+		)
+
+		expect(screen.getByRole("checkbox")).toBeChecked()
+	})
+
+	it("should keep binary reasoning toggle disabled when explicitly set to false", () => {
+		render(
+			<ThinkingBudget
+				{...defaultProps}
+				apiConfiguration={{ enableReasoningEffort: false }}
+				modelInfo={{
+					...mockModelInfo,
+					supportsReasoningBinary: true,
+					supportsReasoningBudget: false,
+					supportsReasoningEffort: false,
+				}}
+			/>,
+		)
+
+		expect(screen.getByRole("checkbox")).not.toBeChecked()
+	})
+	// kilocode_change end
+
 	it("should render sliders when model supports thinking", () => {
 		render(<ThinkingBudget {...defaultProps} />)
 

--- a/webview-ui/src/components/settings/providers/Moonshot.tsx
+++ b/webview-ui/src/components/settings/providers/Moonshot.tsx
@@ -63,9 +63,13 @@ export const Moonshot = ({ apiConfiguration, setApiConfigurationField }: Moonsho
 				{!apiConfiguration?.moonshotApiKey && (
 					<VSCodeButtonLink
 						href={
-							apiConfiguration.moonshotBaseUrl === "https://api.moonshot.cn/v1"
-								? "https://platform.moonshot.cn/console/api-keys"
-								: "https://platform.moonshot.ai/console/api-keys"
+							// kilocode_change start
+							apiConfiguration.moonshotBaseUrl === "https://api.kimi.com/coding/v1"
+								? "https://www.kimi.com/code"
+								: apiConfiguration.moonshotBaseUrl === "https://api.moonshot.cn/v1"
+									? "https://platform.moonshot.cn/console/api-keys"
+									: "https://platform.moonshot.ai/console/api-keys"
+							// kilocode_change end
 						}
 						appearance="secondary">
 						{t("settings:providers.getMoonshotApiKey")}

--- a/webview-ui/src/components/settings/providers/__tests__/Moonshot.spec.tsx
+++ b/webview-ui/src/components/settings/providers/__tests__/Moonshot.spec.tsx
@@ -1,0 +1,89 @@
+// kilocode_change - new file
+import { render, screen } from "@testing-library/react"
+
+import type { ProviderSettings } from "@roo-code/types"
+
+import { Moonshot } from "../Moonshot"
+
+vi.mock("@vscode/webview-ui-toolkit/react", () => ({
+	VSCodeTextField: ({ children, value, onInput, type, placeholder, className }: any) => (
+		<div>
+			{children}
+			<input
+				type={type}
+				value={value}
+				onChange={(event) => onInput?.(event)}
+				placeholder={placeholder}
+				className={className}
+			/>
+		</div>
+	),
+	VSCodeDropdown: ({ children, value, onChange, className }: any) => (
+		<select value={value} onChange={(event) => onChange?.(event)} className={className}>
+			{children}
+		</select>
+	),
+	VSCodeOption: ({ children, value, className }: any) => (
+		<option value={value} className={className}>
+			{children}
+		</option>
+	),
+}))
+
+vi.mock("@src/i18n/TranslationContext", () => ({
+	useAppTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock("@src/components/common/VSCodeButtonLink", () => ({
+	VSCodeButtonLink: ({ href, children }: any) => <a href={href}>{children}</a>,
+}))
+
+describe("Moonshot", () => {
+	const setApiConfigurationField = vi.fn()
+
+	const renderMoonshot = (apiConfiguration: ProviderSettings) =>
+		render(<Moonshot apiConfiguration={apiConfiguration} setApiConfigurationField={setApiConfigurationField} />)
+
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("uses kimi code URL for coding endpoint", () => {
+		renderMoonshot({
+			apiProvider: "moonshot",
+			moonshotBaseUrl: "https://api.kimi.com/coding/v1",
+			moonshotApiKey: "",
+		})
+
+		expect(screen.getByRole("link", { name: "settings:providers.getMoonshotApiKey" })).toHaveAttribute(
+			"href",
+			"https://www.kimi.com/code",
+		)
+	})
+
+	it("uses Moonshot CN URL for CN endpoint", () => {
+		renderMoonshot({
+			apiProvider: "moonshot",
+			moonshotBaseUrl: "https://api.moonshot.cn/v1",
+			moonshotApiKey: "",
+		})
+
+		expect(screen.getByRole("link", { name: "settings:providers.getMoonshotApiKey" })).toHaveAttribute(
+			"href",
+			"https://platform.moonshot.cn/console/api-keys",
+		)
+	})
+
+	it("uses Moonshot global URL for global endpoint", () => {
+		renderMoonshot({
+			apiProvider: "moonshot",
+			moonshotBaseUrl: "https://api.moonshot.ai/v1",
+			moonshotApiKey: "",
+		})
+
+		expect(screen.getByRole("link", { name: "settings:providers.getMoonshotApiKey" })).toHaveAttribute(
+			"href",
+			"https://platform.moonshot.ai/console/api-keys",
+		)
+	})
+})

--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
@@ -11,6 +11,7 @@ import {
 	BEDROCK_1M_CONTEXT_MODEL_IDS,
 	litellmDefaultModelInfo,
 	openAiModelInfoSaneDefaults,
+	moonshotModels,
 } from "@roo-code/types"
 
 import { useSelectedModel } from "../useSelectedModel"
@@ -421,6 +422,35 @@ describe("useSelectedModel", () => {
 			expect(result.current.provider).toBe("anthropic")
 			expect(result.current.id).toBe("claude-sonnet-4-5")
 			expect(result.current.info).toBeUndefined()
+		})
+	})
+
+	describe("moonshot endpoint restrictions", () => {
+		it("falls back to default Moonshot model when kimi-for-coding is used on non-coding endpoint", () => {
+			const apiConfiguration: ProviderSettings = {
+				apiProvider: "moonshot",
+				apiModelId: "kimi-for-coding",
+				moonshotBaseUrl: "https://api.moonshot.ai/v1",
+			}
+
+			const wrapper = createWrapper()
+			const { result } = renderHook(() => useSelectedModel(apiConfiguration), { wrapper })
+
+			const firstNonCodingMoonshotModelId = Object.keys(moonshotModels).find((id) => id !== "kimi-for-coding")
+			expect(result.current.id).toBe(firstNonCodingMoonshotModelId)
+		})
+
+		it("keeps kimi-for-coding when Moonshot coding endpoint is selected", () => {
+			const apiConfiguration: ProviderSettings = {
+				apiProvider: "moonshot",
+				apiModelId: "kimi-for-coding",
+				moonshotBaseUrl: "https://api.kimi.com/coding/v1",
+			}
+
+			const wrapper = createWrapper()
+			const { result } = renderHook(() => useSelectedModel(apiConfiguration), { wrapper })
+
+			expect(result.current.id).toBe("kimi-for-coding")
 		})
 	})
 

--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
@@ -440,6 +440,21 @@ describe("useSelectedModel", () => {
 			expect(result.current.id).toBe(firstNonCodingMoonshotModelId)
 		})
 
+		// kilocode_change start
+		it("forces kimi-for-coding when Moonshot coding endpoint is selected with a non-coding model", () => {
+			const apiConfiguration: ProviderSettings = {
+				apiProvider: "moonshot",
+				apiModelId: "kimi-k2-thinking",
+				moonshotBaseUrl: "https://api.kimi.com/coding/v1",
+			}
+
+			const wrapper = createWrapper()
+			const { result } = renderHook(() => useSelectedModel(apiConfiguration), { wrapper })
+
+			expect(result.current.id).toBe("kimi-for-coding")
+		})
+		// kilocode_change end
+
 		it("keeps kimi-for-coding when Moonshot coding endpoint is selected", () => {
 			const apiConfiguration: ProviderSettings = {
 				apiProvider: "moonshot",

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -9,6 +9,7 @@ import {
 	cerebrasModels,
 	deepSeekModels,
 	moonshotModels,
+	moonshotDefaultModelId,
 	minimaxModels,
 	geminiModels,
 	geminiDefaultModelId,
@@ -313,7 +314,18 @@ function getSelectedModel({
 			return { id, info }
 		}
 		case "moonshot": {
-			const id = apiConfiguration.apiModelId ?? defaultModelId
+			// kilocode_change start
+			const configuredId = apiConfiguration.apiModelId ?? defaultModelId
+			const isKimiCodingEndpoint = apiConfiguration.moonshotBaseUrl === "https://api.kimi.com/coding/v1"
+			const firstAllowedMoonshotModelId =
+				Object.keys(moonshotModels).find(
+					(modelId) => modelId !== "kimi-for-coding" || isKimiCodingEndpoint,
+				) ?? moonshotDefaultModelId
+			const id =
+				configuredId === "kimi-for-coding" && !isKimiCodingEndpoint
+					? firstAllowedMoonshotModelId
+					: configuredId
+			// kilocode_change end
 			const info = moonshotModels[id as keyof typeof moonshotModels]
 			return { id, info }
 		}

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -317,13 +317,12 @@ function getSelectedModel({
 			// kilocode_change start
 			const configuredId = apiConfiguration.apiModelId ?? defaultModelId
 			const isKimiCodingEndpoint = apiConfiguration.moonshotBaseUrl === "https://api.kimi.com/coding/v1"
-			const firstAllowedMoonshotModelId =
-				Object.keys(moonshotModels).find(
-					(modelId) => modelId !== "kimi-for-coding" || isKimiCodingEndpoint,
-				) ?? moonshotDefaultModelId
-			const id =
-				configuredId === "kimi-for-coding" && !isKimiCodingEndpoint
-					? firstAllowedMoonshotModelId
+			const firstNonCodingMoonshotModelId =
+				Object.keys(moonshotModels).find((modelId) => modelId !== "kimi-for-coding") ?? moonshotDefaultModelId
+			const id = isKimiCodingEndpoint
+				? "kimi-for-coding"
+				: configuredId === "kimi-for-coding"
+					? firstNonCodingMoonshotModelId
 					: configuredId
 			// kilocode_change end
 			const info = moonshotModels[id as keyof typeof moonshotModels]


### PR DESCRIPTION
# Here we go again

I would appreciate proper validation this time around 😄 

## Context

This PR fixes the Moonshot/Kimi regression in #5719.

After the AI-SDK migration, users on Moonshot (`kimi-k2.5` and `kimi-for-coding`) could hit a tool-calling loop with `MODEL_NO_TOOLS_USED`. In practice, Kilo would often output literal `<read_file>`-style text instead of executing native tool calls.

We made this fix to re-align our Moonshot/Kimi behavior with Moonshot API expectations and restore reliable native tool execution, without rolling back the migration or changing behavior for unrelated providers.

Root causes addressed:
- `kimi-k2.5` metadata no longer clearly advertised native tool support.
- Moonshot can stream tool arguments via `tool-input-*` events, but we did not always convert those into executable `tool_call` chunks.
- Strict Kimi thinking contract (binary thinking + fixed temperatures) was not enforced consistently.
- Reasoning continuity (`reasoning_content`) needed to be preserved across AI-SDK message conversion.

## Why we did not do a Moonshot-only adapter fix

We considered patching only `MoonshotHandler`, but the primary break happened in the shared AI-SDK/OpenAI-compatible stream layer (`tool-input-*` handling), not only in Moonshot-specific policy code.

A Moonshot-only patch would have:
- duplicated stream-conversion logic in a provider adapter, or
- introduced fragile provider-specific special casing in the wrong layer.

Instead, this PR:
- fixes message/tool stream conversion in the shared OpenAI-compatible base handler (where the regression actually lives),
- keeps Moonshot-specific behavior (thinking toggle + strict temperature policy) in `MoonshotHandler`.

This keeps architecture clean, reduces duplication, and lowers long-term merge/regression risk.

## Implementation

### 1) Restore strict Kimi model capabilities
Updated `packages/types/src/providers/moonshot.ts` for `kimi-k2.5` and `kimi-for-coding`:
- native tools enabled (`supportsNativeTools: true`, `defaultToolProtocol: "native"`)
- reasoning preservation enabled (`preserveReasoning: true`)
- binary/adaptive reasoning metadata enabled
- temperature control disabled for UI/runtime (`supportsTemperature: false`, `defaultTemperature: 0.6`)

Why: ensure runtime and UI choose the correct native tool protocol and strict model behavior.

### 2) Convert Moonshot `tool-input-*` streams into executable tool calls
In `src/api/providers/openai-compatible.ts`:
- added accumulation for `tool-input-start` + `tool-input-delta`
- emit final `tool_call` chunk on `tool-input-end`
- flush pending tool input at stream end
- prevent duplicate emission when direct `tool-call` is also present

Why: Moonshot may stream tool input incrementally; Task execution requires finalized `tool_call` chunks.

### 3) Enforce strict Kimi thinking contract in Moonshot handler
In `src/api/providers/moonshot.ts`, for strict Kimi models only:
- thinking enabled (`enableReasoningEffort !== false`) => force `temperature = 1.0`
- thinking disabled => force `temperature = 0.6`
- ignore arbitrary custom `modelTemperature` for these models
- always send Moonshot provider thinking option (`enabled`/`disabled`)

Why: keep requests compliant with strict Kimi expectations and avoid invalid mixed settings.

### 4) Preserve reasoning continuity in AI-SDK conversion
In `src/api/transform/ai-sdk.ts`:
- preserve user text/tool-result ordering
- preserve assistant text/tool-call ordering
- map assistant reasoning blocks to `providerOptions.openaiCompatible.reasoning_content`

Why: avoid reasoning context loss across turns in the OpenAI-compatible path.

### 5) UI alignment for binary reasoning models
In `webview-ui/src/components/settings/ThinkingBudget.tsx`:
- binary reasoning checkbox now defaults to enabled when unset (`enableReasoningEffort ?? true`)

Why: UI default now matches backend behavior for strict Kimi models.

### 6) Regression coverage
Added/updated tests:
- `src/api/providers/__tests__/moonshot.spec.ts`
- `src/api/transform/__tests__/ai-sdk.spec.ts`
- `src/api/transform/__tests__/model-params.spec.ts`
- `webview-ui/src/components/settings/__tests__/ThinkingBudget.spec.tsx`

Added changeset:
- `.changeset/green-geese-warn.md`

## Screenshots

<table>
<tr><td><img width="955" height="2090" alt="image" src="https://github.com/user-attachments/assets/8434756c-05bf-4431-b07f-076449be7145" />
</table>

## How to Test

1. Run targeted regression tests:
- `cd src && pnpm test api/providers/__tests__/moonshot.spec.ts api/transform/__tests__/ai-sdk.spec.ts api/transform/__tests__/model-params.spec.ts`
- `cd webview-ui && pnpm test src/components/settings/__tests__/ThinkingBudget.spec.tsx`

2. Manual provider check:
- Provider: `moonshot`
- Base URL: `https://api.kimi.com/coding/v1`
- Model: `kimi-k2.5`
- Ask a tool-heavy prompt (for example: read/summarize files)
- Confirm native tool calls execute and it no longer loops with `MODEL_NO_TOOLS_USED`

3. Repeat manual check for:
- Model: `kimi-for-coding`

4. Verify strict thinking behavior:
- Thinking ON => request uses temperature `1.0` and Moonshot thinking `enabled`
- Thinking OFF => request uses temperature `0.6` and Moonshot thinking `disabled`

> [!CAUTION]
> This PR relied heavily on AI assistance. I had already investigated this area in a previous PR attempt and used AI to accelerate implementation while keeping scope tight.