### PR TITLE
feat: support file autocomplete for paths outside project directory

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -1,5 +1,6 @@
 import type { BoxRenderable, TextareaRenderable, KeyEvent, ScrollBoxRenderable } from "@opentui/core"
 import { pathToFileURL } from "bun"
+import path from "path"
 import fuzzysort from "fuzzysort"
 import { firstBy } from "remeda"
 import { createMemo, createResource, createEffect, onMount, onCleanup, Index, Show, createSignal } from "solid-js"
@@ -248,7 +249,7 @@ export function Autocomplete(props: {
         options.push(
           ...sortedFiles.map((item): AutocompleteOption => {
             const baseDir = (sync.data.path.directory || process.cwd()).replace(/\/+$/, "")
-            const fullPath = `${baseDir}/${item}`
+            const fullPath = path.resolve(baseDir, item) // kilocode_change - use path.resolve for ../ paths
             const urlObj = pathToFileURL(fullPath)
             let filename = item
             if (lineRange && !item.endsWith("/")) {
@@ -382,6 +383,13 @@ export function Autocomplete(props: {
     }))
   })
 
+  // kilocode_change start - detect path navigation queries
+  const isPathNavigation = createMemo(() => {
+    const value = search()
+    return value.startsWith("../") || value === ".." || value.startsWith("/") || value.startsWith("~/")
+  })
+  // kilocode_change end
+
   const options = createMemo((prev: AutocompleteOption[] | undefined) => {
     const filesValue = files()
     const agentsValue = agents()
@@ -399,6 +407,13 @@ export function Autocomplete(props: {
     if (files.loading && prev && prev.length > 0) {
       return prev
     }
+
+    // kilocode_change start - skip client-side fuzzy filtering for path navigation queries
+    // The server already returns properly filtered directory listings for these
+    if (isPathNavigation()) {
+      return filesValue || []
+    }
+    // kilocode_change end
 
     const result = fuzzysort.go(removeLineRange(searchValue), mixed, {
       keys: [

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -604,11 +604,68 @@ export namespace File {
     })
   }
 
+  // kilocode_change start
+  function isPathNavigation(query: string): boolean {
+    return query.startsWith("../") || query === ".." || query.startsWith("/") || query.startsWith("~/")
+  }
+
+  async function browseDirectory(input: {
+    query: string
+    limit: number
+    kind: "file" | "directory" | "all"
+  }): Promise<string[]> {
+    const query = input.query
+    const resolved = query.startsWith("~/")
+      ? path.join(Global.Path.home, query.slice(2))
+      : path.resolve(Instance.directory, query)
+
+    // Determine the directory to list and the partial filename filter
+    const stat = await fs.promises.stat(resolved).catch(() => undefined)
+    const isDir = stat?.isDirectory()
+    const dir = isDir ? resolved : path.dirname(resolved)
+    const partial = isDir ? "" : path.basename(resolved).toLowerCase()
+
+    const entries = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => [])
+    const exclude = new Set([".git", ".DS_Store"])
+    const results: string[] = []
+
+    for (const entry of entries) {
+      if (exclude.has(entry.name)) continue
+      if (partial && !entry.name.toLowerCase().startsWith(partial)) continue
+      if (entry.name.startsWith(".") && !partial.startsWith(".")) continue
+
+      const isDirectory = entry.isDirectory()
+      if (input.kind === "file" && isDirectory) continue
+      if (input.kind === "directory" && !isDirectory) continue
+
+      const absolute = path.join(dir, entry.name)
+      const relative = path.relative(Instance.directory, absolute)
+      const display = isDirectory ? relative + "/" : relative
+      results.push(display)
+    }
+
+    results.sort((a, b) => {
+      const aDir = a.endsWith("/")
+      const bDir = b.endsWith("/")
+      if (aDir !== bDir) return aDir ? -1 : 1
+      return a.localeCompare(b)
+    })
+
+    return results.slice(0, input.limit)
+  }
+  // kilocode_change end
+
   export async function search(input: { query: string; limit?: number; dirs?: boolean; type?: "file" | "directory" }) {
     const query = input.query.trim()
     const limit = input.limit ?? 100
     const kind = input.type ?? (input.dirs === false ? "file" : "all")
     log.info("search", { query, kind })
+
+    // kilocode_change start - browse external directories when query is a path navigation
+    if (isPathNavigation(query)) {
+      return browseDirectory({ query, limit, kind })
+    }
+    // kilocode_change end
 
     const result = await state().then((x) => x.files())
 


### PR DESCRIPTION
## Context

When typing `@../path` in the CLI prompt to reference files outside the current project directory, the autocomplete showed "No matching items." This prevented users from easily attaching files from sibling repos, parent directories, or other locations on the filesystem using the `@` mention workflow.

## Implementation

The file autocomplete was restricted to project-internal files because it relied on a ripgrep-indexed cache built from `Instance.directory`. Paths with `../`, `/`, or `~/` prefixes never existed in that cache.

**Server side (`packages/opencode/src/file/index.ts`):**
- Added `isPathNavigation()` to detect when a query uses `../`, `/`, or `~/` prefixes
- Added `browseDirectory()` which resolves the target path, performs `fs.readdir`, filters entries by any partial filename prefix typed so far, and returns results as relative paths from `Instance.directory` (which naturally include `../` components for external paths)
- Routes path navigation queries to `browseDirectory()` before the existing ripgrep-based fuzzy search

**Client side (`packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx`):**
- Changed `fullPath` construction from string concatenation to `path.resolve()` so `../` components resolve correctly to absolute paths for `file://` URLs
- Skips client-side fuzzysort filtering for path navigation queries since the server already returns properly filtered directory listings

No security changes — the file reading pipeline already handles external files via `bypassCwdCheck: true` for user-attached `@` mentions. This change only enables *discovery* in the autocomplete dropdown.

## Screenshots

| before | after |
| ------ | ----- |
| `@../` shows "No matching items" | `@../` lists files and directories in the parent directory |

## How to Test

1. Open `kilo` CLI in any project directory
2. In the prompt, type `@../` — you should see files and directories from the parent directory listed in the autocomplete dropdown
3. Continue typing to filter (e.g., `@../other-repo/`) — Tab on a directory to expand it
4. Select a file to attach it — verify it gets read correctly when the message is sent
5. Also test `@~/` to browse from home directory and `@/` for absolute paths
6. Verify that normal in-project `@` autocomplete (e.g., `@src/`) still works as before via fuzzy search