### PR TITLE
fix(vscode): surface CLI startup errors in VS Code UI

### DIFF
--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -14,6 +14,14 @@ export interface ServerInstance {
 export class ServerManager {
   private instance: ServerInstance | null = null
   private startupPromise: Promise<ServerInstance> | null = null
+  private _output: vscode.OutputChannel | undefined
+
+  private get output(): vscode.OutputChannel {
+    if (!this._output) {
+      this._output = vscode.window.createOutputChannel("Kilo CLI")
+    }
+    return this._output
+  }
 
   constructor(private readonly context: vscode.ExtensionContext) {}
 
@@ -38,6 +46,18 @@ export class ServerManager {
       this.instance = await this.startupPromise
       console.log("[Kilo New] ServerManager: ✅ Server started successfully:", { port: this.instance.port })
       return this.instance
+    } catch (error) {
+      const raw = error instanceof Error ? error.message : String(error)
+      const summary = (raw.length > 200 ? `${raw.slice(0, 200)}…` : raw).replace(/\n/g, " ")
+      this.output.appendLine(`[ERROR] CLI failed to start: ${raw}`)
+      void Promise.resolve(vscode.window.showErrorMessage(`Kilo: CLI failed to start. ${summary}`, "Show Output"))
+        .then((action) => {
+          if (action === "Show Output") {
+            this.output.show()
+          }
+        })
+        .catch((e: unknown) => console.error("[Kilo New] ServerManager: showErrorMessage failed:", e))
+      throw error
     } finally {
       this.startupPromise = null
     }
@@ -82,10 +102,14 @@ export class ServerManager {
       console.log("[Kilo New] ServerManager: 📦 Process spawned with PID:", serverProcess.pid)
 
       let resolved = false
+      const errors: string[] = []
+      let stderrChars = 0
+      const MAX_STDERR_CHARS = 65536
 
       serverProcess.stdout?.on("data", (data: Buffer) => {
         const output = data.toString()
         console.log("[Kilo New] ServerManager: 📥 CLI Server stdout:", output)
+        this.output.append(output)
 
         const port = parseServerPort(output)
         if (port !== null && !resolved) {
@@ -98,11 +122,17 @@ export class ServerManager {
       serverProcess.stderr?.on("data", (data: Buffer) => {
         const errorOutput = data.toString()
         console.error("[Kilo New] ServerManager: ⚠️ CLI Server stderr:", errorOutput)
+        if (stderrChars < MAX_STDERR_CHARS) {
+          errors.push(errorOutput)
+          stderrChars += errorOutput.length
+        }
+        this.output.append(`[stderr] ${errorOutput}`)
       })
 
       serverProcess.on("error", (error) => {
         console.error("[Kilo New] ServerManager: ❌ Process error:", error)
         if (!resolved) {
+          resolved = true
           reject(error)
         }
       })
@@ -113,16 +143,22 @@ export class ServerManager {
           this.instance = null
         }
         if (!resolved) {
-          reject(new Error(`CLI process exited with code ${code} before server started`))
+          resolved = true
+          const stderr = errors.join("").trim()
+          const detail = stderr ? `\n${stderr}` : ""
+          reject(new Error(`CLI process exited with code ${code} before server started${detail}`))
         }
       })
 
       // Timeout after 30 seconds
       setTimeout(() => {
         if (!resolved) {
+          resolved = true
           console.error("[Kilo New] ServerManager: ⏰ Server startup timeout (30s)")
           serverProcess.kill()
-          reject(new Error("Server startup timeout"))
+          const stderr = errors.join("").trim()
+          const detail = stderr ? `\n${stderr}` : ""
+          reject(new Error(`Server startup timeout${detail}`))
         }
       }, 30000)
     })
@@ -141,5 +177,7 @@ export class ServerManager {
       this.instance.process.kill("SIGTERM")
       this.instance = null
     }
+    this._output?.dispose()
+    this._output = undefined
   }
 }


### PR DESCRIPTION
## Summary

- CLI startup errors were silently swallowed - when the CLI process failed to start (wrong bun version, missing deps, port conflict), the user saw no feedback in VS Code
- Adds a lazy-initialized `OutputChannel("Kilo CLI")` that captures stdout and stderr from the CLI process, only created when output is first written
- When the CLI exits before the server starts, stderr is included in the error message so the user sees the actual failure reason
- Shows a non-blocking error notification with a "Show Output" action to open the full log
- stderr accumulation is capped at 100 chunks to prevent unbounded memory growth on long-lived processes

All changes in `packages/kilo-vscode/src/services/cli-backend/server-manager.ts`.

## How to Test

1. Break the CLI intentionally (e.g. delete `node_modules` in `packages/opencode`, or set a wrong bun version)
2. Open VS Code with the extension
3. Try to use Kilo - the CLI will fail to start
4. You should see an error notification with the actual error message and a "Show Output" button
5. Clicking "Show Output" opens the Kilo CLI output channel with full stdout/stderr

Closes #6146