### PR TITLE
fix(vscode): display error and validate model when configured model is unavailable

### DIFF
--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -201,6 +201,7 @@ export type WebviewMessage =
   | { type: "sessionCreated"; session: ReturnType<typeof sessionToWebview> }
   | { type: "sessionUpdated"; session: ReturnType<typeof sessionToWebview> }
   | { type: "messageRemoved"; sessionID: string; messageID: string }
+  | { type: "sessionError"; sessionID?: string; error?: unknown }
   | null
 
 export function mapSSEEventToWebviewMessage(event: Event, sessionID: string | undefined): WebviewMessage {
@@ -294,6 +295,13 @@ export function mapSSEEventToWebviewMessage(event: Event, sessionID: string | un
         type: "questionResolved",
         requestID: event.properties.requestID,
       }
+    case "session.error": {
+      return {
+        type: "sessionError",
+        sessionID: event.properties.sessionID,
+        error: event.properties.error,
+      }
+    }
     case "session.created":
       return {
         type: "sessionCreated",

--- a/packages/kilo-vscode/src/services/cli-backend/connection-utils.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-utils.ts
@@ -17,6 +17,7 @@ export function resolveEventSessionId(
       return event.properties.info.id
     case "session.status":
     case "session.idle":
+    case "session.error":
     case "todo.updated":
       return event.properties.sessionID
     case "message.updated":

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -322,6 +322,7 @@ export const SessionProvider: ParentComponent = (props) => {
 
   // Global model selection per agent/mode
   // Precedence: per-session override > user override > per-mode config > global config model > VS Code default > kilo-auto/free
+  // Each candidate is validated against the provider catalog; invalid models fall through.
   const selected = createMemo<ModelSelection | null>(() => {
     const sid = currentSessionID()
     if (sid) {
@@ -562,6 +563,25 @@ export const SessionProvider: ParentComponent = (props) => {
         case "messageRemoved":
           handleMessageRemoved(message.sessionID, message.messageID)
           break
+
+        case "sessionError": {
+          if (message.error?.name === "MessageAbortedError") break
+          const sid = message.sessionID ?? currentSessionID()
+          if (!sid) break
+          // Find the last user message in this session to use as parentID
+          const msgs = store.messages[sid] ?? []
+          const parent = [...msgs].reverse().find((m) => m.role === "user")
+          const errorMsg: Message = {
+            id: Identifier.ascending("message"),
+            sessionID: sid,
+            role: "assistant",
+            createdAt: new Date().toISOString(),
+            parentID: parent?.id,
+            error: message.error,
+          }
+          handleMessageCreated(errorMsg)
+          break
+        }
 
         case "error":
           // Only clear loading if the error is for the current session

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -456,6 +456,12 @@ export interface SessionStatusMessage {
   next?: number
 }
 
+export interface SessionErrorMessage {
+  type: "sessionError"
+  sessionID?: string
+  error?: { name: string; data?: Record<string, unknown> }
+}
+
 export interface PermissionRequestMessage {
   type: "permissionRequest"
   permission: PermissionRequest
@@ -1184,6 +1190,7 @@ export type ExtensionMessage =
   | SendMessageFailedMessage
   | PartUpdatedMessage
   | SessionStatusMessage
+  | SessionErrorMessage
   | PermissionRequestMessage
   | PermissionResolvedMessage
   | PermissionErrorMessage


### PR DESCRIPTION
## Context

Fixes #7270

When a user's configured model (from `kilo.jsonc`) is removed from the gateway, the VS Code extension silently fails — messages are sent but no response or error is ever shown. The TUI handles this correctly with both pre-send validation and error display.

## Implementation

**Two layers of protection, mirroring the TUI:**

### 1. Pre-send model validation (proactive)

Added `isModelValid()` and `validated()` helpers in `session.tsx` that check each model candidate against the loaded provider catalog before it's used. The `selected` memo, the auto-sync `createEffect`, and the `configModel` memo all now validate each candidate in the selection cascade — invalid models are skipped and fall through to the server's default selection (same behavior as the TUI's `fallbackModel` cascade in `local.tsx`).

Key detail: validation is skipped when providers haven't loaded yet (`Object.keys(providers).length === 0`) to avoid false rejections during startup.

### 2. Session error display in chat (reactive safety net)

The `session.error` SSE event was silently dropped at two levels:
- `resolveEventSessionId()` didn't route it → now added alongside `session.status`/`session.idle`
- `mapSSEEventToWebviewMessage()` returned `null` → now maps to `sessionError` webview message

When a `sessionError` arrives, a synthetic assistant message with the error is injected into the chat via `handleMessageCreated()`. This renders inline through the existing `VscodeSessionTurn` → `ErrorDisplay` component chain — the same red error card used for inference errors.

This catches edge cases where validation can't prevent the error (e.g., model removed between selection and inference).

### Files changed

| File | Change |
|------|--------|
| `src/services/cli-backend/connection-utils.ts` | Route `session.error` events to correct webview |
| `src/kilo-provider-utils.ts` | Map `session.error` SSE to `sessionError` webview message |
| `webview-ui/src/types/messages.ts` | Add `SessionErrorMessage` type |
| `webview-ui/src/context/session.tsx` | Model validation + inline error display |

## Screenshots

<img width="1013" height="2153" alt="Pasted image" src="https://github.com/user-attachments/assets/01b7f3bd-ec22-48dd-86ed-afe7eea386a6" />

## How to Test

### Test 1: Model validation (proactive fallback)
1. Set `"model": "kilo/nonexistent-model-12345"` in `~/.config/kilo/kilo.jsonc`
2. Open VS Code with the extension
3. The model selector should show the server's default model (not the nonexistent one)
4. Sending a message should work normally with the fallback model

### Test 2: Error display (reactive safety net)
1. Temporarily bypass validation (or use a model that exists locally but is rejected by the gateway)
2. Send a message
3. The error should appear inline in the chat as a red error card below your message
4. The input should return to idle state (re-enabled)
