### PR TITLE
Display confirmation toast on MarketPlace installs

### DIFF
--- a/packages/kilo-i18n/src/ar.ts
+++ b/packages/kilo-i18n/src/ar.ts
@@ -65,4 +65,8 @@ export const dict = {
   "marketplace.install": "تثبيت",
   "marketplace.filter.installed": "مثبت",
   "marketplace.error.dismiss": "تجاهل",
+  "marketplace.warning.busyOne": "جلسة واحدة تعمل وستتوقف",
+  "marketplace.warning.busyMany": "عدة جلسات تعمل وستتوقف",
+  "marketplace.warning.installAnyway": "تثبيت على أي حال",
+  "marketplace.warning.cancel": "إلغاء",
 }

--- a/packages/kilo-i18n/src/br.ts
+++ b/packages/kilo-i18n/src/br.ts
@@ -65,4 +65,8 @@ export const dict = {
   "marketplace.install": "Instalar",
   "marketplace.filter.installed": "Instalado",
   "marketplace.error.dismiss": "Dispensar",
+  "marketplace.warning.busyOne": "Uma sessão está em execução e será interrompida",
+  "marketplace.warning.busyMany": "Várias sessões estão em execução e serão interrompidas",
+  "marketplace.warning.installAnyway": "Instalar mesmo assim",
+  "marketplace.warning.cancel": "Cancelar",
 }

--- a/packages/kilo-i18n/src/bs.ts
+++ b/packages/kilo-i18n/src/bs.ts
@@ -70,4 +70,8 @@ export const dict = {
   "marketplace.install": "Instaliraj",
   "marketplace.filter.installed": "Instalirano",
   "marketplace.error.dismiss": "Odbaci",
+  "marketplace.warning.busyOne": "Jedna sesija je pokrenuta i bit će prekinuta",
+  "marketplace.warning.busyMany": "Nekoliko sesija je pokrenuto i bit će prekinuto",
+  "marketplace.warning.installAnyway": "Instaliraj svejedno",
+  "marketplace.warning.cancel": "Otkaži",
 }

--- a/packages/kilo-i18n/src/da.ts
+++ b/packages/kilo-i18n/src/da.ts
@@ -65,4 +65,8 @@ export const dict = {
   "marketplace.install": "Installer",
   "marketplace.filter.installed": "Installeret",
   "marketplace.error.dismiss": "Afvis",
+  "marketplace.warning.busyOne": "En session kører og vil blive afbrudt",
+  "marketplace.warning.busyMany": "Flere sessioner kører og vil blive afbrudt",
+  "marketplace.warning.installAnyway": "Installer alligevel",
+  "marketplace.warning.cancel": "Annuller",
 }

--- a/packages/kilo-i18n/src/de.ts
+++ b/packages/kilo-i18n/src/de.ts
@@ -65,4 +65,8 @@ export const dict = {
   "marketplace.install": "Installieren",
   "marketplace.filter.installed": "Installiert",
   "marketplace.error.dismiss": "Verwerfen",
+  "marketplace.warning.busyOne": "Eine Sitzung läuft und wird unterbrochen",
+  "marketplace.warning.busyMany": "Mehrere Sitzungen laufen und werden unterbrochen",
+  "marketplace.warning.installAnyway": "Trotzdem installieren",
+  "marketplace.warning.cancel": "Abbrechen",
 }

--- a/packages/kilo-i18n/src/en.ts
+++ b/packages/kilo-i18n/src/en.ts
@@ -67,4 +67,8 @@ export const dict = {
   "marketplace.install": "Install",
   "marketplace.filter.installed": "Installed",
   "marketplace.error.dismiss": "Dismiss",
+  "marketplace.warning.busyOne": "One session is running and will be interrupted",
+  "marketplace.warning.busyMany": "Several sessions are running and will be interrupted",
+  "marketplace.warning.installAnyway": "Install anyway",
+  "marketplace.warning.cancel": "Cancel",
 }

--- a/packages/kilo-i18n/src/es.ts
+++ b/packages/kilo-i18n/src/es.ts
@@ -65,4 +65,8 @@ export const dict = {
   "marketplace.install": "Instalar",
   "marketplace.filter.installed": "Instalado",
   "marketplace.error.dismiss": "Descartar",
+  "marketplace.warning.busyOne": "Una sesión está en ejecución y se interrumpirá",
+  "marketplace.warning.busyMany": "Varias sesiones están en ejecución y se interrumpirán",
+  "marketplace.warning.installAnyway": "Instalar de todas formas",
+  "marketplace.warning.cancel": "Cancelar",
 }

