### PR TITLE
fix(snapshot): add missing git config flags to cleanup() for Windows

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -34,7 +34,7 @@ export namespace Snapshot {
       .then(() => true)
       .catch(() => false)
     if (!exists) return
-    const result = await $`git --git-dir ${git} --work-tree ${Instance.worktree} gc --prune=${prune}`
+    const result = await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} gc --prune=${prune}`
       .quiet()
       .cwd(Instance.directory)
       .nothrow()


### PR DESCRIPTION
## Summary

Adds the missing `-c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true` flags to the `git gc` call in `cleanup()` at `packages/opencode/src/snapshot/index.ts:37`.

## Why this matters

On Windows, `cleanup()` calls `git gc --prune` without the config parameters that every other git command in the same file uses. This causes the gc to fail with exit code 128, leaving temporary pack files (`tmp_pack_*`) that accumulate 10-20 GB per session.

## Changes

`packages/opencode/src/snapshot/index.ts` line 37: added `-c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true` to match the pattern used in `track()`, `patch()`, `diff()`, `restore()`, `revert()`, and `diffFull()` in the same file.

Fixes #7415

This contribution was developed with AI assistance (Claude Code).