### PR TITLE
fix: chat message autocomplete respects autocomplete switch

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -3,7 +3,7 @@
  * Text input with send/abort buttons, ghost-text autocomplete, and @ file mention support
  */
 
-import { Component, createSignal, createEffect, on, For, Index, onCleanup, Show, untrack } from "solid-js"
+import { Component, createSignal, createEffect, on, For, Index, onCleanup, onMount, Show, untrack } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { FileIcon } from "@kilocode/kilo-ui/file-icon"
@@ -36,6 +36,7 @@ export const PromptInput: Component = () => {
 
   const [text, setText] = createSignal("")
   const [ghostText, setGhostText] = createSignal("")
+  const [chatAutocompleteEnabled, setChatAutocompleteEnabled] = createSignal(false)
 
   let textareaRef: HTMLTextAreaElement | undefined
   let highlightRef: HTMLDivElement | undefined
@@ -79,6 +80,10 @@ export const PromptInput: Component = () => {
       }
     }
 
+    if (message.type === "autocompleteSettingsLoaded") {
+      setChatAutocompleteEnabled(message.settings.enableChatAutocomplete)
+    }
+
     if (message.type === "setChatBoxMessage") {
       setText(message.text)
       setGhostText("")
@@ -113,6 +118,10 @@ export const PromptInput: Component = () => {
     }
   })
 
+  onMount(() => {
+    vscode.postMessage({ type: "requestAutocompleteSettings" })
+  })
+
   onCleanup(() => {
     // Persist current draft before unmounting
     const current = text()
@@ -122,7 +131,7 @@ export const PromptInput: Component = () => {
   })
 
   const requestAutocomplete = (val: string) => {
-    if (val.length < MIN_TEXT_LENGTH || isDisabled()) {
+    if (val.length < MIN_TEXT_LENGTH || isDisabled() || !chatAutocompleteEnabled()) {
       setGhostText("")
       return
     }


### PR DESCRIPTION
Closes #6531 

## Context

Solving problem that I want autocomplete option turned off everywhere

## Implementation

Modified `PromptInput.tsx` to:

1. Add a signal to track the `enableChatAutocomplete` setting state (defaults to `false`)
2. Subscribe to `autocompleteSettingsLoaded` messages to update the signal
3. Request autocomplete settings on component mount via `requestAutocompleteSettings` message
4. Check the setting in `requestAutocomplete()` before sending completion requests
## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

Turn off autocomplete in VSCode extension and type in chat. Message should not be autocompleted in an way.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
