### PR TITLE
feat(agent-manager): add drag-and-drop reordering for sidebar worktrees

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -275,6 +275,10 @@ export class AgentManagerProvider implements Disposable {
       this.state?.setTabOrder(m.key, m.order)
       return null
     }
+    if (m.type === "agentManager.setWorktreeOrder") {
+      this.state?.setWorktreeOrder(m.order)
+      return null
+    }
     if (m.type === "agentManager.setSessionsCollapsed") {
       this.state?.setSessionsCollapsed(m.collapsed)
       return null
@@ -1414,6 +1418,7 @@ export class AgentManagerProvider implements Disposable {
       sessions: state.getSessions(),
       staleWorktreeIds,
       tabOrder: state.getTabOrder(),
+      worktreeOrder: state.getWorktreeOrder(),
       sessionsCollapsed: state.getSessionsCollapsed(),
       reviewDiffStyle: state.getReviewDiffStyle(),
       isGitRepo: true,

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -47,6 +47,7 @@ interface StateFile {
   worktrees: Record<string, Omit<Worktree, "id">>
   sessions: Record<string, Omit<ManagedSession, "id">>
   tabOrder?: Record<string, string[]>
+  worktreeOrder?: string[]
   sessionsCollapsed?: boolean
   reviewDiffStyle?: "unified" | "split"
   defaultBaseBranch?: string
@@ -67,6 +68,7 @@ export class WorktreeStateManager {
   private worktrees = new Map<string, Worktree>()
   private sessions = new Map<string, ManagedSession>()
   private tabOrder: Record<string, string[]> = {}
+  private worktreeOrder: string[] = []
   private collapsed = false
   private reviewDiffStyle: "unified" | "split" = "unified"
   private defaultBase: string | undefined
@@ -185,6 +187,10 @@ export class WorktreeStateManager {
     // Clean up tab order for this worktree
     delete this.tabOrder[id]
 
+    // Remove from worktree order
+    const idx = this.worktreeOrder.indexOf(id)
+    if (idx !== -1) this.worktreeOrder.splice(idx, 1)
+
     this.log(`Removed worktree ${id}, orphaned ${orphaned.length} sessions`)
     void this.save()
     return orphaned
@@ -237,6 +243,19 @@ export class WorktreeStateManager {
 
   removeTabOrder(key: string): void {
     delete this.tabOrder[key]
+    void this.save()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Worktree order
+  // ---------------------------------------------------------------------------
+
+  getWorktreeOrder(): string[] {
+    return this.worktreeOrder
+  }
+
+  setWorktreeOrder(order: string[]): void {
+    this.worktreeOrder = order
     void this.save()
   }
 
@@ -295,6 +314,7 @@ export class WorktreeStateManager {
       this.worktrees.clear()
       this.sessions.clear()
       this.tabOrder = {}
+      this.worktreeOrder = []
       this.reviewDiffStyle = "unified"
 
       for (const [id, wt] of Object.entries(data.worktrees ?? {})) {
@@ -307,6 +327,9 @@ export class WorktreeStateManager {
       }
       if (data.tabOrder) {
         this.tabOrder = data.tabOrder
+      }
+      if (data.worktreeOrder) {
+        this.worktreeOrder = data.worktreeOrder
       }
       this.collapsed = data.sessionsCollapsed ?? false
       if (data.reviewDiffStyle === "split") {
@@ -378,6 +401,9 @@ export class WorktreeStateManager {
     }
     if (Object.keys(this.tabOrder).length > 0) {
       data.tabOrder = this.tabOrder
+    }
+    if (this.worktreeOrder.length > 0) {
+      data.worktreeOrder = this.worktreeOrder
     }
     if (this.collapsed) {
       data.sessionsCollapsed = true

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -68,6 +68,7 @@ interface StateMessage {
   sessions: ManagedSession[]
   staleWorktreeIds?: string[]
   tabOrder?: Record<string, string[]>
+  worktreeOrder?: string[]
   sessionsCollapsed?: boolean
   reviewDiffStyle?: "unified" | "split"
   isGitRepo?: boolean
@@ -298,6 +299,11 @@ interface SetTabOrderIn {
   order: string[]
 }
 
+interface SetWorktreeOrderIn {
+  type: "agentManager.setWorktreeOrder"
+  order: string[]
+}
+
 interface SetSessionsCollapsedIn {
   type: "agentManager.setSessionsCollapsed"
   collapsed: boolean
@@ -425,6 +431,7 @@ export type AgentManagerInMessage =
   | RequestStateIn
   | RequestBranchesIn
   | SetTabOrderIn
+  | SetWorktreeOrderIn
   | SetSessionsCollapsedIn
   | SetReviewDiffStyleIn
   | SetDefaultBaseBranchIn

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -7,6 +7,7 @@ import {
   createSignal,
   createMemo,
   createEffect,
+  createRoot,
   on,
   onMount,
   onCleanup,
@@ -37,8 +38,16 @@ import type {
   SessionInfo,
   BranchInfo,
 } from "../src/types/messages"
-import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, closestCenter } from "@thisbeyond/solid-dnd"
-import type { DragEvent } from "@thisbeyond/solid-dnd"
+import {
+  DragDropProvider,
+  DragDropSensors,
+  DragOverlay,
+  SortableProvider,
+  closestCenter,
+  createSortable,
+  useDragDropContext,
+} from "@thisbeyond/solid-dnd"
+import type { DragEvent, Transformer } from "@thisbeyond/solid-dnd"
 import { ThemeProvider } from "@kilocode/kilo-ui/theme"
 import { DialogProvider, useDialog } from "@kilocode/kilo-ui/context/dialog"
 import { Dialog } from "@kilocode/kilo-ui/dialog"
@@ -617,6 +626,9 @@ const AgentManagerContent: Component = () => {
   const [draggingTab, setDraggingTab] = createSignal<string | undefined>()
   // Tab ordering: context key → ordered session ID array (recovered from extension state)
   const [worktreeTabOrder, setWorktreeTabOrder] = createSignal<Record<string, string[]>>({})
+  // Sidebar worktree order (persisted to extension state)
+  const [sidebarWorktreeOrder, setSidebarWorktreeOrder] = createSignal<string[]>([])
+  const [draggingWorktree, setDraggingWorktree] = createSignal<string | undefined>()
 
   const addPendingTab = () => {
     const id = `${PENDING_PREFIX}${++pendingCounter}`
@@ -796,14 +808,14 @@ const AgentManagerContent: Component = () => {
 
   const isStaleWorktree = (worktreeId: string): boolean => staleWorktreeIds().has(worktreeId)
 
-  /** Worktrees sorted so that grouped items are always adjacent, ordered by creation time. */
+  /** Worktrees sorted so that grouped items are always adjacent, respecting custom order if set. */
   const sortedWorktrees = createMemo(() => {
-    const all = worktrees()
-    if (all.length === 0) return []
+    const ordered = applyTabOrder(worktrees(), sidebarWorktreeOrder())
+    if (ordered.length === 0) return []
 
     // Collect grouped worktrees by groupId
     const grouped = new Map<string, WorktreeState[]>()
-    for (const wt of all) {
+    for (const wt of ordered) {
       if (!wt.groupId) continue
       const list = grouped.get(wt.groupId) ?? []
       list.push(wt)
@@ -813,7 +825,7 @@ const AgentManagerContent: Component = () => {
     // Build output: interleave groups at the position of their earliest member
     const result: WorktreeState[] = []
     const placed = new Set<string>()
-    for (const wt of all) {
+    for (const wt of ordered) {
       if (placed.has(wt.id)) continue
       if (wt.groupId) {
         if (placed.has(wt.groupId)) continue
@@ -1171,6 +1183,7 @@ const AgentManagerContent: Component = () => {
         // server won't connect to send the sessionsLoaded message.
         if (state.isGitRepo === false && !sessionsLoaded()) setSessionsLoaded(true)
         if (state.tabOrder) setWorktreeTabOrder(state.tabOrder)
+        if (state.worktreeOrder) setSidebarWorktreeOrder(state.worktreeOrder)
         if (state.reviewDiffStyle === "split" || state.reviewDiffStyle === "unified") {
           setReviewDiffStyle(state.reviewDiffStyle)
         }
@@ -2160,59 +2173,147 @@ const AgentManagerContent: Component = () => {
                     setRenamingWt(null)
                   }
 
+                  const wtIds = createMemo(() => sortedWorktrees().map((wt) => wt.id))
+
+                  const onWtDragStart = (event: DragEvent) => {
+                    const id = event.draggable?.id
+                    if (typeof id === "string") setDraggingWorktree(id)
+                    document.body.classList.add("am-wt-dragging-active")
+                  }
+
+                  const onWtDragOver = (event: DragEvent) => {
+                    const from = event.draggable?.id
+                    const to = event.droppable?.id
+                    if (typeof from !== "string" || typeof to !== "string") return
+                    setSidebarWorktreeOrder((prev) => {
+                      const current = applyTabOrder(
+                        sortedWorktrees().map((wt) => ({ id: wt.id })),
+                        prev,
+                      ).map((item) => item.id)
+                      return reorderTabs(current, from, to) ?? prev
+                    })
+                  }
+
+                  const onWtDragEnd = () => {
+                    setDraggingWorktree(undefined)
+                    document.body.classList.remove("am-wt-dragging-active")
+                    const order = sortedWorktrees().map((wt) => wt.id)
+                    if (order.length > 0) {
+                      vscode.postMessage({ type: "agentManager.setWorktreeOrder", order })
+                    }
+                  }
+
+                  /** Lock drag movement to the Y axis (vertical-only worktree dragging). */
+                  const ConstrainDragXAxis: Component = () => {
+                    const ctx = useDragDropContext()
+                    if (!ctx) return null
+                    const [
+                      ,
+                      { onDragStart: onStart, onDragEnd: onEnd, addTransformer: add, removeTransformer: remove },
+                    ] = ctx
+                    const xform: Transformer = { id: "constrain-x-axis", order: 100, callback: (t) => ({ ...t, x: 0 }) }
+                    const dispose = createRoot((dispose) => {
+                      onStart(({ draggable }) => {
+                        if (draggable) add("draggables", draggable.id as string, xform)
+                      })
+                      onEnd(({ draggable }) => {
+                        if (draggable) remove("draggables", draggable.id as string, xform.id)
+                      })
+                      return dispose
+                    })
+                    onCleanup(dispose)
+                    return null
+                  }
+
                   return (
-                    <For each={sortedWorktrees()}>
-                      {(wt, idx) => {
-                        const sessions = createMemo(() => managedSessions().filter((ms) => ms.worktreeId === wt.id))
-                        const navHint = () => {
-                          const flat = [
-                            LOCAL as string,
-                            ...sortedWorktrees().map((w) => w.id),
-                            ...unassignedSessions().map((s) => s.id),
-                          ]
-                          const active = selection() ?? session.currentSessionID() ?? ""
-                          return adjacentHint(wt.id, active, flat, kb().previousSession ?? "", kb().nextSession ?? "")
-                        }
-                        const groupSize = () => {
-                          if (!wt.groupId) return 0
-                          return sortedWorktrees().filter((w) => w.groupId === wt.groupId).length
-                        }
-                        return (
-                          <WorktreeItem
-                            worktree={wt}
-                            label={worktreeLabel(wt)}
-                            active={selection() === wt.id}
-                            pendingDelete={pendingDelete() === wt.id}
-                            busy={busyWorktrees().has(wt.id)}
-                            stale={isStaleWorktree(wt.id)}
-                            shortcut={idx() + 2}
-                            stats={worktreeStats()[wt.id]}
-                            navHint={navHint()}
-                            sessions={sessions().length}
-                            grouped={isGrouped(wt)}
-                            groupStart={isGroupStart(wt, idx())}
-                            groupEnd={isGroupEnd(wt, idx())}
-                            groupSize={groupSize()}
-                            renaming={renamingWt() === wt.id}
-                            renameValue={renameValue()}
-                            closeKeybind={kb().closeWorktree ?? ""}
-                            onClick={() => {
-                              if (pendingDelete() === wt.id) {
-                                confirmDeleteWorktree(wt.id)
-                                return
-                              }
-                              selectWorktree(wt.id)
-                            }}
-                            onDelete={(e) => handleDeleteWorktree(wt.id, e)}
-                            onStartRename={(current) => startRename(wt.id, current)}
-                            onRenameInput={(v) => setRenameValue(v)}
-                            onCommitRename={() => commitRename(wt.id)}
-                            onCancelRename={cancelRename}
-                            onRemoveStale={() => confirmRemoveStaleWorktree(wt.id)}
-                          />
-                        )
-                      }}
-                    </For>
+                    <DragDropProvider
+                      onDragStart={onWtDragStart}
+                      onDragEnd={onWtDragEnd}
+                      onDragOver={onWtDragOver}
+                      collisionDetector={closestCenter}
+                    >
+                      <DragDropSensors />
+                      <ConstrainDragXAxis />
+                      <SortableProvider ids={wtIds()}>
+                        <For each={sortedWorktrees()}>
+                          {(wt, idx) => {
+                            const sessions = createMemo(() => managedSessions().filter((ms) => ms.worktreeId === wt.id))
+                            const navHint = () => {
+                              const flat = [
+                                LOCAL as string,
+                                ...sortedWorktrees().map((w) => w.id),
+                                ...unassignedSessions().map((s) => s.id),
+                              ]
+                              const active = selection() ?? session.currentSessionID() ?? ""
+                              return adjacentHint(
+                                wt.id,
+                                active,
+                                flat,
+                                kb().previousSession ?? "",
+                                kb().nextSession ?? "",
+                              )
+                            }
+                            const groupSize = () => {
+                              if (!wt.groupId) return 0
+                              return sortedWorktrees().filter((w) => w.groupId === wt.groupId).length
+                            }
+                            const sortable = createSortable(wt.id)
+                            void sortable
+                            return (
+                              <div
+                                use:sortable
+                                class={`am-wt-sortable ${sortable.isActiveDraggable ? "am-wt-dragging" : ""}`}
+                              >
+                                <WorktreeItem
+                                  worktree={wt}
+                                  label={worktreeLabel(wt)}
+                                  active={selection() === wt.id}
+                                  pendingDelete={pendingDelete() === wt.id}
+                                  busy={busyWorktrees().has(wt.id)}
+                                  stale={isStaleWorktree(wt.id)}
+                                  shortcut={idx() + 2}
+                                  stats={worktreeStats()[wt.id]}
+                                  navHint={navHint()}
+                                  sessions={sessions().length}
+                                  grouped={isGrouped(wt)}
+                                  groupStart={isGroupStart(wt, idx())}
+                                  groupEnd={isGroupEnd(wt, idx())}
+                                  groupSize={groupSize()}
+                                  renaming={renamingWt() === wt.id}
+                                  renameValue={renameValue()}
+                                  closeKeybind={kb().closeWorktree ?? ""}
+                                  onClick={() => {
+                                    if (pendingDelete() === wt.id) {
+                                      confirmDeleteWorktree(wt.id)
+                                      return
+                                    }
+                                    selectWorktree(wt.id)
+                                  }}
+                                  onDelete={(e) => handleDeleteWorktree(wt.id, e)}
+                                  onStartRename={(current) => startRename(wt.id, current)}
+                                  onRenameInput={(v) => setRenameValue(v)}
+                                  onCommitRename={() => commitRename(wt.id)}
+                                  onCancelRename={cancelRename}
+                                  onRemoveStale={() => confirmRemoveStaleWorktree(wt.id)}
+                                />
+                              </div>
+                            )
+                          }}
+                        </For>
+                      </SortableProvider>
+                      <DragOverlay>
+                        {(() => {
+                          const wt = sortedWorktrees().find((w) => w.id === draggingWorktree())
+                          if (!wt) return null
+                          return (
+                            <div class="am-wt-overlay">
+                              <Icon name="branch" size="small" />
+                              <span>{worktreeLabel(wt)}</span>
+                            </div>
+                          )
+                        })()}
+                      </DragOverlay>
+                    </DragDropProvider>
                   )
                 })()}
                 <Show when={worktrees().length === 0}>

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -753,6 +753,43 @@ button.am-section-toggle:hover .am-section-label {
   color: var(--text-base);
 }
 
+/* Drag-and-drop sortable worktree wrapper */
+
+.am-wt-sortable {
+  touch-action: none;
+  cursor: grab;
+}
+
+body.am-wt-dragging-active,
+body.am-wt-dragging-active * {
+  cursor: grabbing !important;
+}
+
+.am-wt-sortable > [data-slot="hover-card-trigger"] {
+  width: 100%;
+}
+
+.am-wt-dragging {
+  opacity: 0.25;
+}
+
+/* Drag overlay worktree (follows the cursor) */
+
+.am-wt-overlay {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: var(--surface-base);
+  border: 1px solid var(--border-weak-base);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  pointer-events: none;
+  color: var(--text-base);
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+}
+
 .am-tab-add {
   flex-shrink: 0;
   align-self: center;

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -800,6 +800,7 @@ export interface AgentManagerStateMessage {
   sessions: ManagedSessionState[]
   staleWorktreeIds?: string[]
   tabOrder?: Record<string, string[]>
+  worktreeOrder?: string[]
   sessionsCollapsed?: boolean
   reviewDiffStyle?: "unified" | "split"
   isGitRepo?: boolean
@@ -1713,6 +1714,12 @@ export interface SetTabOrderRequest {
   order: string[]
 }
 
+// Persist sidebar worktree order
+export interface SetWorktreeOrderRequest {
+  type: "agentManager.setWorktreeOrder"
+  order: string[]
+}
+
 // Persist sessions collapsed state
 export interface SetSessionsCollapsedRequest {
   type: "agentManager.setSessionsCollapsed"
@@ -1945,6 +1952,7 @@ export type WebviewMessage =
   | AgentManagerOpenFileRequest
   | CreateMultiVersionRequest
   | SetTabOrderRequest
+  | SetWorktreeOrderRequest
   | SetSessionsCollapsedRequest
   | SetReviewDiffStyleRequest
   | PersistVariantRequest


### PR DESCRIPTION
## Summary
- Worktrees in the Agent Manager sidebar can now be reordered via drag-and-drop, matching the existing tab reordering UX
- Order is persisted to `.kilo/agent-manager.json` under a new `worktreeOrder` field and restored on restart
- Uses the same `@thisbeyond/solid-dnd` library already used for tab reordering, with Y-axis locking for vertical-only dragging
- Grab/grabbing cursor feedback during drag via body class (`!important` override needed because `DragOverlay` captures pointer events)
- Stale order entries are cleaned up on worktree removal

## Changes
| File | What |
|---|---|
| `WorktreeStateManager.ts` | `worktreeOrder` field, getter/setter, cleanup on remove, load/save |
| `types.ts` (extension) | `worktreeOrder` on `StateMessage`, new `SetWorktreeOrderIn` message |
| `AgentManagerProvider.ts` | Handle `setWorktreeOrder` message, include in `pushState()` |
| `messages.ts` (webview) | `worktreeOrder` on `AgentManagerStateMessage`, `SetWorktreeOrderRequest` |
| `AgentManagerApp.tsx` | DnD providers, sortable wrappers, drag handlers, order signals |
| `agent-manager.css` | `.am-wt-sortable`, `.am-wt-dragging`, `.am-wt-overlay`, cursor styles |