### PR TITLE
feat(vscode): show discovered skills in Agent Behaviour settings

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -49,6 +49,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private cachedProvidersMessage: unknown = null
   /** Cached agentsLoaded payload so requestAgents can be served before client is ready */
   private cachedAgentsMessage: unknown = null
+  /** Cached skillsLoaded payload so requestSkills can be served before client is ready */
+  private cachedSkillsMessage: unknown = null
   /** Cached configLoaded payload so requestConfig can be served before client is ready */
   private cachedConfigMessage: unknown = null
   /** Cached notificationsLoaded payload */
@@ -412,6 +414,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "requestAgents":
           this.fetchAndSendAgents().catch((e) => console.error("[Kilo New] fetchAndSendAgents failed:", e))
           break
+        case "requestSkills":
+          this.fetchAndSendSkills().catch((e) => console.error("[Kilo New] fetchAndSendSkills failed:", e))
+          break
         case "questionReply":
           await this.handleQuestionReply(message.requestID, message.answers)
           break
@@ -687,10 +692,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       await this.syncWebviewState("initializeConnection")
       await this.flushPendingSessionRefresh("initializeConnection")
 
-      // Fetch providers, agents, config, and notifications in parallel
+      // Fetch providers, agents, skills, config, and notifications in parallel
       await Promise.all([
         this.fetchAndSendProviders(),
         this.fetchAndSendAgents(),
+        this.fetchAndSendSkills(),
         this.fetchAndSendConfig(),
         this.fetchAndSendNotifications(),
       ])
@@ -1065,6 +1071,33 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.postMessage(message)
     } catch (error) {
       console.error("[Kilo New] KiloProvider: Failed to fetch agents:", error)
+    }
+  }
+
+  private async fetchAndSendSkills(): Promise<void> {
+    if (!this.client) {
+      if (this.cachedSkillsMessage) {
+        this.postMessage(this.cachedSkillsMessage)
+      }
+      return
+    }
+
+    try {
+      const workspaceDir = this.getWorkspaceDirectory()
+      const { data: skills } = await this.client.app.skills({ directory: workspaceDir }, { throwOnError: true })
+
+      const message = {
+        type: "skillsLoaded",
+        skills: skills.map((s) => ({
+          name: s.name,
+          description: s.description,
+          location: s.location,
+        })),
+      }
+      this.cachedSkillsMessage = message
+      this.postMessage(message)
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to fetch skills:", error)
     }
   }
 
@@ -1875,6 +1908,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     await Promise.all([
       this.fetchAndSendProviders(),
       this.fetchAndSendAgents(),
+      this.fetchAndSendSkills(),
       this.fetchAndSendConfig(),
       this.fetchAndSendNotifications(),
     ])

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1088,11 +1088,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       const message = {
         type: "skillsLoaded",
-        skills: skills.map((s) => ({
-          name: s.name,
-          description: s.description,
-          location: s.location,
-        })),
+        skills,
       }
       this.cachedSkillsMessage = message
       this.postMessage(message)

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, createMemo, For, Show, onCleanup } from "solid-js"
+import { Component, createSignal, createMemo, createEffect, For, Show, onCleanup } from "solid-js"
 import { Select } from "@kilocode/kilo-ui/select"
 import { TextField } from "@kilocode/kilo-ui/text-field"
 import { Card } from "@kilocode/kilo-ui/card"
@@ -67,8 +67,12 @@ const AgentBehaviourTab: Component = () => {
     }
   })
 
