### PR TITLE
KiloSessions - Publish Session.Event.Created on import to trigger ingestion

### DIFF
--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -1,6 +1,7 @@
 import type { Argv } from "yargs"
 import type { Session as SDKSession, Message, Part } from "@kilocode/sdk/v2"
 import { Session } from "../../session"
+import { Bus } from "../../bus"
 import { cmd } from "./cmd"
 import { bootstrap } from "../bootstrap"
 import { Database } from "../../storage/db"
@@ -131,7 +132,10 @@ export const ImportCommand = cmd({
         return
       }
 
-      Database.use((db) => db.insert(SessionTable).values(Session.toRow(exportData.info)).onConflictDoNothing().run())
+      Database.use((db) => {
+        db.insert(SessionTable).values(Session.toRow(exportData.info)).onConflictDoNothing().run()
+        Database.effect(() => Bus.publish(Session.Event.Created, { info: exportData.info }))
+      })
 
       for (const msg of exportData.messages) {
         Database.use((db) =>


### PR DESCRIPTION
## Summary
- Publish `Session.Event.Created` bus event after importing a session via `kilo import`, so that `KiloSessions` picks it up for server-side ingestion and SSE subscribers are notified.
- Wrap the event publication in `Database.effect()` inside the session insert's `Database.use()` block, consistent with how `Session.create` publishes the same event.