### PR TITLE
fix: prevent MCP servers from restarting on every settings file re-read

### DIFF
--- a/.changeset/rude-jokes-flow.md
+++ b/.changeset/rude-jokes-flow.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix: prevent MCP servers from restarting on every settings file re-read

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -1774,7 +1774,15 @@ export class McpHub {
 				} catch (error) {
 					this.showErrorMessage(`Failed to connect to new MCP server ${name}`, error)
 				}
-			} else if (!deepEqual(JSON.parse(currentConnection.server.config), config)) {
+			} else if (
+				!deepEqual(
+					JSON.parse(currentConnection.server.config),
+					await injectVariables(validatedConfig, {
+						env: process.env,
+						workspaceFolder: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "",
+					}),
+				)
+			) {
 				// Existing server with changed config
 				try {
 					// Only setup file watcher for enabled servers


### PR DESCRIPTION
## Context

MCP servers restart every time a settings file is re-read, even when the configuration hasn't actually changed. This causes disruptive reconnection loops during normal usage (e.g. switching windows, saving unrelated files).

Fixes #5781, #5791

## Implementation

The root cause is an asymmetric comparison in `McpHub.updateServerConnections`. The stored config (`currentConnection.server.config`) has been through both Zod validation (which applies defaults for `timeout`, `alwaysAllow`, `disabledTools`, `cwd`, `type`) and `injectVariables` (which resolves `${env:...}` and `${workspaceFolder}` placeholders). The incoming config from the settings file is raw — neither validated nor injected.

Since a typical user config omits optional fields like `timeout` and `alwaysAllow`, the Zod defaults alone guarantee the two sides of `deepEqual` can never match, triggering `deleteConnection` + `connectToServer` on every re-read.

The fix applies `injectVariables` to the already-validated config before comparison, so both sides are in the same normalized form:

```typescript
// Before (raw config vs stored injected config — always mismatches)
} else if (!deepEqual(JSON.parse(currentConnection.server.config), config)) {

// After (injected validated config vs stored injected config — correct comparison)
} else if (
  !deepEqual(
    JSON.parse(currentConnection.server.config),
    await injectVariables(validatedConfig, {
      env: process.env,
      workspaceFolder: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "",
    }),
  )
) {
```

This is a single-line-to-8-line change in `src/services/mcp/McpHub.ts`.

## Screenshots

N/A — backend logic change, no UI impact.

## How to Test

1. Configure an MCP server in your settings with a variable placeholder (e.g. `${workspaceFolder}` in a path, or omit optional fields like `timeout`)
2. Open a workspace and let the MCP server connect
3. Trigger a settings file re-read (e.g. switch focus away and back, or touch the settings file)
4. **Before fix:** The server disconnects and reconnects on every re-read (visible in MCP server status flashing)
5. **After fix:** The server stays connected as long as the effective config hasn't changed

## Get in Touch

@evanjacobson on the [Kilo Code Discord](https://kilo.ai/discord)