### PR TITLE
Add worktree-only Open action and shortcut in Agent Manager

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -174,6 +174,11 @@
         "category": "Kilo Code"
       },
       {
+        "command": "kilo-code.new.agentManager.openWorktree",
+        "title": "Agent Manager: Open Worktree",
+        "category": "Kilo Code"
+      },
+      {
         "command": "kilo-code.new.agentManager.closeWorktree",
         "title": "Agent Manager: Close Worktree",
         "category": "Kilo Code"
@@ -460,6 +465,12 @@
         "command": "kilo-code.new.agentManager.newWorktree",
         "key": "ctrl+n",
         "mac": "cmd+n",
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.agentManager.openWorktree",
+        "key": "ctrl+shift+o",
+        "mac": "cmd+shift+o",
         "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
       },
       {

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -201,6 +201,10 @@ export class AgentManagerProvider implements vscode.Disposable {
       this.terminalManager.showLocalTerminal()
       return null
     }
+    if (type === "agentManager.openWorktree" && typeof msg.worktreeId === "string") {
+      this.openWorktreeDirectory(msg.worktreeId)
+      return null
+    }
     if (type === "agentManager.showExistingLocalTerminal") {
       this.terminalManager.syncLocalOnSessionSwitch()
       return null
@@ -1515,6 +1519,22 @@ export class AgentManagerProvider implements vscode.Disposable {
   // ---------------------------------------------------------------------------
   // Diff polling
   // ---------------------------------------------------------------------------
+
+  /** Open a worktree directory directly in VS Code. */
+  private openWorktreeDirectory(worktreeId: string): void {
+    const state = this.getStateManager()
+    if (!state) return
+    const worktree = state.getWorktree(worktreeId)
+    if (!worktree) return
+    const target = path.normalize(worktree.path)
+    if (!fs.existsSync(target)) {
+      this.log(`openWorktreeDirectory: missing path ${target}`)
+      void vscode.window.showErrorMessage("Worktree folder does not exist on disk.")
+      return
+    }
+    const uri = vscode.Uri.file(target)
+    void vscode.commands.executeCommand("vscode.openFolder", uri, true)
+  }
 
   /** Open a file from a worktree or local session in the VS Code editor. */
   private openWorktreeFile(sessionId: string, relativePath: string): void {

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -108,6 +108,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("kilo-code.new.agentManager.newWorktree", () => {
       agentManagerProvider.postMessage({ type: "action", action: "newWorktree" })
     }),
+    vscode.commands.registerCommand("kilo-code.new.agentManager.openWorktree", () => {
+      agentManagerProvider.postMessage({ type: "action", action: "openWorktree" })
+    }),
     vscode.commands.registerCommand("kilo-code.new.agentManager.closeWorktree", () => {
       agentManagerProvider.postMessage({ type: "action", action: "closeWorktree" })
     }),

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -128,6 +128,7 @@ const defaultBindings: Record<string, string> = {
   newWorktree: isMac ? "⌘N" : "Ctrl+N",
   advancedWorktree: isMac ? "⌘⇧N" : "Ctrl+Shift+N",
   closeWorktree: isMac ? "⌘⇧W" : "Ctrl+Shift+W",
+  openWorktree: isMac ? "⌘⇧O" : "Ctrl+Shift+O",
   agentManagerOpen: isMac ? "⌘⇧M" : "Ctrl+Shift+M",
   focusPanel: isMac ? "⌘." : "Ctrl+.",
   ...Object.fromEntries(
@@ -238,6 +239,7 @@ function buildShortcutCategories(
         { label: t("agentManager.shortcuts.newWorktree"), binding: bindings.newWorktree ?? "" },
         { label: t("agentManager.shortcuts.advancedWorktree"), binding: bindings.advancedWorktree ?? "" },
         { label: t("agentManager.shortcuts.deleteWorktree"), binding: bindings.closeWorktree ?? "" },
+        { label: t("agentManager.shortcuts.openWorktree"), binding: bindings.openWorktree ?? "" },
       ],
     },
     {
@@ -547,6 +549,12 @@ const AgentManagerContent: Component = () => {
       ),
       resetApplyDialog,
     )
+  }
+
+  const openWorktreeDirectory = () => {
+    const sel = selection()
+    if (!sel || sel === LOCAL) return
+    vscode.postMessage({ type: "agentManager.openWorktree", worktreeId: sel })
   }
 
   createEffect(
@@ -934,6 +942,7 @@ const AgentManagerContent: Component = () => {
       } else if (msg.action === "newTab") handleNewTabForCurrentSelection()
       else if (msg.action === "closeTab") closeActiveTab()
       else if (msg.action === "newWorktree") handleNewWorktreeOrPromote()
+      else if (msg.action === "openWorktree") openWorktreeDirectory()
       else if (msg.action === "advancedWorktree") showAdvancedWorktreeDialog()
       else if (msg.action === "closeWorktree") closeSelectedWorktree()
       else if (msg.action === "focusInput") window.dispatchEvent(new Event("focusPrompt"))
@@ -956,8 +965,8 @@ const AgentManagerContent: Component = () => {
       if (["t", "w", "n", "d", "f"].includes(e.key.toLowerCase()) && !e.shiftKey) {
         e.preventDefault()
       }
-      // Prevent defaults for shift variants (close worktree, advanced new worktree)
-      if (["w", "n"].includes(e.key.toLowerCase()) && e.shiftKey) {
+      // Prevent defaults for shift variants (close worktree, advanced/new open worktree)
+      if (["w", "n", "o"].includes(e.key.toLowerCase()) && e.shiftKey) {
         e.preventDefault()
       }
       // Prevent defaults for jump-to shortcuts (Cmd/Ctrl+1-9)
@@ -2340,19 +2349,26 @@ const AgentManagerContent: Component = () => {
                   return (
                     <>
                       <Show when={isWorktree()}>
-                        <Tooltip value={t("agentManager.apply.tooltip")} placement="bottom">
-                          <Button
-                            size="small"
-                            variant="ghost"
-                            onClick={openApplyDialog}
-                            disabled={!hasChanges() || applyBusy()}
-                          >
-                            <Show when={applyBusy()}>
-                              <Spinner class="am-apply-spinner" />
-                            </Show>
-                            {t("agentManager.apply.globalButton")}
-                          </Button>
-                        </Tooltip>
+                        <>
+                          <Tooltip value={t("agentManager.open.tooltip")} placement="bottom">
+                            <Button size="small" variant="ghost" icon="folder" onClick={openWorktreeDirectory}>
+                              {t("agentManager.open.button")}
+                            </Button>
+                          </Tooltip>
+                          <Tooltip value={t("agentManager.apply.tooltip")} placement="bottom">
+                            <Button
+                              size="small"
+                              variant="ghost"
+                              onClick={openApplyDialog}
+                              disabled={!hasChanges() || applyBusy()}
+                            >
+                              <Show when={applyBusy()}>
+                                <Spinner class="am-apply-spinner" />
+                              </Show>
+                              {t("agentManager.apply.globalButton")}
+                            </Button>
+                          </Tooltip>
+                        </>
                       </Show>
                       <TooltipKeybind
                         title={t("agentManager.diff.toggle")}

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "العنصر السابق",
   "agentManager.shortcuts.nextItem": "العنصر التالي",
   "agentManager.shortcuts.newWorktree": "Worktree جديد",
+  "agentManager.shortcuts.openWorktree": "فتح Worktree",
   "agentManager.shortcuts.advancedWorktree": "Worktree متقدم",
   "agentManager.shortcuts.deleteWorktree": "حذف Worktree",
   "agentManager.shortcuts.previousTab": "علامة التبويب السابقة",
@@ -85,6 +86,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "تبديل الفرق",
   "agentManager.diff.openFile": "فتح الملف",
+  "agentManager.open.button": "فتح",
+  "agentManager.open.tooltip": "فتح Worktree هذا في VS Code",
   "agentManager.apply.button": "تطبيق محليًا",
   "agentManager.apply.globalButton": "تطبيق",
   "agentManager.apply.tooltip": "تطبيق تغييرات شجرة العمل المحددة على الفرع المحلي",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "Item anterior",
   "agentManager.shortcuts.nextItem": "Próximo item",
   "agentManager.shortcuts.newWorktree": "Novo Worktree",
+  "agentManager.shortcuts.openWorktree": "Abrir Worktree",
   "agentManager.shortcuts.advancedWorktree": "Worktree avançado",
   "agentManager.shortcuts.deleteWorktree": "Excluir Worktree",
   "agentManager.shortcuts.previousTab": "Aba anterior",
@@ -85,6 +86,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Alternar diff",
   "agentManager.diff.openFile": "Abrir arquivo",
+  "agentManager.open.button": "Abrir",
+  "agentManager.open.tooltip": "Abrir este Worktree no VS Code",
   "agentManager.apply.button": "Aplicar localmente",
   "agentManager.apply.globalButton": "Aplicar",
   "agentManager.apply.tooltip": "Aplicar alterações da worktree selecionada na branch local",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "Prethodni element",
   "agentManager.shortcuts.nextItem": "Sljedeći element",
   "agentManager.shortcuts.newWorktree": "Novi Worktree",
+  "agentManager.shortcuts.openWorktree": "Otvori worktree",
   "agentManager.shortcuts.advancedWorktree": "Napredni Worktree",
   "agentManager.shortcuts.deleteWorktree": "Obriši Worktree",
   "agentManager.shortcuts.previousTab": "Prethodna kartica",
@@ -85,6 +86,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Prebaci diff",
   "agentManager.diff.openFile": "Otvori datoteku",
+  "agentManager.open.button": "Otvori",
+  "agentManager.open.tooltip": "Otvori ovaj worktree u VS Code-u",
   "agentManager.apply.button": "Primijeni lokalno",
   "agentManager.apply.globalButton": "Primijeni",
   "agentManager.apply.tooltip": "Primijeni promjene odabranog radnog stabla na lokalnu granu",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "Forrige element",
   "agentManager.shortcuts.nextItem": "Næste element",
   "agentManager.shortcuts.newWorktree": "Nyt Worktree",
+  "agentManager.shortcuts.openWorktree": "Åbn Worktree",
   "agentManager.shortcuts.advancedWorktree": "Avanceret Worktree",
   "agentManager.shortcuts.deleteWorktree": "Slet Worktree",
   "agentManager.shortcuts.previousTab": "Forrige fane",
@@ -85,6 +86,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Skift diff",
   "agentManager.diff.openFile": "Åbn fil",
+  "agentManager.open.button": "Åbn",
+  "agentManager.open.tooltip": "Åbn dette Worktree i VS Code",
   "agentManager.apply.button": "Anvend lokalt",
   "agentManager.apply.globalButton": "Anvend",
   "agentManager.apply.tooltip": "Anvend valgte worktree-ændringer på den lokale gren",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "Vorheriges Element",
   "agentManager.shortcuts.nextItem": "Nächstes Element",
   "agentManager.shortcuts.newWorktree": "Neuer Worktree",
+  "agentManager.shortcuts.openWorktree": "Worktree öffnen",
   "agentManager.shortcuts.advancedWorktree": "Erweiterter Worktree",
   "agentManager.shortcuts.deleteWorktree": "Worktree löschen",
   "agentManager.shortcuts.previousTab": "Vorheriger Tab",
@@ -86,6 +87,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Diff umschalten",
   "agentManager.diff.openFile": "Datei öffnen",
+  "agentManager.open.button": "Öffnen",
+  "agentManager.open.tooltip": "Dieses Worktree in VS Code öffnen",
   "agentManager.apply.button": "Lokal anwenden",
   "agentManager.apply.globalButton": "Anwenden",
   "agentManager.apply.tooltip": "Ausgewählte Worktree-Änderungen auf den lokalen Branch anwenden",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -45,6 +45,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "Previous item",
   "agentManager.shortcuts.nextItem": "Next item",
   "agentManager.shortcuts.newWorktree": "New worktree",
+  "agentManager.shortcuts.openWorktree": "Open worktree",
   "agentManager.shortcuts.advancedWorktree": "Advanced worktree",
   "agentManager.shortcuts.deleteWorktree": "Delete worktree",
   "agentManager.shortcuts.previousTab": "Previous tab",
@@ -93,6 +94,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Toggle diff",
   "agentManager.diff.openFile": "Open file",
+  "agentManager.open.button": "Open",
+  "agentManager.open.tooltip": "Open this worktree in VS Code",
   "agentManager.apply.button": "Apply to local",
   "agentManager.apply.globalButton": "Apply",
   "agentManager.apply.tooltip": "Apply selected worktree changes to local branch",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "Elemento anterior",
   "agentManager.shortcuts.nextItem": "Siguiente elemento",
   "agentManager.shortcuts.newWorktree": "Nuevo Worktree",
+  "agentManager.shortcuts.openWorktree": "Abrir Worktree",
   "agentManager.shortcuts.advancedWorktree": "Worktree avanzado",
   "agentManager.shortcuts.deleteWorktree": "Eliminar Worktree",
   "agentManager.shortcuts.previousTab": "Pestaña anterior",
@@ -86,6 +87,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Alternar diff",
   "agentManager.diff.openFile": "Abrir archivo",
+  "agentManager.open.button": "Abrir",
+  "agentManager.open.tooltip": "Abrir este Worktree en VS Code",
   "agentManager.apply.button": "Aplicar en local",
   "agentManager.apply.globalButton": "Aplicar",
   "agentManager.apply.tooltip": "Aplicar los cambios del worktree seleccionado a la rama local",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "Élément précédent",
   "agentManager.shortcuts.nextItem": "Élément suivant",
   "agentManager.shortcuts.newWorktree": "Nouveau Worktree",
+  "agentManager.shortcuts.openWorktree": "Ouvrir le worktree",
   "agentManager.shortcuts.advancedWorktree": "Worktree avancé",
   "agentManager.shortcuts.deleteWorktree": "Supprimer le Worktree",
   "agentManager.shortcuts.previousTab": "Onglet précédent",
@@ -86,6 +87,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Basculer le diff",
   "agentManager.diff.openFile": "Ouvrir le fichier",
+  "agentManager.open.button": "Ouvrir",
+  "agentManager.open.tooltip": "Ouvrir ce worktree dans VS Code",
   "agentManager.apply.button": "Appliquer en local",
   "agentManager.apply.globalButton": "Appliquer",
   "agentManager.apply.tooltip": "Appliquer les modifications du worktree sélectionné à la branche locale",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "前の項目",
   "agentManager.shortcuts.nextItem": "次の項目",
   "agentManager.shortcuts.newWorktree": "新しいWorktree",
+  "agentManager.shortcuts.openWorktree": "Worktreeを開く",
   "agentManager.shortcuts.advancedWorktree": "詳細Worktree",
   "agentManager.shortcuts.deleteWorktree": "Worktreeを削除",
   "agentManager.shortcuts.previousTab": "前のタブ",
@@ -86,6 +87,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "差分を切り替え",
   "agentManager.diff.openFile": "ファイルを開く",
+  "agentManager.open.button": "開く",
+  "agentManager.open.tooltip": "このWorktreeをVS Codeで開く",
   "agentManager.apply.button": "ローカルに適用",
   "agentManager.apply.globalButton": "適用",
   "agentManager.apply.tooltip": "選択したワークツリーの変更をローカルブランチに適用",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "이전 항목",
   "agentManager.shortcuts.nextItem": "다음 항목",
   "agentManager.shortcuts.newWorktree": "새 Worktree",
+  "agentManager.shortcuts.openWorktree": "Worktree 열기",
   "agentManager.shortcuts.advancedWorktree": "고급 Worktree",
   "agentManager.shortcuts.deleteWorktree": "Worktree 삭제",
   "agentManager.shortcuts.previousTab": "이전 탭",
@@ -85,6 +86,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "차이점 전환",
   "agentManager.diff.openFile": "파일 열기",
+  "agentManager.open.button": "열기",
+  "agentManager.open.tooltip": "이 Worktree를 VS Code에서 열기",
   "agentManager.apply.button": "로컬에 적용",
   "agentManager.apply.globalButton": "적용",
   "agentManager.apply.tooltip": "선택한 워크트리 변경사항을 로컬 브랜치에 적용",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "Forrige element",
   "agentManager.shortcuts.nextItem": "Neste element",
   "agentManager.shortcuts.newWorktree": "Nytt Worktree",
+  "agentManager.shortcuts.openWorktree": "Åpne Worktree",
   "agentManager.shortcuts.advancedWorktree": "Avansert Worktree",
   "agentManager.shortcuts.deleteWorktree": "Slett Worktree",
   "agentManager.shortcuts.previousTab": "Forrige fane",
@@ -85,6 +86,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Veksle diff",
   "agentManager.diff.openFile": "Åpne fil",
+  "agentManager.open.button": "Åpne",
+  "agentManager.open.tooltip": "Åpne dette Worktree-et i VS Code",
   "agentManager.apply.button": "Bruk lokalt",
   "agentManager.apply.globalButton": "Bruk",
   "agentManager.apply.tooltip": "Bruk valgte worktree-endringer på den lokale grenen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "Poprzedni element",
   "agentManager.shortcuts.nextItem": "Następny element",
   "agentManager.shortcuts.newWorktree": "Nowy Worktree",
+  "agentManager.shortcuts.openWorktree": "Otwórz Worktree",
   "agentManager.shortcuts.advancedWorktree": "Zaawansowany Worktree",
   "agentManager.shortcuts.deleteWorktree": "Usuń Worktree",
   "agentManager.shortcuts.previousTab": "Poprzednia karta",
@@ -86,6 +87,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Przełącz diff",
   "agentManager.diff.openFile": "Otwórz plik",
+  "agentManager.open.button": "Otwórz",
+  "agentManager.open.tooltip": "Otwórz ten Worktree w VS Code",
   "agentManager.apply.button": "Zastosuj lokalnie",
   "agentManager.apply.globalButton": "Zastosuj",
   "agentManager.apply.tooltip": "Zastosuj wybrane zmiany worktree na lokalnej gałęzi",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "Предыдущий элемент",
   "agentManager.shortcuts.nextItem": "Следующий элемент",
   "agentManager.shortcuts.newWorktree": "Новый Worktree",
+  "agentManager.shortcuts.openWorktree": "Открыть Worktree",
   "agentManager.shortcuts.advancedWorktree": "Расширенный Worktree",
   "agentManager.shortcuts.deleteWorktree": "Удалить Worktree",
   "agentManager.shortcuts.previousTab": "Предыдущая вкладка",
@@ -85,6 +86,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "Переключить diff",
   "agentManager.diff.openFile": "Открыть файл",
+  "agentManager.open.button": "Открыть",
+  "agentManager.open.tooltip": "Открыть этот Worktree в VS Code",
   "agentManager.apply.button": "Применить локально",
   "agentManager.apply.globalButton": "Применить",
   "agentManager.apply.tooltip": "Применить изменения выбранного рабочего дерева к локальной ветке",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "รายการก่อนหน้า",
   "agentManager.shortcuts.nextItem": "รายการถัดไป",
   "agentManager.shortcuts.newWorktree": "Worktree ใหม่",
+  "agentManager.shortcuts.openWorktree": "เปิด Worktree",
   "agentManager.shortcuts.advancedWorktree": "Worktree ขั้นสูง",
   "agentManager.shortcuts.deleteWorktree": "ลบ Worktree",
   "agentManager.shortcuts.previousTab": "แท็บก่อนหน้า",
@@ -86,6 +87,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "สลับ diff",
   "agentManager.diff.openFile": "เปิดไฟล์",
+  "agentManager.open.button": "เปิด",
+  "agentManager.open.tooltip": "เปิด Worktree นี้ใน VS Code",
   "agentManager.apply.button": "นำไปใช้ในเครื่อง",
   "agentManager.apply.globalButton": "นำไปใช้",
   "agentManager.apply.tooltip": "นำการเปลี่ยนแปลงของ worktree ที่เลือกไปใช้กับสาขาในเครื่อง",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "上一项",
   "agentManager.shortcuts.nextItem": "下一项",
   "agentManager.shortcuts.newWorktree": "新建 Worktree",
+  "agentManager.shortcuts.openWorktree": "打开 Worktree",
   "agentManager.shortcuts.advancedWorktree": "高级 Worktree",
   "agentManager.shortcuts.deleteWorktree": "删除 Worktree",
   "agentManager.shortcuts.previousTab": "上一个标签页",
@@ -84,6 +85,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "切换差异",
   "agentManager.diff.openFile": "打开文件",
+  "agentManager.open.button": "打开",
+  "agentManager.open.tooltip": "在 VS Code 中打开此 Worktree",
   "agentManager.apply.button": "应用到本地",
   "agentManager.apply.globalButton": "应用",
   "agentManager.apply.tooltip": "将所选工作树的更改应用到本地分支",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -39,6 +39,7 @@ export const dict = {
   "agentManager.shortcuts.previousItem": "上一個項目",
   "agentManager.shortcuts.nextItem": "下一個項目",
   "agentManager.shortcuts.newWorktree": "新建 Worktree",
+  "agentManager.shortcuts.openWorktree": "開啟 Worktree",
   "agentManager.shortcuts.advancedWorktree": "進階 Worktree",
   "agentManager.shortcuts.deleteWorktree": "刪除 Worktree",
   "agentManager.shortcuts.previousTab": "上一個分頁",
@@ -84,6 +85,8 @@ export const dict = {
 
   "agentManager.diff.toggle": "切換差異",
   "agentManager.diff.openFile": "開啟檔案",
+  "agentManager.open.button": "開啟",
+  "agentManager.open.tooltip": "在 VS Code 中開啟此 Worktree",
   "agentManager.apply.button": "套用到本地",
   "agentManager.apply.globalButton": "套用",
   "agentManager.apply.tooltip": "將所選工作樹的變更套用到本地分支",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1290,6 +1290,12 @@ export interface ShowLocalTerminalRequest {
   type: "agentManager.showLocalTerminal"
 }
 
+// Open a worktree directory in VS Code
+export interface OpenWorktreeRequest {
+  type: "agentManager.openWorktree"
+  worktreeId: string
+}
+
 // Show existing local terminal when switching to local context (no-op if none exists)
 export interface ShowExistingLocalTerminalRequest {
   type: "agentManager.showExistingLocalTerminal"
@@ -1468,6 +1474,7 @@ export type WebviewMessage =
   | ConfigureSetupScriptRequest
   | ShowTerminalRequest
   | ShowLocalTerminalRequest
+  | OpenWorktreeRequest
   | ShowExistingLocalTerminalRequest
   | CreateMultiVersionRequest
   | SetTabOrderRequest


### PR DESCRIPTION
## Summary
- add a worktree-only **Open** button to the Agent Manager tab actions, positioned to the left of **Apply**, with matching button styling and folder icon
- wire a new `agentManager.openWorktree` message/handler so the selected worktree opens directly in a **new VS Code window** (path-normalized for cross-platform behavior)
- add `Cmd/Ctrl+Shift+O` as an Agent Manager scoped command, include it in the shortcuts help panel, and add localization keys across all Agent Manager locale files

<img width="558" height="280" alt="image" src="https://github.com/user-attachments/assets/ed174243-1800-453e-82b7-04c5ab3c23d6" />
