### PR TITLE
Remote - add real-time session relay and remote control over WebSocket

### DIFF
--- a/packages/opencode/src/cli/cmd/remote.ts
+++ b/packages/opencode/src/cli/cmd/remote.ts
@@ -1,0 +1,31 @@
+// kilocode_change - new file
+import { cmd } from "./cmd"
+import { bootstrap } from "../bootstrap"
+import { KiloSessions } from "@/kilo-sessions/kilo-sessions"
+import { Instance } from "@/project/instance"
+
+export const RemoteCommand = cmd({
+  command: "remote",
+  describe: "enable remote connection for real-time session relay",
+  builder: (yargs) => yargs,
+  handler: async () => {
+    await bootstrap(process.cwd(), async () => {
+      await KiloSessions.enableRemote()
+      console.log("Remote connection enabled.")
+
+      const abort = new AbortController()
+      const shutdown = async () => {
+        try {
+          KiloSessions.disableRemote()
+          await Instance.dispose()
+        } finally {
+          abort.abort()
+        }
+      }
+      process.on("SIGTERM", shutdown)
+      process.on("SIGINT", shutdown)
+      process.on("SIGHUP", shutdown)
+      await new Promise((resolve) => abort.signal.addEventListener("abort", resolve))
+    })
+  },
+})

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -261,9 +261,12 @@ function App() {
   }
   const [terminalTitleEnabled, setTerminalTitleEnabled] = createSignal(kv.get("terminal_title_enabled", true))
 
+  // kilocode_change start — notify server which session the user is viewing (for live session indicators)
   createEffect(() => {
-    console.log(JSON.stringify(route.data))
+    const sessionID = route.data.type === "session" ? route.data.sessionID : undefined
+    sdk.client.session.viewed({ sessionID }).catch(() => {})
   })
