### PR TITLE
docs: improve release assets table and fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,13 @@ Download the latest binary or source code from the [Releases page](https://githu
 
 For most users:
 
-- **Windows (most PCs):** `kilo-windows-x64.zip`
-- **macOS Apple Silicon:** `kilo-darwin-arm64.zip`
-- **macOS Intel:** `kilo-darwin-x64.zip`
-- **Linux x64:** `kilo-linux-x64.tar,gz`
-- **Linux on ARM:** `kilo-linux-arm64.tar.gz`
+| OS | Architecture | Asset |
+|----|-------------|-------|
+| **Windows** (most PCs) | x64 | `kilo-windows-x64.zip` |
+| **macOS** Apple Silicon (M1/M2/M3/M4) | arm64 | `kilo-darwin-arm64.zip` |
+| **macOS** Intel | x64 | `kilo-darwin-x64.zip` |
+| **Linux** | x64 | `kilo-linux-x64.tar.gz` |
+| **Linux** ARM (Raspberry Pi, etc.) | arm64 | `kilo-linux-arm64.tar.gz` |
 
 ### Autonomous Mode (CI/CD)
 


### PR DESCRIPTION
## Summary

Improves the "Install from GitHub Releases" section (ref #6293):

1. **Replace plain list with a table** — easier to scan OS/architecture/asset at a glance
2. **Fix typo** — `tar,gz` → `tar.gz` for Linux x64 download link
3. **Add Architecture column** — makes it explicit which CPU arch each asset targets
4. **Add Apple Silicon model names** — `M1/M2/M3/M4` for users unfamiliar with `arm64`

### Before
```
- **Windows (most PCs):** `kilo-windows-x64.zip`
- **macOS Apple Silicon:** `kilo-darwin-arm64.zip`
- **Linux x64:** `kilo-linux-x64.tar,gz`  ← typo
```

### After
| OS | Architecture | Asset |
|----|-------------|-------|
| **Windows** (most PCs) | x64 | `kilo-windows-x64.zip` |
| **macOS** Apple Silicon (M1/M2/M3/M4) | arm64 | `kilo-darwin-arm64.zip` |
| **Linux** | x64 | `kilo-linux-x64.tar.gz` |
| ... | ... | ... |