### PR TITLE
fix(cli): strip trailing assistant messages on retry to prevent prefill errors

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -45,11 +45,31 @@ export namespace ProviderTransform {
     return undefined
   }
 
+  // kilocode_change start - Claude 4.5/4.6 models do not support assistant message prefill
+  export function supportsAssistantPrefill(model: Provider.Model): boolean {
+    const id = model.api.id.toLowerCase()
+    const blocked = ["opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6", "sonnet-4-5", "sonnet-4.5"]
+    return !blocked.some((v) => id.includes(v))
+  }
+
+  function stripTrailingAssistant(msgs: ModelMessage[]): ModelMessage[] {
+    while (msgs.length > 0 && msgs[msgs.length - 1].role === "assistant") {
+      msgs = msgs.slice(0, -1)
+    }
+    return msgs
+  }
+  // kilocode_change end
+
   function normalizeMessages(
     msgs: ModelMessage[],
     model: Provider.Model,
     options: Record<string, unknown>,
   ): ModelMessage[] {
+    // kilocode_change - strip trailing assistant messages for models that don't support prefill
+    if (!supportsAssistantPrefill(model)) {
+      msgs = stripTrailingAssistant(msgs)
+    }
+
     // Anthropic rejects messages with empty content - filter out empty string messages
     // and remove empty text/reasoning parts from array content
     if (model.api.npm === "@ai-sdk/anthropic") {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -49,6 +49,9 @@ export namespace SessionProcessor {
         needsCompaction = false
         const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
         while (true) {
+          // kilocode_change start - track parts created during this attempt for cleanup on retry
+          const pending: string[] = []
+          // kilocode_change end
           try {
             let currentText: MessageV2.TextPart | undefined
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
@@ -78,6 +81,7 @@ export namespace SessionProcessor {
                   }
                   reasoningMap[value.id] = reasoningPart
                   await Session.updatePart(reasoningPart)
+                  pending.push(reasoningPart.id) // kilocode_change
                   break
 
                 case "reasoning-delta":
@@ -125,6 +129,7 @@ export namespace SessionProcessor {
                     },
                   })
                   toolcalls[value.id] = part as MessageV2.ToolPart
+                  pending.push(part.id) // kilocode_change
                   break
 
                 case "tool-input-delta":
@@ -232,17 +237,20 @@ export namespace SessionProcessor {
                 case "error":
                   throw value.error
 
-                case "start-step":
+                case "start-step": {
                   stepStart = performance.now() // kilocode_change
                   snapshot = await Snapshot.track()
+                  const stepID = Identifier.ascending("part")
                   await Session.updatePart({
-                    id: Identifier.ascending("part"),
+                    id: stepID,
                     messageID: input.assistantMessage.id,
                     sessionID: input.sessionID,
                     snapshot,
                     type: "step-start",
                   })
+                  pending.push(stepID) // kilocode_change
                   break
+                }
 
                 case "finish-step":
                   const usage = Session.getUsage({
@@ -323,6 +331,7 @@ export namespace SessionProcessor {
                     metadata: value.providerMetadata,
                   }
                   await Session.updatePart(currentText)
+                  pending.push(currentText.id) // kilocode_change
                   break
 
                 case "text-delta":
@@ -388,6 +397,17 @@ export namespace SessionProcessor {
             } else {
               const retry = SessionRetry.retryable(error)
               if (retry !== undefined) {
+                // kilocode_change start - remove partial parts from failed attempt before retrying
+                // Without this, the partial assistant message stays in the conversation and
+                // causes "does not support assistant message prefill" errors on retry
+                for (const id of pending) {
+                  await Session.removePart({
+                    sessionID: input.sessionID,
+                    messageID: input.assistantMessage.id,
+                    partID: id,
+                  })
+                }
+                // kilocode_change end
                 attempt++
                 const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
                 SessionStatus.set(input.sessionID, {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2737,3 +2737,126 @@ describe("ProviderTransform.variants", () => {
   })
 })
 // kilocode_change end
+
+// kilocode_change start - tests for assistant prefill stripping
+describe("ProviderTransform.supportsAssistantPrefill", () => {
+  const model = (apiId: string) =>
+    ({
+      api: { id: apiId },
+    }) as any
+
+  test("returns false for claude opus 4.6", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-opus-4.6-20250601"))).toBe(false)
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-opus-4-6-20250601"))).toBe(false)
+  })
+
+  test("returns false for claude sonnet 4.6", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-sonnet-4.6-20250514"))).toBe(false)
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-sonnet-4-6-20250514"))).toBe(false)
+  })
+
+  test("returns false for claude sonnet 4.5", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-sonnet-4.5-20250514"))).toBe(false)
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-sonnet-4-5-20250514"))).toBe(false)
+  })
+
+  test("returns true for claude sonnet 4", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-sonnet-4-20250514"))).toBe(true)
+  })
+
+  test("returns true for claude 3.5 sonnet", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-3-5-sonnet-20241022"))).toBe(true)
+  })
+
+  test("returns true for non-claude models", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("gpt-4"))).toBe(true)
+    expect(ProviderTransform.supportsAssistantPrefill(model("gemini-3-pro"))).toBe(true)
+  })
+})
+
+describe("ProviderTransform.message - strip trailing assistant for no-prefill models", () => {
+  const opus46 = {
+    id: "anthropic/claude-opus-4.6",
+    providerID: "anthropic",
+    api: {
+      id: "claude-opus-4.6-20250601",
+      url: "https://api.anthropic.com",
+      npm: "@ai-sdk/anthropic",
+    },
+    name: "Claude Opus 4.6",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: true },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0.015, output: 0.075, cache: { read: 0.0015, write: 0.01875 } },
+    limit: { context: 200000, output: 32000 },
+    status: "active",
+    options: {},
+    headers: {},
+  } as any
+
+  test("strips trailing assistant message for opus 4.6", () => {
+    const msgs = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: [{ type: "text", text: "Partial response..." }] },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, opus46, {})
+
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe("user")
+  })
+
+  test("strips multiple trailing assistant messages", () => {
+    const msgs = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: [{ type: "text", text: "First" }] },
+      { role: "assistant", content: [{ type: "text", text: "Second" }] },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, opus46, {})
+
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe("user")
+  })
+
+  test("does not strip non-trailing assistant messages", () => {
+    const msgs = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: [{ type: "text", text: "Response" }] },
+      { role: "user", content: "Follow up" },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, opus46, {})
+
+    expect(result).toHaveLength(3)
+    expect(result[2].role).toBe("user")
+  })
+
+  test("does not strip for models that support prefill", () => {
+    const sonnet4 = {
+      ...opus46,
+      id: "anthropic/claude-sonnet-4",
+      api: {
+        ...opus46.api,
+        id: "claude-sonnet-4-20250514",
+      },
+    }
+
+    const msgs = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: [{ type: "text", text: "Partial response..." }] },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, sonnet4, {})
+
+    expect(result).toHaveLength(2)
+    expect(result[1].role).toBe("assistant")
+  })
+})
+// kilocode_change end


