### PR TITLE
fix: use toDateString() instead of toISOString() in system prompt to preserve caching

### DIFF
--- a/packages/opencode/src/kilocode/editor-context.ts
+++ b/packages/opencode/src/kilocode/editor-context.ts
@@ -6,9 +6,9 @@ export interface EditorContext {
   timezone?: string
 }
 
-function formatTime(timezone?: string): string[] {
+function formatDate(timezone?: string): string[] {
   const now = new Date()
-  const lines = [`  Current time: ${now.toISOString()}`]
+  const lines = [`  Today's date: ${now.toDateString()}`]
   if (timezone) {
     const offset = -now.getTimezoneOffset()
     const sign = offset >= 0 ? "+" : "-"
@@ -24,7 +24,7 @@ function formatTime(timezone?: string): string[] {
  * Returns an array of pre-formatted `  key: value` strings.
  */
 export function editorContextEnvLines(ctx?: EditorContext): string[] {
-  const lines = formatTime(ctx?.timezone)
+  const lines = formatDate(ctx?.timezone)
   if (ctx?.shell) {
     lines.push(`  Default shell: ${ctx.shell}`)
   }


### PR DESCRIPTION
## Problem

PR #6151 introduced editor context in the system prompt but changed the date format from `toDateString()` (e.g. `Tue Feb 24 2026`) to `toISOString()` (e.g. `2026-02-24T07:28:00.720Z`). Since `toISOString()` includes seconds/milliseconds, the system prompt changes on every request, which breaks prompt caching.

## Fix

Changed back to `toDateString()` which only changes once per day, preserving prompt cache hits. All other editor context improvements from #6151 are kept intact.

## Changes

- `packages/opencode/src/kilocode/editor-context.ts`: Renamed `formatTime` → `formatDate`, changed `Current time: ${now.toISOString()}` → `Today's date: ${now.toDateString()}`