### PR TITLE
fix(vscode): implement mode switching from question tool options

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -51,6 +51,7 @@ interface AssistantMessageProps {
   message: SDKAssistantMessage
   showAssistantCopyPartID?: string | null
   turnDurationMs?: number
+  onModeAction?: (input: { mode: string; text: string; description?: string }) => void
 }
 
 function TodoToolCard(props: { part: ToolPart }) {
@@ -195,7 +196,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
         }}
       </For>
       <Show when={questionForMessage()} keyed>
-        {(req) => <QuestionDock request={req} />}
+        {(req) => <QuestionDock request={req} onModeAction={props.onModeAction} />}
       </Show>
     </>
   )

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -57,7 +57,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // Mode action: waits for session idle, switches agent, sends follow-up prompt
   let modeActionAbort: AbortController | undefined
 
-  const waitForIdle = (signal: AbortSignal) =>
+  const waitForIdle = (sessionID: string, signal: AbortSignal) =>
     new Promise<void>((resolve, reject) => {
       let settled = false
       const ref: { dispose?: () => void } = {}
@@ -76,7 +76,8 @@ export const ChatView: Component<ChatViewProps> = (props) => {
         ref.dispose = dispose
         signal.addEventListener("abort", () => settle(() => reject(new Error("Cancelled"))), { once: true })
         createEffect(() => {
-          if (session.status() !== "idle") return
+          const info = session.allStatusMap()[sessionID]
+          if (info && info.type !== "idle") return
           settle(() => resolve())
         })
       })
@@ -93,7 +94,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
     try {
       // Allow one microtask for session status to reflect the reply before checking idle
       await new Promise((r) => setTimeout(r, 0))
-      await waitForIdle(controller.signal)
+      await waitForIdle(sessionID, controller.signal)
     } catch {
       return
     }
@@ -105,7 +106,8 @@ export const ChatView: Component<ChatViewProps> = (props) => {
     if (id() !== sessionID) return
 
     session.selectAgent(input.mode)
-    session.sendMessage(input.description ?? input.text)
+    const sel = session.selected()
+    session.sendMessage(input.description ?? input.text, sel?.providerID, sel?.modelID)
   }
 
   onCleanup(() => modeActionAbort?.abort())

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -3,7 +3,7 @@
  * Main chat container that combines all chat components
  */
 
-import { Component, For, Show, createEffect, on, onCleanup, onMount } from "solid-js"
+import { Component, For, Show, createEffect, createRoot, on, onCleanup, onMount } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { BasicTool } from "@kilocode/kilo-ui/basic-tool"
@@ -54,6 +54,58 @@ export const ChatView: Component<ChatViewProps> = (props) => {
     }),
   )
 
