### PR TITLE
fix(vscode): allow punctuation after @-mentions in syncMentionedPaths

### DIFF
--- a/packages/kilo-vscode/tests/unit/file-mention-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/file-mention-utils.test.ts
@@ -73,6 +73,24 @@ describe("syncMentionedPaths", () => {
     const result = syncMentionedPaths(paths, "@foo.ts is important")
     expect(result.has("foo.ts")).toBe(true)
   })
+
+  it("keeps mention when followed by a comma", () => {
+    const paths = new Set(["foo.ts"])
+    const result = syncMentionedPaths(paths, "see @foo.ts, it explains things")
+    expect(result.has("foo.ts")).toBe(true)
+  })
+
+  it("keeps mention when followed by a period", () => {
+    const paths = new Set(["foo.ts"])
+    const result = syncMentionedPaths(paths, "check @foo.ts.")
+    expect(result.has("foo.ts")).toBe(true)
+  })
+
+  it("keeps mention when followed by other punctuation", () => {
+    const paths = new Set(["foo.ts"])
+    const result = syncMentionedPaths(paths, "is it @foo.ts?")
+    expect(result.has("foo.ts")).toBe(true)
+  })
 })
 
 describe("buildTextAfterMentionSelect", () => {

--- a/packages/kilo-vscode/webview-ui/src/hooks/file-mention-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/file-mention-utils.ts
@@ -13,15 +13,18 @@ function escape(str: string): string {
  * Sync the set of mentioned paths against the current text.
  * Removes any paths that are no longer present in the text as @path mentions.
  *
- * Uses boundary-aware matching (whitespace or start/end of string) and processes
- * paths longest-first to prevent `@src/a.ts` from false-matching `@src/a.tsx`.
+ * Uses boundary-aware matching: the leading boundary requires whitespace or
+ * start-of-string, and the trailing boundary rejects path-continuation
+ * characters (word chars, `/`, `-`) so `@src/a.ts` won't false-match
+ * `@src/a.tsx` while `@foo.ts,` or `@foo.ts.` (with trailing punctuation)
+ * still count.
  */
 export function syncMentionedPaths(prev: Set<string>, text: string): Set<string> {
   const next = new Set<string>()
   // Sort longest-first so e.g. "src/a.tsx" is checked before "src/a.ts"
   const sorted = [...prev].sort((a, b) => b.length - a.length)
   for (const path of sorted) {
-    const pattern = new RegExp(`(?:^|\\s)@${escape(path)}(?:\\s|$)`)
+    const pattern = new RegExp(`(?:^|\\s)@${escape(path)}(?![\\w/-])`)
     if (pattern.test(text)) next.add(path)
   }
   return next


### PR DESCRIPTION
## Summary

- Fix `syncMentionedPaths` dropping file attachments when punctuation follows an `@`-mention (e.g. `@foo.ts,` or `@foo.ts.`)
- Replace trailing boundary regex `(?:\s|$)` with negative lookahead `(?![\w/-])` that only rejects path-continuation characters
- Add 3 test cases covering comma, period, and question mark after mentions

## Context

Addresses the review comment on #7316: the previous regex only accepted whitespace or end-of-string after a mention path, so typing `@foo.ts,` in a sentence would cause `syncMentionedPaths` to remove the attachment even though `buildFileAttachments` and the prompt highlighter still recognized it.

The fix uses `(?![\w/-])` (negative lookahead) instead of `(?:\s|$)` — this rejects word characters, `/`, and `-` as path-continuation characters while accepting punctuation like `,`, `.`, `!`, `?`, `)`, etc.

## Testing

All 24 file-mention-utils tests pass (21 existing + 3 new).
