### PR TITLE
feat: add optional cwd path argument to serve command

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -20,8 +20,8 @@ export const ServeCommand = cmd({
     if (args.cwd) {
       try {
         process.chdir(args.cwd)
-      } catch {
-        console.error(`Failed to change directory to ${args.cwd}`)
+      } catch(err) {
+        console.error(`Failed to change directory to ${args.cwd}:`, err)
         process.exit(1)
       }
     }

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -5,14 +5,26 @@ import { Flag } from "../../flag/flag"
 import { Instance } from "../../project/instance" // kilocode_change
 
 export const ServeCommand = cmd({
-  command: "serve",
-  builder: (yargs) => withNetworkOptions(yargs),
+  command: "serve [cwd]",
+  builder: (yargs) =>
+    withNetworkOptions(yargs).positional("cwd", {
+      type: "string",
+      describe: "path to start kilo server in", // kilocode_change
+    }),
   describe: "starts a headless kilo server", // kilocode_change
   handler: async (args) => {
     if (!Flag.KILO_SERVER_PASSWORD) {
       console.log("Warning: KILO_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = await resolveNetworkOptions(args)
+    if (args.cwd) {
+      try {
+        process.chdir(args.cwd)
+      } catch {
+        console.error(`Failed to change directory to ${args.cwd}`)
+        process.exit(1)
+      }
+    }
     const server = Server.listen(opts)
     console.log(`kilo server listening on http://${server.hostname}:${server.port}`) // kilocode_change
     // kilocode_change start - graceful signal shutdown


### PR DESCRIPTION
Fixes https://github.com/Kilo-Org/kilocode/issues/6119

### Summary

- for debugging, bun needs to start in the development build directory
- makes it currently impossible to debug different scenarios/projects

This patch adds positional argument for cwd folder `opencode serve [cwd]`

Usage:
```bash
bun run --cwd /path/to/packages/opencode --inspect-wait=ws://localhost:6499/ ./src/index.ts \
  serve --port 4096 /my/project/path
```