### PR TITLE
fix(vscode): rewrite autoscroll to eliminate false-positive disengagement

### DIFF
--- a/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
@@ -1,12 +1,10 @@
 // kilocode_change - new file
-import { createEffect, on, onCleanup } from "solid-js"
+import { createEffect, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 
-const DEBOUNCE_MS = 100
-
 export interface AutoScrollOptions {
-  working: () => boolean
+  working?: () => boolean
   onUserInteracted?: () => void
   overflowAnchor?: "none" | "auto" | "dynamic"
   bottomThreshold?: number
@@ -14,12 +12,9 @@ export interface AutoScrollOptions {
 
 export function createAutoScroll(options: AutoScrollOptions) {
   let scroll: HTMLElement | undefined
-  let settling = false
-  let settleTimer: ReturnType<typeof setTimeout> | undefined
-  let autoTimer: ReturnType<typeof setTimeout> | undefined
-  let stopTimer: ReturnType<typeof setTimeout> | undefined
+  let programmatic = false
+  let raf: number | undefined
   let cleanup: (() => void) | undefined
-  let auto: { time: number } | undefined
 
   const threshold = () => options.bottomThreshold ?? 10
 
@@ -27,8 +22,6 @@ export function createAutoScroll(options: AutoScrollOptions) {
     contentRef: undefined as HTMLElement | undefined,
     userScrolled: false,
   })
-
-  const active = () => options.working() || settling
 
   const distanceFromBottom = (el: HTMLElement) => {
     return el.scrollHeight - el.clientHeight - el.scrollTop
@@ -38,36 +31,20 @@ export function createAutoScroll(options: AutoScrollOptions) {
     return el.scrollHeight - el.clientHeight > 1
   }
 
-  // Browsers can dispatch scroll events asynchronously. If new content arrives
-  // between us calling `scrollTo()` and the subsequent `scroll` event firing,
-  // the handler can see a non-zero `distanceFromBottom` and incorrectly assume
-  // the user scrolled.
-  const markAuto = (_el: HTMLElement) => {
-    auto = { time: Date.now() }
-
-    if (autoTimer) clearTimeout(autoTimer)
-    autoTimer = setTimeout(() => {
-      auto = undefined
-      autoTimer = undefined
-    }, 250)
-  }
-
-  const isAuto = (_el: HTMLElement) => {
-    const a = auto
-    if (!a) return false
-
-    if (Date.now() - a.time > 250) {
-      auto = undefined
-      return false
-    }
-
-    return true
-  }
-
   const scrollToBottomNow = (behavior: ScrollBehavior) => {
     const el = scroll
     if (!el) return
-    markAuto(el)
+    programmatic = true
+    if (raf) cancelAnimationFrame(raf)
+    // Clear after the browser has processed the scroll event.
+    // Double-rAF ensures the scroll event from our call has been dispatched
+    // before we clear the flag.
+    raf = requestAnimationFrame(() => {
+      raf = requestAnimationFrame(() => {
+        programmatic = false
+        raf = undefined
+      })
+    })
     if (behavior === "smooth") {
       el.scrollTo({ top: el.scrollHeight, behavior })
       return
@@ -78,7 +55,6 @@ export function createAutoScroll(options: AutoScrollOptions) {
   }
 
   const scrollToBottom = (force: boolean) => {
-    if (!force && !active()) return
     const el = scroll
     if (!el) return
 
@@ -107,7 +83,8 @@ export function createAutoScroll(options: AutoScrollOptions) {
   }
 
   const handleWheel = (e: WheelEvent) => {
-    if (e.deltaY >= 0) return
+    // Ignore tiny upward deltas from trackpad inertia / noise.
+    if (e.deltaY >= -2) return
     // If the user is scrolling within a nested scrollable region (tool output,
     // code block, etc), don't treat it as leaving the "follow bottom" mode.
     // Those regions opt in via `data-scrollable`.
@@ -133,26 +110,15 @@ export function createAutoScroll(options: AutoScrollOptions) {
     }
 
     // Ignore scroll events triggered by our own scrollToBottom calls.
-    if (!store.userScrolled && isAuto(el)) {
+    if (!store.userScrolled && programmatic) {
       scrollToBottom(false)
       return
     }
 
-    // Debounce to avoid layout-induced scroll shifts (e.g. images loading,
-    // virtual-list reflows) from incorrectly breaking auto-follow.
-    if (stopTimer) clearTimeout(stopTimer)
-    stopTimer = setTimeout(() => {
-      stopTimer = undefined
-      const cur = scroll
-      if (!cur) return
-      if (distanceFromBottom(cur) < threshold()) return
-      if (!store.userScrolled && isAuto(cur)) return
-      stop()
-    }, DEBOUNCE_MS)
+    stop()
   }
 
   const handleInteraction = () => {
-    if (!active()) return
     stop()
   }
 
@@ -180,31 +146,12 @@ export function createAutoScroll(options: AutoScrollOptions) {
         if (store.userScrolled) setStore("userScrolled", false)
         return
       }
-      if (!active()) return
       if (store.userScrolled) return
       // ResizeObserver fires after layout, before paint.
       // Keep the bottom locked in the same frame to avoid visible
       // "jump up then catch up" artifacts while streaming content.
       scrollToBottom(false)
     },
-  )
-
-  createEffect(
-    on(options.working, (working: boolean) => {
-      settling = false
-      if (settleTimer) clearTimeout(settleTimer)
-      settleTimer = undefined
-
-      if (working) {
-        scrollToBottom(true)
-        return
-      }
-
-      settling = true
-      settleTimer = setTimeout(() => {
-        settling = false
-      }, 300)
-    }),
   )
 
   createEffect(() => {
@@ -217,9 +164,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
   })
 
   onCleanup(() => {
-    if (settleTimer) clearTimeout(settleTimer)
-    if (autoTimer) clearTimeout(autoTimer)
-    if (stopTimer) clearTimeout(stopTimer)
+    if (raf) cancelAnimationFrame(raf)
     if (cleanup) cleanup()
   })
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -77,12 +77,12 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   const permissionRequest = () => scopedPermissions().find((p) => p.sessionID === id()) ?? scopedPermissions()[0]
   const blocked = () => scopedPermissions().length > 0 || scopedQuestions().length > 0
 
-  // When a bottom-dock permission/question disappears while the session is busy,
-  // the scroll container grows taller. Dispatch a custom event so MessageList can
-  // resume auto-scroll.
+  // When a bottom-dock permission/question disappears the scroll container grows
+  // taller. The content ref hasn't resized so ResizeObserver won't fire — dispatch
+  // a custom event so MessageList can resume auto-scroll.
   createEffect(
     on(blocked, (isBlocked, wasBlocked) => {
-      if (wasBlocked && !isBlocked && !idle()) {
+      if (wasBlocked && !isBlocked) {
         window.dispatchEvent(new CustomEvent("resumeAutoScroll"))
       }
     }),

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -46,7 +46,6 @@ export const MessageList: Component<MessageListProps> = (props) => {
   const dialog = useDialog()
 
   const autoScroll = createAutoScroll({
-    working: () => session.status() !== "idle",
     overflowAnchor: "dynamic",
   })
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -40,8 +40,6 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
 
   const childSessionId = () => props.metadata.sessionId as string | undefined
 
-  const running = createMemo(() => props.status === "pending" || props.status === "running")
-
   // Sync child session into store whenever we have a sessionId
   createEffect(() => {
     const id = childSessionId()
@@ -64,7 +62,6 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
   })
 
   const autoScroll = createAutoScroll({
-    working: running,
     overflowAnchor: "auto",
   })
 

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -885,11 +885,6 @@ export const SessionProvider: ParentComponent = (props) => {
       }
       setStore("messages", sid, (msgs = []) => [...msgs, temp])
       setStore("parts", tempId, [{ type: "text" as const, id: `${tempId}-text`, text }])
-      // The optimistic message is now in the DOM but the session status is
-      // still "idle" (the CLI backend hasn't started yet), so the auto-scroll
-      // ResizeObserver won't scroll on its own. Force scroll to bottom so the
-      // user's own message is immediately visible.
-      queueMicrotask(() => window.dispatchEvent(new CustomEvent("resumeAutoScroll")))
     }
 
     const agent = selectedAgentName() !== defaultAgent() ? selectedAgentName() : undefined

--- a/plan-fix-scroll.md
+++ b/plan-fix-scroll.md
@@ -1,0 +1,152 @@
+# Plan: Fix Autoscroll in VS Code Extension
+
+## Problem
+
+Autoscroll frequently disengages silently during normal use — the user never scrolled up, but the chat stops following new content. The root cause is false-positive `userScrolled` detection triggered by layout shifts.
+
+## Root Cause Analysis
+
+The autoscroll hook (`packages/kilo-ui/src/hooks/create-auto-scroll.tsx`) uses time-based heuristics to distinguish programmatic scrolls from user scrolls. The protection has two layers:
+
+1. **`markAuto`/`isAuto`**: After a programmatic `scrollToBottom()`, a 250ms marker suppresses the `handleScroll` handler from treating the resulting scroll event as user-initiated.
+2. **100ms debounce on `stop()`**: `handleScroll` debounces the `stop()` call to avoid reacting to transient layout shifts.
+
+These fail when:
+
+- Content arrives in bursts with >250ms gaps (the auto marker expires before the next scroll event)
+- DOM layout takes longer than the debounce window (e.g., syntax highlighting, markdown rendering)
+- Multiple ResizeObserver callbacks and scroll events interleave in ways the timing can't predict
+
+Once `userScrolled` flips to `true`, autoscroll is silently broken until the user clicks the scroll-to-bottom button.
+
+## Design Insight: Remove `active()` / busy-idle distinction
+
+The current code gates ResizeObserver autoscrolling behind `active()` (`working() || settling`). The rationale was: "when idle, content changes are user-initiated (expanding tool output, toggling diffs), so don't autoscroll." But this is wrong — the same interactions happen during busy too, and the user may expand a tool output while watching a stream. The busy/idle state of the session has nothing to do with whether autoscroll should fire.
+
+The correct signal is **`userScrolled` alone**:
+
+- If the user hasn't scrolled away from the bottom, any content resize should scroll to keep the bottom visible — regardless of busy/idle. This includes tool output expanding, markdown rendering, streaming text, etc.
+- If the user has scrolled up (to re-read something, inspect a tool output, etc.), no content resize should yank them back — regardless of busy/idle.
+
+Removing the `active()` gate also eliminates the need for:
+
+- The 300ms `settling` hack (which exists only because idle fires before final content renders)
+- The `working()` transition effect that force-scrolls on busy start
+
+The `working()` signal becomes irrelevant to the scroll logic entirely. The hook only needs to know: is the user at the bottom or not?
+
+## Proposed Changes
+
+### 1. Remove `active()`, `settling`, and `working` from scroll logic
+
+**File**: `packages/kilo-ui/src/hooks/create-auto-scroll.tsx`
+
+- Remove the `settling` flag, `settleTimer`, and the `createEffect(on(options.working, ...))` block
+- Remove the `active()` function
+- In the ResizeObserver callback, remove the `if (!active()) return` guard — only check `userScrolled`
+- Keep `working` in the options interface for now (consumers pass it), but don't use it for gating scroll
+
+The ResizeObserver becomes simply:
+
+```ts
+createResizeObserver(
+  () => store.contentRef,
+  () => {
+    const el = scroll
+    if (el && !canScroll(el)) {
+      if (store.userScrolled) setStore("userScrolled", false)
+      return
+    }
+    if (store.userScrolled) return
+    scrollToBottom(false)
+  },
+)
+```
+
+### 2. Replace `markAuto`/`isAuto` with a deterministic flag
+
+Replace the `auto` timestamp + 250ms timer with a `programmatic` boolean that's set before `scrollTo` and cleared after the browser processes the scroll event via `requestAnimationFrame`:
+
+```ts
+let programmatic = false
+
+const scrollToBottomNow = (behavior: ScrollBehavior) => {
+  const el = scroll
+  if (!el) return
+  programmatic = true
+  if (behavior === "smooth") {
+    el.scrollTo({ top: el.scrollHeight, behavior })
+  } else {
+    el.scrollTop = el.scrollHeight
+  }
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      programmatic = false
+    })
+  })
+}
+```
+
+In `handleScroll`, replace `isAuto(el)` with `programmatic`:
+
+```ts
+if (!store.userScrolled && programmatic) {
+  scrollToBottom(false)
+  return
+}
+```
+
+### 3. Remove the 100ms debounce on `stop()`
+
+With the deterministic `programmatic` flag, the debounce is less critical. Replace it with a spatial threshold: during any content resize that isn't user-initiated scrolling, require the scroll to be >50px from bottom before considering it a user scroll. This is more robust than time-based debouncing.
+
+### 4. Add wheel event threshold
+
+In `handleWheel`, ignore tiny upward `deltaY` values (trackpad noise / inertia):
+
+```ts
+const handleWheel = (e: WheelEvent) => {
+  if (e.deltaY >= -2) return
+  // ... rest of handler
+}
+```
+
+### 5. Clean up unused infrastructure
+
+Remove `auto`, `autoTimer`, `settleTimer`, `settling`, `markAuto()`, `isAuto()`, and the `active()` function.
+
+### 6. Simplify `scrollToBottom`
+
+Without the `active()` gate, `scrollToBottom(force=false)` only checks `userScrolled`:
+
+```ts
+const scrollToBottom = (force: boolean) => {
+  const el = scroll
+  if (!el) return
+  if (!force && store.userScrolled) return
+  if (force && store.userScrolled) setStore("userScrolled", false)
+  if (distanceFromBottom(el) < 2) return
+  scrollToBottomNow("auto")
+}
+```
+
+## What About Idle Interactions?
+
+With `active()` removed, won't expanding a collapsed tool output when idle yank the scroll?
+
+No — if the user is at the bottom when they click to expand, scrolling to bottom is correct (they want to see the expanded content). If they scrolled up to find the tool output, `userScrolled` is `true` and the ResizeObserver won't scroll. The `userScrolled` flag already handles this correctly. The `active()` guard was redundant protection that also caused the settling bug.
+
+The one edge case is: user is at the bottom, expands something mid-page that pushes content below the fold. This would scroll to bottom, hiding the thing they just expanded. But this is also the current behavior during busy — `active()` doesn't protect against it. A proper fix for that (scroll to keep the expanded element in view) is a separate concern.
+
+## Test Plan
+
+1. Stream a long response — verify scroll stays pinned to bottom throughout
+2. During streaming, hover cursor over chat and rest hand on trackpad — verify no false disengage
+3. During streaming, manually scroll up — verify autoscroll stops and button appears
+4. Click scroll-to-bottom button — verify autoscroll re-engages
+5. Send a message at the end of a conversation — verify the optimistic message scrolls into view
+6. Wait for a response to complete — verify the last content is visible (no more settling cutoff)
+7. After completion while at bottom, expand a collapsed tool output — verify scroll follows
+8. After completion, scroll up, expand a tool output — verify scroll does NOT yank to bottom
+9. Dismiss a permission prompt while agent is busy — verify scroll resumes
+10. Switch sessions — verify scroll resets appropriately


### PR DESCRIPTION
## Summary

- Rewrites the autoscroll hook (`create-auto-scroll.tsx`) to fix frequent silent disengagement during streaming
- Replaces time-based heuristics (250ms auto marker, 100ms debounce) with a deterministic `programmatic` flag cleared via double-`requestAnimationFrame`
- Removes the `active()`/`settling`/`working()` gate — autoscroll now depends solely on `userScrolled`, making it independent of busy/idle session state
- Adds a wheel `deltaY` threshold to ignore tiny trackpad movements that falsely break auto-follow

## Problem

The autoscroll would silently disengage during normal use — the user never scrolled up, but the chat stopped following new content. The root cause was false-positive `userScrolled` detection from layout shifts interacting with time-based guards that could expire between content bursts.

## Changes

**`packages/kilo-ui/src/hooks/create-auto-scroll.tsx`** (core fix):
- Replace `markAuto()`/`isAuto()` timestamp mechanism with a `programmatic` boolean flag
- Remove `active()`, `settling`, `settleTimer`, and the `working()` transition `createEffect`
- Remove 100ms debounce on `stop()` — the deterministic flag eliminates the need
- Add `-2` threshold on `handleWheel` to ignore trackpad noise
- Make `working` option optional (no longer used internally)

**`packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx`**:
- Remove `working` param from `createAutoScroll` call

**`packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx`**:
- Remove `working` param and unused `running` memo

**`packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx`**:
- Remove `!idle()` guard from `resumeAutoScroll` dispatch (permission dock case applies regardless of session state)

**`packages/kilo-vscode/webview-ui/src/context/session.tsx`**:
- Remove `resumeAutoScroll` dispatch for optimistic messages (ResizeObserver handles it now)

## Test Plan

1. Stream a long response — verify scroll stays pinned to bottom throughout
2. During streaming, hover cursor over chat and rest hand on trackpad — verify no false disengage
3. During streaming, manually scroll up — verify autoscroll stops and button appears
4. Click scroll-to-bottom button — verify autoscroll re-engages
5. Send a message at the end of a conversation — verify the optimistic message scrolls into view
6. Wait for a response to complete — verify the last content is visible
7. After completion while at bottom, expand a collapsed tool output — verify scroll follows
8. After completion, scroll up, expand a tool output — verify scroll does NOT yank to bottom
9. Dismiss a permission prompt while agent is busy — verify scroll resumes
