### PR TITLE
feat(vscode): add reusable self-test workflow

### DIFF
--- a/.kilocode/skills/vscode-self-test/SKILL.md
+++ b/.kilocode/skills/vscode-self-test/SKILL.md
@@ -31,6 +31,10 @@ bun run --cwd packages/kilo-vscode self-test stop-vscode
 bun run --cwd packages/kilo-vscode self-test stop
 ```
 
+If VS Code is not in a standard macOS install location, or you are running on Linux or Windows, pass `--app-path` or set `VSCODE_EXEC_PATH` before launching.
+
+The `code` shell command is only required for `vsix` mode.
+
 Use the MCP bridge for agent-facing control:
 
 ```bash

--- a/.kilocode/skills/vscode-self-test/SKILL.md
+++ b/.kilocode/skills/vscode-self-test/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: vscode-self-test
+description: Test extension flows end to end in VS Code
+---
+
+Use this skill when you need to verify a VS Code extension feature in `packages/kilo-vscode/` from the real UI.
+
+Prefer the self-test MCP bridge for interactions because screenshots come back inline and make fast iteration easier.
+
+---
+
+# Build first
+
+Build the extension before testing when your changes affect the packaged extension, webview code, commands, or startup behavior.
+
+Use the repo's normal build flow for `packages/kilo-vscode/`, then start or restart the self-test stack if needed.
+
+---
+
+# Start the stack
+
+The self-test daemon is per-worktree and keeps one isolated VS Code instance alive until you stop it.
+
+Use the CLI entrypoint for lifecycle control:
+
+```bash
+bun run --cwd packages/kilo-vscode self-test start
+bun run --cwd packages/kilo-vscode self-test status
+bun run --cwd packages/kilo-vscode self-test launch-vscode
+bun run --cwd packages/kilo-vscode self-test stop-vscode
+bun run --cwd packages/kilo-vscode self-test stop
+```
+
+Use the MCP bridge for agent-facing control:
+
+```bash
+bun run --cwd packages/kilo-vscode mcp:self-test -- --self-check
+```
+
+Architecture reference:
+
+- `cli.mjs` controls lifecycle
+- `daemon.mjs` owns the isolated VS Code instance
+- `mcp.mjs` is the agent-facing bridge
+- `engine-mcp.mjs` runs the Playwright-backed engine
+- `common.mjs` has shared helpers
+
+---
+
+# Prefer generic actions
+
+Favor generic interactions over bespoke helpers.
+
+The main tool set is enough for most end-to-end checks:
+
+- MCP lifecycle: `daemon-status`, `launch-vscode`, `stop-vscode`, `stop-daemon`
+- Quick openers: `open-kilo`, `open-agent-manager`, `open-kilo-settings`
+- Core actions: `vscode-observe`, `vscode-click`, `vscode-type`, `vscode-press`, `vscode-wait`, `vscode-screenshot`
+- Debug tools: `vscode-console`, `vscode-logs`, `vscode-evaluate`, `vscode-frames`
+
+Secondary tools are still available when needed:
+
+- `vscode-state` for quick session metadata
+- `vscode-snapshot` for text-only inspection
+- `vscode-move` and `vscode-scroll` for pointer-heavy flows
+- `vscode-run-command` for command-palette entrypoints
+
+Reach for feature-specific helpers only if generic click/type/wait cannot cover the flow.
+
+---
+
+# Follow the loop
+
+Use a tight observe -> act -> verify loop.
+
+Recommended pattern:
+
+1. Open the right surface with an MCP quick opener
+2. Capture a screenshot before the change
+3. Use `vscode-observe` to inspect the current DOM and accessible labels
+4. Interact with `vscode-click`, `vscode-type`, `vscode-press`, and `vscode-wait`
+5. Capture a screenshot after the change
+6. Inspect console or logs if behavior is unclear
+
+Always keep screenshot evidence for visual changes.
+
+---
+
+# Use quick openers
+
+Use MCP quick openers instead of navigating manually when possible.
+
+Common starting points:
+
+- `open-kilo`
+- `open-agent-manager`
+- `open-kilo-settings`
+
+These are the fastest path into the extension UI before switching back to generic interactions.
+
+---
+
+# Reuse proven selectors
+
+These selectors are already proven useful:
+
+- Kilo activity bar icon: `a[aria-label="Kilo Code (NEW)"]`
+- Agent Manager button: `a[aria-label="Agent Manager (⇧⌘M)"]`
+- Agent Manager textarea: `textarea[placeholder*="Type a message"]`
+- Send button: `[aria-label="Send"]`
+
+Start with these, then refine with `vscode-observe` if labels or layout differ.
+
+---
+
+# Debug deliberately
+
+If the UI does not react as expected, do not guess.
+
+Use:
+
+- `vscode-console` for runtime errors and warnings
+- `vscode-logs` for extension and test-stack logs
+- `vscode-evaluate` for targeted DOM checks
+- `vscode-frames` when the visible UI may live in another frame or webview
+
+When behavior is flaky or ambiguous, capture screenshots before and after each step so the failure point is obvious.
+
+---
+
+# Exercise Agent Manager
+
+This is a proven generic end-to-end recipe for Agent Manager.
+
+1. Open Kilo or click `a[aria-label="Kilo Code (NEW)"]`
+2. Open Agent Manager with `open-agent-manager` or click `a[aria-label="Agent Manager (⇧⌘M)"]`
+3. Capture a screenshot
+4. Focus `textarea[placeholder*="Type a message"]`
+5. Type a short prompt with `vscode-type`
+6. Click `[aria-label="Send"]` or press Enter if the UI supports it
+7. Wait for visible response state with `vscode-wait`
+8. Capture another screenshot
+9. Check console or logs if the result is missing or confusing
+
+This generic flow is preferred over custom Agent Manager helpers.
+
+---
+
+# Keep scope practical
+
+The goal is to validate real user behavior without overengineering the test.
+
+Open the surface, interact like a user, collect screenshot evidence, and use logs only when the UI stops being self-explanatory.

--- a/bun.lock
+++ b/bun.lock
@@ -250,6 +250,7 @@
         "zod": "^3.24.2",
       },
       "devDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2",
         "@playwright/test": "1.58.2",
         "@storybook/addon-docs": "10.2.10",
         "@types/diff": "^6.0.0",

--- a/packages/kilo-vscode/docs/development/vscode-self-test-mcp.md
+++ b/packages/kilo-vscode/docs/development/vscode-self-test-mcp.md
@@ -1,0 +1,134 @@
+# Self-test
+
+Run quick, real VS Code checks against an isolated extension instance.
+
+## Understand it
+
+The self-test stack lives in `packages/kilo-vscode/script/self-test/`.
+
+- `cli.mjs` handles lifecycle commands
+- `daemon.mjs` owns one isolated VS Code instance per worktree
+- `mcp.mjs` exposes agent-facing tools with inline screenshots
+- `engine-mcp.mjs` is the internal Playwright engine
+- `common.mjs` holds shared helpers
+
+Use the CLI for lifecycle. Use MCP for interaction.
+
+## Follow the lifecycle
+
+Each worktree gets its own daemon and isolated VS Code session.
+
+The daemon keeps running until you stop it explicitly, even if the agent or CLI process is interrupted.
+
+Main commands:
+
+```bash
+bun run --cwd packages/kilo-vscode self-test start
+bun run --cwd packages/kilo-vscode self-test status
+bun run --cwd packages/kilo-vscode self-test launch-vscode --mode dev --build true
+bun run --cwd packages/kilo-vscode self-test stop-vscode
+bun run --cwd packages/kilo-vscode self-test stop
+```
+
+Use `start` once per worktree, then `launch-vscode` when you want a fresh window.
+
+## Use the workflow
+
+Keep the flow simple.
+
+1. Start the daemon
+2. Launch VS Code
+3. Use MCP tools to open the target UI
+4. Interact with generic click, type, press, and wait actions
+5. Observe with screenshots often
+6. Stop only when the session is no longer needed
+
+Prefer MCP for UI work because screenshot results come back inline and are easier to inspect than file-based output.
+
+## Use the tools
+
+CLI lifecycle commands:
+
+- `start`
+- `status`
+- `launch-vscode`
+- `stop-vscode`
+- `stop`
+
+MCP quick openers:
+
+- `open-kilo`
+- `open-agent-manager`
+- `open-kilo-settings`
+
+MCP testing tools:
+
+- `vscode-observe`
+- `vscode-click`
+- `vscode-type`
+- `vscode-press`
+- `vscode-wait`
+- `vscode-screenshot`
+
+MCP debug tools:
+
+- `vscode-console`
+- `vscode-logs`
+- `vscode-evaluate`
+- `vscode-frames`
+
+Secondary MCP tools:
+
+- `daemon-status`
+- `launch-vscode`
+- `stop-vscode`
+- `stop-daemon`
+- `vscode-state`
+- `vscode-snapshot`
+- `vscode-move`
+- `vscode-scroll`
+- `vscode-run-command`
+
+Favor generic interactions over custom flows.
+
+## Reuse the recipe
+
+This pattern is enough for most Agent Manager checks.
+
+1. Run `open-agent-manager`
+2. Confirm the view with `vscode-observe`
+3. Click the input
+4. Type a prompt
+5. Click send or press Enter
+6. Wait for the session UI to update
+7. Capture another screenshot
+
+Proven selectors:
+
+```css
+a[aria-label="Kilo Code (NEW)"]
+a[aria-label="Agent Manager (⇧⌘M)"]
+textarea[placeholder*="Type a message"]
+[aria-label="Send"]
+```
+
+This generic click/type/wait loop is enough to verify end-to-end Agent Manager messaging.
+
+## Debug it
+
+Start with `vscode-observe` when the UI state is unclear.
+
+Use the rest when needed:
+
+- `vscode-console` for browser and webview errors
+- `vscode-logs` for VS Code-side logs
+- `vscode-evaluate` for targeted DOM inspection
+- `vscode-frames` for workbench and webview frame discovery
+
+If text snapshots are sparse, trust screenshots first.
+
+## Respect limits
+
+This is a manual self-test harness, not an assertions-first test runner.
+
+Webview text can be incomplete, selectors may still be more reliable than text, and `vsix` checks still depend on local package and install steps working correctly.

