### PR TITLE
feat(vscode): collapsible question dock with compact single-box layout

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-many-options-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-many-options-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3164d510232a0457cf935a3032f736825486f133e89994e544c678ccc7e6849a
+size 30652

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-multi-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-multi-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1f95a30590881f0212823027fe7494390e298d3532fb3e1d488ad7e7a2012599
-size 23362
+oid sha256:dc40d7bbc5f3eaee3b48b4f90046a10e54db3288e71214eec190e4b0fa61cc16
+size 22777

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-single-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-single-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45b84883b6300049d99e09e1be4aa834a1a5eac15dac5b4ce5a1e09d16b72a8b
-size 31636
+oid sha256:3da4a2d29601e45eb4b5fe007a62a203c2b5151b2d74437d22630d2ddc8582a6
+size 28723

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/question-above-chatbox-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/question-above-chatbox-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9d5c9422fae8406813e46e5f088ee5a437a601b5cd96a0babcf28c5fffdd758d
-size 30554
+oid sha256:0dcef8172fb810da542e5d4f364a60fa8cb0d0d3a212ad939e0117ca91b5b57c
+size 30461

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -7,7 +7,6 @@
 import { Component, For, Show, createMemo, createEffect } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Button } from "@kilocode/kilo-ui/button"
-import { DockPrompt } from "@kilocode/kilo-ui/dock-prompt"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
@@ -27,6 +26,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     custom: [] as string[],
     editing: false,
     sending: false,
+    collapsed: false,
   })
 
   // Reset sending state when an error occurs for this question
@@ -148,41 +148,179 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     setStore("editing", false)
   }
 
