### PR TITLE
fix(vscode): preview pasted images in chat input

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1,6 +1,7 @@
 import * as path from "path"
 import * as vscode from "vscode"
 import { z } from "zod"
+import { buildPreviewPath, getPreviewCommand, parseImage } from "./image-preview"
 import { isAbsolutePath } from "./path-utils"
 import type {
   KiloClient,
@@ -412,6 +413,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         case "openSubAgentViewer":
           vscode.commands.executeCommand("kilo-code.new.openSubAgentViewer", message.sessionID, message.title)
+          break
+        case "previewImage":
+          this.handlePreviewImage(message.dataUrl, message.filename)
           break
         case "openFile":
           if (message.filePath) {
@@ -1810,6 +1814,25 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * a worktree path registered via setSessionDirectory), falling back to workspace root.
    * Absolute paths (Unix `/…` or Windows `C:\…`) are used as-is.
    */
+  private handlePreviewImage(dataUrl: string, filename: string): void {
+    const dir = this.extensionContext?.globalStorageUri
+    if (!dir) return
+
+    const img = parseImage(dataUrl, filename)
+    if (!img) return
+
+    const uri = vscode.Uri.joinPath(dir, buildPreviewPath(img.name, Date.now()))
+    const open = () =>
+      vscode.commands
+        .executeCommand(...getPreviewCommand(uri))
+        .then(undefined, () => vscode.commands.executeCommand("vscode.open", uri))
+
+    void vscode.workspace.fs
+      .createDirectory(vscode.Uri.joinPath(dir, "image-preview"))
+      .then(() => vscode.workspace.fs.writeFile(uri, img.data))
+      .then(open, (err) => console.error("[Kilo New] KiloProvider: Failed to preview image:", err))
+  }
+
   private handleOpenFile(filePath: string, line?: number, column?: number): void {
     const uri = isAbsolutePath(filePath)
       ? vscode.Uri.file(filePath)

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1,7 +1,7 @@
 import * as path from "path"
 import * as vscode from "vscode"
 import { z } from "zod"
-import { buildPreviewPath, getPreviewCommand, parseImage } from "./image-preview"
+import { buildPreviewPath, getPreviewCommand, getPreviewDir, parseImage, trimEntries } from "./image-preview"
 import { isAbsolutePath } from "./path-utils"
 import type {
   KiloClient,
@@ -1808,12 +1808,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
-  /**
-   * Handle openFile request from the webview — open a file in the VS Code editor.
-   * Resolves relative paths against the current session's directory (which may be
-   * a worktree path registered via setSessionDirectory), falling back to workspace root.
-   * Absolute paths (Unix `/…` or Windows `C:\…`) are used as-is.
-   */
   private handlePreviewImage(dataUrl: string, filename: string): void {
     const dir = this.extensionContext?.globalStorageUri
     if (!dir) return
@@ -1821,18 +1815,36 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     const img = parseImage(dataUrl, filename)
     if (!img) return
 
+    const root = vscode.Uri.joinPath(dir, getPreviewDir())
     const uri = vscode.Uri.joinPath(dir, buildPreviewPath(img.name, Date.now()))
+    const clean = () =>
+      vscode.workspace.fs.readDirectory(root).then(
+        (items) => {
+          const stale = trimEntries(items.map(([name]) => ({ path: name })))
+          return Promise.all(
+            stale.map((name) => vscode.workspace.fs.delete(vscode.Uri.joinPath(root, name), { recursive: true })),
+          )
+        },
+        () => [],
+      )
     const open = () =>
       vscode.commands
         .executeCommand(...getPreviewCommand(uri))
         .then(undefined, () => vscode.commands.executeCommand("vscode.open", uri))
 
     void vscode.workspace.fs
-      .createDirectory(vscode.Uri.joinPath(dir, "image-preview"))
+      .createDirectory(root)
       .then(() => vscode.workspace.fs.writeFile(uri, img.data))
+      .then(() => clean())
       .then(open, (err) => console.error("[Kilo New] KiloProvider: Failed to preview image:", err))
   }
 
+  /**
+   * Handle openFile request from the webview — open a file in the VS Code editor.
+   * Resolves relative paths against the current session's directory (which may be
+   * a worktree path registered via setSessionDirectory), falling back to workspace root.
+   * Absolute paths (Unix `/…` or Windows `C:\…`) are used as-is.
+   */
   private handleOpenFile(filePath: string, line?: number, column?: number): void {
     const uri = isAbsolutePath(filePath)
       ? vscode.Uri.file(filePath)

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1822,7 +1822,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         (items) => {
           const stale = trimEntries(items.map(([name]) => ({ path: name })))
           return Promise.all(
-            stale.map((name) => vscode.workspace.fs.delete(vscode.Uri.joinPath(root, name), { recursive: true })),
+            stale.map((name) =>
+              Promise.resolve(vscode.workspace.fs.delete(vscode.Uri.joinPath(root, name), { recursive: true })).then(
+                undefined,
+                (err: unknown) => {
+                  console.warn("[Kilo New] KiloProvider: Failed to delete stale preview:", err)
+                },
+              ),
+            ),
           )
         },
         () => [],

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -232,6 +232,9 @@ export class AgentManagerProvider implements vscode.Disposable {
       this.openWorktreeDirectory(m.worktreeId)
       return null
     }
+    if (m.type === "previewImage") {
+      return msg
+    }
     if (m.type === "agentManager.showExistingLocalTerminal") {
       this.terminalManager.syncLocalOnSessionSwitch()
       return null

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -66,6 +66,7 @@ export class AgentManagerProvider implements vscode.Disposable {
   constructor(
     private readonly extensionUri: vscode.Uri,
     private readonly connectionService: KiloConnectionService,
+    private readonly context: vscode.ExtensionContext,
   ) {
     this.outputChannel = vscode.window.createOutputChannel("Kilo Agent Manager")
     this.terminalManager = new SessionTerminalManager(
@@ -147,7 +148,7 @@ export class AgentManagerProvider implements vscode.Disposable {
 
     panel.webview.html = this.getHtml(panel.webview)
 
-    this.provider = new KiloProvider(this.extensionUri, this.connectionService)
+    this.provider = new KiloProvider(this.extensionUri, this.connectionService, this.context)
     this.provider.attachToWebview(panel.webview, {
       onBeforeMessage: (msg) => this.onMessage(msg),
     })

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -379,6 +379,12 @@ interface GenericOpenFileIn {
   column?: number
 }
 
+interface PreviewImageIn {
+  type: "previewImage"
+  dataUrl: string
+  filename: string
+}
+
 interface LoadMessagesIn {
   type: "loadMessages"
   sessionID: string
@@ -434,6 +440,7 @@ export type AgentManagerInMessage =
   | StopDiffWatchIn
   | OpenFileIn
   | GenericOpenFileIn
+  | PreviewImageIn
   | LoadMessagesIn
   | ClearSessionIn
   | AbortIn

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -47,7 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
   )
 
   // Create Agent Manager provider for editor panel
-  const agentManagerProvider = new AgentManagerProvider(context.extensionUri, connectionService)
+  const agentManagerProvider = new AgentManagerProvider(context.extensionUri, connectionService, context)
   context.subscriptions.push(agentManagerProvider)
 
   // Register serializer so Agent Manager restores when VS Code restarts

--- a/packages/kilo-vscode/src/image-preview.ts
+++ b/packages/kilo-vscode/src/image-preview.ts
@@ -1,0 +1,67 @@
+import * as path from "path"
+
+const IMAGE_PREVIEW_ID = "imagePreview.previewEditor"
+
+type Preview = {
+  data: Uint8Array
+  ext: string
+  name: string
+}
+
+export function parseImage(dataUrl: string, filename: string): Preview | null {
+  const sep = dataUrl.indexOf(",")
+  if (sep === -1) return null
+
+  const head = dataUrl.slice(0, sep)
+  const mime = head.match(/^data:(image\/[A-Za-z0-9.+-]+);base64$/)?.[1]
+  if (!mime) return null
+
+  const data = parseBase64(dataUrl.slice(sep + 1))
+  if (!data) return null
+
+  const ext = getExt(mime)
+  const name = buildName(filename, ext)
+  return { data, ext, name }
+}
+
+export function buildPreviewPath(name: string, now: number): string {
+  return path.posix.join("image-preview", `${now}-${name}`)
+}
+
+export function getPreviewCommand(uri: {
+  toString(): string
+}): [string, { resource: { toString(): string }; size: "contain" }] {
+  return [IMAGE_PREVIEW_ID, { resource: uri, size: "contain" }]
+}
+
+function parseBase64(value: string): Uint8Array | null {
+  try {
+    return Buffer.from(value, "base64")
+  } catch {
+    return null
+  }
+}
+
+function getExt(mime: string): string {
+  const raw = mime.split("/")[1] ?? "png"
+  if (raw === "jpeg") return "jpg"
+  if (raw === "svg+xml") return "svg"
+  return raw
+}
+
+function buildName(filename: string, ext: string): string {
+  const raw = path.basename(filename || "image")
+  const item = path.parse(raw)
+  const base = sanitize(item.name) || "image"
+  const tail = sanitize(item.ext.replace(/^\./, ""))
+  const clean = tail ? `${base}.${tail}` : base
+  if (path.extname(clean)) return clean
+  return `${clean}.${ext}`
+}
+
+function sanitize(value: string): string {
+  return value
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+}

--- a/packages/kilo-vscode/src/image-preview.ts
+++ b/packages/kilo-vscode/src/image-preview.ts
@@ -1,6 +1,8 @@
 import * as path from "path"
 
 const IMAGE_PREVIEW_ID = "imagePreview.previewEditor"
+const PREVIEW_DIR = "image-preview"
+const PREVIEW_LIMIT = 20
 
 type Preview = {
   data: Uint8Array
@@ -25,13 +27,27 @@ export function parseImage(dataUrl: string, filename: string): Preview | null {
 }
 
 export function buildPreviewPath(name: string, now: number): string {
-  return path.posix.join("image-preview", `${now}-${name}`)
+  return path.posix.join(PREVIEW_DIR, `${now}-${name}`)
 }
 
 export function getPreviewCommand(uri: {
   toString(): string
 }): [string, { resource: { toString(): string }; size: "contain" }] {
   return [IMAGE_PREVIEW_ID, { resource: uri, size: "contain" }]
+}
+
+export function getPreviewDir(): string {
+  return PREVIEW_DIR
+}
+
+export function trimEntries<T extends { path: string }>(items: T[], limit = PREVIEW_LIMIT): string[] {
+  if (items.length <= limit) return []
+
+  return items
+    .slice()
+    .sort((a, b) => a.path.localeCompare(b.path))
+    .slice(0, items.length - limit)
+    .map((item) => item.path)
 }
 
 function parseBase64(value: string): Uint8Array | null {

--- a/packages/kilo-vscode/tests/setup/vscode-mock.ts
+++ b/packages/kilo-vscode/tests/setup/vscode-mock.ts
@@ -51,6 +51,12 @@ const mockVscode = {
       update: async () => {},
     }),
     asRelativePath: (pathOrUri: string) => pathOrUri,
+    fs: {
+      createDirectory: async () => {},
+      writeFile: async () => {},
+      readFile: async () => new Uint8Array(),
+      stat: async () => ({ type: 1, ctime: 0, mtime: 0, size: 0 }),
+    },
   },
   window: {
     activeTextEditor: undefined,

--- a/packages/kilo-vscode/tests/setup/vscode-mock.ts
+++ b/packages/kilo-vscode/tests/setup/vscode-mock.ts
@@ -55,6 +55,8 @@ const mockVscode = {
       createDirectory: async () => {},
       writeFile: async () => {},
       readFile: async () => new Uint8Array(),
+      readDirectory: async () => [],
+      delete: async () => {},
       stat: async () => ({ type: 1, ctime: 0, mtime: 0, size: 0 }),
     },
   },

--- a/packages/kilo-vscode/tests/unit/image-preview.test.ts
+++ b/packages/kilo-vscode/tests/unit/image-preview.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test"
+import { buildPreviewPath, getPreviewCommand, parseImage } from "../../src/image-preview"
+
+describe("parseImage", () => {
+  it("parses png data urls and preserves a clean extension", () => {
+    const img = parseImage("data:image/png;base64,aGVsbG8=", "screen")
+
+    expect(img).not.toBeNull()
+    expect(img?.name).toBe("screen.png")
+    expect(img?.ext).toBe("png")
+    expect(Buffer.from(img?.data ?? []).toString("utf8")).toBe("hello")
+  })
+
+  it("sanitizes the basename and keeps the existing extension", () => {
+    const img = parseImage("data:image/jpeg;base64,aGVsbG8=", "../../bad name!!.jpeg")
+
+    expect(img).not.toBeNull()
+    expect(img?.name).toBe("bad-name.jpeg")
+    expect(img?.ext).toBe("jpg")
+  })
+
+  it("returns null for non-image data urls", () => {
+    expect(parseImage("data:text/plain;base64,aGVsbG8=", "note.txt")).toBeNull()
+  })
+
+  it("returns null when the header is not base64", () => {
+    expect(parseImage("data:image/png,hello", "screen.png")).toBeNull()
+  })
+})
+
+describe("buildPreviewPath", () => {
+  it("writes previews into a dedicated storage folder", () => {
+    expect(buildPreviewPath("screen.png", 42)).toBe("image-preview/42-screen.png")
+  })
+})
+
+describe("getPreviewCommand", () => {
+  it("targets the built-in preview editor with explicit sizing", () => {
+    const uri = { toString: () => "file:///tmp/screen.png" }
+
+    expect(getPreviewCommand(uri)).toEqual(["imagePreview.previewEditor", { resource: uri, size: "contain" }])
+  })
+})

--- a/packages/kilo-vscode/tests/unit/image-preview.test.ts
+++ b/packages/kilo-vscode/tests/unit/image-preview.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { buildPreviewPath, getPreviewCommand, parseImage } from "../../src/image-preview"
+import { buildPreviewPath, getPreviewCommand, getPreviewDir, parseImage, trimEntries } from "../../src/image-preview"
 
 describe("parseImage", () => {
   it("parses png data urls and preserves a clean extension", () => {
@@ -31,6 +31,24 @@ describe("parseImage", () => {
 describe("buildPreviewPath", () => {
   it("writes previews into a dedicated storage folder", () => {
     expect(buildPreviewPath("screen.png", 42)).toBe("image-preview/42-screen.png")
+  })
+})
+
+describe("getPreviewDir", () => {
+  it("returns the preview storage folder", () => {
+    expect(getPreviewDir()).toBe("image-preview")
+  })
+})
+
+describe("trimEntries", () => {
+  it("drops the oldest preview paths once the limit is exceeded", () => {
+    const items = Array.from({ length: 22 }, (_, i) => ({ path: `${String(i).padStart(2, "0")}-screen.png` }))
+
+    expect(trimEntries(items)).toEqual(["00-screen.png", "01-screen.png"])
+  })
+
+  it("keeps all preview paths when below the limit", () => {
+    expect(trimEntries([{ path: "01-screen.png" }])).toEqual([])
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -247,7 +247,14 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                   <For each={imageAttach.images()}>
                     {(img) => (
                       <div class="image-attachment">
-                        <img src={img.dataUrl} alt={img.filename} title={img.filename} />
+                        <img
+                          src={img.dataUrl}
+                          alt={img.filename}
+                          title={img.filename}
+                          onClick={() =>
+                            vscode.postMessage({ type: "previewImage", dataUrl: img.dataUrl, filename: img.filename })
+                          }
+                        />
                         <button
                           type="button"
                           class="image-attachment-remove"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -536,7 +536,14 @@ export const PromptInput: Component = () => {
           <For each={imageAttach.images()}>
             {(img) => (
               <div class="image-attachment">
-                <img src={img.dataUrl} alt={img.filename} title={img.filename} />
+                <img
+                  src={img.dataUrl}
+                  alt={img.filename}
+                  title={img.filename}
+                  onClick={() =>
+                    vscode.postMessage({ type: "previewImage", dataUrl: img.dataUrl, filename: img.filename })
+                  }
+                />
                 <button
                   type="button"
                   class="image-attachment-remove"

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -707,6 +707,7 @@
   border-radius: 4px;
   border: 1px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.1));
   display: block;
+  cursor: pointer;
 }
 
 .image-attachment-remove {

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1574,6 +1574,13 @@ export interface OpenSubAgentViewerRequest {
   title?: string
 }
 
+// Preview an image attachment in VS Code's built-in image viewer
+export interface PreviewImageRequest {
+  type: "previewImage"
+  dataUrl: string
+  filename: string
+}
+
 // Set default base branch (webview → extension)
 export interface SetDefaultBaseBranchRequest {
   type: "agentManager.setDefaultBaseBranch"
@@ -1668,6 +1675,7 @@ export type WebviewMessage =
   | OpenChangesRequest
   | RetryConnectionRequest
   | OpenSubAgentViewerRequest
+  | PreviewImageRequest
   | SetDefaultBaseBranchRequest
 
 // ============================================


### PR DESCRIPTION
Fixes #7049 

## Context

Restore the old extension behavior where clicking an image pasted into the chat input opens a larger VS Code preview, so users can inspect the attachment at actual size while composing their prompt.

## Implementation

- added a new `previewImage` webview message for attached image thumbnails in both the main chat input and Agent Manager dialog
- handled `previewImage` in `KiloProvider` by parsing the image data URL, writing a preview file into extension storage, and opening it with VS Code's built-in image preview with a fallback to `vscode.open`
- extracted the preview parsing/path helpers into `src/image-preview.ts` and added focused unit coverage plus the minimal VS Code fs mocks needed by the tests

## Screenshots

| before | after |
| ------ | ----- |
| <img width="672" height="246" alt="image" src="https://github.com/user-attachments/assets/31336282-67f7-43bc-bdd9-b5c846932f68" /> | <img width="1490" height="988" alt="Schermafdruk van 2026-03-14 18-50-25" src="https://github.com/user-attachments/assets/fd0cf8c7-6f93-4c81-b44f-4abaa58b020d" /> |

## How to Test

- open the VS Code extension chat input or Agent Manager new worktree dialog
- paste or drag in a PNG/JPEG/GIF/WebP image so it appears as an attachment thumbnail
- click the thumbnail
- verify VS Code opens the image in a larger preview editor
- run `bun test tests/unit/image-preview.test.ts tests/unit/kilo-provider-session-refresh.test.ts` from `packages/kilo-vscode`
- run `bun turbo typecheck` from the repo root

## Get in Touch

thomas07374