### PR TITLE
fix(session): reset session status to idle after successful completion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2885,7 +2885,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#4af877d", {}, "anomalyco-ghostty-web-4af877d", "sha512-fbEK8mtr7ar4ySsF+JUGjhaZrane7dKphanN+SxHt5XXI6yLMAh/Hpf6sNCOyyVa2UlGCd7YpXG/T2v2RUAX+A=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#4af877d", {}, "anomalyco-ghostty-web-4af877d"],
 
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -441,8 +441,17 @@ export namespace SessionProcessor {
           input.assistantMessage.time.completed = Date.now()
           await Session.updateMessage(input.assistantMessage)
           if (needsCompaction) return "compact"
-          if (blocked) return "stop"
-          if (input.assistantMessage.error) return "stop"
+          if (blocked || input.assistantMessage.error) {
+            // kilocode_change start - fix: set status to idle on stop (error or blocked)
+            SessionStatus.set(input.sessionID, { type: "idle" })
+            // kilocode_change end
+            return "stop"
+          }
+          // kilocode_change start - fix: set status to idle when turn completes
+          // The "finish" event handler above is a no-op, so we need to reset the status here
+          // to ensure the UI updates (stop button disappears, input re-enables)
+          SessionStatus.set(input.sessionID, { type: "idle" })
+          // kilocode_change end
           return "continue"
         }
       },


### PR DESCRIPTION
## Summary

Fixes the Agent Manager stop button that remains visible and chat input that stays disabled after the AI finishes responding.

## Problem

The session status was set to busy when LLM streaming started, but never reset to idle on successful completion. The finish event handler was a no-op, so after the stream completed successfully, the UI never received the status update needed to hide the stop button and re-enable the chat input.

## Root Cause

In packages/opencode/src/session/processor.ts:
- SessionStatus.set(idle) was only called in the error handling path (line 407)
- The successful completion path had no status reset

## Fix

Added SessionStatus.set(input.sessionID, { type: idle }) after the message is marked as completed, ensuring the SSE event is emitted and the UI updates correctly.

## Testing

- Typecheck passed: bun run typecheck
- Fix follows kilocode_change marker convention for fork compatibility

## Related Issue

Fixes #7153