### PR TITLE
IngestImport - Bootstrap ingest for imported sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -1,7 +1,6 @@
 import type { Argv } from "yargs"
 import type { Session as SDKSession, Message, Part } from "@kilocode/sdk/v2"
 import { Session } from "../../session"
-import { Bus } from "../../bus"
 import { cmd } from "./cmd"
 import { bootstrap } from "../bootstrap"
 import { Database } from "../../storage/db"
@@ -10,6 +9,9 @@ import { Instance } from "../../project/instance"
 import { ShareNext } from "../../share/share-next"
 import { EOL } from "os"
 import { Filesystem } from "../../util/filesystem"
+import { Log } from "../../util/log"
+
+const log = Log.create({ service: "import-command" })
 
 /** Discriminated union returned by the ShareNext API (GET /api/share/:id/data) */
 export type ShareData =
@@ -64,6 +66,44 @@ export function transformShareData(shareData: ShareData[]): {
     })),
   }
 }
+
+// kilocode_change start
+export function ingestBootstrapWarning(sessionId: string, error: unknown) {
+  const details = error instanceof Error ? error.message : String(error)
+  return `Warning: imported session ${sessionId} locally, but ingest bootstrap failed: ${details}`
+}
+
+async function ingestBootstrap(sessionId: string) {
+  const { KiloSessions } = await import("../../kilo-sessions/kilo-sessions")
+  return KiloSessions.bootstrap(sessionId)
+}
+
+export async function bootstrapImportedSessionIngest(
+  sessionId: string,
+  input?: {
+    bootstrap?: (sessionId: string) => Promise<unknown>
+    warn?: (message: string) => void
+  },
+) {
+  const run = input?.bootstrap ?? ingestBootstrap
+  const warn =
+    input?.warn ??
+    ((message: string) => {
+      process.stderr.write(message)
+      process.stderr.write(EOL)
+    })
+
+  log.info("ingest bootstrap started", { sessionId })
+  await run(sessionId)
+    .then(() => {
+      log.info("ingest bootstrap completed", { sessionId })
+    })
+    .catch((error) => {
+      log.error("ingest bootstrap failed", { sessionId, error })
+      warn(ingestBootstrapWarning(sessionId, error))
+    })
+}
+// kilocode_change end
 
 export const ImportCommand = cmd({
   command: "import <file>",
@@ -134,7 +174,6 @@ export const ImportCommand = cmd({
 
       Database.use((db) => {
         db.insert(SessionTable).values(Session.toRow(exportData.info)).onConflictDoNothing().run()
-        Database.effect(() => Bus.publish(Session.Event.Created, { info: exportData.info }))
       })
 
       for (const msg of exportData.messages) {
@@ -166,6 +205,10 @@ export const ImportCommand = cmd({
           )
         }
       }
+
+      // kilocode_change start
+      await bootstrapImportedSessionIngest(exportData.info.id)
+      // kilocode_change end
 
       process.stdout.write(`Imported session: ${exportData.info.id}`)
       process.stdout.write(EOL)

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -198,17 +198,14 @@ export namespace KiloSessions {
   }
 
   export async function create(sessionId: string) {
-    // kilocode_change start
     const result = await bootstrap(sessionId)
     if (!result) return { id: "", ingestPath: "" }
-    // kilocode_change end
 
     void fullSync(sessionId).catch((error) => log.error("share full sync failed", { sessionId, error }))
 
     return result
   }
 
-  // kilocode_change start
   export async function bootstrap(sessionId: string) {
     if (ingestDisabled) {
       log.info("session bootstrap skipped: ingest disabled", { sessionId })
@@ -240,7 +237,6 @@ export namespace KiloSessions {
 
     return result
   }
-  // kilocode_change end
 
   export async function share(sessionId: string) {
     if (ingestDisabled) {

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -198,8 +198,28 @@ export namespace KiloSessions {
   }
 
   export async function create(sessionId: string) {
+    // kilocode_change start
+    const result = await bootstrap(sessionId)
+    if (!result) return { id: "", ingestPath: "" }
+    // kilocode_change end
+
+    void fullSync(sessionId).catch((error) => log.error("share full sync failed", { sessionId, error }))
+
+    return result
+  }
+
+  // kilocode_change start
+  export async function bootstrap(sessionId: string) {
+    if (ingestDisabled) {
+      log.info("session bootstrap skipped: ingest disabled", { sessionId })
+      return
+    }
+
     const client = await getClient()
-    if (!client) return { id: "", ingestPath: "" }
+    if (!client) {
+      log.info("session bootstrap skipped: no client", { sessionId })
+      return
+    }
 
     log.info("creating session", { sessionId })
 
@@ -216,10 +236,11 @@ export namespace KiloSessions {
 
     await Storage.write(["session_share", sessionId], result)
 
-    void fullSync(sessionId).catch((error) => log.error("share full sync failed", { sessionId, error }))
+    log.info("session bootstrap completed", { sessionId })
 
     return result
   }
+  // kilocode_change end
 
   export async function share(sessionId: string) {
     if (ingestDisabled) {

--- a/packages/opencode/test/cli/import.test.ts
+++ b/packages/opencode/test/cli/import.test.ts
@@ -1,5 +1,11 @@
 import { test, expect } from "bun:test"
-import { parseShareUrl, transformShareData, type ShareData } from "../../src/cli/cmd/import"
+import {
+  parseShareUrl,
+  transformShareData,
+  bootstrapImportedSessionIngest,
+  ingestBootstrapWarning,
+  type ShareData,
+} from "../../src/cli/cmd/import"
 
 // parseShareUrl tests
 test("parses valid share URLs", () => {
@@ -35,4 +41,42 @@ test("returns null for invalid share data", () => {
   expect(transformShareData([])).toBeNull()
   expect(transformShareData([{ type: "message", data: {} as any }])).toBeNull()
   expect(transformShareData([{ type: "session", data: { id: "s" } as any }])).toBeNull() // no messages
+})
+
+test("formats ingest bootstrap warning", () => {
+  expect(ingestBootstrapWarning("session-123", new Error("network failed"))).toContain("session-123")
+  expect(ingestBootstrapWarning("session-123", new Error("network failed"))).toContain("network failed")
+  expect(ingestBootstrapWarning("session-123", "oops")).toContain("oops")
+})
+
+test("bootstrapImportedSessionIngest runs bootstrap and does not warn on success", async () => {
+  const calls: string[] = []
+  const warnings: string[] = []
+
+  await bootstrapImportedSessionIngest("session-success", {
+    bootstrap: async (sessionId) => {
+      calls.push(sessionId)
+    },
+    warn: (message) => warnings.push(message),
+  })
+
+  expect(calls).toEqual(["session-success"])
+  expect(warnings).toHaveLength(0)
+})
+
+test("bootstrapImportedSessionIngest warns and continues on failure", async () => {
+  const warnings: string[] = []
+
+  await expect(
+    bootstrapImportedSessionIngest("session-fail", {
+      bootstrap: async () => {
+        throw new Error("boom")
+      },
+      warn: (message) => warnings.push(message),
+    }),
+  ).resolves.toBeUndefined()
+
+  expect(warnings).toHaveLength(1)
+  expect(warnings[0]).toContain("session-fail")
+  expect(warnings[0]).toContain("boom")
 })


### PR DESCRIPTION
## Summary
- bootstrap session ingest directly during `kilo import` so imported sessions can sync immediately without waiting for event timing
- add `KiloSessions.bootstrap(sessionId)` to initialize remote ingest metadata without forcing a full sync
- keep import resilient by warning (not failing) when ingest bootstrap errors, with tests covering success/failure paths

## Validation
- `bun test test/cli/import.test.ts`