### PR TITLE
docs: add source-links freshness check to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Kilo CLI is an open source AI coding agent that generates code from natural lang
 - **Single test**: `bun test test/tool/tool.test.ts` from `packages/opencode/`
 - **SDK regen**: After changing server endpoints in `packages/opencode/src/server/`, run `./script/generate.ts` from root to regenerate `packages/sdk/js/`
 - **Knip** (unused exports): `bun run knip` from `packages/kilo-vscode/`. CI runs this — all exported types/functions must be imported somewhere. Remove or unexport unused exports before pushing.
+- **Source links**: After adding or changing URLs in `packages/kilo-vscode/`, `packages/kilo-vscode/webview-ui/`, or `packages/opencode/src/`, run `bun run script/extract-source-links.ts` from the repo root and commit the updated `packages/kilo-docs/source-links.md`. CI runs this check — the build fails if the file is stale.
 - **kilocode_change check**: `bun run check-kilocode-change` from `packages/kilo-vscode/`. CI runs this — `kilocode_change` is a marker for upstream merge conflicts and must not appear in `packages/kilo-vscode/` or `packages/kilo-ui/` (these are entirely Kilo Code additions). Remove the markers before pushing.
 
 ## Products


### PR DESCRIPTION
## Summary
- Adds a **Source links** entry to the "Build and Dev" section of `AGENTS.md`, documenting the `source-links-freshness` CI check
- Agents will now know to run `bun run script/extract-source-links.ts` and commit the updated `source-links.md` after adding or changing URLs in extension/CLI source

Fixes the root cause of the CI failure in #7496.
