### PR TITLE
docs: add commit conventions section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,10 @@ const bazFoo = 3
 You MUST avoid using `mocks` as much as possible.
 Tests MUST test actual implementation, do not duplicate logic into a test.
 
+## Commit Conventions
+
+[Conventional Commits](https://www.conventionalcommits.org/) with scopes matching packages: `vscode`, `cli`, `agent-manager`, `sdk`, `ui`, `i18n`, `kilo-docs`, `gateway`, `telemetry`, `desktop`. Omit scope when spanning multiple packages.
+
 ## Fork Merge Process
 
 Kilo CLI is a fork of [opencode](https://github.com/anomalyco/opencode).


### PR DESCRIPTION
## Summary
- Adds a Commit Conventions section to AGENTS.md documenting the project's use of Conventional Commits
- Lists the package-specific scopes (`vscode`, `cli`, `agent-manager`, `sdk`, `ui`, `i18n`, `kilo-docs`, `gateway`, `telemetry`, `desktop`)
- Derived from analysis of ~300 recent commits by maintainers