### PR TITLE
docs: restore missing /docs/img/kilogif.gif asset

### DIFF
--- a/apps/kilocode-docs/public/img/kilogif.gif
+++ b/apps/kilocode-docs/public/img/kilogif.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:886cc2ef559378470546196b141211ca989876366ddeabc3b67fe89af8796c6a
+size 6329619


### PR DESCRIPTION
## Summary
- add missing kilogif.gif under docs public image path
- restores /docs/img/kilogif.gif route expected by docs links

Fixes #4273