### PR TITLE
fix: block cross-drive path traversal on Windows

### DIFF
--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -2,7 +2,7 @@ import { chmod, mkdir, readFile, writeFile } from "fs/promises"
 import { createWriteStream, existsSync, statSync } from "fs"
 import { lookup } from "mime-types"
 import { realpathSync } from "fs"
-import { dirname, join, relative } from "path"
+import { dirname, isAbsolute, join, relative } from "path"
 import { Readable } from "stream"
 import { pipeline } from "stream/promises"
 import { Glob } from "./glob"
@@ -132,7 +132,11 @@ export namespace Filesystem {
   }
 
   export function contains(parent: string, child: string) {
-    return !relative(parent, child).startsWith("..")
+    const rel = relative(parent, child)
+    // On Windows, path.relative across drives returns an absolute path
+    // (e.g. "D:\other\file") instead of a ".." relative path. Treat
+    // absolute results as outside the parent.
+    return !isAbsolute(rel) && !rel.startsWith("..")
   }
 
   export async function findUp(target: string, start: string, stop?: string) {

--- a/packages/opencode/test/file/path-traversal.test.ts
+++ b/packages/opencode/test/file/path-traversal.test.ts
@@ -29,6 +29,13 @@ describe("Filesystem.contains", () => {
     expect(Filesystem.contains("/project", "/project-other/file")).toBe(false)
     expect(Filesystem.contains("/project", "/projectfile")).toBe(false)
   })
+
+  test("blocks cross-drive paths on Windows", () => {
+    // On Windows, path.relative across drives returns an absolute path
+    // instead of a ".." relative path. This must still be treated as external.
+    expect(Filesystem.contains("C:\\Users\\project", "D:\\other\\file")).toBe(false)
+    expect(Filesystem.contains("C:\\workspace", "D:\\workspace\\file")).toBe(false)
+  })
 })
 
 /*


### PR DESCRIPTION
## Summary

- On Windows, `path.relative()` across different drives (e.g. `C:\project` vs `D:\other`) returns an absolute path (`D:\other\file`) instead of a `..` relative path
- `Filesystem.contains()` only checked for `..` prefix, so cross-drive paths were incorrectly treated as **inside** the workspace
- This bypassed `external_directory` permission checks, allowing all tools (write, edit, apply_patch) to write outside the workspace without prompting

## Root cause

```js
// path.relative across drives on Windows:
path.relative("C:\project", "D:\other\file")
// => "D:\other\file" (absolute, NOT "..\..")

// Old check:
!relative(parent, child).startsWith("..")
// => !false => true (WRONG — treated as inside workspace)
```

## Fix

Add an `isAbsolute()` guard to `Filesystem.contains()`:

```ts
const rel = relative(parent, child)
return !isAbsolute(rel) && !rel.startsWith("..")
```

## Test plan

- [x] New test: `Filesystem.contains("C:\Users\project", "D:\other\file")` returns `false`
- [x] New test: `Filesystem.contains("C:\workspace", "D:\workspace\file")` returns `false`
- [x] All 16 existing path traversal tests pass (14 existing + 2 new)
- [ ] Manual: On Windows, set `external_directory: "deny"`, attempt to write a file on a different drive — should be blocked

## Note

The issue title mentions "Fast Apply" but the root cause affects **all** file-writing tools equally (write, edit, apply_patch). "Fast Apply" just selects `apply_patch` vs `edit`/`write` — both paths use `assertExternalDirectory()` → `Instance.containsPath()` → `Filesystem.contains()`, which is where the bug lives.

`Filesystem.overlaps()` has a similar cross-drive issue but is not used in the permission enforcement path.

Closes #6725

🤖 Generated with [Claude Code](https://claude.com/claude-code)