### PR TITLE
fix(vscode): auto-focus prompt textarea in new worktree dialog

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -86,11 +86,6 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
   let textareaRef: HTMLTextAreaElement | undefined
 
   onMount(() => {
-    requestAnimationFrame(() => {
-      if (!textareaRef) return
-      textareaRef.focus()
-      textareaRef.select()
-    })
     setBranchesLoading(true)
     vscode.postMessage({ type: "agentManager.requestBranches" })
   })
@@ -272,6 +267,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                 <div class="prompt-input-ghost-wrapper am-prompt-input-ghost-wrapper">
                   <textarea
                     ref={textareaRef}
+                    autofocus
                     class="prompt-input am-prompt-input"
                     placeholder={t(
                       isMac


### PR DESCRIPTION
## Summary

- Use the built-in `autofocus` attribute on the prompt textarea to leverage the Dialog component's `onOpenAutoFocus` handler, which properly focuses elements after Kobalte Portal rendering
- Removed the previous `requestAnimationFrame` + manual focus approach that didn't work due to Portal timing issues