### PR TITLE
Remove unnecessary kilocode_change markers from kilocode directories

### DIFF
--- a/packages/opencode/src/kilocode/config-injector.ts
+++ b/packages/opencode/src/kilocode/config-injector.ts
@@ -1,8 +1,8 @@
 import { Config } from "../config/config"
 import { ModesMigrator } from "./modes-migrator"
-import { RulesMigrator } from "./rules-migrator" // kilocode_change
+import { RulesMigrator } from "./rules-migrator"
 import { WorkflowsMigrator } from "./workflows-migrator"
-import { IgnoreMigrator } from "./ignore-migrator" // kilocode_change
+import { IgnoreMigrator } from "./ignore-migrator"
 
 export namespace KilocodeConfigInjector {
   export interface InjectionResult {
@@ -46,7 +46,6 @@ export namespace KilocodeConfigInjector {
       config.command = workflowsMigration.commands
     }
 
-    // kilocode_change start - Rules migration
     if (options.includeRules !== false) {
       const rulesMigration = await RulesMigrator.migrate({
         projectDir: options.projectDir,
@@ -60,9 +59,7 @@ export namespace KilocodeConfigInjector {
         config.instructions = rulesMigration.instructions
       }
     }
-    // kilocode_change end
 
-    // kilocode_change start - Ignore migration
     if (options.includeIgnore !== false) {
       const ignoreMigration = await IgnoreMigrator.migrate({
         projectDir: options.projectDir,
@@ -75,7 +72,6 @@ export namespace KilocodeConfigInjector {
         config.permission = mergePermissions(config.permission, ignoreMigration.permission)
       }
     }
-    // kilocode_change end
 
     return {
       configJson: JSON.stringify(config),

--- a/packages/opencode/src/kilocode/const.ts
+++ b/packages/opencode/src/kilocode/const.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 
 import { Installation } from "@/installation"
 

--- a/packages/opencode/src/kilocode/ignore-migrator.ts
+++ b/packages/opencode/src/kilocode/ignore-migrator.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 
 import * as path from "path"
 import os from "os"

--- a/packages/opencode/src/kilocode/index.ts
+++ b/packages/opencode/src/kilocode/index.ts
@@ -2,6 +2,6 @@ export { ModesMigrator } from "./modes-migrator"
 export { RulesMigrator } from "./rules-migrator"
 export { WorkflowsMigrator } from "./workflows-migrator"
 export { McpMigrator } from "./mcp-migrator"
-export { IgnoreMigrator } from "./ignore-migrator" // kilocode_change
+export { IgnoreMigrator } from "./ignore-migrator"
 export { KilocodeConfigInjector } from "./config-injector"
 export { KilocodePaths } from "./paths"

--- a/packages/opencode/src/kilocode/modes-migrator.ts
+++ b/packages/opencode/src/kilocode/modes-migrator.ts
@@ -23,7 +23,6 @@ export namespace ModesMigrator {
   }
 
   // Default modes to skip - these have native Opencode equivalents
-  // kilocode_change - added "build" for backward compatibility after renaming "build" to "code"
   const DEFAULT_MODE_SLUGS = new Set(["code", "build", "architect", "ask", "debug", "orchestrator"])
 
   // Group to permission mapping

--- a/packages/opencode/src/kilocode/project-id.ts
+++ b/packages/opencode/src/kilocode/project-id.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import { Instance } from "@/project/instance"
 import path from "path"
 import { $ } from "bun"

--- a/packages/opencode/src/kilocode/review/command.ts
+++ b/packages/opencode/src/kilocode/review/command.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import type { Command } from "@/command"
 import { Review } from "./review"
 

--- a/packages/opencode/src/kilocode/review/review.ts
+++ b/packages/opencode/src/kilocode/review/review.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import { $ } from "bun"
 import { Log } from "@/util/log"
 import { Instance } from "@/project/instance"

--- a/packages/opencode/src/kilocode/review/types.ts
+++ b/packages/opencode/src/kilocode/review/types.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import z from "zod"
 
 export const DiffHunk = z.object({

--- a/packages/opencode/src/kilocode/rules-migrator.ts
+++ b/packages/opencode/src/kilocode/rules-migrator.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 
 import * as fs from "fs/promises"
 import * as path from "path"

--- a/packages/opencode/src/kilocode/workflows-migrator.ts
+++ b/packages/opencode/src/kilocode/workflows-migrator.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 
 import * as fs from "fs/promises"
 import * as path from "path"

--- a/packages/opencode/test/kilocode/config-injector.test.ts
+++ b/packages/opencode/test/kilocode/config-injector.test.ts
@@ -109,7 +109,6 @@ describe("KilocodeConfigInjector", () => {
       expect(config.command["deploy"]).toBeDefined()
     })
 
-    // kilocode_change start - Rules migration tests
     test("includes rules in config", async () => {
       await using tmp = await tmpdir({
         init: async (dir) => {
@@ -197,9 +196,7 @@ describe("KilocodeConfigInjector", () => {
 
       expect(result.warnings.some((w) => w.includes("Legacy"))).toBe(true)
     })
-    // kilocode_change end
 
-    // kilocode_change start - Ignore migration tests
     test("includes ignore patterns in config", async () => {
       await using tmp = await tmpdir({
         init: async (dir) => {
@@ -283,7 +280,6 @@ describe("KilocodeConfigInjector", () => {
       expect(config.permission.read["*.env"]).toBe("deny")
       expect(config.permission.read[".env.example"]).toBe("allow")
     })
-    // kilocode_change end
   })
 
   describe("getEnvVars", () => {

--- a/packages/opencode/test/kilocode/kilo-gateway-headers.test.ts
+++ b/packages/opencode/test/kilocode/kilo-gateway-headers.test.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import { describe, it, expect, afterEach } from "bun:test"
 import { buildKiloHeaders, getFeatureHeader, getEditorNameHeader } from "@kilocode/kilo-gateway"
 import { HEADER_FEATURE, ENV_FEATURE } from "@kilocode/kilo-gateway"

--- a/packages/opencode/test/kilocode/model-cache-org.test.ts
+++ b/packages/opencode/test/kilocode/model-cache-org.test.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 // Regression test: OAuth accountId must flow into model fetch as kilocodeOrganizationId
 // When a user logs in via OAuth and selects an enterprise organization, the model fetch
 // should use the organization-specific endpoint, not the personal endpoint.


### PR DESCRIPTION
## Summary

- Removes all `kilocode_change` markers from files in `packages/opencode/src/kilocode/` and `packages/opencode/test/kilocode/`
- Per AGENTS.md, these paths are entirely Kilo Code-specific and do not need markers