### PR TITLE
fix: use consistent worktree terminology in agent manager dialog

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -987,7 +987,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "؟ سيؤدي هذا إلى إزالة Worktree من القرص وفصل جميع الجلسات.",
   "agentManager.dialog.deleteWorktree.cancel": "إلغاء",
   "agentManager.dialog.deleteWorktree.confirm": "حذف",
-  "agentManager.dialog.openWorktree": "فتح شجرة العمل",
+  "agentManager.dialog.openWorktree": "شجرة عمل جديدة",
   "agentManager.dialog.tab.new": "جديد",
   "agentManager.dialog.tab.import": "استيراد",
   "agentManager.dialog.namePlaceholder": "اسم Worktree (اختياري)",
@@ -1005,7 +1005,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "مقارنة النماذج",
   "agentManager.dialog.compareModels.searchModels": "البحث عن النماذج...",
   "agentManager.dialog.creating": "جارٍ الإنشاء...",
-  "agentManager.dialog.createWorkspace": "إنشاء مساحة عمل",
+  "agentManager.dialog.createWorkspace": "إنشاء شجرة العمل",
   "agentManager.dialog.removeImage": "إزالة الصورة",
   "agentManager.dialog.advanced": "متقدم...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1001,7 +1001,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "? Isso remove o Worktree do disco e desassocia todas as sessões.",
   "agentManager.dialog.deleteWorktree.cancel": "Cancelar",
   "agentManager.dialog.deleteWorktree.confirm": "Excluir",
-  "agentManager.dialog.openWorktree": "Abrir Worktree",
+  "agentManager.dialog.openWorktree": "Novo Worktree",
   "agentManager.dialog.tab.new": "Novo",
   "agentManager.dialog.tab.import": "Importar",
   "agentManager.dialog.namePlaceholder": "Nome do Worktree (opcional)",
@@ -1019,7 +1019,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "Comparar Modelos",
   "agentManager.dialog.compareModels.searchModels": "Pesquisar modelos...",
   "agentManager.dialog.creating": "Criando...",
-  "agentManager.dialog.createWorkspace": "Criar Workspace",
+  "agentManager.dialog.createWorkspace": "Criar Worktree",
   "agentManager.dialog.removeImage": "Remover imagem",
   "agentManager.dialog.advanced": "Avançado...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1023,7 +1023,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "? Ovo uklanja Worktree sa diska i odvezuje sve sesije.",
   "agentManager.dialog.deleteWorktree.cancel": "Otkaži",
   "agentManager.dialog.deleteWorktree.confirm": "Obriši",
-  "agentManager.dialog.openWorktree": "Otvori worktree",
+  "agentManager.dialog.openWorktree": "Novi worktree",
   "agentManager.dialog.tab.new": "Novo",
   "agentManager.dialog.tab.import": "Uvezi",
   "agentManager.dialog.namePlaceholder": "Naziv Worktree-a (opcionalno)",
@@ -1041,7 +1041,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "Uporedi modele",
   "agentManager.dialog.compareModels.searchModels": "Pretraži modele...",
   "agentManager.dialog.creating": "Kreiranje...",
-  "agentManager.dialog.createWorkspace": "Kreiraj radni prostor",
+  "agentManager.dialog.createWorkspace": "Kreiraj worktree",
   "agentManager.dialog.removeImage": "Ukloni sliku",
   "agentManager.dialog.advanced": "Napredno...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -996,7 +996,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "? Dette fjerner Worktree fra disken og afkobler alle sessioner.",
   "agentManager.dialog.deleteWorktree.cancel": "Annuller",
   "agentManager.dialog.deleteWorktree.confirm": "Slet",
-  "agentManager.dialog.openWorktree": "Åbn Worktree",
+  "agentManager.dialog.openWorktree": "Ny Worktree",
   "agentManager.dialog.tab.new": "Ny",
   "agentManager.dialog.tab.import": "Importér",
   "agentManager.dialog.namePlaceholder": "Worktree-navn (valgfrit)",
@@ -1014,7 +1014,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "Sammenlign modeller",
   "agentManager.dialog.compareModels.searchModels": "Søg modeller...",
   "agentManager.dialog.creating": "Opretter...",
-  "agentManager.dialog.createWorkspace": "Opret Workspace",
+  "agentManager.dialog.createWorkspace": "Opret Worktree",
   "agentManager.dialog.removeImage": "Fjern billede",
   "agentManager.dialog.advanced": "Avanceret...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1010,7 +1010,7 @@ export const dict = {
     "? Dies entfernt den Worktree von der Festplatte und trennt alle Sitzungen.",
   "agentManager.dialog.deleteWorktree.cancel": "Abbrechen",
   "agentManager.dialog.deleteWorktree.confirm": "Löschen",
