### PR TITLE
fix(vscode): prevent stale configLoaded from reverting optimistic settings updates

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -61,6 +61,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private cachedSkillsMessage: unknown = null
   /** Cached configLoaded payload so requestConfig can be served before client is ready */
   private cachedConfigMessage: unknown = null
+  /** True while handleUpdateConfig is in flight; prevents fetchAndSendConfig from sending stale data */
+  private configUpdateInProgress = false
   /** Cached notificationsLoaded payload */
   private cachedNotificationsMessage: unknown = null
   private pendingReviewComments: unknown[][] = []
@@ -1415,6 +1417,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       return
     }
 
+    // Skip if handleUpdateConfig is in flight — sending a configLoaded now
+    // would race with the write and potentially overwrite optimistic webview state.
+    if (this.configUpdateInProgress) {
+      return
+    }
+
     try {
       const workspaceDir = this.getWorkspaceDirectory()
       const { data: config } = await this.client.config.get({ directory: workspaceDir }, { throwOnError: true })
@@ -1722,6 +1730,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       return
     }
 
+    // Belt-and-suspenders guard: prevent fetchAndSendConfig from sending a
+    // stale configLoaded while this write is in flight (the SSE-triggered reload
+    // races with the async config.update() write on the CLI backend).
+    this.configUpdateInProgress = true
     try {
       await this.client.global.config.update({ config: partial }, { throwOnError: true })
 
@@ -1744,6 +1756,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         type: "error",
         message: getErrorMessage(error) || "Failed to update config",
       })
+    } finally {
+      this.configUpdateInProgress = false
     }
   }
 

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -61,8 +61,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private cachedSkillsMessage: unknown = null
   /** Cached configLoaded payload so requestConfig can be served before client is ready */
   private cachedConfigMessage: unknown = null
-  /** True while handleUpdateConfig is in flight; prevents fetchAndSendConfig from sending stale data */
-  private configUpdateInProgress = false
+  /** Ref-count of in-flight handleUpdateConfig calls; prevents fetchAndSendConfig from sending stale data */
+  private pending = 0
   /** Cached notificationsLoaded payload */
   private cachedNotificationsMessage: unknown = null
   private pendingReviewComments: unknown[][] = []
@@ -1419,7 +1419,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     // Skip if handleUpdateConfig is in flight — sending a configLoaded now
     // would race with the write and potentially overwrite optimistic webview state.
-    if (this.configUpdateInProgress) {
+    if (this.pending > 0) {
       return
     }
 
@@ -1733,14 +1733,17 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // Belt-and-suspenders guard: prevent fetchAndSendConfig from sending a
     // stale configLoaded while this write is in flight (the SSE-triggered reload
     // races with the async config.update() write on the CLI backend).
-    this.configUpdateInProgress = true
+    this.pending++
     try {
       await this.client.global.config.update({ config: partial }, { throwOnError: true })
 
+      // global.config.update only resets the global config cache — the
+      // per-instance merged config (Config.state) is still stale. Force a
+      // full instance disposal so the next config.get re-merges all layers.
+      await this.client.global.dispose({ throwOnError: true })
+
       // Re-fetch the full merged config (global + project + all layers) so the
       // webview receives the complete resolved config, not just global-only data.
-      // Without this, the global-only response would overwrite project-level
-      // values in the webview, causing settings to flicker and revert.
       const dir = this.getWorkspaceDirectory()
       const { data: merged } = await this.client.config.get({ directory: dir }, { throwOnError: true })
 
@@ -1756,8 +1759,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         type: "error",
         message: getErrorMessage(error) || "Failed to update config",
       })
+      // Send configUpdated with the last known good config so the webview
+      // decrements its pendingUpdates counter and reverts the optimistic state.
+      if (this.cachedConfigMessage) {
+        this.postMessage({ type: "configUpdated", config: (this.cachedConfigMessage as { config: unknown }).config })
+      }
     } finally {
-      this.configUpdateInProgress = false
+      this.pending--
     }
   }
 

