### PR TITLE
Close sidebar when opening Agent Manager

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -102,6 +102,7 @@ export class AgentManagerProvider implements vscode.Disposable {
       return
     }
     this.log("Opening Agent Manager panel")
+    vscode.commands.executeCommand("workbench.action.closeSidebar")
     TelemetryProxy.capture(TelemetryEventName.AGENT_MANAGER_OPENED, { source: PLATFORM })
 
     this.panel = vscode.window.createWebviewPanel(


### PR DESCRIPTION
## Summary

- Automatically closes the VS Code sidebar when the Agent Manager panel is opened, since the Agent Manager embeds its own chat UI and having both visible is redundant
- Only triggers on first open (not on `reveal` of an already-open panel)
- Does not re-open the sidebar when the Agent Manager is closed — the user can manually reopen it via the activity bar