### PR TITLE
fix(agent-manager): prevent starting agents before state is initialized

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -820,6 +820,7 @@ export class AgentManagerProvider implements vscode.Disposable {
   private async onCreateMultiVersion(
     msg: Extract<AgentManagerInMessage, { type: "agentManager.createMultiVersion" }>,
   ): Promise<null> {
+    await this.waitForStateReady("onCreateMultiVersion")
     const text = msg.text?.trim() || undefined
 
     const worktreeName = msg.name?.trim() || undefined

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -21,8 +21,9 @@ import { createTerminalHost } from "./terminal-host"
 import { executeVscodeTask } from "./task-runner"
 import { forkSession } from "./fork-session"
 import { buildKeybindingMap } from "./format-keybinding"
+import { resolveVersionModels, buildInitialMessages, type CreatedVersion } from "./multi-version"
 import { TelemetryProxy, TelemetryEventName } from "../services/telemetry"
-import { MAX_MULTI_VERSIONS, PLATFORM } from "./constants"
+import { PLATFORM } from "./constants"
 import type { AgentManagerOutMessage, AgentManagerInMessage } from "./types"
 import { getWorkspaceRoot, hashFileDiffs, openFileInEditor, resolveLocalDiffTarget } from "../review-utils"
 
@@ -829,33 +830,15 @@ export class AgentManagerProvider implements vscode.Disposable {
     const baseBranch = msg.baseBranch
     const branchName = msg.branchName?.trim() || undefined
 
-    // Expand model allocations into per-version model assignments
-    const rawAllocations = msg.modelAllocations
-    const perVersionModels: Array<{ providerID: string; modelID: string } | undefined> = []
-    if (rawAllocations && rawAllocations.length > 0) {
-      for (const alloc of rawAllocations) {
-        const clamped = Math.min(Math.max(Math.floor(alloc.count) || 0, 0), MAX_MULTI_VERSIONS)
-        for (let c = 0; c < clamped; c++) {
-          perVersionModels.push({ providerID: alloc.providerID, modelID: alloc.modelID })
-        }
-        if (perVersionModels.length >= MAX_MULTI_VERSIONS) break
-      }
-    }
-
-    const versions =
-      perVersionModels.length > 0
-        ? Math.min(perVersionModels.length, MAX_MULTI_VERSIONS)
-        : Math.min(Math.max(Number(msg.versions) || 1, 1), MAX_MULTI_VERSIONS)
-
-    // Fall back to single model when not in compare mode
-    const providerID = perVersionModels.length > 0 ? undefined : msg.providerID
-    const modelID = perVersionModels.length > 0 ? undefined : msg.modelID
+    const fallback = msg.providerID && msg.modelID ? { providerID: msg.providerID, modelID: msg.modelID } : undefined
+    const resolved = resolveVersionModels(msg.modelAllocations, fallback, Number(msg.versions) || 1)
+    const { models, versions, providerID, modelID } = resolved
 
     // Generate a shared group ID for multi-version worktrees
     const groupId = versions > 1 ? `grp-${Date.now()}` : undefined
 
     this.log(
-      `Creating ${versions} worktrees${perVersionModels.length > 0 ? " (model comparison)" : ""}${text ? ` for: ${text.slice(0, 60)}` : ""}${groupId ? ` (group=${groupId})` : ""}`,
+      `Creating ${versions} worktrees${models.length > 0 ? " (model comparison)" : ""}${text ? ` for: ${text.slice(0, 60)}` : ""}${groupId ? ` (group=${groupId})` : ""}`,
     )
 
     // Notify webview that multi-version creation has started
@@ -868,14 +851,7 @@ export class AgentManagerProvider implements vscode.Disposable {
     })
 
     // Phase 1: Create all worktrees + sessions first
-    const created: Array<{
-      worktreeId: string
-      sessionId: string
-      path: string
-      branch: string
-      parentBranch: string
-      versionIndex: number
-    }> = []
+    const created: CreatedVersion[] = []
 
     for (let i = 0; i < versions; i++) {
       this.log(`Creating worktree ${i + 1}/${versions}`)
@@ -913,7 +889,7 @@ export class AgentManagerProvider implements vscode.Disposable {
       // Set the per-version model immediately so the UI selector reflects
       // the correct model as soon as the worktree appears, before Phase 2.
       // Uses a dedicated message type to avoid clearing the busy state.
-      const versionModel = perVersionModels[i]
+      const versionModel = models[i]
       const earlyProviderID = versionModel?.providerID ?? providerID
       const earlyModelID = versionModel?.modelID ?? modelID
       if (earlyProviderID && earlyModelID) {
@@ -957,40 +933,15 @@ export class AgentManagerProvider implements vscode.Disposable {
     }
 
     // Phase 2: Send the initial prompt to all sessions, or clear busy state if no text.
-    // Always include per-version model so the UI selector reflects the correct model.
-    for (let i = 0; i < created.length; i++) {
-      const entry = created[i]!
-      // Use the original version index to match the correct model from perVersionModels,
-      // since `created` may have gaps if earlier worktree creations failed.
-      const versionModel = perVersionModels[entry.versionIndex]
-      const versionProviderID = versionModel?.providerID ?? providerID
-      const versionModelID = versionModel?.modelID ?? modelID
+    const messages = buildInitialMessages(created, models, { providerID, modelID }, text, agent, files)
+    for (let i = 0; i < messages.length; i++) {
+      const msg = messages[i]!
       if (text) {
-        this.log(
-          `Sending initial message to version ${i + 1} (session=${entry.sessionId}${versionModel ? `, model=${versionProviderID}/${versionModelID}` : ""})`,
-        )
-        this.postToWebview({
-          type: "agentManager.sendInitialMessage",
-          sessionId: entry.sessionId,
-          worktreeId: entry.worktreeId,
-          text,
-          providerID: versionProviderID,
-          modelID: versionModelID,
-          agent,
-          files,
-        })
-        if (i < created.length - 1) {
-          await new Promise((resolve) => setTimeout(resolve, 300))
-        }
-      } else {
-        // No prompt — still include model info so the UI selector is correct
-        this.postToWebview({
-          type: "agentManager.sendInitialMessage",
-          sessionId: entry.sessionId,
-          worktreeId: entry.worktreeId,
-          providerID: versionProviderID,
-          modelID: versionModelID,
-        })
+        this.log(`Sending initial message to version ${i + 1} (session=${msg.sessionId})`)
+      }
+      this.postToWebview({ type: "agentManager.sendInitialMessage", ...msg })
+      if (text && i < messages.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 300))
       }
     }
 

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -699,6 +699,7 @@ export class AgentManagerProvider implements vscode.Disposable {
 
   /** Promote a session: create a worktree and move the session into it. */
   private async onPromoteSession(sessionId: string): Promise<null> {
+    await this.waitForStateReady("onPromoteSession")
     const created = await this.createWorktreeOnDisk({})
     if (!created) return null
 

--- a/packages/kilo-vscode/src/agent-manager/multi-version.ts
+++ b/packages/kilo-vscode/src/agent-manager/multi-version.ts
@@ -1,0 +1,103 @@
+import { MAX_MULTI_VERSIONS } from "./constants"
+
+export interface ModelAllocation {
+  providerID: string
+  modelID: string
+  count: number
+}
+
+interface ModelRef {
+  providerID: string
+  modelID: string
+}
+
+/**
+ * Expand model allocations into a flat per-version model list,
+ * compute the final version count, and derive the fallback model.
+ *
+ * Pure function — no vscode imports.
+ */
+export function resolveVersionModels(
+  allocations: ModelAllocation[] | undefined,
+  fallback: ModelRef | undefined,
+  requested: number,
+): {
+  models: Array<ModelRef | undefined>
+  versions: number
+  providerID: string | undefined
+  modelID: string | undefined
+} {
+  const models: Array<ModelRef | undefined> = []
+  if (allocations && allocations.length > 0) {
+    for (const alloc of allocations) {
+      const clamped = Math.min(Math.max(Math.floor(alloc.count) || 0, 0), MAX_MULTI_VERSIONS)
+      for (let c = 0; c < clamped; c++) {
+        models.push({ providerID: alloc.providerID, modelID: alloc.modelID })
+      }
+      if (models.length >= MAX_MULTI_VERSIONS) break
+    }
+  }
+
+  const compare = models.length > 0
+  const versions = compare
+    ? Math.min(models.length, MAX_MULTI_VERSIONS)
+    : Math.min(Math.max(requested, 1), MAX_MULTI_VERSIONS)
+
+  return {
+    models,
+    versions,
+    providerID: compare ? undefined : fallback?.providerID,
+    modelID: compare ? undefined : fallback?.modelID,
+  }
+}
+
+export interface CreatedVersion {
+  worktreeId: string
+  sessionId: string
+  path: string
+  branch: string
+  parentBranch: string
+  versionIndex: number
+}
+
+export interface InitialMessage {
+  sessionId: string
+  worktreeId: string
+  text?: string
+  providerID?: string
+  modelID?: string
+  agent?: string
+  files?: Array<{ mime: string; url: string }>
+}
+
+/**
+ * Build the list of initial messages to send for each created version.
+ *
+ * Pure function — no vscode imports.
+ */
+export function buildInitialMessages(
+  created: CreatedVersion[],
+  models: Array<ModelRef | undefined>,
+  fallback: { providerID?: string; modelID?: string },
+  prompt?: string,
+  agent?: string,
+  files?: Array<{ mime: string; url: string }>,
+): InitialMessage[] {
+  return created.map((entry) => {
+    const model = models[entry.versionIndex]
+    const pid = model?.providerID ?? fallback.providerID
+    const mid = model?.modelID ?? fallback.modelID
+    const msg: InitialMessage = {
+      sessionId: entry.sessionId,
+      worktreeId: entry.worktreeId,
+      providerID: pid,
+      modelID: mid,
+    }
+    if (prompt) {
+      msg.text = prompt
+      msg.agent = agent
+      msg.files = files
+    }
+    return msg
+  })
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1730,6 +1730,7 @@ const AgentManagerContent: Component = () => {
 
   const handlePromote = (sessionId: string, e: MouseEvent) => {
     e.stopPropagation()
+    if (!loaded()) return
     vscode.postMessage({ type: "agentManager.promoteSession", sessionId })
   }
 
@@ -2557,6 +2558,7 @@ const AgentManagerContent: Component = () => {
                     variant="primary"
                     size="small"
                     onClick={() => {
+                      if (!loaded()) return
                       const sid = session.currentSessionID()
                       if (sid) vscode.postMessage({ type: "agentManager.promoteSession", sessionId: sid })
                     }}

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1636,12 +1636,16 @@ const AgentManagerContent: Component = () => {
     ))
   }
 
+  const loaded = () => worktreesLoaded() && sessionsLoaded()
+
   const handleCreateWorktree = () => {
+    if (!loaded()) return
     vscode.postMessage({ type: "agentManager.createWorktree" })
   }
 
   // Advanced worktree dialog — opens a full dialog with prompt, versions, model, mode
   const showAdvancedWorktreeDialog = () => {
+    if (!loaded()) return
     dialog.show(() => <NewWorktreeDialog onClose={() => dialog.close()} defaultBaseBranch={repoDefaultBranch()} />)
   }
 
@@ -1891,6 +1895,7 @@ const AgentManagerContent: Component = () => {
 
   // Cmd+N: if an unassigned session is selected, promote it; otherwise create a new worktree
   const handleNewWorktreeOrPromote = () => {
+    if (!loaded()) return
     const sel = selection()
     const sid = session.currentSessionID()
     if (sel === null && sid && !worktreeSessionIds().has(sid)) {
@@ -1991,11 +1996,13 @@ const AgentManagerContent: Component = () => {
                     variant="ghost"
                     label={t("agentManager.worktree.new")}
                     onClick={handleCreateWorktree}
+                    disabled={!loaded()}
                   />
                   <DropdownMenu gutter={4} placement="bottom-end">
                     <DropdownMenu.Trigger
                       class="am-split-arrow"
                       aria-label={t("agentManager.worktree.advancedOptions")}
+                      disabled={!loaded()}
                     >
                       <Icon name="chevron-down" size="small" />
                     </DropdownMenu.Trigger>


### PR DESCRIPTION
## Summary

- Disable worktree creation actions (`+` button, Advanced dropdown, `Cmd+N`, `Cmd+Shift+N`) while the Agent Manager is still loading worktrees and sessions
- Add `waitForStateReady` to `onCreateMultiVersion` as a backend safety net, matching the existing pattern in `onCreateWorktree`

## Problem

Starting an agent from the advanced tab (or any create action) while the Agent Manager was still initializing would silently fail — the dialog closed, a progress message appeared, but no agent was created. This happened because `onCreateMultiVersion` didn't wait for state initialization, causing `getWorktreeManager()` to return `undefined`.

## Changes

- **`AgentManagerProvider.ts`**: Add `await this.waitForStateReady()` to `onCreateMultiVersion`
- **`AgentManagerApp.tsx`**: Add `loaded()` guard (`worktreesLoaded && sessionsLoaded`) to `handleCreateWorktree`, `showAdvancedWorktreeDialog`, `handleNewWorktreeOrPromote`, and disable the `+` button and dropdown trigger until loaded