### PR TITLE
docs: improve JSDoc comments in GitOps agent-manager module

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -62,6 +62,7 @@ export class GitOps {
     return this.runGit(args, cwd)
   }
 
+  /** Return the name of the currently checked-out branch, or empty string if detached. */
   async currentBranch(cwd: string): Promise<string> {
     return this.raw(["rev-parse", "--abbrev-ref", "HEAD"], cwd).catch(() => "")
   }
@@ -87,6 +88,7 @@ export class GitOps {
     return "origin"
   }
 
+  /** Resolve the upstream tracking ref for `branch`, or `undefined` if none is set. */
   async resolveTrackingBranch(cwd: string, branch: string): Promise<string | undefined> {
     const upstream = await this.raw(["rev-parse", "--abbrev-ref", "@{upstream}"], cwd).catch(() => "")
     if (upstream) return upstream
@@ -139,6 +141,7 @@ export class GitOps {
     return job
   }
 
+  /** Return the set of worktree paths for the repo, excluding bare entries. */
   async listWorktreePaths(cwd: string): Promise<Set<string>> {
     const raw = await this.raw(["worktree", "list", "--porcelain"], cwd)
     const paths = new Set<string>()
@@ -151,12 +154,13 @@ export class GitOps {
 
   /**
    * Compute working-tree stats (staged + unstaged + untracked) without requiring
-   * a remote or base branch — mirrors the superset approach of running
-   * `git diff --numstat` and `git ls-files --others`.
+   * a remote or base branch. Combines `git diff HEAD --numstat` for tracked
+   * changes with `git ls-files --others` for new files.
+   *
+   * Returns aggregate file count, additions, and deletions across the working tree.
    */
   async workingTreeStats(cwd: string): Promise<{ files: number; additions: number; deletions: number }> {
-    // Staged + unstaged changes relative to HEAD (like superset's dual
-    // git diff --cached --numstat + git diff --numstat, combined).
+    // Single diff against HEAD captures both staged and unstaged changes.
     const [numstat, untracked] = await Promise.all([
       this.raw(["diff", "HEAD", "--numstat"], cwd).catch(() => ""),
       this.raw(["ls-files", "--others", "--exclude-standard"], cwd).catch(() => ""),
@@ -177,8 +181,8 @@ export class GitOps {
         )
       : { files: 0, additions: 0, deletions: 0 }
 
-    // Count lines in untracked files as additions (like superset's
-    // applyUntrackedLineCount). Cap at 1MB to avoid reading huge binaries.
+    // Count lines in untracked files as additions. Cap at 1MB to avoid
+    // reading large binary files into memory.
     if (!untracked) return tracked
 
     const paths = untracked.split("\n").filter((line) => line.trim())
@@ -205,9 +209,9 @@ export class GitOps {
   }
 
   /**
-   * Count commits ahead and behind in a single `rev-list --left-right --count`
-   * call (like superset's approach). Falls back through upstream → remote/branch
-   * → remote/parentBranch → parentBranch.
+   * Count commits ahead and behind using `rev-list --left-right --count`.
+   * Tries the best available ref in order: upstream tracking branch →
+   * remote/branch → remote/parentBranch → local parentBranch.
    */
   async aheadBehind(cwd: string, parentBranch: string): Promise<{ ahead: number; behind: number }> {
     const upstream = await this.raw(["rev-parse", "--abbrev-ref", "@{upstream}"], cwd).catch(() => "")
@@ -241,6 +245,10 @@ export class GitOps {
     return { ahead, behind }
   }
 
+  /**
+   * Build a binary-safe patch of all working-tree changes relative to the
+   * merge-base with `baseBranch`. Optionally scoped to `selectedFiles`.
+   */
   async buildWorktreePatch(sourcePath: string, baseBranch: string, selectedFiles?: string[]): Promise<string> {
     const tmp = await fs.mkdtemp(nodePath.join(os.tmpdir(), "kilo-apply-"))
     const index = nodePath.join(tmp, "index")

--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -88,7 +88,7 @@ export class GitOps {
     return "origin"
   }
 
-  /** Resolve the upstream tracking ref for `branch`, or `undefined` if none is set. */
+  /** Resolve the upstream tracking ref for `branch`, or `undefined` if none is set. Note: the `@{upstream}` check uses the current HEAD, not `branch`. */
   async resolveTrackingBranch(cwd: string, branch: string): Promise<string | undefined> {
     const upstream = await this.raw(["rev-parse", "--abbrev-ref", "@{upstream}"], cwd).catch(() => "")
     if (upstream) return upstream

--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -62,7 +62,7 @@ export class GitOps {
     return this.runGit(args, cwd)
   }
 
-  /** Return the name of the currently checked-out branch, or empty string if detached. */
+  /** Return the name of the currently checked-out branch, or `"HEAD"` if detached. */
   async currentBranch(cwd: string): Promise<string> {
     return this.raw(["rev-parse", "--abbrev-ref", "HEAD"], cwd).catch(() => "")
   }


### PR DESCRIPTION
## Summary

- Add missing JSDoc documentation to several public `GitOps` methods (`currentBranch`, `resolveTrackingBranch`, `listWorktreePaths`, `buildWorktreePatch`)
- Clarify existing comments in `workingTreeStats` and `aheadBehind` to better describe the underlying git operations and fallback behavior