### PR TITLE
refactor(vscode): derive message types from Zod schemas and validate at IO boundary

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -36,6 +36,7 @@ import type {
   SessionInfo,
   BranchInfo,
 } from "../src/types/messages"
+import { extensionMessageSchema } from "../src/types/messages"
 import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, closestCenter } from "@thisbeyond/solid-dnd"
 import type { DragEvent } from "@thisbeyond/solid-dnd"
 import { ThemeProvider } from "@kilocode/kilo-ui/theme"
@@ -944,8 +945,10 @@ const AgentManagerContent: Component = () => {
 
   onMount(() => {
     const handler = (event: MessageEvent) => {
-      const msg = event.data as ExtensionMessage
-      if (msg?.type !== "action") return
+      const result = extensionMessageSchema.safeParse(event.data)
+      if (!result.success) return
+      const msg = result.data
+      if (msg.type !== "action") return
       if (msg.action === "sessionPrevious") navigate("up")
       else if (msg.action === "sessionNext") navigate("down")
       else if (msg.action === "tabPrevious") navigateTab("left")

--- a/packages/kilo-vscode/webview-ui/src/context/vscode.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/vscode.tsx
@@ -5,6 +5,7 @@
 
 import { createContext, useContext, onCleanup, ParentComponent } from "solid-js"
 import type { VSCodeAPI, WebviewMessage, ExtensionMessage } from "../types/messages"
+import { extensionMessageSchema } from "../types/messages"
 
 // Get the VS Code API (only available in webview context)
 let vscodeApi: VSCodeAPI | undefined
@@ -41,10 +42,14 @@ export const VSCodeProvider: ParentComponent = (props) => {
   const api = getVSCodeAPI()
   const handlers = new Set<(message: ExtensionMessage) => void>()
 
-  // Listen for messages from the extension
+  // Listen for messages from the extension — validate at the IO boundary via Zod
   const messageListener = (event: MessageEvent) => {
-    const message = event.data as ExtensionMessage
-    handlers.forEach((handler) => handler(message))
+    const result = extensionMessageSchema.safeParse(event.data)
+    if (!result.success) {
+      console.warn("[Kilo New] Invalid extension message:", result.error.format(), event.data)
+      return
+    }
+    handlers.forEach((handler) => handler(result.data))
   }
 
   window.addEventListener("message", messageListener)

--- a/packages/kilo-vscode/webview-ui/src/types/message-schemas.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/message-schemas.ts
@@ -1,0 +1,1511 @@
+/**
+ * Zod schemas for extension <-> webview message communication.
+ * All TypeScript types in messages.ts are derived from these schemas.
+ * Zod validates/parses at the IO boundary (vscode.tsx) instead of casting.
+ */
+
+import { z } from "zod"
+
+// ============================================
+// Shared enums and primitives
+// ============================================
+
+export const connectionState = z.enum(["connecting", "connected", "disconnected", "error"])
+
+export const sessionStatus = z.enum(["idle", "busy", "retry"])
+
+export const sessionStatusInfo = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("idle") }),
+  z.object({ type: z.literal("busy") }),
+  z.object({ type: z.literal("retry"), attempt: z.number(), message: z.string(), next: z.number() }),
+])
+
+const recordStringUnknown = z.record(z.string(), z.unknown())
+
+export const toolState = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("pending"), input: recordStringUnknown }),
+  z.object({ status: z.literal("running"), input: recordStringUnknown, title: z.string().optional() }),
+  z.object({ status: z.literal("completed"), input: recordStringUnknown, output: z.string(), title: z.string() }),
+  z.object({ status: z.literal("error"), input: recordStringUnknown, error: z.string() }),
+])
+
+// ============================================
+// Part schemas
+// ============================================
+
+const basePart = z.object({
+  id: z.string(),
+  sessionID: z.string().optional(),
+  messageID: z.string().optional(),
+})
+
+export const textPart = basePart.extend({ type: z.literal("text"), text: z.string() })
+export const toolPart = basePart.extend({ type: z.literal("tool"), tool: z.string(), state: toolState })
+export const reasoningPart = basePart.extend({ type: z.literal("reasoning"), text: z.string() })
+export const stepStartPart = basePart.extend({ type: z.literal("step-start") })
+export const stepFinishPart = basePart.extend({
+  type: z.literal("step-finish"),
+  reason: z.string().optional(),
+  cost: z.number().optional(),
+  tokens: z
+    .object({
+      input: z.number(),
+      output: z.number(),
+      reasoning: z.number().optional(),
+      cache: z.object({ read: z.number(), write: z.number() }).optional(),
+    })
+    .optional(),
+})
+
+export const part = z.discriminatedUnion("type", [textPart, toolPart, reasoningPart, stepStartPart, stepFinishPart])
+
+export const partDelta = z.object({
+  type: z.literal("text-delta"),
+  textDelta: z.string().optional(),
+})
+
+// ============================================
+// Token / context usage
+// ============================================
+
+export const tokenUsage = z.object({
+  input: z.number(),
+  output: z.number(),
+  reasoning: z.number().optional(),
+  cache: z.object({ read: z.number(), write: z.number() }).optional(),
+})
+
+export const contextUsage = z.object({
+  tokens: z.number(),
+  percentage: z.number().nullable(),
+})
+
+// ============================================
+// Message / Session
+// ============================================
+
+export const message = z.object({
+  id: z.string(),
+  sessionID: z.string(),
+  role: z.enum(["user", "assistant"]),
+  content: z.string().optional(),
+  parts: z.array(part).optional(),
+  createdAt: z.string(),
+  time: z.object({ created: z.number(), completed: z.number().optional() }).optional(),
+  agent: z.string().optional(),
+  model: z.object({ providerID: z.string(), modelID: z.string() }).optional(),
+  providerID: z.string().optional(),
+  modelID: z.string().optional(),
+  mode: z.string().optional(),
+  parentID: z.string().optional(),
+  path: z.object({ cwd: z.string(), root: z.string() }).optional(),
+  error: z.object({ name: z.string(), data: recordStringUnknown.optional() }).optional(),
+  summary: z
+    .union([
+      z.object({ title: z.string().optional(), body: z.string().optional(), diffs: z.array(z.unknown()).optional() }),
+      z.boolean(),
+    ])
+    .optional(),
+  cost: z.number().optional(),
+  tokens: tokenUsage.optional(),
+})
+
+export const sessionInfo = z.object({
+  id: z.string(),
+  title: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export const cloudSessionInfo = z.object({
+  session_id: z.string(),
+  title: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+// ============================================
+// Permission / Todo / Question
+// ============================================
+
+export const permissionRequest = z.object({
+  id: z.string(),
+  sessionID: z.string(),
+  toolName: z.string(),
+  patterns: z.array(z.string()),
+  args: recordStringUnknown,
+  message: z.string().optional(),
+  tool: z.object({ messageID: z.string(), callID: z.string() }).optional(),
+})
+
+export const todoItem = z.object({
+  id: z.string(),
+  content: z.string(),
+  status: z.enum(["pending", "in_progress", "completed"]),
+})
+
+export const questionOption = z.object({
+  label: z.string(),
+  description: z.string(),
+})
+
+export const questionInfo = z.object({
+  question: z.string(),
+  header: z.string(),
+  options: z.array(questionOption),
+  multiple: z.boolean().optional(),
+  custom: z.boolean().optional(),
+})
+
+export const questionRequest = z.object({
+  id: z.string(),
+  sessionID: z.string(),
+  questions: z.array(questionInfo),
+  tool: z.object({ messageID: z.string(), callID: z.string() }).optional(),
+})
+
+// ============================================
+// Agent / Server / Auth
+// ============================================
+
+export const agentInfo = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  mode: z.enum(["subagent", "primary", "all"]),
+  native: z.boolean().optional(),
+  hidden: z.boolean().optional(),
+  color: z.string().optional(),
+})
+
+export const serverInfo = z.object({
+  port: z.number(),
+  version: z.string().optional(),
+})
+
+export const deviceAuthStatus = z.enum(["idle", "initiating", "pending", "success", "error", "cancelled"])
+
+export const deviceAuthState = z.object({
+  status: deviceAuthStatus,
+  code: z.string().optional(),
+  verificationUrl: z.string().optional(),
+  expiresIn: z.number().optional(),
+  error: z.string().optional(),
+})
+
+// ============================================
+// Notifications
+// ============================================
+
+export const kilocodeNotificationAction = z.object({
+  actionText: z.string(),
+  actionURL: z.string(),
+})
+
+export const kilocodeNotification = z.object({
+  id: z.string(),
+  title: z.string(),
+  message: z.string(),
+  action: kilocodeNotificationAction.optional(),
+  showIn: z.array(z.string()).optional(),
+})
+
+// ============================================
+// Profile
+// ============================================
+
+export const kilocodeBalance = z.object({ balance: z.number() })
+
+export const profileData = z.object({
+  profile: z.object({
+    email: z.string(),
+    name: z.string().optional(),
+    organizations: z.array(z.object({ id: z.string(), name: z.string(), role: z.string() })).optional(),
+  }),
+  balance: kilocodeBalance.nullable(),
+  currentOrgId: z.string().nullable(),
+})
+
+// ============================================
+// Provider / Model
+// ============================================
+
+export const providerModel = z.object({
+  id: z.string(),
+  name: z.string(),
+  inputPrice: z.number().optional(),
+  outputPrice: z.number().optional(),
+  contextLength: z.number().optional(),
+  releaseDate: z.string().optional(),
+  latest: z.boolean().optional(),
+  limit: z.object({ context: z.number(), input: z.number().optional(), output: z.number() }).optional(),
+  variants: z.record(z.string(), recordStringUnknown).optional(),
+  capabilities: z.object({ reasoning: z.boolean() }).optional(),
+})
+
+export const provider = z.object({
+  id: z.string(),
+  name: z.string(),
+  models: z.record(z.string(), providerModel),
+})
+
+export const modelSelection = z.object({
+  providerID: z.string(),
+  modelID: z.string(),
+})
+
+// ============================================
+// Config types
+// ============================================
+
+export const permissionLevel = z.enum(["allow", "ask", "deny"])
+export const permissionRule = z.union([permissionLevel, z.record(z.string(), permissionLevel)])
+export const permissionConfig = z.record(z.string(), permissionRule).partial()
+
+export const agentConfig = z.object({
+  model: z.string().nullable().optional(),
+  prompt: z.string().optional(),
+  temperature: z.number().optional(),
+  top_p: z.number().optional(),
+  steps: z.number().optional(),
+  permission: permissionConfig.optional(),
+})
+
+export const providerConfig = z.object({
+  name: z.string().optional(),
+  api_key: z.string().optional(),
+  base_url: z.string().optional(),
+  models: recordStringUnknown.optional(),
+})
+
+export const mcpConfig = z.object({
+  command: z.string().optional(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  url: z.string().optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+})
+
+export const commandConfig = z.object({
+  command: z.string(),
+  description: z.string().optional(),
+})
+
+export const skillsConfig = z.object({
+  paths: z.array(z.string()).optional(),
+  urls: z.array(z.string()).optional(),
+})
+
+export const compactionConfig = z.object({
+  auto: z.boolean().optional(),
+  prune: z.boolean().optional(),
+})
+
+export const watcherConfig = z.object({
+  ignore: z.array(z.string()).optional(),
+})
+
+export const experimentalConfig = z.object({
+  disable_paste_summary: z.boolean().optional(),
+  batch_tool: z.boolean().optional(),
+  primary_tools: z.array(z.string()).optional(),
+  continue_loop_on_deny: z.boolean().optional(),
+  mcp_timeout: z.number().optional(),
+})
+
+export const config = z.object({
+  permission: permissionConfig.optional(),
+  model: z.string().nullable().optional(),
+  small_model: z.string().nullable().optional(),
+  default_agent: z.string().optional(),
+  agent: z.record(z.string(), agentConfig).optional(),
+  provider: z.record(z.string(), providerConfig).optional(),
+  disabled_providers: z.array(z.string()).optional(),
+  enabled_providers: z.array(z.string()).optional(),
+  mcp: z.record(z.string(), mcpConfig).optional(),
+  command: z.record(z.string(), commandConfig).optional(),
+  instructions: z.array(z.string()).optional(),
+  skills: skillsConfig.optional(),
+  snapshot: z.boolean().optional(),
+  share: z.enum(["manual", "auto", "disabled"]).optional(),
+  username: z.string().optional(),
+  watcher: watcherConfig.optional(),
+  formatter: z.union([z.literal(false), recordStringUnknown]).optional(),
+  lsp: z.union([z.literal(false), recordStringUnknown]).optional(),
+  compaction: compactionConfig.optional(),
+  tools: z.record(z.string(), z.boolean()).optional(),
+  layout: z.enum(["auto", "stretch"]).optional(),
+  experimental: experimentalConfig.optional(),
+})
+
+// ============================================
+// Review comment
+// ============================================
+
+export const reviewComment = z.object({
+  id: z.string(),
+  file: z.string(),
+  side: z.enum(["additions", "deletions"]),
+  line: z.number(),
+  comment: z.string(),
+  selectedText: z.string(),
+})
+
+// ============================================
+// Browser settings
+// ============================================
+
+export const browserSettings = z.object({
+  enabled: z.boolean(),
+  useSystemChrome: z.boolean(),
+  headless: z.boolean(),
+})
+
+// ============================================
+// Agent Manager types
+// ============================================
+
+export const sessionMode = z.enum(["local", "worktree"])
+
+export const worktreeState = z.object({
+  id: z.string(),
+  branch: z.string(),
+  path: z.string(),
+  parentBranch: z.string(),
+  remote: z.string().optional(),
+  createdAt: z.string(),
+  groupId: z.string().optional(),
+  label: z.string().optional(),
+})
+
+export const managedSessionState = z.object({
+  id: z.string(),
+  worktreeId: z.string().nullable(),
+  createdAt: z.string(),
+})
+
+export const worktreeFileDiff = z.object({
+  file: z.string(),
+  before: z.string(),
+  after: z.string(),
+  additions: z.number(),
+  deletions: z.number(),
+  status: z.enum(["added", "deleted", "modified"]).optional(),
+})
+
+export const applyWorktreeDiffStatus = z.enum(["checking", "applying", "success", "conflict", "error"])
+
+export const applyWorktreeDiffConflict = z.object({
+  file: z.string().optional(),
+  reason: z.string(),
+})
+
+export const worktreeGitStats = z.object({
+  worktreeId: z.string(),
+  files: z.number(),
+  additions: z.number(),
+  deletions: z.number(),
+  ahead: z.number(),
+  behind: z.number(),
+})
+
+export const localGitStats = z.object({
+  branch: z.string(),
+  files: z.number(),
+  additions: z.number(),
+  deletions: z.number(),
+  ahead: z.number(),
+  behind: z.number(),
+})
+
+export const branchInfo = z.object({
+  name: z.string(),
+  isLocal: z.boolean(),
+  isRemote: z.boolean(),
+  isDefault: z.boolean(),
+  lastCommitDate: z.string().optional(),
+  isCheckedOut: z.boolean().optional(),
+})
+
+export const externalWorktreeInfo = z.object({
+  path: z.string(),
+  branch: z.string(),
+})
+
+export const fileAttachment = z.object({
+  mime: z.string(),
+  url: z.string(),
+})
+
+export const modelAllocation = z.object({
+  providerID: z.string(),
+  modelID: z.string(),
+  count: z.number(),
+})
+
+// ============================================
+// Legacy migration types
+// ============================================
+
+export const migrationProviderInfo = z.object({
+  profileName: z.string(),
+  provider: z.string(),
+  model: z.string().optional(),
+  hasApiKey: z.boolean(),
+  supported: z.boolean(),
+  newProviderName: z.string().optional(),
+})
+
+export const migrationMcpServerInfo = z.object({
+  name: z.string(),
+  type: z.string(),
+})
+
+export const migrationCustomModeInfo = z.object({
+  name: z.string(),
+  slug: z.string(),
+})
+
+export const legacyAutocompleteSettings = z.object({
+  enableAutoTrigger: z.boolean().optional(),
+  enableSmartInlineTaskKeybinding: z.boolean().optional(),
+  enableChatAutocomplete: z.boolean().optional(),
+})
+
+export const legacySettings = z.object({
+  autoApprovalEnabled: z.boolean().optional(),
+  allowedCommands: z.array(z.string()).optional(),
+  deniedCommands: z.array(z.string()).optional(),
+  alwaysAllowReadOnly: z.boolean().optional(),
+  alwaysAllowReadOnlyOutsideWorkspace: z.boolean().optional(),
+  alwaysAllowWrite: z.boolean().optional(),
+  alwaysAllowExecute: z.boolean().optional(),
+  alwaysAllowMcp: z.boolean().optional(),
+  alwaysAllowModeSwitch: z.boolean().optional(),
+  alwaysAllowSubtasks: z.boolean().optional(),
+  language: z.string().optional(),
+  autocomplete: legacyAutocompleteSettings.optional(),
+})
+
+export const migrationResultItem = z.object({
+  item: z.string(),
+  category: z.enum(["provider", "mcpServer", "customMode", "defaultModel", "settings"]),
+  status: z.enum(["success", "warning", "error"]),
+  message: z.string().optional(),
+})
+
+export const migrationAutoApprovalSelections = z.object({
+  commandRules: z.boolean(),
+  readPermission: z.boolean(),
+  writePermission: z.boolean(),
+  executePermission: z.boolean(),
+  mcpPermission: z.boolean(),
+  taskPermission: z.boolean(),
+})
+
+// ============================================
+// Messages FROM extension TO webview
+// ============================================
+
+export const readyMessage = z.object({
+  type: z.literal("ready"),
+  serverInfo: serverInfo.optional(),
+  extensionVersion: z.string().optional(),
+  vscodeLanguage: z.string().optional(),
+  languageOverride: z.string().optional(),
+  workspaceDirectory: z.string().optional(),
+})
+
+export const workspaceDirectoryChangedMessage = z.object({
+  type: z.literal("workspaceDirectoryChanged"),
+  directory: z.string(),
+})
+
+export const connectionStateMessage = z.object({
+  type: z.literal("connectionState"),
+  state: connectionState,
+  error: z.string().optional(),
+})
+
+export const errorMessage = z.object({
+  type: z.literal("error"),
+  message: z.string(),
+  code: z.string().optional(),
+  sessionID: z.string().optional(),
+})
+
+export const partUpdatedMessage = z.object({
+  type: z.literal("partUpdated"),
+  sessionID: z.string().optional(),
+  messageID: z.string().optional(),
+  part: part,
+  delta: partDelta.optional(),
+})
+
+export const sessionStatusMessage = z.object({
+  type: z.literal("sessionStatus"),
+  sessionID: z.string(),
+  status: sessionStatus,
+  attempt: z.number().optional(),
+  message: z.string().optional(),
+  next: z.number().optional(),
+})
+
+export const permissionRequestMessage = z.object({
+  type: z.literal("permissionRequest"),
+  permission: permissionRequest,
+})
+
+export const permissionResolvedMessage = z.object({
+  type: z.literal("permissionResolved"),
+  permissionID: z.string(),
+})
+
+export const permissionErrorMessage = z.object({
+  type: z.literal("permissionError"),
+  permissionID: z.string(),
+})
+
+export const todoUpdatedMessage = z.object({
+  type: z.literal("todoUpdated"),
+  sessionID: z.string(),
+  items: z.array(todoItem),
+})
+
+export const sessionCreatedMessage = z.object({
+  type: z.literal("sessionCreated"),
+  session: sessionInfo,
+})
+
+export const sessionUpdatedMessage = z.object({
+  type: z.literal("sessionUpdated"),
+  session: sessionInfo,
+})
+
+export const sessionDeletedMessage = z.object({
+  type: z.literal("sessionDeleted"),
+  sessionID: z.string(),
+})
+
+export const messagesLoadedMessage = z.object({
+  type: z.literal("messagesLoaded"),
+  sessionID: z.string(),
+  messages: z.array(message),
+})
+
+export const messageCreatedMessage = z.object({
+  type: z.literal("messageCreated"),
+  message: message,
+})
+
+export const sessionsLoadedMessage = z.object({
+  type: z.literal("sessionsLoaded"),
+  sessions: z.array(sessionInfo),
+})
+
+export const cloudSessionsLoadedMessage = z.object({
+  type: z.literal("cloudSessionsLoaded"),
+  sessions: z.array(cloudSessionInfo),
+  nextCursor: z.string().nullable(),
+})
+
+export const gitRemoteUrlLoadedMessage = z.object({
+  type: z.literal("gitRemoteUrlLoaded"),
+  gitUrl: z.string().nullable(),
+})
+
+export const cloudSessionDataLoadedMessage = z.object({
+  type: z.literal("cloudSessionDataLoaded"),
+  cloudSessionId: z.string(),
+  title: z.string(),
+  messages: z.array(message),
+})
+
+export const cloudSessionImportedMessage = z.object({
+  type: z.literal("cloudSessionImported"),
+  cloudSessionId: z.string(),
+  session: sessionInfo,
+})
+
+export const cloudSessionImportFailedMessage = z.object({
+  type: z.literal("cloudSessionImportFailed"),
+  cloudSessionId: z.string(),
+  error: z.string(),
+})
+
+export const openCloudSessionMessage = z.object({
+  type: z.literal("openCloudSession"),
+  sessionId: z.string(),
+})
+
+export const actionMessage = z.object({
+  type: z.literal("action"),
+  action: z.string(),
+})
+
+export const setChatBoxMessage = z.object({
+  type: z.literal("setChatBoxMessage"),
+  text: z.string(),
+})
+
+export const appendChatBoxMessage = z.object({
+  type: z.literal("appendChatBoxMessage"),
+  text: z.string(),
+})
+
+export const appendReviewCommentsMessage = z.object({
+  type: z.literal("appendReviewComments"),
+  comments: z.array(reviewComment),
+})
+
+export const triggerTaskMessage = z.object({
+  type: z.literal("triggerTask"),
+  text: z.string(),
+})
+
+export const profileDataMessage = z.object({
+  type: z.literal("profileData"),
+  data: profileData.nullable(),
+})
+
+export const deviceAuthStartedMessage = z.object({
+  type: z.literal("deviceAuthStarted"),
+  code: z.string().optional(),
+  verificationUrl: z.string(),
+  expiresIn: z.number(),
+})
+
+export const deviceAuthCompleteMessage = z.object({
+  type: z.literal("deviceAuthComplete"),
+})
+
+export const deviceAuthFailedMessage = z.object({
+  type: z.literal("deviceAuthFailed"),
+  error: z.string(),
+})
+
+export const deviceAuthCancelledMessage = z.object({
+  type: z.literal("deviceAuthCancelled"),
+})
+
+export const navigateMessage = z.object({
+  type: z.literal("navigate"),
+  view: z.enum([
+    "newTask",
+    "marketplace",
+    "history",
+    "cloudHistory",
+    "profile",
+    "settings",
+    "migration",
+    "subAgentViewer",
+  ]),
+})
+
+export const providersLoadedMessage = z.object({
+  type: z.literal("providersLoaded"),
+  providers: z.record(z.string(), provider),
+  connected: z.array(z.string()),
+  defaults: z.record(z.string(), z.string()),
+  defaultSelection: modelSelection,
+})
+
+export const agentsLoadedMessage = z.object({
+  type: z.literal("agentsLoaded"),
+  agents: z.array(agentInfo),
+  defaultAgent: z.string(),
+})
+
+export const autocompleteSettingsLoadedMessage = z.object({
+  type: z.literal("autocompleteSettingsLoaded"),
+  settings: z.object({
+    enableAutoTrigger: z.boolean(),
+    enableSmartInlineTaskKeybinding: z.boolean(),
+    enableChatAutocomplete: z.boolean(),
+  }),
+})
+
+export const chatCompletionResultMessage = z.object({
+  type: z.literal("chatCompletionResult"),
+  text: z.string(),
+  requestId: z.string(),
+})
+
+export const fileSearchResultMessage = z.object({
+  type: z.literal("fileSearchResult"),
+  paths: z.array(z.string()),
+  dir: z.string(),
+  requestId: z.string(),
+})
+
+export const questionRequestMessage = z.object({
+  type: z.literal("questionRequest"),
+  question: questionRequest,
+})
+
+export const questionResolvedMessage = z.object({
+  type: z.literal("questionResolved"),
+  requestID: z.string(),
+})
+
+export const questionErrorMessage = z.object({
+  type: z.literal("questionError"),
+  requestID: z.string(),
+})
+
+export const browserSettingsLoadedMessage = z.object({
+  type: z.literal("browserSettingsLoaded"),
+  settings: browserSettings,
+})
+
+export const configLoadedMessage = z.object({
+  type: z.literal("configLoaded"),
+  config: config,
+})
+
+export const configUpdatedMessage = z.object({
+  type: z.literal("configUpdated"),
+  config: config,
+})
+
+export const notificationSettingsLoadedMessage = z.object({
+  type: z.literal("notificationSettingsLoaded"),
+  settings: z.object({
+    notifyAgent: z.boolean(),
+    notifyPermissions: z.boolean(),
+    notifyErrors: z.boolean(),
+    soundAgent: z.string(),
+    soundPermissions: z.string(),
+    soundErrors: z.string(),
+  }),
+})
+
+export const notificationsLoadedMessage = z.object({
+  type: z.literal("notificationsLoaded"),
+  notifications: z.array(kilocodeNotification),
+  dismissedIds: z.array(z.string()),
+})
+
+export const agentManagerSessionMetaMessage = z.object({
+  type: z.literal("agentManager.sessionMeta"),
+  sessionId: z.string(),
+  mode: sessionMode,
+  branch: z.string().optional(),
+  path: z.string().optional(),
+  parentBranch: z.string().optional(),
+})
+
+export const agentManagerRepoInfoMessage = z.object({
+  type: z.literal("agentManager.repoInfo"),
+  branch: z.string(),
+  defaultBranch: z.string().optional(),
+})
+
+export const agentManagerWorktreeSetupMessage = z.object({
+  type: z.literal("agentManager.worktreeSetup"),
+  status: z.enum(["creating", "starting", "ready", "error"]),
+  message: z.string(),
+  sessionId: z.string().optional(),
+  branch: z.string().optional(),
+  worktreeId: z.string().optional(),
+})
+
+export const agentManagerSessionAddedMessage = z.object({
+  type: z.literal("agentManager.sessionAdded"),
+  sessionId: z.string(),
+  worktreeId: z.string(),
+})
+
+export const agentManagerStateMessage = z.object({
+  type: z.literal("agentManager.state"),
+  worktrees: z.array(worktreeState),
+  sessions: z.array(managedSessionState),
+  staleWorktreeIds: z.array(z.string()).optional(),
+  tabOrder: z.record(z.string(), z.array(z.string())).optional(),
+  sessionsCollapsed: z.boolean().optional(),
+  reviewDiffStyle: z.enum(["unified", "split"]).optional(),
+  isGitRepo: z.boolean().optional(),
+  defaultBaseBranch: z.string().optional(),
+})
+
+export const agentManagerKeybindingsMessage = z.object({
+  type: z.literal("agentManager.keybindings"),
+  bindings: z.record(z.string(), z.string()),
+})
+
+export const agentManagerMultiVersionProgressMessage = z.object({
+  type: z.literal("agentManager.multiVersionProgress"),
+  status: z.enum(["creating", "done"]),
+  total: z.number(),
+  completed: z.number(),
+  groupId: z.string().optional(),
+})
+
+export const variantsLoadedMessage = z.object({
+  type: z.literal("variantsLoaded"),
+  variants: z.record(z.string(), z.string()),
+})
+
+export const agentManagerBranchesMessage = z.object({
+  type: z.literal("agentManager.branches"),
+  branches: z.array(branchInfo),
+  defaultBranch: z.string(),
+})
+
+export const agentManagerExternalWorktreesMessage = z.object({
+  type: z.literal("agentManager.externalWorktrees"),
+  worktrees: z.array(externalWorktreeInfo),
+})
+
+export const agentManagerImportResultMessage = z.object({
+  type: z.literal("agentManager.importResult"),
+  success: z.boolean(),
+  message: z.string(),
+})
+
+export const agentManagerWorktreeDiffMessage = z.object({
+  type: z.literal("agentManager.worktreeDiff"),
+  sessionId: z.string(),
+  diffs: z.array(worktreeFileDiff),
+})
+
+export const agentManagerWorktreeDiffLoadingMessage = z.object({
+  type: z.literal("agentManager.worktreeDiffLoading"),
+  sessionId: z.string(),
+  loading: z.boolean(),
+})
+
+export const agentManagerApplyWorktreeDiffResultMessage = z.object({
+  type: z.literal("agentManager.applyWorktreeDiffResult"),
+  worktreeId: z.string(),
+  status: applyWorktreeDiffStatus,
+  message: z.string(),
+  conflicts: z.array(applyWorktreeDiffConflict).optional(),
+})
+
+export const agentManagerWorktreeStatsMessage = z.object({
+  type: z.literal("agentManager.worktreeStats"),
+  stats: z.array(worktreeGitStats),
+})
+
+export const agentManagerLocalStatsMessage = z.object({
+  type: z.literal("agentManager.localStats"),
+  stats: localGitStats,
+})
+
+export const agentManagerSetSessionModelMessage = z.object({
+  type: z.literal("agentManager.setSessionModel"),
+  sessionId: z.string(),
+  providerID: z.string(),
+  modelID: z.string(),
+})
+
+export const agentManagerSendInitialMessage = z.object({
+  type: z.literal("agentManager.sendInitialMessage"),
+  sessionId: z.string(),
+  worktreeId: z.string(),
+  text: z.string().optional(),
+  providerID: z.string().optional(),
+  modelID: z.string().optional(),
+  agent: z.string().optional(),
+  files: z.array(z.object({ mime: z.string(), url: z.string() })).optional(),
+})
+
+// legacy-migration start
+export const legacyMigrationDataMessage = z.object({
+  type: z.literal("legacyMigrationData"),
+  data: z.object({
+    providers: z.array(migrationProviderInfo),
+    mcpServers: z.array(migrationMcpServerInfo),
+    customModes: z.array(migrationCustomModeInfo),
+    defaultModel: z.object({ provider: z.string(), model: z.string() }).optional(),
+    settings: legacySettings.optional(),
+  }),
+})
+
+export const legacyMigrationProgressMessage = z.object({
+  type: z.literal("legacyMigrationProgress"),
+  item: z.string(),
+  status: z.enum(["migrating", "success", "warning", "error"]),
+  message: z.string().optional(),
+})
+
+export const legacyMigrationCompleteMessage = z.object({
+  type: z.literal("legacyMigrationComplete"),
+  results: z.array(migrationResultItem),
+})
+// legacy-migration end
+
+export const enhancePromptResultMessage = z.object({
+  type: z.literal("enhancePromptResult"),
+  text: z.string(),
+  requestId: z.string(),
+})
+
+export const enhancePromptErrorMessage = z.object({
+  type: z.literal("enhancePromptError"),
+  error: z.string(),
+  requestId: z.string(),
+})
+
+export const viewSubAgentSessionMessage = z.object({
+  type: z.literal("viewSubAgentSession"),
+  sessionID: z.string(),
+})
+
+export const diffViewerDiffsMessage = z.object({
+  type: z.literal("diffViewer.diffs"),
+  diffs: z.array(worktreeFileDiff),
+})
+
+export const diffViewerLoadingMessage = z.object({
+  type: z.literal("diffViewer.loading"),
+  loading: z.boolean(),
+})
+
+// ============================================
+// Extension → Webview union
+// ============================================
+
+export const extensionMessage = z.discriminatedUnion("type", [
+  readyMessage,
+  connectionStateMessage,
+  errorMessage,
+  partUpdatedMessage,
+  sessionStatusMessage,
+  permissionRequestMessage,
+  permissionResolvedMessage,
+  permissionErrorMessage,
+  todoUpdatedMessage,
+  sessionCreatedMessage,
+  sessionUpdatedMessage,
+  sessionDeletedMessage,
+  messagesLoadedMessage,
+  messageCreatedMessage,
+  sessionsLoadedMessage,
+  cloudSessionsLoadedMessage,
+  gitRemoteUrlLoadedMessage,
+  actionMessage,
+  profileDataMessage,
+  deviceAuthStartedMessage,
+  deviceAuthCompleteMessage,
+  deviceAuthFailedMessage,
+  deviceAuthCancelledMessage,
+  navigateMessage,
+  providersLoadedMessage,
+  agentsLoadedMessage,
+  autocompleteSettingsLoadedMessage,
+  chatCompletionResultMessage,
+  fileSearchResultMessage,
+  questionRequestMessage,
+  questionResolvedMessage,
+  questionErrorMessage,
+  browserSettingsLoadedMessage,
+  configLoadedMessage,
+  configUpdatedMessage,
+  notificationSettingsLoadedMessage,
+  notificationsLoadedMessage,
+  agentManagerSessionMetaMessage,
+  agentManagerRepoInfoMessage,
+  agentManagerWorktreeSetupMessage,
+  agentManagerSessionAddedMessage,
+  agentManagerStateMessage,
+  agentManagerKeybindingsMessage,
+  agentManagerMultiVersionProgressMessage,
+  agentManagerSetSessionModelMessage,
+  agentManagerSendInitialMessage,
+  setChatBoxMessage,
+  appendChatBoxMessage,
+  appendReviewCommentsMessage,
+  triggerTaskMessage,
+  variantsLoadedMessage,
+  cloudSessionDataLoadedMessage,
+  cloudSessionImportedMessage,
+  cloudSessionImportFailedMessage,
+  openCloudSessionMessage,
+  agentManagerBranchesMessage,
+  agentManagerExternalWorktreesMessage,
+  agentManagerImportResultMessage,
+  workspaceDirectoryChangedMessage,
+  agentManagerWorktreeDiffMessage,
+  agentManagerWorktreeDiffLoadingMessage,
+  agentManagerApplyWorktreeDiffResultMessage,
+  agentManagerWorktreeStatsMessage,
+  agentManagerLocalStatsMessage,
+  // legacy-migration start
+  legacyMigrationDataMessage,
+  legacyMigrationProgressMessage,
+  legacyMigrationCompleteMessage,
+  // legacy-migration end
+  enhancePromptResultMessage,
+  enhancePromptErrorMessage,
+  viewSubAgentSessionMessage,
+  diffViewerDiffsMessage,
+  diffViewerLoadingMessage,
+])
+
+// ============================================
+// Messages FROM webview TO extension
+// ============================================
+
+export const sendMessageRequest = z.object({
+  type: z.literal("sendMessage"),
+  text: z.string(),
+  sessionID: z.string().optional(),
+  providerID: z.string().optional(),
+  modelID: z.string().optional(),
+  agent: z.string().optional(),
+  variant: z.string().optional(),
+  files: z.array(fileAttachment).optional(),
+})
+
+export const abortRequest = z.object({
+  type: z.literal("abort"),
+  sessionID: z.string(),
+})
+
+export const permissionResponseRequest = z.object({
+  type: z.literal("permissionResponse"),
+  permissionId: z.string(),
+  sessionID: z.string(),
+  response: z.enum(["once", "always", "reject"]),
+})
+
+export const createSessionRequest = z.object({ type: z.literal("createSession") })
+export const clearSessionRequest = z.object({ type: z.literal("clearSession") })
+
+export const loadMessagesRequest = z.object({
+  type: z.literal("loadMessages"),
+  sessionID: z.string(),
+})
+
+export const loadSessionsRequest = z.object({ type: z.literal("loadSessions") })
+
+export const requestCloudSessionsMessage = z.object({
+  type: z.literal("requestCloudSessions"),
+  cursor: z.string().optional(),
+  limit: z.number().optional(),
+  gitUrl: z.string().optional(),
+})
+
+export const requestGitRemoteUrlMessage = z.object({ type: z.literal("requestGitRemoteUrl") })
+
+export const requestCloudSessionDataMessage = z.object({
+  type: z.literal("requestCloudSessionData"),
+  sessionId: z.string(),
+})
+
+export const importAndSendMessage = z.object({
+  type: z.literal("importAndSend"),
+  cloudSessionId: z.string(),
+  text: z.string(),
+  providerID: z.string().optional(),
+  modelID: z.string().optional(),
+  agent: z.string().optional(),
+  variant: z.string().optional(),
+  files: z.array(fileAttachment).optional(),
+})
+
+export const loginRequest = z.object({ type: z.literal("login") })
+export const logoutRequest = z.object({ type: z.literal("logout") })
+export const refreshProfileRequest = z.object({ type: z.literal("refreshProfile") })
+
+export const openExternalRequest = z.object({
+  type: z.literal("openExternal"),
+  url: z.string(),
+})
+
+export const openFileRequest = z.object({
+  type: z.literal("openFile"),
+  filePath: z.string(),
+  line: z.number().optional(),
+  column: z.number().optional(),
+})
+
+export const cancelLoginRequest = z.object({ type: z.literal("cancelLogin") })
+
+export const setOrganizationRequest = z.object({
+  type: z.literal("setOrganization"),
+  organizationId: z.string().nullable(),
+})
+
+export const webviewReadyRequest = z.object({ type: z.literal("webviewReady") })
+
+export const requestProvidersMessage = z.object({ type: z.literal("requestProviders") })
+
+export const compactRequest = z.object({
+  type: z.literal("compact"),
+  sessionID: z.string(),
+  providerID: z.string().optional(),
+  modelID: z.string().optional(),
+})
+
+export const requestAgentsMessage = z.object({ type: z.literal("requestAgents") })
+
+export const setLanguageRequest = z.object({
+  type: z.literal("setLanguage"),
+  locale: z.string(),
+})
+
+export const questionReplyRequest = z.object({
+  type: z.literal("questionReply"),
+  requestID: z.string(),
+  answers: z.array(z.array(z.string())),
+})
+
+export const questionRejectRequest = z.object({
+  type: z.literal("questionReject"),
+  requestID: z.string(),
+})
+
+export const deleteSessionRequest = z.object({
+  type: z.literal("deleteSession"),
+  sessionID: z.string(),
+})
+
+export const renameSessionRequest = z.object({
+  type: z.literal("renameSession"),
+  sessionID: z.string(),
+  title: z.string(),
+})
+
+export const requestAutocompleteSettingsMessage = z.object({ type: z.literal("requestAutocompleteSettings") })
+
+export const updateAutocompleteSettingMessage = z.object({
+  type: z.literal("updateAutocompleteSetting"),
+  key: z.enum(["enableAutoTrigger", "enableSmartInlineTaskKeybinding", "enableChatAutocomplete"]),
+  value: z.boolean(),
+})
+
+export const requestChatCompletionMessage = z.object({
+  type: z.literal("requestChatCompletion"),
+  text: z.string(),
+  requestId: z.string(),
+})
+
+export const requestFileSearchMessage = z.object({
+  type: z.literal("requestFileSearch"),
+  query: z.string(),
+  requestId: z.string(),
+})
+
+export const chatCompletionAcceptedMessage = z.object({
+  type: z.literal("chatCompletionAccepted"),
+  suggestionLength: z.number().optional(),
+})
+
+export const updateSettingRequest = z.object({
+  type: z.literal("updateSetting"),
+  key: z.string(),
+  value: z.unknown(),
+})
+
+export const requestBrowserSettingsMessage = z.object({ type: z.literal("requestBrowserSettings") })
+export const requestConfigMessage = z.object({ type: z.literal("requestConfig") })
+
+export const updateConfigMessage = z.object({
+  type: z.literal("updateConfig"),
+  config: config.partial(),
+})
+
+export const requestNotificationSettingsMessage = z.object({ type: z.literal("requestNotificationSettings") })
+export const resetAllSettingsRequest = z.object({ type: z.literal("resetAllSettings") })
+export const requestNotificationsMessage = z.object({ type: z.literal("requestNotifications") })
+
+export const dismissNotificationMessage = z.object({
+  type: z.literal("dismissNotification"),
+  notificationId: z.string(),
+})
+
+export const syncSessionRequest = z.object({
+  type: z.literal("syncSession"),
+  sessionID: z.string(),
+})
+
+export const createWorktreeSessionRequest = z.object({
+  type: z.literal("agentManager.createWorktreeSession"),
+  text: z.string(),
+  providerID: z.string().optional(),
+  modelID: z.string().optional(),
+  agent: z.string().optional(),
+  files: z.array(fileAttachment).optional(),
+})
+
+export const telemetryRequest = z.object({
+  type: z.literal("telemetry"),
+  event: z.string(),
+  properties: recordStringUnknown.optional(),
+})
+
+export const createWorktreeRequest = z.object({
+  type: z.literal("agentManager.createWorktree"),
+  baseBranch: z.string().optional(),
+  branchName: z.string().optional(),
+})
+
+export const deleteWorktreeRequest = z.object({
+  type: z.literal("agentManager.deleteWorktree"),
+  worktreeId: z.string(),
+})
+
+export const removeStaleWorktreeRequest = z.object({
+  type: z.literal("agentManager.removeStaleWorktree"),
+  worktreeId: z.string(),
+})
+
+export const promoteSessionRequest = z.object({
+  type: z.literal("agentManager.promoteSession"),
+  sessionId: z.string(),
+})
+
+export const addSessionToWorktreeRequest = z.object({
+  type: z.literal("agentManager.addSessionToWorktree"),
+  worktreeId: z.string(),
+})
+
+export const closeSessionRequest = z.object({
+  type: z.literal("agentManager.closeSession"),
+  sessionId: z.string(),
+})
+
+export const renameWorktreeRequest = z.object({
+  type: z.literal("agentManager.renameWorktree"),
+  worktreeId: z.string(),
+  label: z.string(),
+})
+
+export const requestRepoInfoMessage = z.object({ type: z.literal("agentManager.requestRepoInfo") })
+export const requestStateMessage = z.object({ type: z.literal("agentManager.requestState") })
+export const configureSetupScriptRequest = z.object({ type: z.literal("agentManager.configureSetupScript") })
+
+export const showTerminalRequest = z.object({
+  type: z.literal("agentManager.showTerminal"),
+  sessionId: z.string(),
+})
+
+export const showLocalTerminalRequest = z.object({ type: z.literal("agentManager.showLocalTerminal") })
+
+export const openWorktreeRequest = z.object({
+  type: z.literal("agentManager.openWorktree"),
+  worktreeId: z.string(),
+})
+
+export const showExistingLocalTerminalRequest = z.object({ type: z.literal("agentManager.showExistingLocalTerminal") })
+
+export const agentManagerOpenFileRequest = z.object({
+  type: z.literal("agentManager.openFile"),
+  sessionId: z.string(),
+  filePath: z.string(),
+  line: z.number().optional(),
+  column: z.number().optional(),
+})
+
+export const createMultiVersionRequest = z.object({
+  type: z.literal("agentManager.createMultiVersion"),
+  text: z.string().optional(),
+  name: z.string().optional(),
+  versions: z.number(),
+  providerID: z.string().optional(),
+  modelID: z.string().optional(),
+  agent: z.string().optional(),
+  files: z.array(z.object({ mime: z.string(), url: z.string() })).optional(),
+  baseBranch: z.string().optional(),
+  branchName: z.string().optional(),
+  modelAllocations: z.array(modelAllocation).optional(),
+})
+
+export const setTabOrderRequest = z.object({
+  type: z.literal("agentManager.setTabOrder"),
+  key: z.string(),
+  order: z.array(z.string()),
+})
+
+export const setSessionsCollapsedRequest = z.object({
+  type: z.literal("agentManager.setSessionsCollapsed"),
+  collapsed: z.boolean(),
+})
+
+export const setReviewDiffStyleRequest = z.object({
+  type: z.literal("agentManager.setReviewDiffStyle"),
+  style: z.enum(["unified", "split"]),
+})
+
+export const requestBranchesMessage = z.object({ type: z.literal("agentManager.requestBranches") })
+export const requestExternalWorktreesMessage = z.object({ type: z.literal("agentManager.requestExternalWorktrees") })
+
+export const importFromBranchRequest = z.object({
+  type: z.literal("agentManager.importFromBranch"),
+  branch: z.string(),
+})
+
+export const importFromPRRequest = z.object({
+  type: z.literal("agentManager.importFromPR"),
+  url: z.string(),
+})
+
+export const importExternalWorktreeRequest = z.object({
+  type: z.literal("agentManager.importExternalWorktree"),
+  path: z.string(),
+  branch: z.string(),
+})
+
+export const importAllExternalWorktreesRequest = z.object({
+  type: z.literal("agentManager.importAllExternalWorktrees"),
+})
+
+export const requestWorktreeDiffMessage = z.object({
+  type: z.literal("agentManager.requestWorktreeDiff"),
+  sessionId: z.string(),
+})
+
+export const startDiffWatchMessage = z.object({
+  type: z.literal("agentManager.startDiffWatch"),
+  sessionId: z.string(),
+})
+
+export const stopDiffWatchMessage = z.object({ type: z.literal("agentManager.stopDiffWatch") })
+
+export const applyWorktreeDiffMessage = z.object({
+  type: z.literal("agentManager.applyWorktreeDiff"),
+  worktreeId: z.string(),
+  selectedFiles: z.array(z.string()).optional(),
+})
+
+export const persistVariantRequest = z.object({
+  type: z.literal("persistVariant"),
+  key: z.string(),
+  value: z.string(),
+})
+
+export const requestVariantsMessage = z.object({ type: z.literal("requestVariants") })
+
+export const enhancePromptRequest = z.object({
+  type: z.literal("enhancePrompt"),
+  text: z.string(),
+  requestId: z.string(),
+})
+
+export const openChangesRequest = z.object({ type: z.literal("openChanges") })
+
+export const openSubAgentViewerRequest = z.object({
+  type: z.literal("openSubAgentViewer"),
+  sessionID: z.string(),
+  title: z.string().optional(),
+})
+
+export const setDefaultBaseBranchRequest = z.object({
+  type: z.literal("agentManager.setDefaultBaseBranch"),
+  branch: z.string().optional(),
+})
+
+// legacy-migration start
+export const requestLegacyMigrationDataMessage = z.object({ type: z.literal("requestLegacyMigrationData") })
+
+export const startLegacyMigrationMessage = z.object({
+  type: z.literal("startLegacyMigration"),
+  selections: z.object({
+    providers: z.array(z.string()),
+    mcpServers: z.array(z.string()),
+    customModes: z.array(z.string()),
+    defaultModel: z.boolean(),
+    settings: z.object({
+      autoApproval: migrationAutoApprovalSelections,
+      language: z.boolean(),
+      autocomplete: z.boolean(),
+    }),
+  }),
+})
+
+export const skipLegacyMigrationMessage = z.object({ type: z.literal("skipLegacyMigration") })
+export const clearLegacyDataMessage = z.object({ type: z.literal("clearLegacyData") })
+// legacy-migration end
+
+// ============================================
+// Webview → Extension union
+// ============================================
+
+export const webviewMessage = z.discriminatedUnion("type", [
+  sendMessageRequest,
+  abortRequest,
+  permissionResponseRequest,
+  createSessionRequest,
+  clearSessionRequest,
+  loadMessagesRequest,
+  loadSessionsRequest,
+  requestCloudSessionsMessage,
+  requestGitRemoteUrlMessage,
+  loginRequest,
+  logoutRequest,
+  refreshProfileRequest,
+  openExternalRequest,
+  openFileRequest,
+  cancelLoginRequest,
+  setOrganizationRequest,
+  webviewReadyRequest,
+  requestProvidersMessage,
+  compactRequest,
+  requestAgentsMessage,
+  setLanguageRequest,
+  questionReplyRequest,
+  questionRejectRequest,
+  deleteSessionRequest,
+  renameSessionRequest,
+  requestAutocompleteSettingsMessage,
+  updateAutocompleteSettingMessage,
+  requestChatCompletionMessage,
+  requestFileSearchMessage,
+  chatCompletionAcceptedMessage,
+  updateSettingRequest,
+  requestBrowserSettingsMessage,
+  requestConfigMessage,
+  updateConfigMessage,
+  requestNotificationSettingsMessage,
+  resetAllSettingsRequest,
+  syncSessionRequest,
+  createWorktreeSessionRequest,
+  requestNotificationsMessage,
+  dismissNotificationMessage,
+  createWorktreeRequest,
+  deleteWorktreeRequest,
+  removeStaleWorktreeRequest,
+  promoteSessionRequest,
+  addSessionToWorktreeRequest,
+  closeSessionRequest,
+  renameWorktreeRequest,
+  telemetryRequest,
+  requestRepoInfoMessage,
+  requestStateMessage,
+  configureSetupScriptRequest,
+  showTerminalRequest,
+  showLocalTerminalRequest,
+  openWorktreeRequest,
+  showExistingLocalTerminalRequest,
+  agentManagerOpenFileRequest,
+  createMultiVersionRequest,
+  setTabOrderRequest,
+  setSessionsCollapsedRequest,
+  setReviewDiffStyleRequest,
+  persistVariantRequest,
+  requestVariantsMessage,
+  requestCloudSessionDataMessage,
+  importAndSendMessage,
+  requestBranchesMessage,
+  requestExternalWorktreesMessage,
+  importFromBranchRequest,
+  importFromPRRequest,
+  importExternalWorktreeRequest,
+  importAllExternalWorktreesRequest,
+  requestWorktreeDiffMessage,
+  startDiffWatchMessage,
+  stopDiffWatchMessage,
+  // legacy-migration start
+  requestLegacyMigrationDataMessage,
+  startLegacyMigrationMessage,
+  skipLegacyMigrationMessage,
+  clearLegacyDataMessage,
+  // legacy-migration end
+  applyWorktreeDiffMessage,
+  enhancePromptRequest,
+  openChangesRequest,
+  openSubAgentViewerRequest,
+  setDefaultBaseBranchRequest,
+])

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1,1383 +1,290 @@
 /**
- * Types for extension <-> webview message communication
+ * Types for extension <-> webview message communication.
+ * All types are derived from Zod schemas in message-schemas.ts.
+ * Zod validates/parses at the IO boundary (vscode.tsx) instead of casting.
  */
 
-// Connection states
-export type ConnectionState = "connecting" | "connected" | "disconnected" | "error"
+import { z } from "zod"
+import * as schemas from "./message-schemas"
 
-// Session status (simplified from backend)
-export type SessionStatus = "idle" | "busy" | "retry"
-
-// Rich status info for retry countdown and future extensions
-export type SessionStatusInfo =
-  | { type: "idle" }
-  | { type: "busy" }
-  | { type: "retry"; attempt: number; message: string; next: number }
-
-// Tool state for tool parts
-export type ToolState =
-  | { status: "pending"; input: Record<string, unknown> }
-  | { status: "running"; input: Record<string, unknown>; title?: string }
-  | { status: "completed"; input: Record<string, unknown>; output: string; title: string }
-  | { status: "error"; input: Record<string, unknown>; error: string }
-
-// Base part interface - all parts have these fields
-export interface BasePart {
-  id: string
-  sessionID?: string
-  messageID?: string
-}
-
-// Part types from the backend
-export interface TextPart extends BasePart {
-  type: "text"
-  text: string
-}
-
-export interface ToolPart extends BasePart {
-  type: "tool"
-  tool: string
-  state: ToolState
-}
-
-export interface ReasoningPart extends BasePart {
-  type: "reasoning"
-  text: string
-}
-
-// Step parts from the backend
-export interface StepStartPart extends BasePart {
-  type: "step-start"
-}
-
-export interface StepFinishPart extends BasePart {
-  type: "step-finish"
-  reason?: string
-  cost?: number
-  tokens?: {
-    input: number
-    output: number
-    reasoning?: number
-    cache?: { read: number; write: number }
-  }
-}
-
-export type Part = TextPart | ToolPart | ReasoningPart | StepStartPart | StepFinishPart
-
-// Part delta for streaming updates
-export interface PartDelta {
-  type: "text-delta"
-  textDelta?: string
-}
-
-// Token usage for assistant messages
-export interface TokenUsage {
-  input: number
-  output: number
-  reasoning?: number
-  cache?: { read: number; write: number }
-}
-
-// Context usage derived from the last assistant message's tokens
-export interface ContextUsage {
-  tokens: number
-  percentage: number | null
-}
-
-// Message structure (simplified for webview)
-export interface Message {
-  id: string
-  sessionID: string
-  role: "user" | "assistant"
-  content?: string
-  parts?: Part[]
-  createdAt: string
-  time?: { created: number; completed?: number }
-  agent?: string
-  model?: { providerID: string; modelID: string }
-  providerID?: string
-  modelID?: string
-  mode?: string
-  parentID?: string
-  path?: { cwd: string; root: string }
-  error?: { name: string; data?: Record<string, unknown> }
-  summary?: { title?: string; body?: string; diffs?: unknown[] } | boolean
-  cost?: number
-  tokens?: TokenUsage
-}
-
-// Session info (simplified for webview)
-export interface SessionInfo {
-  id: string
-  title?: string
-  createdAt: string
-  updatedAt: string
-}
-
-// Cloud session info (from Kilo cloud API)
-export interface CloudSessionInfo {
-  session_id: string
-  title: string | null
-  created_at: string
-  updated_at: string
-}
-
-// Permission request
-export interface PermissionRequest {
-  id: string
-  sessionID: string
-  toolName: string
-  patterns: string[]
-  args: Record<string, unknown>
-  message?: string
-  tool?: { messageID: string; callID: string }
-}
-
-// Todo item
-export interface TodoItem {
-  id: string
-  content: string
-  status: "pending" | "in_progress" | "completed"
-}
-
-// Question types
-export interface QuestionOption {
-  label: string
-  description: string
-}
-
-export interface QuestionInfo {
-  question: string
-  header: string
-  options: QuestionOption[]
-  multiple?: boolean
-  custom?: boolean
-}
-
-export interface QuestionRequest {
-  id: string
-  sessionID: string
-  questions: QuestionInfo[]
-  tool?: {
-    messageID: string
-    callID: string
-  }
-}
-
-// Agent/mode info from CLI backend
-export interface AgentInfo {
-  name: string
-  description?: string
-  mode: "subagent" | "primary" | "all"
-  native?: boolean
-  hidden?: boolean
-  color?: string
-}
-
-// Server info
-export interface ServerInfo {
-  port: number
-  version?: string
-}
-
-// Device auth flow status
-export type DeviceAuthStatus = "idle" | "initiating" | "pending" | "success" | "error" | "cancelled"
-
-// Device auth state
-export interface DeviceAuthState {
-  status: DeviceAuthStatus
-  code?: string
-  verificationUrl?: string
-  expiresIn?: number
-  error?: string
-}
-
-// Kilo notification types (mirrored from kilo-gateway)
-export interface KilocodeNotificationAction {
-  actionText: string
-  actionURL: string
-}
-
-export interface KilocodeNotification {
-  id: string
-  title: string
-  message: string
-  action?: KilocodeNotificationAction
-  showIn?: string[]
-}
-
-// Profile types from kilo-gateway
-export interface KilocodeBalance {
-  balance: number
-}
-
-export interface ProfileData {
-  profile: {
-    email: string
-    name?: string
-    organizations?: Array<{ id: string; name: string; role: string }>
-  }
-  balance: KilocodeBalance | null
-  currentOrgId: string | null
-}
-
-// Provider/model types for model selector
-
-export interface ProviderModel {
-  id: string
-  name: string
-  inputPrice?: number
-  outputPrice?: number
-  contextLength?: number
-  releaseDate?: string
-  latest?: boolean
-  // Actual shape returned by the server (Provider.Model)
-  limit?: { context: number; input?: number; output: number }
-  variants?: Record<string, Record<string, unknown>>
-  capabilities?: { reasoning: boolean }
-}
-
-export interface Provider {
-  id: string
-  name: string
-  models: Record<string, ProviderModel>
-}
-
-export interface ModelSelection {
-  providerID: string
-  modelID: string
-}
+// Re-export schemas for use at the IO boundary
+export { extensionMessage as extensionMessageSchema, webviewMessage as webviewMessageSchema } from "./message-schemas"
 
 // ============================================
-// Backend Config Types (mirrored for webview)
+// Shared types
 // ============================================
 
-export type PermissionLevel = "allow" | "ask" | "deny"
+export type ConnectionState = z.infer<typeof schemas.connectionState>
+export type SessionStatus = z.infer<typeof schemas.sessionStatus>
+export type SessionStatusInfo = z.infer<typeof schemas.sessionStatusInfo>
+export type ToolState = z.infer<typeof schemas.toolState>
 
-export type PermissionRule = PermissionLevel | Record<string, PermissionLevel>
+// ============================================
+// Part types
+// ============================================
 
-export type PermissionConfig = Partial<Record<string, PermissionRule>>
+export type BasePart =
+  | z.infer<typeof schemas.textPart>
+  | z.infer<typeof schemas.toolPart>
+  | z.infer<typeof schemas.reasoningPart>
+  | z.infer<typeof schemas.stepStartPart>
+  | z.infer<typeof schemas.stepFinishPart>
+export type TextPart = z.infer<typeof schemas.textPart>
+export type ToolPart = z.infer<typeof schemas.toolPart>
+export type ReasoningPart = z.infer<typeof schemas.reasoningPart>
+export type StepStartPart = z.infer<typeof schemas.stepStartPart>
+export type StepFinishPart = z.infer<typeof schemas.stepFinishPart>
+export type Part = z.infer<typeof schemas.part>
+export type PartDelta = z.infer<typeof schemas.partDelta>
 
-export interface AgentConfig {
-  model?: string | null
-  prompt?: string
-  temperature?: number
-  top_p?: number
-  steps?: number
-  permission?: PermissionConfig
-}
+// ============================================
+// Token / context usage
+// ============================================
 
-export interface ProviderConfig {
-  name?: string
-  api_key?: string
-  base_url?: string
-  models?: Record<string, unknown>
-}
+export type TokenUsage = z.infer<typeof schemas.tokenUsage>
+export type ContextUsage = z.infer<typeof schemas.contextUsage>
 
-export interface McpConfig {
-  command?: string
-  args?: string[]
-  env?: Record<string, string>
-  url?: string
-  headers?: Record<string, string>
-}
+// ============================================
+// Message / Session
+// ============================================
 
-export interface CommandConfig {
-  command: string
-  description?: string
-}
+export type Message = z.infer<typeof schemas.message>
+export type SessionInfo = z.infer<typeof schemas.sessionInfo>
+export type CloudSessionInfo = z.infer<typeof schemas.cloudSessionInfo>
 
-export interface SkillsConfig {
-  paths?: string[]
-  urls?: string[]
-}
+// ============================================
+// Permission / Todo / Question
+// ============================================
 
-export interface CompactionConfig {
-  auto?: boolean
-  prune?: boolean
-}
+export type PermissionRequest = z.infer<typeof schemas.permissionRequest>
+export type TodoItem = z.infer<typeof schemas.todoItem>
+export type QuestionOption = z.infer<typeof schemas.questionOption>
+export type QuestionInfo = z.infer<typeof schemas.questionInfo>
+export type QuestionRequest = z.infer<typeof schemas.questionRequest>
 
-export interface WatcherConfig {
-  ignore?: string[]
-}
+// ============================================
+// Agent / Server / Auth
+// ============================================
 
-export interface ExperimentalConfig {
-  disable_paste_summary?: boolean
-  batch_tool?: boolean
-  primary_tools?: string[]
-  continue_loop_on_deny?: boolean
-  mcp_timeout?: number
-}
+export type AgentInfo = z.infer<typeof schemas.agentInfo>
+export type ServerInfo = z.infer<typeof schemas.serverInfo>
+export type DeviceAuthStatus = z.infer<typeof schemas.deviceAuthStatus>
+export type DeviceAuthState = z.infer<typeof schemas.deviceAuthState>
 
-export interface Config {
-  permission?: PermissionConfig
-  model?: string | null
-  small_model?: string | null
-  default_agent?: string
-  agent?: Record<string, AgentConfig>
-  provider?: Record<string, ProviderConfig>
-  disabled_providers?: string[]
-  enabled_providers?: string[]
-  mcp?: Record<string, McpConfig>
-  command?: Record<string, CommandConfig>
-  instructions?: string[]
-  skills?: SkillsConfig
-  snapshot?: boolean
-  share?: "manual" | "auto" | "disabled"
-  username?: string
-  watcher?: WatcherConfig
-  formatter?: false | Record<string, unknown>
-  lsp?: false | Record<string, unknown>
-  compaction?: CompactionConfig
-  tools?: Record<string, boolean>
-  layout?: "auto" | "stretch"
-  experimental?: ExperimentalConfig
-}
+// ============================================
+// Notifications
+// ============================================
+
+export type KilocodeNotificationAction = z.infer<typeof schemas.kilocodeNotificationAction>
+export type KilocodeNotification = z.infer<typeof schemas.kilocodeNotification>
+
+// ============================================
+// Profile
+// ============================================
+
+export type KilocodeBalance = z.infer<typeof schemas.kilocodeBalance>
+export type ProfileData = z.infer<typeof schemas.profileData>
+
+// ============================================
+// Provider / Model
+// ============================================
+
+export type ProviderModel = z.infer<typeof schemas.providerModel>
+export type Provider = z.infer<typeof schemas.provider>
+export type ModelSelection = z.infer<typeof schemas.modelSelection>
+
+// ============================================
+// Config types
+// ============================================
+
+export type PermissionLevel = z.infer<typeof schemas.permissionLevel>
+export type PermissionRule = z.infer<typeof schemas.permissionRule>
+export type PermissionConfig = z.infer<typeof schemas.permissionConfig>
+export type AgentConfig = z.infer<typeof schemas.agentConfig>
+export type ProviderConfig = z.infer<typeof schemas.providerConfig>
+export type McpConfig = z.infer<typeof schemas.mcpConfig>
+export type CommandConfig = z.infer<typeof schemas.commandConfig>
+export type SkillsConfig = z.infer<typeof schemas.skillsConfig>
+export type CompactionConfig = z.infer<typeof schemas.compactionConfig>
+export type WatcherConfig = z.infer<typeof schemas.watcherConfig>
+export type ExperimentalConfig = z.infer<typeof schemas.experimentalConfig>
+export type Config = z.infer<typeof schemas.config>
+
+// ============================================
+// Review / Browser / Agent Manager types
+// ============================================
+
+export type ReviewComment = z.infer<typeof schemas.reviewComment>
+export type BrowserSettings = z.infer<typeof schemas.browserSettings>
+export type WorktreeState = z.infer<typeof schemas.worktreeState>
+export type ManagedSessionState = z.infer<typeof schemas.managedSessionState>
+export type WorktreeFileDiff = z.infer<typeof schemas.worktreeFileDiff>
+export type AgentManagerApplyWorktreeDiffStatus = z.infer<typeof schemas.applyWorktreeDiffStatus>
+export type AgentManagerApplyWorktreeDiffConflict = z.infer<typeof schemas.applyWorktreeDiffConflict>
+export type WorktreeGitStats = z.infer<typeof schemas.worktreeGitStats>
+export type LocalGitStats = z.infer<typeof schemas.localGitStats>
+export type BranchInfo = z.infer<typeof schemas.branchInfo>
+export type ExternalWorktreeInfo = z.infer<typeof schemas.externalWorktreeInfo>
+export type FileAttachment = z.infer<typeof schemas.fileAttachment>
+export type ModelAllocation = z.infer<typeof schemas.modelAllocation>
+
+// ============================================
+// Legacy migration types
+// ============================================
+
+export type MigrationProviderInfo = z.infer<typeof schemas.migrationProviderInfo>
+export type MigrationMcpServerInfo = z.infer<typeof schemas.migrationMcpServerInfo>
+export type MigrationCustomModeInfo = z.infer<typeof schemas.migrationCustomModeInfo>
+export type LegacyAutocompleteSettings = z.infer<typeof schemas.legacyAutocompleteSettings>
+export type LegacySettings = z.infer<typeof schemas.legacySettings>
+export type MigrationResultItem = z.infer<typeof schemas.migrationResultItem>
+export type MigrationAutoApprovalSelections = z.infer<typeof schemas.migrationAutoApprovalSelections>
 
 // ============================================
 // Messages FROM extension TO webview
 // ============================================
 
-export interface ReadyMessage {
-  type: "ready"
-  serverInfo?: ServerInfo
-  extensionVersion?: string
-  vscodeLanguage?: string
-  languageOverride?: string
-  workspaceDirectory?: string
-}
-
-export interface WorkspaceDirectoryChangedMessage {
-  type: "workspaceDirectoryChanged"
-  directory: string
-}
-
-export interface ConnectionStateMessage {
-  type: "connectionState"
-  state: ConnectionState
-  error?: string
-}
-
-export interface ErrorMessage {
-  type: "error"
-  message: string
-  code?: string
-  sessionID?: string
-}
-
-export interface PartUpdatedMessage {
-  type: "partUpdated"
-  sessionID?: string
-  messageID?: string
-  part: Part
-  delta?: PartDelta
-}
-
-export interface SessionStatusMessage {
-  type: "sessionStatus"
-  sessionID: string
-  status: SessionStatus
-  // Retry fields (present when status === "retry")
-  attempt?: number
-  message?: string
-  next?: number
-}
-
-export interface PermissionRequestMessage {
-  type: "permissionRequest"
-  permission: PermissionRequest
-}
-
-export interface PermissionResolvedMessage {
-  type: "permissionResolved"
-  permissionID: string
-}
-
-export interface PermissionErrorMessage {
-  type: "permissionError"
-  permissionID: string
-}
-
-export interface TodoUpdatedMessage {
-  type: "todoUpdated"
-  sessionID: string
-  items: TodoItem[]
-}
-
-export interface SessionCreatedMessage {
-  type: "sessionCreated"
-  session: SessionInfo
-}
-
-export interface SessionUpdatedMessage {
-  type: "sessionUpdated"
-  session: SessionInfo
-}
-
-export interface SessionDeletedMessage {
-  type: "sessionDeleted"
-  sessionID: string
-}
-
-export interface MessagesLoadedMessage {
-  type: "messagesLoaded"
-  sessionID: string
-  messages: Message[]
-}
-
-export interface MessageCreatedMessage {
-  type: "messageCreated"
-  message: Message
-}
-
-export interface SessionsLoadedMessage {
-  type: "sessionsLoaded"
-  sessions: SessionInfo[]
-}
-
-export interface CloudSessionsLoadedMessage {
-  type: "cloudSessionsLoaded"
-  sessions: CloudSessionInfo[]
-  nextCursor: string | null
-}
-
-export interface GitRemoteUrlLoadedMessage {
-  type: "gitRemoteUrlLoaded"
-  gitUrl: string | null
-}
-
-export interface CloudSessionDataLoadedMessage {
-  type: "cloudSessionDataLoaded"
-  cloudSessionId: string
-  title: string
-  messages: Message[]
-}
-
-export interface CloudSessionImportedMessage {
-  type: "cloudSessionImported"
-  cloudSessionId: string
-  session: SessionInfo
-}
-
-export interface CloudSessionImportFailedMessage {
-  type: "cloudSessionImportFailed"
-  cloudSessionId: string
-  error: string
-}
-
-export interface OpenCloudSessionMessage {
-  type: "openCloudSession"
-  sessionId: string
-}
-
-export interface ActionMessage {
-  type: "action"
-  action: string
-}
-
-export interface SetChatBoxMessage {
-  type: "setChatBoxMessage"
-  text: string
-}
-
-export interface AppendChatBoxMessage {
-  type: "appendChatBoxMessage"
-  text: string
-}
-
-export interface ReviewComment {
-  id: string
-  file: string
-  side: "additions" | "deletions"
-  line: number
-  comment: string
-  selectedText: string
-}
-
-export interface AppendReviewCommentsMessage {
-  type: "appendReviewComments"
-  comments: ReviewComment[]
-}
-
-export interface TriggerTaskMessage {
-  type: "triggerTask"
-  text: string
-}
-
-export interface ProfileDataMessage {
-  type: "profileData"
-  data: ProfileData | null
-}
-
-export interface DeviceAuthStartedMessage {
-  type: "deviceAuthStarted"
-  code?: string
-  verificationUrl: string
-  expiresIn: number
-}
-
-export interface DeviceAuthCompleteMessage {
-  type: "deviceAuthComplete"
-}
-
-export interface DeviceAuthFailedMessage {
-  type: "deviceAuthFailed"
-  error: string
-}
-
-export interface DeviceAuthCancelledMessage {
-  type: "deviceAuthCancelled"
-}
-
-export interface NavigateMessage {
-  type: "navigate"
-  view: "newTask" | "marketplace" | "history" | "cloudHistory" | "profile" | "settings" | "migration" | "subAgentViewer" // legacy-migration: "migration"
-}
-
-export interface ProvidersLoadedMessage {
-  type: "providersLoaded"
-  providers: Record<string, Provider>
-  connected: string[]
-  defaults: Record<string, string>
-  defaultSelection: ModelSelection
-}
-
-export interface AgentsLoadedMessage {
-  type: "agentsLoaded"
-  agents: AgentInfo[]
-  defaultAgent: string
-}
-
-export interface AutocompleteSettingsLoadedMessage {
-  type: "autocompleteSettingsLoaded"
-  settings: {
-    enableAutoTrigger: boolean
-    enableSmartInlineTaskKeybinding: boolean
-    enableChatAutocomplete: boolean
-  }
-}
-
-export interface ChatCompletionResultMessage {
-  type: "chatCompletionResult"
-  text: string
-  requestId: string
-}
-
-export interface FileSearchResultMessage {
-  type: "fileSearchResult"
-  paths: string[]
-  dir: string
-  requestId: string
-}
-
-export interface QuestionRequestMessage {
-  type: "questionRequest"
-  question: QuestionRequest
-}
-
-export interface QuestionResolvedMessage {
-  type: "questionResolved"
-  requestID: string
-}
-
-export interface QuestionErrorMessage {
-  type: "questionError"
-  requestID: string
-}
-
-export interface BrowserSettings {
-  enabled: boolean
-  useSystemChrome: boolean
-  headless: boolean
-}
-
-export interface BrowserSettingsLoadedMessage {
-  type: "browserSettingsLoaded"
-  settings: BrowserSettings
-}
-
-export interface ConfigLoadedMessage {
-  type: "configLoaded"
-  config: Config
-}
-
-export interface ConfigUpdatedMessage {
-  type: "configUpdated"
-  config: Config
-}
-
-export interface NotificationSettingsLoadedMessage {
-  type: "notificationSettingsLoaded"
-  settings: {
-    notifyAgent: boolean
-    notifyPermissions: boolean
-    notifyErrors: boolean
-    soundAgent: string
-    soundPermissions: string
-    soundErrors: string
-  }
-}
-
-export interface NotificationsLoadedMessage {
-  type: "notificationsLoaded"
-  notifications: KilocodeNotification[]
-  dismissedIds: string[]
-}
-
-// Agent Manager worktree session metadata
-export interface AgentManagerSessionMetaMessage {
-  type: "agentManager.sessionMeta"
-  sessionId: string
-  mode: import("../context/worktree-mode").SessionMode
-  branch?: string
-  path?: string
-  parentBranch?: string
-}
-
-// Agent Manager repo info (current branch of the main workspace)
-export interface AgentManagerRepoInfoMessage {
-  type: "agentManager.repoInfo"
-  branch: string
-  defaultBranch?: string
-}
-
-// Agent Manager worktree setup progress
-export interface AgentManagerWorktreeSetupMessage {
-  type: "agentManager.worktreeSetup"
-  status: "creating" | "starting" | "ready" | "error"
-  message: string
-  sessionId?: string
-  branch?: string
-  worktreeId?: string
-}
-
-// Agent Manager worktree state types (mirrored from WorktreeStateManager)
-export interface WorktreeState {
-  id: string
-  branch: string
-  path: string
-  /** Bare branch name (e.g. "main"), without remote prefix. */
-  parentBranch: string
-  /** Remote name (e.g. "origin"). */
-  remote?: string
-  createdAt: string
-  /** Shared identifier for worktrees created together via multi-version mode. */
-  groupId?: string
-  /** User-provided display name for the worktree. */
-  label?: string
-}
-
-export interface ManagedSessionState {
-  id: string
-  worktreeId: string | null
-  createdAt: string
-}
-
-// Agent Manager session added to an existing worktree (no setup overlay needed)
-export interface AgentManagerSessionAddedMessage {
-  type: "agentManager.sessionAdded"
-  sessionId: string
-  worktreeId: string
-}
-
-// Full state push from extension to webview
-export interface AgentManagerStateMessage {
-  type: "agentManager.state"
-  worktrees: WorktreeState[]
-  sessions: ManagedSessionState[]
-  staleWorktreeIds?: string[]
-  tabOrder?: Record<string, string[]>
-  sessionsCollapsed?: boolean
-  reviewDiffStyle?: "unified" | "split"
-  isGitRepo?: boolean
-  defaultBaseBranch?: string
-}
-
-// Resolved keybindings for agent manager actions
-export interface AgentManagerKeybindingsMessage {
-  type: "agentManager.keybindings"
-  bindings: Record<string, string>
-}
-
-// Multi-version creation progress (extension → webview)
-export interface AgentManagerMultiVersionProgressMessage {
-  type: "agentManager.multiVersionProgress"
-  status: "creating" | "done"
-  total: number
-  completed: number
-  groupId?: string
-}
-
-// Stored variant selections loaded from extension globalState (extension → webview)
-export interface VariantsLoadedMessage {
-  type: "variantsLoaded"
-  variants: Record<string, string>
-}
-
-export interface BranchInfo {
-  name: string
-  isLocal: boolean
-  isRemote: boolean
-  isDefault: boolean
-  lastCommitDate?: string
-  isCheckedOut?: boolean
-}
-
-export interface AgentManagerBranchesMessage {
-  type: "agentManager.branches"
-  branches: BranchInfo[]
-  defaultBranch: string
-}
-
-// Agent Manager Import tab: external worktrees (extension → webview)
-export interface ExternalWorktreeInfo {
-  path: string
-  branch: string
-}
-
-export interface AgentManagerExternalWorktreesMessage {
-  type: "agentManager.externalWorktrees"
-  worktrees: ExternalWorktreeInfo[]
-}
-
-// Agent Manager Import tab: result feedback (extension → webview)
-export interface AgentManagerImportResultMessage {
-  type: "agentManager.importResult"
-  success: boolean
-  message: string
-}
-
-// Shared FileDiff shape (matches Snapshot.FileDiff from CLI backend)
-export interface WorktreeFileDiff {
-  file: string
-  before: string
-  after: string
-  additions: number
-  deletions: number
-  status?: "added" | "deleted" | "modified"
-}
-
-// Agent Manager: Diff data push (extension → webview)
-export interface AgentManagerWorktreeDiffMessage {
-  type: "agentManager.worktreeDiff"
-  sessionId: string
-  diffs: WorktreeFileDiff[]
-}
-
-// Agent Manager: Diff loading state (extension → webview)
-export interface AgentManagerWorktreeDiffLoadingMessage {
-  type: "agentManager.worktreeDiffLoading"
-  sessionId: string
-  loading: boolean
-}
-
-export type AgentManagerApplyWorktreeDiffStatus = "checking" | "applying" | "success" | "conflict" | "error"
-
-export interface AgentManagerApplyWorktreeDiffConflict {
-  file?: string
-  reason: string
-}
-
-export interface AgentManagerApplyWorktreeDiffResultMessage {
-  type: "agentManager.applyWorktreeDiffResult"
-  worktreeId: string
-  status: AgentManagerApplyWorktreeDiffStatus
-  message: string
-  conflicts?: AgentManagerApplyWorktreeDiffConflict[]
-}
-
-// Per-worktree git stats: diff additions/deletions and ahead/behind counts
-export interface WorktreeGitStats {
-  worktreeId: string
-  files: number
-  additions: number
-  deletions: number
-  ahead: number
-  behind: number
-}
-
-// Agent Manager: Worktree git stats push (extension → webview)
-export interface AgentManagerWorktreeStatsMessage {
-  type: "agentManager.worktreeStats"
-  stats: WorktreeGitStats[]
-}
-
-// Per-local-workspace git stats: branch name, diff additions/deletions, ahead/behind counts
-export interface LocalGitStats {
-  branch: string
-  files: number
-  additions: number
-  deletions: number
-  ahead: number
-  behind: number
-}
-
-// Agent Manager: Local workspace git stats push (extension → webview)
-export interface AgentManagerLocalStatsMessage {
-  type: "agentManager.localStats"
-  stats: LocalGitStats
-}
-
-// Set the model for a session (extension → webview, used during multi-version creation)
-export interface AgentManagerSetSessionModelMessage {
-  type: "agentManager.setSessionModel"
-  sessionId: string
-  providerID: string
-  modelID: string
-}
-
-// Request webview to send initial prompt to a newly created session (extension → webview)
-export interface AgentManagerSendInitialMessage {
-  type: "agentManager.sendInitialMessage"
-  sessionId: string
-  worktreeId: string
-  text?: string
-  providerID?: string
-  modelID?: string
-  agent?: string
-  files?: Array<{ mime: string; url: string }>
-}
-
+export type ReadyMessage = z.infer<typeof schemas.readyMessage>
+export type WorkspaceDirectoryChangedMessage = z.infer<typeof schemas.workspaceDirectoryChangedMessage>
+export type ConnectionStateMessage = z.infer<typeof schemas.connectionStateMessage>
+export type ErrorMessage = z.infer<typeof schemas.errorMessage>
+export type PartUpdatedMessage = z.infer<typeof schemas.partUpdatedMessage>
+export type SessionStatusMessage = z.infer<typeof schemas.sessionStatusMessage>
+export type PermissionRequestMessage = z.infer<typeof schemas.permissionRequestMessage>
+export type PermissionResolvedMessage = z.infer<typeof schemas.permissionResolvedMessage>
+export type PermissionErrorMessage = z.infer<typeof schemas.permissionErrorMessage>
+export type TodoUpdatedMessage = z.infer<typeof schemas.todoUpdatedMessage>
+export type SessionCreatedMessage = z.infer<typeof schemas.sessionCreatedMessage>
+export type SessionUpdatedMessage = z.infer<typeof schemas.sessionUpdatedMessage>
+export type SessionDeletedMessage = z.infer<typeof schemas.sessionDeletedMessage>
+export type MessagesLoadedMessage = z.infer<typeof schemas.messagesLoadedMessage>
+export type MessageCreatedMessage = z.infer<typeof schemas.messageCreatedMessage>
+export type SessionsLoadedMessage = z.infer<typeof schemas.sessionsLoadedMessage>
+export type CloudSessionsLoadedMessage = z.infer<typeof schemas.cloudSessionsLoadedMessage>
+export type GitRemoteUrlLoadedMessage = z.infer<typeof schemas.gitRemoteUrlLoadedMessage>
+export type CloudSessionDataLoadedMessage = z.infer<typeof schemas.cloudSessionDataLoadedMessage>
+export type CloudSessionImportedMessage = z.infer<typeof schemas.cloudSessionImportedMessage>
+export type CloudSessionImportFailedMessage = z.infer<typeof schemas.cloudSessionImportFailedMessage>
+export type OpenCloudSessionMessage = z.infer<typeof schemas.openCloudSessionMessage>
+export type ActionMessage = z.infer<typeof schemas.actionMessage>
+export type SetChatBoxMessage = z.infer<typeof schemas.setChatBoxMessage>
+export type AppendChatBoxMessage = z.infer<typeof schemas.appendChatBoxMessage>
+export type AppendReviewCommentsMessage = z.infer<typeof schemas.appendReviewCommentsMessage>
+export type TriggerTaskMessage = z.infer<typeof schemas.triggerTaskMessage>
+export type ProfileDataMessage = z.infer<typeof schemas.profileDataMessage>
+export type DeviceAuthStartedMessage = z.infer<typeof schemas.deviceAuthStartedMessage>
+export type DeviceAuthCompleteMessage = z.infer<typeof schemas.deviceAuthCompleteMessage>
+export type DeviceAuthFailedMessage = z.infer<typeof schemas.deviceAuthFailedMessage>
+export type DeviceAuthCancelledMessage = z.infer<typeof schemas.deviceAuthCancelledMessage>
+export type NavigateMessage = z.infer<typeof schemas.navigateMessage>
+export type ProvidersLoadedMessage = z.infer<typeof schemas.providersLoadedMessage>
+export type AgentsLoadedMessage = z.infer<typeof schemas.agentsLoadedMessage>
+export type AutocompleteSettingsLoadedMessage = z.infer<typeof schemas.autocompleteSettingsLoadedMessage>
+export type ChatCompletionResultMessage = z.infer<typeof schemas.chatCompletionResultMessage>
+export type FileSearchResultMessage = z.infer<typeof schemas.fileSearchResultMessage>
+export type QuestionRequestMessage = z.infer<typeof schemas.questionRequestMessage>
+export type QuestionResolvedMessage = z.infer<typeof schemas.questionResolvedMessage>
+export type QuestionErrorMessage = z.infer<typeof schemas.questionErrorMessage>
+export type BrowserSettingsLoadedMessage = z.infer<typeof schemas.browserSettingsLoadedMessage>
+export type ConfigLoadedMessage = z.infer<typeof schemas.configLoadedMessage>
+export type ConfigUpdatedMessage = z.infer<typeof schemas.configUpdatedMessage>
+export type NotificationSettingsLoadedMessage = z.infer<typeof schemas.notificationSettingsLoadedMessage>
+export type NotificationsLoadedMessage = z.infer<typeof schemas.notificationsLoadedMessage>
+export type AgentManagerSessionMetaMessage = z.infer<typeof schemas.agentManagerSessionMetaMessage>
+export type AgentManagerRepoInfoMessage = z.infer<typeof schemas.agentManagerRepoInfoMessage>
+export type AgentManagerWorktreeSetupMessage = z.infer<typeof schemas.agentManagerWorktreeSetupMessage>
+export type AgentManagerSessionAddedMessage = z.infer<typeof schemas.agentManagerSessionAddedMessage>
+export type AgentManagerStateMessage = z.infer<typeof schemas.agentManagerStateMessage>
+export type AgentManagerKeybindingsMessage = z.infer<typeof schemas.agentManagerKeybindingsMessage>
+export type AgentManagerMultiVersionProgressMessage = z.infer<typeof schemas.agentManagerMultiVersionProgressMessage>
+export type VariantsLoadedMessage = z.infer<typeof schemas.variantsLoadedMessage>
+export type AgentManagerBranchesMessage = z.infer<typeof schemas.agentManagerBranchesMessage>
+export type AgentManagerExternalWorktreesMessage = z.infer<typeof schemas.agentManagerExternalWorktreesMessage>
+export type AgentManagerImportResultMessage = z.infer<typeof schemas.agentManagerImportResultMessage>
+export type AgentManagerWorktreeDiffMessage = z.infer<typeof schemas.agentManagerWorktreeDiffMessage>
+export type AgentManagerWorktreeDiffLoadingMessage = z.infer<typeof schemas.agentManagerWorktreeDiffLoadingMessage>
+export type AgentManagerApplyWorktreeDiffResultMessage = z.infer<
+  typeof schemas.agentManagerApplyWorktreeDiffResultMessage
+>
+export type AgentManagerWorktreeStatsMessage = z.infer<typeof schemas.agentManagerWorktreeStatsMessage>
+export type AgentManagerLocalStatsMessage = z.infer<typeof schemas.agentManagerLocalStatsMessage>
+export type AgentManagerSetSessionModelMessage = z.infer<typeof schemas.agentManagerSetSessionModelMessage>
+export type AgentManagerSendInitialMessage = z.infer<typeof schemas.agentManagerSendInitialMessage>
 // legacy-migration start
-export interface MigrationProviderInfo {
-  profileName: string
-  provider: string
-  model?: string
-  hasApiKey: boolean
-  supported: boolean
-  newProviderName?: string
-}
-
-export interface MigrationMcpServerInfo {
-  name: string
-  type: string
-}
-
-export interface MigrationCustomModeInfo {
-  name: string
-  slug: string
-}
-
-export interface LegacyAutocompleteSettings {
-  enableAutoTrigger?: boolean
-  enableSmartInlineTaskKeybinding?: boolean
-  enableChatAutocomplete?: boolean
-}
-
-export interface LegacySettings {
-  autoApprovalEnabled?: boolean
-  allowedCommands?: string[]
-  deniedCommands?: string[]
-  // Fine-grained auto-approval (legacy globalState keys — no prefix)
-  alwaysAllowReadOnly?: boolean
-  alwaysAllowReadOnlyOutsideWorkspace?: boolean
-  alwaysAllowWrite?: boolean
-  alwaysAllowExecute?: boolean
-  alwaysAllowMcp?: boolean
-  alwaysAllowModeSwitch?: boolean
-  alwaysAllowSubtasks?: boolean
-  language?: string
-  autocomplete?: LegacyAutocompleteSettings
-}
-
-export interface MigrationResultItem {
-  item: string
-  category: "provider" | "mcpServer" | "customMode" | "defaultModel" | "settings"
-  status: "success" | "warning" | "error"
-  message?: string
-}
-
-export interface LegacyMigrationDataMessage {
-  type: "legacyMigrationData"
-  data: {
-    providers: MigrationProviderInfo[]
-    mcpServers: MigrationMcpServerInfo[]
-    customModes: MigrationCustomModeInfo[]
-    defaultModel?: { provider: string; model: string }
-    settings?: LegacySettings
-  }
-}
-
-export interface LegacyMigrationProgressMessage {
-  type: "legacyMigrationProgress"
-  item: string
-  status: "migrating" | "success" | "warning" | "error"
-  message?: string
-}
-
-export interface LegacyMigrationCompleteMessage {
-  type: "legacyMigrationComplete"
-  results: MigrationResultItem[]
-}
-
-export interface RequestLegacyMigrationDataMessage {
-  type: "requestLegacyMigrationData"
-}
-
-export interface MigrationAutoApprovalSelections {
-  commandRules: boolean
-  readPermission: boolean
-  writePermission: boolean
-  executePermission: boolean
-  mcpPermission: boolean
-  taskPermission: boolean
-}
-
-export interface StartLegacyMigrationMessage {
-  type: "startLegacyMigration"
-  selections: {
-    providers: string[]
-    mcpServers: string[]
-    customModes: string[]
-    defaultModel: boolean
-    settings: {
-      autoApproval: MigrationAutoApprovalSelections
-      language: boolean
-      autocomplete: boolean
-    }
-  }
-}
-
-export interface SkipLegacyMigrationMessage {
-  type: "skipLegacyMigration"
-}
-
-export interface ClearLegacyDataMessage {
-  type: "clearLegacyData"
-}
+export type LegacyMigrationDataMessage = z.infer<typeof schemas.legacyMigrationDataMessage>
+export type LegacyMigrationProgressMessage = z.infer<typeof schemas.legacyMigrationProgressMessage>
+export type LegacyMigrationCompleteMessage = z.infer<typeof schemas.legacyMigrationCompleteMessage>
 // legacy-migration end
+export type EnhancePromptResultMessage = z.infer<typeof schemas.enhancePromptResultMessage>
+export type EnhancePromptErrorMessage = z.infer<typeof schemas.enhancePromptErrorMessage>
+export type ViewSubAgentSessionMessage = z.infer<typeof schemas.viewSubAgentSessionMessage>
+export type DiffViewerDiffsMessage = z.infer<typeof schemas.diffViewerDiffsMessage>
+export type DiffViewerLoadingMessage = z.infer<typeof schemas.diffViewerLoadingMessage>
 
-// Enhance prompt result (extension → webview)
-export interface EnhancePromptResultMessage {
-  type: "enhancePromptResult"
-  text: string
-  requestId: string
-}
-
-// Enhance prompt error (extension → webview)
-export interface EnhancePromptErrorMessage {
-  type: "enhancePromptError"
-  error: string
-  requestId: string
-}
-
-// Sub-agent viewer: open a child session in read-only mode (extension → webview)
-export interface ViewSubAgentSessionMessage {
-  type: "viewSubAgentSession"
-  sessionID: string
-}
-
-export interface DiffViewerDiffsMessage {
-  type: "diffViewer.diffs"
-  diffs: WorktreeFileDiff[]
-}
-
-export interface DiffViewerLoadingMessage {
-  type: "diffViewer.loading"
-  loading: boolean
-}
-
-export type ExtensionMessage =
-  | ReadyMessage
-  | ConnectionStateMessage
-  | ErrorMessage
-  | PartUpdatedMessage
-  | SessionStatusMessage
-  | PermissionRequestMessage
-  | PermissionResolvedMessage
-  | PermissionErrorMessage
-  | TodoUpdatedMessage
-  | SessionCreatedMessage
-  | SessionUpdatedMessage
-  | SessionDeletedMessage
-  | MessagesLoadedMessage
-  | MessageCreatedMessage
-  | SessionsLoadedMessage
-  | CloudSessionsLoadedMessage
-  | GitRemoteUrlLoadedMessage
-  | ActionMessage
-  | ProfileDataMessage
-  | DeviceAuthStartedMessage
-  | DeviceAuthCompleteMessage
-  | DeviceAuthFailedMessage
-  | DeviceAuthCancelledMessage
-  | NavigateMessage
-  | ProvidersLoadedMessage
-  | AgentsLoadedMessage
-  | AutocompleteSettingsLoadedMessage
-  | ChatCompletionResultMessage
-  | FileSearchResultMessage
-  | QuestionRequestMessage
-  | QuestionResolvedMessage
-  | QuestionErrorMessage
-  | BrowserSettingsLoadedMessage
-  | ConfigLoadedMessage
-  | ConfigUpdatedMessage
-  | NotificationSettingsLoadedMessage
-  | NotificationsLoadedMessage
-  | AgentManagerSessionMetaMessage
-  | AgentManagerRepoInfoMessage
-  | AgentManagerWorktreeSetupMessage
-  | AgentManagerSessionAddedMessage
-  | AgentManagerStateMessage
-  | AgentManagerKeybindingsMessage
-  | AgentManagerMultiVersionProgressMessage
-  | AgentManagerSetSessionModelMessage
-  | AgentManagerSendInitialMessage
-  | SetChatBoxMessage
-  | AppendChatBoxMessage
-  | AppendReviewCommentsMessage
-  | TriggerTaskMessage
-  | VariantsLoadedMessage
-  | CloudSessionDataLoadedMessage
-  | CloudSessionImportedMessage
-  | CloudSessionImportFailedMessage
-  | OpenCloudSessionMessage
-  | AgentManagerBranchesMessage
-  | AgentManagerExternalWorktreesMessage
-  | AgentManagerImportResultMessage
-  | WorkspaceDirectoryChangedMessage
-  | AgentManagerWorktreeDiffMessage
-  | AgentManagerWorktreeDiffLoadingMessage
-  | AgentManagerApplyWorktreeDiffResultMessage
-  | AgentManagerWorktreeStatsMessage
-  | AgentManagerLocalStatsMessage
-  // legacy-migration start
-  | LegacyMigrationDataMessage
-  | LegacyMigrationProgressMessage
-  | LegacyMigrationCompleteMessage
-  // legacy-migration end
-  | EnhancePromptResultMessage
-  | EnhancePromptErrorMessage
-  | ViewSubAgentSessionMessage
-  | DiffViewerDiffsMessage
-  | DiffViewerLoadingMessage
+export type ExtensionMessage = z.infer<typeof schemas.extensionMessage>
 
 // ============================================
 // Messages FROM webview TO extension
 // ============================================
 
-export interface FileAttachment {
-  mime: string
-  url: string
-}
-
-export interface SendMessageRequest {
-  type: "sendMessage"
-  text: string
-  sessionID?: string
-  providerID?: string
-  modelID?: string
-  agent?: string
-  variant?: string
-  files?: FileAttachment[]
-}
-
-export interface AbortRequest {
-  type: "abort"
-  sessionID: string
-}
-
-export interface PermissionResponseRequest {
-  type: "permissionResponse"
-  permissionId: string
-  sessionID: string
-  response: "once" | "always" | "reject"
-}
-
-export interface CreateSessionRequest {
-  type: "createSession"
-}
-
-export interface ClearSessionRequest {
-  type: "clearSession"
-}
-
-export interface LoadMessagesRequest {
-  type: "loadMessages"
-  sessionID: string
-}
-
-export interface LoadSessionsRequest {
-  type: "loadSessions"
-}
-
-export interface RequestCloudSessionsMessage {
-  type: "requestCloudSessions"
-  cursor?: string
-  limit?: number
-  gitUrl?: string
-}
-
-export interface RequestGitRemoteUrlMessage {
-  type: "requestGitRemoteUrl"
-}
-
-export interface RequestCloudSessionDataMessage {
-  type: "requestCloudSessionData"
-  sessionId: string
-}
-
-export interface ImportAndSendMessage {
-  type: "importAndSend"
-  cloudSessionId: string
-  text: string
-  providerID?: string
-  modelID?: string
-  agent?: string
-  variant?: string
-  files?: FileAttachment[]
-}
-
-export interface LoginRequest {
-  type: "login"
-}
-
-export interface LogoutRequest {
-  type: "logout"
-}
-
-export interface RefreshProfileRequest {
-  type: "refreshProfile"
-}
-
-export interface OpenExternalRequest {
-  type: "openExternal"
-  url: string
-}
-
-export interface OpenFileRequest {
-  type: "openFile"
-  filePath: string
-  line?: number
-  column?: number
-}
-
-export interface CancelLoginRequest {
-  type: "cancelLogin"
-}
-
-export interface SetOrganizationRequest {
-  type: "setOrganization"
-  organizationId: string | null
-}
-
-export interface WebviewReadyRequest {
-  type: "webviewReady"
-}
-
-export interface RequestProvidersMessage {
-  type: "requestProviders"
-}
-
-export interface CompactRequest {
-  type: "compact"
-  sessionID: string
-  providerID?: string
-  modelID?: string
-}
-
-export interface RequestAgentsMessage {
-  type: "requestAgents"
-}
-
-export interface SetLanguageRequest {
-  type: "setLanguage"
-  locale: string
-}
-
-export interface QuestionReplyRequest {
-  type: "questionReply"
-  requestID: string
-  answers: string[][]
-}
-
-export interface QuestionRejectRequest {
-  type: "questionReject"
-  requestID: string
-}
-
-export interface DeleteSessionRequest {
-  type: "deleteSession"
-  sessionID: string
-}
-
-export interface RenameSessionRequest {
-  type: "renameSession"
-  sessionID: string
-  title: string
-}
-
-export interface RequestAutocompleteSettingsMessage {
-  type: "requestAutocompleteSettings"
-}
-
-export interface UpdateAutocompleteSettingMessage {
-  type: "updateAutocompleteSetting"
-  key: "enableAutoTrigger" | "enableSmartInlineTaskKeybinding" | "enableChatAutocomplete"
-  value: boolean
-}
-
-export interface RequestChatCompletionMessage {
-  type: "requestChatCompletion"
-  text: string
-  requestId: string
-}
-
-export interface RequestFileSearchMessage {
-  type: "requestFileSearch"
-  query: string
-  requestId: string
-}
-
-export interface ChatCompletionAcceptedMessage {
-  type: "chatCompletionAccepted"
-  suggestionLength?: number
-}
-export interface UpdateSettingRequest {
-  type: "updateSetting"
-  key: string
-  value: unknown
-}
-
-export interface RequestBrowserSettingsMessage {
-  type: "requestBrowserSettings"
-}
-
-export interface RequestConfigMessage {
-  type: "requestConfig"
-}
-
-export interface UpdateConfigMessage {
-  type: "updateConfig"
-  config: Partial<Config>
-}
-
-export interface RequestNotificationSettingsMessage {
-  type: "requestNotificationSettings"
-}
-
-export interface ResetAllSettingsRequest {
-  type: "resetAllSettings"
-}
-
-export interface RequestNotificationsMessage {
-  type: "requestNotifications"
-}
-
-export interface DismissNotificationMessage {
-  type: "dismissNotification"
-  notificationId: string
-}
-
-export interface SyncSessionRequest {
-  type: "syncSession"
-  sessionID: string
-}
-
-// Agent Manager worktree messages
-export interface CreateWorktreeSessionRequest {
-  type: "agentManager.createWorktreeSession"
-  text: string
-  providerID?: string
-  modelID?: string
-  agent?: string
-  files?: FileAttachment[]
-}
-
-export interface TelemetryRequest {
-  type: "telemetry"
-  event: string
-  properties?: Record<string, unknown>
-}
-
-// Create a new worktree (with auto-created first session)
-export interface CreateWorktreeRequest {
-  type: "agentManager.createWorktree"
-  baseBranch?: string
-  branchName?: string
-}
-
-// Delete a worktree and dissociate its sessions
-export interface DeleteWorktreeRequest {
-  type: "agentManager.deleteWorktree"
-  worktreeId: string
-}
-
-// Remove a stale worktree entry from state without touching disk
-export interface RemoveStaleWorktreeRequest {
-  type: "agentManager.removeStaleWorktree"
-  worktreeId: string
-}
-
-// Promote a session: create a worktree and move the session into it
-export interface PromoteSessionRequest {
-  type: "agentManager.promoteSession"
-  sessionId: string
-}
-
-// Add a new session to an existing worktree
-export interface AddSessionToWorktreeRequest {
-  type: "agentManager.addSessionToWorktree"
-  worktreeId: string
-}
-
-// Close (remove) a session from its worktree
-export interface CloseSessionRequest {
-  type: "agentManager.closeSession"
-  sessionId: string
-}
-
-// Rename a worktree's display label
-export interface RenameWorktreeRequest {
-  type: "agentManager.renameWorktree"
-  worktreeId: string
-  label: string
-}
-
-export interface RequestRepoInfoMessage {
-  type: "agentManager.requestRepoInfo"
-}
-
-export interface RequestStateMessage {
-  type: "agentManager.requestState"
-}
-
-// Configure worktree setup script
-export interface ConfigureSetupScriptRequest {
-  type: "agentManager.configureSetupScript"
-}
-
-// Show terminal for a session
-export interface ShowTerminalRequest {
-  type: "agentManager.showTerminal"
-  sessionId: string
-}
-
-// Show terminal for the local workspace (when no session is active)
-export interface ShowLocalTerminalRequest {
-  type: "agentManager.showLocalTerminal"
-}
-
-// Open a worktree directory in VS Code
-export interface OpenWorktreeRequest {
-  type: "agentManager.openWorktree"
-  worktreeId: string
-}
-
-// Show existing local terminal when switching to local context (no-op if none exists)
-export interface ShowExistingLocalTerminalRequest {
-  type: "agentManager.showExistingLocalTerminal"
-}
-
-// Open a file in the selected worktree for a specific session
-export interface AgentManagerOpenFileRequest {
-  type: "agentManager.openFile"
-  sessionId: string
-  filePath: string
-  line?: number
-  column?: number
-}
+export type SendMessageRequest = z.infer<typeof schemas.sendMessageRequest>
+export type AbortRequest = z.infer<typeof schemas.abortRequest>
+export type PermissionResponseRequest = z.infer<typeof schemas.permissionResponseRequest>
+export type CreateSessionRequest = z.infer<typeof schemas.createSessionRequest>
+export type ClearSessionRequest = z.infer<typeof schemas.clearSessionRequest>
+export type LoadMessagesRequest = z.infer<typeof schemas.loadMessagesRequest>
+export type LoadSessionsRequest = z.infer<typeof schemas.loadSessionsRequest>
+export type RequestCloudSessionsMessage = z.infer<typeof schemas.requestCloudSessionsMessage>
+export type RequestGitRemoteUrlMessage = z.infer<typeof schemas.requestGitRemoteUrlMessage>
+export type RequestCloudSessionDataMessage = z.infer<typeof schemas.requestCloudSessionDataMessage>
+export type ImportAndSendMessage = z.infer<typeof schemas.importAndSendMessage>
+export type LoginRequest = z.infer<typeof schemas.loginRequest>
+export type LogoutRequest = z.infer<typeof schemas.logoutRequest>
+export type RefreshProfileRequest = z.infer<typeof schemas.refreshProfileRequest>
+export type OpenExternalRequest = z.infer<typeof schemas.openExternalRequest>
+export type OpenFileRequest = z.infer<typeof schemas.openFileRequest>
+export type CancelLoginRequest = z.infer<typeof schemas.cancelLoginRequest>
+export type SetOrganizationRequest = z.infer<typeof schemas.setOrganizationRequest>
+export type WebviewReadyRequest = z.infer<typeof schemas.webviewReadyRequest>
+export type RequestProvidersMessage = z.infer<typeof schemas.requestProvidersMessage>
+export type CompactRequest = z.infer<typeof schemas.compactRequest>
+export type RequestAgentsMessage = z.infer<typeof schemas.requestAgentsMessage>
+export type SetLanguageRequest = z.infer<typeof schemas.setLanguageRequest>
+export type QuestionReplyRequest = z.infer<typeof schemas.questionReplyRequest>
+export type QuestionRejectRequest = z.infer<typeof schemas.questionRejectRequest>
+export type DeleteSessionRequest = z.infer<typeof schemas.deleteSessionRequest>
+export type RenameSessionRequest = z.infer<typeof schemas.renameSessionRequest>
+export type RequestAutocompleteSettingsMessage = z.infer<typeof schemas.requestAutocompleteSettingsMessage>
+export type UpdateAutocompleteSettingMessage = z.infer<typeof schemas.updateAutocompleteSettingMessage>
+export type RequestChatCompletionMessage = z.infer<typeof schemas.requestChatCompletionMessage>
+export type RequestFileSearchMessage = z.infer<typeof schemas.requestFileSearchMessage>
+export type ChatCompletionAcceptedMessage = z.infer<typeof schemas.chatCompletionAcceptedMessage>
+export type UpdateSettingRequest = z.infer<typeof schemas.updateSettingRequest>
+export type RequestBrowserSettingsMessage = z.infer<typeof schemas.requestBrowserSettingsMessage>
+export type RequestConfigMessage = z.infer<typeof schemas.requestConfigMessage>
+export type UpdateConfigMessage = z.infer<typeof schemas.updateConfigMessage>
+export type RequestNotificationSettingsMessage = z.infer<typeof schemas.requestNotificationSettingsMessage>
+export type ResetAllSettingsRequest = z.infer<typeof schemas.resetAllSettingsRequest>
+export type RequestNotificationsMessage = z.infer<typeof schemas.requestNotificationsMessage>
+export type DismissNotificationMessage = z.infer<typeof schemas.dismissNotificationMessage>
+export type SyncSessionRequest = z.infer<typeof schemas.syncSessionRequest>
+export type CreateWorktreeSessionRequest = z.infer<typeof schemas.createWorktreeSessionRequest>
+export type TelemetryRequest = z.infer<typeof schemas.telemetryRequest>
+export type CreateWorktreeRequest = z.infer<typeof schemas.createWorktreeRequest>
+export type DeleteWorktreeRequest = z.infer<typeof schemas.deleteWorktreeRequest>
+export type RemoveStaleWorktreeRequest = z.infer<typeof schemas.removeStaleWorktreeRequest>
+export type PromoteSessionRequest = z.infer<typeof schemas.promoteSessionRequest>
+export type AddSessionToWorktreeRequest = z.infer<typeof schemas.addSessionToWorktreeRequest>
+export type CloseSessionRequest = z.infer<typeof schemas.closeSessionRequest>
+export type RenameWorktreeRequest = z.infer<typeof schemas.renameWorktreeRequest>
+export type RequestRepoInfoMessage = z.infer<typeof schemas.requestRepoInfoMessage>
+export type RequestStateMessage = z.infer<typeof schemas.requestStateMessage>
+export type ConfigureSetupScriptRequest = z.infer<typeof schemas.configureSetupScriptRequest>
+export type ShowTerminalRequest = z.infer<typeof schemas.showTerminalRequest>
+export type ShowLocalTerminalRequest = z.infer<typeof schemas.showLocalTerminalRequest>
+export type OpenWorktreeRequest = z.infer<typeof schemas.openWorktreeRequest>
+export type ShowExistingLocalTerminalRequest = z.infer<typeof schemas.showExistingLocalTerminalRequest>
+export type AgentManagerOpenFileRequest = z.infer<typeof schemas.agentManagerOpenFileRequest>
 
 /**
  * Maximum number of parallel worktree versions for multi-version mode.
@@ -1385,223 +292,34 @@ export interface AgentManagerOpenFileRequest {
  */
 export const MAX_MULTI_VERSIONS = 4
 
-// Per-version model allocation for multi-model comparison mode
-export interface ModelAllocation {
-  providerID: string
-  modelID: string
-  count: number
-}
+export type CreateMultiVersionRequest = z.infer<typeof schemas.createMultiVersionRequest>
+export type SetTabOrderRequest = z.infer<typeof schemas.setTabOrderRequest>
+export type SetSessionsCollapsedRequest = z.infer<typeof schemas.setSessionsCollapsedRequest>
+export type SetReviewDiffStyleRequest = z.infer<typeof schemas.setReviewDiffStyleRequest>
+export type RequestBranchesMessage = z.infer<typeof schemas.requestBranchesMessage>
+export type RequestExternalWorktreesMessage = z.infer<typeof schemas.requestExternalWorktreesMessage>
+export type ImportFromBranchRequest = z.infer<typeof schemas.importFromBranchRequest>
+export type ImportFromPRRequest = z.infer<typeof schemas.importFromPRRequest>
+export type ImportExternalWorktreeRequest = z.infer<typeof schemas.importExternalWorktreeRequest>
+export type ImportAllExternalWorktreesRequest = z.infer<typeof schemas.importAllExternalWorktreesRequest>
+export type RequestWorktreeDiffMessage = z.infer<typeof schemas.requestWorktreeDiffMessage>
+export type StartDiffWatchMessage = z.infer<typeof schemas.startDiffWatchMessage>
+export type StopDiffWatchMessage = z.infer<typeof schemas.stopDiffWatchMessage>
+export type ApplyWorktreeDiffMessage = z.infer<typeof schemas.applyWorktreeDiffMessage>
+export type PersistVariantRequest = z.infer<typeof schemas.persistVariantRequest>
+export type RequestVariantsMessage = z.infer<typeof schemas.requestVariantsMessage>
+export type EnhancePromptRequest = z.infer<typeof schemas.enhancePromptRequest>
+export type OpenChangesRequest = z.infer<typeof schemas.openChangesRequest>
+export type OpenSubAgentViewerRequest = z.infer<typeof schemas.openSubAgentViewerRequest>
+export type SetDefaultBaseBranchRequest = z.infer<typeof schemas.setDefaultBaseBranchRequest>
+// legacy-migration start
+export type RequestLegacyMigrationDataMessage = z.infer<typeof schemas.requestLegacyMigrationDataMessage>
+export type StartLegacyMigrationMessage = z.infer<typeof schemas.startLegacyMigrationMessage>
+export type SkipLegacyMigrationMessage = z.infer<typeof schemas.skipLegacyMigrationMessage>
+export type ClearLegacyDataMessage = z.infer<typeof schemas.clearLegacyDataMessage>
+// legacy-migration end
 
-// Create multiple worktree sessions for the same prompt (multi-version mode)
-export interface CreateMultiVersionRequest {
-  type: "agentManager.createMultiVersion"
-  text?: string
-  name?: string
-  versions: number
-  providerID?: string
-  modelID?: string
-  agent?: string
-  files?: FileAttachment[]
-  baseBranch?: string
-  branchName?: string
-  // Per-version model allocations for multi-model comparison mode.
-  // When set, each entry expands to `count` versions with that model.
-  // Overrides `versions`, `providerID`, and `modelID`.
-  modelAllocations?: ModelAllocation[]
-}
-
-// Persist tab order for a context (worktree ID or "local")
-export interface SetTabOrderRequest {
-  type: "agentManager.setTabOrder"
-  key: string
-  order: string[]
-}
-
-// Persist sessions collapsed state
-export interface SetSessionsCollapsedRequest {
-  type: "agentManager.setSessionsCollapsed"
-  collapsed: boolean
-}
-
-// Persist review diff style preference
-export interface SetReviewDiffStyleRequest {
-  type: "agentManager.setReviewDiffStyle"
-  style: "unified" | "split"
-}
-
-export interface RequestBranchesMessage {
-  type: "agentManager.requestBranches"
-}
-
-export interface RequestExternalWorktreesMessage {
-  type: "agentManager.requestExternalWorktrees"
-}
-
-export interface ImportFromBranchRequest {
-  type: "agentManager.importFromBranch"
-  branch: string
-}
-
-export interface ImportFromPRRequest {
-  type: "agentManager.importFromPR"
-  url: string
-}
-
-export interface ImportExternalWorktreeRequest {
-  type: "agentManager.importExternalWorktree"
-  path: string
-  branch: string
-}
-
-export interface ImportAllExternalWorktreesRequest {
-  type: "agentManager.importAllExternalWorktrees"
-}
-
-// Agent Manager: Request one-shot diff fetch (webview → extension)
-export interface RequestWorktreeDiffMessage {
-  type: "agentManager.requestWorktreeDiff"
-  sessionId: string
-}
-
-// Agent Manager: Start polling for live diff updates (webview → extension)
-export interface StartDiffWatchMessage {
-  type: "agentManager.startDiffWatch"
-  sessionId: string
-}
-
-// Agent Manager: Stop polling for diff updates (webview → extension)
-export interface StopDiffWatchMessage {
-  type: "agentManager.stopDiffWatch"
-}
-
-export interface ApplyWorktreeDiffMessage {
-  type: "agentManager.applyWorktreeDiff"
-  worktreeId: string
-  selectedFiles?: string[]
-}
-
-// Variant persistence (webview → extension)
-export interface PersistVariantRequest {
-  type: "persistVariant"
-  key: string
-  value: string
-}
-
-// Request stored variants from extension (webview → extension)
-export interface RequestVariantsMessage {
-  type: "requestVariants"
-}
-
-// Enhance prompt request (webview → extension)
-export interface EnhancePromptRequest {
-  type: "enhancePrompt"
-  text: string
-  requestId: string
-}
-
-// Open the standalone changes viewer tab from the sidebar
-export interface OpenChangesRequest {
-  type: "openChanges"
-}
-
-// Open a sub-agent session in a read-only editor panel
-export interface OpenSubAgentViewerRequest {
-  type: "openSubAgentViewer"
-  sessionID: string
-  title?: string
-}
-
-// Set default base branch (webview → extension)
-export interface SetDefaultBaseBranchRequest {
-  type: "agentManager.setDefaultBaseBranch"
-  branch?: string
-}
-
-export type WebviewMessage =
-  | SendMessageRequest
-  | AbortRequest
-  | PermissionResponseRequest
-  | CreateSessionRequest
-  | ClearSessionRequest
-  | LoadMessagesRequest
-  | LoadSessionsRequest
-  | RequestCloudSessionsMessage
-  | RequestGitRemoteUrlMessage
-  | LoginRequest
-  | LogoutRequest
-  | RefreshProfileRequest
-  | OpenExternalRequest
-  | OpenFileRequest
-  | CancelLoginRequest
-  | SetOrganizationRequest
-  | WebviewReadyRequest
-  | RequestProvidersMessage
-  | CompactRequest
-  | RequestAgentsMessage
-  | SetLanguageRequest
-  | QuestionReplyRequest
-  | QuestionRejectRequest
-  | DeleteSessionRequest
-  | RenameSessionRequest
-  | RequestAutocompleteSettingsMessage
-  | UpdateAutocompleteSettingMessage
-  | RequestChatCompletionMessage
-  | RequestFileSearchMessage
-  | ChatCompletionAcceptedMessage
-  | UpdateSettingRequest
-  | RequestBrowserSettingsMessage
-  | RequestConfigMessage
-  | UpdateConfigMessage
-  | RequestNotificationSettingsMessage
-  | ResetAllSettingsRequest
-  | SyncSessionRequest
-  | CreateWorktreeSessionRequest
-  | RequestNotificationsMessage
-  | DismissNotificationMessage
-  | CreateWorktreeRequest
-  | DeleteWorktreeRequest
-  | RemoveStaleWorktreeRequest
-  | PromoteSessionRequest
-  | AddSessionToWorktreeRequest
-  | CloseSessionRequest
-  | RenameWorktreeRequest
-  | TelemetryRequest
-  | RequestRepoInfoMessage
-  | RequestStateMessage
-  | ConfigureSetupScriptRequest
-  | ShowTerminalRequest
-  | ShowLocalTerminalRequest
-  | OpenWorktreeRequest
-  | ShowExistingLocalTerminalRequest
-  | AgentManagerOpenFileRequest
-  | CreateMultiVersionRequest
-  | SetTabOrderRequest
-  | SetSessionsCollapsedRequest
-  | SetReviewDiffStyleRequest
-  | PersistVariantRequest
-  | RequestVariantsMessage
-  | RequestCloudSessionDataMessage
-  | ImportAndSendMessage
-  | RequestBranchesMessage
-  | RequestExternalWorktreesMessage
-  | ImportFromBranchRequest
-  | ImportFromPRRequest
-  | ImportExternalWorktreeRequest
-  | ImportAllExternalWorktreesRequest
-  | RequestWorktreeDiffMessage
-  | StartDiffWatchMessage
-  | StopDiffWatchMessage
-  // legacy-migration start
-  | RequestLegacyMigrationDataMessage
-  | StartLegacyMigrationMessage
-  | SkipLegacyMigrationMessage
-  | ClearLegacyDataMessage
-  // legacy-migration end
-  | ApplyWorktreeDiffMessage
-  | EnhancePromptRequest
-  | OpenChangesRequest
-  | OpenSubAgentViewerRequest
-  | SetDefaultBaseBranchRequest
+export type WebviewMessage = z.infer<typeof schemas.webviewMessage>
 
 // ============================================
 // VS Code API type


### PR DESCRIPTION
## Summary

Implements [John's suggestion](https://github.com/Kilo-Org/kilocode/pull/6940#discussion_r2919041525) to derive all extension <-> webview message types from Zod schemas and validate at the IO boundary instead of casting.

- **New file `message-schemas.ts`**: Contains Zod schemas for every message type (extension -> webview and webview -> extension), all shared data types (parts, sessions, config, agent manager types, etc.), and the `extensionMessage` / `webviewMessage` discriminated unions
- **Rewritten `messages.ts`**: All ~100 TypeScript interfaces replaced with `z.infer<typeof schema>` type aliases — types stay in sync with schemas automatically
- **Updated IO boundaries**: `vscode.tsx` and `AgentManagerApp.tsx` now use `extensionMessageSchema.safeParse()` instead of `as ExtensionMessage` casts. Invalid messages are logged and dropped.

## What this enables

- Runtime validation of messages at the IO boundary catches malformed data early
- Types are the single source of truth — no more manual interface/schema drift
- Foundation for future runtime validation on the webview -> extension direction

## Verification

- `bun run check-types:webview` passes cleanly
- `bun run check-types:extension` passes cleanly
- All formatted with prettier