### PR TITLE
fix(agent-manager): prevent compare model selector from hiding create worktree button

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1613,9 +1613,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       console.log("[Kilo New] KiloProvider: 🔐 Login successful")
 
-      await this.client.global.dispose().catch((e: unknown) =>
-        console.warn("[Kilo New] KiloProvider: global.dispose() after login failed:", e),
-      )
+      await this.client.global
+        .dispose()
+        .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: global.dispose() after login failed:", e))
 
       // Step 4: Fetch profile and push to webview
       const { data: profileData } = await this.client.kilo.profile(undefined, { throwOnError: true })
@@ -1662,9 +1662,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       return
     }
 
-    await this.client.global.dispose().catch((e: unknown) =>
-      console.warn("[Kilo New] KiloProvider: global.dispose() after org switch failed:", e),
-    )
+    await this.client.global
+      .dispose()
+      .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: global.dispose() after org switch failed:", e))
 
     // Org switch succeeded — refresh profile and providers independently (best-effort)
     try {
@@ -1719,10 +1719,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         data: null,
       })
 
-      await this.client.global.dispose().catch((e: unknown) =>
-        console.warn("[Kilo New] KiloProvider: global.dispose() after logout failed:", e),
-      )
-
+      await this.client.global
+        .dispose()
+        .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: global.dispose() after logout failed:", e))
     } catch (error) {
       console.error("[Kilo New] KiloProvider: ❌ Logout failed:", error)
       this.postMessage({
@@ -1730,8 +1729,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         message: getErrorMessage(error) || "Failed to logout",
       })
     }
-
-
   }
 
   /**
@@ -1858,7 +1855,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     // Refresh provider and agent lists when the server signals a state disposal
     if (event.type === "server.instance.disposed" || event.type === "global.disposed") {
-      void this.reloadAfterAuthChange();
+      void this.reloadAfterAuthChange()
       return
     }
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2679,6 +2679,7 @@ const NewWorktreeDialog: Component<{ onClose: () => void }> = (props) => {
   const [branchName, setBranchName] = createSignal("")
   const [baseBranch, setBaseBranch] = createSignal<string | null>(null)
   const [baseBranchOpen, setBaseBranchOpen] = createSignal(false)
+  const [compareOpen, setCompareOpen] = createSignal(false)
   const [highlightedIndex, setHighlightedIndex] = createSignal(0)
 
   const imageAttach = useImageAttachments()
@@ -2826,296 +2827,331 @@ const NewWorktreeDialog: Component<{ onClose: () => void }> = (props) => {
       {/* New tab */}
       <Show when={tab() === "new"}>
         <div class="am-nv-dialog" onKeyDown={handleKeyDown}>
