### PR TITLE
Fix ZenMux model metadata and native tool message handling

### DIFF
--- a/.changeset/zenmux-context-window-fix.md
+++ b/.changeset/zenmux-context-window-fix.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed ZenMux context window detection to prevent erroneous context-condensing loops.

--- a/.changeset/zenmux-native-tools-reliability.md
+++ b/.changeset/zenmux-native-tools-reliability.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed ZenMux tool-calling reliability to avoid repeated "tool not used" loops and preserve transformed request messages.

--- a/packages/types/src/providers/zenmux.ts
+++ b/packages/types/src/providers/zenmux.ts
@@ -9,6 +9,10 @@ export const zenmuxDefaultModelInfo: ModelInfo = {
 	contextWindow: 200_000,
 	supportsImages: true,
 	supportsPromptCache: true,
+	// kilocode_change start
+	supportsNativeTools: true,
+	defaultToolProtocol: "native",
+	// kilocode_change end
 	inputPrice: 15.0,
 	outputPrice: 75.0,
 	cacheWritesPrice: 18.75,

--- a/src/api/providers/__tests__/zenmux-native-tools.spec.ts
+++ b/src/api/providers/__tests__/zenmux-native-tools.spec.ts
@@ -1,0 +1,175 @@
+// kilocode_change - new file
+import OpenAI from "openai"
+
+import type { ApiHandlerCreateMessageMetadata } from "../../index"
+import type { ApiHandlerOptions } from "../../../shared/api"
+import { ZenMuxHandler } from "../zenmux"
+
+vi.mock("../fetchers/modelCache", () => ({
+	getModels: vi.fn().mockResolvedValue({}),
+}))
+
+function createMockStream() {
+	return {
+		async *[Symbol.asyncIterator]() {
+			yield {
+				choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+				usage: { prompt_tokens: 1, completion_tokens: 1, cost: 0 },
+			}
+		},
+	}
+}
+
+async function consume(generator: AsyncGenerator<unknown>) {
+	for await (const _chunk of generator) {
+		// Consume all chunks
+	}
+}
+
+describe("ZenMuxHandler native tools and message pipeline", () => {
+	const baseOptions: ApiHandlerOptions = {
+		zenmuxApiKey: "test-key",
+		zenmuxModelId: "z-ai/glm-5",
+		zenmuxBaseUrl: "https://test.zenmux.ai/api/v1",
+	}
+
+	it("merges native tool defaults when model cache entry lacks native metadata", () => {
+		const handler = new ZenMuxHandler(baseOptions)
+		;(handler as unknown as { models: Record<string, unknown> }).models = {
+			"z-ai/glm-5": {
+				maxTokens: 8192,
+				contextWindow: 128000,
+				supportsImages: false,
+				supportsPromptCache: false,
+				inputPrice: 0,
+				outputPrice: 0,
+				description: "GLM 5",
+			},
+		}
+
+		const model = handler.getModel()
+		expect(model.info.supportsNativeTools).toBe(true)
+		expect(model.info.defaultToolProtocol).toBe("native")
+	})
+
+	it("passes tools and tool choice to stream creation when task protocol is native", async () => {
+		const handler = new ZenMuxHandler(baseOptions)
+
+		vi.spyOn(handler, "fetchModel").mockResolvedValue({
+			id: "z-ai/glm-5",
+			info: {
+				maxTokens: 8192,
+				contextWindow: 128000,
+				supportsNativeTools: true,
+				supportsImages: false,
+				supportsPromptCache: false,
+				inputPrice: 0,
+				outputPrice: 0,
+				description: "GLM 5",
+			},
+		} as any)
+
+		const streamSpy = vi.spyOn(handler, "createZenMuxStream").mockResolvedValue(createMockStream() as any)
+
+		const tools: OpenAI.Chat.ChatCompletionTool[] = [
+			{
+				type: "function",
+				function: {
+					name: "attempt_completion",
+					description: "Complete the task",
+					parameters: { type: "object", properties: {} },
+				},
+			},
+		]
+		const metadata: ApiHandlerCreateMessageMetadata = {
+			taskId: "task-native",
+			toolProtocol: "native",
+			tools,
+			tool_choice: "auto",
+			parallelToolCalls: true,
+		}
+
+		await consume(handler.createMessage("system", [{ role: "user", content: "hi" }], metadata))
+
+		expect(streamSpy).toHaveBeenCalledTimes(1)
+		expect(streamSpy.mock.calls[0][6]).toEqual(tools)
+		expect(streamSpy.mock.calls[0][7]).toBe("auto")
+		expect(streamSpy.mock.calls[0][8]).toBe(true)
+	})
+
+	it("omits tools when task protocol is xml even if tools are provided", async () => {
+		const handler = new ZenMuxHandler(baseOptions)
+
+		vi.spyOn(handler, "fetchModel").mockResolvedValue({
+			id: "z-ai/glm-5",
+			info: {
+				maxTokens: 8192,
+				contextWindow: 128000,
+				supportsNativeTools: true,
+				supportsImages: false,
+				supportsPromptCache: false,
+				inputPrice: 0,
+				outputPrice: 0,
+				description: "GLM 5",
+			},
+		} as any)
+
+		const streamSpy = vi.spyOn(handler, "createZenMuxStream").mockResolvedValue(createMockStream() as any)
+
+		const tools: OpenAI.Chat.ChatCompletionTool[] = [
+			{
+				type: "function",
+				function: {
+					name: "ask_followup_question",
+					description: "Ask a follow-up question",
+					parameters: { type: "object", properties: {} },
+				},
+			},
+		]
+
+		await consume(
+			handler.createMessage("system", [{ role: "user", content: "hi" }], {
+				taskId: "task-xml",
+				toolProtocol: "xml",
+				tools,
+				tool_choice: "auto",
+				parallelToolCalls: true,
+			}),
+		)
+
+		expect(streamSpy).toHaveBeenCalledTimes(1)
+		expect(streamSpy.mock.calls[0][6]).toBeUndefined()
+		expect(streamSpy.mock.calls[0][7]).toBeUndefined()
+		expect(streamSpy.mock.calls[0][8]).toBe(false)
+	})
+
+	it("passes transformed DeepSeek R1 messages into stream creation", async () => {
+		const handler = new ZenMuxHandler({
+			...baseOptions,
+			zenmuxModelId: "deepseek/deepseek-r1",
+		})
+
+		vi.spyOn(handler, "fetchModel").mockResolvedValue({
+			id: "deepseek/deepseek-r1",
+			info: {
+				maxTokens: 8192,
+				contextWindow: 128000,
+				supportsNativeTools: true,
+				supportsImages: false,
+				supportsPromptCache: false,
+				inputPrice: 0,
+				outputPrice: 0,
+				description: "DeepSeek R1",
+			},
+		} as any)
+
+		const streamSpy = vi.spyOn(handler, "createZenMuxStream").mockResolvedValue(createMockStream() as any)
+
+		await consume(handler.createMessage("system prompt", [{ role: "user", content: "hi" }], { taskId: "task-r1" }))
+
+		expect(streamSpy).toHaveBeenCalledTimes(1)
+		const sentMessages = streamSpy.mock.calls[0][1] as OpenAI.Chat.ChatCompletionMessageParam[]
+		expect(sentMessages.some((message: any) => message.role === "system")).toBe(false)
+		expect((sentMessages[0] as any).role).toBe("user")
+	})
+})

--- a/src/api/providers/fetchers/__tests__/zenmux.spec.ts
+++ b/src/api/providers/fetchers/__tests__/zenmux.spec.ts
@@ -1,0 +1,66 @@
+// kilocode_change - new file
+import { zenmuxDefaultModelInfo } from "@roo-code/types"
+import { getZenmuxModels } from "../zenmux"
+
+describe("getZenmuxModels", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals()
+		vi.restoreAllMocks()
+	})
+
+	it("maps context_length from ZenMux model payload", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			json: vi.fn().mockResolvedValue({
+				object: "list",
+				data: [
+					{
+						id: "anthropic/claude-opus-4",
+						object: "model",
+						created: 1767146192,
+						owned_by: "anthropic",
+						display_name: "Claude Opus 4",
+						context_length: 200000,
+						input_modalities: ["text", "image"],
+					},
+				],
+			}),
+		})
+		vi.stubGlobal("fetch", fetchMock)
+
+		const models = await getZenmuxModels()
+
+		expect(models["anthropic/claude-opus-4"]).toEqual({
+			maxTokens: 0,
+			contextWindow: 200000,
+			supportsImages: true,
+			supportsPromptCache: false,
+			inputPrice: 0,
+			outputPrice: 0,
+			description: "anthropic model",
+			displayName: "Claude Opus 4",
+		})
+		expect(models["anthropic/claude-opus-4"].contextWindow).toBeGreaterThan(0)
+	})
+
+	it("falls back to default context window when optional metadata is missing", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			json: vi.fn().mockResolvedValue({
+				object: "list",
+				data: [
+					{
+						id: "openai/gpt-5",
+						object: "model",
+						created: 1767146192,
+						owned_by: "openai",
+					},
+				],
+			}),
+		})
+		vi.stubGlobal("fetch", fetchMock)
+
+		const models = await getZenmuxModels()
+
+		expect(models["openai/gpt-5"].contextWindow).toBe(zenmuxDefaultModelInfo.contextWindow)
+		expect(models["openai/gpt-5"].displayName).toBe("openai/gpt-5")
+	})
+})

