### PR TITLE
fix(vscode): fix typecheck error in AgentManagerProvider.getSessionDirectories

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1793,7 +1793,7 @@ export class AgentManagerProvider implements Disposable {
 
   /** Expose worktree session→directory mappings for the auto-approve toggle. */
   public getSessionDirectories(): ReadonlyMap<string, string> {
-    return this.provider?.getSessionDirectories() ?? new Map()
+    return this.panel?.sessions.getSessionDirectories() ?? new Map()
   }
 
   public postMessage(message: unknown): void {

--- a/packages/kilo-vscode/src/agent-manager/host.ts
+++ b/packages/kilo-vscode/src/agent-manager/host.ts
@@ -34,6 +34,7 @@ export interface OutputHandle {
 export interface SessionProvider {
   setSessionDirectory(id: string, directory: string): void
   clearSessionDirectory(id: string): void
+  getSessionDirectories(): ReadonlyMap<string, string>
   trackSession(id: string): void
   refreshSessions(): void
   registerSession(session: Session): void

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -81,6 +81,7 @@ export class VscodeHost implements Host {
     const sessions: SessionProvider = {
       setSessionDirectory: (id, dir) => provider.setSessionDirectory(id, dir),
       clearSessionDirectory: (id) => provider.clearSessionDirectory(id),
+      getSessionDirectories: () => provider.getSessionDirectories(),
       trackSession: (id) => provider.trackSession(id),
       refreshSessions: () => provider.refreshSessions(),
       registerSession: (s) => provider.registerSession(s),


### PR DESCRIPTION
## Summary

- Fixes typecheck failure introduced by #7347 where `AgentManagerProvider.getSessionDirectories()` referenced `this.provider` which doesn't exist on the class
- Adds `getSessionDirectories()` to the `SessionProvider` interface and wires it through `vscode-host.ts`
- Routes the call through `this.panel.sessions` which is the correct abstraction for accessing the underlying `KiloProvider`