### PR TITLE
feat: Add energy/carbon tracking with Neuralwatt provider

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -9,6 +9,7 @@ import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
+import { formatWh } from "../../context/session-utils"
 
 export const TaskHeader: Component = () => {
   const session = useSession()
@@ -26,6 +27,12 @@ export const TaskHeader: Component = () => {
       style: "currency",
       currency: "USD",
     }).format(total)
+  })
+
+  const energy = createMemo(() => {
+    const total = session.totalEnergy()
+    if (total === 0) return undefined
+    return formatWh(total)
   })
 
   const context = createMemo(() => {
@@ -47,6 +54,13 @@ export const TaskHeader: Component = () => {
             {(c) => (
               <Tooltip value={language.t("context.usage.sessionCost")} placement="bottom">
                 <span>{c()}</span>
+              </Tooltip>
+            )}
+          </Show>
+          <Show when={energy()}>
+            {(e) => (
+              <Tooltip value={language.t("context.usage.sessionEnergy")} placement="bottom">
+                <span>{e()}</span>
               </Tooltip>
             )}
           </Show>

--- a/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
@@ -46,6 +46,25 @@ export function calcTotalCost(messages: Array<{ role: string; cost?: number }>):
 }
 
 /**
+ * Calculate total energy (Wh) across all assistant messages.
+ */
+export function calcTotalEnergy(messages: Array<{ role: string; energy?: { wh?: number } }>): number {
+  return messages.reduce((sum, m) => sum + (m.role === "assistant" ? (m.energy?.wh ?? 0) : 0), 0)
+}
+
+/**
+ * Format a watt-hour value with the appropriate metric prefix.
+ */
+export function formatWh(wh: number): string {
+  if (!Number.isFinite(wh) || wh < 0) return "\u2014"
+  if (wh === 0) return "0 Wh"
+  if (wh >= 1000) return (wh / 1000).toFixed(2) + " kWh"
+  if (wh >= 1) return wh.toFixed(2) + " Wh"
+  if (wh >= 0.001) return (wh * 1000).toFixed(1) + " mWh"
+  return (wh * 1_000_000).toFixed(1) + " μWh"
+}
+
+/**
  * Calculate context usage percentage given token counts and a context limit.
  */
 export function calcContextUsage(

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -39,7 +39,7 @@ import type {
   FileAttachment,
 } from "../types/messages"
 import { removeSessionPermissions, upsertPermission } from "./permission-queue"
-import { computeStatus, calcTotalCost, calcContextUsage } from "./session-utils"
+import { computeStatus, calcTotalCost, calcTotalEnergy, calcContextUsage } from "./session-utils"
 
 // Store structure for messages and parts
 interface SessionStore {
@@ -100,8 +100,9 @@ interface SessionContextValue {
   selected: Accessor<ModelSelection | null>
   selectModel: (providerID: string, modelID: string) => void
 
-  // Cost and context usage for the current session
+  // Cost, energy, and context usage for the current session
   totalCost: Accessor<number>
+  totalEnergy: Accessor<number>
   contextUsage: Accessor<ContextUsage | undefined>
 
   // Agent/mode selection (per-session)
@@ -1033,6 +1034,7 @@ export const SessionProvider: ParentComponent = (props) => {
   )
 
   const totalCost = createMemo(() => calcTotalCost(messages()))
+  const totalEnergy = createMemo(() => calcTotalEnergy(messages()))
 
   // Status text derived from last assistant message parts
   const statusText = createMemo<string | undefined>(() => {
@@ -1083,6 +1085,7 @@ export const SessionProvider: ParentComponent = (props) => {
     selected,
     selectModel,
     totalCost,
+    totalEnergy,
     contextUsage,
     agents,
     selectedAgent: selectedAgentName,

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -817,6 +817,7 @@ export const dict = {
   "prompt.placeholder.default": "Type a message... (Enter to send, Shift+Enter for new line)",
 
   "context.usage.sessionCost": "Session cost",
+  "context.usage.sessionEnergy": "Session energy usage",
 
   "time.justNow": "just now",
   "time.minutesAgo": "{{count}} min ago",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -60,6 +60,12 @@ export interface StepFinishPart extends BasePart {
     reasoning?: number
     cache?: { read: number; write: number }
   }
+  energy?: {
+    wh?: number
+    gCO2e?: number
+    source?: "measured" | "estimated"
+    provider?: string
+  }
 }
 
 export type Part = TextPart | ToolPart | ReasoningPart | StepStartPart | StepFinishPart
@@ -104,6 +110,12 @@ export interface Message {
   summary?: { title?: string; body?: string; diffs?: unknown[] } | boolean
   cost?: number
   tokens?: TokenUsage
+  energy?: {
+    wh?: number
+    gCO2e?: number
+    source?: "measured" | "estimated"
+    provider?: string
+  }
 }
 
 // Session info (simplified for webview)

--- a/packages/opencode/src/provider/energy-capture.ts
+++ b/packages/opencode/src/provider/energy-capture.ts
@@ -1,0 +1,126 @@
+/**
+ * Energy capture module for intercepting energy data from SSE streams.
+ *
+ * Supports two formats:
+ * 1. Neuralwatt: SSE comments like `: energy {"energy_joules":1632,...}`
+ * 2. GreenPT: `impact` field in response data chunks
+ *
+ * Energy data is captured via a TransformStream that snoops on the response
+ * body without modifying the stream that the AI SDK consumes.
+ */
+
+import { type Energy, parseNeuralwatt, parseGreenPT } from "./energy"
+
+// Kilo Code processes one LLM request at a time, so a single variable
+// is sufficient to hold the pending energy capture.
+let pending: Energy | undefined
+
+/**
+ * Store captured energy data for later retrieval by the provider handler.
+ * If called multiple times per request (e.g., multiple energy lines in one
+ * stream), the last value wins — the final measurement is typically the
+ * most accurate.
+ */
+export function store(energy: Energy) {
+	pending = energy
+}
+
+/**
+ * Consume (read and clear) captured energy data.
+ * Returns undefined if no energy was captured.
+ */
+export function consume(): Energy | undefined {
+	const energy = pending
+	pending = undefined
+	return energy
+}
+
+/**
+ * Discard any pending energy data. Call this on request failure or abort
+ * to prevent stale entries from leaking to a future request.
+ */
+export function discard() {
+	pending = undefined
+}
+
+/**
+ * Create a Response wrapper that captures energy data from the SSE stream
+ * without modifying the bytes that flow to the downstream consumer (AI SDK).
+ *
+ * This uses a TransformStream as a passthrough sniffer: all bytes are
+ * forwarded unchanged, but we also decode and inspect SSE lines for
+ * energy-related content.
+ */
+export function wrapResponse(response: Response): Response {
+	const body = response.body
+	if (!body) return response
+
+	const decoder = new TextDecoder()
+	let buffer = ""
+
+	const transform = new TransformStream<Uint8Array, Uint8Array>({
+		transform(chunk, controller) {
+			// Pass through unchanged
+			controller.enqueue(chunk)
+
+			// Decode and inspect for energy data
+			const decoded = decoder.decode(chunk, { stream: true })
+			buffer += decoded
+			const lines = buffer.split("\n")
+			buffer = lines.pop() || ""
+
+			for (const line of lines) {
+				// Neuralwatt: SSE comment with energy data
+				if (line.startsWith(": energy ")) {
+					try {
+						const data = JSON.parse(line.slice(9))
+						store(parseNeuralwatt(data))
+					} catch {
+						// Ignore malformed energy comments
+					}
+					continue
+				}
+
+				// GreenPT: impact field in data lines (quick string check avoids
+				// JSON.parse on every SSE data line for non-GreenPT providers)
+				if (line.startsWith("data: ") && line !== "data: [DONE]" && line.includes('"impact"')) {
+					try {
+						const parsed = JSON.parse(line.slice(6))
+						if (parsed.impact && typeof parsed.impact === "object") {
+							store(parseGreenPT(parsed.impact))
+						}
+					} catch {
+						// Ignore malformed data lines
+					}
+				}
+			}
+		},
+		flush() {
+			// Check any remaining buffer for energy data
+			if (buffer.startsWith(": energy ")) {
+				try {
+					const data = JSON.parse(buffer.slice(9))
+					store(parseNeuralwatt(data))
+				} catch {
+					// Ignore
+				}
+			} else if (buffer.startsWith("data: ") && buffer !== "data: [DONE]" && buffer.includes('"impact"')) {
+				try {
+					const parsed = JSON.parse(buffer.slice(6))
+					if (parsed.impact && typeof parsed.impact === "object") {
+						store(parseGreenPT(parsed.impact))
+					}
+				} catch {
+					// Ignore
+				}
+			}
+			buffer = ""
+		},
+	})
+
+	return new Response(body.pipeThrough(transform), {
+		headers: response.headers,
+		status: response.status,
+		statusText: response.statusText,
+	})
+}

--- a/packages/opencode/src/provider/energy.ts
+++ b/packages/opencode/src/provider/energy.ts
@@ -1,0 +1,93 @@
+/**
+ * Energy tracking types, parsing, and formatting utilities.
+ *
+ * Supports two provider formats:
+ * 1. Neuralwatt: SSE comments like `: energy {"energy_joules":1632,...}`
+ * 2. GreenPT: `impact` field in response chunks
+ */
+
+/**
+ * Normalized energy measurement from an LLM inference request.
+ */
+export interface Energy {
+	wh?: number
+	kwh?: number
+	joules?: number
+	gCO2e?: number
+	source: "measured" | "estimated"
+	provider?: string
+	method?: string
+	raw?: Record<string, unknown>
+}
+
+/**
+ * Parse Neuralwatt energy SSE comment data into normalized Energy format.
+ *
+ * Input: {"energy_joules":1632,"energy_kwh":0.000453,"avg_power_watts":379.1,...}
+ */
+export function parseNeuralwatt(data: Record<string, unknown>): Energy {
+	const joules = typeof data.energy_joules === "number" ? data.energy_joules : undefined
+	const kwh = typeof data.energy_kwh === "number" ? data.energy_kwh : undefined
+	return {
+		joules,
+		kwh,
+		wh: kwh !== undefined ? kwh * 1000 : joules !== undefined ? joules / 3600 : undefined,
+		source: "measured",
+		provider: "neuralwatt",
+		method: typeof data.attribution_method === "string" ? data.attribution_method : undefined,
+		raw: data,
+	}
+}
+
+/**
+ * Parse GreenPT impact data into normalized Energy format.
+ *
+ * Input: {"version":"20250922","energy":{"total":40433,"unit":"Wms"},
+ *         "emissions":{"total":1,"unit":"ugCO2e"}}
+ */
+export function parseGreenPT(impact: Record<string, unknown>): Energy {
+	const energy: Energy = {
+		source: "measured",
+		provider: "greenpt",
+		raw: impact,
+	}
+
+	const impactEnergy = impact.energy as { total?: number; unit?: string } | undefined
+	if (impactEnergy?.total !== undefined) {
+		if (impactEnergy.unit === "Wms") {
+			// Watt-milliseconds
+			const wms = impactEnergy.total
+			energy.wh = wms / 3_600_000
+			energy.kwh = wms / 3_600_000_000
+			energy.joules = wms / 1000
+		}
+	}
+
+	const emissions = impact.emissions as { total?: number; unit?: string } | undefined
+	if (emissions?.total !== undefined) {
+		if (emissions.unit === "ugCO2e") {
+			// Micrograms CO2 equivalent to grams
+			energy.gCO2e = emissions.total / 1_000_000
+		}
+	}
+
+	return energy
+}
+
+/**
+ * Format a watt-hour value with the appropriate metric prefix.
+ *
+ * Examples:
+ *   formatWh(1500)    → "1.50 kWh"
+ *   formatWh(2.5)     → "2.50 Wh"
+ *   formatWh(0.175)   → "175.0 mWh"
+ *   formatWh(0.00005) → "50.0 μWh"
+ */
+export function formatWh(wh: number): string {
+	if (!Number.isFinite(wh) || wh < 0) return "\u2014"
+	if (wh === 0) return "0 Wh"
+	if (wh >= 1000) return (wh / 1000).toFixed(2) + " kWh"
+	if (wh >= 1) return wh.toFixed(2) + " Wh"
+	if (wh >= 0.001) return (wh * 1000).toFixed(1) + " mWh"
+	return (wh * 1_000_000).toFixed(1) + " μWh"
+}

--- a/packages/opencode/src/provider/energy.ts
+++ b/packages/opencode/src/provider/energy.ts
@@ -52,7 +52,9 @@ export function parseGreenPT(impact: Record<string, unknown>): Energy {
 		raw: impact,
 	}
 
-	const impactEnergy = impact.energy as { total?: number; unit?: string } | undefined
+	const impactEnergy = typeof impact.energy === "object" && impact.energy !== null
+		? (impact.energy as { total?: number; unit?: string })
+		: undefined
 	if (impactEnergy?.total !== undefined) {
 		if (impactEnergy.unit === "Wms") {
 			// Watt-milliseconds

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -167,7 +167,7 @@ export namespace ModelsDev {
       }
     }
 
-    // neuralwatt_change start - inject Neuralwatt energy-measured provider
+    // kilocode_change start - inject Neuralwatt energy-measured provider
     if (!providers["neuralwatt"]) {
       providers["neuralwatt"] = {
         id: "neuralwatt",
@@ -227,7 +227,7 @@ export namespace ModelsDev {
         },
       }
     }
-    // neuralwatt_change end
+    // kilocode_change end
 
     return providers
     // kilocode_change end

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -167,6 +167,68 @@ export namespace ModelsDev {
       }
     }
 
+    // neuralwatt_change start - inject Neuralwatt energy-measured provider
+    if (!providers["neuralwatt"]) {
+      providers["neuralwatt"] = {
+        id: "neuralwatt",
+        name: "Neuralwatt",
+        env: ["NEURALWATT_API_KEY"],
+        api: "https://api.neuralwatt.com/v1",
+        npm: "@ai-sdk/openai-compatible",
+        models: {
+          "moonshotai/Kimi-K2.5": {
+            id: "moonshotai/Kimi-K2.5",
+            name: "Kimi K2.5",
+            release_date: "2025-07-01",
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            tool_call: true,
+            cost: { input: 0.2, output: 0.6 },
+            limit: { context: 262_144, output: 16_384 },
+            options: {},
+          },
+          "mistralai/Devstral-Small-2-24B-Instruct-2512": {
+            id: "mistralai/Devstral-Small-2-24B-Instruct-2512",
+            name: "Devstral Small 2 24B",
+            release_date: "2025-12-01",
+            attachment: false,
+            reasoning: false,
+            temperature: true,
+            tool_call: true,
+            cost: { input: 0.1, output: 0.3 },
+            limit: { context: 262_144, output: 16_384 },
+            options: {},
+          },
+          "deepseek-ai/deepseek-coder-33b-instruct": {
+            id: "deepseek-ai/deepseek-coder-33b-instruct",
+            name: "DeepSeek Coder 33B",
+            release_date: "2024-01-01",
+            attachment: false,
+            reasoning: false,
+            temperature: true,
+            tool_call: false,
+            cost: { input: 0.1, output: 0.2 },
+            limit: { context: 16_384, output: 16_384 },
+            options: {},
+          },
+          "openai/gpt-oss-20b": {
+            id: "openai/gpt-oss-20b",
+            name: "GPT-OSS 20B",
+            release_date: "2025-06-01",
+            attachment: false,
+            reasoning: false,
+            temperature: true,
+            tool_call: false,
+            cost: { input: 0.1, output: 0.5 },
+            limit: { context: 16_384, output: 16_384 },
+            options: {},
+          },
+        },
+      }
+    }
+    // neuralwatt_change end
+
     return providers
     // kilocode_change end
   }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -20,6 +20,7 @@ import { iife } from "@/util/iife"
 import { Global } from "../global"
 import path from "path"
 import { Filesystem } from "../util/filesystem"
+import * as EnergyCapture from "./energy-capture"
 
 // Direct imports for bundled providers
 import { createAmazonBedrock, type AmazonBedrockProviderSettings } from "@ai-sdk/amazon-bedrock"
@@ -1129,11 +1130,16 @@ export namespace Provider {
           }
         }
 
-        return fetchFn(input, {
+        const response = await fetchFn(input, {
           ...opts,
           // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
           timeout: false,
         })
+        const ct = response.headers.get("content-type") || ""
+        if (ct.includes("text/event-stream")) {
+          return EnergyCapture.wrapResponse(response)
+        }
+        return response
       }
 
       const bundledFn = BUNDLED_PROVIDERS[model.api.npm]

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -17,6 +17,7 @@ import { ProjectTable } from "../project/project.sql"
 import { Storage } from "@/storage/storage"
 import { Log } from "../util/log"
 import { MessageV2 } from "./message-v2"
+import * as EnergyCapture from "../provider/energy-capture"
 import { Instance } from "../project/instance"
 import { SessionPrompt } from "./prompt"
 import { fn } from "@/util/fn"
@@ -866,6 +867,10 @@ export namespace Session {
         },
       }
 
+      // Consume energy once before any return path to avoid double-consume risk
+      const energy = EnergyCapture.consume()
+      const energyResult = energy ? { wh: energy.wh, gCO2e: energy.gCO2e, source: energy.source, provider: energy.provider } : undefined
+
       // kilocode_change start - Use provider-reported cost when available for OpenRouter/Kilo
       // The OpenRouter AI SDK provider exposes cost at providerMetadata.openrouter.usage
       // Reference: https://openrouter.ai/docs/use-cases/usage-accounting
@@ -892,6 +897,7 @@ export namespace Session {
           return {
             cost: safe(providerCost),
             tokens,
+            energy: energyResult,
           }
         }
       }
@@ -914,6 +920,7 @@ export namespace Session {
             .toNumber(),
         ),
         tokens,
+        energy: energyResult,
       }
     },
   )

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -238,6 +238,13 @@ export namespace MessageV2 {
   })
   export type StepStartPart = z.infer<typeof StepStartPart>
 
+  const EnergySchema = z.object({
+    wh: z.number().optional(),
+    gCO2e: z.number().optional(),
+    source: z.enum(["measured", "estimated"]).optional(),
+    provider: z.string().optional(),
+  })
+
   export const StepFinishPart = PartBase.extend({
     type: z.literal("step-finish"),
     reason: z.string(),
@@ -253,6 +260,7 @@ export namespace MessageV2 {
         write: z.number(),
       }),
     }),
