### PR TITLE
fix(vscode): fix file path drop mentions to work with attachment system

### DIFF
--- a/packages/kilo-vscode/tests/unit/path-mentions.test.ts
+++ b/packages/kilo-vscode/tests/unit/path-mentions.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "bun:test"
+import { convertToMentionPath, extractDropPaths } from "../../webview-ui/src/utils/path-mentions"
+
+describe("convertToMentionPath", () => {
+  it("converts an absolute path under cwd to @/relative", () => {
+    expect(convertToMentionPath("/home/user/project/src/index.ts", "/home/user/project")).toBe("@/src/index.ts")
+  })
+
+  it("strips file:// protocol", () => {
+    expect(convertToMentionPath("file:///home/user/project/lib/util.ts", "/home/user/project")).toBe("@/lib/util.ts")
+  })
+
+  it("strips vscode-remote:// protocol", () => {
+    expect(convertToMentionPath("vscode-remote://ssh-remote+host/home/user/project/app.ts", "/home/user/project")).toBe(
+      "@/app.ts",
+    )
+  })
+
+  it("decodes URI-encoded characters", () => {
+    expect(convertToMentionPath("file:///home/user/my%20project/file.ts", "/home/user/my project")).toBe("@/file.ts")
+  })
+
+  it("escapes spaces in relative paths", () => {
+    expect(convertToMentionPath("/workspace/my folder/file.ts", "/workspace")).toBe("@/my\\ folder/file.ts")
+  })
+
+  it("handles Windows file:// paths with leading slash", () => {
+    expect(convertToMentionPath("file:///D:/Projects/app/src/main.ts", "D:\\Projects\\app")).toBe("@/src/main.ts")
+  })
+
+  it("handles Windows backslash cwd", () => {
+    expect(convertToMentionPath("D:\\Projects\\app\\src\\main.ts", "D:\\Projects\\app")).toBe("@/src/main.ts")
+  })
+
+  it("uses case-insensitive comparison for matching", () => {
+    expect(convertToMentionPath("D:/projects/App/src/main.ts", "D:/Projects/app")).toBe("@/src/main.ts")
+  })
+
+  it("returns raw path when outside cwd", () => {
+    expect(convertToMentionPath("/other/dir/file.ts", "/home/user/project")).toBe("/other/dir/file.ts")
+  })
+
+  it("returns cleaned path when cwd is empty", () => {
+    expect(convertToMentionPath("/some/file.ts", "")).toBe("/some/file.ts")
+  })
+
+  it("handles trailing slash on cwd", () => {
+    expect(convertToMentionPath("/workspace/src/index.ts", "/workspace/")).toBe("@/src/index.ts")
+  })
+})
+
+describe("extractDropPaths", () => {
+  it("returns null when no text or URI data is present", () => {
+    const dt = { getData: () => "" } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toBe(null)
+  })
+
+  it("extracts paths from text data", () => {
+    const dt = {
+      getData: (type: string) => (type === "text" ? "/home/user/file.ts" : ""),
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["/home/user/file.ts"])
+  })
+
+  it("extracts paths from application/vnd.code.uri-list", () => {
+    const dt = {
+      getData: (type: string) => (type === "application/vnd.code.uri-list" ? "file:///home/user/a.ts" : ""),
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["file:///home/user/a.ts"])
+  })
+
+  it("splits multiple paths on newlines", () => {
+    const dt = {
+      getData: (type: string) =>
+        type === "text" ? "file:///home/user/a.ts\nfile:///home/user/b.ts\r\nfile:///home/user/c.ts" : "",
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["file:///home/user/a.ts", "file:///home/user/b.ts", "file:///home/user/c.ts"])
+  })
+
+  it("filters out empty lines", () => {
+    const dt = {
+      getData: (type: string) => (type === "text" ? "file:///a.ts\n\n  \nfile:///b.ts" : ""),
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["file:///a.ts", "file:///b.ts"])
+  })
+
+  it("prefers text over uri-list when both are present", () => {
+    const dt = {
+      getData: (type: string) => {
+        if (type === "text") return "/from-text.ts"
+        if (type === "application/vnd.code.uri-list") return "/from-uri.ts"
+        return ""
+      },
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["/from-text.ts"])
+  })
+})

