### PR TITLE
feat(vscode): support file attachments in chat input

### DIFF
--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -722,6 +722,13 @@ export function UserMessageDisplay(props: {
     }),
   )
 
+  const standalone = createMemo(() =>
+    files().filter((f) => {
+      const mime = f.mime
+      return !mime.startsWith("image/") && mime !== "application/pdf" && f.source?.text?.start === undefined
+    }),
+  )
+
   const agents = createMemo(() => (props.parts?.filter((p) => p.type === "agent") as AgentPart[]) ?? [])
 
   const model = createMemo(() => {
@@ -796,6 +803,20 @@ export function UserMessageDisplay(props: {
                       alt={file.filename ?? i18n.t("ui.message.attachment.alt")}
                     />
                   </Show>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+        <Show when={standalone().length > 0}>
+          <div data-slot="user-message-files">
+            <For each={standalone()}>
+              {(file) => (
+                <div data-slot="user-message-file" data-queued={props.queued ? "" : undefined}>
+                  <Icon name="go-to-file" size="small" />
+                  <span data-slot="user-message-file-name">
+                    {file.filename ?? file.url?.split("/").pop() ?? "file"}
+                  </span>
                 </div>
               )}
             </For>

--- a/packages/kilo-ui/src/lucide.ts
+++ b/packages/kilo-ui/src/lucide.ts
@@ -3,4 +3,4 @@
  * Only add icons here that are actually used — esbuild/Vite will
  * tree-shake unused exports but explicit re-exports keep the API small.
  */
-export { WandSparkles } from "lucide-solid"
+export { Paperclip, WandSparkles } from "lucide-solid"

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -558,10 +558,39 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             openLabel: "Attach",
           })
           if (uris && uris.length > 0) {
-            const files = uris.map((uri) => ({
-              url: uri.toString(),
-              name: uri.fsPath.split(/[\\/]/).pop() || uri.fsPath,
-            }))
+            const mimeMap: Record<string, string> = {
+              ".pdf": "application/pdf",
+              ".json": "application/json",
+              ".xml": "application/xml",
+              ".zip": "application/zip",
+              ".gz": "application/gzip",
+              ".tar": "application/x-tar",
+              ".html": "text/html",
+              ".htm": "text/html",
+              ".css": "text/css",
+              ".csv": "text/csv",
+              ".md": "text/markdown",
+              ".svg": "image/svg+xml",
+              ".png": "image/png",
+              ".jpg": "image/jpeg",
+              ".jpeg": "image/jpeg",
+              ".gif": "image/gif",
+              ".webp": "image/webp",
+              ".ico": "image/x-icon",
+              ".mp3": "audio/mpeg",
+              ".wav": "audio/wav",
+              ".mp4": "video/mp4",
+              ".webm": "video/webm",
+              ".wasm": "application/wasm",
+              ".yaml": "text/yaml",
+              ".yml": "text/yaml",
+              ".toml": "text/plain",
+            }
+            const files = uris.map((uri) => {
+              const name = uri.fsPath.split(/[\\/]/).pop() || uri.fsPath
+              const ext = name.includes(".") ? name.slice(name.lastIndexOf(".")).toLowerCase() : ""
+              return { url: uri.toString(), name, mime: mimeMap[ext] || "text/plain" }
+            })
             this.postMessage({ type: "filePickerResult", files })
           }
           break

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -589,7 +589,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             const files = uris.map((uri) => {
               const name = uri.fsPath.split(/[\\/]/).pop() || uri.fsPath
               const ext = name.includes(".") ? name.slice(name.lastIndexOf(".")).toLowerCase() : ""
-              return { url: uri.toString(), name, mime: mimeMap[ext] || "text/plain" }
+              return { url: uri.toString(), name, mime: mimeMap[ext] || "application/octet-stream" }
             })
             this.postMessage({ type: "filePickerResult", files })
           }

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -559,7 +559,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           })
           if (uris && uris.length > 0) {
             const files = uris.map((uri) => ({
-              path: uri.fsPath,
+              url: uri.toString(),
               name: uri.fsPath.split(/[\\/]/).pop() || uri.fsPath,
             }))
             this.postMessage({ type: "filePickerResult", files })

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -550,6 +550,22 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "previewImage":
           this.handlePreviewImage(message.dataUrl, message.filename)
           break
+        case "requestFilePicker": {
+          const uris = await vscode.window.showOpenDialog({
+            canSelectMany: true,
+            canSelectFiles: true,
+            canSelectFolders: false,
+            openLabel: "Attach",
+          })
+          if (uris && uris.length > 0) {
+            const files = uris.map((uri) => ({
+              path: uri.fsPath,
+              name: uri.fsPath.split(/[\\/]/).pop() || uri.fsPath,
+            }))
+            this.postMessage({ type: "filePickerResult", files })
+          }
+          break
+        }
         case "openFile":
           if (message.filePath) {
             this.handleOpenFile(message.filePath, message.line, message.column)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -351,7 +351,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     if (message.type === "filePickerResult") {
       const result = message as import("../../types/messages").FilePickerResultMessage
-      for (const f of result.files) fileAttach.add(`file://${f.path}`, f.name, "text/plain")
+      for (const f of result.files) fileAttach.add(f.url, f.name, "text/plain")
       textareaRef?.focus()
     }
   })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -21,8 +21,9 @@ import { ThinkingSelector } from "../shared/ThinkingSelector"
 import { useFileMention } from "../../hooks/useFileMention"
 import { useSlashCommand } from "../../hooks/useSlashCommand"
 import { useImageAttachments } from "../../hooks/useImageAttachments"
