### PR TITLE
feat(dev): automate missing translations generation

### DIFF
--- a/.kilocode/skills/add-translations/SKILL.md
+++ b/.kilocode/skills/add-translations/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: add-translations
+description: Add missing translations to i18n files in the codebase
+---
+
+When you are working with i18n strings in this project, utilize the following steps to identify missing translations and add them to the language files.
+
+First, to identify missing translation keys: `bun run --cwd packages/kilo-vscode i18n:missing`. This command will print a list of translation keys, with their English string, that are present in the English i18n file but are missing from other translation files.
+
+If the command prints "No missing translations found", stop here. There is no work that needs to be done.
+
+If the command prints a list of files and translation keys, do the following steps for each file in the command's output:
+
+- For each translation key noted, utilize the Translator sub-agent to translate the English string to the target language
+- Insert the key with the translated string into the target i18n TypeScript file
+
+When finished with this task for all files, rerun the `bun run --cwd packages/kilo-vscode i18n:missing` command to validate completion.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,3 +110,9 @@ To keep our backlog manageable, we automatically close inactive issues and PRs a
 - **Variables:** Prefer `const`.
 - **Naming:** Concise single-word identifiers when descriptive.
 - **Runtime APIs:** Use Bun helpers (e.g., `Bun.file()`).
+
+### Translations
+
+Kilo CLI has full translation support for several languages via i18n files in each package. Developers can utilize the `add-translations` skill to have Kilo automatically generate missing translation strings for keys that have been recently added to an `en.json` file.
+
+Using Kilo in the root of this project, in Orchestrator mode, ask Kilo to "Run the add-translations skill". This will run a script to find any missing translation keys, then the agent will generate translations for the new keys.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -705,6 +705,7 @@
     "check-types:webview": "bun script/typecheck.ts --project webview-ui/tsconfig.json",
     "typecheck": "bun run check-types:extension && bun run check-types:webview",
     "check-types:extension": "bun script/typecheck.ts",
+    "i18n:missing": "bun script/list-missing-translations.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "knip": "knip",

--- a/packages/kilo-vscode/script/list-missing-translations.ts
+++ b/packages/kilo-vscode/script/list-missing-translations.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+
+import { findAllMissingRows, names } from "../tests/unit/i18n-shared"
+
+const rows = findAllMissingRows().sort((a, b) => {
+  const file = a.file.localeCompare(b.file)
+  if (file !== 0) return file
+  return a.key.localeCompare(b.key)
+})
+
+if (rows.length === 0) {
+  console.log("No missing translations found")
+  process.exit(0)
+}
+
+const files = rows.reduce((map, row) => {
+  const list = map.get(row.file) ?? []
+  list.push(row)
+  map.set(row.file, list)
+  return map
+}, new Map<string, typeof rows>())
+
+const out = Array.from(files.entries())
+  .map(([file, list]) => {
+    const locale = list[0]?.locale ?? "en"
+    const name = names[locale]
+    const lines = list.map((row) => `${JSON.stringify(row.key)}: ${JSON.stringify(row.source)}`)
+    return [`Missing from \`${file}\` (${name}):`, ...lines].join("\n")
+  })
+  .join("\n\n")
+
+console.log(out)

--- a/packages/kilo-vscode/tests/unit/agent-manager-i18n-split.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-i18n-split.test.ts
@@ -1,82 +1,10 @@
 import { describe, it, expect } from "bun:test"
