### PR TITLE
feat: add Windows ARM64 build support for CLI and VS Code extension

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,7 +34,7 @@ The `publish.yml` workflow runs four jobs sequentially:
 - Builds native binaries for **all supported platforms and architectures**:
   - Linux: x64, arm64 (glibc and musl), plus baseline (non-AVX2) variants
   - macOS: x64, arm64, plus baseline variants
-  - Windows: x64, plus baseline variant
+  - Windows: x64 (plus baseline variant), arm64
 - Patches ELF interpreters on Linux binaries for broad compatibility.
 - Creates platform archives (`.tar.gz` for Linux, `.zip` for macOS/Windows) and uploads them to the draft GitHub Release.
 - Uploads the `dist/` directory as a workflow artifact (`kilo-cli`) for subsequent jobs.
@@ -43,7 +43,7 @@ The `publish.yml` workflow runs four jobs sequentially:
 
 - Downloads the CLI artifacts from the previous job.
 - Runs `packages/kilo-vscode/script/build.ts` to build VSIX packages for all target platforms:
-  - `linux-x64`, `linux-arm64`, `alpine-x64`, `alpine-arm64`, `darwin-x64`, `darwin-arm64`, `win32-x64`
+  - `linux-x64`, `linux-arm64`, `alpine-x64`, `alpine-arm64`, `darwin-x64`, `darwin-arm64`, `win32-x64`, `win32-arm64`
 - Each VSIX bundles the platform-specific CLI binary.
 - Uploads the VSIX files as a workflow artifact (`kilo-vscode`).
 

--- a/bun.lock
+++ b/bun.lock
@@ -414,6 +414,7 @@
         "@parcel/watcher-linux-arm64-musl": "2.5.1",
         "@parcel/watcher-linux-x64-glibc": "2.5.1",
         "@parcel/watcher-linux-x64-musl": "2.5.1",
+        "@parcel/watcher-win32-arm64": "2.5.1",
         "@parcel/watcher-win32-x64": "2.5.1",
         "@standard-schema/spec": "1.0.0",
         "@tsconfig/bun": "catalog:",

--- a/packages/kilo-vscode/script/build.ts
+++ b/packages/kilo-vscode/script/build.ts
@@ -30,6 +30,9 @@ const targets = [
   { target: "darwin-x64", cliDir: "@kilocode/cli-darwin-x64", binary: "kilo" },
   { target: "darwin-arm64", cliDir: "@kilocode/cli-darwin-arm64", binary: "kilo" },
   { target: "win32-x64", cliDir: "@kilocode/cli-windows-x64", binary: "kilo.exe" },
+  // kilocode_change start - added Windows ARM64 target
+  { target: "win32-arm64", cliDir: "@kilocode/cli-windows-arm64", binary: "kilo.exe" },
+  // kilocode_change end
 ]
 
 const binDir = join(import.meta.dir, "..", "bin")

--- a/packages/kilo-vscode/script/build.ts
+++ b/packages/kilo-vscode/script/build.ts
@@ -30,9 +30,7 @@ const targets = [
   { target: "darwin-x64", cliDir: "@kilocode/cli-darwin-x64", binary: "kilo" },
   { target: "darwin-arm64", cliDir: "@kilocode/cli-darwin-arm64", binary: "kilo" },
   { target: "win32-x64", cliDir: "@kilocode/cli-windows-x64", binary: "kilo.exe" },
-  // kilocode_change start - added Windows ARM64 target
   { target: "win32-arm64", cliDir: "@kilocode/cli-windows-arm64", binary: "kilo.exe" },
-  // kilocode_change end
 ]
 
 const binDir = join(import.meta.dir, "..", "bin")

--- a/packages/kilo-vscode/script/publish.ts
+++ b/packages/kilo-vscode/script/publish.ts
@@ -13,7 +13,6 @@ if (!existsSync(outDir)) {
   throw new Error(`VSIX directory not found: ${outDir}`)
 }
 
-// kilocode_change start - added Windows ARM64 target
 const targets = [
   "linux-x64",
   "linux-arm64",
@@ -24,7 +23,6 @@ const targets = [
   "win32-x64",
   "win32-arm64",
 ]
-// kilocode_change end
 
 const vsixFiles: string[] = []
 for (const target of targets) {

--- a/packages/kilo-vscode/script/publish.ts
+++ b/packages/kilo-vscode/script/publish.ts
@@ -13,7 +13,18 @@ if (!existsSync(outDir)) {
   throw new Error(`VSIX directory not found: ${outDir}`)
 }
 
-const targets = ["linux-x64", "linux-arm64", "alpine-x64", "alpine-arm64", "darwin-x64", "darwin-arm64", "win32-x64"]
+// kilocode_change start - added Windows ARM64 target
+const targets = [
+  "linux-x64",
+  "linux-arm64",
+  "alpine-x64",
+  "alpine-arm64",
+  "darwin-x64",
+  "darwin-arm64",
+  "win32-x64",
+  "win32-arm64",
+]
+// kilocode_change end
 
 const vsixFiles: string[] = []
 for (const target of targets) {

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -36,6 +36,7 @@
     "@parcel/watcher-linux-x64-glibc": "2.5.1",
     "@parcel/watcher-linux-x64-musl": "2.5.1",
     "@parcel/watcher-win32-x64": "2.5.1",
+    "@parcel/watcher-win32-arm64": "2.5.1",
     "@standard-schema/spec": "1.0.0",
     "@tsconfig/bun": "catalog:",
     "@types/babel__core": "7.20.5",

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -117,6 +117,12 @@ const allTargets: {
     arch: "x64",
     avx2: false,
   },
+  // kilocode_change start - added Windows ARM64 target
+  {
+    os: "win32",
+    arch: "arm64",
+  },
+  // kilocode_change end
 ]
 
 const targets = singleFlag


### PR DESCRIPTION
## Context

Bun recently added native Windows ARM64 support ([oven-sh/bun#26215](https://github.com/oven-sh/bun/pull/26215)), and `bun-windows-arm64` is now a valid cross-compilation target. This PR adds Windows ARM64 as a supported build target for the CLI binary and the VS Code extension VSIX.

## Implementation

- **`packages/opencode/script/build.ts`**: Added `{ os: "win32", arch: "arm64" }` to the `allTargets` matrix. The build script already handles the naming convention (`win32` → `windows`) and archive creation (`.zip`), so the new target integrates seamlessly.
- **`packages/kilo-vscode/script/build.ts`**: Added `{ target: "win32-arm64", cliDir: "@kilocode/cli-windows-arm64", binary: "kilo.exe" }` to the targets array so the VS Code extension VSIX is packaged with the correct ARM64 binary.
- **`packages/kilo-vscode/script/publish.ts`**: Added `"win32-arm64"` to the publish targets so the VSIX is published to the VS Code Marketplace.
- **`packages/opencode/package.json`**: Added `@parcel/watcher-win32-arm64@2.5.1` as an optional dev dependency (matching the version used for all other platforms) to ensure the native watcher module is available during cross-compilation.
- **`RELEASING.md`**: Updated documentation to reflect the new CLI and VSIX targets.

The dynamic binary resolution in `bin/kilo` and `postinstall.mjs` already handles `win32` + `arm64` via their `platformMap`/`archMap` lookups, so no runtime changes are needed. The CI pipeline (`publish.yml`) runs `build.ts` without a target matrix, so it will automatically build the new target.

