### PR TITLE
docs: make link checker tolerate flaky external links

### DIFF
--- a/packages/kilo-docs/lychee.toml
+++ b/packages/kilo-docs/lychee.toml
@@ -4,6 +4,8 @@ remap = ["kilo-docs/docs kilo-docs/pages"]
 
 format = "detailed"
 max_redirects = 2
+max_retries = 3
+retry_wait_time = 5
 exclude_path = ["node_modules"]
 
 accept = [
@@ -19,7 +21,7 @@ exclude = [
   'https://synthetic.new/user-settings/api',
   'https://platform.slack-edge.com/img/add_to_slack.png',
   'https://console.groq.com/pages/models',
-  'https://glama.ai/settings/gateway/api-keys',
+  '^https?://([A-Za-z0-9-]+\.)?glama\.ai(/|$)',
   '^https?://(api|console)\.mistral\.ai',
   '^https?://(app|console)\.requesty\.ai',
   '^https?://(cloud|console)\.google\.ai',


### PR DESCRIPTION
## Summary
- exclude `glama.ai` links from the docs link checker because the site intermittently returns 500s in CI
- add bounded retries with backoff so transient third-party failures are less likely to fail the workflow