### PR TITLE
fix(cli): disable external proxy to app.opencode.ai

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -5,7 +5,7 @@ import { describeRoute, generateSpecs, validator, resolver, openAPIRouteHandler 
 import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { streamSSE } from "hono/streaming"
-import { proxy } from "hono/proxy"
+// import { proxy } from "hono/proxy" // kilocode_change - disabled external proxy
 import { basicAuth } from "hono/basic-auth"
 import z from "zod"
 import { Provider } from "../provider/provider"
@@ -602,22 +602,11 @@ export namespace Server {
             })
           },
         )
+        // kilocode_change start - disable external proxy to app.opencode.ai for privacy/security
         .all("/*", async (c) => {
-          const path = c.req.path
-
-          const response = await proxy(`https://app.opencode.ai${path}`, {
-            ...c.req,
-            headers: {
-              ...c.req.raw.headers,
-              host: "app.opencode.ai",
-            },
-          })
-          response.headers.set(
-            "Content-Security-Policy",
-            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:",
-          )
-          return response
+          return c.notFound()
         }) as unknown as Hono,
+    // kilocode_change end
   )
 
   export async function openapi() {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -604,6 +604,20 @@ export namespace Server {
         )
         // kilocode_change start - disable external proxy to app.opencode.ai for privacy/security
         .all("/*", async (c) => {
+          // const path = c.req.path
+          //
+          // const response = await proxy(`https://app.opencode.ai${path}`, {
+          //   ...c.req,
+          //   headers: {
+          //     ...c.req.raw.headers,
+          //     host: "app.opencode.ai",
+          //   },
+          // })
+          // response.headers.set(
+          //   "Content-Security-Policy",
+          //   "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:",
+          // )
+          // return response
           return c.notFound()
         }) as unknown as Hono,
     // kilocode_change end


### PR DESCRIPTION
## Summary

- Disables the catch-all proxy route in the CLI server that forwarded unmatched HTTP requests to `app.opencode.ai`
- The proxy previously served static web UI assets from an external domain, raising privacy/security concerns — users' requests were being shipped to a third-party host
- The original proxy code is **commented out** (not deleted) to make upstream merges easier and produce clearer merge conflicts

## Changes

**`packages/opencode/src/server/server.ts`**
- Commented out the `import { proxy } from "hono/proxy"` import (line 8)
- Commented out the proxy handler body inside `.all("/*", ...)` — all original lines are preserved as `//` line comments
- Added `return c.notFound()` as the replacement handler
- Added `kilocode_change` markers to keep upstream merge diffs minimal

## Why

Users have expressed concerns about their requests being proxied to an external domain (`app.opencode.ai`). This change eliminates that external communication for privacy and security.

## Notes

- The diff is intentionally minimal — no lines are deleted, only commented out, so future upstream OpenCode merges will produce clear conflicts if the upstream proxy code changes
- The route structure (`.all("/*")`) is preserved, keeping the chain valid
- `kilocode_change` markers are used per repo convention for tracking Kilo-specific changes in shared code
