### PR TITLE
fix(cli): use configured Code model when implementing a plan

### DIFF
--- a/packages/opencode/src/kilocode/plan-followup.ts
+++ b/packages/opencode/src/kilocode/plan-followup.ts
@@ -115,39 +115,55 @@ export namespace PlanFollowup {
   export const ANSWER_NEW_SESSION = "Start new session"
   export const ANSWER_CONTINUE = "Continue here"
 
-  async function resolveCodeModel(model: MessageV2.User["model"]) {
-    const saved =
+  function resolveVariant(input: { value: string | undefined; model: Provider.Model | undefined }) {
+    if (!input.value) return undefined
+    if (!input.model?.variants?.[input.value]) return undefined
+    return input.value
+  }
+
+  async function resolveCodeModel(input: Pick<MessageV2.User, "model" | "variant">) {
+    const state =
       Flag.KILO_CLIENT === "cli"
         ? await fs
             .readFile(path.join(Global.Path.state, "model.json"), "utf-8")
             .then(
               (item) =>
                 JSON.parse(item) as {
-                  model?: Record<
-                    string,
-                    {
-                      providerID: string
-                      modelID: string
-                    }
-                  >
+                  model?: Record<string, MessageV2.User["model"]>
+                  variant?: Record<string, string | undefined>
                 },
             )
-            .then((item) => item.model?.code)
             .catch(() => undefined)
         : undefined
+    const saved = state?.model?.code
     if (saved) {
-      const match = await Provider.getModel(saved.providerID, saved.modelID).catch(() => undefined)
-      if (match) {
+      const full = await Provider.getModel(saved.providerID, saved.modelID).catch(() => undefined)
+      if (full) {
+        const key = `${saved.providerID}/${saved.modelID}`
         return {
-          providerID: saved.providerID,
-          modelID: saved.modelID,
+          model: saved,
+          variant: resolveVariant({
+            value: state?.variant?.[key],
+            model: full,
+          }),
         }
       }
     }
 
     const agent = await Agent.get("code")
-    if (agent?.model) return agent.model
-    return model
+    if (agent?.model) {
+      const full = agent.variant
+        ? await Provider.getModel(agent.model.providerID, agent.model.modelID).catch(() => undefined)
+        : undefined
+      return {
+        model: agent.model,
+        variant: resolveVariant({
+          value: agent.variant,
+          model: full,
+        }),
+      }
+    }
+    return input
   }
 
   async function resolvePlan(input: {
@@ -180,6 +196,7 @@ export namespace PlanFollowup {
     sessionID: string
     agent: string
     model: MessageV2.User["model"]
+    variant?: MessageV2.User["variant"]
     text: string
     synthetic?: boolean
   }) {
@@ -192,6 +209,7 @@ export namespace PlanFollowup {
       },
       agent: input.agent,
       model: input.model,
+      variant: input.variant,
     }
     await Session.updateMessage(msg)
     await Session.updatePart({
@@ -248,9 +266,13 @@ export namespace PlanFollowup {
     plan: string
     messages: MessageV2.WithParts[]
     model: MessageV2.User["model"]
+    variant?: MessageV2.User["variant"]
     abort?: AbortSignal
   }) {
-    const model = await resolveCodeModel(input.model)
+    const code = await resolveCodeModel({
+      model: input.model,
+      variant: input.variant,
+    })
     const [handover, todos] = await Promise.all([
       generateHandover({ messages: input.messages, model: input.model, abort: input.abort }),
       Todo.get(input.sessionID),
@@ -271,7 +293,8 @@ export namespace PlanFollowup {
     await inject({
       sessionID: next.id,
       agent: "code",
-      model,
+      model: code.model,
+      variant: code.variant,
       text: sections.join("\n\n"),
       synthetic: false,
     })
@@ -322,6 +345,7 @@ export namespace PlanFollowup {
         plan,
         messages: input.messages,
         model: user.model,
+        variant: user.variant,
         abort: input.abort,
       })
       return "break"
@@ -329,11 +353,15 @@ export namespace PlanFollowup {
 
     if (answer === ANSWER_CONTINUE) {
       Telemetry.trackPlanFollowup(input.sessionID, "continue")
-      const model = await resolveCodeModel(user.model)
+      const code = await resolveCodeModel({
+        model: user.model,
+        variant: user.variant,
+      })
       await inject({
         sessionID: input.sessionID,
         agent: "code",
-        model,
+        model: code.model,
+        variant: code.variant,
         text: "Implement the plan above.",
       })
       return "continue"
@@ -344,6 +372,7 @@ export namespace PlanFollowup {
       sessionID: input.sessionID,
       agent: "plan",
       model: user.model,
+      variant: user.variant,
       text: answer,
     })
     return "continue"

--- a/packages/opencode/src/kilocode/plan-followup.ts
+++ b/packages/opencode/src/kilocode/plan-followup.ts
@@ -152,15 +152,17 @@ export namespace PlanFollowup {
 
     const agent = await Agent.get("code")
     if (agent?.model) {
-      const full = agent.variant
-        ? await Provider.getModel(agent.model.providerID, agent.model.modelID).catch(() => undefined)
-        : undefined
-      return {
-        model: agent.model,
-        variant: resolveVariant({
-          value: agent.variant,
-          model: full,
-        }),
+      const full = await Provider.getModel(agent.model.providerID, agent.model.modelID).catch(() => undefined)
+      if (full) {
+        return {
+          model: agent.model,
+          variant: agent.variant
+            ? resolveVariant({
+                value: agent.variant,
+                model: full,
+              })
+            : undefined,
+        }
       }
     }
     return input

--- a/packages/opencode/src/kilocode/plan-followup.ts
+++ b/packages/opencode/src/kilocode/plan-followup.ts
@@ -2,6 +2,8 @@ import { Telemetry } from "@kilocode/kilo-telemetry"
 import { Agent } from "@/agent/agent"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
+import { Flag } from "@/flag/flag"
+import { Global } from "@/global"
 import { Identifier } from "@/id/id"
 import { Provider } from "@/provider/provider"
 import { Question } from "@/question"
@@ -10,6 +12,8 @@ import { LLM } from "@/session/llm"
 import { MessageV2 } from "@/session/message-v2"
 import { Todo } from "@/session/todo"
 import { Log } from "@/util/log"
+import fs from "fs/promises"
+import path from "path"
 
 function toText(item: MessageV2.WithParts): string {
   return item.parts
@@ -111,6 +115,41 @@ export namespace PlanFollowup {
   export const ANSWER_NEW_SESSION = "Start new session"
   export const ANSWER_CONTINUE = "Continue here"
 
+  async function resolveCodeModel(model: MessageV2.User["model"]) {
+    const saved =
+      Flag.KILO_CLIENT === "cli"
+        ? await fs
+            .readFile(path.join(Global.Path.state, "model.json"), "utf-8")
+            .then(
+              (item) =>
+                JSON.parse(item) as {
+                  model?: Record<
+                    string,
+                    {
+                      providerID: string
+                      modelID: string
+                    }
+                  >
+                },
+            )
+            .then((item) => item.model?.code)
+            .catch(() => undefined)
+        : undefined
+    if (saved) {
+      const match = await Provider.getModel(saved.providerID, saved.modelID).catch(() => undefined)
+      if (match) {
+        return {
+          providerID: saved.providerID,
+          modelID: saved.modelID,
+        }
+      }
+    }
+
+    const agent = await Agent.get("code")
+    if (agent?.model) return agent.model
+    return model
+  }
+
   async function resolvePlan(input: {
     assistant?: MessageV2.WithParts
     messages: MessageV2.WithParts[]
@@ -211,6 +250,7 @@ export namespace PlanFollowup {
     model: MessageV2.User["model"]
     abort?: AbortSignal
   }) {
+    const model = await resolveCodeModel(input.model)
     const [handover, todos] = await Promise.all([
       generateHandover({ messages: input.messages, model: input.model, abort: input.abort }),
       Todo.get(input.sessionID),
@@ -231,7 +271,7 @@ export namespace PlanFollowup {
     await inject({
       sessionID: next.id,
       agent: "code",
-      model: input.model,
+      model,
       text: sections.join("\n\n"),
       synthetic: false,
     })
@@ -289,10 +329,11 @@ export namespace PlanFollowup {
 
     if (answer === ANSWER_CONTINUE) {
       Telemetry.trackPlanFollowup(input.sessionID, "continue")
+      const model = await resolveCodeModel(user.model)
       await inject({
         sessionID: input.sessionID,
         agent: "code",
-        model: user.model,
+        model,
         text: "Implement the plan above.",
       })
       return "continue"

--- a/packages/opencode/test/kilocode/plan-followup.test.ts
+++ b/packages/opencode/test/kilocode/plan-followup.test.ts
@@ -31,12 +31,18 @@ const saved = {
   modelID: "gpt-5",
 }
 
+const savedVar = "high"
+
 const config = {
   providerID: "openai",
   modelID: "gpt-4.1",
 }
 
+const configVar = "max"
+const planVar = "medium"
+
 const statePath = path.join(Global.Path.state, "model.json")
+const savedKey = `${saved.providerID}/${saved.modelID}`
 
 async function withInstance(fn: () => Promise<void>) {
   await using tmp = await tmpdir({ git: true })
@@ -52,6 +58,7 @@ async function withInstance(fn: () => Promise<void>) {
 
 async function seed(input: {
   text: string
+  variant?: string
   tools?: Array<{ tool: string; input: Record<string, unknown>; output: string }>
 }) {
   const session = await Session.create({})
@@ -64,6 +71,7 @@ async function seed(input: {
     },
     agent: "plan",
     model,
+    variant: input.variant,
   })
   await Session.updatePart({
     id: Identifier.ascending("part"),
@@ -158,7 +166,10 @@ async function waitQuestion(sessionID: string) {
   }
 }
 
-async function writeState(input: { model?: Record<string, { providerID: string; modelID: string }> }) {
+async function writeState(input: {
+  model?: Record<string, { providerID: string; modelID: string }>
+  variant?: Record<string, string | undefined>
+}) {
   await fs.mkdir(Global.Path.state, { recursive: true })
   await fs.writeFile(statePath, JSON.stringify(input))
 }
@@ -177,6 +188,19 @@ const fakeModel = {
   api: { id: "openai", npm: "@ai-sdk/openai" },
   capabilities: {},
 } as Provider.Model
+
+function full(input: { providerID: string; modelID: string }, vars: string[]) {
+  return {
+    ...fakeModel,
+    id: input.modelID,
+    providerID: input.providerID,
+    variants: Object.fromEntries(vars.map((item) => [item, {}])),
+  } as Provider.Model
+}
+
+const savedFull = full(saved, [savedVar, "low"])
+const savedConfigFull = full(saved, [configVar, "low"])
+const configFull = full(config, [configVar, "low"])
 
 function mockHandoverDeps(text: string, opts?: { agent?: Agent.Info | null }) {
   const agentSpy = spyOn(Agent, "get").mockResolvedValue(
@@ -226,13 +250,16 @@ describe("plan follow-up", () => {
             permission: [],
             options: {},
             model: saved,
+            variant: configVar,
           } as any
         }
         return undefined as any
       })
+      const modelSpy = spyOn(Provider, "getModel").mockResolvedValue(savedConfigFull)
       using _ = {
         [Symbol.dispose]() {
           get.mockRestore()
+          modelSpy.mockRestore()
         },
       }
       const seeded = await seed({ text: "1. Build\n2. Test" })
@@ -257,6 +284,7 @@ describe("plan follow-up", () => {
       if (!user || user.info.role !== "user") return
       expect(user.info.agent).toBe("code")
       expect(user.info.model).toEqual(saved)
+      expect(user.info.variant).toBe(configVar)
 
       const part = user.parts.find((item) => item.type === "text")
       expect(part?.type).toBe("text")
@@ -306,6 +334,7 @@ describe("plan follow-up", () => {
             permission: [],
             options: {},
             model: saved,
+            variant: configVar,
           } as any
         }
         if (name === "compaction") return fakeAgent as any
@@ -347,7 +376,10 @@ describe("plan follow-up", () => {
         },
         parts: [],
       })
-      const modelSpy = spyOn(Provider, "getModel").mockResolvedValue(fakeModel)
+      const modelSpy = spyOn(Provider, "getModel").mockImplementation(async (providerID: string, modelID: string) => {
+        if (providerID === saved.providerID && modelID === saved.modelID) return savedConfigFull
+        return fakeModel
+      })
       const llmSpy = spyOn(LLM, "stream").mockResolvedValue({
         text: Promise.resolve(
           "## Discoveries\n\nFound REST endpoints in src/api.ts\n\n## Relevant Files\n\n- src/api.ts: REST endpoints\n- src/db.ts: Database layer",
@@ -416,6 +448,7 @@ describe("plan follow-up", () => {
       if (!user || user.info.role !== "user") throw new Error("expected seeded user message")
       expect(user.info.agent).toBe("code")
       expect(user.info.model).toEqual(saved)
+      expect(user.info.variant).toBe(configVar)
 
       const part = user.parts.find((item) => item.type === "text")
       expect(part?.type).toBe("text")
@@ -437,6 +470,61 @@ describe("plan follow-up", () => {
       SessionPrompt.cancel(newSessionID)
     }))
 
+  test("ask - prefers saved code variant over configured code variant", () =>
+    withInstance(async () => {
+      await writeState({
+        model: { code: saved },
+        variant: { [savedKey]: savedVar },
+      })
+      const get = spyOn(Agent, "get").mockImplementation(async (name: string) => {
+        if (name === "code") {
+          return {
+            name: "code",
+            mode: "primary",
+            permission: [],
+            options: {},
+            model: config,
+            variant: configVar,
+          } as any
+        }
+        return undefined as any
+      })
+      const modelSpy = spyOn(Provider, "getModel").mockImplementation(async (providerID: string, modelID: string) => {
+        if (providerID === saved.providerID && modelID === saved.modelID) return savedFull
+        if (providerID === config.providerID && modelID === config.modelID) return configFull
+        throw new Error(`unexpected model lookup ${providerID}/${modelID}`)
+      })
+      using _ = {
+        [Symbol.dispose]() {
+          get.mockRestore()
+          modelSpy.mockRestore()
+        },
+      }
+      const seeded = await seed({ text: "1. Build\n2. Test" })
+      const pending = PlanFollowup.ask({
+        sessionID: seeded.sessionID,
+        messages: seeded.messages,
+        abort: AbortSignal.any([]),
+      })
+
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
+      await Question.reply({
+        requestID: item.id,
+        answers: [[PlanFollowup.ANSWER_CONTINUE]],
+      })
+
+      await expect(pending).resolves.toBe("continue")
+
+      const user = await latestUser(seeded.sessionID)
+      expect(user?.info.role).toBe("user")
+      if (!user || user.info.role !== "user") return
+      expect(user.info.agent).toBe("code")
+      expect(user.info.model).toEqual(saved)
+      expect(user.info.variant).toBe(savedVar)
+    }))
+
   test("ask - falls back to configured code model when saved CLI code model is unavailable", () =>
     withInstance(async () => {
       await writeState({ model: { code: { providerID: "missing", modelID: "ghost" } } })
@@ -448,13 +536,19 @@ describe("plan follow-up", () => {
             permission: [],
             options: {},
             model: config,
+            variant: configVar,
           } as any
         }
         return undefined as any
       })
+      const modelSpy = spyOn(Provider, "getModel").mockImplementation(async (providerID: string, modelID: string) => {
+        if (providerID === "missing" && modelID === "ghost") throw new Error("missing model")
+        return configFull
+      })
       using _ = {
         [Symbol.dispose]() {
           get.mockRestore()
+          modelSpy.mockRestore()
         },
       }
       const seeded = await seed({ text: "1. Build\n2. Test" })
@@ -479,6 +573,7 @@ describe("plan follow-up", () => {
       if (!user || user.info.role !== "user") return
       expect(user.info.agent).toBe("code")
       expect(user.info.model).toEqual(config)
+      expect(user.info.variant).toBe(configVar)
     }))
 
   test("ask - falls back to planning model when no saved or configured code model exists", () =>
@@ -492,7 +587,7 @@ describe("plan follow-up", () => {
           get.mockRestore()
         },
       }
-      const seeded = await seed({ text: "1. Build\n2. Test" })
+      const seeded = await seed({ text: "1. Build\n2. Test", variant: planVar })
       const pending = PlanFollowup.ask({
         sessionID: seeded.sessionID,
         messages: seeded.messages,
@@ -514,6 +609,7 @@ describe("plan follow-up", () => {
       if (!user || user.info.role !== "user") return
       expect(user.info.agent).toBe("code")
       expect(user.info.model).toEqual(model)
+      expect(user.info.variant).toBe(planVar)
     }))
 
   test("ask - new session omits handover section when LLM returns empty", () =>

--- a/packages/opencode/test/kilocode/plan-followup.test.ts
+++ b/packages/opencode/test/kilocode/plan-followup.test.ts
@@ -12,19 +12,42 @@ import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
 import { Todo } from "../../src/session/todo"
+import { Global } from "../../src/global"
 import { Log } from "../../src/util/log"
+import path from "path"
+import fs from "fs/promises"
 import { tmpdir } from "../fixture/fixture"
 
 Log.init({ print: false })
+process.env.KILO_CLIENT = "cli"
 
 const model = {
   providerID: "openai",
   modelID: "gpt-4",
 }
 
+const saved = {
+  providerID: "openai",
+  modelID: "gpt-5",
+}
+
+const config = {
+  providerID: "openai",
+  modelID: "gpt-4.1",
+}
+
+const statePath = path.join(Global.Path.state, "model.json")
+
 async function withInstance(fn: () => Promise<void>) {
   await using tmp = await tmpdir({ git: true })
-  await Instance.provide({ directory: tmp.path, fn })
+  await fs.rm(statePath, { force: true }).catch(() => {})
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      await fs.rm(statePath, { force: true }).catch(() => {})
+      await fn()
+    },
+  })
 }
 
 async function seed(input: {
@@ -126,6 +149,20 @@ async function sessions() {
   return Array.fromAsync(Session.list())
 }
 
+async function waitQuestion(sessionID: string) {
+  for (let i = 0; i < 50; i++) {
+    const list = await Question.list()
+    const item = list.find((q) => q.sessionID === sessionID)
+    if (item) return item
+    await Bun.sleep(10)
+  }
+}
+
+async function writeState(input: { model?: Record<string, { providerID: string; modelID: string }> }) {
+  await fs.mkdir(Global.Path.state, { recursive: true })
+  await fs.writeFile(statePath, JSON.stringify(input))
+}
+
 const fakeAgent: Agent.Info = {
   name: "compaction",
   mode: "subagent",
@@ -171,15 +208,33 @@ describe("plan follow-up", () => {
         abort: AbortSignal.any([]),
       })
 
-      const list = await Question.list()
-      expect(list).toHaveLength(1)
-      await Question.reject(list[0].id)
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
+      await Question.reject(item.id)
 
       await expect(pending).resolves.toBe("break")
     }))
 
   test("ask - returns continue and creates code message on Continue here", () =>
     withInstance(async () => {
+      const get = spyOn(Agent, "get").mockImplementation(async (name: string) => {
+        if (name === "code") {
+          return {
+            name: "code",
+            mode: "primary",
+            permission: [],
+            options: {},
+            model: saved,
+          } as any
+        }
+        return undefined as any
+      })
+      using _ = {
+        [Symbol.dispose]() {
+          get.mockRestore()
+        },
+      }
       const seeded = await seed({ text: "1. Build\n2. Test" })
       const pending = PlanFollowup.ask({
         sessionID: seeded.sessionID,
@@ -187,9 +242,11 @@ describe("plan follow-up", () => {
         abort: AbortSignal.any([]),
       })
 
-      const list = await Question.list()
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
       await Question.reply({
-        requestID: list[0].id,
+        requestID: item.id,
         answers: [[PlanFollowup.ANSWER_CONTINUE]],
       })
 
@@ -199,6 +256,7 @@ describe("plan follow-up", () => {
       expect(user?.info.role).toBe("user")
       if (!user || user.info.role !== "user") return
       expect(user.info.agent).toBe("code")
+      expect(user.info.model).toEqual(saved)
 
       const part = user.parts.find((item) => item.type === "text")
       expect(part?.type).toBe("text")
@@ -216,8 +274,11 @@ describe("plan follow-up", () => {
         abort: AbortSignal.any([]),
       })
 
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
       await Question.reply({
-        requestID: (await Question.list())[0].id,
+        requestID: item.id,
         answers: [["Add rollback support too"]],
       })
 
@@ -237,6 +298,24 @@ describe("plan follow-up", () => {
 
   test("ask - creates a new session on Start new session with handover and todos", () =>
     withInstance(async () => {
+      const get = spyOn(Agent, "get").mockImplementation(async (name: string) => {
+        if (name === "code") {
+          return {
+            name: "code",
+            mode: "primary",
+            permission: [],
+            options: {},
+            model: saved,
+          } as any
+        }
+        if (name === "compaction") return fakeAgent as any
+        return undefined as any
+      })
+      using _file = {
+        [Symbol.dispose]() {
+          get.mockRestore()
+        },
+      }
       const loop = spyOn(SessionPrompt, "loop").mockResolvedValue({
         info: {
           id: "msg_test",
@@ -268,9 +347,19 @@ describe("plan follow-up", () => {
         },
         parts: [],
       })
-      using _mocks = mockHandoverDeps(
-        "## Discoveries\n\nFound REST endpoints in src/api.ts\n\n## Relevant Files\n\n- src/api.ts: REST endpoints\n- src/db.ts: Database layer",
-      )
+      const modelSpy = spyOn(Provider, "getModel").mockResolvedValue(fakeModel)
+      const llmSpy = spyOn(LLM, "stream").mockResolvedValue({
+        text: Promise.resolve(
+          "## Discoveries\n\nFound REST endpoints in src/api.ts\n\n## Relevant Files\n\n- src/api.ts: REST endpoints\n- src/db.ts: Database layer",
+        ),
+      } as any)
+      using _mocks = {
+        llmSpy,
+        [Symbol.dispose]() {
+          modelSpy.mockRestore()
+          llmSpy.mockRestore()
+        },
+      }
       using _loop = {
         [Symbol.dispose]() {
           loop.mockRestore()
@@ -300,8 +389,11 @@ describe("plan follow-up", () => {
         abort: AbortSignal.any([]),
       })
 
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
       await Question.reply({
-        requestID: (await Question.list())[0].id,
+        requestID: item.id,
         answers: [[PlanFollowup.ANSWER_NEW_SESSION]],
       })
 
@@ -323,6 +415,7 @@ describe("plan follow-up", () => {
       expect(user?.info.role).toBe("user")
       if (!user || user.info.role !== "user") throw new Error("expected seeded user message")
       expect(user.info.agent).toBe("code")
+      expect(user.info.model).toEqual(saved)
 
       const part = user.parts.find((item) => item.type === "text")
       expect(part?.type).toBe("text")
@@ -342,6 +435,85 @@ describe("plan follow-up", () => {
       expect(newTodos).toContainEqual({ content: "Write tests", status: "pending", priority: "medium" })
 
       SessionPrompt.cancel(newSessionID)
+    }))
+
+  test("ask - falls back to configured code model when saved CLI code model is unavailable", () =>
+    withInstance(async () => {
+      await writeState({ model: { code: { providerID: "missing", modelID: "ghost" } } })
+      const get = spyOn(Agent, "get").mockImplementation(async (name: string) => {
+        if (name === "code") {
+          return {
+            name: "code",
+            mode: "primary",
+            permission: [],
+            options: {},
+            model: config,
+          } as any
+        }
+        return undefined as any
+      })
+      using _ = {
+        [Symbol.dispose]() {
+          get.mockRestore()
+        },
+      }
+      const seeded = await seed({ text: "1. Build\n2. Test" })
+      const pending = PlanFollowup.ask({
+        sessionID: seeded.sessionID,
+        messages: seeded.messages,
+        abort: AbortSignal.any([]),
+      })
+
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
+      await Question.reply({
+        requestID: item.id,
+        answers: [[PlanFollowup.ANSWER_CONTINUE]],
+      })
+
+      await expect(pending).resolves.toBe("continue")
+
+      const user = await latestUser(seeded.sessionID)
+      expect(user?.info.role).toBe("user")
+      if (!user || user.info.role !== "user") return
+      expect(user.info.agent).toBe("code")
+      expect(user.info.model).toEqual(config)
+    }))
+
+  test("ask - falls back to planning model when no saved or configured code model exists", () =>
+    withInstance(async () => {
+      const get = spyOn(Agent, "get").mockImplementation(async (name: string) => {
+        if (name === "code") return undefined as any
+        return undefined as any
+      })
+      using _ = {
+        [Symbol.dispose]() {
+          get.mockRestore()
+        },
+      }
+      const seeded = await seed({ text: "1. Build\n2. Test" })
+      const pending = PlanFollowup.ask({
+        sessionID: seeded.sessionID,
+        messages: seeded.messages,
+        abort: AbortSignal.any([]),
+      })
+
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
+      await Question.reply({
+        requestID: item.id,
+        answers: [[PlanFollowup.ANSWER_CONTINUE]],
+      })
+
+      await expect(pending).resolves.toBe("continue")
+
+      const user = await latestUser(seeded.sessionID)
+      expect(user?.info.role).toBe("user")
+      if (!user || user.info.role !== "user") return
+      expect(user.info.agent).toBe("code")
+      expect(user.info.model).toEqual(model)
     }))
 
   test("ask - new session omits handover section when LLM returns empty", () =>
@@ -387,8 +559,11 @@ describe("plan follow-up", () => {
         abort: AbortSignal.any([]),
       })
 
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
       await Question.reply({
-        requestID: (await Question.list())[0].id,
+        requestID: item.id,
         answers: [[PlanFollowup.ANSWER_NEW_SESSION]],
       })
 
@@ -444,8 +619,9 @@ describe("plan follow-up", () => {
         abort: abort.signal,
       })
 
-      const list = await Question.list()
-      expect(list).toHaveLength(1)
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
 
       abort.abort()
 
@@ -462,8 +638,11 @@ describe("plan follow-up", () => {
         abort: AbortSignal.any([]),
       })
 
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
       await Question.reply({
-        requestID: (await Question.list())[0].id,
+        requestID: item.id,
         answers: [["   "]],
       })
 

--- a/packages/opencode/test/kilocode/plan-followup.test.ts
+++ b/packages/opencode/test/kilocode/plan-followup.test.ts
@@ -51,7 +51,11 @@ async function withInstance(fn: () => Promise<void>) {
     directory: tmp.path,
     fn: async () => {
       await fs.rm(statePath, { force: true }).catch(() => {})
-      await fn()
+      try {
+        await fn()
+      } finally {
+        await fs.rm(statePath, { force: true }).catch(() => {})
+      }
     },
   })
 }


### PR DESCRIPTION
## Context

Closes #6906 

## Implementation

When the user accepts a plan for implementation from Plan mode, load the saved model config, and use the configured Code mode model when switching to Code mode. The current behavior is that the Plan mode model is reused for Code mode, which is unexpected when the user has configured different models for each mode.

This is currently implemented by loading the model config from the `config.json` file. The only state that currently keeps the model config in memory is in `packages/opencode/src/cli/cmd/tui/context/local.*`, which is not accessible to the code that switches to implement a plan. Reusing this would require refactoring that state out into a separate model.

## How to Test

- Have different models configured for Plan and Code agents
- Create a plan in Plan mode
- Accept the plan
- Code mode should use the configured Code agent mode, not the Plan agent model

## Get in Touch

ExpedientFalcon on Discord