### PR TITLE
feat(vscode): add `bun run extension` to build and launch dev VS Code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Kilo CLI is an open source AI coding agent that generates code from natural lang
 ## Build and Dev
 
 - **Dev**: `bun run dev` (runs from root) or `bun run --cwd packages/opencode --conditions=browser src/index.ts`
+- **Extension**: `bun run extension` (build + launch VS Code with the extension in dev mode). Pass `--no-build` to skip the build.
 - **Typecheck**: `bun turbo typecheck` (uses `tsgo`, not `tsc`)
 - **Test**: `bun test` from `packages/opencode/` (NOT from root -- root blocks tests)
 - **Single test**: `bun test test/tool/tool.test.ts` from `packages/opencode/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,16 @@ The Kilo Community is [on Discord](https://kilo.ai/discord).
   bun dev
   ```
 
+### Developing the VS Code Extension
+
+Build and launch the extension in an isolated VS Code instance:
+
+```bash
+bun run extension        # Build + launch in dev mode
+```
+
+This auto-detects VS Code on macOS, Linux, and Windows. Override with `--app-path PATH` or `VSCODE_EXEC_PATH`. Use `--insiders` to prefer Insiders, `--workspace PATH` to open a specific folder, or `--clean` to reset cached state.
+
 ### Running against a different directory
 
 By default, `bun dev` runs Kilo CLI in the `packages/opencode` directory. To run it against a different directory or repository:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "prepare": "husky",
     "random": "echo 'Random script'",
     "hello": "echo 'Hello World!'",
