### PR TITLE
feat(cli): delay paste summary

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -34,6 +34,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { shouldSummarize as shouldPasteSummary } from "@/kilocode/paste-summary"
 
 export type PromptProps = {
   sessionID?: string
@@ -981,15 +982,14 @@ export function Prompt(props: PromptProps) {
                   } catch {}
                 }
 
-                const lineCount = (pastedContent.match(/\n/g)?.length ?? 0) + 1
-                if (
-                  (lineCount >= 3 || pastedContent.length > 150) &&
-                  !sync.data.config.experimental?.disable_paste_summary
-                ) {
+                // kilocode_change start
+                const summary = shouldPasteSummary(pastedContent)
+                if (summary.summarize && !sync.data.config.experimental?.disable_paste_summary) {
                   event.preventDefault()
-                  pasteText(pastedContent, `[Pasted ~${lineCount} lines]`)
+                  pasteText(pastedContent, `[Pasted ~${summary.lines} lines]`)
                   return
                 }
+                // kilocode_change end
 
                 // Force layout update and render for the pasted content
                 setTimeout(() => {

--- a/packages/opencode/src/kilocode/paste-summary.ts
+++ b/packages/opencode/src/kilocode/paste-summary.ts
@@ -1,0 +1,13 @@
+// kilocode_change - new file
+
+export function count(text: string) {
+  return (text.match(/\n/g)?.length ?? 0) + 1
+}
+
+export function shouldSummarize(text: string) {
+  const lines = count(text)
+  return {
+    lines,
+    summarize: lines >= 5 || text.length > 800,
+  }
+}

--- a/packages/opencode/test/kilocode/paste-summary.test.ts
+++ b/packages/opencode/test/kilocode/paste-summary.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test"
+import { shouldSummarize } from "../../src/kilocode/paste-summary"
+
+describe("paste-summary", () => {
+  it("does not summarize 4 lines", () => {
+    const text = Array.from({ length: 4 }, (_, i) => `line ${i + 1}`).join("\n")
+    expect(shouldSummarize(text)).toEqual({ lines: 4, summarize: false })
+  })
+
+  it("summarizes 5 lines", () => {
+    const text = Array.from({ length: 5 }, (_, i) => `line ${i + 1}`).join("\n")
+    expect(shouldSummarize(text)).toEqual({ lines: 5, summarize: true })
+  })
+
+  it("does not summarize 800 chars", () => {
+    const text = "a".repeat(800)
+    expect(shouldSummarize(text)).toEqual({ lines: 1, summarize: false })
+  })
+
+  it("summarizes 801 chars", () => {
+    const text = "a".repeat(801)
+    expect(shouldSummarize(text)).toEqual({ lines: 1, summarize: true })
+  })
+
+  it("summarizes when either threshold triggers independently", () => {
+    const lines = Array.from({ length: 5 }, () => "a").join("\n")
+    const chars = "b".repeat(801)
+
+    expect(shouldSummarize(lines)).toEqual({ lines: 5, summarize: true })
+    expect(shouldSummarize(chars)).toEqual({ lines: 1, summarize: true })
+  })
+
+  it("keeps 4 lines and 780 chars expanded", () => {
+    const row = "a".repeat(194)
+    const text = Array.from({ length: 4 }, () => row).join("\n")
+
+    expect(text.length).toBe(779)
+    expect(shouldSummarize(text)).toEqual({ lines: 4, summarize: false })
+  })
+
+  it("summarizes 5 lines and 500 chars", () => {
+    const row = "b".repeat(96)
+    const text = Array.from({ length: 5 }, () => row).join("\n")
+
+    expect(text.length).toBe(484)
+    expect(shouldSummarize(text)).toEqual({ lines: 5, summarize: true })
+  })
+})


### PR DESCRIPTION
## Why

Long pasted text was getting hidden too early. That made small code samples and short notes harder to read before sending.

## What changed

Pasted text now stays visible for short examples and only folds when it is clearly large enough to get in the way. The app checks both line count and total length so small multi-line notes can stay open while bigger blocks still collapse. Pictures, pasted file paths, and the setting that turns this behavior off still work the same.

## How to test

1. From `packages/opencode/`, run `bun test test/kilocode/paste-summary.test.ts`.
2. From `packages/opencode/`, run `bun run typecheck`.
3. In the TUI, paste 4 lines of plain text at about 780 characters and confirm it stays visible.
4. In the TUI, paste 5 lines of plain text at about 500 characters and confirm it collapses into the pasted text label.
5. In the TUI, paste a single line over 800 characters and confirm it also collapses.