### PR TITLE
feat(vscode): implement Import tab in Open Workspace dialog

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -221,7 +221,7 @@
     },
     "packages/kilo-vscode": {
       "name": "kilo-code",
-      "version": "7.0.25",
+      "version": "1.0.25",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@kilocode/kilo-i18n": "workspace:*",

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -19,9 +19,12 @@ import type {
   AgentManagerKeybindingsMessage,
   AgentManagerMultiVersionProgressMessage,
   AgentManagerSendInitialMessage,
+  AgentManagerBranchesMessage,
+  AgentManagerImportResultMessage,
   WorktreeState,
   ManagedSessionState,
   SessionInfo,
+  BranchInfo,
 } from "../src/types/messages"
 import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, closestCenter } from "@thisbeyond/solid-dnd"
 import type { DragEvent } from "@thisbeyond/solid-dnd"
@@ -34,13 +37,14 @@ import { CodeComponentProvider } from "@kilocode/kilo-ui/context/code"
 import { DiffComponentProvider } from "@kilocode/kilo-ui/context/diff"
 import { Code } from "@kilocode/kilo-ui/code"
 import { Diff } from "@kilocode/kilo-ui/diff"
-import { Toast } from "@kilocode/kilo-ui/toast"
+import { Toast, showToast } from "@kilocode/kilo-ui/toast"
 import { ResizeHandle } from "@kilocode/kilo-ui/resize-handle"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Button } from "@kilocode/kilo-ui/button"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { Tooltip, TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
+import { Popover } from "@kilocode/kilo-ui/popover"
 import { HoverCard } from "@kilocode/kilo-ui/hover-card"
 import { VSCodeProvider, useVSCode } from "../src/context/vscode"
 import { ServerProvider } from "../src/context/server"
@@ -1481,16 +1485,21 @@ const AgentManagerContent: Component = () => {
 }
 
 // ---------------------------------------------------------------------------
-// Advanced "New Worktree" dialog — prompt, versions, model, mode
+// Advanced "New Worktree" dialog — prompt, versions, model, mode + Import tab
 // ---------------------------------------------------------------------------
 
 type VersionCount = 1 | 2 | 3 | 4
 const VERSION_OPTIONS: VersionCount[] = [1, 2, 3, 4]
 
+type DialogTab = "new" | "import"
+
 const NewWorktreeDialog: Component<{ onClose: () => void }> = (props) => {
   const vscode = useVSCode()
   const session = useSession()
 
+  const [tab, setTab] = createSignal<DialogTab>("new")
+
+  // --- New tab state ---
   const [prompt, setPrompt] = createSignal("")
   const [versions, setVersions] = createSignal<VersionCount>(2)
   const [model, setModel] = createSignal<{ providerID: string; modelID: string } | null>(null)
@@ -1543,81 +1552,280 @@ const NewWorktreeDialog: Component<{ onClose: () => void }> = (props) => {
     textareaRef.style.height = `${Math.min(textareaRef.scrollHeight, 200)}px`
   }
 
+  // --- Import tab state ---
+  const [prUrl, setPrUrl] = createSignal("")
+  const [prPending, setPrPending] = createSignal(false)
+  const [branches, setBranches] = createSignal<BranchInfo[]>([])
+  const [branchesLoading, setBranchesLoading] = createSignal(false)
+  const [branchSearch, setBranchSearch] = createSignal("")
+  const [branchOpen, setBranchOpen] = createSignal(false)
+  const [importPending, setImportPending] = createSignal(false)
+
+  const isPending = () => prPending() || importPending()
+
+  // Request data when switching to import tab
+  createEffect(() => {
+    if (tab() !== "import") return
+    setBranchesLoading(true)
+    vscode.postMessage({ type: "agentManager.requestBranches" })
+  })
+
+  // Listen for import-related messages
+  const importUnsub = vscode.onMessage((msg) => {
+    if (msg.type === "agentManager.branches") {
+      const ev = msg as AgentManagerBranchesMessage
+      setBranches(ev.branches)
+      setBranchesLoading(false)
+    }
+    if (msg.type === "agentManager.importResult") {
+      const ev = msg as AgentManagerImportResultMessage
+      setPrPending(false)
+      setImportPending(false)
+      if (ev.success) {
+        props.onClose()
+      } else {
+        showToast({ variant: "error", title: "Import failed", description: ev.message })
+      }
+    }
+  })
+
+  onCleanup(() => importUnsub())
+
+  const filteredBranches = createMemo(() => {
+    const q = branchSearch().toLowerCase()
+    if (!q) return branches()
+    return branches().filter((b) => b.name.toLowerCase().includes(q))
+  })
+
+  const handlePRSubmit = () => {
+    const url = prUrl().trim()
+    if (!url || isPending()) return
+    setPrPending(true)
+    vscode.postMessage({ type: "agentManager.importFromPR", url })
+  }
+
+  const handleBranchSelect = (name: string) => {
+    if (isPending()) return
+    setImportPending(true)
+    setBranchOpen(false)
+    setBranchSearch("")
+    vscode.postMessage({ type: "agentManager.importFromBranch", branch: name })
+  }
+
   return (
-    <Dialog title="New Worktree" fit>
-      <div class="am-nv-dialog" onKeyDown={handleKeyDown}>
-        {/* Prompt input — reuses the sidebar chat-input base classes for consistent styling */}
-        <div class="prompt-input-container am-prompt-input-container">
-          <div class="prompt-input-wrapper am-prompt-input-wrapper">
-            <div class="prompt-input-ghost-wrapper am-prompt-input-ghost-wrapper">
-              <textarea
-                ref={textareaRef}
-                class="prompt-input am-prompt-input"
-                placeholder={`Type a message (${isMac ? "\u2318" : "Ctrl+"}Enter to send)`}
-                value={prompt()}
-                onInput={(e) => {
-                  setPrompt(e.currentTarget.value)
-                  adjustHeight()
-                }}
-                rows={3}
-              />
+    <Dialog title="Open Workspace" fit>
+      {/* Tab switcher */}
+      <div class="am-tab-switcher">
+        <button
+          class="am-tab-switcher-pill"
+          classList={{ "am-tab-switcher-pill-active": tab() === "new" }}
+          onClick={() => setTab("new")}
+          type="button"
+        >
+          New
+        </button>
+        <button
+          class="am-tab-switcher-pill"
+          classList={{ "am-tab-switcher-pill-active": tab() === "import" }}
+          onClick={() => setTab("import")}
+          type="button"
+        >
+          Import
+        </button>
+      </div>
+
+      {/* New tab */}
+      <Show when={tab() === "new"}>
+        <div class="am-nv-dialog" onKeyDown={handleKeyDown}>
+          {/* Prompt input — reuses the sidebar chat-input base classes for consistent styling */}
+          <div class="prompt-input-container am-prompt-input-container">
+            <div class="prompt-input-wrapper am-prompt-input-wrapper">
+              <div class="prompt-input-ghost-wrapper am-prompt-input-ghost-wrapper">
+                <textarea
+                  ref={textareaRef}
+                  class="prompt-input am-prompt-input"
+                  placeholder={`Type a message (${isMac ? "\u2318" : "Ctrl+"}Enter to send)`}
+                  value={prompt()}
+                  onInput={(e) => {
+                    setPrompt(e.currentTarget.value)
+                    adjustHeight()
+                  }}
+                  rows={3}
+                />
+              </div>
+            </div>
+            <div class="prompt-input-hint">
+              <div class="prompt-input-hint-selectors">
+                <ModelSelectorBase
+                  value={model()}
+                  onSelect={(pid, mid) => setModel(pid && mid ? { providerID: pid, modelID: mid } : null)}
+                  placement="top-start"
+                  allowClear
+                  clearLabel="Default"
+                />
+                <Show when={session.agents().length > 1}>
+                  <ModeSwitcherBase agents={session.agents()} value={agent()} onSelect={setAgent} />
+                </Show>
+              </div>
+              <div class="prompt-input-hint-actions">
+                <Tooltip value={`${isMac ? "\u2318" : "Ctrl+"}Enter`} placement="top">
+                  <Button variant="primary" size="small" onClick={handleSubmit} disabled={!canSubmit()}>
+                    <Show
+                      when={!starting()}
+                      fallback={
+                        <>
+                          <Spinner class="am-nv-spinner" />
+                          <span>Creating...</span>
+                        </>
+                      }
+                    >
+                      <svg data-slot="icon-svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                        <path d="M1.5 1.5L14.5 8L1.5 14.5V9L10 8L1.5 7V1.5Z" />
+                      </svg>
+                    </Show>
+                  </Button>
+                </Tooltip>
+              </div>
             </div>
           </div>
-          <div class="prompt-input-hint">
-            <div class="prompt-input-hint-selectors">
-              <ModelSelectorBase
-                value={model()}
-                onSelect={(pid, mid) => setModel(pid && mid ? { providerID: pid, modelID: mid } : null)}
-                placement="top-start"
-                allowClear
-                clearLabel="Default"
-              />
-              <Show when={session.agents().length > 1}>
-                <ModeSwitcherBase agents={session.agents()} value={agent()} onSelect={setAgent} />
-              </Show>
+
+          <div class="am-nv-version-bar">
+            <span class="am-nv-config-label">Versions</span>
+            <div class="am-nv-pills">
+              {VERSION_OPTIONS.map((count) => (
+                <button
+                  class="am-nv-pill"
+                  classList={{ "am-nv-pill-active": versions() === count }}
+                  onClick={() => setVersions(count)}
+                  type="button"
+                >
+                  {count}
+                </button>
+              ))}
             </div>
-            <div class="prompt-input-hint-actions">
-              <Tooltip value={`${isMac ? "\u2318" : "Ctrl+"}Enter`} placement="top">
-                <Button variant="primary" size="small" onClick={handleSubmit} disabled={!canSubmit()}>
+            <Show when={versions() > 1}>
+              <span class="am-nv-version-hint">{versions()} worktrees will run in parallel</span>
+            </Show>
+          </div>
+        </div>
+      </Show>
+
+      {/* Import tab */}
+      <Show when={tab() === "import"}>
+        <div class="am-import-tab">
+          {/* Pull Request section */}
+          <div class="am-import-section">
+            <span class="am-nv-config-label">Pull Request</span>
+            <div class="am-pr-row">
+              <div class="am-pr-input-wrapper">
+                <Icon name="branch" size="small" />
+                <input
+                  class="am-pr-input"
+                  type="text"
+                  placeholder="Paste PR URL..."
+                  value={prUrl()}
+                  onInput={(e) => setPrUrl(e.currentTarget.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault()
+                      handlePRSubmit()
+                    }
+                  }}
+                  disabled={isPending()}
+                />
+              </div>
+              <Button
+                variant="secondary"
+                size="small"
+                onClick={handlePRSubmit}
+                disabled={!prUrl().trim() || isPending()}
+              >
+                <Show when={prPending()} fallback="Open">
+                  <Spinner class="am-nv-spinner" />
+                </Show>
+              </Button>
+            </div>
+          </div>
+
+          <div class="am-import-divider" />
+
+          {/* Branches section */}
+          <div class="am-import-section">
+            <span class="am-nv-config-label">Branches</span>
+            <div class="am-selector-wrapper">
+              <Popover
+                open={branchOpen()}
+                onOpenChange={setBranchOpen}
+                placement="bottom-start"
+                sameWidth
+                class="am-dropdown"
+                trigger={
+                  <button class="am-selector-trigger" disabled={isPending()} type="button">
+                    <span class="am-selector-left">
+                      <Icon name="branch" size="small" />
+                      <span class="am-selector-value">{branchesLoading() ? "Loading..." : "Select branch..."}</span>
+                    </span>
+                    <span class="am-selector-right">
+                      <Icon name="selector" size="small" />
+                    </span>
+                  </button>
+                }
+              >
+                <div class="am-dropdown-search">
+                  <Icon name="magnifying-glass" size="small" />
+                  <input
+                    class="am-dropdown-search-input"
+                    type="text"
+                    placeholder="Search branches..."
+                    value={branchSearch()}
+                    onInput={(e) => setBranchSearch(e.currentTarget.value)}
+                    autofocus
+                  />
+                </div>
+                <div class="am-dropdown-list">
                   <Show
-                    when={!starting()}
+                    when={filteredBranches().length > 0}
                     fallback={
-                      <>
-                        <Spinner class="am-nv-spinner" />
-                        <span>Creating...</span>
-                      </>
+                      <div class="am-dropdown-empty">
+                        {branchesLoading() ? "Loading branches..." : "No matching branches"}
+                      </div>
                     }
                   >
-                    <svg data-slot="icon-svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                      <path d="M1.5 1.5L14.5 8L1.5 14.5V9L10 8L1.5 7V1.5Z" />
-                    </svg>
+                    <For each={filteredBranches()}>
+                      {(branch) => (
+                        <div class="am-branch-item" onClick={() => handleBranchSelect(branch.name)}>
+                          <span class="am-branch-item-left">
+                            <Icon name="branch" size="small" />
+                            <span class="am-branch-item-name">{branch.name}</span>
+                            <Show when={branch.isDefault}>
+                              <span class="am-branch-badge">default</span>
+                            </Show>
+                            <Show when={!branch.isLocal && branch.isRemote}>
+                              <span class="am-branch-badge">remote</span>
+                            </Show>
+                          </span>
+                          <Show when={branch.lastCommitDate}>
+                            <span class="am-branch-item-time">{formatRelativeDate(branch.lastCommitDate!)}</span>
+                          </Show>
+                        </div>
+                      )}
+                    </For>
                   </Show>
-                </Button>
-              </Tooltip>
+                </div>
+              </Popover>
             </div>
           </div>
-        </div>
 
-        {/* Version selector + info */}
-        <div class="am-nv-version-bar">
-          <span class="am-nv-config-label">Versions</span>
-          <div class="am-nv-pills">
-            {VERSION_OPTIONS.map((count) => (
-              <button
-                class="am-nv-pill"
-                classList={{ "am-nv-pill-active": versions() === count }}
-                onClick={() => setVersions(count)}
-                type="button"
-              >
-                {count}
-              </button>
-            ))}
-          </div>
-          <Show when={versions() > 1}>
-            <span class="am-nv-version-hint">{versions()} worktrees will run in parallel</span>
+          {/* Empty state when no branches are available */}
+          <Show when={!branchesLoading() && branches().length === 0}>
+            <div class="am-import-empty">
+              No branches found.
+              <br />
+              Paste a PR URL above or create a new worktree.
+            </div>
           </Show>
         </div>
-      </div>
+      </Show>
     </Dialog>
   )
 }

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1121,3 +1121,301 @@ button.am-section-toggle:hover .am-section-label {
 .am-skeleton-session:nth-child(3) .am-skeleton-session-time {
   animation-delay: 0.3s;
 }
+
+/* Tab switcher for New/Import tabs in the dialog */
+
+.am-tab-switcher {
+  display: flex;
+  gap: 2px;
+  padding: 0 20px;
+  margin-bottom: 4px;
+}
+
+.am-tab-switcher-pill {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 14px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-weak);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 100ms;
+}
+
+.am-tab-switcher-pill:hover {
+  background: var(--surface-inset-base-hover);
+  color: var(--text-base);
+}
+
+.am-tab-switcher-pill-active {
+  background: var(--surface-interactive-base) !important;
+  color: var(--text-on-interactive-base) !important;
+}
+
+/* Import tab layout */
+
+.am-import-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 0 16px 16px;
+  min-width: 460px;
+  max-height: 350px;
+  overflow-y: auto;
+}
+
+.am-import-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.am-import-divider {
+  height: 1px;
+  background: var(--border-weak-base);
+}
+
+/* PR URL input row */
+
+.am-pr-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.am-pr-input-wrapper {
+  flex: 1;
+  position: relative;
+}
+
+.am-pr-input-wrapper [data-component="icon"] {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-weaker);
+  pointer-events: none;
+}
+
+.am-pr-input {
+  width: 100%;
+  height: 32px;
+  padding: 0 12px 0 32px;
+  border: 1px solid var(--border-weak-base);
+  border-radius: var(--radius-sm);
+  background: var(--vscode-input-background, var(--surface-inset-base));
+  color: var(--vscode-input-foreground, var(--text-base));
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.am-pr-input:focus {
+  border-color: var(--border-focus, #007fd4);
+}
+
+.am-pr-input::placeholder {
+  color: var(--vscode-input-placeholderForeground, var(--text-weaker));
+}
+
+.am-pr-input:disabled {
+  opacity: 0.5;
+}
+
+/* Branch/worktree selector — popover trigger must be full-width */
+
+.am-selector-wrapper [data-slot="popover-trigger"] {
+  display: flex;
+  width: 100%;
+}
+
+.am-selector-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--border-weak-base);
+  border-radius: var(--radius-sm);
+  background: var(--vscode-input-background, var(--surface-inset-base));
+  color: var(--text-base);
+  font-size: var(--font-size-base);
+  font-weight: 400;
+  cursor: pointer;
+  text-align: left;
+}
+
+.am-selector-trigger:hover {
+  border-color: var(--text-weaker);
+}
+
+.am-selector-trigger:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.am-selector-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex-shrink: 1;
+}
+
+.am-selector-left [data-component="icon"] {
+  color: var(--text-weaker);
+  flex-shrink: 0;
+}
+
+.am-selector-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-weaker);
+}
+
+.am-selector-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  margin-left: 8px;
+}
+
+.am-selector-right [data-component="icon"] {
+  color: var(--text-weaker);
+}
+
+/* Dropdown popover — must override kilo-ui defaults for max-width and body padding */
+
+.am-dropdown[data-component="popover-content"] {
+  max-width: none;
+  width: var(--kb-popper-anchor-width);
+}
+
+.am-dropdown [data-slot="popover-body"] {
+  padding: 0;
+}
+
+.am-dropdown-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 36px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--border-weak-base);
+}
+
+.am-dropdown-search [data-component="icon"] {
+  color: var(--text-weaker);
+  flex-shrink: 0;
+  opacity: 0.5;
+}
+
+.am-dropdown-search-input {
+  flex: 1;
+  border: none;
+  background: none;
+  color: var(--vscode-input-foreground, var(--text-base));
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  outline: none;
+  min-width: 0;
+}
+
+.am-dropdown-search-input::placeholder {
+  color: var(--vscode-input-placeholderForeground, var(--text-weaker));
+}
+
+.am-dropdown-list {
+  max-height: 200px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 4px;
+}
+
+/* Branch item in dropdown */
+
+.am-branch-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+}
+
+.am-branch-item:hover {
+  background: var(--surface-inset-base-hover);
+}
+
+.am-branch-item-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.am-branch-item-left [data-component="icon"] {
+  color: var(--text-weaker);
+  flex-shrink: 0;
+}
+
+.am-branch-item-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.am-branch-item-time {
+  font-size: 11px;
+  color: var(--text-weaker);
+  white-space: nowrap;
+  flex-shrink: 0;
+  margin-left: 8px;
+}
+
+.am-branch-badge {
+  font-size: 10px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--surface-inset-base);
+  color: var(--text-weaker);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.am-branch-group-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-weaker);
+  padding: 6px 8px 4px;
+}
+
+.am-dropdown-empty {
+  padding: 16px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-weaker);
+}
+
+/* Import empty state */
+
+.am-import-empty {
+  padding: 20px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-weaker);
+  line-height: 1.5;
+}

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -615,6 +615,39 @@ export interface VariantsLoadedMessage {
   variants: Record<string, string>
 }
 
