### PR TITLE
fix(vscode): re-fetch merged config after settings update to prevent revert

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1598,13 +1598,20 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     try {
-      const { data: updated } = await this.client.global.config.update({ config: partial }, { throwOnError: true })
+      await this.client.global.config.update({ config: partial }, { throwOnError: true })
+
+      // Re-fetch the full merged config (global + project + all layers) so the
+      // webview receives the complete resolved config, not just global-only data.
+      // Without this, the global-only response would overwrite project-level
+      // values in the webview, causing settings to flicker and revert.
+      const dir = this.getWorkspaceDirectory()
+      const { data: merged } = await this.client.config.get({ directory: dir }, { throwOnError: true })
 
       const message = {
         type: "configUpdated",
-        config: updated,
+        config: merged,
       }
-      this.cachedConfigMessage = { type: "configLoaded", config: updated }
+      this.cachedConfigMessage = { type: "configLoaded", config: merged }
       this.postMessage(message)
     } catch (error) {
       console.error("[Kilo New] KiloProvider: Failed to update config:", error)


### PR DESCRIPTION
## Summary

- Fixes settings UI controls (select boxes, toggle switches) reverting to previous values immediately after user interaction
- Root cause: after calling `global.config.update`, the extension sent back the **global-only** config response, which replaced the full merged config (global + project + all layers) in the webview, causing values from non-global config layers to be lost

## What Changed

In `KiloProvider.handleUpdateConfig()`, after writing the partial update to the global config, we now re-fetch the full merged config via `config.get()` (which merges all config layers: global, project, remote, etc.) before sending it back to the webview. Previously, the global-only response from `global.config.update` was sent directly, which clobbered project-level config values and caused the optimistic UI update to be overwritten with stale/incomplete data.

Fixes #7202
