### PR TITLE
feat(minimax): add support for model MiniMax-M2.5, MiniMax-M2.5-highspeed and MiniMax-M2.1-highspeed in MiniMax provider

### DIFF
--- a/.changeset/add-minimax-models.md
+++ b/.changeset/add-minimax-models.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Add MiniMax-M2.5, MiniMax-M2.5-highspeed and MiniMax-M2.1-highspeed models

--- a/packages/types/src/providers/minimax.ts
+++ b/packages/types/src/providers/minimax.ts
@@ -91,7 +91,7 @@ export const minimaxModels = {
 		cacheWritesPrice: 0.375,
 		cacheReadsPrice: 0.03,
 		description:
-			"MiniMax M2.5 builds on M2.1 with improved overall performance for agentic coding tasks and significantly faster response times.",
+			"MiniMax M2.5 builds on M2.1 with improved overall performance for agentic coding tasks and the same response times.",
 	},
 	"MiniMax-M2.5-highspeed": {
 		maxTokens: 16_384,

--- a/packages/types/src/providers/minimax.ts
+++ b/packages/types/src/providers/minimax.ts
@@ -59,6 +59,57 @@ export const minimaxModels = {
 		description:
 			"MiniMax M2.1 builds on M2 with improved overall performance for agentic coding tasks and significantly faster response times.",
 	},
+	"MiniMax-M2.1-highspeed": {
+		maxTokens: 16_384,
+		contextWindow: 192_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		includedTools: ["search_and_replace"],
+		excludedTools: ["apply_diff"],
+		preserveReasoning: true,
+		inputPrice: 0.6,
+		outputPrice: 2.4,
+		cacheWritesPrice: 0.375,
+		cacheReadsPrice: 0.06,
+		description:
+			"(high-speed) MiniMax M2.1 builds on M2 with improved overall performance for agentic coding tasks and significantly faster response times.",
+	},
+	"MiniMax-M2.5": {
+		maxTokens: 16_384,
+		contextWindow: 192_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		includedTools: ["search_and_replace"],
+		excludedTools: ["apply_diff"],
+		preserveReasoning: true,
+		inputPrice: 0.3,
+		outputPrice: 1.2,
+		cacheWritesPrice: 0.375,
+		cacheReadsPrice: 0.03,
+		description:
+			"MiniMax M2.5 builds on M2.1 with improved overall performance for agentic coding tasks and significantly faster response times.",
+	},
+	"MiniMax-M2.5-highspeed": {
+		maxTokens: 16_384,
+		contextWindow: 192_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		includedTools: ["search_and_replace"],
+		excludedTools: ["apply_diff"],
+		preserveReasoning: true,
+		inputPrice: 0.6,
+		outputPrice: 2.4,
+		cacheWritesPrice: 0.375,
+		cacheReadsPrice: 0.06,
+		description:
+			"(high-speed) MiniMax M2.5 builds on M2.1 with improved overall performance for agentic coding tasks and significantly faster response times.",
+	},
 } as const satisfies Record<string, ModelInfo>
 
 export const minimaxDefaultModelInfo: ModelInfo = minimaxModels[minimaxDefaultModelId]

--- a/packages/types/src/providers/minimax.ts
+++ b/packages/types/src/providers/minimax.ts
@@ -72,7 +72,7 @@ export const minimaxModels = {
 		inputPrice: 0.6,
 		outputPrice: 2.4,
 		cacheWritesPrice: 0.375,
-		cacheReadsPrice: 0.06,
+		cacheReadsPrice: 0.03,
 		description:
 			"(high-speed) MiniMax M2.1 builds on M2 with improved overall performance for agentic coding tasks and significantly faster response times.",
 	},
@@ -106,7 +106,7 @@ export const minimaxModels = {
 		inputPrice: 0.6,
 		outputPrice: 2.4,
 		cacheWritesPrice: 0.375,
-		cacheReadsPrice: 0.06,
+		cacheReadsPrice: 0.03,
 		description:
 			"(high-speed) MiniMax M2.5 builds on M2.1 with improved overall performance for agentic coding tasks and significantly faster response times.",
 	},

--- a/src/api/providers/__tests__/minimax.spec.ts
+++ b/src/api/providers/__tests__/minimax.spec.ts
@@ -118,6 +118,60 @@ describe("MiniMaxHandler", () => {
 			expect(model.info.cacheWritesPrice).toBe(0.375)
 			expect(model.info.cacheReadsPrice).toBe(0.03)
 		})
