### PR TITLE
fix: restore session hint in permission dock

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/bash-with-permission-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/bash-with-permission-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59b9045133b989b85e3748e4fe509b317e21761280f26b3ee46f837bccf3a1ad
-size 14489
+oid sha256:9aa50e2eda7e775b7f6915e4dff426453720dd92f42af81712add5c4127f2d95
+size 16206

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/glob-with-permission-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/glob-with-permission-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce43eb9d6415fdb082ff03ab15080219c6275f7ae1bd09689f7d020a5511347c
-size 15274
+oid sha256:6d0bb1c439f688ce46d15a4a6523657743bef2561185f3ab82c0f7968960e4f9
+size 16984

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/permission-dock-todo-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/permission-dock-todo-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f6fcd2e69976f2c9a02b24e721e96638ec20a6711d3853d0795e2913315ca0b5
-size 14341
+oid sha256:e9f8daeb67bd3d6eb5f7646645851891b43f8d0f5abda64ed50a2b87ecfa4bf6
+size 16053

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/permission-dock-write-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/permission-dock-write-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ed8885168e17a44fee3cd34e32143a6514fce09c3cd143dcf3be3088164d696
-size 16827
+oid sha256:7446506de4ab6cb9fe7e11d4a034c0d68d71d387d55e47279f232738e99b1d56
+size 18127

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/todo-write-with-permission-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/todo-write-with-permission-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26b18e59c4eccd851e4cb11f62f4b7b09e0fce56e9922b1ec51a94a4d9aeae67
-size 17664
+oid sha256:e88296dadefa48e508acee0212c0b9b8194e53a78726bb7a0eee60d991c61359
+size 18508

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -48,7 +48,7 @@ export const PermissionDock: Component<{
       }
       footer={
         <>
-          <div />
+          <p data-slot="permission-session-hint">{language.t("ui.permission.sessionHint")}</p>
           <div data-slot="permission-footer-actions">
             <Button variant="ghost" size="small" onClick={() => props.onDecide("reject")} disabled={props.responding}>
               {language.t("ui.permission.deny")}

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1136,6 +1136,15 @@
   [data-slot="permission-footer"] {
     padding: 8px;
     margin-top: 0;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  [data-slot="permission-session-hint"] {
+    font-size: 11px;
+    color: var(--text-weak, var(--vscode-descriptionForeground));
+    margin: 0;
+    padding: 0 4px;
   }
 
   [data-slot="permission-footer-actions"] > [data-component="button"][data-variant="primary"] {


### PR DESCRIPTION
## Summary

- Restore the session hint text in the permission dock footer: *"Allow always" applies to this session only. Use settings for global permissions.*
- This was lost during the permission dock refactor in #6868