--- a/packages/kilo-vscode/tests/unit/path-mentions.test.ts
+++ b/packages/kilo-vscode/tests/unit/path-mentions.test.ts
@@ -2,38 +2,42 @@ import { describe, it, expect } from "bun:test"
 import { convertToMentionPath, extractDropPaths } from "../../webview-ui/src/utils/path-mentions"
 
 describe("convertToMentionPath", () => {
-  it("converts an absolute path under cwd to @/relative", () => {
-    expect(convertToMentionPath("/home/user/project/src/index.ts", "/home/user/project")).toBe("@/src/index.ts")
+  it("converts an absolute path under cwd to a relative path", () => {
+    expect(convertToMentionPath("/home/user/project/src/index.ts", "/home/user/project")).toBe("src/index.ts")
   })
 
   it("strips file:// protocol", () => {
-    expect(convertToMentionPath("file:///home/user/project/lib/util.ts", "/home/user/project")).toBe("@/lib/util.ts")
+    expect(convertToMentionPath("file:///home/user/project/lib/util.ts", "/home/user/project")).toBe("lib/util.ts")
   })
 
   it("strips vscode-remote:// protocol", () => {
     expect(convertToMentionPath("vscode-remote://ssh-remote+host/home/user/project/app.ts", "/home/user/project")).toBe(
-      "@/app.ts",
+      "app.ts",
     )
   })
 
   it("decodes URI-encoded characters", () => {
-    expect(convertToMentionPath("file:///home/user/my%20project/file.ts", "/home/user/my project")).toBe("@/file.ts")
+    expect(convertToMentionPath("file:///home/user/my%20project/file.ts", "/home/user/my project")).toBe("file.ts")
   })
 
-  it("escapes spaces in relative paths", () => {
-    expect(convertToMentionPath("/workspace/my folder/file.ts", "/workspace")).toBe("@/my\\ folder/file.ts")
+  it("preserves spaces in relative paths (no escaping)", () => {
+    expect(convertToMentionPath("/workspace/my folder/file.ts", "/workspace")).toBe("my folder/file.ts")
+  })
+
+  it("does not match cwd prefix without boundary", () => {
+    expect(convertToMentionPath("/workspace/app2/file.ts", "/workspace/app")).toBe("/workspace/app2/file.ts")
   })
 
   it("handles Windows file:// paths with leading slash", () => {
-    expect(convertToMentionPath("file:///D:/Projects/app/src/main.ts", "D:\\Projects\\app")).toBe("@/src/main.ts")
+    expect(convertToMentionPath("file:///D:/Projects/app/src/main.ts", "D:\\Projects\\app")).toBe("src/main.ts")
   })
 
   it("handles Windows backslash cwd", () => {
-    expect(convertToMentionPath("D:\\Projects\\app\\src\\main.ts", "D:\\Projects\\app")).toBe("@/src/main.ts")
+    expect(convertToMentionPath("D:\\Projects\\app\\src\\main.ts", "D:\\Projects\\app")).toBe("src/main.ts")
   })
 
   it("uses case-insensitive comparison for matching", () => {
-    expect(convertToMentionPath("D:/projects/App/src/main.ts", "D:/Projects/app")).toBe("@/src/main.ts")
+    expect(convertToMentionPath("D:/projects/App/src/main.ts", "D:/Projects/app")).toBe("src/main.ts")
   })
 
   it("returns raw path when outside cwd", () => {
@@ -45,7 +49,13 @@ describe("convertToMentionPath", () => {
   })
 
   it("handles trailing slash on cwd", () => {
-    expect(convertToMentionPath("/workspace/src/index.ts", "/workspace/")).toBe("@/src/index.ts")
+    expect(convertToMentionPath("/workspace/src/index.ts", "/workspace/")).toBe("src/index.ts")
+  })
+
+  it("does not include @ prefix (callers add it)", () => {
+    const result = convertToMentionPath("/workspace/src/app.ts", "/workspace")
+    expect(result).toBe("src/app.ts")
+    expect(result.startsWith("@")).toBe(false)
   })
 })
 
@@ -55,13 +65,6 @@ describe("extractDropPaths", () => {
     expect(extractDropPaths(dt)).toBe(null)
   })
 
-  it("extracts paths from text data", () => {
-    const dt = {
-      getData: (type: string) => (type === "text" ? "/home/user/file.ts" : ""),
-    } as unknown as DataTransfer
-    expect(extractDropPaths(dt)).toEqual(["/home/user/file.ts"])
-  })
-
   it("extracts paths from application/vnd.code.uri-list", () => {
     const dt = {
       getData: (type: string) => (type === "application/vnd.code.uri-list" ? "file:///home/user/a.ts" : ""),
@@ -69,29 +72,59 @@ describe("extractDropPaths", () => {
     expect(extractDropPaths(dt)).toEqual(["file:///home/user/a.ts"])
   })
 
-  it("splits multiple paths on newlines", () => {
+  it("prefers uri-list over text/plain", () => {
+    const dt = {
+      getData: (type: string) => {
+        if (type === "application/vnd.code.uri-list") return "file:///from-uri.ts"
+        if (type === "text") return "/from-text.ts"
+        return ""
+      },
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["file:///from-uri.ts"])
+  })
+
+  it("falls back to text/plain when lines are file paths", () => {
+    const dt = {
+      getData: (type: string) => (type === "text" ? "/home/user/file.ts" : ""),
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["/home/user/file.ts"])
+  })
+
+  it("accepts Windows absolute paths from text/plain", () => {
+    const dt = {
+      getData: (type: string) => (type === "text" ? "C:\\Users\\me\\file.ts" : ""),
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toEqual(["C:\\Users\\me\\file.ts"])
+  })
+
+  it("rejects plain text that is not a file path", () => {
+    const dt = {
+      getData: (type: string) => (type === "text" ? "hello world" : ""),
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toBe(null)
+  })
+
+  it("rejects mixed text with non-path lines", () => {
+    const dt = {
+      getData: (type: string) => (type === "text" ? "/valid/path.ts\nnot a path" : ""),
+    } as unknown as DataTransfer
+    expect(extractDropPaths(dt)).toBe(null)
+  })
+
+  it("splits multiple paths on newlines from uri-list", () => {
     const dt = {
       getData: (type: string) =>
-        type === "text" ? "file:///home/user/a.ts\nfile:///home/user/b.ts\r\nfile:///home/user/c.ts" : "",
+        type === "application/vnd.code.uri-list"
+          ? "file:///home/user/a.ts\nfile:///home/user/b.ts\r\nfile:///home/user/c.ts"
+          : "",
     } as unknown as DataTransfer
     expect(extractDropPaths(dt)).toEqual(["file:///home/user/a.ts", "file:///home/user/b.ts", "file:///home/user/c.ts"])
   })
 
   it("filters out empty lines", () => {
     const dt = {
-      getData: (type: string) => (type === "text" ? "file:///a.ts\n\n  \nfile:///b.ts" : ""),
+      getData: (type: string) => (type === "application/vnd.code.uri-list" ? "file:///a.ts\n\n  \nfile:///b.ts" : ""),
     } as unknown as DataTransfer
     expect(extractDropPaths(dt)).toEqual(["file:///a.ts", "file:///b.ts"])
-  })
-
-  it("prefers text over uri-list when both are present", () => {
-    const dt = {
-      getData: (type: string) => {
-        if (type === "text") return "/from-text.ts"
-        if (type === "application/vnd.code.uri-list") return "/from-uri.ts"
-        return ""
-      },
-    } as unknown as DataTransfer
-    expect(extractDropPaths(dt)).toEqual(["/from-text.ts"])
   })
 })

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -10,6 +10,7 @@ import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { Popover } from "@kilocode/kilo-ui/popover"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useVSCode } from "../src/context/vscode"
+import { useServer } from "../src/context/server"
 import { useSession } from "../src/context/session"
 import { ModelSelectorBase } from "../src/components/shared/ModelSelector"
 import { ModeSwitcherBase } from "../src/components/shared/ModeSwitcher"
@@ -22,6 +23,7 @@ import {
 } from "./MultiModelSelector"
 import { useLanguage } from "../src/context/language"
 import { useImageAttachments } from "../src/hooks/useImageAttachments"
+import { convertToMentionPath } from "../src/utils/path-mentions"
 import { BranchSelect } from "./BranchSelect"
 
 type VersionCount = 1 | 2 | 3 | 4
@@ -56,6 +58,7 @@ function sanitizeBranchName(name: string): string {
 export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBranch?: string }> = (props) => {
   const { t } = useLanguage()
   const vscode = useVSCode()
+  const server = useServer()
   const session = useSession()
 
   const [tab, setTab] = createSignal<DialogTab>("new")
@@ -84,6 +87,26 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
   const [highlightedIndex, setHighlightedIndex] = createSignal(0)
 
   const imageAttach = useImageAttachments()
+  imageAttach.setFilePathDropHandler((paths) => {
+    const cwd = server.workspaceDirectory()
+    const mentions = paths.map((p) => convertToMentionPath(p, cwd))
+    const ref = textareaRef
+    if (!ref) return
+    const val = ref.value
+    const cursor = ref.selectionStart ?? val.length
+    const before = val.substring(0, cursor)
+    const after = val.substring(cursor)
+    const inserted = mentions.join(" ")
+    const result = before + inserted + " " + after
+    ref.value = result
+    const next = result
+    setPrompt(next)
+    persistPrompt(next)
+    const pos = cursor + inserted.length + 1
+    ref.setSelectionRange(pos, pos)
+    ref.focus()
+    adjustHeight()
+  })
 
   const persistPrompt = (value: string) => {
     const state = vscode.getState<Record<string, unknown>>() ?? {}

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -89,19 +89,18 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
   const imageAttach = useImageAttachments()
   imageAttach.setFilePathDropHandler((paths) => {
     const cwd = server.workspaceDirectory()
-    const mentions = paths.map((p) => convertToMentionPath(p, cwd))
+    const resolved = paths.map((p) => convertToMentionPath(p, cwd))
     const ref = textareaRef
     if (!ref) return
     const val = ref.value
     const cursor = ref.selectionStart ?? val.length
     const before = val.substring(0, cursor)
     const after = val.substring(cursor)
-    const inserted = mentions.join(" ")
+    const inserted = resolved.map((p) => `@${p}`).join(" ")
     const result = before + inserted + " " + after
     ref.value = result
-    const next = result
-    setPrompt(next)
-    persistPrompt(next)
+    setPrompt(result)
+    persistPrompt(result)
     const pos = cursor + inserted.length + 1
     ref.setSelectionRange(pos, pos)
     ref.focus()

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -22,6 +22,7 @@ import { useFileMention } from "../../hooks/useFileMention"
 import { useSlashCommand } from "../../hooks/useSlashCommand"
 import { useGhostText } from "../../hooks/useGhostText"
 import { useImageAttachments } from "../../hooks/useImageAttachments"
+import { convertToMentionPath } from "../../utils/path-mentions"
 import { usePromptHistory } from "../../hooks/usePromptHistory"
 import { WandSparkles } from "@kilocode/kilo-ui/lucide"
 import { fileName, dirName, buildHighlightSegments, atEnd } from "./prompt-input-utils"
@@ -56,6 +57,24 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const excluded = worktree ? new Set(["sessions"]) : undefined
   const slash = useSlashCommand(vscode, excluded)
   const imageAttach = useImageAttachments()
+  imageAttach.setFilePathDropHandler((paths) => {
+    const cwd = server.workspaceDirectory()
+    const mentions = paths.map((p) => convertToMentionPath(p, cwd))
+    const ref = textareaRef
+    if (!ref) return
+    const val = ref.value
+    const cursor = ref.selectionStart ?? val.length
+    const before = val.substring(0, cursor)
+    const after = val.substring(cursor)
+    const inserted = mentions.join(" ")
+    const result = before + inserted + " " + after
+    ref.value = result
+    setText(result)
+    const pos = cursor + inserted.length + 1
+    ref.setSelectionRange(pos, pos)
+    ref.focus()
+    adjustHeight()
+  })
   const history = usePromptHistory()
 
   const sessionKey = () => session.currentSessionID() ?? "__new__"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -59,17 +59,18 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const imageAttach = useImageAttachments()
   imageAttach.setFilePathDropHandler((paths) => {
     const cwd = server.workspaceDirectory()
-    const mentions = paths.map((p) => convertToMentionPath(p, cwd))
+    const resolved = paths.map((p) => convertToMentionPath(p, cwd))
     const ref = textareaRef
     if (!ref) return
     const val = ref.value
     const cursor = ref.selectionStart ?? val.length
     const before = val.substring(0, cursor)
     const after = val.substring(cursor)
-    const inserted = mentions.join(" ")
+    const inserted = resolved.map((p) => `@${p}`).join(" ")
     const result = before + inserted + " " + after
     ref.value = result
     setText(result)
+    mention.addPaths(resolved, cwd)
     const pos = cursor + inserted.length + 1
     ref.setSelectionRange(pos, pos)
     ref.focus()

--- a/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
@@ -36,6 +36,8 @@ export interface FileMention {
   setMentionIndex: (index: number) => void
   closeMention: () => void
   parseFileAttachments: (text: string) => FileAttachment[]
+  /** Register paths as active mentions (used by drag-and-drop). Pass cwd to ensure buildFileAttachments resolves correctly. */
+  addPaths: (paths: string[], cwd: string) => void
 }
 
 export function useFileMention(vscode: VSCodeContext): FileMention {
@@ -157,6 +159,15 @@ export function useFileMention(vscode: VSCodeContext): FileMention {
     return false
   }
 
+  const addPaths = (paths: string[], cwd: string) => {
+    if (cwd) workspaceDir = cwd
+    setMentionedPaths((prev) => {
+      const next = new Set(prev)
+      for (const p of paths) next.add(p)
+      return next
+    })
+  }
+
   const parseFileAttachments = (text: string): FileAttachment[] =>
     buildFileAttachments(text, mentionedPaths(), workspaceDir)
 
@@ -171,5 +182,6 @@ export function useFileMention(vscode: VSCodeContext): FileMention {
     setMentionIndex,
     closeMention,
     parseFileAttachments,
+    addPaths,
   }
 }

--- a/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
@@ -1,5 +1,6 @@
 import { createSignal } from "solid-js"
 import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, isDragLeavingComponent } from "./image-attachments-utils"
+import { extractDropPaths } from "../utils/path-mentions"
 
 export interface ImageAttachment {
   id: string
@@ -8,9 +9,18 @@ export interface ImageAttachment {
   dataUrl: string
 }
 
+/** Callback for handling text/URI file path drops. */
+export type FilePathDropHandler = (paths: string[]) => void
+
 export function useImageAttachments() {
   const [images, setImages] = createSignal<ImageAttachment[]>([])
   const [dragging, setDragging] = createSignal(false)
+  let onFilePaths: FilePathDropHandler | undefined
+
+  /** Register a handler for file path drops (text/URI-list). */
+  const setFilePathDropHandler = (handler: FilePathDropHandler) => {
+    onFilePaths = handler
+  }
 
   const add = (file: File) => {
     if (!isAcceptedImageType(file.type)) return
@@ -47,8 +57,12 @@ export function useImageAttachments() {
   }
 
   const handleDragOver = (event: DragEvent) => {
-    const hasFiles = event.dataTransfer?.types.includes("Files")
-    if (!hasFiles) return
+    const types = event.dataTransfer?.types
+    if (!types) return
+    // Accept both file drops and text/URI drops (from VS Code explorer, editor tabs, etc.)
+    const acceptable =
+      types.includes("Files") || types.includes("text/plain") || types.includes("application/vnd.code.uri-list")
+    if (!acceptable) return
     event.preventDefault()
     setDragging(true)
   }
@@ -62,7 +76,18 @@ export function useImageAttachments() {
   const handleDrop = (event: DragEvent) => {
     setDragging(false)
     event.preventDefault()
-    const files = event.dataTransfer?.files
+    const dt = event.dataTransfer
+    if (!dt) return
+
+    // First: check for text/URI file path drops (VS Code explorer, editor tabs)
+    const paths = extractDropPaths(dt)
+    if (paths && paths.length > 0 && onFilePaths) {
+      onFilePaths(paths)
+      return
+    }
+
+    // Second: fall through to image file drops
+    const files = dt.files
     if (!files) return
     for (const file of Array.from(files)) add(file)
   }
@@ -78,5 +103,6 @@ export function useImageAttachments() {
     handleDragOver,
     handleDragLeave,
     handleDrop,
+    setFilePathDropHandler,
   }
 }

--- a/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
@@ -59,9 +59,9 @@ export function useImageAttachments() {
   const handleDragOver = (event: DragEvent) => {
     const types = event.dataTransfer?.types
     if (!types) return
-    // Accept both file drops and text/URI drops (from VS Code explorer, editor tabs, etc.)
-    const acceptable =
-      types.includes("Files") || types.includes("text/plain") || types.includes("application/vnd.code.uri-list")
+    // Accept file drops and VS Code URI-list drops (explorer, editor tabs).
+    // Do NOT accept bare text/plain here — that would intercept normal text drags.
+    const acceptable = types.includes("Files") || types.includes("application/vnd.code.uri-list")
     if (!acceptable) return
     event.preventDefault()
     setDragging(true)

--- a/packages/kilo-vscode/webview-ui/src/utils/path-mentions.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/path-mentions.ts
@@ -1,0 +1,50 @@
+/**
+ * Convert a dropped file URI or path into an @-mention path relative to the workspace.
+ * Strips file:// and vscode-remote:// protocols, decodes URI components,
+ * and produces @/relative/path when the file is inside the workspace.
+ */
+export function convertToMentionPath(path: string, cwd: string): string {
+  let cleaned = path
+
+  if (cleaned.startsWith("file://")) {
+    cleaned = cleaned.substring(7)
+  } else if (cleaned.startsWith("vscode-remote://")) {
+    const rest = cleaned.substring("vscode-remote://".length)
+    const idx = rest.indexOf("/")
+    cleaned = idx !== -1 ? rest.substring(idx) : ""
+  }
+
+  try {
+    cleaned = decodeURIComponent(cleaned)
+    // Remove leading slash for Windows paths like /d:/...
+    if (cleaned.startsWith("/") && cleaned[2] === ":") {
+      cleaned = cleaned.substring(1)
+    }
+  } catch (err) {
+    console.error("[Kilo New] Failed to decode dropped URI:", err, cleaned)
+  }
+
+  const normalized = cleaned.replace(/\\/g, "/")
+  let root = cwd.replace(/\\/g, "/")
+  if (root.endsWith("/")) root = root.slice(0, -1)
+
+  if (!root) return cleaned
+
+  if (normalized.toLowerCase().startsWith(root.toLowerCase())) {
+    let relative = normalized.substring(root.length)
+    if (!relative.startsWith("/")) relative = "/" + relative
+    return "@" + relative.replace(/ /g, "\\ ")
+  }
+
+  return cleaned
+}
+
+/**
+ * Extract file mention paths from a drop's DataTransfer.
+ * Returns null if the drop contains no text/URI data (i.e. it's a pure file drop).
+ */
+export function extractDropPaths(dt: DataTransfer): string[] | null {
+  const text = dt.getData("text") || dt.getData("application/vnd.code.uri-list")
+  if (!text) return null
+  return text.split(/\r?\n/).filter((line) => line.trim() !== "")
+}

--- a/packages/kilo-vscode/webview-ui/src/utils/path-mentions.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/path-mentions.ts
@@ -1,7 +1,11 @@
 /**
- * Convert a dropped file URI or path into an @-mention path relative to the workspace.
+ * Convert a dropped file URI or absolute path into a relative workspace path.
  * Strips file:// and vscode-remote:// protocols, decodes URI components,
- * and produces @/relative/path when the file is inside the workspace.
+ * and produces a relative path (e.g. "src/index.ts") when the file is inside
+ * the workspace. Returns the cleaned absolute path for files outside the workspace.
+ *
+ * The returned path does NOT include the "@" prefix — callers add that when
+ * inserting into the textarea so the path can also be registered in mentionedPaths.
  */
 export function convertToMentionPath(path: string, cwd: string): string {
   let cleaned = path
@@ -31,20 +35,51 @@ export function convertToMentionPath(path: string, cwd: string): string {
   if (!root) return cleaned
 
   if (normalized.toLowerCase().startsWith(root.toLowerCase())) {
-    let relative = normalized.substring(root.length)
-    if (!relative.startsWith("/")) relative = "/" + relative
-    return "@" + relative.replace(/ /g, "\\ ")
+    const tail = normalized.substring(root.length)
+    // Boundary check: next char must be "/" or end of string to avoid
+    // /workspace/app matching /workspace/app2/file.ts
+    if (tail === "" || tail.startsWith("/")) {
+      const relative = tail.startsWith("/") ? tail.substring(1) : tail
+      return relative || cleaned
+    }
   }
 
   return cleaned
 }
 
+/** Returns true when the line looks like a file URI or absolute path. */
+function isFilePath(line: string): boolean {
+  if (line.startsWith("file://") || line.startsWith("vscode-remote://")) return true
+  // Unix absolute path
+  if (line.startsWith("/")) return true
+  // Windows absolute path (e.g. C:\, D:/)
+  if (/^[A-Za-z]:[\\/]/.test(line)) return true
+  return false
+}
+
 /**
- * Extract file mention paths from a drop's DataTransfer.
- * Returns null if the drop contains no text/URI data (i.e. it's a pure file drop).
+ * Extract file paths from a drop's DataTransfer.
+ * Only considers the URI-list data type (set by VS Code when dragging files
+ * from the explorer or editor tabs). Falls back to text/plain but only when
+ * every non-empty line looks like a file URI or absolute path, to avoid
+ * intercepting normal text drags from the editor.
+ *
+ * Returns null if no file paths are found.
  */
 export function extractDropPaths(dt: DataTransfer): string[] | null {
-  const text = dt.getData("text") || dt.getData("application/vnd.code.uri-list")
-  if (!text) return null
-  return text.split(/\r?\n/).filter((line) => line.trim() !== "")
+  // Prefer the VS Code-specific URI list — this is always file paths
+  const uri = dt.getData("application/vnd.code.uri-list")
+  if (uri) {
+    const paths = uri.split(/\r?\n/).filter((line) => line.trim() !== "")
+    if (paths.length > 0) return paths
+  }
+
+  // Fall back to text/plain only if every line is a recognizable file path
+  const text = dt.getData("text")
+  if (text) {
+    const lines = text.split(/\r?\n/).filter((line) => line.trim() !== "")
+    if (lines.length > 0 && lines.every(isFilePath)) return lines
+  }
+
+  return null
 }


### PR DESCRIPTION
## Summary

Follow-up to #7476. Fixes three bugs where dropped file paths from VS Code's explorer were not properly integrated with the mention/attachment system:

1. **Dropped mentions never became file attachments** — the drop handler inserted `@path` text but never registered paths in `mentionedPaths`, so `parseFileAttachments` couldn't resolve them. Fix: expose `addPaths()` on `useFileMention` and call it from the drop handler.

2. **`@/relative` resolved to wrong absolute path** — `convertToMentionPath` returned `@/src/...` (with `@` prefix and leading `/` baked in), but `buildFileAttachments` expects bare relative paths like `src/index.ts` and adds `@` when matching. Fix: return bare relative path, callers now add `@` prefix when inserting into textarea.

3. **Normal text drags intercepted as file drops** — `handleDragOver` accepted `text/plain`, and `extractDropPaths` treated any non-empty text as file paths. Fix: only accept `application/vnd.code.uri-list` in dragover; `extractDropPaths` now falls back to `text/plain` only when every line passes an `isFilePath` check (file://, vscode-remote://, absolute unix/windows path).

## Changes

- `path-mentions.ts` — `convertToMentionPath` returns bare relative paths; `extractDropPaths` prefers uri-list, validates text/plain lines with `isFilePath()`
- `useFileMention.ts` — new `addPaths()` method on `FileMention` interface
- `useImageAttachments.ts` — `handleDragOver` no longer accepts bare `text/plain`
- `PromptInput.tsx` — drop handler adds `@` prefix, calls `mention.addPaths()`
- `NewWorktreeDialog.tsx` — drop handler adds `@` prefix
- Tests updated: 21 tests covering all new behaviors

## Test plan

1. Drag a file from VS Code Explorer into chat → inserts `@src/index.ts`, send message → AI receives file contents (not just the path text)
2. Drag selected text from an editor → should NOT be intercepted as a file drop (falls through to default behavior)
3. Drag a file from OS file manager → image files still become image attachments