### PR TITLE
feat(cli): add Architect mode with some planning restrictions

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -9,6 +9,7 @@ import { Auth } from "../auth"
 import { ProviderTransform } from "../provider/transform"
 
 import PROMPT_GENERATE from "./generate.txt"
+import PROMPT_ARCHITECT from "./prompt/architect.txt" // kilocode_change
 import PROMPT_COMPACTION from "./prompt/compaction.txt"
 import PROMPT_DEBUG from "./prompt/debug.txt"
 import PROMPT_EXPLORE from "./prompt/explore.txt"
@@ -123,6 +124,35 @@ export namespace Agent {
         mode: "primary",
         native: true,
       },
+      // kilocode_change start - architect mode: planning with hard-enforced restrictions
+      architect: {
+        name: "architect",
+        description:
+          "Plan and design before implementation. Gathers context, asks questions, and produces an actionable plan.",
+        prompt: PROMPT_ARCHITECT,
+        options: {},
+        permission: PermissionNext.merge(
+          defaults,
+          user, // user before architect-specific so architect's deny rules can't be overridden
+          PermissionNext.fromConfig({
+            question: "allow",
+            plan_exit: "allow",
+            external_directory: {
+              [path.join(Global.Path.data, "plans", "*")]: "allow",
+            },
+            edit: {
+              "*": "deny",
+              [path.join(".kilo", "plans", "*.md")]: "allow",
+              [path.join(".opencode", "plans", "*.md")]: "allow",
+              [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
+            },
+            bash: "ask",
+          }),
+        ),
+        mode: "primary",
+        native: true,
+      },
+      // kilocode_change end
       // kilocode_change start - add debug, orchestrator, and ask agents
       debug: {
         name: "debug",

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -147,10 +147,7 @@ export namespace Agent {
               [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
             },
             bash: "ask",
-            task: {
-              "*": "deny",
-              explore: "allow",
-            },
+            task: "deny",
           }),
         ),
         mode: "primary",

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -147,7 +147,10 @@ export namespace Agent {
               [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
             },
             bash: "ask",
-            task: "deny",
+            task: {
+              "*": "deny",
+              explore: "allow",
+            },
           }),
         ),
         mode: "primary",

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -147,6 +147,10 @@ export namespace Agent {
               [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
             },
             bash: "ask",
+            task: {
+              "*": "deny",
+              explore: "allow",
+            },
           }),
         ),
         mode: "primary",

--- a/packages/opencode/src/agent/prompt/architect.txt
+++ b/packages/opencode/src/agent/prompt/architect.txt
@@ -1,0 +1,28 @@
+You are Kilo Code, an experienced technical leader who is inquisitive and an excellent planner. Your goal is to gather information and get context to create a detailed plan for accomplishing the user's task, which the user will review and approve before they switch into another mode to implement the solution.
+
+## Workflow
+
+1. **Gather context** — Use the available read-only tools (read, grep, glob, git commands, web search, MCP tools) to explore the codebase and understand the relevant architecture, patterns, and constraints. Launch explore agents via the task tool for efficient parallel exploration.
+
+2. **Ask clarifying questions** — Use the question tool to resolve ambiguities in the user's request. Don't make large assumptions about intent. Treat this as a collaborative brainstorming session where you discuss the task and refine the approach together.
+
+3. **Create an actionable plan** — Break the task into clear, ordered steps. Each step should be:
+   - Specific and actionable
+   - Listed in logical execution order
+   - Focused on a single, well-defined outcome
+   - Clear enough that another agent could execute it independently
+   - Include paths to the files that need to be modified
+
+4. **Write the plan file** — Write your plan to the designated plan file (the only file you are permitted to edit). The plan should be comprehensive yet concise — detailed enough to execute effectively while avoiding unnecessary verbosity.
+
+5. **Iterate with the user** — Ask if they are satisfied with the plan or want changes. Update the plan as you gather more information or discover new requirements.
+
+6. **Signal completion** — When the plan is finalized, call the plan_exit tool.
+
+## Guidelines
+
+- Include Mermaid diagrams when they help clarify complex workflows or system architecture. Avoid double quotes ("") and parentheses () inside square brackets ([]) in Mermaid syntax to prevent parsing errors.
+- Include a verification section in your plan describing how to test the changes end-to-end.
+- Never provide time estimates (hours, days, weeks) for tasks.
+- Focus on creating clear, actionable plans rather than lengthy prose.
+- Your turn should always end with either asking the user a question or calling plan_exit.

