### PR TITLE
fix(docs): correct kilocode-docs path reference in contributing guide

### DIFF
--- a/packages/kilo-docs/pages/contributing/index.md
+++ b/packages/kilo-docs/pages/contributing/index.md
@@ -119,9 +119,9 @@ Documentation improvements are highly valued contributions:
 2. Test your documentation changes by running the docs site locally:
 
    ```bash
-   cd apps/kilocode-docs
+   cd packages/kilo-docs
    pnpm install
-   pnpm start
+   pnpm dev
    ```
 
 3. Submit a PR with your documentation changes


### PR DESCRIPTION
## Summary
- Changed `apps/kilococode-docs` to `packages/kilo-docs` (correct path)
- Changed `pnpm start` to `pnpm dev` (correct dev command)

## Related
Fixes #7387 (partial - addresses the internal documentation that referenced the old path)