### PR TITLE
fix: consistent icon button sizing in prompt input actions

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/default-420-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/default-420-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d430e85f747c36d72eb73b756c3e5f80bb4cbd9579235187004f78bd4c0f1df9
-size 4858
+oid sha256:1e5fd252dcc1acaeefae5608621a1c32282f99c24f7ee464d375cd149722c4fc
+size 3915

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -881,7 +881,7 @@
   [data-component="button"] {
     background: transparent;
     border: none;
-    padding: 0;
+    padding: 4px;
 
     [data-slot="icon-svg"] {
       color: var(--icon-base);


### PR DESCRIPTION
## Summary

- Fixes inconsistent sizing between the enhance (wand sparkles) and send (paper plane) icon buttons in the prompt input area
- Changed `padding: 0` to `padding: 4px` in `.prompt-input-hint-actions [data-component="button"]` so icon-only buttons render as consistent 24×24px squares (4px padding + 16px icon = 24px height)

## Before
The enhance button was 16px wide × 24px tall (no padding, just the icon width), while the height was set to 24px by `Button size="small"`. This made the buttons appear inconsistently sized.

<img width="85" height="46" alt="image" src="https://github.com/user-attachments/assets/02bf5eb5-35fe-4640-b327-4d33d07a14b1" />


## After
Both buttons are now uniform 24×24px squares with balanced padding around the 16px icons.

<img width="206" height="110" alt="image" src="https://github.com/user-attachments/assets/60e53024-4767-425e-be4d-d5eb25a21624" />
