### PR TITLE
fix: remove redundant vscode.env.openExternal call during login flow

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1713,8 +1713,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const codeMatch = auth.instructions?.match(/code:\s*(\S+)/i)
       const code = codeMatch ? codeMatch[1] : undefined
 
-      // Step 2: Open browser for user to authorize
-      vscode.env.openExternal(vscode.Uri.parse(auth.url))
+      // The backend already opens the browser via the `open` npm package during
+      // authorize(). Calling vscode.env.openExternal() here would show a VS Code
+      // trust dialog that persists after the user completes authentication in the
+      // browser, and would open a second browser tab. The DeviceAuthCard webview
+      // provides an "Open Browser" button as a user-initiated fallback.
 
       // Send device auth details to webview
       this.postMessage({


### PR DESCRIPTION
## Summary

- Removes the redundant `vscode.env.openExternal()` call in `handleLogin()` that caused a VS Code trust dialog popup to appear and persist after browser-based authentication completed
- The backend already opens the browser via the `open` npm package during `authorize()`, and the DeviceAuthCard webview provides an "Open Browser" button as a user-initiated fallback

## Problem

When logging in via the extension, two browser-opening mechanisms fired simultaneously:

1. **Backend** (`kilo-gateway/src/auth/device-auth-tui.ts:74`): `open(verificationUrl)` opens the browser directly during `authorize()`
2. **Extension** (`KiloProvider.ts:1717`): `vscode.env.openExternal()` shows VS Code's "Do you want to open this external website?" trust dialog AND opens a second browser tab

The trust dialog from `vscode.env.openExternal()` persisted after the user completed authentication in the browser because nothing dismissed it. The browser also opened immediately from the backend's `open()` call without waiting for the user to respond to the VS Code popup.

## Fix

Remove the `vscode.env.openExternal()` call from `handleLogin()`. The user-initiated "Open Browser" button in the DeviceAuthCard webview (which also uses `vscode.env.openExternal` via the `openExternal` message handler) is preserved as a fallback.

Closes #7026
