### PR TITLE
fix(vertex): normalize Claude Opus 4.6 legacy model-id aliases

### DIFF
--- a/.changeset/silver-cups-bow.md
+++ b/.changeset/silver-cups-bow.md
@@ -1,7 +1,5 @@
 ---
 "kilo-code": patch
-"@roo-code/vscode-webview": patch
-"@roo-code/types": patch
 ---
 
 Normalize Vertex Claude Opus 4.6 legacy aliases to the canonical model ID to prevent invalid API calls and keep UI/runtime model capabilities consistent.

--- a/.changeset/silver-cups-bow.md
+++ b/.changeset/silver-cups-bow.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": patch
+"@roo-code/vscode-webview": patch
+"@roo-code/types": patch
+---
+
+Normalize Vertex Claude Opus 4.6 legacy aliases to the canonical model ID to prevent invalid API calls and keep UI/runtime model capabilities consistent.

--- a/packages/types/src/providers/__tests__/vertex.spec.ts
+++ b/packages/types/src/providers/__tests__/vertex.spec.ts
@@ -1,0 +1,16 @@
+import { normalizeVertexModelId } from "../vertex.js"
+
+describe("normalizeVertexModelId", () => {
+	test("returns canonical id when already valid", () => {
+		expect(normalizeVertexModelId("claude-opus-4-6")).toBe("claude-opus-4-6")
+	})
+
+	test("normalizes legacy claude-opus-4-6 aliases", () => {
+		expect(normalizeVertexModelId("claude-opus-4-6@default")).toBe("claude-opus-4-6")
+		expect(normalizeVertexModelId("claude-opus-4-6@vertex")).toBe("claude-opus-4-6")
+	})
+
+	test("falls back to vertex default for unknown ids", () => {
+		expect(normalizeVertexModelId("unknown-model")).toBe("claude-sonnet-4-5@20250929")
+	})
+})

