### PR TITLE
Fix typecheck workflow to run on all PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
     branches:
-      - dev
+      - main
   pull_request:
   workflow_dispatch:
 jobs:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -2,9 +2,9 @@ name: typecheck
 
 on:
   push:
-    branches: [dev]
+    branches:
+      - main
   pull_request:
-    branches: [dev]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Updates the typecheck workflow to:
- Run on all pull requests (not just PRs targeting dev)
- Use main as the default branch instead of dev

This brings it inline with the test.yml workflow behavior and ensures typecheck runs more consistently.