### PR TITLE
fix: use vscode theme color for welcome screen feature icons

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -486,7 +486,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
 
           <div class="migration-wizard__features">
             <div class="migration-wizard__feature">
-              <div class="migration-wizard__feature-icon migration-wizard__feature-icon--blue">
+              <div class="migration-wizard__feature-icon">
                 <BoltIcon />
               </div>
               <div class="migration-wizard__feature-text">
@@ -496,7 +496,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
             </div>
 
             <div class="migration-wizard__feature">
-              <div class="migration-wizard__feature-icon migration-wizard__feature-icon--purple">
+              <div class="migration-wizard__feature-icon">
                 <MonitorIcon />
               </div>
               <div class="migration-wizard__feature-text">
@@ -506,7 +506,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
             </div>
 
             <div class="migration-wizard__feature">
-              <div class="migration-wizard__feature-icon migration-wizard__feature-icon--cyan">
+              <div class="migration-wizard__feature-icon">
                 <UsersIcon />
               </div>
               <div class="migration-wizard__feature-text">
@@ -516,7 +516,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
             </div>
 
             <div class="migration-wizard__feature">
-              <div class="migration-wizard__feature-icon migration-wizard__feature-icon--orange">
+              <div class="migration-wizard__feature-icon">
                 <ServerIcon />
               </div>
               <div class="migration-wizard__feature-text">

--- a/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
@@ -113,31 +113,13 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  background: color-mix(in srgb, var(--vscode-button-background) 15%, transparent);
+  color: var(--vscode-button-background);
 }
 
 .migration-wizard__feature-icon svg {
   width: 18px;
   height: 18px;
-}
-
-.migration-wizard__feature-icon--blue {
-  background: color-mix(in srgb, var(--vscode-button-background) 15%, transparent);
-  color: var(--vscode-button-background);
-}
-
-.migration-wizard__feature-icon--purple {
-  background: rgba(167, 139, 250, 0.12);
-  color: #a78bfa;
-}
-
-.migration-wizard__feature-icon--cyan {
-  background: rgba(34, 211, 238, 0.1);
-  color: #22d3ee;
-}
-
-.migration-wizard__feature-icon--orange {
-  background: rgba(251, 146, 60, 0.1);
-  color: #fb923c;
 }
 
 .migration-wizard__feature-text {


### PR DESCRIPTION
## Summary

- Removes hardcoded per-icon color classes (`--blue`, `--purple`, `--cyan`, `--orange`) from the migration wizard welcome screen
- Applies `var(--vscode-button-background)` directly on the base `.migration-wizard__feature-icon` class so all four feature card icons use the user's theme accent color
- Cleans up the corresponding modifier classes from both the CSS and TSX