### PR TITLE
add 'Kilo Extension' output channel for extension-wide logging

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -17,6 +17,7 @@ import { FileIgnoreController } from "./services/autocomplete/shims/FileIgnoreCo
 import { handleChatCompletionRequest } from "./services/autocomplete/chat-autocomplete/handleChatCompletionRequest"
 import { handleChatCompletionAccepted } from "./services/autocomplete/chat-autocomplete/handleChatCompletionAccepted"
 import { buildWebviewHtml } from "./utils"
+import { log } from "./output-channel"
 import { TelemetryProxy, type TelemetryPropertiesProvider } from "./services/telemetry"
 // legacy-migration start
 import * as MigrationService from "./legacy-migration/migration-service"
@@ -125,7 +126,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    */
   private async syncWebviewState(reason: string): Promise<void> {
     const serverInfo = this.connectionService.getServerInfo()
-    console.log("[Kilo New] KiloProvider: 🔄 syncWebviewState()", {
+    log("[Kilo New] KiloProvider: 🔄 syncWebviewState()", {
       reason,
       isWebviewReady: this.isWebviewReady,
       connectionState: this.connectionState,
@@ -134,7 +135,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     })
 
     if (!this.isWebviewReady) {
-      console.log("[Kilo New] KiloProvider: ⏭️ syncWebviewState skipped (webview not ready)")
+      log("[Kilo New] KiloProvider: ⏭️ syncWebviewState skipped (webview not ready)")
       return
     }
 
@@ -161,10 +162,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // Profile returns 401 when user isn't logged into Kilo Gateway — that's expected.
     // Use fire-and-forget (no throwOnError) to match old getProfile() which returned null on error.
     if (this.connectionState === "connected" && this.client) {
-      console.log("[Kilo New] KiloProvider: 👤 syncWebviewState fetching profile...")
+      log("[Kilo New] KiloProvider: 👤 syncWebviewState fetching profile...")
       const profileResult = await this.client.kilo.profile()
       const profileData = profileResult.data ?? null
-      console.log("[Kilo New] KiloProvider: 👤 syncWebviewState profile:", profileData ? "received" : "null")
+      log("[Kilo New] KiloProvider: 👤 syncWebviewState profile:", profileData ? "received" : "null")
       this.postMessage({
         type: "profileData",
         data: profileData,
@@ -311,14 +312,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           if (result === null) return // consumed by interceptor
           message = result
         } catch (error) {
-          console.error("[Kilo New] KiloProvider: interceptor error:", error)
+          log("[Kilo New] KiloProvider: interceptor error:", error)
           return
         }
       }
 
       switch (message.type) {
         case "webviewReady":
-          console.log("[Kilo New] KiloProvider: ✅ webviewReady received")
+          log("[Kilo New] KiloProvider: ✅ webviewReady received")
           this.isWebviewReady = true
           await this.syncWebviewState("webviewReady")
           this.flushPendingReviewComments()
@@ -370,12 +371,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           void this.handleLoadMessages(message.sessionID)
           break
         case "syncSession":
-          this.handleSyncSession(message.sessionID).catch((e) =>
-            console.error("[Kilo New] handleSyncSession failed:", e),
-          )
+          this.handleSyncSession(message.sessionID).catch((e) => log("[Kilo New] handleSyncSession failed:", e))
           break
         case "loadSessions":
-          this.handleLoadSessions().catch((e) => console.error("[Kilo New] handleLoadSessions failed:", e))
+          this.handleLoadSessions().catch((e) => log("[Kilo New] handleLoadSessions failed:", e))
           break
         case "login":
           await this.handleLogin()
@@ -404,10 +403,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           vscode.commands.executeCommand("kilo-code.new.showChanges")
           break
         case "retryConnection":
-          console.log("[Kilo New] KiloProvider: 🔄 Retrying connection...")
-          this.initializeConnection().catch((e) =>
-            console.error("[Kilo New] KiloProvider: ❌ Retry connection failed:", e),
-          )
+          log("[Kilo New] KiloProvider: 🔄 Retrying connection...")
+          this.initializeConnection().catch((e) => log("[Kilo New] KiloProvider: ❌ Retry connection failed:", e))
           break
         case "openSubAgentViewer":
           vscode.commands.executeCommand("kilo-code.new.openSubAgentViewer", message.sessionID, message.title)
@@ -418,21 +415,19 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           }
           break
         case "requestProviders":
-          this.fetchAndSendProviders().catch((e) => console.error("[Kilo New] fetchAndSendProviders failed:", e))
+          this.fetchAndSendProviders().catch((e) => log("[Kilo New] fetchAndSendProviders failed:", e))
           break
         case "compact":
           await this.handleCompact(message.sessionID, message.providerID, message.modelID)
           break
         case "requestAgents":
-          this.fetchAndSendAgents().catch((e) => console.error("[Kilo New] fetchAndSendAgents failed:", e))
+          this.fetchAndSendAgents().catch((e) => log("[Kilo New] fetchAndSendAgents failed:", e))
           break
         case "requestSkills":
-          this.fetchAndSendSkills().catch((e) => console.error("[Kilo New] fetchAndSendSkills failed:", e))
+          this.fetchAndSendSkills().catch((e) => log("[Kilo New] fetchAndSendSkills failed:", e))
           break
         case "removeSkill":
-          this.handleRemoveSkill(message.location).catch((e) =>
-            console.error("[Kilo New] handleRemoveSkill failed:", e),
-          )
+          this.handleRemoveSkill(message.location).catch((e) => log("[Kilo New] handleRemoveSkill failed:", e))
           break
         case "questionReply":
           await this.handleQuestionReply(message.requestID, message.answers)
@@ -441,7 +436,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           await this.handleQuestionReject(message.requestID)
           break
         case "requestConfig":
-          this.fetchAndSendConfig().catch((e) => console.error("[Kilo New] fetchAndSendConfig failed:", e))
+          this.fetchAndSendConfig().catch((e) => log("[Kilo New] fetchAndSendConfig failed:", e))
           break
         case "updateConfig":
           await this.handleUpdateConfig(message.config)
@@ -494,7 +489,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
                 })
               })
               .catch((error: unknown) => {
-                console.error("[Kilo New] File search failed:", error)
+                log("[Kilo New] File search failed:", error)
                 this.postMessage({ type: "fileSearchResult", paths: [], dir, requestId: message.requestId })
               })
           } else {
@@ -521,9 +516,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           this.sendNotificationSettings()
           break
         case "requestNotifications":
-          this.fetchAndSendNotifications().catch((e) =>
-            console.error("[Kilo New] fetchAndSendNotifications failed:", e),
-          )
+          this.fetchAndSendNotifications().catch((e) => log("[Kilo New] fetchAndSendNotifications failed:", e))
           break
         case "requestCloudSessions":
           await this.handleRequestCloudSessions(message)
@@ -610,7 +603,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             })
             .catch((err: unknown) => {
               const msg = getErrorMessage(err) || "Failed to enhance prompt"
-              console.error("[Kilo New] KiloProvider: Failed to enhance prompt:", err)
+              log("[Kilo New] KiloProvider: Failed to enhance prompt:", err)
               vscode.window.showErrorMessage(`Enhance prompt failed: ${msg}`)
               this.postMessage({
                 type: "enhancePromptError",
@@ -639,7 +632,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   private async doInitializeConnection(): Promise<void> {
-    console.log("[Kilo New] KiloProvider: 🔧 Starting initializeConnection...")
+    log("[Kilo New] KiloProvider: 🔧 Starting initializeConnection...")
 
     this.connectionState = "connecting"
     this.postMessage({ type: "connectionState", state: "connecting" })
@@ -689,7 +682,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             await this.flushPendingSessionRefresh("sse-connected")
             await this.fetchAndSendPendingPermissions()
           } catch (error) {
-            console.error("[Kilo New] KiloProvider: ❌ Failed during connected state handling:", error)
+            log("[Kilo New] KiloProvider: ❌ Failed during connected state handling:", error)
             this.postMessage({
               type: "error",
               message: getErrorMessage(error) || "Failed to sync after connecting",
@@ -733,9 +726,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       ])
       this.sendNotificationSettings()
 
-      console.log("[Kilo New] KiloProvider: ✅ initializeConnection completed successfully")
+      log("[Kilo New] KiloProvider: ✅ initializeConnection completed successfully")
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: ❌ Failed to initialize connection:", error)
+      log("[Kilo New] KiloProvider: ❌ Failed to initialize connection:", error)
       this.connectionState = "error"
       this.postMessage({
         type: "connectionState",
@@ -777,7 +770,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         session: this.sessionToWebview(this.currentSession!),
       })
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to create session:", error)
+      log("[Kilo New] KiloProvider: Failed to create session:", error)
       this.postMessage({
         type: "error",
         message: getErrorMessage(error) || "Failed to create session",
@@ -831,7 +824,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             this.currentSession = result.data
           }
         })
-        .catch((err: unknown) => console.warn("[Kilo New] KiloProvider: getSession failed (non-critical):", err))
+        .catch((err: unknown) => log("[Kilo New] KiloProvider: getSession failed (non-critical):", err))
 
       this.postMessage({
         type: "workspaceDirectoryChanged",
@@ -854,7 +847,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             })
           }
         })
-        .catch((err: unknown) => console.error("[Kilo New] KiloProvider: Failed to fetch session statuses:", err))
+        .catch((err: unknown) => log("[Kilo New] KiloProvider: Failed to fetch session statuses:", err))
 
       const messages = messagesData.map((m) => ({
         ...m.info,
@@ -878,7 +871,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     } catch (error) {
       // Silently ignore aborted requests — the user switched to a different session
       if (abort.signal.aborted) return
-      console.error("[Kilo New] KiloProvider: Failed to load messages:", error)
+      log("[Kilo New] KiloProvider: Failed to load messages:", error)
       this.postMessage({
         type: "error",
         message: getErrorMessage(error) || "Failed to load messages",
@@ -921,7 +914,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         messages,
       })
     } catch (err) {
-      console.error("[Kilo New] KiloProvider: Failed to sync child session:", err)
+      log("[Kilo New] KiloProvider: Failed to sync child session:", err)
     }
   }
 
@@ -948,13 +941,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    */
   private async flushPendingSessionRefresh(reason: string): Promise<void> {
     if (!this.pendingSessionRefresh) return
-    console.log("[Kilo New] KiloProvider: 🔄 Flushing deferred sessions refresh", { reason })
+    log("[Kilo New] KiloProvider: 🔄 Flushing deferred sessions refresh", { reason })
     const ctx = this.sessionRefreshContext
     try {
       const resolved = await flushPendingSessionRefreshUtil(ctx)
       if (resolved) this.projectID = resolved
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to flush session refresh:", error)
+      log("[Kilo New] KiloProvider: Failed to flush session refresh:", error)
     }
     this.pendingSessionRefresh = ctx.pendingSessionRefresh
   }
@@ -968,7 +961,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const resolved = await loadSessionsUtil(ctx)
       if (resolved) this.projectID = resolved
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to load sessions:", error)
+      log("[Kilo New] KiloProvider: Failed to load sessions:", error)
       this.postMessage({
         type: "error",
         message: getErrorMessage(error) || "Failed to load sessions",
@@ -997,7 +990,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       }
       this.postMessage({ type: "sessionDeleted", sessionID })
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to delete session:", error)
+      log("[Kilo New] KiloProvider: Failed to delete session:", error)
       this.postMessage({
         type: "error",
         message: getErrorMessage(error) || "Failed to delete session",
@@ -1025,7 +1018,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       }
       this.postMessage({ type: "sessionUpdated", session: this.sessionToWebview(updated) })
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to rename session:", error)
+      log("[Kilo New] KiloProvider: Failed to rename session:", error)
       this.postMessage({
         type: "error",
         message: getErrorMessage(error) || "Failed to rename session",
@@ -1070,7 +1063,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.cachedProvidersMessage = message
       this.postMessage(message)
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to fetch providers:", error)
+      log("[Kilo New] KiloProvider: Failed to fetch providers:", error)
     }
   }
 
@@ -1105,7 +1098,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.cachedAgentsMessage = message
       this.postMessage(message)
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to fetch agents:", error)
+      log("[Kilo New] KiloProvider: Failed to fetch agents:", error)
     }
   }
 
@@ -1128,7 +1121,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.cachedSkillsMessage = message
       this.postMessage(message)
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to fetch skills:", error)
+      log("[Kilo New] KiloProvider: Failed to fetch skills:", error)
     }
   }
 
