### PR TITLE
fix: fill terminal code block background for entire box

### DIFF
--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -345,7 +345,7 @@
   width: 100%;
   border: 1px solid var(--border-weak-base);
   border-radius: 6px;
-  background: transparent;
+  background: var(--background-stronger);
   position: relative;
   overflow: hidden;
 

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -397,6 +397,7 @@
     line-height: var(--line-height-large);
     white-space: pre-wrap;
     overflow-wrap: anywhere;
+    background: transparent;
   }
 }
 


### PR DESCRIPTION
## Summary

- `[data-component="bash-output"]` had `background: transparent`, causing the dark background to only appear behind text characters rather than filling the entire code block box
- Changed to `background: var(--background-stronger)` to match the color used by shiki code blocks and other code-like surfaces in the UI

| Before | After |
|---|---|
|  <img width="840" height="688" alt="CleanShot 2026-02-25 at 15 38 06@2x" src="https://github.com/user-attachments/assets/bb28a6b9-c252-4eb0-b24f-62e2edf1bebe" />| <img width="1844" height="858" alt="CleanShot 2026-02-25 at 15 37 07@2x" src="https://github.com/user-attachments/assets/5d59839f-9f89-4f00-9974-b75aa90b2835" /> |