### PR TITLE
feat(vscode): add image paste and drag-drop support to agent manager dialog

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1808,7 +1808,7 @@ const NewWorktreeDialog: Component<{ onClose: () => void }> = (props) => {
                         type="button"
                         class="image-attachment-remove"
                         onClick={() => imageAttach.remove(img.id)}
-                        aria-label="Remove image"
+                        aria-label={t("agentManager.dialog.removeImage")}
                       >
                         ×
                       </button>

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -58,6 +58,7 @@ import { ModeSwitcherBase } from "../src/components/chat/ModeSwitcher"
 import { LanguageBridge, DataBridge } from "../src/App"
 import { useLanguage } from "../src/context/language"
 import { formatRelativeDate } from "../src/utils/date"
+import { useImageAttachments } from "../src/hooks/useImageAttachments"
 import { validateLocalSession, nextSelectionAfterDelete, adjacentHint, LOCAL } from "./navigate"
 import { reorderTabs, applyTabOrder, firstOrderedTitle } from "./tab-order"
 import { ConstrainDragYAxis, SortableTab } from "./sortable-tab"
@@ -1646,6 +1647,8 @@ const NewWorktreeDialog: Component<{ onClose: () => void }> = (props) => {
   const [baseBranchOpen, setBaseBranchOpen] = createSignal(false)
   const [highlightedIndex, setHighlightedIndex] = createSignal(0)
 
+  const imageAttach = useImageAttachments()
+
   let textareaRef: HTMLTextAreaElement | undefined
 
   onMount(() => {
@@ -1679,6 +1682,8 @@ const NewWorktreeDialog: Component<{ onClose: () => void }> = (props) => {
     const selectedAgent = agent() !== defaultAgent ? agent() : undefined
     const advanced = showAdvanced()
     const customBranch = advanced ? branchName().trim() || undefined : undefined
+    const imgs = imageAttach.images()
+    const imgFiles = imgs.length > 0 ? imgs.map((img) => ({ mime: img.mime, url: img.dataUrl })) : undefined
 
     vscode.postMessage({
       type: "agentManager.createMultiVersion",
@@ -1690,6 +1695,7 @@ const NewWorktreeDialog: Component<{ onClose: () => void }> = (props) => {
       agent: selectedAgent,
       baseBranch: advanced ? (baseBranch() ?? undefined) : undefined,
       branchName: customBranch,
+      files: imgFiles,
     })
 
     props.onClose()
@@ -1785,7 +1791,32 @@ const NewWorktreeDialog: Component<{ onClose: () => void }> = (props) => {
             onInput={(e) => setName(e.currentTarget.value)}
           />
           {/* Prompt input — reuses the sidebar chat-input base classes for consistent styling */}
-          <div class="prompt-input-container am-prompt-input-container">
+          <div
+            class="prompt-input-container am-prompt-input-container"
+            classList={{ "prompt-input-container--dragging": imageAttach.dragging() }}
+            onDragOver={imageAttach.handleDragOver}
+            onDragLeave={imageAttach.handleDragLeave}
+            onDrop={imageAttach.handleDrop}
+          >
+            <Show when={imageAttach.images().length > 0}>
+              <div class="image-attachments">
+                <For each={imageAttach.images()}>
+                  {(img) => (
+                    <div class="image-attachment">
+                      <img src={img.dataUrl} alt={img.filename} title={img.filename} />
+                      <button
+                        type="button"
+                        class="image-attachment-remove"
+                        onClick={() => imageAttach.remove(img.id)}
+                        aria-label="Remove image"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Show>
             <div class="prompt-input-wrapper am-prompt-input-wrapper">
               <div class="prompt-input-ghost-wrapper am-prompt-input-ghost-wrapper">
                 <textarea
@@ -1799,6 +1830,7 @@ const NewWorktreeDialog: Component<{ onClose: () => void }> = (props) => {
                     setPrompt(e.currentTarget.value)
                     adjustHeight()
                   }}
+                  onPaste={(e) => imageAttach.handlePaste(e)}
                   rows={3}
                 />
               </div>

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -997,6 +997,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} Worktrees ستعمل بالتوازي",
   "agentManager.dialog.creating": "جارٍ الإنشاء...",
   "agentManager.dialog.createWorkspace": "إنشاء مساحة عمل",
+  "agentManager.dialog.removeImage": "إزالة الصورة",
   "agentManager.dialog.advanced": "متقدم...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "الصق رابط PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1011,6 +1011,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktrees serão executados em paralelo",
   "agentManager.dialog.creating": "Criando...",
   "agentManager.dialog.createWorkspace": "Criar Workspace",
+  "agentManager.dialog.removeImage": "Remover imagem",
   "agentManager.dialog.advanced": "Avançado...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Cole a URL do PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1033,6 +1033,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktree-ova će se pokrenuti paralelno",
   "agentManager.dialog.creating": "Kreiranje...",
   "agentManager.dialog.createWorkspace": "Kreiraj radni prostor",
+  "agentManager.dialog.removeImage": "Ukloni sliku",
   "agentManager.dialog.advanced": "Napredno...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Zalijepite PR URL...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1006,6 +1006,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktrees vil køre parallelt",
   "agentManager.dialog.creating": "Opretter...",
   "agentManager.dialog.createWorkspace": "Opret Workspace",
+  "agentManager.dialog.removeImage": "Fjern billede",
   "agentManager.dialog.advanced": "Avanceret...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Indsæt PR URL...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1020,6 +1020,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} Worktrees werden parallel ausgeführt",
   "agentManager.dialog.creating": "Wird erstellt...",
   "agentManager.dialog.createWorkspace": "Arbeitsbereich erstellen",
+  "agentManager.dialog.removeImage": "Bild entfernen",
   "agentManager.dialog.advanced": "Erweitert...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "PR-URL einfügen...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1062,6 +1062,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktrees will run in parallel",
   "agentManager.dialog.creating": "Creating...",
   "agentManager.dialog.createWorkspace": "Create Workspace",
+  "agentManager.dialog.removeImage": "Remove image",
   "agentManager.dialog.advanced": "Advanced...",
 
   "agentManager.import.pullRequest": "Pull Request",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1014,6 +1014,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktrees se ejecutarán en paralelo",
   "agentManager.dialog.creating": "Creando...",
   "agentManager.dialog.createWorkspace": "Crear Workspace",
+  "agentManager.dialog.removeImage": "Eliminar imagen",
   "agentManager.dialog.advanced": "Avanzado...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Pegar URL del PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1022,6 +1022,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktrees s'exécuteront en parallèle",
   "agentManager.dialog.creating": "Création...",
   "agentManager.dialog.createWorkspace": "Créer un espace de travail",
+  "agentManager.dialog.removeImage": "Supprimer l'image",
   "agentManager.dialog.advanced": "Avancé...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Coller l'URL du PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1002,6 +1002,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}}個のWorktreeが並行して実行されます",
   "agentManager.dialog.creating": "作成中...",
   "agentManager.dialog.createWorkspace": "ワークスペースを作成",
+  "agentManager.dialog.removeImage": "画像を削除",
   "agentManager.dialog.advanced": "詳細...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "PR URLを貼り付け...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1002,6 +1002,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}}개의 Worktree가 병렬로 실행됩니다",
   "agentManager.dialog.creating": "생성 중...",
   "agentManager.dialog.createWorkspace": "워크스페이스 생성",
+  "agentManager.dialog.removeImage": "이미지 제거",
   "agentManager.dialog.advanced": "고급...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "PR URL 붙여넣기...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1007,6 +1007,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktrees vil kjøre parallelt",
   "agentManager.dialog.creating": "Oppretter...",
   "agentManager.dialog.createWorkspace": "Opprett arbeidsområde",
+  "agentManager.dialog.removeImage": "Fjern bilde",
   "agentManager.dialog.advanced": "Avansert...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Lim inn PR URL...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1009,6 +1009,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktree będą działać równolegle",
   "agentManager.dialog.creating": "Tworzenie...",
   "agentManager.dialog.createWorkspace": "Utwórz Workspace",
+  "agentManager.dialog.removeImage": "Usuń obraz",
   "agentManager.dialog.advanced": "Zaawansowane...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Wklej URL PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1010,6 +1010,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} Worktree будут выполняться параллельно",
   "agentManager.dialog.creating": "Создание...",
   "agentManager.dialog.createWorkspace": "Создать рабочее пространство",
+  "agentManager.dialog.removeImage": "Удалить изображение",
   "agentManager.dialog.advanced": "Дополнительно...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Вставьте URL PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -995,6 +995,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} Worktrees จะทำงานพร้อมกัน",
   "agentManager.dialog.creating": "กำลังสร้าง...",
   "agentManager.dialog.createWorkspace": "สร้าง Workspace",
+  "agentManager.dialog.removeImage": "ลบรูปภาพ",
   "agentManager.dialog.advanced": "ขั้นสูง...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "วาง URL ของ PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -997,6 +997,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} 个 Worktree 将并行运行",
   "agentManager.dialog.creating": "创建中...",
   "agentManager.dialog.createWorkspace": "创建工作区",
+  "agentManager.dialog.removeImage": "移除图片",
   "agentManager.dialog.advanced": "高级...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "粘贴 PR URL...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -993,6 +993,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} 個 Worktree 將並行執行",
   "agentManager.dialog.creating": "建立中...",
   "agentManager.dialog.createWorkspace": "建立工作區",
+  "agentManager.dialog.removeImage": "移除圖片",
   "agentManager.dialog.advanced": "進階...",
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "貼上 PR URL...",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -78,13 +78,15 @@
     "@gitlab/opencode-gitlab-auth": "1.3.3",
     "@hono/standard-validator": "0.1.5",
     "@hono/zod-validator": "catalog:",
+    "@kilocode/kilo-gateway": "workspace:*",
+    "@kilocode/kilo-telemetry": "workspace:*",
+    "@kilocode/plugin": "workspace:*",
+    "@kilocode/sdk": "workspace:*",
     "@modelcontextprotocol/sdk": "1.25.2",
     "@octokit/graphql": "9.0.2",
     "@octokit/rest": "catalog:",
     "@openauthjs/openauth": "catalog:",
-    "@kilocode/plugin": "workspace:*",
     "@opencode-ai/script": "workspace:*",
-    "@kilocode/sdk": "workspace:*",
     "@opencode-ai/util": "workspace:*",
     "@openrouter/ai-sdk-provider": "1.5.4",
     "@opentui/core": "0.1.79",
@@ -115,6 +117,7 @@
     "opentui-spinner": "0.0.6",
     "partial-json": "0.1.7",
     "remeda": "catalog:",
+    "simple-git": "3.31.1",
     "solid-js": "catalog:",
     "strip-ansi": "7.1.2",
     "tree-sitter-bash": "0.25.0",
@@ -125,10 +128,7 @@
     "xdg-basedir": "5.1.0",
     "yargs": "18.0.0",
     "zod": "catalog:",
-    "zod-to-json-schema": "3.24.5",
-    "@kilocode/kilo-gateway": "workspace:*",
-    "@kilocode/kilo-telemetry": "workspace:*",
-    "simple-git": "3.31.1"
+    "zod-to-json-schema": "3.24.5"
   },
   "overrides": {
     "drizzle-orm": "1.0.0-beta.12-a5629fb"

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -78,15 +78,13 @@
     "@gitlab/opencode-gitlab-auth": "1.3.3",
     "@hono/standard-validator": "0.1.5",
     "@hono/zod-validator": "catalog:",
-    "@kilocode/kilo-gateway": "workspace:*",
-    "@kilocode/kilo-telemetry": "workspace:*",
-    "@kilocode/plugin": "workspace:*",
-    "@kilocode/sdk": "workspace:*",
     "@modelcontextprotocol/sdk": "1.25.2",
     "@octokit/graphql": "9.0.2",
     "@octokit/rest": "catalog:",
     "@openauthjs/openauth": "catalog:",
+    "@kilocode/plugin": "workspace:*",
     "@opencode-ai/script": "workspace:*",
+    "@kilocode/sdk": "workspace:*",
     "@opencode-ai/util": "workspace:*",
     "@openrouter/ai-sdk-provider": "1.5.4",
     "@opentui/core": "0.1.79",
@@ -117,7 +115,6 @@
     "opentui-spinner": "0.0.6",
     "partial-json": "0.1.7",
     "remeda": "catalog:",
-    "simple-git": "3.31.1",
     "solid-js": "catalog:",
     "strip-ansi": "7.1.2",
     "tree-sitter-bash": "0.25.0",
@@ -128,7 +125,10 @@
     "xdg-basedir": "5.1.0",
     "yargs": "18.0.0",
     "zod": "catalog:",
-    "zod-to-json-schema": "3.24.5"
+    "zod-to-json-schema": "3.24.5",
+    "@kilocode/kilo-gateway": "workspace:*",
+    "@kilocode/kilo-telemetry": "workspace:*",
+    "simple-git": "3.31.1"
   },
   "overrides": {
     "drizzle-orm": "1.0.0-beta.12-a5629fb"


### PR DESCRIPTION
## Summary

- Adds image paste (clipboard) and drag-and-drop support to the Agent Manager's `NewWorktreeDialog` prompt input, matching the existing sidebar chat behavior
- Pasted/dropped images are shown as 48×48 thumbnails with remove buttons above the textarea
- Images are passed as `files` in the `createMultiVersion` message and forwarded through the existing plumbing to the CLI backend as part of the initial prompt for all created sessions (single and multi-version)

## Details

Reuses the existing `useImageAttachments` hook and CSS classes from `chat.css` — no new styles or utilities needed. The downstream data flow (`AgentManagerProvider` → `sendInitialMessage` → `KiloProvider.handleSendMessage`) already supported `files`; only the UI was missing.

<img width="577" height="517" alt="image" src="https://github.com/user-attachments/assets/cbcd9d1a-0e45-4e34-a393-4864a5838a2b" />
