### PR TITLE
feat(bedrock): add support for claude-sonnet-4-6 and claude-opus-4-6 …

### DIFF
--- a/.changeset/add-bedrock-claude-4-6-models.md
+++ b/.changeset/add-bedrock-claude-4-6-models.md
@@ -1,0 +1,20 @@
+---
+"@roo-code/types": minor
+---
+
+Add support for Claude Sonnet 4.6 and Claude Opus 4.6 on Amazon Bedrock
+
+- Added `anthropic.claude-sonnet-4-6` with tiered pricing:
+  - Standard (≤200K context): $3.00 input, $15.00 output, $3.75 cache write, $0.30 cache read
+  - Long Context (>200K, 1M): $6.00 input, $22.50 output, $7.50 cache write, $0.60 cache read
+
+- Added `anthropic.claude-opus-4-6` with tiered pricing:
+  - Standard (≤200K context): $5.00 input, $25.00 output, $6.25 cache write, $0.50 cache read
+  - Long Context (>200K, 1M): $10.00 input, $37.50 output, $12.50 cache write, $1.00 cache read
+
+Both models support:
+- 200K context window (extendable to 1M with beta flag)
+- 8K max tokens
+- Images, prompt caching, reasoning budget, and native tools
+- Global Inference
+- Added to `BEDROCK_1M_CONTEXT_MODEL_IDS` and `BEDROCK_GLOBAL_INFERENCE_MODEL_IDS`

--- a/packages/types/src/providers/bedrock.ts
+++ b/packages/types/src/providers/bedrock.ts
@@ -13,6 +13,56 @@ export const bedrockDefaultPromptRouterModelId: BedrockModelId = "anthropic.clau
 // of the default prompt routers AWS enabled for GA of the promot router
 // feature.
 export const bedrockModels = {
+	"anthropic.claude-sonnet-4-6": {
+		maxTokens: 8192,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoningBudget: true,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		minTokensPerCachePoint: 1024,
+		maxCachePoints: 4,
+		cachableFields: ["system", "messages", "tools"],
+		tiers: [
+			{
+				contextWindow: 1_000_000,
+				inputPrice: 6.0,
+				outputPrice: 22.5,
+				cacheWritesPrice: 7.5,
+				cacheReadsPrice: 0.6,
+			},
+		],
+	},
+	"anthropic.claude-opus-4-6": {
+		maxTokens: 8192,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoningBudget: true,
+		supportsNativeTools: true,
+		defaultToolProtocol: "native",
+		inputPrice: 5.0,
+		outputPrice: 25.0,
+		cacheWritesPrice: 6.25,
+		cacheReadsPrice: 0.5,
+		minTokensPerCachePoint: 1024,
+		maxCachePoints: 4,
+		cachableFields: ["system", "messages", "tools"],
+		tiers: [
+			{
+				contextWindow: 1_000_000,
+				inputPrice: 10.0,
+				outputPrice: 37.5,
+				cacheWritesPrice: 12.5,
+				cacheReadsPrice: 1.0,
+			},
+		],
+	},
 	"anthropic.claude-sonnet-4-5-20250929-v1:0": {
 		maxTokens: 8192,
 		contextWindow: 200_000,
@@ -530,17 +580,23 @@ export const BEDROCK_REGIONS = [
 export const BEDROCK_1M_CONTEXT_MODEL_IDS = [
 	"anthropic.claude-sonnet-4-20250514-v1:0",
 	"anthropic.claude-sonnet-4-5-20250929-v1:0",
+	"anthropic.claude-sonnet-4-6",
+	"anthropic.claude-opus-4-6",
 ] as const
 
 // Amazon Bedrock models that support Global Inference profiles
 // As of Nov 2025, AWS supports Global Inference for:
 // - Claude Sonnet 4
 // - Claude Sonnet 4.5
+// - Claude Sonnet 4.6
+// - Claude Opus 4.6
 // - Claude Haiku 4.5
 // - Claude Opus 4.5
 export const BEDROCK_GLOBAL_INFERENCE_MODEL_IDS = [
 	"anthropic.claude-sonnet-4-20250514-v1:0",
 	"anthropic.claude-sonnet-4-5-20250929-v1:0",
+	"anthropic.claude-sonnet-4-6",
+	"anthropic.claude-opus-4-6",
 	"anthropic.claude-haiku-4-5-20251001-v1:0",
 	"anthropic.claude-opus-4-5-20251101-v1:0",
 ] as const


### PR DESCRIPTION

- Add anthropic.claude-sonnet-4-6 with standard and long context tiered pricing
- Add anthropic.claude-opus-4-6 with standard and long context tiered pricing
- Both models support 1M context window and global inference with tiered pricing

## Get in Touch

https://discord.com/users/770402101976891403