### PR TITLE
fix(vscode): reload sidebar assets after extension updates

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -9,7 +9,7 @@ import {
 } from "./services/cli-backend"
 import { handleChatCompletionRequest } from "./services/autocomplete/chat-autocomplete/handleChatCompletionRequest"
 import { handleChatCompletionAccepted } from "./services/autocomplete/chat-autocomplete/handleChatCompletionAccepted"
-import { buildWebviewHtml } from "./utils"
+import { buildWebviewHtml, withVersionQuery } from "./utils"
 import { TelemetryProxy, type TelemetryPropertiesProvider } from "./services/telemetry"
 import {
   sessionToWebview,
@@ -1524,8 +1524,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
   private _getHtmlForWebview(webview: vscode.Webview): string {
     return buildWebviewHtml(webview, {
-      scriptUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "webview.js")),
-      styleUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "webview.css")),
+      scriptUri: withVersionQuery(
+        webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "webview.js")),
+        this.extensionVersion,
+      ),
+      styleUri: withVersionQuery(
+        webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "webview.css")),
+        this.extensionVersion,
+      ),
       iconsBaseUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "assets", "icons")),
       title: "Kilo Code",
       port: this.connectionService.getServerInfo()?.port,

--- a/packages/kilo-vscode/src/utils.ts
+++ b/packages/kilo-vscode/src/utils.ts
@@ -6,6 +6,15 @@ export function getNonce(): string {
   return crypto.randomBytes(16).toString("hex")
 }
 
+export function withVersionQuery(uri: vscode.Uri, version?: string): vscode.Uri {
+  if (!version || version === "unknown") {
+    return uri
+  }
+  const query = new URLSearchParams(uri.query)
+  query.set("v", version)
+  return uri.with({ query: query.toString() })
+}
+
 export function buildWebviewHtml(
   webview: vscode.Webview,
   opts: {


### PR DESCRIPTION
## Summary
- add withVersionQuery(...) helper for webview resource URIs
- append extension version query parameter to sidebar webview JS/CSS asset URIs
- ensures webview loads the updated bundle after extension restart/update instead of reusing stale cached assets

## Why
Issue #6086 reports that after updating/restarting the extension, the existing sidebar view can keep rendering the old UI until manually closed and reopened.

Fixes #6086