### PR TITLE
CLI - Add --cloud-fork option to import cloud sessions locally

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -27,6 +27,7 @@ import { SkillTool } from "../../tool/skill"
 import { BashTool } from "../../tool/bash"
 import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "../../util/locale"
+import { importCloudSession, validateCloudFork } from "@/kilocode/cloud-session" // kilocode_change
 
 type ToolProps<T extends Tool.Info> = {
   input: Tool.InferParameters<T>
@@ -248,6 +249,10 @@ export const RunCommand = cmd({
           describe: "fork the session before continuing (requires --continue or --session)",
           type: "boolean",
         })
+        .option("cloud-fork", {
+          describe: "fetch session from cloud and continue locally (requires --session)",
+          type: "boolean",
+        })
         .option("share", {
           type: "boolean",
           describe: "share the session",
@@ -357,6 +362,13 @@ export const RunCommand = cmd({
       UI.error("--fork requires --continue or --session")
       process.exit(1)
     }
+    // kilocode_change start
+    const cloudForkError = validateCloudFork(args)
+    if (cloudForkError) {
+      UI.error(cloudForkError)
+      process.exit(1)
+    }
+    // kilocode_change end
 
     const rules: PermissionNext.Ruleset = [
       {
@@ -384,6 +396,17 @@ export const RunCommand = cmd({
 
     async function session(sdk: KiloClient) {
       const baseID = args.continue ? (await sdk.session.list()).data?.find((s) => !s.parentID)?.id : args.session
+
+      // kilocode_change start
+      if (baseID && args.cloudFork) {
+        const id = await importCloudSession(sdk, baseID).catch(() => undefined)
+        if (!id) {
+          UI.error("Failed to import session from cloud")
+          process.exit(1)
+        }
+        return id
+      }
+      // kilocode_change end
 
       if (baseID && args.fork) {
         const forked = await sdk.session.fork({ sessionID: baseID })

--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -5,6 +5,8 @@ import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
 import { TuiConfig } from "@/config/tui"
 import { Instance } from "@/project/instance"
 import { existsSync } from "fs"
+import { createKiloClient } from "@kilocode/sdk/v2" // kilocode_change
+import { importCloudSession, validateCloudFork } from "@/kilocode/cloud-session" // kilocode_change
 
 export const AttachCommand = cmd({
   command: "attach <url>",
@@ -34,6 +36,10 @@ export const AttachCommand = cmd({
         type: "boolean",
         describe: "fork the session when continuing (use with --continue or --session)",
       })
+      .option("cloud-fork", {
+        type: "boolean",
+        describe: "fetch session from cloud and continue locally (use with --session)",
+      })
       .option("password", {
         alias: ["p"],
         type: "string",
@@ -49,6 +55,15 @@ export const AttachCommand = cmd({
         process.exitCode = 1
         return
       }
+
+      // kilocode_change start
+      const cloudForkError = validateCloudFork(args)
+      if (cloudForkError) {
+        UI.error(cloudForkError)
+        process.exitCode = 1
+        return
+      }
+      // kilocode_change end
 
       const directory = (() => {
         if (!args.dir) return undefined
@@ -70,6 +85,24 @@ export const AttachCommand = cmd({
         directory: directory && existsSync(directory) ? directory : process.cwd(),
         fn: () => TuiConfig.get(),
       })
+      // kilocode_change start - import cloud session before TUI renders
+      if (args.cloudFork && args.session) {
+        UI.println("Importing session from cloud...")
+        const sdk = createKiloClient({
+          baseUrl: args.url,
+          directory,
+          headers,
+        })
+        const id = await importCloudSession(sdk, args.session).catch(() => undefined)
+        if (!id) {
+          UI.error("Failed to import session from cloud")
+          process.exitCode = 1
+          return
+        }
+        args.session = id
+        args.cloudFork = false
+      }
+      // kilocode_change end
       await tui({
         url: args.url,
         config,

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -10,10 +10,12 @@ import { Log } from "@/util/log"
 import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
 import { Filesystem } from "@/util/filesystem"
 import type { Event } from "@kilocode/sdk/v2"
+import { createKiloClient } from "@kilocode/sdk/v2" // kilocode_change
 import type { EventSource } from "./context/sdk"
 import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
 import { TuiConfig } from "@/config/tui"
 import { Instance } from "@/project/instance"
+import { importCloudSession, validateCloudFork } from "@/kilocode/cloud-session" // kilocode_change
 
 declare global {
   const KILO_WORKER_PATH: string // kilocode_change
@@ -73,6 +75,10 @@ export const TuiThreadCommand = cmd({
         type: "boolean",
         describe: "fork the session when continuing (use with --continue or --session)",
       })
+      .option("cloud-fork", {
+        type: "boolean",
+        describe: "fetch session from cloud and continue locally (use with --session)",
+      })
       .option("prompt", {
         type: "string",
         describe: "prompt to use",
@@ -99,6 +105,14 @@ export const TuiThreadCommand = cmd({
         process.exitCode = 1
         return
       }
+      // kilocode_change start
+      const cloudForkError = validateCloudFork(args)
+      if (cloudForkError) {
+        UI.error(cloudForkError)
+        process.exitCode = 1
+        return
+      }
+      // kilocode_change end
 
       // Resolve relative paths against PWD to preserve behavior when using --cwd flag
       const baseCwd = process.env.PWD ?? process.cwd()
@@ -264,6 +278,25 @@ export const TuiThreadCommand = cmd({
         customFetch = createWorkerFetch(client)
         events = createEventSource(client)
       }
+
+      // kilocode_change start - import cloud session before TUI renders
+      if (args.cloudFork && args.session) {
+        UI.println("Importing session from cloud...")
+        const sdk = createKiloClient({
+          baseUrl: url,
+          fetch: customFetch,
+          directory: cwd,
+        })
+        const id = await importCloudSession(sdk, args.session).catch(() => undefined)
+        if (!id) {
+          UI.error("Failed to import session from cloud")
+          shutdownAndExit({ reason: "cloud-fork-failed", code: 1 })
+          return
+        }
+        args.session = id
+        args.cloudFork = false
+      }
+      // kilocode_change end
 
       const tuiPromise = tui({
         url,

--- a/packages/opencode/src/kilocode/cloud-session.ts
+++ b/packages/opencode/src/kilocode/cloud-session.ts
@@ -1,0 +1,36 @@
+/**
+ * Validate --cloud-fork flag combinations and return an error message if invalid.
+ */
+export function validateCloudFork(args: {
+  cloudFork?: boolean
+  fork?: boolean
+  continue?: boolean
+  session?: string
+}): string | undefined {
+  if (!args.cloudFork) return
+  if (args.fork) return "--cloud-fork cannot be used with --fork"
+  if (args.continue) return "--cloud-fork cannot be used with --continue"
+  if (!args.session) return "--cloud-fork requires --session"
+}
+
+/**
+ * Import a cloud session to local storage and return the new local session ID.
+ * Wraps the SDK's `.kilo.cloud.session.import()` which returns `unknown` due to
+ * the OpenAPI spec not typing the response.
+ */
+export async function importCloudSession(
+  client: {
+    kilo: {
+      cloud: {
+        session: {
+          import: (params: { sessionId: string }) => Promise<{ data?: unknown }>
+        }
+      }
+    }
+  },
+  sessionId: string,
+): Promise<string | undefined> {
+  const result = await client.kilo.cloud.session.import({ sessionId })
+  const id = (result.data as Record<string, unknown>)?.id
+  return typeof id === "string" ? id : undefined
+}


### PR DESCRIPTION
## Summary
- Add `--cloud-fork` CLI flag to `run`, `attach`, and `thread` commands that fetches a session from the cloud and imports it to local storage before continuing
- Extract shared `validateCloudFork` helper in `cloud-session.ts` to deduplicate flag validation across all three entry points
- Fix graceful exit handling in `attach.ts` and `thread.ts` to ensure proper cleanup (Win32 guard / worker termination) on cloud-fork failure instead of calling `process.exit(1)` directly

## Usage
```
kilo run --cloud-fork --session <cloud-session-id> "continue working on this"
kilo --cloud-fork --session <cloud-session-id>
kilo attach <url> --cloud-fork --session <cloud-session-id>
```

Mutually exclusive with `--fork` and `--continue`. Requires `--session`.