### PR TITLE
Add .gitattributes for Git LFS tracking

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Git LFS tracking for binary/media files
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Why

The repo uses Git LFS for `.gif` and `.mp4` files in `kilo-docs`, but had no `.gitattributes` file. Without it, LFS tracking rules only exist locally on whoever ran `git lfs track` — new contributors and CI won't know which files belong in LFS.

## What

Adds a `.gitattributes` that codifies what's already in LFS on `main`:

- `*.gif` — animated docs images
- `*.mp4` — docs videos

Scoped to match actual LFS usage on `main`. The visual regression `.png` snapshots (on an unmerged branch) can be added when that lands.