### PR TITLE
feat(init): add pre-commit secret scan guidance

### DIFF
--- a/packages/opencode/src/command/template/initialize.txt
+++ b/packages/opencode/src/command/template/initialize.txt
@@ -1,10 +1,16 @@
 Please analyze this codebase and create an AGENTS.md file containing:
 1. Build/lint/test commands - especially for running a single test
 2. Code style guidelines including imports, formatting, types, naming conventions, error handling, etc.
+3. Security guardrails: verify whether a pre-commit secret scan is configured, and document the setup (or recommended setup if missing)
 
 The file you create will be given to agentic coding agents (such as yourself) that operate in this repository. Make it about 150 lines long.
 If there are Cursor rules (in .cursor/rules/ or .cursorrules) or Copilot rules (in .github/copilot-instructions.md), make sure to include them.
 
 If there's already an AGENTS.md, improve it if it's located in ${path}
+When checking secret scanning, look for existing config in common places like:
+- .pre-commit-config.yaml / pre-commit hooks
+- husky or lint-staged pre-commit scripts
+- gitleaks, detect-secrets, trufflehog, or equivalent scanners
+If no secret scan is configured, include a concrete recommendation in AGENTS.md with commands/files to add for this repo.
 
 $ARGUMENTS


### PR DESCRIPTION
## Summary
- update the `/init` command template to explicitly check/document pre-commit secret scanning
- add guidance to detect existing scanner setups (pre-commit hooks, husky/lint-staged, gitleaks/detect-secrets/trufflehog)
- require a concrete recommendation in generated AGENTS.md when secret scanning is missing

## Why
`/init` should help repositories adopt baseline secret-leak protection as part of project setup guidance.

Fixes #6077