### PR TITLE
Add "New Task" button to TaskHeader

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/chat-view-idle-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/chat-view-idle-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d385bd579ac5587b1f70416196f77b6465d6a69fedf7270b889eedb29d0ac73d
-size 14864
+oid sha256:a3774fc422d473693e38fafba61c00632fd49d2a0c61d2332b9c31482af78a2b
+size 15268

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/chat-view-with-messages-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/chat-view-with-messages-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d69f44620c8e3a2f8d54ec97903c95cde04bef4655fc3b280a318e6da3cb0b5
+size 9082

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-multi-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-multi-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db0467fd219dfc19b4b27e32ff29c7f81e68091c58bb6b9209e6baa4e5f396ac
-size 19507
+oid sha256:7db2475f52aa88237c12cbebe5dabfd3b9ff4f4fdb211f419dcd3562a61935f8
+size 19964

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-single-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-single-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:04d857626cd157bf7f3325f50f48f5c9f95302a836f873cd9249aabbb6b22c8e
-size 25422
+oid sha256:d3e4cfc91ddf3515d7049d348df875ac38ac9296ab7ce606a0b229f40866785f
+size 25935

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/shared/model-selector-no-providers-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/shared/model-selector-no-providers-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56517eed0845a01559a613124e5cf8f48945bbfc6f0fb6e3274ca5607954cb0c
-size 1293
+oid sha256:e0f7858b22d02fc7f30de4faae3f1f95ad7022e5e86741304b67d0f28f423e71
+size 1296

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -170,7 +170,7 @@ const AppContent: Component = () => {
   const handleViewAction = (action: string) => {
     switch (action) {
       case "plusButtonClicked":
-        session.clearCurrentSession()
+        window.dispatchEvent(new CustomEvent("newTaskRequest"))
         setCurrentView("newTask")
         break
       case "marketplaceButtonClicked":

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -105,15 +105,17 @@ export const ChatView: Component<ChatViewProps> = (props) => {
             )}
           </Show>
           <Show when={hasMessages() && idle() && !blocked()}>
-            <Button
-              variant="secondary"
-              size="small"
-              class="new-task-button"
-              onClick={() => window.dispatchEvent(new CustomEvent("newTaskRequest"))}
-              aria-label={language.t("command.session.new.task")}
-            >
-              {language.t("command.session.new.task")}
-            </Button>
+            <div class="new-task-button-wrapper">
+              <Button
+                variant="secondary"
+                size="small"
+                data-full-width="true"
+                onClick={() => window.dispatchEvent(new CustomEvent("newTaskRequest"))}
+                aria-label={language.t("command.session.new.task")}
+              >
+                {language.t("command.session.new.task")}
+              </Button>
+            </div>
           </Show>
           <Show when={!blocked()}>
             <PromptInput />

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -23,6 +23,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   const language = useLanguage()
 
   const id = () => session.currentSessionID()
+  const hasMessages = () => session.messages().length > 0
   const sessionQuestions = () => session.questions().filter((q) => q.sessionID === id())
   const sessionPermissions = () => session.permissions().filter((p) => p.sessionID === id())
 
@@ -101,6 +102,17 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                 </div>
               </div>
             )}
+          </Show>
+          <Show when={hasMessages() && !blocked()}>
+            <Button
+              variant="secondary"
+              size="small"
+              class="new-task-button"
+              onClick={() => window.dispatchEvent(new CustomEvent("newTaskRequest"))}
+              aria-label={language.t("command.session.new.task")}
+            >
+              {language.t("command.session.new.task")}
+            </Button>
           </Show>
           <Show when={!blocked()}>
             <PromptInput />

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -24,6 +24,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
 
   const id = () => session.currentSessionID()
   const hasMessages = () => session.messages().length > 0
+  const idle = () => session.status() !== "busy"
   const sessionQuestions = () => session.questions().filter((q) => q.sessionID === id())
   const sessionPermissions = () => session.permissions().filter((p) => p.sessionID === id())
 
@@ -103,7 +104,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
               </div>
             )}
           </Show>
