### PR TITLE
fix(vscode): append to prompt instead of replacing on Add to Context

### DIFF
--- a/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
@@ -61,8 +61,7 @@ export function registerCodeActions(
         endLine: String(ctx.endLine),
         selectedText: ctx.selectedText,
       })
-      target().postMessage({ type: "setChatBoxMessage", text: prompt })
-      target().postMessage({ type: "action", action: "focusInput" })
+      target().postMessage({ type: "appendChatBoxMessage", text: prompt })
     }),
 
     vscode.commands.registerCommand("kilo-code.new.focusChatInput", () => {


### PR DESCRIPTION
## Summary

- **Fixes #7092**: The "Add to Context" command (`Cmd+K Cmd+A`) was replacing the entire prompt content instead of appending to it, causing users to lose any text they had already typed.

## Root Cause

In `register-code-actions.ts`, the `addToContext` command was sending a `setChatBoxMessage` message to the webview, which overwrites the entire textarea content. The webview already had an `appendChatBoxMessage` handler that correctly preserves existing text and appends new content with a `\n\n` separator.

## Fix

Changed the message type from `setChatBoxMessage` to `appendChatBoxMessage`. This also removes the separate `focusInput` message since `appendChatBoxMessage` already handles focusing the textarea and scrolling to the bottom.
