### PR TITLE
fix: update broken docs link in STT setup popover

### DIFF
--- a/webview-ui/src/components/chat/STTSetupPopover.tsx
+++ b/webview-ui/src/components/chat/STTSetupPopover.tsx
@@ -36,7 +36,7 @@ export const STTSetupPopoverContent: React.FC<STTSetupPopoverContentProps> = ({
 	error,
 }) => {
 	const { t } = useTranslation()
-	const docsUrl = buildDocLink("features/experimental/voice-transcription", "stt_setup")
+	const docsUrl = buildDocLink("code-with-ai/features/speech-to-text", "stt_setup")
 
 	const handleOpenAiHelpClick = () => {
 		vscode.postMessage({ type: "openExternal", url: docsUrl })


### PR DESCRIPTION
The docs link in the speech-to-text setup popover points to
`/docs/features/experimental/voice-transcription`, which returns a 404.

Updated to `/docs/code-with-ai/features/speech-to-text`, which is the
current location of the voice transcription documentation.

Closes #6051