### PR TITLE
feat(cli): add notifications - ring terminal bell on task done and input prompts

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -28,7 +28,6 @@ import { SkillTool } from "../../tool/skill"
 import { BashTool } from "../../tool/bash"
 import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "../../util/locale"
-import { bell } from "../../kilocode/bell" // kilocode_change
 import { importCloudSession, validateCloudFork } from "@/kilocode/cloud-session" // kilocode_change
 
 type ToolProps<T extends Tool.Info> = {
@@ -567,7 +566,6 @@ export const RunCommand = cmd({
             event.properties.sessionID === sessionID &&
             event.properties.status.type === "idle"
           ) {
-            if (args.format !== "json") bell() // kilocode_change
             break
           }
 

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -567,7 +567,7 @@ export const RunCommand = cmd({
             event.properties.sessionID === sessionID &&
             event.properties.status.type === "idle"
           ) {
-            bell() // kilocode_change
+            if (args.format !== "json") bell() // kilocode_change
             break
           }
 

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -28,6 +28,7 @@ import { SkillTool } from "../../tool/skill"
 import { BashTool } from "../../tool/bash"
 import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "../../util/locale"
+import { bell } from "../../kilocode/bell" // kilocode_change
 import { importCloudSession, validateCloudFork } from "@/kilocode/cloud-session" // kilocode_change
 
 type ToolProps<T extends Tool.Info> = {
@@ -566,6 +567,7 @@ export const RunCommand = cmd({
             event.properties.sessionID === sessionID &&
             event.properties.status.type === "idle"
           ) {
+            bell() // kilocode_change
             break
           }
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -646,6 +646,15 @@ function App() {
       },
     },
     {
+      title: kv.get("bell_enabled", true) ? "Disable notifications" : "Enable notifications",
+      value: "app.toggle.notifications",
+      category: "System",
+      onSelect: (dialog) => {
+        kv.set("bell_enabled", !kv.get("bell_enabled", true))
+        dialog.clear()
+      },
+    },
+    {
       title: kv.get("animations_enabled", true) ? "Disable animations" : "Enable animations",
       value: "app.toggle.animations",
       category: "System",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -156,7 +156,7 @@ export function Session() {
       () => [route.sessionID, sync.data.session_status?.[route.sessionID]?.type] as const,
       ([id, type], prev) => {
         if (!prev || prev[0] !== id) return
-        if (prev[1] && prev[1] !== "idle" && type === "idle") bell()
+        if (prev[1] && prev[1] !== "idle" && type === "idle" && bellEnabled()) bell()
       },
     ),
   )
@@ -168,7 +168,7 @@ export function Session() {
       () => [route.sessionID, permissions().length] as const,
       ([id, len], prev) => {
         if (!prev || prev[0] !== id) return
-        if (len > prev[1]) bell()
+        if (len > prev[1] && bellEnabled()) bell()
       },
     ),
   )
@@ -177,7 +177,7 @@ export function Session() {
       () => [route.sessionID, questions().length] as const,
       ([id, len], prev) => {
         if (!prev || prev[0] !== id) return
-        if (len > prev[1]) bell()
+        if (len > prev[1] && bellEnabled()) bell()
       },
     ),
   )
@@ -195,6 +195,7 @@ export function Session() {
   const [showHeader, setShowHeader] = kv.signal("header_visible", true)
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [animationsEnabled, setAnimationsEnabled] = kv.signal("animations_enabled", true)
+  const [bellEnabled, setBellEnabled] = kv.signal("bell_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
 
   const wide = createMemo(() => dimensions().width > 120)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -84,6 +84,7 @@ import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
 
 import { formatMarkdownTables } from "../../util/markdown" // kilocode_change
+import { bell } from "@/kilocode/bell" // kilocode_change
 
 addDefaultParsers(parsers.parsers)
 
@@ -148,6 +149,17 @@ export function Session() {
   const lastAssistant = createMemo(() => {
     return messages().findLast((x) => x.role === "assistant")
   })
+
+  // kilocode_change start - ring terminal bell on task completion
+  createEffect(
+    on(
+      () => sync.data.session_status?.[route.sessionID]?.type,
+      (type, prev) => {
+        if (prev && prev !== "idle" && type === "idle") bell()
+      },
+    ),
+  )
+  // kilocode_change end
 
   const dimensions = useTerminalDimensions()
   const [sidebar, setSidebar] = kv.signal<"auto" | "hide">("sidebar", "auto")

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -161,6 +161,25 @@ export function Session() {
   )
   // kilocode_change end
 
+  // kilocode_change start - ring terminal bell when input is needed
+  createEffect(
+    on(
+      () => permissions().length,
+      (len, prev) => {
+        if (prev !== undefined && len > (prev ?? 0)) bell()
+      },
+    ),
+  )
+  createEffect(
+    on(
+      () => questions().length,
+      (len, prev) => {
+        if (prev !== undefined && len > (prev ?? 0)) bell()
+      },
+    ),
+  )
+  // kilocode_change end
+
   const dimensions = useTerminalDimensions()
   const [sidebar, setSidebar] = kv.signal<"auto" | "hide">("sidebar", "auto")
   const [sidebarOpen, setSidebarOpen] = createSignal(false)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -680,6 +680,15 @@ export function Session() {
       },
     },
     {
+      title: bellEnabled() ? "Disable notifications" : "Enable notifications",
+      value: "session.toggle.bell",
+      category: "Session",
+      onSelect: (dialog) => {
+        setBellEnabled((prev) => !prev)
+        dialog.clear()
+      },
+    },
+    {
       title: "Page up",
       value: "session.page.up",
       keybind: "messages_page_up",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -680,15 +680,6 @@ export function Session() {
       },
     },
     {
-      title: bellEnabled() ? "Disable notifications" : "Enable notifications",
-      value: "session.toggle.bell",
-      category: "Session",
-      onSelect: (dialog) => {
-        setBellEnabled((prev) => !prev)
-        dialog.clear()
-      },
-    },
-    {
       title: "Page up",
       value: "session.page.up",
       keybind: "messages_page_up",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -153,9 +153,10 @@ export function Session() {
   // kilocode_change start - ring terminal bell on task completion
   createEffect(
     on(
-      () => sync.data.session_status?.[route.sessionID]?.type,
-      (type, prev) => {
-        if (prev && prev !== "idle" && type === "idle") bell()
+      () => [route.sessionID, sync.data.session_status?.[route.sessionID]?.type] as const,
+      ([id, type], prev) => {
+        if (!prev || prev[0] !== id) return
+        if (prev[1] && prev[1] !== "idle" && type === "idle") bell()
       },
     ),
   )

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -165,17 +165,19 @@ export function Session() {
   // kilocode_change start - ring terminal bell when input is needed
   createEffect(
     on(
-      () => permissions().length,
-      (len, prev) => {
-        if (prev !== undefined && len > (prev ?? 0)) bell()
+      () => [route.sessionID, permissions().length] as const,
+      ([id, len], prev) => {
+        if (!prev || prev[0] !== id) return
+        if (len > prev[1]) bell()
       },
     ),
   )
   createEffect(
     on(
-      () => questions().length,
-      (len, prev) => {
-        if (prev !== undefined && len > (prev ?? 0)) bell()
+      () => [route.sessionID, questions().length] as const,
+      ([id, len], prev) => {
+        if (!prev || prev[0] !== id) return
+        if (len > prev[1]) bell()
       },
     ),
   )

--- a/packages/opencode/src/kilocode/bell.ts
+++ b/packages/opencode/src/kilocode/bell.ts
@@ -1,0 +1,6 @@
+// kilocode_change - new file
+export function bell() {
+  if (process.stdout.isTTY) {
+    process.stdout.write("\x07")
+  }
+}


### PR DESCRIPTION
## Summary

- Writes the ASCII BEL character (`\x07`) to stdout when the terminal is in the background
- Bounces the dock icon on macOS, flashes the taskbar on Windows, sets urgency hint on Linux
- Zero dependencies — one 3-line utility function

## When it rings

- **Task done**: session status goes to `idle` (both TUI and `kilo run`)
- **Input needed**: a permission request or question prompt appears in the TUI