### PR TITLE
feat: add X-KiloCode-Feature header for microdollar usage tracking

### DIFF
--- a/.changeset/feature-tracking-header.md
+++ b/.changeset/feature-tracking-header.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add X-KiloCode-Feature header for microdollar usage tracking

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -99,6 +99,13 @@ export interface ApiHandlerCreateMessageMetadata {
 	 * @kilocode-only
 	 */
 	projectId?: string
+	/**
+	 * KiloCode-specific: Feature attribution for microdollar usage tracking.
+	 * When set, overrides the default feature detection in customRequestOptions().
+	 * Examples: 'parallel-agent', 'autocomplete'
+	 * @kilocode-only
+	 */
+	feature?: string
 	// kilocode_change end
 	/**
 	 * Optional array of tool definitions to pass to the model.

--- a/src/api/providers/__tests__/kilocode-openrouter.spec.ts
+++ b/src/api/providers/__tests__/kilocode-openrouter.spec.ts
@@ -26,6 +26,7 @@ import {
 	X_KILOCODE_EDITORNAME,
 	X_KILOCODE_MACHINEID,
 	X_KILOCODE_MODE,
+	X_KILOCODE_FEATURE,
 } from "../../../shared/kilocode/headers"
 import { streamSse } from "../../../services/autocomplete/continuedev/core/fetch/stream"
 
@@ -89,6 +90,7 @@ describe("KilocodeOpenrouterHandler", () => {
 					[X_KILOCODE_TASKID]: "test-task-id",
 					[X_KILOCODE_EDITORNAME]: "Visual Studio Code 1.85.0",
 					[X_KILOCODE_MACHINEID]: "test-machine-id",
+					[X_KILOCODE_FEATURE]: "vscode-extension",
 				},
 			})
 		})
@@ -107,6 +109,7 @@ describe("KilocodeOpenrouterHandler", () => {
 					[X_KILOCODE_ORGANIZATIONID]: "test-org-id",
 					[X_KILOCODE_EDITORNAME]: "Visual Studio Code 1.85.0",
 					[X_KILOCODE_MACHINEID]: "test-machine-id",
+					[X_KILOCODE_FEATURE]: "vscode-extension",
 				},
 			})
 		})
@@ -130,6 +133,7 @@ describe("KilocodeOpenrouterHandler", () => {
 					[X_KILOCODE_PROJECTID]: "https://github.com/user/repo.git",
 					[X_KILOCODE_EDITORNAME]: "Visual Studio Code 1.85.0",
 					[X_KILOCODE_MACHINEID]: "test-machine-id",
+					[X_KILOCODE_FEATURE]: "vscode-extension",
 				},
 			})
 		})
@@ -153,6 +157,7 @@ describe("KilocodeOpenrouterHandler", () => {
 					[X_KILOCODE_ORGANIZATIONID]: "test-org-id",
 					[X_KILOCODE_EDITORNAME]: "Visual Studio Code 1.85.0",
 					[X_KILOCODE_MACHINEID]: "test-machine-id",
+					[X_KILOCODE_FEATURE]: "vscode-extension",
 				},
 			})
 		})
@@ -171,6 +176,7 @@ describe("KilocodeOpenrouterHandler", () => {
 					[X_KILOCODE_ORGANIZATIONID]: "test-org-id",
 					[X_KILOCODE_EDITORNAME]: "Visual Studio Code 1.85.0",
 					[X_KILOCODE_MACHINEID]: "test-machine-id",
+					[X_KILOCODE_FEATURE]: "vscode-extension",
 				},
 			})
 			expect(result?.headers).not.toHaveProperty(X_KILOCODE_PROJECTID)
@@ -190,12 +196,13 @@ describe("KilocodeOpenrouterHandler", () => {
 					[X_KILOCODE_TASKID]: "test-task-id",
 					[X_KILOCODE_EDITORNAME]: "Visual Studio Code 1.85.0",
 					[X_KILOCODE_MACHINEID]: "test-machine-id",
+					[X_KILOCODE_FEATURE]: "vscode-extension",
 				},
 			})
 			expect(result?.headers).not.toHaveProperty(X_KILOCODE_PROJECTID)
 		})
 
-		it("returns editorName and machineId headers when no other headers are needed", () => {
+		it("returns editorName, machineId, and feature headers when no other headers are needed", () => {
 			const handler = new KilocodeOpenrouterHandler(mockOptions)
 			const result = handler.customRequestOptions()
 
@@ -203,8 +210,37 @@ describe("KilocodeOpenrouterHandler", () => {
 				headers: {
 					[X_KILOCODE_EDITORNAME]: "Visual Studio Code 1.85.0",
 					[X_KILOCODE_MACHINEID]: "test-machine-id",
+					[X_KILOCODE_FEATURE]: "vscode-extension",
 				},
 			})
+		})
+
+		it("uses metadata.feature when explicitly set (e.g. parallel-agent)", () => {
+			const handler = new KilocodeOpenrouterHandler(mockOptions)
+			const result = handler.customRequestOptions({
+				taskId: "child-task-id",
+				mode: "code",
+				feature: "parallel-agent",
+			})
+
+			expect(result?.headers?.[X_KILOCODE_FEATURE]).toBe("parallel-agent")
+		})
+
+		it("uses metadata.feature for autocomplete override", () => {
+			const handler = new KilocodeOpenrouterHandler(mockOptions)
+			const result = handler.customRequestOptions({
+				taskId: "autocomplete",
+				feature: "autocomplete",
+			})
+
+			expect(result?.headers?.[X_KILOCODE_FEATURE]).toBe("autocomplete")
+		})
+
+		it("defaults to vscode-extension when no feature override and not JetBrains/agent-manager", () => {
+			const handler = new KilocodeOpenrouterHandler(mockOptions)
+			const result = handler.customRequestOptions({ taskId: "test-task-id" })
+
+			expect(result?.headers?.[X_KILOCODE_FEATURE]).toBe("vscode-extension")
 		})
 	})
 

--- a/src/api/providers/kilocode-openrouter.ts
+++ b/src/api/providers/kilocode-openrouter.ts
@@ -203,14 +203,14 @@ export class KilocodeOpenrouterHandler extends OpenRouterHandler {
 		const endpoint = new URL("fim/completions", this.apiFIMBase)
 
 		// Build headers using customRequestOptions for consistency
+		// kilocode_change: pass feature: "autocomplete" through metadata so resolveFeature() handles it centrally
 		const headers: Record<string, string> = {
 			...DEFAULT_HEADERS,
 			"Content-Type": "application/json",
 			Accept: "application/json",
 			"x-api-key": this.options.kilocodeToken ?? "",
 			Authorization: `Bearer ${this.options.kilocodeToken}`,
-			...this.customRequestOptions(taskId ? { taskId, mode: "code" } : undefined)?.headers,
-			[X_KILOCODE_FEATURE]: "autocomplete", // kilocode_change: override feature for FIM completions
+			...this.customRequestOptions({ taskId: taskId ?? "autocomplete", mode: "code", feature: "autocomplete" })?.headers,
 		}
 
 		// temperature: 0.2 is mentioned as a sane example in mistral's docs and is what continue uses.

--- a/src/api/providers/kilocode-openrouter.ts
+++ b/src/api/providers/kilocode-openrouter.ts
@@ -17,10 +17,11 @@ import {
 	X_KILOCODE_TESTER,
 	X_KILOCODE_EDITORNAME,
 	X_KILOCODE_MACHINEID,
+	X_KILOCODE_FEATURE, // kilocode_change
 } from "../../shared/kilocode/headers"
 import { DEFAULT_HEADERS } from "./constants"
 import { streamSse } from "../../services/autocomplete/continuedev/core/fetch/stream"
-import { getEditorNameHeader } from "../../core/kilocode/wrapper"
+import { getEditorNameHeader, getKiloCodeWrapperProperties } from "../../core/kilocode/wrapper"
 import type { FimHandler } from "./kilocode/FimHandler"
 import * as vscode from "vscode"
 
@@ -91,8 +92,37 @@ export class KilocodeOpenrouterHandler extends OpenRouterHandler {
 			headers[X_KILOCODE_TESTER] = "SUPPRESS"
 		}
 
+		// kilocode_change start: Feature attribution for microdollar usage tracking
+		headers[X_KILOCODE_FEATURE] = this.resolveFeature(metadata)
+		// kilocode_change end
+
 		return Object.keys(headers).length > 0 ? { headers } : undefined
 	}
+
+	// kilocode_change start
+	/**
+	 * Determine the feature value for microdollar usage tracking.
+	 * Priority: explicit metadata override > wrapper detection > default
+	 */
+	private resolveFeature(metadata?: ApiHandlerCreateMessageMetadata): string {
+		// 1. Explicit override from metadata (e.g. 'parallel-agent', 'autocomplete')
+		if (metadata?.feature) {
+			return metadata.feature
+		}
+
+		// 2. Detect context from wrapper properties
+		const wrapperProps = getKiloCodeWrapperProperties()
+		if (wrapperProps.kiloCodeWrapperJetbrains) {
+			return "jetbrains-extension"
+		}
+		if (wrapperProps.kiloCodeWrapper === "agent-manager") {
+			return "agent-manager"
+		}
+
+		// 3. Default: VS Code extension
+		return "vscode-extension"
+	}
+	// kilocode_change end
 
 	override getTotalCost(lastUsage: CompletionUsage): number {
 		const model = this.getModel().info
@@ -180,6 +210,7 @@ export class KilocodeOpenrouterHandler extends OpenRouterHandler {
 			"x-api-key": this.options.kilocodeToken ?? "",
 			Authorization: `Bearer ${this.options.kilocodeToken}`,
 			...this.customRequestOptions(taskId ? { taskId, mode: "code" } : undefined)?.headers,
+			[X_KILOCODE_FEATURE]: "autocomplete", // kilocode_change: override feature for FIM completions
 		}
 
 		// temperature: 0.2 is mentioned as a sane example in mistral's docs and is what continue uses.

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -4676,6 +4676,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 					}
 				: {}),
 			projectId: (await kiloConfig)?.project?.id, // kilocode_change: pass projectId for backend tracking (ignored by other providers)
