### PR TITLE
fix(cli): invalidate per-instance config caches on global config update

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -24,6 +24,7 @@ import {
 } from "jsonc-parser"
 // kilocode_change end
 import { Instance } from "../project/instance"
+import { State } from "../project/state" // kilocode_change
 import { LSPServer } from "../lsp/server"
 import { BunProc } from "@/bun"
 import { Installation } from "@/installation"
@@ -1553,11 +1554,12 @@ export namespace Config {
 
     global.reset()
 
-    // kilocode_change start - only reset config cache, don't dispose all instances.
-    // Instance.disposeAll() was destroying all session state, MCP connections, and
-    // in-flight operations across every project whenever any global config changed
-    // (e.g. removing a mode). The cache reset above is sufficient — consumers will
-    // pick up the new config on their next read.
+    // kilocode_change start - reset all derived caches (Config.state, Agent.state,
+    // Provider.state, etc.) so they re-read the updated global config on next access.
+    // Only cache entries without dispose callbacks are cleared — side-effectful state
+    // like sessions, MCP connections, and file watchers are preserved.
+    State.resetCaches()
+
     GlobalBus.emit("event", {
       directory: "global",
       payload: {

--- a/packages/opencode/src/project/state.ts
+++ b/packages/opencode/src/project/state.ts
@@ -28,6 +28,21 @@ export namespace State {
     }
   }
 
+  /**
+   * Reset all cache-only entries (those without dispose callbacks) across all
+   * instances. This invalidates derived state like Config, Agent, Provider,
+   * etc. without tearing down side-effectful resources (MCP connections,
+   * sessions, file watchers, etc.).
+   */
+  export function resetCaches() {
+    for (const entries of recordsByKey.values()) {
+      for (const [init, entry] of entries) {
+        if (entry.dispose) continue
+        entries.delete(init)
+      }
+    }
+  }
+
   export async function dispose(key: string) {
     const entries = recordsByKey.get(key)
     if (!entries) return


### PR DESCRIPTION
## Summary

- Fixes stale per-instance config after `Config.updateGlobal()` — active instances now pick up global config changes (modes, providers, models, etc.) without requiring a server restart
- Adds `State.resetCaches()` which clears all cache-only `Instance.state` entries across all instances without tearing down side-effectful resources

## Problem

PR #7172 correctly removed `Instance.disposeAll()` from `Config.updateGlobal()` to stop it from destroying sessions, MCP connections, and in-flight operations on every config change. However, this left a gap: `global.reset()` only invalidates the process-wide global config lazy cache, not the per-instance `Config.state` (or downstream caches like `Agent.state`, `Provider.state`, etc.) that merge global config at initialization time.

This meant that after a global config change via the VS Code settings panel (e.g. changing default agent, provider, or model), the server's HTTP endpoints (`/config`, `/app/agents`, `/app/providers`) would continue returning stale cached data. The extension would re-fetch after the `global.disposed` SSE event, but get back the old values.

As noted by the review bot on #7172: [comment](https://github.com/Kilo-Org/kilocode/pull/7172#discussion_r2946287612)

## Fix

`State.resetCaches()` iterates all instance state maps and deletes entries that have **no dispose callback**. These are the 18 "pure cache" entries (Config, Agent, Provider, Tool, Skill, Command, Format, Plugin, etc.) that are safe to drop and will be re-computed on next access. The 9 entries with dispose callbacks (Prompt sessions, MCP connections, LSP clients, PTY processes, file watchers, etc.) are preserved.

The flow after the fix:
```
updateGlobal() writes config to disk
  → global.reset()           // clear global config lazy cache
  → State.resetCaches()      // clear all per-instance derived caches
  → emit "global.disposed"   // SSE to extension
  → extension re-fetches     // HTTP requests hit server
  → Config.state() re-inits  // fresh merge with updated global config
  → Agent.state() re-inits   // fresh agent list
  → UI updates correctly
```
