### PR TITLE
fix(kilo-ui): fix reasoning display regression — ordering, collapse, and animation

### DIFF
--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -246,13 +246,22 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
     }
   }
 
-  /* Collapse/expand animation via Kobalte's CSS variable */
+  /* Collapse/expand animation via Kobalte's CSS variable.
+     Uses grid trick: the outer wrapper transitions grid-template-rows
+     between 0fr (collapsed) and 1fr (expanded) so the content smoothly
+     collapses without needing to know the pixel height up front. */
   [data-slot="collapsible-content"] {
-    animation: slideUp 300ms ease-out forwards;
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 250ms ease-out;
     overflow: hidden;
 
+    > * {
+      overflow: hidden;
+    }
+
     &[data-expanded] {
-      animation: slideDown 200ms ease-out forwards;
+      grid-template-rows: 1fr;
     }
   }
 

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -419,11 +419,21 @@ export function AssistantParts(props: {
       if (part.type === "tool") return part.callID || part.id
       return part.id
     }
-    const parts = props.messages.flatMap((message) =>
-      list(data.store.part?.[message.id], emptyParts)
-        .filter((part) => renderable(part, props.showReasoningSummaries ?? true))
-        .map((part) => ({ message, part })),
-    )
+    const parts = props.messages.flatMap((message) => {
+      const filtered = list(data.store.part?.[message.id], emptyParts).filter((part) =>
+        renderable(part, props.showReasoningSummaries ?? true),
+      )
+      // Ensure reasoning parts appear before text parts within each message.
+      // During streaming the reasoning part may arrive after the text part
+      // in the store (SSE order), but visually reasoning always precedes text.
+      const reasoning: typeof filtered = []
+      const rest: typeof filtered = []
+      for (const p of filtered) {
+        if (p.type === "reasoning") reasoning.push(p)
+        else rest.push(p)
+      }
+      return [...reasoning, ...rest].map((part) => ({ message, part }))
+    })
 
     let start = -1
 
@@ -1190,6 +1200,9 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
 // store object (causing <For> to recreate the component) the new instance
 // knows the part was just streaming and can animate the collapse.
 const streamed = new Set<string>()
+// Tracks parts that have already been auto-collapsed once, so component
+// recreation (from store updates while other parts stream) won't collapse again.
+const autocollapsed = new Set<string>()
 
 // Overrides upstream flat markdown render with streaming reasoning block + auto-collapse.
 // Also filters encrypted reasoning data from OpenRouter that appears as [REDACTED].
@@ -1222,13 +1235,13 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props: MessagePartProp
   const [open, setOpen] = createSignal(!done() || was)
 
   // Auto-collapse once when reasoning finishes (streaming → done transition).
-  // Uses a flag so manual reopens are not auto-closed again.
-  let collapsed = false
+  // Collapses immediately so the grid transition runs in sync with the
+  // streaming-height removal. Module-level Set prevents re-triggering on
+  // component recreation or when the user manually reopens.
   createEffect(() => {
-    if (done() && open() && !collapsed) {
-      collapsed = true
-      const timer = setTimeout(() => setOpen(false), 500)
-      onCleanup(() => clearTimeout(timer))
+    if (done() && open() && !autocollapsed.has(id)) {
+      autocollapsed.add(id)
+      setOpen(false)
     }
   })
 


### PR DESCRIPTION
## Summary

- **Reasoning ordering**: Reasoning parts now always render before text parts within a message. During streaming, the reasoning part could arrive after the text part in the SSE store, causing it to appear below the text content.
- **Smooth collapse animation**: Replaced `slideDown`/`slideUp` keyframe animations (which used `forwards` fill mode that locked the height and clipped content) with a CSS grid `grid-template-rows: 0fr ↔ 1fr` transition for smooth expand/collapse.
- **Auto-collapse stability**: Replaced local `let collapsed` flag with a module-level `autocollapsed` Set so component recreation during streaming doesn't re-trigger the collapse. If the user manually reopens reasoning, it stays open. Removed the 500ms setTimeout — collapse now happens immediately in sync with the grid transition.

Fixes regression introduced by upstream revert of "STUPID SEXY TIMELINE" (`565a7e5078`) which changed the collapsible CSS from JS-animated to commented-out CSS animations, breaking Kilo's reasoning collapsible overlay.