### PR TITLE
fix(vscode): add missing RenameWorktreeRequest type and clean up AgentManagerProvider

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -165,7 +165,7 @@ export class AgentManagerProvider implements vscode.Disposable {
     if (type === "agentManager.renameWorktree" && typeof msg.worktreeId === "string" && typeof msg.label === "string") {
       const state = this.getStateManager()
       if (state) {
-        state.updateWorktreeLabel(msg.worktreeId as string, msg.label as string)
+        state.updateWorktreeLabel(msg.worktreeId, msg.label)
         this.pushState()
       }
       return null
@@ -205,28 +205,24 @@ export class AgentManagerProvider implements vscode.Disposable {
       return null
     }
     if (type === "agentManager.setTabOrder" && typeof msg.key === "string" && Array.isArray(msg.order)) {
-      this.state?.setTabOrder(msg.key as string, msg.order as string[])
+      this.state?.setTabOrder(msg.key, msg.order as string[])
       return null
     }
     if (type === "agentManager.setSessionsCollapsed" && typeof msg.collapsed === "boolean") {
-      this.state?.setSessionsCollapsed(msg.collapsed as boolean)
+      this.state?.setSessionsCollapsed(msg.collapsed)
       return null
     }
 
-    if (type === "agentManager.requestBranches") {
-      void this.onRequestBranches()
-      return null
-    }
     if (type === "agentManager.requestExternalWorktrees") {
       void this.onRequestExternalWorktrees()
       return null
     }
     if (type === "agentManager.importFromBranch" && typeof msg.branch === "string") {
-      void this.onImportFromBranch(msg.branch as string)
+      void this.onImportFromBranch(msg.branch)
       return null
     }
     if (type === "agentManager.importFromPR" && typeof msg.url === "string") {
-      void this.onImportFromPR(msg.url as string)
+      void this.onImportFromPR(msg.url)
       return null
     }
     if (
@@ -234,7 +230,7 @@ export class AgentManagerProvider implements vscode.Disposable {
       typeof msg.path === "string" &&
       typeof msg.branch === "string"
     ) {
-      void this.onImportExternalWorktree(msg.path as string, msg.branch as string)
+      void this.onImportExternalWorktree(msg.path, msg.branch)
       return null
     }
     if (type === "agentManager.importAllExternalWorktrees") {

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -952,6 +952,13 @@ export interface CloseSessionRequest {
   sessionId: string
 }
 
+// Rename a worktree's display label
+export interface RenameWorktreeRequest {
+  type: "agentManager.renameWorktree"
+  worktreeId: string
+  label: string
+}
+
 export interface RequestRepoInfoMessage {
   type: "agentManager.requestRepoInfo"
 }
@@ -1080,6 +1087,7 @@ export type WebviewMessage =
   | PromoteSessionRequest
   | AddSessionToWorktreeRequest
   | CloseSessionRequest
+  | RenameWorktreeRequest
   | TelemetryRequest
   | RequestRepoInfoMessage
   | RequestStateMessage


### PR DESCRIPTION
## Summary

- Add typed `RenameWorktreeRequest` interface to `messages.ts` and include it in the `WebviewMessage` discriminated union — previously the only Agent Manager message without a type definition
- Remove duplicate `agentManager.requestBranches` handler (dead code — first handler already matched and returned `null`)
- Strip 7 redundant `as` casts in `AgentManagerProvider.onMessage()` where `typeof` guards already narrow the type