### PR TITLE
docs: refresh Inception provider links and docs issue target

### DIFF
--- a/apps/kilocode-docs/pages/ai-providers/inception.md
+++ b/apps/kilocode-docs/pages/ai-providers/inception.md
@@ -6,11 +6,11 @@ sidebar_label: Inception
 
 Inception provides access to cutting-edge AI models with a focus on performance and reliability. Their infrastructure is designed for enterprise-grade applications requiring consistent, high-quality outputs.
 
-**Website:** [https://inception.ai](https://inception.ai)
+**Website:** [https://www.inceptionlabs.ai](https://www.inceptionlabs.ai)
 
 ## Getting an API Key
 
-1. **Sign Up/Sign In:** Go to the [Inception Platform](https://platform.inception.ai). Create an account or sign in.
+1. **Sign Up/Sign In:** Go to the [Inception website](https://www.inceptionlabs.ai) and access their developer/API dashboard.
 2. **Navigate to API Keys:** Access the API Keys section in your account settings.
 3. **Create a Key:** Click "Create new API key". Give your key a descriptive name (e.g., "Kilo Code").
 4. **Copy the Key:** **Important:** Copy the API key _immediately_. You will not be able to see it again. Store it securely.
@@ -19,7 +19,7 @@ Inception provides access to cutting-edge AI models with a focus on performance 
 
 Kilo Code supports Inception's available models. Model selection and capabilities may vary based on your account tier.
 
-Refer to the [Inception documentation](https://docs.inception.ai) for the most up-to-date list of supported models and their specific capabilities.
+Refer to Inception's current website and developer documentation for the most up-to-date list of supported models and capabilities.
 
 ## Configuration in Kilo Code
 
@@ -33,3 +33,4 @@ Refer to the [Inception documentation](https://docs.inception.ai) for the most u
 - **Enterprise Focus:** Inception is designed for production-grade AI applications with emphasis on reliability and consistency.
 - **Pricing:** Refer to the Inception platform for current pricing details and available subscription options.
 - **Support:** Enterprise customers have access to dedicated support channels for technical assistance.
+- **Docs Feedback:** Report documentation issues at [Kilo-Org/kilocode issues](https://github.com/Kilo-Org/kilocode/issues/new?title=Documentation%20Issue:%20/docs/ai-providers/inception).


### PR DESCRIPTION
## Summary
- replace outdated Inception domain references with current website
- remove stale docs domain reference from provider page
- add explicit docs feedback link targeting Kilo-Org/kilocode issues

Fixes #4142