### PR TITLE
fix(vscode): align filename next to directory path in diff headers

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1181,7 +1181,7 @@ button.am-section-toggle:hover .am-section-label {
 .am-diff-content [data-slot="session-review-directory"],
 .am-review-diff-content [data-slot="session-review-directory"] {
   min-width: 0;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
 }
 
 .am-diff-content [data-slot="session-review-filename"],


### PR DESCRIPTION
## Summary

- Fix directory path and filename misalignment in the Agent Manager's changes tab and fullscreen diff view
- The directory element had `flex-grow: 1` causing it to expand and push the filename to the right edge — changed to `flex-grow: 0` so the filename sits immediately after the path

<img width="1180" height="186" alt="image" src="https://github.com/user-attachments/assets/a334b81e-9b60-43d9-a0cb-9d378651b4e7" />
