### PR TITLE
fix(vscode): add upper bounds check in mode switcher keyboard navigation

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -76,7 +76,7 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
       focusItem(len - 1)
     } else if (e.key === "Enter" || e.key === " ") {
       e.preventDefault()
-      if (cur >= 0) pick(props.agents[cur].name)
+      if (cur >= 0 && cur < len) pick(props.agents[cur].name)
     }
   }
 


### PR DESCRIPTION
## What's wrong

The `onKeyDown` handler in `ModeSwitcherBase` checks `cur >= 0` before accessing `props.agents[cur].name` on Enter/Space, but doesn't check `cur < props.agents.length`. 

The `focused` signal is set by keyboard navigation and clamped by `focusItem()`, but the `agents` array can reactively shrink (e.g., an agent/mode is removed while the popover is open). In that case, `focused()` could point beyond the end of the array, causing `props.agents[cur]` to be `undefined` and `.name` to throw a TypeError.

## The fix

One-line change: `cur >= 0` → `cur >= 0 && cur < len`

`len` is already computed as `props.agents.length` at the top of `onKeyDown`, so this is consistent with the ArrowUp/Down wrap-around arithmetic that already uses `len`.

## Tests

No unit test added — this is a SolidJS UI component with DOM event handling that has no existing test infrastructure. The fix is a single bounds check that's verifiable by inspection. The scenario (agents list shrinking while popover is open) is rare but the guard is zero-cost.

Ref: #7307
cc @marius-kilocode