### PR TITLE
docs: Issue triage findings for P0/P1 issues

### DIFF
--- a/github/issue-triage/6064.md
+++ b/github/issue-triage/6064.md
@@ -1,0 +1,76 @@
+# Issue #6064: [FEATURE]: Autocomplete (VSCode Extension)
+
+**Priority:** P1
+**Board Status:** Ready
+**Verdict:** FIXED
+
+## Issue Summary
+
+The feature request (filed 2026-02-08 by `lambertjosh`) asks for inline autocomplete support within the Kilo Code VS Code extension — i.e. AI-powered fill-in-the-middle (FIM) completions that appear as ghost text while editing.
+
+## Investigation
+
+A comprehensive autocomplete subsystem exists under `packages/kilo-vscode/src/services/autocomplete/`. It is fully wired into the extension activation path and has extensive test coverage. Key components found:
+
+| File | Role |
+|------|------|
+| [`AutocompleteServiceManager.ts`](packages/kilo-vscode/src/services/autocomplete/AutocompleteServiceManager.ts) | Singleton orchestrator — manages settings, snooze, status bar, provider registration |
+| [`AutocompleteInlineCompletionProvider.ts`](packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts) | Implements `vscode.InlineCompletionItemProvider` — provides ghost-text completions |
+| [`AutocompleteModel.ts`](packages/kilo-vscode/src/services/autocomplete/AutocompleteModel.ts) | Resolves the AI provider/model to use for completions |
+| [`AutocompleteCodeActionProvider.ts`](packages/kilo-vscode/src/services/autocomplete/AutocompleteCodeActionProvider.ts) | Code action integration |
+| [`AutocompleteStatusBar.ts`](packages/kilo-vscode/src/services/autocomplete/AutocompleteStatusBar.ts) | Status bar widget showing enable/snooze state and session cost |
+| [`HoleFiller.ts`](packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/HoleFiller.ts) | FIM prompt construction and response parsing |
+| [`ChatTextAreaAutocomplete.ts`](packages/kilo-vscode/src/services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete.ts) | Chat textarea autocomplete (separate from inline) |
+| [`index.ts`](packages/kilo-vscode/src/services/autocomplete/index.ts) | `registerAutocompleteProvider()` — called from `extension.ts` on activation |
+
+### Registration in extension.ts
+
+[`extension.ts`](packages/kilo-vscode/src/extension.ts:145) calls:
+```ts
+registerAutocompleteProvider(context, connectionService)
+```
+
+This registers the `vscode.InlineCompletionItemProvider` for all `file`-scheme documents, as well as VS Code commands (`kilo-code.new.autocomplete.generateSuggestions`, `.disable`, `.reload`, etc.).
+
+### Recent activity
+
+Recent commits show active maintenance and enhancement of this feature:
+- `d6bef71c1` – `feat(autocomplete): abort stale FIM requests on new keystrokes`
+- `2a9e77054` – `refactor(autocomplete): use SDK client for FIM completion instead of manual fetch`
+- `645fabc5a` – `fix(autocomplete): restore OpenAI-compatible SSE chunk parsing in FIM completion`
+- Several test extraction and coverage commits
+
+## Evidence
+
+```
+packages/kilo-vscode/src/services/autocomplete/
+├── AutocompleteServiceManager.ts          # Singleton orchestrator
+├── AutocompleteModel.ts                   # Provider/model resolution
+├── AutocompleteCodeActionProvider.ts      # Code actions
+├── AutocompleteStatusBar.ts               # Status bar
+├── classic-auto-complete/
+│   ├── AutocompleteInlineCompletionProvider.ts   # InlineCompletionItemProvider impl
+│   ├── HoleFiller.ts                             # FIM prompt builder
+│   ├── FillInTheMiddle.ts                        # FIM utilities
+│   └── ...
+├── chat-autocomplete/
+│   └── ChatTextAreaAutocomplete.ts
+└── continuedev/                          # Vendored ContinueDev autocomplete core
+```
+
+The `AutocompleteServiceManager` registers a `vscode.languages.registerInlineCompletionItemProvider` for `{ scheme: "file" }` (line 123 of `AutocompleteServiceManager.ts`), which is the standard VS Code mechanism for ghost-text completions.
+
+Configuration is exposed under `kilo-code.new.autocomplete` with settings for `enableAutoTrigger`, `enableSmartInlineTaskKeybinding`, `enableChatAutocomplete`, and `snoozeUntil`.
+
+## Recommendation
+
+This issue should be **closed**. The feature requested (autocomplete in the VS Code extension) is fully implemented, actively maintained, and wired into the extension activation path. The implementation includes:
+
+- Inline (ghost-text) completions via `vscode.InlineCompletionItemProvider`
+- Manual trigger keybinding
+- Enable/disable/snooze controls
+- Status bar integration
+- Chat textarea autocomplete
+- Extensive unit test coverage
+
+If further work is desired (e.g. specific model support, UX improvements, or settings documentation), a new, more specific issue should be filed.

--- a/github/issue-triage/6068.md
+++ b/github/issue-triage/6068.md
@@ -1,0 +1,63 @@
+# Issue #6068: [FEATURE]: Implement Provider Settings (VSCode Extension)
+
+**Priority:** P1
+**Board Status:** Backlog
+**Verdict:** PARTIALLY FIXED
+
+## Issue Summary
+
+The issue requests implementing provider settings in the VSCode extension's UI, following a Figma design. The design includes provider configuration screens, API key management, and model selection. The specific ask is to allow configuring providers supported by the CLI from within the extension.
+
+A comment from `@lambertjosh` narrowed the scope to provider settings and noted providers should use their "longer form" display names.
+
+## Investigation
+
+A `ProvidersTab` component exists at [`packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx`](packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx) that provides:
+
+1. **Default model selection** — a `ModelSelectorBase` dropdown for selecting the primary model (`config.model`)
+2. **Small model selection** — a `ModelSelectorBase` dropdown for secondary/small model (`config.small_model`)
+3. **Disabled providers** — a list UI to add providers to a "disabled" allowlist
+4. **Enabled providers (allowlist)** — a list UI to restrict to specific providers
+
+The tab is wired up into [`packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx`](packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx) and uses the real backend via `useProvider()` context that fetches from `client.provider.list()`.
+
+Additionally, a visual regression snapshot exists at `packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/settings/providers-configure-chromium-linux.png` confirming the tab is rendered in tests.
+
+**What is NOT implemented:**
+- Per-provider API key configuration (entering and storing API keys for individual providers)
+- Provider-specific settings (base URL overrides, custom headers, etc.)
+- The "longer form" display names for providers (still uses raw provider IDs as labels)
+
+The comment from `@lambertjosh` specifically called out using longer provider names and references the Figma design at `https://www.figma.com/design/YpH0kLX0GHixwAaUvTvBkb/KiloCode---VS-Studio?node-id=2128-17927`
+
+Git log shows a relevant PR referenced in comments: `https://github.com/Kilo-Org/kilo/pull/272` (first big step).
+
+## Evidence
+
+```tsx
+// packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx
+const ProvidersTab: Component = () => {
+  const { config, updateConfig } = useConfig()
+  const provider = useProvider()
+  // ...
+  const providerOptions = createMemo<ProviderOption[]>(() =>
+    Object.keys(provider.providers())
+      .sort()
+      .map((id) => ({ value: id, label: id })),  // ← Uses raw ID, not "longer form" names
+  )
+  // ...
+  // Model selection, enabled/disabled providers — but NO API key management
+}
+```
+
+The `git log` search for provider API key UI found no results in the settings components.
+
+## Recommendation
+
+This issue is **PARTIALLY FIXED**. The basic provider settings tab (model selection, enable/disable providers) is implemented. However:
+
+1. Per-provider API key configuration is absent — users cannot enter API keys in the UI
+2. Provider display names still use raw IDs (not the "longer form" names requested)
+3. The full Figma design likely includes more detailed per-provider configuration
+
+This issue should remain **OPEN**. The assignee (`@catrielmuller`) should implement API key management UI and improve provider display names before considering it done.

--- a/github/issue-triage/6074.md
+++ b/github/issue-triage/6074.md
@@ -1,0 +1,84 @@
+# Issue #6074: [VSCode][Feature] Use correct default model
+
+**Priority:** P1
+**Board Status:** In progress
+**Verdict:** NOT FIXED
+
+## Issue Summary
+
+The new VSCode extension hardcodes `kilo/auto` as the default model instead of using the same default model logic as the CLI or the Roo-based extension. Users who have a preferred model (e.g., Claude Opus) find it reset to `kilo/auto` at the start of each session.
+
+The comments confirm this is actively broken: `@markijbema` tested and confirmed it always uses `kilo/auto` even when the user's default model is set to something else (e.g., Opus).
+
+## Investigation
+
+### How `defaultSelection` is computed:
+
+In [`packages/kilo-vscode/src/KiloProvider.ts`](packages/kilo-vscode/src/KiloProvider.ts:996), the `defaultSelection` sent to the webview is read from VS Code settings with hardcoded defaults:
+
+```ts
+const config = vscode.workspace.getConfiguration("kilo-code.new.model")
+const providerID = config.get<string>("providerID", "kilo")
+const modelID = config.get<string>("modelID", "kilo/auto")
+
+const message = {
+  type: "providersLoaded",
+  providers: normalized,
+  connected: response.connected,
+  defaults: response.default,
+  defaultSelection: { providerID, modelID },
+}
+```
+
+The backend's `response.default` map is sent but NOT used to derive `defaultSelection`. If the user hasn't explicitly set `kilo-code.new.model.providerID` and `kilo-code.new.model.modelID` in their VS Code settings, it falls back to `kilo/kilo/auto`.
+
+### Frontend state:
+
+In [`packages/kilo-vscode/webview-ui/src/context/provider.tsx`](packages/kilo-vscode/webview-ui/src/context/provider.tsx:23), the initial state is:
+
+```ts
+const KILO_AUTO: ModelSelection = { providerID: "kilo", modelID: "kilo/auto" }
+// ...
+const [defaultSelection, setDefaultSelection] = createSignal<ModelSelection>(KILO_AUTO)
+```
+
+And per-session model selection in [`packages/kilo-vscode/webview-ui/src/context/session.tsx`](packages/kilo-vscode/webview-ui/src/context/session.tsx:231) falls back to `provider.defaultSelection()`:
+
+```ts
+getSessionModel: (sessionID: string) => store.modelSelections[sessionID] ?? provider.defaultSelection(),
+```
+
+### The fix that exists:
+
+The `ProvidersTab.tsx` allows users to set a default model stored in config. But that config setting (`config.model`) is NOT used as the `defaultSelection` in `KiloProvider.ts` — it uses the VS Code settings namespace `kilo-code.new.model.providerID/modelID` instead.
+
+### Outstanding issues per PR #6131 (now closed/unmerged):
+
+A PR #6131 attempting to fix this was opened but closed. It aimed to "remove the hardcoded `kilo/kilo/auto` default path by using explicit user override only when set, otherwise resolving from backend provider defaults."
+
+## Evidence
+
+From `KiloProvider.ts` line 996-1003:
+```ts
+const config = vscode.workspace.getConfiguration("kilo-code.new.model")
+const providerID = config.get<string>("providerID", "kilo")
+const modelID = config.get<string>("modelID", "kilo/auto")
+// ...
+defaultSelection: { providerID, modelID },
+```
+
+The backend `response.default` contains the correct default model from the CLI config, but it is not used.
+
+## Recommendation
+
+This issue is **NOT FIXED**. The root cause is clear:
+
+1. `KiloProvider.ts` does not consult `response.default` (the CLI-derived default) when constructing `defaultSelection`
+2. The config set via `ProvidersTab.tsx` (`config.model`) is also not used here
+
+The fix requires updating `KiloProvider.ts` to check (in order of priority):
+1. The user's `config.model` from the CLI config (already fetched in `response`)
+2. The backend provider defaults (`response.default`)
+3. Only fall back to `kilo/auto` if neither is set
+
+This issue should remain **OPEN** until the default model logic is corrected.

