### PR TITLE
fix(review): Fix review select

### DIFF
--- a/webview-ui/src/components/chat/ReviewScopeSelector.tsx
+++ b/webview-ui/src/components/chat/ReviewScopeSelector.tsx
@@ -44,7 +44,7 @@ export function ReviewScopeSelector({ open, onOpenChange, scopeInfo }: ReviewSco
 	const handleStartReview = () => {
 		vscode.postMessage({
 			type: "reviewScopeSelected",
-			reviewScope: selectedScope,
+			reviewScope: effectiveScope,
 		})
 		onOpenChange(false)
 	}


### PR DESCRIPTION
## Context

Fix a bug in Review Mode where selecting "Branch diff" (review against base branch) in the scope selector UI **incorrectly** sent the "uncommitted" scope to the backend, causing the system prompt to instruct the agent to review staged changes instead of branch differences.

## Implementation

The [`ReviewScopeSelector`](webview-ui/src/components/chat/ReviewScopeSelector.tsx:40) component maintains two scope variables:
- `selectedScope` — the raw React state, initialized to `"uncommitted"`
- `effectiveScope` — a computed value that handles auto-selection when the user's chosen scope is unavailable

The UI correctly used `effectiveScope` for display (radio button checked state, styling), but [`handleStartReview()`](webview-ui/src/components/chat/ReviewScopeSelector.tsx:44) was posting `selectedScope` to the backend instead of `effectiveScope`. This one-line fix changes the posted value to `effectiveScope`.

Added two regression tests to verify auto-selection behavior sends the correct scope when only one option is available.

## How to Test

1. Check out a feature branch that has commits ahead of `main`
2. Enter Review mode
3. In the scope selector dialog, select **"Branch diff"**
4. Click **"Start Review"**
5. The review prompt should reference `git diff main` (or your base branch) — **not** `git diff HEAD` / `git diff --cached`

To test auto-selection:
1. Be on a feature branch with commits but no uncommitted changes
2. Enter Review mode
3. The dialog should auto-select "Branch diff" (uncommitted is disabled)
4. Click **"Start Review"** without clicking anything else
5. The review prompt should reference branch diff commands, not staged/unstaged commands

## Get in Touch

We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here.
