### PR TITLE
feat(cli,vscode): change default bash auto-approve rule to ask

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/settings/AutoApproveTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AutoApproveTab.tsx
@@ -112,6 +112,7 @@ const TRAILING_TOOLS: ToolDef[] = [
  * change, this map must be updated to match.
  */
 const TOOL_DEFAULTS: Partial<Record<string, PermissionLevel>> = {
+  bash: "ask",
   doom_loop: "ask",
   external_directory: "ask",
 }

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -63,6 +63,7 @@ export namespace Agent {
     const whitelistedDirs = [Truncate.GLOB, ...skillDirs.map((dir) => path.join(dir, "*"))]
     const defaults = PermissionNext.fromConfig({
       "*": "allow",
+      bash: "ask",
       doom_loop: "ask",
       external_directory: {
         "*": "ask",


### PR DESCRIPTION
## Summary

- Changes the default bash auto-approve rule from `allow` (inherited from `"*": "allow"` wildcard) to `ask`, so users are prompted before shell commands execute
- Updates the VS Code extension's `TOOL_DEFAULTS` mirror in `AutoApproveTab.tsx` to match the backend default

Closes #7436
