### PR TITLE
feat(vscode): add autocomplete keyboard shortcuts (Escape cancel, Ctrl+L generate)

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -128,6 +128,11 @@
         "category": "Kilo Code"
       },
       {
+        "command": "kilo-code.new.autocomplete.cancelSuggestions",
+        "title": "Cancel Suggested Edits",
+        "category": "Kilo Code"
+      },
+      {
         "command": "kilo-code.new.agentManager.previousSession",
         "title": "Agent Manager: Previous Session",
         "category": "Kilo Code"
@@ -557,6 +562,23 @@
         "key": "ctrl+9",
         "mac": "cmd+9",
         "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
+        "command": "kilo-code.new.autocomplete.cancelSuggestions",
+        "key": "escape",
+        "when": "editorTextFocus && !editorTabMovesFocus && !inSnippetMode && kilo-code.new.autocomplete.hasSuggestions"
+      },
+      {
+        "command": "kilo-code.new.autocomplete.generateSuggestions",
+        "key": "ctrl+l",
+        "mac": "cmd+l",
+        "when": "editorTextFocus && !editorTabMovesFocus && !inSnippetMode && kilocode.autocomplete.enableSmartInlineTaskKeybinding && !github.copilot.completions.enabled"
+      },
+      {
+        "command": "kilo-code.new.autocomplete.showIncompatibilityExtensionPopup",
+        "key": "ctrl+l",
+        "mac": "cmd+l",
+        "when": "editorTextFocus && !editorTabMovesFocus && !inSnippetMode && kilocode.autocomplete.enableSmartInlineTaskKeybinding && github.copilot.completions.enabled"
       }
     ],
     "configuration": {

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
@@ -315,6 +315,8 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
     _context: vscode.InlineCompletionContext,
     _token: vscode.CancellationToken,
   ): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList> {
+    vscode.commands.executeCommand("setContext", "kilo-code.new.autocomplete.hasSuggestions", false)
+
     // Build telemetry context
     const telemetryContext: AutocompleteContext = {
       languageId: document.languageId,
@@ -372,6 +374,7 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
         }
         this.telemetry?.captureCacheHit(matchingResult.matchType, telemetryContext, matchingResult.text.length)
         this.telemetry?.startVisibilityTracking(matchingResult.fillInAtCursor, "cache", telemetryContext)
+        vscode.commands.executeCommand("setContext", "kilo-code.new.autocomplete.hasSuggestions", true)
         return stringToInlineCompletions(matchingResult.text, position)
       }
 
@@ -398,6 +401,7 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
         }
         this.telemetry?.captureLlmSuggestionReturned(telemetryContext, cachedResult.text.length)
         this.telemetry?.startVisibilityTracking(cachedResult.fillInAtCursor, "llm", telemetryContext)
+        vscode.commands.executeCommand("setContext", "kilo-code.new.autocomplete.hasSuggestions", true)
       } else {
         this.telemetry?.cancelVisibilityTracking() // No suggestion to show - cancel any pending visibility tracking
       }

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
@@ -171,9 +171,10 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
     this.recentlyVisitedRangesService = new RecentlyVisitedRangesService(ide)
     this.recentlyEditedTracker = new RecentlyEditedTracker(ide)
 
-    this.acceptedCommand = vscode.commands.registerCommand(INLINE_COMPLETION_ACCEPTED_COMMAND, () =>
-      this.telemetry?.captureAcceptSuggestion(this.lastSuggestion?.length),
-    )
+    this.acceptedCommand = vscode.commands.registerCommand(INLINE_COMPLETION_ACCEPTED_COMMAND, () => {
+      this.telemetry?.captureAcceptSuggestion(this.lastSuggestion?.length)
+      vscode.commands.executeCommand("setContext", "kilo-code.new.autocomplete.hasSuggestions", false)
+    })
   }
 
   public updateSuggestions(fillInAtCursor: FillInAtCursorSuggestion): void {

--- a/packages/kilo-vscode/src/services/autocomplete/index.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/index.ts
@@ -21,6 +21,12 @@ export const registerAutocompleteProvider = (
     }),
   )
   context.subscriptions.push(
+    vscode.commands.registerCommand("kilo-code.new.autocomplete.cancelSuggestions", () => {
+      vscode.commands.executeCommand("editor.action.inlineSuggest.hide")
+      vscode.commands.executeCommand("setContext", "kilo-code.new.autocomplete.hasSuggestions", false)
+    }),
+  )
+  context.subscriptions.push(
     vscode.commands.registerCommand("kilo-code.new.autocomplete.generateSuggestions", async () => {
       autocompleteManager.codeSuggestion()
     }),


### PR DESCRIPTION
## Summary

- Add `Escape` keybinding to cancel inline autocomplete suggestions (sets/clears `hasSuggestions` context key)
- Add `Ctrl+L` / `Cmd+L` keybinding to manually trigger suggestion generation (with Copilot conflict detection)
- Register new `cancelSuggestions` command that delegates to VS Code's built-in `editor.action.inlineSuggest.hide`

## Details

Ports missing keyboard shortcuts from the legacy extension (issue #6973, Phase 2b+2c from the keyboard shortcuts plan).

### Changes

**`AutocompleteInlineCompletionProvider.ts`** — Sets `kilo-code.new.autocomplete.hasSuggestions` context key to `false` at the start of each completion request, and `true` before returning non-empty completions (both cache hits and LLM results).

**`autocomplete/index.ts`** — Registers `cancelSuggestions` command that hides inline suggestions and clears the context key.

**`package.json`** — Adds 1 command + 3 keybindings:
- `Escape` → cancel suggestions (only when `hasSuggestions` is true)
- `Ctrl+L`/`Cmd+L` → generate suggestions (when autocomplete enabled, Copilot disabled)
- `Ctrl+L`/`Cmd+L` → show incompatibility popup (when autocomplete enabled, Copilot active)

### Conflict analysis
- **Escape**: `when` clause includes `kilo-code.new.autocomplete.hasSuggestions` — only fires when Kilo has active suggestions
- **Ctrl+L**: Gated by existing `enableSmartInlineTaskKeybinding` context key — retains VS Code default (Expand Line Selection) when disabled

## Test plan
- `cancelSuggestions` command appears in command palette
- `Escape` dismisses inline suggestions when visible, normal behavior otherwise
- `Ctrl+L`/`Cmd+L` triggers generation or shows Copilot conflict popup as appropriate

Closes #6973