### PR TITLE
fix(cli): serve web UI from local app dist

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -17,12 +17,13 @@ async function ensureAppBuilt() {
   console.log("Building web UI...")
   try {
     const bunPath = process.env.BUN_INSTALL?.concat("/bin/bun") || "/root/.bun/bin/bun"
-    const { exitCode } = await Bun.spawn({
+    const proc = Bun.spawn({
       cmd: [bunPath, "run", "build"],
       cwd: resolve(fileURLToPath(new URL("../../../app", import.meta.url))),
       stdout: "inherit",
       stderr: "inherit",
     })
+    const exitCode = await proc.exited
     if (exitCode !== 0) {
       console.log("Warning: Web UI build failed. Server will start but web UI may not be available.")
       return

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -6,6 +6,33 @@ import { Instance } from "../../project/instance" // kilocode_change
 import { Workspace } from "../../control-plane/workspace"
 import { Project } from "../../project/project"
 import { Installation } from "../../installation"
+import { Filesystem } from "@/util/filesystem"
+import { fileURLToPath } from "url"
+import { resolve } from "path"
+
+async function ensureAppBuilt() {
+  const appDist = resolve(fileURLToPath(new URL("../../../app/dist", import.meta.url)), "index.html")
+  if (await Filesystem.exists(appDist)) return
+
+  console.log("Building web UI...")
+  try {
+    const bunPath = process.env.BUN_INSTALL?.concat("/bin/bun") || "/root/.bun/bin/bun"
+    const { exitCode } = await Bun.spawn({
+      cmd: [bunPath, "run", "build"],
+      cwd: resolve(fileURLToPath(new URL("../../../app", import.meta.url))),
+      stdout: "inherit",
+      stderr: "inherit",
+    })
+    if (exitCode !== 0) {
+      console.log("Warning: Web UI build failed. Server will start but web UI may not be available.")
+      return
+    }
+    console.log("Web UI built successfully")
+  } catch (err) {
+    console.log("Warning: Could not build web UI automatically:", (err as Error).message)
+    console.log("To enable the web UI, run: cd packages/app && bun run build")
+  }
+}
 
 export const ServeCommand = cmd({
   command: "serve",
@@ -15,6 +42,7 @@ export const ServeCommand = cmd({
     if (!Flag.KILO_SERVER_PASSWORD) {
       console.log("Warning: KILO_SERVER_PASSWORD is not set; server is unsecured.")
     }
+    await ensureAppBuilt()
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
     console.log(`kilo server listening on http://${server.hostname}:${server.port}`)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -297,6 +297,14 @@ export namespace Server {
           }),
         )
         // kilocode_change end
+        .get("/", async (c) => {
+          const indexPath = new URL("../../../app/dist/index.html", import.meta.url)
+          const file = Bun.file(indexPath)
+          if (await file.exists()) {
+            return c.html(await file.text())
+          }
+          return c.text("Web UI not available. Run 'bun run build' in packages/app to build the web UI.", 503)
+        })
         .route("/", FileRoutes())
         .route("/mcp", McpRoutes())
         .route("/tui", TuiRoutes())
@@ -606,22 +614,19 @@ export namespace Server {
             })
           },
         )
-        // kilocode_change start - disable external proxy to app.opencode.ai for privacy/security
+        // kilocode_change start - serve web UI from local app dist
         .all("/*", async (c) => {
-          // const path = c.req.path
-          //
-          // const response = await proxy(`https://app.opencode.ai${path}`, {
-          //   ...c.req,
-          //   headers: {
-          //     ...c.req.raw.headers,
-          //     host: "app.opencode.ai",
-          //   },
-          // })
-          // response.headers.set(
-          //   "Content-Security-Policy",
-          //   "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:",
-          // )
-          // return response
+          const path = c.req.path.split("?")[0]
+          const distPath = new URL(`../../../app/dist${path}`, import.meta.url)
+          const file = Bun.file(distPath)
+          if (await file.exists()) {
+            return c.body(file)
+          }
+          const indexPath = new URL("../../../app/dist/index.html", import.meta.url)
+          const indexFile = Bun.file(indexPath)
+          if (await indexFile.exists()) {
+            return c.html(await indexFile.text())
+          }
           return c.notFound()
         }) as unknown as Hono,
     // kilocode_change end


### PR DESCRIPTION
## Summary
- Fixes 404 error when accessing kilo serve web UI on v7.0.49+
- Serves web UI from local packages/app/dist/ instead of proxying to app.opencode.ai
- Adds auto-build attempt when dist doesn't exist  
- Maintains API routes functionality

## Changes

### packages/opencode/src/server/server.ts
- Added root handler to serve index.html from packages/app/dist/
- Modified catch-all handler to serve static files from dist and fallback to index.html for SPA routing

### packages/opencode/src/cli/cmd/serve.ts
- Added ensureAppBuilt() function to auto-build app if dist doesn't exist
- Gracefully handles build failures with helpful warning message

## Testing
- Verified server starts and serves index.html from dist
- Verified API routes continue to work
- Verified 503 response when dist doesn't exist

## Fixes
Fixes #7207