### PR TITLE
feat: make file paths clickable in VS Code

### DIFF
--- a/about/plan.md
+++ b/about/plan.md
@@ -1,0 +1,97 @@
+# About Tab — Settings Screen
+
+## Overview
+
+The About tab is the last section in the Settings view. It displays version information, telemetry preferences, community/support links, and settings management buttons (export, import, reset).
+
+## Component
+
+- **File**: `webview-ui/src/components/settings/About.tsx`
+- **Props**:
+  - `telemetrySetting: TelemetrySetting` — current telemetry state (`"enabled"` | `"disabled"`)
+  - `setTelemetrySetting: (setting: TelemetrySetting) => void`
+  - `isVsCode: boolean` — controls whether the telemetry checkbox is visible (hidden in VS Code since VS Code has its own telemetry settings)
+
+## Layout (top to bottom)
+
+```
+┌─────────────────────────────────────────────────────┐
+│ ℹ️  About <Extension Name>                          │
+│     Version: X.Y.Z (commit-sha)                     │
+├─────────────────────────────────────────────────────┤
+│                                                     │
+│ [Telemetry Checkbox] — hidden when isVsCode=true    │
+│   ☐ Allow error and usage reporting                 │
+│   Help improve ... See our privacy policy ...       │
+│                                                     │
+│ Feedback paragraph with links:                      │
+│   "If you have any questions or feedback..."        │
+│   → GitHub link                                     │
+│   → Reddit link                                     │
+│   → Discord link                                    │
+│                                                     │
+│ Support paragraph with link:                        │
+│   "For financial questions, please contact..."      │
+│   → Support link                                    │
+│                                                     │
+│ ┌──────────┐ ┌──────────┐ ┌──────────┐             │
+│ │ ⬆ Export │ │ ⬇ Import │ │ ⚠ Reset  │             │
+│ └──────────┘ └──────────┘ └──────────┘             │
+│                                                     │
+│ [DEV ONLY] "Allocate memory" button                 │
+└─────────────────────────────────────────────────────┘
+```
+
+## Upstream (Roo Code) About keys
+
+The English translation file also contains an `about` section with keys for an upstream variant of the About screen that Kilo Code does not currently render (tests are skipped). These keys are included in `translations.txt` for reference:
+
+- Bug report label + link
+- Feature request label + link
+- Security issue label + link
+- Contact label
+- Community text (Reddit + Discord)
+- "Contact & Community" header
+- "Manage Settings" header
+- Debug mode toggle + description
+
+## Actions
+
+| Button   | Message sent to extension host        |
+|----------|---------------------------------------|
+| Export   | `{ type: "exportSettings" }`          |
+| Import   | `{ type: "importSettings" }`          |
+| Reset    | `{ type: "resetState" }`              |
+
+## Translation keys used
+
+All translation keys are in `webview-ui/src/i18n/locales/<lang>/settings.json`. The relevant keys are:
+
+- `sections.about`
+- `footer.telemetry.label`
+- `footer.telemetry.description`
+- `footer.feedback`
+- `footer.support`
+- `footer.settings.export`
+- `footer.settings.import`
+- `footer.settings.reset`
+- `about.bugReport.label`
+- `about.bugReport.link`
+- `about.featureRequest.label`
+- `about.featureRequest.link`
+- `about.securityIssue.label`
+- `about.securityIssue.link`
+- `about.contact.label`
+- `about.community`
+- `about.contactAndCommunity`
+- `about.manageSettings`
+- `about.debugMode.label`
+- `about.debugMode.description`
+
+## Dependencies
+
+- `@roo/package` — provides `Package.version` and `Package.sha`
+- `@vscode/webview-ui-toolkit/react` — `VSCodeCheckbox`, `VSCodeLink`
+- `lucide-react` — icons: `Info`, `Download`, `Upload`, `TriangleAlert`
+- Custom UI: `Button` (with `variant="destructive"` for Reset)
+- Layout helpers: `SectionHeader`, `Section`

