### PR TITLE
fix: add --force flag to worktree creation for existing branches

### DIFF
--- a/.changeset/worktree-force-flag.md
+++ b/.changeset/worktree-force-flag.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix worktree creation when branch is already checked out

--- a/src/core/kilocode/agent-manager/WorktreeManager.ts
+++ b/src/core/kilocode/agent-manager/WorktreeManager.ts
@@ -106,8 +106,10 @@ export class WorktreeManager {
 		}
 
 		try {
+			// Use --force when checking out an existing branch to allow the same branch
+			// to be checked out in multiple worktrees (e.g., multiple agents on main)
 			const args = params.existingBranch
-				? ["worktree", "add", worktreePath, branch]
+				? ["worktree", "add", "--force", worktreePath, branch]
 				: ["worktree", "add", "-b", branch, worktreePath]
 
 			await this.git.raw(args)

--- a/src/core/kilocode/agent-manager/__tests__/WorktreeManager.test.ts
+++ b/src/core/kilocode/agent-manager/__tests__/WorktreeManager.test.ts
@@ -124,9 +124,9 @@ describe("WorktreeManager", () => {
 			const result = await manager.createWorktree({ existingBranch: "feature/existing-branch" })
 
 			expect(result.branch).toBe("feature/existing-branch")
-			// Check the git raw call - path may use / or \ depending on OS
+			// Check the git raw call includes --force flag for existing branches
 			expect(mockGit.raw).toHaveBeenCalledWith(
-				expect.arrayContaining(["worktree", "add", "feature/existing-branch"]),
+				expect.arrayContaining(["worktree", "add", "--force", "feature/existing-branch"]),
 			)
 		})
 


### PR DESCRIPTION
## Context

When creating a worktree for an existing branch (like `main`), Git refuses if that branch is already checked out in another worktree. This prevents users from running multiple agents on the same branch (e.g., `main`) with their own worktrees.

The error was:
```
fatal: 'main' is already checked out at '/workspaces/kilocode'
```

## Implementation

Added the `--force` flag to the `git worktree add` command when using an existing branch in `WorktreeManager.createWorktree()`. This allows the same branch to be checked out in multiple worktrees simultaneously.

**Changes:**
- `src/core/kilocode/agent-manager/WorktreeManager.ts` - Added `--force` flag to worktree creation command
- `src/core/kilocode/agent-manager/__tests__/WorktreeManager.test.ts` - Updated test to expect `--force` flag

## Screenshots
N/A

## How to Test

1. Open a project on the `main` branch
2. Open the Agent Manager
3. Create a new agent session with "Worktree" mode selected
4. Select `main` as the branch (or leave unselected to use current branch)
5. The worktree should be created successfully without the "already checked out" error

## Get in Touch

thomas07374