### PR TITLE
chore: ignore .husky/_ directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.husky/_
 .DS_Store
 node_modules
 .worktrees


### PR DESCRIPTION
The `.husky/_` directory contains git-lfs hook files that get auto-generated locally and keep showing up as untracked changes in PRs. Adding it to `.gitignore` prevents this noise.