### PR TITLE
feat(vscode): add missing keybindings from legacy extension

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -292,6 +292,31 @@
         "command": "kilo-code.new.focusChatInput",
         "title": "Focus Chat Input",
         "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.toggleAutoApprove",
+        "title": "Toggle Auto-Approve",
+        "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.generateTerminalCommand",
+        "title": "Generate Terminal Command",
+        "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.autocomplete.cancelSuggestions",
+        "title": "Cancel Suggested Edits",
+        "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.cycleAgentMode",
+        "title": "Cycle Agent Mode",
+        "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.cyclePreviousAgentMode",
+        "title": "Cycle Previous Agent Mode",
+        "category": "Kilo Code"
       }
     ],
     "submenus": [
@@ -555,6 +580,39 @@
         "key": "ctrl+9",
         "mac": "cmd+9",
         "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.toggleAutoApprove",
+        "key": "ctrl+alt+a",
+        "mac": "cmd+alt+a"
+      },
+      {
+        "command": "kilo-code.new.generateTerminalCommand",
+        "key": "ctrl+shift+g",
+        "mac": "cmd+shift+g"
+      },
+      {
+        "command": "kilo-code.new.autocomplete.cancelSuggestions",
+        "key": "escape",
+        "when": "editorTextFocus && !editorTabMovesFocus && !inSnippetMode && kilo-code.new.autocomplete.hasSuggestions"
+      },
+      {
+        "command": "kilo-code.new.generateCommitMessage",
+        "key": "ctrl+l",
+        "mac": "cmd+l",
+        "when": "scmInputIsFocused"
+      },
+      {
+        "command": "kilo-code.new.cycleAgentMode",
+        "key": "ctrl+.",
+        "mac": "cmd+.",
+        "when": "activeViewlet == 'workbench.view.extension.kilo-code-sidebar'"
+      },
+      {
+        "command": "kilo-code.new.cyclePreviousAgentMode",
+        "key": "ctrl+shift+.",
+        "mac": "cmd+shift+.",
+        "when": "activeViewlet == 'workbench.view.extension.kilo-code-sidebar'"
       }
     ],
     "configuration": {

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -149,6 +149,24 @@ export function activate(context: vscode.ExtensionContext) {
         agentManagerProvider.postMessage({ type: "action", action: `jumpTo${i + 1}` })
       }),
     ),
+    vscode.commands.registerCommand("kilo-code.new.toggleAutoApprove", () => {
+      provider.postMessage({ type: "action", action: "toggleAutoApprove" })
+    }),
+    vscode.commands.registerCommand("kilo-code.new.generateTerminalCommand", async () => {
+      const input = await vscode.window.showInputBox({
+        prompt: "Describe the terminal command you want to generate",
+        placeHolder: "e.g. find all TypeScript files modified in the last week",
+      })
+      if (!input) return
+      await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
+      provider.postMessage({ type: "triggerTask", text: `Generate a terminal command: ${input}` })
+    }),
+    vscode.commands.registerCommand("kilo-code.new.cycleAgentMode", () => {
+      provider.postMessage({ type: "action", action: "cycleAgentMode" })
+    }),
+    vscode.commands.registerCommand("kilo-code.new.cyclePreviousAgentMode", () => {
+      provider.postMessage({ type: "action", action: "cyclePreviousAgentMode" })
+    }),
   )
 
   // Register URI handler for session imports (vscode://kilocode.kilo-code/kilocode/s/{sessionId})

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
@@ -303,10 +303,14 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
     const isAutoTriggerEnabled = settings?.enableAutoTrigger ?? false
 
     if (!isAutoTriggerEnabled) {
+      void vscode.commands.executeCommand("setContext", "kilo-code.new.autocomplete.hasSuggestions", false)
       return []
     }
 
