### PR TITLE
feat: show resolved model name for kilo-auto variants

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -951,6 +951,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
 
   const variants = createMemo(() => ["default", ...local.model.variant.list()])
+  // kilocode_change start - resolved model name for kilo-auto variants
+  const resolved = createMemo(() => {
+    const m = local.model.current()
+    if (!m?.variants) return undefined
+    const variant = local.model.variant.current()
+    if (!variant) return undefined
+    return (m.variants[variant] as Record<string, unknown>)?.name as string | undefined
+  })
+  // kilocode_change end
   const accepting = createMemo(() => {
     const id = params.id
     if (!id) return permission.isAutoAcceptingDirectory(sdk.directory)
@@ -1436,6 +1445,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                         </Show>
                         <span class="truncate">
                           {local.model.current()?.name ?? language.t("dialog.model.select.title")}
+                          {/* kilocode_change */}
+                          <Show when={resolved()}>{(name) => <span class="text-text-weak"> ({name()})</span>}</Show>
                         </span>
                         <Icon name="chevron-down" size="small" class="shrink-0" />
                       </Button>
@@ -1472,6 +1483,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                       </Show>
                       <span class="truncate">
                         {local.model.current()?.name ?? language.t("dialog.model.select.title")}
+                        {/* kilocode_change */}
+                        <Show when={resolved()}>{(name) => <span class="text-text-weak"> ({name()})</span>}</Show>
                       </span>
                       <Icon name="chevron-down" size="small" class="shrink-0" />
                     </ModelSelectorPopover>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -8,9 +8,11 @@ import { Component, createSignal, For, Show } from "solid-js"
 import { Popover } from "@kilocode/kilo-ui/popover"
 import { Button } from "@kilocode/kilo-ui/button"
 import { useSession } from "../../context/session"
+import { useProvider } from "../../context/provider"
 
 export const ThinkingSelector: Component = () => {
   const session = useSession()
+  const provider = useProvider()
   const [open, setOpen] = createSignal(false)
 
   const variants = () => session.variantList()
@@ -22,9 +24,20 @@ export const ThinkingSelector: Component = () => {
     requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
   }
 
+  const model = () => {
+    const sel = session.selected()
+    return sel ? provider.findModel(sel) : undefined
+  }
+
+  const nameFor = (v: string) =>
+    (model()?.variants?.[v] as Record<string, unknown> | undefined)?.name as string | undefined
+
   const triggerLabel = () => {
     const v = current()
-    return v ? v.charAt(0).toUpperCase() + v.slice(1) : ""
+    if (!v) return ""
+    const label = v.charAt(0).toUpperCase() + v.slice(1)
+    const name = nameFor(v)
+    return name ? `${label} (${name})` : label
   }
 
   return (
@@ -53,7 +66,13 @@ export const ThinkingSelector: Component = () => {
                 aria-selected={current() === v}
                 onClick={() => pick(v)}
               >
-                <span class="thinking-selector-item-name">{v.charAt(0).toUpperCase() + v.slice(1)}</span>
+                <span class="thinking-selector-item-name">
+                  {v.charAt(0).toUpperCase() + v.slice(1)}
+                  {(() => {
+                    const n = nameFor(v)
+                    return n ? ` (${n})` : ""
+                  })()}
+                </span>
               </div>
             )}
           </For>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -8,11 +8,9 @@ import { Component, createSignal, For, Show } from "solid-js"
 import { Popover } from "@kilocode/kilo-ui/popover"
 import { Button } from "@kilocode/kilo-ui/button"
 import { useSession } from "../../context/session"
-import { useProvider } from "../../context/provider"
 
 export const ThinkingSelector: Component = () => {
   const session = useSession()
-  const provider = useProvider()
   const [open, setOpen] = createSignal(false)
 
   const variants = () => session.variantList()
@@ -24,20 +22,9 @@ export const ThinkingSelector: Component = () => {
     requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
   }
 
-  const model = () => {
-    const sel = session.selected()
-    return sel ? provider.findModel(sel) : undefined
-  }
-
-  const nameFor = (v: string) =>
-    (model()?.variants?.[v] as Record<string, unknown> | undefined)?.name as string | undefined
-
   const triggerLabel = () => {
     const v = current()
-    if (!v) return ""
-    const label = v.charAt(0).toUpperCase() + v.slice(1)
-    const name = nameFor(v)
-    return name ? `${label} (${name})` : label
+    return v ? v.charAt(0).toUpperCase() + v.slice(1) : ""
   }
 
   return (
@@ -66,13 +53,7 @@ export const ThinkingSelector: Component = () => {
                 aria-selected={current() === v}
                 onClick={() => pick(v)}
               >
-                <span class="thinking-selector-item-name">
-                  {v.charAt(0).toUpperCase() + v.slice(1)}
-                  {(() => {
-                    const n = nameFor(v)
-                    return n ? ` (${n})` : ""
-                  })()}
-                </span>
+                <span class="thinking-selector-item-name">{v.charAt(0).toUpperCase() + v.slice(1)}</span>
               </div>
             )}
           </For>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -750,6 +750,18 @@ export function Prompt(props: PromptProps) {
     return !!current
   })
 
+  // kilocode_change start - resolved model name for kilo-auto variants
+  const resolved = createMemo(() => {
+    const m = local.model.current()
+    if (!m) return undefined
+    const variant = local.model.variant.current()
+    if (!variant) return undefined
+    const provider = sync.data.provider.find((x) => x.id === m.providerID)
+    const info = provider?.models[m.modelID]
+    return info?.variants?.[variant]?.name as string | undefined
+  })
+  // kilocode_change end
+
   const placeholderText = createMemo(() => {
     if (props.sessionID) return undefined
     if (store.mode === "shell") {
@@ -1031,6 +1043,11 @@ export function Prompt(props: PromptProps) {
                     <text>
                       <span style={{ fg: theme.warning, bold: true }}>{local.model.variant.current()}</span>
                     </text>
+                    {/* kilocode_change start - show resolved model name */}
+                    <Show when={resolved()}>
+                      <text fg={theme.textMuted}>({resolved()})</text>
+                    </Show>
+                    {/* kilocode_change end */}
                   </Show>
                 </box>
               </Show>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -754,11 +754,10 @@ export function Prompt(props: PromptProps) {
   const resolved = createMemo(() => {
     const m = local.model.current()
     if (!m) return undefined
-    const variant = local.model.variant.current()
-    if (!variant) return undefined
+    const agent = local.agent.current().name
     const provider = sync.data.provider.find((x) => x.id === m.providerID)
     const info = provider?.models[m.modelID]
-    return info?.variants?.[variant]?.name as string | undefined
+    return info?.variants?.[agent]?.name as string | undefined
   })
   // kilocode_change end
 
@@ -1037,17 +1036,17 @@ export function Prompt(props: PromptProps) {
                   <text flexShrink={0} fg={keybind.leader ? theme.textMuted : theme.text}>
                     {local.model.parsed().model}
                   </text>
+                  {/* kilocode_change start - show resolved model name */}
+                  <Show when={resolved()}>
+                    <text fg={theme.textMuted}>({resolved()})</text>
+                  </Show>
+                  {/* kilocode_change end */}
                   <text fg={theme.textMuted}>{local.model.parsed().provider}</text>
                   <Show when={showVariant()}>
                     <text fg={theme.textMuted}>·</text>
                     <text>
                       <span style={{ fg: theme.warning, bold: true }}>{local.model.variant.current()}</span>
                     </text>
-                    {/* kilocode_change start - show resolved model name */}
-                    <Show when={resolved()}>
-                      <text fg={theme.textMuted}>({resolved()})</text>
-                    </Show>
-                    {/* kilocode_change end */}
                   </Show>
                 </box>
               </Show>

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -168,6 +168,24 @@ export namespace ModelsDev {
       }
     }
 
+    // Enrich kilo-auto variant values with display names of resolved models
+    const kilo = providers["kilo"]
+    if (kilo) {
+      for (const model of Object.values(kilo.models)) {
+        if (!model.variants) continue
+        for (const variant of Object.values(model.variants)) {
+          const id = variant.model
+          if (typeof id !== "string") continue
+          const slash = id.indexOf("/")
+          if (slash === -1) continue
+          const pid = id.slice(0, slash)
+          const mid = id.slice(slash + 1)
+          const resolved = providers[pid]?.models[mid]
+          if (resolved?.name) variant.name = resolved.name
+        }
+      }
+    }
+
     return providers
     // kilocode_change end
   }


### PR DESCRIPTION
## Summary

Shows the resolved model name for Kilo Auto variants in the CLI TUI. When using a Kilo Auto model, you can see which actual model is running behind it — e.g. `Kilo Auto Frontier (Claude Opus 4.6)  Kilo Gateway`.

## Root cause

The `resolved` memo was reading `local.model.variant.current()`, which only returns a **manually cycled** variant. Since kilo-auto variant keys are agent mode names (`"code"`, `"plan"`, `"architect"`) — not user-cycled values — the lookup always returned `undefined`, hiding the resolved name.

## Changes

### `packages/opencode/src/provider/models.ts`
Enriches kilo-auto variant values with a `name` field by looking up the display name for each variant's underlying model (e.g. `anthropic/claude-sonnet-4-6` → `"Claude Sonnet 4.6"`).

### `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
- **Fix resolved memo**: Changed lookup key from `local.model.variant.current()` to `local.agent.current().name` — the agent name matches the variant keys from the API
- **Move display**: Moved the `<Show when={resolved()}>` block out of the `showVariant` badge and placed it between the model name and provider name

### `packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx`
Reverted to pre-change state — the VS Code extension's session context already falls back to `list[0]` for currentVariant, so no extra lookup was needed. Removed the `useProvider`/`findModel`/`nameFor` additions.

## Display format

```
Before:  Plan  Kilo Auto Frontier  Kilo Gateway
After:   Plan  Kilo Auto Frontier (Claude Opus 4.6)  Kilo Gateway
```

## How to test

1. Select a Kilo Auto model (e.g. "Kilo Auto Frontier")
2. Open the CLI TUI
3. Confirm the resolved model name appears in parentheses next to the model name
4. Switch agents (code → plan) and confirm the resolved name updates
5. Switch to a non-kilo-auto model and confirm no resolved name appears