### PR TITLE
ci: use BOT_PAT instead of GITHUB_TOKEN for visual regression tests

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PAT }}
           ref: ${{ github.head_ref }}
 
       - name: Setup Bun
@@ -92,6 +92,8 @@ jobs:
 
       - name: Commit and push new baselines (if any)
         id: commit-baselines
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -132,7 +134,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PAT }}
           ref: ${{ github.head_ref }}
 
       - name: Setup Bun
@@ -186,6 +188,8 @@ jobs:
 
       - name: Commit and push new baselines (if any)
         id: commit-baselines-vscode
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Switches the visual regression workflow to use `BOT_PAT` (a personal access token) instead of the default `GITHUB_TOKEN` for checkout and pushing baseline commits. This ensures CI workflows are triggered on those commits since pushes from a PAT are treated as real user actions by GitHub.