### PR TITLE
feat(settings): add available agents list to agent behaviour tab

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/settings/agent-behaviour-agents-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/settings/agent-behaviour-agents-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4ce1bb9827a8759ea4e8037a0f32b2cab3ef74aad5b4276491be9820c007ca5
+size 25638

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/settings/agent-behaviour-agents-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/settings/agent-behaviour-agents-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4ce1bb9827a8759ea4e8037a0f32b2cab3ef74aad5b4276491be9820c007ca5
-size 25638
+oid sha256:dcbffafb87bb4b68a3abcd9479cebf2844bf2290aa8c41c00f5f1a3e6129f078
+size 22968

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -202,9 +202,16 @@ const AgentBehaviourTab: Component = () => {
       </Card>
 
       {/* Available agents list */}
-      <h4 style={{ "margin-top": "0", "margin-bottom": "8px" }}>
+      <hr
+        style={{
+          border: "none",
+          "border-top": "1px solid var(--border-weak-base)",
+          margin: "16px 0",
+        }}
+      />
+      <div data-slot="settings-row-label-title" style={{ "margin-bottom": "8px" }}>
         {language.t("settings.agentBehaviour.availableAgents")}
-      </h4>
+      </div>
       <Card style={{ "margin-bottom": "12px" }}>
         <For each={agentNames()}>
           {(name, index) => {
@@ -216,15 +223,9 @@ const AgentBehaviourTab: Component = () => {
                   "align-items": "center",
                   "justify-content": "space-between",
                   padding: "8px 4px",
-                  cursor: "pointer",
                   "border-bottom": index() < agentNames().length - 1 ? "1px solid var(--border-weak-base)" : "none",
-                  "background-color":
-                    selectedAgent() === name
-                      ? "var(--bg-active-base, var(--vscode-list-activeSelectionBackground))"
-                      : "transparent",
                   "border-radius": "4px",
                 }}
-                onClick={() => setSelectedAgent(selectedAgent() === name ? "" : name)}
               >
                 <div>
                   <div style={{ "font-weight": "500", "font-size": "13px" }}>{name}</div>
@@ -240,19 +241,6 @@ const AgentBehaviourTab: Component = () => {
                     </div>
                   </Show>
                 </div>
-                <Show when={agent()?.mode}>
-                  <span
-                    style={{
-                      "font-size": "11px",
-                      padding: "1px 6px",
-                      "border-radius": "4px",
-                      background: "var(--bg-subtle-base, var(--vscode-badge-background))",
-                      color: "var(--text-weak-base, var(--vscode-badge-foreground))",
-                    }}
-                  >
-                    {agent()!.mode}
-                  </span>
-                </Show>
               </div>
             )
           }}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -201,23 +201,62 @@ const AgentBehaviourTab: Component = () => {
         </SettingsRow>
       </Card>
 
+      {/* Available agents list */}
+      <h4 style={{ "margin-top": "0", "margin-bottom": "8px" }}>
+        {language.t("settings.agentBehaviour.availableAgents")}
+      </h4>
       <Card style={{ "margin-bottom": "12px" }}>
-        <SettingsRow
-          title={language.t("settings.agentBehaviour.selectAgent.title")}
-          description={language.t("settings.agentBehaviour.selectAgent.description")}
-          last
-        >
-          <Select
-            options={agentSelectorOptions()}
-            current={agentSelectorOptions().find((o) => o.value === selectedAgent())}
-            value={(o) => o.value}
-            label={(o) => o.label}
-            onSelect={(o) => o && setSelectedAgent(o.value)}
-            variant="secondary"
-            size="small"
-            triggerVariant="settings"
-          />
-        </SettingsRow>
+        <For each={agentNames()}>
+          {(name, index) => {
+            const agent = () => session.agents().find((a) => a.name === name)
+            return (
+              <div
+                style={{
+                  display: "flex",
+                  "align-items": "center",
+                  "justify-content": "space-between",
+                  padding: "8px 4px",
+                  cursor: "pointer",
+                  "border-bottom": index() < agentNames().length - 1 ? "1px solid var(--border-weak-base)" : "none",
+                  "background-color":
+                    selectedAgent() === name
+                      ? "var(--bg-active-base, var(--vscode-list-activeSelectionBackground))"
+                      : "transparent",
+                  "border-radius": "4px",
+                }}
+                onClick={() => setSelectedAgent(selectedAgent() === name ? "" : name)}
+              >
+                <div>
+                  <div style={{ "font-weight": "500", "font-size": "13px" }}>{name}</div>
+                  <Show when={agent()?.description}>
+                    <div
+                      style={{
+                        "font-size": "11px",
+                        color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
+                        "margin-top": "2px",
+                      }}
+                    >
+                      {agent()!.description}
+                    </div>
+                  </Show>
+                </div>
+                <Show when={agent()?.mode}>
+                  <span
+                    style={{
+                      "font-size": "11px",
+                      padding: "1px 6px",
+                      "border-radius": "4px",
+                      background: "var(--bg-subtle-base, var(--vscode-badge-background))",
+                      color: "var(--text-weak-base, var(--vscode-badge-foreground))",
+                    }}
+                  >
+                    {agent()!.mode}
+                  </span>
+                </Show>
+              </div>
+            )
+          }}
+        </For>
       </Card>
 
       <Show when={selectedAgent()}>

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -925,6 +925,7 @@ export const dict = {
   "settings.experimental.toolToggles": "مفاتيح الأدوات",
   "settings.agentBehaviour.defaultAgent.title": "الوكيل الافتراضي",
   "settings.agentBehaviour.defaultAgent.description": "الوكيل المستخدم عند عدم التحديد",
+  "settings.agentBehaviour.availableAgents": "الوكلاء المتاحون",
   "settings.agentBehaviour.selectAgent": "اختر وكيلاً للتهيئة…",
   "settings.agentBehaviour.selectAgent.title": "الوكيل",
   "settings.agentBehaviour.selectAgent.description": "اختر وكيلاً للتهيئة…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -937,6 +937,7 @@ export const dict = {
   "settings.experimental.toolToggles": "Alternadores de ferramentas",
   "settings.agentBehaviour.defaultAgent.title": "Agente padrão",
   "settings.agentBehaviour.defaultAgent.description": "Agente a usar quando nenhum é especificado",
+  "settings.agentBehaviour.availableAgents": "Agentes Disponíveis",
   "settings.agentBehaviour.selectAgent": "Selecionar um agente para configurar…",
   "settings.agentBehaviour.selectAgent.title": "Agente",
   "settings.agentBehaviour.selectAgent.description": "Selecionar um agente para configurar…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -937,6 +937,7 @@ export const dict = {
   "settings.experimental.toolToggles": "Prekidači alata",
   "settings.agentBehaviour.defaultAgent.title": "Zadani agent",
   "settings.agentBehaviour.defaultAgent.description": "Agent koji se koristi kada nijedan nije naveden",
+  "settings.agentBehaviour.availableAgents": "Dostupni agenti",
   "settings.agentBehaviour.selectAgent": "Odaberi agenta za konfiguraciju…",
   "settings.agentBehaviour.selectAgent.title": "Agent",
   "settings.agentBehaviour.selectAgent.description": "Odaberi agenta za konfiguraciju…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -933,6 +933,7 @@ export const dict = {
   "settings.experimental.toolToggles": "Værktøjsskift",
   "settings.agentBehaviour.defaultAgent.title": "Standardagent",
   "settings.agentBehaviour.defaultAgent.description": "Agent til brug, når ingen er angivet",
+  "settings.agentBehaviour.availableAgents": "Tilgængelige agenter",
   "settings.agentBehaviour.selectAgent": "Vælg en agent at konfigurere…",
   "settings.agentBehaviour.selectAgent.title": "Agent",
   "settings.agentBehaviour.selectAgent.description": "Vælg en agent at konfigurere…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -948,6 +948,7 @@ export const dict = {
   "settings.experimental.toolToggles": "Werkzeug-Schalter",
   "settings.agentBehaviour.defaultAgent.title": "Standard-Agent",
   "settings.agentBehaviour.defaultAgent.description": "Agent, der verwendet wird, wenn keiner angegeben ist",
+  "settings.agentBehaviour.availableAgents": "Verfügbare Agenten",
   "settings.agentBehaviour.selectAgent": "Agent zum Konfigurieren auswählen…",
   "settings.agentBehaviour.selectAgent.title": "Agent",
   "settings.agentBehaviour.selectAgent.description": "Agent zum Konfigurieren auswählen…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -944,6 +944,7 @@ export const dict = {
 
   "settings.agentBehaviour.defaultAgent.title": "Default Agent",
   "settings.agentBehaviour.defaultAgent.description": "Agent to use when none is specified",
+  "settings.agentBehaviour.availableAgents": "Available Agents",
   "settings.agentBehaviour.selectAgent": "Select an agent to configure…",
   "settings.agentBehaviour.selectAgent.title": "Agent",
   "settings.agentBehaviour.selectAgent.description": "Select an agent to configure…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -940,6 +940,7 @@ export const dict = {
   "settings.experimental.toolToggles": "Interruptores de herramientas",
   "settings.agentBehaviour.defaultAgent.title": "Agente predeterminado",
   "settings.agentBehaviour.defaultAgent.description": "Agente a usar cuando no se especifica ninguno",
+  "settings.agentBehaviour.availableAgents": "Agentes disponibles",
   "settings.agentBehaviour.selectAgent": "Seleccionar un agente para configurar…",
   "settings.agentBehaviour.selectAgent.title": "Agente",
   "settings.agentBehaviour.selectAgent.description": "Seleccionar un agente para configurar…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -950,6 +950,7 @@ export const dict = {
   "settings.experimental.toolToggles": "Commutateurs d'outils",
   "settings.agentBehaviour.defaultAgent.title": "Agent par défaut",
   "settings.agentBehaviour.defaultAgent.description": "Agent à utiliser lorsqu'aucun n'est spécifié",
+  "settings.agentBehaviour.availableAgents": "Agents disponibles",
   "settings.agentBehaviour.selectAgent": "Sélectionner un agent à configurer…",
   "settings.agentBehaviour.selectAgent.title": "Agent",
   "settings.agentBehaviour.selectAgent.description": "Sélectionner un agent à configurer…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -933,6 +933,7 @@ export const dict = {
   "settings.experimental.toolToggles": "ツールトグル",
   "settings.agentBehaviour.defaultAgent.title": "デフォルトエージェント",
   "settings.agentBehaviour.defaultAgent.description": "指定されていない場合に使用するエージェント",
+  "settings.agentBehaviour.availableAgents": "利用可能なエージェント",
   "settings.agentBehaviour.selectAgent": "設定するエージェントを選択…",
   "settings.agentBehaviour.selectAgent.title": "エージェント",
   "settings.agentBehaviour.selectAgent.description": "設定するエージェントを選択…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -930,6 +930,7 @@ export const dict = {
   "settings.experimental.toolToggles": "도구 토글",
   "settings.agentBehaviour.defaultAgent.title": "기본 에이전트",
   "settings.agentBehaviour.defaultAgent.description": "지정되지 않은 경우 사용할 에이전트",
+  "settings.agentBehaviour.availableAgents": "사용 가능한 에이전트",
   "settings.agentBehaviour.selectAgent": "구성할 에이전트를 선택하세요…",
   "settings.agentBehaviour.selectAgent.title": "에이전트",
   "settings.agentBehaviour.selectAgent.description": "구성할 에이전트를 선택하세요…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -935,6 +935,7 @@ export const dict = {
   "settings.experimental.toolToggles": "Verktøybrytere",
   "settings.agentBehaviour.defaultAgent.title": "Standardagent",
   "settings.agentBehaviour.defaultAgent.description": "Agent å bruke når ingen er angitt",
+  "settings.agentBehaviour.availableAgents": "Tilgjengelige agenter",
   "settings.agentBehaviour.selectAgent": "Velg en agent å konfigurere…",
   "settings.agentBehaviour.selectAgent.title": "Agent",
   "settings.agentBehaviour.selectAgent.description": "Velg en agent å konfigurere…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -935,6 +935,7 @@ export const dict = {
   "settings.experimental.toolToggles": "Przełączniki narzędzi",
   "settings.agentBehaviour.defaultAgent.title": "Domyślny agent",
   "settings.agentBehaviour.defaultAgent.description": "Agent używany, gdy żaden nie jest określony",
+  "settings.agentBehaviour.availableAgents": "Dostępni agenci",
   "settings.agentBehaviour.selectAgent": "Wybierz agenta do konfiguracji…",
   "settings.agentBehaviour.selectAgent.title": "Agent",
   "settings.agentBehaviour.selectAgent.description": "Wybierz agenta do konfiguracji…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -938,6 +938,7 @@ export const dict = {
   "settings.experimental.toolToggles": "Переключатели инструментов",
   "settings.agentBehaviour.defaultAgent.title": "Агент по умолчанию",
   "settings.agentBehaviour.defaultAgent.description": "Агент при отсутствии указания",
+  "settings.agentBehaviour.availableAgents": "Доступные агенты",
   "settings.agentBehaviour.selectAgent": "Выберите агента для настройки…",
   "settings.agentBehaviour.selectAgent.title": "Агент",
   "settings.agentBehaviour.selectAgent.description": "Выберите агента для настройки…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -926,6 +926,7 @@ export const dict = {
   "settings.experimental.toolToggles": "สวิตช์เครื่องมือ",
   "settings.agentBehaviour.defaultAgent.title": "เอเจนต์เริ่มต้น",
   "settings.agentBehaviour.defaultAgent.description": "เอเจนต์ที่ใช้เมื่อไม่ได้ระบุ",
+  "settings.agentBehaviour.availableAgents": "เอเจนต์ที่ใช้งานได้",
   "settings.agentBehaviour.selectAgent": "เลือกเอเจนต์เพื่อกำหนดค่า…",
   "settings.agentBehaviour.selectAgent.title": "เอเจนต์",
   "settings.agentBehaviour.selectAgent.description": "เลือกเอเจนต์เพื่อกำหนดค่า…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -920,6 +920,7 @@ export const dict = {
   "settings.experimental.toolToggles": "工具开关",
   "settings.agentBehaviour.defaultAgent.title": "默认智能体",
   "settings.agentBehaviour.defaultAgent.description": "未指定时使用的智能体",
+  "settings.agentBehaviour.availableAgents": "可用代理",
   "settings.agentBehaviour.selectAgent": "选择要配置的智能体…",
   "settings.agentBehaviour.selectAgent.title": "智能体",
   "settings.agentBehaviour.selectAgent.description": "选择要配置的智能体…",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -921,6 +921,7 @@ export const dict = {
   "settings.experimental.toolToggles": "工具開關",
   "settings.agentBehaviour.defaultAgent.title": "預設 Agent",
   "settings.agentBehaviour.defaultAgent.description": "未指定時使用的 Agent",
+  "settings.agentBehaviour.availableAgents": "可用代理",
   "settings.agentBehaviour.selectAgent": "選擇要設定的 Agent…",
   "settings.agentBehaviour.selectAgent.title": "Agent",
   "settings.agentBehaviour.selectAgent.description": "選擇要設定的 Agent…",

--- a/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
@@ -47,8 +47,8 @@ export const AgentBehaviourAgents: Story = {
       agents: () => [
         { name: "code", description: "General-purpose coding agent", mode: "primary" },
         { name: "debug", description: "Diagnose and fix bugs", mode: "primary" },
-        { name: "architect", description: "Design systems and plan features", mode: "secondary" },
-        { name: "review", description: "Review code for issues and improvements", mode: "secondary" },
+        { name: "architect", description: "Design systems and plan features", mode: "all" },
+        { name: "review", description: "Review code for issues and improvements", mode: "subagent" },
       ],
     }
     return (

--- a/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
@@ -4,9 +4,11 @@
  */
 
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
-import { StoryProviders } from "./StoryProviders"
+import { StoryProviders, mockSessionValue } from "./StoryProviders"
+import { SessionContext } from "../context/session"
 import Settings from "../components/settings/Settings"
 import ProvidersTab from "../components/settings/ProvidersTab"
+import AgentBehaviourTab from "../components/settings/AgentBehaviourTab"
 
 const meta: Meta = {
   title: "Settings",
@@ -35,4 +37,28 @@ export const ProvidersConfigure: Story = {
       </div>
     </StoryProviders>
   ),
+}
+
+export const AgentBehaviourAgents: Story = {
+  name: "AgentBehaviourTab — available agents list",
+  render: () => {
+    const session = {
+      ...mockSessionValue({ id: "agents-story", status: "idle" }),
+      agents: () => [
+        { name: "code", description: "General-purpose coding agent", mode: "primary" },
+        { name: "debug", description: "Diagnose and fix bugs", mode: "primary" },
+        { name: "architect", description: "Design systems and plan features", mode: "secondary" },
+        { name: "review", description: "Review code for issues and improvements", mode: "secondary" },
+      ],
+    }
+    return (
+      <StoryProviders sessionID="agents-story" status="idle">
+        <SessionContext.Provider value={session as any}>
+          <div style={{ width: "420px", "max-height": "700px", overflow: "auto" }}>
+            <AgentBehaviourTab />
+          </div>
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
 }


### PR DESCRIPTION
## Summary
- Adds a visible "Available Agents" list to the Agent Behaviour settings tab
- Shows all agents (built-in and marketplace-installed) with name, description, and mode badge
- Clicking an agent selects it for configuration, replacing the dropdown-only UX that made marketplace-installed modes hard to discover
- Translations added for all 16 locales
