### PR TITLE
fix(agent-manager): scroll sidebar to focused worktree on navigation and creation

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -731,6 +731,17 @@ const AgentManagerContent: Component = () => {
     }
   })
 
+  // Scroll the sidebar to the focused item whenever selection changes (covers keyboard
+  // navigation, new worktree creation, and any other programmatic selection change).
+  createEffect(() => {
+    const id = selection() ?? session.currentSessionID()
+    if (!id) return
+    requestAnimationFrame(() => {
+      const el = document.querySelector(`[data-sidebar-id="${id}"]`)
+      if (el instanceof HTMLElement) scrollIntoView(el)
+    })
+  })
+
   // Read-only mode: viewing an unassigned session (not in a worktree or local)
   const readOnly = createMemo(() => selection() === null && !!session.currentSessionID())
 
@@ -813,7 +824,7 @@ const AgentManagerContent: Component = () => {
   const navigate = (direction: "up" | "down") => {
     const flat: { type: typeof LOCAL | "wt" | "session"; id: string }[] = [
       { type: LOCAL, id: LOCAL },
-      ...worktrees().map((wt) => ({ type: "wt" as const, id: wt.id })),
+      ...sortedWorktrees().map((wt) => ({ type: "wt" as const, id: wt.id })),
       ...unassignedSessions().map((s) => ({ type: "session" as const, id: s.id })),
     ]
     if (flat.length === 0) return


### PR DESCRIPTION
## Summary

- Add a reactive `createEffect` that scrolls the sidebar to the focused worktree whenever selection changes — covers arrow key navigation, new worktree creation, and programmatic selection
- Fix `navigate()` to use `sortedWorktrees()` instead of `worktrees()` so keyboard navigation order matches the visual sidebar order
- Uses `requestAnimationFrame` + `scrollIntoView({ block: "nearest", behavior: "smooth" })` for smooth scrolling that only triggers when the item is out of view