### PR TITLE
fix(vscode): prevent ghost text from re-wrapping preceding visible text

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -830,6 +830,8 @@
   font-family: var(--vscode-font-family);
   font-size: 13px;
   line-height: 1.4;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
   resize: none;
   outline: none;
   scrollbar-gutter: stable;
@@ -875,7 +877,7 @@
   font-size: 13px;
   line-height: 1.4;
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
   overflow-x: hidden;
   overflow-y: auto;
   scrollbar-gutter: stable;

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -830,8 +830,6 @@
   font-family: var(--vscode-font-family);
   font-size: 13px;
   line-height: 1.4;
-  white-space: pre-wrap;
-  overflow-wrap: break-word;
   resize: none;
   outline: none;
   scrollbar-gutter: stable;
@@ -877,7 +875,7 @@
   font-size: 13px;
   line-height: 1.4;
   white-space: pre-wrap;
-  overflow-wrap: break-word;
+  word-wrap: break-word;
   overflow-x: hidden;
   overflow-y: auto;
   scrollbar-gutter: stable;
@@ -891,6 +889,7 @@
 
 .prompt-input-ghost-text {
   color: var(--vscode-editorGhostText-foreground, rgba(255, 255, 255, 0.35));
+  display: inline-flex;
 }
 
 .prompt-input-hint {


### PR DESCRIPTION
## Summary

- Fix ghost text (autocomplete suggestion) causing visible text to wrap while the cursor stays on the original line

## Problem

The chat input uses a transparent-textarea-over-overlay pattern: the `<textarea>` has `color: transparent` and sits on top of a `<div>` overlay that renders the visible text. The cursor follows the textarea's layout, but the visible text follows the overlay's.

Ghost text only exists in the overlay. When a long suggestion (like a URL) is appended inline, the browser re-wraps the entire line — including the preceding visible text. But the cursor stays put because the textarea has no ghost text and doesn't re-wrap. This creates a gap between where the text appears and where the cursor is.

This didn't happen in the legacy extension because it used the inverse z-order: the textarea text was visible (cursor and text aligned), and the overlay text was transparent (so wrapping mismatches were hidden).

## Fix

Add `display: inline-flex` to `.prompt-input-ghost-text`. This makes the ghost text span an atomic inline box — the browser treats it as a single indivisible unit for line-breaking. It either fits on the current line or wraps to the next line as a whole, but never pulls preceding words onto a new line with it.

![CleanShot 2026-03-23 at 11 22 30](https://github.com/user-attachments/assets/e981c07b-eb48-4dc7-935a-b99faad95281)

