### PR TITLE
fix(vscode): prevent extension hang on server shutdown

### DIFF
--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -11,6 +11,10 @@ type StateListener = (state: ConnectionState) => void
 type SSEEventFilter = (event: Event) => boolean
 type NotificationDismissListener = (notificationId: string) => void
 
+// Poll /global/health at the same interval as packages/app/src/context/server.tsx.
+// This provides a second detection channel for server death independent of the SSE heartbeat.
+const HEALTH_POLL_INTERVAL_MS = 10_000
+
 /**
  * Shared connection service that owns the single ServerManager, KiloClient (SDK), and SdkSSEAdapter.
  * Multiple KiloProvider instances subscribe to it for SSE events and state changes.
@@ -23,6 +27,7 @@ export class KiloConnectionService {
   private config: ServerConfig | null = null
   private state: ConnectionState = "disconnected"
   private connectPromise: Promise<void> | null = null
+  private healthPollTimer: ReturnType<typeof setInterval> | null = null
 
   private readonly eventListeners: Set<SSEEventListener> = new Set()
   private readonly stateListeners: Set<StateListener> = new Set()
@@ -174,6 +179,7 @@ export class KiloConnectionService {
    * Clean up everything: kill server, close SSE, clear listeners.
    */
   dispose(): void {
+    this.stopHealthPoll()
     this.sseClient?.dispose()
     this.serverManager.dispose()
     this.eventListeners.clear()
@@ -194,8 +200,56 @@ export class KiloConnectionService {
     }
   }
 
+  /**
+   * Start polling GET /global/health every 10 seconds.
+   * Ported from packages/app/src/context/server.tsx (HEALTH_POLL_INTERVAL_MS).
+   * Provides a second detection channel for server death independent of the SSE heartbeat.
+   * If the health check fails while we believe we are connected, the SSE client is
+   * disconnected so its reconnect loop kicks in immediately.
+   */
+  private startHealthPoll(baseUrl: string, password: string): void {
+    this.stopHealthPoll()
+
+    this.healthPollTimer = setInterval(async () => {
+      if (this.state !== "connected") {
+        return
+      }
+      const healthy = await this.checkHealth(baseUrl, password)
+      if (!healthy && this.state === "connected") {
+        console.warn("[Kilo New] ConnectionService: ❤️‍🩹 Health check failed — forcing SSE reconnect")
+        this.sseClient?.disconnect()
+      }
+    }, HEALTH_POLL_INTERVAL_MS)
+
+    // Don't keep the extension host alive just for the health poll
+    this.healthPollTimer.unref?.()
+  }
+
+  private stopHealthPoll(): void {
+    if (this.healthPollTimer) {
+      clearInterval(this.healthPollTimer)
+      this.healthPollTimer = null
+    }
+  }
+
+  private async checkHealth(baseUrl: string, password: string): Promise<boolean> {
+    try {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), 3000)
+      const res = await fetch(`${baseUrl}/global/health`, {
+        headers: { Authorization: `Basic ${Buffer.from(`kilo:${password}`).toString("base64")}` },
+        signal: controller.signal,
+      })
+      clearTimeout(timer)
+      return res.ok
+    } catch {
+      return false
+    }
+  }
+
   private async doConnect(workspaceDir: string): Promise<void> {
     // If we reconnect, ensure the previous SSE connection is cleaned up first.
+    this.stopHealthPoll()
     this.sseClient?.dispose()
 
     const server = await this.serverManager.getServer()
@@ -265,5 +319,8 @@ export class KiloConnectionService {
     this.sseClient.connect()
 
     await connectedPromise
+
+    // Start the independent health poll once we are confirmed connected.
+    this.startHealthPoll(config.baseUrl, config.password)
   }
 }

--- a/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
@@ -34,7 +34,10 @@ export class SdkSSEAdapter {
   private abortController: AbortController | null = null
   private heartbeatTimer: ReturnType<typeof setTimeout> | null = null
 
-  private static readonly HEARTBEAT_TIMEOUT_MS = 90_000
+  // 15s matches packages/app/src/context/global-sdk.tsx — server sends heartbeats
+  // every 10s, so this gives a 5s grace window before forcing a reconnect.
+  // Reduced from 90s: with 90s a dead connection could linger for ~1.5 minutes.
+  private static readonly HEARTBEAT_TIMEOUT_MS = 15_000
   private static readonly RECONNECT_DELAY_MS = 250
 
   constructor(private readonly client: KiloClient) {}

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -78,6 +78,7 @@ export class ServerManager {
           KILO_VSCODE_VERSION: vscode.version,
         },
         stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
       })
       console.log("[Kilo New] ServerManager: 📦 Process spawned with PID:", serverProcess.pid)
 
