### PR TITLE
fix(kilo-vscode): remove Cursor orange focus border

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -2747,7 +2747,7 @@ body.vscode-high-contrast-light {
 
   .prompt-input-container:focus-within,
   .model-selector-search:focus {
-    border-color: var(--vscode-contrastActiveBorder, var(--vscode-focusBorder));
+    border-color: var(--vscode-focusBorder);
   }
 
   /* Dropdowns and popover panels */
@@ -2823,7 +2823,7 @@ body.vscode-high-contrast-light {
   .feedback-button:focus-visible,
   .recent-session-item:focus-visible,
   .kilo-notifications-nav-btn:focus-visible {
-    outline: 1px solid var(--vscode-contrastActiveBorder, var(--vscode-focusBorder));
+    outline: 1px solid var(--vscode-focusBorder);
     outline-offset: -1px;
   }
 }


### PR DESCRIPTION
## Summary
VSCode extension shows orange focus borders when running under Cursor (a VSCode fork). The issue is that Cursor sets `--vscode-contrastActiveBorder` to orange, which is used as a fallback in focus border styles.

## Root Cause
In `packages/kilo-vscode/webview-ui/src/styles/chat.css`, two focus styles used:
```css
border-color: var(--vscode-contrastActiveBorder, var(--vscode-focusBorder));
outline: 1px solid var(--vscode-contrastActiveBorder, var(--vscode-focusBorder));
```
Cursor sets `--vscode-contrastActiveBorder` to orange, causing unwanted orange borders.

## Fix
Removed the `--vscode-contrastActiveBorder` variable and use `--vscode-focusBorder` directly for consistent focus styling across both VSCode and Cursor.

Changed in 2 locations (lines ~2750 and ~2826):
- `.prompt-input-container:focus-within` and `.model-selector-search:focus`
- `.scroll-to-bottom-button:focus-visible`, `.feedback-button:focus-visible`, `.recent-session-item:focus-visible`, `.kilo-notifications-nav-btn:focus-visible`

Closes #7484