### PR TITLE
docs: add release asset selection guide for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,33 @@
 - Install CLI: `npm install -g @kilocode/cli`
 - [Official Kilo.ai Home page](https://kilo.ai) (learn more)
 
+
+## Choosing the right Release Asset
+
+If you download from the Releases page and see many files, use this quick guide:
+
+- **darwin** = macOS
+- **linux** = Linux
+- **windows** = Windows
+- **arm64 / aarch64** = ARM CPUs (Apple Silicon, ARM servers, some Windows ARM)
+- **x64 / amd64** = Intel/AMD 64-bit CPUs (most Windows PCs)
+- **vsix** = VS Code extension package (for manual extension install), not a standalone CLI
+- **source code (.zip/.tar.gz)** = source snapshot for developers, not required for normal install
+
+### Which file should I pick?
+
+- **Windows (most users):** choose `windows-x64`
+- **Windows ARM device:** choose `windows-arm64`
+- **macOS Intel:** choose `darwin-x64`
+- **macOS Apple Silicon (M1/M2/M3...):** choose `darwin-arm64`
+- **Linux x64 server:** choose `linux-x64`
+
+If you're unsure, check your OS and CPU architecture first:
+
+- Windows: `Settings -> System -> About`
+- macOS: `About This Mac`
+- Linux: `uname -m`
+
 ## Key Features
 
 - **Code Generation:** Kilo can generate code using natural language.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ## Choosing the right Release Asset
 
-If you download from the Releases page and see many files, use this quick guide:
+If you download from the [Releases page](https://github.com/Kilo-Org/kilocode/releases) and see many files, use this quick guide:
 
 - **darwin** = macOS
 - **linux** = Linux
@@ -46,10 +46,11 @@ If you download from the Releases page and see many files, use this quick guide:
 ### Which file should I pick?
 
 - **Windows (most users):** choose `windows-x64`
-- **Windows ARM device:** choose `windows-arm64`
+- **Windows ARM device:** no dedicated ARM asset yet — use x64 emulation or install via npm (`npm install -g @kilocode/cli`)
 - **macOS Intel:** choose `darwin-x64`
 - **macOS Apple Silicon (M1/M2/M3...):** choose `darwin-arm64`
 - **Linux x64 server:** choose `linux-x64`
+- **Linux ARM64 server/device:** choose `linux-arm64`
 
 If you're unsure, check your OS and CPU architecture first:
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ If you download from the [Releases page](https://github.com/Kilo-Org/kilocode/re
 - **arm64 / aarch64** = ARM CPUs (Apple Silicon, ARM servers, some Windows ARM)
 - **x64 / amd64** = Intel/AMD 64-bit CPUs (most Windows PCs)
 - **vsix** = VS Code extension package (for manual extension install), not a standalone CLI
+- **baseline** = compatibility build for older CPUs (use if the default build crashes or fails to start)
+- **musl** = statically linked Linux build (best for Alpine or minimal Docker images without glibc)
 - **source code (.zip/.tar.gz)** = source snapshot for developers, not required for normal install
 
 ### Which file should I pick?
@@ -51,6 +53,7 @@ If you download from the [Releases page](https://github.com/Kilo-Org/kilocode/re
 - **macOS Apple Silicon (M1/M2/M3...):** choose `darwin-arm64`
 - **Linux x64 server:** choose `linux-x64`
 - **Linux ARM64 server/device:** choose `linux-arm64`
+- **Alpine/minimal Docker images:** prefer the matching `*-musl` build
 
 If you're unsure, check your OS and CPU architecture first:
 


### PR DESCRIPTION
## Summary
- Adds a beginner-friendly release asset selection guide to README so users can quickly choose the correct binary/package from Releases
- Explains key terms: darwin/linux/windows, arm64 vs x64, vsix, source archives
- Adds OS/architecture-based quick picks and simple architecture check pointers

Closes Kilo-Org/kilocode#6293

> Re-submitted from Kilo-Org/kilo#586 as the repository has been migrated to kilocode.

## Test plan
- [ ] Verify the new section renders correctly in README
- [ ] Verify all links and formatting are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)