### PR TITLE
feat(cli,vscode): add CLI endpoint for MCP server removal

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1415,23 +1415,24 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   private async handleRemoveMcp(name: string): Promise<void> {
-    const workspace = this.getProjectDirectory(this.currentSession?.id)
-    const mp = this.getMarketplace()
-    const stub = { id: name, type: "mcp" as const, name, description: "", url: "", content: "" }
+    if (!this.client) return
 
-    // Remove from both scopes — an MCP could exist in project, global, or both
-    const project = await mp.remove(stub, "project", workspace)
-    const global = await mp.remove(stub, "global", workspace)
+    try {
+      const result = await this.client.kilocode.removeMcp({ name })
 
-    if (project.success || global.success) {
-      // Use global scope when removed from global (or both) so the global
-      // config cache is also invalidated; project scope is a subset.
-      const scope = global.success ? "global" : "project"
-      await this.disposeCliInstance(scope)
-      this.cachedConfigMessage = null
-      await this.fetchAndSendConfig()
-    } else {
-      console.error("[Kilo New] KiloProvider: Failed to remove MCP server:", name)
+      if (result.error) {
+        console.error("[Kilo New] KiloProvider: removeMcp returned error:", result.error)
+        return
+      }
+
+      if (result.data?.project || result.data?.global) {
+        const scope = result.data.global ? "global" : "project"
+        await this.invalidateAfterMarketplaceChange(scope)
+      } else {
+        console.error("[Kilo New] KiloProvider: MCP server not found in config:", name)
+      }
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to remove MCP server:", name, error)
     }
   }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -943,32 +943,34 @@ export namespace MCP {
 
   /**
    * Remove an MCP server from the config by setting it to null (delete sentinel).
-   * This removes it from both project and global config scopes.
-   * Returns true if removed from at least one scope.
+   * Checks the merged config to see if the MCP exists, then removes it from
+   * both project and global config files unconditionally. The null sentinel is
+   * harmless if the key doesn't exist in a particular scope (stripNulls cleans up).
    */
   export async function remove(name: string): Promise<{ project: boolean; global: boolean }> {
     const result = { project: false, global: false }
 
-    // Try to remove from project config first
-    try {
-      const cfg = await Config.get()
-      if (cfg.mcp?.[name]) {
-        await Config.update({ mcp: { [name]: null as any } })
-        result.project = true
-      }
-    } catch (err) {
-      log.debug("failed to remove MCP from project config", { name, err })
+    // Check the merged config (includes migrator entries) to verify the MCP exists
+    const merged = await Config.get()
+    if (!merged.mcp?.[name]) {
+      log.info("MCP server not found in merged config", { name })
+      return result
     }
 
-    // Try to remove from global config
+    // Remove from global config (marketplace installs write here)
     try {
-      const globalCfg = await Config.getGlobal()
-      if (globalCfg.mcp?.[name]) {
-        await Config.updateGlobal({ mcp: { [name]: null as any } }, { dispose: false })
-        result.global = true
-      }
+      await Config.updateGlobal({ mcp: { [name]: null as any } }, { dispose: false })
+      result.global = true
     } catch (err) {
       log.debug("failed to remove MCP from global config", { name, err })
+    }
+
+    // Remove from project config
+    try {
+      await Config.update({ mcp: { [name]: null as any } })
+      result.project = true
+    } catch (err) {
+      log.debug("failed to remove MCP from project config", { name, err })
     }
 
     // Disconnect the client if it exists

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -942,6 +942,53 @@ export namespace MCP {
   }
 
   /**
+   * Remove an MCP server from the config by setting it to null (delete sentinel).
+   * This removes it from both project and global config scopes.
+   * Returns true if removed from at least one scope.
+   */
+  export async function remove(name: string): Promise<{ project: boolean; global: boolean }> {
+    const result = { project: false, global: false }
+
+    // Try to remove from project config first
+    try {
+      const cfg = await Config.get()
+      if (cfg.mcp?.[name]) {
+        await Config.update({ mcp: { [name]: null as any } })
+        result.project = true
+      }
+    } catch (err) {
+      log.debug("failed to remove MCP from project config", { name, err })
+    }
+
+    // Try to remove from global config
+    try {
+      const globalCfg = await Config.getGlobal()
+      if (globalCfg.mcp?.[name]) {
+        await Config.updateGlobal({ mcp: { [name]: null as any } }, { dispose: false })
+        result.global = true
+      }
+    } catch (err) {
+      log.debug("failed to remove MCP from global config", { name, err })
+    }
+
+    // Disconnect the client if it exists
+    try {
+      const s = await state()
+      const client = s.clients[name]
+      if (client) {
+        await client.close()
+        delete s.clients[name]
+        delete s.status[name]
+      }
+    } catch (err) {
+      log.debug("failed to close MCP client during removal", { name, err })
+    }
+
+    log.info("removed MCP server", { name, project: result.project, global: result.global })
+    return result
+  }
+
+  /**
    * Check if an MCP server supports OAuth (remote servers support OAuth by default unless explicitly disabled).
    */
   export async function supportsOAuth(mcpName: string): Promise<boolean> {

--- a/packages/opencode/src/server/routes/kilocode.ts
+++ b/packages/opencode/src/server/routes/kilocode.ts
@@ -6,6 +6,7 @@ import { describeRoute, validator, resolver } from "hono-openapi"
 import z from "zod"
 import { Skill } from "../../skill/skill"
 import { Agent } from "../../agent/agent"
+import { MCP } from "../../mcp"
 import { lazy } from "../../util/lazy"
 import { errors } from "../error"
 
@@ -69,6 +70,36 @@ export const KilocodeRoutes = lazy(() =>
         const { name } = c.req.valid("json")
         await Agent.remove(name)
         return c.json(true)
+      },
+    )
+    .post(
+      "/mcp/remove",
+      describeRoute({
+        summary: "Remove MCP server",
+        description: "Remove an MCP server from config by name. Removes from both project and global scopes.",
+        operationId: "kilocode.removeMcp",
+        responses: {
+          200: {
+            description: "MCP server removed",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ project: z.boolean(), global: z.boolean() })),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator(
+        "json",
+        z.object({
+          name: z.string(),
+        }),
+      ),
+      async (c) => {
+        const { name } = c.req.valid("json")
+        const result = await MCP.remove(name)
+        return c.json(result)
       },
     ),
 )

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -59,6 +59,8 @@ import type {
   KiloCloudSessionsResponses,
   KilocodeRemoveAgentErrors,
   KilocodeRemoveAgentResponses,
+  KilocodeRemoveMcpErrors,
+  KilocodeRemoveMcpResponses,
   KilocodeRemoveSkillErrors,
   KilocodeRemoveSkillResponses,
   KiloFimErrors,
@@ -3040,6 +3042,43 @@ export class Kilocode extends HeyApiClient {
         },
       },
     )
+  }
+
+  /**
+   * Remove MCP server
+   *
+   * Remove an MCP server from config by name. Removes from both project and global scopes.
+   */
+  public removeMcp<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      name?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "name" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<KilocodeRemoveMcpResponses, KilocodeRemoveMcpErrors, ThrowOnError>({
+      url: "/kilocode/mcp/remove",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4488,6 +4488,39 @@ export type KilocodeRemoveAgentResponses = {
 
 export type KilocodeRemoveAgentResponse = KilocodeRemoveAgentResponses[keyof KilocodeRemoveAgentResponses]
 
+export type KilocodeRemoveMcpData = {
+  body?: {
+    name: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/mcp/remove"
+}
+
+export type KilocodeRemoveMcpErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type KilocodeRemoveMcpError = KilocodeRemoveMcpErrors[keyof KilocodeRemoveMcpErrors]
+
+export type KilocodeRemoveMcpResponses = {
+  /**
+   * MCP server removed
+   */
+  200: {
+    project: boolean
+    global: boolean
+  }
+}
+
+export type KilocodeRemoveMcpResponse = KilocodeRemoveMcpResponses[keyof KilocodeRemoveMcpResponses]
+
 export type KiloProfileData = {
   body?: never
   path?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -376,7 +376,7 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.project.initGit({\n  ...\n})"
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.project.initGit({\n  ...\n})"
           }
         ]
       }
@@ -5544,6 +5544,81 @@
           {
             "lang": "js",
             "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.kilocode.removeAgent({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilocode/mcp/remove": {
+      "post": {
+        "operationId": "kilocode.removeMcp",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Remove MCP server",
+        "description": "Remove an MCP server from config by name. Removes from both project and global scopes.",
+        "responses": {
+          "200": {
+            "description": "MCP server removed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "project": {
+                      "type": "boolean"
+                    },
+                    "global": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["project", "global"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": ["name"]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.kilocode.removeMcp({\n  ...\n})"
           }
         ]
       }
@@ -12072,6 +12147,10 @@
               },
               "batch_tool": {
                 "description": "Enable the batch tool",
+                "type": "boolean"
+              },
+              "codebase_search": {
+                "description": "Enable AI-powered codebase search",
                 "type": "boolean"
               },
               "openTelemetry": {


### PR DESCRIPTION
## Summary

- Add a proper CLI endpoint (`POST /kilocode/mcp/remove`) for removing MCP servers from config, following the same pattern as `removeSkill` and `removeAgent`
- The new `MCP.remove()` function removes MCP entries from both project and global config scopes using null delete sentinels, disconnects the running client, and returns which scopes were affected
- Update `KiloProvider.handleRemoveMcp()` to use the new endpoint instead of the marketplace-based removal, addressing review feedback from #7259 about MCPs defined in `opencode.json` not being removable
- Regenerate SDK to include the new `kilocode.removeMcp` method

Iterates on #7259
