### PR TITLE
fix: Set All permissions includes wildcard to override agent defaults (#6710)

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/settings/AutoApproveTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AutoApproveTab.tsx
@@ -52,7 +52,7 @@ const AutoApproveTab: Component = () => {
   }
 
   const setAll = (level: PermissionLevel) => {
-    const updated: Record<string, PermissionLevel> = {}
+    const updated: Record<string, PermissionLevel> = { "*": level }
     for (const tool of TOOLS) {
       updated[tool] = level
     }


### PR DESCRIPTION
## Summary

- **Root cause**: `setAll()` in `AutoApproveTab.tsx` only set individual tool permissions (`read`, `edit`, `bash`, etc.) without setting the `"*"` wildcard. When `"*": "allow"` existed in the global config (from legacy migration or manual setting), it persisted after "Set all to Ask" because `mergeDeep` only adds/overrides keys, never removes them.
- **Why this matters**: The permission system uses `findLast` on a merged ruleset where user rules come after agent defaults. Agent defaults include `"*": "allow"`. Without a user-level `"*": "ask"` rule, the agent default `"*": "allow"` remains the last matching rule for any permission not explicitly listed in the TOOLS array.
- **Fix**: Include `"*"` in the `setAll` update so it properly overrides the agent-level wildcard default.

### Additional context

The legacy migration (`migration-service.ts:437`) sets `permission: "allow"` as a scalar string when upgrading from old Kilo Code with auto-approval enabled. The config transform converts this to `{"*": "allow"}`. This is the most common path to having `"*": "allow"` in global config.

There's also a secondary display issue: on fresh installs with no config, `getLevel` defaults to `"ask"` but the agent runtime defaults to `"*": "allow"`. This means the Auto Approve tab can show "Ask" when the actual runtime behavior is "Allow". This is a separate issue worth tracking.

## Test plan

- [ ] Upgrade from old Kilo Code with auto-approval enabled (triggers migration that sets `"*": "allow"`)
- [ ] Open Auto Approve settings, verify all tools show "Allow"
- [ ] Click "Set all" → "Ask"
- [ ] Open Agent Manager, start a task
- [ ] Verify the agent prompts for permission instead of auto-approving

Fixes #6710

🤖 Generated with [Claude Code](https://claude.com/claude-code)