-  "agentManager.dialog.openWorktree": "Worktree öffnen",
+  "agentManager.dialog.openWorktree": "Neuer Worktree",
   "agentManager.dialog.tab.new": "Neu",
   "agentManager.dialog.tab.import": "Importieren",
   "agentManager.dialog.namePlaceholder": "Worktree-Name (optional)",
@@ -1028,7 +1028,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "Modelle vergleichen",
   "agentManager.dialog.compareModels.searchModels": "Modelle suchen...",
   "agentManager.dialog.creating": "Wird erstellt...",
-  "agentManager.dialog.createWorkspace": "Arbeitsbereich erstellen",
+  "agentManager.dialog.createWorkspace": "Worktree erstellen",
   "agentManager.dialog.removeImage": "Bild entfernen",
   "agentManager.dialog.advanced": "Erweitert...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1052,7 +1052,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.cancel": "Cancel",
   "agentManager.dialog.deleteWorktree.confirm": "Delete",
 
-  "agentManager.dialog.openWorktree": "Open Worktree",
+  "agentManager.dialog.openWorktree": "New Worktree",
   "agentManager.dialog.tab.new": "New",
   "agentManager.dialog.tab.import": "Import",
   "agentManager.dialog.namePlaceholder": "Worktree name (optional)",
@@ -1070,7 +1070,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "Compare Models",
   "agentManager.dialog.compareModels.searchModels": "Search models...",
   "agentManager.dialog.creating": "Creating...",
-  "agentManager.dialog.createWorkspace": "Create Workspace",
+  "agentManager.dialog.createWorkspace": "Create Worktree",
   "agentManager.dialog.removeImage": "Remove image",
   "agentManager.dialog.advanced": "Advanced...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1004,7 +1004,7 @@ export const dict = {
     "? Esto elimina el Worktree del disco y desasocia todas las sesiones.",
   "agentManager.dialog.deleteWorktree.cancel": "Cancelar",
   "agentManager.dialog.deleteWorktree.confirm": "Eliminar",
-  "agentManager.dialog.openWorktree": "Abrir Worktree",
+  "agentManager.dialog.openWorktree": "Nuevo Worktree",
   "agentManager.dialog.tab.new": "Nuevo",
   "agentManager.dialog.tab.import": "Importar",
   "agentManager.dialog.namePlaceholder": "Nombre del Worktree (opcional)",
@@ -1022,7 +1022,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "Comparar modelos",
   "agentManager.dialog.compareModels.searchModels": "Buscar modelos...",
   "agentManager.dialog.creating": "Creando...",
-  "agentManager.dialog.createWorkspace": "Crear Workspace",
+  "agentManager.dialog.createWorkspace": "Crear Worktree",
   "agentManager.dialog.removeImage": "Eliminar imagen",
   "agentManager.dialog.advanced": "Avanzado...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1012,7 +1012,7 @@ export const dict = {
     " ? Cela supprime le Worktree du disque et dissocie toutes les sessions.",
   "agentManager.dialog.deleteWorktree.cancel": "Annuler",
   "agentManager.dialog.deleteWorktree.confirm": "Supprimer",
-  "agentManager.dialog.openWorktree": "Ouvrir le worktree",
+  "agentManager.dialog.openWorktree": "Nouveau worktree",
   "agentManager.dialog.tab.new": "Nouveau",
   "agentManager.dialog.tab.import": "Importer",
   "agentManager.dialog.namePlaceholder": "Nom du Worktree (optionnel)",
@@ -1030,7 +1030,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "Comparer les modèles",
   "agentManager.dialog.compareModels.searchModels": "Rechercher des modèles...",
   "agentManager.dialog.creating": "Création...",
-  "agentManager.dialog.createWorkspace": "Créer un espace de travail",
+  "agentManager.dialog.createWorkspace": "Créer un worktree",
   "agentManager.dialog.removeImage": "Supprimer l'image",
   "agentManager.dialog.advanced": "Avancé...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -992,7 +992,7 @@ export const dict = {
     "？ ディスクからWorktreeを削除し、すべてのセッションの関連付けを解除します。",
   "agentManager.dialog.deleteWorktree.cancel": "キャンセル",
   "agentManager.dialog.deleteWorktree.confirm": "削除",
