### PR TITLE
feat(vscode): add debug logging for telemetry events

### DIFF
--- a/packages/kilo-vscode/src/services/telemetry/telemetry-proxy.ts
+++ b/packages/kilo-vscode/src/services/telemetry/telemetry-proxy.ts
@@ -20,6 +20,7 @@ export class TelemetryProxy {
   }
 
   static capture(event: TelemetryEventName, properties?: Record<string, unknown>) {
+    console.log("[telemetry]", event, properties ?? "")
     TelemetryProxy.getInstance().capture(event, properties)
   }
 


### PR DESCRIPTION
## Summary

- Add `console.log` for telemetry events in `TelemetryProxy.capture()` so event names and properties are visible in the Extension Host output channel

## Context

The legacy Cline-based extension had telemetry debug logging that made it easy to see which events were firing and with what data during development. This was lost in the rewrite to the new extension architecture. This restores that visibility.
