### PR TITLE
Add banner and pre-release extension info

### DIFF
--- a/apps/kilocode-docs/components/TopNav.tsx
+++ b/apps/kilocode-docs/components/TopNav.tsx
@@ -332,6 +332,16 @@ export function TopNav({ onMobileMenuToggle, isMobileMenuOpen = false, showMobil
 				</div>
 			</div>
 
+			{/* Announcement banner */}
+			<div className="announcement-banner">
+				<p>
+					We're{" "}
+					<Link href="https://blog.kilo.ai/p/kilo-cli">replatforming our extensions on the new Kilo CLI</Link>
+					. Contribute to the new CLI and pre-release extensions at{" "}
+					<Link href="https://github.com/Kilo-Org/kilo">Kilo-Org/kilo</Link>.
+				</p>
+			</div>
+
 			<style jsx>{`
 				.top-header {
 					position: fixed;
@@ -516,6 +526,35 @@ export function TopNav({ onMobileMenuToggle, isMobileMenuOpen = false, showMobil
 
 					.right-actions {
 						gap: 0.5rem;
+					}
+				}
+
+				.announcement-banner {
+					background: #1a1a18;
+					color: #a3a3a2;
+					padding: 0.5rem 1rem;
+					text-align: center;
+					font-size: 0.875rem;
+					border-bottom: 1px solid #3f3f3f;
+				}
+
+				.announcement-banner p {
+					margin: 0;
+				}
+
+				.announcement-banner :global(a) {
+					color: #f8f674;
+					text-decoration: underline;
+					text-underline-offset: 2px;
+				}
+
+				.announcement-banner :global(a:hover) {
+					color: #ffff8d;
+				}
+
+				@media (max-width: 768px) {
+					.announcement-banner {
+						font-size: 0.8rem;
 					}
 				}
 			`}</style>

--- a/apps/kilocode-docs/pages/getting-started/installing.md
+++ b/apps/kilocode-docs/pages/getting-started/installing.md
@@ -45,6 +45,43 @@ Get started with Kilo Code by installing it on your preferred platform. Choose y
 {% /tab %}
 {% /tabs %}
 
+## Pre-Release Extension
+
+{% callout type="info" %}
+We're rebuilding Kilo Code from the ground up on the new [Kilo CLI](https://github.com/Kilo-Org/kilo). The pre-release extension is available for users who want to try the latest architecture and provide feedback, and don't mind some missing features and rough edges.
+{% /callout %}
+
+The pre-release extension is a complete rebuild featuring:
+
+- A new Solid.js-based UI
+- Deep integration with the Kilo CLI backend
+- Improved session management and model switching
+
+### Current Status
+
+This is an early pre-release. Core features like chat, markdown rendering, authentication, and model/mode switching are working. Some features from the stable extension are still being implemented.
+
+For the full feature status, see the [feature parity tracking document](https://github.com/Kilo-Org/kilo/blob/main/packages/kilo-vscode/docs/opencode-migration-plan.md).
+
+### Installing the Pre-Release
+
+1. Open VS Code
+2. Go to Extensions (`Ctrl+Shift+X` / `Cmd+Shift+X`)
+3. Search for "Kilo Code"
+4. Click the dropdown arrow next to **Install** and select **Install Pre-Release Version**
+
+### Switching Back to Stable
+
+If you need to return to the stable version:
+
+1. Open Extensions in VS Code
+2. Find Kilo Code
+3. Click the dropdown and select **Switch to Release Version**
+
+### Feedback and Issues
+
+Report issues or provide feedback in the [Kilo-Org/kilo repository](https://github.com/Kilo-Org/kilo/issues).
+
 ## Manual Installations
 
 ### Open VSX Registry

--- a/apps/kilocode-docs/public/globals.css
+++ b/apps/kilocode-docs/public/globals.css
@@ -4,7 +4,7 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 :root {
-	--top-nav-height: 105px;
+	--top-nav-height: 141px; /* 105px nav + 36px banner */
 	--border-color: #dce6e9;
 	--bg-color: theme(colors.zinc.50);
 	--bg-secondary: theme(colors.zinc.100);
@@ -369,7 +369,7 @@ pre[class*="language-"] {
 
 @media (max-width: 768px) {
 	:root {
-		--top-nav-height: 60px;
+		--top-nav-height: 116px; /* 60px nav + 56px banner */
 	}
 
 	/* Hide desktop sidenav, show via mobile toggle */


### PR DESCRIPTION
Adds a banner to direct potential contributors to the new repository and more broadly announce the change. Also includes a new section about how to try the new extension, and revert page.

<img width="1218" height="169" alt="image" src="https://github.com/user-attachments/assets/d057fcb4-cbbb-4e41-a9b5-2e500195585e" />


<img width="702" height="513" alt="image" src="https://github.com/user-attachments/assets/c803c60e-7bb3-48f0-8347-50bd24db20cc" />
