### PR TITLE
fix: scope question and permission list endpoints by sessionID

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -39,13 +39,12 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   const allPermissions = () => session.permissions()
   const allQuestions = () => session.questions()
 
-  // Bottom-dock permission: prefer current-session permissions,
-  // then fall back to any pending permission (including child sessions).
+  // Bottom-dock permission: prefer current-session non-tool questions/permissions,
+  // then fall back to current-session tool-scoped ones. Never show prompts from
+  // other sessions — that would leak state across Agent Manager tabs.
   const questionRequest = () =>
-    allQuestions().find((q) => q.sessionID === id() && !q.tool) ??
-    allQuestions().find((q) => !q.tool) ??
-    allQuestions()[0]
-  const permissionRequest = () => allPermissions().find((p) => p.sessionID === id()) ?? allPermissions()[0]
+    allQuestions().find((q) => q.sessionID === id() && !q.tool) ?? allQuestions().find((q) => q.sessionID === id())
+  const permissionRequest = () => allPermissions().find((p) => p.sessionID === id())
   const blocked = () => allPermissions().length > 0 || allQuestions().length > 0
 
   // When a bottom-dock permission/question disappears while the session is busy,

--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -279,8 +279,12 @@ export namespace PermissionNext {
     }
   }
 
-  export async function list() {
+  // kilocode_change start
+  export async function list(filter?: { sessionID?: string }) {
     const s = await state()
-    return Object.values(s.pending).map((x) => x.info)
+    const items = Object.values(s.pending).map((x) => x.info)
+    if (filter?.sessionID) return items.filter((x) => x.sessionID === filter.sessionID)
+    return items
   }
+  // kilocode_change end
 }

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -169,7 +169,12 @@ export namespace Question {
     }
   }
 
-  export async function list() {
-    return state().then((x) => Object.values(x.pending).map((x) => x.info))
+  // kilocode_change start
+  export async function list(filter?: { sessionID?: string }) {
+    const s = await state()
+    const items = Object.values(s.pending).map((x) => x.info)
+    if (filter?.sessionID) return items.filter((x) => x.sessionID === filter.sessionID)
+    return items
   }
+  // kilocode_change end
 }

--- a/packages/opencode/src/server/routes/permission.ts
+++ b/packages/opencode/src/server/routes/permission.ts
@@ -60,9 +60,18 @@ export const PermissionRoutes = lazy(() =>
           },
         },
       }),
+      // kilocode_change start
+      validator(
+        "query",
+        z.object({
+          sessionID: z.string().optional(),
+        }),
+      ),
       async (c) => {
-        const permissions = await PermissionNext.list()
+        const query = c.req.valid("query")
+        const permissions = await PermissionNext.list(query.sessionID ? { sessionID: query.sessionID } : undefined)
         return c.json(permissions)
       },
+      // kilocode_change end
     ),
 )

--- a/packages/opencode/src/server/routes/question.ts
+++ b/packages/opencode/src/server/routes/question.ts
@@ -25,10 +25,19 @@ export const QuestionRoutes = lazy(() =>
           },
         },
       }),
+      // kilocode_change start
+      validator(
+        "query",
+        z.object({
+          sessionID: z.string().optional(),
+        }),
+      ),
       async (c) => {
-        const questions = await Question.list()
+        const query = c.req.valid("query")
+        const questions = await Question.list(query.sessionID ? { sessionID: query.sessionID } : undefined)
         return c.json(questions)
       },
+      // kilocode_change end
     )
     .post(
       "/:requestID/reply",

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2091,10 +2091,21 @@ export class Permission extends HeyApiClient {
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
+      sessionID?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "sessionID" },
+          ],
+        },
+      ],
+    )
     return (options?.client ?? this.client).get<PermissionListResponses, unknown, ThrowOnError>({
       url: "/permission",
       ...options,
@@ -2112,10 +2123,21 @@ export class Question extends HeyApiClient {
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
+      sessionID?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "sessionID" },
+          ],
+        },
+      ],
+    )
     return (options?.client ?? this.client).get<QuestionListResponses, unknown, ThrowOnError>({
       url: "/question",
       ...options,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3706,6 +3706,7 @@ export type PermissionListData = {
   path?: never
   query?: {
     directory?: string
+    sessionID?: string
   }
   url: "/permission"
 }
@@ -3724,6 +3725,7 @@ export type QuestionListData = {
   path?: never
   query?: {
     directory?: string
+    sessionID?: string
   }
   url: "/question"
 }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -3660,6 +3660,13 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "sessionID",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "summary": "List pending permissions",
@@ -3694,6 +3701,13 @@
           {
             "in": "query",
             "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sessionID",
             "schema": {
               "type": "string"
             }
@@ -9839,7 +9853,14 @@
         "type": "object",
         "properties": {
           "model": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "variant": {
             "description": "Default model variant for this agent (applies only when using the agent's configured model).",
@@ -10400,11 +10421,25 @@
           },
           "model": {
             "description": "Model to use in the format of provider/model, eg anthropic/claude-2",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "small_model": {
             "description": "Small model to use for tasks like title generation in the format of provider/model",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "default_agent": {
             "description": "Default agent to use when none is specified. Must be a primary agent. Falls back to 'code' if not set or if the specified agent is invalid.",


### PR DESCRIPTION
## Summary

- Add optional `sessionID` filter to `Question.list()` and `PermissionNext.list()` so callers can request only pending items for a specific session
- Expose `sessionID` as a query parameter on `GET /question/` and `GET /permission/` server routes
- Remove cross-session fallback in `ChatView.tsx` that caused questions/permissions from one Agent Manager session to appear in another session's tab
- Regenerate SDK to include the new query parameters

## Problem

Questions and permissions were leaking between sessions within the Agent Manager. The root cause was two-fold:

1. **Backend**: `Question.list()` and `PermissionNext.list()` returned all pending items across all sessions for a project instance with no filtering capability
2. **Webview**: `ChatView.tsx` had a fallback chain (`allQuestions().find(q => !q.tool) ?? allQuestions()[0]`) that would show any session's question when the current session had none

## Testing

- Typecheck passes (`bun turbo typecheck`)
- The `sessionID` parameter is optional and backward-compatible — existing callers that don't pass it get the same behavior as before