### PR TITLE
feat: native agent session tools for orchestrator mode

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode"
 import * as fs from "fs"
 import * as path from "path"
-import type { KiloClient, Session, FileDiff } from "@kilocode/sdk/v2/client"
+import type { KiloClient, Session, FileDiff, Event } from "@kilocode/sdk/v2/client"
 import type { KiloConnectionService } from "../services/cli-backend"
 import { getErrorMessage } from "../kilo-provider-utils"
 import { KiloProvider } from "../KiloProvider"
@@ -52,6 +52,7 @@ export class AgentManagerProvider implements vscode.Disposable {
   private cachedWorktreeStats: Record<string, unknown> | undefined
   private cachedLocalStats: Record<string, unknown> | undefined
   private applyingWorktreeId: string | undefined
+  private unsubscribeServerEvent: (() => void) | undefined
 
   constructor(
     private readonly extensionUri: vscode.Uri,
@@ -81,6 +82,9 @@ export class AgentManagerProvider implements vscode.Disposable {
       },
       log: (...args) => this.log(...args),
       git: this.gitOps,
+    })
+    this.unsubscribeServerEvent = this.connectionService.onEvent((event) => {
+      void this.onManagedSessionEvent(event)
     })
   }
 
@@ -149,6 +153,8 @@ export class AgentManagerProvider implements vscode.Disposable {
 
     await state.load()
 
+    await this.syncManagedSessionsFromServer()
+
     // Do not auto-remove stale worktrees on load.
     // Presence checks run in the shared poller and require explicit user cleanup.
 
@@ -167,6 +173,190 @@ export class AgentManagerProvider implements vscode.Disposable {
     if (state.getSessions().length > 0) {
       this.provider?.refreshSessions()
     }
+  }
+
+  private adoptManagedSession(input: {
+    sessionID: string
+    groupID?: string
+    label?: string
+    worktree: {
+      path: string
+      branch: string
+      baseBranch: string
+    }
+  }) {
+    const state = this.getStateManager()
+    if (!state) return false
+
+    const existingWorktree = state.findWorktreeByPath(input.worktree.path)
+    const worktree =
+      existingWorktree ??
+      state.addWorktree({
+        branch: input.worktree.branch,
+        path: input.worktree.path,
+        parentBranch: input.worktree.baseBranch,
+        groupId: input.groupID,
+        label: input.label,
+      })
+
+    if (input.label && worktree.label !== input.label) {
+      state.updateWorktreeLabel(worktree.id, input.label)
+    }
+
+    const existingSession = state.getSession(input.sessionID)
+    if (!existingSession) {
+      state.addSession(input.sessionID, worktree.id)
+    }
+
+    this.registerWorktreeSession(input.sessionID, worktree.path)
+    return !existingWorktree || !existingSession
+  }
+
+  private async syncManagedSessionsFromServer(): Promise<void> {
+    const root = this.getWorkspaceRoot()
+    if (!root) return
+
+    let client: KiloClient
+    try {
+      client = this.connectionService.getClient()
+    } catch {
+      return
+    }
+
+    const api = (
+      client as unknown as {
+        agentManager?: {
+          list?: (
+            input: { directory?: string },
+            opts?: { throwOnError?: boolean },
+          ) => Promise<{
+            data?: {
+              sessions?: Array<{
+                sessionID: string
+                groupID?: string
+                label?: string
+                worktree?: {
+                  path?: string
+                  branch?: string
+                  baseBranch?: string
+                }
+              }>
+            }
+          }>
+        }
+      }
+    ).agentManager
+
+    const fromSdk = async () => {
+      if (!api?.list) return undefined
+      const result = await api
+        .list(
+          {
+            directory: root,
+          },
+          { throwOnError: true },
+        )
+        .catch(() => undefined)
+      return result?.data?.sessions
+    }
+
+    const fromHttp = async () => {
+      const cfg = this.connectionService.getServerConfig()
+      if (!cfg) return []
+      const url = new URL("/agent-manager/session", cfg.baseUrl)
+      url.searchParams.set("directory", root)
+      const auth = `Basic ${Buffer.from(`kilo:${cfg.password}`).toString("base64")}`
+      const response = await fetch(url.toString(), {
+        method: "GET",
+        headers: {
+          Authorization: auth,
+        },
+      }).catch(() => undefined)
+      if (!response?.ok) return []
+      const body = (await response.json().catch(() => undefined)) as
+        | {
+            sessions?: Array<{
+              sessionID: string
+              groupID?: string
+              label?: string
+              worktree?: {
+                path?: string
+                branch?: string
+                baseBranch?: string
+              }
+            }>
+          }
+        | undefined
+      return body?.sessions ?? []
+    }
+
+    const sessions = (await fromSdk()) ?? (await fromHttp())
+    if (sessions.length === 0) return
+
+    const changed = sessions.some((session) => {
+      const worktree = session.worktree
+      if (!worktree?.path || !worktree?.branch || !worktree?.baseBranch) return false
+      return this.adoptManagedSession({
+        sessionID: session.sessionID,
+        groupID: session.groupID,
+        label: session.label,
+        worktree: {
+          path: worktree.path,
+          branch: worktree.branch,
+          baseBranch: worktree.baseBranch,
+        },
+      })
+    })
+
+    if (!changed) return
+    this.pushState()
+    this.provider?.refreshSessions()
+  }
+
+  private async onManagedSessionEvent(event: Event): Promise<void> {
+    const raw = event as unknown as {
+      type?: string
+      properties?: {
+        sessionID?: string
+        groupID?: string
+        label?: string
+        worktree?: {
+          path?: string
+          branch?: string
+          baseBranch?: string
+        }
+      }
+    }
+    if (raw.type !== "agent-manager.session.created") return
+
+    const sessionID = raw.properties?.sessionID
+    const worktree = raw.properties?.worktree
+    if (!sessionID || !worktree?.path || !worktree.branch || !worktree.baseBranch) return
+
+    if (!this.panel) {
+      this.openPanel()
+    }
+
+    if (this.stateReady) {
+      await this.stateReady.catch((err) => {
+        this.log("stateReady rejected while adopting managed session:", err)
+      })
+    }
+
+    const changed = this.adoptManagedSession({
+      sessionID,
+      groupID: raw.properties?.groupID,
+      label: raw.properties?.label,
+      worktree: {
+        path: worktree.path,
+        branch: worktree.branch,
+        baseBranch: worktree.baseBranch,
+      },
+    })
+
+    if (!changed) return
+    this.pushState()
+    this.provider?.refreshSessions()
   }
 
   // ---------------------------------------------------------------------------
@@ -1763,6 +1953,7 @@ export class AgentManagerProvider implements vscode.Disposable {
   }
 
   public dispose(): void {
+    this.unsubscribeServerEvent?.()
     this.stopDiffPolling()
     this.statsPoller.stop()
     this.terminalManager.dispose()

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -61,6 +61,13 @@ export namespace Agent {
     const defaults = PermissionNext.fromConfig({
       "*": "allow",
       doom_loop: "ask",
+      // kilocode_change start - managed session tools are orchestrator-only by default
+      agent_session_create: "deny",
+      agent_session_list: "deny",
+      agent_session_status: "deny",
+      agent_session_cancel: "deny",
+      agent_session_diff: "deny",
+      // kilocode_change end
       external_directory: {
         "*": "ask",
         ...Object.fromEntries(whitelistedDirs.map((dir) => [dir, "allow"])),
@@ -154,6 +161,13 @@ export namespace Agent {
             task: "allow",
             todoread: "allow",
             todowrite: "allow",
+            // kilocode_change start - allow orchestrator to manage parallel agent sessions
+            agent_session_create: "allow",
+            agent_session_list: "allow",
+            agent_session_status: "allow",
+            agent_session_cancel: "allow",
+            agent_session_diff: "allow",
+            // kilocode_change end
             webfetch: "allow",
             websearch: "allow",
             codesearch: "allow",

--- a/packages/opencode/src/agent/prompt/orchestrator.txt
+++ b/packages/opencode/src/agent/prompt/orchestrator.txt
@@ -9,16 +9,20 @@ Guidelines:
 3. Classify dependencies before executing anything:
    - Which subtasks are independent of each other? These go in the same wave and run in parallel.
    - Which subtasks need the output of a previous one? These go in a later wave.
-   - All agents share the same working directory. If two subtasks are likely to edit the same files, they MUST be in different waves to avoid conflicts. Only subtasks that touch different parts of the codebase can safely run in parallel.
+   - Prefer managed agent sessions (`agent_session_create`) for implementation work. Managed sessions run in isolated git worktrees, so they can safely run in parallel.
+   - Use the task tool for research/exploration and non-persistent delegation.
    - When uncertain about dependencies or file overlap, run subtasks sequentially.
 
 4. Execute wave by wave. Launch all subtasks in a wave as parallel tool calls in a single message. Wait for the wave to complete, analyze results, then start the next wave.
 
-5. For each subtask, use the task tool with the appropriate agent type:
-   - "explore" for codebase research, finding files, understanding patterns
-   - "general" for implementation, analysis, and multi-step tasks
-   Provide each agent with all context it needs to work independently: relevant results from prior waves, file paths, constraints, and a clearly defined scope.
+5. For each subtask, choose the right delegation mechanism:
+   - `agent_session_create` for implementation/code changes.
+   - Use `versions[]` to launch multiple sessions in one call. Each version can have its own `prompt`, `model`, and `agent` overrides — use this for parallel subtasks or model comparisons.
+   - `agent_session_list` and `agent_session_status` to monitor progress.
+   - `agent_session_diff` to inspect output with pagination (set `includePatch=true` only when needed).
+   - task tool with "explore" for codebase research and discovery.
+   Provide each delegate with all context it needs to work independently: relevant results from prior waves, file paths, constraints, and a clearly defined scope.
 
 6. When all waves are complete, synthesize the results into a summary of what was accomplished.
 
-7. Do not edit files directly. Delegate all implementation to agents.
+7. Do not edit files directly. Delegate implementation through managed sessions.

--- a/packages/opencode/src/kilocode/agent-manager/service.ts
+++ b/packages/opencode/src/kilocode/agent-manager/service.ts
@@ -1,0 +1,543 @@
+import { Bus } from "@/bus"
+import { GlobalBus } from "@/bus/global"
+import { BusEvent } from "@/bus/bus-event"
+import { Provider } from "@/provider/provider"
+import { InstanceBootstrap } from "@/project/bootstrap"
+import { Instance } from "@/project/instance"
+import { Project } from "@/project/project"
+import { Vcs } from "@/project/vcs"
+import { Session } from "@/session"
+import { SessionPrompt } from "@/session/prompt"
+import { SessionStatus } from "@/session/status"
+import { Storage } from "@/storage/storage"
+import { fn } from "@/util/fn"
+import { Log } from "@/util/log"
+import { Worktree } from "@/worktree"
+import { $ } from "bun"
+import path from "path"
+import z from "zod"
+import { AgentManagerTypes } from "./types"
+
+export namespace AgentManagerService {
+  const log = Log.create({ service: "agent-manager.service" })
+  const MAX_PATCH = 12_000
+
+  export const Event = {
+    SessionCreated: BusEvent.define("agent-manager.session.created", AgentManagerTypes.CreatedEvent),
+  }
+
+  const Store = AgentManagerTypes.SessionRecord.array()
+  type Store = AgentManagerTypes.SessionRecord[]
+
+  function key() {
+    return ["agent_manager", "session", Instance.project.id]
+  }
+
+  async function readStore(): Promise<Store> {
+    const data = await Storage.read<Store>(key()).catch(() => [])
+    return Store.parse(data)
+  }
+
+  async function writeStore(input: Store) {
+    await Storage.write(key(), input)
+  }
+
+  function group() {
+    return `grp_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+  }
+
+  function worktreeID(name: string) {
+    return `wt_${name}`
+  }
+
+  function toModel(input: z.infer<typeof AgentManagerTypes.ModelInput>) {
+    if (!input) return
+    if (typeof input === "string") return Provider.parseModel(input)
+    return input
+  }
+
+  function modelText(input: { providerID: string; modelID: string } | undefined) {
+    if (!input) return
+    return `${input.providerID}/${input.modelID}`
+  }
+
+  function toStatus(input: SessionStatus.Info | undefined): AgentManagerTypes.Session["status"] {
+    if (!input) return "idle"
+    if (input.type === "busy" || input.type === "retry") return "busy"
+    if (input.type === "idle") return "idle"
+    return "error"
+  }
+
+  function parseCursor(input: string | undefined) {
+    const value = Number.parseInt(input ?? "0", 10)
+    if (!Number.isFinite(value) || value < 0) return 0
+    return value
+  }
+
+  function parseLimit(input: number | undefined, fallback: number, max: number) {
+    const value = input ?? fallback
+    if (!Number.isFinite(value)) return fallback
+    if (value < 1) return 1
+    if (value > max) return max
+    return Math.floor(value)
+  }
+
+  /**
+   * Start listening for worktree ready/failed events BEFORE Worktree.create()
+   * so we never miss the event if setTimeout(0) fires synchronously.
+   * Call `.for(directory)` after Worktree.create() returns to resolve.
+   */
+  function waitForAnyReady(timeout = 120_000) {
+    const resolved = new Map<string, true>()
+    const failed = new Map<string, string>()
+    const waiting = new Map<string, { resolve: () => void; reject: (err: Error) => void }>()
+
+    const handler = (event: { directory?: string; payload: any }) => {
+      const dir = event.directory
+      if (!dir) return
+      const type = event.payload?.type as string | undefined
+      if (type === Worktree.Event.Ready.type) {
+        resolved.set(dir, true)
+        waiting.get(dir)?.resolve()
+        waiting.delete(dir)
+      }
+      if (type === Worktree.Event.Failed.type) {
+        const msg = event.payload.properties?.message ?? "Worktree bootstrap failed"
+        failed.set(dir, msg)
+        waiting.get(dir)?.reject(new Error(msg))
+        waiting.delete(dir)
+      }
+    }
+    GlobalBus.on("event", handler)
+
+    return {
+      for(directory: string): Promise<void> {
+        // Already resolved before we asked
+        if (resolved.has(directory)) {
+          GlobalBus.off("event", handler)
+          return Promise.resolve()
+        }
+        if (failed.has(directory)) {
+          GlobalBus.off("event", handler)
+          return Promise.reject(new Error(failed.get(directory)))
+        }
+        return new Promise((resolve, reject) => {
+          const timer = setTimeout(() => {
+            GlobalBus.off("event", handler)
+            waiting.delete(directory)
+            reject(new Error(`Worktree ready timeout after ${timeout}ms: ${directory}`))
+          }, timeout)
+          waiting.set(directory, {
+            resolve() {
+              clearTimeout(timer)
+              GlobalBus.off("event", handler)
+              resolve()
+            },
+            reject(err) {
+              clearTimeout(timer)
+              GlobalBus.off("event", handler)
+              reject(err)
+            },
+          })
+        })
+      },
+    }
+  }
+
+  function variant(input: {
+    create: AgentManagerTypes.CreateInput
+    count: number
+    idx: number
+    item: z.infer<typeof AgentManagerTypes.Version>
+  }) {
+    const prompt = input.item.prompt?.trim() || input.create.prompt?.trim() || ""
+    const label = input.item.label ?? (input.count > 1 ? `v${input.idx + 1}` : undefined)
+    const model = toModel(input.item.model ?? input.create.model)
+    const agent = input.item.agent ?? input.create.agent
+    const base = input.item.name ?? input.item.label ?? input.create.name
+    const name = base ? (input.count > 1 ? `${base}-${input.idx + 1}` : base) : undefined
+    return {
+      prompt,
+      label,
+      model,
+      agent,
+      name,
+    }
+  }
+
+  async function statusFor(input: AgentManagerTypes.SessionRecord) {
+    if (input.failed) return "error" as const
+    return Instance.provide({
+      directory: input.worktree.path,
+      fn: () => toStatus(SessionStatus.get(input.sessionID)),
+    }).catch(() => "error" as const)
+  }
+
+  async function asSession(input: { record: AgentManagerTypes.SessionRecord; session: Session.Info }) {
+    const status = await statusFor(input.record)
+    return AgentManagerTypes.Session.parse({
+      sessionID: input.record.sessionID,
+      groupID: input.record.groupID,
+      worktree: input.record.worktree,
+      title: input.session.title,
+      agent: input.record.agent,
+      model: input.record.model,
+      label: input.record.label,
+      status,
+      summary: input.session.summary,
+      time: input.session.time,
+    })
+  }
+
+  function truncatePatch(input: string) {
+    if (input.length <= MAX_PATCH) return { patch: input, patchTruncated: false }
+    return { patch: input.slice(0, MAX_PATCH), patchTruncated: true }
+  }
+
+  async function trackedDiff(input: { ancestor: string; directory: string; includePatch: boolean }) {
+    const nameStatus = await $`git -c core.quotepath=false diff --name-status --no-renames ${input.ancestor}`
+      .cwd(input.directory)
+      .quiet()
+      .nothrow()
+    if (nameStatus.exitCode !== 0) return [] as AgentManagerTypes.DiffFile[]
+
+    const statsRaw = await $`git -c core.quotepath=false diff --numstat --no-renames ${input.ancestor}`
+      .cwd(input.directory)
+      .quiet()
+      .nothrow()
+
+    const stats = new Map<string, { additions: number; deletions: number }>()
+    if (statsRaw.exitCode === 0) {
+      for (const line of statsRaw.stdout.toString().trim().split("\n")) {
+        if (!line) continue
+        const parts = line.split("\t")
+        const file = parts.slice(2).join("\t")
+        if (!file) continue
+        const additions = parts[0] === "-" ? 0 : Number.parseInt(parts[0] ?? "0", 10)
+        const deletions = parts[1] === "-" ? 0 : Number.parseInt(parts[1] ?? "0", 10)
+        stats.set(file, {
+          additions: Number.isFinite(additions) ? additions : 0,
+          deletions: Number.isFinite(deletions) ? deletions : 0,
+        })
+      }
+    }
+
+    const files: AgentManagerTypes.DiffFile[] = []
+    for (const line of nameStatus.stdout.toString().trim().split("\n")) {
+      if (!line) continue
+      const parts = line.split("\t")
+      const code = parts[0] ?? "M"
+      const file = parts.slice(1).join("\t")
+      if (!file) continue
+      const kind = code.startsWith("A") ? "added" : code.startsWith("D") ? "deleted" : "modified"
+      const entry = stats.get(file) ?? { additions: 0, deletions: 0 }
+      const patch = await (async () => {
+        if (!input.includePatch) return
+        const raw = await $`git -c core.quotepath=false diff --no-renames ${input.ancestor} -- ${file}`
+          .cwd(input.directory)
+          .quiet()
+          .nothrow()
+        if (raw.exitCode !== 0) return
+        const text = raw.stdout.toString()
+        if (!text) return
+        return truncatePatch(text)
+      })()
+      files.push(
+        AgentManagerTypes.DiffFile.parse({
+          path: file,
+          status: kind,
+          additions: entry.additions,
+          deletions: entry.deletions,
+          patch: patch?.patch,
+          patchTruncated: patch?.patchTruncated,
+        }),
+      )
+    }
+    return files
+  }
+
+  async function untrackedDiff(input: { directory: string; includePatch: boolean; seen: Set<string> }) {
+    const rows = await $`git ls-files --others --exclude-standard`.cwd(input.directory).quiet().nothrow()
+    if (rows.exitCode !== 0) return [] as AgentManagerTypes.DiffFile[]
+
+    const files: AgentManagerTypes.DiffFile[] = []
+    for (const file of rows.stdout.toString().trim().split("\n")) {
+      if (!file || input.seen.has(file)) continue
+      const full = path.join(input.directory, file)
+      const stats = await Bun.file(full)
+        .stat()
+        .catch(() => undefined)
+      if (!stats?.isFile()) continue
+      const text = await Bun.file(full)
+        .text()
+        .catch(() => "")
+      const lines = text ? text.split("\n").length : 0
+      const patch = (() => {
+        if (!input.includePatch) return
+        const body = text
+          .split("\n")
+          .map((line) => `+${line}`)
+          .join("\n")
+        const raw = `diff --git a/${file} b/${file}\nnew file mode 100644\n--- /dev/null\n+++ b/${file}\n@@ -0,0 +1,${lines} @@\n${body}`
+        return truncatePatch(raw)
+      })()
+      files.push(
+        AgentManagerTypes.DiffFile.parse({
+          path: file,
+          status: "added",
+          additions: lines,
+          deletions: 0,
+          patch: patch?.patch,
+          patchTruncated: patch?.patchTruncated,
+        }),
+      )
+    }
+    return files
+  }
+
+  async function allDiff(input: { record: AgentManagerTypes.SessionRecord; includePatch: boolean }) {
+    const merge = await $`git merge-base HEAD ${input.record.worktree.baseBranch}`
+      .cwd(input.record.worktree.path)
+      .quiet()
+      .nothrow()
+    if (merge.exitCode !== 0) {
+      log.warn("merge-base failed", {
+        sessionID: input.record.sessionID,
+        base: input.record.worktree.baseBranch,
+        stderr: merge.stderr.toString().trim(),
+      })
+      return [] as AgentManagerTypes.DiffFile[]
+    }
+    const ancestor = merge.stdout.toString().trim()
+    const tracked = await trackedDiff({
+      ancestor,
+      directory: input.record.worktree.path,
+      includePatch: input.includePatch,
+    })
+    const seen = new Set(tracked.map((item) => item.path))
+    const untracked = await untrackedDiff({
+      directory: input.record.worktree.path,
+      includePatch: input.includePatch,
+      seen,
+    })
+    return [...tracked, ...untracked].toSorted((a, b) => a.path.localeCompare(b.path))
+  }
+
+  export const create = fn(AgentManagerTypes.CreateInput, async (input) => {
+    const baseBranch = input.baseBranch ?? (await Vcs.branch()) ?? "main"
+    const raw: z.infer<typeof AgentManagerTypes.Version>[] = input.versions?.length
+      ? input.versions
+      : [AgentManagerTypes.Version.parse({})]
+    const variants = raw.map((item: z.infer<typeof AgentManagerTypes.Version>, idx: number) =>
+      variant({ create: input, count: raw.length, idx, item }),
+    )
+    const missing = variants.filter((v) => !v.prompt)
+    if (missing.length > 0) {
+      throw new Error("Prompt is required. Provide a top-level prompt or ensure every version has its own prompt.")
+    }
+    const groupID = variants.length > 1 ? group() : undefined
+    const store = await readStore()
+    const sessions: AgentManagerTypes.Session[] = []
+
+    for (const [idx, item] of variants.entries()) {
+      // Register the ready listener BEFORE creating the worktree so we never
+      // miss the event if setTimeout(0) fires before we subscribe.
+      const pending = waitForAnyReady()
+      const created = await Worktree.create({
+        name: item.name,
+        baseBranch,
+      })
+
+      // Worktree.create returns immediately with --no-checkout; the checkout
+      // and InstanceBootstrap run asynchronously in a setTimeout. We must wait
+      // for that to complete before calling Instance.provide — otherwise we
+      // poison the Instance cache without running InstanceBootstrap.
+      await pending.for(created.directory)
+
+      const session = await Instance.provide({
+        directory: created.directory,
+        fn: () =>
+          Session.create({
+            platform: "agent-manager",
+          }),
+      })
+
+      const record = AgentManagerTypes.SessionRecord.parse({
+        sessionID: session.id,
+        groupID,
+        worktree: {
+          id: worktreeID(created.name),
+          path: created.directory,
+          branch: created.branch,
+          baseBranch,
+        },
+        agent: item.agent ?? "code",
+        model: modelText(item.model),
+        label: item.label,
+        time: session.time,
+      })
+
+      store.push(record)
+
+      void Instance.provide({
+        directory: created.directory,
+        async fn() {
+          await SessionPrompt.prompt({
+            sessionID: session.id,
+            agent: item.agent,
+            model: item.model,
+            parts: [
+              {
+                type: "text",
+                text: item.prompt,
+              },
+            ],
+          })
+        },
+      }).catch(async (error) => {
+        log.error("failed to start managed session prompt", {
+          sessionID: session.id,
+          error,
+        })
+        const rows = await readStore().catch(() => [] as Store)
+        const target = rows.find((r) => r.sessionID === session.id)
+        if (target) {
+          target.failed = true
+          await writeStore(rows).catch(() => undefined)
+        }
+      })
+
+      const output = AgentManagerTypes.Session.parse({
+        sessionID: record.sessionID,
+        groupID: record.groupID,
+        worktree: record.worktree,
+        title: session.title,
+        agent: record.agent,
+        model: record.model,
+        label: record.label,
+        status: "busy",
+        summary: session.summary,
+        time: session.time,
+      })
+
+      sessions.push(output)
+
+      await Bus.publish(Event.SessionCreated, {
+        sessionID: record.sessionID,
+        groupID: record.groupID,
+        worktree: record.worktree,
+        model: record.model,
+        label: record.label,
+      })
+
+      log.info("managed session created", {
+        sessionID: record.sessionID,
+        branch: record.worktree.branch,
+        index: idx + 1,
+        total: variants.length,
+      })
+    }
+
+    await writeStore(store)
+    return AgentManagerTypes.CreateOutput.parse({
+      groupID,
+      sessions,
+    })
+  })
+
+  export const list = fn(AgentManagerTypes.ListInput.optional(), async (input) => {
+    const query = AgentManagerTypes.ListInput.parse(input ?? {})
+    const rows = await readStore()
+    const sessions = [...Session.list()]
+    const map = new Map(sessions.map((item) => [item.id, item]))
+    const assembled = await Promise.all(
+      rows.flatMap((record) => {
+        const item = map.get(record.sessionID)
+        if (!item) return []
+        return [asSession({ record, session: item })]
+      }),
+    )
+
+    const filteredByGroup = query.groupID
+      ? assembled.filter((item: AgentManagerTypes.Session) => item.groupID === query.groupID)
+      : assembled
+    const filtered = query.status
+      ? filteredByGroup.filter((item: AgentManagerTypes.Session) => item.status === query.status)
+      : filteredByGroup
+    const ordered = filtered.toSorted(
+      (a: AgentManagerTypes.Session, b: AgentManagerTypes.Session) => b.time.updated - a.time.updated,
+    )
+    const start = parseCursor(query.cursor)
+    const limit = parseLimit(query.limit, 50, 200)
+    const list = ordered.slice(start, start + limit)
+    const cursor = start + list.length < ordered.length ? String(start + list.length) : undefined
+    return AgentManagerTypes.ListOutput.parse({
+      sessions: list,
+      cursor,
+    })
+  })
+
+  export const get = fn(AgentManagerTypes.DetailInput, async (input) => {
+    const rows = await readStore()
+    const record = rows.find((item) => item.sessionID === input.sessionID)
+    if (!record) throw new Error(`Managed session not found: ${input.sessionID}`)
+    const session = await Session.get(input.sessionID)
+    const info = await asSession({ record, session })
+    const messages = await Session.messages({
+      sessionID: input.sessionID,
+      limit: parseLimit(input.limit, 50, 200),
+    })
+    return AgentManagerTypes.DetailOutput.parse({
+      session: info,
+      messages,
+    })
+  })
+
+  export const cancel = fn(AgentManagerTypes.CancelInput, async (input) => {
+    const rows = await readStore()
+    const record = rows.find((item) => item.sessionID === input.sessionID)
+    if (!record) throw new Error(`Managed session not found: ${input.sessionID}`)
+
+    await Instance.provide({
+      directory: record.worktree.path,
+      fn: async () => {
+        SessionPrompt.cancel(input.sessionID)
+        await Worktree.remove({ directory: record.worktree.path }).catch(() => true)
+      },
+    }).catch(async () => {
+      SessionPrompt.cancel(input.sessionID)
+      await Worktree.remove({ directory: record.worktree.path }).catch(() => true)
+    })
+
+    await Project.removeSandbox(Instance.project.id, record.worktree.path).catch(() => undefined)
+    await writeStore(rows.filter((item) => item.sessionID !== input.sessionID))
+    return true
+  })
+
+  export const diff = fn(AgentManagerTypes.DiffInput, async (input) => {
+    const rows = await readStore()
+    const record = rows.find((item) => item.sessionID === input.sessionID)
+    if (!record) throw new Error(`Managed session not found: ${input.sessionID}`)
+
+    const files = await allDiff({
+      record,
+      includePatch: input.includePatch === true,
+    })
+
+    const start = parseCursor(input.cursor)
+    const limit = parseLimit(input.limit, 20, 200)
+    const page = files.slice(start, start + limit)
+    const cursor = start + page.length < files.length ? String(start + page.length) : undefined
+    const summary = {
+      totalFiles: files.length,
+      totalAdditions: files.reduce((sum, item) => sum + item.additions, 0),
+      totalDeletions: files.reduce((sum, item) => sum + item.deletions, 0),
+    }
+
+    return AgentManagerTypes.DiffOutput.parse({
+      files: page,
+      summary,
+      cursor,
+    })
+  })
+}

--- a/packages/opencode/src/kilocode/agent-manager/types.ts
+++ b/packages/opencode/src/kilocode/agent-manager/types.ts
@@ -1,0 +1,220 @@
+import z from "zod"
+import { MessageV2 } from "@/session/message-v2"
+
+export namespace AgentManagerTypes {
+  export const Model = z
+    .object({
+      providerID: z.string(),
+      modelID: z.string(),
+    })
+    .meta({
+      ref: "AgentManagerModel",
+    })
+
+  export const ModelInput = z
+    .union([z.string().describe("Model in provider/model format"), Model])
+    .optional()
+    .meta({
+      ref: "AgentManagerModelInput",
+    })
+
+  export const Version = z
+    .object({
+      label: z.string().optional().describe("Display label for this variant"),
+      name: z.string().optional().describe("Optional branch/worktree name hint for this variant"),
+      prompt: z.string().optional().describe("Optional prompt override for this variant"),
+      agent: z.string().optional().describe("Optional agent override for this variant"),
+      model: ModelInput,
+    })
+    .meta({
+      ref: "AgentManagerVersion",
+    })
+
+  export const CreateInput = z
+    .object({
+      name: z.string().optional().describe("Optional base name used when creating branches/worktrees"),
+      prompt: z.string().optional().describe("Initial prompt applied to all variants unless overridden"),
+      baseBranch: z.string().optional().describe("Base branch or ref to branch from"),
+      agent: z.string().optional().describe("Default agent for all variants"),
+      model: ModelInput,
+      versions: z.array(Version).min(1).max(4).optional().describe("Optional per-variant configuration"),
+    })
+    .meta({
+      ref: "AgentManagerCreateInput",
+    })
+  export type CreateInput = z.infer<typeof CreateInput>
+
+  export const Worktree = z
+    .object({
+      id: z.string(),
+      path: z.string(),
+      branch: z.string(),
+      baseBranch: z.string(),
+    })
+    .meta({
+      ref: "AgentManagerWorktree",
+    })
+  export type Worktree = z.infer<typeof Worktree>
+
+  export const Summary = z
+    .object({
+      additions: z.number(),
+      deletions: z.number(),
+      files: z.number(),
+    })
+    .optional()
+
+  export const Session = z
+    .object({
+      sessionID: z.string(),
+      groupID: z.string().optional(),
+      worktree: Worktree,
+      title: z.string().optional(),
+      agent: z.string(),
+      model: z.string().optional(),
+      label: z.string().optional(),
+      status: z.enum(["idle", "busy", "error"]),
+      summary: Summary,
+      time: z.object({
+        created: z.number(),
+        updated: z.number(),
+      }),
+    })
+    .meta({
+      ref: "AgentManagerSession",
+    })
+  export type Session = z.infer<typeof Session>
+
+  export const SessionRecord = z
+    .object({
+      sessionID: z.string(),
+      groupID: z.string().optional(),
+      worktree: Worktree,
+      agent: z.string(),
+      model: z.string().optional(),
+      label: z.string().optional(),
+      failed: z.boolean().optional(),
+      time: z.object({
+        created: z.number(),
+        updated: z.number(),
+      }),
+    })
+    .meta({
+      ref: "AgentManagerSessionRecord",
+    })
+  export type SessionRecord = z.infer<typeof SessionRecord>
+
+  export const CreateOutput = z
+    .object({
+      groupID: z.string().optional(),
+      sessions: z.array(Session),
+    })
+    .meta({
+      ref: "AgentManagerCreateOutput",
+    })
+  export type CreateOutput = z.infer<typeof CreateOutput>
+
+  export const ListInput = z
+    .object({
+      groupID: z.string().optional(),
+      status: z.enum(["idle", "busy", "error"]).optional(),
+      limit: z.coerce.number().optional(),
+      cursor: z.string().optional(),
+    })
+    .meta({
+      ref: "AgentManagerListInput",
+    })
+  export type ListInput = z.infer<typeof ListInput>
+
+  export const ListOutput = z
+    .object({
+      sessions: z.array(Session),
+      cursor: z.string().optional(),
+    })
+    .meta({
+      ref: "AgentManagerListOutput",
+    })
+  export type ListOutput = z.infer<typeof ListOutput>
+
+  export const DetailInput = z
+    .object({
+      sessionID: z.string(),
+      limit: z.coerce.number().optional(),
+    })
+    .meta({
+      ref: "AgentManagerDetailInput",
+    })
+  export type DetailInput = z.infer<typeof DetailInput>
+
+  export const DetailOutput = z
+    .object({
+      session: Session,
+      messages: z.array(MessageV2.WithParts),
+    })
+    .meta({
+      ref: "AgentManagerDetailOutput",
+    })
+  export type DetailOutput = z.infer<typeof DetailOutput>
+
+  export const CancelInput = z
+    .object({
+      sessionID: z.string(),
+    })
+    .meta({
+      ref: "AgentManagerCancelInput",
+    })
+  export type CancelInput = z.infer<typeof CancelInput>
+
+  export const DiffInput = z
+    .object({
+      sessionID: z.string(),
+      cursor: z.string().optional(),
+      limit: z.coerce.number().optional(),
+      includePatch: z.coerce.boolean().optional(),
+    })
+    .meta({
+      ref: "AgentManagerDiffInput",
+    })
+  export type DiffInput = z.infer<typeof DiffInput>
+
+  export const DiffFile = z
+    .object({
+      path: z.string(),
+      status: z.enum(["added", "modified", "deleted"]),
+      additions: z.number(),
+      deletions: z.number(),
+      patch: z.string().optional(),
+      patchTruncated: z.boolean().optional(),
+    })
+    .meta({
+      ref: "AgentManagerDiffFile",
+    })
+  export type DiffFile = z.infer<typeof DiffFile>
+
+  export const DiffOutput = z
+    .object({
+      files: z.array(DiffFile),
+      summary: z.object({
+        totalFiles: z.number(),
+        totalAdditions: z.number(),
+        totalDeletions: z.number(),
+      }),
+      cursor: z.string().optional(),
+    })
+    .meta({
+      ref: "AgentManagerDiffOutput",
+    })
+  export type DiffOutput = z.infer<typeof DiffOutput>
+
+  export const CreatedEvent = z
+    .object({
+      sessionID: z.string(),
+      groupID: z.string().optional(),
+      worktree: Worktree,
+      model: z.string().optional(),
+      label: z.string().optional(),
+    })
+    .meta({
+      ref: "AgentManagerSessionCreatedEvent",
+    })
+}

--- a/packages/opencode/src/kilocode/server/routes/agent-manager.ts
+++ b/packages/opencode/src/kilocode/server/routes/agent-manager.ts
@@ -1,0 +1,186 @@
+import { AgentManagerService } from "@/kilocode/agent-manager/service"
+import { AgentManagerTypes } from "@/kilocode/agent-manager/types"
+import { errors } from "@/server/error"
+import { lazy } from "@/util/lazy"
+import { Hono } from "hono"
+import { describeRoute, resolver, validator } from "hono-openapi"
+import z from "zod"
+
+export const AgentManagerRoutes = lazy(() =>
+  new Hono()
+    .post(
+      "/session",
+      describeRoute({
+        summary: "Create managed sessions",
+        description:
+          "Create one or more managed agent sessions on isolated git worktrees and start each session asynchronously.",
+        operationId: "agentManager.create",
+        responses: {
+          200: {
+            description: "Created managed sessions",
+            content: {
+              "application/json": {
+                schema: resolver(AgentManagerTypes.CreateOutput),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator("json", AgentManagerTypes.CreateInput),
+      async (c) => {
+        const body = c.req.valid("json")
+        const result = await AgentManagerService.create(body)
+        return c.json(result)
+      },
+    )
+    .get(
+      "/session",
+      describeRoute({
+        summary: "List managed sessions",
+        description: "List managed sessions with optional group, status, and cursor filters.",
+        operationId: "agentManager.list",
+        responses: {
+          200: {
+            description: "Managed sessions",
+            content: {
+              "application/json": {
+                schema: resolver(AgentManagerTypes.ListOutput),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator(
+        "query",
+        z.object({
+          groupID: z.string().optional(),
+          status: z.enum(["idle", "busy", "error"]).optional(),
+          limit: z.coerce.number().optional(),
+          cursor: z.string().optional(),
+        }),
+      ),
+      async (c) => {
+        const query = c.req.valid("query")
+        const result = await AgentManagerService.list(query)
+        return c.json(result)
+      },
+    )
+    .get(
+      "/session/:sessionID",
+      describeRoute({
+        summary: "Get managed session detail",
+        description: "Get details for one managed session, including recent messages.",
+        operationId: "agentManager.get",
+        responses: {
+          200: {
+            description: "Managed session detail",
+            content: {
+              "application/json": {
+                schema: resolver(AgentManagerTypes.DetailOutput),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string(),
+        }),
+      ),
+      validator(
+        "query",
+        z.object({
+          limit: z.coerce.number().optional(),
+        }),
+      ),
+      async (c) => {
+        const param = c.req.valid("param")
+        const query = c.req.valid("query")
+        const result = await AgentManagerService.get({
+          sessionID: param.sessionID,
+          limit: query.limit,
+        })
+        return c.json(result)
+      },
+    )
+    .delete(
+      "/session/:sessionID",
+      describeRoute({
+        summary: "Cancel managed session",
+        description: "Abort a managed session and remove its worktree.",
+        operationId: "agentManager.cancel",
+        responses: {
+          200: {
+            description: "Cancelled",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string(),
+        }),
+      ),
+      async (c) => {
+        const param = c.req.valid("param")
+        const result = await AgentManagerService.cancel({
+          sessionID: param.sessionID,
+        })
+        return c.json(result)
+      },
+    )
+    .get(
+      "/session/:sessionID/diff",
+      describeRoute({
+        summary: "Get managed session diff",
+        description: "Get a paginated diff for one managed session.",
+        operationId: "agentManager.diff",
+        responses: {
+          200: {
+            description: "Diff page",
+            content: {
+              "application/json": {
+                schema: resolver(AgentManagerTypes.DiffOutput),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string(),
+        }),
+      ),
+      validator(
+        "query",
+        z.object({
+          cursor: z.string().optional(),
+          limit: z.coerce.number().optional(),
+          includePatch: z.coerce.boolean().optional(),
+        }),
+      ),
+      async (c) => {
+        const param = c.req.valid("param")
+        const query = c.req.valid("query")
+        const result = await AgentManagerService.diff({
+          sessionID: param.sessionID,
+          cursor: query.cursor,
+          limit: query.limit,
+          includePatch: query.includePatch,
+        })
+        return c.json(result)
+      },
+    ),
+)

--- a/packages/opencode/src/kilocode/tool/agent-session-cancel.txt
+++ b/packages/opencode/src/kilocode/tool/agent-session-cancel.txt
@@ -1,0 +1,3 @@
+Cancel a managed agent session and clean up its worktree.
+
+Use this when a delegated run is no longer needed.

--- a/packages/opencode/src/kilocode/tool/agent-session-create.txt
+++ b/packages/opencode/src/kilocode/tool/agent-session-create.txt
@@ -1,0 +1,13 @@
+Create one or more managed agent sessions on isolated git worktrees.
+
+Use this tool when delegating implementation work to parallel agents.
+
+Supports two modes:
+1. Single session with one prompt.
+2. Multi-version launch using `versions[]`. Each version can override `prompt`, `model`, and `agent`. Use for parallel subtasks with different prompts or model comparisons with the same prompt.
+
+A top-level `prompt` acts as the default; per-version `prompt` overrides it. Either the top-level or every version must supply a prompt.
+
+The call returns immediately after sessions are created and started asynchronously.
+
+Use `agent_session_list` and `agent_session_status` to monitor progress.

--- a/packages/opencode/src/kilocode/tool/agent-session-diff.txt
+++ b/packages/opencode/src/kilocode/tool/agent-session-diff.txt
@@ -1,0 +1,5 @@
+Get a paginated diff for a managed agent session.
+
+Default response is lightweight file metadata. Set `includePatch=true` only when needed to inspect exact hunks.
+
+Use cursor pagination to avoid overloading context windows.

--- a/packages/opencode/src/kilocode/tool/agent-session-list.txt
+++ b/packages/opencode/src/kilocode/tool/agent-session-list.txt
@@ -1,0 +1,5 @@
+List managed agent sessions with optional filters.
+
+Use this tool to monitor progress across parallel delegated sessions.
+
+Supports filtering by groupID and status, plus cursor-based pagination.

--- a/packages/opencode/src/kilocode/tool/agent-session-status.txt
+++ b/packages/opencode/src/kilocode/tool/agent-session-status.txt
@@ -1,0 +1,3 @@
+Get detailed status for a single managed agent session.
+
+Returns session metadata and recent messages so you can inspect progress.

--- a/packages/opencode/src/kilocode/tool/agent-session.ts
+++ b/packages/opencode/src/kilocode/tool/agent-session.ts
@@ -1,0 +1,113 @@
+import { AgentManagerService } from "@/kilocode/agent-manager/service"
+import { AgentManagerTypes } from "@/kilocode/agent-manager/types"
+import { Tool } from "@/tool/tool"
+import CREATE_DESCRIPTION from "./agent-session-create.txt"
+import LIST_DESCRIPTION from "./agent-session-list.txt"
+import STATUS_DESCRIPTION from "./agent-session-status.txt"
+import CANCEL_DESCRIPTION from "./agent-session-cancel.txt"
+import DIFF_DESCRIPTION from "./agent-session-diff.txt"
+
+export const AgentSessionCreateTool = Tool.define("agent_session_create", {
+  description: CREATE_DESCRIPTION,
+  parameters: AgentManagerTypes.CreateInput,
+  async execute(params, ctx) {
+    await ctx.ask({
+      permission: "agent_session_create",
+      patterns: ["*"],
+      metadata: {
+        baseBranch: params.baseBranch,
+        versions: params.versions?.length,
+      },
+      always: ["*"],
+    })
+    const result = await AgentManagerService.create(params)
+    return {
+      title: `Created ${result.sessions.length} managed session${result.sessions.length === 1 ? "" : "s"}`,
+      output: JSON.stringify(result, null, 2),
+      metadata: result,
+    }
+  },
+})
+
+export const AgentSessionListTool = Tool.define("agent_session_list", {
+  description: LIST_DESCRIPTION,
+  parameters: AgentManagerTypes.ListInput,
+  async execute(params, ctx) {
+    await ctx.ask({
+      permission: "agent_session_list",
+      patterns: ["*"],
+      metadata: params,
+      always: ["*"],
+    })
+    const result = await AgentManagerService.list(params)
+    return {
+      title: `Found ${result.sessions.length} managed session${result.sessions.length === 1 ? "" : "s"}`,
+      output: JSON.stringify(result, null, 2),
+      metadata: result,
+    }
+  },
+})
+
+export const AgentSessionStatusTool = Tool.define("agent_session_status", {
+  description: STATUS_DESCRIPTION,
+  parameters: AgentManagerTypes.DetailInput,
+  async execute(params, ctx) {
+    await ctx.ask({
+      permission: "agent_session_status",
+      patterns: ["*"],
+      metadata: {
+        sessionID: params.sessionID,
+      },
+      always: ["*"],
+    })
+    const result = await AgentManagerService.get(params)
+    return {
+      title: `Loaded status for ${result.session.sessionID}`,
+      output: JSON.stringify(result, null, 2),
+      metadata: result,
+    }
+  },
+})
+
+export const AgentSessionCancelTool = Tool.define("agent_session_cancel", {
+  description: CANCEL_DESCRIPTION,
+  parameters: AgentManagerTypes.CancelInput,
+  async execute(params, ctx) {
+    await ctx.ask({
+      permission: "agent_session_cancel",
+      patterns: ["*"],
+      metadata: {
+        sessionID: params.sessionID,
+      },
+      always: ["*"],
+    })
+    const result = await AgentManagerService.cancel(params)
+    return {
+      title: `Cancelled managed session ${params.sessionID}`,
+      output: JSON.stringify({ success: result }, null, 2),
+      metadata: { success: result, sessionID: params.sessionID },
+    }
+  },
+})
+
+export const AgentSessionDiffTool = Tool.define("agent_session_diff", {
+  description: DIFF_DESCRIPTION,
+  parameters: AgentManagerTypes.DiffInput,
+  async execute(params, ctx) {
+    await ctx.ask({
+      permission: "agent_session_diff",
+      patterns: ["*"],
+      metadata: {
+        sessionID: params.sessionID,
+        includePatch: params.includePatch,
+      },
+      always: ["*"],
+    })
+    const result = await AgentManagerService.diff(params)
+    return {
+      title: `Loaded diff for ${params.sessionID}`,
+      output: JSON.stringify(result, null, 2),
+      metadata: result,
+    }
+  },
+})

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -50,6 +50,7 @@ import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
 import { GlobalRoutes } from "./routes/global"
 import { MDNS } from "./mdns"
+import { AgentManagerRoutes } from "@/kilocode/server/routes/agent-manager" // kilocode_change
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -250,6 +251,7 @@ export namespace Server {
         .route("/permission", PermissionRoutes())
         .route("/question", QuestionRoutes())
         .route("/provider", ProviderRoutes())
+        .route("/agent-manager", AgentManagerRoutes()) // kilocode_change
         .route("/telemetry", TelemetryRoutes()) // kilocode_change
         .route("/commit-message", CommitMessageRoutes()) // kilocode_change
         .route("/enhance-prompt", EnhancePromptRoutes()) // kilocode_change

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -30,6 +30,13 @@ import { Truncate } from "./truncation"
 import { ApplyPatchTool } from "./apply_patch"
 import { Glob } from "../util/glob"
 import { pathToFileURL } from "url"
+import {
+  AgentSessionCancelTool,
+  AgentSessionCreateTool,
+  AgentSessionDiffTool,
+  AgentSessionListTool,
+  AgentSessionStatusTool,
+} from "@/kilocode/tool/agent-session" // kilocode_change
 
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
@@ -117,6 +124,13 @@ export namespace ToolRegistry {
       CodeSearchTool,
       SkillTool,
       ApplyPatchTool,
+      // kilocode_change start - native managed agent session tools
+      AgentSessionCreateTool,
+      AgentSessionListTool,
+      AgentSessionStatusTool,
+      AgentSessionCancelTool,
+      AgentSessionDiffTool,
+      // kilocode_change end
       ...(Flag.KILO_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
       ...(Flag.KILO_EXPERIMENTAL_PLAN_MODE && Flag.KILO_CLIENT === "cli" ? [PlanExitTool] : []),

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -48,6 +48,12 @@ export namespace Worktree {
   export const CreateInput = z
     .object({
       name: z.string().optional(),
+      // kilocode_change start - allow creating worktree from a specific base branch
+      baseBranch: z
+        .string()
+        .optional()
+        .describe("Base branch or ref to create the worktree branch from (defaults to current HEAD)"),
+      // kilocode_change end
       startCommand: z
         .string()
         .optional()
@@ -342,10 +348,16 @@ export namespace Worktree {
     const base = input?.name ? slug(input.name) : ""
     const info = await candidate(root, base || undefined)
 
-    const created = await $`git worktree add --no-checkout -b ${info.branch} ${info.directory}`
+    // kilocode_change start - support optional base branch for worktree creation
+    const created = await (
+      input?.baseBranch
+        ? $`git worktree add --no-checkout -b ${info.branch} ${info.directory} ${input.baseBranch}`
+        : $`git worktree add --no-checkout -b ${info.branch} ${info.directory}`
+    )
       .quiet()
       .nothrow()
       .cwd(Instance.worktree)
+    // kilocode_change end
     if (created.exitCode !== 0) {
       throw new CreateFailedError({ message: errorText(created) || "Failed to create git worktree" })
     }

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -78,6 +78,30 @@ test("ask agent has correct default properties", async () => {
     },
   })
 })
+
+test("orchestrator allows managed session tools", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const code = await Agent.get("code")
+      const orchestrator = await Agent.get("orchestrator")
+      expect(code).toBeDefined()
+      expect(orchestrator).toBeDefined()
+      expect(evalPerm(code, "agent_session_create")).toBe("deny")
+      expect(evalPerm(code, "agent_session_list")).toBe("deny")
+      expect(evalPerm(code, "agent_session_status")).toBe("deny")
+      expect(evalPerm(code, "agent_session_cancel")).toBe("deny")
+      expect(evalPerm(code, "agent_session_diff")).toBe("deny")
+      expect(evalPerm(orchestrator, "agent_session_create")).toBe("allow")
+      expect(evalPerm(orchestrator, "agent_session_list")).toBe("allow")
+      expect(evalPerm(orchestrator, "agent_session_status")).toBe("allow")
+      expect(evalPerm(orchestrator, "agent_session_cancel")).toBe("allow")
+      expect(evalPerm(orchestrator, "agent_session_diff")).toBe("allow")
+    },
+  })
+})
+
 test("ask agent denies edit/write/bash even when user config adds a specific edit allow", async () => {
   await using tmp = await tmpdir({
     config: {

--- a/packages/opencode/test/kilocode/agent-manager-service.test.ts
+++ b/packages/opencode/test/kilocode/agent-manager-service.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { AgentManagerService } from "../../src/kilocode/agent-manager/service"
+import { Filesystem } from "../../src/util/filesystem"
+
+// InstanceBootstrap spawns async file watchers, ripgrep scans, etc. inside
+// Worktree.create's setTimeout. We need to let those complete before the
+// tmpdir is cleaned up, otherwise bun attributes the ENOENT to the next test.
+const settle = () => new Promise((r) => setTimeout(r, 1_000))
+
+describe("AgentManagerService", () => {
+  test(
+    "creates grouped parallel sessions and lists them",
+    async () => {
+      await using tmp = await tmpdir({ git: true })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const created = await AgentManagerService.create({
+            prompt: "Build feature X",
+            versions: [
+              {
+                label: "api",
+              },
+              {
+                label: "ui",
+              },
+            ],
+          })
+
+          expect(created.groupID).toBeDefined()
+          expect(created.sessions.length).toBe(2)
+          expect(created.sessions[0]?.sessionID).toBeDefined()
+          expect(created.sessions[1]?.sessionID).toBeDefined()
+
+          const listed = await AgentManagerService.list({ groupID: created.groupID })
+          expect(listed.sessions.length).toBe(2)
+          expect(
+            listed.sessions.every((item: (typeof listed.sessions)[number]) => item.groupID === created.groupID),
+          ).toBe(true)
+
+          for (const session of created.sessions) {
+            await AgentManagerService.cancel({ sessionID: session.sessionID }).catch(() => undefined)
+          }
+          await settle()
+        },
+      })
+    },
+    { timeout: 30_000 },
+  )
+
+  test(
+    "returns paginated diffs and cancels sessions",
+    async () => {
+      await using tmp = await tmpdir({ git: true })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const created = await AgentManagerService.create({
+            prompt: "Implement feature Y",
+          })
+
+          const first = created.sessions[0]
+          expect(first).toBeDefined()
+          if (!first) return
+
+          const added = path.join(first.worktree.path, "agent-manager-added.txt")
+          await Bun.write(added, "hello from managed session\n")
+
+          const diffMeta = await AgentManagerService.diff({
+            sessionID: first.sessionID,
+            limit: 1,
+            includePatch: false,
+          })
+
+          expect(diffMeta.files.length).toBe(1)
+          expect(diffMeta.summary.totalFiles).toBeGreaterThan(0)
+          expect(diffMeta.files[0]?.path).toContain("agent-manager-added.txt")
+
+          const diffPatch = await AgentManagerService.diff({
+            sessionID: first.sessionID,
+            includePatch: true,
+          })
+          const match = diffPatch.files.find((item: (typeof diffPatch.files)[number]) =>
+            item.path.endsWith("agent-manager-added.txt"),
+          )
+          expect(match?.status).toBe("added")
+
+          const cancelled = await AgentManagerService.cancel({ sessionID: first.sessionID })
+          expect(cancelled).toBe(true)
+          expect(await Filesystem.exists(first.worktree.path)).toBe(false)
+          await settle()
+        },
+      })
+    },
+    { timeout: 30_000 },
+  )
+
+  test(
+    "allows per-version prompts without top-level prompt",
+    async () => {
+      await using tmp = await tmpdir({ git: true })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const created = await AgentManagerService.create({
+            versions: [
+              {
+                label: "api",
+                prompt: "Build the API layer",
+              },
+              {
+                label: "ui",
+                prompt: "Build the UI layer",
+              },
+            ],
+          })
+
+          expect(created.sessions.length).toBe(2)
+          expect(created.sessions[0]?.sessionID).toBeDefined()
+          expect(created.sessions[1]?.sessionID).toBeDefined()
+
+          for (const session of created.sessions) {
+            await AgentManagerService.cancel({ sessionID: session.sessionID }).catch(() => undefined)
+          }
+          await settle()
+        },
+      })
+    },
+    { timeout: 30_000 },
+  )
+
+  test("rejects when no prompt is provided at any level", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await expect(
+          AgentManagerService.create({
+            versions: [
+              {
+                label: "api",
+              },
+            ],
+          }),
+        ).rejects.toThrow("Prompt is required")
+      },
+    })
+  })
+})

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -28,6 +28,21 @@ describe("tool.registry", () => {
   })
   // kilocode_change end
 
+  test("managed session tools are registered", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const ids = await ToolRegistry.ids()
+        expect(ids).toContain("agent_session_create")
+        expect(ids).toContain("agent_session_list")
+        expect(ids).toContain("agent_session_status")
+        expect(ids).toContain("agent_session_cancel")
+        expect(ids).toContain("agent_session_diff")
+      },
+    })
+  }, 15000)
+
   test("loads tools from .opencode/tool (singular)", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -3,6 +3,17 @@
 import { client } from "./client.gen.js"
 import { buildClientParams, type Client, type Options as Options2, type TDataShape } from "./client/index.js"
 import type {
+  AgentManagerCancelErrors,
+  AgentManagerCancelResponses,
+  AgentManagerCreateErrors,
+  AgentManagerCreateInput,
+  AgentManagerCreateResponses,
+  AgentManagerDiffErrors,
+  AgentManagerDiffResponses,
+  AgentManagerGetErrors,
+  AgentManagerGetResponses,
+  AgentManagerListErrors,
+  AgentManagerListResponses,
   AgentPartInput,
   AppAgentsResponses,
   AppLogErrors,
@@ -2322,6 +2333,179 @@ export class Provider extends HeyApiClient {
   }
 }
 
+export class AgentManager extends HeyApiClient {
+  /**
+   * List managed sessions
+   *
+   * List managed sessions with optional group, status, and cursor filters.
+   */
+  public list<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      groupID?: string
+      status?: "idle" | "busy" | "error"
+      limit?: number
+      cursor?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "groupID" },
+            { in: "query", key: "status" },
+            { in: "query", key: "limit" },
+            { in: "query", key: "cursor" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<AgentManagerListResponses, AgentManagerListErrors, ThrowOnError>({
+      url: "/agent-manager/session",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Create managed sessions
+   *
+   * Create one or more managed agent sessions on isolated git worktrees and start each session asynchronously.
+   */
+  public create<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      agentManagerCreateInput?: AgentManagerCreateInput
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { key: "agentManagerCreateInput", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<AgentManagerCreateResponses, AgentManagerCreateErrors, ThrowOnError>({
+      url: "/agent-manager/session",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Cancel managed session
+   *
+   * Abort a managed session and remove its worktree.
+   */
+  public cancel<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).delete<AgentManagerCancelResponses, AgentManagerCancelErrors, ThrowOnError>(
+      {
+        url: "/agent-manager/session/{sessionID}",
+        ...options,
+        ...params,
+      },
+    )
+  }
+
+  /**
+   * Get managed session detail
+   *
+   * Get details for one managed session, including recent messages.
+   */
+  public get<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      limit?: number
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "limit" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<AgentManagerGetResponses, AgentManagerGetErrors, ThrowOnError>({
+      url: "/agent-manager/session/{sessionID}",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get managed session diff
+   *
+   * Get a paginated diff for one managed session.
+   */
+  public diff<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      cursor?: string
+      limit?: number
+      includePatch?: boolean
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "cursor" },
+            { in: "query", key: "limit" },
+            { in: "query", key: "includePatch" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<AgentManagerDiffResponses, AgentManagerDiffErrors, ThrowOnError>({
+      url: "/agent-manager/session/{sessionID}/diff",
+      ...options,
+      ...params,
+    })
+  }
+}
+
 export class Telemetry extends HeyApiClient {
   /**
    * Capture telemetry event
@@ -3781,6 +3965,11 @@ export class KiloClient extends HeyApiClient {
   private _provider?: Provider
   get provider(): Provider {
     return (this._provider ??= new Provider({ client: this.client }))
+  }
+
+  private _agentManager?: AgentManager
+  get agentManager(): AgentManager {
+    return (this._agentManager ??= new AgentManager({ client: this.client }))
   }
 
   private _telemetry?: Telemetry

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -726,6 +726,48 @@ export type EventTodoUpdated = {
   }
 }
 
+export type EventVcsBranchUpdated = {
+  type: "vcs.branch.updated"
+  properties: {
+    branch?: string
+  }
+}
+
+export type EventWorktreeReady = {
+  type: "worktree.ready"
+  properties: {
+    name: string
+    branch: string
+  }
+}
+
+export type EventWorktreeFailed = {
+  type: "worktree.failed"
+  properties: {
+    message: string
+  }
+}
+
+export type AgentManagerWorktree = {
+  id: string
+  path: string
+  branch: string
+  baseBranch: string
+}
+
+export type AgentManagerSessionCreatedEvent = {
+  sessionID: string
+  groupID?: string
+  worktree: AgentManagerWorktree
+  model?: string
+  label?: string
+}
+
+export type EventAgentManagerSessionCreated = {
+  type: "agent-manager.session.created"
+  properties: AgentManagerSessionCreatedEvent
+}
+
 export type EventTuiPromptAppend = {
   type: "tui.prompt.append"
   properties: {
@@ -906,13 +948,6 @@ export type EventSessionTurnClose = {
   }
 }
 
-export type EventVcsBranchUpdated = {
-  type: "vcs.branch.updated"
-  properties: {
-    branch?: string
-  }
-}
-
 export type Pty = {
   id: string
   title: string
@@ -952,21 +987,6 @@ export type EventPtyDeleted = {
   }
 }
 
-export type EventWorktreeReady = {
-  type: "worktree.ready"
-  properties: {
-    name: string
-    branch: string
-  }
-}
-
-export type EventWorktreeFailed = {
-  type: "worktree.failed"
-  properties: {
-    message: string
-  }
-}
-
 export type Event =
   | EventInstallationUpdated
   | EventInstallationUpdateAvailable
@@ -992,6 +1012,10 @@ export type Event =
   | EventSessionCompacted
   | EventFileWatcherUpdated
   | EventTodoUpdated
+  | EventVcsBranchUpdated
+  | EventWorktreeReady
+  | EventWorktreeFailed
+  | EventAgentManagerSessionCreated
   | EventTuiPromptAppend
   | EventTuiCommandExecute
   | EventTuiToastShow
@@ -1006,13 +1030,10 @@ export type Event =
   | EventSessionError
   | EventSessionTurnOpen
   | EventSessionTurnClose
-  | EventVcsBranchUpdated
   | EventPtyCreated
   | EventPtyUpdated
   | EventPtyExited
   | EventPtyDeleted
-  | EventWorktreeReady
-  | EventWorktreeFailed
 
 export type GlobalEvent = {
   directory: string
@@ -1657,6 +1678,10 @@ export type Worktree = {
 export type WorktreeCreateInput = {
   name?: string
   /**
+   * Base branch or ref to create the worktree branch from (defaults to current HEAD)
+   */
+  baseBranch?: string
+  /**
    * Additional startup script to run after the project's start command
    */
   startCommand?: string
@@ -1774,6 +1799,114 @@ export type ProviderAuthAuthorization = {
   url: string
   method: "auto" | "code"
   instructions: string
+}
+
+export type AgentManagerSession = {
+  sessionID: string
+  groupID?: string
+  worktree: AgentManagerWorktree
+  title?: string
+  agent: string
+  model?: string
+  label?: string
+  status: "idle" | "busy" | "error"
+  summary?: {
+    additions: number
+    deletions: number
+    files: number
+  }
+  time: {
+    created: number
+    updated: number
+  }
+}
+
+export type AgentManagerCreateOutput = {
+  groupID?: string
+  sessions: Array<AgentManagerSession>
+}
+
+export type AgentManagerModel = {
+  providerID: string
+  modelID: string
+}
+
+export type AgentManagerModelInput = string | AgentManagerModel
+
+export type AgentManagerVersion = {
+  /**
+   * Display label for this variant
+   */
+  label?: string
+  /**
+   * Optional branch/worktree name hint for this variant
+   */
+  name?: string
+  /**
+   * Optional prompt override for this variant
+   */
+  prompt?: string
+  /**
+   * Optional agent override for this variant
+   */
+  agent?: string
+  model?: AgentManagerModelInput
+}
+
+export type AgentManagerCreateInput = {
+  /**
+   * Optional base name used when creating branches/worktrees
+   */
+  name?: string
+  /**
+   * Initial prompt applied to all variants unless overridden
+   */
+  prompt?: string
+  /**
+   * Base branch or ref to branch from
+   */
+  baseBranch?: string
+  /**
+   * Default agent for all variants
+   */
+  agent?: string
+  model?: AgentManagerModelInput
+  /**
+   * Optional per-variant configuration
+   */
+  versions?: Array<AgentManagerVersion>
+}
+
+export type AgentManagerListOutput = {
+  sessions: Array<AgentManagerSession>
+  cursor?: string
+}
+
+export type AgentManagerDetailOutput = {
+  session: AgentManagerSession
+  messages: Array<{
+    info: Message
+    parts: Array<Part>
+  }>
+}
+
+export type AgentManagerDiffFile = {
+  path: string
+  status: "added" | "modified" | "deleted"
+  additions: number
+  deletions: number
+  patch?: string
+  patchTruncated?: boolean
+}
+
+export type AgentManagerDiffOutput = {
+  files: Array<AgentManagerDiffFile>
+  summary: {
+    totalFiles: number
+    totalAdditions: number
+    totalDeletions: number
+  }
+  cursor?: string
 }
 
 export type Symbol = {
@@ -3990,6 +4123,167 @@ export type ProviderOauthCallbackResponses = {
 }
 
 export type ProviderOauthCallbackResponse = ProviderOauthCallbackResponses[keyof ProviderOauthCallbackResponses]
+
+export type AgentManagerListData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    groupID?: string
+    status?: "idle" | "busy" | "error"
+    limit?: number
+    cursor?: string
+  }
+  url: "/agent-manager/session"
+}
+
+export type AgentManagerListErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type AgentManagerListError = AgentManagerListErrors[keyof AgentManagerListErrors]
+
+export type AgentManagerListResponses = {
+  /**
+   * Managed sessions
+   */
+  200: AgentManagerListOutput
+}
+
+export type AgentManagerListResponse = AgentManagerListResponses[keyof AgentManagerListResponses]
+
+export type AgentManagerCreateData = {
+  body?: AgentManagerCreateInput
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/agent-manager/session"
+}
+
+export type AgentManagerCreateErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type AgentManagerCreateError = AgentManagerCreateErrors[keyof AgentManagerCreateErrors]
+
+export type AgentManagerCreateResponses = {
+  /**
+   * Created managed sessions
+   */
+  200: AgentManagerCreateOutput
+}
+
+export type AgentManagerCreateResponse = AgentManagerCreateResponses[keyof AgentManagerCreateResponses]
+
+export type AgentManagerCancelData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/agent-manager/session/{sessionID}"
+}
+
+export type AgentManagerCancelErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type AgentManagerCancelError = AgentManagerCancelErrors[keyof AgentManagerCancelErrors]
+
+export type AgentManagerCancelResponses = {
+  /**
+   * Cancelled
+   */
+  200: boolean
+}
+
+export type AgentManagerCancelResponse = AgentManagerCancelResponses[keyof AgentManagerCancelResponses]
+
+export type AgentManagerGetData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    limit?: number
+  }
+  url: "/agent-manager/session/{sessionID}"
+}
+
+export type AgentManagerGetErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type AgentManagerGetError = AgentManagerGetErrors[keyof AgentManagerGetErrors]
+
+export type AgentManagerGetResponses = {
+  /**
+   * Managed session detail
+   */
+  200: AgentManagerDetailOutput
+}
+
+export type AgentManagerGetResponse = AgentManagerGetResponses[keyof AgentManagerGetResponses]
+
+export type AgentManagerDiffData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    cursor?: string
+    limit?: number
+    includePatch?: boolean
+  }
+  url: "/agent-manager/session/{sessionID}/diff"
+}
+
+export type AgentManagerDiffErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type AgentManagerDiffError = AgentManagerDiffErrors[keyof AgentManagerDiffErrors]
+
+export type AgentManagerDiffResponses = {
+  /**
+   * Diff page
+   */
+  200: AgentManagerDiffOutput
+}
+
+export type AgentManagerDiffResponse = AgentManagerDiffResponses[keyof AgentManagerDiffResponses]
 
 export type TelemetryCaptureData = {
   body?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -4321,6 +4321,342 @@
         ]
       }
     },
+    "/agent-manager/session": {
+      "post": {
+        "operationId": "agentManager.create",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Create managed sessions",
+        "description": "Create one or more managed agent sessions on isolated git worktrees and start each session asynchronously.",
+        "responses": {
+          "200": {
+            "description": "Created managed sessions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentManagerCreateOutput"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentManagerCreateInput"
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.agentManager.create({\n  ...\n})"
+          }
+        ]
+      },
+      "get": {
+        "operationId": "agentManager.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "groupID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "type": "string",
+              "enum": ["idle", "busy", "error"]
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List managed sessions",
+        "description": "List managed sessions with optional group, status, and cursor filters.",
+        "responses": {
+          "200": {
+            "description": "Managed sessions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentManagerListOutput"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.agentManager.list({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/agent-manager/session/{sessionID}": {
+      "get": {
+        "operationId": "agentManager.get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "summary": "Get managed session detail",
+        "description": "Get details for one managed session, including recent messages.",
+        "responses": {
+          "200": {
+            "description": "Managed session detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentManagerDetailOutput"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.agentManager.get({\n  ...\n})"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "agentManager.cancel",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Cancel managed session",
+        "description": "Abort a managed session and remove its worktree.",
+        "responses": {
+          "200": {
+            "description": "Cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.agentManager.cancel({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/agent-manager/session/{sessionID}/diff": {
+      "get": {
+        "operationId": "agentManager.diff",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "includePatch",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "summary": "Get managed session diff",
+        "description": "Get a paginated diff for one managed session.",
+        "responses": {
+          "200": {
+            "description": "Diff page",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentManagerDiffOutput"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.agentManager.diff({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/telemetry/capture": {
       "post": {
         "operationId": "telemetry.capture",
@@ -8904,6 +9240,117 @@
         },
         "required": ["type", "properties"]
       },
+      "Event.vcs.branch.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "vcs.branch.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "branch": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": ["type", "properties"]
+      },
+      "Event.worktree.ready": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "worktree.ready"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "branch": {
+                "type": "string"
+              }
+            },
+            "required": ["name", "branch"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
+      "Event.worktree.failed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "worktree.failed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": ["message"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
+      "AgentManagerWorktree": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "branch": {
+            "type": "string"
+          },
+          "baseBranch": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "path", "branch", "baseBranch"]
+      },
+      "AgentManagerSessionCreatedEvent": {
+        "type": "object",
+        "properties": {
+          "sessionID": {
+            "type": "string"
+          },
+          "groupID": {
+            "type": "string"
+          },
+          "worktree": {
+            "$ref": "#/components/schemas/AgentManagerWorktree"
+          },
+          "model": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          }
+        },
+        "required": ["sessionID", "worktree"]
+      },
+      "Event.agent-manager.session.created": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "agent-manager.session.created"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/AgentManagerSessionCreatedEvent"
+          }
+        },
+        "required": ["type", "properties"]
+      },
       "Event.tui.prompt.append": {
         "type": "object",
         "properties": {
@@ -9380,24 +9827,6 @@
         },
         "required": ["type", "properties"]
       },
-      "Event.vcs.branch.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "vcs.branch.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "branch": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "required": ["type", "properties"]
-      },
       "Pty": {
         "type": "object",
         "properties": {
@@ -9511,47 +9940,6 @@
         },
         "required": ["type", "properties"]
       },
-      "Event.worktree.ready": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "worktree.ready"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "branch": {
-                "type": "string"
-              }
-            },
-            "required": ["name", "branch"]
-          }
-        },
-        "required": ["type", "properties"]
-      },
-      "Event.worktree.failed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "worktree.failed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": ["message"]
-          }
-        },
-        "required": ["type", "properties"]
-      },
       "Event": {
         "anyOf": [
           {
@@ -9627,6 +10015,18 @@
             "$ref": "#/components/schemas/Event.todo.updated"
           },
           {
+            "$ref": "#/components/schemas/Event.vcs.branch.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.worktree.ready"
+          },
+          {
+            "$ref": "#/components/schemas/Event.worktree.failed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.agent-manager.session.created"
+          },
+          {
             "$ref": "#/components/schemas/Event.tui.prompt.append"
           },
           {
@@ -9669,9 +10069,6 @@
             "$ref": "#/components/schemas/Event.session.turn.close"
           },
           {
-            "$ref": "#/components/schemas/Event.vcs.branch.updated"
-          },
-          {
             "$ref": "#/components/schemas/Event.pty.created"
           },
           {
@@ -9682,12 +10079,6 @@
           },
           {
             "$ref": "#/components/schemas/Event.pty.deleted"
-          },
-          {
-            "$ref": "#/components/schemas/Event.worktree.ready"
-          },
-          {
-            "$ref": "#/components/schemas/Event.worktree.failed"
           }
         ]
       },
@@ -11126,6 +11517,10 @@
           "name": {
             "type": "string"
           },
+          "baseBranch": {
+            "description": "Base branch or ref to create the worktree branch from (defaults to current HEAD)",
+            "type": "string"
+          },
           "startCommand": {
             "description": "Additional startup script to run after the project's start command",
             "type": "string"
@@ -11476,6 +11871,256 @@
           }
         },
         "required": ["url", "method", "instructions"]
+      },
+      "AgentManagerSession": {
+        "type": "object",
+        "properties": {
+          "sessionID": {
+            "type": "string"
+          },
+          "groupID": {
+            "type": "string"
+          },
+          "worktree": {
+            "$ref": "#/components/schemas/AgentManagerWorktree"
+          },
+          "title": {
+            "type": "string"
+          },
+          "agent": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["idle", "busy", "error"]
+          },
+          "summary": {
+            "type": "object",
+            "properties": {
+              "additions": {
+                "type": "number"
+              },
+              "deletions": {
+                "type": "number"
+              },
+              "files": {
+                "type": "number"
+              }
+            },
+            "required": ["additions", "deletions", "files"]
+          },
+          "time": {
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              },
+              "updated": {
+                "type": "number"
+              }
+            },
+            "required": ["created", "updated"]
+          }
+        },
+        "required": ["sessionID", "worktree", "agent", "status", "time"]
+      },
+      "AgentManagerCreateOutput": {
+        "type": "object",
+        "properties": {
+          "groupID": {
+            "type": "string"
+          },
+          "sessions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentManagerSession"
+            }
+          }
+        },
+        "required": ["sessions"]
+      },
+      "AgentManagerModel": {
+        "type": "object",
+        "properties": {
+          "providerID": {
+            "type": "string"
+          },
+          "modelID": {
+            "type": "string"
+          }
+        },
+        "required": ["providerID", "modelID"]
+      },
+      "AgentManagerModelInput": {
+        "anyOf": [
+          {
+            "description": "Model in provider/model format",
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/AgentManagerModel"
+          }
+        ]
+      },
+      "AgentManagerVersion": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "description": "Display label for this variant",
+            "type": "string"
+          },
+          "name": {
+            "description": "Optional branch/worktree name hint for this variant",
+            "type": "string"
+          },
+          "prompt": {
+            "description": "Optional prompt override for this variant",
+            "type": "string"
+          },
+          "agent": {
+            "description": "Optional agent override for this variant",
+            "type": "string"
+          },
+          "model": {
+            "$ref": "#/components/schemas/AgentManagerModelInput"
+          }
+        }
+      },
+      "AgentManagerCreateInput": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Optional base name used when creating branches/worktrees",
+            "type": "string"
+          },
+          "prompt": {
+            "description": "Initial prompt applied to all variants unless overridden",
+            "type": "string"
+          },
+          "baseBranch": {
+            "description": "Base branch or ref to branch from",
+            "type": "string"
+          },
+          "agent": {
+            "description": "Default agent for all variants",
+            "type": "string"
+          },
+          "model": {
+            "$ref": "#/components/schemas/AgentManagerModelInput"
+          },
+          "versions": {
+            "description": "Optional per-variant configuration",
+            "minItems": 1,
+            "maxItems": 4,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentManagerVersion"
+            }
+          }
+        }
+      },
+      "AgentManagerListOutput": {
+        "type": "object",
+        "properties": {
+          "sessions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentManagerSession"
+            }
+          },
+          "cursor": {
+            "type": "string"
+          }
+        },
+        "required": ["sessions"]
+      },
+      "AgentManagerDetailOutput": {
+        "type": "object",
+        "properties": {
+          "session": {
+            "$ref": "#/components/schemas/AgentManagerSession"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "info": {
+                  "$ref": "#/components/schemas/Message"
+                },
+                "parts": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Part"
+                  }
+                }
+              },
+              "required": ["info", "parts"]
+            }
+          }
+        },
+        "required": ["session", "messages"]
+      },
+      "AgentManagerDiffFile": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["added", "modified", "deleted"]
+          },
+          "additions": {
+            "type": "number"
+          },
+          "deletions": {
+            "type": "number"
+          },
+          "patch": {
+            "type": "string"
+          },
+          "patchTruncated": {
+            "type": "boolean"
+          }
+        },
+        "required": ["path", "status", "additions", "deletions"]
+      },
+      "AgentManagerDiffOutput": {
+        "type": "object",
+        "properties": {
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentManagerDiffFile"
+            }
+          },
+          "summary": {
+            "type": "object",
+            "properties": {
+              "totalFiles": {
+                "type": "number"
+              },
+              "totalAdditions": {
+                "type": "number"
+              },
+              "totalDeletions": {
+                "type": "number"
+              }
+            },
+            "required": ["totalFiles", "totalAdditions", "totalDeletions"]
+          },
+          "cursor": {
+            "type": "string"
+          }
+        },
+        "required": ["files", "summary"]
       },
       "Symbol": {
         "type": "object",

--- a/specs/agent-manager-mcp-plan.md
+++ b/specs/agent-manager-mcp-plan.md
@@ -1,0 +1,333 @@
+# Agent Manager Native Tools + SDK Plan
+
+## Problem
+
+CLI agents in orchestrator mode cannot directly create and manage Agent Manager sessions. Session/worktree orchestration still sits in the VS Code extension. We need one server-owned API that supports:
+
+- launching isolated worktree sessions
+- launching multiple versions in parallel (different models/agents)
+- tracking status
+- reading diffs in a pageable way
+
+The same API should power native CLI tools and SDK clients.
+
+## Goals
+
+1. Native agent tools first (no MCP/security/process complexity in v1)
+2. Server owns lifecycle and state (no duplicated orchestration logic)
+3. Single simple API for single-run and multi-version launches
+4. Multiple versions with per-version model/agent overrides
+5. Agent Manager auto-opens when server-created sessions appear
+
+## Non-Goals
+
+- Merge/apply automation (user applies manually in Agent Manager UI)
+- PR creation endpoints
+- Replacing Agent Manager UI/terminal UX
+
+---
+
+## Architecture
+
+```
+CLI Orchestrator (native tools)
+        |
+        | in-process tool calls
+        v
+kilo serve
+  └─ agent-manager service + routes
+        |
+        ├─ SDK codegen (`script/generate.ts`)
+        |
+        └─ VS Code Agent Manager (migrates to SDK routes)
+```
+
+### Source of truth
+
+The server is the source of truth for managed sessions and worktrees.
+
+- The server decides worktree location and branch naming.
+- The client does **not** compute or own worktree paths.
+- Every create/list/status response returns canonical IDs and metadata.
+
+---
+
+## Canonical Data Model
+
+All managed-session APIs return these IDs and metadata:
+
+```json
+{
+  "sessionID": "session_xxx",
+  "groupID": "group_xxx",
+  "worktree": {
+    "id": "wt_xxx",
+    "path": "/abs/path",
+    "branch": "opencode/feature-a",
+    "baseBranch": "main"
+  },
+  "agent": "code",
+  "model": "provider/model",
+  "label": "variant-a",
+  "status": "busy"
+}
+```
+
+Notes:
+
+- `groupID` is present for multi-version launches and optional for single launches.
+- `worktree.id` is stable and should be used by clients; `worktree.path` is informational.
+
+---
+
+## Phase 1 (Ship First): Server Endpoints + Native Tools
+
+New server route file:
+
+- `packages/opencode/src/kilocode/server/routes/agent-manager.ts`
+
+New shared service:
+
+- `packages/opencode/src/kilocode/agent-manager/service.ts`
+- `packages/opencode/src/kilocode/agent-manager/types.ts`
+
+Native tools call `service.ts` directly. HTTP routes also call `service.ts`.
+
+### API surface (simple + supports multi-version)
+
+#### `POST /agent-manager/session`
+
+Single endpoint for single launch, model variants, and parallel delegated subtasks.
+
+Single launch:
+
+```json
+{
+  "prompt": "implement X",
+  "baseBranch": "main",
+  "agent": "code",
+  "model": "openai/gpt-5.3-codex"
+}
+```
+
+Multi-version launch (same prompt, different models):
+
+```json
+{
+  "prompt": "implement X",
+  "baseBranch": "main",
+  "versions": [
+    { "label": "v1", "model": "openai/gpt-5.3-codex" },
+    { "label": "v2", "model": "anthropic/claude-sonnet-4" },
+    { "label": "v3", "model": "google/gemini-2.5-pro" }
+  ]
+}
+```
+
+Parallel delegated launch (different prompts per agent):
+
+```json
+{
+  "baseBranch": "main",
+  "versions": [
+    {
+      "label": "api",
+      "prompt": "Implement backend API and data model for feature X",
+      "model": "openai/gpt-5.3-codex"
+    },
+    {
+      "label": "ui",
+      "prompt": "Implement UI and client integration for feature X",
+      "model": "anthropic/claude-sonnet-4"
+    },
+    {
+      "label": "tests",
+      "prompt": "Add integration tests and edge-case coverage for feature X",
+      "model": "google/gemini-2.5-pro"
+    }
+  ]
+}
+```
+
+Rules:
+
+- If `versions` is omitted, create one session.
+- If `versions` is present, create one session per version.
+- Top-level `prompt`/`agent`/`model` act as defaults; per-version values override.
+- `versions[].prompt` enables delegated subtasks in one request.
+- `prompt` is optional when every version provides its own prompt.
+- Cap versions per request (recommendation: max 4, aligned with current Agent Manager UX).
+
+Response:
+
+```json
+{
+  "groupID": "group_xxx",
+  "sessions": [
+    {
+      "sessionID": "session_a",
+      "worktree": { "id": "wt_a", "path": "...", "branch": "...", "baseBranch": "main" },
+      "agent": "code",
+      "model": "openai/gpt-5.3-codex",
+      "label": "v1",
+      "status": "busy"
+    }
+  ]
+}
+```
+
+Implementation flow per version:
+
+1. `Worktree.create({ baseBranch })`
+2. `Instance.provide({ directory: worktreePath }, ...)`
+3. `Session.create({ platform: "agent-manager", permission })`
+4. Resolve per-version input:
+   - `resolvedPrompt = version.prompt ?? input.prompt`
+   - `resolvedAgent = version.agent ?? input.agent`
+   - `resolvedModel = version.model ?? input.model`
+5. `SessionPrompt.prompt(sessionID, resolvedPrompt, { agent: resolvedAgent, model: resolvedModel })` (async)
+6. Emit `agent-manager.session.created`
+
+#### `GET /agent-manager/session`
+
+List managed sessions with filters.
+
+Query params:
+
+- `groupID?`
+- `status?` (`idle|busy|error`)
+- `limit?`
+- `cursor?`
+
+Response includes `sessionID`, `groupID`, `worktree`, `agent`, `model`, `label`, `status`, `time`.
+
+#### `GET /agent-manager/session/:id`
+
+Detailed session view.
+
+Response includes:
+
+- canonical metadata (`sessionID`, `groupID`, `worktree`, etc.)
+- `status`
+- latest messages (bounded)
+
+#### `DELETE /agent-manager/session/:id`
+
+Abort running session (if needed) and remove worktree.
+
+#### `GET /agent-manager/session/:id/diff`
+
+Pageable diff endpoint to keep context usage bounded.
+
+Query params:
+
+- `cursor?`
+- `limit?` (default 20)
+- `includePatch?` (default `false`)
+
+Response:
+
+```json
+{
+  "files": [
+    {
+      "path": "src/foo.ts",
+      "status": "modified",
+      "additions": 10,
+      "deletions": 2,
+      "patch": "...optional/truncated...",
+      "patchTruncated": true
+    }
+  ],
+  "summary": { "totalFiles": 3, "totalAdditions": 22, "totalDeletions": 5 },
+  "cursor": "next_cursor"
+}
+```
+
+Default behavior (`includePatch=false`) returns metadata-only file list for low token usage.
+
+---
+
+## Native Tool Surface
+
+New tool files in `packages/opencode/src/kilocode/tool/`:
+
+- `agent-session-create.ts` / `.txt`
+- `agent-session-list.ts` / `.txt`
+- `agent-session-status.ts` / `.txt`
+- `agent-session-cancel.ts` / `.txt`
+- `agent-session-diff.ts` / `.txt`
+
+### Tool contracts
+
+`agent_session_create` supports both single and multi-version input:
+
+```json
+{
+  "prompt": "...",
+  "baseBranch": "main",
+  "versions": [
+    { "label": "api", "prompt": "build backend for X", "model": "..." },
+    { "label": "ui", "prompt": "build frontend for X", "model": "..." },
+    { "label": "tests", "prompt": "add tests for X", "model": "..." }
+  ]
+}
+```
+
+This is enough for "feature X with 2-3 agents in parallel": one tool call can start all agents, each in its own worktree, with distinct prompts and models.
+
+Other tools stay simple:
+
+- `agent_session_list({ groupID?, status?, limit?, cursor? })`
+- `agent_session_status({ sessionID })`
+- `agent_session_cancel({ sessionID })`
+- `agent_session_diff({ sessionID, cursor?, limit?, includePatch? })`
+
+Register in `packages/opencode/src/tool/registry.ts` and allow in orchestrator permissions in `packages/opencode/src/agent/agent.ts`.
+
+---
+
+## Orchestrator Behavior
+
+Update `packages/opencode/src/agent/prompt/orchestrator.txt` so the model uses multi-version launches correctly.
+
+Expected pattern:
+
+1. Call `agent_session_create` once with `versions[]` when asking for multiple implementations/models.
+   - For delegated parallel work, set different `versions[].prompt` values.
+2. Poll with `agent_session_list` (optionally by `groupID`).
+3. Inspect each with `agent_session_diff` (metadata first, patch only when needed).
+4. If corrections are needed in v1, cancel and relaunch a variant.
+5. Report options to user for manual apply in Agent Manager UI.
+
+---
+
+## VS Code: Auto-Open Agent Manager
+
+Requirement: if agent-session tools are used and Agent Manager is not open, open it automatically.
+
+### Mechanism
+
+1. Server emits `agent-manager.session.created` (with `sessionID`, `groupID`, `worktree.id`, `worktree.path`, `branch`, `baseBranch`, `model`, `label`).
+2. Extension listens to this event in `AgentManagerProvider`.
+3. On event:
+   - call `openPanel()`
+   - register/adopt the session in local state by `worktree.id` + `sessionID`
+   - call `registerWorktreeSession(sessionID, worktree.path)`
+   - `pushState()`
+4. On panel initialization, call `client.agentManager.session.list()` and adopt any missing sessions.
+
+This guarantees visibility for server-created sessions even when the panel was closed.
+
+---
+
+## Implementation Order
+
+1. Add `agent-manager/service.ts` + `types.ts`
+2. Add agent-manager server routes
+3. Run `script/generate.ts` (SDK regen)
+4. Add native tools + registry + orchestrator permissions
+5. Add SSE event + extension auto-open/adopt behavior
+6. Add multi-version support end-to-end (`versions[]`, `groupID`)
+
+V1 is complete after steps 1-6: native CLI tools can launch single or multi-version sessions with different models, and Agent Manager opens automatically and tracks them.


### PR DESCRIPTION
 Proposal Demo PR
 
 ## Summary

Adds native agent session management tools to the CLI, allowing the orchestrator to create, monitor, and manage parallel agent sessions on isolated git worktrees — directly as tool calls, without requiring external MCP servers.

## What this enables

The orchestrator agent can now:
- Launch multiple parallel agent sessions, each in its own git worktree
- Use `versions[]` to run the same prompt across different models, or different prompts across different agents
- Monitor session progress via `agent_session_list` and `agent_session_status`
- Inspect diffs with pagination via `agent_session_diff`
- Cancel sessions and clean up worktrees via `agent_session_cancel`

Server-created sessions automatically appear in the VS Code Agent Manager panel via SSE events.

## Architecture

```
CLI Orchestrator (native tools)
        |
        | in-process tool calls
        v
kilo serve
  └─ AgentManagerService + HTTP routes
        |
        ├─ SDK codegen (auto-generated)
        |
        └─ VS Code Agent Manager (auto-adopts sessions)
```

The server owns session lifecycle and state. The same service powers both the native tools (in-process) and the HTTP API (for SDK clients).

## New tools (orchestrator-only)

| Tool | Purpose |
|---|---|
| `agent_session_create` | Create one or more sessions on isolated worktrees |
| `agent_session_list` | List sessions with group/status filters |
| `agent_session_status` | Get session detail with recent messages |
| `agent_session_cancel` | Abort session and remove worktree |
| `agent_session_diff` | Paginated diff for a session |

## New server endpoints

| Method | Path | Description |
|---|---|---|
| POST | `/agent-manager/session` | Create managed sessions |
| GET | `/agent-manager/session` | List managed sessions |
| GET | `/agent-manager/session/:id` | Session detail + messages |
| DELETE | `/agent-manager/session/:id` | Cancel and cleanup |
| GET | `/agent-manager/session/:id/diff` | Paginated diff |

## Key implementation details

- Worktree creation waits for full bootstrap (`worktree.ready` event) before starting sessions, preventing Instance cache poisoning
- Per-version `prompt`, `model`, and `agent` overrides supported
- Failed prompt starts are tracked in the session store and surfaced as `error` status
- `agent-manager.session.created` SSE event triggers auto-open of Agent Manager panel in VS Code
- Extension syncs managed sessions from server on panel load