### PR TITLE
fix(acp): avoid parsing provider-less kilo default models

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1590,8 +1590,7 @@ export namespace ACP {
 
     // kilocode_change start
     const freeModel = await fetchDefaultModel()
-    const parsed = Provider.parseModel(freeModel)
-    return { providerID: "kilo", modelID: parsed.modelID }
+    return { providerID: "kilo", modelID: freeModel }
     // kilocode_change end
   }
 


### PR DESCRIPTION
## Context

While debugging Kilo default model issues, I found that ACP fallback model handling was parsing Kilo provider-less model IDs incorrectly.

`fetchDefaultModel()` can return values like `kilo-auto/free` or `kilo-auto/frontier`, but the ACP fallback path was treating those like `provider/model` strings and passing them through `parseModel()`. That could turn a valid Kilo default into something invalid like `kilo/free`.

## Implementation

This PR keeps the ACP fix small:

- Stop parsing the fallback value returned by `fetchDefaultModel()`.
- Keep it as the full `modelID` under provider `kilo`.

So instead of rewriting:

- `kilo-auto/free` -> `kilo/free`

We now preserve:

- `providerID: "kilo"`
- `modelID: "kilo-auto/free"`

**Note:** While testing this, I found a second issue where `kilo-auto/frontier` can still fail later in the flow if the Kilo auto-routing models are not present in the model catalog. That seems related to #6686 / #6687, but is separate from this ACP parsing fix.
