### PR TITLE
fix(ui): restore markdown heading hierarchy

### DIFF
--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -50,7 +50,7 @@
 
   h5,
   h6 {
-    font-size: var(--font-size-small);
+    font-size: var(--font-size-base);
   }
 
   /* Emphasis & Strong: Neutral strong color */

--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -16,19 +16,41 @@
     margin-bottom: 0;
   }
 
-  /* Headings: Same size, distinguished by color and spacing */
+  /* Headings: clear visual hierarchy */
   h1,
   h2,
   h3,
   h4,
   h5,
   h6 {
-    font-size: var(--font-size-base);
     color: var(--text-strong);
     font-weight: var(--font-weight-medium);
     margin-top: 2rem;
     margin-bottom: 0.75rem;
     line-height: var(--line-height-large);
+  }
+
+  h1 {
+    font-size: var(--font-size-x-large);
+    line-height: var(--line-height-large);
+  }
+
+  h2 {
+    font-size: calc(var(--font-size-large) + 2px);
+    line-height: var(--line-height-large);
+  }
+
+  h3 {
+    font-size: var(--font-size-large);
+  }
+
+  h4 {
+    font-size: var(--font-size-base);
+  }
+
+  h5,
+  h6 {
+    font-size: var(--font-size-small);
   }
 
   /* Emphasis & Strong: Neutral strong color */


### PR DESCRIPTION
## Summary
- add distinct heading sizes for `h1`-`h6` in shared markdown styles
- keep existing spacing/color rules while restoring readable hierarchy

## Why
Markdown headings in the new VSCode extension were rendering with nearly no size differentiation, making long responses harder to scan.

Fixes #6088

## Validation
- Full workspace typecheck could not be run in this environment because required tooling (`bun` / `tsgo`) is not installed.