### PR TITLE
fix(agent-manager): worktree setup overlay stuck when using custom base branch

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -49,6 +49,17 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "taskDefinitions": [
+      {
+        "type": "kilo-worktree-setup",
+        "properties": {
+          "script": {
+            "type": "string",
+            "description": "The setup script command to execute"
+          }
+        }
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -845,9 +845,9 @@ export class AgentManagerProvider implements Disposable {
         continue
       }
 
-      await this.runSetupScriptForWorktree(wt.result.path, wt.result.branch)
+      await this.runSetupScriptForWorktree(wt.result.path, wt.result.branch, wt.worktree.id)
 
-      const session = await this.createSessionInWorktree(wt.result.path, wt.result.branch)
+      const session = await this.createSessionInWorktree(wt.result.path, wt.result.branch, wt.worktree.id)
       if (!session) {
         const state = this.getStateManager()
         const manager = this.getWorktreeManager()
@@ -860,7 +860,7 @@ export class AgentManagerProvider implements Disposable {
       const state = this.getStateManager()!
       state.addSession(session.id, wt.worktree.id)
       this.registerWorktreeSession(session.id, wt.result.path)
-      this.notifyWorktreeReady(session.id, wt.result)
+      this.notifyWorktreeReady(session.id, wt.result, wt.worktree.id)
 
       // Set the per-version model immediately so the UI selector reflects
       // the correct model as soon as the worktree appears, before Phase 2.
@@ -1334,6 +1334,7 @@ export class AgentManagerProvider implements Disposable {
         status: "error",
         message: `Setup script failed: ${msg}`,
         branch,
+        worktreeId,
       })
     }
   }

--- a/packages/kilo-vscode/src/agent-manager/task-runner.ts
+++ b/packages/kilo-vscode/src/agent-manager/task-runner.ts
@@ -28,7 +28,16 @@ export async function executeVscodeTask(config: SetupTaskConfig): Promise<number
     showReuseMessage: false,
   }
 
-  const execution = await vscode.tasks.executeTask(task)
+  let execution: vscode.TaskExecution
+  try {
+    execution = await vscode.tasks.executeTask(task)
+  } catch {
+    // Task type may not be registered in certain VS Code environments
+    // (e.g. remote, codespaces, or if package.json contribution is not loaded yet).
+    // Return undefined so SetupScriptRunner treats it as a non-fatal skip
+    // rather than VS Code surfacing its own error notification.
+    return undefined
+  }
 
   return new Promise((resolve, reject) => {
     let done = false


### PR DESCRIPTION
## Summary

- Fix permanent setup overlay when creating worktrees via the Advanced dialog (with or without custom base branch)
- Fix VS Code error notification for undeclared `kilo-worktree-setup` task type

## Problem

`onCreateMultiVersion` (the codepath used by the Advanced worktree dialog, even for single-version) was missing `worktreeId` in three calls: `runSetupScriptForWorktree`, `createSessionInWorktree`, and `notifyWorktreeReady`. The webview tracks busy worktrees by `worktreeId` — without it, the setup overlay (`position: absolute; inset: 0; z-index: 10; background: solid`) could never be cleared, permanently blocking all interaction with the worktree.

Separately, the `kilo-worktree-setup` task type was never declared in `package.json`, so VS Code rejected `executeTask()` and showed a persistent error notification for users who had setup scripts configured.

## Changes

- **`AgentManagerProvider.ts`**: Pass `wt.worktree.id` to `runSetupScriptForWorktree`, `createSessionInWorktree`, and `notifyWorktreeReady` in `onCreateMultiVersion`. Also include `worktreeId` in the setup script error message so the webview can clear busy state on failure.
- **`package.json`**: Declare `kilo-worktree-setup` in `contributes.taskDefinitions`.
- **`task-runner.ts`**: Catch `executeTask` failures gracefully, returning `undefined` instead of letting VS Code surface its own error notification.

## Testing

1. Open Agent Manager → Advanced dialog (+ dropdown)
2. Expand "Advanced options", select a non-default base branch
3. Create worktree — overlay should dismiss once ready
4. If a setup script is configured (`.kilo/setup-script`), it should run in a VS Code task terminal without errors