### PR TITLE
fix: restore caret position after paste in chat input

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -359,13 +359,19 @@ export const PromptInput: Component = () => {
   const handleInput = (e: InputEvent) => {
     const target = e.target as HTMLTextAreaElement
     const val = target.value
+    // Save caret position before setText() — SolidJS's reactive value={text()}
+    // binding re-sets textarea.value when text() changes, which resets the caret.
+    const start = target.selectionStart
+    const end = target.selectionEnd
     setText(val)
+    // Restore caret after the reactive update
+    if (start !== null) target.setSelectionRange(start, end)
     preEnhanceText = null
     adjustHeight()
     setGhostText("")
     syncHighlightScroll()
 
-    mention.onInput(val, target.selectionStart ?? val.length)
+    mention.onInput(val, start ?? val.length)
 
     if (mention.showMention()) {
       setGhostText("")


### PR DESCRIPTION
## Context

Fixes #7109 — the text cursor (caret) position becomes visually out of sync with the actual text position after pasting content into the chat input textarea. This is the most fundamental interaction in the extension and was reported independently by multiple users.

## Implementation

**Root cause:** SolidJS's reactive `value={text()}` binding on the `<textarea>` re-sets `textarea.value` whenever the `text()` signal changes. When the user pastes text, the browser natively updates the textarea value and positions the caret correctly, but then `handleInput` calls `setText(val)` which triggers SolidJS to write the same value back to `textarea.value`, resetting the caret to position 0 as a side-effect.

**Fix:** In `handleInput`, save `selectionStart`/`selectionEnd` before calling `setText()`, then restore them via `setSelectionRange()` immediately after. This counteracts the caret reset caused by SolidJS's reactive value binding. The same pattern is already used successfully in `useFileMention.ts` for @mention insertion.

The change is minimal — 7 lines added, 1 line changed — and confined to `handleInput` in `PromptInput.tsx`.

## How to Test

1. Open the VS Code extension chat
2. Type some text in the input field (e.g. "Hello world")
3. Place the cursor in the middle of the text
4. Paste text from clipboard (Cmd+V / Ctrl+V)
5. Verify the cursor remains at the correct position (immediately after pasted text)
6. Continue typing — text should appear where the cursor is displayed
7. Test pasting multi-line content
8. Test pasting into empty input, beginning, middle, and end of existing text