### PR TITLE
Fixes broken /slash-commands after continue or interrupted tool-use

### DIFF
--- a/.changeset/free-toes-hammer.md
+++ b/.changeset/free-toes-hammer.md
@@ -1,0 +1,14 @@
+---
+"kilo-code": patch
+---
+
+fix(mentions): process slash commands in tool_result blocks
+
+Previously, parseKiloSlashCommands was only called for text blocks,
+causing slash commands in tool_result blocks to be ignored. This fix
+extends the processing to tool_result blocks by using the new
+processTextContent helper function that combines parseMentions and
+parseKiloSlashCommands.
+
+The regression test ensures that slash commands in tool responses are
+properly processed and transformed.

--- a/src/core/mentions/__tests__/processKiloUserContentMentions.spec.ts
+++ b/src/core/mentions/__tests__/processKiloUserContentMentions.spec.ts
@@ -1,0 +1,191 @@
+// Regression test for slash command processing in tool_result blocks
+// This test will FAIL with the current implementation because parseKiloSlashCommands
+// is not called for tool_result blocks. It should pass after the bug is fixed.
+
+// **The Bug:**
+// In `src/core/mentions/processKiloUserContentMentions.ts`, the function calls `parseKiloSlashCommands` for `text` blocks but NOT for `tool_result` blocks. This means when a user answers with a slash command to a tool like "ask for feedback", the command is ignored.
+
+// **Expected Behavior:**
+// When the tests pass, the bug will be fixed and slash commands in tool responses will be properly processed.
+
+import { processKiloUserContentMentions } from "../processKiloUserContentMentions"
+import { parseMentions } from "../index"
+import { parseKiloSlashCommands } from "../../slash-commands/kilo"
+import { refreshWorkflowToggles } from "../../context/instructions/workflows"
+import { ensureLocalKilorulesDirExists } from "../../context/instructions/kilo-rules"
+import { UrlContentFetcher } from "../../../services/browser/UrlContentFetcher"
+import { FileContextTracker } from "../../context-tracking/FileContextTracker"
+import * as vscode from "vscode"
+
+// Mock dependencies
+vi.mock("../index", () => ({
+	parseMentions: vi.fn(),
+}))
+
+vi.mock("../../slash-commands/kilo", () => ({
+	parseKiloSlashCommands: vi.fn(),
+}))
+
+vi.mock("../../context/instructions/workflows", () => ({
+	refreshWorkflowToggles: vi.fn(),
+}))
+
+vi.mock("../../context/instructions/kilo-rules", () => ({
+	ensureLocalKilorulesDirExists: vi.fn(),
+}))
+
+describe("processKiloUserContentMentions - slash command regression", () => {
+	const mockContext = {} as vscode.ExtensionContext
+	const mockUrlContentFetcher = {} as UrlContentFetcher
+	const mockFileContextTracker = {} as FileContextTracker
+	const mockRooIgnoreController = {} as any
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		// Default mocks
+		vi.mocked(parseMentions).mockImplementation(async (text) => ({
+			text: `parsed: ${text}`,
+			mode: undefined,
+		}))
+
+		vi.mocked(parseKiloSlashCommands).mockImplementation(async (text, localToggles, globalToggles) => ({
+			processedText: text,
+			needsRulesFileCheck: false,
+		}))
+
+		vi.mocked(refreshWorkflowToggles).mockResolvedValue({
+			localWorkflowToggles: {},
+			globalWorkflowToggles: {},
+		})
+
+		vi.mocked(ensureLocalKilorulesDirExists).mockResolvedValue(false)
+	})
+
+	const defaultParams = {
+		context: mockContext,
+		cwd: "/test",
+		urlContentFetcher: mockUrlContentFetcher,
+		fileContextTracker: mockFileContextTracker,
+		rooIgnoreController: mockRooIgnoreController,
+		showRooIgnoredFiles: false,
+		includeDiagnosticMessages: true,
+		maxDiagnosticMessages: 50,
+	}
+
+	describe("slash command processing in tool_result blocks", () => {
+		it("should call parseKiloSlashCommands for tool_result with string content containing <user_message> and slash command", async () => {
+			const userContent = [
+				{
+					type: "tool_result" as const,
+					tool_use_id: "call_123",
+					content: "<user_message>/just-do-this-workflow.md</user_message>",
+				},
+			]
+
+			const [result] = await processKiloUserContentMentions({
+				...defaultParams,
+				userContent,
+			})
+
+			// Verify parseKiloSlashCommands was called with the text after parseMentions
+			expect(parseKiloSlashCommands).toHaveBeenCalledWith(
+				"parsed: <user_message>/just-do-this-workflow.md</user_message>",
+				{},
+				{},
+			)
+
+			// The content should be the processed result from parseKiloSlashCommands
+			expect(result[0]).toEqual({
+				type: "tool_result",
+				tool_use_id: "call_123",
+				content: "parsed: <user_message>/just-do-this-workflow.md</user_message>",
+			})
+		})
+
+		it("should call parseKiloSlashCommands for tool_result with array content containing <user_message> and slash command", async () => {
+			const userContent = [
+				{
+					type: "tool_result" as const,
+					tool_use_id: "call_456",
+					content: [
+						{
+							type: "text" as const,
+							text: "<user_message>/newtask</user_message>",
+						},
+					],
+				},
+			]
+
+			const [result] = await processKiloUserContentMentions({
+				...defaultParams,
+				userContent,
+			})
+
+			// Verify parseKiloSlashCommands was called
+			expect(parseKiloSlashCommands).toHaveBeenCalledWith("parsed: <user_message>/newtask</user_message>", {}, {})
+
+			// The content array should have the processed text
+			expect(result[0]).toEqual({
+				type: "tool_result",
+				tool_use_id: "call_456",
+				content: [
+					{
+						type: "text",
+						text: "parsed: <user_message>/newtask</user_message>",
+					},
+				],
+			})
+		})
+
+		it("should handle slash command transformation in tool_result", async () => {
+			// Mock parseKiloSlashCommands to actually transform the slash command
+			vi.mocked(parseKiloSlashCommands).mockResolvedValue({
+				processedText:
+					'<explicit_instructions type="new_task">\n</explicit_instructions>\n<user_message></user_message>',
+				needsRulesFileCheck: false,
+			})
+
+			const userContent = [
+				{
+					type: "tool_result" as const,
+					tool_use_id: "call_789",
+					content: "<user_message>/newtask</user_message>",
+				},
+			]
+
+			const [result] = await processKiloUserContentMentions({
+				...defaultParams,
+				userContent,
+			})
+
+			// The content should be the transformed text
+			expect(result[0]).toEqual({
+				type: "tool_result",
+				tool_use_id: "call_789",
+				content:
+					'<explicit_instructions type="new_task">\n</explicit_instructions>\n<user_message></user_message>',
+			})
+		})
+
+		it("should not call parseKiloSlashCommands for tool_result without mention tags", async () => {
+			const userContent = [
+				{
+					type: "tool_result" as const,
+					tool_use_id: "call_999",
+					content: "Just regular feedback without special tags",
+				},
+			]
+
+			await processKiloUserContentMentions({
+				...defaultParams,
+				userContent,
+			})
+
+			// parseMentions should not be called because no mention tags
+			expect(parseMentions).not.toHaveBeenCalled()
+			// parseKiloSlashCommands should not be called
+			expect(parseKiloSlashCommands).not.toHaveBeenCalled()
+		})
+	})
+})


