### PR TITLE
feat(agent-manager): add rename hint to worktree hover card

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2150,6 +2150,11 @@ const AgentManagerContent: Component = () => {
                                     </Show>
                                   )
                                 })()}
+                                <div class="am-hover-card-divider" />
+                                <div class="am-hover-card-hint">
+                                  <Icon name="edit" size="small" />
+                                  <span>{t("agentManager.worktree.doubleClickRename")}</span>
+                                </div>
                               </div>
                             </HoverCard>
                           </>

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2042,6 +2042,18 @@ button.am-section-toggle:hover .am-section-label {
   justify-content: flex-start;
 }
 
+.am-hover-card-hint {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-weaker);
+  font-size: 11px;
+}
+
+.am-hover-card-hint [data-component="icon"] {
+  opacity: 0.8;
+}
+
 /* Keyboard shortcuts dialog */
 
 .am-shortcuts {


### PR DESCRIPTION
## Summary

- Adds a "Double-click to rename" hint with an edit icon at the bottom of the worktree hover card in the Agent Manager sidebar
- Reuses the existing `agentManager.worktree.doubleClickRename` translation key, already localized in all 16 languages
- Adds `.am-hover-card-hint` CSS class for consistent styling

<img width="598" height="337" alt="image" src="https://github.com/user-attachments/assets/25841b07-7ef7-4fe7-ad9f-9792aac8bed7" />
