### PR TITLE
fix(vscode): increase chat input field size to match legacy extension

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/chat-view-idle-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/chat-view-idle-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d23a2e49a796acc94f387f7d4cddf783de1c630a3cd3902f3cf558083839b043
-size 17817
+oid sha256:911a22fc391f3c138990bcd92c1d50f9264747a10e0c973dd1124c1f4962beb4
+size 17824

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/permission-dock-bash-many-rules-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/permission-dock-bash-many-rules-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c43a0a2f6a351d53da542aba6b68113e8231c1ee9cf7276bf6a16263b65d811
-size 18775
+oid sha256:0d6fea46e595ddf14bdc848e95dd33c0114f65892da4566b0760c67d18437581
+size 18607

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/permission-dock-write-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/permission-dock-write-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38712f08584902b1ccb267fed0271c6c1a9b5f549b47bd743ca344604df2095a
-size 17433
+oid sha256:d42a2d19917e678e79a8fe35e86b98243bd8bc898abae2dbb5644cfecf4d9a8f
+size 17347

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/default-200-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/default-200-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2eb5ca750d8a590df5a4c7a1be493290aa90535a98c5dc0f6fadfc802872567
-size 3520
+oid sha256:abb239ba98940397b93ee8bddcdb52669883d73f44fe66f9a0ac9ff05f88e687
+size 3655

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/default-420-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/default-420-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e5fd252dcc1acaeefae5608621a1c32282f99c24f7ee464d375cd149722c4fc
-size 3915
+oid sha256:946a305e9af39cfabd2613a8959976bcf888400e14e3c8e2215373caab7fbcf0
+size 4086

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/with-model-override-200-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/with-model-override-200-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2da4bbf78414fd58ef84b03f421954741edae16df0a0fccc4ad4e99e752e70ff
-size 3882
+oid sha256:58224cf0f7d0bf3308434d20c31695f3ccda71b63cb167be20050a49d8563dc4
+size 4010

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/with-model-override-420-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/with-model-override-420-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca37ae191123410c4488e6c54a2f104c830c4adb98b2dc3f5a2ac344e4b64356
-size 4107
+oid sha256:9ed92016d8cae9c5b787204cb0aa9c8513c0846c727bda044a19b57ce0dcfe72
+size 4290

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/with-thinking-200-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/with-thinking-200-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a6043cb26f5fe15cf84106a8a63c0f04a96ca04b23b9e55c276cc5db8f8104a
-size 4159
+oid sha256:6de6bf95ca6bdbbae2e1d14ff1c939fe42db984139f2d3ec7b49c2bed1f429b9
+size 4308

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/with-thinking-420-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/prompt-input/with-thinking-420-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:22b2d117440cfcd773be53b8d20ac1ed5561f02c7b07f307efc54e722341e14b
-size 4606
+oid sha256:3d25c6895bbf2e7292355415a5cfd3938fa6432d2cc0175cd308a5b0f7d0bf16
+size 4777

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -148,7 +148,7 @@ export const PromptInput: Component = () => {
         textareaRef.value = draft
         // Reset height then adjust
         textareaRef.style.height = "auto"
-        textareaRef.style.height = `${Math.min(textareaRef.scrollHeight, 200)}px`
+        textareaRef.style.height = `${Math.min(textareaRef.scrollHeight, 300)}px`
       }
       window.dispatchEvent(new Event("focusPrompt"))
     }),
@@ -342,7 +342,7 @@ export const PromptInput: Component = () => {
   const adjustHeight = () => {
     if (!textareaRef) return
     textareaRef.style.height = "auto"
-    textareaRef.style.height = `${Math.min(textareaRef.scrollHeight, 200)}px`
+    textareaRef.style.height = `${Math.min(textareaRef.scrollHeight, 300)}px`
   }
 
   const handlePaste = (e: ClipboardEvent) => {
@@ -600,7 +600,7 @@ export const PromptInput: Component = () => {
             onPaste={handlePaste}
             onScroll={syncHighlightScroll}
             disabled={isDisabled()}
-            rows={1}
+            rows={3}
           />
         </div>
       </div>

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -752,8 +752,8 @@
 
 .prompt-input {
   flex: 1;
-  min-height: 54px;
-  max-height: 200px;
+  min-height: 90px;
+  max-height: 300px;
   padding: 8px 8px calc(8px + 1.4em);
   color: transparent;
   caret-color: var(--vscode-input-foreground);


### PR DESCRIPTION
## Summary

- Increases the sidebar chat textarea min-height from 54px to 90px and max-height from 200px to 300px to match the legacy Kilo Code extension (`kilocode-legacy`)
- Changes initial `rows` from 1 to 3, matching the legacy's `minRows={3}` / `min-h-[90px]` sizing
- Updates the JS auto-resize cap from 200px to 300px (closer to legacy's `maxRows={15}`)

Before:
<img width="420" height="251" alt="image" src="https://github.com/user-attachments/assets/2a4b1138-56ce-4c1f-ba59-23380492ec73" />

After:
<img width="417" height="257" alt="image" src="https://github.com/user-attachments/assets/a250a745-ce58-4953-960f-cd770588634e" />



## Legacy reference

The old extension used `react-textarea-autosize` with `minRows={3}`, `maxRows={15}`, and `min-h-[90px]`. The new extension's input was significantly smaller at `rows={1}` / `min-height: 54px` / `max-height: 200px`.