### PR TITLE
Fix Kilo Quota | OpenRouter error handling and retry flow

### DIFF
--- a/.changeset/slow-pillows-tap.md
+++ b/.changeset/slow-pillows-tap.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Kilo Quota | OpenRouter error handling and retry flow

--- a/src/api/providers/utils/error-handler.ts
+++ b/src/api/providers/utils/error-handler.ts
@@ -11,6 +11,86 @@
 
 import i18n from "../../../i18n/setup"
 
+// kilocode_change start
+const NO_OUTPUT_GENERATED_MESSAGE = "No output generated. Check the stream for errors."
+
+type ExtractedErrorPayload = {
+	message?: string
+	errorDetails?: unknown
+	status?: number
+}
+
+function safeJsonParse(value: string): unknown {
+	try {
+		return JSON.parse(value)
+	} catch {
+		return undefined
+	}
+}
+
+function getFirstNonEmptyString(values: unknown[]): string | undefined {
+	for (const value of values) {
+		if (typeof value === "string" && value.trim().length > 0) {
+			return value.trim()
+		}
+	}
+	return undefined
+}
+
+function extractErrorPayload(payload: unknown): ExtractedErrorPayload {
+	if (payload === null || payload === undefined) {
+		return {}
+	}
+
+	let normalizedPayload: unknown = payload
+	if (typeof normalizedPayload === "string") {
+		const parsed = safeJsonParse(normalizedPayload)
+		if (parsed === undefined) {
+			return { message: normalizedPayload.trim() || undefined }
+		}
+		normalizedPayload = parsed
+	}
+
+	if (typeof normalizedPayload !== "object" || normalizedPayload === null) {
+		return {}
+	}
+
+	const root = normalizedPayload as Record<string, unknown>
+	const nestedError =
+		typeof root.error === "object" && root.error !== null ? (root.error as Record<string, unknown>) : undefined
+
+	const message = getFirstNonEmptyString([
+		nestedError?.message,
+		root.message,
+		root.detail,
+		root.error_description,
+		typeof root.error === "string" ? root.error : undefined,
+	])
+
+	const rawStatus = root.status ?? root.statusCode ?? nestedError?.status ?? nestedError?.statusCode
+	const status = typeof rawStatus === "number" ? rawStatus : undefined
+
+	return {
+		message,
+		errorDetails: nestedError?.details ?? root.errorDetails ?? root.details,
+		status,
+	}
+}
+
+function resolveErrorStatus(error: any, fallbackStatus?: number): number | undefined {
+	if (typeof error?.status === "number") {
+		return error.status
+	}
+	if (typeof error?.statusCode === "number") {
+		return error.statusCode
+	}
+	if (typeof error?.$metadata?.httpStatusCode === "number") {
+		return error.$metadata.httpStatusCode
+	}
+	return fallbackStatus
+}
+// kilocode_change end
+
 /**
  * Handles API provider errors and transforms them into user-friendly messages
  * while preserving important metadata for retry logic and UI display.
@@ -48,14 +128,33 @@ export function handleProviderError(
 
 	if (error instanceof Error) {
 		const anyErr = error as any
-		const msg = anyErr?.error?.metadata?.raw || error.message || ""
+		// kilocode_change start
+		const metadataRaw =
+			typeof anyErr?.error?.metadata?.raw === "string" && anyErr.error.metadata.raw.trim().length > 0
+				? anyErr.error.metadata.raw
+				: undefined
+		const responsePayload = extractErrorPayload(anyErr?.responseBody ?? anyErr?.data)
+		const nestedPayload = extractErrorPayload(anyErr?.cause)
+
+		const nestedMessage = responsePayload.message ?? nestedPayload.message
+		let msg = metadataRaw || nestedMessage || error.message || ""
+
+		// AI SDK can emit generic "No output generated" while nested payload has the real provider failure.
+		if (msg.includes(NO_OUTPUT_GENERATED_MESSAGE) && nestedMessage) {
+			msg = nestedMessage
+		}
+
+		const status = resolveErrorStatus(anyErr, responsePayload.status ?? nestedPayload.status)
+		const errorDetails = anyErr.errorDetails ?? responsePayload.errorDetails ?? nestedPayload.errorDetails
+		// kilocode_change end
 
 		// Log the original error details for debugging
 		console.error(`[${providerName}] API error:`, {
 			message: msg,
 			name: error.name,
 			stack: error.stack,
-			status: anyErr.status,
+			// kilocode_change
+			status,
 		})
 
 		let wrapped: Error
@@ -75,12 +174,14 @@ export function handleProviderError(
 		// Preserve HTTP status and structured details for retry/backoff + UI
 		// These fields are used by Task.backoffAndAnnounce() and ChatRow/ErrorRow
 		// to provide status-aware error messages and handling
-		if (anyErr.status !== undefined) {
-			;(wrapped as any).status = anyErr.status
+		// kilocode_change start
+		if (status !== undefined) {
+			;(wrapped as any).status = status
 		}
-		if (anyErr.errorDetails !== undefined) {
-			;(wrapped as any).errorDetails = anyErr.errorDetails
+		if (errorDetails !== undefined) {
+			;(wrapped as any).errorDetails = errorDetails
 		}
+		// kilocode_change end
 		if (anyErr.code !== undefined) {
 			;(wrapped as any).code = anyErr.code
 		}
@@ -98,9 +199,12 @@ export function handleProviderError(
 
 	// Also try to preserve status for non-Error exceptions (e.g., plain objects with status)
 	const anyErr = error as any
-	if (typeof anyErr?.status === "number") {
-		;(wrapped as any).status = anyErr.status
+	// kilocode_change start
+	const status = resolveErrorStatus(anyErr)
+	if (status !== undefined) {
+		;(wrapped as any).status = status
 	}
+	// kilocode_change end
 
 	return wrapped
 }


### PR DESCRIPTION
## Context

A user reported repeated `API Streaming Failed` / `Unknown API error` failures on Moonshot (`kimi-for-coding`) with details like:

`Provider ended the request: No output generated. Check the stream for errors.`

This PR updates the earlier quota-focused direction and addresses the actual failing path:

- `MoonshotHandler` uses the AI SDK `OpenAICompatibleHandler` stream path.
- AI SDK `error` stream parts were not being escalated into actionable provider errors.
- `Task` does not handle `chunk.type === "error"` in the stream switch, so those parts were effectively dropped.
- Then `await result.usage` could throw generic `"No output generated..."`, which caused downstream UI fallback to unknown/generic error handling.

## Implementation

- Updated `src/api/providers/openai-compatible.ts`:
- Throw immediately when `result.fullStream` emits `part.type === "error"` instead of yielding a non-actionable chunk.
- Wrap full stream iteration and `await result.usage` in `try/catch` and rethrow via:
  - `handleProviderError(error, providerName, { messagePrefix: "streaming" })`
- Preserved existing tool-stream behavior (tool-input accumulation/flush and usage emission on success).

- Hardened `src/api/providers/utils/error-handler.ts`:
- Preserve status from `status`, `statusCode`, and `$metadata.httpStatusCode`.
- Improve message extraction priority:
  - `metadata.raw` -> parsed `responseBody`/`data`/`cause` -> fallback `error.message`.
- If top-level message is generic `"No output generated. Check the stream for errors."`, prefer nested provider message when present.
- Preserve structured `errorDetails` from payloads (`responseBody`/`data`/`cause`) for retry/backoff/UI detail surfaces.

- Added regression coverage:
- `src/api/providers/__tests__/moonshot.spec.ts`
  - stream `error` part with `statusCode` + `responseBody` is normalized and thrown with preserved details.
  - generic usage rejection still surfaces nested provider context.
- `src/api/providers/utils/__tests__/error-handler.spec.ts`
  - preserves `statusCode`.
  - extracts message/details from `responseBody`.
  - falls back to AWS metadata HTTP status when needed.

## How to Test

- Targeted regressions:
- `cd src && pnpm test api/providers/__tests__/moonshot.spec.ts`
- `cd src && pnpm test api/providers/utils/__tests__/error-handler.spec.ts`

- Quality gates:
- `pnpm check-types`
- `pnpm lint`
- `pnpm build`

- Manual scenario:
- Configure Moonshot with `kimi-for-coding`.
- Trigger a request in a quota/credit-limited state (or equivalent provider-side failure).
- Confirm the surfaced error includes actionable provider context (status/message/details), not only generic `"No output generated..."`.

## Validation Performed

- `pnpm check-types` passed.
- `pnpm lint` passed.
- `pnpm build` passed.
- `cd src && pnpm test api/providers/__tests__/moonshot.spec.ts` passed.
- `cd src && pnpm test api/providers/utils/__tests__/error-handler.spec.ts` passed.

> [!NOTE]
> This PR focuses on the Moonshot/AI-SDK stream error path and shared error normalization hardening, not the older OpenRouter/Kilo quota branch.
