### PR TITLE
docs: fix broken Unbound gateway links in provider docs

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/unbound.md
+++ b/packages/kilo-docs/pages/ai-providers/unbound.md
@@ -10,8 +10,8 @@ Kilo Code supports accessing models through [Unbound](https://getunbound.ai/), a
 
 ## Creating an Account
 
-1.  **Sign Up/Sign In:** Go to the [Unbound gateway](https://gateway.getunbound.ai). Create an account or sign in.
-2.  **Create an Application:** Go to the [Applications](https://gateway.getunbound.ai/ai-gateway-applications) page and hit the "Create Application" button.
+1.  **Sign Up/Sign In:** Go to [Unbound](https://getunbound.ai/) and sign up or sign in to access the gateway dashboard.
+2.  **Create an Application:** Navigate to the Applications page in the dashboard and hit the "Create Application" button.
 3.  **Copy the API Key:** Copy the API key to your clipboard.
 
 ## Supported Models


### PR DESCRIPTION
## Summary

Fixes the broken `gateway.getunbound.ai/ai-gateway-applications` URL in the Unbound provider documentation.

### Problem
The URL `https://gateway.getunbound.ai/ai-gateway-applications` (referenced in step 2 of "Creating an Account") returns a 308 redirect to `/applications`, which then 404s. The gateway dashboard URLs have been restructured since these docs were written, causing recurring CI link-check failures.

### Fix
- Replaced the deep-link to the gateway sign-in page with a link to the main `getunbound.ai` site, which has working sign-up/login flows
- Changed the Applications link to a text reference ("Navigate to the Applications page in the dashboard") since it's an authenticated dashboard page that can't be deep-linked reliably

### Related
Closes the link issue identified in #7115.

cc @olearycrew for review