### PR TITLE
fix(cli): cancel running sub-agents when session is aborted

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -42,6 +42,8 @@ import { TaskTool } from "@/tool/task"
 import { Tool } from "@/tool/tool"
 import { PermissionNext } from "@/permission/next"
 import { SessionStatus } from "./status"
+import { Database, eq } from "../storage/db" // kilocode_change
+import { SessionTable } from "./session.sql" // kilocode_change
 import { LLM } from "./llm"
 import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
@@ -290,6 +292,14 @@ export namespace SessionPrompt {
     match.abort.abort()
     delete s[sessionID]
     SessionStatus.set(sessionID, { type: "idle" })
+    // kilocode_change start - cancel running child sessions (sub-agents)
+    const kids = Database.use((db) =>
+      db.select({ id: SessionTable.id }).from(SessionTable).where(eq(SessionTable.parent_id, sessionID)).all(),
+    )
+    for (const kid of kids) {
+      if (s[kid.id]) cancel(kid.id)
+    }
+    // kilocode_change end
     return
   }
 


### PR DESCRIPTION
## Summary

- Fixes the stop button not halting running sub-agents by making `SessionPrompt.cancel()` recursively cancel child sessions
- When a session is aborted, the function now queries the database for child sessions and cancels any that are currently running in the in-memory state

## Problem

When a user presses the "stop" button, `SessionPrompt.cancel(parentSessionID)` fires the parent session's `AbortController`. The cancellation of child sessions (sub-agents) was supposed to propagate through the Vercel AI SDK's abort signal to the task tool's event listener (`ctx.abort.addEventListener("abort", cancel)` in `task.ts`). However, this propagation is unreliable — the SDK may not always forward the abort signal to tools that are mid-execution, leaving sub-agent sessions running after the parent was stopped.

## Fix

In `SessionPrompt.cancel()`, after aborting the parent session, the function now:
1. Queries the database for all child sessions of the cancelled parent (synchronous SQLite query)
2. For each child that is currently running (has an entry in the in-memory `state()`), recursively calls `cancel()` on it

This ensures sub-agents are always stopped regardless of whether the AI SDK abort signal propagation succeeds, acting as a belt-and-suspenders safeguard alongside the existing task tool abort listener.

## Changed files

- `packages/opencode/src/session/prompt.ts` — Added child session cancellation logic to `cancel()` function, plus necessary `Database` and `SessionTable` imports