### PR TITLE
fix(vscode): sanitize custom worktree names into valid git branch names

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -10,7 +10,7 @@ import * as path from "path"
 import * as fs from "fs"
 import * as cp from "child_process"
 import simpleGit, { type SimpleGit } from "simple-git"
-import { generateBranchName } from "./branch-name"
+import { generateBranchName, sanitizeBranchName } from "./branch-name"
 import {
   parsePRUrl,
   localBranchName,
@@ -91,7 +91,8 @@ export class WorktreeManager {
       }
     }
 
-    let branch = params.existingBranch ?? params.branchName ?? generateBranchName(params.prompt || "agent-task")
+    const sanitized = params.branchName ? sanitizeBranchName(params.branchName) : undefined
+    let branch = params.existingBranch ?? (sanitized || undefined) ?? generateBranchName(params.prompt || "agent-task")
 
     if (params.existingBranch) {
       const exists = await this.branchExists(branch)

--- a/packages/kilo-vscode/src/agent-manager/branch-name.ts
+++ b/packages/kilo-vscode/src/agent-manager/branch-name.ts
@@ -1,14 +1,21 @@
 /**
- * Generate a valid git branch name from a prompt.
+ * Sanitize a string into a valid git branch name segment.
+ * Keeps lowercase alphanumeric chars and hyphens, collapses runs, strips edges.
  */
-export function generateBranchName(prompt: string): string {
-  const sanitized = prompt
-    .slice(0, 50)
+export function sanitizeBranchName(name: string, maxLength = 50): string {
+  return name
+    .slice(0, maxLength)
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .replace(/-+/g, "-")
+}
 
+/**
+ * Generate a valid git branch name from a prompt.
+ */
+export function generateBranchName(prompt: string): string {
+  const sanitized = sanitizeBranchName(prompt)
   return `${sanitized || "kilo"}-${Date.now()}`
 }
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -78,13 +78,15 @@
     "@gitlab/opencode-gitlab-auth": "1.3.3",
     "@hono/standard-validator": "0.1.5",
     "@hono/zod-validator": "catalog:",
+    "@kilocode/kilo-gateway": "workspace:*",
+    "@kilocode/kilo-telemetry": "workspace:*",
+    "@kilocode/plugin": "workspace:*",
+    "@kilocode/sdk": "workspace:*",
     "@modelcontextprotocol/sdk": "1.25.2",
     "@octokit/graphql": "9.0.2",
     "@octokit/rest": "catalog:",
     "@openauthjs/openauth": "catalog:",
-    "@kilocode/plugin": "workspace:*",
     "@opencode-ai/script": "workspace:*",
-    "@kilocode/sdk": "workspace:*",
     "@opencode-ai/util": "workspace:*",
     "@openrouter/ai-sdk-provider": "1.5.4",
     "@opentui/core": "0.1.79",
@@ -115,6 +117,7 @@
     "opentui-spinner": "0.0.6",
     "partial-json": "0.1.7",
     "remeda": "catalog:",
+    "simple-git": "3.31.1",
     "solid-js": "catalog:",
     "strip-ansi": "7.1.2",
     "tree-sitter-bash": "0.25.0",
@@ -125,10 +128,7 @@
     "xdg-basedir": "5.1.0",
     "yargs": "18.0.0",
     "zod": "catalog:",
-    "zod-to-json-schema": "3.24.5",
-    "@kilocode/kilo-gateway": "workspace:*",
-    "@kilocode/kilo-telemetry": "workspace:*",
-    "simple-git": "3.31.1"
+    "zod-to-json-schema": "3.24.5"
   },
   "overrides": {
     "drizzle-orm": "1.0.0-beta.12-a5629fb"

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -78,15 +78,13 @@
     "@gitlab/opencode-gitlab-auth": "1.3.3",
     "@hono/standard-validator": "0.1.5",
     "@hono/zod-validator": "catalog:",
-    "@kilocode/kilo-gateway": "workspace:*",
-    "@kilocode/kilo-telemetry": "workspace:*",
-    "@kilocode/plugin": "workspace:*",
-    "@kilocode/sdk": "workspace:*",
     "@modelcontextprotocol/sdk": "1.25.2",
     "@octokit/graphql": "9.0.2",
     "@octokit/rest": "catalog:",
     "@openauthjs/openauth": "catalog:",
+    "@kilocode/plugin": "workspace:*",
     "@opencode-ai/script": "workspace:*",
+    "@kilocode/sdk": "workspace:*",
     "@opencode-ai/util": "workspace:*",
     "@openrouter/ai-sdk-provider": "1.5.4",
     "@opentui/core": "0.1.79",
@@ -117,7 +115,6 @@
     "opentui-spinner": "0.0.6",
     "partial-json": "0.1.7",
     "remeda": "catalog:",
-    "simple-git": "3.31.1",
     "solid-js": "catalog:",
     "strip-ansi": "7.1.2",
     "tree-sitter-bash": "0.25.0",
@@ -128,7 +125,10 @@
     "xdg-basedir": "5.1.0",
     "yargs": "18.0.0",
     "zod": "catalog:",
-    "zod-to-json-schema": "3.24.5"
+    "zod-to-json-schema": "3.24.5",
+    "@kilocode/kilo-gateway": "workspace:*",
+    "@kilocode/kilo-telemetry": "workspace:*",
+    "simple-git": "3.31.1"
   },
   "overrides": {
     "drizzle-orm": "1.0.0-beta.12-a5629fb"


### PR DESCRIPTION
## Summary

- User-provided worktree names with spaces (e.g. "model comparison") were passed directly as git branch names, causing `fatal: 'model comparison' is not a valid branch name` errors
- Extracted `sanitizeBranchName()` from `generateBranchName()` in `branch-name.ts` and applied it to user-provided `branchName` params in `WorktreeManager.createWorktree`
- If sanitization produces an empty string (e.g. all-symbol input), falls through to auto-generated branch name

## Test plan

- Added 9 unit tests for `sanitizeBranchName` covering spaces, special chars, casing, truncation, and edge cases
- All 55 existing tests continue to pass