### PR TITLE
fix(acp): use Kilo Code branding in auth methods and agent info

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -519,22 +519,23 @@ export namespace ACP {
     async initialize(params: InitializeRequest): Promise<InitializeResponse> {
       log.info("initialize", { protocolVersion: params.protocolVersion })
 
+      // kilocode_change start
       const authMethod: AuthMethod = {
-        description: "Run `opencode auth login` in the terminal",
-        name: "Login with opencode",
-        id: "opencode-login",
+        description: "Run `kilocode auth login` in the terminal",
+        name: "Login with Kilo Code",
+        id: "kilocode-login",
       }
 
-      // If client supports terminal-auth capability, use that instead.
       if (params.clientCapabilities?._meta?.["terminal-auth"] === true) {
         authMethod._meta = {
           "terminal-auth": {
-            command: "opencode",
+            command: "kilocode",
             args: ["auth", "login"],
-            label: "OpenCode Login",
+            label: "Kilo Code Login",
           },
         }
       }
+      // kilocode_change end
 
       return {
         protocolVersion: 1,
@@ -556,7 +557,7 @@ export namespace ACP {
         },
         authMethods: [authMethod],
         agentInfo: {
-          name: "OpenCode",
+          name: "Kilo Code", // kilocode_change
           version: Installation.VERSION,
         },
       }

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -529,7 +529,7 @@ export namespace ACP {
       if (params.clientCapabilities?._meta?.["terminal-auth"] === true) {
         authMethod._meta = {
           "terminal-auth": {
-            command: "kilocode",
+            command: "kilo",
             args: ["auth", "login"],
             label: "Kilo Code Login",
           },


### PR DESCRIPTION
## Summary
Replaces OpenCode branding with Kilo Code in ACP auth methods and agent info.

## Changes
- Auth description: use `kilocode auth login` instead of `opencode auth login`
- Auth method name: `Login with Kilo Code` instead of `Login with opencode`
- Auth method id: `kilocode-login` instead of `opencode-login`
- Terminal-auth command: `kilocode` instead of `opencode`
- Agent info name: `Kilo Code` instead of `OpenCode`

## Why
Fabriqa.ai settings showed OpenCode auth instructions instead of Kilo Code ones.

Fixes #6876