--- a/packages/kilo-i18n/src/fr.ts
+++ b/packages/kilo-i18n/src/fr.ts
@@ -65,4 +65,8 @@ export const dict = {
   "marketplace.install": "Installer",
   "marketplace.filter.installed": "Installé",
   "marketplace.error.dismiss": "Ignorer",
+  "marketplace.warning.busyOne": "Une session est en cours et sera interrompue",
+  "marketplace.warning.busyMany": "Plusieurs sessions sont en cours et seront interrompues",
+  "marketplace.warning.installAnyway": "Installer quand même",
+  "marketplace.warning.cancel": "Annuler",
 }

--- a/packages/kilo-i18n/src/ja.ts
+++ b/packages/kilo-i18n/src/ja.ts
@@ -63,4 +63,8 @@ export const dict = {
   "marketplace.install": "インストール",
   "marketplace.filter.installed": "インストール済み",
   "marketplace.error.dismiss": "閉じる",
+  "marketplace.warning.busyOne": "1つのセッションが実行中で中断されます",
+  "marketplace.warning.busyMany": "複数のセッションが実行中で中断されます",
+  "marketplace.warning.installAnyway": "それでもインストール",
+  "marketplace.warning.cancel": "キャンセル",
 }

--- a/packages/kilo-i18n/src/ko.ts
+++ b/packages/kilo-i18n/src/ko.ts
@@ -63,4 +63,8 @@ export const dict = {
   "marketplace.install": "설치",
   "marketplace.filter.installed": "설치됨",
   "marketplace.error.dismiss": "닫기",
+  "marketplace.warning.busyOne": "하나의 세션이 실행 중이며 중단됩니다",
+  "marketplace.warning.busyMany": "여러 세션이 실행 중이며 중단됩니다",
+  "marketplace.warning.installAnyway": "그래도 설치",
+  "marketplace.warning.cancel": "취소",
 }

--- a/packages/kilo-i18n/src/no.ts
+++ b/packages/kilo-i18n/src/no.ts
@@ -65,4 +65,8 @@ export const dict = {
   "marketplace.install": "Installer",
   "marketplace.filter.installed": "Installert",
   "marketplace.error.dismiss": "Avvis",
+  "marketplace.warning.busyOne": "En økt kjører og vil bli avbrutt",
+  "marketplace.warning.busyMany": "Flere økter kjører og vil bli avbrutt",
+  "marketplace.warning.installAnyway": "Installer uansett",
+  "marketplace.warning.cancel": "Avbryt",
 }

--- a/packages/kilo-i18n/src/pl.ts
+++ b/packages/kilo-i18n/src/pl.ts
@@ -65,4 +65,8 @@ export const dict = {
   "marketplace.install": "Zainstaluj",
   "marketplace.filter.installed": "Zainstalowano",
   "marketplace.error.dismiss": "Odrzuć",
+  "marketplace.warning.busyOne": "Jedna sesja jest uruchomiona i zostanie przerwana",
+  "marketplace.warning.busyMany": "Kilka sesji jest uruchomionych i zostanie przerwanych",
+  "marketplace.warning.installAnyway": "Zainstaluj mimo to",
+  "marketplace.warning.cancel": "Anuluj",
 }

--- a/packages/kilo-i18n/src/ru.ts
+++ b/packages/kilo-i18n/src/ru.ts
@@ -65,4 +65,8 @@ export const dict = {
   "marketplace.install": "Установить",
   "marketplace.filter.installed": "Установлено",
   "marketplace.error.dismiss": "Закрыть",
+  "marketplace.warning.busyOne": "Один сеанс выполняется и будет прерван",
+  "marketplace.warning.busyMany": "Несколько сеансов выполняются и будут прерваны",
+  "marketplace.warning.installAnyway": "Установить в любом случае",
+  "marketplace.warning.cancel": "Отмена",
 }

--- a/packages/kilo-i18n/src/th.ts
+++ b/packages/kilo-i18n/src/th.ts
@@ -65,4 +65,8 @@ export const dict = {
   "marketplace.install": "ติดตั้ง",
   "marketplace.filter.installed": "ติดตั้งแล้ว",
   "marketplace.error.dismiss": "ปิด",
+  "marketplace.warning.busyOne": "มีเซสชันหนึ่งกำลังทำงานและจะถูกขัดจังหวะ",
+  "marketplace.warning.busyMany": "มีหลายเซสชันกำลังทำงานและจะถูกขัดจังหวะ",
+  "marketplace.warning.installAnyway": "ติดตั้งต่อไป",
+  "marketplace.warning.cancel": "ยกเลิก",
 }

