### PR TITLE
feat(compaction): add configurable protectedTools to exempt tools from pruning

### DIFF
--- a/.changeset/configurable-prune-protected-tools.md
+++ b/.changeset/configurable-prune-protected-tools.md
@@ -1,0 +1,22 @@
+---
+"@kilocode/opencode": minor
+---
+
+feat(compaction): add configurable `compaction.protectedTools` to protect additional tools from pruning
+
+The pruner currently only protects the built-in `skill` tool from having its output replaced with `[Old tool result content cleared]`. This makes it impossible for users with MCP-based skill loaders or other context-injecting tools to prevent their content from being silently erased.
+
+This change adds `compaction.protectedTools` to the config schema, allowing users to specify additional tool names that should be exempt from pruning:
+
+```json
+{
+  "compaction": {
+    "protectedTools": ["my_mcp_server_skill_loader"]
+  }
+}
+```
+
+- The built-in `["skill"]` default is always preserved
+- User-specified tools are merged with defaults (concat + dedup)
+- Multiple config layers are merged correctly via `mergeConfigConcatArrays`
+- Fully backward-compatible: no behavior change without explicit config

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -75,6 +75,12 @@ export namespace Config {
     if (target.instructions && source.instructions) {
       merged.instructions = Array.from(new Set([...target.instructions, ...source.instructions]))
     }
+    if (target.compaction?.protectedTools && source.compaction?.protectedTools) {
+      merged.compaction = {
+        ...merged.compaction,
+        protectedTools: Array.from(new Set([...target.compaction.protectedTools, ...source.compaction.protectedTools])),
+      }
+    }
     return merged
   }
 
@@ -1259,6 +1265,10 @@ export namespace Config {
             .min(0)
             .optional()
             .describe("Token buffer for compaction. Leaves enough window to avoid overflow during compaction."),
+          protectedTools: z
+            .array(z.string())
+            .optional()
+            .describe("Additional tool names to protect from pruning (merged with built-in defaults)"),
         })
         .optional(),
       experimental: z

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -50,7 +50,7 @@ export namespace SessionCompaction {
   export const PRUNE_MINIMUM = 20_000
   export const PRUNE_PROTECT = 40_000
 
-  const PRUNE_PROTECTED_TOOLS = ["skill"]
+  const PRUNE_PROTECTED_TOOLS_DEFAULT = ["skill"]
 
   // goes backwards through parts until there are 40_000 tokens worth of tool
   // calls. then erases output of previous tool calls. idea is to throw away old
@@ -58,6 +58,10 @@ export namespace SessionCompaction {
   export async function prune(input: { sessionID: string }) {
     const config = await Config.get()
     if (config.compaction?.prune === false) return
+    const pruneProtectedTools = [
+      ...PRUNE_PROTECTED_TOOLS_DEFAULT,
+      ...(config.compaction?.protectedTools ?? []),
+    ]
     log.info("pruning")
     const msgs = await Session.messages({ sessionID: input.sessionID })
     let total = 0
@@ -74,7 +78,7 @@ export namespace SessionCompaction {
         const part = msg.parts[partIndex]
         if (part.type === "tool")
           if (part.state.status === "completed") {
-            if (PRUNE_PROTECTED_TOOLS.includes(part.tool)) continue
+            if (pruneProtectedTools.includes(part.tool)) continue
 
             if (part.state.time.compacted) break loop
             const estimate = Token.estimate(part.state.output)


### PR DESCRIPTION
## Summary

- Adds `compaction.protectedTools` config option (`string[]`) to specify additional tool names that should be exempt from context pruning
- The built-in `"skill"` tool remains always protected as a hardcoded default
- User-specified tools are merged with defaults using concat + dedup, following the existing pattern for `plugin` and `instructions` arrays

## Problem

The pruner (`prune()` in `compaction.ts`) replaces old tool outputs with `"[Old tool result content cleared]"` to save context window space. Currently, only the built-in `skill` tool is protected from this behavior via a hardcoded array.

Users who rely on MCP-based skill/context loaders (or any tool whose output must persist throughout the session) have no way to prevent their content from being silently erased after ~40k tokens of newer tool output accumulate. This causes the model to lose critical operational context mid-session.

## Solution

Make the protection list configurable:

```json
{
  "compaction": {
    "protectedTools": ["my_mcp_server_skill_loader", "another_context_tool"]
  }
}
```

### Changes

| File | Change |
|------|--------|
| `src/config/config.ts` | Add `protectedTools: z.array(z.string()).optional()` to compaction schema |
| `src/config/config.ts` | Extend `mergeConfigConcatArrays()` to handle nested `compaction.protectedTools` array |
| `src/session/compaction.ts` | Read `protectedTools` from config and merge with built-in default `["skill"]` |

### Design decisions

- **Additive merge, not replace**: User config extends the default list rather than replacing it, so `"skill"` is always protected even if not explicitly listed
- **Follows existing pattern**: `plugin` and `instructions` already use concat + dedup in `mergeConfigConcatArrays()` — this adds the same logic for a nested field
- **Fully backward-compatible**: Without explicit config, behavior is identical to current main
- **Zero runtime cost when unused**: Falls back to spread of empty array (`?? []`)