### PR TITLE
feat(cli): change default bash permission to ask for new users only

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -64,6 +64,7 @@ export namespace Agent {
     const whitelistedDirs = [Truncate.GLOB, ...skillDirs.map((dir) => path.join(dir, "*"))]
     const defaults = PermissionNext.fromConfig({
       "*": "allow",
+      bash: "ask", // kilocode_change
       doom_loop: "ask",
       external_directory: {
         "*": "ask",

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -62,9 +62,90 @@ export namespace Agent {
 
     const skillDirs = await Skill.dirs()
     const whitelistedDirs = [Truncate.GLOB, ...skillDirs.map((dir) => path.join(dir, "*"))]
+    // kilocode_change start — safe bash commands that don't need user approval
+    const bash: Record<string, string> = {
+      "*": "ask",
+      // read-only / informational
+      "cat *": "allow",
+      "head *": "allow",
+      "tail *": "allow",
+      "less *": "allow",
+      "ls *": "allow",
+      "tree *": "allow",
+      "pwd *": "allow",
+      "echo *": "allow",
+      "wc *": "allow",
+      "find *": "allow",
+      "which *": "allow",
+      "type *": "allow",
+      "file *": "allow",
+      "diff *": "allow",
+      "du *": "allow",
+      "df *": "allow",
+      "date *": "allow",
+      "uname *": "allow",
+      "whoami *": "allow",
+      "env *": "allow",
+      "printenv *": "allow",
+      "man *": "allow",
+      // text processing
+      "grep *": "allow",
+      "rg *": "allow",
+      "ag *": "allow",
+      "awk *": "allow",
+      "sed *": "allow",
+      "sort *": "allow",
+      "uniq *": "allow",
+      "cut *": "allow",
+      "tr *": "allow",
+      "jq *": "allow",
+      // file operations
+      "touch *": "allow",
+      "mkdir *": "allow",
+      "cp *": "allow",
+      "mv *": "allow",
+      // version control
+      "git *": "allow",
+      // package managers & runtimes
+      "node *": "allow",
+      "npx *": "allow",
+      "npm *": "allow",
+      "yarn *": "allow",
+      "pnpm *": "allow",
+      "bun *": "allow",
+      "bunx *": "allow",
+      "deno *": "allow",
+      // build & language tools
+      "tsc *": "allow",
+      "tsgo *": "allow",
+      "cargo *": "allow",
+      "go *": "allow",
+      "python *": "allow",
+      "python3 *": "allow",
+      "pip *": "allow",
+      "pip3 *": "allow",
+      "uv *": "allow",
+      "ruby *": "allow",
+      "gem *": "allow",
+      "make *": "allow",
+      "cmake *": "allow",
+      "dotnet *": "allow",
+      // http & archive
+      "curl *": "allow",
+      "wget *": "allow",
+      "tar *": "allow",
+      "unzip *": "allow",
+      "gzip *": "allow",
+      "gunzip *": "allow",
+      // containers
+      "docker *": "allow",
+      "docker-compose *": "allow",
+      "kubectl *": "allow",
+    }
+    // kilocode_change end
     const defaults = PermissionNext.fromConfig({
       "*": "allow",
-      bash: "ask", // kilocode_change
+      bash, // kilocode_change
       doom_loop: "ask",
       external_directory: {
         "*": "ask",

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -62,7 +62,8 @@ export namespace Agent {
 
     const skillDirs = await Skill.dirs()
     const whitelistedDirs = [Truncate.GLOB, ...skillDirs.map((dir) => path.join(dir, "*"))]
-    // kilocode_change start — safe bash commands that don't need user approval
+    // kilocode_change start — safe bash commands that don't need user approval.
+    // only commands that cannot execute arbitrary code or subprocesses.
     const bash: Record<string, "allow" | "ask" | "deny"> = {
       "*": "ask",
       // read-only / informational
@@ -75,7 +76,6 @@ export namespace Agent {
       "pwd *": "allow",
       "echo *": "allow",
       "wc *": "allow",
-      "find *": "allow",
       "which *": "allow",
       "type *": "allow",
       "file *": "allow",
@@ -85,7 +85,6 @@ export namespace Agent {
       "date *": "allow",
       "uname *": "allow",
       "whoami *": "allow",
-      "env *": "allow",
       "printenv *": "allow",
       "man *": "allow",
       // text processing
@@ -102,17 +101,9 @@ export namespace Agent {
       "mkdir *": "allow",
       "cp *": "allow",
       "mv *": "allow",
-      // version control
-      "git *": "allow",
-      // package managers (install/build, not arbitrary execution)
-      "npm *": "allow",
-      "yarn *": "allow",
-      "pnpm *": "allow",
-      "bun *": "allow",
-      // build tools (compilers, not script runners)
+      // compilers (no script execution)
       "tsc *": "allow",
       "tsgo *": "allow",
-      "make *": "allow",
       // archive
       "tar *": "allow",
       "unzip *": "allow",

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -63,7 +63,7 @@ export namespace Agent {
     const skillDirs = await Skill.dirs()
     const whitelistedDirs = [Truncate.GLOB, ...skillDirs.map((dir) => path.join(dir, "*"))]
     // kilocode_change start — safe bash commands that don't need user approval
-    const bash: Record<string, string> = {
+    const bash: Record<string, "allow" | "ask" | "deny"> = {
       "*": "ask",
       // read-only / informational
       "cat *": "allow",

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -92,8 +92,6 @@ export namespace Agent {
       "grep *": "allow",
       "rg *": "allow",
       "ag *": "allow",
-      "awk *": "allow",
-      "sed *": "allow",
       "sort *": "allow",
       "uniq *": "allow",
       "cut *": "allow",
@@ -106,41 +104,20 @@ export namespace Agent {
       "mv *": "allow",
       // version control
       "git *": "allow",
-      // package managers & runtimes
-      "node *": "allow",
-      "npx *": "allow",
+      // package managers (install/build, not arbitrary execution)
       "npm *": "allow",
       "yarn *": "allow",
       "pnpm *": "allow",
       "bun *": "allow",
-      "bunx *": "allow",
-      "deno *": "allow",
-      // build & language tools
+      // build tools (compilers, not script runners)
       "tsc *": "allow",
       "tsgo *": "allow",
-      "cargo *": "allow",
-      "go *": "allow",
-      "python *": "allow",
-      "python3 *": "allow",
-      "pip *": "allow",
-      "pip3 *": "allow",
-      "uv *": "allow",
-      "ruby *": "allow",
-      "gem *": "allow",
       "make *": "allow",
-      "cmake *": "allow",
-      "dotnet *": "allow",
-      // http & archive
-      "curl *": "allow",
-      "wget *": "allow",
+      // archive
       "tar *": "allow",
       "unzip *": "allow",
       "gzip *": "allow",
       "gunzip *": "allow",
-      // containers
-      "docker *": "allow",
-      "docker-compose *": "allow",
-      "kubectl *": "allow",
     }
     // kilocode_change end
     const defaults = PermissionNext.fromConfig({

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1335,7 +1335,43 @@ export namespace Config {
 
   export type Info = z.output<typeof Info>
 
+  // kilocode_change start — migrate bash permission for existing users before config is consumed
+  const GLOBAL_CONFIG_FILES = ["config.json", "kilo.json", "kilo.jsonc", "opencode.json", "opencode.jsonc"]
+
+  async function migrateBashPermission() {
+    const files = GLOBAL_CONFIG_FILES.map((file) => path.join(Global.Path.config, file))
+    const existing: string[] = []
+    for (const file of files) {
+      if (existsSync(file)) existing.push(file)
+    }
+    // no global config → new user, they'll get the new bash:ask default
+    if (existing.length === 0) return
+    // check if any config file already has an explicit bash permission
+    for (const file of existing) {
+      const text = await Bun.file(file).text()
+      const data = parseJsonc(text) ?? {}
+      if (data.permission?.bash) return
+    }
+    // existing user without bash permission in any file → write bash:allow to the
+    // highest-precedence existing file to preserve their current behavior
+    const target = existing[existing.length - 1]
+    const text = await Bun.file(target).text()
+    if (target.endsWith(".jsonc")) {
+      const edits = modify(text, ["permission", "bash"], "allow", {
+        formattingOptions: { insertSpaces: true, tabSize: 2 },
+      })
+      await Bun.write(target, applyEdits(text, edits))
+    } else {
+      const data = parseJsonc(text) ?? {}
+      const merged = { ...data, permission: { ...data.permission, bash: "allow" } }
+      await Bun.write(target, JSON.stringify(merged, null, 2))
+    }
+    log.info("migrated bash permission to allow for existing user", { path: target })
+  }
+  // kilocode_change end
+
   export const global = lazy(async () => {
+    await migrateBashPermission() // kilocode_change — run before config is read
     let result: Info = pipe(
       {},
       mergeDeep(await loadFile(path.join(Global.Path.config, "config.json"))),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1340,12 +1340,15 @@ export namespace Config {
 
   async function migrateBashPermission() {
     const files = GLOBAL_CONFIG_FILES.map((file) => path.join(Global.Path.config, file))
+    // also check legacy TOML config — its presence means existing user
+    const legacy = path.join(Global.Path.config, "config")
     const existing: string[] = []
     for (const file of files) {
       if (existsSync(file)) existing.push(file)
     }
+    const hasLegacy = existsSync(legacy)
     // no global config → new user, they'll get the new bash:ask default
-    if (existing.length === 0) return
+    if (existing.length === 0 && !hasLegacy) return
     // check if any config file already has an explicit bash permission
     for (const file of existing) {
       const text = await Bun.file(file).text()
@@ -1353,9 +1356,12 @@ export namespace Config {
       if (data.permission?.bash) return
     }
     // existing user without bash permission in any file → write bash:allow to the
-    // highest-precedence existing file to preserve their current behavior
-    const target = existing[existing.length - 1]
-    const text = await Bun.file(target).text()
+    // highest-precedence existing file to preserve their current behavior.
+    // if only the legacy TOML file exists, write to config.json (the TOML migration will merge into it)
+    const target = existing.length > 0 ? existing[existing.length - 1] : path.join(Global.Path.config, "config.json")
+    const text = await Bun.file(target)
+      .text()
+      .catch(() => "{}")
     if (target.endsWith(".jsonc")) {
       const edits = modify(text, ["permission", "bash"], "allow", {
         formattingOptions: { insertSpaces: true, tabSize: 2 },

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1355,6 +1355,11 @@ export namespace Config {
       const data = parseJsonc(text) ?? {}
       if (data.permission?.bash) return
     }
+    // also check legacy TOML config for bash permission
+    if (hasLegacy) {
+      const toml = await import(pathToFileURL(legacy).href, { with: { type: "toml" } }).catch(() => undefined)
+      if (toml?.default?.permission?.bash) return
+    }
     // existing user without bash permission in any file → write bash:allow to the
     // highest-precedence existing file to preserve their current behavior.
     // if only the legacy TOML file exists, write to config.json (the TOML migration will merge into it)

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -7,6 +7,7 @@ import { lazy } from "../util/lazy"
 import { Lock } from "../util/lock"
 import { $ } from "bun"
 import { NamedError } from "@opencode-ai/util/error"
+import { modify, applyEdits, parse as parseJsonc } from "jsonc-parser" // kilocode_change
 import z from "zod"
 import { Glob } from "../util/glob"
 
@@ -136,6 +137,35 @@ export namespace Storage {
         })
       }
     },
+    // kilocode_change start — preserve bash:allow for existing users when default changes to bash:ask
+    async () => {
+      const candidates = ["opencode.jsonc", "opencode.json", "config.json"].map((file) =>
+        path.join(Global.Path.config, file),
+      )
+      const existing = await (async () => {
+        for (const file of candidates) {
+          if (await Bun.file(file).exists()) return file
+        }
+      })()
+      // no global config → new user, they'll get the new bash:ask default
+      if (!existing) return
+      const text = await Bun.file(existing).text()
+      const data = parseJsonc(text) ?? {}
+      // user already has an explicit bash permission → nothing to do
+      if (data.permission?.bash) return
+      // existing user without bash permission → write bash:allow to preserve their current behavior
+      if (existing.endsWith(".jsonc")) {
+        const edits = modify(text, ["permission", "bash"], "allow", {
+          formattingOptions: { insertSpaces: true, tabSize: 2 },
+        })
+        await Bun.write(existing, applyEdits(text, edits))
+      } else {
+        const merged = { ...data, permission: { ...data.permission, bash: "allow" } }
+        await Bun.write(existing, JSON.stringify(merged, null, 2))
+      }
+      log.info("migrated bash permission to allow for existing user", { path: existing })
+    },
+    // kilocode_change end
   ]
 
   const state = lazy(async () => {

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -7,7 +7,6 @@ import { lazy } from "../util/lazy"
 import { Lock } from "../util/lock"
 import { $ } from "bun"
 import { NamedError } from "@opencode-ai/util/error"
-import { modify, applyEdits, parse as parseJsonc } from "jsonc-parser" // kilocode_change
 import z from "zod"
 import { Glob } from "../util/glob"
 
@@ -137,35 +136,6 @@ export namespace Storage {
         })
       }
     },
-    // kilocode_change start — preserve bash:allow for existing users when default changes to bash:ask
-    async () => {
-      const candidates = ["opencode.jsonc", "opencode.json", "config.json"].map((file) =>
-        path.join(Global.Path.config, file),
-      )
-      const existing = await (async () => {
-        for (const file of candidates) {
-          if (await Bun.file(file).exists()) return file
-        }
-      })()
-      // no global config → new user, they'll get the new bash:ask default
-      if (!existing) return
-      const text = await Bun.file(existing).text()
-      const data = parseJsonc(text) ?? {}
-      // user already has an explicit bash permission → nothing to do
-      if (data.permission?.bash) return
-      // existing user without bash permission → write bash:allow to preserve their current behavior
-      if (existing.endsWith(".jsonc")) {
-        const edits = modify(text, ["permission", "bash"], "allow", {
-          formattingOptions: { insertSpaces: true, tabSize: 2 },
-        })
-        await Bun.write(existing, applyEdits(text, edits))
-      } else {
-        const merged = { ...data, permission: { ...data.permission, bash: "allow" } }
-        await Bun.write(existing, JSON.stringify(merged, null, 2))
-      }
-      log.info("migrated bash permission to allow for existing user", { path: existing })
-    },
-    // kilocode_change end
   ]
 
   const state = lazy(async () => {


### PR DESCRIPTION
## Summary

Re-implements #7439 (default bash permission to `ask`) but only for **new users**, without affecting existing users.

- Adds `bash: "ask"` to the hardcoded permission defaults in `agent.ts`, so new users are prompted before shell commands execute
- Adds a storage migration that detects existing users (by checking for a global config file) and writes `bash: "allow"` to their config to preserve their current behavior
- Supports both JSON and JSONC config formats in the migration

### How it works

| User type | Has global config? | Has `bash` permission? | Result |
|---|---|---|---|
| New user | No | N/A | Gets new `bash: "ask"` default |
| Existing user, never customized bash | Yes | No | Migration writes `bash: "allow"` → no behavior change |
| Existing user, already customized bash | Yes | Yes | Migration skips → their setting preserved |

Closes #7436
