### PR TITLE
Add Support for Enabled Providers (allow list)

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx
@@ -41,8 +41,10 @@ const ProvidersTab: Component = () => {
   )
 
   const [newDisabled, setNewDisabled] = createSignal<ProviderOption | undefined>()
+  const [newEnabled, setNewEnabled] = createSignal<ProviderOption | undefined>()
 
   const disabledProviders = () => config().disabled_providers ?? []
+  const enabledProviders = () => config().enabled_providers ?? []
 
   const addDisabled = (value: string) => {
     const current = [...disabledProviders()]
@@ -56,6 +58,20 @@ const ProvidersTab: Component = () => {
     const current = [...disabledProviders()]
     current.splice(index, 1)
     updateConfig({ disabled_providers: current })
+  }
+
+  const addEnabled = (value: string) => {
+    const current = [...enabledProviders()]
+    if (value && !current.includes(value)) {
+      current.push(value)
+      updateConfig({ enabled_providers: current })
+    }
+  }
+
+  const removeEnabled = (index: number) => {
+    const current = [...enabledProviders()]
+    current.splice(index, 1)
+    updateConfig({ enabled_providers: current })
   }
 
   function handleModelSelect(configKey: "model" | "small_model") {
@@ -128,6 +144,70 @@ const ProvidersTab: Component = () => {
                 clearLabel={language.t("settings.providers.notSet")}
               />
             </SettingsRow>
+          )}
+        </For>
+      </Card>
+
+      {/* Enabled providers (allowlist) */}
+      <h4 style={{ "margin-top": "16px", "margin-bottom": "8px" }}>{language.t("settings.providers.enabled")}</h4>
+      <Card>
+        <div
+          style={{
+            "font-size": "12px",
+            color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
+            "padding-bottom": "8px",
+            "border-bottom": "1px solid var(--border-weak-base)",
+          }}
+        >
+          {language.t("settings.providers.enabled.description")}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: "8px",
+            "align-items": "center",
+            padding: "8px 0",
+            "border-bottom": enabledProviders().length > 0 ? "1px solid var(--border-weak-base)" : "none",
+          }}
+        >
+          <div style={{ flex: 1 }}>
+            <Select
+              options={providerOptions().filter((o) => !enabledProviders().includes(o.value))}
+              current={newEnabled()}
+              value={(o) => o.value}
+              label={(o) => o.label}
+              onSelect={(o) => setNewEnabled(o)}
+              variant="secondary"
+              triggerVariant="settings"
+              placeholder="Select provider…"
+            />
+          </div>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              if (newEnabled()) {
+                addEnabled(newEnabled()!.value)
+                setNewEnabled(undefined)
+              }
+            }}
+          >
+            {language.t("common.add")}
+          </Button>
+        </div>
+        <For each={enabledProviders()}>
+          {(id, index) => (
+            <div
+              style={{
+                display: "flex",
+                "align-items": "center",
+                "justify-content": "space-between",
+                padding: "6px 0",
+                "border-bottom": index() < enabledProviders().length - 1 ? "1px solid var(--border-weak-base)" : "none",
+              }}
+            >
+              <span style={{ "font-size": "12px" }}>{id}</span>
+              <IconButton variant="ghost" icon="close" onClick={() => removeEnabled(index())} />
+            </div>
           )}
         </For>
       </Card>


### PR DESCRIPTION
# Context

The backend already supports both disabled_providers (denylist) and enabled_providers (allowlist) in the config. When enabled_providers is set, only the listed providers are loaded — all others are ignored. Despite being fully implemented in the backend, wired into the SDK types, and translated in all 16 locale files, there was no UI to view, add, or remove entries from enabled_providers. This PR closes that gap.

# Implementation

ProvidersTab.tsx already had a complete add/list/remove UI for disabled_providers. This PR mirrors that pattern exactly for enabled_providers:

* Added a newEnabled signal for the select input state
* Added enabledProviders() accessor reading config().enabled_providers ?? []
* Added addEnabled(value) and removeEnabled(index) handlers that call updateConfig({ enabled_providers: ... })
* Added a rendered card section (placed above the existing Disabled Providers card) with a description, provider select + Add button, and a list of current entries each with a remove button
* No backend, type, SDK, or i18n changes were required — everything was already in place.

# Screenshots 

<img width="587" height="217" alt="Screenshot 2026-03-10 at 1 35 42 PM" src="https://github.com/user-attachments/assets/3b6d0ddc-6e55-46e4-9294-682dfac749ad" />

# How to Test

1. Open the VS Code extension and navigate to Settings → Providers tab
2. Scroll to the new Enabled Providers (Allowlist) section
3. Select a provider from the dropdown (e.g. anthropic) and click Add — it should appear in the list
4. Click the × next to the entry to remove it
5. Add two providers to the allowlist, then open a new chat — only models from those providers should be available in the model selector
6. Confirm the existing Disabled Providers section below still works correctly and is unaffected

# Get in Touch

mcowger on Discord

