### PR TITLE
chore(kilo-vscode): move SolidJS directive types to shared .d.ts file

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/sortable-tab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/sortable-tab.tsx
@@ -2,14 +2,6 @@
  * Drag-and-drop sortable tab components for the agent manager tab bar.
  */
 
-declare module "solid-js" {
-  namespace JSX {
-    interface Directives {
-      sortable: true
-    }
-  }
-}
-
 import { Component, onCleanup } from "solid-js"
 import { createSortable, useDragDropContext } from "@thisbeyond/solid-dnd"
 import type { Transformer } from "@thisbeyond/solid-dnd"

--- a/packages/kilo-vscode/webview-ui/tsconfig.json
+++ b/packages/kilo-vscode/webview-ui/tsconfig.json
@@ -12,5 +12,5 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*", "agent-manager/**/*"]
+  "include": ["src/**/*", "agent-manager/**/*", "types/**/*"]
 }

--- a/packages/kilo-vscode/webview-ui/types/solid-directives.d.ts
+++ b/packages/kilo-vscode/webview-ui/types/solid-directives.d.ts
@@ -1,0 +1,18 @@
+/**
+ * SolidJS custom directive type declarations.
+ *
+ * SolidJS intentionally ships `JSX.Directives` as an empty interface for
+ * consumers to extend via module augmentation. Libraries like
+ * `@thisbeyond/solid-dnd` use `use:sortable` but don't ship their own
+ * type declarations, so we declare them here.
+ *
+ * @see https://docs.solidjs.com/concepts/refs#directive-typing
+ */
+
+declare module "solid-js" {
+	namespace JSX {
+		interface Directives {
+			sortable: true
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Move the inline `declare module "solid-js"` augmentation from `sortable-tab.tsx` to a dedicated `webview-ui/types/solid-directives.d.ts` file.

## Changes

- **New:** `webview-ui/types/solid-directives.d.ts` — centralized SolidJS custom directive type declarations with doc comments and reference link
- **Modified:** `webview-ui/agent-manager/sortable-tab.tsx` — removed inline module augmentation (now picked up from the shared .d.ts)
- **Modified:** `webview-ui/tsconfig.json` — added `types/**/*` to `include` so the declaration file is visible to the type checker

## Why

The inline augmentation was added in #6785. As noted in the [review discussion](https://github.com/Kilo-Org/kilocode/pull/6785#discussion_r2917041970), module augmentations are better placed in a shared type declaration file where they're discoverable and can be extended as new custom directives are added.

## Testing

- `bun script/typecheck.ts --project webview-ui/tsconfig.json` passes clean
- `bun script/typecheck.ts` (extension) passes clean
- No runtime changes — this is a types-only refactor