### PR TITLE
docs: add baseline CLI documentation for older CPUs without AVX support

### DIFF
--- a/packages/kilo-docs/markdoc/partials/install-cli.md
+++ b/packages/kilo-docs/markdoc/partials/install-cli.md
@@ -6,6 +6,17 @@ Use Kilo Code directly from your terminal for maximum flexibility.
 npm install -g @kilocode/cli
 ```
 
+### Older CPUs (No AVX Support)
+
+If you're running on an older CPU without AVX support (e.g., Intel Xeon Nehalem, AMD Bulldozer, or older), the CLI may crash with "Illegal instruction". In that case, download the **baseline** variant from GitHub releases:
+
+1. Go to [Kilo Releases](https://github.com/Kilo-Org/kilo/releases)
+2. Download the `-baseline` variant for your platform:
+   - Linux x64: `kilo-linux-x64-baseline.tar.gz`
+   - macOS x64: `kilo-darwin-x64-baseline.zip`
+   - Windows x64: `kilo-windows-x64-baseline.zip`
+3. Extract and run the `kilo` binary directly
+
 ### Verify Installation
 
 ```bash

--- a/packages/kilo-docs/markdoc/partials/install-cli.md
+++ b/packages/kilo-docs/markdoc/partials/install-cli.md
@@ -10,7 +10,7 @@ npm install -g @kilocode/cli
 
 If you're running on an older CPU without AVX support (e.g., Intel Xeon Nehalem, AMD Bulldozer, or older), the CLI may crash with "Illegal instruction". In that case, download the **baseline** variant from GitHub releases:
 
-1. Go to [Kilo Releases](https://github.com/Kilo-Org/kilo/releases)
+1. Go to [Kilo Releases](https://github.com/Kilo-Org/kilocode/releases)
 2. Download the `-baseline` variant for your platform:
    - Linux x64: `kilo-linux-x64-baseline.tar.gz`
    - macOS x64: `kilo-darwin-x64-baseline.zip`


### PR DESCRIPTION
Add documentation for users experiencing "Illegal instruction" crashes on CPUs without AVX support (issue #5929).

Verified that packages/opencode/script/build.ts already builds baseline (non-AVX) binaries in CI - they are uploaded to GitHub releases with "-baseline" suffix. Added CLI installation docs to redirect users to download the appropriate baseline variant for their platform.

## Context

<!-- Brief description of WHAT you're doing and WHY. -->

Fixes #5929 - CLI crashes with "Illegal instruction" on CPUs without AVX support.

Users with older CPUs (e.g., Intel Xeon Nehalem, AMD Bulldozer, or older) experience crashes when running the Kilo CLI because the default binary requires AVX instructions.

## Implementation

<!-- Some description of HOW you achieved it. -->

Verified that `packages/opencode/script/build.ts` already builds baseline (non-AVX) binaries in CI - they are uploaded to GitHub releases with "-baseline" suffix. Added CLI installation docs to redirect users to download the appropriate baseline variant for their platform.

Key finding: The build script at `packages/opencode/script/build.ts` lines 46-89 already defines `avx2: false` targets for all x64 platforms (Linux, Darwin, Windows). When running without `--single` flag (CI default), all targets including baseline are built and uploaded.

## Screenshots

N/A - Documentation only change

## How to Test

1. Visit the CLI installation docs at `/docs/getting-started/installing`
2. Scroll to "Older CPUs (No AVX Support)" section
3. Verify the section explains:
   - What the issue is (older CPUs without AVX)
   - Where to find the baseline packages (GitHub releases)
   - Which baseline package to download for their platform

## Get in Touch

`billy_butcher99`
