### PR TITLE
fix(vscode): fix variable shadowing in worktree dropdown keyboard shortcut rendering

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1100,7 +1100,7 @@ const AgentManagerContent: Component = () => {
                           <DropdownMenu.ItemLabel>{t("agentManager.worktree.new")}</DropdownMenu.ItemLabel>
                           <span class="am-menu-shortcut">
                             {parseBindingTokens(kb().newWorktree ?? "").map((token) => (
-                              <kbd class="am-menu-key">{t}</kbd>
+                              <kbd class="am-menu-key">{token}</kbd>
                             ))}
                           </span>
                         </DropdownMenu.Item>
@@ -1109,8 +1109,8 @@ const AgentManagerContent: Component = () => {
                           <Icon name="settings-gear" size="small" />
                           <DropdownMenu.ItemLabel>{t("agentManager.dialog.advanced")}</DropdownMenu.ItemLabel>
                           <span class="am-menu-shortcut">
-                            {parseBindingTokens(kb().advancedWorktree ?? "").map((t) => (
-                              <kbd class="am-menu-key">{t}</kbd>
+                            {parseBindingTokens(kb().advancedWorktree ?? "").map((token) => (
+                              <kbd class="am-menu-key">{token}</kbd>
                             ))}
                           </span>
                         </DropdownMenu.Item>


### PR DESCRIPTION
## Summary

- Fix the "New Worktree" dropdown menu showing `undefined` for keyboard shortcut keys (⌘N and ⌘⇧N) due to variable shadowing introduced in the i18n localization commit (#6231)
- Add a `t()` shadowing lint test to `agent-manager-i18n.test.ts` that catches both direct `{t}` misuse in `.map()` callbacks and `t` parameter shadowing in JSX-rendering contexts

## Root Cause

In `AgentManagerApp.tsx`, two `.map()` callbacks that render keyboard shortcut tokens had variable naming bugs:

1. **Line 1103**: `.map((token) => <kbd>{t}</kbd>)` — rendered the `t` i18n function object instead of the `token` loop variable
2. **Line 1112**: `.map((t) => <kbd>{t}</kbd>)` — parameter `t` shadowed the outer `t` translation function (worked by accident)

## Why Tests Didn't Catch It

The Agent Manager webview is in a validation blind spot: no rendering tests, ESLint excludes `.tsx` files and `webview-ui/`, TypeScript config excludes `agent-manager/`, and `noUnusedParameters` is disabled. The new lint test fills this gap using ts-morph static analysis.