### PR TITLE
feat(vscode): keyboard navigation for mode/agent switcher

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -28,12 +28,51 @@ export interface ModeSwitcherBaseProps {
 
 export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
   const [open, setOpen] = createSignal(false)
+  const [focused, setFocused] = createSignal(-1)
+  let listRef: HTMLDivElement | undefined
 
   const hasAgents = () => props.agents.length > 1
 
   function pick(name: string) {
     props.onSelect(name)
     setOpen(false)
+  }
+
+  function focusItem(idx: number) {
+    const items = listRef?.querySelectorAll<HTMLElement>("[role=option]")
+    if (!items) return
+    const clamped = Math.max(0, Math.min(idx, items.length - 1))
+    setFocused(clamped)
+    items[clamped]?.focus()
+  }
+
+  function onOpen(val: boolean) {
+    setOpen(val)
+    if (val) {
+      const idx = props.agents.findIndex((a) => a.name === props.value)
+      requestAnimationFrame(() => focusItem(idx >= 0 ? idx : 0))
+    }
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    const len = props.agents.length
+    const cur = focused()
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      focusItem((cur + 1) % len)
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault()
+      focusItem((cur - 1 + len) % len)
+    } else if (e.key === "Home") {
+      e.preventDefault()
+      focusItem(0)
+    } else if (e.key === "End") {
+      e.preventDefault()
+      focusItem(len - 1)
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault()
+      if (cur >= 0) pick(props.agents[cur].name)
+    }
   }
 
   const triggerLabel = () => {
@@ -50,7 +89,7 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
         placement="top-start"
         fitViewport
         open={open()}
-        onOpenChange={setOpen}
+        onOpenChange={onOpen}
         triggerAs={Button}
         triggerProps={{ variant: "ghost", size: "small" }}
         trigger={
@@ -62,14 +101,16 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
           </>
         }
       >
-        <div class="mode-switcher-list" role="listbox">
+        <div class="mode-switcher-list" role="listbox" ref={listRef} onKeyDown={onKeyDown}>
           <For each={props.agents}>
-            {(agent) => (
+            {(agent, i) => (
               <div
                 class={`mode-switcher-item${agent.name === props.value ? " selected" : ""}`}
                 role="option"
                 aria-selected={agent.name === props.value}
+                tabindex={focused() === i() ? 0 : -1}
                 onClick={() => pick(agent.name)}
+                onFocus={() => setFocused(i())}
               >
                 <span class="mode-switcher-item-name">{agent.name.charAt(0).toUpperCase() + agent.name.slice(1)}</span>
                 <Show when={agent.description}>


### PR DESCRIPTION
## Summary

- Add full keyboard navigation to `ModeSwitcherBase` (used in both sidebar and Agent Manager new-worktree dialog)
- Arrow Up/Down moves focus between items with wrap-around; Home/End jump to first/last
- Enter or Space selects the focused item and closes the popover
- When the popover opens, focus is automatically placed on the currently selected item (falling back to first)
- Uses roving tabindex pattern (`tabindex=0` on focused item, `tabindex=-1` on others)