### PR TITLE
fix: enforce agent manager locale parity and localize new strings

### DIFF
--- a/packages/kilo-vscode/tests/unit/agent-manager-i18n-split.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-i18n-split.test.ts
@@ -72,6 +72,12 @@ const appLocales = {
   bs: appBs,
 }
 
+function placeholders(text: string): string[] {
+  return Array.from(text.matchAll(/\{\{\s*([\w.]+)\s*\}\}/g))
+    .flatMap((match) => (match[1] ? [match[1]] : []))
+    .sort()
+}
+
 describe("Agent Manager i18n split", () => {
   it("keeps agent manager keys out of general locale dictionaries", () => {
     for (const [locale, dict] of Object.entries(appLocales)) {
@@ -89,6 +95,35 @@ describe("Agent Manager i18n split", () => {
       expect(keys.length, `locale ${locale} should have agent manager keys`).toBeGreaterThan(0)
       const invalid = keys.filter((key) => !key.startsWith(PREFIX))
       expect(invalid, `locale ${locale} has non-agent-manager keys`).toEqual([])
+    }
+  })
+
+  it("keeps every agent manager locale keyset aligned with english", () => {
+    const baseKeys = Object.keys(amEn)
+
+    for (const [locale, dict] of Object.entries(locales)) {
+      const keySet = new Set(Object.keys(dict))
+      const missing = baseKeys.filter((key) => !keySet.has(key))
+      const extra = Array.from(keySet).filter((key) => !(key in amEn))
+
+      expect(missing, `locale ${locale} is missing agent manager keys`).toEqual([])
+      expect(extra, `locale ${locale} has unexpected agent manager keys`).toEqual([])
+    }
+  })
+
+  it("keeps interpolation placeholders aligned with english", () => {
+    for (const [locale, dict] of Object.entries(locales)) {
+      if (locale === "en") continue
+
+      for (const [key, value] of Object.entries(amEn)) {
+        const localized = (dict as Record<string, string>)[key]
+        expect(localized, `missing key ${key} in locale ${locale}`).toBeDefined()
+        if (!localized) continue
+
+        const baseVars = placeholders(value)
+        const localeVars = placeholders(localized)
+        expect(localeVars, `placeholder mismatch for ${key} in locale ${locale}`).toEqual(baseVars)
+      }
     }
   })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -127,8 +127,10 @@ export const dict = {
   "agentManager.review.sendToChat": "إرسال إلى الدردشة",
   "agentManager.review.collapsedOnly": "{{count}} مطوي",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} مطوي، {{large}} كبير",
+  "agentManager.review.largeFileCollapsed": "ملف كبير (مطوي)",
+  "agentManager.review.endOfLongDiff": "لقد وصلت إلى النهاية!",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "طلب سحب",
   "agentManager.import.pastePrUrl": "الصق رابط PR...",
   "agentManager.import.open": "فتح",
   "agentManager.import.branches": "الفروع",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -127,8 +127,10 @@ export const dict = {
   "agentManager.review.sendToChat": "Enviar para o chat",
   "agentManager.review.collapsedOnly": "{{count}} recolhidos",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} recolhidos, {{large}} grandes",
+  "agentManager.review.largeFileCollapsed": "Arquivo grande (recolhido)",
+  "agentManager.review.endOfLongDiff": "Você chegou ao fim!",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "Solicitação de extração",
   "agentManager.import.pastePrUrl": "Cole a URL do PR...",
   "agentManager.import.open": "Abrir",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -127,8 +127,10 @@ export const dict = {
   "agentManager.review.sendToChat": "Pošalji u chat",
   "agentManager.review.collapsedOnly": "{{count}} sažeto",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} sažeto, {{large}} velikih",
+  "agentManager.review.largeFileCollapsed": "Velika datoteka (skupljeno)",
+  "agentManager.review.endOfLongDiff": "Stigli ste do kraja!",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "Zahtjev za povlačenje",
   "agentManager.import.pastePrUrl": "Zalijepite PR URL...",
   "agentManager.import.open": "Otvori",
   "agentManager.import.branches": "Branchevi",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -127,8 +127,10 @@ export const dict = {
   "agentManager.review.sendToChat": "Send til chat",
   "agentManager.review.collapsedOnly": "{{count}} foldet sammen",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} foldet sammen, {{large}} store",
+  "agentManager.review.largeFileCollapsed": "Stor fil (kollapset)",
+  "agentManager.review.endOfLongDiff": "Du er nået til slutningen!",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "Fletteanmodning",
   "agentManager.import.pastePrUrl": "Indsæt PR URL...",
   "agentManager.import.open": "Åbn",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -128,8 +128,10 @@ export const dict = {
   "agentManager.review.sendToChat": "An Chat senden",
   "agentManager.review.collapsedOnly": "{{count}} eingeklappt",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} eingeklappt, {{large}} groß",
+  "agentManager.review.largeFileCollapsed": "Große Datei (zugeklappt)",
+  "agentManager.review.endOfLongDiff": "Du hast das Ende erreicht!",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "Zusammenführungsanfrage",
   "agentManager.import.pastePrUrl": "PR-URL einfügen...",
   "agentManager.import.open": "Öffnen",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -128,8 +128,10 @@ export const dict = {
   "agentManager.review.sendToChat": "Enviar al chat",
   "agentManager.review.collapsedOnly": "{{count}} contraídos",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} contraídos, {{large}} grandes",
+  "agentManager.review.largeFileCollapsed": "Archivo grande (contraído)",
+  "agentManager.review.endOfLongDiff": "¡Has llegado al final!",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "Solicitud de extracción",
   "agentManager.import.pastePrUrl": "Pegar URL del PR...",
   "agentManager.import.open": "Abrir",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -129,8 +129,10 @@ export const dict = {
   "agentManager.review.sendToChat": "Envoyer au chat",
   "agentManager.review.collapsedOnly": "{{count}} repliés",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} repliés, {{large}} volumineux",
+  "agentManager.review.largeFileCollapsed": "Fichier volumineux (réduit)",
+  "agentManager.review.endOfLongDiff": "Vous êtes arrivé à la fin !",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "Demande d'extraction",
   "agentManager.import.pastePrUrl": "Coller l'URL du PR...",
   "agentManager.import.open": "Ouvrir",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -129,8 +129,10 @@ export const dict = {
   "agentManager.review.sendToChat": "チャットに送信",
   "agentManager.review.collapsedOnly": "{{count}} 件折りたたみ",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} 件折りたたみ、{{large}} 件がサイズ大",
+  "agentManager.review.largeFileCollapsed": "大きなファイル (折りたたみ済み)",
+  "agentManager.review.endOfLongDiff": "最後まで到達しました！",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "プルリクエスト",
   "agentManager.import.pastePrUrl": "PR URLを貼り付け...",
   "agentManager.import.open": "開く",
   "agentManager.import.branches": "ブランチ",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -128,8 +128,10 @@ export const dict = {
   "agentManager.review.sendToChat": "채팅으로 보내기",
   "agentManager.review.collapsedOnly": "{{count}}개 접힘",
   "agentManager.review.collapsedWithLarge": "{{collapsed}}개 접힘, {{large}}개 대용량",
+  "agentManager.review.largeFileCollapsed": "큰 파일 (접힘)",
+  "agentManager.review.endOfLongDiff": "끝까지 확인하셨습니다!",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "풀 리퀘스트",
   "agentManager.import.pastePrUrl": "PR URL 붙여넣기...",
   "agentManager.import.open": "열기",
   "agentManager.import.branches": "브랜치",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -127,8 +127,10 @@ export const dict = {
   "agentManager.review.sendToChat": "Send til chat",
   "agentManager.review.collapsedOnly": "{{count}} kollapset",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} kollapset, {{large}} store",
+  "agentManager.review.largeFileCollapsed": "Stor fil (kollapset)",
+  "agentManager.review.endOfLongDiff": "Du har nådd slutten!",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "Fletteforespørsel",
   "agentManager.import.pastePrUrl": "Lim inn PR URL...",
   "agentManager.import.open": "Åpne",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -128,8 +128,10 @@ export const dict = {
   "agentManager.review.sendToChat": "Wyślij do czatu",
   "agentManager.review.collapsedOnly": "{{count}} zwiniętych",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} zwiniętych, {{large}} dużych",
+  "agentManager.review.largeFileCollapsed": "Duży plik (zwinięty)",
+  "agentManager.review.endOfLongDiff": "Dotarłeś do końca!",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "Prośba o scalenie",
   "agentManager.import.pastePrUrl": "Wklej URL PR...",
   "agentManager.import.open": "Otwórz",
   "agentManager.import.branches": "Branche",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -127,8 +127,10 @@ export const dict = {
   "agentManager.review.sendToChat": "Отправить в чат",
   "agentManager.review.collapsedOnly": "{{count}} свернуто",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} свернуто, {{large}} больших",
+  "agentManager.review.largeFileCollapsed": "Большой файл (свернут)",
+  "agentManager.review.endOfLongDiff": "Вы дошли до конца!",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "Запрос на слияние",
   "agentManager.import.pastePrUrl": "Вставьте URL PR...",
   "agentManager.import.open": "Открыть",
   "agentManager.import.branches": "Ветки",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -128,8 +128,10 @@ export const dict = {
   "agentManager.review.sendToChat": "ส่งไปยังแชท",
   "agentManager.review.collapsedOnly": "ยุบ {{count}} รายการ",
   "agentManager.review.collapsedWithLarge": "ยุบ {{collapsed}} รายการ, ขนาดใหญ่ {{large}} รายการ",
+  "agentManager.review.largeFileCollapsed": "ไฟล์ขนาดใหญ่ (ย่อไว้)",
+  "agentManager.review.endOfLongDiff": "คุณมาถึงส่วนท้ายแล้ว!",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "คำขอดึง",
   "agentManager.import.pastePrUrl": "วาง URL ของ PR...",
   "agentManager.import.open": "เปิด",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -126,8 +126,10 @@ export const dict = {
   "agentManager.review.sendToChat": "发送到聊天",
   "agentManager.review.collapsedOnly": "{{count}} 个已折叠",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} 个已折叠，{{large}} 个过大",
+  "agentManager.review.largeFileCollapsed": "大文件（已折叠）",
+  "agentManager.review.endOfLongDiff": "您已到达末尾！",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "拉取请求",
   "agentManager.import.pastePrUrl": "粘贴 PR URL...",
   "agentManager.import.open": "打开",
   "agentManager.import.branches": "分支",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -126,8 +126,10 @@ export const dict = {
   "agentManager.review.sendToChat": "傳送到聊天",
   "agentManager.review.collapsedOnly": "{{count}} 個已摺疊",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} 個已摺疊，{{large}} 個過大",
+  "agentManager.review.largeFileCollapsed": "大檔案（已摺疊）",
+  "agentManager.review.endOfLongDiff": "您已到達底部！",
 
-  "agentManager.import.pullRequest": "Pull Request",
+  "agentManager.import.pullRequest": "拉取請求",
   "agentManager.import.pastePrUrl": "貼上 PR URL...",
   "agentManager.import.open": "開啟",
   "agentManager.import.branches": "分支",


### PR DESCRIPTION
## Summary
- add stricter Agent Manager i18n lint coverage to validate full locale key parity against English
- validate interpolation placeholder parity (`{{...}}`) across Agent Manager locales
- localize newly added Agent Manager strings for large-diff labels and import tab wording in all non-English locales

## Validation
- `bun run compile`
- `bun run test:unit`