### PR TITLE
fix(agent-manager): prevent Escape key from committing worktree rename

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1117,14 +1117,23 @@ const AgentManagerContent: Component = () => {
                     setRenameValue(current)
                   }
 
+                  let cancelled = false
+
                   const commitRename = (wtId: string) => {
+                    if (cancelled) {
+                      cancelled = false
+                      return
+                    }
                     const value = renameValue().trim()
                     setRenamingWt(null)
                     if (!value) return
                     vscode.postMessage({ type: "agentManager.renameWorktree", worktreeId: wtId, label: value })
                   }
 
-                  const cancelRename = () => setRenamingWt(null)
+                  const cancelRename = () => {
+                    cancelled = true
+                    setRenamingWt(null)
+                  }
 
                   return (
                     <For each={sortedWorktrees()}>


### PR DESCRIPTION
## Summary

- Fix bug where pressing Escape during inline worktree rename would still commit the rename due to the `onBlur` handler firing on unmount
- Add a `cancelled` flag so `commitRename` bails out when triggered by blur after Escape

Follow-up to #6175.