### PR TITLE
feat(kilo-docs): add PostHog reverse proxy via Next.js rewrites

### DIFF
--- a/packages/kilo-docs/.env.docs.sample
+++ b/packages/kilo-docs/.env.docs.sample
@@ -3,4 +3,4 @@ NEXT_PUBLIC_ALGOLIA_API_KEY=zyz6789
 NEXT_PUBLIC_ALGOLIA_INDEX_NAME="Kilo Code Docs"
 NEXT_PUBLIC_ALGOLIA_ASSISTANT_ID=foo-bar
 NEXT_PUBLIC_POSTHOG_KEY=phc_QWERTY
-NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+# NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com  # no longer needed; proxy via /ingest rewrites

--- a/packages/kilo-docs/.env.docs.sample
+++ b/packages/kilo-docs/.env.docs.sample
@@ -3,4 +3,3 @@ NEXT_PUBLIC_ALGOLIA_API_KEY=zyz6789
 NEXT_PUBLIC_ALGOLIA_INDEX_NAME="Kilo Code Docs"
 NEXT_PUBLIC_ALGOLIA_ASSISTANT_ID=foo-bar
 NEXT_PUBLIC_POSTHOG_KEY=phc_QWERTY
-# NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com  # no longer needed; proxy via /ingest rewrites

--- a/packages/kilo-docs/instrumentation-client.ts
+++ b/packages/kilo-docs/instrumentation-client.ts
@@ -2,7 +2,8 @@ import posthog from "posthog-js"
 
 if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    api_host: "/ingest",
+    ui_host: "https://us.posthog.com",
     person_profiles: "identified_only",
     capture_pageview: false, // Handled manually in _app.tsx on routeChangeComplete
     capture_pageleave: true,

--- a/packages/kilo-docs/next.config.js
+++ b/packages/kilo-docs/next.config.js
@@ -5,6 +5,7 @@ module.exports = withMarkdoc(/* config: https://markdoc.io/docs/nextjs#options *
   pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdoc"],
   basePath: "/docs",
   turbopack: {},
+  skipTrailingSlashRedirect: true,
   async redirects() {
     return [
       {
@@ -29,6 +30,11 @@ module.exports = withMarkdoc(/* config: https://markdoc.io/docs/nextjs#options *
           source: "/llms.txt",
           destination: "/api/llms.txt",
         },
+      ],
+      afterFiles: [
+        { source: "/ingest/static/:path*", destination: "https://us-assets.i.posthog.com/static/:path*" },
+        { source: "/ingest/decide",        destination: "https://us.i.posthog.com/decide" },
+        { source: "/ingest/:path*",        destination: "https://us.i.posthog.com/:path*" },
       ],
     }
   },

--- a/packages/kilo-docs/next.config.js
+++ b/packages/kilo-docs/next.config.js
@@ -5,7 +5,7 @@ module.exports = withMarkdoc(/* config: https://markdoc.io/docs/nextjs#options *
   pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdoc"],
   basePath: "/docs",
   turbopack: {},
-  skipTrailingSlashRedirect: true,
+  skipTrailingSlashRedirect: true, // PostHog sends trailing-slash requests that Next.js would otherwise 308-redirect
   async redirects() {
     return [
       {
@@ -34,7 +34,7 @@ module.exports = withMarkdoc(/* config: https://markdoc.io/docs/nextjs#options *
       afterFiles: [
         { source: "/ingest/static/:path*", destination: "https://us-assets.i.posthog.com/static/:path*" },
         { source: "/ingest/decide",        destination: "https://us.i.posthog.com/decide" },
-        { source: "/ingest/:path*",        destination: "https://us.i.posthog.com/:path*" },
+        { source: "/ingest/:path*",        destination: "https://us.i.posthog.com/:path*" }, // catch-all must be last
       ],
     }
   },

--- a/packages/kilo-docs/next.config.js
+++ b/packages/kilo-docs/next.config.js
@@ -32,9 +32,9 @@ module.exports = withMarkdoc(/* config: https://markdoc.io/docs/nextjs#options *
         },
       ],
       afterFiles: [
-        { source: "/ingest/static/:path*", destination: "https://us-assets.i.posthog.com/static/:path*" },
-        { source: "/ingest/decide",        destination: "https://us.i.posthog.com/decide" },
-        { source: "/ingest/:path*",        destination: "https://us.i.posthog.com/:path*" }, // catch-all must be last
+        { source: "/ingest/static/:path*", destination: "https://us-assets.i.posthog.com/static/:path*", basePath: false },
+        { source: "/ingest/decide",        destination: "https://us.i.posthog.com/decide",               basePath: false },
+        { source: "/ingest/:path*",        destination: "https://us.i.posthog.com/:path*",               basePath: false }, // catch-all must be last
       ],
     }
   },


### PR DESCRIPTION
## Context

Adds a PostHog reverse proxy to `kilo-docs` so that browser-side analytics traffic is routed through the app's own domain (`/ingest/*`) rather than directly to `us.i.posthog.com`. This prevents ad-blockers and privacy extensions from silently dropping PostHog events, consistent with the pattern already used in `cloud` and `kilocode-landing`.

## Implementation

Three `afterFiles` rewrites are added to `packages/kilo-docs/next.config.js` with `basePath: false` (so they match at `/ingest/*` rather than `/docs/ingest/*`):
- `/ingest/static/:path*` → `https://us-assets.i.posthog.com/static/:path*` (PostHog JS bundle)
- `/ingest/decide` → `https://us.i.posthog.com/decide` (feature flag evaluation)
- `/ingest/:path*` → `https://us.i.posthog.com/:path*` (event capture catch-all)

The `/ingest/decide` rule is placed **before** the wildcard catch-all — this is intentional and more correct than the `cloud` reference where the decide rule is unreachable (listed after the wildcard). The `/decide` endpoint is used for feature flag evaluation; correct proxying of this endpoint is important.

`skipTrailingSlashRedirect: true` is added at the config root level, required because PostHog sends requests to paths with trailing slashes (e.g. `/e/`, `/batch/`) which Next.js would otherwise redirect away before the rewrite fires.

`instrumentation-client.ts` is updated to use `api_host: "/ingest"` (the local proxy path) and `ui_host: "https://us.posthog.com"` (so the PostHog toolbar still links to the correct dashboard). `NEXT_PUBLIC_POSTHOG_HOST` is removed from `.env.docs.sample` as it is no longer needed.

## Screenshots

| before | after |
| ------ | ----- |
| PostHog requests go directly to `us.i.posthog.com` | PostHog requests routed via `/ingest/*` on the docs domain |

## How to Test

- Run `kilo-docs` locally with `NEXT_PUBLIC_POSTHOG_KEY` set
- Open the browser DevTools Network tab and filter for `ingest`
- Navigate between pages — `$pageview` events should POST to `/ingest/e/` (same origin) rather than `us.i.posthog.com`
- Verify the PostHog `/decide` endpoint is called at `/ingest/decide` for feature flag evaluation

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->