### PR TITLE
fix(vscode): fix agent list scroll in settings and mode selector

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
@@ -75,7 +75,7 @@ const Settings: Component<SettingsProps> = (props) => {
   }
 
   return (
-    <div style={{ display: "flex", "flex-direction": "column", height: "100%" }}>
+    <div style={{ display: "flex", "flex-direction": "column", height: "100%", "min-height": 0 }}>
       {/* Header */}
       <div
         style={{

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -93,6 +93,8 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
       <PopupSelector
         expanded={false}
         placement="top-start"
+        preferredHeight={300}
+        minHeight={100}
         open={open()}
         onOpenChange={onOpen}
         triggerAs={Button}


### PR DESCRIPTION
## Summary

Fixes #7398 — with many configured agents/modes, the agent list becomes unreachable in both the Settings panel and the mode selector popup.

Supersedes #7400 with a proper fix at the layout level instead of a hardcoded `max-height` wrapper.

## Changes

- **Settings tab** (`Settings.tsx`): Added `min-height: 0` to the root flex container. This fixes the classic flexbox scroll bug — without it, flex children default to `min-height: auto` (content size), which prevents them from shrinking and blocks `overflow-y: auto` on `[data-slot="tabs-content"]` from ever activating.

- **Mode selector popup** (`ModeSwitcher.tsx`): Added `preferredHeight={300}` and `minHeight={100}` to `PopupSelector`. This uses the same floating-ui constraint mechanism as `ModelSelector` — Kobalte measures `--kb-popper-content-available-height` and the list is clamped to fit the available viewport space.

<img width="410" height="501" alt="image" src="https://github.com/user-attachments/assets/39d852ad-811e-46ca-8aac-2b9181267473" />


## How to Test

1. Configure 10+ agents/modes (e.g. via `opencode.jsonc` or `.opencode/agents/`)
2. Open Settings > Agent Behaviour — the tab content should scroll, all agents visible
3. Click the mode selector in the prompt input area — the popup should be constrained and scrollable