-import { dict as appEn } from "../../webview-ui/src/i18n/en"
-import { dict as appZh } from "../../webview-ui/src/i18n/zh"
-import { dict as appZht } from "../../webview-ui/src/i18n/zht"
-import { dict as appKo } from "../../webview-ui/src/i18n/ko"
-import { dict as appDe } from "../../webview-ui/src/i18n/de"
-import { dict as appEs } from "../../webview-ui/src/i18n/es"
-import { dict as appFr } from "../../webview-ui/src/i18n/fr"
-import { dict as appDa } from "../../webview-ui/src/i18n/da"
-import { dict as appJa } from "../../webview-ui/src/i18n/ja"
-import { dict as appPl } from "../../webview-ui/src/i18n/pl"
-import { dict as appRu } from "../../webview-ui/src/i18n/ru"
-import { dict as appAr } from "../../webview-ui/src/i18n/ar"
-import { dict as appNo } from "../../webview-ui/src/i18n/no"
-import { dict as appBr } from "../../webview-ui/src/i18n/br"
-import { dict as appTh } from "../../webview-ui/src/i18n/th"
-import { dict as appBs } from "../../webview-ui/src/i18n/bs"
-import { dict as amEn } from "../../webview-ui/agent-manager/i18n/en"
-import { dict as amZh } from "../../webview-ui/agent-manager/i18n/zh"
-import { dict as amZht } from "../../webview-ui/agent-manager/i18n/zht"
-import { dict as amKo } from "../../webview-ui/agent-manager/i18n/ko"
-import { dict as amDe } from "../../webview-ui/agent-manager/i18n/de"
-import { dict as amEs } from "../../webview-ui/agent-manager/i18n/es"
-import { dict as amFr } from "../../webview-ui/agent-manager/i18n/fr"
-import { dict as amDa } from "../../webview-ui/agent-manager/i18n/da"
-import { dict as amJa } from "../../webview-ui/agent-manager/i18n/ja"
-import { dict as amPl } from "../../webview-ui/agent-manager/i18n/pl"
-import { dict as amRu } from "../../webview-ui/agent-manager/i18n/ru"
-import { dict as amAr } from "../../webview-ui/agent-manager/i18n/ar"
-import { dict as amNo } from "../../webview-ui/agent-manager/i18n/no"
-import { dict as amBr } from "../../webview-ui/agent-manager/i18n/br"
-import { dict as amTh } from "../../webview-ui/agent-manager/i18n/th"
-import { dict as amBs } from "../../webview-ui/agent-manager/i18n/bs"
+import { amLocales, appLocales, placeholders } from "./i18n-shared"
 
 const PREFIX = "agentManager."
 
