### PR TITLE
Remove (NEW) labels and feature toggle from VS Code extension

### DIFF
--- a/packages/kilo-vscode/AGENTS.md
+++ b/packages/kilo-vscode/AGENTS.md
@@ -194,10 +194,6 @@ New webview features must use **`@kilocode/kilo-ui`** components instead of raw 
 - All VSCode commands must use `kilo-code.new.` prefix (not `kilo-code.`)
 - All view IDs must use `kilo-code.new.` prefix (e.g., `kilo-code.new.sidebarView`)
 
-## Coexistence with Old Extension
-
-While the old extension coexists, runtime labels append `(NEW)` — controlled by the flag in [`constants.ts`](src/constants.ts). Static labels in `package.json` must be updated separately. Remove this convention once the old extension is retired.
-
 ## Kilocode Change Markers
 
 This package is entirely Kilo-specific — `kilocode_change` markers are NOT needed in any files under `packages/kilo-vscode/`. The markers are only necessary when modifying shared upstream opencode files.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -53,7 +53,7 @@
       "activitybar": [
         {
           "id": "kilo-code-sidebar",
-          "title": "Kilo Code (NEW)",
+          "title": "Kilo Code",
           "icon": "assets/icons/kilo-light.png",
           "darkIcon": "assets/icons/kilo-dark.png"
         }
@@ -64,7 +64,7 @@
         {
           "type": "webview",
           "id": "kilo-code.new.sidebarView",
-          "name": "Kilo Code (NEW)"
+          "name": "Kilo Code"
         }
       ]
     },
@@ -106,7 +106,7 @@
       },
       {
         "command": "kilo-code.new.openInTab",
-        "title": "Kilo Code (NEW)",
+        "title": "Kilo Code",
         "icon": {
           "light": "assets/icons/kilo-light.svg",
           "dark": "assets/icons/kilo-dark.svg"
@@ -249,7 +249,7 @@
       {
         "command": "kilo-code.new.generateCommitMessage",
         "title": "Generate Commit Message",
-        "category": "Kilo Code (NEW)",
+        "category": "Kilo Code",
         "icon": {
           "light": "assets/icons/kilo-light.svg",
           "dark": "assets/icons/kilo-dark.svg"

--- a/packages/kilo-vscode/src/constants.ts
+++ b/packages/kilo-vscode/src/constants.ts
@@ -1,17 +1,1 @@
-/**
- * When true, appends " (NEW)" to user-visible extension labels (command tooltips,
- * sidebar title, tab title, etc.) so users can distinguish this extension from the
- * old one while both are installed side-by-side.
- *
- * Set to false (or remove usages) once the old extension is retired.
- *
- * NOTE: This flag only controls *runtime* labels. The following static values in
- * package.json must also be updated manually when removing this flag:
- * - contributes.commands[*].title — any command title containing "(NEW)"
- * - contributes.viewsContainers.activitybar[0].title
- * - contributes.views.kilo-code-sidebar[0].name
- */
-const NEW_EXTENSION_IS_STILL_EXPERIMENTAL_SO_SHOW_EXTRA_TEXTS_TO_SHOW_DIFFERENCE = true
-
-export const EXTENSION_DISPLAY_NAME =
-  "Kilo Code" + (NEW_EXTENSION_IS_STILL_EXPERIMENTAL_SO_SHOW_EXTRA_TEXTS_TO_SHOW_DIFFERENCE ? " (NEW)" : "")
+export const EXTENSION_DISPLAY_NAME = "Kilo Code"


### PR DESCRIPTION
## Summary

- Removes the `NEW_EXTENSION_IS_STILL_EXPERIMENTAL_SO_SHOW_EXTRA_TEXTS_TO_SHOW_DIFFERENCE` feature toggle flag and simplifies `EXTENSION_DISPLAY_NAME` to a plain `"Kilo Code"` string in `constants.ts`
- Removes 4 hardcoded `(NEW)` suffixes from `package.json` (activity bar title, sidebar view name, open-in-tab command title, generate commit message category)
- Removes the "Coexistence with Old Extension" documentation section from `AGENTS.md`

The old extension has been retired so the `(NEW)` suffix is no longer needed to distinguish between extensions.