@@ -121,7 +122,7 @@ export class ServerManager {
       setTimeout(() => {
         if (!resolved) {
           console.error("[Kilo New] ServerManager: ⏰ Server startup timeout (30s)")
-          serverProcess.kill()
+          ServerManager.killProcess(serverProcess)
           reject(new Error("Server startup timeout"))
         }
       }, 30000)
@@ -136,10 +137,49 @@ export class ServerManager {
     return cliPath
   }
 
-  dispose(): void {
-    if (this.instance) {
-      this.instance.process.kill("SIGTERM")
-      this.instance = null
+  /**
+   * Kill a process and its entire process group.
+   * On Unix, we send the signal to -pid (negative) to reach the whole group,
+   * mirroring the desktop app's ProcessGroup::leader() + start_kill() pattern.
+   * On Windows, process.kill() on the child handle is sufficient.
+   */
+  private static killProcess(proc: ChildProcess, signal: NodeJS.Signals = "SIGTERM"): void {
+    if (proc.pid === undefined) {
+      return
     }
+    try {
+      if (process.platform !== "win32") {
+        // Negative PID targets the entire process group
+        process.kill(-proc.pid, signal)
+      } else {
+        proc.kill(signal)
+      }
+    } catch {
+      // Process already gone — ignore
+    }
+  }
+
+  dispose(): void {
+    if (!this.instance) {
+      return
+    }
+    const proc = this.instance.process
+    this.instance = null
+
+    console.log("[Kilo New] ServerManager: 🔴 Disposing — sending SIGTERM to process group, PID:", proc.pid)
+    ServerManager.killProcess(proc, "SIGTERM")
+
+    // SIGKILL fallback after 5s: mirrors the desktop app going straight to
+    // start_kill(). Ensures the process tree dies even if SIGTERM is ignored
+    // or Instance.disposeAll() hangs past the serve.ts shutdown timeout.
+    const timer = setTimeout(() => {
+      if (proc.exitCode === null) {
+        console.warn("[Kilo New] ServerManager: ⚠️ Process did not exit after SIGTERM, sending SIGKILL")
+        ServerManager.killProcess(proc, "SIGKILL")
+      }
+    }, 5000)
+    // unref so this timer doesn't prevent the extension host from exiting
+    timer.unref()
+    proc.on("exit", () => clearTimeout(timer))
   }
 }

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -19,7 +19,9 @@ export const ServeCommand = cmd({
     const abort = new AbortController()
     const shutdown = async () => {
       try {
-        await Instance.disposeAll()
+        // Race disposeAll against a 5s timeout so hung MCP subprocesses
+        // cannot prevent the server from shutting down gracefully.
+        await Promise.race([Instance.disposeAll(), new Promise<void>((resolve) => setTimeout(resolve, 5000))])
         await server.stop(true)
       } finally {
         abort.abort()
@@ -28,7 +30,21 @@ export const ServeCommand = cmd({
     process.on("SIGTERM", shutdown)
     process.on("SIGINT", shutdown)
     process.on("SIGHUP", shutdown)
+    // Orphan detection: exit if the parent process (extension host) dies.
+    // Mirrors the pattern in tui/thread.ts to prevent zombie server processes
+    // accumulating across extension restarts.
+    const ppid = process.ppid
+    const orphanCheck = setInterval(() => {
+      try {
+        process.kill(ppid, 0)
+      } catch {
+        clearInterval(orphanCheck)
+        process.exit(143)
+      }
+    }, 1000)
+    orphanCheck.unref()
     await new Promise((resolve) => abort.signal.addEventListener("abort", resolve))
+    clearInterval(orphanCheck)
     // kilocode_change end
   },
 })


### PR DESCRIPTION
Related: #6721

## Summary

- **Reduce SSE heartbeat timeout** from 90s → 15s so dead connections are detected within seconds instead of ~1.5 minutes (server sends heartbeats every 10s, 5s grace window)
- **Add independent health poll** every 10s via `GET /global/health` as a second detection channel for server death, matching the pattern in `packages/app/src/context/server.tsx`
- **Kill entire process group** on dispose (SIGTERM then SIGKILL after 5s) instead of only the direct child process, ensuring spawned subprocesses (MCP servers, etc.) are also cleaned up
- **Orphan detection in `serve.ts`**: server polls its parent PID every 1s and exits with code 143 if the extension host process has died, preventing zombie server processes accumulating across extension restarts
- **Timeout `Instance.disposeAll()`** with a 5s race so hung MCP subprocesses cannot block graceful shutdown

## Root cause

The extension host could hang indefinitely because:
1. The SSE heartbeat timeout was 90s — a dead server connection would linger for up to 1.5 minutes
2. The child `kilo serve` process was killed alone; its spawned subprocesses (MCP servers) became orphans and kept the process tree alive
3. `Instance.disposeAll()` has no timeout, so a hung MCP subprocess could block the shutdown signal handler forever