### PR TITLE
docs: autocomplete transplant documentation

### DIFF
--- a/src/services/autocomplete/docs/TRANSPLANT-PLAN.md
+++ b/src/services/autocomplete/docs/TRANSPLANT-PLAN.md
@@ -1,0 +1,704 @@
+# Transplant Plan: `src/services/autocomplete/` → standalone VS Code extension
+
+## 1. Executive Summary
+
+The `src/services/autocomplete/` module provides two autocomplete experiences:
+
+1. **Inline code completion (ghost text)** via a VS Code [`vscode.InlineCompletionItemProvider`](src/services/autocomplete/docs/investigation-vscode-integration.md:245).
+2. **Chat textarea autocomplete** for a webview chat input (optional), driven by webview messages ([`requestChatCompletion`](src/services/autocomplete/docs/investigation-vscode-integration.md:188)).
+
+To transplant this module into a new VS Code extension, you can copy most of the directory tree as-is, but you must rebuild a small “host shell” around it:
+
+- A VS Code extension activation/registration layer (commands, providers, status bar, context keys).
+- A **settings/state store** that persists the autocomplete settings object.
+- An **LLM provider abstraction** that supports streaming **FIM** (fill-in-the-middle) and streaming **chat completions**, plus model metadata and usage/cost reporting.
+- A **file ignore / access control abstraction** (to replicate `.kilocodeignore` behavior and prevent sensitive files from being used).
+- A **telemetry abstraction** for the events the module emits.
+- (Optional) A webview messaging bridge if you want a UI for settings or chat textarea autocomplete.
+
+This plan defines those interfaces and the minimum VS Code extension scaffolding required, without coupling the new extension to Kilo Code’s current provider implementations.
+
+---
+
+## 2. Interfaces to Implement
+
+This section defines the abstract interfaces the transplanted module expects.
+
+> Design principle: the autocomplete module should depend on small, stable interfaces and plain types, not the host extension’s internal classes.
+
+### 2.1 `IAutocompleteLLMProvider` (LLM Provider Interface)
+
+**Purpose**: Provide streaming LLM completions for both strategies:
+
+- **FIM** (prefix + suffix → streamed insertion)
+- **Chat completion** (system prompt + user prompt → streamed text and/or structured chunks)
+
+The module currently routes these via [`AutocompleteModel.generateFimResponse()`](src/services/autocomplete/AutocompleteModel.ts:109) and [`AutocompleteModel.generateResponse()`](src/services/autocomplete/AutocompleteModel.ts:153).
+
+#### Required API (proposed)
+
+```ts
+export interface AutocompleteUsage {
+	cost: number
+	inputTokens: number
+	outputTokens: number
+	cacheWriteTokens: number
+	cacheReadTokens: number
+}
+
+export interface AutocompleteModelInfo {
+	providerId: string // stable identifier, e.g. openai, anthropic, custom
+	providerDisplayName?: string // for status bar/UI
+	modelId: string // stable model identifier
+	modelDisplayName?: string
+	supportsFim: boolean
+}
+
+export type ChatStreamChunk = { type: "text"; text: string } | { type: "usage"; usage: AutocompleteUsage }
+
+export interface IAutocompleteLLMProvider {
+	/**
+	 * Returns the currently selected model/provider metadata.
+	 * Used for status bar + telemetry context.
+	 */
+	getModelInfo(): AutocompleteModelInfo | undefined
+
+	/**
+	 * Whether the selected model supports FIM.
+	 * Used to pick between FIM vs hole-filler strategy.
+	 */
+	supportsFim(): boolean
+
+	/**
+	 * Stream a FIM completion. The generator yields raw text chunks.
+	 * Must be abortable.
+	 */
+	streamFim(params: {
+		prefix: string
+		suffix: string
+		signal: AbortSignal
+		requestId?: string
+		onUsage?: (usage: AutocompleteUsage) => void
+	}): AsyncGenerator<string>
+
+	/**
+	 * Stream a chat completion. The generator yields text chunks and MAY yield usage.
+	 * Must be abortable.
+	 */
+	streamChat(params: {
+		systemPrompt: string
+		userPrompt: string
+		signal: AbortSignal
+		requestId?: string
+	}): AsyncGenerator<ChatStreamChunk>
+}
+```
+
+#### Where it is used
+
+- Inline completion pipeline triggers either:
+    - FIM flow via [`AutocompleteModel.generateFimResponse()`](src/services/autocomplete/AutocompleteModel.ts:109), or
+    - Chat flow via [`AutocompleteModel.generateResponse()`](src/services/autocomplete/AutocompleteModel.ts:153).
+- Strategy selection checks [`AutocompleteModel.supportsFim()`](src/services/autocomplete/AutocompleteModel.ts:98).
+
+#### Notes / constraints
+
+- **Streaming is mandatory**: the module assumes tokens/chunks arrive incrementally.
+- **Abort is mandatory**: VS Code frequently cancels inline completion requests.
+- **Usage/cost reporting** is needed for:
+    - status bar display (session cost), and
+    - telemetry properties (latency/cost/tokens).
+
+---
+
+### 2.2 `IAutocompleteProfileResolver` (Model selection + credentials)
+
+**Purpose**: Choose which provider/model to use for autocomplete, and validate credentials.
+
+In the current code, [`AutocompleteModel.reload()`](src/services/autocomplete/AutocompleteModel.ts:49) scans “profiles” from a settings manager and picks one (including special handling for the `kilocode` provider).
+
+For a new extension, keep this logic but abstract it.
+
+#### Required API (proposed)
+
+```ts
+export interface AutocompleteProfile {
+	id: string
+	name?: string
+	type?: "autocomplete" | "general"
+	providerId: string
+	modelId: string
+	// provider-specific credential payload is opaque to autocomplete
+	credentials: unknown
+}
+
+export interface IAutocompleteProfileResolver {
+	/** Return all configured profiles the host wants autocomplete to consider. */
+	listProfiles(): Promise<AutocompleteProfile[]>
+
+	/** Resolve the full profile (including credentials) for a selected profile id. */
+	getProfile(id: string): Promise<AutocompleteProfile>
+
+	/**
+	 * Create an LLM provider instance for the selected profile.
+	 * The autocomplete module treats the provider as opaque beyond the interface.
+	 */
+	buildLLMProvider(profile: AutocompleteProfile): Promise<IAutocompleteLLMProvider>
+}
+```
+
+#### Where it is used
+
+- Provider/model selection and (optional) credential checks happen in [`AutocompleteModel.reload()`](src/services/autocomplete/AutocompleteModel.ts:49).
+
+---
+
+### 2.3 `IAutocompleteSettingsStore` (Settings/State Manager)
+
+**Purpose**: Persist and retrieve the autocomplete settings object.
+
+The module currently uses a global state key named `ghostServiceSettings` via `ContextProxy` ([investigation](src/services/autocomplete/docs/investigation-vscode-integration.md:201)).
+
+#### Settings schema (minimum)
+
+From [`autocompleteServiceSettingsSchema`](src/services/autocomplete/docs/investigation-vscode-integration.md:216), the settings object is effectively:
+
+```ts
+export interface AutocompleteServiceSettings {
+	enableAutoTrigger?: boolean
+	enableSmartInlineTaskKeybinding?: boolean
+	enableChatAutocomplete?: boolean
+	provider?: string
+	model?: string
+	snoozeUntil?: number
+	hasKilocodeProfileWithNoBalance?: boolean
+}
+```
+
+The host should own validation (zod or equivalent). The autocomplete module assumes the object exists or is `undefined`.
+
+#### Required API (proposed)
+
+```ts
+export interface IAutocompleteSettingsStore {
+	getSettings(): Promise<AutocompleteServiceSettings | undefined>
+	setSettings(settings: AutocompleteServiceSettings | undefined): Promise<void>
+
+	/** Optional: subscribe for settings changes coming from UI/webview. */
+	onDidChangeSettings?(listener: (s: AutocompleteServiceSettings | undefined) => void): { dispose(): void }
+}
+```
+
+#### Where it is used
+
+- Read settings on startup in [`AutocompleteServiceManager.load()`](src/services/autocomplete/docs/investigation-vscode-integration.md:133).
+- Write enriched settings back after load (same section).
+- Webview can update settings by message type `ghostServiceSettings` ([`webviewMessageHandler`](src/services/autocomplete/docs/investigation-vscode-integration.md:164)).
+
+---
+
+### 2.4 `IFileIgnoreController` (File Ignore Controller)
+
+**Purpose**: Decide whether the module may read/use a file path for context.
+
+In current code this is `RooIgnoreController` (see mock interface in [`RooIgnoreController`](src/core/ignore/__mocks__/RooIgnoreController.ts:3)). It is used for:
+
+- Filtering/snippet inclusion (only-my-code, ignore patterns)
+- Visible editor context filtering
+
+#### Required API (proposed)
+
+```ts
+export interface IFileIgnoreController {
+	initialize(): Promise<void>
+
+	/** True if the file can be read/used as context. */
+	validateAccess(filePath: string): boolean
+
+	/** Filter a list of candidate paths to those allowed. */
+	filterPaths(paths: string[]): string[]
+
+	/** Optional: returns user-facing instructions explaining why access is restricted. */
+	getInstructions(): string | undefined
+
+	dispose(): void
+}
+```
+
+#### Where it is used
+
+- Inline completion gating checks include ignore validation ([architecture summary](src/services/autocomplete/docs/investigation-internal-architecture.md:161)).
+- Visible editor context is filtered in [`VisibleCodeTracker`](src/services/autocomplete/docs/investigation-internal-architecture.md:339).
+
+---
+
+### 2.5 `IDE` / `VsCodeIde` (IDE Abstraction)
+
+**Purpose**: Provide an IDE-agnostic layer used by the embedded Continue.dev fork.
+
+The continuedev core defines an `IDE` interface in [`continuedev/core/index.d.ts`](src/services/autocomplete/continuedev/core/index.d.ts:376) and ships a VS Code implementation [`VsCodeIde`](src/services/autocomplete/continuedev/core/vscode-test-harness/src/VSCodeIde.ts:1).
+
+#### Minimum needed methods
+
+The module’s autocomplete pipeline uses the `IDE` abstraction for:
+
+- Workspace discovery, reading and writing files
+- Open/current file content
+- LSP calls (definitions, references, symbols)
+- Clipboard access
+- Editor-change callback
+
+The authoritative method list is the `IDE` interface in [`IDE`](src/services/autocomplete/continuedev/core/index.d.ts:376). For transplantation you have two viable options:
+
+1. **Copy and keep `VsCodeIde`** as-is, and keep the `IDE` interface unchanged.
+2. Replace with your own implementation, but it must still satisfy the `IDE` interface contract.
+
+---
+
+### 2.6 `ITelemetryClient` (Telemetry Interface)
+
+**Purpose**: Record the module’s key product events.
+
+Current code uses a singleton `TelemetryService` ([`AutocompleteTelemetry`](src/services/autocomplete/classic-auto-complete/AutocompleteTelemetry.ts:57)). To transplant cleanly, replace it with an injected interface.
+
+#### Events currently captured
+
+From [`AutocompleteTelemetry`](src/services/autocomplete/classic-auto-complete/AutocompleteTelemetry.ts:105):
+
+- `AUTOCOMPLETE_SUGGESTION_REQUESTED`
+- `AUTOCOMPLETE_SUGGESTION_FILTERED`
+- `AUTOCOMPLETE_SUGGESTION_CACHE_HIT`
+- `AUTOCOMPLETE_LLM_SUGGESTION_RETURNED`
+- `AUTOCOMPLETE_LLM_REQUEST_COMPLETED`
+- `AUTOCOMPLETE_LLM_REQUEST_FAILED`
+- `AUTOCOMPLETE_ACCEPT_SUGGESTION`
+- `AUTOCOMPLETE_UNIQUE_SUGGESTION_SHOWN`
+
+Additional events mentioned in integration doc:
+
+- `INLINE_ASSIST_AUTO_TASK`
+- `GHOST_SERVICE_DISABLED`
+
+See telemetry summary in [`investigation-vscode-integration.md`](src/services/autocomplete/docs/investigation-vscode-integration.md:357).
+
+#### Required API (proposed)
+
+```ts
+export type TelemetryEventName = string
+
+export interface ITelemetryClient {
+	captureEvent(event: TelemetryEventName, properties?: Record<string, unknown>): void
+}
+```
+
+#### Where it is used
+
+- Inline completion telemetry: [`AutocompleteTelemetry`](src/services/autocomplete/classic-auto-complete/AutocompleteTelemetry.ts:57)
+- Service-level disable / code-suggestion telemetry: referenced in [`investigation-vscode-integration.md`](src/services/autocomplete/docs/investigation-vscode-integration.md:357)
+
+---
+
+### 2.7 `IWebviewBridge` (Optional)
+
+**Purpose**: If your new extension has a settings UI and/or chat panel, you need a bridge for messages.
+
+Current integration uses `ClineProvider` for posting state and receiving messages (see host dependencies list in [`investigation-vscode-integration.md`](src/services/autocomplete/docs/investigation-vscode-integration.md:367)).
+
+Minimum message types used by autocomplete (optional but defined):
+
+- `ghostServiceSettings` (write settings)
+- `snoozeAutocomplete`
+- `requestChatCompletion`
+- `chatCompletionAccepted`
+
+If you are not building a webview, you can skip this and omit `chat-autocomplete/` entirely.
+
+---
+
+## 3. VSCode Extension Shell
+
+This section describes what the new extension must contribute to make the module functional.
+
+### 3.1 `package.json`
+
+#### 3.1.1 Activation events
+
+Current Kilo Code activates broadly:
+
+- `onLanguage`
+- `onStartupFinished`
+
+See [`src/package.json` snippet in investigation](src/services/autocomplete/docs/investigation-vscode-integration.md:13).
+
+For a standalone extension you can keep these, or narrow them (e.g. only `onStartupFinished`).
+
+#### 3.1.2 Commands
+
+Commands declared in Kilo Code’s `package.json` (some are placeholders):
+
+- `kilo-code.autocomplete.generateSuggestions` (registered)
+- `kilo-code.autocomplete.cancelSuggestions` (declared, not registered)
+- `kilo-code.autocomplete.applyCurrentSuggestions` (declared, not registered)
+- `kilo-code.autocomplete.applyAllSuggestions` (declared, not registered)
+- `kilo-code.autocomplete.goToNextSuggestion` (declared, not registered)
+- `kilo-code.autocomplete.goToPreviousSuggestion` (declared, not registered)
+
+See command table in [`investigation-vscode-integration.md`](src/services/autocomplete/docs/investigation-vscode-integration.md:23).
+
+Commands registered programmatically (must be declared if you want them visible/consistent):
+
+- `kilo-code.autocomplete.reload` ([`index.ts`](src/services/autocomplete/docs/investigation-vscode-integration.md:117))
+- `kilo-code.autocomplete.codeActionQuickFix` (stub)
+- `kilo-code.autocomplete.showIncompatibilityExtensionPopup`
+- `kilo-code.autocomplete.disable`
+- `kilocode.autocomplete.inline-completion.accepted` (acceptance callback)
+- `kilo-code.jetbrains.getInlineCompletions` (JetBrains bridge)
+
+Recommendation for the new extension:
+
+- Keep only the commands you truly support.
+- If you do not implement “suggested edits” UX, you can drop `apply*` and `goTo*` placeholders.
+
+#### 3.1.3 Keybindings
+
+Kilo Code binds:
+
+- `Escape` → cancel suggestions (but depends on a context key that is never set)
+- `Ctrl+L` / `Cmd+L` → generate suggestions (with Copilot conflict split)
+
+See keybindings in [`investigation-vscode-integration.md`](src/services/autocomplete/docs/investigation-vscode-integration.md:47).
+
+Recommendation:
+
+- Only contribute keybindings once you implement the associated command end-to-end.
+- Ensure any context keys referenced in `when` clauses are actually set.
+
+#### 3.1.4 Code actions
+
+If you want the Quick Fix entry point (“Suggested edits”), keep:
+
+- `contributes.codeActions` declaration
+- Register a `CodeActionsProvider` programmatically (as Kilo Code does)
+
+See code action registration in [`investigation-vscode-integration.md`](src/services/autocomplete/docs/investigation-vscode-integration.md:72).
+
+#### 3.1.5 Configuration contributions
+
+Kilo Code does **not** contribute `configuration` settings; it stores everything in global state.
+
+For a new extension you can choose either:
+
+1. **Global state only** (closest transplant), or
+2. **Real VS Code settings** (`contributes.configuration`) and have your settings store bridge to `workspace.getConfiguration`.
+
+### 3.2 `extension.ts` (activation)
+
+Minimum activation responsibilities:
+
+1. Construct/inject dependencies:
+    - `IAutocompleteSettingsStore`
+    - `IAutocompleteProfileResolver` / `IAutocompleteLLMProvider`
+    - `IFileIgnoreController` factory
+    - `ITelemetryClient`
+    - (optional) `IWebviewBridge`
+2. Initialize ignore controller and settings defaults.
+3. Create the autocomplete manager and register VS Code providers.
+
+The current integration is via `registerAutocompleteProvider(context, provider)` (see activation notes in [`investigation-vscode-integration.md`](src/services/autocomplete/docs/investigation-vscode-integration.md:98)).
+
+Recommendation for transplant structure:
+
+- Keep `src/services/autocomplete/index.ts` but change it to accept a dependency container instead of a `ClineProvider`.
+
+---
+
+## 4. External Dependencies (npm packages)
+
+This list is derived from the external import investigation.
+
+### 4.1 Direct dependencies (autocomplete module)
+
+- `zod` (JetBrains bridge + continuedev adapters) ([imports list](src/services/autocomplete/docs/investigation-external-imports.md:240))
+- `web-tree-sitter` (continuedev tree-sitter integration) ([imports list](src/services/autocomplete/docs/investigation-external-imports.md:252))
+- `diff` (continuedev diff utilities) ([imports list](src/services/autocomplete/docs/investigation-external-imports.md:266))
+- `fastest-levenshtein` (text similarity) ([imports list](src/services/autocomplete/docs/investigation-external-imports.md:273))
+- `lru-cache` and `quick-lru` (caching) ([imports list](src/services/autocomplete/docs/investigation-external-imports.md:286))
+- `ignore` (gitignore-like matching in continuedev) ([imports list](src/services/autocomplete/docs/investigation-external-imports.md:300))
+- `js-tiktoken` (token counting) ([imports list](src/services/autocomplete/docs/investigation-external-imports.md:280))
+- `uri-js` (URI parsing in `VSCodeIde`) ([imports list](src/services/autocomplete/docs/investigation-external-imports.md:313))
+
+### 4.2 LLM SDKs (only if you keep continuedev’s provider adapters)
+
+The continuedev fork includes many LLM adapters and imports these SDKs:
+
+- `openai`
+- `@anthropic-ai/sdk`
+- `@aws-sdk/client-bedrock-runtime`
+- `@aws-sdk/credential-providers`
+- `google-auth-library`
+- `dotenv`
+
+See list in [`investigation-external-imports.md`](src/services/autocomplete/docs/investigation-external-imports.md:169).
+
+If the new extension has its own LLM system, consider:
+
+- either stripping unused continuedev adapters to reduce dependency footprint, or
+- leaving them but ensuring they do not bloat the extension bundle (tree-shaking).
+
+### 4.3 Tree-sitter WASM assets
+
+You must ship tree-sitter WASM and query assets required by continuedev:
+
+- `web-tree-sitter` expects parser initialization with a `.wasm` file.
+- Language grammars are needed to parse various file types.
+- Query files live under [`continuedev/tree-sitter/`](src/services/autocomplete/docs/investigation-internal-architecture.md:143) and should be copied.
+
+Plan for the new extension:
+
+- Bundle the wasm assets in your extension `dist` or `media` folder.
+- Ensure runtime code can resolve them (using `ExtensionContext.extensionUri`).
+
+---
+
+## 5. Files to Copy As-Is
+
+The following parts are designed to be largely self-contained (per architecture investigation):
+
+### 5.1 Continue.dev fork (library)
+
+Copy the entire directory:
+
+- [`src/services/autocomplete/continuedev/`](src/services/autocomplete/continuedev/core/index.d.ts:1)
+
+This includes context gathering, templating, postprocessing, tree-sitter queries, and utility helpers.
+
+### 5.2 Inline completion implementation
+
+Copy:
+
+- `src/services/autocomplete/classic-auto-complete/` (all files)
+- `src/services/autocomplete/context/` (visible code tracker)
+- `src/services/autocomplete/types.ts`
+
+### 5.3 VS Code UX helpers
+
+Copy:
+
+- `src/services/autocomplete/AutocompleteStatusBar.ts`
+- `src/services/autocomplete/AutocompleteCodeActionProvider.ts`
+
+### 5.4 Optional chat textarea autocomplete
+
+Copy if you have a webview chat UI:
+
+- `src/services/autocomplete/chat-autocomplete/`
+
+---
+
+## 6. Files Requiring Modification
+
+Most modifications are to replace Kilo Code specific imports with the new interfaces.
+
+### 6.1 `AutocompleteModel.ts`
+
+File: [`AutocompleteModel`](src/services/autocomplete/AutocompleteModel.ts:26)
+
+Why:
+
+- Currently depends on `src/api` handlers and `ProviderSettingsManager`.
+- Also depends on webview UI constant `PROVIDERS`.
+
+Change plan:
+
+- Replace `ProviderSettingsManager` usage with `IAutocompleteProfileResolver`.
+- Replace `buildApiHandler` / `ApiHandler` / `FimHandler` with `IAutocompleteLLMProvider`.
+- Replace `PROVIDERS` mapping with `providerDisplayName` from `AutocompleteModelInfo`.
+- Keep the public surface area stable where possible:
+    - `supportsFim()`
+    - `generateFimResponse()`
+    - `generateResponse()`
+    - `getModelName()` / `getProviderDisplayName()`
+
+### 6.2 `AutocompleteServiceManager.ts` and `index.ts`
+
+Why:
+
+- Current glue code expects `ContextProxy`, `ClineProvider`, and `TelemetryService`.
+
+Change plan:
+
+- Inject `IAutocompleteSettingsStore`, `ITelemetryClient`, ignore-controller factory.
+- Replace any webview posting with an optional `IWebviewBridge`.
+- Ensure `setContext` keys are correctly set (notably `kilocode.autocomplete.enableSmartInlineTaskKeybinding`, see [`investigation-vscode-integration.md`](src/services/autocomplete/docs/investigation-vscode-integration.md:145)).
+
+### 6.3 `types.ts`
+
+Why:
+
+- Imports `RooIgnoreController` directly.
+- Exposes `AutocompleteContextProvider` referencing `VsCodeIde` and `AutocompleteModel`.
+
+Change plan:
+
+- Replace `RooIgnoreController` type with `IFileIgnoreController`.
+- Keep `VsCodeIde` dependency if you keep continuedev’s VS Code harness; otherwise replace with your own `IDE` implementation.
+
+### 6.4 `VisibleCodeTracker.ts`
+
+Why:
+
+- Depends on `RooIgnoreController` and path utils.
+
+Change plan:
+
+- Replace ignore controller import with `IFileIgnoreController`.
+- Replace `toRelativePath` with an equivalent helper in the new extension.
+
+### 6.5 JetBrains bridge
+
+File: `src/services/autocomplete/AutocompleteJetbrainsBridge.ts`.
+
+Why:
+
+- Uses internal Kilo Code wrapper and webview provider.
+
+Change plan:
+
+- If the new extension does not support JetBrains, omit it.
+- If you do, implement a dedicated transport layer; keep the bridge logic but replace:
+    - `ClineProvider`
+    - `getKiloCodeWrapperProperties`
+    - any Kilo Code-specific types
+
+---
+
+## 7. i18n Setup
+
+There are two separate i18n mechanisms involved.
+
+### 7.1 `package.nls.json` (command titles)
+
+Kilo Code’s `package.json` command titles reference NLS keys like:
+
+- `autocomplete.commands.generateSuggestions`
+- `autocomplete.commands.cancelSuggestions`
+- …
+
+See full list in [`investigation-vscode-integration.md`](src/services/autocomplete/docs/investigation-vscode-integration.md:269).
+
+Transplant options:
+
+1. Reuse the same keys and provide at least `package.nls.json` (and optionally localized variants).
+2. Rename keys and update command declarations accordingly.
+
+### 7.2 Runtime `t()` keys (status bar/tooltips/progress)
+
+Runtime strings are accessed via `t()` from `src/i18n` (Kilo Code).
+
+Keys used live under namespace `kilocode:autocomplete.*` (see JSON excerpt in [`investigation-vscode-integration.md`](src/services/autocomplete/docs/investigation-vscode-integration.md:287)).
+
+Transplant plan:
+
+- If the new extension already has i18n, add equivalent keys to its runtime translation system.
+- Otherwise, simplest is:
+    - implement a tiny `t(key, vars?)` function that maps to a JSON bundle.
+
+Minimum runtime keys needed for feature completeness:
+
+- status bar labels + tooltips (enabled/disabled/snoozed + provider/model + cost)
+- progress titles (analyzing/generating/processing/showing)
+- incompatibility popup text (if you keep Copilot conflict logic)
+
+---
+
+## 8. Webview Integration (Optional)
+
+If you want a settings UI or chat panel, you need:
+
+### 8.1 State shape
+
+Expose `ghostServiceSettings` (or renamed equivalent) to the webview state.
+
+See state passing described in [`investigation-vscode-integration.md`](src/services/autocomplete/docs/investigation-vscode-integration.md:154).
+
+### 8.2 Message types
+
+Support these messages:
+
+- `ghostServiceSettings` → validate + persist → trigger reload
+- `snoozeAutocomplete` → snooze/unsnooze
+- `requestChatCompletion` → call chat textarea autocomplete pipeline → respond `chatCompletionResult`
+- `chatCompletionAccepted` → fire telemetry
+
+The message handling mapping is documented in [`investigation-vscode-integration.md`](src/services/autocomplete/docs/investigation-vscode-integration.md:164).
+
+---
+
+## 9. MockTextDocument
+
+The JetBrains bridge depends on `MockTextDocument` which is outside the autocomplete directory.
+
+Copy:
+
+- [`src/services/mocking/MockTextDocument.ts`](src/services/mocking/MockTextDocument.ts:1)
+
+If you don’t transplant JetBrains support, you can skip this file.
+
+---
+
+## 10. Migration Checklist
+
+Use this as the practical step-by-step transplant procedure.
+
+### 10.1 Prepare new extension
+
+1. Create a new VS Code extension repo (TypeScript).
+2. Ensure build pipeline can bundle wasm assets.
+3. Add required dependencies (Section 4).
+
+### 10.2 Copy files
+
+1. Copy `src/services/autocomplete/` directory into the new extension.
+2. If supporting JetBrains bridge, also copy [`MockTextDocument`](src/services/mocking/MockTextDocument.ts:1).
+3. Copy tree-sitter query assets under `continuedev/tree-sitter/`.
+
+### 10.3 Implement host interfaces
+
+1. Implement [`IAutocompleteSettingsStore`](src/services/autocomplete/docs/TRANSPLANT-PLAN.md:1) (this document) using either:
+    - `ExtensionContext.globalState`, or
+    - `workspace.getConfiguration`.
+2. Implement [`IFileIgnoreController`](src/services/autocomplete/docs/TRANSPLANT-PLAN.md:1) (this document).
+3. Implement [`ITelemetryClient`](src/services/autocomplete/docs/TRANSPLANT-PLAN.md:1) (this document).
+4. Implement [`IAutocompleteProfileResolver`](src/services/autocomplete/docs/TRANSPLANT-PLAN.md:1) (this document).
+5. Implement [`IAutocompleteLLMProvider`](src/services/autocomplete/docs/TRANSPLANT-PLAN.md:1) (this document) backed by the new extension’s LLM system.
+
+### 10.4 Refactor autocomplete glue
+
+1. Refactor [`AutocompleteModel`](src/services/autocomplete/AutocompleteModel.ts:26) to use the new LLM/provider resolver interfaces.
+2. Refactor service initialization ([`AutocompleteServiceManager`](src/services/autocomplete/docs/investigation-vscode-integration.md:125)) to use the new settings/telemetry/ignore interfaces.
+3. Refactor `index.ts` entry point to accept dependency injection rather than Kilo Code’s provider.
+
+### 10.5 Wire VS Code extension shell
+
+1. Implement activation in `extension.ts`:
+    - instantiate dependencies
+    - call `registerAutocompleteProvider(...)`
+2. Add `package.json` contributions:
+    - activation events
+    - commands
+    - keybindings (optional)
+    - codeActions contribution (optional)
+3. Ensure context keys used in `when` clauses are set via `vscode.commands.executeCommand("setContext", ...)`.
+
+### 10.6 Validate runtime behavior
+
+1. Inline completion:
+    - confirm cancellation works
+    - confirm debounce behavior
+    - confirm suggestions appear only for allowed files
+2. Status bar:
+    - confirm provider/model shown
+    - confirm cost increments
+3. (Optional) Webview:
+    - confirm settings update triggers reload
+    - confirm chat textarea completion roundtrip works

