### PR TITLE
fix: eliminate flaky vscode unit tests with shared preload mock

### DIFF
--- a/packages/kilo-vscode/bunfig.toml
+++ b/packages/kilo-vscode/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./tests/setup/vscode-mock.ts"]

--- a/packages/kilo-vscode/tests/setup/vscode-mock.ts
+++ b/packages/kilo-vscode/tests/setup/vscode-mock.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared vscode module mock for all Bun unit tests.
+ *
+ * Registered as a preload in bunfig.toml so the mock is applied ONCE before
+ * any test file loads. This eliminates race conditions when multiple test
+ * files each call mock.module("vscode", ...) with competing mock shapes.
+ */
+import { mock } from "bun:test"
+
+const kind = (value: string): { value: string; append: (part: string) => ReturnType<typeof kind> } => ({
+  value,
+  append: (part: string) => kind(`${value}.${part}`),
+})
+
+const noop = () => {}
+
+const mockUri = {
+  parse: (value: string) => ({ scheme: "https", authority: "", path: value, query: "", fragment: "", fsPath: value }),
+  file: (path: string) => ({ scheme: "file", authority: "", path, query: "", fragment: "", fsPath: path }),
+  joinPath: (base: { fsPath: string }, ...segments: string[]) => {
+    const joined = [base.fsPath, ...segments].join("/")
+    return { scheme: "file", authority: "", path: joined, query: "", fragment: "", fsPath: joined }
+  },
+}
+
+const mockVscode = {
+  Uri: mockUri,
+  extensions: {
+    getExtension: (id: string) => {
+      if (id === "vscode.git") return undefined
+      return { packageJSON: { version: "test", contributes: { configuration: { properties: {} } } }, isActive: true, exports: undefined }
+    },
+  },
+  env: {
+    appName: "VS Code",
+    language: "en",
+    machineId: "test-machine",
+    isTelemetryEnabled: false,
+    shell: "/bin/bash",
+    openExternal: noop,
+  },
+  version: "1.90.0",
+  workspace: {
+    workspaceFolders: [{ uri: { fsPath: "/repo" } }],
+    getConfiguration: () => ({
+      get: <T>(_key: string, value?: T) => value,
+      update: async () => {},
+    }),
+    asRelativePath: (pathOrUri: string) => pathOrUri,
+  },
+  window: {
+    activeTextEditor: undefined,
+    visibleTextEditors: [],
+    tabGroups: { all: [] },
+    showTextDocument: async () => {},
+    showWarningMessage: async () => undefined,
+    createTerminal: () => ({ show: noop, sendText: noop, dispose: noop }),
+  },
+  commands: {
+    registerCommand: () => ({ dispose: noop }),
+    executeCommand: async () => {},
+  },
+  CodeAction: class {
+    command?: { command: string; title: string }
+    isPreferred?: boolean
+    constructor(public title: string, public kind: { value: string }) {}
+  },
+  CodeActionKind: {
+    QuickFix: kind("quickfix"),
+    RefactorRewrite: kind("refactor.rewrite"),
+  },
+  ConfigurationTarget: {
+    Global: 1,
+    Workspace: 2,
+    WorkspaceFolder: 3,
+  },
+  TabInputText: class {
+    constructor(public uri: { scheme: string; fsPath: string }) {}
+  },
+  Position: class {
+    constructor(public line: number, public character: number) {}
+  },
+  Range: class {
+    constructor(public start: { line: number; character: number }, public end: { line: number; character: number }) {}
+  },
+  Disposable: class {
+    constructor(private callback: () => void = noop) {}
+    dispose() {
+      this.callback()
+    }
+  },
+  EventEmitter: class {
+    event = noop
+    fire = noop
+    dispose = noop
+  },
+  TreeItem: class {
+    constructor(public label: string) {}
+  },
+  TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+  ViewColumn: { One: 1, Two: 2, Three: 3 },
+}
+
+mock.module("vscode", () => mockVscode)

--- a/packages/kilo-vscode/tests/unit/code-action-provider.test.ts
+++ b/packages/kilo-vscode/tests/unit/code-action-provider.test.ts
@@ -1,31 +1,6 @@
-import { describe, it, expect, mock } from "bun:test"
+import { describe, it, expect } from "bun:test"
 
-const makeAction = (title: string, kind: string) => ({ title, kind })
-const makeKind = (value: string) => ({
-  value,
-  append: (v: string) => makeKind(`${value}.${v}`),
-})
-
-const QuickFix = makeKind("quickfix")
-const RefactorRewrite = makeKind("refactor.rewrite")
-
-const mockVscode = {
-  CodeAction: class {
-    command?: { command: string; title: string }
-    isPreferred?: boolean
-    constructor(
-      public title: string,
-      public kind: { value: string },
-    ) {}
-  },
-  CodeActionKind: {
-    QuickFix,
-    RefactorRewrite,
-  },
-}
-
-mock.module("vscode", () => mockVscode)
-
+// vscode mock is provided by the shared preload (tests/setup/vscode-mock.ts)
 const { KiloCodeActionProvider } = await import("../../src/services/code-actions/code-action-provider")
 
 const provider = new KiloCodeActionProvider()

