### PR TITLE
feat(agent-manager): add Cmd+1-9 quick switch shortcuts for sidebar items

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -179,6 +179,51 @@
         "category": "Kilo Code"
       },
       {
+        "command": "kilo-code.new.agentManager.jumpTo1",
+        "title": "Agent Manager: Jump to Item 1",
+        "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo2",
+        "title": "Agent Manager: Jump to Item 2",
+        "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo3",
+        "title": "Agent Manager: Jump to Item 3",
+        "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo4",
+        "title": "Agent Manager: Jump to Item 4",
+        "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo5",
+        "title": "Agent Manager: Jump to Item 5",
+        "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo6",
+        "title": "Agent Manager: Jump to Item 6",
+        "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo7",
+        "title": "Agent Manager: Jump to Item 7",
+        "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo8",
+        "title": "Agent Manager: Jump to Item 8",
+        "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo9",
+        "title": "Agent Manager: Jump to Item 9",
+        "category": "Kilo Code"
+      },
+      {
         "command": "kilo-code.new.generateCommitMessage",
         "title": "Generate Commit Message",
         "category": "Kilo Code (NEW)",
@@ -422,6 +467,60 @@
         "command": "kilo-code.new.agentManager.advancedWorktree",
         "key": "ctrl+shift+n",
         "mac": "cmd+shift+n",
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo1",
+        "key": "ctrl+1",
+        "mac": "cmd+1",
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo2",
+        "key": "ctrl+2",
+        "mac": "cmd+2",
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo3",
+        "key": "ctrl+3",
+        "mac": "cmd+3",
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo4",
+        "key": "ctrl+4",
+        "mac": "cmd+4",
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo5",
+        "key": "ctrl+5",
+        "mac": "cmd+5",
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo6",
+        "key": "ctrl+6",
+        "mac": "cmd+6",
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo7",
+        "key": "ctrl+7",
+        "mac": "cmd+7",
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo8",
+        "key": "ctrl+8",
+        "mac": "cmd+8",
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.agentManager.jumpTo9",
+        "key": "ctrl+9",
+        "mac": "cmd+9",
         "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
       }
     ],

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -109,6 +109,11 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("kilo-code.new.agentManager.advancedWorktree", () => {
       agentManagerProvider.postMessage({ type: "action", action: "advancedWorktree" })
     }),
