### PR TITLE
Disable 'kilo web' command (unsupported opencode web UI)

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -25,7 +25,7 @@ import { AttachCommand } from "./cli/cmd/tui/attach"
 import { TuiThreadCommand } from "./cli/cmd/tui/thread"
 import { AcpCommand } from "./cli/cmd/acp"
 import { EOL } from "os"
-import { WebCommand } from "./cli/cmd/web"
+// import { WebCommand } from "./cli/cmd/web" // kilocode_change (Disabled unsupported opencode web UI)
 import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
 // kilocode_change start - Import telemetry, instance disposal, and legacy migration
@@ -178,7 +178,7 @@ let cli = yargs(hideBin(process.argv))
   .command(UpgradeCommand)
   .command(UninstallCommand)
   .command(ServeCommand)
-  .command(WebCommand)
+  // .command(WebCommand) // kilocode_change (Disabled unsupported opencode web UI)
   .command(ModelsCommand)
   .command(StatsCommand)
   .command(ExportCommand)


### PR DESCRIPTION
## Summary

- Disables the `kilo web` command by commenting out its import and registration in `packages/opencode/src/index.ts`
- The web app launched by this command displays the "opencode" branding and is inherited from the upstream fork — it is not supported or maintained by Kilo
- Running `kilo web` will now show an "Unknown argument: web" error instead of launching the unsupported web UI

## Details

The change is minimal (2 lines commented out), following the same pattern already used for the disabled `GithubCommand`. The web app source code (`packages/opencode/src/cli/cmd/web.ts`, `packages/app/`) is left intact for potential future cleanup or re-enablement.

---

Built for [Mark](https://kilo-code.slack.com/archives/C09GD7US2UB/p1772626203495599?thread_ts=1772615184.549779&cid=C09GD7US2UB) by [Kilo for Slack](https://kilo.ai/features/slack-integration)