### PR TITLE
fix(project): normalize Windows git rev-parse paths

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -51,16 +51,7 @@ export namespace Project {
   }
 
   export function normalizeGitPath(raw: string, cwd: string, win = process.platform === "win32") {
-    const value = raw.trim()
-    if (!value) return ""
-    if (!win) return path.resolve(cwd, value)
-    if (/^[a-z]:[\\/]/i.test(value)) return path.win32.normalize(value)
-    if (/^\/[a-z]\//i.test(value)) {
-      const drive = value[1]!.toUpperCase()
-      const rest = value.slice(3).replace(/\//g, "\\")
-      return path.win32.normalize(`${drive}:\\${rest}`)
-    }
-    return path.win32.resolve(cwd, value)
+    return Filesystem.normalizeGitPath(raw, cwd, win ? "win32" : "linux")
   }
 
   export async function fromDirectory(directory: string) {

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -59,6 +59,20 @@ export namespace Filesystem {
       return p
     }
   }
+
+  export function normalizeGitPath(raw: string, cwd: string, platform = process.platform): string {
+    const value = raw.trim()
+    if (!value) return ""
+    if (platform !== "win32") return path.resolve(cwd, value)
+    if (/^[a-z]:[\\/]/i.test(value)) return path.win32.normalize(value)
+    if (/^\/[a-z]\//i.test(value)) {
+      const drive = value[1]!.toUpperCase()
+      const rest = value.slice(3).replace(/\//g, "\\")
+      return path.win32.normalize(`${drive}:\\${rest}`)
+    }
+    return path.win32.resolve(cwd, value)
+  }
+
   export function overlaps(a: string, b: string, platform = process.platform) {
     return isInside(a, b, platform) || isInside(b, a, platform)
   }

--- a/packages/opencode/test/file/path-traversal.test.ts
+++ b/packages/opencode/test/file/path-traversal.test.ts
@@ -29,6 +29,15 @@ describe("Filesystem.contains", () => {
     expect(Filesystem.contains("/project", "/project-other/file")).toBe(false)
     expect(Filesystem.contains("/project", "/projectfile")).toBe(false)
   })
+
+  test("blocks cross-drive access on Windows", () => {
+    expect(Filesystem.contains("C:\\project", "D:\\other\\file.txt", "win32")).toBe(false)
+  })
+
+  test("handles Git Bash style paths on Windows", () => {
+    expect(Filesystem.contains("C:\\project", "/c/project/src/file.ts", "win32")).toBe(true)
+    expect(Filesystem.contains("C:\\project", "/d/project/src/file.ts", "win32")).toBe(false)
+  })
 })
 
 /*

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -136,6 +136,26 @@ describe("Project.fromDirectory", () => {
   })
 })
 
+describe("Project.normalizeGitPath", () => {
+  test("normalizes git bash drive-prefixed paths on Windows", async () => {
+    const p = await loadProject()
+    const result = p.normalizeGitPath("/d/workspaces/repo\n", "C:\\Users\\dev\\repo", true)
+    expect(result).toBe(path.win32.normalize("D:\\workspaces\\repo"))
+  })
+
+  test("resolves relative git paths on Windows", async () => {
+    const p = await loadProject()
+    const result = p.normalizeGitPath(".git\n", "C:\\Users\\dev\\repo", true)
+    expect(result).toBe(path.win32.normalize("C:\\Users\\dev\\repo\\.git"))
+  })
+
+  test("resolves absolute paths on non-Windows", async () => {
+    const p = await loadProject()
+    const result = p.normalizeGitPath("/tmp/repo\n", "/home/dev/repo", false)
+    expect(result).toBe("/tmp/repo")
+  })
+})
+
 describe("Project.fromDirectory with worktrees", () => {
   test("should set worktree to root when called from root", async () => {
     const p = await loadProject()

--- a/packages/opencode/test/util/filesystem.test.ts
+++ b/packages/opencode/test/util/filesystem.test.ts
@@ -36,4 +36,19 @@ describe("util.filesystem", () => {
 
     await rm(tmp, { recursive: true, force: true })
   })
+
+  test("normalizeGitPath handles Git Bash drive-prefixed paths on Windows", () => {
+    const result = Filesystem.normalizeGitPath("/d/workspaces/repo", "C:\\code", "win32")
+    expect(result).toBe("D:\\workspaces\\repo")
+  })
+
+  test("normalizeGitPath resolves relative Windows paths against cwd", () => {
+    const result = Filesystem.normalizeGitPath("..\\shared\\.git", "C:\\work\\repo", "win32")
+    expect(result).toBe(path.win32.resolve("C:\\work\\repo", "..\\shared\\.git"))
+  })
+
+  test("normalizeGitPath resolves non-Windows paths with path.resolve", () => {
+    const result = Filesystem.normalizeGitPath("../.git", "/home/user/repo", "linux")
+    expect(result).toBe(path.resolve("/home/user/repo", "../.git"))
+  })
 })


### PR DESCRIPTION
## Summary
- add `Project.normalizeGitPath(...)` to normalize git `rev-parse` output across Windows shells
- convert Git Bash/MSYS style paths like `/c/...` and `/d/...` to proper `win32` absolute paths
- apply normalization to both `--show-toplevel` and `--git-common-dir` path handling
- harden `Filesystem.contains` and `Filesystem.overlaps` for Windows cross-drive boundaries
- normalize Git Bash path forms in containment checks used by permission/path guards
- normalize `git rev-parse --git-dir` output in file watcher setup to avoid mixed path mismatches
- refactor duplicated git-path normalization into shared `Filesystem.normalizeGitPath(...)`
- add regression tests for Windows path normalization and containment edge cases

## Scope
This PR addresses part of the Windows path issues tracked in #6099.
