### PR TITLE
feat(vscode): show todo permissions inline, add todo progress to TaskHeader

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/task-header-with-todos-all-done-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/task-header-with-todos-all-done-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc5f6d5b31970c33aaf062756bbdd73637db17f1bc74c1558e9a81c33c5d602d
+size 4582

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/task-header-with-todos-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/task-header-with-todos-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd828877cfcbb7d3f3af475c2ca5f92b2fd627ae41f1a03725ab91a948b40833
+size 4704

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/todo-write-completed-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/todo-write-completed-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e2858ce7b19d599752259a5791c3158c694169bacb05e46c9dc6ee4a110d3b2
-size 6204
+oid sha256:7e3d24b86091c0041a1e7426209a1d1d826b656f04b9fed1d662e3d5b67aa95f
+size 6185

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/todo-write-completed-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/todo-write-completed-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e2858ce7b19d599752259a5791c3158c694169bacb05e46c9dc6ee4a110d3b2
+size 6204

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/todo-write-with-permission-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/todo-write-with-permission-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2cca23b76889bf981f00881ac9dedbb6aeb700fd2165b860bccf7ba919d59c5d
-size 14856
+oid sha256:9777ee1cb00c3632e71c64d2518f86aab1e4199d52e95b36c0d6344ac042994a
+size 14844

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/todo-write-with-permission-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/todo-write-with-permission-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cca23b76889bf981f00881ac9dedbb6aeb700fd2165b860bccf7ba919d59c5d
+size 14856

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -17,7 +17,7 @@ import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import { QuestionDock } from "./QuestionDock"
 
