### PR TITLE
fix: improve Agent Manager i18n translation quality

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -131,10 +131,10 @@ export const dict = {
   "agentManager.review.sendToChat": "Pošalji u chat",
   "agentManager.review.collapsedOnly": "{{count}} sažeto",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} sažeto, {{large}} velikih",
-  "agentManager.review.largeFileCollapsed": "Velika datoteka (skupljeno)",
-  "agentManager.review.endOfLongDiff": "Stigli ste do kraja!",
+  "agentManager.review.largeFileCollapsed": "Velika datoteka (sažeto)",
+  "agentManager.review.endOfLongDiff": "Došli ste do kraja!",
 
-  "agentManager.import.pullRequest": "Zahtjev za povlačenje",
+  "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Zalijepite PR URL...",
   "agentManager.import.open": "Otvori",
   "agentManager.import.branches": "Branchevi",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -131,10 +131,10 @@ export const dict = {
   "agentManager.review.sendToChat": "Send til chat",
   "agentManager.review.collapsedOnly": "{{count}} foldet sammen",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} foldet sammen, {{large}} store",
-  "agentManager.review.largeFileCollapsed": "Stor fil (kollapset)",
-  "agentManager.review.endOfLongDiff": "Du er nået til slutningen!",
+  "agentManager.review.largeFileCollapsed": "Stor fil (sammenklappet)",
+  "agentManager.review.endOfLongDiff": "Du nåede slutningen!",
 
-  "agentManager.import.pullRequest": "Fletteanmodning",
+  "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Indsæt PR URL...",
   "agentManager.import.open": "Åbn",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -132,10 +132,10 @@ export const dict = {
   "agentManager.review.sendToChat": "An Chat senden",
   "agentManager.review.collapsedOnly": "{{count}} eingeklappt",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} eingeklappt, {{large}} groß",
-  "agentManager.review.largeFileCollapsed": "Große Datei (zugeklappt)",
+  "agentManager.review.largeFileCollapsed": "Große Datei (eingeklappt)",
   "agentManager.review.endOfLongDiff": "Du hast das Ende erreicht!",
 
-  "agentManager.import.pullRequest": "Zusammenführungsanfrage",
+  "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "PR-URL einfügen...",
   "agentManager.import.open": "Öffnen",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -133,9 +133,9 @@ export const dict = {
   "agentManager.review.collapsedOnly": "{{count}} contraídos",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} contraídos, {{large}} grandes",
   "agentManager.review.largeFileCollapsed": "Archivo grande (contraído)",
-  "agentManager.review.endOfLongDiff": "¡Has llegado al final!",
+  "agentManager.review.endOfLongDiff": "¡Llegaste al final!",
 
-  "agentManager.import.pullRequest": "Solicitud de extracción",
+  "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Pegar URL del PR...",
   "agentManager.import.open": "Abrir",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -133,10 +133,10 @@ export const dict = {
   "agentManager.review.sendToChat": "Envoyer au chat",
   "agentManager.review.collapsedOnly": "{{count}} repliés",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} repliés, {{large}} volumineux",
-  "agentManager.review.largeFileCollapsed": "Fichier volumineux (réduit)",
+  "agentManager.review.largeFileCollapsed": "Fichier volumineux (replié)",
   "agentManager.review.endOfLongDiff": "Vous êtes arrivé à la fin !",
 
-  "agentManager.import.pullRequest": "Demande d'extraction",
+  "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Coller l'URL du PR...",
   "agentManager.import.open": "Ouvrir",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -133,10 +133,10 @@ export const dict = {
   "agentManager.review.sendToChat": "チャットに送信",
   "agentManager.review.collapsedOnly": "{{count}} 件折りたたみ",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} 件折りたたみ、{{large}} 件がサイズ大",
-  "agentManager.review.largeFileCollapsed": "大きなファイル (折りたたみ済み)",
+  "agentManager.review.largeFileCollapsed": "大きなファイル（折りたたみ）",
   "agentManager.review.endOfLongDiff": "最後まで到達しました！",
 
