### PR TITLE
fix(kilo-vscode): implement mode switching after question option selection

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -73,6 +73,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private migrationCheckInFlight = false // legacy-migration
   private unsubscribeNotificationDismiss: (() => void) | null = null
   private webviewMessageDisposable: vscode.Disposable | null = null
+  /** Pending mode switch to execute when the session becomes idle after a question reply. */
+  private pendingModeSwitch: {
+    sessionID: string
+    mode: string
+    text: string
+    timeout: ReturnType<typeof setTimeout>
+  } | null = null
 
   /** Lazily initialized ignore controller for .kilocodeignore filtering */
   private ignoreController: FileIgnoreController | null = null
@@ -413,6 +420,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         case "questionReject":
           await this.handleQuestionReject(message.requestID)
+          break
+        case "questionModeSwitch":
+          this.scheduleModeSwitchAfterIdle(message.sessionID, message.mode, message.text)
           break
         case "requestConfig":
           this.fetchAndSendConfig().catch((e) => console.error("[Kilo New] fetchAndSendConfig failed:", e))
@@ -1616,8 +1626,44 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   /**
+   * Schedule a mode switch to execute after the session becomes idle.
+   * This is used when a question option has a `mode` property â after the question
+   * reply resolves, we wait for the session to become idle, then switch to the
+   * requested agent/mode and send a follow-up prompt.
+   */
+  private scheduleModeSwitchAfterIdle(sessionID: string, mode: string, text: string): void {
+    // Cancel any existing pending mode switch
+    if (this.pendingModeSwitch) {
+      clearTimeout(this.pendingModeSwitch.timeout)
+    }
+
+    const timeout = setTimeout(() => {
+      console.warn("[Kilo New] KiloProvider: Mode switch timed out waiting for idle", { sessionID, mode })
+      this.pendingModeSwitch = null
+    }, 30_000)
+
+    this.pendingModeSwitch = { sessionID, mode, text, timeout }
+    console.log("[Kilo New] KiloProvider: Scheduled mode switch after idle", { sessionID, mode })
+  }
+
+  /**
+   * Execute a pending mode switch by sending a new prompt with the target agent.
+   */
+  private async executeModeSwitch(sessionID: string, mode: string, text: string): Promise<void> {
+    if (!this.client) return
+
+    console.log("[Kilo New] KiloProvider: Executing mode switch", { sessionID, mode })
+
+    try {
+      await this.handleSendMessage(text, sessionID, undefined, undefined, mode)
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to execute mode switch:", error)
+    }
+  }
+
+  /**
    * Handle login request from the webview.
-   * Uses the provider OAuth flow: authorize → open browser → callback (polls until complete).
+   * Uses the provider OAuth flow: authorize â open browser â callback (polls until complete).
    * Sends device auth messages so the webview can display a QR code, verification code, and timer.
    */
   private async handleLogin(): Promise<void> {
@@ -1928,6 +1974,17 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     const msg = mapSSEEventToWebviewMessage(event, sessionID)
     if (msg) {
       this.postMessage(msg)
+    }
+
+    // Check for pending mode switch when session becomes idle
+    if (event.type === "session.status" && this.pendingModeSwitch && sessionID === this.pendingModeSwitch.sessionID) {
+      const status = event.properties?.status
+      if (status?.type === "idle") {
+        const pending = this.pendingModeSwitch
+        clearTimeout(pending.timeout)
+        this.pendingModeSwitch = null
+        void this.executeModeSwitch(pending.sessionID, pending.mode, pending.text)
+      }
     }
   }
 
@@ -2251,5 +2308,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.syncedChildSessions.clear()
     this.sessionDirectories.clear()
     this.ignoreController?.dispose()
+    if (this.pendingModeSwitch) {
+      clearTimeout(this.pendingModeSwitch.timeout)
+      this.pendingModeSwitch = null
+    }
   }
 }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -11,12 +11,14 @@ import { DockPrompt } from "@kilocode/kilo-ui/dock-prompt"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
