### PR TITLE
CLI - Restore Kilo share URL support in import command

### DIFF
--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -139,7 +139,8 @@ export const ImportCommand = cmd({
           return
         }
 
-        const response = await fetch(`https://ingest.kilosessions.ai/session/${encodeURIComponent(slug)}`)
+        const base = process.env["KILO_SESSION_INGEST_URL"] ?? "https://ingest.kilosessions.ai"
+        const response = await fetch(`${base}/session/${encodeURIComponent(slug)}`)
 
         if (!response.ok) {
           process.stdout.write(`Failed to fetch share data: ${response.statusText}`)

--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -6,7 +6,6 @@ import { bootstrap } from "../bootstrap"
 import { Database } from "../../storage/db"
 import { SessionTable, MessageTable, PartTable } from "../../session/session.sql"
 import { Instance } from "../../project/instance"
-import { ShareNext } from "../../share/share-next"
 import { EOL } from "os"
 import { Filesystem } from "../../util/filesystem"
 import { Log } from "../../util/log"
@@ -21,11 +20,13 @@ export type ShareData =
   | { type: "session_diff"; data: unknown }
   | { type: "model"; data: unknown }
 
-/** Extract share ID from a share URL like https://opncd.ai/share/abc123 */
+// kilocode_change start
+/** Extract share ID from a Kilo share URL like https://app.kilo.ai/s/abc123 */
 export function parseShareUrl(url: string): string | null {
-  const match = url.match(/^https?:\/\/[^/]+\/share\/([a-zA-Z0-9_-]+)$/)
+  const match = url.match(/^https?:\/\/app\.kilo\.ai\/s\/([a-zA-Z0-9_-]+)$/)
   return match ? match[1] : null
 }
+// kilocode_change end
 
 /**
  * Transform ShareNext API response (flat array) into the nested structure for local file storage.
@@ -130,16 +131,15 @@ export const ImportCommand = cmd({
       const isUrl = args.file.startsWith("http://") || args.file.startsWith("https://")
 
       if (isUrl) {
+        // kilocode_change start
         const slug = parseShareUrl(args.file)
         if (!slug) {
-          const baseUrl = await ShareNext.url()
-          process.stdout.write(`Invalid URL format. Expected: ${baseUrl}/share/<slug>`)
+          process.stdout.write(`Invalid URL format. Expected: https://app.kilo.ai/s/<id>`)
           process.stdout.write(EOL)
           return
         }
 
-        const baseUrl = await ShareNext.url()
-        const response = await fetch(`${baseUrl}/api/share/${slug}/data`)
+        const response = await fetch(`https://ingest.kilosessions.ai/session/${encodeURIComponent(slug)}`)
 
         if (!response.ok) {
           process.stdout.write(`Failed to fetch share data: ${response.statusText}`)
@@ -147,16 +147,16 @@ export const ImportCommand = cmd({
           return
         }
 
-        const shareData: ShareData[] = await response.json()
-        const transformed = transformShareData(shareData)
+        const data = await response.json()
 
-        if (!transformed) {
+        if (!data.info || !data.messages || !Array.isArray(data.messages)) {
           process.stdout.write(`Share not found or empty: ${slug}`)
           process.stdout.write(EOL)
           return
         }
 
-        exportData = transformed
+        exportData = data
+        // kilocode_change end
       } else {
         exportData = await Filesystem.readJson<NonNullable<typeof exportData>>(args.file).catch(() => undefined)
         if (!exportData) {

--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -150,7 +150,7 @@ export const ImportCommand = cmd({
 
         const data = await response.json()
 
-        if (!data.info || !data.messages || !Array.isArray(data.messages)) {
+        if (!data || typeof data !== "object" || !data.info || !data.messages || !Array.isArray(data.messages)) {
           process.stdout.write(`Share not found or empty: ${slug}`)
           process.stdout.write(EOL)
           return

--- a/packages/opencode/test/cli/import.test.ts
+++ b/packages/opencode/test/cli/import.test.ts
@@ -8,16 +8,19 @@ import {
 } from "../../src/cli/cmd/import"
 
 // parseShareUrl tests
-test("parses valid share URLs", () => {
-  expect(parseShareUrl("https://opncd.ai/share/Jsj3hNIW")).toBe("Jsj3hNIW")
-  expect(parseShareUrl("https://custom.example.com/share/abc123")).toBe("abc123")
-  expect(parseShareUrl("http://localhost:3000/share/test_id-123")).toBe("test_id-123")
+test("parses valid Kilo share URLs", () => {
+  expect(parseShareUrl("https://app.kilo.ai/s/7a755b04-b0fe-4e66-8b30-0ab52a181bd4")).toBe(
+    "7a755b04-b0fe-4e66-8b30-0ab52a181bd4",
+  )
+  expect(parseShareUrl("https://app.kilo.ai/s/Jsj3hNIW")).toBe("Jsj3hNIW")
+  expect(parseShareUrl("https://app.kilo.ai/s/test_id-123")).toBe("test_id-123")
 })
 
 test("rejects invalid URLs", () => {
-  expect(parseShareUrl("https://opncd.ai/s/Jsj3hNIW")).toBeNull() // legacy format
-  expect(parseShareUrl("https://opncd.ai/share/")).toBeNull()
-  expect(parseShareUrl("https://opncd.ai/share/id/extra")).toBeNull()
+  expect(parseShareUrl("https://app.kilo.ai/s/")).toBeNull()
+  expect(parseShareUrl("https://app.kilo.ai/s/id/extra")).toBeNull()
+  expect(parseShareUrl("https://opncd.ai/share/Jsj3hNIW")).toBeNull()
+  expect(parseShareUrl("https://other.example.com/s/abc")).toBeNull()
   expect(parseShareUrl("not-a-url")).toBeNull()
 })
 


### PR DESCRIPTION
## Summary

- Restores `app.kilo.ai/s/<id>` URL parsing in the import command, which was overwritten during the upstream opencode v1.1.54 merge
- Routes import fetches to `ingest.kilosessions.ai/session/<id>` (pre-structured response format) instead of the upstream `opncd.ai/api/share/<id>/data` flat array API
- Adds `kilocode_change` markers to prevent future merge overwrites