### PR TITLE
fix: use --no-verify on visual regression baseline push to skip husky hooks

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -183,7 +183,7 @@ jobs:
           else
             git commit -m "chore: update visual regression baselines"
             git lfs push --all origin
-            git push
+            git push --no-verify
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -381,7 +381,7 @@ jobs:
           else
             git commit -m "chore: update kilo-vscode visual regression baselines"
             git lfs push --all origin
-            git push
+            git push --no-verify
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary

- Adds `--no-verify` flag to `git push` commands in the visual regression workflow to skip husky hooks that can fail in CI
- Applies to both the main visual regression baselines push and the kilo-vscode visual regression baselines push

Cherry-picked from #7133 (commit 2dfd1f2).
