### PR TITLE
docs: Add ACP integration documentation and acpx compatibility

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -131,19 +131,6 @@ kx exec "help me fix this bug"
 kx sessions new --name backend-work
 ```
 
-### Alternative: Use kx Alias (Optional)
-
-If you want to avoid typing `kilo acp` every time, you can create a shell alias:
-
-```bash
-# Add to your shell profile (.bashrc, .zshrc, etc.)
-alias kx='acpx --agent "kilo acp"'
-
-# Then use the shorter form
-kx exec "help me fix this bug"
-kx sessions new --name backend-work
-```
-
 ### Supported ACP Clients
 
 - **[acpx](https://github.com/openclaw/acpx)** - Headless CLI client for agent orchestration

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -105,13 +105,26 @@ Kilo CLI supports the [Agent Client Protocol (ACP)](https://agentclientprotocol.
 npm install -g @kilocode/cli
 npm install -g acpx
 
-# Use immediately
-acpx opencode exec "help me fix this bug"
-acpx opencode sessions new --name backend-work
-acpx opencode --session backend-work "continue working on the API"
+# Use with Kilo CLI via --agent flag
+acpx --agent "kilo acp" exec "help me fix this bug"
+acpx --agent "kilo acp" sessions new --name backend-work
+acpx --agent "kilo acp" --session backend-work "continue working on the API"
 
 # Auto-approve permissions for CI/automation
-acpx opencode --approve-all exec "run the test suite and fix any failures"
+acpx --agent "kilo acp" --approve-all exec "run the test suite and fix any failures"
+```
+
+### Alternative: Use kx Alias (Optional)
+
+If you want to avoid typing `kilo acp` every time, you can create a shell alias:
+
+```bash
+# Add to your shell profile (.bashrc, .zshrc, etc.)
+alias kx='acpx --agent "kilo acp"'
+
+# Then use the shorter form
+kx exec "help me fix this bug"
+kx sessions new --name backend-work
 ```
 
 ### Supported ACP Clients

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -110,8 +110,25 @@ acpx --agent "kilo acp" exec "help me fix this bug"
 acpx --agent "kilo acp" sessions new --name backend-work
 acpx --agent "kilo acp" --session backend-work "continue working on the API"
 
-# Auto-approve permissions for CI/automation
+# Auto-approve permissions for CI/automation (only use in trusted environments)
 acpx --agent "kilo acp" --approve-all exec "run the test suite and fix any failures"
