### PR TITLE
fix(vscode): default model to kilo-auto/free for anonymous users

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -610,7 +610,7 @@
         },
         "kilo-code.new.model.modelID": {
           "type": "string",
-          "default": "kilo-auto/frontier",
+          "default": "kilo-auto/free",
           "description": "Default model ID for new sessions"
         },
         "kilo-code.new.autocomplete.enableAutoTrigger": {

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1013,7 +1013,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       const config = vscode.workspace.getConfiguration("kilo-code.new.model")
       const providerID = config.get<string>("providerID", "kilo")
-      const modelID = config.get<string>("modelID", "kilo-auto/frontier")
+      const modelID = config.get<string>("modelID", "kilo-auto/free")
 
       const message = {
         type: "providersLoaded",

--- a/packages/kilo-vscode/webview-ui/src/context/provider.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/provider.tsx
@@ -20,7 +20,7 @@ interface ProviderContextValue {
   findModel: (selection: ModelSelection | null) => EnrichedModel | undefined
 }
 
-const KILO_AUTO: ModelSelection = { providerID: "kilo", modelID: "kilo-auto/frontier" }
+const KILO_AUTO: ModelSelection = { providerID: "kilo", modelID: "kilo-auto/free" }
 
 export const ProviderContext = createContext<ProviderContextValue>()
 

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -250,7 +250,7 @@ export const SessionProvider: ParentComponent = (props) => {
   })
 
   // Global model selection per agent/mode
-  // Precedence: user override > per-mode config > global config model > VS Code default > kilo-auto/frontier
+  // Precedence: user override > per-mode config > global config model > VS Code default > kilo-auto/free
   const selected = createMemo<ModelSelection | null>(() => {
     const agentName = selectedAgentName()
     const override = store.modelSelections[agentName]


### PR DESCRIPTION
## Summary
- Change the hardcoded default model from `kilo-auto/frontier` to `kilo-auto/free` across the extension
- Anonymous users (not signed in) don't have access to `kilo-auto/frontier` (a paid model set), so the extension silently fails when they try to use it
- This ensures new installs work out of the box without requiring login

## Changes
| File | Change |
| --- | --- |
| `package.json` | VS Code setting default |
| `KiloProvider.ts` | `config.get` fallback |
| `provider.tsx` | `KILO_AUTO` initial constant |
| `session.tsx` | Comment update |

## Follow-up
A separate PR will add auth-aware switching so that signed-in users with credits automatically get `kilo-auto/frontier` as their default.