### PR TITLE
docs: add /community page for Kilo community projects

### DIFF
--- a/apps/kilocode-docs/components/TopNav.tsx
+++ b/apps/kilocode-docs/components/TopNav.tsx
@@ -48,6 +48,7 @@ const contributingItems: DropdownItem[] = [
 const helpItems: DropdownItem[] = [
 	{ label: "Documentation", href: "/", description: "Browse all documentation" },
 	{ label: "FAQ", href: "/getting-started/faq", description: "Frequently asked questions" },
+	{ label: "Community Projects", href: "/community", description: "Explore community resources" },
 	{ label: "Support", href: "https://kilo.ai/support", description: "Get help from the team" },
 	{
 		label: "Changelog",

--- a/apps/kilocode-docs/pages/community/index.md
+++ b/apps/kilocode-docs/pages/community/index.md
@@ -1,0 +1,35 @@
+---
+title: "Community Projects"
+description: "Community-maintained resources and projects that work with Kilo Code"
+---
+
+# Community Projects
+
+This page highlights community-driven resources that are relevant for Kilo Code users.
+
+{% callout type="note" title="Community-Maintained" %}
+These resources are maintained by the community unless explicitly noted otherwise. Verify compatibility and security before using them in production environments.
+{% /callout %}
+
+## Recommended Starting Points
+
+- **[Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace)**  
+  Share and install community-created Modes, Skills, and MCP servers.
+- **[Kilo Code Show and Tell Discussions](https://github.com/Kilo-Org/kilocode/discussions/categories/show-and-tell)**  
+  Real examples from users building workflows with Kilo Code.
+- **[MCP Official Resources](https://github.com/modelcontextprotocol)**  
+  Reference implementations and docs for MCP servers used with Kilo.
+
+## Compatibility Checklist
+
+Before adopting a community project, check:
+
+1. Active maintenance (recent commits/releases)
+2. Clear setup instructions for Kilo Code or MCP
+3. License terms appropriate for your use case
+4. Security posture (dependency hygiene, least-privilege permissions)
+
+## Share Your Project
+
+Built something useful with Kilo Code?  
+Share it in [Show and Tell](https://github.com/Kilo-Org/kilocode/discussions/categories/show-and-tell) or contribute it to the [Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace).


### PR DESCRIPTION
## Summary
- add a new /community docs page with Kilo-relevant community resources
- include compatibility checks before adopting community projects
- link the page from the Help dropdown for discoverability

Fixes #2167