### PR TITLE
feat(agent-manager): resizable diff panel with cursor and width memory

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1662,15 +1662,15 @@ const AgentManagerContent: Component = () => {
               </Show>
             </div>
             <Show when={diffOpen()}>
-              <ResizeHandle
-                direction="horizontal"
-                edge="end"
-                size={diffWidth()}
-                min={200}
-                max={Math.round(window.innerWidth * 0.8)}
-                onResize={(w) => setDiffWidth(Math.max(200, Math.min(w, window.innerWidth * 0.8)))}
-              />
               <div class="am-diff-panel-wrapper" style={{ width: `${diffWidth()}px`, "flex-shrink": "0" }}>
+                <ResizeHandle
+                  direction="horizontal"
+                  edge="start"
+                  size={diffWidth()}
+                  min={200}
+                  max={Math.round(window.innerWidth * 0.8)}
+                  onResize={(w) => setDiffWidth(Math.max(200, Math.min(w, window.innerWidth * 0.8)))}
+                />
                 <DiffPanel
                   diffs={diffDatas()[session.currentSessionID() ?? ""] ?? []}
                   loading={diffLoading()}

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -643,10 +643,15 @@ button.am-section-toggle:hover .am-section-label {
 }
 
 .am-diff-panel-wrapper {
+  position: relative;
   min-width: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+.am-diff-panel-wrapper > [data-component="resize-handle"]::after {
+  background: var(--surface-interactive-base);
 }
 
 .am-diff-panel {

--- a/packages/ui/src/components/resize-handle.tsx
+++ b/packages/ui/src/components/resize-handle.tsx
@@ -32,8 +32,12 @@ export function ResizeHandle(props: ResizeHandleProps) {
     const startSize = local.size
     let current = startSize
 
+    // kilocode_change start - set resize cursor on body during drag
+    const cursor = local.direction === "horizontal" ? "col-resize" : "row-resize"
+    // kilocode_change end
     document.body.style.userSelect = "none"
     document.body.style.overflow = "hidden"
+    document.body.style.cursor = cursor // kilocode_change
 
     const onMouseMove = (moveEvent: MouseEvent) => {
       const pos = local.direction === "horizontal" ? moveEvent.clientX : moveEvent.clientY
@@ -53,6 +57,7 @@ export function ResizeHandle(props: ResizeHandleProps) {
     const onMouseUp = () => {
       document.body.style.userSelect = ""
       document.body.style.overflow = ""
+      document.body.style.cursor = "" // kilocode_change
       document.removeEventListener("mousemove", onMouseMove)
       document.removeEventListener("mouseup", onMouseUp)
 


### PR DESCRIPTION
## Summary

- Makes the diff panel / chat split resizable by fixing the `ResizeHandle` positioning (moved inside `am-diff-panel-wrapper` with `edge="start"`)
- Sets `col-resize` cursor on `document.body` during drag so it persists even when the mouse leaves the thin handle hitzone
- Diff panel width persists in memory across open/close cycles (the `diffWidth` signal lives in the parent component scope, outside the `<Show>` conditional)
- Adds visual indicator styling for the diff resize handle (matching the sidebar pattern)

## Changes

| File | What |
| --- | --- |
| `packages/ui/src/components/resize-handle.tsx` | Set body cursor during drag (with `kilocode_change` markers) |
| `packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx` | Move `ResizeHandle` inside diff wrapper, use `edge="start"` |
| `packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css` | Add `position: relative` to wrapper, resize handle indicator color |