+  const toggleCollapse = () => setStore("collapsed", !store.collapsed)
+
   return (
-    <div onClick={(e: MouseEvent) => e.stopPropagation()}>
-      <DockPrompt
-        kind="question"
-        header={
-          <>
-            <div data-slot="question-header-title">{summary()}</div>
-            <Show when={!single()}>
-              <div data-slot="question-progress">
-                <button
-                  type="button"
-                  data-slot="question-progress-nav"
-                  disabled={store.sending || store.tab <= 0}
-                  onClick={back}
-                >
-                  <Icon name="chevron-left" size="small" />
-                </button>
-                <button
-                  type="button"
-                  data-slot="question-progress-nav"
-                  disabled={
-                    store.sending ||
-                    store.tab >= questions().length ||
-                    (!confirm() && (store.answers[store.tab]?.length ?? 0) === 0)
-                  }
-                  onClick={() => selectTab(store.tab + 1)}
-                >
-                  <Icon name="chevron-right" size="small" />
-                </button>
-              </div>
+    <div
+      data-component="question-dock"
+      data-collapsed={store.collapsed ? "true" : "false"}
+      onClick={(e: MouseEvent) => e.stopPropagation()}
+    >
+      {/* Single unified header row — always visible */}
+      <div data-slot="question-dock-header">
+        <div data-slot="question-dock-header-content">
+          <div data-slot="question-header-title">{summary()}</div>
+          <Show when={store.collapsed}>
+            <div data-slot="question-collapsed-preview">{question()?.question}</div>
+          </Show>
+        </div>
+        <div data-slot="question-header-actions">
+          <Show when={!store.collapsed && !single()}>
+            <div data-slot="question-progress">
+              <button
+                type="button"
+                data-slot="question-progress-nav"
+                disabled={store.sending || store.tab <= 0}
+                onClick={back}
+              >
+                <Icon name="chevron-left" size="small" />
+              </button>
+              <button
+                type="button"
+                data-slot="question-progress-nav"
+                disabled={
+                  store.sending ||
+                  store.tab >= questions().length ||
+                  (!confirm() && (store.answers[store.tab]?.length ?? 0) === 0)
+                }
+                onClick={() => selectTab(store.tab + 1)}
+              >
+                <Icon name="chevron-right" size="small" />
+              </button>
+            </div>
+          </Show>
+          <button
+            type="button"
+            data-slot="question-collapse-toggle"
+            onClick={toggleCollapse}
+            aria-label={store.collapsed ? "Expand" : "Collapse"}
+          >
+            <Icon name="chevron-down" size="small" />
+          </button>
+        </div>
+      </div>
+
+      {/* Animated body — hidden when collapsed */}
+      <div data-slot="question-dock-body">
+        <div data-slot="question-dock-body-inner">
+          <Show when={!confirm()}>
+            <div data-slot="question-text">{question()?.question}</div>
+            <Show when={multi()} fallback={<div data-slot="question-hint">{language.t("ui.question.singleHint")}</div>}>
+              <div data-slot="question-hint">{language.t("ui.question.multiHint")}</div>
             </Show>
-          </>
-        }
-        footer={
-          <>
+            <div data-slot="question-options">
+              <For each={options()}>
+                {(opt, i) => {
+                  const picked = () => store.answers[store.tab]?.includes(opt.label) ?? false
+                  return (
+                    <button
+                      data-slot="question-option"
+                      data-picked={picked()}
+                      disabled={store.sending}
+                      onClick={() => selectOption(i())}
+                    >
+                      <span data-slot="question-option-check" aria-hidden="true">
+                        <span
+                          data-slot="question-option-box"
+                          data-type={multi() ? "checkbox" : "radio"}
+                          data-picked={picked()}
+                        >
+                          <Show when={multi()} fallback={<span data-slot="question-option-radio-dot" />}>
+                            <Icon name="check-small" size="small" />
+                          </Show>
+                        </span>
+                      </span>
+                      <span data-slot="question-option-main">
+                        <span data-slot="option-label">{opt.label}</span>
+                        <Show when={opt.description}>
+                          <span data-slot="option-description">{opt.description}</span>
+                        </Show>
+                      </span>
+                    </button>
+                  )
+                }}
+              </For>
+              <Show when={question()?.custom !== false}>
+                <button
+                  data-slot="question-option"
+                  data-custom="true"
+                  data-picked={customPicked()}
+                  disabled={store.sending}
+                  onClick={() => selectOption(options().length)}
+                >
+                  <span data-slot="question-option-check" aria-hidden="true">
+                    <span
+                      data-slot="question-option-box"
+                      data-type={multi() ? "checkbox" : "radio"}
+                      data-picked={customPicked()}
+                    >
+                      <Show when={multi()} fallback={<span data-slot="question-option-radio-dot" />}>
+                        <Icon name="check-small" size="small" />
+                      </Show>
+                    </span>
+                  </span>
+                  <span data-slot="question-option-main">
+                    <span data-slot="option-label">{language.t("ui.messagePart.option.typeOwnAnswer")}</span>
+                    <span data-slot="option-description" data-placeholder={!input()}>
+                      {input() || language.t("ui.question.custom.placeholder")}
+                    </span>
+                  </span>
+                </button>
+                <Show when={store.editing}>
+                  <form data-slot="custom-input-form" onSubmit={handleCustomSubmit}>
+                    <input
+                      ref={(el) => setTimeout(() => el.focus(), 0)}
+                      type="text"
+                      data-slot="custom-input"
+                      placeholder={language.t("ui.question.custom.placeholder")}
+                      value={input()}
+                      disabled={store.sending}
+                      onInput={(e) => {
+                        const inputs = [...store.custom]
+                        inputs[store.tab] = e.currentTarget.value
+                        setStore("custom", inputs)
+                      }}
+                    />
+                    <Button type="submit" variant="primary" size="small" disabled={store.sending}>
+                      {multi() ? language.t("ui.common.add") : language.t("ui.common.submit")}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="small"
+                      disabled={store.sending}
+                      onClick={() => setStore("editing", false)}
+                    >
+                      {language.t("ui.common.cancel")}
+                    </Button>
+                  </form>
+                </Show>
+              </Show>
+            </div>
+          </Show>
+
+          <Show when={confirm()}>
+            <div data-slot="question-review">
+              <div data-slot="review-title">{language.t("ui.messagePart.review.title")}</div>
+              <For each={questions()}>
+                {(q, index) => {
+                  const value = () => store.answers[index()]?.join(", ") ?? ""
+                  const answered = () => Boolean(value())
+                  return (
+                    <div data-slot="review-item">
+                      <span data-slot="review-label">{q.question}</span>
+                      <span data-slot="review-value" data-answered={answered()}>
+                        {answered() ? value() : language.t("ui.question.review.notAnswered")}
+                      </span>
+                    </div>
+                  )
+                }}
+              </For>
+            </div>
+          </Show>
+
+          {/* Footer row — inside the same box */}
+          <div data-slot="question-dock-footer">
             <Button variant="ghost" size="small" onClick={reject} disabled={store.sending}>
               {language.t("ui.common.dismiss")}
             </Button>
@@ -214,125 +352,9 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
                 </Button>
               </Show>
             </div>
-          </>
-        }
-      >
-        <Show when={!confirm()}>
-          <div data-slot="question-text">{question()?.question}</div>
-          <Show when={multi()} fallback={<div data-slot="question-hint">{language.t("ui.question.singleHint")}</div>}>
-            <div data-slot="question-hint">{language.t("ui.question.multiHint")}</div>
-          </Show>
-          <div data-slot="question-options">
-            <For each={options()}>
-              {(opt, i) => {
-                const picked = () => store.answers[store.tab]?.includes(opt.label) ?? false
-                return (
-                  <button
-                    data-slot="question-option"
-                    data-picked={picked()}
-                    disabled={store.sending}
-                    onClick={() => selectOption(i())}
-                  >
-                    <span data-slot="question-option-check" aria-hidden="true">
-                      <span
-                        data-slot="question-option-box"
-                        data-type={multi() ? "checkbox" : "radio"}
-                        data-picked={picked()}
-                      >
-                        <Show when={multi()} fallback={<span data-slot="question-option-radio-dot" />}>
-                          <Icon name="check-small" size="small" />
-                        </Show>
-                      </span>
-                    </span>
-                    <span data-slot="question-option-main">
-                      <span data-slot="option-label">{opt.label}</span>
-                      <Show when={opt.description}>
-                        <span data-slot="option-description">{opt.description}</span>
-                      </Show>
-                    </span>
-                  </button>
-                )
-              }}
-            </For>
-            <Show when={question()?.custom !== false}>
-              <button
-                data-slot="question-option"
-                data-custom="true"
-                data-picked={customPicked()}
-                disabled={store.sending}
-                onClick={() => selectOption(options().length)}
-              >
-                <span data-slot="question-option-check" aria-hidden="true">
-                  <span
-                    data-slot="question-option-box"
-                    data-type={multi() ? "checkbox" : "radio"}
-                    data-picked={customPicked()}
-                  >
-                    <Show when={multi()} fallback={<span data-slot="question-option-radio-dot" />}>
-                      <Icon name="check-small" size="small" />
-                    </Show>
-                  </span>
-                </span>
-                <span data-slot="question-option-main">
-                  <span data-slot="option-label">{language.t("ui.messagePart.option.typeOwnAnswer")}</span>
-                  <span data-slot="option-description" data-placeholder={!input()}>
-                    {input() || language.t("ui.question.custom.placeholder")}
-                  </span>
-                </span>
-              </button>
-              <Show when={store.editing}>
-                <form data-slot="custom-input-form" onSubmit={handleCustomSubmit}>
-                  <input
-                    ref={(el) => setTimeout(() => el.focus(), 0)}
-                    type="text"
-                    data-slot="custom-input"
-                    placeholder={language.t("ui.question.custom.placeholder")}
-                    value={input()}
-                    disabled={store.sending}
-                    onInput={(e) => {
-                      const inputs = [...store.custom]
-                      inputs[store.tab] = e.currentTarget.value
-                      setStore("custom", inputs)
-                    }}
-                  />
-                  <Button type="submit" variant="primary" size="small" disabled={store.sending}>
-                    {multi() ? language.t("ui.common.add") : language.t("ui.common.submit")}
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="small"
-                    disabled={store.sending}
-                    onClick={() => setStore("editing", false)}
-                  >
-                    {language.t("ui.common.cancel")}
-                  </Button>
-                </form>
-              </Show>
-            </Show>
           </div>
-        </Show>
-
-        <Show when={confirm()}>
-          <div data-slot="question-review">
-            <div data-slot="review-title">{language.t("ui.messagePart.review.title")}</div>
-            <For each={questions()}>
-              {(q, index) => {
-                const value = () => store.answers[index()]?.join(", ") ?? ""
-                const answered = () => Boolean(value())
-                return (
-                  <div data-slot="review-item">
-                    <span data-slot="review-label">{q.question}</span>
-                    <span data-slot="review-value" data-answered={answered()}>
-                      {answered() ? value() : language.t("ui.question.review.notAnswered")}
-                    </span>
-                  </div>
-                )
-              }}
-            </For>
-          </div>
-        </Show>
-      </DockPrompt>
+        </div>
+      </div>
     </div>
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -139,6 +139,38 @@ export const QuestionDockMulti: Story = {
   ),
 }
 
