### PR TITLE
fix: stop doing models.length for every model

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -24,6 +24,19 @@ export function DialogModel(props: { providerID?: string }) {
 
   const connected = useConnected()
   const providers = createDialogProviderOptions()
+  // kilocode_change start
+  // Memoize anything that iterates all Kilo models to avoid calculating it for
+  // each Kilo model and tanking the UI at a couple hundred models
+  const kiloRank = createMemo(() => {
+    const provider = sync.data.provider.find((provider) => provider.id === "kilo")
+    const models = provider?.models ?? {}
+    return new Map(
+      Object.entries(models).map(
+        ([id, info]) => [id, info.recommendedIndex ?? Infinity] as const,
+      ),
+    )
+  })
+  // kilocode_change end
 
   const showExtra = createMemo(() => connected() && !props.providerID)
 
@@ -107,14 +120,8 @@ export function DialogModel(props: { providerID?: string }) {
             return true
           }),
           sortBy(
-            // kilocode_change start - Sort recommended models first for Kilo Gateway
-            (x) => {
-              if (x.value.providerID !== "kilo") return 0
-              const provider = sync.data.provider.find((p) => p.id === "kilo")
-              const model = provider?.models[x.value.modelID]
-              if (model?.recommendedIndex !== undefined) return model.recommendedIndex
-              return Object.keys(provider?.models ?? {}).length
-            },
+            // kilocode_change start - Sort within Recommended / Kilo Gateway
+            (x) => (x.value.providerID === "kilo" ? kiloRank().get(x.value.modelID) ?? Infinity : 0),
             // kilocode_change end
             (x) => x.footer !== "Free",
             (x) => x.title,


### PR DESCRIPTION
## Context

The model picker tanks when you type anything into the filter after connected to the gateway (~300 models).

## Implementation

We were calling `Object.keys().length` on the list of all models for the Kilo provider, which forces an iteration of the keys to get the length, for every single model. We did this to calculate the rank within the provider; when none is explicitly specified, we'd default to `.length` as I guess a number that's for sure larger than any explicit index.

A simpler patch is to just use `Infinity` when there's no explicit index. But I added a memo instead, since it's easy to do something like this on accident.

## Screenshots

Left is the slow version, right is the fast version. A little hard to tell until the end.

https://github.com/user-attachments/assets/ece3defb-f7fe-41fa-b48b-95b1da6fc0c4

## How to Test

Run the CLI when connected to the gateway. Open the model picker. Type anything. Before, very slow. After, not slow.