### PR TITLE
fix(vscode): restore Agent Manager panel on VS Code restart

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -44,7 +44,9 @@
     "Kilo Code",
     "kilocode"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onWebviewPanel:kilo-code.new.AgentManagerPanel"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "viewsContainers": {

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -133,6 +133,13 @@ export class AgentManagerProvider implements vscode.Disposable {
   private attachPanel(panel: vscode.WebviewPanel): void {
     this.panel = panel
 
+    // Reapply options — required for deserialized panels where enableScripts
+    // and localResourceRoots are not carried over from the original creation.
+    panel.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [this.extensionUri],
+    }
+
     panel.iconPath = {
       light: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-light.svg"),
       dark: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-dark.svg"),

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -109,7 +109,7 @@ export class AgentManagerProvider implements vscode.Disposable {
     this.log("Opening Agent Manager panel")
     TelemetryProxy.capture(TelemetryEventName.AGENT_MANAGER_OPENED, { source: PLATFORM })
 
-    this.panel = vscode.window.createWebviewPanel(
+    const panel = vscode.window.createWebviewPanel(
       AgentManagerProvider.viewType,
       "Agent Manager",
       vscode.ViewColumn.One,
@@ -120,15 +120,28 @@ export class AgentManagerProvider implements vscode.Disposable {
       },
     )
 
-    this.panel.iconPath = {
+    this.attachPanel(panel)
+  }
+
+  /** Restore the Agent Manager panel from a previously serialized state (VS Code restart). */
+  public deserializeWebviewPanel(panel: vscode.WebviewPanel): void {
+    this.log("Deserializing Agent Manager panel")
+    this.attachPanel(panel)
+  }
+
+  /** Wire up a webview panel (shared by openPanel and deserializeWebviewPanel). */
+  private attachPanel(panel: vscode.WebviewPanel): void {
+    this.panel = panel
+
+    panel.iconPath = {
       light: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-light.svg"),
       dark: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-dark.svg"),
     }
 
-    this.panel.webview.html = this.getHtml(this.panel.webview)
+    panel.webview.html = this.getHtml(panel.webview)
 
     this.provider = new KiloProvider(this.extensionUri, this.connectionService)
-    this.provider.attachToWebview(this.panel.webview, {
+    this.provider.attachToWebview(panel.webview, {
       onBeforeMessage: (msg) => this.onMessage(msg),
     })
 
@@ -136,7 +149,7 @@ export class AgentManagerProvider implements vscode.Disposable {
     void this.sendRepoInfo()
     this.sendKeybindings()
 
-    this.panel.onDidDispose(() => {
+    panel.onDidDispose(() => {
       this.log("Panel disposed")
       this.statsPoller.stop()
       this.stopDiffPolling()

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -50,6 +50,16 @@ export function activate(context: vscode.ExtensionContext) {
   const agentManagerProvider = new AgentManagerProvider(context.extensionUri, connectionService)
   context.subscriptions.push(agentManagerProvider)
 
+  // Register serializer so Agent Manager restores when VS Code restarts
+  context.subscriptions.push(
+    vscode.window.registerWebviewPanelSerializer(AgentManagerProvider.viewType, {
+      deserializeWebviewPanel(panel: vscode.WebviewPanel) {
+        agentManagerProvider.deserializeWebviewPanel(panel)
+        return Promise.resolve()
+      },
+    }),
+  )
+
   // Create standalone diff viewer provider for the sidebar "Show Changes" action
   const diffViewerProvider = new DiffViewerProvider(context.extensionUri, connectionService)
   diffViewerProvider.setCommentHandler((comments) => {


### PR DESCRIPTION
## Summary
- Register a `WebviewPanelSerializer` for the Agent Manager so VS Code automatically reopens the panel when the window is restored (previously only the sidebar was restored)
- Extract panel setup into a shared `attachPanel()` method used by both `openPanel()` and the new `deserializeWebviewPanel()` entry point
- Underlying worktree/session state was already persisted to `.kilo/agent-manager.json` — this change ensures the panel itself also survives restarts