### PR TITLE
docs: investigate freeze/crash when switching from legacy extension (#6721)

### DIFF
--- a/docs/investigations/freeze-on-extension-switch.md
+++ b/docs/investigations/freeze-on-extension-switch.md
@@ -1,0 +1,80 @@
+# Investigation: Freeze / Crash When Switching from Legacy Extension
+
+**Issue:** [#6721](https://github.com/Kilo-Org/kilocode/issues/6721)
+**Symptom:** Long freeze (a few minutes), high CPU, when first launching the new extension after using the old Kilo Code v5.x extension.
+
+---
+
+## Root Cause
+
+### The JSON → SQLite One-Time Migration
+
+The most likely cause is the **one-time database migration** the CLI runs on its very first startup.
+
+When the CLI (`kilo serve`) starts for the first time, it checks whether `~/.local/share/kilo/kilo.db` exists. If it does not (i.e. first run of the new extension), it runs `JsonMigration.run()` before starting the HTTP server (`packages/opencode/src/index.ts:131-165`).
+
+This migration scans `~/.local/share/kilo/storage/` and reads every JSON file for all past sessions:
+
+- `project/*.json`
+- `session/*/*.json`
+- `message/*/*.json` — one file per message, per session
+- `part/*/*.json` — one file per message part
+- `todo/*.json`, `permission/*.json`, `session_share/*.json`
+
+For a heavy user of the old extension who already had the new CLI installed (e.g. via `kilo` TUI) and accumulated many sessions, this can involve **thousands of JSON files**. The CLI itself says "may take a few minutes" (`packages/opencode/src/index.ts:133`).
+
+**The critical problem:** The VS Code extension's `ServerManager` waits for the CLI to emit its port to stdout before marking startup as complete, with a **hard 30-second timeout** (`server-manager.ts:122-128`). The migration runs _before_ the port is emitted. If the migration takes longer than 30 seconds, the extension kills the process and throws `"Server startup timeout"`, causing the extension to appear frozen and then crash.
+
+Even when it finishes within 30s, the migration is CPU-bound file I/O running in the foreground, which explains the high CPU usage observed by users.
+
+### Secondary: Two Extensions Running Simultaneously
+
+If users still have the old `kilo-code` (v5.x) extension enabled alongside the new one, both extensions are active at the same time. The old extension is itself heavyweight at startup — it scans task history, initializes the auto-purge scheduler, etc. The combined startup load of two full extensions can cause a perceptible freeze in VS Code.
+
+### What Was Previously Ruled Out
+
+- **Migration wizard** (`checkAndShowMigrationWizard`): This runs _after_ the CLI connection is established and only reads SecretStorage + a few small files. It is unlikely to be the cause.
+- **Large marketplace GIF**: Already removed.
+
+---
+
+## Evidence
+
+| Location                                                                  | Relevance                                                           |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `packages/opencode/src/index.ts:130-165`                                  | JSON→SQLite migration runs on first startup, before port is emitted |
+| `packages/opencode/src/storage/json-migration.ts:108-118`                 | Scans all session/message/part files before processing              |
+| `packages/kilo-vscode/src/services/cli-backend/server-manager.ts:121-128` | 30-second startup timeout — migration can exceed this               |
+| `packages/opencode/src/index.ts:133`                                      | CLI itself warns "may take a few minutes"                           |
+
+---
+
+## Recommended Fixes
+
+### 1. Detect and surface migration progress in the extension (highest impact)
+
+The CLI already emits progress on stderr in non-TTY mode:
+
+```
+sqlite-migration:0
+sqlite-migration:25
+...
+sqlite-migration:done
+```
+
+The `ServerManager` already listens to `serverProcess.stderr` but only logs it. It should:
+
+- Parse `sqlite-migration:N` lines and report progress to the VS Code UI (e.g. via `vscode.window.withProgress`)
+- Extend the startup timeout while migration is in progress (or remove the timeout during migration and apply it only after `sqlite-migration:done`)
+
+### 2. Increase the startup timeout
+
+The 30-second hard limit (`server-manager.ts:122`) is too short for users with large session histories. A more generous timeout (e.g. 5 minutes) with a progress indicator would prevent false "Server startup timeout" crashes.
+
+### 3. Run the JSON migration as an explicit step before spawning the server
+
+Alternatively, run the migration as a separate `kilo db migrate` command _before_ spawning `kilo serve`. This makes it easier to show progress without modifying the serve startup path, and the server timeout only starts after migration completes.
+
+### 4. Prompt users to disable the old extension
+
+After migration, show a notification guiding users to disable the legacy `kilo-code` extension. Running both simultaneously doubles startup overhead.

--- a/docs/investigations/freeze-on-extension-switch.md
+++ b/docs/investigations/freeze-on-extension-switch.md
@@ -61,6 +61,51 @@ However, testing shows the binary starts and emits its port in ~0.7s when securi
 
 ---
 
+---
+
+## Three Additional Cross-Platform Causes
+
+### Cause 2: npm Package Install on First Request (`opencode-anthropic-auth`)
+
+`Plugin.init()` is called inside `InstanceBootstrap`, which runs on the **first HTTP request** after connecting (the `provider.list` call triggered by `fetchAndSendProviders()`). `Plugin.init()` tries to install the built-in plugin `opencode-anthropic-auth@0.0.13` via `BunProc.install()` (`plugin/index.ts:72`).
+
+`BunProc.install()` runs **`bun add opencode-anthropic-auth@0.0.13`** as a child process (`bun/index.ts:104`). This:
+
+- Makes a network request to the npm registry to download the package
+- On first run, has no cache — must download, extract, and write to disk
+- On subsequent runs with a pinned version, skips the install — but if the version is `latest`, it first calls `bun info` (another network round-trip) to check for updates (`registry.ts:39`)
+
+A slow npm registry response or poor network connectivity causes this to block for seconds to minutes. This affects **all platforms** and is completely independent of the old extension.
+
+**Evidence:** `plugin/index.ts:60-72` — `BUILTIN = ["opencode-anthropic-auth@0.0.13"]` is always installed unless `KILO_DISABLE_DEFAULT_PLUGINS` is set. `bun/index.ts:73-113` — install runs synchronously within the request handler.
+
+### Cause 3: Antivirus Scanning the CLI Binary (Windows)
+
+On Windows, the equivalent of macOS Gatekeeper is **Windows Defender** (or any third-party AV). When an unknown 118 MB executable is run for the first time, Windows Defender performs a **real-time scan** of the entire binary before allowing it to execute. This scan:
+
+- Is CPU-intensive and can take 1–5 minutes for large binaries
+- Blocks process startup until the scan completes
+- Only happens on first execution (subsequent runs use the cached scan result)
+- Is triggered by `ServerManager.startServer()` calling `spawn(cliPath, ...)` — the OS won't execute the binary until AV clears it
+
+This is the Windows equivalent of the macOS Gatekeeper finding and explains the same symptoms on that platform. The fix is the same: properly sign the binary (Authenticode signing on Windows, Developer ID on macOS), which helps AV scanners trust it faster.
+
+### Cause 4: Ripgrep Full File-Tree Scan of a Large Workspace
+
+`InstanceBootstrap` calls `File.init()`, which lazily triggers a **full recursive ripgrep scan** of the workspace directory (`file/index.ts:382`):
+
+```ts
+for await (const file of Ripgrep.files({ cwd: Instance.directory })) {
+```
+
+The ripgrep call uses `--hidden --glob=!.git/*` (`file/ripgrep.ts:224-226`). It respects `.gitignore` but scans all other files including hidden files. For users who had `customStoragePath` pointing anywhere inside their workspace in the old extension, the workspace may contain a `tasks/` subdirectory with **thousands of JSON files** (one per task message). Ripgrep would enumerate all of these.
+
+More generally, users with large monorepos, deep dependency trees, or home directories as their workspace can experience multi-minute scans. The scan runs concurrently but still consumes significant CPU and I/O, causing VS Code to feel frozen.
+
+This affects all platforms and is triggered every time a new `Instance` initializes (first request per workspace). It is not specific to switching from the old extension, but the old extension's `customStoragePath` feature makes it more likely to affect switchers.
+
+---
+
 ## Ruled Out
 
 | Hypothesis                             | Why Ruled Out                                                        |

--- a/docs/investigations/freeze-on-extension-switch.md
+++ b/docs/investigations/freeze-on-extension-switch.md
@@ -5,76 +5,95 @@
 
 ---
 
-## Root Cause
+## Most Probable Root Cause: macOS Security Scanning of the CLI Binary
 
-### The JSON → SQLite One-Time Migration
+The new extension works fundamentally differently from the old one: it bundles and spawns a **118 MB native binary** (`bin/kilo`, a Bun standalone executable) as a child process. The old extension ran entirely inside VS Code's extension host.
 
-The most likely cause is the **one-time database migration** the CLI runs on its very first startup.
+On macOS, the first execution of a new binary triggers security checks by the OS:
 
-When the CLI (`kilo serve`) starts for the first time, it checks whether `~/.local/share/kilo/kilo.db` exists. If it does not (i.e. first run of the new extension), it runs `JsonMigration.run()` before starting the HTTP server (`packages/opencode/src/index.ts:131-165`).
+- **Gatekeeper** verifies the code signature
+- **XProtect** (Apple's built-in malware scanner) scans the binary
+- **Notarization** staple verification (if not stapled, an online check may occur)
 
-This migration scans `~/.local/share/kilo/storage/` and reads every JSON file for all past sessions:
+The binary is currently **ad-hoc signed** (`Signature=adhoc`, `TeamIdentifier=not set`), not signed with an Apple Developer certificate:
 
-- `project/*.json`
-- `session/*/*.json`
-- `message/*/*.json` — one file per message, per session
-- `part/*/*.json` — one file per message part
-- `todo/*.json`, `permission/*.json`, `session_share/*.json`
+```
+$ codesign -dv bin/kilo
+CodeDirectory v=20400 flags=0x20002(adhoc,linker-signed)
+Signature=adhoc
+TeamIdentifier=not set
+```
 
-For a heavy user of the old extension who already had the new CLI installed (e.g. via `kilo` TUI) and accumulated many sessions, this can involve **thousands of JSON files**. The CLI itself says "may take a few minutes" (`packages/opencode/src/index.ts:133`).
+For an unsigned or ad-hoc signed 118 MB binary, macOS security subsystems perform an **extended scan of the entire file**. This is CPU-intensive and can take **1–5 minutes** on a cold system, which matches the reported symptom exactly. After the first run, macOS caches the scan result and subsequent launches are fast.
 
-**The critical problem:** The VS Code extension's `ServerManager` waits for the CLI to emit its port to stdout before marking startup as complete, with a **hard 30-second timeout** (`server-manager.ts:122-128`). The migration runs _before_ the port is emitted. If the migration takes longer than 30 seconds, the extension kills the process and throws `"Server startup timeout"`, causing the extension to appear frozen and then crash.
+This explains all the observed characteristics:
 
-Even when it finishes within 30s, the migration is CPU-bound file I/O running in the foreground, which explains the high CPU usage observed by users.
+- **High CPU** (XProtect/Gatekeeper doing cryptographic work across 118 MB)
+- **"A few minutes"** duration (proportional to binary size)
+- **Only happens once** (the first time the binary runs after install/upgrade)
+- **Specific to switching** (new users of the CLI-backed extension encounter this binary for the first time; users already using the `kilo` TUI would have already triggered this scan)
 
-### Secondary: Two Extensions Running Simultaneously
+### Evidence
 
-If users still have the old `kilo-code` (v5.x) extension enabled alongside the new one, both extensions are active at the same time. The old extension is itself heavyweight at startup — it scans task history, initializes the auto-purge scheduler, etc. The combined startup load of two full extensions can cause a perceptible freeze in VS Code.
+```
+$ codesign --verify bin/kilo
+bin/kilo: invalid signature (code or signature have been modified)
+In architecture: arm64
 
-### What Was Previously Ruled Out
-
-- **Migration wizard** (`checkAndShowMigrationWizard`): This runs _after_ the CLI connection is established and only reads SecretStorage + a few small files. It is unlikely to be the cause.
-- **Large marketplace GIF**: Already removed.
+$ ls -la bin/kilo
+-rwxr-xr-x  1 mark  staff  118167824  bin/kilo  # 118 MB
+```
 
 ---
 
-## Evidence
+## Secondary Issue: 30-Second Startup Timeout
 
-| Location                                                                  | Relevance                                                           |
-| ------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `packages/opencode/src/index.ts:130-165`                                  | JSON→SQLite migration runs on first startup, before port is emitted |
-| `packages/opencode/src/storage/json-migration.ts:108-118`                 | Scans all session/message/part files before processing              |
-| `packages/kilo-vscode/src/services/cli-backend/server-manager.ts:121-128` | 30-second startup timeout — migration can exceed this               |
-| `packages/opencode/src/index.ts:133`                                      | CLI itself warns "may take a few minutes"                           |
+The `ServerManager` waits for the CLI to print its port to stdout, with a hard 30-second timeout (`server-manager.ts:122-128`). The port is only printed after the yargs middleware completes, which includes:
+
+- `Config.getGlobal()` — reads config files
+- `Telemetry.init()` — initializes PostHog/OTel
+- `migrateLegacyKiloAuth()` — reads `~/.kilocode/cli/config.json`
+- JSON→SQLite migration check (fast for new users, potentially slow for CLI veterans with many sessions)
+
+If macOS security scanning delays the binary's first output to stdout by more than 30 seconds, the extension kills the process and shows a "Server startup timeout" error, which manifests as a crash.
+
+However, testing shows the binary starts and emits its port in ~0.7s when security scans are already cached, so this only compounds the Gatekeeper issue.
+
+---
+
+## Ruled Out
+
+| Hypothesis                             | Why Ruled Out                                                        |
+| -------------------------------------- | -------------------------------------------------------------------- |
+| Migration wizard blocking startup      | Runs after CLI connects; only reads small secrets/files              |
+| Large `taskHistory` in globalState     | Contains only metadata (no message content); parsing is fast         |
+| JSON→SQLite one-time migration         | Returns immediately when storage dir doesn't exist (new CLI users)   |
+| Running both extensions simultaneously | Same publisher+name prevents co-installation; VS Code won't allow it |
+| Model list fetch from `api.kilo.ai`    | 10-second timeout; doesn't cause minutes-long freeze                 |
+| Extension host memory pressure         | Both extensions can't be active at once (same ID)                    |
 
 ---
 
 ## Recommended Fixes
 
-### 1. Detect and surface migration progress in the extension (highest impact)
+### 1. Properly sign and notarize the binary (highest impact)
 
-The CLI already emits progress on stderr in non-TTY mode:
+Sign the CLI binary with an Apple Developer certificate and notarize it before bundling it into the VSIX. This eliminates the macOS security scan on first execution and also removes the Gatekeeper dialog that otherwise blocks users.
 
+### 2. Show a progress notification during CLI startup
+
+Display a VS Code progress notification while waiting for the CLI to start. This prevents VS Code from appearing frozen even if startup takes longer than expected:
+
+```ts
+await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Kilo: Starting..." }, () =>
+  this.connectionService.connect(),
+)
 ```
-sqlite-migration:0
-sqlite-migration:25
-...
-sqlite-migration:done
-```
 
-The `ServerManager` already listens to `serverProcess.stderr` but only logs it. It should:
+### 3. Increase the startup timeout
 
-- Parse `sqlite-migration:N` lines and report progress to the VS Code UI (e.g. via `vscode.window.withProgress`)
-- Extend the startup timeout while migration is in progress (or remove the timeout during migration and apply it only after `sqlite-migration:done`)
+The 30-second hard limit (`server-manager.ts:122`) is too tight for first-run scenarios. Increasing it to 3–5 minutes prevents false "Server startup timeout" crashes while macOS scans the binary.
 
-### 2. Increase the startup timeout
+### 4. Detect and surface the first-run delay
 
-The 30-second hard limit (`server-manager.ts:122`) is too short for users with large session histories. A more generous timeout (e.g. 5 minutes) with a progress indicator would prevent false "Server startup timeout" crashes.
-
-### 3. Run the JSON migration as an explicit step before spawning the server
-
-Alternatively, run the migration as a separate `kilo db migrate` command _before_ spawning `kilo serve`. This makes it easier to show progress without modifying the serve startup path, and the server timeout only starts after migration completes.
-
-### 4. Prompt users to disable the old extension
-
-After migration, show a notification guiding users to disable the legacy `kilo-code` extension. Running both simultaneously doubles startup overhead.
+The extension could check whether the binary has been run before (e.g. by testing if a sentinel file exists in the CLI's data dir) and show a "First run: initializing…" message to set user expectations.


### PR DESCRIPTION
## Summary

Investigation into issue #6721 — long freeze and high CPU when switching from the legacy Kilo Code v5.x extension to the new one.