-    "test": "echo 'do not run tests from root' && exit 1"
+    "test": "echo 'do not run tests from root' && exit 1",
+    "extension": "bun --cwd packages/kilo-vscode script/launch.ts"
   },
   "workspaces": {
     "packages": [

--- a/packages/kilo-vscode/AGENTS.md
+++ b/packages/kilo-vscode/AGENTS.md
@@ -62,12 +62,15 @@ Every client spawns or connects to a `kilo serve` process and communicates via H
 ## Commands
 
 ```bash
+bun run extension        # Build + launch VS Code with the extension in dev mode
 bun run compile          # Type-check + lint + build
 bun run watch            # Watch mode (esbuild + tsc)
 bun run test             # Run tests (requires pretest compilation)
 bun run lint             # ESLint on src/
 bun run format           # Run formatter (do this before committing to avoid styling-only changes in commits)
 ```
+
+The `extension` commands also work from the repo root. Pass `--insiders` to prefer VS Code Insiders, `--workspace PATH` to open a different folder, `--clean` to wipe cached state, or `--wait` to block until VS Code closes. VS Code is auto-detected on macOS, Linux, and Windows; override with `--app-path` or `VSCODE_EXEC_PATH`.
 
 Single test: `bun run test -- --grep "test name"`
 

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -718,7 +718,8 @@
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
     "snapshot:build": "bun script/dev-snapshot.ts build",
-    "snapshot:install": "bun script/dev-snapshot.ts install"
+    "snapshot:install": "bun script/dev-snapshot.ts install",
+    "extension": "bun script/launch.ts"
   },
   "devDependencies": {
     "@playwright/test": "1.57.0",

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -1,0 +1,338 @@
+#!/usr/bin/env bun
+/**
+ * Build the Kilo VS Code extension and launch it in a development host.
+ *
+ * Usage:
+ *   bun script/launch.ts [options]
+ *
+ * Options:
+ *   --no-build        Skip the build step (reuse last build)
+ *   --workspace PATH  Folder to open in VS Code (default: repo root)
+ *   --mode dev|vsix   "dev" uses --extensionDevelopmentPath, "vsix" packages a VSIX (default: dev)
+ *   --app-path PATH   Explicit path to the VS Code executable (auto-detected if omitted)
+ *   --insiders        Prefer VS Code Insiders over stable
+ *   --wait            Block until the VS Code window is closed
+ *   --clean           Wipe the user-data and extensions dirs before launching
+ *
+ * Environment:
+ *   VSCODE_EXEC_PATH  Path to VS Code executable (same as --app-path)
+ *
+ * Cross-platform: macOS, Linux, and Windows are all supported.
+ *
+ * The script uses a stable directory per repo checkout under the OS temp dir
+ * so nothing accumulates — the same dirs are reused on every launch.
+ */
+import { $ } from "bun"
+import { createHash } from "node:crypto"
+import { existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { delimiter, join, resolve } from "node:path"
+import { spawn } from "node:child_process"
+
+const win = process.platform === "win32"
+const root = join(import.meta.dir, "..")
+const repo = resolve(root, "..", "..")
+
+// Stable per-repo directory under OS temp — no accumulation
+const hash = createHash("sha256").update(repo).digest("hex").slice(0, 12)
+const base = join(tmpdir(), `kilo-vscode-dev-${hash}`)
+const userDir = join(base, "user-data")
+const extDir = join(base, "extensions")
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+function parse(argv: string[]) {
+  const result: Record<string, string | boolean> = {}
+
+  for (let i = 0; i < argv.length; i++) {
+    const item = argv[i]!
+    if (!item.startsWith("--")) continue
+
+    if (item.startsWith("--no-")) {
+      result[item.slice(5)] = false
+      continue
+    }
+
+    const parts = item.slice(2).split("=", 2)
+    const key = parts[0]!
+    const raw = parts[1]
+    if (raw !== undefined) {
+      result[key] = raw
+      continue
+    }
+
+    const next = argv[i + 1]
+    if (!next || next.startsWith("--")) {
+      result[key] = true
+      continue
+    }
+
+    result[key] = next
+    i++
+  }
+
+  return result
+}
+
+const opts = parse(process.argv.slice(2))
+const shouldBuild = opts["build"] !== false
+const mode = (opts["mode"] as string) ?? "dev"
+const workspace = opts["workspace"] ? resolve(opts["workspace"] as string) : repo
+const insiders = opts["insiders"] === true
+const explicit = opts["app-path"] as string | undefined
+const blocking = opts["wait"] === true
+const clean = opts["clean"] === true
+
+// ---------------------------------------------------------------------------
+// VS Code executable detection
+// ---------------------------------------------------------------------------
+
+function which(name: string): string | null {
+  const paths = (process.env.PATH ?? "").split(delimiter).filter(Boolean)
+  const exts = win ? [".cmd", ".exe", ".bat", ""] : [""]
+
+  for (const dir of paths) {
+    for (const ext of exts) {
+      const full = join(dir, name.endsWith(ext) ? name : `${name}${ext}`)
+      if (existsSync(full)) return full
+    }
+  }
+
+  return null
+}
+
+function detect(): string {
+  const env = explicit ?? process.env["VSCODE_EXEC_PATH"]
+  if (env && existsSync(env)) return env
+
+  const candidates: string[] = []
+  const prefer = insiders ? "insiders" : "stable"
+
+  if (process.platform === "darwin") {
+    const order =
+      prefer === "insiders"
+        ? [
+            "/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Code - Insiders",
+            "/Applications/Visual Studio Code.app/Contents/MacOS/Code",
+          ]
+        : [
+            "/Applications/Visual Studio Code.app/Contents/MacOS/Code",
+            "/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Code - Insiders",
+          ]
+    candidates.push(...order)
+  }
+
+  if (process.platform === "linux") {
+    const stable = [
+      "/usr/share/code/code",
+      "/usr/bin/code",
+      "/snap/code/current/usr/share/code/code",
+      "/var/lib/flatpak/exports/bin/com.visualstudio.code",
+    ]
+    const ins = [
+      "/usr/share/code-insiders/code-insiders",
+      "/usr/bin/code-insiders",
+      "/snap/code-insiders/current/usr/share/code-insiders/code-insiders",
+      "/var/lib/flatpak/exports/bin/com.visualstudio.code.insiders",
+    ]
+    candidates.push(...(prefer === "insiders" ? [...ins, ...stable] : [...stable, ...ins]))
+  }
+
+  if (win) {
+    const local = process.env["LOCALAPPDATA"] ?? ""
+    const program = process.env["PROGRAMFILES"] ?? "C:\\Program Files"
+
+    const stable = [
+      join(local, "Programs", "Microsoft VS Code", "Code.exe"),
+      join(program, "Microsoft VS Code", "Code.exe"),
+    ]
+    const ins = [
+      join(local, "Programs", "Microsoft VS Code Insiders", "Code - Insiders.exe"),
+      join(program, "Microsoft VS Code Insiders", "Code - Insiders.exe"),
+    ]
+    candidates.push(...(prefer === "insiders" ? [...ins, ...stable] : [...stable, ...ins]))
+  }
+
+  const found = candidates.find((c) => existsSync(c))
+  if (found) return found
+
+  // Last resort: PATH lookup
+  const path = insiders ? (which("code-insiders") ?? which("code")) : (which("code") ?? which("code-insiders"))
+  if (path) return path
+
+  console.error(
+    `Could not find VS Code. Set VSCODE_EXEC_PATH or pass --app-path.\n` +
+      `Searched:\n${candidates.map((c) => `  ${c}`).join("\n")}`,
+  )
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// CLI path detection (needed for --mode vsix)
+// ---------------------------------------------------------------------------
+
+function codeCli(app: string): string {
+  const name = app.toLowerCase().includes("insiders") ? "code-insiders" : "code"
+  const direct = which(name)
+  if (direct) return direct
+
+  if (process.platform === "darwin") {
+    const bundled = app.includes("Insiders")
+      ? "/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code"
+      : "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+    if (existsSync(bundled)) return bundled
+  }
+
+  console.error(`VS Code CLI (${name}) not found on PATH. Install the shell command or use --mode dev instead.`)
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function newest(paths: string[]) {
+  return [...paths].sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs)
+}
+
+// ---------------------------------------------------------------------------
+// Build
+// ---------------------------------------------------------------------------
+
+async function compile() {
+  if (!shouldBuild) {
+    console.log("[launch] Skipping build (--no-build)")
+    return
+  }
+
+  console.log("[launch] Building extension...")
+  await $`bun run package`.cwd(root)
+  console.log("[launch] Build complete")
+}
+
+// ---------------------------------------------------------------------------
+// VSIX packaging (only for --mode vsix)
+// ---------------------------------------------------------------------------
+
+async function packageVsix(out: string): Promise<string> {
+  await $`bunx vsce package --no-dependencies --skip-license -o ${out}/`.cwd(root)
+  const files = newest(
+    readdirSync(out)
+      .filter((f) => f.endsWith(".vsix"))
+      .map((f) => join(out, f)),
+  )
+  const vsix = files.at(0)
+  if (!vsix) {
+    console.error(`No VSIX was created in ${out}`)
+    process.exit(1)
+  }
+  return vsix
+}
+
+async function installVsix(path: string, app: string) {
+  const cmd = codeCli(app)
+  await $`${cmd} --extensions-dir ${extDir} --user-data-dir ${userDir} --install-extension ${path} --force`.cwd(root)
+}
+
+// ---------------------------------------------------------------------------
+// Settings for isolated instance
+// ---------------------------------------------------------------------------
+
+function settings() {
+  const dir = join(userDir, "User")
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, "settings.json"),
+    JSON.stringify(
+      {
+        "editor.accessibilitySupport": "off",
+        "extensions.autoCheckUpdates": false,
+        "extensions.autoUpdate": false,
+        "extensions.ignoreRecommendations": true,
+        "security.workspace.trust.enabled": false,
+        "task.allowAutomaticTasks": "off",
+        "telemetry.telemetryLevel": "off",
+        "update.mode": "none",
+        "workbench.startupEditor": "none",
+        "workbench.tips.enabled": false,
+        "window.commandCenter": false,
+      },
+      null,
+      2,
+    ) + "\n",
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Launch
+// ---------------------------------------------------------------------------
+
+async function launch() {
+  await compile()
+
+  if (clean) {
+    console.log("[launch] Cleaning previous state...")
+    rmSync(base, { recursive: true, force: true })
+  }
+
+  mkdirSync(userDir, { recursive: true })
+  mkdirSync(extDir, { recursive: true })
+
+  const app = detect()
+
+  settings()
+
+  const args = [workspace, `--extensions-dir=${extDir}`, `--user-data-dir=${userDir}`, "--skip-release-notes"]
+
+  if (mode === "dev") {
+    args.push(`--extensionDevelopmentPath=${root}`)
+    args.push("--disable-extension=kilocode.kilo-code")
+  }
+
+  if (mode === "vsix") {
+    const out = join(base, "vsix")
+    mkdirSync(out, { recursive: true })
+    const vsix = await packageVsix(out)
+    await installVsix(vsix, app)
+    console.log(`[launch] Installed VSIX: ${vsix}`)
+  }
+
+  if (blocking) {
+    args.push("--wait")
+  }
+
+  console.log(`[launch] Starting VS Code (${mode} mode)`)
+  console.log(`[launch] Executable: ${app}`)
+  console.log(`[launch] Workspace:  ${workspace}`)
+  console.log(`[launch] State:      ${base}`)
+
+  if (blocking) {
+    const result = Bun.spawnSync([app, ...args], {
+      cwd: workspace,
+      env: process.env,
+      stdio: ["ignore", "inherit", "inherit"],
+    })
+    console.log(`[launch] VS Code exited (code ${result.exitCode})`)
+    return
+  }
+
+  const child = spawn(app, args, {
+    cwd: workspace,
+    detached: !win,
+    env: process.env,
+    stdio: "ignore",
+    ...(win ? { shell: true } : {}),
+  })
+  child.unref()
+
+  console.log(`[launch] VS Code launched (pid ${child.pid})`)
+}
+
+try {
+  await launch()
+} catch (err) {
+  console.error(`[launch] ERROR: ${err instanceof Error ? err.message : String(err)}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

- Add `packages/kilo-vscode/script/launch.ts` — a cross-platform script that builds the extension and launches an isolated VS Code instance in development mode
- Add `bun run extension` script to both root and `packages/kilo-vscode/` package.json
- Document the new command in `AGENTS.md`, `packages/kilo-vscode/AGENTS.md`, and `CONTRIBUTING.md`

## Details

The script replaces a manual fish shell one-liner with a single command that works on macOS, Linux, and Windows:

```bash
bun run extension          # build + launch
bun run extension --no-build  # skip build, reuse last
```

**VS Code detection** covers standard install paths for all three platforms (including snap, flatpak on Linux), PATH lookup, and `VSCODE_EXEC_PATH` / `--app-path` override.

**Isolation**: launches VS Code with `--extensionDevelopmentPath`, `--user-data-dir`, and `--extensions-dir` pointing to a stable temp directory keyed by repo path hash — no accumulation across runs.

**Flags**: `--no-build`, `--mode dev|vsix`, `--insiders`, `--workspace PATH`, `--clean`, `--wait`, `--app-path PATH`