### PR TITLE
fix: handle array-format MCP command in settings display

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -372,7 +372,10 @@ const AgentBehaviourTab: Component = () => {
                   >
                     <Show when={mcp.command}>
                       <div>
-                        command: {mcp.command} {(mcp.args ?? []).join(" ")}
+                        command:{" "}
+                        {Array.isArray(mcp.command)
+                          ? mcp.command.join(" ")
+                          : `${mcp.command} ${(mcp.args ?? []).join(" ")}`}
                       </div>
                     </Show>
                     <Show when={mcp.url}>


### PR DESCRIPTION
## Summary

- Fix MCP command display in Agent Behaviour settings tab to handle both array format (`["npx", "-y", "server"]`) and legacy string+args format (`command: "npx", args: ["-y", "server"]`)

The opencode/kilo.json config format stores MCP commands as arrays, but the settings UI only handled the legacy string format, causing array commands to render incorrectly.
