### PR TITLE
fix(jetbrains): add missing vsix dependency for build pipeline

### DIFF
--- a/.changeset/fix-jetbrains-build.md
+++ b/.changeset/fix-jetbrains-build.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix JetBrains build failure by adding missing vsix dependency for build pipeline

--- a/jetbrains/plugin/turbo.json
+++ b/jetbrains/plugin/turbo.json
@@ -22,11 +22,11 @@
 		},
 		"copy:kilocode": {
 			"cache": false,
-			"dependsOn": ["clean:kilocode", "kilo-code#vsix:unpacked"]
+			"dependsOn": ["clean:kilocode", "kilo-code#vsix", "kilo-code#vsix:unpacked"]
 		},
 		"copy:resource-kilocode": {
 			"cache": false,
-			"dependsOn": ["clean:resource-kilocode", "kilo-code#vsix:unpacked"]
+			"dependsOn": ["clean:resource-kilocode", "kilo-code#vsix", "kilo-code#vsix:unpacked"]
 		},
 		"copy:resource-host": {
 			"cache": false,


### PR DESCRIPTION
## Context

The JetBrains build GitHub Action was failing with error exit code 9 because the `vsix:unpacked` task couldn't find the VSIX file to unzip.

## Implementation

The issue was in `jetbrains/plugin/turbo.json` where `copy:kilocode` and `copy:resource-kilocode` tasks depended on `kilo-code#vsix:unpacked` but not on `kilo-code#vsix` to create the VSIX file first.

The fix adds `"kilo-code#vsix"` as a dependency for both tasks:
- `copy:kilocode`: now depends on `["clean:kilocode", "kilo-code#vsix", "kilo-code#vsix:unpacked"]`
- `copy:resource-kilocode`: now depends on `["clean:resource-kilocode", "kilo-code#vsix", "kilo-code#vsix:unpacked"]`

This ensures the VSIX file is built (`kilo-code#vsix` → `../bin/kilo-code-*.vsix`) before being unpacked (`kilo-code#vsix:unpacked` → `../bin-unpacked`).

## How to Test

Run the JetBrains build pipeline:
```
pnpm turbo jetbrains:build
```

The build should complete successfully without the "unzip: cannot find or open" error.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
