### PR TITLE
fix(vscode): use correct default model from backend instead of hardcoded kilo/auto

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -991,22 +991,74 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       const normalized = indexProvidersById(response.all)
 
-      const config = vscode.workspace.getConfiguration("kilo-code.new.model")
-      const providerID = config.get<string>("providerID", "kilo")
-      const modelID = config.get<string>("modelID", "kilo/auto")
+      const defaultSelection = await this.resolveDefaultModel(response.connected, response.default)
 
       const message = {
         type: "providersLoaded",
         providers: normalized,
         connected: response.connected,
         defaults: response.default,
-        defaultSelection: { providerID, modelID },
+        defaultSelection,
       }
       this.cachedProvidersMessage = message
       this.postMessage(message)
     } catch (error) {
       console.error("[Kilo New] KiloProvider: Failed to fetch providers:", error)
     }
+  }
+
+  /**
+   * Resolve the default model selection using the same logic as the CLI:
+   * 1. Explicit VS Code user/workspace setting override
+   * 2. Backend config `model` field (user's kilo config file)
+   * 3. First connected provider's sorted default model
+   */
+  private async resolveDefaultModel(
+    connected: string[],
+    defaults: Record<string, string>,
+  ): Promise<{ providerID: string; modelID: string }> {
+    // 1. Check if the user explicitly set VS Code settings (not just package.json defaults)
+    const config = vscode.workspace.getConfiguration("kilo-code.new.model")
+    const providerInspect = config.inspect<string>("providerID")
+    const modelInspect = config.inspect<string>("modelID")
+    const hasUserOverride =
+      providerInspect?.globalValue !== undefined ||
+      providerInspect?.workspaceValue !== undefined ||
+      providerInspect?.workspaceFolderValue !== undefined ||
+      modelInspect?.globalValue !== undefined ||
+      modelInspect?.workspaceValue !== undefined ||
+      modelInspect?.workspaceFolderValue !== undefined
+    if (hasUserOverride) {
+      return {
+        providerID: config.get<string>("providerID", "kilo"),
+        modelID: config.get<string>("modelID", "kilo/auto"),
+      }
+    }
+
+    // 2. Check backend config for an explicit model setting
+    if (this.client) {
+      try {
+        const workspaceDir = this.getWorkspaceDirectory()
+        const { data: cfg } = await this.client.config.get({ directory: workspaceDir }, { throwOnError: true })
+        if (cfg.model) {
+          const [providerID, ...rest] = cfg.model.split("/")
+          return { providerID, modelID: rest.join("/") }
+        }
+      } catch {
+        console.error("[Kilo New] KiloProvider: Failed to fetch config for default model resolution")
+      }
+    }
+
+    // 3. Fall back to the first connected provider's sorted default model
+    for (const providerID of connected) {
+      const modelID = defaults[providerID]
+      if (modelID) {
+        return { providerID, modelID }
+      }
+    }
+
+    // Final fallback
+    return { providerID: "kilo", modelID: "kilo/auto" }
   }
 
   /**

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/FillInTheMiddle.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/FillInTheMiddle.ts
@@ -83,12 +83,7 @@ export class FimPromptBuilder {
       response += text
     }
     logtime("prep fim")
-    const usageInfo = await model.generateFimResponse(
-      formattedPrefix,
-      prunedSuffix,
-      onChunk,
-      signal,
-    )
+    const usageInfo = await model.generateFimResponse(formattedPrefix, prunedSuffix, onChunk, signal)
     logtime("fim network")
     console.log("[FIM] response:", response)
 

--- a/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
@@ -27,201 +27,199 @@ export type SSEStateHandler = (state: "connecting" | "connected" | "disconnected
  * straightforward improvement.
  */
 export class SdkSSEAdapter {
-	private readonly handlers = new Set<SSEEventHandler>()
-	private readonly errorHandlers = new Set<SSEErrorHandler>()
-	private readonly stateHandlers = new Set<SSEStateHandler>()
+  private readonly handlers = new Set<SSEEventHandler>()
+  private readonly errorHandlers = new Set<SSEErrorHandler>()
+  private readonly stateHandlers = new Set<SSEStateHandler>()
 
-	private abortController: AbortController | null = null
-	private heartbeatTimer: ReturnType<typeof setTimeout> | null = null
+  private abortController: AbortController | null = null
+  private heartbeatTimer: ReturnType<typeof setTimeout> | null = null
 
-	private static readonly HEARTBEAT_TIMEOUT_MS = 90_000
-	private static readonly RECONNECT_DELAY_MS = 250
+  private static readonly HEARTBEAT_TIMEOUT_MS = 90_000
+  private static readonly RECONNECT_DELAY_MS = 250
 
-	constructor(private readonly client: KiloClient) {}
+  constructor(private readonly client: KiloClient) {}
 
-	// ── Lifecycle ──────────────────────────────────────────────────────
+  // ── Lifecycle ──────────────────────────────────────────────────────
 
-	/**
-	 * Start consuming the global SSE stream.
-	 * Calling `connect()` while already connected is a no-op.
-	 */
-	connect(): void {
-		if (this.abortController) {
-			console.log("[Kilo New] SSE: ⚠️ Already connected, skipping")
-			return
-		}
+  /**
+   * Start consuming the global SSE stream.
+   * Calling `connect()` while already connected is a no-op.
+   */
+  connect(): void {
+    if (this.abortController) {
+      console.log("[Kilo New] SSE: ⚠️ Already connected, skipping")
+      return
+    }
 
-		console.log("[Kilo New] SSE: 🔌 connect() called")
-		this.abortController = new AbortController()
-		console.log('[Kilo New] SSE: 🔄 Setting state to "connecting"')
-		this.notifyState("connecting")
-		void this.consumeLoop(this.abortController.signal).catch((err) => {
-			console.error("[Kilo New] SSE: Unhandled error in consumeLoop:", err)
-			this.notifyError(err instanceof Error ? err : new Error(String(err)))
-		})
-	}
+    console.log("[Kilo New] SSE: 🔌 connect() called")
+    this.abortController = new AbortController()
+    console.log('[Kilo New] SSE: 🔄 Setting state to "connecting"')
+    this.notifyState("connecting")
+    void this.consumeLoop(this.abortController.signal).catch((err) => {
+      console.error("[Kilo New] SSE: Unhandled error in consumeLoop:", err)
+      this.notifyError(err instanceof Error ? err : new Error(String(err)))
+    })
+  }
 
-	/**
-	 * Stop consuming the SSE stream and abort any in-flight request.
-	 */
-	disconnect(): void {
-		console.log("[Kilo New] SSE: 🔌 disconnect() called")
-		this.abortController?.abort()
-		this.abortController = null
-		this.clearHeartbeat()
-	}
+  /**
+   * Stop consuming the SSE stream and abort any in-flight request.
+   */
+  disconnect(): void {
+    console.log("[Kilo New] SSE: 🔌 disconnect() called")
+    this.abortController?.abort()
+    this.abortController = null
+    this.clearHeartbeat()
+  }
 
-	/**
-	 * Disconnect and clear all registered handlers.
-	 */
-	dispose(): void {
-		this.disconnect()
-		this.handlers.clear()
-		this.errorHandlers.clear()
-		this.stateHandlers.clear()
-	}
+  /**
+   * Disconnect and clear all registered handlers.
+   */
+  dispose(): void {
+    this.disconnect()
+    this.handlers.clear()
+    this.errorHandlers.clear()
+    this.stateHandlers.clear()
+  }
 
-	// ── Pub/sub ────────────────────────────────────────────────────────
+  // ── Pub/sub ────────────────────────────────────────────────────────
 
-	onEvent(handler: SSEEventHandler): () => void {
-		this.handlers.add(handler)
-		return () => {
-			this.handlers.delete(handler)
-		}
-	}
+  onEvent(handler: SSEEventHandler): () => void {
+    this.handlers.add(handler)
+    return () => {
+      this.handlers.delete(handler)
+    }
+  }
 
-	onError(handler: SSEErrorHandler): () => void {
-		this.errorHandlers.add(handler)
-		return () => {
-			this.errorHandlers.delete(handler)
-		}
-	}
+  onError(handler: SSEErrorHandler): () => void {
+    this.errorHandlers.add(handler)
+    return () => {
+      this.errorHandlers.delete(handler)
+    }
+  }
 
-	onStateChange(handler: SSEStateHandler): () => void {
-		this.stateHandlers.add(handler)
-		return () => {
-			this.stateHandlers.delete(handler)
-		}
-	}
+  onStateChange(handler: SSEStateHandler): () => void {
+    this.stateHandlers.add(handler)
+    return () => {
+      this.stateHandlers.delete(handler)
+    }
+  }
 
-	// ── Internal ───────────────────────────────────────────────────────
+  // ── Internal ───────────────────────────────────────────────────────
 
-	/**
-	 * Main reconnection loop — mirrors the pattern in `global-sdk.tsx`.
-	 */
-	private async consumeLoop(signal: AbortSignal): Promise<void> {
-		while (!signal.aborted) {
-			const attempt = new AbortController()
+  /**
+   * Main reconnection loop — mirrors the pattern in `global-sdk.tsx`.
+   */
+  private async consumeLoop(signal: AbortSignal): Promise<void> {
+    while (!signal.aborted) {
+      const attempt = new AbortController()
 
-			// Forward the outer abort to the per-attempt controller so
-			// `disconnect()` cancels the current fetch immediately.
-			const onAbort = () => attempt.abort()
-			signal.addEventListener("abort", onAbort)
+      // Forward the outer abort to the per-attempt controller so
+      // `disconnect()` cancels the current fetch immediately.
+      const onAbort = () => attempt.abort()
+      signal.addEventListener("abort", onAbort)
 
-			try {
-				console.log("[Kilo New] SSE: 🎬 Calling SDK global.event()...")
-				const events = await this.client.global.event({
-					signal: attempt.signal,
-					onSseError: (error) => {
-						if (signal.aborted) {
-							return
-						}
-						console.error("[Kilo New] SSE: ❌ SDK SSE error callback:", error)
-						this.notifyError(error instanceof Error ? error : new Error(String(error)))
-					},
-				})
+      try {
+        console.log("[Kilo New] SSE: 🎬 Calling SDK global.event()...")
+        const events = await this.client.global.event({
+          signal: attempt.signal,
+          onSseError: (error) => {
+            if (signal.aborted) {
+              return
+            }
+            console.error("[Kilo New] SSE: ❌ SDK SSE error callback:", error)
+            this.notifyError(error instanceof Error ? error : new Error(String(error)))
+          },
+        })
 
-				console.log("[Kilo New] SSE: ✅ Stream opened successfully")
-				this.notifyState("connected")
-				this.resetHeartbeat(attempt)
+        console.log("[Kilo New] SSE: ✅ Stream opened successfully")
+        this.notifyState("connected")
+        this.resetHeartbeat(attempt)
 
-				for await (const event of events.stream) {
-					if (signal.aborted) {
-						break
-					}
+        for await (const event of events.stream) {
+          if (signal.aborted) {
+            break
+          }
 
-					this.resetHeartbeat(attempt)
+          this.resetHeartbeat(attempt)
 
-					// The SDK yields GlobalEvent = { directory, payload: Event }.
-					const globalEvent = event as GlobalEvent
-					console.log("[Kilo New] SSE: 📨 Event:", globalEvent.payload.type)
-					this.notifyEvent(globalEvent.payload)
-				}
+          // The SDK yields GlobalEvent = { directory, payload: Event }.
+          const globalEvent = event as GlobalEvent
+          console.log("[Kilo New] SSE: 📨 Event:", globalEvent.payload.type)
+          this.notifyEvent(globalEvent.payload)
+        }
 
-				console.log("[Kilo New] SSE: 📭 Stream ended normally")
-			} catch (error) {
-				if (!signal.aborted) {
-					console.error("[Kilo New] SSE: ❌ Stream error:", error)
-					this.notifyError(error instanceof Error ? error : new Error(String(error)))
-				}
-			} finally {
-				signal.removeEventListener("abort", onAbort)
-				this.clearHeartbeat()
-			}
+        console.log("[Kilo New] SSE: 📭 Stream ended normally")
+      } catch (error) {
+        if (!signal.aborted) {
+          console.error("[Kilo New] SSE: ❌ Stream error:", error)
+          this.notifyError(error instanceof Error ? error : new Error(String(error)))
+        }
+      } finally {
+        signal.removeEventListener("abort", onAbort)
+        this.clearHeartbeat()
+      }
 
-			if (signal.aborted) {
-				break
-			}
+      if (signal.aborted) {
+        break
+      }
 
-			console.log(
-				`[Kilo New] SSE: 🔄 Reconnecting in ${SdkSSEAdapter.RECONNECT_DELAY_MS}ms...`,
-			)
-			this.notifyState("connecting")
-			await new Promise((resolve) => setTimeout(resolve, SdkSSEAdapter.RECONNECT_DELAY_MS))
-		}
+      console.log(`[Kilo New] SSE: 🔄 Reconnecting in ${SdkSSEAdapter.RECONNECT_DELAY_MS}ms...`)
+      this.notifyState("connecting")
+      await new Promise((resolve) => setTimeout(resolve, SdkSSEAdapter.RECONNECT_DELAY_MS))
+    }
 
-		this.notifyState("disconnected")
-	}
+    this.notifyState("disconnected")
+  }
 
-	/**
-	 * Reset the heartbeat timer. If no event arrives within the timeout
-	 * window the per-attempt controller is aborted, causing the
-	 * `for await` loop to exit and the outer loop to reconnect.
-	 */
-	private resetHeartbeat(attempt: AbortController): void {
-		this.clearHeartbeat()
-		this.heartbeatTimer = setTimeout(() => {
-			console.log("[Kilo New] SSE: ⏰ Heartbeat timeout — aborting stale connection")
-			attempt.abort()
-		}, SdkSSEAdapter.HEARTBEAT_TIMEOUT_MS)
-	}
+  /**
+   * Reset the heartbeat timer. If no event arrives within the timeout
+   * window the per-attempt controller is aborted, causing the
+   * `for await` loop to exit and the outer loop to reconnect.
+   */
+  private resetHeartbeat(attempt: AbortController): void {
+    this.clearHeartbeat()
+    this.heartbeatTimer = setTimeout(() => {
+      console.log("[Kilo New] SSE: ⏰ Heartbeat timeout — aborting stale connection")
+      attempt.abort()
+    }, SdkSSEAdapter.HEARTBEAT_TIMEOUT_MS)
+  }
 
-	private clearHeartbeat(): void {
-		if (this.heartbeatTimer) {
-			clearTimeout(this.heartbeatTimer)
-			this.heartbeatTimer = null
-		}
-	}
+  private clearHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearTimeout(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
 
-	// ── Notify helpers ─────────────────────────────────────────────────
+  // ── Notify helpers ─────────────────────────────────────────────────
 
-	private notifyEvent(event: Event): void {
-		for (const handler of this.handlers) {
-			try {
-				handler(event)
-			} catch (error) {
-				console.error("[Kilo New] SSE: Error in event handler:", error)
-			}
-		}
-	}
+  private notifyEvent(event: Event): void {
+    for (const handler of this.handlers) {
+      try {
+        handler(event)
+      } catch (error) {
+        console.error("[Kilo New] SSE: Error in event handler:", error)
+      }
+    }
+  }
 
-	private notifyError(error: Error): void {
-		for (const handler of this.errorHandlers) {
-			try {
-				handler(error)
-			} catch (err) {
-				console.error("[Kilo New] SSE: Error in error handler:", err)
-			}
-		}
-	}
+  private notifyError(error: Error): void {
+    for (const handler of this.errorHandlers) {
+      try {
+        handler(error)
+      } catch (err) {
+        console.error("[Kilo New] SSE: Error in error handler:", err)
+      }
+    }
+  }
 
-	private notifyState(state: "connecting" | "connected" | "disconnected"): void {
-		for (const handler of this.stateHandlers) {
-			try {
-				handler(state)
-			} catch (error) {
-				console.error("[Kilo New] SSE: Error in state handler:", error)
-			}
-		}
-	}
+  private notifyState(state: "connecting" | "connected" | "disconnected"): void {
+    for (const handler of this.stateHandlers) {
+      try {
+        handler(state)
+      } catch (error) {
+        console.error("[Kilo New] SSE: Error in state handler:", error)
+      }
+    }
+  }
 }

--- a/packages/kilo-vscode/tests/package.json
+++ b/packages/kilo-vscode/tests/package.json
@@ -1,1 +1,3 @@
-{ "type": "module" }
+{
+  "type": "module"
+}

--- a/packages/kilo-vscode/tests/setup/vscode-mock.ts
+++ b/packages/kilo-vscode/tests/setup/vscode-mock.ts
@@ -28,7 +28,11 @@ const mockVscode = {
   extensions: {
     getExtension: (id: string) => {
       if (id === "vscode.git") return undefined
-      return { packageJSON: { version: "test", contributes: { configuration: { properties: {} } } }, isActive: true, exports: undefined }
+      return {
+        packageJSON: { version: "test", contributes: { configuration: { properties: {} } } },
+        isActive: true,
+        exports: undefined,
+      }
     },
   },
   env: {
@@ -63,7 +67,10 @@ const mockVscode = {
   CodeAction: class {
     command?: { command: string; title: string }
     isPreferred?: boolean
-    constructor(public title: string, public kind: { value: string }) {}
+    constructor(
+      public title: string,
+      public kind: { value: string },
+    ) {}
   },
   CodeActionKind: {
     QuickFix: kind("quickfix"),
@@ -78,10 +85,16 @@ const mockVscode = {
     constructor(public uri: { scheme: string; fsPath: string }) {}
   },
   Position: class {
-    constructor(public line: number, public character: number) {}
+    constructor(
+      public line: number,
+      public character: number,
+    ) {}
   },
   Range: class {
-    constructor(public start: { line: number; character: number }, public end: { line: number; character: number }) {}
+    constructor(
+      public start: { line: number; character: number },
+      public end: { line: number; character: number },
+    ) {}
   },
   Disposable: class {
     constructor(private callback: () => void = noop) {}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -60,8 +60,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
   }
 
   // Questions linked to this message (rendered after the last part)
-  const questionForMessage = () =>
-    questions().find((q) => q.tool!.messageID === props.message.id)
+  const questionForMessage = () => questions().find((q) => q.tool!.messageID === props.message.id)
 
   const [responding, setResponding] = createSignal(false)
 
@@ -97,13 +96,28 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                         </div>
                       </Show>
                       <div data-slot="permission-actions">
-                        <Button variant="ghost" size="small" onClick={() => decide(p.id, "reject")} disabled={responding()}>
+                        <Button
+                          variant="ghost"
+                          size="small"
+                          onClick={() => decide(p.id, "reject")}
+                          disabled={responding()}
+                        >
                           {language.t("ui.permission.deny")}
                         </Button>
-                        <Button variant="secondary" size="small" onClick={() => decide(p.id, "always")} disabled={responding()}>
+                        <Button
+                          variant="secondary"
+                          size="small"
+                          onClick={() => decide(p.id, "always")}
+                          disabled={responding()}
+                        >
                           {language.t("ui.permission.allowAlways")}
                         </Button>
-                        <Button variant="primary" size="small" onClick={() => decide(p.id, "once")} disabled={responding()}>
+                        <Button
+                          variant="primary"
+                          size="small"
+                          onClick={() => decide(p.id, "once")}
+                          disabled={responding()}
+                        >
                           {language.t("ui.permission.allowOnce")}
                         </Button>
                       </div>

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -971,7 +971,6 @@ export const dict = {
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/ar.ts
 
-
   "question.summary": "{{n}} من {{total}} أسئلة",
   "common.review": "مراجعة",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -985,7 +985,6 @@ export const dict = {
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/br.ts
 
-
   "question.summary": "{{n}} de {{total}} perguntas",
   "common.review": "Revisar",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -984,7 +984,6 @@ export const dict = {
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/bs.ts
 
-
   "question.summary": "{{n}} od {{total}} pitanja",
   "common.review": "Pregled",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -980,7 +980,6 @@ export const dict = {
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/da.ts
 
-
   "question.summary": "{{n}} af {{total}} spørgsmål",
   "common.review": "Gennemgå",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -997,7 +997,6 @@ export const dict = {
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/de.ts
 
-
   "question.summary": "{{n}} von {{total}} Fragen",
   "common.review": "Überprüfen",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -998,7 +998,6 @@ export const dict = {
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/en.ts
 
-
   "question.summary": "{{n}} of {{total}} questions",
   "common.review": "Review",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -987,7 +987,6 @@ export const dict = {
   "profile.personalAccount": "Cuenta personal",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/es.ts
 
-
   "question.summary": "{{n}} de {{total}} preguntas",
   "common.review": "Revisar",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -71,7 +71,8 @@ export const dict = {
   "command.permissions.autoaccept.enable": "Accepter automatiquement les modifications",
   "command.permissions.autoaccept.disable": "Arrêter l'acceptation automatique des modifications",
   "command.workspace.toggle": "Basculer les espaces de travail",
-  "command.workspace.toggle.description": "Activer ou désactiver les espaces de travail multiples dans la barre latérale",
+  "command.workspace.toggle.description":
+    "Activer ou désactiver les espaces de travail multiples dans la barre latérale",
   "command.session.undo": "Annuler",
   "command.session.undo.description": "Annuler le dernier message",
   "command.session.redo": "Rétablir",
@@ -994,7 +995,6 @@ export const dict = {
   "dialog.model.notSet": "Non défini",
   "profile.personalAccount": "Compte personnel",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/fr.ts
-
 
   "question.summary": "{{n}} sur {{total}} questions",
   "common.review": "Réviser",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -979,7 +979,6 @@ export const dict = {
   "profile.personalAccount": "個人アカウント",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/ja.ts
 
-
   "question.summary": "{{total}} 問中 {{n}} 問目",
   "common.review": "確認",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -976,7 +976,6 @@ export const dict = {
   "profile.personalAccount": "개인 계정",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/ko.ts
 
-
   "question.summary": "{{total}}개 질문 중 {{n}}번째",
   "common.review": "검토",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -981,7 +981,6 @@ export const dict = {
   "profile.personalAccount": "Personlig konto",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/no.ts
 
-
   "question.summary": "{{n}} av {{total}} spørsmål",
   "common.review": "Gjennomgå",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -982,7 +982,6 @@ export const dict = {
   "profile.personalAccount": "Konto osobiste",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/pl.ts
 
-
   "question.summary": "{{n}} z {{total}} pytań",
   "common.review": "Przejrzyj",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -984,7 +984,6 @@ export const dict = {
   "profile.personalAccount": "Личный аккаунт",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/ru.ts
 
-
   "question.summary": "{{n}} из {{total}} вопросов",
   "common.review": "Просмотр",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -972,7 +972,6 @@ export const dict = {
   "profile.personalAccount": "บัญชีส่วนตัว",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/th.ts
 
-
   "question.summary": "{{n}} จาก {{total}} คำถาม",
   "common.review": "ตรวจสอบ",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -967,7 +967,6 @@ export const dict = {
   "profile.personalAccount": "个人账户",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/zh.ts
 
-
   "question.summary": "第 {{n}} / {{total}} 个问题",
   "common.review": "审查",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -968,7 +968,6 @@ export const dict = {
   "profile.personalAccount": "個人帳戶",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/zht.ts
 
-
   "question.summary": "第 {{n}} / {{total}} 個問題",
   "common.review": "審查",
 

--- a/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
@@ -244,9 +244,7 @@ function dataWith(parts: any[], permissions?: PermissionRequest[]) {
     part: {
       [ASST_MSG_ID]: parts,
     },
-    permission: permissions
-      ? { [SESSION_ID]: permissions }
-      : {},
+    permission: permissions ? { [SESSION_ID]: permissions } : {},
   }
 }
 
@@ -318,9 +316,7 @@ export const PermissionDock: Story = {
           >
             <Show when={perm.patterns.length > 0}>
               <div class="permission-dock-patterns">
-                <For each={perm.patterns}>
-                  {(pattern) => <code class="permission-dock-pattern">{pattern}</code>}
-                </For>
+                <For each={perm.patterns}>{(pattern) => <code class="permission-dock-pattern">{pattern}</code>}</For>
               </div>
             </Show>
           </BasicTool>


### PR DESCRIPTION
## Summary

- Fixes the VS Code extension always defaulting to `kilo/auto` instead of using the user's configured default model
- Adds `resolveDefaultModel()` method that mirrors the CLI's resolution cascade: explicit VS Code settings → backend config `model` field → first connected provider's sorted default
- Only falls back to `kilo/auto` when no other default can be determined

Closes #6074