### PR DESCRIPTION
## Context

**What problem does this fix?**

This fixes a bug where slash commands in `tool_result` blocks were being ignored. When a user responds to a tool (e.g., "ask for feedback"), or the attempt_completion, or the user cancels a tool and then responds with a slash command like `/newtask` or a workflow file within `<user_message>` tags, or if the user canceled, the command was not being processed. The root cause was that `parseKiloSlashCommands` was only called for `text` blocks, not for `tool_result` blocks in the `processKiloUserContentMentions` function.

## Implementation

**How was it achieved?**

1. **Refactored with a helper function**: Created `processTextContent` that combines `parseMentions` and `parseKiloSlashCommands` into a single pipeline. This eliminates code duplication and ensures consistent processing across all block types.

2. **Extended processing to `tool_result` blocks**:
   - For `tool_result` with string content: now processes through `processTextContent` when mention tags are present
   - For `tool_result` with array content: each text block is processed through `processTextContent`
   - Properly propagates `needsRulesFileCheck` flag in all cases

3. **Added comprehensive regression tests**: Created 4 test cases covering:
   - String content in `tool_result` with slash commands
   - Array content in `tool_result` with slash commands
   - Slash command transformation verification
   - No-op when no mention tags present

**Tradeoffs**: None - this is a pure bug fix that extends existing logic to a missing case without changing behavior for other scenarios.

**Important attention points**:
- The fix maintains the `needsRulesFileCheck` flag correctly across all code paths
- The helper function signature uses `ClineRulesToggles` type for consistency
- All existing tests continue to pass (verified: 37 mentions tests pass, as do the 3000+ src/core tests)

## Screenshots

| before | after |
| ------ | ----- |
| N/A (logic bug) | N/A (logic bug) |

*This is a backend logic fix with no UI changes.*

## How to Test

**Manual testing:**

1. Trigger a tool that asks for feedback (e.g., `/ask` or any tool that returns a `tool_result`)
2. In your response, include a slash command within `<user_message>` tags:
   - Example 1: `<user_message>/newtask</user_message>`
   - Example 2: `<user_message>/just-do-this-workflow.md</user_message>`
3. Verify the slash command is properly processed and transformed (e.g., new task is created, workflow is executed)
4. Test both formats: when `tool_result.content` is a string and when it's an array of text blocks

**Automated testing:**

```bash
cd src && pnpm test core/mentions/__tests__/processKiloUserContentMentions.spec.ts
```

Expected: All 4 new regression tests pass, plus all existing mentions tests (37 total) pass.

The changeset has been created at `.changeset/free-toes-hammer.md`.

## Get in Touch

Madrawn in Discord

