### PR TITLE
feat(agent-manager): auto-copy .env files into new worktrees

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -13,6 +13,7 @@ import { versionedName } from "./branch-name"
 import { normalizePath, classifyWorktreeError } from "./git-import"
 import { SetupScriptService } from "./SetupScriptService"
 import { SetupScriptRunner } from "./SetupScriptRunner"
+import { copyEnvFiles } from "./env-copy"
 import { SessionTerminalManager } from "./SessionTerminalManager"
 import { createTerminalHost } from "./terminal-host"
 import { executeVscodeTask } from "./task-runner"
@@ -1306,10 +1307,14 @@ export class AgentManagerProvider implements Disposable {
     }
   }
 
-  /** Run the worktree setup script if configured. Blocks until complete. Shows progress in overlay. */
+  /** Copy .env files and run the worktree setup script. Blocks until complete. Shows progress in overlay. */
   private async runSetupScriptForWorktree(worktreePath: string, branch?: string, worktreeId?: string): Promise<void> {
     const root = this.getRoot()
     if (!root) return
+
+    // Always copy .env files from the main repo (before the setup script so it can override)
+    await copyEnvFiles(root, worktreePath, (msg) => this.outputChannel.appendLine(`[EnvCopy] ${msg}`))
+
     try {
       const service = this.getSetupScriptService()
       if (!service || !service.hasScript()) return

--- a/packages/kilo-vscode/src/agent-manager/env-copy.ts
+++ b/packages/kilo-vscode/src/agent-manager/env-copy.ts
@@ -11,6 +11,7 @@
  */
 
 import * as fs from "node:fs"
+import { constants } from "node:fs"
 import * as path from "node:path"
 
 /** Result returned after a copy attempt. */
@@ -65,17 +66,17 @@ export async function copyEnvFiles(
     const src = path.join(repoPath, name)
     const dst = path.join(worktreePath, name)
 
-    if (fs.existsSync(dst)) {
-      log(`Skipping ${name} (already exists in worktree)`)
-      result.skipped.push(name)
-      continue
-    }
-
     try {
-      await fs.promises.copyFile(src, dst)
+      // COPYFILE_EXCL fails atomically if dst exists — no TOCTOU race.
+      await fs.promises.copyFile(src, dst, constants.COPYFILE_EXCL)
       log(`Copied ${name}`)
       result.copied.push(name)
-    } catch (err) {
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && err.code === "EEXIST") {
+        log(`Skipping ${name} (already exists in worktree)`)
+        result.skipped.push(name)
+        continue
+      }
       log(`Failed to copy ${name}: ${err}`)
     }
   }

--- a/packages/kilo-vscode/src/agent-manager/env-copy.ts
+++ b/packages/kilo-vscode/src/agent-manager/env-copy.ts
@@ -1,0 +1,84 @@
+/**
+ * Copies .env files from the main repository into a worktree.
+ *
+ * Runs automatically before the user setup script so worktrees inherit
+ * environment configuration without manual copying.  Only plain files
+ * named exactly `.env` or matching `.env.<qualifier>` (e.g. `.env.local`,
+ * `.env.development`) at the repo root are considered.  Files like `.envrc`
+ * or `.environment` are excluded — they follow different conventions.
+ * Nested directories are not traversed and existing files in the worktree
+ * are never overwritten.
+ */
+
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+/** Result returned after a copy attempt. */
+export interface EnvCopyResult {
+  /** Files that were copied. */
+  copied: string[]
+  /** Files that were skipped because they already exist in the worktree. */
+  skipped: string[]
+}
+
+type Log = (msg: string) => void
+
+/** Match `.env` exactly, or `.env.` followed by a qualifier. */
+function isEnvFile(name: string): boolean {
+  return name === ".env" || name.startsWith(".env.")
+}
+
+/**
+ * List `.env` / `.env.*` filenames at the root of `dir`.
+ * Returns basenames only (e.g. `[".env", ".env.local"]`).
+ */
+export function listEnvFiles(dir: string): string[] {
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+    return entries.filter((e) => e.isFile() && isEnvFile(e.name)).map((e) => e.name)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Copy `.env` / `.env.*` files from `repoPath` into `worktreePath`.
+ *
+ * - Only root-level files named `.env` or `.env.<qualifier>` are copied.
+ * - Files that already exist in the worktree are skipped (no overwrite).
+ * - Cross-platform: uses only Node `fs` APIs.
+ */
+export async function copyEnvFiles(
+  repoPath: string,
+  worktreePath: string,
+  log: Log = () => {},
+): Promise<EnvCopyResult> {
+  const names = listEnvFiles(repoPath)
+  if (names.length === 0) {
+    log("No .env files found in main repo")
+    return { copied: [], skipped: [] }
+  }
+
+  const result: EnvCopyResult = { copied: [], skipped: [] }
+
+  for (const name of names) {
+    const src = path.join(repoPath, name)
+    const dst = path.join(worktreePath, name)
+
+    if (fs.existsSync(dst)) {
+      log(`Skipping ${name} (already exists in worktree)`)
+      result.skipped.push(name)
+      continue
+    }
+
+    try {
+      await fs.promises.copyFile(src, dst)
+      log(`Copied ${name}`)
+      result.copied.push(name)
+    } catch (err) {
+      log(`Failed to copy ${name}: ${err}`)
+    }
+  }
+
+  return result
+}

--- a/packages/kilo-vscode/tests/unit/env-copy.test.ts
+++ b/packages/kilo-vscode/tests/unit/env-copy.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import * as os from "node:os"
+import { listEnvFiles, copyEnvFiles } from "../../src/agent-manager/env-copy"
+
+function tmpdir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "env-copy-test-"))
+}
+
+describe("listEnvFiles", () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = tmpdir()
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it("returns empty array when no .env files exist", () => {
+    expect(listEnvFiles(dir)).toEqual([])
+  })
+
+  it("finds .env at root", () => {
+    fs.writeFileSync(path.join(dir, ".env"), "KEY=val")
+    expect(listEnvFiles(dir)).toEqual([".env"])
+  })
+
+  it("finds multiple .env variants", () => {
+    fs.writeFileSync(path.join(dir, ".env"), "A=1")
+    fs.writeFileSync(path.join(dir, ".env.local"), "B=2")
+    fs.writeFileSync(path.join(dir, ".env.development"), "C=3")
+    const result = listEnvFiles(dir).sort()
+    expect(result).toEqual([".env", ".env.development", ".env.local"])
+  })
+
+  it("ignores directories named .env", () => {
+    fs.mkdirSync(path.join(dir, ".env"))
+    fs.mkdirSync(path.join(dir, ".env.local"))
+    expect(listEnvFiles(dir)).toEqual([])
+  })
+
+  it("ignores .envrc and other non-dotenv files", () => {
+    fs.writeFileSync(path.join(dir, ".envrc"), "use nix")
+    fs.writeFileSync(path.join(dir, ".environment"), "X=1")
+    fs.writeFileSync(path.join(dir, ".env-cmdrc"), "{}")
+    fs.writeFileSync(path.join(dir, "not-env"), "Y=2")
+    fs.writeFileSync(path.join(dir, "env.bak"), "Z=3")
+    expect(listEnvFiles(dir)).toEqual([])
+  })
+
+  it("returns empty array for nonexistent directory", () => {
+    expect(listEnvFiles(path.join(dir, "nope"))).toEqual([])
+  })
+})
+
+describe("copyEnvFiles", () => {
+  let repo: string
+  let worktree: string
+  let logs: string[]
+
+  beforeEach(() => {
+    repo = tmpdir()
+    worktree = tmpdir()
+    logs = []
+  })
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true })
+    fs.rmSync(worktree, { recursive: true, force: true })
+  })
+
+  function log(msg: string) {
+    logs.push(msg)
+  }
+
+  it("copies .env files from repo to worktree", async () => {
+    fs.writeFileSync(path.join(repo, ".env"), "SECRET=abc")
+    fs.writeFileSync(path.join(repo, ".env.local"), "LOCAL=xyz")
+
+    const result = await copyEnvFiles(repo, worktree, log)
+
+    expect(result.copied.sort()).toEqual([".env", ".env.local"])
+    expect(result.skipped).toEqual([])
+    expect(fs.readFileSync(path.join(worktree, ".env"), "utf-8")).toBe("SECRET=abc")
+    expect(fs.readFileSync(path.join(worktree, ".env.local"), "utf-8")).toBe("LOCAL=xyz")
+  })
+
+  it("skips files that already exist in worktree", async () => {
+    fs.writeFileSync(path.join(repo, ".env"), "NEW=val")
+    fs.writeFileSync(path.join(worktree, ".env"), "EXISTING=val")
+
+    const result = await copyEnvFiles(repo, worktree, log)
+
+    expect(result.copied).toEqual([])
+    expect(result.skipped).toEqual([".env"])
+    expect(fs.readFileSync(path.join(worktree, ".env"), "utf-8")).toBe("EXISTING=val")
+  })
+
+  it("copies some and skips others", async () => {
+    fs.writeFileSync(path.join(repo, ".env"), "A=1")
+    fs.writeFileSync(path.join(repo, ".env.local"), "B=2")
+    fs.writeFileSync(path.join(worktree, ".env"), "KEEP=me")
+
+    const result = await copyEnvFiles(repo, worktree, log)
+
+    expect(result.copied).toEqual([".env.local"])
+    expect(result.skipped).toEqual([".env"])
+    expect(fs.readFileSync(path.join(worktree, ".env"), "utf-8")).toBe("KEEP=me")
+    expect(fs.readFileSync(path.join(worktree, ".env.local"), "utf-8")).toBe("B=2")
+  })
+
+  it("returns empty result when repo has no .env files", async () => {
+    const result = await copyEnvFiles(repo, worktree, log)
+    expect(result.copied).toEqual([])
+    expect(result.skipped).toEqual([])
+  })
+
+  it("logs copy actions", async () => {
+    fs.writeFileSync(path.join(repo, ".env"), "X=1")
+    fs.writeFileSync(path.join(repo, ".env.local"), "Y=2")
+    fs.writeFileSync(path.join(worktree, ".env.local"), "Z=3")
+
+    await copyEnvFiles(repo, worktree, log)
+
+    expect(logs).toContain("Copied .env")
+    expect(logs.some((l) => l.includes("Skipping .env.local"))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Automatically copies `.env` and `.env.*` files from the main repo into new worktrees before the setup script runs
- Eliminates the need for users to manually copy env files to each worktree
- Existing files in the worktree are never overwritten (git-tracked `.env` files are safe)

## Details

New vscode-free helper module `env-copy.ts` with two exported functions:
- `listEnvFiles(dir)` — scans for files matching `.env` or `.env.<qualifier>` (excludes `.envrc`, `.environment`, etc.)
- `copyEnvFiles(repoPath, worktreePath, log)` — copies with skip-on-exist semantics

Integrated into `AgentManagerProvider.runSetupScriptForWorktree()` which covers all 5 worktree creation paths (create, promote, multi-version, import branch, import PR).

Runs **before** the user's setup script so the script can override copied files if needed.

## Test plan

11 unit tests covering: finding `.env` variants, copying, skip-on-exist, mixed scenarios, logging, edge cases (empty dirs, nonexistent paths, directories named `.env*`, non-env files like `.envrc`).