### PR TITLE
feat(telemetry): add plan followup tracking

### DIFF
--- a/packages/kilo-telemetry/src/events.ts
+++ b/packages/kilo-telemetry/src/events.ts
@@ -15,6 +15,7 @@ export enum TelemetryEvent {
   COMMAND_USED = "Command Used",
   TOOL_USED = "Tool Used",
   AGENT_USED = "Agent Used",
+  PLAN_FOLLOWUP = "Plan Followup",
 
   // Share Events
   SHARE_CREATED = "Share Created",

--- a/packages/kilo-telemetry/src/telemetry.ts
+++ b/packages/kilo-telemetry/src/telemetry.ts
@@ -162,6 +162,10 @@ export namespace Telemetry {
     track(TelemetryEvent.AGENT_USED, { agent, sessionId })
   }
 
+  export function trackPlanFollowup(sessionId: string, choice: "new_session" | "continue" | "custom" | "dismissed") {
+    track(TelemetryEvent.PLAN_FOLLOWUP, { sessionId, choice })
+  }
+
   // Share
   export function trackShareCreated(sessionId: string) {
     track(TelemetryEvent.SHARE_CREATED, { sessionId })

--- a/packages/opencode/src/kilocode/plan-followup.ts
+++ b/packages/opencode/src/kilocode/plan-followup.ts
@@ -1,3 +1,4 @@
+import { Telemetry } from "@kilocode/kilo-telemetry"
 import { Agent } from "@/agent/agent"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
@@ -237,12 +238,19 @@ export namespace PlanFollowup {
     if (!user || user.role !== "user" || !user.model) return "break"
 
     const answers = await prompt({ sessionID: input.sessionID, abort: input.abort })
-    if (!answers) return "break"
+    if (!answers) {
+      Telemetry.trackPlanFollowup(input.sessionID, "dismissed")
+      return "break"
+    }
 
     const answer = answers[0]?.[0]?.trim()
-    if (!answer) return "break"
+    if (!answer) {
+      Telemetry.trackPlanFollowup(input.sessionID, "dismissed")
+      return "break"
+    }
 
     if (answer === ANSWER_NEW_SESSION) {
+      Telemetry.trackPlanFollowup(input.sessionID, "new_session")
       await startNew({
         sessionID: input.sessionID,
         plan,
@@ -254,6 +262,7 @@ export namespace PlanFollowup {
     }
 
     if (answer === ANSWER_CONTINUE) {
+      Telemetry.trackPlanFollowup(input.sessionID, "continue")
       await inject({
         sessionID: input.sessionID,
         agent: "code",
@@ -263,6 +272,7 @@ export namespace PlanFollowup {
       return "continue"
     }
 
+    Telemetry.trackPlanFollowup(input.sessionID, "custom")
     await inject({
       sessionID: input.sessionID,
       agent: "plan",


### PR DESCRIPTION
## Context

Add tracking to see what users choose frequently after planning sessions.

<img width="907" height="458" alt="Screenshot 2026-02-23 at 10 56 34" src="https://github.com/user-attachments/assets/61148ad1-c0fc-4a62-bb0c-7d52119f841a" />

### Note
- `custom` even is triggered when user choose "type your answer here"

## Get in Touch

We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here.