--- a/src/services/autocomplete/docs/investigation-external-imports.md
+++ b/src/services/autocomplete/docs/investigation-external-imports.md
@@ -1,0 +1,409 @@
+# External Imports Investigation — `src/services/autocomplete/`
+
+> Generated: 2026-02-12
+>
+> This document catalogs **every import** in the autocomplete module that references code
+> **outside** of `src/services/autocomplete/`. Test files (`*.test.ts`, `*.spec.ts`, `__tests__/`)
+> are excluded.
+
+---
+
+## Table of Contents
+
+1. [Summary](#summary)
+2. [VSCode API](#1-vscode-api)
+3. [Internal Project Imports (non-continuedev)](#2-internal-project-imports-non-continuedev-files)
+4. [Internal Project Imports (continuedev → outside autocomplete)](#3-internal-project-imports-continuedev-files-reaching-outside-autocomplete)
+5. [Webview UI Imports](#4-webview-ui-imports)
+6. [Monorepo Packages (`@roo-code/*`)](#5-monorepo-packages-roo-code)
+7. [Third-Party npm Packages](#6-third-party-npm-packages)
+8. [Node.js Built-in Modules](#7-nodejs-built-in-modules)
+
+---
+
+## Summary
+
+| Category                                 | Unique Modules                               | Total Import Sites |
+| ---------------------------------------- | -------------------------------------------- | ------------------ |
+| VSCode API                               | 1 (`vscode`)                                 | 14                 |
+| Internal project (non-continuedev)       | 12 distinct targets                          | 27                 |
+| Internal project (continuedev → outside) | 3 distinct targets                           | 3                  |
+| Webview UI                               | 1 (`PROVIDERS`)                              | 2                  |
+| Monorepo packages                        | 2 (`@roo-code/types`, `@roo-code/telemetry`) | 9                  |
+| Third-party npm                          | 16 distinct packages                         | 60+                |
+| Node.js built-ins                        | 8 modules                                    | 20+                |
+
+---
+
+## 1. VSCode API
+
+All files import `* as vscode from "vscode"`.
+
+| Source File                                                                             | Symbols       |
+| --------------------------------------------------------------------------------------- | ------------- |
+| `AutocompleteCodeActionProvider.ts`                                                     | `* as vscode` |
+| `AutocompleteJetbrainsBridge.ts`                                                        | `* as vscode` |
+| `AutocompleteServiceManager.ts`                                                         | `* as vscode` |
+| `AutocompleteStatusBar.ts`                                                              | `* as vscode` |
+| `index.ts`                                                                              | `* as vscode` |
+| `types.ts`                                                                              | `* as vscode` |
+| `chat-autocomplete/ChatTextAreaAutocomplete.ts`                                         | `* as vscode` |
+| `classic-auto-complete/AutocompleteInlineCompletionProvider.ts`                         | `* as vscode` |
+| `classic-auto-complete/getProcessedSnippets.ts`                                         | `* as vscode` |
+| `context/VisibleCodeTracker.ts`                                                         | `* as vscode` |
+| `continuedev/core/vscode-test-harness/src/VSCodeIde.ts`                                 | `* as vscode` |
+| `continuedev/core/vscode-test-harness/src/autocomplete/lsp.ts`                          | `* as vscode` |
+| `continuedev/core/vscode-test-harness/src/autocomplete/recentlyEdited.ts`               | `* as vscode` |
+| `continuedev/core/vscode-test-harness/src/autocomplete/RecentlyVisitedRangesService.ts` | `* as vscode` |
+
+---
+
+## 2. Internal Project Imports (non-continuedev files)
+
+These are imports from files **outside** the `src/services/autocomplete/` directory tree,
+originating from the "Kilo Code" layer (not the continuedev fork).
+
+### `src/core/` imports
+
+| Source File                                                     | Module Path                                    | Symbols                            |
+| --------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------- |
+| `AutocompleteJetbrainsBridge.ts`                                | `../../core/webview/ClineProvider`             | `{ ClineProvider }`                |
+| `AutocompleteJetbrainsBridge.ts`                                | `../../core/kilocode/wrapper`                  | `{ getKiloCodeWrapperProperties }` |
+| `AutocompleteModel.ts`                                          | `../../core/config/ProviderSettingsManager`    | `{ ProviderSettingsManager }`      |
+| `AutocompleteServiceManager.ts`                                 | `../../core/config/ContextProxy`               | `{ ContextProxy }`                 |
+| `AutocompleteServiceManager.ts`                                 | `../../core/webview/ClineProvider`             | `{ ClineProvider }`                |
+| `index.ts`                                                      | `../../core/webview/ClineProvider`             | `{ ClineProvider }`                |
+| `types.ts`                                                      | `../../core/ignore/RooIgnoreController`        | `{ RooIgnoreController }`          |
+| `chat-autocomplete/ChatTextAreaAutocomplete.ts`                 | `../../../core/config/ProviderSettingsManager` | `{ ProviderSettingsManager }`      |
+| `chat-autocomplete/handleChatCompletionRequest.ts`              | `../../../core/webview/ClineProvider`          | `{ ClineProvider }`                |
+| `classic-auto-complete/AutocompleteInlineCompletionProvider.ts` | `../../../core/ignore/RooIgnoreController`     | `{ RooIgnoreController }`          |
+| `classic-auto-complete/AutocompleteInlineCompletionProvider.ts` | `../../../core/webview/ClineProvider`          | `{ ClineProvider }`                |
+| `classic-auto-complete/getProcessedSnippets.ts`                 | `../../../core/ignore/RooIgnoreController`     | `{ RooIgnoreController }`          |
+| `context/VisibleCodeTracker.ts`                                 | `../../../core/ignore/RooIgnoreController`     | `type { RooIgnoreController }`     |
+
+### `src/api/` imports
+
+| Source File                           | Module Path                               | Symbols                                       |
+| ------------------------------------- | ----------------------------------------- | --------------------------------------------- |
+| `AutocompleteModel.ts`                | `../../api`                               | `{ ApiHandler, buildApiHandler, FimHandler }` |
+| `AutocompleteModel.ts`                | `../../api/providers`                     | `{ OpenRouterHandler }`                       |
+| `AutocompleteModel.ts`                | `../../api/providers/openrouter`          | `{ CompletionUsage }`                         |
+| `AutocompleteModel.ts`                | `../../api/transform/stream`              | `{ ApiStreamChunk }`                          |
+| `AutocompleteModel.ts`                | `../../api/providers/kilocode-openrouter` | `{ KilocodeOpenrouterHandler }`               |
+| `classic-auto-complete/HoleFiller.ts` | `../../../api/transform/stream`           | `{ ApiStreamChunk }`                          |
+
+### `src/i18n` imports
+
+| Source File                         | Module Path  | Symbols |
+| ----------------------------------- | ------------ | ------- |
+| `AutocompleteCodeActionProvider.ts` | `../../i18n` | `{ t }` |
+| `AutocompleteServiceManager.ts`     | `../../i18n` | `{ t }` |
+| `AutocompleteStatusBar.ts`          | `../../i18n` | `{ t }` |
+
+### `src/shared/` imports
+
+| Source File                                         | Module Path                      | Symbols              |
+| --------------------------------------------------- | -------------------------------- | -------------------- |
+| `chat-autocomplete/handleChatCompletionAccepted.ts` | `../../../shared/WebviewMessage` | `{ WebviewMessage }` |
+| `chat-autocomplete/handleChatCompletionRequest.ts`  | `../../../shared/WebviewMessage` | `{ WebviewMessage }` |
+
+### `src/utils/` imports
+
+| Source File                     | Module Path           | Symbols              |
+| ------------------------------- | --------------------- | -------------------- |
+| `context/VisibleCodeTracker.ts` | `../../../utils/path` | `{ toRelativePath }` |
+
+### `src/services/mocking/` imports
+
+| Source File                      | Module Path                   | Symbols                |
+| -------------------------------- | ----------------------------- | ---------------------- |
+| `AutocompleteJetbrainsBridge.ts` | `../mocking/MockTextDocument` | `{ MockTextDocument }` |
+
+---
+
+## 3. Internal Project Imports (continuedev files reaching outside autocomplete)
+
+These imports originate from `continuedev/` files but reach out of the autocomplete
+directory tree entirely (via deeply nested `../../../../../../` paths).
+
+| Source File                             | Module Path                                             | Symbols                  |
+| --------------------------------------- | ------------------------------------------------------- | ------------------------ |
+| `continuedev/core/llm/llms/KiloCode.ts` | `../../../../../../shared/kilocode/headers`             | `{ X_KILOCODE_VERSION }` |
+| `continuedev/core/llm/llms/KiloCode.ts` | `../../../../../../shared/package`                      | `{ Package }`            |
+| `continuedev/core/llm/llms/KiloCode.ts` | `../../../../../../api/providers/kilocode/IFimProvider` | `{ IFimProvider }`       |
+
+---
+
+## 4. Webview UI Imports
+
+| Source File                | Module Path                                             | Symbols         |
+| -------------------------- | ------------------------------------------------------- | --------------- |
+| `AutocompleteModel.ts`     | `../../../webview-ui/src/components/settings/constants` | `{ PROVIDERS }` |
+| `AutocompleteStatusBar.ts` | `../../../webview-ui/src/components/settings/constants` | `{ PROVIDERS }` |
+
+---
+
+## 5. Monorepo Packages (`@roo-code/*`)
+
+### `@roo-code/types`
+
+| Source File                                                     | Symbols                                                                              |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `AutocompleteModel.ts`                                          | `{ modelIdKeysByProvider, ProviderName }`                                            |
+| `AutocompleteServiceManager.ts`                                 | `{ AutocompleteServiceSettings, TelemetryEventName }`                                |
+| `AutocompleteStatusBar.ts`                                      | `{ AUTOCOMPLETE_PROVIDER_MODELS, ProviderName }`                                     |
+| `classic-auto-complete/AutocompleteInlineCompletionProvider.ts` | `type { AutocompleteServiceSettings }`                                               |
+| `classic-auto-complete/AutocompleteTelemetry.ts`                | `{ TelemetryEventName }`                                                             |
+| `utils/kilocode-utils.ts`                                       | `{ getKiloBaseUriFromToken, AUTOCOMPLETE_PROVIDER_MODELS, AutocompleteProviderKey }` |
+| `continuedev/core/llm/llms/KiloCode.ts`                         | `{ getKiloUrlFromToken }`                                                            |
+
+### `@roo-code/telemetry`
+
+| Source File                                      | Symbols                |
+| ------------------------------------------------ | ---------------------- |
+| `AutocompleteServiceManager.ts`                  | `{ TelemetryService }` |
+| `classic-auto-complete/AutocompleteTelemetry.ts` | `{ TelemetryService }` |
+
+---
+
+## 6. Third-Party npm Packages
+
+### `openai` / `openai/*` (OpenAI SDK)
+
+Used extensively in `continuedev/core/llm/` for LLM API adapters.
+
+| Source File                                                        | Module Path                        | Symbols                                                                                                                   |
+| ------------------------------------------------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `continuedev/core/llm/index.ts`                                    | `openai/resources/index`           | `{ ChatCompletionCreateParams }`                                                                                          |
+| `continuedev/core/llm/llms/OpenAI.ts`                              | `openai/resources/index`           | `{ ChatCompletionCreateParams, ChatCompletionMessageParam }`                                                              |
+| `continuedev/core/llm/llms/OpenRouter.ts`                          | `openai/resources/index`           | `{ ChatCompletionCreateParams }`                                                                                          |
+| `continuedev/core/llm/openaiTypeConverters.ts`                     | `openai/resources/index`           | `{ ChatCompletion, ChatCompletionChunk, ChatCompletionCreateParams, ChatCompletionMessageParam, CompletionCreateParams }` |
+| `continuedev/core/llm/openai-adapters/apis/Anthropic.ts`           | `openai/index`                     | `{ OpenAI }`                                                                                                              |
+| `continuedev/core/llm/openai-adapters/apis/Anthropic.ts`           | `openai/resources/index`           | `{ ChatCompletionChunk, ChatCompletionCreateParams, ... }`                                                                |
+| `continuedev/core/llm/openai-adapters/apis/Anthropic.ts`           | `openai/resources/index.js`        | `{ ChatCompletionCreateParams }`                                                                                          |
+| `continuedev/core/llm/openai-adapters/apis/AnthropicUtils.ts`      | `openai/resources`                 | `{ ChatCompletionTool, ChatCompletionToolChoiceOption }`                                                                  |
+| `continuedev/core/llm/openai-adapters/apis/Azure.ts`               | `openai/index`                     | `{ OpenAI }`                                                                                                              |
+| `continuedev/core/llm/openai-adapters/apis/Azure.ts`               | `openai/resources/index`           | `{ ChatCompletionChunk, ... }`                                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/base.ts`                | `openai/resources/index`           | `{ ChatCompletion, ChatCompletionChunk, ChatCompletionCreateParams, ... }`                                                |
+| `continuedev/core/llm/openai-adapters/apis/Bedrock.ts`             | `openai/index`                     | `{ OpenAI }`                                                                                                              |
+| `continuedev/core/llm/openai-adapters/apis/Bedrock.ts`             | `openai/resources/index`           | `{ ChatCompletionChunk, ... }`                                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/Cohere.ts`              | `openai/index`                     | `{ OpenAI }`                                                                                                              |
+| `continuedev/core/llm/openai-adapters/apis/Cohere.ts`              | `openai/resources/index`           | `{ ChatCompletion, ChatCompletionChunk, ... }`                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/CometAPI.ts`            | `openai/resources/index`           | `{ ChatCompletion, ChatCompletionChunk, ... }`                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/ContinueProxy.ts`       | `openai/resources/index`           | `{ ChatCompletion, ChatCompletionChunk, ... }`                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/DeepSeek.ts`            | `openai/resources/index`           | `{ ChatCompletionChunk, Model }`                                                                                          |
+| `continuedev/core/llm/openai-adapters/apis/Gemini.ts`              | `openai/index`                     | `{ OpenAI }`                                                                                                              |
+| `continuedev/core/llm/openai-adapters/apis/Gemini.ts`              | `openai/resources/index`           | `{ ChatCompletionChunk, ... }`                                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/Inception.ts`           | `openai/resources/index`           | `{ ChatCompletionChunk, ... }`                                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/Jina.ts`                | `openai/resources/index`           | `{ ChatCompletionChunk, ... }`                                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/LlamaStack.ts`          | `openai/resources/index`           | `{ ChatCompletionChunk }`                                                                                                 |
+| `continuedev/core/llm/openai-adapters/apis/Mock.ts`                | `openai/resources/index`           | `{ ChatCompletionChunk, ... }`                                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/Moonshot.ts`            | `openai/resources/index`           | `{ ChatCompletionChunk, Model }`                                                                                          |
+| `continuedev/core/llm/openai-adapters/apis/OpenAI.ts`              | `openai/index`                     | `{ OpenAI }`                                                                                                              |
+| `continuedev/core/llm/openai-adapters/apis/OpenAI.ts`              | `openai/resources/index`           | `{ ChatCompletion, ChatCompletionChunk, ... }`                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/OpenRouter.ts`          | `openai/resources/index`           | `{ ChatCompletionCreateParams }`                                                                                          |
+| `continuedev/core/llm/openai-adapters/apis/OpenRouterCaching.ts`   | `openai/resources/index`           | `{ ChatCompletionCreateParams, ChatCompletionMessageParam }`                                                              |
+| `continuedev/core/llm/openai-adapters/apis/Relace.ts`              | `openai/resources/completions.mjs` | `{ Completion, CompletionUsage }`                                                                                         |
+| `continuedev/core/llm/openai-adapters/apis/Relace.ts`              | `openai/resources/index.mjs`       | `{ ChatCompletion, ChatCompletionChunk, ... }`                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/Relace.ts`              | `openai/resources/models.mjs`      | `{ Model }`                                                                                                               |
+| `continuedev/core/llm/openai-adapters/apis/VertexAI.ts`            | `openai/resources/index`           | `{ ChatCompletionChunk, ... }`                                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/WatsonX.ts`             | `openai/index`                     | `{ OpenAI }`                                                                                                              |
+| `continuedev/core/llm/openai-adapters/apis/WatsonX.ts`             | `openai/resources/index`           | `{ ChatCompletionChunk, ... }`                                                                                            |
+| `continuedev/core/llm/openai-adapters/apis/WatsonX.ts`             | `openai/resources/index.js`        | `{ ChatCompletionCreateParams }`                                                                                          |
+| `continuedev/core/llm/openai-adapters/util.ts`                     | `openai/resources/index`           | `{ ChatCompletionChunk, CompletionUsage }`                                                                                |
+| `continuedev/core/llm/openai-adapters/util.ts`                     | `openai/resources/index.js`        | `{ ChatCompletion }`                                                                                                      |
+| `continuedev/core/llm/openai-adapters/util/emptyChatCompletion.ts` | `openai/resources/index`           | `{ ChatCompletion }`                                                                                                      |
+| `continuedev/core/llm/openai-adapters/util/gemini-types.ts`        | `openai/resources/index.mjs`       | `{ ChatCompletionTool }`                                                                                                  |
+
+### `@anthropic-ai/sdk`
+
+| Source File                                                               | Module Path                   | Symbols                                                                                                                 |
+| ------------------------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `continuedev/core/llm/openai-adapters/apis/Anthropic.ts`                  | `@anthropic-ai/sdk/resources` | `{ ContentBlock, ContentBlockDelta, MessageDelta, MessageStartEvent, RawContentBlockStartEvent, RawMessageDeltaEvent }` |
+| `continuedev/core/llm/openai-adapters/apis/AnthropicCachingStrategies.ts` | `@anthropic-ai/sdk/resources` | `{ MessageCreateParams }`                                                                                               |
+| `continuedev/core/llm/openai-adapters/apis/AnthropicUtils.ts`             | `@anthropic-ai/sdk/resources` | `{ Base64ImageSource, MessageParam, Tool, ToolChoice }`                                                                 |
+| `continuedev/core/llm/openai-adapters/apis/OpenRouterCaching.ts`          | `@anthropic-ai/sdk/resources` | `{ ContentBlockParam, MessageCreateParams, MessageParam }`                                                              |
+
+### `@aws-sdk/*`
+
+| Source File                                            | Module Path                       | Symbols                                                                                      |
+| ------------------------------------------------------ | --------------------------------- | -------------------------------------------------------------------------------------------- |
+| `continuedev/core/llm/openai-adapters/apis/Bedrock.ts` | `@aws-sdk/client-bedrock-runtime` | `{ BedrockRuntimeClient, ConverseStreamCommand, InvokeModelWithResponseStreamCommand, ... }` |
+| `continuedev/core/llm/openai-adapters/apis/Bedrock.ts` | `@aws-sdk/credential-providers`   | `{ fromNodeProviderChain }`                                                                  |
+
+### `google-auth-library`
+
+| Source File                                             | Module Path           | Symbols                                 |
+| ------------------------------------------------------- | --------------------- | --------------------------------------- |
+| `continuedev/core/llm/openai-adapters/apis/VertexAI.ts` | `google-auth-library` | `{ AuthClient, GoogleAuth, JWT, auth }` |
+
+### `zod`
+
+| Source File                                                  | Module Path | Symbols  |
+| ------------------------------------------------------------ | ----------- | -------- |
+| `AutocompleteJetbrainsBridge.ts`                             | `zod`       | `{ z }`  |
+| `continuedev/core/llm/openai-adapters/apis/Azure.ts`         | `zod`       | `{ z }`  |
+| `continuedev/core/llm/openai-adapters/apis/ContinueProxy.ts` | `zod`       | `{ z }`  |
+| `continuedev/core/llm/openai-adapters/apis/OpenAI.ts`        | `zod`       | `{ z }`  |
+| `continuedev/core/llm/openai-adapters/apis/Relace.ts`        | `zod`       | `{ z }`  |
+| `continuedev/core/llm/openai-adapters/index.ts`              | `zod`       | `{ z }`  |
+| `continuedev/core/llm/openai-adapters/types.ts`              | `zod`       | `* as z` |
+
+### `web-tree-sitter`
+
+| Source File                                                                         | Module Path       | Symbols                                              |
+| ----------------------------------------------------------------------------------- | ----------------- | ---------------------------------------------------- |
+| `continuedev/core/index.d.ts`                                                       | `web-tree-sitter` | `Parser` (default)                                   |
+| `continuedev/core/autocomplete/util/ast.ts`                                         | `web-tree-sitter` | `{ Node as SyntaxNode, Tree }`                       |
+| `continuedev/core/autocomplete/context/root-path-context/RootPathContextService.ts` | `web-tree-sitter` | `{ Node as SyntaxNode, Query, Point }`               |
+| `continuedev/core/autocomplete/context/root-path-context/testUtils.ts`              | `web-tree-sitter` | `Parser` (default)                                   |
+| `continuedev/core/autocomplete/context/static-context/StaticContextService.ts`      | `web-tree-sitter` | `{ Node as SyntaxNode }`                             |
+| `continuedev/core/autocomplete/context/static-context/tree-sitter-utils.ts`         | `web-tree-sitter` | `{ Node as SyntaxNode, QueryMatch, Tree }`           |
+| `continuedev/core/autocomplete/context/static-context/types.ts`                     | `web-tree-sitter` | `{ Tree }`                                           |
+| `continuedev/core/util/treeSitter.ts`                                               | `web-tree-sitter` | `type { Language, Node as SyntaxNode, Query, Tree }` |
+| `continuedev/core/vscode-test-harness/src/autocomplete/lsp.ts`                      | `web-tree-sitter` | `type { Node as SyntaxNode }`                        |
+
+### `diff`
+
+| Source File                                                         | Module Path | Symbols                                 |
+| ------------------------------------------------------------------- | ----------- | --------------------------------------- |
+| `continuedev/core/autocomplete/util/processSingleLineCompletion.ts` | `diff`      | `* as Diff`                             |
+| `continuedev/core/diff/myers.ts`                                    | `diff`      | `{ diffChars, diffLines, type Change }` |
+
+### `fastest-levenshtein`
+
+| Source File                                            | Module Path           | Symbols        |
+| ------------------------------------------------------ | --------------------- | -------------- |
+| `continuedev/core/autocomplete/util/textSimilarity.ts` | `fastest-levenshtein` | `{ distance }` |
+| `continuedev/core/diff/util.ts`                        | `fastest-levenshtein` | `{ distance }` |
+
+### `js-tiktoken`
+
+| Source File                           | Module Path   | Symbols                                               |
+| ------------------------------------- | ------------- | ----------------------------------------------------- |
+| `continuedev/core/llm/countTokens.ts` | `js-tiktoken` | `{ Tiktoken, encodingForModel as _encodingForModel }` |
+
+### `lru-cache`
+
+| Source File                                                                             | Module Path | Symbols        |
+| --------------------------------------------------------------------------------------- | ----------- | -------------- |
+| `continuedev/core/autocomplete/util/AutocompleteLruCacheInMem.ts`                       | `lru-cache` | `{ LRUCache }` |
+| `continuedev/core/autocomplete/context/root-path-context/RootPathContextService.ts`     | `lru-cache` | `{ LRUCache }` |
+| `continuedev/core/vscode-test-harness/src/autocomplete/RecentlyVisitedRangesService.ts` | `lru-cache` | `{ LRUCache }` |
+
+### `quick-lru`
+
+| Source File                                                 | Module Path | Symbols              |
+| ----------------------------------------------------------- | ----------- | -------------------- |
+| `continuedev/core/autocomplete/util/openedFilesLruCache.ts` | `quick-lru` | `QuickLRU` (default) |
+
+### `ignore`
+
+| Source File                                           | Module Path | Symbols            |
+| ----------------------------------------------------- | ----------- | ------------------ |
+| `continuedev/core/autocomplete/prefiltering/index.ts` | `ignore`    | `ignore` (default) |
+| `continuedev/core/indexing/ignore.ts`                 | `ignore`    | `ignore` (default) |
+
+### `dotenv`
+
+| Source File                                     | Module Path | Symbols            |
+| ----------------------------------------------- | ----------- | ------------------ |
+| `continuedev/core/llm/openai-adapters/index.ts` | `dotenv`    | `dotenv` (default) |
+
+### `uri-js`
+
+| Source File                                             | Module Path | Symbols    |
+| ------------------------------------------------------- | ----------- | ---------- |
+| `continuedev/core/vscode-test-harness/src/VSCodeIde.ts` | `uri-js`    | `* as URI` |
+
+### `vitest`
+
+| Source File                                                            | Module Path | Symbols          |
+| ---------------------------------------------------------------------- | ----------- | ---------------- |
+| `continuedev/core/autocomplete/context/root-path-context/testUtils.ts` | `vitest`    | `{ expect, vi }` |
+| `continuedev/core/autocomplete/filtering/test/util.ts`                 | `vitest`    | `{ expect }`     |
+| `continuedev/core/test/vitest.setup.ts`                                | `vitest`    | `{ beforeAll }`  |
+
+---
+
+## 7. Node.js Built-in Modules
+
+| Source File                                                                         | Module        | Symbols                            |
+| ----------------------------------------------------------------------------------- | ------------- | ---------------------------------- |
+| `AutocompleteServiceManager.ts`                                                     | `crypto`      | `crypto` (default)                 |
+| `continuedev/core/autocomplete/util/AutocompleteDebouncer.ts`                       | `node:crypto` | `{ randomUUID }`                   |
+| `continuedev/core/llm/openai-adapters/apis/Bedrock.ts`                              | `node:crypto` | `{ randomUUID }`                   |
+| `continuedev/core/autocomplete/context/root-path-context/RootPathContextService.ts` | `crypto`      | `{ createHash }`                   |
+| `continuedev/core/autocomplete/context/root-path-context/testUtils.ts`              | `fs`          | `fs` (default)                     |
+| `continuedev/core/autocomplete/context/root-path-context/testUtils.ts`              | `path`        | `path` (default)                   |
+| `continuedev/core/autocomplete/context/root-path-context/testUtils.ts`              | `node:url`    | `{ fileURLToPath }`                |
+| `continuedev/core/autocomplete/context/static-context/StaticContextService.ts`      | `fs/promises` | `* as fs`                          |
+| `continuedev/core/autocomplete/context/static-context/StaticContextService.ts`      | `path`        | `path` (default)                   |
+| `continuedev/core/autocomplete/context/static-context/StaticContextService.ts`      | `url`         | `{ pathToFileURL }`                |
+| `continuedev/core/autocomplete/context/static-context/tree-sitter-utils.ts`         | `fs/promises` | `* as fs`                          |
+| `continuedev/core/indexing/ignore.ts`                                               | `path`        | `path` (default)                   |
+| `continuedev/core/indexing/ignore.ts`                                               | `url`         | `{ fileURLToPath }`                |
+| `continuedev/core/test/testDir.ts`                                                  | `fs`          | `fs` (default)                     |
+| `continuedev/core/test/testDir.ts`                                                  | `os`          | `os` (default)                     |
+| `continuedev/core/test/testDir.ts`                                                  | `path`        | `path` (default)                   |
+| `continuedev/core/test/vitest.global-setup.ts`                                      | `fs`          | `fs` (default)                     |
+| `continuedev/core/test/vitest.global-setup.ts`                                      | `path`        | `path` (default)                   |
+| `continuedev/core/test/vitest.setup.ts`                                             | `util`        | `{ TextDecoder, TextEncoder }`     |
+| `continuedev/core/util/filesystem.ts`                                               | `node:fs`     | `* as fs`                          |
+| `continuedev/core/util/filesystem.ts`                                               | `node:url`    | `{ fileURLToPath }`                |
+| `continuedev/core/util/paths.ts`                                                    | `fs`          | `* as fs`                          |
+| `continuedev/core/util/paths.ts`                                                    | `os`          | `* as os`                          |
+| `continuedev/core/util/paths.ts`                                                    | `path`        | `* as path`                        |
+| `continuedev/core/util/pathToUri.ts`                                                | `url`         | `{ fileURLToPath, pathToFileURL }` |
+| `continuedev/core/util/treeSitter.ts`                                               | `node:fs`     | `fs` (default)                     |
+| `continuedev/core/util/treeSitter.ts`                                               | `path`        | `path` (default)                   |
+
+---
+
+## Appendix: Unique External Dependency List
+
+### npm packages (non-Node.js built-in)
+
+```
+@anthropic-ai/sdk
+@aws-sdk/client-bedrock-runtime
+@aws-sdk/credential-providers
+@roo-code/telemetry
+@roo-code/types
+diff
+dotenv
+fastest-levenshtein
+google-auth-library
+ignore
+js-tiktoken
+lru-cache
+openai
+quick-lru
+uri-js
+vitest
+web-tree-sitter
+zod
+```
+
+### Internal project modules imported (outside autocomplete)
+
+```
+src/api                                    (../../api)
+src/api/providers                          (../../api/providers)
+src/api/providers/kilocode-openrouter      (../../api/providers/kilocode-openrouter)
+src/api/providers/kilocode/IFimProvider    (via continuedev KiloCode.ts)
+src/api/providers/openrouter               (../../api/providers/openrouter)
+src/api/transform/stream                   (../../api/transform/stream)
+src/core/config/ContextProxy               (../../core/config/ContextProxy)
+src/core/config/ProviderSettingsManager    (../../core/config/ProviderSettingsManager)
+src/core/ignore/RooIgnoreController        (../../core/ignore/RooIgnoreController)
+src/core/kilocode/wrapper                  (../../core/kilocode/wrapper)
+src/core/webview/ClineProvider             (../../core/webview/ClineProvider)
+src/i18n                                   (../../i18n)
+src/services/mocking/MockTextDocument      (../mocking/MockTextDocument)
+src/shared/WebviewMessage                  (../../shared/WebviewMessage)
+src/shared/kilocode/headers                (via continuedev KiloCode.ts)
+src/shared/package                         (via continuedev KiloCode.ts)
+src/utils/path                             (../../utils/path)
+webview-ui/src/components/settings/constants
+```

--- a/src/services/autocomplete/docs/investigation-internal-architecture.md
+++ b/src/services/autocomplete/docs/investigation-internal-architecture.md
@@ -1,0 +1,456 @@
+# Internal Architecture of the Autocomplete Module
+
+> Investigation date: 2026-02-12  
+> Scope: `src/services/autocomplete/` — all subdirectories and root-level files
+
+---
+
+## High-Level Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  VS Code Extension Host                                             │
+│                                                                      │
+│  index.ts ─► registerAutocompleteProvider()                          │
+│                  │                                                    │
+│                  ▼                                                    │
+│  ┌──────────────────────────────────────────────────────────────┐    │
+│  │  AutocompleteServiceManager  (singleton orchestrator)         │    │
+│  │  • settings, status bar, cost tracking, snooze, commands      │    │
+│  │  • owns AutocompleteModel + two completion strategies         │    │
+│  └────┬─────────────────────┬──────────────────────┬────────────┘    │
+│       │                     │                      │                 │
+│       ▼                     ▼                      ▼                 │
+│  ┌──────────┐   ┌─────────────────┐   ┌──────────────────────┐      │
+│  │ Autocomplete│  │ Classic Auto-   │   │ Chat Text Area      │      │
+│  │ Model       │  │ Complete        │   │ Autocomplete        │      │
+│  │ (LLM layer) │  │ (inline ghosts) │   │ (webview chat)      │      │
+│  └──────┬───┘   └──────┬──────────┘   └───────┬──────────────┘      │
+│         │              │                       │                     │
+│         │              ▼                       ▼                     │
+│         │   ┌──────────────────────┐  ┌────────────────────┐        │
+│         │   │ continuedev/ library │  │ context/           │        │
+│         │   │ (forked Continue.dev)│  │ VisibleCodeTracker │        │
+│         │   │                      │  └────────────────────┘        │
+│         │   │ • context retrieval  │                                 │
+│         │   │ • snippet gathering  │  ┌────────────────────┐        │
+│         │   │ • prompt templating  │  │ utils/             │        │
+│         │   │ • postprocessing     │  │ kilocode-utils.ts  │        │
+│         │   │ • tree-sitter queries│  └────────────────────┘        │
+│         │   │ • LLM providers      │                                 │
+│         │   └──────────────────────┘                                 │
+│         │                                                            │
+│         ▼                                                            │
+│  ┌──────────────────────────────────────────────────┐               │
+│  │  External: src/api/ (ApiHandler, FimHandler,      │               │
+│  │  buildApiHandler, OpenRouterHandler, etc.)         │               │
+│  └──────────────────────────────────────────────────┘               │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 1. Root-Level Files
+
+### [`index.ts`](../index.ts)
+
+Entry point. Registers the `AutocompleteServiceManager`, JetBrains bridge, and all VS Code commands (`reload`, `generateSuggestions`, `disable`, `showIncompatibilityExtensionPopup`, code actions).
+
+### [`AutocompleteServiceManager.ts`](../AutocompleteServiceManager.ts)
+
+**Singleton orchestrator** for the entire module.
+
+- Owns an [`AutocompleteModel`](../AutocompleteModel.ts) (LLM abstraction) and an [`AutocompleteInlineCompletionProvider`](../classic-auto-complete/AutocompleteInlineCompletionProvider.ts).
+- Manages lifecycle: loads settings from `ContextProxy`, registers/unregisters the VS Code inline completion provider, handles snooze timers.
+- Delegates manual "code suggestion" to the inline completion provider.
+- Tracks session cost and completion count; forwards them to the status bar.
+
+**External dependencies:**
+
+- `vscode` API
+- `@roo-code/types` (`AutocompleteServiceSettings`, `TelemetryEventName`)
+- `@roo-code/telemetry` (`TelemetryService`)
+- `../../core/config/ContextProxy`
+- `../../core/webview/ClineProvider`
+- `../../i18n` (`t()`)
+
+### [`AutocompleteModel.ts`](../AutocompleteModel.ts)
+
+**LLM abstraction layer** — bridges autocomplete requests to the Kilo Code API system.
+
+- `reload(providerSettingsManager)`: Scans configured profiles to find a usable autocomplete provider. Supports dedicated `"autocomplete"` profiles and fallback to general profiles matching `AUTOCOMPLETE_PROVIDER_MODELS`.
+- `supportsFim()`: Checks if the current API handler has a FIM endpoint.
+- `generateFimResponse(prefix, suffix, onChunk)`: Streams a Fill-In-the-Middle completion via `FimHandler.streamFim()`.
+- `generateResponse(system, user, onChunk)`: Streams a chat completion via `ApiHandler.createMessage()`.
+- `hasValidCredentials()`, `getModelName()`, `getProviderDisplayName()`.
+
+**External dependencies:**
+
+- `../../api` (`ApiHandler`, `buildApiHandler`, `FimHandler`)
+- `../../api/providers` (`OpenRouterHandler`, `KilocodeOpenrouterHandler`)
+- `../../api/transform/stream` (`ApiStreamChunk`)
+- `../../core/config/ProviderSettingsManager`
+- `@roo-code/types` (`modelIdKeysByProvider`, `ProviderName`)
+- `webview-ui/.../constants` (`PROVIDERS`)
+
+### [`AutocompleteStatusBar.ts`](../AutocompleteStatusBar.ts)
+
+VS Code status bar item showing autocomplete status (enabled/snoozed/disabled, model, cost).
+
+### [`AutocompleteCodeActionProvider.ts`](../AutocompleteCodeActionProvider.ts)
+
+VS Code code action provider (quick fix integration point).
+
+### [`AutocompleteJetbrainsBridge.ts`](../AutocompleteJetbrainsBridge.ts)
+
+Bridge for JetBrains IDE integration — proxies autocomplete requests from JetBrains to the classic auto-complete provider.
+
+### [`types.ts`](../types.ts)
+
+Central type definitions shared across subdirectories:
+
+- `AutocompleteInput`, `AutocompleteOutcome`, `AutocompletePrompt` (discriminated union: `FimAutocompletePrompt | HoleFillerAutocompletePrompt`)
+- `FillInAtCursorSuggestion`, `ResponseMetaData`, `CostTrackingCallback`
+- `VisibleCodeContext`, `VisibleEditorInfo`, `VisibleRange`, `DiffInfo`
+- `ChatCompletionRequest`, `ChatTextCompletionResult`
+- Utility functions: `extractPrefixSuffix()`, `contextToAutocompleteInput()`
+
+---
+
+## 2. `continuedev/` — Forked Continue.dev Library
+
+### Purpose
+
+A **streamlined extraction** from the [Continue.dev](https://github.com/continuedev/continue) project, containing only autocomplete and NextEdit functionality. All GUI, chat, agents, and other features have been removed. It serves as a **TypeScript service library** providing:
+
+1. **Autocomplete pipeline** — `CompletionProvider` orchestrates: prefiltering → context gathering → snippet retrieval → prompt templating → LLM streaming → stream filtering → postprocessing → caching.
+2. **Context retrieval** — `ContextRetrievalService`, `ImportDefinitionsService`, `RootPathContextService`.
+3. **Snippet gathering** — `getAllSnippets()` collects recently edited files, recently visited ranges, LSP definitions, clipboard, diffs.
+4. **Prompt templating** — Model-specific FIM templates (`codestral`, `starcoder`, `deepseek`, etc.), prefix/suffix construction, token-limited rendering.
+5. **Stream filtering** — `BracketMatchingService`, `charStream`/`lineStream` transforms, `StreamTransformPipeline`.
+6. **Postprocessing** — bracket cleanup, `removePrefixOverlap`, completion formatting.
+7. **Tree-sitter integration** — `.scm` query files for 15+ languages covering: code snippets, imports, root-path context, static context (hole/header/type queries), and tag queries.
+8. **LLM providers** — `ILLM` interface with implementations for OpenAI, Mistral, OpenRouter, KiloCode, Mock.
+9. **Diff engine** — Myers diff algorithm, streaming diff.
+10. **Utility layer** — Token counting (llama tokenizer), LRU caching, logging service, debouncing, helper variables.
+
+### Key Files
+
+| File                                                                                                                                                                    | Role                                                                                      |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [`core/index.d.ts`](../continuedev/core/index.d.ts)                                                                                                                     | Core type definitions: `IDE`, `ILLM`, `TabAutocompleteOptions`, `Position`, `Range`, etc. |
+| [`core/autocomplete/CompletionProvider.ts`](../continuedev/core/autocomplete/CompletionProvider.ts)                                                                     | Main orchestrator (not used directly by classic-auto-complete; serves as reference)       |
+| [`core/autocomplete/context/ContextRetrievalService.ts`](../continuedev/core/autocomplete/context/)                                                                     | Context gathering service                                                                 |
+| [`core/autocomplete/snippets/getAllSnippets.ts`](../continuedev/core/autocomplete/snippets/getAllSnippets.ts)                                                           | Collects all context snippets                                                             |
+| [`core/autocomplete/templating/`](../continuedev/core/autocomplete/templating/)                                                                                         | Prompt construction, formatting, model-specific templates                                 |
+| [`core/autocomplete/postprocessing/`](../continuedev/core/autocomplete/postprocessing/)                                                                                 | Post-processing pipeline                                                                  |
+| [`core/autocomplete/util/HelperVars.ts`](../continuedev/core/autocomplete/util/HelperVars.ts)                                                                           | Cursor context, pruned prefix/suffix computation                                          |
+| [`core/vscode-test-harness/src/VSCodeIde.ts`](../continuedev/core/vscode-test-harness/src/VSCodeIde.ts)                                                                 | VS Code `IDE` interface implementation                                                    |
+| [`core/vscode-test-harness/src/autocomplete/lsp.ts`](../continuedev/core/vscode-test-harness/src/autocomplete/lsp.ts)                                                   | LSP definition retrieval                                                                  |
+| [`core/vscode-test-harness/src/autocomplete/RecentlyVisitedRangesService.ts`](../continuedev/core/vscode-test-harness/src/autocomplete/RecentlyVisitedRangesService.ts) | Tracks recently visited code ranges                                                       |
+| [`core/vscode-test-harness/src/autocomplete/recentlyEdited.ts`](../continuedev/core/vscode-test-harness/src/autocomplete/recentlyEdited.ts)                             | Tracks recently edited code ranges                                                        |
+| [`core/llm/`](../continuedev/core/llm/)                                                                                                                                 | LLM implementations (OpenAI, Mistral, etc.)                                               |
+| [`core/util/parameters.ts`](../continuedev/core/util/parameters.ts)                                                                                                     | `DEFAULT_AUTOCOMPLETE_OPTS`                                                               |
+| [`tree-sitter/`](../continuedev/tree-sitter/)                                                                                                                           | `.scm` query files for all supported languages                                            |
+
+### Self-containedness
+
+The continuedev library is **largely self-contained** with its own:
+
+- `IDE` interface (abstraction over VS Code/JetBrains)
+- `ILLM` interface (abstraction over LLM providers)
+- Tree-sitter integration
+- Utility layer
+
+It imports `web-tree-sitter` as an external npm dependency. The `VsCodeIde.ts` implementation within it imports `vscode` API directly.
+
+---
+
+## 3. `classic-auto-complete/` — Inline Code Completion Pipeline
+
+### Purpose
+
+The **primary code editor autocomplete** feature. Implements `vscode.InlineCompletionItemProvider` to show ghost text completions as the user types.
+
+### Completion Pipeline Flow
+
+```
+VS Code triggers provideInlineCompletionItems()
+    │
+    ▼
+┌──────────────────────────────────────────┐
+│ 1. Gate checks                           │
+│    • Is auto-trigger enabled?            │
+│    • Has valid model/credentials?        │
+│    • Is file accessible (RooIgnore)?     │
+└──────────┬───────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────┐
+│ 2. Cache lookup (suggestions history)     │
+│    findMatchingSuggestion():             │
+│    • exact match                         │
+│    • partial_typing (user typed ahead)   │
+│    • backward_deletion (user backspaced) │
+│    → If cache hit, return immediately    │
+└──────────┬───────────────────────────────┘
+           │ (cache miss)
+           ▼
+┌──────────────────────────────────────────┐
+│ 3. Contextual skip                       │
+│    shouldSkipAutocomplete():             │
+│    • mid-word typing (len > 2)           │
+│    • at end of statement (;, }, ))       │
+│    → If skip, return empty               │
+└──────────┬───────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────┐
+│ 4. Prompt building                       │
+│    Strategy chosen by model.supportsFim()│
+│                                          │
+│    FIM path (FimPromptBuilder):          │
+│    • getProcessedSnippets() → HelperVars │
+│    • getAllSnippetsWithoutRace() →        │
+│      context, snippets, LSP defs         │
+│    • getTemplateForModel() → FIM format  │
+│    • compilePrefixSuffix() → formatted   │
+│                                          │
+│    Chat path (HoleFiller):               │
+│    • Same context gathering              │
+│    • formatSnippets() → comment context  │
+│    • System prompt (hole-filler pattern) │
+│    • {{FILL_HERE}} template              │
+└──────────┬───────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────┐
+│ 5. Debounced LLM request                 │
+│    • Leading edge on first call          │
+│    • Adaptive delay (avg of recent       │
+│      latencies, 150ms–1000ms range)      │
+│    • Reuses covering pending requests    │
+└──────────┬───────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────┐
+│ 6. LLM call (via AutocompleteModel)      │
+│    FIM: model.generateFimResponse()      │
+│         → FimHandler.streamFim()         │
+│    Chat: model.generateResponse()        │
+│         → ApiHandler.createMessage()     │
+│    → Collects streaming chunks           │
+└──────────┬───────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────┐
+│ 7. Post-processing                       │
+│    processSuggestion() →                 │
+│    postprocessAutocompleteSuggestion():   │
+│    a. continuedev postprocessCompletion() │
+│       (prefix overlap removal, etc.)     │
+│    b. applyLanguageFilter() (markdown)   │
+│    c. suggestionConsideredDuplication()   │
+│       • prefix/suffix duplication        │
+│       • edge-line duplication            │
+│       • repetitive phrase detection      │
+│       • normalized complete-line check   │
+└──────────┬───────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────┐
+│ 8. Display logic                         │
+│    • applyFirstLineOnly() — truncate     │
+│      multi-line if cursor is mid-line    │
+│    • stringToInlineCompletions() →       │
+│      vscode.InlineCompletionItem         │
+│    • Track in suggestionsHistory         │
+│    • Cost tracking callback              │
+│    • Telemetry (requested, returned,     │
+│      filtered, cache hit, accepted,      │
+│      unique shown, visibility tracking)  │
+└──────────────────────────────────────────┘
+```
+
+### Key Files
+
+| File                                                                                                          | Role                                                                                           |
+| ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [`AutocompleteInlineCompletionProvider.ts`](../classic-auto-complete/AutocompleteInlineCompletionProvider.ts) | Main provider: debouncing, cache, pipeline orchestration                                       |
+| [`FillInTheMiddle.ts`](../classic-auto-complete/FillInTheMiddle.ts)                                           | `FimPromptBuilder` — builds FIM prompts using continuedev's templating                         |
+| [`HoleFiller.ts`](../classic-auto-complete/HoleFiller.ts)                                                     | Chat-based completion with `{{FILL_HERE}}` / `<COMPLETION>` XML tag protocol                   |
+| [`getProcessedSnippets.ts`](../classic-auto-complete/getProcessedSnippets.ts)                                 | Orchestrates context gathering: `HelperVars`, `getAllSnippetsWithoutRace`, access filtering    |
+| [`contextualSkip.ts`](../classic-auto-complete/contextualSkip.ts)                                             | Determines when to skip autocomplete (mid-word, end-of-statement)                              |
+| [`uselessSuggestionFilter.ts`](../classic-auto-complete/uselessSuggestionFilter.ts)                           | Duplication detection, postprocessing pipeline integration                                     |
+| [`AutocompleteTelemetry.ts`](../classic-auto-complete/AutocompleteTelemetry.ts)                               | Telemetry events: requested, filtered, cache hit, LLM completed/failed, accepted, unique shown |
+| [`language-filters/index.ts`](../classic-auto-complete/language-filters/index.ts)                             | Language-specific post-filters (currently: markdown)                                           |
+
+### External Dependencies (outside autocomplete module)
+
+- `vscode` API (`InlineCompletionItemProvider`, `TextDocument`, `Position`, etc.)
+- `../../api/transform/stream` (`ApiStreamChunk`)
+- `../../core/ignore/RooIgnoreController` (file access filtering)
+- `../../core/webview/ClineProvider`
+- `@roo-code/types`, `@roo-code/telemetry`
+
+---
+
+## 4. `chat-autocomplete/` — Chat Text Area Autocomplete
+
+### Purpose
+
+Provides **autocomplete for the chat input text area** in the Kilo Code webview. When the user is typing a message in the chat panel, this module suggests completions for natural language text.
+
+### Architecture
+
+```
+Webview sends "requestChatCompletion" message
+    │
+    ▼
+handleChatCompletionRequest()
+    │
+    ├── Creates VisibleCodeTracker → captureVisibleCode()
+    ├── Creates ChatTextAreaAutocomplete
+    │       │
+    │       ├── Initializes AutocompleteModel (same LLM layer)
+    │       ├── buildPrefix() — includes visible code context
+    │       │
+    │       ├── FIM path: model.generateFimResponse()
+    │       └── Chat path: model.generateResponse() with chat-specific prompts
+    │
+    │       cleanSuggestion():
+    │       ├── removePrefixOverlap()
+    │       ├── postprocessAutocompleteSuggestion()
+    │       ├── Filter code-looking suggestions (//, /*, #)
+    │       └── Truncate at first newline
+    │
+    └── Sends "chatCompletionResult" back to webview
+```
+
+### Communication
+
+- **Request**: Webview → Extension: `{ type: "requestChatCompletion", text, requestId }`
+- **Response**: Extension → Webview: `{ type: "chatCompletionResult", text, requestId }`
+- **Acceptance**: Webview → Extension: `{ type: "chatCompletionAccepted", suggestionLength }`
+
+### Key Files
+
+| File                                                                                      | Role                                                                      |
+| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| [`ChatTextAreaAutocomplete.ts`](../chat-autocomplete/ChatTextAreaAutocomplete.ts)         | Core logic: prompt building with visible code context, LLM call, cleaning |
+| [`handleChatCompletionRequest.ts`](../chat-autocomplete/handleChatCompletionRequest.ts)   | Message handler: creates tracker + autocomplete, sends result to webview  |
+| [`handleChatCompletionAccepted.ts`](../chat-autocomplete/handleChatCompletionAccepted.ts) | Telemetry handler for accepted suggestions                                |
+
+### External Dependencies
+
+- `../../core/webview/ClineProvider` (webview messaging)
+- `../../core/config/ProviderSettingsManager`
+- Reuses `AutocompleteTelemetry` and `postprocessAutocompleteSuggestion` from classic-auto-complete
+
+---
+
+## 5. `context/` — Visible Code Context
+
+### Purpose
+
+Captures what code is **actually visible** in the user's VS Code editor viewports (not just which files are open).
+
+### [`VisibleCodeTracker.ts`](../context/VisibleCodeTracker.ts)
+
+- Iterates `vscode.window.visibleTextEditors`
+- For each editor: captures file path, language ID, visible line ranges, cursor position, selections
+- Extracts diff information from git-scheme URIs
+- Filters out files matching security patterns (`isSecurityConcern`) and `.kilocodeignore` rules
+
+### External Dependencies
+
+- `vscode` API (`window.visibleTextEditors`, `TextEditor`)
+- `../../../utils/path` (`toRelativePath`)
+- `../continuedev/core/indexing/ignore` (`isSecurityConcern`)
+- `../../../core/ignore/RooIgnoreController`
+
+---
+
+## 6. `utils/` — Utility Functions
+
+### [`kilocode-utils.ts`](../utils/kilocode-utils.ts)
+
+- `checkKilocodeBalance(token, orgId)`: HTTP call to `/api/profile/balance` to verify positive balance.
+- Re-exports `AUTOCOMPLETE_PROVIDER_MODELS` and `AutocompleteProviderKey` from `@roo-code/types`.
+
+### External Dependencies
+
+- `@roo-code/types` (`getKiloBaseUriFromToken`, `AUTOCOMPLETE_PROVIDER_MODELS`, `AutocompleteProviderKey`)
+- Node.js `fetch`
+
+---
+
+## Key Interfaces and Abstractions
+
+### Within the Module
+
+| Interface                     | Defined In | Purpose                                                                                       |
+| ----------------------------- | ---------- | --------------------------------------------------------------------------------------------- |
+| `AutocompleteInput`           | `types.ts` | Input for both FIM and hole-filler strategies                                                 |
+| `AutocompletePrompt`          | `types.ts` | Discriminated union: `FimAutocompletePrompt \| HoleFillerAutocompletePrompt`                  |
+| `FillInAtCursorSuggestion`    | `types.ts` | Result: `{ text, prefix, suffix }`                                                            |
+| `ResponseMetaData`            | `types.ts` | Cost/token tracking                                                                           |
+| `AutocompleteContextProvider` | `types.ts` | Bundles `ContextRetrievalService` + `VsCodeIde` + `AutocompleteModel` + `RooIgnoreController` |
+| `CostTrackingCallback`        | `types.ts` | `(cost, inputTokens, outputTokens) => void`                                                   |
+| `VisibleCodeContext`          | `types.ts` | Captured visible editor state                                                                 |
+
+### From continuedev
+
+| Interface                | Defined In                               | Purpose                                                        |
+| ------------------------ | ---------------------------------------- | -------------------------------------------------------------- |
+| `IDE`                    | `continuedev/core/index.d.ts`            | IDE abstraction (file I/O, LSP, editor state)                  |
+| `ILLM`                   | `continuedev/core/index.d.ts`            | LLM abstraction (streamComplete, streamFim, chat, countTokens) |
+| `TabAutocompleteOptions` | `continuedev/core/index.d.ts`            | Autocomplete configuration options                             |
+| `AutocompleteSnippet`    | `continuedev/core/autocomplete/types.ts` | Context snippet with type discrimination                       |
+
+### From External Code
+
+| Interface/Class           | From                  | Used For                           |
+| ------------------------- | --------------------- | ---------------------------------- |
+| `ApiHandler`              | `src/api/`            | Chat-based LLM streaming           |
+| `FimHandler`              | `src/api/`            | FIM completion streaming           |
+| `ProviderSettingsManager` | `src/core/config/`    | Profile and provider configuration |
+| `ContextProxy`            | `src/core/config/`    | Global state persistence           |
+| `ClineProvider`           | `src/core/webview/`   | Webview messaging, task access     |
+| `RooIgnoreController`     | `src/core/ignore/`    | File access filtering              |
+| `TelemetryService`        | `@roo-code/telemetry` | Event tracking                     |
+
+---
+
+## Self-Contained vs. External Dependencies Summary
+
+### Self-Contained (within `src/services/autocomplete/`)
+
+- ✅ Completion pipeline logic (classic + chat)
+- ✅ Contextual skip heuristics
+- ✅ Suggestion history/cache management
+- ✅ Duplication and uselessness filtering
+- ✅ Language-specific filters
+- ✅ Adaptive debouncing
+- ✅ Visible code context capture
+- ✅ Chat text area completion logic
+- ✅ Telemetry event definitions
+- ✅ continuedev library (context retrieval, snippet gathering, prompt templating, tree-sitter queries, postprocessing, LLM abstractions)
+
+### Requires External Reconstruction
+
+| Dependency                  | Source               | What It Provides                                                                  |
+| --------------------------- | -------------------- | --------------------------------------------------------------------------------- |
+| `ApiHandler` / `FimHandler` | `src/api/`           | Actual LLM API calls (streaming FIM + chat)                                       |
+| `buildApiHandler()`         | `src/api/`           | Factory to create API handlers from profiles                                      |
+| `ProviderSettingsManager`   | `src/core/config/`   | Profile management, provider config                                               |
+| `ContextProxy`              | `src/core/config/`   | Persistent global state                                                           |
+| `ClineProvider`             | `src/core/webview/`  | Webview messaging + task state                                                    |
+| `RooIgnoreController`       | `src/core/ignore/`   | `.kilocodeignore` pattern matching                                                |
+| `vscode` API                | VS Code              | All editor integration (inline completions, status bar, commands, text documents) |
+| `@roo-code/types`           | `packages/types`     | Shared type definitions, provider constants                                       |
+| `@roo-code/telemetry`       | `packages/telemetry` | Telemetry event capture                                                           |
+| `../../i18n`                | `src/i18n/`          | Localization                                                                      |
+| `../../utils/path`          | `src/utils/`         | Path utilities (`toRelativePath`)                                                 |
+| `web-tree-sitter`           | npm                  | Tree-sitter WASM parser (used by continuedev)                                     |
+| `PROVIDERS` constant        | `webview-ui/`        | Provider display name mapping                                                     |

--- a/src/services/autocomplete/docs/investigation-vscode-integration.md
+++ b/src/services/autocomplete/docs/investigation-vscode-integration.md
@@ -1,0 +1,412 @@
+# Investigation: VSCode Extension Integration Points for Autocomplete
+
+This document captures every integration point between the autocomplete feature and the
+VSCode extension infrastructure. It's intended for use when recreating the extension shell
+in a standalone package.
+
+---
+
+## 1. package.json Contributions
+
+### 1.1 Activation Events
+
+```jsonc
+// src/package.json lines 51-54
+"activationEvents": [
+  "onLanguage",       // activates for ANY language
+  "onStartupFinished" // activates after startup completes
+]
+```
+
+There are no autocomplete-specific activation events. Both events are general-purpose.
+
+### 1.2 Commands
+
+Commands declared in `src/package.json` `contributes.commands`:
+
+| Command ID                                       | Title Key                                        | Registered in Code?                        |
+| ------------------------------------------------ | ------------------------------------------------ | ------------------------------------------ |
+| `kilo-code.autocomplete.generateSuggestions`     | `%autocomplete.commands.generateSuggestions%`    | ✅ `src/services/autocomplete/index.ts:26` |
+| `kilo-code.autocomplete.cancelSuggestions`       | `%autocomplete.commands.cancelSuggestions%`      | ❌ Never registered — placeholder          |
+| `kilo-code.autocomplete.applyCurrentSuggestions` | `%autocomplete.commands.applyCurrentSuggestion%` | ❌ Never registered — placeholder          |
+| `kilo-code.autocomplete.applyAllSuggestions`     | `%autocomplete.commands.applyAllSuggestions%`    | ❌ Never registered — placeholder          |
+| `kilo-code.autocomplete.goToNextSuggestion`      | `%autocomplete.commands.goToNextSuggestion%`     | ❌ Never registered — placeholder          |
+| `kilo-code.autocomplete.goToPreviousSuggestion`  | `%autocomplete.commands.goToPreviousSuggestion%` | ❌ Never registered — placeholder          |
+
+Additional commands registered **programmatically** but NOT declared in package.json:
+
+| Command ID                                                 | Registered in                                                                                 | Notes                                       |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `kilo-code.autocomplete.reload`                            | `src/services/autocomplete/index.ts:16`                                                       | Reloads settings and model                  |
+| `kilo-code.autocomplete.codeActionQuickFix`                | `src/services/autocomplete/index.ts:21`                                                       | No-op stub                                  |
+| `kilo-code.autocomplete.showIncompatibilityExtensionPopup` | `src/services/autocomplete/index.ts:31`                                                       | Shows Copilot conflict dialog               |
+| `kilo-code.autocomplete.disable`                           | `src/services/autocomplete/index.ts:36`                                                       | Disables autocomplete                       |
+| `kilocode.autocomplete.inline-completion.accepted`         | `src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts:313` | Telemetry callback when suggestion accepted |
+| `kilo-code.jetbrains.getInlineCompletions`                 | `src/services/autocomplete/AutocompleteJetbrainsBridge.ts:289`                                | JetBrains bridge                            |
+
+### 1.3 Keybindings
+
+From `src/package.json` `contributes.keybindings`:
+
+| Command                                                    | Key      | Mac     | When Clause                                                                                                                                                 |
+| ---------------------------------------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kilo-code.autocomplete.cancelSuggestions`                 | `Escape` | same    | `editorTextFocus && !editorTabMovesFocus && !inSnippetMode && kilocode.autocomplete.hasSuggestions`                                                         |
+| `kilo-code.autocomplete.generateSuggestions`               | `Ctrl+L` | `Cmd+L` | `editorTextFocus && !editorTabMovesFocus && !inSnippetMode && kilocode.autocomplete.enableSmartInlineTaskKeybinding && !github.copilot.completions.enabled` |
+| `kilo-code.autocomplete.showIncompatibilityExtensionPopup` | `Ctrl+L` | `Cmd+L` | `editorTextFocus && !editorTabMovesFocus && !inSnippetMode && kilocode.autocomplete.enableSmartInlineTaskKeybinding && github.copilot.completions.enabled`  |
+
+**Note**: The `Escape` keybinding references `kilocode.autocomplete.hasSuggestions` which is
+**never set** in code via `setContext`. This means the keybinding is currently inert
+(would never activate).
+
+### 1.4 Menus
+
+There are **no menu contributions** for autocomplete commands. The autocomplete commands
+do not appear in any editor/context, view/title, or other menu.
+
+### 1.5 Configuration Settings
+
+There are **no VSCode `configuration` contributions** for autocomplete in `package.json`.
+Autocomplete settings are stored entirely in VSCode global state via `ContextProxy` under
+the key `ghostServiceSettings`, not as workspace/user settings.
+
+### 1.6 Code Actions
+
+From `src/package.json`:
+
+```jsonc
+"codeActions": [{
+  "languages": ["*"],
+  "providedCodeActionKinds": ["vscode.CodeActionKind.QuickFix"]
+}]
+```
+
+This is a general declaration. The autocomplete-specific code action provider is registered
+programmatically in `src/services/autocomplete/index.ts:42-46`:
+
+```typescript
+vscode.languages.registerCodeActionsProvider("*", autocompleteManager.codeActionProvider, {
+	providedCodeActionKinds: Object.values(autocompleteManager.codeActionProvider.providedCodeActionKinds),
+})
+```
+
+The `AutocompleteCodeActionProvider` (`src/services/autocomplete/AutocompleteCodeActionProvider.ts`)
+provides a QuickFix action that triggers `kilo-code.autocomplete.generateSuggestions`.
+
+---
+
+## 2. Extension Activation & Service Initialization
+
+### 2.1 Extension activation flow (`src/extension.ts`)
+
+1. **Import**: `registerAutocompleteProvider` imported from `./services/autocomplete` (line 49)
+2. **First-install defaults** (lines 400-414): On first install, autocomplete is enabled:
+    ```typescript
+    const currentAutocompleteSettings = contextProxy.getValue("ghostServiceSettings")
+    await contextProxy.setValue("ghostServiceSettings", {
+    	...currentAutocompleteSettings,
+    	enableAutoTrigger: !kiloCodeWrapperJetbrains, // disabled for JetBrains
+    	enableSmartInlineTaskKeybinding: true,
+    })
+    ```
+3. **Registration** (lines 512-520): Autocomplete is registered unless running as CLI:
+    ```typescript
+    if (kiloCodeWrapperCode !== "cli") {
+    	registerAutocompleteProvider(context, provider)
+    }
+    ```
+
+### 2.2 `registerAutocompleteProvider` (`src/services/autocomplete/index.ts`)
+
+This function:
+
+1. Creates `AutocompleteServiceManager` singleton
+2. Registers JetBrains bridge via `registerAutocompleteJetbrainsBridge`
+3. Registers 5 commands (reload, codeActionQuickFix, generateSuggestions, showIncompatibilityExtensionPopup, disable)
+4. Registers `CodeActionsProvider` for all languages (`"*"`)
+
+### 2.3 `AutocompleteServiceManager` initialization
+
+On construction (`src/services/autocomplete/AutocompleteServiceManager.ts:37-61`):
+
+1. Creates `AutocompleteModel` for provider/model management
+2. Creates `AutocompleteCodeActionProvider` for QuickFix code actions
+3. Creates `AutocompleteInlineCompletionProvider` for inline completions
+4. Calls `this.load()` to initialize
+
+### 2.4 `load()` method
+
+On load (`src/services/autocomplete/AutocompleteServiceManager.ts:70-99`):
+
+1. Reads `ghostServiceSettings` from `ContextProxy`
+2. Sets context key `kilocode.autocomplete.enableSmartInlineTaskKeybinding` via `setContext`
+3. Registers/unregisters `InlineCompletionItemProvider` based on `enableAutoTrigger` state
+4. Updates status bar
+5. Writes enriched settings (with provider/model info) back to `ContextProxy`
+6. Posts state to webview
+
+---
+
+## 3. Context Keys (setContext)
+
+| Context Key                                             | Where Set                                                         | Purpose                                                  |
+| ------------------------------------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------- |
+| `kilocode.autocomplete.enableSmartInlineTaskKeybinding` | `AutocompleteServiceManager.updateGlobalContext()` (line 286-290) | Controls whether `Cmd+L` / `Ctrl+L` keybinding is active |
+| `kilocode.autocomplete.hasSuggestions`                  | ❌ Never set                                                      | Would control `Escape` keybinding — currently dead code  |
+
+---
+
+## 4. Webview State Integration
+
+### 4.1 State passing to webview (`src/core/webview/ClineProvider.ts`)
+
+The `ghostServiceSettings` is destructured from global state and included in the
+state object sent to the webview at:
+
+- Line 2284: `ghostServiceSettings` extracted from state values
+- Line 2480: `ghostServiceSettings: ghostServiceSettings` included in state to webview
+- Line 2758: `ghostServiceSettings: stateValues.ghostServiceSettings` included in full state
+
+### 4.2 Webview message handlers (`src/core/webview/webviewMessageHandler.ts`)
+
+Three autocomplete-related message types are handled:
+
+1. **`ghostServiceSettings`** (lines 1972-1982):
+
+    ```typescript
+    case "ghostServiceSettings":
+      const validatedSettings = autocompleteServiceSettingsSchema.parse(message.values)
+      await updateGlobalState("ghostServiceSettings", validatedSettings)
+      await provider.postStateToWebview()
+      vscode.commands.executeCommand("kilo-code.autocomplete.reload")
+    ```
+
+    This is the primary way the webview UI writes autocomplete settings.
+
+2. **`snoozeAutocomplete`** (lines 1983-1989):
+
+    ```typescript
+    case "snoozeAutocomplete":
+      if (typeof message.value === "number" && message.value > 0) {
+        await AutocompleteServiceManager.getInstance()?.snooze(message.value)
+      } else {
+        await AutocompleteServiceManager.getInstance()?.unsnooze()
+      }
+    ```
+
+3. **`requestChatCompletion`** (lines 3969-3975): Handles chat textarea FIM autocomplete.
+4. **`chatCompletionAccepted`** (lines 3977-3979): Handles chat completion acceptance telemetry.
+
+### 4.3 Autocomplete reload triggered from webview
+
+The `kilo-code.autocomplete.reload` command is also triggered when API profiles change:
+
+- `saveApiConfiguration` (line 2231)
+- `upsertApiConfiguration` (lines 2294, 2303)
+- `renameApiConfiguration` (line 2330)
+- `deleteApiConfiguration` (line 2407)
+
+---
+
+## 5. Global State / ContextProxy
+
+### 5.1 State key
+
+The autocomplete feature uses a single global state key:
+
+```
+ghostServiceSettings: AutocompleteServiceSettings
+```
+
+Defined in `packages/types/src/global-settings.ts:230`:
+
+```typescript
+ghostServiceSettings: autocompleteServiceSettingsSchema
+```
+
+### 5.2 Schema (`packages/types/src/kilocode/kilocode.ts:9-19`)
+
+```typescript
+export const autocompleteServiceSettingsSchema = z
+	.object({
+		enableAutoTrigger: z.boolean().optional(),
+		enableSmartInlineTaskKeybinding: z.boolean().optional(),
+		enableChatAutocomplete: z.boolean().optional(),
+		provider: z.string().optional(),
+		model: z.string().optional(),
+		snoozeUntil: z.number().optional(),
+		hasKilocodeProfileWithNoBalance: z.boolean().optional(),
+	})
+	.optional()
+```
+
+### 5.3 Read/write patterns
+
+- **Read**: `ContextProxy.instance.getGlobalState("ghostServiceSettings")`
+- **Write**: `ContextProxy.instance.setValues({ ghostServiceSettings: ... })`
+- **WebView write**: sends `{ type: "ghostServiceSettings", values: ... }` message
+
+### 5.4 VSCode global state references
+
+The key `ghostServiceSettings` is listed as a valid global state key for webview
+communication in `packages/types/src/vscode-extension-host.ts:546` and `795`.
+
+---
+
+## 6. VSCode API Providers Registered
+
+| Provider Type                  | Registration                                                              | Scope                                                |
+| ------------------------------ | ------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `InlineCompletionItemProvider` | `AutocompleteServiceManager.updateInlineCompletionProviderRegistration()` | `{ scheme: "file" }` — only for file-based documents |
+| `CodeActionsProvider`          | `src/services/autocomplete/index.ts:42`                                   | `"*"` — all languages                                |
+
+The inline completion provider is conditionally registered/disposed based on
+`enableAutoTrigger` and snooze state.
+
+---
+
+## 7. Status Bar
+
+`AutocompleteStatusBar` (`src/services/autocomplete/AutocompleteStatusBar.ts`):
+
+- Alignment: `vscode.StatusBarAlignment.Right`, priority 100
+- Shows/hides based on `enableAutoTrigger` setting
+- Displays completion count, cost, provider info, and snoozed state
+- Uses `$(kilo-logo)` codicon (custom icon font)
+
+---
+
+## 8. i18n / Localization
+
+### 8.1 Package NLS keys (`src/package.nls.json` and locale variants)
+
+Keys used in `package.json` command titles:
+
+| Key                                            | English Value                                  |
+| ---------------------------------------------- | ---------------------------------------------- |
+| `autocomplete.commands.generateSuggestions`    | Generate Suggested Edits                       |
+| `autocomplete.commands.displaySuggestions`     | Display Suggested Edits                        |
+| `autocomplete.commands.cancelSuggestions`      | Cancel Suggested Edits                         |
+| `autocomplete.commands.applyCurrentSuggestion` | Apply Current Suggested Edit                   |
+| `autocomplete.commands.applyAllSuggestions`    | Apply All Suggested Edits                      |
+| `autocomplete.commands.goToNextSuggestion`     | Go To Next Suggestion                          |
+| `autocomplete.commands.goToPreviousSuggestion` | Go To Previous Suggestion                      |
+| `autocomplete.input.title`                     | Press 'Enter' to confirm or 'Escape' to cancel |
+| `autocomplete.input.placeholder`               | Describe what you want to do...                |
+
+Translated in 20+ locale files: `src/package.nls.{de,fr,es,it,ja,ko,nl,pl,pt-BR,ru,sk,cs,uk,zh-CN,zh-TW,ar,ca,hi,id,th,tr,vi}.json`.
+
+### 8.2 Runtime i18n keys (src/i18n/locales/en/kilocode.json)
+
+Namespace: `kilocode:autocomplete.*`
+
+```jsonc
+{
+	"autocomplete": {
+		"statusBar": {
+			"enabled": "$(kilo-logo) Autocomplete",
+			"snoozed": "snoozed",
+			"warning": "$(warning) Autocomplete",
+			"tooltip": {
+				"basic": "Kilo Code Autocomplete",
+				"disabled": "Kilo Code Autocomplete (disabled)",
+				"noCredits": "...",
+				"noUsableProvider": "...",
+				"sessionTotal": "Session total cost:",
+				"provider": "Provider:",
+				"model": "Model:",
+				"profile": "Profile: ",
+				"defaultProfile": "Default",
+				"completionSummary": "Performed {{count}} completions between {{startTime}} and {{endTime}}, for a total cost of {{cost}}.",
+				"providerInfo": "Autocompletions provided by {{model}} via {{provider}}.",
+			},
+			"cost": {
+				"zero": "$0.00",
+				"lessThanCent": "<$0.01",
+			},
+		},
+		"toggleMessage": "Kilo Code Autocomplete {{status}}",
+		"progress": {
+			"title": "Kilo Code",
+			"analyzing": "Analyzing your code...",
+			"generating": "Generating suggested edits...",
+			"processing": "Processing suggested edits...",
+			"showing": "Displaying suggested edits...",
+		},
+		"input": {
+			"title": "Kilo Code: Quick Task",
+			"placeholder": "e.g., 'refactor this function to be more efficient'",
+		},
+		"commands": {
+			"generateSuggestions": "Kilo Code: Generate Suggested Edits",
+			"displaySuggestions": "Display Suggested Edits",
+			"cancelSuggestions": "Cancel Suggested Edits",
+			"applyCurrentSuggestion": "Apply Current Suggested Edit",
+			"applyAllSuggestions": "Apply All Suggested Edits",
+			"category": "Kilo Code",
+		},
+		"codeAction": {
+			"title": "Kilo Code: Suggested Edits",
+		},
+		"chatParticipant": {
+			"fullName": "Kilo Code Agent",
+			"name": "Agent",
+			"description": "I can help you with quick tasks and suggested edits.",
+		},
+		"incompatibilityExtensionPopup": {
+			"message": "The Kilo Code Autocomplete is being blocked by a conflict with GitHub Copilot. To fix this, you must disable Copilot's inline suggestions.",
+			"disableCopilot": "Disable Copilot",
+			"disableInlineAssist": "Disable Autocomplete",
+		},
+	},
+}
+```
+
+Translated in all locale files under `src/i18n/locales/{locale}/kilocode.json`.
+
+---
+
+## 9. Telemetry Events
+
+| Event                                        | Where Used                                                           |
+| -------------------------------------------- | -------------------------------------------------------------------- |
+| `TelemetryEventName.INLINE_ASSIST_AUTO_TASK` | `AutocompleteServiceManager.codeSuggestion()`                        |
+| `TelemetryEventName.GHOST_SERVICE_DISABLED`  | `AutocompleteServiceManager.disable()`                               |
+| Accept suggestion telemetry                  | `AutocompleteInlineCompletionProvider` via accepted command callback |
+
+---
+
+## 10. Dependencies on Host Extension
+
+The autocomplete service depends on:
+
+1. **`ClineProvider`** — for `providerSettingsManager` (API provider configs), `postStateToWebview()`
+2. **`ContextProxy`** — singleton for global state read/write
+3. **`vscode.ExtensionContext`** — for `subscriptions` (disposable management), `globalState`
+4. **Webview messaging** — bidirectional communication for settings changes
+5. **Custom icon font** — `$(kilo-logo)` codicon from `assets/icons/kilo-icon-font.woff2`
+
+---
+
+## 11. Legacy: Ghost Service
+
+The code refers to `ghostServiceSettings` and `GhostServiceManager` in
+`src/services/ghost/` — this appears to be the original/predecessor copy.
+The current active autocomplete uses `src/services/autocomplete/` which is
+a refactored version. The `ghost` name persists in the global state key
+`ghostServiceSettings` for backwards compatibility.
+
+---
+
+## 12. Summary: What a New Extension Would Need
+
+To recreate the autocomplete as a standalone extension:
+
+1. **package.json**: 6 declared commands + keybindings + code action declaration
+2. **Activation**: `onLanguage` + `onStartupFinished`, register providers on activate
+3. **Providers**: `InlineCompletionItemProvider` (file scheme), `CodeActionsProvider` (all langs)
+4. **Context keys**: `kilocode.autocomplete.enableSmartInlineTaskKeybinding` (via setContext)
+5. **Status bar**: Right-aligned status bar item with custom icon
+6. **State**: Single `ghostServiceSettings` object in global state (or a new key)
+7. **Webview communication**: Message types `ghostServiceSettings`, `snoozeAutocomplete`, `requestChatCompletion`, `chatCompletionAccepted`
+8. **i18n**: ~10 NLS keys in package.nls.json + ~30 runtime keys in kilocode.json
+9. **Telemetry**: 2 primary event types

--- a/src/services/autocomplete/i18n/ar.ts
+++ b/src/services/autocomplete/i18n/ar.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// ar runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "متوقف مؤقتاً",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (معطل)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**لا يوجد رصيد في حسابك**\n\nحساب Kilo Code الخاص بك لا يحتوي على رصيد. لاستخدام الإكمال التلقائي، يرجى إضافة رصيد إلى حسابك.\n\n[فتح الإعدادات](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**لم يتم تكوين نموذج الإكمال التلقائي**\n\nلتمكين الإكمال التلقائي، أضف ملفًا شخصيًا مع أحد هذه المزودين المدعومين: {{providers}}.\n\n[فتح الإعدادات](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "إجمالي تكلفة الجلسة:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "المزود:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "النموذج:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "الملف الشخصي: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "افتراضي",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"تم إجراء {{count}} إكمال بين {{startTime}} و {{endTime}}، بتكلفة إجمالية {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"يتم توفير الإكمال التلقائي بواسطة {{model}} عبر {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "تحليل الكود الخاص بك...",
+	"kilocode:autocomplete.progress.generating": "إنشاء التعديلات المقترحة...",
+	"kilocode:autocomplete.progress.processing": "معالجة التعديلات المقترحة...",
+	"kilocode:autocomplete.progress.showing": "عرض التعديلات المقترحة...",
+	"kilocode:autocomplete.input.title": "Kilo Code: مهمة سريعة",
+	"kilocode:autocomplete.input.placeholder": "مثال، 'أعد هيكلة هذه الدالة لتكون أكثر كفاءة'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: إنشاء التعديلات المقترحة",
+	"kilocode:autocomplete.commands.displaySuggestions": "عرض التعديلات المقترحة",
+	"kilocode:autocomplete.commands.cancelSuggestions": "إلغاء التعديلات المقترحة",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "تطبيق التعديل المقترح الحالي",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "تطبيق جميع التعديلات المقترحة",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: التعديلات المقترحة",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "يمكنني مساعدتك في المهام السريعة والتعديلات المقترحة.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"يتم حظر Kilo Code Autocomplete بسبب تعارض مع GitHub Copilot. لإصلاح هذا، يجب عليك تعطيل اقتراحات Copilot المضمنة.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "تعطيل Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "تعطيل الإكمال التلقائي",
+}

--- a/src/services/autocomplete/i18n/ca.ts
+++ b/src/services/autocomplete/i18n/ca.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// ca runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "pausat",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (desactivat)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**No tens crèdits al teu compte**\n\nEl teu compte de Kilo Code no té crèdits. Per utilitzar l'autocompletat, si us plau afegeix crèdits al teu compte.\n\n[Obrir Configuració](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**No s'ha configurat cap model d'autocompletat**\n\nPer habilitar l'autocompletat, afegeix un perfil amb un d'aquests proveïdors compatibles: {{providers}}.\n\n[Obrir Configuració](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Cost total de la sessió:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Proveïdor:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Model:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Perfil: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Per defecte",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"S'han realitzat {{count}} completacions entre {{startTime}} i {{endTime}}, amb un cost total de {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Les completacions automàtiques són proporcionades per {{model}} via {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Analitzant el teu codi...",
+	"kilocode:autocomplete.progress.generating": "Generant edicions suggerides...",
+	"kilocode:autocomplete.progress.processing": "Processant edicions suggerides...",
+	"kilocode:autocomplete.progress.showing": "Mostrant edicions suggerides...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Tasca Ràpida",
+	"kilocode:autocomplete.input.placeholder": "p. ex., 'refactoritza aquesta funció per ser més eficient'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Generar Edicions Suggerides",
+	"kilocode:autocomplete.commands.displaySuggestions": "Mostrar Edicions Suggerides",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Cancel·lar Edicions Suggerides",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Aplicar Edició Suggerida Actual",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Aplicar Totes les Edicions Suggerides",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Edicions Suggerides",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "Puc ajudar-te amb tasques ràpides i edicions suggerides.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"El Kilo Code Autocomplete està sent bloquejat per un conflicte amb GitHub Copilot. Per solucionar això, has de desactivar els suggeriments en línia de Copilot.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Desactivar Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Desactivar Autocomplete",
+}

--- a/src/services/autocomplete/i18n/cs.ts
+++ b/src/services/autocomplete/i18n/cs.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// cs runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "pozastaveno",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (zakázáno)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**Na tvém účtu nejsou žádné kredity**\n\nTvůj účet Kilo Code nemá žádné kredity. Pro použití automatického doplňování prosím přidej kredity na svůj účet.\n\n[Otevřít Nastavení](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Není nakonfigurován žádný model automatického doplňování**\n\nPro povolení automatického doplňování přidej profil s jedním z těchto podporovaných poskytovatelů: {{providers}}.\n\n[Otevřít Nastavení](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Celkové náklady relace:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Poskytovatel:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Model:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Profil: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Výchozí",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"Provedeno {{count}} dokončení mezi {{startTime}} a {{endTime}}, s celkovými náklady {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Automatické dokončování poskytuje {{model}} přes {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Analyzuji tvůj kód...",
+	"kilocode:autocomplete.progress.generating": "Generuji navrhované úpravy...",
+	"kilocode:autocomplete.progress.processing": "Zpracovávám navrhované úpravy...",
+	"kilocode:autocomplete.progress.showing": "Zobrazuji navrhované úpravy...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Rychlý úkol",
+	"kilocode:autocomplete.input.placeholder": "např. 'refaktoruj tuto funkci, aby byla efektivnější'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Generovat navrhované úpravy",
+	"kilocode:autocomplete.commands.displaySuggestions": "Zobrazit navrhované úpravy",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Zrušit navrhované úpravy",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Použít aktuální navrhovanou úpravu",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Použít všechny navrhované úpravy",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Navrhované úpravy",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "Mohu ti pomoci s rychlými úkoly a navrženými úpravami.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete je blokováno konfliktem s GitHub Copilot. Pro vyřešení tohoto problému musíš zakázat inline návrhy Copilot.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Zakázat Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Zakázat Autocomplete",
+}

--- a/src/services/autocomplete/i18n/de.ts
+++ b/src/services/autocomplete/i18n/de.ts
@@ -1,0 +1,48 @@
+// kilocode_change - new file
+// de runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "pausiert",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (deaktiviert)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**Kein Guthaben auf deinem Konto**\n\nDein Kilo Code Konto hat kein Guthaben. Um Autocomplete zu nutzen, füge bitte Guthaben zu deinem Konto hinzu.\n\n[Einstellungen öffnen](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Kein Autocomplete-Modell konfiguriert**\n\nUm Autocomplete zu aktivieren, füge ein Profil mit einem dieser unterstützten Anbieter hinzu: {{providers}}.\n\n[Einstellungen öffnen](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Sitzungsgesamtkosten:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Anbieter:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Modell:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Profil: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Standard",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"{{count}} Vervollständigungen zwischen {{startTime}} und {{endTime}} durchgeführt, für Gesamtkosten von {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Autovervollständigungen bereitgestellt von {{model}} über {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Analysiere deinen Code...",
+	"kilocode:autocomplete.progress.generating": "Generiere Bearbeitungsvorschläge...",
+	"kilocode:autocomplete.progress.processing": "Verarbeite Bearbeitungsvorschläge...",
+	"kilocode:autocomplete.progress.showing": "Zeige Bearbeitungsvorschläge...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Schnellaufgabe",
+	"kilocode:autocomplete.input.placeholder": "z.B. 'refaktoriere diese Funktion für mehr Effizienz'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Bearbeitungsvorschläge generieren",
+	"kilocode:autocomplete.commands.displaySuggestions": "Bearbeitungsvorschläge anzeigen",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Bearbeitungsvorschläge abbrechen",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Aktuellen Bearbeitungsvorschlag anwenden",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Alle Bearbeitungsvorschläge anwenden",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Bearbeitungsvorschläge",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description":
+		"Ich kann dir bei Schnellaufgaben und Bearbeitungsvorschlägen helfen.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Das Kilo Code Autocomplete wird durch einen Konflikt mit GitHub Copilot blockiert. Um dies zu beheben, musst du Copilots Inline-Vorschläge deaktivieren.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Copilot deaktivieren",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Autocomplete deaktivieren",
+}

--- a/src/services/autocomplete/i18n/en.ts
+++ b/src/services/autocomplete/i18n/en.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// English runtime translations for autocomplete (kilocode:autocomplete.* namespace)
+// Source: src/i18n/locales/en/kilocode.json → "autocomplete" section
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "snoozed",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (disabled)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**No credits in your account**\n\nYour Kilo Code account has no credits. To use autocomplete, please add credits to your account.\n\n[Open Settings](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**No autocomplete model configured**\n\nTo enable autocomplete, add a profile with one of these supported providers: {{providers}}.\n\n[Open Settings](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Session total cost:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Provider:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Model:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Profile: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Default",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"Performed {{count}} completions between {{startTime}} and {{endTime}}, for a total cost of {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo": "Autocompletions provided by {{model}} via {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Analyzing your code...",
+	"kilocode:autocomplete.progress.generating": "Generating suggested edits...",
+	"kilocode:autocomplete.progress.processing": "Processing suggested edits...",
+	"kilocode:autocomplete.progress.showing": "Displaying suggested edits...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Quick Task",
+	"kilocode:autocomplete.input.placeholder": "e.g., 'refactor this function to be more efficient'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Generate Suggested Edits",
+	"kilocode:autocomplete.commands.displaySuggestions": "Display Suggested Edits",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Cancel Suggested Edits",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Apply Current Suggested Edit",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Apply All Suggested Edits",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Suggested Edits",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "I can help you with quick tasks and suggested edits.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"The Kilo Code Autocomplete is being blocked by a conflict with GitHub Copilot. To fix this, you must disable Copilot's inline suggestions.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Disable Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Disable Autocomplete",
+}

--- a/src/services/autocomplete/i18n/es.ts
+++ b/src/services/autocomplete/i18n/es.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// es runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "pausado",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (deshabilitado)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**No hay créditos en tu cuenta**\n\nTu cuenta de Kilo Code no tiene créditos. Para usar el autocompletado, por favor añade créditos a tu cuenta.\n\n[Abrir Configuración](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**No hay modelo de autocompletado configurado**\n\nPara habilitar el autocompletado, añade un perfil con uno de estos proveedores compatibles: {{providers}}.\n\n[Abrir Configuración](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Costo total de la sesión:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Proveedor:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Modelo:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Perfil: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Predeterminado",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"Se realizaron {{count}} completaciones entre {{startTime}} y {{endTime}}, por un costo total de {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Autocompletaciones proporcionadas por {{model}} a través de {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Analizando tu código...",
+	"kilocode:autocomplete.progress.generating": "Generando ediciones sugeridas...",
+	"kilocode:autocomplete.progress.processing": "Procesando ediciones sugeridas...",
+	"kilocode:autocomplete.progress.showing": "Mostrando ediciones sugeridas...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Tarea Rápida",
+	"kilocode:autocomplete.input.placeholder": "ej., 'refactoriza esta función para que sea más eficiente'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Generar Ediciones Sugeridas",
+	"kilocode:autocomplete.commands.displaySuggestions": "Mostrar Ediciones Sugeridas",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Cancelar Ediciones Sugeridas",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Aplicar Edición Sugerida Actual",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Aplicar Todas las Ediciones Sugeridas",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Ediciones Sugeridas",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "Puedo ayudarte con tareas rápidas y ediciones sugeridas.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"El Kilo Code Autocomplete está siendo bloqueado por un conflicto con GitHub Copilot. Para solucionarlo, debes desactivar las sugerencias en línea de Copilot.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Desactivar Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Desactivar Autocomplete",
+}

--- a/src/services/autocomplete/i18n/fr.ts
+++ b/src/services/autocomplete/i18n/fr.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// fr runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "en pause",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (désactivé)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**Pas de crédits sur ton compte**\n\nTon compte Kilo Code n'a pas de crédits. Pour utiliser l'autocomplétion, ajoute des crédits à ton compte.\n\n[Ouvrir les Paramètres](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Aucun modèle d'autocomplétion configuré**\n\nPour activer l'autocomplétion, ajoute un profil avec l'un de ces fournisseurs pris en charge : {{providers}}.\n\n[Ouvrir les Paramètres](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Coût total de la session :",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Fournisseur:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Modèle :",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Profil : ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Par défaut",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"{{count}} complétions effectuées entre {{startTime}} et {{endTime}}, pour un coût total de {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo": "Auto-complétions fournies par {{model}} via {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Analyse de ton code...",
+	"kilocode:autocomplete.progress.generating": "Génération des modifications suggérées...",
+	"kilocode:autocomplete.progress.processing": "Traitement des modifications suggérées...",
+	"kilocode:autocomplete.progress.showing": "Affichage des modifications suggérées...",
+	"kilocode:autocomplete.input.title": "Kilo Code : Tâche Rapide",
+	"kilocode:autocomplete.input.placeholder": "ex., 'refactorise cette fonction pour plus d'efficacité'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code : Générer des Modifications Suggérées",
+	"kilocode:autocomplete.commands.displaySuggestions": "Afficher les Modifications Suggérées",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Annuler les Modifications Suggérées",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Appliquer la Modification Suggérée Actuelle",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Appliquer Toutes les Modifications Suggérées",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code : Modifications Suggérées",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description":
+		"Je peux t'aider avec des tâches rapides et des modifications suggérées.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Le Kilo Code Autocomplete est bloqué par un conflit avec GitHub Copilot. Pour résoudre cela, tu dois désactiver les suggestions en ligne de Copilot.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Désactiver Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Désactiver Autocomplete",
+}

--- a/src/services/autocomplete/i18n/hi.ts
+++ b/src/services/autocomplete/i18n/hi.ts
@@ -1,0 +1,48 @@
+// kilocode_change - new file
+// hi runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "रोका गया",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (अक्षम)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**आपके खाते में कोई क्रेडिट नहीं है**\n\nआपके Kilo Code खाते में कोई क्रेडिट नहीं है। ऑटोकम्प्लीट का उपयोग करने के लिए, कृपया अपने खाते में क्रेडिट जोड़ें।\n\n[सेटिंग्स खोलें](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**कोई ऑटोकम्प्लीट मॉडल कॉन्फ़िगर नहीं किया गया**\n\nऑटोकम्प्लीट सक्षम करने के लिए, इन समर्थित प्रदाताओं में से एक के साथ एक प्रोफ़ाइल जोड़ें: {{providers}}।\n\n[सेटिंग्स खोलें](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "सत्र की कुल लागत:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "प्रदाता:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "मॉडल:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "प्रोफ़ाइल: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "डिफ़ॉल्ट",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"{{startTime}} और {{endTime}} के बीच {{count}} पूर्णताएं की गईं, कुल लागत {{cost}}।",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"स्वत: पूर्णता {{provider}} के माध्यम से {{model}} द्वारा प्रदान की जाती है।",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "आपके कोड का विश्लेषण कर रहे हैं...",
+	"kilocode:autocomplete.progress.generating": "सुझाए गए संपादन बना रहे हैं...",
+	"kilocode:autocomplete.progress.processing": "सुझाए गए संपादन प्रोसेस कर रहे हैं...",
+	"kilocode:autocomplete.progress.showing": "सुझाए गए संपादन दिखा रहे हैं...",
+	"kilocode:autocomplete.input.title": "Kilo Code: त्वरित कार्य",
+	"kilocode:autocomplete.input.placeholder": "जैसे, 'इस फ़ंक्शन को अधिक कुशल बनाने के लिए रिफैक्टर करें'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: सुझाए गए संपादन जेनरेट करें",
+	"kilocode:autocomplete.commands.displaySuggestions": "सुझाए गए संपादन दिखाएं",
+	"kilocode:autocomplete.commands.cancelSuggestions": "सुझाए गए संपादन रद्द करें",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "वर्तमान सुझाए गए संपादन लागू करें",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "सभी सुझाए गए संपादन लागू करें",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: सुझाए गए संपादन",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description":
+		"मैं त्वरित कार्यों और सुझाए गए संपादनों में आपकी सहायता कर सकता हूं।",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete को GitHub Copilot के साथ संघर्ष के कारण ब्लॉक किया जा रहा है। इसे ठीक करने के लिए, आपको Copilot के इनलाइन सुझावों को अक्षम करना होगा।",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Copilot अक्षम करें",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Autocomplete अक्षम करें",
+}

--- a/src/services/autocomplete/i18n/id.ts
+++ b/src/services/autocomplete/i18n/id.ts
@@ -1,0 +1,48 @@
+// kilocode_change - new file
+// id runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "dijeda",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (dinonaktifkan)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**Tidak ada kredit di akun kamu**\n\nAkun Kilo Code kamu tidak memiliki kredit. Untuk menggunakan autocomplete, silakan tambahkan kredit ke akun kamu.\n\n[Buka Pengaturan](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Tidak ada model autocomplete yang dikonfigurasi**\n\nUntuk mengaktifkan autocomplete, tambahkan profil dengan salah satu penyedia yang didukung ini: {{providers}}.\n\n[Buka Pengaturan](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Total biaya sesi:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Penyedia:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Model:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Profil: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Default",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"Melakukan {{count}} penyelesaian antara {{startTime}} dan {{endTime}}, dengan total biaya {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Pelengkapan otomatis disediakan oleh {{model}} melalui {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Menganalisis kode Anda...",
+	"kilocode:autocomplete.progress.generating": "Menghasilkan suntingan yang disarankan...",
+	"kilocode:autocomplete.progress.processing": "Memproses suntingan yang disarankan...",
+	"kilocode:autocomplete.progress.showing": "Menampilkan suntingan yang disarankan...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Tugas Cepat",
+	"kilocode:autocomplete.input.placeholder": "mis., 'refaktor fungsi ini agar lebih efisien'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Hasilkan Suntingan yang Disarankan",
+	"kilocode:autocomplete.commands.displaySuggestions": "Tampilkan Suntingan yang Disarankan",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Batalkan Suntingan yang Disarankan",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Terapkan Suntingan yang Disarankan Saat Ini",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Terapkan Semua Suntingan yang Disarankan",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Suntingan yang Disarankan",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description":
+		"Saya dapat membantu Anda dengan tugas cepat dan suntingan yang disarankan.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete diblokir oleh konflik dengan GitHub Copilot. Untuk memperbaiki ini, Anda harus menonaktifkan saran inline Copilot.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Nonaktifkan Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Nonaktifkan Autocomplete",
+}

--- a/src/services/autocomplete/i18n/it.ts
+++ b/src/services/autocomplete/i18n/it.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// it runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "in pausa",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (disabilitato)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**Nessun credito nel tuo account**\n\nIl tuo account Kilo Code non ha crediti. Per usare l'autocompletamento, aggiungi crediti al tuo account.\n\n[Apri Impostazioni](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Nessun modello di autocompletamento configurato**\n\nPer abilitare l'autocompletamento, aggiungi un profilo con uno di questi provider supportati: {{providers}}.\n\n[Apri Impostazioni](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Costo totale della sessione:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Provider:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Modello:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Profilo: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Predefinito",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"Eseguiti {{count}} completamenti tra {{startTime}} e {{endTime}}, per un costo totale di {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Autocompletamenti forniti da {{model}} tramite {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Analizzando il tuo codice...",
+	"kilocode:autocomplete.progress.generating": "Generando modifiche suggerite...",
+	"kilocode:autocomplete.progress.processing": "Elaborando modifiche suggerite...",
+	"kilocode:autocomplete.progress.showing": "Mostrando modifiche suggerite...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Attività Rapida",
+	"kilocode:autocomplete.input.placeholder": "es., 'refactorizza questa funzione per renderla più efficiente'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Genera Modifiche Suggerite",
+	"kilocode:autocomplete.commands.displaySuggestions": "Mostra Modifiche Suggerite",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Annulla Modifiche Suggerite",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Applica Modifica Suggerita Corrente",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Applica Tutte le Modifiche Suggerite",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Modifiche Suggerite",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "Posso aiutarti con attività rapide e modifiche suggerite.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Il Kilo Code Autocomplete è bloccato da un conflitto con GitHub Copilot. Per risolvere questo problema, devi disabilitare i suggerimenti in linea di Copilot.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Disabilita Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Disabilita Autocomplete",
+}

--- a/src/services/autocomplete/i18n/ja.ts
+++ b/src/services/autocomplete/i18n/ja.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// ja runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "一時停止中",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete（無効）",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**アカウントにクレジットがありません**\n\nKilo Code アカウントにクレジットがありません。オートコンプリートを使用するには、アカウントにクレジットを追加してください。\n\n[設定を開く](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**オートコンプリートモデルが設定されていません**\n\nオートコンプリートを有効にするには、これらのサポートされているプロバイダーのいずれかでプロファイルを追加してください: {{providers}}。\n\n[設定を開く](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "セッション合計コスト:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "プロバイダー:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "モデル:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "プロファイル: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "デフォルト",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"{{startTime}}から{{endTime}}の間に{{count}}回の補完を実行し、合計コストは{{cost}}です。",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"オートコンプリートは{{provider}}経由で{{model}}によって提供されています。",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "コードを分析中...",
+	"kilocode:autocomplete.progress.generating": "編集提案を生成中...",
+	"kilocode:autocomplete.progress.processing": "編集提案を処理中...",
+	"kilocode:autocomplete.progress.showing": "編集提案を表示中...",
+	"kilocode:autocomplete.input.title": "Kilo Code: クイックタスク",
+	"kilocode:autocomplete.input.placeholder": "例：「この関数をより効率的にリファクタリングして」",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: 編集提案を生成",
+	"kilocode:autocomplete.commands.displaySuggestions": "編集提案を表示",
+	"kilocode:autocomplete.commands.cancelSuggestions": "編集提案をキャンセル",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "現在の編集提案を適用",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "すべての編集提案を適用",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: 編集提案",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "クイックタスクと編集提案でお手伝いできます。",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code AutocompleteがGitHub Copilotとの競合によってブロックされています。これを修正するには、Copilotのインライン提案を無効にする必要があります。",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Copilotを無効にする",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Autocompleteを無効にする",
+}

--- a/src/services/autocomplete/i18n/ko.ts
+++ b/src/services/autocomplete/i18n/ko.ts
@@ -1,0 +1,46 @@
+// kilocode_change - new file
+// ko runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "일시 중지됨",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (비활성화됨)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**계정에 크레딧이 없습니다**\n\nKilo Code 계정에 크레딧이 없습니다. 자동완성을 사용하려면 계정에 크레딧을 추가해 주세요.\n\n[설정 열기](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**자동완성 모델이 구성되지 않았습니다**\n\n자동완성을 활성화하려면 다음 지원되는 제공업체 중 하나로 프로필을 추가하세요: {{providers}}.\n\n[설정 열기](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "세션 총 비용:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "제공업체:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "모델:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "프로필: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "기본값",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"{{startTime}}부터 {{endTime}}까지 {{count}}회 완성을 수행했으며, 총 비용은 {{cost}}입니다.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo": "자동완성은 {{provider}}를 통해 {{model}}에서 제공됩니다.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "코드 분석 중...",
+	"kilocode:autocomplete.progress.generating": "제안된 편집 생성 중...",
+	"kilocode:autocomplete.progress.processing": "제안된 편집 처리 중...",
+	"kilocode:autocomplete.progress.showing": "제안된 편집 표시 중...",
+	"kilocode:autocomplete.input.title": "Kilo Code: 빠른 작업",
+	"kilocode:autocomplete.input.placeholder": "예: '이 함수를 더 효율적으로 리팩토링해줘'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: 제안된 편집 생성",
+	"kilocode:autocomplete.commands.displaySuggestions": "제안된 편집 표시",
+	"kilocode:autocomplete.commands.cancelSuggestions": "제안된 편집 취소",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "현재 제안된 편집 적용",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "모든 제안된 편집 적용",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: 제안된 편집",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "빠른 작업과 제안된 편집으로 도움을 드릴 수 있습니다.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete가 GitHub Copilot과의 충돌로 인해 차단되고 있습니다. 이를 해결하려면 Copilot의 인라인 제안을 비활성화해야 합니다.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Copilot 비활성화",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Autocomplete 비활성화",
+}

--- a/src/services/autocomplete/i18n/nl.ts
+++ b/src/services/autocomplete/i18n/nl.ts
@@ -1,0 +1,48 @@
+// kilocode_change - new file
+// nl runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "gepauzeerd",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (uitgeschakeld)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**Geen tegoed op je account**\n\nJe Kilo Code account heeft geen tegoed. Om autocomplete te gebruiken, voeg tegoed toe aan je account.\n\n[Instellingen openen](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Geen autocomplete model geconfigureerd**\n\nOm autocomplete in te schakelen, voeg een profiel toe met een van deze ondersteunde providers: {{providers}}.\n\n[Instellingen openen](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Totale sessiekosten:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Provider:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Model:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Profiel: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Standaard",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"{{count}} voltooiingen uitgevoerd tussen {{startTime}} en {{endTime}}, voor een totale kostprijs van {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Automatische aanvullingen geleverd door {{model}} via {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Je code analyseren...",
+	"kilocode:autocomplete.progress.generating": "Voorgestelde bewerkingen genereren...",
+	"kilocode:autocomplete.progress.processing": "Voorgestelde bewerkingen verwerken...",
+	"kilocode:autocomplete.progress.showing": "Voorgestelde bewerkingen tonen...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Snelle Taak",
+	"kilocode:autocomplete.input.placeholder": "bijv., 'refactor deze functie om efficiënter te zijn'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Voorgestelde Bewerkingen Genereren",
+	"kilocode:autocomplete.commands.displaySuggestions": "Voorgestelde Bewerkingen Tonen",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Voorgestelde Bewerkingen Annuleren",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Huidige Voorgestelde Bewerking Toepassen",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Alle Voorgestelde Bewerkingen Toepassen",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Voorgestelde Bewerkingen",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description":
+		"Ik kan je helpen met snelle taken en voorgestelde bewerkingen.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"De Kilo Code Autocomplete wordt geblokkeerd door een conflict met GitHub Copilot. Om dit op te lossen, moet je Copilot's inline suggesties uitschakelen.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Copilot Uitschakelen",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Autocomplete Uitschakelen",
+}

--- a/src/services/autocomplete/i18n/package-nls-ar.ts
+++ b/src/services/autocomplete/i18n/package-nls-ar.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// ar package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "اضغط 'Enter' للتأكيد أو 'Escape' للإلغاء",
+	"autocomplete.input.placeholder": "صف ما تريد فعله...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: إنشاء التعديلات المقترحة",
+	"autocomplete.commands.displaySuggestions": "عرض التعديلات المقترحة",
+	"autocomplete.commands.cancelSuggestions": "إلغاء التعديلات المقترحة",
+	"autocomplete.commands.applyCurrentSuggestion": "تطبيق التعديل المقترح الحالي",
+	"autocomplete.commands.applyAllSuggestions": "تطبيق جميع التعديلات المقترحة",
+	"autocomplete.commands.goToNextSuggestion": "انتقل إلى الاقتراح التالي",
+	"autocomplete.commands.goToPreviousSuggestion": "انتقل إلى الاقتراح السابق",
+}

--- a/src/services/autocomplete/i18n/package-nls-ca.ts
+++ b/src/services/autocomplete/i18n/package-nls-ca.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// ca package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Premeu 'Enter' per confirmar o 'Escape' per cancel·lar",
+	"autocomplete.input.placeholder": "Descriviu què voleu fer...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Generar Edicions Suggerides",
+	"autocomplete.commands.displaySuggestions": "Mostrar Edicions Suggerides",
+	"autocomplete.commands.cancelSuggestions": "Cancel·lar Edicions Suggerides",
+	"autocomplete.commands.applyCurrentSuggestion": "Aplicar Edició Suggerida Actual",
+	"autocomplete.commands.applyAllSuggestions": "Aplicar Totes les Edicions Suggerides",
+	"autocomplete.commands.goToNextSuggestion": "Anar al Suggeriment Següent",
+	"autocomplete.commands.goToPreviousSuggestion": "Anar al Suggeriment Anterior",
+}

--- a/src/services/autocomplete/i18n/package-nls-cs.ts
+++ b/src/services/autocomplete/i18n/package-nls-cs.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// cs package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Stiskněte 'Enter' pro potvrzení nebo 'Escape' pro zrušení",
+	"autocomplete.input.placeholder": "Popište, co chcete udělat...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Generovat Navrhované Úpravy",
+	"autocomplete.commands.displaySuggestions": "Zobrazit Navrhované Úpravy",
+	"autocomplete.commands.cancelSuggestions": "Zrušit Navrhované Úpravy",
+	"autocomplete.commands.applyCurrentSuggestion": "Použít Aktuální Navrženou Úpravu",
+	"autocomplete.commands.applyAllSuggestions": "Použít Všechny Navrhované Úpravy",
+	"autocomplete.commands.goToNextSuggestion": "Přejít na Další Návrh",
+	"autocomplete.commands.goToPreviousSuggestion": "Přejít na Předchozí Návrh",
+}

--- a/src/services/autocomplete/i18n/package-nls-de.ts
+++ b/src/services/autocomplete/i18n/package-nls-de.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// de package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Kilo Code Geisterschreiber",
+	"autocomplete.input.placeholder": "Beschreiben Sie, was Sie programmieren möchten...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Vorgeschlagene Bearbeitungen Generieren",
+	"autocomplete.commands.displaySuggestions": "Vorgeschlagene Bearbeitungen Anzeigen",
+	"autocomplete.commands.cancelSuggestions": "Vorgeschlagene Bearbeitungen Abbrechen",
+	"autocomplete.commands.applyCurrentSuggestion": "Aktuelle Vorgeschlagene Bearbeitung Anwenden",
+	"autocomplete.commands.applyAllSuggestions": "Alle Vorgeschlagenen Bearbeitungen Anwenden",
+	"autocomplete.commands.goToNextSuggestion": "Zur Nächsten Vorgeschlagenen Bearbeitung",
+	"autocomplete.commands.goToPreviousSuggestion": "Zur Vorherigen Vorgeschlagenen Bearbeitung",
+}

--- a/src/services/autocomplete/i18n/package-nls-en.ts
+++ b/src/services/autocomplete/i18n/package-nls-en.ts
@@ -1,0 +1,15 @@
+// kilocode_change - new file
+// English package.nls translations for autocomplete (used in package.json command titles/descriptions)
+// Source: src/package.nls.json → "autocomplete.*" keys
+
+export const dict = {
+	"autocomplete.input.title": "Press 'Enter' to confirm or 'Escape' to cancel",
+	"autocomplete.input.placeholder": "Describe what you want to do...",
+	"autocomplete.commands.generateSuggestions": "Generate Suggested Edits",
+	"autocomplete.commands.displaySuggestions": "Display Suggested Edits",
+	"autocomplete.commands.cancelSuggestions": "Cancel Suggested Edits",
+	"autocomplete.commands.applyCurrentSuggestion": "Apply Current Suggested Edit",
+	"autocomplete.commands.applyAllSuggestions": "Apply All Suggested Edits",
+	"autocomplete.commands.goToNextSuggestion": "Go To Next Suggestion",
+	"autocomplete.commands.goToPreviousSuggestion": "Go To Previous Suggestion",
+}

--- a/src/services/autocomplete/i18n/package-nls-es.ts
+++ b/src/services/autocomplete/i18n/package-nls-es.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// es package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Presiona 'Enter' para confirmar o 'Escape' para cancelar",
+	"autocomplete.input.placeholder": "Describe lo que quieres hacer...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Generar Ediciones Sugeridas",
+	"autocomplete.commands.displaySuggestions": "Mostrar Ediciones Sugeridas",
+	"autocomplete.commands.cancelSuggestions": "Cancelar Ediciones Sugeridas",
+	"autocomplete.commands.applyCurrentSuggestion": "Aplicar Edición Sugerida Actual",
+	"autocomplete.commands.applyAllSuggestions": "Aplicar Todas las Ediciones Sugeridas",
+	"autocomplete.commands.goToNextSuggestion": "Ir a la Siguiente Sugerencia",
+	"autocomplete.commands.goToPreviousSuggestion": "Ir a la Sugerencia Anterior",
+}

--- a/src/services/autocomplete/i18n/package-nls-fr.ts
+++ b/src/services/autocomplete/i18n/package-nls-fr.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// fr package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Écrivain fantôme Kilo Code",
+	"autocomplete.input.placeholder": "Décrivez ce que vous voulez coder...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code : Générer des Modifications Suggérées",
+	"autocomplete.commands.displaySuggestions": "Afficher les Modifications Suggérées",
+	"autocomplete.commands.cancelSuggestions": "Annuler les Modifications Suggérées",
+	"autocomplete.commands.applyCurrentSuggestion": "Appliquer la Modification Suggérée Actuelle",
+	"autocomplete.commands.applyAllSuggestions": "Appliquer Toutes les Modifications Suggérées",
+	"autocomplete.commands.goToNextSuggestion": "Aller à la Suggestion Suivante",
+	"autocomplete.commands.goToPreviousSuggestion": "Aller à la Suggestion Précédente",
+}

--- a/src/services/autocomplete/i18n/package-nls-hi.ts
+++ b/src/services/autocomplete/i18n/package-nls-hi.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// hi package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "पुष्टि के लिए 'Enter' दबाएं या रद्द करने के लिए 'Escape' दबाएं",
+	"autocomplete.input.placeholder": "वर्णन करें कि आप क्या करना चाहते हैं...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: सुझाए गए संपादन जेनरेट करें",
+	"autocomplete.commands.displaySuggestions": "सुझाए गए संपादन दिखाएं",
+	"autocomplete.commands.cancelSuggestions": "सुझाए गए संपादन रद्द करें",
+	"autocomplete.commands.applyCurrentSuggestion": "वर्तमान सुझाया गया संपादन लागू करें",
+	"autocomplete.commands.applyAllSuggestions": "सभी सुझाए गए संपादन लागू करें",
+	"autocomplete.commands.goToNextSuggestion": "अगले सुझाव पर जाएं",
+	"autocomplete.commands.goToPreviousSuggestion": "पिछले सुझाव पर जाएं",
+}

--- a/src/services/autocomplete/i18n/package-nls-id.ts
+++ b/src/services/autocomplete/i18n/package-nls-id.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// id package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Tekan 'Enter' untuk konfirmasi atau 'Escape' untuk membatalkan",
+	"autocomplete.input.placeholder": "Jelaskan apa yang ingin Anda lakukan...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Buat Saran Pengeditan",
+	"autocomplete.commands.displaySuggestions": "Tampilkan Saran Pengeditan",
+	"autocomplete.commands.cancelSuggestions": "Batalkan Saran Pengeditan",
+	"autocomplete.commands.applyCurrentSuggestion": "Terapkan Saran Pengeditan Saat Ini",
+	"autocomplete.commands.applyAllSuggestions": "Terapkan Semua Saran Pengeditan",
+	"autocomplete.commands.goToNextSuggestion": "Pergi ke Saran Berikutnya",
+	"autocomplete.commands.goToPreviousSuggestion": "Pergi ke Saran Sebelumnya",
+}

--- a/src/services/autocomplete/i18n/package-nls-it.ts
+++ b/src/services/autocomplete/i18n/package-nls-it.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// it package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Scrittore Fantasma Kilo Code",
+	"autocomplete.input.placeholder": "Descrivi cosa vuoi programmare...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Genera Modifiche Suggerite",
+	"autocomplete.commands.displaySuggestions": "Visualizza Modifiche Suggerite",
+	"autocomplete.commands.cancelSuggestions": "Annulla Modifiche Suggerite",
+	"autocomplete.commands.applyCurrentSuggestion": "Applica Modifica Suggerita Corrente",
+	"autocomplete.commands.applyAllSuggestions": "Applica Tutte le Modifiche Suggerite",
+	"autocomplete.commands.goToNextSuggestion": "Vai alla Prossima Suggerimento",
+	"autocomplete.commands.goToPreviousSuggestion": "Vai al Suggerimento Precedente",
+}

--- a/src/services/autocomplete/i18n/package-nls-ja.ts
+++ b/src/services/autocomplete/i18n/package-nls-ja.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// ja package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Kilo Code ゴーストライター",
+	"autocomplete.input.placeholder": "コーディングしたい内容を説明してください...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: 提案された編集を生成",
+	"autocomplete.commands.displaySuggestions": "提案された編集を表示",
+	"autocomplete.commands.cancelSuggestions": "提案された編集をキャンセル",
+	"autocomplete.commands.applyCurrentSuggestion": "現在の提案された編集を適用",
+	"autocomplete.commands.applyAllSuggestions": "すべての提案された編集を適用",
+	"autocomplete.commands.goToNextSuggestion": "次の提案に移動",
+	"autocomplete.commands.goToPreviousSuggestion": "前の提案に移動",
+}

--- a/src/services/autocomplete/i18n/package-nls-ko.ts
+++ b/src/services/autocomplete/i18n/package-nls-ko.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// ko package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "'Enter'를 눌러 확인하거나 'Escape'를 눌러 취소하세요",
+	"autocomplete.input.placeholder": "무엇을 하고 싶은지 설명해주세요...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: 편집 제안 생성",
+	"autocomplete.commands.displaySuggestions": "편집 제안 표시",
+	"autocomplete.commands.cancelSuggestions": "편집 제안 취소",
+	"autocomplete.commands.applyCurrentSuggestion": "현재 편집 제안 적용",
+	"autocomplete.commands.applyAllSuggestions": "모든 편집 제안 적용",
+	"autocomplete.commands.goToNextSuggestion": "다음 제안으로 이동",
+	"autocomplete.commands.goToPreviousSuggestion": "이전 제안으로 이동",
+}

--- a/src/services/autocomplete/i18n/package-nls-nl.ts
+++ b/src/services/autocomplete/i18n/package-nls-nl.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// nl package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Druk op 'Enter' om te bevestigen of 'Escape' om te annuleren",
+	"autocomplete.input.placeholder": "Beschrijf wat je wilt doen...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Bewerkingssuggesties Genereren",
+	"autocomplete.commands.displaySuggestions": "Bewerkingssuggesties Weergeven",
+	"autocomplete.commands.cancelSuggestions": "Bewerkingssuggesties Annuleren",
+	"autocomplete.commands.applyCurrentSuggestion": "Huidige Bewerkingssuggestie Toepassen",
+	"autocomplete.commands.applyAllSuggestions": "Alle Bewerkingssuggesties Toepassen",
+	"autocomplete.commands.goToNextSuggestion": "Ga Naar Volgende Suggestie",
+	"autocomplete.commands.goToPreviousSuggestion": "Ga Naar Vorige Suggestie",
+}

--- a/src/services/autocomplete/i18n/package-nls-pl.ts
+++ b/src/services/autocomplete/i18n/package-nls-pl.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// pl package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Naciśnij 'Enter' aby potwierdzić lub 'Escape' aby anulować",
+	"autocomplete.input.placeholder": "Opisz co chcesz zrobić...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Generuj Sugestie Edycji",
+	"autocomplete.commands.displaySuggestions": "Wyświetl Sugestie Edycji",
+	"autocomplete.commands.cancelSuggestions": "Anuluj Sugestie Edycji",
+	"autocomplete.commands.applyCurrentSuggestion": "Zastosuj Bieżącą Sugestię Edycji",
+	"autocomplete.commands.applyAllSuggestions": "Zastosuj Wszystkie Sugestie Edycji",
+	"autocomplete.commands.goToNextSuggestion": "Przejdź do Następnej Sugestii",
+	"autocomplete.commands.goToPreviousSuggestion": "Przejdź do Poprzedniej Sugestii",
+}

--- a/src/services/autocomplete/i18n/package-nls-pt-BR.ts
+++ b/src/services/autocomplete/i18n/package-nls-pt-BR.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// pt-BR package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Pressione 'Enter' para confirmar ou 'Escape' para cancelar",
+	"autocomplete.input.placeholder": "Descreva o que você quer fazer...",
+	"autocomplete.commands.generateSuggestions": "Gerar Sugestões de Edição",
+	"autocomplete.commands.displaySuggestions": "Exibir Sugestões de Edição",
+	"autocomplete.commands.cancelSuggestions": "Cancelar Sugestões de Edição",
+	"autocomplete.commands.applyCurrentSuggestion": "Aplicar a Sugestão de Edição Atual",
+	"autocomplete.commands.applyAllSuggestions": "Aplicar Todas as Sugestões de Edição",
+	"autocomplete.commands.goToNextSuggestion": "Ir para a Próxima Sugestão",
+	"autocomplete.commands.goToPreviousSuggestion": "Voltar para a Sugestão Anterior",
+}

--- a/src/services/autocomplete/i18n/package-nls-ru.ts
+++ b/src/services/autocomplete/i18n/package-nls-ru.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// ru package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Нажмите 'Enter' для подтверждения или 'Escape' для отмены",
+	"autocomplete.input.placeholder": "Опишите, что вы хотите сделать...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Генерировать Предлагаемые Правки",
+	"autocomplete.commands.displaySuggestions": "Показать Предлагаемые Правки",
+	"autocomplete.commands.cancelSuggestions": "Отменить Предлагаемые Правки",
+	"autocomplete.commands.applyCurrentSuggestion": "Применить Текущую Предлагаемую Правку",
+	"autocomplete.commands.applyAllSuggestions": "Применить Все Предлагаемые Правки",
+	"autocomplete.commands.goToNextSuggestion": "Перейти к Следующему Предложению",
+	"autocomplete.commands.goToPreviousSuggestion": "Перейти к Предыдущему Предложению",
+}

--- a/src/services/autocomplete/i18n/package-nls-sk.ts
+++ b/src/services/autocomplete/i18n/package-nls-sk.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// sk package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Stlačte 'Enter' pre potvrdenie alebo 'Escape' pre zrušenie",
+	"autocomplete.input.placeholder": "Popíšte, čo chcete urobiť...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Generovať Navrhované Úpravy",
+	"autocomplete.commands.displaySuggestions": "Zobraziť Navrhované Úpravy",
+	"autocomplete.commands.cancelSuggestions": "Zrušiť Navrhované Úpravy",
+	"autocomplete.commands.applyCurrentSuggestion": "Použiť Aktuálnu Navrhnutú Úpravu",
+	"autocomplete.commands.applyAllSuggestions": "Použiť Všetky Navrhované Úpravy",
+	"autocomplete.commands.goToNextSuggestion": "Prejsť na Ďalší Návrh",
+	"autocomplete.commands.goToPreviousSuggestion": "Prejsť na Predchádzajúci Návrh",
+}

--- a/src/services/autocomplete/i18n/package-nls-th.ts
+++ b/src/services/autocomplete/i18n/package-nls-th.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// th package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "กด 'Enter' เพื่อยืนยันหรือ 'Escape' เพื่อยกเลิก",
+	"autocomplete.input.placeholder": "อธิบายสิ่งที่คุณต้องการทำ...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: สร้างข้อเสนอแนะการแก้ไข",
+	"autocomplete.commands.displaySuggestions": "แสดงข้อเสนอแนะการแก้ไข",
+	"autocomplete.commands.cancelSuggestions": "ยกเลิกข้อเสนอแนะการแก้ไข",
+	"autocomplete.commands.applyCurrentSuggestion": "ใช้ข้อเสนอแนะการแก้ไขปัจจุบัน",
+	"autocomplete.commands.applyAllSuggestions": "ใช้ข้อเสนอแนะการแก้ไขทั้งหมด",
+	"autocomplete.commands.goToNextSuggestion": "ไปยังข้อเสนอแนะถัดไป",
+	"autocomplete.commands.goToPreviousSuggestion": "ไปยังข้อเสนอแนะก่อนหน้า",
+}

--- a/src/services/autocomplete/i18n/package-nls-tr.ts
+++ b/src/services/autocomplete/i18n/package-nls-tr.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// tr package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Onaylamak için 'Enter'a, iptal etmek için 'Escape'e basın",
+	"autocomplete.input.placeholder": "Ne yapmak istediğinizi açıklayın...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Düzenleme Önerileri Oluştur",
+	"autocomplete.commands.displaySuggestions": "Düzenleme Önerilerini Göster",
+	"autocomplete.commands.cancelSuggestions": "Düzenleme Önerilerini İptal Et",
+	"autocomplete.commands.applyCurrentSuggestion": "Mevcut Düzenleme Önerisini Uygula",
+	"autocomplete.commands.applyAllSuggestions": "Tüm Düzenleme Önerilerini Uygula",
+	"autocomplete.commands.goToNextSuggestion": "Sonraki Öneriye Git",
+	"autocomplete.commands.goToPreviousSuggestion": "Önceki Öneriye Git",
+}

--- a/src/services/autocomplete/i18n/package-nls-uk.ts
+++ b/src/services/autocomplete/i18n/package-nls-uk.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// uk package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Натисніть 'Enter' для підтвердження або 'Escape' для скасування",
+	"autocomplete.input.placeholder": "Опишіть, що ви хочете зробити...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Генерувати Пропозиції Редагування",
+	"autocomplete.commands.displaySuggestions": "Показати Пропозиції Редагування",
+	"autocomplete.commands.cancelSuggestions": "Скасувати Пропозиції Редагування",
+	"autocomplete.commands.applyCurrentSuggestion": "Застосувати Поточну Пропозицію Редагування",
+	"autocomplete.commands.applyAllSuggestions": "Застосувати Всі Пропозиції Редагування",
+	"autocomplete.commands.goToNextSuggestion": "Перейти до Наступної Пропозиції",
+	"autocomplete.commands.goToPreviousSuggestion": "Перейти до Попередньої Пропозиції",
+}

--- a/src/services/autocomplete/i18n/package-nls-vi.ts
+++ b/src/services/autocomplete/i18n/package-nls-vi.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// vi package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Nhấn 'Enter' để xác nhận hoặc 'Escape' để hủy",
+	"autocomplete.input.placeholder": "Mô tả những gì bạn muốn làm...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: Tạo Gợi Ý Chỉnh Sửa",
+	"autocomplete.commands.displaySuggestions": "Hiển Thị Gợi Ý Chỉnh Sửa",
+	"autocomplete.commands.cancelSuggestions": "Hủy Gợi Ý Chỉnh Sửa",
+	"autocomplete.commands.applyCurrentSuggestion": "Áp Dụng Gợi Ý Chỉnh Sửa Hiện Tại",
+	"autocomplete.commands.applyAllSuggestions": "Áp Dụng Tất Cả Gợi Ý Chỉnh Sửa",
+	"autocomplete.commands.goToNextSuggestion": "Đi Đến Gợi Ý Tiếp Theo",
+	"autocomplete.commands.goToPreviousSuggestion": "Đi Đến Gợi Ý Trước Đó",
+}

--- a/src/services/autocomplete/i18n/package-nls-zh-CN.ts
+++ b/src/services/autocomplete/i18n/package-nls-zh-CN.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// zh-CN package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "Kilo Code 幽灵写手",
+	"autocomplete.input.placeholder": "描述您想要编程的内容...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code：生成建议编辑",
+	"autocomplete.commands.displaySuggestions": "显示建议编辑",
+	"autocomplete.commands.cancelSuggestions": "取消建议编辑",
+	"autocomplete.commands.applyCurrentSuggestion": "应用当前建议编辑",
+	"autocomplete.commands.applyAllSuggestions": "应用所有建议编辑",
+	"autocomplete.commands.goToNextSuggestion": "转到下一个建议",
+	"autocomplete.commands.goToPreviousSuggestion": "转到上一个建议",
+}

--- a/src/services/autocomplete/i18n/package-nls-zh-TW.ts
+++ b/src/services/autocomplete/i18n/package-nls-zh-TW.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// zh-TW package.nls translations for autocomplete
+
+export const dict = {
+	"autocomplete.input.title": "按 'Enter' 確認或按 'Escape' 取消",
+	"autocomplete.input.placeholder": "描述您想要做什麼...",
+	"autocomplete.commands.generateSuggestions": "Kilo Code: 產生編輯建議",
+	"autocomplete.commands.displaySuggestions": "顯示編輯建議",
+	"autocomplete.commands.cancelSuggestions": "取消編輯建議",
+	"autocomplete.commands.applyCurrentSuggestion": "套用目前編輯建議",
+	"autocomplete.commands.applyAllSuggestions": "套用所有編輯建議",
+	"autocomplete.commands.goToNextSuggestion": "前往下一個建議",
+	"autocomplete.commands.goToPreviousSuggestion": "前往上一個建議",
+}

--- a/src/services/autocomplete/i18n/pl.ts
+++ b/src/services/autocomplete/i18n/pl.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// pl runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "wstrzymane",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (wyłączone)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**Brak środków na koncie**\n\nTwoje konto Kilo Code nie ma środków. Aby korzystać z autouzupełniania, dodaj środki do swojego konta.\n\n[Otwórz Ustawienia](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Nie skonfigurowano modelu autouzupełniania**\n\nAby włączyć autouzupełnianie, dodaj profil z jednym z tych obsługiwanych dostawców: {{providers}}.\n\n[Otwórz Ustawienia](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Całkowity koszt sesji:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Dostawca:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Model:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Profil: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Domyślny",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"Wykonano {{count}} uzupełnień między {{startTime}} a {{endTime}}, za łączny koszt {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Autouzupełnianie zapewniane przez {{model}} za pośrednictwem {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Analizuję twój kod...",
+	"kilocode:autocomplete.progress.generating": "Generuję sugerowane edycje...",
+	"kilocode:autocomplete.progress.processing": "Przetwarzam sugerowane edycje...",
+	"kilocode:autocomplete.progress.showing": "Wyświetlam sugerowane edycje...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Szybkie Zadanie",
+	"kilocode:autocomplete.input.placeholder": "np. 'zrefaktoruj tę funkcję, aby była bardziej wydajna'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Generuj Sugerowane Edycje",
+	"kilocode:autocomplete.commands.displaySuggestions": "Wyświetl Sugerowane Edycje",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Anuluj Sugerowane Edycje",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Zastosuj Bieżącą Sugerowaną Edycję",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Zastosuj Wszystkie Sugerowane Edycje",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Sugerowane Edycje",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "Mogę pomóc ci w szybkich zadaniach i sugerowanych edycjach.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete jest blokowane przez konflikt z GitHub Copilot. Aby to naprawić, musisz wyłączyć sugestie inline Copilot.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Wyłącz Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Wyłącz Autocomplete",
+}

--- a/src/services/autocomplete/i18n/pt-BR.ts
+++ b/src/services/autocomplete/i18n/pt-BR.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// pt-BR runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "pausado",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (desabilitado)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**Sem créditos na sua conta**\n\nSua conta Kilo Code não tem créditos. Para usar o autocompletar, adicione créditos à sua conta.\n\n[Abrir Configurações](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Nenhum modelo de autocompletar configurado**\n\nPara habilitar o autocompletar, adicione um perfil com um destes provedores suportados: {{providers}}.\n\n[Abrir Configurações](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Custo total da sessão:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Provedor:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Modelo:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Perfil: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Padrão",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"Realizadas {{count}} conclusões entre {{startTime}} e {{endTime}}, por um custo total de {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Autocompletações fornecidas por {{model}} via {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Analisando seu código...",
+	"kilocode:autocomplete.progress.generating": "Gerando edições sugeridas...",
+	"kilocode:autocomplete.progress.processing": "Processando edições sugeridas...",
+	"kilocode:autocomplete.progress.showing": "Exibindo edições sugeridas...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Tarefa Rápida",
+	"kilocode:autocomplete.input.placeholder": "ex., 'refatore esta função para ser mais eficiente'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Gerar Edições Sugeridas",
+	"kilocode:autocomplete.commands.displaySuggestions": "Exibir Edições Sugeridas",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Cancelar Edições Sugeridas",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Aplicar Edição Sugerida Atual",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Aplicar Todas as Edições Sugeridas",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Edições Sugeridas",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "Posso te ajudar com tarefas rápidas e edições sugeridas.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"O Kilo Code Autocomplete está sendo bloqueado por um conflito com o GitHub Copilot. Para corrigir isso, você deve desabilitar as sugestões inline do Copilot.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Desabilitar Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Desabilitar Autocomplete",
+}

--- a/src/services/autocomplete/i18n/ru.ts
+++ b/src/services/autocomplete/i18n/ru.ts
@@ -1,0 +1,48 @@
+// kilocode_change - new file
+// ru runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "приостановлено",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (отключено)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**На вашем счёте нет кредитов**\n\nНа вашем счёте Kilo Code нет кредитов. Чтобы использовать автодополнение, пожалуйста, пополните счёт.\n\n[Открыть Настройки](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Модель автодополнения не настроена**\n\nЧтобы включить автодополнение, добавьте профиль с одним из поддерживаемых провайдеров: {{providers}}.\n\n[Открыть Настройки](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Общая стоимость сессии:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Провайдер:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Модель:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Профиль: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "По умолчанию",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"Выполнено {{count}} автодополнений между {{startTime}} и {{endTime}}, общая стоимость {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Автодополнение предоставляется {{model}} через {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Анализирую твой код...",
+	"kilocode:autocomplete.progress.generating": "Генерирую предлагаемые правки...",
+	"kilocode:autocomplete.progress.processing": "Обрабатываю предлагаемые правки...",
+	"kilocode:autocomplete.progress.showing": "Показываю предлагаемые правки...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Быстрая Задача",
+	"kilocode:autocomplete.input.placeholder": "напр., 'рефактори эту функцию для большей эффективности'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Генерировать Предлагаемые Правки",
+	"kilocode:autocomplete.commands.displaySuggestions": "Показать Предлагаемые Правки",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Отменить Предлагаемые Правки",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Применить Текущую Предлагаемую Правку",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Применить Все Предлагаемые Правки",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Предлагаемые Правки",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description":
+		"Я могу помочь тебе с быстрыми задачами и предлагаемыми правками.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete блокируется конфликтом с GitHub Copilot. Чтобы исправить это, ты должен отключить встроенные предложения Copilot.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Отключить Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Отключить Autocomplete",
+}

--- a/src/services/autocomplete/i18n/sk.ts
+++ b/src/services/autocomplete/i18n/sk.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// sk runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "pozastavené",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (zakázané)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**Na tvojom účte nie sú žiadne kredity**\n\nTvoj účet Kilo Code nemá žiadne kredity. Pre použitie automatického doplňovania prosím pridaj kredity na svoj účet.\n\n[Otvoriť Nastavenia](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Nie je nakonfigurovaný žiadny model automatického doplňovania**\n\nPre povolenie automatického doplňovania pridaj profil s jedným z týchto podporovaných poskytovateľov: {{providers}}.\n\n[Otvoriť Nastavenia](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Celkové náklady relácie:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Poskytovateľ:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Model:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Profil: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Predvolený",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"Vykonaných {{count}} dokončení medzi {{startTime}} a {{endTime}}, s celkovými nákladmi {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Automatické dokončovanie poskytuje {{model}} cez {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Analyzujem tvoj kód...",
+	"kilocode:autocomplete.progress.generating": "Generujem navrhované úpravy...",
+	"kilocode:autocomplete.progress.processing": "Spracovávam navrhované úpravy...",
+	"kilocode:autocomplete.progress.showing": "Zobrazujem navrhované úpravy...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Rýchla úloha",
+	"kilocode:autocomplete.input.placeholder": "napr. 'refaktoruj túto funkciu, aby bola efektívnejšia'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Generovať navrhované úpravy",
+	"kilocode:autocomplete.commands.displaySuggestions": "Zobraziť navrhované úpravy",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Zrušiť navrhované úpravy",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Použiť aktuálnu navrhnutú úpravu",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Použiť všetky navrhované úpravy",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Navrhované úpravy",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "Môžem ti pomôcť s rýchlymi úlohami a navrhnutými úpravami.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete je blokované konfliktom s GitHub Copilot. Pre vyriešenie tohto problému musíš zakázať inline návrhy Copilot.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Zakázať Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Zakázať Autocomplete",
+}

--- a/src/services/autocomplete/i18n/th.ts
+++ b/src/services/autocomplete/i18n/th.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// th runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "หยุดชั่วคราว",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (ปิดใช้งาน)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**ไม่มีเครดิตในบัญชีของคุณ**\n\nบัญชี Kilo Code ของคุณไม่มีเครดิต หากต้องการใช้การเติมข้อความอัตโนมัติ กรุณาเพิ่มเครดิตในบัญชีของคุณ\n\n[เปิดการตั้งค่า](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**ไม่ได้กำหนดค่าโมเดลการเติมข้อความอัตโนมัติ**\n\nหากต้องการเปิดใช้งานการเติมข้อความอัตโนมัติ ให้เพิ่มโปรไฟล์กับผู้ให้บริการที่รองรับเหล่านี้: {{providers}}\n\n[เปิดการตั้งค่า](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "ค่าใช้จ่ายรวมของเซสชัน:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "ผู้ให้บริการ:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "โมเดล:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "โปรไฟล์: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "ค่าเริ่มต้น",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"ดำเนินการเติมเต็ม {{count}} ครั้งระหว่าง {{startTime}} ถึง {{endTime}} ด้วยค่าใช้จ่ายรวม {{cost}}",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"การเติมเต็มอัตโนมัติให้บริการโดย {{model}} ผ่าน {{provider}}",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "กำลังวิเคราะห์โค้ดของคุณ...",
+	"kilocode:autocomplete.progress.generating": "กำลังสร้างการแก้ไขที่แนะนำ...",
+	"kilocode:autocomplete.progress.processing": "กำลังประมวลผลการแก้ไขที่แนะนำ...",
+	"kilocode:autocomplete.progress.showing": "กำลังแสดงการแก้ไขที่แนะนำ...",
+	"kilocode:autocomplete.input.title": "Kilo Code: งานด่วน",
+	"kilocode:autocomplete.input.placeholder": "เช่น 'ปรับโครงสร้างฟังก์ชันนี้ให้มีประสิทธิภาพมากขึ้น'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: สร้างการแก้ไขที่แนะนำ",
+	"kilocode:autocomplete.commands.displaySuggestions": "แสดงการแก้ไขที่แนะนำ",
+	"kilocode:autocomplete.commands.cancelSuggestions": "ยกเลิกการแก้ไขที่แนะนำ",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "ใช้การแก้ไขที่แนะนำปัจจุบัน",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "ใช้การแก้ไขที่แนะนำทั้งหมด",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: การแก้ไขที่แนะนำ",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "ฉันสามารถช่วยคุณในงานด่วนและการแก้ไขที่แนะนำได้",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete ถูกบล็อกโดยความขัดแย้งกับ GitHub Copilot เพื่อแก้ไขปัญหานี้ คุณต้องปิดใช้งานคำแนะนำแบบอินไลน์ของ Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "ปิดใช้งาน Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "ปิดใช้งาน Autocomplete",
+}

--- a/src/services/autocomplete/i18n/tr.ts
+++ b/src/services/autocomplete/i18n/tr.ts
@@ -1,0 +1,48 @@
+// kilocode_change - new file
+// tr runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "duraklatıldı",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (devre dışı)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**Hesabınızda kredi yok**\n\nKilo Code hesabınızda kredi bulunmuyor. Otomatik tamamlamayı kullanmak için lütfen hesabınıza kredi ekleyin.\n\n[Ayarları Aç](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Otomatik tamamlama modeli yapılandırılmadı**\n\nOtomatik tamamlamayı etkinleştirmek için desteklenen sağlayıcılardan biriyle bir profil ekleyin: {{providers}}.\n\n[Ayarları Aç](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Oturum toplam maliyeti:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Sağlayıcı:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Model:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Profil: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Varsayılan",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"{{startTime}} ile {{endTime}} arasında {{count}} tamamlama gerçekleştirildi, toplam maliyet {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Otomatik tamamlamalar {{provider}} üzerinden {{model}} tarafından sağlanmaktadır.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Kodun analiz ediliyor...",
+	"kilocode:autocomplete.progress.generating": "Önerilen düzenlemeler oluşturuluyor...",
+	"kilocode:autocomplete.progress.processing": "Önerilen düzenlemeler işleniyor...",
+	"kilocode:autocomplete.progress.showing": "Önerilen düzenlemeler gösteriliyor...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Hızlı Görev",
+	"kilocode:autocomplete.input.placeholder": "örn., 'bu fonksiyonu daha verimli olacak şekilde yeniden düzenle'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Önerilen Düzenlemeler Oluştur",
+	"kilocode:autocomplete.commands.displaySuggestions": "Önerilen Düzenlemeleri Göster",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Önerilen Düzenlemeleri İptal Et",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Mevcut Önerilen Düzenlemeyi Uygula",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Tüm Önerilen Düzenlemeleri Uygula",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Önerilen Düzenlemeler",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description":
+		"Hızlı görevler ve önerilen düzenlemeler konusunda sana yardımcı olabilirim.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete, GitHub Copilot ile bir çakışma nedeniyle engelleniyor. Bunu düzeltmek için Copilot'un satır içi önerilerini devre dışı bırakmalısın.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Copilot'u Devre Dışı Bırak",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Autocomplete'i Devre Dışı Bırak",
+}

--- a/src/services/autocomplete/i18n/uk.ts
+++ b/src/services/autocomplete/i18n/uk.ts
@@ -1,0 +1,47 @@
+// kilocode_change - new file
+// uk runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "призупинено",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (вимкнено)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**На вашому рахунку немає кредитів**\n\nНа вашому рахунку Kilo Code немає кредитів. Щоб використовувати автодоповнення, будь ласка, поповніть рахунок.\n\n[Відкрити Налаштування](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Модель автодоповнення не налаштована**\n\nЩоб увімкнути автодоповнення, додайте профіль з одним із підтримуваних провайдерів: {{providers}}.\n\n[Відкрити Налаштування](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Загальна вартість сесії:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Провайдер:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Модель:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Профіль: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "За замовчуванням",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"Виконано {{count}} автодоповнень між {{startTime}} та {{endTime}}, загальна вартість {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo": "Автодоповнення надається {{model}} через {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Аналізую твій код...",
+	"kilocode:autocomplete.progress.generating": "Генерую запропоновані правки...",
+	"kilocode:autocomplete.progress.processing": "Обробляю запропоновані правки...",
+	"kilocode:autocomplete.progress.showing": "Показую запропоновані правки...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Швидке Завдання",
+	"kilocode:autocomplete.input.placeholder": "напр., 'рефактори цю функцію для більшої ефективності'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Генерувати Запропоновані Правки",
+	"kilocode:autocomplete.commands.displaySuggestions": "Показати Запропоновані Правки",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Скасувати Запропоновані Правки",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Застосувати Поточну Запропоновану Правку",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Застосувати Всі Запропоновані Правки",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Запропоновані Правки",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description":
+		"Я можу допомогти тобі зі швидкими завданнями та запропонованими правками.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete блокується конфліктом з GitHub Copilot. Щоб виправити це, ти повинен вимкнути вбудовані пропозиції Copilot.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Вимкнути Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Вимкнути Autocomplete",
+}

--- a/src/services/autocomplete/i18n/vi.ts
+++ b/src/services/autocomplete/i18n/vi.ts
@@ -1,0 +1,48 @@
+// kilocode_change - new file
+// vi runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "tạm dừng",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (đã tắt)",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**Không có tín dụng trong tài khoản của bạn**\n\nTài khoản Kilo Code của bạn không có tín dụng. Để sử dụng tự động hoàn thành, vui lòng thêm tín dụng vào tài khoản của bạn.\n\n[Mở Cài đặt](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**Chưa cấu hình mô hình tự động hoàn thành**\n\nĐể bật tự động hoàn thành, hãy thêm hồ sơ với một trong các nhà cung cấp được hỗ trợ sau: {{providers}}.\n\n[Mở Cài đặt](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Tổng chi phí phiên:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "Nhà cung cấp:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "Mô hình:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "Hồ sơ: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "Mặc định",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"Đã thực hiện {{count}} lần hoàn thành từ {{startTime}} đến {{endTime}}, với tổng chi phí {{cost}}.",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo":
+		"Tự động hoàn thành được cung cấp bởi {{model}} thông qua {{provider}}.",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "Đang phân tích mã của bạn...",
+	"kilocode:autocomplete.progress.generating": "Đang tạo các chỉnh sửa được đề xuất...",
+	"kilocode:autocomplete.progress.processing": "Đang xử lý các chỉnh sửa được đề xuất...",
+	"kilocode:autocomplete.progress.showing": "Đang hiển thị các chỉnh sửa được đề xuất...",
+	"kilocode:autocomplete.input.title": "Kilo Code: Tác Vụ Nhanh",
+	"kilocode:autocomplete.input.placeholder": "ví dụ, 'tái cấu trúc hàm này để hiệu quả hơn'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Tạo Các Chỉnh Sửa Được Đề Xuất",
+	"kilocode:autocomplete.commands.displaySuggestions": "Hiển Thị Các Chỉnh Sửa Được Đề Xuất",
+	"kilocode:autocomplete.commands.cancelSuggestions": "Hủy Các Chỉnh Sửa Được Đề Xuất",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "Áp Dụng Chỉnh Sửa Được Đề Xuất Hiện Tại",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "Áp Dụng Tất Cả Các Chỉnh Sửa Được Đề Xuất",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: Các Chỉnh Sửa Được Đề Xuất",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description":
+		"Tôi có thể giúp bạn với các tác vụ nhanh và chỉnh sửa được đề xuất.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete đang bị chặn do xung đột với GitHub Copilot. Để khắc phục điều này, bạn phải tắt các gợi ý inline của Copilot.",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Tắt Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Tắt Autocomplete",
+}

--- a/src/services/autocomplete/i18n/zh-CN.ts
+++ b/src/services/autocomplete/i18n/zh-CN.ts
@@ -1,0 +1,46 @@
+// kilocode_change - new file
+// zh-CN runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "已暂停",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete（已禁用）",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**账户余额不足**\n\n你的 Kilo Code 账户没有余额。要使用自动补全功能，请为账户充值。\n\n[打开设置](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**未配置自动补全模型**\n\n要启用自动补全，请添加一个使用以下支持的提供商的配置文件：{{providers}}。\n\n[打开设置](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "会话总费用:",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "提供商:",
+	"kilocode:autocomplete.statusBar.tooltip.model": "模型:",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "配置: ",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "默认",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"在{{startTime}}至{{endTime}}期间执行了{{count}}次补全，总费用为{{cost}}。",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo": "自动补全由{{model}}通过{{provider}}提供。",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "正在分析你的代码...",
+	"kilocode:autocomplete.progress.generating": "正在生成建议编辑...",
+	"kilocode:autocomplete.progress.processing": "正在处理建议编辑...",
+	"kilocode:autocomplete.progress.showing": "正在显示建议编辑...",
+	"kilocode:autocomplete.input.title": "Kilo Code: 快速任务",
+	"kilocode:autocomplete.input.placeholder": "例如：'重构这个函数使其更高效'",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: 生成建议编辑",
+	"kilocode:autocomplete.commands.displaySuggestions": "显示建议编辑",
+	"kilocode:autocomplete.commands.cancelSuggestions": "取消建议编辑",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "应用当前建议编辑",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "应用所有建议编辑",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code: 建议编辑",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "我可以帮助你完成快速任务和建议编辑。",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete 被与 GitHub Copilot 的冲突阻止。要解决此问题，你必须禁用 Copilot 的内联建议。",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "禁用 Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "禁用 Autocomplete",
+}

--- a/src/services/autocomplete/i18n/zh-TW.ts
+++ b/src/services/autocomplete/i18n/zh-TW.ts
@@ -1,0 +1,46 @@
+// kilocode_change - new file
+// zh-TW runtime translations for autocomplete
+
+export const dict = {
+	"kilocode:autocomplete.statusBar.enabled": "$(kilo-logo) Autocomplete",
+	"kilocode:autocomplete.statusBar.snoozed": "已暫停",
+	"kilocode:autocomplete.statusBar.warning": "$(warning) Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
+	"kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete（已停用）",
+	"kilocode:autocomplete.statusBar.tooltip.noCredits":
+		"**帳戶中沒有額度**\n\nKilo Code 帳戶沒有額度。若要使用 Autocomplete，請為帳戶儲值。\n\n[開啟設定](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
+		"**未設定 Autocomplete 模型**\n\n若要啟用 Autocomplete，請新增一個使用以下支援供應商的設定檔：{{providers}}。\n\n[開啟設定](command:kilo-code.settingsButtonClicked)",
+	"kilocode:autocomplete.statusBar.tooltip.sessionTotal": "工作階段總費用：",
+	"kilocode:autocomplete.statusBar.tooltip.provider": "供應商：",
+	"kilocode:autocomplete.statusBar.tooltip.model": "模型：",
+	"kilocode:autocomplete.statusBar.tooltip.profile": "設定檔：",
+	"kilocode:autocomplete.statusBar.tooltip.defaultProfile": "預設",
+	"kilocode:autocomplete.statusBar.tooltip.completionSummary":
+		"在 {{startTime}} 至 {{endTime}} 之間完成了 {{count}} 次補齊，總費用為 {{cost}}。",
+	"kilocode:autocomplete.statusBar.tooltip.providerInfo": "Autocomplete 由 {{provider}} 的 {{model}} 提供。",
+	"kilocode:autocomplete.statusBar.cost.zero": "$0.00",
+	"kilocode:autocomplete.statusBar.cost.lessThanCent": "<$0.01",
+	"kilocode:autocomplete.toggleMessage": "Kilo Code Autocomplete {{status}}",
+	"kilocode:autocomplete.progress.title": "Kilo Code",
+	"kilocode:autocomplete.progress.analyzing": "正在分析程式碼...",
+	"kilocode:autocomplete.progress.generating": "正在產生建議編輯...",
+	"kilocode:autocomplete.progress.processing": "正在處理建議編輯...",
+	"kilocode:autocomplete.progress.showing": "正在顯示建議編輯...",
+	"kilocode:autocomplete.input.title": "Kilo Code：快速任務",
+	"kilocode:autocomplete.input.placeholder": "例如「重構此函式以提升效率」",
+	"kilocode:autocomplete.commands.generateSuggestions": "Kilo Code：產生建議編輯",
+	"kilocode:autocomplete.commands.displaySuggestions": "顯示建議編輯",
+	"kilocode:autocomplete.commands.cancelSuggestions": "取消建議編輯",
+	"kilocode:autocomplete.commands.applyCurrentSuggestion": "套用目前的建議編輯",
+	"kilocode:autocomplete.commands.applyAllSuggestions": "套用所有建議編輯",
+	"kilocode:autocomplete.commands.category": "Kilo Code",
+	"kilocode:autocomplete.codeAction.title": "Kilo Code：建議編輯",
+	"kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
+	"kilocode:autocomplete.chatParticipant.name": "Agent",
+	"kilocode:autocomplete.chatParticipant.description": "可以協助處理快速任務和建議編輯。",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.message":
+		"Kilo Code Autocomplete 因與 GitHub Copilot 衝突而被封鎖。若要修正此問題，必須停用 Copilot 的行內建議。",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "停用 Copilot",
+	"kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "停用 Autocomplete",
+}


### PR DESCRIPTION
Documentation for transplanting the autocomplete module to a standalone extension. Includes investigation reports on external imports, VSCode integration points, internal architecture, and a comprehensive transplant plan.