--- a/packages/kilo-vscode/docs/development/vscode-self-test-mcp.md
+++ b/packages/kilo-vscode/docs/development/vscode-self-test-mcp.md
@@ -32,6 +32,10 @@ bun run --cwd packages/kilo-vscode self-test stop
 
 Use `start` once per worktree, then `launch-vscode` when you want a fresh window.
 
+If VS Code is installed in a non-standard location, or you are testing on Linux or Windows, pass `--app-path` or set `VSCODE_EXEC_PATH` before launching.
+
+The `code` shell command is only required for `vsix` mode, where the workflow installs a packaged extension into the isolated profile.
+
 ## Use the workflow
 
 Keep the flow simple.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -702,6 +702,9 @@
     "check-types": "tsc --noEmit",
     "check-types:webview": "bun script/typecheck.ts --project webview-ui/tsconfig.json",
     "typecheck": "bun run check-types:extension && bun run check-types:webview",
+    "mcp:self-test": "node script/self-test/mcp.mjs",
+    "self-test": "node script/self-test/cli.mjs",
+    "self-test:daemon": "node script/self-test/daemon.mjs",
     "check-types:extension": "bun script/typecheck.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -717,6 +720,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "@storybook/addon-docs": "10.2.10",
     "@types/diff": "^6.0.0",
     "@types/mocha": "^10.0.10",

--- a/packages/kilo-vscode/script/self-test/cli.mjs
+++ b/packages/kilo-vscode/script/self-test/cli.mjs
@@ -1,0 +1,441 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process"
+import { openSync } from "node:fs"
+import { join, resolve } from "node:path"
+import {
+  delay,
+  ensureStateDir,
+  isAlive,
+  logPath,
+  output,
+  ping,
+  readState,
+  removeState,
+  repo,
+  request,
+  root,
+} from "./common.mjs"
+
+function fail(message) {
+  throw new Error(message)
+}
+
+function parse(argv) {
+  const result = { _: [] }
+
+  for (let index = 0; index < argv.length; index++) {
+    const item = argv[index]
+    if (!item.startsWith("--")) {
+      result._.push(item)
+      continue
+    }
+
+    if (item.startsWith("--no-")) {
+      result[item.slice(5)] = false
+      continue
+    }
+
+    const [key, raw] = item.slice(2).split("=", 2)
+    if (raw !== undefined) {
+      result[key] = raw
+      continue
+    }
+
+    const next = argv[index + 1]
+    if (!next || next.startsWith("--")) {
+      result[key] = true
+      continue
+    }
+
+    result[key] = next
+    index++
+  }
+
+  return result
+}
+
+function bool(options, key, fallback) {
+  const value = options[key]
+  if (value === undefined) {
+    return fallback
+  }
+
+  if (typeof value === "boolean") {
+    return value
+  }
+
+  if (value === "true") {
+    return true
+  }
+
+  if (value === "false") {
+    return false
+  }
+
+  return Boolean(value)
+}
+
+function num(options, key, fallback) {
+  const value = options[key]
+  if (value === undefined) {
+    return fallback
+  }
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) {
+    return fail(`Invalid number for --${key}: ${value}`)
+  }
+
+  return parsed
+}
+
+function str(options, key, fallback) {
+  return options[key] ?? fallback
+}
+
+function filepath(options, key) {
+  const value = options[key]
+  if (!value) {
+    return undefined
+  }
+
+  return resolve(process.cwd(), value)
+}
+
+async function active(timeoutMs = 0) {
+  const state = readState()
+  if (!state) {
+    return null
+  }
+
+  const started = Date.now()
+  while (Date.now() - started <= timeoutMs) {
+    const info = await ping(state)
+    if (info) {
+      return { info, state }
+    }
+
+    await delay(200)
+  }
+
+  const info = await ping(state)
+  if (info) {
+    return { info, state }
+  }
+
+  if (!isAlive(state.pid)) {
+    removeState()
+    return null
+  }
+
+  return null
+}
+
+async function start() {
+  const found = await active(500)
+  if (found) {
+    return found
+  }
+
+  ensureStateDir()
+  const fd = openSync(logPath, "a")
+  const child = spawn(process.execPath, [join(root, "script", "self-test", "daemon.mjs")], {
+    cwd: root,
+    detached: true,
+    stdio: ["ignore", fd, fd],
+  })
+  child.unref()
+
+  const started = Date.now()
+  while (Date.now() - started <= 10000) {
+    const next = await active(500)
+    if (next) {
+      return next
+    }
+
+    await delay(200)
+  }
+
+  return fail(`Timed out waiting for self-test daemon. Check ${logPath}`)
+}
+
+async function daemon(required = true) {
+  const found = await active(500)
+  if (found || !required) {
+    return found
+  }
+
+  return start()
+}
+
+async function tool(name, input) {
+  const current = await daemon(true)
+  const result = await request(current.state, "/tool", { arguments: input, name })
+  output(result)
+}
+
+function help() {
+  process.stdout.write(`vscode-self-test commands:
+
+  start
+  stop
+  status
+  launch-vscode [--mode dev|vsix] [--build true|false] [--workspace PATH]
+  stop-vscode [--cleanup true|false]
+  state [--max-chars N]
+  frames
+  observe [--path FILE] [--frame MATCH] [--selector CSS] [--text TEXT]
+  screenshot [--path FILE] [--frame MATCH] [--selector CSS] [--text TEXT]
+  click [--selector CSS | --text TEXT | --x N --y N] [--frame MATCH]
+  move --x N --y N [--steps N]
+  scroll [--delta-x N] [--delta-y N]
+  type --value TEXT [--selector CSS | --text TEXT]
+  press --keys SHORTCUT
+  wait [--selector CSS | --text TEXT] [--state visible|hidden|attached|detached]
+  run-command --command TEXT
+  open-kilo
+  open-agent-manager
+  open-kilo-settings
+  logs
+  console
+  evaluate --script JS [--frame MATCH]
+`)
+}
+
+const command = process.argv[2]
+const options = parse(process.argv.slice(3))
+
+if (!command || command === "help" || command === "--help") {
+  help()
+  process.exit(0)
+}
+
+if (command === "start") {
+  const current = await start()
+  output(current.info)
+  process.exit(0)
+}
+
+if (command === "stop") {
+  const current = await daemon(false)
+  if (!current) {
+    output({ stopped: false })
+    process.exit(0)
+  }
+
+  await request(current.state, "/stop", {})
+  const started = Date.now()
+  while (Date.now() - started <= 5000) {
+    const next = await daemon(false)
+    if (!next) {
+      output({ stopped: true })
+      process.exit(0)
+    }
+
+    await delay(200)
+  }
+
+  if (!isAlive(current.state.pid)) {
+    removeState()
+    output({ stopped: true, forced: true })
+    process.exit(0)
+  }
+
+  fail(`Timed out stopping self-test daemon ${current.state.pid}`)
+}
+
+if (command === "status") {
+  const current = await daemon(false)
+  output(current?.info ?? { running: false })
+  process.exit(0)
+}
+
+if (command === "launch-vscode" || command === "restart-vscode") {
+  await tool("launch-vscode", {
+    appPath: str(options, "app-path", undefined),
+    build: bool(options, "build", true),
+    mode: str(options, "mode", "dev"),
+    waitMs: num(options, "wait-ms", 3000),
+    workspace: resolve(str(options, "workspace", repo)),
+  })
+  process.exit(0)
+}
+
+if (command === "stop-vscode") {
+  await tool("stop-vscode", {
+    cleanup: bool(options, "cleanup", true),
+  })
+  process.exit(0)
+}
+
+if (command === "state") {
+  await tool("vscode-state", {
+    maxChars: num(options, "max-chars", 4000),
+  })
+  process.exit(0)
+}
+
+if (command === "frames") {
+  await tool("vscode-frames", {})
+  process.exit(0)
+}
+
+if (command === "snapshot") {
+  await tool("vscode-snapshot", {
+    frame: str(options, "frame", undefined),
+    maxChars: num(options, "max-chars", 4000),
+  })
+  process.exit(0)
+}
+
+if (command === "screenshot") {
+  await tool("vscode-screenshot", {
+    frame: str(options, "frame", undefined),
+    fullPage: bool(options, "full-page", true),
+    path: filepath(options, "path"),
+    selector: str(options, "selector", undefined),
+    text: str(options, "text", undefined),
+  })
+  process.exit(0)
+}
+
+if (command === "observe") {
+  await tool("vscode-observe", {
+    frame: str(options, "frame", undefined),
+    fullPage: bool(options, "full-page", true),
+    maxChars: num(options, "max-chars", 4000),
+    path: filepath(options, "path"),
+    selector: str(options, "selector", undefined),
+    text: str(options, "text", undefined),
+  })
+  process.exit(0)
+}
+
+if (command === "click") {
+  await tool("vscode-click", {
+    button: str(options, "button", undefined),
+    exact: bool(options, "exact", undefined),
+    frame: str(options, "frame", undefined),
+    nth: num(options, "nth", undefined),
+    selector: str(options, "selector", undefined),
+    text: str(options, "text", undefined),
+    waitMs: num(options, "wait-ms", 500),
+    x: num(options, "x", undefined),
+    y: num(options, "y", undefined),
+  })
+  process.exit(0)
+}
+
+if (command === "move") {
+  await tool("vscode-move", {
+    steps: num(options, "steps", 1),
+    waitMs: num(options, "wait-ms", 100),
+    x: num(options, "x", undefined),
+    y: num(options, "y", undefined),
+  })
+  process.exit(0)
+}
+
+if (command === "scroll") {
+  await tool("vscode-scroll", {
+    deltaX: num(options, "delta-x", 0),
+    deltaY: num(options, "delta-y", 0),
+    waitMs: num(options, "wait-ms", 250),
+  })
+  process.exit(0)
+}
+
+if (command === "type") {
+  await tool("vscode-type", {
+    clear: bool(options, "clear", false),
+    exact: bool(options, "exact", undefined),
+    frame: str(options, "frame", undefined),
+    nth: num(options, "nth", undefined),
+    selector: str(options, "selector", undefined),
+    submit: bool(options, "submit", false),
+    text: str(options, "text", undefined),
+    value: str(options, "value", undefined) ?? fail("Missing --value"),
+    waitMs: num(options, "wait-ms", 500),
+  })
+  process.exit(0)
+}
+
+if (command === "press") {
+  await tool("vscode-press", {
+    keys: str(options, "keys", options._[0]) ?? fail("Missing --keys"),
+    waitMs: num(options, "wait-ms", 500),
+  })
+  process.exit(0)
+}
+
+if (command === "wait") {
+  await tool("vscode-wait", {
+    exact: bool(options, "exact", undefined),
+    frame: str(options, "frame", undefined),
+    nth: num(options, "nth", undefined),
+    selector: str(options, "selector", undefined),
+    state: str(options, "state", undefined),
+    text: str(options, "text", undefined),
+    timeoutMs: num(options, "timeout-ms", 10000),
+  })
+  process.exit(0)
+}
+
+if (command === "run-command") {
+  await tool("vscode-run-command", {
+    command: str(options, "command", options._[0]) ?? fail("Missing --command"),
+    waitMs: num(options, "wait-ms", 1000),
+  })
+  process.exit(0)
+}
+
+if (command === "open-kilo" || command === "open-kilo-sidebar") {
+  await tool("open-kilo", {
+    waitMs: num(options, "wait-ms", 1500),
+  })
+  process.exit(0)
+}
+
+if (command === "open-agent-manager") {
+  await tool("open-agent-manager", {
+    waitMs: num(options, "wait-ms", 2500),
+  })
+  process.exit(0)
+}
+
+if (command === "open-kilo-settings") {
+  await tool("open-kilo-settings", {
+    waitMs: num(options, "wait-ms", 2500),
+  })
+  process.exit(0)
+}
+
+if (command === "logs") {
+  await tool("vscode-logs", {
+    filter: str(options, "filter", undefined),
+    limit: num(options, "limit", 40),
+    maxChars: num(options, "max-chars", 12000),
+  })
+  process.exit(0)
+}
+
+if (command === "console") {
+  await tool("vscode-console", {
+    limit: num(options, "limit", 50),
+    maxChars: num(options, "max-chars", 4000),
+    type: str(options, "type", undefined),
+  })
+  process.exit(0)
+}
+
+if (command === "evaluate") {
+  await tool("vscode-evaluate", {
+    frame: str(options, "frame", undefined),
+    maxChars: num(options, "max-chars", 4000),
+    script: str(options, "script", undefined) ?? fail("Missing --script"),
+  })
+  process.exit(0)
+}
+
+help()
+process.exit(1)

