### PR TITLE
fix: support Ollama embed models with custom dimensions

### DIFF
--- a/.changeset/old-planes-start.md
+++ b/.changeset/old-planes-start.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Support custom embed dimensions for Ollama provider

--- a/src/services/code-index/embedders/ollama.ts
+++ b/src/services/code-index/embedders/ollama.ts
@@ -14,7 +14,7 @@ import { getApiRequestTimeout } from "../../../api/providers/utils/timeout-confi
 export class CodeIndexOllamaEmbedder implements IEmbedder {
 	private readonly baseUrl: string
 	private readonly defaultModelId: string
-	private readonly dimensions?: number
+	private readonly dimensions?: number // kilocode_change
 
 	constructor(options: ApiHandlerOptions) {
 		// Ensure ollamaBaseUrl and ollamaModelId exist on ApiHandlerOptions or add defaults
@@ -25,7 +25,7 @@ export class CodeIndexOllamaEmbedder implements IEmbedder {
 
 		this.baseUrl = baseUrl
 		this.defaultModelId = options.ollamaModelId || "nomic-embed-text:latest"
-		this.dimensions = options.ollamaNumCtx
+		this.dimensions = options.ollamaNumCtx // kilocode_change
 	}
 
 	/**
@@ -36,7 +36,7 @@ export class CodeIndexOllamaEmbedder implements IEmbedder {
 	 */
 	async createEmbeddings(texts: string[], model?: string): Promise<EmbeddingResponse> {
 		const modelToUse = model || this.defaultModelId
-		const dimensions = this.dimensions
+		const dimensions = this.dimensions // kilocode_change
 		const url = `${this.baseUrl}/api/embed` // Endpoint as specified
 
 		// Apply model-specific query prefix if required
@@ -83,7 +83,7 @@ export class CodeIndexOllamaEmbedder implements IEmbedder {
 				body: JSON.stringify({
 					model: modelToUse,
 					input: processedTexts, // Using 'input' as requested
-					dimensions,
+					dimensions, // kilocode_change
 				}),
 				signal: controller.signal,
 			})

--- a/src/services/code-index/embedders/ollama.ts
+++ b/src/services/code-index/embedders/ollama.ts
@@ -14,6 +14,7 @@ import { getApiRequestTimeout } from "../../../api/providers/utils/timeout-confi
 export class CodeIndexOllamaEmbedder implements IEmbedder {
 	private readonly baseUrl: string
 	private readonly defaultModelId: string
+	private readonly dimensions?: number
 
 	constructor(options: ApiHandlerOptions) {
 		// Ensure ollamaBaseUrl and ollamaModelId exist on ApiHandlerOptions or add defaults
@@ -24,6 +25,7 @@ export class CodeIndexOllamaEmbedder implements IEmbedder {
 
 		this.baseUrl = baseUrl
 		this.defaultModelId = options.ollamaModelId || "nomic-embed-text:latest"
+		this.dimensions = options.ollamaNumCtx
 	}
 
 	/**
@@ -34,6 +36,7 @@ export class CodeIndexOllamaEmbedder implements IEmbedder {
 	 */
 	async createEmbeddings(texts: string[], model?: string): Promise<EmbeddingResponse> {
 		const modelToUse = model || this.defaultModelId
+		const dimensions = this.dimensions
 		const url = `${this.baseUrl}/api/embed` // Endpoint as specified
 
 		// Apply model-specific query prefix if required
@@ -80,6 +83,7 @@ export class CodeIndexOllamaEmbedder implements IEmbedder {
 				body: JSON.stringify({
 					model: modelToUse,
 					input: processedTexts, // Using 'input' as requested
+					dimensions,
 				}),
 				signal: controller.signal,
 			})

--- a/src/services/code-index/service-factory.ts
+++ b/src/services/code-index/service-factory.ts
@@ -65,7 +65,7 @@ export class CodeIndexServiceFactory {
 			return new CodeIndexOllamaEmbedder({
 				...config.ollamaOptions,
 				ollamaModelId: config.modelId,
-				ollamaNumCtx: config.modelDimension,
+				ollamaNumCtx: config.modelDimension, // kilocode_change
 			})
 		} else if (provider === "openai-compatible") {
 			if (!config.openAiCompatibleOptions?.baseUrl || !config.openAiCompatibleOptions?.apiKey) {

--- a/src/services/code-index/service-factory.ts
+++ b/src/services/code-index/service-factory.ts
@@ -65,6 +65,7 @@ export class CodeIndexServiceFactory {
 			return new CodeIndexOllamaEmbedder({
 				...config.ollamaOptions,
 				ollamaModelId: config.modelId,
+				ollamaNumCtx: config.modelDimension,
 			})
 		} else if (provider === "openai-compatible") {
 			if (!config.openAiCompatibleOptions?.baseUrl || !config.openAiCompatibleOptions?.apiKey) {


### PR DESCRIPTION
## Context

Some Ollama models, such as qwen3-embedding, support custom dimension values. Currently this errors because Kilo Code does not pass the user's specified dimensions to Ollama, so the dimensions generated by the model (the default value) will not match the dimensions in the vector database.

## Implementation

This change has Kilo Code pass the user's specified dimensions to Ollama, which will result in the model generating the user's specified number of dimensions, if supported by the model. Ollama will return an error when the dimensions value is not supported by the model.

## Screenshots

<img width="409" height="742" alt="Screenshot_20260211_232324" src="https://github.com/user-attachments/assets/0b23b188-bebf-40a7-822c-3c44e39f5113" />

## How to Test

- Configure indexing to use an Ollama instance using the model `qwen3-embedding:8b` and dimensions of `1024` (the default is 4096)
- Start indexing