+/** Many options to verify the max-height scroll constraint */
+const manyOptionsQuestion: QuestionRequest = {
+  id: "q-many-001",
+  sessionID: SESSION_ID,
+  questions: [
+    {
+      question: "What would you like to work on today?",
+      header: "Quick check-in",
+      options: [
+        { label: "Fix a bug", description: "Debug and resolve an issue in the codebase" },
+        { label: "Add a feature", description: "Implement new functionality" },
+        { label: "Refactor code", description: "Improve existing code structure or quality" },
+        { label: "Write tests", description: "Add or improve test coverage" },
+        { label: "Review code", description: "Provide feedback on code changes" },
+        { label: "Update docs", description: "Improve documentation" },
+        { label: "Performance", description: "Optimize for speed or memory" },
+      ],
+    },
+  ],
+}
+
+export const QuestionDockManyOptions: Story = {
+  name: "QuestionDock — many options (scrollable)",
+  render: () => (
+    <StoryProviders sessionID={SESSION_ID} questions={[manyOptionsQuestion]}>
+      <div style={{ width: "100%" }}>
+        <QuestionDock request={manyOptionsQuestion} />
+      </div>
+    </StoryProviders>
+  ),
+}
+
 // ---------------------------------------------------------------------------
 // TaskHeader with todos
 // ---------------------------------------------------------------------------

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1643,13 +1643,64 @@
 }
 
 /* ============================================
-   Question Prompt (VS Code overrides)
+   Question Dock
    ============================================ */
 
