### PR TITLE
feat(agent-manager): lazy-load worktree diff details

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode"
 import * as fs from "fs"
 import * as path from "path"
-import type { KiloClient, Session, FileDiff } from "@kilocode/sdk/v2/client"
+import type { KiloClient, Session } from "@kilocode/sdk/v2/client"
 import type { KiloConnectionService } from "../services/cli-backend"
 import { getErrorMessage } from "../kilo-provider-utils"
 import { isAbsolutePath } from "../path-utils"
@@ -309,6 +309,10 @@ export class AgentManagerProvider implements vscode.Disposable {
     }
     if (m.type === "agentManager.requestWorktreeDiff") {
       void this.onRequestWorktreeDiff(m.sessionId)
+      return null
+    }
+    if (m.type === "agentManager.requestWorktreeDiffFile") {
+      void this.onRequestWorktreeDiffFile(m.sessionId, m.file)
       return null
     }
     if (m.type === "agentManager.applyWorktreeDiff") {
@@ -1717,7 +1721,7 @@ export class AgentManagerProvider implements vscode.Disposable {
     this.postToWebview({ type: "agentManager.worktreeDiffLoading", sessionId, loading: true })
     try {
       const client = this.connectionService.getClient()
-      const { data: diffs } = await client.worktree.diff(
+      const { data: diffs } = await client.worktree.diffSummary(
         { directory: target.directory, base: target.baseBranch },
         { throwOnError: true },
       )
@@ -1744,7 +1748,7 @@ export class AgentManagerProvider implements vscode.Disposable {
 
     try {
       const client = this.connectionService.getClient()
-      const { data: diffs } = await client.worktree.diff(
+      const { data: diffs } = await client.worktree.diffSummary(
         { directory: target.directory, base: target.baseBranch },
         { throwOnError: true },
       )
@@ -1758,6 +1762,31 @@ export class AgentManagerProvider implements vscode.Disposable {
       this.postToWebview({ type: "agentManager.worktreeDiff", sessionId, diffs: files })
     } catch (err) {
       this.log("Failed to poll worktree diff:", err)
+    }
+  }
+
+  private async onRequestWorktreeDiffFile(sessionId: string, file: string): Promise<void> {
+    if (!file) return
+
+    if (this.stateReady) {
+      await this.stateReady.catch((err) => this.log("stateReady rejected, continuing diff detail resolve:", err))
+    }
+
+    const target = this.cachedDiffTarget ?? (await this.resolveDiffTarget(sessionId))
+    if (!target) return
+
+    this.cachedDiffTarget = target
+
+    try {
+      const client = this.connectionService.getClient()
+      const { data } = await client.worktree.diffFile(
+        { directory: target.directory, base: target.baseBranch, file },
+        { throwOnError: true },
+      )
+      this.postToWebview({ type: "agentManager.worktreeDiffFile", sessionId, file, diff: data ?? null })
+    } catch (err) {
+      this.log("Failed to fetch worktree diff file:", err)
+      this.postToWebview({ type: "agentManager.worktreeDiffFile", sessionId, file, diff: null })
     }
   }
 

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -53,7 +53,7 @@ export class AgentManagerProvider implements vscode.Disposable {
   private lastDiffHash: string | undefined
   private statsPoller: GitStatsPoller
   private gitOps: GitOps
-  private cachedDiffTarget: { directory: string; baseBranch: string } | undefined
+  private cachedDiffTarget: { sessionId: string; directory: string; baseBranch: string } | undefined
   private staleWorktreeIds = new Set<string>()
   private cachedWorktreeStats: AgentManagerOutMessage | undefined
   private cachedLocalStats: AgentManagerOutMessage | undefined
@@ -1716,7 +1716,7 @@ export class AgentManagerProvider implements vscode.Disposable {
     if (!target) return
 
     // Cache the resolved target so subsequent polls skip resolution entirely
-    this.cachedDiffTarget = target
+    this.cachedDiffTarget = { sessionId, ...target }
 
     this.postToWebview({ type: "agentManager.worktreeDiffLoading", sessionId, loading: true })
     try {
@@ -1743,7 +1743,7 @@ export class AgentManagerProvider implements vscode.Disposable {
 
   /** Polling diff fetch — uses cached target, no loading state, only pushes when hash changes. */
   private async pollDiff(sessionId: string): Promise<void> {
-    const target = this.cachedDiffTarget
+    const target = this.cachedDiffTarget?.sessionId === sessionId ? this.cachedDiffTarget : undefined
     if (!target) return
 
     try {
@@ -1772,10 +1772,11 @@ export class AgentManagerProvider implements vscode.Disposable {
       await this.stateReady.catch((err) => this.log("stateReady rejected, continuing diff detail resolve:", err))
     }
 
-    const target = this.cachedDiffTarget ?? (await this.resolveDiffTarget(sessionId))
+    const target =
+      this.cachedDiffTarget?.sessionId === sessionId ? this.cachedDiffTarget : await this.resolveDiffTarget(sessionId)
     if (!target) return
 
-    this.cachedDiffTarget = target
+    this.cachedDiffTarget = { sessionId, directory: target.directory, baseBranch: target.baseBranch }
 
     try {
       const client = this.connectionService.getClient()

--- a/packages/kilo-vscode/src/agent-manager/GitStatsPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitStatsPoller.ts
@@ -149,7 +149,7 @@ export class GitStatsPoller {
           try {
             const base = remoteRef(wt)
             const [{ data: diffs }, ab] = await Promise.all([
-              client.worktree.diff({ directory: wt.path, base }, { throwOnError: true }),
+              client.worktree.diffSummary({ directory: wt.path, base }, { throwOnError: true }),
               this.git.aheadBehind(wt.path, base, wt.remote),
             ])
             const files = diffs.length
@@ -250,7 +250,7 @@ export class GitStatsPoller {
         if (base && client) {
           this.options.log(`Local stats: using HTTP client with base=${base}`)
           const [{ data: diffs }, ab] = await Promise.all([
-            client.worktree.diff({ directory: root, base }, { throwOnError: true }),
+            client.worktree.diffSummary({ directory: root, base }, { throwOnError: true }),
             this.git.aheadBehind(root, base, remote),
           ])
           files = diffs.length

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -26,6 +26,7 @@ export type WorktreeDiffEntry = FileDiff & {
   tracked?: boolean
   generatedLike?: boolean
   summarized?: boolean
+  stamp?: string
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -22,6 +22,12 @@ type SessionMode = "worktree" | "local"
 
 export type ApplyDiffStatus = "checking" | "applying" | "success" | "conflict" | "error"
 
+export type WorktreeDiffEntry = FileDiff & {
+  tracked?: boolean
+  generatedLike?: boolean
+  summarized?: boolean
+}
+
 // ---------------------------------------------------------------------------
 // Extension → Webview messages (postToWebview)
 // ---------------------------------------------------------------------------
@@ -148,7 +154,14 @@ interface WorktreeDiffLoadingMessage {
 interface WorktreeDiffMessage {
   type: "agentManager.worktreeDiff"
   sessionId: string
-  diffs: FileDiff[]
+  diffs: WorktreeDiffEntry[]
+}
+
+interface WorktreeDiffFileMessage {
+  type: "agentManager.worktreeDiffFile"
+  sessionId: string
+  file: string
+  diff: WorktreeDiffEntry | null
 }
 
 interface ActionOutMessage {
@@ -176,6 +189,7 @@ export type AgentManagerOutMessage =
   | ApplyWorktreeDiffResultMessage
   | WorktreeDiffLoadingMessage
   | WorktreeDiffMessage
+  | WorktreeDiffFileMessage
   | ActionOutMessage
 
 // ---------------------------------------------------------------------------
@@ -323,6 +337,12 @@ interface ApplyWorktreeDiffIn {
   selectedFiles?: string[]
 }
 
+interface RequestWorktreeDiffFileIn {
+  type: "agentManager.requestWorktreeDiffFile"
+  sessionId: string
+  file: string
+}
+
 interface StartDiffWatchIn {
   type: "agentManager.startDiffWatch"
   sessionId: string
@@ -390,6 +410,7 @@ export type AgentManagerInMessage =
   | ImportExternalWorktreeIn
   | ImportAllExternalWorktreesIn
   | RequestWorktreeDiffIn
+  | RequestWorktreeDiffFileIn
   | ApplyWorktreeDiffIn
   | StartDiffWatchIn
   | StopDiffWatchIn

--- a/packages/kilo-vscode/src/review-utils.ts
+++ b/packages/kilo-vscode/src/review-utils.ts
@@ -42,8 +42,30 @@ export async function resolveLocalDiffTarget(
   return { directory: root, baseBranch: base }
 }
 
-export function hashFileDiffs(diffs: FileDiff[]): string {
-  return diffs.map((diff) => `${diff.file}:${diff.status}:${diff.additions}:${diff.deletions}:${diff.after}`).join("|")
+export function hashFileDiffs(
+  diffs: Array<
+    FileDiff & {
+      tracked?: boolean
+      generatedLike?: boolean
+      summarized?: boolean
+    }
+  >,
+): string {
+  return diffs
+    .map((diff) => {
+      const content = diff.summarized ? "" : `${diff.before}:${diff.after}`
+      return [
+        diff.file,
+        diff.status,
+        diff.additions,
+        diff.deletions,
+        diff.tracked ? "tracked" : "untracked",
+        diff.generatedLike ? "generated" : "source",
+        diff.summarized ? "summary" : "detail",
+        content,
+      ].join(":")
+    })
+    .join("|")
 }
 
 export function openFileInEditor(

--- a/packages/kilo-vscode/src/review-utils.ts
+++ b/packages/kilo-vscode/src/review-utils.ts
@@ -48,6 +48,7 @@ export function hashFileDiffs(
       tracked?: boolean
       generatedLike?: boolean
       summarized?: boolean
+      stamp?: string
     }
   >,
 ): string {
@@ -62,6 +63,7 @@ export function hashFileDiffs(
         diff.tracked ? "tracked" : "untracked",
         diff.generatedLike ? "generated" : "source",
         diff.summarized ? "summary" : "detail",
+        diff.stamp ?? "",
         content,
       ].join(":")
     })

--- a/packages/kilo-vscode/tests/unit/agent-manager-diff-state.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-diff-state.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test"
+import { mergeWorktreeDiffs } from "../../webview-ui/agent-manager/diff-state"
+import { initialOpenFiles } from "../../webview-ui/agent-manager/diff-open-policy"
+import type { WorktreeFileDiff } from "../../webview-ui/src/types/messages"
+
+function diff(overrides: Partial<WorktreeFileDiff>): WorktreeFileDiff {
+  return {
+    file: "src/app.ts",
+    before: "",
+    after: "",
+    additions: 1,
+    deletions: 0,
+    status: "modified",
+    tracked: true,
+    generatedLike: false,
+    summarized: true,
+    ...overrides,
+  }
+}
+
+describe("agent manager diff state", () => {
+  it("preserves loaded detail when summary metadata is unchanged", () => {
+    const prev = [diff({ summarized: false, before: "old\n", after: "new\n" })]
+    const next = [diff({ summarized: true })]
+
+    expect(mergeWorktreeDiffs(prev, next)).toEqual([diff({ summarized: false, before: "old\n", after: "new\n" })])
+  })
+
+  it("drops cached detail when summary metadata changes", () => {
+    const prev = [diff({ summarized: false, before: "old\n", after: "new\n", additions: 1 })]
+    const next = [diff({ summarized: true, additions: 2 })]
+
+    expect(mergeWorktreeDiffs(prev, next)).toEqual(next)
+  })
+
+  it("does not auto-open generated-like files or large diff sets", () => {
+    expect(
+      initialOpenFiles([
+        diff({ file: "src/app.ts", generatedLike: false, additions: 3 }),
+        diff({ file: "node_modules/pkg/index.js", generatedLike: true, additions: 3 }),
+      ]),
+    ).toEqual(["src/app.ts"])
+
+    const many = Array.from({ length: 26 }, (_, i) => diff({ file: `src/${i}.ts` }))
+    expect(initialOpenFiles(many)).toEqual([])
+  })
+})

--- a/packages/kilo-vscode/tests/unit/agent-manager-diff-state.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-diff-state.test.ts
@@ -14,6 +14,7 @@ function diff(overrides: Partial<WorktreeFileDiff>): WorktreeFileDiff {
     tracked: true,
     generatedLike: false,
     summarized: true,
+    stamp: "1:1",
     ...overrides,
   }
 }
@@ -29,6 +30,13 @@ describe("agent manager diff state", () => {
   it("drops cached detail when summary metadata changes", () => {
     const prev = [diff({ summarized: false, before: "old\n", after: "new\n", additions: 1 })]
     const next = [diff({ summarized: true, additions: 2 })]
+
+    expect(mergeWorktreeDiffs(prev, next)).toEqual(next)
+  })
+
+  it("drops cached detail when the summary stamp changes", () => {
+    const prev = [diff({ summarized: false, before: "old\n", after: "new\n", stamp: "1:1" })]
+    const next = [diff({ summarized: true, stamp: "1:2" })]
 
     expect(mergeWorktreeDiffs(prev, next)).toEqual(next)
   })

--- a/packages/kilo-vscode/tests/unit/git-stats-poller.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-stats-poller.test.ts
@@ -46,7 +46,7 @@ describe("GitStatsPoller", () => {
 
     const client = {
       worktree: {
-        diff: async () => {
+        diffSummary: async () => {
           calls += 1
           running += 1
           max = Math.max(max, running)
@@ -89,7 +89,7 @@ describe("GitStatsPoller", () => {
 
     const client = {
       worktree: {
-        diff: async () => {
+        diffSummary: async () => {
           calls += 1
           if (calls === 1) return { data: diff(7, 3) }
           throw new Error("transient backend failure")
@@ -208,7 +208,7 @@ describe("GitStatsPoller", () => {
 
     const client = {
       worktree: {
-        diff: async ({ directory }: { directory: string }) => {
+        diffSummary: async ({ directory }: { directory: string }) => {
           calls.push(directory)
           return { data: diff(1, 1) }
         },
@@ -268,7 +268,7 @@ describe("GitStatsPoller", () => {
 
     const client = {
       worktree: {
-        diff: async () => {
+        diffSummary: async () => {
           diffCalls += 1
           if (diffCalls === 1) return { data: diff(5, 2) }
           throw new Error("transient backend failure")
@@ -316,7 +316,7 @@ describe("GitStatsPoller", () => {
     }> = []
 
     const client = {
-      worktree: { diff: async () => ({ data: diff(10, 4) }) },
+      worktree: { diffSummary: async () => ({ data: diff(10, 4) }) },
     } as unknown as KiloClient
 
     const poller = new GitStatsPoller({
@@ -366,7 +366,7 @@ describe("GitStatsPoller", () => {
     }> = []
 
     const client = {
-      worktree: { diff: async () => ({ data: diff(0, 0) }) },
+      worktree: { diffSummary: async () => ({ data: diff(0, 0) }) },
     } as unknown as KiloClient
 
     const poller = new GitStatsPoller({
@@ -413,7 +413,7 @@ describe("GitStatsPoller", () => {
     > = []
 
     const client = {
-      worktree: { diff: async () => ({ data: diff(0, 0) }) },
+      worktree: { diffSummary: async () => ({ data: diff(0, 0) }) },
     } as unknown as KiloClient
 
     // Worktrees store remote="upstream" so aheadBehind receives "upstream/main"

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -22,6 +22,7 @@ import type {
   AgentManagerSendInitialMessage,
   AgentManagerBranchesMessage,
   AgentManagerWorktreeDiffMessage,
+  AgentManagerWorktreeDiffFileMessage,
   AgentManagerWorktreeDiffLoadingMessage,
   AgentManagerApplyWorktreeDiffResultMessage,
   AgentManagerApplyWorktreeDiffStatus,
@@ -76,6 +77,7 @@ import { groupApplyConflicts } from "./apply-conflicts"
 import type { ReviewComment } from "./review-comments"
 import { BranchSelect } from "./BranchSelect"
 import { WorktreeItem } from "./WorktreeItem"
+import { mergeWorktreeDiffs } from "./diff-state"
 import "./agent-manager.css"
 import "./agent-manager-review.css"
 
@@ -325,6 +327,7 @@ const AgentManagerContent: Component = () => {
   const [diffOpen, setDiffOpen] = createSignal(false)
   const [diffDatas, setDiffDatas] = createSignal<Record<string, WorktreeFileDiff[]>>({})
   const [diffLoading, setDiffLoading] = createSignal(false)
+  const [diffFileLoading, setDiffFileLoading] = createSignal<Record<string, Record<string, true>>>({})
   const [diffWidth, setDiffWidth] = createSignal(Math.round(window.innerWidth * 0.5))
 
   // Full-screen review state (in-memory, per sidebar context: local/worktree)
@@ -1215,22 +1218,40 @@ const AgentManagerContent: Component = () => {
         const ev = msg as AgentManagerWorktreeDiffMessage
         setDiffDatas((prev) => {
           const existing = prev[ev.sessionId]
-          // Reuse previous array reference when content is unchanged to prevent
-          // <For> from tearing down / rebuilding <Diff> components (which resets scroll)
-          if (existing && existing.length === ev.diffs.length) {
+          const next = existing ? mergeWorktreeDiffs(existing, ev.diffs) : ev.diffs
+          if (existing && existing.length === next.length) {
             const same = existing.every((old, i) => {
-              const next = ev.diffs[i]!
+              const item = next[i]!
               return (
-                old.file === next.file &&
-                old.before === next.before &&
-                old.after === next.after &&
-                old.status === next.status
+                old.file === item.file &&
+                old.before === item.before &&
+                old.after === item.after &&
+                old.status === item.status &&
+                old.tracked === item.tracked &&
+                old.generatedLike === item.generatedLike &&
+                old.summarized === item.summarized &&
+                old.additions === item.additions &&
+                old.deletions === item.deletions
               )
             })
             if (same) return prev
           }
-          return { ...prev, [ev.sessionId]: ev.diffs }
+          return { ...prev, [ev.sessionId]: next }
         })
+      }
+
+      if (msg.type === "agentManager.worktreeDiffFile") {
+        const ev = msg as AgentManagerWorktreeDiffFileMessage
+        if (ev.diff) {
+          setDiffDatas((prev) => {
+            const existing = prev[ev.sessionId] ?? []
+            const next = existing.map((item) => (item.file === ev.diff!.file ? ev.diff! : item))
+            return { ...prev, [ev.sessionId]: next }
+          })
+          setDiffFilePending(ev.sessionId, ev.diff.file, false)
+          return
+        }
+        setDiffFilePending(ev.sessionId, ev.file, false)
       }
 
       if (msg.type === "agentManager.worktreeDiffLoading") {
@@ -1394,6 +1415,20 @@ const AgentManagerContent: Component = () => {
     return []
   })
 
+  const currentDiffSessionId = createMemo(() => {
+    const sel = selection()
+    if (sel === LOCAL) return LOCAL
+
+    const current = session.currentSessionID()
+    if (current) {
+      const item = managedSessions().find((entry) => entry.id === current)
+      if (sel && item?.worktreeId === sel) return current
+    }
+
+    if (!sel) return undefined
+    return managedSessions().find((entry) => entry.worktreeId === sel)?.id
+  })
+
   const diffSessionKey = createMemo(() => {
     const sel = selection()
     if (sel === LOCAL) return `local:${LOCAL}`
@@ -1406,6 +1441,46 @@ const AgentManagerContent: Component = () => {
     setReviewDiffStyle(style)
     vscode.postMessage({ type: "agentManager.setReviewDiffStyle", style })
   }
+
+  const setDiffFilePending = (sessionId: string, file: string, value: boolean) => {
+    setDiffFileLoading((prev) => {
+      const session = prev[sessionId] ?? {}
+      if (value) {
+        if (session[file]) return prev
+        return {
+          ...prev,
+          [sessionId]: { ...session, [file]: true },
+        }
+      }
+
+      if (!session[file]) return prev
+      const next = { ...session }
+      delete next[file]
+      if (Object.keys(next).length === 0) {
+        const result = { ...prev }
+        delete result[sessionId]
+        return result
+      }
+      return {
+        ...prev,
+        [sessionId]: next,
+      }
+    })
+  }
+
+  const requestDiffFile = (file: string) => {
+    const sessionId = currentDiffSessionId()
+    if (!sessionId) return
+    if (diffFileLoading()[sessionId]?.[file]) return
+    setDiffFilePending(sessionId, file, true)
+    vscode.postMessage({ type: "agentManager.requestWorktreeDiffFile", sessionId, file })
+  }
+
+  const diffFileLoadingForCurrent = createMemo(() => {
+    const sessionId = currentDiffSessionId()
+    if (!sessionId) return new Set<string>()
+    return new Set(Object.keys(diffFileLoading()[sessionId] ?? {}))
+  })
 
   const handleConfigureSetupScript = () => {
     vscode.postMessage({ type: "agentManager.configureSetupScript" })
@@ -2463,8 +2538,10 @@ const AgentManagerContent: Component = () => {
                 />
                 <div class="am-diff-panel-wrapper">
                   <DiffPanel
-                    diffs={diffDatas()[selection() === LOCAL ? LOCAL : (session.currentSessionID() ?? "")] ?? []}
+                    diffs={diffDatas()[currentDiffSessionId() ?? ""] ?? []}
                     loading={diffLoading()}
+                    loadingFiles={diffFileLoadingForCurrent()}
+                    sessionId={currentDiffSessionId()}
                     sessionKey={diffSessionKey()}
                     diffStyle={reviewDiffStyle()}
                     onDiffStyleChange={setSharedDiffStyle}
@@ -2472,8 +2549,9 @@ const AgentManagerContent: Component = () => {
                     onCommentsChange={setReviewCommentsForSelection}
                     onClose={() => setDiffOpen(false)}
                     onExpand={selection() !== null ? openReviewTab : undefined}
+                    onRequestDiff={requestDiffFile}
                     onOpenFile={(file) => {
-                      const id = session.currentSessionID()
+                      const id = currentDiffSessionId()
                       if (id) vscode.postMessage({ type: "agentManager.openFile", sessionId: id, filePath: file })
                       else if (selection() === LOCAL) vscode.postMessage({ type: "openFile", filePath: file })
                     }}
@@ -2488,14 +2566,17 @@ const AgentManagerContent: Component = () => {
               <FullScreenDiffView
                 diffs={reviewDiffs()}
                 loading={diffLoading()}
+                loadingFiles={diffFileLoadingForCurrent()}
+                sessionId={currentDiffSessionId()}
                 sessionKey={diffSessionKey()}
                 comments={reviewComments()}
                 onCommentsChange={setReviewCommentsForSelection}
                 onSendAll={closeReviewTab}
                 diffStyle={reviewDiffStyle()}
                 onDiffStyleChange={setSharedDiffStyle}
+                onRequestDiff={requestDiffFile}
                 onOpenFile={(file) => {
-                  const id = session.currentSessionID()
+                  const id = currentDiffSessionId()
                   if (id) vscode.postMessage({ type: "agentManager.openFile", sessionId: id, filePath: file })
                   else if (selection() === LOCAL) vscode.postMessage({ type: "openFile", filePath: file })
                 }}

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -23,6 +23,8 @@ import { DiffEndMarker } from "./DiffEndMarker"
 interface DiffPanelProps {
   diffs: WorktreeFileDiff[]
   loading: boolean
+  loadingFiles?: Set<string>
+  sessionId?: string
   sessionKey?: string
   diffStyle?: "unified" | "split"
   onDiffStyleChange?: (style: "unified" | "split") => void
@@ -31,6 +33,7 @@ interface DiffPanelProps {
   onSendAll?: () => void
   onClose: () => void
   onExpand?: () => void
+  onRequestDiff?: (file: string) => void
   onOpenFile?: (relativePath: string) => void
 }
 
@@ -142,6 +145,22 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
           return filtered
         })
       },
+    ),
+  )
+
+  createEffect(
+    on(
+      () => [open(), props.diffs] as const,
+      ([next]) => {
+        const loading = props.loadingFiles ?? new Set<string>()
+        for (const file of next) {
+          if (loading.has(file)) continue
+          const diff = props.diffs.find((item) => item.file === file)
+          if (!diff || diff.summarized !== true) continue
+          props.onRequestDiff?.(file)
+        }
+      },
+      { defer: true },
     ),
   )
 
@@ -371,6 +390,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                 const isAdded = () => diff.status === "added"
                 const isDeleted = () => diff.status === "deleted"
                 const isLargeCollapsed = () => isLargeDiffFile(diff) && !open().includes(diff.file)
+                const isLoadingDetail = () => props.loadingFiles?.has(diff.file) ?? false
                 const fileCommentCount = () => (commentsByFile().get(diff.file) ?? []).length
 
                 return (
@@ -405,6 +425,12 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                             <Show when={isLargeCollapsed()}>
                               <span class="am-diff-large-pill">{t("agentManager.review.largeFileCollapsed")}</span>
                             </Show>
+                            <Show when={diff.tracked === false}>
+                              <span class="am-diff-summary-pill">untracked</span>
+                            </Show>
+                            <Show when={diff.generatedLike === true}>
+                              <span class="am-diff-summary-pill">generated</span>
+                            </Show>
                             <Show when={props.onOpenFile && !isDeleted()}>
                               <Tooltip value={t("agentManager.diff.openFile")} placement="top">
                                 <IconButton
@@ -428,15 +454,29 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                     </StickyAccordionHeader>
                     <Accordion.Content>
                       <Show when={open().includes(diff.file)}>
-                        <Diff<AnnotationMeta>
-                          before={{ name: diff.file, contents: diff.before }}
-                          after={{ name: diff.file, contents: diff.after }}
-                          diffStyle={props.diffStyle ?? "unified"}
-                          annotations={annotationsForFile(diff.file)}
-                          renderAnnotation={buildAnnotation}
-                          enableGutterUtility={true}
-                          onGutterUtilityClick={(result) => handleGutterClick(diff.file, result)}
-                        />
+                        <Show
+                          when={diff.summarized !== true}
+                          fallback={
+                            <div class="am-diff-summary-state">
+                              <Show when={isLoadingDetail()} fallback={<span>Diff preview loads on demand.</span>}>
+                                <>
+                                  <Spinner />
+                                  <span>Loading diff...</span>
+                                </>
+                              </Show>
+                            </div>
+                          }
+                        >
+                          <Diff<AnnotationMeta>
+                            before={{ name: diff.file, contents: diff.before }}
+                            after={{ name: diff.file, contents: diff.after }}
+                            diffStyle={props.diffStyle ?? "unified"}
+                            annotations={annotationsForFile(diff.file)}
+                            renderAnnotation={buildAnnotation}
+                            enableGutterUtility={true}
+                            onGutterUtilityClick={(result) => handleGutterClick(diff.file, result)}
+                          />
+                        </Show>
                       </Show>
                     </Accordion.Content>
                   </Accordion.Item>

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -25,12 +25,15 @@ type DiffStyle = "unified" | "split"
 interface FullScreenDiffViewProps {
   diffs: WorktreeFileDiff[]
   loading: boolean
+  loadingFiles?: Set<string>
+  sessionId?: string
   sessionKey?: string
   comments: ReviewComment[]
   onCommentsChange: (comments: ReviewComment[]) => void
   onSendAll?: () => void
   diffStyle: DiffStyle
   onDiffStyleChange: (style: DiffStyle) => void
+  onRequestDiff?: (file: string) => void
   onOpenFile?: (relativePath: string) => void
   onClose: () => void
 }
@@ -143,6 +146,22 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
           return filtered
         })
       },
+    ),
+  )
+
+  createEffect(
+    on(
+      () => [open(), props.diffs] as const,
+      ([next]) => {
+        const loading = props.loadingFiles ?? new Set<string>()
+        for (const file of next) {
+          if (loading.has(file)) continue
+          const diff = props.diffs.find((item) => item.file === file)
+          if (!diff || diff.summarized !== true) continue
+          props.onRequestDiff?.(file)
+        }
+      },
+      { defer: true },
     ),
   )
 
@@ -471,6 +490,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                     const isAdded = () => diff.status === "added"
                     const isDeleted = () => diff.status === "deleted"
                     const isLargeCollapsed = () => isLargeDiffFile(diff) && !open().includes(diff.file)
+                    const isLoadingDetail = () => props.loadingFiles?.has(diff.file) ?? false
                     const fileCommentCount = () => (commentsByFile().get(diff.file) ?? []).length
 
                     return (
@@ -505,6 +525,12 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                                 <Show when={isLargeCollapsed()}>
                                   <span class="am-diff-large-pill">{t("agentManager.review.largeFileCollapsed")}</span>
                                 </Show>
+                                <Show when={diff.tracked === false}>
+                                  <span class="am-diff-summary-pill">untracked</span>
+                                </Show>
+                                <Show when={diff.generatedLike === true}>
+                                  <span class="am-diff-summary-pill">generated</span>
+                                </Show>
                                 <Show when={props.onOpenFile && !isDeleted()}>
                                   <Tooltip value={t("agentManager.diff.openFile")} placement="top">
                                     <IconButton
@@ -528,15 +554,29 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                         </StickyAccordionHeader>
                         <Accordion.Content>
                           <Show when={open().includes(diff.file)}>
-                            <Diff<AnnotationMeta>
-                              before={{ name: diff.file, contents: diff.before }}
-                              after={{ name: diff.file, contents: diff.after }}
-                              diffStyle={props.diffStyle}
-                              annotations={annotationsForFile(diff.file)}
-                              renderAnnotation={buildAnnotation}
-                              enableGutterUtility={true}
-                              onGutterUtilityClick={(result) => handleGutterClick(diff.file, result)}
-                            />
+                            <Show
+                              when={diff.summarized !== true}
+                              fallback={
+                                <div class="am-diff-summary-state">
+                                  <Show when={isLoadingDetail()} fallback={<span>Diff preview loads on demand.</span>}>
+                                    <>
+                                      <Spinner />
+                                      <span>Loading diff...</span>
+                                    </>
+                                  </Show>
+                                </div>
+                              }
+                            >
+                              <Diff<AnnotationMeta>
+                                before={{ name: diff.file, contents: diff.before }}
+                                after={{ name: diff.file, contents: diff.after }}
+                                diffStyle={props.diffStyle}
+                                annotations={annotationsForFile(diff.file)}
+                                renderAnnotation={buildAnnotation}
+                                enableGutterUtility={true}
+                                onGutterUtilityClick={(result) => handleGutterClick(diff.file, result)}
+                              />
+                            </Show>
                           </Show>
                         </Accordion.Content>
                       </Accordion.Item>

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1367,6 +1367,33 @@ button.am-section-toggle:hover .am-section-label {
   flex-shrink: 0;
 }
 
+.am-diff-summary-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  height: 18px;
+  border-radius: 9px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-weak);
+  background: color-mix(in oklab, var(--surface-interactive-base) 70%, transparent);
+  border: 1px solid var(--border-weak-base);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.am-diff-summary-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 96px;
+  padding: 12px;
+  border-top: 1px solid var(--border-weak-base);
+  color: var(--text-weak);
+  font-size: var(--font-size-small);
+}
+
 /* Comments footer bar */
 
 .am-diff-comments-footer {

--- a/packages/kilo-vscode/webview-ui/agent-manager/diff-open-policy.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/diff-open-policy.ts
@@ -1,6 +1,8 @@
 import type { WorktreeFileDiff } from "../src/types/messages"
 
 export const LONG_DIFF_MARKER_FILE_COUNT = 50
+const AUTO_OPEN_FILE_COUNT = 25
+const AUTO_OPEN_LIMIT = 8
 const LARGE_FILE_CHANGED_LINES = 400
 
 export function isLargeDiffFile(diff: WorktreeFileDiff): boolean {
@@ -9,7 +11,11 @@ export function isLargeDiffFile(diff: WorktreeFileDiff): boolean {
 
 export function initialOpenFiles(diffs: WorktreeFileDiff[]): string[] {
   if (diffs.length === 0) return []
+  if (diffs.length > AUTO_OPEN_FILE_COUNT) return []
 
-  const files = diffs.filter((diff) => !isLargeDiffFile(diff)).map((diff) => diff.file)
+  const files = diffs
+    .filter((diff) => !isLargeDiffFile(diff) && diff.generatedLike !== true)
+    .slice(0, AUTO_OPEN_LIMIT)
+    .map((diff) => diff.file)
   return files
 }

--- a/packages/kilo-vscode/webview-ui/agent-manager/diff-state.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/diff-state.ts
@@ -8,7 +8,8 @@ export function sameDiffMeta(left: WorktreeFileDiff, right: WorktreeFileDiff) {
     left.deletions === right.deletions &&
     left.tracked === right.tracked &&
     left.generatedLike === right.generatedLike &&
-    left.summarized === right.summarized
+    left.summarized === right.summarized &&
+    left.stamp === right.stamp
   )
 }
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/diff-state.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/diff-state.ts
@@ -23,7 +23,3 @@ export function mergeWorktreeDiffs(prev: WorktreeFileDiff[], next: WorktreeFileD
     return { ...diff, before: existing.before, after: existing.after, summarized: false }
   })
 }
-
-export function hasDiffDetail(diff: WorktreeFileDiff) {
-  return diff.summarized !== true
-}

--- a/packages/kilo-vscode/webview-ui/agent-manager/diff-state.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/diff-state.ts
@@ -1,0 +1,29 @@
+import type { WorktreeFileDiff } from "../src/types/messages"
+
+export function sameDiffMeta(left: WorktreeFileDiff, right: WorktreeFileDiff) {
+  return (
+    left.file === right.file &&
+    left.status === right.status &&
+    left.additions === right.additions &&
+    left.deletions === right.deletions &&
+    left.tracked === right.tracked &&
+    left.generatedLike === right.generatedLike &&
+    left.summarized === right.summarized
+  )
+}
+
+export function mergeWorktreeDiffs(prev: WorktreeFileDiff[], next: WorktreeFileDiff[]) {
+  const map = new Map(prev.map((diff) => [diff.file, diff]))
+  return next.map((diff) => {
+    const existing = map.get(diff.file)
+    if (!existing) return diff
+    if (existing.summarized) return diff
+    if (!diff.summarized) return diff
+    if (!sameDiffMeta({ ...existing, summarized: true }, diff)) return diff
+    return { ...diff, before: existing.before, after: existing.after, summarized: false }
+  })
+}
+
+export function hasDiffDetail(diff: WorktreeFileDiff) {
+  return diff.summarized !== true
+}

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -755,6 +755,9 @@ export interface WorktreeFileDiff {
   additions: number
   deletions: number
   status?: "added" | "deleted" | "modified"
+  tracked?: boolean
+  generatedLike?: boolean
+  summarized?: boolean
 }
 
 // Agent Manager: Diff data push (extension → webview)
@@ -762,6 +765,13 @@ export interface AgentManagerWorktreeDiffMessage {
   type: "agentManager.worktreeDiff"
   sessionId: string
   diffs: WorktreeFileDiff[]
+}
+
+export interface AgentManagerWorktreeDiffFileMessage {
+  type: "agentManager.worktreeDiffFile"
+  sessionId: string
+  file: string
+  diff: WorktreeFileDiff | null
 }
 
 // Agent Manager: Diff loading state (extension → webview)
@@ -1038,6 +1048,7 @@ export type ExtensionMessage =
   | AgentManagerImportResultMessage
   | WorkspaceDirectoryChangedMessage
   | AgentManagerWorktreeDiffMessage
+  | AgentManagerWorktreeDiffFileMessage
   | AgentManagerWorktreeDiffLoadingMessage
   | AgentManagerApplyWorktreeDiffResultMessage
   | AgentManagerWorktreeStatsMessage
@@ -1463,6 +1474,12 @@ export interface RequestWorktreeDiffMessage {
   sessionId: string
 }
 
+export interface RequestWorktreeDiffFileMessage {
+  type: "agentManager.requestWorktreeDiffFile"
+  sessionId: string
+  file: string
+}
+
 // Agent Manager: Start polling for live diff updates (webview → extension)
 export interface StartDiffWatchMessage {
   type: "agentManager.startDiffWatch"
@@ -1589,6 +1606,7 @@ export type WebviewMessage =
   | ImportExternalWorktreeRequest
   | ImportAllExternalWorktreesRequest
   | RequestWorktreeDiffMessage
+  | RequestWorktreeDiffFileMessage
   | StartDiffWatchMessage
   | StopDiffWatchMessage
   // legacy-migration start

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -758,6 +758,7 @@ export interface WorktreeFileDiff {
   tracked?: boolean
   generatedLike?: boolean
   summarized?: boolean
+  stamp?: string
 }
 
 // Agent Manager: Diff data push (extension → webview)

--- a/packages/opencode/src/kilocode/review/worktree-diff.ts
+++ b/packages/opencode/src/kilocode/review/worktree-diff.ts
@@ -136,6 +136,62 @@ export namespace WorktreeDiff {
     return result
   }
 
+  async function detailMeta(dir: string, ancestor: string, file: string): Promise<Meta | undefined> {
+    const tracked = await $`git ls-files --error-unmatch -- ${file}`.cwd(dir).quiet().nothrow()
+    if (tracked.exitCode !== 0) {
+      const after = Bun.file(path.join(dir, file))
+      if (!(await after.exists())) return undefined
+      return {
+        file,
+        additions: await lineCount(path.join(dir, file)),
+        deletions: 0,
+        status: "added",
+        tracked: false,
+        generatedLike: generatedLike(file),
+        stamp: await statStamp(dir, file),
+      }
+    }
+
+    const nameStatus = await $`git -c core.quotepath=false diff --name-status --no-renames ${ancestor} -- ${file}`
+      .cwd(dir)
+      .quiet()
+      .nothrow()
+    if (nameStatus.exitCode !== 0) return undefined
+    const line = nameStatus.stdout.toString().trim().split("\n")[0]
+    if (!line) return undefined
+
+    const parts = line.split("\t")
+    const code = parts[0]
+    const pathPart = parts.slice(1).join("\t") || file
+    if (!code) return undefined
+
+    const numstat = await $`git -c core.quotepath=false diff --numstat --no-renames ${ancestor} -- ${file}`
+      .cwd(dir)
+      .quiet()
+      .nothrow()
+    const statLine = numstat.stdout.toString().trim().split("\n")[0]
+    const stat = statLine
+      ? (() => {
+          const values = statLine.split("\t")
+          return {
+            additions: values[0] === "-" ? 0 : parseInt(values[0] || "0", 10),
+            deletions: values[1] === "-" ? 0 : parseInt(values[1] || "0", 10),
+          }
+        })()
+      : { additions: 0, deletions: 0 }
+
+    const status = code === "A" ? "added" : code === "D" ? "deleted" : "modified"
+    return {
+      file: pathPart,
+      additions: stat.additions,
+      deletions: stat.deletions,
+      status,
+      tracked: true,
+      generatedLike: generatedLike(pathPart),
+      stamp: status === "deleted" ? `deleted:${ancestor}` : await statStamp(dir, pathPart),
+    }
+  }
+
   function lines(text: string) {
     if (!text) return 0
     return text.endsWith("\n") ? text.split("\n").length - 1 : text.split("\n").length
@@ -228,8 +284,7 @@ export namespace WorktreeDiff {
     const log = input.log ?? Log.create({ service: "worktree-diff" })
     const ancestorHash = await ancestor(input.dir, input.base, log)
     if (!ancestorHash) return undefined
-    const items = await list(input.dir, ancestorHash, log)
-    const item = items.find((item) => item.file === input.file)
+    const item = await detailMeta(input.dir, ancestorHash, input.file)
     if (!item) return undefined
     return await load(input.dir, ancestorHash, item)
   }

--- a/packages/opencode/src/kilocode/review/worktree-diff.ts
+++ b/packages/opencode/src/kilocode/review/worktree-diff.ts
@@ -1,0 +1,214 @@
+// kilocode_change - new file
+import { $ } from "bun"
+import path from "node:path"
+import z from "zod"
+import { FileIgnore } from "@/file/ignore"
+import { Snapshot } from "@/snapshot"
+import { Log } from "@/util/log"
+
+export namespace WorktreeDiff {
+  export const Item = Snapshot.FileDiff.extend({
+    tracked: z.boolean(),
+    generatedLike: z.boolean(),
+    summarized: z.boolean(),
+  }).meta({
+    ref: "WorktreeDiffItem",
+  })
+  export type Item = z.infer<typeof Item>
+
+  type Status = NonNullable<Snapshot.FileDiff["status"]>
+
+  type Meta = {
+    file: string
+    additions: number
+    deletions: number
+    status: Status
+    tracked: boolean
+    generatedLike: boolean
+  }
+
+  function generatedLike(file: string) {
+    return FileIgnore.match(file)
+  }
+
+  async function ancestor(dir: string, base: string, log: Log.Logger) {
+    const result = await $`git merge-base HEAD ${base}`.cwd(dir).quiet().nothrow()
+    if (result.exitCode !== 0) {
+      log.warn("git merge-base failed", {
+        exitCode: result.exitCode,
+        stderr: result.stderr.toString().trim(),
+        dir,
+        base,
+      })
+      return
+    }
+    return result.stdout.toString().trim()
+  }
+
+  async function stats(dir: string, ancestor: string) {
+    const result = await $`git -c core.quotepath=false diff --numstat --no-renames ${ancestor}`
+      .cwd(dir)
+      .quiet()
+      .nothrow()
+    const map = new Map<string, { additions: number; deletions: number }>()
+    if (result.exitCode !== 0) return map
+
+    for (const line of result.stdout.toString().trim().split("\n")) {
+      if (!line) continue
+      const parts = line.split("\t")
+      const add = parts[0]
+      const del = parts[1]
+      const file = parts.slice(2).join("\t")
+      if (!file) continue
+      map.set(file, {
+        additions: add === "-" ? 0 : parseInt(add || "0", 10),
+        deletions: del === "-" ? 0 : parseInt(del || "0", 10),
+      })
+    }
+
+    return map
+  }
+
+  async function list(dir: string, ancestor: string, log: Log.Logger): Promise<Meta[]> {
+    const nameStatus = await $`git -c core.quotepath=false diff --name-status --no-renames ${ancestor}`
+      .cwd(dir)
+      .quiet()
+      .nothrow()
+    if (nameStatus.exitCode !== 0) return []
+
+    const result: Meta[] = []
+    const seen = new Set<string>()
+    const stat = await stats(dir, ancestor)
+
+    for (const line of nameStatus.stdout.toString().trim().split("\n")) {
+      if (!line) continue
+      const parts = line.split("\t")
+      const code = parts[0]
+      const file = parts.slice(1).join("\t")
+      if (!file || !code) continue
+
+      seen.add(file)
+      const status = code === "A" ? "added" : code === "D" ? "deleted" : "modified"
+      const counts = stat.get(file) ?? { additions: 0, deletions: 0 }
+      result.push({
+        file,
+        additions: counts.additions,
+        deletions: counts.deletions,
+        status,
+        tracked: true,
+        generatedLike: generatedLike(file),
+      })
+    }
+
+    const untracked = await $`git ls-files --others --exclude-standard`.cwd(dir).quiet().nothrow()
+    if (untracked.exitCode !== 0) {
+      log.warn("git ls-files failed", {
+        exitCode: untracked.exitCode,
+        stderr: untracked.stderr.toString().trim(),
+      })
+      return result
+    }
+
+    const files = untracked.stdout.toString().trim()
+    if (files) {
+      log.info("untracked files found", { count: files.split("\n").length })
+    }
+
+    for (const file of files.split("\n")) {
+      if (!file || seen.has(file)) continue
+      const after = Bun.file(path.join(dir, file))
+      if (!(await after.exists())) continue
+      result.push({
+        file,
+        additions: 0,
+        deletions: 0,
+        status: "added",
+        tracked: false,
+        generatedLike: generatedLike(file),
+      })
+    }
+
+    return result
+  }
+
+  function lines(text: string) {
+    if (!text) return 0
+    return text.endsWith("\n") ? text.split("\n").length - 1 : text.split("\n").length
+  }
+
+  async function readBefore(dir: string, ancestor: string, file: string, status: Status) {
+    if (status === "added") return ""
+    const result = await $`git show ${ancestor}:${file}`.cwd(dir).quiet().nothrow()
+    return result.exitCode === 0 ? result.stdout.toString() : ""
+  }
+
+  async function readAfter(dir: string, file: string, status: Status) {
+    if (status === "deleted") return ""
+    const result = Bun.file(path.join(dir, file))
+    return (await result.exists()) ? await result.text() : ""
+  }
+
+  async function load(dir: string, ancestor: string, meta: Meta): Promise<Item> {
+    const before = await readBefore(dir, ancestor, meta.file, meta.status)
+    const after = await readAfter(dir, meta.file, meta.status)
+    const additions = meta.status === "added" && meta.additions === 0 && !meta.tracked ? lines(after) : meta.additions
+    return {
+      file: meta.file,
+      before,
+      after,
+      additions,
+      deletions: meta.deletions,
+      status: meta.status,
+      tracked: meta.tracked,
+      generatedLike: meta.generatedLike,
+      summarized: false,
+    }
+  }
+
+  function summarize(meta: Meta): Item {
+    return {
+      file: meta.file,
+      before: "",
+      after: "",
+      additions: meta.additions,
+      deletions: meta.deletions,
+      status: meta.status,
+      tracked: meta.tracked,
+      generatedLike: meta.generatedLike,
+      summarized: true,
+    }
+  }
+
+  export async function summary(input: { dir: string; base: string; log?: Log.Logger }) {
+    const log = input.log ?? Log.create({ service: "worktree-diff" })
+    const base = input.base
+    const ancestorHash = await ancestor(input.dir, base, log)
+    if (!ancestorHash) return []
+    log.info("merge-base resolved", { ancestor: ancestorHash.slice(0, 12) })
+    const items = await list(input.dir, ancestorHash, log)
+    log.info("diff summary complete", { totalFiles: items.length })
+    return items.map(summarize)
+  }
+
+  export async function detail(input: { dir: string; base: string; file: string; log?: Log.Logger }) {
+    const log = input.log ?? Log.create({ service: "worktree-diff" })
+    const ancestorHash = await ancestor(input.dir, input.base, log)
+    if (!ancestorHash) return undefined
+    const items = await list(input.dir, ancestorHash, log)
+    const item = items.find((item) => item.file === input.file)
+    if (!item) return undefined
+    return await load(input.dir, ancestorHash, item)
+  }
+
+  export async function full(input: { dir: string; base: string; log?: Log.Logger }) {
+    const log = input.log ?? Log.create({ service: "worktree-diff" })
+    const base = input.base
+    const ancestorHash = await ancestor(input.dir, base, log)
+    if (!ancestorHash) return []
+    log.info("merge-base resolved", { ancestor: ancestorHash.slice(0, 12) })
+    const items = await list(input.dir, ancestorHash, log)
+    const result = await Promise.all(items.map((item) => load(input.dir, ancestorHash, item)))
+    log.info("diff complete", { totalFiles: result.length })
+    return result
+  }
+}

--- a/packages/opencode/src/kilocode/review/worktree-diff.ts
+++ b/packages/opencode/src/kilocode/review/worktree-diff.ts
@@ -122,10 +122,9 @@ export namespace WorktreeDiff {
       if (!file || seen.has(file)) continue
       const after = Bun.file(path.join(dir, file))
       if (!(await after.exists())) continue
-      const text = await after.text()
       result.push({
         file,
-        additions: lines(text),
+        additions: await lineCount(path.join(dir, file)),
         deletions: 0,
         status: "added",
         tracked: false,
@@ -140,6 +139,27 @@ export namespace WorktreeDiff {
   function lines(text: string) {
     if (!text) return 0
     return text.endsWith("\n") ? text.split("\n").length - 1 : text.split("\n").length
+  }
+
+  async function lineCount(file: string) {
+    let count = 0
+    let size = 0
+    let last = 10
+    const reader = Bun.file(file).stream().getReader()
+
+    while (true) {
+      const result = await reader.read()
+      if (result.done) break
+      const bytes = result.value instanceof Uint8Array ? result.value : new Uint8Array(result.value)
+      size += bytes.length
+      for (const byte of bytes) {
+        if (byte === 10) count += 1
+        last = byte
+      }
+    }
+
+    if (size === 0) return 0
+    return last === 10 ? count : count + 1
   }
 
   async function statStamp(dir: string, file: string) {

--- a/packages/opencode/src/kilocode/review/worktree-diff.ts
+++ b/packages/opencode/src/kilocode/review/worktree-diff.ts
@@ -1,5 +1,6 @@
 // kilocode_change - new file
 import { $ } from "bun"
+import fs from "node:fs/promises"
 import path from "node:path"
 import z from "zod"
 import { FileIgnore } from "@/file/ignore"
@@ -11,6 +12,7 @@ export namespace WorktreeDiff {
     tracked: z.boolean(),
     generatedLike: z.boolean(),
     summarized: z.boolean(),
+    stamp: z.string(),
   }).meta({
     ref: "WorktreeDiffItem",
   })
@@ -25,6 +27,7 @@ export namespace WorktreeDiff {
     status: Status
     tracked: boolean
     generatedLike: boolean
+    stamp: string
   }
 
   function generatedLike(file: string) {
@@ -97,6 +100,7 @@ export namespace WorktreeDiff {
         status,
         tracked: true,
         generatedLike: generatedLike(file),
+        stamp: status === "deleted" ? `deleted:${ancestor}` : await statStamp(dir, file),
       })
     }
 
@@ -118,13 +122,15 @@ export namespace WorktreeDiff {
       if (!file || seen.has(file)) continue
       const after = Bun.file(path.join(dir, file))
       if (!(await after.exists())) continue
+      const text = await after.text()
       result.push({
         file,
-        additions: 0,
+        additions: lines(text),
         deletions: 0,
         status: "added",
         tracked: false,
         generatedLike: generatedLike(file),
+        stamp: await statStamp(dir, file),
       })
     }
 
@@ -134,6 +140,12 @@ export namespace WorktreeDiff {
   function lines(text: string) {
     if (!text) return 0
     return text.endsWith("\n") ? text.split("\n").length - 1 : text.split("\n").length
+  }
+
+  async function statStamp(dir: string, file: string) {
+    const stat = await fs.stat(path.join(dir, file)).catch(() => undefined)
+    if (!stat) return `missing:${file}`
+    return `${stat.size}:${stat.mtimeMs}`
   }
 
   async function readBefore(dir: string, ancestor: string, file: string, status: Status) {
@@ -162,6 +174,7 @@ export namespace WorktreeDiff {
       tracked: meta.tracked,
       generatedLike: meta.generatedLike,
       summarized: false,
+      stamp: meta.stamp,
     }
   }
 
@@ -176,6 +189,7 @@ export namespace WorktreeDiff {
       tracked: meta.tracked,
       generatedLike: meta.generatedLike,
       summarized: true,
+      stamp: meta.stamp,
     }
   }
 

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -10,10 +10,9 @@ import { Session } from "../../session"
 import { zodToJsonSchema } from "zod-to-json-schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
-import { $ } from "bun" // kilocode_change
-import path from "path" // kilocode_change
 import { Snapshot } from "../../snapshot" // kilocode_change
 import { Review } from "../../kilocode/review/review" // kilocode_change
+import { WorktreeDiff } from "../../kilocode/review/worktree-diff" // kilocode_change
 import { Log } from "../../util/log" // kilocode_change
 
 export const ExperimentalRoutes = lazy(() =>
@@ -223,118 +222,84 @@ export const ExperimentalRoutes = lazy(() =>
         // kilocode_change end
         const dir = Instance.directory
         log.info("computing diff", { dir, base })
-
-        const mergeBaseResult = await $`git merge-base HEAD ${base}`.cwd(dir).quiet().nothrow()
-        if (mergeBaseResult.exitCode !== 0) {
-          log.warn("git merge-base failed", {
-            exitCode: mergeBaseResult.exitCode,
-            stderr: mergeBaseResult.stderr.toString().trim(),
-            dir,
-            base,
-          })
-          return c.json([])
-        }
-        const ancestor = mergeBaseResult.stdout.toString().trim()
-        log.info("merge-base resolved", { ancestor: ancestor.slice(0, 12) })
-
-        const nameStatus = await $`git -c core.quotepath=false diff --name-status --no-renames ${ancestor}`
-          .cwd(dir)
-          .quiet()
-          .nothrow()
-        if (nameStatus.exitCode !== 0) return c.json([])
-
-        const numstat = await $`git -c core.quotepath=false diff --numstat --no-renames ${ancestor}`
-          .cwd(dir)
-          .quiet()
-          .nothrow()
-        const stats = new Map<string, { additions: number; deletions: number }>()
-        if (numstat.exitCode === 0) {
-          for (const line of numstat.stdout.toString().trim().split("\n")) {
-            if (!line) continue
-            const parts = line.split("\t")
-            const add = parts[0]
-            const del = parts[1]
-            const file = parts.slice(2).join("\t")
-            if (file)
-              stats.set(file, {
-                additions: add === "-" ? 0 : parseInt(add!, 10),
-                deletions: del === "-" ? 0 : parseInt(del!, 10),
-              })
-          }
-        }
-
-        const diffs: Snapshot.FileDiff[] = []
-        const seen = new Set<string>()
-        for (const line of nameStatus.stdout.toString().trim().split("\n")) {
-          if (!line) continue
-          const parts = line.split("\t")
-          const statusChar = parts[0]
-          const file = parts.slice(1).join("\t")
-          if (!file || !statusChar) continue
-
-          seen.add(file)
-          const status =
-            statusChar === "A" ? ("added" as const) : statusChar === "D" ? ("deleted" as const) : ("modified" as const)
-
-          const before =
-            status === "added"
-              ? ""
-              : await (async () => {
-                  const result = await $`git show ${ancestor}:${file}`.cwd(dir).quiet().nothrow()
-                  return result.exitCode === 0 ? result.stdout.toString() : ""
-                })()
-
-          const after =
-            status === "deleted"
-              ? ""
-              : await (async () => {
-                  const f = Bun.file(path.join(dir, file))
-                  return (await f.exists()) ? await f.text() : ""
-                })()
-
-          const stat = stats.get(file) ?? { additions: 0, deletions: 0 }
-          diffs.push({
-            file,
-            before,
-            after,
-            additions: stat.additions,
-            deletions: stat.deletions,
-            status,
-          })
-        }
-
-        // Include untracked files (new files never staged) so the diff
-        // viewer shows all working-tree changes, not just tracked ones.
-        const untrackedResult = await $`git ls-files --others --exclude-standard`.cwd(dir).quiet().nothrow()
-        if (untrackedResult.exitCode === 0) {
-          const untrackedFiles = untrackedResult.stdout.toString().trim()
-          if (untrackedFiles) {
-            log.info("untracked files found", { count: untrackedFiles.split("\n").length })
-          }
-          for (const file of untrackedFiles.split("\n")) {
-            if (!file || seen.has(file)) continue
-            const f = Bun.file(path.join(dir, file))
-            if (!(await f.exists())) continue
-            const content = await f.text()
-            const lines = content.endsWith("\n") ? content.split("\n").length - 1 : content.split("\n").length
-            diffs.push({
-              file,
-              before: "",
-              after: content,
-              additions: lines,
-              deletions: 0,
-              status: "added",
-            })
-          }
-        } else {
-          log.warn("git ls-files failed", {
-            exitCode: untrackedResult.exitCode,
-            stderr: untrackedResult.stderr.toString().trim(),
-          })
-        }
-
-        log.info("diff complete", { totalFiles: diffs.length })
-        return c.json(diffs)
+        const diffs = await WorktreeDiff.full({ dir, base, log })
+        return c.json(
+          diffs.map((diff) => ({
+            file: diff.file,
+            before: diff.before,
+            after: diff.after,
+            additions: diff.additions,
+            deletions: diff.deletions,
+            status: diff.status,
+          })),
+        )
+      },
+    )
+    .get(
+      "/worktree/diff/summary",
+      describeRoute({
+        summary: "Get worktree diff summary",
+        description: "Get lightweight file diff metadata for a worktree compared to its base branch.",
+        operationId: "worktree.diffSummary",
+        responses: {
+          200: {
+            description: "Diff summary items",
+            content: {
+              "application/json": {
+                schema: resolver(z.array(WorktreeDiff.Item)),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator(
+        "query",
+        z.object({
+          base: z.string().optional().meta({ description: "Base branch or ref to diff against" }),
+        }),
+      ),
+      async (c) => {
+        const log = Log.create({ service: "worktree-diff" })
+        const query = c.req.valid("query")
+        const base = query.base || (await Review.getBaseBranch())
+        const dir = Instance.directory
+        log.info("computing diff summary", { dir, base })
+        return c.json(await WorktreeDiff.summary({ dir, base, log }))
+      },
+    )
+    .get(
+      "/worktree/diff/file",
+      describeRoute({
+        summary: "Get worktree diff detail",
+        description: "Get full diff contents for one worktree file compared to its base branch.",
+        operationId: "worktree.diffFile",
+        responses: {
+          200: {
+            description: "Diff detail item",
+            content: {
+              "application/json": {
+                schema: resolver(WorktreeDiff.Item.nullable()),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator(
+        "query",
+        z.object({
+          base: z.string().optional().meta({ description: "Base branch or ref to diff against" }),
+          file: z.string().meta({ description: "Relative file path to load diff contents for" }),
+        }),
+      ),
+      async (c) => {
+        const log = Log.create({ service: "worktree-diff" })
+        const query = c.req.valid("query")
+        const base = query.base || (await Review.getBaseBranch())
+        const dir = Instance.directory
+        log.info("computing diff detail", { dir, base, file: query.file })
+        return c.json((await WorktreeDiff.detail({ dir, base, file: query.file, log })) ?? null)
       },
     )
     // kilocode_change end

--- a/packages/opencode/test/kilocode/worktree-diff-summary.test.ts
+++ b/packages/opencode/test/kilocode/worktree-diff-summary.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test"
+import { $ } from "bun"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { tmpdir } from "../fixture/fixture"
+import { WorktreeDiff } from "../../src/kilocode/review/worktree-diff"
+
+describe("WorktreeDiff summary", () => {
+  async function setup() {
+    return await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "tracked.txt"), "hello\n")
+        await $`git add tracked.txt`.cwd(dir).quiet()
+        await $`git commit -m "init"`.cwd(dir).quiet()
+      },
+    })
+  }
+
+  test("summary returns metadata without loading contents", async () => {
+    await using tmp = await setup()
+    await Bun.write(path.join(tmp.path, "tracked.txt"), "hello\nworld\n")
+    await fs.mkdir(path.join(tmp.path, "node_modules", "pkg"), { recursive: true })
+    await Bun.write(path.join(tmp.path, "node_modules", "pkg", "index.js"), "module.exports = 1\n")
+
+    const diffs = await WorktreeDiff.summary({ dir: tmp.path, base: "HEAD" })
+    const tracked = diffs.find((diff) => diff.file === "tracked.txt")
+    const generated = diffs.find((diff) => diff.file === "node_modules/pkg/index.js")
+
+    expect(tracked).toBeDefined()
+    expect(tracked?.tracked).toBe(true)
+    expect(tracked?.summarized).toBe(true)
+    expect(tracked?.before).toBe("")
+    expect(tracked?.after).toBe("")
+    expect(tracked?.status).toBe("modified")
+
+    expect(generated).toBeDefined()
+    expect(generated?.tracked).toBe(false)
+    expect(generated?.generatedLike).toBe(true)
+    expect(generated?.summarized).toBe(true)
+    expect(generated?.before).toBe("")
+    expect(generated?.after).toBe("")
+    expect(generated?.status).toBe("added")
+  })
+
+  test("detail loads one file and computes untracked line counts", async () => {
+    await using tmp = await setup()
+    await fs.mkdir(path.join(tmp.path, "vendor"), { recursive: true })
+    await Bun.write(path.join(tmp.path, "vendor", "bundle.js"), "one\ntwo\nthree\n")
+
+    const diff = await WorktreeDiff.detail({ dir: tmp.path, base: "HEAD", file: "vendor/bundle.js" })
+
+    expect(diff).toBeDefined()
+    expect(diff?.summarized).toBe(false)
+    expect(diff?.tracked).toBe(false)
+    expect(diff?.generatedLike).toBe(true)
+    expect(diff?.before).toBe("")
+    expect(diff?.after).toBe("one\ntwo\nthree\n")
+    expect(diff?.additions).toBe(3)
+    expect(diff?.status).toBe("added")
+  })
+})

--- a/packages/opencode/test/kilocode/worktree-diff-summary.test.ts
+++ b/packages/opencode/test/kilocode/worktree-diff-summary.test.ts
@@ -40,7 +40,9 @@ describe("WorktreeDiff summary", () => {
     expect(generated?.summarized).toBe(true)
     expect(generated?.before).toBe("")
     expect(generated?.after).toBe("")
+    expect(generated?.additions).toBe(1)
     expect(generated?.status).toBe("added")
+    expect(generated?.stamp?.length).toBeGreaterThan(0)
   })
 
   test("detail loads one file and computes untracked line counts", async () => {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -191,7 +191,11 @@ import type {
   WorktreeCreateInput,
   WorktreeCreateResponses,
   WorktreeDiffErrors,
+  WorktreeDiffFileErrors,
+  WorktreeDiffFileResponses,
   WorktreeDiffResponses,
+  WorktreeDiffSummaryErrors,
+  WorktreeDiffSummaryResponses,
   WorktreeListResponses,
   WorktreeRemoveErrors,
   WorktreeRemoveInput,
@@ -947,6 +951,68 @@ export class Worktree extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<WorktreeDiffResponses, WorktreeDiffErrors, ThrowOnError>({
       url: "/experimental/worktree/diff",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get worktree diff summary
+   *
+   * Get lightweight file diff metadata for a worktree compared to its base branch.
+   */
+  public diffSummary<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      base?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "base" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<WorktreeDiffSummaryResponses, WorktreeDiffSummaryErrors, ThrowOnError>({
+      url: "/experimental/worktree/diff/summary",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get worktree diff detail
+   *
+   * Get full diff contents for one worktree file compared to its base branch.
+   */
+  public diffFile<ThrowOnError extends boolean = false>(
+    parameters: {
+      directory?: string
+      base?: string
+      file: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "base" },
+            { in: "query", key: "file" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<WorktreeDiffFileResponses, WorktreeDiffFileErrors, ThrowOnError>({
+      url: "/experimental/worktree/diff/file",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1682,6 +1682,7 @@ export type WorktreeDiffItem = {
   tracked: boolean
   generatedLike: boolean
   summarized: boolean
+  stamp: string
 }
 
 export type ProjectSummary = {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1672,6 +1672,18 @@ export type WorktreeResetInput = {
   directory: string
 }
 
+export type WorktreeDiffItem = {
+  file: string
+  before: string
+  after: string
+  additions: number
+  deletions: number
+  status?: "added" | "deleted" | "modified"
+  tracked: boolean
+  generatedLike: boolean
+  summarized: boolean
+}
+
 export type ProjectSummary = {
   id: string
   name?: string
@@ -2567,6 +2579,72 @@ export type WorktreeDiffResponses = {
 }
 
 export type WorktreeDiffResponse = WorktreeDiffResponses[keyof WorktreeDiffResponses]
+
+export type WorktreeDiffSummaryData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    /**
+     * Base branch or ref to diff against
+     */
+    base?: string
+  }
+  url: "/experimental/worktree/diff/summary"
+}
+
+export type WorktreeDiffSummaryErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type WorktreeDiffSummaryError = WorktreeDiffSummaryErrors[keyof WorktreeDiffSummaryErrors]
+
+export type WorktreeDiffSummaryResponses = {
+  /**
+   * Diff summary items
+   */
+  200: Array<WorktreeDiffItem>
+}
+
+export type WorktreeDiffSummaryResponse = WorktreeDiffSummaryResponses[keyof WorktreeDiffSummaryResponses]
+
+export type WorktreeDiffFileData = {
+  body?: never
+  path?: never
+  query: {
+    directory?: string
+    /**
+     * Base branch or ref to diff against
+     */
+    base?: string
+    /**
+     * Relative file path to load diff contents for
+     */
+    file: string
+  }
+  url: "/experimental/worktree/diff/file"
+}
+
+export type WorktreeDiffFileErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type WorktreeDiffFileError = WorktreeDiffFileErrors[keyof WorktreeDiffFileErrors]
+
+export type WorktreeDiffFileResponses = {
+  /**
+   * Diff detail item
+   */
+  200: WorktreeDiffItem | null
+}
+
+export type WorktreeDiffFileResponse = WorktreeDiffFileResponses[keyof WorktreeDiffFileResponses]
 
 export type ExperimentalSessionListData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1257,6 +1257,129 @@
         ]
       }
     },
+    "/experimental/worktree/diff/summary": {
+      "get": {
+        "operationId": "worktree.diffSummary",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "base",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Base branch or ref to diff against"
+          }
+        ],
+        "summary": "Get worktree diff summary",
+        "description": "Get lightweight file diff metadata for a worktree compared to its base branch.",
+        "responses": {
+          "200": {
+            "description": "Diff summary items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorktreeDiffItem"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.worktree.diffSummary({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/experimental/worktree/diff/file": {
+      "get": {
+        "operationId": "worktree.diffFile",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "base",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Base branch or ref to diff against"
+          },
+          {
+            "in": "query",
+            "name": "file",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Relative file path to load diff contents for"
+          }
+        ],
+        "summary": "Get worktree diff detail",
+        "description": "Get full diff contents for one worktree file compared to its base branch.",
+        "responses": {
+          "200": {
+            "description": "Diff detail item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/WorktreeDiffItem"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.worktree.diffFile({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/experimental/session": {
       "get": {
         "operationId": "experimental.session.list",
@@ -9839,7 +9962,14 @@
         "type": "object",
         "properties": {
           "model": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "variant": {
             "description": "Default model variant for this agent (applies only when using the agent's configured model).",
@@ -10400,11 +10530,25 @@
           },
           "model": {
             "description": "Model to use in the format of provider/model, eg anthropic/claude-2",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "small_model": {
             "description": "Small model to use for tasks like title generation in the format of provider/model",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "default_agent": {
             "description": "Default agent to use when none is specified. Must be a primary agent. Falls back to 'code' if not set or if the specified agent is invalid.",
@@ -11149,6 +11293,40 @@
           }
         },
         "required": ["directory"]
+      },
+      "WorktreeDiffItem": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string"
+          },
+          "before": {
+            "type": "string"
+          },
+          "after": {
+            "type": "string"
+          },
+          "additions": {
+            "type": "number"
+          },
+          "deletions": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["added", "deleted", "modified"]
+          },
+          "tracked": {
+            "type": "boolean"
+          },
+          "generatedLike": {
+            "type": "boolean"
+          },
+          "summarized": {
+            "type": "boolean"
+          }
+        },
+        "required": ["file", "before", "after", "additions", "deletions", "tracked", "generatedLike", "summarized"]
       },
       "ProjectSummary": {
         "type": "object",

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11324,9 +11324,22 @@
           },
           "summarized": {
             "type": "boolean"
+          },
+          "stamp": {
+            "type": "string"
           }
         },
-        "required": ["file", "before", "after", "additions", "deletions", "tracked", "generatedLike", "summarized"]
+        "required": [
+          "file",
+          "before",
+          "after",
+          "additions",
+          "deletions",
+          "tracked",
+          "generatedLike",
+          "summarized",
+          "stamp"
+        ]
       },
       "ProjectSummary": {
         "type": "object",


### PR DESCRIPTION
## Why merge this
- fixes the main Agent Manager review bottleneck for sessions with large non-ignored generated/dependency trees by stopping the repeated full-diff payload fetch on every poll
- keeps accidental-commit visibility intact because risky paths still appear in review instead of being hidden or ignored
- reduces review UI churn by avoiding eager auto-open and eager diff rendering for large change sets

## What changes
- add a summary-first worktree diff flow: poll lightweight metadata for all files, then fetch full `before` / `after` only when a file is opened
- keep the existing full diff route for compatibility, while adding targeted `worktree.diffSummary` and `worktree.diffFile` endpoints for Agent Manager
- preserve correctness for cached detail views with a per-file `stamp`, so same-sized edits still invalidate stale preview data
- compute untracked-file summary counts without loading the full file text into memory, and avoid rescanning the whole worktree for each detail request
- keep generated-like paths visible in the UI with badges, while preventing large/generated diff sets from auto-opening by default

## User impact
- opening Agent Manager review is faster on branches with many changed files or large generated trees
- background polling is much cheaper for the server, extension host, and webview
- users can still immediately spot accidental `node_modules`, `vendor`, `dist`, `build`, and similar changes before committing
- actual diff content still appears when a file is opened, so review quality is preserved

## Testing
- `packages/opencode`: `bun run typecheck`
- `packages/opencode`: `bun test test/kilocode/worktree-diff.test.ts test/kilocode/worktree-diff-summary.test.ts`
- `packages/kilo-vscode`: `bun run typecheck`
- `packages/kilo-vscode`: `bun run lint`
- `packages/kilo-vscode`: `bun run knip`
- `packages/kilo-vscode`: `bun test tests/unit/agent-manager-diff-state.test.ts tests/unit/git-stats-poller.test.ts tests/unit/agent-manager-arch.test.ts`