### PR TITLE
Fix: Prevent terminal focus stealing in Agent Manager (fixes #5946)

### DIFF
--- a/.changeset/eight-hounds-sleep.md
+++ b/.changeset/eight-hounds-sleep.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix: Prevent terminal focus stealing in Agent Manager (fixes #5946)

--- a/src/core/kilocode/agent-manager/SessionTerminalManager.ts
+++ b/src/core/kilocode/agent-manager/SessionTerminalManager.ts
@@ -141,7 +141,7 @@ export class SessionTerminalManager {
 			)
 		}
 
-		entry.terminal.show()
+		entry.terminal.show(true)
 	}
 
 	/**
@@ -173,7 +173,7 @@ export class SessionTerminalManager {
 			return false
 		}
 
-		entry.terminal.show()
+		entry.terminal.show(true)
 		this.outputChannel.appendLine(`[AgentManager] showExistingTerminal: revealed terminal for session ${sessionId}`)
 		return true
 	}


### PR DESCRIPTION
I've fixed the GitHub issue #5946 "Kilo Code steals terminal focus when the agent invokes a terminal command".

Changes:
- Modified showOrCreateTerminal() to use terminal.show(true)
- Modified showExistingTerminal() to use terminal.show(true)

The VSCode API's terminal.show(true) reveals the terminal while preserving focus on the current window.

<!--
NOTE: New versions of the VS Code extension and CLI are being developed in https://github.com/Kilo-Org/Kilo
(extension: packages/kilo-vscode, CLI: packages/opencode).
If your changes are for the extension or CLI, please open your PR in that repository instead.
-->

## Context
When users start a Kilo Code agent session and then switch to a VS Code terminal window for parallel work, the focus would jump back to the Kilo Code Terminal tab each time the agent invoked a terminal command. This made it very disruptive to use Kilo Code for background tasks.

## Implementation
The fix is straightforward - the VSCode Terminal API provides a `preserveFocus` parameter for the `show()` method. By passing `true` to this parameter, the terminal is revealed (made visible in the terminal panel) without stealing focus from the current window.

Changes made in `src/core/kilocode/agent-manager/SessionTerminalManager.ts`:
- `showOrCreateTerminal()`: Changed `entry.terminal.show()` to `entry.terminal.show(true)`
- `showExistingTerminal()`: Changed `entry.terminal.show()` to `entry.terminal.show(true)`

Note: The main extension's `ExecuteCommandTool.ts` already correctly uses `terminal.terminal.show(true)`, so this fix specifically addresses the Agent Manager's SessionTerminalManager which was the culprit for agent sessions.

## How to Test
1. Start a Kilo Code agent session (Agent Manager)
2. Switch to a different VS Code terminal window to do some parallel work
3. Wait for the agent to invoke a terminal command
4. Verify that focus remains on your current terminal window instead of being yanked to the Kilo Code terminal

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
