### PR TITLE
Update documentation link for customizing modes

### DIFF
--- a/webview-ui/src/components/modes/ModesView.tsx
+++ b/webview-ui/src/components/modes/ModesView.tsx
@@ -718,7 +718,7 @@ const ModesView = ({ hideHeader = false }: { hideHeader?: boolean }) => {
 								style={{ display: "inline" }}
 								aria-label="Learn about using modes"></VSCodeLink>
 							<VSCodeLink
-								href={buildDocLink("features/custom-modes", "prompts_view_modes")}
+								href={buildDocLink("customize/custom-modes", "prompts_view_modes")}
 								style={{ display: "inline" }}
 								aria-label="Learn about customizing modes"></VSCodeLink>
 						</Trans>


### PR DESCRIPTION
Fixed Customizing Modes link.
old link https://kilo.ai/docs/features/custom-modes gives 404 errror. 
new link should be: https://kilo.ai/docs/customize/custom-modes
<img width="731" height="357" alt="image" src="https://github.com/user-attachments/assets/3e4aaf5a-1207-4931-baa2-9e8fcc4dab3e" />
