### PR TITLE
feat(agent-manager): style delete confirmation hint as button

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/agentmanager/worktree-item-pending-delete-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/agentmanager/worktree-item-pending-delete-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d4fc23f1b7bf2940b3554623d8964f04fc95bedf0752f45a0601bce34b5d585
-size 2554
+oid sha256:8d6e11c6f2880d3e919cbc544f0cc1055b0d6c086a52aac7e92fdd19d4d86ab6
+size 2580

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -326,11 +326,18 @@ button.am-section-toggle:hover .am-section-label {
 
 .am-worktree-delete-hint {
   font-size: var(--font-size-small);
-  color: var(--icon-critical-base);
+  color: var(--text-on-brand-base);
+  background: var(--surface-critical-strong);
   white-space: nowrap;
   flex-shrink: 0;
-  padding-right: 4px;
+  padding: 1px 8px;
+  border-radius: 4px;
+  cursor: pointer;
   animation: am-hint-slide-in 200ms ease;
+}
+
+.am-worktree-delete-hint:hover {
+  opacity: 0.9;
 }
 
 @keyframes am-hint-slide-in {


### PR DESCRIPTION
## Summary
- Restyled the inline "Delete?" confirmation text in worktree sidebar deletion to look like a small destructive button
- Red background with white text, border-radius, padding, and hover feedback make it visually obvious the element is clickable
- No behavioral changes — click handling is unchanged

<img width="290" height="95" alt="image" src="https://github.com/user-attachments/assets/2f3657c8-0fd7-4615-bdfb-8ee9f9e9d96b" />
