### PR TITLE
fix: use proper SVG icon for scroll-to-bottom button in VS Code extension

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -8,6 +8,7 @@
  */
 
 import { Component, For, Show, createEffect, createMemo, onCleanup, JSX } from "solid-js"
+import { Icon } from "@kilocode/kilo-ui/icon"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { Button } from "@kilocode/kilo-ui/button"
 import { useDialog } from "@kilocode/kilo-ui/context/dialog"
@@ -144,7 +145,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
           onClick={() => autoScroll.resume()}
           aria-label={language.t("session.messages.scrollToBottom")}
         >
-          ↓
+          <Icon name="arrow-down-to-line" />
         </button>
       </Show>
     </div>


### PR DESCRIPTION
## Summary

- Replace plain Unicode `↓` character with `<Icon name="arrow-down-to-line" />` from `@kilocode/kilo-ui` in the scroll-to-bottom button
- Aligns the VS Code extension with the desktop app's implementation (`packages/app/src/pages/session/message-timeline.tsx:323`)
- The Unicode arrow looked chunky and inconsistent with the rest of the SVG icon system

Before:
<img width="54" height="61" alt="image" src="https://github.com/user-attachments/assets/7263dfea-8f32-42da-852d-a12a19217034" />

After:
<img width="111" height="93" alt="image" src="https://github.com/user-attachments/assets/62903d7e-36d7-44d2-af6d-d7cdb153990f" />
