### PR TITLE
fix(agent-manager): resolveTrackingBranch queries passed branch instead of HEAD

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -88,9 +88,9 @@ export class GitOps {
     return "origin"
   }
 
-  /** Resolve the upstream tracking ref for `branch`, or `undefined` if none is set. Note: the `@{upstream}` check uses the current HEAD, not `branch`. */
+  /** Resolve the upstream tracking ref for `branch`, or `undefined` if none is set. */
   async resolveTrackingBranch(cwd: string, branch: string): Promise<string | undefined> {
-    const upstream = await this.raw(["rev-parse", "--abbrev-ref", "@{upstream}"], cwd).catch(() => "")
+    const upstream = await this.raw(["rev-parse", "--abbrev-ref", `${branch}@{upstream}`], cwd).catch(() => "")
     if (upstream) return upstream
 
     const remote = await this.resolveRemote(cwd, branch)

--- a/packages/kilo-vscode/tests/unit/git-ops.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-ops.test.ts
@@ -99,16 +99,32 @@ describe("GitOps", () => {
   describe("resolveTrackingBranch", () => {
     it("returns configured upstream", async () => {
       const git = ops(async (args) => {
-        if (args[0] === "rev-parse" && args[2] === "@{upstream}") return "origin/feature"
+        if (args[0] === "rev-parse" && args[2] === "feature@{upstream}") return "origin/feature"
         return ""
       })
       expect(await git.resolveTrackingBranch("/repo", "feature")).toBe("origin/feature")
     })
 
+    it("queries the passed branch, not HEAD", async () => {
+      // Regression: the old code used bare @{upstream} which resolves HEAD's upstream,
+      // not the upstream of the requested branch. This test ensures the branch parameter
+      // is included in the git rev-parse argument.
+      let capturedArg = ""
+      const git = ops(async (args) => {
+        if (args[0] === "rev-parse" && args[1] === "--abbrev-ref" && args[2]?.includes("@{upstream}")) {
+          capturedArg = args[2]
+          return "origin/other-branch"
+        }
+        return ""
+      })
+      await git.resolveTrackingBranch("/repo", "other-branch")
+      expect(capturedArg).toBe("other-branch@{upstream}")
+    })
+
     it("falls back to <remote>/<branch> when no upstream", async () => {
       const git = ops(async (args) => {
         // resolveTrackingBranch: no upstream
-        if (args[0] === "rev-parse" && args[1] === "--abbrev-ref" && args[2] === "@{upstream}")
+        if (args[0] === "rev-parse" && args[1] === "--abbrev-ref" && args[2] === "feature@{upstream}")
           throw new Error("no upstream")
         // resolveRemote: no upstream, config says "myfork"
         if (args[0] === "rev-parse" && args[3] === "@{upstream}") throw new Error("no upstream")
@@ -122,7 +138,7 @@ describe("GitOps", () => {
 
     it("falls back to origin/<branch> when no branch config", async () => {
       const git = ops(async (args) => {
-        if (args[0] === "rev-parse" && args[1] === "--abbrev-ref" && args[2] === "@{upstream}")
+        if (args[0] === "rev-parse" && args[1] === "--abbrev-ref" && args[2] === "feature@{upstream}")
           throw new Error("no upstream")
         if (args[0] === "rev-parse" && args[3] === "@{upstream}") throw new Error("no upstream")
         if (args[0] === "config") throw new Error("no config")


### PR DESCRIPTION
## Fix

`resolveTrackingBranch(cwd, branch)` accepted a `branch` parameter but used bare `@{upstream}` in the git rev-parse call. This resolves the upstream of whatever branch HEAD points to, not the requested `branch` parameter.

**Example:** If you're on `main` (tracking `origin/main`) and call `resolveTrackingBranch(cwd, 'feature')`, the old code returns `origin/main` instead of `origin/feature`.

**Fix:** Use `${branch}@{upstream}` so the correct branch's tracking ref is queried.

## Tests

- Added regression test `queries the passed branch, not HEAD` that captures the actual git argument and asserts it includes the branch name
- Updated existing mock matchers from `@{upstream}` to `feature@{upstream}`
- All 40 git-ops tests pass

Ref: #6684
cc @marius-kilocode