### PR TITLE
feat(agent-manager): show spinner on sidebar items when agent is actively working

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -796,6 +796,32 @@ const AgentManagerContent: Component = () => {
 
   const isStaleWorktree = (worktreeId: string): boolean => staleWorktreeIds().has(worktreeId)
 
+  /** True when any session in the given ID list is actively working (busy/retry and not blocked by permissions/questions). */
+  const isAnySessionBusy = (ids: string[]): boolean => {
+    if (ids.length === 0) return false
+    const statuses = session.allStatusMap()
+    const perms = session.permissions()
+    const qs = session.questions()
+    for (const id of ids) {
+      const info = statuses[id]
+      if (!info || info.type === "idle") continue
+      const blocked = perms.some((p) => p.sessionID === id) || qs.some((q) => q.sessionID === id)
+      if (!blocked) return true
+    }
+    return false
+  }
+
+  /** True when an agent session assigned to this worktree is actively working. */
+  const isAgentBusy = (worktreeId: string): boolean => {
+    const ids = managedSessions()
+      .filter((ms) => ms.worktreeId === worktreeId)
+      .map((ms) => ms.id)
+    return isAnySessionBusy(ids)
+  }
+
+  /** True when a local session is actively working. */
+  const isLocalBusy = (): boolean => isAnySessionBusy(localSessionIDs())
+
   /** Worktrees sorted so that grouped items are always adjacent, ordered by creation time. */
   const sortedWorktrees = createMemo(() => {
     const all = worktrees()
@@ -1974,11 +2000,13 @@ const AgentManagerContent: Component = () => {
           data-sidebar-id="local"
           onClick={() => selectLocal()}
         >
-          <svg class="am-local-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect x="2.5" y="3.5" width="15" height="10" rx="1" stroke="currentColor" />
-            <path d="M6 16.5H14" stroke="currentColor" stroke-linecap="square" />
-            <path d="M10 13.5V16.5" stroke="currentColor" />
-          </svg>
+          <Show when={!isLocalBusy()} fallback={<Spinner class="am-worktree-spinner" />}>
+            <svg class="am-local-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect x="2.5" y="3.5" width="15" height="10" rx="1" stroke="currentColor" />
+              <path d="M6 16.5H14" stroke="currentColor" stroke-linecap="square" />
+              <path d="M10 13.5V16.5" stroke="currentColor" />
+            </svg>
+          </Show>
           <div class="am-local-text">
             <span class="am-local-label">{t("agentManager.local")}</span>
             <Show when={repoBranch()}>
@@ -2183,7 +2211,7 @@ const AgentManagerContent: Component = () => {
                             label={worktreeLabel(wt)}
                             active={selection() === wt.id}
                             pendingDelete={pendingDelete() === wt.id}
-                            busy={busyWorktrees().has(wt.id)}
+                            busy={busyWorktrees().has(wt.id) || isAgentBusy(wt.id)}
                             stale={isStaleWorktree(wt.id)}
                             shortcut={idx() + 2}
                             stats={worktreeStats()[wt.id]}

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2211,7 +2211,8 @@ const AgentManagerContent: Component = () => {
                             label={worktreeLabel(wt)}
                             active={selection() === wt.id}
                             pendingDelete={pendingDelete() === wt.id}
-                            busy={busyWorktrees().has(wt.id) || isAgentBusy(wt.id)}
+                            busy={busyWorktrees().has(wt.id)}
+                            working={isAgentBusy(wt.id)}
                             stale={isStaleWorktree(wt.id)}
                             shortcut={idx() + 2}
                             stats={worktreeStats()[wt.id]}

--- a/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
@@ -22,6 +22,8 @@ interface WorktreeItemProps {
   active: boolean
   pendingDelete: boolean
   busy: boolean
+  /** Whether an agent session on this worktree is actively working (shows spinner instead of branch icon). */
+  working: boolean
   stale: boolean
   /** 1-indexed shortcut number shown as ⌘2, ⌘3, etc. Pass 0 or >9 to hide. */
   shortcut: number
@@ -91,7 +93,7 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
             data-sidebar-id={props.worktree.id}
             onClick={() => props.onClick()}
           >
-            <Show when={!props.busy} fallback={<Spinner class="am-worktree-spinner" />}>
+            <Show when={!props.busy && !props.working} fallback={<Spinner class="am-worktree-spinner" />}>
               <Icon name="branch" size="small" />
             </Show>
             <Show when={props.stale}>

--- a/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
@@ -159,6 +159,7 @@ const defaultProps = {
   active: false,
   pendingDelete: false,
   busy: false,
+  working: false,
   stale: false,
   shortcut: 2,
   sessions: 1,


### PR DESCRIPTION
## Summary
- Replaces the branch icon (worktrees) and monitor icon (local repo) with a loading spinner in the Agent Manager sidebar when an agent session is actively working
- Spinner only shows when the session is busy/retrying AND not blocked by permissions or questions — reverts to normal icon when agent goes idle or needs user input
- Shared `isAnySessionBusy()` helper handles both local and worktree contexts

<img width="302" height="170" alt="image" src="https://github.com/user-attachments/assets/5cc8a481-c114-428c-b920-51a5b1ee6fc3" />