-const locales = {
-  en: amEn,
-  zh: amZh,
-  zht: amZht,
-  ko: amKo,
-  de: amDe,
-  es: amEs,
-  fr: amFr,
-  da: amDa,
-  ja: amJa,
-  pl: amPl,
-  ru: amRu,
-  ar: amAr,
-  no: amNo,
-  br: amBr,
-  th: amTh,
-  bs: amBs,
-}
-
-const appLocales = {
-  en: appEn,
-  zh: appZh,
-  zht: appZht,
-  ko: appKo,
-  de: appDe,
-  es: appEs,
-  fr: appFr,
-  da: appDa,
-  ja: appJa,
-  pl: appPl,
-  ru: appRu,
-  ar: appAr,
-  no: appNo,
-  br: appBr,
-  th: appTh,
-  bs: appBs,
-}
-
-function placeholders(text: string): string[] {
-  return Array.from(text.matchAll(/\{\{\s*([\w.]+)\s*\}\}/g))
-    .flatMap((match) => (match[1] ? [match[1]] : []))
-    .sort()
-}
+const locales = amLocales
+const amEn = amLocales.en
 
 describe("Agent Manager i18n split", () => {
   it("keeps agent manager keys out of general locale dictionaries", () => {

--- a/packages/kilo-vscode/tests/unit/i18n-keys.test.ts
+++ b/packages/kilo-vscode/tests/unit/i18n-keys.test.ts
@@ -17,62 +17,18 @@
 import { describe, it, expect } from "bun:test"
 import { Glob } from "bun"
 import path from "node:path"
+import { appLocales, cliLocales, findMissingLocaleKeys, kiloLocales, uiLocales } from "./i18n-shared"
 
 // ── Webview dictionaries ────────────────────────────────────────────────────
 
 // Layer 1: app-local (sidebar)
 import { dict as appEn } from "../../webview-ui/src/i18n/en"
-import { dict as appZh } from "../../webview-ui/src/i18n/zh"
-import { dict as appZht } from "../../webview-ui/src/i18n/zht"
-import { dict as appKo } from "../../webview-ui/src/i18n/ko"
-import { dict as appDe } from "../../webview-ui/src/i18n/de"
-import { dict as appEs } from "../../webview-ui/src/i18n/es"
-import { dict as appFr } from "../../webview-ui/src/i18n/fr"
-import { dict as appDa } from "../../webview-ui/src/i18n/da"
-import { dict as appJa } from "../../webview-ui/src/i18n/ja"
-import { dict as appPl } from "../../webview-ui/src/i18n/pl"
-import { dict as appRu } from "../../webview-ui/src/i18n/ru"
-import { dict as appAr } from "../../webview-ui/src/i18n/ar"
-import { dict as appNo } from "../../webview-ui/src/i18n/no"
-import { dict as appBr } from "../../webview-ui/src/i18n/br"
-import { dict as appTh } from "../../webview-ui/src/i18n/th"
-import { dict as appBs } from "../../webview-ui/src/i18n/bs"
 
 // Layer 2: upstream UI (@opencode-ai/ui re-exported via @kilocode/kilo-ui)
 import { dict as uiEn } from "../../../ui/src/i18n/en"
-import { dict as uiZh } from "../../../ui/src/i18n/zh"
-import { dict as uiZht } from "../../../ui/src/i18n/zht"
-import { dict as uiKo } from "../../../ui/src/i18n/ko"
-import { dict as uiDe } from "../../../ui/src/i18n/de"
-import { dict as uiEs } from "../../../ui/src/i18n/es"
-import { dict as uiFr } from "../../../ui/src/i18n/fr"
-import { dict as uiDa } from "../../../ui/src/i18n/da"
-import { dict as uiJa } from "../../../ui/src/i18n/ja"
-import { dict as uiPl } from "../../../ui/src/i18n/pl"
-import { dict as uiRu } from "../../../ui/src/i18n/ru"
-import { dict as uiAr } from "../../../ui/src/i18n/ar"
-import { dict as uiNo } from "../../../ui/src/i18n/no"
-import { dict as uiBr } from "../../../ui/src/i18n/br"
-import { dict as uiTh } from "../../../ui/src/i18n/th"
-import { dict as uiBs } from "../../../ui/src/i18n/bs"
 
 // Layer 3: kilo-i18n overrides
 import { dict as kiloEn } from "../../../kilo-i18n/src/en"
-import { dict as kiloZh } from "../../../kilo-i18n/src/zh"
-import { dict as kiloZht } from "../../../kilo-i18n/src/zht"
-import { dict as kiloKo } from "../../../kilo-i18n/src/ko"
-import { dict as kiloDe } from "../../../kilo-i18n/src/de"
-import { dict as kiloEs } from "../../../kilo-i18n/src/es"
-import { dict as kiloFr } from "../../../kilo-i18n/src/fr"
-import { dict as kiloDa } from "../../../kilo-i18n/src/da"
-import { dict as kiloJa } from "../../../kilo-i18n/src/ja"
-import { dict as kiloPl } from "../../../kilo-i18n/src/pl"
-import { dict as kiloRu } from "../../../kilo-i18n/src/ru"
-import { dict as kiloAr } from "../../../kilo-i18n/src/ar"
-import { dict as kiloNo } from "../../../kilo-i18n/src/no"
-import { dict as kiloBr } from "../../../kilo-i18n/src/br"
-import { dict as kiloTh } from "../../../kilo-i18n/src/th"
-import { dict as kiloBs } from "../../../kilo-i18n/src/bs"
 
 // Layer 4: agent manager (locale alignment already tested in agent-manager-i18n-split.test.ts)
 import { dict as amEn } from "../../webview-ui/agent-manager/i18n/en"
@@ -80,103 +36,12 @@ import { dict as amEn } from "../../webview-ui/agent-manager/i18n/en"
 // ── Extension-side dictionaries ─────────────────────────────────────────────
 
 import { dict as cliEn } from "../../src/services/cli-backend/i18n/en"
-import { dict as cliZh } from "../../src/services/cli-backend/i18n/zh"
-import { dict as cliZht } from "../../src/services/cli-backend/i18n/zht"
-import { dict as cliDe } from "../../src/services/cli-backend/i18n/de"
-import { dict as cliEs } from "../../src/services/cli-backend/i18n/es"
-import { dict as cliFr } from "../../src/services/cli-backend/i18n/fr"
-import { dict as cliDa } from "../../src/services/cli-backend/i18n/da"
-import { dict as cliJa } from "../../src/services/cli-backend/i18n/ja"
-import { dict as cliKo } from "../../src/services/cli-backend/i18n/ko"
-import { dict as cliPl } from "../../src/services/cli-backend/i18n/pl"
-import { dict as cliRu } from "../../src/services/cli-backend/i18n/ru"
-import { dict as cliAr } from "../../src/services/cli-backend/i18n/ar"
-import { dict as cliNo } from "../../src/services/cli-backend/i18n/no"
-import { dict as cliBr } from "../../src/services/cli-backend/i18n/br"
-import { dict as cliTh } from "../../src/services/cli-backend/i18n/th"
-import { dict as cliBs } from "../../src/services/cli-backend/i18n/bs"
 
 import { dict as acEn } from "../../src/services/autocomplete/i18n/en"
 
 // ── Locale maps ─────────────────────────────────────────────────────────────
 
 const ROOT = path.resolve(import.meta.dir, "../..")
-
-const appLocales: Record<string, Record<string, string>> = {
-  en: appEn,
-  zh: appZh,
-  zht: appZht,
-  ko: appKo,
-  de: appDe,
-  es: appEs,
-  fr: appFr,
-  da: appDa,
-  ja: appJa,
-  pl: appPl,
-  ru: appRu,
-  ar: appAr,
-  no: appNo,
-  br: appBr,
-  th: appTh,
-  bs: appBs,
-}
-
-const kiloLocales: Record<string, Record<string, string>> = {
-  en: kiloEn,
-  zh: kiloZh,
-  zht: kiloZht,
-  ko: kiloKo,
-  de: kiloDe,
-  es: kiloEs,
-  fr: kiloFr,
-  da: kiloDa,
-  ja: kiloJa,
-  pl: kiloPl,
-  ru: kiloRu,
-  ar: kiloAr,
-  no: kiloNo,
-  br: kiloBr,
-  th: kiloTh,
-  bs: kiloBs,
-}
-
-const uiLocales: Record<string, Record<string, string>> = {
-  en: uiEn,
-  zh: uiZh,
-  zht: uiZht,
-  ko: uiKo,
-  de: uiDe,
-  es: uiEs,
-  fr: uiFr,
-  da: uiDa,
-  ja: uiJa,
-  pl: uiPl,
-  ru: uiRu,
-  ar: uiAr,
-  no: uiNo,
-  br: uiBr,
-  th: uiTh,
-  bs: uiBs,
-}
-
-const cliLocales: Record<string, Record<string, string>> = {
-  en: cliEn,
-  zh: cliZh,
-  zht: cliZht,
-  de: cliDe,
-  es: cliEs,
-  fr: cliFr,
-  da: cliDa,
-  ja: cliJa,
-  ko: cliKo,
-  pl: cliPl,
-  ru: cliRu,
-  ar: cliAr,
-  no: cliNo,
-  br: cliBr,
-  th: cliTh,
-  bs: cliBs,
-}
 
 // Merge webview dictionaries in the same priority order as language.tsx
 const webviewKeys = new Set(Object.keys({ ...appEn, ...uiEn, ...kiloEn, ...amEn }))
@@ -293,26 +158,6 @@ async function findAutocompleteMissing(): Promise<Missing[]> {
     }
   }
   return missing
-}
-
-// ── Locale completeness helpers ─────────────────────────────────────────────
-
-function findMissingLocaleKeys(
-  en: Record<string, string>,
-  locales: Record<string, Record<string, string>>,
-): Array<{ locale: string; key: string }> {
-  const base = Object.keys(en)
-  const results: Array<{ locale: string; key: string }> = []
-  for (const [locale, dict] of Object.entries(locales)) {
-    if (locale === "en") continue
-    const keys = new Set(Object.keys(dict))
-    for (const key of base) {
-      if (!keys.has(key)) {
-        results.push({ locale, key })
-      }
-    }
-  }
-  return results
 }
 
 function formatLocaleReport(items: Array<{ locale: string; key: string }>): string {

--- a/packages/kilo-vscode/tests/unit/i18n-shared.ts
+++ b/packages/kilo-vscode/tests/unit/i18n-shared.ts
@@ -1,0 +1,284 @@
+import { dict as appEn } from "../../webview-ui/src/i18n/en"
+import { dict as appZh } from "../../webview-ui/src/i18n/zh"
+import { dict as appZht } from "../../webview-ui/src/i18n/zht"
+import { dict as appKo } from "../../webview-ui/src/i18n/ko"
+import { dict as appDe } from "../../webview-ui/src/i18n/de"
+import { dict as appEs } from "../../webview-ui/src/i18n/es"
+import { dict as appFr } from "../../webview-ui/src/i18n/fr"
+import { dict as appDa } from "../../webview-ui/src/i18n/da"
+import { dict as appJa } from "../../webview-ui/src/i18n/ja"
+import { dict as appPl } from "../../webview-ui/src/i18n/pl"
+import { dict as appRu } from "../../webview-ui/src/i18n/ru"
+import { dict as appAr } from "../../webview-ui/src/i18n/ar"
+import { dict as appNo } from "../../webview-ui/src/i18n/no"
+import { dict as appBr } from "../../webview-ui/src/i18n/br"
+import { dict as appTh } from "../../webview-ui/src/i18n/th"
+import { dict as appBs } from "../../webview-ui/src/i18n/bs"
+import { dict as amEn } from "../../webview-ui/agent-manager/i18n/en"
+import { dict as amZh } from "../../webview-ui/agent-manager/i18n/zh"
+import { dict as amZht } from "../../webview-ui/agent-manager/i18n/zht"
+import { dict as amKo } from "../../webview-ui/agent-manager/i18n/ko"
+import { dict as amDe } from "../../webview-ui/agent-manager/i18n/de"
+import { dict as amEs } from "../../webview-ui/agent-manager/i18n/es"
+import { dict as amFr } from "../../webview-ui/agent-manager/i18n/fr"
+import { dict as amDa } from "../../webview-ui/agent-manager/i18n/da"
+import { dict as amJa } from "../../webview-ui/agent-manager/i18n/ja"
+import { dict as amPl } from "../../webview-ui/agent-manager/i18n/pl"
+import { dict as amRu } from "../../webview-ui/agent-manager/i18n/ru"
+import { dict as amAr } from "../../webview-ui/agent-manager/i18n/ar"
+import { dict as amNo } from "../../webview-ui/agent-manager/i18n/no"
+import { dict as amBr } from "../../webview-ui/agent-manager/i18n/br"
+import { dict as amTh } from "../../webview-ui/agent-manager/i18n/th"
+import { dict as amBs } from "../../webview-ui/agent-manager/i18n/bs"
+import { dict as uiEn } from "../../../ui/src/i18n/en"
+import { dict as uiZh } from "../../../ui/src/i18n/zh"
+import { dict as uiZht } from "../../../ui/src/i18n/zht"
+import { dict as uiKo } from "../../../ui/src/i18n/ko"
+import { dict as uiDe } from "../../../ui/src/i18n/de"
+import { dict as uiEs } from "../../../ui/src/i18n/es"
+import { dict as uiFr } from "../../../ui/src/i18n/fr"
+import { dict as uiDa } from "../../../ui/src/i18n/da"
+import { dict as uiJa } from "../../../ui/src/i18n/ja"
+import { dict as uiPl } from "../../../ui/src/i18n/pl"
+import { dict as uiRu } from "../../../ui/src/i18n/ru"
+import { dict as uiAr } from "../../../ui/src/i18n/ar"
+import { dict as uiNo } from "../../../ui/src/i18n/no"
+import { dict as uiBr } from "../../../ui/src/i18n/br"
+import { dict as uiTh } from "../../../ui/src/i18n/th"
+import { dict as uiTr } from "../../../ui/src/i18n/tr"
+import { dict as uiBs } from "../../../ui/src/i18n/bs"
+import { dict as kiloEn } from "../../../kilo-i18n/src/en"
+import { dict as kiloZh } from "../../../kilo-i18n/src/zh"
+import { dict as kiloZht } from "../../../kilo-i18n/src/zht"
+import { dict as kiloKo } from "../../../kilo-i18n/src/ko"
+import { dict as kiloDe } from "../../../kilo-i18n/src/de"
+import { dict as kiloEs } from "../../../kilo-i18n/src/es"
+import { dict as kiloFr } from "../../../kilo-i18n/src/fr"
+import { dict as kiloDa } from "../../../kilo-i18n/src/da"
+import { dict as kiloJa } from "../../../kilo-i18n/src/ja"
+import { dict as kiloPl } from "../../../kilo-i18n/src/pl"
+import { dict as kiloRu } from "../../../kilo-i18n/src/ru"
+import { dict as kiloAr } from "../../../kilo-i18n/src/ar"
+import { dict as kiloNo } from "../../../kilo-i18n/src/no"
+import { dict as kiloBr } from "../../../kilo-i18n/src/br"
+import { dict as kiloTh } from "../../../kilo-i18n/src/th"
+import { dict as kiloTr } from "../../../kilo-i18n/src/tr"
+import { dict as kiloBs } from "../../../kilo-i18n/src/bs"
+import { dict as cliEn } from "../../src/services/cli-backend/i18n/en"
+import { dict as cliZh } from "../../src/services/cli-backend/i18n/zh"
+import { dict as cliZht } from "../../src/services/cli-backend/i18n/zht"
+import { dict as cliDe } from "../../src/services/cli-backend/i18n/de"
+import { dict as cliEs } from "../../src/services/cli-backend/i18n/es"
+import { dict as cliFr } from "../../src/services/cli-backend/i18n/fr"
+import { dict as cliDa } from "../../src/services/cli-backend/i18n/da"
+import { dict as cliJa } from "../../src/services/cli-backend/i18n/ja"
+import { dict as cliKo } from "../../src/services/cli-backend/i18n/ko"
+import { dict as cliPl } from "../../src/services/cli-backend/i18n/pl"
+import { dict as cliRu } from "../../src/services/cli-backend/i18n/ru"
+import { dict as cliAr } from "../../src/services/cli-backend/i18n/ar"
+import { dict as cliNo } from "../../src/services/cli-backend/i18n/no"
+import { dict as cliBr } from "../../src/services/cli-backend/i18n/br"
+import { dict as cliTh } from "../../src/services/cli-backend/i18n/th"
+import { dict as cliBs } from "../../src/services/cli-backend/i18n/bs"
+
+export type Dict = Record<string, string>
+export type Locale =
+  | "en"
+  | "zh"
+  | "zht"
+  | "ko"
+  | "de"
+  | "es"
+  | "fr"
+  | "da"
+  | "ja"
+  | "pl"
+  | "ru"
+  | "ar"
+  | "no"
+  | "br"
+  | "th"
+  | "tr"
+  | "bs"
+
+export const names: Record<Locale, string> = {
+  en: "English",
+  zh: "Chinese (Simplified)",
+  zht: "Chinese (Traditional)",
+  ko: "Korean",
+  de: "German",
+  es: "Spanish",
+  fr: "French",
+  da: "Danish",
+  ja: "Japanese",
+  pl: "Polish",
+  ru: "Russian",
+  ar: "Arabic",
+  no: "Norwegian",
+  br: "Brazilian Portuguese",
+  th: "Thai",
+  tr: "Turkish",
+  bs: "Bosnian",
+}
+
+export const appLocales: Partial<Record<Locale, Dict>> = {
+  en: appEn,
+  zh: appZh,
+  zht: appZht,
+  ko: appKo,
+  de: appDe,
+  es: appEs,
+  fr: appFr,
+  da: appDa,
+  ja: appJa,
+  pl: appPl,
+  ru: appRu,
+  ar: appAr,
+  no: appNo,
+  br: appBr,
+  th: appTh,
+  bs: appBs,
+}
+
+export const amLocales: Partial<Record<Locale, Dict>> = {
+  en: amEn,
+  zh: amZh,
+  zht: amZht,
+  ko: amKo,
+  de: amDe,
+  es: amEs,
+  fr: amFr,
+  da: amDa,
+  ja: amJa,
+  pl: amPl,
+  ru: amRu,
+  ar: amAr,
+  no: amNo,
+  br: amBr,
+  th: amTh,
+  bs: amBs,
+}
+
+export const uiLocales: Partial<Record<Locale, Dict>> = {
+  en: uiEn,
+  zh: uiZh,
+  zht: uiZht,
+  ko: uiKo,
+  de: uiDe,
+  es: uiEs,
+  fr: uiFr,
+  da: uiDa,
+  ja: uiJa,
+  pl: uiPl,
+  ru: uiRu,
+  ar: uiAr,
+  no: uiNo,
+  br: uiBr,
+  th: uiTh,
+  tr: uiTr,
+  bs: uiBs,
+}
+
+export const kiloLocales: Partial<Record<Locale, Dict>> = {
+  en: kiloEn,
+  zh: kiloZh,
+  zht: kiloZht,
+  ko: kiloKo,
+  de: kiloDe,
+  es: kiloEs,
+  fr: kiloFr,
+  da: kiloDa,
+  ja: kiloJa,
+  pl: kiloPl,
+  ru: kiloRu,
+  ar: kiloAr,
+  no: kiloNo,
+  br: kiloBr,
+  th: kiloTh,
+  tr: kiloTr,
+  bs: kiloBs,
+}
+
+export const cliLocales: Partial<Record<Locale, Dict>> = {
+  en: cliEn,
+  zh: cliZh,
+  zht: cliZht,
+  de: cliDe,
+  es: cliEs,
+  fr: cliFr,
+  da: cliDa,
+  ja: cliJa,
+  ko: cliKo,
+  pl: cliPl,
+  ru: cliRu,
+  ar: cliAr,
+  no: cliNo,
+  br: cliBr,
+  th: cliTh,
+  bs: cliBs,
+}
+
+export interface Group {
+  name: string
+  root: string
+  en: Dict
+  locales: Partial<Record<Locale, Dict>>
+}
+
+export interface Missing {
+  locale: Locale
+  file: string
+  key: string
+  source: string
+}
+
+export const groups: Group[] = [
+  { name: "shared UI", root: "packages/ui/src/i18n", en: uiEn, locales: uiLocales },
+  { name: "sidebar", root: "packages/kilo-vscode/webview-ui/src/i18n", en: appEn, locales: appLocales },
+  { name: "kilo-i18n", root: "packages/kilo-i18n/src", en: kiloEn, locales: kiloLocales },
+  { name: "agent manager", root: "packages/kilo-vscode/webview-ui/agent-manager/i18n", en: amEn, locales: amLocales },
+  { name: "cli-backend", root: "packages/kilo-vscode/src/services/cli-backend/i18n", en: cliEn, locales: cliLocales },
+]
+
+export function placeholders(text: string): string[] {
+  return Array.from(text.matchAll(/\{\{\s*([\w.]+)\s*\}\}/g))
+    .flatMap((match) => (match[1] ? [match[1]] : []))
+    .sort()
+}
+
+export function findMissingLocaleKeys(en: Dict, locales: Record<string, Dict>): Array<{ locale: string; key: string }> {
+  const base = Object.keys(en)
+  const results: Array<{ locale: string; key: string }> = []
+  for (const [locale, dict] of Object.entries(locales)) {
+    if (locale === "en") continue
+    const keys = new Set(Object.keys(dict))
+    for (const key of base) {
+      if (!keys.has(key)) {
+        results.push({ locale, key })
+      }
+    }
+  }
+  return results
+}
+
+export function findMissingRows(group: Group): Missing[] {
+  const rows: Missing[] = []
+  for (const [locale, dict] of Object.entries(group.locales) as Array<[Locale, Dict]>) {
+    if (locale === "en") continue
+    const keys = new Set(Object.keys(dict))
+    for (const [key, source] of Object.entries(group.en)) {
+      if (keys.has(key)) continue
+      rows.push({
+        locale,
+        file: `${group.root}/${locale}.ts`,
+        key,
+        source,
+      })
+    }
+  }
+  return rows
+}
+
+export function findAllMissingRows(): Missing[] {
+  return groups.flatMap(findMissingRows)
+}


### PR DESCRIPTION
## Context

Add a way to automate generating new translation keys.

## Implementation

This adds a script to list all missing translation keys, and a new skill that can be invoked to instruct the agent to utilize this new script plus the existing Translator agent to generate the new strings.

## How to Test

- Add new translation keys to a `en.json` file
- As noted in `CONTRIBUTING.md`, ask Kilo to "Run the add-translations skill"

## Get in Touch

ExpedientFalcon on Discord