### PR TITLE
fix: align globalConfigFile() write target with read precedence

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1415,14 +1415,18 @@ export namespace Config {
 
   function globalConfigFile() {
     // kilocode_change start
-    const candidates = ["kilo.jsonc", "kilo.json", "opencode.jsonc", "opencode.json", "config.json"].map((file) =>
-      // kilocode_change end
+    // Order must match the read-merge order in Config.global (lines 1297-1303)
+    // so that writes go to the highest-precedence existing file.
+    const candidates = ["config.json", "kilo.json", "kilo.jsonc", "opencode.json", "opencode.jsonc"].map((file) =>
       path.join(Global.Path.config, file),
     )
-    for (const file of candidates) {
-      if (existsSync(file)) return file
+    // Return the last existing file (highest read precedence)
+    for (let i = candidates.length - 1; i >= 0; i--) {
+      if (existsSync(candidates[i])) return candidates[i]
     }
-    return candidates[0]
+    // kilocode_change end
+    // Default to kilo.jsonc for new installations
+    return path.join(Global.Path.config, "kilo.jsonc")
   }
 
   function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary

- `globalConfigFile()` (the write path) returned the **first existing** file from an arbitrary order, while `Config.global` (the read path) merges files with the **last one winning**
- When a user has multiple config files (e.g. both `kilo.jsonc` and `opencode.jsonc`), writes via `updateGlobal()` could go to a lower-precedence file that gets silently overridden on the next read
- Fix aligns the candidate order with the read-merge order and iterates in reverse to return the highest-precedence existing file

## Test plan

- [x] Verified the TS error on line 1295 is pre-existing on `main` (not introduced by this change)
- [x] Confirmed `globalConfigFile()` is only called from `updateGlobal()` — no other callers affected
- [ ] With both `kilo.jsonc` and `opencode.jsonc` present: `updateGlobal()` now writes to `opencode.jsonc` (highest precedence)
- [ ] With only `kilo.json` present: still writes to `kilo.json`
- [ ] With no config files: creates `kilo.jsonc` (default for new installations)

Closes #6742