### PR TITLE
docs: clarify YAML-first custom modes behavior

### DIFF
--- a/apps/kilocode-docs/pages/customize/custom-modes.md
+++ b/apps/kilocode-docs/pages/customize/custom-modes.md
@@ -74,7 +74,7 @@ Modes are accessed from the Prompts tab (notebook icon), which contains the Mode
 
 1. Open the Prompts Tab (click the <Codicon name="notebook" /> icon in the top menu bar)
 2. Click the Import Mode button (upload icon)
-3. Select the mode's YAML file
+3. Select the mode's YAML file (`.yaml`)
 4. Choose the import level:
     - **Project:** Available only in current workspace (saved to `.kilocodemodes` file)
     - **Global:** Available in all projects (saved to global settings)
@@ -121,10 +121,14 @@ The interface provides fields for Name, Slug, Description, Save Location, Role D
 
 You can directly edit the configuration files to create or modify custom modes. This method offers the most control over all properties. Kilo Code now supports both YAML (preferred) and JSON formats.
 
-- **Global Modes:** Edit the `custom_modes.yaml` (preferred) or `custom_modes.json` file. Access it via Prompts Tab > <Codicon name="gear" /> (Settings Menu icon next to "Global Prompts") > "Edit Global Modes"
-- **Project Modes:** Edit the `.kilocodemodes` file (which can be YAML or JSON) in your project root. Access it via Prompts Tab > <Codicon name="gear" /> (Settings Menu icon next to "Project Prompts") > "Edit Project Modes"
+- **Global Modes:** Edit `custom_modes.yaml` (primary). `custom_modes.json` is a legacy fallback and may still exist in older setups.
+- **Project Modes:** Edit `.kilocodemodes` in your project root (YAML preferred; JSON still supported for compatibility).
 
 These files define an array/list of custom modes.
+
+{% callout type="info" title="Why JSON Files May Still Exist" %}
+If you see both YAML and JSON mode files, this is usually from legacy configuration. Kilo Code reads YAML first and does not keep both files synchronized line-by-line. In practice, edit YAML unless you have a specific reason to stay on JSON.
+{% /callout %}
 
 ## YAML Configuration Format (Preferred)
 


### PR DESCRIPTION
## Summary
- clarify that custom modes import expects .yaml files
- explain that custom_modes.json can still exist as a legacy compatibility file
- document that YAML is read first and should be the primary editable source

Fixes #2147