### PR TITLE
feat(vscode): lower minimum VS Code version to 1.105.1 for Cursor compatibility

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -15,7 +15,7 @@
     "directory": "packages/kilo-vscode"
   },
   "engines": {
-    "vscode": "^1.108.0"
+    "vscode": "^1.105.1"
   },
   "author": {
     "name": "Kilo Code"
@@ -791,7 +791,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
     "@types/qrcode": "^1.5.6",
-    "@types/vscode": "^1.108.0",
+    "@types/vscode": "^1.105.1",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.7.1",


### PR DESCRIPTION
## Context

Cursor IDE 2.1+ upgraded its Extension API surface to VS Code 1.105.1. Because the Kilo extension previously required `^1.108.0`, it was blocked from installing on Cursor. This PR lowers the minimum version to `^1.105.1` to enable Cursor users to install Kilo Code.

## Implementation

Two changes in `packages/kilo-vscode/package.json`:
- `engines.vscode`: `^1.108.0` → `^1.105.1`
- `@types/vscode` (devDependency): `^1.108.0` → `^1.105.1`

Keeping `@types/vscode` in sync with `engines.vscode` is important — if types were left at 1.108 while the engine is 1.105, TypeScript would not catch accidental usage of 1.106–1.108 APIs, creating silent runtime failures on Cursor.

## Compatibility Report

### APIs introduced in 1.106–1.108 that could break on 1.105.1

| Version | New Finalized API | Used by Kilo? |
|---------|-------------------|---------------|
| 1.108 | `QuickPick.prompt`, `QuickPickItem.resourceUri` | **No** |
| 1.107 | No new finalized extension APIs | N/A |
| 1.106 | `secondarySidebar` view container, `AuthenticationSession.idToken`, Git `getRepositoryWorkspace` | **No** |

The extension uses only well-established APIs available well before 1.105.1: webview providers, commands, workspace configuration, `workspace.fs`, terminal creation, code actions, status bar items, and diagnostics.

## Screenshot

<img width="1622" height="1145" alt="Screen Shot 2026-03-22 at 4 37 32 PM" src="https://github.com/user-attachments/assets/33345cfd-d7bf-488c-81b1-f46d59368d45" />


## Safety Concerns

1. **Cursor runtime vs. API surface mismatch** — Cursor 2.1 only upgraded the *Extension API surface* to 1.105.1; the underlying runtime is based on an earlier VS Code version. This means some VS Code UI features (e.g. git graph file listings, quick diff for staged changes) are absent. However, Kilo does not depend on any of these internal VS Code UI capabilities — it only uses the extension API, so this is not a concern.

2. **ESM extensions** — Cursor 2.1 does not support ESM-based extensions (introduced in VS Code 1.100), even though the API surface claims 1.105.1. Kilo builds as CommonJS via esbuild, so this does not apply.

3. **API regression guard** — By also lowering `@types/vscode` to `^1.105.1`, TypeScript will now fail at compile time if a 1.106+ API is accidentally introduced, preserving the compatibility guarantee going forward.

## Screenshots

N/A — no UI changes.

## How to Test

1. Build the `.vsix` from this branch
2. Install it in Cursor 2.1+ (Extensions → Install from VSIX)
3. Verify the extension loads and functions normally
4. Also verify no regressions on VS Code 1.105.1 stable

## Get in Touch

<!-- Discord handle if applicable -->