### PR TITLE
feat(vscode): support file path drops as @-mentions in chat input

### DIFF
--- a/packages/kilo-vscode/tests/unit/path-mentions.test.ts
+++ b/packages/kilo-vscode/tests/unit/path-mentions.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "bun:test"
+import { convertToMentionPath, extractDropPaths } from "../../webview-ui/src/utils/path-mentions"
+
+describe("convertToMentionPath", () => {
+  it("converts an absolute path under cwd to @/relative", () => {
+    expect(convertToMentionPath("/home/user/project/src/index.ts", "/home/user/project")).toBe("@/src/index.ts")
+  })
+
+  it("strips file:// protocol", () => {
+    expect(convertToMentionPath("file:///home/user/project/lib/util.ts", "/home/user/project")).toBe("@/lib/util.ts")
+  })
+
+  it("strips vscode-remote:// protocol", () => {
+    expect(convertToMentionPath("vscode-remote://ssh-remote+host/home/user/project/app.ts", "/home/user/project")).toBe(
+      "@/app.ts",
+    )
+  })
+
+  it("decodes URI-encoded characters", () => {
+    expect(convertToMentionPath("file:///home/user/my%20project/file.ts", "/home/user/my project")).toBe("@/file.ts")
+  })
+
+  it("escapes spaces in relative paths", () => {
+    expect(convertToMentionPath("/workspace/my folder/file.ts", "/workspace")).toBe("@/my\\ folder/file.ts")
+  })
+
+  it("handles Windows file:// paths with leading slash", () => {
+    expect(convertToMentionPath("file:///D:/Projects/app/src/main.ts", "D:\\Projects\\app")).toBe("@/src/main.ts")
+  })
+
+  it("handles Windows backslash cwd", () => {
+    expect(convertToMentionPath("D:\\Projects\\app\\src\\main.ts", "D:\\Projects\\app")).toBe("@/src/main.ts")
+  })
+
+  it("uses case-insensitive comparison for matching", () => {
+    expect(convertToMentionPath("D:/projects/App/src/main.ts", "D:/Projects/app")).toBe("@/src/main.ts")
+  })
+
+  it("returns raw path when outside cwd", () => {
+    expect(convertToMentionPath("/other/dir/file.ts", "/home/user/project")).toBe("/other/dir/file.ts")
+  })
+
+  it("returns cleaned path when cwd is empty", () => {
+    expect(convertToMentionPath("/some/file.ts", "")).toBe("/some/file.ts")
+  })
+
+  it("handles trailing slash on cwd", () => {
+    expect(convertToMentionPath("/workspace/src/index.ts", "/workspace/")).toBe("@/src/index.ts")
+  })
+})
+
+describe("extractDropPaths", () => {
+  it("returns null when no text or URI data is present", () => {
+    const dt = { getData: () => "" } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toBe(null)
+  })
+
+  it("extracts paths from text data", () => {
+    const dt = {
+      getData: (type: string) => (type === "text" ? "/home/user/file.ts" : ""),
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["/home/user/file.ts"])
+  })
+
+  it("extracts paths from application/vnd.code.uri-list", () => {
+    const dt = {
+      getData: (type: string) => (type === "application/vnd.code.uri-list" ? "file:///home/user/a.ts" : ""),
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["file:///home/user/a.ts"])
+  })
+
+  it("splits multiple paths on newlines", () => {
+    const dt = {
+      getData: (type: string) =>
+        type === "text" ? "file:///home/user/a.ts\nfile:///home/user/b.ts\r\nfile:///home/user/c.ts" : "",
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["file:///home/user/a.ts", "file:///home/user/b.ts", "file:///home/user/c.ts"])
+  })
+
+  it("filters out empty lines", () => {
+    const dt = {
+      getData: (type: string) => (type === "text" ? "file:///a.ts\n\n  \nfile:///b.ts" : ""),
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["file:///a.ts", "file:///b.ts"])
+  })
+
+  it("prefers text over uri-list when both are present", () => {
+    const dt = {
+      getData: (type: string) => {
+        if (type === "text") return "/from-text.ts"
+        if (type === "application/vnd.code.uri-list") return "/from-uri.ts"
+        return ""
+      },
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["/from-text.ts"])
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -10,6 +10,7 @@ import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { Popover } from "@kilocode/kilo-ui/popover"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useVSCode } from "../src/context/vscode"
+import { useServer } from "../src/context/server"
 import { useSession } from "../src/context/session"
 import { ModelSelectorBase } from "../src/components/shared/ModelSelector"
 import { ModeSwitcherBase } from "../src/components/shared/ModeSwitcher"
@@ -22,6 +23,7 @@ import {
 } from "./MultiModelSelector"
 import { useLanguage } from "../src/context/language"
 import { useImageAttachments } from "../src/hooks/useImageAttachments"
+import { convertToMentionPath } from "../src/utils/path-mentions"
 import { BranchSelect } from "./BranchSelect"
 
 type VersionCount = 1 | 2 | 3 | 4
@@ -56,6 +58,7 @@ function sanitizeBranchName(name: string): string {
 export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBranch?: string }> = (props) => {
   const { t } = useLanguage()
   const vscode = useVSCode()
+  const server = useServer()
   const session = useSession()
 
   const [tab, setTab] = createSignal<DialogTab>("new")
@@ -84,6 +87,26 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
   const [highlightedIndex, setHighlightedIndex] = createSignal(0)
 
   const imageAttach = useImageAttachments()
+  imageAttach.setFilePathDropHandler((paths) => {
+    const cwd = server.workspaceDirectory()
+    const mentions = paths.map((p) => convertToMentionPath(p, cwd))
+    const ref = textareaRef
+    if (!ref) return
+    const val = ref.value
+    const cursor = ref.selectionStart ?? val.length
+    const before = val.substring(0, cursor)
+    const after = val.substring(cursor)
+    const inserted = mentions.join(" ")
+    const result = before + inserted + " " + after
+    ref.value = result
+    const next = result
+    setPrompt(next)
+    persistPrompt(next)
+    const pos = cursor + inserted.length + 1
+    ref.setSelectionRange(pos, pos)
+    ref.focus()
+    adjustHeight()
+  })
 
   const persistPrompt = (value: string) => {
     const state = vscode.getState<Record<string, unknown>>() ?? {}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -22,6 +22,7 @@ import { useFileMention } from "../../hooks/useFileMention"
 import { useSlashCommand } from "../../hooks/useSlashCommand"
 import { useGhostText } from "../../hooks/useGhostText"
 import { useImageAttachments } from "../../hooks/useImageAttachments"
+import { convertToMentionPath } from "../../utils/path-mentions"
 import { usePromptHistory } from "../../hooks/usePromptHistory"
 import { WandSparkles } from "@kilocode/kilo-ui/lucide"
 import { fileName, dirName, buildHighlightSegments, atEnd } from "./prompt-input-utils"
@@ -56,6 +57,24 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const excluded = worktree ? new Set(["sessions"]) : undefined
   const slash = useSlashCommand(vscode, excluded)
   const imageAttach = useImageAttachments()
+  imageAttach.setFilePathDropHandler((paths) => {
+    const cwd = server.workspaceDirectory()
+    const mentions = paths.map((p) => convertToMentionPath(p, cwd))
+    const ref = textareaRef
+    if (!ref) return
+    const val = ref.value
+    const cursor = ref.selectionStart ?? val.length
+    const before = val.substring(0, cursor)
+    const after = val.substring(cursor)
+    const inserted = mentions.join(" ")
+    const result = before + inserted + " " + after
+    ref.value = result
+    setText(result)
+    const pos = cursor + inserted.length + 1
+    ref.setSelectionRange(pos, pos)
+    ref.focus()
+    adjustHeight()
+  })
   const history = usePromptHistory()
 
   const sessionKey = () => session.currentSessionID() ?? "__new__"

--- a/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
@@ -1,5 +1,6 @@
 import { createSignal } from "solid-js"
 import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, isDragLeavingComponent } from "./image-attachments-utils"
+import { extractDropPaths } from "../utils/path-mentions"
 
 export interface ImageAttachment {
   id: string
@@ -8,9 +9,18 @@ export interface ImageAttachment {
   dataUrl: string
 }
 
+/** Callback for handling text/URI file path drops. */
+export type FilePathDropHandler = (paths: string[]) => void
+
 export function useImageAttachments() {
   const [images, setImages] = createSignal<ImageAttachment[]>([])
   const [dragging, setDragging] = createSignal(false)
+  let onFilePaths: FilePathDropHandler | undefined
+
+  /** Register a handler for file path drops (text/URI-list). */
+  const setFilePathDropHandler = (handler: FilePathDropHandler) => {
+    onFilePaths = handler
+  }
 
   const add = (file: File) => {
     if (!isAcceptedImageType(file.type)) return
@@ -47,8 +57,12 @@ export function useImageAttachments() {
   }
 
   const handleDragOver = (event: DragEvent) => {
-    const hasFiles = event.dataTransfer?.types.includes("Files")
-    if (!hasFiles) return
+    const types = event.dataTransfer?.types
+    if (!types) return
+    // Accept both file drops and text/URI drops (from VS Code explorer, editor tabs, etc.)
+    const acceptable =
+      types.includes("Files") || types.includes("text/plain") || types.includes("application/vnd.code.uri-list")
+    if (!acceptable) return
     event.preventDefault()
     setDragging(true)
   }
@@ -62,7 +76,18 @@ export function useImageAttachments() {
   const handleDrop = (event: DragEvent) => {
     setDragging(false)
     event.preventDefault()
-    const files = event.dataTransfer?.files
+    const dt = event.dataTransfer
+    if (!dt) return
+
+    // First: check for text/URI file path drops (VS Code explorer, editor tabs)
+    const paths = extractDropPaths(dt)
+    if (paths && paths.length > 0 && onFilePaths) {
+      onFilePaths(paths)
+      return
+    }
+
+    // Second: fall through to image file drops
+    const files = dt.files
     if (!files) return
     for (const file of Array.from(files)) add(file)
   }
@@ -78,5 +103,6 @@ export function useImageAttachments() {
     handleDragOver,
     handleDragLeave,
     handleDrop,
+    setFilePathDropHandler,
   }
 }

--- a/packages/kilo-vscode/webview-ui/src/utils/path-mentions.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/path-mentions.ts
@@ -1,0 +1,50 @@
+/**
+ * Convert a dropped file URI or path into an @-mention path relative to the workspace.
+ * Strips file:// and vscode-remote:// protocols, decodes URI components,
+ * and produces @/relative/path when the file is inside the workspace.
+ */
+export function convertToMentionPath(path: string, cwd: string): string {
+  let cleaned = path
+
+  if (cleaned.startsWith("file://")) {
+    cleaned = cleaned.substring(7)
+  } else if (cleaned.startsWith("vscode-remote://")) {
+    const rest = cleaned.substring("vscode-remote://".length)
+    const idx = rest.indexOf("/")
+    cleaned = idx !== -1 ? rest.substring(idx) : ""
+  }
+
+  try {
+    cleaned = decodeURIComponent(cleaned)
+    // Remove leading slash for Windows paths like /d:/...
+    if (cleaned.startsWith("/") && cleaned[2] === ":") {
+      cleaned = cleaned.substring(1)
+    }
+  } catch (err) {
+    console.error("[Kilo New] Failed to decode dropped URI:", err, cleaned)
+  }
+
+  const normalized = cleaned.replace(/\\/g, "/")
+  let root = cwd.replace(/\\/g, "/")
+  if (root.endsWith("/")) root = root.slice(0, -1)
+
+  if (!root) return cleaned
+
+  if (normalized.toLowerCase().startsWith(root.toLowerCase())) {
+    let relative = normalized.substring(root.length)
+    if (!relative.startsWith("/")) relative = "/" + relative
+    return "@" + relative.replace(/ /g, "\\ ")
+  }
+
+  return cleaned
+}
+
+/**
+ * Extract file mention paths from a drop's DataTransfer.
+ * Returns null if the drop contains no text/URI data (i.e. it's a pure file drop).
+ */
+export function extractDropPaths(dt: DataTransfer): string[] | null {
+  const text = dt.getData("text") || dt.getData("application/vnd.code.uri-list")
+  if (!text) return null
+  return text.split(/\r?\n/).filter((line) => line.trim() !== "")
+}


### PR DESCRIPTION
## Summary

- Adds drag-and-drop support for files/folders from VS Code's explorer and editor tabs into the chat prompt, converting them to `@/relative/path` mentions (matching legacy extension behavior)
- Image drops from the OS file manager continue to work as image attachments (unchanged)
- Works in both the sidebar chat and the Agent Manager's new worktree dialog

## Changes

- **New**: `webview-ui/src/utils/path-mentions.ts` — `convertToMentionPath()` strips `file://` and `vscode-remote://` protocols, decodes URIs, handles Windows paths, and produces `@/relative/path` mentions. `extractDropPaths()` reads text/URI-list from DataTransfer.
- **Modified**: `useImageAttachments` hook — `handleDragOver` now accepts `text/plain` and `application/vnd.code.uri-list` drag types; `handleDrop` checks for text/URI paths first and delegates to a registered handler before falling through to image handling.
- **Modified**: `PromptInput.tsx` and `NewWorktreeDialog.tsx` — register file path drop handlers that insert `@/path` mentions at the cursor position.
- **New**: `tests/unit/path-mentions.test.ts` — 17 tests covering protocol stripping, URI decoding, Windows paths, vscode-remote, space escaping, case-insensitive matching, and `extractDropPaths`.

## Test plan

1. Open a project in VS Code with the extension
2. Drag a file from the Explorer panel into the chat prompt → should insert `@/relative/path`
3. Drag multiple files → should insert space-separated mentions
4. Drag an editor tab → should insert `@/path`
5. Drag an image from Finder/OS explorer → should still create an image attachment
6. Open Agent Manager → New → drag files into prompt → same mention behavior