### PR TITLE
fix: remove unused eslint-disable and use strict equality in kilo-vscode

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -55,7 +55,6 @@ interface AssistantMessageProps {
 
 function TodoToolCard(props: { part: ToolPart }) {
   const render = ToolRegistry.render(props.part.tool)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const state = props.part.state as any
   return (
     <Show when={render}>

--- a/packages/kilo-vscode/webview-ui/src/components/settings/SettingsRow.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/SettingsRow.tsx
@@ -9,14 +9,19 @@ const SettingsRow: Component<{ title: string; description?: string; last?: boole
       "margin-bottom": props.last ? "0" : "8px",
       "padding-bottom": props.last ? "0" : "8px",
       "border-bottom": props.last ? "none" : "1px solid var(--border-weak-base)",
-      ...(props.description == null ? { "align-items": "center" } : {}),
+      ...(props.description === null || props.description === undefined ? { "align-items": "center" } : {}),
     }}
   >
     <div data-slot="settings-row-label">
-      <div data-slot="settings-row-label-title" style={props.description == null ? { "margin-bottom": "0" } : {}}>
+      <div
+        data-slot="settings-row-label-title"
+        style={props.description === null || props.description === undefined ? { "margin-bottom": "0" } : {}}
+      >
         {props.title}
       </div>
-      {props.description != null && <div data-slot="settings-row-label-subtitle">{props.description}</div>}
+      {props.description !== null && props.description !== undefined && (
+        <div data-slot="settings-row-label-subtitle">{props.description}</div>
+      )}
     </div>
     <div data-slot="settings-row-input">{props.children}</div>
   </div>


### PR DESCRIPTION
Fixes 4 ESLint warnings in the kilo-vscode package:

- Remove unused `eslint-disable-next-line @typescript-eslint/no-explicit-any` comment in `AssistantMessage.tsx`
- Replace `==` and `!=` with `===` and `!==` in `SettingsRow.tsx`