### PR TITLE
fix(agent-manager): filter sessions by project ID to prevent cross-repo leaks

### DIFF
--- a/packages/kilo-vscode/src/services/cli-backend/sse-utils.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/sse-utils.ts
@@ -14,3 +14,16 @@ export function unwrapSSEPayload(raw: unknown): SSEEvent | null {
   }
   return event
 }
+
+/**
+ * Check whether an SSE event belongs to a different project and should be dropped.
+ * Returns true when the event carries a projectID that does not match the expected one.
+ * When expectedProjectID is undefined (not yet resolved), nothing is filtered.
+ */
+export function isEventFromForeignProject(event: SSEEvent, expectedProjectID: string | undefined): boolean {
+  if (!expectedProjectID) return false
+  if (event.type === "session.created" || event.type === "session.updated") {
+    return event.properties.info.projectID !== expectedProjectID
+  }
+  return false
+}

--- a/packages/kilo-vscode/src/services/cli-backend/types.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/types.ts
@@ -1,6 +1,7 @@
 // Session types from @kilocode/cli
 export interface SessionInfo {
   id: string
+  projectID: string
   title: string
   directory: string
   parentID?: string

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -604,6 +604,18 @@ export const SessionProvider: ParentComponent = (props) => {
 
   function handleSessionsLoaded(loaded: SessionInfo[]) {
     batch(() => {
+      // Reconcile: remove sessions not in the loaded list to prevent stale
+      // entries from other projects accumulating in the store.
+      const ids = new Set(loaded.map((s) => s.id))
+      setStore(
+        "sessions",
+        produce((sessions) => {
+          for (const id of Object.keys(sessions)) {
+            if (id.startsWith("cloud:")) continue
+            if (!ids.has(id)) delete sessions[id]
+          }
+        }),
+      )
       for (const s of loaded) {
         setStore("sessions", s.id, s)
       }


### PR DESCRIPTION
## Summary

- Store the workspace `projectID` on `KiloProvider` and use it to reject SSE `session.created` events from other repositories, preventing cross-project session leaks into the Agent Manager
- Reconcile the webview session store on each `sessionsLoaded` bulk load — removes stale sessions that no longer belong to the current project instead of only appending
- Add the missing `projectID` field to the `SessionInfo` type definition for type safety

## How it works

The project ID is derived from the git root commit hash (`git rev-list --max-parents=0 --all`), so all worktrees of the same repo share the same ID. The backend already scopes `Session.list()` by `project_id`, but SSE events are broadcast globally. These changes close the gap on the extension side.