### PR TITLE
feat(vscode): add fork session context menu to Agent Manager tabs

### DIFF
--- a/packages/kilo-vscode/AGENTS.md
+++ b/packages/kilo-vscode/AGENTS.md
@@ -211,6 +211,10 @@ Follow monorepo root AGENTS.md style guide:
 - Avoid `try`/`catch`, avoid `any` type
 - ESLint enforces: curly braces, strict equality, semicolons, camelCase/PascalCase imports
 
+## File Size Caps (maxLines)
+
+Large files in `src/agent-manager/` have `maxLines` caps enforced by `tests/unit/agent-manager-arch.test.ts`. **Do not raise these caps.** If adding a feature would exceed a cap, extract logic into a vscode-free helper module and call it from the provider. See `fork-session.ts` and `format-keybinding.ts` for examples of this pattern.
+
 ## Markdown Tables
 
 Do not pad markdown table cells for column alignment. Use `| content |` with single spaces, not `| content       |` with extra padding. Padding creates spurious diffs. Markdown files are excluded from prettier (via `.prettierignore`) to prevent auto-reformatting of tables.

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -214,6 +214,7 @@ export class AgentManagerProvider implements vscode.Disposable {
     if (m.type === "agentManager.removeStaleWorktree") return this.onRemoveStaleWorktree(m.worktreeId)
     if (m.type === "agentManager.promoteSession") return this.onPromoteSession(m.sessionId)
     if (m.type === "agentManager.addSessionToWorktree") return this.onAddSessionToWorktree(m.worktreeId)
+    if (m.type === "agentManager.forkSession") return this.onForkSession(m.sessionId, m.worktreeId)
     if (m.type === "agentManager.closeSession") return this.onCloseSession(m.sessionId)
     if (m.type === "agentManager.configureSetupScript") {
       void this.configureSetupScript()
@@ -770,6 +771,60 @@ export class AgentManagerProvider implements vscode.Disposable {
       worktreeId,
     })
     this.log(`Added session ${session.id} to worktree ${worktreeId}`)
+    return null
+  }
+
+  /** Fork an existing session, copying its conversation history via the CLI. */
+  private async onForkSession(sessionId: string, worktreeId?: string): Promise<null> {
+    let client: KiloClient
+    try {
+      client = this.connectionService.getClient()
+    } catch (err) {
+      this.log("onForkSession: client not available:", err)
+      this.postToWebview({ type: "error", message: "Not connected to CLI backend" })
+      return null
+    }
+
+    const state = this.getStateManager()
+    const directory = (() => {
+      if (!worktreeId || !state) return undefined
+      const worktree = state.getWorktree(worktreeId)
+      return worktree?.path
+    })()
+
+    let forked: Session
+    try {
+      const { data } = await client.session.fork({ sessionID: sessionId, directory }, { throwOnError: true })
+      forked = data
+    } catch (error) {
+      const err = getErrorMessage(error)
+      this.postToWebview({ type: "error", message: `Failed to fork session: ${err}` })
+      TelemetryProxy.capture(TelemetryEventName.AGENT_MANAGER_SESSION_ERROR, {
+        source: PLATFORM,
+        error: err,
+        context: "forkSession",
+        sessionId,
+      })
+      return null
+    }
+
+    if (worktreeId && state) {
+      state.addSession(forked.id, worktreeId)
+      if (directory) this.registerWorktreeSession(forked.id, directory)
+    }
+    this.pushState()
+    this.postToWebview({
+      type: "agentManager.sessionForked",
+      sessionId: forked.id,
+      forkedFromId: sessionId,
+      worktreeId,
+    })
+
+    if (this.provider) {
+      this.provider.registerSession(forked)
+    }
+
+    this.log(`Forked session ${sessionId} → ${forked.id}${worktreeId ? ` in worktree ${worktreeId}` : ""}`)
     return null
   }
 

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -19,6 +19,7 @@ import { SetupScriptRunner } from "./SetupScriptRunner"
 import { SessionTerminalManager } from "./SessionTerminalManager"
 import { createTerminalHost } from "./terminal-host"
 import { executeVscodeTask } from "./task-runner"
+import { forkSession } from "./fork-session"
 import { formatKeybinding } from "./format-keybinding"
 import { TelemetryProxy, TelemetryEventName } from "../services/telemetry"
 import { MAX_MULTI_VERSIONS } from "./constants"
@@ -774,58 +775,27 @@ export class AgentManagerProvider implements vscode.Disposable {
     return null
   }
 