-          <input
-            class="am-nv-name-input"
-            placeholder={t("agentManager.dialog.namePlaceholder")}
-            value={name()}
-            onInput={(e) => setName(e.currentTarget.value)}
-          />
-          {/* Prompt input — reuses the sidebar chat-input base classes for consistent styling */}
-          <div
-            class="prompt-input-container am-prompt-input-container"
-            classList={{ "prompt-input-container--dragging": imageAttach.dragging() }}
-            onDragOver={imageAttach.handleDragOver}
-            onDragLeave={imageAttach.handleDragLeave}
-            onDrop={imageAttach.handleDrop}
-          >
-            <Show when={imageAttach.images().length > 0}>
-              <div class="image-attachments">
-                <For each={imageAttach.images()}>
-                  {(img) => (
-                    <div class="image-attachment">
-                      <img src={img.dataUrl} alt={img.filename} title={img.filename} />
-                      <button
-                        type="button"
-                        class="image-attachment-remove"
-                        onClick={() => imageAttach.remove(img.id)}
-                        aria-label={t("agentManager.dialog.removeImage")}
-                      >
-                        ×
-                      </button>
-                    </div>
-                  )}
-                </For>
-              </div>
-            </Show>
-            <div class="prompt-input-wrapper am-prompt-input-wrapper">
-              <div class="prompt-input-ghost-wrapper am-prompt-input-ghost-wrapper">
-                <textarea
-                  ref={textareaRef}
-                  class="prompt-input am-prompt-input"
-                  placeholder={t(
-                    isMac ? "agentManager.dialog.promptPlaceholder.mac" : "agentManager.dialog.promptPlaceholder.other",
-                  )}
-                  value={prompt()}
-                  onInput={(e) => {
-                    setPrompt(e.currentTarget.value)
-                    adjustHeight()
-                  }}
-                  onPaste={(e) => imageAttach.handlePaste(e)}
-                  rows={3}
-                />
-              </div>
-            </div>
-            <div class="prompt-input-hint">
-              <div class="prompt-input-hint-selectors">
-                <Show when={!compareMode()}>
-                  <ModelSelectorBase
-                    value={model()}
-                    onSelect={(pid, mid) => setModel(pid && mid ? { providerID: pid, modelID: mid } : null)}
-                    placement="top-start"
-                    allowClear
-                    clearLabel="Default"
-                  />
-                </Show>
-                <Show when={session.agents().length > 1}>
-                  <ModeSwitcherBase agents={session.agents()} value={agent()} onSelect={setAgent} />
-                </Show>
-              </div>
-              <div class="prompt-input-hint-actions" />
-            </div>
-          </div>
-
-          {/* Advanced options toggle */}
-          <button class="am-advanced-toggle" onClick={() => setShowAdvanced(!showAdvanced())} type="button">
-            <Icon name={showAdvanced() ? "chevron-down" : "chevron-right"} size="small" />
-            <span>{t("agentManager.dialog.advancedOptions")}</span>
-          </button>
-
-          <Show when={showAdvanced()}>
-            <div class="am-advanced-section">
-              <div class="am-advanced-field">
-                <span class="am-nv-config-label">{t("agentManager.dialog.branchName")}</span>
-                <input
-                  class="am-advanced-input"
-                  type="text"
-                  placeholder={t("agentManager.dialog.branchNamePlaceholder")}
-                  value={branchName()}
-                  onInput={(e) => setBranchName(sanitizeBranchName(e.currentTarget.value))}
-                />
-              </div>
-              <div class="am-advanced-field">
-                <span class="am-nv-config-label">{t("agentManager.dialog.baseBranch")}</span>
-                <div class="am-selector-wrapper">
-                  <Popover
-                    open={baseBranchOpen()}
-                    onOpenChange={(open) => {
-                      setBaseBranchOpen(open)
-                      if (!open) {
-                        setBranchSearch("")
-                        setHighlightedIndex(0)
-                      }
+          <div class="am-nv-dialog-content">
+            <input
+              class="am-nv-name-input"
+              placeholder={t("agentManager.dialog.namePlaceholder")}
+              value={name()}
+              onInput={(e) => setName(e.currentTarget.value)}
+            />
+            {/* Prompt input — reuses the sidebar chat-input base classes for consistent styling */}
+            <div
+              class="prompt-input-container am-prompt-input-container"
+              classList={{ "prompt-input-container--dragging": imageAttach.dragging() }}
+              onDragOver={imageAttach.handleDragOver}
+              onDragLeave={imageAttach.handleDragLeave}
+              onDrop={imageAttach.handleDrop}
+            >
+              <Show when={imageAttach.images().length > 0}>
+                <div class="image-attachments">
+                  <For each={imageAttach.images()}>
+                    {(img) => (
+                      <div class="image-attachment">
+                        <img src={img.dataUrl} alt={img.filename} title={img.filename} />
+                        <button
+                          type="button"
+                          class="image-attachment-remove"
+                          onClick={() => imageAttach.remove(img.id)}
+                          aria-label={t("agentManager.dialog.removeImage")}
+                        >
+                          ×
+                        </button>
+                      </div>
+                    )}
+                  </For>
+                </div>
+              </Show>
+              <div class="prompt-input-wrapper am-prompt-input-wrapper">
+                <div class="prompt-input-ghost-wrapper am-prompt-input-ghost-wrapper">
+                  <textarea
+                    ref={textareaRef}
+                    class="prompt-input am-prompt-input"
+                    placeholder={t(
+                      isMac
+                        ? "agentManager.dialog.promptPlaceholder.mac"
+                        : "agentManager.dialog.promptPlaceholder.other",
+                    )}
+                    value={prompt()}
+                    onInput={(e) => {
+                      setPrompt(e.currentTarget.value)
+                      adjustHeight()
                     }}
-                    placement="bottom-start"
-                    sameWidth
-                    class="am-dropdown"
-                    trigger={
-                      <button class="am-selector-trigger" type="button">
-                        <span class="am-selector-left">
-                          <Icon name="branch" size="small" />
-                          <span class="am-selector-value" style={{ color: "var(--text-base)" }}>
-                            {effectiveBaseBranch()}
-                          </span>
-                          <Show when={!baseBranch()}>
-                            <span class="am-branch-badge">{t("agentManager.dialog.branchBadge.default")}</span>
-                          </Show>
-                        </span>
-                        <span class="am-selector-right">
-                          <Icon name="selector" size="small" />
-                        </span>
-                      </button>
-                    }
-                  >
-                    <div class="am-dropdown-search">
-                      <Icon name="magnifying-glass" size="small" />
-                      <input
-                        class="am-dropdown-search-input"
-                        type="text"
-                        placeholder={t("agentManager.dialog.searchBranches")}
-                        value={branchSearch()}
-                        autofocus
-                        onInput={(e) => {
-                          setBranchSearch(e.currentTarget.value)
+                    onPaste={(e) => imageAttach.handlePaste(e)}
+                    rows={3}
+                  />
+                </div>
+              </div>
+              <div class="prompt-input-hint">
+                <div class="prompt-input-hint-selectors">
+                  <Show when={!compareMode()}>
+                    <ModelSelectorBase
+                      value={model()}
+                      onSelect={(pid, mid) => setModel(pid && mid ? { providerID: pid, modelID: mid } : null)}
+                      placement="top-start"
+                      allowClear
+                      clearLabel="Default"
+                    />
+                  </Show>
+                  <Show when={session.agents().length > 1}>
+                    <ModeSwitcherBase agents={session.agents()} value={agent()} onSelect={setAgent} />
+                  </Show>
+                </div>
+                <div class="prompt-input-hint-actions" />
+              </div>
+            </div>
+
+            {/* Advanced options toggle */}
+            <button class="am-advanced-toggle" onClick={() => setShowAdvanced(!showAdvanced())} type="button">
+              <Icon name={showAdvanced() ? "chevron-down" : "chevron-right"} size="small" />
+              <span>{t("agentManager.dialog.advancedOptions")}</span>
+            </button>
+
+            <Show when={showAdvanced()}>
+              <div class="am-advanced-section">
+                <div class="am-advanced-field">
+                  <span class="am-nv-config-label">{t("agentManager.dialog.branchName")}</span>
+                  <input
+                    class="am-advanced-input"
+                    type="text"
+                    placeholder={t("agentManager.dialog.branchNamePlaceholder")}
+                    value={branchName()}
+                    onInput={(e) => setBranchName(sanitizeBranchName(e.currentTarget.value))}
+                  />
+                </div>
+                <div class="am-advanced-field">
+                  <span class="am-nv-config-label">{t("agentManager.dialog.baseBranch")}</span>
+                  <div class="am-selector-wrapper">
+                    <Popover
+                      open={baseBranchOpen()}
+                      onOpenChange={(open) => {
+                        setBaseBranchOpen(open)
+                        if (!open) {
+                          setBranchSearch("")
                           setHighlightedIndex(0)
-                        }}
-                        onKeyDown={(e) => {
-                          const items = filteredBranches()
-                          if (e.key === "ArrowDown") {
-                            e.preventDefault()
-                            e.stopPropagation()
-                            const next = Math.min(highlightedIndex() + 1, items.length - 1)
-                            setHighlightedIndex(next)
-                            requestAnimationFrame(() => {
-                              document
-                                .querySelector(`.am-branch-item[data-index="${next}"]`)
-                                ?.scrollIntoView({ block: "nearest" })
-                            })
-                          } else if (e.key === "ArrowUp") {
-                            e.preventDefault()
-                            e.stopPropagation()
-                            const prev = Math.max(highlightedIndex() - 1, 0)
-                            setHighlightedIndex(prev)
-                            requestAnimationFrame(() => {
-                              document
-                                .querySelector(`.am-branch-item[data-index="${prev}"]`)
-                                ?.scrollIntoView({ block: "nearest" })
-                            })
-                          } else if (e.key === "Enter") {
-                            e.preventDefault()
-                            e.stopPropagation()
-                            const selected = items[highlightedIndex()]
-                            if (selected) {
-                              setBaseBranch(selected.name)
+                        }
+                      }}
+                      placement="bottom-start"
+                      sameWidth
+                      class="am-dropdown"
+                      trigger={
+                        <button class="am-selector-trigger" type="button">
+                          <span class="am-selector-left">
+                            <Icon name="branch" size="small" />
+                            <span class="am-selector-value">{effectiveBaseBranch()}</span>
+                            <Show when={!baseBranch()}>
+                              <span class="am-branch-badge">{t("agentManager.dialog.branchBadge.default")}</span>
+                            </Show>
+                          </span>
+                          <span class="am-selector-right">
+                            <Icon name="selector" size="small" />
+                          </span>
+                        </button>
+                      }
+                    >
+                      <div class="am-dropdown-search">
+                        <Icon name="magnifying-glass" size="small" />
+                        <input
+                          class="am-dropdown-search-input"
+                          type="text"
+                          placeholder={t("agentManager.dialog.searchBranches")}
+                          value={branchSearch()}
+                          autofocus
+                          onInput={(e) => {
+                            setBranchSearch(e.currentTarget.value)
+                            setHighlightedIndex(0)
+                          }}
+                          onKeyDown={(e) => {
+                            const items = filteredBranches()
+                            if (e.key === "ArrowDown") {
+                              e.preventDefault()
+                              e.stopPropagation()
+                              const next = Math.min(highlightedIndex() + 1, items.length - 1)
+                              setHighlightedIndex(next)
+                              requestAnimationFrame(() => {
+                                document
+                                  .querySelector(`.am-branch-item[data-index="${next}"]`)
+                                  ?.scrollIntoView({ block: "nearest" })
+                              })
+                            } else if (e.key === "ArrowUp") {
+                              e.preventDefault()
+                              e.stopPropagation()
+                              const prev = Math.max(highlightedIndex() - 1, 0)
+                              setHighlightedIndex(prev)
+                              requestAnimationFrame(() => {
+                                document
+                                  .querySelector(`.am-branch-item[data-index="${prev}"]`)
+                                  ?.scrollIntoView({ block: "nearest" })
+                              })
+                            } else if (e.key === "Enter") {
+                              e.preventDefault()
+                              e.stopPropagation()
+                              const selected = items[highlightedIndex()]
+                              if (selected) {
+                                setBaseBranch(selected.name)
+                                setBaseBranchOpen(false)
+                                setBranchSearch("")
+                                setHighlightedIndex(0)
+                              }
+                            } else if (e.key === "Escape") {
+                              e.preventDefault()
+                              e.stopPropagation()
                               setBaseBranchOpen(false)
                               setBranchSearch("")
                               setHighlightedIndex(0)
                             }
-                          } else if (e.key === "Escape") {
-                            e.preventDefault()
-                            e.stopPropagation()
-                            setBaseBranchOpen(false)
-                            setBranchSearch("")
-                            setHighlightedIndex(0)
-                          }
-                        }}
-                      />
-                    </div>
-                    <div class="am-dropdown-list">
-                      <For each={filteredBranches()}>
-                        {(branch, index) => (
-                          <button
-                            class="am-branch-item"
-                            classList={{
-                              "am-branch-item-active": effectiveBaseBranch() === branch.name,
-                              "am-branch-item-highlighted": highlightedIndex() === index(),
-                            }}
-                            data-index={index()}
-                            onClick={() => {
-                              setBaseBranch(branch.name)
-                              setBaseBranchOpen(false)
-                              setBranchSearch("")
-                              setHighlightedIndex(0)
-                            }}
-                            onMouseEnter={() => setHighlightedIndex(index())}
-                            type="button"
-                          >
-                            <span class="am-branch-item-left">
-                              <Icon name="branch" size="small" />
-                              <span class="am-branch-item-name">{branch.name}</span>
-                              <Show when={branch.isDefault}>
-                                <span class="am-branch-badge">{t("agentManager.dialog.branchBadge.default")}</span>
+                          }}
+                        />
+                      </div>
+                      <div class="am-dropdown-list">
+                        <For each={filteredBranches()}>
+                          {(branch, index) => (
+                            <button
+                              class="am-branch-item"
+                              classList={{
+                                "am-branch-item-active": effectiveBaseBranch() === branch.name,
+                                "am-branch-item-highlighted": highlightedIndex() === index(),
+                              }}
+                              data-index={index()}
+                              onClick={() => {
+                                setBaseBranch(branch.name)
+                                setBaseBranchOpen(false)
+                                setBranchSearch("")
+                                setHighlightedIndex(0)
+                              }}
+                              onMouseEnter={() => setHighlightedIndex(index())}
+                              type="button"
+                            >
+                              <span class="am-branch-item-left">
+                                <Icon name="branch" size="small" />
+                                <span class="am-branch-item-name">{branch.name}</span>
+                                <Show when={branch.isDefault}>
+                                  <span class="am-branch-badge">{t("agentManager.dialog.branchBadge.default")}</span>
+                                </Show>
+                                <Show when={!branch.isLocal && branch.isRemote}>
+                                  <span class="am-branch-badge am-branch-badge-remote">
+                                    {t("agentManager.dialog.branchBadge.remote")}
+                                  </span>
+                                </Show>
+                              </span>
+                              <Show when={branch.lastCommitDate}>
+                                <span class="am-branch-item-time">{formatRelativeDate(branch.lastCommitDate!)}</span>
                               </Show>
-                              <Show when={!branch.isLocal && branch.isRemote}>
-                                <span class="am-branch-badge am-branch-badge-remote">
-                                  {t("agentManager.dialog.branchBadge.remote")}
-                                </span>
-                              </Show>
-                            </span>
-                            <Show when={branch.lastCommitDate}>
-                              <span class="am-branch-item-time">{formatRelativeDate(branch.lastCommitDate!)}</span>
-                            </Show>
-                          </button>
-                        )}
-                      </For>
-                    </div>
-                  </Popover>
+                            </button>
+                          )}
+                        </For>
+                      </div>
+                    </Popover>
+                  </div>
                 </div>
               </div>
-            </div>
-          </Show>
+            </Show>
 
-          {/* Version / compare mode selector */}
-          <Show
-            when={compareMode()}
-            fallback={
-              <div class="am-nv-version-bar">
-                <span class="am-nv-config-label">{t("agentManager.dialog.versions")}</span>
-                <div class="am-nv-pills">
-                  {VERSION_OPTIONS.map((count) => (
+            {/* Version / compare mode selector */}
+            <Show
+              when={compareMode()}
+              fallback={
+                <div class="am-nv-version-bar">
+                  <span class="am-nv-config-label">{t("agentManager.dialog.versions")}</span>
+                  <div class="am-nv-pills">
+                    {VERSION_OPTIONS.map((count) => (
+                      <button
+                        class="am-nv-pill"
+                        classList={{ "am-nv-pill-active": versions() === count }}
+                        onClick={() => setVersions(count)}
+                        type="button"
+                      >
+                        {count}
+                      </button>
+                    ))}
                     <button
-                      class="am-nv-pill"
-                      classList={{ "am-nv-pill-active": versions() === count }}
-                      onClick={() => setVersions(count)}
+                      class="am-nv-pill am-nv-pill-compare"
+                      onClick={() => setCompareMode(true)}
                       type="button"
+                      title={t("agentManager.dialog.compareModels")}
                     >
-                      {count}
+                      <Icon name="layers" size="small" />
                     </button>
-                  ))}
-                  <button
-                    class="am-nv-pill am-nv-pill-compare"
-                    onClick={() => setCompareMode(true)}
-                    type="button"
-                    title={t("agentManager.dialog.compareModels")}
-                  >
-                    <Icon name="layers" size="small" />
-                  </button>
-                </div>
-                <Show when={versions() > 1}>
-                  <span class="am-nv-version-hint">{t("agentManager.dialog.versionHint", { count: versions() })}</span>
-                </Show>
-              </div>
-            }
-          >
-            <div class="am-nv-compare-section">
-              <div class="am-nv-version-bar">
-                <span class="am-nv-config-label">
-                  {t("agentManager.dialog.compareModels")}
-                  <Show when={totalAllocations(modelAllocations()) > 0}>
-                    <span class="am-nv-compare-count">
-                      {totalAllocations(modelAllocations())}/{MAX_MULTI_VERSIONS}
+                  </div>
+                  <Show when={versions() > 1}>
+                    <span class="am-nv-version-hint">
+                      {t("agentManager.dialog.versionHint", { count: versions() })}
                     </span>
                   </Show>
-                </span>
-                <button
-                  class="am-nv-pill-back"
-                  onClick={() => {
-                    setCompareMode(false)
-                    setModelAllocations(new Map())
-                  }}
-                  type="button"
-                  title={t("agentManager.dialog.versions")}
-                >
-                  <Icon name="close-small" size="small" />
-                </button>
-              </div>
-              <MultiModelSelector allocations={modelAllocations()} onChange={setModelAllocations} />
-            </div>
-          </Show>
-
-          {/* Submit button */}
-          <Button variant="primary" size="large" class="am-nv-submit" onClick={handleSubmit} disabled={!canSubmit()}>
-            <Show
-              when={!starting()}
-              fallback={
-                <>
-                  <Spinner class="am-nv-spinner" />
-                  <span>{t("agentManager.dialog.creating")}</span>
-                </>
+                </div>
               }
             >
-              {t("agentManager.dialog.createWorkspace")}
+              <div class="am-nv-compare-section">
+                <div class="am-nv-version-bar">
+                  <span class="am-nv-config-label">
+                    {t("agentManager.dialog.compareModels")}
+                    <Show when={totalAllocations(modelAllocations()) > 0}>
+                      <span class="am-nv-compare-count">
+                        {totalAllocations(modelAllocations())}/{MAX_MULTI_VERSIONS}
+                      </span>
+                    </Show>
+                  </span>
+                  <button
+                    class="am-nv-pill-back"
+                    onClick={() => {
+                      setCompareMode(false)
+                      setModelAllocations(new Map())
+                    }}
+                    type="button"
+                    title={t("agentManager.dialog.versions")}
+                  >
+                    <Icon name="close-small" size="small" />
+                  </button>
+                </div>
+                <Popover
+                  open={compareOpen()}
+                  onOpenChange={setCompareOpen}
+                  placement="bottom-start"
+                  sameWidth
+                  class="am-compare-popover"
+                  trigger={
+                    <button class="am-selector-trigger" type="button">
+                      <span class="am-selector-left">
+                        <Icon name="layers" size="small" />
+                        <Show
+                          when={modelAllocations().size > 0}
+                          fallback={
+                            <span class="am-selector-value am-selector-placeholder">
+                              {t("agentManager.dialog.compareModels.selectModels")}
+                            </span>
+                          }
+                        >
+                          <span class="am-selector-value">
+                            {[...modelAllocations().values()].map((e) => e.name).join(", ")}
+                          </span>
+                        </Show>
+                      </span>
+                      <span class="am-selector-right">
+                        <Icon name="selector" size="small" />
+                      </span>
+                    </button>
+                  }
+                >
+                  <MultiModelSelector allocations={modelAllocations()} onChange={setModelAllocations} />
+                </Popover>
+              </div>
             </Show>
-          </Button>
+          </div>
+          {/* Submit button — fixed footer, always visible */}
+          <div class="am-nv-dialog-footer">
+            <Button variant="primary" size="large" class="am-nv-submit" onClick={handleSubmit} disabled={!canSubmit()}>
+              <Show
+                when={!starting()}
+                fallback={
+                  <>
+                    <Spinner class="am-nv-spinner" />
+                    <span>{t("agentManager.dialog.creating")}</span>
+                  </>
+                }
+              >
+                {t("agentManager.dialog.createWorkspace")}
+              </Show>
+            </Button>
+          </div>
         </div>
       </Show>
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1502,19 +1502,32 @@ button.am-section-toggle:hover .am-section-label {
 .am-nv-dialog {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding: 0 20px 20px;
   min-width: 460px;
+  flex: 1;
+  min-height: 0;
 }
 
-/* Allow dropdowns to escape the dialog bounds, but scroll when content is tall */
+/* Allow portal-based dropdowns to escape the dialog bounds */
 [data-component="dialog"]:has(.am-nv-dialog) [data-slot="dialog-content"] {
   overflow: visible;
   max-height: 85vh;
 }
-[data-component="dialog"]:has(.am-nv-dialog) [data-slot="dialog-body"] {
-  overflow-x: visible;
+
+/* Scrollable form content area — keeps submit button always visible */
+.am-nv-dialog-content {
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 0 20px;
+}
+
+/* Fixed footer for the submit button */
+.am-nv-dialog-footer {
+  flex-shrink: 0;
+  padding: 14px 20px 20px;
 }
 
 .am-nv-name-input {
@@ -1672,14 +1685,20 @@ button.am-section-toggle:hover .am-section-label {
   color: var(--text-base);
 }
 
-/* Multi-model selector */
+/* Multi-model selector popover */
+
+.am-compare-popover[data-component="popover-content"] {
+  max-width: none;
+  width: var(--kb-popper-anchor-width);
+}
+
+.am-compare-popover [data-slot="popover-body"] {
+  padding: 0;
+}
 
 .am-mm-wrapper {
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--border-base);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
 }
 
 .am-mm-search {
@@ -2233,6 +2252,7 @@ button.am-section-toggle:hover .am-section-label {
 
 .am-tab-switcher {
   display: flex;
+  flex-shrink: 0;
   gap: 2px;
   padding: 0 20px;
   margin-bottom: 4px;
@@ -2385,6 +2405,10 @@ button.am-section-toggle:hover .am-section-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: var(--text-base);
+}
+
+.am-selector-placeholder {
   color: var(--text-weaker);
 }
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -80,6 +80,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} Worktrees ستعمل بالتوازي",
   "agentManager.dialog.compareModels": "مقارنة النماذج",
   "agentManager.dialog.compareModels.searchModels": "البحث عن النماذج...",
+  "agentManager.dialog.compareModels.selectModels": "اختر النماذج...",
   "agentManager.dialog.creating": "جارٍ الإنشاء...",
   "agentManager.dialog.createWorkspace": "إنشاء شجرة العمل",
   "agentManager.dialog.removeImage": "إزالة الصورة",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -80,6 +80,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktrees serão executados em paralelo",
   "agentManager.dialog.compareModels": "Comparar Modelos",
   "agentManager.dialog.compareModels.searchModels": "Pesquisar modelos...",
+  "agentManager.dialog.compareModels.selectModels": "Selecionar modelos...",
   "agentManager.dialog.creating": "Criando...",
   "agentManager.dialog.createWorkspace": "Criar Worktree",
   "agentManager.dialog.removeImage": "Remover imagem",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -80,6 +80,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktree-ova će se pokrenuti paralelno",
   "agentManager.dialog.compareModels": "Uporedi modele",
   "agentManager.dialog.compareModels.searchModels": "Pretraži modele...",
+  "agentManager.dialog.compareModels.selectModels": "Odaberi modele...",
   "agentManager.dialog.creating": "Kreiranje...",
   "agentManager.dialog.createWorkspace": "Kreiraj worktree",
   "agentManager.dialog.removeImage": "Ukloni sliku",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -80,6 +80,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktrees vil køre parallelt",
   "agentManager.dialog.compareModels": "Sammenlign modeller",
   "agentManager.dialog.compareModels.searchModels": "Søg modeller...",
+  "agentManager.dialog.compareModels.selectModels": "Vælg modeller...",
   "agentManager.dialog.creating": "Opretter...",
   "agentManager.dialog.createWorkspace": "Opret Worktree",
   "agentManager.dialog.removeImage": "Fjern billede",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -81,6 +81,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} Worktrees werden parallel ausgeführt",
   "agentManager.dialog.compareModels": "Modelle vergleichen",
   "agentManager.dialog.compareModels.searchModels": "Modelle suchen...",
+  "agentManager.dialog.compareModels.selectModels": "Modelle auswählen...",
   "agentManager.dialog.creating": "Wird erstellt...",
   "agentManager.dialog.createWorkspace": "Worktree erstellen",
   "agentManager.dialog.removeImage": "Bild entfernen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -88,6 +88,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktrees will run in parallel",
   "agentManager.dialog.compareModels": "Compare Models",
   "agentManager.dialog.compareModels.searchModels": "Search models...",
+  "agentManager.dialog.compareModels.selectModels": "Select models...",
   "agentManager.dialog.creating": "Creating...",
   "agentManager.dialog.createWorkspace": "Create Worktree",
   "agentManager.dialog.removeImage": "Remove image",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -81,6 +81,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktrees se ejecutarán en paralelo",
   "agentManager.dialog.compareModels": "Comparar modelos",
   "agentManager.dialog.compareModels.searchModels": "Buscar modelos...",
+  "agentManager.dialog.compareModels.selectModels": "Seleccionar modelos...",
   "agentManager.dialog.creating": "Creando...",
   "agentManager.dialog.createWorkspace": "Crear Worktree",
   "agentManager.dialog.removeImage": "Eliminar imagen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -81,6 +81,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktrees s'exécuteront en parallèle",
   "agentManager.dialog.compareModels": "Comparer les modèles",
   "agentManager.dialog.compareModels.searchModels": "Rechercher des modèles...",
+  "agentManager.dialog.compareModels.selectModels": "Sélectionner des modèles...",
   "agentManager.dialog.creating": "Création...",
   "agentManager.dialog.createWorkspace": "Créer un worktree",
   "agentManager.dialog.removeImage": "Supprimer l'image",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -81,6 +81,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}}個のWorktreeが並行して実行されます",
   "agentManager.dialog.compareModels": "モデルを比較",
   "agentManager.dialog.compareModels.searchModels": "モデルを検索...",
+  "agentManager.dialog.compareModels.selectModels": "モデルを選択...",
   "agentManager.dialog.creating": "作成中...",
   "agentManager.dialog.createWorkspace": "ワークツリーを作成",
   "agentManager.dialog.removeImage": "画像を削除",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -80,6 +80,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}}개의 Worktree가 병렬로 실행됩니다",
   "agentManager.dialog.compareModels": "모델 비교",
   "agentManager.dialog.compareModels.searchModels": "모델 검색...",
+  "agentManager.dialog.compareModels.selectModels": "모델 선택...",
   "agentManager.dialog.creating": "생성 중...",
   "agentManager.dialog.createWorkspace": "워크트리 생성",
   "agentManager.dialog.removeImage": "이미지 제거",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -80,6 +80,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktrees vil kjøre parallelt",
   "agentManager.dialog.compareModels": "Sammenlign modeller",
   "agentManager.dialog.compareModels.searchModels": "Søk modeller...",
+  "agentManager.dialog.compareModels.selectModels": "Velg modeller...",
   "agentManager.dialog.creating": "Oppretter...",
   "agentManager.dialog.createWorkspace": "Opprett worktree",
   "agentManager.dialog.removeImage": "Fjern bilde",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -81,6 +81,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} worktree będą działać równolegle",
   "agentManager.dialog.compareModels": "Porównaj modele",
   "agentManager.dialog.compareModels.searchModels": "Szukaj modeli...",
+  "agentManager.dialog.compareModels.selectModels": "Wybierz modele...",
   "agentManager.dialog.creating": "Tworzenie...",
   "agentManager.dialog.createWorkspace": "Utwórz Worktree",
   "agentManager.dialog.removeImage": "Usuń obraz",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -80,6 +80,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} Worktree будут выполняться параллельно",
   "agentManager.dialog.compareModels": "Сравнить модели",
   "agentManager.dialog.compareModels.searchModels": "Поиск моделей...",
