### PR TITLE
Update SSO instructions

### DIFF
--- a/packages/kilo-docs/pages/collaborate/enterprise/sso.md
+++ b/packages/kilo-docs/pages/collaborate/enterprise/sso.md
@@ -11,13 +11,6 @@ Kilo Enterprise lets your organization securely manage access using **Single Sig
 **IDP-initiated logins are not currently supported.** Users must navigate to the [Kilo Web App](https://app.kilo.ai) to log in. Logging in directly from your identity provider's dashboard is not supported at this time.
 {% /callout %}
 
-## Why Enable SSO?
-
-- **Centralized access control:** Manage permissions through your existing identity provider.
-- **Faster onboarding:** New team members automatically gain access when added to your company directory.
-- **Improved security:** Enforce company-wide password, MFA, and session policies.
-- **Easy offboarding:** Smoothly remove access when users leave your organization.
-
 ## Prerequisites
 
 You’ll need:
@@ -25,7 +18,7 @@ You’ll need:
 - Admin or Owner permissions for your Kilo organization.
 - Access to your **Identity Provider (IdP)** (e.g. Okta, Google Workspace, Azure AD).
 
-## Step-by-Step Setup
+## Initiating SSO Configuration
 
 ### 1. Open [Organization](https://app.kilo.ai/organizations) Dashboard
 
@@ -36,10 +29,25 @@ Find the Single Sign-On (SSO) Configuration panel, and click "Set up SSO":
 
 Fill in your contact information and someone from our team will reach out soon to help you configure SSO.
 
-## ✅ Next Steps
+## Implementing SSO Configuration
+
+Once the Kilo team has enabled SSO for your organization, your named admin will get an email from WorkOS to configure SSO.
+
+{% callout type="warning" %}
+**Save domain policy for last.**
+
+If you configure domain policy before setting up SSO, you may lock users out of Kilo.
+{% /callout %}
+
+Your admin will need to use the WorkOS link to:
+
+1. Configure your Identity Provider Configuration in WorkOS.
+2. Copy the Service Provider details (Entity ID, ACS URL, and Metadata) from the WorkOS dashboard and apply them in your Identity Provider.
+3. Set the organization policy and user provisioning settings according to your organization's needs.
+4. Configure domain policy and domain verification in WorkOS.
 
 After enabling SSO:
 
 - Invite new users with their company email domain.
-- Manage team access and roles from the **[Organization](/docs/collaborate/adoption-dashboard/overview)** tab.
-- View user activity across the team in the **[Audit Logs](/docs/collaborate/enterprise/audit-logs)** tab
+- Manage team access and roles from the **[Organization](/docs/plans/dashboard)** tab.
+- View user activity across the team in the **[Audit Logs](/docs/plans/enterprise/audit-logs)** tab

--- a/packages/kilo-docs/pages/collaborate/enterprise/sso.md
+++ b/packages/kilo-docs/pages/collaborate/enterprise/sso.md
@@ -41,7 +41,7 @@ If you configure domain policy before setting up SSO, you may lock users out of 
 
 Your admin will need to use the WorkOS link to:
 
-###  Configure your Identity Provider in WorkOS
+### Configure your Identity Provider in WorkOS
 
 Find the Metadata in your Identity Provider and apply that configuration in WorkOS.
 

--- a/packages/kilo-docs/pages/collaborate/enterprise/sso.md
+++ b/packages/kilo-docs/pages/collaborate/enterprise/sso.md
@@ -41,13 +41,21 @@ If you configure domain policy before setting up SSO, you may lock users out of 
 
 Your admin will need to use the WorkOS link to:
 
-1. Configure your Identity Provider Configuration in WorkOS.
-2. Copy the Service Provider details (Entity ID, ACS URL, and Metadata) from the WorkOS dashboard and apply them in your Identity Provider.
-3. Set the organization policy and user provisioning settings according to your organization's needs.
-4. Configure domain policy and domain verification in WorkOS.
+###  Configure your Identity Provider in WorkOS
+
+Find the Metadata in your Identity Provider and apply that configuration in WorkOS.
+
+### Configure WorkOS in your Identity Provider
+
+Copy the Service Provider details (Entity ID, ACS URL, and Metadata) from the WorkOS dashboard and apply them in your Identity Provider.
+
+### Configure Policy and Domain Settings in WorkOS
+
+1. Set the organization policy and user provisioning settings according to your organization's needs.
+2. Configure domain policy and domain verification in WorkOS.
 
 After enabling SSO:
 
 - Invite new users with their company email domain.
 - Manage team access and roles from the **[Organization](/docs/plans/dashboard)** tab.
-- View user activity across the team in the **[Audit Logs](/docs/plans/enterprise/audit-logs)** tab
+- View user activity across the team in the **[Audit Logs](/docs/plans/enterprise/audit-logs)** tab.

--- a/packages/kilo-docs/pages/collaborate/enterprise/sso.md
+++ b/packages/kilo-docs/pages/collaborate/enterprise/sso.md
@@ -50,4 +50,4 @@ After enabling SSO:
 
 - Invite new users with their company email domain.
 - Manage team access and roles from the **[Organization](/docs/collaborate/adoption-dashboard/overview)** tab.
-- View user activity across the team in the **[Audit Logs](/docs/plans/enterprise/audit-logs)** tab
+- View user activity across the team in the **[Audit Logs](/docs/collaborate/enterprise/audit-logs)** tab

--- a/packages/kilo-docs/pages/collaborate/enterprise/sso.md
+++ b/packages/kilo-docs/pages/collaborate/enterprise/sso.md
@@ -41,15 +41,15 @@ If you configure domain policy before setting up SSO, you may lock users out of 
 
 Your admin will need to use the WorkOS link to:
 
-### Configure your Identity Provider in WorkOS
+### 1. Configure your Identity Provider in WorkOS
 
 Find the Metadata in your Identity Provider and apply that configuration in WorkOS.
 
-### Configure WorkOS in your Identity Provider
+### 2. Configure WorkOS in your Identity Provider
 
 Copy the Service Provider details (Entity ID, ACS URL, and Metadata) from the WorkOS dashboard and apply them in your Identity Provider.
 
-### Configure Policy and Domain Settings in WorkOS
+### 3. Configure Policy and Domain Settings in WorkOS
 
 1. Set the organization policy and user provisioning settings according to your organization's needs.
 2. Configure domain policy and domain verification in WorkOS.

--- a/packages/kilo-docs/pages/collaborate/enterprise/sso.md
+++ b/packages/kilo-docs/pages/collaborate/enterprise/sso.md
@@ -49,5 +49,5 @@ Your admin will need to use the WorkOS link to:
 After enabling SSO:
 
 - Invite new users with their company email domain.
-- Manage team access and roles from the **[Organization](/docs/plans/dashboard)** tab.
+- Manage team access and roles from the **[Organization](/docs/collaborate/adoption-dashboard/overview)** tab.
 - View user activity across the team in the **[Audit Logs](/docs/plans/enterprise/audit-logs)** tab


### PR DESCRIPTION
## Context

Our old SSO configuration instructions had basically no detail, and users could get themselves into a bad state by configuring domain before other attributes.