### PR TITLE
feat(anthropic): support custom model typing and endpoint discovery for Anthropic-compatible providers

### DIFF
--- a/.changeset/fifty-carpets-wave.md
+++ b/.changeset/fifty-carpets-wave.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Added support for custom Anthropic-compatible model IDs and manual Anthropic model entry in provider settings.

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -227,6 +227,7 @@ const anthropicSchema = apiModelIdProviderModelSchema.extend({
 	anthropicBaseUrl: z.string().optional(),
 	anthropicUseAuthToken: z.boolean().optional(),
 	anthropicDeploymentName: z.string().optional(), // kilocode_change
+	anthropicCustomAdaptiveThinking: z.boolean().optional(), // kilocode_change
 	anthropicBeta1MContext: z.boolean().optional(), // Enable 'context-1m-2025-08-07' beta for 1M context window.
 })
 

--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -150,6 +150,7 @@ export interface ExtensionMessage {
 		| "listApiConfig"
 		| "routerModels"
 		| "openAiModels"
+		| "anthropicModels" // kilocode_change
 		| "ollamaModels"
 		| "lmStudioModels"
 		| "vsCodeLmModels"
@@ -303,6 +304,7 @@ export interface ExtensionMessage {
 	clineMessage?: ClineMessage
 	routerModels?: RouterModels
 	openAiModels?: string[]
+	anthropicModels?: string[] // kilocode_change
 	ollamaModels?: ModelRecord
 	lmStudioModels?: ModelRecord
 	vsCodeLmModels?: { vendor?: string; family?: string; version?: string; id?: string }[]
@@ -733,6 +735,7 @@ export interface WebviewMessage {
 		| "flushRouterModels"
 		| "requestRouterModels"
 		| "requestOpenAiModels"
+		| "requestAnthropicModels" // kilocode_change
 		| "requestOllamaModels"
 		| "requestLmStudioModels"
 		| "requestRooModels"

--- a/src/api/providers/__tests__/anthropic.spec.ts
+++ b/src/api/providers/__tests__/anthropic.spec.ts
@@ -267,8 +267,12 @@ describe("AnthropicHandler", () => {
 	// kilocode_change start
 	describe("getAnthropicSdkBaseUrl", () => {
 		it("strips trailing /v1 from custom base URLs", () => {
-			expect(getAnthropicSdkBaseUrl("https://anthropic-compatible.example.com/v1")).toBe("https://anthropic-compatible.example.com")
-			expect(getAnthropicSdkBaseUrl("https://anthropic-compatible.example.com")).toBe("https://anthropic-compatible.example.com")
+			expect(getAnthropicSdkBaseUrl("https://anthropic-compatible.example.com/v1")).toBe(
+				"https://anthropic-compatible.example.com",
+			)
+			expect(getAnthropicSdkBaseUrl("https://anthropic-compatible.example.com")).toBe(
+				"https://anthropic-compatible.example.com",
+			)
 		})
 	})
 
@@ -451,6 +455,20 @@ describe("AnthropicHandler", () => {
 
 			expect(model.id).toBe("MinMax-M2")
 			expect(model.info).toBeDefined()
+		})
+
+		it("enables adaptive thinking capability for custom model IDs when explicitly toggled", () => {
+			const handlerWithCustomModel = new AnthropicHandler({
+				...mockOptions,
+				apiModelId: "ac/op-46",
+				anthropicCustomAdaptiveThinking: true,
+			})
+
+			const model = handlerWithCustomModel.getModel()
+
+			expect(model.id).toBe("ac/op-46")
+			expect(model.info.supportsAdaptiveThinking).toBe(true)
+			expect(model.reasoning).toEqual({ type: "adaptive" })
 		})
 		// kilocode_change end
 	})

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -403,6 +403,7 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 					// Allow advanced controls for Anthropic-compatible custom models.
 					supportsReasoningBudget: true,
 					supportsVerbosity: defaultInfo.supportsVerbosity || ["low", "medium", "high", "max"],
+					supportsAdaptiveThinking: this.options.anthropicCustomAdaptiveThinking === true,
 				}
 		// kilocode_change end
 

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -4,6 +4,9 @@ import type { Mock } from "vitest"
 
 // Mock dependencies - must come before imports
 vi.mock("../../../api/providers/fetchers/modelCache")
+vi.mock("../../../api/providers/anthropic", () => ({
+	getAnthropicModels: vi.fn(),
+}))
 
 vi.mock("../../../integrations/openai-codex/oauth", () => ({
 	openAiCodexOAuthManager: {
@@ -26,10 +29,12 @@ import type { ModelRecord } from "@roo-code/types"
 import { webviewMessageHandler } from "../webviewMessageHandler"
 import type { ClineProvider } from "../ClineProvider"
 import { getModels } from "../../../api/providers/fetchers/modelCache"
+import { getAnthropicModels } from "../../../api/providers/anthropic"
 const { openAiCodexOAuthManager } = await import("../../../integrations/openai-codex/oauth")
 const { fetchOpenAiCodexRateLimitInfo } = await import("../../../integrations/openai-codex/rate-limits")
 
 const mockGetModels = getModels as Mock<typeof getModels>
+const mockGetAnthropicModels = getAnthropicModels as Mock<typeof getAnthropicModels>
 const mockGetAccessToken = vi.mocked(openAiCodexOAuthManager.getAccessToken)
 const mockGetAccountId = vi.mocked(openAiCodexOAuthManager.getAccountId)
 const mockFetchOpenAiCodexRateLimitInfo = vi.mocked(fetchOpenAiCodexRateLimitInfo)
@@ -755,6 +760,33 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 		})
 	})
 })