+import { useFileAttachments } from "../../hooks/useFileAttachments"
 import { usePromptHistory } from "../../hooks/usePromptHistory"
-import { WandSparkles } from "@kilocode/kilo-ui/lucide"
+import { Paperclip, WandSparkles } from "@kilocode/kilo-ui/lucide"
 import { fileName, dirName, buildHighlightSegments, atEnd } from "./prompt-input-utils"
 import type { ReviewComment, TextPart } from "../../types/messages"
 import { formatReviewCommentsMarkdown } from "../../utils/review-comment-markdown"
@@ -58,6 +59,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const excluded = worktree ? new Set(["sessions"]) : undefined
   const slash = useSlashCommand(vscode, excluded)
   const imageAttach = useImageAttachments()
+  const fileAttach = useFileAttachments()
   const history = usePromptHistory()
 
   const sessionKey = () => session.currentSessionID() ?? "__new__"
@@ -211,7 +213,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const isBusy = () => session.status() === "busy"
   const isDisabled = () => !server.isConnected()
-  const hasInput = () => text().trim().length > 0 || imageAttach.images().length > 0 || reviewComments().length > 0
+  const hasInput = () =>
+    text().trim().length > 0 ||
+    imageAttach.images().length > 0 ||
+    fileAttach.files().length > 0 ||
+    reviewComments().length > 0
   const canSend = () => hasInput() && !isDisabled() && !props.blocked?.()
   const showStop = () => isBusy() && !hasInput()
   const isAtEnd = () =>
@@ -282,7 +288,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       // Only restore draft if the failure is for the current session and the
       // input is empty (user hasn't started typing something new).
       const target = failed.sessionID ?? "__new__"
-      if (target === sessionKey() && !text().trim() && imageAttach.images().length === 0) {
+      if (
+        target === sessionKey() &&
+        !text().trim() &&
+        imageAttach.images().length === 0 &&
+        fileAttach.files().length === 0
+      ) {
         if (failed.text) {
           setText(failed.text)
           setGhostText("")
@@ -301,6 +312,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             dataUrl: f.url,
           }))
         if (images.length > 0) imageAttach.replace(images)
+        const restored = (failed.files ?? [])
+          .filter((f) => f.url.startsWith("file://"))
+          .map((f) => ({
+            id: crypto.randomUUID(),
+            path: f.url.slice(7),
+            name: f.filename ?? f.url.split("/").pop() ?? "file",
+          }))
+        if (restored.length > 0) fileAttach.replace(restored)
       }
     }
 
@@ -327,6 +346,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       if (result.requestId === `enhance-${enhanceCounter}`) {
         setEnhancing(false)
       }
+    }
+
+    if (message.type === "filePickerResult") {
+      const result = message as import("../../types/messages").FilePickerResultMessage
+      for (const f of result.files) fileAttach.add(f.path, f.name)
+      textareaRef?.focus()
     }
   })
 
@@ -566,14 +591,20 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
 
     const imgs = imageAttach.images()
+    const attached = fileAttach.files()
     const pending = reviewComments()
     const review = pending.length > 0 ? formatReviewCommentsMarkdown(pending) : ""
     const message = draft && review ? `${review}\n\n${draft}` : draft || review
-    if ((!message && imgs.length === 0) || isDisabled() || props.blocked?.()) return
+    if ((!message && imgs.length === 0 && attached.length === 0) || isDisabled() || props.blocked?.()) return
 
     const mentionFiles = mention.parseFileAttachments(draft)
     const imgFiles = imgs.map((img) => ({ mime: img.mime, url: img.dataUrl, filename: img.filename }))