+  "agentManager.dialog.compareModels.selectModels": "Выбрать модели...",
   "agentManager.dialog.creating": "Создание...",
   "agentManager.dialog.createWorkspace": "Создать worktree",
   "agentManager.dialog.removeImage": "Удалить изображение",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -81,6 +81,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} Worktrees จะทำงานพร้อมกัน",
   "agentManager.dialog.compareModels": "เปรียบเทียบโมเดล",
   "agentManager.dialog.compareModels.searchModels": "ค้นหาโมเดล...",
+  "agentManager.dialog.compareModels.selectModels": "เลือกโมเดล...",
   "agentManager.dialog.creating": "กำลังสร้าง...",
   "agentManager.dialog.createWorkspace": "สร้าง Worktree",
   "agentManager.dialog.removeImage": "ลบรูปภาพ",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -79,6 +79,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} 个 Worktree 将并行运行",
   "agentManager.dialog.compareModels": "比较模型",
   "agentManager.dialog.compareModels.searchModels": "搜索模型...",
+  "agentManager.dialog.compareModels.selectModels": "选择模型...",
   "agentManager.dialog.creating": "创建中...",
   "agentManager.dialog.createWorkspace": "创建工作树",
   "agentManager.dialog.removeImage": "移除图片",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -79,6 +79,7 @@ export const dict = {
   "agentManager.dialog.versionHint": "{{count}} 個 Worktree 將並行執行",
   "agentManager.dialog.compareModels": "比較模型",
   "agentManager.dialog.compareModels.searchModels": "搜尋模型...",
+  "agentManager.dialog.compareModels.selectModels": "選擇模型...",
   "agentManager.dialog.creating": "建立中...",
   "agentManager.dialog.createWorkspace": "建立工作樹",
   "agentManager.dialog.removeImage": "移除圖片",

--- a/packages/kilo-vscode/webview-ui/src/components/shared/model-selector-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/model-selector-utils.ts
@@ -31,8 +31,7 @@ export function buildTriggerLabel(
   hasProviders: boolean,
   labels: { select: string; noProviders: string; notSet: string },
 ): string {
-  if (resolvedName)
-    return providerID === KILO_GATEWAY_ID ? stripSubProviderPrefix(resolvedName) : resolvedName
+  if (resolvedName) return providerID === KILO_GATEWAY_ID ? stripSubProviderPrefix(resolvedName) : resolvedName
   if (raw?.providerID && raw?.modelID) {
     return raw.providerID === KILO_GATEWAY_ID ? raw.modelID : `${raw.providerID} / ${raw.modelID}`
   }


### PR DESCRIPTION
## Summary
- Split the New Worktree dialog into a scrollable content area (`.am-nv-dialog-content`) and a fixed footer (`.am-nv-dialog-footer`) so the **Create Worktree** button is always visible regardless of content height
- Converted the inline `MultiModelSelector` into a **Popover dropdown** that opens on click and dismisses on outside click or Escape — no longer pushes dialog content off-screen
- Added `selectModels` i18n key across all 16 language files

## Before
When compare mode was active, the model selector list expanded inline and pushed the submit button below the visible dialog area. Users had to scroll down and couldn't dismiss the model list.

## After
The model selector appears as a compact trigger button. Clicking it opens a popover overlay with the full model search/checklist. The Create Worktree button stays pinned at the bottom of the dialog.