### PR TITLE
fix: wrap long text in question option descriptions and mode descriptions

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1154,7 +1154,9 @@
 
 .mode-switcher-item-desc {
   font-size: 11px;
-  overflow-wrap: anywhere;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .mode-switcher-item:not(.selected) .mode-switcher-item-desc {

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1154,9 +1154,7 @@
 
 .mode-switcher-item-desc {
   font-size: 11px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .mode-switcher-item:not(.selected) .mode-switcher-item-desc {

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -1075,18 +1075,7 @@
     line-height: var(--line-height-large);
     color: var(--text-base);
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  [data-slot="question-option"][data-custom="true"] {
-    [data-slot="option-description"] {
-      overflow: visible;
-      text-overflow: clip;
-      white-space: normal;
-      overflow-wrap: anywhere;
-    }
+    overflow-wrap: anywhere;
   }
 
   [data-slot="question-custom"] {


### PR DESCRIPTION
## Context

Question option descriptions and mode switcher descriptions were being truncated with ellipsis (`text-overflow: ellipsis`) when they exceeded a single line. This caused important information to be hidden from users. The fix makes text wrap instead of truncate.

https://github.com/Kilo-Org/kilocode/issues/6988

## Implementation

- Removed `overflow: hidden`, `text-overflow: ellipsis`, and `white-space: nowrap` from `[data-slot="option-description"]` in `message-part.css`
- Also removed the special-case override for `[data-slot="question-option"][data-custom="true"]` that manually re-enabled wrapping for custom options — now all options wrap consistently


## Screenshots

<img width="1520" height="1046" alt="Screen Shot 2026-03-12 at 4 24 14 PM" src="https://github.com/user-attachments/assets/fc03a9b6-e721-4afd-881a-1e6cf468fbf5" />


## How to Test

- Open a chat and trigger a question with options that have long descriptions (e.g. use a mode with a long description or a custom question option)
- Verify that long descriptions wrap to multiple lines instead of being cut off with ellipsis

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->