### PR TITLE
fix(cli): cancel running sub-agents when session is aborted

### DIFF
--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -28,6 +28,11 @@ export class KiloConnectionService {
   private state: ConnectionState = "disconnected"
   private connectPromise: Promise<void> | null = null
   private healthPollTimer: ReturnType<typeof setInterval> | null = null
+  private unsubscribeServerExit: (() => void) | null = null
+  /** Directory passed to the last successful connect(), used for auto-restart. */
+  private lastWorkspaceDir: string | null = null
+  /** Whether an auto-restart is currently in progress. */
+  private restarting = false
 
   private readonly eventListeners: Set<SSEEventListener> = new Set()
   private readonly stateListeners: Set<StateListener> = new Set()
@@ -180,6 +185,7 @@ export class KiloConnectionService {
    */
   dispose(): void {
     this.stopHealthPoll()
+    this.unsubscribeServerExit?.()
     this.sseClient?.dispose()
     this.serverManager.dispose()
     this.eventListeners.clear()
@@ -247,10 +253,52 @@ export class KiloConnectionService {
     }
   }
 
+  /**
+   * Automatically restart the server after an unexpected process exit.
+   * Transitions to "error" if the restart fails, giving the UI a chance
+   * to show the StartupErrorBanner with a manual "Retry" button.
+   */
+  private async autoRestart(code: number | null): Promise<void> {
+    if (this.restarting) return
+    this.restarting = true
+    const dir = this.lastWorkspaceDir
+    if (!dir) {
+      console.error("[Kilo New] ConnectionService: Cannot auto-restart — no workspace directory recorded")
+      this.setState("error")
+      this.restarting = false
+      return
+    }
+
+    console.warn(`[Kilo New] ConnectionService: 🔄 Server process exited (code ${code}), auto-restarting...`)
+
+    // Clean up the dead connection before restarting
+    this.stopHealthPoll()
+    this.sseClient?.dispose()
+    this.sseClient = null
+    this.client = null
+    this.config = null
+    this.info = null
+    this.connectPromise = null
+    this.setState("connecting")
+
+    try {
+      await this.doConnect(dir)
+      console.log("[Kilo New] ConnectionService: ✅ Auto-restart successful")
+    } catch (error) {
+      console.error("[Kilo New] ConnectionService: ❌ Auto-restart failed:", error)
+      this.setState("error")
+    } finally {
+      this.restarting = false
+    }
+  }
+
   private async doConnect(workspaceDir: string): Promise<void> {
     // If we reconnect, ensure the previous SSE connection is cleaned up first.
     this.stopHealthPoll()
     this.sseClient?.dispose()
+    this.unsubscribeServerExit?.()
+
+    this.lastWorkspaceDir = workspaceDir
 
     const server = await this.serverManager.getServer()
     this.info = { port: server.port }
@@ -314,6 +362,13 @@ export class KiloConnectionService {
         resolveConnected = null
         rejectConnected = null
       }
+    })
+
+    // Subscribe to server process exit so we can auto-restart.
+    // This must be set up before connect() so the exit handler is ready
+    // in case the process dies during SSE setup.
+    this.unsubscribeServerExit = this.serverManager.onExit((code) => {
+      void this.autoRestart(code)
     })
 
     this.sseClient.connect()

--- a/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
@@ -19,12 +19,13 @@ export type SSEStateHandler = (state: "connecting" | "connected" | "disconnected
  * consistency with the original strategy but use a generous 90 s timeout to
  * avoid false-positive reconnections during idle periods.
  *
- * NOTE on event coalescing:
- * The app batches rapid events into 16 ms windows before flushing to the UI.
- * We don't do that here because `postMessage()` to the webview already acts as
- * an implicit async buffer. If profiling shows the webview is overwhelmed by
- * high-frequency events, adding a similar coalescing queue here would be a
- * straightforward improvement.
+ * Event coalescing:
+ * During AI streaming, `message.part.delta` events fire at very high frequency
+ * (every token). Dispatching each one individually via `postMessage()` to the
+ * webview can saturate the main thread, causing 300-500ms+ frame blocks and
+ * triggering VS Code's "application unresponsive" dialog on Windows.
+ * We batch rapid events into 16ms windows (matching the app's strategy in
+ * `packages/app/src/context/global-sdk.tsx`) before flushing to listeners.
  */
 export class SdkSSEAdapter {
   private readonly handlers = new Set<SSEEventHandler>()
@@ -34,11 +35,23 @@ export class SdkSSEAdapter {
   private abortController: AbortController | null = null
   private heartbeatTimer: ReturnType<typeof setTimeout> | null = null
 
+  /** Queued events waiting to be flushed in the current coalescing window. */
+  private eventQueue: Event[] = []
+  private flushTimer: ReturnType<typeof setTimeout> | null = null
+  private static readonly COALESCE_MS = 16
+
   // 15s matches packages/app/src/context/global-sdk.tsx — server sends heartbeats
   // every 10s, so this gives a 5s grace window before forcing a reconnect.
   // Reduced from 90s: with 90s a dead connection could linger for ~1.5 minutes.
   private static readonly HEARTBEAT_TIMEOUT_MS = 15_000
   private static readonly RECONNECT_DELAY_MS = 250
+  /** Maximum reconnect delay when using exponential backoff (10 seconds). */
+  private static readonly MAX_RECONNECT_DELAY_MS = 10_000
+  /** Number of consecutive reconnect failures before escalating to error state. */
+  private static readonly MAX_RECONNECT_FAILURES = 5
+
+  /** Tracks consecutive reconnect failures for exponential backoff. */
+  private failures = 0
 
   constructor(private readonly client: KiloClient) {}
 
@@ -72,6 +85,7 @@ export class SdkSSEAdapter {
     this.abortController?.abort()
     this.abortController = null
     this.clearHeartbeat()
+    this.flushEventQueue()
   }
 
   /**
@@ -82,6 +96,7 @@ export class SdkSSEAdapter {
     this.handlers.clear()
     this.errorHandlers.clear()
     this.stateHandlers.clear()
+    this.eventQueue.length = 0
   }
 
   // ── Pub/sub ────────────────────────────────────────────────────────
@@ -111,6 +126,8 @@ export class SdkSSEAdapter {
 
   /**
    * Main reconnection loop — mirrors the pattern in `global-sdk.tsx`.
+   * Uses exponential backoff (250ms → 500ms → 1s → ... capped at 10s) to
+   * avoid tight failure loops when the server is down.
    */
   private async consumeLoop(signal: AbortSignal): Promise<void> {
     while (!signal.aborted) {
@@ -135,6 +152,7 @@ export class SdkSSEAdapter {
         })
 
         console.log("[Kilo New] SSE: ✅ Stream opened successfully")
+        this.failures = 0
         this.notifyState("connected")
         this.resetHeartbeat(attempt)
 
@@ -148,27 +166,34 @@ export class SdkSSEAdapter {
           // The SDK yields GlobalEvent = { directory, payload: Event }.
           const globalEvent = event as GlobalEvent
           console.log("[Kilo New] SSE: 📨 Event:", globalEvent.payload.type)
-          this.notifyEvent(globalEvent.payload)
+          this.enqueueEvent(globalEvent.payload)
         }
 
         console.log("[Kilo New] SSE: 📭 Stream ended normally")
       } catch (error) {
         if (!signal.aborted) {
-          console.error("[Kilo New] SSE: ❌ Stream error:", error)
+          this.failures++
+          console.error("[Kilo New] SSE: ❌ Stream error (attempt", this.failures, "):", error)
           this.notifyError(error instanceof Error ? error : new Error(String(error)))
         }
       } finally {
         signal.removeEventListener("abort", onAbort)
         this.clearHeartbeat()
+        this.flushEventQueue()
       }
 
       if (signal.aborted) {
         break
       }
 
-      console.log(`[Kilo New] SSE: 🔄 Reconnecting in ${SdkSSEAdapter.RECONNECT_DELAY_MS}ms...`)
+      // Exponential backoff: 250ms, 500ms, 1s, 2s, 4s, 8s, 10s (capped)
+      const delay = Math.min(
+        SdkSSEAdapter.RECONNECT_DELAY_MS * Math.pow(2, this.failures - 1),
+        SdkSSEAdapter.MAX_RECONNECT_DELAY_MS,
+      )
+      console.log(`[Kilo New] SSE: 🔄 Reconnecting in ${delay}ms...`)
       this.notifyState("connecting")
-      await new Promise((resolve) => setTimeout(resolve, SdkSSEAdapter.RECONNECT_DELAY_MS))
+      await new Promise((resolve) => setTimeout(resolve, delay))
     }
 
     this.notifyState("disconnected")
@@ -191,6 +216,35 @@ export class SdkSSEAdapter {
     if (this.heartbeatTimer) {
       clearTimeout(this.heartbeatTimer)
       this.heartbeatTimer = null
+    }
+  }
+
+  // ── Event coalescing ────────────────────────────────────────────────
+
+  /**
+   * Enqueue an event for batched dispatch. If this is the first event in
+   * the current window, schedule a flush after COALESCE_MS (16ms).
+   * This reduces webview main-thread pressure during AI streaming where
+   * `message.part.delta` events fire per-token at very high frequency.
+   */
+  private enqueueEvent(event: Event): void {
+    this.eventQueue.push(event)
+    if (!this.flushTimer) {
+      this.flushTimer = setTimeout(() => this.flushEventQueue(), SdkSSEAdapter.COALESCE_MS)
+    }
+  }
+
+  /**
+   * Flush all queued events to handlers immediately.
+   */
+  private flushEventQueue(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer)
+      this.flushTimer = null
+    }
+    const batch = this.eventQueue.splice(0)
+    for (const event of batch) {
+      this.notifyEvent(event)
     }
   }
 

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -1,4 +1,4 @@
-import { spawn, ChildProcess } from "child_process"
+import { spawn, execSync, ChildProcess } from "child_process"
 import * as crypto from "crypto"
 import * as fs from "fs"
 import * as path from "path"
@@ -12,13 +12,27 @@ export interface ServerInstance {
   process: ChildProcess
 }
 
+type ExitListener = (code: number | null) => void
+
 const STARTUP_TIMEOUT_SECONDS = 30
 
 export class ServerManager {
   private instance: ServerInstance | null = null
   private startupPromise: Promise<ServerInstance> | null = null
+  private readonly exitListeners = new Set<ExitListener>()
 
   constructor(private readonly context: vscode.ExtensionContext) {}
+
+  /**
+   * Subscribe to server process exit events. Returns unsubscribe function.
+   * Listeners are called when the server process exits unexpectedly (after startup).
+   */
+  onExit(listener: ExitListener): () => void {
+    this.exitListeners.add(listener)
+    return () => {
+      this.exitListeners.delete(listener)
+    }
+  }
 
   /**
    * Get or start the server instance
@@ -116,7 +130,8 @@ export class ServerManager {
 
       serverProcess.on("exit", (code) => {
         console.log("[Kilo New] ServerManager: 🛑 Process exited with code:", code)
-        if (this.instance?.process === serverProcess) {
+        const wasRunning = this.instance?.process === serverProcess
+        if (wasRunning) {
           this.instance = null
         }
         if (!resolved) {
@@ -126,6 +141,11 @@ export class ServerManager {
             cliPath,
           )
           reject(new ServerStartupError(userMessage, userDetails))
+        } else if (wasRunning) {
+          // Server died after successful startup — notify listeners
+          for (const listener of this.exitListeners) {
+            listener(code)
+          }
         }
       })
 
@@ -156,7 +176,9 @@ export class ServerManager {
    * Kill a process and its entire process group.
    * On Unix, we send the signal to -pid (negative) to reach the whole group,
    * mirroring the desktop app's ProcessGroup::leader() + start_kill() pattern.
-   * On Windows, process.kill() on the child handle is sufficient.
+   * On Windows, use `taskkill /T /F` to kill the entire process tree —
+   * plain `proc.kill()` only terminates the direct child, leaving orphan
+   * subprocesses (MCP servers, subagents) that can hold ports and file locks.
    */
   private static killProcess(proc: ChildProcess, signal: NodeJS.Signals = "SIGTERM"): void {
     if (proc.pid === undefined) {
@@ -167,7 +189,13 @@ export class ServerManager {
         // Negative PID targets the entire process group
         process.kill(-proc.pid, signal)
       } else {
-        proc.kill(signal)
+        // taskkill /T kills the entire process tree; /F forces termination
+        try {
+          execSync(`taskkill /T /F /PID ${proc.pid}`, { stdio: "ignore", timeout: 5000 })
+        } catch {
+          // taskkill may fail if the process is already gone — fall back
+          proc.kill(signal)
+        }
       }
     } catch {
       // Process already gone — ignore


### PR DESCRIPTION
## Summary

- Fixes the stop button not halting running sub-agents by making `SessionPrompt.cancel()` recursively cancel child sessions
- When a session is aborted, the function now queries the database for child sessions and cancels any that are currently running in the in-memory state

## Problem

When a user presses the "stop" button, `SessionPrompt.cancel(parentSessionID)` fires the parent session's `AbortController`. The cancellation of child sessions (sub-agents) was supposed to propagate through the Vercel AI SDK's abort signal to the task tool's event listener (`ctx.abort.addEventListener("abort", cancel)` in `task.ts`). However, this propagation is unreliable — the SDK may not always forward the abort signal to tools that are mid-execution, leaving sub-agent sessions running after the parent was stopped.

## Fix

In `SessionPrompt.cancel()`, after aborting the parent session, the function now:
1. Queries the database for all child sessions of the cancelled parent (synchronous SQLite query)
2. For each child that is currently running (has an entry in the in-memory `state()`), recursively calls `cancel()` on it

This ensures sub-agents are always stopped regardless of whether the AI SDK abort signal propagation succeeds, acting as a belt-and-suspenders safeguard alongside the existing task tool abort listener.

## Changed files

- `packages/opencode/src/session/prompt.ts` — Added child session cancellation logic to `cancel()` function, plus necessary `Database` and `SessionTable` imports