--- a/src/api/providers/fetchers/__tests__/zenmux.spec.ts
+++ b/src/api/providers/fetchers/__tests__/zenmux.spec.ts
@@ -34,6 +34,8 @@ describe("getZenmuxModels", () => {
 			contextWindow: 200000,
 			supportsImages: true,
 			supportsPromptCache: false,
+			supportsNativeTools: true,
+			defaultToolProtocol: "native",
 			inputPrice: 0,
 			outputPrice: 0,
 			description: "anthropic model",
@@ -62,5 +64,7 @@ describe("getZenmuxModels", () => {
 
 		expect(models["openai/gpt-5"].contextWindow).toBe(zenmuxDefaultModelInfo.contextWindow)
 		expect(models["openai/gpt-5"].displayName).toBe("openai/gpt-5")
+		expect(models["openai/gpt-5"].supportsNativeTools).toBe(true)
+		expect(models["openai/gpt-5"].defaultToolProtocol).toBe("native")
 	})
 })

--- a/src/api/providers/fetchers/zenmux.ts
+++ b/src/api/providers/fetchers/zenmux.ts
@@ -1,9 +1,8 @@
 import { z } from "zod"
 
-import { type ModelInfo } from "@roo-code/types"
+import { type ModelInfo, zenmuxDefaultModelInfo } from "@roo-code/types"
 import type { ApiHandlerOptions } from "../../../shared/api"
 import { DEFAULT_HEADERS } from "../constants"
