### PR TITLE
Fix Agent Manager worktree diff base branch handling

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1507,14 +1507,16 @@ export class AgentManagerProvider implements vscode.Disposable {
     this.postToWebview({ type: "agentManager.worktreeDiffLoading", sessionId, loading: true })
     try {
       const client = this.connectionService.getClient()
-      this.log(`Fetching worktree diff for session ${sessionId}: dir=${target.directory}, base=${target.baseBranch}`)
       const { data: diffs } = await client.worktree.diff(
-        { directory: target.directory },
+        { directory: target.directory, base: target.baseBranch },
         { throwOnError: true },
       )
+
       this.log(`Worktree diff returned ${diffs.length} file(s) for session ${sessionId}`)
 
-      const hash = diffs.map((d: FileDiff) => `${d.file}:${d.status}:${d.additions}:${d.deletions}:${d.after.length}`).join("|")
+      const hash = diffs
+        .map((d: FileDiff) => `${d.file}:${d.status}:${d.additions}:${d.deletions}:${d.after.length}`)
+        .join("|")
       this.lastDiffHash = hash
       this.diffSessionId = sessionId
 
@@ -1534,11 +1536,13 @@ export class AgentManagerProvider implements vscode.Disposable {
     try {
       const client = this.connectionService.getClient()
       const { data: diffs } = await client.worktree.diff(
-        { directory: target.directory },
+        { directory: target.directory, base: target.baseBranch },
         { throwOnError: true },
       )
 
-      const hash = diffs.map((d: FileDiff) => `${d.file}:${d.status}:${d.additions}:${d.deletions}:${d.after.length}`).join("|")
+      const hash = diffs
+        .map((d: FileDiff) => `${d.file}:${d.status}:${d.additions}:${d.deletions}:${d.after.length}`)
+        .join("|")
       if (hash === this.lastDiffHash && this.diffSessionId === sessionId) return
       this.lastDiffHash = hash
       this.diffSessionId = sessionId

--- a/packages/kilo-vscode/src/agent-manager/GitStatsPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitStatsPoller.ts
@@ -110,7 +110,10 @@ export class GitStatsPoller {
       await Promise.all(
         worktrees.map(async (wt) => {
           try {
-            const { data: diffs } = await client.worktree.diff({ directory: wt.path }, { throwOnError: true })
+            const { data: diffs } = await client.worktree.diff(
+              { directory: wt.path, base: wt.parentBranch },
+              { throwOnError: true },
+            )
             const additions = diffs.reduce((sum: number, diff: FileDiff) => sum + diff.additions, 0)
             const deletions = diffs.reduce((sum: number, diff: FileDiff) => sum + diff.deletions, 0)
             const commits = await this.git.countMissingOriginCommits(wt.path, wt.parentBranch)
@@ -183,7 +186,7 @@ export class GitStatsPoller {
       let commits: number
       try {
         if (base) {
-          const { data: diffs } = await client.worktree.diff({ directory: root }, { throwOnError: true })
+          const { data: diffs } = await client.worktree.diff({ directory: root, base }, { throwOnError: true })
           additions = diffs.reduce((sum: number, d: FileDiff) => sum + d.additions, 0)
           deletions = diffs.reduce((sum: number, d: FileDiff) => sum + d.deletions, 0)
           commits = await this.git.countMissingOriginCommits(root, base)

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -209,9 +209,18 @@ export const ExperimentalRoutes = lazy(() =>
           ...errors(400),
         },
       }),
+      // kilocode_change start
+      validator(
+        "query",
+        z.object({
+          base: z.string().optional().meta({ description: "Base branch or ref to diff against" }),
+        }),
+      ),
       async (c) => {
         const log = Log.create({ service: "worktree-diff" })
-        const base = c.req.query("base") || (await Review.getBaseBranch())
+        const query = c.req.valid("query")
+        const base = query.base || (await Review.getBaseBranch())
+        // kilocode_change end
         const dir = Instance.directory
         log.info("computing diff", { dir, base })
 

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -928,10 +928,21 @@ export class Worktree extends HeyApiClient {
   public diff<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
+      base?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "base" },
+          ],
+        },
+      ],
+    )
     return (options?.client ?? this.client).get<WorktreeDiffResponses, WorktreeDiffErrors, ThrowOnError>({
       url: "/experimental/worktree/diff",
       ...options,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2540,6 +2540,10 @@ export type WorktreeDiffData = {
   path?: never
   query?: {
     directory?: string
+    /**
+     * Base branch or ref to diff against
+     */
+    base?: string
   }
   url: "/experimental/worktree/diff"
 }


### PR DESCRIPTION
## Summary
- restore the worktree diff endpoint query schema so the generated SDK supports a `base` parameter again
- pass each worktree or local session's resolved base branch through Agent Manager diff and stats requests
- regenerate the SDK client types for the updated diff endpoint