### PR TITLE
fix(ui): escape HTML in codespan renderer to prevent tag injection

### DIFF
--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -632,12 +632,18 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
           // kilocode_change start
           codespan({ text }) {
             const file = parseFilePath(text)
+            const escaped = text
+              .replace(/&/g, "&amp;")
+              .replace(/</g, "&lt;")
+              .replace(/>/g, "&gt;")
+              .replace(/"/g, "&quot;")
+              .replace(/'/g, "&#39;")
             if (file) {
               const lineAttr = file.line ? ` data-file-line="${file.line}"` : ""
               const colAttr = file.column ? ` data-file-col="${file.column}"` : ""
-              return `<code class="file-link" data-file-path="${file.path}"${lineAttr}${colAttr}>${text}</code>`
+              return `<code class="file-link" data-file-path="${file.path}"${lineAttr}${colAttr}>${escaped}</code>`
             }
-            return `<code>${text}</code>`
+            return `<code>${escaped}</code>`
           },
           code({ text, lang }) {
             const escaped = text


### PR DESCRIPTION
## Summary

- Fix HTML tags inside backtick code spans being injected as raw HTML into the DOM instead of being escaped

## Problem

The custom `codespan` renderer in `packages/ui/src/context/marked.tsx` injected the raw `text` token from marked directly into `<code>` tags without HTML-escaping. When backtick-wrapped content contained HTML tags (e.g. `` `<textarea>` ``), the raw tags entered the DOM.

This is particularly bad with `<textarea>` because it's a **raw text element** in HTML — once the browser's parser encounters it, everything until `</textarea>` is consumed as textarea content. This broke `<code>` tag pairing downstream, leaving `</code>` visible as literal text in the rendered output.

### Reproduction

Send this prompt in the VS Code extension chat:

```
echo back this exact text: The `<textarea>` tag has `color: transparent` and the `<code>input</code>` to match the overlay
```

On **main**: `</code>` appears as visible text in the rendered output.

## Fix

Escape HTML entities (`<`, `>`, `&`, `"`, `'`) in the codespan `text` before embedding it in the `<code>` output. This matches what marked's default `codespan` renderer does and what the project's `code` block renderer already does.

File path detection via `parseFilePath()` is unaffected since it runs on the raw text before escaping.

| Before | After | 
| --- | --- | 
| <img width="657" height="245" alt="CleanShot 2026-03-23 at 13 18 23" src="https://github.com/user-attachments/assets/a8929008-14b0-4ff3-aee9-94098dceb288" /> | <img width="306" height="392" alt="CleanShot 2026-03-23 at 13 19 14" src="https://github.com/user-attachments/assets/9593ac75-bbe6-40fc-ba6c-9d44b58446a1" /> |
