### PR TITLE
fix(moonshot): allow full model list on coding endpoint

### DIFF
--- a/.changeset/clever-moles-smile.md
+++ b/.changeset/clever-moles-smile.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Moonshot coding endpoint model selection so it includes all Moonshot models while keeping `kimi-for-coding` hidden on non-coding endpoints.

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -344,9 +344,8 @@ const ApiOptions = ({
 				? Object.fromEntries(
 						Object.entries(filteredModels).filter(
 							([modelId]) =>
-								apiConfiguration.moonshotBaseUrl === "https://api.kimi.com/coding/v1"
-									? modelId === "kimi-for-coding"
-									: modelId !== "kimi-for-coding",
+								modelId !== "kimi-for-coding" ||
+								apiConfiguration.moonshotBaseUrl === "https://api.kimi.com/coding/v1",
 						),
 					)
 				: filteredModels

--- a/webview-ui/src/components/settings/__tests__/ApiOptions.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiOptions.spec.tsx
@@ -390,7 +390,7 @@ describe("ApiOptions", () => {
 		})
 
 		expect(screen.getByRole("option", { name: "kimi-for-coding" })).toBeInTheDocument()
-		expect(screen.queryByRole("option", { name: "kimi-k2-thinking" })).not.toBeInTheDocument() // kilocode_change
+		expect(screen.getByRole("option", { name: "kimi-k2-thinking" })).toBeInTheDocument() // kilocode_change
 	})
 
 	it("shows diff settings, temperature and rate limit controls by default", () => {

--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
@@ -441,7 +441,7 @@ describe("useSelectedModel", () => {
 		})
 
 		// kilocode_change start
-		it("forces kimi-for-coding when Moonshot coding endpoint is selected with a non-coding model", () => {
+		it("keeps non-coding model when Moonshot coding endpoint is selected", () => {
 			const apiConfiguration: ProviderSettings = {
 				apiProvider: "moonshot",
 				apiModelId: "kimi-k2-thinking",
@@ -451,7 +451,7 @@ describe("useSelectedModel", () => {
 			const wrapper = createWrapper()
 			const { result } = renderHook(() => useSelectedModel(apiConfiguration), { wrapper })
 
-			expect(result.current.id).toBe("kimi-for-coding")
+			expect(result.current.id).toBe("kimi-k2-thinking")
 		})
 		// kilocode_change end
 

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -321,9 +321,8 @@ function getSelectedModel({
 			const isKimiCodingEndpoint = apiConfiguration.moonshotBaseUrl === "https://api.kimi.com/coding/v1"
 			const firstNonCodingMoonshotModelId =
 				Object.keys(moonshotModels).find((modelId) => modelId !== "kimi-for-coding") ?? moonshotDefaultModelId
-			const id = isKimiCodingEndpoint
-				? "kimi-for-coding"
-				: configuredId === "kimi-for-coding"
+			const id =
+				configuredId === "kimi-for-coding" && !isKimiCodingEndpoint
 					? firstNonCodingMoonshotModelId
 					: configuredId
 			// kilocode_change end


### PR DESCRIPTION

PR #5722 was too aggressive with limiting the selection of the `kimi-for-coding` model on Moonshot endpoints. Non-coding Moonshot endpoints should exclude `kimi-for-coding` (correct behavior by PR 5722), but the Moonshot coding endpoint supports more than just `kimi-for-coding` and should have the full Moonshot model list available to it (PR 5722 excludes all models **_except_** `kimi-for-coding` for the Moonshot coding endpoint, which is wrong behavior).

This PR removes the limitation of the Moonshot coding endpoint to only `kimi-for-coding`.