### PR TITLE
fix(vscode): stack notification below account switcher on welcome screen

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/welcome-with-switcher-and-notification-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/welcome-with-switcher-and-notification-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5236457b1993d510ffd683a6ca3c8e538defe5ab607cbb92185bf9169764e8bf
+size 28744

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, createMemo, Switch, Match, Show, onMount, onCleanup } from "solid-js"
+import { Component, createSignal, createMemo, Switch, Match, onMount, onCleanup } from "solid-js"
 import { ThemeProvider } from "@kilocode/kilo-ui/theme"
 import { DialogProvider } from "@kilocode/kilo-ui/context/dialog"
 import { MarkedProvider } from "@kilocode/kilo-ui/context/marked"
@@ -20,7 +20,6 @@ import { SessionProvider, useSession } from "./context/session"
 import { LanguageProvider } from "./context/language"
 import { ChatView } from "./components/chat"
 import { MarketplaceView } from "./components/marketplace"
-import { KiloNotifications } from "./components/chat/KiloNotifications"
 import { registerExpandedTaskTool } from "./components/chat/TaskToolExpanded"
 import { registerVscodeToolOverrides } from "./components/chat/VscodeToolOverrides"
 
@@ -232,9 +231,6 @@ const AppContent: Component = () => {
     <div class="container">
       <Switch fallback={<ChatView />}>
         <Match when={currentView() === "newTask"}>
-          <Show when={!session.currentSessionID()}>
-            <KiloNotifications />
-          </Show>
           <ChatView onSelectSession={handleSelectSession} />
         </Match>
         <Match when={currentView() === "marketplace"}>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -22,6 +22,7 @@ import { FeedbackDialog } from "./FeedbackDialog"
 import { VscodeSessionTurn } from "./VscodeSessionTurn"
 import { RevertBanner } from "./RevertBanner"
 import { AccountSwitcher } from "../shared/AccountSwitcher"
+import { KiloNotifications } from "./KiloNotifications"
 import { WorkingIndicator } from "../shared/WorkingIndicator"
 import { activeUserMessageID as getActiveUserMessageID } from "../../context/session-queue"
 
@@ -92,7 +93,10 @@ export const MessageList: Component<MessageListProps> = (props) => {
   return (
     <div class="message-list-container">
       <Show when={isEmpty()}>
-        <AccountSwitcher class="account-switcher-welcome" />
+        <div class="welcome-header">
+          <AccountSwitcher class="account-switcher-welcome" />
+          <KiloNotifications />
+        </div>
       </Show>
       <div
         ref={autoScroll.scrollRef}

--- a/packages/kilo-vscode/webview-ui/src/context/notifications.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/notifications.tsx
@@ -17,7 +17,7 @@ interface NotificationsContextValue {
   dismiss: (id: string) => void
 }
 
-const NotificationsContext = createContext<NotificationsContextValue>()
+export const NotificationsContext = createContext<NotificationsContextValue>()
 
 export const NotificationsProvider: ParentComponent = (props) => {
   const vscode = useVSCode()

--- a/packages/kilo-vscode/webview-ui/src/context/server.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/server.tsx
@@ -22,7 +22,7 @@ interface ServerContextValue {
   workspaceDirectory: Accessor<string>
 }
 
-const ServerContext = createContext<ServerContextValue>()
+export const ServerContext = createContext<ServerContextValue>()
 
 const initialDeviceAuth: DeviceAuthState = { status: "idle" }
 

--- a/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
@@ -26,13 +26,14 @@ import { Diff } from "@kilocode/kilo-ui/diff"
 import { Code } from "@kilocode/kilo-ui/code"
 import { File } from "@kilocode/kilo-ui/file"
 import { SessionContext } from "../context/session"
+import { NotificationsContext } from "../context/notifications"
 import { LanguageContext } from "../context/language"
 import { dict as uiEn } from "@kilocode/kilo-ui/i18n/en"
 import { dict as appEn } from "../i18n/en"
 import { dict as amEn } from "../../agent-manager/i18n/en"
 import { dict as kiloEn } from "@kilocode/kilo-i18n/en"
 import { resolveTemplate } from "../context/language-utils"
-import type { Config, PermissionRequest, QuestionRequest } from "../types/messages"
+import type { Config, KilocodeNotification, PermissionRequest, QuestionRequest } from "../types/messages"
 
 // Merged English dictionary (same merge order as the real LanguageProvider)
 const dict: Record<string, string> = { ...appEn, ...amEn, ...uiEn, ...kiloEn }
@@ -98,10 +99,22 @@ export const defaultMockData = {
 }
 
 // ---------------------------------------------------------------------------
-// Mock SessionContext value — only the subset used by components
+// Mock NotificationsContext value
 // ---------------------------------------------------------------------------
 
 function noop() {}
+
+function mockNotificationsValue(items: KilocodeNotification[] = []) {
+  return {
+    notifications: () => items,
+    filteredNotifications: () => items,
+    dismiss: noop,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock SessionContext value — only the subset used by components
+// ---------------------------------------------------------------------------
 
 export function mockSessionValue(overrides?: {
   id?: string
@@ -190,6 +203,7 @@ interface StoryProvidersProps {
   data?: any
   permissions?: PermissionRequest[]
   questions?: QuestionRequest[]
+  notifications?: KilocodeNotification[]
   status?: string
   sessionID?: string
   /** When provided, injects a mock ConfigContext with this config instead of the real ConfigProvider. */
@@ -222,6 +236,7 @@ export const StoryProviders: ParentComponent<StoryProvidersProps> = (props) => {
     questions: props.questions,
     status: props.status,
   })
+  const notifications = mockNotificationsValue(props.notifications)
   const [locale] = createSignal<"en">("en")
 
   return (
@@ -239,23 +254,25 @@ export const StoryProviders: ParentComponent<StoryProvidersProps> = (props) => {
                 }}
               >
                 <I18nProvider value={{ locale: () => "en", t }}>
-                  <SessionContext.Provider value={session as any}>
-                    <DataProvider data={data()} directory="/project/">
-                      <DiffComponentProvider component={Diff}>
-                        <CodeComponentProvider component={Code}>
-                          <FileComponentProvider component={File}>
-                            <MarkedProvider>
-                              {props.noPadding ? (
-                                props.children
-                              ) : (
-                                <div style={{ padding: "12px" }}>{props.children}</div>
-                              )}
-                            </MarkedProvider>
-                          </FileComponentProvider>
-                        </CodeComponentProvider>
-                      </DiffComponentProvider>
-                    </DataProvider>
-                  </SessionContext.Provider>
+                  <NotificationsContext.Provider value={notifications}>
+                    <SessionContext.Provider value={session as any}>
+                      <DataProvider data={data()} directory="/project/">
+                        <DiffComponentProvider component={Diff}>
+                          <CodeComponentProvider component={Code}>
+                            <FileComponentProvider component={File}>
+                              <MarkedProvider>
+                                {props.noPadding ? (
+                                  props.children
+                                ) : (
+                                  <div style={{ padding: "12px" }}>{props.children}</div>
+                                )}
+                              </MarkedProvider>
+                            </FileComponentProvider>
+                          </CodeComponentProvider>
+                        </DiffComponentProvider>
+                      </DataProvider>
+                    </SessionContext.Provider>
+                  </NotificationsContext.Provider>
                 </I18nProvider>
               </LanguageContext.Provider>
             </DialogProvider>

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -13,6 +13,7 @@ import { ChatView } from "../components/chat/ChatView"
 import { TaskHeader } from "../components/chat/TaskHeader"
 import { QuestionDock } from "../components/chat/QuestionDock"
 import { SessionContext } from "../context/session"
+import { ServerContext } from "../context/server"
 import type { QuestionRequest, TodoItem } from "../types/messages"
 
 const SESSION_ID = "story-session-chat-001"
@@ -236,4 +237,52 @@ export const TaskHeaderWithTodosAllDone: Story = {
       </StoryProviders>
     )
   },
+}
+
+// ---------------------------------------------------------------------------
+// Welcome screen with AccountSwitcher + KiloNotifications
+// ---------------------------------------------------------------------------
+
+const MOCK_NOTIFICATION = {
+  id: "notif-1",
+  title: "Try BYOK for Kilo Gateway",
+  message: "Bring your own API key for even more flexibility with Kilo Gateway models.",
+  action: { actionText: "Learn more", actionURL: "https://kilo.ai/docs" },
+}
+
+/** Mock server context with profile data so AccountSwitcher is visible */
+const mockServer = {
+  connectionState: () => "connected" as const,
+  serverInfo: () => undefined,
+  extensionVersion: () => "1.0.0",
+  errorMessage: () => undefined,
+  errorDetails: () => undefined,
+  isConnected: () => true,
+  profileData: () => ({
+    profile: {
+      email: "dev@kilo.dev",
+      name: "Dev User",
+      organizations: [{ id: "org-1", name: "Kilo Org", role: "member" }],
+    },
+    balance: { balance: 5.0 },
+    currentOrgId: "org-1",
+  }),
+  deviceAuth: () => ({ status: "idle" as const }),
+  startLogin: () => {},
+  vscodeLanguage: () => "en",
+  languageOverride: () => undefined,
+  workspaceDirectory: () => "/project",
+}
+
+export const WelcomeWithSwitcherAndNotification: Story = {
+  name: "Welcome — account switcher + notification",
+  render: () => (
+    <StoryProviders sessionID={SESSION_ID} status="idle" noPadding notifications={[MOCK_NOTIFICATION]}>
+      <ServerContext.Provider value={mockServer as any}>
+        <div style={{ width: "100%", height: "600px", display: "flex", "flex-direction": "column" }}>
+          <ChatView />
+        </div>
+      </ServerContext.Provider>
+    </StoryProviders>
+  ),
 }

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1580,12 +1580,19 @@
   position: relative;
 }
 
-.account-switcher-welcome {
+.welcome-header {
   position: absolute;
   top: 12px;
   right: 12px;
-  width: 160px;
   z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.account-switcher-welcome {
+  width: 160px;
 }
 
 .account-switcher-trigger {
@@ -2120,30 +2127,29 @@
    ============================================ */
 
 .kilo-notifications {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 1000;
+  width: 280px;
   display: flex;
   flex-direction: column;
-  border-bottom: 1px solid var(--vscode-panel-border);
+  border-radius: 6px;
   animation: kilo-notifications-slide-in 0.3s ease-out;
+  overflow: hidden;
 }
 
 @keyframes kilo-notifications-slide-in {
   from {
-    transform: translateY(-100%);
+    transform: translateX(20px);
     opacity: 0;
   }
   to {
-    transform: translateY(0);
+    transform: translateX(0);
     opacity: 1;
   }
 }
 
 .kilo-notifications-card {
   background-color: var(--vscode-editor-background);
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 6px;
   padding: 12px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- Fixes notification card overlapping the AccountSwitcher badge on the welcome screen (#7469)
- Moves `KiloNotifications` from `App.tsx` into `MessageList.tsx` alongside `AccountSwitcher`, wrapping both in a `.welcome-header` flex container that stacks them vertically (account switcher on top, notification below)
- Removes absolute positioning from both individual elements in favor of a single positioned wrapper with `flex-direction: column`
