### PR TITLE
fix(vscode): replace context compaction icon to avoid close-button confusion

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -87,7 +87,7 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
           <Show when={!props.readonly}>
             <Tooltip value={language.t("command.session.compact")} placement="bottom">
               <IconButton
-                icon="collapse"
+                icon="compress"
                 size="small"
                 variant="ghost"
                 disabled={!canCompact()}

--- a/packages/ui/src/components/icon.tsx
+++ b/packages/ui/src/components/icon.tsx
@@ -23,6 +23,7 @@ const icons = {
   console: `<path d="M3.75 5.4165L8.33333 9.99984L3.75 14.5832M10.4167 14.5832H16.25" stroke="currentColor" stroke-linecap="square"/>`,
   expand: `<path d="M4.58301 10.4163V15.4163H9.58301M10.4163 4.58301H15.4163V9.58301" stroke="currentColor" stroke-linecap="square"/>`,
   collapse: `<path d="M16.666 8.33398H11.666V3.33398" stroke="currentColor" stroke-linecap="square"/><path d="M8.33398 16.666V11.666H3.33398" stroke="currentColor" stroke-linecap="square"/>`,
+  compress: `<path d="M5 10H15M6.667 4.167L10 7.5L13.333 4.167M6.667 15.833L10 12.5L13.333 15.833" stroke="currentColor" stroke-linecap="square"/>`,
   code: `<path d="M8.7513 7.5013L6.2513 10.0013L8.7513 12.5013M11.2513 7.5013L13.7513 10.0013L11.2513 12.5013M2.91797 2.91797H17.0846V17.0846H2.91797V2.91797Z" stroke="currentColor"/>`,
   "code-lines": `<path d="M2.08325 3.75H11.2499M14.5833 3.75H17.9166M2.08325 10L7.08325 10M10.4166 10L17.9166 10M2.08325 16.25L8.74992 16.25M12.0833 16.25L17.9166 16.25" stroke="currentColor" stroke-linecap="square" stroke-linejoin="round"/>`,
   "circle-ban-sign": `<path d="M15.3675 4.63087L4.55742 15.441M17.9163 9.9987C17.9163 14.371 14.3719 17.9154 9.99967 17.9154C7.81355 17.9154 5.83438 17.0293 4.40175 15.5966C2.96911 14.164 2.08301 12.1848 2.08301 9.9987C2.08301 5.62644 5.62742 2.08203 9.99967 2.08203C12.1858 2.08203 14.165 2.96813 15.5976 4.40077C17.0302 5.8334 17.9163 7.81257 17.9163 9.9987Z" stroke="currentColor" stroke-linecap="round"/>`,


### PR DESCRIPTION
## Summary

- Adds a new `compress` icon (center line with inward-pointing chevrons) to the shared icon set
- Replaces the `collapse` icon on the context compaction button in the VS Code extension's `TaskHeader`
- The old `collapse` icon (two L-shaped inward arrows) was reported as looking like a close button at small sizes

Before:

<img width="63" height="39" alt="image" src="https://github.com/user-attachments/assets/72bd7269-8804-4adc-8c78-64f2171c6475" />

After:

<img width="534" height="356" alt="image" src="https://github.com/user-attachments/assets/dac8586f-0ce1-45eb-9472-77cbd50f1211" />


Closes #6081