### PR TITLE
fix(tui): route mouse scroll to messages panel instead of input history

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -43,6 +43,7 @@ export type PromptProps = {
   ref?: (ref: PromptRef) => void
   hint?: JSX.Element
   showPlaceholder?: boolean
+  onScroll?: (direction: "up" | "down") => void
 }
 
 export type PromptRef = {
@@ -1007,6 +1008,14 @@ export function Prompt(props: PromptProps) {
                 }, 0)
               }}
               onMouseDown={(r: MouseEvent) => r.target?.focus()}
+              onMouseScroll={(e: MouseEvent) => {
+                if (!props.onScroll) return
+                const direction = e.scroll?.direction
+                if (direction === "up" || direction === "down") {
+                  e.preventDefault()
+                  props.onScroll(direction)
+                }
+              }}
               focusedBackgroundColor={theme.backgroundElement}
               cursorColor={theme.text}
               syntaxStyle={syntax()}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1135,6 +1135,9 @@ export function Session() {
                 onSubmit={() => {
                   toBottom()
                 }}
+                onScroll={(direction) => {
+                  scroll.scrollBy(direction === "up" ? -3 : 3)
+                }}
                 sessionID={route.sessionID}
               />
             </box>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1136,7 +1136,8 @@ export function Session() {
                   toBottom()
                 }}
                 onScroll={(direction) => {
-                  scroll.scrollBy(direction === "up" ? -3 : 3)
+                  const speed = scrollAcceleration().tick()
+                  scroll.scrollBy(direction === "up" ? -speed : speed)
                 }}
                 sessionID={route.sessionID}
               />


### PR DESCRIPTION
## Context

Closes #6310

Mouse scroll wheel on the input textarea was triggering command history navigation (up/down arrows) instead of scrolling the messages panel. This was unexpected UX - users intuitively expect scroll wheel to scroll content, not navigate history.

## Implementation

The OpenTUI framework routes mouse scroll events to the focused component. Since the `<textarea>` (prompt input) holds focus, scroll events were being consumed by it and triggering history navigation.

**Solution:**
1. Added `onScroll?: (direction: "up" | "down") => void` prop to the `Prompt` component
2. Added `onMouseScroll` handler to the textarea that:
   - Calls `e.preventDefault()` to stop the textarea from handling the event
   - Forwards the scroll direction to the parent via the callback
3. In the `Session` component, passed a handler that calls `scroll.scrollBy(direction === "up" ? -3 : 3)` - scrolling 3 lines (matching existing `CustomSpeedScroll(3)` default)

**Files changed:**
- `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx` - Added scroll interception
- `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx` - Wired up scroll handler

## How to Test

1. Open a session in the TUI (`kilo` or `kilo chat`)
2. Have multiple messages so the messages panel is scrollable
3. Focus the input textarea (click or type)
4. Use mouse scroll wheel
5. **Expected:** Messages panel scrolls up/down
6. **Also verify:** Up/down arrow keys still navigate command history when the cursor is at the start/end of input

## Get in Touch

aravhawk on [Kilo Code Discord](https://kilo.ai/discord)