### PR TITLE
feat(agent-manager): custom worktree names with persistent labels and inline rename

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -20,6 +20,8 @@ export interface Worktree {
   createdAt: string
   /** Shared identifier for worktrees created together via multi-version mode. */
   groupId?: string
+  /** User-provided display name for the worktree. */
+  label?: string
 }
 
 export interface ManagedSession {
@@ -109,7 +111,13 @@ export class WorktreeStateManager {
   // Mutations
   // ---------------------------------------------------------------------------
 
-  addWorktree(params: { branch: string; path: string; parentBranch: string; groupId?: string }): Worktree {
+  addWorktree(params: {
+    branch: string
+    path: string
+    parentBranch: string
+    groupId?: string
+    label?: string
+  }): Worktree {
     const id = generateId("wt")
     const wt: Worktree = {
       id,
@@ -119,10 +127,21 @@ export class WorktreeStateManager {
       createdAt: new Date().toISOString(),
     }
     if (params.groupId) wt.groupId = params.groupId
+    if (params.label) wt.label = params.label
     this.worktrees.set(id, wt)
-    this.log(`Added worktree ${id}: ${params.branch}${params.groupId ? ` (group=${params.groupId})` : ""}`)
+    this.log(
+      `Added worktree ${id}: ${params.branch}${params.label ? ` (label=${params.label})` : ""}${params.groupId ? ` (group=${params.groupId})` : ""}`,
+    )
     void this.save()
     return wt
+  }
+
+  updateWorktreeLabel(id: string, label: string): void {
+    const wt = this.worktrees.get(id)
+    if (!wt) return
+    wt.label = label || undefined
+    this.log(`Updated worktree ${id} label to "${label}"`)
+    void this.save()
   }
 
   removeWorktree(id: string): ManagedSession[] {

--- a/packages/kilo-vscode/src/agent-manager/branch-name.ts
+++ b/packages/kilo-vscode/src/agent-manager/branch-name.ts
@@ -11,3 +11,22 @@ export function generateBranchName(prompt: string): string {
 
   return `${sanitized || "kilo"}-${Date.now()}`
 }
+
+/**
+ * Compute the branch name and display label for a version in a multi-version group.
+ * Returns undefined values when no custom name is provided (falls back to auto-generated).
+ */
+export function versionedName(
+  base: string | undefined,
+  index: number,
+  total: number,
+): { branch: string | undefined; label: string | undefined } {
+  if (!base) return { branch: undefined, label: undefined }
+  if (total > 1 && index > 0) {
+    return {
+      branch: `${base}_v${index + 1}`,
+      label: `${base} v${index + 1}`,
+    }
+  }
+  return { branch: base, label: base }
+}

--- a/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
@@ -3,7 +3,8 @@ import os from "node:os"
 import path from "node:path"
 import fs from "node:fs/promises"
 import { WorktreeManager } from "../../src/agent-manager/WorktreeManager"
-import { generateBranchName } from "../../src/agent-manager/branch-name"
+import { generateBranchName, versionedName } from "../../src/agent-manager/branch-name"
+import { WorktreeStateManager } from "../../src/agent-manager/WorktreeStateManager"
 import simpleGit from "simple-git"
 
 // Each test gets its own temp directory -- no shared state, safe to run in parallel.
@@ -76,6 +77,100 @@ describe("generateBranchName", () => {
   it("lowercases input", () => {
     const name = generateBranchName("FIX BUG")
     expect(name).toMatch(/^fix-bug-\d+$/)
+  })
+
+  it("handles custom name with version suffix _v2", () => {
+    const name = generateBranchName("my-feature_v2")
+    expect(name).toMatch(/^my-feature-v2-\d+$/)
+  })
+
+  it("handles a clean custom name", () => {
+    const name = generateBranchName("auth-refactor")
+    expect(name).toMatch(/^auth-refactor-\d+$/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// versionedName
+// ---------------------------------------------------------------------------
+
+describe("versionedName", () => {
+  it("returns base name for first version", () => {
+    const result = versionedName("auth-refactor", 0, 3)
+    expect(result).toEqual({ branch: "auth-refactor", label: "auth-refactor" })
+  })
+
+  it("appends _v2 to branch and v2 to label for second version", () => {
+    const result = versionedName("auth-refactor", 1, 3)
+    expect(result).toEqual({ branch: "auth-refactor_v2", label: "auth-refactor v2" })
+  })
+
+  it("appends _v3 to branch and v3 to label for third version", () => {
+    const result = versionedName("auth-refactor", 2, 3)
+    expect(result).toEqual({ branch: "auth-refactor_v3", label: "auth-refactor v3" })
+  })
+
+  it("returns undefined for both when no name provided", () => {
+    expect(versionedName(undefined, 0, 3)).toEqual({ branch: undefined, label: undefined })
+    expect(versionedName(undefined, 1, 3)).toEqual({ branch: undefined, label: undefined })
+  })
+
+  it("returns undefined for empty string name", () => {
+    expect(versionedName("", 0, 2)).toEqual({ branch: undefined, label: undefined })
+  })
+
+  it("no suffix for single version", () => {
+    const result = versionedName("test", 0, 1)
+    expect(result).toEqual({ branch: "test", label: "test" })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// WorktreeStateManager -- updateWorktreeLabel
+// ---------------------------------------------------------------------------
+
+describe("WorktreeStateManager.updateWorktreeLabel", () => {
+  it("persists label on a worktree", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-wt-label-"))
+    tempDirs.push(dir)
+    const state = new WorktreeStateManager(dir, () => {})
+    const wt = state.addWorktree({ branch: "test", path: dir, parentBranch: "main" })
+    state.updateWorktreeLabel(wt.id, "my custom name")
+    await state.flush()
+
+    expect(state.getWorktree(wt.id)?.label).toBe("my custom name")
+  })
+
+  it("clears label when set to empty string", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-wt-label-"))
+    tempDirs.push(dir)
+    const state = new WorktreeStateManager(dir, () => {})
+    const wt = state.addWorktree({ branch: "test", path: dir, parentBranch: "main", label: "initial" })
+    await state.flush()
+    state.updateWorktreeLabel(wt.id, "")
+    await state.flush()
+
+    expect(state.getWorktree(wt.id)?.label).toBeUndefined()
+  })
+
+  it("survives save and reload", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-wt-label-"))
+    tempDirs.push(dir)
+    const state = new WorktreeStateManager(dir, () => {})
+    const wt = state.addWorktree({ branch: "test", path: dir, parentBranch: "main", label: "persisted" })
+    await state.flush()
+
+    const state2 = new WorktreeStateManager(dir, () => {})
+    await state2.load()
+    expect(state2.getWorktree(wt.id)?.label).toBe("persisted")
+  })
+
+  it("no-ops for nonexistent worktree", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-wt-label-"))
+    tempDirs.push(dir)
+    const state = new WorktreeStateManager(dir, () => {})
+    state.updateWorktreeLabel("nonexistent", "test")
+    await state.flush()
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -209,6 +209,21 @@ button.am-section-toggle:hover .am-section-label {
   min-width: 0;
 }
 
+.am-worktree-rename-input {
+  flex: 1;
+  min-width: 0;
+  height: 22px;
+  padding: 0 4px;
+  border: 1px solid var(--border-focus, #007fd4);
+  border-radius: 3px;
+  background: var(--surface-base);
+  color: var(--text-base);
+  font-size: inherit;
+  font-weight: 500;
+  font-family: inherit;
+  outline: none;
+}
+
 .am-worktree-close {
   position: absolute;
   right: 4px;
@@ -223,6 +238,11 @@ button.am-section-toggle:hover .am-section-label {
 
 .am-worktree-item:hover .am-worktree-close {
   opacity: 1;
+}
+
+.am-worktree-item:has(.am-worktree-rename-input) .am-worktree-close {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .am-worktree-spinner {
@@ -773,6 +793,27 @@ button.am-section-toggle:hover .am-section-label {
   gap: 14px;
   padding: 0 20px 20px;
   min-width: 460px;
+}
+
+.am-nv-name-input {
+  width: 100%;
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  background: var(--surface-base);
+  color: var(--text-base);
+  font-size: 13px;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.am-nv-name-input:focus {
+  border-color: var(--border-focus, #007fd4);
+}
+
+.am-nv-name-input::placeholder {
+  color: var(--text-weaker);
 }
 
 /* Dialog overrides for prompt-input-container — resizable from bottom edge */

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -569,6 +569,8 @@ export interface WorktreeState {
   createdAt: string
   /** Shared identifier for worktrees created together via multi-version mode. */
   groupId?: string
+  /** User-provided display name for the worktree. */
+  label?: string
 }
 
 export interface ManagedSessionState {


### PR DESCRIPTION
## Summary

- Add a "Worktree name (optional)" input to the New Worktree dialog so users can set a custom name when creating worktrees (including multi-version)
- Persist the name as a `label` field on the worktree state in `agent-manager.json`, so it survives session removal and restarts
- Add double-click inline rename on worktree sidebar items, stored as the worktree label (not session title)
- Extract `versionedName()` into a testable utility in `branch-name.ts`
- Hide the delete button while the rename input is active to prevent overlap

## Files changed

| File | Change |
| --- | --- |
| `WorktreeStateManager.ts` | `label` field on `Worktree`, `addWorktree` accepts label, new `updateWorktreeLabel()` |
| `messages.ts` | `label` on `WorktreeState` |
| `AgentManagerProvider.ts` | Pass name/label through creation flow, handle `agentManager.renameWorktree` |
| `branch-name.ts` | New `versionedName()` utility |
| `AgentManagerApp.tsx` | Name input in dialog, `worktreeLabel()` prefers `wt.label`, sidebar double-click rename |
| `agent-manager.css` | `.am-nv-name-input`, `.am-worktree-rename-input`, hide close during rename |
| `worktree-manager.test.ts` | Tests for `versionedName`, `updateWorktreeLabel` persistence |