### PR TITLE
fix(ui): strip :line:col suffixes in extractFilePathFromHref

### DIFF
--- a/packages/ui/src/file-path.test.ts
+++ b/packages/ui/src/file-path.test.ts
@@ -208,6 +208,24 @@ describe("extractFilePathFromHref", () => {
     })
   })
 
+  describe("strips :line and :line:col suffixes", () => {
+    it("strips :line suffix", () => {
+      expect(extractFilePathFromHref("src/foo.ts:42")).toBe("src/foo.ts")
+    })
+
+    it("strips :line:col suffix", () => {
+      expect(extractFilePathFromHref("src/foo.ts:42:10")).toBe("src/foo.ts")
+    })
+
+    it("strips suffix from relative path", () => {
+      expect(extractFilePathFromHref("./utils/helper.js:100")).toBe("./utils/helper.js")
+    })
+
+    it("returns path without suffix unchanged", () => {
+      expect(extractFilePathFromHref("src/foo.ts")).toBe("src/foo.ts")
+    })
+  })
+
   describe("rejects anchors and non-file values", () => {
     it("pure anchor", () => {
       expect(extractFilePathFromHref("#section")).toBeUndefined()

--- a/packages/ui/src/file-path.ts
+++ b/packages/ui/src/file-path.ts
@@ -66,5 +66,8 @@ export function extractFilePathFromHref(href: string): string | undefined {
   if (!cleaned) return undefined
   // Must look like a file path (has a dot for extension)
   if (!cleaned.includes(".")) return undefined
-  return cleaned
+  // Strip :line and :line:col suffixes so they aren't treated as part of the filename.
+  // parseFilePath handles these correctly, so use it to extract just the path component.
+  const parsed = parseFilePath(cleaned)
+  return parsed ? parsed.path : cleaned
 }


### PR DESCRIPTION
## Fix

`extractFilePathFromHref('src/foo.ts:42')` returned `'src/foo.ts:42'` — the `:line:col` suffix was passed through as part of the filename. When this was used to open a file, the editor would try to open a file literally named `src/foo.ts:42`, which doesn't exist.

**Fix:** Use `parseFilePath()` (which already correctly handles `:line:col` suffixes) to extract just the path component before returning.

## Tests

- `strips :line suffix` — `src/foo.ts:42` → `src/foo.ts`
- `strips :line:col suffix` — `src/foo.ts:42:10` → `src/foo.ts`
- `strips suffix from relative path` — `./utils/helper.js:100` → `./utils/helper.js`
- `returns path without suffix unchanged` — existing behavior preserved

Note: there is a pre-existing test failure for `file:// URL` handling (the implementation extracts the path but the test expects `undefined`). This is unrelated to this change.

Ref: #6696
cc @marius-kilocode