+  // Mode action: waits for session idle, switches agent, sends follow-up prompt
+  let modeActionAbort: AbortController | undefined
+
+  const waitForIdle = (signal: AbortSignal) =>
+    new Promise<void>((resolve, reject) => {
+      let settled = false
+      const ref: { dispose?: () => void } = {}
+      const settle = (fn: () => void) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        ref.dispose?.()
+        fn()
+      }
+      const timeout = setTimeout(() => {
+        settle(() => reject(new Error("Timed out waiting for session idle")))
+      }, 30_000)
+
+      createRoot((dispose) => {
+        ref.dispose = dispose
+        signal.addEventListener("abort", () => settle(() => reject(new Error("Cancelled"))), { once: true })
+        createEffect(() => {
+          if (session.status() !== "idle") return
+          settle(() => resolve())
+        })
+      })
+    })
+
+  const handleModeAction = async (input: { mode: string; text: string; description?: string }) => {
+    const sessionID = id()
+    if (!sessionID) return
+
+    modeActionAbort?.abort()
+    const controller = new AbortController()
+    modeActionAbort = controller
+
+    try {
+      // Allow one microtask for session status to reflect the reply before checking idle
+      await new Promise((r) => setTimeout(r, 0))
+      await waitForIdle(controller.signal)
+    } catch {
+      return
+    }
+
+    if (controller.signal.aborted) return
+
+    session.selectAgent(input.mode)
+    session.sendMessage(input.description ?? input.text)
+  }
+
+  onCleanup(() => modeActionAbort?.abort())
+
   onMount(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === "Escape" && session.status() === "busy") {
@@ -76,14 +128,14 @@ export const ChatView: Component<ChatViewProps> = (props) => {
       <TaskHeader />
       <div class="chat-messages-wrapper">
         <div class="chat-messages">
-          <MessageList onSelectSession={props.onSelectSession} />
+          <MessageList onSelectSession={props.onSelectSession} onModeAction={handleModeAction} />
         </div>
       </div>
 
       <Show when={!props.readonly}>
         <div class="chat-input">
           <Show when={questionRequest()} keyed>
-            {(req) => <QuestionDock request={req} />}
+            {(req) => <QuestionDock request={req} onModeAction={handleModeAction} />}
           </Show>
           <Show when={permissionRequest()} keyed>
             {(perm) => (

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -100,6 +100,10 @@ export const ChatView: Component<ChatViewProps> = (props) => {
 
     if (controller.signal.aborted) return
 
+    // Guard against session switch during the wait — if the user navigated to a
+    // different session, don't apply the mode change to the wrong session
+    if (id() !== sessionID) return
+
     session.selectAgent(input.mode)
     session.sendMessage(input.description ?? input.text)
   }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -36,6 +36,7 @@ const KiloLogo = (): JSX.Element => {
 
 interface MessageListProps {
   onSelectSession?: (id: string) => void
+  onModeAction?: (input: { mode: string; text: string; description?: string }) => void
 }
 
 export const MessageList: Component<MessageListProps> = (props) => {
@@ -130,6 +131,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
                   sessionID={session.currentSessionID() ?? ""}
                   messageID={msg.id}
                   lastUserMessageID={lastUserMessageID()}
+                  onModeAction={props.onModeAction}
                 />
               )}
             </For>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -14,7 +14,10 @@ import { useLanguage } from "../../context/language"
 import type { QuestionRequest } from "../../types/messages"
 import { toggleAnswer } from "./question-dock-utils"
 
-export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => {
+export const QuestionDock: Component<{
+  request: QuestionRequest
+  onModeAction?: (input: { mode: string; text: string; description?: string }) => void
+}> = (props) => {
   const session = useSession()
   const language = useLanguage()
 
@@ -78,6 +81,9 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
   }
 
   const pick = (answer: string, custom = false) => {
+    // Find the option to check for mode (custom answers won't match)
+    const option = custom ? undefined : options().find((o) => o.label === answer)
+
     const answers = [...store.answers]
     answers[store.tab] = [answer]
     setStore("answers", answers)
@@ -86,6 +92,15 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
       const inputs = [...store.custom]
       inputs[store.tab] = answer
       setStore("custom", inputs)
+    }
+
+    // For single-question with a mode option, reply immediately and trigger mode switch
+    if (single() && !multi() && option?.mode && props.onModeAction) {
+      if (store.sending) return
+      setStore("sending", true)
+      session.replyToQuestion(props.request.id, [[answer]])
+      props.onModeAction({ mode: option.mode, text: answer, description: option.description })
+      return
     }
 
     if (!single() && !multi()) {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -109,10 +109,17 @@ export const QuestionDock: Component<{
       session.replyToQuestion(requestId, [[answer]])
 
       // Wait for the question to be resolved before triggering mode action
-      const timeout = setTimeout(() => controller.abort(), 30_000)
       const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), 30_000)
       createRoot((dispose) => {
-        controller.signal.addEventListener("abort", () => dispose(), { once: true })
+        controller.signal.addEventListener(
+          "abort",
+          () => {
+            dispose()
+            setStore("sending", false)
+          },
+          { once: true },
+        )
         createEffect(() => {
           const pending = session.questions().some((q) => q.id === requestId)
           if (pending) return

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -4,7 +4,7 @@
  * Uses kilo-ui's DockPrompt component for proper surface styling.
  */
 
-import { Component, For, Show, createMemo, createEffect } from "solid-js"
+import { Component, For, Show, createMemo, createEffect, createRoot } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Button } from "@kilocode/kilo-ui/button"
 import { DockPrompt } from "@kilocode/kilo-ui/dock-prompt"
@@ -94,12 +94,33 @@ export const QuestionDock: Component<{
       setStore("custom", inputs)
     }
 
-    // For single-question with a mode option, reply immediately and trigger mode switch
+    // For single-question with a mode option, reply and trigger mode switch only after the
+    // question is resolved (removed from the queue). This ensures the reply was actually
+    // processed before we attempt mode switching — replyToQuestion is fire-and-forget via
+    // postMessage, so we observe the question disappearing as confirmation.
     if (single() && !multi() && option?.mode && props.onModeAction) {
       if (store.sending) return
       setStore("sending", true)
-      session.replyToQuestion(props.request.id, [[answer]])
-      props.onModeAction({ mode: option.mode, text: answer, description: option.description })
+      const requestId = props.request.id
+      const action = props.onModeAction
+      const mode = option.mode
+      const description = option.description
+
+      session.replyToQuestion(requestId, [[answer]])
+
+      // Wait for the question to be resolved before triggering mode action
+      const timeout = setTimeout(() => controller.abort(), 30_000)
+      const controller = new AbortController()
+      createRoot((dispose) => {
+        controller.signal.addEventListener("abort", () => dispose(), { once: true })
+        createEffect(() => {
+          const pending = session.questions().some((q) => q.id === requestId)
+          if (pending) return
+          clearTimeout(timeout)
+          dispose()
+          action({ mode, text: answer, description })
+        })
+      })
       return
     }
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
@@ -46,6 +46,7 @@ interface VscodeSessionTurnProps {
   sessionID: string
   messageID: string
   lastUserMessageID?: string
+  onModeAction?: (input: { mode: string; text: string; description?: string }) => void
 }
 
 export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
@@ -179,6 +180,7 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
                     message={msg}
                     showAssistantCopyPartID={showAssistantCopyPartID()}
                     turnDurationMs={turnDurationMs()}
+                    onModeAction={props.onModeAction}
                   />
                 )}
               </For>

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -144,6 +144,7 @@ export interface TodoItem {
 export interface QuestionOption {
   label: string
   description: string
+  mode?: string
 }
 
 export interface QuestionInfo {


### PR DESCRIPTION
## Summary

- Implements mode switching support in the VS Code extension's QuestionDock when the agent asks a question with `mode` options (e.g., "Switch to Code mode?")
- Previously, selecting such an option just sent the answer back but never switched modes, causing the agent to halt since it couldn't use the tools needed in the current mode
- Adds `handleModeAction` to `ChatView` that waits for idle, switches the agent, and sends a follow-up prompt in the new mode — matching the existing web app behavior

## Root Cause Analysis

The bug was a **missing feature** in the VS Code extension. The web app (`packages/app/`) had full mode switching support via:
1. `onModeAction` prop on `SessionQuestionDock` 
2. `handleModeAction` in `session.tsx` that waits for idle → switches agent → sends follow-up prompt

The VS Code extension's `QuestionDock` had **none of this**:
- `QuestionOption` type was missing the `mode` field entirely
- `pick()` function only stored the label text, ignoring mode metadata
- No mechanism to switch agents and send a follow-up prompt after the mode switch

When the agent asked about mode switching, the user's "yes" answer was sent back, the agent continued in the old mode (e.g., Ask mode), couldn't use editing tools, and appeared to halt.

## Changes

| File | Change |
|---|---|
| `types/messages.ts` | Add `mode?: string` to `QuestionOption` |
| `QuestionDock.tsx` | Detect mode options in `pick()`, immediately reply + trigger mode action |
| `ChatView.tsx` | Add `handleModeAction` with `waitForIdle` → `selectAgent` → `sendMessage` flow |
| `MessageList.tsx` | Thread `onModeAction` prop for inline questions |
| `VscodeSessionTurn.tsx` | Thread `onModeAction` prop |
| `AssistantMessage.tsx` | Thread `onModeAction` prop to inline `QuestionDock` |

Built for [Mark](https://kilo-code.slack.com/archives/C0AFBRXUH2N/p1773139035657709?thread_ts=1772987070.925449&cid=C0AFBRXUH2N) by [Kilo for Slack](https://kilo.ai/features/slack-integration)