--- a/packages/kilo-vscode/script/self-test/common.mjs
+++ b/packages/kilo-vscode/script/self-test/common.mjs
@@ -1,0 +1,99 @@
+import { randomUUID } from "node:crypto"
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { join, resolve } from "node:path"
+
+export const root = resolve(import.meta.dirname, "..", "..")
+export const repo = resolve(root, "..", "..")
+export const stateDir = join(repo, ".kilo", "vscode-self-test")
+export const statePath = join(stateDir, "state.json")
+export const logPath = join(stateDir, "daemon.log")
+
+export function ensureStateDir() {
+  mkdirSync(stateDir, { recursive: true })
+}
+
+export function readState() {
+  if (!existsSync(statePath)) {
+    return null
+  }
+
+  return JSON.parse(readFileSync(statePath, "utf8"))
+}
+
+export function writeState(value) {
+  ensureStateDir()
+  writeFileSync(statePath, JSON.stringify(value, null, 2) + "\n")
+}
+
+export function removeState() {
+  rmSync(statePath, { force: true })
+}
+
+export function token() {
+  return randomUUID().replaceAll("-", "")
+}
+
+export function output(value) {
+  process.stdout.write(JSON.stringify(value, null, 2) + "\n")
+}
+
+export function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export function isAlive(pid) {
+  if (!pid) {
+    return false
+  }
+
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function url(value) {
+  return `http://127.0.0.1:${value.port}`
+}
+
+function headers(state) {
+  return {
+    "content-type": "application/json",
+    "x-kilo-self-test-token": state.token,
+  }
+}
+
+export async function ping(state) {
+  if (!state) {
+    return null
+  }
+
+  const response = await fetch(`${url(state)}/status`, {
+    headers: headers(state),
+  }).catch(() => null)
+
+  if (!response?.ok) {
+    return null
+  }
+
+  return response.json()
+}
+
+export async function request(state, route, body) {
+  const response = await fetch(`${url(state)}${route}`, {
+    body: body ? JSON.stringify(body) : undefined,
+    headers: headers(state),
+    method: body ? "POST" : "GET",
+  })
+
+  const text = await response.text()
+  const data = text ? JSON.parse(text) : {}
+
+  if (!response.ok) {
+    throw new Error(data.error ?? `${route} failed with ${response.status}`)
+  }
+
+  return data
+}

--- a/packages/kilo-vscode/script/self-test/daemon.mjs
+++ b/packages/kilo-vscode/script/self-test/daemon.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+import { createServer } from "node:http"
+import { join } from "node:path"
+import { logPath, output, removeState, repo, root, statePath, token, writeState } from "./common.mjs"
+
+const auth = token()
+const state = {
+  closing: false,
+  port: 0,
+  session: null,
+  startedAt: new Date().toISOString(),
+  tools: [],
+}
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [join(root, "script", "self-test", "engine-mcp.mjs")],
+  cwd: root,
+  stderr: "inherit",
+})
+
+const client = new Client({
+  name: "vscode-self-test-daemon",
+  version: "1.0.0",
+})
+
+function payload(result) {
+  const text = result.content
+    ?.filter((item) => item.type === "text")
+    .map((item) => item.text)
+    .join("\n")
+
+  const images = result.content
+    ?.filter((item) => item.type === "image")
+    .map((item) => ({
+      mimeType: item.mimeType,
+      path: result.structuredContent?.path ?? null,
+      type: item.type,
+    }))
+
+  return {
+    images: images ?? [],
+    isError: result.isError ?? false,
+    structuredContent: result.structuredContent ?? null,
+    text: text?.trim() || null,
+  }
+}
+
+function snapshot() {
+  return {
+    logPath,
+    pid: process.pid,
+    port: state.port,
+    repo,
+    session: state.session,
+    startedAt: state.startedAt,
+    statePath,
+    tools: state.tools,
+  }
+}
+
+function persist() {
+  writeState({
+    logPath,
+    pid: process.pid,
+    port: state.port,
+    repo,
+    startedAt: state.startedAt,
+    statePath,
+    token: auth,
+  })
+}
+
+function json(res, code, value) {
+  res.writeHead(code, { "content-type": "application/json" })
+  res.end(JSON.stringify(value, null, 2))
+}
+
+function unauthorized(req, res) {
+  if (req.headers["x-kilo-self-test-token"] === auth) {
+    return false
+  }
+
+  json(res, 401, { error: "Unauthorized" })
+  return true
+}
+
+async function body(req) {
+  const chunks = []
+  for await (const chunk of req) {
+    chunks.push(chunk)
+  }
+
+  if (chunks.length === 0) {
+    return {}
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"))
+}
+
+async function invoke(name, input) {
+  const result = await client.callTool({
+    name,
+    arguments: input ?? {},
+  })
+
+  const current = result.structuredContent ?? null
+
+  if (name === "launch-vscode") {
+    state.session = current
+  }
+
+  if (name === "stop-vscode") {
+    state.session = null
+  }
+
+  if (name !== "launch-vscode" && name !== "stop-vscode" && state.session && current && typeof current === "object") {
+    state.session = {
+      ...state.session,
+      ...current,
+    }
+  }
+
+  return payload(result)
+}
+
+async function shutdown() {
+  if (state.closing) {
+    return
+  }
+
+  state.closing = true
+  removeState()
+  await invoke("stop-vscode", { cleanup: true }).catch(() => undefined)
+  await client.close().catch(() => undefined)
+  await new Promise((resolve) => server.close(resolve))
+  process.exit(0)
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    if (unauthorized(req, res)) {
+      return
+    }
+
+    if (req.method === "GET" && req.url === "/status") {
+      json(res, 200, snapshot())
+      return
+    }
+
+    if (req.method === "POST" && req.url === "/stop") {
+      json(res, 200, { stopping: true })
+      setTimeout(() => {
+        void shutdown()
+      }, 50)
+      return
+    }
+
+    if (req.method === "POST" && req.url === "/tool") {
+      const input = await body(req)
+      const result = await invoke(input.name, input.arguments)
+      json(res, 200, result)
+      return
+    }
+
+    json(res, 404, { error: "Not found" })
+  } catch (error) {
+    json(res, 500, { error: error instanceof Error ? error.message : String(error) })
+  }
+})
+
+await client.connect(transport)
+const tools = await client.listTools()
+state.tools = tools.tools.map((item) => item.name)
+
+await new Promise((resolve) => {
+  server.listen(0, "127.0.0.1", () => {
+    const address = server.address()
+    state.port = typeof address === "object" && address ? address.port : 0
+    persist()
+    output({ started: true, ...snapshot() })
+    resolve(undefined)
+  })
+})
+
+process.on("SIGINT", () => {
+  void shutdown()
+})
+
+process.on("SIGTERM", () => {
+  void shutdown()
+})

