### PR TITLE
feat(agent-manager): add advanced worktree creation with base branch and custom branch name

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -135,6 +135,11 @@
         "category": "Kilo Code"
       },
       {
+        "command": "kilo-code.new.agentManager.advancedWorktree",
+        "title": "Agent Manager: Advanced New Worktree",
+        "category": "Kilo Code"
+      },
+      {
         "command": "kilo-code.new.generateCommitMessage",
         "title": "Generate Commit Message",
         "category": "Kilo Code (NEW)",
@@ -361,6 +366,12 @@
         "command": "kilo-code.new.agentManager.closeWorktree",
         "key": "ctrl+shift+w",
         "mac": "cmd+shift+w",
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.agentManager.advancedWorktree",
+        "key": "ctrl+shift+n",
+        "mac": "cmd+shift+n",
         "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
       }
     ],

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -100,6 +100,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("kilo-code.new.agentManager.closeWorktree", () => {
       agentManagerProvider.postMessage({ type: "action", action: "closeWorktree" })
     }),
+    vscode.commands.registerCommand("kilo-code.new.agentManager.advancedWorktree", () => {
+      agentManagerProvider.postMessage({ type: "action", action: "advancedWorktree" })
+    }),
   )
 
   // Register autocomplete provider

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1069,15 +1069,6 @@ button.am-section-toggle:hover .am-section-label {
   padding: 4px 0;
 }
 
-.am-branch-group-label {
-  padding: 6px 10px 4px;
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-  color: var(--text-weaker);
-}
-
 .am-branch-item {
   display: flex;
   align-items: center;
@@ -1141,13 +1132,6 @@ button.am-section-toggle:hover .am-section-label {
   font-size: 11px;
   color: var(--text-weaker);
   white-space: nowrap;
-}
-
-.am-branch-empty {
-  padding: 12px 10px;
-  font-size: 12px;
-  color: var(--text-weaker);
-  text-align: center;
 }
 
 /* HoverCard popover for worktree items */

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -795,6 +795,14 @@ button.am-section-toggle:hover .am-section-label {
   min-width: 460px;
 }
 
+/* Allow dropdowns to escape the dialog bounds */
+[data-component="dialog"]:has(.am-nv-dialog) [data-slot="dialog-content"] {
+  overflow: visible;
+}
+[data-component="dialog"]:has(.am-nv-dialog) [data-slot="dialog-body"] {
+  overflow: visible;
+}
+
 .am-nv-name-input {
   width: 100%;
   height: 32px;
@@ -907,6 +915,239 @@ button.am-section-toggle:hover .am-section-label {
 .am-nv-spinner {
   width: 14px;
   height: 14px;
+}
+
+.am-nv-submit {
+  width: 100%;
+  justify-content: center;
+}
+
+/* Advanced options toggle */
+
+.am-advanced-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 0;
+  border: none;
+  background: none;
+  color: var(--text-weak);
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 100ms;
+}
+
+.am-advanced-toggle:hover {
+  color: var(--text-base);
+}
+
+/* Advanced options section */
+
+.am-advanced-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 8px 0;
+}
+
+.am-advanced-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.am-advanced-input {
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  background: var(--surface-base);
+  color: var(--text-base);
+  font-size: 12px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 120ms;
+}
+
+.am-advanced-input:focus {
+  border-color: var(--border-focus, #007fd4);
+}
+
+.am-advanced-input::placeholder {
+  color: var(--text-weaker);
+}
+
+/* Branch selector trigger + dropdown */
+
+.am-branch-selector-wrapper {
+  position: relative;
+}
+
+.am-branch-selector-trigger {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  background: var(--surface-base);
+  color: var(--text-base);
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color 120ms;
+}
+
+.am-branch-selector-trigger:hover {
+  border-color: var(--border-hover);
+}
+
+.am-branch-selector-value {
+  flex: 1;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.am-branch-badge {
+  font-size: 10px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--surface-raised-stronger-non-alpha);
+  color: var(--text-weak);
+  white-space: nowrap;
+}
+
+.am-branch-badge-remote {
+  background: var(--surface-raised-base);
+  opacity: 0.7;
+}
+
+.am-branch-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 100;
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  background: var(--surface-float-base, var(--surface-raised-base));
+  box-shadow: var(--shadow-lg-border-base, 0 8px 24px rgba(0, 0, 0, 0.3));
+  max-height: 280px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.am-branch-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-base);
+}
+
+.am-branch-search-input {
+  flex: 1;
+  border: none;
+  background: none;
+  color: var(--text-base);
+  font-size: 12px;
+  font-family: inherit;
+  outline: none;
+}
+
+.am-branch-search-input::placeholder {
+  color: var(--text-weaker);
+}
+
+.am-branch-list {
+  overflow-y: auto;
+  max-height: 220px;
+  padding: 4px 0;
+}
+
+.am-branch-group-label {
+  padding: 6px 10px 4px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--text-weaker);
+}
+
+.am-branch-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  background: none;
+  color: var(--text-base);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 80ms;
+  text-align: left;
+}
+
+.am-branch-item:hover {
+  background: var(--surface-raised-base-hover);
+}
+
+.am-branch-item-active {
+  background: var(--surface-raised-base);
+}
+
+.am-branch-item-highlighted {
+  background: var(--surface-raised-base-hover);
+}
+
+/* Keyboard shortcut hints in dropdown menus */
+
+.am-menu-shortcut {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.am-menu-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 3px;
+  background: var(--surface-raised-stronger-non-alpha);
+  color: var(--text-weak);
+  font-size: 10px;
+  font-family: inherit;
+  line-height: 1;
+}
+
+.am-branch-item-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono, monospace);
+}
+
+.am-branch-item-time {
+  font-size: 11px;
+  color: var(--text-weaker);
+  white-space: nowrap;
+}
+
+.am-branch-empty {
+  padding: 12px 10px;
+  font-size: 12px;
+  color: var(--text-weaker);
+  text-align: center;
 }
 
 /* HoverCard popover for worktree items */

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -611,6 +611,22 @@ export interface AgentManagerMultiVersionProgressMessage {
   groupId?: string
 }
 
