### PR TITLE
refactor: move dynamic editor context from system prompt to user message

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2334,15 +2334,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // Shell
     const shell = vscode.env.shell || undefined
 
-    // Timezone
-    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || undefined
-
     return {
       ...(visibleFiles.length > 0 ? { visibleFiles } : {}),
       ...(openTabs.length > 0 ? { openTabs } : {}),
       ...(activeFile ? { activeFile } : {}),
       ...(shell ? { shell } : {}),
-      ...(timezone ? { timezone } : {}),
     }
   }
 

--- a/packages/kilo-vscode/src/services/cli-backend/types.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/types.ts
@@ -113,6 +113,4 @@ export interface EditorContext {
   activeFile?: string
   /** User's default shell (from vscode.env.shell) */
   shell?: string
-  /** User's timezone (e.g. "Europe/Amsterdam") */
-  timezone?: string
 }

--- a/packages/opencode/src/kilocode/editor-context.ts
+++ b/packages/opencode/src/kilocode/editor-context.ts
@@ -6,36 +6,50 @@ export interface EditorContext {
   timezone?: string
 }
 
-function formatDate(timezone?: string): string[] {
+/**
+ * Build static <env> lines from editor context.
+ * These rarely change during a session and belong in the system prompt
+ * so they benefit from prompt caching.
+ */
+export function staticEnvLines(ctx?: EditorContext): string[] {
   const now = new Date()
   const lines = [`  Today's date: ${now.toDateString()}`]
-  if (timezone) {
+  if (ctx?.timezone) {
     const offset = -now.getTimezoneOffset()
     const sign = offset >= 0 ? "+" : "-"
     const hours = Math.floor(Math.abs(offset) / 60)
     const mins = Math.abs(offset) % 60
-    lines.push(`  User timezone: ${timezone}, UTC${sign}${hours}:${mins.toString().padStart(2, "0")}`)
+    lines.push(`  User timezone: ${ctx.timezone}, UTC${sign}${hours}:${mins.toString().padStart(2, "0")}`)
+  }
+  if (ctx?.shell) {
+    lines.push(`  Default shell: ${ctx.shell}`)
   }
   return lines
 }
 
 /**
- * Build additional <env> lines from VS Code editor context.
- * Returns an array of pre-formatted `  key: value` strings.
+ * Build a per-message <environment_details> block from editor context.
+ * These change frequently (user switches files/tabs) and belong in the
+ * user message so the model always has fresh context.
+ * Returns undefined when there is nothing dynamic to report.
  */
-export function editorContextEnvLines(ctx?: EditorContext): string[] {
-  const lines = formatDate(ctx?.timezone)
-  if (ctx?.shell) {
-    lines.push(`  Default shell: ${ctx.shell}`)
-  }
+export function environmentDetails(ctx?: EditorContext): string | undefined {
+  const lines: string[] = []
   if (ctx?.activeFile) {
-    lines.push(`  Active file: ${ctx.activeFile}`)
+    lines.push(`Active file: ${ctx.activeFile}`)
   }
   if (ctx?.visibleFiles?.length) {
-    lines.push(`  Visible files: ${ctx.visibleFiles.join(", ")}`)
+    lines.push(`Visible files:`)
+    for (const f of ctx.visibleFiles) {
+      lines.push(`  ${f}`)
+    }
   }
   if (ctx?.openTabs?.length) {
-    lines.push(`  Open tabs: ${ctx.openTabs.join(", ")}`)
+    lines.push(`Open tabs:`)
+    for (const f of ctx.openTabs) {
+      lines.push(`  ${f}`)
+    }
   }
-  return lines
+  if (lines.length === 0) return undefined
+  return ["<environment_details>", ...lines, "</environment_details>"].join("\n")
 }

--- a/packages/opencode/src/kilocode/editor-context.ts
+++ b/packages/opencode/src/kilocode/editor-context.ts
@@ -11,7 +11,7 @@ export interface EditorContext {
  * so they benefit from prompt caching.
  */
 export function staticEnvLines(ctx?: EditorContext): string[] {
-  const lines = [`  Today's date: ${new Date().toDateString()}`]
+  const lines: string[] = []
   if (ctx?.shell) {
     lines.push(`  Default shell: ${ctx.shell}`)
   }
@@ -22,10 +22,22 @@ export function staticEnvLines(ctx?: EditorContext): string[] {
  * Build a per-message <environment_details> block from editor context.
  * These change frequently (user switches files/tabs) and belong in the
  * user message so the model always has fresh context.
- * Returns undefined when there is nothing dynamic to report.
+ * Always includes at least the current timestamp.
  */
-export function environmentDetails(ctx?: EditorContext): string | undefined {
-  const lines: string[] = []
+function timestamp(): string {
+  const now = new Date()
+  const offset = -now.getTimezoneOffset()
+  const sign = offset >= 0 ? "+" : "-"
+  const h = Math.floor(Math.abs(offset) / 60)
+    .toString()
+    .padStart(2, "0")
+  const m = (Math.abs(offset) % 60).toString().padStart(2, "0")
+  const pad = (n: number) => n.toString().padStart(2, "0")
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}${sign}${h}:${m}`
+}
+
+export function environmentDetails(ctx?: EditorContext): string {
+  const lines: string[] = [`Current time: ${timestamp()}`]
   if (ctx?.activeFile) {
     lines.push(`Active file: ${ctx.activeFile}`)
   }
@@ -41,6 +53,5 @@ export function environmentDetails(ctx?: EditorContext): string | undefined {
       lines.push(`  ${f}`)
     }
   }
-  if (lines.length === 0) return undefined
   return ["<environment_details>", ...lines, "</environment_details>"].join("\n")
 }

--- a/packages/opencode/src/kilocode/editor-context.ts
+++ b/packages/opencode/src/kilocode/editor-context.ts
@@ -3,7 +3,6 @@ export interface EditorContext {
   openTabs?: string[]
   activeFile?: string
   shell?: string
-  timezone?: string
 }
 
 /**
@@ -12,15 +11,7 @@ export interface EditorContext {
  * so they benefit from prompt caching.
  */
 export function staticEnvLines(ctx?: EditorContext): string[] {
-  const now = new Date()
-  const lines = [`  Today's date: ${now.toDateString()}`]
-  if (ctx?.timezone) {
-    const offset = -now.getTimezoneOffset()
-    const sign = offset >= 0 ? "+" : "-"
-    const hours = Math.floor(Math.abs(offset) / 60)
-    const mins = Math.abs(offset) % 60
-    lines.push(`  User timezone: ${ctx.timezone}, UTC${sign}${hours}:${mins.toString().padStart(2, "0")}`)
-  }
+  const lines = [`  Today's date: ${new Date().toDateString()}`]
   if (ctx?.shell) {
     lines.push(`  Default shell: ${ctx.shell}`)
   }

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -375,7 +375,6 @@ export namespace MessageV2 {
         openTabs: z.array(z.string()).optional(),
         activeFile: z.string().optional(),
         shell: z.string().optional(),
-        timezone: z.string().optional(),
       })
       .optional(),
     // kilocode_change end

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -714,6 +714,9 @@ export namespace SessionPrompt {
             parts: [
               ...msgs[idx].parts,
               {
+                id: Identifier.ascending("part"),
+                sessionID,
+                messageID: msgs[idx].info.id,
                 type: "text",
                 text: envBlock,
               } satisfies MessageV2.TextPart,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -47,6 +47,7 @@ import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncation"
 import { PlanFollowup } from "@/kilocode/plan-followup" // kilocode_change
+import { environmentDetails } from "@/kilocode/editor-context" // kilocode_change
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1354,6 +1355,20 @@ export namespace SessionPrompt {
         ]
       }),
     ).then((x) => x.flat().map(assign))
+
+    // kilocode_change start — inject dynamic editor context into user message
+    const envBlock = environmentDetails(input.editorContext)
+    if (envBlock) {
+      parts.push({
+        id: Identifier.ascending("part"),
+        messageID: info.id,
+        sessionID: input.sessionID,
+        type: "text",
+        text: envBlock,
+        synthetic: true,
+      })
+    }
+    // kilocode_change end
 
     await Plugin.trigger(
       "chat.message",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -131,7 +131,6 @@ export namespace SessionPrompt {
         openTabs: z.array(z.string()).optional(),
         activeFile: z.string().optional(),
         shell: z.string().optional(),
-        timezone: z.string().optional(),
       })
       .optional(),
     // kilocode_change end

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -716,7 +716,7 @@ export namespace SessionPrompt {
               {
                 type: "text",
                 text: envBlock,
-              } as MessageV2.TextPart,
+              } satisfies MessageV2.TextPart,
             ],
           }
       }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -562,6 +562,7 @@ export namespace SessionPrompt {
             },
             agent: lastUser.agent,
             model: lastUser.model,
+            editorContext: lastUser.editorContext, // kilocode_change — preserve editor context
           }
           await Session.updateMessage(summaryUserMsg)
           await Session.updatePart({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -707,12 +707,18 @@ export namespace SessionPrompt {
         envUser = lastUser.id
       }
       if (envBlock) {
-        const last = msgs.findLast((m) => m.info.role === "user")
-        if (last)
-          last.parts.push({
-            type: "text",
-            text: envBlock,
-          } as MessageV2.TextPart)
+        const idx = msgs.findLastIndex((m) => m.info.role === "user")
+        if (idx !== -1)
+          msgs[idx] = {
+            ...msgs[idx],
+            parts: [
+              ...msgs[idx].parts,
+              {
+                type: "text",
+                text: envBlock,
+              } as MessageV2.TextPart,
+            ],
+          }
       }
       // kilocode_change end
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -324,6 +324,10 @@ export namespace SessionPrompt {
     // on the user message and will be retrieved from lastUser below
     let structuredOutput: unknown | undefined
 
+    // kilocode_change — cache environment details per turn so the last user
+    // message stays byte-identical across tool-loop steps (prompt caching).
+    let envBlock: string | undefined
+
     let step = 0
     const session = await Session.get(sessionID)
     while (true) {
@@ -695,7 +699,7 @@ export namespace SessionPrompt {
       await Plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
       // kilocode_change start — ephemerally inject dynamic editor context into last user message
-      const envBlock = environmentDetails(lastUser.editorContext)
+      envBlock ??= environmentDetails(lastUser.editorContext)
       if (envBlock) {
         const last = msgs.findLast((m) => m.info.role === "user")
         if (last)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -326,7 +326,9 @@ export namespace SessionPrompt {
 
     // kilocode_change — cache environment details per turn so the last user
     // message stays byte-identical across tool-loop steps (prompt caching).
+    // Keyed by user message ID so it recomputes when a new user message arrives.
     let envBlock: string | undefined
+    let envUser: string | undefined
 
     let step = 0
     const session = await Session.get(sessionID)
@@ -699,7 +701,10 @@ export namespace SessionPrompt {
       await Plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
       // kilocode_change start — ephemerally inject dynamic editor context into last user message
-      envBlock ??= environmentDetails(lastUser.editorContext)
+      if (envUser !== lastUser.id) {
+        envBlock = environmentDetails(lastUser.editorContext)
+        envUser = lastUser.id
+      }
       if (envBlock) {
         const last = msgs.findLast((m) => m.info.role === "user")
         if (last)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -694,6 +694,18 @@ export namespace SessionPrompt {
 
       await Plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
+      // kilocode_change start — ephemerally inject dynamic editor context into last user message
+      const envBlock = environmentDetails(lastUser.editorContext)
+      if (envBlock) {
+        const last = msgs.findLast((m) => m.info.role === "user")
+        if (last)
+          last.parts.push({
+            type: "text",
+            text: envBlock,
+          } as MessageV2.TextPart)
+      }
+      // kilocode_change end
+
       // Build system prompt, adding structured output instruction if needed
       const system = [
         ...(await SystemPrompt.environment(model, lastUser.editorContext)),
@@ -1354,20 +1366,6 @@ export namespace SessionPrompt {
         ]
       }),
     ).then((x) => x.flat().map(assign))
-
-    // kilocode_change start — inject dynamic editor context into user message
-    const envBlock = environmentDetails(input.editorContext)
-    if (envBlock) {
-      parts.push({
-        id: Identifier.ascending("part"),
-        messageID: info.id,
-        sessionID: input.sessionID,
-        type: "text",
-        text: envBlock,
-        synthetic: true,
-      })
-    }
-    // kilocode_change end
 
     await Plugin.trigger(
       "chat.message",

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -13,7 +13,7 @@ import type { Provider } from "@/provider/provider"
 
 // kilocode_change start
 import SOUL from "../kilocode/soul.txt"
-import { editorContextEnvLines, type EditorContext } from "../kilocode/editor-context"
+import { staticEnvLines, type EditorContext } from "../kilocode/editor-context"
 // kilocode_change end
 
 export namespace SystemPrompt {
@@ -67,7 +67,7 @@ export namespace SystemPrompt {
         `  Working directory: ${Instance.directory}`,
         `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
-        ...editorContextEnvLines(editorContext), // kilocode_change
+        ...staticEnvLines(editorContext), // kilocode_change
         `</env>`,
         `<directories>`,
         `  ${

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -79,6 +79,10 @@ export namespace SystemPrompt {
             : ""
         }`,
         `</directories>`,
+        // kilocode_change start
+        ``,
+        `At the end of each user message, you may receive <environment_details> with information about the user's currently active file, visible editors, and open tabs. This is auto-generated context — use it to understand which files the user is working with.`,
+        // kilocode_change end
       ].join("\n"),
     ]
   }

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -79,10 +79,6 @@ export namespace SystemPrompt {
             : ""
         }`,
         `</directories>`,
-        // kilocode_change start
-        ``,
-        `At the end of each user message, you may receive <environment_details> with information about the user's currently active file, visible editors, and open tabs. This is auto-generated context — use it to understand which files the user is working with.`,
-        // kilocode_change end
       ].join("\n"),
     ]
   }

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1943,7 +1943,6 @@ export class Session2 extends HeyApiClient {
         openTabs?: Array<string>
         activeFile?: string
         shell?: string
-        timezone?: string
       }
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
@@ -2083,7 +2082,6 @@ export class Session2 extends HeyApiClient {
         openTabs?: Array<string>
         activeFile?: string
         shell?: string
-        timezone?: string
       }
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -143,7 +143,6 @@ export type UserMessage = {
     openTabs?: Array<string>
     activeFile?: string
     shell?: string
-    timezone?: string
   }
 }
 
@@ -3428,7 +3427,6 @@ export type SessionPromptData = {
       openTabs?: Array<string>
       activeFile?: string
       shell?: string
-      timezone?: string
     }
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
@@ -3668,7 +3666,6 @@ export type SessionPromptAsyncData = {
       openTabs?: Array<string>
       activeFile?: string
       shell?: string
-      timezone?: string
     }
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -3186,9 +3186,6 @@
                       },
                       "shell": {
                         "type": "string"
-                      },
-                      "timezone": {
-                        "type": "string"
                       }
                     }
                   },
@@ -3695,9 +3692,6 @@
                         "type": "string"
                       },
                       "shell": {
-                        "type": "string"
-                      },
-                      "timezone": {
                         "type": "string"
                       }
                     }
@@ -8581,9 +8575,6 @@
               },
               "shell": {
                 "type": "string"
-              },
-              "timezone": {
-                "type": "string"
               }
             }
           }