-  "agentManager.import.pullRequest": "プルリクエスト",
+  "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "PR URLを貼り付け...",
   "agentManager.import.open": "開く",
   "agentManager.import.branches": "ブランチ",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -132,10 +132,10 @@ export const dict = {
   "agentManager.review.sendToChat": "채팅으로 보내기",
   "agentManager.review.collapsedOnly": "{{count}}개 접힘",
   "agentManager.review.collapsedWithLarge": "{{collapsed}}개 접힘, {{large}}개 대용량",
-  "agentManager.review.largeFileCollapsed": "큰 파일 (접힘)",
-  "agentManager.review.endOfLongDiff": "끝까지 확인하셨습니다!",
+  "agentManager.review.largeFileCollapsed": "큰 파일(접힘)",
+  "agentManager.review.endOfLongDiff": "끝까지 도달했습니다!",
 
-  "agentManager.import.pullRequest": "풀 리퀘스트",
+  "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "PR URL 붙여넣기...",
   "agentManager.import.open": "열기",
   "agentManager.import.branches": "브랜치",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -131,10 +131,10 @@ export const dict = {
   "agentManager.review.sendToChat": "Send til chat",
   "agentManager.review.collapsedOnly": "{{count}} kollapset",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} kollapset, {{large}} store",
-  "agentManager.review.largeFileCollapsed": "Stor fil (kollapset)",
-  "agentManager.review.endOfLongDiff": "Du har nådd slutten!",
+  "agentManager.review.largeFileCollapsed": "Stor fil (sammenfoldet)",
+  "agentManager.review.endOfLongDiff": "Du nådde slutten!",
 
-  "agentManager.import.pullRequest": "Fletteforespørsel",
+  "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "Lim inn PR URL...",
   "agentManager.import.open": "Åpne",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -132,10 +132,10 @@ export const dict = {
   "agentManager.review.sendToChat": "ส่งไปยังแชท",
   "agentManager.review.collapsedOnly": "ยุบ {{count}} รายการ",
   "agentManager.review.collapsedWithLarge": "ยุบ {{collapsed}} รายการ, ขนาดใหญ่ {{large}} รายการ",
-  "agentManager.review.largeFileCollapsed": "ไฟล์ขนาดใหญ่ (ย่อไว้)",
-  "agentManager.review.endOfLongDiff": "คุณมาถึงส่วนท้ายแล้ว!",
+  "agentManager.review.largeFileCollapsed": "ไฟล์ขนาดใหญ่ (พับอยู่)",
+  "agentManager.review.endOfLongDiff": "คุณมาถึงท้ายสุดแล้ว!",
 
-  "agentManager.import.pullRequest": "คำขอดึง",
+  "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "วาง URL ของ PR...",
   "agentManager.import.open": "เปิด",
   "agentManager.import.branches": "Branches",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -131,9 +131,9 @@ export const dict = {
   "agentManager.review.collapsedOnly": "{{count}} 个已折叠",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} 个已折叠，{{large}} 个过大",
   "agentManager.review.largeFileCollapsed": "大文件（已折叠）",
-  "agentManager.review.endOfLongDiff": "您已到达末尾！",
+  "agentManager.review.endOfLongDiff": "你已经到末尾了！",
 
-  "agentManager.import.pullRequest": "拉取请求",
+  "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "粘贴 PR URL...",
   "agentManager.import.open": "打开",
   "agentManager.import.branches": "分支",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -130,10 +130,10 @@ export const dict = {
   "agentManager.review.sendToChat": "傳送到聊天",
   "agentManager.review.collapsedOnly": "{{count}} 個已摺疊",
   "agentManager.review.collapsedWithLarge": "{{collapsed}} 個已摺疊，{{large}} 個過大",
-  "agentManager.review.largeFileCollapsed": "大檔案（已摺疊）",
-  "agentManager.review.endOfLongDiff": "您已到達底部！",
+  "agentManager.review.largeFileCollapsed": "大型檔案（已摺疊）",
+  "agentManager.review.endOfLongDiff": "你已經到最後了！",
 
-  "agentManager.import.pullRequest": "拉取請求",
+  "agentManager.import.pullRequest": "Pull Request",
   "agentManager.import.pastePrUrl": "貼上 PR URL...",
   "agentManager.import.open": "開啟",
   "agentManager.import.branches": "分支",


### PR DESCRIPTION
## Summary

- Keep "Pull Request" untranslated across all 11 non-English locales (bs, da, de, es, fr, ja, ko, no, th, zh, zht) since it's a universally-recognized developer term
- Fix `largeFileCollapsed` parenthetical wording for more accurate translations in 9 locales
- Improve `endOfLongDiff` phrasing for more natural tone in 8 locales

No new keys added, no keys removed, no structural changes — only string value improvements.