--- a/packages/kilo-vscode/script/self-test/engine-mcp.mjs
+++ b/packages/kilo-vscode/script/self-test/engine-mcp.mjs
@@ -1,0 +1,963 @@
+#!/usr/bin/env node
+import { _electron as electron } from "@playwright/test"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { execFile } from "node:child_process"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { delimiter, dirname, join, resolve } from "node:path"
+import { promisify } from "node:util"
+import { z } from "zod"
+
+const execFileP = promisify(execFile)
+const root = resolve(import.meta.dirname, "..", "..")
+const repo = resolve(root, "..", "..")
+const pkg = await JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
+
+const state = {
+  console: [],
+  session: null,
+}
+
+function record(entry) {
+  state.console = [...state.console.slice(-199), entry]
+}
+
+function textResult(text, structuredContent) {
+  if (!structuredContent) {
+    return {
+      content: [{ type: "text", text }],
+    }
+  }
+
+  return {
+    content: [{ type: "text", text }],
+    structuredContent,
+  }
+}
+
+function imageResult(text, path, structuredContent) {
+  const data = Buffer.from(readFileSync(path)).toString("base64")
+
+  return {
+    content: [
+      { type: "text", text },
+      { type: "image", data, mimeType: "image/png" },
+    ],
+    structuredContent: { path, ...(structuredContent ?? {}) },
+  }
+}
+
+function fail(message) {
+  throw new Error(message)
+}
+
+function clip(value, size) {
+  if (value.length <= size) {
+    return value
+  }
+
+  return `${value.slice(0, size)}\n...<truncated ${value.length - size} chars>`
+}
+
+function temp(prefix) {
+  return mkdtempSync(join(tmpdir(), prefix))
+}
+
+function activeSession() {
+  return state.session ?? fail("No VS Code session is running. Call launch-vscode first.")
+}
+
+function resolveOnPath(name) {
+  const paths = (process.env.PATH ?? "").split(delimiter).filter(Boolean)
+  const exts = process.platform === "win32" ? [".cmd", ".exe", ".bat", ""] : [""]
+
+  const hit = paths
+    .flatMap((dir) => exts.map((ext) => join(dir, name.endsWith(ext) ? name : `${name}${ext}`)))
+    .find((item) => existsSync(item))
+
+  return hit ?? null
+}
+
+function bunPath() {
+  return resolveOnPath("bun") ?? fail("Bun is required to build and package the extension.")
+}
+
+async function run(command, args, cwd) {
+  await execFileP(command, args, {
+    cwd,
+    env: process.env,
+    maxBuffer: 32 * 1024 * 1024,
+  })
+}
+
+function detectAppPath(appPath) {
+  const envPath = appPath ?? process.env["VSCODE_EXEC_PATH"]
+  if (envPath && existsSync(envPath)) {
+    return envPath
+  }
+
+  const candidates =
+    process.platform === "darwin"
+      ? [
+          "/Applications/Visual Studio Code.app/Contents/MacOS/Code",
+          "/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Code - Insiders",
+        ]
+      : []
+
+  const found = candidates.find((item) => existsSync(item))
+  if (found) {
+    return found
+  }
+
+  return fail("VS Code app executable not found. Pass appPath explicitly.")
+}
+
+function detectCliPath(appPath) {
+  const preferred = appPath.includes("Insiders") ? "code-insiders" : "code"
+  const direct = resolveOnPath(preferred)
+  if (direct) {
+    return direct
+  }
+
+  const bundled = appPath.includes("Visual Studio Code - Insiders.app")
+    ? "/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code"
+    : "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+
+  if (existsSync(bundled)) {
+    return bundled
+  }
+
+  return fail("VS Code CLI not found. Install the `code` shell command first.")
+}
+
+function writeSettings(userDir) {
+  const dir = join(userDir, "User")
+  mkdirSync(dir, { recursive: true })
+  const value = {
+    "editor.accessibilitySupport": "off",
+    "extensions.autoCheckUpdates": false,
+    "extensions.autoUpdate": false,
+    "extensions.ignoreRecommendations": true,
+    "security.workspace.trust.enabled": false,
+    "task.allowAutomaticTasks": "off",
+    "telemetry.telemetryLevel": "off",
+    "update.mode": "none",
+    "workbench.startupEditor": "none",
+    "workbench.tips.enabled": false,
+    "window.commandCenter": false,
+  }
+  writeFileSync(join(dir, "settings.json"), JSON.stringify(value, null, 2) + "\n")
+}
+
+async function buildExtension() {
+  await run(bunPath(), ["run", "package"], root)
+}
+
+function newest(paths) {
+  return [...paths].sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs)
+}
+
+async function packageVsix(outDir) {
+  await run(bunPath(), ["x", "vsce", "package", "--no-dependencies", "--skip-license", "-o", `${outDir}/`], root)
+  const files = newest(
+    readdirSync(outDir)
+      .filter((item) => item.endsWith(".vsix"))
+      .map((item) => join(outDir, item)),
+  )
+  const vsix = files.at(0)
+  if (!vsix) {
+    return fail(`No VSIX package was created in ${outDir}`)
+  }
+  return vsix
+}
+
+async function installVsix(cliPath, userDir, extDir, vsix) {
+  await run(
+    cliPath,
+    ["--extensions-dir", extDir, "--user-data-dir", userDir, "--install-extension", vsix, "--force"],
+    root,
+  )
+}
+
+async function closeSession(cleanup) {
+  const active = state.session
+  if (!active) {
+    return { removed: [] }
+  }
+
+  state.session = null
+  state.console = []
+  await active.app.close().catch(() => undefined)
+
+  const removed = cleanup
+    ? [active.userDir, active.extDir, active.outDir].filter(Boolean).map((item) => {
+        rmSync(item, { recursive: true, force: true })
+        return item
+      })
+    : []
+
+  return {
+    extDir: active.extDir,
+    mode: active.mode,
+    removed,
+    userDir: active.userDir,
+    vsix: active.vsix,
+    workspace: active.workspace,
+  }
+}
+
+async function launchVsCode(input) {
+  await closeSession(true)
+
+  const appPath = detectAppPath(input.appPath)
+  const cliPath = detectCliPath(appPath)
+  const mode = input.mode ?? "vsix"
+  const workspace = resolve(input.workspace ?? repo)
+  const userDir = temp("kilo-vscode-user-")
+  const extDir = temp("kilo-vscode-ext-")
+  const outDir = mode === "vsix" ? temp("kilo-vscode-vsix-") : null
+  const waitMs = input.waitMs ?? 5000
+
+  writeSettings(userDir)
+
+  if (input.build ?? true) {
+    await buildExtension()
+  }
+
+  const vsix = mode === "vsix" && outDir ? await packageVsix(outDir) : null
+
+  if (vsix) {
+    await installVsix(cliPath, userDir, extDir, vsix)
+  }
+
+  const args = [workspace, `--extensions-dir=${extDir}`, `--user-data-dir=${userDir}`, "--skip-release-notes"]
+  if (mode === "dev") {
+    args.push(`--extensionDevelopmentPath=${root}`)
+    args.push("--disable-extension=kilocode.kilo-code")
+  }
+
+  const app = await electron.launch({
+    args,
+    executablePath: appPath,
+  })
+
+  const page = await app.firstWindow()
+  state.console = []
+  page.on("console", (message) => {
+    const location = message.location()
+    record({
+      source: location.url || page.url(),
+      text: message.text(),
+      time: new Date().toISOString(),
+      type: message.type(),
+    })
+  })
+  page.on("pageerror", (error) => {
+    record({
+      source: page.url(),
+      text: error.stack || error.message,
+      time: new Date().toISOString(),
+      type: "pageerror",
+    })
+  })
+  await page.waitForTimeout(waitMs)
+
+  const active = {
+    app,
+    appPath,
+    cliPath,
+    extDir,
+    mode,
+    outDir,
+    page,
+    userDir,
+    vsix,
+    workspace,
+  }
+
+  state.session = active
+  return active
+}
+
+function frames() {
+  return activeSession()
+    .page.frames()
+    .map((item, index) => ({
+      index,
+      name: item.name(),
+      url: item.url(),
+    }))
+}
+
+function view(match) {
+  if (!match) {
+    return activeSession().page
+  }
+
+  const hit = activeSession()
+    .page.frames()
+    .find((item) => item.name().includes(match) || item.url().includes(match))
+
+  if (hit) {
+    return hit
+  }
+
+  return fail(`Frame matching \`${match}\` not found. Known frames: ${JSON.stringify(frames())}`)
+}
+
+function locator(input) {
+  const target = view(input.frame)
+  const nth = input.nth ?? 0
+
+  if (input.selector) {
+    return target.locator(input.selector).nth(nth)
+  }
+
+  if (input.text) {
+    return target.getByText(input.text, { exact: input.exact ?? false }).nth(nth)
+  }
+
+  return fail("Provide either selector or text.")
+}
+
+async function bodyText(match) {
+  return view(match)
+    .locator("body")
+    .innerText()
+    .catch(() => "")
+}
+
+async function frameText(frame) {
+  return frame
+    .locator("body")
+    .innerText()
+    .catch(() => "")
+}
+
+async function kiloFrames() {
+  const items = await Promise.all(
+    activeSession()
+      .page.frames()
+      .map(async (frame, index) => ({
+        frame,
+        index,
+        name: frame.name(),
+        text: await frameText(frame),
+        url: frame.url(),
+      })),
+  )
+
+  return items.filter((item) => item.url.includes("extensionId=kilocode.kilo-code") || item.url.includes("fake.html"))
+}
+
+async function kiloFrame(kind) {
+  const items = await kiloFrames()
+  const hit =
+    kind === "agentManager"
+      ? items.find((item) => item.text.includes("WORKTREES") && item.text.includes("SESSIONS"))
+      : items.find(
+          (item) =>
+            !item.text.includes("WORKTREES") &&
+            (item.text.includes("Import from cloud") ||
+              item.text.includes("Feedback & Support") ||
+              item.text.includes("Kilo Code is an AI coding assistant.")),
+        )
+
+  if (hit) {
+    return hit.frame
+  }
+
+  return fail(
+    `Kilo ${kind} frame not found. Known frames: ${JSON.stringify(items.map((item) => ({ index: item.index, name: item.name, url: item.url, text: clip(item.text, 200) })))}`,
+  )
+}
+
+async function saveScreenshot(input, path) {
+  if (input.selector || input.text) {
+    await locator(input).screenshot({ path })
+    return
+  }
+
+  if (input.frame) {
+    await view(input.frame).locator("body").screenshot({ path })
+    return
+  }
+
+  await activeSession().page.screenshot({ fullPage: input.fullPage ?? true, path })
+}
+
+async function runCommand(command, waitMs) {
+  const page = activeSession().page
+  await page.keyboard.press("F1")
+  const target = page.locator(".quick-input-widget input").last()
+  await target.waitFor({ state: "visible", timeout: 5000 })
+  await target.fill(`>${command}`)
+  await page.waitForTimeout(500)
+  await target.press("Enter")
+  await page.waitForTimeout(waitMs ?? 1000)
+}
+
+async function openKiloSidebar(waitMs) {
+  await runCommand("Kilo Code (NEW): Focus on Kilo Code (NEW) View", waitMs ?? 1500)
+}
+
+async function openAgentManager(waitMs) {
+  await openKiloSidebar(1200)
+  const page = activeSession().page
+  const target = page.getByLabel(/Agent Manager/).first()
+  await target.waitFor({ state: "visible", timeout: 10000 })
+  await target.click()
+  await page.waitForTimeout(waitMs ?? 2500)
+  const frame = await kiloFrame("agentManager")
+
+  return {
+    frame: { name: frame.name(), url: frame.url() },
+    title: await page.title(),
+  }
+}
+
+async function openKiloSettings(waitMs) {
+  await openKiloSidebar(1200)
+  const page = activeSession().page
+  const target = page.locator('a[aria-label="Settings"]').first()
+  await target.waitFor({ state: "visible", timeout: 10000 })
+  await target.click()
+  await page.waitForTimeout(waitMs ?? 2500)
+
+  return {
+    title: await page.title(),
+    url: page.url(),
+  }
+}
+
+function walk(dir) {
+  if (!existsSync(dir)) {
+    return []
+  }
+
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      return walk(path)
+    }
+
+    return [path]
+  })
+}
+
+function tail(path, lines) {
+  const value = readFileSync(path, "utf8").trimEnd()
+  if (!value) {
+    return ""
+  }
+
+  return value.split("\n").slice(-lines).join("\n")
+}
+
+const server = new McpServer({
+  name: "kilo-vscode-self-test",
+  version: pkg.version,
+})
+
+server.registerTool(
+  "launch-vscode",
+  {
+    description:
+      "Build the extension, install or load it into an isolated VS Code instance, and launch it for manual testing.",
+    inputSchema: {
+      appPath: z.string().optional(),
+      build: z.boolean().optional(),
+      mode: z.enum(["dev", "vsix"]).optional(),
+      waitMs: z.number().int().positive().max(60000).optional(),
+      workspace: z.string().optional(),
+    },
+  },
+  async (input) => {
+    const active = await launchVsCode(input)
+
+    return textResult(`Launched VS Code in ${active.mode} mode for ${active.workspace}.`, {
+      appPath: active.appPath,
+      extDir: active.extDir,
+      frames: frames(),
+      mode: active.mode,
+      title: await active.page.title(),
+      userDir: active.userDir,
+      vsix: active.vsix,
+      workspace: active.workspace,
+    })
+  },
+)
+
+server.registerTool(
+  "vscode-state",
+  {
+    description: "Show the current isolated VS Code session details and a text snapshot of the active window.",
+    inputSchema: {
+      maxChars: z.number().int().positive().max(20000).optional(),
+    },
+  },
+  async (input) => {
+    const active = activeSession()
+    const text = clip(await bodyText(), input.maxChars ?? 4000)
+
+    return textResult("Current VS Code session state.", {
+      appPath: active.appPath,
+      extDir: active.extDir,
+      frames: frames(),
+      mode: active.mode,
+      text,
+      url: active.page.url(),
+      userDir: active.userDir,
+      vsix: active.vsix,
+      workspace: active.workspace,
+    })
+  },
+)
+
+server.registerTool(
+  "vscode-frames",
+  {
+    description: "List the active Playwright frames in the VS Code window.",
+    inputSchema: {},
+  },
+  async () => textResult("Active VS Code frames.", { frames: frames() }),
+)
+
+server.registerTool(
+  "vscode-snapshot",
+  {
+    description: "Capture the visible text content from the VS Code window or a matching frame.",
+    inputSchema: {
+      frame: z.string().optional(),
+      maxChars: z.number().int().positive().max(50000).optional(),
+    },
+  },
+  async (input) => {
+    const text = clip(await bodyText(input.frame), input.maxChars ?? 4000)
+
+    return textResult("Captured VS Code text snapshot.", {
+      frame: input.frame ?? null,
+      frames: frames(),
+      text,
+      title: await activeSession().page.title(),
+      url: activeSession().page.url(),
+    })
+  },
+)
+
+server.registerTool(
+  "vscode-screenshot",
+  {
+    description: "Capture a screenshot of the VS Code window or a matching element.",
+    inputSchema: {
+      frame: z.string().optional(),
+      fullPage: z.boolean().optional(),
+      path: z.string().optional(),
+      selector: z.string().optional(),
+      text: z.string().optional(),
+    },
+  },
+  async (input) => {
+    const path = resolve(input.path ?? join(temp("kilo-vscode-shot-"), "capture.png"))
+    mkdirSync(dirname(path), { recursive: true })
+
+    await saveScreenshot(input, path)
+
+    return imageResult(`Saved screenshot to ${path}.`, path)
+  },
+)
+
+server.registerTool(
+  "vscode-observe",
+  {
+    description: "Capture a screenshot and text snapshot together for an observe-action loop.",
+    inputSchema: {
+      frame: z.string().optional(),
+      fullPage: z.boolean().optional(),
+      maxChars: z.number().int().positive().max(50000).optional(),
+      path: z.string().optional(),
+      selector: z.string().optional(),
+      text: z.string().optional(),
+    },
+  },
+  async (input) => {
+    const path = resolve(input.path ?? join(temp("kilo-vscode-observe-"), "observe.png"))
+    mkdirSync(dirname(path), { recursive: true })
+    await saveScreenshot(input, path)
+    const snapshot = clip(await bodyText(input.frame), input.maxChars ?? 4000)
+
+    return imageResult("Captured VS Code observation.", path, {
+      frame: input.frame ?? null,
+      frames: frames(),
+      text: snapshot,
+      title: await activeSession().page.title(),
+      url: activeSession().page.url(),
+    })
+  },
+)
+
+server.registerTool(
+  "open-kilo",
+  {
+    description: "Focus the Kilo sidebar view in VS Code.",
+    inputSchema: {
+      waitMs: z.number().int().min(0).max(60000).optional(),
+    },
+  },
+  async (input) => {
+    await openKiloSidebar(input.waitMs)
+    const frame = await kiloFrame("sidebar")
+
+    return textResult("Focused the Kilo sidebar.", {
+      frame: { name: frame.name(), url: frame.url() },
+      title: await activeSession().page.title(),
+    })
+  },
+)
+
+server.registerTool(
+  "open-agent-manager",
+  {
+    description: "Open the Agent Manager from the Kilo sidebar toolbar button.",
+    inputSchema: {
+      waitMs: z.number().int().min(0).max(60000).optional(),
+    },
+  },
+  async (input) => {
+    const result = await openAgentManager(input.waitMs)
+    return textResult("Opened Agent Manager.", result)
+  },
+)
+
+server.registerTool(
+  "open-kilo-settings",
+  {
+    description: "Open the Kilo settings panel from the Kilo sidebar toolbar button.",
+    inputSchema: {
+      waitMs: z.number().int().min(0).max(60000).optional(),
+    },
+  },
+  async (input) => {
+    const result = await openKiloSettings(input.waitMs)
+    return textResult("Opened Kilo settings.", result)
+  },
+)
+
+server.registerTool(
+  "vscode-click",
+  {
+    description: "Click a VS Code element by selector or visible text, or click absolute window coordinates.",
+    inputSchema: {
+      button: z.enum(["left", "middle", "right"]).optional(),
+      exact: z.boolean().optional(),
+      frame: z.string().optional(),
+      nth: z.number().int().min(0).optional(),
+      selector: z.string().optional(),
+      text: z.string().optional(),
+      waitMs: z.number().int().min(0).max(60000).optional(),
+      x: z.number().optional(),
+      y: z.number().optional(),
+    },
+  },
+  async (input) => {
+    const hasPoint = typeof input.x === "number" && typeof input.y === "number"
+
+    if (hasPoint) {
+      await activeSession().page.mouse.click(input.x, input.y, { button: input.button ?? "left" })
+    }
+
+    if (!hasPoint) {
+      const target = locator(input)
+      await target.click({ button: input.button ?? "left" })
+    }
+
+    await activeSession().page.waitForTimeout(input.waitMs ?? 500)
+
+    return textResult("Clicked VS Code element.", {
+      button: input.button ?? "left",
+      frame: input.frame ?? null,
+      selector: input.selector ?? null,
+      text: input.text ?? null,
+      x: hasPoint ? input.x : null,
+      y: hasPoint ? input.y : null,
+    })
+  },
+)
+
+server.registerTool(
+  "vscode-move",
+  {
+    description: "Move the mouse to absolute window coordinates.",
+    inputSchema: {
+      steps: z.number().int().positive().max(200).optional(),
+      waitMs: z.number().int().min(0).max(60000).optional(),
+      x: z.number(),
+      y: z.number(),
+    },
+  },
+  async (input) => {
+    await activeSession().page.mouse.move(input.x, input.y, { steps: input.steps ?? 1 })
+    await activeSession().page.waitForTimeout(input.waitMs ?? 100)
+
+    return textResult("Moved mouse in VS Code.", {
+      steps: input.steps ?? 1,
+      x: input.x,
+      y: input.y,
+    })
+  },
+)
+
+server.registerTool(
+  "vscode-scroll",
+  {
+    description: "Scroll the VS Code window using mouse wheel deltas.",
+    inputSchema: {
+      deltaX: z.number().optional(),
+      deltaY: z.number().optional(),
+      waitMs: z.number().int().min(0).max(60000).optional(),
+    },
+  },
+  async (input) => {
+    await activeSession().page.mouse.wheel(input.deltaX ?? 0, input.deltaY ?? 0)
+    await activeSession().page.waitForTimeout(input.waitMs ?? 250)
+
+    return textResult("Scrolled VS Code.", {
+      deltaX: input.deltaX ?? 0,
+      deltaY: input.deltaY ?? 0,
+    })
+  },
+)
+
+server.registerTool(
+  "vscode-evaluate",
+  {
+    description:
+      "Run JavaScript in the current VS Code page or a matching frame and return a JSON-serializable result.",
+    inputSchema: {
+      frame: z.string().optional(),
+      maxChars: z.number().int().positive().max(50000).optional(),
+      script: z.string(),
+    },
+  },
+  async (input) => {
+    const result = await view(input.frame).evaluate((script) => {
+      const value = Function(`"use strict";\n${script}`)()
+      if (value === undefined) {
+        return null
+      }
+
+      return JSON.parse(JSON.stringify(value))
+    }, input.script)
+
+    return textResult("Executed JavaScript in VS Code.", {
+      frame: input.frame ?? null,
+      result: clip(JSON.stringify(result, null, 2), input.maxChars ?? 4000),
+    })
+  },
+)
+
+server.registerTool(
+  "vscode-type",
+  {
+    description: "Type text into the current VS Code focus target or an element selected by selector or text.",
+    inputSchema: {
+      clear: z.boolean().optional(),
+      exact: z.boolean().optional(),
+      frame: z.string().optional(),
+      nth: z.number().int().min(0).optional(),
+      selector: z.string().optional(),
+      submit: z.boolean().optional(),
+      text: z.string().optional(),
+      value: z.string(),
+      waitMs: z.number().int().min(0).max(60000).optional(),
+    },
+  },
+  async (input) => {
+    if (input.selector || input.text) {
+      const target = locator(input)
+      await target.click()
+      if (input.clear) {
+        await target.fill("")
+      }
+    }
+
+    await activeSession().page.keyboard.type(input.value)
+    if (input.submit) {
+      await activeSession().page.keyboard.press("Enter")
+    }
+
+    await activeSession().page.waitForTimeout(input.waitMs ?? 500)
+
+    return textResult("Typed into VS Code.", {
+      frame: input.frame ?? null,
+      selector: input.selector ?? null,
+      submitted: input.submit ?? false,
+      text: input.text ?? null,
+      value: input.value,
+    })
+  },
+)
+
+server.registerTool(
+  "vscode-press",
+  {
+    description: "Send a keyboard shortcut to the VS Code window.",
+    inputSchema: {
+      keys: z.string(),
+      waitMs: z.number().int().min(0).max(60000).optional(),
+    },
+  },
+  async (input) => {
+    await activeSession().page.keyboard.press(input.keys)
+    await activeSession().page.waitForTimeout(input.waitMs ?? 500)
+
+    return textResult(`Pressed ${input.keys}.`, { keys: input.keys })
+  },
+)
+
+server.registerTool(
+  "vscode-run-command",
+  {
+    description: "Open the command palette, search for a command, and execute it.",
+    inputSchema: {
+      command: z.string(),
+      waitMs: z.number().int().min(0).max(60000).optional(),
+    },
+  },
+  async (input) => {
+    await runCommand(input.command, input.waitMs)
+
+    return textResult(`Ran VS Code command: ${input.command}.`, { command: input.command })
+  },
+)
+
+server.registerTool(
+  "vscode-wait",
+  {
+    description: "Wait for a VS Code element or visible text to reach a given state.",
+    inputSchema: {
+      exact: z.boolean().optional(),
+      frame: z.string().optional(),
+      nth: z.number().int().min(0).optional(),
+      selector: z.string().optional(),
+      state: z.enum(["attached", "detached", "hidden", "visible"]).optional(),
+      text: z.string().optional(),
+      timeoutMs: z.number().int().positive().max(60000).optional(),
+    },
+  },
+  async (input) => {
+    await locator(input).waitFor({ state: input.state ?? "visible", timeout: input.timeoutMs ?? 10000 })
+
+    return textResult("Wait condition satisfied.", {
+      frame: input.frame ?? null,
+      selector: input.selector ?? null,
+      state: input.state ?? "visible",
+      text: input.text ?? null,
+      timeoutMs: input.timeoutMs ?? 10000,
+    })
+  },
+)
+
+server.registerTool(
+  "vscode-logs",
+  {
+    description: "Read the newest VS Code log files from the isolated user-data directory.",
+    inputSchema: {
+      filter: z.string().optional(),
+      limit: z.number().int().positive().max(200).optional(),
+      maxChars: z.number().int().positive().max(50000).optional(),
+    },
+  },
+  async (input) => {
+    const active = activeSession()
+    const files = newest(
+      walk(join(active.userDir, "logs")).filter(
+        (item) => item.endsWith(".log") && (!input.filter || item.includes(input.filter)),
+      ),
+    ).slice(0, 5)
+
+    const logs = files.map((item) => ({
+      path: item,
+      text: clip(tail(item, input.limit ?? 40), input.maxChars ?? 12000),
+    }))
+
+    return textResult("Collected recent VS Code logs.", { logs, userDir: active.userDir })
+  },
+)
+
+server.registerTool(
+  "vscode-console",
+  {
+    description: "Read recent browser and webview console messages captured from the live VS Code window.",
+    inputSchema: {
+      limit: z.number().int().positive().max(200).optional(),
+      maxChars: z.number().int().positive().max(50000).optional(),
+      type: z.string().optional(),
+    },
+  },
+  async (input) => {
+    const items = state.console
+      .filter((item) => !input.type || item.type === input.type)
+      .slice(-(input.limit ?? 50))
+      .map((item) => ({
+        ...item,
+        text: clip(item.text, input.maxChars ?? 4000),
+      }))
+
+    return textResult("Collected recent VS Code console messages.", { items })
+  },
+)
+
+server.registerTool(
+  "stop-vscode",
+  {
+    description: "Close the isolated VS Code session and optionally remove its temp directories.",
+    inputSchema: {
+      cleanup: z.boolean().optional(),
+    },
+  },
+  async (input) => {
+    const result = await closeSession(input.cleanup ?? true)
+    return textResult("Stopped isolated VS Code session.", result)
+  },
+)
+
+async function shutdown() {
+  await closeSession(true)
+  await server.close().catch(() => undefined)
+}
+
+process.on("SIGINT", () => {
+  void shutdown().finally(() => process.exit(0))
+})
+
+process.on("SIGTERM", () => {
+  void shutdown().finally(() => process.exit(0))
+})
+
+if (process.argv.includes("--self-check")) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [import.meta.filename],
+    cwd: root,
+    stderr: "inherit",
+  })
+  const client = new Client({ name: "self-check", version: "1.0.0" })
+  await client.connect(transport)
+  const tools = await client.listTools()
+  console.log(
+    JSON.stringify(
+      tools.tools.map((item) => item.name),
+      null,
+      2,
+    ),
+  )
+  await client.close()
+  process.exit(0)
+}
+
+const transport = new StdioServerTransport()
+await server.connect(transport)