--- a/packages/opencode/src/agent/prompt/architect.txt
+++ b/packages/opencode/src/agent/prompt/architect.txt
@@ -2,7 +2,7 @@ You are Kilo Code, an experienced technical leader who is inquisitive and an exc
 
 ## Workflow
 
-1. **Gather context** — Use the available read-only tools (read, grep, glob, web search, MCP tools) to explore the codebase and understand the relevant architecture, patterns, and constraints. Launch explore agents via the task tool for efficient parallel exploration. Note: only explore subagents are available to you.
+1. **Gather context** — Use the available read-only tools (read, grep, glob, web search, MCP tools) to explore the codebase and understand the relevant architecture, patterns, and constraints.
 
 2. **Ask clarifying questions** — Use the question tool to resolve ambiguities in the user's request. Don't make large assumptions about intent. Treat this as a collaborative brainstorming session where you discuss the task and refine the approach together.
 

--- a/packages/opencode/src/agent/prompt/architect.txt
+++ b/packages/opencode/src/agent/prompt/architect.txt
@@ -2,7 +2,7 @@ You are Kilo Code, an experienced technical leader who is inquisitive and an exc
 
 ## Workflow
 
-1. **Gather context** — Use the available read-only tools (read, grep, glob, git commands, web search, MCP tools) to explore the codebase and understand the relevant architecture, patterns, and constraints. Launch explore agents via the task tool for efficient parallel exploration.
+1. **Gather context** — Use the available read-only tools (read, grep, glob, web search, MCP tools) to explore the codebase and understand the relevant architecture, patterns, and constraints. Launch explore agents via the task tool for efficient parallel exploration. Note: only explore subagents are available to you.
 
 2. **Ask clarifying questions** — Use the question tool to resolve ambiguities in the user's request. Don't make large assumptions about intent. Treat this as a collaborative brainstorming session where you discuss the task and refine the approach together.
 

--- a/packages/opencode/src/kilocode/plan-followup.ts
+++ b/packages/opencode/src/kilocode/plan-followup.ts
@@ -299,12 +299,15 @@ export namespace PlanFollowup {
     }
 
     Telemetry.trackPlanFollowup(input.sessionID, "custom")
+    // kilocode_change start - preserve originating planning agent (plan or architect)
+    const origin = assistant.info.agent
     await inject({
       sessionID: input.sessionID,
-      agent: "plan",
+      agent: origin,
       model: user.model,
       text: answer,
     })
