### PR TITLE
fix(agent-manager): prevent duplicate panels via deserialization and stale dispose

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -117,6 +117,11 @@ export class AgentManagerProvider implements Disposable {
   /** Restore the Agent Manager panel from a previously serialized state.
    *  The caller (extension.ts / vscode-host.ts) wraps the raw panel before passing it. */
   public deserializePanel(ctx: PanelContext): void {
+    if (this.panel) {
+      this.log("Panel already exists during deserialization, disposing duplicate")
+      ctx.dispose()
+      return
+    }
     this.log("Deserializing Agent Manager panel")
     this.attachPanel(ctx)
   }
@@ -128,6 +133,11 @@ export class AgentManagerProvider implements Disposable {
 
   /** Wire up a panel context (shared by openPanel and deserializePanel). */
   private attachPanel(ctx: PanelContext): void {
+    if (this.panel) {
+      this.log("Disposing previous panel before attaching new one")
+      this.panel.dispose()
+      this.panel = undefined
+    }
     this.panel = ctx
 
     this.stateReady = this.initializeState()
@@ -135,11 +145,15 @@ export class AgentManagerProvider implements Disposable {
     this.sendKeybindings()
 
     ctx.onDidDispose(() => {
-      this.log("Panel disposed")
-      this.statsPoller.stop()
-      this.stopDiffPolling()
+      // Only clear if this is still the active panel — a newer panel may
+      // have already replaced us via attachPanel.
+      if (this.panel === ctx) {
+        this.log("Panel disposed")
+        this.statsPoller.stop()
+        this.stopDiffPolling()
+        this.panel = undefined
+      }
       ctx.sessions.dispose()
-      this.panel = undefined
     })
   }
 


### PR DESCRIPTION
## Summary

- Adds singleton guard to `deserializePanel` — if a panel already exists when VS Code restores serialized panels (e.g. after crash or workspace state corruption), the duplicate is immediately disposed
- Adds defensive guard in `attachPanel` — disposes the previous panel before wiring up a new one, preventing orphaned live panels
- Fixes stale `onDidDispose` closure — the callback now checks `this.panel === ctx` so a replaced panel's dispose won't clear the reference to the newer active panel

## Problem

Multiple agent-manager tabs could open simultaneously, causing cross-contamination where changes in one panel appeared in the other. The existing singleton guard in `openPanel()` only covered the manual-open path. The deserialization path (`deserializePanel`) had no guard at all, and `attachPanel` would silently overwrite `this.panel` without disposing the previous one.