### PR TITLE
Add GLM 5

### DIFF
--- a/.changeset/zai-glm5-default-lines.md
+++ b/.changeset/zai-glm5-default-lines.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Set Z.ai default to `glm-5` and align Z.ai API line model selection in VS Code and webview settings
+Add support for GLM 5 and set Z.ai default to `glm-5` and align Z.ai API line model selection in VS Code and webview settings

--- a/.changeset/zai-glm5-default-lines.md
+++ b/.changeset/zai-glm5-default-lines.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Set Z.ai default to `glm-5` and align Z.ai API line model selection in VS Code and webview settings

--- a/packages/types/src/providers/zai.ts
+++ b/packages/types/src/providers/zai.ts
@@ -6,11 +6,12 @@ import { ZaiApiLine } from "../provider-settings.js"
 // https://docs.z.ai/guides/llm/glm-4.5
 // https://docs.z.ai/guides/llm/glm-4.6
 // https://docs.z.ai/guides/llm/glm-4.7
+// https://docs.z.ai/guides/llm/glm-5 // kilocode_change
 // https://docs.z.ai/guides/overview/pricing
 // https://bigmodel.cn/pricing
 
 export type InternationalZAiModelId = keyof typeof internationalZAiModels
-export const internationalZAiDefaultModelId: InternationalZAiModelId = "glm-4.7"
+export const internationalZAiDefaultModelId: InternationalZAiModelId = "glm-5" // kilocode_change
 export const internationalZAiModels = {
 	"glm-4.5": {
 		maxTokens: 16_384,
@@ -157,6 +158,24 @@ export const internationalZAiModels = {
 		preferredIndex: 1,
 	},
 	// kilocode_change start
+	"glm-5": {
+		maxTokens: 131_072,
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		supportsReasoningEffort: ["disable", "medium"],
+		reasoningEffort: "medium",
+		preserveReasoning: true,
+		inputPrice: 1,
+		outputPrice: 3.2,
+		cacheWritesPrice: 0,
+		cacheReadsPrice: 0.2,
+		description:
+			"GLM-5 is Z.AI's flagship text model with 200K context, 128K max output, thinking mode, function calling, and context caching.",
+		preferredIndex: 0,
+	},
 	"glm-4.7-flash": {
 		maxTokens: 16_384,
 		contextWindow: 200_000,
@@ -189,7 +208,7 @@ export const internationalZAiModels = {
 } as const satisfies Record<string, ModelInfo>
 
 export type MainlandZAiModelId = keyof typeof mainlandZAiModels
-export const mainlandZAiDefaultModelId: MainlandZAiModelId = "glm-4.7"
+export const mainlandZAiDefaultModelId: MainlandZAiModelId = "glm-5" // kilocode_change
 export const mainlandZAiModels = {
 	"glm-4.5": {
 		maxTokens: 16_384,
@@ -306,6 +325,24 @@ export const mainlandZAiModels = {
 		preferredIndex: 1,
 	},
 	// kilocode_change start
+	"glm-5": {
+		maxTokens: 131_072,
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		supportsReasoningEffort: ["disable", "medium"],
+		reasoningEffort: "medium",
+		preserveReasoning: true,
+		inputPrice: 0.57,
+		outputPrice: 2.57,
+		cacheWritesPrice: 0,
+		cacheReadsPrice: 0.14,
+		description:
+			"GLM-5 is Z.AI's flagship text model with 200K context, 128K max output, thinking mode, function calling, and context caching.",
+		preferredIndex: 0,
+	},
 	"glm-4.7-flash": {
 		maxTokens: 16_384,
 		contextWindow: 204_800,

--- a/src/api/providers/__tests__/zai.spec.ts
+++ b/src/api/providers/__tests__/zai.spec.ts
@@ -108,6 +108,25 @@ describe("ZAiHandler", () => {
 			expect(model.info.preserveReasoning).toBe(true)
 		})
 
+		// kilocode_change start
+		it("should return GLM-5 international model with documented limits", () => {
+			const testModelId: InternationalZAiModelId = "glm-5"
+			const handlerWithModel = new ZAiHandler({
+				apiModelId: testModelId,
+				zaiApiKey: "test-zai-api-key",
+				zaiApiLine: "international_coding",
+			})
+			const model = handlerWithModel.getModel()
+			expect(model.id).toBe(testModelId)
+			expect(model.info).toEqual(internationalZAiModels[testModelId])
+			expect(model.info.contextWindow).toBe(200_000)
+			expect(model.info.maxTokens).toBe(131_072)
+			expect(model.info.supportsReasoningEffort).toEqual(["disable", "medium"])
+			expect(model.info.reasoningEffort).toBe("medium")
+			expect(model.info.preserveReasoning).toBe(true)
+		})
+		// kilocode_change end
+
 		it("should return GLM-4.5v international model with vision support", () => {
 			const testModelId: InternationalZAiModelId = "glm-4.5v"
 			const handlerWithModel = new ZAiHandler({
@@ -203,6 +222,25 @@ describe("ZAiHandler", () => {
 			expect(model.info.reasoningEffort).toBe("medium")
 			expect(model.info.preserveReasoning).toBe(true)
 		})
+
+		// kilocode_change start
+		it("should return GLM-5 China model with documented limits", () => {
+			const testModelId: MainlandZAiModelId = "glm-5"
+			const handlerWithModel = new ZAiHandler({
+				apiModelId: testModelId,
+				zaiApiKey: "test-zai-api-key",
+				zaiApiLine: "china_coding",
+			})
+			const model = handlerWithModel.getModel()
+			expect(model.id).toBe(testModelId)
+			expect(model.info).toEqual(mainlandZAiModels[testModelId])
+			expect(model.info.contextWindow).toBe(200_000)
+			expect(model.info.maxTokens).toBe(131_072)
+			expect(model.info.supportsReasoningEffort).toEqual(["disable", "medium"])
+			expect(model.info.reasoningEffort).toBe("medium")
+			expect(model.info.preserveReasoning).toBe(true)
+		})
+		// kilocode_change end
 	})
 
 	describe("International API", () => {
@@ -242,6 +280,23 @@ describe("ZAiHandler", () => {
 			expect(model.id).toBe(testModelId)
 			expect(model.info).toEqual(internationalZAiModels[testModelId])
 		})
+
+		// kilocode_change start
+		it("should return GLM-5 international API model with documented limits", () => {
+			const testModelId: InternationalZAiModelId = "glm-5"
+			const handlerWithModel = new ZAiHandler({
+				apiModelId: testModelId,
+				zaiApiKey: "test-zai-api-key",
+				zaiApiLine: "international_api",
+			})
+			const model = handlerWithModel.getModel()
+			expect(model.id).toBe(testModelId)
+			expect(model.info).toEqual(internationalZAiModels[testModelId])
+			expect(model.info.contextWindow).toBe(200_000)
+			expect(model.info.maxTokens).toBe(131_072)
+			expect(model.info.supportsReasoningEffort).toEqual(["disable", "medium"])
+		})
+		// kilocode_change end
 	})
 
 	describe("China API", () => {
@@ -281,6 +336,23 @@ describe("ZAiHandler", () => {
 			expect(model.id).toBe(testModelId)
 			expect(model.info).toEqual(mainlandZAiModels[testModelId])
 		})
+
+		// kilocode_change start
+		it("should return GLM-5 China API model with documented limits", () => {
+			const testModelId: MainlandZAiModelId = "glm-5"
+			const handlerWithModel = new ZAiHandler({
+				apiModelId: testModelId,
+				zaiApiKey: "test-zai-api-key",
+				zaiApiLine: "china_api",
+			})
+			const model = handlerWithModel.getModel()
+			expect(model.id).toBe(testModelId)
+			expect(model.info).toEqual(mainlandZAiModels[testModelId])
+			expect(model.info.contextWindow).toBe(200_000)
+			expect(model.info.maxTokens).toBe(131_072)
+			expect(model.info.supportsReasoningEffort).toEqual(["disable", "medium"])
+		})
+		// kilocode_change end
 	})
 
 	describe("Default behavior", () => {
@@ -414,7 +486,8 @@ describe("ZAiHandler", () => {
 		})
 	})
 
-	describe("GLM-4.7 Thinking Mode", () => {
+	// kilocode_change start
+	describe("Z.ai Thinking Mode", () => {
 		it("should enable thinking by default for GLM-4.7 (default reasoningEffort is medium)", async () => {
 			const handlerWithModel = new ZAiHandler({
 				apiModelId: "glm-4.7",
@@ -507,6 +580,64 @@ describe("ZAiHandler", () => {
 			)
 		})
 
+		it("should enable thinking by default for GLM-5 (default reasoningEffort is medium)", async () => {
+			const handlerWithModel = new ZAiHandler({
+				apiModelId: "glm-5",
+				zaiApiKey: "test-zai-api-key",
+				zaiApiLine: "international_coding",
+			})
+
+			mockCreate.mockImplementationOnce(() => {
+				return {
+					[Symbol.asyncIterator]: () => ({
+						async next() {
+							return { done: true }
+						},
+					}),
+				}
+			})
+
+			const messageGenerator = handlerWithModel.createMessage("system prompt", [])
+			await messageGenerator.next()
+
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: "glm-5",
+					thinking: { type: "enabled" },
+				}),
+			)
+		})
+
+		it("should disable thinking for GLM-5 when reasoningEffort is set to disable", async () => {
+			const handlerWithModel = new ZAiHandler({
+				apiModelId: "glm-5",
+				zaiApiKey: "test-zai-api-key",
+				zaiApiLine: "international_coding",
+				enableReasoningEffort: true,
+				reasoningEffort: "disable",
+			})
+
+			mockCreate.mockImplementationOnce(() => {
+				return {
+					[Symbol.asyncIterator]: () => ({
+						async next() {
+							return { done: true }
+						},
+					}),
+				}
+			})
+
+			const messageGenerator = handlerWithModel.createMessage("system prompt", [])
+			await messageGenerator.next()
+
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: "glm-5",
+					thinking: { type: "disabled" },
+				}),
+			)
+		})
+
 		it("should NOT add thinking parameter for non-thinking models like GLM-4.6", async () => {
 			const handlerWithModel = new ZAiHandler({
 				apiModelId: "glm-4.6",
@@ -532,4 +663,5 @@ describe("ZAiHandler", () => {
 			expect(callArgs.thinking).toBeUndefined()
 		})
 	})
+	// kilocode_change end
 })

--- a/webview-ui/src/components/kilocode/hooks/__tests__/getModelsByProvider.spec.ts
+++ b/webview-ui/src/components/kilocode/hooks/__tests__/getModelsByProvider.spec.ts
@@ -117,4 +117,11 @@ describe("getOptionsForProvider", () => {
 		const result = getOptionsForProvider("zai", { zaiApiLine: "china_coding" })
 		expect(result).toEqual({ isChina: true })
 	})
+
+	// kilocode_change start
+	it("returns isChina: true for zai provider with china_api apiConfiguration", () => {
+		const result = getOptionsForProvider("zai", { zaiApiLine: "china_api" })
+		expect(result).toEqual({ isChina: true })
+	})
+	// kilocode_change end
 })

--- a/webview-ui/src/components/kilocode/hooks/useProviderModels.ts
+++ b/webview-ui/src/components/kilocode/hooks/useProviderModels.ts
@@ -357,7 +357,12 @@ export const getOptionsForProvider = (provider: ProviderName, apiConfiguration?:
 	switch (provider) {
 		case "zai":
 			// Determine which Z.AI model set to use based on the API line configuration
-			return { isChina: apiConfiguration?.zaiApiLine === "china_coding" }
+			// kilocode_change start
+			return {
+				isChina:
+					apiConfiguration?.zaiApiLine === "china_coding" || apiConfiguration?.zaiApiLine === "china_api",
+			}
+			// kilocode_change end
 		default:
 			return {}
 	}

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -460,7 +460,8 @@ const ApiOptions = ({
 				zai: {
 					field: "apiModelId",
 					default:
-						apiConfiguration.zaiApiLine === "china_coding"
+						// kilocode_change - china_api uses mainland model catalog too.
+						apiConfiguration.zaiApiLine === "china_coding" || apiConfiguration.zaiApiLine === "china_api"
 							? mainlandZAiDefaultModelId
 							: internationalZAiDefaultModelId,
 				},

--- a/webview-ui/src/components/settings/__tests__/ApiOptions.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiOptions.spec.tsx
@@ -3,7 +3,12 @@
 import { render, screen, fireEvent } from "@/utils/test-utils"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
-import { type ModelInfo, type ProviderSettings, openAiModelInfoSaneDefaults } from "@roo-code/types"
+import {
+	type ModelInfo,
+	type ProviderSettings,
+	mainlandZAiDefaultModelId,
+	openAiModelInfoSaneDefaults,
+} from "@roo-code/types"
 import { openAiCodexDefaultModelId } from "@roo-code/types"
 
 import * as ExtensionStateContext from "@src/context/ExtensionStateContext"
@@ -338,6 +343,30 @@ describe("ApiOptions", () => {
 		// Model is reset to the provider default since the previous value is invalid for this provider
 		expect(mockSetApiConfigurationField).toHaveBeenCalledWith("apiModelId", openAiCodexDefaultModelId, false)
 	})
+
+	// kilocode_change start
+	it("resets model to mainland Z.ai default when switching to Z.ai with china_api line", () => {
+		const mockSetApiConfigurationField = vi.fn()
+
+		renderApiOptions({
+			apiConfiguration: {
+				apiProvider: "anthropic",
+				apiModelId: "claude-3-5-sonnet-20241022",
+				zaiApiLine: "china_api",
+			},
+			setApiConfigurationField: mockSetApiConfigurationField,
+		})
+
+		const providerSelectContainer = screen.getByTestId("provider-select")
+		const providerSelect = providerSelectContainer.querySelector("select") as HTMLSelectElement
+		expect(providerSelect).toBeInTheDocument()
+
+		fireEvent.change(providerSelect, { target: { value: "zai" } })
+
+		expect(mockSetApiConfigurationField).toHaveBeenCalledWith("apiProvider", "zai")
+		expect(mockSetApiConfigurationField).toHaveBeenCalledWith("apiModelId", mainlandZAiDefaultModelId, false)
+	})
+	// kilocode_change end
 
 	it("hides kimi-for-coding from model options when Moonshot endpoint is not coding", () => {
 		renderApiOptions({

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -336,7 +336,8 @@ function getSelectedModel({
 			return { id, info }
 		}
 		case "zai": {
-			const isChina = apiConfiguration.zaiApiLine === "china_coding"
+			// kilocode_change - china_api uses mainland model catalog too.
+			const isChina = apiConfiguration.zaiApiLine === "china_coding" || apiConfiguration.zaiApiLine === "china_api"
 			const models = isChina ? mainlandZAiModels : internationalZAiModels
 			const defaultModelId = getProviderDefaultModelId(provider, { isChina })
 			const id = apiConfiguration.apiModelId ?? defaultModelId


### PR DESCRIPTION
## Context

This PR updates Z.ai support to make `glm-5` the default model and keep model selection consistent across all Z.ai API lines (`international_coding`, `international_api`, `china_coding`, `china_api`) in the extension/webview flow.

## Implementation

- Switched Z.ai default model IDs from `glm-4.7` to `glm-5` in the Z.ai provider model catalogs.
- Fixed mainland line handling so both `china_coding` and `china_api` resolve to the mainland model catalog in:
  - provider model resolution
  - webview model list hooks
  - selected-model resolution
  - settings default-model reset behavior
- Added/updated tests for:
  - GLM-5 selection on coding and non-coding Z.ai lines
  - `china_api` mapping to mainland defaults/model sets
  - settings behavior when provider/line changes
- Added a dedicated changeset for this work.

### Where the values come from

- Primary source: official Z.ai GLM-5 docs (`https://docs.z.ai/guides/llm/glm-5`).
- Validation source: live `/models` and `/chat/completions` probes against Z.ai endpoints.
- OpenRouter model metadata was used only as a cross-check, not as the canonical source for Z.ai endpoint behavior.

## How to Test

- Run provider tests:
  - `cd src && pnpm exec vitest run api/providers/__tests__/zai.spec.ts`
- Run webview tests:
  - `cd webview-ui && pnpm exec vitest run src/components/kilocode/hooks/__tests__/getModelsByProvider.spec.ts`
  - `cd webview-ui && pnpm exec vitest run src/components/settings/__tests__/ApiOptions.spec.tsx`
- Manual settings check:
  - Open settings, choose provider `zai`.
  - Set `zaiApiLine` to `china_api`.
  - Switch providers away/back if needed.
  - Confirm default model resolves from mainland Z.ai defaults and is now `glm-5`.
- Optional live sanity checks:
  - Verify `glm-5` appears on Z.ai `/models` responses for each supported line.
  - Verify `glm-5` chat completion succeeds on coding lines (non-coding line behavior may depend on account/package state).


> [!NOTE]
> I did not test if the provider works myself