+  // kilocode_change end
 
   // Update terminal window title based on current route and session
   createEffect(() => {

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -16,6 +16,8 @@ import { useKV } from "../context/kv"
 import { useCommandDialog } from "../component/dialog-command"
 import { KiloNews } from "@/kilocode/components/kilo-news" // kilocode_change
 import { useConnected } from "../component/dialog-model" // kilocode_change
+import { RemoteIndicator } from "@/kilocode/remote-tui" // kilocode_change
+import { useSDK } from "../context/sdk" // kilocode_change
 
 // TODO: what is the best way to do this?
 let once = false
@@ -27,6 +29,7 @@ export function Home() {
   const route = useRouteData("home")
   const promptRef = usePromptRef()
   const command = useCommandDialog()
+  const sdk = useSDK() // kilocode_change
   const mcp = createMemo(() => Object.keys(sync.data.mcp).length > 0)
   const mcpError = createMemo(() => {
     return Object.values(sync.data.mcp).some((x) => x.status === "failed")
@@ -149,6 +152,7 @@ export function Home() {
       <box paddingTop={1} paddingBottom={1} paddingLeft={2} paddingRight={2} flexDirection="row" flexShrink={0} gap={2}>
         <text fg={theme.textMuted}>{directory()}</text>
         <box gap={1} flexDirection="row" flexShrink={0}>
+          <RemoteIndicator sdk={sdk} theme={theme} kilo={sync.data.provider_next.connected.includes("kilo")} />
           <Show when={mcp()}>
             <text fg={theme.text}>
               <Switch>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
@@ -3,8 +3,10 @@ import { useTheme } from "../../context/theme"
 import { useSync } from "../../context/sync"
 import { useDirectory } from "../../context/directory"
 import { useConnected } from "../../component/dialog-model"
+import { useSDK } from "../../context/sdk" // kilocode_change
 import { createStore } from "solid-js/store"
 import { useRoute } from "../../context/route"
+import { RemoteIndicator } from "@/kilocode/remote-tui" // kilocode_change
 
 export function Footer() {
   const { theme } = useTheme()
@@ -19,6 +21,7 @@ export function Footer() {
   })
   const directory = useDirectory()
   const connected = useConnected()
+  const sdk = useSDK() // kilocode_change
 
   const [store, setStore] = createStore({
     welcome: false,
@@ -53,6 +56,7 @@ export function Footer() {
     <box flexDirection="row" justifyContent="space-between" gap={1} flexShrink={0}>
       <text fg={theme.textMuted}>{directory()}</text>
       <box gap={2} flexDirection="row" flexShrink={0}>
+        <RemoteIndicator sdk={sdk} theme={theme} kilo={sync.data.provider_next.connected.includes("kilo")} />
         <Switch>
           <Match when={store.welcome}>
             <text fg={theme.text}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1222,6 +1222,8 @@ export function Session() {
             </box>
           </Show>
           <Toast />
+          {/* kilocode_change */}
+          <Footer />
         </box>
         <Show when={sidebarVisible()}>
           <Switch>

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -28,6 +28,7 @@ import { EOL } from "os"
 // import { WebCommand } from "./cli/cmd/web" // kilocode_change (Disabled unsupported opencode web UI)
 import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
+import { RemoteCommand } from "./cli/cmd/remote" // kilocode_change
 // kilocode_change start - Import telemetry, instance disposal, and legacy migration
 import { Telemetry } from "@kilocode/kilo-telemetry"
 import { Instance } from "./project/instance" // kilocode_change
@@ -192,6 +193,7 @@ let cli = yargs(hideBin(process.argv))
   // .command(GithubCommand) // kilocode_change (Disabled until backend is ready)
   .command(PrCommand)
   .command(SessionCommand)
+  .command(RemoteCommand) // kilocode_change
   .command(DbCommand)
 
 if (Installation.isLocal()) {

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -13,6 +13,9 @@ import { KILO_API_BASE } from "@kilocode/kilo-gateway"
 import { Instance } from "@/project/instance"
 import { Vcs } from "@/project/vcs"
 import simpleGit from "simple-git"
+import { RemoteWS } from "@/kilo-sessions/remote-ws"
+import { RemoteSender } from "@/kilo-sessions/remote-sender"
+import { SessionStatus } from "@/session/status"
 
 export namespace KiloSessions {
   const log = Log.create({ service: "kilo-sessions" })
@@ -127,6 +130,12 @@ export namespace KiloSessions {
     },
   })
 
+  const remoteEnabled = process.env["KILO_REMOTE"] === "1"
+  let remote: { conn: RemoteWS.Connection; sender: RemoteSender.Sender; heartbeat: () => Promise<void> } | undefined
+  let enabling: Promise<void> | undefined
+  let remoteSeq = 0
+  let viewedSessionId: string | undefined
+
   export async function init() {
     if (ingestDisabled) return
 
@@ -195,6 +204,116 @@ export namespace KiloSessions {
     Bus.subscribe(Session.Event.TurnClose, async (evt) => {
       await ingest.sync(evt.properties.sessionID, [{ type: "session_close", data: { reason: evt.properties.reason } }])
     })
+
+    if (remoteEnabled) enableRemote().catch((err) => log.warn("remote not enabled", { error: String(err) }))
+    Bus.subscribe(Bus.InstanceDisposed, () => disableRemote())
+  }
+
+  export async function enableRemote() {
+    if (remote) return
+    if (ingestDisabled) return
+    if (enabling) return enabling
+    const seq = ++remoteSeq
+    enabling = (async () => {
+      const token = await kilocodeToken()
+      if (!token) {
+        throw new Error("Unable to enable remote: no Kilo credentials found. Run `kilo auth login`.")
+      }
+
+      const valid = await authValid(token)
+      if (valid === false) {
+        throw new Error("Unable to enable remote: invalid or expired Kilo credentials. Run `kilo auth login`.")
+      }
+      if (valid === undefined) throw new Error("Unable to enable remote: failed to verify Kilo credentials.")
+
+      const url = (process.env["KILO_SESSION_INGEST_URL"] ?? "https://ingest.kilosessions.ai")
+        .replace(/^https:\/\//, "wss://")
+        .replace(/^http:\/\//, "ws://")
+
+      // Capture directory so the heartbeat timer can re-enter the Instance context
+      // (setInterval runs outside AsyncLocalStorage scope)
+      const directory = Instance.directory
+      const getSessions = async () => {
+        const [gitUrl, gitBranch] = await Promise.all([
+          getGitUrl().catch(() => undefined),
+          Vcs.branch().catch(() => undefined),
+        ])
+        const statuses = SessionStatus.list()
+        const ids = new Set(Object.keys(statuses))
+        if (viewedSessionId) ids.add(viewedSessionId)
+        const results = await Promise.all(
+          [...ids].map(async (id) => {
+            const session = await Session.get(id).catch(() => undefined)
+            if (!session) return undefined
+            return {
+              id,
+              status: statuses[id]?.type ?? "idle",
+              title: session.title,
+              gitUrl,
+              gitBranch,
+            }
+          }),
+        )
+        return results.filter((r): r is NonNullable<typeof r> => !!r)
+      }
+
+      const conn = RemoteWS.connect({
+        url,
+        getToken: kilocodeToken,
+        withContext: (fn) => Instance.provide({ directory, fn }),
+        getSessions,
+        log,
+        onMessage: (msg) => {
+          // Must run inside Instance.provide so Bus.subscribeAll can access
+          // the instance-scoped subscription map via Instance.state().
+          void Instance.provide({ directory, fn: () => sender.handle(msg) })
+        },
+      })
+
+      const sender = RemoteSender.create({
+        conn,
+        directory: Instance.directory,
+        log,
+      })
+
+      const heartbeat = async () => {
+        conn.send({ type: "heartbeat", sessions: await getSessions() })
+      }
+
+      if (seq !== remoteSeq) {
+        sender.dispose()
+        conn.close()
+        return
+      }
+
+      remote = { conn, sender, heartbeat }
+      log.info("remote connection enabled")
+    })().finally(() => {
+      enabling = undefined
+    })
+
+    return enabling
+  }
+
+  export function disableRemote() {
+    remoteSeq += 1
+    enabling = undefined
+    if (!remote) return
+    remote.sender.dispose()
+    remote.conn.close()
+    remote = undefined
+    log.info("remote connection disabled")
+  }
+
+  export function remoteStatus() {
+    return {
+      enabled: !!remote,
+      connected: remote?.conn.connected ?? false,
+    }
+  }
+  export function setViewedSession(sessionID: string | undefined) {
+    viewedSessionId = sessionID
+    if (remote) void remote.heartbeat().catch((err) => log.warn("heartbeat failed", { error: String(err) }))
   }
 
   export async function create(sessionId: string) {

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -268,6 +268,7 @@ export namespace KiloSessions {
           // the instance-scoped subscription map via Instance.state().
           void Instance.provide({ directory, fn: () => sender.handle(msg) })
         },
+        onClose: () => disableRemote(),
       })
 
       const sender = RemoteSender.create({
@@ -289,7 +290,7 @@ export namespace KiloSessions {
       remote = { conn, sender, heartbeat }
       log.info("remote connection enabled")
     })().finally(() => {
-      enabling = undefined
+      if (remoteSeq === seq) enabling = undefined
     })
 
     return enabling

--- a/packages/opencode/src/kilo-sessions/remote-protocol.ts
+++ b/packages/opencode/src/kilo-sessions/remote-protocol.ts
@@ -1,0 +1,78 @@
+import z from "zod"
+
+export namespace RemoteProtocol {
+  // --- Shared ---
+
+  export const SessionInfo = z.object({
+    id: z.string(),
+    status: z.string(),
+    title: z.string(),
+    gitUrl: z.string().optional(),
+    gitBranch: z.string().optional(),
+  })
+  export type SessionInfo = z.infer<typeof SessionInfo>
+
+  // --- CLI → DO (Outbound) ---
+
+  export const Heartbeat = z.object({
+    type: z.literal("heartbeat"),
+    sessions: z.array(SessionInfo),
+  })
+  export type Heartbeat = z.infer<typeof Heartbeat>
+
+  export const Event = z.object({
+    type: z.literal("event"),
+    sessionId: z.string(),
+    parentSessionId: z.string().optional(),
+    event: z.string(),
+    data: z.unknown(),
+  })
+  export type Event = z.infer<typeof Event>
+
+  export const Response = z.object({
+    type: z.literal("response"),
+    id: z.string(),
+    result: z.unknown().optional(),
+    error: z.unknown().optional(),
+  })
+  export type Response = z.infer<typeof Response>
+
+  export const Outbound = z.discriminatedUnion("type", [Heartbeat, Event, Response])
+  export type Outbound = z.infer<typeof Outbound>
+
+  // --- DO → CLI (Inbound) ---
+
+  export const Subscribe = z.object({
+    type: z.literal("subscribe"),
+    sessionId: z.string(),
+  })
+  export type Subscribe = z.infer<typeof Subscribe>
+
+  export const Unsubscribe = z.object({
+    type: z.literal("unsubscribe"),
+    sessionId: z.string(),
+  })
+  export type Unsubscribe = z.infer<typeof Unsubscribe>
+
+  export const Command = z.object({
+    type: z.literal("command"),
+    id: z.string(),
+    command: z.string(),
+    sessionId: z.string().optional(),
+    data: z.unknown(),
+  })
+  export type Command = z.infer<typeof Command>
+
+  export const System = z.object({
+    type: z.literal("system"),
+    event: z.string(),
+    data: z.unknown(),
+  })
+  export type System = z.infer<typeof System>
+
+  export const Inbound = z.discriminatedUnion("type", [Subscribe, Unsubscribe, Command, System])
+  export type Inbound = z.infer<typeof Inbound>
+
+  /** Lightweight schema for diagnostic logging before full parse. */
+  export const Preview = z.object({ type: z.string(), id: z.string().optional() })
+}

--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -1,0 +1,321 @@
+import { RemoteProtocol } from "@/kilo-sessions/remote-protocol"
+import type { RemoteWS } from "@/kilo-sessions/remote-ws"
+import { Bus } from "@/bus"
+import { Instance } from "@/project/instance"
+import { Session } from "@/session"
+import { SessionPrompt } from "@/session/prompt"
+import { Question } from "@/question"
+import { PermissionNext } from "@/permission/next"
+import { Log } from "@/util/log"
+import z from "zod"
+
+const QuestionData = z.object({
+  requestID: z.string(),
+  answers: z.array(z.array(z.string())),
+})
+
+const PermissionData = z.object({
+  requestID: z.string(),
+  reply: z.enum(["once", "always", "reject"]),
+  message: z.string().optional(),
+})
+
+const RemotePromptInput = SessionPrompt.PromptInput.extend({
+  model: z.string().optional(),
+})
+
+function normalizeModel(model: z.infer<typeof RemotePromptInput.shape.model>) {
+  if (!model) return undefined
+  return {
+    providerID: "kilo",
+    modelID: model.startsWith("kilocode/") ? model.slice("kilocode/".length) : model,
+  }
+}
+
+function normalizePrompt(input: z.infer<typeof RemotePromptInput>): SessionPrompt.PromptInput {
+  return {
+    ...input,
+    model: normalizeModel(input.model),
+  }
+}
+
+export namespace RemoteSender {
+  export type Options = {
+    conn: RemoteWS.Connection
+    directory: string
+    log: {
+      info: (...args: any[]) => void
+      error: (...args: any[]) => void
+      warn: (...args: any[]) => void
+    }
+    subscribe?: typeof Bus.subscribeAll
+    provide?: typeof Instance.provide
+  }
+
+  export type Sender = {
+    handle(msg: RemoteProtocol.Inbound): void
+    dispose(): void
+  }
+
+  export function create(options: Options): Sender {
+    const sessions = new Set<string>()
+    const children = new Map<string, string>() // childId → parentId
+    let unsub: (() => void) | undefined
+
+    const sub = options.subscribe ?? Bus.subscribeAll
+
+    function subscribed(sid: string) {
+      if (sessions.has(sid)) return true
+      const root = rootOf(sid)
+      return root ? sessions.has(root) : false
+    }
+
+    function rootOf(sid: string): string | undefined {
+      const parent = children.get(sid)
+      if (!parent) return undefined
+      return rootOf(parent) ?? parent
+    }
+
+    async function backfillChildren(parentId: string) {
+      const provide = options.provide ?? Instance.provide
+      try {
+        await provide({
+          directory: options.directory,
+          fn: async () => {
+            await discoverChildren(parentId)
+          },
+        })
+      } catch (e) {
+        options.log.error("backfill children failed", { parentId, error: String(e) })
+      }
+    }
+
+    // Replay pending questions/permissions so a newly-subscribed web client
+    // sees state that was asked before it connected — analogous to the Cloud
+    // Agent's `connected` event carrying pending question/permission fields.
+    async function backfillPendingState(sessionId: string) {
+      const provide = options.provide ?? Instance.provide
+      try {
+        await provide({
+          directory: options.directory,
+          fn: async () => {
+            const [questions, permissions] = await Promise.all([Question.list(), PermissionNext.list()])
+            for (const q of questions) {
+              if (q.sessionID !== sessionId) continue
+              options.conn.send({
+                type: "event",
+                sessionId,
+                event: "question.asked",
+                data: q,
+              })
+            }
+            for (const p of permissions) {
+              if (p.sessionID !== sessionId) continue
+              options.conn.send({
+                type: "event",
+                sessionId,
+                event: "permission.asked",
+                data: p,
+              })
+            }
+          },
+        })
+      } catch (e) {
+        options.log.error("backfill pending state failed", { sessionId, error: String(e) })
+      }
+    }
+
+    async function discoverChildren(parentId: string) {
+      const childSessions = await Session.children(parentId)
+      for (const child of childSessions) {
+        children.set(child.id, parentId)
+        const root = rootOf(child.id) ?? parentId
+        options.conn.send({
+          type: "event",
+          sessionId: child.id,
+          parentSessionId: root,
+          event: "session.created",
+          data: { info: child },
+        })
+        await discoverChildren(child.id)
+      }
+    }
+
+    // Extract session ID from the correct nested location depending on event type.
+    // Different events store the session ID in different places:
+    //   - Top-level: session.diff, session.turn.*, message.part.delta, session.status, session.idle
+    //   - info.sessionID: message.updated
+    //   - info.id: session.created, session.updated (the session's own ID)
+    //   - part.sessionID: message.part.updated, message.part.removed
+    function extractSessionId(props: any): string | undefined {
+      if (!props) return undefined
+      if (typeof props.sessionID === "string") return props.sessionID
+      if (typeof props.info?.sessionID === "string") return props.info.sessionID
+      if (typeof props.info?.id === "string") return props.info.id
+      if (typeof props.part?.sessionID === "string") return props.part.sessionID
+      return undefined
+    }
+
+    function forwarder(event: { type: string; properties?: any }) {
+      // Track child sessions as they're created
+      if (event.type === "session.created") {
+        const parent = event.properties?.info?.parentID
+        const child = event.properties?.info?.id
+        if (parent && child) children.set(child, parent)
+      }
+
+      const sid = extractSessionId(event.properties)
+      if (!sid || !subscribed(sid)) return
+      const root = rootOf(sid)
+      options.conn.send({
+        type: "event",
+        sessionId: sid,
+        ...(root ? { parentSessionId: root } : {}),
+        event: event.type,
+        data: event.properties,
+      })
+    }
+
+    function dispatchLongRunning(msg: RemoteProtocol.Command, work: () => Promise<void>) {
+      const provide = options.provide ?? Instance.provide
+      options.conn.send({ type: "response", id: msg.id, result: {} })
+      void (async () => {
+        try {
+          await provide({ directory: options.directory, fn: work })
+        } catch (e) {
+          options.log.error("long-running command failed after ACK", {
+            id: msg.id,
+            command: msg.command,
+            error: String(e),
+          })
+        }
+      })()
+    }
+
+    function dispatchQuick(msg: RemoteProtocol.Command, work: () => Promise<void>) {
+      const provide = options.provide ?? Instance.provide
+      void (async () => {
+        try {
+          await provide({ directory: options.directory, fn: work })
+          options.conn.send({ type: "response", id: msg.id, result: {} })
+        } catch (e) {
+          options.conn.send({ type: "response", id: msg.id, error: String(e) })
+        }
+      })()
+    }
+
+    function dispatch(msg: RemoteProtocol.Command) {
+      if (msg.command === "send_message") {
+        const parsed = RemotePromptInput.safeParse(msg.data)
+        if (!parsed.success) {
+          options.conn.send({
+            type: "response",
+            id: msg.id,
+            error: "invalid send_message data: " + parsed.error.message,
+          })
+          return
+        }
+        const input = SessionPrompt.PromptInput.safeParse(normalizePrompt(parsed.data))
+        if (!input.success) {
+          options.conn.send({
+            type: "response",
+            id: msg.id,
+            error: "invalid send_message data: " + input.error.message,
+          })
+          return
+        }
+        dispatchLongRunning(msg, async () => {
+          await SessionPrompt.prompt(input.data)
+        })
+        return
+      }
+      if (msg.command === "question_reply") {
+        const parsed = QuestionData.safeParse(msg.data)
+        if (!parsed.success) {
+          options.conn.send({
+            type: "response",
+            id: msg.id,
+            error: "invalid question_reply data: " + parsed.error.message,
+          })
+          return
+        }
+        dispatchQuick(msg, () => Question.reply(parsed.data))
+        return
+      }
+      if (msg.command === "question_reject") {
+        const parsed = z.object({ requestID: z.string() }).safeParse(msg.data)
+        if (!parsed.success) {
+          options.conn.send({
+            type: "response",
+            id: msg.id,
+            error: "invalid question_reject data: " + parsed.error.message,
+          })
+          return
+        }
+        dispatchQuick(msg, () => Question.reject(parsed.data.requestID))
+        return
+      }
+      if (msg.command === "permission_respond") {
+        const parsed = PermissionData.safeParse(msg.data)
+        if (!parsed.success) {
+          options.conn.send({
+            type: "response",
+            id: msg.id,
+            error: "invalid permission_respond data: " + parsed.error.message,
+          })
+          return
+        }
+        dispatchQuick(msg, () => PermissionNext.reply(parsed.data))
+        return
+      }
+      options.conn.send({
+        type: "response",
+        id: msg.id,
+        error: `unknown command: ${msg.command}`,
+      })
+      options.log.warn("unknown command", { command: msg.command })
+    }
+
+    function handle(msg: RemoteProtocol.Inbound) {
+      if (msg.type === "subscribe") {
+        if (sessions.has(msg.sessionId)) return
+        sessions.add(msg.sessionId)
+        void backfillChildren(msg.sessionId)
+        void backfillPendingState(msg.sessionId)
+        if (!unsub) unsub = sub(forwarder)
+        return
+      }
+      if (msg.type === "unsubscribe") {
+        sessions.delete(msg.sessionId)
+        for (const [child, parent] of children) {
+          if (parent === msg.sessionId) children.delete(child)
+        }
+        if (sessions.size === 0 && unsub) {
+          unsub()
+          unsub = undefined
+        }
+        return
+      }
+      if (msg.type === "command") {
+        options.log.info("received command", { id: msg.id, command: msg.command })
+        dispatch(msg)
+        return
+      }
+      if (msg.type === "system") {
+        options.log.info("system event", { event: msg.event })
+        return
+      }
+    }
+
+    function dispose() {
+      if (unsub) {
+        unsub()
+        unsub = undefined
+      }
+      sessions.clear()
+      children.clear()
+    }
+
+    return { handle, dispose }
+  }
+}

--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -93,32 +93,34 @@ export namespace RemoteSender {
     // Replay pending questions/permissions so a newly-subscribed web client
     // sees state that was asked before it connected — analogous to the Cloud
     // Agent's `connected` event carrying pending question/permission fields.
+    async function replay(sessionId: string) {
+      const [questions, permissions] = await Promise.all([Question.list(), PermissionNext.list()])
+      for (const q of questions) {
+        if (q.sessionID !== sessionId) continue
+        options.conn.send({
+          type: "event",
+          sessionId,
+          event: "question.asked",
+          data: q,
+        })
+      }
+      for (const p of permissions) {
+        if (p.sessionID !== sessionId) continue
+        options.conn.send({
+          type: "event",
+          sessionId,
+          event: "permission.asked",
+          data: p,
+        })
+      }
+    }
+
     async function backfillPendingState(sessionId: string) {
       const provide = options.provide ?? Instance.provide
       try {
         await provide({
           directory: options.directory,
-          fn: async () => {
-            const [questions, permissions] = await Promise.all([Question.list(), PermissionNext.list()])
-            for (const q of questions) {
-              if (q.sessionID !== sessionId) continue
-              options.conn.send({
-                type: "event",
-                sessionId,
-                event: "question.asked",
-                data: q,
-              })
-            }
-            for (const p of permissions) {
-              if (p.sessionID !== sessionId) continue
-              options.conn.send({
-                type: "event",
-                sessionId,
-                event: "permission.asked",
-                data: p,
-              })
-            }
-          },
+          fn: () => replay(sessionId),
         })
       } catch (e) {
         options.log.error("backfill pending state failed", { sessionId, error: String(e) })
@@ -137,6 +139,7 @@ export namespace RemoteSender {
           event: "session.created",
           data: { info: child },
         })
+        await replay(child.id)
         await discoverChildren(child.id)
       }
     }
@@ -287,8 +290,15 @@ export namespace RemoteSender {
       }
       if (msg.type === "unsubscribe") {
         sessions.delete(msg.sessionId)
-        for (const [child, parent] of children) {
-          if (parent === msg.sessionId) children.delete(child)
+        const queue = [msg.sessionId]
+        while (queue.length) {
+          const id = queue.pop()!
+          for (const [child, parent] of children) {
+            if (parent === id) {
+              children.delete(child)
+              queue.push(child)
+            }
+          }
         }
         if (sessions.size === 0 && unsub) {
           unsub()

--- a/packages/opencode/src/kilo-sessions/remote-ws.ts
+++ b/packages/opencode/src/kilo-sessions/remote-ws.ts
@@ -1,0 +1,149 @@
+import { RemoteProtocol } from "@/kilo-sessions/remote-protocol"
+
+export namespace RemoteWS {
+  export type SessionInfo = RemoteProtocol.SessionInfo
+
+  export type Options = {
+    url: string
+    getToken: () => Promise<string | undefined>
+    getSessions: () => SessionInfo[] | Promise<SessionInfo[]>
+    log: {
+      info: (...args: any[]) => void
+      error: (...args: any[]) => void
+      warn: (...args: any[]) => void
+    }
+    onMessage?: (msg: RemoteProtocol.Inbound) => void
+    heartbeat?: number
+    /** Wraps callbacks that need to run in a specific async context (e.g. Instance.provide) */
+    withContext?: <R>(fn: () => R) => Promise<R> | R
+  }
+
+  export type Connection = {
+    readonly connectionId: string
+    send(msg: RemoteProtocol.Outbound): void
+    close(): void
+    readonly connected: boolean
+  }
+
+  type Timer = ReturnType<typeof setTimeout>
+
+  export function connect(options: Options): Connection {
+    const interval = options.heartbeat ?? 10_000
+    const connectionId = crypto.randomUUID()
+    const withContext = options.withContext ?? ((fn) => fn())
+    let ws: WebSocket | undefined
+    let backoff = 1000
+    let timer: Timer | undefined
+    let beat: Timer | undefined
+    let closed = false
+    const buffer: string[] = []
+
+    function startHeartbeat() {
+      stopHeartbeat()
+      beat = setInterval(() => {
+        void withContext(async () => {
+          send({ type: "heartbeat", sessions: await options.getSessions() })
+        }).catch((err) => {
+          options.log.error("remote-ws heartbeat failed", { error: String(err) })
+        })
+      }, interval)
+    }
+
+    function stopHeartbeat() {
+      if (beat) clearInterval(beat)
+      beat = undefined
+    }
+
+    async function open() {
+      if (closed) return
+      const token = await options.getToken()
+      if (!token) {
+        options.log.warn("remote-ws no token, will retry")
+        schedule()
+        return
+      }
+      const endpoint = `${options.url}/api/user/cli?token=${encodeURIComponent(token)}&connectionId=${connectionId}`
+      options.log.info("remote-ws connecting", { connectionId, endpoint: endpoint.replace(/token=[^&]+/, "token=***") })
+      ws = new WebSocket(endpoint)
+
+      ws.onopen = () => {
+        options.log.info("remote-ws connected", { buffered: buffer.length })
+        backoff = 1000
+        for (const msg of buffer) ws!.send(msg)
+        buffer.length = 0
+        startHeartbeat()
+      }
+
+      ws.onmessage = (event) => {
+        const raw = String(event.data)
+        let json: unknown
+        try {
+          json = JSON.parse(raw)
+        } catch {
+          options.log.warn("remote-ws invalid JSON", { bytes: raw.length })
+          return
+        }
+        const preview = RemoteProtocol.Preview.safeParse(json)
+        options.log.info("remote-ws received", { bytes: raw.length, ...preview.data })
+        const parsed = RemoteProtocol.Inbound.safeParse(json)
+        if (!parsed.success) {
+          options.log.warn("remote-ws message parse failed", { error: parsed.error })
+          return
+        }
+        options.onMessage?.(parsed.data)
+      }
+
+      ws.onclose = (event) => {
+        options.log.info("remote-ws closed", { code: event.code, reason: event.reason })
+        ws = undefined
+        stopHeartbeat()
+        if (event.code === 4401 || event.code === 4403 || event.code === 4409) {
+          options.log.warn("remote-ws closed permanently", {
+            code: event.code,
+            reason: event.reason,
+          })
+          return
+        }
+        schedule()
+      }
+
+      ws.onerror = (event) => {
+        options.log.error("remote-ws error", { error: event })
+      }
+    }
+
+    function schedule() {
+      if (closed) return
+      timer = setTimeout(() => open(), backoff)
+      backoff = Math.min(backoff * 2, 60000)
+    }
+
+    function send(msg: RemoteProtocol.Outbound) {
+      const raw = JSON.stringify(msg)
+      if (ws?.readyState === WebSocket.OPEN) {
+        ws.send(raw)
+        return
+      }
+      buffer.push(raw)
+      if (buffer.length > 200) buffer.shift()
+    }
+
+    function close() {
+      closed = true
+      stopHeartbeat()
+      if (timer) clearTimeout(timer)
+      if (ws) ws.close()
+    }
+
+    open()
+
+    return {
+      connectionId,
+      send,
+      close,
+      get connected() {
+        return ws?.readyState === WebSocket.OPEN
+      },
+    }
+  }
+}

--- a/packages/opencode/src/kilo-sessions/remote-ws.ts
+++ b/packages/opencode/src/kilo-sessions/remote-ws.ts
@@ -16,6 +16,8 @@ export namespace RemoteWS {
     heartbeat?: number
     /** Wraps callbacks that need to run in a specific async context (e.g. Instance.provide) */
     withContext?: <R>(fn: () => R) => Promise<R> | R
+    /** Called when the server permanently closes the connection (e.g. auth failure, conflict) */
+    onClose?: (code: number, reason: string) => void
   }
 
   export type Connection = {
@@ -102,6 +104,7 @@ export namespace RemoteWS {
             code: event.code,
             reason: event.reason,
           })
+          options.onClose?.(event.code, event.reason)
           return
         }
         schedule()

--- a/packages/opencode/src/kilocode/kilo-commands.tsx
+++ b/packages/opencode/src/kilocode/kilo-commands.tsx
@@ -37,6 +37,45 @@ export function registerKiloCommands(useSDK: () => UseSDK) {
   })
 
   command.register(() => [
+    // /remote command
+    {
+      value: "remote.toggle",
+      title: "Toggle remote",
+      description: "Enable or disable remote session relay",
+      category: "Kilo",
+      slash: { name: "remote" },
+      enabled: isKiloConnected(),
+      hidden: !isKiloConnected(),
+      onSelect: async () => {
+        try {
+          const current = await sdk.client.remote.status()
+
+          if (current.error || !current.data) {
+            dialog.replace(() => <DialogAlert title="Error" message="Failed to fetch remote status." />)
+            return
+          }
+
+          if (current.data.enabled) {
+            await sdk.client.remote.disable()
+            toast.show({ message: "Remote disabled", variant: "success" })
+          } else {
+            const result = await sdk.client.remote.enable()
+            if (result.error) {
+              dialog.replace(() => (
+                <DialogAlert title="Not authorized" message="Run `kilo auth login` to enable remote." />
+              ))
+              return
+            }
+            toast.show({ message: "Remote enabled", variant: "success" })
+          }
+
+          dialog.clear()
+        } catch (error) {
+          dialog.replace(() => <DialogAlert title="Error" message={`Failed to toggle remote: ${error}`} />)
+        }
+      },
+    },
+
     // /profile command
     {
       value: "kilo.profile",

--- a/packages/opencode/src/kilocode/kilo-commands.tsx
+++ b/packages/opencode/src/kilocode/kilo-commands.tsx
@@ -61,9 +61,9 @@ export function registerKiloCommands(useSDK: () => UseSDK) {
           } else {
             const result = await sdk.client.remote.enable()
             if (result.error) {
-              dialog.replace(() => (
-                <DialogAlert title="Not authorized" message="Run `kilo auth login` to enable remote." />
-              ))
+              const err = result.error as { error?: string }
+              const msg = err?.error ?? "Failed to enable remote."
+              dialog.replace(() => <DialogAlert title="Error" message={msg} />)
               return
             }
             toast.show({ message: "Remote enabled", variant: "success" })

--- a/packages/opencode/src/kilocode/remote-tui.tsx
+++ b/packages/opencode/src/kilocode/remote-tui.tsx
@@ -1,0 +1,36 @@
+/**
+ * Remote Session Relay TUI indicator
+ *
+ * RemoteIndicator component for the footer status bar.
+ */
+
+import { createSignal, onMount, onCleanup, Show } from "solid-js"
+
+/**
+ * Footer indicator showing remote connection status.
+ * Polls every 5 seconds. Only renders when kilo gateway is connected and remote is enabled.
+ */
+export function RemoteIndicator(props: { sdk: any; theme: any; kilo: boolean }) {
+  const [status, setStatus] = createSignal<{
+    enabled: boolean
+    connected: boolean
+  } | null>(null)
+
+  onMount(() => {
+    const poll = async () => {
+      const res = await props.sdk.client.remote.status().catch(() => null)
+      if (res?.data) setStatus(res.data)
+    }
+    poll()
+    const timer = setInterval(poll, 5000)
+    onCleanup(() => clearInterval(timer))
+  })
+
+  return (
+    <Show when={props.kilo && status()?.enabled}>
+      <text fg={status()?.connected ? props.theme.success : props.theme.warning}>
+        ◆ Remote{status()?.connected ? "" : " …"}
+      </text>
+    </Show>
+  )
+}

--- a/packages/opencode/src/server/routes/remote.ts
+++ b/packages/opencode/src/server/routes/remote.ts
@@ -1,0 +1,84 @@
+// kilocode_change - new file
+import { Hono } from "hono"
+import { describeRoute, resolver } from "hono-openapi"
+import z from "zod"
+import { KiloSessions } from "@/kilo-sessions/kilo-sessions"
+import { lazy } from "../../util/lazy"
+
+const Status = z.object({
+  enabled: z.boolean(),
+  connected: z.boolean(),
+})
+
+export const RemoteRoutes = lazy(() =>
+  new Hono()
+    .post(
+      "/enable",
+      describeRoute({
+        summary: "Enable remote connection",
+        description: "Enable WebSocket connection to UserConnectionDO for real-time session relay and commands.",
+        operationId: "remote.enable",
+        responses: {
+          200: {
+            description: "Remote connection enabled",
+            content: {
+              "application/json": {
+                schema: resolver(Status),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        try {
+          await KiloSessions.enableRemote()
+        } catch (err) {
+          return c.json({ error: err instanceof Error ? err.message : String(err) }, 401)
+        }
+        return c.json(KiloSessions.remoteStatus())
+      },
+    )
+    .post(
+      "/disable",
+      describeRoute({
+        summary: "Disable remote connection",
+        description: "Close the remote WebSocket connection to UserConnectionDO.",
+        operationId: "remote.disable",
+        responses: {
+          200: {
+            description: "Remote connection disabled",
+            content: {
+              "application/json": {
+                schema: resolver(Status),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        KiloSessions.disableRemote()
+        return c.json(KiloSessions.remoteStatus())
+      },
+    )
+    .get(
+      "/status",
+      describeRoute({
+        summary: "Get remote connection status",
+        description: "Get the current state of the remote WebSocket connection.",
+        operationId: "remote.status",
+        responses: {
+          200: {
+            description: "Remote connection status",
+            content: {
+              "application/json": {
+                schema: resolver(Status),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        return c.json(KiloSessions.remoteStatus())
+      },
+    ),
+)

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -968,5 +968,25 @@ export const SessionRoutes = lazy(() =>
         })
         return c.json(true)
       },
+    )
+    .post(
+      "/viewed",
+      describeRoute({
+        summary: "Set viewed session",
+        description: "Notify the server which session the user is currently viewing, or clear it.",
+        operationId: "session.viewed",
+        responses: {
+          200: {
+            description: "Viewed session updated",
+            content: { "application/json": { schema: resolver(z.boolean()) } },
+          },
+        },
+      }),
+      validator("json", z.object({ sessionID: z.string().optional() })),
+      async (c) => {
+        const { KiloSessions } = await import("../../kilo-sessions/kilo-sessions")
+        await KiloSessions.setViewedSession(c.req.valid("json").sessionID)
+        return c.json(true)
+      },
     ),
 )

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -51,6 +51,7 @@ import { KilocodeRoutes } from "./routes/kilocode" // kilocode_change
 import { Filesystem } from "@/util/filesystem"
 import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
+import { RemoteRoutes } from "./routes/remote" // kilocode_change
 import { GlobalRoutes } from "./routes/global"
 import { MDNS } from "./mdns"
 
@@ -270,6 +271,7 @@ export namespace Server {
         .route("/question", QuestionRoutes())
         .route("/provider", ProviderRoutes())
         .route("/telemetry", TelemetryRoutes()) // kilocode_change
+        .route("/remote", RemoteRoutes()) // kilocode_change
         .route("/commit-message", CommitMessageRoutes()) // kilocode_change
         .route("/enhance-prompt", EnhancePromptRoutes()) // kilocode_change
         .route("/kilocode", KilocodeRoutes()) // kilocode_change

--- a/packages/opencode/test/kilo-sessions/kilo-sessions-enable-remote.test.ts
+++ b/packages/opencode/test/kilo-sessions/kilo-sessions-enable-remote.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+
+const state = {
+  connects: 0,
+  closes: 0,
+  disposes: 0,
+  userStatus: 200,
+  gate: Promise.resolve(),
+  userError: false,
+}
+
+mock.module("../../src/auth", () => ({
+  OAUTH_DUMMY_KEY: "opencode-oauth-dummy-key",
+  Auth: {
+    get: async () => ({ type: "api", key: "tok" }),
+  },
+}))
+
+mock.module("../../src/project/vcs", () => ({
+  Vcs: {
+    branch: async () => "main",
+  },
+}))
+
+mock.module("simple-git", () => ({
+  default: () => ({
+    remote: async () => "origin\thttps://example.com/repo.git (fetch)",
+  }),
+}))
+
+mock.module("../../src/kilo-sessions/remote-sender", () => ({
+  RemoteSender: {
+    create: () => ({
+      handle() {},
+      dispose() {
+        state.disposes += 1
+      },
+    }),
+  },
+}))
+
+mock.module("../../src/kilo-sessions/remote-ws", () => ({
+  RemoteWS: {
+    connect: () => {
+      state.connects += 1
+      return {
+        connectionId: `conn-${state.connects}`,
+        send() {},
+        close() {
+          state.closes += 1
+        },
+        get connected() {
+          return true
+        },
+      }
+    },
+  },
+}))
+
+describe("KiloSessions.enableRemote", () => {
+  beforeEach(() => {
+    state.connects = 0
+    state.closes = 0
+    state.disposes = 0
+    state.userStatus = 200
+    state.gate = Promise.resolve()
+    state.userError = false
+    process.env["KILO_DISABLE_SESSION_INGEST"] = "0"
+    delete process.env["KILO_SESSION_INGEST_URL"]
+    globalThis.fetch = mock(async (input) => {
+      await state.gate
+      if (String(input).endsWith("/api/user")) {
+        if (state.userError) throw new Error("network down")
+        return new Response(null, { status: state.userStatus })
+      }
+      return new Response(null, { status: 200 })
+    }) as unknown as typeof fetch
+  })
+
+  afterEach(async () => {
+    const { KiloSessions } = await import("../../src/kilo-sessions/kilo-sessions")
+    KiloSessions.disableRemote()
+  })
+
+  test("concurrent enableRemote shares one connection", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const { Instance } = await import("../../src/project/instance")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { KiloSessions } = await import("../../src/kilo-sessions/kilo-sessions")
+        await Promise.all([KiloSessions.enableRemote(), KiloSessions.enableRemote(), KiloSessions.enableRemote()])
+        expect(state.connects).toBe(1)
+        expect(KiloSessions.remoteStatus()).toEqual({ enabled: true, connected: true })
+      },
+    })
+  })
+
+  test("enableRemote fails when token is invalid", async () => {
+    state.userStatus = 401
+    await using tmp = await tmpdir({ git: true })
+    const { Instance } = await import("../../src/project/instance")
+    const { KiloSessions } = await import("../../src/kilo-sessions/kilo-sessions")
+    const key = "kilo-sessions:token-valid:tok"
+    const { clearInFlightCache } = await import("../../src/kilo-sessions/inflight-cache")
+
+    KiloSessions.disableRemote()
+    clearInFlightCache(key)
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await expect(KiloSessions.enableRemote()).rejects.toThrow(
+          "Unable to enable remote: invalid or expired Kilo credentials. Run `kilo auth login`.",
+        )
+        expect(state.connects).toBe(0)
+        expect(KiloSessions.remoteStatus()).toEqual({ enabled: false, connected: false })
+      },
+    })
+  })
+
+  test("disableRemote cancels in-flight enableRemote", async () => {
+    let release = () => {}
+    state.gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    await using tmp = await tmpdir({ git: true })
+    const { Instance } = await import("../../src/project/instance")
+    const { clearInFlightCache } = await import("../../src/kilo-sessions/inflight-cache")
+
+    clearInFlightCache("kilo-sessions:token-valid:tok")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { KiloSessions } = await import("../../src/kilo-sessions/kilo-sessions")
+        const pending = KiloSessions.enableRemote()
+        KiloSessions.disableRemote()
+        release()
+        await pending
+        expect(state.connects).toBe(1)
+        expect(state.disposes).toBe(1)
+        expect(state.closes).toBe(1)
+        expect(KiloSessions.remoteStatus()).toEqual({ enabled: false, connected: false })
+      },
+    })
+  })
+
+  test("transient auth check failure is retryable and does not connect", async () => {
+    state.userError = true
+    await using tmp = await tmpdir({ git: true })
+    const { Instance } = await import("../../src/project/instance")
+    const { KiloSessions } = await import("../../src/kilo-sessions/kilo-sessions")
+    const { clearInFlightCache } = await import("../../src/kilo-sessions/inflight-cache")
+
+    KiloSessions.disableRemote()
+    clearInFlightCache("kilo-sessions:token-valid:tok")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await expect(KiloSessions.enableRemote()).rejects.toThrow(
+          "Unable to enable remote: failed to verify Kilo credentials.",
+        )
+        expect(state.connects).toBe(0)
+        expect(KiloSessions.remoteStatus()).toEqual({ enabled: false, connected: false })
+      },
+    })
+  })
+
+  test("disable then re-enable replaces stale pending connection", async () => {
+    let release = () => {}
+    state.gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    await using tmp = await tmpdir({ git: true })
+    const { Instance } = await import("../../src/project/instance")
+    const { clearInFlightCache } = await import("../../src/kilo-sessions/inflight-cache")
+
+    clearInFlightCache("kilo-sessions:token-valid:tok")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { KiloSessions } = await import("../../src/kilo-sessions/kilo-sessions")
+        const first = KiloSessions.enableRemote()
+        KiloSessions.disableRemote()
+        const second = KiloSessions.enableRemote()
+        release()
+        await Promise.all([first, second])
+        expect(state.connects).toBe(2)
+        expect(state.disposes).toBe(1)
+        expect(state.closes).toBe(1)
+        expect(KiloSessions.remoteStatus()).toEqual({ enabled: true, connected: true })
+      },
+    })
+  })
+})

--- a/packages/opencode/test/kilo-sessions/remote-protocol.test.ts
+++ b/packages/opencode/test/kilo-sessions/remote-protocol.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "bun:test"
+import { RemoteProtocol } from "../../src/kilo-sessions/remote-protocol"
+
+describe("RemoteProtocol", () => {
+  // --- Outbound (CLI → DO) ---
+
+  test("valid heartbeat parses", () => {
+    const msg = {
+      type: "heartbeat",
+      sessions: [{ id: "ses_1", status: "busy", title: "Fix auth" }],
+    }
+    const result = RemoteProtocol.Heartbeat.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sessions).toHaveLength(1)
+      expect(result.data.sessions[0].id).toBe("ses_1")
+    }
+  })
+
+  test("valid event parses", () => {
+    const msg = {
+      type: "event",
+      sessionId: "ses_1",
+      event: "message.updated",
+      data: { text: "hello" },
+    }
+    const result = RemoteProtocol.Event.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sessionId).toBe("ses_1")
+      expect(result.data.event).toBe("message.updated")
+    }
+  })
+
+  test("valid response parses", () => {
+    const msg = { type: "response", id: "req_1", result: { ok: true } }
+    const result = RemoteProtocol.Response.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.id).toBe("req_1")
+      expect(result.data.result).toEqual({ ok: true })
+      expect(result.data.error).toBeUndefined()
+    }
+  })
+
+  test("response with error parses", () => {
+    const msg = { type: "response", id: "req_2", error: "not found" }
+    const result = RemoteProtocol.Response.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.error).toBe("not found")
+      expect(result.data.result).toBeUndefined()
+    }
+  })
+
+  // --- Inbound (DO → CLI) ---
+
+  test("valid subscribe parses", () => {
+    const msg = { type: "subscribe", sessionId: "ses_1" }
+    const result = RemoteProtocol.Subscribe.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sessionId).toBe("ses_1")
+    }
+  })
+
+  test("valid unsubscribe parses", () => {
+    const msg = { type: "unsubscribe", sessionId: "ses_1" }
+    const result = RemoteProtocol.Unsubscribe.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sessionId).toBe("ses_1")
+    }
+  })
+
+  test("valid command parses", () => {
+    const msg = {
+      type: "command",
+      id: "cmd_1",
+      command: "send_message",
+      sessionId: "ses_1",
+      data: { text: "hi" },
+    }
+    const result = RemoteProtocol.Command.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.id).toBe("cmd_1")
+      expect(result.data.command).toBe("send_message")
+      expect(result.data.sessionId).toBe("ses_1")
+    }
+  })
+
+  test("command without sessionId parses", () => {
+    const msg = {
+      type: "command",
+      id: "cmd_2",
+      command: "list_sessions",
+      data: null,
+    }
+    const result = RemoteProtocol.Command.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sessionId).toBeUndefined()
+    }
+  })
+
+  test("valid system parses", () => {
+    const msg = {
+      type: "system",
+      event: "cli.connected",
+      data: { pid: 1234 },
+    }
+    const result = RemoteProtocol.System.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.event).toBe("cli.connected")
+    }
+  })
+
+  // --- Discriminated unions ---
+
+  test("outbound union picks heartbeat", () => {
+    const msg = { type: "heartbeat", sessions: [] }
+    const result = RemoteProtocol.Outbound.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.type).toBe("heartbeat")
+    }
+  })
+
+  test("outbound union picks event", () => {
+    const msg = {
+      type: "event",
+      sessionId: "ses_1",
+      event: "session.updated",
+      data: {},
+    }
+    const result = RemoteProtocol.Outbound.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.type).toBe("event")
+    }
+  })
+
+  test("outbound union picks response", () => {
+    const msg = { type: "response", id: "r1" }
+    const result = RemoteProtocol.Outbound.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.type).toBe("response")
+    }
+  })
+
+  test("inbound union picks subscribe", () => {
+    const msg = { type: "subscribe", sessionId: "ses_1" }
+    const result = RemoteProtocol.Inbound.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.type).toBe("subscribe")
+    }
+  })
+
+  test("inbound union picks command", () => {
+    const msg = {
+      type: "command",
+      id: "c1",
+      command: "ping",
+      data: null,
+    }
+    const result = RemoteProtocol.Inbound.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.type).toBe("command")
+    }
+  })
+
+  test("inbound union picks system", () => {
+    const msg = { type: "system", event: "shutdown", data: null }
+    const result = RemoteProtocol.Inbound.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.type).toBe("system")
+    }
+  })
+
+  // --- Rejection ---
+
+  test("outbound rejects unknown type", () => {
+    const msg = { type: "bogus", data: 1 }
+    const result = RemoteProtocol.Outbound.safeParse(msg)
+    expect(result.success).toBe(false)
+  })
+
+  test("inbound rejects unknown type", () => {
+    const msg = { type: "bogus", data: 1 }
+    const result = RemoteProtocol.Inbound.safeParse(msg)
+    expect(result.success).toBe(false)
+  })
+
+  test("heartbeat rejects missing sessions", () => {
+    const msg = { type: "heartbeat" }
+    const result = RemoteProtocol.Heartbeat.safeParse(msg)
+    expect(result.success).toBe(false)
+  })
+
+  test("event rejects missing sessionId", () => {
+    const msg = { type: "event", event: "x", data: null }
+    const result = RemoteProtocol.Event.safeParse(msg)
+    expect(result.success).toBe(false)
+  })
+
+  test("command rejects missing id", () => {
+    const msg = { type: "command", command: "ping", data: null }
+    const result = RemoteProtocol.Command.safeParse(msg)
+    expect(result.success).toBe(false)
+  })
+
+  test("subscribe rejects missing sessionId", () => {
+    const msg = { type: "subscribe" }
+    const result = RemoteProtocol.Subscribe.safeParse(msg)
+    expect(result.success).toBe(false)
+  })
+
+  test("session info rejects missing fields", () => {
+    const result = RemoteProtocol.SessionInfo.safeParse({ id: "x" })
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/opencode/test/kilo-sessions/remote-sender.test.ts
+++ b/packages/opencode/test/kilo-sessions/remote-sender.test.ts
@@ -1,0 +1,893 @@
+import { describe, expect, test } from "bun:test"
+// kilocode_change start
+import { afterEach, mock, spyOn } from "bun:test"
+// kilocode_change end
+import { RemoteSender } from "../../src/kilo-sessions/remote-sender"
+import type { RemoteWS } from "../../src/kilo-sessions/remote-ws"
+import type { RemoteProtocol } from "../../src/kilo-sessions/remote-protocol"
+// kilocode_change start
+import { SessionPrompt } from "../../src/session/prompt"
+import { Question } from "../../src/question"
+import { PermissionNext } from "../../src/permission/next"
+// kilocode_change end
+
+function fakeConn() {
+  const sent: any[] = []
+  return {
+    conn: {
+      send(msg: any) {
+        sent.push(msg)
+      },
+      close() {},
+      get connected() {
+        return true
+      },
+    } as RemoteWS.Connection,
+    sent,
+  }
+}
+
+function fakeBus() {
+  const handlers: ((event: any) => void)[] = []
+  const subscribe = (cb: (event: any) => void) => {
+    handlers.push(cb)
+    return () => {
+      const idx = handlers.indexOf(cb)
+      if (idx >= 0) handlers.splice(idx, 1)
+    }
+  }
+  return {
+    subscribe,
+    fire: (event: any) => handlers.forEach((h) => h(event)),
+    count: () => handlers.length,
+  }
+}
+
+const nolog = {
+  info: () => {},
+  error: () => {},
+  warn: () => {},
+}
+
+// kilocode_change start
+afterEach(() => {
+  mock.restore()
+})
+// kilocode_change end
+
+describe("RemoteSender", () => {
+  test("subscribe adds bus subscription, event forwarded", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_abc" })
+
+    bus.fire({
+      type: "message.updated",
+      properties: { sessionID: "ses_abc", text: "hello" },
+    })
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toEqual({
+      type: "event",
+      sessionId: "ses_abc",
+      event: "message.updated",
+      data: { sessionID: "ses_abc", text: "hello" },
+    })
+  })
+
+  test("unsubscribe removes subscription, events stop", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_abc" })
+    sender.handle({ type: "unsubscribe", sessionId: "ses_abc" })
+
+    bus.fire({
+      type: "message.updated",
+      properties: { sessionID: "ses_abc", text: "hello" },
+    })
+
+    expect(sent).toHaveLength(0)
+    expect(bus.count()).toBe(0)
+  })
+
+  test("only forwards for subscribed sessions", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_a" })
+
+    bus.fire({
+      type: "session.updated",
+      properties: { sessionID: "ses_b", title: "other" },
+    })
+
+    expect(sent).toHaveLength(0)
+  })
+
+  test("duplicate subscribe is idempotent", () => {
+    const { conn } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_a" })
+    sender.handle({ type: "subscribe", sessionId: "ses_a" })
+
+    expect(bus.count()).toBe(1)
+  })
+
+  test("single bus subscription for multiple sessions", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_a" })
+    sender.handle({ type: "subscribe", sessionId: "ses_b" })
+
+    expect(bus.count()).toBe(1)
+
+    bus.fire({
+      type: "message.updated",
+      properties: { sessionID: "ses_a", text: "a" },
+    })
+    bus.fire({
+      type: "message.updated",
+      properties: { sessionID: "ses_b", text: "b" },
+    })
+
+    expect(sent).toHaveLength(2)
+    expect(sent[0].sessionId).toBe("ses_a")
+    expect(sent[1].sessionId).toBe("ses_b")
+  })
+
+  test("unsubscribe one session keeps bus alive for others", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_a" })
+    sender.handle({ type: "subscribe", sessionId: "ses_b" })
+    sender.handle({ type: "unsubscribe", sessionId: "ses_a" })
+
+    expect(bus.count()).toBe(1)
+
+    bus.fire({
+      type: "session.updated",
+      properties: { sessionID: "ses_b", title: "still here" },
+    })
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].sessionId).toBe("ses_b")
+  })
+
+  test("send_message sends ACK immediately before provide resolves", async () => {
+    const { conn, sent } = fakeConn()
+    let resolveProvide: () => void
+    const provideStarted = new Promise<void>((r) => {
+      resolveProvide = r
+    })
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async (input: any) => {
+        resolveProvide!()
+        // Simulate long-running work — never resolves during this test
+        await new Promise(() => {})
+        return {} as any
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_1",
+      command: "send_message",
+      data: { sessionID: "ses_x", parts: [{ type: "text", text: "hi" }] },
+    })
+
+    // ACK is sent synchronously before provide even starts
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toEqual({ type: "response", id: "req_1", result: {} })
+
+    // provide was still called
+    await provideStarted
+  })
+
+  test("send_message with invalid data sends error response immediately", () => {
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async () => ({}) as any,
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_bad",
+      command: "send_message",
+      data: { invalid: true },
+    })
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].type).toBe("response")
+    expect(sent[0].id).toBe("req_bad")
+    expect(sent[0].error).toContain("invalid send_message data")
+  })
+
+  test("unknown command sends error response with matching id", () => {
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async () => ({}) as any,
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_unknown",
+      command: "unknown_command",
+      data: { foo: "bar" },
+    } as RemoteProtocol.Command)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toEqual({
+      type: "response",
+      id: "req_unknown",
+      error: "unknown command: unknown_command",
+    })
+  })
+
+  test("send_message with agent is accepted", async () => {
+    const { conn, sent } = fakeConn()
+    let resolveProvide: () => void
+    const provideStarted = new Promise<void>((r) => {
+      resolveProvide = r
+    })
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async (input: any) => {
+        resolveProvide!()
+        await new Promise(() => {})
+        return {} as any
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_model",
+      command: "send_message",
+      data: {
+        sessionID: "ses_x",
+        parts: [{ type: "text", text: "hello" }],
+        agent: "plan",
+      },
+    })
+
+    // ACK sent (not error) — model and agent were accepted by PromptInput validation
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toEqual({ type: "response", id: "req_model", result: {} })
+
+    await provideStarted
+  })
+
+  // kilocode_change start
+  test("send_message normalizes string model without prefix", async () => {
+    const { conn, sent } = fakeConn()
+    const prompt = spyOn(SessionPrompt, "prompt").mockResolvedValue({} as never)
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; init?: () => Promise<unknown>; fn: () => R }) => input.fn(),
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_model_string",
+      command: "send_message",
+      data: {
+        sessionID: "ses_x",
+        parts: [{ type: "text", text: "hello" }],
+        model: "anthropic/claude-sonnet-4-20250514",
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(sent[0]).toEqual({ type: "response", id: "req_model_string", result: {} })
+    expect(prompt).toHaveBeenCalledWith({
+      sessionID: "ses_x",
+      parts: [{ type: "text", text: "hello" }],
+      model: { providerID: "kilo", modelID: "anthropic/claude-sonnet-4-20250514" },
+    })
+  })
+
+  test("send_message keeps kilocode-prefixed model unchanged before internal conversion", async () => {
+    const { conn } = fakeConn()
+    const prompt = spyOn(SessionPrompt, "prompt").mockResolvedValue({} as never)
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; init?: () => Promise<unknown>; fn: () => R }) => input.fn(),
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_model_kilocode",
+      command: "send_message",
+      data: {
+        sessionID: "ses_x",
+        parts: [{ type: "text", text: "hello" }],
+        model: "kilocode/gpt-5-mini",
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(prompt).toHaveBeenCalledWith({
+      sessionID: "ses_x",
+      parts: [{ type: "text", text: "hello" }],
+      model: { providerID: "kilo", modelID: "gpt-5-mini" },
+    })
+  })
+
+  test("send_message rejects structured model on remote path", () => {
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; init?: () => Promise<unknown>; fn: () => R }) => input.fn(),
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_model_alias",
+      command: "send_message",
+      data: {
+        sessionID: "ses_x",
+        parts: [{ type: "text", text: "hello" }],
+        model: { providerID: "kilocode", modelID: "gpt-5-mini" },
+      },
+    })
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].type).toBe("response")
+    expect(sent[0].id).toBe("req_model_alias")
+    expect(sent[0].error).toContain("invalid send_message data")
+  })
+
+  test("send_message does not special-case kilo-prefixed model", async () => {
+    const { conn, sent } = fakeConn()
+    const prompt = spyOn(SessionPrompt, "prompt").mockResolvedValue({} as never)
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; init?: () => Promise<unknown>; fn: () => R }) => input.fn(),
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_model_kilo",
+      command: "send_message",
+      data: {
+        sessionID: "ses_x",
+        parts: [{ type: "text", text: "hello" }],
+        model: "kilo/gpt-5-mini",
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(sent[0]).toEqual({ type: "response", id: "req_model_kilo", result: {} })
+    expect(prompt).toHaveBeenCalledWith({
+      sessionID: "ses_x",
+      parts: [{ type: "text", text: "hello" }],
+      model: { providerID: "kilo", modelID: "kilo/gpt-5-mini" },
+    })
+  })
+  // kilocode_change end
+
+  test("question_reply sends response after work completes", async () => {
+    const { conn, sent } = fakeConn()
+    let provideCalled = false
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async () => {
+        provideCalled = true
+        return {} as any
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_q",
+      command: "question_reply",
+      data: { requestID: "r1", answers: [["yes"]] },
+    })
+
+    // Response not sent synchronously — waits for provide to finish
+    expect(sent).toHaveLength(0)
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(provideCalled).toBe(true)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toEqual({ type: "response", id: "req_q", result: {} })
+  })
+
+  test("question_reply error sends error response", async () => {
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async () => {
+        throw new Error("boom")
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_qe",
+      command: "question_reply",
+      data: { requestID: "r1", answers: [["yes"]] },
+    })
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].type).toBe("response")
+    expect(sent[0].id).toBe("req_qe")
+    expect(sent[0].error).toContain("boom")
+  })
+
+  test("question_reject sends response after work completes", async () => {
+    const { conn, sent } = fakeConn()
+    let provideCalled = false
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async () => {
+        provideCalled = true
+        return {} as any
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_qr",
+      command: "question_reject",
+      data: { requestID: "r1" },
+    })
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(provideCalled).toBe(true)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toEqual({ type: "response", id: "req_qr", result: {} })
+  })
+
+  test("question_reject with invalid data sends error response", () => {
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async () => ({}) as any,
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_qr_bad",
+      command: "question_reject",
+      data: { wrong: true },
+    } as any)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].type).toBe("response")
+    expect(sent[0].id).toBe("req_qr_bad")
+    expect(sent[0].error).toContain("invalid question_reject data")
+  })
+
+  test("events without sessionID are not forwarded", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_a" })
+
+    bus.fire({ type: "server.connected", properties: {} })
+    bus.fire({ type: "lsp.updated", properties: undefined })
+
+    expect(sent).toHaveLength(0)
+  })
+
+  test("dispose clears all subscriptions", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_a" })
+    sender.handle({ type: "subscribe", sessionId: "ses_b" })
+
+    sender.dispose()
+
+    bus.fire({
+      type: "message.updated",
+      properties: { sessionID: "ses_a", text: "hello" },
+    })
+
+    expect(sent).toHaveLength(0)
+    expect(bus.count()).toBe(0)
+  })
+
+  test("child session events forwarded when parent subscribed", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_parent" })
+
+    // Child session created with parentID
+    bus.fire({
+      type: "session.created",
+      properties: { info: { id: "ses_child", parentID: "ses_parent", title: "sub" }, sessionID: "ses_child" },
+    })
+
+    // Event on the child session should be forwarded
+    bus.fire({
+      type: "message.updated",
+      properties: { sessionID: "ses_child", text: "from child" },
+    })
+
+    // session.created + message.updated
+    expect(sent).toHaveLength(2)
+    expect(sent[0].sessionId).toBe("ses_child")
+    expect(sent[0].parentSessionId).toBe("ses_parent")
+    expect(sent[0].event).toBe("session.created")
+    expect(sent[1].sessionId).toBe("ses_child")
+    expect(sent[1].parentSessionId).toBe("ses_parent")
+    expect(sent[1].event).toBe("message.updated")
+  })
+
+  test("child session events not forwarded when parent not subscribed", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_other" })
+
+    bus.fire({
+      type: "session.created",
+      properties: { info: { id: "ses_child", parentID: "ses_unrelated", title: "sub" }, sessionID: "ses_child" },
+    })
+
+    bus.fire({
+      type: "message.updated",
+      properties: { sessionID: "ses_child", text: "from child" },
+    })
+
+    expect(sent).toHaveLength(0)
+  })
+
+  test("unsubscribe parent cleans up child tracking", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_parent" })
+
+    bus.fire({
+      type: "session.created",
+      properties: { info: { id: "ses_child", parentID: "ses_parent", title: "sub" }, sessionID: "ses_child" },
+    })
+
+    sender.handle({ type: "unsubscribe", sessionId: "ses_parent" })
+
+    // Keep another session alive so bus stays subscribed
+    sender.handle({ type: "subscribe", sessionId: "ses_keep" })
+
+    bus.fire({
+      type: "message.updated",
+      properties: { sessionID: "ses_child", text: "after unsub" },
+    })
+
+    expect(sent.filter((m: any) => m.event === "message.updated")).toHaveLength(0)
+  })
+
+  test("root session events do not include parentSessionId", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_root" })
+
+    bus.fire({
+      type: "message.updated",
+      properties: { sessionID: "ses_root", text: "hello" },
+    })
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].sessionId).toBe("ses_root")
+    expect(sent[0]).not.toHaveProperty("parentSessionId")
+  })
+
+  test("nested child events include root parentSessionId", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_root" })
+
+    // Root → child
+    bus.fire({
+      type: "session.created",
+      properties: { info: { id: "ses_child", parentID: "ses_root", title: "child" }, sessionID: "ses_child" },
+    })
+
+    // child → grandchild
+    bus.fire({
+      type: "session.created",
+      properties: {
+        info: { id: "ses_grandchild", parentID: "ses_child", title: "grandchild" },
+        sessionID: "ses_grandchild",
+      },
+    })
+
+    // Event on grandchild should have parentSessionId pointing to root
+    bus.fire({
+      type: "message.updated",
+      properties: { sessionID: "ses_grandchild", text: "from grandchild" },
+    })
+
+    // 3 events: session.created (child), session.created (grandchild), message.updated (grandchild)
+    expect(sent).toHaveLength(3)
+    expect(sent[0].parentSessionId).toBe("ses_root")
+    expect(sent[1].parentSessionId).toBe("ses_root")
+    expect(sent[2].parentSessionId).toBe("ses_root")
+    expect(sent[2].sessionId).toBe("ses_grandchild")
+  })
+
+  test("subscribe triggers backfill of existing children", async () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+      provide: async (input: any) => input.fn(),
+    })
+
+    // backfill calls Session.children which requires real DB context.
+    // Our provide mock just calls fn() directly, so Session.children will fail.
+    // The backfill logs the error silently and doesn't break normal operation.
+
+    sender.handle({ type: "subscribe", sessionId: "ses_parent" })
+
+    // Wait for async backfill to attempt (and fail silently in test context)
+    await new Promise((r) => setTimeout(r, 10))
+
+    // Normal event forwarding still works
+    bus.fire({
+      type: "session.created",
+      properties: { info: { id: "ses_new_child", parentID: "ses_parent", title: "new" }, sessionID: "ses_new_child" },
+    })
+
+    expect(sent.filter((m: any) => m.event === "session.created")).toHaveLength(1)
+    expect(sent[0].sessionId).toBe("ses_new_child")
+    expect(sent[0].parentSessionId).toBe("ses_parent")
+  })
+
+  test("subscribe replays pending question for the subscribed session", async () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+
+    spyOn(Question, "list").mockResolvedValue([
+      { id: "question_1", sessionID: "ses_target", questions: [{ type: "text", text: "Continue?" }] } as any,
+      { id: "question_2", sessionID: "ses_other", questions: [{ type: "text", text: "Unrelated?" }] } as any,
+    ])
+    spyOn(PermissionNext, "list").mockResolvedValue([])
+
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+      provide: async (input: any) => input.fn(),
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_target" })
+    await new Promise((r) => setTimeout(r, 10))
+
+    const questionEvents = sent.filter((m: any) => m.event === "question.asked")
+    expect(questionEvents).toHaveLength(1)
+    expect(questionEvents[0]).toEqual({
+      type: "event",
+      sessionId: "ses_target",
+      event: "question.asked",
+      data: { id: "question_1", sessionID: "ses_target", questions: [{ type: "text", text: "Continue?" }] },
+    })
+  })
+
+  test("subscribe replays pending permission for the subscribed session", async () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+
+    spyOn(Question, "list").mockResolvedValue([])
+    spyOn(PermissionNext, "list").mockResolvedValue([
+      {
+        id: "permission_1",
+        sessionID: "ses_target",
+        permission: "file.write",
+        patterns: ["src/**"],
+        metadata: {},
+        always: [],
+      } as any,
+      { id: "permission_2", sessionID: "ses_other", permission: "file.read", patterns: ["*"], metadata: {}, always: [] } as any,
+    ])
+
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+      provide: async (input: any) => input.fn(),
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_target" })
+    await new Promise((r) => setTimeout(r, 10))
+
+    const permEvents = sent.filter((m: any) => m.event === "permission.asked")
+    expect(permEvents).toHaveLength(1)
+    expect(permEvents[0]).toEqual({
+      type: "event",
+      sessionId: "ses_target",
+      event: "permission.asked",
+      data: {
+        id: "permission_1",
+        sessionID: "ses_target",
+        permission: "file.write",
+        patterns: ["src/**"],
+        metadata: {},
+        always: [],
+      },
+    })
+  })
+
+  test("subscribe does not replay state for sessions with no pending questions or permissions", async () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+
+    spyOn(Question, "list").mockResolvedValue([
+      { id: "question_1", sessionID: "ses_other", questions: [] } as any,
+    ])
+    spyOn(PermissionNext, "list").mockResolvedValue([
+      { id: "permission_1", sessionID: "ses_other", permission: "file.write", patterns: [], metadata: {}, always: [] } as any,
+    ])
+
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+      provide: async (input: any) => input.fn(),
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_target" })
+    await new Promise((r) => setTimeout(r, 10))
+
+    const events = sent.filter((m: any) => m.type === "event")
+    expect(events).toHaveLength(0)
+  })
+
+  test("system message is handled without error", () => {
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+    })
+
+    sender.handle({
+      type: "system",
+      event: "cli.connected",
+      data: { version: "1.0" },
+    })
+
+    expect(sent).toHaveLength(0)
+  })
+})

