### PR TITLE
refactor: pass settings command URI as i18n interpolation variable

### DIFF
--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -95,8 +95,8 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("kilo-code.new.profileButtonClicked", () => {
       settingsEditorProvider.openPanel("profile")
     }),
-    vscode.commands.registerCommand("kilo-code.new.settingsButtonClicked", () => {
-      settingsEditorProvider.openPanel("settings")
+    vscode.commands.registerCommand("kilo-code.new.settingsButtonClicked", (tab?: string) => {
+      settingsEditorProvider.openPanel("settings", tab)
     }),
     // legacy-migration start
     vscode.commands.registerCommand("kilo-code.new.openMigrationWizard", () => {

--- a/packages/kilo-vscode/src/services/autocomplete/AutocompleteStatusBar.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/AutocompleteStatusBar.ts
@@ -4,6 +4,7 @@ import type { AutocompleteStatusBarStateProps } from "./types"
 import { humanFormatSessionCost, formatTime } from "./statusbar-utils"
 
 const SUPPORTED_PROVIDER_DISPLAY_NAME = "Kilo Gateway"
+const SETTINGS_COMMAND = "command:kilo-code.new.settingsButtonClicked"
 
 export class AutocompleteStatusBar {
   statusBar: vscode.StatusBarItem
@@ -96,13 +97,18 @@ export class AutocompleteStatusBar {
 
   private renderNoCreditsError() {
     this.statusBar.text = t("kilocode:autocomplete.statusBar.warning")
-    this.statusBar.tooltip = this.createMarkdownTooltip(t("kilocode:autocomplete.statusBar.tooltip.noCredits"))
+    this.statusBar.tooltip = this.createMarkdownTooltip(
+      t("kilocode:autocomplete.statusBar.tooltip.noCredits", { command: SETTINGS_COMMAND }),
+    )
   }
 
   private renderNoUsableProviderError() {
     this.statusBar.text = t("kilocode:autocomplete.statusBar.warning")
     this.statusBar.tooltip = this.createMarkdownTooltip(
-      t("kilocode:autocomplete.statusBar.tooltip.noUsableProvider", { providers: SUPPORTED_PROVIDER_DISPLAY_NAME }),
+      t("kilocode:autocomplete.statusBar.tooltip.noUsableProvider", {
+        providers: SUPPORTED_PROVIDER_DISPLAY_NAME,
+        command: SETTINGS_COMMAND,
+      }),
     )
   }
 }

--- a/packages/kilo-vscode/src/services/autocomplete/AutocompleteStatusBar.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/AutocompleteStatusBar.ts
@@ -4,7 +4,7 @@ import type { AutocompleteStatusBarStateProps } from "./types"
 import { humanFormatSessionCost, formatTime } from "./statusbar-utils"
 
 const SUPPORTED_PROVIDER_DISPLAY_NAME = "Kilo Gateway"
-const SETTINGS_COMMAND = "command:kilo-code.new.settingsButtonClicked"
+const SETTINGS_COMMAND = `command:kilo-code.new.settingsButtonClicked?${encodeURIComponent(JSON.stringify(["autocomplete"]))}`
 
 export class AutocompleteStatusBar {
   statusBar: vscode.StatusBarItem

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/ar.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/ar.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (معطل)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**لا يوجد رصيد في حسابك**\n\nحساب Kilo Code الخاص بك لا يحتوي على رصيد. لاستخدام الإكمال التلقائي، يرجى إضافة رصيد إلى حسابك.\n\n[فتح الإعدادات](command:kilo-code.settingsButtonClicked)",
+    "**لا يوجد رصيد في حسابك**\n\nحساب Kilo Code الخاص بك لا يحتوي على رصيد. لاستخدام الإكمال التلقائي، يرجى إضافة رصيد إلى حسابك.\n\n[فتح الإعدادات]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**لم يتم تكوين نموذج الإكمال التلقائي**\n\nلتمكين الإكمال التلقائي، أضف ملفًا شخصيًا مع أحد هذه المزودين المدعومين: {{providers}}.\n\n[فتح الإعدادات](command:kilo-code.settingsButtonClicked)",
+    "**لم يتم تكوين نموذج الإكمال التلقائي**\n\nلتمكين الإكمال التلقائي، أضف ملفًا شخصيًا مع أحد هذه المزودين المدعومين: {{providers}}.\n\n[فتح الإعدادات]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "إجمالي تكلفة الجلسة:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "المزود:",
   "kilocode:autocomplete.statusBar.tooltip.model": "النموذج:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/ca.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/ca.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (desactivat)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**No tens crèdits al teu compte**\n\nEl teu compte de Kilo Code no té crèdits. Per utilitzar l'autocompletat, si us plau afegeix crèdits al teu compte.\n\n[Obrir Configuració](command:kilo-code.settingsButtonClicked)",
+    "**No tens crèdits al teu compte**\n\nEl teu compte de Kilo Code no té crèdits. Per utilitzar l'autocompletat, si us plau afegeix crèdits al teu compte.\n\n[Obrir Configuració]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**No s'ha configurat cap model d'autocompletat**\n\nPer habilitar l'autocompletat, afegeix un perfil amb un d'aquests proveïdors compatibles: {{providers}}.\n\n[Obrir Configuració](command:kilo-code.settingsButtonClicked)",
+    "**No s'ha configurat cap model d'autocompletat**\n\nPer habilitar l'autocompletat, afegeix un perfil amb un d'aquests proveïdors compatibles: {{providers}}.\n\n[Obrir Configuració]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Cost total de la sessió:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Proveïdor:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Model:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/cs.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/cs.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (zakázáno)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**Na tvém účtu nejsou žádné kredity**\n\nTvůj účet Kilo Code nemá žádné kredity. Pro použití automatického doplňování prosím přidej kredity na svůj účet.\n\n[Otevřít Nastavení](command:kilo-code.settingsButtonClicked)",
+    "**Na tvém účtu nejsou žádné kredity**\n\nTvůj účet Kilo Code nemá žádné kredity. Pro použití automatického doplňování prosím přidej kredity na svůj účet.\n\n[Otevřít Nastavení]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Není nakonfigurován žádný model automatického doplňování**\n\nPro povolení automatického doplňování přidej profil s jedním z těchto podporovaných poskytovatelů: {{providers}}.\n\n[Otevřít Nastavení](command:kilo-code.settingsButtonClicked)",
+    "**Není nakonfigurován žádný model automatického doplňování**\n\nPro povolení automatického doplňování přidej profil s jedním z těchto podporovaných poskytovatelů: {{providers}}.\n\n[Otevřít Nastavení]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Celkové náklady relace:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Poskytovatel:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Model:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/de.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/de.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (deaktiviert)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**Kein Guthaben auf deinem Konto**\n\nDein Kilo Code Konto hat kein Guthaben. Um Autocomplete zu nutzen, füge bitte Guthaben zu deinem Konto hinzu.\n\n[Einstellungen öffnen](command:kilo-code.settingsButtonClicked)",
+    "**Kein Guthaben auf deinem Konto**\n\nDein Kilo Code Konto hat kein Guthaben. Um Autocomplete zu nutzen, füge bitte Guthaben zu deinem Konto hinzu.\n\n[Einstellungen öffnen]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Kein Autocomplete-Modell konfiguriert**\n\nUm Autocomplete zu aktivieren, füge ein Profil mit einem dieser unterstützten Anbieter hinzu: {{providers}}.\n\n[Einstellungen öffnen](command:kilo-code.settingsButtonClicked)",
+    "**Kein Autocomplete-Modell konfiguriert**\n\nUm Autocomplete zu aktivieren, füge ein Profil mit einem dieser unterstützten Anbieter hinzu: {{providers}}.\n\n[Einstellungen öffnen]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Sitzungsgesamtkosten:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Anbieter:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Modell:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/en.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/en.ts
@@ -8,9 +8,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (disabled)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**No credits in your account**\n\nYour Kilo Code account has no credits. To use autocomplete, please add credits to your account.\n\n[Open Settings](command:kilo-code.settingsButtonClicked)",
+    "**No credits in your account**\n\nYour Kilo Code account has no credits. To use autocomplete, please add credits to your account.\n\n[Open Settings]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**No autocomplete model configured**\n\nTo enable autocomplete, add a profile with one of these supported providers: {{providers}}.\n\n[Open Settings](command:kilo-code.settingsButtonClicked)",
+    "**No autocomplete model configured**\n\nTo enable autocomplete, add a profile with one of these supported providers: {{providers}}.\n\n[Open Settings]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Session total cost:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Provider:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Model:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/es.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/es.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (deshabilitado)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**No hay créditos en tu cuenta**\n\nTu cuenta de Kilo Code no tiene créditos. Para usar el autocompletado, por favor añade créditos a tu cuenta.\n\n[Abrir Configuración](command:kilo-code.settingsButtonClicked)",
+    "**No hay créditos en tu cuenta**\n\nTu cuenta de Kilo Code no tiene créditos. Para usar el autocompletado, por favor añade créditos a tu cuenta.\n\n[Abrir Configuración]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**No hay modelo de autocompletado configurado**\n\nPara habilitar el autocompletado, añade un perfil con uno de estos proveedores compatibles: {{providers}}.\n\n[Abrir Configuración](command:kilo-code.settingsButtonClicked)",
+    "**No hay modelo de autocompletado configurado**\n\nPara habilitar el autocompletado, añade un perfil con uno de estos proveedores compatibles: {{providers}}.\n\n[Abrir Configuración]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Costo total de la sesión:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Proveedor:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Modelo:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/fr.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/fr.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (désactivé)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**Pas de crédits sur ton compte**\n\nTon compte Kilo Code n'a pas de crédits. Pour utiliser l'autocomplétion, ajoute des crédits à ton compte.\n\n[Ouvrir les Paramètres](command:kilo-code.settingsButtonClicked)",
+    "**Pas de crédits sur ton compte**\n\nTon compte Kilo Code n'a pas de crédits. Pour utiliser l'autocomplétion, ajoute des crédits à ton compte.\n\n[Ouvrir les Paramètres]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Aucun modèle d'autocomplétion configuré**\n\nPour activer l'autocomplétion, ajoute un profil avec l'un de ces fournisseurs pris en charge : {{providers}}.\n\n[Ouvrir les Paramètres](command:kilo-code.settingsButtonClicked)",
+    "**Aucun modèle d'autocomplétion configuré**\n\nPour activer l'autocomplétion, ajoute un profil avec l'un de ces fournisseurs pris en charge : {{providers}}.\n\n[Ouvrir les Paramètres]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Coût total de la session :",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Fournisseur:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Modèle :",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/hi.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/hi.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (अक्षम)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**आपके खाते में कोई क्रेडिट नहीं है**\n\nआपके Kilo Code खाते में कोई क्रेडिट नहीं है। ऑटोकम्प्लीट का उपयोग करने के लिए, कृपया अपने खाते में क्रेडिट जोड़ें।\n\n[सेटिंग्स खोलें](command:kilo-code.settingsButtonClicked)",
+    "**आपके खाते में कोई क्रेडिट नहीं है**\n\nआपके Kilo Code खाते में कोई क्रेडिट नहीं है। ऑटोकम्प्लीट का उपयोग करने के लिए, कृपया अपने खाते में क्रेडिट जोड़ें।\n\n[सेटिंग्स खोलें]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**कोई ऑटोकम्प्लीट मॉडल कॉन्फ़िगर नहीं किया गया**\n\nऑटोकम्प्लीट सक्षम करने के लिए, इन समर्थित प्रदाताओं में से एक के साथ एक प्रोफ़ाइल जोड़ें: {{providers}}।\n\n[सेटिंग्स खोलें](command:kilo-code.settingsButtonClicked)",
+    "**कोई ऑटोकम्प्लीट मॉडल कॉन्फ़िगर नहीं किया गया**\n\nऑटोकम्प्लीट सक्षम करने के लिए, इन समर्थित प्रदाताओं में से एक के साथ एक प्रोफ़ाइल जोड़ें: {{providers}}।\n\n[सेटिंग्स खोलें]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "सत्र की कुल लागत:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "प्रदाता:",
   "kilocode:autocomplete.statusBar.tooltip.model": "मॉडल:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/id.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/id.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (dinonaktifkan)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**Tidak ada kredit di akun kamu**\n\nAkun Kilo Code kamu tidak memiliki kredit. Untuk menggunakan autocomplete, silakan tambahkan kredit ke akun kamu.\n\n[Buka Pengaturan](command:kilo-code.settingsButtonClicked)",
+    "**Tidak ada kredit di akun kamu**\n\nAkun Kilo Code kamu tidak memiliki kredit. Untuk menggunakan autocomplete, silakan tambahkan kredit ke akun kamu.\n\n[Buka Pengaturan]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Tidak ada model autocomplete yang dikonfigurasi**\n\nUntuk mengaktifkan autocomplete, tambahkan profil dengan salah satu penyedia yang didukung ini: {{providers}}.\n\n[Buka Pengaturan](command:kilo-code.settingsButtonClicked)",
+    "**Tidak ada model autocomplete yang dikonfigurasi**\n\nUntuk mengaktifkan autocomplete, tambahkan profil dengan salah satu penyedia yang didukung ini: {{providers}}.\n\n[Buka Pengaturan]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Total biaya sesi:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Penyedia:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Model:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/it.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/it.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (disabilitato)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**Nessun credito nel tuo account**\n\nIl tuo account Kilo Code non ha crediti. Per usare l'autocompletamento, aggiungi crediti al tuo account.\n\n[Apri Impostazioni](command:kilo-code.settingsButtonClicked)",
+    "**Nessun credito nel tuo account**\n\nIl tuo account Kilo Code non ha crediti. Per usare l'autocompletamento, aggiungi crediti al tuo account.\n\n[Apri Impostazioni]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Nessun modello di autocompletamento configurato**\n\nPer abilitare l'autocompletamento, aggiungi un profilo con uno di questi provider supportati: {{providers}}.\n\n[Apri Impostazioni](command:kilo-code.settingsButtonClicked)",
+    "**Nessun modello di autocompletamento configurato**\n\nPer abilitare l'autocompletamento, aggiungi un profilo con uno di questi provider supportati: {{providers}}.\n\n[Apri Impostazioni]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Costo totale della sessione:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Provider:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Modello:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/ja.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/ja.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete（無効）",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**アカウントにクレジットがありません**\n\nKilo Code アカウントにクレジットがありません。オートコンプリートを使用するには、アカウントにクレジットを追加してください。\n\n[設定を開く](command:kilo-code.settingsButtonClicked)",
+    "**アカウントにクレジットがありません**\n\nKilo Code アカウントにクレジットがありません。オートコンプリートを使用するには、アカウントにクレジットを追加してください。\n\n[設定を開く]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**オートコンプリートモデルが設定されていません**\n\nオートコンプリートを有効にするには、これらのサポートされているプロバイダーのいずれかでプロファイルを追加してください: {{providers}}。\n\n[設定を開く](command:kilo-code.settingsButtonClicked)",
+    "**オートコンプリートモデルが設定されていません**\n\nオートコンプリートを有効にするには、これらのサポートされているプロバイダーのいずれかでプロファイルを追加してください: {{providers}}。\n\n[設定を開く]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "セッション合計コスト:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "プロバイダー:",
   "kilocode:autocomplete.statusBar.tooltip.model": "モデル:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/ko.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/ko.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (비활성화됨)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**계정에 크레딧이 없습니다**\n\nKilo Code 계정에 크레딧이 없습니다. 자동완성을 사용하려면 계정에 크레딧을 추가해 주세요.\n\n[설정 열기](command:kilo-code.settingsButtonClicked)",
+    "**계정에 크레딧이 없습니다**\n\nKilo Code 계정에 크레딧이 없습니다. 자동완성을 사용하려면 계정에 크레딧을 추가해 주세요.\n\n[설정 열기]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**자동완성 모델이 구성되지 않았습니다**\n\n자동완성을 활성화하려면 다음 지원되는 제공업체 중 하나로 프로필을 추가하세요: {{providers}}.\n\n[설정 열기](command:kilo-code.settingsButtonClicked)",
+    "**자동완성 모델이 구성되지 않았습니다**\n\n자동완성을 활성화하려면 다음 지원되는 제공업체 중 하나로 프로필을 추가하세요: {{providers}}.\n\n[설정 열기]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "세션 총 비용:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "제공업체:",
   "kilocode:autocomplete.statusBar.tooltip.model": "모델:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/nl.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/nl.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (uitgeschakeld)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**Geen tegoed op je account**\n\nJe Kilo Code account heeft geen tegoed. Om autocomplete te gebruiken, voeg tegoed toe aan je account.\n\n[Instellingen openen](command:kilo-code.settingsButtonClicked)",
+    "**Geen tegoed op je account**\n\nJe Kilo Code account heeft geen tegoed. Om autocomplete te gebruiken, voeg tegoed toe aan je account.\n\n[Instellingen openen]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Geen autocomplete model geconfigureerd**\n\nOm autocomplete in te schakelen, voeg een profiel toe met een van deze ondersteunde providers: {{providers}}.\n\n[Instellingen openen](command:kilo-code.settingsButtonClicked)",
+    "**Geen autocomplete model geconfigureerd**\n\nOm autocomplete in te schakelen, voeg een profiel toe met een van deze ondersteunde providers: {{providers}}.\n\n[Instellingen openen]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Totale sessiekosten:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Provider:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Model:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/pl.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/pl.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (wyłączone)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**Brak środków na koncie**\n\nTwoje konto Kilo Code nie ma środków. Aby korzystać z autouzupełniania, dodaj środki do swojego konta.\n\n[Otwórz Ustawienia](command:kilo-code.settingsButtonClicked)",
+    "**Brak środków na koncie**\n\nTwoje konto Kilo Code nie ma środków. Aby korzystać z autouzupełniania, dodaj środki do swojego konta.\n\n[Otwórz Ustawienia]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Nie skonfigurowano modelu autouzupełniania**\n\nAby włączyć autouzupełnianie, dodaj profil z jednym z tych obsługiwanych dostawców: {{providers}}.\n\n[Otwórz Ustawienia](command:kilo-code.settingsButtonClicked)",
+    "**Nie skonfigurowano modelu autouzupełniania**\n\nAby włączyć autouzupełnianie, dodaj profil z jednym z tych obsługiwanych dostawców: {{providers}}.\n\n[Otwórz Ustawienia]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Całkowity koszt sesji:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Dostawca:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Model:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/pt-BR.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/pt-BR.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (desabilitado)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**Sem créditos na sua conta**\n\nSua conta Kilo Code não tem créditos. Para usar o autocompletar, adicione créditos à sua conta.\n\n[Abrir Configurações](command:kilo-code.settingsButtonClicked)",
+    "**Sem créditos na sua conta**\n\nSua conta Kilo Code não tem créditos. Para usar o autocompletar, adicione créditos à sua conta.\n\n[Abrir Configurações]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Nenhum modelo de autocompletar configurado**\n\nPara habilitar o autocompletar, adicione um perfil com um destes provedores suportados: {{providers}}.\n\n[Abrir Configurações](command:kilo-code.settingsButtonClicked)",
+    "**Nenhum modelo de autocompletar configurado**\n\nPara habilitar o autocompletar, adicione um perfil com um destes provedores suportados: {{providers}}.\n\n[Abrir Configurações]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Custo total da sessão:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Provedor:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Modelo:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/ru.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/ru.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (отключено)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**На вашем счёте нет кредитов**\n\nНа вашем счёте Kilo Code нет кредитов. Чтобы использовать автодополнение, пожалуйста, пополните счёт.\n\n[Открыть Настройки](command:kilo-code.settingsButtonClicked)",
+    "**На вашем счёте нет кредитов**\n\nНа вашем счёте Kilo Code нет кредитов. Чтобы использовать автодополнение, пожалуйста, пополните счёт.\n\n[Открыть Настройки]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Модель автодополнения не настроена**\n\nЧтобы включить автодополнение, добавьте профиль с одним из поддерживаемых провайдеров: {{providers}}.\n\n[Открыть Настройки](command:kilo-code.settingsButtonClicked)",
+    "**Модель автодополнения не настроена**\n\nЧтобы включить автодополнение, добавьте профиль с одним из поддерживаемых провайдеров: {{providers}}.\n\n[Открыть Настройки]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Общая стоимость сессии:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Провайдер:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Модель:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/sk.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/sk.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (zakázané)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**Na tvojom účte nie sú žiadne kredity**\n\nTvoj účet Kilo Code nemá žiadne kredity. Pre použitie automatického doplňovania prosím pridaj kredity na svoj účet.\n\n[Otvoriť Nastavenia](command:kilo-code.settingsButtonClicked)",
+    "**Na tvojom účte nie sú žiadne kredity**\n\nTvoj účet Kilo Code nemá žiadne kredity. Pre použitie automatického doplňovania prosím pridaj kredity na svoj účet.\n\n[Otvoriť Nastavenia]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Nie je nakonfigurovaný žiadny model automatického doplňovania**\n\nPre povolenie automatického doplňovania pridaj profil s jedným z týchto podporovaných poskytovateľov: {{providers}}.\n\n[Otvoriť Nastavenia](command:kilo-code.settingsButtonClicked)",
+    "**Nie je nakonfigurovaný žiadny model automatického doplňovania**\n\nPre povolenie automatického doplňovania pridaj profil s jedným z týchto podporovaných poskytovateľov: {{providers}}.\n\n[Otvoriť Nastavenia]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Celkové náklady relácie:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Poskytovateľ:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Model:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/th.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/th.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (ปิดใช้งาน)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**ไม่มีเครดิตในบัญชีของคุณ**\n\nบัญชี Kilo Code ของคุณไม่มีเครดิต หากต้องการใช้การเติมข้อความอัตโนมัติ กรุณาเพิ่มเครดิตในบัญชีของคุณ\n\n[เปิดการตั้งค่า](command:kilo-code.settingsButtonClicked)",
+    "**ไม่มีเครดิตในบัญชีของคุณ**\n\nบัญชี Kilo Code ของคุณไม่มีเครดิต หากต้องการใช้การเติมข้อความอัตโนมัติ กรุณาเพิ่มเครดิตในบัญชีของคุณ\n\n[เปิดการตั้งค่า]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**ไม่ได้กำหนดค่าโมเดลการเติมข้อความอัตโนมัติ**\n\nหากต้องการเปิดใช้งานการเติมข้อความอัตโนมัติ ให้เพิ่มโปรไฟล์กับผู้ให้บริการที่รองรับเหล่านี้: {{providers}}\n\n[เปิดการตั้งค่า](command:kilo-code.settingsButtonClicked)",
+    "**ไม่ได้กำหนดค่าโมเดลการเติมข้อความอัตโนมัติ**\n\nหากต้องการเปิดใช้งานการเติมข้อความอัตโนมัติ ให้เพิ่มโปรไฟล์กับผู้ให้บริการที่รองรับเหล่านี้: {{providers}}\n\n[เปิดการตั้งค่า]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "ค่าใช้จ่ายรวมของเซสชัน:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "ผู้ให้บริการ:",
   "kilocode:autocomplete.statusBar.tooltip.model": "โมเดล:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/tr.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/tr.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (devre dışı)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**Hesabınızda kredi yok**\n\nKilo Code hesabınızda kredi bulunmuyor. Otomatik tamamlamayı kullanmak için lütfen hesabınıza kredi ekleyin.\n\n[Ayarları Aç](command:kilo-code.settingsButtonClicked)",
+    "**Hesabınızda kredi yok**\n\nKilo Code hesabınızda kredi bulunmuyor. Otomatik tamamlamayı kullanmak için lütfen hesabınıza kredi ekleyin.\n\n[Ayarları Aç]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Otomatik tamamlama modeli yapılandırılmadı**\n\nOtomatik tamamlamayı etkinleştirmek için desteklenen sağlayıcılardan biriyle bir profil ekleyin: {{providers}}.\n\n[Ayarları Aç](command:kilo-code.settingsButtonClicked)",
+    "**Otomatik tamamlama modeli yapılandırılmadı**\n\nOtomatik tamamlamayı etkinleştirmek için desteklenen sağlayıcılardan biriyle bir profil ekleyin: {{providers}}.\n\n[Ayarları Aç]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Oturum toplam maliyeti:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Sağlayıcı:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Model:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/uk.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/uk.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (вимкнено)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**На вашому рахунку немає кредитів**\n\nНа вашому рахунку Kilo Code немає кредитів. Щоб використовувати автодоповнення, будь ласка, поповніть рахунок.\n\n[Відкрити Налаштування](command:kilo-code.settingsButtonClicked)",
+    "**На вашому рахунку немає кредитів**\n\nНа вашому рахунку Kilo Code немає кредитів. Щоб використовувати автодоповнення, будь ласка, поповніть рахунок.\n\n[Відкрити Налаштування]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Модель автодоповнення не налаштована**\n\nЩоб увімкнути автодоповнення, додайте профіль з одним із підтримуваних провайдерів: {{providers}}.\n\n[Відкрити Налаштування](command:kilo-code.settingsButtonClicked)",
+    "**Модель автодоповнення не налаштована**\n\nЩоб увімкнути автодоповнення, додайте профіль з одним із підтримуваних провайдерів: {{providers}}.\n\n[Відкрити Налаштування]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Загальна вартість сесії:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Провайдер:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Модель:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/vi.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/vi.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete (đã tắt)",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**Không có tín dụng trong tài khoản của bạn**\n\nTài khoản Kilo Code của bạn không có tín dụng. Để sử dụng tự động hoàn thành, vui lòng thêm tín dụng vào tài khoản của bạn.\n\n[Mở Cài đặt](command:kilo-code.settingsButtonClicked)",
+    "**Không có tín dụng trong tài khoản của bạn**\n\nTài khoản Kilo Code của bạn không có tín dụng. Để sử dụng tự động hoàn thành, vui lòng thêm tín dụng vào tài khoản của bạn.\n\n[Mở Cài đặt]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**Chưa cấu hình mô hình tự động hoàn thành**\n\nĐể bật tự động hoàn thành, hãy thêm hồ sơ với một trong các nhà cung cấp được hỗ trợ sau: {{providers}}.\n\n[Mở Cài đặt](command:kilo-code.settingsButtonClicked)",
+    "**Chưa cấu hình mô hình tự động hoàn thành**\n\nĐể bật tự động hoàn thành, hãy thêm hồ sơ với một trong các nhà cung cấp được hỗ trợ sau: {{providers}}.\n\n[Mở Cài đặt]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "Tổng chi phí phiên:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "Nhà cung cấp:",
   "kilocode:autocomplete.statusBar.tooltip.model": "Mô hình:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/zh-CN.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/zh-CN.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete（已禁用）",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**账户余额不足**\n\n你的 Kilo Code 账户没有余额。要使用自动补全功能，请为账户充值。\n\n[打开设置](command:kilo-code.settingsButtonClicked)",
+    "**账户余额不足**\n\n你的 Kilo Code 账户没有余额。要使用自动补全功能，请为账户充值。\n\n[打开设置]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**未配置自动补全模型**\n\n要启用自动补全，请添加一个使用以下支持的提供商的配置文件：{{providers}}。\n\n[打开设置](command:kilo-code.settingsButtonClicked)",
+    "**未配置自动补全模型**\n\n要启用自动补全，请添加一个使用以下支持的提供商的配置文件：{{providers}}。\n\n[打开设置]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "会话总费用:",
   "kilocode:autocomplete.statusBar.tooltip.provider": "提供商:",
   "kilocode:autocomplete.statusBar.tooltip.model": "模型:",

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/zh-TW.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/zh-TW.ts
@@ -7,9 +7,9 @@ export const dict = {
   "kilocode:autocomplete.statusBar.tooltip.basic": "Kilo Code Autocomplete",
   "kilocode:autocomplete.statusBar.tooltip.disabled": "Kilo Code Autocomplete（已停用）",
   "kilocode:autocomplete.statusBar.tooltip.noCredits":
-    "**帳戶中沒有額度**\n\nKilo Code 帳戶沒有額度。若要使用 Autocomplete，請為帳戶儲值。\n\n[開啟設定](command:kilo-code.settingsButtonClicked)",
+    "**帳戶中沒有額度**\n\nKilo Code 帳戶沒有額度。若要使用 Autocomplete，請為帳戶儲值。\n\n[開啟設定]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.noUsableProvider":
-    "**未設定 Autocomplete 模型**\n\n若要啟用 Autocomplete，請新增一個使用以下支援供應商的設定檔：{{providers}}。\n\n[開啟設定](command:kilo-code.settingsButtonClicked)",
+    "**未設定 Autocomplete 模型**\n\n若要啟用 Autocomplete，請新增一個使用以下支援供應商的設定檔：{{providers}}。\n\n[開啟設定]({{command}})",
   "kilocode:autocomplete.statusBar.tooltip.sessionTotal": "工作階段總費用：",
   "kilocode:autocomplete.statusBar.tooltip.provider": "供應商：",
   "kilocode:autocomplete.statusBar.tooltip.model": "模型：",

--- a/packages/kilo-vscode/tests/unit/i18n-shim.test.ts
+++ b/packages/kilo-vscode/tests/unit/i18n-shim.test.ts
@@ -20,6 +20,7 @@ describe("t()", () => {
   it("interpolates a single variable", () => {
     const result = t("kilocode:autocomplete.statusBar.tooltip.noUsableProvider", {
       providers: "OpenAI, Anthropic",
+      command: "command:kilo-code.new.settingsButtonClicked",
     })
     expect(result).toContain("OpenAI, Anthropic")
     expect(result).not.toContain("{{providers}}")


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `command:kilo-code.settingsButtonClicked` URI in all 23 i18n locale files with a `{{command}}` interpolation placeholder
- Defines the correct command URI (`command:kilo-code.new.settingsButtonClicked`) as a single constant `SETTINGS_COMMAND` in `AutocompleteStatusBar.ts` and passes it to the `t()` function
- Updates the i18n shim test to account for the new interpolation variable

## Motivation

PR #7080 fixed a bug where the command URI was wrong across 23 locale files. Having the command string hardcoded in every translation file is fragile — if the command name changes again, all 23 files must be updated in lockstep. By using i18n interpolation (which the existing `t()` shim already supports via `{{variable}}` syntax), the command is defined once in the code that calls the translation function, eliminating this class of bugs entirely.

## Changes

| File | Change |
| --- | --- |
| `AutocompleteStatusBar.ts` | Added `SETTINGS_COMMAND` constant; pass `{ command: SETTINGS_COMMAND }` to both `t()` calls for `noCredits` and `noUsableProvider` |
| `i18n/*.ts` (23 files) | Replaced `command:kilo-code.settingsButtonClicked` with `{{command}}` in `noCredits` and `noUsableProvider` translation strings |
| `tests/unit/i18n-shim.test.ts` | Updated test to pass the `command` variable alongside `providers` |
