### PR TITLE
fix(settings): avoid Agent Behaviour nav label overflow on narrow panes

### DIFF
--- a/packages/kilo-ui/src/components/tabs.css
+++ b/packages/kilo-ui/src/components/tabs.css
@@ -55,20 +55,12 @@
 
     @container (max-width: 640px) {
       [data-slot="tabs-list"] {
-        width: 56px;
-        min-width: 56px;
+        width: 52px;
+        min-width: 52px;
       }
 
       [data-slot="tabs-trigger"] .label {
-        position: absolute;
-        width: 1px;
-        height: 1px;
-        padding: 0;
-        margin: -1px;
-        overflow: hidden;
-        clip: rect(0, 0, 0, 0);
-        white-space: nowrap;
-        border: 0;
+        display: none;
       }
     }
 

--- a/packages/kilo-ui/src/components/tabs.css
+++ b/packages/kilo-ui/src/components/tabs.css
@@ -53,11 +53,12 @@
       min-width: 180px;
     }
 
-    @container (max-width: 500px) {
+    @container (max-width: 640px) {
       [data-slot="tabs-list"] {
-        width: auto;
-        min-width: auto;
+        width: 56px;
+        min-width: 56px;
       }
+
       [data-slot="tabs-trigger"] .label {
         display: none;
       }

--- a/packages/kilo-ui/src/components/tabs.css
+++ b/packages/kilo-ui/src/components/tabs.css
@@ -60,7 +60,15 @@
       }
 
       [data-slot="tabs-trigger"] .label {
-        display: none;
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
       }
     }
 


### PR DESCRIPTION
## Summary
- switch settings sidebar into icon-only mode earlier for narrow containers
- use a fixed compact sidebar width (`56px`) so icon mode is stable and avoids label clipping
- keep existing full-label behavior for wider layouts

Closes #6672

## Validation
- `bun run --cwd packages/kilo-vscode check-types` ✅
- `bun run --cwd packages/kilo-vscode lint` ✅
- `git push -u sonwr fix/settings-agent-behaviour-compact-nav-6672` (pre-push hook runs `bun turbo typecheck`) ✅
