### PR TITLE
fix(ui): reject dotted code identifiers as file-link paths in chat

### DIFF
--- a/packages/kilo-ui/src/file-path.ts
+++ b/packages/kilo-ui/src/file-path.ts
@@ -7,6 +7,14 @@ const FILE_PATH_UNIX_RE =
   /^((?:\/|\.\.?\/)?(?:[a-zA-Z0-9_@-][a-zA-Z0-9_@./-]*\/)*[a-zA-Z0-9_@.-]+\.[a-zA-Z0-9]+)(?::(\d+)(?::(\d+))?)?$/
 const FILE_PATH_WIN_RE = /^((?:[a-zA-Z]:[/\\]|\\\\)(?:[^\\/]+[/\\])*[^\\/]+\.[a-zA-Z0-9]+)(?::(\d+)(?::(\d+))?)?$/
 
+// For bare names (no path separator), reject dotted identifiers like
+// `session.updateMode` or `Object.keys`. Real file extensions are short
+// and lowercase (e.g. .ts, .json, .graphql). Extensions containing
+// uppercase letters (camelCase method names) or longer than 7 chars
+// are almost certainly code identifiers, not files.
+const BARE_EXT_RE = /\.([a-zA-Z0-9]+)(?::\d+(?::\d+)?)?$/
+const MAX_BARE_EXT = 7
+
 /**
  * Parse an inline code span into a file path with optional line/column.
  * Returns undefined when the text does not look like a file reference.
@@ -19,8 +27,20 @@ export function parseFilePath(text: string): { path: string; line?: number; colu
   if (text.includes(" ")) return undefined
   const match = FILE_PATH_UNIX_RE.exec(text) ?? FILE_PATH_WIN_RE.exec(text)
   if (!match) return undefined
+  // For bare names without a path separator, validate the extension.
+  // Dotted code identifiers like `session.updateMode` or `React.useState`
+  // have camelCase or long "extensions" that real files never use.
+  const bare = !text.includes("/") && !text.includes("\\")
+  if (bare) {
+    const ext = BARE_EXT_RE.exec(text)
+    const suffix = ext?.[1]
+    if (suffix) {
+      if (suffix.length > MAX_BARE_EXT) return undefined
+      if (suffix !== suffix.toLowerCase()) return undefined
+    }
+  }
   return {
-    path: match[1],
+    path: match[1]!,
     line: match[2] ? parseInt(match[2], 10) : undefined,
     column: match[3] ? parseInt(match[3], 10) : undefined,
   }

--- a/packages/ui/src/file-path.test.ts
+++ b/packages/ui/src/file-path.test.ts
@@ -130,6 +130,48 @@ describe("parseFilePath", () => {
     it("path without extension", () => {
       expect(parseFilePath("src/Makefile")).toBeUndefined()
     })
+
+    it("dotted code identifier with camelCase extension", () => {
+      expect(parseFilePath("session.updateMode")).toBeUndefined()
+    })
+
+    it("React hook reference", () => {
+      expect(parseFilePath("React.useState")).toBeUndefined()
+    })
+
+    it("Object method reference", () => {
+      expect(parseFilePath("Object.fromEntries")).toBeUndefined()
+    })
+
+    it("method with long extension", () => {
+      expect(parseFilePath("config.something")).toBeUndefined()
+    })
+
+    it("allows bare name with short lowercase extension", () => {
+      // Ambiguous cases like path.posix still match — the heuristic
+      // targets camelCase and long extensions which are clearly code.
+      expect(parseFilePath("path.posix")).toEqual({ path: "path.posix", line: undefined, column: undefined })
+    })
+
+    it("bare file with short lowercase extension", () => {
+      expect(parseFilePath("foo.ts")).toEqual({ path: "foo.ts", line: undefined, column: undefined })
+    })
+
+    it("bare file with json extension", () => {
+      expect(parseFilePath("package.json")).toEqual({ path: "package.json", line: undefined, column: undefined })
+    })
+
+    it("bare file with graphql extension", () => {
+      expect(parseFilePath("schema.graphql")).toEqual({ path: "schema.graphql", line: undefined, column: undefined })
+    })
+
+    it("dotted path with slash still works", () => {
+      expect(parseFilePath("src/session.updateMode.ts")).toEqual({
+        path: "src/session.updateMode.ts",
+        line: undefined,
+        column: undefined,
+      })
+    })
   })
 })
 

--- a/packages/ui/src/file-path.ts
+++ b/packages/ui/src/file-path.ts
@@ -9,6 +9,14 @@ const FILE_PATH_UNIX_RE =
   /^((?:\/|\.\.?\/)?(?:[a-zA-Z0-9_@-][a-zA-Z0-9_@./-]*\/)*[a-zA-Z0-9_@.-]+\.[a-zA-Z0-9]+)(?::(\d+)(?::(\d+))?)?$/
 const FILE_PATH_WIN_RE = /^((?:[a-zA-Z]:[/\\]|\\\\)(?:[^\\/]+[/\\])*[^\\/]+\.[a-zA-Z0-9]+)(?::(\d+)(?::(\d+))?)?$/
 
+// For bare names (no path separator), reject dotted identifiers like
+// `session.updateMode` or `Object.keys`. Real file extensions are short
+// and lowercase (e.g. .ts, .json, .graphql). Extensions containing
+// uppercase letters (camelCase method names) or longer than 7 chars
+// are almost certainly code identifiers, not files.
+const BARE_EXT_RE = /\.([a-zA-Z0-9]+)(?::\d+(?::\d+)?)?$/
+const MAX_BARE_EXT = 7
+
 /**
  * Parse an inline code span into a file path with optional line/column.
  * Returns undefined when the text does not look like a file reference.
@@ -21,8 +29,20 @@ export function parseFilePath(text: string): { path: string; line?: number; colu
   if (text.includes(" ")) return undefined
   const match = FILE_PATH_UNIX_RE.exec(text) ?? FILE_PATH_WIN_RE.exec(text)
   if (!match) return undefined
+  // For bare names without a path separator, validate the extension.
+  // Dotted code identifiers like `session.updateMode` or `React.useState`
+  // have camelCase or long "extensions" that real files never use.
+  const bare = !text.includes("/") && !text.includes("\\")
+  if (bare) {
+    const ext = BARE_EXT_RE.exec(text)
+    const suffix = ext?.[1]
+    if (suffix) {
+      if (suffix.length > MAX_BARE_EXT) return undefined
+      if (suffix !== suffix.toLowerCase()) return undefined
+    }
+  }
   return {
-    path: match[1],
+    path: match[1]!,
     line: match[2] ? parseInt(match[2], 10) : undefined,
     column: match[3] ? parseInt(match[3], 10) : undefined,
   }


### PR DESCRIPTION
## Summary

- **Root cause**: `parseFilePath()` in `packages/ui/src/file-path.ts` used a regex that matched any `word.word` pattern as a file path. This caused dotted code identifiers like `session.updateMode`, `React.useState`, `Object.fromEntries` to be classified as file links in chat, styled with underline + pointer cursor + link color — but clicking them tried to open non-existent files.

- **Fix**: For bare names (no `/` or `\` path separator), the extension portion is now validated:
  - Must be **lowercase only** — rejects camelCase identifiers like `updateMode`, `useState`, `fromEntries`
  - Must be **at most 7 characters** — rejects long identifiers like `something`, `configure`

- Paths with directory separators (e.g. `src/session.updateMode.ts`) are **unaffected** since the separator is strong evidence of a real file path.

- Both `packages/ui/src/file-path.ts` and `packages/kilo-ui/src/file-path.ts` (duplicate) are updated. New test cases added covering the false-positive patterns.
