### PR TITLE
fix: always set reasoning_content on interleaved model assistant messages

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -145,24 +145,19 @@ export namespace ProviderTransform {
           // Filter out reasoning parts from content
           const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
 
-          // Include reasoning_content | reasoning_details directly on the message for all assistant messages
-          if (reasoningText) {
-            return {
-              ...msg,
-              content: filteredContent,
-              providerOptions: {
-                ...msg.providerOptions,
-                openaiCompatible: {
-                  ...(msg.providerOptions as any)?.openaiCompatible,
-                  [field]: reasoningText,
-                },
-              },
-            }
-          }
-
+          // Always include reasoning_content | reasoning_details on assistant messages.
+          // Some backends (e.g. Kimi) require the field on every assistant message
+          // when thinking is enabled, even if the message only contains tool calls.
           return {
             ...msg,
             content: filteredContent,
+            providerOptions: {
+              ...msg.providerOptions,
+              openaiCompatible: {
+                ...(msg.providerOptions as any)?.openaiCompatible,
+                [field]: reasoningText || "",
+              },
+            },
           }
         }
 


### PR DESCRIPTION
## Summary

- OpenAI-compatible backends like Kimi require `reasoning_content` on **every** assistant message when thinking is enabled, including messages that only contain tool calls
- Previously, the interleaved reasoning handler only set the field when reasoning parts existed, leaving it absent on tool-call-only messages
- This caused `400 thinking is enabled but reasoning_content is missing in assistant tool call message` errors
- Fix: always set `reasoning_content` (to extracted text or empty string) on all assistant messages when the interleaved handler is active

The change also simplifies the code by removing a conditional branch -- one return path instead of two.

Fixes #6746

## Test plan

- [ ] Use a Kimi model (kimi-for-coding or moonshotai-cn) with reasoning + tool calls enabled
- [ ] Verify no `400` error on assistant messages containing tool calls
- [ ] Verify reasoning content is still correctly extracted and passed through on messages that do have reasoning parts
- [ ] Verify other interleaved models (moonshotai) still work correctly