### PR TITLE
fix(agent-manager): resolve macOS shell PATH for GUI-launched VS Code

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -8,10 +8,10 @@
 
 import * as path from "path"
 import * as fs from "fs"
-import * as cp from "child_process"
 import simpleGit, { type SimpleGit } from "simple-git"
 import { generateBranchName, sanitizeBranchName } from "./branch-name"
 import type { GitOps } from "./GitOps"
+import { execWithShellEnv } from "./shell-env"
 import {
   parsePRUrl,
   localBranchName,
@@ -561,13 +561,9 @@ export class WorktreeManager {
     }
   }
 
-  private exec(cmd: string, args: string[], timeout = 120000): Promise<string> {
-    return new Promise((resolve, reject) => {
-      cp.execFile(cmd, args, { cwd: this.root, timeout, encoding: "utf-8" }, (error, stdout) => {
-        if (error) reject(error)
-        else resolve(stdout)
-      })
-    })
+  private async exec(cmd: string, args: string[], timeout = 120000): Promise<string> {
+    const { stdout } = await execWithShellEnv(cmd, args, { cwd: this.root, timeout })
+    return stdout
   }
 
   private async gitExec(args: string[]): Promise<void> {

--- a/packages/kilo-vscode/src/agent-manager/shell-env.ts
+++ b/packages/kilo-vscode/src/agent-manager/shell-env.ts
@@ -1,0 +1,129 @@
+/**
+ * macOS shell environment PATH resolution.
+ *
+ * When VS Code is launched from Finder, Spotlight, or the Dock, the extension
+ * host inherits a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) that excludes
+ * directories added by package managers (homebrew, nvm, pipx, etc.) and shell
+ * profiles (.zshrc, .bash_profile).
+ *
+ * This module lazily resolves the user's real PATH by spawning a login shell
+ * and caches the result. The fix is applied on first ENOENT and persisted to
+ * process.env.PATH so all subsequent child_process calls benefit.
+ */
+
+import { type ExecFileOptionsWithStringEncoding, execFile } from "child_process"
+import * as os from "os"
+import { promisify } from "util"
+
+const run = promisify(execFile)
+
+let cached: Record<string, string> | null = null
+let cacheTime = 0
+let fallback = false
+const TTL = 60_000
+const FALLBACK_TTL = 10_000
+
+let fixAttempted = false
+let fixSucceeded = false
+
+/**
+ * Spawn the user's login shell to capture environment variables (primarily PATH).
+ * Uses `-lc` (login + command) — avoids `-i` (interactive) to skip TTY prompts.
+ * Results are cached for 1 minute (10 seconds when the fallback was used).
+ */
+export async function getShellEnvironment(): Promise<Record<string, string>> {
+  const now = Date.now()
+  const ttl = fallback ? FALLBACK_TTL : TTL
+  if (cached && now - cacheTime < ttl) return { ...cached }
+
+  const shell = process.env.SHELL || (process.platform === "darwin" ? "/bin/zsh" : "/bin/bash")
+
+  try {
+    const { stdout } = await run(shell, ["-lc", "env"], {
+      timeout: 10_000,
+      env: { ...process.env, HOME: os.homedir() },
+    })
+
+    const env: Record<string, string> = {}
+    for (const line of stdout.split("\n")) {
+      const idx = line.indexOf("=")
+      if (idx > 0) {
+        env[line.substring(0, idx)] = line.substring(idx + 1)
+      }
+    }
+
+    cached = env
+    cacheTime = now
+    fallback = false
+    return { ...env }
+  } catch (error) {
+    console.warn(`[shell-env] Failed to get shell environment: ${error}. Falling back to process.env`)
+    const env: Record<string, string> = {}
+    for (const [key, value] of Object.entries(process.env)) {
+      if (typeof value === "string") env[key] = value
+    }
+    cached = env
+    cacheTime = now
+    fallback = true
+    return { ...env }
+  }
+}
+
+/**
+ * Execute a command, retrying once with shell environment on ENOENT.
+ *
+ * On macOS GUI launches, binaries installed by homebrew / nvm / etc. are not
+ * on the inherited PATH. When the first exec fails with ENOENT (command not
+ * found), this function resolves the user's login shell environment, patches
+ * process.env.PATH permanently, and retries the command.
+ */
+export async function execWithShellEnv(
+  cmd: string,
+  args: string[],
+  options?: Omit<ExecFileOptionsWithStringEncoding, "encoding">,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await run(cmd, args, { ...options, encoding: "utf8" })
+  } catch (error) {
+    if (
+      process.platform !== "darwin" ||
+      fixSucceeded ||
+      fixAttempted ||
+      !(error instanceof Error) ||
+      !("code" in error) ||
+      (error as NodeJS.ErrnoException).code !== "ENOENT"
+    ) {
+      throw error
+    }
+
+    fixAttempted = true
+    console.log(`[shell-env] "${cmd}" not found, resolving shell environment`)
+
+    try {
+      const env = await getShellEnvironment()
+
+      if (env.PATH) {
+        process.env.PATH = env.PATH
+        fixSucceeded = true
+        console.log("[shell-env] Patched process.env.PATH for GUI app")
+      }
+
+      const retry = env.PATH ? { ...env, ...options?.env, PATH: env.PATH } : { ...env, ...options?.env }
+
+      return await run(cmd, args, { ...options, encoding: "utf8", env: retry })
+    } catch (retryError) {
+      fixAttempted = false
+      console.error("[shell-env] Retry failed:", retryError)
+      throw retryError
+    }
+  }
+}
+
+/** Clear the cached environment (for tests). */
+export function clearShellEnvCache(): void {
+  cached = null
+  cacheTime = 0
+  fallback = false
+  fixAttempted = false
+  fixSucceeded = false
+}

--- a/packages/kilo-vscode/src/agent-manager/shell-env.ts
+++ b/packages/kilo-vscode/src/agent-manager/shell-env.ts
@@ -17,14 +17,45 @@ import { promisify } from "util"
 
 const run = promisify(execFile)
 
+// Environment variable keys match: letters, digits, underscores, starting with a non-digit.
+const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*=/
+
 let cached: Record<string, string> | null = null
 let cacheTime = 0
-let fallback = false
+let wasFallback = false
 const TTL = 60_000
 const FALLBACK_TTL = 10_000
 
-let fixAttempted = false
-let fixSucceeded = false
+/** In-flight fix promise so concurrent ENOENT callers wait on the same resolution. */
+let fixing: Promise<boolean> | null = null
+let fixed = false
+
+/**
+ * Parse `env` output, handling multiline variable values correctly.
+ *
+ * A new entry starts when a line matches `KEY=value` (KEY is a valid
+ * environment variable name). Lines that don't match are continuations
+ * of the previous value.
+ */
+function parseEnvOutput(stdout: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  let key: string | null = null
+  let value = ""
+
+  for (const line of stdout.split("\n")) {
+    const match = ENV_KEY_RE.exec(line)
+    if (match) {
+      if (key) env[key] = value
+      const idx = match[0].length - 1 // position of '='
+      key = line.substring(0, idx)
+      value = line.substring(idx + 1)
+    } else if (key) {
+      value += "\n" + line
+    }
+  }
+  if (key) env[key] = value
+  return env
+}
 
 /**
  * Spawn the user's login shell to capture environment variables (primarily PATH).
@@ -33,7 +64,7 @@ let fixSucceeded = false
  */
 export async function getShellEnvironment(): Promise<Record<string, string>> {
   const now = Date.now()
-  const ttl = fallback ? FALLBACK_TTL : TTL
+  const ttl = wasFallback ? FALLBACK_TTL : TTL
   if (cached && now - cacheTime < ttl) return { ...cached }
 
   const shell = process.env.SHELL || (process.platform === "darwin" ? "/bin/zsh" : "/bin/bash")
@@ -44,17 +75,10 @@ export async function getShellEnvironment(): Promise<Record<string, string>> {
       env: { ...process.env, HOME: os.homedir() },
     })
 
-    const env: Record<string, string> = {}
-    for (const line of stdout.split("\n")) {
-      const idx = line.indexOf("=")
-      if (idx > 0) {
-        env[line.substring(0, idx)] = line.substring(idx + 1)
-      }
-    }
-
+    const env = parseEnvOutput(stdout)
     cached = env
     cacheTime = now
-    fallback = false
+    wasFallback = false
     return { ...env }
   } catch (error) {
     console.warn(`[shell-env] Failed to get shell environment: ${error}. Falling back to process.env`)
@@ -64,9 +88,26 @@ export async function getShellEnvironment(): Promise<Record<string, string>> {
     }
     cached = env
     cacheTime = now
-    fallback = true
+    wasFallback = true
     return { ...env }
   }
