### PR TITLE
fix(vscode): stop config update loop from flooding SSE and killing server

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -239,7 +239,12 @@ const AgentBehaviourTab: Component = () => {
             current={defaultAgentOptions().find((o) => o.value === (config().default_agent ?? ""))}
             value={(o) => o.value}
             label={(o) => o.label}
-            onSelect={(o) => o && updateConfig({ default_agent: o.value || undefined })}
+            onSelect={(o) => {
+              if (!o) return
+              const next = o.value || undefined
+              if (next === (config().default_agent ?? undefined)) return
+              updateConfig({ default_agent: next })
+            }}
             variant="secondary"
             size="small"
             triggerVariant="settings"

--- a/packages/kilo-vscode/webview-ui/src/components/settings/DisplayTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/DisplayTab.tsx
@@ -46,7 +46,12 @@ const DisplayTab: Component = () => {
             current={LAYOUT_OPTIONS.find((o) => o.value === (config().layout ?? "auto"))}
             value={(o) => o.value}
             label={(o) => language.t(o.labelKey)}
-            onSelect={(o) => o && updateConfig({ layout: o.value as "auto" | "stretch" })}
+            onSelect={(o) => {
+              if (!o) return
+              const next = o.value as "auto" | "stretch"
+              if (next === (config().layout ?? "auto")) return
+              updateConfig({ layout: next })
+            }}
             variant="secondary"
             size="small"
             triggerVariant="settings"

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
@@ -43,7 +43,12 @@ const ExperimentalTab: Component = () => {
             current={SHARE_OPTIONS.find((o) => o.value === (config().share ?? "manual"))}
             value={(o) => o.value}
             label={(o) => language.t(o.labelKey)}
-            onSelect={(o) => o && updateConfig({ share: o.value as "manual" | "auto" | "disabled" })}
+            onSelect={(o) => {
+              if (!o) return
+              const next = o.value as "manual" | "auto" | "disabled"
+              if (next === (config().share ?? "manual")) return
+              updateConfig({ share: next })
+            }}
             variant="secondary"
             size="small"
             triggerVariant="settings"

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1553,17 +1553,19 @@ export namespace Config {
 
     global.reset()
 
-    void Instance.disposeAll()
-      .catch(() => undefined)
-      .finally(() => {
-        GlobalBus.emit("event", {
-          directory: "global",
-          payload: {
-            type: Event.Disposed.type,
-            properties: {},
-          },
-        })
-      })
+    // kilocode_change start - only reset config cache, don't dispose all instances.
+    // Instance.disposeAll() was destroying all session state, MCP connections, and
+    // in-flight operations across every project whenever any global config changed
+    // (e.g. removing a mode). The cache reset above is sufficient — consumers will
+    // pick up the new config on their next read.
+    GlobalBus.emit("event", {
+      directory: "global",
+      payload: {
+        type: Event.Disposed.type,
+        properties: {},
+      },
+    })
+    // kilocode_change end
 
     return next
   }


### PR DESCRIPTION
## Summary

Two fixes for the settings panel flooding the server with events and killing it:

1. **Stop `Instance.disposeAll()` from being called on every global config update.** Previously, `Config.updateGlobal()` would nuke all running CLI instances (destroying session state, MCP connections, and in-flight operations across every project) whenever *any* global config changed. The `global.reset()` call already clears the config cache so consumers pick up the new config on their next read. The `disposeAll()` was unnecessary overkill.

2. **Break infinite loop caused by Kobalte Select firing `onChange` on options list changes.** Kobalte's `Select` has an internal `createEffect` that re-filters selected keys whenever `flattenOptionKeys` changes. When a `global.disposed` or `server.instance.disposed` SSE event arrives, the extension re-fetches config and pushes `configLoaded` to the webview. Solid creates new array references for the options, Kobalte detects the change, fires `onChange` with the same value, which calls `updateConfig` → PATCH `/global/config` → emits `global.disposed` → loop. With `allowDuplicateSelectionEvents: true` (Kobalte's default), this fires even when the value hasn't changed.

## The loop

```
configLoaded → setConfig() → new options array ref
  → Kobalte Select internal effect fires onChange
  → onSelect → updateConfig({ default_agent: ... })
  → PATCH /global/config → Config.updateGlobal()
  → global.disposed event via SSE
  → reloadAfterAuthChange() → fetchAndSendConfig()
  → configLoaded → repeat ×N KiloProvider instances
```

## Fix

- Remove `Instance.disposeAll()` from `updateGlobal()` (separate correctness fix — this was collateral damage on each loop iteration, not the cause)
- Guard all three settings `Select` `onSelect` handlers to skip `updateConfig` when the new value equals the current config value, breaking the loop
