### PR TITLE
fix: always show copy button at end of AI responses

### DIFF
--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -11,6 +11,10 @@
   [data-slot="text-part-copy-wrapper"] {
     display: none;
   }
+
+  [data-slot="text-part-copy-wrapper"][data-is-turn-copy] {
+    display: block;
+  }
 }
 
 /* Prevent long title/path from hiding the collapsible expand arrow */

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -214,6 +214,12 @@
     gap: 12px;
   }
 
+  /* kilocode_change: always show copy button for the final turn response */
+  [data-slot="text-part-copy-wrapper"][data-is-turn-copy] {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
   &:hover [data-slot="text-part-copy-wrapper"],
   &:focus-within [data-slot="text-part-copy-wrapper"] {
     opacity: 1;

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1114,7 +1114,16 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
           <Markdown text={throttledText()} cacheKey={part.id} onClick={handleMarkdownClick} /> {/* kilocode_change */}
         </div>
         <Show when={showCopy()}>
-          <div data-slot="text-part-copy-wrapper" data-interrupted={interrupted() ? "" : undefined}>
+          {/* kilocode_change: data-is-turn-copy makes the copy button always visible for the final response */}
+          <div
+            data-slot="text-part-copy-wrapper"
+            data-interrupted={interrupted() ? "" : undefined}
+            data-is-turn-copy={
+              typeof props.showAssistantCopyPartID === "string" && props.showAssistantCopyPartID === part.id
+                ? ""
+                : undefined
+            }
+          >
             <Tooltip
               value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
               placement="top"


### PR DESCRIPTION
## Summary

- The copy button on the final text part of an AI response was hidden by default (`opacity: 0`) and only appeared on hover, making it easy to miss
- Users coming from Cline expected a persistently visible copy button at the bottom of each complete answer
- Adds a `data-is-turn-copy` attribute to the copy wrapper div when it is the designated turn-level copy button (`showAssistantCopyPartID` matches the part ID), and a CSS rule that keeps it always visible

## Changes

- `packages/ui/src/components/message-part.tsx`: Add `data-is-turn-copy` attribute to the copy wrapper `<div>` when it's the final-turn copy button
- `packages/ui/src/components/message-part.css`: Add CSS rule `[data-slot="text-part-copy-wrapper"][data-is-turn-copy] { opacity: 1; pointer-events: auto; }` so the button is permanently visible

The hover-reveal behavior is preserved for all other copy buttons (user messages, intermediate text parts). Only the final response copy button in each turn is affected.

Closes #6227