### PR TITLE
docs(kilo-docs): add VS Code rollback install guidance

### DIFF
--- a/packages/kilo-docs/pages/getting-started/installing.md
+++ b/packages/kilo-docs/pages/getting-started/installing.md
@@ -119,6 +119,15 @@ If you prefer to download and install the VSIX file directly:
    - Select "Install from VSIX..."
    - Browse to and select your downloaded `.vsix` file
 
+If you need to temporarily go back to an earlier version, use the same flow with a `.vsix` asset from an older release:
+
+1. Open the [Kilo Code GitHub Releases page](https://github.com/Kilo-Org/kilocode/releases)
+2. Pick the release you want to stay on and download its VS Code `.vsix` asset
+3. In VS Code, open Extensions, click the "..." menu, and select "Install from VSIX..."
+4. Choose the downloaded `.vsix` file to install that version
+
+If you plan to remain on that version for a while, you may also want to temporarily disable extension auto-update in VS Code so it does not immediately update again.
+
 {% image src="/docs/img/installing-vsix.png" alt="Installing Kilo Code using VS Code's Install from VSIX dialog" width="600px" caption="Installing Kilo Code using VS Code's \"Install from VSIX\" dialog" /%}
 
 ## Troubleshooting


### PR DESCRIPTION
Fixes #7183 

## Context

Document an escape hatch for users who hit problems after a VS Code extension release by explaining how to temporarily install an earlier version.

## Implementation

Added previous-version install guidance to the existing VSIX section in the installing docs. The new note points users to GitHub Releases for older `.vsix` assets, walks through VS Code's `Install from VSIX...` flow, and mentions temporarily disabling auto-update if they need to stay on that version.

## Screenshots

N/A

## How to Test

- Open `packages/kilo-docs/pages/getting-started/installing.md`
- Verify the `Via VSIX` section now includes guidance for installing an earlier release from GitHub Releases
- Confirm the instructions use the `Install from VSIX...` flow and mention temporarily disabling auto-update

## Get in Touch

thomas07374