### PR TITLE
fix: guard temperature and prevent prompt injection in enhance-prompt

### DIFF
--- a/packages/opencode/src/kilocode/enhance-prompt.ts
+++ b/packages/opencode/src/kilocode/enhance-prompt.ts
@@ -30,10 +30,11 @@ export async function enhancePrompt(text: string): Promise<string> {
 
   const result = await generateText({
     model: language,
-    temperature: 0.7,
+    temperature: model.capabilities.temperature ? 0.7 : undefined,
     providerOptions: ProviderTransform.providerOptions(model, ProviderTransform.smallOptions(model)),
     maxRetries: 3,
-    messages: [{ role: "user" as const, content: `${INSTRUCTION}\n\n${text}` }],
+    system: INSTRUCTION,
+    messages: [{ role: "user" as const, content: text }],
   })
 
   log.info("enhanced", { length: result.text.length })

--- a/packages/opencode/src/kilocode/enhance-prompt.ts
+++ b/packages/opencode/src/kilocode/enhance-prompt.ts
@@ -1,4 +1,5 @@
 import { generateText } from "ai"
+import { mergeDeep } from "remeda"
 import { Provider } from "@/provider/provider"
 import { ProviderTransform } from "@/provider/transform"
 import { Log } from "@/util/log"
@@ -31,7 +32,10 @@ export async function enhancePrompt(text: string): Promise<string> {
   const result = await generateText({
     model: language,
     temperature: model.capabilities.temperature ? 0.7 : undefined,
-    providerOptions: ProviderTransform.providerOptions(model, ProviderTransform.smallOptions(model)),
+    providerOptions: ProviderTransform.providerOptions(
+      model,
+      mergeDeep(ProviderTransform.smallOptions(model), model.options),
+    ),
     maxRetries: 3,
     system: INSTRUCTION,
     messages: [{ role: "user" as const, content: text }],


### PR DESCRIPTION
## Summary

Follow-up to #7101 addressing review bot feedback:

- Guard `temperature` behind `model.capabilities.temperature` check — some models (e.g. Codex OAuth) disable temperature and would fail without this
- Move the enhance instruction from the user message to a `system` message to prevent the user's draft text from overriding the "enhance-only" behavior via prompt injection