### PR TITLE
fix: filter subagent sessions from session history

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -870,7 +870,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       pendingSessionRefresh: this.pendingSessionRefresh,
       connectionState: this.connectionState,
       listSessions: client
-        ? (dir: string) => client.session.list({ directory: dir }, { throwOnError: true }).then(({ data }) => data)
+        ? (dir: string) =>
+            client.session.list({ directory: dir, roots: true }, { throwOnError: true }).then(({ data }) => data)
         : null,
       sessionDirectories: this.sessionDirectories,
       workspaceDirectory: this.getWorkspaceDirectory(),


### PR DESCRIPTION
## Summary

- Filter out subagent sessions from the session history list by passing `roots: true` to `client.session.list()` in `KiloProvider.ts`
- Subagent sessions (spawned by a parent session via the task tool) were appearing in the session history even though users didn't intentionally start them
- The backend already supports the `roots` parameter to filter to only root sessions (those with no parent ID); this change simply wires it up in the VS Code extension

Tested locally and compared with main

Fixes #6403