### PR TITLE
fix(gateway): include kilo/auto models in models endpoint mapping

### DIFF
--- a/packages/kilo-gateway/src/api/models.ts
+++ b/packages/kilo-gateway/src/api/models.ts
@@ -54,6 +54,17 @@ const openRouterModelsResponseSchema = z.object({
 
 type OpenRouterModel = z.infer<typeof openRouterModelSchema>
 
+type KiloFetchStatus = "success" | "fallback"
+
+function markFetchStatus(models: Record<string, any>, status: KiloFetchStatus) {
+  Object.defineProperty(models, "__kiloFetchStatus", {
+    value: status,
+    enumerable: false,
+    configurable: true,
+    writable: false,
+  })
+}
+
 /**
  * Parse API price string to number (e.g. "0.00001" -> 0.00001)
  */
@@ -112,6 +123,7 @@ export async function fetchKiloModels(options?: {
     if (!result.success) {
       console.error("Kilo models response validation failed:", result.error.format())
       ensureAutoRoutingModels(models)
+      markFetchStatus(models, "fallback")
       return models
     }
 
@@ -128,11 +140,13 @@ export async function fetchKiloModels(options?: {
     }
 
     ensureAutoRoutingModels(models)
+    markFetchStatus(models, "success")
 
     return models
   } catch (error) {
     console.error("Error fetching Kilo models:", error)
     ensureAutoRoutingModels(models)
+    markFetchStatus(models, "fallback")
     return models
   }
 }

--- a/packages/kilo-gateway/src/api/models.ts
+++ b/packages/kilo-gateway/src/api/models.ts
@@ -1,7 +1,13 @@
 import { z } from "zod"
 import { getKiloUrlFromToken } from "../auth/token.js"
 import { DEFAULT_HEADERS } from "../headers.js"
-import { KILO_API_BASE, KILO_OPENROUTER_BASE, MODELS_FETCH_TIMEOUT_MS } from "./constants.js"
+import {
+  DEFAULT_FREE_MODEL,
+  DEFAULT_MODEL,
+  KILO_API_BASE,
+  KILO_OPENROUTER_BASE,
+  MODELS_FETCH_TIMEOUT_MS,
+} from "./constants.js"
 
 /**
  * OpenRouter model schema
@@ -119,10 +125,50 @@ export async function fetchKiloModels(options?: {
       models[model.id] = transformedModel
     }
 
+    ensureAutoRoutingModels(models)
+
     return models
   } catch (error) {
     console.error("Error fetching Kilo models:", error)
     return {}
+  }
+}
+
+function ensureAutoRoutingModels(models: Record<string, any>) {
+  const today = new Date().toISOString().split("T")[0]
+
+  if (!models[DEFAULT_MODEL]) {
+    models[DEFAULT_MODEL] = {
+      id: DEFAULT_MODEL,
+      name: "Kilo: Auto",
+      family: "kilo",
+      release_date: today,
+      attachment: true,
+      reasoning: true,
+      temperature: true,
+      tool_call: true,
+      cost: { input: 0.000005, output: 0.000025 },
+      limit: { context: 1000000, output: 128000 },
+      modalities: { input: ["text", "image"], output: ["text"] },
+      options: { description: "Automatically routes to the best model for the task" },
+    }
+  }
+
+  if (!models[DEFAULT_FREE_MODEL]) {
+    models[DEFAULT_FREE_MODEL] = {
+      id: DEFAULT_FREE_MODEL,
+      name: "Kilo: Auto Free",
+      family: "kilo",
+      release_date: today,
+      attachment: false,
+      reasoning: true,
+      temperature: true,
+      tool_call: true,
+      cost: { input: 0, output: 0 },
+      limit: { context: 204800, output: 131072 },
+      modalities: { input: ["text"], output: ["text"] },
+      options: { description: "Automatically routes to the best free model" },
+    }
   }
 }
 

--- a/packages/kilo-gateway/src/api/models.ts
+++ b/packages/kilo-gateway/src/api/models.ts
@@ -88,6 +88,8 @@ export async function fetchKiloModels(options?: {
   // Construct models endpoint
   const modelsURL = `${finalBaseURL}/models`
 
+  const models: Record<string, any> = {}
+
   try {
     // Fetch models with timeout
     const response = await fetch(modelsURL, {
@@ -109,11 +111,11 @@ export async function fetchKiloModels(options?: {
 
     if (!result.success) {
       console.error("Kilo models response validation failed:", result.error.format())
-      return {}
+      ensureAutoRoutingModels(models)
+      return models
     }
 
     // Transform models to ModelsDev.Model format
-    const models: Record<string, any> = {}
 
     for (const model of result.data.data) {
       // Skip image generation models
@@ -130,7 +132,8 @@ export async function fetchKiloModels(options?: {
     return models
   } catch (error) {
     console.error("Error fetching Kilo models:", error)
-    return {}
+    ensureAutoRoutingModels(models)
+    return models
   }
 }
 

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -162,7 +162,11 @@ export namespace ModelsDev {
         npm: "@kilocode/kilo-gateway",
         models: kiloModels,
       }
-      if (Object.keys(kiloModels).length === 0) {
+      const fetchedModelIds = Object.keys(kiloModels).filter(
+        (id) => id !== "kilo/auto" && id !== "kilo/auto-free",
+      )
+
+      if (fetchedModelIds.length === 0) {
         ModelCache.refresh("kilo", kiloFetchOptions).catch(() => {})
       }
     }

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -162,11 +162,9 @@ export namespace ModelsDev {
         npm: "@kilocode/kilo-gateway",
         models: kiloModels,
       }
-      const fetchedModelIds = Object.keys(kiloModels).filter(
-        (id) => id !== "kilo/auto" && id !== "kilo/auto-free",
-      )
+      const fetchStatus = (kiloModels as { __kiloFetchStatus?: "success" | "fallback" }).__kiloFetchStatus
 
-      if (fetchedModelIds.length === 0) {
+      if (fetchStatus === "fallback") {
         ModelCache.refresh("kilo", kiloFetchOptions).catch(() => {})
       }
     }


### PR DESCRIPTION
## Summary
- ensure fetchKiloModels() always includes kilo/auto and kilo/auto-free in the returned model map
- keep existing API-provided entries untouched (only inject when missing)
- use the same model ids from shared constants to avoid drift

Closes #6686

## Validation
- bun run typecheck (in packages/kilo-gateway) ✅
- bun run build (in packages/kilo-gateway) ✅
- git push -u sonwr fix/gateway-models-include-auto-6686 (repo pre-push hook ran bun turbo typecheck) ✅
