### PR TITLE
fix: change Agent Manager nav shortcuts to Cmd+Alt+Arrow to avoid text editing conflict

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -399,26 +399,26 @@
       },
       {
         "command": "kilo-code.new.agentManager.previousSession",
-        "key": "ctrl+up",
-        "mac": "cmd+up",
+        "key": "ctrl+alt+up",
+        "mac": "cmd+alt+up",
         "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
       },
       {
         "command": "kilo-code.new.agentManager.nextSession",
-        "key": "ctrl+down",
-        "mac": "cmd+down",
+        "key": "ctrl+alt+down",
+        "mac": "cmd+alt+down",
         "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
       },
       {
         "command": "kilo-code.new.agentManager.previousTab",
-        "key": "ctrl+left",
-        "mac": "cmd+left",
+        "key": "ctrl+alt+left",
+        "mac": "cmd+alt+left",
         "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
       },
       {
         "command": "kilo-code.new.agentManager.nextTab",
-        "key": "ctrl+right",
-        "mac": "cmd+right",
+        "key": "ctrl+alt+right",
+        "mac": "cmd+alt+right",
         "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
       },
       {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -106,10 +106,10 @@ const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigat
 const MAX_JUMP_INDEX = 9
 
 const defaultBindings: Record<string, string> = {
-  previousSession: isMac ? "⌘↑" : "Ctrl+↑",
-  nextSession: isMac ? "⌘↓" : "Ctrl+↓",
-  previousTab: isMac ? "⌘←" : "Ctrl+←",
-  nextTab: isMac ? "⌘→" : "Ctrl+→",
+  previousSession: isMac ? "⌘⌥↑" : "Ctrl+Alt+↑",
+  nextSession: isMac ? "⌘⌥↓" : "Ctrl+Alt+↓",
+  previousTab: isMac ? "⌘⌥←" : "Ctrl+Alt+←",
+  nextTab: isMac ? "⌘⌥→" : "Ctrl+Alt+→",
   showTerminal: isMac ? "⌘/" : "Ctrl+/",
   newTab: isMac ? "⌘T" : "Ctrl+T",
   closeTab: isMac ? "⌘W" : "Ctrl+W",
@@ -624,7 +624,7 @@ const AgentManagerContent: Component = () => {
     if (el instanceof HTMLElement) scrollIntoView(el)
   }
 
-  // Navigate tabs with Cmd+Left/Right
+  // Navigate tabs with Cmd+Alt+Left/Right
   const navigateTab = (direction: "left" | "right") => {
     const ids = tabIds()
     if (ids.length === 0) return
@@ -727,7 +727,8 @@ const AgentManagerContent: Component = () => {
     // Prevent Cmd/Ctrl shortcuts from triggering native browser actions
     const preventDefaults = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return
-      if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key)) {
+      // Arrow navigation requires Alt modifier (Cmd+Alt+Arrow for tabs/sessions)
+      if (e.altKey && ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key)) {
         e.preventDefault()
       }
       // Prevent browser defaults for our shortcuts (new tab, close tab, new window, toggle diff, find)


### PR DESCRIPTION
- Changes Agent Manager tab switching from `Cmd+Left/Right` to `Cmd+Alt+Left/Right` and session/worktree navigation from `Cmd+Up/Down` to `Cmd+Alt+Up/Down`
- Fixes conflict where `Cmd+Arrow` was intercepting native macOS text cursor movement (jump to beginning/end of line) while typing in the chat textarea
- Users can still remap back to `Cmd+Arrow` via VS Code's keyboard shortcuts settings