+    energy: EnergySchema.optional(),
   }).meta({
     ref: "StepFinishPart",
   })
@@ -440,6 +448,7 @@ export namespace MessageV2 {
         write: z.number(),
       }),
     }),
+    energy: EnergySchema.optional(),
     structured: z.any().optional(),
     variant: z.string().optional(),
     finish: z.string().optional(),

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -16,6 +16,7 @@ import { SessionCompaction } from "./compaction"
 import { PermissionNext } from "@/permission/next"
 import { Question } from "@/question"
 import { Telemetry } from "@kilocode/kilo-telemetry" // kilocode_change
+import * as EnergyCapture from "@/provider/energy-capture"
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
@@ -273,6 +274,16 @@ export namespace SessionProcessor {
                   input.assistantMessage.finish = value.finishReason
                   input.assistantMessage.cost += usage.cost
                   input.assistantMessage.tokens = usage.tokens
+                  if (usage.energy) {
+                    if (!input.assistantMessage.energy) {
+                      input.assistantMessage.energy = { ...usage.energy }
+                    } else {
+                      input.assistantMessage.energy.wh = (input.assistantMessage.energy.wh ?? 0) + (usage.energy.wh ?? 0)
+                      input.assistantMessage.energy.gCO2e = (input.assistantMessage.energy.gCO2e ?? 0) + (usage.energy.gCO2e ?? 0)
+                      input.assistantMessage.energy.source = usage.energy.source
+                      input.assistantMessage.energy.provider = usage.energy.provider
+                    }
+                  }
                   await Session.updatePart({
                     id: Identifier.ascending("part"),
                     reason: value.finishReason,
@@ -282,6 +293,7 @@ export namespace SessionProcessor {
                     type: "step-finish",
                     tokens: usage.tokens,
                     cost: usage.cost,
+                    energy: usage.energy,
                   })
                   await Session.updateMessage(input.assistantMessage)
                   if (snapshot) {
@@ -371,6 +383,7 @@ export namespace SessionProcessor {
               if (needsCompaction) break
             }
           } catch (e: any) {
+            EnergyCapture.discard()
             log.error("process", {
               error: e,
               stack: JSON.stringify(e.stack),

--- a/packages/opencode/test/provider/energy-capture.test.ts
+++ b/packages/opencode/test/provider/energy-capture.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, afterEach } from "bun:test"
+import * as EnergyCapture from "../../src/provider/energy-capture"
+
+describe("EnergyCapture", () => {
+	afterEach(() => {
+		EnergyCapture.discard()
+	})
+
+	describe("store and consume", () => {
+		it("should store and consume energy data", () => {
+			const energy = { wh: 0.5, joules: 1800, source: "measured" as const, provider: "neuralwatt" }
+			EnergyCapture.store(energy)
+
+			const result = EnergyCapture.consume()
+			expect(result).toEqual(energy)
+		})
+
+		it("should return undefined when no energy is stored", () => {
+			expect(EnergyCapture.consume()).toBeUndefined()
+		})
+
+		it("should clear energy after consume", () => {
+			EnergyCapture.store({ wh: 0.5, source: "measured" })
+			EnergyCapture.consume()
+
+			expect(EnergyCapture.consume()).toBeUndefined()
+		})
+
+		it("should overwrite previous energy on second store", () => {
+			EnergyCapture.store({ wh: 0.1, source: "measured" })
+			EnergyCapture.store({ wh: 0.2, source: "measured" })
+
+			const result = EnergyCapture.consume()
+			expect(result?.wh).toBe(0.2)
+		})
+	})
+
+	describe("discard", () => {
+		it("should clear stored energy", () => {
+			EnergyCapture.store({ wh: 0.5, source: "measured" })
+			EnergyCapture.discard()
+
+			expect(EnergyCapture.consume()).toBeUndefined()
+		})
+	})
+
+	describe("wrapResponse", () => {
+		it("should capture Neuralwatt energy from SSE comments", async () => {
+			const sseBody = [
+				'data: {"choices":[{"delta":{"content":"hello"}}]}\n',
+				"\n",
+				': energy {"energy_joules":1632,"energy_kwh":0.000453,"attribution_method":"rapl"}\n',
+				"\n",
+				"data: [DONE]\n",
+			].join("")
+
+			const response = new Response(sseBody, {
+				headers: { "content-type": "text/event-stream" },
+			})
+
+			const wrapped = EnergyCapture.wrapResponse(response)
+			// Consume the stream to trigger the transform
+			await new Response(wrapped.body).text()
+
+			const energy = EnergyCapture.consume()
+			expect(energy).toBeDefined()
+			expect(energy!.joules).toBe(1632)
+			expect(energy!.kwh).toBe(0.000453)
+			expect(energy!.provider).toBe("neuralwatt")
+			expect(energy!.method).toBe("rapl")
+		})
+
+		it("should capture GreenPT energy from impact fields", async () => {
+			const sseBody = [
+				'data: {"choices":[{"delta":{"content":"hi"}}],"impact":{"energy":{"total":3600000,"unit":"Wms"},"emissions":{"total":1000000,"unit":"ugCO2e"}}}\n',
+				"\n",
+				"data: [DONE]\n",
+			].join("")
+
+			const response = new Response(sseBody, {
+				headers: { "content-type": "text/event-stream" },
+			})
+
+			const wrapped = EnergyCapture.wrapResponse(response)
+			await new Response(wrapped.body).text()
+
+			const energy = EnergyCapture.consume()
+			expect(energy).toBeDefined()
+			expect(energy!.wh).toBeCloseTo(1.0)
+			expect(energy!.gCO2e).toBeCloseTo(1.0)
+			expect(energy!.provider).toBe("greenpt")
+		})
+
+		it("should pass through response bytes unchanged", async () => {
+			const sseBody = 'data: {"choices":[{"delta":{"content":"hello"}}]}\n\ndata: [DONE]\n'
+
+			const response = new Response(sseBody, {
+				headers: { "content-type": "text/event-stream" },
+			})
+
+			const wrapped = EnergyCapture.wrapResponse(response)
+			const text = await new Response(wrapped.body).text()
+
+			expect(text).toBe(sseBody)
+		})
+
+		it("should return response unchanged when body is null", () => {
+			const response = new Response(null)
+			const wrapped = EnergyCapture.wrapResponse(response)
+			expect(wrapped).toBe(response)
+		})
+	})
+})

--- a/packages/opencode/test/provider/energy.test.ts
+++ b/packages/opencode/test/provider/energy.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "bun:test"
+import { parseNeuralwatt, parseGreenPT, formatWh } from "../../src/provider/energy"
+
+describe("parseNeuralwatt", () => {
+	it("should parse energy_joules and energy_kwh", () => {
+		const result = parseNeuralwatt({
+			energy_joules: 1632,
+			energy_kwh: 0.000453,
+			avg_power_watts: 379.1,
+			attribution_method: "rapl",
+		})
+
+		expect(result.joules).toBe(1632)
+		expect(result.kwh).toBe(0.000453)
+		expect(result.wh).toBe(0.453) // kwh * 1000
+		expect(result.source).toBe("measured")
+		expect(result.provider).toBe("neuralwatt")
+		expect(result.method).toBe("rapl")
+		expect(result.raw).toEqual({
+			energy_joules: 1632,
+			energy_kwh: 0.000453,
+			avg_power_watts: 379.1,
+			attribution_method: "rapl",
+		})
+	})
+
+	it("should derive wh from joules when kwh is absent", () => {
+		const result = parseNeuralwatt({ energy_joules: 3600 })
+
+		expect(result.joules).toBe(3600)
+		expect(result.kwh).toBeUndefined()
+		expect(result.wh).toBeCloseTo(1.0) // 3600 / 3600
+	})
+
+	it("should handle missing energy fields", () => {
+		const result = parseNeuralwatt({})
+
+		expect(result.joules).toBeUndefined()
+		expect(result.kwh).toBeUndefined()
+		expect(result.wh).toBeUndefined()
+		expect(result.source).toBe("measured")
+		expect(result.provider).toBe("neuralwatt")
+	})
+
+	it("should ignore non-numeric energy values", () => {
+		const result = parseNeuralwatt({ energy_joules: "not a number", energy_kwh: null })
+
+		expect(result.joules).toBeUndefined()
+		expect(result.kwh).toBeUndefined()
+		expect(result.wh).toBeUndefined()
+	})
+})
+
+describe("parseGreenPT", () => {
+	it("should parse Watt-milliseconds energy and ugCO2e emissions", () => {
+		const result = parseGreenPT({
+			version: "20250922",
+			energy: { total: 3_600_000, unit: "Wms" },
+			emissions: { total: 1_000_000, unit: "ugCO2e" },
+		})
+
+		expect(result.wh).toBeCloseTo(1.0) // 3_600_000 / 3_600_000
+		expect(result.kwh).toBeCloseTo(0.001)
+		expect(result.joules).toBeCloseTo(3600) // 3_600_000 / 1000
+		expect(result.gCO2e).toBeCloseTo(1.0) // 1_000_000 / 1_000_000
+		expect(result.source).toBe("measured")
+		expect(result.provider).toBe("greenpt")
+	})
+
+	it("should handle missing energy field", () => {
+		const result = parseGreenPT({
+			emissions: { total: 500_000, unit: "ugCO2e" },
+		})
+
+		expect(result.wh).toBeUndefined()
+		expect(result.joules).toBeUndefined()
+		expect(result.gCO2e).toBeCloseTo(0.5)
+	})
+
+	it("should handle missing emissions field", () => {
+		const result = parseGreenPT({
+			energy: { total: 7_200_000, unit: "Wms" },
+		})
+
+		expect(result.wh).toBeCloseTo(2.0)
+		expect(result.gCO2e).toBeUndefined()
+	})
+
+	it("should ignore unsupported energy units", () => {
+		const result = parseGreenPT({
+			energy: { total: 100, unit: "kWh" },
+		})
+
+		expect(result.wh).toBeUndefined()
+		expect(result.joules).toBeUndefined()
+	})
+
+	it("should ignore unsupported emissions units", () => {
+		const result = parseGreenPT({
+			emissions: { total: 100, unit: "gCO2" },
+		})
+
+		expect(result.gCO2e).toBeUndefined()
+	})
+})
+
+describe("formatWh", () => {
+	it("should format kilowatt-hours", () => {
+		expect(formatWh(1500)).toBe("1.50 kWh")
+		expect(formatWh(1000)).toBe("1.00 kWh")
+	})
+
+	it("should format watt-hours", () => {
+		expect(formatWh(2.5)).toBe("2.50 Wh")
+		expect(formatWh(1)).toBe("1.00 Wh")
+		expect(formatWh(999.99)).toBe("999.99 Wh")
+	})
+
+	it("should format milliwatt-hours", () => {
+		expect(formatWh(0.175)).toBe("175.0 mWh")
+		expect(formatWh(0.001)).toBe("1.0 mWh")
+	})
+
+	it("should format microwatt-hours", () => {
+		expect(formatWh(0.00005)).toBe("50.0 μWh")
+		expect(formatWh(0.0000001)).toBe("0.1 μWh")
+	})
+
+	it("should handle zero", () => {
+		expect(formatWh(0)).toBe("0 Wh")
+	})
+
+	it("should return em-dash for negative values", () => {
+		expect(formatWh(-1)).toBe("\u2014")
+	})
+
+	it("should return em-dash for non-finite values", () => {
+		expect(formatWh(NaN)).toBe("\u2014")
+		expect(formatWh(Infinity)).toBe("\u2014")
+		expect(formatWh(-Infinity)).toBe("\u2014")
+	})
+})


### PR DESCRIPTION
Closes #6535

## Summary

Add optional energy tracking to Kilo Code. When a provider returns energy data in its SSE stream, the value is captured and displayed in the task header alongside cost and tokens. Providers that don't return energy data are unaffected.

Also registers Neuralwatt as an OpenAI-compatible provider (4 models) so the feature can be tested end-to-end.

## How it works

A `TransformStream` wraps the fetch response in `getSDK()`, passing all bytes through unchanged while inspecting SSE lines for energy data. Two formats are supported (Neuralwatt SSE comments, GreenPT impact fields). Energy flows through the existing pipeline: `getSDK() fetch → EnergyCapture.store() → getUsage() → processor finish-step → message schema → TaskHeader`.

Non-energy providers pay only the cost of checking a line prefix before short-circuiting. No changes to the Vercel AI SDK.

## Changes

**New files (4)**
- `packages/opencode/src/provider/energy.ts` — Energy types, parsing (Neuralwatt + GreenPT), formatting
- `packages/opencode/src/provider/energy-capture.ts` — TransformStream sniffer, store/consume/discard
- `packages/opencode/test/provider/energy.test.ts` — 16 tests (parsing + formatting)
- `packages/opencode/test/provider/energy-capture.test.ts` — 9 tests (capture + wrap)

**Modified files (10)**
| File | Change |
|-|-|
| `packages/opencode/src/provider/provider.ts` | Wrap SSE fetch responses with energy sniffer in `getSDK()` |
| `packages/opencode/src/provider/models.ts` | Register Neuralwatt provider with 4 models |
| `packages/opencode/src/session/message-v2.ts` | Add `energy` field to `StepFinishPart` and `Assistant` schemas |
| `packages/opencode/src/session/index.ts` | Consume energy in `getUsage()` return values |
| `packages/opencode/src/session/processor.ts` | Accumulate energy on assistant messages, discard on error |
| `packages/kilo-vscode/webview-ui/src/types/messages.ts` | Add `energy` to `StepFinishPart` and `Message` interfaces |
| `packages/kilo-vscode/webview-ui/src/context/session-utils.ts` | Add `calcTotalEnergy()` and `formatWh()` |
| `packages/kilo-vscode/webview-ui/src/context/session.tsx` | Add `totalEnergy` accessor to session context |
| `packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx` | Display energy in task header after cost |
| `packages/kilo-vscode/webview-ui/src/i18n/en.ts` | Add `"context.usage.sessionEnergy"` key |

## Test plan

- [ ] `bun test test/provider/energy.test.ts test/provider/energy-capture.test.ts` — 25 tests pass
- [ ] TypeScript compiles clean
- [ ] Launch Extension Development Host with `NEURALWATT_API_KEY` set, select a Neuralwatt model, verify energy appears in task header
- [ ] Verify non-energy providers show no energy UI

## Screenshots

### Neuralwatt provider (with energy tracking)

**Before** (main branch, no energy feature):
<img width="599" height="849" alt="nw_model_before" src="https://github.com/user-attachments/assets/01d87669-b4dd-4cc5-a0cc-3e2e180fd2d3" />

**After** (this PR — energy appears in TaskHeader):
<img width="664" height="846" alt="nw_model_after" src="https://github.com/user-attachments/assets/677f1970-0b3c-42d8-a8ec-c7dd3c21fcef" />

### Non-energy provider (no regressions)

**Before** (main branch):
<img width="589" height="849" alt="kilo_model_before" src="https://github.com/user-attachments/assets/cb21009e-c49f-4e73-832a-b89ab0b0e40c" />

**After** (this PR — no energy shown, UI unchanged):
<img width="665" height="847" alt="kilo_model_after" src="https://github.com/user-attachments/assets/0f0fafb8-bdf4-471f-be17-9641d6754c4d" />
