### PR TITLE
fix(agent-runtime): fix doubled path in VSCode.applyEdit.spec.ts

### DIFF
--- a/packages/agent-runtime/src/host/__tests__/VSCode.applyEdit.spec.ts
+++ b/packages/agent-runtime/src/host/__tests__/VSCode.applyEdit.spec.ts
@@ -4,7 +4,7 @@ import path from "path"
 import { createVSCodeAPIMock, Uri, WorkspaceEdit, Position, Range } from "../VSCode.js"
 
 describe("WorkspaceAPI.applyEdit", () => {
-	const tempDir = path.join(process.cwd(), "packages/agent-runtime/src/host/__tests__/__tmp__")
+	const tempDir = path.join(__dirname, "__tmp__")
 	const filePath = path.join(tempDir, "apply-edit.txt")
 
 	beforeEach(() => {


### PR DESCRIPTION
## Summary

Fixes 2 test failures in `@kilocode/agent-runtime` caused by a doubled directory path in `VSCode.applyEdit.spec.ts`.

## Problem

The test constructs a temp directory path using `process.cwd()` + a relative path that includes the package directory:

```typescript
const tempDir = path.join(process.cwd(), "packages/agent-runtime/src/host/__tests__/__tmp__")
```

When vitest runs from the package root (`/workspaces/kilocode/packages/agent-runtime`), this produces a doubled path:

```
.../packages/agent-runtime/packages/agent-runtime/src/host/__tests__/__tmp__/apply-edit.txt
```

Two tests fail with `ENOENT`:
- `handles multi-line replacements without duplicating tail lines`
- `handles mixed line endings correctly`

## Fix

One-line change — use `__dirname` (resolves to the test file's directory) instead of `process.cwd()` + relative path:

```diff
- const tempDir = path.join(process.cwd(), "packages/agent-runtime/src/host/__tests__/__tmp__")
+ const tempDir = path.join(__dirname, "__tmp__")
```

## Test Results

| Test | Before | After |
|------|--------|-------|
| `VSCode.applyEdit.spec.ts` (src) | 2 FAIL | 4 PASS |
| `VSCode.applyEdit.spec.js` (dist) | 2 FAIL | 4 PASS |
| `@kilocode/agent-runtime` total | 110 pass, 2 fail | **112 pass, 0 fail** |

Verified on both source (`.ts`) and compiled (`.js`) test files after rebuild.