-  "agentManager.dialog.openWorktree": "ワークツリーを開く",
+  "agentManager.dialog.openWorktree": "新規ワークツリー",
   "agentManager.dialog.tab.new": "新規",
   "agentManager.dialog.tab.import": "インポート",
   "agentManager.dialog.namePlaceholder": "Worktree名（任意）",
@@ -1010,7 +1010,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "モデルを比較",
   "agentManager.dialog.compareModels.searchModels": "モデルを検索...",
   "agentManager.dialog.creating": "作成中...",
-  "agentManager.dialog.createWorkspace": "ワークスペースを作成",
+  "agentManager.dialog.createWorkspace": "ワークツリーを作成",
   "agentManager.dialog.removeImage": "画像を削除",
   "agentManager.dialog.advanced": "詳細...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -992,7 +992,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "? 디스크에서 Worktree를 제거하고 모든 세션의 연결을 해제합니다.",
   "agentManager.dialog.deleteWorktree.cancel": "취소",
   "agentManager.dialog.deleteWorktree.confirm": "삭제",
-  "agentManager.dialog.openWorktree": "워크트리 열기",
+  "agentManager.dialog.openWorktree": "새 워크트리",
   "agentManager.dialog.tab.new": "새로 만들기",
   "agentManager.dialog.tab.import": "가져오기",
   "agentManager.dialog.namePlaceholder": "Worktree 이름 (선택사항)",
@@ -1010,7 +1010,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "모델 비교",
   "agentManager.dialog.compareModels.searchModels": "모델 검색...",
   "agentManager.dialog.creating": "생성 중...",
-  "agentManager.dialog.createWorkspace": "워크스페이스 생성",
+  "agentManager.dialog.createWorkspace": "워크트리 생성",
   "agentManager.dialog.removeImage": "이미지 제거",
   "agentManager.dialog.advanced": "고급...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -997,7 +997,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "? Dette fjerner Worktree fra disken og kobler fra alle økter.",
   "agentManager.dialog.deleteWorktree.cancel": "Avbryt",
   "agentManager.dialog.deleteWorktree.confirm": "Slett",
-  "agentManager.dialog.openWorktree": "Åpne worktree",
+  "agentManager.dialog.openWorktree": "Ny worktree",
   "agentManager.dialog.tab.new": "Ny",
   "agentManager.dialog.tab.import": "Importer",
   "agentManager.dialog.namePlaceholder": "Worktree-navn (valgfritt)",
@@ -1015,7 +1015,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "Sammenlign modeller",
   "agentManager.dialog.compareModels.searchModels": "Søk modeller...",
   "agentManager.dialog.creating": "Oppretter...",
-  "agentManager.dialog.createWorkspace": "Opprett arbeidsområde",
+  "agentManager.dialog.createWorkspace": "Opprett worktree",
   "agentManager.dialog.removeImage": "Fjern bilde",
   "agentManager.dialog.advanced": "Avansert...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -999,7 +999,7 @@ export const dict = {
     "? Spowoduje to usunięcie Worktree z dysku i odłączenie wszystkich sesji.",
   "agentManager.dialog.deleteWorktree.cancel": "Anuluj",
   "agentManager.dialog.deleteWorktree.confirm": "Usuń",
-  "agentManager.dialog.openWorktree": "Otwórz Worktree",
+  "agentManager.dialog.openWorktree": "Nowy Worktree",
   "agentManager.dialog.tab.new": "Nowy",
   "agentManager.dialog.tab.import": "Importuj",
   "agentManager.dialog.namePlaceholder": "Nazwa Worktree (opcjonalnie)",
@@ -1017,7 +1017,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "Porównaj modele",
   "agentManager.dialog.compareModels.searchModels": "Szukaj modeli...",
   "agentManager.dialog.creating": "Tworzenie...",
-  "agentManager.dialog.createWorkspace": "Utwórz Workspace",
+  "agentManager.dialog.createWorkspace": "Utwórz Worktree",
   "agentManager.dialog.removeImage": "Usuń obraz",
   "agentManager.dialog.advanced": "Zaawansowane...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1000,7 +1000,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "? Это удалит Worktree с диска и отключит все сессии.",
   "agentManager.dialog.deleteWorktree.cancel": "Отмена",
   "agentManager.dialog.deleteWorktree.confirm": "Удалить",
-  "agentManager.dialog.openWorktree": "Открыть worktree",
+  "agentManager.dialog.openWorktree": "Новый worktree",
   "agentManager.dialog.tab.new": "Новый",
   "agentManager.dialog.tab.import": "Импорт",
   "agentManager.dialog.namePlaceholder": "Имя Worktree (необязательно)",
