### PR TITLE
fix(api): retry gemini requests on signature validation failure

### DIFF
--- a/src/api/providers/__tests__/gemini.spec.ts
+++ b/src/api/providers/__tests__/gemini.spec.ts
@@ -134,6 +134,7 @@ describe("GeminiHandler", () => {
 			}).rejects.toThrow()
 		})
 
+		// kilocode_change start
 		it("should retry once with fallback thought signatures when signature validation fails before streaming", async () => {
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
 			let firstAttemptContents: any[] | undefined
@@ -226,6 +227,7 @@ describe("GeminiHandler", () => {
 
 			warnSpy.mockRestore()
 		})
+		// kilocode_change end
 	})
 
 	describe("completePrompt", () => {

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -412,7 +412,7 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 				if (
 					!hasYielded &&
 					attempt === 0 &&
-					(errorMessage.toLowerCase().includes("signature") ||
+					(errorMessage.toLowerCase().includes("thoughtsignature") ||
 						errorMessage.toLowerCase().includes("thoughtsignature"))
 				) {
 					console.warn(

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -260,6 +260,7 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 
 		const params: GenerateContentParameters = { model, contents, config }
 
+		// kilocode_change start
 		let attempt = 0
 		let hasYielded = false
 
@@ -303,7 +304,6 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 								thoughtSignature?: string
 								functionCall?: { name: string; args: Record<string, unknown> }
 							}>) {
-								hasYielded = true
 								// Capture thought signatures so they can be persisted into API history.
 								const thoughtSignature = part.thoughtSignature
 								// Persist thought signatures so they can be round-tripped in the next step.
@@ -317,10 +317,12 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 									// This is a thinking/reasoning part
 									if (part.text) {
 										hasReasoning = true
+										hasYielded = true
 										yield { type: "reasoning", text: part.text }
 									}
 								} else if (part.functionCall) {
 									hasContent = true
+									hasYielded = true
 									// Gemini sends complete function calls in a single chunk
 									// Emit as partial chunks for consistent handling with NativeToolCallParser
 									const callId = `${part.functionCall.name}-${toolCallCounter}`
@@ -349,6 +351,7 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 									// This is regular content
 									if (part.text) {
 										hasContent = true
+										hasYielded = true
 										yield { type: "text", text: part.text }
 									}
 								}
@@ -413,7 +416,6 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 					!hasYielded &&
 					attempt === 0 &&
 					(errorMessage.toLowerCase().includes("thoughtsignature") ||
-					errorMessage.toLowerCase().includes("thoughtsignature") ||
 						errorMessage.toLowerCase().includes("thought_signature"))
 				) {
 					console.warn(
@@ -442,6 +444,7 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 				throw error
 			}
 		} // end while
+		// kilocode_change end
 	}
 
 	override getModel() {

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -413,7 +413,8 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 					!hasYielded &&
 					attempt === 0 &&
 					(errorMessage.toLowerCase().includes("thoughtsignature") ||
-						errorMessage.toLowerCase().includes("thoughtsignature"))
+					errorMessage.toLowerCase().includes("thoughtsignature") ||
+						errorMessage.toLowerCase().includes("thought_signature"))
 				) {
 					console.warn(
 						"[GeminiHandler] Thought signature validation failed, retrying with fallback signatures...",

--- a/src/api/transform/__tests__/gemini-format.spec.ts
+++ b/src/api/transform/__tests__/gemini-format.spec.ts
@@ -174,7 +174,7 @@ describe("convertAnthropicMessageToGemini", () => {
 		])
 	})
 