+
+// kilocode_change start
+describe("webviewMessageHandler - requestAnthropicModels", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("fetches anthropic-compatible models and posts them to the webview", async () => {
+		mockGetAnthropicModels.mockResolvedValue(["claude-sonnet-4-5-20250929", "MinMax-M2"])
+
+		await webviewMessageHandler(mockClineProvider, {
+			type: "requestAnthropicModels",
+			values: {
+				baseUrl: "https://anthropic-compatible.example.com/v1",
+				apiKey: "test-key",
+				useAuthToken: true,
+			},
+		} as any)
+
+		expect(mockGetAnthropicModels).toHaveBeenCalledWith("https://anthropic-compatible.example.com/v1", "test-key", true)
+		expect(mockClineProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "anthropicModels",
+			anthropicModels: ["claude-sonnet-4-5-20250929", "MinMax-M2"],
+		})
+	})
+})
+// kilocode_change end
 
 describe("webviewMessageHandler - requestOpenAiCodexRateLimits", () => {
 	beforeEach(() => {

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -72,6 +72,7 @@ import { singleCompletionHandler } from "../../utils/single-completion-handler" 
 import { searchCommits } from "../../utils/git"
 import { exportSettings, importSettingsWithFeedback } from "../config/importExport"
 import { getOpenAiModels } from "../../api/providers/openai"
+import { getAnthropicModels } from "../../api/providers/anthropic" // kilocode_change
 import { getVsCodeLmModels } from "../../api/providers/vscode-lm"
 import { openMention } from "../mentions"
 import { resolveImageMentions } from "../mentions/resolveImageMentions"
@@ -806,9 +807,7 @@ export const webviewMessageHandler = async (
 					await provider.postStateToWebview()
 					console.log(`Batch deletion completed: ${ids.length} tasks processed`)
 				} catch (error) {
-					console.log(
-						`Batch deletion failed: ${error instanceof Error ? error.message : String(error)}`,
-					)
+					console.log(`Batch deletion failed: ${error instanceof Error ? error.message : String(error)}`)
 				}
 				// kilocode_change end
 			}
@@ -1200,6 +1199,18 @@ export const webviewMessageHandler = async (
 			}
 
 			break
+		// kilocode_change start
+		case "requestAnthropicModels": {
+			const anthropicModels = await getAnthropicModels(
+				message?.values?.baseUrl,
+				message?.values?.apiKey,
+				message?.values?.useAuthToken === true,
+			)
+
+			provider.postMessageToWebview({ type: "anthropicModels", anthropicModels })
+			break
+		}
+		// kilocode_change end
 		case "requestVsCodeLmModels":
 			const vsCodeLmModels = await getVsCodeLmModels()
 			// TODO: Cache like we do for OpenRouter, etc?

--- a/webview-ui/src/components/settings/ThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudget.tsx
@@ -144,6 +144,9 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 	const customMaxOutputTokens = apiConfiguration.modelMaxTokens || DEFAULT_HYBRID_REASONING_MODEL_MAX_TOKENS
 	const customMaxThinkingTokens =
 		apiConfiguration.modelMaxThinkingTokens || DEFAULT_HYBRID_REASONING_MODEL_THINKING_TOKENS
+	// kilocode_change start
+	const isAdaptiveThinkingActive = !!modelInfo?.supportsAdaptiveThinking && enableReasoningEffort !== false
+	// kilocode_change end
 
 	// Dynamically expand or shrink the max thinking budget based on the custom
 	// max output tokens so that there's always a 20% buffer.
@@ -222,19 +225,31 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 							<div className="w-12 text-sm text-center">{customMaxOutputTokens}</div>
 						</div>
 					</div>
-					<div className="flex flex-col gap-1">
-						<div className="font-medium">{t("settings:thinkingBudget.maxThinkingTokens")}</div>
-						<div className="flex items-center gap-1" data-testid="reasoning-budget">
-							<Slider
-								min={minThinkingTokens}
-								max={modelMaxThinkingTokens}
-								step={minThinkingTokens === 128 ? 128 : 1024}
-								value={[customMaxThinkingTokens]}
-								onValueChange={([value]) => setApiConfigurationField("modelMaxThinkingTokens", value)}
-							/>
-							<div className="w-12 text-sm text-center">{customMaxThinkingTokens}</div>
+					{/* kilocode_change start */}
+					{isAdaptiveThinkingActive ? (
+						<div
+							className="text-xs text-vscode-descriptionForeground"
+							data-testid="adaptive-thinking-budget-hint">
+							{t("settings:thinkingBudget.adaptiveThinkingBudgetHint")}
 						</div>
-					</div>
+					) : (
+						<div className="flex flex-col gap-1">
+							<div className="font-medium">{t("settings:thinkingBudget.maxThinkingTokens")}</div>
+							<div className="flex items-center gap-1" data-testid="reasoning-budget">
+								<Slider
+									min={minThinkingTokens}
+									max={modelMaxThinkingTokens}
+									step={minThinkingTokens === 128 ? 128 : 1024}
+									value={[customMaxThinkingTokens]}
+									onValueChange={([value]) =>
+										setApiConfigurationField("modelMaxThinkingTokens", value)
+									}
+								/>
+								<div className="w-12 text-sm text-center">{customMaxThinkingTokens}</div>
+							</div>
+						</div>
+					)}
+					{/* kilocode_change end */}
 				</>
 			)}
 		</>

--- a/webview-ui/src/components/settings/__tests__/ThinkingBudget.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ThinkingBudget.spec.tsx
@@ -117,6 +117,21 @@ describe("ThinkingBudget", () => {
 		expect(screen.getAllByTestId("slider")).toHaveLength(2)
 	})
 
+	it("should hide max thinking slider and show hint when adaptive thinking is active", () => {
+		render(
+			<ThinkingBudget
+				{...defaultProps}
+				apiConfiguration={{ enableReasoningEffort: true }}
+				modelInfo={{ ...mockModelInfo, supportsAdaptiveThinking: true }}
+			/>,
+		)
+
+		expect(screen.getAllByTestId("slider")).toHaveLength(1)
+		expect(screen.queryByTestId("reasoning-budget")).not.toBeInTheDocument()
+		expect(screen.getByTestId("adaptive-thinking-budget-hint")).toBeInTheDocument()
+		expect(screen.getByText("settings:thinkingBudget.adaptiveThinkingBudgetHint")).toBeInTheDocument()
+	})
+
 	it("should update modelMaxThinkingTokens", () => {
 		const setApiConfigurationField = vi.fn()
 

--- a/webview-ui/src/components/settings/providers/Anthropic.tsx
+++ b/webview-ui/src/components/settings/providers/Anthropic.tsx
@@ -79,7 +79,7 @@ export const Anthropic = ({ apiConfiguration, setApiConfigurationField }: Anthro
 							value={apiConfiguration?.anthropicBaseUrl || ""}
 							type="url"
 							onInput={handleInputChange("anthropicBaseUrl")}
-							placeholder="https://api.anthropic.com"
+							placeholder="https://anthropic-compatible.example.com/v1" // kilocode_change
 							className="w-full mt-1"
 						/>
 						<Checkbox

--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
@@ -43,6 +43,38 @@ const createWrapper = () => {
 }
 
 describe("useSelectedModel", () => {
+	// kilocode_change start
+	describe("Anthropic custom model capabilities", () => {
+		it("provides reasoning and verbosity capability defaults for unknown Anthropic-compatible model IDs", () => {
+			mockUseRouterModels.mockReturnValue({
+				data: undefined,
+				isLoading: false,
+				isError: false,
+			} as any)
+
+			mockUseOpenRouterModelProviders.mockReturnValue({
+				data: {},
+				isLoading: false,
+				isError: false,
+			} as any)
+
+			const wrapper = createWrapper()
+			const { result } = renderHook(
+				() =>
+					useSelectedModel({
+						apiProvider: "anthropic",
+						apiModelId: "MinMax-M2",
+					}),
+				{ wrapper },
+			)
+
+			expect(result.current.id).toBe("MinMax-M2")
+			expect(result.current.info?.supportsReasoningBudget).toBe(true)
+			expect(result.current.info?.supportsVerbosity).toBeTruthy()
+		})
+	})
+	// kilocode_change end
+
 	describe("OpenRouter provider merging", () => {
 		it("should merge base model info with specific provider info when both exist", () => {
 			const baseModelInfo: ModelInfo = {

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -574,6 +574,7 @@ function getSelectedModel({
 							...defaultInfo,
 							supportsReasoningBudget: true,
 							supportsVerbosity: defaultInfo.supportsVerbosity || ["low", "medium", "high", "max"],
+							supportsAdaptiveThinking: apiConfiguration.anthropicCustomAdaptiveThinking === true,
 						}
 					: knownInfo
 			// kilocode_change end

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -565,7 +565,18 @@ function getSelectedModel({
 		default: {
 			provider satisfies "anthropic" | "fake-ai" | "human-relay" | "kilocode"
 			const id = apiConfiguration.apiModelId ?? defaultModelId
-			const baseInfo = anthropicModels[id as keyof typeof anthropicModels]
+			// kilocode_change start
+			const knownInfo = anthropicModels[id as keyof typeof anthropicModels]
+			const defaultInfo: ModelInfo = anthropicModels[defaultModelId as keyof typeof anthropicModels]
+			const baseInfo =
+				provider === "anthropic" && !knownInfo
+					? {
+							...defaultInfo,
+							supportsReasoningBudget: true,
+							supportsVerbosity: defaultInfo.supportsVerbosity || ["low", "medium", "high", "max"],
+						}
+					: knownInfo
+			// kilocode_change end
 
 			// Apply 1M context beta tier pricing for Claude Sonnet 4
 			if (

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -1131,7 +1131,8 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Max Tokens",
-		"maxThinkingTokens": "Max Thinking Tokens"
+		"maxThinkingTokens": "Max Thinking Tokens",
+		"adaptiveThinkingBudgetHint": "Adaptive thinking is enabled for this model. Max Thinking Tokens is ignored in adaptive mode."
 	},
 	"validation": {
 		"apiKey": "You must provide a valid API key.",

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -387,6 +387,8 @@
 		"anthropic1MContextBetaDescription": "Extends context window to 1 million tokens for Claude Sonnet 4",
 		"anthropicUseAzureDeployment": "Use Azure deployment name",
 		"anthropicAzureDeploymentPlaceholder": "Enter deployment name...",
+		"customAnthropicAdaptiveThinking": "Use adaptive thinking for custom model IDs",
+		"customAnthropicAdaptiveThinkingDescription": "If enabled, Kilo Code sends thinking.type=\"adaptive\" for custom Anthropic-compatible model IDs. Disable this if your endpoint rejects adaptive thinking.",
 		"awsBedrock1MContextBetaLabel": "Enable 1M context window (Beta)",
 		"awsBedrock1MContextBetaDescription": "Extends context window to 1 million tokens for Claude Sonnet 4",
 		"vertex1MContextBetaLabel": "Enable 1M context window (Beta)",


### PR DESCRIPTION
## Context

Add support for Anthropic-compatible providers where model IDs are not in Kilo Code’s static Anthropic list, and where available models should be discovered from custom base URLs.

Anthropic model selection now also supports typing a custom model ID directly, similar to the OpenAI Compatible API Provider flow.

This PR also adds explicit adaptive-thinking handling for Anthropic custom model IDs, including settings/UI behavior and provider/runtime support.

Fixes #3544 #3545.

## Implementation

- Added Anthropic base URL normalization for SDK usage, including stripping trailing `/v1` to avoid duplicate path issues.
- Added `getAnthropicModels()` to fetch model IDs from `.../v1/models` using either `x-api-key` or `Authorization: Bearer ...`.
- Added new webview message flow:
  - `requestAnthropicModels` (webview -> extension)
  - `anthropicModels` (extension -> webview)
- Updated shared extension/webview message types to include Anthropic model discovery payloads.
- Updated Anthropic settings UI:
  - Request discovered models when Anthropic is selected.
  - Use `ModelPicker` for Anthropic so users can manually type custom model IDs.
  - Keep behavior aligned with OpenAI Compatible API Provider custom model entry.
  - Merge discovered + selected custom IDs into picker options.
- Updated selected-model logic and Anthropic provider logic so unknown Anthropic-compatible model IDs are preserved and keep advanced capability defaults (reasoning/verbosity).

### Additional changes (custom adaptive-thinking support)

- Added provider setting: `anthropicCustomAdaptiveThinking`.
- For unknown/custom Anthropic model IDs, adaptive-thinking capability is now derived from this setting.
- Added settings checkbox for custom Anthropic model IDs:
  - `Use adaptive thinking for custom model IDs`
- Synced behavior with reasoning toggle:
  - Enabling custom adaptive-thinking auto-enables `Enable reasoning`.
  - Disabling `Enable reasoning` auto-disables custom adaptive-thinking.
- Improved reasoning budget UX when adaptive is active:
  - Hide `Max Thinking Tokens` slider when adaptive thinking is active.
  - Show helper text explaining that manual thinking budget is ignored in adaptive mode.
  - Keep `Max Tokens` visible as the hard output cap.
- Added i18n strings for the new setting and adaptive-budget hint.
- Added/updated tests for:
  - Anthropic provider custom adaptive-thinking capability behavior.
  - Settings UI custom adaptive-thinking toggle visibility/update/sync behavior.
  - ThinkingBudget adaptive UX behavior (hide budget slider + show hint).

## Screenshots

| before | after |
| ------ | ----- |
| <img width="448" height="973" alt="image" src="https://github.com/user-attachments/assets/1d86f47d-55bb-42b6-9654-be5ba12f355f" /> | <img width="410" height="979" alt="image - 2026-02-10T101013 436" src="https://github.com/user-attachments/assets/c6f19e58-e583-46fc-bfae-53c36766fc33" /> |
| | <img width="402" height="969" alt="image" src="https://github.com/user-attachments/assets/d04ebc24-50f3-4e1f-af06-c9efda46c82c" /> |
| | <img width="409" height="975" alt="image" src="https://github.com/user-attachments/assets/e52adfe6-71ee-45cc-b2a8-37a9d3ab40a1" /> |
| | <img width="407" height="972" alt="image" src="https://github.com/user-attachments/assets/2b87011f-439f-4b71-a038-20b025f6de30" /> |
| | <img width="386" height="973" alt="image" src="https://github.com/user-attachments/assets/25069832-c882-4af7-b251-ff32873bafcf" /> |
| | <img width="385" height="972" alt="image" src="https://github.com/user-attachments/assets/a3adbbe1-1652-4154-90bd-9c498e72b91b" /> |

## How to Test

- In Settings, select `Anthropic` provider.
- Set:
  - `Base URL`: `https://endpoint.api/v1` (Anthropic-compatible `/messages` endpoint)
  - API key/token
- Confirm the UI requests Anthropic models and discovered models become available in the model picker.
- Enter a custom model ID not in the static list and select it or type the custom model ID manually.
- Start a task and confirm the selected custom model ID is used (not replaced by default).
- Confirm Anthropic advanced controls remain available for custom IDs.
- For a custom model ID:
  - Enable `Use adaptive thinking for custom model IDs` and verify `Enable reasoning` is also enabled.
  - Disable `Enable reasoning` and verify `Use adaptive thinking for custom model IDs` is automatically disabled.
  - With adaptive enabled, verify `Max Thinking Tokens` is hidden and the adaptive-mode hint is shown.
  - Verify `Max Tokens` remains available.

Optional targeted test runs:

- `cd src && pnpm test api/providers/__tests__/anthropic.spec.ts`
- `cd src && pnpm test core/webview/__tests__/webviewMessageHandler.spec.ts`
- `cd webview-ui && pnpm test src/components/settings/__tests__/ApiOptions.spec.tsx`
- `cd webview-ui && pnpm test src/components/ui/hooks/__tests__/useSelectedModel.spec.ts`
- `cd webview-ui && pnpm test src/components/settings/__tests__/ThinkingBudget.spec.tsx`
