### PR TITLE
Update to beta blog post link on migration screen to beta blog post

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -527,7 +527,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
           </div>
 
           <div class="migration-wizard__blog-link">
-            <a href="https://blog.kilo.ai/p/kilo-cli">
+            <a href="https://blog.kilo.ai/we-completely-rebuilt-the-kilo-vs-code-extension">
               {language.t("migration.whatsNew.blogLink")} <span>&rarr;</span>
             </a>
           </div>


### PR DESCRIPTION
Updates the blog post link on the migration screen from the CLI blog to the beta blog post.