### PR TITLE
fix: auto-approve piped commands when allowlist contains redirection

### DIFF
--- a/.changeset/wide-mammals-open.md
+++ b/.changeset/wide-mammals-open.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Minor improvement of auto-execute commands with input redirection

--- a/src/core/auto-approval/__tests__/commands.spec.ts
+++ b/src/core/auto-approval/__tests__/commands.spec.ts
@@ -1,3 +1,4 @@
+// kilocode_change - new file
 import { getCommandDecision } from "../commands"
 
 describe("getCommandDecision", () => {

--- a/src/core/auto-approval/__tests__/commands.spec.ts
+++ b/src/core/auto-approval/__tests__/commands.spec.ts
@@ -1,0 +1,28 @@
+import { getCommandDecision } from "../commands"
+
+describe("getCommandDecision", () => {
+	describe("piped commands with redirections", () => {
+		it("should auto-approve piped command when allowlist contains redirection pattern", () => {
+			// When the allowlist contains "pnpm compile 2>&1" and "head",
+			// the command "pnpm compile 2>&1 | head -100" should be auto-approved
+			const allowedCommands = ["pnpm compile 2>&1", "head"]
+			const deniedCommands: string[] = []
+
+			const result = getCommandDecision("pnpm compile 2>&1 | head -100", allowedCommands, deniedCommands)
+
+			expect(result).toBe("auto_approve")
+		})
+
+		it("should auto-approve when allowlist has command without redirection and command uses redirection", () => {
+			// When the allowlist contains "pnpm compile" (without redirection),
+			// the command "pnpm compile 2>&1 | head -100" should still be auto-approved
+			// because stripping the redirection from the command should match the allowlist
+			const allowedCommands = ["pnpm compile", "head"]
+			const deniedCommands: string[] = []
+
+			const result = getCommandDecision("pnpm compile 2>&1 | head -100", allowedCommands, deniedCommands)
+
+			expect(result).toBe("auto_approve")
+		})
+	})
+})

--- a/src/core/auto-approval/commands.ts
+++ b/src/core/auto-approval/commands.ts
@@ -286,15 +286,11 @@ export function getCommandDecision(
 
 		// If either version is auto-approved, use that decision (prefer approval)
 		// If either version is auto-denied, use that decision (prefer denial over ask_user)
-		if (decisionWithoutRedirection === "auto_approve" || decisionWithRedirection === "auto_approve") {
-			// But if one is denied, denial takes precedence
-			if (decisionWithoutRedirection === "auto_deny" || decisionWithRedirection === "auto_deny") {
-				return "auto_deny"
-			}
-			return "auto_approve"
-		}
 		if (decisionWithoutRedirection === "auto_deny" || decisionWithRedirection === "auto_deny") {
 			return "auto_deny"
+		}
+		if (decisionWithoutRedirection === "auto_approve" || decisionWithRedirection === "auto_approve") {
+			return "auto_approve"
 		}
 		return "ask_user"
 		// kilocode_change end

--- a/src/core/auto-approval/commands.ts
+++ b/src/core/auto-approval/commands.ts
@@ -273,6 +273,7 @@ export function getCommandDecision(
 		// Remove simple PowerShell-like redirections (e.g. 2>&1) before checking
 		const cmdWithoutRedirection = cmd.replace(/\d*>&\d*/, "").trim()
 
+		// kilocode_change start
 		// Try matching both the original command and the stripped command.
 		// This handles the case where the allowlist contains a pattern with redirection
 		// (e.g., "pnpm compile 2>&1") but the stripped command doesn't match it.
@@ -296,6 +297,7 @@ export function getCommandDecision(
 			return "auto_deny"
 		}
 		return "ask_user"
+		// kilocode_change end
 	})
 
 	// If any sub-command is denied, deny the whole command


### PR DESCRIPTION
## Problem

The command `pnpm compile 2>&1 | head -100` was not being auto-approved even though both `pnpm compile 2>&1` and `head` were in the allowlist.

## Root Cause

In `getCommandDecision()`, the redirection stripping regex `/\d*>&\d*/` was removing `2>&1` from commands **before** matching against the allowlist. This caused `pnpm compile 2>&1` to become `pnpm compile`, which didn't match the allowlist pattern `pnpm compile 2>&1` (prefix matching requires the command to START with the pattern).

## Fix

Modified the matching logic to try BOTH the original command AND the stripped command against the allowlist. If either version matches, the command is approved (unless the other is denied).

## Testing

Added test in `src/core/auto-approval/__tests__/commands.spec.ts` that verifies piped commands like `pnpm compile 2>&1 | head -100` are auto-approved when the allowlist contains `pnpm compile 2>&1` and `head`.