-const HIDDEN_TOOLS = new Set(["todowrite", "todoread"])
+export const HIDDEN_TOOLS = new Set(["todowrite", "todoread"])
 
 function isRenderable(part: SDKPart): boolean {
   if (part.type === "tool") {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -25,9 +25,6 @@ import { QuestionDock } from "./QuestionDock"
 // these tool permissions (since they're shown inline in the message stream).
 export const UPSTREAM_SUPPRESSED_TOOLS = new Set(["todowrite", "todoread"])
 
-// Keep the old export name for ChatView compatibility
-export const HIDDEN_TOOLS = UPSTREAM_SUPPRESSED_TOOLS
-
 function isRenderable(part: SDKPart, pendingPermissionCallIDs: Set<string>): boolean {
   if (part.type === "tool") {
     const tool = (part as SDKPart & { tool: string }).tool

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -18,13 +18,21 @@ import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import { QuestionDock } from "./QuestionDock"
 
-export const HIDDEN_TOOLS = new Set(["todowrite", "todoread"])
+// Tools that the upstream message-part renderer suppresses (returns null for).
+// We render these ourselves via ToolRegistry when they have a pending permission
+// or when they complete, so the user can see what the AI set up.
+// We also use this set in ChatView to know NOT to block the prompt input for
+// these tool permissions (since they're shown inline in the message stream).
+export const UPSTREAM_SUPPRESSED_TOOLS = new Set(["todowrite", "todoread"])
+
+// Keep the old export name for ChatView compatibility
+export const HIDDEN_TOOLS = UPSTREAM_SUPPRESSED_TOOLS
 
 function isRenderable(part: SDKPart, pendingPermissionCallIDs: Set<string>): boolean {
   if (part.type === "tool") {
     const tool = (part as SDKPart & { tool: string }).tool
     const state = (part as SDKPart & { state: { status: string } }).state
-    if (HIDDEN_TOOLS.has(tool)) {
+    if (UPSTREAM_SUPPRESSED_TOOLS.has(tool)) {
       const callID = (part as SDKPart & { callID: string }).callID
       // Show todo parts when waiting for permission (inline) or when completed (to show what happened)
       return pendingPermissionCallIDs.has(callID) || state.status === "completed"
@@ -41,6 +49,27 @@ interface AssistantMessageProps {
   message: SDKAssistantMessage
   showAssistantCopyPartID?: string | null
   turnDurationMs?: number
+}
+
+function TodoToolCard(props: { part: ToolPart }) {
+  const render = ToolRegistry.render(props.part.tool)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const state = props.part.state as any
+  return (
+    <Show when={render}>
+      {(renderFn) => (
+        <Dynamic
+          component={renderFn()}
+          input={state?.input ?? {}}
+          metadata={state?.metadata ?? {}}
+          tool={props.part.tool}
+          output={state?.output}
+          status={state?.status}
+          defaultOpen
+        />
+      )}
+    </Show>
+  )
 }
 
 export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
@@ -89,12 +118,14 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
       <For each={parts()}>
         {(part) => {
           const perm = () => permissionForPart(part)
-          const isTodoTool = part.type === "tool" && HIDDEN_TOOLS.has((part as SDKPart & { tool: string }).tool)
+          // Upstream PART_MAPPING["tool"] returns null for todowrite/todoread,
+          // so we detect them here and render via ToolRegistry directly.
+          const isUpstreamSuppressed = part.type === "tool" && UPSTREAM_SUPPRESSED_TOOLS.has((part as SDKPart & { tool: string }).tool)
           return (
-            <Show when={isTodoTool || PART_MAPPING[part.type]}>
+            <Show when={isUpstreamSuppressed || PART_MAPPING[part.type]}>
               <div data-component="tool-part-wrapper" data-permission={!!perm()} data-part-type={part.type}>
                 <Show
-                  when={isTodoTool}
+                  when={isUpstreamSuppressed}
                   fallback={
                     <Part
                       part={part}
@@ -104,31 +135,11 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                     />
                   }
                 >
-                  {() => {
-                    const toolPart = part as unknown as ToolPart
-                    const render = ToolRegistry.render(toolPart.tool)
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    const state = toolPart.state as any
-                    return (
-                      <Show when={render}>
-                        {(renderFn) => (
-                          <Dynamic
-                            component={renderFn()}
-                            input={state?.input ?? {}}
-                            metadata={state?.metadata ?? {}}
-                            tool={toolPart.tool}
-                            output={state?.output}
-                            status={state?.status}
-                            defaultOpen
-                          />
-                        )}
-                      </Show>
-                    )
-                  }}
+                  <TodoToolCard part={part as unknown as ToolPart} />
                 </Show>
                 <Show when={perm()} keyed>
                   {(p) => {
-                    const isTodoPerm = HIDDEN_TOOLS.has(p.toolName)
+                    const isTodoPerm = UPSTREAM_SUPPRESSED_TOOLS.has(p.toolName)
                     // For todo tools: show the friendly operation description instead of raw patterns like '*'
                     // For other tools: show patterns only if they're meaningful (not just '*')
                     const meaningfulPatterns = p.patterns.filter((pat) => pat !== "*")

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -127,14 +127,26 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                   }}
                 </Show>
                 <Show when={perm()} keyed>
-                  {(p) => (
+                  {(p) => {
+                    const isTodoPerm = HIDDEN_TOOLS.has(p.toolName)
+                    // For todo tools: show the friendly operation description instead of raw patterns like '*'
+                    // For other tools: show patterns only if they're meaningful (not just '*')
+                    const meaningfulPatterns = p.patterns.filter((pat) => pat !== "*")
+                    return (
                     <div data-component="permission-prompt" onClick={(e: MouseEvent) => e.stopPropagation()}>
-                      <Show when={p.patterns.length > 0}>
+                      <Show when={!isTodoPerm && meaningfulPatterns.length > 0}>
                         <div class="permission-dock-patterns">
-                          <For each={p.patterns}>
+                          <For each={meaningfulPatterns}>
                             {(pattern) => <code class="permission-dock-pattern">{pattern}</code>}
                           </For>
                         </div>
+                      </Show>
+                      <Show when={isTodoPerm}>
+                        <p data-slot="permission-description">
+                          {p.toolName === "todowrite"
+                            ? language.t("settings.permissions.tool.todowrite.description")
+                            : language.t("settings.permissions.tool.todoread.description")}
+                        </p>
                       </Show>
                       <div data-slot="permission-actions">
                         <Button
@@ -164,7 +176,8 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                       </div>
                       <p data-slot="permission-hint">{language.t("ui.permission.sessionHint")}</p>
                     </div>
-                  )}
+                    )
+                  }}
                 </Show>
               </div>
             </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -9,9 +9,10 @@
  */
 
 import { Component, For, Show, createMemo, createSignal } from "solid-js"
-import { Part, PART_MAPPING } from "@kilocode/kilo-ui/message-part"
+import { Dynamic } from "solid-js/web"
+import { Part, PART_MAPPING, ToolRegistry } from "@kilocode/kilo-ui/message-part"
 import { Button } from "@kilocode/kilo-ui/button"
-import type { AssistantMessage as SDKAssistantMessage, Part as SDKPart, Message as SDKMessage } from "@kilocode/sdk/v2"
+import type { AssistantMessage as SDKAssistantMessage, Part as SDKPart, Message as SDKMessage, ToolPart } from "@kilocode/sdk/v2"
 import { useData } from "@kilocode/kilo-ui/context/data"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
@@ -19,11 +20,15 @@ import { QuestionDock } from "./QuestionDock"
 
 export const HIDDEN_TOOLS = new Set(["todowrite", "todoread"])
 
-function isRenderable(part: SDKPart): boolean {
+function isRenderable(part: SDKPart, pendingPermissionCallIDs: Set<string>): boolean {
   if (part.type === "tool") {
     const tool = (part as SDKPart & { tool: string }).tool
-    if (HIDDEN_TOOLS.has(tool)) return false
     const state = (part as SDKPart & { state: { status: string } }).state
+    if (HIDDEN_TOOLS.has(tool)) {
+      const callID = (part as SDKPart & { callID: string }).callID
+      // Show todo parts when waiting for permission (inline) or when completed (to show what happened)
+      return pendingPermissionCallIDs.has(callID) || state.status === "completed"
+    }
     if (tool === "question" && (state.status === "pending" || state.status === "running")) return false
     return true
   }
@@ -43,15 +48,23 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
   const session = useSession()
   const language = useLanguage()
 
-  const parts = createMemo(() => {
-    const stored = data.store.part?.[props.message.id]
-    if (!stored) return []
-    return (stored as SDKPart[]).filter(isRenderable)
-  })
-
   const id = () => session.currentSessionID()
   const permissions = () => session.permissions().filter((p) => p.sessionID === id() && p.tool)
   const questions = () => session.questions().filter((q) => q.sessionID === id() && q.tool)
+
+  const pendingPermissionCallIDs = createMemo(() => {
+    const ids = new Set<string>()
+    for (const p of permissions()) {
+      if (p.tool?.messageID === props.message.id) ids.add(p.tool.callID)
+    }
+    return ids
+  })
+
+  const parts = createMemo(() => {
+    const stored = data.store.part?.[props.message.id]
+    if (!stored) return []
+    return (stored as SDKPart[]).filter((part) => isRenderable(part, pendingPermissionCallIDs()))
+  })
 
   const permissionForPart = (part: SDKPart) => {
     if (part.type !== "tool") return undefined
@@ -76,15 +89,43 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
       <For each={parts()}>
         {(part) => {
           const perm = () => permissionForPart(part)
+          const isTodoTool = part.type === "tool" && HIDDEN_TOOLS.has((part as SDKPart & { tool: string }).tool)
           return (
-            <Show when={PART_MAPPING[part.type]}>
+            <Show when={isTodoTool || PART_MAPPING[part.type]}>
               <div data-component="tool-part-wrapper" data-permission={!!perm()} data-part-type={part.type}>
-                <Part
-                  part={part}
-                  message={props.message as SDKMessage}
-                  showAssistantCopyPartID={props.showAssistantCopyPartID}
-                  turnDurationMs={props.turnDurationMs}
-                />
+                <Show
+                  when={isTodoTool}
+                  fallback={
+                    <Part
+                      part={part}
+                      message={props.message as SDKMessage}
+                      showAssistantCopyPartID={props.showAssistantCopyPartID}
+                      turnDurationMs={props.turnDurationMs}
+                    />
+                  }
+                >
+                  {() => {
+                    const toolPart = part as unknown as ToolPart
+                    const render = ToolRegistry.render(toolPart.tool)
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    const state = toolPart.state as any
+                    return (
+                      <Show when={render}>
+                        {(renderFn) => (
+                          <Dynamic
+                            component={renderFn()}
+                            input={state?.input ?? {}}
+                            metadata={state?.metadata ?? {}}
+                            tool={toolPart.tool}
+                            output={state?.output}
+                            status={state?.status}
+                            defaultOpen
+                          />
+                        )}
+                      </Show>
+                    )
+                  }}
+                </Show>
                 <Show when={perm()} keyed>
                   {(p) => (
                     <div data-component="permission-prompt" onClick={(e: MouseEvent) => e.stopPropagation()}>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -13,6 +13,7 @@ import { QuestionDock } from "./QuestionDock"
 import { HIDDEN_TOOLS } from "./AssistantMessage"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
+import type { PermissionRequest } from "../../types/messages"
 
 interface ChatViewProps {
   onSelectSession?: (id: string) => void
@@ -30,8 +31,11 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   const sessionPermissions = () => session.permissions().filter((p) => p.sessionID === id())
 
   const questionRequest = () => sessionQuestions().find((q) => !q.tool)
-  const permissionRequest = () => sessionPermissions().find((p) => !p.tool || HIDDEN_TOOLS.has(p.toolName))
-  const blocked = () => sessionPermissions().length > 0 || sessionQuestions().length > 0
+  const permissionRequest = () => sessionPermissions().find((p) => !p.tool)
+  // Only block the prompt when there's a non-todo permission (todo permissions are shown inline)
+  const isInlinePermission = (p: PermissionRequest) => p.tool && HIDDEN_TOOLS.has(p.toolName)
+  const blocked = () =>
+    sessionPermissions().some((p) => !isInlinePermission(p)) || sessionQuestions().length > 0
 
   // When a bottom-dock permission/question disappears while the session is busy,
   // the scroll container grows taller. Dispatch a custom event so MessageList can

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -10,7 +10,7 @@ import { TaskHeader } from "./TaskHeader"
 import { MessageList } from "./MessageList"
 import { PromptInput } from "./PromptInput"
 import { QuestionDock } from "./QuestionDock"
-import { HIDDEN_TOOLS } from "./AssistantMessage"
+import { UPSTREAM_SUPPRESSED_TOOLS } from "./AssistantMessage"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import type { PermissionRequest } from "../../types/messages"
@@ -33,7 +33,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   const questionRequest = () => sessionQuestions().find((q) => !q.tool)
   const permissionRequest = () => sessionPermissions().find((p) => !p.tool)
   // Only block the prompt when there's a non-todo permission (todo permissions are shown inline)
-  const isInlinePermission = (p: PermissionRequest) => p.tool && HIDDEN_TOOLS.has(p.toolName)
+  const isInlinePermission = (p: PermissionRequest) => p.tool && UPSTREAM_SUPPRESSED_TOOLS.has(p.toolName)
   const blocked = () =>
     sessionPermissions().some((p) => !isInlinePermission(p)) || sessionQuestions().length > 0
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -10,6 +10,7 @@ import { TaskHeader } from "./TaskHeader"
 import { MessageList } from "./MessageList"
 import { PromptInput } from "./PromptInput"
 import { QuestionDock } from "./QuestionDock"
+import { HIDDEN_TOOLS } from "./AssistantMessage"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 
@@ -29,7 +30,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   const sessionPermissions = () => session.permissions().filter((p) => p.sessionID === id())
 
   const questionRequest = () => sessionQuestions().find((q) => !q.tool)
-  const permissionRequest = () => sessionPermissions().find((p) => !p.tool)
+  const permissionRequest = () => sessionPermissions().find((p) => !p.tool || HIDDEN_TOOLS.has(p.toolName))
   const blocked = () => sessionPermissions().length > 0 || sessionQuestions().length > 0
 
   // When a bottom-dock permission/question disappears while the session is busy,

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -2,13 +2,17 @@
  * TaskHeader component
  * Sticky header above the chat messages showing session title,
  * cost, context usage, and a compact button.
+ * Also shows todo progress when the session has todos.
  */
 
-import { Component, Show, createMemo } from "solid-js"
+import { Component, For, Show, createMemo, createSignal } from "solid-js"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
+import { Icon } from "@kilocode/kilo-ui/icon"
+import { Checkbox } from "@kilocode/kilo-ui/checkbox"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
+import type { TodoItem } from "../../types/messages"
 
 export const TaskHeader: Component = () => {
   const session = useSession()
@@ -35,6 +39,22 @@ export const TaskHeader: Component = () => {
     const pct = usage.percentage !== null ? `${usage.percentage}%` : undefined
     return { tokens, pct }
   })
+
+  const todos = createMemo(() => session.todos())
+  const hasTodos = createMemo(() => todos().length > 0)
+  const doneCount = createMemo(() => todos().filter((t: TodoItem) => t.status === "completed").length)
+  const totalCount = createMemo(() => todos().length)
+  const allDone = createMemo(() => doneCount() === totalCount() && totalCount() > 0)
+
+  const todoSummary = createMemo(() => {
+    const done = doneCount()
+    const total = totalCount()
+    if (total === 0) return ""
+    if (done === total) return language.t("task.todos.allDone", { count: String(total) })
+    return language.t("task.todos.progress", { done: String(done), total: String(total) })
+  })
+
+  const [todosOpen, setTodosOpen] = createSignal(false)
 
   return (
     <Show when={hasMessages()}>
@@ -72,6 +92,42 @@ export const TaskHeader: Component = () => {
           </Tooltip>
         </div>
       </div>
+      <Show when={hasTodos()}>
+        <div data-component="task-header-todos">
+          <button
+            data-slot="task-header-todos-trigger"
+            onClick={() => setTodosOpen((v) => !v)}
+            aria-expanded={todosOpen()}
+          >
+            <Icon name="checklist" size="small" />
+            <span data-slot="task-header-todos-summary" data-all-done={allDone() ? "" : undefined}>
+              {todoSummary()}
+            </span>
+            <Icon
+              name="chevron-down"
+              size="small"
+              data-slot="task-header-todos-arrow"
+              data-open={todosOpen() ? "" : undefined}
+            />
+          </button>
+          <Show when={todosOpen()}>
+            <div data-slot="task-header-todos-list">
+              <For each={todos()}>
+                {(todo: TodoItem) => (
+                  <Checkbox readOnly checked={todo.status === "completed"}>
+                    <span
+                      data-slot="task-header-todo-content"
+                      data-completed={todo.status === "completed" ? "" : undefined}
+                    >
+                      {todo.content}
+                    </span>
+                  </Checkbox>
+                )}
+              </For>
+            </div>
+          </Show>
+        </div>
+      </Show>
     </Show>
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1042,4 +1042,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "التفاصيل",
+
+  "task.todos.progress": "{{done}}/{{total}} مهام مكتملة",
+  "task.todos.allDone": "{{count}} مهام مكتملة",
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1056,4 +1056,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "Detalhes",
+
+  "task.todos.progress": "{{done}}/{{total}} tarefas concluídas",
+  "task.todos.allDone": "{{count}} tarefas concluídas",
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1055,4 +1055,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "Detalji",
+
+  "task.todos.progress": "{{done}}/{{total}} zadataka završeno",
+  "task.todos.allDone": "{{count}} zadataka završeno",
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1052,4 +1052,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "Detaljer",
+
+  "task.todos.progress": "{{done}}/{{total}} opgaver udført",
+  "task.todos.allDone": "{{count}} opgaver udført",
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1070,4 +1070,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "Details",
+
+  "task.todos.progress": "{{done}}/{{total}} Aufgaben erledigt",
+  "task.todos.allDone": "{{count}} Aufgaben erledigt",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1073,4 +1073,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "Details",
+
+  "task.todos.progress": "{{done}}/{{total}} to-dos done",
+  "task.todos.allDone": "{{count}} to-dos done",
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1059,4 +1059,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "Detalles",
+
+  "task.todos.progress": "{{done}}/{{total}} tareas completadas",
+  "task.todos.allDone": "{{count}} tareas completadas",
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1068,4 +1068,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "Détails",
+
+  "task.todos.progress": "{{done}}/{{total}} tâches terminées",
+  "task.todos.allDone": "{{count}} tâches terminées",
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1050,4 +1050,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "詳細",
+
+  "task.todos.progress": "{{done}}/{{total}} タスク完了",
+  "task.todos.allDone": "{{count}} タスク完了",
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1047,4 +1047,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "상세 정보",
+
+  "task.todos.progress": "{{done}}/{{total}} 할 일 완료",
+  "task.todos.allDone": "{{count}} 할 일 완료",
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1050,4 +1050,7 @@ export const dict = {
     "Dette fjerner de gamle innstillingene fra VS Code-lagringen. Du vil ikke kunne kjøre denne migreringen på nytt.",
   "migration.complete.done": "Ferdig",
   // legacy-migration end
+
+  "task.todos.progress": "{{done}}/{{total}} oppgaver fullført",
+  "task.todos.allDone": "{{count}} oppgaver fullført",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1053,4 +1053,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "Szczegóły",
+
+  "task.todos.progress": "{{done}}/{{total}} zadań ukończono",
+  "task.todos.allDone": "{{count}} zadań ukończono",
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1055,4 +1055,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "Подробности",
+
+  "task.todos.progress": "{{done}}/{{total}} задач выполнено",
+  "task.todos.allDone": "{{count}} задач выполнено",
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1043,4 +1043,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "รายละเอียด",
+
+  "task.todos.progress": "{{done}}/{{total}} งานเสร็จแล้ว",
+  "task.todos.allDone": "{{count}} งานเสร็จแล้ว",
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1035,4 +1035,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "详细信息",
+
+  "task.todos.progress": "{{done}}/{{total}} 个待办已完成",
+  "task.todos.allDone": "{{count}} 个待办已完成",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1036,4 +1036,7 @@ export const dict = {
   // legacy-migration end
 
   "error.details.show": "詳細資訊",
+
+  "task.todos.progress": "{{done}}/{{total}} 個待辦已完成",
+  "task.todos.allDone": "{{count}} 個待辦已完成",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource solid-js */
 /**
  * Stories for high-priority chat components:
- * ChatView, MessageList, QuestionDock
+ * ChatView, MessageList, QuestionDock, TaskHeader
  *
  * These render with mocked session/server/provider contexts — the components
  * will show their "idle / empty" states since no real extension host is connected.
@@ -10,9 +10,10 @@
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
 import { StoryProviders, mockSessionValue } from "./StoryProviders"
 import { ChatView } from "../components/chat/ChatView"
+import { TaskHeader } from "../components/chat/TaskHeader"
 import { QuestionDock } from "../components/chat/QuestionDock"
 import { SessionContext } from "../context/session"
-import type { QuestionRequest } from "../types/messages"
+import type { QuestionRequest, TodoItem } from "../types/messages"
 
 const SESSION_ID = "story-session-chat-001"
 
@@ -136,4 +137,71 @@ export const QuestionDockMulti: Story = {
       </div>
     </StoryProviders>
   ),
+}
+
+// ---------------------------------------------------------------------------
+// TaskHeader with todos
+// ---------------------------------------------------------------------------
+
+const mockTodosInProgress: TodoItem[] = [
+  { id: "1", content: "Create a haiku about Jan", status: "completed" },
+  { id: "2", content: "Create a poem about Henk", status: "in_progress" },
+  { id: "3", content: "Write a limerick about the team", status: "pending" },
+]
+
+const mockTodosAllDone: TodoItem[] = [
+  { id: "1", content: "Create a haiku about Jan", status: "completed" },
+  { id: "2", content: "Create a poem about Henk", status: "completed" },
+]
+
+export const TaskHeaderWithTodos: Story = {
+  name: "TaskHeader — with todos (in progress)",
+  render: () => {
+    const session = {
+      ...mockSessionValue({ id: SESSION_ID, status: "busy" }),
+      messages: () => [{ id: "msg-001" }] as any[],
+      currentSession: () => ({
+        id: SESSION_ID,
+        title: "Writing poems about the team",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }),
+      todos: () => mockTodosInProgress,
+    }
+    return (
+      <StoryProviders sessionID={SESSION_ID} status="busy" noPadding>
+        <SessionContext.Provider value={session as any}>
+          <div style={{ width: "380px" }}>
+            <TaskHeader />
+          </div>
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
+}
+
+export const TaskHeaderWithTodosAllDone: Story = {
+  name: "TaskHeader — with todos (all done)",
+  render: () => {
+    const session = {
+      ...mockSessionValue({ id: SESSION_ID, status: "idle" }),
+      messages: () => [{ id: "msg-001" }] as any[],
+      currentSession: () => ({
+        id: SESSION_ID,
+        title: "Writing poems about the team",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }),
+      todos: () => mockTodosAllDone,
+    }
+    return (
+      <StoryProviders sessionID={SESSION_ID} status="idle" noPadding>
+        <SessionContext.Provider value={session as any}>
+          <div style={{ width: "380px" }}>
+            <TaskHeader />
+          </div>
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
 }

--- a/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
@@ -249,6 +249,64 @@ const questionDismissedPart: ToolPart = {
 }
 
 // ---------------------------------------------------------------------------
+// Todo tool parts
+// ---------------------------------------------------------------------------
+
+const todoWritePending: ToolPart = {
+  id: "part-todo-001",
+  sessionID: SESSION_ID,
+  messageID: ASST_MSG_ID,
+  type: "tool",
+  callID: "call-todo-001",
+  tool: "todowrite",
+  state: {
+    status: "pending",
+    input: {
+      todos: [
+        { id: "1", content: "Create a haiku about Jan", status: "pending" },
+        { id: "2", content: "Create a poem about Henk", status: "pending" },
+      ],
+    },
+  } as any,
+}
+
+const todoWriteCompleted: ToolPart = {
+  id: "part-todo-002",
+  sessionID: SESSION_ID,
+  messageID: ASST_MSG_ID,
+  type: "tool",
+  callID: "call-todo-002",
+  tool: "todowrite",
+  state: {
+    status: "completed",
+    input: {
+      todos: [
+        { id: "1", content: "Create a haiku about Jan", status: "completed" },
+        { id: "2", content: "Create a poem about Henk", status: "in_progress" },
+      ],
+    },
+    output: "Updated 2 todos",
+    title: "Updated to-dos",
+    metadata: {
+      todos: [
+        { id: "1", content: "Create a haiku about Jan", status: "completed" },
+        { id: "2", content: "Create a poem about Henk", status: "in_progress" },
+      ],
+    },
+    time: { start: now - 3000, end: now - 2800 },
+  },
+}
+
+const todoWritePermission: PermissionRequest = {
+  id: "perm-todo-001",
+  sessionID: SESSION_ID,
+  toolName: "todowrite",
+  patterns: ["*"],
+  args: {},
+  tool: { messageID: ASST_MSG_ID, callID: "call-todo-001" },
+}
+
+// ---------------------------------------------------------------------------
 // Data helpers
 // ---------------------------------------------------------------------------
 
@@ -483,6 +541,39 @@ export const QuestionDismissed: Story = {
   name: "Question Dismissed",
   render: () => {
     const data = dataWith([textPart, questionDismissedPart])
+    return (
+      <StoryProviders data={data} sessionID={SESSION_ID}>
+        <AssistantMessage message={baseAssistantMessage} />
+      </StoryProviders>
+    )
+  },
+}
+
+// ---------------------------------------------------------------------------
+// 10. TodoWrite with inline permission (pending — shows todo list + permission prompt)
+// ---------------------------------------------------------------------------
+
+export const TodoWriteWithPermission: Story = {
+  name: "TodoWrite + Inline Permission",
+  render: () => {
+    const perms = [todoWritePermission]
+    const data = dataWith([todoWritePending], perms)
+    return (
+      <StoryProviders data={data} permissions={perms} sessionID={SESSION_ID}>
+        <AssistantMessage message={baseAssistantMessage} />
+      </StoryProviders>
+    )
+  },
+}
+
+// ---------------------------------------------------------------------------
+// 11. TodoWrite completed (inline in chat after permission granted)
+// ---------------------------------------------------------------------------
+
+export const TodoWriteCompleted: Story = {
+  name: "TodoWrite — Completed Inline",
+  render: () => {
+    const data = dataWith([todoWriteCompleted])
     return (
       <StoryProviders data={data} sessionID={SESSION_ID}>
         <AssistantMessage message={baseAssistantMessage} />

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -4,6 +4,66 @@
  */
 
 /* ============================================
+   Task Header Todos
+   ============================================ */
+
+[data-component="task-header-todos"] {
+  border-bottom: 1px solid var(--border-weak-base);
+  background-color: var(--background-base);
+  flex-shrink: 0;
+
+  [data-slot="task-header-todos-trigger"] {
+    all: unset;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 6px 16px;
+    cursor: pointer;
+    font-size: 12px;
+    color: var(--text-weak);
+    box-sizing: border-box;
+
+    &:hover {
+      color: var(--text-base);
+    }
+  }
+
+  [data-slot="task-header-todos-summary"] {
+    flex: 1;
+
+    &[data-all-done] {
+      color: var(--text-success, var(--vscode-testing-iconPassed, #5cb85c));
+    }
+  }
+
+  [data-slot="task-header-todos-arrow"] {
+    transition: transform 0.15s ease;
+
+    &[data-open] {
+      transform: rotate(180deg);
+    }
+  }
+
+  [data-slot="task-header-todos-list"] {
+    padding: 4px 16px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  [data-slot="task-header-todo-content"] {
+    font-size: 12px;
+    color: var(--text-base);
+
+    &[data-completed] {
+      text-decoration: line-through;
+      color: var(--text-weak);
+    }
+  }
+}
+
+/* ============================================
    Chat View Layout
    ============================================ */
 

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1227,7 +1227,7 @@
    The trigger has 8px left padding, 16px icon, 8px gap = 32px total offset.
    ============================================ */
 
-.vscode-session-turn-assistant [data-component="todos"] {
+[data-component="todos"] {
   padding-left: 32px;
 }
 

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1223,6 +1223,15 @@
 }
 
 /* ============================================
+   Todo tool — align checkboxes with icon in header
+   The trigger has 8px left padding, 16px icon, 8px gap = 32px total offset.
+   ============================================ */
+
+.vscode-session-turn-assistant [data-component="todos"] {
+  padding-left: 32px;
+}
+
+/* ============================================
    Task Tool (sub-agent, v1.0.25 style)
    tool-output scrollable container size override
    ============================================ */

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -941,6 +941,12 @@
   padding: 8px 12px;
 }
 
+[data-component="permission-prompt"] [data-slot="permission-description"] {
+  font-size: 12px;
+  color: var(--text-weak, var(--vscode-descriptionForeground));
+  margin: 0 0 8px;
+}
+
 [data-component="permission-prompt"] [data-slot="permission-actions"] {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

This PR improves the todo tool experience in the VS Code extension chat:

1. **Todo permissions shown inline** — `todowrite`/`todoread` permission requests now appear inline in the chat (like bash, glob, etc.) with the todo list displayed above the permission buttons. No more invisible permission prompts causing the session to look stuck.

2. **Prompt stays visible** — The `PromptInput` is no longer hidden when a todo permission is pending (since it's shown inline, not in the bottom dock).

3. **Todo result shown after completion** — After granting permission, the completed todo list renders inline in the chat so you can see what the AI set up.

4. **Clear permission description** — Instead of a raw `*` pattern, todo permissions show "Update the todo list" or "Read the todo list".

5. **Todo progress in TaskHeader** — A collapsible section below the session title shows todo progress ("2/3 to-dos done"). Click to expand and see the full todo list with checkboxes. All-done state shows in success color.

## Changes

### `AssistantMessage.tsx`
- `UPSTREAM_SUPPRESSED_TOOLS` (ex-`HIDDEN_TOOLS`) — tools suppressed by the upstream renderer. Todo tools are now shown when:
  - Permission is pending (show inline with permission buttons)
  - Tool completed (show the resulting todo list)
- `TodoToolCard` component renders todo tools via `ToolRegistry` directly, bypassing the upstream `null` return
- Permission description shows tool-friendly text instead of `*` for todo permissions

### `ChatView.tsx`
- Only blocks the prompt for non-todo permissions (todo permissions shown inline)

### `TaskHeader.tsx`
- New collapsible todo progress row using `Icon` + `Checkbox` from kilo-ui
- Shows `N/M to-dos done` summary; click to expand full list

### `chat.css`
- Styles for `task-header-todos` component
- Todo checkboxes aligned with header icon (32px left indent)
- `permission-description` slot gets proper spacing

### `en.ts`
- `task.todos.progress`: "{{done}}/{{total}} to-dos done"
- `task.todos.allDone`: "{{count}} to-dos done"

### `composite.stories.tsx` + `chat.stories.tsx`
- `TodoWriteWithPermission` — pending permission inline
- `TodoWriteCompleted` — completed todo list inline
- `TaskHeaderWithTodos` — header with in-progress todos
- `TaskHeaderWithTodosAllDone` — header with all todos complete

## Note on `UPSTREAM_SUPPRESSED_TOOLS`

`todowrite`/`todoread` are suppressed by the upstream `message-part.tsx` renderer (it returns `null` for them). There is no dedicated todo dock in the VS Code extension — the suppression was just inherited. The set is kept to mark which tool permissions don't block the prompt (they're shown inline).
