### PR TITLE
fix(vscode): skip non-file URIs in ImportDefinitionsService parser lookup

### DIFF
--- a/packages/kilo-vscode/src/services/autocomplete/continuedev/core/autocomplete/context/ImportDefinitionsService.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/continuedev/core/autocomplete/context/ImportDefinitionsService.ts
@@ -33,6 +33,12 @@ export class ImportDefinitionsService {
       return null
     }
 
+    // Skip non-file URIs (e.g. output:tasks, vscode:, untitled:) — these are
+    // VS Code virtual documents that have no parseable source.
+    if (/^[a-zA-Z][\w+.-]*:/.test(filepath) && !filepath.startsWith("file:") && !filepath.startsWith("/")) {
+      return null
+    }
+
     const parser = await getParserForFile(filepath)
     if (!parser) {
       return {

--- a/packages/kilo-vscode/src/services/autocomplete/continuedev/core/util/treeSitter.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/continuedev/core/util/treeSitter.ts
@@ -126,6 +126,9 @@ export async function getParserForFile(filepath: string) {
   try {
     // Dynamically import Parser to avoid issues with WASM loading
     const { Parser } = require("web-tree-sitter")
+    if (!Parser) {
+      return undefined
+    }
 
     await Parser.init()
     const parser = new Parser()


### PR DESCRIPTION
## Summary

- Skip VS Code virtual document URIs (e.g. `output:tasks`, `output:extension-output-...`) in `ImportDefinitionsService._getFileInfo` before attempting tree-sitter parser loading
- Add defensive null check on `Parser` export from `web-tree-sitter` in `getParserForFile` to prevent `TypeError: Cannot read properties of undefined (reading 'init')`

## Problem

When VS Code switches focus to output panels, the `onDidChangeActiveTextEditor` listener passes non-file URIs like `output:tasks` into the parser pipeline. The `require("web-tree-sitter")` destructuring yields an undefined `Parser`, and calling `.init()` on it throws a `TypeError` that spams the extension host error logs.

## Changes

- `ImportDefinitionsService.ts`: Early-return `null` for any URI with a non-file scheme (matches `scheme:` pattern, excludes `file:` and absolute paths)
- `treeSitter.ts`: Guard against `Parser` being undefined after dynamic require