### PR TITLE
ci: run vscode unit tests on packages/ui and packages/kilo-ui changes

### DIFF
--- a/.github/workflows/test-vscode.yml
+++ b/.github/workflows/test-vscode.yml
@@ -6,9 +6,13 @@ on:
       - dev
     paths:
       - "packages/kilo-vscode/**"
+      - "packages/ui/**"
+      - "packages/kilo-ui/**"
   pull_request:
     paths:
       - "packages/kilo-vscode/**"
+      - "packages/ui/**"
+      - "packages/kilo-ui/**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Problem

The `test-vscode.yml` workflow only triggers when `packages/kilo-vscode/**` files change. An upstream opencode merge PR that modifies `packages/ui` or `packages/kilo-ui` — the UI packages the extension webview depends on — would skip all kilo-vscode unit tests entirely.

This means contract regressions (renamed exports, removed tool registrations, lost `kilocode_change` customizations, etc.) could merge undetected.

## Fix

Add `packages/ui/**` and `packages/kilo-ui/**` to the `paths` trigger:

```diff
  pull_request:
    paths:
      - "packages/kilo-vscode/**"
+     - "packages/ui/**"
+     - "packages/kilo-ui/**"
```

## Why this is safe

The vscode unit tests (`bun test tests/unit/`) are pure — they test utility functions with inline mocks. No CLI binary is built or spawned. Adding these paths has no performance cost.

The existing tests already cover several contracts that would break if upstream renamed exports:
- `message-contract.test.ts` — checks all message types in `WebviewMessage` union exist
- `kilo-provider-utils.test.ts` — covers SSE event mapping
- `worktree-manager.test.ts` — pure git logic

## Related

Part of the testing gap analysis documented in #6502.