### PR TITLE
chore(vscode): run bun install before F5 compile task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -69,7 +69,7 @@
       "label": "VSCode - Install",
       "type": "shell",
       "command": "bun",
-      "args": ["install"],
+      "args": ["install", "--frozen-lockfile"],
       "group": "build",
       "presentation": {
         "reveal": "silent"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -66,6 +66,20 @@
       "problemMatcher": []
     },
     {
+      "label": "VSCode - Install",
+      "type": "shell",
+      "command": "bun",
+      "args": ["install"],
+      "group": "build",
+      "presentation": {
+        "reveal": "silent"
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "VSCode - Compile",
       "type": "shell",
       "command": "bun",
@@ -77,6 +91,7 @@
       "options": {
         "cwd": "${workspaceFolder}/packages/kilo-vscode"
       },
+      "dependsOn": ["VSCode - Install"],
       "problemMatcher": ["$tsc", "$eslint-stylish"]
     },
     {


### PR DESCRIPTION
## Summary
- Adds a `VSCode - Install` task that runs `bun install` from the workspace root
- Makes the `VSCode - Compile` preLaunchTask depend on it, so F5 always installs dependencies before building
- Fixes the common issue where F5 fails because dependencies are out of date after pulling new changes
