### PR TITLE
feat: auto-update changelog on GitHub release

### DIFF
--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -1,0 +1,121 @@
+name: release-changelog
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  changelog-pr:
+    runs-on: ubuntu-24.04
+    if: github.repository == 'Kilo-Org/kilocode' && !github.event.release.prerelease
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Git Committer
+        id: committer
+        uses: ./.github/actions/setup-git-committer
+        with:
+          kilo-maintainer-app-id: ${{ secrets.KILO_MAINTAINER_APP_ID }}
+          kilo-maintainer-app-secret: ${{ secrets.KILO_MAINTAINER_APP_SECRET }}
+
+      - name: Get release info
+        id: release
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          BODY: ${{ github.event.release.body }}
+        run: |
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          # Write body to a temp file to avoid shell escaping issues
+          printf '%s' "$BODY" > /tmp/release-body.md
+
+      - name: Update CHANGELOG.md
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          BODY=$(cat /tmp/release-body.md)
+
+          # Build the new entry
+          ENTRY=$(printf '## [%s] - %s\n\n%s\n' "$TAG" "$DATE" "$BODY")
+
+          if [ -f CHANGELOG.md ]; then
+            # Insert after the header block (first blank line after the opening lines)
+            # Find line number of first "## " heading or end of header
+            INSERT_LINE=$(grep -n "^## \[" CHANGELOG.md | head -1 | cut -d: -f1)
+
+            if [ -n "$INSERT_LINE" ]; then
+              # Insert before the first existing version heading
+              {
+                head -n $((INSERT_LINE - 1)) CHANGELOG.md
+                printf '\n%s\n\n' "$ENTRY"
+                tail -n +$INSERT_LINE CHANGELOG.md
+              } > CHANGELOG.md.tmp
+            else
+              # No existing entries - append after the file content
+              {
+                cat CHANGELOG.md
+                printf '\n%s\n' "$ENTRY"
+              } > CHANGELOG.md.tmp
+            fi
+            mv CHANGELOG.md.tmp CHANGELOG.md
+          else
+            # Create fresh
+            printf '# Changelog\n\nAll notable changes to Kilo Code are documented here and on the [docs changelog page](https://kilo.ai/docs/community/changelog).\n\n%s\n' "$ENTRY" > CHANGELOG.md
+          fi
+
+      - name: Update docs changelog
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          DOCS_CHANGELOG="packages/kilo-docs/pages/community/changelog.md"
+          DATE=$(date -u +%Y-%m-%d)
+          BODY=$(cat /tmp/release-body.md)
+
+          ENTRY=$(printf '## [%s] - %s\n\n%s\n' "$TAG" "$DATE" "$BODY")
+
+          if [ -f "$DOCS_CHANGELOG" ]; then
+            INSERT_LINE=$(grep -n "^## \[" "$DOCS_CHANGELOG" | head -1 | cut -d: -f1)
+
+            if [ -n "$INSERT_LINE" ]; then
+              {
+                head -n $((INSERT_LINE - 1)) "$DOCS_CHANGELOG"
+                printf '\n%s\n\n' "$ENTRY"
+                tail -n +$INSERT_LINE "$DOCS_CHANGELOG"
+              } > "${DOCS_CHANGELOG}.tmp"
+            else
+              {
+                cat "$DOCS_CHANGELOG"
+                printf '\n%s\n' "$ENTRY"
+              } > "${DOCS_CHANGELOG}.tmp"
+            fi
+            mv "${DOCS_CHANGELOG}.tmp" "$DOCS_CHANGELOG"
+          else
+            printf -- '---\ntitle: "Changelog"\ndescription: "Release notes for Kilo Code"\n---\n\n# Changelog\n\nThis page is automatically updated when a new version of Kilo Code is released.\n\n%s\n' "$ENTRY" > "$DOCS_CHANGELOG"
+          fi
+
+      - name: Create PR
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+          GH_TOKEN: ${{ steps.committer.outputs.token }}
+        run: |
+          BRANCH="changelog/$TAG"
+          git checkout -b "$BRANCH"
+          git add CHANGELOG.md packages/kilo-docs/pages/community/changelog.md
+          git commit -m "docs: add $TAG release notes to changelog"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "docs: add $TAG release notes to changelog" \
+            --body "Automated PR to add release notes from [$TAG](https://github.com/${{ github.repository }}/releases/tag/$TAG) to the changelog.
+
+          Updates:
+          - \`CHANGELOG.md\` (root)
+          - \`packages/kilo-docs/pages/community/changelog.md\` (docs site)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to Kilo Code are documented here and on the [docs changelog page](https://kilo.ai/docs/community/changelog).
+
+This file is automatically updated by the [release-changelog workflow](.github/workflows/release-changelog.yml) when a new GitHub release is published.

--- a/packages/kilo-docs/components/SideNav.tsx
+++ b/packages/kilo-docs/components/SideNav.tsx
@@ -14,6 +14,7 @@ const sectionNavItems: SectionNav = {
   automate: Nav.AutomateNav,
   "deploy-secure": Nav.DeploySecureNav,
   contributing: Nav.ContributingNav,
+  community: Nav.ContributingNav, // kilocode_change - community pages share the contributing nav
   "ai-providers": Nav.AiProvidersNav,
   gateway: Nav.GatewayNav,
 }

--- a/packages/kilo-docs/lib/nav/contributing.ts
+++ b/packages/kilo-docs/lib/nav/contributing.ts
@@ -82,4 +82,10 @@ export const ContributingNav: NavSection[] = [
       },
     ],
   },
+  {
+    title: "Resources",
+    links: [
+      { href: "/community/changelog", children: "Changelog" },
+    ],
+  },
 ]

--- a/packages/kilo-docs/pages/community/changelog.md
+++ b/packages/kilo-docs/pages/community/changelog.md
@@ -1,0 +1,8 @@
+---
+title: "Changelog"
+description: "Release notes for Kilo Code"
+---
+
+# Changelog
+
+This page is automatically updated when a new version of Kilo Code is released. You can also view the full changelog on [GitHub](https://github.com/Kilo-Org/kilocode/blob/main/CHANGELOG.md).


### PR DESCRIPTION
Add a GitHub Actions workflow that triggers when a release is published and automatically:

1. Prepends the release notes to `CHANGELOG.md` (root)
2. Updates the docs changelog page at `packages/kilo-docs/pages/community/changelog.md`
3. Creates a PR with the changes (the **inner** PR, created by the workflow)

## New files
- `.github/workflows/release-changelog.yml` — the workflow
- `CHANGELOG.md` — root changelog (auto-updated)
- `packages/kilo-docs/pages/community/changelog.md` — docs changelog page

## Modified files
- `packages/kilo-docs/lib/nav/contributing.ts` — adds Changelog link under Resources
- `packages/kilo-docs/components/SideNav.tsx` — maps `/community` routes to the contributing sidebar nav

## How it works
When a non-prerelease GitHub release is published, the `release-changelog` workflow:
1. Checks out `main`
2. Reads the release tag and body
3. Prepends a `## [vX.Y.Z] - YYYY-MM-DD` entry to both changelog files
4. Creates a `changelog/vX.Y.Z` branch and opens a PR against `main`