### PR TITLE
feat(vscode): add generate terminal command shortcut and SCM input menu entry

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -294,6 +294,11 @@
         "command": "kilo-code.new.focusChatInput",
         "title": "Focus Chat Input",
         "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.generateTerminalCommand",
+        "title": "Generate Terminal Command",
+        "category": "Kilo Code"
       }
     ],
     "submenus": [
@@ -345,6 +350,13 @@
         }
       ],
       "scm/title": [
+        {
+          "command": "kilo-code.new.generateCommitMessage",
+          "group": "navigation",
+          "when": "scmProvider == git"
+        }
+      ],
+      "scm/input": [
         {
           "command": "kilo-code.new.generateCommitMessage",
           "group": "navigation",
@@ -408,6 +420,11 @@
         "command": "kilo-code.new.focusChatInput",
         "key": "ctrl+shift+a",
         "mac": "cmd+shift+a"
+      },
+      {
+        "command": "kilo-code.new.generateTerminalCommand",
+        "key": "ctrl+shift+g",
+        "mac": "cmd+shift+g"
       },
       {
         "command": "kilo-code.new.agentManagerOpen",

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -69,7 +69,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   /** Cached notificationsLoaded payload */
   private cachedNotificationsMessage: unknown = null
   private pendingReviewComments: unknown[][] = []
-
+  private readyResolvers: (() => void)[] = []
   private trackedSessionIds: Set<string> = new Set()
   private syncedChildSessions: Set<string> = new Set()
   /** Tracks the latest status for each session, used to warn before destructive config operations. */
@@ -410,6 +410,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           this.isWebviewReady = true
           await this.syncWebviewState("webviewReady")
           this.flushPendingReviewComments()
+          this.readyResolvers.splice(0).forEach((r) => r())
           break
         case "sendMessage": {
           const files = z
@@ -2678,10 +2679,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     })
   }
 
-  /**
-   * Post a message to the webview.
-   * Public so toolbar button commands can send messages.
-   */
+  /** Wait until the webview has sent "webviewReady". Resolves immediately when already ready. */
+  public waitForReady(): Promise<void> {
+    return this.isWebviewReady && this.webview ? Promise.resolve() : new Promise((r) => this.readyResolvers.push(r))
+  }
+  /** Post a message to the webview. Public so toolbar button commands can send messages. */
   public postMessage(message: unknown): void {
     if (!this.webview) {
       const type =

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -103,6 +103,15 @@ export function activate(context: vscode.ExtensionContext) {
       provider.postMessage({ type: "navigate", view: "migration" })
     }),
     // legacy-migration end
+    vscode.commands.registerCommand("kilo-code.new.generateTerminalCommand", async () => {
+      const input = await vscode.window.showInputBox({
+        prompt: "Describe the terminal command you want to generate",
+        placeHolder: "e.g., find all .ts files modified in the last 24 hours",
+      })
+      if (!input) return
+      await vscode.commands.executeCommand("kilo-code.SidebarProvider.focus")
+      provider.postMessage({ type: "triggerTask", text: `Generate a terminal command: ${input}` })
+    }),
     vscode.commands.registerCommand("kilo-code.new.openInTab", () => {
       return openKiloInNewTab(context, connectionService)
     }),

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -110,6 +110,7 @@ export function activate(context: vscode.ExtensionContext) {
       })
       if (!input) return
       await vscode.commands.executeCommand("kilo-code.SidebarProvider.focus")
+      await provider.waitForReady()
       provider.postMessage({ type: "triggerTask", text: `Generate a terminal command: ${input}` })
     }),
     vscode.commands.registerCommand("kilo-code.new.openInTab", () => {


### PR DESCRIPTION
## Summary

- Add `Ctrl+Shift+G` / `Cmd+Shift+G` shortcut to generate terminal commands via AI chat (shows input box, sends description as a task to the sidebar)
- Add `generateCommitMessage` button to the `scm/input` menu (SCM input box), matching the existing `scm/title` toolbar entry
- Uses the existing `triggerTask` message pattern (same as `explainCode`, `fixCode`, etc.) — no new backend or webview changes needed

Closes #6973 (Phase 3 / P2 items)