--- a/packages/opencode/test/kilo-sessions/remote-sender.test.ts
+++ b/packages/opencode/test/kilo-sessions/remote-sender.test.ts
@@ -676,6 +676,48 @@ describe("RemoteSender", () => {
     expect(sent.filter((m: any) => m.event === "message.updated")).toHaveLength(0)
   })
 
+  test("unsubscribe parent cleans up grandchild tracking", () => {
+    const { conn, sent } = fakeConn()
+    const bus = fakeBus()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: bus.subscribe,
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_root" })
+
+    bus.fire({
+      type: "session.created",
+      properties: { info: { id: "ses_child", parentID: "ses_root", title: "child" }, sessionID: "ses_child" },
+    })
+    bus.fire({
+      type: "session.created",
+      properties: {
+        info: { id: "ses_grandchild", parentID: "ses_child", title: "grandchild" },
+        sessionID: "ses_grandchild",
+      },
+    })
+
+    sender.handle({ type: "unsubscribe", sessionId: "ses_root" })
+    sender.handle({ type: "subscribe", sessionId: "ses_keep" })
+
+    // Clear events from subscribe/session.created
+    sent.length = 0
+
+    bus.fire({
+      type: "message.updated",
+      properties: { sessionID: "ses_child", text: "after unsub" },
+    })
+    bus.fire({
+      type: "message.updated",
+      properties: { sessionID: "ses_grandchild", text: "after unsub" },
+    })
+
+    expect(sent).toHaveLength(0)
+  })
+
   test("root session events do not include parentSessionId", () => {
     const { conn, sent } = fakeConn()
     const bus = fakeBus()
@@ -816,7 +858,14 @@ describe("RemoteSender", () => {
         metadata: {},
         always: [],
       } as any,
-      { id: "permission_2", sessionID: "ses_other", permission: "file.read", patterns: ["*"], metadata: {}, always: [] } as any,
+      {
+        id: "permission_2",
+        sessionID: "ses_other",
+        permission: "file.read",
+        patterns: ["*"],
+        metadata: {},
+        always: [],
+      } as any,
     ])
 
     const sender = RemoteSender.create({
@@ -851,11 +900,16 @@ describe("RemoteSender", () => {
     const { conn, sent } = fakeConn()
     const bus = fakeBus()
 
-    spyOn(Question, "list").mockResolvedValue([
-      { id: "question_1", sessionID: "ses_other", questions: [] } as any,
-    ])
+    spyOn(Question, "list").mockResolvedValue([{ id: "question_1", sessionID: "ses_other", questions: [] } as any])
     spyOn(PermissionNext, "list").mockResolvedValue([
-      { id: "permission_1", sessionID: "ses_other", permission: "file.write", patterns: [], metadata: {}, always: [] } as any,
+      {
+        id: "permission_1",
+        sessionID: "ses_other",
+        permission: "file.write",
+        patterns: [],
+        metadata: {},
+        always: [],
+      } as any,
     ])
 
     const sender = RemoteSender.create({

--- a/packages/opencode/test/kilo-sessions/remote-ws.test.ts
+++ b/packages/opencode/test/kilo-sessions/remote-ws.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { RemoteWS } from "../../src/kilo-sessions/remote-ws"
+import type { ServerWebSocket } from "bun"
+
+function nolog() {
+  return {
+    info: () => {},
+    error: () => {},
+    warn: () => {},
+  }
+}
+
+function capture() {
+  const calls: unknown[][] = []
+  return {
+    calls,
+    log: {
+      info: (...args: unknown[]) => calls.push(args),
+      error: (...args: unknown[]) => calls.push(args),
+      warn: (...args: unknown[]) => calls.push(args),
+    },
+  }
+}
+
+function createServer() {
+  const messages: string[] = []
+  const clients: ServerWebSocket<unknown>[] = []
+  const pending: {
+    connect: ((ws: ServerWebSocket<unknown>) => void)[]
+    message: ((msg: string) => void)[]
+  } = { connect: [], message: [] }
+
+  const server = Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      const upgraded = server.upgrade(req)
+      if (!upgraded) return new Response("Not found", { status: 404 })
+      return undefined
+    },
+    websocket: {
+      open(ws) {
+        clients.push(ws)
+        const cb = pending.connect.shift()
+        cb?.(ws)
+      },
+      message(_ws, msg) {
+        const str = String(msg)
+        messages.push(str)
+        const cb = pending.message.shift()
+        cb?.(str)
+      },
+      close(ws) {
+        const idx = clients.indexOf(ws)
+        if (idx >= 0) clients.splice(idx, 1)
+      },
+    },
+  })
+
+  return {
+    url: `ws://localhost:${server.port}`,
+    messages,
+    clients,
+    stop: () => server.stop(true),
+    waitForConnect: () =>
+      new Promise<ServerWebSocket<unknown>>((resolve) => {
+        pending.connect.push(resolve)
+      }),
+    waitForMessage: () =>
+      new Promise<string>((resolve) => {
+        pending.message.push(resolve)
+      }),
+  }
+}
+
+async function settled() {
+  await Bun.sleep(20)
+}
+
+describe("RemoteWS", () => {
+  let server: ReturnType<typeof createServer>
+  let conn: RemoteWS.Connection | undefined
+
+  afterEach(() => {
+    conn?.close()
+    conn = undefined
+    server?.stop()
+  })
+
+  test("connects and sends heartbeat", async () => {
+    server = createServer()
+    const connecting = server.waitForConnect()
+    const msg = server.waitForMessage()
+
+    conn = RemoteWS.connect({
+      url: server.url,
+      getToken: async () => "tok",
+      getSessions: () => [{ id: "s1", status: "active", title: "Test" }],
+      log: nolog(),
+      heartbeat: 100,
+    })
+
+    await connecting
+    await settled()
+    expect(conn.connected).toBe(true)
+
+    const raw = await msg
+    const parsed = JSON.parse(raw)
+    expect(parsed.type).toBe("heartbeat")
+    expect(parsed.sessions).toEqual([{ id: "s1", status: "active", title: "Test" }])
+  })
+
+  test("buffers when disconnected, flushes on reconnect", async () => {
+    server = createServer()
+    const connecting = server.waitForConnect()
+
+    conn = RemoteWS.connect({
+      url: server.url,
+      getToken: async () => "tok",
+      getSessions: () => [],
+      log: nolog(),
+      heartbeat: 60_000,
+    })
+
+    await connecting
+    await settled()
+
+    for (const ws of [...server.clients]) ws.close()
+    await Bun.sleep(50)
+
+    expect(conn.connected).toBe(false)
+
+    conn.send({ type: "event", sessionId: "s1", event: "test", data: { a: 1 } })
+    conn.send({ type: "event", sessionId: "s2", event: "test", data: { b: 2 } })
+
+    const msg1 = server.waitForMessage()
+    const msg2 = server.waitForMessage()
+    await server.waitForConnect()
+    await settled()
+
+    const r1 = JSON.parse(await msg1)
+    const r2 = JSON.parse(await msg2)
+    expect(r1.sessionId).toBe("s1")
+    expect(r2.sessionId).toBe("s2")
+  })
+
+  test("reconnects with backoff after server close", async () => {
+    server = createServer()
+
+    conn = RemoteWS.connect({
+      url: server.url,
+      getToken: async () => "tok",
+      getSessions: () => [],
+      log: nolog(),
+      heartbeat: 60_000,
+    })
+
+    const ws1 = await server.waitForConnect()
+    await settled()
+
+    const reconnecting = server.waitForConnect()
+    ws1.close()
+    await Bun.sleep(50)
+
+    expect(conn.connected).toBe(false)
+
+    const ws2 = await reconnecting
+    expect(ws2).toBeDefined()
+    await settled()
+    expect(conn.connected).toBe(true)
+  })
+
+  test("stops reconnecting on 4401", async () => {
+    server = createServer()
+
+    conn = RemoteWS.connect({
+      url: server.url,
+      getToken: async () => "tok",
+      getSessions: () => [],
+      log: nolog(),
+      heartbeat: 60_000,
+    })
+
+    const ws1 = await server.waitForConnect()
+    await settled()
+
+    ws1.close(4401, "unauthorized")
+
+    await Bun.sleep(2000)
+
+    expect(conn.connected).toBe(false)
+    expect(server.clients.length).toBe(0)
+  })
+
+  test("incoming message delivered to onMessage", async () => {
+    server = createServer()
+    const received: unknown[] = []
+    const cap = capture()
+    const secret = "user secret prompt"
+
+    conn = RemoteWS.connect({
+      url: server.url,
+      getToken: async () => "tok",
+      getSessions: () => [],
+      log: cap.log,
+      heartbeat: 60_000,
+      onMessage: (msg) => received.push(msg),
+    })
+
+    const ws = await server.waitForConnect()
+    await settled()
+
+    ws.send(
+      JSON.stringify({
+        type: "command",
+        id: "c1",
+        command: "send_message",
+        sessionId: "s1",
+        data: { text: secret },
+      }),
+    )
+
+    await Bun.sleep(50)
+    expect(received.length).toBe(1)
+    expect(received[0]).toEqual({
+      type: "command",
+      id: "c1",
+      command: "send_message",
+      sessionId: "s1",
+      data: { text: secret },
+    })
+
+    const seen = JSON.stringify(cap.calls)
+    expect(seen.includes(secret)).toBe(false)
+    expect(cap.calls).toContainEqual(["remote-ws received", { bytes: expect.any(Number), type: "command", id: "c1" }])
+  })
+
+  test("close() prevents further reconnection and stops heartbeat", async () => {
+    server = createServer()
+
+    conn = RemoteWS.connect({
+      url: server.url,
+      getToken: async () => "tok",
+      getSessions: () => [{ id: "s1", status: "active", title: "Test" }],
+      log: nolog(),
+      heartbeat: 100,
+    })
+
+    await server.waitForConnect()
+    await settled()
+
+    // Drain initial heartbeat message(s)
+    server.messages.length = 0
+
+    conn.close()
+    conn = undefined
+
+    // Wait long enough for heartbeat and reconnect if they were still running
+    await Bun.sleep(500)
+
+    // No new connections and no new heartbeat messages
+    expect(server.clients.length).toBe(0)
+    expect(server.messages.length).toBe(0)
+  })
+})

--- a/packages/opencode/test/kilo-sessions/remote-ws.test.ts
+++ b/packages/opencode/test/kilo-sessions/remote-ws.test.ts
@@ -191,6 +191,29 @@ describe("RemoteWS", () => {
     expect(server.clients.length).toBe(0)
   })
 
+  test("onClose callback fires on permanent close", async () => {
+    server = createServer()
+    const codes: number[] = []
+
+    conn = RemoteWS.connect({
+      url: server.url,
+      getToken: async () => "tok",
+      getSessions: () => [],
+      log: nolog(),
+      heartbeat: 60_000,
+      onClose: (code) => codes.push(code),
+    })
+
+    const ws1 = await server.waitForConnect()
+    await settled()
+
+    ws1.close(4401, "unauthorized")
+    await Bun.sleep(100)
+
+    expect(codes).toEqual([4401])
+    expect(conn.connected).toBe(false)
+  })
+
   test("incoming message delivered to onMessage", async () => {
     server = createServer()
     const received: unknown[] = []

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -128,6 +128,9 @@ import type {
   QuestionRejectResponses,
   QuestionReplyErrors,
   QuestionReplyResponses,
+  RemoteDisableResponses,
+  RemoteEnableResponses,
+  RemoteStatusResponses,
   SessionAbortErrors,
   SessionAbortResponses,
   SessionChildrenErrors,
@@ -173,6 +176,7 @@ import type {
   SessionUnshareResponses,
   SessionUpdateErrors,
   SessionUpdateResponses,
+  SessionViewedResponses,
   SubtaskPartInput,
   TelemetryCaptureErrors,
   TelemetryCaptureResponses,
@@ -2328,6 +2332,43 @@ export class Session2 extends HeyApiClient {
       ...params,
     })
   }
+
+  /**
+   * Set viewed session
+   *
+   * Notify the server which session the user is currently viewing, or clear it.
+   */
+  public viewed<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      sessionID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "sessionID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionViewedResponses, unknown, ThrowOnError>({
+      url: "/session/viewed",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
 }
 
 export class Part extends HeyApiClient {
@@ -2867,6 +2908,98 @@ export class Telemetry extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
+    })
+  }
+}
+
+export class Remote extends HeyApiClient {
+  /**
+   * Enable remote connection
+   *
+   * Enable WebSocket connection to UserConnectionDO for real-time session relay and commands.
+   */
+  public enable<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<RemoteEnableResponses, unknown, ThrowOnError>({
+      url: "/remote/enable",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Disable remote connection
+   *
+   * Close the remote WebSocket connection to UserConnectionDO.
+   */
+  public disable<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<RemoteDisableResponses, unknown, ThrowOnError>({
+      url: "/remote/disable",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get remote connection status
+   *
+   * Get the current state of the remote WebSocket connection.
+   */
+  public status<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<RemoteStatusResponses, unknown, ThrowOnError>({
+      url: "/remote/status",
+      ...options,
+      ...params,
     })
   }
 }
@@ -4646,6 +4779,11 @@ export class KiloClient extends HeyApiClient {
   private _telemetry?: Telemetry
   get telemetry(): Telemetry {
     return (this._telemetry ??= new Telemetry({ client: this.client }))
+  }
+
+  private _remote?: Remote
+  get remote(): Remote {
+    return (this._remote ??= new Remote({ client: this.client }))
   }
 
   private _commitMessage?: CommitMessage

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3940,6 +3940,27 @@ export type PermissionRespondResponses = {
 
 export type PermissionRespondResponse = PermissionRespondResponses[keyof PermissionRespondResponses]
 
+export type SessionViewedData = {
+  body?: {
+    sessionID?: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/viewed"
+}
+
+export type SessionViewedResponses = {
+  /**
+   * Viewed session updated
+   */
+  200: boolean
+}
+
+export type SessionViewedResponse = SessionViewedResponses[keyof SessionViewedResponses]
+
 export type PermissionReplyData = {
   body?: {
     reply: "once" | "always" | "reject"
@@ -4354,6 +4375,72 @@ export type TelemetryCaptureResponses = {
 }
 
 export type TelemetryCaptureResponse = TelemetryCaptureResponses[keyof TelemetryCaptureResponses]
+
+export type RemoteEnableData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/remote/enable"
+}
+
+export type RemoteEnableResponses = {
+  /**
+   * Remote connection enabled
+   */
+  200: {
+    enabled: boolean
+    connected: boolean
+  }
+}
+
+export type RemoteEnableResponse = RemoteEnableResponses[keyof RemoteEnableResponses]
+
+export type RemoteDisableData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/remote/disable"
+}
+
+export type RemoteDisableResponses = {
+  /**
+   * Remote connection disabled
+   */
+  200: {
+    enabled: boolean
+    connected: boolean
+  }
+}
+
+export type RemoteDisableResponse = RemoteDisableResponses[keyof RemoteDisableResponses]
+
+export type RemoteStatusData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/remote/status"
+}
+
+export type RemoteStatusResponses = {
+  /**
+   * Remote connection status
+   */
+  200: {
+    enabled: boolean
+    connected: boolean
+  }
+}
+
+export type RemoteStatusResponse = RemoteStatusResponses[keyof RemoteStatusResponses]
 
 export type CommitMessageGenerateData = {
   body?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -4267,6 +4267,61 @@
         ]
       }
     },
+    "/session/viewed": {
+      "post": {
+        "operationId": "session.viewed",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Set viewed session",
+        "description": "Notify the server which session the user is currently viewing, or clear it.",
+        "responses": {
+          "200": {
+            "description": "Viewed session updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionID": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.session.viewed({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/permission/{requestID}/reply": {
       "post": {
         "operationId": "permission.reply",
@@ -5248,6 +5303,156 @@
           {
             "lang": "js",
             "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.telemetry.capture({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/remote/enable": {
+      "post": {
+        "operationId": "remote.enable",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Enable remote connection",
+        "description": "Enable WebSocket connection to UserConnectionDO for real-time session relay and commands.",
+        "responses": {
+          "200": {
+            "description": "Remote connection enabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "connected": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["enabled", "connected"]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.remote.enable({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/remote/disable": {
+      "post": {
+        "operationId": "remote.disable",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Disable remote connection",
+        "description": "Close the remote WebSocket connection to UserConnectionDO.",
+        "responses": {
+          "200": {
+            "description": "Remote connection disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "connected": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["enabled", "connected"]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.remote.disable({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/remote/status": {
+      "get": {
+        "operationId": "remote.status",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get remote connection status",
+        "description": "Get the current state of the remote WebSocket connection.",
+        "responses": {
+          "200": {
+            "description": "Remote connection status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "connected": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["enabled", "connected"]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.remote.status({\n  ...\n})"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- add an opt-in remote WebSocket relay for Kilo sessions that can be controlled from the CLI, TUI, server API, or `KILO_REMOTE=1`
- relay live session events and remote commands over a single connection, including viewed-session updates and typed SDK support for clients
- harden the remote path by preventing duplicate `enableRemote()` setup, normalizing remote `send_message` models, and returning explicit errors for unsupported commands

## Testing
- bun test test/kilo-sessions/remote-sender.test.ts
- bun test test/kilo-sessions/kilo-sessions-enable-remote.test.ts
- bun turbo typecheck