### PR TITLE
fix(agent-manager): suppress native browser context menu

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1977,7 +1977,7 @@ const AgentManagerContent: Component = () => {
   }
 
   return (
-    <div class="am-layout">
+    <div class="am-layout" onContextMenu={(e) => e.preventDefault()}>
       <div class="am-sidebar" style={{ width: `${sidebarWidth()}px` }}>
         <ResizeHandle
           direction="horizontal"


### PR DESCRIPTION
## Summary
- Prevents the native browser right-click menu (Cut/Copy/Paste) from appearing on sessions, worktree items, and other areas in the agent manager where it serves no purpose
- Adds `onContextMenu` with `preventDefault` on the root layout div
- Custom Kobalte `ContextMenu` on session tabs continues to work since it intercepts the event at the trigger level before it bubbles up