--- a/packages/types/src/providers/__tests__/vertex.spec.ts
+++ b/packages/types/src/providers/__tests__/vertex.spec.ts
@@ -1,3 +1,4 @@
+// kilocode_change - new file
 import { normalizeVertexModelId } from "../vertex.js"
 
 describe("normalizeVertexModelId", () => {

--- a/packages/types/src/providers/vertex.ts
+++ b/packages/types/src/providers/vertex.ts
@@ -595,6 +595,7 @@ export const vertexModels = {
 	},
 } as const satisfies Record<string, ModelInfo>
 
+// kilocode_change start
 /**
  * Normalize legacy Vertex model IDs to canonical IDs.
  *
@@ -617,6 +618,7 @@ export function normalizeVertexModelId(modelId: string): VertexModelId {
 			return vertexDefaultModelId
 	}
 }
+// kilocode_change end
 
 // Vertex AI models that support 1M context window beta
 // Uses the same beta header 'context-1m-2025-08-07' as Anthropic and Bedrock

--- a/packages/types/src/providers/vertex.ts
+++ b/packages/types/src/providers/vertex.ts
@@ -7,7 +7,7 @@ export const vertexDefaultModelId: VertexModelId = "claude-sonnet-4-5@20250929"
 
 export const vertexModels = {
 	// kilocode_change start
-	"claude-opus-4-6@default": {
+	"claude-opus-4-6": {
 		maxTokens: 128_000,
 		contextWindow: 200_000,
 		supportsImages: true,
@@ -594,6 +594,29 @@ export const vertexModels = {
 		description: "Qwen3 235B A22B Instruct. Available in us-south1",
 	},
 } as const satisfies Record<string, ModelInfo>
+
+/**
+ * Normalize legacy Vertex model IDs to canonical IDs.
+ *
+ * Legacy aliases are kept here to support existing saved settings while ensuring
+ * API requests use valid Vertex model names.
+ */
+export function normalizeVertexModelId(modelId: string): VertexModelId {
+	const normalized = modelId.trim()
+
+	// Use Object.hasOwn() instead of 'in' to avoid inherited properties.
+	if (Object.hasOwn(vertexModels, normalized)) {
+		return normalized as VertexModelId
+	}
+
+	switch (normalized.toLowerCase()) {
+		case "claude-opus-4-6@default":
+		case "claude-opus-4-6@vertex":
+			return "claude-opus-4-6"
+		default:
+			return vertexDefaultModelId
+	}
+}
 
 // Vertex AI models that support 1M context window beta
 // Uses the same beta header 'context-1m-2025-08-07' as Anthropic and Bedrock

--- a/src/api/providers/__tests__/anthropic-vertex.spec.ts
+++ b/src/api/providers/__tests__/anthropic-vertex.spec.ts
@@ -838,6 +838,7 @@ describe("VertexHandler", () => {
 			expect(modelInfo.info.contextWindow).toBe(200_000)
 		})
 
+		// kilocode_change start
 		it("should normalize legacy claude-opus-4-6 aliases", () => {
 			handler = new AnthropicVertexHandler({
 				apiModelId: "claude-opus-4-6@default",
@@ -849,6 +850,7 @@ describe("VertexHandler", () => {
 			expect(modelInfo.id).toBe("claude-opus-4-6")
 			expect(modelInfo.info.supportsImages).toBe(true)
 		})
+		// kilocode_change end
 
 		it("honors custom maxTokens for thinking models", () => {
 			const handler = new AnthropicVertexHandler({

--- a/src/api/providers/__tests__/anthropic-vertex.spec.ts
+++ b/src/api/providers/__tests__/anthropic-vertex.spec.ts
@@ -838,6 +838,18 @@ describe("VertexHandler", () => {
 			expect(modelInfo.info.contextWindow).toBe(200_000)
 		})
 
+		it("should normalize legacy claude-opus-4-6 aliases", () => {
+			handler = new AnthropicVertexHandler({
+				apiModelId: "claude-opus-4-6@default",
+				vertexProjectId: "test-project",
+				vertexRegion: "us-central1",
+			})
+
+			const modelInfo = handler.getModel()
+			expect(modelInfo.id).toBe("claude-opus-4-6")
+			expect(modelInfo.info.supportsImages).toBe(true)
+		})
+
 		it("honors custom maxTokens for thinking models", () => {
 			const handler = new AnthropicVertexHandler({
 				apiKey: "test-api-key",

--- a/src/api/providers/__tests__/vertex.spec.ts
+++ b/src/api/providers/__tests__/vertex.spec.ts
@@ -150,6 +150,7 @@ describe("VertexHandler", () => {
 			expect(modelInfo.info.contextWindow).toBe(1048576)
 		})
 
+		// kilocode_change start
 		it("should normalize legacy claude-opus-4-6 aliases", () => {
 			const testHandler = new VertexHandler({
 				apiModelId: "claude-opus-4-6@default",
@@ -161,6 +162,7 @@ describe("VertexHandler", () => {
 			expect(modelInfo.id).toBe("claude-opus-4-6")
 			expect(modelInfo.info.supportsImages).toBe(true)
 		})
+		// kilocode_change end
 
 		// kilocode_change start
 		it("should expose native tools metadata for gemini-3.1-pro-preview", () => {
@@ -176,5 +178,5 @@ describe("VertexHandler", () => {
 			expect(modelInfo.info.defaultToolProtocol).toBe("native")
 		})
 		// kilocode_change end
-		})
 	})
+})

--- a/src/api/providers/__tests__/vertex.spec.ts
+++ b/src/api/providers/__tests__/vertex.spec.ts
@@ -150,19 +150,31 @@ describe("VertexHandler", () => {
 			expect(modelInfo.info.contextWindow).toBe(1048576)
 		})
 
-		// kilocode_change start
-		it("should expose native tools metadata for gemini-3.1-pro-preview", () => {
-			const testHandler = new VertexHandler({
-				apiModelId: "gemini-3.1-pro-preview",
-				vertexProjectId: "test-project",
-				vertexRegion: "us-central1",
+			it("should normalize legacy claude-opus-4-6 aliases", () => {
+				const testHandler = new VertexHandler({
+					apiModelId: "claude-opus-4-6@default",
+					vertexProjectId: "test-project",
+					vertexRegion: "us-central1",
+				})
+
+				const modelInfo = testHandler.getModel()
+				expect(modelInfo.id).toBe("claude-opus-4-6")
+				expect(modelInfo.info.supportsImages).toBe(true)
 			})
 
-			const modelInfo = testHandler.getModel()
-			expect(modelInfo.id).toBe("gemini-3.1-pro-preview")
-			expect(modelInfo.info.supportsNativeTools).toBe(true)
-			expect(modelInfo.info.defaultToolProtocol).toBe("native")
+			// kilocode_change start
+			it("should expose native tools metadata for gemini-3.1-pro-preview", () => {
+				const testHandler = new VertexHandler({
+					apiModelId: "gemini-3.1-pro-preview",
+					vertexProjectId: "test-project",
+					vertexRegion: "us-central1",
+				})
+
+				const modelInfo = testHandler.getModel()
+				expect(modelInfo.id).toBe("gemini-3.1-pro-preview")
+				expect(modelInfo.info.supportsNativeTools).toBe(true)
+				expect(modelInfo.info.defaultToolProtocol).toBe("native")
+			})
+			// kilocode_change end
 		})
-		// kilocode_change end
 	})
-})

--- a/src/api/providers/__tests__/vertex.spec.ts
+++ b/src/api/providers/__tests__/vertex.spec.ts
@@ -150,31 +150,31 @@ describe("VertexHandler", () => {
 			expect(modelInfo.info.contextWindow).toBe(1048576)
 		})
 
-			it("should normalize legacy claude-opus-4-6 aliases", () => {
-				const testHandler = new VertexHandler({
-					apiModelId: "claude-opus-4-6@default",
-					vertexProjectId: "test-project",
-					vertexRegion: "us-central1",
-				})
-
-				const modelInfo = testHandler.getModel()
-				expect(modelInfo.id).toBe("claude-opus-4-6")
-				expect(modelInfo.info.supportsImages).toBe(true)
+		it("should normalize legacy claude-opus-4-6 aliases", () => {
+			const testHandler = new VertexHandler({
+				apiModelId: "claude-opus-4-6@default",
+				vertexProjectId: "test-project",
+				vertexRegion: "us-central1",
 			})
 
-			// kilocode_change start
-			it("should expose native tools metadata for gemini-3.1-pro-preview", () => {
-				const testHandler = new VertexHandler({
-					apiModelId: "gemini-3.1-pro-preview",
-					vertexProjectId: "test-project",
-					vertexRegion: "us-central1",
-				})
+			const modelInfo = testHandler.getModel()
+			expect(modelInfo.id).toBe("claude-opus-4-6")
+			expect(modelInfo.info.supportsImages).toBe(true)
+		})
 
-				const modelInfo = testHandler.getModel()
-				expect(modelInfo.id).toBe("gemini-3.1-pro-preview")
-				expect(modelInfo.info.supportsNativeTools).toBe(true)
-				expect(modelInfo.info.defaultToolProtocol).toBe("native")
+		// kilocode_change start
+		it("should expose native tools metadata for gemini-3.1-pro-preview", () => {
+			const testHandler = new VertexHandler({
+				apiModelId: "gemini-3.1-pro-preview",
+				vertexProjectId: "test-project",
+				vertexRegion: "us-central1",
 			})
-			// kilocode_change end
+
+			const modelInfo = testHandler.getModel()
+			expect(modelInfo.id).toBe("gemini-3.1-pro-preview")
+			expect(modelInfo.info.supportsNativeTools).toBe(true)
+			expect(modelInfo.info.defaultToolProtocol).toBe("native")
+		})
+		// kilocode_change end
 		})
 	})

--- a/src/api/providers/anthropic-vertex.ts
+++ b/src/api/providers/anthropic-vertex.ts
@@ -5,7 +5,7 @@ import { GoogleAuth, JWTInput } from "google-auth-library"
 import {
 	type ModelInfo,
 	type VertexModelId,
-	vertexDefaultModelId,
+	normalizeVertexModelId,
 	vertexModels,
 	ANTHROPIC_DEFAULT_MAX_TOKENS,
 	TOOL_PROTOCOL,
@@ -223,7 +223,7 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 
 	getModel() {
 		const modelId = this.options.apiModelId
-		let id = modelId && modelId in vertexModels ? (modelId as VertexModelId) : vertexDefaultModelId
+		let id: VertexModelId = modelId ? normalizeVertexModelId(modelId) : normalizeVertexModelId("")
 		let info: ModelInfo = vertexModels[id]
 
 		// Check if 1M context beta should be enabled for supported models

--- a/src/api/providers/anthropic-vertex.ts
+++ b/src/api/providers/anthropic-vertex.ts
@@ -223,8 +223,10 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 
 	getModel() {
 		const modelId = this.options.apiModelId
+		// kilocode_change start
 		let id: VertexModelId = modelId ? normalizeVertexModelId(modelId) : normalizeVertexModelId("")
 		let info: ModelInfo = vertexModels[id]
+		// kilocode_change end
 
 		// Check if 1M context beta should be enabled for supported models
 		const supports1MContext = VERTEX_1M_CONTEXT_MODEL_IDS.includes(

--- a/src/api/providers/vertex.ts
+++ b/src/api/providers/vertex.ts
@@ -14,8 +14,10 @@ export class VertexHandler extends GeminiHandler implements SingleCompletionHand
 
 	override getModel() {
 		const modelId = this.options.apiModelId
+		// kilocode_change start
 		let id: VertexModelId = modelId ? normalizeVertexModelId(modelId) : normalizeVertexModelId("")
 		const info: ModelInfo = vertexModels[id]
+		// kilocode_change end
 		const params = getModelParams({ format: "gemini", modelId: id, model: info, settings: this.options })
 
 		// The `:thinking` suffix indicates that the model is a "Hybrid"

--- a/src/api/providers/vertex.ts
+++ b/src/api/providers/vertex.ts
@@ -1,4 +1,4 @@
-import { type ModelInfo, type VertexModelId, vertexDefaultModelId, vertexModels } from "@roo-code/types"
+import { type ModelInfo, type VertexModelId, normalizeVertexModelId, vertexModels } from "@roo-code/types"
 
 import type { ApiHandlerOptions } from "../../shared/api"
 
@@ -14,7 +14,7 @@ export class VertexHandler extends GeminiHandler implements SingleCompletionHand
 
 	override getModel() {
 		const modelId = this.options.apiModelId
-		let id = modelId && modelId in vertexModels ? (modelId as VertexModelId) : vertexDefaultModelId
+		let id: VertexModelId = modelId ? normalizeVertexModelId(modelId) : normalizeVertexModelId("")
 		const info: ModelInfo = vertexModels[id]
 		const params = getModelParams({ format: "gemini", modelId: id, model: info, settings: this.options })
 

--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
@@ -792,7 +792,8 @@ describe("useSelectedModel", () => {
 		})
 	})
 
-	describe("vertex provider", () => {
+		// kilocode_change start
+		describe("vertex provider", () => {
 		beforeEach(() => {
 			mockUseRouterModels.mockReturnValue({
 				data: {
@@ -827,9 +828,10 @@ describe("useSelectedModel", () => {
 			expect(result.current.id).toBe("claude-opus-4-6")
 			expect(result.current.info?.supportsImages).toBe(true)
 		})
-	})
+		})
+		// kilocode_change end
 
-	describe("litellm provider", () => {
+		describe("litellm provider", () => {
 		beforeEach(() => {
 			mockUseOpenRouterModelProviders.mockReturnValue({
 				data: {},

--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
@@ -792,6 +792,43 @@ describe("useSelectedModel", () => {
 		})
 	})
 
+	describe("vertex provider", () => {
+		beforeEach(() => {
+			mockUseRouterModels.mockReturnValue({
+				data: {
+					openrouter: {},
+					requesty: {},
+					glama: {},
+					unbound: {},
+					litellm: {},
+					"io-intelligence": {},
+				},
+				isLoading: false,
+				isError: false,
+			} as any)
+
+			mockUseOpenRouterModelProviders.mockReturnValue({
+				data: {},
+				isLoading: false,
+				isError: false,
+			} as any)
+		})
+
+		it("normalizes legacy claude-opus-4-6 aliases", () => {
+			const apiConfiguration: ProviderSettings = {
+				apiProvider: "vertex",
+				apiModelId: "claude-opus-4-6@default",
+			}
+
+			const wrapper = createWrapper()
+			const { result } = renderHook(() => useSelectedModel(apiConfiguration), { wrapper })
+
+			expect(result.current.provider).toBe("vertex")
+			expect(result.current.id).toBe("claude-opus-4-6")
+			expect(result.current.info?.supportsImages).toBe(true)
+		})
+	})
+
 	describe("litellm provider", () => {
 		beforeEach(() => {
 			mockUseOpenRouterModelProviders.mockReturnValue({

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -22,7 +22,7 @@ import {
 	openAiModelInfoSaneDefaults,
 	openAiNativeModels,
 	vertexModels,
-	normalizeVertexModelId,
+	normalizeVertexModelId, // kilocode_change
 	xaiModels,
 	groqModels,
 	vscodeLlmModels,
@@ -294,10 +294,12 @@ function getSelectedModel({
 			return { id, info: baseInfo }
 		}
 		case "vertex": {
+			// kilocode_change start
 			const rawId = apiConfiguration.apiModelId ?? defaultModelId
 			const id = normalizeVertexModelId(rawId)
 			const info = vertexModels[id as keyof typeof vertexModels]
 			return { id, info }
+			// kilocode_change end
 		}
 		// kilocode_change start
 		case "gemini": {

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -22,6 +22,7 @@ import {
 	openAiModelInfoSaneDefaults,
 	openAiNativeModels,
 	vertexModels,
+	normalizeVertexModelId,
 	xaiModels,
 	groqModels,
 	vscodeLlmModels,
@@ -293,7 +294,8 @@ function getSelectedModel({
 			return { id, info: baseInfo }
 		}
 		case "vertex": {
-			const id = apiConfiguration.apiModelId ?? defaultModelId
+			const rawId = apiConfiguration.apiModelId ?? defaultModelId
+			const id = normalizeVertexModelId(rawId)
 			const info = vertexModels[id as keyof typeof vertexModels]
 			return { id, info }
 		}


### PR DESCRIPTION
## Summary
- switch the Vertex Claude Opus 4.6 catalog entry to canonical claude-opus-4-6
- add 
ormalizeVertexModelId in types to map legacy aliases (claude-opus-4-6@default, claude-opus-4-6@vertex) to the canonical ID
- use normalization in Vertex runtime handlers and webview selected-model hook so saved legacy config is auto-corrected
- add regression tests in packages/types, src/api/providers, and webview-ui

## Why
Some saved Vertex configurations use a legacy alias for Opus 4.6, which can lead to invalid API model names and request failures. This keeps backward compatibility while always sending valid model IDs.

Fixes #5772