### PR TITLE
fix(vscode): remove card border from dismissed question text

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/question-dismissed-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/question-dismissed-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e51b88fada85811d734dd451b7c3c22cb5b4f9eb92898b613e5c8e68afac4d42
-size 5053
+oid sha256:9cf21f9d28d5f30abc87e816a266d4f82acfe4cfef31440bf02b4451bb8a840b
+size 4896

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -82,9 +82,15 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
           // so we detect them here and render via ToolRegistry directly.
           const isUpstreamSuppressed =
             part.type === "tool" && UPSTREAM_SUPPRESSED_TOOLS.has((part as SDKPart & { tool: string }).tool)
+          // Dismissed questions render as plain text — skip the card border
+          const dismissed =
+            part.type === "tool" &&
+            (part as unknown as ToolPart).tool === "question" &&
+            (part as unknown as ToolPart).state.status === "error" &&
+            ((part as unknown as ToolPart).state as any).error?.includes("dismissed this question")
           return (
             <Show when={isUpstreamSuppressed || PART_MAPPING[part.type]}>
-              <div data-component="tool-part-wrapper" data-part-type={part.type}>
+              <div data-component="tool-part-wrapper" data-part-type={dismissed ? undefined : part.type}>
                 <Show
                   when={isUpstreamSuppressed}
                   fallback={

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1224,7 +1224,9 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
       <Show when={!hideQuestion()}>
         <div data-component="tool-part-wrapper">
           <div style="width: 100%; display: flex; justify-content: flex-end; padding: 4px 0;">
-            <span class="text-13-regular text-text-weak cursor-default">{i18n.t("ui.tool.questions")} dismissed</span>
+            <span class="text-13-regular text-text-weak cursor-default">
+              {i18n.t("ui.messagePart.questions.dismissed")}
+            </span>
           </div>
         </div>
       </Show>


### PR DESCRIPTION
## Summary

- Dismissed question parts ("Questions dismissed") no longer render inside a bordered card in the VS Code sidebar — they display as plain right-aligned text
- Fixed an i18n bug where the dismissed label concatenated a translated word with hardcoded English instead of using the dedicated `ui.messagePart.questions.dismissed` key (affects all 16 locales)

## Changes

- `AssistantMessage.tsx`: Detect dismissed question parts and omit `data-part-type="tool"` so the VS Code theme card border CSS does not match
- `message-part.tsx`: Replace `{i18n.t("ui.tool.questions")} dismissed` with `{i18n.t("ui.messagePart.questions.dismissed")}`