### PR TITLE
Add Gemini 3.1 Pro support and set Gemini default model (#11608)

### DIFF
--- a/.changeset/gemini-3-1-pro-default-model.md
+++ b/.changeset/gemini-3-1-pro-default-model.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Update Gemini default model metadata for Gemini 3.1 Pro and keep tool calling behavior consistent.

--- a/packages/types/src/providers/gemini.ts
+++ b/packages/types/src/providers/gemini.ts
@@ -3,9 +3,71 @@ import type { ModelInfo } from "../model.js"
 // https://ai.google.dev/gemini-api/docs/models/gemini
 export type GeminiModelId = keyof typeof geminiModels
 
-export const geminiDefaultModelId: GeminiModelId = "gemini-3-pro-preview"
+export const geminiDefaultModelId: GeminiModelId = "gemini-3.1-pro-preview"
 
 export const geminiModels = {
+	"gemini-3.1-pro-preview": {
+		maxTokens: 65_536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsNativeTools: true, // kilocode_change
+		defaultToolProtocol: "native", // kilocode_change
+		supportsPromptCache: true,
+		supportsReasoningEffort: ["low", "medium", "high"],
+		reasoningEffort: "low",
+
+		supportsTemperature: true,
+		defaultTemperature: 1,
+		inputPrice: 4.0,
+		outputPrice: 18.0,
+		cacheReadsPrice: 0.4,
+		cacheWritesPrice: 4.5,
+		tiers: [
+			{
+				contextWindow: 200_000,
+				inputPrice: 2.0,
+				outputPrice: 12.0,
+				cacheReadsPrice: 0.2,
+			},
+			{
+				contextWindow: Infinity,
+				inputPrice: 4.0,
+				outputPrice: 18.0,
+				cacheReadsPrice: 0.4,
+			},
+		],
+	},
+	"gemini-3.1-pro-preview-customtools": {
+		maxTokens: 65_536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsNativeTools: true, // kilocode_change
+		defaultToolProtocol: "native", // kilocode_change
+		supportsPromptCache: true,
+		supportsReasoningEffort: ["low", "medium", "high"],
+		reasoningEffort: "low",
+
+		supportsTemperature: true,
+		defaultTemperature: 1,
+		inputPrice: 4.0,
+		outputPrice: 18.0,
+		cacheReadsPrice: 0.4,
+		cacheWritesPrice: 4.5,
+		tiers: [
+			{
+				contextWindow: 200_000,
+				inputPrice: 2.0,
+				outputPrice: 12.0,
+				cacheReadsPrice: 0.2,
+			},
+			{
+				contextWindow: Infinity,
+				inputPrice: 4.0,
+				outputPrice: 18.0,
+				cacheReadsPrice: 0.4,
+			},
+		],
+	},
 	"gemini-3-pro-preview": {
 		maxTokens: 65_536,
 		contextWindow: 1_048_576,

--- a/packages/types/src/providers/vertex.ts
+++ b/packages/types/src/providers/vertex.ts
@@ -22,6 +22,37 @@ export const vertexModels = {
 		supportsVerbosity: ["low", "medium", "high", "max"],
 	},
 	// kilocode_change end
+	"gemini-3.1-pro-preview": {
+		maxTokens: 65_536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsNativeTools: true, // kilocode_change
+		defaultToolProtocol: "native", // kilocode_change
+		supportsPromptCache: true,
+		supportsReasoningEffort: ["low", "medium", "high"],
+		reasoningEffort: "low",
+
+		supportsTemperature: true,
+		defaultTemperature: 1,
+		inputPrice: 4.0,
+		outputPrice: 18.0,
+		cacheReadsPrice: 0.4,
+		cacheWritesPrice: 4.5,
+		tiers: [
+			{
+				contextWindow: 200_000,
+				inputPrice: 2.0,
+				outputPrice: 12.0,
+				cacheReadsPrice: 0.2,
+			},
+			{
+				contextWindow: Infinity,
+				inputPrice: 4.0,
+				outputPrice: 18.0,
+				cacheReadsPrice: 0.4,
+			},
+		],
+	},
 	"gemini-3-pro-preview": {
 		maxTokens: 65_536,
 		contextWindow: 1_048_576,

--- a/src/api/providers/__tests__/vertex.spec.ts
+++ b/src/api/providers/__tests__/vertex.spec.ts
@@ -149,5 +149,20 @@ describe("VertexHandler", () => {
 			expect(modelInfo.info.maxTokens).toBe(8192)
 			expect(modelInfo.info.contextWindow).toBe(1048576)
 		})
+
+		// kilocode_change start
+		it("should expose native tools metadata for gemini-3.1-pro-preview", () => {
+			const testHandler = new VertexHandler({
+				apiModelId: "gemini-3.1-pro-preview",
+				vertexProjectId: "test-project",
+				vertexRegion: "us-central1",
+			})
+
+			const modelInfo = testHandler.getModel()
+			expect(modelInfo.id).toBe("gemini-3.1-pro-preview")
+			expect(modelInfo.info.supportsNativeTools).toBe(true)
+			expect(modelInfo.info.defaultToolProtocol).toBe("native")
+		})
+		// kilocode_change end
 	})
 })

