### PR TITLE
fix(cli): always use kilo.db regardless of channel

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -57,7 +57,6 @@ export namespace Flag {
   export const KILO_EXPERIMENTAL_MARKDOWN = !falsy("KILO_EXPERIMENTAL_MARKDOWN")
   export const KILO_MODELS_URL = process.env["KILO_MODELS_URL"]
   export const KILO_MODELS_PATH = process.env["KILO_MODELS_PATH"]
-  export const KILO_DISABLE_CHANNEL_DB = truthy("KILO_DISABLE_CHANNEL_DB")
   export const KILO_SKIP_MIGRATIONS = truthy("KILO_SKIP_MIGRATIONS")
 
   function number(key: string) {

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -12,9 +12,7 @@ import z from "zod"
 import path from "path"
 import { readFileSync, readdirSync, existsSync } from "fs"
 import * as schema from "./schema"
-import { Installation } from "../installation"
 import { Flag } from "../flag/flag"
-import { iife } from "@/util/iife"
 
 declare const KILO_MIGRATIONS: { sql: string; timestamp: number; name: string }[] | undefined
 
@@ -28,15 +26,8 @@ export const NotFoundError = NamedError.create(
 const log = Log.create({ service: "db" })
 
 export namespace Database {
-  export const Path = iife(() => {
-    const channel = Installation.CHANNEL
-    // kilocode_change start
-    if (["latest", "beta"].includes(channel) || Flag.KILO_DISABLE_CHANNEL_DB)
-      return path.join(Global.Path.data, "kilo.db")
-    const safe = channel.replace(/[^a-zA-Z0-9._-]/g, "-")
-    return path.join(Global.Path.data, `kilo-${safe}.db`)
-    // kilocode_change end
-  })
+  // kilocode_change - always use kilo.db regardless of channel
+  export const Path = path.join(Global.Path.data, "kilo.db")
 
   type Schema = typeof schema
   export type Transaction = SQLiteTransaction<"sync", void, Schema>

--- a/packages/opencode/test/storage/db.test.ts
+++ b/packages/opencode/test/storage/db.test.ts
@@ -1,16 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
-import { Installation } from "../../src/installation"
 import { Database } from "../../src/storage/db"
 
 describe("Database.Path", () => {
-  test("returns database path for the current channel", () => {
+  // kilocode_change - always use kilo.db regardless of channel
+  test("always uses kilo.db", () => {
     const file = path.basename(Database.Path)
-    // kilocode_change start
-    const expected = ["latest", "beta"].includes(Installation.CHANNEL)
-      ? "kilo.db"
-      : `kilo-${Installation.CHANNEL.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`
-    // kilocode_change end
-    expect(file).toBe(expected)
+    expect(file).toBe("kilo.db")
   })
 })


### PR DESCRIPTION
## Summary

- Always use `kilo.db` regardless of the installation channel, fixing saved sessions disappearing after the v1.2.22 upstream merge
- Remove the now-unused `KILO_DISABLE_CHANNEL_DB` flag
- Update the database path test to match the simplified behavior

## Context

PR #7240 merged upstream OpenCode changes that introduced channel-based database path separation (`kilo-<channel>.db`). This caused any build where `KILO_CHANNEL` is not `"latest"` or `"beta"` (e.g. preview builds, dev/local builds) to open a different SQLite database file, making all existing sessions invisible.

Closes #7472
