### PR TITLE
test: add P0 coverage for agent-manager hotspots

### DIFF
--- a/packages/kilo-vscode/tests/unit/git-ops.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-ops.test.ts
@@ -381,6 +381,27 @@ describe("GitOps", () => {
         expect(patch).not.toContain("a/b.txt")
       })
     })
+
+    it("filters absolute paths and .. traversal from selectedFiles", async () => {
+      await withRepo(async (cwd) => {
+        const git = new GitOps({ log: () => undefined })
+        await fs.writeFile(nodePath.join(cwd, "a.txt"), "one\n", "utf8")
+        await fs.writeFile(nodePath.join(cwd, "b.txt"), "one\n", "utf8")
+        runGit(cwd, ["add", "-A"])
+        runGit(cwd, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"])
+
+        await fs.writeFile(nodePath.join(cwd, "a.txt"), "two\n", "utf8")
+        await fs.writeFile(nodePath.join(cwd, "b.txt"), "two\n", "utf8")
+
+        const branch = runGit(cwd, ["branch", "--show-current"]) || "HEAD"
+        const patch = await git.buildWorktreePatch(cwd, branch, ["a.txt", "/etc/passwd", "../../../secret", "", "  "])
+
+        expect(patch).toContain("a/a.txt")
+        expect(patch).not.toContain("b.txt")
+        expect(patch).not.toContain("passwd")
+        expect(patch).not.toContain("secret")
+      })
+    })
   })
 
   describe("checkApplyPatch", () => {
@@ -407,6 +428,35 @@ describe("GitOps", () => {
       const result = await git.checkApplyPatch("/tmp", "")
       expect(result.ok).toBe(true)
       expect(result.message).toBe("No changes to apply")
+    })
+
+    it("reports conflicts when patch context does not match", async () => {
+      await withRepo(async (cwd) => {
+        const git = new GitOps({ log: () => undefined })
+        // File content that does NOT match the patch context
+        await fs.writeFile(nodePath.join(cwd, "a.txt"), "completely different content\n", "utf8")
+        runGit(cwd, ["add", "-A"])
+        runGit(cwd, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"])
+
+        // Craft a patch whose context lines don't exist in the file
+        // and has no full-index blob SHAs, so --3way can't recover
+        const patch = [
+          "diff --git a/a.txt b/a.txt",
+          "--- a/a.txt",
+          "+++ b/a.txt",
+          "@@ -1,3 +1,3 @@",
+          " line1",
+          "-line2",
+          "+patched",
+          " line3",
+          "",
+        ].join("\n")
+
+        const result = await git.checkApplyPatch(cwd, patch)
+        expect(result.ok).toBe(false)
+        expect(result.conflicts.length).toBeGreaterThan(0)
+        expect(result.message).toBeTruthy()
+      })
     })
   })
 
@@ -436,6 +486,99 @@ describe("GitOps", () => {
       const result = await git.applyPatch("/tmp", "")
       expect(result.ok).toBe(true)
       expect(result.message).toBe("No changes to apply")
+    })
+
+    it("returns conflicts when applying a conflicting patch", async () => {
+      await withRepo(async (cwd) => {
+        const git = new GitOps({ log: () => undefined })
+        await fs.writeFile(nodePath.join(cwd, "a.txt"), "line1\nline2\nline3\n", "utf8")
+        runGit(cwd, ["add", "-A"])
+        runGit(cwd, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"])
+
+        await fs.writeFile(nodePath.join(cwd, "a.txt"), "line1\npatched\nline3\n", "utf8")
+        const branch = runGit(cwd, ["branch", "--show-current"]) || "HEAD"
+        const patch = await git.buildWorktreePatch(cwd, branch)
+
+        await fs.writeFile(nodePath.join(cwd, "a.txt"), "line1\ndifferent\nline3\n", "utf8")
+        runGit(cwd, ["add", "-A"])
+        runGit(cwd, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "diverge"])
+
+        const result = await git.applyPatch(cwd, patch)
+        expect(result.ok).toBe(false)
+        expect(result.conflicts.length).toBeGreaterThan(0)
+      })
+    })
+  })
+
+  describe("workingTreeStats", () => {
+    it("parses numstat for tracked changes", async () => {
+      const git = ops(async (args) => {
+        if (args[0] === "diff") return "3\t1\tsrc/a.ts\n0\t5\tsrc/b.ts"
+        if (args[0] === "ls-files") return ""
+        return ""
+      })
+      const stats = await git.workingTreeStats("/repo")
+      expect(stats).toEqual({ files: 2, additions: 3, deletions: 6 })
+    })
+
+    it("treats binary numstat entries as zero additions and deletions", async () => {
+      const git = ops(async (args) => {
+        if (args[0] === "diff") return "2\t1\ttext.ts\n-\t-\timage.png"
+        if (args[0] === "ls-files") return ""
+        return ""
+      })
+      const stats = await git.workingTreeStats("/repo")
+      expect(stats).toEqual({ files: 2, additions: 2, deletions: 1 })
+    })
+
+    it("returns zeros for a clean working tree", async () => {
+      const git = ops(async (args) => {
+        if (args[0] === "diff") return ""
+        if (args[0] === "ls-files") return ""
+        return ""
+      })
+      const stats = await git.workingTreeStats("/repo")
+      expect(stats).toEqual({ files: 0, additions: 0, deletions: 0 })
+    })
+
+    it("returns zeros when git commands fail", async () => {
+      const git = ops(async () => {
+        throw new Error("not a git repo")
+      })
+      const stats = await git.workingTreeStats("/repo")
+      expect(stats).toEqual({ files: 0, additions: 0, deletions: 0 })
+    })
+
+    it("counts untracked file lines as additions", async () => {
+      await withRepo(async (cwd) => {
+        const git = new GitOps({ log: () => undefined })
+        await fs.writeFile(nodePath.join(cwd, "init.txt"), "x\n", "utf8")
+        runGit(cwd, ["add", "-A"])
+        runGit(cwd, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"])
+
+        await fs.writeFile(nodePath.join(cwd, "new.txt"), "a\nb\nc", "utf8")
+
+        const stats = await git.workingTreeStats(cwd)
+        expect(stats.files).toBe(1)
+        expect(stats.additions).toBe(3)
+      })
+    })
+
+    it("skips untracked files larger than 1MB", async () => {
+      await withRepo(async (cwd) => {
+        const git = new GitOps({ log: () => undefined })
+        await fs.writeFile(nodePath.join(cwd, "init.txt"), "x\n", "utf8")
+        runGit(cwd, ["add", "-A"])
+        runGit(cwd, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"])
+
+        await fs.writeFile(nodePath.join(cwd, "huge.bin"), Buffer.alloc(1_000_001, 0x41))
+        await fs.writeFile(nodePath.join(cwd, "small.txt"), "hello", "utf8")
+
+        const stats = await git.workingTreeStats(cwd)
+        expect(stats.files).toBe(2)
+        // small.txt: "hello".split("\n").length = 1, huge.bin: skipped (0)
+        expect(stats.additions).toBe(1)
+      })
     })
   })
 })

