### PR TITLE
fix: restore editor tab and sub-agent panels on VS Code reload instead of leaving zombie tabs

### DIFF
--- a/packages/kilo-vscode/src/SubAgentViewerProvider.ts
+++ b/packages/kilo-vscode/src/SubAgentViewerProvider.ts
@@ -44,13 +44,18 @@ export class SubAgentViewerProvider implements vscode.Disposable {
     const provider = new KiloProvider(this.extensionUri, this.connectionService, this.context)
     provider.resolveWebviewPanel(panel)
 
-    // Once the webview is ready, fetch the session and display it in read-only mode.
-    const readyDisposable = panel.webview.onDidReceiveMessage(async (msg) => {
-      if (msg.type !== "webviewReady") return
-      readyDisposable.dispose()
+    // Once the webview is ready AND the backend is connected, fetch the session
+    // and display it in read-only mode. The backend is usually already connected
+    // when opening manually, but we use the same dual-signal pattern as restorePanel
+    // to be robust against race conditions.
+    let webviewReady = false
+    let backendReady = this.connectionService.getConnectionState() === "connected"
 
-      // Small delay to let KiloProvider's own webviewReady handler finish first
-      await new Promise((resolve) => setTimeout(resolve, 50))
+    const tryLoadSession = async () => {
+      if (!webviewReady || !backendReady) return
+
+      readyDisposable.dispose()
+      unsubscribeState()
 
       try {
         const client = this.connectionService.getClient()
@@ -79,6 +84,19 @@ export class SubAgentViewerProvider implements vscode.Disposable {
       } catch (err) {
         console.error("[Kilo New] SubAgentViewerProvider: Failed to load session:", err)
       }
+    }
+
+    const readyDisposable = panel.webview.onDidReceiveMessage((msg) => {
+      if (msg.type !== "webviewReady") return
+      webviewReady = true
+      void tryLoadSession()
+    })
+
+    const unsubscribeState = this.connectionService.onStateChange((state) => {
+      if (state === "connected") {
+        backendReady = true
+        void tryLoadSession()
+      }
     })
 
     // Listen for closePanel from the webview (back button)
@@ -93,6 +111,8 @@ export class SubAgentViewerProvider implements vscode.Disposable {
 
     panel.onDidDispose(() => {
       console.log("[Kilo New] Sub-agent viewer panel disposed:", sessionID)
+      readyDisposable.dispose()
+      unsubscribeState()
       closeDisposable.dispose()
       provider.dispose()
       this.panels.delete(sessionID)
@@ -120,13 +140,19 @@ export class SubAgentViewerProvider implements vscode.Disposable {
     const provider = new KiloProvider(this.extensionUri, this.connectionService, this.context)
     provider.resolveWebviewPanel(panel)
 
-    // Once the webview is ready, fetch the session and display it in read-only mode.
-    const readyDisposable = panel.webview.onDidReceiveMessage(async (msg) => {
-      if (msg.type !== "webviewReady") return
-      readyDisposable.dispose()
+    // Once the webview is ready AND the backend is connected, fetch the session
+    // and display it in read-only mode. During restore after VS Code reload,
+    // the webview fires webviewReady before the backend has finished connecting,
+    // so we wait for both signals before fetching.
+    let webviewReady = false
+    let backendReady = this.connectionService.getConnectionState() === "connected"
 
-      // Small delay to let KiloProvider's own webviewReady handler finish first
-      await new Promise((resolve) => setTimeout(resolve, 50))
+    const tryLoadSession = async () => {
+      if (!webviewReady || !backendReady) return
+
+      // Clean up listeners since we only need to load once
+      readyDisposable.dispose()
+      unsubscribeState()
 
       try {
         const client = this.connectionService.getClient()
@@ -152,6 +178,19 @@ export class SubAgentViewerProvider implements vscode.Disposable {
         panel.dispose()
         return
       }
+    }
+
+    const readyDisposable = panel.webview.onDidReceiveMessage((msg) => {
+      if (msg.type !== "webviewReady") return
+      webviewReady = true
+      void tryLoadSession()
+    })
+
+    const unsubscribeState = this.connectionService.onStateChange((state) => {
+      if (state === "connected") {
+        backendReady = true
+        void tryLoadSession()
+      }
     })
 
     // Listen for closePanel from the webview (back button)
@@ -166,6 +205,8 @@ export class SubAgentViewerProvider implements vscode.Disposable {
 
     panel.onDidDispose(() => {
       console.log("[Kilo New] Restored sub-agent viewer panel disposed:", sessionID)
+      readyDisposable.dispose()
+      unsubscribeState()
       closeDisposable.dispose()
       provider.dispose()
       this.panels.delete(sessionID)

--- a/packages/kilo-vscode/src/SubAgentViewerProvider.ts
+++ b/packages/kilo-vscode/src/SubAgentViewerProvider.ts
@@ -100,6 +100,79 @@ export class SubAgentViewerProvider implements vscode.Disposable {
     })
   }
 
+  /**
+   * Restore a deserialized panel after VS Code reload.
+   * Wires up the panel the same way openPanel() does, but reuses the
+   * already-existing WebviewPanel that VS Code hands back from the serializer.
+   */
+  restorePanel(panel: vscode.WebviewPanel, sessionID: string): void {
+    // If we already have a panel for this session, dispose the stale one
+    const existing = this.panels.get(sessionID)
+    if (existing) {
+      existing.dispose()
+    }
+
+    panel.iconPath = {
+      light: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-light.svg"),
+      dark: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-dark.svg"),
+    }
+
+    const provider = new KiloProvider(this.extensionUri, this.connectionService, this.context)
+    provider.resolveWebviewPanel(panel)
+
+    // Once the webview is ready, fetch the session and display it in read-only mode.
+    const readyDisposable = panel.webview.onDidReceiveMessage(async (msg) => {
+      if (msg.type !== "webviewReady") return
+      readyDisposable.dispose()
+
+      // Small delay to let KiloProvider's own webviewReady handler finish first
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      try {
+        const client = this.connectionService.getClient()
+        const { data: session } = await client.session.get({ sessionID }, { throwOnError: true })
+
+        provider.registerSession(session)
+
+        const { data: messagesData } = await client.session.messages({ sessionID }, { throwOnError: true })
+        const messages = messagesData.map((m) => ({
+          ...m.info,
+          parts: m.parts,
+          createdAt: new Date(m.info.time.created).toISOString(),
+        }))
+        provider.postMessage({
+          type: "messagesLoaded",
+          sessionID,
+          messages,
+        })
+
+        provider.postMessage({ type: "viewSubAgentSession", sessionID })
+      } catch (err) {
+        console.error("[Kilo New] SubAgentViewerProvider: Failed to restore session:", err)
+        panel.dispose()
+        return
+      }
+    })
+
+    // Listen for closePanel from the webview (back button)
+    const closeDisposable = panel.webview.onDidReceiveMessage((msg) => {
+      if (msg.type === "closePanel") {
+        panel.dispose()
+      }
+    })
+
+    this.panels.set(sessionID, panel)
+    this.providers.set(sessionID, provider)
+
+    panel.onDidDispose(() => {
+      console.log("[Kilo New] Restored sub-agent viewer panel disposed:", sessionID)
+      closeDisposable.dispose()
+      provider.dispose()
+      this.panels.delete(sessionID)
+      this.providers.delete(sessionID)
+    })
+  }
+
   dispose(): void {
     for (const [, panel] of this.panels) {
       panel.dispose()

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -65,6 +65,43 @@ export function activate(context: vscode.ExtensionContext) {
   const subAgentViewerProvider = new SubAgentViewerProvider(context.extensionUri, connectionService, context)
   context.subscriptions.push(subAgentViewerProvider)
 
+  // Register serializers so VS Code can restore (or close) webview panels after reload.
+  // TabPanel gets a full restore; ephemeral panels (settings, profile, sub-agent, diff, agent manager)
+  // are disposed immediately since they require runtime state that doesn't survive a reload.
+  context.subscriptions.push(
+    vscode.window.registerWebviewPanelSerializer("kilo-code.new.TabPanel", {
+      async deserializeWebviewPanel(panel: vscode.WebviewPanel) {
+        console.log("[Kilo New] Restoring TabPanel after reload")
+
+        panel.iconPath = {
+          light: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "kilo-light.svg"),
+          dark: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "kilo-dark.svg"),
+        }
+
+        const tabProvider = new KiloProvider(context.extensionUri, connectionService, context)
+        tabProvider.resolveWebviewPanel(panel)
+
+        panel.onDidDispose(
+          () => {
+            console.log("[Kilo New] Restored tab panel disposed")
+            tabProvider.dispose()
+          },
+          null,
+          context.subscriptions,
+        )
+      },
+    }),
+    ...["settingsPanel", "profilePanel", "SubAgentViewerPanel", "DiffViewerPanel", "AgentManagerPanel"].map(
+      (viewType) =>
+        vscode.window.registerWebviewPanelSerializer(`kilo-code.new.${viewType}`, {
+          async deserializeWebviewPanel(panel: vscode.WebviewPanel) {
+            console.log(`[Kilo New] Closing stale ${viewType} after reload`)
+            panel.dispose()
+          },
+        }),
+    ),
+  )
+
   // Register toolbar button command handlers
   context.subscriptions.push(
     vscode.commands.registerCommand("kilo-code.new.plusButtonClicked", () => {

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -66,7 +66,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(subAgentViewerProvider)
 
   // Register serializers so VS Code can restore (or close) webview panels after reload.
-  // TabPanel gets a full restore; ephemeral panels (settings, profile, sub-agent, diff, agent manager)
+  // TabPanel and SubAgentViewerPanel get a full restore; ephemeral panels (settings, profile, diff, agent manager)
   // are disposed immediately since they require runtime state that doesn't survive a reload.
   context.subscriptions.push(
     vscode.window.registerWebviewPanelSerializer("kilo-code.new.TabPanel", {
@@ -91,14 +91,25 @@ export function activate(context: vscode.ExtensionContext) {
         )
       },
     }),
-    ...["settingsPanel", "profilePanel", "SubAgentViewerPanel", "DiffViewerPanel", "AgentManagerPanel"].map(
-      (viewType) =>
-        vscode.window.registerWebviewPanelSerializer(`kilo-code.new.${viewType}`, {
-          async deserializeWebviewPanel(panel: vscode.WebviewPanel) {
-            console.log(`[Kilo New] Closing stale ${viewType} after reload`)
-            panel.dispose()
-          },
-        }),
+    vscode.window.registerWebviewPanelSerializer("kilo-code.new.SubAgentViewerPanel", {
+      async deserializeWebviewPanel(panel: vscode.WebviewPanel, state: { sessionID?: string } | undefined) {
+        const sessionID = state?.sessionID
+        if (!sessionID) {
+          console.log("[Kilo New] Closing stale SubAgentViewerPanel after reload (no session state)")
+          panel.dispose()
+          return
+        }
+        console.log("[Kilo New] Restoring SubAgentViewerPanel after reload:", sessionID)
+        subAgentViewerProvider.restorePanel(panel, sessionID)
+      },
+    }),
+    ...["settingsPanel", "profilePanel", "DiffViewerPanel", "AgentManagerPanel"].map((viewType) =>
+      vscode.window.registerWebviewPanelSerializer(`kilo-code.new.${viewType}`, {
+        async deserializeWebviewPanel(panel: vscode.WebviewPanel) {
+          console.log(`[Kilo New] Closing stale ${viewType} after reload`)
+          panel.dispose()
+        },
+      }),
     ),
   )
 

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -179,6 +179,7 @@ const AppContent: Component = () => {
   const [migrationReturnView, setMigrationReturnView] = createSignal<ViewType>("newTask") // legacy-migration
   const session = useSession()
   const server = useServer()
+  const vsc = useVSCode()
 
   const handleViewAction = (action: string) => {
     switch (action) {
@@ -224,6 +225,8 @@ const AppContent: Component = () => {
         console.log("[Kilo New] App: 🔍 viewSubAgentSession:", message.sessionID)
         session.setCurrentSessionID(message.sessionID)
         setCurrentView("subAgentViewer")
+        // Persist session ID so VS Code can restore this panel after reload
+        vsc.setState({ sessionID: message.sessionID })
       }
     }
     window.addEventListener("message", handler)

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -151,8 +151,16 @@ export const SessionProvider: ParentComponent = (props) => {
   const { config } = useConfig()
   const language = useLanguage()
 
-  // Current session ID
-  const [currentSessionID, setCurrentSessionID] = createSignal<string | undefined>()
+  // Current session ID — initialize from persisted state if available (VS Code reload)
+  const persisted = vscode.getState<{ sessionID?: string }>()
+  const [currentSessionID, setCurrentSessionID] = createSignal<string | undefined>(persisted?.sessionID)
+
+  // Persist the current session ID so VS Code can restore the correct session
+  // after a reload (TabPanel serializer reads this via vscode.getState()).
+  createEffect(() => {
+    const id = currentSessionID()
+    vscode.setState({ sessionID: id })
+  })
 
   // Per-session status map — keyed by sessionID
   const [statusMap, setStatusMap] = createStore<Record<string, SessionStatusInfo>>({})
@@ -680,6 +688,18 @@ export const SessionProvider: ParentComponent = (props) => {
       )
       for (const s of loaded) {
         setStore("sessions", s.id, s)
+      }
+
+      // After a VS Code reload, restore the previously active session.
+      // currentSessionID is initialized from persisted vscode.getState() above.
+      const restored = currentSessionID()
+      if (restored && ids.has(restored) && !store.messages[restored]?.length) {
+        setLoading(true)
+        vscode.postMessage({ type: "loadMessages", sessionID: restored })
+      }
+      // Clear stale persisted session ID if the session no longer exists
+      if (restored && !ids.has(restored)) {
+        setCurrentSessionID(undefined)
       }
     })
   }


### PR DESCRIPTION
## Summary

- Register `WebviewPanelSerializer` for `kilo-code.new.TabPanel` so editor pane tabs are properly restored on VS Code reload instead of becoming zombie tabs
- Register a full-restore serializer for `kilo-code.new.SubAgentViewerPanel` that persists `sessionID` via `vscode.setState()` and re-fetches the session from the backend on reload, restoring the read-only chat view
- Register close-on-restore serializers for remaining ephemeral panel types (settings, profile, diff viewer, agent manager) so they are cleanly disposed on reload rather than lingering as broken tabs
