### PR TITLE
fix: replace all opencode binary references with kilo across the codebase

### DIFF
--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -64,7 +64,9 @@ export async function createOpencodeServer(options?: ServerOptions) {
   const args = [`serve`, `--hostname=${options.hostname}`, `--port=${options.port}`]
   if (options.config?.logLevel) args.push(`--log-level=${options.config.logLevel}`)
 
-  const proc = spawn(`opencode`, args, {
+  // kilocode_change start
+  const proc = spawn(`kilo`, args, {
+    // kilocode_change end
     signal: options.signal,
     env: {
       ...process.env,
@@ -141,7 +143,9 @@ export function createOpencodeTui(options?: TuiOptions) {
     args.push(`--agent=${options.agent}`)
   }
 
-  const proc = spawn(`opencode`, args, {
+  // kilocode_change start
+  const proc = spawn(`kilo`, args, {
+    // kilocode_change end
     signal: options?.signal,
     stdio: "inherit",
     env: {


### PR DESCRIPTION
## Summary

- Replaces `opencode` binary/CLI references with `kilo` across the entire codebase
- Adds `kilocode_change` markers on all modified shared files

## Files Changed

**Critical - direct binary spawn/exec:**
- `packages/opencode/src/cli/cmd/pr.ts` — `spawn("kilo")` and `` $`kilo import` ``
- `packages/desktop/src-tauri/src/cli.rs` — `CLI_BINARY_NAME`, WSL binary path, install script name, server spawn error message
- `packages/extensions/zed/extension.toml` — `cmd = "./kilo"` and archive URLs updated to `kilo-*`
- `sdks/vscode/src/extension.ts` — terminal name and `kilo --port` command

**High - user-facing CLI command strings:**
- `packages/opencode/src/acp/agent.ts` — ACP terminal-auth command and labels
- `packages/opencode/src/mcp/index.ts` — auth toast message and BUN_BE_BUN env check
- `packages/opencode/src/provider/provider.ts` — Cloudflare AI Gateway error message
- `packages/opencode/src/installation/index.ts` — brew/scoop/choco detection, formula names, upgrade commands, install URL
- `packages/opencode/src/cli/cmd/uninstall.ts` — `brew uninstall kilo`

**Medium - workflows and i18n:**
- `.github/workflows/daily-pr-recap.yml` + `daily-issues-recap.yml` — install and run `kilo`
- `packages/desktop/src/i18n/*.ts` — all 15 locale files updated to reference `'kilo'` command
- `packages/desktop/src-tauri/src/server.rs` — HTTP basic auth username matches `KILO_SERVER_USERNAME`