### PR TITLE
fix: allow dropdowns in Modes modal to be changed

### DIFF
--- a/.changeset/hungry-socks-grin.md
+++ b/.changeset/hungry-socks-grin.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix: allow dropdowns in Modes modal to be changed

--- a/webview-ui/src/components/kilocode/rules/KiloRulesToggleModal.tsx
+++ b/webview-ui/src/components/kilocode/rules/KiloRulesToggleModal.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect } from "react"
-import { useWindowSize, useClickAway } from "react-use"
+import { useWindowSize } from "react-use"
 import { useTranslation } from "react-i18next"
 import styled from "styled-components"
 
@@ -30,9 +30,21 @@ const KiloRulesToggleModal: React.FC = () => {
 	const [menuPosition, setMenuPosition] = useState(0)
 	const [currentView, setCurrentView] = useState<"modes" | "mcp" | "rule" | "workflow" | "skills">("rule")
 
-	useClickAway(modalRef, () => {
-		setIsVisible(false)
-	})
+	useEffect(() => {
+		const handler = (event: MouseEvent | TouchEvent) => {
+			const target = event.target as HTMLElement
+			if (modalRef.current?.contains(target)) return
+			// Ignore clicks on Radix portaled content (Select/Popover dropdowns)
+			if (target.closest("[data-radix-popper-content-wrapper]")) return
+			setIsVisible(false)
+		}
+		document.addEventListener("mousedown", handler)
+		document.addEventListener("touchstart", handler)
+		return () => {
+			document.removeEventListener("mousedown", handler)
+			document.removeEventListener("touchstart", handler)
+		}
+	}, [])
 
 	useEffect(() => {
 		if (isVisible && buttonRef.current) {


### PR DESCRIPTION

<!--
NOTE: New versions of the VS Code extension and CLI are being developed in https://github.com/Kilo-Org/Kilo
(extension: packages/kilo-vscode, CLI: packages/opencode).
If your changes are for the extension or CLI, please open your PR in that repository instead.
-->

## Context

Currently if a user clicks either of the dropdowns (Mode or API Configuration)  within the Modes modal, the modal will close, and their action will not save.

## Implementation

This change prevents the close-on-click action from affecting the dropdowns which are rendered in a portal outside of the modal, so that the dropdowns work as intended.

## How to Test

- Open the Modes modal
- Click one of the dropdowns
- Change the selected option