### PR TITLE
feat(vscode): add install-dev-extension task with dev version indicator

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -99,6 +99,24 @@
       "label": "VSCode - Tests (Composite)",
       "dependsOn": ["VSCode - Watch", "VSCode - Tests"],
       "problemMatcher": []
+    },
+    {
+      "label": "install-dev-extension",
+      "type": "shell",
+      "command": "bun script/install-dev-extension.ts",
+      "group": "build",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder}/packages/kilo-vscode"
+      },
+      "problemMatcher": []
     }
   ]
 }

--- a/packages/kilo-vscode/.vscodeignore
+++ b/packages/kilo-vscode/.vscodeignore
@@ -17,6 +17,8 @@ vsc-extension-quickstart.md
 **/.vscode-test.*
 AGENTS.md
 .prettierignore
+.env
+.env.*
 
 # Include dist/ directory for compiled extension (production)
 !dist/**

--- a/packages/kilo-vscode/script/install-dev-extension.ts
+++ b/packages/kilo-vscode/script/install-dev-extension.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+import { $ } from "bun"
+import { join } from "node:path"
+import { rmSync, mkdirSync, existsSync, statSync } from "node:fs"
+
+const root = join(import.meta.dir, "..")
+const outDir = join(root, "out")
+const pkgPath = join(root, "package.json")
+
+if (existsSync(outDir) && !statSync(outDir).isDirectory()) {
+  rmSync(outDir)
+}
+mkdirSync(outDir, { recursive: true })
+
+const pkg = await Bun.file(pkgPath).json()
+const sha = (await $`git rev-parse --short HEAD`.text()).trim()
+const devVersion = `${pkg.version}-dev+${sha}`
+
+await Bun.write(pkgPath, JSON.stringify({ ...pkg, version: devVersion }, null, 2) + "\n")
+
+try {
+  await $`bun script/local-bin.ts`.cwd(root)
+  await $`bun run check-types`.cwd(root)
+  await $`bun run lint`.cwd(root)
+  await $`node ${join(root, "esbuild.js")} --production`.cwd(root)
+  await $`bunx @vscode/vsce package --no-dependencies --skip-license -o ${outDir}/`.cwd(root)
+} finally {
+  await Bun.write(pkgPath, JSON.stringify(pkg, null, 2) + "\n")
+}
+
+const vsix = (await $`ls -1v ${outDir}/*.vsix`.text()).trim().split("\n").at(-1)!
+await $`code --force --install-extension ${vsix}`


### PR DESCRIPTION
## Summary

- Adds an `install-dev-extension` VS Code task that builds and installs the local dev extension in one step via **Command Palette** → `Tasks: Run Task` → `install-dev-extension`
- Extracts the build logic into `packages/kilo-vscode/script/install-dev-extension.ts` for readability
- Embeds the git SHA into the extension version during dev builds (e.g. `7.0.29-dev+800c24a`), making it immediately visible in the About screen that a dev build is installed
- Excludes `.env` files from the vsix package

<img width="1352" height="614" alt="CleanShot 2026-02-25 at 13 28 57@2x" src="https://github.com/user-attachments/assets/db734b24-9363-42f8-9f71-f0cc1806aad7" />