### PR TITLE
fix(agent-manager): preserve review comments when switching session tabs

### DIFF
--- a/packages/kilo-vscode/tests/unit/review-comments.test.ts
+++ b/packages/kilo-vscode/tests/unit/review-comments.test.ts
@@ -120,6 +120,31 @@ describe("sanitizeReviewComments", () => {
     const result = sanitizeReviewComments([valid, invalid, missing], [diff("a.ts", "", "content")])
     expect(result).toEqual([valid])
   })
+
+  // Regression: when switching session tabs within a worktree while the diff
+  // panel is open, the DiffPanel's diffs prop resolves to [] because the new
+  // session's diffs haven't been fetched yet (diffDatas keyed by session ID
+  // has no entry for the newly-selected session). sanitizeReviewComments then
+  // runs with the worktree's real comments against an empty diff set and wipes
+  // every comment — since no file in an empty map matches any comment.
+  //
+  // This test proves the data loss mechanism: valid comments are destroyed
+  // when sanitize receives an empty diff set (transient during session switch).
+  it("wipes all valid comments when diffs is empty (session switch race)", () => {
+    const existing = [
+      comment({ file: "src/auth.ts", line: 5 }),
+      comment({ file: "src/auth.ts", line: 12 }),
+      comment({ file: "src/db.ts", line: 3 }),
+    ]
+    // During a tab switch the DiffPanel momentarily receives [] because
+    // diffDatas has no entry for the new session ID yet.
+    const result = sanitizeReviewComments(existing, [])
+    expect(result).toEqual([])
+    // ^ This is the bug: comments should NOT be wiped by a transient empty state.
+    // The fix is in the DiffPanel's diffs source, not in sanitizeReviewComments
+    // itself — DiffPanel must use reviewDiffs() (which has worktree-level fallback)
+    // instead of a direct session-ID lookup into diffDatas.
+  })
 })
 
 // ── formatReviewCommentsMarkdown ────────────────────────────────────────────

--- a/packages/kilo-vscode/tests/unit/review-comments.test.ts
+++ b/packages/kilo-vscode/tests/unit/review-comments.test.ts
@@ -120,31 +120,6 @@ describe("sanitizeReviewComments", () => {
     const result = sanitizeReviewComments([valid, invalid, missing], [diff("a.ts", "", "content")])
     expect(result).toEqual([valid])
   })
-
-  // Regression: when switching session tabs within a worktree while the diff
-  // panel is open, the DiffPanel's diffs prop resolves to [] because the new
-  // session's diffs haven't been fetched yet (diffDatas keyed by session ID
-  // has no entry for the newly-selected session). sanitizeReviewComments then
-  // runs with the worktree's real comments against an empty diff set and wipes
-  // every comment — since no file in an empty map matches any comment.
-  //
-  // This test proves the data loss mechanism: valid comments are destroyed
-  // when sanitize receives an empty diff set (transient during session switch).
-  it("wipes all valid comments when diffs is empty (session switch race)", () => {
-    const existing = [
-      comment({ file: "src/auth.ts", line: 5 }),
-      comment({ file: "src/auth.ts", line: 12 }),
-      comment({ file: "src/db.ts", line: 3 }),
-    ]
-    // During a tab switch the DiffPanel momentarily receives [] because
-    // diffDatas has no entry for the new session ID yet.
-    const result = sanitizeReviewComments(existing, [])
-    expect(result).toEqual([])
-    // ^ This is the bug: comments should NOT be wiped by a transient empty state.
-    // The fix is in the DiffPanel's diffs source, not in sanitizeReviewComments
-    // itself — DiffPanel must use reviewDiffs() (which has worktree-level fallback)
-    // instead of a direct session-ID lookup into diffDatas.
-  })
 })
 
 // ── formatReviewCommentsMarkdown ────────────────────────────────────────────

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2773,7 +2773,7 @@ const AgentManagerContent: Component = () => {
                 />
                 <div class="am-diff-panel-wrapper">
                   <DiffPanel
-                    diffs={diffDatas()[currentDiffSessionId() ?? ""] ?? []}
+                    diffs={reviewDiffs()}
                     loading={diffLoading()}
                     loadingFiles={diffFileLoadingForCurrent()}
                     sessionId={currentDiffSessionId()}


### PR DESCRIPTION
## Summary

- DiffPanel resolved diffs via a direct session-ID lookup into `diffDatas`, which returned `[]` when switching to a tab whose diffs hadn't been fetched yet. The sanitize effect then wiped all worktree-scoped comments against the empty diff set.
- Use `reviewDiffs()` (which falls back to any session in the same worktree) so the diffs source matches the worktree-level comment storage.

## How to test

1. Open Agent Manager (`Cmd+Shift+M`)
2. Select a worktree with uncommitted file changes
3. Open the diff panel (layers icon in tab actions)
4. Click a line gutter to add a comment
5. Click `+` to create a second session tab in the same worktree
6. Switch to the new tab, then switch back
7. The comment should still be there (before this fix it was gone)