+    ...Array.from({ length: 9 }, (_, i) =>
+      vscode.commands.registerCommand(`kilo-code.new.agentManager.jumpTo${i + 1}`, () => {
+        agentManagerProvider.postMessage({ type: "action", action: `jumpTo${i + 1}` })
+      }),
+    ),
   )
 
   // Register URI handler for session imports (vscode://kilocode.kilo-code/kilocode/s/{sessionId})

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -25,6 +25,7 @@
 /* Fixed local workspace item */
 
 .am-local-item {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -224,6 +225,50 @@ button.am-section-toggle:hover .am-section-label {
   outline: none;
 }
 
+/* Shortcut badge — hover-reveal index badge (⌘1, ⌘2, etc.) matching Superset style */
+
+.am-shortcut-badge {
+  position: absolute;
+  right: 30px;
+  opacity: 0;
+  transition: opacity 150ms ease;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-weaker);
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.am-local-item .am-shortcut-badge {
+  right: 8px;
+}
+
+.am-local-item:hover .am-shortcut-badge,
+.am-worktree-item:hover .am-shortcut-badge {
+  opacity: 1;
+}
+
+.am-local-item:hover .am-local-branch {
+  mask-image: linear-gradient(to right, black calc(100% - 40px), transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, black calc(100% - 40px), transparent 100%);
+}
+
+.am-worktree-item-active .am-shortcut-badge {
+  color: color-mix(in srgb, var(--text-on-interactive-base) 60%, transparent);
+}
+
+.am-worktree-item-active:hover .am-shortcut-badge {
+  opacity: 0.8;
+}
+
+.am-local-item-active .am-shortcut-badge {
+  color: var(--text-weak);
+}
+
+.am-worktree-item:has(.am-worktree-rename-input) .am-shortcut-badge {
+  opacity: 0;
+}
+
 .am-worktree-close {
   position: absolute;
   right: 4px;
@@ -232,8 +277,8 @@ button.am-section-toggle:hover .am-section-label {
 }
 
 .am-worktree-item:hover .am-worktree-branch {
-  mask-image: linear-gradient(to right, black calc(100% - 48px), transparent calc(100% - 16px));
-  -webkit-mask-image: linear-gradient(to right, black calc(100% - 48px), transparent calc(100% - 16px));
+  mask-image: linear-gradient(to right, black calc(100% - 72px), transparent calc(100% - 36px));
+  -webkit-mask-image: linear-gradient(to right, black calc(100% - 72px), transparent calc(100% - 36px));
 }
 
 .am-worktree-item:hover .am-worktree-close {

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1011,6 +1011,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "تبديل الفرق",
   "agentManager.shortcuts.toggleDiff": "تبديل لوحة الفرق",
+  "agentManager.shortcuts.category.quickSwitch": "التبديل السريع",
+  "agentManager.shortcuts.jumpToItem": "الانتقال إلى العنصر 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "الصق رابط PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1025,6 +1025,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Alternar diff",
   "agentManager.shortcuts.toggleDiff": "Alternar painel de diff",
+  "agentManager.shortcuts.category.quickSwitch": "Troca rápida",
+  "agentManager.shortcuts.jumpToItem": "Ir para o item 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Cole a URL do PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1047,6 +1047,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Prebaci diff",
   "agentManager.shortcuts.toggleDiff": "Prebaci panel za diff",
+  "agentManager.shortcuts.category.quickSwitch": "Brzo prebacivanje",
+  "agentManager.shortcuts.jumpToItem": "Idi na stavku 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Zalijepite PR URL...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1020,6 +1020,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Skift diff",
   "agentManager.shortcuts.toggleDiff": "Skift diff-panel",
+  "agentManager.shortcuts.category.quickSwitch": "Hurtigskift",
+  "agentManager.shortcuts.jumpToItem": "Hop til element 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Indsæt PR URL...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1034,6 +1034,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Diff umschalten",
   "agentManager.shortcuts.toggleDiff": "Diff-Panel umschalten",
+  "agentManager.shortcuts.category.quickSwitch": "Schnellwechsel",
+  "agentManager.shortcuts.jumpToItem": "Zu Element 1\u20139 springen",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "PR-URL einfügen...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1076,6 +1076,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Toggle diff",
   "agentManager.shortcuts.toggleDiff": "Toggle diff panel",
+  "agentManager.shortcuts.category.quickSwitch": "Quick Switch",
+  "agentManager.shortcuts.jumpToItem": "Jump to item 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Paste PR URL...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1028,6 +1028,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Alternar diff",
   "agentManager.shortcuts.toggleDiff": "Alternar panel de diff",
+  "agentManager.shortcuts.category.quickSwitch": "Cambio rápido",
+  "agentManager.shortcuts.jumpToItem": "Ir al elemento 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Pegar URL del PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1036,6 +1036,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Basculer le diff",
   "agentManager.shortcuts.toggleDiff": "Basculer le panneau de diff",
+  "agentManager.shortcuts.category.quickSwitch": "Changement rapide",
+  "agentManager.shortcuts.jumpToItem": "Aller à l'élément 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Coller l'URL du PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1016,6 +1016,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "差分を切り替え",
   "agentManager.shortcuts.toggleDiff": "差分パネルを切り替え",
+  "agentManager.shortcuts.category.quickSwitch": "クイック切り替え",
+  "agentManager.shortcuts.jumpToItem": "項目 1\u20139 に移動",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "PR URLを貼り付け...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1016,6 +1016,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "차이점 전환",
   "agentManager.shortcuts.toggleDiff": "차이점 패널 전환",
+  "agentManager.shortcuts.category.quickSwitch": "빠른 전환",
+  "agentManager.shortcuts.jumpToItem": "항목 1\u20139(으)로 이동",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "PR URL 붙여넣기...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1021,6 +1021,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Veksle diff",
   "agentManager.shortcuts.toggleDiff": "Veksle diff-panel",
+  "agentManager.shortcuts.category.quickSwitch": "Hurtigbytte",
+  "agentManager.shortcuts.jumpToItem": "Hopp til element 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Lim inn PR URL...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1023,6 +1023,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Przełącz diff",
   "agentManager.shortcuts.toggleDiff": "Przełącz panel diff",
+  "agentManager.shortcuts.category.quickSwitch": "Szybkie przełączanie",
+  "agentManager.shortcuts.jumpToItem": "Przejdź do elementu 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Wklej URL PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1024,6 +1024,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Переключить diff",
   "agentManager.shortcuts.toggleDiff": "Переключить панель diff",
+  "agentManager.shortcuts.category.quickSwitch": "Быстрое переключение",
+  "agentManager.shortcuts.jumpToItem": "Перейти к элементу 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Вставьте URL PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1009,6 +1009,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "สลับ diff",
   "agentManager.shortcuts.toggleDiff": "สลับแผง diff",
+  "agentManager.shortcuts.category.quickSwitch": "สลับด่วน",
+  "agentManager.shortcuts.jumpToItem": "ข้ามไปยังรายการ 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "วาง URL ของ PR...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1011,6 +1011,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "切换差异",
   "agentManager.shortcuts.toggleDiff": "切换差异面板",
+  "agentManager.shortcuts.category.quickSwitch": "快速切换",
+  "agentManager.shortcuts.jumpToItem": "跳转到项目 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "粘贴 PR URL...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1007,6 +1007,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "切換差異",
   "agentManager.shortcuts.toggleDiff": "切換差異面板",
+  "agentManager.shortcuts.category.quickSwitch": "快速切換",
+  "agentManager.shortcuts.jumpToItem": "跳至項目 1\u20139",
 
   "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "貼上 PR URL...",


### PR DESCRIPTION
## Summary

- Add `Cmd+1`–`Cmd+9` (Mac) / `Ctrl+1`–`Ctrl+9` (Windows/Linux) keyboard shortcuts to jump directly to sidebar items in the Agent Manager
- `Cmd+1` selects **Local**, `Cmd+2`–`Cmd+9` select worktrees in display order
- Shortcuts are scoped to the Agent Manager panel only (via `activeWebviewPanelId` when-clause)
- Hover-reveal shortcut badge on each sidebar item with a smooth `opacity` fade-in transition (matching Superset's design pattern)
- New **Quick Switch** category in the keyboard shortcuts dialog
- Full Windows/Linux support: `Ctrl+1`–`Ctrl+9` keybindings, platform-aware badge display and default bindings

<img width="738" height="254" alt="image" src="https://github.com/user-attachments/assets/f153242b-1c0b-4481-8ee7-f10f56f17d12" />
