### PR TITLE
fix: ask mode respects user permission config for edit tools

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -173,6 +173,7 @@ export namespace Agent {
         options: {},
         permission: PermissionNext.merge(
           defaults,
+          user, // kilocode_change: user before ask-specific so ask's deny+allowlist wins
           PermissionNext.fromConfig({
             "*": "deny",
             read: {
@@ -192,7 +193,6 @@ export namespace Agent {
               [Truncate.GLOB]: "allow",
             },
           }),
-          user,
         ),
         mode: "primary",
         native: true,

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -91,8 +91,9 @@ test("ask agent denies edit/write/bash even when user config adds a specific edi
     fn: async () => {
       const ask = await Agent.get("ask")
       expect(ask).toBeDefined()
-      // user config must not leak edit capability into ask mode
-      expect(evalPerm(ask, "edit")).toBe("deny")
+      // user config must not leak edit capability into ask mode — even for the
+      // specific path the user allowed, ask mode must still deny it
+      expect(PermissionNext.evaluate("edit", "src/output.log", ask!.permission).action).toBe("deny")
       expect(evalPerm(ask, "bash")).toBe("deny")
       expect(evalPerm(ask, "task")).toBe("deny")
       // safe tools still work

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -78,6 +78,34 @@ test("ask agent has correct default properties", async () => {
     },
   })
 })
+test("ask agent denies edit/write/bash even when user config adds a specific edit allow", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      permission: {
+        edit: { "src/output.log": "allow" },
+      },
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const ask = await Agent.get("ask")
+      expect(ask).toBeDefined()
+      // user config must not leak edit capability into ask mode
+      expect(evalPerm(ask, "edit")).toBe("deny")
+      expect(evalPerm(ask, "bash")).toBe("deny")
+      expect(evalPerm(ask, "task")).toBe("deny")
+      // safe tools still work
+      expect(evalPerm(ask, "read")).toBe("allow")
+      expect(evalPerm(ask, "grep")).toBe("allow")
+      // disabled() must also reflect the deny (tools hidden from LLM)
+      const disabled = PermissionNext.disabled(["edit", "write", "bash"], ask!.permission)
+      expect(disabled.has("edit")).toBe(true)
+      expect(disabled.has("write")).toBe(true)
+      expect(disabled.has("bash")).toBe(true)
+    },
+  })
+})
 // kilocode_change end
 
 test("plan agent denies edits except .opencode/plans/*", async () => {


### PR DESCRIPTION
## Summary

Fixes #6235 — ask mode could make edits when a user had global permission config containing specific-pattern `edit` rules (e.g. `edit: { "src/log.ts": "allow" }`).

## Root cause

The ask agent built its permission ruleset as `merge(defaults, askRules, user)`. With `user` last, a specific-path `edit` rule from global config was appended after ask's `"*": "deny"`. `PermissionNext.disabled()` uses `findLast` to find the last rule matching a permission — it would stop at the user's specific-pattern rule, see `pattern !== "*"`, and **not** remove edit/write/bash from the LLM's tool list.

## Fix

Swap the merge order so ask's deny+allowlist comes **after** `user`:

```ts
// Before
merge(defaults, fromConfig({ "*": "deny", read: ..., grep: "allow", ... }), user)

// After
merge(defaults, user, fromConfig({ "*": "deny", read: ..., grep: "allow", ... }))
```

Now ask's `"*": "deny"` is always the last wildcard rule for `edit`/`bash`/`task`, so `disabled()` correctly removes them from the LLM's tool list regardless of user config.

## Changes

- `packages/opencode/src/agent/agent.ts` — swap merge order for ask agent (1-line change)
- `packages/opencode/test/agent/agent.test.ts` — add regression test covering the bypass scenario