### PR TITLE
fix: constrain mode switcher popover width to prevent overflow

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -52,6 +52,7 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
         onOpenChange={setOpen}
         triggerAs={Button}
         triggerProps={{ variant: "ghost", size: "small" }}
+        class="mode-switcher-popover"
         trigger={
           <>
             <span class="mode-switcher-trigger-label">{triggerLabel()}</span>

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -637,6 +637,11 @@
   text-transform: capitalize;
 }
 
+.mode-switcher-popover {
+  width: 280px;
+  max-width: 280px;
+}
+
 .mode-switcher-list {
   max-height: 280px;
   overflow-y: auto;


### PR DESCRIPTION
## Context

When selecting modes (Code, Ask, Review), the mode switcher dropdown menu items extend beyond the popover container bounds because no width constraint was set.

## Implementation

Added a `mode-switcher-popover` class to the Popover content with `width: 280px` and `max-width: 280px`, following the same pattern used by the model selector popover. This constrains the dropdown width and prevents overflow.

**Changes:**
- `ModeSwitcher.tsx`: Added `class="mode-switcher-popover"` to the Popover component
- `chat.css`: Added `.mode-switcher-popover` style with width constraints

## Screenshots

| before | after |
| ------ | ----- |
| Menu items extend beyond popover | Items contained within popover bounds |

## How to Test

1. Open Kilo Code in VSCode
2. Click the mode selector (Code/Ask/Review) in the chat input area
3. Verify all menu items are contained within the dropdown bounds
4. Verify item descriptions are properly truncated with ellipsis

## Get in Touch

N/A

Closes #6446