### PR TITLE
feat(cli): show RAM usage in sidebar

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -25,7 +25,7 @@ import { createSimpleContext } from "./helper"
 import type { Snapshot } from "@/snapshot"
 import { useExit } from "./exit"
 import { useArgs } from "./args"
-import { batch, onMount } from "solid-js"
+import { batch, onCleanup, onMount } from "solid-js"
 import { Log } from "@/util/log"
 import type { Path } from "@kilocode/sdk"
 
@@ -73,6 +73,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       formatter: FormatterStatus[]
       vcs: VcsInfo | undefined
       path: Path
+      memory: { rss: number } | undefined // kilocode_change
     }>({
       provider_next: {
         all: [],
@@ -100,6 +101,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       formatter: [],
       vcs: undefined,
       path: { state: "", config: "", worktree: "", directory: "" },
+      memory: undefined, // kilocode_change
     })
 
     const sdk = useSDK()
@@ -413,6 +415,11 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             sdk.client.provider.auth().then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
             sdk.client.vcs.get().then((x) => setStore("vcs", reconcile(x.data))),
             sdk.client.path.get().then((x) => setStore("path", reconcile(x.data!))),
+            // kilocode_change start
+            sdk.client.memory.status().then((x) => {
+              if (x.data) setStore("memory", x.data)
+            }),
+            // kilocode_change end
           ]).then(() => {
             setStore("status", "complete")
           })
@@ -429,6 +436,17 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
     onMount(() => {
       bootstrap()
+      // kilocode_change start
+      const poll = setInterval(() => {
+        sdk.client.memory
+          .status()
+          .then((x) => {
+            if (x.data) setStore("memory", x.data)
+          })
+          .catch(() => {})
+      }, 10_000)
+      onCleanup(() => clearInterval(poll))
+      // kilocode_change end
     })
 
     const fullSyncedSessions = new Set<string>()

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -12,6 +12,12 @@ import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
 
+// kilocode_change start
+function formatGB(bytes: number): string {
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+// kilocode_change end
+
 export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   const sync = useSync()
   const { theme } = useTheme()
@@ -59,6 +65,14 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
       percentage: model?.limit.context ? Math.round((total / model.limit.context) * 100) : null,
     }
   })
+
+  // kilocode_change start
+  const memory = createMemo(() => sync.data.memory)
+  const high = createMemo(() => {
+    const mem = memory()
+    return mem !== undefined && mem.rss > 2 * 1024 * 1024 * 1024
+  })
+  // kilocode_change end
 
   const directory = useDirectory()
   const kv = useKV()
@@ -109,6 +123,34 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
               <text fg={theme.textMuted}>{context()?.percentage ?? 0}% used</text>
               <text fg={theme.textMuted}>{cost()} spent</text>
             </box>
+            {/* kilocode_change start */}
+            <Show when={high()}>
+              <box>
+                <box flexDirection="row" justifyContent="space-between">
+                  <text fg={theme.warning}>
+                    <b>Memory</b>
+                  </text>
+                  <text fg={theme.warning}>{formatGB(memory()!.rss)}</text>
+                </box>
+                <Show when={connectedMcpCount() > 0}>
+                  <text fg={theme.textMuted}>
+                    {connectedMcpCount()} MCP server{connectedMcpCount() > 1 ? "s" : ""} running
+                  </text>
+                </Show>
+                <Show when={(sync.data.config.plugin ?? []).length > 0}>
+                  <text fg={theme.textMuted}>
+                    {(sync.data.config.plugin ?? []).length} plugin
+                    {(sync.data.config.plugin ?? []).length > 1 ? "s" : ""} active
+                  </text>
+                </Show>
+                <text fg={theme.textMuted}>
+                  {messages().length >= 100 ? "100+" : messages().length} message
+                  {messages().length !== 1 ? "s" : ""} in session
+                </text>
+                <text fg={theme.textMuted}>/compact or /new to free memory</text>
+              </box>
+            </Show>
+            {/* kilocode_change end */}
             <Show when={mcpEntries().length > 0}>
               <box>
                 <box

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -548,6 +548,33 @@ export namespace Server {
             return c.json(await Format.status())
           },
         )
