### PR TITLE
fix(agent-manager): dispose vscode.onMessage listener via onCleanup in branch dialog

### DIFF
--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -388,6 +388,50 @@ describe("KiloProvider — pending session refresh on reconnect", () => {
   })
 })
 
+// ---------------------------------------------------------------------------
+// handleChangeDefaultBaseBranch — listener leak fix
+// ---------------------------------------------------------------------------
+
+describe("Agent Manager — dialog listener cleanup", () => {
+  const tsx = fs.readFileSync(TSX_FILE, "utf-8")
+
+  /**
+   * Regression: handleChangeDefaultBaseBranch subscribes to vscode.onMessage
+   * for branch data. Previously unsub() was only called inside selectBranch()
+   * and the Escape keydown handler. If the dialog closed via backdrop click or
+   * external dialog.close(), the listener leaked and stacked on every reopen.
+   *
+   * The fix ties unsub() to Solid's onCleanup inside the dialog.show() render
+   * function so it always disposes regardless of how the dialog closes.
+   */
+  it("handleChangeDefaultBaseBranch uses onCleanup(unsub) inside dialog.show", () => {
+    const fnStart = tsx.indexOf("const handleChangeDefaultBaseBranch")
+    expect(fnStart, "handleChangeDefaultBaseBranch must exist").toBeGreaterThan(-1)
+
+    // Grab the function body (enough to cover the dialog.show callback)
+    const snippet = tsx.slice(fnStart, fnStart + 2000)
+
+    // The dialog.show callback must register onCleanup(unsub)
+    const showIdx = snippet.indexOf("dialog.show(")
+    expect(showIdx, "dialog.show() call must exist").toBeGreaterThan(-1)
+    const afterShow = snippet.slice(showIdx)
+    expect(afterShow, "onCleanup(unsub) must be inside dialog.show callback").toContain("onCleanup(unsub)")
+  })
+
+  it("selectBranch does not manually call unsub (handled by onCleanup)", () => {
+    const fnStart = tsx.indexOf("const handleChangeDefaultBaseBranch")
+    const snippet = tsx.slice(fnStart, fnStart + 2000)
+
+    // Find the selectBranch function body
+    const selStart = snippet.indexOf("const selectBranch")
+    expect(selStart, "selectBranch must exist").toBeGreaterThan(-1)
+    const selEnd = snippet.indexOf("}", selStart + 50)
+    const selBody = snippet.slice(selStart, selEnd + 1)
+
+    expect(selBody, "selectBranch should not call unsub() directly").not.toContain("unsub()")
+  })
+})
+
 describe("SetupScriptRunner — task execution model", () => {
   const runner = fs.readFileSync(SETUP_SCRIPT_RUNNER_FILE, "utf-8")
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1445,7 +1445,6 @@ const AgentManagerContent: Component = () => {
     const selectBranch = (name: string | undefined) => {
       vscode.postMessage({ type: "agentManager.setDefaultBaseBranch", branch: name })
       setDefaultBaseBranch(name)
-      unsub()
       dialog.close()
     }
 
@@ -1474,44 +1473,46 @@ const AgentManagerContent: Component = () => {
       } else if (e.key === "Escape") {
         e.preventDefault()
         e.stopPropagation()
-        unsub()
         dialog.close()
       }
     }
 
-    dialog.show(() => (
-      <Dialog title={t("agentManager.worktree.defaultBaseBranch")} fit>
-        <div class="am-default-base-branch">
-          <BranchSelect
-            branches={filtered()}
-            loading={loading()}
-            search={search()}
-            onSearch={(v) => {
-              setSearch(v)
-              setHighlighted(-1)
-            }}
-            onSelect={(b) => selectBranch(b.name)}
-            onSearchKeyDown={handleKeyDown}
-            selected={defaultBaseBranch()}
-            highlighted={highlighted()}
-            onHighlight={setHighlighted}
-            searchPlaceholder={t("agentManager.dialog.searchBranches")}
-            emptyLabel={t("agentManager.import.noMatchingBranches")}
-            loadingLabel={t("agentManager.import.loadingBranches")}
-            defaultLabel={t("agentManager.dialog.branchBadge.default")}
-            remoteLabel={t("agentManager.dialog.branchBadge.remote")}
-            defaultName={defaultBaseBranch()}
-            autoOption={{
-              label: t("agentManager.worktree.defaultBaseBranchAuto"),
-              hint: repoDetectedBranch(),
-              active: !hasConfiguredBranch(),
-              highlighted: highlighted() === -1,
-              onSelect: () => selectBranch(undefined),
-            }}
-          />
-        </div>
-      </Dialog>
-    ))
+    dialog.show(() => {
+      onCleanup(unsub)
+      return (
+        <Dialog title={t("agentManager.worktree.defaultBaseBranch")} fit>
+          <div class="am-default-base-branch">
+            <BranchSelect
+              branches={filtered()}
+              loading={loading()}
+              search={search()}
+              onSearch={(v) => {
+                setSearch(v)
+                setHighlighted(-1)
+              }}
+              onSelect={(b) => selectBranch(b.name)}
+              onSearchKeyDown={handleKeyDown}
+              selected={defaultBaseBranch()}
+              highlighted={highlighted()}
+              onHighlight={setHighlighted}
+              searchPlaceholder={t("agentManager.dialog.searchBranches")}
+              emptyLabel={t("agentManager.import.noMatchingBranches")}
+              loadingLabel={t("agentManager.import.loadingBranches")}
+              defaultLabel={t("agentManager.dialog.branchBadge.default")}
+              remoteLabel={t("agentManager.dialog.branchBadge.remote")}
+              defaultName={defaultBaseBranch()}
+              autoOption={{
+                label: t("agentManager.worktree.defaultBaseBranchAuto"),
+                hint: repoDetectedBranch(),
+                active: !hasConfiguredBranch(),
+                highlighted: highlighted() === -1,
+                onSelect: () => selectBranch(undefined),
+              }}
+            />
+          </div>
+        </Dialog>
+      )
+    })
   }
 
   const handleShowKeyboardShortcuts = () => {


### PR DESCRIPTION
## Summary

- Fix listener leak in `handleChangeDefaultBaseBranch` where the `vscode.onMessage` subscription was only disposed in `selectBranch()` and the Escape key handler — closing the dialog via backdrop click or external `dialog.close()` left the listener active, stacking a new one on every reopen
- Move `unsub()` into Solid's `onCleanup()` inside the `dialog.show()` render function so it always disposes regardless of how the dialog closes
- Add regression tests verifying the `onCleanup(unsub)` pattern and that `selectBranch` no longer calls `unsub()` manually