### PR TITLE
perf(vscode): unblock message queue and batch store updates for faster session switching

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -42,6 +42,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private cachedNotificationsMessage: unknown = null
 
   private trackedSessionIds: Set<string> = new Set()
+  private syncedChildSessions: Set<string> = new Set()
   /** Per-session directory overrides (e.g., worktree paths registered by AgentManagerProvider). */
   private sessionDirectories = new Map<string, string>()
   /** Abort controller for the current loadMessages request; aborted when a new session is selected. */
@@ -317,10 +318,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           void this.handleLoadMessages(message.sessionID)
           break
         case "syncSession":
-          await this.handleSyncSession(message.sessionID)
+          this.handleSyncSession(message.sessionID).catch((e) =>
+            console.error("[Kilo New] handleSyncSession failed:", e),
+          )
           break
         case "loadSessions":
-          await this.handleLoadSessions()
+          this.handleLoadSessions().catch((e) => console.error("[Kilo New] handleLoadSessions failed:", e))
           break
         case "login":
           await this.handleLogin()
@@ -351,13 +354,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           }
           break
         case "requestProviders":
-          await this.fetchAndSendProviders()
+          this.fetchAndSendProviders().catch((e) => console.error("[Kilo New] fetchAndSendProviders failed:", e))
           break
         case "compact":
           await this.handleCompact(message.sessionID, message.providerID, message.modelID)
           break
         case "requestAgents":
-          await this.fetchAndSendAgents()
+          this.fetchAndSendAgents().catch((e) => console.error("[Kilo New] fetchAndSendAgents failed:", e))
           break
         case "questionReply":
           await this.handleQuestionReply(message.requestID, message.answers)
@@ -366,7 +369,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           await this.handleQuestionReject(message.requestID)
           break
         case "requestConfig":
-          await this.fetchAndSendConfig()
+          this.fetchAndSendConfig().catch((e) => console.error("[Kilo New] fetchAndSendConfig failed:", e))
           break
         case "updateConfig":
           await this.handleUpdateConfig(message.config)
@@ -437,7 +440,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           this.sendNotificationSettings()
           break
         case "requestNotifications":
-          await this.fetchAndSendNotifications()
+          this.fetchAndSendNotifications().catch((e) =>
+            console.error("[Kilo New] fetchAndSendNotifications failed:", e),
+          )
           break
         case "dismissNotification":
           await this.handleDismissNotification(message.notificationId)
@@ -544,11 +549,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.postMessage({ type: "connectionState", state: this.connectionState })
       await this.syncWebviewState("initializeConnection")
 
-      // Fetch providers and agents, then send to webview
-      await this.fetchAndSendProviders()
-      await this.fetchAndSendAgents()
-      await this.fetchAndSendConfig()
-      await this.fetchAndSendNotifications()
+      // Fetch providers, agents, config, and notifications in parallel
+      await Promise.all([
+        this.fetchAndSendProviders(),
+        this.fetchAndSendAgents(),
+        this.fetchAndSendConfig(),
+        this.fetchAndSendNotifications(),
+      ])
       this.sendNotificationSettings()
 
       console.log("[Kilo New] KiloProvider: ✅ initializeConnection completed successfully")
