### PR TITLE
Make OpenAI-compatible API key optional for local codebase indexing

### DIFF
--- a/.changeset/openai-compatible-codeindex-optional-key.md
+++ b/.changeset/openai-compatible-codeindex-optional-key.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Codebase indexing now allows OpenAI-compatible endpoints without requiring an API key, improving local/self-hosted setup compatibility.

--- a/src/services/code-index/__tests__/manager.spec.ts
+++ b/src/services/code-index/__tests__/manager.spec.ts
@@ -294,6 +294,32 @@ describe("CodeIndexManager - handleSettingsChange regression", () => {
 		})
 	})
 
+	describe("initialize regression", () => {
+		it("should recreate services when manager is partially initialized", async () => {
+			// kilocode_change start - regression for stale _serviceFactory without orchestrator/search service
+			const mockConfigManager = {
+				loadConfiguration: vi.fn().mockResolvedValue({ requiresRestart: false }),
+				isFeatureConfigured: true,
+				isFeatureEnabled: true,
+			}
+			;(manager as any)._configManager = mockConfigManager
+			;(manager as any)._cacheManager = {
+				initialize: vi.fn(),
+				clearCacheFile: vi.fn(),
+			}
+			;(manager as any)._serviceFactory = {}
+			;(manager as any)._orchestrator = undefined
+			;(manager as any)._searchService = undefined
+
+			const recreateServicesSpy = vi.spyOn(manager as any, "_recreateServices").mockResolvedValue(undefined)
+
+			await manager.initialize({} as any)
+
+			expect(recreateServicesSpy).toHaveBeenCalled()
+			// kilocode_change end
+		})
+	})
+
 	describe("embedder validation integration", () => {
 		let mockServiceFactoryInstance: any
 		let mockStateManager: any

--- a/src/services/code-index/__tests__/service-factory.spec.ts
+++ b/src/services/code-index/__tests__/service-factory.spec.ts
@@ -239,7 +239,8 @@ describe("CodeIndexServiceFactory", () => {
 			expect(() => factory.createEmbedder()).toThrow("serviceFactory.openAiCompatibleConfigMissing")
 		})
 
-		it("should throw error when OpenAI Compatible API key is missing", () => {
+		// kilocode_change start
+		it("should pass empty API key when OpenAI Compatible API key is missing", () => {
 			// Arrange
 			const testConfig = {
 				embedderProvider: "openai-compatible",
@@ -251,9 +252,17 @@ describe("CodeIndexServiceFactory", () => {
 			}
 			mockConfigManager.getConfig.mockReturnValue(testConfig as any)
 
-			// Act & Assert
-			expect(() => factory.createEmbedder()).toThrow("serviceFactory.openAiCompatibleConfigMissing")
+			// Act
+			factory.createEmbedder()
+
+			// Assert
+			expect(MockedOpenAICompatibleEmbedder).toHaveBeenCalledWith(
+				"https://api.example.com/v1",
+				"",
+				"text-embedding-3-large",
+			)
 		})
+		// kilocode_change end
 
 		it("should throw error when OpenAI Compatible options are missing", () => {
 			// Arrange

--- a/src/services/code-index/config-manager.ts
+++ b/src/services/code-index/config-manager.ts
@@ -20,7 +20,7 @@ export class CodeIndexConfigManager {
 	private modelDimension?: number
 	private openAiOptions?: ApiHandlerOptions
 	private ollamaOptions?: ApiHandlerOptions
-	private openAiCompatibleOptions?: { baseUrl: string; apiKey: string }
+	private openAiCompatibleOptions?: { baseUrl: string; apiKey?: string } // kilocode_change
 	private geminiOptions?: { apiKey: string }
 	private mistralOptions?: { apiKey: string }
 	private vercelAiGatewayOptions?: { apiKey: string }
@@ -202,13 +202,14 @@ export class CodeIndexConfigManager {
 			ollamaBaseUrl: codebaseIndexEmbedderBaseUrl,
 		}
 
-		this.openAiCompatibleOptions =
-			openAiCompatibleBaseUrl && openAiCompatibleApiKey
-				? {
-						baseUrl: openAiCompatibleBaseUrl,
-						apiKey: openAiCompatibleApiKey,
-					}
-				: undefined
+		// kilocode_change start
+		this.openAiCompatibleOptions = openAiCompatibleBaseUrl
+			? {
+					baseUrl: openAiCompatibleBaseUrl,
+					apiKey: openAiCompatibleApiKey,
+				}
+			: undefined
+		// kilocode_change end
 
 		this.geminiOptions = geminiApiKey ? { apiKey: geminiApiKey } : undefined
 		this.mistralOptions = mistralApiKey ? { apiKey: mistralApiKey } : undefined
@@ -235,7 +236,7 @@ export class CodeIndexConfigManager {
 			modelDimension?: number
 			openAiOptions?: ApiHandlerOptions
 			ollamaOptions?: ApiHandlerOptions
-			openAiCompatibleOptions?: { baseUrl: string; apiKey: string }
+			openAiCompatibleOptions?: { baseUrl: string; apiKey?: string } // kilocode_change
 			geminiOptions?: { apiKey: string }
 			mistralOptions?: { apiKey: string }
 			vercelAiGatewayOptions?: { apiKey: string }
@@ -327,9 +328,9 @@ export class CodeIndexConfigManager {
 			return !!(ollamaBaseUrl && qdrantUrl)
 		} else if (this.embedderProvider === "openai-compatible") {
 			const baseUrl = this.openAiCompatibleOptions?.baseUrl
-			const apiKey = this.openAiCompatibleOptions?.apiKey
 			const qdrantUrl = this.qdrantUrl
-			const isConfigured = !!(baseUrl && apiKey && qdrantUrl)
+			// kilocode_change
+			const isConfigured = !!(baseUrl && qdrantUrl)
 			return isConfigured
 		} else if (this.embedderProvider === "gemini") {
 			const apiKey = this.geminiOptions?.apiKey

--- a/src/services/code-index/interfaces/config.ts
+++ b/src/services/code-index/interfaces/config.ts
@@ -15,7 +15,7 @@ export interface CodeIndexConfig {
 	modelDimension?: number // Generic dimension property for all providers
 	openAiOptions?: ApiHandlerOptions
 	ollamaOptions?: ApiHandlerOptions
-	openAiCompatibleOptions?: { baseUrl: string; apiKey: string }
+	openAiCompatibleOptions?: { baseUrl: string; apiKey?: string } // kilocode_change
 	geminiOptions?: { apiKey: string }
 	mistralOptions?: { apiKey: string }
 	vercelAiGatewayOptions?: { apiKey: string }

--- a/src/services/code-index/service-factory.ts
+++ b/src/services/code-index/service-factory.ts
@@ -69,14 +69,16 @@ export class CodeIndexServiceFactory {
 				ollamaNumCtx: config.modelDimension, // kilocode_change
 			})
 		} else if (provider === "openai-compatible") {
-			if (!config.openAiCompatibleOptions?.baseUrl || !config.openAiCompatibleOptions?.apiKey) {
+			// kilocode_change start
+			if (!config.openAiCompatibleOptions?.baseUrl) {
 				throw new Error(t("embeddings:serviceFactory.openAiCompatibleConfigMissing"))
 			}
 			return new OpenAICompatibleEmbedder(
 				config.openAiCompatibleOptions.baseUrl,
-				config.openAiCompatibleOptions.apiKey,
+				config.openAiCompatibleOptions.apiKey ?? "",
 				config.modelId,
 			)
+			// kilocode_change end
 		} else if (provider === "gemini") {
 			if (!config.geminiOptions?.apiKey) {
 				throw new Error(t("embeddings:serviceFactory.geminiConfigMissing"))

--- a/webview-ui/src/components/chat/CodeIndexPopover.tsx
+++ b/webview-ui/src/components/chat/CodeIndexPopover.tsx
@@ -101,7 +101,9 @@ interface LocalCodeIndexSettings {
 }
 
 // Validation schema for codebase index settings
-const createValidationSchema = (provider: EmbedderProvider, t: any) => {
+// kilocode_change start
+export const createValidationSchema = (provider: EmbedderProvider, t: any) => {
+// kilocode_change end
 	const baseSchema = z.object({
 		codebaseIndexEnabled: z.boolean(),
 		codebaseIndexQdrantUrl: z
@@ -134,19 +136,19 @@ const createValidationSchema = (provider: EmbedderProvider, t: any) => {
 			})
 
 		case "openai-compatible":
+			// kilocode_change start
 			return baseSchema.extend({
 				codebaseIndexOpenAiCompatibleBaseUrl: z
 					.string()
 					.min(1, t("settings:codeIndex.validation.baseUrlRequired"))
 					.url(t("settings:codeIndex.validation.invalidBaseUrl")),
-				codebaseIndexOpenAiCompatibleApiKey: z
-					.string()
-					.min(1, t("settings:codeIndex.validation.apiKeyRequired")),
+				codebaseIndexOpenAiCompatibleApiKey: z.string().optional(),
 				codebaseIndexEmbedderModelId: z.string().min(1, t("settings:codeIndex.validation.modelIdRequired")),
 				codebaseIndexEmbedderModelDimension: z
 					.number()
 					.min(1, t("settings:codeIndex.validation.modelDimensionRequired")),
 			})
+			// kilocode_change end
 
 		case "gemini":
 			return baseSchema.extend({

--- a/webview-ui/src/components/chat/__tests__/CodeIndexPopover.validation.spec.ts
+++ b/webview-ui/src/components/chat/__tests__/CodeIndexPopover.validation.spec.ts
@@ -1,0 +1,51 @@
+// kilocode_change - new file
+import { createValidationSchema } from "../CodeIndexPopover"
+
+const t = (key: string) => key
+
+const buildOpenAiCompatiblePayload = (overrides: Record<string, unknown> = {}) => ({
+	codebaseIndexEnabled: true,
+	codebaseIndexQdrantUrl: "http://localhost:6333",
+	codebaseIndexOpenAiCompatibleBaseUrl: "http://localhost:8080",
+	codebaseIndexOpenAiCompatibleApiKey: "",
+	codebaseIndexEmbedderModelId: "text-embedding-3-small",
+	codebaseIndexEmbedderModelDimension: 1536,
+	...overrides,
+})
+
+describe("CodeIndexPopover openai-compatible validation schema", () => {
+	it("accepts empty API key", () => {
+		const schema = createValidationSchema("openai-compatible", t)
+		const result = schema.safeParse(buildOpenAiCompatiblePayload())
+
+		expect(result.success).toBe(true)
+	})
+
+	it("rejects missing base URL", () => {
+		const schema = createValidationSchema("openai-compatible", t)
+		const result = schema.safeParse(
+			buildOpenAiCompatiblePayload({
+				codebaseIndexOpenAiCompatibleBaseUrl: "",
+			}),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error?.issues.some((issue) => issue.path[0] === "codebaseIndexOpenAiCompatibleBaseUrl")).toBe(
+			true,
+		)
+	})
+
+	it("rejects malformed base URL", () => {
+		const schema = createValidationSchema("openai-compatible", t)
+		const result = schema.safeParse(
+			buildOpenAiCompatiblePayload({
+				codebaseIndexOpenAiCompatibleBaseUrl: "not-a-valid-url",
+			}),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error?.issues.some((issue) => issue.path[0] === "codebaseIndexOpenAiCompatibleBaseUrl")).toBe(
+			true,
+		)
+	})
+})


### PR DESCRIPTION
## Context

This PR is triggered by a real user scenario discussed in Discord. With **Codebase Indexing** + **OpenAI Compatible** on local/self-hosted endpoints, leaving the API key empty caused broken runtime behavior even after settings were saved.

The reported symptoms were:

- indexing did not start when key was empty
- no embedding requests reached LM Studio
- UI state could show indexing as disabled/standby despite enabled settings
- runtime error: `CodeIndexManager not initialized. Call initialize() first.`

There were also activation/runtime messages in VS Code output (`popoutButtonClicked already registered`, missing activity bar container), but those are unrelated noise and not the indexing root cause.

## Implementation

- UI/config behavior remains API-key-optional for OpenAI-compatible setups.
- OpenAI-compatible config modeling keeps `apiKey` optional, while requiring valid base URL + other required fields.
- OpenAI-compatible configuration is treated as configured when:
  - `baseUrl` is present
  - `qdrantUrl` is present
  - API key may be empty
- Service factory for OpenAI-compatible now:
  - still throws when options/base URL are missing
  - does not throw when API key is empty
  - passes empty string to embedder when unset
- OpenAI-compatible embedder now:
  - accepts empty/undefined API key
  - uses fallback `"EMPTY"` for SDK constructor compatibility
  - in direct full-endpoint fetch mode, sends auth headers with real key if present, otherwise fallback token (`"EMPTY"`) so keyless local providers that still expect auth-shaped headers work
- Fixed code-index manager lifecycle regression:
  - service recreation is now triggered when manager is partially initialized, not only when `_serviceFactory` is missing
  - `_serviceFactory` is assigned only after successful full service recreation
  - prevents half-initialized state that produced `CodeIndexManager not initialized`
- Fixed webview indexing flow:
  - always calls `initialize()` before checking `isFeatureEnabled/isFeatureConfigured` on save/start paths
  - avoids stale flag checks and incorrect standby/disabled UI state
- Regression-focused tests were added/updated across:
  - embedder behavior and header behavior for empty API key
  - service factory contract for optional key
  - manager partial-initialization lifecycle regression
  - existing config/UI validation coverage remains aligned
- Added changeset for patch release notes.

## How to Test

- Reproduce the initiating scenario:
  1. Open Codebase Indexing settings.
  2. Set Embedder Provider to **OpenAI Compatible**.
  3. Set Base URL to local LM Studio endpoint (for example `http://127.0.0.1:1234/v1/embeddings`).
  4. Leave API Key empty.
  5. Save and start indexing.
  6. Verify indexing transitions out of standby, no `CodeIndexManager not initialized` error appears, and LM Studio receives `/v1/embeddings` requests.
- Verify guardrails still hold:
  - Missing Base URL still fails validation/configuration.
  - Malformed Base URL still fails validation.
- Verify behavior split:
  - Keyless local endpoint: indexing starts and embedding calls are sent.
  - Key-required endpoint: providing API key continues to work normally.
- Run focused automated tests:
  - `cd src && pnpm test services/code-index/embedders/__tests__/openai-compatible.spec.ts`
  - `cd src && pnpm test services/code-index/__tests__/manager.spec.ts`
  - `cd src && pnpm test services/code-index/__tests__/service-factory.spec.ts`
  - `cd src && pnpm test services/code-index/__tests__/config-manager.spec.ts`
  - `cd webview-ui && pnpm test src/components/chat/__tests__/CodeIndexPopover.validation.spec.ts`
  - `cd webview-ui && pnpm test src/components/chat/__tests__/CodeIndexPopover.spec.tsx`
- Run full quality gates:
  - `cd src && pnpm test`
  - `pnpm lint`
  - `pnpm check-types`
  - `pnpm build`