--- a/about/translations.md
+++ b/about/translations.md
@@ -1,0 +1,64 @@
+# About Tab — All Translation Strings
+
+Source: `webview-ui/src/i18n/locales/en/settings.json`
+
+**Note:** `<tagName>...</tagName>` are interpolation placeholders for React components (links).
+`{{variable}}` are i18next interpolation variables.
+
+---
+
+## Currently Rendered in Kilo Code's About.tsx
+
+### Section header
+
+| Key | English |
+|-----|---------|
+| `sections.about` | About Kilo Code |
+
+### Telemetry checkbox (hidden when running inside VS Code)
+
+| Key | English |
+|-----|---------|
+| `footer.telemetry.label` | Allow error and usage reporting |
+| `footer.telemetry.description` | Help improve Kilo Code by sending usage data and error reports. No code, prompts, or personal information is ever sent. See our privacy policy for more details. |
+
+### Feedback paragraph (contains embedded links)
+
+| Key | English |
+|-----|---------|
+| `footer.feedback` | If you have any questions or feedback, feel free to open an issue at `<githubLink>`github.com/Kilo-Org/kilocode`</githubLink>` or join `<redditLink>`reddit.com/r/kilocode`</redditLink>` or `<discordLink>`kilo.ai/discord`</discordLink>`. |
+
+### Support paragraph (Kilo Code addition)
+
+| Key | English |
+|-----|---------|
+| `footer.support` | For financial questions, please contact Customer Support at `<supportLink>`https://kilo.ai/support`</supportLink>` |
+
+### Settings management buttons
+
+| Key | English |
+|-----|---------|
+| `footer.settings.export` | Export |
+| `footer.settings.import` | Import |
+| `footer.settings.reset` | Reset |
+
+---
+
+## Upstream (Roo Code) About Keys
+
+These keys exist in `settings.json` but are **NOT** currently rendered by Kilo Code's `About.tsx` (tests are skipped with `describe.skip`).
+
+| Key | English |
+|-----|---------|
+| `about.bugReport.label` | Found a bug? |
+| `about.bugReport.link` | Report on GitHub |
+| `about.featureRequest.label` | Have an idea? |
+| `about.featureRequest.link` | Share it with us |
+| `about.securityIssue.label` | Discovered a vulnerability? |
+| `about.securityIssue.link` | Follow our disclosure process |
+| `about.contact.label` | Need to talk to us? Write |
+| `about.community` | Want tips or to just hang out with other Kilo Code users? Join `<redditLink>`reddit.com/r/kilocode`</redditLink>` or `<discordLink>`kilo.ai/discord`</discordLink>` |
+| `about.contactAndCommunity` | Contact & Community |
+| `about.manageSettings` | Manage Settings |
+| `about.debugMode.label` | Enable debug mode |
+| `about.debugMode.description` | Enable debug mode to show additional buttons in the task header for viewing API conversation history and UI messages as prettified JSON in temporary files. |

--- a/bun.lock
+++ b/bun.lock
@@ -216,6 +216,7 @@
       },
       "peerDependencies": {
         "@opencode-ai/ui": "workspace:*",
+        "@opencode-ai/util": "workspace:*",
         "solid-js": "catalog:",
       },
     },

--- a/llm-completion-telemetry.md
+++ b/llm-completion-telemetry.md
@@ -1,0 +1,43 @@
+# LLM_COMPLETION Telemetry Event
+
+## When it fires
+
+After each LLM API response stream completes, once token usage data is received (`src/core/task/Task.ts:3451`).
+
+**Guard condition**: only fires if at least one of `inputTokens`, `outputTokens`, `cacheWriteTokens`, or `cacheReadTokens` is > 0.
+
+## Properties
+
+| Property            | Type     | Required | Description                                   |
+| ------------------- | -------- | -------- | --------------------------------------------- |
+| `inputTokens`       | `number` | yes      | Total input tokens (after cost normalization) |
+| `outputTokens`      | `number` | yes      | Total output tokens                           |
+| `cacheWriteTokens`  | `number` | yes      | Cache write tokens (0 if unsupported)         |
+| `cacheReadTokens`   | `number` | yes      | Cache read tokens (0 if unsupported)          |
+| `cost`              | `number` | no       | Calculated or provider-reported cost in USD   |
+| `completionTime`    | `number` | no       | ms from request start to usage received       |
+| `inferenceProvider` | `string` | no       | Provider used for inference                   |
+
+Plus standard context properties attached to all events (taskId, modelId, apiProvider, etc.).
+
+## Implementation plan
+
+1. **Define the event name**: `LLM_COMPLETION = "LLM Completion"`
+
+2. **Define the event schema**:
+
+    ```typescript
+    {
+      inputTokens: number,
+      outputTokens: number,
+      cacheReadTokens?: number,
+      cacheWriteTokens?: number,
+      cost?: number,
+    }
+    ```
+
+3. **Fire after each LLM stream finishes** — specifically after the usage chunk is received (not on the first delta). Record `performance.now()` at request start and compute `completionTime` delta when usage arrives.
+
+4. **Guard**: only fire if at least one token count > 0.
+
+5. **Cost calculation** (optional): multiply input/output/cache token counts by per-token rates for the model. Kilo uses `calculateApiCostAnthropic` / `calculateApiCostOpenAI` based on API protocol.

