### PR TITLE
fix(vscode): terminate full sidecar process tree on shutdown

### DIFF
--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -3,7 +3,7 @@ import * as crypto from "crypto"
 import * as fs from "fs"
 import * as path from "path"
 import * as vscode from "vscode"
-import { parseServerPort } from "./server-utils"
+import { killProcessTree, parseServerPort } from "./server-utils"
 
 export interface ServerInstance {
   port: number
@@ -76,6 +76,7 @@ export class ServerManager {
           KILO_APP_VERSION: this.context.extension.packageJSON.version,
           KILO_VSCODE_VERSION: vscode.version,
         },
+        detached: process.platform !== "win32",
         stdio: ["ignore", "pipe", "pipe"],
       })
       console.log("[Kilo New] ServerManager: 📦 Process spawned with PID:", serverProcess.pid)
@@ -120,7 +121,7 @@ export class ServerManager {
       setTimeout(() => {
         if (!resolved) {
           console.error("[Kilo New] ServerManager: ⏰ Server startup timeout (30s)")
-          serverProcess.kill()
+          killProcessTree(serverProcess)
           reject(new Error("Server startup timeout"))
         }
       }, 30000)
@@ -137,7 +138,7 @@ export class ServerManager {
 
   dispose(): void {
     if (this.instance) {
-      this.instance.process.kill("SIGTERM")
+      killProcessTree(this.instance.process)
       this.instance = null
     }
   }

--- a/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
@@ -56,7 +56,7 @@ describe("buildKillTreeCommand", () => {
   it("builds process-group kill command on POSIX", () => {
     expect(buildKillTreeCommand(987, "linux")).toEqual({
       command: "kill",
-      args: ["-TERM", "-987"],
+      args: ["-TERM", "--", "-987"],
     })
   })
 })

--- a/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { parseServerPort } from "../../src/services/cli-backend/server-utils"
+import { buildKillTreeCommand, parseServerPort } from "../../src/services/cli-backend/server-utils"
 
 describe("parseServerPort", () => {
   it("parses port from standard CLI startup message", () => {
@@ -42,5 +42,21 @@ describe("parseServerPort", () => {
   it("matches only first occurrence when multiple ports present", () => {
     const output = "listening on http://127.0.0.1:3000 and http://127.0.0.1:4000"
     expect(parseServerPort(output)).toBe(3000)
+  })
+})
+
+describe("buildKillTreeCommand", () => {
+  it("builds taskkill command on Windows", () => {
+    expect(buildKillTreeCommand(1234, "win32")).toEqual({
+      command: "taskkill",
+      args: ["/pid", "1234", "/f", "/t"],
+    })
+  })
+
+  it("builds process-group kill command on POSIX", () => {
+    expect(buildKillTreeCommand(987, "linux")).toEqual({
+      command: "kill",
+      args: ["-TERM", "-987"],
+    })
   })
 })


### PR DESCRIPTION
## Summary
- terminate the CLI sidecar using full process-tree termination instead of killing only the parent process
- run sidecar as a detached process group on non-Windows so group signals can cleanly terminate all descendants
- apply tree termination both on startup timeout and extension dispose
- add unit tests for cross-platform kill-command generation
- guard kill-command spawn failures by attaching `error` listeners to spawned `kill`/`taskkill` processes

## Testing
- `bun` is not available in this environment, so local bun test execution was not possible

Fixes #6083
