### PR TITLE
fix(vscode): improve question dock visual design

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-many-options-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-many-options-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0bbec9564c9fa46fce155ada8e176641e540c912461102b7b424d317b3283c38
-size 31033
+oid sha256:3de2fd382cc403a5b0dff91cead7804941d75f84ccd4610e4854d63e5b1cbd74
+size 29490

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-multi-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-multi-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48ebccc3ab71403efa74803f140b17d97a000989b64dd42c65d8f9774d059cb8
-size 23139
+oid sha256:b2fa88bc34c4dafe5271612b3ba640027c92aba28b282863e09026afdf8902f5
+size 21883

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-single-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-single-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:371621a81d9c42d1dc327492fb2e3d2516857dfa189adf3c924ac6951d33e910
-size 29073
+oid sha256:82b35af7032de0f55d48a8a175042166d72890be8aa6e0f1d81bc7dfa7b2c592
+size 27585

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/question-above-chatbox-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/question-above-chatbox-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3f472c100d4432064af12da764bd44baa3295ad4b20c6158cc3fa467667797a
-size 30794
+oid sha256:7576fe3532b45c91e0d4d65c97b515565e7b3ad26d6d713d0d52fdab0e0c0565
+size 29627

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1877,9 +1877,8 @@
 
 [data-component="question-dock"] {
   margin: 8px;
-  background-color: var(--surface-raised-stronger-non-alpha);
-  box-shadow: var(--shadow-xs-border);
-  border-radius: 12px;
+  background-color: var(--surface-base);
+  border-radius: 8px;
   overflow: hidden;
 
   /* ── Header (always visible) ── */
@@ -1888,7 +1887,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 8px;
-    padding: 8px 8px 8px 12px;
+    padding: 10px 10px 6px 14px;
     cursor: pointer;
   }
 
@@ -2001,7 +2000,7 @@
     font-weight: var(--font-weight-medium);
     line-height: var(--line-height-large);
     color: var(--text-strong);
-    padding: 0 12px;
+    padding: 0 14px;
   }
 
   [data-slot="question-hint"] {
@@ -2010,14 +2009,14 @@
     font-weight: var(--font-weight-regular);
     line-height: var(--line-height-large);
     color: var(--text-weak);
-    padding: 0 12px;
+    padding: 0 14px;
   }
 
   [data-slot="question-options"] {
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    padding: 4px 8px;
+    gap: 2px;
+    padding: 4px 4px;
     max-height: 40vh;
     overflow-y: auto;
     scrollbar-width: none;
@@ -2031,25 +2030,21 @@
     display: flex;
     align-items: flex-start;
     gap: 12px;
-    padding: 6px 8px 6px 10px;
-    background-color: var(--surface-raised-stronger-non-alpha);
-    border: 1px solid var(--border-weak-base);
+    padding: 8px 10px;
+    background-color: transparent;
+    border: none;
     border-radius: 6px;
     text-align: left;
     width: 100%;
     cursor: pointer;
-    transition:
-      background-color 0.15s ease,
-      border-color 0.15s ease;
+    transition: background-color 0.15s ease;
 
     &:hover:not([data-picked="true"]) {
-      background-color: var(--background-base);
+      background-color: var(--surface-raised-stronger-non-alpha);
     }
 
     &[data-picked="true"] {
       background-color: var(--surface-interactive-weak);
-      border-color: transparent;
-      box-shadow: var(--shadow-xs-border-hover);
     }
 
     &:disabled {
@@ -2068,7 +2063,7 @@
     height: 16px;
     padding: 2px;
     border-radius: var(--radius-sm);
-    border: 1px solid var(--border-weak-base);
+    border: 1px solid var(--border-base);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -2080,7 +2075,7 @@
 
     [data-component="icon"] {
       opacity: 0;
-      color: var(--icon-base);
+      color: var(--vscode-button-foreground);
     }
 
     &[data-type="radio"] {
@@ -2091,24 +2086,24 @@
       width: 6px;
       height: 6px;
       border-radius: 999px;
-      background-color: var(--background-stronger);
+      background-color: var(--vscode-button-foreground);
       opacity: 0;
     }
 
     &[data-picked="true"] {
-      border-color: var(--icon-interactive-base);
+      border-color: var(--vscode-button-background);
 
       [data-component="icon"] {
         opacity: 1;
-        color: var(--icon-invert-base);
+        color: var(--vscode-button-foreground);
       }
 
       &[data-type="checkbox"] {
-        background-color: var(--icon-interactive-base);
+        background-color: var(--vscode-button-background);
       }
 
       &[data-type="radio"] {
-        background-color: var(--icon-interactive-base);
+        background-color: var(--vscode-button-background);
 
         [data-slot="question-option-radio-dot"] {
           opacity: 1;
@@ -2150,11 +2145,11 @@
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 6px 8px;
-    margin: 0 8px;
+    padding: 6px 10px;
+    margin: 0 4px;
     background-color: var(--surface-raised-stronger-non-alpha);
-    border: 1px solid var(--border-weak-base);
-    border-radius: var(--radius-lg);
+    border: none;
+    border-radius: 6px;
   }
 
   [data-slot="custom-input"] {
@@ -2220,7 +2215,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 6px 8px 8px;
+    padding: 6px 10px 10px;
   }
 
   [data-slot="question-footer-actions"] {
@@ -2413,7 +2408,7 @@ body.vscode-high-contrast-light {
   }
 
   [data-component="question-dock"] [data-slot="question-option"] {
-    border-color: var(--vscode-contrastBorder, var(--border-weak-base));
+    border: 1px solid var(--vscode-contrastBorder, transparent);
   }
 
   [data-component="question-dock"] [data-slot="question-option-box"] {
@@ -2421,7 +2416,7 @@ body.vscode-high-contrast-light {
   }
 
   [data-component="question-dock"] [data-slot="custom-input-form"] {
-    border-color: var(--vscode-contrastBorder, var(--border-weak-base));
+    border: 1px solid var(--vscode-contrastBorder, transparent);
   }
 
   /* Prompt hint selector buttons */


### PR DESCRIPTION
## Summary

- Replaces the outer question dock outline/border with a fill background (`--surface-base`), reducing visual noise from stacked borders
- Removes individual option borders in favor of transparent background with hover/selected states, reducing indentation levels
- Normalizes border radii (8px outer, 6px inner) and fixes radio/checkbox visibility in light themes by using `--border-base` instead of `--border-weak-base`
- Matches selected checkbox/radio color to the submit button (`--vscode-button-background`) for visual consistency
- High contrast theme overrides updated to work with the borderless option design

<img width="410" height="543" alt="image" src="https://github.com/user-attachments/assets/80c7b00e-487f-499a-89b3-5777106e19b4" />

<img width="451" height="487" alt="image" src="https://github.com/user-attachments/assets/fcf32aae-bb4d-4cbb-9eed-ed24b97023eb" />


## Testing

Manually tested across 6 VS Code themes:
- Dark Modern, Light Modern, Dark+, Light+, High Contrast Dark, High Contrast Light

Typecheck passes across all packages.