### PR TITLE
fix(nix): remove stale TEAM_MEMBERS reference breaking release builds

### DIFF
--- a/nix/node_modules.nix
+++ b/nix/node_modules.nix
@@ -31,7 +31,6 @@ stdenvNoCC.mkDerivation {
         ../package.json
         ../patches
         ../install # required by desktop build (cli.rs include_str!)
-        ../.github/TEAM_MEMBERS # required by @opencode-ai/script
       ]
     );
   };


### PR DESCRIPTION
## Summary

- Removes the stale `.github/TEAM_MEMBERS` reference from `nix/node_modules.nix` that was causing the `nix-hashes` CI job to fail on release v7.1.0
- The file was deleted in `990170320e` ("Remove unused files") but the nix reference survived a later upstream merge
- This fork never used `TEAM_MEMBERS` — the `@opencode-ai/script` package hardcodes Kilo team members directly via a `kilocode_change` block

Fixes the `compute-hash` failures in the release workflow.