+// Branch info for branch selector (extension → webview)
+export interface AgentManagerBranchInfo {
+  name: string
+  isLocal: boolean
+  isRemote: boolean
+  lastCommitDate: number
+  isDefault: boolean
+}
+
+// Branch list response (extension → webview)
+export interface AgentManagerBranchesMessage {
+  type: "agentManager.branches"
+  branches: AgentManagerBranchInfo[]
+  defaultBranch: string
+}
+
 // Stored variant selections loaded from extension globalState (extension → webview)
 export interface VariantsLoadedMessage {
   type: "variantsLoaded"
@@ -889,6 +905,8 @@ export interface TelemetryRequest {
 // Create a new worktree (with auto-created first session)
 export interface CreateWorktreeRequest {
   type: "agentManager.createWorktree"
+  baseBranch?: string
+  branchName?: string
 }
 
 // Delete a worktree and dissociate its sessions
@@ -937,13 +955,14 @@ export interface ShowTerminalRequest {
 // Create multiple worktree sessions for the same prompt (multi-version mode)
 export interface CreateMultiVersionRequest {
   type: "agentManager.createMultiVersion"
-  text: string
+  text?: string
   versions: number
   providerID?: string
   modelID?: string
   agent?: string
   files?: FileAttachment[]
   baseBranch?: string
+  branchName?: string
 }
 
 // Persist tab order for a context (worktree ID or "local")
@@ -957,6 +976,11 @@ export interface SetTabOrderRequest {
 export interface SetSessionsCollapsedRequest {
   type: "agentManager.setSessionsCollapsed"
   collapsed: boolean
+}
+
+// Request branch list for base branch selector
+export interface RequestBranchesMessage {
+  type: "agentManager.requestBranches"
 }
 
 // Variant persistence (webview → extension)
@@ -1025,6 +1049,7 @@ export type WebviewMessage =
   | SetSessionsCollapsedRequest
   | PersistVariantRequest
   | RequestVariantsMessage
+  | RequestBranchesMessage
 
 // ============================================
 // VS Code API type

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -638,7 +638,7 @@ export interface AgentManagerSendInitialMessage {
   type: "agentManager.sendInitialMessage"
   sessionId: string
   worktreeId: string
-  text: string
+  text?: string
   providerID?: string
   modelID?: string
   agent?: string


### PR DESCRIPTION
## Summary

Adds an "Advanced..." option to the Agent Manager's worktree creation dropdown that opens a dialog with configurable base branch and custom branch name, matching the UX from the reference implementation.

## Changes

### New Worktree Dialog — Advanced Options
- Collapsible "Advanced options" section with:
  - **Branch name input** — auto-sanitized as you type (lowercase, spaces→hyphens, strips illegal git chars, preserves `/` for path-style names)
  - **Base branch selector** — searchable dropdown with arrow key navigation, Enter/Escape, default/remote badges, relative commit time
- Default version count changed from 2 → 1
- Allow creating worktree without a prompt text (creates session without sending initial message)
- "Create Workspace" submit button moved to bottom of dialog

### Keyboard Shortcut
- `⌘⇧N` / `Ctrl+Shift+N` opens the Advanced dialog directly
- Shortcut shown in dropdown menu as styled key caps
- Added to Keyboard Shortcuts dialog under Sidebar section

### Backend
- `WorktreeManager.createWorktree()` accepts `baseBranch` and `branchName` params
- Base branch validation + remote-only branch fetch support
- "Already checked out" error detection with worktree path info
- `listBranches()` method for branch discovery (local + remote, sorted by commit date)
- Directory name sanitization (slashes → dashes) for filesystem safety

### Message Types
- `baseBranch` and `branchName` on `CreateWorktreeRequest` and `CreateMultiVersionRequest`
- `text` made optional on `CreateMultiVersionRequest` (allows no-prompt creation)
- `RequestBranchesMessage` / `AgentManagerBranchesMessage` for branch list request/response

### Multi-version support
- Custom branch name used as prefix with `-v1`, `-v2` suffixes for multi-version
- `baseBranch` passed through to all version worktrees


<img width="314" height="182" alt="image" src="https://github.com/user-attachments/assets/41b193c7-89d5-420d-80b2-9b96de4bd571" />

<img width="552" height="591" alt="image" src="https://github.com/user-attachments/assets/5c4a380e-fac1-4692-9d5b-44eb975318fe" />

