### PR TITLE
fix(vscode): clear syncedChildSessions on session clear, delete, and dispose

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -311,6 +311,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "clearSession":
           this.currentSession = null
           this.trackedSessionIds.clear()
+          this.syncedChildSessions.clear()
           break
         case "loadMessages":
           // Don't await: allow parallel loads so rapid session switching
@@ -798,6 +799,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const workspaceDir = this.getWorkspaceDirectory(sessionID)
       await this.httpClient.deleteSession(sessionID, workspaceDir)
       this.trackedSessionIds.delete(sessionID)
+      this.syncedChildSessions.delete(sessionID)
       this.sessionDirectories.delete(sessionID)
       if (this.currentSession?.id === sessionID) {
         this.currentSession = null
@@ -1630,6 +1632,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.unsubscribeNotificationDismiss?.()
     this.webviewMessageDisposable?.dispose()
     this.trackedSessionIds.clear()
+    this.syncedChildSessions.clear()
     this.sessionDirectories.clear()
     this.ignoreController?.dispose()
   }


### PR DESCRIPTION
## Summary

Follow-up to #6222. The new `syncedChildSessions` Set was never cleared alongside `trackedSessionIds`, causing child sessions to never re-sync after a session was cleared and re-entered.

## Changes

Added `syncedChildSessions` cleanup in three locations in `KiloProvider.ts`:

- **`clearSession`**: `this.syncedChildSessions.clear()` — ensures re-entering a session re-syncs its child sessions
- **`handleDeleteSession`**: `this.syncedChildSessions.delete(sessionID)` — ensures a deleted session's children can be re-synced if recreated
- **`dispose()`**: `this.syncedChildSessions.clear()` — proper cleanup on provider disposal

Each mirrors the existing `trackedSessionIds` cleanup at the same location.