### PR TITLE
fix: add windowsHide to all spawn calls to prevent CMD window flash on Windows

### DIFF
--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -79,6 +79,7 @@ export class ServerManager {
         },
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
+        windowsHide: true,
       })
       console.log("[Kilo New] ServerManager: 📦 Process spawned with PID:", serverProcess.pid)
 

--- a/packages/opencode/src/cli/cmd/db.ts
+++ b/packages/opencode/src/cli/cmd/db.ts
@@ -47,6 +47,7 @@ const QueryCommand = cmd({
     }
     const child = spawn("sqlite3", [Database.Path], {
       stdio: "inherit",
+      windowsHide: true, // kilocode_change - prevent CMD window flash on Windows
     })
     await new Promise((resolve) => child.on("close", resolve))
   },

--- a/packages/opencode/src/cli/cmd/pr.ts
+++ b/packages/opencode/src/cli/cmd/pr.ts
@@ -97,6 +97,7 @@ export const PrCommand = cmd({
         const opencodeProcess = spawn("opencode", opencodeArgs, {
           stdio: "inherit",
           cwd: process.cwd(),
+          windowsHide: true, // kilocode_change - prevent CMD window flash on Windows
         })
 
         await new Promise<void>((resolve, reject) => {

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -118,6 +118,7 @@ export namespace LSP {
                   ...process.env,
                   ...item.env,
                 },
+                windowsHide: true, // kilocode_change - prevent CMD window flash on Windows
               }),
               initialization: item.initialization,
             }

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "child_process"
+import { spawn as _spawn, type ChildProcessWithoutNullStreams, type SpawnOptions } from "child_process"
 import path from "path"
 import os from "os"
 import { Global } from "../global"
@@ -12,6 +12,16 @@ import { Instance } from "../project/instance"
 import { Flag } from "../flag/flag"
 import { Archive } from "../util/archive"
 import { Process } from "../util/process"
+
+// kilocode_change start - prevent CMD window flash on Windows for all LSP server spawns
+function spawn(cmd: string, opts?: SpawnOptions): ChildProcessWithoutNullStreams
+function spawn(cmd: string, args: readonly string[], opts?: SpawnOptions): ChildProcessWithoutNullStreams
+function spawn(cmd: string, ...rest: any[]): ChildProcessWithoutNullStreams {
+  const opts = typeof rest[rest.length - 1] === "object" && !Array.isArray(rest[rest.length - 1]) ? rest.pop() : {}
+  const args = rest[0] as readonly string[] | undefined
+  return args ? _spawn(cmd, args, { ...opts, windowsHide: true }) : _spawn(cmd, { ...opts, windowsHide: true })
+}
+// kilocode_change end
 
 export namespace LSPServer {
   const log = Log.create({ service: "lsp.server" })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1694,6 +1694,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         ...shellEnv.env,
         TERM: "dumb",
       },
+      windowsHide: true, // kilocode_change - prevent CMD window flash on Windows
     })
 
     let output = ""

--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -13,7 +13,7 @@ export namespace Shell {
 
     if (process.platform === "win32") {
       await new Promise<void>((resolve) => {
-        const killer = spawn("taskkill", ["/pid", String(pid), "/f", "/t"], { stdio: "ignore" })
+        const killer = spawn("taskkill", ["/pid", String(pid), "/f", "/t"], { stdio: "ignore", windowsHide: true })
         killer.once("exit", () => resolve())
         killer.once("error", () => resolve())
       })

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -178,6 +178,7 @@ export const BashTool = Tool.define("bash", async () => {
         },
         stdio: ["ignore", "pipe", "pipe"],
         detached: process.platform !== "win32",
+        windowsHide: true, // kilocode_change - prevent CMD window flash on Windows
       })
 
       let output = ""

--- a/packages/opencode/src/util/process.ts
+++ b/packages/opencode/src/util/process.ts
@@ -56,6 +56,7 @@ export namespace Process {
       cwd: opts.cwd,
       env: opts.env === null ? {} : opts.env ? { ...process.env, ...opts.env } : undefined,
       stdio: [opts.stdin ?? "ignore", opts.stdout ?? "ignore", opts.stderr ?? "ignore"],
+      windowsHide: true, // kilocode_change - prevent CMD window flash on Windows
     })
 
     let closed = false


### PR DESCRIPTION
## Summary

- Add `windowsHide: true` to every `child_process.spawn()` call site across the CLI and VS Code extension to prevent a visible CMD console window from flashing open on each subprocess invocation on Windows
- Covers bash tool, shell prompt, LSP servers (~40 spawns via a local wrapper), grep/clipboard/installs (via `Process.spawn` utility), `taskkill` tree kill, and the VS Code extension's server manager
- The option is a no-op on non-Windows platforms, so no behavioral change elsewhere

## Root Cause

On Windows, Node.js `child_process.spawn()` allocates a new console for each child process by default. Without `windowsHide: true` (which maps to the Win32 `CREATE_NO_WINDOW` flag), every tool invocation, LSP server startup, ripgrep search, and clipboard operation caused a CMD window to briefly flash on screen.

## Changes

| File | What |
|------|------|
| `packages/opencode/src/util/process.ts` | `Process.spawn()` — covers grep, clipboard, pager, LSP installs |
| `packages/opencode/src/tool/bash.ts` | Bash tool shell command execution |
| `packages/opencode/src/session/prompt.ts` | `/shell` prompt command execution |
| `packages/opencode/src/lsp/server.ts` | Wrapper over `spawn` import — covers all ~40 LSP server spawn calls |
| `packages/opencode/src/lsp/index.ts` | Custom user-configured LSP servers |
| `packages/opencode/src/shell/shell.ts` | `taskkill` process tree cleanup |
| `packages/opencode/src/cli/cmd/pr.ts` | TUI launch from `pr checkout` |
| `packages/opencode/src/cli/cmd/db.ts` | sqlite3 interactive shell |
| `packages/kilo-vscode/src/services/cli-backend/server-manager.ts` | VS Code extension CLI backend process |