-  /** Fork an existing session, copying its conversation history via the CLI. */
-  private async onForkSession(sessionId: string, worktreeId?: string): Promise<null> {
-    let client: KiloClient
-    try {
-      client = this.connectionService.getClient()
-    } catch (err) {
-      this.log("onForkSession: client not available:", err)
-      this.postToWebview({ type: "error", message: "Not connected to CLI backend" })
-      return null
-    }
-
-    const state = this.getStateManager()
-    const directory = (() => {
-      if (!worktreeId || !state) return undefined
-      const worktree = state.getWorktree(worktreeId)
-      return worktree?.path
-    })()
-
-    let forked: Session
-    try {
-      const { data } = await client.session.fork({ sessionID: sessionId, directory }, { throwOnError: true })
-      forked = data
-    } catch (error) {
-      const err = getErrorMessage(error)
-      this.postToWebview({ type: "error", message: `Failed to fork session: ${err}` })
-      TelemetryProxy.capture(TelemetryEventName.AGENT_MANAGER_SESSION_ERROR, {
-        source: PLATFORM,
-        error: err,
-        context: "forkSession",
-        sessionId,
-      })
-      return null
-    }
-
-    if (worktreeId && state) {
-      state.addSession(forked.id, worktreeId)
-      if (directory) this.registerWorktreeSession(forked.id, directory)
-    }
-    this.pushState()
-    this.postToWebview({
-      type: "agentManager.sessionForked",
-      sessionId: forked.id,
-      forkedFromId: sessionId,
+  private onForkSession(sessionId: string, worktreeId?: string) {
+    return forkSession(
+      {
+        getClient: () => this.connectionService.getClient(),
+        state: this.getStateManager(),
+        postError: (msg) => this.postToWebview({ type: "error", message: msg }),
+        registerWorktreeSession: (sid, dir) => this.registerWorktreeSession(sid, dir),
+        pushState: () => this.pushState(),
+        notifyForked: (s, from, wt) =>
+          this.postToWebview({
+            type: "agentManager.sessionForked",
+            sessionId: s.id,
+            forkedFromId: from,
+            worktreeId: wt,
+          }),
+        registerSession: (s) => this.provider?.registerSession(s),
+        log: (...args) => this.log(...args),
+      },
+      sessionId,
       worktreeId,
-    })
-
-    if (this.provider) {
-      this.provider.registerSession(forked)
-    }
-
-    this.log(`Forked session ${sessionId} → ${forked.id}${worktreeId ? ` in worktree ${worktreeId}` : ""}`)
-    return null
+    )
   }
 
   /** Close (remove) a session from its worktree. */

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -20,9 +20,9 @@ import { SessionTerminalManager } from "./SessionTerminalManager"
 import { createTerminalHost } from "./terminal-host"
 import { executeVscodeTask } from "./task-runner"
 import { forkSession } from "./fork-session"
-import { formatKeybinding } from "./format-keybinding"
+import { buildKeybindingMap } from "./format-keybinding"
 import { TelemetryProxy, TelemetryEventName } from "../services/telemetry"
-import { MAX_MULTI_VERSIONS } from "./constants"
+import { MAX_MULTI_VERSIONS, PLATFORM } from "./constants"
 import type { AgentManagerOutMessage, AgentManagerInMessage } from "./types"
 import { getWorkspaceRoot, hashFileDiffs, openFileInEditor, resolveLocalDiffTarget } from "../review-utils"
 
@@ -34,7 +34,6 @@ import { getWorkspaceRoot, hashFileDiffs, openFileInEditor, resolveLocalDiffTarg
  * sections: WORKTREES (top) with managed worktrees + their sessions, and
  * SESSIONS (bottom) with unassociated workspace sessions.
  */
-const PLATFORM = "agent-manager" as const
 const LOCAL_DIFF_ID = "local" as const
 
 export class AgentManagerProvider implements vscode.Disposable {
@@ -1353,36 +1352,7 @@ export class AgentManagerProvider implements vscode.Disposable {
     const ext = vscode.extensions.getExtension("kilocode.kilo-code")
     const keybindings: Array<{ command: string; key?: string; mac?: string }> =
       ext?.packageJSON?.contributes?.keybindings ?? []
-
-    const mac = process.platform === "darwin"
-    const prefix = "kilo-code.new.agentManager."
-    const bindings: Record<string, string> = {}
-
-    // Global keybindings exposed to the shortcuts dialog
-    const globals: Record<string, string> = {
-      "kilo-code.new.agentManagerOpen": "agentManagerOpen",
-    }
-
-    for (const kb of keybindings) {
-      const raw = mac ? (kb.mac ?? kb.key) : kb.key
-      if (!raw) continue
-
-      if (kb.command.startsWith(prefix)) {
-        bindings[kb.command.slice(prefix.length)] = formatKeybinding(raw, mac)
-      } else if (globals[kb.command]) {
-        bindings[globals[kb.command]] = formatKeybinding(raw, mac)
-      }
-    }
-
-    // Ensure toggleDiff binding is always present (may be missing from
-    // cached packageJSON if the extension hasn't been fully reloaded)
-    if (!bindings.toggleDiff) {
-      bindings.toggleDiff = formatKeybinding(mac ? "cmd+d" : "ctrl+d", mac)
-    }
-    if (!bindings.showShortcuts) {
-      bindings.showShortcuts = formatKeybinding(mac ? "cmd+shift+/" : "ctrl+shift+/", mac)
-    }
-
+    const bindings = buildKeybindingMap(keybindings, process.platform === "darwin")
     this.postToWebview({ type: "agentManager.keybindings", bindings })
   }
 

--- a/packages/kilo-vscode/src/agent-manager/constants.ts
+++ b/packages/kilo-vscode/src/agent-manager/constants.ts
@@ -10,6 +10,9 @@ import * as path from "node:path"
  */
 export const MAX_MULTI_VERSIONS = 4
 
+/** Telemetry source identifier for all Agent Manager events. */
+export const PLATFORM = "agent-manager" as const
+
 /** Kilo config directory name (project-level and inside worktrees). */
 export const KILO_DIR = ".kilo"
 

--- a/packages/kilo-vscode/src/agent-manager/fork-session.ts
+++ b/packages/kilo-vscode/src/agent-manager/fork-session.ts
@@ -1,0 +1,66 @@
+import type { KiloClient, Session } from "@kilocode/sdk/v2/client"
+import { getErrorMessage } from "../kilo-provider-utils"
+import { TelemetryProxy, TelemetryEventName } from "../services/telemetry"
+import type { WorktreeStateManager } from "./WorktreeStateManager"
+
+const PLATFORM = "agent-manager"
+
+export interface ForkContext {
+  getClient: () => KiloClient
+  state: WorktreeStateManager | undefined
+  postError: (message: string) => void
+  registerWorktreeSession: (sessionId: string, directory: string) => void
+  pushState: () => void
+  notifyForked: (session: Session, forkedFromId: string, worktreeId?: string) => void
+  registerSession: (session: Session) => void
+  log: (...args: unknown[]) => void
+}
+
+/**
+ * Fork a session via the CLI backend, register the new session in state,
+ * and notify the webview.
+ *
+ * Pure orchestration — no vscode imports.
+ */
+export async function forkSession(ctx: ForkContext, sessionId: string, worktreeId?: string): Promise<null> {
+  let client: KiloClient
+  try {
+    client = ctx.getClient()
+  } catch (err) {
+    ctx.log("forkSession: client not available:", err)
+    ctx.postError("Not connected to CLI backend")
+    return null
+  }
+
+  const directory = (() => {
+    if (!worktreeId || !ctx.state) return undefined
+    return ctx.state.getWorktree(worktreeId)?.path
+  })()
+
+  let forked: Session
+  try {
+    const { data } = await client.session.fork({ sessionID: sessionId, directory }, { throwOnError: true })
+    forked = data
+  } catch (error) {
+    const err = getErrorMessage(error)
+    ctx.postError(`Failed to fork session: ${err}`)
+    TelemetryProxy.capture(TelemetryEventName.AGENT_MANAGER_SESSION_ERROR, {
+      source: PLATFORM,
+      error: err,
+      context: "forkSession",
+      sessionId,
+    })
+    return null
+  }
+
+  if (worktreeId && ctx.state) {
+    ctx.state.addSession(forked.id, worktreeId)
+    if (directory) ctx.registerWorktreeSession(forked.id, directory)
+  }
+
+  ctx.pushState()
+  ctx.notifyForked(forked, sessionId, worktreeId)
+  ctx.registerSession(forked)
+  ctx.log(`Forked session ${sessionId} → ${forked.id}${worktreeId ? ` in worktree ${worktreeId}` : ""}`)
+  return null
+}

--- a/packages/kilo-vscode/src/agent-manager/fork-session.ts
+++ b/packages/kilo-vscode/src/agent-manager/fork-session.ts
@@ -2,8 +2,7 @@ import type { KiloClient, Session } from "@kilocode/sdk/v2/client"
 import { getErrorMessage } from "../kilo-provider-utils"
 import { TelemetryProxy, TelemetryEventName } from "../services/telemetry"
 import type { WorktreeStateManager } from "./WorktreeStateManager"
-
-const PLATFORM = "agent-manager"
+import { PLATFORM } from "./constants"
 
 export interface ForkContext {
   getClient: () => KiloClient

--- a/packages/kilo-vscode/src/agent-manager/format-keybinding.ts
+++ b/packages/kilo-vscode/src/agent-manager/format-keybinding.ts
@@ -32,3 +32,40 @@ export function formatKeybinding(raw: string, mac: boolean): string {
     })
   return mac ? symbols.join("") : symbols.join("+")
 }
+
+/** Agent Manager command prefix for keybinding extraction. */
+const AM_PREFIX = "kilo-code.new.agentManager."
+
+/** Global commands whose keybindings are forwarded to the webview. */
+const GLOBAL_KEYBINDINGS: Record<string, string> = {
+  "kilo-code.new.agentManagerOpen": "agentManagerOpen",
+}
+
+/**
+ * Build a keybinding map from VS Code's raw `contributes.keybindings` array.
+ * Returns a record of action name → formatted shortcut string.
+ */
+export function buildKeybindingMap(
+  keybindings: Array<{ command: string; key?: string; mac?: string }>,
+  mac: boolean,
+): Record<string, string> {
+  const bindings: Record<string, string> = {}
+
+  for (const kb of keybindings) {
+    const raw = mac ? (kb.mac ?? kb.key) : kb.key
+    if (!raw) continue
+
+    if (kb.command.startsWith(AM_PREFIX)) {
+      bindings[kb.command.slice(AM_PREFIX.length)] = formatKeybinding(raw, mac)
+    } else if (GLOBAL_KEYBINDINGS[kb.command]) {
+      bindings[GLOBAL_KEYBINDINGS[kb.command]] = formatKeybinding(raw, mac)
+    }
+  }
+
+  // Ensure fallback bindings are always present (may be missing from
+  // cached packageJSON if the extension hasn't been fully reloaded)
+  if (!bindings.toggleDiff) bindings.toggleDiff = formatKeybinding(mac ? "cmd+d" : "ctrl+d", mac)
+  if (!bindings.showShortcuts) bindings.showShortcuts = formatKeybinding(mac ? "cmd+shift+/" : "ctrl+shift+/", mac)
+
+  return bindings
+}

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -85,6 +85,13 @@ interface SessionAddedMessage {
   worktreeId: string
 }
 
+interface SessionForkedMessage {
+  type: "agentManager.sessionForked"
+  sessionId: string
+  forkedFromId: string
+  worktreeId?: string
+}
+
 interface MultiVersionProgressMessage {
   type: "agentManager.multiVersionProgress"
   status: "creating" | "done"
@@ -181,6 +188,7 @@ export type AgentManagerOutMessage =
   | StateMessage
   | ErrorOutMessage
   | SessionAddedMessage
+  | SessionForkedMessage
   | MultiVersionProgressMessage
   | SetSessionModelMessage
   | SendInitialMessage
@@ -380,6 +388,12 @@ interface ClearSessionIn {
   type: "clearSession"
 }
 
+interface ForkSessionIn {
+  type: "agentManager.forkSession"
+  sessionId: string
+  worktreeId?: string
+}
+
 interface AbortIn {
   type: "abort"
   sessionID: string
@@ -393,6 +407,7 @@ export type AgentManagerInMessage =
   | PromoteSessionIn
   | AddSessionToWorktreeIn
   | CloseSessionIn
+  | ForkSessionIn
   | ConfigureSetupScriptIn
   | ShowTerminalIn
   | ShowLocalTerminalIn

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -493,11 +493,17 @@ const AGENT_MANAGER_DIR = path.join(ROOT, "src/agent-manager")
  *
  * When you extract code out of one of these files, lower its maxLines to
  * the new line count rounded up to the nearest 50.
+ *
+ * DO NOT raise maxLines to accommodate new code. If adding a feature would
+ * exceed the cap, extract logic into a vscode-free helper module and have
+ * the provider call it. Only raise the cap as a last resort when the code
+ * is structurally impossible to extract (e.g. deep vscode API interleaving)
+ * — and document the reason in the entry's `note` field.
  */
 const VSCODE_ALLOWED: Record<string, { maxLines: number; note: string }> = {
   // God class — decompose into WorktreeOrchestrator, DiffManager, ApplyManager, etc.
   "AgentManagerProvider.ts": {
-    maxLines: 2000,
+    maxLines: 1900,
     note: "primary extraction target: break into vscode-free orchestrators",
   },
   // Thin adapter: wraps vscode.window terminal APIs behind TerminalHost interface
@@ -544,13 +550,16 @@ describe("Agent Manager — VS Code import boundary", () => {
       const filepath = path.join(AGENT_MANAGER_DIR, file)
       if (!fs.existsSync(filepath)) continue
       const lines = fs.readFileSync(filepath, "utf-8").split("\n").length
-      if (lines > maxLines) overweight.push(`${file}: ${lines} lines (maxLines: ${maxLines})`)
+      if (lines > maxLines) overweight.push(`${file}: ${lines} lines (cap: ${maxLines})`)
     }
     expect(
       overweight,
-      `These VS Code integration files exceed their maxLines cap.\n` +
-        `Extract business logic into vscode-free modules and lower maxLines:\n` +
-        overweight.map((o) => `  - ${o}`).join("\n"),
+      `File too large — needs better modularization.\n\n` +
+        overweight.map((o) => `  ${o}`).join("\n") +
+        `\n\n` +
+        `Do NOT raise maxLines. Instead, extract logic into a vscode-free\n` +
+        `helper module and call it from the provider. See fork-session.ts\n` +
+        `for an example of this pattern.`,
     ).toEqual([])
   })
 

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -172,6 +172,7 @@ describe("Agent Manager Provider — onMessage routing", () => {
       "agentManager.deleteWorktree",
       "agentManager.promoteSession",
       "agentManager.addSessionToWorktree",
+      "agentManager.forkSession",
       "agentManager.closeSession",
       "agentManager.configureSetupScript",
       "agentManager.showTerminal",
@@ -496,7 +497,7 @@ const AGENT_MANAGER_DIR = path.join(ROOT, "src/agent-manager")
 const VSCODE_ALLOWED: Record<string, { maxLines: number; note: string }> = {
   // God class — decompose into WorktreeOrchestrator, DiffManager, ApplyManager, etc.
   "AgentManagerProvider.ts": {
-    maxLines: 1900,
+    maxLines: 1950,
     note: "primary extraction target: break into vscode-free orchestrators",
   },
   // Thin adapter: wraps vscode.window terminal APIs behind TerminalHost interface

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -497,7 +497,7 @@ const AGENT_MANAGER_DIR = path.join(ROOT, "src/agent-manager")
 const VSCODE_ALLOWED: Record<string, { maxLines: number; note: string }> = {
   // God class — decompose into WorktreeOrchestrator, DiffManager, ApplyManager, etc.
   "AgentManagerProvider.ts": {
-    maxLines: 1950,
+    maxLines: 2000,
     note: "primary extraction target: break into vscode-free orchestrators",
   },
   // Thin adapter: wraps vscode.window terminal APIs behind TerminalHost interface

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1106,6 +1106,19 @@ const AgentManagerContent: Component = () => {
         session.selectSession(ev.sessionId)
       }
 
+      if (msg.type === "agentManager.sessionForked") {
+        const ev = msg as { type: string; sessionId: string; forkedFromId: string; worktreeId?: string }
+        if (!ev.worktreeId) {
+          // Local session: insert new tab after the forked-from tab
+          setLocalSessionIDs((prev) => {
+            const idx = prev.indexOf(ev.forkedFromId)
+            if (idx >= 0) return [...prev.slice(0, idx + 1), ev.sessionId, ...prev.slice(idx + 1)]
+            return [...prev, ev.sessionId]
+          })
+        }
+        session.selectSession(ev.sessionId)
+      }
+
       if (msg.type === "agentManager.keybindings") {
         const ev = msg as AgentManagerKeybindingsMessage
         setKb(ev.bindings)
@@ -1725,8 +1738,16 @@ const AgentManagerContent: Component = () => {
     }
   }
 
-  const handleCloseTab = (sessionId: string, e: MouseEvent) => {
-    e.stopPropagation()
+  const handleForkSession = (sessionId: string) => {
+    const sel = selection()
+    if (sel === LOCAL) {
+      vscode.postMessage({ type: "agentManager.forkSession", sessionId })
+    } else if (sel) {
+      vscode.postMessage({ type: "agentManager.forkSession", sessionId, worktreeId: sel })
+    }
+  }
+
+  const handleCloseTab = (sessionId: string) => {
     const pending = isPending(sessionId)
     const isActive = pending ? sessionId === activePendingId() : session.currentSessionID() === sessionId
     if (isActive) {
@@ -1756,7 +1777,7 @@ const AgentManagerContent: Component = () => {
   const handleTabMouseDown = (sessionId: string, e: MouseEvent) => {
     if (e.button === 1) {
       e.preventDefault()
-      handleCloseTab(sessionId, e)
+      handleCloseTab(sessionId)
     }
   }
 
@@ -1854,8 +1875,7 @@ const AgentManagerContent: Component = () => {
         ? tabs.find((s) => s.id === pending)
         : undefined
     if (!target) return
-    const synthetic = new MouseEvent("click")
-    handleCloseTab(target.id, synthetic)
+    handleCloseTab(target.id)
   }
 
   // Cmd+T: add a new tab strictly to the current selection (no side effects)
@@ -2310,7 +2330,8 @@ const AgentManagerContent: Component = () => {
                               session.selectSession(s.id)
                             }}
                             onMiddleClick={(e: MouseEvent) => handleTabMouseDown(s.id, e)}
-                            onClose={(e: MouseEvent) => handleCloseTab(s.id, e)}
+                            onClose={() => handleCloseTab(s.id)}
+                            onFork={pending ? undefined : () => handleForkSession(s.id)}
                           />
                         )
                       }}

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "لا توجد جلسات مفتوحة",
   "agentManager.tab.close": "إغلاق",
   "agentManager.tab.closeTab": "إغلاق علامة التبويب",
+  "agentManager.tab.forkSession": "تفريع الجلسة",
   "agentManager.tab.terminal": "الطرفية",
   "agentManager.tab.openTerminal": "فتح الطرفية",
   "agentManager.setup.failed": "فشل إعداد مساحة العمل",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "Nenhuma sessão aberta",
   "agentManager.tab.close": "Fechar",
   "agentManager.tab.closeTab": "Fechar aba",
+  "agentManager.tab.forkSession": "Bifurcar sessão",
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Abrir Terminal",
   "agentManager.setup.failed": "Falha na configuração do workspace",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "Nema otvorenih sesija",
   "agentManager.tab.close": "Zatvori",
   "agentManager.tab.closeTab": "Zatvori karticu",
+  "agentManager.tab.forkSession": "Razdvoji sesiju",
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Otvori Terminal",
   "agentManager.setup.failed": "Postavljanje radnog prostora neuspješno",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "Ingen åbne sessioner",
   "agentManager.tab.close": "Luk",
   "agentManager.tab.closeTab": "Luk fane",
+  "agentManager.tab.forkSession": "Forgren session",
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Åbn Terminal",
   "agentManager.setup.failed": "Opsætning af workspace mislykkedes",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "Keine Sitzungen geöffnet",
   "agentManager.tab.close": "Schließen",
   "agentManager.tab.closeTab": "Tab schließen",
+  "agentManager.tab.forkSession": "Sitzung verzweigen",
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Terminal öffnen",
   "agentManager.setup.failed": "Einrichtung des Arbeitsbereichs fehlgeschlagen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -34,6 +34,7 @@ export const dict = {
 
   "agentManager.tab.close": "Close",
   "agentManager.tab.closeTab": "Close tab",
+  "agentManager.tab.forkSession": "Fork Session",
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Open Terminal",
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "No hay sesiones abiertas",
   "agentManager.tab.close": "Cerrar",
   "agentManager.tab.closeTab": "Cerrar pestaña",
+  "agentManager.tab.forkSession": "Bifurcar sesión",
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Abrir Terminal",
   "agentManager.setup.failed": "Error en la configuración del workspace",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "Aucune session ouverte",
   "agentManager.tab.close": "Fermer",
   "agentManager.tab.closeTab": "Fermer l'onglet",
+  "agentManager.tab.forkSession": "Dupliquer la session",
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Ouvrir le Terminal",
   "agentManager.setup.failed": "Échec de la configuration de l'espace de travail",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "開いているセッションがありません",
   "agentManager.tab.close": "閉じる",
   "agentManager.tab.closeTab": "タブを閉じる",
+  "agentManager.tab.forkSession": "セッションをフォーク",
   "agentManager.tab.terminal": "ターミナル",
   "agentManager.tab.openTerminal": "ターミナルを開く",
   "agentManager.setup.failed": "ワークスペースのセットアップに失敗しました",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "열린 세션 없음",
   "agentManager.tab.close": "닫기",
   "agentManager.tab.closeTab": "탭 닫기",
+  "agentManager.tab.forkSession": "세션 포크",
   "agentManager.tab.terminal": "터미널",
   "agentManager.tab.openTerminal": "터미널 열기",
   "agentManager.setup.failed": "워크스페이스 설정 실패",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "Ingen åpne økter",
   "agentManager.tab.close": "Lukk",
   "agentManager.tab.closeTab": "Lukk fane",
+  "agentManager.tab.forkSession": "Forgrein økt",
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Åpne Terminal",
   "agentManager.setup.failed": "Oppsett av arbeidsområde mislyktes",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "Brak otwartych sesji",
   "agentManager.tab.close": "Zamknij",
   "agentManager.tab.closeTab": "Zamknij kartę",
+  "agentManager.tab.forkSession": "Rozgałęź sesję",
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Otwórz Terminal",
   "agentManager.setup.failed": "Konfiguracja workspace nie powiodła się",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "Нет открытых сессий",
   "agentManager.tab.close": "Закрыть",
   "agentManager.tab.closeTab": "Закрыть вкладку",
+  "agentManager.tab.forkSession": "Ответвить сессию",
   "agentManager.tab.terminal": "Терминал",
   "agentManager.tab.openTerminal": "Открыть терминал",
   "agentManager.setup.failed": "Не удалось настроить рабочее пространство",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "ไม่มีเซสชันที่เปิดอยู่",
   "agentManager.tab.close": "ปิด",
   "agentManager.tab.closeTab": "ปิดแท็บ",
+  "agentManager.tab.forkSession": "แยกเซสชัน",
   "agentManager.tab.terminal": "เทอร์มินัล",
   "agentManager.tab.openTerminal": "เปิดเทอร์มินัล",
   "agentManager.setup.failed": "ตั้งค่า Workspace ล้มเหลว",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "没有打开的会话",
   "agentManager.tab.close": "关闭",
   "agentManager.tab.closeTab": "关闭标签页",
+  "agentManager.tab.forkSession": "复制会话",
   "agentManager.tab.terminal": "终端",
   "agentManager.tab.openTerminal": "打开终端",
   "agentManager.setup.failed": "工作区设置失败",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -30,6 +30,7 @@ export const dict = {
   "agentManager.session.noSessions": "沒有開啟的工作階段",
   "agentManager.tab.close": "關閉",
   "agentManager.tab.closeTab": "關閉分頁",
+  "agentManager.tab.forkSession": "複製工作階段",
   "agentManager.tab.terminal": "終端機",
   "agentManager.tab.openTerminal": "開啟終端機",
   "agentManager.setup.failed": "工作區設定失敗",

--- a/packages/kilo-vscode/webview-ui/agent-manager/sortable-tab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/sortable-tab.tsx
@@ -10,7 +10,7 @@ declare module "solid-js" {
   }
 }
 
-import { Component, onCleanup } from "solid-js"
+import { Component, onCleanup, Show } from "solid-js"
 import { createSortable, useDragDropContext } from "@thisbeyond/solid-dnd"
 import type { Transformer } from "@thisbeyond/solid-dnd"
 import { createRoot } from "solid-js"
@@ -18,6 +18,7 @@ import type { SessionInfo } from "../src/types/messages"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
+import { ContextMenu } from "@kilocode/kilo-ui/context-menu"
 import { useLanguage } from "../src/context/language"
 
 /** Lock drag movement to the X axis (horizontal-only tab dragging). */
@@ -47,7 +48,8 @@ export const SortableTab: Component<{
   closeKeybind?: string
   onSelect: () => void
   onMiddleClick: (e: MouseEvent) => void
-  onClose: (e: MouseEvent) => void
+  onClose: () => void
+  onFork?: () => void
 }> = (props) => {
   const { t } = useLanguage()
   const sortable = createSortable(props.tab.id)
@@ -59,30 +61,52 @@ export const SortableTab: Component<{
       class={`am-tab-sortable ${sortable.isActiveDraggable ? "am-tab-dragging" : ""}`}
       data-tab-id={props.tab.id}
     >
-      <TooltipKeybind
-        title={props.tab.title || t("agentManager.session.untitled")}
-        keybind={props.keybind ?? ""}
-        placement="bottom"
-        inactive={props.active}
-      >
-        <div
-          class={`am-tab ${props.active ? "am-tab-active" : ""}`}
-          onClick={props.onSelect}
-          onMouseDown={props.onMiddleClick}
-        >
-          <span class="am-tab-label">{props.tab.title || t("agentManager.session.untitled")}</span>
-          <TooltipKeybind title={t("agentManager.tab.close")} keybind={props.closeKeybind ?? ""} placement="bottom">
-            <IconButton
-              icon="close-small"
-              size="small"
-              variant="ghost"
-              label={t("agentManager.tab.closeTab")}
-              class="am-tab-close"
-              onClick={props.onClose}
-            />
+      <ContextMenu>
+        <ContextMenu.Trigger as="div" style={{ display: "contents" }}>
+          <TooltipKeybind
+            title={props.tab.title || t("agentManager.session.untitled")}
+            keybind={props.keybind ?? ""}
+            placement="bottom"
+            inactive={props.active}
+          >
+            <div
+              class={`am-tab ${props.active ? "am-tab-active" : ""}`}
+              onClick={props.onSelect}
+              onMouseDown={props.onMiddleClick}
+            >
+              <span class="am-tab-label">{props.tab.title || t("agentManager.session.untitled")}</span>
+              <TooltipKeybind title={t("agentManager.tab.close")} keybind={props.closeKeybind ?? ""} placement="bottom">
+                <IconButton
+                  icon="close-small"
+                  size="small"
+                  variant="ghost"
+                  label={t("agentManager.tab.closeTab")}
+                  class="am-tab-close"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    props.onClose()
+                  }}
+                />
+              </TooltipKeybind>
+            </div>
           </TooltipKeybind>
-        </div>
-      </TooltipKeybind>
+        </ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Content class="am-tab-context-menu">
+            <Show when={props.onFork}>
+              <ContextMenu.Item onSelect={() => props.onFork?.()}>
+                <Icon name="branch" size="small" />
+                <ContextMenu.ItemLabel>{t("agentManager.tab.forkSession")}</ContextMenu.ItemLabel>
+              </ContextMenu.Item>
+              <ContextMenu.Separator />
+            </Show>
+            <ContextMenu.Item onSelect={props.onClose}>
+              <Icon name="close" size="small" />
+              <ContextMenu.ItemLabel>{t("agentManager.tab.close")}</ContextMenu.ItemLabel>
+            </ContextMenu.Item>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
+      </ContextMenu>
     </div>
   )
 }

--- a/packages/kilo-vscode/webview-ui/agent-manager/sortable-tab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/sortable-tab.tsx
@@ -92,7 +92,7 @@ export const SortableTab: Component<{
           </TooltipKeybind>
         </ContextMenu.Trigger>
         <ContextMenu.Portal>
-          <ContextMenu.Content class="am-tab-context-menu">
+          <ContextMenu.Content>
             <Show when={props.onFork}>
               <ContextMenu.Item onSelect={() => props.onFork?.()}>
                 <Icon name="branch" size="small" />

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -697,6 +697,14 @@ export interface AgentManagerSessionAddedMessage {
   worktreeId: string
 }
 
+// Agent Manager session forked from an existing session
+export interface AgentManagerSessionForkedMessage {
+  type: "agentManager.sessionForked"
+  sessionId: string
+  forkedFromId: string
+  worktreeId?: string
+}
+
 // Full state push from extension to webview
 export interface AgentManagerStateMessage {
   type: "agentManager.state"
@@ -1049,6 +1057,7 @@ export type ExtensionMessage =
   | AgentManagerRepoInfoMessage
   | AgentManagerWorktreeSetupMessage
   | AgentManagerSessionAddedMessage
+  | AgentManagerSessionForkedMessage
   | AgentManagerStateMessage
   | AgentManagerKeybindingsMessage
   | AgentManagerMultiVersionProgressMessage
@@ -1357,6 +1366,13 @@ export interface AddSessionToWorktreeRequest {
   worktreeId: string
 }
 
+// Fork an existing session (copies conversation history)
+export interface ForkSessionRequest {
+  type: "agentManager.forkSession"
+  sessionId: string
+  worktreeId?: string
+}
+
 // Close (remove) a session from its worktree
 export interface CloseSessionRequest {
   type: "agentManager.closeSession"
@@ -1609,6 +1625,7 @@ export type WebviewMessage =
   | RemoveStaleWorktreeRequest
   | PromoteSessionRequest
   | AddSessionToWorktreeRequest
+  | ForkSessionRequest
   | CloseSessionRequest
   | RenameWorktreeRequest
   | TelemetryRequest


### PR DESCRIPTION
## Summary

- Add right-click context menu on Agent Manager session tabs with "Fork Session" and "Close" options
- Fork creates a new session copying full conversation history via CLI `session.fork()` API
- Supports both worktree sessions (scoped to worktree directory) and local sessions
- Pending tabs only show "Close" (no fork option)
- Uses existing `ContextMenu` component from `@kilocode/kilo-ui`
- i18n translations added for all 16 locales
- Clean `onClose` callback signature (no synthetic MouseEvent hack)

<img width="220" height="98" alt="image" src="https://github.com/user-attachments/assets/ccb484ae-5521-4a62-96e2-1084e9d475dc" />
