### PR TITLE
fix(vscode): only show and accept chat suggestions at prompt end

### DIFF
--- a/packages/kilo-vscode/tests/unit/prompt-input-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-input-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { fileName, dirName, buildHighlightSegments } from "../../webview-ui/src/components/chat/prompt-input-utils"
+import { fileName, isEnd, dirName, buildHighlightSegments } from "../../webview-ui/src/components/chat/prompt-input-utils"
 
 describe("fileName", () => {
   it("extracts the last segment of a unix path", () => {
@@ -20,6 +20,27 @@ describe("fileName", () => {
 
   it("handles mixed separators", () => {
     expect(fileName("src\\components/chat/File.tsx")).toBe("File.tsx")
+  })
+})
+
+describe("isEnd", () => {
+  it("returns true when node is undefined", () => {
+    expect(isEnd(undefined)).toBe(true)
+  })
+
+  it("returns true when caret is collapsed at the end", () => {
+    const node = { selectionStart: 5, selectionEnd: 5, value: "hello" } as unknown as HTMLTextAreaElement
+    expect(isEnd(node)).toBe(true)
+  })
+
+  it("returns false when caret is in the middle", () => {
+    const node = { selectionStart: 2, selectionEnd: 2, value: "hello" } as unknown as HTMLTextAreaElement
+    expect(isEnd(node)).toBe(false)
+  })
+
+  it("returns false when text is selected", () => {
+    const node = { selectionStart: 1, selectionEnd: 3, value: "hello" } as unknown as HTMLTextAreaElement
+    expect(isEnd(node)).toBe(false)
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/prompt-input-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-input-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "bun:test"
-import { fileName, isEnd, dirName, buildHighlightSegments } from "../../webview-ui/src/components/chat/prompt-input-utils"
+import {
+  fileName,
+  isEnd,
+  dirName,
+  buildHighlightSegments,
+} from "../../webview-ui/src/components/chat/prompt-input-utils"
 
 describe("fileName", () => {
   it("extracts the last segment of a unix path", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -21,7 +21,7 @@ import { ThinkingSelector } from "../shared/ThinkingSelector"
 import { useFileMention } from "../../hooks/useFileMention"
 import { useImageAttachments } from "../../hooks/useImageAttachments"
 import { WandSparkles } from "@kilocode/kilo-ui/lucide"
-import { fileName, dirName, buildHighlightSegments } from "./prompt-input-utils"
+import { fileName, dirName, buildHighlightSegments, isEnd } from "./prompt-input-utils"
 import type { ReviewComment } from "../../types/messages"
 import { formatReviewCommentsMarkdown } from "../../utils/review-comment-markdown"
 
@@ -130,6 +130,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   let textareaRef: HTMLTextAreaElement | undefined
   let highlightRef: HTMLDivElement | undefined
+  let ghostRef: HTMLSpanElement | undefined
   let dropdownRef: HTMLDivElement | undefined
   let debounceTimer: ReturnType<typeof setTimeout> | undefined
   let requestCounter = 0
@@ -194,6 +195,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       const result = message as { type: "chatCompletionResult"; text: string; requestId: string }
       if (result.requestId === `chat-ac-${requestCounter}` && result.text) {
         setGhostText(result.text)
+        queueMicrotask(() => updateGhostVisibility())
       }
     }
 
@@ -343,6 +345,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
   }
 
+  const updateGhostVisibility = (node = textareaRef) => {
+    if (!ghostRef) return
+    ghostRef.hidden = !isEnd(node)
+  }
+
   const adjustHeight = () => {
     if (!textareaRef) return
     textareaRef.style.height = "auto"
@@ -403,6 +410,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
 
     if ((e.key === "Tab" || e.key === "ArrowRight") && ghostText()) {
+      // Ghost completion is appended at the end, so only accept when caret is at end.
+      const node = textareaRef
+      if (!node) return
+      if (!isEnd(node)) return
       e.preventDefault()
       acceptSuggestion()
       return
@@ -598,7 +609,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               )}
             </Index>
             <Show when={ghostText()}>
-              <span class="prompt-input-ghost-text">{ghostText()}</span>
+              <span ref={ghostRef} class="prompt-input-ghost-text">
+                {ghostText()}
+              </span>
             </Show>
           </div>
           <textarea
@@ -608,7 +621,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             value={text()}
             onInput={handleInput}
             onKeyDown={handleKeyDown}
+            onKeyUp={() => updateGhostVisibility()}
             onPaste={handlePaste}
+            onMouseUp={() => updateGhostVisibility()}
             onScroll={syncHighlightScroll}
             disabled={isDisabled()}
             rows={1}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/prompt-input-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/prompt-input-utils.ts
@@ -3,6 +3,13 @@ export function fileName(path: string): string {
   return normalized.split("/").pop() ?? normalized
 }
 
+export function isEnd(node: HTMLTextAreaElement | undefined): boolean {
+  if (!node) return true
+  const start = node.selectionStart ?? 0
+  const end = node.selectionEnd ?? 0
+  return start === end && end === node.value.length
+}
+
 export function dirName(path: string): string {
   const parts = path.replaceAll("\\", "/").replace(/\/+$/, "").split("/")
   if (parts.length <= 1) return ""


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->
Fixes #6822

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

- Suggested ghost text is now only applied when your cursor is at the end of the prompt.
- `Tab` and `Right Arrow` only accept a suggestion when the cursor is at the end.
- If you move the cursor away from the end, the ghost text is hidden.
- If you move back to the end, the ghost text can show again.
- Added tests to cover this cursor-at-end check.


## Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

https://github.com/user-attachments/assets/d2d372cd-9839-4184-bcdf-0ae57584d7ae


## State behavior

- Moving the cursor does not reset prompt text state.
- **Moving the cursor also does not reset ghost suggestion state.**
- We only toggle ghost visibility in the UI.
- Ghost state still changes only in normal cases (new input, accept, dismiss, or new result).

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->

Discord: `hdcode.dev`
