### PR TITLE
feat(cli): add config location awareness

### DIFF
--- a/packages/opencode/src/kilocode/components/tips.tsx
+++ b/packages/opencode/src/kilocode/components/tips.tsx
@@ -142,4 +142,5 @@ const TIPS = [
   "Run {highlight}/help{/highlight} to show the help dialog",
   "Use {highlight}/rename{/highlight} to rename the current session",
   "Press {highlight}Ctrl+Z{/highlight} to suspend the terminal and return to your shell",
+  "Doing something often? Ask Kilo to save it as a {highlight}/command{/highlight}",
 ]

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -68,7 +68,7 @@ export namespace SystemPrompt {
         `  Working directory: ${Instance.directory}`,
         `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
-        `  Project config: .kilo/ (command/*.md, agent/*.md, kilo.json, AGENTS.md). Reuse .kilocode/ or .opencode/ if already present; otherwise create .kilo/.`, // kilocode_change
+        `  Project config: .kilo/ (command/*.md, agent/*.md, kilo.json, AGENTS.md). Reuse .kilocode/ if already present; otherwise create .kilo/.`, // kilocode_change
         `  Global config: ${Global.Path.config}/ (same structure)`, // kilocode_change
         ...staticEnvLines(editorContext), // kilocode_change
         `</env>`,

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -68,7 +68,7 @@ export namespace SystemPrompt {
         `  Working directory: ${Instance.directory}`,
         `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
-        `  Project config: .kilo/ (command/*.md, agent/*.md, kilo.json, AGENTS.md). Reuse .kilocode/ if already present; otherwise create .kilo/.`, // kilocode_change
+        `  Project config: .kilo/ (command/*.md, agent/*.md, kilo.json, AGENTS.md). Always use .kilo/ for new config. Do not use .kilocode/ or .opencode/.`, // kilocode_change
         `  Global config: ${Global.Path.config}/ (same structure)`, // kilocode_change
         ...staticEnvLines(editorContext), // kilocode_change
         `</env>`,

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -68,7 +68,7 @@ export namespace SystemPrompt {
         `  Working directory: ${Instance.directory}`,
         `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
-        `  Project config: .kilo/ (command/*.md, agent/*.md, kilo.json, AGENTS.md)`, // kilocode_change
+        `  Project config: .kilo/ (command/*.md, agent/*.md, kilo.json, AGENTS.md). Reuse .kilocode/ or .opencode/ if already present; otherwise create .kilo/.`, // kilocode_change
         `  Global config: ${Global.Path.config}/ (same structure)`, // kilocode_change
         ...staticEnvLines(editorContext), // kilocode_change
         `</env>`,

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -1,5 +1,6 @@
 import { Ripgrep } from "../file/ripgrep"
 
+import { Global } from "../global" // kilocode_change
 import { Instance } from "../project/instance"
 
 import PROMPT_ANTHROPIC from "./prompt/anthropic.txt"
@@ -67,6 +68,8 @@ export namespace SystemPrompt {
         `  Working directory: ${Instance.directory}`,
         `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
+        `  Project config: .kilo/ (command/*.md, agent/*.md, kilo.json, AGENTS.md)`, // kilocode_change
+        `  Global config: ${Global.Path.config}/ (same structure)`, // kilocode_change
         ...staticEnvLines(editorContext), // kilocode_change
         `</env>`,
         `<directories>`,

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -68,7 +68,7 @@ export namespace SystemPrompt {
         `  Working directory: ${Instance.directory}`,
         `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
-        `  Project config: .kilo/ (command/*.md, agent/*.md, kilo.json, AGENTS.md). Always use .kilo/ for new config. Do not use .kilocode/ or .opencode/.`, // kilocode_change
+        `  Project config: .kilo/command/*.md, .kilo/agent/*.md, kilo.json, AGENTS.md. Put new commands and agents in .kilo/. Do not use .kilocode/ or .opencode/.`, // kilocode_change
         `  Global config: ${Global.Path.config}/ (same structure)`, // kilocode_change
         ...staticEnvLines(editorContext), // kilocode_change
         `</env>`,


### PR DESCRIPTION
## Why

When a user asks the AI to create a command, agent, or config file, the model has no idea where those files should go. It has to guess or ask, which wastes time and often gets it wrong.

The user can simply ask now:

```
> create a new command /extra-review-pr that spawns many sub-agents each specific to performance, security etc
```

By default it will create it at repo level, but ask it and it can make it global.

## What changed

The system prompt now tells the model about the two places Kilo stores configuration: the project-level `.kilo/` directory and the global config directory. This is done by adding two short lines to the existing environment block that every session already includes. A new tip was also added to the home screen encouraging users to turn repetitive tasks into reusable slash commands.

## How to test

1. Start Kilo with `bun run dev`
2. Ask the model "create a command that runs my test suite"
3. Verify the model knows to place the file in `.kilo/command/` without being told
4. On the home screen, cycle through tips until you see "Doing something often? Ask Kilo to save it as a /command"