+}
+
+/**
+ * Attempt to resolve the shell environment and patch process.env.PATH.
+ * Returns true if PATH was actually changed, false otherwise.
+ */
+async function resolvePath(): Promise<boolean> {
+  const original = process.env.PATH
+  const env = await getShellEnvironment()
+
+  if (env.PATH && env.PATH !== original) {
+    process.env.PATH = env.PATH
+    console.log("[shell-env] Patched process.env.PATH for GUI app")
+    return true
+  }
+  // Shell env was a fallback or PATH didn't change — resolution didn't help
+  return false
 }
 
 /**
@@ -76,6 +117,9 @@ export async function getShellEnvironment(): Promise<Record<string, string>> {
  * on the inherited PATH. When the first exec fails with ENOENT (command not
  * found), this function resolves the user's login shell environment, patches
  * process.env.PATH permanently, and retries the command.
+ *
+ * Concurrent callers that hit ENOENT share a single resolution promise so
+ * none are rejected prematurely.
  */
 export async function execWithShellEnv(
   cmd: string,
@@ -87,8 +131,6 @@ export async function execWithShellEnv(
   } catch (error) {
     if (
       process.platform !== "darwin" ||
-      fixSucceeded ||
-      fixAttempted ||
       !(error instanceof Error) ||
       !("code" in error) ||
       (error as NodeJS.ErrnoException).code !== "ENOENT"
@@ -96,26 +138,28 @@ export async function execWithShellEnv(
       throw error
     }
 
-    fixAttempted = true
+    // Already resolved and PATH was actually changed — no point retrying resolution.
+    // Just retry with the (already-patched) process.env.
+    if (fixed) {
+      return await run(cmd, args, { ...options, encoding: "utf8" })
+    }
+
+    // If another caller is already resolving, wait for it then retry.
+    if (fixing) {
+      await fixing
+      return await run(cmd, args, { ...options, encoding: "utf8" })
+    }
+
     console.log(`[shell-env] "${cmd}" not found, resolving shell environment`)
 
+    fixing = resolvePath()
     try {
-      const env = await getShellEnvironment()
-
-      if (env.PATH) {
-        process.env.PATH = env.PATH
-        fixSucceeded = true
-        console.log("[shell-env] Patched process.env.PATH for GUI app")
-      }
-
-      const retry = env.PATH ? { ...env, ...options?.env, PATH: env.PATH } : { ...env, ...options?.env }
-
-      return await run(cmd, args, { ...options, encoding: "utf8", env: retry })
-    } catch (retryError) {
-      fixAttempted = false
-      console.error("[shell-env] Retry failed:", retryError)
-      throw retryError
+      fixed = await fixing
+    } finally {
+      fixing = null
     }
+
+    return await run(cmd, args, { ...options, encoding: "utf8" })
   }
 }
 
@@ -123,7 +167,7 @@ export async function execWithShellEnv(
 export function clearShellEnvCache(): void {
   cached = null
   cacheTime = 0
-  fallback = false
-  fixAttempted = false
-  fixSucceeded = false
+  wasFallback = false
+  fixing = null
+  fixed = false
 }

--- a/packages/kilo-vscode/tests/unit/shell-env.test.ts
+++ b/packages/kilo-vscode/tests/unit/shell-env.test.ts
@@ -10,7 +10,7 @@ describe("getShellEnvironment", () => {
     const env = await getShellEnvironment()
     expect(env).toBeDefined()
     expect(typeof env.PATH).toBe("string")
-    expect(env.PATH.length).toBeGreaterThan(0)
+    expect(env.PATH!.length).toBeGreaterThan(0)
   })
 
   it("returns HOME", async () => {
@@ -30,6 +30,14 @@ describe("getShellEnvironment", () => {
     const second = await getShellEnvironment()
     expect(second.PATH).not.toBe("/mutated")
   })
+
+  it("handles multiline env values without corrupting PATH", async () => {
+    // PATH should never contain newlines — verify it parses correctly
+    // even if other env vars have multiline values (e.g. BASH_FUNC_*)
+    const env = await getShellEnvironment()
+    expect(env.PATH).toBeDefined()
+    expect(env.PATH).not.toContain("\n")
+  })
 })
 
 describe("execWithShellEnv", () => {
@@ -46,6 +54,13 @@ describe("execWithShellEnv", () => {
 
   it("throws on non-ENOENT errors", async () => {
     await expect(execWithShellEnv("ls", ["--nonexistent-flag-that-fails"])).rejects.toThrow()
+  })
+
+  it("concurrent calls don't reject prematurely", async () => {
+    // Both calls should succeed — neither should throw due to a race
+    const [a, b] = await Promise.all([execWithShellEnv("echo", ["first"]), execWithShellEnv("echo", ["second"])])
+    expect(a.stdout.trim()).toBe("first")
+    expect(b.stdout.trim()).toBe("second")
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/shell-env.test.ts
+++ b/packages/kilo-vscode/tests/unit/shell-env.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { getShellEnvironment, execWithShellEnv, clearShellEnvCache } from "../../src/agent-manager/shell-env"
+
+afterEach(() => {
+  clearShellEnvCache()
+})
+
+describe("getShellEnvironment", () => {
+  it("returns an object with PATH", async () => {
+    const env = await getShellEnvironment()
+    expect(env).toBeDefined()
+    expect(typeof env.PATH).toBe("string")
+    expect(env.PATH.length).toBeGreaterThan(0)
+  })
+
+  it("returns HOME", async () => {
+    const env = await getShellEnvironment()
+    expect(typeof env.HOME).toBe("string")
+  })
+
+  it("caches results across calls", async () => {
+    const first = await getShellEnvironment()
+    const second = await getShellEnvironment()
+    expect(first.PATH).toBe(second.PATH)
+  })
+
+  it("returns a copy (mutations don't corrupt cache)", async () => {
+    const first = await getShellEnvironment()
+    first.PATH = "/mutated"
+    const second = await getShellEnvironment()
+    expect(second.PATH).not.toBe("/mutated")
+  })
+})
+
+describe("execWithShellEnv", () => {
+  it("executes a simple command", async () => {
+    const { stdout } = await execWithShellEnv("echo", ["hello"])
+    expect(stdout.trim()).toBe("hello")
+  })
+
+  it("passes cwd option through", async () => {
+    const { stdout } = await execWithShellEnv("pwd", [], { cwd: "/tmp" })
+    // /tmp may resolve to /private/tmp on macOS
+    expect(stdout.trim()).toMatch(/\/tmp$/)
+  })
+
+  it("throws on non-ENOENT errors", async () => {
+    await expect(execWithShellEnv("ls", ["--nonexistent-flag-that-fails"])).rejects.toThrow()
+  })
+})
+
+describe("clearShellEnvCache", () => {
+  it("forces fresh resolution on next call", async () => {
+    const first = await getShellEnvironment()
+    clearShellEnvCache()
+    const second = await getShellEnvironment()
+    // Both should succeed and contain PATH
+    expect(first.PATH).toBeDefined()
+    expect(second.PATH).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

- When VS Code is launched from Finder, Spotlight, or Dock on macOS, the extension host inherits a minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`) that excludes homebrew, nvm, pipx, and other user-installed tool directories
- This causes `gh` and `git lfs` commands in the Agent Manager to fail with ENOENT ("not installed") even though they work in the terminal
- Adds a `shell-env` utility that lazily spawns the user's login shell (`$SHELL -lc env`) on first ENOENT to capture the real PATH, caches the result, and permanently patches `process.env.PATH` so all subsequent exec calls benefit
- Routes `WorktreeManager.exec()` through `execWithShellEnv()` so all downstream callers (`fetchPRInfo` → `gh`, `gitExec` → `git`, etc.) are fixed automatically

## Changes

- **`shell-env.ts`** (new) — `getShellEnvironment()`, `execWithShellEnv()`, `clearShellEnvCache()`
- **`WorktreeManager.ts`** — replaced `cp.execFile` with `execWithShellEnv` in `exec()`
- **`shell-env.test.ts`** (new) — 8 tests covering caching, isolation, execution, and cache clearing