### PR TITLE
fix(opencode): persist MCP server toggle state to config

### DIFF
--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -47,7 +47,8 @@ export namespace Filesystem {
     return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer
   }
 
-  function isEnoent(e: unknown): e is { code: "ENOENT" } {
+  export function isEnoent(e: unknown): e is { code: "ENOENT" } {
+    // kilocode_change: export for reuse
     return typeof e === "object" && e !== null && "code" in e && (e as { code: string }).code === "ENOENT"
   }
 


### PR DESCRIPTION
## Summary

- Toggling MCP servers via `connect()`/`disconnect()` in the CLI/TUI only modified runtime state - changes were lost on restart
- Adds `Config.update()` calls to persist `enabled: true/false` to the project-level config file
- Only persists on successful connection (when `mcpClient` is present) to avoid writing `enabled: true` for servers that failed to connect
- `Config.update` errors are caught and logged rather than propagated, so a disk write failure does not break the connect/disconnect flow

The fix is scoped to `packages/opencode/src/mcp/index.ts` - two `Config.update()` calls guarded by connection success and wrapped in error handling.

## How to Test

1. Run `bun dev` and configure an MCP server
2. Toggle the server off via the TUI
3. Restart the CLI
4. Verify the server remains disabled (check `config.json` for `"enabled": false`)
5. Toggle it back on, restart again - should stay enabled

Closes #6157