### PR TITLE
fix(mcp-migrator): handle malformed JSON in legacy .kilocode/mcp.json

### DIFF
--- a/packages/opencode/src/kilocode/mcp-migrator.ts
+++ b/packages/opencode/src/kilocode/mcp-migrator.ts
@@ -41,8 +41,13 @@ export namespace McpMigrator {
   export async function readMcpSettings(filepath: string): Promise<KilocodeMcpSettings | null> {
     if (!(await Filesystem.exists(filepath))) return null
 
-    const content = await fs.readFile(filepath, "utf-8")
-    return JSON.parse(content) as KilocodeMcpSettings
+    try {
+      const content = await fs.readFile(filepath, "utf-8")
+      return JSON.parse(content) as KilocodeMcpSettings
+    } catch (err) {
+      log.warn("failed to parse MCP settings file, skipping", { filepath, error: err })
+      return null
+    }
   }
 
   export function convertServer(name: string, server: KilocodeMcpServer): Config.Mcp | null {

--- a/packages/opencode/test/kilocode/mcp-migrator.test.ts
+++ b/packages/opencode/test/kilocode/mcp-migrator.test.ts
@@ -125,6 +125,18 @@ describe("McpMigrator", () => {
       expect(result?.mcpServers.filesystem.args).toEqual(["-y", "@modelcontextprotocol/server-filesystem"])
     })
 
+    test("returns null for malformed JSON file instead of throwing", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await Bun.write(path.join(dir, "mcp_settings.json"), "{ not valid json !!!")
+        },
+      })
+
+      const result = await McpMigrator.readMcpSettings(path.join(tmp.path, "mcp_settings.json"))
+
+      expect(result).toBeNull()
+    })
+
     test("reads file with multiple servers", async () => {
       await using tmp = await tmpdir({
         init: async (dir) => {
@@ -218,6 +230,34 @@ describe("McpMigrator", () => {
       expect(result.mcp.legacy).toEqual({
         type: "local",
         command: ["node", "legacy-server.js"],
+      })
+    })
+
+    // Regression: malformed .kilocode/mcp.json must not prevent .kilo/mcp.json from loading
+    test("loads .kilo/mcp.json even when .kilocode/mcp.json is malformed", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await Bun.write(path.join(dir, ".kilocode", "mcp.json"), "{ corrupt json !!!")
+          await Bun.write(
+            path.join(dir, ".kilo", "mcp.json"),
+            JSON.stringify({
+              mcpServers: {
+                valid: { command: "valid-cmd", args: ["--ok"] },
+              },
+            }),
+          )
+        },
+      })
+
+      const result = await McpMigrator.migrate({
+        projectDir: tmp.path,
+        skipGlobalPaths: true,
+      })
+
+      expect(result.mcp).toHaveProperty("valid")
+      expect(result.mcp.valid).toEqual({
+        type: "local",
+        command: ["valid-cmd", "--ok"],
       })
     })
 


### PR DESCRIPTION
## What's wrong

`readMcpSettings()` calls `JSON.parse()` without a try/catch. In `migrate()`, the function iterates over `[".kilocode", ".kilo"]` directories to load MCP config with a "later wins" precedence strategy. If `.kilocode/mcp.json` exists but contains malformed JSON, the uncaught `SyntaxError` propagates out of the loop, and `.kilo/mcp.json` is never read.

The outer `loadMcpConfig()` catches the error and returns `{}` — silently losing all valid MCP server configuration from `.kilo/mcp.json`.

**Scenario:** User has a stale/corrupt `.kilocode/mcp.json` leftover from a previous install, and a perfectly valid `.kilo/mcp.json`. Their MCP servers silently fail to load.

## The fix

Wrap the file read + JSON parse in `readMcpSettings()` with a try/catch. On parse failure, log a warning with the filepath and error, then return `null` so the migration loop continues to the next directory.

This is the minimal, correct fix — the function already returns `null` for non-existent files, so returning `null` for unparseable files is consistent.

## Tests

Two regression tests added:

1. **Unit test** (`readMcpSettings`): Verifies that a malformed JSON file returns `null` instead of throwing
2. **Integration test** (`migrate`): Writes malformed JSON to `.kilocode/mcp.json` and valid config to `.kilo/mcp.json`, then verifies `migrate()` successfully returns the valid `.kilo` config

Both tests fail without the fix and pass with it.

Found during automated review of #6881. cc @marius-kilocode