+        // kilocode_change start
+        .get(
+          "/memory",
+          describeRoute({
+            summary: "Get memory usage",
+            description: "Get process memory usage statistics.",
+            operationId: "memory.status",
+            responses: {
+              200: {
+                description: "Memory usage",
+                content: {
+                  "application/json": {
+                    schema: resolver(
+                      z.object({
+                        rss: z.number().describe("Resident set size in bytes"),
+                      }),
+                    ),
+                  },
+                },
+              },
+            },
+          }),
+          async (c) => {
+            return c.json({ rss: process.memoryUsage.rss() })
+          },
+        )
+        // kilocode_change end
         .get(
           "/event",
           describeRoute({

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -85,6 +85,7 @@ import type {
   McpLocalConfig,
   McpRemoteConfig,
   McpStatusResponses,
+  MemoryStatusResponses,
   OutputFormat,
   Part as Part2,
   PartDeleteErrors,
@@ -4538,6 +4539,38 @@ export class Formatter extends HeyApiClient {
   }
 }
 
+export class Memory extends HeyApiClient {
+  /**
+   * Get memory usage
+   *
+   * Get process memory usage statistics.
+   */
+  public status<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<MemoryStatusResponses, unknown, ThrowOnError>({
+      url: "/memory",
+      ...options,
+      ...params,
+    })
+  }
+}
+
 export class Event extends HeyApiClient {
   /**
    * Subscribe to events
@@ -4721,6 +4754,11 @@ export class KiloClient extends HeyApiClient {
   private _formatter?: Formatter
   get formatter(): Formatter {
     return (this._formatter ??= new Formatter({ client: this.client }))
+  }
+
+  private _memory?: Memory
+  get memory(): Memory {
+    return (this._memory ??= new Memory({ client: this.client }))
   }
 
   private _event?: Event

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5636,6 +5636,30 @@ export type FormatterStatusResponses = {
 
 export type FormatterStatusResponse = FormatterStatusResponses[keyof FormatterStatusResponses]
 
+export type MemoryStatusData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/memory"
+}
+
+export type MemoryStatusResponses = {
+  /**
+   * Memory usage
+   */
+  200: {
+    /**
+     * Resident set size in bytes
+     */
+    rss: number
+  }
+}
+
+export type MemoryStatusResponse = MemoryStatusResponses[keyof MemoryStatusResponses]
+
 export type EventSubscribeData = {
   body?: never
   path?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -376,7 +376,7 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.project.initGit({\n  ...\n})"
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.project.initGit({\n  ...\n})"
           }
         ]
       }
@@ -8195,6 +8195,54 @@
         ]
       }
     },
+    "/memory": {
+      "get": {
+        "operationId": "memory.status",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get memory usage",
+        "description": "Get process memory usage statistics.",
+        "responses": {
+          "200": {
+            "description": "Memory usage",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rss": {
+                      "description": "Resident set size in bytes",
+                      "type": "number"
+                    }
+                  },
+                  "required": ["rss"]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.memory.status({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/event": {
       "get": {
         "operationId": "event.subscribe",
@@ -8392,6 +8440,20 @@
           "type": {
             "type": "string",
             "const": "global.disposed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": ["type", "properties"]
+      },
+      "Event.global.config.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "global.config.updated"
           },
           "properties": {
             "type": "object",
@@ -10931,6 +10993,9 @@
             "$ref": "#/components/schemas/Event.global.disposed"
           },
           {
+            "$ref": "#/components/schemas/Event.global.config.updated"
+          },
+          {
             "$ref": "#/components/schemas/Event.lsp.client.diagnostics"
           },
           {
@@ -11105,8 +11170,15 @@
         "additionalProperties": false
       },
       "PermissionActionConfig": {
-        "type": "string",
-        "enum": ["ask", "allow", "deny"]
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": ["ask", "allow", "deny"]
+          },
+          {
+            "type": "null"
+          }
+        ]
       },
       "PermissionObjectConfig": {
         "type": "object",


### PR DESCRIPTION
## Why

When the CLI process uses a lot of memory, users have no way to know about it or what to do. They only find out when their system slows down or the process gets killed.

## What changed

The TUI sidebar now shows a "Memory" section when the process uses more than 2 GB of RAM. It displays total memory in a warning color alongside what's currently active — connected MCP servers, plugins, and messages in the session — so users can understand what's contributing. It also suggests running `/compact` or `/new` to free memory. The server exposes a lightweight memory endpoint, and the TUI polls it every 10 seconds with negligible overhead since it runs in-process.

## How to test

1. Start the CLI with `bun run dev` and open a session
2. The Memory section should not appear (RSS is below 2 GB in normal use)
3. To verify it works, temporarily lower the threshold in `sidebar.tsx` from `2 * 1024 * 1024 * 1024` to something small like `1`
4. Confirm the sidebar shows "Memory" with the current GB value, active counts, and the `/compact or /new` tip
5. Restore the original threshold