### PR TITLE
fix(vscode): improve mode switcher item sizing and description overflow

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -48,6 +48,7 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
     <Show when={hasAgents()}>
       <Popover
         placement="top-start"
+        fitViewport
         open={open()}
         onOpenChange={setOpen}
         triggerAs={Button}

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1133,7 +1133,7 @@
   gap: 2px;
   padding: 8px 12px;
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--vscode-font-size);
 }
 
 .mode-switcher-item:hover {
@@ -1154,12 +1154,6 @@
 
 .mode-switcher-item-desc {
   font-size: 11px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.mode-switcher-item:not(.selected) .mode-switcher-item-desc {
   color: var(--text-weak, var(--vscode-descriptionForeground));
 }
 

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1157,6 +1157,10 @@
   color: var(--text-weak, var(--vscode-descriptionForeground));
 }
 
+.mode-switcher-item.selected .mode-switcher-item-desc {
+  color: inherit;
+}
+
 /* ============================================
    Permission Dock (VS Code overrides)
    ============================================ */

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1123,7 +1123,7 @@
 }
 
 .mode-switcher-list {
-  max-height: 280px;
+  max-height: var(--kb-popper-content-available-height, 280px);
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Context

The mode switcher item (`.mode-switcher-item`) had a hardcoded `font-size: 12px` which made the item name feel too small. Additionally, the description text had `overflow: hidden` / `text-overflow: ellipsis` / `white-space: nowrap` which was clipping the description text.

## Implementation

- Replaced hardcoded `font-size: 12px` on `.mode-switcher-item` with `var(--vscode-font-size)` so the item name respects the user's VS Code editor font size setting (typically 13px by default) — no longer hardcoded, uses the standard VS Code style token
- Removed `overflow: hidden`, `text-overflow: ellipsis`, and `white-space: nowrap` from `.mode-switcher-item-desc` to fix description text being cut off
- Removed the now-redundant `.mode-switcher-item:not(.selected) .mode-switcher-item-desc` rule

## Screenshots

### Before
<img width="558" height="517" alt="before" src="https://github.com/user-attachments/assets/d8538d0a-c872-4ce7-b2b9-dc08ddee3486" />

### After

<img width="615" height="525" alt="after" src="https://github.com/user-attachments/assets/c4a74cbb-96ac-4b1a-b1e9-0e5d0929b250" />

<img width="608" height="476" alt="after-dark" src="https://github.com/user-attachments/assets/b6b8e528-4954-4dc1-accc-e46a3711411a" />


## How to Test

- Open the mode switcher in the Kilo sidebar
- Verify the item name is slightly larger and matches the VS Code editor font size
- Verify the mode description text is no longer truncated/clipped with an ellipsis