### PR TITLE
fix: add windowsHide to remaining spawn/exec calls to prevent CMD flash on Windows

### DIFF
--- a/packages/desktop-electron/src/main/apps.ts
+++ b/packages/desktop-electron/src/main/apps.ts
@@ -21,11 +21,11 @@ export function wslPath(path: string, mode: "windows" | "linux" | null): string 
     if (path.startsWith("~")) {
       const suffix = path.slice(1)
       const cmd = `wslpath ${flag} \"$HOME${suffix.replace(/\"/g, '\\"')}\"`
-      const output = execFileSync("wsl", ["-e", "sh", "-lc", cmd])
+      const output = execFileSync("wsl", ["-e", "sh", "-lc", cmd], { windowsHide: true })
       return output.toString().trim()
     }
 
-    const output = execFileSync("wsl", ["-e", "wslpath", flag, path])
+    const output = execFileSync("wsl", ["-e", "wslpath", flag, path], { windowsHide: true })
     return output.toString().trim()
   } catch (error) {
     throw new Error(`Failed to run wslpath: ${String(error)}`)
@@ -51,7 +51,7 @@ function checkMacosApp(appName: string) {
 function resolveWindowsAppPath(appName: string): string | null {
   let output: string
   try {
-    output = execFileSync("where", [appName]).toString()
+    output = execFileSync("where", [appName], { windowsHide: true }).toString()
   } catch {
     return null
   }

--- a/packages/desktop-electron/src/main/cli.ts
+++ b/packages/desktop-electron/src/main/cli.ts
@@ -84,7 +84,7 @@ export async function installCli(): Promise<string> {
   writeFileSync(tempScript, script, "utf8")
   chmodSync(tempScript, 0o755)
 
-  const cmd = spawn(tempScript, ["--binary", sidecar], { stdio: "pipe" })
+  const cmd = spawn(tempScript, ["--binary", sidecar], { stdio: "pipe", windowsHide: true })
   return await new Promise<string>((resolve, reject) => {
     cmd.on("exit", (code: number | null) => {
       try {
@@ -107,7 +107,7 @@ export function syncCli() {
 
   let version = ""
   try {
-    version = execFileSync(installPath, ["--version"]).toString().trim()
+    version = execFileSync(installPath, ["--version"], { windowsHide: true }).toString().trim()
   } catch {
     return
   }

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -123,7 +123,7 @@ export function registerIpcHandlers(deps: Deps) {
     await new Promise<void>((resolve, reject) => {
       const [cmd, args] =
         process.platform === "darwin" ? (["open", ["-a", app, path]] as const) : ([app, [path]] as const)
-      execFile(cmd, args, (err) => (err ? reject(err) : resolve()))
+      execFile(cmd, args, { windowsHide: true }, (err) => (err ? reject(err) : resolve()))
     })
   })
 

--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -357,6 +357,7 @@ export class GitOps {
           env: options?.env,
           encoding: "utf8",
           maxBuffer: 64 * 1024 * 1024,
+          windowsHide: true,
         },
         (error, stdout, stderr) => {
           if (!error) {

--- a/packages/kilo-vscode/src/agent-manager/shell-env.ts
+++ b/packages/kilo-vscode/src/agent-manager/shell-env.ts
@@ -73,6 +73,7 @@ export async function getShellEnvironment(): Promise<Record<string, string>> {
     const { stdout } = await run(shell, ["-lc", "env"], {
       timeout: 10_000,
       env: { ...process.env, HOME: os.homedir() },
+      windowsHide: true,
     })
 
     const env = parseEnvOutput(stdout)
@@ -127,7 +128,7 @@ export async function execWithShellEnv(
   options?: Omit<ExecFileOptionsWithStringEncoding, "encoding">,
 ): Promise<{ stdout: string; stderr: string }> {
   try {
-    return await run(cmd, args, { ...options, encoding: "utf8" })
+    return await run(cmd, args, { ...options, encoding: "utf8", windowsHide: true })
   } catch (error) {
     if (
       process.platform !== "darwin" ||
@@ -141,13 +142,13 @@ export async function execWithShellEnv(
     // Already resolved and PATH was actually changed — no point retrying resolution.
     // Just retry with the (already-patched) process.env.
     if (fixed) {
-      return await run(cmd, args, { ...options, encoding: "utf8" })
+      return await run(cmd, args, { ...options, encoding: "utf8", windowsHide: true })
     }
 
     // If another caller is already resolving, wait for it then retry.
     if (fixing) {
       await fixing
-      return await run(cmd, args, { ...options, encoding: "utf8" })
+      return await run(cmd, args, { ...options, encoding: "utf8", windowsHide: true })
     }
 
     console.log(`[shell-env] "${cmd}" not found, resolving shell environment`)
@@ -159,7 +160,7 @@ export async function execWithShellEnv(
       fixing = null
     }
 
-    return await run(cmd, args, { ...options, encoding: "utf8" })
+    return await run(cmd, args, { ...options, encoding: "utf8", windowsHide: true })
   }
 }
 

--- a/packages/kilo-vscode/src/services/marketplace/installer.ts
+++ b/packages/kilo-vscode/src/services/marketplace/installer.ts
@@ -152,7 +152,7 @@ export class MarketplaceInstaller {
       await fs.writeFile(tarball, buffer)
 
       await fs.mkdir(staging, { recursive: true })
-      await exec("tar", ["-xzf", tarball, "--strip-components=1", "-C", staging])
+      await exec("tar", ["-xzf", tarball, "--strip-components=1", "-C", staging], { windowsHide: true })
 
       const escaped = await findEscapedPaths(staging)
       if (escaped.length > 0) {

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -330,7 +330,7 @@ export const GithubInstallCommand = cmd({
                   ? `start "" "${url}"`
                   : `xdg-open "${url}"`
 
-            exec(command, (error) => {
+            exec(command, { windowsHide: true }, (error) => {
               if (error) {
                 prompts.log.warn(`Could not open browser. Please visit: ${url}`)
               }

--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -68,6 +68,7 @@ export async function createKiloServer(options?: ServerOptions) {
   const proc = spawn(`kilo`, args, {
     // kilocode_change end
     signal: options.signal,
+    windowsHide: true, // kilocode_change - prevent CMD window flash on Windows
     env: {
       ...process.env,
       KILO_CONFIG_CONTENT: buildConfigEnv(options.config), // kilocode_change
@@ -148,6 +149,7 @@ export function createKiloTui(options?: TuiOptions) {
     // kilocode_change end
     signal: options?.signal,
     stdio: "inherit",
+    windowsHide: true, // kilocode_change - prevent CMD window flash on Windows
     env: {
       ...process.env,
       KILO_CONFIG_CONTENT: buildConfigEnv(options?.config), // kilocode_change

--- a/packages/sdk/js/src/v2/server.ts
+++ b/packages/sdk/js/src/v2/server.ts
@@ -68,6 +68,7 @@ export async function createKiloServer(options?: ServerOptions) {
   const proc = spawn(`kilo`, args, {
     // kilocode_change end
     signal: options.signal,
+    windowsHide: true, // kilocode_change - prevent CMD window flash on Windows
     env: {
       ...process.env,
       KILO_CONFIG_CONTENT: buildConfigEnv(options.config), // kilocode_change
@@ -148,6 +149,7 @@ export function createKiloTui(options?: TuiOptions) {
     // kilocode_change end
     signal: options?.signal,
     stdio: "inherit",
+    windowsHide: true, // kilocode_change - prevent CMD window flash on Windows
     env: {
       ...process.env,
       KILO_CONFIG_CONTENT: buildConfigEnv(options?.config), // kilocode_change


### PR DESCRIPTION
## Summary

- PR #6813 fixed the CMD window flash on Windows by adding `windowsHide: true` to spawn calls in the CLI core, but missed several call sites across the SDK, VS Code extension, and desktop-electron packages
- This PR adds `windowsHide: true` to all remaining `child_process` spawn/exec/execFile/execFileSync call sites that were not covered
- The option is a no-op on non-Windows platforms, so no behavioral change elsewhere

## Root Cause

PR #6813 correctly identified the issue (Node.js `child_process.spawn()` allocates a new console for each child process by default on Windows) and fixed the core CLI spawn sites. However, several call sites in the SDK, VS Code extension Agent Manager, marketplace installer, and desktop-electron packages were not covered, causing CMD windows to continue flashing during:

- Git operations in the Agent Manager (GitOps.ts `execFile`)
- Shell environment resolution (shell-env.ts `execFile`)  
- Skill marketplace tarball extraction (installer.ts `execFile`)
- SDK server/TUI spawning (server.ts `spawn`)
- Browser opening for GitHub app install (github.ts `exec`)
- Desktop app CLI install, version check, WSL path resolution, and app opening

## Changes

| File | What |
|------|------|
| `packages/sdk/js/src/server.ts` | `createKiloServer()` + `createKiloTui()` spawn calls |
| `packages/sdk/js/src/v2/server.ts` | Same as above for v2 SDK |
| `packages/kilo-vscode/src/agent-manager/GitOps.ts` | `exec()` private method — all git operations |
| `packages/kilo-vscode/src/agent-manager/shell-env.ts` | `getShellEnvironment()` + all `execWithShellEnv()` retry paths |
| `packages/kilo-vscode/src/services/marketplace/installer.ts` | `tar` extraction call |
| `packages/opencode/src/cli/cmd/github.ts` | Browser open via `exec()` |
| `packages/desktop-electron/src/main/cli.ts` | Install script `spawn` + version check `execFileSync` |
| `packages/desktop-electron/src/main/ipc.ts` | `open-path` handler `execFile` |
| `packages/desktop-electron/src/main/apps.ts` | WSL `execFileSync` + Windows `where` `execFileSync` |

## Testing

- `windowsHide: true` is a no-op on macOS/Linux — no behavioral change for non-Windows users
- Maps to the Win32 `CREATE_NO_WINDOW` flag, preventing console allocation for child processes
