### PR TITLE
fix: sync highlight overlay overflow with textarea to prevent caret drift

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -556,7 +556,8 @@
   line-height: 1.4;
   white-space: pre-wrap;
   word-wrap: break-word;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   z-index: 0;
   color: var(--vscode-input-foreground);
 }


### PR DESCRIPTION
## Summary
- Fixes #6678 — when the textarea scrollbar appears, the caret position goes out of sync with the visible text
- Changes the highlight overlay from `overflow: hidden` to `overflow-x: hidden; overflow-y: auto` so it allocates the same scrollbar space as the textarea, keeping text wrapping consistent between the two layers

## Test plan
- [x] Type enough text in the prompt input to exceed the 200px max-height and trigger the vertical scrollbar
- [x] Verify the caret stays aligned with the visible text after scrollbar appears
- [x] Verify ghost text and file mention highlights remain properly aligned
- [x] Verify no visual regression when content is short (no scrollbar)