### PR TITLE
docs: add knip check to AGENTS.md build instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Kilo CLI is an open source AI coding agent that generates code from natural lang
 - **Test**: `bun test` from `packages/opencode/` (NOT from root -- root blocks tests)
 - **Single test**: `bun test test/tool/tool.test.ts` from `packages/opencode/`
 - **SDK regen**: After changing server endpoints in `packages/opencode/src/server/`, run `./script/generate.ts` from root to regenerate `packages/sdk/js/`
+- **Knip** (unused exports): `bun run knip` from `packages/kilo-vscode/`. CI runs this — all exported types/functions must be imported somewhere. Remove or unexport unused exports before pushing.
 
 ## Products
 


### PR DESCRIPTION
Adds the knip (unused exports) check to the Build and Dev section of AGENTS.md so agents know to run `bun run knip` from `packages/kilo-vscode/` before pushing. CI enforces this check.