+import { useVSCode } from "../../context/vscode"
 import type { QuestionRequest } from "../../types/messages"
 import { toggleAnswer } from "./question-dock-utils"
 
 export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => {
   const session = useSession()
   const language = useLanguage()
+  const vscode = useVSCode()
 
   const questions = createMemo(() => props.request.questions)
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
@@ -69,6 +71,22 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
 
   const submit = () => {
     reply(questions().map((_, i) => [...(store.answers[i] ?? [])]))
+
+    // Check if any selected answer maps to an option with a mode for single-question forms
+    if (single()) {
+      const answer = store.answers[0]?.[0]
+      if (answer) {
+        const option = options().find((o) => o.label === answer)
+        if (option?.mode) {
+          vscode.postMessage({
+            type: "questionModeSwitch",
+            sessionID: props.request.sessionID,
+            mode: option.mode,
+            text: option.description ?? answer,
+          })
+        }
+      }
+    }
   }
 
   const back = () => {
@@ -78,6 +96,10 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
   }
 
   const pick = (answer: string, custom = false) => {
+    // Find the matching option to check for mode switching
+    // Custom answers won't match a predefined option, so mode switching is intentionally skipped
+    const option = options().find((o) => o.label === answer)
+
     const answers = [...store.answers]
     answers[store.tab] = [answer]
     setStore("answers", answers)
@@ -88,7 +110,22 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
       setStore("custom", inputs)
     }
 
-    if (!single() && !multi()) {
+    // For single-select single-question: reply immediately and trigger mode switch if needed
+    if (single()) {
+      reply([[answer]])
+      if (option?.mode) {
+        const sid = props.request.sessionID
+        vscode.postMessage({
+          type: "questionModeSwitch",
+          sessionID: sid,
+          mode: option.mode,
+          text: option.description ?? answer,
+        })
+      }
+      return
+    }
+
+    if (!multi()) {
       setStore("tab", store.tab + 1)
     }
   }

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -144,6 +144,7 @@ export interface TodoItem {
 export interface QuestionOption {
   label: string
   description: string
+  mode?: string
 }
 
 export interface QuestionInfo {
@@ -1190,6 +1191,13 @@ export interface QuestionRejectRequest {
   requestID: string
 }
 
+export interface QuestionModeSwitchRequest {
+  type: "questionModeSwitch"
+  sessionID: string
+  mode: string
+  text: string
+}
+
 export interface DeleteSessionRequest {
   type: "deleteSession"
   sessionID: string
@@ -1527,6 +1535,7 @@ export type WebviewMessage =
   | SetLanguageRequest
   | QuestionReplyRequest
   | QuestionRejectRequest
+  | QuestionModeSwitchRequest
   | DeleteSessionRequest
   | RenameSessionRequest
   | RequestAutocompleteSettingsMessage


### PR DESCRIPTION
## Summary

- Fixes a bug where selecting a question option with a `mode` property (e.g., "Fix all issues" → code mode after a review) would cause the extension to stop/do nothing instead of switching modes and continuing
- Ports the mode-switching logic from `packages/app` (desktop/web) to the VS Code extension, which was missing this feature entirely
- Adds a `questionModeSwitch` message flow: webview detects the `mode` field on selected options → extension waits for session idle via SSE → sends follow-up prompt with the target agent

## Root Cause

The `QuestionOption` schema in the CLI defines an optional `mode` field that tells the client to switch agent/mode when that option is selected. The `packages/app` implementation correctly handles this by:
1. Detecting the `mode` on the selected option
2. Waiting for the session to become idle after the question reply
3. Switching the agent and sending a new prompt

The VS Code extension's `QuestionDock` was sending only the answer labels (`string[][]`) back to the CLI — the `mode` field was completely ignored. After the question reply resolved, the LLM would see "User answered: Fix all issues" but the session was still in the original agent (e.g., review/ask mode) which couldn't perform the requested action, so it would stop.

## Changes

| File | Change |
| --- | --- |
| `webview-ui/src/types/messages.ts` | Add `mode?: string` to `QuestionOption`, add `QuestionModeSwitchRequest` message type |
| `webview-ui/src/components/chat/QuestionDock.tsx` | Detect `mode` on selected options, send `questionModeSwitch` message after reply, auto-submit for single-select questions (matches app behavior) |
| `src/KiloProvider.ts` | Handle `questionModeSwitch` message: schedule mode switch, listen for session idle via SSE, execute mode switch by sending follow-up prompt with target agent |

Built for [Mark](https://kilo-code.slack.com/archives/C0AFBRXUH2N/p1773221552208679?thread_ts=1772987070.925449&cid=C0AFBRXUH2N) by [Kilo for Slack](https://kilo.ai/features/slack-integration)