### PR TITLE
fix: use correct config.json schema URL (app.kilo.ai)

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -196,7 +196,7 @@ You can set permissions globally (with `*`), and override specific tools.
 
 ```json
 {
-  "$schema": "https://kilo.ai/config.json",
+  "$schema": "https://app.kilo.ai/config.json",
   "permission": {
     "*": "ask",
     "bash": "allow",
@@ -209,7 +209,7 @@ You can also set all permissions at once:
 
 ```json
 {
-  "$schema": "https://kilo.ai/config.json",
+  "$schema": "https://app.kilo.ai/config.json",
   "permission": "allow"
 }
 ```
@@ -261,7 +261,7 @@ Use `external_directory` to allow tool calls that touch paths outside the workin
 
 ```json
 {
-  "$schema": "https://kilo.ai/config.json",
+  "$schema": "https://app.kilo.ai/config.json",
   "permission": {
     "external_directory": {
       "~/projects/personal/**": "allow"
@@ -274,7 +274,7 @@ Any directory allowed here inherits the same defaults as the current workspace. 
 
 ```json
 {
-  "$schema": "https://kilo.ai/config.json",
+  "$schema": "https://app.kilo.ai/config.json",
   "permission": {
     "external_directory": {
       "~/projects/personal/**": "allow"

--- a/packages/kilo-docs/pages/customize/custom-subagents.md
+++ b/packages/kilo-docs/pages/customize/custom-subagents.md
@@ -51,7 +51,7 @@ Add agents to the `agent` section of your `kilo.json` config file. Any key that 
 
 ```json
 {
-  "$schema": "https://kilo.ai/config.json",
+  "$schema": "https://app.kilo.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -186,7 +186,7 @@ export namespace Config {
         const wellknown = (await response.json()) as any
         const remoteConfig = wellknown.config ?? {}
         // Add $schema to prevent load() from trying to write back to a non-existent file
-        if (!remoteConfig.$schema) remoteConfig.$schema = "https://kilo.ai/config.json" // kilocode_change
+        if (!remoteConfig.$schema) remoteConfig.$schema = "https://app.kilo.ai/config.json" // kilocode_change
         result = mergeConfigConcatArrays(
           result,
           await load(JSON.stringify(remoteConfig), {
@@ -1330,7 +1330,7 @@ export namespace Config {
         .then(async (mod) => {
           const { provider, model, ...rest } = mod.default
           if (provider && model) result.model = `${provider}/${model}`
-          result["$schema"] = "https://kilo.ai/config.json" // kilocode_change
+          result["$schema"] = "https://app.kilo.ai/config.json" // kilocode_change
           result = mergeDeep(result, rest)
           await Filesystem.writeJson(path.join(Global.Path.config, "config.json"), result)
           await fs.unlink(legacy)
@@ -1374,8 +1374,8 @@ export namespace Config {
     const parsed = Info.safeParse(normalized)
     if (parsed.success) {
       if (!parsed.data.$schema && isFile) {
-        parsed.data.$schema = "https://kilo.ai/config.json" // kilocode_change
-        const updated = original.replace(/^\s*\{/, '{\n  "$schema": "https://kilo.ai/config.json",') // kilocode_change
+        parsed.data.$schema = "https://app.kilo.ai/config.json" // kilocode_change
+        const updated = original.replace(/^\s*\{/, '{\n  "$schema": "https://app.kilo.ai/config.json",') // kilocode_change
         await Bun.write(options.path, updated).catch(() => {})
       }
       const data = parsed.data


### PR DESCRIPTION
## What

Updates the `$schema` URL from `https://kilo.ai/config.json` (404) to `https://app.kilo.ai/config.json` (valid).

## Why

As reported in #7063, `https://kilo.ai/config.json` returns 404. The correct schema URL is `https://app.kilo.ai/config.json`, which is already used in the test files.

## Changes

| File | Occurrences |
|------|-------------|
| `packages/opencode/src/config/config.ts` | 4 |
| `packages/kilo-docs/pages/code-with-ai/platforms/cli.md` | 4 |
| `packages/kilo-docs/pages/customize/custom-subagents.md` | 1 |

**Total:** 9 replacements across 3 files.

## How verified

- Confirmed `https://kilo.ai/config.json` returns 404
- Confirmed `https://app.kilo.ai/config.json` returns valid JSON schema
- All test files already use the correct URL — no test changes needed
- Grep confirms zero remaining references to the old URL

Fixes #7063