### PR TITLE
ci: bump stale operations-per-run from 30 to 200

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -30,3 +30,4 @@ jobs:
             Closing this one out since it's been inactive for a while — not because it's a bad PR, just that older items tend to lose context over time and we'd rather start fresh if this is still relevant.
 
             Please feel free to reopen (or open a new PR) if you're still working on this. We're happy to take another look! 🙏
+          operations-per-run: 200


### PR DESCRIPTION
The default `operations-per-run` for [actions/stale](https://github.com/actions/stale#operations-per-run) is 30, which may not be enough to process all stale issues in a single run. This bumps it to 200.