### PR TITLE
fix(vscode): return focus to textarea after selector popover closes

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -34,6 +34,7 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
   function pick(name: string) {
     props.onSelect(name)
     setOpen(false)
+    requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
   }
 
   const triggerLabel = () => {

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -34,7 +34,6 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
   function pick(name: string) {
     props.onSelect(name)
     setOpen(false)
-    requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
   }
 
   const triggerLabel = () => {
@@ -92,5 +91,14 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
 export const ModeSwitcher: Component = () => {
   const session = useSession()
 
-  return <ModeSwitcherBase agents={session.agents()} value={session.selectedAgent()} onSelect={session.selectAgent} />
+  return (
+    <ModeSwitcherBase
+      agents={session.agents()}
+      value={session.selectedAgent()}
+      onSelect={(name) => {
+        session.selectAgent(name)
+        requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
+      }}
+    />
+  )
 }

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -130,13 +130,11 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
   function pick(model: EnrichedModel) {
     props.onSelect(model.providerID, model.id)
     setOpen(false)
-    requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
   }
 
   function pickClear() {
     props.onSelect("", "")
     setOpen(false)
-    requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
   }
 
   function handleKeyDown(e: KeyboardEvent) {
@@ -297,7 +295,10 @@ export const ModelSelector: Component = () => {
   return (
     <ModelSelectorBase
       value={session.selected()}
-      onSelect={(providerID, modelID) => session.selectModel(providerID, modelID)}
+      onSelect={(providerID, modelID) => {
+        session.selectModel(providerID, modelID)
+        requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
+      }}
     />
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -130,11 +130,13 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
   function pick(model: EnrichedModel) {
     props.onSelect(model.providerID, model.id)
     setOpen(false)
+    requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
   }
 
   function pickClear() {
     props.onSelect("", "")
     setOpen(false)
+    requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
   }
 
   function handleKeyDown(e: KeyboardEvent) {

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -19,6 +19,7 @@ export const ThinkingSelector: Component = () => {
   function pick(value: string) {
     session.selectVariant(value)
     setOpen(false)
+    requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
   }
 
   const triggerLabel = () => {


### PR DESCRIPTION
## Summary

- After selecting a model, reasoning variant, or agent mode from the prompt-area popovers, focus was staying on the popover trigger button instead of returning to the message textarea
- Dispatches the existing `focusPrompt` event after each selector's `pick()` closes the popover, using `requestAnimationFrame` to run after Kobalte's `onCloseAutoFocus` completes
- Applied consistently to `ModelSelector`, `ThinkingSelector`, and `ModeSwitcher`