-    const allFiles = [...mentionFiles, ...imgFiles]
+    const pickedFiles = attached.map((f) => ({
+      mime: "text/plain",
+      url: `file://${f.path}`,
+      filename: f.name,
+    }))
+    const allFiles = [...mentionFiles, ...imgFiles, ...pickedFiles]
 
     const sel = session.selected()
     const attachments = allFiles.length > 0 ? allFiles : undefined
@@ -594,6 +625,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     setGhostText("")
     clearReviewComments()
     imageAttach.clear()
+    fileAttach.clear()
     if (debounceTimer) clearTimeout(debounceTimer)
     mention.closeMention()
     slash.close()
@@ -773,6 +805,26 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           </For>
         </div>
       </Show>
+      <Show when={fileAttach.files().length > 0}>
+        <div class="file-attachments">
+          <For each={fileAttach.files()}>
+            {(f) => (
+              <div class="file-attachment" title={f.path}>
+                <FileIcon node={{ path: f.name, type: "file" }} class="file-attachment-icon" />
+                <span class="file-attachment-name">{f.name}</span>
+                <button
+                  type="button"
+                  class="file-attachment-remove"
+                  onClick={() => fileAttach.remove(f.id)}
+                  aria-label={language.t("prompt.attachment.remove")}
+                >
+                  ×
+                </button>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
       <div class="prompt-input-wrapper">
         <div class="prompt-input-ghost-wrapper">
           <div class="prompt-input-highlight-overlay" ref={highlightRef} aria-hidden="true">
@@ -826,6 +878,17 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           </Show>
         </div>
         <div class="prompt-input-hint-actions">
+          <Tooltip value={language.t("prompt.action.attachFile")} placement="top">
+            <Button
+              variant="ghost"
+              size="small"
+              onClick={() => vscode.postMessage({ type: "requestFilePicker" })}
+              disabled={isDisabled()}
+              aria-label={language.t("prompt.action.attachFile")}
+            >
+              <Paperclip size={16} />
+            </Button>
+          </Tooltip>
           <Tooltip value={language.t("prompt.action.enhance")} placement="top">
             <Button
               variant="ghost"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -351,7 +351,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     if (message.type === "filePickerResult") {
       const result = message as import("../../types/messages").FilePickerResultMessage
-      for (const f of result.files) fileAttach.add(f.url, f.name, "text/plain")
+      for (const f of result.files) fileAttach.add(f.url, f.name, f.mime)
       textareaRef?.focus()
     }
   })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -313,11 +313,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           }))
         if (images.length > 0) imageAttach.replace(images)
         const restored = (failed.files ?? [])
-          .filter((f) => f.url.startsWith("file://"))
+          .filter((f) => !f.mime.startsWith("image/"))
           .map((f) => ({
             id: crypto.randomUUID(),
-            path: f.url.slice(7),
+            url: f.url,
             name: f.filename ?? f.url.split("/").pop() ?? "file",
+            mime: f.mime,
           }))
         if (restored.length > 0) fileAttach.replace(restored)
       }
@@ -350,7 +351,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     if (message.type === "filePickerResult") {
       const result = message as import("../../types/messages").FilePickerResultMessage
-      for (const f of result.files) fileAttach.add(f.path, f.name)
+      for (const f of result.files) fileAttach.add(`file://${f.path}`, f.name, "text/plain")
       textareaRef?.focus()
     }
   })
@@ -600,8 +601,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const mentionFiles = mention.parseFileAttachments(draft)
     const imgFiles = imgs.map((img) => ({ mime: img.mime, url: img.dataUrl, filename: img.filename }))
     const pickedFiles = attached.map((f) => ({
-      mime: "text/plain",
-      url: `file://${f.path}`,
+      mime: f.mime,
+      url: f.url,
       filename: f.name,
     }))
     const allFiles = [...mentionFiles, ...imgFiles, ...pickedFiles]
@@ -640,7 +641,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       classList={{ "prompt-input-container--dragging": imageAttach.dragging() }}
       onDragOver={imageAttach.handleDragOver}
       onDragLeave={imageAttach.handleDragLeave}
-      onDrop={imageAttach.handleDrop}
+      onDrop={(e: DragEvent) => {
+        imageAttach.handleDrop(e)
+        fileAttach.handleDrop(e)
+      }}
     >
       <Show when={reviewComments().length > 0}>
         <div class="prompt-review-comments">
