### PR TITLE
fix(vscode): use correct SCM repository for commit message generation in worktrees

### DIFF
--- a/packages/kilo-vscode/src/services/commit-message/__tests__/index.spec.ts
+++ b/packages/kilo-vscode/src/services/commit-message/__tests__/index.spec.ts
@@ -203,5 +203,56 @@ describe("commit-message service", () => {
         expect.any(Function),
       )
     })
+
+    it("uses the matching repository when SourceControl arg is provided", async () => {
+      const mainInputBox = { value: "" }
+      const worktreeInputBox = { value: "" }
+      vi.mocked(vscode.extensions.getExtension).mockReturnValue({
+        isActive: true,
+        activate: vi.fn().mockResolvedValue(undefined),
+        exports: {
+          getAPI: () => ({
+            repositories: [
+              { inputBox: mainInputBox, rootUri: { fsPath: "/main-repo" } },
+              { inputBox: worktreeInputBox, rootUri: { fsPath: "/worktree-repo" } },
+            ],
+          }),
+        },
+      } as any)
+
+      vi.mocked(vscode.window.withProgress).mockImplementation(async (_options, task) => {
+        await task({} as any, {} as any)
+      })
+
+      // Simulate SCM title/input passing the SourceControl for the worktree repo
+      const scmArg = { rootUri: { fsPath: "/worktree-repo" } } as vscode.SourceControl
+      await commandCallback(scmArg)
+
+      // The worktree repo's inputBox should be updated, not the main repo's
+      expect(worktreeInputBox.value).toBe("feat: add new feature")
+      expect(mainInputBox.value).toBe("")
+    })
+
+    it("falls back to first repository when SourceControl arg has no match", async () => {
+      const mainInputBox = { value: "" }
+      vi.mocked(vscode.extensions.getExtension).mockReturnValue({
+        isActive: true,
+        activate: vi.fn().mockResolvedValue(undefined),
+        exports: {
+          getAPI: () => ({
+            repositories: [{ inputBox: mainInputBox, rootUri: { fsPath: "/main-repo" } }],
+          }),
+        },
+      } as any)
+
+      vi.mocked(vscode.window.withProgress).mockImplementation(async (_options, task) => {
+        await task({} as any, {} as any)
+      })
+
+      const scmArg = { rootUri: { fsPath: "/nonexistent-repo" } } as vscode.SourceControl
+      await commandCallback(scmArg)
+
+      expect(mainInputBox.value).toBe("feat: add new feature")
+    })
   })
 })

--- a/packages/kilo-vscode/src/services/commit-message/index.ts
+++ b/packages/kilo-vscode/src/services/commit-message/index.ts
@@ -19,65 +19,78 @@ interface GitExtensionExports {
   getAPI(version: number): GitAPI
 }
 
