### PR TITLE
refactor(vscode): use SDK createKiloServer for CLI process management

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -397,6 +397,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "openChanges":
           vscode.commands.executeCommand("kilo-code.new.showChanges")
           break
+        case "retryConnection":
+          console.log("[Kilo New] KiloProvider: 🔄 Retrying connection...")
+          this.initializeConnection().catch((e) =>
+            console.error("[Kilo New] KiloProvider: ❌ Retry connection failed:", e),
+          )
+          break
         case "openSubAgentViewer":
           vscode.commands.executeCommand("kilo-code.new.openSubAgentViewer", message.sessionID, message.title)
           break
@@ -612,6 +618,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    */
   private async initializeConnection(): Promise<void> {
     console.log("[Kilo New] KiloProvider: 🔧 Starting initializeConnection...")
+
+    this.connectionState = "connecting"
+    this.postMessage({ type: "connectionState", state: "connecting" })
 
     // Clean up any existing subscriptions (e.g., sidebar re-shown)
     this.unsubscribeEvent?.()

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -1,14 +1,18 @@
-import { spawn, ChildProcess } from "child_process"
 import * as crypto from "crypto"
 import * as fs from "fs"
 import * as path from "path"
 import * as vscode from "vscode"
-import { parseServerPort } from "./server-utils"
+import { createKiloServer, type ServerResult } from "@kilocode/sdk/v2/server"
 
 export interface ServerInstance {
   port: number
   password: string
-  process: ChildProcess
+  /** PID of the spawned CLI process, used for process-group cleanup. */
+  pid: number | undefined
+  /** Collected stderr output from CLI startup — surfaced to the user on failure. */
+  stderr: string
+  /** Kill the CLI server process via the SDK handle. */
+  close(): void
 }
 
 export class ServerManager {
@@ -60,11 +64,15 @@ export class ServerManager {
     console.log("[Kilo New] ServerManager: 📄 CLI isFile:", stat.isFile())
     console.log("[Kilo New] ServerManager: 📄 CLI mode (octal):", (stat.mode & 0o777).toString(8))
 
-    return new Promise((resolve, reject) => {
-      console.log("[Kilo New] ServerManager: 🎬 Spawning CLI process:", cliPath, ["serve", "--port", "0"])
-      const serverProcess = spawn(cliPath, ["serve", "--port", "0"], {
+    console.log("[Kilo New] ServerManager: 🎬 Starting CLI server via SDK:", cliPath)
+
+    let result: ServerResult
+    try {
+      result = await createKiloServer({
+        command: cliPath,
+        port: 0,
+        timeout: 30000,
         env: {
-          ...process.env,
           KILO_SERVER_PASSWORD: password,
           KILO_CLIENT: "vscode",
           KILO_ENABLE_QUESTION_TOOL: "true",
@@ -77,57 +85,27 @@ export class ServerManager {
           KILO_APP_VERSION: this.context.extension.packageJSON.version,
           KILO_VSCODE_VERSION: vscode.version,
         },
-        stdio: ["ignore", "pipe", "pipe"],
-        detached: true,
-        windowsHide: true,
+        spawnOptions: {
+          detached: true,
+          windowsHide: true,
+        },
       })
-      console.log("[Kilo New] ServerManager: 📦 Process spawned with PID:", serverProcess.pid)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      const { text } = toErrorMessage(message, cliPath)
+      throw new Error(text)
+    }
 
-      let resolved = false
+    console.log("[Kilo New] ServerManager: 📦 Process spawned with PID:", result.pid)
+    console.log("[Kilo New] ServerManager: 🎯 Port detected:", result.port)
 
-      serverProcess.stdout?.on("data", (data: Buffer) => {
-        const output = data.toString()
-        console.log("[Kilo New] ServerManager: 📥 CLI Server stdout:", output)
-
-        const port = parseServerPort(output)
-        if (port !== null && !resolved) {
-          resolved = true
-          console.log("[Kilo New] ServerManager: 🎯 Port detected:", port)
-          resolve({ port, password, process: serverProcess })
-        }
-      })
-
-      serverProcess.stderr?.on("data", (data: Buffer) => {
-        const errorOutput = data.toString()
-        console.error("[Kilo New] ServerManager: ⚠️ CLI Server stderr:", errorOutput)
-      })
-
-      serverProcess.on("error", (error) => {
-        console.error("[Kilo New] ServerManager: ❌ Process error:", error)
-        if (!resolved) {
-          reject(error)
-        }
-      })
-
-      serverProcess.on("exit", (code) => {
-        console.log("[Kilo New] ServerManager: 🛑 Process exited with code:", code)
-        if (this.instance?.process === serverProcess) {
-          this.instance = null
-        }
-        if (!resolved) {
-          reject(new Error(`CLI process exited with code ${code} before server started`))
-        }
-      })
-
-      // Timeout after 30 seconds
-      setTimeout(() => {
-        if (!resolved) {
-          console.error("[Kilo New] ServerManager: ⏰ Server startup timeout (30s)")
-          ServerManager.killProcess(serverProcess)
-          reject(new Error("Server startup timeout"))
-        }
-      }, 30000)
-    })
+    return {
+      port: result.port,
+      password,
+      pid: result.pid,
+      stderr: result.stderr,
+      close: result.close,
+    }
   }
 
   private getCliPath(): string {
@@ -139,24 +117,33 @@ export class ServerManager {
   }
 
   /**
-   * Kill a process and its entire process group.
+   * Kill a process and its entire process group by PID.
    * On Unix, we send the signal to -pid (negative) to reach the whole group,
    * mirroring the desktop app's ProcessGroup::leader() + start_kill() pattern.
-   * On Windows, process.kill() on the child handle is sufficient.
+   * On Windows, process.kill() on the PID is sufficient.
    */
-  private static killProcess(proc: ChildProcess, signal: NodeJS.Signals = "SIGTERM"): void {
-    if (proc.pid === undefined) {
-      return
-    }
+  private static killByPid(pid: number, signal: NodeJS.Signals = "SIGTERM"): void {
     try {
       if (process.platform !== "win32") {
         // Negative PID targets the entire process group
-        process.kill(-proc.pid, signal)
+        process.kill(-pid, signal)
       } else {
-        proc.kill(signal)
+        process.kill(pid, signal)
       }
     } catch {
       // Process already gone — ignore
+    }
+  }
+
+  /**
+   * Check whether the process is still running.
+   */
+  private static isProcessAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0)
+      return true
+    } catch {
+      return false
     }
   }
 
@@ -164,23 +151,35 @@ export class ServerManager {
     if (!this.instance) {
       return
     }
-    const proc = this.instance.process
+    const { pid, close } = this.instance
     this.instance = null
 
-    console.log("[Kilo New] ServerManager: 🔴 Disposing — sending SIGTERM to process group, PID:", proc.pid)
-    ServerManager.killProcess(proc, "SIGTERM")
+    console.log("[Kilo New] ServerManager: 🔴 Disposing — sending SIGTERM to process group, PID:", pid)
+
+    if (pid !== undefined) {
+      ServerManager.killByPid(pid, "SIGTERM")
+    } else {
+      // Fallback: use the SDK close() if PID is unavailable
+      close()
+    }
 
     // SIGKILL fallback after 5s: mirrors the desktop app going straight to
     // start_kill(). Ensures the process tree dies even if SIGTERM is ignored
     // or Instance.disposeAll() hangs past the serve.ts shutdown timeout.
-    const timer = setTimeout(() => {
-      if (proc.exitCode === null) {
-        console.warn("[Kilo New] ServerManager: ⚠️ Process did not exit after SIGTERM, sending SIGKILL")
-        ServerManager.killProcess(proc, "SIGKILL")
-      }
-    }, 5000)
-    // unref so this timer doesn't prevent the extension host from exiting
-    timer.unref()
-    proc.on("exit", () => clearTimeout(timer))
+    if (pid !== undefined) {
+      const timer = setTimeout(() => {
+        if (ServerManager.isProcessAlive(pid)) {
+          console.warn("[Kilo New] ServerManager: ⚠️ Process did not exit after SIGTERM, sending SIGKILL")
+          ServerManager.killByPid(pid, "SIGKILL")
+        }
+      }, 5000)
+      // unref so this timer doesn't prevent the extension host from exiting
+      timer.unref()
+    }
   }
+}
+
+function toErrorMessage(message: string, cliPath?: string): { text: string } {
+  const header = cliPath ? `${message}\nCLI path: ${cliPath}` : message
+  return { text: header }
 }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -11,10 +11,12 @@ import { MessageList } from "./MessageList"
 import { PromptInput } from "./PromptInput"
 import { QuestionDock } from "./QuestionDock"
 import { PermissionDock } from "./PermissionDock"
+import { StartupErrorBanner } from "./StartupErrorBanner"
 import { useSession } from "../../context/session"
 import { useVSCode } from "../../context/vscode"
 import { useLanguage } from "../../context/language"
 import { useWorktreeMode } from "../../context/worktree-mode"
+import { useServer } from "../../context/server"
 
 interface ChatViewProps {
   onSelectSession?: (id: string) => void
@@ -26,6 +28,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   const vscode = useVSCode()
   const language = useLanguage()
   const worktreeMode = useWorktreeMode()
+  const server = useServer()
   // Show "Show Changes" only in the standalone sidebar, not inside Agent Manager
   const isSidebar = () => worktreeMode === undefined
 
@@ -117,6 +120,9 @@ export const ChatView: Component<ChatViewProps> = (props) => {
 
       <Show when={!props.readonly}>
         <div class="chat-input">
+          <Show when={server.connectionState() === "error" && server.error()}>
+            <StartupErrorBanner error={server.error()!} />
+          </Show>
           <Show when={questionRequest()} keyed>
             {(req) => <QuestionDock request={req} />}
           </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -175,6 +175,16 @@ export const PromptInput: Component = () => {
     (text().trim().length > 0 || imageAttach.images().length > 0 || reviewComments().length > 0) &&
     !isBusy() &&
     !isDisabled()
+  const placeholder = () => {
+    switch (server.connectionState()) {
+      case "connecting":
+        return language.t("prompt.placeholder.connecting")
+      case "error":
+        return language.t("prompt.placeholder.error")
+      default:
+        return language.t("prompt.placeholder.default")
+    }
+  }
 
   const unsubscribe = vscode.onMessage((message) => {
     if (message.type === "chatCompletionResult") {
@@ -557,9 +567,7 @@ export const PromptInput: Component = () => {
           <textarea
             ref={textareaRef}
             class="prompt-input"
-            placeholder={
-              isDisabled() ? language.t("prompt.placeholder.connecting") : language.t("prompt.placeholder.default")
-            }
+            placeholder={placeholder()}
             value={text()}
             onInput={handleInput}
             onKeyDown={handleKeyDown}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/StartupErrorBanner.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/StartupErrorBanner.tsx
@@ -1,0 +1,51 @@
+/**
+ * StartupErrorBanner
+ * Shown in the chat view when the CLI server fails to start.
+ */
+
+import { Component, createSignal, Show } from "solid-js"
+import { Icon } from "@kilocode/kilo-ui/icon"
+import { useLanguage } from "../../context/language"
+import { useVSCode } from "../../context/vscode"
+
+interface StartupErrorBannerProps {
+  error: string
+}
+
+export const StartupErrorBanner: Component<StartupErrorBannerProps> = (props) => {
+  const language = useLanguage()
+  const vscode = useVSCode()
+  const [expanded, setExpanded] = createSignal(false)
+
+  const firstLine = () => props.error.split("\n")[0] ?? ""
+
+  const retry = () => {
+    vscode.postMessage({ type: "retryConnection" })
+  }
+
+  return (
+    <div class="startup-error-banner">
+      <div class="startup-error-header" onClick={() => setExpanded((v) => !v)} role="button" aria-expanded={expanded()}>
+        <span class={`startup-error-chevron${expanded() ? " startup-error-chevron-expanded" : ""}`}>
+          <Icon name="chevron-right" size="small" />
+        </span>
+        <span class="startup-error-title">
+          {language.t("error.startup.title")}: <span class="startup-error-firstline">{firstLine()}</span>
+        </span>
+        <button
+          class="startup-error-retry"
+          onClick={(e) => {
+            e.stopPropagation()
+            retry()
+          }}
+          aria-label={language.t("common.retry")}
+        >
+          {language.t("common.retry")}
+        </button>
+      </div>
+      <Show when={expanded()}>
+        <pre class="startup-error-details">{props.error}</pre>
+      </Show>
+    </div>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -411,6 +411,8 @@ export const dict = {
 
   "error.globalSync.connectFailed": "Could not connect to server. Is there a server running at `{{url}}`?",
 
+  "error.startup.title": "Server connection failed",
+
   "error.paidModel.title": "You need to sign in to use this model",
   "error.paidModel.description":
     "Sign in or create an account to access over 500 models, use credits at cost, or bring your own key.",
@@ -838,6 +840,7 @@ export const dict = {
 
   "prompt.placeholder.connecting": "Connecting to server...",
   "prompt.placeholder.default": "Type a message... (Enter to send, Shift+Enter for new line)",
+  "prompt.placeholder.error": "",
 
   "context.usage.sessionCost": "Session cost",
 

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -101,6 +101,76 @@
   border-top: 1px solid var(--vscode-panel-border);
 }
 
+/* Startup Error Banner */
+.startup-error-banner {
+  margin: 8px 12px;
+  border: 1px solid var(--vscode-inputValidation-errorBorder, #f14c4c);
+  border-radius: 4px;
+  background: var(--vscode-inputValidation-errorBackground, rgba(241, 76, 76, 0.1));
+  font-size: 12px;
+}
+
+.startup-error-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  user-select: none;
+  min-width: 0;
+}
+
+.startup-error-title {
+  flex: 1;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.startup-error-firstline {
+  font-weight: 400;
+}
+
+.startup-error-chevron {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  transition: transform 150ms;
+}
+
+.startup-error-chevron-expanded {
+  transform: rotate(90deg);
+}
+
+.startup-error-retry {
+  background: none;
+  border: none;
+  color: var(--vscode-textLink-foreground);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.startup-error-retry:hover {
+  text-decoration: underline;
+}
+
+.startup-error-details {
+  margin: 0;
+  padding: 8px 10px;
+  border-top: 1px solid var(--vscode-inputValidation-errorBorder, #f14c4c);
+  background: var(--vscode-editor-background);
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
 /* New Task Button */
 .new-task-button-wrapper {
   padding: 8px 12px 0;

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1521,6 +1521,10 @@ export interface OpenChangesRequest {
   type: "openChanges"
 }
 
+export interface RetryConnectionRequest {
+  type: "retryConnection"
+}
+
 // Open a sub-agent session in a read-only editor panel
 export interface OpenSubAgentViewerRequest {
   type: "openSubAgentViewer"
@@ -1618,6 +1622,7 @@ export type WebviewMessage =
   | ApplyWorktreeDiffMessage
   | EnhancePromptRequest
   | OpenChangesRequest
+  | RetryConnectionRequest
   | OpenSubAgentViewerRequest
   | SetDefaultBaseBranchRequest
 

--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process"
+import { spawn, type SpawnOptions } from "node:child_process"
 import { type Config } from "./gen/types.gen.js"
 
 // kilocode_change start - Merge existing KILO_CONFIG_CONTENT with new config
@@ -40,7 +40,28 @@ export type ServerOptions = {
   signal?: AbortSignal
   timeout?: number
   config?: Config
+  /** Path to the CLI binary. Defaults to "kilo" (resolved via PATH). */ // kilocode_change
+  command?: string // kilocode_change
+  /** Additional environment variables merged on top of process.env. */ // kilocode_change
+  env?: Record<string, string | undefined> // kilocode_change
+  /** Extra options forwarded to child_process.spawn (e.g. detached, windowsHide). */ // kilocode_change
+  spawnOptions?: Pick<SpawnOptions, "detached" | "windowsHide"> // kilocode_change
 }
+
+// kilocode_change start
+export type ServerResult = {
+  /** Full URL the server is listening on (e.g. "http://127.0.0.1:12345"). */
+  url: string
+  /** Port extracted from the URL. */
+  port: number
+  /** PID of the spawned process (undefined if the process failed to spawn). */
+  pid: number | undefined
+  /** Collected stderr output up to the point the server started (or failed). */
+  stderr: string
+  /** Kill the server process. */
+  close(): void
+}
+// kilocode_change end
 
 export type TuiOptions = {
   project?: string
@@ -51,7 +72,7 @@ export type TuiOptions = {
   config?: Config
 }
 
-export async function createKiloServer(options?: ServerOptions) {
+export async function createKiloServer(options?: ServerOptions): Promise<ServerResult> {
   options = Object.assign(
     {
       hostname: "127.0.0.1",
@@ -65,14 +86,21 @@ export async function createKiloServer(options?: ServerOptions) {
   if (options.config?.logLevel) args.push(`--log-level=${options.config.logLevel}`)
 
   // kilocode_change start
-  const proc = spawn(`kilo`, args, {
+  const proc = spawn(options.command ?? `kilo`, args, {
     // kilocode_change end
     signal: options.signal,
     env: {
       ...process.env,
+      ...options.env, // kilocode_change
       KILO_CONFIG_CONTENT: buildConfigEnv(options.config), // kilocode_change
     },
+    stdio: ["ignore", "pipe", "pipe"], // kilocode_change
+    ...options.spawnOptions, // kilocode_change
   })
+
+  // kilocode_change start
+  const stderrLines: string[] = []
+  // kilocode_change end
 
   const url = await new Promise<string>((resolve, reject) => {
     const id = setTimeout(() => {
@@ -97,7 +125,9 @@ export async function createKiloServer(options?: ServerOptions) {
       }
     })
     proc.stderr?.on("data", (chunk) => {
-      output += chunk.toString()
+      const text = chunk.toString()
+      output += text
+      stderrLines.push(text) // kilocode_change
     })
     proc.on("exit", (code) => {
       clearTimeout(id)
@@ -119,8 +149,15 @@ export async function createKiloServer(options?: ServerOptions) {
     }
   })
 
+  // kilocode_change start
+  const parsed = new URL(url)
+  // kilocode_change end
+
   return {
     url,
+    port: parseInt(parsed.port, 10), // kilocode_change
+    pid: proc.pid, // kilocode_change
+    stderr: stderrLines.join(""), // kilocode_change
     close() {
       proc.kill()
     },

--- a/packages/sdk/js/src/v2/server.ts
+++ b/packages/sdk/js/src/v2/server.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process"
+import { spawn, type SpawnOptions } from "node:child_process"
 import { type Config } from "./gen/types.gen.js"
 
 // kilocode_change start - Merge existing KILO_CONFIG_CONTENT with new config
@@ -40,7 +40,28 @@ export type ServerOptions = {
   signal?: AbortSignal
   timeout?: number
   config?: Config
+  /** Path to the CLI binary. Defaults to "kilo" (resolved via PATH). */ // kilocode_change
+  command?: string // kilocode_change
+  /** Additional environment variables merged on top of process.env. */ // kilocode_change
+  env?: Record<string, string | undefined> // kilocode_change
+  /** Extra options forwarded to child_process.spawn (e.g. detached, windowsHide). */ // kilocode_change
+  spawnOptions?: Pick<SpawnOptions, "detached" | "windowsHide"> // kilocode_change
 }
+
+// kilocode_change start
+export type ServerResult = {
+  /** Full URL the server is listening on (e.g. "http://127.0.0.1:12345"). */
+  url: string
+  /** Port extracted from the URL. */
+  port: number
+  /** PID of the spawned process (undefined if the process failed to spawn). */
+  pid: number | undefined
+  /** Collected stderr output up to the point the server started (or failed). */
+  stderr: string
+  /** Kill the server process. */
+  close(): void
+}
+// kilocode_change end
 
 export type TuiOptions = {
   project?: string
@@ -51,7 +72,7 @@ export type TuiOptions = {
   config?: Config
 }
 
-export async function createKiloServer(options?: ServerOptions) {
+export async function createKiloServer(options?: ServerOptions): Promise<ServerResult> {
   options = Object.assign(
     {
       hostname: "127.0.0.1",
@@ -65,14 +86,21 @@ export async function createKiloServer(options?: ServerOptions) {
   if (options.config?.logLevel) args.push(`--log-level=${options.config.logLevel}`)
 
   // kilocode_change start
-  const proc = spawn(`kilo`, args, {
+  const proc = spawn(options.command ?? `kilo`, args, {
     // kilocode_change end
     signal: options.signal,
     env: {
       ...process.env,
+      ...options.env, // kilocode_change
       KILO_CONFIG_CONTENT: buildConfigEnv(options.config), // kilocode_change
     },
+    stdio: ["ignore", "pipe", "pipe"], // kilocode_change
+    ...options.spawnOptions, // kilocode_change
   })
+
+  // kilocode_change start
+  const stderrLines: string[] = []
+  // kilocode_change end
 
   const url = await new Promise<string>((resolve, reject) => {
     const id = setTimeout(() => {
@@ -97,7 +125,9 @@ export async function createKiloServer(options?: ServerOptions) {
       }
     })
     proc.stderr?.on("data", (chunk) => {
-      output += chunk.toString()
+      const text = chunk.toString()
+      output += text
+      stderrLines.push(text) // kilocode_change
     })
     proc.on("exit", (code) => {
       clearTimeout(id)
@@ -119,8 +149,15 @@ export async function createKiloServer(options?: ServerOptions) {
     }
   })
 
+  // kilocode_change start
+  const parsed = new URL(url)
+  // kilocode_change end
+
   return {
     url,
+    port: parseInt(parsed.port, 10), // kilocode_change
+    pid: proc.pid, // kilocode_change
+    stderr: stderrLines.join(""), // kilocode_change
     close() {
       proc.kill()
     },


### PR DESCRIPTION
## Summary

- Refactors the VSCode extension's `ServerManager` to use the SDK's `createKiloServer` instead of directly managing `child_process.spawn`, eliminating duplicated server startup logic between the SDK and extension
- Extends the SDK's `createKiloServer` with `command`, `env`, and `spawnOptions` options plus a richer `ServerResult` return type (includes `port`, `pid`, `stderr`)
- Adds CLI startup error surfacing UI (StartupErrorBanner, retry connection, connection-state placeholder) from PR #6955 scope, integrated with the SDK-based approach

## Context

PR #6955 added CLI process management directly in the VSCode extension. However, the SDK at `packages/sdk/js/src/server.ts` already provides `createKiloServer` for CLI server process management. This PR refactors the extension to delegate to the SDK instead of duplicating process management logic.

## Changes

### SDK (`packages/sdk/js`)
- `ServerOptions`: Added `command` (custom binary path), `env` (extra env vars), `spawnOptions` (detached, windowsHide)
- `ServerResult`: New return type with `url`, `port`, `pid`, `stderr`, and `close()`
- Stderr is now captured separately for richer error diagnostics
- Both `src/server.ts` and `src/v2/server.ts` updated in sync

### Extension (`packages/kilo-vscode`)
- `ServerManager`: Replaced direct `spawn()` + stdout/stderr parsing with `createKiloServer()` call from `@kilocode/sdk/v2/server`
- Process group kill logic preserved using the returned `pid`
- Added `StartupErrorBanner` component — collapsible error banner with retry button shown when CLI fails to start
- Added `retryConnection` message handler in `KiloProvider`
- Added connection-state-aware placeholder text in `PromptInput`
- `server-utils.ts` and its tests retained (still valid as contract tests for CLI output format)

## How to Test

1. Build the extension and point it at a broken/missing CLI binary
2. Open the Kilo sidebar — the error banner should appear with the failure message and CLI path
3. Expand the banner to see full CLI output
4. Click **Retry** — the extension should attempt to reconnect
5. With a working binary, verify normal startup/connection works unchanged