--- a/github/issue-triage/6082.md
+++ b/github/issue-triage/6082.md
@@ -1,0 +1,59 @@
+# Issue #6082: [FEATURE]: Implement anonymous signin prompts (VSCode)
+
+**Priority:** P1
+**Board Status:** In progress
+**Verdict:** NOT FIXED
+
+## Issue Summary
+
+The issue requests implementing signup/sign-in prompts for anonymous (unauthenticated) users in the new VSCode extension when they:
+1. Try to use a paid model
+2. Exceed 100 messages
+
+The request is to copy the messaging from the existing Roo-based VSCode extension.
+
+The issue itself was flagged by the compliance bot for a title mismatch (the original title referenced "Add support for passing highlighted content to model when editing"), but the content is clear. The issue is assigned to `@imanolmzd-svg`.
+
+## Investigation
+
+A thorough search of the codebase found **no implementation** of anonymous sign-in prompts or message limit enforcement in the new VSCode extension.
+
+### What was searched:
+- `packages/kilo-vscode/webview-ui/src/components/` — for any dialog, prompt, or banner that triggers on anonymous usage or message limits
+- `packages/kilo-vscode/src/` — for extension-side detection of anonymous users, paid model attempts, or message count thresholds
+- i18n strings in `packages/kilo-vscode/webview-ui/src/i18n/en.ts` — found only `dialog.model.unpaid.freeModels.title` and `dialog.model.unpaid.addMore.title` keys, but no component rendering these strings was found
+- Git log for "anonymous", "signup", "sign-in", "#6082"
+
+### Existing sign-in infrastructure:
+A `DeviceAuthCard` component exists in [`packages/kilo-vscode/webview-ui/src/components/profile/DeviceAuthCard.tsx`](packages/kilo-vscode/webview-ui/src/components/profile/DeviceAuthCard.tsx) and a `ProfileView` at [`packages/kilo-vscode/webview-ui/src/components/profile/ProfileView.tsx`](packages/kilo-vscode/webview-ui/src/components/profile/ProfileView.tsx), which handle the sign-in flow if a user actively navigates to the profile section. However, **there is no proactive prompt** that appears when an anonymous user tries to use a paid model or hits a message limit.
+
+A general notification system exists via [`packages/kilo-vscode/webview-ui/src/components/chat/KiloNotifications.tsx`](packages/kilo-vscode/webview-ui/src/components/chat/KiloNotifications.tsx) that can display banner notifications from the backend, but it is not wired to trigger anonymous-user-specific sign-in prompts.
+
+### Relevant i18n keys found but unused:
+```ts
+// packages/kilo-vscode/webview-ui/src/i18n/en.ts
+"dialog.model.unpaid.freeModels.title": "Free models provided by Kilo",
+"dialog.model.unpaid.addMore.title": "Add more models from popular providers",
+```
+These keys exist but no dialog or component currently renders them in context.
+
+## Evidence
+
+No sign-in prompt components found for anonymous users. Search result:
+```
+packages/kilo-vscode/webview-ui/src/i18n/en.ts:113:  "dialog.model.unpaid.freeModels.title": "Free models provided by Kilo",
+packages/kilo-vscode/webview-ui/src/i18n/en.ts:114:  "dialog.model.unpaid.addMore.title": "Add more models from popular providers",
+```
+
+No corresponding component consumes these keys currently in the main UI flow.
+
+## Recommendation
+
+This issue is **NOT FIXED**. The anonymous sign-in prompt feature is entirely unimplemented in the new VSCode extension. The work needed includes:
+
+1. Detecting when an anonymous user selects or attempts to use a paid model
+2. Detecting when the 100-message limit is reached
+3. Rendering a contextual prompt (modal, banner, or inline notice) with a sign-in CTA
+4. Potentially wiring through the KiloNotifications system or a dedicated dialog
+
+The assignee (`@imanolmzd-svg`) should implement this using the existing `DeviceAuthCard` for the sign-in flow as a building block.

