### PR TITLE
fix(vscode): rename "Open Workspace" to "Open Worktree" in agent manager dialog

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1754,7 +1754,7 @@ const NewWorktreeDialog: Component<{ onClose: () => void }> = (props) => {
   }
 
   return (
-    <Dialog title={t("agentManager.dialog.openWorkspace")} fit>
+    <Dialog title={t("agentManager.dialog.openWorktree")} fit>
       {/* Tab switcher */}
       <div class="am-tab-switcher">
         <button

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -980,7 +980,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "؟ سيؤدي هذا إلى إزالة Worktree من القرص وفصل جميع الجلسات.",
   "agentManager.dialog.deleteWorktree.cancel": "إلغاء",
   "agentManager.dialog.deleteWorktree.confirm": "حذف",
-  "agentManager.dialog.openWorkspace": "فتح مساحة العمل",
+  "agentManager.dialog.openWorktree": "فتح شجرة العمل",
   "agentManager.dialog.tab.new": "جديد",
   "agentManager.dialog.tab.import": "استيراد",
   "agentManager.dialog.namePlaceholder": "اسم Worktree (اختياري)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -994,7 +994,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "? Isso remove o Worktree do disco e desassocia todas as sessões.",
   "agentManager.dialog.deleteWorktree.cancel": "Cancelar",
   "agentManager.dialog.deleteWorktree.confirm": "Excluir",
-  "agentManager.dialog.openWorkspace": "Abrir Workspace",
+  "agentManager.dialog.openWorktree": "Abrir Worktree",
   "agentManager.dialog.tab.new": "Novo",
   "agentManager.dialog.tab.import": "Importar",
   "agentManager.dialog.namePlaceholder": "Nome do Worktree (opcional)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1016,7 +1016,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "? Ovo uklanja Worktree sa diska i odvezuje sve sesije.",
   "agentManager.dialog.deleteWorktree.cancel": "Otkaži",
   "agentManager.dialog.deleteWorktree.confirm": "Obriši",
-  "agentManager.dialog.openWorkspace": "Otvori radni prostor",
+  "agentManager.dialog.openWorktree": "Otvori worktree",
   "agentManager.dialog.tab.new": "Novo",
   "agentManager.dialog.tab.import": "Uvezi",
   "agentManager.dialog.namePlaceholder": "Naziv Worktree-a (opcionalno)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -989,7 +989,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "? Dette fjerner Worktree fra disken og afkobler alle sessioner.",
   "agentManager.dialog.deleteWorktree.cancel": "Annuller",
   "agentManager.dialog.deleteWorktree.confirm": "Slet",
-  "agentManager.dialog.openWorkspace": "Åbn Workspace",
+  "agentManager.dialog.openWorktree": "Åbn Worktree",
   "agentManager.dialog.tab.new": "Ny",
   "agentManager.dialog.tab.import": "Importér",
   "agentManager.dialog.namePlaceholder": "Worktree-navn (valgfrit)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1003,7 +1003,7 @@ export const dict = {
     "? Dies entfernt den Worktree von der Festplatte und trennt alle Sitzungen.",
   "agentManager.dialog.deleteWorktree.cancel": "Abbrechen",
   "agentManager.dialog.deleteWorktree.confirm": "Löschen",
-  "agentManager.dialog.openWorkspace": "Arbeitsbereich öffnen",
+  "agentManager.dialog.openWorktree": "Worktree öffnen",
   "agentManager.dialog.tab.new": "Neu",
   "agentManager.dialog.tab.import": "Importieren",
   "agentManager.dialog.namePlaceholder": "Worktree-Name (optional)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1045,7 +1045,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.cancel": "Cancel",
   "agentManager.dialog.deleteWorktree.confirm": "Delete",
 
-  "agentManager.dialog.openWorkspace": "Open Workspace",
+  "agentManager.dialog.openWorktree": "Open Worktree",
   "agentManager.dialog.tab.new": "New",
   "agentManager.dialog.tab.import": "Import",
   "agentManager.dialog.namePlaceholder": "Worktree name (optional)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -997,7 +997,7 @@ export const dict = {
     "? Esto elimina el Worktree del disco y desasocia todas las sesiones.",
   "agentManager.dialog.deleteWorktree.cancel": "Cancelar",
   "agentManager.dialog.deleteWorktree.confirm": "Eliminar",
-  "agentManager.dialog.openWorkspace": "Abrir Workspace",
+  "agentManager.dialog.openWorktree": "Abrir Worktree",
   "agentManager.dialog.tab.new": "Nuevo",
   "agentManager.dialog.tab.import": "Importar",
   "agentManager.dialog.namePlaceholder": "Nombre del Worktree (opcional)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1005,7 +1005,7 @@ export const dict = {
     " ? Cela supprime le Worktree du disque et dissocie toutes les sessions.",
   "agentManager.dialog.deleteWorktree.cancel": "Annuler",
   "agentManager.dialog.deleteWorktree.confirm": "Supprimer",
-  "agentManager.dialog.openWorkspace": "Ouvrir l'espace de travail",
+  "agentManager.dialog.openWorktree": "Ouvrir le worktree",
   "agentManager.dialog.tab.new": "Nouveau",
   "agentManager.dialog.tab.import": "Importer",
   "agentManager.dialog.namePlaceholder": "Nom du Worktree (optionnel)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -985,7 +985,7 @@ export const dict = {
     "？ ディスクからWorktreeを削除し、すべてのセッションの関連付けを解除します。",
   "agentManager.dialog.deleteWorktree.cancel": "キャンセル",
   "agentManager.dialog.deleteWorktree.confirm": "削除",
-  "agentManager.dialog.openWorkspace": "ワークスペースを開く",
+  "agentManager.dialog.openWorktree": "ワークツリーを開く",
   "agentManager.dialog.tab.new": "新規",
   "agentManager.dialog.tab.import": "インポート",
   "agentManager.dialog.namePlaceholder": "Worktree名（任意）",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -985,7 +985,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "? 디스크에서 Worktree를 제거하고 모든 세션의 연결을 해제합니다.",
   "agentManager.dialog.deleteWorktree.cancel": "취소",
   "agentManager.dialog.deleteWorktree.confirm": "삭제",
-  "agentManager.dialog.openWorkspace": "워크스페이스 열기",
+  "agentManager.dialog.openWorktree": "워크트리 열기",
   "agentManager.dialog.tab.new": "새로 만들기",
   "agentManager.dialog.tab.import": "가져오기",
   "agentManager.dialog.namePlaceholder": "Worktree 이름 (선택사항)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -990,7 +990,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "? Dette fjerner Worktree fra disken og kobler fra alle økter.",
   "agentManager.dialog.deleteWorktree.cancel": "Avbryt",
   "agentManager.dialog.deleteWorktree.confirm": "Slett",
-  "agentManager.dialog.openWorkspace": "Åpne arbeidsområde",
+  "agentManager.dialog.openWorktree": "Åpne worktree",
   "agentManager.dialog.tab.new": "Ny",
   "agentManager.dialog.tab.import": "Importer",
   "agentManager.dialog.namePlaceholder": "Worktree-navn (valgfritt)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -992,7 +992,7 @@ export const dict = {
     "? Spowoduje to usunięcie Worktree z dysku i odłączenie wszystkich sesji.",
   "agentManager.dialog.deleteWorktree.cancel": "Anuluj",
   "agentManager.dialog.deleteWorktree.confirm": "Usuń",
-  "agentManager.dialog.openWorkspace": "Otwórz Workspace",
+  "agentManager.dialog.openWorktree": "Otwórz Worktree",
   "agentManager.dialog.tab.new": "Nowy",
   "agentManager.dialog.tab.import": "Importuj",
   "agentManager.dialog.namePlaceholder": "Nazwa Worktree (opcjonalnie)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -993,7 +993,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "? Это удалит Worktree с диска и отключит все сессии.",
   "agentManager.dialog.deleteWorktree.cancel": "Отмена",
   "agentManager.dialog.deleteWorktree.confirm": "Удалить",
-  "agentManager.dialog.openWorkspace": "Открыть рабочее пространство",
+  "agentManager.dialog.openWorktree": "Открыть worktree",
   "agentManager.dialog.tab.new": "Новый",
   "agentManager.dialog.tab.import": "Импорт",
   "agentManager.dialog.namePlaceholder": "Имя Worktree (необязательно)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -978,7 +978,7 @@ export const dict = {
     "? การดำเนินการนี้จะลบ Worktree ออกจากดิสก์และยกเลิกการเชื่อมโยงเซสชันทั้งหมด",
   "agentManager.dialog.deleteWorktree.cancel": "ยกเลิก",
   "agentManager.dialog.deleteWorktree.confirm": "ลบ",
-  "agentManager.dialog.openWorkspace": "เปิด Workspace",
+  "agentManager.dialog.openWorktree": "เปิด Worktree",
   "agentManager.dialog.tab.new": "ใหม่",
   "agentManager.dialog.tab.import": "นำเข้า",
   "agentManager.dialog.namePlaceholder": "ชื่อ Worktree (ไม่บังคับ)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -980,7 +980,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "？这将从磁盘中移除 Worktree 并取消所有会话的关联。",
   "agentManager.dialog.deleteWorktree.cancel": "取消",
   "agentManager.dialog.deleteWorktree.confirm": "删除",
-  "agentManager.dialog.openWorkspace": "打开工作区",
+  "agentManager.dialog.openWorktree": "打开工作树",
   "agentManager.dialog.tab.new": "新建",
   "agentManager.dialog.tab.import": "导入",
   "agentManager.dialog.namePlaceholder": "Worktree 名称（可选）",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -976,7 +976,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "？這將從磁碟中移除 Worktree 並取消所有工作階段的關聯。",
   "agentManager.dialog.deleteWorktree.cancel": "取消",
   "agentManager.dialog.deleteWorktree.confirm": "刪除",
-  "agentManager.dialog.openWorkspace": "開啟工作區",
+  "agentManager.dialog.openWorktree": "開啟工作樹",
   "agentManager.dialog.tab.new": "新建",
   "agentManager.dialog.tab.import": "匯入",
   "agentManager.dialog.namePlaceholder": "Worktree 名稱（選填）",


### PR DESCRIPTION
## Summary
- Renamed the agent manager dialog title from "Open Workspace" to "Open Worktree" across all 16 languages
- The dialog creates git worktrees, not VS Code workspaces — the terminology was misleading
- Updated the i18n key from `agentManager.dialog.openWorkspace` to `agentManager.dialog.openWorktree`