--- a/packages/kilo-vscode/script/self-test/engine-mcp.mjs
+++ b/packages/kilo-vscode/script/self-test/engine-mcp.mjs
@@ -112,7 +112,9 @@ function detectAppPath(appPath) {
     return found
   }
 
-  return fail("VS Code app executable not found. Pass appPath explicitly.")
+  return fail(
+    "VS Code app executable not found. Auto-detection currently probes standard macOS installs only; set VSCODE_EXEC_PATH or pass appPath explicitly.",
+  )
 }
 
 function detectCliPath(appPath) {
@@ -212,9 +214,9 @@ async function closeSession(cleanup) {
 async function launchVsCode(input) {
   await closeSession(true)
 
-  const appPath = detectAppPath(input.appPath)
-  const cliPath = detectCliPath(appPath)
   const mode = input.mode ?? "vsix"
+  const appPath = detectAppPath(input.appPath)
+  const cliPath = mode === "vsix" ? detectCliPath(appPath) : null
   const workspace = resolve(input.workspace ?? repo)
   const userDir = temp("kilo-vscode-user-")
   const extDir = temp("kilo-vscode-ext-")

--- a/packages/kilo-vscode/script/self-test/mcp.mjs
+++ b/packages/kilo-vscode/script/self-test/mcp.mjs
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { spawn } from "node:child_process"
+import { openSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { z } from "zod"
+import {
+  delay,
+  ensureStateDir,
+  isAlive,
+  logPath,
+  output,
+  ping,
+  readState,
+  removeState,
+  request,
+  root,
+} from "./common.mjs"
+
+function fail(message) {
+  throw new Error(message)
+}
+
+async function active(timeoutMs = 0) {
+  const state = readState()
+  if (!state) {
+    return null
+  }
+
+  const started = Date.now()
+  while (Date.now() - started <= timeoutMs) {
+    const info = await ping(state)
+    if (info) {
+      return { info, state }
+    }
+
+    await delay(200)
+  }
+
+  const info = await ping(state)
+  if (info) {
+    return { info, state }
+  }
+
+  if (!isAlive(state.pid)) {
+    removeState()
+    return null
+  }
+
+  return null
+}
+
+async function start() {
+  const found = await active(500)
+  if (found) {
+    return found
+  }
+
+  ensureStateDir()
+  const fd = openSync(logPath, "a")
+  const child = spawn(process.execPath, [join(root, "script", "self-test", "daemon.mjs")], {
+    cwd: root,
+    detached: true,
+    stdio: ["ignore", fd, fd],
+  })
+  child.unref()
+
+  const started = Date.now()
+  while (Date.now() - started <= 10000) {
+    const next = await active(500)
+    if (next) {
+      return next
+    }
+
+    await delay(200)
+  }
+
+  return fail(`Timed out waiting for self-test daemon. Check ${logPath}`)
+}
+
+async function daemon(required = true) {
+  const found = await active(500)
+  if (found || !required) {
+    return found
+  }
+
+  return start()
+}
+
+function result(value) {
+  const text = value.text ? [{ type: "text", text: value.text }] : []
+  const images = (value.images ?? []).map((item) => ({
+    type: "image",
+    data: Buffer.from(readFileSync(item.path)).toString("base64"),
+    mimeType: item.mimeType,
+  }))
+  const content = [...text, ...images]
+
+  if (!value.structuredContent) {
+    return { content }
+  }
+
+  return {
+    content,
+    structuredContent: value.structuredContent,
+  }
+}
+
+async function call(name, input) {
+  const current = await daemon(true)
+  const value = await request(current.state, "/tool", { arguments: input, name })
+  return result(value)
+}
+
+const server = new McpServer({
+  name: "kilo-vscode-self-test",
+  version: "1.0.0",
+})
+
+server.registerTool(
+  "daemon-status",
+  {
+    description: "Show the status of the per-worktree VS Code self-test daemon.",
+    inputSchema: {},
+  },
+  async () => {
+    const current = await daemon(false)
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: current ? "Self-test daemon is running." : "Self-test daemon is not running.",
+        },
+      ],
+      structuredContent: current?.info ?? { running: false },
+    }
+  },
+)
+
+server.registerTool(
+  "stop-daemon",
+  {
+    description: "Stop the per-worktree self-test daemon and any owned VS Code instance.",
+    inputSchema: {},
+  },
+  async () => {
+    const current = await daemon(false)
+    if (!current) {
+      return {
+        content: [{ type: "text", text: "Self-test daemon is already stopped." }],
+        structuredContent: { stopped: false },
+      }
+    }
+
+    await request(current.state, "/stop", {})
+    return {
+      content: [{ type: "text", text: "Stopping self-test daemon." }],
+      structuredContent: { stopping: true },
+    }
+  },
+)
+
+const tools = [
+  [
+    "launch-vscode",
+    "Build the extension, install or load it into an isolated VS Code instance, and launch it for manual testing.",
+    {
+      appPath: z.string().optional(),
+      build: z.boolean().optional(),
+      mode: z.enum(["dev", "vsix"]).optional(),
+      waitMs: z.number().int().positive().max(60000).optional(),
+      workspace: z.string().optional(),
+    },
+  ],
+  [
+    "vscode-state",
+    "Show the current isolated VS Code session details and a text snapshot of the active window.",
+    { maxChars: z.number().int().positive().max(20000).optional() },
+  ],
+  ["vscode-frames", "List the active Playwright frames in the VS Code window.", {}],
+  [
+    "vscode-snapshot",
+    "Capture the visible text content from the VS Code window or a matching frame.",
+    { frame: z.string().optional(), maxChars: z.number().int().positive().max(50000).optional() },
+  ],
+  [
+    "vscode-screenshot",
+    "Capture a screenshot of the VS Code window or a matching element.",
+    {
+      frame: z.string().optional(),
+      fullPage: z.boolean().optional(),
+      path: z.string().optional(),
+      selector: z.string().optional(),
+      text: z.string().optional(),
+    },
+  ],
+  [
+    "vscode-observe",
+    "Capture a screenshot and text snapshot together for an observe-action loop.",
+    {
+      frame: z.string().optional(),
+      fullPage: z.boolean().optional(),
+      maxChars: z.number().int().positive().max(50000).optional(),
+      path: z.string().optional(),
+      selector: z.string().optional(),
+      text: z.string().optional(),
+    },
+  ],
+  ["open-kilo", "Focus the Kilo sidebar view in VS Code.", { waitMs: z.number().int().min(0).max(60000).optional() }],
+  [
+    "open-agent-manager",
+    "Open the Agent Manager from the Kilo sidebar toolbar button.",
+    { waitMs: z.number().int().min(0).max(60000).optional() },
+  ],
+  [
+    "open-kilo-settings",
+    "Open the Kilo settings panel from the Kilo sidebar toolbar button.",
+    { waitMs: z.number().int().min(0).max(60000).optional() },
+  ],
+  [
+    "vscode-click",
+    "Click a VS Code element by selector or visible text, or click absolute window coordinates.",
+    {
+      button: z.enum(["left", "middle", "right"]).optional(),
+      exact: z.boolean().optional(),
+      frame: z.string().optional(),
+      nth: z.number().int().min(0).optional(),
+      selector: z.string().optional(),
+      text: z.string().optional(),
+      waitMs: z.number().int().min(0).max(60000).optional(),
+      x: z.number().optional(),
+      y: z.number().optional(),
+    },
+  ],
+  [
+    "vscode-move",
+    "Move the mouse to absolute window coordinates.",
+    {
+      steps: z.number().int().positive().max(200).optional(),
+      waitMs: z.number().int().min(0).max(60000).optional(),
+      x: z.number(),
+      y: z.number(),
+    },
+  ],
+  [
+    "vscode-scroll",
+    "Scroll the VS Code window using mouse wheel deltas.",
+    {
+      deltaX: z.number().optional(),
+      deltaY: z.number().optional(),
+      waitMs: z.number().int().min(0).max(60000).optional(),
+    },
+  ],
+  [
+    "vscode-evaluate",
+    "Run JavaScript in the current VS Code page or a matching frame and return a JSON-serializable result.",
+    { frame: z.string().optional(), maxChars: z.number().int().positive().max(50000).optional(), script: z.string() },
+  ],
+  [
+    "vscode-type",
+    "Type text into the current VS Code focus target or an element selected by selector or text.",
+    {
+      clear: z.boolean().optional(),
+      exact: z.boolean().optional(),
+      frame: z.string().optional(),
+      nth: z.number().int().min(0).optional(),
+      selector: z.string().optional(),
+      submit: z.boolean().optional(),
+      text: z.string().optional(),
+      value: z.string(),
+      waitMs: z.number().int().min(0).max(60000).optional(),
+    },
+  ],
+  [
+    "vscode-press",
+    "Send a keyboard shortcut to the VS Code window.",
+    { keys: z.string(), waitMs: z.number().int().min(0).max(60000).optional() },
+  ],
+  [
+    "vscode-run-command",
+    "Open the command palette, search for a command, and execute it.",
+    { command: z.string(), waitMs: z.number().int().min(0).max(60000).optional() },
+  ],
+  [
+    "vscode-wait",
+    "Wait for a VS Code element or visible text to reach a given state.",
+    {
+      exact: z.boolean().optional(),
+      frame: z.string().optional(),
+      nth: z.number().int().min(0).optional(),
+      selector: z.string().optional(),
+      state: z.enum(["attached", "detached", "hidden", "visible"]).optional(),
+      text: z.string().optional(),
+      timeoutMs: z.number().int().positive().max(60000).optional(),
+    },
+  ],
+  [
+    "vscode-logs",
+    "Read the newest VS Code log files from the isolated user-data directory.",
+    {
+      filter: z.string().optional(),
+      limit: z.number().int().positive().max(200).optional(),
+      maxChars: z.number().int().positive().max(50000).optional(),
+    },
+  ],
+  [
+    "vscode-console",
+    "Read recent browser and webview console messages captured from the live VS Code window.",
+    {
+      limit: z.number().int().positive().max(200).optional(),
+      maxChars: z.number().int().positive().max(50000).optional(),
+      type: z.string().optional(),
+    },
+  ],
+  [
+    "stop-vscode",
+    "Close the isolated VS Code session and optionally remove its temp directories.",
+    { cleanup: z.boolean().optional() },
+  ],
+]
+
+for (const [name, description, inputSchema] of tools) {
+  server.registerTool(name, { description, inputSchema }, async (input) => call(name, input))
+}
+
+if (process.argv.includes("--self-check")) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [import.meta.filename],
+    cwd: root,
+    stderr: "inherit",
+  })
+  const client = new Client({ name: "self-check", version: "1.0.0" })
+  await client.connect(transport)
+  const tools = await client.listTools()
+  output(tools.tools.map((item) => item.name))
+  await client.close()
+  process.exit(0)
+}
+
+const transport = new StdioServerTransport()
+await server.connect(transport)


