### PR TITLE
feat: show skills as slash commands in TUI autocomplete

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -357,8 +357,7 @@ export function Autocomplete(props: {
     const results: AutocompleteOption[] = [...command.slashes()]
 
     for (const serverCommand of sync.data.command) {
-      if (serverCommand.source === "skill") continue
-      const label = serverCommand.source === "mcp" ? ":mcp" : ""
+      const label = serverCommand.source === "mcp" ? ":mcp" : serverCommand.source === "skill" ? ":skill" : ""
       results.push({
         display: "/" + serverCommand.name + label,
         description: serverCommand.description,


### PR DESCRIPTION
## Summary

- Skills defined in `.kilocode/skills/` (or global/remote sources) are now surfaced as `/skill-name:skill` slash commands in the TUI autocomplete
- Previously, skills were registered as commands on the server and transmitted to the client, but explicitly filtered out in the TUI's autocomplete component (line 360 of `autocomplete.tsx`)
- The web/desktop app (`packages/app`) already shows skills as slash commands with a "skill" badge — this change brings the TUI to parity

## Changes

**`packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx`**
- Removed `if (serverCommand.source === "skill") continue` filter
- Extended the label logic to append `:skill` suffix (matching the existing `:mcp` pattern for MCP prompts)

## How it works

The full pipeline was already built:
1. `Command.ts` registers skills as commands with `source: "skill"` ✅
2. `sync.tsx` transmits them to the client via `sdk.client.command.list()` ✅  
3. `autocomplete.tsx` renders them when typing `/` — **was blocked, now enabled** ✅
4. Selecting a skill inserts `/skill-name ` into the prompt, which the command processor resolves to the skill's template content ✅

Built-in commands with the same name take precedence (existing guard at `command/index.ts:136`).

## Test plan

- [ ] Create a skill in `.kilocode/skills/test-skill/SKILL.md` with valid frontmatter
- [ ] Type `/` in TUI prompt — skill appears in autocomplete as `/test-skill:skill`
- [ ] Select the skill — `/test-skill ` is inserted into the prompt
- [ ] Submit — skill content is loaded and used as context
- [ ] Verify built-in commands still take precedence over skills with conflicting names
- [ ] Verify MCP prompts still show as `/prompt-name:mcp`

Closes #6731

🤖 Generated with [Claude Code](https://claude.com/claude-code)