### PR TITLE
docs(kiloclaw): add model commands section to Control UI page

### DIFF
--- a/packages/kilo-docs/pages/kiloclaw/control-ui.md
+++ b/packages/kilo-docs/pages/kiloclaw/control-ui.md
@@ -27,6 +27,22 @@ For more details, please see the official [OpenClaw documentation](https://docs.
 Do not use the **Update** feature in the Control UI to update KiloClaw. Use **Redeploy** from the [KiloClaw Dashboard](/docs/kiloclaw/dashboard#redeploy) instead. Updating via the Control UI will not apply the correct KiloClaw platform image and may break your instance.
 {% /callout %}
 
+## Changing Models
+
+The Control UI Chat tab doubles as a command line for model management. KiloClaw exposes 335+ models through the `kilocode` provider â far more than the [dashboard dropdown](/docs/kiloclaw/dashboard#changing-the-model) â and you can browse and switch between them without leaving the chat.
+
+| Command                              | Description                                                                     |
+| ------------------------------------ | ------------------------------------------------------------------------------- |
+| `/model status`                      | View the currently active model and provider                                    |
+| `/models kilocode`                   | Browse available models (paginated, 20 per page)                                |
+| `/models kilocode <page>`            | Jump to a specific page (e.g. `/models kilocode 2`)                             |
+| `/model kilocode/<provider>/<model>` | Switch to a specific model (e.g. `/model kilocode/anthropic/claude-sonnet-4.6`) |
+| `/models kilocode all`               | List every available model at once                                              |
+
+Each `/models` response includes helper text at the bottom with shortcuts for switching, paging, and listing all models.
+
+{% image src="/docs/img/kiloclaw/control-ui-model-commands.png" alt="Control UI Chat showing model commands: /model status, /models kilocode with pagination, and /model switch" width="700" caption="Browsing and switching models in the Control UI Chat" /%}
+
 ## Authentication
 
 Auth is handled via token or password on the WebSocket handshake. Remote connections require one-time device pairing — the pairing request appears on the [KiloClaw Dashboard](/docs/kiloclaw/dashboard#pairing-requests) or in the Control UI itself.

--- a/packages/kilo-docs/pages/kiloclaw/control-ui.md
+++ b/packages/kilo-docs/pages/kiloclaw/control-ui.md
@@ -41,7 +41,7 @@ The Control UI Chat tab doubles as a command line for model management. KiloClaw
 
 Each `/models` response includes helper text at the bottom with shortcuts for switching, paging, and listing all models.
 
-Switching via `/model` applies to the **current session only** â other active sessions keep their own model. To change the default model for all new sessions, edit `agents.defaults.model.primary` in your `openclaw.json` via **Config** in the Control UI (or the [KiloClaw Dashboard](/docs/kiloclaw/dashboard#changing-the-model) for a quick dropdown pick).
+To change the default model for all new sessions, edit `agents.defaults.model.primary` in your `openclaw.json` via **Config** in the Control UI (or the [KiloClaw Dashboard](/docs/kiloclaw/dashboard#changing-the-model) for a quick dropdown pick).
 
 For the full list of providers, advanced configuration, and CLI commands, see the [OpenClaw Model Providers documentation](https://docs.openclaw.ai/providers).
 

--- a/packages/kilo-docs/pages/kiloclaw/control-ui.md
+++ b/packages/kilo-docs/pages/kiloclaw/control-ui.md
@@ -41,7 +41,9 @@ The Control UI Chat tab doubles as a command line for model management. KiloClaw
 
 Each `/models` response includes helper text at the bottom with shortcuts for switching, paging, and listing all models.
 
-{% image src="/docs/img/kiloclaw/control-ui-model-commands.png" alt="Control UI Chat showing model commands: /model status, /models kilocode with pagination, and /model switch" width="700" caption="Browsing and switching models in the Control UI Chat" /%}
+Switching via `/model` applies to the **current session only** â other active sessions keep their own model. To change the default model for all new sessions, edit `agents.defaults.model.primary` in your `openclaw.json` via **Config** in the Control UI (or the [KiloClaw Dashboard](/docs/kiloclaw/dashboard#changing-the-model) for a quick dropdown pick).
+
+For the full list of providers, advanced configuration, and CLI commands, see the [OpenClaw Model Providers documentation](https://docs.openclaw.ai/providers).
 
 ## Authentication
 

--- a/packages/kilo-docs/pages/kiloclaw/control-ui.md
+++ b/packages/kilo-docs/pages/kiloclaw/control-ui.md
@@ -29,7 +29,7 @@ Do not use the **Update** feature in the Control UI to update KiloClaw. Use **Re
 
 ## Changing Models
 
-The Control UI Chat tab doubles as a command line for model management. KiloClaw exposes 335+ models through the `kilocode` provider â far more than the [dashboard dropdown](/docs/kiloclaw/dashboard#changing-the-model) â and you can browse and switch between them without leaving the chat.
+The Control UI Chat tab doubles as a command line for model management. KiloClaw exposes 335+ models through the `kilocode` provider and you can browse and switch between them without leaving the chat.
 
 | Command                              | Description                                                                     |
 | ------------------------------------ | ------------------------------------------------------------------------------- |

--- a/packages/kilo-docs/pages/kiloclaw/dashboard.md
+++ b/packages/kilo-docs/pages/kiloclaw/dashboard.md
@@ -80,6 +80,8 @@ Gateway process info is only available when the machine is running.
 
 Select a model from the dropdown and click **Save & Provision**. The API key is platform-managed and refreshes automatically when you save — you never need to enter one. The key has a 30-day expiry.
 
+For access to the full catalog of 335+ models, use the `/model` and `/models` commands in the [Control UI Chat](/docs/kiloclaw/control-ui#changing-models).
+
 ### Channels
 
 You can connect Telegram, Discord, and Slack by entering bot tokens in the Settings tab. See [Connecting Chat Platforms](/docs/kiloclaw/chat-platforms) for setup instructions.


### PR DESCRIPTION
## Summary

- Add a **Changing Models** section to `control-ui.md` documenting the `/model` and `/models` slash commands for browsing and switching between 335+ models via the Control UI Chat
