### PR TITLE
feat(VSCode): pass highlighted content as model context

### DIFF
--- a/packages/kilo-docs/components/TopNav.tsx
+++ b/packages/kilo-docs/components/TopNav.tsx
@@ -337,7 +337,7 @@ export function TopNav({ onMobileMenuToggle, isMobileMenuOpen = false, showMobil
         <p>
           We're <Link href="https://blog.kilo.ai/p/kilo-cli">replatforming our extensions on the new Kilo CLI</Link>.
           Contribute to the new CLI and pre-release extensions at{" "}
-          <Link href="https://github.com/Kilo-Org/kilo">Kilo-Org/kilo</Link>.
+          <Link href="https://github.com/Kilo-Org/kilocode">Kilo-Org/kilocode</Link>.
         </p>
       </div>
 

--- a/packages/kilo-docs/pages/ai-providers/zenmux.md
+++ b/packages/kilo-docs/pages/ai-providers/zenmux.md
@@ -194,4 +194,4 @@ For additional support:
 
 - Visit the [ZenMux documentation](https://zenmux.ai/docs)
 - Contact ZenMux support through their dashboard
-- Check the [Kilo Code GitHub repository](https://github.com/Kilo-Org/kilo) for integration-specific issues
+- Check the [Kilo Code GitHub repository](https://github.com/Kilo-Org/kilocode) for integration-specific issues

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -13,7 +13,7 @@ Orchestrate agents from your terminal. Plan, debug, and code fast with keyboard-
 
 The Kilo Code CLI uses the same underlying technology that powers the IDE extensions, so you can expect the same workflow to handle agentic coding tasks from start to finish.
 
-**Source code & issues (Kilo CLI 1.0):** [Kilo-Org/kilo](https://github.com/Kilo-Org/kilo) · [Report an issue](https://github.com/Kilo-Org/kilo/issues)
+**Source code & issues (Kilo CLI 1.0):** [Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode) · [Report an issue](https://github.com/Kilo-Org/kilocode/issues)
 
 ## Getting Started
 
@@ -167,7 +167,7 @@ Review your code locally before pushing — catch issues early without waiting f
 Configuration is managed through:
 
 - `/connect` command for provider setup (interactive)
-- Config files in **`~/.config/kilo/`**: the CLI (Kilo CLI 1.0 from [Kilo-Org/kilo](https://github.com/Kilo-Org/kilo)) merges `config.json`, `opencode.json`, and `opencode.jsonc`. Use **`opencode.json`** (or `opencode.jsonc`) for provider, model, permission, and **MCP** settings. Restart the CLI after editing. See [Using MCP in the CLI](/docs/automate/mcp/using-in-cli) for MCP config format.
+- Config files in **`~/.config/kilo/`**: the CLI (Kilo CLI 1.0 from [Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode)) merges `config.json`, `opencode.json`, and `opencode.jsonc`. Use **`opencode.json`** (or `opencode.jsonc`) for provider, model, permission, and **MCP** settings. Restart the CLI after editing. See [Using MCP in the CLI](/docs/automate/mcp/using-in-cli) for MCP config format.
 - `kilo auth` for credential management
 
 ## Slash Commands
@@ -290,7 +290,7 @@ Any directory allowed here inherits the same defaults as the current workspace. 
 
 ## Configuration
 
-The Kilo CLI is a fork of [OpenCode](https://opencode.ai) and supports the same configuration options. The CLI you install with `npm install -g @kilocode/cli` (Kilo CLI 1.0) is built from [Kilo-Org/kilo](https://github.com/Kilo-Org/kilo). For comprehensive configuration documentation, see the [OpenCode Config documentation](https://opencode.ai/docs/config).
+The Kilo CLI is a fork of [OpenCode](https://opencode.ai) and supports the same configuration options. The CLI you install with `npm install -g @kilocode/cli` (Kilo CLI 1.0) is built from [Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode). For comprehensive configuration documentation, see the [OpenCode Config documentation](https://opencode.ai/docs/config).
 
 ### Config File Location (Kilo CLI 1.0)
 

--- a/packages/kilo-docs/pages/contributing/development-environment.md
+++ b/packages/kilo-docs/pages/contributing/development-environment.md
@@ -6,7 +6,7 @@ description: "Set up your development environment for contributing"
 # Development Environment
 
 {% callout type="info" %}
-**New versions of the VS Code extension and CLI are being developed in [Kilo-Org/Kilo](https://github.com/Kilo-Org/Kilo)** (extension at `packages/kilo-vscode`, CLI at `packages/opencode`). For extension and CLI development, please head over to that repository.
+**New versions of the VS Code extension and CLI are being developed in [Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode)** (extension at `packages/kilo-vscode`, CLI at `packages/opencode`). For extension and CLI development, please head over to that repository.
 {% /callout %}
 
 This document will help you set up your development environment and understand how to work with the codebase. Whether you're fixing bugs, adding features, or just exploring the code, this guide will get you started.
@@ -25,12 +25,12 @@ Before you begin, make sure you have the following installed:
 
 1. **Fork and Clone the Repository**:
    - **Fork the Repository**:
-     - Visit the [Kilo Code GitHub repository](https://github.com/Kilo-Org/kilo)
+     - Visit the [Kilo Code GitHub repository](https://github.com/Kilo-Org/kilocode)
      - Click the "Fork" button in the top-right corner to create your own copy.
    - **Clone Your Fork**:
      ```bash
-     git clone https://github.com/[YOUR-USERNAME]/kilo.git
-     cd kilo
+     git clone https://github.com/[YOUR-USERNAME]/kilocode.git
+     cd kilocode
      ```
      Replace `[YOUR-USERNAME]` with your actual GitHub username.
 

--- a/packages/kilo-docs/pages/getting-started/installing.md
+++ b/packages/kilo-docs/pages/getting-started/installing.md
@@ -48,7 +48,7 @@ Get started with Kilo Code by installing it on your preferred platform. Choose y
 ## Pre-Release Extension
 
 {% callout type="info" %}
-We're rebuilding Kilo Code from the ground up on the new [Kilo CLI](https://github.com/Kilo-Org/kilo). The pre-release extension is available for users who want to try the latest architecture and provide feedback, and don't mind some missing features and rough edges.
+We're rebuilding Kilo Code from the ground up on the new [Kilo CLI](https://github.com/Kilo-Org/kilocode). The pre-release extension is available for users who want to try the latest architecture and provide feedback, and don't mind some missing features and rough edges.
 {% /callout %}
 
 The pre-release extension is a complete rebuild featuring:
@@ -61,7 +61,7 @@ The pre-release extension is a complete rebuild featuring:
 
 This is an early pre-release. Core features like chat, markdown rendering, authentication, and model/mode switching are working. Some features from the stable extension are still being implemented.
 
-For the full feature status, see the [feature parity tracking document](https://github.com/Kilo-Org/kilo/blob/main/packages/kilo-vscode/docs/opencode-migration-plan.md).
+For the full feature status, see the [feature parity tracking document](https://github.com/Kilo-Org/kilocode/blob/main/packages/kilo-vscode/docs/opencode-migration-plan.md).
 
 ### Installing the Pre-Release
 
@@ -80,7 +80,7 @@ If you need to return to the stable version:
 
 ### Feedback and Issues
 
-Report issues or provide feedback in the [Kilo-Org/kilo repository](https://github.com/Kilo-Org/kilo/issues).
+Report issues or provide feedback in the [Kilo-Org/kilocode repository](https://github.com/Kilo-Org/kilocode/issues).
 
 ## Manual Installations
 

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1060,7 +1060,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const editor = vscode.window.activeTextEditor
       if (editor && editor.document.uri.scheme === "file") {
         const url = editorContextUrl(editor)
-        const already = files?.some((f) => f.url === url)
+        const baseUrl = url.split("?")[0]
+        const already = files?.some((f) => f.url.split("?")[0] === baseUrl)
         if (!already) {
           parts.push({ type: "file", mime: "text/plain", url })
         }

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -18,6 +18,7 @@ import {
   buildSettingPath,
   mapSSEEventToWebviewMessage,
 } from "./kilo-provider-utils"
+import { editorContextUrl } from "./editor-context"
 
 export class KiloProvider implements vscode.WebviewViewProvider, TelemetryPropertiesProvider {
   public static readonly viewType = "kilo-code.new.sidebarView"
@@ -1058,7 +1059,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       // Inject active editor file as context
       const editor = vscode.window.activeTextEditor
       if (editor && editor.document.uri.scheme === "file") {
-        const url = editor.document.uri.toString()
+        const url = editorContextUrl(editor)
         const already = files?.some((f) => f.url === url)
         if (!already) {
           parts.push({ type: "file", mime: "text/plain", url })

--- a/packages/kilo-vscode/src/editor-context.ts
+++ b/packages/kilo-vscode/src/editor-context.ts
@@ -28,8 +28,5 @@ export function editorContextUrl(editor: Editor): string {
   const end =
     selection.end.character === 0 && selection.end.line > selection.start.line ? Math.max(start, rawEnd - 1) : rawEnd
 
-  const file = new URL(uri)
-  file.searchParams.set("start", String(start))
-  file.searchParams.set("end", String(end))
-  return file.toString()
+  return `${uri}?start=${start}&end=${end}`
 }

--- a/packages/kilo-vscode/src/editor-context.ts
+++ b/packages/kilo-vscode/src/editor-context.ts
@@ -1,0 +1,35 @@
+type Position = {
+  line: number
+  character: number
+}
+
+type Selection = {
+  isEmpty: boolean
+  start: Position
+  end: Position
+}
+
+type Editor = {
+  document: {
+    uri: {
+      toString(): string
+    }
+  }
+  selection: Selection
+}
+
+export function editorContextUrl(editor: Editor): string {
+  const uri = editor.document.uri.toString()
+  const selection = editor.selection
+  if (selection.isEmpty) return uri
+
+  const start = Math.min(selection.start.line, selection.end.line) + 1
+  const rawEnd = Math.max(selection.start.line, selection.end.line) + 1
+  const end =
+    selection.end.character === 0 && selection.end.line > selection.start.line ? Math.max(start, rawEnd - 1) : rawEnd
+
+  const file = new URL(uri)
+  file.searchParams.set("start", String(start))
+  file.searchParams.set("end", String(end))
+  return file.toString()
+}

--- a/packages/kilo-vscode/tests/unit/editor-context.test.ts
+++ b/packages/kilo-vscode/tests/unit/editor-context.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test"
+import { editorContextUrl } from "../../src/editor-context"
+
+function createEditor(input: {
+  uri: string
+  isEmpty: boolean
+  startLine: number
+  startChar: number
+  endLine: number
+  endChar: number
+}) {
+  return {
+    document: {
+      uri: {
+        toString: () => input.uri,
+      },
+    },
+    selection: {
+      isEmpty: input.isEmpty,
+      start: { line: input.startLine, character: input.startChar },
+      end: { line: input.endLine, character: input.endChar },
+    },
+  }
+}
+
+describe("editorContextUrl", () => {
+  it("returns original URL when selection is empty", () => {
+    const editor = createEditor({
+      uri: "file:///workspace/a.ts",
+      isEmpty: true,
+      startLine: 4,
+      startChar: 2,
+      endLine: 4,
+      endChar: 2,
+    })
+
+    expect(editorContextUrl(editor)).toBe("file:///workspace/a.ts")
+  })
+
+  it("adds start/end lines for normal multi-line selection", () => {
+    const editor = createEditor({
+      uri: "file:///workspace/a.ts",
+      isEmpty: false,
+      startLine: 2,
+      startChar: 1,
+      endLine: 5,
+      endChar: 8,
+    })
+
+    expect(editorContextUrl(editor)).toBe("file:///workspace/a.ts?start=3&end=6")
+  })
+
+  it("normalizes reversed selection direction", () => {
+    const editor = createEditor({
+      uri: "file:///workspace/a.ts",
+      isEmpty: false,
+      startLine: 9,
+      startChar: 3,
+      endLine: 6,
+      endChar: 1,
+    })
+
+    expect(editorContextUrl(editor)).toBe("file:///workspace/a.ts?start=7&end=10")
+  })
+
+  it("avoids over-including trailing line when selection ends at column zero", () => {
+    const editor = createEditor({
+      uri: "file:///workspace/a.ts",
+      isEmpty: false,
+      startLine: 2,
+      startChar: 5,
+      endLine: 6,
+      endChar: 0,
+    })
+
+    expect(editorContextUrl(editor)).toBe("file:///workspace/a.ts?start=3&end=6")
+  })
+})


### PR DESCRIPTION
Fixes #401 

## Context

This PR adds VS Code support for passing the currently highlighted editor content as focused model context when sending a chat/edit message. This addresses #401 and helps the model focus on the exact block a user is asking about.

## Implementation

- Added `editorContextUrl()` in `packages/kilo-vscode/src/editor-context.ts`.
- The helper converts the active editor selection into `file://...?...start=<line>&end=<line>` query params.
- Updated `KiloProvider` to use that helper when injecting active editor file context.
- Kept previous behavior for empty selection (full file URL without range params).
- Added targeted unit tests for URL generation edge cases:
  - empty selection
  - normal multi-line selection
  - reversed selection direction
  - line-boundary selection ending at column 0

## Screenshots

| before | after |
| ------ | ----- |
| N/A (context payload change) | N/A (context payload change) |

## How to Test

- Open VS Code with the Kilo extension and any code file.
- Highlight a block of code and send a prompt (for example: `what does this code block do?`).
- Confirm model responses are focused on the selected block.
- Repeat with no selection and confirm normal full-file context behavior.
- Automated checks run in this branch:
  - `bun run --cwd packages/kilo-vscode check-types`
  - `bun test tests/unit/editor-context.test.ts` (from `packages/kilo-vscode/`)

## Get in Touch

thomas07374