### PR TITLE
fix(vscode): add inert to collapsed question dock body for keyboard accessibility

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -201,7 +201,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
       </div>
 
       {/* Animated body — hidden when collapsed */}
-      <div data-slot="question-dock-body">
+      <div data-slot="question-dock-body" inert={store.collapsed || undefined}>
         <div data-slot="question-dock-body-inner">
           <Show when={!confirm()}>
             <div data-slot="question-text">{question()?.question}</div>


### PR DESCRIPTION
## Summary

- Adds the `inert` attribute to the `question-dock-body` div when the question dock is collapsed, preventing keyboard users from tabbing into visually hidden controls
- Follow-up to #7112 (collapsible question dock) addressing review feedback about focus management