### PR TITLE
fix: inherit font-family on button elements in agent manager sidebar

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -37,6 +37,7 @@
   width: 100%;
   text-align: left;
   color: var(--text-base);
+  font-family: inherit;
   font-size: var(--font-size-base);
   flex-shrink: 0;
 }
@@ -50,15 +51,17 @@
 }
 
 .am-local-item-active {
-  background: var(--surface-base-active);
+  background: var(--surface-interactive-base);
+  color: var(--text-on-interactive-base);
 }
 
 .am-local-item-active .am-local-icon {
-  color: var(--text-base);
+  color: var(--text-on-interactive-base);
 }
 
 .am-local-item-active .am-local-branch {
-  color: var(--text-weak);
+  color: var(--text-on-interactive-base);
+  opacity: 0.7;
 }
 
 .am-local-item-active .am-stat-files {
@@ -469,6 +472,7 @@ button.am-section-toggle:hover .am-section-label {
   width: 100%;
   text-align: left;
   color: var(--text-base);
+  font-family: inherit;
   font-size: var(--font-size-base);
 }
 
@@ -481,8 +485,8 @@ button.am-section-toggle:hover .am-section-label {
 }
 
 .am-item-active {
-  background: var(--surface-base-active);
-  color: var(--text-base);
+  background: var(--surface-interactive-base);
+  color: var(--text-on-interactive-base);
 }
 
 .am-item-title {
@@ -502,7 +506,8 @@ button.am-section-toggle:hover .am-section-label {
 }
 
 .am-item-active .am-item-time {
-  color: var(--text-weaker);
+  color: var(--text-on-interactive-base);
+  opacity: 0.7;
 }
 
 /* Promote button on session rows */


### PR DESCRIPTION
## Summary
- Adds `font-family: inherit` to `.am-local-item` and `.am-item` button elements in the agent manager sidebar
- Browser default: `<button>` elements don't inherit `font-family`, so they render with the system form-control font instead of the theme's sans-serif font
- Worktree items use `<div>` elements which inherit font naturally — this fix makes the local session and session list items consistent with them

Before:
<img width="730" height="222" alt="image" src="https://github.com/user-attachments/assets/ae090635-72e3-40a2-bf57-c9f6233eefc9" />

After:
<img width="738" height="174" alt="image" src="https://github.com/user-attachments/assets/9eb6c5c9-a604-4b6b-bb17-2b8543e4ef18" />
