### PR TITLE
fix(vscode): let the chat textarea render visible text directly

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -3,7 +3,7 @@
  * Text input with send/abort buttons, ghost-text autocomplete, and @ file mention support
  */
 
-import { Component, createSignal, createEffect, on, For, Index, onCleanup, onMount, Show, untrack } from "solid-js"
+import { Component, createSignal, createEffect, on, For, onCleanup, onMount, Show, untrack } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Dialog } from "@kilocode/kilo-ui/dialog"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
@@ -21,7 +21,7 @@ import { ThinkingSelector } from "../shared/ThinkingSelector"
 import { useFileMention } from "../../hooks/useFileMention"
 import { useImageAttachments } from "../../hooks/useImageAttachments"
 import { WandSparkles } from "@kilocode/kilo-ui/lucide"
-import { fileName, dirName, buildHighlightSegments } from "./prompt-input-utils"
+import { fileName, dirName } from "./prompt-input-utils"
 import type { ReviewComment } from "../../types/messages"
 import { formatReviewCommentsMarkdown } from "../../utils/review-comment-markdown"
 
@@ -125,7 +125,7 @@ export const PromptInput: Component = () => {
   }
 
   let textareaRef: HTMLTextAreaElement | undefined
-  let highlightRef: HTMLDivElement | undefined
+  let ghostRef: HTMLDivElement | undefined
   let dropdownRef: HTMLDivElement | undefined
   let debounceTimer: ReturnType<typeof setTimeout> | undefined
   let requestCounter = 0
@@ -297,9 +297,9 @@ export const PromptInput: Component = () => {
     if (active) active.scrollIntoView({ block: "nearest" })
   }
 
