### PR TITLE
fix: use separate taskID for title generation to prevent model leak

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1993,7 +1993,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       tools: {},
       model,
       abort: new AbortController().signal,
-      sessionID: input.session.id,
+      sessionID: `title-${input.session.id}`, // kilocode_change - separate taskID to prevent small-model leak (#6552)
       retries: 2,
       messages: [
         {


### PR DESCRIPTION
## Summary

Fixes #6552

- `ensureTitle` was sending small-model requests (`kilo-auto/small`) with the same `HEADER_TASKID` as the agent session
- The gateway saw two different models under the same task and routed to both
- Prefix the title generation sessionID with `title-` to isolate it from the agent task

## Test plan

- [ ] With Kilo Gateway provider, generate a commit message or enhanced prompt
- [ ] Immediately start a new chat session
- [ ] Verify the first agent request only hits the main model (not both small + main)