### PR TITLE
fix: prevent MCP servers from restarting repeatedly on settings save

### DIFF
--- a/.changeset/fix-mcp-restart-loop.md
+++ b/.changeset/fix-mcp-restart-loop.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix MCP servers restarting repeatedly when saving settings

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -593,6 +593,19 @@ export class McpHub {
 	}
 
 	/**
+	 * Attempts to schedule a reconnect only if the disconnect was not intentional.
+	 * This prevents auto-reconnect from firing when we programmatically close connections.
+	 * @param serverName The name of the server
+	 * @param source The server source (global or project)
+	 */
+	private scheduleReconnectIfNotIntentional(serverName: string, source: "global" | "project"): void {
+		const intentionalKey = `${source}-${serverName}`
+		if (!this.intentionalDisconnects.has(intentionalKey)) {
+			this.scheduleReconnect(serverName, source)
+		}
+	}
+
+	/**
 	 * Cancels any scheduled reconnect for a server.
 	 * @param serverName The name of the server
 	 * @param source The server source (global or project)
@@ -1215,10 +1228,7 @@ export class McpHub {
 					}
 					await this.notifyWebviewOfServerChanges()
 					// kilocode_change - Schedule auto-reconnect on error (skip if intentional disconnect)
-					const intentionalKey = `${source}-${name}`
-					if (!this.intentionalDisconnects.has(intentionalKey)) {
-						this.scheduleReconnect(name, source)
-					}
+					this.scheduleReconnectIfNotIntentional(name, source)
 				}
 
 				transport.onclose = async () => {
@@ -1228,10 +1238,7 @@ export class McpHub {
 					}
 					await this.notifyWebviewOfServerChanges()
 					// kilocode_change - Schedule auto-reconnect on close (skip if intentional disconnect)
-					const intentionalKey = `${source}-${name}`
-					if (!this.intentionalDisconnects.has(intentionalKey)) {
-						this.scheduleReconnect(name, source)
-					}
+					this.scheduleReconnectIfNotIntentional(name, source)
 				}
 
 				// transport.stderr is only available after the process has been started. However we can't start it separately from the .connect() call because it also starts the transport. And we can't place this after the connect call since we need to capture the stderr stream before the connection is established, in order to capture errors during the connection process.
@@ -1292,10 +1299,7 @@ export class McpHub {
 					}
 					await this.notifyWebviewOfServerChanges()
 					// kilocode_change - Schedule auto-reconnect on error (skip if intentional disconnect)
-					const intentionalKey = `${source}-${name}`
-					if (!this.intentionalDisconnects.has(intentionalKey)) {
-						this.scheduleReconnect(name, source)
-					}
+					this.scheduleReconnectIfNotIntentional(name, source)
 				}
 
 				transport.onclose = async () => {
@@ -1305,10 +1309,7 @@ export class McpHub {
 					}
 					await this.notifyWebviewOfServerChanges()
 					// kilocode_change - Schedule auto-reconnect on close (skip if intentional disconnect)
-					const intentionalKey = `${source}-${name}`
-					if (!this.intentionalDisconnects.has(intentionalKey)) {
-						this.scheduleReconnect(name, source)
-					}
+					this.scheduleReconnectIfNotIntentional(name, source)
 				}
 			} else if (configInjected.type === "sse") {
 				// SSE connection
@@ -1360,10 +1361,7 @@ export class McpHub {
 					}
 					await this.notifyWebviewOfServerChanges()
 					// kilocode_change - Schedule auto-reconnect on error (skip if intentional disconnect)
-					const intentionalKey = `${source}-${name}`
-					if (!this.intentionalDisconnects.has(intentionalKey)) {
-						this.scheduleReconnect(name, source)
-					}
+					this.scheduleReconnectIfNotIntentional(name, source)
 				}
 
 				transport.onclose = async () => {
@@ -1373,10 +1371,7 @@ export class McpHub {
 					}
 					await this.notifyWebviewOfServerChanges()
 					// kilocode_change - Schedule auto-reconnect on close (skip if intentional disconnect)
-					const intentionalKey = `${source}-${name}`
-					if (!this.intentionalDisconnects.has(intentionalKey)) {
-						this.scheduleReconnect(name, source)
-					}
+					this.scheduleReconnectIfNotIntentional(name, source)
 				}
 			} else {
 				// Should not happen if validateServerConfig is correct

--- a/src/services/mcp/__tests__/McpHub.spec.ts
+++ b/src/services/mcp/__tests__/McpHub.spec.ts
@@ -307,6 +307,7 @@ describe("McpHub", () => {
 			// Directly set up a connected connection
 			const connectedConnection: ConnectedMcpConnection = {
 				type: "connected",
+				rawConfig: "{}",
 				server: {
 					name: "test-server",
 					config: JSON.stringify({ command: "node", args: ["test.js"] }),
@@ -331,6 +332,7 @@ describe("McpHub", () => {
 			// Now test with a disconnected connection
 			const disconnectedConnection: DisconnectedMcpConnection = {
 				type: "disconnected",
+				rawConfig: "{}",
 				server: {
 					name: "disabled-server",
 					config: JSON.stringify({ command: "node", args: ["test.js"], disabled: true }),
@@ -797,6 +799,7 @@ describe("McpHub", () => {
 			// Set up mock connection without alwaysAllow
 			const mockConnection: ConnectedMcpConnection = {
 				type: "connected",
+				rawConfig: "{}",
 				server: {
 					name: "test-server",
 					type: "stdio",
@@ -846,6 +849,7 @@ describe("McpHub", () => {
 			// Set up mock connection
 			const mockConnection: ConnectedMcpConnection = {
 				type: "connected",
+				rawConfig: "{}",
 				server: {
 					name: "test-server",
 					type: "stdio",
@@ -895,6 +899,7 @@ describe("McpHub", () => {
 			// Set up mock connection
 			const mockConnection: ConnectedMcpConnection = {
 				type: "connected",
+				rawConfig: "{}",
 				server: {
 					name: "test-server",
 					type: "stdio",
@@ -941,6 +946,7 @@ describe("McpHub", () => {
 			// Set up mock connection
 			const mockConnection: ConnectedMcpConnection = {
 				type: "connected",
+				rawConfig: "{}",
 				server: {
 					name: "test-server",
 					config: "test-server-config",
@@ -989,6 +995,7 @@ describe("McpHub", () => {
 			// Set up mock connection
 			const mockConnection: ConnectedMcpConnection = {
 				type: "connected",
+				rawConfig: "{}",
 				server: {
 					name: "test-server",
 					config: "test-server-config",
@@ -1036,6 +1043,7 @@ describe("McpHub", () => {
 			// Set up mock connection
 			const mockConnection: ConnectedMcpConnection = {
 				type: "connected",
+				rawConfig: "{}",
 				server: {
 					name: "test-server",
 					config: "test-server-config",
@@ -1087,6 +1095,7 @@ describe("McpHub", () => {
 			// Set up mock connection
 			const mockConnection: ConnectedMcpConnection = {
 				type: "connected",
+				rawConfig: "{}",
 				server: {
 					name: "test-server",
 					type: "stdio",
@@ -1119,6 +1128,7 @@ describe("McpHub", () => {
 			const mockConnections: McpConnection[] = [
 				{
 					type: "connected",
+					rawConfig: "{}",
 					server: {
 						name: "enabled-server",
 						config: "{}",
@@ -1130,6 +1140,7 @@ describe("McpHub", () => {
 				} as ConnectedMcpConnection,
 				{
 					type: "disconnected",
+					rawConfig: "{}",
 					server: {
 						name: "disabled-server",
 						config: "{}",
@@ -1152,6 +1163,7 @@ describe("McpHub", () => {
 			const mockConnections: McpConnection[] = [
 				{
 					type: "connected",
+					rawConfig: "{}",
 					server: {
 						name: "shared-server",
 						config: '{"source":"global"}',
@@ -1164,6 +1176,7 @@ describe("McpHub", () => {
 				} as ConnectedMcpConnection,
 				{
 					type: "connected",
+					rawConfig: "{}",
 					server: {
 						name: "shared-server",
 						config: '{"source":"project"}',
@@ -1176,6 +1189,7 @@ describe("McpHub", () => {
 				} as ConnectedMcpConnection,
 				{
 					type: "connected",
+					rawConfig: "{}",
 					server: {
 						name: "unique-global-server",
 						config: "{}",
@@ -1209,6 +1223,7 @@ describe("McpHub", () => {
 			const mockConnections: McpConnection[] = [
 				{
 					type: "connected",
+					rawConfig: "{}",
 					server: {
 						name: "global-only-server",
 						config: "{}",
@@ -1297,6 +1312,7 @@ describe("McpHub", () => {
 			// Mock the connection with a minimal client implementation
 			const mockConnection: ConnectedMcpConnection = {
 				type: "connected",
+				rawConfig: "{}",
 				server: {
 					name: "test-server",
 					config: JSON.stringify({}),
@@ -1361,6 +1377,7 @@ describe("McpHub", () => {
 			it("should use default timeout of 60 seconds if not specified", async () => {
 				const mockConnection: ConnectedMcpConnection = {
 					type: "connected",
+					rawConfig: "{}",
 					server: {
 						name: "test-server",
 						config: JSON.stringify({ type: "stdio", command: "test" }), // No timeout specified
@@ -1385,6 +1402,7 @@ describe("McpHub", () => {
 			it("should apply configured timeout to tool calls", async () => {
 				const mockConnection: ConnectedMcpConnection = {
 					type: "connected",
+					rawConfig: "{}",
 					server: {
 						name: "test-server",
 						config: JSON.stringify({ type: "stdio", command: "test", timeout: 120 }), // 2 minutes
@@ -1426,6 +1444,7 @@ describe("McpHub", () => {
 				// Set up mock connection
 				const mockConnection: ConnectedMcpConnection = {
 					type: "connected",
+					rawConfig: "{}",
 					server: {
 						name: "test-server",
 						type: "stdio",
@@ -1472,6 +1491,7 @@ describe("McpHub", () => {
 				// Set up mock connection before updating
 				const mockConnectionInitial: ConnectedMcpConnection = {
 					type: "connected",
+					rawConfig: "{}",
 					server: {
 						name: "test-server",
 						type: "stdio",
@@ -1496,6 +1516,7 @@ describe("McpHub", () => {
 				// Setup connection with invalid timeout
 				const mockConnectionInvalid: ConnectedMcpConnection = {
 					type: "connected",
+					rawConfig: "{}",
 					server: {
 						name: "test-server",
 						config: JSON.stringify({
@@ -1542,6 +1563,7 @@ describe("McpHub", () => {
 				// Set up mock connection
 				const mockConnection: ConnectedMcpConnection = {
 					type: "connected",
+					rawConfig: "{}",
 					server: {
 						name: "test-server",
 						type: "stdio",
@@ -1582,6 +1604,7 @@ describe("McpHub", () => {
 				// Set up mock connection
 				const mockConnection: ConnectedMcpConnection = {
 					type: "connected",
+					rawConfig: "{}",
 					server: {
 						name: "test-server",
 						type: "stdio",


### PR DESCRIPTION
## Problem

When saving settings, all MCP servers restart and keep restarting in a loop.

## Root Causes & Fixes

### 1. Config deep-equal mismatch (stored injected config vs raw validated config)

`updateServerConnections()` compared the stored config (post-`injectVariables()`) against the incoming Zod-validated config (pre-injection). If any variable substitution occurred (`${workspaceFolder}`, `${env:*}`, etc.), configs would **never** match — causing every server to restart on every config re-read.

**Fix:** Added `rawConfig` field to connection types that stores the pre-injection validated config. Changed the comparison in `updateServerConnections()` to use `rawConfig` against `validatedConfig`.

### 2. `isProgrammaticUpdate` flag timing race

`debounceConfigChange()` checked the flag only at entry time. The debounced handler fires 500ms later, but the flag resets at 600ms. If a file system event arrives after the flag resets, the config change would be processed — restarting servers for config we wrote ourselves.

**Fix:** Added a re-check of `isProgrammaticUpdate` inside the debounced callback.

### 3. Fire-and-forget `transport.close()` triggering auto-reconnect

`deleteConnection()` called `cancelReconnect()` then fired `transport.close()` as fire-and-forget (not awaited). The `onclose` handler would run after `cancelReconnect` completed, calling `scheduleReconnect()` again — racing with the normal restart flow.

**Fix:** Added `intentionalDisconnects` set. `deleteConnection()` marks servers before closing. All `onclose`/`onerror` handlers skip `scheduleReconnect()` for intentional disconnects.

## Testing

All 44 existing McpHub tests pass.