### PR TITLE
fix(cli,vscode): invalidate caches on config update and sync marketplace/settings state

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1341,39 +1341,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const stub = { id: name, type: "mode" as const, name, description: "", content: "" }
       const project = await mp.remove(stub, "project", workspace)
       const global = await mp.remove(stub, "global", workspace)
-      if (project.success || global.success) {
-        await this.disposeCliInstance("global")
-        removed = true
-      }
+      if (project.success || global.success) removed = true
     }
 
     if (!removed) {
       console.error("[Kilo New] KiloProvider: Failed to remove mode:", name)
     }
 
-    this.cachedAgentsMessage = null
-    await this.fetchAndSendAgents()
-    await this.fetchAndSendMarketplaceData()
-  }
-
-  /**
-   * Dispose the CLI backend instance so it re-reads config from disk.
-   * Call after any marketplace install/remove that writes config files directly.
-   * Global-scope changes need global.dispose() to also reset the global config cache.
-   */
-  private async disposeCliInstance(scope: "project" | "global"): Promise<void> {
-    if (!this.client) return
-    if (scope === "global") {
-      await this.client.global.dispose().catch((e: unknown) => {
-        console.warn("[Kilo New] global.dispose() after marketplace change failed:", e)
-      })
-    }
-    // Always dispose the per-project instance so it rebuilds state from
-    // the (possibly updated) global + project config on the next request.
-    const dir = this.getWorkspaceDirectory()
-    await this.client.instance.dispose({ directory: dir }).catch((e: unknown) => {
-      console.warn("[Kilo New] instance.dispose() after marketplace change failed:", e)
-    })
+    await this.invalidateAfterMarketplaceChange("global")
   }
 
   /**
@@ -1410,7 +1385,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     })
     this.cachedAgentsMessage = null
     this.cachedConfigMessage = null
-    await Promise.all([this.fetchAndSendAgents(), this.fetchAndSendConfig()])
+    await Promise.all([this.fetchAndSendAgents(), this.fetchAndSendConfig(), this.fetchAndSendMarketplaceData()])
   }
 
   /**

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1270,6 +1270,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
+  private async fetchAndSendMarketplaceData(): Promise<void> {
+    const workspace = this.getProjectDirectory(this.currentSession?.id)
+    const mp = this.getMarketplace()
+    const skills = await this.fetchCliSkills()
+    const data = await mp.fetchData(workspace, skills)
+    this.postMessage({ type: "marketplaceData", ...data })
+  }
+
   private async fetchCliSkills(): Promise<Array<{ name: string; location: string }> | undefined> {
     if (!this.client) return undefined
     try {
@@ -1345,6 +1353,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     this.cachedAgentsMessage = null
     await this.fetchAndSendAgents()
+    await this.fetchAndSendMarketplaceData()
   }
 
   /**

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -24,6 +24,7 @@ import {
 } from "jsonc-parser"
 // kilocode_change end
 import { Instance } from "../project/instance"
+import { State } from "../project/state" // kilocode_change
 import { LSPServer } from "../lsp/server"
 import { BunProc } from "@/bun"
 import { Installation } from "@/installation"
@@ -1588,6 +1589,13 @@ export namespace Config {
     })()
 
     global.reset()
+
+    // kilocode_change start - reset all derived caches (Config.state, Agent.state,
+    // Provider.state, etc.) so they re-read the updated global config on next access.
+    // Only cache entries without dispose callbacks are cleared — side-effectful state
+    // like sessions, MCP connections, and file watchers are preserved.
+    State.resetCaches()
+    // kilocode_change end
 
     GlobalBus.emit("event", {
       directory: "global",

--- a/packages/opencode/src/project/state.ts
+++ b/packages/opencode/src/project/state.ts
@@ -28,6 +28,21 @@ export namespace State {
     }
   }
 
+  /**
+   * Reset all cache-only entries (those without dispose callbacks) across all
+   * instances. This invalidates derived state like Config, Agent, Provider,
+   * etc. without tearing down side-effectful resources (MCP connections,
+   * sessions, file watchers, etc.).
+   */
+  export function resetCaches() {
+    for (const entries of recordsByKey.values()) {
+      for (const [init, entry] of entries) {
+        if (entry.dispose) continue
+        entries.delete(init)
+      }
+    }
+  }
+
   export async function dispose(key: string) {
     const entries = recordsByKey.get(key)
     if (!entries) return


### PR DESCRIPTION
## Summary

- Fixes stale per-instance config after `Config.updateGlobal()` — active instances now pick up global config changes (modes, providers, models, etc.) without requiring a server restart
- Adds `State.resetCaches()` which clears all cache-only `Instance.state` entries across all instances without tearing down side-effectful resources
- Fixes marketplace installed state not updating when removing a mode from the settings panel
- Fixes newly installed marketplace modes not appearing in Agent Behaviour settings

## Problem

PR #7172 correctly removed `Instance.disposeAll()` from `Config.updateGlobal()` to stop it from destroying sessions, MCP connections, and in-flight operations on every config change. However, this left a gap: `global.reset()` only invalidates the process-wide global config lazy cache, not the per-instance `Config.state` (or downstream caches like `Agent.state`, `Provider.state`, etc.) that merge global config at initialization time.

This meant that after a global config change via the VS Code settings panel (e.g. changing default agent, provider, or model), the server's HTTP endpoints (`/config`, `/app/agents`, `/app/providers`) would continue returning stale cached data. The extension would re-fetch after the `global.disposed` SSE event, but get back the old values.

Additionally, marketplace install/remove operations only refreshed the agents list but not the config context or marketplace metadata, causing:
- Settings panel showing stale agent data after marketplace changes
- Marketplace showing modes as still installed after removal from settings

As noted by the review bot on #7172: [comment](https://github.com/Kilo-Org/kilocode/pull/7172#discussion_r2946287612)

## Fix

**CLI (`State.resetCaches`):** Iterates all instance state maps and deletes entries that have **no dispose callback**. These are the 18 "pure cache" entries (Config, Agent, Provider, Tool, Skill, Command, Format, Plugin, etc.) that are safe to drop and will be re-computed on next access. The 9 entries with dispose callbacks (Prompt sessions, MCP connections, LSP clients, PTY processes, file watchers, etc.) are preserved.

The flow after the fix:
```
updateGlobal() writes config to disk
  → global.reset()           // clear global config lazy cache
  → State.resetCaches()      // clear all per-instance derived caches
  → emit "global.disposed"   // SSE to extension
  → extension re-fetches     // HTTP requests hit server
  → Config.state() re-inits  // fresh merge with updated global config
  → Agent.state() re-inits   // fresh agent list
  → UI updates correctly
```

**Extension (`refreshAfterMarketplaceChange`):** After every marketplace install or remove, pushes fresh agents, config, **and** marketplace metadata to the webview in parallel. Previously only `agentsLoaded` was sent, leaving the config context stale — so `config().agent` in the settings view wouldn't reflect the change until the fire-and-forget SSE `reloadAfterAuthChange` happened to complete.

**Extension (`handleRemoveMode`):** Calls `refreshAfterMarketplaceChange` after removing a mode from the settings panel, so the marketplace view immediately reflects the removal.