--- a/packages/kilo-ui/package.json
+++ b/packages/kilo-ui/package.json
@@ -78,6 +78,7 @@
   },
   "peerDependencies": {
     "@opencode-ai/ui": "workspace:*",
+    "@opencode-ai/util": "workspace:*",
     "solid-js": "catalog:"
   },
   "devDependencies": {

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1,2 +1,469 @@
 // kilocode_change - new file
 export * from "@opencode-ai/ui/message-part"
+
+import {
+  createMemo,
+  createSignal,
+  For,
+  Show,
+  onCleanup,
+  createEffect,
+} from "solid-js"
+import { Dynamic } from "solid-js/web"
+import type { TextPart, ToolPart } from "@kilocode/sdk/v2"
+import { ToolRegistry, PART_MAPPING } from "@opencode-ai/ui/message-part"
+import { BasicTool } from "@opencode-ai/ui/basic-tool"
+import { Icon } from "@opencode-ai/ui/icon"
+import { Markdown } from "@opencode-ai/ui/markdown"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
+import { IconButton } from "@opencode-ai/ui/icon-button"
+import { DiffChanges } from "@opencode-ai/ui/diff-changes"
+import { useData } from "@opencode-ai/ui/context/data"
+import { useI18n } from "@opencode-ai/ui/context/i18n"
+import { useDiffComponent } from "@opencode-ai/ui/context/diff"
+import { useCodeComponent } from "@opencode-ai/ui/context/code"
+import { getDirectory as _getDirectory, getFilename } from "@opencode-ai/util/path"
+import { checksum } from "@opencode-ai/util/encode"
+import type { OpenFileFn } from "@opencode-ai/ui/context/data"
+
+function relativizeProjectPaths(text: string, directory?: string) {
+  if (!text) return ""
+  if (!directory) return text
+  return text.split(directory).join("")
+}
+
+function getDirectory(path: string | undefined) {
+  const data = useData()
+  return relativizeProjectPaths(_getDirectory(path), data.directory)
+}
+
+interface Diagnostic {
+  range: {
+    start: { line: number; character: number }
+    end: { line: number; character: number }
+  }
+  message: string
+  severity?: number
+}
+
+function getDiagnostics(
+  diagnosticsByFile: Record<string, Diagnostic[]> | undefined,
+  filePath: string | undefined,
+): Diagnostic[] {
+  if (!diagnosticsByFile || !filePath) return []
+  const diagnostics = diagnosticsByFile[filePath] ?? []
+  return diagnostics.filter((d) => d.severity === 1).slice(0, 3)
+}
+
+function DiagnosticsDisplay(props: { diagnostics: Diagnostic[] }) {
+  const i18n = useI18n()
+  return (
+    <Show when={props.diagnostics.length > 0}>
+      <div data-component="diagnostics">
+        <For each={props.diagnostics}>
+          {(diagnostic) => (
+            <div data-slot="diagnostic">
+              <span data-slot="diagnostic-label">{i18n.t("ui.messagePart.diagnostic.error")}</span>
+              <span data-slot="diagnostic-location">
+                [{diagnostic.range.start.line + 1}:{diagnostic.range.start.character + 1}]
+              </span>
+              <span data-slot="diagnostic-message">{diagnostic.message}</span>
+            </div>
+          )}
+        </For>
+      </div>
+    </Show>
+  )
+}
+
+/** Check if text looks like a file path (contains / and has a file extension) */
+const FILE_PATH_RE = /^\.{0,2}\/.*\.\w+$|^[a-zA-Z]:\\.*\.\w+$|^\w[\w.-]*\/.*\.\w+$/
+
+function isFilePath(text: string): boolean {
+  return FILE_PATH_RE.test(text.trim())
+}
+
+/**
+ * Renders tool output text with file paths as clickable elements.
+ * Lines that look like file paths become clickable to open the file in the editor.
+ */
+function ClickableFileOutput(props: { text: string; openFile?: OpenFileFn; directory?: string }) {
+  const lines = createMemo(() => props.text.split("\n").filter((l) => l.trim()))
+  const hasClickable = () => !!props.openFile
+
+  return (
+    <div data-component="clickable-file-output">
+      <For each={lines()}>
+        {(line) => {
+          const trimmed = line.trim()
+          const displayPath = props.directory ? relativizeProjectPaths(trimmed, props.directory) : trimmed
+          return (
+            <Show
+              when={hasClickable() && isFilePath(trimmed)}
+              fallback={<div data-slot="file-output-line">{displayPath}</div>}
+            >
+              <div
+                data-slot="file-output-line"
+                class="clickable"
+                onClick={() => props.openFile!(trimmed)}
+              >
+                {displayPath}
+              </div>
+            </Show>
+          )
+        }}
+      </For>
+    </div>
+  )
+}
+
+const TEXT_RENDER_THROTTLE_MS = 100
+
+function createThrottledValue(getValue: () => string) {
+  const [value, setValue] = createSignal(getValue())
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let last = 0
+
+  createEffect(() => {
+    const next = getValue()
+    const now = Date.now()
+    const remaining = TEXT_RENDER_THROTTLE_MS - (now - last)
+    if (remaining <= 0) {
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = undefined
+      }
+      last = now
+      setValue(next)
+      return
+    }
+    if (timeout) clearTimeout(timeout)
+    timeout = setTimeout(() => {
+      last = Date.now()
+      setValue(next)
+      timeout = undefined
+    }, remaining)
+  })
+
+  onCleanup(() => {
+    if (timeout) clearTimeout(timeout)
+  })
+
+  return value
+}
+
+// Override TextPartDisplay to make inline code file paths clickable
+PART_MAPPING["text"] = function TextPartDisplay(props) {
+  const data = useData()
+  const i18n = useI18n()
+  const part = props.part as TextPart
+  const displayText = () => relativizeProjectPaths((part.text ?? "").trim(), data.directory)
+  const throttledText = createThrottledValue(displayText)
+  const [copied, setCopied] = createSignal(false)
+
+  const handleCopy = async () => {
+    const content = displayText()
+    if (!content) return
+    await navigator.clipboard.writeText(content)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const handleCodeClick = (e: MouseEvent) => {
+    if (!data.openFile) return
+    const target = e.target as HTMLElement
+    const code = target.closest("code")
+    if (!code || code.closest("pre")) return
+    const text = code.textContent?.trim()
+    if (!text || !isFilePath(text)) return
+    e.preventDefault()
+    e.stopPropagation()
+    data.openFile(text)
+  }
+
+  return (
+    <Show when={throttledText()}>
+      <div data-component="text-part" data-has-open-file={!!data.openFile || undefined}>
+        <div data-slot="text-part-body" onClick={handleCodeClick}>
+          <Markdown text={throttledText()} cacheKey={part.id} />
+          <div data-slot="text-part-copy-wrapper">
+            <Tooltip
+              value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")}
+              placement="top"
+              gutter={8}
+            >
+              <IconButton
+                icon={copied() ? "check" : "copy"}
+                size="small"
+                variant="secondary"
+                onMouseDown={(e: MouseEvent) => e.preventDefault()}
+                onClick={handleCopy}
+                aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")}
+              />
+            </Tooltip>
+          </div>
+        </div>
+      </div>
+    </Show>
+  )
+}
+
+// Override read tool to add clickable subtitle and loaded file paths
+ToolRegistry.register({
+  name: "read",
+  render(props) {
+    const data = useData()
+    const i18n = useI18n()
+    const args: string[] = []
+    if (props.input.offset) args.push("offset=" + props.input.offset)
+    if (props.input.limit) args.push("limit=" + props.input.limit)
+    const loaded = createMemo(() => {
+      if (props.status !== "completed") return []
+      const value = props.metadata.loaded
+      if (!value || !Array.isArray(value)) return []
+      return value.filter((p): p is string => typeof p === "string")
+    })
+    const openFile = () => {
+      if (props.input.filePath && data.openFile) data.openFile(props.input.filePath)
+    }
+    return (
+      <>
+        <BasicTool
+          {...props}
+          icon="glasses"
+          trigger={{
+            title: i18n.t("ui.tool.read"),
+            subtitle: props.input.filePath ? getFilename(props.input.filePath) : "",
+            args,
+          }}
+          onSubtitleClick={props.input.filePath ? openFile : undefined}
+        />
+        <For each={loaded()}>
+          {(filepath) => (
+            <div data-component="tool-loaded-file">
+              <Icon name="enter" size="small" />
+              <span
+                classList={{ clickable: !!data.openFile }}
+                onClick={(e) => {
+                  if (data.openFile) {
+                    e.stopPropagation()
+                    data.openFile(filepath)
+                  }
+                }}
+              >
+                {i18n.t("ui.tool.loaded")} {relativizeProjectPaths(filepath, data.directory)}
+              </span>
+            </div>
+          )}
+        </For>
+      </>
+    )
+  },
+})
+
+// Override list tool to use clickable file output
+ToolRegistry.register({
+  name: "list",
+  render(props) {
+    const data = useData()
+    const i18n = useI18n()
+    return (
+      <BasicTool
+        {...props}
+        icon="bullet-list"
+        trigger={{ title: i18n.t("ui.tool.list"), subtitle: getDirectory(props.input.path || "/") }}
+      >
+        <Show when={props.output}>
+          {(output) => (
+            <div data-component="tool-output" data-scrollable>
+              <ClickableFileOutput text={output()} openFile={data.openFile} directory={data.directory} />
+            </div>
+          )}
+        </Show>
+      </BasicTool>
+    )
+  },
+})
+
+// Override glob tool to use clickable file output
+ToolRegistry.register({
+  name: "glob",
+  render(props) {
+    const data = useData()
+    const i18n = useI18n()
+    return (
+      <BasicTool
+        {...props}
+        icon="magnifying-glass-menu"
+        trigger={{
+          title: i18n.t("ui.tool.glob"),
+          subtitle: getDirectory(props.input.path || "/"),
+          args: props.input.pattern ? ["pattern=" + props.input.pattern] : [],
+        }}
+      >
+        <Show when={props.output}>
+          {(output) => (
+            <div data-component="tool-output" data-scrollable>
+              <ClickableFileOutput text={output()} openFile={data.openFile} directory={data.directory} />
+            </div>
+          )}
+        </Show>
+      </BasicTool>
+    )
+  },
+})
+
+// Override grep tool to use clickable file output
+ToolRegistry.register({
+  name: "grep",
+  render(props) {
+    const data = useData()
+    const i18n = useI18n()
+    const args: string[] = []
+    if (props.input.pattern) args.push("pattern=" + props.input.pattern)
+    if (props.input.include) args.push("include=" + props.input.include)
+    return (
+      <BasicTool
+        {...props}
+        icon="magnifying-glass-menu"
+        trigger={{
+          title: i18n.t("ui.tool.grep"),
+          subtitle: getDirectory(props.input.path || "/"),
+          args,
+        }}
+      >
+        <Show when={props.output}>
+          {(output) => (
+            <div data-component="tool-output" data-scrollable>
+              <ClickableFileOutput text={output()} openFile={data.openFile} directory={data.directory} />
+            </div>
+          )}
+        </Show>
+      </BasicTool>
+    )
+  },
+})
+
+// Override edit tool to add clickable filename
+ToolRegistry.register({
+  name: "edit",
+  render(props) {
+    const data = useData()
+    const i18n = useI18n()
+    const diffComponent = useDiffComponent()
+    const diagnostics = createMemo(() => getDiagnostics(props.metadata.diagnostics, props.input.filePath))
+    const filename = () => getFilename(props.input.filePath ?? "")
+    const openFile = (e: MouseEvent) => {
+      e.stopPropagation()
+      if (props.input.filePath && data.openFile) data.openFile(props.input.filePath)
+    }
+    return (
+      <BasicTool
+        {...props}
+        icon="code-lines"
+        trigger={
+          <div data-component="edit-trigger">
+            <div data-slot="message-part-title-area">
+              <div data-slot="message-part-title">
+                <span data-slot="message-part-title-text">{i18n.t("ui.messagePart.title.edit")}</span>
+                <span
+                  data-slot="message-part-title-filename"
+                  classList={{ clickable: !!data.openFile && !!props.input.filePath }}
+                  onClick={data.openFile && props.input.filePath ? openFile : undefined}
+                >
+                  {filename()}
+                </span>
+              </div>
+              <Show when={props.input.filePath?.includes("/")}>
+                <div data-slot="message-part-path">
+                  <span data-slot="message-part-directory">{getDirectory(props.input.filePath!)}</span>
+                </div>
+              </Show>
+            </div>
+            <div data-slot="message-part-actions">
+              <Show when={props.metadata.filediff}>
+                <DiffChanges changes={props.metadata.filediff} />
+              </Show>
+            </div>
+          </div>
+        }
+      >
+        <Show when={props.metadata.filediff?.path || props.input.filePath}>
+          <div data-component="edit-content">
+            <Dynamic
+              component={diffComponent}
+              before={{
+                name: props.metadata?.filediff?.file || props.input.filePath,
+                contents: props.metadata?.filediff?.before || props.input.oldString,
+              }}
+              after={{
+                name: props.metadata?.filediff?.file || props.input.filePath,
+                contents: props.metadata?.filediff?.after || props.input.newString,
+              }}
+            />
+          </div>
+        </Show>
+        <DiagnosticsDisplay diagnostics={diagnostics()} />
+      </BasicTool>
+    )
+  },
+})
+
+// Override write tool to add clickable filename
+ToolRegistry.register({
+  name: "write",
+  render(props) {
+    const data = useData()
+    const i18n = useI18n()
+    const codeComponent = useCodeComponent()
+    const diagnostics = createMemo(() => getDiagnostics(props.metadata.diagnostics, props.input.filePath))
+    const filename = () => getFilename(props.input.filePath ?? "")
+    const openFile = (e: MouseEvent) => {
+      e.stopPropagation()
+      if (props.input.filePath && data.openFile) data.openFile(props.input.filePath)
+    }
+    return (
+      <BasicTool
+        {...props}
+        icon="code-lines"
+        trigger={
+          <div data-component="write-trigger">
+            <div data-slot="message-part-title-area">
+              <div data-slot="message-part-title">
+                <span data-slot="message-part-title-text">{i18n.t("ui.messagePart.title.write")}</span>
+                <span
+                  data-slot="message-part-title-filename"
+                  classList={{ clickable: !!data.openFile && !!props.input.filePath }}
+                  onClick={data.openFile && props.input.filePath ? openFile : undefined}
+                >
+                  {filename()}
+                </span>
+              </div>
+              <Show when={props.input.filePath?.includes("/")}>
+                <div data-slot="message-part-path">
+                  <span data-slot="message-part-directory">{getDirectory(props.input.filePath!)}</span>
+                </div>
+              </Show>
+            </div>
+            <div data-slot="message-part-actions">{/* placeholder */}</div>
+          </div>
+        }
+      >
+        <Show when={props.input.content}>
+          <div data-component="write-content">
+            <Dynamic
+              component={codeComponent}
+              file={{
+                name: props.input.filePath,
+                contents: props.input.content,
+                cacheKey: checksum(props.input.content),
+              }}
+              overflow="scroll"
+            />
+          </div>
+        </Show>
+        <DiagnosticsDisplay diagnostics={diagnostics()} />
+      </BasicTool>
+    )
+  },
+})

--- a/packages/kilo-vscode/docs/reviews/pr-333-review.md
+++ b/packages/kilo-vscode/docs/reviews/pr-333-review.md
@@ -1,0 +1,141 @@
+# PR #333 Review: feat(vscode): part 1 - foundation utils and gateway bridge
+
+| Field | Value |
+| --- | --- |
+| Author | @bernaferrari (Bernardo Ferrari) |
+| Additions | 548 |
+| Deletions | 5 |
+| Changed Files | 12 |
+| Parent PR | #321 (split — this is part 1/20) |
+
+## Summary
+
+This PR introduces low-risk foundation utilities for the kilo-vscode extension and gateway plumbing for cloud features. It adds:
+
+1. **kilo-vscode utility modules** — logger, URL-allowlist validation, workspace-path containment, telemetry stub, and CSP builder
+2. **kilo-gateway API additions** — extension-settings endpoint, remote-sessions CRUD (list + messages), and helper extractors (`getToken`, `getOrganizationId`)
+3. **kilo-ui CSS bridge** — typography variable bridging from VS Code CSS custom properties
+4. **Unit tests** — for open-external URL validation, path-security, and CSP builder
+
+The scope is well-contained and the splitting strategy is reasonable — these are leaf utilities with no side-effects on existing code paths.
+
+## Files Changed
+
+| File | Type | Description |
+| --- | --- | --- |
+| `packages/kilo-gateway/src/api/profile.ts` | Modified | Added `fetchExtensionSettings()` |
+| `packages/kilo-gateway/src/api/remote-sessions.ts` | New | tRPC client for remote sessions list & messages |
+| `packages/kilo-gateway/src/server/routes.ts` | Modified | 3 new routes + `getToken`/`getOrganizationId` helpers |
+| `packages/kilo-ui/src/styles/vscode-bridge.css` | Modified | Typography CSS variable bridging |
+| `packages/kilo-vscode/src/utils/logger.ts` | New | OutputChannel-based structured logger |
+| `packages/kilo-vscode/src/utils/open-external.ts` | New | URL scheme allowlist for `openExternal` |
+| `packages/kilo-vscode/src/utils/path-security.ts` | New | Workspace path containment (symlink-aware) |
+| `packages/kilo-vscode/src/utils/telemetry.ts` | New | Telemetry event name schema + stub capture |
+| `packages/kilo-vscode/src/utils/webview-csp.ts` | New | CSP string builder for webviews |
+| `packages/kilo-vscode/tests/unit/open-external-url.test.ts` | New | Tests for URL allowlist |
+| `packages/kilo-vscode/tests/unit/path-security.test.ts` | New | Tests for path containment |
+| `packages/kilo-vscode/tests/unit/webview-csp.test.ts` | New | Tests for CSP builder |
+
+## Detailed Findings
+
+### 🔴 High Severity
+
+#### H1: `any` type used for `auth` and Hono context in [`routes.ts`](packages/kilo-gateway/src/server/routes.ts)
+
+`getToken(auth: any)`, `getOrganizationId(auth: any)`, and every route handler `async (c: any)` use `any`. The AGENTS.md style guide explicitly says "avoid `any` type". The `auth` object has a known shape (discriminated union on `type`); this should be typed. The Hono context `c` should use proper Hono typing.
+
+```ts
+// Current
+function getToken(auth: any): string | undefined { ... }
+
+// Suggested — define or import the auth union
+type KiloAuth =
+  | { type: "api"; key: string }
+  | { type: "oauth"; access: string; accountId?: string }
+  | { type: "wellknown"; token: string }
+
+function getToken(auth: KiloAuth): string | undefined { ... }
+```
+
+> **Note**: The existing code already used `any` for `c` in the notifications route, so this PR is at least consistent with the status quo. However, adding *more* `any` is the wrong direction — ideally the helpers should fix this for all usages.
+
+#### H2: `throw` in `fetchExtensionSettings` / `fetchRemoteSessions` / `fetchRemoteSessionMessages` without route-level error handling
+
+[`profile.ts`](packages/kilo-gateway/src/api/profile.ts) and [`remote-sessions.ts`](packages/kilo-gateway/src/api/remote-sessions.ts) throw on non-OK responses and invalid payloads. The route handlers in [`routes.ts`](packages/kilo-gateway/src/server/routes.ts) do **not** wrap these calls in try/catch or have per-route error middleware. If the upstream API returns a 500, the gateway will throw an unhandled error and likely respond with a generic 500 (or crash, depending on Hono config).
+
+The AGENTS.md style says "avoid try/catch", which typically means using Result types or error-returning patterns instead. Currently these throw + are uncaught, which is the worst of both worlds. Consider:
+- Returning `{ ok: false, error: ... }` result types from the fetch helpers, or
+- Adding Hono error middleware if not already present
+
+### 🟡 Medium Severity
+
+#### M1: `color-scheme: normal` was removed from [`vscode-bridge.css`](packages/kilo-ui/src/styles/vscode-bridge.css)
+
+The original CSS had `color-scheme: normal;` which told the browser to let VS Code control the color scheme instead of OS preference. This line was removed and replaced with typography variables. The removal is likely unintentional — the `color-scheme` declaration should be preserved alongside the new typography additions.
+
+#### M2: `unknown` return types throughout remote-sessions API
+
+[`remote-sessions.ts`](packages/kilo-gateway/src/api/remote-sessions.ts) uses `unknown` extensively:
+- `RemoteSessionInfo` is well-typed, but `fetchRemoteSessionMessages` returns `unknown[]`
+- `fetchExtensionSettings` returns `{ organization?: unknown; user?: unknown }`
+- Route schemas use `z.unknown()` / `z.array(z.unknown())`
+
+For "part 1" foundation code this is acceptable as a pass-through, but it defers schema validation to callers and loses type safety. Consider adding a TODO comment noting these should be tightened when the consuming code lands.
+
+#### M3: Logger module state uses mutable `let` variables
+
+[`logger.ts`](packages/kilo-vscode/src/utils/logger.ts) declares:
+```ts
+let outputChannel: vscode.OutputChannel | undefined
+let debugEnabled = false
+```
+
+Per AGENTS.md, prefer `const` over `let`. These could be encapsulated in a class instance or a frozen config object that's set once. The current mutable module-level state is harder to test (tests must remember to reset it) and risks accidental re-initialization.
+
+#### M4: `captureTelemetryEvent` in [`telemetry.ts`](packages/kilo-vscode/src/utils/telemetry.ts) is a no-op stub
+
+The function only logs to debug and exits. This is fine as a placeholder, but there's no TODO or tracking issue indicating when actual telemetry will be wired up. Future PRs in this 20-part series may depend on this being real. Add a comment or link to the tracking issue.
+
+#### M5: Tests use `bun:test` but AGENTS.md says the package uses pnpm
+
+Tests import from `bun:test` which means they run under Bun's test runner, not the pnpm-based `pnpm test` flow (which compiles to `out/` and likely uses a different runner). This should be clarified — are these tests meant to run via `bun test tests/unit/` separately? If so, document the command. If they should integrate with the existing test setup, they need to use the correct test framework.
+
+### 🟢 Low Severity
+
+#### L1: `http:` scheme missing from [`open-external.ts`](packages/kilo-vscode/src/utils/open-external.ts) allowlist
+
+Only `https:` and `vscode:` are allowed. This is likely intentional for security, but if any legitimate use case requires plain `http:` (e.g., localhost dev servers), it would be blocked silently. The function returns `null` without logging, making debugging harder. Consider adding a `logger.debug` call when a URL is rejected.
+
+#### L2: No test cleanup in [`path-security.test.ts`](packages/kilo-vscode/tests/unit/path-security.test.ts)
+
+Tests create temp directories and files via `fs.mkdtemp` / `fs.writeFile` / `fs.symlink` but never clean them up. While OS temp directories are eventually purged, adding `afterEach` cleanup is good practice and prevents test pollution in CI.
+
+#### L3: `trpcGet` in [`remote-sessions.ts`](packages/kilo-gateway/src/api/remote-sessions.ts) is a generic tRPC client that could be shared
+
+The helper is well-written and generic. If other gateway modules need tRPC access later, this should be extracted to a shared utility rather than duplicated.
+
+#### L4: Missing `http:` in CSP `connect-src`
+
+[`webview-csp.ts`](packages/kilo-vscode/src/utils/webview-csp.ts) only includes `cspSource` in `connect-src`. If the extension ever needs to connect to localhost (e.g., the CLI backend server), a `http://localhost:*` or `http://127.0.0.1:*` directive may be needed. This is fine for now but worth noting.
+
+#### L5: CSS variable naming convention
+
+The typography variables in [`vscode-bridge.css`](packages/kilo-ui/src/styles/vscode-bridge.css) use inconsistent nesting:
+```css
+--font-family-sans: ...;
+--font-family-sans--font-feature-settings: normal;
+```
+The double-dash `--font-family-sans--font-feature-settings` reads like a BEM modifier rather than a CSS custom property convention. Verify this matches the consuming components' expectations.
+
+## Recommendations
+
+1. **Fix the `color-scheme: normal` removal** (M1) — this looks like an accidental deletion that could affect dark/light theme behavior
+2. **Type the auth parameter** (H1) — replace `any` with a proper discriminated union, even if the existing code uses `any`. This PR adds helpers that centralize access, making it the perfect time to add types
+3. **Add error handling strategy for route handlers** (H2) — either use Result types in the fetch helpers or add Hono error middleware to prevent unhandled throws
+4. **Add a cleanup step to path-security tests** (L2) — minor but good practice
+5. **Clarify test runner** (M5) — document whether `bun test` is the intended runner for these unit tests
+6. **Add TODOs for `unknown` types** (M2) and **telemetry stub** (M4) — so future PRs in the series have clear follow-up markers
+
+## Verdict
+
+This is a solid foundation PR with well-scoped utilities, good test coverage for the security-sensitive modules, and a clean separation of concerns. The main concerns are the `any` types in the gateway routes, the missing error handling, and the potential `color-scheme` regression. None are blockers, but H1 and M1 should ideally be addressed before merge.

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -115,6 +115,15 @@
 [data-component="text-part"] {
   width: 100%;
 
+  &[data-has-open-file] [data-slot="text-part-body"] code:not(pre code) {
+    cursor: pointer;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: var(--text-strong);
+    }
+  }
+
   [data-slot="text-part-body"] {
     position: relative;
     margin-top: 32px;

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -59,6 +59,10 @@ interface Diagnostic {
   severity?: number
 }
 
+// kilocode_change start - export for kilo-ui overrides
+export { type Diagnostic, getDiagnostics, DiagnosticsDisplay, relativizeProjectPaths, getDirectory, createThrottledValue }
+// kilocode_change end
+
 function getDiagnostics(
   diagnosticsByFile: Record<string, Diagnostic[]> | undefined,
   filePath: string | undefined,

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -533,10 +533,16 @@ export const ToolRegistry = {
   render: getTool,
 }
 
+/** Check if text looks like a file path (contains / and has a file extension) */
+const FILE_PATH_RE = /^\.{0,2}\/.*\.\w+$|^[a-zA-Z]:\\.*\.\w+$|^\w[\w.-]*\/.*\.\w+$/
+
+function isFilePath(text: string): boolean {
+  return FILE_PATH_RE.test(text.trim())
+}
+
 /**
  * Renders tool output text with file paths as clickable elements.
- * Lines that look like file paths (start with / or contain common path patterns)
- * become clickable to open the file in the editor.
+ * Lines that look like file paths become clickable to open the file in the editor.
  */
 function ClickableFileOutput(props: { text: string; openFile?: OpenFileFn; directory?: string }) {
   const lines = createMemo(() => props.text.split("\n").filter((l) => l.trim()))
@@ -547,11 +553,10 @@ function ClickableFileOutput(props: { text: string; openFile?: OpenFileFn; direc
       <For each={lines()}>
         {(line) => {
           const trimmed = line.trim()
-          const isPath = trimmed.startsWith("/") || trimmed.match(/^[a-zA-Z]:\\/) || trimmed.match(/^\w[\w.-]*\//)
           const displayPath = props.directory ? relativizeProjectPaths(trimmed, props.directory) : trimmed
           return (
             <Show
-              when={hasClickable() && isPath}
+              when={hasClickable() && isFilePath(trimmed)}
               fallback={<div data-slot="file-output-line">{displayPath}</div>}
             >
               <div


### PR DESCRIPTION
Port of clickable filenames feature from upstream. This includes:

- Make filenames clickable in tool results to open in VS Code
- Make file paths clickable in glob/grep/list output and fix path resolution
- Make inline code file paths clickable in assistant text messages
- Deduplicate isFilePath - move to single definition shared by ClickableFileOutput and TextPartDisplay
- Move clickable file path changes from packages/ui to packages/kilo-ui
- Export upstream helpers instead of duplicating them in kilo-ui

Based on https://github.com/Kilo-Org/kilo/pull/486