### PR TITLE
fix(vscode): fix subagent permission prompts not appearing

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -51,7 +51,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
         if (!msgParts) continue
         for (const p of msgParts) {
           if (p.type !== "tool") continue
-          const child = (p as { metadata?: { sessionId?: string } }).metadata?.sessionId
+          const child = (p as { state?: { metadata?: { sessionId?: string } } }).state?.metadata?.sessionId
           if (child && !family.has(child)) {
             family.add(child)
             queue.push(child)


### PR DESCRIPTION
## Summary

- Fix subagent permission/question prompts not appearing in the chat dock

## Problem

PR #6884 introduced a `sessionFamily` memo that walks tool parts to discover child session IDs (subagents). However, it reads the session ID from `part.metadata?.sessionId` — the **top-level** provider metadata populated by the LLM — which never contains `sessionId`.

The task tool stores the child session ID at `part.state.metadata.sessionId` (see `packages/opencode/src/tool/task.ts:114`), and this is the same path used by `message-part.tsx` when passing metadata to tool renderers (`part.state?.metadata`).

Because `sessionFamily` never found any children, it only contained `{rootSessionId}`, causing `scopedPermissions()` and `scopedQuestions()` to filter out all subagent prompts.

## Fix

One-line change: read from `part.state?.metadata?.sessionId` instead of `part.metadata?.sessionId`.
