### PR TITLE
fix: extract readable message from NamedError objects (#6568)

### DIFF
--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -33,6 +33,13 @@ export function getErrorMessage(error: unknown): string {
       if (typeof first === "string") return first
       if (first && typeof first.message === "string") return first.message
     }
+    // NamedError shape from server: { name: "SomeError", data: { field: "..." } }
+    if (typeof obj.name === "string" && obj.data && typeof obj.data === "object") {
+      const data = obj.data as Record<string, unknown>
+      const parts = Object.values(data).filter((v) => typeof v === "string")
+      if (parts.length > 0) return `${obj.name}: ${parts.join(", ")}`
+      return obj.name
+    }
   }
   return String(error)
 }


### PR DESCRIPTION
## Summary

- When the small model is misconfigured, commit message generation showed `Failed to generate commit message: [object Object]`
- The server serializes `ProviderModelNotFoundError` as `{ name: "ProviderModelNotFoundError", data: { providerID: "...", modelID: "..." } }` — a NamedError shape with no `data.message` field
- `getErrorMessage()` in `kilo-provider-utils.ts` had handlers for `Error` instances, strings, `{ message }`, `{ error }`, `{ data: { message } }`, and `{ errors: [] }` — but not the NamedError shape
- The fallback `String(error)` produced `[object Object]`

**Fix:** Added a handler for NamedError-shaped objects (`{ name: string, data: object }`) that extracts string values from `data` and formats them with the error name. For example: `ProviderModelNotFoundError: anthropic, claude-nonexistent`.

## Test plan

- [ ] Configure a non-existent model as the small model
- [ ] Click the commit message generation button (SCM)
- [ ] Verify the error message shows the error name and model details instead of `[object Object]`

Fixes #6568

🤖 Generated with [Claude Code](https://claude.com/claude-code)