+// Agent Manager Import tab: branch list (extension → webview)
+export interface BranchInfo {
+  name: string
+  isLocal: boolean
+  isRemote: boolean
+  isDefault: boolean
+  lastCommitDate?: string
+}
+
+export interface AgentManagerBranchesMessage {
+  type: "agentManager.branches"
+  branches: BranchInfo[]
+  defaultBranch: string
+}
+
+// Agent Manager Import tab: external worktrees (extension → webview)
+export interface ExternalWorktreeInfo {
+  path: string
+  branch: string
+}
+
+export interface AgentManagerExternalWorktreesMessage {
+  type: "agentManager.externalWorktrees"
+  worktrees: ExternalWorktreeInfo[]
+}
+
+// Agent Manager Import tab: result feedback (extension → webview)
+export interface AgentManagerImportResultMessage {
+  type: "agentManager.importResult"
+  success: boolean
+  message: string
+}
+
 // Request webview to send initial prompt to a newly created session (extension → webview)
 export interface AgentManagerSendInitialMessage {
   type: "agentManager.sendInitialMessage"
@@ -672,6 +705,9 @@ export type ExtensionMessage =
   | SetChatBoxMessage
   | TriggerTaskMessage
   | VariantsLoadedMessage
+  | AgentManagerBranchesMessage
+  | AgentManagerExternalWorktreesMessage
+  | AgentManagerImportResultMessage
 
 // ============================================
 // Messages FROM webview TO extension
@@ -957,6 +993,40 @@ export interface SetSessionsCollapsedRequest {
   collapsed: boolean
 }
 
+// Agent Manager Import tab: request branch list (webview → extension)
+export interface RequestBranchesMessage {
+  type: "agentManager.requestBranches"
+}
+
+// Agent Manager Import tab: request external worktrees (webview → extension)
+export interface RequestExternalWorktreesMessage {
+  type: "agentManager.requestExternalWorktrees"
+}
+
+// Agent Manager Import tab: import from existing branch (webview → extension)
+export interface ImportFromBranchRequest {
+  type: "agentManager.importFromBranch"
+  branch: string
+}
+
+// Agent Manager Import tab: import from PR URL (webview → extension)
+export interface ImportFromPRRequest {
+  type: "agentManager.importFromPR"
+  url: string
+}
+
+// Agent Manager Import tab: import a single external worktree (webview → extension)
+export interface ImportExternalWorktreeRequest {
+  type: "agentManager.importExternalWorktree"
+  path: string
+  branch: string
+}
+
+// Agent Manager Import tab: import all external worktrees (webview → extension)
+export interface ImportAllExternalWorktreesRequest {
+  type: "agentManager.importAllExternalWorktrees"
+}
+
 // Variant persistence (webview → extension)
 export interface PersistVariantRequest {
   type: "persistVariant"
@@ -1023,6 +1093,12 @@ export type WebviewMessage =
   | SetSessionsCollapsedRequest
   | PersistVariantRequest
   | RequestVariantsMessage
+  | RequestBranchesMessage
+  | RequestExternalWorktreesMessage
+  | ImportFromBranchRequest
+  | ImportFromPRRequest
+  | ImportExternalWorktreeRequest
+  | ImportAllExternalWorktreesRequest
 
 // ============================================
 // VS Code API type


### PR DESCRIPTION
## Summary

- Adds an **Import** tab to the Agent Manager's "Open Workspace" dialog alongside the existing "New" tab
- **PR URL import**: paste a GitHub PR URL to create a worktree from the PR branch — supports both same-repo and fork PRs via `gh` CLI
- **Branch selector**: searchable dropdown listing all available branches (with default/remote badges, relative timestamps), filtered to exclude branches already checked out in any worktree
- **Validation & error handling**: duplicate branch detection, user-friendly toast errors for `gh` not installed, not authenticated, PR not found, branch already in use
- Dialog closes on successful import; stays open with error toast on failure

<img width="1118" height="1088" alt="image" src="https://github.com/user-attachments/assets/aa36bda7-ab61-49a6-bad0-dcb0bd8deea7" />
