### PR TITLE
docs(kilo-docs): add platform tabs to getting-started pages

### DIFF
--- a/packages/kilo-docs/lib/nav/getting-started.ts
+++ b/packages/kilo-docs/lib/nav/getting-started.ts
@@ -30,8 +30,12 @@ export const GettingStartedNav: NavSection[] = [
         children: "Settings",
         subLinks: [
           { href: "/getting-started/settings/auto-approving-actions", children: "Auto-Approving Actions" },
-          { href: "/getting-started/settings/auto-cleanup", children: "Auto Cleanup" },
-          { href: "/getting-started/settings/system-notifications", children: "System Notifications" },
+          { href: "/getting-started/settings/auto-cleanup", children: "Auto Cleanup", platform: "legacy" },
+          {
+            href: "/getting-started/settings/system-notifications",
+            children: "System Notifications",
+            platform: "legacy",
+          },
         ],
       },
       { href: "/getting-started/adding-credits", children: "Adding Credits" },

--- a/packages/kilo-docs/pages/getting-started/quickstart.md
+++ b/packages/kilo-docs/pages/getting-started/quickstart.md
@@ -5,11 +5,14 @@ description: "Get up and running with Kilo Code in minutes"
 
 # Quickstart
 
+After you [set up Kilo Code](/docs/getting-started/setup-authentication), follow the guide for your platform below.
+
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 ## Video Tour
 
 {% youtube url="https://www.youtube.com/watch?v=pO7zRLQS-p0" caption="This quick tour shows how Kilo Code handles a simple request from start to finish" /%}
-
-After you [set up Kilo Code](/docs/getting-started/setup-authentication), follow these steps:
 
 ## Step by Step Guide
 
