### PR TITLE
Update lychee action to use our pinned fork version

### DIFF
--- a/.github/workflows/docs-check-links.yml
+++ b/.github/workflows/docs-check-links.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2
+        uses: Kilo-Org/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
           args: "**/*.md"
           workingDirectory: packages/kilo-docs

--- a/packages/kilo-docs/lychee.toml
+++ b/packages/kilo-docs/lychee.toml
@@ -24,5 +24,6 @@ exclude = [
   '^https?://(app|console)\.requesty\.ai',
   '^https?://(cloud|console)\.google\.ai',
   'https://opencode.ai/pages/config',
-  '^localhost:3000/'
+  '^localhost:3000/',
+  'https://tbench.ai/'
 ]


### PR DESCRIPTION
This updates our link checking action to use our forked version of the action, pinned to a commit