### PR TITLE
fix(agent-manager): open file in diff viewer for local sessions

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1553,8 +1553,7 @@ export class AgentManagerProvider implements vscode.Disposable {
     const state = this.getStateManager()
     if (!state) return
     const session = state.getSession(sessionId)
-    if (!session) return
-    const base = session.worktreeId ? state.getWorktree(session.worktreeId)?.path : this.getWorkspaceRoot()
+    const base = session?.worktreeId ? state.getWorktree(session.worktreeId)?.path : this.getWorkspaceRoot()
     if (!base) return
     // Resolve real paths to prevent symlink traversal and normalize for
     // consistent comparison on both Unix and Windows.

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2590,6 +2590,7 @@ const AgentManagerContent: Component = () => {
                     onOpenFile={(file) => {
                       const id = session.currentSessionID()
                       if (id) vscode.postMessage({ type: "agentManager.openFile", sessionId: id, filePath: file })
+                      else if (selection() === LOCAL) vscode.postMessage({ type: "openFile", filePath: file })
                     }}
                   />
                 </div>
@@ -2611,6 +2612,7 @@ const AgentManagerContent: Component = () => {
                 onOpenFile={(file) => {
                   const id = session.currentSessionID()
                   if (id) vscode.postMessage({ type: "agentManager.openFile", sessionId: id, filePath: file })
+                  else if (selection() === LOCAL) vscode.postMessage({ type: "openFile", filePath: file })
                 }}
                 onClose={closeReviewTab}
               />


### PR DESCRIPTION
## Summary

- Fixes "open file" / "go to file" button doing nothing in the Agent Manager's diff viewer and fullscreen diff viewer when viewing local (non-worktree) sessions
- Two-layer bug: the webview never sent the message (guarded on `currentSessionID()` which is `undefined` for pending local sessions), and the extension early-returned when the session wasn't found in `WorktreeStateManager`

## Changes

**`AgentManagerProvider.ts`** — `openWorktreeFile()` no longer early-returns when `state.getSession()` returns `undefined`. Instead, it uses optional chaining (`session?.worktreeId`) so the ternary falls through to `getWorkspaceRoot()` as the base path for local sessions.

**`AgentManagerApp.tsx`** — Both `DiffPanel` and `FullScreenDiffView` `onOpenFile` callbacks now fall back to sending the plain `openFile` message when on a local tab without an active CLI session ID, matching the pattern already used in `PromptInput.tsx`.