### PR TITLE
fix(ui): truncate long file names and paths in tool triggers

### DIFF
--- a/packages/kilo-ui/src/components/basic-tool.css
+++ b/packages/kilo-ui/src/components/basic-tool.css
@@ -10,6 +10,11 @@
     font-size: 12px;
   }
 
+  [data-slot="basic-tool-tool-info-structured"] {
+    min-width: 0;
+    overflow: hidden;
+  }
+
   [data-slot="message-part-title"] {
     align-items: baseline;
   }
@@ -20,6 +25,7 @@
 
   [data-slot="basic-tool-tool-info-main"] {
     align-items: baseline;
+    overflow: hidden;
   }
 
   [data-slot="basic-tool-icon"] {
@@ -40,6 +46,57 @@
 
   [data-slot="message-part-title-filename"] {
     font-size: 12px;
+  }
+
+  [data-slot="message-part-meta-line"] {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    overflow: hidden;
+    white-space: nowrap;
+    min-width: 0;
+    flex-shrink: 1;
+    font-size: 12px;
+
+    &.clickable {
+      cursor: pointer;
+      transition: color 0.15s ease;
+
+      &:hover {
+        color: var(--text-base);
+      }
+    }
+  }
+
+  [data-slot="message-part-title-filename"] {
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    direction: rtl;
+    text-align: left;
+  }
+
+  [data-slot="message-part-directory-inline"] {
+    color: var(--text-weak);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    direction: rtl;
+    text-align: left;
+    flex-shrink: 1;
+    min-width: 0;
+    font-size: 12px;
+  }
+
+  [data-slot="webfetch-meta"] {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    overflow: hidden;
+    min-width: 0;
+    flex-shrink: 1;
   }
 }
 

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -37,6 +37,59 @@
   [data-slot="message-part-title-text"] {
     flex-shrink: 0;
   }
+
+  [data-slot="message-part-meta-line"] {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    overflow: hidden;
+    white-space: nowrap;
+    min-width: 0;
+    flex-shrink: 1;
+
+    &.clickable {
+      cursor: pointer;
+      transition: color 0.15s ease;
+
+      &:hover {
+        color: var(--text-base);
+      }
+    }
+  }
+
+  [data-slot="message-part-title-filename"] {
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    direction: rtl;
+    text-align: left;
+  }
+
+  [data-slot="message-part-directory-inline"] {
+    color: var(--text-weak);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    direction: rtl;
+    text-align: left;
+    flex-shrink: 1;
+    min-width: 0;
+  }
+}
+
+/* Prevent long filenames in apply-patch accordion from hiding diff changes */
+[data-component="accordion"][data-scope="apply-patch"] {
+  [data-slot="apply-patch-filename"] {
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    direction: rtl;
+    text-align: left;
+  }
 }
 
 /* Task tool child-session tool list (v1.0.25 style) */

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -51,11 +51,7 @@ import { TextShimmer } from "@opencode-ai/ui/text-shimmer"
 import { GrowBox } from "./grow-box"
 import { COLLAPSIBLE_SPRING } from "./motion"
 import { busy, createThrottledValue, useToolFade, useContextToolPending } from "./tool-utils"
-import {
-  ContextToolGroupHeader,
-  ContextToolExpandedList,
-  ContextToolRollingResults,
-} from "./context-tool-results"
+import { ContextToolGroupHeader, ContextToolExpandedList, ContextToolRollingResults } from "./context-tool-results"
 import { ShellRollingResults } from "./shell-rolling-results"
 import { extractFilePathFromHref } from "../file-path"
 
@@ -1291,6 +1287,7 @@ function WebfetchMeta(props: { url: string; animate?: boolean }) {
       <a
         data-slot="basic-tool-tool-subtitle"
         class="clickable subagent-link"
+        title={props.url}
         href={props.url}
         target="_blank"
         rel="noopener noreferrer"
@@ -1403,6 +1400,7 @@ function ToolMetaLine(props: {
   return (
     <span
       ref={ref}
+      title={props.path ? `${props.filename} ${props.path}` : props.filename}
       data-slot={props.soft ? "basic-tool-tool-subtitle" : "message-part-meta-line"}
       classList={{
         "message-part-meta-line": !!props.soft,


### PR DESCRIPTION
## Context

Fix tool titles overflowing and becoming unreadable at narrow widths. Long file names, directory paths, and URLs in tool triggers (Edit, Write, Patch, Webfetch) were wrapping or pushing the collapsible arrow and diff changes off-screen.

Closes #7339

## Implementation

Added CSS overrides in `packages/kilo-ui/` to properly truncate overflowing text in tool trigger headers:

- **Front-ellipsis truncation** (`direction: rtl` + `text-overflow: ellipsis`) on filenames, directory paths, and apply-patch accordion filenames — the ellipsis appears at the start of the text so the file extension and end of the path remain visible (e.g., `…edit-tool-display.ts`)
- **Flex shrink constraints** on structured tool info containers (`basic-tool-tool-info-structured`, `basic-tool-tool-info-main`) so they participate in flex layout shrinking instead of overflowing
- **Webfetch URL containment** — the `webfetch-meta` wrapper now constrains long URLs within its flex container
- **Native title tooltips** on `ToolMetaLine` and `WebfetchMeta` components so hovering reveals the full path/URL
- **Apply-patch accordion fix** — `apply-patch-filename` now shrinks with front-ellipsis instead of pushing diff changes (`+4 -0`) off-screen

### Files changed
- `packages/kilo-ui/src/components/basic-tool.css` — CSS truncation rules for tool triggers
- `packages/kilo-ui/src/components/message-part.css` — CSS truncation rules for edit/write triggers and apply-patch accordion
- `packages/kilo-ui/src/components/message-part.tsx` — `title` attributes for native tooltips

## Screenshots

<img width="1195" height="1459" alt="image" src="https://github.com/user-attachments/assets/48601165-aad0-4bdc-877c-312b4db7cac4" />
<img width="2034" height="1387" alt="image" src="https://github.com/user-attachments/assets/d4711584-9816-41a7-beb8-f04023692663" />

## How to Test

1. Open the VS Code extension sidebar
2. Trigger tools that produce long file paths (Edit, Write, or Patch on a deeply nested file with a long name)
3. Verify the filename shows front-ellipsis (e.g., `…long-file-name.ts`) instead of wrapping or overflowing
4. Verify the collapsible arrow and diff changes remain visible
5. Hover over the truncated filename/path to see the full path in a tooltip
6. Test with a Webfetch tool call using a long URL — verify it truncates with tooltip on hover
7. For apply-patch with multiple files, verify long filenames in the accordion don't push the `+N -N` changes off-screen