### PR TITLE
feat(vscode): add keyboard shortcuts to permission prompt

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -108,9 +108,11 @@ export const PermissionDock: Component<{
   const focusPrompt = () => requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
 
   const onRoot = (e: KeyboardEvent) => {
-    // Ignore key events from interactive elements inside the rules section
+    // Only handle shortcuts when focus is on the dock wrapper itself.
+    // Skip buttons (toggle/expand controls), inputs, and textareas so
+    // Enter activates the focused control instead of approving the permission.
     const tag = (e.target as HTMLElement).tagName
-    if (tag === "INPUT" || tag === "TEXTAREA") return
+    if (tag === "BUTTON" || tag === "INPUT" || tag === "TEXTAREA") return
 
     if (e.key === "Escape") {
       e.preventDefault()

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -108,12 +108,10 @@ export const PermissionDock: Component<{
   const focusPrompt = () => requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
 
   const onRoot = (e: KeyboardEvent) => {
-    // Only handle shortcuts when focus is on the dock wrapper itself.
-    // Skip buttons (toggle/expand controls), inputs, and textareas so
-    // Enter activates the focused control instead of approving the permission.
     const tag = (e.target as HTMLElement).tagName
-    if (tag === "BUTTON" || tag === "INPUT" || tag === "TEXTAREA") return
 
+    // Escape always denies — even from focused buttons — and stopPropagation
+    // prevents ChatView's global Escape handler from calling session.abort().
     if (e.key === "Escape") {
       e.preventDefault()
       e.stopPropagation()
@@ -123,6 +121,11 @@ export const PermissionDock: Component<{
       focusPrompt()
       return
     }
+
+    // Enter approves, but only when focus is on the dock wrapper itself.
+    // Skip buttons, inputs, and textareas so Enter activates the focused
+    // control (e.g. toggle/expand) instead of approving the permission.
+    if (tag === "BUTTON" || tag === "INPUT" || tag === "TEXTAREA") return
     if (e.key === "Enter") {
       e.preventDefault()
       e.stopPropagation()

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -9,7 +9,7 @@
  * The command buttons (Deny / Run) control the current command.
  */
 
-import { Component, For, Show, createMemo, createSignal } from "solid-js"
+import { Component, For, Show, createEffect, createMemo, createSignal } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { DockPrompt } from "@kilocode/kilo-ui/dock-prompt"
 import { Icon } from "@kilocode/kilo-ui/icon"
@@ -52,6 +52,8 @@ export const PermissionDock: Component<{
   const loadState = savedRuleStates(rules(), saved)
   const [decisions, setDecisions] = createSignal<Record<number, RuleDecision>>(loadState)
   const [expanded, setExpanded] = createSignal(rulesExpandedPreference)
+
+  let root!: HTMLDivElement
 
   const hasRules = () => rules().length > 0
 
@@ -103,121 +105,156 @@ export const PermissionDock: Component<{
   const title = () =>
     fromChild() ? language.t("notification.permission.titleSubagent") : language.t("notification.permission.title")
 
-  return (
-    <DockPrompt
-      kind="permission"
-      header={
-        <div data-slot="permission-row" data-variant="header">
-          <span data-slot="permission-icon">
-            <Icon name="warning" size="small" />
-          </span>
-          <div data-slot="permission-header-title">{title()}</div>
-        </div>
-      }
-      footer={
-        <Show when={hasRules()}>
-          <div data-slot="permission-rules-section">
-            <button
-              type="button"
-              data-slot="permission-rules-header"
-              data-open={expanded() ? "" : undefined}
-              onClick={toggleExpanded}
-              aria-expanded={expanded()}
-            >
-              <span data-slot="permission-rules-header-chevron" data-open={expanded() ? "" : undefined}>
-                <Icon name="chevron-down" size="small" />
-              </span>
-              <span data-slot="permission-rules-header-title">{language.t("ui.permission.manageAutoApprove")}</span>
-            </button>
+  const focusPrompt = () => requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
 
-            <div data-slot="permission-rules-collapse" data-open={expanded() ? "" : undefined}>
-              <div data-slot="permission-rules-collapse-inner">
-                <div data-slot="permission-rules">
-                  <For each={rules()}>
-                    {(rule, index) => (
-                      <div data-slot="permission-rule-row" data-decision={decision(index())}>
-                        <div data-slot="permission-rule-actions">
-                          <Tooltip value={approveTooltip(index())} placement="top">
-                            <button
-                              data-slot="permission-rule-toggle"
-                              data-variant="approve"
-                              data-active={decision(index()) === "approved" ? "" : undefined}
-                              disabled={props.responding}
-                              onClick={() => toggleRule(index(), "approved")}
-                              aria-label={approveTooltip(index())}
-                            >
-                              <Icon name="check-small" size="small" />
-                            </button>
-                          </Tooltip>
-                          <Tooltip value={denyTooltip(index())} placement="top">
-                            <button
-                              data-slot="permission-rule-toggle"
-                              data-variant="deny"
-                              data-active={decision(index()) === "denied" ? "" : undefined}
-                              disabled={props.responding}
-                              onClick={() => toggleRule(index(), "denied")}
-                              aria-label={denyTooltip(index())}
-                            >
-                              <Icon name="close-small" size="small" />
-                            </button>
-                          </Tooltip>
+  const onRoot = (e: KeyboardEvent) => {
+    // Ignore key events from interactive elements inside the rules section
+    const tag = (e.target as HTMLElement).tagName
+    if (tag === "INPUT" || tag === "TEXTAREA") return
+
+    if (e.key === "Escape") {
+      e.preventDefault()
+      e.stopPropagation()
+      if (props.responding) return
+      const { approved, denied } = collectRules()
+      props.onDecide("reject", approved, denied)
+      focusPrompt()
+      return
+    }
+    if (e.key === "Enter") {
+      e.preventDefault()
+      e.stopPropagation()
+      if (props.responding) return
+      const { approved, denied } = collectRules()
+      props.onDecide("once", approved, denied)
+      focusPrompt()
+      return
+    }
+  }
+
+  // Auto-focus the dock when it appears so keyboard shortcuts work immediately
+  createEffect(() => {
+    void props.request.id
+    requestAnimationFrame(() => root?.focus())
+  })
+
+  return (
+    <div ref={root} tabIndex={-1} onKeyDown={onRoot} style={{ outline: "none" }}>
+      <DockPrompt
+        kind="permission"
+        header={
+          <div data-slot="permission-row" data-variant="header">
+            <span data-slot="permission-icon">
+              <Icon name="warning" size="small" />
+            </span>
+            <div data-slot="permission-header-title">{title()}</div>
+          </div>
+        }
+        footer={
+          <Show when={hasRules()}>
+            <div data-slot="permission-rules-section">
+              <button
+                type="button"
+                data-slot="permission-rules-header"
+                data-open={expanded() ? "" : undefined}
+                onClick={toggleExpanded}
+                aria-expanded={expanded()}
+              >
+                <span data-slot="permission-rules-header-chevron" data-open={expanded() ? "" : undefined}>
+                  <Icon name="chevron-down" size="small" />
+                </span>
+                <span data-slot="permission-rules-header-title">{language.t("ui.permission.manageAutoApprove")}</span>
+              </button>
+
+              <div data-slot="permission-rules-collapse" data-open={expanded() ? "" : undefined}>
+                <div data-slot="permission-rules-collapse-inner">
+                  <div data-slot="permission-rules">
+                    <For each={rules()}>
+                      {(rule, index) => (
+                        <div data-slot="permission-rule-row" data-decision={decision(index())}>
+                          <div data-slot="permission-rule-actions">
+                            <Tooltip value={approveTooltip(index())} placement="top">
+                              <button
+                                data-slot="permission-rule-toggle"
+                                data-variant="approve"
+                                data-active={decision(index()) === "approved" ? "" : undefined}
+                                disabled={props.responding}
+                                onClick={() => toggleRule(index(), "approved")}
+                                aria-label={approveTooltip(index())}
+                              >
+                                <Icon name="check-small" size="small" />
+                              </button>
+                            </Tooltip>
+                            <Tooltip value={denyTooltip(index())} placement="top">
+                              <button
+                                data-slot="permission-rule-toggle"
+                                data-variant="deny"
+                                data-active={decision(index()) === "denied" ? "" : undefined}
+                                disabled={props.responding}
+                                onClick={() => toggleRule(index(), "denied")}
+                                aria-label={denyTooltip(index())}
+                              >
+                                <Icon name="close-small" size="small" />
+                              </button>
+                            </Tooltip>
+                          </div>
+                          <code data-slot="permission-rule">
+                            {command()
+                              ? label(rule)
+                              : rule === "*"
+                                ? resolveLabel(props.request.toolName, language.t)
+                                : `${resolveLabel(props.request.toolName, language.t)} ${rule}`}
+                          </code>
                         </div>
-                        <code data-slot="permission-rule">
-                          {command()
-                            ? label(rule)
-                            : rule === "*"
-                              ? resolveLabel(props.request.toolName, language.t)
-                              : `${resolveLabel(props.request.toolName, language.t)} ${rule}`}
-                        </code>
-                      </div>
-                    )}
-                  </For>
+                      )}
+                    </For>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </Show>
-      }
-    >
-      <Show when={command()}>{(cmd) => <PermissionCommand command={cmd()} />}</Show>
+          </Show>
+        }
+      >
+        <Show when={command()}>{(cmd) => <PermissionCommand command={cmd()} />}</Show>
 
-      {(() => {
-        const desc = description()
-        if (!desc)
-          return !command() && toolDescription() ? <div data-slot="permission-hint">{toolDescription()}</div> : null
-        if (desc.kind === "single") return <div data-slot="permission-hint">{desc.text}</div>
-        return (
-          <div data-slot="permission-patterns">
-            <span data-slot="permission-patterns-title">{desc.title}</span>
-            <For each={desc.paths}>{(path) => <code data-slot="permission-pattern">{path}</code>}</For>
-          </div>
-        )
-      })()}
+        {(() => {
+          const desc = description()
+          if (!desc)
+            return !command() && toolDescription() ? <div data-slot="permission-hint">{toolDescription()}</div> : null
+          if (desc.kind === "single") return <div data-slot="permission-hint">{desc.text}</div>
+          return (
+            <div data-slot="permission-patterns">
+              <span data-slot="permission-patterns-title">{desc.title}</span>
+              <For each={desc.paths}>{(path) => <code data-slot="permission-pattern">{path}</code>}</For>
+            </div>
+          )
+        })()}
 
-      <div data-slot="permission-actions">
-        <Button
-          variant="primary"
-          size="small"
-          onClick={() => {
-            const { approved, denied } = collectRules()
-            props.onDecide("once", approved, denied)
-          }}
-          disabled={props.responding}
-        >
-          {language.t("ui.permission.run")}
-        </Button>
-        <Button
-          variant="ghost"
-          size="small"
-          onClick={() => {
-            const { approved, denied } = collectRules()
-            props.onDecide("reject", approved, denied)
-          }}
-          disabled={props.responding}
-        >
-          {language.t("ui.permission.deny")}
-        </Button>
-      </div>
-    </DockPrompt>
+        <div data-slot="permission-actions">
+          <Button
+            variant="primary"
+            size="small"
+            onClick={() => {
+              const { approved, denied } = collectRules()
+              props.onDecide("once", approved, denied)
+            }}
+            disabled={props.responding}
+          >
+            {language.t("ui.permission.run")}
+          </Button>
+          <Button
+            variant="ghost"
+            size="small"
+            onClick={() => {
+              const { approved, denied } = collectRules()
+              props.onDecide("reject", approved, denied)
+            }}
+            disabled={props.responding}
+          >
+            {language.t("ui.permission.deny")}
+          </Button>
+        </div>
+      </DockPrompt>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary

- Add keyboard controls to the permission dock: **Enter** to approve (Run), **Escape** to deny
- Auto-focus the dock when a permission request appears so keyboard works immediately
- Follows the same pattern as `QuestionDock` which already has keyboard support
- Uses `stopPropagation` to prevent `ChatView`'s global Escape handler from firing `session.abort()` when denying a permission

## Details

The permission prompt previously required mouse interaction. This adds:

| Key | Action |
|---|---|
| `Enter` | Run (approve once) |
| `Escape` | Deny (reject) |

Both shortcuts respect the per-rule toggle states from the "Manage auto-approve" section, and return focus to the prompt input after acting. Events from INPUT/TEXTAREA elements inside the dock are ignored to avoid conflicts.