--- a/packages/kilo-vscode/webview-ui/src/context/config.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/config.tsx
@@ -53,16 +53,38 @@ export const ConfigProvider: ParentComponent = (props) => {
   const [config, setConfig] = createSignal<Config>({})
   const [loading, setLoading] = createSignal(true)
 
+  // Race-condition guard: track how many updateConfig calls are in-flight.
+  //
+  // Why this is needed:
+  // When the user picks a new dropdown value, updateConfig() optimistically
+  // updates local state and sends an "updateConfig" message to the extension.
+  // The extension writes the change, then sends back "configUpdated".
+  // However, the CLI backend may emit a "global.disposed" SSE event as part
+  // of its config-reload cycle, causing KiloProvider to call fetchAndSendConfig()
+  // which may return the *old* config (before the write is committed) and send
+  // a "configLoaded" message. Without this guard, that stale "configLoaded"
+  // would overwrite the optimistic state, causing a visible flash/revert.
+  //
+  // Solution: increment pendingUpdates on each updateConfig() call and
+  // decrement on each "configUpdated" response. Discard any "configLoaded"
+  // message that arrives while pendingUpdates > 0.
+  const [pendingUpdates, setPendingUpdates] = createSignal(0)
+
   // Register handler immediately (not in onMount) so we never miss
   // a configLoaded message that arrives before the DOM mount.
   const unsubscribe = vscode.onMessage((message: ExtensionMessage) => {
     if (message.type === "configLoaded") {
-      setConfig(message.config)
-      setLoading(false)
+      // Only apply if no update is in flight — a stale configLoaded must not
+      // overwrite the optimistically-updated state (see pendingUpdates above).
+      if (pendingUpdates() === 0) {
+        setConfig(message.config)
+        setLoading(false)
+      }
       return
     }
     if (message.type === "configUpdated") {
       setConfig(message.config)
+      setPendingUpdates((n) => Math.max(0, n - 1))
       return
     }
   })
@@ -92,6 +114,8 @@ export const ConfigProvider: ParentComponent = (props) => {
   function updateConfig(partial: Partial<Config>) {
     // Optimistically update local state with deep merge + null stripping
     setConfig((prev) => stripNulls(deepMerge(prev, partial)))
+    // Track this in-flight update so stale configLoaded messages are ignored
+    setPendingUpdates((n) => n + 1)
     // Send to extension for persistence
     vscode.postMessage({ type: "updateConfig", config: partial })
   }


### PR DESCRIPTION
## Summary

- **`config.tsx`**: Added a `pendingUpdates` SolidJS signal counter. `updateConfig()` increments it; `configUpdated` handler decrements it. `configLoaded` messages are discarded while `pendingUpdates > 0`, preventing stale backend responses from overwriting optimistic UI state after a user selection.

- **`KiloProvider.ts`**: Added `configUpdateInProgress` boolean flag. Set to `true` before the async config write in `handleUpdateConfig()`, cleared in `finally`. `fetchAndSendConfig()` returns early if the flag is set, blocking SSE-triggered reloads from racing the write and sending stale `configLoaded` messages.

- **`PermissionDock` + `permission-dock-utils.ts`**: Added human-readable permission descriptions (`describePatterns`, `resolveLabel`, `TOOL_LABEL_KEYS`) with i18n support across all 16 locales. Updated visual regression snapshots and added unit tests.

## Changes

- `packages/kilo-vscode/src/KiloProvider.ts` — backend guard via `configUpdateInProgress` flag
- `packages/kilo-vscode/webview-ui/src/context/config.tsx` — frontend guard via `pendingUpdates` signal
- `packages/kilo-vscode/webview-ui/src/components/chat/permission-dock-utils.ts` — new `describePatterns`/`resolveLabel` helpers
- `packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx` — improved permission UI using new helpers
- `packages/kilo-vscode/webview-ui/src/i18n/*.ts` — 16 locale files updated with new `toolLabel` and `titleSubagent` keys
- `packages/kilo-vscode/tests/unit/permission-description.test.ts` — new unit tests for `describePatterns`/`resolveLabel`
- Visual regression snapshots updated