### PR TITLE
fix(vscode): auto-submit custom question answer on Enter and make collapsed dock clickable

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -173,6 +173,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
 
     pick(value, true)
     setStore("editing", false)
+    if (single()) submit()
   }
 
   const toggleCollapse = () => setStore("collapsed", !store.collapsed)
@@ -217,14 +218,14 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
       onKeyDown={onRoot}
     >
       {/* Single unified header row — always visible */}
-      <div data-slot="question-dock-header">
+      <div data-slot="question-dock-header" onClick={toggleCollapse}>
         <div data-slot="question-dock-header-content">
           <div data-slot="question-header-title">{summary()}</div>
           <Show when={store.collapsed}>
             <div data-slot="question-collapsed-preview">{question()?.question}</div>
           </Show>
         </div>
-        <div data-slot="question-header-actions">
+        <div data-slot="question-header-actions" onClick={(e: MouseEvent) => e.stopPropagation()}>
           <Show when={!store.collapsed && !single()}>
             <div data-slot="question-progress">
               <button


### PR DESCRIPTION
## Summary
- Custom text answers in single-select, single-question scenarios now submit immediately on Enter, instead of requiring a separate Submit button click
- Clicking anywhere on the collapsed question dock header expands it (not just the chevron button)
- Header action buttons (nav, chevron) stop event propagation to prevent double-toggle