-  // Request skills from the backend
-  vscode.postMessage({ type: "requestSkills" })
+  // Fetch skills whenever the skills subtab becomes active
+  createEffect(() => {
+    if (activeSubtab() === "skills") {
+      vscode.postMessage({ type: "requestSkills" })
+    }
+  })
 
   onCleanup(() => unsub())
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -371,14 +371,7 @@ const AgentBehaviourTab: Component = () => {
         when={discoveredSkills().length > 0}
         fallback={
           <Card style={{ "margin-bottom": "16px" }}>
-            <div
-              style={{
-                "font-size": "12px",
-                color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
-              }}
-            >
-              {language.t("settings.agentBehaviour.noSkillsFound")}
-            </div>
+            <div data-slot="settings-row-label-subtitle">{language.t("settings.agentBehaviour.noSkillsFound")}</div>
           </Card>
         }
       >
@@ -392,11 +385,12 @@ const AgentBehaviourTab: Component = () => {
                     index() < discoveredSkills().length - 1 ? "1px solid var(--border-weak-base)" : "none",
                 }}
               >
-                <div style={{ "font-weight": "500" }}>{skill.name}</div>
+                <div data-slot="settings-row-label-title" style={{ "margin-bottom": "0" }}>
+                  {skill.name}
+                </div>
                 <div
+                  data-slot="settings-row-label-subtitle"
                   style={{
-                    "font-size": "12px",
-                    color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
                     "margin-top": "4px",
                     "font-family": "var(--vscode-editor-font-family, monospace)",
                   }}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, createMemo, For, Show } from "solid-js"
+import { Component, createSignal, createMemo, For, Show, onCleanup } from "solid-js"
 import { Select } from "@kilocode/kilo-ui/select"
 import { TextField } from "@kilocode/kilo-ui/text-field"
 import { Card } from "@kilocode/kilo-ui/card"
@@ -8,7 +8,8 @@ import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { useConfig } from "../../context/config"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
-import type { AgentConfig } from "../../types/messages"
+import { useVSCode } from "../../context/vscode"
+import type { AgentConfig, SkillInfo, ExtensionMessage } from "../../types/messages"
 
 type SubtabId = "agents" | "mcpServers" | "rules" | "workflows" | "skills"
 
