### PR TITLE
fix: prevent cmd.exe windows from appearing on Windows

### DIFF
--- a/packages/kilo-vscode/AGENTS.md
+++ b/packages/kilo-vscode/AGENTS.md
@@ -201,6 +201,16 @@ New webview features must use **`@kilocode/kilo-ui`** components instead of raw 
 
 This package is entirely Kilo-specific — `kilocode_change` markers are NOT needed in any files under `packages/kilo-vscode/`. The markers are only necessary when modifying shared upstream opencode files.
 
+## Process Spawning (Windows)
+
+On Windows, any `spawn`/`execFile`/`exec` call that does not set `windowsHide: true` will flash a cmd.exe console window at the user. To prevent this, **never import `spawn`, `execFile`, or `exec` from `child_process` directly**. Use the wrappers in `src/util/process.ts` instead — they enforce `windowsHide: true` automatically:
+
+```ts
+import { spawn, exec } from "../util/process"
+```
+
+The `spawn` wrapper covers long-lived processes (e.g. `kilo serve`). The `exec` wrapper covers short commands (e.g. `git`, `tar`). If you need the raw callback form of `execFile` for some reason, pass `windowsHide: true` explicitly in the options object.
+
 ## Style
 
 Follow monorepo root AGENTS.md style guide:

