### PR TITLE
feat(vscode): add team/org account switcher to chat prompt area

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -131,6 +131,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   /** Guard to prevent checkAndShowMigrationWizard running concurrently. */ // legacy-migration
   private migrationCheckInFlight = false // legacy-migration
   private unsubscribeNotificationDismiss: (() => void) | null = null
+  private unsubscribeProfileChange: (() => void) | null = null
   private initConnectionPromise: Promise<void> | null = null
   private webviewMessageDisposable: vscode.Disposable | null = null
 
@@ -863,6 +864,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.unsubscribeEvent?.()
     this.unsubscribeState?.()
     this.unsubscribeNotificationDismiss?.()
+    this.unsubscribeProfileChange?.()
 
     try {
       const workspaceDir = this.getWorkspaceDirectory()
@@ -922,6 +924,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       // Subscribe to notification dismiss broadcast from other KiloProvider instances
       this.unsubscribeNotificationDismiss = this.connectionService.onNotificationDismissed(() => {
         this.fetchAndSendNotifications()
+      })
+
+      // Subscribe to profile change broadcast from other KiloProvider instances
+      this.unsubscribeProfileChange = this.connectionService.onProfileChanged((data) => {
+        this.postMessage({ type: "profileData", data })
       })
 
       // Get current state and push to webview
@@ -2116,7 +2123,21 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     await this.client.global
       .dispose()
-      .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: global.dispose() failed:", e))
+      .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: global.dispose() after org switch failed:", e))
+
+    // Org switch succeeded — refresh profile and providers independently (best-effort)
+    try {
+      const profileResult = await sdkClient.kilo.profile()
+      // Broadcast to all webviews (sidebar, profile tab, agent manager, etc.)
+      this.connectionService.notifyProfileChanged(profileResult.data ?? null)
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to refresh profile after org switch:", error)
+    }
+    try {
+      await this.fetchAndSendProviders()
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to refresh providers after org switch:", error)
+    }
   }
 
   private handlePreviewImage(dataUrl: string, filename: string): void {
@@ -2568,6 +2589,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.unsubscribeEvent?.()
     this.unsubscribeState?.()
     this.unsubscribeNotificationDismiss?.()
+    this.unsubscribeProfileChange?.()
     this.webviewMessageDisposable?.dispose()
     this.trackedSessionIds.clear()
     this.syncedChildSessions.clear()

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2127,7 +2127,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     // Org switch succeeded — refresh profile and providers independently (best-effort)
     try {
-      const profileResult = await sdkClient.kilo.profile()
+      const profileResult = await this.client!.kilo.profile()
       // Broadcast to all webviews (sidebar, profile tab, agent manager, etc.)
       this.connectionService.notifyProfileChanged(profileResult.data ?? null)
     } catch (error) {

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -10,6 +10,7 @@ type SSEEventListener = (event: Event) => void
 type StateListener = (state: ConnectionState) => void
 type SSEEventFilter = (event: Event) => boolean
 type NotificationDismissListener = (notificationId: string) => void
+type ProfileChangeListener = (data: unknown) => void
 
 // Poll /global/health at the same interval as packages/app/src/context/server.tsx.
 // This provides a second detection channel for server death independent of the SSE heartbeat.
@@ -32,6 +33,7 @@ export class KiloConnectionService {
   private readonly eventListeners: Set<SSEEventListener> = new Set()
   private readonly stateListeners: Set<StateListener> = new Set()
   private readonly notificationDismissListeners: Set<NotificationDismissListener> = new Set()
+  private readonly profileChangeListeners: Set<ProfileChangeListener> = new Set()
 
   /**
    * Shared mapping used to resolve session scope for events that don't reliably include a sessionID.
@@ -166,6 +168,25 @@ export class KiloConnectionService {
   }
 
   /**
+   * Subscribe to profile change events broadcast from any KiloProvider. Returns unsubscribe function.
+   */
+  onProfileChanged(listener: ProfileChangeListener): () => void {
+    this.profileChangeListeners.add(listener)
+    return () => {
+      this.profileChangeListeners.delete(listener)
+    }
+  }
+
+  /**
+   * Broadcast a profile change event to all subscribed KiloProvider instances.
+   */
+  notifyProfileChanged(data: unknown): void {
+    for (const listener of this.profileChangeListeners) {
+      listener(data)
+    }
+  }
+
+  /**
    * Subscribe to connection state changes. Returns unsubscribe function.
    */
   onStateChange(listener: StateListener): () => void {
@@ -185,6 +206,7 @@ export class KiloConnectionService {
     this.eventListeners.clear()
     this.stateListeners.clear()
     this.notificationDismissListeners.clear()
+    this.profileChangeListeners.clear()
     this.messageSessionIdsByMessageId.clear()
     this.client = null
     this.sseClient = null

--- a/packages/kilo-vscode/tests/unit/kilo-provider-session-refresh.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-session-refresh.test.ts
@@ -78,6 +78,7 @@ function createConnection(client: ReturnType<typeof createClient>) {
     onEventFiltered: () => () => undefined,
     onStateChange: (_listener: (state: State) => void) => () => undefined,
     onNotificationDismissed: () => () => undefined,
+    onProfileChanged: () => () => undefined,
     getServerInfo: () => ({ port: 12345 }),
     getConnectionState: () => "connected" as const,
     resolveEventSessionId: () => undefined,

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/chat-view-idle-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/chat-view-idle-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81ddefe3d2539c6d211b98593f87f886de0fbeba6ca2c50da773ecd69cba4ac5
-size 17856
+oid sha256:d23a2e49a796acc94f387f7d4cddf783de1c630a3cd3902f3cf558083839b043
+size 17817

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/chat-view-idle-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/chat-view-idle-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d23a2e49a796acc94f387f7d4cddf783de1c630a3cd3902f3cf558083839b043
-size 17817
+oid sha256:81ddefe3d2539c6d211b98593f87f886de0fbeba6ca2c50da773ecd69cba4ac5
+size 17856

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -91,6 +91,9 @@ export const MessageList: Component<MessageListProps> = (props) => {
 
   return (
     <div class="message-list-container">
+      <Show when={isEmpty()}>
+        <AccountSwitcher class="account-switcher-welcome" />
+      </Show>
       <div
         ref={autoScroll.scrollRef}
         onScroll={autoScroll.handleScroll}
@@ -107,7 +110,6 @@ export const MessageList: Component<MessageListProps> = (props) => {
           </Show>
           <Show when={isEmpty()}>
             <div class="message-list-empty">
-              <AccountSwitcher class="account-switcher-welcome" />
               <KiloLogo />
               <p class="kilo-about-text">{language.t("session.messages.welcome")}</p>
               <Show when={recent().length > 0 && props.onSelectSession}>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -21,6 +21,7 @@ import { CloudImportDialog } from "./CloudImportDialog"
 import { FeedbackDialog } from "./FeedbackDialog"
 import { VscodeSessionTurn } from "./VscodeSessionTurn"
 import { RevertBanner } from "./RevertBanner"
+import { AccountSwitcher } from "../shared/AccountSwitcher"
 import { WorkingIndicator } from "../shared/WorkingIndicator"
 import { activeUserMessageID as getActiveUserMessageID } from "../../context/session-queue"
 
@@ -105,6 +106,9 @@ export const MessageList: Component<MessageListProps> = (props) => {
             </div>
           </Show>
           <Show when={isEmpty()}>
+            <div class="message-list-empty-header">
+              <AccountSwitcher class="account-switcher-welcome" />
+            </div>
             <div class="message-list-empty">
               <KiloLogo />
               <p class="kilo-about-text">{language.t("session.messages.welcome")}</p>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -106,10 +106,8 @@ export const MessageList: Component<MessageListProps> = (props) => {
             </div>
           </Show>
           <Show when={isEmpty()}>
-            <div class="message-list-empty-header">
-              <AccountSwitcher class="account-switcher-welcome" />
-            </div>
             <div class="message-list-empty">
+              <AccountSwitcher class="account-switcher-welcome" />
               <KiloLogo />
               <p class="kilo-about-text">{language.t("session.messages.welcome")}</p>
               <Show when={recent().length > 0 && props.onSelectSession}>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -15,6 +15,7 @@ import { useServer } from "../../context/server"
 import { useLanguage } from "../../context/language"
 import { useVSCode } from "../../context/vscode"
 import { useWorktreeMode } from "../../context/worktree-mode"
+import { AccountSwitcher } from "../shared/AccountSwitcher"
 import { ModelSelector } from "../shared/ModelSelector"
 import { ModeSwitcher } from "../shared/ModeSwitcher"
 import { ThinkingSelector } from "../shared/ThinkingSelector"
@@ -758,6 +759,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           <ModeSwitcher />
           <ModelSelector />
           <ThinkingSelector />
+          <AccountSwitcher />
           <Show when={session.hasModelOverride()}>
             <Tooltip value={language.t("prompt.action.resetModel")} placement="top">
               <Button

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -15,7 +15,6 @@ import { useServer } from "../../context/server"
 import { useLanguage } from "../../context/language"
 import { useVSCode } from "../../context/vscode"
 import { useWorktreeMode } from "../../context/worktree-mode"
-import { AccountSwitcher } from "../shared/AccountSwitcher"
 import { ModelSelector } from "../shared/ModelSelector"
 import { ModeSwitcher } from "../shared/ModeSwitcher"
 import { ThinkingSelector } from "../shared/ThinkingSelector"
@@ -759,7 +758,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           <ModeSwitcher />
           <ModelSelector />
           <ThinkingSelector />
-          <AccountSwitcher />
           <Show when={session.hasModelOverride()}>
             <Tooltip value={language.t("prompt.action.resetModel")} placement="top">
               <Button

--- a/packages/kilo-vscode/webview-ui/src/components/shared/AccountSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/AccountSwitcher.tsx
@@ -1,161 +1,128 @@
 /**
  * AccountSwitcher component
- * Compact popover for switching between personal and organization accounts
- * in the prompt input hint bar. Visible only when the user is logged in
- * and belongs to at least one organization.
+ * Dropdown for switching between personal and organization accounts.
+ * Placed in the welcome screen header, matching the legacy OrganizationSelector pattern.
+ * Visible only when the user is logged in and belongs to at least one organization.
  */
 
-import { Component, createSignal, createMemo, createEffect, For, Show } from "solid-js"
-import { Popover } from "@kilocode/kilo-ui/popover"
-import { Button } from "@kilocode/kilo-ui/button"
+import { Component, createSignal, createMemo, createEffect, For, Show, onCleanup } from "solid-js"
 import { useServer } from "../../context/server"
 import { useVSCode } from "../../context/vscode"
 import { useLanguage } from "../../context/language"
 
 const PERSONAL = "personal"
 
-/* Inline SVG icon: single person silhouette (16x16) */
-const PersonIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-    <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm5 7a5 5 0 0 0-10 0h10Z" />
-  </svg>
-)
-
-/* Inline SVG icon: building / team (16x16) */
-const TeamIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-    <path d="M3 1h10v14H3V1Zm2 2v2h2V3H5Zm4 0v2h2V3H9ZM5 7v2h2V7H5Zm4 0v2h2V7H9Zm-2 4v4h2v-4H7Z" />
-  </svg>
-)
-
-export const AccountSwitcher: Component = () => {
+export const AccountSwitcher: Component<{ class?: string }> = (props) => {
   const server = useServer()
   const vscode = useVSCode()
   const language = useLanguage()
   const [open, setOpen] = createSignal(false)
-  const [focused, setFocused] = createSignal(-1)
-  const [switching, setSwitching] = createSignal(false)
-  let listRef: HTMLDivElement | undefined
+  let ref: HTMLDivElement | undefined
 
   const profile = () => server.profileData()
   const orgs = () => profile()?.profile.organizations ?? []
   const visible = () => !!profile() && orgs().length > 0
   const current = () => profile()?.currentOrgId ?? PERSONAL
 
-  // Reset switching state when profile updates (org switch completed)
-  createEffect(() => {
-    profile()
-    setSwitching(false)
-  })
-
-  const label = createMemo(() => {
+  const selected = createMemo(() => {
     const id = current()
-    if (id === PERSONAL) return language.t("profile.personalAccount")
-    const org = orgs().find((o) => o.id === id)
-    return org?.name ?? language.t("profile.personalAccount")
+    if (id === PERSONAL) return undefined
+    return orgs().find((o) => o.id === id)
   })
 
-  const items = createMemo(() => [
-    { id: PERSONAL, name: language.t("profile.personalAccount"), role: "" },
-    ...orgs().map((o) => ({ id: o.id, name: o.name, role: o.role })),
-  ])
+  const label = createMemo(() => selected()?.name ?? language.t("profile.personalAccount"))
 
-  function pick(id: string) {
-    if (id === current()) {
+  function pick(org: { id: string; name: string; role: string } | null) {
+    if (org?.id === current() || (!org && current() === PERSONAL)) {
       setOpen(false)
       return
     }
-    setSwitching(true)
     vscode.postMessage({
       type: "setOrganization",
-      organizationId: id === PERSONAL ? null : id,
+      organizationId: org?.id ?? null,
     })
     setOpen(false)
   }
 
-  function focusItem(idx: number) {
-    const nodes = listRef?.querySelectorAll<HTMLElement>("[role=option]")
-    if (!nodes) return
-    const clamped = Math.max(0, Math.min(idx, nodes.length - 1))
-    setFocused(clamped)
-    nodes[clamped]?.focus()
-  }
+  // Close on Escape or outside click
+  createEffect(() => {
+    if (!open()) return
 
-  function onOpen(val: boolean) {
-    setOpen(val)
-    if (val) {
-      const idx = items().findIndex((i) => i.id === current())
-      requestAnimationFrame(() => focusItem(idx >= 0 ? idx : 0))
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false)
     }
-  }
+    const onMouse = (e: MouseEvent) => {
+      if (ref && !ref.contains(e.target as Node)) setOpen(false)
+    }
 
-  function onKeyDown(e: KeyboardEvent) {
-    const len = items().length
-    const cur = focused()
-    if (e.key === "ArrowDown") {
-      e.preventDefault()
-      focusItem((cur + 1) % len)
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault()
-      focusItem((cur - 1 + len) % len)
-    } else if (e.key === "Home") {
-      e.preventDefault()
-      focusItem(0)
-    } else if (e.key === "End") {
-      e.preventDefault()
-      focusItem(len - 1)
-    } else if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault()
-      if (cur >= 0) pick(items()[cur].id)
-    }
-  }
+    window.addEventListener("keydown", onKey)
+    window.addEventListener("mousedown", onMouse)
+    onCleanup(() => {
+      window.removeEventListener("keydown", onKey)
+      window.removeEventListener("mousedown", onMouse)
+    })
+  })
 
   return (
     <Show when={visible()}>
-      <Popover
-        placement="top-start"
-        fitViewport
-        open={open()}
-        onOpenChange={onOpen}
-        triggerAs={Button}
-        triggerProps={{ variant: "ghost", size: "small", disabled: switching() }}
-        trigger={
-          <>
-            <Show when={current() !== PERSONAL} fallback={<PersonIcon />}>
-              <TeamIcon />
+      <div class={`account-switcher ${props.class ?? ""}`} ref={ref}>
+        <button
+          type="button"
+          class="account-switcher-trigger"
+          onClick={() => setOpen((v) => !v)}
+          aria-haspopup="listbox"
+          aria-expanded={open()}
+          title={
+            selected()
+              ? `${selected()!.name} – ${selected()!.role.toUpperCase()}`
+              : language.t("profile.personalAccount")
+          }
+        >
+          <span class="account-switcher-label">{label()}</span>
+          <span class="account-switcher-badges">
+            <Show when={selected()}>
+              <span class="account-switcher-role">{selected()!.role.toUpperCase()}</span>
             </Show>
-            <span class="account-switcher-label">{label()}</span>
-            <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor" style={{ "flex-shrink": "0" }}>
-              <path d="M8 4l4 5H4l4-5z" />
+            <svg
+              class={`account-switcher-chevron ${open() ? "open" : ""}`}
+              viewBox="0 0 12 12"
+              fill="none"
+              stroke="rgb(156 163 175)"
+              aria-hidden="true"
+            >
+              <path d="M3 4.5L6 7.5L9 4.5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
             </svg>
-          </>
-        }
-      >
-        <div class="account-switcher-list" role="listbox" ref={listRef} onKeyDown={onKeyDown}>
-          <For each={items()}>
-            {(item, i) => (
-              <div
-                class={`account-switcher-item${item.id === current() ? " selected" : ""}`}
-                role="option"
-                aria-selected={item.id === current()}
-                tabindex={focused() === i() ? 0 : -1}
-                onClick={() => pick(item.id)}
-                onFocus={() => setFocused(i())}
-              >
-                <Show when={item.id === PERSONAL} fallback={<TeamIcon />}>
-                  <PersonIcon />
-                </Show>
-                <div class="account-switcher-item-text">
-                  <span class="account-switcher-item-name">{item.name}</span>
-                  <Show when={item.role}>
-                    <span class="account-switcher-item-role">{item.role}</span>
-                  </Show>
-                </div>
-              </div>
-            )}
-          </For>
-        </div>
-      </Popover>
+          </span>
+        </button>
+
+        <Show when={open()}>
+          <div class="account-switcher-dropdown" role="listbox" aria-label="Account">
+            <button
+              type="button"
+              role="option"
+              aria-selected={current() === PERSONAL}
+              class="account-switcher-item"
+              onClick={() => pick(null)}
+            >
+              <span class="account-switcher-item-name">{language.t("profile.personalAccount")}</span>
+            </button>
+            <For each={orgs()}>
+              {(org) => (
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={current() === org.id}
+                  class="account-switcher-item"
+                  onClick={() => pick(org)}
+                >
+                  <span class="account-switcher-item-name">{org.name}</span>
+                  <span class="account-switcher-role">{org.role.toUpperCase()}</span>
+                </button>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
     </Show>
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/components/shared/AccountSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/AccountSwitcher.tsx
@@ -1,0 +1,161 @@
+/**
+ * AccountSwitcher component
+ * Compact popover for switching between personal and organization accounts
+ * in the prompt input hint bar. Visible only when the user is logged in
+ * and belongs to at least one organization.
+ */
+
+import { Component, createSignal, createMemo, createEffect, For, Show } from "solid-js"
+import { Popover } from "@kilocode/kilo-ui/popover"
+import { Button } from "@kilocode/kilo-ui/button"
+import { useServer } from "../../context/server"
+import { useVSCode } from "../../context/vscode"
+import { useLanguage } from "../../context/language"
+
+const PERSONAL = "personal"
+
+/* Inline SVG icon: single person silhouette (16x16) */
+const PersonIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm5 7a5 5 0 0 0-10 0h10Z" />
+  </svg>
+)
+
+/* Inline SVG icon: building / team (16x16) */
+const TeamIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <path d="M3 1h10v14H3V1Zm2 2v2h2V3H5Zm4 0v2h2V3H9ZM5 7v2h2V7H5Zm4 0v2h2V7H9Zm-2 4v4h2v-4H7Z" />
+  </svg>
+)
+
+export const AccountSwitcher: Component = () => {
+  const server = useServer()
+  const vscode = useVSCode()
+  const language = useLanguage()
+  const [open, setOpen] = createSignal(false)
+  const [focused, setFocused] = createSignal(-1)
+  const [switching, setSwitching] = createSignal(false)
+  let listRef: HTMLDivElement | undefined
+
+  const profile = () => server.profileData()
+  const orgs = () => profile()?.profile.organizations ?? []
+  const visible = () => !!profile() && orgs().length > 0
+  const current = () => profile()?.currentOrgId ?? PERSONAL
+
+  // Reset switching state when profile updates (org switch completed)
+  createEffect(() => {
+    profile()
+    setSwitching(false)
+  })
+
+  const label = createMemo(() => {
+    const id = current()
+    if (id === PERSONAL) return language.t("profile.personalAccount")
+    const org = orgs().find((o) => o.id === id)
+    return org?.name ?? language.t("profile.personalAccount")
+  })
+
+  const items = createMemo(() => [
+    { id: PERSONAL, name: language.t("profile.personalAccount"), role: "" },
+    ...orgs().map((o) => ({ id: o.id, name: o.name, role: o.role })),
+  ])
+
+  function pick(id: string) {
+    if (id === current()) {
+      setOpen(false)
+      return
+    }
+    setSwitching(true)
+    vscode.postMessage({
+      type: "setOrganization",
+      organizationId: id === PERSONAL ? null : id,
+    })
+    setOpen(false)
+  }
+
+  function focusItem(idx: number) {
+    const nodes = listRef?.querySelectorAll<HTMLElement>("[role=option]")
+    if (!nodes) return
+    const clamped = Math.max(0, Math.min(idx, nodes.length - 1))
+    setFocused(clamped)
+    nodes[clamped]?.focus()
+  }
+
+  function onOpen(val: boolean) {
+    setOpen(val)
+    if (val) {
+      const idx = items().findIndex((i) => i.id === current())
+      requestAnimationFrame(() => focusItem(idx >= 0 ? idx : 0))
+    }
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    const len = items().length
+    const cur = focused()
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      focusItem((cur + 1) % len)
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault()
+      focusItem((cur - 1 + len) % len)
+    } else if (e.key === "Home") {
+      e.preventDefault()
+      focusItem(0)
+    } else if (e.key === "End") {
+      e.preventDefault()
+      focusItem(len - 1)
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault()
+      if (cur >= 0) pick(items()[cur].id)
+    }
+  }
+
+  return (
+    <Show when={visible()}>
+      <Popover
+        placement="top-start"
+        fitViewport
+        open={open()}
+        onOpenChange={onOpen}
+        triggerAs={Button}
+        triggerProps={{ variant: "ghost", size: "small", disabled: switching() }}
+        trigger={
+          <>
+            <Show when={current() !== PERSONAL} fallback={<PersonIcon />}>
+              <TeamIcon />
+            </Show>
+            <span class="account-switcher-label">{label()}</span>
+            <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor" style={{ "flex-shrink": "0" }}>
+              <path d="M8 4l4 5H4l4-5z" />
+            </svg>
+          </>
+        }
+      >
+        <div class="account-switcher-list" role="listbox" ref={listRef} onKeyDown={onKeyDown}>
+          <For each={items()}>
+            {(item, i) => (
+              <div
+                class={`account-switcher-item${item.id === current() ? " selected" : ""}`}
+                role="option"
+                aria-selected={item.id === current()}
+                tabindex={focused() === i() ? 0 : -1}
+                onClick={() => pick(item.id)}
+                onFocus={() => setFocused(i())}
+              >
+                <Show when={item.id === PERSONAL} fallback={<TeamIcon />}>
+                  <PersonIcon />
+                </Show>
+                <div class="account-switcher-item-text">
+                  <span class="account-switcher-item-name">{item.name}</span>
+                  <Show when={item.role}>
+                    <span class="account-switcher-item-role">{item.role}</span>
+                  </Show>
+                </div>
+              </div>
+            )}
+          </For>
+        </div>
+      </Popover>
+    </Show>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/src/components/shared/AccountSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/AccountSwitcher.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Component, createSignal, createMemo, createEffect, For, Show, onCleanup } from "solid-js"
+import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { useServer } from "../../context/server"
 import { useVSCode } from "../../context/vscode"
 import { useLanguage } from "../../context/language"
@@ -17,6 +18,7 @@ export const AccountSwitcher: Component<{ class?: string }> = (props) => {
   const vscode = useVSCode()
   const language = useLanguage()
   const [open, setOpen] = createSignal(false)
+  const [switching, setSwitching] = createSignal(false)
   let ref: HTMLDivElement | undefined
 
   const profile = () => server.profileData()
@@ -32,11 +34,18 @@ export const AccountSwitcher: Component<{ class?: string }> = (props) => {
 
   const label = createMemo(() => selected()?.name ?? language.t("profile.personalAccount"))
 
+  // Clear switching state when profile data changes (switch completed or failed)
+  createEffect(() => {
+    profile()
+    setSwitching(false)
+  })
+
   function pick(org: { id: string; name: string; role: string } | null) {
     if (org?.id === current() || (!org && current() === PERSONAL)) {
       setOpen(false)
       return
     }
+    setSwitching(true)
     vscode.postMessage({
       type: "setOrganization",
       organizationId: org?.id ?? null,
@@ -68,34 +77,45 @@ export const AccountSwitcher: Component<{ class?: string }> = (props) => {
       <div class={`account-switcher ${props.class ?? ""}`} ref={ref}>
         <button
           type="button"
-          class="account-switcher-trigger"
-          onClick={() => setOpen((v) => !v)}
+          class={`account-switcher-trigger ${switching() ? "account-switcher-switching" : ""}`}
+          onClick={() => !switching() && setOpen((v) => !v)}
+          disabled={switching()}
           aria-haspopup="listbox"
           aria-expanded={open()}
+          aria-busy={switching()}
           title={
-            selected()
-              ? `${selected()!.name} – ${selected()!.role.toUpperCase()}`
-              : language.t("profile.personalAccount")
+            switching()
+              ? language.t("profile.switchingAccount")
+              : selected()
+                ? `${selected()!.name} – ${selected()!.role.toUpperCase()}`
+                : language.t("profile.personalAccount")
           }
         >
           <span class="account-switcher-label">{label()}</span>
           <span class="account-switcher-badges">
-            <Show when={selected()}>
+            <Show when={selected() && !switching()}>
               <span class="account-switcher-role">{selected()!.role.toUpperCase()}</span>
             </Show>
-            <svg
-              class={`account-switcher-chevron ${open() ? "open" : ""}`}
-              viewBox="0 0 12 12"
-              fill="none"
-              stroke="rgb(156 163 175)"
-              aria-hidden="true"
+            <Show
+              when={switching()}
+              fallback={
+                <svg
+                  class={`account-switcher-chevron ${open() ? "open" : ""}`}
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  stroke="rgb(156 163 175)"
+                  aria-hidden="true"
+                >
+                  <path d="M3 4.5L6 7.5L9 4.5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              }
             >
-              <path d="M3 4.5L6 7.5L9 4.5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-            </svg>
+              <Spinner style={{ width: "12px", height: "12px" }} />
+            </Show>
           </span>
         </button>
 
-        <Show when={open()}>
+        <Show when={open() && !switching()}>
           <div class="account-switcher-dropdown" role="listbox" aria-label="Account">
             <button
               type="button"

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1113,6 +1113,7 @@ export const dict = {
   "settings.providers.notSet": "غير محدد (استخدام الافتراضي)",
   "dialog.model.notSet": "غير محدد",
   "profile.personalAccount": "حساب شخصي",
+  "profile.switchingAccount": "جارٍ تبديل الحساب…",
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/ar.ts
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1136,6 +1136,7 @@ export const dict = {
   "settings.providers.notSet": "Não definido (usar padrão do servidor)",
   "dialog.model.notSet": "Não definido",
   "profile.personalAccount": "Conta pessoal",
+  "profile.switchingAccount": "Trocando de conta…",
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/br.ts
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1135,6 +1135,7 @@ export const dict = {
   "settings.providers.notSet": "Nije postavljeno (koristi zadano servera)",
   "dialog.model.notSet": "Nije postavljeno",
   "profile.personalAccount": "Osobni račun",
+  "profile.switchingAccount": "Prebacivanje računa…",
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/bs.ts
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1127,6 +1127,7 @@ export const dict = {
   "settings.providers.notSet": "Ikke angivet (brug serverstandard)",
   "dialog.model.notSet": "Ikke angivet",
   "profile.personalAccount": "Personlig konto",
+  "profile.switchingAccount": "Skifter konto…",
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/da.ts
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1148,6 +1148,7 @@ export const dict = {
   "settings.providers.notSet": "Nicht festgelegt (Server-Standard verwenden)",
   "dialog.model.notSet": "Nicht festgelegt",
   "profile.personalAccount": "Persönliches Konto",
+  "profile.switchingAccount": "Konto wird gewechselt…",
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/de.ts
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1140,6 +1140,7 @@ export const dict = {
   "dialog.model.notSet": "Not set",
 
   "profile.personalAccount": "Personal Account",
+  "profile.switchingAccount": "Switching account…",
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/en.ts
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1139,6 +1139,7 @@ export const dict = {
   "settings.providers.notSet": "No establecido (usar predeterminado del servidor)",
   "dialog.model.notSet": "No establecido",
   "profile.personalAccount": "Cuenta personal",
+  "profile.switchingAccount": "Cambiando de cuenta…",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/es.ts
 
   "question.summary": "{{n}} de {{total}} preguntas",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1151,6 +1151,7 @@ export const dict = {
   "settings.providers.notSet": "Non défini (utiliser la valeur par défaut du serveur)",
   "dialog.model.notSet": "Non défini",
   "profile.personalAccount": "Compte personnel",
+  "profile.switchingAccount": "Changement de compte…",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/fr.ts
 
   "question.summary": "{{n}} sur {{total}} questions",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1126,6 +1126,7 @@ export const dict = {
   "settings.providers.notSet": "未設定（サーバーのデフォルトを使用）",
   "dialog.model.notSet": "未設定",
   "profile.personalAccount": "個人アカウント",
+  "profile.switchingAccount": "アカウントを切り替え中…",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/ja.ts
 
   "question.summary": "{{total}} 問中 {{n}} 問目",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1117,6 +1117,7 @@ export const dict = {
   "settings.providers.notSet": "설정되지 않음 (서버 기본값 사용)",
   "dialog.model.notSet": "설정되지 않음",
   "profile.personalAccount": "개인 계정",
+  "profile.switchingAccount": "계정 전환 중…",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/ko.ts
 
   "question.summary": "{{total}}개 질문 중 {{n}}번째",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1156,6 +1156,7 @@ export const dict = {
   "dialog.model.notSet": "Niet ingesteld",
 
   "profile.personalAccount": "Persoonlijk Account",
+  "profile.switchingAccount": "Account wisselen…",
 
   // Agent Manager strings live in webview-ui/agent-manager/i18n/en.ts
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1129,6 +1129,7 @@ export const dict = {
   "settings.providers.notSet": "Ikke angitt (bruk serverstandard)",
   "dialog.model.notSet": "Ikke angitt",
   "profile.personalAccount": "Personlig konto",
+  "profile.switchingAccount": "Bytter konto…",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/no.ts
 
   "question.summary": "{{n}} av {{total}} spørsmål",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1134,6 +1134,7 @@ export const dict = {
   "settings.providers.notSet": "Nie ustawiono (użyj domyślnego serwera)",
   "dialog.model.notSet": "Nie ustawiono",
   "profile.personalAccount": "Konto osobiste",
+  "profile.switchingAccount": "Przełączanie konta…",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/pl.ts
 
   "question.summary": "{{n}} z {{total}} pytań",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1133,6 +1133,7 @@ export const dict = {
   "settings.providers.notSet": "Не задано (использовать значение сервера по умолчанию)",
   "dialog.model.notSet": "Не задано",
   "profile.personalAccount": "Личный аккаунт",
+  "profile.switchingAccount": "Переключение аккаунта…",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/ru.ts
 
   "question.summary": "{{n}} из {{total}} вопросов",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1113,6 +1113,7 @@ export const dict = {
   "settings.providers.notSet": "ไม่ได้ตั้งค่า (ใช้ค่าเริ่มต้นของเซิร์ฟเวอร์)",
   "dialog.model.notSet": "ไม่ได้ตั้งค่า",
   "profile.personalAccount": "บัญชีส่วนตัว",
+  "profile.switchingAccount": "กำลังสลับบัญชี…",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/th.ts
 
   "question.summary": "{{n}} จาก {{total}} คำถาม",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1098,6 +1098,7 @@ export const dict = {
   "settings.providers.notSet": "未设置（使用服务器默认值）",
   "dialog.model.notSet": "未设置",
   "profile.personalAccount": "个人账户",
+  "profile.switchingAccount": "正在切换账户…",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/zh.ts
 
   "question.summary": "第 {{n}} / {{total}} 个问题",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1099,6 +1099,7 @@ export const dict = {
   "settings.providers.notSet": "未設定（使用伺服器預設值）",
   "dialog.model.notSet": "未設定",
   "profile.personalAccount": "個人帳戶",
+  "profile.switchingAccount": "正在切換帳戶…",
   // Agent Manager strings live in webview-ui/agent-manager/i18n/zht.ts
 
   "question.summary": "第 {{n}} / {{total}} 個問題",

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1609,7 +1609,13 @@
     border-color 150ms;
 }
 
-.account-switcher-trigger:hover {
+.account-switcher-switching {
+  opacity: 0.6;
+  pointer-events: none;
+  cursor: default;
+}
+
+.account-switcher-trigger:hover:not(:disabled) {
   opacity: 1;
   background: rgba(255, 255, 255, 0.03);
   border-color: rgba(255, 255, 255, 0.15);

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -210,6 +210,7 @@
 }
 
 .message-list-empty {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1576,21 +1577,15 @@
    Account Switcher (welcome screen header)
    ============================================ */
 
-.message-list-empty-header {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  width: 100%;
-  padding: 8px 12px 0;
-}
-
 .account-switcher {
   position: relative;
 }
 
 .account-switcher-welcome {
+  position: absolute;
+  top: 0;
+  right: 0;
   width: 160px;
-  flex-shrink: 0;
 }
 
 .account-switcher-trigger {

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1573,6 +1573,71 @@
 }
 
 /* ============================================
+   Account Switcher (uses kilo-ui Popover)
+   ============================================ */
+
+.account-switcher-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 120px;
+}
+
+.account-switcher-list {
+  max-height: var(--kb-popper-content-available-height, 280px);
+  overflow-y: auto;
+}
+
+.account-switcher-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: var(--vscode-font-size);
+}
+
+.account-switcher-item:hover {
+  background: var(--surface-interactive-hover, var(--vscode-list-hoverBackground));
+}
+
+.account-switcher-item.selected {
+  background: var(
+    --surface-interactive-active,
+    var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground))
+  );
+  color: var(--text-on-interactive-base, var(--vscode-list-activeSelectionForeground));
+}
+
+.account-switcher-item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.account-switcher-item-name {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.account-switcher-item-role {
+  font-size: 11px;
+  color: var(--text-weak, var(--vscode-descriptionForeground));
+  text-transform: capitalize;
+}
+
+.account-switcher-item.selected .account-switcher-item-name {
+  font-weight: 600;
+}
+
+.account-switcher-item.selected .account-switcher-item-role {
+  color: inherit;
+}
+
+/* ============================================
    Permission Dock (VS Code overrides)
    ============================================ */
 
@@ -2634,7 +2699,8 @@ body.vscode-high-contrast-light {
   .slash-command-item--active,
   .model-selector-item.active,
   .thinking-selector-item.selected,
-  .mode-switcher-item.selected {
+  .mode-switcher-item.selected,
+  .account-switcher-item.selected {
     outline: 1px solid var(--vscode-contrastBorder, transparent);
     outline-offset: -1px;
   }

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1573,68 +1573,129 @@
 }
 
 /* ============================================
-   Account Switcher (uses kilo-ui Popover)
+   Account Switcher (welcome screen header)
    ============================================ */
+
+.message-list-empty-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
+  padding: 8px 12px 0;
+}
+
+.account-switcher {
+  position: relative;
+}
+
+.account-switcher-welcome {
+  width: 160px;
+  flex-shrink: 0;
+}
+
+.account-switcher-trigger {
+  width: 100%;
+  cursor: pointer;
+  border: 1px solid var(--vscode-dropdown-border);
+  background: var(--vscode-dropdown-background);
+  color: var(--vscode-dropdown-foreground);
+  border-radius: 4px;
+  padding: 4px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  font-family: inherit;
+  font-size: var(--vscode-font-size);
+  opacity: 0.9;
+  transition:
+    opacity 150ms,
+    background 150ms,
+    border-color 150ms;
+}
+
+.account-switcher-trigger:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.account-switcher-trigger:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
 
 .account-switcher-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 120px;
 }
 
-.account-switcher-list {
-  max-height: var(--kb-popper-content-available-height, 280px);
+.account-switcher-badges {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.account-switcher-role {
+  border-radius: 9999px;
+  padding: 1px 6px;
+  font-size: 10px;
+  letter-spacing: 0.3px;
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}
+
+.account-switcher-chevron {
+  width: 12px;
+  height: 12px;
+  transition: transform 150ms;
+}
+
+.account-switcher-chevron.open {
+  transform: rotate(180deg);
+}
+
+.account-switcher-dropdown {
+  position: absolute;
+  z-index: 20;
+  margin-top: 4px;
+  right: 0;
+  width: max-content;
+  min-width: 100%;
+  max-height: 240px;
   overflow-y: auto;
+  border-radius: 4px;
+  border: 1px solid var(--vscode-dropdown-border);
+  background: var(--vscode-dropdown-background);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
 .account-switcher-item {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
+  width: 100%;
   cursor: pointer;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  color: var(--vscode-foreground);
+  font-family: inherit;
   font-size: var(--vscode-font-size);
+  text-align: left;
 }
 
 .account-switcher-item:hover {
-  background: var(--surface-interactive-hover, var(--vscode-list-hoverBackground));
-}
-
-.account-switcher-item.selected {
-  background: var(
-    --surface-interactive-active,
-    var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground))
-  );
-  color: var(--text-on-interactive-base, var(--vscode-list-activeSelectionForeground));
-}
-
-.account-switcher-item-text {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  min-width: 0;
+  background: var(--vscode-list-hoverBackground);
 }
 
 .account-switcher-item-name {
-  font-weight: 500;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.account-switcher-item-role {
-  font-size: 11px;
-  color: var(--text-weak, var(--vscode-descriptionForeground));
-  text-transform: capitalize;
-}
-
-.account-switcher-item.selected .account-switcher-item-name {
-  font-weight: 600;
-}
-
-.account-switcher-item.selected .account-switcher-item-role {
-  color: inherit;
+  white-space: nowrap;
 }
 
 /* ============================================
@@ -2699,8 +2760,7 @@ body.vscode-high-contrast-light {
   .slash-command-item--active,
   .model-selector-item.active,
   .thinking-selector-item.selected,
-  .mode-switcher-item.selected,
-  .account-switcher-item.selected {
+  .mode-switcher-item.selected {
     outline: 1px solid var(--vscode-contrastBorder, transparent);
     outline-offset: -1px;
   }

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -210,7 +210,6 @@
 }
 
 .message-list-empty {
-  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1583,9 +1582,10 @@
 
 .account-switcher-welcome {
   position: absolute;
-  top: 0;
-  right: 0;
+  top: 12px;
+  right: 12px;
   width: 160px;
+  z-index: 10;
 }
 
 .account-switcher-trigger {


### PR DESCRIPTION
## Summary
- Adds an `AccountSwitcher` popover dropdown to the chat prompt hint bar (next to Mode, Model, and Thinking selectors)
- Shows the current account (Personal Account or organization name) and allows switching between accounts directly from the chat window
- Only visible when the user is logged in and belongs to at least one organization
- Reuses the same `setOrganization` message protocol and `profileData` state used by the Profile view

## Implementation
- **New component**: `AccountSwitcher.tsx` — compact Popover-based selector following the same pattern as `ModeSwitcher`
- **PromptInput integration**: Added to the hint-selectors row in the prompt input area
- **CSS**: Matching styles in `chat.css` including high-contrast theme support
- Uses existing i18n string `profile.personalAccount`

## How it works
- Reads user profile and organizations from `useServer().profileData()`
- Posts `setOrganization` message to extension host on selection change
- Displays person icon for personal account, building icon for organizations
- Shows organization role as secondary text in the dropdown

Closes #7282

<img width="982" height="1274" alt="CleanShot 2026-03-23 at 15 08 42@2x" src="https://github.com/user-attachments/assets/ce51b8db-30ad-49d0-a701-65bb5e8f40fd" />
