### PR TITLE
docs(kilo-docs): add platform tabs to agent-manager page

### DIFF
--- a/.kilo/plans/1774328102661-tidy-river.md
+++ b/.kilo/plans/1774328102661-tidy-river.md
@@ -1,0 +1,770 @@
+# Plan: Break PR #6831 Into Manageable PRs
+
+## Context
+
+PR #6831 (`docs/version-switcher`) adds platform tabs across the entire docs site for VSCode, VSCode (Pre-release), and CLI. It touches **103 files** across `packages/kilo-docs/` with 5,677 additions and 388 deletions. The PR also includes non-docs code changes (extension, CLI, i18n, etc.) that are unrelated to the docs effort.
+
+The branch is stale — it predates several commits to `main` (e.g., VSIX rollback guidance from PR #7372). A rebase produces extensive merge conflicts due to the breadth of changes.
+
+### Principles
+
+- **DO NOT change existing docs for the old extension unless fixing a factual error**
+- Validate old extension behavior against `../kilocode-legacy`
+- Validate new extension/CLI behavior against this repo (`packages/opencode/`, `packages/kilo-vscode/`)
+- Each PR should be self-contained and reviewable independently
+- Infrastructure PR must land first (others depend on tabs/badges)
+
+---
+
+## Proposed PR Breakdown
+
+### PR 1: Infrastructure + Platform Markers (frontmatter-only)
+
+**~35 files — low risk, mechanical**
+
+Components and config that all other PRs depend on:
+
+- `components/Tabs.tsx` — hydration fix
+- `components/SideNav.tsx` — PlatformBadge component
+- `components/PageVersionSwitcher.tsx` — banner text updates
+- `components/index.js` — exports
+- `pages/_app.tsx` — reads `frontmatter.platform`
+- `lib/types.ts` — Platform type definition
+- `lib/nav/*.ts` — platform tags on nav items
+- `lychee.toml`, `package.json`, `source-links.md`
+- `previous-docs-redirects.js` — redirect for deleted `using-in-cli.md`
+- All ~25 frontmatter-only changes (`platform: classic` or `platform: next`):
+  - 15 tool pages, `auto-launch.md`, `how-tools-work.md`, `tools/index.md`
+  - `fast-edits.md`, `speech-to-text.md`, `task-todo-list.md`
+  - `codebase-indexing.md`, `large-projects.md`
+  - `custom-subagents.md`, `workflows.md`
+  - `auto-cleanup.md`, `system-notifications.md`
+  - `jetbrains.md`
+
+**Validation needed:**
+
+- Confirm each `platform: classic` page is truly classic-only (not available in new CLI/extension)
+- Confirm each `platform: next` page is truly new-only
+- Verify `PlatformBadge` and nav tag rendering works correctly
+
+### PR 2: Getting Started (5-7 pages)
+
+- `installing.md` — revert VSIX rollback deletion only
+- `quickstart.md` — new VSCode (Pre-release) and CLI tabs
+- `setup-authentication.md` — tabbed auth flows
+- `settings/index.md` — tabbed settings management
+- `settings/auto-approving-actions.md` — tabbed permission systems
+
+**Validation needed for each new tab:**
+
+- Does `kilo auth login` exist? What's the exact flow?
+- Does `kilo run` exist with `--auto` flag?
+- Are permissions configured via `permission` key in `kilo.json`?
+- Does the Settings webview read/write `kilo.json` config files?
+- What are the actual Settings UI navigation paths in the pre-release extension?
+- Config file names/paths — verify against `packages/opencode/src/config/`
+- Permission evaluation order — verify first-match vs last-match
+
+### PR 3: Code with AI — Agents (5 pages)
+
+- `chat-interface.md`
+- `using-modes.md`
+- `context-mentions.md`
+- `model-selection.md`
+- `orchestrator-mode.md`
+
+**Validation needed:**
+
+- Does the new extension have @-mentions? (plan says it does)
+- Are modes called "agents"? What are the built-in agents?
+- Does CLI TUI have `@`-mention autocomplete?
+- Does `--file` flag exist only on `kilo run`?
+- Does `docs` subagent exist? (plan says no)
+- Does `architect` agent exist? (plan says no)
+- Verify heading renames are reverted (plan identified ~25)
+- Verify content deletions are reverted (plan identified ~17)
+
+### PR 4: Code with AI — Features (7 pages)
+
+- `autocomplete/index.md`
+- `code-actions.md`
+- `git-commit-generation.md`
+- `browser-use.md`
+- `checkpoints.md`
+- `platforms/vscode.md`
+- `platforms/cli.md`
+
+**Validation needed:**
+
+- Autocomplete: FIM with Codestral — verify against `packages/kilo-vscode/src/services/autocomplete/`
+- Browser headless default — `true` or `false`?
+- Checkpoints encoding bugs — `→` corrupted to `â`?
+- `checkpoints.md` — `config.snapshot` vs `snapshot`
+- Code actions: exact terminal action names
+
+### PR 5: Customize (7 pages)
+
+- `custom-modes.md`
+- `custom-rules.md`
+- `custom-instructions.md`
+- `agents-md.md`
+- `skills.md`
+- `context/kilocodeignore.md`
+- `context/context-condensing.md`
+
+**Validation needed:**
+
+- Agent config format: `.kilo/agents/*.md` with YAML frontmatter?
+- Custom rules path: `.kilo/` directory, `instructions` config key?
+- `.kilocodeignore` evaluation: first-match or last-match? (code uses `findLast()`)
+- `KILO_DISABLE_EXTERNAL_SKILLS` — does it disable agent files or only skills?
+- Verify wording/formatting reverts needed
+
+### PR 6: Automate — Agent Manager (standalone)
+
+- `agent-manager.md`
+
+**Validation needed (extensive — 8 review comments from @marius-kilocode):**
+
+- Parallel mode → worktree architecture (multi-version mode)
+- Worktree path: `.kilo/worktrees/` not `.kilocode/worktrees/`
+- No automated cleanup (manual removal via trash icon)
+- CLI is bundled — not a prerequisite
+- Local card concept (sessions without worktrees)
+- Session promotion flow
+- Review button flow
+- Keyboard shortcuts — verify against `package.json` keybindings
+
+### PR 7: Automate — MCP + Shell Integration (3-4 pages)
+
+- `mcp/using-in-kilo-code.md`
+- `mcp/using-in-cli.md` (deleted, merged into above)
+- `extending/shell-integration.md`
+- `automate/index.md` (stale link fix)
+
+**Validation needed:**
+
+- Config table file paths/names
+- MCP timeout: 5000 vs 30000?
+- SSE transport: "Classic Only" or also CLI?
+- Missing MCP commands: `logout`, `debug`
+- Broken anchor: `#understanding-transport-types`
+
+### PR 8: AI Providers (30 pages)
+
+- `ai-providers/index.md`
+- 29 individual provider pages
+
+**Validation needed (high priority — many confirmed wrong):**
+
+- Provider IDs: bedrock→amazon-bedrock, fireworks→fireworks-ai, chutes-ai→chutes, moonshot→moonshotai, vercel-ai-gateway→vercel
+- Env vars: vertex, sap-ai-core, vercel, ovhcloud
+- Unsupported providers: glama, unbound (no CLI config)
+- `groq.md` "Tips and Notes" section deletion — should be reverted
+
+---
+
+## Validation Approach
+
+For each PR, before writing any content:
+
+1. **Old extension claims** — check `../kilocode-legacy` source code
+2. **New extension claims** — check `packages/kilo-vscode/` source code
+3. **CLI claims** — check `packages/opencode/` source code, especially:
+   - `src/config/` — config file handling, file names, paths
+   - `src/cli/cmd/` — CLI commands, flags
+   - `src/agent/` — agent definitions
+   - `src/tool/` — tool definitions
+   - `src/permission/` — permission system (first-match vs last-match)
+   - `src/provider/` — provider IDs and env vars
+4. **Unnecessary changes** — diff each file, flag any heading renames, content deletions, wording changes, formatting changes that aren't tab-wrapping or new tab content
+
+---
+
+---
+
+## Code-Verified Findings: PR 2 (Getting Started)
+
+### `installing.md` — REVERT ONLY
+
+The only diff is deletion of the VSIX rollback paragraph (added to `main` by PR #7372 after the branch was created). This content is accurate and should be kept.
+
+**Action:** Revert the deletion. No new tab content needed — the installing page already has platform tabs on main.
+
+---
+
+### `quickstart.md` — NEW TABS ARE MOSTLY CORRECT
+
+The PR adds new VSCode (Pre-release) and CLI tabs. Existing VSCode tab content is untouched except the intro sentence moved above the tabs (acceptable).
+
+**Verified claims:**
+
+| Claim                                    | Status | Evidence                                              |
+| ---------------------------------------- | ------ | ----------------------------------------------------- |
+| `kilo auth login` exists                 | ✅     | `packages/opencode/src/cli/cmd/auth.ts:268`           |
+| `kilo run` with `--auto` flag            | ✅     | `packages/opencode/src/cli/cmd/run.ts:315-320`        |
+| Settings managed via `kilo.json`         | ✅     | `packages/opencode/src/config/config.ts`              |
+| Permissions use granular per-tool system | ✅     | `AutoApproveTab.tsx`, `permission/next.ts`            |
+| Modes called "agents"                    | ✅     | `packages/opencode/src/agent/agent.ts:86-333`         |
+| Agents configured as `.md` files         | ✅     | Agent schema supports markdown frontmatter            |
+| Autocomplete uses FIM with Codestral     | ✅     | `AutocompleteModel.ts:4` — `mistralai/codestral-2508` |
+
+**Issues found:**
+
+- None — new tab content is factually accurate
+
+**Action:** Keep as-is.
+
+---
+
+### `setup-authentication.md` — MOSTLY CORRECT, ONE FIX
+
+New tabs added for VSCode (Pre-release) and CLI auth flows.
+
+**Verified claims:**
+
+| Claim                           | Status | Evidence                                                 |
+| ------------------------------- | ------ | -------------------------------------------------------- |
+| `kilo auth login` opens browser | ✅     | OAuth providers do; API key providers prompt in terminal |
+| `kilo auth list` shows status   | ✅     | `auth.ts:214-266` — shows credentials + env vars         |
+| Extension shares auth with CLI  | ✅     | Extension communicates via CLI backend                   |
+
+**Issues found:**
+
+1. **Provider config example is misleading.** The CLI tab shows:
+
+   ```jsonc
+   { "provider": { "anthropic": { "env": ["ANTHROPIC_API_KEY"] } } }
+   ```
+
+   The `env` field is models.dev metadata format, not typical user config. The correct user-facing approach is either:
+   - Set `ANTHROPIC_API_KEY` as an env var (already shown in the next code block ✅)
+   - Or use `"provider": { "anthropic": { "options": { "apiKey": "sk-..." } } }`
+
+   **Fix:** Remove the `env` config example since the env var approach is already shown directly below it. Or replace with the `options.apiKey` format.
+
+2. **Minor:** Colon removed from "4. Choose your model:" → "4. Choose your model" in the VSCode tab. Unnecessary change to existing content.
+
+   **Fix:** Revert the colon deletion.
+
+---
+
+### `settings/index.md` — ONE FACTUAL ERROR, CONTENT DUPLICATION
+
+New tabs with config file locations, precedence, and feature docs.
+
+**Verified claims:**
+
+| Claim                                       | Status | Evidence                                                        |
+| ------------------------------------------- | ------ | --------------------------------------------------------------- |
+| Global config at `~/.config/kilo/kilo.json` | ✅     | `global/index.ts:7,11` — app="kilo", path=$XDG_CONFIG_HOME/kilo |
+| Project config at `./kilo.json`             | ✅     | `config.ts:219-222`                                             |
+| 8-level precedence system                   | ✅     | Config loading order in `config.ts:1308-1353`                   |
+| `$schema` auto-injection                    | ✅     | `config.ts:1382-1385`                                           |
+| `kilo export` / `kilo import`               | ✅     | `cli/cmd/export.ts`, `cli/cmd/import.ts`                        |
+
+**Issues found:**
+
+1. **FACTUAL ERROR: Variable substitution does not exist.** The CLI tab claims:
+
+   > Config files support two forms of variable substitution:
+   >
+   > - `{env:VAR_NAME}` — replaced with the value of the environment variable
+   > - `{file:path}` — replaced with the contents of the file at path
+
+   This is **FALSE**. Searched `packages/opencode/src/config/` — zero matches for `{env:`, `{file:`, or any interpolation/substitution logic. The config loading code (`loadFile` at lines 1352-1399) does straight JSON/JSONC parse with Zod, no string interpolation.
+
+   **Fix:** Remove the entire "Variable Substitution" section.
+
+2. **Content duplication.** The "Config File Locations" and "Config File Precedence" sections are copy-pasted between the VSCode (Pre-release) and CLI tabs. Since these are identical, they should be shared content outside the tabs.
+
+   **Fix:** Move shared config location/precedence content above or below the tabs, or into a single "VSCode (Pre-release) & CLI" tab.
+
+3. **Config filename recommendation.** Both tabs recommend `kilo.json` but the CLI's `globalConfigFile()` defaults to creating `kilo.jsonc` when no file exists yet (`config.ts:1448`). For project-level, `kilo.jsonc` is loaded before `kilo.json` (higher precedence). Consider recommending `kilo.jsonc` or at least noting both work.
+
+4. **Heading demotions** (## → ###) for Export/Import/Reset in the VSCode tab are acceptable — structurally necessary since they're now nested under "Managing Settings."
+
+---
+
+### `auto-approving-actions.md` — EXTENSIVE NEW CONTENT, WELL-VERIFIED
+
+Adds detailed Pre-release and CLI tabs documenting the granular permission system.
+
+**Verified claims:**
+
+| Claim                                    | Status | Evidence                                                     |
+| ---------------------------------------- | ------ | ------------------------------------------------------------ |
+| Per-tool Allow/Ask/Deny                  | ✅     | `AutoApproveTab.tsx:13-17`                                   |
+| `permission` key in `kilo.json`          | ✅     | `config.ts:1269`                                             |
+| All 17 tool permissions listed           | ✅     | `config.ts:743-774` — schema matches exactly                 |
+| Last matching rule wins                  | ✅     | `permission/next.ts:340` — uses `findLast()`                 |
+| Default `"*": "allow"`                   | ✅     | `agent.ts:66`                                                |
+| `bash` defaults to `"ask"`               | ✅     | `agent.ts:67`                                                |
+| `.env` read protection with patterns     | ✅     | `agent.ts:79-81` — `*.env`, `*.env.*`, `*.env.example` allow |
+| `external_directory` asks                | ✅     | `agent.ts:69-72`                                             |
+| `doom_loop` asks                         | ✅     | `agent.ts:68`                                                |
+| Per-agent permission overrides           | ✅     | `config.ts:827` — Agent schema has `permission` field        |
+| Fallback to `"ask"` when no rule matches | ✅     | `permission/next.ts:344`                                     |
+
+**Issues found:**
+
+- None significant. The content is thorough and code-verified.
+- The existing VSCode tab content is wrapped without modification (correct).
+
+**Action:** Keep as-is. This is the strongest section of the PR.
+
+---
+
+## Summary of Required Fixes for PR 2
+
+| File                      | Fix                                                                     | Severity     |
+| ------------------------- | ----------------------------------------------------------------------- | ------------ |
+| `installing.md`           | Revert VSIX rollback paragraph deletion                                 | Must fix     |
+| `setup-authentication.md` | Remove misleading `env` config example; revert colon deletion           | Should fix   |
+| `settings/index.md`       | **Remove false "Variable Substitution" section**                        | Must fix     |
+| `settings/index.md`       | Deduplicate config location/precedence between Pre-release and CLI tabs | Should fix   |
+| `settings/index.md`       | Consider recommending `kilo.jsonc` (the default the CLI creates)        | Nice to have |
+
+---
+
+---
+
+## Code-Verified Findings: PR 3 (Code with AI — Agents)
+
+### `chat-interface.md` — GOOD, MINOR ISSUES
+
+New tabs for Quick Setup, Chat Interface, Suggested Responses, and Tips sections.
+
+**Verified claims:**
+
+| Claim                          | Status | Evidence                                                          |
+| ------------------------------ | ------ | ----------------------------------------------------------------- |
+| TUI `@` file autocomplete      | ✅     | `tui/component/prompt/autocomplete.tsx:532-542` — triggers on `@` |
+| `kilo run -f` for file context | ✅     | `run.ts:276-281` — `-f`/`--file` flag                             |
+| `-f` not available in TUI      | ✅     | `tui/thread.ts:71-107` — no `--file` flag in TUI builder          |
+| Agent dropdown in sidebar      | ✅     | Extension has agent selector                                      |
+| TUI keyboard-driven            | ✅     | General TUI design                                                |
+
+**Issues found:**
+
+1. **VSCode tab adds @-mention list.** The diff adds a `@file`, `@url`, `@problems`, `@terminal`, `@git-changes`, `@commit` list to the VSCode tab. This is new content added to the existing tab — need to verify these are correct for the old extension via `../kilocode-legacy`. Likely fine since these are well-known classic extension features.
+
+2. **The "Quick Interactions" and "Suggested Responses" sections** are correctly split — VSCode tab gets the detailed version, Pre-release/CLI gets simplified version.
+
+**Action:** Mostly keep. Verify @-mention list against `../kilocode-legacy` during implementation.
+
+---
+
+### `using-modes.md` — GOOD, ONE IMPORTANT NOTE
+
+Adds callout explaining modes vs agents, tabs for switching methods and built-in modes.
+
+**Verified claims:**
+
+| Claim                                                 | Status | Evidence                                           |
+| ----------------------------------------------------- | ------ | -------------------------------------------------- |
+| Built-in agents: code, ask, plan, debug, orchestrator | ✅     | `agent.ts:88-241`                                  |
+| `architect` NOT listed as built-in in new tab         | ✅     | Correct — architect PR is in progress, not shipped |
+| No built-in Review agent in new system                | ✅     | Not in `agent.ts`                                  |
+| `default_agent` config key exists                     | ✅     | `config.ts:1161-1167`                              |
+| YouTube video moved into VSCode tab                   | ✅     | Acceptable — video shows classic extension         |
+
+**Issues found:**
+
+1. **"Sticky Models" section deleted from shared content and moved into VSCode tab.** This is correct — the new system doesn't have sticky models per mode.
+
+2. **HTML comment block at the end was removed.** Fine — it was a migration TODO.
+
+3. **`plan` description says "Replaces the VSCode version's Architect mode"** — this is misleading. The old extension has BOTH Architect and Ask modes. `plan` in the new system is more like Architect (read-only + restricted editing), while `ask` is the same concept. Suggest softer wording: "Similar to the VSCode version's Architect mode."
+
+**Action:** Keep with wording fix for plan description.
+
+---
+
+### `context-mentions.md` — GOOD, THOROUGH
+
+Wraps existing VSCode content in a tab, adds Pre-release and CLI tabs explaining tool-based context model.
+
+**Verified claims:**
+
+| Claim                                   | Status | Evidence                                              |
+| --------------------------------------- | ------ | ----------------------------------------------------- |
+| Extension sends active file + open tabs | ✅     | `KiloProvider.ts:2497-2538` — `gatherEditorContext()` |
+| Selection/diagnostics NOT auto-sent     | ✅     | Only sent via Code Actions, not default context       |
+| TUI has `@` autocomplete                | ✅     | `autocomplete.tsx:532-542`                            |
+| `kilo run -f` for file context          | ✅     | `run.ts:276-281`                                      |
+| Agent has read/glob/grep/bash tools     | ✅     | Standard tool access                                  |
+
+**Issues found:** None. Well-written new content.
+
+**Action:** Keep as-is.
+
+---
+
+### `model-selection.md` — MINOR FORMATTING ISSUE
+
+Adds tabs for model selection methods.
+
+**Verified claims:**
+
+| Claim                        | Status | Evidence              |
+| ---------------------------- | ------ | --------------------- |
+| `model` key in `kilo.json`   | ✅     | `config.ts:1153-1155` |
+| `--model` flag on `kilo run` | ✅     | `run.ts:261-265`      |
+| TUI model picker             | ✅     | TUI has model cycling |
+
+**Issues found:**
+
+1. **Tab ordering:** VSCode → CLI → VSCode (Pre-release). Inconsistent with every other page which uses VSCode → VSCode (Pre-release) → CLI. Should reorder.
+
+2. **Indentation is wrong** — tab content is indented with extra spaces, causing Markdoc rendering issues.
+
+**Action:** Fix tab order and indentation.
+
+---
+
+### `orchestrator-mode.md` — GOOD
+
+YouTube video moved into VSCode tab. New tab describes `task` tool and subagent sessions.
+
+**Verified claims:**
+
+| Claim                                | Status | Evidence                                                         |
+| ------------------------------------ | ------ | ---------------------------------------------------------------- |
+| `task` tool creates child sessions   | ✅     | `tool/task.ts:66-102` — calls `Session.create()` with `parentID` |
+| Child sessions are isolated          | ✅     | Each gets own conversation context                               |
+| Returns single message to parent     | ✅     | `task.ts:145-162`                                                |
+| Can launch multiple concurrently     | ✅     | Orchestrator prompt explicitly encourages parallel               |
+| Orchestrator has access to `explore` | ✅     | `agent.ts:193` + `orchestrator.txt:5`                            |
+
+**Issues found:**
+
+1. **YouTube video REMOVED from shared content**, only in VSCode tab now. The video was previously visible to all users. Acceptable since it demonstrates the classic extension.
+
+2. **Footnotes 1-3 at the end reference `new_task` and `attempt_completion` tools which are classic-only.** These should be inside the VSCode tab, not shared. Currently they sit between the shared content and the new tabs — need to move them.
+
+**Action:** Move footnotes into VSCode tab.
+
+---
+
+## Code-Verified Findings: PR 4 (Code with AI — Features)
+
+### `autocomplete/index.md` — GOOD
+
+Wraps existing VSCode content, adds Pre-release tab with FIM/Codestral details.
+
+**Verified claims:**
+
+| Claim                                           | Status | Evidence                         |
+| ----------------------------------------------- | ------ | -------------------------------- |
+| FIM with Codestral (`mistralai/codestral-2508`) | ✅     | `AutocompleteModel.ts:4`         |
+| Auto-trigger enabled by default                 | ✅     | Default behavior                 |
+| `Cmd+L` / `Ctrl+L` manual trigger               | ✅     | Extension keybinding             |
+| Status bar with snooze/cost tracking            | ✅     | `AutocompleteServiceManager.ts`  |
+| Copilot conflict detection                      | ✅     | Extension detects GitHub Copilot |
+
+**Issues found:**
+
+1. **Existing VSCode tab intro sentence changed:** "It offers both automatic and manual triggering options." was part of the shared intro but is removed. The plan flagged this — should revert.
+
+**Action:** Revert the sentence deletion from the shared intro.
+
+---
+
+### `browser-use.md` — GOOD, ONE ERROR
+
+New tabs document Playwright MCP approach for the new system.
+
+**Verified claims:**
+
+| Claim                        | Status | Evidence                                          |
+| ---------------------------- | ------ | ------------------------------------------------- |
+| Uses Playwright via MCP      | ✅     | Extension registers `kilo-playwright` dynamically |
+| Auto-configured in extension | ✅     | `Settings → Browser` tab                          |
+| CLI needs manual MCP config  | ✅     | No auto-registration in CLI                       |
+
+**Issues found:**
+
+1. **Headless default not stated** — the plan flagged the old docs saying "default: enabled" was wrong (actual default is `false` — headless disabled). The new tab says "default: disabled" which is correct. ✅
+
+**Action:** Keep as-is.
+
+---
+
+### `checkpoints.md` — GOOD
+
+New tabs for configuration and working with checkpoints.
+
+**Verified claims:**
+
+| Claim                         | Status | Evidence                   |
+| ----------------------------- | ------ | -------------------------- |
+| `snapshot` boolean config key | ✅     | Config schema              |
+| Shadow Git repository         | ✅     | `snapshot/index.ts`        |
+| Per-file revert capability    | ✅     | `Snapshot.revert(patches)` |
+
+**Issues found:**
+
+1. **Limitations section moved from inside content to after tabs.** Acceptable — it applies to both platforms.
+
+2. **Plan flagged encoding bugs** — `→` corrupted to `â`. Need to verify during implementation.
+
+**Action:** Check for encoding corruption during implementation.
+
+---
+
+### `code-actions.md` — GOOD
+
+Wraps VSCode content, adds Pre-release tab.
+
+**Verified claims:**
+
+| Claim                                 | Status | Evidence                        |
+| ------------------------------------- | ------ | ------------------------------- |
+| Add to Context, Explain, Fix, Improve | ✅     | Extension code actions          |
+| Terminal context menu actions         | ✅     | Extension adds terminal actions |
+| Agent Manager integration             | ✅     | Routes to AM session if active  |
+
+**Issues found:**
+
+1. **Callout added saying "not available in CLI/TUI"** — correct.
+
+2. **Existing VSCode tab content is untouched** — existing intro sentence "This can save you time..." is preserved in the shared outro. ✅
+
+**Action:** Keep as-is.
+
+---
+
+### `git-commit-generation.md` — GOOD
+
+Wraps config section in tabs, adds Pre-release tab.
+
+**Verified:** SCM button exists in pre-release, uses CLI backend's `commitMessage.generate()`.
+
+**Issues found:** None. Correctly notes "not available in CLI/TUI."
+
+**Action:** Keep as-is.
+
+---
+
+### `vscode.md` — GOOD, NEW CONTENT
+
+Adds feature comparison between VSCode and Pre-release. Mostly a feature list with links.
+
+**Issues found:**
+
+1. **Claims "Everything in the Classic extension, plus:" is implied by the structure** — the plan flagged this as unverified parity claim. Should soften to "Key features include:" (already done in the diff ✅).
+
+**Action:** Keep as-is.
+
+---
+
+### `cli.md` — MINIMAL CHANGE
+
+Only change: stale link `/using-in-cli` → `/using-in-kilo-code`. Plus `platform: next` frontmatter.
+
+**Action:** Keep as-is. Correct fix.
+
+---
+
+## Code-Verified Findings: PR 5 (Customize)
+
+### `custom-modes.md` — EXTENSIVE, MOSTLY CORRECT
+
+Massive diff (653 lines). Wraps existing VSCode content, adds detailed Pre-release and CLI tabs covering agent definitions, YAML frontmatter format, config file format, examples, migration, and troubleshooting.
+
+**Verified claims:**
+
+| Claim                                                                   | Status | Evidence                                               |
+| ----------------------------------------------------------------------- | ------ | ------------------------------------------------------ |
+| Agents defined as `.md` files with YAML frontmatter                     | ✅     | `config.ts:492-540`                                    |
+| Agent directories: `.kilo/agents/`, `.kilo/agent/`, `.opencode/agents/` | ✅     | `paths.ts:22-43` + glob `{agent,agents}/**/*.md`       |
+| `agent` key in `kilo.json`                                              | ✅     | `config.ts:1199-1202`                                  |
+| `kilo agent create` command                                             | ✅     | `cli/cmd/agent.ts:31-33`                               |
+| Agent properties: mode, permission, color, steps, temperature, etc.     | ✅     | Agent schema in `config.ts:794-829`                    |
+| Migration from `.kilocodemodes`                                         | ✅     | `modes-migrator.ts:109-171` — automatic at config load |
+| Configuration precedence (built-in → global → project → .kilo/)         | ✅     | Config loading order                                   |
+| `architect` NOT listed as built-in                                      | ✅     | Correct — not shipped yet                              |
+
+**Issues found:**
+
+1. **PERMISSION YAML FORMAT IS BACKWARDS.** The docs show:
+
+   ```yaml
+   permission:
+     edit:
+       allow: "*.md"
+       deny: "*"
+   ```
+
+   The actual format is `pattern: action` (pattern as key, action as value):
+
+   ```yaml
+   permission:
+     edit:
+       "*.md": "allow"
+       "*": "deny"
+   ```
+
+   This appears in multiple agent file examples and the regex section. **ALL permission examples need fixing.**
+   Evidence: `config.ts:713` — `PermissionObject = z.record(z.string(), PermissionAction)` — keys are patterns, values are actions.
+
+2. **"Sticky Models" section deleted from shared content.** Moved into VSCode tab. Correct — new system doesn't have sticky models.
+
+3. **"YAML Example" heading removed.** Minor — the example follows directly after the format description. Acceptable.
+
+4. **Migration section says `architect` has "native agent equivalent"** — not yet shipped. Fix: remove `architect` from the skipped list, or note it's coming.
+
+5. **Extensive content duplication between Pre-release and CLI tabs.** The agent property tables, file format examples, and troubleshooting are nearly identical. Consider using a single "VSCode (Pre-release) & CLI" tab for the shared content, with small callouts for extension-only features (Settings UI) and CLI-only features (`kilo agent create`).
+
+**Action:** Fix permission format (must fix), fix architect reference, consider deduplication.
+
+---
+
+### Remaining Customize files (quick assessment)
+
+**`custom-rules.md`, `custom-instructions.md`, `agents-md.md`, `skills.md`** — These follow the same pattern of wrapping existing content and adding new tabs. Need to verify during implementation but lower risk since they're simpler pages.
+
+**`kilocodeignore.md`** — Plan flagged that "first matching rule wins" should be "last matching rule wins" (`findLast()`). Also flagged `watcher.ignore` wrongly nested under `"config"`. Need to verify.
+
+**`context-condensing.md`** — Simple tab wrapping. Low risk.
+
+---
+
+## Code-Verified Findings: PR 6 (Agent Manager)
+
+### `agent-manager.md` — SIGNIFICANT REWRITE
+
+274-line diff. Splits most sections into VSCode and Pre-release tabs. Major new sections: Diff Panel, Import from GitHub PR, Keyboard Shortcuts.
+
+**Verified claims:**
+
+| Claim                                | Status | Evidence                                                                                         |
+| ------------------------------------ | ------ | ------------------------------------------------------------------------------------------------ |
+| Worktree path `.kilo/worktrees/`     | ✅     | Extension code uses `.kilo/worktrees/`                                                           |
+| `.git/info/exclude` for worktree dir | ✅     | WorktreeManager code                                                                             |
+| No automated cleanup                 | ✅     | `AgentManagerProvider.ts:183-184` — explicit "Do not auto-remove"                                |
+| CLI bundled in extension             | ⚠️     | Correct for pre-release, but the Prerequisites tab still says "Install/update the Kilo Code CLI" |
+| `Cmd+Shift+M` shortcut               | ✅     | `package.json` keybinding                                                                        |
+| `Cmd+D` toggle diff                  | ✅     | `package.json` keybinding                                                                        |
+| Multi-model comparison               | ✅     | Agent Manager feature                                                                            |
+
+**Issues found:**
+
+1. **CLI prerequisite still in Pre-release tab.** Line: "Install/update the Kilo Code CLI (latest) — see CLI setup". This is wrong — the extension bundles the CLI. **Fix:** Remove this line from the Pre-release prerequisites.
+
+2. **Shared "Core capabilities" list includes "Parallel Mode"** — reviewer @marius-kilocode said this terminology is outdated. The new system uses worktrees without a "Parallel Mode" toggle per se. Keep the line but consider rewording.
+
+3. **VSCode tab for "Sending messages"** is missing the Cancel vs Stop distinction — it just says "Cancel sends..." and "Stop force-terminates..." which was moved from shared to the VSCode tab only. The Pre-release tab DOESN'T have cancel/stop. Need to verify if the Pre-release extension has a different stop mechanism.
+
+4. **"After Completion" in VSCode tab** says "worktree is cleaned up automatically, but the branch is preserved." Need to verify for the old extension. The new extension confirmed NO auto-cleanup.
+
+5. **Keyboard shortcuts table is incomplete** — only lists 3 shortcuts. The actual extension has 15+. The plan suggests at minimum referencing the shortcut helper: "Press `Cmd+Shift+/` to see all shortcuts."
+
+6. **Authentication section** changes "CLI with Kilo Code Provider" to "(VSCode (Pre-release) only)" — need to verify this is correct.
+
+**Action:** Fix CLI prerequisite, verify cancel/stop for both, expand shortcuts reference.
+
+---
+
+## Code-Verified Findings: PR 7 (Automate — MCP + Shell)
+
+### `using-in-kilo-code.md` — 407-LINE DIFF, MANY FIXES NEEDED
+
+**Verified claims:**
+
+| Claim                       | Status | Evidence                                       |
+| --------------------------- | ------ | ---------------------------------------------- |
+| MCP timeout default 30000ms | ✅     | `mcp/index.ts:29` — `DEFAULT_TIMEOUT = 30_000` |
+| CLI supports SSE transport  | ✅     | `mcp/index.ts:365-379` — SSE as fallback       |
+| `kilo mcp logout` exists    | ✅     | `cli/cmd/mcp.ts:321-322`                       |
+| `kilo mcp debug` exists     | ✅     | `cli/cmd/mcp.ts:596-598`                       |
+
+**Issues to fix from plan:**
+
+1. Timeout: 5000 → 30000 ✅ confirmed
+2. SSE "Classic Only" label — wrong, CLI also supports SSE
+3. Missing `logout` and `debug` from CLI commands table
+4. Config table file paths need verification (already verified in PR 2 findings)
+5. Heading rename `### Understanding Transport Types` → should be kept, NOT renamed (anchor link from `server-transports.md:199` points to it)
+
+**Action:** Apply all five fixes. This is one of the most error-dense files.
+
+---
+
+### `shell-integration.md` — 95-LINE DIFF
+
+Simple tab wrapping. Low risk. Need to verify during implementation.
+
+---
+
+## Code-Verified Findings: PR 8 (AI Providers)
+
+### Provider ID and Env Var Errors — CONFIRMED
+
+| Provider       | Docs ID             | Correct ID                | Docs Env Var                    | Correct Env Var                                                       |
+| -------------- | ------------------- | ------------------------- | ------------------------------- | --------------------------------------------------------------------- |
+| Amazon Bedrock | `bedrock`           | `amazon-bedrock`          | —                               | `AWS_ACCESS_KEY_ID`, etc.                                             |
+| Fireworks      | `fireworks`         | `fireworks-ai`            | —                               | `FIREWORKS_API_KEY`                                                   |
+| Chutes AI      | `chutes-ai`         | `chutes`                  | —                               | `CHUTES_API_KEY`                                                      |
+| Moonshot       | `moonshot`          | `moonshotai`              | —                               | `MOONSHOT_API_KEY`                                                    |
+| Vercel         | `vercel-ai-gateway` | `vercel`                  | `VERCEL_AI_GATEWAY_API_KEY`     | `AI_GATEWAY_API_KEY`                                                  |
+| OVHcloud       | —                   | `ovhcloud`                | `OVH_AI_ENDPOINTS_ACCESS_TOKEN` | `OVHCLOUD_API_KEY`                                                    |
+| Vertex         | —                   | `google-vertex`           | `GOOGLE_CLOUD_REGION`           | `GOOGLE_CLOUD_LOCATION`                                               |
+| SAP AI Core    | —                   | `sap-ai-core`             | `SAP_AI_CORE_*`                 | `AICORE_SERVICE_KEY`, `AICORE_DEPLOYMENT_ID`, `AICORE_RESOURCE_GROUP` |
+| Glama          | exists in docs      | **does NOT exist in CLI** | —                               | —                                                                     |
+| Unbound        | exists in docs      | **does NOT exist in CLI** | —                               | —                                                                     |
+
+### Provider Config Format Issue
+
+All ~29 provider CLI tabs use `"env": ["API_KEY"]` format. This is models.dev metadata, not user-facing config. The user-facing approach is:
+
+- Set env var directly (e.g., `export ANTHROPIC_API_KEY="..."`)
+- Or configure via `"provider": { "anthropic": { "options": { "apiKey": "..." } } }`
+
+**Action:** Fix all provider IDs, env vars, and config format across 30 pages. For Glama and Unbound, show only a "not available in CLI" note (already done in a later commit per the plan).
+
+### `groq.md` — Content Deletion
+
+"Tips and Notes" section (4 bullet points about Groq performance/pricing) was deleted. Should revert.
+
+---
+
+## Implementation Order
+
+1. **PR 1: Infrastructure** — Create clean branch from `main`, apply only infrastructure components + frontmatter markers
+2. **PR 2: Getting Started** — Apply validated new tab content with fixes above
+3. **PR 3: Code with AI — Agents** — Apply with tab order fix (model-selection.md) and wording fixes
+4. **PR 4: Code with AI — Features** — Apply with autocomplete sentence revert
+5. **PR 5: Customize** — Apply with **permission YAML format fix** (critical) and deduplication
+6. **PR 6: Agent Manager** — Apply with CLI prerequisite removal and shortcuts expansion
+7. **PR 7: MCP + Shell** — Apply with all 5 MCP fixes (timeout, SSE, commands, heading, config)
+8. **PR 8: AI Providers** — Apply with all provider ID/env var/config format fixes across 30 pages
+
+For each PR:
+
+1. Create a fresh branch from `main` (e.g., `docs/getting-started-tabs`)
+2. Manually apply only the validated changes from `docs/version-switcher`
+3. Apply fixes from the findings above
+4. Do NOT include plan files or non-docs code changes
+5. Close PR #6831 after all section PRs have landed
+
+---
+
+## Critical Fixes Summary (across all PRs)
+
+| Severity  | Fix                                                                               | PR   | File(s)                                                                             |
+| --------- | --------------------------------------------------------------------------------- | ---- | ----------------------------------------------------------------------------------- |
+| 🔴 Must   | Permission YAML format is backwards (`allow: "*.md"` should be `"*.md": "allow"`) | 5    | `custom-modes.md` (multiple examples)                                               |
+| 🔴 Must   | Variable substitution `{env:}` / `{file:}` doesn't exist                          | 2    | `settings/index.md`                                                                 |
+| 🔴 Must   | 8 wrong provider IDs across provider pages                                        | 8    | `bedrock.md`, `fireworks.md`, `chutes-ai.md`, `moonshot.md`, `vercel-ai-gateway.md` |
+| 🔴 Must   | 4 wrong env vars across provider pages                                            | 8    | `vertex.md`, `sap-ai-core.md`, `vercel-ai-gateway.md`, `ovhcloud.md`                |
+| 🔴 Must   | Glama/Unbound don't exist in CLI                                                  | 8    | `glama.md`, `unbound.md`                                                            |
+| 🟡 Should | Provider config `env` format is misleading (30 pages)                             | 8, 2 | All provider CLI tabs, `setup-authentication.md`                                    |
+| 🟡 Should | MCP timeout 5000→30000                                                            | 7    | `using-in-kilo-code.md`                                                             |
+| 🟡 Should | SSE "Classic Only" is wrong                                                       | 7    | `using-in-kilo-code.md`                                                             |
+| 🟡 Should | CLI prerequisite in Agent Manager pre-release tab                                 | 6    | `agent-manager.md`                                                                  |
+| 🟡 Should | Revert VSIX rollback deletion                                                     | 2    | `installing.md`                                                                     |
+| 🟡 Should | `architect` referenced as shipped but isn't                                       | 5    | `custom-modes.md`                                                                   |
+| 🟢 Nice   | Tab order inconsistency                                                           | 3    | `model-selection.md`                                                                |
+| 🟢 Nice   | Content duplication between Pre-release and CLI tabs                              | 2, 5 | `settings/index.md`, `custom-modes.md`                                              |

--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -14,54 +14,131 @@ The Agent Manager is a dedicated control panel for running and supervising Kilo 
 
 This page reflects the actual implementation in the extension.
 
+**Core capabilities shared by both extensions:**
+
+- Start new sessions and resume existing ones
+- Parallel Mode with Git worktree isolation for safe, independent changes
+- Per-session terminals
+- Setup scripts for environment configuration
+- Remote/cloud-synced sessions filtered to your current repository
+
 ## Prerequisites
 
-- Install/update the Kilo Code CLI (latest) — see [CLI setup](/docs/code-with-ai/platforms/cli)
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 - Open a project in VS Code (workspace required)
+- Authentication: Sign in through the extension settings
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+- The extension bundles its own CLI binary — no separate installation needed
+- Open a `git` enabled project in VS Code (workspace required)
 - Authentication: You must be logged in via the extension settings OR use CLI with kilocode as provider (see [Authentication Requirements](#authentication-requirements))
+
+{% /tab %}
+{% /tabs %}
 
 ## Opening the Agent Manager
 
-- Command Palette: “Kilo Code: Open Agent Manager”
-- Or use the title/menu entry if available in your Kilo Code UI
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
 
-The panel opens as a webview and stays active across focus changes.
+- Command Palette: "Kilo Code: Open Agent Manager"
+- The panel opens as a webview with a session sidebar and detail view
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+- Command Palette: "Kilo Code: Open Agent Manager"
+- Keyboard shortcut: `Cmd+Shift+M` (macOS) / `Ctrl+Shift+M` (Windows/Linux)
+- The panel opens as a webview and stays active across focus changes
+- Tabs can be reordered via drag-and-drop
+
+{% /tab %}
+{% /tabs %}
 
 ## Sending messages, approvals, and control
 
-- Continue the conversation: Send a follow-up message to the running agent
-- Approvals: If the agent asks to use a tool, run a command, launch the browser, or connect to an MCP server, the UI shows an approval prompt
-  - Approve or reject, optionally adding a short note
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
+- Type a message to start or continue a conversation
+- Approvals: If the agent requests tool use, the UI shows an approval prompt — approve or reject
 - Cancel vs Stop
   - Cancel sends a structured cancel message to the running process (clean cooperative stop)
-  - Stop force-terminates the underlying CLI process, updating status to “stopped”
+  - Stop force-terminates the underlying CLI process, updating status to "stopped"
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+- Send follow-up messages to the running agent at any time
+- Approvals: If the agent asks to use a tool, run a command, launch the browser, or connect to an MCP server, the UI shows an approval prompt
+  - Approve or reject, optionally adding a short note
+
+{% /tab %}
+{% /tabs %}
 
 ## Resuming an existing session
 
 You can continue a session later (local or remote):
 
-- If a session is not currently running, the Agent Manager will spawn a new CLI process attached to that session’s ID
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
+- Select a previous session from the sidebar to resume it
+- The extension spawns a new agent process attached to that session
+- Labels from the original session are preserved
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+- If a session is not currently running, the Agent Manager will spawn a new CLI process attached to that session's ID
 - Labels from the original session are preserved whenever possible
 - Your first follow-up message becomes the continuation input
+- You can also fork an existing session to create a new branch of exploration, or promote a session to become the active working session
+
+{% /tab %}
+{% /tabs %}
 
 ## Parallel Mode
 
 Parallel Mode runs the agent in an isolated Git worktree branch, keeping your main branch clean.
 
-- Enable the "Parallel Mode" toggle before starting
-- The extension prevents using Parallel Mode inside an existing worktree
-  - Open the main repository (where .git is a directory) to use this feature
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
+- Enable the "Parallel Mode" toggle before starting a session
+- The extension creates and manages worktrees automatically
+- Cannot be used from inside an existing worktree — open the main repository
 
 ### Worktree Location
 
-Worktrees are created in `.kilocode/worktrees/` within your project directory. This folder is automatically excluded from git via `.git/info/exclude` (a local-only ignore file that doesn't require a commit).
+Worktrees are created in `.kilo/worktrees/` within your project directory, automatically excluded from git via `.git/info/exclude`.
+
+### After Completion
+
+- The worktree is cleaned up automatically, but the branch is preserved
+- Review and merge the branch in your VCS UI
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+- Enable the "Parallel Mode" toggle before starting
+- The extension prevents using Parallel Mode inside an existing worktree
+  - Open the main repository (where `.git` is a directory) to use this feature
+
+### Worktree Location
+
+Worktrees are created in `.kilo/worktrees/` within your project directory. This folder is automatically excluded from git via `.git/info/exclude` (a local-only ignore file that doesn't require a commit).
 
 ```
 your-project/
 ├── .git/
 │   └── info/
-│       └── exclude   # local ignore rules (includes .kilocode/worktrees/)
-├── .kilocode/
+│       └── exclude   # local ignore rules (includes .kilo/worktrees/)
+├── .kilo/
 │   └── worktrees/
 │       └── feature-branch-1234567890/   # isolated working directory
 └── ...
@@ -88,6 +165,57 @@ If you resume a Parallel Mode session later, the extension will:
 1. Reuse the existing worktree if it still exists
 2. Or recreate it from the session's branch
 
+{% /tab %}
+{% /tabs %}
+
+## Diff Panel and Code Review
+
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
+Session changes are visible through standard VS Code source control. The **VSCode** version does not include a built-in diff panel.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+The current **VSCode** version includes a rich diff panel for reviewing agent-produced changes:
+
+- **Open the diff panel:** `Cmd+D` (macOS) / `Ctrl+D` (Windows/Linux), or via the toolbar
+- **Full-screen diff view** for focused review
+- **Apply workflow:** Accept or reject individual file changes with conflict resolution support
+- **Code review annotations:** Leave inline comments on agent-produced diffs
+- **Multi-model comparison:** Compare up to 4 model outputs side-by-side for the same prompt to evaluate different approaches
+
+{% /tab %}
+{% /tabs %}
+
+## Import from GitHub PR
+
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
+Not available in the **VSCode** version.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Paste a GitHub Pull Request URL to import the PR context into a new Agent Manager session. This allows you to continue working on or reviewing a PR directly within the Agent Manager.
+
+{% /tab %}
+{% /tabs %}
+
+## Keyboard Shortcuts
+
+The current **VSCode** version includes dedicated keyboard shortcuts:
+
+| Shortcut                      | Action                    |
+| ----------------------------- | ------------------------- |
+| `Cmd+Shift+M`                 | Open Agent Manager        |
+| `Cmd+Alt+Up` / `Cmd+Alt+Down` | Navigate between sessions |
+| `Cmd+D`                       | Toggle diff panel         |
+
+(On Windows/Linux, replace `Cmd` with `Ctrl`.)
+
 ## Authentication Requirements
 
 The Agent Manager requires proper authentication for full functionality, including session syncing and cloud features.
@@ -99,7 +227,7 @@ The Agent Manager requires proper authentication for full functionality, includi
    - Provides seamless authentication for the Agent Manager
    - Enables session syncing and cloud features
 
-2. **CLI with Kilo Code Provider**
+2. **CLI with Kilo Code Provider** (VSCode only)
    - Use the CLI configured with `kilocode` as the provider
    - Run `kilocode config` to set up authentication
    - See [CLI setup](/docs/code-with-ai/platforms/cli) for details
@@ -120,6 +248,15 @@ To use the Agent Manager with all features enabled, switch to the Kilo Code prov
 
 When signed in (Kilo Cloud), the Agent Manager lists your recent cloud-synced sessions:
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
+- Sessions are fetched and filtered to the current repository
+- Select a remote session to view its transcript and continue the work locally
+
+{% /tab %}
+{% tab label="VSCode" %}
+
 - Up to 50 sessions are fetched
 - Sessions are filtered to the current repository via normalized Git remote URL
   - If the current workspace has no remote, only sessions without a git_url are shown
@@ -128,21 +265,36 @@ When signed in (Kilo Cloud), the Agent Manager lists your recent cloud-synced se
 
 Message transcripts are fetched from a signed blob and exclude internal checkpoint "save" markers as chat rows (checkpoints still appear as dedicated entries in the UI).
 
+{% /tab %}
+{% /tabs %}
+
 ## Troubleshooting
+
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
+- "Please open a folder…" error — the Agent Manager requires a VS Code workspace folder
+- "Cannot use parallel mode from within a git worktree" — open the main repository, not a worktree checkout
+- Remote sessions not visible — ensure you're signed in and the repo's remote URL matches
+- Authentication errors — verify you're logged in via extension settings
+
+{% /tab %}
+{% tab label="VSCode" %}
 
 - CLI not found or outdated
   - Install/update the CLI: [CLI setup](/docs/code-with-ai/platforms/cli)
   - If you see an "unknown option --json-io" error, update to the latest CLI
-- "Please open a folder…" error
-  - The Agent Manager requires a VS Code workspace folder
-- "Cannot use parallel mode from within a git worktree"
-  - Open the main repository (where .git is a directory), not a worktree checkout
+- "Please open a folder…" error — the Agent Manager requires a VS Code workspace folder
+- "Cannot use parallel mode from within a git worktree" — open the main repository (where `.git` is a directory), not a worktree checkout
 - Remote sessions not visible
   - Ensure you're signed in and the repo's remote URL matches the sessions you expect to see
   - If using BYOK, session syncing is not available — switch to Kilo Code provider or sign in through the extension
 - Authentication errors
   - Verify you're logged in via extension settings or using CLI with kilocode provider
   - BYOK configurations do not support Agent Manager authentication
+
+{% /tab %}
+{% /tabs %}
 
 ## Related features
 


### PR DESCRIPTION
## Summary

Splits Agent Manager documentation into VSCode and Pre-release tabs. **PR 6 of 8** from the docs platform tabs effort.

### Changes

- **Prerequisites**: VSCode needs workspace only; Pre-release bundles its own CLI (no separate install)
- **Opening**: Added keyboard shortcut `Cmd+Shift+M` for Pre-release
- **Messaging/approvals**: Platform-specific control flows
- **Session resume**: Fork and promote capabilities in Pre-release
- **Parallel mode**: Worktree path corrected to `.kilo/worktrees/` (was `.kilocode/worktrees/`)
- **New sections**: Diff panel, code review annotations, GitHub PR import, keyboard shortcuts table
- **Authentication**: CLI provider option marked Pre-release only
- **Troubleshooting**: Split per platform with specific guidance

### Fix applied

Removed misleading "Install/update the Kilo Code CLI" prerequisite from the Pre-release tab — the extension bundles its own CLI binary.

Depends on #7497 for infrastructure.