### PR TITLE
feat: sync VS Code telemetry preference to CLI at runtime

### DIFF
--- a/packages/kilo-vscode/src/services/cli-backend/http-client.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/http-client.ts
@@ -487,6 +487,18 @@ export class HttpClient {
   }
 
   // ============================================
+  // Telemetry Methods
+  // ============================================
+
+  /**
+   * Dynamically update the CLI server's telemetry enabled state.
+   * Used to sync the VS Code telemetry preference after the CLI has started.
+   */
+  async setTelemetryEnabled(enabled: boolean): Promise<void> {
+    await this.request<boolean>("POST", "/telemetry/set-enabled", { enabled })
+  }
+
+  // ============================================
   // MCP Methods
   // ============================================
 

--- a/packages/opencode/src/server/routes/telemetry.ts
+++ b/packages/opencode/src/server/routes/telemetry.ts
@@ -7,39 +7,71 @@ import { lazy } from "../../util/lazy"
 import { errors } from "../error"
 
 export const TelemetryRoutes = lazy(() =>
-  new Hono().post(
-    "/capture",
-    describeRoute({
-      summary: "Capture telemetry event",
-      description: "Forward a telemetry event to PostHog via kilo-telemetry.",
-      operationId: "telemetry.capture",
-      responses: {
-        200: {
-          description: "Event captured",
-          content: {
-            "application/json": {
-              schema: resolver(z.boolean()),
+  new Hono()
+    .post(
+      "/capture",
+      describeRoute({
+        summary: "Capture telemetry event",
+        description: "Forward a telemetry event to PostHog via kilo-telemetry.",
+        operationId: "telemetry.capture",
+        responses: {
+          200: {
+            description: "Event captured",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
             },
           },
+          ...errors(400),
         },
-        ...errors(400),
-      },
-    }),
-    validator(
-      "json",
-      z.object({
-        event: z.string().meta({ description: "Event name" }),
-        properties: z.record(z.string(), z.any()).optional().meta({ description: "Event properties" }),
       }),
+      validator(
+        "json",
+        z.object({
+          event: z.string().meta({ description: "Event name" }),
+          properties: z.record(z.string(), z.any()).optional().meta({ description: "Event properties" }),
+        }),
+      ),
+      async (c) => {
+        const body = c.req.valid("json")
+        try {
+          Telemetry.track(body.event as any, body.properties)
+        } catch {
+          // fire-and-forget: swallow errors
+        }
+        return c.json(true)
+      },
+    )
+    .post(
+      "/set-enabled",
+      describeRoute({
+        summary: "Set telemetry enabled state",
+        description:
+          "Dynamically enable or disable telemetry at runtime. Used by the VS Code extension to sync the user's telemetry preference after the CLI process has started.",
+        operationId: "telemetry.setEnabled",
+        responses: {
+          200: {
+            description: "Telemetry state updated",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator(
+        "json",
+        z.object({
+          enabled: z.boolean().meta({ description: "Whether telemetry should be enabled" }),
+        }),
+      ),
+      async (c) => {
+        const body = c.req.valid("json")
+        Telemetry.setEnabled(body.enabled)
+        return c.json(true)
+      },
     ),
-    async (c) => {
-      const body = c.req.valid("json")
-      try {
-        Telemetry.track(body.event as any, body.properties)
-      } catch {
-        // fire-and-forget: swallow errors
-      }
-      return c.json(true)
-    },
-  ),
 )

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -153,6 +153,8 @@ import type {
   SubtaskPartInput,
   TelemetryCaptureErrors,
   TelemetryCaptureResponses,
+  TelemetrySetEnabledErrors,
+  TelemetrySetEnabledResponses,
   TextPartInput,
   ToolIdsErrors,
   ToolIdsResponses,
@@ -2216,6 +2218,43 @@ export class Telemetry extends HeyApiClient {
         ...params.headers,
       },
     })
+  }
+
+  /**
+   * Set telemetry enabled state
+   *
+   * Dynamically enable or disable telemetry at runtime. Used by the VS Code extension to sync the user's telemetry preference after the CLI process has started.
+   */
+  public setEnabled<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      enabled?: boolean
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "body", key: "enabled" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<TelemetrySetEnabledResponses, TelemetrySetEnabledErrors, ThrowOnError>(
+      {
+        url: "/telemetry/set-enabled",
+        ...options,
+        ...params,
+        headers: {
+          "Content-Type": "application/json",
+          ...options?.headers,
+          ...params.headers,
+        },
+      },
+    )
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4258,6 +4258,38 @@ export type TelemetryCaptureResponses = {
 
 export type TelemetryCaptureResponse = TelemetryCaptureResponses[keyof TelemetryCaptureResponses]
 
+export type TelemetrySetEnabledData = {
+  body?: {
+    /**
+     * Whether telemetry should be enabled
+     */
+    enabled: boolean
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/telemetry/set-enabled"
+}
+
+export type TelemetrySetEnabledErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type TelemetrySetEnabledError = TelemetrySetEnabledErrors[keyof TelemetrySetEnabledErrors]
+
+export type TelemetrySetEnabledResponses = {
+  /**
+   * Telemetry state updated
+   */
+  200: boolean
+}
+
+export type TelemetrySetEnabledResponse = TelemetrySetEnabledResponses[keyof TelemetrySetEnabledResponses]
+
 export type CommitMessageGenerateData = {
   body?: {
     /**

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -4122,6 +4122,66 @@
         ]
       }
     },
+    "/telemetry/set-enabled": {
+      "post": {
+        "operationId": "telemetry.setEnabled",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Set telemetry enabled state",
+        "description": "Dynamically enable or disable telemetry at runtime. Used by the VS Code extension to sync the user's telemetry preference after the CLI process has started.",
+        "responses": {
+          "200": {
+            "description": "Telemetry state updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "description": "Whether telemetry should be enabled",
+                    "type": "boolean"
+                  }
+                },
+                "required": ["enabled"]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@kilocode/sdk\n\nconst client = createOpencodeClient()\nawait client.telemetry.setEnabled({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/commit-message": {
       "post": {
         "operationId": "commitMessage.generate",


### PR DESCRIPTION
## Problem

When the VS Code extension spawns the CLI server, it passes `KILO_TELEMETRY_LEVEL` as an environment variable based on `vscode.env.isTelemetryEnabled` at that moment. However, this value is **frozen at spawn time**. If the user toggles their VS Code telemetry setting after the CLI process is already running:

- **Extension-originated events** (e.g. `Task Created`, `Autocomplete Accept`) — correctly blocked because `TelemetryProxy.capture()` checks `vscode.env.isTelemetryEnabled` live on every call
- **CLI-native events** (e.g. `LLM Completion`, `CLI Start/Exit`, `Auth Success`, `Plan Followup`) — **still sent to PostHog** because the running CLI process still has `KILO_TELEMETRY_LEVEL=all` from the original spawn

There was no mechanism to dynamically update the CLI telemetry state after process startup.

## Solution

Three changes:

1. **New `POST /telemetry/set-enabled` route** on the CLI server — calls `Telemetry.setEnabled(bool)` which toggles both the PostHog client (`optIn`/`optOut`) and the OpenTelemetry span exporter at runtime

2. **`HttpClient.setTelemetryEnabled()`** in the extension — thin wrapper for the new route

3. **`vscode.env.onDidChangeTelemetryEnabled` subscription** in `extension.ts` — syncs the preference to the CLI immediately when the user toggles the setting. Also syncs on every connection (covers initial connect + SSE reconnects).

## Before

| Scenario | Extension events | CLI-native events |
|---|---|---|
| Telemetry ON at spawn, turned OFF later | ✅ Blocked (live check) | ❌ **Still sent** |

## After

| Scenario | Extension events | CLI-native events |
|---|---|---|
| Telemetry ON at spawn, turned OFF later | ✅ Blocked | ✅ **Now also blocked** |
