### PR TITLE
Remove old kilo gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
 - 🎁 API keys optional
 - 💡 **Get $20 in bonus credits when you top-up for the first time** Credits can be used with 500+ models like Gemini 3.1 Pro, Claude 4.6 Sonnet & Opus, and GPT-5.2
 
-
 ## Quick Links
 
 - [VS Code Marketplace](https://kilo.ai/vscode-marketplace?utm_source=Readme) (download)

--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@
 - 🎁 API keys optional
 - 💡 **Get $20 in bonus credits when you top-up for the first time** Credits can be used with 500+ models like Gemini 3.1 Pro, Claude 4.6 Sonnet & Opus, and GPT-5.2
 
-<p align="center">
-  <img src="https://media.githubusercontent.com/media/Kilo-Org/kilocode/main/kilo.gif" width="100%" />
-</p>
 
 ## Quick Links
 

--- a/kilo.gif
+++ b/kilo.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:886cc2ef559378470546196b141211ca989876366ddeabc3b67fe89af8796c6a
-size 6329619

--- a/packages/kilo-docs/public/img/kilogif.gif
+++ b/packages/kilo-docs/public/img/kilogif.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:886cc2ef559378470546196b141211ca989876366ddeabc3b67fe89af8796c6a
-size 6329619

--- a/packages/kilo-vscode/README.md
+++ b/packages/kilo-vscode/README.md
@@ -20,9 +20,6 @@
 - 🎁 API keys optional
 - 💡 **Get $20 in bonus credits when you top-up for the first time** Credits can be used with 500+ models like Gemini 3 Pro, Claude 4.5 Sonnet & Opus, and GPT-5
 
-<p align="center">
-  <img src="https://media.githubusercontent.com/media/Kilo-Org/kilocode/main/kilo.gif" width="100%" />
-</p>
 
 ## Quick Links
 

--- a/packages/kilo-vscode/README.md
+++ b/packages/kilo-vscode/README.md
@@ -20,7 +20,6 @@
 - 🎁 API keys optional
 - 💡 **Get $20 in bonus credits when you top-up for the first time** Credits can be used with 500+ models like Gemini 3 Pro, Claude 4.5 Sonnet & Opus, and GPT-5
 
-
 ## Quick Links
 
 - [VS Code Marketplace](https://kilo.ai/vscode-marketplace?utm_source=Readme) (download)


### PR DESCRIPTION

Removed two Kilo gifs.

One was in the docs files and was not used: kilogif.gif.
The other (kilo.gif) appeared in the project's README and on the extension README, meaning it loads on the VSCode extension page too.

We have decided to get rid of these files as they were causing problems on the VSCode load page (It's a 6MB gif) and to prevent development issues after moving from raw binaries to having .gif's on Git LFS

### Testing
- Basic testing that the new extension compiles and works
- Will check after the merge that the GIF is not displayed on the README files