@@ -809,7 +813,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         <div class="file-attachments">
           <For each={fileAttach.files()}>
             {(f) => (
-              <div class="file-attachment" title={f.path}>
+              <div class="file-attachment" title={f.name}>
                 <FileIcon node={{ path: f.name, type: "file" }} class="file-attachment-icon" />
                 <span class="file-attachment-name">{f.name}</span>
                 <button

--- a/packages/kilo-vscode/webview-ui/src/hooks/useFileAttachments.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useFileAttachments.ts
@@ -1,0 +1,32 @@
+import { createSignal } from "solid-js"
+
+export interface FileAttachmentItem {
+  id: string
+  path: string
+  name: string
+}
+
+export function useFileAttachments() {
+  const [files, setFiles] = createSignal<FileAttachmentItem[]>([])
+
+  const add = (path: string, name: string) => {
+    const exists = files().some((f) => f.path === path)
+    if (exists) return
+    const item: FileAttachmentItem = {
+      id: crypto.randomUUID(),
+      path,
+      name,
+    }
+    setFiles((prev) => [...prev, item])
+  }
+
+  const remove = (id: string) => {
+    setFiles((prev) => prev.filter((f) => f.id !== id))
+  }
+
+  const clear = () => setFiles([])
+
+  const replace = (next: FileAttachmentItem[]) => setFiles(next)
+
+  return { files, add, remove, clear, replace }
+}

--- a/packages/kilo-vscode/webview-ui/src/hooks/useFileAttachments.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useFileAttachments.ts
@@ -1,21 +1,25 @@
 import { createSignal } from "solid-js"
+import { isAcceptedImageType } from "./image-attachments-utils"
 
 export interface FileAttachmentItem {
   id: string
-  path: string
+  /** Absolute filesystem path (from file picker) OR data: URL (from drag-drop) */
+  url: string
   name: string
+  mime: string
 }
 
 export function useFileAttachments() {
   const [files, setFiles] = createSignal<FileAttachmentItem[]>([])
 
-  const add = (path: string, name: string) => {
-    const exists = files().some((f) => f.path === path)
+  const add = (url: string, name: string, mime: string) => {
+    const exists = files().some((f) => f.url === url)
     if (exists) return
     const item: FileAttachmentItem = {
       id: crypto.randomUUID(),
-      path,
+      url,
       name,
+      mime,
     }
     setFiles((prev) => [...prev, item])
   }
@@ -28,5 +32,21 @@ export function useFileAttachments() {
 
   const replace = (next: FileAttachmentItem[]) => setFiles(next)
 
-  return { files, add, remove, clear, replace }
+  /** Handle dropped files — reads non-image files as data: URLs */
+  const handleDrop = (event: DragEvent) => {
+    const dropped = event.dataTransfer?.files
+    if (!dropped) return
+    for (const file of Array.from(dropped)) {
+      if (isAcceptedImageType(file.type)) continue
+      if (file.size === 0 && !file.type) continue
+      const reader = new FileReader()
+      reader.onload = () => {
+        const mime = file.type || "application/octet-stream"
+        add(reader.result as string, file.name, mime)
+      }
+      reader.readAsDataURL(file)
+    }
+  }
+
+  return { files, add, remove, clear, replace, handleDrop }
 }

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -814,6 +814,69 @@
   border-style: dashed;
 }
 
+/* File Attachments */
+.file-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px 8px 0;
+}
+
+.file-attachment {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+  background: var(--vscode-editor-background, rgba(127, 127, 127, 0.08));
+  font-size: 11px;
+  color: var(--vscode-foreground);
+  max-width: 200px;
+  min-width: 0;
+}
+
+.file-attachment-icon {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+}
+
+.file-attachment-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.file-attachment-remove {
+  width: 14px;
+  height: 14px;
+  border: none;
+  border-radius: 999px;
+  background: var(--surface-inset-base, rgba(127, 127, 127, 0.16));
+  color: var(--text-weak, var(--vscode-descriptionForeground));
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.file-attachment-remove:hover {
+  color: var(--vscode-foreground);
+  background: var(--surface-inset-base-hover, rgba(127, 127, 127, 0.24));
+}
+
+.file-attachment:hover .file-attachment-remove {
+  opacity: 1;
+}
+
 .prompt-input-wrapper {
   display: flex;
   gap: 8px;

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -670,7 +670,7 @@ export interface FileSearchResultMessage {
 
 export interface FilePickerResultMessage {
   type: "filePickerResult"
-  files: Array<{ path: string; name: string }>
+  files: Array<{ url: string; name: string }>
 }
 
 export interface QuestionRequestMessage {

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -668,6 +668,11 @@ export interface FileSearchResultMessage {
   requestId: string
 }
 
+export interface FilePickerResultMessage {
+  type: "filePickerResult"
+  files: Array<{ path: string; name: string }>
+}
+
 export interface QuestionRequestMessage {
   type: "questionRequest"
   question: QuestionRequest
@@ -1218,6 +1223,7 @@ export type ExtensionMessage =
   | AutocompleteSettingsLoadedMessage
   | ChatCompletionResultMessage
   | FileSearchResultMessage
+  | FilePickerResultMessage
   | QuestionRequestMessage
   | QuestionResolvedMessage
   | QuestionErrorMessage
@@ -1813,6 +1819,11 @@ export interface OpenSubAgentViewerRequest {
   title?: string
 }
 
+// Request the extension to open a native file picker dialog
+export interface RequestFilePickerMessage {
+  type: "requestFilePicker"
+}
+
 // Preview an image attachment in VS Code's built-in image viewer
 export interface PreviewImageRequest {
   type: "previewImage"
@@ -1969,6 +1980,7 @@ export type WebviewMessage =
   | RetryConnectionRequest
   | OpenSubAgentViewerRequest
   | PreviewImageRequest
+  | RequestFilePickerMessage
   | SetDefaultBaseBranchRequest
   | FetchMarketplaceDataMessage
   | FilterMarketplaceItemsMessage

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -670,7 +670,7 @@ export interface FileSearchResultMessage {
 
 export interface FilePickerResultMessage {
   type: "filePickerResult"
-  files: Array<{ url: string; name: string }>
+  files: Array<{ url: string; name: string; mime: string }>
 }
 
 export interface QuestionRequestMessage {

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -90,6 +90,47 @@
     }
   }
 
+  [data-slot="user-message-files"] {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 6px;
+    width: fit-content;
+    max-width: min(82%, 64ch);
+    margin-left: auto;
+    margin-bottom: 4px;
+  }
+
+  [data-slot="user-message-file"] {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 8px;
+    background: var(--surface-base);
+    border: 1px solid var(--border-weak-base);
+    font-size: var(--font-size-small, 12px);
+    color: var(--text-base);
+    max-width: 200px;
+    transition: opacity 0.3s ease;
+
+    [data-component="icon"] {
+      flex-shrink: 0;
+      color: var(--icon-weak);
+    }
+
+    &[data-queued] {
+      opacity: 0.6;
+    }
+  }
+
+  [data-slot="user-message-file-name"] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
   [data-slot="user-message-body"] {
     width: fit-content;
     max-width: min(82%, 64ch);


### PR DESCRIPTION
Fixes #6078 

## Context

Implements file attachment support for the VSCode extension chat input, addressing the feature request in #6078. Users can now attach workspace files (markdown plans, config files, etc.) to their chat messages using a native file picker dialog.

## Implementation

- **New hook** (`useFileAttachments`): Manages file attachment state (add/remove/clear/replace) as SolidJS signals, following the same pattern as `useImageAttachments`
- **File picker flow**: A paperclip button in the action bar sends a `requestFilePicker` message to the extension, which opens `vscode.window.showOpenDialog()`. Selected files are sent back via `filePickerResult` and added to the attachment list
- **Message types**: Added `RequestFilePickerMessage` (webview→extension) and `FilePickerResultMessage` (extension→webview) to the type system
- **UI**: Attached files render as removable chips with file icons above the textarea, using the existing `FileIcon` component. File attachments are sent as `file://` URL parts alongside existing image and @mention attachments
- **Resilience**: File attachments are restored from `sendMessageFailed` events, matching the existing pattern for image attachments
- **Lucide icon**: Added `Paperclip` to the `@kilocode/kilo-ui/lucide` re-exports
- **i18n**: All 16 locale files already had `prompt.action.attachFile` and `prompt.attachment.remove` keys with proper translations

## Screenshots

| before | after |
| ------ | ----- |
| No file attachment button | Paperclip button in action bar, file chips above textarea |

## How to Test

1. Open the Kilo sidebar in VS Code
2. Click the paperclip (📎) button in the chat input action bar (between model selectors and enhance button)
3. Select one or more files from the native file picker dialog
4. Verify attached files appear as chips with file icons and filenames above the textarea
5. Hover over a chip to see the remove (×) button; click it to remove the attachment
6. Type a message and press Enter — the files should be sent as part of the message
7. Verify the `hasInput` indicator works correctly when only file attachments are present (no text)

## Get in Touch

thomas07374