### PR TITLE
fix: add missing toggleDiff fallback in Agent Manager keyboard shortcuts

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -115,6 +115,7 @@ const defaultBindings: Record<string, string> = {
   previousTab: isMac ? "⌘⌥←" : "Ctrl+Alt+←",
   nextTab: isMac ? "⌘⌥→" : "Ctrl+Alt+→",
   showTerminal: isMac ? "⌘/" : "Ctrl+/",
+  toggleDiff: isMac ? "⌘D" : "Ctrl+D",
   showShortcuts: isMac ? "⌘⇧/" : "Ctrl+Shift+/",
   newTab: isMac ? "⌘T" : "Ctrl+T",
   closeTab: isMac ? "⌘W" : "Ctrl+W",


### PR DESCRIPTION
## Summary

- Adds `toggleDiff` entry to the `defaultBindings` map in the Agent Manager's `AgentManagerApp.tsx`
- Fixes the "Toggle diff panel" row in the keyboard shortcuts dialog showing no shortcut key when the extension's resolved keybindings haven't arrived yet
- Every other shortcut in the Terminal category (`showTerminal`, `focusPanel`) already had a fallback; `toggleDiff` was the only one missing