### PR TITLE
fix(ui): add fallback for ghost icon button hover background

### DIFF
--- a/packages/kilo-ui/src/components/icon-button.css
+++ b/packages/kilo-ui/src/components/icon-button.css
@@ -12,7 +12,7 @@
     opacity 120ms;
 
   &[data-variant="ghost"]:hover:not(:disabled) {
-    background: var(--button-ghost-hover, var(--surface-base-hover));
+    background: var(--button-ghost-hover, var(--surface-base-hover, rgba(128, 128, 128, 0.2)));
   }
 
   &:active:not([data-disabled]) {


### PR DESCRIPTION
## Summary
- Adds explicit fallback value for ghost icon button hover background in kilo-ui to ensure visibility even when VS Code theme CSS variables are undefined

<img width="190" height="75" alt="image" src="https://github.com/user-attachments/assets/ae263286-4591-45bd-8621-a046a8e1bee2" />