-          <Show when={hasMessages() && !blocked()}>
+          <Show when={hasMessages() && idle() && !blocked()}>
             <Button
               variant="secondary"
               size="small"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -72,6 +72,27 @@ export const PromptInput: Component = () => {
   window.addEventListener("focusPrompt", onFocusPrompt)
   onCleanup(() => window.removeEventListener("focusPrompt", onFocusPrompt))
 
+  // Start a new task, carrying over the current prompt text if any
+  const onNewTaskRequest = () => {
+    const prompt = text().trim()
+    const sel = session.selected()
+    session.clearCurrentSession()
+    if (prompt) {
+      session.sendMessage(prompt, sel?.providerID, sel?.modelID)
+      setText("")
+      setGhostText("")
+      imageAttach.clear()
+      if (debounceTimer) clearTimeout(debounceTimer)
+      mention.closeMention()
+      if (textareaRef) {
+        textareaRef.value = ""
+        textareaRef.style.height = "auto"
+      }
+    }
+  }
+  window.addEventListener("newTaskRequest", onNewTaskRequest)
+  onCleanup(() => window.removeEventListener("newTaskRequest", onNewTaskRequest))
+
   const isBusy = () => session.status() === "busy"
   const isDisabled = () => !server.isConnected()
   const canSend = () => (text().trim().length > 0 || imageAttach.images().length > 0) && !isBusy() && !isDisabled()

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -72,23 +72,12 @@ export const PromptInput: Component = () => {
   window.addEventListener("focusPrompt", onFocusPrompt)
   onCleanup(() => window.removeEventListener("focusPrompt", onFocusPrompt))
 
-  // Start a new task, carrying over the current prompt text if any
+  // Start a new task, carrying over the current prompt text (without auto-sending it)
   const onNewTaskRequest = () => {
     const prompt = text().trim()
-    const sel = session.selected()
+    // Pre-populate the draft for the new (empty) session so the effect restores it
+    if (prompt) drafts.set("__new__", prompt)
     session.clearCurrentSession()
-    if (prompt) {
-      session.sendMessage(prompt, sel?.providerID, sel?.modelID)
-      setText("")
-      setGhostText("")
-      imageAttach.clear()
-      if (debounceTimer) clearTimeout(debounceTimer)
-      mention.closeMention()
-      if (textareaRef) {
-        textareaRef.value = ""
-        textareaRef.style.height = "auto"
-      }
-    }
   }
   window.addEventListener("newTaskRequest", onNewTaskRequest)
   onCleanup(() => window.removeEventListener("newTaskRequest", onNewTaskRequest))

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -18,7 +18,6 @@ export const TaskHeader: Component = () => {
   const hasMessages = createMemo(() => session.messages().length > 0)
   const busy = createMemo(() => session.status() === "busy")
   const canCompact = createMemo(() => !busy() && hasMessages() && !!session.selected())
-  const canNewTask = createMemo(() => !busy() && hasMessages())
 
   const cost = createMemo(() => {
     const total = session.totalCost()
@@ -61,16 +60,6 @@ export const TaskHeader: Component = () => {
               </Tooltip>
             )}
           </Show>
-          <Tooltip value={language.t("command.session.new.task")} placement="bottom">
-            <IconButton
-              icon="new-session"
-              size="small"
-              variant="ghost"
-              disabled={!canNewTask()}
-              onClick={() => window.dispatchEvent(new CustomEvent("newTaskRequest"))}
-              aria-label={language.t("command.session.new.task")}
-            />
-          </Tooltip>
           <Tooltip value={language.t("command.session.compact")} placement="bottom">
             <IconButton
               icon="collapse"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -67,7 +67,7 @@ export const TaskHeader: Component = () => {
               size="small"
               variant="ghost"
               disabled={!canNewTask()}
-              onClick={() => session.clearCurrentSession()}
+              onClick={() => window.dispatchEvent(new CustomEvent("newTaskRequest"))}
               aria-label={language.t("command.session.new.task")}
             />
           </Tooltip>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -18,6 +18,7 @@ export const TaskHeader: Component = () => {
   const hasMessages = createMemo(() => session.messages().length > 0)
   const busy = createMemo(() => session.status() === "busy")
   const canCompact = createMemo(() => !busy() && hasMessages() && !!session.selected())
+  const canNewTask = createMemo(() => !busy() && hasMessages())
 
   const cost = createMemo(() => {
     const total = session.totalCost()
@@ -60,6 +61,16 @@ export const TaskHeader: Component = () => {
               </Tooltip>
             )}
           </Show>
+          <Tooltip value={language.t("command.session.new.task")} placement="bottom">
+            <IconButton
+              icon="new-session"
+              size="small"
+              variant="ghost"
+              disabled={!canNewTask()}
+              onClick={() => session.clearCurrentSession()}
+              aria-label={language.t("command.session.new.task")}
+            />
+          </Tooltip>
           <Tooltip value={language.t("command.session.compact")} placement="bottom">
             <IconButton
               icon="collapse"

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -43,6 +43,7 @@ export const dict = {
   "command.language.set": "استخدام اللغة: {{language}}",
 
   "command.session.new": "جلسة جديدة",
+  "command.session.new.task": "مهمة جديدة",
   "command.file.open": "فتح ملف",
   "command.tab.close": "إغلاق علامة التبويب",
   "command.context.addSelection": "إضافة التحديد إلى السياق",
@@ -970,7 +971,6 @@ export const dict = {
   "profile.personalAccount": "حساب شخصي",
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/ar.ts
-
 
   "question.summary": "{{n}} من {{total}} أسئلة",
   "common.review": "مراجعة",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -43,6 +43,7 @@ export const dict = {
   "command.language.set": "Usar idioma: {{language}}",
 
   "command.session.new": "Nova sessão",
+  "command.session.new.task": "Nova tarefa",
   "command.file.open": "Abrir arquivo",
   "command.tab.close": "Fechar aba",
   "command.context.addSelection": "Adicionar seleção ao contexto",
@@ -984,7 +985,6 @@ export const dict = {
   "profile.personalAccount": "Conta pessoal",
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/br.ts
-
 
   "question.summary": "{{n}} de {{total}} perguntas",
   "common.review": "Revisar",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -43,6 +43,7 @@ export const dict = {
   "command.language.set": "Koristi jezik: {{language}}",
 
   "command.session.new": "Nova sesija",
+  "command.session.new.task": "Novi zadatak",
   "command.file.open": "Otvori datoteku",
   "command.tab.close": "Zatvori karticu",
   "command.context.addSelection": "Dodaj odabir u kontekst",
@@ -983,7 +984,6 @@ export const dict = {
   "profile.personalAccount": "Osobni račun",
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/bs.ts
-
 
   "question.summary": "{{n}} od {{total}} pitanja",
   "common.review": "Pregled",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -43,6 +43,7 @@ export const dict = {
   "command.language.set": "Brug sprog: {{language}}",
 
   "command.session.new": "Ny session",
+  "command.session.new.task": "Ny opgave",
   "command.file.open": "Åbn fil",
   "command.tab.close": "Luk fane",
   "command.context.addSelection": "Tilføj markering til kontekst",
@@ -979,7 +980,6 @@ export const dict = {
   "profile.personalAccount": "Personlig konto",
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/da.ts
-
 
   "question.summary": "{{n}} af {{total}} spørgsmål",
   "common.review": "Gennemgå",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -47,6 +47,7 @@ export const dict = {
   "command.language.set": "Sprache verwenden: {{language}}",
 
   "command.session.new": "Neue Sitzung",
+  "command.session.new.task": "Neue Aufgabe",
   "command.file.open": "Datei öffnen",
   "command.tab.close": "Tab schließen",
   "command.context.addSelection": "Auswahl zum Kontext hinzufügen",
@@ -996,7 +997,6 @@ export const dict = {
   "profile.personalAccount": "Persönliches Konto",
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/de.ts
-
 
   "question.summary": "{{n}} von {{total}} Fragen",
   "common.review": "Überprüfen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -43,6 +43,7 @@ export const dict = {
   "command.language.set": "Use language: {{language}}",
 
   "command.session.new": "New session",
+  "command.session.new.task": "New task",
   "command.file.open": "Open file",
   "command.tab.close": "Close tab",
   "command.context.addSelection": "Add selection to context",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -43,6 +43,7 @@ export const dict = {
   "command.language.set": "Usar idioma: {{language}}",
 
   "command.session.new": "Nueva sesión",
+  "command.session.new.task": "Nueva tarea",
   "command.file.open": "Abrir archivo",
   "command.tab.close": "Cerrar pestaña",
   "command.context.addSelection": "Añadir selección al contexto",
@@ -986,7 +987,6 @@ export const dict = {
   "dialog.model.notSet": "No establecido",
   "profile.personalAccount": "Cuenta personal",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/es.ts
-
 
   "question.summary": "{{n}} de {{total}} preguntas",
   "common.review": "Revisar",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -43,6 +43,7 @@ export const dict = {
   "command.language.set": "Utiliser la langue : {{language}}",
 
   "command.session.new": "Nouvelle session",
+  "command.session.new.task": "Nouvelle tâche",
   "command.file.open": "Ouvrir un fichier",
   "command.tab.close": "Fermer l'onglet",
   "command.context.addSelection": "Ajouter la sélection au contexte",
@@ -994,7 +995,6 @@ export const dict = {
   "dialog.model.notSet": "Non défini",
   "profile.personalAccount": "Compte personnel",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/fr.ts
-
 
   "question.summary": "{{n}} sur {{total}} questions",
   "common.review": "Réviser",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -43,6 +43,7 @@ export const dict = {
   "command.language.set": "言語を使用: {{language}}",
 
   "command.session.new": "新しいセッション",
+  "command.session.new.task": "新しいタスク",
   "command.file.open": "ファイルを開く",
   "command.tab.close": "タブを閉じる",
   "command.context.addSelection": "選択範囲をコンテキストに追加",
@@ -978,7 +979,6 @@ export const dict = {
   "dialog.model.notSet": "未設定",
   "profile.personalAccount": "個人アカウント",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/ja.ts
-
 
   "question.summary": "{{total}} 問中 {{n}} 問目",
   "common.review": "確認",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -47,6 +47,7 @@ export const dict = {
   "command.language.set": "언어 사용: {{language}}",
 
   "command.session.new": "새 세션",
+  "command.session.new.task": "새 작업",
   "command.file.open": "파일 열기",
   "command.tab.close": "탭 닫기",
   "command.context.addSelection": "선택 영역을 컨텍스트에 추가",
@@ -975,7 +976,6 @@ export const dict = {
   "dialog.model.notSet": "설정되지 않음",
   "profile.personalAccount": "개인 계정",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/ko.ts
-
 
   "question.summary": "{{total}}개 질문 중 {{n}}번째",
   "common.review": "검토",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -46,6 +46,7 @@ export const dict = {
   "command.language.set": "Bruk språk: {{language}}",
 
   "command.session.new": "Ny sesjon",
+  "command.session.new.task": "Ny oppgave",
   "command.file.open": "Åpne fil",
   "command.tab.close": "Lukk fane",
   "command.context.addSelection": "Legg til markering i kontekst",
@@ -980,7 +981,6 @@ export const dict = {
   "dialog.model.notSet": "Ikke angitt",
   "profile.personalAccount": "Personlig konto",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/no.ts
-
 
   "question.summary": "{{n}} av {{total}} spørsmål",
   "common.review": "Gjennomgå",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -43,6 +43,7 @@ export const dict = {
   "command.language.set": "Użyj języka: {{language}}",
 
   "command.session.new": "Nowa sesja",
+  "command.session.new.task": "Nowe zadanie",
   "command.file.open": "Otwórz plik",
   "command.tab.close": "Zamknij kartę",
   "command.context.addSelection": "Dodaj zaznaczenie do kontekstu",
@@ -981,7 +982,6 @@ export const dict = {
   "dialog.model.notSet": "Nie ustawiono",
   "profile.personalAccount": "Konto osobiste",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/pl.ts
-
 
   "question.summary": "{{n}} z {{total}} pytań",
   "common.review": "Przejrzyj",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -43,6 +43,7 @@ export const dict = {
   "command.language.set": "Использовать язык: {{language}}",
 
   "command.session.new": "Новая сессия",
+  "command.session.new.task": "Новая задача",
   "command.file.open": "Открыть файл",
   "command.tab.close": "Закрыть вкладку",
   "command.context.addSelection": "Добавить выделение в контекст",
@@ -983,7 +984,6 @@ export const dict = {
   "dialog.model.notSet": "Не задано",
   "profile.personalAccount": "Личный аккаунт",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/ru.ts
-
 
   "question.summary": "{{n}} из {{total}} вопросов",
   "common.review": "Просмотр",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -43,6 +43,7 @@ export const dict = {
   "command.language.set": "ใช้ภาษา: {{language}}",
 
   "command.session.new": "เซสชันใหม่",
+  "command.session.new.task": "งานใหม่",
   "command.file.open": "เปิดไฟล์",
   "command.tab.close": "ปิดแท็บ",
   "command.context.addSelection": "เพิ่มส่วนที่เลือกไปยังบริบท",
@@ -971,7 +972,6 @@ export const dict = {
   "dialog.model.notSet": "ไม่ได้ตั้งค่า",
   "profile.personalAccount": "บัญชีส่วนตัว",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/th.ts
-
 
   "question.summary": "{{n}} จาก {{total}} คำถาม",
   "common.review": "ตรวจสอบ",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -47,6 +47,7 @@ export const dict = {
   "command.language.set": "使用语言：{{language}}",
 
   "command.session.new": "新建会话",
+  "command.session.new.task": "新建任务",
   "command.file.open": "打开文件",
   "command.tab.close": "关闭标签页",
   "command.context.addSelection": "将所选内容添加到上下文",
@@ -966,7 +967,6 @@ export const dict = {
   "dialog.model.notSet": "未设置",
   "profile.personalAccount": "个人账户",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/zh.ts
-
 
   "question.summary": "第 {{n}} / {{total}} 个问题",
   "common.review": "审查",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -47,6 +47,7 @@ export const dict = {
   "command.language.set": "使用語言：{{language}}",
 
   "command.session.new": "新增工作階段",
+  "command.session.new.task": "新增任務",
   "command.file.open": "開啟檔案",
   "command.tab.close": "關閉分頁",
   "command.context.addSelection": "將選取內容加入上下文",
@@ -967,7 +968,6 @@ export const dict = {
   "dialog.model.notSet": "未設定",
   "profile.personalAccount": "個人帳戶",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/zht.ts
-
 
   "question.summary": "第 {{n}} / {{total}} 個問題",
   "common.review": "審查",

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource solid-js */
 /**
  * Stories for high-priority chat components:
- * ChatView, MessageList, QuestionDock, TaskHeader
+ * ChatView, MessageList, QuestionDock
  *
  * These render with mocked session/server/provider contexts — the components
  * will show their "idle / empty" states since no real extension host is connected.
@@ -10,7 +10,6 @@
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
 import { StoryProviders, mockSessionValue } from "./StoryProviders"
 import { ChatView } from "../components/chat/ChatView"
-import { TaskHeader } from "../components/chat/TaskHeader"
 import { QuestionDock } from "../components/chat/QuestionDock"
 import { SessionContext } from "../context/session"
 import type { QuestionRequest } from "../types/messages"
@@ -137,52 +136,4 @@ export const QuestionDockMulti: Story = {
       </div>
     </StoryProviders>
   ),
-}
-
-// ---------------------------------------------------------------------------
-// TaskHeader stories
-// ---------------------------------------------------------------------------
-
-/** TaskHeader with messages (idle) — shows New Task + Compact buttons enabled */
-export const TaskHeaderWithMessages: Story = {
-  name: "TaskHeader — with messages (idle)",
-  render: () => {
-    const session = {
-      ...mockSessionValue({ id: SESSION_ID, status: "idle" }),
-      messages: () => [{ id: "msg-001" }] as any[],
-      totalCost: () => 0.0023,
-      contextUsage: () => ({ tokens: 1024, percentage: 12 }),
-    }
-    return (
-      <StoryProviders sessionID={SESSION_ID} status="idle" noPadding>
-        <SessionContext.Provider value={session as any}>
-          <div style={{ width: "420px" }}>
-            <TaskHeader />
-          </div>
-        </SessionContext.Provider>
-      </StoryProviders>
-    )
-  },
-}
-
-/** TaskHeader with messages (busy) — New Task + Compact buttons are disabled */
-export const TaskHeaderBusy: Story = {
-  name: "TaskHeader — with messages (busy)",
-  render: () => {
-    const session = {
-      ...mockSessionValue({ id: SESSION_ID, status: "busy" }),
-      messages: () => [{ id: "msg-001" }] as any[],
-      totalCost: () => 0,
-      contextUsage: () => undefined,
-    }
-    return (
-      <StoryProviders sessionID={SESSION_ID} status="busy" noPadding>
-        <SessionContext.Provider value={session as any}>
-          <div style={{ width: "420px" }}>
-            <TaskHeader />
-          </div>
-        </SessionContext.Provider>
-      </StoryProviders>
-    )
-  },
 }

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -91,6 +91,28 @@ export const ChatViewIdle: Story = {
   ),
 }
 
+/** ChatView with messages — shows the full-width "New task" button above the prompt */
+export const ChatViewWithMessages: Story = {
+  name: "ChatView — with messages (shows New Task button)",
+  render: () => {
+    const session = {
+      ...mockSessionValue({ id: SESSION_ID, status: "idle" }),
+      messages: () => [{ id: "msg-001" }] as any[],
+      totalCost: () => 0.0012,
+      contextUsage: () => ({ tokens: 512, percentage: 6 }),
+    }
+    return (
+      <StoryProviders sessionID={SESSION_ID} status="idle">
+        <SessionContext.Provider value={session as any}>
+          <div style={{ width: "420px", height: "600px", display: "flex", "flex-direction": "column" }}>
+            <ChatView />
+          </div>
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
+}
+
 // ---------------------------------------------------------------------------
 // QuestionDock stories
 // ---------------------------------------------------------------------------

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -1,16 +1,18 @@
 /** @jsxImportSource solid-js */
 /**
  * Stories for high-priority chat components:
- * ChatView, MessageList, QuestionDock
+ * ChatView, MessageList, QuestionDock, TaskHeader
  *
  * These render with mocked session/server/provider contexts — the components
  * will show their "idle / empty" states since no real extension host is connected.
  */
 
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
-import { StoryProviders } from "./StoryProviders"
+import { StoryProviders, mockSessionValue } from "./StoryProviders"
 import { ChatView } from "../components/chat/ChatView"
+import { TaskHeader } from "../components/chat/TaskHeader"
 import { QuestionDock } from "../components/chat/QuestionDock"
+import { SessionContext } from "../context/session"
 import type { QuestionRequest } from "../types/messages"
 
 const SESSION_ID = "story-session-chat-001"
@@ -113,4 +115,52 @@ export const QuestionDockMulti: Story = {
       </div>
     </StoryProviders>
   ),
+}
+
+// ---------------------------------------------------------------------------
+// TaskHeader stories
+// ---------------------------------------------------------------------------
+
+/** Session with messages (idle) — shows the "New task" and Compact buttons */
+export const TaskHeaderWithMessages: Story = {
+  name: "TaskHeader — with messages (idle)",
+  render: () => {
+    const session = {
+      ...mockSessionValue({ id: SESSION_ID, status: "idle" }),
+      messages: () => [{ id: "msg-001" }] as any[],
+      totalCost: () => 0.0023,
+      contextUsage: () => ({ tokens: 1024, percentage: 12 }),
+    }
+    return (
+      <StoryProviders sessionID={SESSION_ID} status="idle">
+        <SessionContext.Provider value={session as any}>
+          <div style={{ width: "420px" }}>
+            <TaskHeader />
+          </div>
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
+}
+
+/** Session with messages (busy) — "New task" and Compact buttons are disabled */
+export const TaskHeaderBusy: Story = {
+  name: "TaskHeader — with messages (busy)",
+  render: () => {
+    const session = {
+      ...mockSessionValue({ id: SESSION_ID, status: "busy" }),
+      messages: () => [{ id: "msg-001" }] as any[],
+      totalCost: () => 0,
+      contextUsage: () => undefined,
+    }
+    return (
+      <StoryProviders sessionID={SESSION_ID} status="busy">
+        <SessionContext.Provider value={session as any}>
+          <div style={{ width: "420px" }}>
+            <TaskHeader />
+          </div>
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
 }

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -70,7 +70,7 @@ const multiQuestion: QuestionRequest = {
 
 const meta: Meta = {
   title: "Chat",
-  parameters: { layout: "padded" },
+  parameters: { layout: "fullscreen" },
 }
 export default meta
 type Story = StoryObj
@@ -83,7 +83,7 @@ export const ChatViewIdle: Story = {
   name: "ChatView — idle (empty)",
   render: () => (
     <StoryProviders sessionID={SESSION_ID} status="idle">
-      <div style={{ width: "420px", height: "600px", display: "flex", "flex-direction": "column" }}>
+      <div style={{ width: "100%", height: "600px", display: "flex", "flex-direction": "column" }}>
         <ChatView />
       </div>
     </StoryProviders>
@@ -103,7 +103,7 @@ export const ChatViewWithMessages: Story = {
     return (
       <StoryProviders sessionID={SESSION_ID} status="idle" noPadding>
         <SessionContext.Provider value={session as any}>
-          <div style={{ width: "420px", height: "200px", display: "flex", "flex-direction": "column" }}>
+          <div style={{ width: "100%", height: "200px", display: "flex", "flex-direction": "column" }}>
             <ChatView />
           </div>
         </SessionContext.Provider>
@@ -120,7 +120,7 @@ export const QuestionDockSingle: Story = {
   name: "QuestionDock — single question",
   render: () => (
     <StoryProviders sessionID={SESSION_ID} questions={[singleQuestion]}>
-      <div style={{ width: "420px" }}>
+      <div style={{ width: "100%" }}>
         <QuestionDock request={singleQuestion} />
       </div>
     </StoryProviders>
@@ -131,7 +131,7 @@ export const QuestionDockMulti: Story = {
   name: "QuestionDock — multi-question wizard",
   render: () => (
     <StoryProviders sessionID={SESSION_ID} questions={[multiQuestion]}>
-      <div style={{ width: "420px" }}>
+      <div style={{ width: "100%" }}>
         <QuestionDock request={multiQuestion} />
       </div>
     </StoryProviders>

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -10,6 +10,7 @@
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
 import { StoryProviders, mockSessionValue } from "./StoryProviders"
 import { ChatView } from "../components/chat/ChatView"
+import { TaskHeader } from "../components/chat/TaskHeader"
 import { QuestionDock } from "../components/chat/QuestionDock"
 import { SessionContext } from "../context/session"
 import type { QuestionRequest } from "../types/messages"
@@ -136,4 +137,52 @@ export const QuestionDockMulti: Story = {
       </div>
     </StoryProviders>
   ),
+}
+
+// ---------------------------------------------------------------------------
+// TaskHeader stories
+// ---------------------------------------------------------------------------
+
+/** TaskHeader with messages (idle) — shows New Task + Compact buttons enabled */
+export const TaskHeaderWithMessages: Story = {
+  name: "TaskHeader — with messages (idle)",
+  render: () => {
+    const session = {
+      ...mockSessionValue({ id: SESSION_ID, status: "idle" }),
+      messages: () => [{ id: "msg-001" }] as any[],
+      totalCost: () => 0.0023,
+      contextUsage: () => ({ tokens: 1024, percentage: 12 }),
+    }
+    return (
+      <StoryProviders sessionID={SESSION_ID} status="idle" noPadding>
+        <SessionContext.Provider value={session as any}>
+          <div style={{ width: "420px" }}>
+            <TaskHeader />
+          </div>
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
+}
+
+/** TaskHeader with messages (busy) — New Task + Compact buttons are disabled */
+export const TaskHeaderBusy: Story = {
+  name: "TaskHeader — with messages (busy)",
+  render: () => {
+    const session = {
+      ...mockSessionValue({ id: SESSION_ID, status: "busy" }),
+      messages: () => [{ id: "msg-001" }] as any[],
+      totalCost: () => 0,
+      contextUsage: () => undefined,
+    }
+    return (
+      <StoryProviders sessionID={SESSION_ID} status="busy" noPadding>
+        <SessionContext.Provider value={session as any}>
+          <div style={{ width: "420px" }}>
+            <TaskHeader />
+          </div>
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
 }

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -10,7 +10,6 @@
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
 import { StoryProviders, mockSessionValue } from "./StoryProviders"
 import { ChatView } from "../components/chat/ChatView"
-import { TaskHeader } from "../components/chat/TaskHeader"
 import { QuestionDock } from "../components/chat/QuestionDock"
 import { SessionContext } from "../context/session"
 import type { QuestionRequest } from "../types/messages"
@@ -102,9 +101,9 @@ export const ChatViewWithMessages: Story = {
       contextUsage: () => ({ tokens: 512, percentage: 6 }),
     }
     return (
-      <StoryProviders sessionID={SESSION_ID} status="idle">
+      <StoryProviders sessionID={SESSION_ID} status="idle" noPadding>
         <SessionContext.Provider value={session as any}>
-          <div style={{ width: "420px", height: "600px", display: "flex", "flex-direction": "column" }}>
+          <div style={{ width: "420px", height: "200px", display: "flex", "flex-direction": "column" }}>
             <ChatView />
           </div>
         </SessionContext.Provider>
@@ -137,52 +136,4 @@ export const QuestionDockMulti: Story = {
       </div>
     </StoryProviders>
   ),
-}
-
-// ---------------------------------------------------------------------------
-// TaskHeader stories
-// ---------------------------------------------------------------------------
-
-/** Session with messages (idle) — shows the "New task" and Compact buttons */
-export const TaskHeaderWithMessages: Story = {
-  name: "TaskHeader — with messages (idle)",
-  render: () => {
-    const session = {
-      ...mockSessionValue({ id: SESSION_ID, status: "idle" }),
-      messages: () => [{ id: "msg-001" }] as any[],
-      totalCost: () => 0.0023,
-      contextUsage: () => ({ tokens: 1024, percentage: 12 }),
-    }
-    return (
-      <StoryProviders sessionID={SESSION_ID} status="idle">
-        <SessionContext.Provider value={session as any}>
-          <div style={{ width: "420px" }}>
-            <TaskHeader />
-          </div>
-        </SessionContext.Provider>
-      </StoryProviders>
-    )
-  },
-}
-
-/** Session with messages (busy) — "New task" and Compact buttons are disabled */
-export const TaskHeaderBusy: Story = {
-  name: "TaskHeader — with messages (busy)",
-  render: () => {
-    const session = {
-      ...mockSessionValue({ id: SESSION_ID, status: "busy" }),
-      messages: () => [{ id: "msg-001" }] as any[],
-      totalCost: () => 0,
-      contextUsage: () => undefined,
-    }
-    return (
-      <StoryProviders sessionID={SESSION_ID} status="busy">
-        <SessionContext.Provider value={session as any}>
-          <div style={{ width: "420px" }}>
-            <TaskHeader />
-          </div>
-        </SessionContext.Provider>
-      </StoryProviders>
-    )
-  },
 }

--- a/packages/kilo-vscode/webview-ui/src/stories/shared.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/shared.stories.tsx
@@ -9,7 +9,7 @@ import { ModelSelectorBase } from "../components/shared/ModelSelector"
 
 const meta: Meta = {
   title: "Shared",
-  parameters: { layout: "padded" },
+  parameters: { layout: "fullscreen" },
 }
 export default meta
 type Story = StoryObj

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -44,8 +44,9 @@
 /* New Task Button */
 .new-task-button {
   display: block;
-  width: calc(100% - 24px);
+  width: auto;
   margin: 8px 12px 0;
+  box-sizing: border-box;
 }
 
 /* ============================================

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -44,9 +44,8 @@
 /* New Task Button */
 .new-task-button {
   display: block;
-  width: 100%;
-  border-radius: 0;
-  border-bottom: 1px solid var(--vscode-panel-border);
+  width: calc(100% - 24px);
+  margin: 8px 12px 0;
 }
 
 /* ============================================

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -41,6 +41,14 @@
   border-top: 1px solid var(--vscode-panel-border);
 }
 
+/* New Task Button */
+.new-task-button {
+  display: block;
+  width: 100%;
+  border-radius: 0;
+  border-bottom: 1px solid var(--vscode-panel-border);
+}
+
 /* ============================================
    Message List
    ============================================ */

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -42,11 +42,8 @@
 }
 
 /* New Task Button */
-.new-task-button {
-  display: block;
-  width: auto;
-  margin: 8px 12px 0;
-  box-sizing: border-box;
+.new-task-button-wrapper {
+  padding: 8px 12px 0;
 }
 
 /* ============================================


### PR DESCRIPTION
Closes #6250

## Summary

- Adds a "New Task" icon button (`new-session` icon) to the `TaskHeader` component, placed next to the existing compact button
- Button is disabled while the session is busy, enabled whenever there are messages in the current session
- Clicking calls `session.clearCurrentSession()`, resetting to a fresh session (same behavior as the `+` button in the VS Code sidebar header)
- Adds `"command.session.new.task": "New task"` i18n key

This gives users a quick way to start a new task while staying in the chat area — especially useful when you've already typed a prompt and realize you want a fresh context.

The full-width "Start new Task" button from the legacy extension was intentionally not brought back (per feedback in #6250 that it was too easy to hit accidentally). The header button is a less intrusive alternative.