### PR TITLE
fix: resolve eslint warnings in kilo-vscode autocomplete code

### DIFF
--- a/packages/kilo-vscode/src/services/autocomplete/continuedev/core/autocomplete/generation/GeneratorReuseManager.test.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/continuedev/core/autocomplete/generation/GeneratorReuseManager.test.ts
@@ -161,7 +161,6 @@ describe("GeneratorReuseManager", () => {
 
   test("calls onError when generator throws an error", async () => {
     const error = new Error("Generator error")
-    // eslint-disable-next-line require-yield
     const mockGenerator = async function* () {
       throw error
     }

--- a/packages/kilo-vscode/src/services/autocomplete/continuedev/core/llm/index.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/continuedev/core/llm/index.ts
@@ -232,7 +232,6 @@ export abstract class BaseLLM implements ILLM {
     return `<${msg.role}>\n${contentToShow}\n\n`
   }
 
-  // eslint-disable-next-line require-yield
   protected async *_streamFim(
     _prefix: string,
     _suffix: string,
@@ -629,7 +628,6 @@ export abstract class BaseLLM implements ILLM {
     throw new Error(`Reranking is not supported for provider type ${this.providerName}`)
   }
 
-  // eslint-disable-next-line require-yield
   protected async *_streamComplete(
     _prompt: string,
     _signal: AbortSignal,

--- a/packages/kilo-vscode/src/services/autocomplete/continuedev/core/llm/llamaTokenizer.js
+++ b/packages/kilo-vscode/src/services/autocomplete/continuedev/core/llm/llamaTokenizer.js
@@ -35,7 +35,7 @@ class PriorityQueue {
     return this._heap.length
   }
   isEmpty() {
-    return this.size() == 0
+    return this.size() === 0
   }
   peek() {
     return this._heap[0]
@@ -395,10 +395,10 @@ class LlamaTokenizer {
     function testCase(inputString, expectedTokenIds) {
       const actualTokens = tokenizer.encode(inputString, true, true, true)
       if (!isEqual(actualTokens, expectedTokenIds)) {
-        throw `Test failed. LLaMA Tokenizer Encoder returned unexpected result: expected tokenize(${inputString}) === ${expectedTokenIds}, actual was: ${actualTokens}`
+        throw new Error(`Test failed. LLaMA Tokenizer Encoder returned unexpected result: expected tokenize(${inputString}) === ${expectedTokenIds}, actual was: ${actualTokens}`)
       }
       if (inputString !== tokenizer.decode(actualTokens)) {
-        throw `Test failed. LLaMA Tokenizer Decoder returned unexpected result: expected decode(${actualTokens}) === ${inputString}, actual was: ${decode(actualTokens)}`
+        throw new Error(`Test failed. LLaMA Tokenizer Decoder returned unexpected result: expected decode(${actualTokens}) === ${inputString}, actual was: ${decode(actualTokens)}`)
       }
     }
 


### PR DESCRIPTION
Fixes 6 eslint warnings that appear during `bun run compile` in kilo-vscode:

### Changes

**Remove unused `eslint-disable` directives** (3 warnings):
- `GeneratorReuseManager.test.ts:164` — unused `eslint-disable-next-line require-yield`
- `llm/index.ts:235` — unused `eslint-disable-next-line require-yield`  
- `llm/index.ts:632` — unused `eslint-disable-next-line require-yield`

**Fix `eqeqeq` warning** (1 warning):
- `llamaTokenizer.js:38` — changed `==` to `===` in `PriorityQueue.isEmpty()`

**Fix `no-throw-literal` warnings** (2 warnings):
- `llamaTokenizer.js:398` — wrap string template literal in `new Error()`
- `llamaTokenizer.js:401` — wrap string template literal in `new Error()`