### PR TITLE
fix: restore sessions after extension restart

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -318,6 +318,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           this.isWebviewReady = true
           await this.syncWebviewState("webviewReady")
           this.flushPendingReviewComments()
+          await this.handleLoadSessions()
           break
         case "sendMessage": {
           const files = z

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -371,6 +371,13 @@ export const SessionProvider: ParentComponent = (props) => {
 
   onCleanup(unsubVariants)
 
+ const unsubSessionsLoaded = vscode.onMessage((message: ExtensionMessage) => {
+    if (message.type !== "sessionsLoaded") return
+    handleSessionsLoaded(message.sessions)
+  })
+
+  onCleanup(unsubSessionsLoaded)
+
   // Handle messages from extension
   onMount(() => {
     const unsubscribe = vscode.onMessage((message: ExtensionMessage) => {
@@ -421,10 +428,6 @@ export const SessionProvider: ParentComponent = (props) => {
 
         case "questionError":
           handleQuestionError(message.requestID)
-          break
-
-        case "sessionsLoaded":
-          handleSessionsLoaded(message.sessions)
           break
 
         case "sessionUpdated":


### PR DESCRIPTION
fix  : #6867


### Problem
Sessions disappear after the extension restarts (e.g. updates or reloads).

### Solution
- Refresh sessions when `webviewReady` is received so the list is updated after the webview loads
- Subscribe to `sessionsLoaded` immediately (outside `onMount`) so it isn’t missed if it arrives before mount

### Changes
- `KiloProvider`: call `handleLoadSessions()` in the `webviewReady` handler
- `SessionProvider`: add early subscription for `sessionsLoaded`, remove it from the `onMount` switch