+			// kilocode_change: child tasks (spawned via new_task tool) are parallel agents
+			...(this.parentTaskId ? { feature: "parallel-agent" } : {}),
 		}
 
 		// Create an AbortController to allow cancelling the request mid-stream

--- a/src/services/autocomplete/AutocompleteModel.ts
+++ b/src/services/autocomplete/AutocompleteModel.ts
@@ -162,9 +162,12 @@ export class AutocompleteModel {
 
 		console.log("USED MODEL", this.apiHandler.getModel())
 
-		const stream = this.apiHandler.createMessage(systemPrompt, [
-			{ role: "user", content: [{ type: "text", text: userPrompt }] },
-		])
+		// kilocode_change: pass feature metadata for microdollar usage tracking
+		const stream = this.apiHandler.createMessage(
+			systemPrompt,
+			[{ role: "user", content: [{ type: "text", text: userPrompt }] }],
+			{ taskId: "autocomplete", feature: "autocomplete" },
+		)
 
 		let cost = 0
 		let inputTokens = 0

--- a/src/shared/kilocode/headers.ts
+++ b/src/shared/kilocode/headers.ts
@@ -6,3 +6,4 @@ export const X_KILOCODE_EDITORNAME = "X-KiloCode-EditorName"
 export const X_KILOCODE_MACHINEID = "X-KiloCode-MachineId"
 export const X_KILOCODE_MODE = "X-KiloCode-Mode"
 export const X_KILOCODE_TESTER = "X-KILOCODE-TESTER"
+export const X_KILOCODE_FEATURE = "X-KiloCode-Feature" // kilocode_change


### PR DESCRIPTION
## Summary

Adds the `X-KiloCode-Feature` header to all LLM requests from the old extension (`KilocodeOpenrouterHandler`) for microdollar usage tracking. This enables per-feature WAU attribution in the `microdollar_usage` table.

## Changes

### Header constant
- Added `X_KILOCODE_FEATURE` to `src/shared/kilocode/headers.ts`

### Metadata interface
- Added `feature?: string` to `ApiHandlerCreateMessageMetadata` in `src/api/index.ts`

### Feature detection (`src/api/providers/kilocode-openrouter.ts`)
- New `resolveFeature()` method with priority-based detection:
  1. Explicit `metadata.feature` override (e.g. `parallel-agent`, `autocomplete`)
  2. JetBrains detection via `kiloCodeWrapperJetbrains`
  3. Agent-manager detection via `kiloCodeWrapper === "agent-manager"`
  4. Default: `vscode-extension`
- `customRequestOptions()` always includes the feature header
- `streamFim()` overrides feature to `autocomplete` for FIM completions

### Parallel agent detection (`src/core/task/Task.ts`)
- Sets `feature: "parallel-agent"` in metadata when `parentTaskId` is set (child tasks spawned via `new_task` tool)

### Chat-based autocomplete (`src/services/autocomplete/AutocompleteModel.ts`)
- `generateResponse()` now passes `{ taskId: "autocomplete", feature: "autocomplete" }` metadata

## Feature values set by this repo

| Feature | Value | Detection mechanism |
|---|---|---|
| VS Code Extension | `vscode-extension` | Default fallback |
| JetBrains Extension | `jetbrains-extension` | Wrapper properties |
| Autocomplete (FIM) | `autocomplete` | Hardcoded in `streamFim()` |
| Autocomplete (chat) | `autocomplete` | Explicit metadata |
| Parallel Agent | `parallel-agent` | `parentTaskId` in Task.ts |
| Agent Manager | `agent-manager` | Wrapper appName detection |

## Testing
- 16 unit tests passing (updated existing + 3 new feature detection tests)
- Debugger-verified `vscode-extension` and `parallel-agent` values in Extension Development Host

## Related
- Cloud repo: feature column + gateway validation already deployed
- Kilo repo: kilo-gateway headers + CLI entry point already deployed
- Plan: `cloud/plans/microdollar-feature-tracking.md` (Step 6)