### PR TITLE
fix(vscode): restore scrolling in Agent Behaviour agent list

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -264,38 +264,45 @@ const AgentBehaviourTab: Component = () => {
         {language.t("settings.agentBehaviour.availableAgents")}
       </div>
       <Card style={{ "margin-bottom": "12px" }}>
-        <For each={agentNames()}>
-          {(name, index) => {
-            const agent = () => session.agents().find((a) => a.name === name)
-            return (
-              <div
-                style={{
-                  display: "flex",
-                  "align-items": "center",
-                  "justify-content": "space-between",
-                  padding: "8px 4px",
-                  "border-bottom": index() < agentNames().length - 1 ? "1px solid var(--border-weak-base)" : "none",
-                  "border-radius": "4px",
-                }}
-              >
-                <div>
-                  <div style={{ "font-weight": "500", "font-size": "13px" }}>{name}</div>
-                  <Show when={agent()?.description}>
-                    <div
-                      style={{
-                        "font-size": "11px",
-                        color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
-                        "margin-top": "2px",
-                      }}
-                    >
-                      {agent()!.description}
-                    </div>
-                  </Show>
-                </div>
-              </div>
-            )
+        <div
+          style={{
+            "max-height": "320px",
+            "overflow-y": "auto",
           }}
-        </For>
+        >
+          <For each={agentNames()}>
+            {(name, index) => {
+              const agent = () => session.agents().find((a) => a.name === name)
+              return (
+                <div
+                  style={{
+                    display: "flex",
+                    "align-items": "center",
+                    "justify-content": "space-between",
+                    padding: "8px 4px",
+                    "border-bottom": index() < agentNames().length - 1 ? "1px solid var(--border-weak-base)" : "none",
+                    "border-radius": "4px",
+                  }}
+                >
+                  <div>
+                    <div style={{ "font-weight": "500", "font-size": "13px" }}>{name}</div>
+                    <Show when={agent()?.description}>
+                      <div
+                        style={{
+                          "font-size": "11px",
+                          color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
+                          "margin-top": "2px",
+                        }}
+                      >
+                        {agent()!.description}
+                      </div>
+                    </Show>
+                  </div>
+                </div>
+              )
+            }}
+          </For>
+        </div>
       </Card>
 
       <Show when={selectedAgent()}>

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -266,7 +266,7 @@ const AgentBehaviourTab: Component = () => {
       <Card style={{ "margin-bottom": "12px" }}>
         <div
           style={{
-            "max-height": "320px",
+            "max-height": "50vh",
             "overflow-y": "auto",
           }}
         >

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1525,6 +1525,7 @@
 
 .mode-switcher-list {
   overflow-y: auto;
+  max-height: min(50vh, 300px);
 }
 
 .mode-switcher-item {


### PR DESCRIPTION
## Context

Fixes [#7398](https://github.com/Kilo-Org/kilocode/issues/7398): with many configured agents/modes, the Agent Behaviour panel could hide top items and made them unreachable.

## Implementation

The `Available agents` section in `AgentBehaviourTab` now uses an explicit scroll container (`max-height` + `overflow-y: auto`) so long lists stay navigable.

This keeps layout stable while ensuring users can always scroll back to built-in modes such as `code` and `debug`.

## Screenshots

| before | after |
| ------ | ----- |
| Top agents could be clipped/unreachable with 10+ entries | Agent list scrolls and all entries are reachable |

## How to Test

- Configure 10+ agents/modes (for example via `.kilocodemodes`)
- Open `Settings > Agent Behaviour`
- Verify the `Available agents` card is vertically scrollable
- Scroll to confirm top entries (e.g. `code`, `debug`) are visible and selectable

## Get in Touch
thomas07374

Made with [Cursor](https://cursor.com)