### PR TITLE
fix(agent-manager): prevent Cmd+F from breaking webview layout

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -719,14 +719,14 @@ const AgentManagerContent: Component = () => {
     }
     window.addEventListener("message", handler)
 
-    // Prevent Cmd+Arrow/T/W/N/digit from triggering native browser actions
+    // Prevent Cmd/Ctrl shortcuts from triggering native browser actions
     const preventDefaults = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return
       if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key)) {
         e.preventDefault()
       }
-      // Prevent browser defaults for our shortcuts (new tab, close tab, new window, toggle diff)
-      if (["t", "w", "n", "d"].includes(e.key.toLowerCase()) && !e.shiftKey) {
+      // Prevent browser defaults for our shortcuts (new tab, close tab, new window, toggle diff, find)
+      if (["t", "w", "n", "d", "f"].includes(e.key.toLowerCase()) && !e.shiftKey) {
         e.preventDefault()
       }
       // Prevent defaults for shift variants (close worktree, advanced new worktree)
@@ -738,7 +738,7 @@ const AgentManagerContent: Component = () => {
         e.preventDefault()
       }
     }
-    window.addEventListener("keydown", preventDefaults)
+    window.addEventListener("keydown", preventDefaults, true)
 
     // When the panel regains focus (e.g. returning from terminal), focus the prompt
     // and clear any stale body styles left by Kobalte modal overlays (dropdowns/dialogs
@@ -969,7 +969,7 @@ const AgentManagerContent: Component = () => {
 
     onCleanup(() => {
       window.removeEventListener("message", handler)
-      window.removeEventListener("keydown", preventDefaults)
+      window.removeEventListener("keydown", preventDefaults, true)
       window.removeEventListener("focus", onWindowFocus)
       unsubCreate()
       unsubSessions()


### PR DESCRIPTION
## Why
Pressing Cmd/Ctrl+F inside Agent Manager opened the native webview find UI, which shifted the layout and hid key interface elements.

## What changed
- Intercept Cmd/Ctrl shortcuts in Agent Manager keydown handling.
- Explicitly block browser default for `f` alongside existing Agent Manager shortcuts.
- Register the keydown handler in capture phase and mirror cleanup with the same capture option for reliable prevention before native find handling.

## Result
Cmd/Ctrl+F no longer triggers the native find widget in Agent Manager, so the UI remains stable and fully visible.