### PR TITLE
tui: show model and provider name on assistant responses

### DIFF
--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -274,6 +274,12 @@ export function mapSSEEventToWebviewMessage(event: Event, sessionID: string | un
 }
 
 export function mapCloudSessionMessageToWebviewMessage(message: CloudSessionMessage) {
+  const model =
+    message.info.model ??
+    (message.info.providerID && message.info.modelID
+      ? { providerID: message.info.providerID, modelID: message.info.modelID }
+      : undefined)
+
   return {
     id: message.info.id,
     sessionID: message.info.sessionID,
@@ -283,6 +289,9 @@ export function mapCloudSessionMessageToWebviewMessage(message: CloudSessionMess
       ? new Date(message.info.time.created).toISOString()
       : new Date().toISOString(),
     time: message.info.time,
+    model,
+    providerID: model?.providerID,
+    modelID: model?.modelID,
     cost: message.info.cost,
     tokens: message.info.tokens,
   }

--- a/packages/kilo-vscode/src/services/cli-backend/types.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/types.ts
@@ -70,8 +70,11 @@ export interface CloudSessionMessage {
     id: string
     sessionID: string
     role: "user" | "assistant"
+    model?: { providerID: string; modelID: string }
+    providerID?: string
+    modelID?: string
     time: { created: number; completed?: number }
-    cost?: { input: number; output: number; reasoning?: number; cache?: { read: number; write: number } }
+    cost?: number | { input: number; output: number; reasoning?: number; cache?: { read: number; write: number } }
     tokens?: { input: number; output: number; reasoning?: number; cache?: { read: number; write: number } }
     [key: string]: unknown
   }

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -208,6 +208,29 @@
     user-select: none;
   }
 
+  [data-slot="assistant-model-notice"] {
+    user-select: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    padding: 1px 6px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 999px;
+    background: var(--surface-secondary);
+
+    [data-component="provider-icon"] {
+      flex: 0 0 auto;
+    }
+  }
+
+  [data-slot="assistant-model-notice-text"] {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   [data-slot="text-part-copy-wrapper"][data-interrupted] {
     width: 100%;
     justify-content: flex-end;

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -72,6 +72,8 @@ import { checksum } from "@opencode-ai/util/encode"
 import { Tooltip } from "./tooltip"
 import { IconButton } from "./icon-button"
 import { TextShimmer } from "./text-shimmer"
+import { iconNames, type IconName } from "./provider-icons/types"
+import { ProviderIcon } from "./provider-icon"
 
 interface Diagnostic {
   range: {
@@ -175,6 +177,57 @@ function relativizeProjectPaths(text: string, directory?: string) {
   if (directory === "/") return text
   if (directory === "\\") return text
   return text.split(directory).join("")
+}
+
+function title(text: string | undefined) {
+  if (!text) return ""
+  return text[0]?.toUpperCase() + text.slice(1)
+}
+
+function useProviderMeta(providerID: () => string | undefined, modelID: () => string | undefined) {
+  const data = useData()
+  const provider = createMemo(() => {
+    const id = providerID()
+    if (!id) return
+    return data.store.provider?.all?.find((item) => item.id === id)
+  })
+  const model = createMemo(() => {
+    const id = modelID()
+    if (!id) return ""
+    return provider()?.models?.[id]?.name ?? id
+  })
+  const gateway = createMemo(() => {
+    const value = provider()?.name ?? providerID() ?? ""
+    return value.trim()
+  })
+  const icon = createMemo(() => {
+    const id = providerID()
+    if (!id) return
+    return iconNames.includes(id as IconName) ? (id as IconName) : undefined
+  })
+  return { provider, model, gateway, icon }
+}
+
+function AssistantModelNotice(props: { providerID?: string; modelID?: string }) {
+  const meta = useProviderMeta(
+    () => props.providerID,
+    () => props.modelID,
+  )
+  const text = createMemo(() => {
+    const items = [meta.gateway(), meta.model()].filter((item) => !!item)
+    return items.join(" · ")
+  })
+
+  return (
+    <Show when={text()}>
+      <span data-slot="assistant-model-notice" class="text-12-regular text-text-weak cursor-default">
+        <Show when={meta.icon()}>
+          {(icon) => <ProviderIcon id={icon()} width="12" height="12" aria-hidden="true" />}
+        </Show>
+        <span data-slot="assistant-model-notice-text">{text()}</span>
+      </span>
+    </Show>
+  )
 }
 
 function getDirectory(path: string | undefined) {
@@ -736,7 +789,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
 
   const metaHead = createMemo(() => {
     const agent = props.message.agent
-    const items = [agent ? agent[0]?.toUpperCase() + agent.slice(1) : "", model()]
+    const items = [title(agent), model()]
     return items.filter((x) => !!x).join("\u00A0\u00B7\u00A0")
   })
 
@@ -1051,19 +1104,24 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
 }
 
 PART_MAPPING["text"] = function TextPartDisplay(props) {
-  const data = useData()
   const i18n = useI18n()
   const part = props.part as TextPart
+  const data = useData()
+  const message = createMemo(() =>
+    props.message.role === "assistant" ? (props.message as AssistantMessage) : undefined,
+  )
+  const providerMeta = useProviderMeta(
+    () => message()?.providerID,
+    () => message()?.modelID,
+  )
   const interrupted = createMemo(
     () =>
       props.message.role === "assistant" && (props.message as AssistantMessage).error?.name === "MessageAbortedError",
   )
 
-  const model = createMemo(() => {
-    if (props.message.role !== "assistant") return ""
-    const message = props.message as AssistantMessage
-    const match = data.store.provider?.all?.find((p) => p.id === message.providerID)
-    return match?.models?.[message.modelID]?.name ?? message.modelID
+  const provenance = createMemo(() => {
+    const items = [providerMeta.gateway(), providerMeta.model()].filter((item) => !!item)
+    return items.join(" \u00B7 ")
   })
 
   const duration = createMemo(() => {
@@ -1087,12 +1145,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   const meta = createMemo(() => {
     if (props.message.role !== "assistant") return ""
     const agent = (props.message as AssistantMessage).agent
-    const items = [
-      agent ? agent[0]?.toUpperCase() + agent.slice(1) : "",
-      model(),
-      duration(),
-      interrupted() ? i18n.t("ui.message.interrupted") : "",
-    ]
+    const items = [title(agent), duration(), interrupted() ? i18n.t("ui.message.interrupted") : ""]
     return items.filter((x) => !!x).join(" \u00B7 ")
   })
 
@@ -1182,6 +1235,17 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
                 aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
               />
             </Tooltip>
+            <Show when={props.message.role === "assistant"}>
+              <AssistantModelNotice
+                providerID={(props.message as AssistantMessage).providerID}
+                modelID={(props.message as AssistantMessage).modelID}
+              />
+            </Show>
+            <Show when={provenance() && !meta()}>
+              <span data-slot="text-part-meta" class="text-12-regular text-text-weak cursor-default">
+                {provenance()}
+              </span>
+            </Show>
             <Show when={meta()}>
               <span data-slot="text-part-meta" class="text-12-regular text-text-weak cursor-default">
                 {meta()}


### PR DESCRIPTION
## Context

Users can now see which AI model and provider generated each assistant response. This helps users understand and track which specific models were used to generate their code or answers.

## Implementation

Added model and provider information display to assistant message components:

1. Extended `CloudSessionMessage` type to include `model`, `providerID`, and `modelID` fields
2. Updated `mapCloudSessionMessageToWebviewMessage` to extract and normalize model information
3. Created `AssistantModelNotice` component with provider icon and model name display
4. Added `useProviderMeta` hook to resolve provider and model metadata from the store
5. Updated message UI to show model/provider info next to assistant responses

The component displays as a small pill with provider icon, gateway name, and model name (e.g., "OpenAI · GPT-4").

## Screenshots

| before | after |
| ------ | ----- |
| No model information shown | Model and provider displayed next to assistant response with provider icon |

## How to Test

1. Open the Kilo VS Code extension
2. Send a message to an assistant
3. Observe that the assistant response now displays the model and provider information
4. The display should show the provider icon (if available) followed by gateway name and model name

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->