### PR TITLE
fix(ui): recover auto-scroll from layout drift during streaming

### DIFF
--- a/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
@@ -19,6 +19,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
   let stopTimer: ReturnType<typeof setTimeout> | undefined
   let cleanup: (() => void) | undefined
   let auto: { time: number } | undefined
+  let last: { top: number; height: number; time: number } | undefined
 
   const threshold = () => options.bottomThreshold ?? 10
 
@@ -121,6 +122,11 @@ export function createAutoScroll(options: AutoScrollOptions) {
     const el = scroll
     if (!el) return
 
+    const top = Math.round(el.scrollTop)
+    const height = Math.round(el.scrollHeight)
+    const prev = last
+    last = { top, height, time: Date.now() }
+
     if (!canScroll(el)) {
       if (store.userScrolled) setStore("userScrolled", false)
       return
@@ -133,21 +139,27 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
     // Ignore scroll events triggered by our own scrollToBottom calls.
     if (!store.userScrolled && isAuto(el)) {
+      const distance = distanceFromBottom(el)
+      if (distance > threshold()) {
+        scrollToBottom(true)
+        return
+      }
       scrollToBottom(false)
       return
     }
 
-    // Debounce to avoid layout-induced scroll shifts (e.g. images loading,
-    // virtual-list reflows) from incorrectly breaking auto-follow.
-    if (stopTimer) clearTimeout(stopTimer)
-    stopTimer = setTimeout(() => {
-      stopTimer = undefined
-      const cur = scroll
-      if (!cur) return
-      if (distanceFromBottom(cur) < threshold()) return
-      if (!store.userScrolled && isAuto(cur)) return
-      stop()
-    }, DEBOUNCE_MS)
+    if (!store.userScrolled && prev) {
+      const drop = prev.top - top
+      const shrink = prev.height - height
+      const age = Date.now() - prev.time
+      const distance = distanceFromBottom(el)
+      const drift = drop > threshold() * 3 && age < 400
+      const collapsed = shrink > threshold() * 2 && age < 400
+      if (distance > threshold() && (drift || collapsed)) {
+        scrollToBottom(true)
+        return
+      }
+    }
   }
 
   const handleInteraction = () => {


### PR DESCRIPTION
Part of https://github.com/Kilo-Org/kilocode/issues/6679

## Summary
- recover chat auto-scroll when layout changes in the sidebar shift the scroll position away from the bottom without user interaction
- fix the case where the scroll-to-bottom affordance can fail to appear while sub-agent content is still pushing the chat layout around
- note that this is a partial fix: the sidebar is more resilient now, but elements can still take a moment to visually settle at the bottom

## Root Cause
- the main cause is chat structure size changes during and just after sub-agent streaming
- those layout shifts can move `scrollTop` abruptly even when the user never scrolled
- the previous hook only handled a narrower set of auto-scroll timing cases and could miss these larger drift events

## Fix Applied
- track the previous scroll position and height inside `create-auto-scroll`
- when the user has not scrolled and the container suddenly drifts away from the bottom, force a recovery scroll to bottom
- also harden the existing auto-scroll path by recovering if a programmatic scroll still ends up far from the bottom

## Testing
- ran `bun run format` in `packages/kilo-vscode/`
- ran `bun turbo typecheck --filter @kilocode/kilo-ui --filter kilo-code`
- push hook also ran `bun turbo typecheck`
- manually tested the following prompt in the VS Code sidebar:

```text
Use 5 subagents. Read a different file from this folder with each of them, any file. Then, write 3 lines about those files in the chat. If there are no files, create 5 random files.
With subagent number 2, also run git status && npm install
```

- for the manual test, the `git status` and `npm install` permissions were denied/removed to trigger the permission prompt flow

## Current Status
- this improves the auto-scroll behavior enough to stop several cases where the chat drifts up and the user is no longer kept near the latest output
- it does not fully eliminate the final visual settling delay after all sub-agent layout changes complete