### PR TITLE
fix(agent-manager): show non-git notice instead of infinite skeleton

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -172,19 +172,30 @@ export class AgentManagerProvider implements vscode.Disposable {
     if (type === "agentManager.requestState") {
       void this.stateReady
         ?.then(() => {
+          // When the workspace is not a git repo (or has no folder open),
+          // this.state is never created. pushState() silently returns in that
+          // case, so re-send the empty/non-git state explicitly.
+          if (!this.state) {
+            this.pushEmptyState()
+            return
+          }
           this.pushState()
           // Refresh sessions after pushState so the webview's sessionsLoaded
           // handler is guaranteed to be registered (requestState fires from
           // onMount). Without this, the initial refreshSessions() in
           // initializeState() can race ahead of webview mount, causing
           // sessionsLoaded to never flip to true.
-          if (this.state && this.state.getSessions().length > 0) {
+          if (this.state.getSessions().length > 0) {
             this.provider?.refreshSessions()
           }
         })
         .catch((err) => {
           this.log("initializeState failed, pushing partial state:", err)
-          this.pushState()
+          if (!this.state) {
+            this.pushEmptyState()
+          } else {
+            this.pushState()
+          }
         })
       return null
     }

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -657,6 +657,9 @@ const AgentManagerContent: Component = () => {
         setManagedSessions(state.sessions)
         if (state.isGitRepo !== undefined) setIsGitRepo(state.isGitRepo)
         if (!worktreesLoaded()) setWorktreesLoaded(true)
+        // When not a git repo, also mark sessions as loaded since the Kilo
+        // server won't connect to send the sessionsLoaded message.
+        if (state.isGitRepo === false && !sessionsLoaded()) setSessionsLoaded(true)
         if (state.tabOrder) setWorktreeTabOrder(state.tabOrder)
         const current = session.currentSessionID()
         if (current) {


### PR DESCRIPTION
## Problem

When Agent Manager is opened in a non-git directory (or empty folder), the loading skeletons are shown forever instead of the \"Not a git repository\" notice.

**Root cause — two issues:**

1. **Webview stuck on skeleton:** The worktree list `<Show>` requires both `worktreesLoaded()` and `sessionsLoaded()` to be true. In a non-git workspace, `pushEmptyState()` sets `worktreesLoaded = true`, but `sessionsLoaded` depends on a `"sessionsLoaded"` message from `KiloProvider.handleLoadSessions()` — which bails out early because `httpClient` is null when no server connects. So `sessionsLoaded` never flips and the skeleton stays forever.

2. **Race condition on panel open:** The `agentManager.requestState` handler (sent from `onMount`) called `pushState()` which silently returns when `this.state` is `undefined` (non-git case). If the webview mounted after the initial `pushEmptyState()` already fired, the empty state was never resent.

## Fix

- **`AgentManagerApp.tsx`:** When `agentManager.state` arrives with `isGitRepo === false`, also set `sessionsLoaded(true)` — there are no sessions to wait for in a non-git workspace.
- **`AgentManagerProvider.ts`:** In the `requestState` handler, explicitly call `pushEmptyState()` when `this.state` is undefined instead of falling through to the silent no-op in `pushState()`.

## Tests

Static-analysis regression tests added to `agent-manager-arch.test.ts` (no mocks — inspects actual source):
- `requestState` handler calls `pushEmptyState` guarded by `!this.state`
- `requestState` handler still calls `pushState` for the normal path
- `agentManager.state` handler calls `setSessionsLoaded` when `isGitRepo === false`