@@ -1143,13 +1136,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const dir = this.getWorkspaceDirectory()
       const result = await this.client.kilocode.removeSkill({ location, directory: dir })
       if (result.error) {
-        console.error("[Kilo New] KiloProvider: removeSkill returned error:", result.error)
+        log("[Kilo New] KiloProvider: removeSkill returned error:", result.error)
         this.cachedSkillsMessage = null
         await this.fetchAndSendSkills()
         return
       }
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to remove skill:", error)
+      log("[Kilo New] KiloProvider: Failed to remove skill:", error)
       this.cachedSkillsMessage = null
       await this.fetchAndSendSkills()
       return
@@ -1180,7 +1173,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.cachedConfigMessage = message
       this.postMessage(message)
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to fetch config:", error)
+      log("[Kilo New] KiloProvider: Failed to fetch config:", error)
     }
   }
 
@@ -1209,7 +1202,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.cachedNotificationsMessage = message
       this.postMessage(message)
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to fetch notifications:", error)
+      log("[Kilo New] KiloProvider: Failed to fetch notifications:", error)
     }
   }
 
@@ -1243,7 +1236,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         nextCursor: result.data?.nextCursor ?? null,
       })
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to fetch cloud sessions:", error)
+      log("[Kilo New] KiloProvider: Failed to fetch cloud sessions:", error)
       this.postMessage({
         type: "error",
         message: error instanceof Error ? error.message : "Failed to fetch cloud sessions",
@@ -1286,7 +1279,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         messages,
       })
     } catch (err) {
-      console.error("[Kilo New] Failed to load cloud session data:", err)
+      log("[Kilo New] Failed to load cloud session data:", err)
       this.postMessage({
         type: "cloudSessionImportFailed",
         cloudSessionId: sessionId,
@@ -1330,7 +1323,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       })
       session = importResult.data as Session | undefined
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: ❌ Cloud session import failed:", error)
+      log("[Kilo New] KiloProvider: ❌ Cloud session import failed:", error)
       this.postMessage({
         type: "cloudSessionImportFailed",
         cloudSessionId,
@@ -1390,7 +1383,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         { throwOnError: true },
       )
     } catch (err) {
-      console.error("[Kilo New] Failed to send message after cloud import:", err)
+      log("[Kilo New] Failed to send message after cloud import:", err)
       this.postMessage({
         type: "sendMessageFailed",
         error: err instanceof Error ? err.message : "Failed to send message after import",
@@ -1455,7 +1448,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.cachedConfigMessage = { type: "configLoaded", config: updated }
       this.postMessage(message)
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to update config:", error)
+      log("[Kilo New] KiloProvider: Failed to update config:", error)
       this.postMessage({
         type: "error",
         message: getErrorMessage(error) || "Failed to update config",
@@ -1547,7 +1540,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         { throwOnError: true },
       )
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to send message:", error)
+      log("[Kilo New] KiloProvider: Failed to send message:", error)
       this.postMessage({
         type: "sendMessageFailed",
         error: getErrorMessage(error) || "Failed to send message",
@@ -1576,7 +1569,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const workspaceDir = this.getWorkspaceDirectory(targetSessionID)
       await this.client.session.abort({ sessionID: targetSessionID, directory: workspaceDir }, { throwOnError: true })
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to abort session:", error)
+      log("[Kilo New] KiloProvider: Failed to abort session:", error)
     }
   }
 
@@ -1594,12 +1587,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     const target = sessionID || this.currentSession?.id
     if (!target) {
-      console.error("[Kilo New] KiloProvider: No sessionID for compact")
+      log("[Kilo New] KiloProvider: No sessionID for compact")
       return
     }
 
     if (!providerID || !modelID) {
-      console.error("[Kilo New] KiloProvider: No model selected for compact")
+      log("[Kilo New] KiloProvider: No model selected for compact")
       this.postMessage({
         type: "error",
         message: "No model selected. Connect a provider to compact this session.",
@@ -1614,7 +1607,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         { throwOnError: true },
       )
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to compact session:", error)
+      log("[Kilo New] KiloProvider: Failed to compact session:", error)
       this.postMessage({
         type: "error",
         message: getErrorMessage(error) || "Failed to compact session",
@@ -1640,7 +1633,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     const targetSessionID = sessionID || this.currentSession?.id
     if (!targetSessionID) {
-      console.error("[Kilo New] KiloProvider: No sessionID for permission response")
+      log("[Kilo New] KiloProvider: No sessionID for permission response")
       this.postMessage({ type: "permissionError", permissionID: permissionId })
       return
     }
@@ -1666,7 +1659,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         { throwOnError: true },
       )
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to respond to permission:", error)
+      log("[Kilo New] KiloProvider: Failed to respond to permission:", error)
       this.postMessage({ type: "permissionError", permissionID: permissionId })
     }
   }
@@ -1699,7 +1692,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         })
       }
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to fetch pending permissions:", error)
+      log("[Kilo New] KiloProvider: Failed to fetch pending permissions:", error)
     }
   }
 
@@ -1718,7 +1711,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         { throwOnError: true },
       )
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to reply to question:", error)
+      log("[Kilo New] KiloProvider: Failed to reply to question:", error)
       this.postMessage({ type: "questionError", requestID })
     }
   }
