### PR TITLE
fix(vscode): clean out directory before building dev extension

### DIFF
--- a/packages/kilo-vscode/script/install-dev-extension.ts
+++ b/packages/kilo-vscode/script/install-dev-extension.ts
@@ -7,8 +7,8 @@ const root = join(import.meta.dir, "..")
 const outDir = join(root, "out")
 const pkgPath = join(root, "package.json")
 
-if (existsSync(outDir) && !statSync(outDir).isDirectory()) {
-  rmSync(outDir)
+if (existsSync(outDir)) {
+  rmSync(outDir, { recursive: true, force: true })
 }
 mkdirSync(outDir, { recursive: true })
 


### PR DESCRIPTION
## Summary

- The `install-dev-extension.ts` script was only removing the `out` path if it existed *and* was not a directory, meaning stale `.vsix` files from previous builds were never cleaned up.
- This caused `code --install-extension` to pick up an old version instead of the freshly built one.
- Fix: fully remove and recreate the `out` directory before each build.