### PR TITLE
fix(vscode): restore webview panels on extension restart/update

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -45,7 +45,13 @@
     "kilocode"
   ],
   "activationEvents": [
-    "onWebviewPanel:kilo-code.new.AgentManagerPanel"
+    "onWebviewPanel:kilo-code.new.AgentManagerPanel",
+    "onWebviewPanel:kilo-code.new.TabPanel",
+    "onWebviewPanel:kilo-code.new.settingsPanel",
+    "onWebviewPanel:kilo-code.new.profilePanel",
+    "onWebviewPanel:kilo-code.new.marketplacePanel",
+    "onWebviewPanel:kilo-code.new.DiffViewerPanel",
+    "onWebviewPanel:kilo-code.new.SubAgentViewerPanel"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/packages/kilo-vscode/src/DiffViewerProvider.ts
+++ b/packages/kilo-vscode/src/DiffViewerProvider.ts
@@ -48,21 +48,32 @@ export class DiffViewerProvider implements vscode.Disposable {
       return
     }
 
-    this.panel = vscode.window.createWebviewPanel(DiffViewerProvider.viewType, "Changes", vscode.ViewColumn.One, {
+    const panel = vscode.window.createWebviewPanel(DiffViewerProvider.viewType, "Changes", vscode.ViewColumn.One, {
       enableScripts: true,
       retainContextWhenHidden: true,
       localResourceRoots: [this.extensionUri],
     })
 
-    this.panel.iconPath = {
+    this.wirePanel(panel)
+  }
+
+  /** Re-wire a deserialized panel after extension restart. */
+  public deserializePanel(panel: vscode.WebviewPanel): void {
+    this.wirePanel(panel)
+  }
+
+  private wirePanel(panel: vscode.WebviewPanel): void {
+    this.panel = panel
+
+    panel.iconPath = {
       light: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-light.svg"),
       dark: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-dark.svg"),
     }
 
-    this.panel.webview.onDidReceiveMessage((msg) => this.onMessage(msg), undefined, [])
-    this.panel.webview.html = this.getHtml(this.panel.webview)
+    panel.webview.onDidReceiveMessage((msg) => this.onMessage(msg), undefined, [])
+    panel.webview.html = this.getHtml(panel.webview)
 
-    this.panel.onDidDispose(() => {
+    panel.onDidDispose(() => {
       this.log("Panel disposed")
       this.stopDiffPolling()
       this.panel = undefined

--- a/packages/kilo-vscode/src/SettingsEditorProvider.ts
+++ b/packages/kilo-vscode/src/SettingsEditorProvider.ts
@@ -42,6 +42,15 @@ export class SettingsEditorProvider implements vscode.Disposable {
     return resolvePanelProjectDirectory(active, vscode.workspace.workspaceFolders)
   }
 
+  /** Extract the PanelView from a viewType string like "kilo-code.new.settingsPanel". */
+  static viewFromType(type: string): PanelView | undefined {
+    const match = type.match(/^kilo-code\.new\.(\w+)Panel$/)
+    if (!match) return undefined
+    const view = match[1] as PanelView
+    if (!(view in PANEL_TITLES)) return undefined
+    return view
+  }
+
   openPanel(view: PanelView, tab?: string): void {
     if (tab) this.tabs.set(view, tab)
 
@@ -57,14 +66,31 @@ export class SettingsEditorProvider implements vscode.Disposable {
       return
     }
 
-    const title = PANEL_TITLES[view]
+    const panel = vscode.window.createWebviewPanel(
+      `kilo-code.new.${view}Panel`,
+      PANEL_TITLES[view],
+      vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [this.extensionUri],
+      },
+    )
 
-    const panel = vscode.window.createWebviewPanel(`kilo-code.new.${view}Panel`, title, vscode.ViewColumn.One, {
-      enableScripts: true,
-      retainContextWhenHidden: true,
-      localResourceRoots: [this.extensionUri],
-    })
+    this.wirePanel(panel, view, projectDirectory)
+  }
 
+  /** Re-wire a deserialized panel after extension restart. */
+  deserializePanel(panel: vscode.WebviewPanel): void {
+    const view = SettingsEditorProvider.viewFromType(panel.viewType)
+    if (!view) {
+      panel.dispose()
+      return
+    }
+    this.wirePanel(panel, view, this.getProjectDirectory())
+  }
+
+  private wirePanel(panel: vscode.WebviewPanel, view: PanelView, projectDirectory: string | null): void {
     panel.iconPath = {
       light: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-light.svg"),
       dark: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-dark.svg"),
@@ -105,6 +131,7 @@ export class SettingsEditorProvider implements vscode.Disposable {
     this.panels.set(view, panel)
     this.providers.set(view, provider)
 
+    const title = PANEL_TITLES[view]
     panel.onDidDispose(() => {
       console.log(`[Kilo New] ${title} panel disposed`)
       closePanelDisposable.dispose()

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -66,6 +66,25 @@ export function activate(context: vscode.ExtensionContext) {
     }),
   )
 
+  // Register serializer so "Open in Tab" restores when VS Code restarts
+  context.subscriptions.push(
+    vscode.window.registerWebviewPanelSerializer("kilo-code.new.TabPanel", {
+      deserializeWebviewPanel(panel: vscode.WebviewPanel) {
+        const tabProvider = new KiloProvider(context.extensionUri, connectionService, context)
+        tabProvider.resolveWebviewPanel(panel)
+        panel.onDidDispose(
+          () => {
+            console.log("[Kilo New] Tab panel restored from restart disposed")
+            tabProvider.dispose()
+          },
+          null,
+          context.subscriptions,
+        )
+        return Promise.resolve()
+      },
+    }),
+  )
+
   // Create standalone diff viewer provider for the sidebar "Show Changes" action
   const diffViewerProvider = new DiffViewerProvider(context.extensionUri, connectionService)
   diffViewerProvider.setCommentHandler((comments) => {
@@ -80,6 +99,39 @@ export function activate(context: vscode.ExtensionContext) {
   // Create sub-agent viewer provider (read-only editor panel for sub-agent sessions)
   const subAgentViewerProvider = new SubAgentViewerProvider(context.extensionUri, connectionService, context)
   context.subscriptions.push(subAgentViewerProvider)
+
+  // Register serializers so settings/diff/sub-agent panels restore on restart
+  const settingsViews = ["settingsPanel", "profilePanel", "marketplacePanel"] as const
+  for (const suffix of settingsViews) {
+    context.subscriptions.push(
+      vscode.window.registerWebviewPanelSerializer(`kilo-code.new.${suffix}`, {
+        deserializeWebviewPanel(panel: vscode.WebviewPanel) {
+          settingsEditorProvider.deserializePanel(panel)
+          return Promise.resolve()
+        },
+      }),
+    )
+  }
+
+  context.subscriptions.push(
+    vscode.window.registerWebviewPanelSerializer(DiffViewerProvider.viewType, {
+      deserializeWebviewPanel(panel: vscode.WebviewPanel) {
+        diffViewerProvider.deserializePanel(panel)
+        return Promise.resolve()
+      },
+    }),
+  )
+
+  context.subscriptions.push(
+    vscode.window.registerWebviewPanelSerializer("kilo-code.new.SubAgentViewerPanel", {
+      deserializeWebviewPanel(panel: vscode.WebviewPanel) {
+        // Sub-agent viewer requires a session ID that can't be recovered
+        // after restart, so dispose the stale panel cleanly.
+        panel.dispose()
+        return Promise.resolve()
+      },
+    }),
+  )
 
   // Register toolbar button command handlers
   context.subscriptions.push(


### PR DESCRIPTION
## Context

Fixes #6086. When the VS Code extension restarts (e.g., after an update), only the sidebar and Agent Manager views refreshed properly. All other `WebviewPanel`-based views (Open in Tab, Settings, Profile, Marketplace, DiffViewer, SubAgentViewer) retained stale HTML with old JS bundles because they lacked `WebviewPanelSerializer` registrations.

## Implementation

Registered `WebviewPanelSerializer` for every panel type, following the pattern already established by the Agent Manager serializer. Each serializer re-wires the deserialized panel with fresh HTML and a new `KiloProvider` (or provider-specific setup):

- **TabPanel**: Creates a fresh `KiloProvider` and calls `resolveWebviewPanel()` to set new HTML and re-establish the backend connection.
- **Settings/Profile/Marketplace**: Refactored `SettingsEditorProvider` to extract a shared `wirePanel()` helper used by both `openPanel()` and a new `deserializePanel()` method. Added `viewFromType()` static to parse the view name from the panel's `viewType`.
- **DiffViewerPanel**: Same refactor pattern — extracted `wirePanel()` from `openPanel()` and added `deserializePanel()`.
- **SubAgentViewerPanel**: Disposes the panel cleanly on restart since session context (session ID) can't be recovered.

Also added `onWebviewPanel:*` activation events to `package.json` for all 6 new panel types so VS Code triggers extension activation when deserializing them.

## Screenshots

N/A — behavioral fix, no visual changes.

## How to Test

1. Build and launch the extension (`bun run extension`)
2. Open various panel types:
   - "Open in Tab" (`Ctrl+Shift+P` → "Kilo Code: Open in Tab")
   - Settings panel (gear icon)
   - Agent Manager (`Cmd+Shift+M` / `Ctrl+Shift+M`)
   - Diff Viewer ("Show Changes" from sidebar)
3. Run `Developer: Restart Extension Host` from the command palette
4. Verify all panels refresh with the new UI and reconnect to the CLI backend
5. Verify SubAgentViewer panel (if open) is cleanly closed