### PR TITLE
fix(agent-manager): hide changes panel during worktree setup

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1097,6 +1097,9 @@ const AgentManagerContent: Component = () => {
             )
             setSelection(ev.worktreeId)
           }
+          // Close diff/review panels — nothing to show during setup
+          setDiffOpen(false)
+          setReviewActive(false)
           setSetup({ active: true, message: ev.message, branch: ev.branch, worktreeId: ev.worktreeId })
         }
       }

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -885,6 +885,7 @@ button.am-section-toggle:hover .am-section-label {
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  isolation: isolate;
 }
 
 .am-detail-split {


### PR DESCRIPTION
## Summary
- Close diff and review panels when a worktree enters setup mode so the "Changes" panel doesn't show through the "Setting up workspace" overlay
- Add `isolation: isolate` to `.am-detail-content` to contain the diff header `z-index: 20` within its stacking context, preventing it from bleeding above the setup overlay (`z-index: 10`)