### PR TITLE
fix(ui): defer popover dismiss listeners to prevent premature close in modals

### DIFF
--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -104,13 +104,23 @@ export function Popover<T extends ValidComponent = "div">(props: PopoverProps<T>
     }
 
     window.addEventListener("keydown", onKeyDown, true)
-    window.addEventListener("pointerdown", onPointerDown, true)
-    window.addEventListener("focusin", onFocusIn, true)
+
+    // Defer pointer/focus listeners so the portal content has time to mount
+    // and contentRef is assigned. Without this, autofocus or modal focus-trap
+    // events fire before the ref exists, causing the popover to immediately close.
+    const pending = {
+      id: requestAnimationFrame(() => {
+        pending.id = 0
+        window.addEventListener("pointerdown", onPointerDown, true)
+        window.addEventListener("focusin", onFocusIn, true)
+      }),
+    }
 
     onCleanup(() => {
       window.removeEventListener("keydown", onKeyDown, true)
       window.removeEventListener("pointerdown", onPointerDown, true)
       window.removeEventListener("focusin", onFocusIn, true)
+      if (pending.id) cancelAnimationFrame(pending.id)
     })
   })
 


### PR DESCRIPTION
## Summary

- Fixes dropdown "blink and die" bug in the Agent Manager's worktree creation dialog where all dropdowns (base branch, model selector, mode switcher, compare models, import branch) would flash open then immediately close and become unresponsive
- Defers registration of `pointerdown` and `focusin` dismiss listeners in the Popover component by one animation frame, allowing the portal content to mount and `contentRef` to be assigned before dismiss logic starts listening

## Root Cause

When a `Popover` opens inside a modal Kobalte `Dialog` (as in the Agent Manager), the custom dismiss handlers registered in `popover.tsx` race against portal mounting:

1. `createEffect` fires when `opened()` becomes true → registers `onFocusIn` capture listener immediately
2. Portal content hasn't mounted yet → `contentRef()` is `undefined`
3. `autofocus` on the search input (or the Dialog's focus trap) fires a `focusin` event
4. `inside()` check fails because `contentRef()` isn't set → popover closes itself

## Fix

Defer `pointerdown` and `focusin` listener registration by one `requestAnimationFrame`, giving the portal time to mount. The `keydown` (Escape) listener remains immediate since it doesn't depend on portal mounting.

Closes #7333