### PR TITLE
Remove kilocode_change markers from kilo-specific packages

### DIFF
--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-checkout "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-commit "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-merge "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs pre-push "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs pre-push "$@"

--- a/packages/kilo-gateway/src/api/constants.ts
+++ b/packages/kilo-gateway/src/api/constants.ts
@@ -61,10 +61,8 @@ export const ENV_EDITOR_NAME = "KILOCODE_EDITOR_NAME"
 /** Tester header value for suppressing warnings */
 export const TESTER_SUPPRESS_VALUE = "SUPPRESS"
 
-// kilocode_change start
 /** Header name for feature tracking */
 export const HEADER_FEATURE = "X-KILOCODE-FEATURE"
 
 /** Environment variable name for feature override */
 export const ENV_FEATURE = "KILOCODE_FEATURE"
-// kilocode_change end

--- a/packages/kilo-gateway/src/api/notifications.ts
+++ b/packages/kilo-gateway/src/api/notifications.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import { z } from "zod"
 import { KILO_API_BASE } from "./constants.js"
 

--- a/packages/kilo-gateway/src/auth/legacy-migration.ts
+++ b/packages/kilo-gateway/src/auth/legacy-migration.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 /**
  * Legacy Kilo CLI migration module
  *

--- a/packages/kilo-gateway/src/headers.ts
+++ b/packages/kilo-gateway/src/headers.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_EDITOR_NAME,
   ENV_EDITOR_NAME,
   TESTER_SUPPRESS_VALUE,
-  ENV_FEATURE, // kilocode_change
+  ENV_FEATURE,
 } from "./api/constants.js"
 
 /**
@@ -62,13 +62,11 @@ export function buildKiloHeaders(
     machineId?: string
   },
 ): Record<string, string> {
-  // kilocode_change start
   const feature = getFeatureHeader()
   const headers: Record<string, string> = {
     [X_KILOCODE_EDITORNAME]: getEditorNameHeader(),
     ...(feature ? { [X_KILOCODE_FEATURE]: feature } : {}),
   }
-  // kilocode_change end
 
   if (metadata?.taskId) {
     headers[X_KILOCODE_TASKID] = metadata.taskId

--- a/packages/kilo-gateway/src/index.ts
+++ b/packages/kilo-gateway/src/index.ts
@@ -9,7 +9,7 @@ export { KiloAuthPlugin, default } from "./plugin.js"
 export { createKilo } from "./provider.js"
 export { createKiloDebug } from "./provider-debug.js"
 export { kiloCustomLoader } from "./loader.js"
-export { buildKiloHeaders, getEditorNameHeader, getFeatureHeader, DEFAULT_HEADERS } from "./headers.js" // kilocode_change - added getFeatureHeader
+export { buildKiloHeaders, getEditorNameHeader, getFeatureHeader, DEFAULT_HEADERS } from "./headers.js"
 
 // ============================================================================
 // Auth

--- a/packages/kilo-gateway/src/types.ts
+++ b/packages/kilo-gateway/src/types.ts
@@ -1,4 +1,3 @@
-// kilocode_change - Kilo Gateway types
 import type { Provider as SDK } from "ai"
 import type { LanguageModelV2 } from "@openrouter/ai-sdk-provider"
 

--- a/packages/kilo-i18n/src/ar.ts
+++ b/packages/kilo-i18n/src/ar.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/br.ts
+++ b/packages/kilo-i18n/src/br.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/bs.ts
+++ b/packages/kilo-i18n/src/bs.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/da.ts
+++ b/packages/kilo-i18n/src/da.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/de.ts
+++ b/packages/kilo-i18n/src/de.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/en.ts
+++ b/packages/kilo-i18n/src/en.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 // Kilo-specific translations and overrides
 // Keys here will override any matching keys from upstream translations
 export const dict = {

--- a/packages/kilo-i18n/src/es.ts
+++ b/packages/kilo-i18n/src/es.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/fr.ts
+++ b/packages/kilo-i18n/src/fr.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/ja.ts
+++ b/packages/kilo-i18n/src/ja.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/ko.ts
+++ b/packages/kilo-i18n/src/ko.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/no.ts
+++ b/packages/kilo-i18n/src/no.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/pl.ts
+++ b/packages/kilo-i18n/src/pl.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/ru.ts
+++ b/packages/kilo-i18n/src/ru.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/th.ts
+++ b/packages/kilo-i18n/src/th.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1":

--- a/packages/kilo-i18n/src/zh.ts
+++ b/packages/kilo-i18n/src/zh.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1": "Kilo Gateway 为您提供一组精选的可靠优化模型，专为编码代理设计。",

--- a/packages/kilo-i18n/src/zht.ts
+++ b/packages/kilo-i18n/src/zht.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export const dict = {
   // Kilo Gateway provider translations
   "provider.connect.kiloGateway.line1": "Kilo Gateway 為您提供一組精選的可靠優化模型，專為編碼代理設計。",

--- a/packages/kilo-ui/src/components/accordion.css
+++ b/packages/kilo-ui/src/components/accordion.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Accordion overrides */
 
 [data-component="accordion"] {

--- a/packages/kilo-ui/src/components/accordion.tsx
+++ b/packages/kilo-ui/src/components/accordion.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/accordion"

--- a/packages/kilo-ui/src/components/app-icon.tsx
+++ b/packages/kilo-ui/src/components/app-icon.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/app-icon"

--- a/packages/kilo-ui/src/components/app-icons/types.ts
+++ b/packages/kilo-ui/src/components/app-icons/types.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/icons/app"

--- a/packages/kilo-ui/src/components/auto-approve-bar.css
+++ b/packages/kilo-ui/src/components/auto-approve-bar.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Auto-approve Bar overrides */
 
 [data-component="auto-approve-bar"] {

--- a/packages/kilo-ui/src/components/avatar.tsx
+++ b/packages/kilo-ui/src/components/avatar.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/avatar"

--- a/packages/kilo-ui/src/components/basic-tool.css
+++ b/packages/kilo-ui/src/components/basic-tool.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Prevent tool-trigger content from pushing the collapsible arrow off-screen */
 [data-component="tool-trigger"] {
   [data-slot="basic-tool-tool-trigger-content"] {

--- a/packages/kilo-ui/src/components/basic-tool.tsx
+++ b/packages/kilo-ui/src/components/basic-tool.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/basic-tool"

--- a/packages/kilo-ui/src/components/button.css
+++ b/packages/kilo-ui/src/components/button.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Button overrides – sized to match @vscode/webview-ui-toolkit */
 
 [data-component="button"] {

--- a/packages/kilo-ui/src/components/button.tsx
+++ b/packages/kilo-ui/src/components/button.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/button"

--- a/packages/kilo-ui/src/components/card.css
+++ b/packages/kilo-ui/src/components/card.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Card overrides – harmonized with @vscode/webview-ui-toolkit */
 
 [data-component="card"] {

--- a/packages/kilo-ui/src/components/card.tsx
+++ b/packages/kilo-ui/src/components/card.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/card"

--- a/packages/kilo-ui/src/components/chat-input.css
+++ b/packages/kilo-ui/src/components/chat-input.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Chat Input (Textarea with blue border) overrides – sized to match @vscode/webview-ui-toolkit */
 
 [data-component="chat-input"],

--- a/packages/kilo-ui/src/components/checkbox.css
+++ b/packages/kilo-ui/src/components/checkbox.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Checkbox overrides – sized to match @vscode/webview-ui-toolkit */
 
 [data-component="checkbox"] {

--- a/packages/kilo-ui/src/components/checkbox.tsx
+++ b/packages/kilo-ui/src/components/checkbox.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/checkbox"

--- a/packages/kilo-ui/src/components/code.css
+++ b/packages/kilo-ui/src/components/code.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Code overrides */
 
 [data-component="code"] {

--- a/packages/kilo-ui/src/components/code.tsx
+++ b/packages/kilo-ui/src/components/code.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/code"

--- a/packages/kilo-ui/src/components/collapsible.tsx
+++ b/packages/kilo-ui/src/components/collapsible.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/collapsible"

--- a/packages/kilo-ui/src/components/context-menu.css
+++ b/packages/kilo-ui/src/components/context-menu.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Context Menu overrides – sized to match @vscode/webview-ui-toolkit */
 
 [data-component="context-menu-content"],

--- a/packages/kilo-ui/src/components/context-menu.tsx
+++ b/packages/kilo-ui/src/components/context-menu.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/context-menu"

--- a/packages/kilo-ui/src/components/dialog.css
+++ b/packages/kilo-ui/src/components/dialog.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Dialog overrides – harmonized with @vscode/webview-ui-toolkit */
 
 [data-component="dialog-overlay"] {

--- a/packages/kilo-ui/src/components/dialog.tsx
+++ b/packages/kilo-ui/src/components/dialog.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/dialog"

--- a/packages/kilo-ui/src/components/diff-changes.tsx
+++ b/packages/kilo-ui/src/components/diff-changes.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/diff-changes"

--- a/packages/kilo-ui/src/components/diff-ssr.tsx
+++ b/packages/kilo-ui/src/components/diff-ssr.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/diff-ssr"

--- a/packages/kilo-ui/src/components/diff.tsx
+++ b/packages/kilo-ui/src/components/diff.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/diff"

--- a/packages/kilo-ui/src/components/dock-prompt.tsx
+++ b/packages/kilo-ui/src/components/dock-prompt.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/dock-prompt"

--- a/packages/kilo-ui/src/components/dock-surface.tsx
+++ b/packages/kilo-ui/src/components/dock-surface.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/dock-surface"

--- a/packages/kilo-ui/src/components/dropdown-menu.css
+++ b/packages/kilo-ui/src/components/dropdown-menu.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Dropdown Menu overrides – sized to match @vscode/webview-ui-toolkit */
 
 [data-component="dropdown-menu-content"],
@@ -21,12 +20,10 @@
       color: var(--text-on-interactive-base, var(--text-strong));
     }
 
-    /* kilocode_change start - preserve disabled state behavior from upstream */
     &[data-disabled] {
       cursor: default;
       pointer-events: none;
     }
-    /* kilocode_change end */
   }
 
   [data-slot="dropdown-menu-separator"] {

--- a/packages/kilo-ui/src/components/dropdown-menu.tsx
+++ b/packages/kilo-ui/src/components/dropdown-menu.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/dropdown-menu"

--- a/packages/kilo-ui/src/components/favicon.tsx
+++ b/packages/kilo-ui/src/components/favicon.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/favicon"

--- a/packages/kilo-ui/src/components/file-icon.tsx
+++ b/packages/kilo-ui/src/components/file-icon.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/file-icon"

--- a/packages/kilo-ui/src/components/file-icons/types.ts
+++ b/packages/kilo-ui/src/components/file-icons/types.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/icons/file-type"

--- a/packages/kilo-ui/src/components/font.tsx
+++ b/packages/kilo-ui/src/components/font.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/font"

--- a/packages/kilo-ui/src/components/hover-card.tsx
+++ b/packages/kilo-ui/src/components/hover-card.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/hover-card"

--- a/packages/kilo-ui/src/components/icon-button.css
+++ b/packages/kilo-ui/src/components/icon-button.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Icon Button overrides – sized to match @vscode/webview-ui-toolkit */
 
 [data-component="icon-button"] {

--- a/packages/kilo-ui/src/components/icon-button.tsx
+++ b/packages/kilo-ui/src/components/icon-button.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/icon-button"

--- a/packages/kilo-ui/src/components/icon.tsx
+++ b/packages/kilo-ui/src/components/icon.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/icon"

--- a/packages/kilo-ui/src/components/image-preview.tsx
+++ b/packages/kilo-ui/src/components/image-preview.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/image-preview"

--- a/packages/kilo-ui/src/components/inline-input.css
+++ b/packages/kilo-ui/src/components/inline-input.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Inline Input overrides */
 
 [data-component="inline-input"] {

--- a/packages/kilo-ui/src/components/inline-input.tsx
+++ b/packages/kilo-ui/src/components/inline-input.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/inline-input"

--- a/packages/kilo-ui/src/components/keybind.tsx
+++ b/packages/kilo-ui/src/components/keybind.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/keybind"

--- a/packages/kilo-ui/src/components/line-comment.tsx
+++ b/packages/kilo-ui/src/components/line-comment.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/line-comment"

--- a/packages/kilo-ui/src/components/list.css
+++ b/packages/kilo-ui/src/components/list.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo List overrides – styled to match legacy SelectDropdown items */
 
 [data-component="list"] {

--- a/packages/kilo-ui/src/components/list.tsx
+++ b/packages/kilo-ui/src/components/list.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/list"

--- a/packages/kilo-ui/src/components/logo.tsx
+++ b/packages/kilo-ui/src/components/logo.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/logo"

--- a/packages/kilo-ui/src/components/markdown.tsx
+++ b/packages/kilo-ui/src/components/markdown.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/markdown"

--- a/packages/kilo-ui/src/components/message-nav.tsx
+++ b/packages/kilo-ui/src/components/message-nav.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/message-nav"

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Message Part overrides */
 
 [data-component="text-part"] {

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/message-part"

--- a/packages/kilo-ui/src/components/message-row.css
+++ b/packages/kilo-ui/src/components/message-row.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Message Row overrides */
 
 [data-component="message-row"] {

--- a/packages/kilo-ui/src/components/model-info-card.css
+++ b/packages/kilo-ui/src/components/model-info-card.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Model Info Card overrides – harmonized with @vscode/webview-ui-toolkit */
 
 [data-component="model-info-card"] {

--- a/packages/kilo-ui/src/components/model-selector.css
+++ b/packages/kilo-ui/src/components/model-selector.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Model Selector Popover overrides – styled to match VSCode look */
 
 /* ModelSelectorPopover content panel */

--- a/packages/kilo-ui/src/components/popover.css
+++ b/packages/kilo-ui/src/components/popover.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Popover overrides */
 
 [data-component="popover-content"] {

--- a/packages/kilo-ui/src/components/popover.tsx
+++ b/packages/kilo-ui/src/components/popover.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/popover"

--- a/packages/kilo-ui/src/components/progress-circle.tsx
+++ b/packages/kilo-ui/src/components/progress-circle.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/progress-circle"

--- a/packages/kilo-ui/src/components/prompt-input.css
+++ b/packages/kilo-ui/src/components/prompt-input.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Prompt Input overrides – styled to match legacy ChatTextArea look */
 
 /* Form wrapper: VS Code native input look instead of pill shape */

--- a/packages/kilo-ui/src/components/provider-icon.tsx
+++ b/packages/kilo-ui/src/components/provider-icon.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/provider-icon"

--- a/packages/kilo-ui/src/components/provider-icons/types.ts
+++ b/packages/kilo-ui/src/components/provider-icons/types.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/icons/provider"

--- a/packages/kilo-ui/src/components/radio-group.tsx
+++ b/packages/kilo-ui/src/components/radio-group.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/radio-group"

--- a/packages/kilo-ui/src/components/resize-handle.tsx
+++ b/packages/kilo-ui/src/components/resize-handle.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/resize-handle"

--- a/packages/kilo-ui/src/components/select.css
+++ b/packages/kilo-ui/src/components/select.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Select overrides – styled to match legacy SelectDropdown look */
 
 /* Select trigger (renders as a Button, override the button sizing) */

--- a/packages/kilo-ui/src/components/select.tsx
+++ b/packages/kilo-ui/src/components/select.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/select"

--- a/packages/kilo-ui/src/components/session-review.tsx
+++ b/packages/kilo-ui/src/components/session-review.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/session-review"

--- a/packages/kilo-ui/src/components/session-turn.tsx
+++ b/packages/kilo-ui/src/components/session-turn.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/session-turn"

--- a/packages/kilo-ui/src/components/settings-sidebar.css
+++ b/packages/kilo-ui/src/components/settings-sidebar.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Settings Sidebar overrides */
 
 [data-component="settings-sidebar"] {

--- a/packages/kilo-ui/src/components/spinner.tsx
+++ b/packages/kilo-ui/src/components/spinner.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/spinner"

--- a/packages/kilo-ui/src/components/status-indicator.css
+++ b/packages/kilo-ui/src/components/status-indicator.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Status Indicators overrides */
 
 [data-component="status-indicator"] {

--- a/packages/kilo-ui/src/components/sticky-accordion-header.tsx
+++ b/packages/kilo-ui/src/components/sticky-accordion-header.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/sticky-accordion-header"

--- a/packages/kilo-ui/src/components/switch.css
+++ b/packages/kilo-ui/src/components/switch.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Switch overrides */
 
 [data-component="switch"] {

--- a/packages/kilo-ui/src/components/switch.tsx
+++ b/packages/kilo-ui/src/components/switch.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/switch"

--- a/packages/kilo-ui/src/components/tabs.css
+++ b/packages/kilo-ui/src/components/tabs.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Tabs overrides – sized to match @vscode/webview-ui-toolkit panels */
 
 [data-component="tabs"] {

--- a/packages/kilo-ui/src/components/tabs.tsx
+++ b/packages/kilo-ui/src/components/tabs.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/tabs"

--- a/packages/kilo-ui/src/components/tag.css
+++ b/packages/kilo-ui/src/components/tag.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Tag (maps to legacy Badge) overrides – sized to match @vscode/webview-ui-toolkit */
 
 [data-component="tag"],

--- a/packages/kilo-ui/src/components/tag.tsx
+++ b/packages/kilo-ui/src/components/tag.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/tag"

--- a/packages/kilo-ui/src/components/task-header.css
+++ b/packages/kilo-ui/src/components/task-header.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Task Header overrides */
 
 [data-component="task-header"] {

--- a/packages/kilo-ui/src/components/text-field.css
+++ b/packages/kilo-ui/src/components/text-field.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Input / TextField overrides – sized to match @vscode/webview-ui-toolkit */
 
 [data-component="input"] {

--- a/packages/kilo-ui/src/components/text-field.tsx
+++ b/packages/kilo-ui/src/components/text-field.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/text-field"

--- a/packages/kilo-ui/src/components/toast.css
+++ b/packages/kilo-ui/src/components/toast.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Toast overrides – harmonized with @vscode/webview-ui-toolkit */
 
 [data-component="toast"] {

--- a/packages/kilo-ui/src/components/toast.tsx
+++ b/packages/kilo-ui/src/components/toast.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/toast"

--- a/packages/kilo-ui/src/components/tooltip.css
+++ b/packages/kilo-ui/src/components/tooltip.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Kilo Tooltip overrides – sized to match @vscode/webview-ui-toolkit */
 
 [data-component="tooltip"] {

--- a/packages/kilo-ui/src/components/tooltip.tsx
+++ b/packages/kilo-ui/src/components/tooltip.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/tooltip"

--- a/packages/kilo-ui/src/components/typewriter.tsx
+++ b/packages/kilo-ui/src/components/typewriter.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/typewriter"

--- a/packages/kilo-ui/src/context/code.tsx
+++ b/packages/kilo-ui/src/context/code.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/context/code"

--- a/packages/kilo-ui/src/context/data.tsx
+++ b/packages/kilo-ui/src/context/data.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/context/data"

--- a/packages/kilo-ui/src/context/dialog.tsx
+++ b/packages/kilo-ui/src/context/dialog.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/context/dialog"

--- a/packages/kilo-ui/src/context/diff.tsx
+++ b/packages/kilo-ui/src/context/diff.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/context/diff"

--- a/packages/kilo-ui/src/context/helper.tsx
+++ b/packages/kilo-ui/src/context/helper.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/context/helper"

--- a/packages/kilo-ui/src/context/i18n.tsx
+++ b/packages/kilo-ui/src/context/i18n.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/context/i18n"

--- a/packages/kilo-ui/src/context/index.ts
+++ b/packages/kilo-ui/src/context/index.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/context"

--- a/packages/kilo-ui/src/context/marked.tsx
+++ b/packages/kilo-ui/src/context/marked.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/context/marked"

--- a/packages/kilo-ui/src/context/worker-pool.tsx
+++ b/packages/kilo-ui/src/context/worker-pool.tsx
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/context/worker-pool"

--- a/packages/kilo-ui/src/hooks/index.ts
+++ b/packages/kilo-ui/src/hooks/index.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/hooks"

--- a/packages/kilo-ui/src/i18n/ar.ts
+++ b/packages/kilo-ui/src/i18n/ar.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/ar"

--- a/packages/kilo-ui/src/i18n/br.ts
+++ b/packages/kilo-ui/src/i18n/br.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/br"

--- a/packages/kilo-ui/src/i18n/bs.ts
+++ b/packages/kilo-ui/src/i18n/bs.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/bs"

--- a/packages/kilo-ui/src/i18n/da.ts
+++ b/packages/kilo-ui/src/i18n/da.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/da"

--- a/packages/kilo-ui/src/i18n/de.ts
+++ b/packages/kilo-ui/src/i18n/de.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/de"

--- a/packages/kilo-ui/src/i18n/en.ts
+++ b/packages/kilo-ui/src/i18n/en.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/en"

--- a/packages/kilo-ui/src/i18n/es.ts
+++ b/packages/kilo-ui/src/i18n/es.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/es"

--- a/packages/kilo-ui/src/i18n/fr.ts
+++ b/packages/kilo-ui/src/i18n/fr.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/fr"

--- a/packages/kilo-ui/src/i18n/ja.ts
+++ b/packages/kilo-ui/src/i18n/ja.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/ja"

--- a/packages/kilo-ui/src/i18n/ko.ts
+++ b/packages/kilo-ui/src/i18n/ko.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/ko"

--- a/packages/kilo-ui/src/i18n/no.ts
+++ b/packages/kilo-ui/src/i18n/no.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/no"

--- a/packages/kilo-ui/src/i18n/pl.ts
+++ b/packages/kilo-ui/src/i18n/pl.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/pl"

--- a/packages/kilo-ui/src/i18n/ru.ts
+++ b/packages/kilo-ui/src/i18n/ru.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/ru"

--- a/packages/kilo-ui/src/i18n/th.ts
+++ b/packages/kilo-ui/src/i18n/th.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/th"

--- a/packages/kilo-ui/src/i18n/zh.ts
+++ b/packages/kilo-ui/src/i18n/zh.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/zh"

--- a/packages/kilo-ui/src/i18n/zht.ts
+++ b/packages/kilo-ui/src/i18n/zht.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/i18n/zht"

--- a/packages/kilo-ui/src/index.ts
+++ b/packages/kilo-ui/src/index.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 //
 // @kilocode/kilo-ui
 //

--- a/packages/kilo-ui/src/pierre/index.ts
+++ b/packages/kilo-ui/src/pierre/index.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/pierre"

--- a/packages/kilo-ui/src/pierre/worker.ts
+++ b/packages/kilo-ui/src/pierre/worker.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/pierre/worker"

--- a/packages/kilo-ui/src/styles/globals.css
+++ b/packages/kilo-ui/src/styles/globals.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /*
  * Kilo UI Global Overrides
  *

--- a/packages/kilo-ui/src/styles/index.css
+++ b/packages/kilo-ui/src/styles/index.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Wraps upstream styles and adds Kilo overrides */
 @import "@opencode-ai/ui/styles";
 

--- a/packages/kilo-ui/src/styles/tailwind/index.css
+++ b/packages/kilo-ui/src/styles/tailwind/index.css
@@ -1,4 +1,3 @@
-/* kilocode_change - new file */
 /* Wraps upstream tailwind styles and adds Kilo overrides */
 @import "@opencode-ai/ui/styles/tailwind";
 

--- a/packages/kilo-ui/src/theme/color.ts
+++ b/packages/kilo-ui/src/theme/color.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/theme/color"

--- a/packages/kilo-ui/src/theme/context.tsx
+++ b/packages/kilo-ui/src/theme/context.tsx
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 // Copy of @opencode-ai/ui/theme/context.tsx with two changes:
 // 1. Imports DEFAULT_THEMES from our local default-themes (which includes Kilo themes)
 // 2. Default theme changed from "oc-1" to "kilo"
@@ -11,7 +10,7 @@ import { createSimpleContext } from "@opencode-ai/ui/context/helper"
 
 export type ColorScheme = "light" | "dark" | "system"
 
-const DEFAULT_THEME_ID = "kilo" // kilocode_change: was "oc-1"
+const DEFAULT_THEME_ID = "kilo"
 
 const STORAGE_KEYS = {
   THEME_ID: "opencode-theme-id",
@@ -77,7 +76,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   init: (props: { defaultTheme?: string }) => {
     const [store, setStore] = createStore({
       themes: DEFAULT_THEMES as Record<string, DesktopTheme>,
-      themeId: props.defaultTheme ?? DEFAULT_THEME_ID, // kilocode_change: was "oc-1"
+      themeId: props.defaultTheme ?? DEFAULT_THEME_ID,
       colorScheme: "system" as ColorScheme,
       mode: getSystemMode(),
       previewThemeId: null as string | null,

--- a/packages/kilo-ui/src/theme/default-themes.ts
+++ b/packages/kilo-ui/src/theme/default-themes.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import type { DesktopTheme } from "@opencode-ai/ui/theme/types"
 import { DEFAULT_THEMES as UPSTREAM_THEMES } from "@opencode-ai/ui/theme/default-themes"
 import kiloJson from "./themes/kilo.json"

--- a/packages/kilo-ui/src/theme/index.ts
+++ b/packages/kilo-ui/src/theme/index.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 export type {
   DesktopTheme,
   ThemeSeedColors,

--- a/packages/kilo-ui/src/theme/loader.ts
+++ b/packages/kilo-ui/src/theme/loader.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/theme/loader"

--- a/packages/kilo-ui/src/theme/resolve.ts
+++ b/packages/kilo-ui/src/theme/resolve.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/theme/resolve"

--- a/packages/kilo-ui/src/theme/types.ts
+++ b/packages/kilo-ui/src/theme/types.ts
@@ -1,2 +1,1 @@
-// kilocode_change - new file
 export * from "@opencode-ai/ui/theme/types"

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1707,7 +1707,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * settings from the previous version of the extension which shares the same
    * extension ID and "kilo-code.*" namespace.
    */
-  // kilocode_change start
   private async handleResetAllSettings(): Promise<void> {
     const confirmed = await vscode.window.showWarningMessage(
       "Reset all Kilo Code extension settings to defaults?",
@@ -1735,7 +1734,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.sendBrowserSettings()
     this.sendNotificationSettings()
   }
-  // kilocode_change end
 
   /**
    * Read the current browser automation settings and push them to the webview.

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -68,7 +68,7 @@ export class ServerManager {
           KILO_SERVER_PASSWORD: password,
           KILO_CLIENT: "vscode",
           KILO_ENABLE_QUESTION_TOOL: "true",
-          KILOCODE_FEATURE: "vscode-extension", // kilocode_change - feature tracking
+          KILOCODE_FEATURE: "vscode-extension",
           KILO_TELEMETRY_LEVEL: vscode.env.isTelemetryEnabled ? "all" : "off",
           KILO_APP_NAME: "kilo-code",
           KILO_EDITOR_NAME: vscode.env.appName,
@@ -130,7 +130,7 @@ export class ServerManager {
 
   private getCliPath(): string {
     // Always use the bundled binary from the extension directory
-    const binName = process.platform === "win32" ? "kilo.exe" : "kilo" // kilocode_change
+    const binName = process.platform === "win32" ? "kilo.exe" : "kilo"
     const cliPath = path.join(this.context.extensionPath, "bin", binName)
     console.log("[Kilo New] ServerManager: 📦 Using CLI path:", cliPath)
     return cliPath

--- a/packages/opencode/src/kilocode/components/dialog-kilo-auto-method.tsx
+++ b/packages/opencode/src/kilocode/components/dialog-kilo-auto-method.tsx
@@ -1,4 +1,3 @@
-// kilocode_change - Kilo Gateway TUI component
 /**
  * Custom OAuth handler for Kilo Gateway
  *

--- a/packages/opencode/src/kilocode/components/dialog-kilo-notifications.tsx
+++ b/packages/opencode/src/kilocode/components/dialog-kilo-notifications.tsx
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 /**
  * Kilo Notifications Dialog
  *

--- a/packages/opencode/src/kilocode/components/dialog-kilo-organization.tsx
+++ b/packages/opencode/src/kilocode/components/dialog-kilo-organization.tsx
@@ -1,4 +1,3 @@
-// kilocode_change - Kilo Gateway TUI component
 /**
  * Kilo Gateway Organization Selection Dialog
  *

--- a/packages/opencode/src/kilocode/components/dialog-kilo-profile.tsx
+++ b/packages/opencode/src/kilocode/components/dialog-kilo-profile.tsx
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 /**
  * Kilo Gateway Profile Dialog
  *

--- a/packages/opencode/src/kilocode/components/dialog-kilo-team-select.tsx
+++ b/packages/opencode/src/kilocode/components/dialog-kilo-team-select.tsx
@@ -1,4 +1,3 @@
-// kilocode_change - Kilo Gateway TUI component
 /**
  * Kilo Gateway Team Selection Dialog
  *

--- a/packages/opencode/src/kilocode/components/kilo-news.tsx
+++ b/packages/opencode/src/kilocode/components/kilo-news.tsx
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 /**
  * Kilo News Component
  *

--- a/packages/opencode/src/kilocode/components/notification-banner.tsx
+++ b/packages/opencode/src/kilocode/components/notification-banner.tsx
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 /**
  * Kilo Notification Banner
  *

--- a/packages/opencode/src/kilocode/components/tips.tsx
+++ b/packages/opencode/src/kilocode/components/tips.tsx
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 
 import { For } from "solid-js"
 import { DEFAULT_THEMES, useTheme } from "@tui/context/theme"

--- a/packages/opencode/src/kilocode/config-injector.ts
+++ b/packages/opencode/src/kilocode/config-injector.ts
@@ -1,8 +1,8 @@
 import { Config } from "../config/config"
 import { ModesMigrator } from "./modes-migrator"
-import { RulesMigrator } from "./rules-migrator" // kilocode_change
+import { RulesMigrator } from "./rules-migrator"
 import { WorkflowsMigrator } from "./workflows-migrator"
-import { IgnoreMigrator } from "./ignore-migrator" // kilocode_change
+import { IgnoreMigrator } from "./ignore-migrator"
 
 export namespace KilocodeConfigInjector {
   export interface InjectionResult {
@@ -46,7 +46,6 @@ export namespace KilocodeConfigInjector {
       config.command = workflowsMigration.commands
     }
 
-    // kilocode_change start - Rules migration
     if (options.includeRules !== false) {
       const rulesMigration = await RulesMigrator.migrate({
         projectDir: options.projectDir,
@@ -60,9 +59,7 @@ export namespace KilocodeConfigInjector {
         config.instructions = rulesMigration.instructions
       }
     }
-    // kilocode_change end
 
-    // kilocode_change start - Ignore migration
     if (options.includeIgnore !== false) {
       const ignoreMigration = await IgnoreMigrator.migrate({
         projectDir: options.projectDir,
@@ -75,7 +72,6 @@ export namespace KilocodeConfigInjector {
         config.permission = mergePermissions(config.permission, ignoreMigration.permission)
       }
     }
-    // kilocode_change end
 
     return {
       configJson: JSON.stringify(config),

--- a/packages/opencode/src/kilocode/const.ts
+++ b/packages/opencode/src/kilocode/const.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 
 import { Installation } from "@/installation"
 

--- a/packages/opencode/src/kilocode/enhance-prompt.ts
+++ b/packages/opencode/src/kilocode/enhance-prompt.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import { Provider } from "@/provider/provider"
 import { LLM } from "@/session/llm"
 import { Agent } from "@/agent/agent"

--- a/packages/opencode/src/kilocode/ignore-migrator.ts
+++ b/packages/opencode/src/kilocode/ignore-migrator.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 
 import * as path from "path"
 import os from "os"

--- a/packages/opencode/src/kilocode/index.ts
+++ b/packages/opencode/src/kilocode/index.ts
@@ -2,6 +2,6 @@ export { ModesMigrator } from "./modes-migrator"
 export { RulesMigrator } from "./rules-migrator"
 export { WorkflowsMigrator } from "./workflows-migrator"
 export { McpMigrator } from "./mcp-migrator"
-export { IgnoreMigrator } from "./ignore-migrator" // kilocode_change
+export { IgnoreMigrator } from "./ignore-migrator"
 export { KilocodeConfigInjector } from "./config-injector"
 export { KilocodePaths } from "./paths"

--- a/packages/opencode/src/kilocode/modes-migrator.ts
+++ b/packages/opencode/src/kilocode/modes-migrator.ts
@@ -23,7 +23,6 @@ export namespace ModesMigrator {
   }
 
   // Default modes to skip - these have native Opencode equivalents
-  // kilocode_change - added "build" for backward compatibility after renaming "build" to "code"
   const DEFAULT_MODE_SLUGS = new Set(["code", "build", "architect", "ask", "debug", "orchestrator"])
 
   // Group to permission mapping

--- a/packages/opencode/src/kilocode/project-id.ts
+++ b/packages/opencode/src/kilocode/project-id.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import { Instance } from "@/project/instance"
 import path from "path"
 import { $ } from "bun"

--- a/packages/opencode/src/kilocode/review/command.ts
+++ b/packages/opencode/src/kilocode/review/command.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import type { Command } from "@/command"
 import { Review } from "./review"
 

--- a/packages/opencode/src/kilocode/review/review.ts
+++ b/packages/opencode/src/kilocode/review/review.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import { $ } from "bun"
 import { Log } from "@/util/log"
 import { Instance } from "@/project/instance"

--- a/packages/opencode/src/kilocode/review/types.ts
+++ b/packages/opencode/src/kilocode/review/types.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import z from "zod"
 
 export const DiffHunk = z.object({

--- a/packages/opencode/src/kilocode/rules-migrator.ts
+++ b/packages/opencode/src/kilocode/rules-migrator.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 
 import * as fs from "fs/promises"
 import * as path from "path"

--- a/packages/opencode/src/kilocode/workflows-migrator.ts
+++ b/packages/opencode/src/kilocode/workflows-migrator.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 
 import * as fs from "fs/promises"
 import * as path from "path"

--- a/packages/opencode/test/kilocode/config-injector.test.ts
+++ b/packages/opencode/test/kilocode/config-injector.test.ts
@@ -109,7 +109,6 @@ describe("KilocodeConfigInjector", () => {
       expect(config.command["deploy"]).toBeDefined()
     })
 
-    // kilocode_change start - Rules migration tests
     test("includes rules in config", async () => {
       await using tmp = await tmpdir({
         init: async (dir) => {
@@ -197,9 +196,7 @@ describe("KilocodeConfigInjector", () => {
 
       expect(result.warnings.some((w) => w.includes("Legacy"))).toBe(true)
     })
-    // kilocode_change end
 
-    // kilocode_change start - Ignore migration tests
     test("includes ignore patterns in config", async () => {
       await using tmp = await tmpdir({
         init: async (dir) => {
@@ -283,7 +280,6 @@ describe("KilocodeConfigInjector", () => {
       expect(config.permission.read["*.env"]).toBe("deny")
       expect(config.permission.read[".env.example"]).toBe("allow")
     })
-    // kilocode_change end
   })
 
   describe("getEnvVars", () => {

--- a/packages/opencode/test/kilocode/kilo-gateway-headers.test.ts
+++ b/packages/opencode/test/kilocode/kilo-gateway-headers.test.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import { describe, it, expect, afterEach } from "bun:test"
 import { buildKiloHeaders, getFeatureHeader, getEditorNameHeader } from "@kilocode/kilo-gateway"
 import { HEADER_FEATURE, ENV_FEATURE } from "@kilocode/kilo-gateway"

--- a/packages/opencode/test/kilocode/model-cache-org.test.ts
+++ b/packages/opencode/test/kilocode/model-cache-org.test.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 // Regression test: OAuth accountId must flow into model fetch as kilocodeOrganizationId
 // When a user logs in via OAuth and selects an enterprise organization, the model fetch
 // should use the organization-specific endpoint, not the personal endpoint.


### PR DESCRIPTION
## Summary

- Removes all `kilocode_change` markers from kilo-specific packages (`packages/opencode/src/kilocode/`, `packages/opencode/test/kilocode/`, `packages/kilo-gateway/`, `packages/kilo-ui/`, `packages/kilo-i18n/`, `packages/kilo-vscode/`, etc.)
- These markers exist only to prevent merge conflicts when syncing with upstream opencode — they have no purpose inside files that are entirely kilo-specific
- 185 markers removed across 170 files

all changes are actually in dirs with kilo