### PR TITLE
fix(provider): enable thinking by default for glm-5 models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -771,7 +771,8 @@ export namespace ProviderTransform {
 
     if (
       input.model.providerID === "baseten" ||
-      (input.model.providerID === "opencode" && ["kimi-k2-thinking", "glm-4.6"].includes(input.model.api.id))
+      ((input.model.providerID === "opencode" || input.model.providerID === "zai") &&
+        ["kimi-k2-thinking", "glm-4.6", "glm-5"].includes(input.model.api.id))
     ) {
       result["chat_template_args"] = { enable_thinking: true }
     }


### PR DESCRIPTION
## Summary
- Add `glm-5` to the `chat_template_args` enable_thinking list in `transform.ts`
- Extend condition to also match `zai` provider (in addition to `opencode`)
- Follows existing pattern established for `glm-4.6`

## Testing
- No new type errors introduced (verified with `tsgo --noEmit`)

Fixes #7350