### PR TITLE
Config - Fix plugin package name for auto-installed dependencies

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -378,7 +378,7 @@ export namespace Config {
     }))
     json.dependencies = {
       ...json.dependencies,
-      "@opencode-ai/plugin": targetVersion,
+      "@kilocode/plugin": targetVersion, // kilocode_change
     }
     await Filesystem.writeJson(pkg, json)
     await new Promise((resolve) => setTimeout(resolve, 3000))
@@ -427,15 +427,17 @@ export namespace Config {
 
     const parsed = await Filesystem.readJson<{ dependencies?: Record<string, string> }>(pkg).catch(() => null)
     const dependencies = parsed?.dependencies ?? {}
-    const depVersion = dependencies["@opencode-ai/plugin"]
+    // kilocode_change start
+    const depVersion = dependencies["@kilocode/plugin"]
     if (!depVersion) return true
 
     const targetVersion = Installation.isLocal() ? "latest" : Installation.VERSION
     if (targetVersion === "latest") {
-      const isOutdated = await PackageRegistry.isOutdated("@opencode-ai/plugin", depVersion, dir)
+      const isOutdated = await PackageRegistry.isOutdated("@kilocode/plugin", depVersion, dir)
       if (!isOutdated) return false
       log.info("Cached version is outdated, proceeding with install", {
-        pkg: "@opencode-ai/plugin",
+        pkg: "@kilocode/plugin",
+        // kilocode_change end
         cachedVersion: depVersion,
       })
       return true

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -437,11 +437,11 @@ export namespace Config {
       if (!isOutdated) return false
       log.info("Cached version is outdated, proceeding with install", {
         pkg: "@kilocode/plugin",
-        // kilocode_change end
         cachedVersion: depVersion,
       })
       return true
     }
+    // kilocode_change end
     if (depVersion === targetVersion) return false
     return true
   }


### PR DESCRIPTION
## Summary

- Fix `installDependencies()` and `needsInstall()` in `packages/opencode/src/config/config.ts` to reference `@kilocode/plugin` instead of the old upstream package name `@opencode-ai/plugin`

## Problem

The CLI's config module auto-generates a `.opencode/package.json` and installs the plugin SDK for custom tools/plugins. Two functions still referenced the old upstream package name `@opencode-ai/plugin`:

- **`installDependencies()`** wrote `"@opencode-ai/plugin"` into the generated `package.json`, but tool/plugin files import from `@kilocode/plugin` — causing a "can't find @kilocode/plugin" error on startup
- **`needsInstall()`** checked `dependencies["@opencode-ai/plugin"]` which was always `undefined` (since the key didn't exist), causing unnecessary reinstalls every launch — and installing the wrong package

## Fix

Four string replacements in `config.ts`, changing `@opencode-ai/plugin` → `@kilocode/plugin` in both functions. This aligns with the actual published package name in `packages/plugin/package.json`.


Before:

<img width="1146" height="819" alt="Screenshot 2026-02-25 at 10 42 38" src="https://github.com/user-attachments/assets/ebb1c79d-2436-49e3-87f0-1393e395889c" />

After:

<img width="1149" height="822" alt="Screenshot 2026-02-25 at 10 43 25" src="https://github.com/user-attachments/assets/3b1bcfcf-5a5d-4065-b93c-d00e416254d6" />