+
+		it("should return MiniMax-M2.1-highspeed model with correct configuration", () => {
+			const testModelId: MinimaxModelId = "MiniMax-M2.1-highspeed"
+			const handlerWithModel = new MiniMaxHandler({
+				apiModelId: testModelId,
+				minimaxApiKey: "test-minimax-api-key",
+			})
+			const model = handlerWithModel.getModel()
+			expect(model.id).toBe(testModelId)
+			expect(model.info).toEqual(minimaxModels[testModelId])
+			expect(model.info.contextWindow).toBe(192_000)
+			expect(model.info.maxTokens).toBe(16_384)
+			expect(model.info.supportsPromptCache).toBe(true)
+			expect(model.info.cacheWritesPrice).toBe(0.375)
+			expect(model.info.cacheReadsPrice).toBe(0.03)
+			expect(model.info.inputPrice).toBe(0.6)
+			expect(model.info.outputPrice).toBe(2.4)
+		})
+
+		it("should return MiniMax-M2.5 model with correct configuration", () => {
+			const testModelId: MinimaxModelId = "MiniMax-M2.5"
+			const handlerWithModel = new MiniMaxHandler({
+				apiModelId: testModelId,
+				minimaxApiKey: "test-minimax-api-key",
+			})
+			const model = handlerWithModel.getModel()
+			expect(model.id).toBe(testModelId)
+			expect(model.info).toEqual(minimaxModels[testModelId])
+			expect(model.info.contextWindow).toBe(192_000)
+			expect(model.info.maxTokens).toBe(16_384)
+			expect(model.info.supportsPromptCache).toBe(true)
+			expect(model.info.cacheWritesPrice).toBe(0.375)
+			expect(model.info.cacheReadsPrice).toBe(0.03)
+			expect(model.info.inputPrice).toBe(0.3)
+			expect(model.info.outputPrice).toBe(1.2)
+		})
+
+		it("should return MiniMax-M2.5-highspeed model with correct configuration", () => {
+			const testModelId: MinimaxModelId = "MiniMax-M2.5-highspeed"
+			const handlerWithModel = new MiniMaxHandler({
+				apiModelId: testModelId,
+				minimaxApiKey: "test-minimax-api-key",
+			})
+			const model = handlerWithModel.getModel()
+			expect(model.id).toBe(testModelId)
+			expect(model.info).toEqual(minimaxModels[testModelId])
+			expect(model.info.contextWindow).toBe(192_000)
+			expect(model.info.maxTokens).toBe(16_384)
+			expect(model.info.supportsPromptCache).toBe(true)
+			expect(model.info.cacheWritesPrice).toBe(0.375)
+			expect(model.info.cacheReadsPrice).toBe(0.03)
+			expect(model.info.inputPrice).toBe(0.6)
+			expect(model.info.outputPrice).toBe(2.4)
+		})
 	})
 
 	describe("China MiniMax", () => {
@@ -400,6 +454,42 @@ describe("MiniMaxHandler", () => {
 			expect(model.supportsPromptCache).toBe(true)
 			expect(model.inputPrice).toBe(0.3)
 			expect(model.outputPrice).toBe(1.2)
+			expect(model.cacheWritesPrice).toBe(0.375)
+			expect(model.cacheReadsPrice).toBe(0.03)
+		})
+
+		it("should correctly configure MiniMax-M2.1-highspeed model properties", () => {
+			const model = minimaxModels["MiniMax-M2.1-highspeed"]
+			expect(model.maxTokens).toBe(16_384)
+			expect(model.contextWindow).toBe(192_000)
+			expect(model.supportsImages).toBe(false)
+			expect(model.supportsPromptCache).toBe(true)
+			expect(model.inputPrice).toBe(0.6)
+			expect(model.outputPrice).toBe(2.4)
+			expect(model.cacheWritesPrice).toBe(0.375)
+			expect(model.cacheReadsPrice).toBe(0.03)
+		})
+
+		it("should correctly configure MiniMax-M2.5 model properties", () => {
+			const model = minimaxModels["MiniMax-M2.5"]
+			expect(model.maxTokens).toBe(16_384)
+			expect(model.contextWindow).toBe(192_000)
+			expect(model.supportsImages).toBe(false)
+			expect(model.supportsPromptCache).toBe(true)
+			expect(model.inputPrice).toBe(0.3)
+			expect(model.outputPrice).toBe(1.2)
+			expect(model.cacheWritesPrice).toBe(0.375)
+			expect(model.cacheReadsPrice).toBe(0.03)
+		})
+
+		it("should correctly configure MiniMax-M2.5-highspeed model properties", () => {
+			const model = minimaxModels["MiniMax-M2.5-highspeed"]
+			expect(model.maxTokens).toBe(16_384)
+			expect(model.contextWindow).toBe(192_000)
+			expect(model.supportsImages).toBe(false)
+			expect(model.supportsPromptCache).toBe(true)
+			expect(model.inputPrice).toBe(0.6)
+			expect(model.outputPrice).toBe(2.4)
 			expect(model.cacheWritesPrice).toBe(0.375)
 			expect(model.cacheReadsPrice).toBe(0.03)
 		})


### PR DESCRIPTION
## Context

This is unofficial support (not from the MiniMax team) for some new models, provided by adding entries to the configuration file.

## Implementation

It seems there are no fundamental changes relative to prior models, so I just followed the previous confs. This may be optimized later by the official team.

## Screenshots

| before | after |
| ------ | ----- |
|     <img width="427" height="218" alt="image" src="https://github.com/user-attachments/assets/f8f9e3e5-abb1-4ce1-9d74-49b2796849f7" />   |    <img width="404" height="297" alt="image" src="https://github.com/user-attachments/assets/41885e8f-8840-47f2-8e38-c8549e89c382" />  |




## How to Test

- Activate these 3 new models through the MiniMax provider
- And they should work fine.

## Get in Touch

Discord handle: vendetta65536
