### PR TITLE
fix(vscode): use npx instead of bunx for vsce in dev install script

### DIFF
--- a/packages/kilo-vscode/script/install-dev-extension.ts
+++ b/packages/kilo-vscode/script/install-dev-extension.ts
@@ -23,7 +23,7 @@ try {
   await $`bun run check-types`.cwd(root)
   await $`bun run lint`.cwd(root)
   await $`node ${join(root, "esbuild.js")} --production`.cwd(root)
-  await $`bunx @vscode/vsce package --no-dependencies --skip-license -o ${outDir}/`.cwd(root)
+  await $`npx -y @vscode/vsce package --no-dependencies --skip-license -o ${outDir}/`.cwd(root)
 } finally {
   await Bun.write(pkgPath, JSON.stringify(pkg, null, 2) + "\n")
 }


### PR DESCRIPTION
## Summary

- Replaces `bunx @vscode/vsce` with `npx -y @vscode/vsce` in `install-dev-extension.ts`
- `bunx` fails to resolve transitive dependencies (`buffer-crc32` via `yazl`) when downloading `@vscode/vsce` to a temp directory, causing `MODULE_NOT_FOUND` errors
- `-y` flag auto-confirms the npx install prompt so the script doesn't hang in non-interactive contexts