@@ -51,11 +52,25 @@ const AgentBehaviourTab: Component = () => {
   const language = useLanguage()
   const { config, updateConfig } = useConfig()
   const session = useSession()
+  const vscode = useVSCode()
   const [activeSubtab, setActiveSubtab] = createSignal<SubtabId>("agents")
   const [selectedAgent, setSelectedAgent] = createSignal<string>("")
   const [newSkillPath, setNewSkillPath] = createSignal("")
   const [newSkillUrl, setNewSkillUrl] = createSignal("")
   const [newInstruction, setNewInstruction] = createSignal("")
+  const [discoveredSkills, setDiscoveredSkills] = createSignal<SkillInfo[]>([])
+
+  // Subscribe to skillsLoaded messages from the extension
+  const unsub = vscode.onMessage((message: ExtensionMessage) => {
+    if (message.type === "skillsLoaded") {
+      setDiscoveredSkills(message.skills)
+    }
+  })
+
+  // Request skills from the backend
+  vscode.postMessage({ type: "requestSkills" })
+
+  onCleanup(() => unsub())
 
   const agentNames = createMemo(() => {
     const names = session.agents().map((a) => a.name)
@@ -344,6 +359,62 @@ const AgentBehaviourTab: Component = () => {
 
   const renderSkillsSubtab = () => (
     <div>
+      {/* Discovered skills */}
+      <h4 style={{ "margin-top": "0", "margin-bottom": "8px" }}>
+        {language.t("settings.agentBehaviour.discoveredSkills")}
+      </h4>
+      <Show
+        when={discoveredSkills().length > 0}
+        fallback={
+          <Card style={{ "margin-bottom": "16px" }}>
+            <div
+              style={{
+                "font-size": "12px",
+                color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
+              }}
+            >
+              {language.t("settings.agentBehaviour.noSkillsFound")}
+            </div>
+          </Card>
+        }
+      >
+        <Card style={{ "margin-bottom": "16px" }}>
+          <For each={discoveredSkills()}>
+            {(skill, index) => (
+              <div
+                style={{
+                  padding: "8px 0",
+                  "border-bottom":
+                    index() < discoveredSkills().length - 1 ? "1px solid var(--border-weak-base)" : "none",
+                }}
+              >
+                <div style={{ "font-weight": "500" }}>{skill.name}</div>
+                <div
+                  style={{
+                    "font-size": "12px",
+                    color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
+                    "margin-top": "2px",
+                  }}
+                >
+                  {skill.description}
+                </div>
+                <div
+                  style={{
+                    "font-size": "11px",
+                    color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
+                    "margin-top": "4px",
+                    "font-family": "var(--vscode-editor-font-family, monospace)",
+                    "word-break": "break-all",
+                  }}
+                >
+                  {skill.location}
+                </div>
+              </div>
+            )}
+          </For>
+        </Card>
+      </Show>
+
       {/* Skill paths */}
       <h4 style={{ "margin-top": "0", "margin-bottom": "8px" }}>{language.t("settings.agentBehaviour.skillPaths")}</h4>
       <Card style={{ "margin-bottom": "16px" }}>

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -393,21 +393,12 @@ const AgentBehaviourTab: Component = () => {
                   style={{
                     "font-size": "12px",
                     color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
-                    "margin-top": "2px",
-                  }}
-                >
-                  {skill.description}
-                </div>
-                <div
-                  style={{
-                    "font-size": "11px",
-                    color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
                     "margin-top": "4px",
                     "font-family": "var(--vscode-editor-font-family, monospace)",
-                    "word-break": "break-all",
                   }}
                 >
-                  {skill.location}
+                  <div>{skill.description}</div>
+                  <div>{skill.location}</div>
                 </div>
               </div>
             )}

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -938,6 +938,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "معامل أخذ العينات النووي (0-1)",
   "settings.agentBehaviour.maxSteps.title": "الحد الأقصى للخطوات",
   "settings.agentBehaviour.maxSteps.description": "الحد الأقصى لتكرارات الوكيل",
+  "settings.agentBehaviour.discoveredSkills": "المهارات المكتشفة",
+  "settings.agentBehaviour.noSkillsFound":
+    "لم يتم العثور على مهارات. أضف مسارات مجلدات أو عناوين URL أدناه لإتاحة المهارات.",
   "settings.agentBehaviour.skillPaths": "مسارات مجلدات المهارات",
   "settings.agentBehaviour.skillUrls": "عناوين URL للمهارات",
   "settings.agentBehaviour.instructionFiles": "ملفات تعليمات إضافية",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -950,6 +950,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Parâmetro de amostragem nucleus (0-1)",
   "settings.agentBehaviour.maxSteps.title": "Passos máximos",
   "settings.agentBehaviour.maxSteps.description": "Iterações máximas do agente",
+  "settings.agentBehaviour.discoveredSkills": "Habilidades descobertas",
+  "settings.agentBehaviour.noSkillsFound":
+    "Nenhuma habilidade encontrada. Adicione caminhos de pastas ou URLs abaixo para disponibilizar habilidades.",
   "settings.agentBehaviour.skillPaths": "Caminhos de pastas de habilidades",
   "settings.agentBehaviour.skillUrls": "URLs de habilidades",
   "settings.agentBehaviour.instructionFiles": "Arquivos de instruções adicionais",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -950,6 +950,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Nucleus parametar uzorkovanja (0-1)",
   "settings.agentBehaviour.maxSteps.title": "Maks. koraci",
   "settings.agentBehaviour.maxSteps.description": "Maksimalne iteracije agenta",
+  "settings.agentBehaviour.discoveredSkills": "Otkrivene vještine",
+  "settings.agentBehaviour.noSkillsFound":
+    "Nisu pronađene vještine. Dodajte putanje mapa ili URL-ove ispod kako biste učinili vještine dostupnim.",
   "settings.agentBehaviour.skillPaths": "Putanje mapa vještina",
   "settings.agentBehaviour.skillUrls": "URL-ovi vještina",
   "settings.agentBehaviour.instructionFiles": "Dodatne datoteke uputa",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -946,6 +946,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Nucleus-samplingparameter (0-1)",
   "settings.agentBehaviour.maxSteps.title": "Maks. trin",
   "settings.agentBehaviour.maxSteps.description": "Maksimale agentiterationer",
+  "settings.agentBehaviour.discoveredSkills": "Opdagede skills",
+  "settings.agentBehaviour.noSkillsFound":
+    "Ingen skills fundet. Tilføj skill-mappestier eller URL'er nedenfor for at gøre skills tilgængelige.",
   "settings.agentBehaviour.skillPaths": "Skill-mappestier",
   "settings.agentBehaviour.skillUrls": "Skill-URL'er",
   "settings.agentBehaviour.instructionFiles": "Yderligere instruktionsfiler",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -961,6 +961,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Nucleus-Sampling-Parameter (0-1)",
   "settings.agentBehaviour.maxSteps.title": "Max. Schritte",
   "settings.agentBehaviour.maxSteps.description": "Maximale Agent-Iterationen",
+  "settings.agentBehaviour.discoveredSkills": "Erkannte Skills",
+  "settings.agentBehaviour.noSkillsFound":
+    "Keine Skills gefunden. Fügen Sie unten Skill-Ordnerpfade oder URLs hinzu, um Skills verfügbar zu machen.",
   "settings.agentBehaviour.skillPaths": "Skill-Ordnerpfade",
   "settings.agentBehaviour.skillUrls": "Skill-URLs",
   "settings.agentBehaviour.instructionFiles": "Zusätzliche Anweisungsdateien",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -957,6 +957,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Nucleus sampling parameter (0-1)",
   "settings.agentBehaviour.maxSteps.title": "Max Steps",
   "settings.agentBehaviour.maxSteps.description": "Maximum agentic iterations",
+  "settings.agentBehaviour.discoveredSkills": "Discovered Skills",
+  "settings.agentBehaviour.noSkillsFound":
+    "No skills discovered. Add skill folder paths or URLs below to make skills available.",
   "settings.agentBehaviour.skillPaths": "Skill Folder Paths",
   "settings.agentBehaviour.skillUrls": "Skill URLs",
   "settings.agentBehaviour.instructionFiles": "Additional Instruction Files",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -953,6 +953,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Parámetro de muestreo nucleus (0-1)",
   "settings.agentBehaviour.maxSteps.title": "Pasos máximos",
   "settings.agentBehaviour.maxSteps.description": "Iteraciones máximas del agente",
+  "settings.agentBehaviour.discoveredSkills": "Habilidades descubiertas",
+  "settings.agentBehaviour.noSkillsFound":
+    "No se encontraron habilidades. Agregue rutas de carpetas o URLs abajo para hacer disponibles las habilidades.",
   "settings.agentBehaviour.skillPaths": "Rutas de carpetas de habilidades",
   "settings.agentBehaviour.skillUrls": "URLs de habilidades",
   "settings.agentBehaviour.instructionFiles": "Archivos de instrucciones adicionales",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -963,6 +963,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Paramètre d'échantillonnage nucleus (0-1)",
   "settings.agentBehaviour.maxSteps.title": "Étapes max.",
   "settings.agentBehaviour.maxSteps.description": "Itérations maximales de l'agent",
+  "settings.agentBehaviour.discoveredSkills": "Compétences découvertes",
+  "settings.agentBehaviour.noSkillsFound":
+    "Aucune compétence découverte. Ajoutez des chemins de dossiers ou des URLs ci-dessous pour rendre les compétences disponibles.",
   "settings.agentBehaviour.skillPaths": "Chemins des dossiers de compétences",
   "settings.agentBehaviour.skillUrls": "URLs de compétences",
   "settings.agentBehaviour.instructionFiles": "Fichiers d'instructions supplémentaires",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -946,6 +946,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "核サンプリングパラメータ（0-1）",
   "settings.agentBehaviour.maxSteps.title": "最大ステップ数",
   "settings.agentBehaviour.maxSteps.description": "最大エージェント反復回数",
+  "settings.agentBehaviour.discoveredSkills": "検出されたスキル",
+  "settings.agentBehaviour.noSkillsFound":
+    "スキルが見つかりません。スキルを利用可能にするには、以下にスキルフォルダパスまたはURLを追加してください。",
   "settings.agentBehaviour.skillPaths": "スキルフォルダパス",
   "settings.agentBehaviour.skillUrls": "スキルURL",
   "settings.agentBehaviour.instructionFiles": "追加の指示ファイル",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -943,6 +943,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "핵 샘플링 매개변수 (0-1)",
   "settings.agentBehaviour.maxSteps.title": "최대 단계",
   "settings.agentBehaviour.maxSteps.description": "최대 에이전트 반복 횟수",
+  "settings.agentBehaviour.discoveredSkills": "검색된 스킬",
+  "settings.agentBehaviour.noSkillsFound":
+    "스킬을 찾을 수 없습니다. 스킬을 사용하려면 아래에 스킬 폴더 경로 또는 URL을 추가하세요.",
   "settings.agentBehaviour.skillPaths": "스킬 폴더 경로",
   "settings.agentBehaviour.skillUrls": "스킬 URL",
   "settings.agentBehaviour.instructionFiles": "추가 지시 파일",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -948,6 +948,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Nucleus-samplingsparameter (0-1)",
   "settings.agentBehaviour.maxSteps.title": "Maks. trinn",
   "settings.agentBehaviour.maxSteps.description": "Maksimale agentiterasjoner",
+  "settings.agentBehaviour.discoveredSkills": "Oppdagede ferdigheter",
+  "settings.agentBehaviour.noSkillsFound":
+    "Ingen ferdigheter funnet. Legg til ferdighetsmappestier eller URLer nedenfor for å gjøre ferdigheter tilgjengelige.",
   "settings.agentBehaviour.skillPaths": "Ferdighetsmappe-stier",
   "settings.agentBehaviour.skillUrls": "Ferdighets-URLer",
   "settings.agentBehaviour.instructionFiles": "Ekstra instruksjonsfiler",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -948,6 +948,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Parametr próbkowania nucleus (0-1)",
   "settings.agentBehaviour.maxSteps.title": "Maks. kroki",
   "settings.agentBehaviour.maxSteps.description": "Maksymalna liczba iteracji agenta",
+  "settings.agentBehaviour.discoveredSkills": "Wykryte umiejętności",
+  "settings.agentBehaviour.noSkillsFound":
+    "Nie znaleziono umiejętności. Dodaj ścieżki folderów lub adresy URL poniżej, aby udostępnić umiejętności.",
   "settings.agentBehaviour.skillPaths": "Ścieżki folderów umiejętności",
   "settings.agentBehaviour.skillUrls": "Adresy URL umiejętności",
   "settings.agentBehaviour.instructionFiles": "Dodatkowe pliki instrukcji",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -951,6 +951,9 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Параметр nucleus-сэмплирования (0-1)",
   "settings.agentBehaviour.maxSteps.title": "Макс. шагов",
   "settings.agentBehaviour.maxSteps.description": "Максимальное число итераций агента",
+  "settings.agentBehaviour.discoveredSkills": "Обнаруженные навыки",
+  "settings.agentBehaviour.noSkillsFound":
+    "Навыки не обнаружены. Добавьте пути к папкам навыков или URL-адреса ниже, чтобы сделать навыки доступными.",
   "settings.agentBehaviour.skillPaths": "Пути папок навыков",
   "settings.agentBehaviour.skillUrls": "URL навыков",
   "settings.agentBehaviour.instructionFiles": "Дополнительные файлы инструкций",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -939,6 +939,8 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "พารามิเตอร์ nucleus sampling (0-1)",
   "settings.agentBehaviour.maxSteps.title": "ขั้นตอนสูงสุด",
   "settings.agentBehaviour.maxSteps.description": "จำนวนรอบเอเจนต์สูงสุด",
+  "settings.agentBehaviour.discoveredSkills": "ทักษะที่ค้นพบ",
+  "settings.agentBehaviour.noSkillsFound": "ไม่พบทักษะ เพิ่มเส้นทางโฟลเดอร์หรือ URL ด้านล่างเพื่อทำให้ทักษะพร้อมใช้งาน",
   "settings.agentBehaviour.skillPaths": "เส้นทางโฟลเดอร์ทักษะ",
   "settings.agentBehaviour.skillUrls": "URL ทักษะ",
   "settings.agentBehaviour.instructionFiles": "ไฟล์คำสั่งเพิ่มเติม",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -933,6 +933,8 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "核采样参数（0-1）",
   "settings.agentBehaviour.maxSteps.title": "最大步数",
   "settings.agentBehaviour.maxSteps.description": "最大智能体迭代次数",
+  "settings.agentBehaviour.discoveredSkills": "已发现的技能",
+  "settings.agentBehaviour.noSkillsFound": "未发现任何技能。请在下方添加技能文件夹路径或 URL 以使技能可用。",
   "settings.agentBehaviour.skillPaths": "技能文件夹路径",
   "settings.agentBehaviour.skillUrls": "技能 URL",
   "settings.agentBehaviour.instructionFiles": "附加指令文件",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -934,6 +934,8 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "核取樣參數（0-1）",
   "settings.agentBehaviour.maxSteps.title": "最大步數",
   "settings.agentBehaviour.maxSteps.description": "最大 Agent 迭代次數",
+  "settings.agentBehaviour.discoveredSkills": "已發現的 Skill",
+  "settings.agentBehaviour.noSkillsFound": "未發現任何 Skill。請在下方新增 Skill 資料夾路徑或 URL 以使 Skill 可用。",
   "settings.agentBehaviour.skillPaths": "Skill 資料夾路徑",
   "settings.agentBehaviour.skillUrls": "Skill URL",
   "settings.agentBehaviour.instructionFiles": "附加指令檔案",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -164,6 +164,13 @@ export interface QuestionRequest {
   }
 }
 
+// Skill info from CLI backend
+export interface SkillInfo {
+  name: string
+  description: string
+  location: string
+}
+
 // Agent/mode info from CLI backend
 export interface AgentInfo {
   name: string
@@ -546,6 +553,11 @@ export interface AgentsLoadedMessage {
   type: "agentsLoaded"
   agents: AgentInfo[]
   defaultAgent: string
+}
+
+export interface SkillsLoadedMessage {
+  type: "skillsLoaded"
+  skills: SkillInfo[]
 }
 
 export interface AutocompleteSettingsLoadedMessage {
@@ -1004,6 +1016,7 @@ export type ExtensionMessage =
   | NavigateMessage
   | ProvidersLoadedMessage
   | AgentsLoadedMessage
+  | SkillsLoadedMessage
   | AutocompleteSettingsLoadedMessage
   | ChatCompletionResultMessage
   | FileSearchResultMessage
@@ -1179,6 +1192,10 @@ export interface CompactRequest {
 
 export interface RequestAgentsMessage {
   type: "requestAgents"
+}
+
+export interface RequestSkillsMessage {
+  type: "requestSkills"
 }
 
 export interface SetLanguageRequest {
@@ -1538,6 +1555,7 @@ export type WebviewMessage =
   | RequestProvidersMessage
   | CompactRequest
   | RequestAgentsMessage
+  | RequestSkillsMessage
   | SetLanguageRequest
   | QuestionReplyRequest
   | QuestionRejectRequest


### PR DESCRIPTION
## Summary

- Adds a **Discovered Skills** section to the Agent Behaviour → Skills settings tab that shows all currently available skills fetched from the CLI backend (`GET /skill`)
- Each skill card displays the skill name, description, and the full file path to its `SKILL.md` location
- Follows the existing cached message pattern (like agents/providers) for fetching and pushing skill data to the webview
- i18n strings added for all 16 locales

<img width="1487" height="172" alt="CleanShot 2026-03-11 at 15 59 43" src="https://github.com/user-attachments/assets/9a5b59b2-f9f2-4cf6-926e-5a8963c318e9" />
