### PR TITLE
fix: add yellow warning border to permissions box for visual clarity

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -698,6 +698,8 @@
 
 /* Permission Prompt (inline with tool cards) */
 [data-component="tool-part-wrapper"][data-permission="true"] {
+  border-color: var(--border-warning-base, var(--vscode-charts-yellow));
+
   /* When wrapping a Part + permission, the outer wrapper provides the card border.
      Remove the inner Part's tool-part-wrapper border so we don't get double borders. */
   > [data-component="tool-part-wrapper"] {


### PR DESCRIPTION
## Summary

- Adds a `border-color: var(--border-warning-base, var(--vscode-charts-yellow))` to the `[data-component="tool-part-wrapper"][data-permission="true"]` selector in `chat.css`, giving the permissions approval box a distinct yellow/warning border so it stands out from regular tool output.

Fixes #6617