@@ -696,8 +703,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    */
   private async handleSyncSession(sessionID: string): Promise<void> {
     if (!this.httpClient) return
-    if (this.trackedSessionIds.has(sessionID)) return
+    if (this.syncedChildSessions.has(sessionID)) return
 
+    this.syncedChildSessions.add(sessionID)
     this.trackedSessionIds.add(sessionID)
 
     try {
@@ -1568,8 +1576,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     const activeEditor = vscode.window.activeTextEditor
     const activeRel =
       activeEditor?.document.uri.scheme === "file" ? toRelative(activeEditor.document.uri.fsPath) : undefined
-    const activeFile =
-      activeRel && controller.validateAccess(activeEditor!.document.uri.fsPath) ? activeRel : undefined
+    const activeFile = activeRel && controller.validateAccess(activeEditor!.document.uri.fsPath) ? activeRel : undefined
 
     // Shell
     const shell = vscode.env.shell || undefined

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -410,13 +410,15 @@ export const SessionProvider: ParentComponent = (props) => {
   }
 
   function handleMessagesLoaded(sessionID: string, messages: Message[]) {
-    if (sessionID === currentSessionID()) setLoading(false)
-    setStore("messages", sessionID, messages)
+    batch(() => {
+      if (sessionID === currentSessionID()) setLoading(false)
+      setStore("messages", sessionID, messages)
 
-    // Also extract parts from messages
-    messages.forEach((msg) => {
-      if (msg.parts && msg.parts.length > 0) {
-        setStore("parts", msg.id, msg.parts)
+      // Also extract parts from messages
+      for (const msg of messages) {
+        if (msg.parts && msg.parts.length > 0) {
+          setStore("parts", msg.id, msg.parts)
+        }
       }
     })
   }


### PR DESCRIPTION
## Summary

Session switching in the Agent Manager was taking 3-7+ seconds due to three independent bottlenecks discovered through profiling. This PR fixes all three.

## Profiling Methodology

We instrumented timing traces across the full message loading pipeline — from the webview `selectSession` click through VS Code IPC, the extension's message handler queue, the HTTP fetch to the CLI backend, SQLite queries, JSON serialization, and back through IPC to the webview's SolidJS store update and DOM rendering.

Additionally, Chrome DevTools Performance traces were captured from the Agent Manager webview to identify CPU-level bottlenecks (flame charts, CPU profile sampling).

### Key profiling findings

1. **Message queue head-of-line blocking**: The extension's `onDidReceiveMessage` handler is `async` with a sequential switch statement. With 4 webviews firing initialization messages, `loadMessages` was queued behind 16+ sequential `await`ed HTTP calls totaling ~3.3s.

2. **SolidJS reactivity cascade**: `handleMessagesLoaded` called `setStore` N+1 times (1 for the message array + N for individual parts). Each call triggered a full reactivity cascade. Chrome DevTools trace showed `setStore` → `setter` → `writeSignal` → `runUpdates` → `render` repeating for each store write, totaling 7.5s for 45 messages/164 parts.

3. **Child session sync flood**: Every `task` tool part component fired a `syncSession` message via a SolidJS `createEffect`. Since `trackedSessionIds` was cleared on each `clearSession` (which fires on every session switch), the same child sessions were re-synced 3+ times per switch — 9+ redundant HTTP calls per session switch.

4. **Synchronous syntax highlighting**: `findNextMatchSync` (Oniguruma/TextMate regex) consumed 2.3s (91.4% of CPU time) during rendering — this is tracked separately in #6221 as it requires changes to the shared UI library.

## Changes

### 1. Unblock the webview message queue

Six handlers (`requestProviders`, `requestConfig`, `requestAgents`, `requestNotifications`, `loadSessions`, `syncSession`) were `await`ed in the message handler switch, blocking the queue. Changed to non-blocking `.catch()` calls. Each handler already has internal try/catch and sends results via `postMessage`, so awaiting provided no additional error handling.

### 2. Parallel initialization fetches

`initializeConnection` ran `fetchAndSendProviders`, `fetchAndSendAgents`, `fetchAndSendConfig`, `fetchAndSendNotifications` sequentially (~700ms total). Changed to `Promise.all` (~480ms, limited by the slowest call).

### 3. Deduplicate child session syncs

Added a persistent `syncedChildSessions` Set (not cleared on `clearSession`) so each child session syncs exactly once per KiloProvider lifetime. SSE events still flow because `trackedSessionIds` is set on first sync.

### 4. Batch SolidJS store updates

Wrapped all `setStore` calls in `handleMessagesLoaded` in `batch()` so SolidJS triggers one consolidated reactivity pass instead of N+1.

## Measured Impact

Profiling data from a session with 45 messages, 164 parts, 1.49MB payload:

| Metric | Before | After | Improvement |
|---|---|---|---|
| Queue wait (before loadMessages starts) | ~3.3s | ~0ms | Eliminated |
| initializeConnection fetches | ~700ms | ~480ms | 30% faster |
| handleMessagesLoaded rendering | ~7.5s | ~2.5s | 67% faster |
| syncSession calls per switch | 9+ | 0 (after first load) | Eliminated |
| Total perceived session switch | 7-10s | ~2.5s | 70-75% faster |

Remaining ~2.5s is synchronous syntax highlighting (`findNextMatchSync` / Shiki Oniguruma at 91.4% CPU) — tracked separately in #6221.

### Individual operation timings (from profiling traces)

| Operation | Time |
|---|---|
| Server SQLite query (45 msgs, 164 parts) | 4-8ms |
| Server JSON serialization (1.49MB) | 2-4ms |
| HTTP round-trip (localhost) | 10-25ms |
| Extension transform + postMessage | 5-10ms |
| Webview store update (with batch) | ~50ms |
| Syntax highlighting (Shiki) | ~2,300ms |

## Files Changed

- `packages/kilo-vscode/src/KiloProvider.ts` — message queue unblocking, parallel init, syncSession dedup
- `packages/kilo-vscode/webview-ui/src/context/session.tsx` — batch() wrapper for handleMessagesLoaded
