### PR TITLE
docs: redirect legacy voice transcription docs URL

### DIFF
--- a/packages/kilo-docs/previous-docs-redirects.js
+++ b/packages/kilo-docs/previous-docs-redirects.js
@@ -201,6 +201,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source: "/docs/features/experimental/voice-transcription",
+    destination: "/docs/code-with-ai/features/speech-to-text",
+    basePath: false,
+    permanent: true,
+  },
+  {
     source: "/docs/basic-usage/task-todo-list",
     destination: "/docs/code-with-ai/features/task-todo-list",
     basePath: false,


### PR DESCRIPTION
## Summary
- add a permanent docs redirect for the broken speech-recognition setup link
- map /docs/features/experimental/voice-transcription to /docs/code-with-ai/features/speech-to-text
- preserve backward compatibility for extension versions that still point to the legacy path

Fixes #6051