### PR TITLE
fix(vscode): MCP marketplace installs not appearing in Agent Behaviour settings

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -734,7 +734,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           if (result.success) {
             await this.disposeCliInstance(scope)
             this.cachedAgentsMessage = null
-            await this.fetchAndSendAgents()
+            this.cachedConfigMessage = null
+            await Promise.all([this.fetchAndSendAgents(), this.fetchAndSendConfig()])
           }
           this.postMessage({
             type: "marketplaceInstallResult",
@@ -751,7 +752,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           if (result.success) {
             await this.disposeCliInstance(scope)
             this.cachedAgentsMessage = null
-            await this.fetchAndSendAgents()
+            this.cachedConfigMessage = null
+            await Promise.all([this.fetchAndSendAgents(), this.fetchAndSendConfig()])
           }
           this.postMessage({
             type: "marketplaceRemoveResult",

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -732,10 +732,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           const scope = message.mpInstallOptions?.target ?? "project"
           const result = await this.getMarketplace().install(message.mpItem, message.mpInstallOptions, workspace)
           if (result.success) {
-            await this.disposeCliInstance(scope)
-            this.cachedAgentsMessage = null
-            this.cachedConfigMessage = null
-            await Promise.all([this.fetchAndSendAgents(), this.fetchAndSendConfig()])
+            await this.invalidateAfterMarketplaceChange(scope)
           }
           this.postMessage({
             type: "marketplaceInstallResult",
@@ -750,10 +747,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           const scope = message.mpInstallOptions?.target ?? "project"
           const result = await this.getMarketplace().remove(message.mpItem, scope, workspace)
           if (result.success) {
-            await this.disposeCliInstance(scope)
-            this.cachedAgentsMessage = null
-            this.cachedConfigMessage = null
-            await Promise.all([this.fetchAndSendAgents(), this.fetchAndSendConfig()])
+            await this.invalidateAfterMarketplaceChange(scope)
           }
           this.postMessage({
             type: "marketplaceRemoveResult",
@@ -1371,6 +1365,43 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     await this.client.instance.dispose({ directory: dir }).catch((e: unknown) => {
       console.warn("[Kilo New] instance.dispose() after marketplace change failed:", e)
     })
+  }
+
+  /**
+   * Invalidate CLI caches and refresh the webview after a marketplace install/remove.
+   *
+   * For global scope: uses global.config.update with the freshly-written config file
+   * contents rather than global.dispose. This goes through Config.updateGlobal() which
+   * calls Config.global.reset() to invalidate the lazy-cached global config, ensuring
+   * the newly installed/removed MCP entry is visible on the next config.get call.
+   * (global.dispose alone is not sufficient on older CLI versions that lack the
+   * Config.global.reset() call in the dispose handler.)
+   *
+   * For project scope: instance.dispose is sufficient because the per-instance
+   * Config.state is cleared and re-reads all files (including global) on next access.
+   */
+  private async invalidateAfterMarketplaceChange(scope: "project" | "global"): Promise<void> {
+    if (!this.client) return
+    if (scope === "global") {
+      // Use global.config.update with an empty config to trigger Config.updateGlobal()
+      // which calls Config.global.reset(). This invalidates the lazy-cached global
+      // config in the CLI process so it re-reads kilo.json from disk.
+      // An empty object merge is a no-op for the file content but resets the cache.
+      // (global.dispose alone is insufficient on older CLI versions that lack
+      // the Config.global.reset() call in the dispose handler.)
+      await this.client.global.config.update({ config: {} }).catch((e: unknown) => {
+        console.warn("[Kilo New] global.config.update after marketplace change failed:", e)
+      })
+    }
+    // Always dispose the per-project instance so it rebuilds state from
+    // the (possibly updated) global + project config on the next request.
+    const dir = this.getWorkspaceDirectory()
+    await this.client.instance.dispose({ directory: dir }).catch((e: unknown) => {
+      console.warn("[Kilo New] instance.dispose() after marketplace change failed:", e)
+    })
+    this.cachedAgentsMessage = null
+    this.cachedConfigMessage = null
+    await Promise.all([this.fetchAndSendAgents(), this.fetchAndSendConfig()])
   }
 
   /**

--- a/packages/kilo-vscode/src/services/marketplace/installer.ts
+++ b/packages/kilo-vscode/src/services/marketplace/installer.ts
@@ -80,7 +80,8 @@ export class MarketplaceInstaller {
   private buildMcpEntry(content: string, params?: Record<string, unknown>): Record<string, unknown> {
     const filtered = Object.fromEntries(Object.entries(params ?? {}).filter(([k]) => k !== "__method"))
     const replaced = Object.keys(filtered).length > 0 ? substituteParams(content, filtered) : content
-    return JSON.parse(replaced)
+    const raw = JSON.parse(replaced) as Record<string, unknown>
+    return normalizeMcpEntry(raw)
   }
 
   // ── Mode ────────────────────────────────────────────────────────────
@@ -272,6 +273,48 @@ export class MarketplaceInstaller {
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Normalize a marketplace MCP entry from the old Kilocode format to the CLI's expected format.
+ *
+ * Old format (from marketplace API):
+ *   { "command": "npx", "args": [...], "env": {...} }
+ *   { "type": "sse"|"streamable-http", "url": "...", "headers": {...} }
+ *
+ * New format (CLI Config.Mcp schema):
+ *   { "type": "local", "command": ["npx", ...], "environment": {...} }
+ *   { "type": "remote", "url": "...", "headers": {...} }
+ */
+function normalizeMcpEntry(raw: Record<string, unknown>): Record<string, unknown> {
+  // Already in new format
+  if (raw.type === "local" || raw.type === "remote") return raw
+
+  // Remote MCP (sse / streamable-http) → type: "remote"
+  if (typeof raw.url === "string") {
+    const { type: _type, url, headers, ...rest } = raw
+    const entry: Record<string, unknown> = { type: "remote", url }
+    if (headers && typeof headers === "object") entry.headers = headers
+    // Carry through any other recognized fields (enabled, timeout, oauth)
+    for (const key of ["enabled", "timeout", "oauth"] as const) {
+      if (key in rest) entry[key] = rest[key]
+    }
+    return entry
+  }
+
+  // Local MCP (command string + args array) → type: "local", command array
+  if (typeof raw.command === "string") {
+    const args = (raw.args as string[] | undefined) ?? []
+    const env = raw.env
+    const entry: Record<string, unknown> = { type: "local", command: [raw.command, ...args] }
+    if (env && typeof env === "object" && Object.keys(env as object).length > 0) entry.environment = env
+    for (const key of ["enabled", "timeout"] as const) {
+      if (key in raw) entry[key] = raw[key]
+    }
+    return entry
+  }
+
+  return raw
+}
 
 function isSafeId(id: string): boolean {
   if (!id || id.includes("..") || id.includes("/") || id.includes("\\")) return false

--- a/packages/kilo-vscode/tests/unit/marketplace-installer.test.ts
+++ b/packages/kilo-vscode/tests/unit/marketplace-installer.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterEach } from "bun:test"
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+import { MarketplaceInstaller } from "../../src/services/marketplace/installer"
+import { MarketplacePaths } from "../../src/services/marketplace/paths"
+
+const tmpDir = path.join(os.tmpdir(), `kilo-test-${Date.now()}`)
+
+class TestPaths extends MarketplacePaths {
+  override configPath(scope: "project" | "global", workspace?: string): string {
+    if (scope === "global") return path.join(tmpDir, "global", "kilo.json")
+    return path.join(tmpDir, "project", ".kilo", "kilo.json")
+  }
+  override skillsDir(scope: "project" | "global", workspace?: string): string {
+    return path.join(tmpDir, "skills")
+  }
+}
+
+describe("MarketplaceInstaller MCP format normalization", () => {
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {})
+  })
+
+  it("converts local command+args+env format to CLI format", async () => {
+    const installer = new MarketplaceInstaller(new TestPaths())
+    const item = {
+      type: "mcp" as const,
+      id: "memory",
+      name: "Memory",
+      description: "test",
+      url: "https://example.com",
+      content: JSON.stringify({
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-memory"],
+        env: { MY_KEY: "my-value" },
+      }),
+    }
+    const result = await installer.install(item, { target: "global" }, undefined)
+    expect(result.success).toBe(true)
+
+    const written = JSON.parse(await fs.readFile(new TestPaths().configPath("global"), "utf-8"))
+    const mcp = written.mcp?.memory
+    expect(mcp.type).toBe("local")
+    expect(mcp.command).toEqual(["npx", "-y", "@modelcontextprotocol/server-memory"])
+    expect(mcp.environment).toEqual({ MY_KEY: "my-value" })
+    expect(mcp.args).toBeUndefined()
+    expect(mcp.env).toBeUndefined()
+  })
+
+  it("converts sse type to remote type", async () => {
+    const installer = new MarketplaceInstaller(new TestPaths())
+    const item = {
+      type: "mcp" as const,
+      id: "myremote",
+      name: "Remote",
+      description: "test",
+      url: "https://example.com",
+      content: JSON.stringify({
+        type: "sse",
+        url: "https://example.com/sse",
+        headers: { Authorization: "Bearer token" },
+      }),
+    }
+    const result = await installer.install(item, { target: "global" }, undefined)
+    expect(result.success).toBe(true)
+
+    const written = JSON.parse(await fs.readFile(new TestPaths().configPath("global"), "utf-8"))
+    const mcp = written.mcp?.myremote
+    expect(mcp.type).toBe("remote")
+    expect(mcp.url).toBe("https://example.com/sse")
+    expect(mcp.headers).toEqual({ Authorization: "Bearer token" })
+  })
+
+  it("keeps already-normalized local format unchanged", async () => {
+    const installer = new MarketplaceInstaller(new TestPaths())
+    const item = {
+      type: "mcp" as const,
+      id: "already",
+      name: "Already Done",
+      description: "test",
+      url: "https://example.com",
+      content: JSON.stringify({
+        type: "local",
+        command: ["npx", "-y", "someserver"],
+        environment: { KEY: "val" },
+      }),
+    }
+    const result = await installer.install(item, { target: "global" }, undefined)
+    expect(result.success).toBe(true)
+
+    const written = JSON.parse(await fs.readFile(new TestPaths().configPath("global"), "utf-8"))
+    const mcp = written.mcp?.already
+    expect(mcp).toEqual({ type: "local", command: ["npx", "-y", "someserver"], environment: { KEY: "val" } })
+  })
+})


### PR DESCRIPTION
## Summary

MCPs installed from the marketplace never appeared in the Agent Behaviour settings tab. Three bugs combined to cause this:

### Bug 1 — Wrong MCP format written to disk
The marketplace API returns entries in the old Kilocode format:
```json
{ "command": "npx", "args": ["-y", "some-mcp"], "env": { "KEY": "val" } }
```
But the CLI's `Config.Mcp` schema (with `.strict()`) requires:
```json
{ "type": "local", "command": ["npx", "-y", "some-mcp"], "environment": { "KEY": "val" } }
```
The strict Zod validation silently dropped every installed MCP entry from the merged config. **Fixed in `installer.ts:buildMcpEntry`** — now normalises the format before writing to `kilo.json`.

### Bug 2 — Config not refreshed after install
After a marketplace install, `KiloProvider` only called `fetchAndSendAgents()` and never called `fetchAndSendConfig()`. The webview's config state (which drives the MCP settings tab) stayed stale. **Fixed in `KiloProvider.ts`** — the new `invalidateAfterMarketplaceChange()` method clears cached messages and refreshes both agents and config.

### Bug 3 — CLI global config cache not invalidated (global scope only)
For global-scope installs, `global.dispose` alone didn't invalidate the CLI's lazy-cached global config (`Config.global`). The fix in commit `6d6e285bb` added `Config.global.reset()` to the dispose handler, but this isn't present in older CLI binaries.

**Fixed by using `global.config.update` with an empty config object** instead of relying on `global.dispose`. This routes through `Config.updateGlobal()` which always calls `global.reset()` — an empty merge is a no-op for the file content but properly resets the cache. Works on both old and new CLI binaries.

## Testing

Verified end-to-end against a live dev CLI server:
- **Project scope**: install → `instance.dispose` → `config.get` returns the MCP ✓
- **Global scope**: install → `global.config.update({})` → `instance.dispose` → `config.get` returns the MCP ✓
- **Global removal**: remove → `global.config.update({})` → `instance.dispose` → `config.get` returns no MCP ✓
- `kilo.jsonc` is not modified by the empty config update ✓

Unit tests added for the format normalisation covering local (`command`+`args`+`env`), remote (`sse`/`streamable-http`), and already-normalised formats.