@@ -65,6 +68,106 @@ You can learn more about [using modes](/docs/code-with-ai/agents/using-modes) an
 Kilo Code works iteratively. After each action, it waits for your feedback before proposing the next step. Continue this review-approve cycle until your task is complete.
 
 {% image src="/docs/img/your-first-task/your-first-task-8.png" alt="Final result of a completed task showing the iteration process" width="500" caption="After completing the task, Kilo Code shows the final result and awaits your next instruction." /%}
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+## Step by Step Guide
+
+### Step 1: Open Kilo Code
+
+Click the Kilo Code icon in the VS Code Primary Side Bar to open the chat panel. If you don't see the icon, verify the [extension is installed](/docs/getting-started/installing).
+
+### Step 2: Type Your Task
+
+Type a clear, concise description of what you want Kilo Code to do in the chat box. The same examples work here:
+
+- "Create a file named `hello.txt` containing 'Hello, world!'."
+- "Write a Python function that adds two numbers."
+- "Create an HTML file for a simple website with the title 'Kilo test'"
+
+No special commands or syntax needed—just use plain English.
+
+### Step 3: Send Your Task
+
+Press **Enter** to send.
+
+### Step 4: Review & Approve Actions
+
+Kilo Code analyzes your request and proposes actions. By default, most tools prompt for approval before executing. You'll see the tool name, arguments, and can approve or reject each action.
+
+To change which actions require approval, open **Settings** (gear icon) and go to the **Auto-Approve** tab. You can set each tool to Allow, Ask, or Deny. See [Auto-Approving Actions](/docs/getting-started/settings/auto-approving-actions) for details.
+
+### Step 5: Iterate
+
+Kilo Code works iteratively. Continue giving feedback or follow-up instructions until your task is complete.
+
+### Key Differences from Classic
+
+- **Settings** are managed via `kilo.json` config files (the Settings webview reads and writes the same files)
+- **Permissions** use a granular per-tool system instead of broad approval categories
+- **Modes** are called "agents" and configured as `.md` files or via the `agent` config key
+- **Autocomplete** uses FIM (Fill-in-the-Middle) with Codestral
+
+{% /tab %}
+{% tab label="CLI" %}
+
+## CLI Quickstart
+
+### Step 1: Open a Terminal
+
+Navigate to your project directory:
+
+```bash
+cd /path/to/your/project
+```
+
+### Step 2: Launch Kilo
+
+Run the `kilo` command to start the interactive TUI (terminal user interface):
+
+```bash
+kilo
+```
+
+If this is your first time, run `kilo auth login` first to authenticate (see [Setup & Authentication](/docs/getting-started/setup-authentication)).
+
+### Step 3: Type Your Task
+
+Type your request in natural language at the prompt. The same examples work here:
+
+- "Create a file named `hello.txt` containing 'Hello, world!'."
+- "Write a Python function that adds two numbers."
+- "Create an HTML file for a simple website with the title 'Kilo test'"
+
+Press **Enter** to send.
+
+### Step 4: Review & Approve Actions
+
+Kilo analyzes your request and proposes actions. By default, most tools prompt for approval before executing. You'll see the tool name, arguments, and can approve or reject each action.
+
+To change permission defaults, configure the `permission` key in your `kilo.json` config file. See [Auto-Approving Actions](/docs/getting-started/settings/auto-approving-actions) for details.
+
+### Step 5: Iterate
+
+Kilo works iteratively. Continue giving feedback or follow-up instructions until your task is complete.
+
+### One-Shot Mode
+
+For quick, non-interactive tasks, use `kilo run`:
+
+```bash
+kilo run "add error handling to src/api.ts"
+```
+
+Add `--auto` to auto-approve all permissions (use carefully):
+
+```bash
+kilo run --auto "fix the failing tests in test/auth.test.ts"
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Conclusion
 

--- a/packages/kilo-docs/pages/getting-started/settings/auto-approving-actions.md
+++ b/packages/kilo-docs/pages/getting-started/settings/auto-approving-actions.md
@@ -9,7 +9,10 @@ description: "Configure automatic approval settings for Kilo Code operations"
 **Security Warning:** Auto-approve settings bypass confirmation prompts, giving Kilo Code direct access to your system. This can result in data loss, file corruption, or worse. Command line access is particularly dangerous, as it can potentially execute harmful operations that could damage your system or compromise security. Only enable auto-approval for actions you fully trust.
 {% /callout %}
 
-Auto-approve settings speed up your workflow by eliminating repetitive confirmation prompts, but they significantly increase security risks.
+Auto-approve settings speed up your workflow by eliminating repetitive confirmation prompts, but they significantly increase security risks. The **VSCode (Legacy)**, **VSCode**, and **CLI** versions each handle permissions differently — choose the tab that matches your setup.
+
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
 
 ## Quick Start Guide
 
@@ -343,3 +346,250 @@ You can optionally enable an AI Safety Gatekeeper, which reviews every intended 
 
 This is the fastest way to work with Kilo Code, but also the riskiest. Use it only when you fully trust the AI and are prepared for the consequences.
 {% /callout %}
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+## Overview
+
+The new extension uses a granular, per-tool permission system. You can configure permissions through the **Settings → Auto Approve** tab, which provides a UI with per-tool **Allow / Ask / Deny** dropdowns.
+
+The UI reads and writes to the same `kilo.json` config files used by the CLI, so changes made in either place are reflected in both.
+
+## Permission Levels
+
+Each tool permission can be set to one of three values:
+
+| Value     | Behavior                                                  |
+| --------- | --------------------------------------------------------- |
+| `"allow"` | The tool runs automatically without prompting             |
+| `"ask"`   | Kilo pauses and asks for approval before running the tool |
+| `"deny"`  | The tool is blocked entirely                              |
+
+When no rule matches a permission check, the default action is `ask`.
+
+## Available Tool Permissions
+
+The Auto Approve tab lists the following tool-specific permissions:
+
+| Permission           | Controls                                               |
+| -------------------- | ------------------------------------------------------ |
+| `read`               | Reading file contents                                  |
+| `edit`               | Editing existing files                                 |
+| `glob`               | File pattern matching / searching by name              |
+| `grep`               | Searching file contents by regex                       |
+| `list`               | Listing directory contents                             |
+| `bash`               | Executing shell commands                               |
+| `task`               | Launching sub-agents                                   |
+| `skill`              | Loading specialized skills                             |
+| `lsp`                | Language server protocol operations                    |
+| `todoread`           | Reading the todo list                                  |
+| `todowrite`          | Updating the todo list                                 |
+| `webfetch`           | Fetching content from URLs                             |
+| `websearch`          | Performing web searches                                |
+| `codesearch`         | Searching code examples and documentation              |
+| `external_directory` | Accessing files outside the project directory          |
+| `doom_loop`          | Allowing the agent to continue after repeated failures |
+
+## Set All (Bulk Control)
+
+Use the **Set All** control to quickly set all tools to the same permission level (`allow`, `ask`, or `deny`). This is useful for:
+
+- Quickly locking down all permissions before working on sensitive code
+- Opening up all permissions for rapid prototyping in a safe environment
+- Resetting to a known baseline
+
+## Runtime Permission Requests
+
+When a tool is set to `"ask"`, Kilo pauses and displays a permission request popup. You have three options:
+
+| Option     | Behavior                                                 |
+| ---------- | -------------------------------------------------------- |
+| **Once**   | Allow this specific invocation only                      |
+| **Always** | Allow this tool (or pattern) for the rest of the session |
+| **Reject** | Block this specific invocation                           |
+
+## Defaults
+
+Most tools default to `"*": "allow"` for a smooth out-of-the-box experience. Notable exceptions that prompt by default:
+
+- **`.env` files** — reading `.env` files prompts for approval. Files matching `*.env.*` (e.g., `.env.local`, `.env.production`) also trigger an ask, while `*.env.example` is explicitly allowed.
+- **`external_directory`** — accessing files outside the project prompts for approval
+- **`doom_loop`** — prompts when the agent enters a repeated failure cycle
+
+{% /tab %}
+{% tab label="CLI" %}
+
+## Overview
+
+The CLI uses a granular, per-tool permission system configured in `kilo.json`. Instead of broad categories like "read" or "write," each tool has its own permission level with glob-pattern rules for fine-grained control.
+
+## Permission Levels
+
+Each tool permission can be set to one of three values:
+
+| Value     | Behavior                                                  |
+| --------- | --------------------------------------------------------- |
+| `"allow"` | The tool runs automatically without prompting             |
+| `"ask"`   | Kilo pauses and asks for approval before running the tool |
+| `"deny"`  | The tool is blocked entirely                              |
+
+When no rule matches a permission check, the default action is `ask`.
+
+## Available Tool Permissions
+
+Permissions are configured under the `permission` key in `kilo.json`. The following tool-specific permission levels are available:
+
+| Permission           | Controls                                               |
+| -------------------- | ------------------------------------------------------ |
+| `read`               | Reading file contents                                  |
+| `edit`               | Editing existing files                                 |
+| `glob`               | File pattern matching / searching by name              |
+| `grep`               | Searching file contents by regex                       |
+| `list`               | Listing directory contents                             |
+| `bash`               | Executing shell commands                               |
+| `task`               | Launching sub-agents                                   |
+| `skill`              | Loading specialized skills                             |
+| `lsp`                | Language server protocol operations                    |
+| `todoread`           | Reading the todo list                                  |
+| `todowrite`          | Updating the todo list                                 |
+| `webfetch`           | Fetching content from URLs                             |
+| `websearch`          | Performing web searches                                |
+| `codesearch`         | Searching code examples and documentation              |
+| `external_directory` | Accessing files outside the project directory          |
+| `doom_loop`          | Allowing the agent to continue after repeated failures |
+
+## Glob-Pattern Rules
+
+Instead of a simple `"allow"` or `"deny"`, each tool can use glob-pattern rules for granular control. Patterns are matched against the tool's arguments (command strings, file paths, etc.), and the last matching rule wins.
+
+### Example: Shell Commands
+
+Allow git commands automatically, but prompt for everything else:
+
+```json
+{
+  "permission": {
+    "bash": {
+      "git *": "allow",
+      "*": "ask"
+    }
+  }
+}
+```
+
+### Example: File Reading
+
+Prompt before reading `.env` files, but allow all other reads:
+
+```json
+{
+  "permission": {
+    "read": {
+      "*.env": "ask",
+      "*": "allow"
+    }
+  }
+}
+```
+
+### Example: Blocking Dangerous Commands
+
+Deny `rm -rf` commands, allow common dev commands, and ask for anything else:
+
+```json
+{
+  "permission": {
+    "bash": {
+      "rm -rf *": "deny",
+      "npm *": "allow",
+      "bun *": "allow",
+      "git *": "allow",
+      "*": "ask"
+    }
+  }
+}
+```
+
+## Per-Agent Permission Overrides
+
+Different agents can have different permission levels. Override the default permissions for a specific agent under the `agent.<name>.permission` key:
+
+```json
+{
+  "permission": {
+    "bash": { "*": "ask" }
+  },
+  "agent": {
+    "code": {
+      "permission": {
+        "bash": { "git *": "allow", "*": "ask" }
+      }
+    },
+    "plan": {
+      "permission": {
+        "bash": { "*": "deny" }
+      }
+    }
+  }
+}
+```
+
+In this example, the `code` agent can run `git` commands automatically and asks for other shell commands, while the `plan` agent cannot run shell commands at all.
+
+## Runtime Permission Requests
+
+When a tool is set to `"ask"`, Kilo pauses and displays a permission request popup. You have three options:
+
+| Option     | Behavior                                                 |
+| ---------- | -------------------------------------------------------- |
+| **Once**   | Allow this specific invocation only                      |
+| **Always** | Allow this tool (or pattern) for the rest of the session |
+| **Reject** | Block this specific invocation                           |
+
+## Defaults
+
+Most tools default to `"*": "allow"` for a smooth out-of-the-box experience. Notable exceptions that prompt by default:
+
+- **`.env` files** — reading `.env` files prompts for approval. Files matching `*.env.*` (e.g., `.env.local`, `.env.production`) also trigger an ask, while `*.env.example` is explicitly allowed.
+- **`external_directory`** — accessing files outside the project prompts for approval
+- **`doom_loop`** — prompts when the agent enters a repeated failure cycle
+
+## Full Configuration Example
+
+{% callout type="info" %}
+This is a custom example showing the available configuration options — it does not represent the shipped defaults.
+{% /callout %}
+
+```json
+{
+  "permission": {
+    "read": { "*.env": "ask", "*": "allow" },
+    "edit": { "*.env": "ask", "*": "allow" },
+    "glob": { "*": "allow" },
+    "grep": { "*": "allow" },
+    "list": { "*": "allow" },
+    "bash": { "git *": "allow", "npm *": "allow", "*": "ask" },
+    "task": { "*": "allow" },
+    "skill": { "*": "allow" },
+    "lsp": { "*": "allow" },
+    "todoread": { "*": "allow" },
+    "todowrite": { "*": "allow" },
+    "webfetch": { "*": "allow" },
+    "websearch": { "*": "allow" },
+    "codesearch": { "*": "allow" },
+    "external_directory": { "*": "ask" },
+    "doom_loop": { "*": "ask" }
+  },
+  "agent": {
+    "code": {
+      "permission": {
+        "bash": { "git *": "allow", "npm *": "allow", "*": "ask" }
+      }
+    }
+  }
+}
+```
+
+{% /tab %}
+{% /tabs %}

--- a/packages/kilo-docs/pages/getting-started/settings/auto-cleanup.md
+++ b/packages/kilo-docs/pages/getting-started/settings/auto-cleanup.md
@@ -1,3 +1,7 @@
+---
+platform: legacy
+---
+
 # Auto Cleanup
 
 Auto Cleanup automatically manages your task history by removing old tasks to free up disk space and improve performance. Tasks are intelligently classified and retained based on their type and age, ensuring important work is preserved while temporary or experimental tasks are cleaned up.

--- a/packages/kilo-docs/pages/getting-started/settings/index.md
+++ b/packages/kilo-docs/pages/getting-started/settings/index.md
@@ -5,13 +5,20 @@ description: "Configure Kilo Code settings and preferences"
 
 # Settings
 
+Kilo Code offers multiple platforms, each with its own approach to configuration. The **VSCode (Legacy)** version uses the VS Code settings UI with export/import/reset workflows. The current **VSCode** extension provides a Settings webview that reads and writes to JSONC config files. The **CLI** uses portable JSONC config files directly.
+
+## Managing Settings
+
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 Kilo Code allows you to manage your configuration settings effectively through export, import, and reset options. These features are useful for backing up your setup, sharing configurations with others, or restoring default settings if needed.
 
 You can find these options at the bottom of the Kilo Code settings page, accessible via the gear icon ({% codicon name="gear" /%}) in the Kilo Code chat view.
 
 {% image src="/docs/img/settings-management/settings-management.png" alt="Export, Import, and Reset buttons in Kilo Code settings" width="800" caption="Export, Import, and Reset buttons" /%}
 
-## Export Settings
+### Export Settings
 
 Clicking the **Export** button saves your current Kilo Code settings to a JSON file.
 
@@ -24,7 +31,7 @@ Clicking the **Export** button saves your current Kilo Code settings to a JSON f
 
 This creates a backup of your configuration or a file you can share.
 
-## Import Settings
+### Import Settings
 
 Clicking the **Import** button allows you to load settings from a previously exported JSON file.
 
@@ -35,7 +42,7 @@ Clicking the **Import** button allows you to load settings from a previously exp
 - **Merging:** Importing settings **merges** the configurations. It adds new API profiles and updates existing ones and global settings based on the file content. It does **not** delete configurations present in your current setup but missing from the imported file.
 - **Validation:** Only valid settings matching the internal schema can be imported, preventing configuration errors. A success notification appears upon completion.
 
-## Reset Settings
+### Reset Settings
 
 Clicking the **Reset** button completely clears all Kilo Code configuration data and returns the extension to its default state. This is a destructive action intended for troubleshooting or starting fresh.
 
@@ -57,7 +64,88 @@ Clicking the **Reset** button completely clears all Kilo Code configuration data
 
 Use this option only if you are certain you want to remove all Kilo Code data or if instructed during troubleshooting. Consider exporting your settings first if you might want to restore them later.
 
+{% /tab %}
+{% tab label="VSCode" %}
+
+The VS Code extension provides a **Settings webview UI** accessible from the extension sidebar by clicking the gear icon ({% codicon name="gear" /%}). The UI is organized into tabs including Providers, Auto-Approve, Models, and more.
+
+This UI reads and writes to the same underlying JSONC config files used by the CLI, so changes made in either place are reflected in both.
+
+### Config File Locations
+
+There are two primary config files:
+
+- **Global config:** `~/.config/kilo/kilo.json` -- applies to all projects.
+- **Project config:** `kilo.json` in the root of your project -- overrides global settings for that project.
+
+### Config File Precedence
+
+Settings are resolved through an 8-level precedence system (lowest to highest priority):
+
+1. **Legacy Kilocode** -- migrated settings from the VSCode extension
+2. **Remote well-known** -- remotely fetched defaults
+3. **Global** -- `~/.config/kilo/kilo.json`
+4. **Custom** -- additional custom config paths
+5. **Project** -- `kilo.json` in the project root
+6. **`.kilo` directory** -- config from a `.kilo/` directory in the project
+7. **Inline environment** -- environment variable overrides
+8. **Managed / Enterprise** -- enterprise-managed configuration (highest priority)
+
+Higher-priority levels override lower ones. This allows organizations to enforce settings at the enterprise level while still letting individual developers customize their local environment.
+
+### Export and Import
+
+There is no traditional export/import of settings -- the JSONC config files themselves are portable. Copy `~/.config/kilo/kilo.json` or `kilo.json` to another machine and you're done.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+In the CLI, settings are managed via **JSONC config files** directly. Config files are plain-text and portable -- you can copy them between machines or check them into version control.
+
+### Config File Locations
+
+There are two primary config files:
+
+- **Global config:** `~/.config/kilo/kilo.json` -- applies to all projects.
+- **Project config:** `kilo.json` in the root of your project -- overrides global settings for that project.
+
+Both files use the [JSONC](https://code.visualstudio.com/docs/languages/json#_json-with-comments) format (JSON with comments).
+
+### Config File Precedence
+
+Settings are resolved through an 8-level precedence system (lowest to highest priority):
+
+1. **Legacy Kilocode** -- migrated settings from the VSCode extension
+2. **Remote well-known** -- remotely fetched defaults
+3. **Global** -- `~/.config/kilo/kilo.json`
+4. **Custom** -- additional custom config paths
+5. **Project** -- `kilo.json` in the project root
+6. **`.kilo` directory** -- config from a `.kilo/` directory in the project
+7. **Inline environment** -- environment variable overrides
+8. **Managed / Enterprise** -- enterprise-managed configuration (highest priority)
+
+Higher-priority levels override lower ones. This allows organizations to enforce settings at the enterprise level while still letting individual developers customize their local environment.
+
+### Schema Auto-Injection
+
+When you create or open a `kilo.json` file, the CLI automatically injects a `$schema` property pointing to the config JSON schema. This gives you **autocompletion and validation** in any editor that supports JSON Schema (VS Code, JetBrains, etc.).
+
+### Export and Import
+
+There is no traditional export/import of settings -- the JSONC config files themselves are portable. Copy `~/.config/kilo/kilo.json` or `kilo.json` to another machine and you're done.
+
+For **session** export and import, use the CLI commands:
+
+- `kilo export` -- export session data
+- `kilo import` -- import session data
+
+{% /tab %}
+{% /tabs %}
+
 ## Experimental Features
+
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
 
 {% callout type="info" %}
 These features are experimental and may change in future releases. They provide advanced control over Kilo Code's behavior for specific use cases.
@@ -106,3 +194,16 @@ This setting controls the number of lines read from a file in one batch. To mana
 **Default:** Set in Advanced Settings
 
 You can find this setting in the Kilo Code settings under 'Advanced Settings'.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+The new extension does not currently expose the same experimental feature toggles as the **VSCode** version. Advanced options are configured via the JSONC config files that the Settings webview reads and writes. Refer to the auto-generated `$schema` in your `kilo.json` for the full list of available options.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+The CLI does not currently expose the same experimental feature toggles as the **VSCode** version. Configuration of model behavior, file editing strategies, and other advanced options is handled directly in the JSONC config files. Refer to the auto-generated `$schema` in your `kilo.json` for the full list of available options.
+
+{% /tab %}
+{% /tabs %}

--- a/packages/kilo-docs/pages/getting-started/settings/system-notifications.md
+++ b/packages/kilo-docs/pages/getting-started/settings/system-notifications.md
@@ -1,6 +1,7 @@
 ---
 title: "System Notifications"
 description: "Configure native OS notifications for Kilo Code"
+platform: legacy
 ---
 
 # System Notifications

--- a/packages/kilo-docs/pages/getting-started/setup-authentication.md
+++ b/packages/kilo-docs/pages/getting-started/setup-authentication.md
@@ -9,6 +9,9 @@ When you install Kilo Code, you'll be prompted to sign in or create a free accou
 
 ## Quick Start with Kilo Account
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1. Click **"Try Kilo Code for Free"** in the extension
 2. Sign in with your Google account
 3. Allow VS Code to open the authorization URL
@@ -16,6 +19,31 @@ When you install Kilo Code, you'll be prompted to sign in or create a free accou
 {% image src="/docs/img/signupflow.gif" alt="Sign up and registration flow with Kilo Code" /%}
 
 That's it! You're ready to [start your first task](/docs/getting-started/quickstart).
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+The extension prompts you to sign in when you first open the sidebar. Click **Sign In** and complete the browser-based flow. The extension communicates with the CLI backend, so authentication is shared between the CLI and extension.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Run the auth command and follow the browser-based sign-in flow:
+
+```bash
+kilo auth login
+```
+
+This may open your browser to complete authentication. Once signed in, your credentials are stored locally and used for all future sessions.
+
+To verify your auth status:
+
+```bash
+kilo auth list
+```
+
+{% /tab %}
+{% /tabs %}
 
 {% callout type="tip" title="Bonus Credits" %}
 [Add credits to your account](https://app.kilo.ai/profile) and get $20 bonus credits, or sign up for [Kilo Pass](https://kilo.ai/features/kilo-pass).
@@ -75,11 +103,47 @@ Already have a ChatGPT subscription? You can use it with Kilo Code through the [
 
 ### Configuring Your Provider
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1. Click the {% kilo-code-icon /%} icon in the VS Code sidebar
 2. Select your API provider from the dropdown
 3. Paste your API key
-4. Choose your model:
+4. Choose your model
 5. Click **"Let's go!"**
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+1. Open the Kilo Code sidebar in VS Code
+2. Click the gear icon ({% codicon name="gear" /%}) to open **Settings**
+3. Go to the **Providers** tab
+4. Select your provider and enter your API key
+5. Choose your model
+
+You can also use `kilo auth login` for providers that support OAuth (like GitHub Copilot). The extension reads from the same underlying config files as the CLI, so provider settings are shared.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+Or use `kilo auth login` for providers that support OAuth (like GitHub Copilot).
+
+To set a default model:
+
+```jsonc
+{
+  "model": "anthropic/claude-sonnet-4-20250514",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 {% callout type="info" title="Need Help?" %}
 Reach out to our [support team](mailto:hi@kilo.ai) or join our [Discord community](https://kilo.ai/discord).


### PR DESCRIPTION
## Summary

Adds VSCode (Pre-release) and CLI tabs to the getting-started section. **PR 2 of 8** from the docs platform tabs effort.

### Pages updated

- **quickstart.md** — New tabs with auth flow (`kilo auth login`), non-interactive mode (`kilo run --auto`), config overview, agent/permission system intro
- **setup-authentication.md** — Tabbed auth flows: VSCode UI settings, extension Providers tab, CLI env vars + `kilo auth login`
- **settings/index.md** — Config file locations (`kilo.json`), 8-level precedence system, schema auto-injection, session export/import
- **auto-approving-actions.md** — Granular per-tool permission system with Allow/Ask/Deny, glob patterns, last-match-wins evaluation

### Fixes from code validation

- **Removed false "Variable Substitution" section** from settings/index.md — `{env:VAR_NAME}` and `{file:path}` interpolation does not exist in `packages/opencode/src/config/`
- **Replaced misleading provider `env` config format** in setup-authentication.md — the `"env": ["API_KEY"]` format is models.dev metadata, not user-facing config

### All claims verified against code

| Claim | File | Evidence |
|-------|------|----------|
| `kilo auth login` | `cli/cmd/auth.ts:268` | ✅ |
| `kilo run --auto` | `cli/cmd/run.ts:315-320` | ✅ |
| `kilo auth list` | `cli/cmd/auth.ts:214-266` | ✅ |
| `kilo export` / `kilo import` | `cli/cmd/export.ts`, `cli/cmd/import.ts` | ✅ |
| Global config `~/.config/kilo/kilo.json` | `global/index.ts:7,11` | ✅ |
| 8-level config precedence | `config.ts:1308-1353` | ✅ |
| Per-tool Allow/Ask/Deny permissions | `config.ts:743-774` | ✅ |
| Last-match-wins (`findLast`) | `permission/next.ts:340` | ✅ |
| Default permissions (bash=ask, etc.) | `agent.ts:66-81` | ✅ |

Depends on #7497 for infrastructure.