### PR TITLE
Add auto-docs workflow for merged feat PRs

### DIFF
--- a/.github/workflows/auto-docs.yml
+++ b/.github/workflows/auto-docs.yml
@@ -1,0 +1,26 @@
+name: Documentation Webhook on trigger on Feat PRs
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  webhook:
+    # Only run if the PR was merged AND the head branch name contains 'feat'
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.head.ref, 'feat')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Webhook
+        run: |
+          curl -X POST ${{ secrets.DOC_WEBHOOK_URL }} \
+          -H "Content-Type: application/json" \
+           -d '{
+            "repo": "${{ github.repository }}",
+            "pr_number": "${{ github.event.pull_request.number }}",
+            "title": "${{ github.event.pull_request.title }}",
+            "description": "${{ github.event.pull_request.body }}",
+            "author": "${{ github.event.pull_request.user.login }}",
+            "merged_at": "${{ github.event.pull_request.merged_at }}"
+          }'

--- a/.github/workflows/auto-docs.yml
+++ b/.github/workflows/auto-docs.yml
@@ -1,26 +1,35 @@
-name: Documentation Webhook on trigger on Feat PRs
+name: Trigger webhook for feat PRs
 
 on:
   pull_request:
     types: [closed]
-    branches:
-      - main
 
 jobs:
-  webhook:
-    # Only run if the PR was merged AND the head branch name contains 'feat'
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.head.ref, 'feat')
+  call-webhook:
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.title, 'feat:')
     runs-on: ubuntu-latest
+
     steps:
-      - name: Send Webhook
+      - name: Send webhook safely
         run: |
-          curl -X POST ${{ secrets.DOC_WEBHOOK_URL }} \
-          -H "Content-Type: application/json" \
-           -d '{
-            "repo": "${{ github.repository }}",
-            "pr_number": "${{ github.event.pull_request.number }}",
-            "title": "${{ github.event.pull_request.title }}",
-            "description": "${{ github.event.pull_request.body }}",
-            "author": "${{ github.event.pull_request.user.login }}",
-            "merged_at": "${{ github.event.pull_request.merged_at }}"
-          }'
+          payload=$(jq -n \
+            --arg repo "${GITHUB_REPOSITORY}" \
+            --arg pr_number "${{ github.event.pull_request.number }}" \
+            --arg title "${{ github.event.pull_request.title }}" \
+            --arg body "${{ github.event.pull_request.body }}" \
+            --arg author "${{ github.event.pull_request.user.login }}" \
+            --arg merged_at "${{ github.event.pull_request.merged_at }}" \
+            '{
+              repo: $repo,
+              pr_number: $pr_number,
+              title: $title,
+              description: $body,
+              author: $author,
+              merged_at: $merged_at
+            }'
+          )
+          curl --fail-with-body -X POST "${{ secrets.DOC_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            --data-raw "$payload"


### PR DESCRIPTION
This workflow triggers a webhook when a pull request is closed and merged, specifically for branches containing 'feat'. It sends relevant PR data to a specified webhook URL.

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
