### PR TITLE
fix(ci): support fork PRs in visual regression workflow

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -25,6 +25,7 @@ jobs:
           lfs: true
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -77,6 +78,7 @@ jobs:
 
       - name: Commit and push new baselines (if any)
         id: commit-baselines
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -91,11 +93,20 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Fail if baselines changed
+      - name: Fail if baselines changed (same-repo PR)
         if: steps.commit-baselines.outputs.changed == 'true'
         run: |
           echo "::error::Visual regression baselines changed. New baselines have been committed to the branch. Please pull and review."
           exit 1
+
+      - name: Fail if baselines changed (fork PR)
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          git add packages/kilo-ui/tests/visual-regression.spec.ts-snapshots/
+          if ! git diff --cached --quiet; then
+            echo "::error::Visual regression baselines need updating. Please run 'bun run test:visual:update' locally and commit the changes."
+            exit 1
+          fi
 
       - name: Upload test results on failure
         if: failure()
@@ -117,6 +128,7 @@ jobs:
           lfs: true
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -169,6 +181,7 @@ jobs:
 
       - name: Commit and push new baselines (if any)
         id: commit-baselines-vscode
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -183,11 +196,20 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Fail if baselines changed
+      - name: Fail if baselines changed (same-repo PR)
         if: steps.commit-baselines-vscode.outputs.changed == 'true'
         run: |
           echo "::error::Visual regression baselines changed. New baselines have been committed to the branch. Please pull and review."
           exit 1
+
+      - name: Fail if baselines changed (fork PR)
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          git add packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/
+          if ! git diff --cached --quiet; then
+            echo "::error::Visual regression baselines need updating. Please run 'bun run test:visual:update' locally and commit the changes."
+            exit 1
+          fi
 
       - name: Upload test results on failure
         if: failure()


### PR DESCRIPTION
## Context

https://github.com/Kilo-Org/kilocode/actions/runs/22636380662/job/65600277822?pr=6561

The Visual Regression Tests workflow was failing for fork PRs (e.g. [#6561](https://github.com/Kilo-Org/kilocode/pull/6561)) because `actions/checkout@v4` was trying to fetch `github.head_ref` from the base repository (`Kilo-Org/kilocode`), but the branch only exists in the contributor's fork. This caused a fatal git fetch error on all 3 retry attempts.

Additionally, the "Commit and push new baselines" step would also fail for fork PRs since `GITHUB_TOKEN` does not have write access to external forks.

## Implementation

Three changes applied to both jobs (`visual-regression` and `visual-regression-vscode`):

1. **Added `repository:` to checkout steps** — uses `github.event.pull_request.head.repo.full_name` so the action fetches from the fork's repo when the PR is cross-repository.

2. **Guarded the commit/push step** — added `if: github.event.pull_request.head.repo.full_name == github.repository` so the auto-commit of new baselines is skipped for fork PRs (where we have no push access).

3. **Added a fork-specific baseline check** — a new step runs only for fork PRs (`if: ... != github.repository`) and detects if `test:visual:update` generated new/changed snapshots, failing with a clear error message directing the contributor to run the command locally and commit the results.

## Screenshots

N/A — CI workflow change only.

## How to Test

- Open a fork PR that touches `packages/kilo-ui/**` or `packages/kilo-vscode/webview-ui/**`
- The Visual Regression Tests workflow should now complete the checkout step successfully instead of failing with `git fetch exit code 1`

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->