### PR TITLE
feat: add --auto mode to TUI for bypassing permission prompts for single session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -45,6 +45,7 @@ import { registerKiloCommands } from "@/kilocode/kilo-commands" // kilocode_chan
 import { initializeTUIDependencies } from "@kilocode/kilo-gateway/tui" // kilocode_change
 import { TuiConfigProvider } from "./context/tui-config"
 import { TuiConfig } from "@/config/tui"
+import { AutoModeProvider, useAutoMode } from "./context/auto" // kilocode_change
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -142,45 +143,49 @@ export function tui(input: {
             fallback={(error, reset) => <ErrorComponent error={error} reset={reset} onExit={onExit} mode={mode} />}
           >
             <ArgsProvider {...input.args}>
-              <ExitProvider onExit={onExit}>
-                <KVProvider>
-                  <ToastProvider>
-                    <RouteProvider>
-                      <TuiConfigProvider config={input.config}>
-                        <SDKProvider
-                          url={input.url}
-                          directory={input.directory}
-                          fetch={input.fetch}
-                          headers={input.headers}
-                          events={input.events}
-                        >
-                          <SyncProvider>
-                            <ThemeProvider mode={mode}>
-                              <LocalProvider>
-                                <KeybindProvider>
-                                  <PromptStashProvider>
-                                    <DialogProvider>
-                                      <CommandProvider>
-                                        <FrecencyProvider>
-                                          <PromptHistoryProvider>
-                                            <PromptRefProvider>
-                                              <App />
-                                            </PromptRefProvider>
-                                          </PromptHistoryProvider>
-                                        </FrecencyProvider>
-                                      </CommandProvider>
-                                    </DialogProvider>
-                                  </PromptStashProvider>
-                                </KeybindProvider>
-                              </LocalProvider>
-                            </ThemeProvider>
-                          </SyncProvider>
-                        </SDKProvider>
-                      </TuiConfigProvider>
-                    </RouteProvider>
-                  </ToastProvider>
-                </KVProvider>
-              </ExitProvider>
+              {/* kilocode_change start - auto mode context */}
+              <AutoModeProvider initial={input.args.auto}>
+                {/* kilocode_change end */}
+                <ExitProvider onExit={onExit}>
+                  <KVProvider>
+                    <ToastProvider>
+                      <RouteProvider>
+                        <TuiConfigProvider config={input.config}>
+                          <SDKProvider
+                            url={input.url}
+                            directory={input.directory}
+                            fetch={input.fetch}
+                            headers={input.headers}
+                            events={input.events}
+                          >
+                            <SyncProvider>
+                              <ThemeProvider mode={mode}>
+                                <LocalProvider>
+                                  <KeybindProvider>
+                                    <PromptStashProvider>
+                                      <DialogProvider>
+                                        <CommandProvider>
+                                          <FrecencyProvider>
+                                            <PromptHistoryProvider>
+                                              <PromptRefProvider>
+                                                <App />
+                                              </PromptRefProvider>
+                                            </PromptHistoryProvider>
+                                          </FrecencyProvider>
+                                        </CommandProvider>
+                                      </DialogProvider>
+                                    </PromptStashProvider>
+                                  </KeybindProvider>
+                                </LocalProvider>
+                              </ThemeProvider>
+                            </SyncProvider>
+                          </SDKProvider>
+                        </TuiConfigProvider>
+                      </RouteProvider>
+                    </ToastProvider>
+                  </KVProvider>
+                </ExitProvider>
+              </AutoModeProvider>
             </ArgsProvider>
           </ErrorBoundary>
         )
@@ -215,6 +220,7 @@ function App() {
   const kv = useKV()
   const command = useCommandDialog()
   const sdk = useSDK()
+  const auto = useAutoMode() // kilocode_change
   const toast = useToast()
   const { theme, mode, setMode } = useTheme()
   const sync = useSync()
@@ -292,6 +298,15 @@ function App() {
 
   const args = useArgs()
   onMount(() => {
+    // kilocode_change start - warn on startup when --auto flag is used
+    if (auto.enabled()) {
+      toast.show({
+        variant: "warning",
+        message: "Auto mode enabled - all permissions will be auto-approved",
+        duration: 5000,
+      })
+    }
+    // kilocode_change end
     batch(() => {
       if (args.agent) local.agent.set(args.agent)
       if (args.model) {
@@ -664,6 +679,24 @@ function App() {
         dialog.clear()
       },
     },
+    // kilocode_change start - auto mode toggle
+    {
+      title: auto.enabled() ? "Disable auto mode" : "Enable auto mode",
+      description: "Auto-approve all permissions without prompting",
+      value: "permission.auto",
+      category: "System",
+      slash: { name: "auto" },
+      onSelect: (dialog) => {
+        auto.toggle()
+        toast.show({
+          variant: auto.enabled() ? "warning" : "info",
+          message: auto.enabled() ? "Auto mode enabled - all permissions will be auto-approved" : "Auto mode disabled",
+          duration: 3000,
+        })
+        dialog.clear()
+      },
+    },
+    // kilocode_change end
   ])
 
   // kilocode_change start - Initialize TUI dependencies for kilo-gateway

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -682,15 +682,16 @@ function App() {
     // kilocode_change start - auto mode toggle
     {
       title: auto.enabled() ? "Disable auto mode" : "Enable auto mode",
-      description: "Auto-approve all permissions without prompting",
+      description: "Skip permission prompts",
       value: "permission.auto",
+      keybind: "auto_toggle",
       category: "System",
       slash: { name: "auto" },
       onSelect: (dialog) => {
         auto.toggle()
         toast.show({
           variant: auto.enabled() ? "warning" : "info",
-          message: auto.enabled() ? "Auto mode enabled - all permissions will be auto-approved" : "Auto mode disabled",
+          message: auto.enabled() ? "Auto mode enabled" : "Auto mode disabled",
           duration: 3000,
         })
         dialog.clear()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1063,9 +1063,8 @@ export function Prompt(props: PromptProps) {
         {/* kilocode_change start - persistent auto mode banner */}
         <Show when={auto.enabled()}>
           <box flexDirection="row" justifyContent="space-between" paddingLeft={1} paddingRight={1}>
-            <text fg={theme.warning}>{"△ "}Auto mode — permissions are auto-approved</text>
-            <text fg={theme.textMuted}>
-              {keybind.print("auto_toggle")} <span style={{ fg: theme.textMuted }}>disable</span>
+            <text fg={theme.warning}>
+              {"△ "}Auto mode — permissions are auto-approved{"  "}({keybind.print("auto_toggle")} to toggle)
             </text>
           </box>
         </Show>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -34,6 +34,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { useAutoMode } from "../../context/auto" // kilocode_change
 
 export type PromptProps = {
   sessionID?: string
@@ -77,6 +78,7 @@ export function Prompt(props: PromptProps) {
   const renderer = useRenderer()
   const { theme, syntax } = useTheme()
   const kv = useKV()
+  const auto = useAutoMode() // kilocode_change
 
   function promptModelWarning() {
     toast.show({
@@ -1058,6 +1060,16 @@ export function Prompt(props: PromptProps) {
             }
           />
         </box>
+        {/* kilocode_change start - persistent auto mode banner */}
+        <Show when={auto.enabled()}>
+          <box flexDirection="row" justifyContent="space-between" paddingLeft={1} paddingRight={1}>
+            <text fg={theme.warning}>{"△ "}Auto mode — permissions are auto-approved</text>
+            <text fg={theme.textMuted}>
+              {keybind.print("auto_toggle")} <span style={{ fg: theme.textMuted }}>disable</span>
+            </text>
+          </box>
+        </Show>
+        {/* kilocode_change end */}
         <box flexDirection="row" justifyContent="space-between">
           <Show when={status().type !== "idle"} fallback={<text />}>
             <box

--- a/packages/opencode/src/cli/cmd/tui/context/args.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/args.tsx
@@ -7,6 +7,7 @@ export interface Args {
   continue?: boolean
   sessionID?: string
   fork?: boolean
+  auto?: boolean // kilocode_change
 }
 
 export const { use: useArgs, provider: ArgsProvider } = createSimpleContext({

--- a/packages/opencode/src/cli/cmd/tui/context/auto.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/auto.tsx
@@ -1,0 +1,21 @@
+// kilocode_change - new file
+import { createSignal, type Accessor } from "solid-js"
+import { createSimpleContext } from "./helper"
+
+export interface AutoMode {
+  enabled: Accessor<boolean>
+  toggle: () => void
+}
+
+export const { use: useAutoMode, provider: AutoModeProvider } = createSimpleContext({
+  name: "AutoMode",
+  init: (props: { initial?: boolean }) => {
+    const [enabled, setEnabled] = createSignal(props.initial ?? false)
+    return {
+      enabled,
+      toggle() {
+        setEnabled((prev) => !prev)
+      },
+    }
+  },
+})

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -129,14 +129,30 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
         case "permission.asked": {
           const request = event.properties
-          // kilocode_change start - auto-approve immediately, skip store
+          // kilocode_change start - auto-approve immediately, fall back to store on failure
           if (auto.enabled()) {
             sdk.client.permission
               .reply({
                 reply: "once",
                 requestID: request.id,
               })
-              .catch((err) => Log.Default.debug("auto-reply failed", { err }))
+              .catch((err) => {
+                Log.Default.debug("auto-reply failed, adding to store for retry", { err })
+                const existing = store.permission[request.sessionID]
+                if (!existing) {
+                  setStore("permission", request.sessionID, [request])
+                  return
+                }
+                const match = Binary.search(existing, request.id, (r) => r.id)
+                if (match.found) return
+                setStore(
+                  "permission",
+                  request.sessionID,
+                  produce((draft) => {
+                    draft.splice(match.index, 0, request)
+                  }),
+                )
+              })
             break
           }
           // kilocode_change end

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -25,6 +25,7 @@ import { createSimpleContext } from "./helper"
 import type { Snapshot } from "@/snapshot"
 import { useExit } from "./exit"
 import { useArgs } from "./args"
+import { useAutoMode } from "./auto" // kilocode_change
 import { batch, onMount } from "solid-js"
 import { Log } from "@/util/log"
 import type { Path } from "@kilocode/sdk"
@@ -103,6 +104,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     })
 
     const sdk = useSDK()
+    const auto = useAutoMode() // kilocode_change
 
     sdk.event.listen((e) => {
       const event = e.details
@@ -127,6 +129,17 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
         case "permission.asked": {
           const request = event.properties
+          // kilocode_change start - auto-approve immediately, skip store
+          if (auto.enabled()) {
+            sdk.client.permission
+              .reply({
+                reply: "once",
+                requestID: request.id,
+              })
+              .catch((err) => Log.Default.debug("auto-reply failed", { err }))
+            break
+          }
+          // kilocode_change end
           const requests = store.permission[request.sessionID]
           if (!requests) {
             setStore("permission", request.sessionID, [request])

--- a/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
@@ -5,7 +5,6 @@ import { useDirectory } from "../../context/directory"
 import { useConnected } from "../../component/dialog-model"
 import { createStore } from "solid-js/store"
 import { useRoute } from "../../context/route"
-import { useAutoMode } from "../../context/auto" // kilocode_change
 
 export function Footer() {
   const { theme } = useTheme()
@@ -20,7 +19,6 @@ export function Footer() {
   })
   const directory = useDirectory()
   const connected = useConnected()
-  const auto = useAutoMode() // kilocode_change
 
   const [store, setStore] = createStore({
     welcome: false,
@@ -62,11 +60,6 @@ export function Footer() {
             </text>
           </Match>
           <Match when={connected()}>
-            {/* kilocode_change start - auto mode indicator */}
-            <Show when={auto.enabled()}>
-              <text fg={theme.warning}>AUTO</text>
-            </Show>
-            {/* kilocode_change end */}
             <Show when={permissions().length > 0}>
               <text fg={theme.warning}>
                 <span style={{ fg: theme.warning }}>△</span> {permissions().length} Permission

--- a/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
@@ -5,6 +5,7 @@ import { useDirectory } from "../../context/directory"
 import { useConnected } from "../../component/dialog-model"
 import { createStore } from "solid-js/store"
 import { useRoute } from "../../context/route"
+import { useAutoMode } from "../../context/auto" // kilocode_change
 
 export function Footer() {
   const { theme } = useTheme()
@@ -19,6 +20,7 @@ export function Footer() {
   })
   const directory = useDirectory()
   const connected = useConnected()
+  const auto = useAutoMode() // kilocode_change
 
   const [store, setStore] = createStore({
     welcome: false,
@@ -60,6 +62,11 @@ export function Footer() {
             </text>
           </Match>
           <Match when={connected()}>
+            {/* kilocode_change start - auto mode indicator */}
+            <Show when={auto.enabled()}>
+              <text fg={theme.warning}>AUTO</text>
+            </Show>
+            {/* kilocode_change end */}
             <Show when={permissions().length > 0}>
               <text fg={theme.warning}>
                 <span style={{ fg: theme.warning }}>△</span> {permissions().length} Permission

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -208,8 +208,10 @@ export function Session() {
   // kilocode_change start - auto-approve permissions when auto mode is active
   const replied = new Set<string>()
   const inflight = new Set<string>()
+  const [retryTick, setRetryTick] = createSignal(0)
   createEffect(() => {
     if (!auto.enabled()) return
+    retryTick()
     for (const request of permissions()) {
       if (replied.has(request.id)) continue
       if (inflight.has(request.id)) continue
@@ -223,7 +225,8 @@ export function Session() {
           replied.add(request.id)
         })
         .catch((err) => {
-          console.error("auto-reply failed, will retry", err)
+          console.error("auto-reply failed, retrying in 2s", err)
+          setTimeout(() => setRetryTick((n) => n + 1), 2000)
         })
         .finally(() => {
           inflight.delete(request.id)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -82,6 +82,7 @@ import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
 
 import { formatMarkdownTables } from "../../util/markdown" // kilocode_change
+import { useAutoMode } from "../../context/auto" // kilocode_change
 
 addDefaultParsers(parsers.parsers)
 
@@ -138,6 +139,8 @@ export function Session() {
     if (session()?.parentID) return []
     return children().flatMap((x) => sync.data.question[x.id] ?? [])
   })
+
+  const auto = useAutoMode() // kilocode_change
 
   const pending = createMemo(() => {
     return messages().findLast((x) => x.role === "assistant" && !x.time.completed)?.id
@@ -201,6 +204,23 @@ export function Session() {
 
   const toast = useToast()
   const sdk = useSDK()
+
+  // kilocode_change start - auto-approve permissions when auto mode is active
+  const replied = new Set<string>()
+  createEffect(() => {
+    if (!auto.enabled()) return
+    for (const request of permissions()) {
+      if (replied.has(request.id)) continue
+      replied.add(request.id)
+      sdk.client.permission
+        .reply({
+          reply: "once",
+          requestID: request.id,
+        })
+        .catch((err) => console.error("auto-reply failed", err))
+    }
+  })
+  // kilocode_change end
 
   // Handle initial prompt from fork
   createEffect(() => {
@@ -1120,14 +1140,18 @@ export function Session() {
               </For>
             </scrollbox>
             <box flexShrink={0}>
-              <Show when={permissions().length > 0}>
+              {/* kilocode_change - skip permission prompt when auto mode is active */}
+              <Show when={permissions().length > 0 && !auto.enabled()}>
                 <PermissionPrompt request={permissions()[0]} />
               </Show>
               <Show when={permissions().length === 0 && questions().length > 0}>
                 <QuestionPrompt request={questions()[0]} />
               </Show>
+              {/* kilocode_change - treat permissions as absent when auto mode handles them */}
               <Prompt
-                visible={!session()?.parentID && permissions().length === 0 && questions().length === 0}
+                visible={
+                  !session()?.parentID && (auto.enabled() || permissions().length === 0) && questions().length === 0
+                }
                 ref={(r) => {
                   prompt = r
                   promptRef.set(r)
@@ -1136,7 +1160,7 @@ export function Session() {
                     r.set(route.initialPrompt)
                   }
                 }}
-                disabled={permissions().length > 0 || questions().length > 0}
+                disabled={(!auto.enabled() && permissions().length > 0) || questions().length > 0}
                 onSubmit={() => {
                   toBottom()
                 }}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -207,17 +207,27 @@ export function Session() {
 
   // kilocode_change start - auto-approve permissions when auto mode is active
   const replied = new Set<string>()
+  const inflight = new Set<string>()
   createEffect(() => {
     if (!auto.enabled()) return
     for (const request of permissions()) {
       if (replied.has(request.id)) continue
-      replied.add(request.id)
+      if (inflight.has(request.id)) continue
+      inflight.add(request.id)
       sdk.client.permission
         .reply({
           reply: "once",
           requestID: request.id,
         })
-        .catch((err) => console.error("auto-reply failed", err))
+        .then(() => {
+          replied.add(request.id)
+        })
+        .catch((err) => {
+          console.error("auto-reply failed, will retry", err)
+        })
+        .finally(() => {
+          inflight.delete(request.id)
+        })
     }
   })
   // kilocode_change end

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -80,7 +80,14 @@ export const TuiThreadCommand = cmd({
       .option("agent", {
         type: "string",
         describe: "agent to use",
+      })
+      // kilocode_change start - auto-approve all permissions in TUI
+      .option("auto", {
+        type: "boolean",
+        describe: "auto-approve all permissions",
+        default: false,
       }),
+  // kilocode_change end
   handler: async (args) => {
     // Keep ENABLE_PROCESSED_INPUT cleared even if other code flips it.
     // (Important when running under `bun run` wrappers on Windows.)
@@ -278,6 +285,7 @@ export const TuiThreadCommand = cmd({
           model: args.model,
           prompt,
           fork: args.fork,
+          auto: args.auto, // kilocode_change
         },
         onExit: () => terminateWorker(),
       })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1014,6 +1014,7 @@ export namespace Config {
       tips_toggle: z.string().optional().default("<leader>h").describe("Toggle tips on home screen"),
       news_toggle: z.string().optional().default("none").describe("Toggle news on home screen"), // kilocode_change
       display_thinking: z.string().optional().default("none").describe("Toggle thinking blocks visibility"),
+      auto_toggle: z.string().optional().default("ctrl+shift+a").describe("Toggle auto-approve permissions"), // kilocode_change
     })
     .strict()
     .meta({
@@ -1130,10 +1131,12 @@ export namespace Config {
         .optional()
         .describe("When set, ONLY these providers will be enabled. All other providers will be ignored"),
       // kilocode_change start - nullable for delete sentinel
-      model: ModelId.nullable().describe("Model to use in the format of provider/model, eg anthropic/claude-2").optional(),
-      small_model: ModelId.nullable().describe(
-        "Small model to use for tasks like title generation in the format of provider/model",
-      ).optional(),
+      model: ModelId.nullable()
+        .describe("Model to use in the format of provider/model, eg anthropic/claude-2")
+        .optional(),
+      small_model: ModelId.nullable()
+        .describe("Small model to use for tasks like title generation in the format of provider/model")
+        .optional(),
       // kilocode_change end
       // kilocode_change start - renamed from "build" to "code"
       default_agent: z

--- a/packages/opencode/test/kilocode/auto-mode.test.ts
+++ b/packages/opencode/test/kilocode/auto-mode.test.ts
@@ -5,9 +5,10 @@
 // - Deduplication of auto-replies
 
 import { describe, test, expect } from "bun:test"
-import { createRoot, createSignal, createEffect } from "solid-js"
+import { createRoot, createSignal } from "solid-js"
 import { PermissionNext } from "../../src/permission/next"
 import { Instance } from "../../src/project/instance"
+import { Config } from "../../src/config/config"
 import { tmpdir } from "../fixture/fixture"
 
 // ── AutoMode context logic ──────────────────────────────────────────────────
@@ -298,5 +299,116 @@ describe("auto mode deduplication", () => {
     }
 
     expect(calls).toEqual(["perm_a", "perm_b", "perm_c"])
+  })
+})
+
+// ── Config schema ───────────────────────────────────────────────────────────
+
+describe("auto mode config", () => {
+  test("auto_toggle keybind defaults to ctrl+shift+a", () => {
+    const result = Config.Keybinds.parse({})
+    expect(result.auto_toggle).toBe("ctrl+shift+a")
+  })
+})
+
+// ── Edge cases ──────────────────────────────────────────────────────────────
+
+describe("auto mode edge cases", () => {
+  test("reply to never-existed permission ID is a no-op", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        // Reply to an ID that was never ask()ed — should not throw
+        await PermissionNext.reply({ requestID: "permission_nonexistent", reply: "once" })
+      },
+    })
+  })
+
+  test("once reply does not cascade to other pending permissions", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const promise1 = PermissionNext.ask({
+          id: "permission_cascade1",
+          sessionID: "session_cascade",
+          permission: "bash",
+          patterns: ["echo 1"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        })
+
+        const promise2 = PermissionNext.ask({
+          id: "permission_cascade2",
+          sessionID: "session_cascade",
+          permission: "edit",
+          patterns: ["file.ts"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        })
+
+        // Reply "once" to the first — should NOT cascade to the second
+        await PermissionNext.reply({ requestID: "permission_cascade1", reply: "once" })
+        await promise1
+
+        // Second should still be pending
+        let resolved = false
+        promise2.then(() => {
+          resolved = true
+        })
+        await new Promise((r) => setTimeout(r, 10))
+        expect(resolved).toBe(false)
+
+        // Clean up
+        await PermissionNext.reply({ requestID: "permission_cascade2", reply: "once" })
+        await promise2
+      },
+    })
+  })
+
+  test("list returns empty after all pending permissions are replied", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const promise1 = PermissionNext.ask({
+          id: "permission_list1",
+          sessionID: "session_list",
+          permission: "bash",
+          patterns: ["ls"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        })
+
+        const promise2 = PermissionNext.ask({
+          id: "permission_list2",
+          sessionID: "session_list",
+          permission: "edit",
+          patterns: ["foo.ts"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        })
+
+        // Both should be pending
+        const pending = await PermissionNext.list()
+        expect(pending).toHaveLength(2)
+        expect(pending.map((p) => p.id).sort()).toEqual(["permission_list1", "permission_list2"])
+
+        // Reply to both with "once"
+        await PermissionNext.reply({ requestID: "permission_list1", reply: "once" })
+        await PermissionNext.reply({ requestID: "permission_list2", reply: "once" })
+        await promise1
+        await promise2
+
+        // List should now be empty
+        const remaining = await PermissionNext.list()
+        expect(remaining).toHaveLength(0)
+      },
+    })
   })
 })

--- a/packages/opencode/test/kilocode/auto-mode.test.ts
+++ b/packages/opencode/test/kilocode/auto-mode.test.ts
@@ -1,0 +1,302 @@
+// kilocode_change - new file
+// Tests for TUI auto-mode feature:
+// - AutoMode context signal/toggle behavior
+// - Permission auto-reply integration (PermissionNext.ask + reply with "once")
+// - Deduplication of auto-replies
+
+import { describe, test, expect } from "bun:test"
+import { createRoot, createSignal, createEffect } from "solid-js"
+import { PermissionNext } from "../../src/permission/next"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+
+// ── AutoMode context logic ──────────────────────────────────────────────────
+// Tests the core signal/toggle behavior that AutoModeProvider uses.
+// We replicate the context's init logic directly since SolidJS SSR build
+// (used in bun test) evaluates signals synchronously.
+
+describe("auto mode context", () => {
+  test("defaults to disabled", () => {
+    createRoot((dispose) => {
+      const [enabled] = createSignal(false)
+      expect(enabled()).toBe(false)
+      dispose()
+    })
+  })
+
+  test("initializes from CLI flag", () => {
+    createRoot((dispose) => {
+      const [enabled] = createSignal(true)
+      expect(enabled()).toBe(true)
+      dispose()
+    })
+  })
+
+  test("toggle flips state", () => {
+    createRoot((dispose) => {
+      const [enabled, setEnabled] = createSignal(false)
+      const toggle = () => setEnabled((prev) => !prev)
+
+      expect(enabled()).toBe(false)
+      toggle()
+      expect(enabled()).toBe(true)
+      toggle()
+      expect(enabled()).toBe(false)
+      dispose()
+    })
+  })
+})
+
+// ── Permission auto-reply with "once" ───────────────────────────────────────
+// Tests that replying "once" to a permission request resolves it without
+// creating persistent allow rules (unlike "always").
+
+describe("auto mode permission reply", () => {
+  test("reply once resolves the permission", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const promise = PermissionNext.ask({
+          id: "permission_auto1",
+          sessionID: "session_auto",
+          permission: "bash",
+          patterns: ["echo hello"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        })
+
+        await PermissionNext.reply({
+          requestID: "permission_auto1",
+          reply: "once",
+        })
+
+        const result = await promise
+        expect(result).toBeUndefined()
+      },
+    })
+  })
+
+  test("reply once does not create persistent allow rules", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        // First: ask and reply once
+        const promise = PermissionNext.ask({
+          id: "permission_auto2",
+          sessionID: "session_auto",
+          permission: "edit",
+          patterns: ["src/foo.ts"],
+          metadata: {},
+          always: ["src/*"],
+          ruleset: [],
+        })
+
+        await PermissionNext.reply({
+          requestID: "permission_auto2",
+          reply: "once",
+        })
+
+        await promise
+
+        // Second: same permission should still require approval (not auto-allowed)
+        // because "once" does not add to the approved ruleset
+        const promise2 = PermissionNext.ask({
+          id: "permission_auto3",
+          sessionID: "session_auto",
+          permission: "edit",
+          patterns: ["src/foo.ts"],
+          metadata: {},
+          always: ["src/*"],
+          ruleset: [],
+        })
+
+        // If "once" correctly avoided creating persistent rules, this should
+        // block (pending), not resolve immediately
+        let resolved = false
+        promise2.then(() => {
+          resolved = true
+        })
+
+        // Give microtasks a chance to settle
+        await new Promise((r) => setTimeout(r, 10))
+        expect(resolved).toBe(false)
+
+        // Clean up: reply to unblock
+        await PermissionNext.reply({
+          requestID: "permission_auto3",
+          reply: "once",
+        })
+        await promise2
+      },
+    })
+  })
+
+  test("reply always creates persistent allow rules", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const promise = PermissionNext.ask({
+          id: "permission_auto4",
+          sessionID: "session_auto",
+          permission: "bash",
+          patterns: ["git status"],
+          metadata: {},
+          always: ["git *"],
+          ruleset: [],
+        })
+
+        await PermissionNext.reply({
+          requestID: "permission_auto4",
+          reply: "always",
+        })
+
+        await promise
+
+        // Same pattern should now be auto-allowed without asking
+        const result = await PermissionNext.ask({
+          id: "permission_auto5",
+          sessionID: "session_auto",
+          permission: "bash",
+          patterns: ["git log"],
+          metadata: {},
+          always: ["git *"],
+          ruleset: [],
+        })
+
+        // Should resolve immediately (auto-allowed by the "always" rule)
+        expect(result).toBeUndefined()
+      },
+    })
+  })
+
+  test("multiple permissions can be replied to independently", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const promise1 = PermissionNext.ask({
+          id: "permission_multi1",
+          sessionID: "session_multi",
+          permission: "bash",
+          patterns: ["echo 1"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        })
+
+        const promise2 = PermissionNext.ask({
+          id: "permission_multi2",
+          sessionID: "session_multi",
+          permission: "edit",
+          patterns: ["file.ts"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        })
+
+        const promise3 = PermissionNext.ask({
+          id: "permission_multi3",
+          sessionID: "session_multi",
+          permission: "read",
+          patterns: ["/etc/hosts"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        })
+
+        // Reply to all with "once" (simulating auto-mode behavior)
+        await PermissionNext.reply({ requestID: "permission_multi1", reply: "once" })
+        await PermissionNext.reply({ requestID: "permission_multi2", reply: "once" })
+        await PermissionNext.reply({ requestID: "permission_multi3", reply: "once" })
+
+        // All should resolve
+        expect(await promise1).toBeUndefined()
+        expect(await promise2).toBeUndefined()
+        expect(await promise3).toBeUndefined()
+      },
+    })
+  })
+
+  test("replying to already-resolved permission is a no-op", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const promise = PermissionNext.ask({
+          id: "permission_dup1",
+          sessionID: "session_dup",
+          permission: "bash",
+          patterns: ["echo hello"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        })
+
+        await PermissionNext.reply({ requestID: "permission_dup1", reply: "once" })
+        await promise
+
+        // Second reply to same ID should not throw
+        await PermissionNext.reply({ requestID: "permission_dup1", reply: "once" })
+      },
+    })
+  })
+})
+
+// ── Deduplication logic ─────────────────────────────────────────────────────
+// Tests the Set-based deduplication used in the Session component's
+// createEffect to prevent O(N²) duplicate replies.
+
+describe("auto mode deduplication", () => {
+  test("Set prevents duplicate replies", () => {
+    const replied = new Set<string>()
+    const calls: string[] = []
+
+    const permissions = [{ id: "perm_1" }, { id: "perm_2" }, { id: "perm_3" }]
+
+    // First pass: all should be processed
+    for (const request of permissions) {
+      if (replied.has(request.id)) continue
+      replied.add(request.id)
+      calls.push(request.id)
+    }
+
+    expect(calls).toEqual(["perm_1", "perm_2", "perm_3"])
+
+    // Second pass: none should be processed (already replied)
+    const calls2: string[] = []
+    for (const request of permissions) {
+      if (replied.has(request.id)) continue
+      replied.add(request.id)
+      calls2.push(request.id)
+    }
+
+    expect(calls2).toEqual([])
+  })
+
+  test("Set allows new permissions after initial drain", () => {
+    const replied = new Set<string>()
+    const calls: string[] = []
+
+    // Initial batch
+    const batch1 = [{ id: "perm_a" }, { id: "perm_b" }]
+    for (const request of batch1) {
+      if (replied.has(request.id)) continue
+      replied.add(request.id)
+      calls.push(request.id)
+    }
+
+    // New batch with one old and one new
+    const batch2 = [{ id: "perm_b" }, { id: "perm_c" }]
+    for (const request of batch2) {
+      if (replied.has(request.id)) continue
+      replied.add(request.id)
+      calls.push(request.id)
+    }
+
+    expect(calls).toEqual(["perm_a", "perm_b", "perm_c"])
+  })
+})


### PR DESCRIPTION
## Summary

- Adds auto mode to the interactive TUI, allowing all permission requests to be auto-approved without prompting
- Activatable via `kilo --auto` CLI flag, `/auto` slash command, or `ctrl+shift+a` keybind
- Persistent warning banner below the chat textbox when active
- Non-persisted — resets on TUI restart for safety

## How it works

**Dual-layer auto-approval architecture:**

1. **SyncProvider intercept** — When a `permission.asked` SSE event arrives while auto mode is on, it immediately replies `"once"` and skips adding the permission to the reactive store. This eliminates the race condition where permissions arrive before the Session component mounts.

2. **Session effect fallback** — A `createEffect` in the Session component drains any permissions already in the store when auto mode is toggled on mid-session. Uses a `Set<string>` to prevent duplicate replies.

Both layers use `reply: "once"` (not `"always"`) so no persistent allow rules are created that survive toggling auto mode off.

## Activation methods

| Method | Usage |
|---|---|
| CLI flag | `kilo --auto` |
| Slash command | `/auto` in the prompt |
| Keybind | `ctrl+shift+a` (configurable via `keybinds.auto_toggle`) |
| Command palette | `ctrl+p` → "Enable auto mode" |

## UI

- Warning-colored banner below the chat textbox: `△ Auto mode — permissions are auto-approved  (ctrl+shift+a to toggle)`
- Startup toast when `--auto` flag is used
- Prompt remains visible and enabled during auto-approval (no flicker)
<img width="872" height="492" alt="image" src="https://github.com/user-attachments/assets/d9210f4d-1185-4140-9b54-36be0697c0c9" />
<img width="739" height="189" alt="image" src="https://github.com/user-attachments/assets/2e5dbdb0-4140-434f-8635-72bff33ba382" />
<img width="650" height="235" alt="image" src="https://github.com/user-attachments/assets/7f7c22b1-e525-42d8-b449-5bb228c87dca" />
<img width="639" height="220" alt="image" src="https://github.com/user-attachments/assets/63caf2da-887d-4339-b566-1027f1f5d5a6" />


## Files changed

| File | Change |
|---|---|
| `src/cli/cmd/tui/context/auto.tsx` | **New** — `AutoModeProvider` context with non-persisted signal |
| `src/cli/cmd/tui/thread.ts` | `--auto` CLI flag |
| `src/cli/cmd/tui/context/args.tsx` | `auto` field on `Args` interface |
| `src/cli/cmd/tui/app.tsx` | Provider tree, `/auto` command, startup toast |
| `src/cli/cmd/tui/context/sync.tsx` | Layer 1 — SSE event intercept |
| `src/cli/cmd/tui/routes/session/index.tsx` | Layer 2 — Session effect + Prompt visible/disabled fix |
| `src/cli/cmd/tui/component/prompt/index.tsx` | Persistent banner |
| `src/config/config.ts` | `auto_toggle` keybind (default `ctrl+shift+a`) |
| `test/kilocode/auto-mode.test.ts` | **New** — 14 tests covering context logic, permission reply semantics, deduplication, config schema, and edge cases |

## Test plan

- 14 tests, all passing (`bun test test/kilocode/auto-mode.test.ts`)
- Typecheck clean (`bun run typecheck`)
- Manually verified in TUI: flag, slash command, keybind, banner, toast