### PR TITLE
feat: add discoverable keyboard shortcuts help in Agent Manager

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -153,6 +153,12 @@
         "icon": "$(diff)"
       },
       {
+        "command": "kilo-code.new.agentManager.showShortcuts",
+        "title": "Agent Manager: Show Keyboard Shortcuts",
+        "category": "Kilo Code",
+        "icon": "$(keyboard)"
+      },
+      {
         "command": "kilo-code.new.agentManager.focusPanel",
         "title": "Agent Manager: Focus Panel",
         "category": "Kilo Code",
@@ -436,6 +442,12 @@
         "command": "kilo-code.new.agentManager.toggleDiff",
         "key": "ctrl+d",
         "mac": "cmd+d",
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.agentManager.showShortcuts",
+        "key": "ctrl+shift+/",
+        "mac": "cmd+shift+/",
         "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
       },
       {

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1239,6 +1239,9 @@ export class AgentManagerProvider implements vscode.Disposable {
     if (!bindings.toggleDiff) {
       bindings.toggleDiff = formatKeybinding(mac ? "cmd+d" : "ctrl+d", mac)
     }
+    if (!bindings.showShortcuts) {
+      bindings.showShortcuts = formatKeybinding(mac ? "cmd+shift+/" : "ctrl+shift+/", mac)
+    }
 
     this.postToWebview({ type: "agentManager.keybindings", bindings })
   }

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -96,6 +96,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("kilo-code.new.agentManager.toggleDiff", () => {
       agentManagerProvider.postMessage({ type: "action", action: "toggleDiff" })
     }),
+    vscode.commands.registerCommand("kilo-code.new.agentManager.showShortcuts", () => {
+      agentManagerProvider.postMessage({ type: "action", action: "showShortcuts" })
+    }),
     vscode.commands.registerCommand("kilo-code.new.agentManager.focusPanel", () => {
       agentManagerProvider.focusPanel()
     }),

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -123,6 +123,7 @@ const defaultBindings: Record<string, string> = {
   previousTab: isMac ? "⌘⌥←" : "Ctrl+Alt+←",
   nextTab: isMac ? "⌘⌥→" : "Ctrl+Alt+→",
   showTerminal: isMac ? "⌘/" : "Ctrl+/",
+  showShortcuts: isMac ? "⌘⇧/" : "Ctrl+Shift+/",
   newTab: isMac ? "⌘T" : "Ctrl+T",
   closeTab: isMac ? "⌘W" : "Ctrl+W",
   newWorktree: isMac ? "⌘N" : "Ctrl+N",
@@ -261,6 +262,7 @@ function buildShortcutCategories(
       title: t("agentManager.shortcuts.category.global"),
       shortcuts: [
         { label: t("agentManager.shortcuts.openAgentManager"), binding: bindings.agentManagerOpen ?? "" },
+        { label: t("agentManager.shortcuts.showShortcuts"), binding: bindings.showShortcuts ?? "" },
       ].filter((s) => s.binding),
     },
   ].filter((c) => c.shortcuts.length > 0)
@@ -936,6 +938,7 @@ const AgentManagerContent: Component = () => {
       else if (msg.action === "newWorktree") handleNewWorktreeOrPromote()
       else if (msg.action === "advancedWorktree") showAdvancedWorktreeDialog()
       else if (msg.action === "closeWorktree") closeSelectedWorktree()
+      else if (msg.action === "showShortcuts") handleShowKeyboardShortcuts()
       else if (msg.action === "focusInput") window.dispatchEvent(new Event("focusPrompt"))
       else {
         // Handle jumpTo1 through jumpTo9
@@ -958,6 +961,10 @@ const AgentManagerContent: Component = () => {
       }
       // Prevent defaults for shift variants (close worktree, advanced new worktree)
       if (["w", "n"].includes(e.key.toLowerCase()) && e.shiftKey) {
+        e.preventDefault()
+      }
+      // Prevent browser defaults for shortcuts help (Cmd/Ctrl+Shift+/)
+      if (["/", "?"].includes(e.key) && e.shiftKey) {
         e.preventDefault()
       }
       // Prevent defaults for jump-to shortcuts (Cmd/Ctrl+1-9)
@@ -1739,6 +1746,19 @@ const AgentManagerContent: Component = () => {
             <span class="am-section-label">{t("agentManager.section.worktrees")}</span>
             <Show when={isGitRepo()}>
               <div class="am-section-actions">
+                <TooltipKeybind
+                  title={t("agentManager.shortcuts.title")}
+                  keybind={kb().showShortcuts ?? ""}
+                  placement="bottom"
+                >
+                  <IconButton
+                    icon="keyboard"
+                    size="small"
+                    variant="ghost"
+                    label={t("agentManager.shortcuts.title")}
+                    onClick={handleShowKeyboardShortcuts}
+                  />
+                </TooltipKeybind>
                 <DropdownMenu gutter={4} placement="bottom-end">
                   <DropdownMenu.Trigger
                     as={IconButton}
@@ -1751,6 +1771,11 @@ const AgentManagerContent: Component = () => {
                     <DropdownMenu.Content class="am-split-menu">
                       <DropdownMenu.Item onSelect={handleShowKeyboardShortcuts}>
                         <DropdownMenu.ItemLabel>{t("agentManager.shortcuts.title")}</DropdownMenu.ItemLabel>
+                        <span class="am-menu-shortcut">
+                          {parseBindingTokens(kb().showShortcuts ?? "").map((token) => (
+                            <kbd class="am-menu-key">{token}</kbd>
+                          ))}
+                        </span>
                       </DropdownMenu.Item>
                       <DropdownMenu.Separator />
                       <DropdownMenu.Item onSelect={handleConfigureSetupScript}>

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1746,44 +1746,6 @@ const AgentManagerContent: Component = () => {
             <span class="am-section-label">{t("agentManager.section.worktrees")}</span>
             <Show when={isGitRepo()}>
               <div class="am-section-actions">
-                <TooltipKeybind
-                  title={t("agentManager.shortcuts.title")}
-                  keybind={kb().showShortcuts ?? ""}
-                  placement="bottom"
-                >
-                  <IconButton
-                    icon="keyboard"
-                    size="small"
-                    variant="ghost"
-                    label={t("agentManager.shortcuts.title")}
-                    onClick={handleShowKeyboardShortcuts}
-                  />
-                </TooltipKeybind>
-                <DropdownMenu gutter={4} placement="bottom-end">
-                  <DropdownMenu.Trigger
-                    as={IconButton}
-                    icon="settings-gear"
-                    size="small"
-                    variant="ghost"
-                    label={t("agentManager.worktree.settings")}
-                  />
-                  <DropdownMenu.Portal>
-                    <DropdownMenu.Content class="am-split-menu">
-                      <DropdownMenu.Item onSelect={handleShowKeyboardShortcuts}>
-                        <DropdownMenu.ItemLabel>{t("agentManager.shortcuts.title")}</DropdownMenu.ItemLabel>
-                        <span class="am-menu-shortcut">
-                          {parseBindingTokens(kb().showShortcuts ?? "").map((token) => (
-                            <kbd class="am-menu-key">{token}</kbd>
-                          ))}
-                        </span>
-                      </DropdownMenu.Item>
-                      <DropdownMenu.Separator />
-                      <DropdownMenu.Item onSelect={handleConfigureSetupScript}>
-                        <DropdownMenu.ItemLabel>{t("agentManager.worktree.setupScript")}</DropdownMenu.ItemLabel>
-                      </DropdownMenu.Item>
-                    </DropdownMenu.Content>
-                  </DropdownMenu.Portal>
-                </DropdownMenu>
                 <div class="am-split-button">
                   <IconButton
                     icon="plus"
@@ -1823,6 +1785,35 @@ const AgentManagerContent: Component = () => {
                     </DropdownMenu.Portal>
                   </DropdownMenu>
                 </div>
+                <TooltipKeybind
+                  title={t("agentManager.shortcuts.title")}
+                  keybind={kb().showShortcuts ?? ""}
+                  placement="bottom"
+                >
+                  <IconButton
+                    icon="keyboard"
+                    size="small"
+                    variant="ghost"
+                    label={t("agentManager.shortcuts.title")}
+                    onClick={handleShowKeyboardShortcuts}
+                  />
+                </TooltipKeybind>
+                <DropdownMenu gutter={4} placement="bottom-end">
+                  <DropdownMenu.Trigger
+                    as={IconButton}
+                    icon="settings-gear"
+                    size="small"
+                    variant="ghost"
+                    label={t("agentManager.worktree.settings")}
+                  />
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Content class="am-split-menu">
+                      <DropdownMenu.Item onSelect={handleConfigureSetupScript}>
+                        <DropdownMenu.ItemLabel>{t("agentManager.worktree.setupScript")}</DropdownMenu.ItemLabel>
+                      </DropdownMenu.Item>
+                    </DropdownMenu.Content>
+                  </DropdownMenu.Portal>
+                </DropdownMenu>
               </div>
             </Show>
           </div>

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "تبديل الطرفية",
   "agentManager.shortcuts.focusPanel": "تركيز اللوحة",
   "agentManager.shortcuts.openAgentManager": "فتح Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "إظهار اختصارات لوحة المفاتيح",
   "agentManager.dialog.deleteWorktree.title": "حذف Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "حذف Worktree ",
   "agentManager.dialog.deleteWorktree.messagePost": "؟ سيؤدي هذا إلى إزالة Worktree من القرص وفصل جميع الجلسات.",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "Alternar terminal",
   "agentManager.shortcuts.focusPanel": "Focar painel",
   "agentManager.shortcuts.openAgentManager": "Abrir Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "Mostrar atalhos de teclado",
   "agentManager.dialog.deleteWorktree.title": "Excluir Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "Excluir Worktree ",
   "agentManager.dialog.deleteWorktree.messagePost": "? Isso remove o Worktree do disco e desassocia todas as sessões.",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "Prebaci terminal",
   "agentManager.shortcuts.focusPanel": "Fokusiraj panel",
   "agentManager.shortcuts.openAgentManager": "Otvori Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "Prikaži prečice na tastaturi",
   "agentManager.dialog.deleteWorktree.title": "Obriši Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "Obriši Worktree ",
   "agentManager.dialog.deleteWorktree.messagePost": "? Ovo uklanja Worktree sa diska i odvezuje sve sesije.",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "Skift terminal",
   "agentManager.shortcuts.focusPanel": "Fokuser panel",
   "agentManager.shortcuts.openAgentManager": "Åbn Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "Vis tastaturgenveje",
   "agentManager.dialog.deleteWorktree.title": "Slet Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "Slet Worktree ",
   "agentManager.dialog.deleteWorktree.messagePost": "? Dette fjerner Worktree fra disken og afkobler alle sessioner.",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "Terminal umschalten",
   "agentManager.shortcuts.focusPanel": "Panel fokussieren",
   "agentManager.shortcuts.openAgentManager": "Agent Manager öffnen",
+  "agentManager.shortcuts.showShortcuts": "Tastenkürzel anzeigen",
   "agentManager.dialog.deleteWorktree.title": "Worktree löschen",
   "agentManager.dialog.deleteWorktree.messagePre": "Worktree löschen ",
   "agentManager.dialog.deleteWorktree.messagePost":

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -54,6 +54,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "Toggle terminal",
   "agentManager.shortcuts.focusPanel": "Focus panel",
   "agentManager.shortcuts.openAgentManager": "Open Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "Show keyboard shortcuts",
 
   "agentManager.dialog.deleteWorktree.title": "Delete Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "Delete worktree ",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "Alternar terminal",
   "agentManager.shortcuts.focusPanel": "Enfocar panel",
   "agentManager.shortcuts.openAgentManager": "Abrir Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "Mostrar atajos de teclado",
   "agentManager.dialog.deleteWorktree.title": "Eliminar Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "¿Eliminar Worktree ",
   "agentManager.dialog.deleteWorktree.messagePost":

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "Basculer le terminal",
   "agentManager.shortcuts.focusPanel": "Focaliser le panneau",
   "agentManager.shortcuts.openAgentManager": "Ouvrir Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "Afficher les raccourcis clavier",
   "agentManager.dialog.deleteWorktree.title": "Supprimer le Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "Supprimer le Worktree ",
   "agentManager.dialog.deleteWorktree.messagePost":

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "ターミナルの切り替え",
   "agentManager.shortcuts.focusPanel": "パネルにフォーカス",
   "agentManager.shortcuts.openAgentManager": "Agent Managerを開く",
+  "agentManager.shortcuts.showShortcuts": "キーボードショートカットを表示",
   "agentManager.dialog.deleteWorktree.title": "Worktreeを削除",
   "agentManager.dialog.deleteWorktree.messagePre": "Worktreeを削除 ",
   "agentManager.dialog.deleteWorktree.messagePost":

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "터미널 전환",
   "agentManager.shortcuts.focusPanel": "패널 포커스",
   "agentManager.shortcuts.openAgentManager": "Agent Manager 열기",
+  "agentManager.shortcuts.showShortcuts": "키보드 단축키 표시",
   "agentManager.dialog.deleteWorktree.title": "Worktree 삭제",
   "agentManager.dialog.deleteWorktree.messagePre": "Worktree 삭제 ",
   "agentManager.dialog.deleteWorktree.messagePost": "? 디스크에서 Worktree를 제거하고 모든 세션의 연결을 해제합니다.",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "Veksle terminal",
   "agentManager.shortcuts.focusPanel": "Fokuser panel",
   "agentManager.shortcuts.openAgentManager": "Åpne Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "Vis tastatursnarveier",
   "agentManager.dialog.deleteWorktree.title": "Slett Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "Slett Worktree ",
   "agentManager.dialog.deleteWorktree.messagePost": "? Dette fjerner Worktree fra disken og kobler fra alle økter.",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "Przełącz terminal",
   "agentManager.shortcuts.focusPanel": "Fokus na panelu",
   "agentManager.shortcuts.openAgentManager": "Otwórz Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "Pokaż skróty klawiszowe",
   "agentManager.dialog.deleteWorktree.title": "Usuń Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "Usunąć Worktree ",
   "agentManager.dialog.deleteWorktree.messagePost":

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "Переключить терминал",
   "agentManager.shortcuts.focusPanel": "Фокус на панели",
   "agentManager.shortcuts.openAgentManager": "Открыть Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "Показать сочетания клавиш",
   "agentManager.dialog.deleteWorktree.title": "Удалить Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "Удалить Worktree ",
   "agentManager.dialog.deleteWorktree.messagePost": "? Это удалит Worktree с диска и отключит все сессии.",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "สลับเทอร์มินัล",
   "agentManager.shortcuts.focusPanel": "โฟกัสแผง",
   "agentManager.shortcuts.openAgentManager": "เปิด Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "แสดงปุ่มลัดแป้นพิมพ์",
   "agentManager.dialog.deleteWorktree.title": "ลบ Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "ลบ Worktree ",
   "agentManager.dialog.deleteWorktree.messagePost":

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "切换终端",
   "agentManager.shortcuts.focusPanel": "聚焦面板",
   "agentManager.shortcuts.openAgentManager": "打开 Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "显示键盘快捷键",
   "agentManager.dialog.deleteWorktree.title": "删除 Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "删除 Worktree ",
   "agentManager.dialog.deleteWorktree.messagePost": "？这将从磁盘中移除 Worktree 并取消所有会话的关联。",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -48,6 +48,7 @@ export const dict = {
   "agentManager.shortcuts.toggleTerminal": "切換終端機",
   "agentManager.shortcuts.focusPanel": "聚焦面板",
   "agentManager.shortcuts.openAgentManager": "開啟 Agent Manager",
+  "agentManager.shortcuts.showShortcuts": "顯示鍵盤快捷鍵",
   "agentManager.dialog.deleteWorktree.title": "刪除 Worktree",
   "agentManager.dialog.deleteWorktree.messagePre": "刪除 Worktree ",
   "agentManager.dialog.deleteWorktree.messagePost": "？這將從磁碟中移除 Worktree 並取消所有工作階段的關聯。",


### PR DESCRIPTION
## Summary
- add a dedicated Agent Manager command and keybinding (`Cmd/Ctrl+Shift+/`) to open the keyboard shortcuts help dialog
- make shortcuts help discoverable via a subtle always-visible keyboard icon button plus inline keybinding hint in the settings dropdown
- include the help shortcut in the shortcuts dialog itself and add localized labels across all Agent Manager locales
- reordered buttons to have similar order like in the extension sidebar

<img width="444" height="202" alt="image" src="https://github.com/user-attachments/assets/d2851d9c-9e1c-4fe8-8926-3389c8710979" />

<img width="714" height="206" alt="image" src="https://github.com/user-attachments/assets/a4c7e111-77ea-4972-8aa4-0c940100903b" />


## Validation
- run `bun run compile` in `packages/kilo-vscode`