### PR TITLE
Feat: Profile condense override with model-aware token caps

### DIFF
--- a/.changeset/bright-taxis-share.md
+++ b/.changeset/bright-taxis-share.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Redesigned context condensing thresholds so global behavior stays percentage-based while each profile can optionally override with either percent-of-limit or fixed token triggers.

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -53,6 +53,17 @@ export const DEFAULT_CHECKPOINT_TIMEOUT_SECONDS = 15
  * GlobalSettings
  */
 
+// kilocode_change start
+export const profileCondenseOverrideModeSchema = z.enum(["percent", "tokens"])
+export const profileCondenseOverrideSchema = z.object({
+	enabled: z.boolean(),
+	mode: profileCondenseOverrideModeSchema,
+	percent: z.number(),
+	tokens: z.number(),
+})
+export type ProfileCondenseOverride = z.infer<typeof profileCondenseOverrideSchema>
+// kilocode_change end
+
 export const globalSettingsSchema = z.object({
 	currentApiConfigName: z.string().optional(),
 	listApiConfigMeta: z.array(providerSettingsEntrySchema).optional(),
@@ -244,6 +255,9 @@ export const globalSettingsSchema = z.object({
 	 */
 	enterBehavior: z.enum(["send", "newline"]).optional(),
 	profileThresholds: z.record(z.string(), z.number()).optional(),
+	// kilocode_change start
+	profileCondenseOverrides: z.record(z.string(), profileCondenseOverrideSchema).optional(),
+	// kilocode_change end
 	hasOpenedModeSelector: z.boolean().optional(),
 	hasCompletedOnboarding: z.boolean().optional(), // kilocode_change: Track if user has completed onboarding flow
 	lastModeExportPath: z.string().optional(),

--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -556,6 +556,9 @@ export type ExtensionState = Pick<
 	| "codebaseIndexConfig"
 	| "codebaseIndexModels"
 	| "profileThresholds"
+	// kilocode_change start
+	| "profileCondenseOverrides"
+	// kilocode_change end
 	| "systemNotificationsEnabled" // kilocode_change
 	| "includeDiagnosticMessages"
 	| "maxDiagnosticMessages"
@@ -640,6 +643,12 @@ export type ExtensionState = Pick<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	marketplaceInstalledMetadata?: { project: Record<string, any>; global: Record<string, any> }
 	profileThresholds: Record<string, number>
+	// kilocode_change start
+	profileCondenseOverrides?: Record<
+		string,
+		{ enabled: boolean; mode: "percent" | "tokens"; percent: number; tokens: number }
+	>
+	// kilocode_change end
 	hasOpenedModeSelector: boolean
 	hasCompletedOnboarding?: boolean // kilocode_change: Track if user has completed onboarding flow
 	openRouterImageApiKey?: string

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -4246,6 +4246,9 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	private async handleContextWindowExceededError(): Promise<void> {
 		const state = await this.providerRef.deref()?.getState()
 		const { profileThresholds = {} } = state ?? {}
+		// kilocode_change start
+		const { profileCondenseOverrides = {} } = state ?? {}
+		// kilocode_change end
 
 		const { contextTokens } = this.getTokenUsage()
 		// kilocode_change start: Initialize virtual quota fallback handler
@@ -4292,6 +4295,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			systemPrompt: await this.getSystemPrompt(),
 			taskId: this.taskId,
 			profileThresholds,
+			// kilocode_change
+			profileCondenseOverrides,
 			currentProfileId,
 			useNativeTools,
 		})
@@ -4402,6 +4407,9 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			autoCondenseContext = true,
 			autoCondenseContextPercent = 100,
 			profileThresholds = {},
+			// kilocode_change start
+			profileCondenseOverrides = {},
+			// kilocode_change end
 		} = state ?? {}
 
 		// Get condensing configuration for automatic triggers.
@@ -4487,6 +4495,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				autoCondenseContext,
 				autoCondenseContextPercent,
 				profileThresholds,
+				// kilocode_change
+				profileCondenseOverrides,
 				currentProfileId,
 				lastMessageTokens,
 			})
@@ -4513,6 +4523,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				customCondensingPrompt,
 				condensingApiHandler,
 				profileThresholds,
+				// kilocode_change
+				profileCondenseOverrides,
 				currentProfileId,
 				useNativeTools,
 			})

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2293,6 +2293,9 @@ export class ClineProvider
 			codebaseIndexConfig,
 			codebaseIndexModels,
 			profileThresholds,
+			// kilocode_change start
+			profileCondenseOverrides,
+			// kilocode_change end
 			systemNotificationsEnabled, // kilocode_change
 			dismissedNotificationIds, // kilocode_change
 			morphApiKey, // kilocode_change
@@ -2517,6 +2520,9 @@ export class ClineProvider
 			// undefined means no MDM policy, true means compliant, false means non-compliant
 			mdmCompliant: this.mdmService?.requiresCloudAuth() ? this.checkMdmCompliance() : undefined,
 			profileThresholds: profileThresholds ?? {},
+			// kilocode_change start
+			profileCondenseOverrides: profileCondenseOverrides ?? {},
+			// kilocode_change end
 			cloudApiUrl: getRooCodeApiUrl(),
 			hasOpenedModeSelector: this.getGlobalState("hasOpenedModeSelector") ?? false,
 			hasCompletedOnboarding: this.getGlobalState("hasCompletedOnboarding"), // kilocode_change: Track onboarding completion - undefined means new user
@@ -2841,6 +2847,9 @@ export class ClineProvider
 					stateValues.codebaseIndexConfig?.codebaseIndexOpenRouterSpecificProvider,
 			},
 			profileThresholds: stateValues.profileThresholds ?? {},
