### PR TITLE
fix: add consistent hover highlight to agent manager icon buttons

### DIFF
--- a/packages/kilo-ui/src/components/icon-button.css
+++ b/packages/kilo-ui/src/components/icon-button.css
@@ -11,7 +11,7 @@
     color 120ms,
     opacity 120ms;
 
-  &:hover:not(:disabled):not([data-disabled]) {
+  &[data-variant="ghost"]:hover:not(:disabled) {
     background: var(--button-ghost-hover, var(--surface-base-hover));
   }
 

--- a/packages/kilo-ui/src/components/icon-button.css
+++ b/packages/kilo-ui/src/components/icon-button.css
@@ -6,6 +6,14 @@
   border-radius: 5px;
   padding: 3px;
   border: none;
+  transition:
+    background 120ms,
+    color 120ms,
+    opacity 120ms;
+
+  &:hover:not(:disabled):not([data-disabled]) {
+    background: var(--button-ghost-hover, var(--surface-base-hover));
+  }
 
   &:active:not([data-disabled]) {
     opacity: 0.8;

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -588,6 +588,9 @@ button.am-section-toggle:hover .am-section-label {
   color: var(--text-weak);
   font-size: 12px;
   cursor: pointer;
+  transition:
+    background-color 120ms,
+    color 120ms;
 }
 
 .am-worktree-create:hover {
@@ -828,17 +831,20 @@ button.am-section-toggle:hover .am-section-label {
   background: transparent;
   color: var(--text-weak);
   cursor: pointer;
-  padding: 4px 6px;
-  border-radius: var(--radius-sm);
+  padding: 3px 6px;
+  border-radius: 5px;
   font-family: var(--font-mono, monospace);
   font-size: 10px;
   font-variant-numeric: tabular-nums;
   line-height: 1;
   white-space: nowrap;
+  transition:
+    background 120ms,
+    color 120ms;
 }
 
 .am-diff-toggle-btn:hover {
-  background: var(--surface-inset-base-hover);
+  background: var(--button-ghost-hover, var(--surface-base-hover));
   color: var(--text-base);
 }
 
@@ -1314,6 +1320,9 @@ button.am-section-toggle:hover .am-section-label {
   padding: 0;
   vertical-align: middle;
   line-height: 1;
+  transition:
+    background-color 120ms,
+    color 120ms;
 }
 
 .am-annotation-icon-btn svg {


### PR DESCRIPTION
## Summary
- Adds smooth 120ms hover highlight animation to all icon buttons in the agent manager
- Aligns the diff toggle button (`am-diff-toggle-btn`) to use the same `border-radius: 5px`, hover background token (`--button-ghost-hover`), and transition timing as the kilo-ui `IconButton` component
- Adds hover transitions to annotation icon buttons and worktree create button for consistency

Previously, the kilo-ui `IconButton` override set `background: transparent` but had no hover or transition styles — the upstream ghost variant hover wasn't taking effect. The diff toggle button also used a different hover token and border radius than adjacent `IconButton` instances.