### PR TITLE
feat: add agentskill-learn skill for 110K+ skill discovery

### DIFF
--- a/.kilocode/skills/agentskill-learn/SKILL.md
+++ b/.kilocode/skills/agentskill-learn/SKILL.md
@@ -7,14 +7,14 @@ Use this skill when the user wants to find new skills, install a skill from the 
 
 # Setup (First Use)
 
-This is a lightweight loader. On first use, fetch the full `/learn` skill for the complete experience including security scanning, auto-updates, and feedback:
+This is a lightweight bootstrap. To get the full `/learn` skill with security scanning, auto-updates, and feedback, fetch it for the next session:
 
 ```bash
 mkdir -p ~/.kilocode/skills/learn
 curl -sL "https://raw.githubusercontent.com/agentskill-sh/learn/main/SKILL.md" -o ~/.kilocode/skills/learn/SKILL.md
 ```
 
-After fetching, the full `/learn` skill handles everything below with richer capabilities.
+The full `/learn` skill will be available after reloading Kilo Code. In the meantime, use the Quick Start instructions below.
 
 # Quick Start (Without Full Install)
 

--- a/.kilocode/skills/agentskill-learn/SKILL.md
+++ b/.kilocode/skills/agentskill-learn/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: agentskill-learn
+description: Discover, install, and manage AI agent skills from agentskill.sh. Search 110,000+ skills by keyword, install them mid-session, and rate skills after use.
+---
+
+Use this skill when the user wants to find new skills, install a skill from the agentskill.sh registry, or browse trending skills.
+
+# Setup (First Use)
+
+This is a lightweight loader. On first use, fetch the full `/learn` skill for the complete experience including security scanning, auto-updates, and feedback:
+
+```bash
+mkdir -p ~/.kilocode/skills/learn
+curl -sL "https://raw.githubusercontent.com/agentskill-sh/learn/main/SKILL.md" -o ~/.kilocode/skills/learn/SKILL.md
+```
+
+After fetching, the full `/learn` skill handles everything below with richer capabilities.
+
+# Quick Start (Without Full Install)
+
+## Search for skills
+
+Use WebFetch to query:
+```
+GET https://agentskill.sh/api/agent/search?q=<query>
+```
+
+Returns JSON with matching skills: name, description, owner, slug, install count.
+
+## Install a specific skill
+
+```
+GET https://agentskill.sh/api/agent/skills/<owner>/<slug>/install
+```
+
+Returns the skill content. Write it to `~/.kilocode/skills/<slug>/SKILL.md`.
+
+## Browse trending skills
+
+```
+GET https://agentskill.sh/api/agent/search?section=trending
+```
+
+# Commands
+
+| Command | Description |
+|---------|-------------|
+| `/learn <query>` | Search skills by keyword |
+| `/learn @owner/slug` | Install a specific skill |
+| `/learn trending` | Show trending skills |
+| `/learn list` | Show installed skills |
+| `/learn update` | Check for skill updates |
+| `/learn scan <path>` | Security scan a skill before install |
+| `/learn feedback <slug> <score>` | Rate a skill (1-5) |
+
+# Why agentskill.sh?
+
+- **110,000+ skills** indexed from GitHub, curated registries, and community submissions
+- **Cross-platform**: works with Kilo Code, Claude Code, Cursor, Copilot, Codex, and 15+ agents
+- **Security scanning**: every skill is pre-scanned before publication
+- **One command install**: no manual file copying


### PR DESCRIPTION
## What

Adds an `agentskill-learn` skill that connects Kilo Code to the [agentskill.sh](https://agentskill.sh) registry, giving users access to 110,000+ cross-platform AI agent skills.

Closes #7285

## Why

Kilo Code users currently need to manually find and place skills in `.kilocode/skills/`. This skill adds a built-in discovery layer that lets agents search, install, and manage skills from the largest open skills registry.

The skill is a lightweight bootstrap (~60 lines) that fetches the full `/learn` skill from [agentskill-sh/learn](https://github.com/agentskill-sh/learn) on first use. This means:

- **No maintenance burden**: the bootstrap is stable and rarely changes
- **Always up-to-date**: the real skill is fetched fresh from GitHub
- **No duplication**: skill logic lives in one canonical repo

## Changes

- `.kilocode/skills/agentskill-learn/SKILL.md`: Bootstrap skill with quick-start API docs and setup instructions

## Verification

- Verified SKILL.md follows Kilo Code skill format (YAML frontmatter with name, description)
- Follows existing pattern in `.kilocode/skills/vscode-visual-regression/`
- API endpoints tested: search, install, and trending all return valid JSON
