### PR TITLE
fix(vscode): persist notification dismissals so they don't reappear

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1426,7 +1426,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const notifications = all.filter((n) => !n.showIn || n.showIn.includes("extension"))
       const existing = this.extensionContext?.globalState.get<string[]>("kilo.dismissedNotificationIds", []) ?? []
       const active = new Set(notifications.map((n) => n.id))
-      const dismissedIds = existing.filter((id) => active.has(id))
+      // Only prune stale dismissed IDs when we have a non-empty notification
+      // list. An empty list may mean the API returned nothing due to being
+      // unauthenticated (e.g. right after logout), not that all notifications
+      // are gone — pruning in that case would wipe the persisted dismissals.
+      const dismissedIds = notifications.length > 0 ? existing.filter((id) => active.has(id)) : existing
       if (dismissedIds.length !== existing.length) {
         await this.extensionContext?.globalState.update("kilo.dismissedNotificationIds", dismissedIds)
       }

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1404,6 +1404,18 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private async fetchAndSendNotifications(): Promise<void> {
     if (!this.client) {
       if (this.cachedNotificationsMessage) {
+        // Merge the latest dismissed IDs from globalState into the cached
+        // message so that dismissals persisted while offline are honoured.
+        const persisted = this.extensionContext?.globalState.get<string[]>("kilo.dismissedNotificationIds", []) ?? []
+        if (persisted.length > 0) {
+          const cached = this.cachedNotificationsMessage as {
+            type: string
+            notifications: unknown[]
+            dismissedIds: string[]
+          }
+          const merged = Array.from(new Set([...cached.dismissedIds, ...persisted]))
+          this.cachedNotificationsMessage = { ...cached, dismissedIds: merged }
+        }
         this.postMessage(this.cachedNotificationsMessage)
       }
       return
@@ -1623,6 +1635,21 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     const existing = this.extensionContext.globalState.get<string[]>("kilo.dismissedNotificationIds", [])
     if (!existing.includes(notificationId)) {
       await this.extensionContext.globalState.update("kilo.dismissedNotificationIds", [...existing, notificationId])
+    }
+    // Update the cached message so the dismiss persists even if
+    // fetchAndSendNotifications() fails (e.g. no client / API error).
+    if (this.cachedNotificationsMessage) {
+      const cached = this.cachedNotificationsMessage as {
+        type: string
+        notifications: unknown[]
+        dismissedIds: string[]
+      }
+      if (!cached.dismissedIds.includes(notificationId)) {
+        this.cachedNotificationsMessage = {
+          ...cached,
+          dismissedIds: [...cached.dismissedIds, notificationId],
+        }
+      }
     }
     await this.fetchAndSendNotifications()
     this.connectionService.notifyNotificationDismissed(notificationId)

--- a/packages/kilo-vscode/webview-ui/src/context/notifications.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/notifications.tsx
@@ -57,6 +57,7 @@ export const NotificationsProvider: ParentComponent = (props) => {
   })
 
   const dismiss = (id: string) => {
+    setDismissedIds((prev) => (prev.includes(id) ? prev : [...prev, id]))
     vscode.postMessage({ type: "dismissNotification", notificationId: id })
   }
 


### PR DESCRIPTION
## Summary

- Adds **optimistic dismiss** in the webview `NotificationsProvider` so the notification hides immediately when the user clicks the dismiss button, without waiting for the extension round-trip
- Updates the **cached notifications message** in `KiloProvider.handleDismissNotification()` so the dismiss survives API failures / offline fallback paths
- Merges **persisted globalState dismissed IDs** into the cached message in `fetchAndSendNotifications()` when the CLI client is unavailable, ensuring previously-dismissed notifications stay hidden

## Problem

Dismissed notifications kept reappearing because:

1. The webview `dismiss()` function only posted a message to the extension without optimistically updating local state — the notification remained visible until the extension responded
2. `handleDismissNotification()` persisted the ID to globalState but then called `fetchAndSendNotifications()` which could fail (no client, API error), leaving the cached message with stale `dismissedIds`
3. When the client was unavailable, `fetchAndSendNotifications()` served the cached message as-is, without incorporating dismissed IDs that had been persisted to globalState

## Changes

| File | Change |
| --- | --- |
| `webview-ui/src/context/notifications.tsx` | Optimistically add dismissed ID to local signal before posting message to extension |
| `src/KiloProvider.ts` (`handleDismissNotification`) | Update cached notifications message with the newly dismissed ID |
| `src/KiloProvider.ts` (`fetchAndSendNotifications`) | Merge globalState dismissed IDs into cached message when serving offline fallback |

## Testing

- Typecheck passes (`bun turbo typecheck`)
- Knip passes (no unused exports)
- `kilocode_change` check passes
