### PR TITLE
fix(vscode): prevent ghost text from showing over placeholder in empty input

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/hooks/useGhostText.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useGhostText.ts
@@ -112,13 +112,6 @@ export function useGhostText(vscode: VSCodeContext, getText: () => string, conne
       return
     }
 
-    // Never show ghost text on an empty input — the native placeholder is
-    // visible and would overlap with the ghost text overlay.
-    if (!val) {
-      setGhost("")
-      return
-    }
-
     // Cursor must be at end (if textarea is available)
     if (textarea) {
       const atEnd = textarea.selectionStart === textarea.selectionEnd && textarea.selectionEnd === textarea.value.length

--- a/packages/kilo-vscode/webview-ui/src/hooks/useGhostText.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useGhostText.ts
@@ -112,6 +112,13 @@ export function useGhostText(vscode: VSCodeContext, getText: () => string, conne
       return
     }
 
+    // Never show ghost text on an empty input — the native placeholder is
+    // visible and would overlap with the ghost text overlay.
+    if (!val) {
+      setGhost("")
+      return
+    }
+
     // Cursor must be at end (if textarea is available)
     if (textarea) {
       const atEnd = textarea.selectionStart === textarea.selectionEnd && textarea.selectionEnd === textarea.value.length
@@ -130,10 +137,18 @@ export function useGhostText(vscode: VSCodeContext, getText: () => string, conne
   // Also cancels pending debounce when text is cleared (e.g., on send).
   createEffect(() => {
     const val = getText()
-    if (!val && timer) {
-      // Text cleared - cancel pending debounce to prevent empty-text completion
-      clearTimeout(timer)
-      timer = undefined
+    if (!val) {
+      // Text cleared — cancel pending debounce and invalidate any in-flight
+      // requests so a stale completion response cannot resurface ghost text
+      // over the native placeholder.
+      if (timer) {
+        clearTimeout(timer)
+        timer = undefined
+      }
+      saved = ""
+      savedPrefix = ""
+      prefix = ""
+      counter++
     }
     syncInternal(undefined)
   })


### PR DESCRIPTION
## Summary

Fixes ghost text (AI autocomplete suggestion) appearing under/overlapping with the placeholder text in the chat textarea when the input is empty.

## Problem

The chat textarea uses a layered rendering approach:
- The textarea itself has `color: transparent` — its text is invisible
- An absolute-positioned highlight overlay behind the textarea renders the visible text (with @mention highlights and ghost text)
- The textarea's native `::placeholder` has a visible color override

When ghost text was shown while the textarea was empty, both the placeholder ("Ask anything...") and the ghost text were visible simultaneously, overlapping each other. The ghost text appeared "under" the placeholder since the overlay is at z-index 0 and the textarea (with placeholder) is at z-index 1.

## How to reproduce on main

This is a race condition, so timing matters:

1. Enable chat autocomplete in Settings > Autocomplete
2. Type a message (3+ characters) in the chat textarea and wait ~500ms for the debounce to fire a completion request
3. Quickly send the message (Enter) — this clears the text, but the in-flight completion response is still pending
4. If the stale completion response arrives after the text is cleared, the message handler would accept it (counter still matches), set `saved`/`savedPrefix`, and call `syncInternal`. Normally `syncInternal` catches this because `getText() !== savedPrefix`, but the state (`saved`, `savedPrefix`, `prefix`) is left dirty — meaning any subsequent code path that happens to align the text with the stale `savedPrefix` could resurface ghost text.

The easiest way to force the visual issue: temporarily add `saved = "test suggestion"; savedPrefix = "";` right before `syncInternal(undefined)` in the `createEffect` — this simulates the stale state that causes ghost text to overlap with the placeholder.

## Fix

When text is cleared, the `createEffect` now fully invalidates ghost state (`saved`, `savedPrefix`, `prefix`) and increments the request counter. This ensures stale in-flight completion responses are rejected at the `requestId` check and can never populate ghost state for an empty input. No display-side guards needed — `syncInternal` naturally won't show ghost text because `saved` will always be empty when the input is empty.