@@ -12025,6 +12016,10 @@
               },
               "batch_tool": {
                 "description": "Enable the batch tool",
+                "type": "boolean"
+              },
+              "codebase_search": {
+                "description": "Enable AI-powered codebase search",
                 "type": "boolean"
               },
               "openTelemetry": {


### PR DESCRIPTION
## Motivation

PR #6151 added editor context (active file, visible files, open tabs, shell, timezone) to the system prompt `<env>` block. However, the system prompt is built once per session and cached — putting dynamic information like active file and open tabs there means the model sees **stale data** as the session progresses.

This matches the pattern used by the legacy VS Code extension, where `getEnvironmentDetails()` is called before every agent turn.

## Changes

Split editor context into **static** and **dynamic** parts:

### Static → System prompt (cached)
| Context | Why static |
|---|---|
| Today's date (`toDateString()`) | Only changes once per day |
| User timezone | Rarely changes |
| Default shell | Rarely changes |

### Dynamic → User message (per-turn)
| Context | Why dynamic |
|---|---|
| Active file | Changes as user switches editors |
| Visible files | Changes as user opens/closes files |
| Open tabs | Changes as user opens/closes tabs |

Dynamic context is injected as a synthetic `<environment_details>` text part on each user message, so the model always has fresh context.

## Files changed

- [`packages/opencode/src/kilocode/editor-context.ts`](packages/opencode/src/kilocode/editor-context.ts) — Split `editorContextEnvLines()` into `staticEnvLines()` + `environmentDetails()`
- [`packages/opencode/src/session/system.ts`](packages/opencode/src/session/system.ts) — Use `staticEnvLines` for system prompt
- [`packages/opencode/src/session/prompt.ts`](packages/opencode/src/session/prompt.ts) — Inject `environmentDetails()` as synthetic part on user message