### PR TITLE
ci: suppress stale messages since close is immediate

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -22,6 +22,8 @@ jobs:
           days-before-pr-stale: ${{ env.DAYS_BEFORE_PR_CLOSE }}
           days-before-issue-close: 0
           days-before-pr-close: 0
+          stale-issue-message: ""
+          stale-pr-message: ""
           close-issue-message: |
             Closing this one out since it's been inactive for a while — not because it's a bad issue, just that older items tend to lose context over time and we'd rather start fresh if this is still a problem.
 


### PR DESCRIPTION
With `days-before-issue-close: 0` and `days-before-pr-close: 0`, items are marked stale and closed in the same run. Without suppressing the stale message, two comments are posted simultaneously (stale + close), e.g. https://github.com/Kilo-Org/kilocode/issues/3353#issuecomment-3946083125

Setting `stale-issue-message` and `stale-pr-message` to empty strings prevents the redundant stale comment, so only the close message is posted.