-  const syncHighlightScroll = () => {
-    if (highlightRef && textareaRef) {
-      highlightRef.scrollTop = textareaRef.scrollTop
+  const syncGhostScroll = () => {
+    if (ghostRef && textareaRef) {
+      ghostRef.scrollTop = textareaRef.scrollTop
     }
   }
 
@@ -316,7 +316,7 @@ export const PromptInput: Component = () => {
     // Defer height recalculation to after the browser completes the reflow.
     requestAnimationFrame(() => {
       adjustHeight()
-      syncHighlightScroll()
+      syncGhostScroll()
     })
   }
 
@@ -327,7 +327,7 @@ export const PromptInput: Component = () => {
     preEnhanceText = null
     adjustHeight()
     setGhostText("")
-    syncHighlightScroll()
+    syncGhostScroll()
 
     mention.onInput(val, target.selectionStart ?? val.length)
 
@@ -541,34 +541,26 @@ export const PromptInput: Component = () => {
         </div>
       </Show>
       <div class="prompt-input-wrapper">
-        <div class="prompt-input-ghost-wrapper">
-          <div class="prompt-input-highlight-overlay" ref={highlightRef} aria-hidden="true">
-            <Index each={buildHighlightSegments(text(), mention.mentionedPaths())}>
-              {(seg) => (
-                <Show when={seg().highlight} fallback={<span>{seg().text}</span>}>
-                  <span class="prompt-input-file-mention">{seg().text}</span>
-                </Show>
-              )}
-            </Index>
-            <Show when={ghostText()}>
-              <span class="prompt-input-ghost-text">{ghostText()}</span>
-            </Show>
-          </div>
-          <textarea
-            ref={textareaRef}
-            class="prompt-input"
-            placeholder={
-              isDisabled() ? language.t("prompt.placeholder.connecting") : language.t("prompt.placeholder.default")
-            }
-            value={text()}
-            onInput={handleInput}
-            onKeyDown={handleKeyDown}
-            onPaste={handlePaste}
-            onScroll={syncHighlightScroll}
-            disabled={isDisabled()}
-            rows={1}
-          />
+        <div class="prompt-input-ghost-overlay" ref={ghostRef} aria-hidden="true">
+          <span class="prompt-input-ghost-padding">{text()}</span>
+          <Show when={ghostText()}>
+            <span class="prompt-input-ghost-text">{ghostText()}</span>
+          </Show>
         </div>
+        <textarea
+          ref={textareaRef}
+          class="prompt-input"
+          placeholder={
+            isDisabled() ? language.t("prompt.placeholder.connecting") : language.t("prompt.placeholder.default")
+          }
+          value={text()}
+          onInput={handleInput}
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+          onScroll={syncGhostScroll}
+          disabled={isDisabled()}
+          rows={1}
+        />
       </div>
       <div class="prompt-input-hint">
         <div class="prompt-input-hint-selectors">

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -498,20 +498,27 @@
   display: flex;
   gap: 8px;
   align-items: flex-end;
+  position: relative;
 }
 
 .prompt-input {
   flex: 1;
+  width: 100%;
   min-height: 54px;
   max-height: 200px;
   padding: 8px 8px calc(8px + 1.4em);
-  color: transparent;
+  color: var(--vscode-input-foreground);
   caret-color: var(--vscode-input-foreground);
   font-family: var(--vscode-font-family);
   font-size: 13px;
   line-height: 1.4;
   resize: none;
   outline: none;
+  display: block;
+  position: relative;
+  z-index: 1;
+  background: transparent;
+  box-sizing: border-box;
 }
 
 .prompt-input:focus {
@@ -527,23 +534,8 @@
   color: var(--vscode-input-placeholderForeground);
 }
 
-/* Input overlay (highlight + ghost text) */
-.prompt-input-ghost-wrapper {
-  position: relative;
-  flex: 1;
-  min-width: 0;
-}
-
-.prompt-input-ghost-wrapper .prompt-input {
-  display: block;
-  position: relative;
-  z-index: 1;
-  background: transparent;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.prompt-input-highlight-overlay {
+/* Input ghost text */
+.prompt-input-ghost-overlay {
   position: absolute;
   top: 0;
   left: 0;
@@ -559,11 +551,11 @@
   overflow-x: hidden;
   overflow-y: auto;
   z-index: 0;
-  color: var(--vscode-input-foreground);
+  color: transparent;
 }
 
-.prompt-input-file-mention {
-  color: var(--vscode-textLink-foreground, #3794ff);
+.prompt-input-ghost-padding {
+  color: transparent;
 }
 
 .prompt-input-ghost-text {


### PR DESCRIPTION
Closes #6087
Related to #6678, #6734

## Context

This addresses the cursor misalignment issue in #6087 and builds on the recent overlay sync fixes in #6734.

The root cause was that the chat input used two separate layout layers:
- A transparent `textarea` as the real editable element.
- A separate overlay div for visible text rendering.

Even with the recent sync improvements, small layout differences between those layers could still accumulate with long or wrapped text and cause caret drift.

This also means the old overlay was doing two jobs at once: rendering the main visible text and styling inline `@file` mentions inside the composer. This fix prioritizes caret accuracy by removing the overlay from the main text rendering path, while keeping `@file` mention behavior itself intact.

## Implementation

This applies a simple root-cause fix: let the `textarea` render the visible text directly.

What changed:
- Restored normal text rendering on the chat textarea.
- Removed the overlay as the primary visible text layer.
- Kept a lightweight overlay only for ghost autocomplete rendering.

So the visible text and the caret now go through the same native layout path, which avoids the drift caused by dual-layer rendering.

`@file` mentions still work as before for selection, insertion, and attachment parsing. The only behavior change is that inline visual highlighting inside the composer is no longer rendered through the old overlay text layer.

This is intentionally a minimal fix focused on caret accuracy and input stability.

## How to Test

- Open the VS Code chat input.
- Paste 10+ lines of text.
- Continue typing until the input wraps across many lines and starts scrolling.
- Verify the caret stays aligned with the visible text throughout.
- Verify ghost autocomplete still renders and can still be accepted.
- Verify `@file` mention selection and insertion still work.