### PR TITLE
fix(agent-manager): stop showing running state after completion

### DIFF
--- a/.changeset/quiet-signal-finish.md
+++ b/.changeset/quiet-signal-finish.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Agent Manager tasks now stop showing running state when completed.

--- a/src/core/kilocode/agent-manager/__tests__/RuntimeProcessHandler.spec.ts
+++ b/src/core/kilocode/agent-manager/__tests__/RuntimeProcessHandler.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest"
+import type { ChildProcess } from "node:child_process"
+import { RuntimeProcessHandler, type RuntimeProcessHandlerCallbacks } from "../RuntimeProcessHandler"
+import { AgentRegistry } from "../AgentRegistry"
+import type { StreamEvent } from "../CliOutputParser"
+
+type TestableRuntimeProcessHandler = {
+	activeSessions: Map<string, { process: ChildProcess; sessionId: string }>
+	handleExtensionMessage: (
+		proc: ChildProcess,
+		payload: unknown,
+		onEvent: (sessionId: string, event: StreamEvent) => void,
+	) => void
+}
+
+function createCallbacks(): RuntimeProcessHandlerCallbacks {
+	return {
+		onLog: vi.fn(),
+		onSessionLog: vi.fn(),
+		onStateChanged: vi.fn(),
+		onPendingSessionChanged: vi.fn(),
+		onStartSessionFailed: vi.fn(),
+		onChatMessages: vi.fn(),
+		onSessionCreated: vi.fn(),
+	}
+}
+
+describe("RuntimeProcessHandler completion state emission", () => {
+	it("emits synthetic completion state event from extension state messages", () => {
+		const registry = new AgentRegistry()
+		const callbacks = createCallbacks()
+		const handler = new RuntimeProcessHandler(registry, callbacks)
+		const testableHandler = handler as unknown as TestableRuntimeProcessHandler
+		const sessionId = "session-complete"
+		const proc = {} as ChildProcess
+		const onEvent = vi.fn<(sessionId: string, event: StreamEvent) => void>()
+
+		registry.createSession(sessionId, "prompt")
+		testableHandler.activeSessions.set(sessionId, { process: proc, sessionId })
+		testableHandler.handleExtensionMessage(
+			proc,
+			{
+				type: "state",
+				state: {
+					clineMessages: [
+						{ ts: 1000, type: "say", say: "text", text: "Working" },
+						{ ts: 1001, type: "ask", ask: "completion_result", text: "Done" },
+					],
+				},
+			},
+			onEvent,
+		)
+
+		expect(onEvent).toHaveBeenCalledWith(
+			sessionId,
+			expect.objectContaining({
+				streamEventType: "kilocode",
+				payload: expect.objectContaining({
+					type: "ask",
+					ask: "completion_result",
+				}),
+			}),
+		)
+		expect(callbacks.onChatMessages).toHaveBeenCalledWith(sessionId, [
+			expect.objectContaining({ ts: 1000, type: "say", say: "text" }),
+		])
+	})
+
+	it("does not emit duplicate completion event for unchanged state snapshots", () => {
+		const registry = new AgentRegistry()
+		const callbacks = createCallbacks()
+		const handler = new RuntimeProcessHandler(registry, callbacks)
+		const testableHandler = handler as unknown as TestableRuntimeProcessHandler
+		const sessionId = "session-complete-dup"
+		const proc = {} as ChildProcess
+		const onEvent = vi.fn<(sessionId: string, event: StreamEvent) => void>()
+
+		registry.createSession(sessionId, "prompt")
+		testableHandler.activeSessions.set(sessionId, { process: proc, sessionId })
+
+		const stateMessage = {
+			type: "state",
+			state: {
+				clineMessages: [
+					{ ts: 1000, type: "say", say: "text", text: "Working" },
+					{ ts: 1001, type: "say", say: "completion_result", text: "Done" },
+				],
+			},
+		}
+
+		testableHandler.handleExtensionMessage(proc, stateMessage, onEvent)
+		testableHandler.handleExtensionMessage(proc, stateMessage, onEvent)
+
+		const completionCalls = onEvent.mock.calls.filter(
+			([, event]) =>
+				event.streamEventType === "kilocode" &&
+				(event as { payload?: { type?: string; ask?: string } }).payload?.type === "ask" &&
+				(event as { payload?: { type?: string; ask?: string } }).payload?.ask === "completion_result",
+		)
+		expect(completionCalls).toHaveLength(1)
+	})
+})

