### PR TITLE
docs(custom-modes): clarify legacy Prompts/JSON references

### DIFF
--- a/packages/kilo-docs/pages/customize/custom-modes.md
+++ b/packages/kilo-docs/pages/customize/custom-modes.md
@@ -125,6 +125,10 @@ You can directly edit the configuration files to create or modify custom modes. 
 - **Project Modes:** Edit `.kilocodemodes` in your project root (YAML preferred; JSON still supported for compatibility).
 - **Open from UI:** Open the Modes area, click <Codicon name="gear" /> next to Global or Project Modes, then choose **Edit Global Modes** or **Edit Project Modes**.
 
+{% callout type="info" title="Legacy Docs Note" %}
+Older references to a "Prompts" tab or JSON-only mode editing are outdated. Current versions use the **Modes** area and write to YAML-first files (with JSON fallback for compatibility).
+{% /callout %}
+
 These files define an array/list of custom modes.
 
 {% callout type="info" title="Why JSON Files May Still Exist" %}

--- a/packages/kilo-docs/previous-docs-redirects.js
+++ b/packages/kilo-docs/previous-docs-redirects.js
@@ -201,6 +201,12 @@ module.exports = [
     permanent: true,
   },
   {
+    source: "/docs/features/custom-modes",
+    destination: "/docs/customize/custom-modes",
+    basePath: false,
+    permanent: true,
+  },
+  {
     source: "/docs/basic-usage/task-todo-list",
     destination: "/docs/code-with-ai/features/task-todo-list",
     basePath: false,


### PR DESCRIPTION
## Summary
- add redirect from legacy /docs/features/custom-modes to current custom modes docs
- add explicit legacy note clarifying that current UI uses the Modes area (not old Prompts wording)
- clarify YAML-first mode editing with JSON fallback compatibility

Fixes #2147