### PR DESCRIPTION
## Why
- this is intentionally a test PR to evaluate a practical self-test loop during VS Code extension feature development
- the goal is to give Kilo a CUA-style feedback loop so the agent can autonomously open the extension, observe screenshots, click, type, and validate its own UI changes instead of relying entirely on human manual testing
- that should materially raise the agent's success rate because each feature can at least brush-test itself before deeper manual review
- this is much more feasible now because the CUA ability of models like GPT-5.4 and Opus 4.6 has improved significantly, and that capability should continue to improve

## Summary
- add a daemon-backed VS Code self-test stack under `packages/kilo-vscode/script/self-test` so each worktree can own and reuse its own isolated Extension Development Host
- keep lifecycle in a per-worktree CLI/daemon while exposing the interaction loop through MCP with inline screenshot output
- simplify the tool surface around quick openers plus generic observe/click/type/wait tools, and document the workflow with a dedicated repo skill
- document the current limits: standard app auto-detection is macOS-first, and the `code` shell command is only required for `vsix` mode

## Testing
- `bun run --cwd packages/kilo-vscode mcp:self-test -- --self-check`
- `bun run --cwd packages/kilo-vscode self-test help`
- `PATH="$(dirname "$(which node)"):/usr/bin:/bin" node script/self-test/cli.mjs start && PATH="$(dirname "$(which node)"):/usr/bin:/bin" node script/self-test/cli.mjs launch-vscode --mode dev --build false --app-path "/Applications/Visual Studio Code.app/Contents/MacOS/Code" --wait-ms 2000 && PATH="$(dirname "$(which node)"):/usr/bin:/bin" node script/self-test/cli.mjs stop`
- smoke-tested the daemon-backed lifecycle and MCP tools against a live Extension Development Host, including opening Kilo, opening Agent Manager and settings, sending prompts, waiting for responses, and capturing screenshots