--- a/packages/kilo-vscode/tests/unit/kilo-provider-session-refresh.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-session-refresh.test.ts
@@ -1,75 +1,6 @@
-import { describe, it, expect, mock } from "bun:test"
+import { describe, it, expect } from "bun:test"
 
-const kind = (value: string) => ({
-  value,
-  append: (part: string) => kind(`${value}.${part}`),
-})
-
-class MockUri {
-  constructor(
-    public readonly scheme: string,
-    public readonly fsPath: string,
-    public readonly path: string,
-  ) {}
-  static parse(value: string) {
-    return new MockUri("file", value, value)
-  }
-  static file(p: string) {
-    return new MockUri("file", p, p)
-  }
-  static joinPath(base: MockUri, ...parts: string[]) {
-    return new MockUri(base.scheme, [base.fsPath, ...parts].join("/"), [base.path, ...parts].join("/"))
-  }
-}
-
-const mockVscode = {
-  Uri: MockUri,
-  Disposable: class {
-    constructor(public callOnDispose: () => void) {}
-    dispose() {
-      this.callOnDispose()
-    }
-  },
-  EventEmitter: class {
-    event = () => ({ dispose: () => {} })
-    fire() {}
-    dispose() {}
-  },
-  WebviewViewProvider: {},
-  extensions: {
-    getExtension: () => ({
-      packageJSON: { version: "test" },
-    }),
-  },
-  env: {
-    appName: "VS Code",
-    language: "en",
-    machineId: "machine",
-    isTelemetryEnabled: false,
-  },
-  version: "1.0.0",
-  workspace: {
-    workspaceFolders: [{ uri: { fsPath: "/repo" } }],
-    getConfiguration: () => ({
-      get: <T>(_key: string, value?: T) => value,
-    }),
-  },
-  CodeAction: class {
-    command?: { command: string; title: string }
-    isPreferred?: boolean
-    constructor(
-      public title: string,
-      public kind: { value: string },
-    ) {}
-  },
-  CodeActionKind: {
-    QuickFix: kind("quickfix"),
-    RefactorRewrite: kind("refactor.rewrite"),
-  },
-}
-
-mock.module("vscode", () => mockVscode)
-
+// vscode mock is provided by the shared preload (tests/setup/vscode-mock.ts)
 const { KiloProvider } = await import("../../src/KiloProvider")
 
 type State = "connecting" | "connected" | "disconnected" | "error"
@@ -132,10 +63,10 @@ function createConnection(client: ReturnType<typeof createClient>) {
 }
 
 describe("KiloProvider pending session refresh", () => {
-  it.skip("flushes deferred refresh in initializeConnection without relying on connected event callback", async () => {
+  it("flushes deferred refresh in initializeConnection without relying on connected event callback", async () => {
     const client = createClient()
     const connection = createConnection(client)
-    const provider = new KiloProvider(MockUri.file("/ext") as never, connection as never)
+    const provider = new KiloProvider({} as never, connection as never)
     const internal = provider as unknown as ProviderInternals
 
     provider.setSessionDirectory("ses_1", "/worktree")
@@ -149,10 +80,10 @@ describe("KiloProvider pending session refresh", () => {
     expect(internal.pendingSessionRefresh).toBe(false)
   })
 
-  it.skip("does not post not-connected errors while still connecting", async () => {
+  it("does not post not-connected errors while still connecting", async () => {
     const client = createClient()
     const connection = createConnection(client)
-    const provider = new KiloProvider(MockUri.file("/ext") as never, connection as never)
+    const provider = new KiloProvider({} as never, connection as never)
     const internal = provider as unknown as ProviderInternals
     const sent: unknown[] = []
 


### PR DESCRIPTION
## Problem

The two `KiloProvider pending session refresh` tests in `kilo-provider-session-refresh.test.ts` fail intermittently across all PRs — they're unrelated to actual code changes.

**Error:**
```
TypeError: undefined is not an object (near '...}...')
    at new KiloProvider (KiloProvider.ts:70:22)
```

## Root cause

Two test files each call `mock.module('vscode', ...)` with **different** mock shapes:
- `kilo-provider-session-refresh.test.ts` mocks `extensions`, `env`, `workspace`, etc.
- `code-action-provider.test.ts` mocks only `CodeAction` and `CodeActionKind`

Since Bun's `mock.module` is global and test files run concurrently, module resolution can non-deterministically pick up the wrong mock depending on execution order and module caching. When `KiloProvider` or its transitive deps resolve `vscode` and get the wrong (incomplete) mock, the constructor blows up.

## Fix

- Create a **shared comprehensive vscode mock** in `tests/setup/vscode-mock.ts`
- Register it as a **Bun preload** via `bunfig.toml` (`[test].preload`)
- Remove the per-file `mock.module('vscode', ...)` calls from both test files

This ensures a single mock is registered once before any test file loads, eliminating the race condition.

## Test results

All 834 unit tests pass locally (0 failures).