### PR TITLE
fix: auto-scroll to bottom after sending a message in chat

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -849,6 +849,11 @@ export const SessionProvider: ParentComponent = (props) => {
       }
       setStore("messages", sid, (msgs = []) => [...msgs, temp])
       setStore("parts", tempId, [{ type: "text" as const, id: `${tempId}-text`, text }])
+      // The optimistic message is now in the DOM but the session status is
+      // still "idle" (the CLI backend hasn't started yet), so the auto-scroll
+      // ResizeObserver won't scroll on its own. Force scroll to bottom so the
+      // user's own message is immediately visible.
+      queueMicrotask(() => window.dispatchEvent(new CustomEvent("resumeAutoScroll")))
     }
 
     const agent = selectedAgentName() !== defaultAgent() ? selectedAgentName() : undefined


### PR DESCRIPTION
## Summary

- Fixes chat not auto-scrolling to the user's newly sent message in both the Agent Manager and sidebar
- The optimistic user message is added to the DOM immediately, but auto-scroll didn't trigger because the session status was still `idle` (CLI backend round-trip hadn't completed yet)
- Dispatches `resumeAutoScroll` event via `queueMicrotask` after adding the optimistic message, reusing the existing scroll-to-bottom mechanism in `MessageList`