--- a/github/issue-triage/6092.md
+++ b/github/issue-triage/6092.md
@@ -1,0 +1,74 @@
+# Issue #6092: After streamline of approval boxes the full path is never shown
+
+**Priority:** P1
+**Board Status:** In progress
+**Verdict:** PARTIALLY FIXED
+
+## Issue Summary
+
+After consolidating permission/approval dialogs into a single box, the full path is not shown — especially for paths outside the workspace. The user sees only a directory name (e.g., `someapp/`) instead of the full absolute path (e.g., `/home/user/.config/someapp/`). This is a security/usability issue as users cannot verify what they're approving.
+
+## Investigation
+
+### The core issue: two locations for permission display
+
+Permission requests are rendered in two places:
+
+1. **Inline (per-message):** [`packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx`](packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx) — shown inline next to the tool call in the conversation
+2. **Bottom dock (global):** [`packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx`](packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx) — shown at the bottom of the chat view
+
+### Fix applied (Mar 3, 2026):
+
+Commit `21ea0fe23` ("fix(vscode): show permission patterns in inline permission prompt") fixed the inline location — it now renders `p.patterns` in the same `permission-dock-patterns` style as the bottom dock.
+
+**Before:** Inline permission prompts showed only `toolName` (e.g., `read`) with no path information.
+**After:** Both the inline and bottom dock prompts now display `perm.patterns`.
+
+### What `patterns` contains per tool:
+
+- **`read.ts` (file/directory reads):** `patterns: [filepath]` — uses the **full absolute path** ✅
+- **`edit.ts` (file edits):** `patterns: [path.relative(Instance.worktree, filePath)]` — uses **relative path** ⚠️
+- **`write.ts` (file writes):** `patterns: [path.relative(Instance.worktree, filepath)]` — uses **relative path** ⚠️
+
+For `edit.ts` and `write.ts`, when a file is outside the workspace, `path.relative()` returns a relative path like `../../home/user/.config/someapp/config.yaml` rather than the full absolute path. This is not trivially readable but does leak the path structure through `..` traversal notation.
+
+### PR #6134 (closed without merge):
+
+A community PR (#6134) proposed a broader fix: "surface full permission targets in the approval prompt (patterns + metadata paths like path/filePath/parentDir)." This was closed without merging on Feb 25, 2026.
+
+## Evidence
+
+```ts
+// packages/opencode/src/tool/read.ts:47 — CORRECT: uses absolute path
+patterns: [filepath],
+
+// packages/opencode/src/tool/edit.ts:58 — PROBLEMATIC for outside-workspace
+patterns: [path.relative(Instance.worktree, filePath)],
+
+// packages/opencode/src/tool/write.ts:37 — PROBLEMATIC for outside-workspace
+patterns: [path.relative(Instance.worktree, filepath)],
+```
+
+```tsx
+// packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx (after fix)
+<Show when={p.patterns.length > 0}>
+  <div class="permission-dock-patterns">
+    <For each={p.patterns}>
+      {(pattern) => <code class="permission-dock-pattern">{pattern}</code>}
+    </For>
+  </div>
+</Show>
+```
+
+The doc file at [`packages/kilo-vscode/docs/ui-polish/approval-box-full-path.md`](packages/kilo-vscode/docs/ui-polish/approval-box-full-path.md) explicitly states status as "🔨 Partial (assigned)".
+
+## Recommendation
+
+This issue is **PARTIALLY FIXED**:
+
+- ✅ The inline permission prompt now shows patterns (commit `21ea0fe23`, Mar 3, 2026)
+- ✅ `read.ts` sends the full absolute path as the pattern (for directory listing — the original reported scenario)
+- ⚠️ `edit.ts` and `write.ts` still use `path.relative()`, which produces `../../...` style paths for outside-workspace files — not ideal but functions
+- ❌ No "⚠ outside workspace" indicator as specified in the docs
+
+For the specific scenario in the issue (listing a directory outside the workspace), the fix is in place: `read.ts` passes the full absolute path in `patterns`, and the inline prompt now renders patterns. The issue could be closed with a note about the remaining edge case for `edit`/`write` relative paths outside workspace, or kept open until the out-of-workspace indicator is implemented.

--- a/github/issue-triage/6143.md
+++ b/github/issue-triage/6143.md
@@ -1,0 +1,47 @@
+# Issue #6143: Continually prompted whether to implement when in Plan mode
+
+**Priority:** P1
+**Board Status:** In progress
+**Verdict:** FIXED
+
+## Issue Summary
+When using Plan mode, the agent was aggressively and repeatedly asking "Ready to implement?" even mid-conversation, before the plan was complete. This was highly disruptive as it wouldn't let users continue refining their plan.
+
+## Investigation
+The root cause was that the "Ready to implement?" prompt (`PlanFollowup.ask`) was being triggered incorrectly — either before `plan_exit` was actually called, or during ongoing conversation turns.
+
+Two key commits addressed this:
+
+1. **`0886ef8fa`** — `fix(plan): Show implementation suggestions only when LLM has all the information`  
+   - Introduced `shouldAskPlanFollowup()` in [`packages/opencode/src/session/prompt.ts`](packages/opencode/src/session/prompt.ts:65) to gate the prompt on `plan_exit` being called with `status === "completed"`.
+   - Added comprehensive tests in `packages/opencode/test/kilocode/plan-exit-detection.test.ts`.
+   - Updated [`packages/opencode/src/session/prompt/plan.txt`](packages/opencode/src/session/prompt/plan.txt) to emphasize calling `plan_exit` only when done.
+   - Updated the `plan_exit` tool description to prevent premature calls.
+
+2. **`7143683e2`** — `fix: Fix plan_exit call`  
+   - Further refined the `plan_exit` detection logic and expanded the test suite with 200+ additional test cases.
+
+The fix gates the follow-up prompt on whether `plan_exit` has been called with `status === "completed"` for any message after the last user message:
+
+```typescript
+export function shouldAskPlanFollowup(input: { messages: MessageV2.WithParts[]; abort: AbortSignal }) {
+  if (input.abort.aborted) return false
+  if (!["cli", "vscode"].includes(Flag.KILO_CLIENT)) return false
+  const lastUserIdx = input.messages.findLastIndex((m) => m.info.role === "user")
+  return input.messages
+    .slice(lastUserIdx + 1)
+    .some((msg) =>
+      msg.parts.some((p) => p.type === "tool" && p.tool === "plan_exit" && p.state.status === "completed"),
+    )
+}
+```
+
+## Evidence
+- Commit `0886ef8fa` — fix(plan): Show implementation suggestions only when LLM has all the information
+- Commit `7143683e2` — fix: Fix plan_exit call
+- [`packages/opencode/src/kilocode/plan-followup.ts`](packages/opencode/src/kilocode/plan-followup.ts) — PlanFollowup.ask() now guarded by `shouldAskPlanFollowup()`
+- [`packages/opencode/test/kilocode/plan-exit-detection.test.ts`](packages/opencode/test/kilocode/plan-exit-detection.test.ts) — extensive tests for correct detection
+- [`packages/opencode/src/session/prompt/plan.txt`](packages/opencode/src/session/prompt/plan.txt) — Plan mode system prompt updated with clearer `plan_exit` guidance
+
+## Recommendation
+**Close the issue.** The fix is in place: the "Ready to implement?" prompt is now only shown when `plan_exit` has been explicitly called with a completed status, preventing the mid-conversation interruptions described in the issue. The fix is covered by a comprehensive test suite.

--- a/github/issue-triage/6163.md
+++ b/github/issue-triage/6163.md
@@ -1,0 +1,45 @@
+# Issue #6163: VS Code Extension: Add Custom OpenAI-Compatible Provider UI
+
+**Priority:** P1
+**Board Status:** In progress
+**Verdict:** NOT FIXED
+
+## Issue Summary
+The VS Code extension is missing a UI for adding custom OpenAI-compatible providers. Users must manually edit `opencode.json` to configure local models (Ollama, LM Studio), custom API endpoints, or enterprise deployments. The web/TUI app has a full dialog for this (`dialog-custom-provider.tsx`), but the VS Code extension's `ProvidersTab` doesn't expose this functionality.
+
+## Investigation
+The current [`packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx`](packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx) was checked and confirmed to only provide:
+- Default model selector
+- Small model selector
+- Disabled providers list (add/remove from dropdown of existing providers)
+- Enabled providers list (add/remove from dropdown of existing providers)
+
+There is **no** custom provider dialog, no form for entering base URL / API key / model IDs, and no "Add custom provider" button.
+
+A search across the entire `packages/kilo-vscode/webview-ui/` tree for `CustomProvider`, `DialogCustom`, `dialog-custom`, `openai-compatible`, `baseURL`, and `addProvider` returned zero results, confirming the feature hasn't been implemented.
+
+The git log for `ProvidersTab.tsx` shows only incremental styling/refactoring work (e.g., Card-based layout, model selector unification, i18n), with no new feature addition:
+```
+d6ce06173 refactor: vscode / kilo-ui style
+98100e6f5 refactor(vscode): reorganize webview component folder structure
+f48a994b2 feat(kilo-vscode): internationalize settings tabs
+87d1c2c36 refactor(vscode): unify settings tabs to Card-based SettingsRow pattern
+55c015b4f refactor(settings): reuse model selector pattern in ProvidersTab
+686d0d73c refactor(settings): use kilo-ui components in ContextTab and ProvidersTab
+b8d827bff feat(settings): implement Providers tab with model selection and provider lists
+```
+
+## Evidence
+- [`packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx`](packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx) — 234 lines, no custom provider form
+- `find packages/kilo-vscode/webview-ui -name "*.tsx" | xargs grep -l "CustomProvider\|dialog-custom\|baseURL"` returns empty results
+- The issue description itself documents the gap (markijbema filed and is the assignee)
+- The backend plumbing (`KiloProvider.handleUpdateConfig()`, `/global/config` endpoint) is already in place per the issue's implementation notes
+
+## Recommendation
+**Keep open.** The feature has not been implemented. The VS Code `ProvidersTab` still has no UI for adding custom OpenAI-compatible providers. The backend integration points exist and are documented in the issue.
+
+Work remaining:
+1. Port `DialogCustomProvider` component from `packages/app/src/components/dialog-custom-provider.tsx`
+2. Add a "Custom Provider" section to `ProvidersTab.tsx`
+3. Wire up to `handleUpdateConfig` and `/global/auth/set` endpoints
+4. Add i18n keys

--- a/github/issue-triage/6188.md
+++ b/github/issue-triage/6188.md
@@ -1,0 +1,45 @@
+# Issue #6188: Add 'onboarding' experience for people upgrading to the new extension
+
+**Priority:** P1
+**Board Status:** Backlog
+**Verdict:** PARTIALLY FIXED
+
+## Issue Summary
+Users upgrading from the old Kilo Code extension to the new extension are greeted with a confusing experience: their existing sessions are no longer visible (different architecture), and they receive no explanation. The request was to add an onboarding/upgrade experience that explains:
+1. Why their sessions aren't visible anymore
+2. What settings/configurations can and cannot be migrated
+3. An option to explicitly import/migrate old settings
+
+## Investigation
+A migration wizard (`MigrationWizard`) has been implemented in the VS Code extension that partially addresses this issue.
+
+### What IS implemented:
+**Auto-detection and navigation:** [`packages/kilo-vscode/src/KiloProvider.ts`](packages/kilo-vscode/src/KiloProvider.ts:2058) — `checkAndShowMigrationWizard()` automatically detects legacy data on startup and navigates to the migration wizard if the user hasn't already been prompted.
+
+**4-step migration wizard:** [`packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx`](packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx)
+- **Step 1 (Welcome):** Informs users about what can/cannot be migrated. Includes a warning card that explicitly states: "Chat sessions and history cannot be migrated — the new version uses a different architecture." (i18n key: `migration.welcome.sessionsInfo`)
+- **Step 2 (Select):** Checkboxes for providers, MCP servers, custom modes, and default model
+- **Step 3 (Progress):** Live progress indicators during migration
+- **Step 4 (Complete):** Summary with optional cleanup
+
+**Manual re-trigger:** `kilo-code.new.openMigrationWizard` command is registered, and a migration option is accessible via Settings → About.
+
+**Legacy service:** [`packages/kilo-vscode/src/legacy-migration/migration-service.ts`](packages/kilo-vscode/src/legacy-migration/migration-service.ts) handles actual migration of API keys, MCP servers, custom modes, and default model.
+
+### What is NOT implemented (the nuance of the issue):
+The issue specifically mentions users who are **upgrading within the new extension** (not from the old to new), who see an empty session list and don't understand why. The migration wizard only triggers when **legacy data from the old extension** is detected (`detectLegacyData` → `data.hasData`). Users who came from the old extension but already did the migration — or who have no legacy data but are confused by the empty state — see no onboarding.
+
+The `createSession` function still resets to `provider.defaultSelection()` rather than preserving last used model, and there is no general "welcome/onboarding" screen for new users without legacy data.
+
+## Evidence
+- [`packages/kilo-vscode/src/KiloProvider.ts:2058`](packages/kilo-vscode/src/KiloProvider.ts:2058) — `checkAndShowMigrationWizard()`
+- [`packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx:437`](packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx:437) — sessions warning card
+- i18n key: `"migration.welcome.sessionsInfo": "Chat sessions and history cannot be migrated — the new version uses a different architecture."`
+- [`packages/kilo-vscode/src/legacy-migration/migration-service.ts`](packages/kilo-vscode/src/legacy-migration/migration-service.ts) — full migration implementation
+
+## Recommendation
+**Partially close or update scope.** The core concern from the issue — explaining that sessions aren't visible and offering migration of settings — is addressed via the migration wizard for users with legacy data. However, if the concern was broader (all upgrading users, including those without legacy Kilo Code data who are just confused), additional work is needed.
+
+Specifically, what may still be missing:
+- Empty-state UX improvement when session list is empty (explain the new architecture rather than just "No sessions yet")
+- The migration wizard is only shown to users who had the old extension installed; users who are simply new to the rewritten extension get no onboarding

--- a/github/issue-triage/6211.md
+++ b/github/issue-triage/6211.md
@@ -1,0 +1,58 @@
+# Issue #6211: [FEATURE]: Remember users last model choice (VSCode)
+
+**Priority:** P1
+**Board Status:** Backlog
+**Verdict:** PARTIALLY FIXED
+
+## Issue Summary
+Currently, every new session in the VS Code extension defaults to "Kilo: Auto", regardless of which model the user selected in their previous session. The feature request is to remember the user's last selected model and use it as the default for new sessions, while leaving existing sessions unaffected.
+
+## Investigation
+
+### What IS implemented:
+
+**Persistence infrastructure exists:** Commit `cb293856d` ("feat: extension-side provider fetch and model persistence") added:
+1. VS Code configuration keys `kilo-code.new.model.providerID` and `kilo-code.new.model.modelID` in [`packages/kilo-vscode/package.json`](packages/kilo-vscode/package.json)
+2. [`fetchAndSendProviders()`](packages/kilo-vscode/src/KiloProvider.ts:979) reads persisted model from VS Code config and sends it as `defaultSelection` in the `providersLoaded` message
+3. The webview [`ProviderProvider`](packages/kilo-vscode/webview-ui/src/context/provider.tsx:42) receives `defaultSelection` and uses it to initialize the default model
+
+**Per-session model tracking:** [`packages/kilo-vscode/webview-ui/src/context/session.tsx`](packages/kilo-vscode/webview-ui/src/context/session.tsx) maintains `modelSelections` per session, so switching between existing sessions correctly restores each session's model.
+
+**Model sent on message:** When `sendMessage` is called, it forwards `providerID` and `modelID` to the backend session prompt.
+
+### What is NOT implemented (the gap):
+
+**The model is never written back** when the user changes their selection. The original `handleSaveModel` added in `cb293856d` does not appear in the current `KiloProvider.ts` — there is no `case "saveModel":` handler and no `handleSaveModel` method in the current codebase. The `saveModel` message type is also absent from [`packages/kilo-vscode/webview-ui/src/types/messages.ts`](packages/kilo-vscode/webview-ui/src/types/messages.ts).
+
+The `selectModel()` function in `session.tsx` updates the in-memory pending selection but sends no message to the extension host to persist it to VS Code settings.
+
+The `createSession()` function explicitly resets pending selection to `provider.defaultSelection()`:
+```typescript
+function createSession() {
+  // Reset pending selection to default for the new session
+  setPendingModelSelection(provider.defaultSelection())
+  setPendingWasUserSet(false)
+  ...
+}
+```
+
+This means if users change the model in the dropdown, then click "New Session", the selection resets to whatever was saved (or the hardcoded fallback `"kilo"/"kilo/auto"`).
+
+### Net state:
+The infrastructure to **load** a persisted model exists; the mechanism to **save** the user's selection back is missing. The `kilo-code.new.model` settings will remain at their defaults (`"kilo"/"kilo/auto"`) unless some other code path writes them.
+
+## Evidence
+- [`packages/kilo-vscode/src/KiloProvider.ts:979`](packages/kilo-vscode/src/KiloProvider.ts:979) — `fetchAndSendProviders()` reads `kilo-code.new.model.providerID` and sends as `defaultSelection`
+- [`packages/kilo-vscode/package.json`](packages/kilo-vscode/package.json) — configuration properties `kilo-code.new.model.providerID`, `kilo-code.new.model.modelID`
+- [`packages/kilo-vscode/webview-ui/src/context/session.tsx:928`](packages/kilo-vscode/webview-ui/src/context/session.tsx:928) — `createSession()` resets to `provider.defaultSelection()`
+- No `saveModel` message type in `messages.ts`
+- No `handleSaveModel` in `KiloProvider.ts`
+- `grep -rn "saveModel" packages/kilo-vscode/` returns empty results in current code
+
+## Recommendation
+**Keep open.** The read side (loading persisted model on startup) is implemented, but the write side (persisting the user's selection when they change it) is missing. Without the write side, the feature is incomplete — the model will always load as the hardcoded default or whatever was manually set.
+
+Work remaining:
+1. Add `saveModel` message type to `messages.ts`
+2. Add `case "saveModel":` handler in `KiloProvider.ts` that calls `config.update("providerID", ...)` and `config.update("modelID", ...)`
+3. Call `vscode.postMessage({ type: "saveModel", providerID, modelID })` from `selectModel()` in `session.tsx` when user explicitly changes their model

--- a/github/issue-triage/6221.md
+++ b/github/issue-triage/6221.md
@@ -1,0 +1,51 @@
+# Issue #6221: perf: Markdown syntax highlighting blocks main thread for 2.3s+ during session switching
+
+**Priority:** P1
+**Board Status:** In progress
+**Verdict:** NOT FIXED
+
+## Issue Summary
+
+When switching sessions in the VS Code extension (Agent Manager), the webview main thread is blocked for 2.3+ seconds by synchronous syntax highlighting in the Markdown rendering pipeline. The root cause is that `marked-shiki`'s `highlight()` callback in the `markedShiki()` plugin calls `highlighter.codeToHtml()` which internally runs Oniguruma regex (`findNextMatchSync`) synchronously on the main thread. This accounts for 91.4% of the entire message-load CPU time.
+
+## Investigation
+
+Examined the relevant files exactly as described in the issue:
+
+- **[`packages/ui/src/context/marked.tsx`](packages/ui/src/context/marked.tsx:511)**: The `markedShiki` plugin is configured at line 511–526 with an `async highlight(code, lang)` callback. However, `getSharedHighlighter` and then `highlighter.codeToHtml()` are called in this callback — `codeToHtml` is a synchronous CPU operation even though the outer function is async. The Oniguruma WASM regex engine does blocking computation on the main thread.
+
+- **[`packages/ui/src/components/markdown.tsx`](packages/ui/src/components/markdown.tsx:237)**: The `Markdown` component uses `createResource` with `marked.parse()` at line 253. The 200-entry LRU cache (lines 14–15) is present. No two-pass rendering or `requestIdleCallback` deferral has been added. No web worker offloading is in place for the markdown path.
+
+- **[`packages/ui/src/pierre/worker.ts`](packages/ui/src/pierre/worker.ts)**: The Code/Diff components still use the separate worker pool, but markdown does not.
+
+None of the proposed fix options (A–D) from the issue appear to have been implemented.
+
+## Evidence
+
+```typescript
+// packages/ui/src/context/marked.tsx lines 511–526
+markedShiki({
+  async highlight(code, lang) {
+    const highlighter = await getSharedHighlighter({ themes: ["Kilo"], langs: [] })
+    if (!(lang in bundledLanguages)) {
+      lang = "text"
+    }
+    if (!highlighter.getLoadedLanguages().includes(lang)) {
+      await highlighter.loadLanguage(lang as BundledLanguage)
+    }
+    return highlighter.codeToHtml(code, {   // <-- synchronous Oniguruma CPU work
+      lang: lang || "text",
+      theme: "Kilo",
+      tabindex: false,
+    })
+  },
+}),
+```
+
+The `markdown.tsx` component (lines 237–258) has no two-pass rendering or idle-callback deferral — it still calls `await marked.parse(markdown)` in a single blocking pass.
+
+## Recommendation
+
+This issue is **NOT FIXED**. The main thread is still blocked during bulk session load. The recommended implementation path is Option A (two-pass render: plain `<pre><code>` first, then deferred syntax highlighting via `requestIdleCallback`) or Option D (verify whether `createJavaScriptRegexEngine` is actually being used instead of the Oniguruma WASM engine). Should remain open and prioritized. Assignee should implement a fix in:
+- [`packages/ui/src/context/marked.tsx`](packages/ui/src/context/marked.tsx)
+- [`packages/ui/src/components/markdown.tsx`](packages/ui/src/components/markdown.tsx)

--- a/github/issue-triage/6230.md
+++ b/github/issue-triage/6230.md
@@ -1,0 +1,53 @@
+# Issue #6230: Consider re-adding Architect mode (or enhancing Plan mode to write plans to /plans)
+
+**Priority:** P1
+**Board Status:** Backlog
+**Verdict:** NOT FIXED
+
+## Issue Summary
+
+Users miss the old Architect mode's behavior of writing plan files as `.md` to a visible `/plans` directory in the project root. Plan mode exists and works, but its plans are stored inside `.opencode/plans/` — hidden and not easily accessible. The request is to either re-add Architect mode as a distinct mode, or enhance Plan mode to also write plan files to a top-level `/plans` directory.
+
+## Investigation
+
+Examined relevant files:
+
+- **[`packages/opencode/src/session/index.ts`](packages/opencode/src/session/index.ts:361)**: The `Session.plan()` function at line 361 stores plans at `.opencode/plans/{timestamp}-{slug}.md` (inside `.opencode/`, not a top-level `/plans` folder). This is unchanged from what the issue describes.
+
+- **[`packages/opencode/src/tool/plan.ts`](packages/opencode/src/tool/plan.ts)**: The `PlanExitTool` tool exists (lines 20–32) and signals planning is complete. The plan file path returned is relative to the worktree but it points to `.opencode/plans/`. The `PlanEnterTool` is commented out (lines 35–92).
+
+- **[`packages/opencode/src/kilocode/modes-migrator.ts`](packages/opencode/src/kilocode/modes-migrator.ts:26)**: "architect" is listed in `DEFAULT_MODE_SLUGS` as a mode to skip during migration from the old Kilo Code config — indicating architect mode is recognized, but it has no native implementation (it maps to an old kilo-code custom mode that would get migrated).
+
+- **[`packages/opencode/src/kilocode/rules-migrator.ts`](packages/opencode/src/kilocode/rules-migrator.ts:15)**: "architect" is listed in `KNOWN_MODES` for legacy rule discovery, confirming it was previously a distinct mode.
+
+- **[`packages/opencode/src/config/config.ts`](packages/opencode/src/config/config.ts)**: No architect mode definition is present as a built-in mode.
+
+No Architect mode exists as a built-in agent. Plan mode stores plans in `.opencode/plans/` instead of a user-visible top-level `/plans` directory.
+
+## Evidence
+
+```typescript
+// packages/opencode/src/session/index.ts lines 361–368
+export function plan(input: { slug: string; time: { created: number } }) {
+  const base = Instance.project.vcs
+    ? path.join(Instance.worktree, ".opencode", "plans")  // hidden inside .opencode
+    : path.join(Global.Path.data, "plans")
+  return path.join(base, [input.time.created, input.slug].join("-") + ".md")
+}
+```
+
+The plan path resolves to `.opencode/plans/` — NOT a top-level `/plans` folder as users expect from the old Architect mode behavior.
+
+```typescript
+// packages/opencode/src/kilocode/modes-migrator.ts line 26
+const DEFAULT_MODE_SLUGS = new Set(["code", "build", "architect", "ask", "debug", "orchestrator"])
+// "architect" is recognized as a default/legacy mode but has no native built-in implementation
+```
+
+## Recommendation
+
+This issue is **NOT FIXED**. The request has two distinct asks:
+1. **Re-add Architect mode** — it is recognized in migration code but no built-in implementation exists.
+2. **Plan mode writing to `/plans`** — plans go to `.opencode/plans/` not a top-level `/plans` folder.
+
+To address this: update `Session.plan()` to write to a top-level `plans/` directory, or add an Architect-equivalent built-in mode. Assigned to `lambertjosh`, should remain in Backlog for prioritization.

--- a/github/issue-triage/6255.md
+++ b/github/issue-triage/6255.md
@@ -1,0 +1,40 @@
+# Issue #6255: Clickable items should change the cursor
+
+**Priority:** P1
+**Board Status:** In progress
+**Verdict:** FIXED
+
+## Issue Summary
+
+Clickable elements in the chat UI (tool cards, file names, links in markdown) did not show `cursor: pointer` on hover, making it hard for users to tell what was interactive. The same problem applied to links in markdown output.
+
+## Investigation
+
+The issue is **already closed** on GitHub (closed by `markijbema` on 2026-03-05 with `state_reason: "completed"`).
+
+Examination of the CSS files confirms that `cursor: pointer` has been added to the relevant elements:
+
+- **[`packages/ui/src/components/message-part.css`](packages/ui/src/components/message-part.css:49)**: `cursor: pointer` added (marked with `/* kilocode_change */`) at line 49 for tool cards, plus `.clickable` class with `cursor: pointer` at lines 463–464, 492–493, 1234–1235, 1289–1290.
+- **[`packages/ui/src/components/markdown.css`](packages/ui/src/components/markdown.css:223)**: `cursor: pointer` added for `.file-link` (inline file path links in code spans) at lines 222–224.
+- **[`packages/ui/src/components/basic-tool.css`](packages/ui/src/components/basic-tool.css:108)**: `cursor: pointer` with `text-decoration: underline` on `.clickable` elements.
+- **[`packages/ui/src/components/session-review.css`](packages/ui/src/components/session-review.css:143)**: `cursor: pointer` on session review clickable rows.
+
+## Evidence
+
+```css
+/* packages/ui/src/components/message-part.css line 47-50 */
+  border: 1px solid var(--border-weak-base);
+  cursor: pointer; /* kilocode_change */
+  transition: border-color 0.15s ease;
+
+/* packages/ui/src/components/markdown.css lines 222-224 */
+  &.file-link {
+    cursor: pointer;
+    text-decoration-line: underline;
+```
+
+The issue was closed on 2026-03-05 with `state_reason: "completed"`, confirming the fix was shipped.
+
+## Recommendation
+
+This issue is **FIXED** and already closed. No further action required.

--- a/github/issue-triage/6256.md
+++ b/github/issue-triage/6256.md
@@ -1,0 +1,63 @@
+# Issue #6256: [VSCode] Show terminal command execution details and output in the ui
+
+**Priority:** P1
+**Board Status:** Backlog
+**Verdict:** PARTIALLY FIXED
+
+## Issue Summary
+
+Users want to see: (1) the actual command being run, (2) truncated output sample in real time, and (3) success/failure status indicator — directly in the VS Code extension chat UI, matching the CLI's visibility. Currently the extension feels "spooky" since it only shows a heading without command details or output.
+
+## Investigation
+
+Examined the bash tool renderer in [`packages/ui/src/components/message-part.tsx`](packages/ui/src/components/message-part.tsx:1429):
+
+**What has been addressed:**
+- The bash tool registration at line 1430 renders the command (`cmd()`) and output (`out()`) together as `$ {cmd}\n\n{output}` inside a `<pre><code>` block.
+- The component passes `defaultOpen` prop (`// kilocode_change`) at line 1453, meaning the bash tool details panel starts open/expanded by default — the command and output are immediately visible without requiring a click to expand.
+- The `trigger` shows "Shell" as title and `props.input.description` as subtitle, providing context.
+
+**What is NOT addressed:**
+- **Success/failure status** — there is no exit code indicator, no visual success/error state (e.g. green checkmark vs red × based on exit code). The `props.status` is passed to `BasicTool` but this controls the "running/pending/done" lifecycle state, not the command's exit code.
+- The issue specifically calls for: *"I want to see in an easy way if the command succeeded or not"* — this is not implemented.
+
+## Evidence
+
+```typescript
+// packages/ui/src/components/message-part.tsx lines 1429–1485
+ToolRegistry.register({
+  name: "bash",
+  render(props) {
+    const cmd = createMemo(() => props.input.command ?? props.metadata.command ?? "")
+    const out = createMemo(() => stripAnsi(props.output || props.metadata.output || ""))
+    const text = createMemo(() => `$ ${cmd()}${out() ? "\n\n" + out() : ""}`)
+    // ...
+    return (
+      <BasicTool
+        {...props}
+        defaultOpen // kilocode_change — opens the panel by default
+        icon="console"
+        trigger={{
+          title: i18n.t("ui.tool.shell"),
+          subtitle: props.input.description,   // description shown
+        }}
+      >
+        <div data-component="bash-output">
+          {/* command + output rendered as pre/code */}
+          <pre data-slot="bash-pre">
+            <code>{text()}</code>  {/* $ cmd\n\noutput */}
+          </pre>
+        </div>
+      </BasicTool>
+    )
+  },
+})
+```
+
+Command and output are shown (request #1 and #2 satisfied), but there is **no success/failure status indicator** (request #3 not implemented).
+
+## Recommendation
+
+This issue is **PARTIALLY FIXED**: requirements 1 (show command) and 2 (show output) are addressed by the `defaultOpen` + combined `$ cmd\noutput` rendering added as a `kilocode_change`. Requirement 3 (show success/failure status via exit code indicator) is **still missing** and the issue remains open. Work remaining:
+- Surface the command exit code from the tool metadata/output
+- Add a visual success/failure indicator to the bash tool card (e.g., colored status icon, exit code badge)

--- a/github/issue-triage/6339.md
+++ b/github/issue-triage/6339.md
@@ -1,0 +1,54 @@
+# Issue #6339: Make switching from plan to code work properly
+
+**Priority:** P1
+**Board Status:** Backlog
+**Verdict:** PARTIALLY FIXED
+
+## Issue Summary
+
+When the agent finishes planning and asks the user if it should switch to implement, it was sticking at plan mode instead of switching to code mode. The issue also requested an auto-switch option similar to the old extension.
+
+## Investigation
+
+The codebase has significant work done around this issue via the `PlanFollowup` system in `packages/opencode/src/kilocode/plan-followup.ts`. The approach was fundamentally redesigned:
+
+1. The original `PlanEnterTool` (which asked the user to switch to plan mode) has been **commented out** — replaced by a signal-only `PlanExitTool` that just indicates planning is complete.
+2. `SessionPrompt.shouldAskPlanFollowup()` detects when `plan_exit` was called and triggers the follow-up prompt.
+3. `PlanFollowup.ask()` now presents users with: "Start new session" or "Continue here" (with an option to type a custom response).
+4. "Start new session" creates a new session in `code` agent mode with the plan injected as context, including a handover summary.
+5. "Continue here" injects a `code`-agent message saying "Implement the plan above."
+
+There are comprehensive tests in `packages/opencode/test/kilocode/plan-exit-detection.test.ts` and `packages/opencode/test/kilocode/plan-followup.test.ts`.
+
+However, the second part of the issue — **auto-switch like in the old extension** — has NOT been implemented. There is no auto-switch setting or permission to automatically switch from plan to code without user confirmation. The comments in the issue also mention: "We should: 1. Have a permission for auto-switching modes. 2. The default should be ask."
+
+## Evidence
+
+```typescript
+// packages/opencode/src/kilocode/plan-followup.ts
+export namespace PlanFollowup {
+  export const ANSWER_NEW_SESSION = "Start new session"
+  export const ANSWER_CONTINUE = "Continue here"
+  // ...
+  function prompt(input: { sessionID: string; abort: AbortSignal }) {
+    const promise = Question.ask({
+      questions: [{
+        question: "Ready to implement?",
+        header: "Implement",
+        custom: true,
+        options: [
+          { label: ANSWER_NEW_SESSION, description: "Implement in a fresh session with a clean context" },
+          { label: ANSWER_CONTINUE, description: "Implement the plan in this session" },
+        ],
+      }],
+    })
+    // ...
+  }
+}
+```
+
+The original sticky-at-plan issue appears fixed (the question system and follow-up prompt are in place). But the auto-switch feature has not been added.
+
+## Recommendation
+
+The core mode-switching bug (agent sticking at plan) appears to be **fixed** — the `PlanFollowup` system correctly offers a switch-to-code option. However, the requested auto-switch permission/setting has not been implemented. This issue should remain **open** for the auto-switch feature, or a new issue should be created specifically for that enhancement.

--- a/github/issue-triage/6370.md
+++ b/github/issue-triage/6370.md
@@ -1,0 +1,57 @@
+# Issue #6370: Plan files in ask mode are saved in a opencode directory
+
+**Priority:** P1
+**Board Status:** In progress
+**Verdict:** NOT FIXED
+
+## Issue Summary
+
+When in Ask mode, plan files are visibly saved in a `./opencode` directory (i.e., `.opencode/plans/`). The issue is that the plan files are saved to the `.opencode` path which is the upstream OpenCode project name, whereas the product is now called Kilo Code. Additionally, ask mode shouldn't be creating plan files at all since ask mode is explicitly for getting answers without making changes.
+
+## Investigation
+
+In `packages/opencode/src/session/index.ts`, the `plan()` function determines where plan files are saved:
+
+```typescript
+export function plan(input: { slug: string; time: { created: number } }) {
+  const base = Instance.project.vcs
+    ? path.join(Instance.worktree, ".opencode", "plans")
+    : path.join(Global.Path.data, "plans")
+  return path.join(base, [input.time.created, input.slug].join("-") + ".md")
+}
+```
+
+The path still uses `.opencode/plans` which is the upstream directory name — it has not been renamed to `.kilocode/plans`. This is the core of the bug: plan files are being created in the `.opencode` directory.
+
+There are two sub-problems:
+1. **Path branding**: The path uses `.opencode` instead of `.kilocode` or another Kilo-appropriate path.
+2. **Ask mode creating plans**: The `ask` agent in `packages/opencode/src/agent/agent.ts` has the `plan_exit` permission set. If the plan tool is available to the ask agent, it can create plan files even though ask mode should be read-only.
+
+Looking at `packages/opencode/src/agent/agent.ts`, the ask agent has:
+```typescript
+name: "ask",
+description: "Get answers and explanations without making changes to the codebase.",
+```
+But if the plan_exit tool is enabled (e.g., via `KILO_EXPERIMENTAL_PLAN_MODE`), the ask agent can call it.
+
+There is a commit `b3ae1931f fix: plan path permissions` but it doesn't appear to address the `.opencode` directory naming. There are no commits renaming `.opencode/plans` to `.kilocode/plans`.
+
+## Evidence
+
+```typescript
+// packages/opencode/src/session/index.ts line 361-366
+export function plan(input: { slug: string; time: { created: number } }) {
+  const base = Instance.project.vcs
+    ? path.join(Instance.worktree, ".opencode", "plans")
+    : path.join(Global.Path.data, "plans")
+  return path.join(base, [input.time.created, input.slug].join("-") + ".md")
+}
+```
+
+The `.opencode/plans` directory is still hardcoded. No rename to `.kilocode`.
+
+## Recommendation
+
+This issue is NOT fixed. Two changes are needed:
+1. Rename the plan path from `.opencode/plans` to `.kilocode/plans` in `Session.plan()` at `packages/opencode/src/session/index.ts:363`.
+2. Verify whether the ask agent should have access to the plan tools at all. If not, disable plan tool permission in the ask agent definition.

--- a/github/issue-triage/6371.md
+++ b/github/issue-triage/6371.md
@@ -1,0 +1,55 @@
+# Issue #6371: [FEATURE]: Improve Permission Settings (VSCode Extension)
+
+**Priority:** P1
+**Board Status:** Backlog
+**Verdict:** PARTIALLY FIXED
+
+## Issue Summary
+
+The request was to support the configuration of permissions supported by the CLI in the VS Code extension, using a Figma design as reference. The goal is a full-featured permission settings UI to manage tool auto-approval settings.
+
+## Investigation
+
+Looking at `packages/kilo-vscode/webview-ui/src/components/settings/AutoApproveTab.tsx`, there is a working permission settings tab in the VS Code extension that allows users to:
+
+1. Set global permission levels for all tools at once ("Set All")
+2. Configure individual permission levels (`allow`, `ask`, `deny`) for each tool: `read`, `edit`, `glob`, `grep`, `list`, `bash`, `task`, `skill`, `lsp`, `todoread`, `todowrite`, `webfetch`, `websearch`, `codesearch`, `external_directory`, `doom_loop`
+3. Values are persisted via `updateConfig()` to the Kilo config
+
+The settings tab is accessible via `packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx` under the "Auto Approve" tab name.
+
+However, the feature request specifically references a Figma design (`https://www.figma.com/board/9FB55otnTi8z04ZLYKQwZQ/`) that may specify additional capabilities beyond what's currently implemented. Without access to the Figma design, it's hard to determine if the current implementation matches all requirements.
+
+What IS implemented:
+- Per-tool allow/ask/deny settings
+- Set-all control
+- Settings are wired to the CLI config system
+
+What the Figma may have requested but is NOT visible in the current code:
+- Per-pattern bash command rules (e.g., "allow `git push` but deny `rm -rf`")
+- Per-directory external_directory rules
+- Import/export of permission profiles
+- More granular bash command pattern configuration (related to issue #6541)
+
+## Evidence
+
+```typescript
+// packages/kilo-vscode/webview-ui/src/components/settings/AutoApproveTab.tsx
+const TOOLS = [
+  "read", "edit", "glob", "grep", "list", "bash", "task", "skill",
+  "lsp", "todoread", "todowrite", "webfetch", "websearch", "codesearch",
+  "external_directory", "doom_loop",
+] as const
+
+const LEVEL_OPTIONS: LevelOption[] = [
+  { value: "allow", labelKey: "settings.autoApprove.level.allow" },
+  { value: "ask", labelKey: "settings.autoApprove.level.ask" },
+  { value: "deny", labelKey: "settings.autoApprove.level.deny" },
+]
+```
+
+The `AutoApproveTab` provides per-tool permission levels, which is a basic implementation of what was requested.
+
+## Recommendation
+
+The basic permission settings UI is in place and functional (PARTIALLY FIXED). However, the issue references a specific Figma design that likely specifies more detailed capabilities. The issue should remain open until compared against the Figma design requirements. Key missing capabilities likely include per-pattern command/directory rules which are tracked separately in issue #6541.

--- a/github/issue-triage/6373.md
+++ b/github/issue-triage/6373.md
@@ -1,0 +1,41 @@
+# Issue #6373: [FEATURE]: Add feedback button prior to the beta
+
+**Priority:** P1
+**Board Status:** Backlog
+**Verdict:** NOT FIXED
+
+## Issue Summary
+
+A visible feedback button should be added to the beta to allow users to submit feedback on issues, bugs, etc. The request is for a dedicated, prominent feedback mechanism — not buried in settings — so users can easily report issues or bugs. The feedback could route to Slack or a GitHub issue form.
+
+## Investigation
+
+Searching the entire VS Code extension webview UI (`packages/kilo-vscode/webview-ui/src/`) for feedback button implementations:
+
+- There is **no dedicated feedback button** in the chat UI, header, sidebar, or anywhere prominent in the main interface.
+- The only feedback-related content found is in `packages/kilo-vscode/webview-ui/src/components/settings/AboutKiloCodeTab.tsx`, which has text like "If you have any questions or feedback, feel free to open an issue on [GitHub] or [Discord]" as plain text — not a visible button.
+- Searching for `feedbackButton`, `FeedbackButton`, `report.*issue`, `submit.*feedback` returns no results in the extension codebase.
+
+The existing feedback mechanism is a passive text link hidden inside the "About Kilo Code" settings tab. This does not satisfy the requirement for "a fairly visible feedback button to the beta."
+
+## Evidence
+
+```typescript
+// packages/kilo-vscode/webview-ui/src/components/settings/AboutKiloCodeTab.tsx
+// The only feedback reference found - passive text link, buried in settings:
+{language.t("settings.aboutKiloCode.feedback.prefix")}{" "}
+// ...links to GitHub/Discord...
+, {language.t("settings.aboutKiloCode.feedback.or")}{" "}
+```
+
+i18n key value:
+```typescript
+// packages/kilo-vscode/webview-ui/src/i18n/en.ts
+"settings.aboutKiloCode.feedback.prefix": "If you have any questions or feedback, feel free to open an issue on",
+```
+
+No dedicated feedback button UI component exists anywhere in the codebase.
+
+## Recommendation
+
+This feature is NOT implemented. To fix this, a visible feedback button should be added to a prominent location (e.g., the chat header, the bottom toolbar, or the settings panel header). It should link to a GitHub issue template or a Slack feedback channel. This is a relatively quick UI addition that would significantly improve the pre-beta feedback loop.

--- a/github/issue-triage/6399.md
+++ b/github/issue-triage/6399.md
@@ -1,0 +1,81 @@
+# Issue #6399: Logging in/out isn't persisted properly to the backend
+
+**Priority:** P1
+**Board Status:** Ready
+**Verdict:** PARTIALLY FIXED
+
+## Issue Summary
+
+When a user logs in or out via the VS Code extension, the authentication state change was not being correctly propagated to the CLI backend. The backend still used the stale auth token captured at startup. Consequence: even after logout, requests to paid models still succeeded because the backend used the cached (pre-logout) token.
+
+## Investigation
+
+### Root Cause (Not Yet Merged to `main`)
+
+The primary bug is in [`packages/opencode/src/provider/provider.ts`](packages/opencode/src/provider/provider.ts): the `CUSTOM_LOADER` for the `kilo` provider ran once at server startup (via `Instance.state()` caching), capturing the auth token (from `Auth.get("kilo")`) at init time. The resulting SDK instance was cached and reused for all subsequent requests, so any login/logout after startup would not affect the cached token.
+
+**Fix in commit `28d1f88d6`** (branch `remotes/origin/mark/fix-auth-persistence-6399`, **NOT merged to `main`**):
+
+Injects a dynamic `fetch` function into the kilo provider options that calls `Auth.get("kilo")` on every request, overriding any stale `Authorization` header. This ensures the current token (or its absence after logout) is always fresh:
+
+```typescript
+// From packages/opencode/src/provider/provider.ts (branch only, not in main)
+const kiloId = input.id
+options.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+  const auth = await Auth.get(kiloId)
+  const token = auth?.type === "oauth" ? auth.access : auth?.type === "api" ? auth.key : undefined
+  const headers = new Headers(init?.headers)
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`)
+  } else {
+    // Remove any stale token header when logged out
+    headers.delete("Authorization")
+  }
+  return fetch(input, { ...init, headers })
+}
+```
+
+This commit even explicitly references `Fixes #6399` in the commit message.
+
+### Partial Fix (Already Merged — PR #6659)
+
+Commit `c3ed9466a` (merged to `main` via PR #6659) addressed related symptoms:
+
+1. **Model cache invalidation**: Added `ModelCache.clear(providerID)` to the `auth.remove` and `auth.set` server routes in [`packages/opencode/src/server/server.ts`](packages/opencode/src/server/server.ts:203-210), and also added `ModelCache.clear("kilo")` to organization-switch in [`packages/kilo-gateway/src/server/routes.ts`](packages/kilo-gateway/src/server/routes.ts:203).
+
+2. **State reload after dispose**: In [`packages/kilo-vscode/src/KiloProvider.ts`](packages/kilo-vscode/src/KiloProvider.ts), added `global.dispose()` calls after login, logout, and org-switch, and added a `reloadAfterAuthChange()` helper that refetches providers, agents, config, and notifications when a `global.disposed` SSE event is received. This mirrors the TUI's `sync.bootstrap()` pattern.
+
+3. **Auth persistence** ([`packages/opencode/src/auth/index.ts`](packages/opencode/src/auth/index.ts)): Auth is already properly persisted via `Auth.remove()` which writes to `auth.json` on disk. The issue was not in persistence to disk but in the in-memory cached SDK instance.
+
+### Remaining Gaps
+
+The `auth.remove` route in the server properly removes the key from disk and calls `scheduleDisposeAll()` (which calls `Instance.disposeAll()` 300ms later via the debounce in [`packages/opencode/src/kilocode/dispose.ts`](packages/opencode/src/kilocode/dispose.ts)). However without the dynamic `fetch` function, the SDK-level model calls will still use the cached token from when the instance was initialized.
+
+There is also a minor bug in the current `handleLogout()` in [`packages/kilo-vscode/src/KiloProvider.ts`](packages/kilo-vscode/src/KiloProvider.ts:1707): `global.dispose()` is called **after** the catch block, meaning it always runs regardless of whether the logout succeeded or failed, and runs even if `this.client` becomes null after the `auth.remove` call fails. This is low-severity.
+
+## Evidence
+
+### Core fix commit (on branch, not merged):
+```
+28d1f88d6 fix: read kilo auth token dynamically per-request to fix login/logout persistence
+  remotes/origin/mark/fix-auth-persistence-6399
+```
+
+Commit message: _"The kilo provider's CUSTOM_LOADER previously ran once at startup (via Instance.state() caching), so the auth token was captured at init time. Login or logout after startup wouldn't affect the cached SDK instance. Fix by injecting a dynamic fetch function into the kilo provider options that calls Auth.get('kilo') on every request. Fixes #6399"_
+
+### Related merged fix (PR #6659 — addresses symptoms but not root cause):
+```
+c3ed9466a fix: invalidate model cache on auth/org changes and reload state after dispose
+  merged to main via 51a4a4f8f (PR #6659)
+```
+
+## Recommendation
+
+**Do NOT close this issue.** The root fix (`28d1f88d6`) is on a separate branch (`mark/fix-auth-persistence-6399`) and has not been merged to `main` yet. The PR containing that branch should be reviewed and merged.
+
+After that fix is merged, retest to confirm that:
+1. Logging out actually prevents requests to paid models from succeeding
+2. Logging in mid-session makes paid model access work without restarting
+3. Organization switching propagates correctly
+
+Once the root fix PR is merged, this issue can be closed.

--- a/github/issue-triage/6403.md
+++ b/github/issue-triage/6403.md
@@ -1,0 +1,49 @@
+# Issue #6403: Filter subagent sessions from session history
+
+**Priority:** P1
+**Board Status:** Done (Closed)
+**Verdict:** PARTIALLY FIXED
+
+## Issue Summary
+
+Subagent sessions (sessions created automatically as part of a parent session's execution) were showing up in the session history list, making it confusing for users who didn't intentionally start them. They should be filtered out since they're part of a parent session.
+
+## Investigation
+
+The issue is marked as **closed** and the board status is **Done**, and there is a dedicated branch `origin/fix/6403-filter-subagent-sessions` with commit `eb7b0f8b1 fix: filter subagent sessions from session history`. However, this commit is **NOT yet merged into `main`**.
+
+In the current `main` branch:
+
+1. **Server-side**: The `session.list` API in `packages/opencode/src/server/routes/session.ts` supports a `roots: true` query parameter to filter sessions with no `parentID`. This is backed by `packages/opencode/src/session/index.ts` which adds `isNull(SessionTable.parent_id)` condition when `roots: true`.
+
+2. **Extension client**: In `packages/kilo-vscode/src/KiloProvider.ts` line 873, sessions are fetched as:
+   ```typescript
+   client.session.list({ directory: dir }, { throwOnError: true }).then(({ data }) => data)
+   ```
+   The `roots: true` flag is **NOT** being passed, meaning subagent sessions are included.
+
+3. **SessionInfo type**: In `packages/kilo-vscode/webview-ui/src/types/messages.ts`, `SessionInfo` doesn't expose `parentID`, so the webview can't filter client-side either.
+
+The fix exists in a branch but hasn't been merged to main.
+
+## Evidence
+
+```typescript
+// packages/kilo-vscode/src/KiloProvider.ts:873 - missing roots:true
+listSessions: client
+  ? (dir: string) => client.session.list({ directory: dir }, { throwOnError: true }).then(({ data }) => data)
+  : null,
+```
+
+```typescript
+// packages/opencode/src/session/index.ts:574-576 - server-side filter exists but not called
+if (input?.roots) {
+  conditions.push(isNull(SessionTable.parent_id))
+}
+```
+
+Branch with fix: `origin/fix/6403-filter-subagent-sessions` (commit `eb7b0f8b1`)
+
+## Recommendation
+
+The fix exists in branch `fix/6403-filter-subagent-sessions` but has not been merged to `main`. The PR should be reviewed and merged. Once merged, this issue would be fully resolved. Do NOT re-close this issue as "done" until the branch is merged.

--- a/github/issue-triage/6541.md
+++ b/github/issue-triage/6541.md
@@ -1,0 +1,78 @@
+# Issue #6541: [FEATURE]: Make it clear what command/folder is being added to permissions, provide multiple options
+
+**Priority:** P1
+**Board Status:** Backlog
+**Verdict:** NOT FIXED
+
+## Issue Summary
+
+When clicking "Allow Always" in the permission approval prompt, it should be clear what exact permission pattern will be saved. Additionally, multiple granularity options should be offered (e.g., "allow this exact command", "allow this command prefix", "allow all commands") similar to how Claude Code and the prior Kilo extension handled it.
+
+## Investigation
+
+Looking at the current permission approval UI in `packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx`:
+
+```tsx
+<div data-component="permission-prompt">
+  <div data-slot="permission-actions">
+    <Button variant="ghost" size="small" onClick={() => decide("reject")}>
+      {language.t("ui.permission.deny")}
+    </Button>
+    <Button variant="secondary" size="small" onClick={() => decide("always")}>
+      {language.t("ui.permission.allowAlways")}
+    </Button>
+    <Button variant="primary" size="small" onClick={() => decide("once")}>
+      {language.t("ui.permission.allowOnce")}
+    </Button>
+  </div>
+  <p data-slot="permission-hint">{language.t("ui.permission.sessionHint")}</p>
+</div>
+```
+
+The UI shows patterns (from `perm.patterns`) as code blocks but provides only three binary choices: Deny, Allow Always, Allow Once. There is **no UI to:**
+1. Show exactly what pattern will be saved to config when clicking "Allow Always"
+2. Offer multiple specificity levels (e.g., "allow just `git commit`" vs "allow all `git` commands" vs "allow all bash commands")
+
+Looking at `packages/kilo-vscode/webview-ui/src/types/messages.ts`, the `PermissionRequest` type includes `patterns: string[]` but there's no UI element that explains what those patterns mean in practice or what will be saved.
+
+No recent commits address this specific feature. There's no component or logic for multi-option permission approval.
+
+The related doc `packages/kilo-vscode/docs/ui-polish/approval-box-full-path.md` shows there was work on showing the full path in the approval box, but that doesn't cover the multiple granularity options requested here.
+
+## Evidence
+
+```typescript
+// packages/kilo-vscode/webview-ui/src/types/messages.ts
+export interface PermissionRequest {
+  id: string
+  sessionID: string
+  toolName: string
+  patterns: string[]
+}
+```
+
+```tsx
+// packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+// Patterns ARE shown but as bare code blocks:
+<Show when={perm.patterns.length > 0}>
+  <div class="permission-dock-patterns">
+    <For each={perm.patterns}>
+      {(pattern) => <code class="permission-dock-pattern">{pattern}</code>}
+    </For>
+  </div>
+</Show>
+// No explanation of what "Allow Always" will save, no multiple granularity options
+```
+
+## Recommendation
+
+This feature is **NOT implemented**. The permission approval dialog needs:
+
+1. **Clarity**: Show explicitly what pattern will be added to `~/.config/kilo/config.json` if "Allow Always" is clicked (e.g., "This will add `bash.git commit` = allow to your config")
+2. **Multiple options**: Offer granularity choices, for example:
+   - Allow this exact command: `git commit -m "..."`  
+   - Allow all `git commit` commands: `bash.git commit`
+   - Allow all `git` commands: `bash.git *`
+   - Allow all bash commands: `bash.*`
+
+This is a significant UX improvement for the permission system and requires UI work in `ChatView.tsx` and likely changes to how the permission decision is sent back to the server.

--- a/github/issue-triage/6552.md
+++ b/github/issue-triage/6552.md
@@ -1,0 +1,107 @@
+# Issue #6552: LLM.stream small-model requests leak into subsequent agent session
+
+**Priority:** P0
+**Board Status:** In progress
+**Verdict:** NOT FIXED
+
+## Issue Summary
+
+When a small-model `LLM.stream` request (commit message generation or enhance prompt) is followed by an agent session prompt, the first agent request is sent to **both** the small model and the main agent model. This happens because the Kilo Gateway routes requests based on the `X-KILOCODE-TASKID` header (= `input.sessionID`), and the small-model requests use static/predictable session IDs (`"commit-message"` or `"enhance-prompt"`). The gateway-side session state from these static IDs then leaks into the real agent session.
+
+## Investigation
+
+### Key files examined
+
+1. **[`packages/opencode/src/session/llm.ts`](packages/opencode/src/session/llm.ts:241)** — The `LLM.stream()` function at line 241 sends `input.sessionID` as `X-KILOCODE-TASKID` header unconditionally for the `kilo` provider:
+   ```ts
+   ...(isKilo ? { [HEADER_TASKID]: input.sessionID } : {}),
+   ```
+
+2. **[`packages/opencode/src/kilocode/enhance-prompt.ts`](packages/opencode/src/kilocode/enhance-prompt.ts:40)** — passes `sessionID: "enhance-prompt"` as a static string:
+   ```ts
+   sessionID: "enhance-prompt",
+   ```
+
+3. **[`packages/opencode/src/commit-message/generate.ts`](packages/opencode/src/commit-message/generate.ts)** — passes `sessionID: "commit-message"` as a static string:
+   ```ts
+   sessionID: "commit-message",
+   ```
+
+4. **[`packages/kilo-gateway/src/provider.ts`](packages/kilo-gateway/src/provider.ts)** — `createKilo()` wraps OpenRouter with a fixed `wrappedFetch` that sets static headers at construction time (lines 38–66). The SDK instance is then **cached** in `provider.ts` state by a hash of `{providerID, npm, options}`, meaning both small-model and main-model requests through the same `kilo` provider share the same SDK instance and `createOpenRouter` session state.
+
+5. **[`packages/opencode/src/provider/provider.ts:1093`](packages/opencode/src/provider/provider.ts:1093)** — SDK caching key:
+   ```ts
+   const key = Bun.hash.xxHash32(JSON.stringify({ providerID: model.providerID, npm: model.api.npm, options }))
+   const existing = s.sdk.get(key)
+   if (existing) return existing
+   ```
+   The cache key does **not** include the model ID nor the session ID, so all requests to `kilo/auto-small` and `kilo/claude-sonnet-4` (or any other kilo model) reuse the **same** SDK instance.
+
+6. **[`packages/opencode/src/provider/provider.ts:1196`](packages/opencode/src/provider/provider.ts:1196)** — `getLanguage()` further caches at a `providerID/modelID` level:
+   ```ts
+   const key = `${model.providerID}/${model.id}`
+   if (s.models.has(key)) return s.models.get(key)!
+   ```
+   This means `kilo/auto-small` and `kilo/claude-sonnet-4` get different language model instances, but they are both backed by the **same** `createKilo()` SDK instance and thus share the same OpenRouter session state.
+
+### The root cause
+
+The `X-KILOCODE-TASKID` header is sent per-request via `streamText`'s `headers` param in `LLM.stream()`. The `kilo` gateway server-side uses this value to associate the request with a "task" (session). When a small-model request sends `X-KILOCODE-TASKID: commit-message` (or `enhance-prompt`), the gateway tracks that task ID with the small model. 
+
+However, the issue also involves the `createKilo()` SDK instance caching in the provider—both the small model (e.g., `auto-small`) and the main model share the same OpenRouter provider session. If OpenRouter/Kilo Gateway maintains state keyed on something in the shared provider instance (e.g., a connection-level session or per-origin state), the first request to the main agent could be contaminated.
+
+The **per-request** `X-KILOCODE-TASKID` header *is* passed correctly through `streamText`'s `headers` field and should reach the gateway server on each call. But the static IDs (`"commit-message"`, `"enhance-prompt"`) are **never unique per invocation**—meaning every commit message generation ever done maps to the same task ID on the gateway, and that gateway task state may bleed into subsequent requests if not properly isolated server-side.
+
+### What has NOT changed
+
+No commits since the issue was filed (2026-03-03) address:
+- The static `sessionID` strings in `enhance-prompt.ts` or `commit-message/generate.ts`
+- Any per-invocation uniqueness for small-model session IDs
+- Any server-side isolation in `kilo-gateway` for small vs. agent task IDs
+
+Recent commits since issue creation:
+- `55928ab3c` — fix: remove duplicate reasoning hack (unrelated)
+- `c3ed9466a` — fix: invalidate model cache on auth/org changes (different issue)
+
+## Evidence
+
+### Static session IDs:
+
+[`packages/opencode/src/kilocode/enhance-prompt.ts`](packages/opencode/src/kilocode/enhance-prompt.ts:40):
+```ts
+sessionID: "enhance-prompt",   // always the same — never unique
+```
+
+[`packages/opencode/src/commit-message/generate.ts`](packages/opencode/src/commit-message/generate.ts):
+```ts
+sessionID: "commit-message",   // always the same — never unique
+```
+
+### Header sent to Kilo Gateway:
+
+[`packages/opencode/src/session/llm.ts:241`](packages/opencode/src/session/llm.ts:241):
+```ts
+...(isKilo ? { [HEADER_TASKID]: input.sessionID } : {}),
+```
+
+This means the gateway receives `X-KILOCODE-TASKID: commit-message` for all commit message requests and `X-KILOCODE-TASKID: enhance-prompt` for all enhance prompt requests. If the gateway maintains per-task routing state (e.g., model affinity, streaming session), that state from the small-model task could then appear when the next actual agent session begins—especially if the first real session request races with or follows immediately after such a small-model request.
+
+### SDK instance sharing:
+
+[`packages/opencode/src/provider/provider.ts:1093`](packages/opencode/src/provider/provider.ts:1093) — The cache key is based on `{providerID, npm, options}` only. Both `kilo/auto-small` and `kilo/claude-sonnet-4` use the same provider options, so they share one `createKilo()` SDK instance, including its `wrappedFetch` closure, which could be carrying state.
+
+## Recommendation
+
+This issue is **NOT FIXED**. The following work is needed:
+
+1. **Generate unique session IDs for small-model requests.** Instead of the hardcoded strings `"commit-message"` and `"enhance-prompt"`, generate a per-invocation unique ID (e.g., using a UUID or a timestamp-based ID):
+   ```ts
+   sessionID: `commit-message-${crypto.randomUUID()}`,
+   sessionID: `enhance-prompt-${crypto.randomUUID()}`,
+   ```
+
+2. **Verify gateway-side task isolation.** Confirm that the Kilo Gateway does not persist state across distinct task IDs that would cause routing contamination when a new agent session starts immediately after a small-model task.
+
+3. **Consider not sending `HEADER_TASKID` for small/utility requests** that are not real agent sessions, or ensure the gateway explicitly ignores/resets state for non-agent task-ID patterns.
+
+The issue should remain open until these client-side and server-side changes are verified.

--- a/github/issue-triage/6558.md
+++ b/github/issue-triage/6558.md
@@ -1,0 +1,83 @@
+# Issue #6558: Make it easy to grab provider/inference error details
+
+**Priority:** P0
+**Board Status:** Backlog
+**Verdict:** PARTIALLY FIXED
+
+## Issue Summary
+
+When a provider/inference error occurs during a chat session, users cannot easily see or copy the error details (model name, provider, error message, status code, response body). The request is to:
+1. Show major errors (those stopping the session) directly in the chat session
+2. For minor errors (tool call errors, etc.), make them clickable so detailed info is accessible
+
+This issue was flagged as a duplicate of [#6207](https://github.com/Kilo-Org/kilocode/issues/6207), which requests inline exposure of error details without needing to open a popup.
+
+## Investigation
+
+### Backend error handling (`packages/opencode/src/provider/error.ts`)
+
+The `ProviderError` namespace provides robust error parsing:
+- [`ProviderError.parseAPICallError()`](packages/opencode/src/provider/error.ts:166) captures: `message`, `statusCode`, `isRetryable`, `responseHeaders`, `responseBody`, `metadata` (including API `url`)
+- [`ProviderError.parseStreamError()`](packages/opencode/src/provider/error.ts:112) handles mid-stream OpenAI-style errors
+- The `message()` function at line 50 attempts to extract clean human-readable messages from raw response bodies
+- A recent fix (commit `6b7e6bde4`, 2026-03-01) improved HTML error response parsing
+
+### Error data model (`packages/opencode/src/session/message-v2.ts`)
+
+The [`MessageV2.APIError`](packages/opencode/src/session/message-v2.ts:36) type stores full error details in the schema:
+- `message`, `statusCode`, `isRetryable`, `responseHeaders`, `responseBody`, `metadata`
+
+These rich error details are persisted on the `assistantMessage.error` and in [`RetryPart`](packages/opencode/src/session/message-v2.ts:221) parts.
+
+### Frontend error display (`packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx`)
+
+The UI currently:
+1. [`errorText()`](packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx:142) extracts only `error?.data?.message` from the error object — discarding `statusCode`, `responseBody`, `metadata`, `providerID`, and model name
+2. The error is rendered at lines 329–334 as a simple `<Card variant="error">` showing just the single error text string — **no copy-to-clipboard**, **no expandable details**, **no status code or provider shown**
+3. No "Details" link or click-to-expand mechanism exists in the current implementation
+
+The `unwrapError()` helper (lines 43–83) does sophisticated JSON parsing to extract nested error messages from raw API responses, which covers the "show message" portion of the request.
+
+## Evidence
+
+**Error is displayed** (partially addresses the issue):
+```tsx
+{/* Error card */}
+<Show when={error()}>
+  <Card variant="error" class="error-card">
+    {errorText()}   {/* Only shows message, not statusCode/responseBody/providerID */}
+  </Card>
+</Show>
+```
+— [`VscodeSessionTurn.tsx:329-334`](packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx:329)
+
+**Rich error data available but not surfaced to UI:**
+```typescript
+export const APIError = NamedError.create(
+  "APIError",
+  z.object({
+    message: z.string(),
+    statusCode: z.number().optional(),
+    isRetryable: z.boolean(),
+    responseHeaders: z.record(z.string(), z.string()).optional(),
+    responseBody: z.string().optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
+  }),
+)
+```
+— [`message-v2.ts:36-47`](packages/opencode/src/session/message-v2.ts:36)
+
+**Missing in UI:** No copy button, no expandable detail panel, no provider/model/statusCode display on the error card. The referenced issue #6207 (the "original" duplicate) is also still open.
+
+## Recommendation
+
+The issue is **partially fixed**: major provider errors are now shown in the chat session (the error card is rendered inline), but:
+
+1. **Not fixed**: No easy way to copy error details — `responseBody`, `statusCode`, `providerID`, and model name are available in the data layer but not surfaced
+2. **Not fixed**: No expandable "Details" or copy-to-clipboard button on the error card
+3. **Not fixed**: Minor tool errors don't have a clickable expand mechanism for details
+
+The issue should remain **open**. Work remaining:
+- Add a copy button or expandable section to the error card in [`VscodeSessionTurn.tsx`](packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx:329)
+- Surface `statusCode`, `providerID`, and `responseBody` in the expanded/copied error text
+- Consider consolidating with issue #6207 since they are near-identical requests

--- a/github/issue-triage/6574.md
+++ b/github/issue-triage/6574.md
@@ -1,0 +1,105 @@
+# Issue #6574: Permissions boxes for Read don't show the file name until after you've approved it
+
+**Priority:** P0
+**Board Status:** Done (reopened)
+**Verdict:** PARTIALLY FIXED
+
+## Issue Summary
+
+When the AI agent requests permission to read a file, the permission approval box did not show the file name (subtitle) before the user approved it. The file name only appeared after approval, making it hard to verify what was being accessed.
+
+## Investigation
+
+### Root Cause
+
+The structural cause is in [`packages/ui/src/components/basic-tool.tsx`](packages/ui/src/components/basic-tool.tsx:108):
+
+```tsx
+const pending = () => props.status === "pending" || props.status === "running"
+
+<Show when={!pending()}>
+  <Show when={trigger().subtitle}>
+    <span data-slot="basic-tool-tool-subtitle">
+      {trigger().subtitle}
+    </span>
+  </Show>
+</Show>
+```
+
+The subtitle (which contains the filename derived from `input.filePath`) is **hidden whenever the tool status is `"pending"` or `"running"`**. When a permission prompt is shown, the tool is in `"pending"` state, so the filename is suppressed.
+
+The `read` tool renderer in [`packages/ui/src/components/message-part.tsx`](packages/ui/src/components/message-part.tsx:1172) correctly constructs the subtitle from the already-available input:
+
+```tsx
+ToolRegistry.register({
+  name: "read",
+  render(props) {
+    return (
+      <BasicTool
+        {...props}
+        icon="glasses"
+        trigger={{
+          title: i18n.t("ui.tool.read"),
+          subtitle: props.input.filePath ? getFilename(props.input.filePath) : "",
+          args,
+        }}
+        ...
+      />
+    )
+  },
+})
+```
+
+The `input.filePath` IS available in the pending state — the file name data is there, but `BasicTool`'s `<Show when={!pending()}>` guard prevents it from being rendered.
+
+### Git History
+
+Several related commits address this area:
+
+- **`ef1bbe64c`** (`fix(vscode): register renderers for glob/grep/read/list with input details`) — Added a `ContextToolRenderer` in VS Code's `VscodeToolOverrides.tsx` that explicitly computed and passed title/subtitle/args from tool input for all states including pending.  
+- **`a438272ae`** (`revert: remove ContextToolRenderer override for glob/grep/read/list`) — Reverted the above because "the upstream kilo-ui already registers proper renderers for these tools that show subtitle and args." However, the structural issue in `BasicTool` that hides the subtitle in pending state persists.
+
+A comment from `markijbema` on March 5, 2026 states:
+> "I've made a hacky fix for certain permissions prompt, but there is still something structurally wrong. The subject giving permission for should show right to the type of permission (read; glob, ..). So currently not all work (though read probably does, but in a hacky way)"
+
+### Current State of VscodeToolOverrides.tsx
+
+[`packages/kilo-vscode/webview-ui/src/components/chat/VscodeToolOverrides.tsx`](packages/kilo-vscode/webview-ui/src/components/chat/VscodeToolOverrides.tsx) only overrides `bash` to be open by default — no subtitle fix exists here.
+
+## Evidence
+
+**The blocking line in BasicTool:**  
+[`packages/ui/src/components/basic-tool.tsx:108`](packages/ui/src/components/basic-tool.tsx:108):
+```tsx
+<Show when={!pending()}>
+  <Show when={trigger().subtitle}>
+    ...{trigger().subtitle}...
+  </Show>
+</Show>
+```
+
+**The PermissionRequest type** in [`packages/kilo-vscode/webview-ui/src/types/messages.ts:126`](packages/kilo-vscode/webview-ui/src/types/messages.ts:126) does include a `patterns` field:
+```ts
+export interface PermissionRequest {
+  id: string
+  sessionID: string
+  toolName: string
+  patterns: string[]        // patterns are passed  
+  args: Record<string, unknown>
+  ...
+}
+```
+
+The `patterns` field is shown in the permission prompt in [`AssistantMessage.tsx:91`](packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx:91) — so `patterns` do render. The issue is the tool card's subtitle (the filename from `input.filePath`) is hidden while pending.
+
+**The "hacky fix" referenced** is in the upstream `kilo-ui`'s `basic-tool.tsx` — it now includes a `kilocode_change` icon rendering. But the core subtitle suppression logic hasn't changed structurally.
+
+## Recommendation
+
+**The issue should remain open.** Mark's own comment confirms it is only partially fixed with a "hacky" workaround for `read`. The proper fix requires either:
+
+1. **Change `BasicTool`** to show the subtitle even in pending state (when the subtitle comes from `input`, not from `output`/runtime data). The guard `<Show when={!pending()}>` should be removed or the logic split so that input-derived subtitles always show.
+
+2. **Pass the filename via a different field** (e.g., a separate `alwaysShowSubtitle` prop on `BasicTool`) that bypasses the pending suppression.
+
+The fix applies to `basic-tool.tsx` in `packages/ui/src/components/` (shared by all UI surfaces) or at the individual tool-renderer level (making the `read`/`glob`/`grep`/`list` renderers use the JSX trigger form instead of `TriggerTitle`, so they can control their own visibility logic independently of `BasicTool`'s pending guard).

--- a/github/issue-triage/6617.md
+++ b/github/issue-triage/6617.md
@@ -1,0 +1,111 @@
+# Issue #6617: Increase clarity of permissions box
+
+**Priority:** P0
+**Board Status:** In progress
+**Verdict:** PARTIALLY FIXED
+
+## Issue Summary
+
+The permissions approval box (shown when Kilo requests permission to perform a tool action requiring user approval) looks visually similar to normal shell output, making it hard to quickly identify as requiring user attention. Two improvements were requested:
+
+1. Restore a yellowish outline/border to draw attention to the box
+2. (Nice-to-have) Make the approve/deny buttons slightly larger for easier interaction
+
+A follow-up comment from the designer (`halyna-hlynska`) confirmed both ideas and noted that upcoming button color improvements (more vibrant blue accent) and possibly switching from small (24px) to standard (32px) button size would also help.
+
+## Investigation
+
+### Permission Box Component
+
+The permission box is rendered in several places in `packages/kilo-vscode/webview-ui/src/`:
+
+- **[`AssistantMessage.tsx`](packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx:81)** — inline permission prompts attached to tool calls (tool-linked permissions)
+- **[`ChatView.tsx`](packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx:81)** — bottom-dock permission prompts for non-tool-linked permissions
+- **[`TaskToolExpanded.tsx`](packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx:134)** — permissions from child (sub-agent) sessions
+
+All permission boxes use `data-component="tool-part-wrapper"` with `data-permission="true"` on the outer wrapper, and `data-component="permission-prompt"` for the actions section.
+
+### CSS Styling
+
+Current permission box styles in [`chat.css`](packages/kilo-vscode/webview-ui/src/styles/chat.css:705):
+
+```css
+/* Permission Prompt (inline with tool cards) */
+[data-component="tool-part-wrapper"][data-permission="true"] {
+  /* When wrapping a Part + permission, the outer wrapper provides the card border.
+     Remove the inner Part's tool-part-wrapper border so we don't get double borders. */
+  > [data-component="tool-part-wrapper"] {
+    border: none;
+    border-radius: 0;
+  }
+}
+
+[data-component="permission-prompt"] {
+  border-top: 1px solid var(--border-weak-base, var(--vscode-panel-border));
+  padding: 8px 12px;
+}
+```
+
+**No yellow/warning border** is applied to the outer wrapper in the current `main` branch — the border uses whatever the default `tool-part-wrapper` border is (from `kilo-ui`), blending in with regular tool output.
+
+### Recent Commits Addressing the Issue
+
+A flurry of permission-related commits were made (all on ~2026-03-03 to 2026-03-05):
+
+| Commit | Message |
+|--------|---------|
+| `b420bac7b` | `fix(vscode): render permission prompt inside tool card border` |
+| `0c78cb26e` | `fix(vscode): add CSS styles for permission-prompt layout` |
+| `cb15ccb49` | `fix(vscode): render permission prompts inline with tool calls` |
+| `7711e8553` | `fix(vscode): show permission dock for tool-associated permissions` |
+| `21ea0fe23` | `fix(vscode): show permission patterns in inline permission prompt` |
+| `d1ec83690` | **`fix: add yellow warning border to permissions box for visual clarity`** |
+
+The key commit `d1ec83690` adds exactly what the issue requested — a yellow/warning border:
+
+```css
+[data-component="tool-part-wrapper"][data-permission="true"] {
+  border-color: var(--border-warning-base, var(--vscode-charts-yellow));
+  /* ... */
+}
+```
+
+### PR Status
+
+Two PRs were created to address this fix — **both are closed but NOT merged into `main`**:
+
+- **PR #6632** (kilo-code-bot, 2026-03-05): Closed without merge
+- **PR #6646** (markijbema, draft, 2026-03-05): Closed without merge — `merged: false`
+
+The fix commit lives on the remote branch `origin/fix/6617-permissions-box-clarity` only.
+
+## Evidence
+
+**Current `main` CSS** (lines 705–712 of [`chat.css`](packages/kilo-vscode/webview-ui/src/styles/chat.css:705)):
+```css
+[data-component="tool-part-wrapper"][data-permission="true"] {
+  /* No border-color — blends with normal tool output */
+  > [data-component="tool-part-wrapper"] {
+    border: none;
+    border-radius: 0;
+  }
+}
+```
+
+**Fix on `origin/fix/6617-permissions-box-clarity`** (commit `d1ec83690`):
+```diff
+ [data-component="tool-part-wrapper"][data-permission="true"] {
++  border-color: var(--border-warning-base, var(--vscode-charts-yellow));
++
+   /* When wrapping a Part + permission, the outer wrapper provides the card border. */
+```
+
+**Issue request #2 (button size/color):** Not addressed in any committed code. The designer's comment (2026-03-05) noted:
+- A more vibrant blue button color is coming in a separate button update
+- Standard (32px) button size could also help
+
+## Recommendation
+
+- **Do NOT close this issue** — the fix (`d1ec83690`) exists on branch `origin/fix/6617-permissions-box-clarity` but was never merged into `main` (both PRs #6632 and #6646 were closed without merging).
+- **Action needed:** Re-open PR #6646 as non-draft (or create a new PR) to merge the yellow border fix into `main`.
+- **Addressing item #2** (buttons): The designer commented that a forthcoming button color update may resolve this. The button size upgrade (small → standard/32px) is still pending and may warrant a follow-up issue or be tracked here.

--- a/github/issue-triage/6618.md
+++ b/github/issue-triage/6618.md
@@ -1,0 +1,88 @@
+# Issue #6618: Make it clear what you are always approving for permissions
+
+**Priority:** P0
+**Board Status:** In progress
+**Verdict:** NOT FIXED
+
+## Issue Summary
+
+When a user clicks "Always approve" (or "Allow always") in the VS Code extension permission prompt, there is no second confirmation dialog showing *which rule will be permanently added*. In the CLI (TUI), selecting "Allow always" transitions to a second `stage === "always"` screen that explicitly shows what pattern(s) will be remembered (e.g., `gh pr *` instead of the exact command `gh pr create <args>`). The extension skips this second step entirely — wiring the "always" button click directly to `permission.reply("always")` with no confirmation UI showing the derived rule scope.
+
+## Investigation
+
+### CLI TUI (reference implementation — works correctly)
+
+In [`packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx`](packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx:153), the `PermissionPrompt` component uses a two-stage flow:
+
+1. **Stage `"permission"`** — shows the specific tool call (e.g., `$ gh pr create --draft`).  
+   When the user selects "Allow always", it transitions to `setStore("stage", "always")`.
+2. **Stage `"always"`** — shows the *rule* that would be saved, drawn from `props.request.always[]`:
+   - If `always === ["*"]`, shows "This will allow `<permission>` until Kilo is restarted."
+   - Otherwise lists each pattern (e.g., `gh pr *`).
+   
+   The user must then click **Confirm** or **Cancel** before the SDK call is made.
+
+The `always` field is populated by the backend (`PermissionNext.Request.always: z.string().array()` at [`packages/opencode/src/permission/next.ts:75`](packages/opencode/src/permission/next.ts:75)).
+
+### VS Code Extension (broken)
+
+The `always` field from the SDK `PermissionRequest` is **not forwarded** to the webview. In [`packages/kilo-vscode/src/kilo-provider-utils.ts:218-230`](packages/kilo-vscode/src/kilo-provider-utils.ts:218), the `mapSSEEventToWebviewMessage` handler for `permission.asked` constructs only:
+
+```ts
+permission: {
+  id: event.properties.id,
+  sessionID: event.properties.sessionID,
+  toolName: event.properties.permission,
+  patterns: event.properties.patterns ?? [],
+  args: event.properties.metadata,
+  message: `Permission required: ${event.properties.permission}`,
+  tool: event.properties.tool,
+}
+```
+
+`event.properties.always` is dropped — it is not included in the mapped object.
+
+The webview-side `PermissionRequest` type at [`packages/kilo-vscode/webview-ui/src/types/messages.ts:126-134`](packages/kilo-vscode/webview-ui/src/types/messages.ts:126) also lacks an `always` field:
+
+```ts
+export interface PermissionRequest {
+  id: string
+  sessionID: string
+  toolName: string
+  patterns: string[]
+  args: Record<string, unknown>
+  message?: string
+  tool?: { messageID: string; callID: string }
+}
+```
+
+In [`packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx:110`](packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx:110) and [`packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx:106`](packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx:106), the "Allow always" button fires immediately without any intermediate confirmation:
+
+```tsx
+<Button variant="secondary" size="small" onClick={() => decide(p.id, "always")}>
+  {language.t("ui.permission.allowAlways")}
+</Button>
+```
+
+No second-stage dialog or rule-preview pane exists.
+
+### Recent commits
+
+Commits `21ea0fe23`, `b420bac7b`, `cb15ccb49`, `7711e8553` (all titled `fix(vscode): …permission…`) improved the rendering of permission prompts inline with tool cards and show patterns, but none added the second "Always allow" confirmation stage showing the rule being added.
+
+## Evidence
+
+1. **`always` field dropped in bridge** — [`packages/kilo-vscode/src/kilo-provider-utils.ts:218-230`](packages/kilo-vscode/src/kilo-provider-utils.ts:218): `event.properties.always` not mapped.
+2. **Webview type missing `always`** — [`packages/kilo-vscode/webview-ui/src/types/messages.ts:126-134`](packages/kilo-vscode/webview-ui/src/types/messages.ts:126).
+3. **No second-stage dialog** — [`packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx:110`](packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx:110), [`ChatView.tsx:106`](packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx:106), [`TaskToolExpanded.tsx:148`](packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx:148) — all fire `"always"` immediately.
+4. **TUI reference** — [`packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx:153-191`](packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx:153) shows the two-stage pattern that the extension is missing.
+
+## Recommendation
+
+This issue is **not fixed**. The following changes are needed:
+
+1. **Forward `always` in the bridge** — In [`kilo-provider-utils.ts`](packages/kilo-vscode/src/kilo-provider-utils.ts:218), add `always: event.properties.always ?? []` to the permission object.
+2. **Add `always` to the webview type** — In [`messages.ts`](packages/kilo-vscode/webview-ui/src/types/messages.ts:126), extend `PermissionRequest` with `always: string[]`.
+3. **Add second-stage confirmation dialog** — In `AssistantMessage.tsx`, `ChatView.tsx`, and `TaskToolExpanded.tsx`, add an intermediate state (similar to TUI's `stage === "always"`) that displays the rule patterns before confirming. When the user clicks "Allow always", show a summary such as "This will always allow `bash: gh pr *`" with Confirm/Cancel buttons.
+
+The issue should remain **open** until these three changes are implemented.

--- a/github/issue-triage/README.md
+++ b/github/issue-triage/README.md
@@ -1,0 +1,58 @@
+# Issue Triage Findings
+
+Investigation of open P0/P1 issues from [Project Board #25](https://github.com/orgs/Kilo-Org/projects/25) to determine if any have already been fixed in the codebase.
+
+## Summary
+
+Investigated **25 open issues** (5 P0, 20 P1). Found:
+
+- **3 issues that should be CLOSED** (fully fixed)
+- **11 issues PARTIALLY FIXED** (some work done, more needed)
+- **11 issues NOT FIXED** (still need work)
+
+### ✅ Issues That Should Be Closed
+
+| # | Priority | Title | Notes |
+|---|----------|-------|-------|
+| [#6064](6064.md) | P1 | Autocomplete (VSCode Extension) | Full autocomplete subsystem implemented with ~30 files |
+| [#6143](6143.md) | P1 | Continually prompted to implement in Plan mode | Fixed via `shouldAskPlanFollowup()` with comprehensive tests |
+| [#6255](6255.md) | P1 | Clickable items should change the cursor | Already closed on GitHub; `cursor: pointer` added to all interactive elements |
+
+### ⚠️ Issues Partially Fixed (need remaining work or unmerged PRs)
+
+| # | Priority | Title | What's Missing |
+|---|----------|-------|----------------|
+| [#6574](6574.md) | P0 | Permissions boxes for Read don't show filename | `BasicTool` suppresses subtitle in pending state; hacky fix exists but structural issue remains |
+| [#6617](6617.md) | P0 | Increase clarity of permissions box | Yellow border fix exists on branch but PRs were closed without merging |
+| [#6558](6558.md) | P0 | Make it easy to grab provider/inference error details | Backend captures rich errors but UI only shows message text, no copy/expand |
+| [#6399](6399.md) | P1 | Logging in/out isn't persisted properly | Root fix on unmerged branch `mark/fix-auth-persistence-6399`; symptom mitigation merged |
+| [#6068](6068.md) | P1 | Provider Settings (VSCode Extension) | ProvidersTab exists but missing API key management and proper provider names |
+| [#6092](6092.md) | P1 | Full path never shown in approval boxes | Fixed for read/directory listing; edit/write still use relative paths |
+| [#6188](6188.md) | P1 | Onboarding experience for upgraders | Migration wizard works for legacy users; no onboarding for fresh installs |
+| [#6211](6211.md) | P1 | Remember last model choice (VSCode) | Read side implemented; write side (persisting changes) missing |
+| [#6256](6256.md) | P1 | Show terminal command details in UI | Command and output shown inline; exit code indicator missing |
+| [#6339](6339.md) | P1 | Plan to code switching | PlanFollowup system works; auto-switch permission setting not implemented |
+| [#6371](6371.md) | P1 | Improve Permission Settings (VSCode) | AutoApproveTab exists with per-tool settings; per-pattern command rules missing |
+| [#6403](6403.md) | P1 | Filter subagent sessions from history | Fix exists on unmerged branch `fix/6403-filter-subagent-sessions` |
+
+### ❌ Issues Not Fixed
+
+| # | Priority | Title | Notes |
+|---|----------|-------|-------|
+| [#6552](6552.md) | P0 | LLM.stream small-model requests leak into subsequent session | Static session IDs and shared SDK instances cause cross-session contamination |
+| [#6618](6618.md) | P0 | Make it clear what you are always approving | VS Code extension missing two-stage "always approve" confirmation (TUI has it) |
+| [#6074](6074.md) | P1 | Use correct default model | Hardcoded fallbacks ignore CLI defaults and user config |
+| [#6082](6082.md) | P1 | Anonymous signin prompts (VSCode) | No proactive sign-in prompts for anonymous users |
+| [#6163](6163.md) | P1 | Custom OpenAI-Compatible Provider UI | No custom provider form in settings UI |
+| [#6221](6221.md) | P1 | Markdown syntax highlighting blocks main thread | Still synchronous `codeToHtml()` on main thread |
+| [#6230](6230.md) | P1 | Re-adding Architect mode / Plan writes to /plans | No Architect mode; plans stored in `.opencode/plans/` not top-level |
+| [#6370](6370.md) | P1 | Plan files saved in opencode directory | Still hardcoded to `.opencode/plans/` instead of `.kilocode/plans/` |
+| [#6373](6373.md) | P1 | Feedback button prior to beta | No dedicated feedback button; only passive link in About tab |
+| [#6541](6541.md) | P1 | Clear what command/folder added to permissions | No explanation or granularity options in "Allow Always" dialog |
+
+### Key Themes
+
+1. **Unmerged fix branches**: Several issues (#6399, #6403, #6617) have working fixes on branches that were never merged to `main`
+2. **Permissions UX**: 5 of the 25 issues relate to permission box clarity — this is the biggest UX gap
+3. **VS Code ↔ CLI parity**: The TUI often has features (two-stage always-approve, plan follow-up) that the VS Code extension lacks
+4. **Branding**: `.opencode/` paths haven't been renamed to `.kilocode/` (#6370)


### PR DESCRIPTION
Investigation of 25 open P0/P1 issues from [Project Board #25](https://github.com/orgs/Kilo-Org/projects/25) to determine which are already fixed in the codebase.

## Key Findings

- **3 issues can be closed** -- fully fixed: #6064, #6143, #6255
- **11 issues partially fixed** -- some work done, more needed (several have working fixes on unmerged branches)
- **11 issues not fixed** -- still need work

## Issues That Should Be Closed

- **#6064** -- Autocomplete (VSCode Extension): full autocomplete subsystem implemented with ~30 files
- **#6143** -- Continually prompted to implement in Plan mode: fixed via shouldAskPlanFollowup() with comprehensive tests
- **#6255** -- Clickable items should change the cursor: already closed on GitHub; cursor: pointer added to all interactive elements

## Partially Fixed -- Unmerged Branches

Several issues have working fixes sitting on branches that were never merged to main:

- **#6399** -- Auth persistence fix on mark/fix-auth-persistence-6399
- **#6403** -- Subagent session filtering on fix/6403-filter-subagent-sessions
- **#6617** -- Permissions box clarity yellow border fix exists on a closed branch

## Key Themes

1. **Permissions UX**: 5 of 25 issues relate to permission box clarity -- the biggest UX gap
2. **VS Code vs CLI parity**: TUI has features (two-stage always-approve, plan follow-up) missing from the extension
3. **Branding**: .opencode/ paths not yet renamed to .kilocode/ (#6370)

Full details in github/issue-triage/README.md with individual issue files for each of the 25 issues.