+```
+
+{% callout type="warning" %}
+**Security Note:** The `--approve-all` flag auto-approves all permission requests including file writes and command execution. Only use this in trusted CI/automation environments where you control the input.
+{% /callout %}
+
+### Alternative: Use kx Alias (Optional)
+
+If you want to avoid typing `kilo acp` every time, you can create a personal shell alias (note: this is your own alias, not a shipped command):
+
+```bash
+# Add to your shell profile (.bashrc, .zshrc, etc.)
+alias kx='acpx --agent "kilo acp"'
+
+# Then use the shorter form
+kx exec "help me fix this bug"
+kx sessions new --name backend-work
 ```
 
 ### Alternative: Use kx Alias (Optional)

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -81,6 +81,7 @@ Or use npm:
 | `kilo github`             | Manage GitHub agent (install, run)         |
 | `kilo debug`              | Debugging and troubleshooting tools        |
 | `kilo completion`         | Generate shell completion script           |
+| `kilo acp`                | Start ACP (Agent Client Protocol) server   |
 
 ### Global Options
 
@@ -90,6 +91,48 @@ Or use npm:
 | `--version`, `-v` | Show version number                 |
 | `--print-logs`    | Print logs to stderr                |
 | `--log-level`     | Log level: DEBUG, INFO, WARN, ERROR |
+
+## ACP Integration
+
+Kilo CLI supports the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/), enabling integration with any ACP-compatible client.
+
+### Quick Start with acpx
+
+[acpx](https://github.com/openclaw/acpx) is a headless CLI client for ACP agents that works perfectly with Kilo:
+
+```bash
+# Install both tools
+npm install -g @kilocode/cli
+npm install -g acpx
+
+# Use immediately
+acpx opencode exec "help me fix this bug"
+acpx opencode sessions new --name backend-work
+acpx opencode --session backend-work "continue working on the API"
+
+# Auto-approve permissions for CI/automation
+acpx opencode --approve-all exec "run the test suite and fix any failures"
+```
+
+### Supported ACP Clients
+
+- **[acpx](https://github.com/openclaw/acpx)** - Headless CLI client for agent orchestration
+- **Zed Editor** - Built-in ACP support for coding agents
+- **Any ACP v1 client** - Full protocol compliance
+
+### Manual ACP Server
+
+If you want to use Kilo with a custom ACP client, you can start the ACP server manually:
+
+```bash
+# Start ACP server on stdio
+kilo acp
+
+# With specific working directory
+kilo acp --cwd /path/to/project
+```
+
+For detailed technical information, see the [ACP Implementation README](https://github.com/Kilo-Org/kilocode/tree/main/packages/opencode/src/acp).
 
 ### Interactive Slash Commands
 

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -122,6 +122,7 @@ export namespace ACP {
       })
   }
 
+  // kilocode_change start
   export async function init({ sdk: _sdk, defaultCwd }: { sdk: KiloClient; defaultCwd?: string }) {
     return {
       create: (connection: AgentSideConnection, fullConfig: ACPConfig) => {
@@ -129,6 +130,7 @@ export namespace ACP {
       },
     }
   }
+  // kilocode_change end
 
   export class Agent implements ACPAgent {
     private connection: AgentSideConnection

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -669,11 +669,12 @@ export namespace ACP {
       try {
         const cursor = params.cursor ? Number(params.cursor) : undefined
         const limit = 100
+        const directory = params.cwd ?? this.config.defaultCwd ?? process.cwd()
 
         const sessions = await this.sdk.session
           .list(
             {
-              directory: params.cwd ?? undefined,
+              directory: directory,
               roots: true,
             },
             { throwOnError: true },

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -122,10 +122,10 @@ export namespace ACP {
       })
   }
 
-  export async function init({ sdk: _sdk }: { sdk: KiloClient }) {
+  export async function init({ sdk: _sdk, defaultCwd }: { sdk: KiloClient; defaultCwd?: string }) {
     return {
       create: (connection: AgentSideConnection, fullConfig: ACPConfig) => {
-        return new Agent(connection, fullConfig)
+        return new Agent(connection, { ...fullConfig, defaultCwd })
       },
     }
   }
@@ -567,7 +567,7 @@ export namespace ACP {
     }
 
     async newSession(params: NewSessionRequest) {
-      const directory = params.cwd
+      const directory = params.cwd ?? this.config.defaultCwd ?? process.cwd()
       try {
         const model = await defaultModel(this.config, directory)
 
@@ -601,7 +601,7 @@ export namespace ACP {
     }
 
     async loadSession(params: LoadSessionRequest) {
-      const directory = params.cwd
+      const directory = params.cwd ?? this.config.defaultCwd ?? process.cwd()
       const sessionId = params.sessionId
 
       try {
@@ -711,7 +711,7 @@ export namespace ACP {
     }
 
     async unstable_forkSession(params: ForkSessionRequest): Promise<ForkSessionResponse> {
-      const directory = params.cwd
+      const directory = params.cwd ?? this.config.defaultCwd ?? process.cwd()
       const mcpServers = params.mcpServers ?? []
 
       try {
@@ -776,7 +776,7 @@ export namespace ACP {
     }
 
     async unstable_resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {
-      const directory = params.cwd
+      const directory = params.cwd ?? this.config.defaultCwd ?? process.cwd()
       const sessionId = params.sessionId
       const mcpServers = params.mcpServers ?? []
 
@@ -1147,7 +1147,7 @@ export namespace ACP {
     }
 
     private async loadSessionMode(params: LoadSessionRequest) {
-      const directory = params.cwd
+      const directory = params.cwd ?? this.config.defaultCwd ?? process.cwd()
       const model = await defaultModel(this.config, directory)
       const sessionId = params.sessionId
 

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -572,7 +572,7 @@ export namespace ACP {
         const model = await defaultModel(this.config, directory)
 
         // Store ACP session state
-        const state = await this.sessionManager.create(params.cwd, params.mcpServers, model)
+        const state = await this.sessionManager.create(directory, params.mcpServers, model)
         const sessionId = state.id
 
         log.info("creating_session", { sessionId, mcpServers: params.mcpServers.length })
@@ -608,7 +608,7 @@ export namespace ACP {
         const model = await defaultModel(this.config, directory)
 
         // Store ACP session state
-        await this.sessionManager.load(sessionId, params.cwd, params.mcpServers, model)
+        await this.sessionManager.load(sessionId, directory, params.mcpServers, model)
 
         log.info("load_session", { sessionId, mcpServers: params.mcpServers.length })
 

--- a/packages/opencode/src/acp/types.ts
+++ b/packages/opencode/src/acp/types.ts
@@ -20,5 +20,5 @@ export interface ACPConfig {
     providerID: string
     modelID: string
   }
-  defaultCwd?: string
+  defaultCwd?: string // kilocode_change
 }

--- a/packages/opencode/src/acp/types.ts
+++ b/packages/opencode/src/acp/types.ts
@@ -20,4 +20,5 @@ export interface ACPConfig {
     providerID: string
     modelID: string
   }
+  defaultCwd?: string
 }

--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -21,7 +21,7 @@ export const AcpCommand = cmd({
   },
   handler: async (args) => {
     process.env.KILO_CLIENT = "acp"
-    await bootstrap(process.cwd(), async () => {
+    await bootstrap(args.cwd, async () => {
       const opts = await resolveNetworkOptions(args)
       const server = Server.listen(opts)
 

--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -53,10 +53,10 @@ export const AcpCommand = cmd({
       })
 
       const stream = ndJsonStream(input, output)
-      const agent = await ACP.init({ sdk })
+      const agent = await ACP.init({ sdk, defaultCwd: args.cwd })
 
       new AgentSideConnection((conn) => {
-        return agent.create(conn, { sdk })
+        return agent.create(conn, { sdk, defaultCwd: args.cwd })
       }, stream)
 
       log.info("setup connection")

--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -9,6 +9,7 @@ import { withNetworkOptions, resolveNetworkOptions } from "../network"
 
 const log = Log.create({ service: "acp-command" })
 
+// kilocode_change start
 export const AcpCommand = cmd({
   command: "acp",
   describe: "start ACP (Agent Client Protocol) server",
@@ -58,6 +59,7 @@ export const AcpCommand = cmd({
       new AgentSideConnection((conn) => {
         return agent.create(conn, { sdk, defaultCwd: args.cwd })
       }, stream)
+      // kilocode_change end
 
       log.info("setup connection")
       process.stdin.resume()


### PR DESCRIPTION
## Summary

Add comprehensive documentation for Kilo's Agent Client Protocol (ACP) capabilities and third-party client integration, particularly with acpx.

## Changes

### 1. Added `kilo acp` to CLI Commands Table
Added the ACP server command to the main CLI reference table.

### 2. New ACP Integration Section
Added a complete "ACP Integration" section covering:

- **Quick Start with acpx** - Installation and correct usage with `--agent` flag
- **Optional kx alias** - For convenience in daily use  
- **Security warning** - For --approve-all flag usage
- **Supported ACP Clients** - acpx, Zed Editor, any ACP v1 client
- **Manual ACP Server** - How to use `kilo acp` directly

### 3. Bug Fix: --cwd flag
Fixed `--cwd` flag in ACP command - was being parsed but ignored. Now properly passes the cwd argument to bootstrap().

## Testing

- ✅ Docs build verified (187 pages)
- ✅ All 10 existing ACP tests pass
- ✅ Manual testing with acpx confirmed working

## Related Issues

- Closes #6766