@@ -1738,7 +1731,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         { throwOnError: true },
       )
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to reject question:", error)
+      log("[Kilo New] KiloProvider: Failed to reject question:", error)
       this.postMessage({ type: "questionError", requestID })
     }
   }
@@ -1755,7 +1748,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     const attempt = ++this.loginAttempt
 
-    console.log("[Kilo New] KiloProvider: 🔐 Starting login flow...")
+    log("[Kilo New] KiloProvider: 🔐 Starting login flow...")
 
     try {
       const workspaceDir = this.getWorkspaceDirectory()
@@ -1765,7 +1758,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         { providerID: "kilo", method: 0, directory: workspaceDir },
         { throwOnError: true },
       )
-      console.log("[Kilo New] KiloProvider: 🔐 Got auth URL:", auth.url)
+      log("[Kilo New] KiloProvider: 🔐 Got auth URL:", auth.url)
 
       // Parse code from instructions (format: "Open URL and enter code: ABCD-1234")
       const codeMatch = auth.instructions?.match(/code:\s*(\S+)/i)
@@ -1796,11 +1789,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         return
       }
 
-      console.log("[Kilo New] KiloProvider: 🔐 Login successful")
+      log("[Kilo New] KiloProvider: 🔐 Login successful")
 
       await this.client.global
         .dispose()
-        .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: global.dispose() after login failed:", e))
+        .catch((e: unknown) => log("[Kilo New] KiloProvider: global.dispose() after login failed:", e))
 
       // Step 4: Fetch profile and push to webview
       const { data: profileData } = await this.client.kilo.profile(undefined, { throwOnError: true })
@@ -1832,36 +1825,36 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       return
     }
 
-    console.log("[Kilo New] KiloProvider: Switching organization:", organizationId ?? "personal")
+    log("[Kilo New] KiloProvider: Switching organization:", organizationId ?? "personal")
     try {
       await sdkClient.kilo.organization.set({ organizationId }, { throwOnError: true })
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to switch organization:", error)
+      log("[Kilo New] KiloProvider: Failed to switch organization:", error)
       // Re-fetch current profile to reset webview state (clears switching indicator) — best-effort
       try {
         const profileResult = await sdkClient.kilo.profile()
         this.postMessage({ type: "profileData", data: profileResult.data ?? null })
       } catch (profileError) {
-        console.error("[Kilo New] KiloProvider: Failed to refresh profile after org switch error:", profileError)
+        log("[Kilo New] KiloProvider: Failed to refresh profile after org switch error:", profileError)
       }
       return
     }
 
     await this.client.global
       .dispose()
-      .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: global.dispose() after org switch failed:", e))
+      .catch((e: unknown) => log("[Kilo New] KiloProvider: global.dispose() after org switch failed:", e))
 
     // Org switch succeeded — refresh profile and providers independently (best-effort)
     try {
       const profileResult = await sdkClient.kilo.profile()
       this.postMessage({ type: "profileData", data: profileResult.data ?? null })
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to refresh profile after org switch:", error)
+      log("[Kilo New] KiloProvider: Failed to refresh profile after org switch:", error)
     }
     try {
       await this.fetchAndSendProviders()
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to refresh providers after org switch:", error)
+      log("[Kilo New] KiloProvider: Failed to refresh providers after org switch:", error)
     }
   }
 