@@ -1018,7 +1018,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "Сравнить модели",
   "agentManager.dialog.compareModels.searchModels": "Поиск моделей...",
   "agentManager.dialog.creating": "Создание...",
-  "agentManager.dialog.createWorkspace": "Создать рабочее пространство",
+  "agentManager.dialog.createWorkspace": "Создать worktree",
   "agentManager.dialog.removeImage": "Удалить изображение",
   "agentManager.dialog.advanced": "Дополнительно...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -985,7 +985,7 @@ export const dict = {
     "? การดำเนินการนี้จะลบ Worktree ออกจากดิสก์และยกเลิกการเชื่อมโยงเซสชันทั้งหมด",
   "agentManager.dialog.deleteWorktree.cancel": "ยกเลิก",
   "agentManager.dialog.deleteWorktree.confirm": "ลบ",
-  "agentManager.dialog.openWorktree": "เปิด Worktree",
+  "agentManager.dialog.openWorktree": "Worktree ใหม่",
   "agentManager.dialog.tab.new": "ใหม่",
   "agentManager.dialog.tab.import": "นำเข้า",
   "agentManager.dialog.namePlaceholder": "ชื่อ Worktree (ไม่บังคับ)",
@@ -1003,7 +1003,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "เปรียบเทียบโมเดล",
   "agentManager.dialog.compareModels.searchModels": "ค้นหาโมเดล...",
   "agentManager.dialog.creating": "กำลังสร้าง...",
-  "agentManager.dialog.createWorkspace": "สร้าง Workspace",
+  "agentManager.dialog.createWorkspace": "สร้าง Worktree",
   "agentManager.dialog.removeImage": "ลบรูปภาพ",
   "agentManager.dialog.advanced": "ขั้นสูง...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -987,7 +987,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "？这将从磁盘中移除 Worktree 并取消所有会话的关联。",
   "agentManager.dialog.deleteWorktree.cancel": "取消",
   "agentManager.dialog.deleteWorktree.confirm": "删除",
-  "agentManager.dialog.openWorktree": "打开工作树",
+  "agentManager.dialog.openWorktree": "新建工作树",
   "agentManager.dialog.tab.new": "新建",
   "agentManager.dialog.tab.import": "导入",
   "agentManager.dialog.namePlaceholder": "Worktree 名称（可选）",
@@ -1005,7 +1005,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "比较模型",
   "agentManager.dialog.compareModels.searchModels": "搜索模型...",
   "agentManager.dialog.creating": "创建中...",
-  "agentManager.dialog.createWorkspace": "创建工作区",
+  "agentManager.dialog.createWorkspace": "创建工作树",
   "agentManager.dialog.removeImage": "移除图片",
   "agentManager.dialog.advanced": "高级...",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -983,7 +983,7 @@ export const dict = {
   "agentManager.dialog.deleteWorktree.messagePost": "？這將從磁碟中移除 Worktree 並取消所有工作階段的關聯。",
   "agentManager.dialog.deleteWorktree.cancel": "取消",
   "agentManager.dialog.deleteWorktree.confirm": "刪除",
-  "agentManager.dialog.openWorktree": "開啟工作樹",
+  "agentManager.dialog.openWorktree": "新建工作樹",
   "agentManager.dialog.tab.new": "新建",
   "agentManager.dialog.tab.import": "匯入",
   "agentManager.dialog.namePlaceholder": "Worktree 名稱（選填）",
@@ -1001,7 +1001,7 @@ export const dict = {
   "agentManager.dialog.compareModels": "比較模型",
   "agentManager.dialog.compareModels.searchModels": "搜尋模型...",
   "agentManager.dialog.creating": "建立中...",
-  "agentManager.dialog.createWorkspace": "建立工作區",
+  "agentManager.dialog.createWorkspace": "建立工作樹",
   "agentManager.dialog.removeImage": "移除圖片",
   "agentManager.dialog.advanced": "進階...",
 


### PR DESCRIPTION
## Summary

- Renames dialog title from "Open Worktree" to **"New Worktree"** — the action creates a new worktree, not opens an existing one
- Renames submit button from "Create Workspace" to **"Create Worktree"** — uses the correct noun consistent with all other UI labels
- Updated across all 16 locales (ar, br, bs, da, de, en, es, fr, ja, ko, no, pl, ru, th, zh, zht)

The flow is now consistent: toolbar button "New Worktree" → dialog title "New Worktree" → submit button "Create Worktree" → loading state "Creating..."