--- a/packages/kilo-i18n/src/tr.ts
+++ b/packages/kilo-i18n/src/tr.ts
@@ -65,4 +65,8 @@ export const dict = {
   "marketplace.install": "Yükle",
   "marketplace.filter.installed": "Yüklendi",
   "marketplace.error.dismiss": "Kapat",
+  "marketplace.warning.busyOne": "Bir oturum çalışıyor ve kesintiye uğrayacak",
+  "marketplace.warning.busyMany": "Birden fazla oturum çalışıyor ve kesintiye uğrayacak",
+  "marketplace.warning.installAnyway": "Yine de yükle",
+  "marketplace.warning.cancel": "İptal",
 }

--- a/packages/kilo-i18n/src/zh.ts
+++ b/packages/kilo-i18n/src/zh.ts
@@ -62,4 +62,8 @@ export const dict = {
   "marketplace.install": "安装",
   "marketplace.filter.installed": "已安装",
   "marketplace.error.dismiss": "关闭",
+  "marketplace.warning.busyOne": "一个会话正在运行，将被中断",
+  "marketplace.warning.busyMany": "多个会话正在运行，将被中断",
+  "marketplace.warning.installAnyway": "仍然安装",
+  "marketplace.warning.cancel": "取消",
 }

--- a/packages/kilo-i18n/src/zht.ts
+++ b/packages/kilo-i18n/src/zht.ts
@@ -62,4 +62,8 @@ export const dict = {
   "marketplace.install": "安裝",
   "marketplace.filter.installed": "已安裝",
   "marketplace.error.dismiss": "關閉",
+  "marketplace.warning.busyOne": "一個工作階段正在執行，將被中斷",
+  "marketplace.warning.busyMany": "多個工作階段正在執行，將被中斷",
+  "marketplace.warning.installAnyway": "仍然安裝",
+  "marketplace.warning.cancel": "取消",
 }

--- a/packages/kilo-vscode/webview-ui/src/components/marketplace/InstallModal.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/marketplace/InstallModal.tsx
@@ -5,9 +5,11 @@ import { RadioGroup } from "@kilocode/kilo-ui/radio-group"
 import { Select } from "@kilocode/kilo-ui/select"
 import { TextField } from "@kilocode/kilo-ui/text-field"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
+import { showToast } from "@kilocode/kilo-ui/toast"
 import { useVSCode } from "../../context/vscode"
 import { useServer } from "../../context/server"
 import { useLanguage } from "../../context/language"
+import { useSession } from "../../context/session"
 import type { MarketplaceItem, McpMarketplaceItem, McpInstallationMethod, McpParameter } from "../../types/marketplace"
 
 interface ScopeOption {
@@ -29,6 +31,7 @@ export const InstallModal = (props: Props) => {
   const vscode = useVSCode()
   const server = useServer()
   const { t } = useLanguage()
+  const session = useSession()
 
   const workspace = () => server.workspaceDirectory()
   const options = (): ScopeOption[] =>
@@ -90,7 +93,7 @@ export const InstallModal = (props: Props) => {
     onCleanup(unsub)
   })
 
-  const handleInstall = () => {
+  const doInstall = () => {
     setInstalling(true)
     const paramValues: Record<string, unknown> = { ...params() }
     if (method()) {
@@ -103,6 +106,24 @@ export const InstallModal = (props: Props) => {
         target: scope().value,
         parameters: Object.keys(paramValues).length > 0 ? paramValues : undefined,
       },
+    })
+  }
+
+  const handleInstall = () => {
+    const busy = Object.values(session.allStatusMap()).filter((s) => s.type === "busy").length
+    if (busy === 0) {
+      doInstall()
+      return
+    }
+    const msg = busy === 1 ? t("marketplace.warning.busyOne") : t("marketplace.warning.busyMany")
+    showToast({
+      variant: "error",
+      title: msg,
+      persistent: true,
+      actions: [
+        { label: t("marketplace.warning.installAnyway"), onClick: doInstall },
+        { label: t("marketplace.warning.cancel"), onClick: "dismiss" },
+      ],
     })
   }
 


### PR DESCRIPTION

Fixes https://github.com/Kilo-Org/kilocode/issues/7329

## Context

Display a confirmation toast when installing from Marketplace, and there are sessions open


## Video

[Screencast from 2026-03-19 23-18-15.webm](https://github.com/user-attachments/assets/49262f21-3f27-4c26-b9bc-129d5143dc59)


##  Testing

- Unit tests
- Manual sanity tests