### PR TITLE
fix: anchor regex patterns in MCP tool JSON schemas

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -126,8 +126,16 @@ export namespace MCP {
     if (typeof result.pattern === "string") {
       // Guard against escaped \^ or \$ being mistaken for anchors.
       // Account for even-length backslash sequences (e.g. \\$ is a real anchor, \$ is not).
-      if (!/^\^/.test(result.pattern)) result.pattern = "^" + result.pattern
-      if (!/(^|[^\\])(\\\\)*\$$/.test(result.pattern)) result.pattern = result.pattern + "$"
+      const hasStart = /^\^/.test(result.pattern)
+      const hasEnd = /(^|[^\\])(\\\\)*\$$/.test(result.pattern)
+      if (!hasStart && !hasEnd && result.pattern.includes("|")) {
+        // Wrap in non-capturing group to preserve alternation semantics
+        // e.g. "foo|bar" → "^(?:foo|bar)$" not "^foo|bar$"
+        result.pattern = "^(?:" + result.pattern + ")$"
+      } else {
+        if (!hasStart) result.pattern = "^" + result.pattern
+        if (!hasEnd) result.pattern = result.pattern + "$"
+      }
     }
 
     if (result.properties) {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -117,6 +117,28 @@ export namespace MCP {
   }
 
   // kilocode_change start - Anchor regex patterns for providers that require ^/$ (e.g. llama.cpp)
+  // Check for unescaped `|` at the top level of a regex pattern (not inside [...] or (...)).
+  function hasTopLevelAlternation(pattern: string): boolean {
+    let inCharClass = false
+    let depth = 0
+    for (let i = 0; i < pattern.length; i++) {
+      const ch = pattern[i]
+      if (ch === "\\") {
+        i++
+        continue
+      }
+      if (inCharClass) {
+        if (ch === "]") inCharClass = false
+        continue
+      }
+      if (ch === "[") inCharClass = true
+      else if (ch === "(") depth++
+      else if (ch === ")" && depth > 0) depth--
+      else if (ch === "|" && depth === 0) return true
+    }
+    return false
+  }
+
   // Recursively anchor regex patterns in JSON schemas.
   // Some providers (e.g. llama.cpp) require patterns to start with ^ and end with $.
   export function anchorPatterns(schema: JSONSchema7): JSONSchema7 {
@@ -128,7 +150,7 @@ export namespace MCP {
       // Account for even-length backslash sequences (e.g. \\$ is a real anchor, \$ is not).
       const hasStart = /^\^/.test(result.pattern)
       const hasEnd = /(^|[^\\])(\\\\)*\$$/.test(result.pattern)
-      if (result.pattern.includes("|") && (!hasStart || !hasEnd)) {
+      if (hasTopLevelAlternation(result.pattern) && (!hasStart || !hasEnd)) {
         // Wrap in non-capturing group to preserve alternation semantics.
         // Applies to unanchored ("foo|bar"), and partially-anchored ("^foo|bar", "foo|bar$")
         // patterns — naively prepending/appending anchors would change regex semantics.

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -116,16 +116,18 @@ export namespace MCP {
     })
   }
 
+  // kilocode_change start - Anchor regex patterns for providers that require ^/$ (e.g. llama.cpp)
   // Recursively anchor regex patterns in JSON schemas.
   // Some providers (e.g. llama.cpp) require patterns to start with ^ and end with $.
-  function anchorPatterns(schema: JSONSchema7): JSONSchema7 {
+  export function anchorPatterns(schema: JSONSchema7): JSONSchema7 {
     if (!schema || typeof schema !== "object") return schema
     const result = { ...schema }
 
     if (typeof result.pattern === "string") {
-      // Guard against escaped \$ or \^ being mistaken for anchors
-      if (!result.pattern.startsWith("^")) result.pattern = "^" + result.pattern
-      if (!/(^|[^\\])\$$/.test(result.pattern)) result.pattern = result.pattern + "$"
+      // Guard against escaped \^ or \$ being mistaken for anchors.
+      // Account for even-length backslash sequences (e.g. \\$ is a real anchor, \$ is not).
+      if (!/^\^/.test(result.pattern)) result.pattern = "^" + result.pattern
+      if (!/(^|[^\\])(\\\\)*\$$/.test(result.pattern)) result.pattern = result.pattern + "$"
     }
 
     if (result.properties) {
@@ -187,13 +189,14 @@ export namespace MCP {
 
     return result
   }
+  // kilocode_change end
 
   // Convert MCP tool definition to AI SDK Tool type
   async function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number): Promise<Tool> {
     const inputSchema = mcpTool.inputSchema
 
     // Spread first, then override type to ensure it's always "object"
-    const schema: JSONSchema7 = anchorPatterns({
+    const schema: JSONSchema7 = anchorPatterns({ // kilocode_change - anchor patterns for llama.cpp compatibility
       ...(inputSchema as JSONSchema7),
       type: "object",
       properties: (inputSchema.properties ?? {}) as JSONSchema7["properties"],

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -123,8 +123,9 @@ export namespace MCP {
     const result = { ...schema }
 
     if (typeof result.pattern === "string") {
+      // Guard against escaped \$ or \^ being mistaken for anchors
       if (!result.pattern.startsWith("^")) result.pattern = "^" + result.pattern
-      if (!result.pattern.endsWith("$")) result.pattern = result.pattern + "$"
+      if (!/(^|[^\\])\$$/.test(result.pattern)) result.pattern = result.pattern + "$"
     }
 
     if (result.properties) {
@@ -135,15 +136,52 @@ export namespace MCP {
       result.properties = props
     }
 
+    if (result.patternProperties) {
+      const pp: Record<string, JSONSchema7> = {}
+      for (const [key, value] of Object.entries(result.patternProperties)) {
+        pp[key] = anchorPatterns(value as JSONSchema7)
+      }
+      result.patternProperties = pp
+    }
+
+    if (typeof result.additionalProperties === "object" && result.additionalProperties !== null) {
+      result.additionalProperties = anchorPatterns(result.additionalProperties as JSONSchema7)
+    }
+
     if (result.items) {
       result.items = Array.isArray(result.items)
         ? result.items.map((item) => anchorPatterns(item as JSONSchema7))
         : anchorPatterns(result.items as JSONSchema7)
     }
 
+    if (typeof result.contains === "object" && result.contains !== null) {
+      result.contains = anchorPatterns(result.contains as JSONSchema7)
+    }
+
+    if (typeof result.not === "object" && result.not !== null) {
+      result.not = anchorPatterns(result.not as JSONSchema7)
+    }
+
     for (const key of ["anyOf", "oneOf", "allOf"] as const) {
       if (Array.isArray(result[key])) {
         ;(result as any)[key] = (result[key] as JSONSchema7[]).map((s) => anchorPatterns(s))
+      }
+    }
+
+    for (const key of ["if", "then", "else"] as const) {
+      if (typeof (result as any)[key] === "object" && (result as any)[key] !== null) {
+        ;(result as any)[key] = anchorPatterns((result as any)[key] as JSONSchema7)
+      }
+    }
+
+    for (const key of ["definitions", "$defs"] as const) {
+      const defs = (result as any)[key]
+      if (typeof defs === "object" && defs !== null) {
+        const out: Record<string, JSONSchema7> = {}
+        for (const [k, v] of Object.entries(defs)) {
+          out[k] = anchorPatterns(v as JSONSchema7)
+        }
+        ;(result as any)[key] = out
       }
     }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -128,10 +128,12 @@ export namespace MCP {
       // Account for even-length backslash sequences (e.g. \\$ is a real anchor, \$ is not).
       const hasStart = /^\^/.test(result.pattern)
       const hasEnd = /(^|[^\\])(\\\\)*\$$/.test(result.pattern)
-      if (!hasStart && !hasEnd && result.pattern.includes("|")) {
-        // Wrap in non-capturing group to preserve alternation semantics
-        // e.g. "foo|bar" → "^(?:foo|bar)$" not "^foo|bar$"
-        result.pattern = "^(?:" + result.pattern + ")$"
+      if (result.pattern.includes("|") && (!hasStart || !hasEnd)) {
+        // Wrap in non-capturing group to preserve alternation semantics.
+        // Applies to unanchored ("foo|bar"), and partially-anchored ("^foo|bar", "foo|bar$")
+        // patterns — naively prepending/appending anchors would change regex semantics.
+        const inner = result.pattern.replace(/^\^/, "").replace(/(^|[^\\])(\\\\)*\$$/, "$1$2")
+        result.pattern = "^(?:" + inner + ")$"
       } else {
         if (!hasStart) result.pattern = "^" + result.pattern
         if (!hasEnd) result.pattern = result.pattern + "$"

--- a/packages/opencode/test/mcp/anchor-patterns.test.ts
+++ b/packages/opencode/test/mcp/anchor-patterns.test.ts
@@ -1,0 +1,162 @@
+import { test, expect, describe } from "bun:test"
+import { MCP } from "../../src/mcp/index"
+import type { JSONSchema7 } from "ai"
+
+const anchorPatterns = MCP.anchorPatterns
+
+describe("anchorPatterns", () => {
+  test("adds anchors to unanchored pattern", () => {
+    const schema: JSONSchema7 = { type: "string", pattern: "[a-z]+" }
+    const result = anchorPatterns(schema)
+    expect(result.pattern).toBe("^[a-z]+$")
+  })
+
+  test("leaves already-anchored pattern unchanged", () => {
+    const schema: JSONSchema7 = { type: "string", pattern: "^[a-z]+$" }
+    const result = anchorPatterns(schema)
+    expect(result.pattern).toBe("^[a-z]+$")
+  })
+
+  test("adds only missing anchor", () => {
+    expect(anchorPatterns({ pattern: "^foo" } as JSONSchema7).pattern).toBe("^foo$")
+    expect(anchorPatterns({ pattern: "foo$" } as JSONSchema7).pattern).toBe("^foo$")
+  })
+
+  test("handles escaped \\$ (literal dollar) — should add anchor", () => {
+    const schema: JSONSchema7 = { pattern: "price\\$" }
+    const result = anchorPatterns(schema)
+    expect(result.pattern).toBe("^price\\$$")
+  })
+
+  test("handles \\\\$ (escaped backslash + real anchor) — should not add anchor", () => {
+    const schema: JSONSchema7 = { pattern: "foo\\\\$" }
+    const result = anchorPatterns(schema)
+    expect(result.pattern).toBe("^foo\\\\$")
+  })
+
+  test("returns non-object schema as-is", () => {
+    expect(anchorPatterns(null as any)).toBeNull()
+    expect(anchorPatterns(undefined as any)).toBeUndefined()
+  })
+
+  test("recurses into properties", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      properties: {
+        name: { type: "string", pattern: "[a-z]+" },
+      },
+    }
+    const result = anchorPatterns(schema)
+    expect((result.properties!.name as JSONSchema7).pattern).toBe("^[a-z]+$")
+  })
+
+  test("recurses into items (single schema)", () => {
+    const schema: JSONSchema7 = {
+      type: "array",
+      items: { type: "string", pattern: "\\d+" },
+    }
+    const result = anchorPatterns(schema)
+    expect((result.items as JSONSchema7).pattern).toBe("^\\d+$")
+  })
+
+  test("recurses into items (tuple array)", () => {
+    const schema: JSONSchema7 = {
+      type: "array",
+      items: [{ type: "string", pattern: "[a-z]+" }],
+    }
+    const result = anchorPatterns(schema)
+    expect((result.items as JSONSchema7[])[0].pattern).toBe("^[a-z]+$")
+  })
+
+  test("recurses into additionalProperties", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      additionalProperties: { type: "string", pattern: "[0-9]+" },
+    }
+    const result = anchorPatterns(schema)
+    expect((result.additionalProperties as JSONSchema7).pattern).toBe("^[0-9]+$")
+  })
+
+  test("recurses into anyOf/oneOf/allOf", () => {
+    const schema: JSONSchema7 = {
+      anyOf: [{ pattern: "a+" }],
+      oneOf: [{ pattern: "b+" }],
+      allOf: [{ pattern: "c+" }],
+    }
+    const result = anchorPatterns(schema)
+    expect((result.anyOf![0] as JSONSchema7).pattern).toBe("^a+$")
+    expect((result.oneOf![0] as JSONSchema7).pattern).toBe("^b+$")
+    expect((result.allOf![0] as JSONSchema7).pattern).toBe("^c+$")
+  })
+
+  test("recurses into not", () => {
+    const schema: JSONSchema7 = {
+      not: { pattern: "bad" },
+    }
+    const result = anchorPatterns(schema)
+    expect((result.not as JSONSchema7).pattern).toBe("^bad$")
+  })
+
+  test("recurses into if/then/else", () => {
+    const schema: any = {
+      if: { pattern: "a" },
+      then: { pattern: "b" },
+      else: { pattern: "c" },
+    }
+    const result = anchorPatterns(schema) as any
+    expect(result.if.pattern).toBe("^a$")
+    expect(result.then.pattern).toBe("^b$")
+    expect(result.else.pattern).toBe("^c$")
+  })
+
+  test("recurses into definitions/$defs", () => {
+    const schema: any = {
+      definitions: { foo: { pattern: "x+" } },
+      $defs: { bar: { pattern: "y+" } },
+    }
+    const result = anchorPatterns(schema) as any
+    expect(result.definitions.foo.pattern).toBe("^x+$")
+    expect(result.$defs.bar.pattern).toBe("^y+$")
+  })
+
+  test("recurses into patternProperties", () => {
+    const schema: JSONSchema7 = {
+      patternProperties: {
+        "^S_": { type: "string", pattern: "[a-z]+" },
+      },
+    }
+    const result = anchorPatterns(schema)
+    expect((result.patternProperties!["^S_"] as JSONSchema7).pattern).toBe("^[a-z]+$")
+  })
+
+  test("recurses into contains", () => {
+    const schema: JSONSchema7 = {
+      contains: { pattern: "item" },
+    }
+    const result = anchorPatterns(schema)
+    expect((result.contains as JSONSchema7).pattern).toBe("^item$")
+  })
+
+  test("handles deeply nested schemas", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      properties: {
+        nested: {
+          type: "object",
+          properties: {
+            deep: { type: "string", pattern: "[0-9a-f]+" },
+          },
+        },
+      },
+    }
+    const result = anchorPatterns(schema)
+    const deep = (result.properties!.nested as JSONSchema7).properties!.deep as JSONSchema7
+    expect(deep.pattern).toBe("^[0-9a-f]+$")
+  })
+
+  test("does not mutate original schema", () => {
+    const original: JSONSchema7 = { type: "string", pattern: "[a-z]+" }
+    anchorPatterns(original)
+    expect(original.pattern).toBe("[a-z]+")
+  })
+})

--- a/packages/opencode/test/mcp/anchor-patterns.test.ts
+++ b/packages/opencode/test/mcp/anchor-patterns.test.ts
@@ -196,6 +196,30 @@ describe("anchorPatterns", () => {
     expect((result.properties!.name as JSONSchema7).pattern).toBe("^[a-z]+$")
   })
 
+  test("does not wrap pipe inside character class", () => {
+    const schema: JSONSchema7 = { pattern: "[a|b]+" }
+    const result = anchorPatterns(schema)
+    expect(result.pattern).toBe("^[a|b]+$")
+  })
+
+  test("does not wrap alternation fully inside a group", () => {
+    const schema: JSONSchema7 = { pattern: "(foo|bar)" }
+    const result = anchorPatterns(schema)
+    expect(result.pattern).toBe("^(foo|bar)$")
+  })
+
+  test("wraps when top-level alternation exists alongside groups", () => {
+    const schema: JSONSchema7 = { pattern: "(foo|bar)|baz" }
+    const result = anchorPatterns(schema)
+    expect(result.pattern).toBe("^(?:(foo|bar)|baz)$")
+  })
+
+  test("does not wrap escaped pipe", () => {
+    const schema: JSONSchema7 = { pattern: "foo\\|bar" }
+    const result = anchorPatterns(schema)
+    expect(result.pattern).toBe("^foo\\|bar$")
+  })
+
   test("does not mutate original schema", () => {
     const original: JSONSchema7 = { type: "string", pattern: "[a-z]+" }
     anchorPatterns(original)

--- a/packages/opencode/test/mcp/anchor-patterns.test.ts
+++ b/packages/opencode/test/mcp/anchor-patterns.test.ts
@@ -154,6 +154,36 @@ describe("anchorPatterns", () => {
     expect(deep.pattern).toBe("^[0-9a-f]+$")
   })
 
+  test("wraps top-level alternation in non-capturing group", () => {
+    const schema: JSONSchema7 = { pattern: "foo|bar" }
+    const result = anchorPatterns(schema)
+    expect(result.pattern).toBe("^(?:foo|bar)$")
+  })
+
+  test("wraps complex alternation in non-capturing group", () => {
+    const schema: JSONSchema7 = { pattern: "error|warn|info" }
+    const result = anchorPatterns(schema)
+    expect(result.pattern).toBe("^(?:error|warn|info)$")
+  })
+
+  test("does not wrap alternation when already anchored", () => {
+    const schema: JSONSchema7 = { pattern: "^foo|bar$" }
+    const result = anchorPatterns(schema)
+    // Only missing end anchor, so no group wrapping needed
+    expect(result.pattern).toBe("^foo|bar$")
+  })
+
+  test("skips additionalProperties when boolean", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      properties: { name: { type: "string", pattern: "[a-z]+" } },
+      additionalProperties: false,
+    }
+    const result = anchorPatterns(schema)
+    expect(result.additionalProperties).toBe(false)
+    expect((result.properties!.name as JSONSchema7).pattern).toBe("^[a-z]+$")
+  })
+
   test("does not mutate original schema", () => {
     const original: JSONSchema7 = { type: "string", pattern: "[a-z]+" }
     anchorPatterns(original)

--- a/packages/opencode/test/mcp/anchor-patterns.test.ts
+++ b/packages/opencode/test/mcp/anchor-patterns.test.ts
@@ -166,11 +166,23 @@ describe("anchorPatterns", () => {
     expect(result.pattern).toBe("^(?:error|warn|info)$")
   })
 
-  test("does not wrap alternation when already anchored", () => {
+  test("does not modify alternation when already fully anchored", () => {
     const schema: JSONSchema7 = { pattern: "^foo|bar$" }
     const result = anchorPatterns(schema)
-    // Only missing end anchor, so no group wrapping needed
+    // Both anchors detected (hasStart=true, hasEnd=true), so no modification needed
     expect(result.pattern).toBe("^foo|bar$")
+  })
+
+  test("wraps partially-anchored alternation with start anchor only", () => {
+    const schema: JSONSchema7 = { pattern: "^foo|bar" }
+    const result = anchorPatterns(schema)
+    expect(result.pattern).toBe("^(?:foo|bar)$")
+  })
+
+  test("wraps partially-anchored alternation with end anchor only", () => {
+    const schema: JSONSchema7 = { pattern: "foo|bar$" }
+    const result = anchorPatterns(schema)
+    expect(result.pattern).toBe("^(?:foo|bar)$")
   })
 
   test("skips additionalProperties when boolean", () => {


### PR DESCRIPTION
## Context

Some LLM providers (e.g. llama.cpp) require JSON schema `pattern` properties to be anchored with `^` and `$`. When MCP servers provide unanchored patterns, the provider returns `400 JSON schema conversion failed: Pattern must start with '^' and end with '$'`.

This was reported with chrome-devtools-mcp v1.8.0 and local llama.cpp models. While MCP 1.8.1 fixed their patterns, Kilo should handle unanchored patterns defensively.

## Implementation

Added a recursive `anchorPatterns` function that normalizes all `pattern` properties in the tool input schema before passing it to the AI SDK. The function:

- Adds `^` prefix if missing
- Adds `$` suffix if missing
- Recursively traverses `properties`, `items`, `anyOf`, `oneOf`, and `allOf`

Applied during `convertMcpTool` so all MCP tool schemas are sanitized at registration time.

## Screenshots

N/A — backend fix

## How to Test

1. Configure an MCP server that provides JSON schema patterns without `^`/`$` anchors
2. Use a local llama.cpp backend
3. Send a message that triggers the MCP tool
4. Verify no 400 error occurs

## Get in Touch

N/A

Closes #6379