### PR TITLE
fix: remove duplicate text yield in OpenAI non-streaming mode

### DIFF
--- a/.changeset/ready-taxis-hide.md
+++ b/.changeset/ready-taxis-hide.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix duplicate text output when using OpenAI-compatible providers with streaming disabled.

--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -148,11 +148,11 @@ describe("OpenAiHandler", () => {
 			}
 
 			expect(chunks.length).toBeGreaterThan(0)
-			const textChunk = chunks.find((chunk) => chunk.type === "text")
+			const textChunks = chunks.filter((chunk) => chunk.type === "text")
 			const usageChunk = chunks.find((chunk) => chunk.type === "usage")
 
-			expect(textChunk).toBeDefined()
-			expect(textChunk?.text).toBe("Test response")
+			expect(textChunks).toHaveLength(1)
+			expect(textChunks[0]?.text).toBe("Test response")
 			expect(usageChunk).toBeDefined()
 			expect(usageChunk?.inputTokens).toBe(10)
 			expect(usageChunk?.outputTokens).toBe(5)

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -291,11 +291,6 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 				}
 			}
 
-			yield {
-				type: "text",
-				text: message?.content || "",
-			}
-
 			yield this.processUsageMetrics(response.usage, modelInfo)
 		}
 	}


### PR DESCRIPTION
## Context

Fix duplicate text output when using OpenAI-compatible providers with streaming disabled. In non-streaming mode, `OpenAiHandler.createMessage()` yielded the response text twice — once in the `kilocode_change` block (added for reasoning support) and again in the original unconditional yield. Since `Task.ts` accumulates text via `assistantMessage += chunk.text`, this caused the entire response to appear doubled for users.

## Implementation

Removed the redundant `yield { type: "text", text: message?.content || "" }` at lines 294-297 of `src/api/providers/openai.ts`. The `kilocode_change` block at lines 272-277 already correctly yields the text content when `message.content` is truthy, so the second yield was purely duplicative.

Also updated the test for `"should handle non-streaming mode"` in `src/api/providers/__tests__/openai.spec.ts` to use `.filter()` + `.toHaveLength(1)` instead of `.find()`. The original test used `.find()` which only returns the first match, masking the fact that two text chunks were being produced.

## Screenshots

| before | after |
| ------ | ----- |
| <img width="1200" height="1999" alt="bug-reproduction" src="https://github.com/user-attachments/assets/176cf9d1-6f3a-4db7-982a-e85f1d85cf68" /> | <img width="1009" height="869" alt="bug-fix-verified" src="https://github.com/user-attachments/assets/7984e5f5-fb4d-4fb8-965f-154c25ed9f75" /> |

The test I actually pushed is a little cleaner but this should be a good enough illustration.

## How to Test

- Configure an OpenAI-compatible provider (e.g. OpenAI, OpenRouter, or any OpenAI-compatible API)
- Disable streaming in the provider settings (`openAiStreamingEnabled: false`)
- Send a message and observe the response — it should appear once, not duplicated
- Alternatively, run the unit test directly:
  ```
  npx vitest run src/api/providers/__tests__/openai.spec.ts -t "should handle non-streaming mode"
  ```
  The test asserts exactly 1 text chunk is yielded (was 2 before the fix)

## Get in Touch
@ evan.discorb