### PR TITLE
docs(codebase-indexing): clarify llama.cpp batch tuning

### DIFF
--- a/packages/kilo-docs/pages/customize/context/codebase-indexing.md
+++ b/packages/kilo-docs/pages/customize/context/codebase-indexing.md
@@ -199,6 +199,23 @@ The indexer automatically excludes:
 
 If your local embedding server is based on llama.cpp (including Ollama), indexing can fail with errors about `n_ubatch` or `GGML_ASSERT`. Ensure both batch size (`-b`) and micro-batch size (`-ub`) are set to the same value for embedding models, then restart the server. For Ollama, configure `num_batch` in your Modelfile or request options to match the same effective value.
 
+Recommended baseline for llama.cpp embedding servers:
+
+- Keep `-ub` and `-b` equal (for example, both `8192`)
+- Set `-c` to `np * ub` (for example, `-np 4` and `-ub 8192` implies `-c 32768`)
+- Restart the embedding server after changing these values
+
+Example:
+
+```bash
+llama-server \
+  --embeddings \
+  -np 4 \
+  -ub 8192 \
+  -b 8192 \
+  -c 32768
+```
+
 ## Using the Search Feature
 
 Once indexed, Kilo Code can use the [`codebase_search`](/docs/automate/tools/codebase-search) tool to find relevant code:


### PR DESCRIPTION
## Summary
- expand llama.cpp/Ollama troubleshooting guidance for embedding-related indexing failures
- document practical parameter relationships (-ub, -b, -c, -np) that avoid 
_ubatch assertion errors
- add a concrete command example users can adapt quickly

Fixes #1553