### PR TITLE
refactor: replace x-opencode-* headers with x-kilo-* across codebase and upstream scripts

### DIFF
--- a/packages/opencode/src/control-plane/adaptors/worktree.ts
+++ b/packages/opencode/src/control-plane/adaptors/worktree.ts
@@ -38,7 +38,7 @@ export const WorktreeAdaptor: Adaptor = {
     const { WorkspaceServer } = await import("../workspace-server/server")
     const url = input instanceof Request || input instanceof URL ? input : new URL(input, "http://kilo.internal")
     const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined))
-    headers.set("x-opencode-directory", config.directory)
+    headers.set("x-kilo-directory", config.directory)
 
     const request = new Request(url, { ...init, headers })
     return WorkspaceServer.App().fetch(request)

--- a/packages/opencode/src/control-plane/workspace-server/server.ts
+++ b/packages/opencode/src/control-plane/workspace-server/server.ts
@@ -20,8 +20,8 @@ export namespace WorkspaceServer {
 
     return new Hono()
       .use(async (c, next) => {
-        const workspaceID = c.req.query("workspace") || c.req.header("x-opencode-workspace")
-        const raw = c.req.query("directory") || c.req.header("x-opencode-directory")
+        const workspaceID = c.req.query("workspace") || c.req.header("x-kilo-workspace")
+        const raw = c.req.query("directory") || c.req.header("x-kilo-directory")
         if (workspaceID == null) {
           throw new Error("workspaceID parameter is required")
         }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -213,8 +213,8 @@ export namespace Server {
         )
         .use(async (c, next) => {
           if (c.req.path === "/log") return next()
-          const workspaceID = c.req.query("workspace") || c.req.header("x-opencode-workspace")
-          const raw = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
+          const workspaceID = c.req.query("workspace") || c.req.header("x-kilo-workspace")
+          const raw = c.req.query("directory") || c.req.header("x-kilo-directory") || process.cwd()
           const directory = Filesystem.resolve(
             (() => {
               try {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -226,9 +226,9 @@ export namespace LLM {
       headers: {
         ...(input.model.providerID.startsWith("opencode")
           ? {
-              "x-opencode-project": Instance.project.id,
-              "x-opencode-session": input.sessionID,
-              "x-opencode-request": input.user.id,
+              "x-kilo-project": Instance.project.id,
+              "x-kilo-session": input.sessionID,
+              "x-kilo-request": input.user.id,
               "x-kilo-client": Flag.KILO_CLIENT,
             }
           : input.model.providerID !== "anthropic"

--- a/packages/opencode/test/control-plane/workspace-server-sse.test.ts
+++ b/packages/opencode/test/control-plane/workspace-server-sse.test.ts
@@ -22,8 +22,8 @@ describe("control-plane/workspace-server SSE", () => {
       const response = await app.request("/event", {
         signal: stop.signal,
         headers: {
-          "x-opencode-workspace": "wrk_test_workspace",
-          "x-opencode-directory": tmp.path,
+          "x-kilo-workspace": "wrk_test_workspace",
+          "x-kilo-directory": tmp.path,
         },
       })
 

--- a/packages/opencode/test/server/project-init-git.test.ts
+++ b/packages/opencode/test/server/project-init-git.test.ts
@@ -32,7 +32,7 @@ describe("project.initGit endpoint", () => {
       const init = await app.request("/project/git/init", {
         method: "POST",
         headers: {
-          "x-opencode-directory": tmp.path,
+          "x-kilo-directory": tmp.path,
         },
       })
       const body = await init.json()
@@ -51,7 +51,7 @@ describe("project.initGit endpoint", () => {
 
       const current = await app.request("/project/current", {
         headers: {
-          "x-opencode-directory": tmp.path,
+          "x-kilo-directory": tmp.path,
         },
       })
       expect(current.status).toBe(200)
@@ -88,7 +88,7 @@ describe("project.initGit endpoint", () => {
       const init = await app.request("/project/git/init", {
         method: "POST",
         headers: {
-          "x-opencode-directory": tmp.path,
+          "x-kilo-directory": tmp.path,
         },
       })
       expect(init.status).toBe(200)
@@ -103,7 +103,7 @@ describe("project.initGit endpoint", () => {
 
       const current = await app.request("/project/current", {
         headers: {
-          "x-opencode-directory": tmp.path,
+          "x-kilo-directory": tmp.path,
         },
       })
       expect(current.status).toBe(200)

--- a/packages/sdk/js/src/client.ts
+++ b/packages/sdk/js/src/client.ts
@@ -21,7 +21,7 @@ export function createKiloClient(config?: Config & { directory?: string }) {
   if (config?.directory) {
     config.headers = {
       ...config.headers,
-      "x-opencode-directory": encodeURIComponent(config.directory),
+      "x-kilo-directory": encodeURIComponent(config.directory),
     }
   }
 

--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -23,14 +23,14 @@ export function createKiloClient(config?: Config & { directory?: string; experim
     const encodedDirectory = isNonASCII ? encodeURIComponent(config.directory) : config.directory
     config.headers = {
       ...config.headers,
-      "x-opencode-directory": encodedDirectory,
+      "x-kilo-directory": encodedDirectory,
     }
   }
 
   if (config?.experimental_workspaceID) {
     config.headers = {
       ...config.headers,
-      "x-opencode-workspace": config.experimental_workspaceID,
+      "x-kilo-workspace": config.experimental_workspaceID,
     }
   }
 

--- a/script/upstream/codemods/transform-strings.ts
+++ b/script/upstream/codemods/transform-strings.ts
@@ -40,6 +40,9 @@ const STRING_REPLACEMENTS: StringReplacement[] = [
   // Binary name references (be careful with these)
   { pattern: /\bopencode upgrade\b/g, replacement: "kilo upgrade" },
 
+  // HTTP header prefix
+  { pattern: /x-opencode-/g, replacement: "x-kilo-" },
+
   // Environment variables (exclude OPENCODE_API_KEY - upstream Zen SaaS key)
   { pattern: /\bOPENCODE_(?!API_KEY\b)([A-Z_]+)\b/g, replacement: "KILO_$1" },
   { pattern: /\bVITE_OPENCODE_/g, replacement: "VITE_KILO_" },

--- a/script/upstream/transforms/transform-take-theirs.ts
+++ b/script/upstream/transforms/transform-take-theirs.ts
@@ -122,9 +122,9 @@ const BRANDING_REPLACEMENTS: BrandingReplacement[] = [
     description: "Window global",
   },
   {
-    pattern: /x-opencode-client/g,
-    replacement: "x-kilo-client",
-    description: "HTTP header",
+    pattern: /x-opencode-/g,
+    replacement: "x-kilo-",
+    description: "HTTP header prefix",
   },
   {
     pattern: /_EXTENSION_OPENCODE_/g,


### PR DESCRIPTION
## Context

Replace all `x-opencode-*` HTTP headers with `x-kilo-*` across the codebase and update the upstream merge scripts to automatically handle this transformation during future merges.

The upstream OpenCode project uses `x-opencode-*` headers for internal HTTP communication (directory, workspace, project, session, request, client). These were not being fully transformed to Kilo branding — only `x-opencode-client` had a specific rule. This PR adds a generic transform and applies the replacement to all existing files.

## Implementation

### Part 1: Upstream merge script updates

- **`script/upstream/transforms/transform-take-theirs.ts`** — Replaced the specific `x-opencode-client` → `x-kilo-client` rule with a generic `x-opencode-` → `x-kilo-` regex. This catches all current and future `x-opencode-*` headers automatically during upstream merges.
- **`script/upstream/codemods/transform-strings.ts`** — Added `x-opencode-` → `x-kilo-` to `STRING_REPLACEMENTS` for AST-based string literal transforms.

### Part 2: Source file replacements (8 files)

Applied the header rename across all files that use `x-opencode-*` headers, keeping SDK clients and servers in sync:

| File | Headers replaced |
|------|-----------------|
| `packages/sdk/js/src/v2/client.ts` | directory, workspace |
| `packages/sdk/js/src/client.ts` | directory |
| `packages/opencode/src/server/server.ts` | workspace, directory |
| `packages/opencode/src/session/llm.ts` | project, session, request |
| `packages/opencode/src/control-plane/adaptors/worktree.ts` | directory |
| `packages/opencode/src/control-plane/workspace-server/server.ts` | workspace, directory |
| `packages/opencode/test/server/project-init-git.test.ts` | directory (4 occurrences) |
| `packages/opencode/test/control-plane/workspace-server-sse.test.ts` | workspace, directory |

## Screenshots

N/A — no UI changes.

## How to Test

1. Run `bun turbo typecheck` — all 12 packages should pass
2. Run `bun test` from `packages/opencode/` — header-related tests should pass (the `project-init-git` test that doesn't require git identity confirms the new headers work end-to-end)
3. Verify no remaining `x-opencode-` references: `rg 'x-opencode-' --glob '!.git' --glob '!script/upstream/' --glob '!.kilocode/' --glob '!*.md' --glob '!node_modules'` should return zero results
