### PR TITLE
fix: align vscode extension publish version with CLI version

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "kilo-code",
   "displayName": "Kilo Code: AI Coding Agent, Copilot, and Autocomplete",
   "description": "Open Source AI coding agent that generates code from natural language, automates tasks, and runs terminal commands. Features inline autocomplete, browser automation, automated refactoring, and custom modes for planning, coding, and debugging. Supports 500+ AI models including Claude (Anthropic), Gemini, Grok, GPT, Codex and GLM.",
-  "version": "7.0.25",
+  "version": "1.0.25",
   "icon": "assets/icons/logo-outline-black.png",
   "publisher": "kilocode",
   "repository": {

--- a/packages/kilo-vscode/script/build.ts
+++ b/packages/kilo-vscode/script/build.ts
@@ -5,9 +5,7 @@ import { existsSync, mkdirSync, rmSync, chmodSync } from "node:fs"
 
 const packageJsonPath = join(import.meta.dir, "..", "package.json")
 const packageJson = await Bun.file(packageJsonPath).json()
-const version = process.env.KILO_VERSION
-  ? process.env.KILO_VERSION.replace(/^\d+/, (m) => String(Number(m) + 6))
-  : packageJson.version
+const version = process.env.KILO_VERSION ? process.env.KILO_VERSION : packageJson.version
 
 console.log(`Building VSCode extension version: ${version}`)
 

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -41,11 +41,7 @@ const pkgjsons = await Array.fromAsync(
 
 for (const file of pkgjsons) {
   let pkg = await Bun.file(file).text()
-  // kilocode_change start
-  const version = file.includes("packages/kilo-vscode/")
-    ? Script.version.replace(/^\d+/, (m) => String(Number(m) + 6))
-    : Script.version
-  // kilocode_change end
+  const version = Script.version
   pkg = pkg.replaceAll(/"version": "[^"]+"/g, `"version": "${version}"`)
   console.log("updated:", file)
   await Bun.file(file).write(pkg)


### PR DESCRIPTION
## Context

The `kilo-vscode` package was being published with a version 6 major versions ahead of the CLI. For example, when the CLI was at `1.0.25`, the VS Code extension was published as `7.0.25`. This was caused by an intentional `+6` major offset applied in both the build and publish scripts. The versions should be identical.

## Implementation

Removed the `.replace(/^\d+/, (m) => String(Number(m) + 6))` transform from two places:

- `packages/kilo-vscode/script/build.ts` — the build script now uses `KILO_VERSION` as-is when set
- `script/publish.ts` — the publish script now uses `Script.version` uniformly for all packages (removed the `kilo-vscode`-specific branch and `kilocode_change` markers)

Also corrected the local `packages/kilo-vscode/package.json` version from `7.0.25` → `1.0.25` to reflect the current correct version.
