### PR TITLE
fix: show "return to Kilo" in OAuth success page

### DIFF
--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -6,7 +6,7 @@ const log = Log.create({ service: "mcp.oauth-callback" })
 const HTML_SUCCESS = `<!DOCTYPE html>
 <html>
 <head>
-  <title>OpenCode - Authorization Successful</title>
+  <title>Kilo - Authorization Successful</title>
   <style>
     body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
     .container { text-align: center; padding: 2rem; }
@@ -17,7 +17,7 @@ const HTML_SUCCESS = `<!DOCTYPE html>
 <body>
   <div class="container">
     <h1>Authorization Successful</h1>
-    <p>You can close this window and return to OpenCode.</p>
+    <p>You can close this window and return to Kilo.</p>
   </div>
   <script>setTimeout(() => window.close(), 2000);</script>
 </body>

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -176,7 +176,7 @@ const HTML_SUCCESS = `<!doctype html>
   <body>
     <div class="container">
       <h1>Authorization Successful</h1>
-      <p>You can close this window and return to OpenCode.</p>
+      <p>You can close this window and return to Kilo.</p>
     </div>
     <script>
       setTimeout(() => window.close(), 2000)


### PR DESCRIPTION
## Summary

- Replace \"return to OpenCode\" with \"return to Kilo\" in the OAuth authorization success page
- Fixes both the MCP OAuth callback (`src/mcp/oauth-callback.ts`) and the Codex plugin auth flow (`src/plugin/codex.ts`)
- Also updates the page `<title>` tag in the MCP callback from \"OpenCode - Authorization Successful\" to \"Kilo - Authorization Successful\"