### PR TITLE
feat: always show prompt input during permission prompts

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -151,9 +151,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
               </Show>
             </div>
           </Show>
-          <Show when={!blocked()}>
-            <PromptInput />
-          </Show>
+          <PromptInput />
         </div>
       </Show>
     </div>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
@@ -71,8 +71,17 @@ export const WorkingIndicator: Component = () => {
     return `${m}m ${rem}s`
   }
 
+  const blocked = () => {
+    const id = session.currentSessionID()
+    const perms = session
+      .permissions()
+      .filter((p) => p.sessionID === id && !(p.tool && ["todowrite", "todoread"].includes(p.toolName)))
+    const questions = session.questions().filter((q) => q.sessionID === id)
+    return perms.length > 0 || questions.length > 0
+  }
+
   return (
-    <Show when={session.status() !== "idle"}>
+    <Show when={session.status() !== "idle" && !blocked()}>
       <div class="working-indicator">
         <Spinner />
         <span class="working-text">{statusText()}</span>


### PR DESCRIPTION
## Summary

- Remove the `<Show when={!blocked()}>` wrapper around `<PromptInput />` in `ChatView.tsx`
- The prompt input box is now always visible, even when bash/question permission prompts are active