+    // kilocode_change end
     return "continue"
   }
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1416,8 +1416,17 @@ export namespace SessionPrompt {
     const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
     if (!userMessage) return input.messages
 
+    // kilocode_change start - helper to identify planning agents
+    const PLANNING_AGENTS = new Set(["plan", "architect"])
+    const isPlanningAgent = PLANNING_AGENTS.has(input.agent.name)
+    const wasPlanningAgent = input.messages.some(
+      (msg) => msg.info.role === "assistant" && PLANNING_AGENTS.has(msg.info.agent),
+    )
+    // kilocode_change end
+
     // Original logic when experimental plan mode is disabled
     if (!Flag.KILO_EXPERIMENTAL_PLAN_MODE) {
+      // kilocode_change start - architect mode gets plan file reminder instead of PROMPT_PLAN
       if (input.agent.name === "plan") {
         userMessage.parts.push({
           id: Identifier.ascending("part"),
@@ -1428,9 +1437,29 @@ export namespace SessionPrompt {
           synthetic: true,
         })
       }
-      const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
-      // kilocode_change start - renamed from "build" to "code"
-      if (wasPlan && input.agent.name === "code") {
+      if (input.agent.name === "architect") {
+        const plan = Session.plan(input.session)
+        const exists = await Filesystem.exists(plan)
+        if (!exists) await fs.mkdir(path.dirname(plan), { recursive: true })
+        userMessage.parts.push({
+          id: Identifier.ascending("part"),
+          messageID: userMessage.info.id,
+          sessionID: userMessage.info.sessionID,
+          type: "text",
+          text: `<system-reminder>
+## Plan File
+
+${exists ? `A plan file already exists at ${plan}. You can read it and make incremental edits using the edit tool.` : `No plan file exists yet. You should create your plan at ${plan} using the write tool.`}
+This is the only file you are permitted to edit. All other tools you have access to are read-only.
+
+When you have finalized your plan and are confident it is ready for implementation, call the plan_exit tool to signal completion. Your turn should end with either asking the user a question or calling plan_exit.
+</system-reminder>`,
+          synthetic: true,
+        })
+      }
+      // kilocode_change end
+      // kilocode_change start - handle code-switch from any planning agent
+      if (wasPlanningAgent && input.agent.name === "code") {
         // kilocode_change end
         userMessage.parts.push({
           id: Identifier.ascending("part"),
@@ -1447,8 +1476,9 @@ export namespace SessionPrompt {
     // New plan mode logic when flag is enabled
     const assistantMessage = input.messages.findLast((msg) => msg.info.role === "assistant")
 
-    // Switching from plan mode to build mode
-    if (input.agent.name !== "plan" && assistantMessage?.info.agent === "plan") {
+    // Switching from plan/architect mode to build mode
+    // kilocode_change start - handle architect alongside plan
+    if (!isPlanningAgent && assistantMessage?.info.agent && PLANNING_AGENTS.has(assistantMessage.info.agent)) {
       const plan = Session.plan(input.session)
       const exists = await Filesystem.exists(plan)
       if (exists) {
@@ -1466,8 +1496,9 @@ export namespace SessionPrompt {
       return input.messages
     }
 
-    // Entering plan mode
-    if (input.agent.name === "plan" && assistantMessage?.info.agent !== "plan") {
+    // Entering plan/architect mode
+    // kilocode_change start - handle architect alongside plan
+    if (isPlanningAgent && !(assistantMessage?.info.agent && PLANNING_AGENTS.has(assistantMessage.info.agent))) {
       const plan = Session.plan(input.session)
       const exists = await Filesystem.exists(plan)
       if (!exists) await fs.mkdir(path.dirname(plan), { recursive: true })


### PR DESCRIPTION
## Summary

- Adds a new native `architect` agent modeled after the legacy Kilo Code Architect mode — an inquisitive technical leader that gathers context, asks clarifying questions, and produces actionable plans before implementation
- Edit permissions hard-denied except `.kilo/plans/*.md` (plan file only), bash set to `ask` so users approve each command, and user config merged before agent rules so safety restrictions can't be overridden
- Reuses `plan_exit` tool and plan followup flow; prompt injection handles architect alongside plan in both experimental and non-experimental code paths

## Changes

| File | Description |
|------|-------------|
| `packages/opencode/src/agent/prompt/architect.txt` | New system prompt with legacy Architect tone and 6-step planning workflow |
| `packages/opencode/src/agent/agent.ts` | New `architect` agent definition with non-overridable permission restrictions |
| `packages/opencode/src/session/prompt.ts` | `insertReminders` updated to handle architect mode alongside plan mode |
| `packages/opencode/src/kilocode/plan-followup.ts` | Custom text followup preserves originating planning agent |

## Permission enforcement

| Tool | Enforcement | Detail |
|------|-------------|--------|
| `edit`/`write`/`patch` | **Hard deny** | `edit: { "*": "deny" }` with exception only for `.kilo/plans/*.md` |
| `bash` | **Ask** | Every shell command requires explicit user approval; prompt instructs read-only only |
| `plan_exit` | **Allow** | Reuses existing plan_exit tool |
| `question` | **Allow** | Can ask clarifying questions |
| MCP, read, grep, glob, task, web tools | **Allow** | Full info-gathering capability |

User config cannot override these restrictions — `user` rules are merged before architect-specific rules (same pattern as `ask` mode).