### PR TITLE
Save permissions without disposing instances

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -7,7 +7,6 @@
  * For bash, the hierarchical rules from metadata.rules are shown.
  * For other tools, the always array is shown so users can configure per-tool permissions.
  * The command buttons (Deny / Run) control the current command.
- * When all rules are toggled ✓, the command auto-runs.
  */
 
 import { Component, For, Show, createMemo, createSignal } from "solid-js"
@@ -80,11 +79,6 @@ export const PermissionDock: Component<{
     const updated = { ...decisions(), [index]: next }
     setDecisions(updated)
 
-    const total = rules().length
-    const count = Object.values(updated).filter((d) => d === "approved").length
-    if (count === total && total > 0) {
-      props.onDecide("once", [...rules()], [])
-    }
   }
 
   const decision = (index: number): RuleDecision => decisions()[index] ?? "pending"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -78,7 +78,6 @@ export const PermissionDock: Component<{
     const next = current === decision ? "pending" : decision
     const updated = { ...decisions(), [index]: next }
     setDecisions(updated)
-
   }
 
   const decision = (index: number): RuleDecision => decisions()[index] ?? "pending"

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1587,15 +1587,25 @@ export namespace Config {
       return merged
     })()
 
-    global.reset()
+    // kilocode_change start — skip dispose when caller opts out (e.g. permission-only saves)
+    await global.reset()
 
-    GlobalBus.emit("event", {
-      directory: "global",
-      payload: {
-        type: Event.Disposed.type,
-        properties: {},
-      },
-    })
+    if (!dispose) return next;
+    // kilocode_change end
+
+
+    void Instance.disposeAll()
+      .catch(() => undefined)
+      .finally(() => {
+        GlobalBus.emit("event", {
+          directory: "global",
+          payload: {
+            type: Event.Disposed.type,
+            properties: {},
+          },
+        })
+      })
+
 
     return next
   }

--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -233,7 +233,7 @@ export namespace PermissionNext {
       s.approved.push(...newRules)
 
       if (newRules.length > 0) {
-        await Config.updateGlobal({ permission: toConfig(newRules) })
+        await Config.updateGlobal({ permission: toConfig(newRules) }, { dispose: false })
       }
     },
   )
@@ -315,7 +315,7 @@ export namespace PermissionNext {
           action: "allow" as const,
         }))
         if (alwaysRules.length > 0) {
-          await Config.updateGlobal({ permission: toConfig(alwaysRules) })
+          await Config.updateGlobal({ permission: toConfig(alwaysRules) }, { dispose: false })
         }
         // kilocode_change end
         return


### PR DESCRIPTION

## Context

- I have added back a call to dispose all instances when global config is updated. With the exception that if we pass a specific param it will skip the dispose.
- This change is needed for permissions, where we need to update the permissions config but not dispose all instances, because this would destroy in-flight processes. So when updating permissions, we don't dispose. We only reset the config to save changes.

- Another small fix is that we don't close the permission prompt right away when all permissions are approved. This was causing the problem that when there was a single permission, it would automatically close, and be confusing.


## Screenshots

N / A

## Testing

- Manual sanity tests
- Unit tests
- Check that changes in Settings -> Auto-Approve are processed by the current session correctly.
- Check that the external directory permission can read nested folders if the parent folder is approved