@@ -1885,7 +1878,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         }
         vscode.window.showTextDocument(doc, options)
       },
-      (err) => console.error("[Kilo New] KiloProvider: Failed to open file:", uri.fsPath, err),
+      (err) => log("[Kilo New] KiloProvider: Failed to open file:", uri.fsPath, err),
     )
   }
 
@@ -1898,9 +1891,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     try {
-      console.log("[Kilo New] KiloProvider: 🚪 Logging out...")
+      log("[Kilo New] KiloProvider: 🚪 Logging out...")
       await this.client.auth.remove({ providerID: "kilo" }, { throwOnError: true })
-      console.log("[Kilo New] KiloProvider: 🚪 Logged out successfully")
+      log("[Kilo New] KiloProvider: 🚪 Logged out successfully")
       this.postMessage({
         type: "profileData",
         data: null,
@@ -1908,9 +1901,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       await this.client.global
         .dispose()
-        .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: global.dispose() after logout failed:", e))
+        .catch((e: unknown) => log("[Kilo New] KiloProvider: global.dispose() after logout failed:", e))
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: ❌ Logout failed:", error)
+      log("[Kilo New] KiloProvider: ❌ Logout failed:", error)
       this.postMessage({
         type: "error",
         message: getErrorMessage(error) || "Failed to logout",
@@ -1926,7 +1919,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       return
     }
 
-    console.log("[Kilo New] KiloProvider: 🔄 Refreshing profile...")
+    log("[Kilo New] KiloProvider: 🔄 Refreshing profile...")
     const profileResult = await this.client.kilo.profile().catch(() => ({ data: null }))
     this.postMessage({
       type: "profileData",
@@ -2091,12 +2084,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         typeof (message as { type?: unknown }).type === "string"
           ? (message as { type: string }).type
           : "<unknown>"
-      console.warn("[Kilo New] KiloProvider: ⚠️ postMessage dropped (no webview)", { type })
+      log("[Kilo New] KiloProvider: ⚠️ postMessage dropped (no webview)", { type })
       return
     }
 
     void this.webview.postMessage(message).then(undefined, (error) => {
-      console.error("[Kilo New] KiloProvider: ❌ postMessage failed", error)
+      log("[Kilo New] KiloProvider: ❌ postMessage failed", error)
     })
   }
 
@@ -2136,7 +2129,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const remote = repo.state?.remotes?.find((r: { name: string }) => r.name === "origin")
       return remote?.fetchUrl ?? remote?.pushUrl
     } catch (error) {
-      console.warn("[Kilo New] KiloProvider: Failed to get git remote URL:", error)
+      log("[Kilo New] KiloProvider: Failed to get git remote URL:", error)
       return undefined
     }
   }
@@ -2277,7 +2270,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // Cache so migrate() doesn't re-read from SecretStorage/disk
     this.cachedLegacyData = data
 
-    console.log("[Kilo New] KiloProvider: 🔄 Legacy data detected, showing migration wizard")
+    log("[Kilo New] KiloProvider: 🔄 Legacy data detected, showing migration wizard")
     this.postMessage({ type: "navigate", view: "migration" })
     this.postMessage({
       type: "legacyMigrationData",
@@ -2329,7 +2322,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       // Reloading the data will be handled once the server replies with a global.disposed event
       await this.client.global
         .dispose()
-        .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: global.dispose() after migration failed:", e))
+        .catch((e: unknown) => log("[Kilo New] KiloProvider: global.dispose() after migration failed:", e))
 
       // Only mark as completed if at least one item succeeded — if everything failed
       // the user can still re-run migration via Settings → About.
@@ -2341,7 +2334,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       this.postMessage({ type: "legacyMigrationComplete", results })
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: ❌ Migration failed", error)
+      log("[Kilo New] KiloProvider: ❌ Migration failed", error)
       this.postMessage({
         type: "legacyMigrationComplete",
         results: [

--- a/packages/kilo-vscode/src/SettingsEditorProvider.ts
+++ b/packages/kilo-vscode/src/SettingsEditorProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import { KiloProvider } from "./KiloProvider"
 import type { KiloConnectionService } from "./services/cli-backend"
+import { log } from "./output-channel"
 
 type PanelView = "settings" | "profile"
 
@@ -86,7 +87,7 @@ export class SettingsEditorProvider implements vscode.Disposable {
     this.providers.set(view, provider)
 
     panel.onDidDispose(() => {
-      console.log(`[Kilo New] ${title} panel disposed`)
+      log(`[Kilo New] ${title} panel disposed`)
       closePanelDisposable.dispose()
       readyDisposable.dispose()
       tabDisposable.dispose()

--- a/packages/kilo-vscode/src/SubAgentViewerProvider.ts
+++ b/packages/kilo-vscode/src/SubAgentViewerProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import { KiloProvider } from "./KiloProvider"
 import type { KiloConnectionService } from "./services/cli-backend"
+import { log } from "./output-channel"
 
 /**
  * Opens a read-only editor panel to view a sub-agent session.
@@ -77,7 +78,7 @@ export class SubAgentViewerProvider implements vscode.Disposable {
         // Navigate to the sub-agent viewer
         provider.postMessage({ type: "viewSubAgentSession", sessionID })
       } catch (err) {
-        console.error("[Kilo New] SubAgentViewerProvider: Failed to load session:", err)
+        log("[Kilo New] SubAgentViewerProvider: Failed to load session:", err)
       }
     })
 
@@ -92,7 +93,7 @@ export class SubAgentViewerProvider implements vscode.Disposable {
     this.providers.set(sessionID, provider)
 
     panel.onDidDispose(() => {
-      console.log("[Kilo New] Sub-agent viewer panel disposed:", sessionID)
+      log("[Kilo New] Sub-agent viewer panel disposed:", sessionID)
       closeDisposable.dispose()
       provider.dispose()
       this.panels.delete(sessionID)

--- a/packages/kilo-vscode/src/agent-manager/SetupScriptService.ts
+++ b/packages/kilo-vscode/src/agent-manager/SetupScriptService.ts
@@ -8,6 +8,7 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
 import { SETUP_SCRIPT_TEMPLATE, SETUP_SCRIPT_TEMPLATE_POWERSHELL } from "./setup-script-template"
+import { log as extensionLog } from "../output-channel"
 import { KILO_DIR } from "./constants"
 
 const SETUP_SCRIPT_FILENAME = "setup-script"
@@ -116,7 +117,6 @@ export class SetupScriptService {
   }
 
   private log(message: string): void {
-    // Log to console since we don't have an OutputChannel here
-    console.log(`[SetupScriptService] ${message}`)
+    extensionLog(`[SetupScriptService] ${message}`)
   }
 }

--- a/packages/kilo-vscode/src/agent-manager/shell-env.ts
+++ b/packages/kilo-vscode/src/agent-manager/shell-env.ts
@@ -14,6 +14,7 @@
 import { type ExecFileOptionsWithStringEncoding, execFile } from "child_process"
 import * as os from "os"
 import { promisify } from "util"
+import { log } from "../output-channel"
 
 const run = promisify(execFile)
 
@@ -81,7 +82,7 @@ export async function getShellEnvironment(): Promise<Record<string, string>> {
     wasFallback = false
     return { ...env }
   } catch (error) {
-    console.warn(`[shell-env] Failed to get shell environment: ${error}. Falling back to process.env`)
+    log(`[shell-env] Failed to get shell environment: ${error}. Falling back to process.env`)
     const env: Record<string, string> = {}
     for (const [key, value] of Object.entries(process.env)) {
       if (typeof value === "string") env[key] = value
@@ -103,7 +104,7 @@ async function resolvePath(): Promise<boolean> {
 
   if (env.PATH && env.PATH !== original) {
     process.env.PATH = env.PATH
-    console.log("[shell-env] Patched process.env.PATH for GUI app")
+    log("[shell-env] Patched process.env.PATH for GUI app")
     return true
   }
   // Shell env was a fallback or PATH didn't change — resolution didn't help
@@ -150,7 +151,7 @@ export async function execWithShellEnv(
       return await run(cmd, args, { ...options, encoding: "utf8" })
     }
 
-    console.log(`[shell-env] "${cmd}" not found, resolving shell environment`)
+    log(`[shell-env] "${cmd}" not found, resolving shell environment`)
 
     fixing = resolvePath()
     try {

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -5,6 +5,7 @@ import { DiffViewerProvider } from "./DiffViewerProvider"
 import { SettingsEditorProvider } from "./SettingsEditorProvider"
 import { SubAgentViewerProvider } from "./SubAgentViewerProvider"
 import { EXTENSION_DISPLAY_NAME } from "./constants"
+import { log } from "./output-channel"
 import { KiloConnectionService } from "./services/cli-backend"
 import { registerAutocompleteProvider } from "./services/autocomplete"
 import { BrowserAutomationService } from "./services/browser-automation"
@@ -13,7 +14,7 @@ import { registerCommitMessageService } from "./services/commit-message"
 import { registerCodeActions, registerTerminalActions, KiloCodeActionProvider } from "./services/code-actions"
 
 export function activate(context: vscode.ExtensionContext) {
-  console.log("Kilo Code extension is now active")
+  log("Kilo Code extension is now active")
 
   const telemetry = TelemetryProxy.getInstance()
 
@@ -168,7 +169,7 @@ export function activate(context: vscode.ExtensionContext) {
         const match = uri.path.match(/^\/kilocode\/s\/([a-zA-Z0-9_-]+)$/)
         if (!match) return
         const sessionId = match[1]
-        console.log("[Kilo New] URI handler: opening cloud session:", sessionId)
+        log("[Kilo New] URI handler: opening cloud session:", sessionId)
         await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
         provider.openCloudSession(sessionId)
       },
@@ -240,7 +241,7 @@ async function openKiloInNewTab(context: vscode.ExtensionContext, connectionServ
 
   panel.onDidDispose(
     () => {
-      console.log("[Kilo New] Tab panel disposed")
+      log("[Kilo New] Tab panel disposed")
       tabProvider.dispose()
     },
     null,

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -1,5 +1,6 @@
 import type { Session, Agent, Event, ProviderListResponse } from "@kilocode/sdk/v2/client"
 import type { CloudSessionMessage } from "./services/cli-backend/types"
+import { log } from "./output-channel"
 
 /** A single provider entry as returned by the /provider list endpoint. */
 export type ProviderInfo = ProviderListResponse["all"][number]
@@ -97,7 +98,7 @@ export async function loadSessions(ctx: SessionRefreshContext): Promise<string |
   const extra = await Promise.all(
     [...worktreeDirs].map((dir) =>
       list(dir).catch((err: unknown) => {
-        console.error(`[Kilo] Failed to list sessions for ${dir}:`, err)
+        log(`[Kilo] Failed to list sessions for ${dir}:`, err)
         return [] as Session[]
       }),
     ),

--- a/packages/kilo-vscode/src/output-channel.ts
+++ b/packages/kilo-vscode/src/output-channel.ts
@@ -1,0 +1,23 @@
+import * as vscode from "vscode"
+import { inspect } from "util"
+
+let channel: vscode.OutputChannel | undefined
+
+/**
+ * Get the shared "Kilo Extension" output channel, creating it lazily on first use.
+ * All extension logging (outside Agent Manager and Diff Viewer) goes here.
+ */
+export function getOutputChannel(): vscode.OutputChannel {
+  return (channel ??= vscode.window.createOutputChannel("Kilo Extension"))
+}
+
+/**
+ * Write a formatted log line to the "Kilo Extension" output channel.
+ * Accepts the same variadic signature as console.log.
+ */
+export function log(...args: unknown[]): void {
+  const msg = args
+    .map((item) => (typeof item === "string" ? item : inspect(item, { breakLength: Infinity, depth: 4 })))
+    .join(" ")
+  getOutputChannel().appendLine(`${new Date().toISOString()} ${msg}`)
+}

--- a/packages/kilo-vscode/src/review-utils.ts
+++ b/packages/kilo-vscode/src/review-utils.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode"
 import { inspect } from "util"
 import type { FileDiff } from "@kilocode/sdk/v2/client"
 import { GitOps } from "./agent-manager/GitOps"
+import { log } from "./output-channel"
 
 export function appendOutput(channel: vscode.OutputChannel, prefix: string, ...args: unknown[]): void {
   const msg = args
@@ -85,7 +86,7 @@ export function openFileInEditor(
 
   vscode.workspace.openTextDocument(uri).then(
     (doc) => vscode.window.showTextDocument(doc, { viewColumn, preview: true, selection }),
-    (err) => console.error(`[Kilo New] ${prefix}: Failed to open file:`, uri.fsPath, err),
+    (err) => log(`[Kilo New] ${prefix}: Failed to open file:`, uri.fsPath, err),
   )
 }
 

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/FillInTheMiddle.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/FillInTheMiddle.ts
@@ -8,6 +8,7 @@ import {
 import { getProcessedSnippets } from "./getProcessedSnippets"
 import { getTemplateForModel } from "../continuedev/core/autocomplete/templating/AutocompleteTemplate"
 import { AutocompleteModel } from "../AutocompleteModel"
+import { log } from "../../../output-channel"
 
 export type { FimAutocompletePrompt, FimCompletionResult }
 
@@ -76,7 +77,7 @@ export class FimPromptBuilder {
 
     logtime("snippets")
 
-    console.log("[FIM] formattedPrefix:", formattedPrefix)
+    log("[FIM] formattedPrefix:", formattedPrefix)
 
     let response = ""
     const onChunk = (text: string) => {
@@ -85,15 +86,15 @@ export class FimPromptBuilder {
     logtime("prep fim")
     const usageInfo = await model.generateFimResponse(formattedPrefix, prunedSuffix, onChunk, signal)
     logtime("fim network")
-    console.log("[FIM] response:", response)
+    log("[FIM] response:", response)
 
     const fillInAtCursorSuggestion = processSuggestion(response)
 
     if (fillInAtCursorSuggestion.text) {
-      console.info("Final FIM suggestion:", fillInAtCursorSuggestion)
+      log("Final FIM suggestion:", fillInAtCursorSuggestion)
     }
     logtime("processSuggestion")
-    console.log(perflog + `lengths: ${formattedPrefix.length + prunedSuffix.length}\n`)
+    log(perflog + `lengths: ${formattedPrefix.length + prunedSuffix.length}\n`)
     return {
       suggestion: fillInAtCursorSuggestion,
       cost: usageInfo.cost,

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/getProcessedSnippets.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/getProcessedSnippets.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode"
+import { log } from "../../../output-channel"
 import { ContextRetrievalService } from "../continuedev/core/autocomplete/context/ContextRetrievalService"
 import { VsCodeIde } from "../continuedev/core/vscode-test-harness/src/VSCodeIde"
 import { AutocompleteInput } from "../types"
@@ -56,7 +57,7 @@ async function filterSnippetsByAccess(
       return true
     })
   } catch (error) {
-    console.error("[AutocompleteContextProvider] Error filtering snippets by access:", error)
+    log("[AutocompleteContextProvider] Error filtering snippets by access:", error)
     // On error, be conservative and filter out file-based snippets
     return snippets.filter((snippet) => {
       return !hasFilepath(snippet) || !snippet.filepath

--- a/packages/kilo-vscode/src/services/autocomplete/context/VisibleCodeTracker.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/context/VisibleCodeTracker.ts
@@ -12,6 +12,7 @@ import * as vscode from "vscode"
 
 import { isSecurityConcern } from "../continuedev/core/indexing/ignore"
 import type { FileIgnoreController } from "../shims/FileIgnoreController"
+import { log } from "../../../output-channel"
 
 function toRelativePath(absolutePath: string, workspacePath: string): string {
   return vscode.workspace.asRelativePath(absolutePath, false) || absolutePath.replace(workspacePath + "/", "")
@@ -57,11 +58,11 @@ export class VisibleCodeTracker {
       const relativePath = toRelativePath(filePath, this.workspacePath)
 
       if (isSecurityConcern(filePath)) {
-        console.log(`[VisibleCodeTracker] Filtered (security): ${relativePath}`)
+        log(`[VisibleCodeTracker] Filtered (security): ${relativePath}`)
         continue
       }
       if (this.ignoreController && !this.ignoreController.validateAccess(relativePath)) {
-        console.log(`[VisibleCodeTracker] Filtered (.kilocodeignore): ${relativePath}`)
+        log(`[VisibleCodeTracker] Filtered (.kilocodeignore): ${relativePath}`)
         continue
       }
 

--- a/packages/kilo-vscode/src/services/browser-automation/browser-automation-service.ts
+++ b/packages/kilo-vscode/src/services/browser-automation/browser-automation-service.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import type { KiloClient, McpStatus } from "@kilocode/sdk/v2/client"
 import type { KiloConnectionService } from "../cli-backend"
+import { log } from "../../output-channel"
 
 export type BrowserAutomationState = "disabled" | "registering" | "connected" | "failed" | "disconnected"
 
@@ -74,7 +75,7 @@ export class BrowserAutomationService implements vscode.Disposable {
 
     const client = this.getClient()
     if (!client) {
-      console.error("[Kilo New] BrowserAutomationService: No SDK client available")
+      log("[Kilo New] BrowserAutomationService: No SDK client available")
       this.setState("failed")
       return
     }
@@ -112,16 +113,13 @@ export class BrowserAutomationService implements vscode.Disposable {
       if (serverStatus?.status === "connected") {
         this.setState("connected")
       } else if (serverStatus?.status === "failed") {
-        console.error(
-          "[Kilo New] BrowserAutomationService: MCP server failed:",
-          (serverStatus as { error?: string }).error,
-        )
+        log("[Kilo New] BrowserAutomationService: MCP server failed:", (serverStatus as { error?: string }).error)
         this.setState("failed")
       } else {
         this.setState("disconnected")
       }
     } catch (error) {
-      console.error("[Kilo New] BrowserAutomationService: Failed to register MCP server:", error)
+      log("[Kilo New] BrowserAutomationService: Failed to register MCP server:", error)
       this.setState("failed")
     }
   }
@@ -143,7 +141,7 @@ export class BrowserAutomationService implements vscode.Disposable {
           { throwOnError: true },
         )
       } catch (error) {
-        console.error("[Kilo New] BrowserAutomationService: Failed to disconnect MCP server:", error)
+        log("[Kilo New] BrowserAutomationService: Failed to disconnect MCP server:", error)
       }
     }
 
@@ -188,7 +186,7 @@ export class BrowserAutomationService implements vscode.Disposable {
     if (this.state === state) {
       return
     }
-    console.log(`[Kilo New] BrowserAutomationService: State ${this.state} → ${state}`)
+    log(`[Kilo New] BrowserAutomationService: State ${this.state} → ${state}`)
     this.state = state
     for (const listener of this.stateListeners) {
       listener(state)

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -4,6 +4,7 @@ import { createKiloClient, type KiloClient, type Event } from "@kilocode/sdk/v2/
 import { SdkSSEAdapter } from "./sdk-sse-adapter"
 import type { ServerConfig } from "./types"
 import { resolveEventSessionId as resolveEventSessionIdPure } from "./connection-utils"
+import { log } from "../../output-channel"
 
 export type ConnectionState = "connecting" | "connected" | "disconnected" | "error"
 type SSEEventListener = (event: Event) => void
@@ -216,7 +217,7 @@ export class KiloConnectionService {
       }
       const healthy = await this.checkHealth(baseUrl, password)
       if (!healthy && this.state === "connected") {
-        console.warn("[Kilo New] ConnectionService: ❤️‍🩹 Health check failed — forcing SSE reconnect")
+        log("[Kilo New] ConnectionService: Health check failed — forcing SSE reconnect")
         this.sseClient?.disconnect()
       }
     }, HEALTH_POLL_INTERVAL_MS)

--- a/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
@@ -1,4 +1,5 @@
 import type { KiloClient, GlobalEvent, Event } from "@kilocode/sdk/v2/client"
+import { log } from "../../output-channel"
 
 export type SSEEventHandler = (event: Event) => void
 export type SSEErrorHandler = (error: Error) => void
@@ -50,16 +51,16 @@ export class SdkSSEAdapter {
    */
   connect(): void {
     if (this.abortController) {
-      console.log("[Kilo New] SSE: ⚠️ Already connected, skipping")
+      log("[Kilo New] SSE: ⚠️ Already connected, skipping")
       return
     }
 
-    console.log("[Kilo New] SSE: 🔌 connect() called")
+    log("[Kilo New] SSE: 🔌 connect() called")
     this.abortController = new AbortController()
-    console.log('[Kilo New] SSE: 🔄 Setting state to "connecting"')
+    log('[Kilo New] SSE: Setting state to "connecting"')
     this.notifyState("connecting")
     void this.consumeLoop(this.abortController.signal).catch((err) => {
-      console.error("[Kilo New] SSE: Unhandled error in consumeLoop:", err)
+      log("[Kilo New] SSE: Unhandled error in consumeLoop:", err)
       this.notifyError(err instanceof Error ? err : new Error(String(err)))
     })
   }
@@ -68,7 +69,7 @@ export class SdkSSEAdapter {
    * Stop consuming the SSE stream and abort any in-flight request.
    */
   disconnect(): void {
-    console.log("[Kilo New] SSE: 🔌 disconnect() called")
+    log("[Kilo New] SSE: 🔌 disconnect() called")
     this.abortController?.abort()
     this.abortController = null
     this.clearHeartbeat()
@@ -122,19 +123,19 @@ export class SdkSSEAdapter {
       signal.addEventListener("abort", onAbort)
 
       try {
-        console.log("[Kilo New] SSE: 🎬 Calling SDK global.event()...")
+        log("[Kilo New] SSE: 🎬 Calling SDK global.event()...")
         const events = await this.client.global.event({
           signal: attempt.signal,
           onSseError: (error) => {
             if (signal.aborted) {
               return
             }
-            console.error("[Kilo New] SSE: ❌ SDK SSE error callback:", error)
+            log("[Kilo New] SSE: ❌ SDK SSE error callback:", error)
             this.notifyError(error instanceof Error ? error : new Error(String(error)))
           },
         })
 
-        console.log("[Kilo New] SSE: ✅ Stream opened successfully")
+        log("[Kilo New] SSE: ✅ Stream opened successfully")
         this.notifyState("connected")
         this.resetHeartbeat(attempt)
 
@@ -147,14 +148,14 @@ export class SdkSSEAdapter {
 
           // The SDK yields GlobalEvent = { directory, payload: Event }.
           const globalEvent = event as GlobalEvent
-          console.log("[Kilo New] SSE: 📨 Event:", globalEvent.payload.type)
+          log("[Kilo New] SSE: 📨 Event:", globalEvent.payload.type)
           this.notifyEvent(globalEvent.payload)
         }
 
-        console.log("[Kilo New] SSE: 📭 Stream ended normally")
+        log("[Kilo New] SSE: 📭 Stream ended normally")
       } catch (error) {
         if (!signal.aborted) {
-          console.error("[Kilo New] SSE: ❌ Stream error:", error)
+          log("[Kilo New] SSE: ❌ Stream error:", error)
           this.notifyError(error instanceof Error ? error : new Error(String(error)))
         }
       } finally {
@@ -166,7 +167,7 @@ export class SdkSSEAdapter {
         break
       }
 
-      console.log(`[Kilo New] SSE: 🔄 Reconnecting in ${SdkSSEAdapter.RECONNECT_DELAY_MS}ms...`)
+      log(`[Kilo New] SSE: Reconnecting in ${SdkSSEAdapter.RECONNECT_DELAY_MS}ms...`)
       this.notifyState("connecting")
       await new Promise((resolve) => setTimeout(resolve, SdkSSEAdapter.RECONNECT_DELAY_MS))
     }
@@ -182,7 +183,7 @@ export class SdkSSEAdapter {
   private resetHeartbeat(attempt: AbortController): void {
     this.clearHeartbeat()
     this.heartbeatTimer = setTimeout(() => {
-      console.log("[Kilo New] SSE: ⏰ Heartbeat timeout — aborting stale connection")
+      log("[Kilo New] SSE: ⏰ Heartbeat timeout — aborting stale connection")
       attempt.abort()
     }, SdkSSEAdapter.HEARTBEAT_TIMEOUT_MS)
   }
@@ -201,7 +202,7 @@ export class SdkSSEAdapter {
       try {
         handler(event)
       } catch (error) {
-        console.error("[Kilo New] SSE: Error in event handler:", error)
+        log("[Kilo New] SSE: Error in event handler:", error)
       }
     }
   }
@@ -211,7 +212,7 @@ export class SdkSSEAdapter {
       try {
         handler(error)
       } catch (err) {
-        console.error("[Kilo New] SSE: Error in error handler:", err)
+        log("[Kilo New] SSE: Error in error handler:", err)
       }
     }
   }
@@ -221,7 +222,7 @@ export class SdkSSEAdapter {
       try {
         handler(state)
       } catch (error) {
-        console.error("[Kilo New] SSE: Error in state handler:", error)
+        log("[Kilo New] SSE: Error in state handler:", error)
       }
     }
   }

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -5,6 +5,7 @@ import * as path from "path"
 import * as vscode from "vscode"
 import { t } from "./i18n"
 import { parseServerPort } from "./server-utils"
+import { log } from "../../output-channel"
 
 export interface ServerInstance {
   port: number
@@ -24,22 +25,22 @@ export class ServerManager {
    * Get or start the server instance
    */
   async getServer(): Promise<ServerInstance> {
-    console.log("[Kilo New] ServerManager: 🔍 getServer called")
+    log("[Kilo New] ServerManager: 🔍 getServer called")
     if (this.instance) {
-      console.log("[Kilo New] ServerManager: ♻️ Returning existing instance:", { port: this.instance.port })
+      log("[Kilo New] ServerManager: ♻️ Returning existing instance:", { port: this.instance.port })
       return this.instance
     }
 
     if (this.startupPromise) {
-      console.log("[Kilo New] ServerManager: ⏳ Startup already in progress, waiting...")
+      log("[Kilo New] ServerManager: ⏳ Startup already in progress, waiting...")
       return this.startupPromise
     }
 
-    console.log("[Kilo New] ServerManager: 🚀 Starting new server instance...")
+    log("[Kilo New] ServerManager: 🚀 Starting new server instance...")
     this.startupPromise = this.startServer()
     try {
       this.instance = await this.startupPromise
-      console.log("[Kilo New] ServerManager: ✅ Server started successfully:", { port: this.instance.port })
+      log("[Kilo New] ServerManager: ✅ Server started successfully:", { port: this.instance.port })
       return this.instance
     } finally {
       this.startupPromise = null
@@ -49,8 +50,8 @@ export class ServerManager {
   private async startServer(): Promise<ServerInstance> {
     const password = crypto.randomBytes(32).toString("hex")
     const cliPath = this.getCliPath()
-    console.log("[Kilo New] ServerManager: 📍 CLI path:", cliPath)
-    console.log("[Kilo New] ServerManager: 🔐 Generated password (length):", password.length)
+    log("[Kilo New] ServerManager: 📍 CLI path:", cliPath)
+    log("[Kilo New] ServerManager: 🔐 Generated password (length):", password.length)
 
     // Verify the CLI binary exists
     if (!fs.existsSync(cliPath)) {
@@ -60,11 +61,11 @@ export class ServerManager {
     }
 
     const stat = fs.statSync(cliPath)
-    console.log("[Kilo New] ServerManager: 📄 CLI isFile:", stat.isFile())
-    console.log("[Kilo New] ServerManager: 📄 CLI mode (octal):", (stat.mode & 0o777).toString(8))
+    log("[Kilo New] ServerManager: 📄 CLI isFile:", stat.isFile())
+    log("[Kilo New] ServerManager: 📄 CLI mode (octal):", (stat.mode & 0o777).toString(8))
 
     return new Promise((resolve, reject) => {
-      console.log("[Kilo New] ServerManager: 🎬 Spawning CLI process:", cliPath, ["serve", "--port", "0"])
+      log("[Kilo New] ServerManager: 🎬 Spawning CLI process:", cliPath, ["serve", "--port", "0"])
       const serverProcess = spawn(cliPath, ["serve", "--port", "0"], {
         env: {
           ...process.env,
@@ -84,38 +85,38 @@ export class ServerManager {
         detached: true,
         windowsHide: true,
       })
-      console.log("[Kilo New] ServerManager: 📦 Process spawned with PID:", serverProcess.pid)
+      log("[Kilo New] ServerManager: 📦 Process spawned with PID:", serverProcess.pid)
 
       let resolved = false
       const stderrLines: string[] = []
 
       serverProcess.stdout?.on("data", (data: Buffer) => {
         const output = data.toString()
-        console.log("[Kilo New] ServerManager: 📥 CLI Server stdout:", output)
+        log("[Kilo New] ServerManager: 📥 CLI Server stdout:", output)
 
         const port = parseServerPort(output)
         if (port !== null && !resolved) {
           resolved = true
-          console.log("[Kilo New] ServerManager: 🎯 Port detected:", port)
+          log("[Kilo New] ServerManager: 🎯 Port detected:", port)
           resolve({ port, password, process: serverProcess })
         }
       })
 
       serverProcess.stderr?.on("data", (data: Buffer) => {
         const errorOutput = data.toString()
-        console.error("[Kilo New] ServerManager: ⚠️ CLI Server stderr:", errorOutput)
+        log("[Kilo New] ServerManager: ⚠️ CLI Server stderr:", errorOutput)
         stderrLines.push(errorOutput)
       })
 
       serverProcess.on("error", (error) => {
-        console.error("[Kilo New] ServerManager: ❌ Process error:", error)
+        log("[Kilo New] ServerManager: ❌ Process error:", error)
         if (!resolved) {
           reject(error)
         }
       })
 
       serverProcess.on("exit", (code) => {
-        console.log("[Kilo New] ServerManager: 🛑 Process exited with code:", code)
+        log("[Kilo New] ServerManager: 🛑 Process exited with code:", code)
         if (this.instance?.process === serverProcess) {
           this.instance = null
         }
@@ -131,7 +132,7 @@ export class ServerManager {
 
       setTimeout(() => {
         if (!resolved) {
-          console.error(`[Kilo New] ServerManager: ⏰ Server startup timeout (${STARTUP_TIMEOUT_SECONDS}s)`)
+          log(`[Kilo New] ServerManager: Server startup timeout (${STARTUP_TIMEOUT_SECONDS}s)`)
           ServerManager.killProcess(serverProcess)
           const { userMessage, userDetails } = toErrorMessage(
             t("server.startupTimeout", { seconds: STARTUP_TIMEOUT_SECONDS }),
@@ -148,7 +149,7 @@ export class ServerManager {
     // Always use the bundled binary from the extension directory
     const binName = process.platform === "win32" ? "kilo.exe" : "kilo"
     const cliPath = path.join(this.context.extensionPath, "bin", binName)
-    console.log("[Kilo New] ServerManager: 📦 Using CLI path:", cliPath)
+    log("[Kilo New] ServerManager: 📦 Using CLI path:", cliPath)
     return cliPath
   }
 
@@ -181,7 +182,7 @@ export class ServerManager {
     const proc = this.instance.process
     this.instance = null
 
-    console.log("[Kilo New] ServerManager: 🔴 Disposing — sending SIGTERM to process group, PID:", proc.pid)
+    log("[Kilo New] ServerManager: 🔴 Disposing — sending SIGTERM to process group, PID:", proc.pid)
     ServerManager.killProcess(proc, "SIGTERM")
 
     // SIGKILL fallback after 5s: mirrors the desktop app going straight to
@@ -189,7 +190,7 @@ export class ServerManager {
     // or Instance.disposeAll() hangs past the serve.ts shutdown timeout.
     const timer = setTimeout(() => {
       if (proc.exitCode === null) {
-        console.warn("[Kilo New] ServerManager: ⚠️ Process did not exit after SIGTERM, sending SIGKILL")
+        log("[Kilo New] ServerManager: ⚠️ Process did not exit after SIGTERM, sending SIGKILL")
         ServerManager.killProcess(proc, "SIGKILL")
       }
     }, 5000)

--- a/packages/kilo-vscode/src/services/commit-message/index.ts
+++ b/packages/kilo-vscode/src/services/commit-message/index.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode"
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 import type { KiloConnectionService } from "../cli-backend/connection-service"
 import { getErrorMessage } from "../../kilo-provider-utils"
+import { log } from "../../output-channel"
 
 let lastGeneratedMessage: string | undefined
 let lastWorkspacePath: string | undefined
@@ -69,12 +70,12 @@ export function registerCommitMessageService(
           repository.inputBox.value = message
           lastGeneratedMessage = message
           lastWorkspacePath = path
-          console.log("[Kilo New] Commit message generated successfully")
+          log("[Kilo New] Commit message generated successfully")
         },
       )
       .then(undefined, (error: unknown) => {
         const msg = getErrorMessage(error)
-        console.error("[Kilo New] Failed to generate commit message:", msg)
+        log("[Kilo New] Failed to generate commit message:", msg)
         vscode.window.showErrorMessage(`Failed to generate commit message: ${msg}`)
       })
   })

--- a/packages/kilo-vscode/src/services/telemetry/telemetry-proxy.ts
+++ b/packages/kilo-vscode/src/services/telemetry/telemetry-proxy.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import { TelemetryEventName, type TelemetryPropertiesProvider } from "./types"
 import { buildTelemetryPayload, buildTelemetryAuthHeader } from "./telemetry-proxy-utils"
+import { log } from "../../output-channel"
 
 /**
  * Singleton proxy that captures telemetry events and forwards them to the CLI
@@ -57,7 +58,7 @@ export class TelemetryProxy {
         "Content-Type": "application/json",
       },
       body: payload,
-    }).catch((err) => console.error("[Kilo New] Telemetry capture failed:", err))
+    }).catch((err) => log("[Kilo New] Telemetry capture failed:", err))
   }
 
   /**


### PR DESCRIPTION
Replace all console.log/error/warn calls with a shared output channel so extension logs are visible in the VS Code Output panel under 'Kilo Extension', alongside the existing 'Kilo Agent Manager' and 'Kilo Diff Viewer' channels.

- Add src/output-channel.ts with lazy-init getOutputChannel() and log() helper
- Update 17 files to import and use log() instead of console.*
- Exclude Agent Manager and Diff Viewer (they have their own channels)
- Exclude continuedev upstream code (has its own Logger class)

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
