### PR TITLE
fix: strip leading $ prompt indicator when copying shell commands

### DIFF
--- a/packages/kilo-ui/tests/visual-regression.spec.ts-snapshots/components-sessionturn/default-chromium-linux.png
+++ b/packages/kilo-ui/tests/visual-regression.spec.ts-snapshots/components-sessionturn/default-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c67c7cc21cd458c632228bdcee310615fae82c6d4c76e4d1170fa00224a9ac3
-size 29215
+oid sha256:1de30d219cd299acf26c9fe473c00f18cf057297db2e9b1ae44fb3116b0392f0
+size 31305

--- a/packages/kilo-ui/tests/visual-regression.spec.ts-snapshots/components-sessionturn/with-steps-expanded-chromium-linux.png
+++ b/packages/kilo-ui/tests/visual-regression.spec.ts-snapshots/components-sessionturn/with-steps-expanded-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c67c7cc21cd458c632228bdcee310615fae82c6d4c76e4d1170fa00224a9ac3
-size 29215
+oid sha256:1de30d219cd299acf26c9fe473c00f18cf057297db2e9b1ae44fb3116b0392f0
+size 31305

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1438,8 +1438,11 @@ ToolRegistry.register({
     const [copied, setCopied] = createSignal(false)
 
     const handleCopy = async () => {
-      const content = text()
-      if (!content) return
+      // kilocode_change start - strip leading "$ " prompt indicator from copied text
+      const raw = text()
+      if (!raw) return
+      const content = raw.startsWith("$ ") ? raw.slice(2) : raw
+      // kilocode_change end
       await navigator.clipboard.writeText(content)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1430,19 +1430,17 @@ ToolRegistry.register({
   name: "bash",
   render(props) {
     const i18n = useI18n()
-    const text = createMemo(() => {
-      const cmd = props.input.command ?? props.metadata.command ?? ""
-      const out = stripAnsi(props.output || props.metadata.output || "")
-      return `$ ${cmd}${out ? "\n\n" + out : ""}`
-    })
+    // kilocode_change start - separate cmd/output memos so copy excludes the "$ " display prefix
+    const cmd = createMemo(() => props.input.command ?? props.metadata.command ?? "")
+    const out = createMemo(() => stripAnsi(props.output || props.metadata.output || ""))
+    const text = createMemo(() => `$ ${cmd()}${out() ? "\n\n" + out() : ""}`)
+    // kilocode_change end
     const [copied, setCopied] = createSignal(false)
 
     const handleCopy = async () => {
-      // kilocode_change start - strip leading "$ " prompt indicator from copied text
-      const raw = text()
-      if (!raw) return
-      const content = raw.startsWith("$ ") ? raw.slice(2) : raw
-      // kilocode_change end
+      const command = cmd()
+      if (!command) return
+      const content = out() ? `${command}\n\n${out()}` : command // kilocode_change
       await navigator.clipboard.writeText(content)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1438,7 +1438,7 @@ ToolRegistry.register({
     const [copied, setCopied] = createSignal(false)
 
     const handleCopy = async () => {
-      const command = cmd()
+      const command = cmd() // kilocode_change
       if (!command) return
       const content = out() ? `${command}\n\n${out()}` : command // kilocode_change
       await navigator.clipboard.writeText(content)


### PR DESCRIPTION
## Summary

- When clicking the copy button on a bash tool output block, the copied text incorrectly included the `$ ` prompt prefix
- The `$ ` prefix is only meant for visual display and should not be included in the clipboard content
- Fixed by stripping the `$ ` prefix in `handleCopy` before writing to clipboard, while leaving the display unchanged

Fixes #6559