### PR TITLE
fix: show tool name in inline permission prompt (#6574)

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -88,13 +88,12 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                 <Show when={perm()} keyed>
                   {(p) => (
                     <div data-component="permission-prompt" onClick={(e: MouseEvent) => e.stopPropagation()}>
-                      <Show when={p.patterns.length > 0}>
-                        <div class="permission-dock-patterns">
-                          <For each={p.patterns}>
-                            {(pattern) => <code class="permission-dock-pattern">{pattern}</code>}
-                          </For>
-                        </div>
-                      </Show>
+                      <div class="permission-dock-patterns">
+                        <span class="permission-dock-tool">{p.toolName}</span>
+                        <For each={p.patterns}>
+                          {(pattern) => <code class="permission-dock-pattern">{pattern}</code>}
+                        </For>
+                      </div>
                       <div data-slot="permission-actions">
                         <Button
                           variant="ghost"

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -919,6 +919,14 @@
   padding: 8px 12px;
 }
 
+.permission-dock-tool {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--text-weak-base, var(--vscode-descriptionForeground));
+  letter-spacing: 0.05em;
+}
+
 .permission-dock-pattern {
   font-size: 12px;
   font-family: var(--vscode-editor-font-family, monospace);


### PR DESCRIPTION
## Summary

- The inline permission prompt (attached to tool calls in assistant messages) showed file patterns but didn't identify which permission was being requested
- Users couldn't tell if a prompt was for `read`, `edit`, `bash`, etc. until after approving
- The bottom-dock permission prompt (ChatView.tsx) already showed the tool name via `perm.toolName` in the BasicTool subtitle — the inline version was missing it

**Fix:** Added the tool name as an uppercase label (e.g. `READ`, `EDIT`) above the file patterns in the inline permission prompt. Also removed the `patterns.length > 0` gate so the container always renders, since the tool name provides useful context even without patterns.

## Test plan

- [ ] Set permissions to "Ask" for read/edit/bash tools
- [ ] Start a task that triggers permission prompts
- [ ] Verify the inline permission prompt shows the tool name (READ, EDIT, BASH) above the file patterns
- [ ] Verify the bottom-dock prompt still works as before

Fixes #6574

🤖 Generated with [Claude Code](https://claude.com/claude-code)