-[data-component="dock-prompt"][data-kind="question"] {
+[data-component="question-dock"] {
   margin: 8px;
+  background-color: var(--surface-raised-stronger-non-alpha);
+  box-shadow: var(--shadow-xs-border);
+  border-radius: 12px;
+  overflow: hidden;
 
-  [data-slot="question-progress-nav"] {
+  /* ── Header (always visible) ── */
+  [data-slot="question-dock-header"] {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px 8px 8px 12px;
+    cursor: pointer;
+  }
+
+  [data-slot="question-dock-header-content"] {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  [data-slot="question-header-title"] {
+    font-family: var(--font-family-sans);
+    font-size: 12px;
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-large);
+    color: var(--text-weak);
+  }
+
+  /* Shown only when collapsed — truncated question preview */
+  [data-slot="question-collapsed-preview"] {
+    font-family: var(--font-family-sans);
+    font-size: 13px;
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-large);
+    color: var(--text-strong);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  [data-slot="question-header-actions"] {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+
+  /* ── Icon buttons in header ── */
+  [data-slot="question-progress-nav"],
+  [data-slot="question-collapse-toggle"] {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1661,13 +1712,14 @@
     border-radius: var(--radius-sm);
     color: var(--icon-base);
     cursor: pointer;
+    flex-shrink: 0;
     transition:
       color 0.15s ease,
       background-color 0.15s ease;
 
     &:hover:not(:disabled) {
       color: var(--icon-strong-base);
-      background: var(--surface-base-hover);
+      background-color: var(--surface-base-hover);
     }
 
     &:disabled {
@@ -1676,30 +1728,232 @@
     }
   }
 
-  [data-slot="question-footer"] > [data-component="button"][data-variant="ghost"] {
-    border: none;
-    box-shadow: none;
+  [data-slot="question-collapse-toggle"] {
+    transition:
+      color 0.15s ease,
+      background-color 0.15s ease,
+      transform 0.2s ease;
   }
 
-  [data-slot="question-footer-actions"] > [data-component="button"][data-variant="primary"] {
-    color: var(--vscode-button-foreground);
-    background-color: var(--vscode-button-background);
-    border: 1px solid var(--vscode-button-border, transparent);
+  [data-slot="question-progress"] {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
 
-    &:hover:not(:disabled) {
-      background-color: var(--vscode-button-hoverBackground);
+  /* ── Animated body ── */
+  [data-slot="question-dock-body"] {
+    display: grid;
+    grid-template-rows: 1fr;
+    opacity: 1;
+    transition:
+      grid-template-rows 0.22s ease,
+      opacity 0.18s ease;
+  }
+
+  &[data-collapsed="true"] [data-slot="question-dock-body"] {
+    grid-template-rows: 0fr;
+    opacity: 0;
+  }
+
+  /* Inner wrapper: overflow hidden is required for grid-template-rows animation */
+  [data-slot="question-dock-body-inner"] {
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-bottom: 2px;
+  }
+
+  /* ── Body content ── */
+  [data-slot="question-text"] {
+    font-family: var(--font-family-sans);
+    font-size: 14px;
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-large);
+    color: var(--text-strong);
+    padding: 0 12px;
+  }
+
+  [data-slot="question-hint"] {
+    font-family: var(--font-family-sans);
+    font-size: 13px;
+    font-weight: var(--font-weight-regular);
+    line-height: var(--line-height-large);
+    color: var(--text-weak);
+    padding: 0 12px;
+  }
+
+  [data-slot="question-options"] {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 4px 8px;
+    max-height: 40vh;
+    overflow-y: auto;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
     }
   }
 
-  [data-slot="option-description"][data-placeholder="true"] {
-    color: var(--text-weaker);
+  [data-slot="question-option"] {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 6px 8px 6px 10px;
+    background-color: var(--surface-raised-stronger-non-alpha);
+    border: 1px solid var(--border-weak-base);
+    border-radius: 6px;
+    text-align: left;
+    width: 100%;
+    cursor: pointer;
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease;
+
+    &:hover:not([data-picked="true"]) {
+      background-color: var(--background-base);
+    }
+
+    &[data-picked="true"] {
+      background-color: var(--surface-interactive-weak);
+      border-color: transparent;
+      box-shadow: var(--shadow-xs-border-hover);
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+  }
+
+  [data-slot="question-option-check"] {
+    display: inline-flex;
+    transform: translateY(2px);
+  }
+
+  [data-slot="question-option-box"] {
+    width: 16px;
+    height: 16px;
+    padding: 2px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-weak-base);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    background-color: transparent;
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease;
+
+    [data-component="icon"] {
+      opacity: 0;
+      color: var(--icon-base);
+    }
+
+    &[data-type="radio"] {
+      border-radius: 999px;
+    }
+
+    [data-slot="question-option-radio-dot"] {
+      width: 6px;
+      height: 6px;
+      border-radius: 999px;
+      background-color: var(--background-stronger);
+      opacity: 0;
+    }
+
+    &[data-picked="true"] {
+      border-color: var(--icon-interactive-base);
+
+      [data-component="icon"] {
+        opacity: 1;
+        color: var(--icon-invert-base);
+      }
+
+      &[data-type="checkbox"] {
+        background-color: var(--icon-interactive-base);
+      }
+
+      &[data-type="radio"] {
+        background-color: var(--icon-interactive-base);
+
+        [data-slot="question-option-radio-dot"] {
+          opacity: 1;
+        }
+      }
+    }
+  }
+
+  [data-slot="question-option-main"] {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  [data-slot="option-label"] {
+    font-family: var(--font-family-sans);
+    font-size: 14px;
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-large);
+    color: var(--text-strong);
+  }
+
+  [data-slot="option-description"] {
+    font-family: var(--font-family-sans);
+    font-size: 14px;
+    font-weight: var(--font-weight-regular);
+    line-height: var(--line-height-large);
+    color: var(--text-base);
+    overflow-wrap: anywhere;
+
+    &[data-placeholder="true"] {
+      color: var(--text-weaker);
+    }
+  }
+
+  [data-slot="custom-input-form"] {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    margin: 0 8px;
+    background-color: var(--surface-raised-stronger-non-alpha);
+    border: 1px solid var(--border-weak-base);
+    border-radius: var(--radius-lg);
+  }
+
+  [data-slot="custom-input"] {
+    flex: 1;
+    min-width: 0;
+    padding: 2px 4px;
+    background: transparent;
+    border: none;
+    outline: none;
+    font-family: var(--font-family-sans);
+    font-size: var(--font-size-base);
+    color: var(--text-base);
+    line-height: var(--line-height-large);
+
+    &::placeholder {
+      color: var(--text-weak);
+    }
+
+    &:disabled {
+      opacity: 0.6;
+    }
   }
 
   [data-slot="question-review"] {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    padding: 4px 10px;
+    padding: 4px 12px;
   }
 
   [data-slot="review-title"] {
@@ -1732,36 +1986,39 @@
     }
   }
 
-  [data-slot="custom-input-form"] {
+  /* ── Footer (inside the same box) ── */
+  [data-slot="question-dock-footer"] {
     display: flex;
     align-items: center;
-    gap: 6px;
-    padding: 6px 8px;
-    background-color: var(--surface-raised-stronger-non-alpha);
-    border: 1px solid var(--border-weak-base);
-    border-radius: var(--radius-lg);
+    justify-content: space-between;
+    padding: 6px 8px 8px;
   }
 
-  [data-slot="custom-input"] {
-    flex: 1;
-    min-width: 0;
-    padding: 2px 4px;
-    background: transparent;
+  [data-slot="question-footer-actions"] {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  [data-slot="question-dock-footer"] > [data-component="button"][data-variant="ghost"] {
     border: none;
-    outline: none;
-    font-family: var(--font-family-sans);
-    font-size: var(--font-size-base);
-    color: var(--text-base);
-    line-height: var(--line-height-large);
+    box-shadow: none;
+  }
 
-    &::placeholder {
-      color: var(--text-weak);
-    }
+  [data-slot="question-footer-actions"] > [data-component="button"][data-variant="primary"] {
+    color: var(--vscode-button-foreground);
+    background-color: var(--vscode-button-background);
+    border: 1px solid var(--vscode-button-border, transparent);
 
-    &:disabled {
-      opacity: 0.6;
+    &:hover:not(:disabled) {
+      background-color: var(--vscode-button-hoverBackground);
     }
   }
+}
+
+/* Collapsed: chevron points UP (rotate 180). Expanded: chevron points DOWN (default). */
+[data-component="question-dock"][data-collapsed="true"] [data-slot="question-collapse-toggle"] {
+  transform: rotate(180deg);
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary

Resolves #6898 — Makes it possible to read chat history while answering questions by adding a collapsible question dock with a more compact layout.

## Changes

- **Collapsible dock**: Added a collapse/expand toggle (chevron button) to the question dock header. When collapsed, shows a compact single-line bar with the question text preview. Animated open/close transition using `grid-template-rows`.
- **Single unified box**: Replaced the `DockPrompt` two-box layout (shell + tray) with a custom `question-dock` component that renders everything — header, options, and footer buttons — inside a single rounded card.
- **Compact spacing**: Reduced internal padding, option gaps, and footer spacing. Added `max-height: 40vh` with scroll on the options list so long option lists don't push chat history off screen.
- **New story**: Added `QuestionDockManyOptions` storybook story with 7 options to verify scrollable constraint.

<img width="345" height="846" alt="image" src="https://github.com/user-attachments/assets/a3ce7178-5c7c-4561-9407-f8bea522be64" />

<img width="314" height="389" alt="image" src="https://github.com/user-attachments/assets/39248e76-014b-40f3-98c1-7eb1d1248210" />