-    return this.provideInlineCompletionItems_Internal(document, position, _context, _token)
+    const result = await this.provideInlineCompletionItems_Internal(document, position, _context, _token)
+    const items = Array.isArray(result) ? result : result.items
+    void vscode.commands.executeCommand("setContext", "kilo-code.new.autocomplete.hasSuggestions", items.length > 0)
+    return result
   }
 
   public async provideInlineCompletionItems_Internal(

--- a/packages/kilo-vscode/src/services/autocomplete/index.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/index.ts
@@ -26,6 +26,11 @@ export const registerAutocompleteProvider = (
     }),
   )
   context.subscriptions.push(
+    vscode.commands.registerCommand("kilo-code.new.autocomplete.cancelSuggestions", () => {
+      void vscode.commands.executeCommand("editor.action.inlineSuggest.hide")
+    }),
+  )
+  context.subscriptions.push(
     vscode.commands.registerCommand("kilo-code.new.autocomplete.showIncompatibilityExtensionPopup", async () => {
       await autocompleteManager.showIncompatibilityExtensionPopup()
     }),

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -15,7 +15,7 @@ import ProfileView from "./components/profile/ProfileView"
 import { VSCodeProvider, useVSCode } from "./context/vscode"
 import { ServerProvider, useServer } from "./context/server"
 import { ProviderProvider, useProvider } from "./context/provider"
-import { ConfigProvider } from "./context/config"
+import { ConfigProvider, useConfig } from "./context/config"
 import { SessionProvider, useSession } from "./context/session"
 import { LanguageProvider } from "./context/language"
 import { ChatView } from "./components/chat"
@@ -179,6 +179,18 @@ const AppContent: Component = () => {
   const [migrationReturnView, setMigrationReturnView] = createSignal<ViewType>("newTask") // legacy-migration
   const session = useSession()
   const server = useServer()
+  const { config, updateConfig } = useConfig()
+
+  const cycleAgent = (direction: 1 | -1) => {
+    const available = session.agents().filter((a) => a.mode !== "subagent" && !a.hidden)
+    if (available.length === 0) return
+    const current = session.selectedAgent()
+    const idx = available.findIndex((a) => a.name === current)
+    const raw = idx + direction
+    const next = raw < 0 ? available.length - 1 : raw >= available.length ? 0 : raw
+    const agent = available[next]
+    if (agent) session.selectAgent(agent.name)
+  }
 
   const handleViewAction = (action: string) => {
     switch (action) {
@@ -200,6 +212,28 @@ const AppContent: Component = () => {
         break
       case "settingsButtonClicked":
         setCurrentView("settings")
+        break
+      case "cycleAgentMode":
+        cycleAgent(1)
+        break
+      case "cyclePreviousAgentMode":
+        cycleAgent(-1)
+        break
+      case "toggleAutoApprove": {
+        const perm = config().permission ?? {}
+        const values = Object.values(perm)
+        const hasAllow = values.some(
+          (v) => v === "allow" || (typeof v === "object" && Object.values(v).some((l) => l === "allow")),
+        )
+        const target = hasAllow ? "ask" : "allow"
+        const updated: Record<string, typeof target> = {}
+        for (const key of Object.keys(perm)) {
+          updated[key] = target
+        }
+        updateConfig({ permission: updated })
+        break
+      }
+      case "generateTerminalCommand":
         break
     }
   }


### PR DESCRIPTION
## Summary

Adds keybindings that existed in the legacy Kilo VS Code extension (kilocode-legacy) but were missing in the new extension (packages/kilo-vscode/).

Closes #6973

## Changes

### New keybindings

| Keybinding | Command | Description |
|---|---|---|
| `Ctrl+Alt+A` / `Cmd+Alt+A` | `toggleAutoApprove` | Toggles all tool permissions between "allow" and "ask" |
| `Ctrl+Shift+G` / `Cmd+Shift+G` | `generateTerminalCommand` | Prompts for a command description, sends to chat agent |
| `Escape` | `autocomplete.cancelSuggestions` | Dismisses inline completion suggestions (gated on `hasSuggestions` context key) |
| `Ctrl+L` / `Cmd+L` | `generateCommitMessage` | Generate commit message when SCM input is focused (existing command, new keybinding) |
| `Ctrl+.` / `Cmd+.` | `cycleAgentMode` | Cycle forward through agent modes (when sidebar is active) |
| `Ctrl+Shift+.` / `Cmd+Shift+.` | `cyclePreviousAgentMode` | Cycle backward through agent modes (when sidebar is active) |

### Files modified

- **`package.json`**: Added 5 new command definitions and 7 new keybinding entries
- **`src/extension.ts`**: Registered command handlers for toggleAutoApprove, generateTerminalCommand, cycleAgentMode, and cyclePreviousAgentMode
- **`src/services/autocomplete/index.ts`**: Registered `cancelSuggestions` command that hides inline suggestions
- **`src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts`**: Sets `kilo-code.new.autocomplete.hasSuggestions` context key based on whether inline completions are shown
- **`webview-ui/src/App.tsx`**: Added webview action handlers for agent mode cycling (with wrap-around) and auto-approve toggling (toggles all permissions between allow/ask)

### Implementation notes

- **Agent cycling** mirrors the logic from `packages/app/src/context/local.tsx` — filters out subagent/hidden agents and wraps around at boundaries
- **Toggle auto-approve** checks if any permission is set to "allow" — if so, switches all to "ask"; otherwise switches all to "allow"
- **Generate terminal command** uses VS Code's `showInputBox` to prompt for a description, then sends a `triggerTask` message to the chat agent
- **Cancel suggestions** follows the same pattern as the legacy extension: the Escape keybinding is gated on a `hasSuggestions` context key that's set/cleared by the inline completion provider
