### PR TITLE
fix: prevent small-model LLM.stream requests from leaking into agent sessions

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -280,12 +280,13 @@ export namespace LLM {
 
   async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user">) {
     const disabled = PermissionNext.disabled(Object.keys(input.tools), input.agent.permission)
-    for (const tool of Object.keys(input.tools)) {
+    const tools = { ...input.tools }
+    for (const tool of Object.keys(tools)) {
       if (input.user.tools?.[tool] === false || disabled.has(tool)) {
-        delete input.tools[tool]
+        delete tools[tool]
       }
     }
-    return input.tools
+    return tools
   }
 
   // Check if messages contain any tool-call content

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1993,7 +1993,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       tools: {},
       model,
       abort: new AbortController().signal,
-      sessionID: input.session.id,
+      sessionID: `title-${input.session.id}`, // kilocode_change - avoid task ID collision with main agent request
       retries: 2,
       messages: [
         {


### PR DESCRIPTION
## Summary

Fixes #6552

### Root cause

When `ensureTitle` fires on the first step of an agent session, it calls `LLM.stream` with `small: true` and **the same `sessionID`** as the main agent request. Because `ensureTitle` is not awaited, both the title-generation request (small model) and the main agent request race to the Kilo Gateway simultaneously with the same `HEADER_TASKID`, causing the gateway to attribute both requests to the same session/task — the observable symptom of the bug.

### Fix

- **`prompt.ts`**: Use `title-{sessionID}` as the `sessionID` for `ensureTitle`'s `LLM.stream` call, giving it a distinct `HEADER_TASKID` from the main agent request so the gateway keeps them separate.

- **`llm.ts`**: `resolveTools` was deleting from `input.tools` directly (mutates the caller's shared object). Fixed by shallow-copying first, so tool availability is not silently degraded across loop iterations in the processor.