### PR TITLE
Fix Opus 4.6 model name

### DIFF
--- a/.changeset/big-kiwis-add.md
+++ b/.changeset/big-kiwis-add.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Opus 4.6 model name

--- a/packages/types/src/providers/vertex.ts
+++ b/packages/types/src/providers/vertex.ts
@@ -7,7 +7,7 @@ export const vertexDefaultModelId: VertexModelId = "claude-sonnet-4-5@20250929"
 
 export const vertexModels = {
 	// kilocode_change start
-	"claude-opus-4-6@vertex": {
+	"claude-opus-4-6@default": {
 		maxTokens: 128_000,
 		contextWindow: 200_000,
 		supportsImages: true,


### PR DESCRIPTION
Fixes #5743

Per [the documentation here](https://console.cloud.google.com/vertex-ai/publishers/anthropic/model-garden/claude-opus-4-6), the version name of this model is `claude-opus-4-6@default`.