### PR TITLE
fix: copy buttons overlaying text and misaligned in chat UI

### DIFF
--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -12,7 +12,7 @@
   }
 
   [data-slot="text-part-copy-wrapper"][data-is-turn-copy] {
-    display: block;
+    display: flex;
   }
 }
 
@@ -93,25 +93,21 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
 }
 
 /* Remove the empty space below user message bubbles.
- * The upstream copy wrapper is a normal-flow block with min-height + margin,
- * so it reserves ~28px even when invisible. Override it to be absolutely
- * positioned over the bottom-right corner of the bubble — zero layout impact
- * when hidden, overlays on hover exactly like the text-part copy button. */
+ * The upstream copy wrapper uses opacity:0 when hidden but still takes up
+ * layout space (~28px). Override with display:none so it takes zero space,
+ * and restore display:flex on hover for proper vertical centering. */
 [data-component="user-message"] {
-  position: relative;
-
   [data-slot="user-message-copy-wrapper"] {
-    position: absolute;
-    top: 4px;
-    right: 4px;
-    bottom: auto;
-    min-height: unset;
-    margin-top: 0;
-    width: auto;
+    display: none;
     /* hide meta text; only the icon-button matters in the sidebar */
     [data-slot="user-message-meta-wrap"] {
       display: none;
     }
+  }
+
+  &:hover [data-slot="user-message-copy-wrapper"],
+  &:focus-within [data-slot="user-message-copy-wrapper"] {
+    display: flex;
   }
 }
 

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -101,6 +101,8 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
   [data-slot="user-message-copy-wrapper"] {
     opacity: 0;
     height: 0;
+    min-height: 0;
+    margin-top: 0;
     overflow: hidden;
     pointer-events: none;
     /* hide meta text; only the icon-button matters in the sidebar */

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -94,11 +94,15 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
 
 /* Remove the empty space below user message bubbles.
  * The upstream copy wrapper uses opacity:0 when hidden but still takes up
- * layout space (~28px). Override with display:none so it takes zero space,
- * and restore display:flex on hover for proper vertical centering. */
+ * layout space (~28px). Collapse it to zero height so it takes no space,
+ * but keep it rendered so the button stays in the tab order and
+ * :focus-within can fire for keyboard access. */
 [data-component="user-message"] {
   [data-slot="user-message-copy-wrapper"] {
-    display: none;
+    opacity: 0;
+    height: 0;
+    overflow: hidden;
+    pointer-events: none;
     /* hide meta text; only the icon-button matters in the sidebar */
     [data-slot="user-message-meta-wrap"] {
       display: none;
@@ -107,6 +111,10 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
 
   &:hover [data-slot="user-message-copy-wrapper"],
   &:focus-within [data-slot="user-message-copy-wrapper"] {
+    opacity: 1;
+    height: auto;
+    overflow: visible;
+    pointer-events: auto;
     display: flex;
   }
 }

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -13,6 +13,11 @@
 
   [data-slot="text-part-copy-wrapper"][data-is-turn-copy] {
     display: flex;
+
+    [data-component="icon-button"] {
+      width: 20px;
+      height: 20px;
+    }
   }
 }
 
@@ -92,32 +97,29 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
   margin-bottom: 0px;
 }
 
-/* Remove the empty space below user message bubbles.
- * The upstream copy wrapper uses opacity:0 when hidden but still takes up
- * layout space (~28px). Collapse it to zero height so it takes no space,
- * but keep it rendered so the button stays in the tab order and
- * :focus-within can fire for keyboard access. */
+/* User message copy button: tiny reserved space, button overflows on hover.
+ * height:2px keeps layout stable; overflow:hidden clips the invisible button;
+ * on hover overflow:visible lets the button appear without shifting content. */
 [data-component="user-message"] {
   [data-slot="user-message-copy-wrapper"] {
-    opacity: 0;
-    height: 0;
     min-height: 0;
+    height: 10px;
     margin-top: 0;
     overflow: hidden;
-    pointer-events: none;
-    /* hide meta text; only the icon-button matters in the sidebar */
+
     [data-slot="user-message-meta-wrap"] {
       display: none;
+    }
+
+    [data-component="icon-button"] {
+      width: 20px;
+      height: 20px;
     }
   }
 
   &:hover [data-slot="user-message-copy-wrapper"],
   &:focus-within [data-slot="user-message-copy-wrapper"] {
-    opacity: 1;
-    height: auto;
     overflow: visible;
-    pointer-events: auto;
-    display: flex;
   }
 }
 

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -970,7 +970,7 @@ export function UserMessageDisplay(props: {
             </Show>
             <Tooltip
               value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyMessage")}
-              placement="top"
+              placement="right" // kilocode_change: avoid overlapping message text
               gutter={4}
             >
               <IconButton
@@ -1349,7 +1349,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
           >
             <Tooltip
               value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
-              placement="top"
+              placement="right" // kilocode_change: avoid overlapping message text above
               gutter={4}
             >
               <IconButton

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1349,7 +1349,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
           >
             <Tooltip
               value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
-              placement="right" // kilocode_change: avoid overlapping message text above
+              placement="bottom" // kilocode_change: avoid overlapping message text above and metadata to the right
               gutter={4}
             >
               <IconButton


### PR DESCRIPTION
## Context

Fixes #6917:
1. **Copy button overlaying text** — the copy icon was positioned absolutely over message content, obscuring it
2. **Copy button not centered with text** — the copy icon and meta text ("Code · Kilo Auto · 15s") were vertically misaligned
3. **Tooltip overlaying text** — the "Copy response" / "Copy message" tooltip appeared above the button, covering the message text

## Implementation

Three targeted CSS/JSX changes:

- **User message copy wrapper** (`packages/kilo-ui/src/components/message-part.css`): Replaced `position: absolute; top: 4px; right: 4px` with `display: none` / `display: flex` toggle. The button now takes zero layout space when hidden and appears in normal document flow on hover, instead of overlaying the bubble text.

- **Assistant copy wrapper** (`packages/kilo-ui/src/components/message-part.css`): Changed `display: block` → `display: flex` for the `[data-is-turn-copy]` selector. The `block` value was overriding the upstream `display: flex; align-items: center` layout, causing the copy icon and meta text to stack vertically instead of aligning side-by-side.

- **Tooltip placement** (`packages/ui/src/components/message-part.tsx`): Changed `placement="bottom"` → `placement="right"` for both the "Copy response" and "Copy message" tooltips. With `top` placement, the tooltip appeared directly above the button, overlapping the message content. `right` placement puts it beside the button where horizontal space is available.

## Screenshots

| before | after |
| ------ | ----- |
| <img width="306" height="174" alt="image" src="https://github.com/user-attachments/assets/72ae1416-d10d-4dbc-be49-0d6102e55db4" /> | <img width="630" height="171" alt="image" src="https://github.com/user-attachments/assets/5330101e-c333-4b31-8699-1cb11fe6a875" /> |
| <img width="632" height="218" alt="image" src="https://github.com/user-attachments/assets/960d79d4-f951-4c3a-9984-eee445da6b62" /> | <img width="623" height="100" alt="image" src="https://github.com/user-attachments/assets/5945f20b-d753-41a6-88c1-cce40930f5c0" />|

## How to Test

1. Open the Kilo VS Code extension sidebar
2. Send a message and wait for the assistant response to complete
3. Hover over the copy button at the bottom of the assistant response:
   - The "Copy response" tooltip should appear to the **right** of the button, not above it
   - The copy icon and "Code · Model · Xs" meta text should be on the **same row**, vertically centered
4. Hover over a user message bubble:
   - The copy button should appear **below** the bubble, not overlapping the text inside it
   - The "Copy message" tooltip should appear to the **bottom** of the button

## Get in Touch

thomas07374