### PR TITLE
feat(vscode): add delete session button to task header

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/history-sessionlist/with-items-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/history-sessionlist/with-items-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:79c47f310dacd31434abff158e167a7b837ac4497d1c38f31582b61f854d08fa
-size 17996
+oid sha256:65686e2d0978adcf09ae504d9414e2d81f304eb18ff2275be7a33a9c3579a5e5
+size 18209

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -10,9 +10,6 @@ import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Checkbox } from "@kilocode/kilo-ui/checkbox"
-import { Dialog } from "@kilocode/kilo-ui/dialog"
-import { Button } from "@kilocode/kilo-ui/button"
-import { useDialog } from "@kilocode/kilo-ui/context/dialog"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import type { TodoItem } from "../../types/messages"
@@ -24,13 +21,11 @@ interface TaskHeaderProps {
 export const TaskHeader: Component<TaskHeaderProps> = (props) => {
   const session = useSession()
   const language = useLanguage()
-  const dialog = useDialog()
 
   const title = createMemo(() => session.currentSession()?.title ?? language.t("command.session.new"))
   const hasMessages = createMemo(() => session.messages().length > 0)
   const busy = createMemo(() => session.status() === "busy")
   const canCompact = createMemo(() => !busy() && hasMessages() && !!session.selected())
-  const canDelete = createMemo(() => !busy() && !!session.currentSessionID())
 
   const cost = createMemo(() => {
     const total = session.totalCost()
@@ -65,33 +60,6 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
 
   const [todosOpen, setTodosOpen] = createSignal(false)
 
-  function confirmDelete() {
-    const name = session.currentSession()?.title || language.t("session.untitled")
-    dialog.show(() => (
-      <Dialog title={language.t("session.delete.title")} fit>
-        <div class="dialog-confirm-body">
-          <span>{language.t("session.delete.confirm", { name })}</span>
-          <div class="dialog-confirm-actions">
-            <Button variant="ghost" size="large" onClick={() => dialog.close()}>
-              {language.t("common.cancel")}
-            </Button>
-            <Button
-              variant="primary"
-              size="large"
-              onClick={() => {
-                const id = session.currentSessionID()
-                if (id) session.deleteSession(id)
-                dialog.close()
-              }}
-            >
-              {language.t("session.delete.button")}
-            </Button>
-          </div>
-        </div>
-      </Dialog>
-    ))
-  }
-
   return (
     <Show when={hasMessages()}>
       <div data-component="task-header">
@@ -125,16 +93,6 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
                 disabled={!canCompact()}
                 onClick={() => session.compact()}
                 aria-label={language.t("command.session.compact")}
-              />
-            </Tooltip>
-            <Tooltip value={language.t("session.delete.title")} placement="bottom">
-              <IconButton
-                icon="trash"
-                size="small"
-                variant="ghost"
-                disabled={!canDelete()}
-                onClick={() => confirmDelete()}
-                aria-label={language.t("session.delete.title")}
               />
             </Tooltip>
           </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -10,6 +10,9 @@ import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Checkbox } from "@kilocode/kilo-ui/checkbox"
+import { Dialog } from "@kilocode/kilo-ui/dialog"
+import { Button } from "@kilocode/kilo-ui/button"
+import { useDialog } from "@kilocode/kilo-ui/context/dialog"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import type { TodoItem } from "../../types/messages"
@@ -21,11 +24,13 @@ interface TaskHeaderProps {
 export const TaskHeader: Component<TaskHeaderProps> = (props) => {
   const session = useSession()
   const language = useLanguage()
+  const dialog = useDialog()
 
   const title = createMemo(() => session.currentSession()?.title ?? language.t("command.session.new"))
   const hasMessages = createMemo(() => session.messages().length > 0)
   const busy = createMemo(() => session.status() === "busy")
   const canCompact = createMemo(() => !busy() && hasMessages() && !!session.selected())
+  const canDelete = createMemo(() => !busy() && !!session.currentSessionID())
 
   const cost = createMemo(() => {
     const total = session.totalCost()
@@ -60,6 +65,33 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
 
   const [todosOpen, setTodosOpen] = createSignal(false)
 
+  function confirmDelete() {
+    const name = session.currentSession()?.title || language.t("session.untitled")
+    dialog.show(() => (
+      <Dialog title={language.t("session.delete.title")} fit>
+        <div class="dialog-confirm-body">
+          <span>{language.t("session.delete.confirm", { name })}</span>
+          <div class="dialog-confirm-actions">
+            <Button variant="ghost" size="large" onClick={() => dialog.close()}>
+              {language.t("common.cancel")}
+            </Button>
+            <Button
+              variant="primary"
+              size="large"
+              onClick={() => {
+                const id = session.currentSessionID()
+                if (id) session.deleteSession(id)
+                dialog.close()
+              }}
+            >
+              {language.t("session.delete.button")}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    ))
+  }
+
   return (
     <Show when={hasMessages()}>
       <div data-component="task-header">
@@ -93,6 +125,16 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
                 disabled={!canCompact()}
                 onClick={() => session.compact()}
                 aria-label={language.t("command.session.compact")}
+              />
+            </Tooltip>
+            <Tooltip value={language.t("session.delete.title")} placement="bottom">
+              <IconButton
+                icon="trash"
+                size="small"
+                variant="ghost"
+                disabled={!canDelete()}
+                onClick={() => confirmDelete()}
+                aria-label={language.t("session.delete.title")}
               />
             </Tooltip>
           </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/history/SessionList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/history/SessionList.tsx
@@ -9,6 +9,7 @@ import { List } from "@kilocode/kilo-ui/list"
 import { ContextMenu } from "@kilocode/kilo-ui/context-menu"
 import { Dialog } from "@kilocode/kilo-ui/dialog"
 import { Button } from "@kilocode/kilo-ui/button"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { InlineInput } from "@kilocode/kilo-ui/inline-input"
 import { useDialog } from "@kilocode/kilo-ui/context/dialog"
 import { useSession } from "../../context/session"
@@ -155,6 +156,20 @@ const SessionList: Component<SessionListProps> = (props) => {
               <>
                 <span data-slot="list-item-title">{s.title || language.t("session.untitled")}</span>
                 <span data-slot="list-item-description">{formatRelativeDate(s.updatedAt)}</span>
+                <span
+                  data-slot="session-delete-button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    confirmDelete(s)
+                  }}
+                >
+                  <IconButton
+                    icon="trash"
+                    size="small"
+                    variant="ghost"
+                    aria-label={language.t("session.delete.title")}
+                  />
+                </span>
               </>
             }
           >

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1221,6 +1221,13 @@ export const SessionProvider: ParentComponent = (props) => {
       console.warn("[Kilo New] Cannot delete session: not connected")
       return
     }
+    // Optimistically remove from the list so the UI updates immediately
+    setStore(
+      "sessions",
+      produce((sessions) => {
+        delete sessions[id]
+      }),
+    )
     vscode.postMessage({ type: "deleteSession", sessionID: id })
   }
 

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1480,6 +1480,18 @@
   white-space: nowrap;
 }
 
+.session-list [data-slot="session-delete-button"] {
+  flex-shrink: 0;
+  margin-left: 4px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.session-list [data-slot="list-item"]:hover [data-slot="session-delete-button"],
+.session-list [data-slot="list-item"][data-active="true"] [data-slot="session-delete-button"] {
+  opacity: 1;
+}
+
 /* Cloud Session List */
 .cloud-session-list {
   display: flex;


### PR DESCRIPTION
## Summary

Session deletion was already fully wired up but only accessible via right-click context menu on session list items — easy to miss if you don't know it's there.

This PR makes it more discoverable and responsive:

- **Visible delete button**: adds an inline trash icon to each session item in the history list, shown on hover. Clicking it opens the same confirmation dialog that the context menu uses.
- **Instant visual feedback**: optimistically removes the session from the list when the user confirms deletion, instead of waiting for the server round-trip. The full cleanup (messages, parts, todos) still runs when the server confirms.

fixes https://github.com/Kilo-Org/kilocode/issues/7113
