### PR TITLE
fix(vscode): fix @-mention boundary matching and dedup selectMentionFile

### DIFF
--- a/packages/kilo-vscode/tests/unit/file-mention-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/file-mention-utils.test.ts
@@ -54,6 +54,25 @@ describe("syncMentionedPaths", () => {
     syncMentionedPaths(paths, "no references")
     expect(paths.has("foo.ts")).toBe(true)
   })
+
+  it("does not false-match when a shorter path is prefix of a longer one", () => {
+    const paths = new Set(["src/a.ts", "src/a.tsx"])
+    const result = syncMentionedPaths(paths, "@src/a.tsx only")
+    expect(result.has("src/a.tsx")).toBe(true)
+    expect(result.has("src/a.ts")).toBe(false)
+  })
+
+  it("matches @path at end of text (no trailing space)", () => {
+    const paths = new Set(["foo.ts"])
+    const result = syncMentionedPaths(paths, "check @foo.ts")
+    expect(result.has("foo.ts")).toBe(true)
+  })
+
+  it("matches @path at start of text", () => {
+    const paths = new Set(["foo.ts"])
+    const result = syncMentionedPaths(paths, "@foo.ts is important")
+    expect(result.has("foo.ts")).toBe(true)
+  })
 })
 
 describe("buildTextAfterMentionSelect", () => {

--- a/packages/kilo-vscode/webview-ui/src/hooks/file-mention-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/file-mention-utils.ts
@@ -3,13 +3,26 @@ import type { FileAttachment } from "../types/messages"
 export const AT_PATTERN = /(?:^|\s)@(\S*)$/
 
 /**
+ * Escape special regex characters in a string so it can be used in a RegExp.
+ */
+function escape(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+/**
  * Sync the set of mentioned paths against the current text.
  * Removes any paths that are no longer present in the text as @path mentions.
+ *
+ * Uses boundary-aware matching (whitespace or start/end of string) and processes
+ * paths longest-first to prevent `@src/a.ts` from false-matching `@src/a.tsx`.
  */
 export function syncMentionedPaths(prev: Set<string>, text: string): Set<string> {
   const next = new Set<string>()
-  for (const path of prev) {
-    if (text.includes(`@${path}`)) next.add(path)
+  // Sort longest-first so e.g. "src/a.tsx" is checked before "src/a.ts"
+  const sorted = [...prev].sort((a, b) => b.length - a.length)
+  for (const path of sorted) {
+    const pattern = new RegExp(`(?:^|\\s)@${escape(path)}(?:\\s|$)`)
+    if (pattern.test(text)) next.add(path)
   }
   return next
 }

--- a/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
@@ -1,7 +1,12 @@
 import { createEffect, createSignal, onCleanup } from "solid-js"
 import type { Accessor } from "solid-js"
 import type { FileAttachment, WebviewMessage, ExtensionMessage } from "../types/messages"
-import { AT_PATTERN, syncMentionedPaths as _syncMentionedPaths, buildFileAttachments } from "./file-mention-utils"
+import {
+  AT_PATTERN,
+  syncMentionedPaths as _syncMentionedPaths,
+  buildTextAfterMentionSelect,
+  buildFileAttachments,
+} from "./file-mention-utils"
 
 const FILE_SEARCH_DEBOUNCE_MS = 150
 
@@ -92,16 +97,13 @@ export function useFileMention(vscode: VSCodeContext): FileMention {
     const before = val.substring(0, cursor)
     const after = val.substring(cursor)
 
-    const replaced = before.replace(AT_PATTERN, (match) => {
-      const prefix = match.startsWith(" ") ? " " : ""
-      return `${prefix}@${path}`
-    })
-    const newText = replaced + after
-    textarea.value = newText
-    setText(newText)
+    const result = buildTextAfterMentionSelect(before, after, path)
+    textarea.value = result
+    setText(result)
 
-    const newCursor = replaced.length
-    textarea.setSelectionRange(newCursor, newCursor)
+    // Position cursor right after the inserted @path
+    const pos = result.length - after.length
+    textarea.setSelectionRange(pos, pos)
     textarea.focus()
 
     setMentionedPaths((prev) => new Set([...prev, path]))


### PR DESCRIPTION
## Summary

Fix @-mention edge cases in the chat input's file mention tracking and selection.

## Changes

- **`syncMentionedPaths`**: Replace naive `text.includes(@${path})` with boundary-aware regex matching. Paths are processed longest-first to prevent `@src/a.ts` from false-matching `@src/a.tsx`.
- **`selectMentionFile`**: Call `buildTextAfterMentionSelect()` instead of duplicating the same `AT_PATTERN` replace logic inline.
- **Tests**: Add cases for prefix-overlapping paths (`src/a.ts` vs `src/a.tsx`) and boundary matching (start/end of text).

## Testing

- All 21 file-mention-utils tests pass (3 new)
- Build passes
