### PR TITLE
fix(lsp): terminate LSP process trees on failure and shutdown

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -12,6 +12,7 @@ import { NamedError } from "@opencode-ai/util/error"
 import { withTimeout } from "../util/timeout"
 import { Instance } from "../project/instance"
 import { Filesystem } from "../util/filesystem"
+import { Shell } from "../shell/shell" // kilocode_change
 
 const DIAGNOSTICS_DEBOUNCE_MS = 150
 
@@ -240,7 +241,7 @@ export namespace LSPClient {
         l.info("shutting down")
         connection.end()
         connection.dispose()
-        input.server.process.kill()
+        await Shell.killTree(input.server.process) // kilocode_change
         l.info("shutdown")
       },
     }

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -115,6 +115,7 @@ export namespace LSP {
             return {
               process: spawn(item.command[0], item.command.slice(1), {
                 cwd: root,
+                detached: process.platform !== "win32",
                 env: {
                   ...process.env,
                   ...item.env,

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -10,6 +10,7 @@ import { Config } from "../config/config"
 import { spawn } from "child_process"
 import { Instance } from "../project/instance"
 import { Flag } from "@/flag/flag"
+import { Shell } from "../shell/shell" // kilocode_change
 
 export namespace LSP {
   const log = Log.create({ service: "lsp" })
@@ -199,21 +200,21 @@ export namespace LSP {
         serverID: server.id,
         server: handle,
         root,
-      }).catch((err) => {
+      }).catch(async (err) => {
         s.broken.add(key)
-        handle.process.kill()
+        await Shell.killTree(handle.process) // kilocode_change
         log.error(`Failed to initialize LSP client ${server.id}`, { error: err })
         return undefined
       })
 
       if (!client) {
-        handle.process.kill()
+        await Shell.killTree(handle.process) // kilocode_change
         return undefined
       }
 
       const existing = s.clients.find((x) => x.root === root && x.serverID === server.id)
       if (existing) {
-        handle.process.kill()
+        await Shell.killTree(handle.process) // kilocode_change
         return existing
       }
 


### PR DESCRIPTION
## Summary
- replace direct `process.kill()` usage in LSP lifecycle paths with `Shell.killTree(...)`
- apply tree-kill on client initialization failure, duplicate client short-circuit, and client shutdown
- spawn LSP servers in detached process groups on non-Windows so process-tree termination can kill descendants
- ensure Windows LSP child-process trees (like biome `lsp-proxy`) are actually terminated

## Why
Issue #6109 reports lingering LSP processes on Windows after CLI exit. `ChildProcess.kill()` is not enough for process trees on Windows.

Fixes #6109
