### PR TITLE
fix: Refactor autocomplete status bar into shared Kilo status bar service

### DIFF
--- a/packages/kilo-vscode/src/services/autocomplete/AutocompleteStatusBar.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/AutocompleteStatusBar.ts
@@ -1,25 +1,28 @@
 import * as vscode from "vscode"
+import { StatusBar } from "../statusbar"
+import { formatTime } from "../statusbar/utils"
 import { t } from "./shims/i18n"
+import { humanFormatSessionCost } from "./statusbar-utils"
 import type { AutocompleteStatusBarStateProps } from "./types"
-import { humanFormatSessionCost, formatTime } from "./statusbar-utils"
 
 const SUPPORTED_PROVIDER_DISPLAY_NAME = "Kilo Gateway"
 
 export class AutocompleteStatusBar {
-  statusBar: vscode.StatusBarItem
+  private readonly bar: StatusBar
   private props: AutocompleteStatusBarStateProps
 
   constructor(params: AutocompleteStatusBarStateProps) {
-    this.statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100)
+    this.bar = new StatusBar(vscode.StatusBarAlignment.Right, 100)
     this.props = params
-
     this.init()
   }
 
   private init() {
-    this.statusBar.text = t("kilocode:autocomplete.statusBar.enabled")
-    this.statusBar.tooltip = this.createMarkdownTooltip(t("kilocode:autocomplete.statusBar.tooltip.basic"))
-    this.statusBar.show()
+    this.bar.update(
+      t("kilocode:autocomplete.statusBar.enabled"),
+      this.createMarkdownTooltip(t("kilocode:autocomplete.statusBar.tooltip.basic")),
+      true,
+    )
   }
 
   private createMarkdownTooltip(text: string): vscode.MarkdownString {
@@ -28,81 +31,51 @@ export class AutocompleteStatusBar {
     return markdown
   }
 
-  private updateVisible() {
-    if (this.props.enabled) {
-      this.statusBar.show()
-    } else {
-      this.statusBar.hide()
-    }
-  }
-
   public dispose() {
-    this.statusBar.dispose()
-  }
-
-  private humanFormatSessionCost(): string {
-    return humanFormatSessionCost(this.props.totalSessionCost)
+    this.bar.dispose()
   }
 
   public update(params: Partial<AutocompleteStatusBarStateProps>) {
     this.props = { ...this.props, ...params }
+    this.bar.update(this.getText(), this.createMarkdownTooltip(this.getTooltip()), this.props.enabled ?? false)
+  }
 
-    this.updateVisible()
-    if (this.props.enabled) {
-      this.render()
+  private getText(): string {
+    if (this.props.hasKilocodeProfileWithNoBalance || this.props.hasNoUsableProvider) {
+      return t("kilocode:autocomplete.statusBar.warning")
     }
-  }
-
-  private formatTime(timestamp: number): string {
-    return formatTime(timestamp)
-  }
-
-  private renderDefault() {
-    const sessionStartTime = this.formatTime(this.props.sessionStartTime)
-    const now = this.formatTime(Date.now())
-
     const snoozedSuffix = this.props.snoozed ? ` (${t("kilocode:autocomplete.statusBar.snoozed")})` : ""
-    this.statusBar.text = `${t("kilocode:autocomplete.statusBar.enabled")} (${this.props.completionCount})${snoozedSuffix}`
-
-    this.statusBar.tooltip = this.createMarkdownTooltip(
-      [
-        t("kilocode:autocomplete.statusBar.tooltip.completionSummary", {
-          count: this.props.completionCount,
-          startTime: sessionStartTime,
-          endTime: now,
-          cost: this.humanFormatSessionCost(),
-        }),
-        this.props.model && this.props.provider
-          ? t("kilocode:autocomplete.statusBar.tooltip.providerInfo", {
-              model: this.props.model,
-              provider: this.props.provider,
-            })
-          : undefined,
-      ]
-        .filter(Boolean)
-        .join("\n\n"),
-    )
+    return `${t("kilocode:autocomplete.statusBar.enabled")} (${this.props.completionCount})${snoozedSuffix}`
   }
 
-  public render() {
+  private getTooltip(): string {
     if (this.props.hasKilocodeProfileWithNoBalance) {
-      return this.renderNoCreditsError()
+      return t("kilocode:autocomplete.statusBar.tooltip.noCredits")
     }
     if (this.props.hasNoUsableProvider) {
-      return this.renderNoUsableProviderError()
+      return t("kilocode:autocomplete.statusBar.tooltip.noUsableProvider", {
+        providers: SUPPORTED_PROVIDER_DISPLAY_NAME,
+      })
     }
-    return this.renderDefault()
+    const sessionStartTime = formatTime(this.props.sessionStartTime)
+    const now = formatTime(Date.now())
+    const parts = [
+      t("kilocode:autocomplete.statusBar.tooltip.completionSummary", {
+        count: this.props.completionCount,
+        startTime: sessionStartTime,
+        endTime: now,
+        cost: humanFormatSessionCost(this.props.totalSessionCost),
+      }),
+    ]
+    if (this.props.model && this.props.provider) {
+      parts.push(
+        t("kilocode:autocomplete.statusBar.tooltip.providerInfo", {
+          model: this.props.model,
+          provider: this.props.provider,
+        }),
+      )
+    }
+    return parts.join("\n\n")
   }
 
-  private renderNoCreditsError() {
-    this.statusBar.text = t("kilocode:autocomplete.statusBar.warning")
-    this.statusBar.tooltip = this.createMarkdownTooltip(t("kilocode:autocomplete.statusBar.tooltip.noCredits"))
-  }
-
-  private renderNoUsableProviderError() {
-    this.statusBar.text = t("kilocode:autocomplete.statusBar.warning")
-    this.statusBar.tooltip = this.createMarkdownTooltip(
-      t("kilocode:autocomplete.statusBar.tooltip.noUsableProvider", { providers: SUPPORTED_PROVIDER_DISPLAY_NAME }),
-    )
-  }
 }

--- a/packages/kilo-vscode/src/services/autocomplete/statusbar-utils.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/statusbar-utils.ts
@@ -1,11 +1,5 @@
 import { t } from "./shims/i18n"
 
-/**
- * Format a session cost value to a human-readable string.
- * - $0 → translated zero string
- * - $0.001 → translated "less than a cent"
- * - $0.12 → "$0.12"
- */
 export function humanFormatSessionCost(cost: number): string {
   if (cost === 0) {
     return t("kilocode:autocomplete.statusBar.cost.zero")
@@ -14,11 +8,4 @@ export function humanFormatSessionCost(cost: number): string {
     return t("kilocode:autocomplete.statusBar.cost.lessThanCent")
   }
   return `$${cost.toFixed(2)}`
-}
-
-/**
- * Format a Unix timestamp (ms) as a locale time string.
- */
-export function formatTime(timestamp: number): string {
-  return new Date(timestamp).toLocaleTimeString()
 }

--- a/packages/kilo-vscode/src/services/statusbar/StatusBar.ts
+++ b/packages/kilo-vscode/src/services/statusbar/StatusBar.ts
@@ -1,0 +1,23 @@
+import * as vscode from "vscode"
+
+export class StatusBar {
+  private readonly item: vscode.StatusBarItem
+
+  constructor(alignment: vscode.StatusBarAlignment = vscode.StatusBarAlignment.Right, priority = 100) {
+    this.item = vscode.window.createStatusBarItem(alignment, priority)
+  }
+
+  update(text: string, tooltip: string | vscode.MarkdownString, visible: boolean): void {
+    this.item.text = text
+    this.item.tooltip = tooltip
+    if (visible) {
+      this.item.show()
+    } else {
+      this.item.hide()
+    }
+  }
+
+  dispose(): void {
+    this.item.dispose()
+  }
+}

--- a/packages/kilo-vscode/src/services/statusbar/index.ts
+++ b/packages/kilo-vscode/src/services/statusbar/index.ts
@@ -1,0 +1,2 @@
+export { StatusBar } from "./StatusBar"
+export { formatTime } from "./utils"

--- a/packages/kilo-vscode/src/services/statusbar/utils.ts
+++ b/packages/kilo-vscode/src/services/statusbar/utils.ts
@@ -1,0 +1,3 @@
+export function formatTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString()
+}

--- a/packages/kilo-vscode/tests/unit/autocomplete-statusbar-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/autocomplete-statusbar-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test"
-import { humanFormatSessionCost, formatTime } from "../../src/services/autocomplete/statusbar-utils"
+import { humanFormatSessionCost } from "../../src/services/autocomplete/statusbar-utils"
+import { formatTime } from "../../src/services/statusbar/utils"
 
 describe("humanFormatSessionCost", () => {
   it("returns '$0.00' for 0 cost", () => {


### PR DESCRIPTION
fix : #6795

### Context

- Status bar logic was tied to autocomplete; now it’s a shared Kilo status bar service.

### Implementation

- Added generic StatusBar + formatTime in src/services/statusbar/.
- AutocompleteStatusBar now uses StatusBar; humanFormatSessionCost stays in autocomplete.

### Screenshots

- before : autocomplete status bar
- after: same UI, now via shared service

### How to Test

- Enable autocomplete, type, and confirm status bar text + tooltip.
- Disable autocomplete and confirm status bar hides.
- Run bun test tests/unit/autocomplete-statusbar-utils.test.ts in packages/kilo-vscode.