### PR TITLE
fix(ci): add GH_REPO env var to publish workflow steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,7 @@ jobs:
           ./script/version.ts
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           KILO_BUMP: ${{ inputs.bump }}
           KILO_VERSION: ${{ inputs.version }}
           KILO_API_KEY: ${{ secrets.KILO_API_KEY }}
@@ -312,6 +313,7 @@ jobs:
         env:
           KILO_VERSION: ${{ needs.version.outputs.version }}
           KILO_RELEASE: ${{ needs.version.outputs.release }}
+          GH_REPO: ${{ github.repository }}
           AUR_KEY: ${{ secrets.AUR_KEY }}
           GITHUB_TOKEN: ${{ steps.committer.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,6 +79,7 @@ jobs:
           KILO_VERSION: ${{ needs.version.outputs.version }}
           KILO_RELEASE: ${{ needs.version.outputs.release }}
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -116,6 +117,7 @@ jobs:
         env:
           CLI_DIST_DIR: ../../packages/opencode/dist
           KILO_VERSION: ${{ needs.build-cli.outputs.version }}
+          GH_REPO: ${{ github.repository }}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- Fixes `expected the "[HOST/]OWNER/REPO" format, got "undefined"` error in the publish workflow
- `GH_REPO` was used in `script/version.ts` and `script/publish.ts` (for `gh release create/view/edit --repo`) but was never passed as an environment variable in the workflow
- Added `GH_REPO: ${{ github.repository }}` to both the `version` job step and the `publish` job run step