### PR TITLE
docs(kilo-docs): add platform tabs to AI provider pages

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/anthropic.md
+++ b/packages/kilo-docs/pages/ai-providers/anthropic.md
@@ -17,11 +17,55 @@ Anthropic is an AI safety and research company that builds reliable, interpretab
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "Anthropic" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your Anthropic API key into the "Anthropic API Key" field.
 4.  **Select Model:** Choose your desired Claude model from the "Model" dropdown.
 5.  **(Optional) Custom Base URL:** If you need to use a custom base URL for the Anthropic API, check "Use custom base URL" and enter the URL. Most people won't need to adjust this.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Anthropic and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export ANTHROPIC_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "anthropic": {
+      "env": ["ANTHROPIC_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "anthropic/claude-sonnet-4-20250514",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/bedrock.md
+++ b/packages/kilo-docs/pages/ai-providers/bedrock.md
@@ -34,6 +34,9 @@ You have three options for configuring AWS credentials:
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "Bedrock" from the "API Provider" dropdown.
 3.  **Select Authentication Method:**
@@ -47,6 +50,53 @@ You have three options for configuring AWS credentials:
 4.  **Select Region:** Choose the AWS region where your Bedrock service is available (e.g., "us-east-1").
 5.  **(Optional) Cross-Region Inference:** Check "Use cross-region inference" if you want to access models in a region different from your configured AWS region.
 6.  **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add AWS Bedrock. The extension uses the AWS credentials chain for authentication — configure your AWS credentials using the AWS CLI or environment variables before adding the provider.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Bedrock uses the AWS credentials chain for authentication. Configure your AWS credentials using the AWS CLI or environment variables:
+
+**Environment variables:**
+
+```bash
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+export AWS_REGION="us-east-1"
+```
+
+Or use an AWS profile:
+
+```bash
+aws configure --profile bedrock
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "amazon-bedrock": {},
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/bedrock.md
+++ b/packages/kilo-docs/pages/ai-providers/bedrock.md
@@ -91,7 +91,7 @@ Then set your default model:
 
 ```jsonc
 {
-  "model": "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+  "model": "amazon-bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
 }
 ```
 

--- a/packages/kilo-docs/pages/ai-providers/cerebras.md
+++ b/packages/kilo-docs/pages/ai-providers/cerebras.md
@@ -17,10 +17,54 @@ Cerebras is known for their ultra-fast AI inference powered by the Cerebras CS-3
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2. **Select Provider:** Choose "Cerebras" from the "API Provider" dropdown.
 3. **Enter API Key:** Paste your Cerebras API key into the "Cerebras API Key" field.
 4. **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Cerebras and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export CEREBRAS_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "cerebras": {
+      "env": ["CEREBRAS_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "cerebras/llama-4-scout-17b-16e-instruct",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/chutes-ai.md
+++ b/packages/kilo-docs/pages/ai-providers/chutes-ai.md
@@ -20,10 +20,54 @@ Always refer to the official Chutes AI documentation or your dashboard for the m
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "Chutes AI" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your Chutes AI API key into the "Chutes AI API Key" field.
 4.  **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Chutes AI and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export CHUTES_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "chutes": {
+      "env": ["CHUTES_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "chutes-ai/model-name",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/chutes-ai.md
+++ b/packages/kilo-docs/pages/ai-providers/chutes-ai.md
@@ -62,7 +62,7 @@ Then set your default model:
 
 ```jsonc
 {
-  "model": "chutes-ai/model-name",
+  "model": "chutes/model-name",
 }
 ```
 

--- a/packages/kilo-docs/pages/ai-providers/claude-code.md
+++ b/packages/kilo-docs/pages/ai-providers/claude-code.md
@@ -34,10 +34,59 @@ The specific models available depend on your Claude subscription and plan. See [
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2. **Select Provider:** Choose "Claude Code" from the "API Provider" dropdown.
 3. **Select Model:** Choose your desired Claude model from the "Model" dropdown.
 4. **(Optional) Custom CLI Path:** If you installed Claude Code to a location other than the default `claude` command, enter the full path to your Claude executable in the "Claude Code Path" field. Most users won't need to change this.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab. Claude Code uses your existing Anthropic credentials from the `claude` CLI — make sure it is installed and authenticated before adding the provider.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Claude Code uses your existing Anthropic credentials (from the `claude` CLI). Make sure the Claude Code CLI is installed and authenticated:
+
+```bash
+claude --version
+claude auth login
+```
+
+If you have an `ANTHROPIC_API_KEY` environment variable set, the Claude CLI will use it automatically:
+
+```bash
+export ANTHROPIC_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "anthropic": {
+      "env": ["ANTHROPIC_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "anthropic/claude-sonnet-4-20250514",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/claude-code.md
+++ b/packages/kilo-docs/pages/ai-providers/claude-code.md
@@ -45,9 +45,9 @@ The specific models available depend on your Claude subscription and plan. See [
 {% /tab %}
 {% tab label="VSCode" %}
 
-Open **Settings** (gear icon) and go to the **Providers** tab. Claude Code uses your existing Anthropic credentials from the `claude` CLI — make sure it is installed and authenticated before adding the provider.
-
-The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+{% callout type="warning" %}
+Claude Code credentials no longer work in Kilo Code. Please use the [Anthropic provider](/docs/ai-providers/anthropic) with an API key instead.
+{% /callout %}
 
 {% /tab %}
 {% tab label="CLI" %}

--- a/packages/kilo-docs/pages/ai-providers/deepseek.md
+++ b/packages/kilo-docs/pages/ai-providers/deepseek.md
@@ -17,10 +17,54 @@ Kilo Code supports accessing models through the DeepSeek API, including `deepsee
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "DeepSeek" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your DeepSeek API key into the "DeepSeek API Key" field.
 4.  **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add DeepSeek and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export DEEPSEEK_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "deepseek": {
+      "env": ["DEEPSEEK_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "deepseek/deepseek-chat",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/fireworks.md
+++ b/packages/kilo-docs/pages/ai-providers/fireworks.md
@@ -17,10 +17,54 @@ Fireworks AI is a high-performance platform for running AI models that offers fa
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2. **Select Provider:** Choose "Fireworks AI" from the "API Provider" dropdown.
 3. **Enter API Key:** Paste your Fireworks AI API key into the "Fireworks AI API Key" field.
 4. **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Fireworks AI and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export FIREWORKS_AI_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "fireworks-ai": {
+      "env": ["FIREWORKS_AI_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "fireworks/accounts/fireworks/models/llama4-scout-instruct-basic",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/fireworks.md
+++ b/packages/kilo-docs/pages/ai-providers/fireworks.md
@@ -40,7 +40,7 @@ Set the API key as an environment variable or configure it in your `kilo.json` c
 **Environment variable:**
 
 ```bash
-export FIREWORKS_AI_API_KEY="your-api-key"
+export FIREWORKS_API_KEY="your-api-key"
 ```
 
 **Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
@@ -49,7 +49,7 @@ export FIREWORKS_AI_API_KEY="your-api-key"
 {
   "provider": {
     "fireworks-ai": {
-      "env": ["FIREWORKS_AI_API_KEY"],
+      "env": ["FIREWORKS_API_KEY"],
     },
   },
 }
@@ -59,7 +59,7 @@ Then set your default model:
 
 ```jsonc
 {
-  "model": "fireworks/accounts/fireworks/models/llama4-scout-instruct-basic",
+  "model": "fireworks-ai/accounts/fireworks/models/llama4-scout-instruct-basic",
 }
 ```
 

--- a/packages/kilo-docs/pages/ai-providers/gemini.md
+++ b/packages/kilo-docs/pages/ai-providers/gemini.md
@@ -17,10 +17,54 @@ Kilo Code supports Google's Gemini family of models through the Google AI Gemini
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "Google Gemini" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your Gemini API key into the "Gemini API Key" field.
 4.  **Select Model:** Choose your desired Gemini model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Google Gemini and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export GOOGLE_GENERATIVE_AI_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "google": {
+      "env": ["GOOGLE_GENERATIVE_AI_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "google/gemini-2.5-pro",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/glama.md
+++ b/packages/kilo-docs/pages/ai-providers/glama.md
@@ -26,10 +26,30 @@ Refer to the [Glama documentation](https://glama.ai/models) for the most up-to-d
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "Glama" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your Glama API key into the "Glama API Key" field.
 4.  **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Glama and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+{% callout type="warning" %}
+Glama is not yet available as a CLI provider. Check the [Kilo Code releases](https://github.com/Kilo-Org/kilocode/releases) for updates on provider support.
+{% /callout %}
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/groq.md
+++ b/packages/kilo-docs/pages/ai-providers/groq.md
@@ -20,17 +20,54 @@ Kilo Code will attempt to fetch the list of available models from the Groq API.
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "Groq" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your Groq API key into the "Groq API Key" field.
 4.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
-## Tips and Notes
+{% /tab %}
+{% tab label="VSCode" %}
 
-- **High-Speed Inference:** Groq's LPUs provide exceptionally fast response times, making it ideal for interactive development workflows.
-- **Token Limits:** Some models have specific `max_tokens` limits that are automatically handled by Kilo Code (e.g., the `moonshotai/kimi-k2-instruct` model).
-- **Cost Efficiency:** Groq often provides competitive pricing for high-speed inference compared to other providers.
-- **Model Selection:** Choose models based on your specific needs - larger models like `llama3-70b-8192` for complex reasoning tasks, or smaller models like `llama3-8b-8192` for faster, simpler operations.
+Open **Settings** (gear icon) and go to the **Providers** tab to add Groq and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export GROQ_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "groq": {
+      "env": ["GROQ_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "groq/llama-3.3-70b-versatile",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Supported Models
 
@@ -45,13 +82,6 @@ Kilo Code supports the following models through Groq:
 | `mixtral-8x7b-32768`          | Mistral AI  | 32K tokens     | Mixture of experts architecture       |
 
 **Note:** Model availability may change. Refer to the [Groq documentation](https://console.groq.com/docs/models) for the latest model list and specifications.
-
-## Configuration in Kilo Code
-
-1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2. **Select Provider:** Choose "Groq" from the "API Provider" dropdown.
-3. **Enter API Key:** Paste your Groq API key into the "Groq API Key" field.
-4. **Select Model:** Choose your desired model from the "Model" dropdown.
 
 ## Model-Specific Features
 

--- a/packages/kilo-docs/pages/ai-providers/inception.md
+++ b/packages/kilo-docs/pages/ai-providers/inception.md
@@ -23,10 +23,54 @@ Refer to Inception's current website and developer documentation for the most up
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2. **Select Provider:** Choose "Inception" from the "API Provider" dropdown.
 3. **Enter API Key:** Paste your Inception API key into the "Inception API Key" field.
 4. **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Inception and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export INCEPTION_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "inception": {
+      "env": ["INCEPTION_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "inception/mercury-coder-small-beta",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/index.md
+++ b/packages/kilo-docs/pages/ai-providers/index.md
@@ -58,11 +58,7 @@ Route requests through unified APIs with additional features:
 - **Regional** - Better latency in certain locations
 
 {% callout type="note" %}
-All API keys use VS Code's Secret Storage—never stored in plain text.
-{% /callout %}
-
-{% callout type="warning" title="Time-to-first-byte timeout" %}
-For all providers, there is a **five-minute timeout** on time to first token. This means if a provider does not begin streaming a response within five minutes of the request being sent, the request will be cancelled. This is a constraint of the Bun runtime and cannot be easily configured.
+In the **VSCode (Legacy)** version, API keys use VS Code's Secret Storage. In the current **VSCode & CLI** version, keys are set via environment variables or referenced in `kilo.json` config files. See individual provider pages for setup instructions for each platform.
 {% /callout %}
 
 ## Next Steps

--- a/packages/kilo-docs/pages/ai-providers/lmstudio.md
+++ b/packages/kilo-docs/pages/ai-providers/lmstudio.md
@@ -27,11 +27,49 @@ Kilo Code supports running models locally using LM Studio. LM Studio provides a 
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "LM Studio" from the "API Provider" dropdown.
 3.  **Enter Model ID:** Enter the _file name_ of the model you loaded in LM Studio (e.g., `codellama-7b.Q4_0.gguf`). You can find this in the LM Studio "Local Server" tab.
 4.  **(Optional) Base URL:** By default, Kilo Code will connect to LM Studio at `http://localhost:1234`. If you've configured LM Studio to use a different address or port, enter the full URL here.
 5.  **(Optional) Timeout:** By default, API requests time out after 10 minutes. Local models can be slow, if you hit this timeout you can consider increasing it here: VS Code Extensions panel > Kilo Code gear menu > Settings > API Request Timeout.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add LM Studio. No API key is needed since LM Studio runs locally. You can configure the base URL if LM Studio is running on a different host or port.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+LM Studio runs locally, so no API key is needed. Configure the base URL if LM Studio is running on a different host or port:
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "lmstudio": {
+      "baseURL": "http://localhost:1234/v1",
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "lmstudio/codellama-7b",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/minimax.md
+++ b/packages/kilo-docs/pages/ai-providers/minimax.md
@@ -17,10 +17,54 @@ MiniMax is a global AI foundation model company focused on fast, cost-efficient 
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2. **Select Provider:** Navigate to **Providers**. Choose **MiniMax** from the API Provider dropdown.
 3. **Enter API Key:** Paste your MiniMax API key into the MiniMax API Key field.
 4. **Select Model:** Choose your desired MiniMax model from the Model dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add MiniMax and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export MINIMAX_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "minimax": {
+      "env": ["MINIMAX_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "minimax/MiniMax-M1",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/mistral.md
+++ b/packages/kilo-docs/pages/ai-providers/mistral.md
@@ -17,10 +17,54 @@ Kilo Code supports accessing models through the Mistral AI API, including both s
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "Mistral" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your Mistral API key into the "Mistral API Key" field if you're using a `mistral` model. If you intend to use `codestral-latest`, see the "Codestral" section below.
 4.  **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Mistral and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export MISTRAL_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "mistral": {
+      "env": ["MISTRAL_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "mistral/mistral-large-latest",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Using Codestral
 

--- a/packages/kilo-docs/pages/ai-providers/moonshot.md
+++ b/packages/kilo-docs/pages/ai-providers/moonshot.md
@@ -17,10 +17,54 @@ Moonshot.ai is a Chinese AI company known for their **Kimi** models featuring ul
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2. **Select Provider:** Choose "Moonshot.ai" from the "API Provider" dropdown.
 3. **Enter API Key:** Paste your Moonshot.ai API key into the "Moonshot.ai API Key" field.
 4. **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Moonshot.ai and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export MOONSHOT_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "moonshotai": {
+      "env": ["MOONSHOT_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "moonshot/moonshot-v1-auto",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/moonshot.md
+++ b/packages/kilo-docs/pages/ai-providers/moonshot.md
@@ -59,7 +59,7 @@ Then set your default model:
 
 ```jsonc
 {
-  "model": "moonshot/moonshot-v1-auto",
+  "model": "moonshotai/moonshot-v1-auto",
 }
 ```
 

--- a/packages/kilo-docs/pages/ai-providers/ollama.md
+++ b/packages/kilo-docs/pages/ai-providers/ollama.md
@@ -72,11 +72,49 @@ By default, API requests time out after 10 minutes. Local models can be slow, if
 
 ### Configure Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 - Open the Kilo Code panel ({% kiloCodeIcon size="1em" /%}).
 - Click the Settings gear icon ({% codicon name="gear" /%}).
 - Select "Ollama" as the API Provider.
 - Select the model configured in the previous step.
 - (Optional) You can configure the base URL if you're running Ollama on a different machine. The default is `http://localhost:11434`.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Ollama. No API key is needed since Ollama runs locally. You can configure the base URL if Ollama is running on a different host.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Ollama runs locally, so no API key is needed. Configure the base URL if Ollama is running on a different host:
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "ollama": {
+      "baseURL": "http://localhost:11434/v1",
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "ollama/qwen3-coder:30b",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Further Reading
 

--- a/packages/kilo-docs/pages/ai-providers/openai-chatgpt-plus-pro.md
+++ b/packages/kilo-docs/pages/ai-providers/openai-chatgpt-plus-pro.md
@@ -4,12 +4,52 @@ sidebar_label: ChatGPT Plus/Pro
 
 # Using ChatGPT Subscriptions With Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1. Open Kilo Code settings (click the gear icon {% codicon name="gear" /%} in the Kilo Code panel).
 2. In **API Provider**, select **OpenAI – ChatGPT Plus/Pro**.
 3. Click **Sign in to OpenAI Codex**.
 4. Finish the sign-in flow in your browser.
 5. Back in Kilo Code settings, pick a model from the dropdown.
 6. Save.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab. ChatGPT Plus/Pro uses OAuth authentication — follow the sign-in flow to connect your ChatGPT subscription.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+ChatGPT Plus/Pro uses OAuth authentication, which is only available in the VS Code extension. For the CLI, use the [OpenAI API provider](/docs/ai-providers/openai) with an API key instead:
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "openai": {
+      "env": ["OPENAI_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "openai/gpt-4.1",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/openai-compatible.md
+++ b/packages/kilo-docs/pages/ai-providers/openai-compatible.md
@@ -14,6 +14,9 @@ This document focuses on setting up providers _other than_ the official OpenAI A
 
 ## General Configuration
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 The key to using an OpenAI-compatible provider is to configure two main settings:
 
 1.  **Base URL:** This is the API endpoint for the provider. It will _not_ be `https://api.openai.com/v1` (that's for the official OpenAI API).
@@ -33,6 +36,48 @@ You'll find these settings in the Kilo Code settings panel (click the {% codicon
   - Computer Use
   - Input Price
   - Output Price
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add an OpenAI Compatible provider. Enter your API key and the provider's base URL.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key and base URL as environment variables or configure them in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "openai-compatible": {
+      "env": ["OPENAI_API_KEY"],
+      "baseURL": "https://api.your-provider.com/v1",
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "openai-compatible/model-name",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ### Full Endpoint URL Support
 

--- a/packages/kilo-docs/pages/ai-providers/openai.md
+++ b/packages/kilo-docs/pages/ai-providers/openai.md
@@ -17,10 +17,54 @@ Kilo Code supports accessing models directly through the official OpenAI API.
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "OpenAI" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your OpenAI API key into the "OpenAI API Key" field.
 4.  **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add OpenAI and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "openai": {
+      "env": ["OPENAI_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "openai/gpt-4.1",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/openrouter.md
+++ b/packages/kilo-docs/pages/ai-providers/openrouter.md
@@ -16,11 +16,55 @@ OpenRouter is an AI platform that provides access to a wide variety of language 
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "OpenRouter" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your OpenRouter API key into the "OpenRouter API Key" field.
 4.  **Select Model:** Choose your desired model from the "Model" dropdown.
 5.  **(Optional) Custom Base URL:** If you need to use a custom base URL for the OpenRouter API, check "Use custom base URL" and enter the URL. Leave this blank for most users.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add OpenRouter and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export OPENROUTER_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "openrouter": {
+      "env": ["OPENROUTER_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "openrouter/anthropic/claude-sonnet-4-20250514",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Supported Transforms
 

--- a/packages/kilo-docs/pages/ai-providers/ovhcloud.md
+++ b/packages/kilo-docs/pages/ai-providers/ovhcloud.md
@@ -24,7 +24,51 @@ You can report any bugs or feedbacks by chatting with us in our [Discord server]
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "OVHcloud AI Endpoints" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your AI Endpoints API key into the "OVHcloud AI Endpoints API Key" field.
 4.  **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add OVHcloud AI Endpoints and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export OVHCLOUD_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "ovhcloud": {
+      "env": ["OVHCLOUD_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "ovhcloud/model-name",
+}
+```
+
+{% /tab %}
+{% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/requesty.md
+++ b/packages/kilo-docs/pages/ai-providers/requesty.md
@@ -15,10 +15,54 @@ Kilo Code supports accessing models through the [Requesty](https://www.requesty.
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "Requesty" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your Requesty API key into the "Requesty API Key" field.
 4.  **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Requesty and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export REQUESTY_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "requesty": {
+      "env": ["REQUESTY_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "requesty/anthropic/claude-sonnet-4-20250514",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/sap-ai-core.md
+++ b/packages/kilo-docs/pages/ai-providers/sap-ai-core.md
@@ -77,6 +77,9 @@ The exact list of available models depends on your SAP AI Core configuration and
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2. **Select Provider:** Choose "SAP AI Core" from the "API Provider" dropdown.
 3. **Enter Credentials:**
@@ -90,6 +93,47 @@ The exact list of available models depends on your SAP AI Core configuration and
    - **Foundation Models Mode:** Leave unchecked to use foundation models with deployments
 5. **Select Model:** Choose your desired model from the dropdown
 6. **Select Deployment:** (Foundation Models Mode only) Choose an active deployment for your selected model
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add SAP AI Core. Enter your OAuth2 client credentials (Client ID, Client Secret, Base URL, and Auth URL) in the provider settings.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+SAP AI Core uses OAuth2 client credentials for authentication. Set the credentials as environment variables or in your config file:
+
+**Environment variables:**
+
+```bash
+export AICORE_SERVICE_KEY='{"your": "service-key-json"}'
+export AICORE_DEPLOYMENT_ID="your-deployment-id"
+export AICORE_RESOURCE_GROUP="your-resource-group"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "sap-ai-core": {},
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "sap-ai-core/model-name",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Deployments (Foundation Models Mode)
 

--- a/packages/kilo-docs/pages/ai-providers/unbound.md
+++ b/packages/kilo-docs/pages/ai-providers/unbound.md
@@ -20,10 +20,30 @@ Unbound allows you configure a list of supported models in your application, and
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "Unbound" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your Unbound API key into the "Unbound API Key" field.
 4.  **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Unbound and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+{% callout type="warning" %}
+Unbound is not yet available as a CLI provider. Check the [Kilo Code releases](https://github.com/Kilo-Org/kilocode/releases) for updates on provider support.
+{% /callout %}
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/v0.md
+++ b/packages/kilo-docs/pages/ai-providers/v0.md
@@ -15,6 +15,9 @@ To use v0 with Kilo Code, you'll need:
 
 ## Configuration
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 Setting up v0 in Kilo Code is straightforward:
 
 1. In Kilo Code settings (click the {% codicon name="gear" /%} icon):
@@ -25,6 +28,48 @@ Setting up v0 in Kilo Code is straightforward:
    - Click **Verify** to confirm the connection
 
 <!-- <img src="/docs/img/providers/v0-setup.png" alt="v0 configuration in Kilo Code settings" width="600" /> -->
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add an OpenAI Compatible provider. Set the base URL to `https://api.v0.dev/v1` and enter your v0 API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+v0 uses the OpenAI-compatible provider. Set the API key and base URL in your config:
+
+**Environment variable:**
+
+```bash
+export OPENAI_API_KEY="your-v0-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "openai-compatible": {
+      "env": ["OPENAI_API_KEY"],
+      "baseURL": "https://api.v0.dev/v1",
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "openai-compatible/v0-1.0-md",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Troubleshooting
 

--- a/packages/kilo-docs/pages/ai-providers/vercel-ai-gateway.md
+++ b/packages/kilo-docs/pages/ai-providers/vercel-ai-gateway.md
@@ -54,10 +54,54 @@ Check the model description in the dropdown for specific capabilities.
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "Vercel AI Gateway" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your Vercel AI Gateway API key into the "Vercel AI Gateway API Key" field.
 4.  **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add Vercel AI Gateway and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export AI_GATEWAY_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "vercel": {
+      "env": ["AI_GATEWAY_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "vercel-ai-gateway/anthropic/claude-sonnet-4",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ---
 

--- a/packages/kilo-docs/pages/ai-providers/vercel-ai-gateway.md
+++ b/packages/kilo-docs/pages/ai-providers/vercel-ai-gateway.md
@@ -96,7 +96,7 @@ Then set your default model:
 
 ```jsonc
 {
-  "model": "vercel-ai-gateway/anthropic/claude-sonnet-4",
+  "model": "vercel/anthropic/claude-sonnet-4",
 }
 ```
 

--- a/packages/kilo-docs/pages/ai-providers/vertex.md
+++ b/packages/kilo-docs/pages/ai-providers/vertex.md
@@ -20,6 +20,9 @@ Kilo Code supports accessing models through Google Cloud Platform's Vertex AI, a
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "GCP Vertex AI" from the "API Provider" dropdown.
 3.  **Configure Authentication:**
@@ -30,6 +33,50 @@ Kilo Code supports accessing models through Google Cloud Platform's Vertex AI, a
 4.  **Enter Project ID:** Enter your Google Cloud Project ID.
 5.  **Select Region:** Choose the region where your Vertex AI resources are located (e.g., `us-east5`).
 6.  **Select Model:** Choose your desired model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add GCP Vertex AI. The extension uses Google Application Default Credentials (ADC) for authentication — run `gcloud auth application-default login` before adding the provider. Set your project ID and region in the provider settings.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Vertex AI uses Google Application Default Credentials (ADC) for authentication. Set up ADC using the Google Cloud CLI:
+
+```bash
+gcloud auth application-default login
+```
+
+Set your project and region as environment variables:
+
+```bash
+export GOOGLE_CLOUD_PROJECT="your-project-id"
+export GOOGLE_CLOUD_LOCATION="us-east5"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "google-vertex": {},
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "google-vertex/claude-sonnet-4@20250514",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/xai.md
+++ b/packages/kilo-docs/pages/ai-providers/xai.md
@@ -17,10 +17,54 @@ xAI is the company behind Grok, a large language model known for its conversatio
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2.  **Select Provider:** Choose "xAI" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your xAI API key into the "xAI API Key" field.
 4.  **Select Model:** Choose your desired Grok model from the "Model" dropdown.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add xAI and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export XAI_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "xai": {
+      "env": ["XAI_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "xai/grok-3",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Reasoning Capabilities
 

--- a/packages/kilo-docs/pages/ai-providers/zenmux.md
+++ b/packages/kilo-docs/pages/ai-providers/zenmux.md
@@ -16,11 +16,55 @@ import Codicon from "@site/src/components/Codicon";
 
 ## Configuration in Kilo Code
 
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
 1. **Open Kilo Code Settings:** Click the gear icon (<Codicon name="gear" />) in the Kilo Code panel.
 2. **Select Provider:** Choose "ZenMux" from the "API Provider" dropdown.
 3. **Enter API Key:** Paste your ZenMux API key into the "ZenMux API Key" field.
 4. **Select Model:** Choose your desired model from the "Model" dropdown.
 5. **(Optional) Custom Base URL:** If you need to use a custom base URL for the ZenMux API, check "Use custom base URL" and enter the URL. Leave this blank for most users.
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add ZenMux and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export ZENMUX_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "zenmux": {
+      "env": ["ZENMUX_API_KEY"],
+    },
+  },
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "zenmux/openai/gpt-5",
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Supported Models
 


### PR DESCRIPTION
## Summary

Adds VSCode (Pre-release) and CLI tabs to all 30 AI provider pages. **PR 8 of 8** from the docs platform tabs effort.

### Pages updated

- **index.md** — Overview with platform-specific provider configuration
- **29 individual provider pages** — Each gets VSCode, Pre-release, and CLI tabs

### Provider IDs verified against code

| Provider | Correct ID | Wrong ID (avoided) |
|----------|-----------|-------------------|
| Amazon Bedrock | `amazon-bedrock` | `bedrock` |
| Fireworks | `fireworks-ai` | `fireworks` |
| Chutes AI | `chutes` | `chutes-ai` |
| Moonshot | `moonshotai` | `moonshot` |
| Vercel | `vercel` | `vercel-ai-gateway` |

### Env vars verified

| Provider | Correct Env Var | Wrong Env Var (avoided) |
|----------|----------------|------------------------|
| Vercel | `AI_GATEWAY_API_KEY` | `VERCEL_AI_GATEWAY_API_KEY` |
| OVHcloud | `OVHCLOUD_API_KEY` | `OVH_AI_ENDPOINTS_ACCESS_TOKEN` |
| Vertex | `GOOGLE_CLOUD_LOCATION` | `GOOGLE_CLOUD_REGION` |
| SAP AI Core | `AICORE_SERVICE_KEY` | `SAP_AI_CORE_*` |

### Unsupported providers

Glama and Unbound show "not yet available as a CLI provider" warning callouts since they don't exist in `packages/opencode/src/provider/`.

Depends on #7497 for infrastructure.