### PR TITLE
fix: read kilo auth token dynamically per-request to fix login/logout persistence

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -585,12 +585,28 @@ export namespace Provider {
       }
 
       // Build options from KILO_* env vars
-      const options: Record<string, string> = {}
+      const options: Record<string, any> = {}
       if (env.KILO_ORG_ID) {
         options.kilocodeOrganizationId = env.KILO_ORG_ID
       }
       if (!hasKey) {
         options.apiKey = "anonymous"
+      }
+
+      // Provide a dynamic fetch function that reads auth on every request,
+      // so login/logout changes are picked up without restarting the server.
+      const kiloId = input.id
+      options.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const auth = await Auth.get(kiloId)
+        const token = auth?.type === "oauth" ? auth.access : auth?.type === "api" ? auth.key : undefined
+        const headers = new Headers(init?.headers)
+        if (token) {
+          headers.set("Authorization", `Bearer ${token}`)
+        } else {
+          // Remove any stale token header when logged out
+          headers.delete("Authorization")
+        }
+        return fetch(input, { ...init, headers })
       }
 
       return {


### PR DESCRIPTION
## Problem

Fixes #6399

When you log out of Kilo, you could still send requests to paid models and get responses. Same for logging in halfway - it would not take effect.

## Root Cause

The `Provider.state()` function is initialized once via `Instance.state()` (which caches all provider state per directory). The `kilo` CUSTOM_LOADER runs at startup and calls `Auth.get("kilo")` once. The resulting options are passed to `createKilo()`, which captures the token in a closure and caches the SDK instance.

So after login or logout, the stale token (or absence of one) is used for all subsequent requests.

## Fix

Inject a dynamic `fetch` function into the `kilo` provider options that calls `Auth.get("kilo")` on every request. This function overrides any `Authorization` header set by `createKilo`'s static closure, ensuring the current token (or absence thereof) is always used.

- On logout: the header is deleted so no token is sent
- On login after startup: the fresh token is set
- On re-login with a different account: the new token is used

## Testing

- Login: requests use the new token
- Logout: requests use no Kilo token (falls back to anonymous/free models)
- Login with a different account: requests use the new account's token