-import { parseApiPrice } from "../../../shared/cost"
 
 /**
  * ZenMuxModel
@@ -13,6 +12,9 @@ const zenMuxModelSchema = z.object({
 	object: z.string(),
 	created: z.number(),
 	owned_by: z.string(),
+	display_name: z.string().optional(),
+	context_length: z.number().optional(),
+	input_modalities: z.array(z.string()).optional(),
 })
 
 export type ZenMuxModel = z.infer<typeof zenMuxModelSchema>
@@ -32,7 +34,7 @@ export async function getZenmuxModels(
 	options?: ApiHandlerOptions & { headers?: Record<string, string> },
 ): Promise<Record<string, ModelInfo>> {
 	const models: Record<string, ModelInfo> = {}
-	const baseURL = "https://zenmux.ai/api/v1"
+	const baseURL = options?.openRouterBaseUrl || "https://zenmux.ai/api/v1"
 	try {
 		const response = await fetch(`${baseURL}/models`, {
 			headers: { ...DEFAULT_HEADERS, ...(options?.headers ?? {}) },
@@ -47,16 +49,19 @@ export async function getZenmuxModels(
 		const data = result.data.data
 
 		for (const model of data) {
-			const { id, owned_by } = model
+			const { id, owned_by, display_name, context_length, input_modalities } = model
+			const contextWindow = context_length && context_length > 0 ? context_length : zenmuxDefaultModelInfo.contextWindow
 
 			const modelInfo: ModelInfo = {
+				// Keep max tokens conservative and let centralized max-token logic decide runtime reservation.
 				maxTokens: 0,
-				contextWindow: 0,
+				contextWindow,
+				supportsImages: input_modalities?.includes("image") ?? false,
 				supportsPromptCache: false,
 				inputPrice: 0,
 				outputPrice: 0,
 				description: `${owned_by || "ZenMux"} model`,
-				displayName: id,
+				displayName: display_name || id,
 			}
 
 			models[id] = modelInfo

--- a/src/api/providers/fetchers/zenmux.ts
+++ b/src/api/providers/fetchers/zenmux.ts
@@ -58,6 +58,10 @@ export async function getZenmuxModels(
 				contextWindow,
 				supportsImages: input_modalities?.includes("image") ?? false,
 				supportsPromptCache: false,
+				// kilocode_change start
+				supportsNativeTools: true,
+				defaultToolProtocol: "native",
+				// kilocode_change end
 				inputPrice: 0,
 				outputPrice: 0,
 				description: `${owned_by || "ZenMux"} model`,


### PR DESCRIPTION
## Context

ZenMux had two related reliability issues:

1. Model metadata/caching could produce invalid or incomplete model capabilities (notably around context window and native tool support), which led to unstable behavior.
2. Native tool-call flow in ZenMux could trigger repeated "tool not used" retry loops because tool capability and request-shaping were not consistently preserved through runtime paths.

This PR hardens ZenMux model normalization/caching and fixes the native tool/message pipeline so tool-enabled tasks behave consistently.

## Implementation

This PR combines two branch commits:

- `first commit`: Context window/cache hardening
  - Maps ZenMux `context_length` into `contextWindow`.
  - Adds fallback behavior when optional model metadata is missing.
  - Adds stale ZenMux cache self-healing for invalid `contextWindow <= 0` records.
  - Adds/extends ZenMux fetcher and model cache tests for stale cache rejection and valid cache acceptance.

- `second commit`: Native tool reliability + pipeline cleanup
  - Adds explicit native-tool defaults for ZenMux model info (`supportsNativeTools`, `defaultToolProtocol`).
  - Ensures fetched ZenMux models include native-tool metadata.
  - Merges native-tool defaults at runtime to self-heal stale model entries missing native tool fields.
  - Respects task-locked `toolProtocol` and gates tool params accordingly.
  - Refactors ZenMux stream creation to use already-transformed OpenAI messages (instead of rebuilding from raw messages), preserving protocol/model-specific transforms.
  - Adds dedicated regression tests covering:
    - stale metadata default merge
    - native vs xml tool gating
    - DeepSeek R1 transformed-message passthrough
  - Adds user-facing patch changeset for release notes.

## How to Test

1. Run ZenMux-targeted backend tests from `src`:
- `cd src && pnpm test api/providers/fetchers/__tests__/zenmux.spec.ts`
- `cd src && pnpm test api/providers/__tests__/zenmux.spec.ts`
- `cd src && pnpm test api/providers/__tests__/zenmux-native-tools.spec.ts`

2. Run extension-wide backend suite:
- `cd src && pnpm test`

3. Validate repo gates:
- `pnpm check-types`
- `pnpm lint`
- `pnpm build`

4. Manual behavior check (ZenMux):
- Configure provider: `zenmux`
- Use model: `z-ai/glm-5`
- In Ask mode, send a simple prompt like `hi`
- Confirm it does not enter repeated "did not use a tool" retry loops due to missing native-tool wiring.

> [!NOTE]
> The final implementation was AI assisted

@simonleung963 reported the problem on [Discord](https://discord.com/channels/1349288496988160052/1471428700342980651/1471430620784623751) and tested my custom builds.