### PR TITLE
fix: use per-block start_line in MultiFileSearchReplaceDiffStrategy

### DIFF
--- a/.changeset/shaggy-trees-nail.md
+++ b/.changeset/shaggy-trees-nail.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed a bug where every block searches the entire file, which can cause wrong matches when duplicate code patterns exist at different locations.

--- a/src/core/diff/strategies/multi-file-search-replace.ts
+++ b/src/core/diff/strategies/multi-file-search-replace.ts
@@ -485,7 +485,7 @@ Each file requires its own path, start_line, and diff elements.
 
 		const replacements = matches
 			.map((match) => ({
-				startLine: _paramStartLine ?? Number(match[2] ?? 0),
+				startLine: Number(match[2] ?? 0),
 				searchContent: match[6],
 				replaceContent: match[7],
 			}))

--- a/src/core/tools/ApplyDiffTool.ts
+++ b/src/core/tools/ApplyDiffTool.ts
@@ -79,11 +79,7 @@ export class ApplyDiffTool extends BaseTool<"apply_diff"> {
 			const originalContent: string = await fs.readFile(absolutePath, "utf-8")
 
 			// Apply the diff to the original content
-			const diffResult = (await task.diffStrategy?.applyDiff(
-				originalContent,
-				diffContent,
-				parseInt(params.diff.match(/:start_line:(\d+)/)?.[1] ?? ""),
-			)) ?? {
+			const diffResult = (await task.diffStrategy?.applyDiff(originalContent, diffContent, undefined)) ?? {
 				success: false,
 				error: "No diff strategy available",
 			}


### PR DESCRIPTION
## Context

When `ApplyDiffTool` calls `applyDiff` with a string diff containing multiple SEARCH/REPLACE blocks, each block's individual `:start_line:` hint is silently ignored. Instead, every block searches the entire file, which can cause wrong matches when duplicate code patterns exist at different locations.

The root cause is a `NaN` propagation bug: `parseInt("")` returns `NaN`, and `NaN ?? fallback` evaluates to `NaN` (not the fallback) because `NaN` is not nullish.

## Implementation

**Commit 1** (`fix: use per-block start_line`): In `MultiFileSearchReplaceDiffStrategy.applySingleDiff`, the replacement mapping used `_paramStartLine ?? Number(match[2] ?? 0)`. Since `_paramStartLine` was `NaN` (passed from the caller), the `??` operator never fell through to the per-block inline value. Removed the `_paramStartLine` override so each block always uses its own inline `:start_line:` — matching the existing `MultiSearchReplaceDiffStrategy` (single-file) behavior.

**Commit 2** (`fix: remove dead parseInt code`): In `ApplyDiffTool.ts`, removed the top-level `parseInt(params.diff.match(/:start_line:(\d+)/)?.[1] ?? "")` that extracted only the first `:start_line:` from the entire diff string. This was dead code producing `NaN`, now replaced with `undefined`.

No other callers are affected — `MultiApplyDiffTool` passes arrays to `applyDiff` (a different code path that already uses per-item `startLine`).

## Screenshots

N/A — logic-only fix, no UI changes.

## How to Test

1. Configure Kilo Code to use the `MultiFileSearchReplace` diff strategy
2. Ask the agent to make two edits in a single file where duplicate patterns exist at different line numbers (e.g., two functions with the same signature but different bodies)
3. Before this fix: blocks would lose their `:start_line:` hints and could match the wrong location
4. After this fix: each block correctly narrows its search to the region around its own `:start_line:`

Alternatively, verify via unit tests:
```bash
npx vitest run "core/diff/strategies/__tests__/multi-file-search-replace"
npx vitest run "core/diff/strategies/__tests__/multi-search-replace"
```

All 74 existing tests pass (9 multi-file + 65 single-file strategy).

## Get in Touch

@evan.discorb