--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -357,6 +357,7 @@ export class GitOps {
           env: options?.env,
           encoding: "utf8",
           maxBuffer: 64 * 1024 * 1024,
+          windowsHide: true,
         },
         (error, stdout, stderr) => {
           if (!error) {

--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -1,7 +1,7 @@
 import * as nodePath from "path"
 import * as os from "os"
-import * as cp from "child_process"
 import * as fs from "fs/promises"
+import { spawn } from "../util/process"
 import simpleGit from "simple-git"
 import { parseWorktreeList, normalizePath } from "./git-import"
 
@@ -349,27 +349,11 @@ export class GitOps {
 
   private exec(args: string[], cwd: string, options?: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve) => {
-      const child = cp.execFile(
-        "git",
-        args,
-        {
-          cwd,
-          env: options?.env,
-          encoding: "utf8",
-          maxBuffer: 64 * 1024 * 1024,
-          windowsHide: true,
-        },
-        (error, stdout, stderr) => {
-          if (!error) {
-            resolve({ code: 0, stdout, stderr })
-            return
-          }
-          const exec = error as cp.ExecException
-          const code = typeof exec.code === "number" ? exec.code : 1
-          const fallback = exec.message || "Git command failed"
-          resolve({ code, stdout: stdout ?? "", stderr: stderr || fallback })
-        },
-      )
+      const child = spawn("git", args, {
+        cwd,
+        env: options?.env,
+        stdio: ["pipe", "pipe", "pipe"],
+      })
 
       if (options?.stdin !== undefined) {
         if (!child.stdin) {
@@ -378,6 +362,22 @@ export class GitOps {
         }
         child.stdin.end(options.stdin)
       }
+
+      const out: Buffer[] = []
+      const err: Buffer[] = []
+      child.stdout?.on("data", (chunk: Buffer) => out.push(chunk))
+      child.stderr?.on("data", (chunk: Buffer) => err.push(chunk))
+
+      child.on("error", (error) => {
+        resolve({ code: 1, stdout: "", stderr: error.message })
+      })
+      child.on("close", (code) => {
+        resolve({
+          code: code ?? 1,
+          stdout: Buffer.concat(out).toString("utf8"),
+          stderr: Buffer.concat(err).toString("utf8"),
+        })
+      })
     })
   }
 }

--- a/packages/kilo-vscode/src/agent-manager/shell-env.ts
+++ b/packages/kilo-vscode/src/agent-manager/shell-env.ts
@@ -11,11 +11,9 @@
  * process.env.PATH so all subsequent child_process calls benefit.
  */
 
-import { type ExecFileOptionsWithStringEncoding, execFile } from "child_process"
+import { type ExecFileOptionsWithStringEncoding } from "child_process"
 import * as os from "os"
-import { promisify } from "util"
-
-const run = promisify(execFile)
+import { exec } from "../util/process"
 
 // Environment variable keys match: letters, digits, underscores, starting with a non-digit.
 const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*=/
@@ -70,7 +68,7 @@ export async function getShellEnvironment(): Promise<Record<string, string>> {
   const shell = process.env.SHELL || (process.platform === "darwin" ? "/bin/zsh" : "/bin/bash")
 
   try {
-    const { stdout } = await run(shell, ["-lc", "env"], {
+    const { stdout } = await exec(shell, ["-lc", "env"], {
       timeout: 10_000,
       env: { ...process.env, HOME: os.homedir() },
     })
@@ -127,7 +125,7 @@ export async function execWithShellEnv(
   options?: Omit<ExecFileOptionsWithStringEncoding, "encoding">,
 ): Promise<{ stdout: string; stderr: string }> {
   try {
-    return await run(cmd, args, { ...options, encoding: "utf8" })
+    return await exec(cmd, args, options)
   } catch (error) {
     if (
       process.platform !== "darwin" ||
@@ -141,13 +139,13 @@ export async function execWithShellEnv(
     // Already resolved and PATH was actually changed — no point retrying resolution.
     // Just retry with the (already-patched) process.env.
     if (fixed) {
-      return await run(cmd, args, { ...options, encoding: "utf8" })
+      return await exec(cmd, args, options)
     }
 
     // If another caller is already resolving, wait for it then retry.
     if (fixing) {
       await fixing
-      return await run(cmd, args, { ...options, encoding: "utf8" })
+      return await exec(cmd, args, options)
     }
 
     console.log(`[shell-env] "${cmd}" not found, resolving shell environment`)
@@ -159,7 +157,7 @@ export async function execWithShellEnv(
       fixing = null
     }
 
-    return await run(cmd, args, { ...options, encoding: "utf8" })
+    return await exec(cmd, args, options)
   }
 }
 

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -1,4 +1,5 @@
-import { spawn, ChildProcess } from "child_process"
+import { type ChildProcess } from "child_process"
+import { spawn } from "../../util/process"
 import * as crypto from "crypto"
 import * as fs from "fs"
 import * as path from "path"
@@ -82,7 +83,6 @@ export class ServerManager {
         },
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
-        windowsHide: true,
       })
       console.log("[Kilo New] ServerManager: 📦 Process spawned with PID:", serverProcess.pid)
 

--- a/packages/kilo-vscode/src/services/marketplace/installer.ts
+++ b/packages/kilo-vscode/src/services/marketplace/installer.ts
@@ -1,9 +1,8 @@
 import * as fs from "fs/promises"
 import * as path from "path"
 import * as os from "os"
-import { execFile } from "child_process"
-import { promisify } from "util"
 import * as yaml from "yaml"
+import { exec } from "../../util/process"
 import type {
   MarketplaceItem,
   SkillMarketplaceItem,
@@ -15,8 +14,6 @@ import type {
   RemoveResult,
 } from "./types"
 import { MarketplacePaths } from "./paths"
-
-const exec = promisify(execFile)
 
 export class MarketplaceInstaller {
   constructor(private paths: MarketplacePaths) {}
@@ -152,7 +149,7 @@ export class MarketplaceInstaller {
       await fs.writeFile(tarball, buffer)
 
       await fs.mkdir(staging, { recursive: true })
-      await exec("tar", ["-xzf", tarball, "--strip-components=1", "-C", staging], { windowsHide: true })
+      await exec("tar", ["-xzf", tarball, "--strip-components=1", "-C", staging])
 
       const escaped = await findEscapedPaths(staging)
       if (escaped.length > 0) {

--- a/packages/kilo-vscode/src/services/marketplace/installer.ts
+++ b/packages/kilo-vscode/src/services/marketplace/installer.ts
@@ -152,7 +152,7 @@ export class MarketplaceInstaller {
       await fs.writeFile(tarball, buffer)
 
       await fs.mkdir(staging, { recursive: true })
-      await exec("tar", ["-xzf", tarball, "--strip-components=1", "-C", staging])
+      await exec("tar", ["-xzf", tarball, "--strip-components=1", "-C", staging], { windowsHide: true })
 
       const escaped = await findEscapedPaths(staging)
       if (escaped.length > 0) {

--- a/packages/kilo-vscode/src/util/process.ts
+++ b/packages/kilo-vscode/src/util/process.ts
@@ -1,0 +1,35 @@
+/**
+ * Process spawning utilities for the VS Code extension.
+ *
+ * All helpers set `windowsHide: true` to prevent cmd.exe console windows from
+ * flashing on Windows. Always use these instead of importing `spawn` or
+ * `execFile` from `child_process` directly.
+ *
+ * If you need the raw callback form of `execFile`, pass `windowsHide: true`
+ * explicitly in the options object.
+ */
+
+import {
+  spawn as _spawn,
+  execFile as _execFile,
+  type SpawnOptions,
+  type ExecFileOptionsWithStringEncoding,
+  type ChildProcess,
+} from "child_process"
+import { promisify } from "util"
+
+const _exec = promisify(_execFile)
+
+/** `child_process.spawn` with `windowsHide: true` forced on. */
+export function spawn(cmd: string, args: string[], opts: SpawnOptions = {}): ChildProcess {
+  return _spawn(cmd, args, { windowsHide: true, ...opts })
+}
+
+/** Promisified `child_process.execFile` with `windowsHide: true` forced on. */
+export async function exec(
+  cmd: string,
+  args: string[],
+  opts: Omit<ExecFileOptionsWithStringEncoding, "encoding"> = {},
+): Promise<{ stdout: string; stderr: string }> {
+  return _exec(cmd, args, { ...opts, encoding: "utf8", windowsHide: true })
+}

--- a/packages/opencode/AGENTS.md
+++ b/packages/opencode/AGENTS.md
@@ -49,6 +49,12 @@ export const get = fn(z.object({ id: z.string() }), async (input) => { ... })
 
 **Logging** -- Use `Log.create({ service: "name" })` pattern.
 
+## Process Spawning (Windows)
+
+On Windows, any `spawn`/`execFile` call without `windowsHide: true` will flash a cmd.exe console window at the user. Use `Process.spawn` from `src/util/process.ts` — it enforces `windowsHide: true` automatically. For `Bun.spawn`/`Bun.spawnSync`, pass `windowsHide` via the options object if the subprocess could create a visible console.
+
+The MCP `StdioClientTransport` (third-party SDK) is handled separately via a process shim in `src/mcp/index.ts` that sets `process.type = "browser"` when running inside the VS Code extension (`KILO_PLATFORM=vscode`), which causes the SDK's internal `isElectron()` check to return `true` and enable `windowsHide`.
+
 ## Storage
 
 Filesystem-based JSON, not a database. Data lives in `~/.local/share/kilo/storage/`. Keys are path arrays: `Storage.write(["session", projectID, sessionID], data)`.

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -3,6 +3,13 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+// kilocode_change start
+// The MCP SDK only sets windowsHide:true in Electron (checks `'type' in process`).
+// Set process.type so the SDK hides cmd.exe windows when spawning MCP servers on Windows.
+if (process.platform === "win32" && !("type" in process)) {
+  ;(process as NodeJS.Process & { type: string }).type = "browser"
+}
+// kilocode_change end
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import {
   CallToolResultSchema,

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -5,8 +5,10 @@ import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 // kilocode_change start
 // The MCP SDK only sets windowsHide:true in Electron (checks `'type' in process`).
-// Set process.type so the SDK hides cmd.exe windows when spawning MCP servers on Windows.
-if (process.platform === "win32" && !("type" in process)) {
+// When running inside the VS Code extension on Windows, set process.type so the SDK
+// hides cmd.exe windows when spawning MCP servers. The extension passes KILO_PLATFORM=vscode
+// so we use that to scope this shim to the vscode context only.
+if (process.platform === "win32" && process.env.KILO_PLATFORM === "vscode" && !("type" in process)) {
   ;(process as NodeJS.Process & { type: string }).type = "browser"
 }
 // kilocode_change end


### PR DESCRIPTION
## Summary

Fixes cmd.exe popup windows that still appear on Windows after #4475, specifically when enabling MCP servers (e.g. browser integration) and during Agent Manager git operations.

## Root Causes Fixed

### 1. MCP server spawning via `StdioClientTransport` (primary cause of popups on MCP enable)
The `@modelcontextprotocol/sdk`'s `StdioClientTransport` only sets `windowsHide: true` when running in Electron (it checks `'type' in process`). In a Bun/Node.js child process `process.type` is undefined, so `isElectron()` returns `false` — causing every MCP server spawn to flash a cmd.exe window.

**Fix:** Set `process.type = "browser"` in `packages/opencode/src/mcp/index.ts` before any `StdioClientTransport` is instantiated. Gated to `process.platform === "win32"` and only if `type` isn't already set.

### 2. Agent Manager git operations (`GitOps.ts`)
All git commands run by the Agent Manager were missing `windowsHide: true` on their `cp.execFile` calls.

### 3. Marketplace skill installer
The `tar` extraction during skill installation was missing `windowsHide: true`.