### PR TITLE
fix: use configured default model for new ACP sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -6,6 +6,7 @@ import { ACP } from "@/acp/agent"
 import { Server } from "@/server/server"
 import { createKiloClient } from "@kilocode/sdk/v2"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { Provider } from "@/provider/provider"
 
 const log = Log.create({ service: "acp-command" })
 
@@ -55,8 +56,10 @@ export const AcpCommand = cmd({
       const stream = ndJsonStream(input, output)
       const agent = await ACP.init({ sdk })
 
+      const defaultModel = await Provider.defaultModel()
+
       new AgentSideConnection((conn) => {
-        return agent.create(conn, { sdk })
+        return agent.create(conn, { sdk, defaultModel })
       }, stream)
 
       log.info("setup connection")


### PR DESCRIPTION
## Context

The user's default model setting from config was not being passed to new ACP sessions, causing them to default to "Frontier" instead of the user's configured model (e.g., "Opus 4.6").

## Implementation

The fix adds `defaultModel` to the `ACPConfig` passed when creating the ACP agent. Now `Provider.defaultModel()` is called at startup and the result is passed to `agent.create(conn, { sdk, defaultModel })`, ensuring the user's configured default model is used for all new sessions.

## How to Test

1. Set a default model in settings (e.g., "Opus 4.6")
2. Start a new session (either via CLI `kilo serve` or VS Code extension)
3. Verify the session uses the configured default model instead of "Frontier"

Fixes #6762