### PR DESCRIPTION
## Summary

Fixes agent session crashes on Anthropic models (Claude Opus 4.6, Sonnet 4.5/4.6) caused by partial assistant messages from failed LLM streams triggering "does not support assistant message prefill" errors on retry.

Closes Kilo-Org/cloud#1425

## Changes

Two complementary fixes (Option C from the issue):

### 1. Transport layer defense (`packages/opencode/src/provider/transform.ts`)

- Added `supportsAssistantPrefill()` — returns `false` for Claude 4.5/4.6 models that reject assistant message prefill
- Added `stripTrailingAssistant()` — removes trailing assistant messages from the message array before sending to the API
- Called at the start of `normalizeMessages()` for models that don't support prefill

This provides defense-in-depth: regardless of how a trailing assistant message ends up in the conversation (retry loop, interrupted stream, isLastStep, nudge injection), it will be stripped before reaching Anthropic.

### 2. Retry loop cleanup (`packages/opencode/src/session/processor.ts`)

- Track all part IDs created during each stream attempt in a `pending` array
- On retryable error (429, 500, overloaded), remove all partial parts via `Session.removePart()` before sleeping and retrying
- Prevents partial assistant content from accumulating across retries (each retry previously added more partial content to the same message)

### Tests (`packages/opencode/test/provider/transform.test.ts`)

- `supportsAssistantPrefill`: verifies correct detection for Opus 4.6, Sonnet 4.5/4.6, Sonnet 4, Claude 3.5, and non-Claude models
- `strip trailing assistant for no-prefill models`: verifies stripping behavior through `ProviderTransform.message()` for trailing, multiple trailing, non-trailing, and prefill-supporting models

## Impact

Critical fix for all agent sessions on Anthropic Claude 4.5/4.6 models. Especially impacts:
- Long-running sessions (mayor) that share rate limits with other agents
- Multi-tool-call workflows (refinery) that are rate-limit-sensitive
- Any session during high concurrent usage periods