### PR TITLE
fix(vscode, cli): sync agent selector after plan_exit code switch

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -664,6 +664,23 @@ export const SessionProvider: ParentComponent = (props) => {
     if (message.parts && message.parts.length > 0) {
       setStore("parts", message.id, message.parts)
     }
+
+    // Sync the agent selector when a server-injected user message arrives
+    // with a different agent (e.g. PlanFollowup injects agent:"code" after
+    // plan_exit). Without this, the UI stays on the previous agent and the
+    // user's next manual message would re-enter the old agent's permissions.
+    if (
+      !wasOptimistic &&
+      message.role === "user" &&
+      message.agent &&
+      message.sessionID === currentSessionID() &&
+      agents().some((a) => a.name === message.agent && a.mode !== "subagent")
+    ) {
+      const current = store.agentSelections[message.sessionID] ?? defaultAgent()
+      if (current !== message.agent) {
+        setStore("agentSelections", message.sessionID, message.agent)
+      }
+    }
   }
 
   function handlePartUpdated(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1460,16 +1460,20 @@ When you have finalized your plan and are confident it is ready for implementati
       // kilocode_change end
       // kilocode_change start - handle code-switch from any planning agent
       if (wasPlanningAgent && input.agent.name === "code") {
-        // kilocode_change end
+        const plan = Session.plan(input.session)
+        const exists = await Filesystem.exists(plan)
         userMessage.parts.push({
           id: Identifier.ascending("part"),
           messageID: userMessage.info.id,
           sessionID: userMessage.info.sessionID,
           type: "text",
-          text: CODE_SWITCH,
+          text: exists
+            ? CODE_SWITCH + "\n\n" + `A plan file exists at ${plan}. You should execute on the plan defined within it.`
+            : CODE_SWITCH,
           synthetic: true,
         })
       }
+      // kilocode_change end
       return input.messages
     }
 

--- a/packages/opencode/src/session/prompt/code-switch.txt
+++ b/packages/opencode/src/session/prompt/code-switch.txt
@@ -1,5 +1,5 @@
 <system-reminder>
-Your operational mode has changed from plan to code.
+Your operational mode has changed to code.
 You are no longer in read-only mode.
 You are permitted to make file changes, run shell commands, and utilize your arsenal of tools as needed.
 </system-reminder>


### PR DESCRIPTION
## Summary

Fixes the VS Code extension getting stuck in architect mode's restricted permissions after transitioning to code mode via `plan_exit` → "Continue here".

- **Root cause**: The VS Code webview did not sync its agent selector when the server injected a synthetic user message with `agent: "code"` (via `PlanFollowup`). The CLI TUI had this sync but the extension did not, so the user's next manual message would re-enter architect mode with `edit: {"*": "deny"}` — allowing only plan file edits.
- **Primary fix**: Sync the agent selector in `handleMessageCreated` when a non-optimistic server-injected user message arrives with a different primary agent.
- **Additional improvements**: Include plan file reference in the non-experimental code switch prompt; fix `code-switch.txt` wording for architect→code transitions.

## Test plan

1. Start a session in architect mode in the VS Code extension
2. Let the architect create a plan and call `plan_exit`
3. Click "Continue here" on the followup prompt
4. Verify the agent selector switches to "code" in the UI
5. Verify the code agent can edit files without restriction
6. Type a follow-up message and verify it stays in code mode