### PR TITLE
fix(vscode): align settings dropdown styling with split-button dropdown

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1060,7 +1060,7 @@ const AgentManagerContent: Component = () => {
             <span class="am-section-label">{t("agentManager.section.worktrees")}</span>
             <Show when={isGitRepo()}>
               <div class="am-section-actions">
-                <DropdownMenu>
+                <DropdownMenu gutter={4} placement="bottom-end">
                   <DropdownMenu.Trigger
                     as={IconButton}
                     icon="settings-gear"
@@ -1069,7 +1069,7 @@ const AgentManagerContent: Component = () => {
                     label={t("agentManager.worktree.settings")}
                   />
                   <DropdownMenu.Portal>
-                    <DropdownMenu.Content>
+                    <DropdownMenu.Content class="am-split-menu">
                       <DropdownMenu.Item onSelect={handleShowKeyboardShortcuts}>
                         <DropdownMenu.ItemLabel>{t("agentManager.shortcuts.title")}</DropdownMenu.ItemLabel>
                       </DropdownMenu.Item>


### PR DESCRIPTION
## Summary

- Adds `gutter={4}` and `placement="bottom-end"` props to the settings gear dropdown, matching the split-button (+ chevron) dropdown
- Applies the `am-split-menu` class to the settings dropdown content for consistent `min-width`, item padding, and separator spacing

Before: the settings dropdown used default Kobalte positioning and base kilo-ui styles, making it visually inconsistent with the adjacent split-button dropdown.

After: both dropdowns share the same positioning, width, padding, and separator styling.