+function findRepository(repositories: GitRepository[], arg?: vscode.SourceControl): GitRepository | undefined {
+  if (!repositories.length) return undefined
+  if (arg?.rootUri) {
+    const target = arg.rootUri.fsPath
+    const match = repositories.find((r) => r.rootUri.fsPath === target)
+    if (match) return match
+  }
+  return repositories[0]
+}
+
 export function registerCommitMessageService(
   context: vscode.ExtensionContext,
   connectionService: KiloConnectionService,
 ): vscode.Disposable[] {
-  const command = vscode.commands.registerCommand("kilo-code.new.generateCommitMessage", async () => {
-    const extension = vscode.extensions.getExtension<GitExtensionExports>("vscode.git")
-    if (!extension) {
-      vscode.window.showErrorMessage("Git extension not found")
-      return
-    }
+  const command = vscode.commands.registerCommand(
+    "kilo-code.new.generateCommitMessage",
+    async (arg?: vscode.SourceControl) => {
+      const extension = vscode.extensions.getExtension<GitExtensionExports>("vscode.git")
+      if (!extension) {
+        vscode.window.showErrorMessage("Git extension not found")
+        return
+      }
 
-    if (!extension.isActive) {
-      await extension.activate()
-    }
+      if (!extension.isActive) {
+        await extension.activate()
+      }
 
-    const git = extension.exports?.getAPI(1)
-    const repository = git?.repositories[0]
-    if (!repository) {
-      vscode.window.showErrorMessage("No Git repository found")
-      return
-    }
+      const git = extension.exports?.getAPI(1)
+      const repository = findRepository(git?.repositories ?? [], arg)
+      if (!repository) {
+        vscode.window.showErrorMessage("No Git repository found")
+        return
+      }
 
-    let client: KiloClient | undefined
-    try {
-      client = connectionService.getClient()
-    } catch {
-      vscode.window.showErrorMessage("Kilo backend is not connected. Please wait for the connection to establish.")
-      return
-    }
-    if (!client) {
-      vscode.window.showErrorMessage("Kilo backend is not connected. Please wait for the connection to establish.")
-      return
-    }
+      let client: KiloClient | undefined
+      try {
+        client = connectionService.getClient()
+      } catch {
+        vscode.window.showErrorMessage("Kilo backend is not connected. Please wait for the connection to establish.")
+        return
+      }
+      if (!client) {
+        vscode.window.showErrorMessage("Kilo backend is not connected. Please wait for the connection to establish.")
+        return
+      }
 
-    const path = repository.rootUri.fsPath
+      const path = repository.rootUri.fsPath
 
-    const previousMessage = lastWorkspacePath === path ? lastGeneratedMessage : undefined
+      const previousMessage = lastWorkspacePath === path ? lastGeneratedMessage : undefined
 
-    await vscode.window
-      .withProgress(
-        { location: vscode.ProgressLocation.SourceControl, title: "Generating commit message..." },
-        async () => {
-          const { data } = await client.commitMessage.generate(
-            { path, selectedFiles: undefined, previousMessage },
-            { throwOnError: true },
-          )
-          const message = data.message
-          repository.inputBox.value = message
-          lastGeneratedMessage = message
-          lastWorkspacePath = path
-          console.log("[Kilo New] Commit message generated successfully")
-        },
-      )
-      .then(undefined, (error: unknown) => {
-        const msg = getErrorMessage(error)
-        console.error("[Kilo New] Failed to generate commit message:", msg)
-        vscode.window.showErrorMessage(`Failed to generate commit message: ${msg}`)
-      })
-  })
+      await vscode.window
+        .withProgress(
+          { location: vscode.ProgressLocation.SourceControl, title: "Generating commit message..." },
+          async () => {
+            const { data } = await client.commitMessage.generate(
+              { path, selectedFiles: undefined, previousMessage },
+              { throwOnError: true },
+            )
+            const message = data.message
+            repository.inputBox.value = message
+            lastGeneratedMessage = message
+            lastWorkspacePath = path
+            console.log("[Kilo New] Commit message generated successfully")
+          },
+        )
+        .then(undefined, (error: unknown) => {
+          const msg = getErrorMessage(error)
+          console.error("[Kilo New] Failed to generate commit message:", msg)
+          vscode.window.showErrorMessage(`Failed to generate commit message: ${msg}`)
+        })
+    },
+  )
 
   context.subscriptions.push(command)
   return [command]


### PR DESCRIPTION
## Summary

- **Fix**: Commit message generation always used `repositories[0]` from VS Code's Git extension, ignoring which SCM panel the user clicked. With worktrees (or multi-root workspaces), this meant the command would look for changes in the wrong repository and report "no changes found."
- **Solution**: Accept the `SourceControl` argument that VS Code passes when commands are invoked from `scm/title` and `scm/input` menus, and match it against the Git extension's repository list by `rootUri.fsPath`. Falls back to `repositories[0]` when no argument is provided (e.g. command palette).
- Added tests for the worktree/multi-repo matching behavior.

## Root Cause

When the `generateCommitMessage` command is contributed to `scm/title` and `scm/input` menus, VS Code passes a `SourceControl` object as the first argument identifying which repository's SCM panel was clicked. The handler was defined as `async () => { ... }` with no parameters, so it always fell back to `git?.repositories[0]` — which may not be the repository the user is looking at.