+			// kilocode_change start
+			profileCondenseOverrides: stateValues.profileCondenseOverrides ?? {},
+			// kilocode_change end
 			includeDiagnosticMessages: stateValues.includeDiagnosticMessages ?? true,
 			maxDiagnosticMessages: stateValues.maxDiagnosticMessages ?? 50,
 			includeTaskHistoryInEnhance: stateValues.includeTaskHistoryInEnhance ?? true,

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -620,6 +620,7 @@ describe("ClineProvider", () => {
 			sharingEnabled: false,
 			publicSharingEnabled: false,
 			profileThresholds: {},
+			profileCondenseOverrides: {},
 			hasOpenedModeSelector: false,
 			diagnosticsEnabled: true,
 			openRouterImageApiKey: undefined,
@@ -808,6 +809,34 @@ describe("ClineProvider", () => {
 		expect(state).toHaveProperty("diffEnabled")
 		expect(state).toHaveProperty("writeDelayMs")
 	})
+
+	// kilocode_change start
+	test("getState includes profileCondenseOverrides default", async () => {
+		const state = await provider.getState()
+
+		expect(state.profileCondenseOverrides).toEqual({})
+	})
+
+	test("handles profileCondenseOverrides updates through updateSettings", async () => {
+		await provider.resolveWebviewView(mockWebviewView)
+		const messageHandler = (mockWebviewView.webview.onDidReceiveMessage as any).mock.calls[0][0]
+
+		const overrides = {
+			"test-profile-id": {
+				enabled: true,
+				mode: "tokens" as const,
+				percent: 75,
+				tokens: 25000,
+			},
+		}
+
+		await messageHandler({ type: "updateSettings", updatedSettings: { profileCondenseOverrides: overrides } })
+
+		expect(updateGlobalStateSpy).toHaveBeenCalledWith("profileCondenseOverrides", overrides)
+		expect(mockContext.globalState.update).toHaveBeenCalledWith("profileCondenseOverrides", overrides)
+		expect((await provider.getState()).profileCondenseOverrides).toEqual(overrides)
+	})
+	// kilocode_change end
 
 	test("language is set to VSCode language", async () => {
 		// Mock VSCode language as Spanish

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -244,7 +244,6 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>((props, ref)
 		customCondensingPrompt,
 		yoloGatekeeperApiConfigId, // kilocode_change: AI gatekeeper for YOLO mode
 		customSupportPrompts,
-		profileThresholds,
 		// kilocode_change
 		profileCondenseOverrides,
 		systemNotificationsEnabled, // kilocode_change

--- a/webview-ui/src/components/settings/__tests__/ContextManagementSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ContextManagementSettings.spec.tsx
@@ -1,565 +1,314 @@
-// npx vitest src/components/settings/__tests__/ContextManagementSettings.spec.tsx
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@/utils/test-utils"
 
-import { render, screen, fireEvent, waitFor } from "@/utils/test-utils"
 import { ContextManagementSettings } from "../ContextManagementSettings"
 
-// Mock the translation hook
-vi.mock("@/hooks/useAppTranslation", () => ({
+vi.mock("@/i18n/TranslationContext", () => ({
 	useAppTranslation: () => ({
-		t: (key: string) => {
-			// Return specific translations for our test cases
-			if (key === "settings:contextManagement.diagnostics.maxMessages.unlimitedLabel") {
-				return "Unlimited"
-			}
-			return key
-		},
+		t: (key: string) => key,
 	}),
 }))
 
-// Mock the UI components
 vi.mock("@/components/ui", () => ({
-	...vi.importActual("@/components/ui"),
-	Slider: ({ value, onValueChange, "data-testid": dataTestId, disabled, min, max }: any) => (
+	Slider: ({ value, onValueChange, "data-testid": dataTestId, disabled, min, max, step }: any) => (
 		<input
 			type="range"
 			value={value?.[0] ?? 0}
 			min={min}
 			max={max}
+			step={step ?? 1}
 			onChange={(e) => onValueChange([parseFloat(e.target.value)])}
-			onKeyDown={(e) => {
-				const currentValue = value?.[0] ?? 0
-				if (e.key === "ArrowRight") {
-					onValueChange([currentValue + 1])
-				} else if (e.key === "ArrowLeft") {
-					onValueChange([currentValue - 1])
-				}
-			}}
 			data-testid={dataTestId}
 			disabled={disabled}
-			role="slider"
 		/>
 	),
-	Input: ({ value, onChange, "data-testid": dataTestId, ...props }: any) => (
-		<input value={value} onChange={onChange} data-testid={dataTestId} {...props} />
+	Input: ({ value, onChange, "data-testid": dataTestId, disabled, ...props }: any) => (
+		<input value={value} onChange={onChange} data-testid={dataTestId} disabled={disabled} {...props} />
 	),
-	Button: ({ children, onClick, ...props }: any) => (
-		<button onClick={onClick} {...props}>
+	Button: ({ children, onClick, disabled, ...props }: any) => (
+		<button onClick={onClick} disabled={disabled} {...props}>
 			{children}
 		</button>
 	),
-	Select: ({ children, ...props }: any) => (
-		<div role="combobox" {...props}>
-			{children}
-		</div>
+	Select: ({ value, onValueChange, disabled, "data-testid": dataTestId }: any) => (
+		<select
+			role="combobox"
+			value={value}
+			onChange={(e) => onValueChange?.(e.target.value)}
+			disabled={disabled}
+			data-testid={dataTestId}>
+			<option value="percent">percent</option>
+			<option value="tokens">tokens</option>
+		</select>
 	),
-	SelectTrigger: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-	SelectValue: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-	SelectContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-	SelectItem: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+	SelectTrigger: ({ children }: any) => <>{children}</>,
+	SelectValue: () => null,
+	SelectContent: ({ children }: any) => <>{children}</>,
+	SelectItem: () => null,
 }))
 
-// Mock vscode utilities - this is necessary since we're not in a VSCode environment
-
-vi.mock("@/utils/vscode", () => ({
-	vscode: {
-		postMessage: vi.fn(),
-	},
-}))
-
-// Mock VSCode components to behave like standard HTML elements
 vi.mock("@vscode/webview-ui-toolkit/react", () => ({
 	VSCodeCheckbox: ({ checked, onChange, children, "data-testid": dataTestId, ...props }: any) => (
 		<label data-testid={dataTestId} {...props}>
 			<input
 				type="checkbox"
-				role="checkbox"
 				checked={checked || false}
-				aria-checked={checked || false}
 				onChange={(e: any) => onChange?.({ target: { checked: e.target.checked } })}
 			/>
 			{children}
 		</label>
 	),
-	VSCodeTextArea: ({ value, onChange, ...props }: any) => <textarea value={value} onChange={onChange} {...props} />,
 }))
 
-describe("ContextManagementSettings", () => {
-	const defaultProps = {
-		autoCondenseContext: false,
-		autoCondenseContextPercent: 80,
-		condensingApiConfigId: undefined,
-		customCondensingPrompt: undefined,
-		listApiConfigMeta: [],
-		maxOpenTabsContext: 20,
-		maxWorkspaceFiles: 200,
-		showRooIgnoredFiles: false,
-		maxReadFileLine: -1,
-		maxConcurrentFileReads: 5,
-		profileThresholds: {},
-		includeDiagnosticMessages: true,
-		maxDiagnosticMessages: 50,
-		writeDelayMs: 1000,
-		setCachedStateField: vi.fn(),
+type ProfileCondenseOverrideValue = {
+	enabled: boolean
+	mode: "percent" | "tokens"
+	percent: number
+	tokens: number
+}
+
+const CURRENT_PROFILE_ID = "profile-default"
+
+const createProps = (overrides: Partial<React.ComponentProps<typeof ContextManagementSettings>> = {}) => ({
+	autoCondenseContext: true,
+	autoCondenseContextPercent: 80,
+	maxOpenTabsContext: 20,
+	maxWorkspaceFiles: 200,
+	showRooIgnoredFiles: false,
+	enableSubfolderRules: false,
+	maxReadFileLine: 500,
+	maxImageFileSize: 5,
+	maxTotalImageSize: 20,
+	maxConcurrentFileReads: 5,
+	allowVeryLargeReads: false,
+	profileCondenseOverrides: {} as Record<string, ProfileCondenseOverrideValue>,
+	currentProfileName: "Default",
+	currentProfileId: CURRENT_PROFILE_ID,
+	condenseEffectiveBudgetTokens: 10_000,
+	includeDiagnosticMessages: true,
+	maxDiagnosticMessages: 50,
+	writeDelayMs: 1000,
+	includeCurrentTime: true,
+	includeCurrentCost: true,
+	maxGitStatusFiles: 0,
+	setCachedStateField: vi.fn(),
+	...overrides,
+})
+
+const renderWithState = (overrides: Partial<React.ComponentProps<typeof ContextManagementSettings>> = {}) => {
+	const setCachedStateFieldSpy = vi.fn()
+
+	const Stateful = () => {
+		const [profileCondenseOverrides, setProfileCondenseOverrides] = React.useState<
+			Record<string, ProfileCondenseOverrideValue>
+		>((overrides.profileCondenseOverrides as Record<string, ProfileCondenseOverrideValue>) ?? {})
+
+		const mergedProps = createProps({
+			...overrides,
+			profileCondenseOverrides,
+			setCachedStateField: ((field: string, value: unknown) => {
+				setCachedStateFieldSpy(field, value)
+				if (field === "profileCondenseOverrides") {
+					setProfileCondenseOverrides(value as Record<string, ProfileCondenseOverrideValue>)
+				}
+			}) as any,
+		})
+
+		return <ContextManagementSettings {...mergedProps} />
 	}
 
+	render(<Stateful />)
+
+	return { setCachedStateFieldSpy }
+}
+
+describe("ContextManagementSettings", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 	})
 
-	it("renders diagnostic settings", () => {
-		render(<ContextManagementSettings {...defaultProps} />)
+	it("hides condensing threshold controls when auto-condense is disabled", () => {
+		render(<ContextManagementSettings {...createProps({ autoCondenseContext: false })} />)
 
-		// Check for diagnostic checkbox
-		expect(screen.getByTestId("include-diagnostic-messages-checkbox")).toBeInTheDocument()
-
-		// Check for slider
-		expect(screen.getByTestId("max-diagnostic-messages-slider")).toBeInTheDocument()
-		expect(screen.getByText("50")).toBeInTheDocument()
+		expect(screen.queryByTestId("condense-threshold-slider")).not.toBeInTheDocument()
 	})
 
-	it("renders with diagnostic messages enabled", () => {
-		render(<ContextManagementSettings {...defaultProps} includeDiagnosticMessages={true} />)
+	it("disables current-profile override controls when override is off", () => {
+		render(<ContextManagementSettings {...createProps()} />)
 
-		const checkbox = screen.getByTestId("include-diagnostic-messages-checkbox")
-		expect(checkbox.querySelector("input")).toBeChecked()
-
-		const slider = screen.getByTestId("max-diagnostic-messages-slider")
-		expect(slider).toBeInTheDocument()
-		expect(slider).toHaveValue("50")
+		expect(screen.getByTestId("condense-current-profile-override-checkbox").querySelector("input")).not.toBeChecked()
+		expect(screen.getByTestId("condense-threshold-mode-select")).toBeDisabled()
+		expect(screen.getByTestId("condense-profile-percent-slider")).toBeDisabled()
 	})
 
-	it("renders with diagnostic messages disabled", () => {
-		render(<ContextManagementSettings {...defaultProps} includeDiagnosticMessages={false} />)
+	it("enables override and updates profile override state in percent mode", async () => {
+		const { setCachedStateFieldSpy } = renderWithState()
 
-		const checkbox = screen.getByTestId("include-diagnostic-messages-checkbox")
-		expect(checkbox.querySelector("input")).not.toBeChecked()
+		fireEvent.click(screen.getByTestId("condense-current-profile-override-checkbox"))
 
-		// Slider should still be rendered when diagnostics are disabled
-		expect(screen.getByTestId("max-diagnostic-messages-slider")).toBeInTheDocument()
-		expect(screen.getByText("50")).toBeInTheDocument()
+		await waitFor(() => {
+			expect(setCachedStateFieldSpy).toHaveBeenCalledWith(
+				"profileCondenseOverrides",
+				expect.objectContaining({
+					[CURRENT_PROFILE_ID]: expect.objectContaining({
+						enabled: true,
+						mode: "percent",
+					}),
+				}),
+			)
+		})
+
+		expect(screen.getByTestId("condense-threshold-mode-select")).not.toBeDisabled()
+		expect(screen.getByTestId("condense-profile-percent-slider")).not.toBeDisabled()
+		expect(
+			screen.getByText("settings:contextManagement.condensingThreshold.percentEquivalent"),
+		).toBeInTheDocument()
 	})
 
-	it("calls setCachedStateField when include diagnostic messages checkbox is toggled", async () => {
+	it("supports token mode and clamps typed token value to effective budget", async () => {
+		const { setCachedStateFieldSpy } = renderWithState({
+			profileCondenseOverrides: {
+				[CURRENT_PROFILE_ID]: {
+					enabled: true,
+					mode: "percent",
+					percent: 70,
+					tokens: 7000,
+				},
+			},
+			condenseEffectiveBudgetTokens: 5000,
+		})
+
+		fireEvent.change(screen.getByTestId("condense-threshold-mode-select"), {
+			target: { value: "tokens" },
+		})
+
+		await waitFor(() => {
+			expect(setCachedStateFieldSpy).toHaveBeenCalledWith(
+				"profileCondenseOverrides",
+				expect.objectContaining({
+					[CURRENT_PROFILE_ID]: expect.objectContaining({
+						mode: "tokens",
+					}),
+				}),
+			)
+		})
+
+		const tokenInput = await screen.findByTestId("condense-profile-token-input")
+		fireEvent.change(tokenInput, { target: { value: "9000" } })
+
+		await waitFor(() => {
+			expect(setCachedStateFieldSpy).toHaveBeenCalledWith(
+				"profileCondenseOverrides",
+				expect.objectContaining({
+					[CURRENT_PROFILE_ID]: expect.objectContaining({
+						mode: "tokens",
+						tokens: 5000,
+					}),
+				}),
+			)
+		})
+	})
+
+	it("auto-clamps saved token override on model cap reduction and shows inline notice", async () => {
 		const setCachedStateField = vi.fn()
-		render(<ContextManagementSettings {...defaultProps} setCachedStateField={setCachedStateField} />)
+		const initial = createProps({
+			profileCondenseOverrides: {
+				[CURRENT_PROFILE_ID]: {
+					enabled: true,
+					mode: "tokens",
+					percent: 80,
+					tokens: 9000,
+				},
+			},
+			condenseEffectiveBudgetTokens: 9000,
+			setCachedStateField,
+		})
 
-		const checkbox = screen.getByTestId("include-diagnostic-messages-checkbox").querySelector("input")!
-		fireEvent.click(checkbox)
+		const { rerender } = render(<ContextManagementSettings {...initial} />)
+
+		rerender(
+			<ContextManagementSettings
+				{...initial}
+				condenseEffectiveBudgetTokens={5000}
+				setCachedStateField={setCachedStateField}
+			/>,
+		)
+
+		await waitFor(() => {
+			expect(setCachedStateField).toHaveBeenCalledWith(
+				"profileCondenseOverrides",
+				expect.objectContaining({
+					[CURRENT_PROFILE_ID]: expect.objectContaining({
+						tokens: 5000,
+					}),
+				}),
+			)
+		})
+
+		expect(screen.getByTestId("condense-token-clamp-notice")).toBeInTheDocument()
+	})
+
+	it("does not render legacy profile selector inside condense threshold section", () => {
+		render(<ContextManagementSettings {...createProps()} />)
+
+		expect(
+			screen.queryByText("settings:contextManagement.condensingThreshold.selectProfileLabel"),
+		).not.toBeInTheDocument()
+	})
+
+	it("still updates global percent slider independently of profile override", async () => {
+		const setCachedStateField = vi.fn()
+		render(<ContextManagementSettings {...createProps({ setCachedStateField })} />)
+
+		fireEvent.change(screen.getByTestId("condense-threshold-slider"), { target: { value: "65" } })
+
+		await waitFor(() => {
+			expect(setCachedStateField).toHaveBeenCalledWith("autoCondenseContextPercent", 65)
+		})
+	})
+
+	it("keeps diagnostic include toggle behavior unchanged", async () => {
+		const setCachedStateField = vi.fn()
+		render(
+			<ContextManagementSettings
+				{...createProps({
+					includeDiagnosticMessages: true,
+					setCachedStateField,
+				})}
+			/>,
+		)
+
+		fireEvent.click(screen.getByTestId("include-diagnostic-messages-checkbox"))
 
 		await waitFor(() => {
 			expect(setCachedStateField).toHaveBeenCalledWith("includeDiagnosticMessages", false)
 		})
 	})
 
-	it("calls setCachedStateField when max diagnostic messages slider is changed", async () => {
+	it("keeps diagnostic max slider unlimited mapping unchanged", async () => {
 		const setCachedStateField = vi.fn()
-		render(<ContextManagementSettings {...defaultProps} setCachedStateField={setCachedStateField} />)
+		render(<ContextManagementSettings {...createProps({ setCachedStateField })} />)
 
-		const slider = screen.getByTestId("max-diagnostic-messages-slider")
-		fireEvent.change(slider, { target: { value: "100" } })
+		fireEvent.change(screen.getByTestId("max-diagnostic-messages-slider"), { target: { value: "100" } })
 
 		await waitFor(() => {
 			expect(setCachedStateField).toHaveBeenCalledWith("maxDiagnosticMessages", -1)
 		})
 	})
 
-	it("keeps slider visible when include diagnostic messages is unchecked", () => {
-		const { rerender } = render(<ContextManagementSettings {...defaultProps} includeDiagnosticMessages={true} />)
+	it("keeps max-read-file controls behavior unchanged", async () => {
+		const setCachedStateField = vi.fn()
+		render(<ContextManagementSettings {...createProps({ maxReadFileLine: 500, setCachedStateField })} />)
 
-		const slider = screen.getByTestId("max-diagnostic-messages-slider")
-		expect(slider).toBeInTheDocument()
+		fireEvent.change(screen.getByTestId("max-read-file-line-input"), { target: { value: "1000" } })
+		fireEvent.click(screen.getByTestId("max-read-file-always-full-checkbox"))
 
-		// Update to disabled - slider should still be visible
-		rerender(<ContextManagementSettings {...defaultProps} includeDiagnosticMessages={false} />)
-		expect(screen.getByTestId("max-diagnostic-messages-slider")).toBeInTheDocument()
-	})
-
-	it("displays correct max diagnostic messages value", () => {
-		const { rerender } = render(<ContextManagementSettings {...defaultProps} maxDiagnosticMessages={25} />)
-
-		expect(screen.getByText("25")).toBeInTheDocument()
-
-		// Update value - 100 should display as "Unlimited"
-		rerender(<ContextManagementSettings {...defaultProps} maxDiagnosticMessages={100} />)
-		expect(
-			screen.getByText("settings:contextManagement.diagnostics.maxMessages.unlimitedLabel"),
-		).toBeInTheDocument()
-
-		// Test unlimited value (-1) displays as "Unlimited"
-		rerender(<ContextManagementSettings {...defaultProps} maxDiagnosticMessages={-1} />)
-		expect(
-			screen.getByText("settings:contextManagement.diagnostics.maxMessages.unlimitedLabel"),
-		).toBeInTheDocument()
-	})
-
-	it("renders other context management settings", () => {
-		render(<ContextManagementSettings {...defaultProps} />)
-
-		// Check for other sliders
-		expect(screen.getByTestId("open-tabs-limit-slider")).toBeInTheDocument()
-		expect(screen.getByTestId("workspace-files-limit-slider")).toBeInTheDocument()
-		expect(screen.getByTestId("max-concurrent-file-reads-slider")).toBeInTheDocument()
-
-		// Check for checkboxes
-		expect(screen.getByTestId("show-rooignored-files-checkbox")).toBeInTheDocument()
-		expect(screen.getByTestId("auto-condense-context-checkbox")).toBeInTheDocument()
-	})
-
-	describe("Edge cases for maxDiagnosticMessages", () => {
-		it("handles zero value as unlimited", async () => {
-			const setCachedStateField = vi.fn()
-			render(
-				<ContextManagementSettings
-					{...defaultProps}
-					maxDiagnosticMessages={0}
-					setCachedStateField={setCachedStateField}
-				/>,
-			)
-
-			// Zero is now treated as unlimited
-			expect(
-				screen.getByText("settings:contextManagement.diagnostics.maxMessages.unlimitedLabel"),
-			).toBeInTheDocument()
-
-			const slider = screen.getByTestId("max-diagnostic-messages-slider")
-			// Zero should map to slider position 100 (unlimited)
-			expect(slider).toHaveValue("100")
+		await waitFor(() => {
+			expect(setCachedStateField).toHaveBeenCalledWith("maxReadFileLine", 1000)
 		})
 
-		it("handles negative values as unlimited", async () => {
-			const setCachedStateField = vi.fn()
-			render(
-				<ContextManagementSettings
-					{...defaultProps}
-					maxDiagnosticMessages={-10}
-					setCachedStateField={setCachedStateField}
-				/>,
-			)
-
-			// Component displays "Unlimited" for any negative value
-			expect(
-				screen.getByText("settings:contextManagement.diagnostics.maxMessages.unlimitedLabel"),
-			).toBeInTheDocument()
-
-			// Slider should be at max position (100) for negative values
-			const slider = screen.getByTestId("max-diagnostic-messages-slider")
-			expect(slider).toHaveValue("100")
-		})
-
-		it("handles very large numbers by capping at maximum", async () => {
-			const setCachedStateField = vi.fn()
-			const largeNumber = 1000
-			render(
-				<ContextManagementSettings
-					{...defaultProps}
-					maxDiagnosticMessages={largeNumber}
-					setCachedStateField={setCachedStateField}
-				/>,
-			)
-
-			// Should display the actual value even if it exceeds slider max
-			expect(screen.getByText(largeNumber.toString())).toBeInTheDocument()
-
-			// Slider value would be capped at max (100)
-			const slider = screen.getByTestId("max-diagnostic-messages-slider")
-			expect(slider).toHaveValue("100")
-		})
-
-		it("enforces maximum value constraint", async () => {
-			const setCachedStateField = vi.fn()
-			render(<ContextManagementSettings {...defaultProps} setCachedStateField={setCachedStateField} />)
-
-			const slider = screen.getByTestId("max-diagnostic-messages-slider")
-
-			// Test that setting value above 100 gets capped
-			fireEvent.change(slider, { target: { value: "150" } })
-
-			await waitFor(() => {
-				// Should be capped at 100, which maps to -1 (unlimited)
-				expect(setCachedStateField).toHaveBeenCalledWith("maxDiagnosticMessages", -1)
-			})
-		})
-
-		it("handles boundary value at minimum (1)", async () => {
-			const setCachedStateField = vi.fn()
-			render(<ContextManagementSettings {...defaultProps} setCachedStateField={setCachedStateField} />)
-
-			const slider = screen.getByTestId("max-diagnostic-messages-slider")
-			fireEvent.change(slider, { target: { value: "1" } })
-
-			await waitFor(() => {
-				expect(setCachedStateField).toHaveBeenCalledWith("maxDiagnosticMessages", 1)
-			})
-		})
-
-		it("handles boundary value at maximum (100) as unlimited (-1)", async () => {
-			const setCachedStateField = vi.fn()
-			render(<ContextManagementSettings {...defaultProps} setCachedStateField={setCachedStateField} />)
-
-			const slider = screen.getByTestId("max-diagnostic-messages-slider")
-			fireEvent.change(slider, { target: { value: "100" } })
-
-			await waitFor(() => {
-				// When slider is at 100, it should set the value to -1 (unlimited)
-				expect(setCachedStateField).toHaveBeenCalledWith("maxDiagnosticMessages", -1)
-			})
-		})
-
-		it("handles decimal values by parsing as float", async () => {
-			const setCachedStateField = vi.fn()
-			render(<ContextManagementSettings {...defaultProps} setCachedStateField={setCachedStateField} />)
-
-			const slider = screen.getByTestId("max-diagnostic-messages-slider")
-			fireEvent.change(slider, { target: { value: "50.7" } })
-
-			await waitFor(() => {
-				// The mock slider component parses as float
-				expect(setCachedStateField).toHaveBeenCalledWith("maxDiagnosticMessages", 50.7)
-			})
-		})
-	})
-
-	it("renders max read file line controls", () => {
-		const propsWithMaxReadFileLine = {
-			...defaultProps,
-			maxReadFileLine: 500,
-		}
-		render(<ContextManagementSettings {...propsWithMaxReadFileLine} />)
-
-		// Max read file line input
-		const maxReadFileInput = screen.getByTestId("max-read-file-line-input")
-		expect(maxReadFileInput).toBeInTheDocument()
-		expect(maxReadFileInput).toHaveValue(500)
-
-		// Always full read checkbox
-		const alwaysFullReadCheckbox = screen.getByTestId("max-read-file-always-full-checkbox")
-		expect(alwaysFullReadCheckbox).toBeInTheDocument()
-		expect(alwaysFullReadCheckbox).not.toBeChecked()
-	})
-
-	it("updates max read file line setting", () => {
-		const propsWithMaxReadFileLine = {
-			...defaultProps,
-			maxReadFileLine: 500,
-		}
-		render(<ContextManagementSettings {...propsWithMaxReadFileLine} />)
-
-		const input = screen.getByTestId("max-read-file-line-input")
-		fireEvent.change(input, { target: { value: "1000" } })
-
-		expect(defaultProps.setCachedStateField).toHaveBeenCalledWith("maxReadFileLine", 1000)
-	})
-
-	it("toggles always full read setting", () => {
-		const propsWithMaxReadFileLine = {
-			...defaultProps,
-			maxReadFileLine: 500,
-		}
-		render(<ContextManagementSettings {...propsWithMaxReadFileLine} />)
-
-		const checkbox = screen.getByTestId("max-read-file-always-full-checkbox")
-		fireEvent.click(checkbox)
-
-		expect(defaultProps.setCachedStateField).toHaveBeenCalledWith("maxReadFileLine", -1)
-	})
-
-	it("renders with autoCondenseContext enabled", () => {
-		const propsWithAutoCondense = {
-			...defaultProps,
-			autoCondenseContext: true,
-			autoCondenseContextPercent: 75,
-		}
-		render(<ContextManagementSettings {...propsWithAutoCondense} />)
-
-		// Should render the auto condense section
-		const autoCondenseCheckbox = screen.getByTestId("auto-condense-context-checkbox")
-		expect(autoCondenseCheckbox).toBeInTheDocument()
-
-		// Should render the threshold slider with correct value
-		const slider = screen.getByTestId("condense-threshold-slider")
-		expect(slider).toBeInTheDocument()
-
-		// Should render the profile select dropdown
-		const selects = screen.getAllByRole("combobox")
-		expect(selects).toHaveLength(1)
-	})
-
-	describe("Auto Condense Context functionality", () => {
-		const autoCondenseProps = {
-			...defaultProps,
-			autoCondenseContext: true,
-			autoCondenseContextPercent: 75,
-			listApiConfigMeta: [
-				{ id: "config-1", name: "Config 1" },
-				{ id: "config-2", name: "Config 2" },
-			],
-		}
-
-		it("toggles auto condense context setting", () => {
-			const mockSetCachedStateField = vitest.fn()
-			const props = { ...autoCondenseProps, setCachedStateField: mockSetCachedStateField }
-			render(<ContextManagementSettings {...props} />)
-
-			const checkbox = screen.getByTestId("auto-condense-context-checkbox")
-			const input = checkbox.querySelector('input[type="checkbox"]')
-			expect(input).toBeChecked()
-
-			// Toggle off
-			fireEvent.click(checkbox)
-			expect(mockSetCachedStateField).toHaveBeenCalledWith("autoCondenseContext", false)
-		})
-
-		it("shows threshold settings when auto condense is enabled", () => {
-			render(<ContextManagementSettings {...autoCondenseProps} />)
-
-			// Threshold settings should be visible
-			expect(screen.getByTestId("condense-threshold-slider")).toBeInTheDocument()
-			// One combobox for profile selection
-			expect(screen.getAllByRole("combobox")).toHaveLength(1)
-		})
-
-		it("updates auto condense context percent", () => {
-			const mockSetCachedStateField = vitest.fn()
-			const props = { ...autoCondenseProps, setCachedStateField: mockSetCachedStateField }
-			render(<ContextManagementSettings {...props} />)
-
-			// Find the condense threshold slider
-			const slider = screen.getByTestId("condense-threshold-slider")
-
-			// Test slider interaction
-			slider.focus()
-			fireEvent.keyDown(slider, { key: "ArrowRight" })
-
-			expect(mockSetCachedStateField).toHaveBeenCalledWith("autoCondenseContextPercent", 76)
-		})
-
-		it("displays correct auto condense context percent value", () => {
-			render(<ContextManagementSettings {...autoCondenseProps} />)
-			expect(screen.getByText("75%")).toBeInTheDocument()
-		})
-	})
-
-	it("renders max read file line controls with -1 value", () => {
-		const propsWithMaxReadFileLine = {
-			...defaultProps,
-			maxReadFileLine: -1,
-		}
-		render(<ContextManagementSettings {...propsWithMaxReadFileLine} />)
-
-		const checkbox = screen.getByTestId("max-read-file-always-full-checkbox")
-		const input = checkbox.querySelector('input[type="checkbox"]')
-		expect(input).toBeChecked()
-	})
-
-	it("handles boundary values for sliders", () => {
-		const mockSetCachedStateField = vitest.fn()
-		const props = {
-			...defaultProps,
-			maxOpenTabsContext: 0,
-			maxWorkspaceFiles: 500,
-			maxGitStatusFiles: 0,
-			setCachedStateField: mockSetCachedStateField,
-		}
-		render(<ContextManagementSettings {...props} />)
-
-		// Check boundary values are displayed by checking the slider values directly
-		const openTabsSlider = screen.getByTestId("open-tabs-limit-slider")
-		expect(openTabsSlider).toHaveValue("0")
-
-		const workspaceFilesSlider = screen.getByTestId("workspace-files-limit-slider")
-		expect(workspaceFilesSlider).toHaveValue("500")
-
-		const gitStatusSlider = screen.getByTestId("max-git-status-files-slider")
-		expect(gitStatusSlider).toHaveValue("0")
-	})
-
-	it("handles undefined optional props gracefully", () => {
-		const propsWithUndefined = {
-			...defaultProps,
-			showRooIgnoredFiles: undefined,
-			maxReadFileLine: undefined,
-		}
-
-		expect(() => {
-			render(<ContextManagementSettings {...propsWithUndefined} />)
-		}).not.toThrow()
-
-		// Should use default values
-		expect(screen.getByText("20")).toBeInTheDocument() // default maxOpenTabsContext
-		expect(screen.getByText("200")).toBeInTheDocument() // default maxWorkspaceFiles
-	})
-
-	describe("Conditional rendering", () => {
-		it("does not render threshold settings when autoCondenseContext is false", () => {
-			const propsWithoutAutoCondense = {
-				...defaultProps,
-				autoCondenseContext: false,
-			}
-			render(<ContextManagementSettings {...propsWithoutAutoCondense} />)
-
-			// When auto condense is false, threshold slider should not be visible
-			expect(screen.queryByTestId("condense-threshold-slider")).not.toBeInTheDocument()
-		})
-
-		it("renders max read file controls with default value when maxReadFileLine is undefined", () => {
-			const propsWithoutMaxReadFile = {
-				...defaultProps,
-				maxReadFileLine: undefined,
-			}
-			render(<ContextManagementSettings {...propsWithoutMaxReadFile} />)
-
-			// Controls should still be rendered with default value of -1
-			const input = screen.getByTestId("max-read-file-line-input")
-			const checkbox = screen.getByTestId("max-read-file-always-full-checkbox")
-
-			expect(input).toBeInTheDocument()
-			expect(input).toHaveValue(500 /* kilocode_change */)
-			expect(input).not.toBeDisabled() // Input is not disabled when maxReadFileLine is undefined (only when explicitly set to -1)
-			expect(checkbox).toBeInTheDocument()
-			expect(checkbox).not.toBeChecked() // Checkbox is not checked when maxReadFileLine is undefined (only when explicitly set to -1)
-		})
-	})
-
-	describe("Accessibility", () => {
-		it("has proper labels and descriptions", () => {
-			render(<ContextManagementSettings {...defaultProps} />)
-
-			// Check that labels are present
-			expect(screen.getByText("settings:contextManagement.openTabs.label")).toBeInTheDocument()
-			expect(screen.getByText("settings:contextManagement.workspaceFiles.label")).toBeInTheDocument()
-			expect(screen.getByText("settings:contextManagement.rooignore.label")).toBeInTheDocument()
-
-			// Check that descriptions are present
-			expect(screen.getByText("settings:contextManagement.openTabs.description")).toBeInTheDocument()
-			expect(screen.getByText("settings:contextManagement.workspaceFiles.description")).toBeInTheDocument()
-			expect(screen.getByText("settings:contextManagement.rooignore.description")).toBeInTheDocument()
-		})
-
-		it("has proper test ids for all interactive elements", () => {
-			const propsWithMaxReadFile = {
-				...defaultProps,
-				maxReadFileLine: 500,
-			}
-			render(<ContextManagementSettings {...propsWithMaxReadFile} />)
-
-			expect(screen.getByTestId("open-tabs-limit-slider")).toBeInTheDocument()
-			expect(screen.getByTestId("workspace-files-limit-slider")).toBeInTheDocument()
-			expect(screen.getByTestId("show-rooignored-files-checkbox")).toBeInTheDocument()
-			expect(screen.getByTestId("max-read-file-line-input")).toBeInTheDocument()
-			expect(screen.getByTestId("max-read-file-always-full-checkbox")).toBeInTheDocument()
-		})
-	})
-
-	describe("Integration with translation system", () => {
-		it("uses translation keys for all text content", () => {
-			render(<ContextManagementSettings {...defaultProps} />)
-
-			// Verify that translation keys are being used (mocked to return the key)
-			expect(screen.getByText("settings:sections.contextManagement")).toBeInTheDocument()
-			expect(screen.getByText("settings:contextManagement.description")).toBeInTheDocument()
-			expect(screen.getByText("settings:contextManagement.openTabs.label")).toBeInTheDocument()
-			expect(screen.getByText("settings:contextManagement.workspaceFiles.label")).toBeInTheDocument()
-			expect(screen.getByText("settings:contextManagement.rooignore.label")).toBeInTheDocument()
+		await waitFor(() => {
+			expect(setCachedStateField).toHaveBeenCalledWith("maxReadFileLine", -1)
 		})
 	})
 })

--- a/webview-ui/src/components/settings/__tests__/SettingsView.change-detection.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/SettingsView.change-detection.spec.tsx
@@ -200,6 +200,7 @@ describe("SettingsView - Change Detection Fix", () => {
 		customCondensingPrompt: "",
 		customSupportPrompts: {},
 		profileThresholds: {},
+		profileCondenseOverrides: {},
 		alwaysAllowFollowupQuestions: false,
 		followupAutoApproveTimeoutMs: undefined,
 		includeDiagnosticMessages: false,

--- a/webview-ui/src/components/settings/__tests__/SettingsView.unsaved-changes.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/SettingsView.unsaved-changes.spec.tsx
@@ -206,6 +206,7 @@ describe("SettingsView - Unsaved Changes Detection", () => {
 		customCondensingPrompt: "",
 		customSupportPrompts: {},
 		profileThresholds: {},
+		profileCondenseOverrides: {},
 		alwaysAllowFollowupQuestions: false,
 		followupAutoApproveTimeoutMs: undefined,
 		includeDiagnosticMessages: false,

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -111,7 +111,17 @@ export interface ExtensionStateContextType extends ExtensionState {
 	marketplaceItems?: any[]
 	marketplaceInstalledMetadata?: MarketplaceInstalledMetadata
 	profileThresholds: Record<string, number>
+	// kilocode_change start
+	profileCondenseOverrides: Record<
+		string,
+		{ enabled: boolean; mode: "percent" | "tokens"; percent: number; tokens: number }
+	>
+	// kilocode_change end
 	setProfileThresholds: (value: Record<string, number>) => void
+	// kilocode_change
+	setProfileCondenseOverrides: (
+		value: Record<string, { enabled: boolean; mode: "percent" | "tokens"; percent: number; tokens: number }>,
+	) => void
 	setApiConfiguration: (config: ProviderSettings) => void
 	setCustomInstructions: (value?: string) => void
 	setAlwaysAllowReadOnly: (value: boolean) => void
@@ -335,6 +345,8 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		autoCondenseContext: true,
 		autoCondenseContextPercent: 100,
 		profileThresholds: {},
+		// kilocode_change
+		profileCondenseOverrides: {},
 		codebaseIndexConfig: {
 			codebaseIndexEnabled: true,
 			codebaseIndexQdrantUrl: "http://localhost:6333",
@@ -588,6 +600,8 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		marketplaceItems,
 		marketplaceInstalledMetadata,
 		profileThresholds: state.profileThresholds ?? {},
+		// kilocode_change
+		profileCondenseOverrides: state.profileCondenseOverrides ?? {},
 		alwaysAllowFollowupQuestions,
 		followupAutoApproveTimeoutMs,
 		remoteControlEnabled: state.remoteControlEnabled ?? false,
@@ -725,6 +739,9 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setYoloGatekeeperApiConfigId: (value) =>
 			setState((prevState) => ({ ...prevState, yoloGatekeeperApiConfigId: value })), // kilocode_change: AI gatekeeper for YOLO mode
 		setProfileThresholds: (value) => setState((prevState) => ({ ...prevState, profileThresholds: value })),
+		// kilocode_change
+		setProfileCondenseOverrides: (value) =>
+			setState((prevState) => ({ ...prevState, profileCondenseOverrides: value })),
 		// kilocode_change start
 		setSystemNotificationsEnabled: (value) =>
 			setState((prevState) => ({ ...prevState, systemNotificationsEnabled: value })),

--- a/webview-ui/src/context/__tests__/ExtensionStateContext.spec.tsx
+++ b/webview-ui/src/context/__tests__/ExtensionStateContext.spec.tsx
@@ -255,6 +255,7 @@ describe("mergeExtensionState", () => {
 			sharingEnabled: false,
 			publicSharingEnabled: false,
 			profileThresholds: {},
+			profileCondenseOverrides: {},
 			hasOpenedModeSelector: false, // Add the new required property
 			maxImageFileSize: 5,
 			maxTotalImageSize: 20,

--- a/webview-ui/src/i18n/locales/ar/settings.json
+++ b/webview-ui/src/i18n/locales/ar/settings.json
@@ -922,6 +922,16 @@
 			"defaultProfile": "افتراضي عام",
 			"defaultDescription": "إذا وصل السياق للنسبة يختصر (لكل الملفات).",
 			"profileDescription": "نسبة مخصصة لهذا الملف فقط.",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "هذا الملف يرث النسبة العامة ({{threshold}}%)",
 			"usesGlobal": "(يستخدم {{threshold}}% عام)"
 		},

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -820,6 +820,16 @@
 			"defaultProfile": "Per defecte global (tots els perfils)",
 			"defaultDescription": "Quan el context arribi a aquest percentatge, es condensarà automàticament per a tots els perfils tret que tinguin configuracions personalitzades",
 			"profileDescription": "Llindar personalitzat només per a aquest perfil (substitueix el per defecte global)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Aquest perfil hereta el llindar per defecte global ({{threshold}}%)",
 			"usesGlobal": "(utilitza global {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/cs/settings.json
+++ b/webview-ui/src/i18n/locales/cs/settings.json
@@ -913,6 +913,16 @@
 			"defaultProfile": "Globální výchozí (všechny profily)",
 			"defaultDescription": "Když kontext dosáhne tohoto procenta, bude automaticky zhuštěn pro všechny profily, pokud nemají vlastní nastavení",
 			"profileDescription": "Vlastní prahová hodnota pouze pro tento profil (přepisuje globální výchozí)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Tento profil dědí globální výchozí prahovou hodnotu ({{threshold}}%)",
 			"usesGlobal": "(používá globální {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -820,6 +820,16 @@
 			"defaultProfile": "Globaler Standard (alle Profile)",
 			"defaultDescription": "Wenn der Kontext diesen Prozentsatz erreicht, wird er automatisch für alle Profile komprimiert, es sei denn, sie haben benutzerdefinierte Einstellungen",
 			"profileDescription": "Benutzerdefinierter Schwellenwert nur für dieses Profil (überschreibt globalen Standard)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Dieses Profil erbt den globalen Standard-Schwellenwert ({{threshold}}%)",
 			"usesGlobal": "(verwendet global {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -867,10 +867,19 @@
 		},
 		"condensingThreshold": {
 			"label": "Condensing Trigger Threshold",
-			"selectProfile": "Configure threshold for profile",
 			"defaultProfile": "Global Default (all profiles)",
 			"defaultDescription": "When context reaches this percentage, it will be automatically condensed for all profiles unless they have custom settings",
-			"profileDescription": "Custom threshold for this profile only (overrides global default)",
+			"profileDescription": "This override applies only to the profile currently selected in Settings.",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "This profile inherits the global default threshold ({{threshold}}%)",
 			"usesGlobal": "(uses global {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -830,6 +830,16 @@
 			"defaultProfile": "Predeterminado global (todos los perfiles)",
 			"defaultDescription": "Cuando el contexto alcance este porcentaje, se condensará automáticamente para todos los perfiles a menos que tengan configuraciones personalizadas",
 			"profileDescription": "Umbral personalizado solo para este perfil (anula el predeterminado global)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Este perfil hereda el umbral predeterminado global ({{threshold}}%)",
 			"usesGlobal": "(usa global {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -830,6 +830,16 @@
 			"defaultProfile": "Par défaut global (tous les profils)",
 			"defaultDescription": "Lorsque le contexte atteint ce pourcentage, il sera automatiquement condensé pour tous les profils sauf s'ils ont des paramètres personnalisés",
 			"profileDescription": "Seuil personnalisé pour ce profil uniquement (remplace le défaut global)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Ce profil hérite du seuil par défaut global ({{threshold}}%)",
 			"usesGlobal": "(utilise global {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -821,6 +821,16 @@
 			"defaultProfile": "वैश्विक डिफ़ॉल्ट (सभी प्रोफ़ाइल)",
 			"defaultDescription": "जब संदर्भ इस प्रतिशत तक पहुंचता है, तो यह सभी प्रोफ़ाइल के लिए स्वचालित रूप से संघनित हो जाएगा जब तक कि उनकी कस्टम सेटिंग्स न हों",
 			"profileDescription": "केवल इस प्रोफ़ाइल के लिए कस्टम सीमा (वैश्विक डिफ़ॉल्ट को ओवरराइड करता है)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "यह प्रोफ़ाइल वैश्विक डिफ़ॉल्ट सीमा को इनहेरिट करता है ({{threshold}}%)",
 			"usesGlobal": "(वैश्विक {{threshold}}% का उपयोग करता है)"
 		},

--- a/webview-ui/src/i18n/locales/id/settings.json
+++ b/webview-ui/src/i18n/locales/id/settings.json
@@ -799,6 +799,16 @@
 			"defaultProfile": "Default Global (semua profil)",
 			"defaultDescription": "Ketika konteks mencapai persentase ini, akan secara otomatis dikondensasi untuk semua profil kecuali mereka memiliki pengaturan kustom",
 			"profileDescription": "Ambang batas kustom untuk profil ini saja (menimpa default global)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Profil ini mewarisi ambang batas default global ({{threshold}}%)",
 			"usesGlobal": "(menggunakan global {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -826,6 +826,16 @@
 			"defaultProfile": "Predefinito globale (tutti i profili)",
 			"defaultDescription": "Quando il contesto raggiunge questa percentuale, verrà automaticamente condensato per tutti i profili a meno che non abbiano impostazioni personalizzate",
 			"profileDescription": "Soglia personalizzata solo per questo profilo (sovrascrive il predefinito globale)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Questo profilo eredita la soglia predefinita globale ({{threshold}}%)",
 			"usesGlobal": "(usa globale {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -826,6 +826,16 @@
 			"defaultProfile": "グローバルデフォルト（全プロファイル）",
 			"defaultDescription": "コンテキストがこの割合に達すると、カスタム設定がない限り、すべてのプロファイルで自動的に圧縮されます",
 			"profileDescription": "このプロファイルのみのカスタムしきい値（グローバルデフォルトを上書き）",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "このプロファイルはグローバルデフォルトしきい値を継承します（{{threshold}}%）",
 			"usesGlobal": "（グローバル {{threshold}}% を使用）"
 		},

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -821,6 +821,16 @@
 			"defaultProfile": "글로벌 기본값 (모든 프로필)",
 			"defaultDescription": "컨텍스트가 이 비율에 도달하면 사용자 정의 설정이 없는 한 모든 프로필에 대해 자동으로 압축됩니다",
 			"profileDescription": "이 프로필만을 위한 사용자 정의 임계값 (글로벌 기본값 재정의)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "이 프로필은 글로벌 기본 임계값을 상속합니다 ({{threshold}}%)",
 			"usesGlobal": "(글로벌 {{threshold}}% 사용)"
 		},

--- a/webview-ui/src/i18n/locales/nl/settings.json
+++ b/webview-ui/src/i18n/locales/nl/settings.json
@@ -831,6 +831,16 @@
 			"defaultProfile": "Globale standaard (alle profielen)",
 			"defaultDescription": "Wanneer de context dit percentage bereikt, wordt het automatisch gecomprimeerd voor alle profielen tenzij ze aangepaste instellingen hebben",
 			"profileDescription": "Aangepaste drempelwaarde alleen voor dit profiel (overschrijft globale standaard)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Dit profiel erft de globale standaard drempelwaarde ({{threshold}}%)",
 			"usesGlobal": "(gebruikt globaal {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -821,6 +821,16 @@
 			"defaultProfile": "Globalny domyślny (wszystkie profile)",
 			"defaultDescription": "Gdy kontekst osiągnie ten procent, zostanie automatycznie skondensowany dla wszystkich profili, chyba że mają niestandardowe ustawienia",
 			"profileDescription": "Niestandardowy próg tylko dla tego profilu (zastępuje globalny domyślny)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Ten profil dziedziczy globalny domyślny próg ({{threshold}}%)",
 			"usesGlobal": "(używa globalnego {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -821,6 +821,16 @@
 			"defaultProfile": "Padrão Global (todos os perfis)",
 			"defaultDescription": "Quando o contexto atingir essa porcentagem, será automaticamente condensado para todos os perfis, a menos que tenham configurações personalizadas",
 			"profileDescription": "Limite personalizado apenas para este perfil (substitui o padrão global)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Este perfil herda o limite padrão global ({{threshold}}%)",
 			"usesGlobal": "(usa global {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/ru/settings.json
+++ b/webview-ui/src/i18n/locales/ru/settings.json
@@ -821,6 +821,16 @@
 			"defaultProfile": "Глобальный по умолчанию (все профили)",
 			"defaultDescription": "Когда контекст достигнет этого процента, он будет автоматически сжат для всех профилей, если у них нет пользовательских настроек",
 			"profileDescription": "Пользовательский порог только для этого профиля (переопределяет глобальный по умолчанию)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Этот профиль наследует глобальный порог по умолчанию ({{threshold}}%)",
 			"usesGlobal": "(использует глобальный {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/sk/settings.json
+++ b/webview-ui/src/i18n/locales/sk/settings.json
@@ -922,6 +922,16 @@
 			"defaultProfile": "Globálne predvolené (všetky profily)",
 			"defaultDescription": "Keď kontext dosiahne toto percento, bude automaticky zhustený pre všetky profily, ak nemajú vlastné nastavenie",
 			"profileDescription": "Vlastná prahová hodnota iba pre tento profil (prepisuje globálne predvolené)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Tento profil dedí globálnu predvolenú prahovú hodnotu ({{threshold}}%)",
 			"usesGlobal": "(používa globálne {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/th/settings.json
+++ b/webview-ui/src/i18n/locales/th/settings.json
@@ -920,6 +920,16 @@
 			"defaultProfile": "ค่าเริ่มต้นสากล (ทุกโปรไฟล์)",
 			"defaultDescription": "เมื่อบริบทถึงเปอร์เซ็นต์นี้ จะถูกย่อโดยอัตโนมัติสำหรับทุกโปรไฟล์ เว้นแต่จะมีการตั้งค่าที่กำหนดเอง",
 			"profileDescription": "เกณฑ์ที่กำหนดเองสำหรับโปรไฟล์นี้เท่านั้น (แทนที่ค่าเริ่มต้นสากล)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "โปรไฟล์นี้สืบทอดเกณฑ์เริ่มต้นสากล ({{threshold}}%)",
 			"usesGlobal": "(ใช้ค่าสากล {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -821,6 +821,16 @@
 			"defaultProfile": "Küresel Varsayılan (tüm profiller)",
 			"defaultDescription": "Bağlam bu yüzdeye ulaştığında, özel ayarları olmadıkça tüm profiller için otomatik olarak sıkıştırılacak",
 			"profileDescription": "Sadece bu profil için özel eşik (küresel varsayılanı geçersiz kılar)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Bu profil küresel varsayılan eşiği miras alır ({{threshold}}%)",
 			"usesGlobal": "(küresel {{threshold}}% kullanır)"
 		},

--- a/webview-ui/src/i18n/locales/uk/settings.json
+++ b/webview-ui/src/i18n/locales/uk/settings.json
@@ -907,6 +907,16 @@
 			"defaultProfile": "Глобальний за замовчуванням (усі профілі)",
 			"defaultDescription": "Коли контекст досягне цього відсотка, він буде автоматично стиснутий для всіх профілів, якщо вони не мають власних налаштувань",
 			"profileDescription": "Власний поріг лише для цього профілю (перевизначає глобальний за замовчуванням)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Цей профіль успадковує глобальний поріг за замовчуванням ({{threshold}}%)",
 			"usesGlobal": "(використовує глобальний {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/vi/settings.json
+++ b/webview-ui/src/i18n/locales/vi/settings.json
@@ -821,6 +821,16 @@
 			"defaultProfile": "Mặc định toàn cục (tất cả hồ sơ)",
 			"defaultDescription": "Khi ngữ cảnh đạt đến tỷ lệ phần trăm này, nó sẽ được tự động nén cho tất cả hồ sơ trừ khi chúng có cài đặt tùy chỉnh",
 			"profileDescription": "Ngưỡng tùy chỉnh chỉ cho hồ sơ này (ghi đè mặc định toàn cục)",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "Hồ sơ này kế thừa ngưỡng mặc định toàn cục ({{threshold}}%)",
 			"usesGlobal": "(sử dụng toàn cục {{threshold}}%)"
 		},

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -821,6 +821,16 @@
 			"defaultProfile": "全局默认（所有配置文件）",
 			"defaultDescription": "当上下文达到此百分比时，将自动为所有配置文件压缩，除非它们有自定义设置",
 			"profileDescription": "仅此配置文件的自定义阈值（覆盖全局默认）",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "此配置文件继承全局默认阈值（{{threshold}}%）",
 			"usesGlobal": "（使用全局 {{threshold}}%）"
 		},

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -841,6 +841,16 @@
 			"defaultProfile": "全域預設（所有設定檔）",
 			"defaultDescription": "當上下文達到此百分比時，除非有自訂設定，所有設定檔都會自動壓縮。",
 			"profileDescription": "僅此設定檔的自訂閾值（覆寫全域預設）",
+			"profileOverrideLabel": "Override for this profile",
+			"currentProfileLabel": "Current profile: {{profile}}",
+			"hardLimitLabel": "Hard limit for this model: {{tokens}} tokens",
+			"mode": {
+				"percent": "% of hard limit",
+				"tokens": "Fixed token limit"
+			},
+			"percentEquivalent": "Equivalent trigger: {{tokens}} tokens",
+			"tokensUnit": "tokens",
+			"profileTokenClamped": "Token threshold was reduced to {{tokens}} to fit this model's hard limit.",
 			"inheritDescription": "此設定檔沿用全域預設閾值（{{threshold}}%）",
 			"usesGlobal": "（使用全域 {{threshold}}%）"
 		},


### PR DESCRIPTION
## Context

Implemented a surgical redesign of condense trigger settings so global behavior stays percent-based, while profile-level behavior can be explicitly overridden per settings-selected profile using either `% of hard limit` or a fixed token threshold.  
This addresses UX confusion around percentage-only control by allowing direct token targeting without changing global semantics.

## Implementation

Added a new `profileCondenseOverrides` setting shape and threaded it through shared types, extension state, provider serialization, webview settings payload flow, and runtime threshold resolution.

Key changes:
- Kept global auto-condense toggle + global percent slider behavior unchanged.
- Removed inline profile selector from condense threshold controls.
- Added a current-profile-only override block with:
  - `Override for this profile` enable checkbox
  - mode selector: `% of hard limit` / `Fixed token limit`
  - percent editor (`5..100`) with computed token equivalent
  - token editor clamped to model effective budget
  - hard-limit/cap display and inline clamp notice when cap decreases
- Implemented centralized runtime threshold resolution so `willManageContext` and `manageContext` share the same logic.
- Preserved hard safety behavior (`prevContextTokens > allowedTokens` still forces context management).
- Kept legacy `profileThresholds` as backward-compatible read fallback; new writes use `profileCondenseOverrides`.
- Added/updated tests for UI behavior, settings payload/change detection, provider round-trip/defaults, and core context trigger behavior.
- Added a changeset for the user-facing feature.

## How to Test

1. In Settings, go to `Context Management`.
2. Verify global auto-condense + global percent slider still behaves as before.
3. Verify there is no profile dropdown inside condense threshold controls.
4. In the new current-profile override block:
   - Toggle override OFF and confirm mode/inputs are disabled.
   - Toggle override ON and confirm mode/inputs are enabled.
5. In `%` mode:
   - Set a percent value and confirm computed token equivalent updates.
6. In `Fixed token limit` mode:
   - Enter a token value and confirm it clamps to the displayed model hard cap/effective budget.
7. Change profile/model from settings-selected profile and confirm:
   - token value auto-clamps when cap decreases
   - inline clamp notice is shown.
8. Validate tests:
   - `cd webview-ui && pnpm test src/components/settings/__tests__/ContextManagementSettings.spec.tsx`
   - `cd webview-ui && pnpm test src/components/settings/__tests__/SettingsView.change-detection.spec.tsx`
   - `cd webview-ui && pnpm test src/components/settings/__tests__/SettingsView.unsaved-changes.spec.tsx`
   - `cd src && pnpm test core/context-management/__tests__/context-management.spec.ts`
   - `cd src && pnpm test core/webview/__tests__/ClineProvider.spec.ts`
9. Repo-level checks:
   - `cd src && pnpm check-types`
   - `cd src && pnpm lint`
   - `pnpm build`

> [!NOTE]
> Research done by myself (mostly) but implementation was **fully** done by AI this time.

I have only tested the basics, so I'm not aware of edge cases.

@abdulrahimpds @mikij @bernaferrari @kevinvandijk 