### PR TITLE
KiloSessions - Add debug logging for session ingest flush

### DIFF
--- a/packages/opencode/src/kilo-sessions/ingest-queue.ts
+++ b/packages/opencode/src/kilo-sessions/ingest-queue.ts
@@ -227,8 +227,7 @@ export namespace IngestQueue {
 
           const delay = backoff(count)
           retry.set(sessionId, { count, until: now() + delay })
-          options.log.info?.("ingest flush retry", { sessionId, attempt: count, delayMs: delay })
-          options.log.error("share sync failed", { sessionId, error: "network", retryInMs: delay })
+          options.log.error("share sync failed", { sessionId, error: "network", attempt: count, retryInMs: delay })
           enqueue(sessionId, items, "fill", now() + delay)
           return
         }
@@ -272,11 +271,11 @@ export namespace IngestQueue {
 
         const delay = backoff(count)
         retry.set(sessionId, { count, until: now() + delay })
-        options.log.info?.("ingest flush retry", { sessionId, attempt: count, delayMs: delay })
         options.log.error("share sync failed", {
           sessionId,
           status: response.status,
           statusText: response.statusText,
+          attempt: count,
           retryInMs: delay,
         })
         enqueue(sessionId, items, "fill", now() + delay)

--- a/packages/opencode/src/kilo-sessions/ingest-queue.ts
+++ b/packages/opencode/src/kilo-sessions/ingest-queue.ts
@@ -199,13 +199,15 @@ export namespace IngestQueue {
         const client = await options.getClient()
         if (!client) return
 
-        const types = items.map((d) => d.type).join(",")
-        options.log.info?.("ingest flush", {
-          sessionId,
-          url: `${client.url}${share.ingestPath}?v=1`,
-          items: items.length,
-          types,
-        })
+        if (options.log.info) {
+          const types = items.map((d) => d.type).join(",")
+          options.log.info("ingest flush", {
+            sessionId,
+            url: `${client.url}${share.ingestPath}?v=1`,
+            items: items.length,
+            types,
+          })
+        }
 
         const response = await client
           .fetch(`${client.url}${share.ingestPath}?v=1`, {
@@ -293,8 +295,10 @@ export namespace IngestQueue {
       const client = await options.getClient()
       if (!client) return
 
-      const types = data.map((d) => d.type).join(",")
-      options.log.info?.("ingest sync", { sessionId, types })
+      if (options.log.info) {
+        const types = data.map((d) => d.type).join(",")
+        options.log.info("ingest sync", { sessionId, types })
+      }
 
       const until = retry.get(sessionId)?.until ?? 0
       const base = queue.get(sessionId)?.due ?? now() + 1000

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -107,20 +107,25 @@ export namespace KiloSessions {
     })
   }
 
+  const shareDisabled = process.env["KILO_DISABLE_SHARE"] === "true" || process.env["KILO_DISABLE_SHARE"] === "1"
+  const ingestDisabled =
+    process.env["KILO_DISABLE_SESSION_INGEST"] === "true" || process.env["KILO_DISABLE_SESSION_INGEST"] === "1"
+  const debugIngest =
+    process.env["KILO_DEBUG_SESSION_INGEST"] === "true" || process.env["KILO_DEBUG_SESSION_INGEST"] === "1"
+
   const ingest = IngestQueue.create({
     getShare: async (sessionId) => get(sessionId).catch(() => undefined),
     getClient,
-    log,
+    log: {
+      ...(debugIngest ? { info: log.info.bind(log) } : {}),
+      error: log.error.bind(log),
+    },
     onAuthError: () => {
       // Non-retryable until credentials are fixed.
       // Clearing caches prevents repeated use of a now-invalid token/client.
       clearCache()
     },
   })
-
-  const shareDisabled = process.env["KILO_DISABLE_SHARE"] === "true" || process.env["KILO_DISABLE_SHARE"] === "1"
-  const ingestDisabled =
-    process.env["KILO_DISABLE_SESSION_INGEST"] === "true" || process.env["KILO_DISABLE_SESSION_INGEST"] === "1"
 
   export async function init() {
     if (ingestDisabled) return


### PR DESCRIPTION
## Summary
- Add optional `info` log handler to `IngestQueue` for tracing sync/flush/retry lifecycle events
- Gate debug logging behind `KILO_DEBUG_SESSION_INGEST` env var so it's silent by default
- Log ingest sync entry, flush request (with URL, item count, types), flush success, and retry attempts with backoff delay