### PR TITLE
fix: prevent permission prompts from interrupting auto-scroll

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -87,7 +87,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                 />
                 <Show when={perm()} keyed>
                   {(p) => (
-                    <div data-component="permission-prompt">
+                    <div data-component="permission-prompt" onClick={(e: MouseEvent) => e.stopPropagation()}>
                       <Show when={p.patterns.length > 0}>
                         <div class="permission-dock-patterns">
                           <For each={p.patterns}>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -3,7 +3,7 @@
  * Main chat container that combines all chat components
  */
 
-import { Component, For, Show, createSignal, onCleanup, onMount } from "solid-js"
+import { Component, For, Show, createSignal, createEffect, on, onCleanup, onMount } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { BasicTool } from "@kilocode/kilo-ui/basic-tool"
 import { TaskHeader } from "./TaskHeader"
@@ -31,6 +31,17 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   const questionRequest = () => sessionQuestions().find((q) => !q.tool)
   const permissionRequest = () => sessionPermissions().find((p) => !p.tool)
   const blocked = () => sessionPermissions().length > 0 || sessionQuestions().length > 0
+
+  // When a bottom-dock permission/question disappears while the session is busy,
+  // the scroll container grows taller. Dispatch a custom event so MessageList can
+  // resume auto-scroll.
+  createEffect(
+    on(blocked, (isBlocked, wasBlocked) => {
+      if (wasBlocked && !isBlocked && !idle()) {
+        window.dispatchEvent(new CustomEvent("resumeAutoScroll"))
+      }
+    }),
+  )
 
   const [responding, setResponding] = createSignal(false)
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -7,7 +7,7 @@
  * Shows recent sessions in the empty state for quick resumption.
  */
 
-import { Component, For, Show, createEffect, createMemo, JSX } from "solid-js"
+import { Component, For, Show, createEffect, createMemo, onCleanup, JSX } from "solid-js"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { Button } from "@kilocode/kilo-ui/button"
 import { useDialog } from "@kilocode/kilo-ui/context/dialog"
@@ -47,6 +47,11 @@ export const MessageList: Component<MessageListProps> = (props) => {
     working: () => session.status() !== "idle",
     overflowAnchor: "dynamic",
   })
+
+  // Resume auto-scroll when a bottom-dock permission/question is dismissed
+  const onResumeAutoScroll = () => autoScroll.resume()
+  window.addEventListener("resumeAutoScroll", onResumeAutoScroll)
+  onCleanup(() => window.removeEventListener("resumeAutoScroll", onResumeAutoScroll))
 
   let loaded = false
   createEffect(() => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -148,7 +148,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
   }
 
   return (
-    <div data-component="tool-part-wrapper" data-question="true">
+    <div data-component="tool-part-wrapper" data-question="true" onClick={(e: MouseEvent) => e.stopPropagation()}>
       <div data-component="question-prompt">
         <div data-slot="question-body">
           <div data-slot="question-header">


### PR DESCRIPTION
## Summary
- Stop inline permission/question button clicks from bubbling up to the message list's `handleInteraction`, which was disabling auto-scroll
- Resume auto-scroll when bottom-dock permission/question prompts disappear during an active session by dispatching a `resumeAutoScroll` custom event

Closes #6621

## Test plan
- [x] Start a task that triggers permission prompts (e.g., file edit requiring approval)
- [x] Click "Allow Once" and verify output continues auto-scrolling
- [x] Test with both inline tool permissions and bottom-dock permissions
- [x] Verify manually scrolling up still correctly pauses auto-scroll
- [x] Verify the "scroll to bottom" button still works