### PR TITLE
fix(ui): show full permission targets in approval prompt

### DIFF
--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -586,6 +586,24 @@
     margin: 4px 0 0 0;
     text-align: right;
   }
+
+  [data-slot="permission-targets"] {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 8px;
+    max-height: 120px;
+    overflow-y: auto;
+  }
+
+  [data-slot="permission-target"] {
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-small);
+    line-height: var(--line-height-large);
+    color: var(--text-base);
+    word-break: break-all;
+    white-space: normal;
+  }
 }
 
 [data-component="question-prompt"] {


### PR DESCRIPTION
## Summary
- surface full permission targets directly in the approval prompt for tool permissions
- include request patterns plus path/filePath/filepath/parentDir metadata when present
- apply the same visibility improvement to both direct tool permissions and child-session permissions

## Why
After the approval UI streamlining, users could miss critical path context when approving permissions. This makes full target paths visible before approval.

Fixes #6092

## Validation
- Typecheck could not be run in this environment because required workspace tooling (`bun` / `tsgo`) is not installed.