### PR TITLE
fix: vscode tsconfig DOM lib + install-dev-extension insiders detection

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -114,7 +114,10 @@
         "clear": false
       },
       "options": {
-        "cwd": "${workspaceFolder}/packages/kilo-vscode"
+        "cwd": "${workspaceFolder}/packages/kilo-vscode",
+        "env": {
+          "VSCODE_EXEC_PATH": "${execPath}"
+        }
       },
       "problemMatcher": []
     }

--- a/packages/kilo-vscode/script/install-dev-extension.ts
+++ b/packages/kilo-vscode/script/install-dev-extension.ts
@@ -31,4 +31,5 @@ try {
 const vsix = (await $`ls -1v ${outDir}/*.vsix`.text()).trim().split("\n").at(-1)!
 const ipc = process.env.VSCODE_IPC_HOOK ?? ""
 const cli = ipc.includes("Insiders") ? "code-insiders" : "code"
+console.log(`Installing into: ${cli} (VSCODE_IPC_HOOK=${ipc || "<not set>"})`)
 await $`${cli} --force --install-extension ${vsix}`

--- a/packages/kilo-vscode/script/install-dev-extension.ts
+++ b/packages/kilo-vscode/script/install-dev-extension.ts
@@ -29,4 +29,5 @@ try {
 }
 
 const vsix = (await $`ls -1v ${outDir}/*.vsix`.text()).trim().split("\n").at(-1)!
-await $`code --force --install-extension ${vsix}`
+const codeCmd = (await $`which code-insiders`.nothrow().text()).trim() ? "code-insiders" : "code"
+await $`${codeCmd} --force --install-extension ${vsix}`

--- a/packages/kilo-vscode/script/install-dev-extension.ts
+++ b/packages/kilo-vscode/script/install-dev-extension.ts
@@ -29,5 +29,6 @@ try {
 }
 
 const vsix = (await $`ls -1v ${outDir}/*.vsix`.text()).trim().split("\n").at(-1)!
-const codeCmd = (await $`which code-insiders`.nothrow().text()).trim() ? "code-insiders" : "code"
-await $`${codeCmd} --force --install-extension ${vsix}`
+const ipc = process.env.VSCODE_IPC_HOOK ?? ""
+const cli = ipc.includes("Insiders") ? "code-insiders" : "code"
+await $`${cli} --force --install-extension ${vsix}`

--- a/packages/kilo-vscode/script/install-dev-extension.ts
+++ b/packages/kilo-vscode/script/install-dev-extension.ts
@@ -29,7 +29,7 @@ try {
 }
 
 const vsix = (await $`ls -1v ${outDir}/*.vsix`.text()).trim().split("\n").at(-1)!
-const ipc = process.env.VSCODE_IPC_HOOK ?? ""
-const cli = ipc.includes("Insiders") ? "code-insiders" : "code"
-console.log(`Installing into: ${cli} (VSCODE_IPC_HOOK=${ipc || "<not set>"})`)
+const execPath = process.env.VSCODE_EXEC_PATH ?? ""
+const cli = execPath.toLowerCase().includes("insiders") ? "code-insiders" : "code"
+console.log(`Installing into: ${cli} (VSCODE_EXEC_PATH=${execPath || "<not set>"})`)
 await $`${cli} --force --install-extension ${vsix}`

--- a/packages/kilo-vscode/tsconfig.json
+++ b/packages/kilo-vscode/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */,


### PR DESCRIPTION
## Summary

- Adds `"DOM"` to the `lib` array in `packages/kilo-vscode/tsconfig.json` to fix `TS2304: Cannot find name 'HeadersInit'` error caused by the generated SDK types referencing the DOM global `HeadersInit`
- Fixes `install-dev-extension.ts` to detect `code-insiders` and use it instead of `code`, so the dev extension installs into the correct VS Code variant
