### PR TITLE
fix(agent-manager): make Cmd+Shift+M work from VS Code terminal

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -102,6 +102,7 @@ export class AgentManagerProvider implements Disposable {
     if (this.panel) {
       this.log("Panel already open, revealing")
       this.panel.reveal()
+      this.postToWebview({ type: "action", action: "focusInput" })
       return
     }
     this.log("Opening Agent Manager panel")
@@ -1790,6 +1791,7 @@ export class AgentManagerProvider implements Disposable {
   public focusPanel(): void {
     if (!this.panel) return
     this.panel.reveal(false)
+    this.postToWebview({ type: "action", action: "focusInput" })
   }
 
   public isActive(): boolean {

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -367,10 +367,17 @@ async function openKiloInNewTab(context: vscode.ExtensionContext, connectionServ
  */
 function ensureCommandsSkipShell(commands: string[]): void {
   const config = vscode.workspace.getConfiguration("terminal.integrated")
-  const current: string[] = config.get("commandsToSkipShell", [])
-  const missing = commands.filter((cmd) => !current.includes(cmd))
+  const info = config.inspect<string[]>("commandsToSkipShell")
+  // Update whichever scope already carries an override so we don't
+  // shadow workspace settings or leak workspace values into global.
+  const [existing, target] = info?.workspaceFolderValue
+    ? [info.workspaceFolderValue, vscode.ConfigurationTarget.WorkspaceFolder]
+    : info?.workspaceValue
+      ? [info.workspaceValue, vscode.ConfigurationTarget.Workspace]
+      : [info?.globalValue ?? [], vscode.ConfigurationTarget.Global]
+  const missing = commands.filter((cmd) => !existing.includes(cmd))
   if (missing.length === 0) return
-  config.update("commandsToSkipShell", [...current, ...missing], vscode.ConfigurationTarget.Global)
+  config.update("commandsToSkipShell", [...existing, ...missing], target)
 }
 
 function waitForWebviewPanelToBeActive(panel: vscode.WebviewPanel): Promise<void> {

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -56,6 +56,12 @@ export function activate(context: vscode.ExtensionContext) {
     }),
   )
 
+  // Ensure Agent Manager keybindings work when a VS Code terminal has focus.
+  // The terminal intercepts all keystrokes unless the command is listed in
+  // terminal.integrated.commandsToSkipShell, which only contains built-in
+  // commands by default.
+  ensureCommandsSkipShell(["kilo-code.new.agentManagerOpen", "kilo-code.new.agentManager.showTerminal"])
+
   // Create Agent Manager provider for editor panel
   const agentManagerHost = new VscodeHost(context.extensionUri, connectionService, context)
   const agentManagerProvider = new AgentManagerProvider(agentManagerHost, connectionService)
@@ -352,6 +358,19 @@ async function openKiloInNewTab(context: vscode.ExtensionContext, connectionServ
     null,
     context.subscriptions,
   )
+}
+
+/**
+ * Add extension commands to terminal.integrated.commandsToSkipShell so they
+ * work when a VS Code terminal has focus. The setting only ships with built-in
+ * commands; extension commands must be added explicitly.
+ */
+function ensureCommandsSkipShell(commands: string[]): void {
+  const config = vscode.workspace.getConfiguration("terminal.integrated")
+  const current: string[] = config.get("commandsToSkipShell", [])
+  const missing = commands.filter((cmd) => !current.includes(cmd))
+  if (missing.length === 0) return
+  config.update("commandsToSkipShell", [...current, ...missing], vscode.ConfigurationTarget.Global)
 }
 
 function waitForWebviewPanelToBeActive(panel: vscode.WebviewPanel): Promise<void> {


### PR DESCRIPTION
## Summary

Core idea:
I want to switch in between worktree terminal and agent session without using the mouse.

- Registers `agentManagerOpen` and `showTerminal` commands in `terminal.integrated.commandsToSkipShell` on activation so keybindings fire when a VS Code terminal has focus
- Posts `focusInput` to the webview after revealing the Agent Manager panel so the prompt textarea is focused reliably

## Problem

`Cmd+Shift+M` (open Agent Manager) and `Cmd+/` (show terminal) did not work when a VS Code terminal had focus. The terminal intercepts all keystrokes by default — only commands listed in `terminal.integrated.commandsToSkipShell` are forwarded to VS Code's keybinding system, and that list only includes built-in commands, not extension commands.

## Test

1. Open Agent Manager (`Cmd+Shift+M`)
2. Open a terminal (`Cmd+/`)
3. Press `Cmd+Shift+M` — Agent Manager should focus with the prompt input selected