### PR TITLE
fix(vscode): skip tool reveal animations on session switch to prevent flickering

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -58,6 +58,7 @@ function TodoToolCard(props: { part: ToolPart }) {
           output={state?.output}
           status={state?.status}
           defaultOpen
+          reveal={false}
         />
       )}
     </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -91,6 +91,11 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                       part={part}
                       message={props.message as SDKMessage}
                       showAssistantCopyPartID={props.showAssistantCopyPartID}
+                      animate={
+                        part.type === "tool" &&
+                        ((part as unknown as ToolPart).state?.status === "pending" ||
+                          (part as unknown as ToolPart).state?.status === "running")
+                      }
                     />
                   }
                 >


### PR DESCRIPTION
## Summary

- Fixes UI flickering when switching between worktrees/sessions in the Agent Manager caused by tool reveal animations replaying on every component remount

## Regression Origin

Upstream OpenCode's ["STUPID SEXY TIMELINE" PR](https://github.com/anomalyco/opencode/pull/16420) (`bbd0f3a2`) by Kit Langton added spring-driven reveal animations (wipe + blur + opacity fade) to all tool blocks in `packages/ui/`. This was actually reverted upstream in `565a7e50` but entered the Kilo codebase via `9ff04d93` ("fix(kilo-ui): Restore kilo-ui message-part fork dependencies removed by upstream v1.2.23") which copied these animation files into `packages/kilo-ui/`.

## What It Caused

Every tool block (bash, edit, glob, etc.) now animates on mount: `opacity: 0→1`, `blur: 3px→0px`, horizontal wipe mask — via `useToolFade` in `tool-utils.ts`. In the desktop/TUI context this looks fine because tools appear once during streaming. But in the VS Code Agent Manager, switching sessions causes SolidJS's `<For>` to unmount all old message parts and remount new ones, replaying every reveal animation from scratch. With dozens of tool blocks in a session, this creates visible flickering across the entire chat view.

## Fix

Pass `animate` to `<Part>` in `AssistantMessage` based on whether the tool is actively pending/running. Completed tools skip the reveal animation on mount. Tools that are actively streaming still animate on first appearance since they mount with `status: "pending"`.

| Scenario | `animate` at mount | Animation? |
|---|---|---|
| Tool just started streaming | `true` (pending/running) | Yes |
| Session switch (tools already completed) | `false` | No |
| Tool completes while mounted | Already ran on mount | No re-animation |