### PR TITLE
fix: resolve diff viewer race condition and add diagnostics for Agent Manager

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1301,7 +1301,10 @@ export class AgentManagerProvider implements vscode.Disposable {
   private async onRequestWorktreeDiff(sessionId: string): Promise<void> {
     // Ensure state is loaded before resolving diff target — avoids race where
     // startDiffWatch arrives before initializeState() finishes loading state from disk.
-    if (this.stateReady) await this.stateReady
+    // Catch so a rejected stateReady doesn't permanently break diff polling.
+    if (this.stateReady) {
+      await this.stateReady.catch((err) => this.log("stateReady rejected, continuing diff resolve:", err))
+    }
 
     const target = this.resolveDiffTarget(sessionId)
     if (!target) return

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1274,23 +1274,44 @@ export class AgentManagerProvider implements vscode.Disposable {
   /** Resolve worktree path + parentBranch for a session, or undefined if not applicable. */
   private resolveDiffTarget(sessionId: string): { directory: string; baseBranch: string } | undefined {
     const state = this.getStateManager()
-    if (!state) return undefined
+    if (!state) {
+      this.log(`resolveDiffTarget: no state manager for session ${sessionId}`)
+      return undefined
+    }
     const session = state.getSession(sessionId)
-    if (!session?.worktreeId) return undefined
+    if (!session) {
+      this.log(
+        `resolveDiffTarget: session ${sessionId} not found in state (${state.getSessions().length} total sessions)`,
+      )
+      return undefined
+    }
+    if (!session.worktreeId) {
+      this.log(`resolveDiffTarget: session ${sessionId} has no worktreeId (local session)`)
+      return undefined
+    }
     const worktree = state.getWorktree(session.worktreeId)
-    if (!worktree) return undefined
+    if (!worktree) {
+      this.log(`resolveDiffTarget: worktree ${session.worktreeId} not found for session ${sessionId}`)
+      return undefined
+    }
     return { directory: worktree.path, baseBranch: worktree.parentBranch }
   }
 
   /** One-shot diff fetch with loading indicators. Used by requestWorktreeDiff. */
   private async onRequestWorktreeDiff(sessionId: string): Promise<void> {
+    // Ensure state is loaded before resolving diff target — avoids race where
+    // startDiffWatch arrives before initializeState() finishes loading state from disk.
+    if (this.stateReady) await this.stateReady
+
     const target = this.resolveDiffTarget(sessionId)
     if (!target) return
 
     this.postToWebview({ type: "agentManager.worktreeDiffLoading", sessionId, loading: true })
     try {
       const client = this.connectionService.getHttpClient()
+      this.log(`Fetching worktree diff for session ${sessionId}: dir=${target.directory}, base=${target.baseBranch}`)
       const diffs = await client.getWorktreeDiff(target.directory, target.baseBranch)
+      this.log(`Worktree diff returned ${diffs.length} file(s) for session ${sessionId}`)
 
       const hash = diffs.map((d) => `${d.file}:${d.status}:${d.additions}:${d.deletions}:${d.after.length}`).join("|")
       this.lastDiffHash = hash
@@ -1328,6 +1349,7 @@ export class AgentManagerProvider implements vscode.Disposable {
     this.stopDiffPolling()
     this.diffSessionId = sessionId
     this.lastDiffHash = undefined
+    this.log(`Starting diff polling for session ${sessionId}`)
 
     // Initial fetch with loading state
     void this.onRequestWorktreeDiff(sessionId)

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1301,7 +1301,9 @@ export class AgentManagerProvider implements vscode.Disposable {
   private async onRequestWorktreeDiff(sessionId: string): Promise<void> {
     // Ensure state is loaded before resolving diff target — avoids race where
     // startDiffWatch arrives before initializeState() finishes loading state from disk.
-    // Catch so a rejected stateReady doesn't permanently break diff polling.
+    // The .catch() is required: this method is called via `void` (fire-and-forget),
+    // so an uncaught rejection would become an unhandled promise rejection. On failure
+    // we log and fall through to resolveDiffTarget which logs the specific reason.
     if (this.stateReady) {
       await this.stateReady.catch((err) => this.log("stateReady rejected, continuing diff resolve:", err))
     }


### PR DESCRIPTION
## Summary

- Fix race condition where `onRequestWorktreeDiff` could run before `initializeState()` finishes loading worktree/session mappings from disk, causing `resolveDiffTarget` to silently return `undefined` and the diff panel to permanently show "No changes detected"
- Add diagnostic logging throughout the diff flow (extension + server) so silent failures become visible in the "Kilo Agent Manager" output channel

## Problem

The Agent Manager diff viewer ("Changes" panel) was not detecting file changes in worktrees despite files being correctly present on disk (`git status` confirmed untracked files existed).

Root cause: `startDiffPolling` → `onRequestWorktreeDiff` → `resolveDiffTarget` accesses the `WorktreeStateManager` without waiting for `stateReady` to resolve. If the webview's `createEffect` fires `startDiffWatch` before the state file (`.kilocode/agent-manager.json`) finishes loading, the session lookup fails silently — no HTTP request is ever made to the server, and no error is shown.

Additionally, multiple failure points in the diff flow were completely silent:
- `resolveDiffTarget` returned `undefined` with no logging (4 different failure conditions)
- HTTP errors from the server's diff endpoint were caught with `silent: true`
- Server-side git command failures (`merge-base`, `ls-files`) returned empty arrays with no logging

## Changes

**`packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts`**
- `onRequestWorktreeDiff`: await `this.stateReady` before resolving diff target
- `resolveDiffTarget`: log specific reason when returning `undefined` (no state manager, session not found, no worktreeId, worktree not found)
- `startDiffPolling` / `onRequestWorktreeDiff`: log polling start, directory/baseBranch used, and file count returned

**`packages/opencode/src/server/routes/experimental.ts`**
- Log `dir` and `base` parameters on each diff request
- Log `merge-base` failures with exit code and stderr
- Log untracked file count from `git ls-files`
- Log `git ls-files` failures
- Log total file count in final response

## Architecture note

There is ONE `kilo serve` process per workspace. Worktree isolation uses the `x-opencode-directory` HTTP header — no separate server per worktree.