--- a/webview-ui/src/kilocode/agent-manager/components/SessionDetail.tsx
+++ b/webview-ui/src/kilocode/agent-manager/components/SessionDetail.tsx
@@ -104,8 +104,8 @@ export function SessionDetail() {
 		setIsEditingTitle(false)
 	}
 
-	// Auto-cancel session when it ends (as if user clicked the red cancel button)
-	// Only send cancel once when transitioning from "running" to a terminal state
+	// Auto-cancel mirrors explicit user stop action only.
+	// Send cancel once when transitioning from "running" to "stopped".
 	// Track both sessionId and status to avoid spurious cancels on session switches
 	useEffect(() => {
 		if (!selectedSession) return
@@ -116,8 +116,8 @@ export function SessionDetail() {
 		// Update the ref for next render
 		prevSessionStateRef.current = currentState
 
-		// Only send cancel if same session transitioned from running to terminal state
-		if (prevState?.id === currentState.id && prevState.status === "running" && currentState.status !== "running") {
+		// Only send cancel for explicit stop transitions (not successful completion) // kilocode_change
+		if (prevState?.id === currentState.id && prevState.status === "running" && currentState.status === "stopped") {
 			vscode.postMessage({
 				type: "agentManager.cancelSession",
 				sessionId: selectedSession.sessionId,

--- a/webview-ui/src/kilocode/agent-manager/state/__tests__/messageToEvent.spec.ts
+++ b/webview-ui/src/kilocode/agent-manager/state/__tests__/messageToEvent.spec.ts
@@ -2,6 +2,17 @@ import { describe, it, expect } from "vitest"
 import { messageToEvent } from "../atoms/messages"
 
 describe("messageToEvent", () => {
+	it("maps say completion_result to ask_completion_result", () => {
+		const event = messageToEvent({
+			ts: 1,
+			type: "say",
+			say: "completion_result",
+			text: "Done",
+		})
+
+		expect(event).toEqual({ type: "ask_completion_result" })
+	})
+
 	it("maps resume_completed_task to ask_resume_task", () => {
 		const event = messageToEvent({
 			ts: 1,

--- a/webview-ui/src/kilocode/agent-manager/state/atoms/messages.ts
+++ b/webview-ui/src/kilocode/agent-manager/state/atoms/messages.ts
@@ -132,10 +132,12 @@ export function messageToEvent(msg: ClineMessage): SessionEvent | null {
 			case "user_feedback_diff":
 			case "api_req_finished":
 			case "api_req_retried":
-			case "completion_result":
 			case "shell_integration_warning":
 			case "checkpoint_saved":
 				return { type: "say_text", partial }
+
+			case "completion_result":
+				return { type: "ask_completion_result" } // kilocode_change
 
 			default:
 				return { type: "say_text", partial }


### PR DESCRIPTION
## Context

Agent Manager sessions could finish logically while the UI still looked active: task rows kept the spinner and the stop action remained available. This happened when completion was observed in streamed state/messages before process exit, so the webview state machine never transitioned to completed in time.

## Implementation

- Emit a synthetic completion state event from `RuntimeProcessHandler` as soon as completion is detected in extension state snapshots (`ask:completion_result` or `say:completion_result`), with per-session dedupe.
- Keep `ask:completion_result` filtered from displayed chat while preserving the completion transition signal.
- Map `say:completion_result` to `ask_completion_result` in UI message-to-event mapping so completion transitions the state machine even from message reconciliation.
- Restrict `SessionDetail` auto-cancel behavior to `running -> stopped` only, preventing successful completion (`running -> done`) from being converted into a stop flow.
- Add regression tests for runtime completion event emission/deduping, message mapping, and SessionDetail transition behavior.
- Add a patch changeset for release notes.

## Screenshots

N/A

## How to Test

- Run backend test:
  - `cd src && pnpm test core/kilocode/agent-manager/__tests__/RuntimeProcessHandler.spec.ts`
- Run webview tests:
  - `cd webview-ui && pnpm test src/kilocode/agent-manager/state/__tests__/messageToEvent.spec.ts src/kilocode/agent-manager/components/__tests__/SessionDetail.spec.tsx`
- In Agent Manager, start a session and let it complete.
- Verify the task/session UI leaves running state immediately on completion (spinner stops, stop action no longer shown).
- Verify explicit stop still behaves as before.

## Get in Touch

thomas07374