--- a/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
@@ -813,3 +813,58 @@ describe("WorktreeManager.createWorktree advanced", () => {
     expect(headParams.latest?.hash).toBe(devParams.latest?.hash)
   })
 })
+
+// ---------------------------------------------------------------------------
+// WorktreeManager -- git lock serialization
+// ---------------------------------------------------------------------------
+
+describe("WorktreeManager git lock serialization", () => {
+  it("concurrent worktree creations both succeed", async () => {
+    const root = await createTempRepo()
+    const mgr = createManager(root)
+
+    const [a, b] = await Promise.all([
+      mgr.createWorktree({ prompt: "concurrent-a" }),
+      mgr.createWorktree({ prompt: "concurrent-b" }),
+    ])
+
+    expect(a.branch).not.toBe(b.branch)
+
+    const statA = await fs.stat(path.join(a.path, ".git"))
+    const statB = await fs.stat(path.join(b.path, ".git"))
+    expect(statA.isFile()).toBe(true)
+    expect(statB.isFile()).toBe(true)
+  })
+
+  it("lock releases after error so subsequent operations succeed", async () => {
+    const root = await createTempRepo()
+    const mgr = createManager(root)
+
+    // First operation fails (nonexistent branch)
+    const failing = mgr.createWorktree({ existingBranch: "nonexistent" }).catch((e: unknown) => e)
+    // Second operation queues behind the first and should succeed after lock release
+    const succeeding = mgr.createWorktree({ prompt: "after-error" })
+
+    const [err, result] = await Promise.all([failing, succeeding])
+    expect(err).toBeInstanceOf(Error)
+    expect(result.branch).toBeTruthy()
+
+    const stat = await fs.stat(path.join(result.path, ".git"))
+    expect(stat.isFile()).toBe(true)
+  })
+
+  it("concurrent remove and create on the same repo do not conflict", async () => {
+    const root = await createTempRepo()
+    const mgr = createManager(root)
+
+    // Create a worktree first
+    const wt = await mgr.createWorktree({ prompt: "to-remove" })
+
+    // Concurrently remove and create
+    const [, created] = await Promise.all([mgr.removeWorktree(wt.path), mgr.createWorktree({ prompt: "new-one" })])
+
+    expect(created.branch).toBeTruthy()
+    const stat = await fs.stat(path.join(created.path, ".git"))
+    expect(stat.isFile()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds 12 new tests covering the highest-risk untested code paths in the agent-manager
- Covers `GitOps.workingTreeStats` (degraded-mode fallback), `parseApplyConflicts` (conflict detection), `buildWorktreePatch` pathspec security filtering, and `WorktreeManager.withGitLock` (concurrency serialization)

## Details

### GitOps.workingTreeStats (6 tests)
The only stats path when the CLI backend is unavailable — previously had zero tests:
- Normal `numstat` parsing (file count, additions, deletions)
- Binary file (`-\t-`) handling (no NaN inflation)
- Clean working tree returns zeros
- Git command failures degrade gracefully to zeros
- Untracked file line counting (real repo)
- 1MB size cap skips large untracked files

### GitOps conflict handling (2 tests)
`parseApplyConflicts` was never exercised through `checkApplyPatch`/`applyPatch`:
- `checkApplyPatch` with context mismatch → `ok: false` with parsed conflicts
- `applyPatch` with diverged changes → `ok: false` with conflicts array

### buildWorktreePatch pathspec filtering (1 test)
Security boundary for `selectedFiles` was untested:
- Rejects absolute paths (`/etc/passwd`), `..` traversal, and empty strings

### WorktreeManager.withGitLock (3 tests)
Concurrency primitive for all git-writing operations had zero tests:
- Two concurrent `createWorktree` calls both succeed (would get `index.lock` without lock)
- Lock releases after error so subsequent operations proceed
- Concurrent remove + create serialized correctly