### PR TITLE
ci: make visual regression workflow always run with path-based skip

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -12,7 +12,7 @@ jobs:
       matched: ${{ steps.filter.outputs.matched }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v2
+      - uses: Kilo-Org/paths-filter@master
         id: filter
         with:
           filters: |

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -2,6 +2,7 @@ name: Visual Regression Tests
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   check-paths:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -2,18 +2,32 @@ name: Visual Regression Tests
 
 on:
   pull_request:
-    paths:
-      - "packages/kilo-ui/**"
-      - "packages/ui/**"
-      - "packages/util/**"
-      - "packages/sdk/js/**"
-      - "packages/kilo-vscode/webview-ui/**"
-      - "packages/kilo-vscode/.storybook/**"
-      - "packages/kilo-vscode/tests/visual-regression*"
-      - ".github/workflows/visual-regression.yml"
 
 jobs:
+  check-paths:
+    name: Check changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      matched: ${{ steps.filter.outputs.matched }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            matched:
+              - "packages/kilo-ui/**"
+              - "packages/ui/**"
+              - "packages/util/**"
+              - "packages/sdk/js/**"
+              - "packages/kilo-vscode/webview-ui/**"
+              - "packages/kilo-vscode/.storybook/**"
+              - "packages/kilo-vscode/tests/visual-regression*"
+              - ".github/workflows/visual-regression.yml"
+
   visual-regression:
+    needs: check-paths
+    if: needs.check-paths.outputs.matched == 'true'
     name: Visual Regression (kilo-ui)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
@@ -106,6 +120,8 @@ jobs:
           retention-days: 7
 
   visual-regression-vscode:
+    needs: check-paths
+    if: needs.check-paths.outputs.matched == 'true'
     name: Visual Regression (kilo-vscode webview)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -11,7 +11,7 @@ jobs:
       matched: ${{ steps.filter.outputs.matched }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v2
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Summary

- Removes the workflow-level `paths:` filter so the workflow always triggers on every PR
- Adds a `check-paths` job using `dorny/paths-filter` that detects whether relevant files changed
- Gates both `visual-regression` and `visual-regression-vscode` jobs on `check-paths` output

This allows all three jobs to be set as required status checks. When the paths don't match, `check-paths` is green and the real jobs are skipped (which GitHub counts as passing).