--- a/src/api/providers/fetchers/__tests__/gemini.spec.ts
+++ b/src/api/providers/fetchers/__tests__/gemini.spec.ts
@@ -1,0 +1,101 @@
+// kilocode_change - new file
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const listModelsMock = vi.hoisted(() => vi.fn())
+const googleGenAICtorMock = vi.hoisted(() =>
+	vi.fn(() => ({
+		models: {
+			list: listModelsMock,
+		},
+	})),
+)
+
+vi.mock("@google/genai", () => ({
+	GoogleGenAI: googleGenAICtorMock,
+}))
+
+import { getGeminiModels } from "../gemini"
+
+const createPager = (models: Array<Record<string, any>>) => ({
+	async *[Symbol.asyncIterator]() {
+		for (const model of models) {
+			yield model
+		}
+	},
+})
+
+describe("getGeminiModels", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	// kilocode_change start
+	it("adds customtools alias when gemini-3.1-pro-preview is available", async () => {
+		listModelsMock.mockResolvedValueOnce(
+			createPager([
+				{
+					name: "models/gemini-3.1-pro-preview",
+					inputTokenLimit: 222_222,
+					outputTokenLimit: 11_111,
+					displayName: "Gemini 3.1 Pro",
+				},
+			]),
+		)
+
+		const models = await getGeminiModels({ apiKey: "test-key" })
+
+		expect(googleGenAICtorMock).toHaveBeenCalledWith({ apiKey: "test-key" })
+		expect(models["gemini-3.1-pro-preview"]).toBeDefined()
+		expect(models["gemini-3.1-pro-preview-customtools"]).toMatchObject({
+			supportsNativeTools: true,
+			defaultToolProtocol: "native",
+			contextWindow: 222_222,
+			maxTokens: 11_111,
+		})
+	})
+
+	it("does not add customtools alias when gemini-3.1-pro-preview is unavailable", async () => {
+		listModelsMock.mockResolvedValueOnce(
+			createPager([
+				{
+					name: "models/gemini-2.5-pro",
+					inputTokenLimit: 1_048_576,
+					outputTokenLimit: 65_536,
+				},
+			]),
+		)
+
+		const models = await getGeminiModels({ apiKey: "test-key" })
+
+		expect(models["gemini-3.1-pro-preview-customtools"]).toBeUndefined()
+	})
+
+	it("does not overwrite API metadata when customtools alias is returned by API", async () => {
+		listModelsMock.mockResolvedValueOnce(
+			createPager([
+				{
+					name: "models/gemini-3.1-pro-preview",
+					inputTokenLimit: 1_048_576,
+					outputTokenLimit: 65_536,
+				},
+				{
+					name: "models/gemini-3.1-pro-preview-customtools",
+					inputTokenLimit: 333_333,
+					outputTokenLimit: 12_345,
+					displayName: "Gemini 3.1 Pro Custom Tools from API",
+					description: "API alias description",
+				},
+			]),
+		)
+
+		const models = await getGeminiModels({ apiKey: "test-key" })
+		const alias = models["gemini-3.1-pro-preview-customtools"]
+
+		expect(alias).toBeDefined()
+		expect(alias.displayName).toBe("Gemini 3.1 Pro Custom Tools from API")
+		expect(alias.description).toBe("API alias description")
+		expect(alias.maxTokens).toBe(12_345)
+		expect(alias.contextWindow).toBe(333_333)
+	})
+	// kilocode_change end
+})


### PR DESCRIPTION
## Context

This change updates Gemini defaults and model metadata to support
Gemini 3.1 Pro without regressing tool-calling behavior.

- Switch Gemini default model to `gemini-3.1-pro-preview`
- Add Gemini 3.1 static entries for Gemini and Vertex providers
- Ensure Gemini 3.1 models are marked as native-tool capable
- Keep the `-customtools` alias behavior consistent with dynamic
  model loading

## Implementation

- Updated `packages/types/src/providers/gemini.ts`
  - Set `geminiDefaultModelId` to `gemini-3.1-pro-preview`
  - Added `gemini-3.1-pro-preview` model metadata
  - Added `gemini-3.1-pro-preview-customtools` model metadata
  - Set `supportsNativeTools: true` and
    `defaultToolProtocol: "native"` for the new Gemini 3.1 entries
- Updated `packages/types/src/providers/vertex.ts`
  - Added `gemini-3.1-pro-preview` with native tool metadata
- Updated `src/api/providers/fetchers/gemini.ts`
  - Added alias mapping for
    `gemini-3.1-pro-preview-customtools -> gemini-3.1-pro-preview`
  - Backfill alias only when alias is missing and parsed base model
    info exists
  - Reuse dynamic token limits from base model when creating alias to
    keep `maxTokens/contextWindow` consistent
- Added and updated regression tests
  - `src/api/providers/__tests__/gemini.spec.ts`
  - `src/api/providers/__tests__/vertex.spec.ts`
  - `src/api/providers/fetchers/__tests__/gemini.spec.ts`

Official references used for model/pricing metadata:

- https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview
- https://ai.google.dev/gemini-api/docs/pricing
- https://ai.google.dev/gemini-api/docs/thinking
- https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-pro
- https://cloud.google.com/vertex-ai/generative-ai/pricing
- https://cloud.google.com/blog/products/ai-machine-learning/gemini-3-1-pro-on-gemini-cli-gemini-enterprise-and-vertex-ai
- https://deepmind.google/models/model-cards/gemini-3-1-pro/
- https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-pro/

## Screenshots

| before | after |
| ------ | ----- |
| N/A (provider/model metadata only) | N/A (provider/model metadata only) |

## How to Test

1. Run:
   `cd src && pnpm test api/providers/__tests__/gemini.spec.ts api/providers/__tests__/vertex.spec.ts api/providers/fetchers/__tests__/gemini.spec.ts`
2. Verify all 3 test files pass (27 tests total).
3. Optional manual check:
   confirm `gemini-3.1-pro-preview-customtools` is only backfilled
   when base model info exists in fetched/parsed models.

## Get in Touch

Discord: @PeterDaveHello 