### PR TITLE
docs: update Kilo-Org/kilo references to Kilo-Org/kilocode

### DIFF
--- a/packages/kilo-docs/components/TopNav.tsx
+++ b/packages/kilo-docs/components/TopNav.tsx
@@ -337,7 +337,7 @@ export function TopNav({ onMobileMenuToggle, isMobileMenuOpen = false, showMobil
         <p>
           We're <Link href="https://blog.kilo.ai/p/kilo-cli">replatforming our extensions on the new Kilo CLI</Link>.
           Contribute to the new CLI and pre-release extensions at{" "}
-          <Link href="https://github.com/Kilo-Org/kilo">Kilo-Org/kilo</Link>.
+          <Link href="https://github.com/Kilo-Org/kilocode">Kilo-Org/kilocode</Link>.
         </p>
       </div>
 

--- a/packages/kilo-docs/pages/ai-providers/zenmux.md
+++ b/packages/kilo-docs/pages/ai-providers/zenmux.md
@@ -194,4 +194,4 @@ For additional support:
 
 - Visit the [ZenMux documentation](https://zenmux.ai/docs)
 - Contact ZenMux support through their dashboard
-- Check the [Kilo Code GitHub repository](https://github.com/Kilo-Org/kilo) for integration-specific issues
+- Check the [Kilo Code GitHub repository](https://github.com/Kilo-Org/kilocode) for integration-specific issues

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -13,7 +13,7 @@ Orchestrate agents from your terminal. Plan, debug, and code fast with keyboard-
 
 The Kilo Code CLI uses the same underlying technology that powers the IDE extensions, so you can expect the same workflow to handle agentic coding tasks from start to finish.
 
-**Source code & issues (Kilo CLI 1.0):** [Kilo-Org/kilo](https://github.com/Kilo-Org/kilo) · [Report an issue](https://github.com/Kilo-Org/kilo/issues)
+**Source code & issues (Kilo CLI 1.0):** [Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode) · [Report an issue](https://github.com/Kilo-Org/kilocode/issues)
 
 ## Getting Started
 
@@ -167,7 +167,7 @@ Review your code locally before pushing — catch issues early without waiting f
 Configuration is managed through:
 
 - `/connect` command for provider setup (interactive)
-- Config files in **`~/.config/kilo/`**: the CLI (Kilo CLI 1.0 from [Kilo-Org/kilo](https://github.com/Kilo-Org/kilo)) merges `config.json`, `opencode.json`, and `opencode.jsonc`. Use **`opencode.json`** (or `opencode.jsonc`) for provider, model, permission, and **MCP** settings. Restart the CLI after editing. See [Using MCP in the CLI](/docs/automate/mcp/using-in-cli) for MCP config format.
+- Config files in **`~/.config/kilo/`**: the CLI (Kilo CLI 1.0 from [Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode)) merges `config.json`, `opencode.json`, and `opencode.jsonc`. Use **`opencode.json`** (or `opencode.jsonc`) for provider, model, permission, and **MCP** settings. Restart the CLI after editing. See [Using MCP in the CLI](/docs/automate/mcp/using-in-cli) for MCP config format.
 - `kilo auth` for credential management
 
 ## Slash Commands
@@ -290,7 +290,7 @@ Any directory allowed here inherits the same defaults as the current workspace. 
 
 ## Configuration
 
-The Kilo CLI is a fork of [OpenCode](https://opencode.ai) and supports the same configuration options. The CLI you install with `npm install -g @kilocode/cli` (Kilo CLI 1.0) is built from [Kilo-Org/kilo](https://github.com/Kilo-Org/kilo). For comprehensive configuration documentation, see the [OpenCode Config documentation](https://opencode.ai/docs/config).
+The Kilo CLI is a fork of [OpenCode](https://opencode.ai) and supports the same configuration options. The CLI you install with `npm install -g @kilocode/cli` (Kilo CLI 1.0) is built from [Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode). For comprehensive configuration documentation, see the [OpenCode Config documentation](https://opencode.ai/docs/config).
 
 ### Config File Location (Kilo CLI 1.0)
 

--- a/packages/kilo-docs/pages/contributing/development-environment.md
+++ b/packages/kilo-docs/pages/contributing/development-environment.md
@@ -6,7 +6,7 @@ description: "Set up your development environment for contributing"
 # Development Environment
 
 {% callout type="info" %}
-**New versions of the VS Code extension and CLI are being developed in [Kilo-Org/Kilo](https://github.com/Kilo-Org/Kilo)** (extension at `packages/kilo-vscode`, CLI at `packages/opencode`). For extension and CLI development, please head over to that repository.
+**New versions of the VS Code extension and CLI are being developed in [Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode)** (extension at `packages/kilo-vscode`, CLI at `packages/opencode`). For extension and CLI development, please head over to that repository.
 {% /callout %}
 
 This document will help you set up your development environment and understand how to work with the codebase. Whether you're fixing bugs, adding features, or just exploring the code, this guide will get you started.
@@ -25,12 +25,12 @@ Before you begin, make sure you have the following installed:
 
 1. **Fork and Clone the Repository**:
    - **Fork the Repository**:
-     - Visit the [Kilo Code GitHub repository](https://github.com/Kilo-Org/kilo)
+     - Visit the [Kilo Code GitHub repository](https://github.com/Kilo-Org/kilocode)
      - Click the "Fork" button in the top-right corner to create your own copy.
    - **Clone Your Fork**:
      ```bash
-     git clone https://github.com/[YOUR-USERNAME]/kilo.git
-     cd kilo
+     git clone https://github.com/[YOUR-USERNAME]/kilocode.git
+     cd kilocode
      ```
      Replace `[YOUR-USERNAME]` with your actual GitHub username.
 

--- a/packages/kilo-docs/pages/getting-started/installing.md
+++ b/packages/kilo-docs/pages/getting-started/installing.md
@@ -48,7 +48,7 @@ Get started with Kilo Code by installing it on your preferred platform. Choose y
 ## Pre-Release Extension
 
 {% callout type="info" %}
-We're rebuilding Kilo Code from the ground up on the new [Kilo CLI](https://github.com/Kilo-Org/kilo). The pre-release extension is available for users who want to try the latest architecture and provide feedback, and don't mind some missing features and rough edges.
+We're rebuilding Kilo Code from the ground up on the new [Kilo CLI](https://github.com/Kilo-Org/kilocode). The pre-release extension is available for users who want to try the latest architecture and provide feedback, and don't mind some missing features and rough edges.
 {% /callout %}
 
 The pre-release extension is a complete rebuild featuring:
@@ -61,7 +61,7 @@ The pre-release extension is a complete rebuild featuring:
 
 This is an early pre-release. Core features like chat, markdown rendering, authentication, and model/mode switching are working. Some features from the stable extension are still being implemented.
 
-For the full feature status, see the [feature parity tracking document](https://github.com/Kilo-Org/kilo/blob/main/packages/kilo-vscode/docs/opencode-migration-plan.md).
+For the full feature status, see the [feature parity tracking document](https://github.com/Kilo-Org/kilocode/blob/main/packages/kilo-vscode/docs/opencode-migration-plan.md).
 
 ### Installing the Pre-Release
 
@@ -80,7 +80,7 @@ If you need to return to the stable version:
 
 ### Feedback and Issues
 
-Report issues or provide feedback in the [Kilo-Org/kilo repository](https://github.com/Kilo-Org/kilo/issues).
+Report issues or provide feedback in the [Kilo-Org/kilocode repository](https://github.com/Kilo-Org/kilocode/issues).
 
 ## Manual Installations
 


### PR DESCRIPTION
The repo was moved from `github.com/Kilo-Org/kilo` to `github.com/Kilo-Org/kilocode`. This PR updates all stale references in the docs.

### Files changed
- `packages/kilo-docs/components/TopNav.tsx` — announcement banner link
- `packages/kilo-docs/pages/ai-providers/zenmux.md` — support section repo link
- `packages/kilo-docs/pages/code-with-ai/platforms/cli.md` — source code, issues, config ref links
- `packages/kilo-docs/pages/contributing/development-environment.md` — callout, fork/clone URLs
- `packages/kilo-docs/pages/getting-started/installing.md` — CLI link, feature parity doc, feedback link