### PR TITLE
fix: show actual command in CLI shell permission prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -139,7 +139,7 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
     if (!tool) return {}
     const parts = sync.data.part[tool.messageID] ?? []
     for (const part of parts) {
-      if (part.type === "tool" && part.callID === tool.callID && part.state.status !== "pending") {
+      if (part.type === "tool" && part.callID === tool.callID) {
         return part.state.input ?? {}
       }
     }


### PR DESCRIPTION
## Context

The CLI shell permission prompt displays only `$` instead of the actual command being requested for approval.

## Implementation

The permission prompt reads tool input to display the command. However, it was filtering out tools in `pending` state (`part.state.status !== "pending"`). Since permissions are asked *while* the tool is still in pending state (before execution begins), the input lookup always returned `{}`, making the command string empty.

Removed the `pending` status filter. The `input` field is available in all tool states (pending, running, completed, error) per the `ToolStatePending` schema, so this is safe.

**Changed file:** `packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx`

## Screenshots

| before | after |
| ------ | ----- |
| Permission prompt shows only `$` | Permission prompt shows `$ <actual command>` |

## How to Test

1. Run `bun dev` to start the CLI
2. Trigger a tool call that requires shell permission (e.g., ask the agent to run a command)
3. Verify the permission prompt shows the actual command after `$`

## Get in Touch

N/A

Closes #6416