### PR TITLE
feat: cloud session browse-then-clone flow

### DIFF
--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -6,6 +6,7 @@
  * This factory function accepts OpenCode dependencies to create Kilo-specific routes
  */
 
+import { randomBytes } from "crypto"
 import { fetchProfile, fetchBalance } from "../api/profile.js"
 import { fetchKilocodeNotifications, KilocodeNotificationSchema } from "../api/notifications.js"
 import { KILO_API_BASE, HEADER_FEATURE } from "../api/constants.js" // kilocode_change - added HEADER_FEATURE
@@ -28,6 +29,8 @@ interface KiloRoutesDeps {
   errors: Errors
   Auth: Auth
   z: Z
+  Storage: any
+  Instance: any
 }
 
 /**
@@ -53,8 +56,20 @@ interface KiloRoutesDeps {
  * })
  * ```
  */
+function generateId(prefix: string, descending: boolean): string {
+  const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+  const bytes = randomBytes(14)
+  let rand = ""
+  for (let i = 0; i < 14; i++) rand += chars[bytes[i] % 62]
+  let now = BigInt(Date.now()) * BigInt(0x1000) + BigInt(1)
+  if (descending) now = ~now
+  const buf = Buffer.alloc(6)
+  for (let i = 0; i < 6; i++) buf[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff))
+  return prefix + "_" + buf.toString("hex") + rand
+}
+
 export function createKiloRoutes(deps: KiloRoutesDeps) {
-  const { Hono, describeRoute, validator, resolver, errors, Auth, z } = deps
+  const { Hono, describeRoute, validator, resolver, errors, Auth, z, Storage, Instance } = deps
 
   const Organization = z.object({
     id: z.string(),
@@ -320,6 +335,85 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
 
         const data = await response.json()
         return c.json(data)
+      },
+    )
+    .post(
+      "/cloud/session/import",
+      describeRoute({
+        summary: "Import session from cloud",
+        description: "Download a cloud-synced session and write it to local storage with fresh IDs.",
+        operationId: "kilo.cloud.session.import",
+        responses: {
+          200: {
+            description: "Imported session info",
+            content: {
+              "application/json": {
+                schema: resolver(z.unknown()),
+              },
+            },
+          },
+          ...errors(400, 401, 404),
+        },
+      }),
+      validator(
+        "json",
+        z.object({
+          sessionId: z.string(),
+        }),
+      ),
+      async (c: any) => {
+        const { sessionId } = c.req.valid("json")
+
+        const auth = await Auth.get("kilo")
+        if (!auth) return c.json({ error: "Not authenticated with Kilo" }, 401)
+        const token = auth.type === "api" ? auth.key : auth.type === "oauth" ? auth.access : undefined
+        if (!token) return c.json({ error: "No valid token found" }, 401)
+
+        const base = process.env.KILO_SESSION_INGEST_URL ?? "https://ingest.kilosessions.ai"
+        const response = await fetch(`${base}/api/session/${sessionId}/export`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            ...buildKiloHeaders(),
+          },
+        })
+
+        if (response.status === 404) return c.json({ error: "Session not found in cloud" }, 404)
+        if (!response.ok) {
+          const text = await response.text()
+          console.error("[Kilo Gateway] cloud/session/import: export failed", {
+            status: response.status,
+            body: text.slice(0, 500),
+          })
+          return c.json({ error: `Import failed: ${response.status}` }, response.status as any)
+        }
+
+        const data = (await response.json()) as any
+        if (!data?.info?.id) return c.json({ error: "Invalid export data" }, 400)
+
+        const localSessionID = generateId("ses", true)
+        const msgMap = new Map<string, string>()
+        const projectID = Instance.project.id
+
+        data.info.id = localSessionID
+        data.info.projectID = projectID
+        await Storage.write(["session", projectID, localSessionID], data.info)
+
+        for (const msg of data.messages ?? []) {
+          const msgID = generateId("msg", false)
+          msgMap.set(msg.info.id, msgID)
+          msg.info.id = msgID
+          msg.info.sessionID = localSessionID
+          if (msg.info.parentID) msg.info.parentID = msgMap.get(msg.info.parentID) ?? msg.info.parentID
+          await Storage.write(["message", localSessionID, msgID], msg.info)
+          for (const part of msg.parts ?? []) {
+            part.id = generateId("prt", false)
+            part.messageID = msgID
+            part.sessionID = localSessionID
+            await Storage.write(["part", msgID, part.id], part)
+          }
+        }
+
+        return c.json(data.info)
       },
     )
     .get(

--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -35,6 +35,8 @@ interface KiloRoutesDeps {
   MessageTable: any
   PartTable: any
   SessionToRow: (info: any) => any
+  Bus: { publish: (event: any, payload: any) => void }
+  SessionCreatedEvent: any
 }
 
 /**
@@ -87,6 +89,8 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
     MessageTable,
     PartTable,
     SessionToRow,
+    Bus,
+    SessionCreatedEvent,
   } = deps
 
   const Organization = z.object({
@@ -455,6 +459,8 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
                 .run()
             }
           }
+
+          Database.effect(() => Bus.publish(SessionCreatedEvent, { info: data.info }))
         })
 
         return c.json(data.info)

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -440,6 +440,31 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             this.postMessage({ type: "gitRemoteUrlLoaded", gitUrl: url ?? null })
           })
           break
+        case "requestCloudSessionData":
+          void this.handleRequestCloudSessionData(message.sessionId)
+          break
+        case "importAndSend": {
+          const files = z
+            .array(
+              z.object({
+                mime: z.string(),
+                url: z.string().refine((u) => u.startsWith("file://") || u.startsWith("data:")),
+              }),
+            )
+            .optional()
+            .catch(undefined)
+            .parse(message.files)
+          void this.handleImportAndSend(
+            message.cloudSessionId,
+            message.text,
+            message.providerID,
+            message.modelID,
+            message.agent,
+            message.variant,
+            files,
+          )
+          break
+        }
         case "dismissNotification":
           await this.handleDismissNotification(message.notificationId)
           break
@@ -996,6 +1021,123 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         message: error instanceof Error ? error.message : "Failed to fetch cloud sessions",
       })
     }
+  }
+
+  /**
+   * Fetch full cloud session data for read-only preview.
+   * Transforms the export data into webview message format and sends it back.
+   */
+  private async handleRequestCloudSessionData(sessionId: string): Promise<void> {
+    if (!this.httpClient) {
+      this.postMessage({
+        type: "cloudSessionImportFailed",
+        cloudSessionId: sessionId,
+        error: "Not connected to CLI backend",
+      })
+      return
+    }
+
+    const data = await this.httpClient.getCloudSession(sessionId)
+    if (!data) {
+      this.postMessage({
+        type: "cloudSessionImportFailed",
+        cloudSessionId: sessionId,
+        error: "Failed to fetch cloud session",
+      })
+      return
+    }
+
+    const messages = (data.messages ?? []).map((m) => ({
+      id: m.info.id,
+      sessionID: m.info.sessionID,
+      role: m.info.role as "user" | "assistant",
+      parts: m.parts,
+      createdAt: new Date(m.info.time.created).toISOString(),
+      cost: m.info.cost,
+      tokens: m.info.tokens,
+    }))
+
+    this.postMessage({
+      type: "cloudSessionDataLoaded",
+      cloudSessionId: sessionId,
+      title: data.info.title ?? "Untitled",
+      messages,
+    })
+  }
+
+  /**
+   * Import a cloud session to local storage, then send a new message on it.
+   * This is the "clone on first message" flow — the cloud session becomes a
+   * local session only when the user decides to continue it.
+   */
+  private async handleImportAndSend(
+    cloudSessionId: string,
+    text: string,
+    providerID?: string,
+    modelID?: string,
+    agent?: string,
+    variant?: string,
+    files?: Array<{ mime: string; url: string }>,
+  ): Promise<void> {
+    if (!this.httpClient) {
+      this.postMessage({
+        type: "cloudSessionImportFailed",
+        cloudSessionId,
+        error: "Not connected to CLI backend",
+      })
+      return
+    }
+
+    const workspaceDir = this.getWorkspaceDirectory()
+
+    // Step 1: Import the cloud session with fresh IDs
+    const session = await this.httpClient.importCloudSession(cloudSessionId)
+    if (!session) {
+      this.postMessage({
+        type: "cloudSessionImportFailed",
+        cloudSessionId,
+        error: "Failed to import session from cloud",
+      })
+      return
+    }
+
+    // Track the new local session
+    this.currentSession = session
+    this.trackedSessionIds.add(session.id)
+
+    // Notify webview of the import success
+    this.postMessage({
+      type: "cloudSessionImported",
+      cloudSessionId,
+      session: this.sessionToWebview(session),
+    })
+
+    // Step 2: Send the user's message on the new local session
+    const parts: Array<{ type: "text"; text: string } | { type: "file"; mime: string; url: string }> = []
+
+    const editor = vscode.window.activeTextEditor
+    if (editor && editor.document.uri.scheme === "file") {
+      const url = editor.document.uri.toString()
+      const already = files?.some((f) => f.url === url)
+      if (!already) {
+        parts.push({ type: "file", mime: "text/plain", url })
+      }
+    }
+
+    if (files) {
+      for (const f of files) {
+        parts.push({ type: "file", mime: f.mime, url: f.url })
+      }
+    }
+
+    parts.push({ type: "text", text })
+
+    await this.httpClient.sendMessage(session.id, parts, workspaceDir, {
+      providerID,
+      modelID,
+      agent,
+      variant,
+    })
   }
 
   /**

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1091,7 +1091,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     const workspaceDir = this.getWorkspaceDirectory()
 
     // Step 1: Import the cloud session with fresh IDs
-    const session = await this.httpClient.importCloudSession(cloudSessionId)
+    const session = await this.httpClient.importCloudSession(cloudSessionId, workspaceDir)
     if (!session) {
       this.postMessage({
         type: "cloudSessionImportFailed",

--- a/packages/kilo-vscode/src/services/cli-backend/http-client.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/http-client.ts
@@ -13,6 +13,7 @@ import type {
   Config,
   KilocodeNotification,
   CloudSessionsResponse,
+  CloudSessionData,
 } from "./types"
 import { extractHttpErrorMessage, parseSSEDataLine } from "./http-utils"
 
@@ -359,6 +360,32 @@ export class HttpClient {
       return await this.request<CloudSessionsResponse>("GET", `/kilo/cloud-sessions${qs ? `?${qs}` : ""}`)
     } catch (err) {
       console.warn("[Kilo] Failed to fetch cloud sessions:", err)
+      return null
+    }
+  }
+
+  /**
+   * Fetch full cloud session data for read-only preview.
+   * Returns null if the session is not found or the request fails.
+   */
+  async getCloudSession(sessionId: string): Promise<CloudSessionData | null> {
+    try {
+      return await this.request<CloudSessionData>("GET", `/kilo/cloud/session/${sessionId}`)
+    } catch (err) {
+      console.warn("[Kilo] Failed to fetch cloud session:", err)
+      return null
+    }
+  }
+
+  /**
+   * Import a cloud session into local storage with fresh IDs.
+   * Returns the imported session info, or null on failure.
+   */
+  async importCloudSession(sessionId: string): Promise<SessionInfo | null> {
+    try {
+      return await this.request<SessionInfo>("POST", "/kilo/cloud/session/import", { sessionId })
+    } catch (err) {
+      console.warn("[Kilo] Failed to import cloud session:", err)
       return null
     }
   }

--- a/packages/kilo-vscode/src/services/cli-backend/http-client.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/http-client.ts
@@ -381,9 +381,9 @@ export class HttpClient {
    * Import a cloud session into local storage with fresh IDs.
    * Returns the imported session info, or null on failure.
    */
-  async importCloudSession(sessionId: string): Promise<SessionInfo | null> {
+  async importCloudSession(sessionId: string, directory: string): Promise<SessionInfo | null> {
     try {
-      return await this.request<SessionInfo>("POST", "/kilo/cloud/session/import", { sessionId })
+      return await this.request<SessionInfo>("POST", "/kilo/cloud/session/import", { sessionId }, { directory })
     } catch (err) {
       console.warn("[Kilo] Failed to import cloud session:", err)
       return null

--- a/packages/kilo-vscode/src/services/cli-backend/index.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/index.ts
@@ -28,6 +28,7 @@ export type {
   Config,
   KilocodeNotification,
   KilocodeNotificationAction,
+  CloudSessionData,
 } from "./types"
 
 export { ServerManager } from "./server-manager"

--- a/packages/kilo-vscode/src/services/cli-backend/types.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/types.ts
@@ -351,3 +351,31 @@ export interface CloudSessionsResponse {
   cliSessions: CloudSessionInfo[]
   nextCursor: string | null
 }
+
+// Full cloud session data for preview (from /kilo/cloud/session/:id)
+export interface CloudSessionData {
+  info: {
+    id: string
+    title: string
+    time: { created: number; updated: number }
+    [key: string]: unknown
+  }
+  messages: Array<{
+    info: {
+      id: string
+      sessionID: string
+      role: "user" | "assistant"
+      time: { created: number; completed?: number }
+      cost?: { input: number; output: number; reasoning?: number; cache?: { read: number; write: number } }
+      tokens?: { input: number; output: number; reasoning?: number; cache?: { read: number; write: number } }
+      [key: string]: unknown
+    }
+    parts: Array<{
+      id: string
+      sessionID: string
+      messageID: string
+      type: string
+      [key: string]: unknown
+    }>
+  }>
+}

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -171,7 +171,12 @@ const AppContent: Component = () => {
           <SessionList onSelectSession={handleSelectSession} />
         </Match>
         <Match when={currentView() === "cloudHistory"}>
-          <CloudSessionList />
+          <CloudSessionList
+            onSelectSession={(cloudSessionId) => {
+              session.selectCloudSession(cloudSessionId)
+              setCurrentView("newTask")
+            }}
+          />
         </Match>
         <Match when={currentView() === "profile"}>
           <ProfileView

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -125,6 +125,10 @@ interface SessionContextValue {
   deleteSession: (id: string) => void
   renameSession: (id: string, title: string) => void
   syncSession: (sessionID: string) => void
+
+  // Cloud session preview
+  cloudPreviewId: Accessor<string | null>
+  selectCloudSession: (cloudSessionId: string) => void
 }
 
 const SessionContext = createContext<SessionContextValue>()
@@ -174,6 +178,9 @@ export const SessionProvider: ParentComponent = (props) => {
 
   // Pending agent selection for before a session exists (mirrors pendingModelSelection)
   const [pendingAgentSelection, setPendingAgentSelection] = createSignal<string | null>(null)
+
+  // Cloud session preview state
+  const [cloudPreviewId, setCloudPreviewId] = createSignal<string | null>(null)
 
   // Store for sessions, messages, parts, todos, modelSelections, agentSelections
   const [store, setStore] = createStore<SessionStore>({
@@ -375,6 +382,20 @@ export const SessionProvider: ParentComponent = (props) => {
           // Only clear loading if the error is for the current session
           // (or has no sessionID for backwards compatibility)
           if (!message.sessionID || message.sessionID === currentSessionID()) setLoading(false)
+          break
+
+        case "cloudSessionDataLoaded":
+          handleCloudSessionDataLoaded(message.cloudSessionId, message.title, message.messages)
+          break
+
+        case "cloudSessionImported":
+          handleCloudSessionImported(message.cloudSessionId, message.session)
+          break
+
+        case "cloudSessionImportFailed":
+          setCloudPreviewId(null)
+          setLoading(false)
+          console.error("[Kilo New] Cloud session import failed:", message.error)
           break
       }
     })
@@ -639,6 +660,59 @@ export const SessionProvider: ParentComponent = (props) => {
     })
   }
 
+  function handleCloudSessionDataLoaded(cloudSessionId: string, title: string, messages: Message[]) {
+    const key = `cloud:${cloudSessionId}`
+    batch(() => {
+      setStore("sessions", key, {
+        id: key,
+        title,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+      setStore("messages", key, messages)
+      for (const msg of messages) {
+        if (msg.parts && msg.parts.length > 0) {
+          setStore("parts", msg.id, msg.parts)
+        }
+      }
+      setCurrentSessionID(key)
+      setLoading(false)
+    })
+  }
+
+  function handleCloudSessionImported(cloudSessionId: string, session: SessionInfo) {
+    const cloudKey = `cloud:${cloudSessionId}`
+    batch(() => {
+      setStore("sessions", session.id, session)
+
+      const pending = pendingModelSelection()
+      if (pending && !store.modelSelections[session.id]) {
+        setStore("modelSelections", session.id, pending)
+      }
+      const pendingAgent = pendingAgentSelection()
+      if (pendingAgent && !store.agentSelections[session.id]) {
+        setStore("agentSelections", session.id, pendingAgent)
+      }
+
+      setCloudPreviewId(null)
+      setCurrentSessionID(session.id)
+      setLoading(true)
+
+      setStore(
+        "sessions",
+        produce((sessions) => {
+          delete sessions[cloudKey]
+        }),
+      )
+      setStore(
+        "messages",
+        produce((messages) => {
+          delete messages[cloudKey]
+        }),
+      )
+    })
+  }
+
   // Actions
   function selectAgent(name: string) {
     const id = currentSessionID()
@@ -655,7 +729,22 @@ export const SessionProvider: ParentComponent = (props) => {
       return
     }
 
-    // Phase 4: optimistic user message
+    const preview = cloudPreviewId()
+    if (preview) {
+      const agent = selectedAgentName() !== defaultAgent() ? selectedAgentName() : undefined
+      vscode.postMessage({
+        type: "importAndSend",
+        cloudSessionId: preview,
+        text,
+        providerID,
+        modelID,
+        agent,
+        variant: currentVariant(),
+        files,
+      })
+      return
+    }
+
     const sid = currentSessionID()
     if (sid) {
       const tempId = `optimistic-${crypto.randomUUID()}`
@@ -802,6 +891,16 @@ export const SessionProvider: ParentComponent = (props) => {
     vscode.postMessage({ type: "loadMessages", sessionID: id })
   }
 
+  function selectCloudSession(cloudSessionId: string) {
+    if (!server.isConnected()) {
+      console.warn("[Kilo New] Cannot select cloud session: not connected")
+      return
+    }
+    setCloudPreviewId(cloudSessionId)
+    setLoading(true)
+    vscode.postMessage({ type: "requestCloudSessionData", sessionId: cloudSessionId })
+  }
+
   function deleteSession(id: string) {
     if (!server.isConnected()) {
       console.warn("[Kilo New] Cannot delete session: not connected")
@@ -930,6 +1029,8 @@ export const SessionProvider: ParentComponent = (props) => {
     deleteSession,
     renameSession,
     syncSession,
+    cloudPreviewId,
+    selectCloudSession,
   }
 
   return <SessionContext.Provider value={value}>{props.children}</SessionContext.Provider>

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -896,7 +896,9 @@ export const SessionProvider: ParentComponent = (props) => {
       console.warn("[Kilo New] Cannot select cloud session: not connected")
       return
     }
+    const key = `cloud:${cloudSessionId}`
     setCloudPreviewId(cloudSessionId)
+    setCurrentSessionID(key)
     setLoading(true)
     vscode.postMessage({ type: "requestCloudSessionData", sessionId: cloudSessionId })
   }

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -682,6 +682,7 @@ export const SessionProvider: ParentComponent = (props) => {
 
   function handleCloudSessionImported(cloudSessionId: string, session: SessionInfo) {
     const cloudKey = `cloud:${cloudSessionId}`
+    const cloudMessages = store.messages[cloudKey] ?? []
     batch(() => {
       setStore("sessions", session.id, session)
 
@@ -694,9 +695,11 @@ export const SessionProvider: ParentComponent = (props) => {
         setStore("agentSelections", session.id, pendingAgent)
       }
 
+      // Carry over cloud messages so there's no loading flash
+      setStore("messages", session.id, cloudMessages)
+
       setCloudPreviewId(null)
       setCurrentSessionID(session.id)
-      setLoading(true)
 
       setStore(
         "sessions",
@@ -711,6 +714,8 @@ export const SessionProvider: ParentComponent = (props) => {
         }),
       )
     })
+    // Load real messages in the background (picks up server-assigned IDs
+    // and the new user message once the send completes via SSE)
     vscode.postMessage({ type: "loadMessages", sessionID: session.id })
   }
 

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -711,6 +711,7 @@ export const SessionProvider: ParentComponent = (props) => {
         }),
       )
     })
+    vscode.postMessage({ type: "loadMessages", sessionID: session.id })
   }
 
   // Actions

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -886,6 +886,10 @@ export const SessionProvider: ParentComponent = (props) => {
       console.warn("[Kilo New] Cannot select session: not connected")
       return
     }
+    if (id.startsWith("cloud:")) {
+      console.warn("[Kilo New] Cannot select cloud preview session via selectSession")
+      return
+    }
     setCurrentSessionID(id)
     setLoading(true)
     vscode.postMessage({ type: "loadMessages", sessionID: id })
@@ -948,7 +952,9 @@ export const SessionProvider: ParentComponent = (props) => {
   }
 
   const sessions = createMemo(() =>
-    Object.values(store.sessions).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
+    Object.values(store.sessions)
+      .filter((s) => !s.id.startsWith("cloud:"))
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
   )
 
   const totalCost = createMemo(() => calcTotalCost(messages()))

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -418,6 +418,25 @@ export interface GitRemoteUrlLoadedMessage {
   gitUrl: string | null
 }
 
+export interface CloudSessionDataLoadedMessage {
+  type: "cloudSessionDataLoaded"
+  cloudSessionId: string
+  title: string
+  messages: Message[]
+}
+
+export interface CloudSessionImportedMessage {
+  type: "cloudSessionImported"
+  cloudSessionId: string
+  session: SessionInfo
+}
+
+export interface CloudSessionImportFailedMessage {
+  type: "cloudSessionImportFailed"
+  cloudSessionId: string
+  error: string
+}
+
 export interface ActionMessage {
   type: "action"
   action: string
@@ -695,6 +714,9 @@ export type ExtensionMessage =
   | SetChatBoxMessage
   | TriggerTaskMessage
   | VariantsLoadedMessage
+  | CloudSessionDataLoadedMessage
+  | CloudSessionImportedMessage
+  | CloudSessionImportFailedMessage
 
 // ============================================
 // Messages FROM webview TO extension
@@ -754,6 +776,22 @@ export interface RequestCloudSessionsMessage {
 
 export interface RequestGitRemoteUrlMessage {
   type: "requestGitRemoteUrl"
+}
+
+export interface RequestCloudSessionDataMessage {
+  type: "requestCloudSessionData"
+  sessionId: string
+}
+
+export interface ImportAndSendMessage {
+  type: "importAndSend"
+  cloudSessionId: string
+  text: string
+  providerID?: string
+  modelID?: string
+  agent?: string
+  variant?: string
+  files?: FileAttachment[]
 }
 
 export interface LoginRequest {
@@ -1059,6 +1097,8 @@ export type WebviewMessage =
   | SetSessionsCollapsedRequest
   | PersistVariantRequest
   | RequestVariantsMessage
+  | RequestCloudSessionDataMessage
+  | ImportAndSendMessage
 
 // ============================================
 // VS Code API type

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -31,7 +31,9 @@ import { ExperimentalRoutes } from "./routes/experimental"
 import { TelemetryRoutes } from "./routes/telemetry" // kilocode_change
 import { ProviderRoutes } from "./routes/provider"
 import { createKiloRoutes } from "@kilocode/kilo-gateway" // kilocode_change
-import { Storage } from "../storage/storage" // kilocode_change
+import { Database } from "../storage/db" // kilocode_change
+import { Session } from "../session" // kilocode_change
+import { SessionTable, MessageTable, PartTable } from "../session/session.sql" // kilocode_change
 import { lazy } from "../util/lazy"
 import { InstanceBootstrap } from "../project/bootstrap"
 import { NotFoundError } from "../storage/db"
@@ -249,8 +251,12 @@ export namespace Server {
             errors,
             Auth,
             z,
-            Storage, // kilocode_change
+            Database, // kilocode_change
             Instance, // kilocode_change
+            SessionTable, // kilocode_change
+            MessageTable, // kilocode_change
+            PartTable, // kilocode_change
+            SessionToRow: Session.toRow, // kilocode_change
           }),
         )
         // kilocode_change end

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -31,6 +31,7 @@ import { ExperimentalRoutes } from "./routes/experimental"
 import { TelemetryRoutes } from "./routes/telemetry" // kilocode_change
 import { ProviderRoutes } from "./routes/provider"
 import { createKiloRoutes } from "@kilocode/kilo-gateway" // kilocode_change
+import { Storage } from "../storage/storage" // kilocode_change
 import { lazy } from "../util/lazy"
 import { InstanceBootstrap } from "../project/bootstrap"
 import { NotFoundError } from "../storage/db"
@@ -248,6 +249,8 @@ export namespace Server {
             errors,
             Auth,
             z,
+            Storage, // kilocode_change
+            Instance, // kilocode_change
           }),
         )
         // kilocode_change end

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -257,6 +257,8 @@ export namespace Server {
             MessageTable, // kilocode_change
             PartTable, // kilocode_change
             SessionToRow: Session.toRow, // kilocode_change
+            Bus, // kilocode_change
+            SessionCreatedEvent: Session.Event.Created, // kilocode_change
           }),
         )
         // kilocode_change end

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4444,6 +4444,101 @@ export type KiloNotificationsResponses = {
 
 export type KiloNotificationsResponse = KiloNotificationsResponses[keyof KiloNotificationsResponses]
 
+export type KiloCloudSessionGetData = {
+  body?: never
+  path: {
+    id: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/kilo/cloud/session/{id}"
+}
+
+export type KiloCloudSessionGetErrors = {
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type KiloCloudSessionGetError = KiloCloudSessionGetErrors[keyof KiloCloudSessionGetErrors]
+
+export type KiloCloudSessionGetResponses = {
+  /**
+   * Cloud session data
+   */
+  200: unknown
+}
+
+export type KiloCloudSessionImportData = {
+  body?: {
+    sessionId: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/kilo/cloud/session/import"
+}
+
+export type KiloCloudSessionImportErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type KiloCloudSessionImportError = KiloCloudSessionImportErrors[keyof KiloCloudSessionImportErrors]
+
+export type KiloCloudSessionImportResponses = {
+  /**
+   * Imported session info
+   */
+  200: unknown
+}
+
+export type KiloCloudSessionsData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/kilo/cloud-sessions"
+}
+
+export type KiloCloudSessionsErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type KiloCloudSessionsError = KiloCloudSessionsErrors[keyof KiloCloudSessionsErrors]
+
+export type KiloCloudSessionsResponses = {
+  /**
+   * Cloud sessions list
+   */
+  200: {
+    cliSessions: Array<{
+      session_id: string
+      title: string | null
+      cloud_agent_session_id: string | null
+      created_at: string
+      updated_at: string
+      version: number
+    }>
+    nextCursor: string | null
+  }
+}
+
+export type KiloCloudSessionsResponse = KiloCloudSessionsResponses[keyof KiloCloudSessionsResponses]
+
 export type FindTextData = {
   body?: never
   path?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -4514,6 +4514,228 @@
         ]
       }
     },
+    "/kilo/cloud/session/{id}": {
+      "get": {
+        "operationId": "kilo.cloud.session.get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Get cloud session",
+        "description": "Fetch full session data from the Kilo cloud for preview",
+        "responses": {
+          "200": {
+            "description": "Cloud session data",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@kilocode/sdk\n\nconst client = createOpencodeClient()\nawait client.kilo.cloud.session.get({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilo/cloud/session/import": {
+      "post": {
+        "operationId": "kilo.cloud.session.import",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Import session from cloud",
+        "description": "Download a cloud-synced session and write it to local storage with fresh IDs.",
+        "responses": {
+          "200": {
+            "description": "Imported session info",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionId": {
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionId"]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@kilocode/sdk\n\nconst client = createOpencodeClient()\nawait client.kilo.cloud.session.import({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilo/cloud-sessions": {
+      "get": {
+        "operationId": "kilo.cloudSessions",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get cloud sessions",
+        "description": "Fetch cloud CLI sessions from Kilo API",
+        "responses": {
+          "200": {
+            "description": "Cloud sessions list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "cliSessions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "session_id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "cloud_agent_session_id": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "session_id",
+                          "title",
+                          "cloud_agent_session_id",
+                          "created_at",
+                          "updated_at",
+                          "version"
+                        ]
+                      }
+                    },
+                    "nextCursor": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["cliSessions", "nextCursor"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@kilocode/sdk\n\nconst client = createOpencodeClient()\nawait client.kilo.cloudSessions({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/find": {
       "get": {
         "operationId": "find.text",


### PR DESCRIPTION
## Summary

- Clicking a cloud session fetches full session data from the cloud for **read-only preview** — no local storage write occurs
- Messages render normally in the ChatView; the user can browse the full conversation history
- A **local session is only created when the user sends a new message** — the cloud session is imported with fresh IDs (`ses_`, `msg_`, `prt_`) to avoid collisions during sync
- After import, the session seamlessly transitions from cloud preview to a normal local session

## Changes

### kilo-gateway
- `GET /kilo/cloud/session/:id` — proxies the cloud ingest export API to return full session data (messages + parts) for preview
- `POST /kilo/cloud/session/import` — imports a cloud session into local storage, generating fresh IDs for session, messages, and parts

### opencode (server.ts)
- Passes `Storage` and `Instance` deps to kilo gateway routes (needed for the import endpoint)

### kilo-vscode (extension host)
- `HttpClient.getCloudSession()` and `HttpClient.importCloudSession()` methods
- `KiloProvider.handleRequestCloudSessionData()` — fetches cloud session, transforms to webview format
- `KiloProvider.handleImportAndSend()` — imports cloud session then sends the user's new message

### kilo-vscode (webview)
- New message types: `requestCloudSessionData`, `cloudSessionDataLoaded`, `importAndSend`, `cloudSessionImported`, `cloudSessionImportFailed`
- Session context: `selectCloudSession()`, `cloudPreviewId` signal, modified `sendMessage()` that intercepts cloud preview mode
- `CloudSessionList` click now wired to `selectCloudSession()` → chat view

### SDK
- Regenerated for new gateway endpoints