### PR TITLE
feat: allow Enter key to accept permission prompts in VS Code extension

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -51,6 +51,15 @@ export const ChatView: Component<ChatViewProps> = (props) => {
         e.preventDefault()
         session.abort()
       }
+      if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
+        const perm = sessionPermissions()[0]
+        if (perm && !responding()) {
+          e.preventDefault()
+          setResponding(true)
+          session.respondToPermission(perm.id, "once")
+          setResponding(false)
+        }
+      }
     }
     document.addEventListener("keydown", handler)
     onCleanup(() => document.removeEventListener("keydown", handler))


### PR DESCRIPTION
## Summary

- Adds an `Enter` key handler to the VS Code extension's ChatView so that pressing Enter while a permission prompt is visible triggers "Allow Once" on the first pending permission
- The `PromptInput` textarea is already unmounted when permissions are pending (gated by `blocked()`), so there is no conflict with the normal send-message Enter handler
- Modifier keys (Shift/Ctrl/Meta + Enter) are excluded to avoid interfering with other shortcuts