-	it("should use skip_thought_signature_validator and drop text signatures when fallbackThoughtSignatures is true", () => {
+	it("should use skip_thought_signature_validator and drop thoughtSignature blocks when fallbackThoughtSignatures is true", () => { // kilocode_change
 		const anthropicMessage: Anthropic.Messages.MessageParam = {
 			role: "assistant",
 			content: [

--- a/src/api/transform/__tests__/gemini-format.spec.ts
+++ b/src/api/transform/__tests__/gemini-format.spec.ts
@@ -140,6 +140,7 @@ describe("convertAnthropicMessageToGemini", () => {
 		])
 	})
 
+	// kilocode_change start
 	it("should omit thoughtSignature when includeThoughtSignatures is false", () => {
 		const anthropicMessage: Anthropic.Messages.MessageParam = {
 			role: "assistant",
@@ -209,6 +210,7 @@ describe("convertAnthropicMessageToGemini", () => {
 			},
 		])
 	})
+	// kilocode_change end
 
 	it("should only attach thoughtSignature to the first functionCall in the message", () => {
 		const anthropicMessage: Anthropic.Messages.MessageParam = {

--- a/src/api/transform/gemini-format.ts
+++ b/src/api/transform/gemini-format.ts
@@ -46,8 +46,8 @@ export function convertAnthropicContentToGemini(
 	}
 
 	// kilocode_change start
-	if (options?.fallbackThoughtSignatures) {
-		activeThoughtSignature = undefined
+	if (options?.fallbackThoughtSignatures && !activeThoughtSignature) {
+		activeThoughtSignature = "skip_thought_signature_validator"
 	}
 	// kilocode_change end
 

--- a/src/api/transform/gemini-format.ts
+++ b/src/api/transform/gemini-format.ts
@@ -46,7 +46,7 @@ export function convertAnthropicContentToGemini(
 	}
 
 	// kilocode_change start
-	if (options?.fallbackThoughtSignatures && !activeThoughtSignature) {
+	if (options?.fallbackThoughtSignatures) {
 		activeThoughtSignature = "skip_thought_signature_validator"
 	}
 	// kilocode_change end

--- a/src/api/transform/gemini-format.ts
+++ b/src/api/transform/gemini-format.ts
@@ -25,7 +25,11 @@ function isThoughtSignatureContentBlock(block: ExtendedContentBlockParam): block
 
 export function convertAnthropicContentToGemini(
 	content: ExtendedAnthropicContent,
-	options?: { includeThoughtSignatures?: boolean; toolIdToName?: Map<string, string> },
+	options?: {
+		includeThoughtSignatures?: boolean
+		toolIdToName?: Map<string, string>
+		fallbackThoughtSignatures?: boolean
+	},
 ): Part[] {
 	const includeThoughtSignatures = options?.includeThoughtSignatures ?? true
 	const toolIdToName = options?.toolIdToName
@@ -37,6 +41,10 @@ export function convertAnthropicContentToGemini(
 		if (sigBlock?.thoughtSignature) {
 			activeThoughtSignature = sigBlock.thoughtSignature
 		}
+	}
+
+	if (options?.fallbackThoughtSignatures) {
+		activeThoughtSignature = undefined
 	}
 
 	// Determine the signature to attach to function calls.
@@ -182,7 +190,11 @@ export function convertAnthropicContentToGemini(
 
 export function convertAnthropicMessageToGemini(
 	message: Anthropic.Messages.MessageParam,
-	options?: { includeThoughtSignatures?: boolean; toolIdToName?: Map<string, string> },
+	options?: {
+		includeThoughtSignatures?: boolean
+		toolIdToName?: Map<string, string>
+		fallbackThoughtSignatures?: boolean
+	},
 ): Content[] {
 	const parts = convertAnthropicContentToGemini(message.content, options)
 

--- a/src/api/transform/gemini-format.ts
+++ b/src/api/transform/gemini-format.ts
@@ -25,11 +25,13 @@ function isThoughtSignatureContentBlock(block: ExtendedContentBlockParam): block
 
 export function convertAnthropicContentToGemini(
 	content: ExtendedAnthropicContent,
+	// kilocode_change start
 	options?: {
 		includeThoughtSignatures?: boolean
 		toolIdToName?: Map<string, string>
 		fallbackThoughtSignatures?: boolean
 	},
+	// kilocode_change end
 ): Part[] {
 	const includeThoughtSignatures = options?.includeThoughtSignatures ?? true
 	const toolIdToName = options?.toolIdToName
@@ -43,9 +45,11 @@ export function convertAnthropicContentToGemini(
 		}
 	}
 
+	// kilocode_change start
 	if (options?.fallbackThoughtSignatures) {
 		activeThoughtSignature = undefined
 	}
+	// kilocode_change end
 
 	// Determine the signature to attach to function calls.
 	// If we're in a mode that expects signatures (includeThoughtSignatures is true):
@@ -190,11 +194,13 @@ export function convertAnthropicContentToGemini(
 
 export function convertAnthropicMessageToGemini(
 	message: Anthropic.Messages.MessageParam,
+	// kilocode_change start
 	options?: {
 		includeThoughtSignatures?: boolean
 		toolIdToName?: Map<string, string>
 		fallbackThoughtSignatures?: boolean
 	},
+	// kilocode_change end
 ): Content[] {
 	const parts = convertAnthropicContentToGemini(message.content, options)
 


### PR DESCRIPTION
This pull request introduces improved handling and testing of "thought signatures" for tool calls in Gemini and Vertex AI providers, specifically addressing cases where signature validation fails due to backend switching. The changes add robust retry logic with fallback signatures, expand test coverage, and enhance the conversion utilities for message formatting.

**GeminiHandler: Robust Retry Logic for Thought Signature Validation**
- Added retry logic to `GeminiHandler.createMessage` so that if signature validation fails before streaming, the handler retries once with fallback signatures (`skip_thought_signature_validator`), ensuring compatibility across backend switches [[1]](diffhunk://#diff-f12ab159cb6b5ce7823fbffc9b28ca717838b8170403c1bf7b99a1b9bae9d6a9R263-R266) [[2]](diffhunk://#diff-f12ab159cb6b5ce7823fbffc9b28ca717838b8170403c1bf7b99a1b9bae9d6a9R405-R433) [[3]](diffhunk://#diff-f12ab159cb6b5ce7823fbffc9b28ca717838b8170403c1bf7b99a1b9bae9d6a9R443).
- Updated streaming logic to track whether any content has been yielded, preventing unnecessary retries if partial success occurs [[1]](diffhunk://#diff-f12ab159cb6b5ce7823fbffc9b28ca717838b8170403c1bf7b99a1b9bae9d6a9R306) [[2]](diffhunk://#diff-f12ab159cb6b5ce7823fbffc9b28ca717838b8170403c1bf7b99a1b9bae9d6a9R361).

**Conversion Utilities: Support for Fallback Signatures**
- Enhanced `convertAnthropicContentToGemini` and `convertAnthropicMessageToGemini` to accept a `fallbackThoughtSignatures` option, which omits or replaces signatures as needed for retry scenarios [[1]](diffhunk://#diff-32451b44cbc6341d76fb8554cbdd01be1c187d41b5673fff6a0fb849259afdaaL28-R32) [[2]](diffhunk://#diff-32451b44cbc6341d76fb8554cbdd01be1c187d41b5673fff6a0fb849259afdaaR46-R49) [[3]](diffhunk://#diff-32451b44cbc6341d76fb8554cbdd01be1c187d41b5673fff6a0fb849259afdaaL185-R197).

**Test Coverage: Edge Cases and Fallbacks**
- Added tests to verify retry behavior in GeminiHandler when signature validation fails, confirming correct fallback signature usage and warning logging.
- Added tests to ensure `convertAnthropicMessageToGemini` omits or substitutes thought signatures based on options, covering both normal and fallback scenarios.

**VertexHandler: Consistent Tool Call History**
- Added a test to ensure that when native tools are enabled, Vertex tool call history includes the fallback thought signature (`skip_thought_signature_validator`) for compatibility.