### PR TITLE
docs: document environment variables for local backend testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,26 @@ kilo serve           # Start headless API server
 kilo web             # Start server + open web interface
 ```
 
+### Testing with a local backend
+
+To point the CLI at a local backend (e.g., a locally running Kilo API server on port 3000), set the `KILO_API_URL` environment variable:
+
+```bash
+KILO_API_URL=http://localhost:3000 bun dev
+```
+
+This redirects all gateway traffic (auth, model listing, provider routing, profile, etc.) to your local server. The default is `https://api.kilo.ai`.
+
+There are also optional overrides for other services:
+
+| Variable                  | Default                          | Purpose                                   |
+| ------------------------- | -------------------------------- | ----------------------------------------- |
+| `KILO_API_URL`            | `https://api.kilo.ai`            | Kilo API (gateway, auth, models, profile) |
+| `KILO_SESSION_INGEST_URL` | `https://ingest.kilosessions.ai` | Session export / cloud sync               |
+| `KILO_MODELS_URL`         | `https://models.dev`             | Model metadata                            |
+
+> **VS Code:** The repo includes a "VSCode - Run Extension (Local Backend)" launch config in `.vscode/launch.json` that sets `KILO_API_URL=http://localhost:3000` automatically.
+
 ### Pull Request Expectations
 
 - **Issue First Policy:** All PRs must reference an existing issue.


### PR DESCRIPTION
## Summary

- Adds a "Testing with a local backend" section to `CONTRIBUTING.md` documenting the `KILO_API_URL`, `KILO_SESSION_INGEST_URL`, and `KILO_MODELS_URL` environment variables
- Shows how to run the CLI against a local backend server (`KILO_API_URL=http://localhost:3000 bun dev`)
- Notes the existing VS Code launch config for local backend development