### PR TITLE
docs(mcp): fix CLI config path to ~/.config/kilo/opencode.json

### DIFF
--- a/apps/kilocode-docs/pages/automate/mcp/using-in-cli.md
+++ b/apps/kilocode-docs/pages/automate/mcp/using-in-cli.md
@@ -11,14 +11,16 @@ The Kilo Code CLI supports MCP servers, but uses a **different configuration pat
 
 | Environment | MCP Settings Path                                   |
 | ----------- | --------------------------------------------------- |
-| **CLI**     | `~/.kilocode/cli/global/settings/mcp_settings.json` |
+| **CLI**     | `~/.config/kilo/opencode.json`                     |
 | **VS Code** | VS Code's global storage directory                  |
 
-MCP servers configured in VS Code are **not** automatically available in the CLI. You must configure them separately.
+The CLI reads and writes MCP server configuration in the global config file above. Use `kilo mcp add` to add servers (it updates this file); `kilo mcp list` reflects what is stored there. MCP servers configured in VS Code are **not** automatically available in the CLI. You must configure them separately.
+
+> **Former location:** The CLI previously used `~/.kilocode/cli/global/settings/mcp_settings.json`. That path is no longer used; editing it has no effect. Use `~/.config/kilo/opencode.json` instead.
 
 ## Configuration Format
 
-Edit `~/.kilocode/cli/global/settings/mcp_settings.json`:
+Edit `~/.config/kilo/opencode.json` (or use `kilo mcp add` to add servers and let the CLI update the file):
 
 ```json
 {


### PR DESCRIPTION
## Context

The doc `using-in-cli.md` told CLI users to edit `~/.kilocode/cli/global/settings/mcp_settings.json` for MCP servers, but the CLI actually uses `~/.config/kilo/opencode.json` (e.g. `kilo mcp add` writes there and `kilo mcp list` reads from it). Editing the old path has no effect, so users could not get MCP servers working in the CLI.

## Implementation

- Updated the **Configuration Location** table: CLI row now points to `~/.config/kilo/opencode.json`.
- Added one sentence explaining that `kilo mcp add` / `kilo mcp list` use this file.
- Added a **Former location** note that `~/.kilocode/cli/global/settings/mcp_settings.json` is no longer used.
- Replaced the old path with the new one in the "Configuration Format" section and mentioned using `kilo mcp add` as an alternative to editing the file.

No code changes; docs only.

## Screenshots

| before                                                                               | after                                                                           |
| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
| Table and examples referred to `~/.kilocode/cli/global/settings/mcp_settings.json` | Table and examples refer to `~/.config/kilo/opencode.json`; legacy path noted |

## How to Test

1. Run `kilo mcp add <any-mcp-server> …` (e.g. any MCP you use) and confirm it creates/updates `~/.config/kilo/opencode.json`.
2. Run `kilo mcp list` and confirm it reflects the servers in that file.
3. Open `apps/kilocode-docs/pages/automate/mcp/using-in-cli.md` and confirm the table and examples use `~/.config/kilo/opencode.json` and the legacy path is mentioned in a note.

## Get in Touch

<!-- Discord handle or leave as-is -->