### PR TITLE
fix(vscode): implement terminal Add to Context using clipboard-based selection

### DIFF
--- a/packages/kilo-vscode/docs/non-agent-features/editor-context-menus-and-code-actions.md
+++ b/packages/kilo-vscode/docs/non-agent-features/editor-context-menus-and-code-actions.md
@@ -14,7 +14,6 @@
 
 ## Remaining Work
 
-- Terminal content capture — `getTerminalSelection()` is a **placeholder** returning empty string. Needs VS Code shell integration API for actual terminal content reading
 - Custom prompt overrides via extension settings (user-customizable prompt templates)
 
 ## Prompt Templates Reference

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -183,7 +183,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register code actions (editor context menus, terminal context menus, keyboard shortcuts)
   registerCodeActions(context, provider, agentManagerProvider)
-  registerTerminalActions(context, provider)
+  registerTerminalActions(context, provider, agentManagerProvider)
 
   // Register CodeActionProvider (lightbulb quick fixes)
   context.subscriptions.push(

--- a/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
@@ -61,8 +61,7 @@ export function registerCodeActions(
         endLine: String(ctx.endLine),
         selectedText: ctx.selectedText,
       })
-      target().postMessage({ type: "setChatBoxMessage", text: prompt })
-      target().postMessage({ type: "action", action: "focusInput" })
+      target().postMessage({ type: "appendChatBoxMessage", text: prompt })
     }),
 
     vscode.commands.registerCommand("kilo-code.new.focusChatInput", () => {

--- a/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
@@ -61,11 +61,8 @@ export function registerCodeActions(
         endLine: String(ctx.endLine),
         selectedText: ctx.selectedText,
       })
-      target().postMessage({ type: "appendChatBoxMessage", text: prompt })
-<<<<<<< HEAD
-=======
+      target().postMessage({ type: "setChatBoxMessage", text: prompt })
       target().postMessage({ type: "action", action: "focusInput" })
->>>>>>> 70920c798 (fix(vscode): implement terminal Add to Context using clipboard-based selection)
     }),
 
     vscode.commands.registerCommand("kilo-code.new.focusChatInput", () => {

--- a/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
@@ -62,6 +62,10 @@ export function registerCodeActions(
         selectedText: ctx.selectedText,
       })
       target().postMessage({ type: "appendChatBoxMessage", text: prompt })
+<<<<<<< HEAD
+=======
+      target().postMessage({ type: "action", action: "focusInput" })
+>>>>>>> 70920c798 (fix(vscode): implement terminal Add to Context using clipboard-based selection)
     }),
 
     vscode.commands.registerCommand("kilo-code.new.focusChatInput", () => {

--- a/packages/kilo-vscode/src/services/code-actions/register-terminal-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-terminal-actions.ts
@@ -3,21 +3,50 @@ import type { KiloProvider } from "../../KiloProvider"
 import type { AgentManagerProvider } from "../../agent-manager/AgentManagerProvider"
 import { createPrompt } from "./support-prompt"
 
-async function getTerminalSelection(): Promise<string> {
-  const terminal = vscode.window.activeTerminal
-  if (!terminal) return ""
-  // VS Code terminal API doesn't expose selection text directly.
-  // Copy the terminal selection to clipboard, read it, then restore.
-  const previous = await vscode.env.clipboard.readText()
-  await vscode.commands.executeCommand("workbench.action.terminal.copySelection")
-  const selection = await vscode.env.clipboard.readText()
-  // Restore original clipboard content if it changed
-  if (selection !== previous) {
-    await vscode.env.clipboard.writeText(previous)
+/**
+ * Read terminal content via clipboard.
+ * When `commands` is negative, selects all terminal content.
+ * When positive, selects the last N commands.
+ */
+async function getTerminalContents(commands = -1): Promise<string> {
+  const saved = await vscode.env.clipboard.readText()
+
+  try {
+    if (commands < 0) {
+      await vscode.commands.executeCommand("workbench.action.terminal.selectAll")
+    } else {
+      for (let i = 0; i < commands; i++) {
+        await vscode.commands.executeCommand("workbench.action.terminal.selectToPreviousCommand")
+      }
+    }
+
+    await vscode.commands.executeCommand("workbench.action.terminal.copySelection")
+    await vscode.commands.executeCommand("workbench.action.terminal.clearSelection")
+
+    let content = (await vscode.env.clipboard.readText()).trim()
+
+    await vscode.env.clipboard.writeText(saved)
+
+    if (saved === content) {
+      return ""
+    }
+
+    // Trim duplicate trailing prompt line
+    const lines = content.split("\n")
+    const last = lines.pop()?.trim()
+    if (last) {
+      let i = lines.length - 1
+      while (i >= 0 && !lines[i].trim().startsWith(last)) {
+        i--
+      }
+      content = lines.slice(Math.max(i, 0)).join("\n")
+    }
+
+    return content
+  } catch (err) {
+    await vscode.env.clipboard.writeText(saved)
+    throw err
   }
-  // If clipboard didn't change, nothing was selected
-  if (selection === previous) return ""
-  return selection
 }
 
 export function registerTerminalActions(
@@ -28,8 +57,11 @@ export function registerTerminalActions(
   const target = () => (agentManager?.isActive() ? agentManager : provider)
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("kilo-code.new.terminalAddToContext", async () => {
-      const content = await getTerminalSelection()
+    vscode.commands.registerCommand("kilo-code.new.terminalAddToContext", async (args: any) => {
+      let content = args?.selection as string | undefined
+      if (!content) {
+        content = await getTerminalContents(-1)
+      }
       if (!content) {
         vscode.window.showInformationMessage("No terminal content available. Select text in the terminal first.")
         return
@@ -42,8 +74,11 @@ export function registerTerminalActions(
       target().postMessage({ type: "action", action: "focusInput" })
     }),
 
-    vscode.commands.registerCommand("kilo-code.new.terminalFixCommand", async () => {
-      const content = await getTerminalSelection()
+    vscode.commands.registerCommand("kilo-code.new.terminalFixCommand", async (args: any) => {
+      let content = args?.selection as string | undefined
+      if (!content) {
+        content = await getTerminalContents(1)
+      }
       if (!content) {
         vscode.window.showInformationMessage("No terminal content available. Select text in the terminal first.")
         return
@@ -55,8 +90,11 @@ export function registerTerminalActions(
       target().postMessage({ type: "triggerTask", text: prompt })
     }),
 
-    vscode.commands.registerCommand("kilo-code.new.terminalExplainCommand", async () => {
-      const content = await getTerminalSelection()
+    vscode.commands.registerCommand("kilo-code.new.terminalExplainCommand", async (args: any) => {
+      let content = args?.selection as string | undefined
+      if (!content) {
+        content = await getTerminalContents(1)
+      }
       if (!content) {
         vscode.window.showInformationMessage("No terminal content available. Select text in the terminal first.")
         return

--- a/packages/kilo-vscode/src/services/code-actions/register-terminal-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-terminal-actions.ts
@@ -1,21 +1,35 @@
 import * as vscode from "vscode"
 import type { KiloProvider } from "../../KiloProvider"
+import type { AgentManagerProvider } from "../../agent-manager/AgentManagerProvider"
 import { createPrompt } from "./support-prompt"
 
-function getTerminalSelection(): string {
+async function getTerminalSelection(): Promise<string> {
   const terminal = vscode.window.activeTerminal
   if (!terminal) return ""
-  // VS Code terminal API doesn't expose buffer contents directly.
-  // Terminal selection is available via clipboard in some cases.
-  // For now, this is a placeholder — full implementation requires
-  // VS Code shell integration API (terminal.shellIntegration).
-  return ""
+  // VS Code terminal API doesn't expose selection text directly.
+  // Copy the terminal selection to clipboard, read it, then restore.
+  const previous = await vscode.env.clipboard.readText()
+  await vscode.commands.executeCommand("workbench.action.terminal.copySelection")
+  const selection = await vscode.env.clipboard.readText()
+  // Restore original clipboard content if it changed
+  if (selection !== previous) {
+    await vscode.env.clipboard.writeText(previous)
+  }
+  // If clipboard didn't change, nothing was selected
+  if (selection === previous) return ""
+  return selection
 }
 
-export function registerTerminalActions(context: vscode.ExtensionContext, provider: KiloProvider): void {
+export function registerTerminalActions(
+  context: vscode.ExtensionContext,
+  provider: KiloProvider,
+  agentManager?: AgentManagerProvider,
+): void {
+  const target = () => (agentManager?.isActive() ? agentManager : provider)
+
   context.subscriptions.push(
-    vscode.commands.registerCommand("kilo-code.new.terminalAddToContext", () => {
-      const content = getTerminalSelection()
+    vscode.commands.registerCommand("kilo-code.new.terminalAddToContext", async () => {
+      const content = await getTerminalSelection()
       if (!content) {
         vscode.window.showInformationMessage("No terminal content available. Select text in the terminal first.")
         return
@@ -24,12 +38,12 @@ export function registerTerminalActions(context: vscode.ExtensionContext, provid
         terminalContent: content,
         userInput: "",
       })
-      provider.postMessage({ type: "setChatBoxMessage", text: prompt })
-      provider.postMessage({ type: "action", action: "focusInput" })
+      target().postMessage({ type: "appendChatBoxMessage", text: prompt })
+      target().postMessage({ type: "action", action: "focusInput" })
     }),
 
-    vscode.commands.registerCommand("kilo-code.new.terminalFixCommand", () => {
-      const content = getTerminalSelection()
+    vscode.commands.registerCommand("kilo-code.new.terminalFixCommand", async () => {
+      const content = await getTerminalSelection()
       if (!content) {
         vscode.window.showInformationMessage("No terminal content available. Select text in the terminal first.")
         return
@@ -38,11 +52,11 @@ export function registerTerminalActions(context: vscode.ExtensionContext, provid
         terminalContent: content,
         userInput: "",
       })
-      provider.postMessage({ type: "triggerTask", text: prompt })
+      target().postMessage({ type: "triggerTask", text: prompt })
     }),
 
-    vscode.commands.registerCommand("kilo-code.new.terminalExplainCommand", () => {
-      const content = getTerminalSelection()
+    vscode.commands.registerCommand("kilo-code.new.terminalExplainCommand", async () => {
+      const content = await getTerminalSelection()
       if (!content) {
         vscode.window.showInformationMessage("No terminal content available. Select text in the terminal first.")
         return
@@ -51,7 +65,7 @@ export function registerTerminalActions(context: vscode.ExtensionContext, provid
         terminalContent: content,
         userInput: "",
       })
-      provider.postMessage({ type: "triggerTask", text: prompt })
+      target().postMessage({ type: "triggerTask", text: prompt })
     }),
   )
 }


### PR DESCRIPTION
## Summary

- Fixes terminal "Add to Context", "Fix This Command", and "Explain This Command" actions which were completely non-functional (always showed "No terminal content available")
- Changes editor "Add to Context" to append to chat input instead of replacing it

## Root Cause

`getTerminalSelection()` in `register-terminal-actions.ts` was a placeholder that always returned an empty string. The VS Code Terminal API does not expose a `terminal.selection` property, so the function had no way to read the selected terminal text.

## Changes

### `register-terminal-actions.ts`
- Replaced the placeholder `getTerminalSelection()` with a working clipboard-based implementation: copies the terminal selection via `workbench.action.terminal.copySelection`, reads it from the clipboard, then restores the original clipboard content
- Made all command handlers `async` to support the clipboard operations
- Added `agentManager` parameter so terminal actions route to the active panel (sidebar or Agent Manager), matching the editor code actions pattern
- Changed `setChatBoxMessage` to `appendChatBoxMessage` for "Add to Context" so it appends to existing chat input instead of replacing it

### `register-code-actions.ts`
- Changed `setChatBoxMessage` to `appendChatBoxMessage` for editor "Add to Context" to match the terminal fix and prevent replacing existing chat input (same issue as PR #7093)

### `extension.ts`
- Passes `agentManagerProvider` to `registerTerminalActions()` so terminal actions can target the Agent Manager panel

### `docs/non-agent-features/editor-context-menus-and-code-actions.md`
- Removed the "placeholder" note since terminal content capture is now implemented
