### PR TITLE
fix(cli): respect configured model for subagents

### DIFF
--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -1,8 +1,21 @@
 // kilocode_change - new file
+import { Effect } from "effect"
+import path from "path"
 import { Permission } from "@/permission"
+import { Flag } from "@/flag/flag"
+import { Global } from "@/global"
+import { ModelID, ProviderID } from "@/provider/schema"
 import type { Session } from "../../session"
 import type { Agent } from "../../agent/agent"
 import type { Config } from "../../config"
+import z from "zod"
+
+// RATIONALE: Mirror narrow state slice Task tool consumes and ignore unrelated TUI fields.
+const ModelState = z
+  .object({
+    model: z.record(z.string(), z.object({ providerID: ProviderID.zod, modelID: ModelID.zod })).optional(),
+  })
+  .passthrough()
 
 export namespace KiloTask {
   /** Reject primary agents used as subagents */
@@ -35,4 +48,20 @@ export namespace KiloTask {
   export function permissions(rules: Permission.Ruleset): Permission.Ruleset {
     return [{ permission: "task", pattern: "*", action: "deny" }, ...rules]
   }
+
+  /** Return saved CLI model for agent, if any. */
+  export const resolveModel = Effect.fn("KiloTask.resolveModel")(function* (name: string) {
+    if (Flag.KILO_CLIENT !== "cli") return undefined
+    const file = path.join(Global.Path.state, "model.json")
+    const state = yield* Effect.tryPromise({
+      try: () =>
+        Bun.file(file)
+          .text()
+          .then((raw) => ModelState.safeParse(JSON.parse(raw)))
+          .then((result) => (result.success ? result.data : undefined))
+          .catch(() => undefined),
+      catch: () => undefined,
+    })
+    return state?.model?.[name]
+  })
 }

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -14,6 +14,7 @@ import z from "zod"
 const ModelState = z
   .object({
     model: z.record(z.string(), z.object({ providerID: ProviderID.zod, modelID: ModelID.zod })).optional(),
+    variant: z.record(z.string(), z.string().optional()).optional(),
   })
   .passthrough()
 
@@ -62,6 +63,11 @@ export namespace KiloTask {
           .catch(() => undefined),
       catch: () => undefined,
     })
-    return state?.model?.[name]
+    const model = state?.model?.[name]
+    if (!model) return undefined
+    return {
+      ...model,
+      variant: state?.variant?.[`${model.providerID}/${model.modelID}`],
+    }
   })
 }

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -112,10 +112,14 @@ export const TaskTool = Tool.define(
       const msg = yield* Effect.sync(() => MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }))
       if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
 
-      const model = next.model ?? {
-        modelID: msg.info.modelID,
-        providerID: msg.info.providerID,
-      }
+      // kilocode_change start — prefer user's CLI-saved pick for this subagent
+      const saved = yield* KiloTask.resolveModel(next.name)
+      const model = saved ??
+        next.model ?? {
+          modelID: msg.info.modelID,
+          providerID: msg.info.providerID,
+        }
+      // kilocode_change end
 
       yield* ctx.metadata({
         title: params.description,

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -119,6 +119,7 @@ export const TaskTool = Tool.define(
           modelID: msg.info.modelID,
           providerID: msg.info.providerID,
         }
+      const variant = saved?.variant ?? (saved ? undefined : next.variant)
       // kilocode_change end
 
       yield* ctx.metadata({
@@ -126,6 +127,7 @@ export const TaskTool = Tool.define(
         metadata: {
           sessionId: nextSession.id,
           model,
+          variant, // kilocode_change
         },
       })
 
@@ -152,6 +154,7 @@ export const TaskTool = Tool.define(
                 modelID: model.modelID,
                 providerID: model.providerID,
               },
+              variant, // kilocode_change
               agent: next.name,
               tools: {
                 ...(canTodo ? {} : { todowrite: false }),
@@ -166,6 +169,7 @@ export const TaskTool = Tool.define(
               metadata: {
                 sessionId: nextSession.id,
                 model,
+                variant, // kilocode_change
               },
               output: [
                 `task_id: ${nextSession.id} (for resuming to continue this task if needed)`,

--- a/packages/opencode/test/kilocode/tool-task-model.test.ts
+++ b/packages/opencode/test/kilocode/tool-task-model.test.ts
@@ -1,0 +1,303 @@
+import { afterEach, beforeAll, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import fs from "fs/promises"
+import path from "path"
+import { Agent } from "../../src/agent/agent"
+import { Config } from "../../src/config"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Global } from "../../src/global"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import type { SessionPrompt } from "../../src/session/prompt"
+import { MessageID, PartID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { TaskTool, type TaskPromptOps } from "../../src/tool/task"
+import { Truncate } from "../../src/tool"
+import { ToolRegistry } from "../../src/tool"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const state = path.join(Global.Path.state, "model.json")
+
+afterEach(async () => {
+  process.env.KILO_CLIENT = "cli"
+  await fs.rm(state, { force: true }).catch(() => undefined)
+  await Instance.disposeAll()
+})
+
+beforeAll(async () => {
+  process.env.KILO_CLIENT = "cli"
+  await fs.rm(state, { force: true }).catch(() => undefined)
+})
+
+const parent = {
+  providerID: ProviderID.make("parent-provider"),
+  modelID: ModelID.make("parent-model"),
+}
+
+const saved = {
+  providerID: ProviderID.make("saved-provider"),
+  modelID: ModelID.make("saved-model"),
+}
+
+const cfg = {
+  providerID: ProviderID.make("config-provider"),
+  modelID: ModelID.make("config-model"),
+}
+
+const it = testEffect(
+  Layer.mergeAll(
+    Agent.defaultLayer,
+    Config.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    Session.defaultLayer,
+    Truncate.defaultLayer,
+    ToolRegistry.defaultLayer,
+  ),
+)
+
+const seed = Effect.fn("TaskToolModelTest.seed")(function* (title = "Parent") {
+  const session = yield* Session.Service
+  const chat = yield* session.create({ title })
+  const user = yield* session.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID: chat.id,
+    agent: "build",
+    model: parent,
+    time: { created: Date.now() },
+  })
+  const assistant: MessageV2.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    parentID: user.id,
+    sessionID: chat.id,
+    mode: "build",
+    agent: "build",
+    cost: 0,
+    path: { cwd: "/tmp", root: "/tmp" },
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: parent.modelID,
+    providerID: parent.providerID,
+    time: { created: Date.now() },
+  }
+  yield* session.updateMessage(assistant)
+  return { chat, assistant }
+})
+
+function stubOps(opts?: { onPrompt?: (input: SessionPrompt.PromptInput) => void; text?: string }): TaskPromptOps {
+  return {
+    cancel() {},
+    resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
+    prompt: (input) =>
+      Effect.sync(() => {
+        opts?.onPrompt?.(input)
+        return reply(input, opts?.text ?? "done")
+      }),
+  }
+}
+
+function reply(input: SessionPrompt.PromptInput, text: string): MessageV2.WithParts {
+  const id = MessageID.ascending()
+  return {
+    info: {
+      id,
+      role: "assistant",
+      parentID: input.messageID ?? MessageID.ascending(),
+      sessionID: input.sessionID,
+      mode: input.agent ?? "general",
+      agent: input.agent ?? "general",
+      cost: 0,
+      path: { cwd: "/tmp", root: "/tmp" },
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: input.model?.modelID ?? parent.modelID,
+      providerID: input.model?.providerID ?? parent.providerID,
+      time: { created: Date.now() },
+      finish: "stop",
+    },
+    parts: [
+      {
+        id: PartID.ascending(),
+        messageID: id,
+        sessionID: input.sessionID,
+        type: "text",
+        text,
+      },
+    ],
+  }
+}
+
+function writeState(input: unknown) {
+  return Effect.promise(async () => {
+    await fs.mkdir(Global.Path.state, { recursive: true })
+    await fs.writeFile(state, JSON.stringify(input))
+  })
+}
+
+function run(input: { agent: "pinned" | "worker"; state?: unknown; client?: string }) {
+  return provideTmpdirInstance(
+    () =>
+      Effect.gen(function* () {
+        process.env.KILO_CLIENT = input.client ?? "cli"
+        if (input.state) yield* writeState(input.state)
+
+        const { chat, assistant } = yield* seed(input.agent)
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        let seen: SessionPrompt.PromptInput | undefined
+        const promptOps = stubOps({ onPrompt: (value) => (seen = value) })
+
+        const result = yield* def.execute(
+          {
+            description: `run ${input.agent}`,
+            prompt: "inspect resolution",
+            subagent_type: input.agent,
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps, bypassAgentCheck: true },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        return {
+          prompt: seen?.model,
+          model: result.metadata.model,
+        }
+      }),
+    {
+      config: {
+        agent: {
+          worker: { mode: "subagent" },
+          pinned: { mode: "subagent", model: "config-provider/config-model" },
+        },
+      },
+    },
+  )
+}
+
+describe("tool.task model resolution", () => {
+  it.live("saved model beats agent config for pinned", () =>
+    run({
+      agent: "pinned",
+      state: { model: { pinned: saved } },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(saved)
+          expect(result.model).toEqual(saved)
+        }),
+      ),
+    ),
+  )
+
+  it.live("saved model beats parent for worker", () =>
+    run({
+      agent: "worker",
+      state: { model: { worker: saved } },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(saved)
+          expect(result.model).toEqual(saved)
+        }),
+      ),
+    ),
+  )
+
+  it.live("missing saved entry falls back to agent config for pinned", () =>
+    run({
+      agent: "pinned",
+      state: { model: { worker: saved } },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(cfg)
+          expect(result.model).toEqual(cfg)
+        }),
+      ),
+    ),
+  )
+
+  it.live("no file and no agent config falls back to parent for worker", () =>
+    run({
+      agent: "worker",
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(parent)
+          expect(result.model).toEqual(parent)
+        }),
+      ),
+    ),
+  )
+
+  it.live("malformed file ignored and falls back to agent config for pinned", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          process.env.KILO_CLIENT = "cli"
+          yield* Effect.promise(async () => {
+            await fs.mkdir(Global.Path.state, { recursive: true })
+            await fs.writeFile(state, "{bad json")
+          })
+
+          const { chat, assistant } = yield* seed("pinned")
+          const tool = yield* TaskTool
+          const def = yield* tool.init()
+          let seen: SessionPrompt.PromptInput | undefined
+          const promptOps = stubOps({ onPrompt: (value) => (seen = value) })
+
+          const result = yield* def.execute(
+            {
+              description: "run pinned",
+              prompt: "inspect resolution",
+              subagent_type: "pinned",
+            },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              extra: { promptOps, bypassAgentCheck: true },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+
+          expect(seen?.model).toEqual(cfg)
+          expect(result.metadata.model).toEqual(cfg)
+        }),
+      {
+        config: {
+          agent: {
+            worker: { mode: "subagent" },
+            pinned: { mode: "subagent", model: "config-provider/config-model" },
+          },
+        },
+      },
+    ),
+  )
+
+  it.live("non-CLI client gate ignores saved worker model and uses parent", () =>
+    run({
+      agent: "worker",
+      client: "vscode",
+      state: { model: { worker: saved } },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(parent)
+          expect(result.model).toEqual(parent)
+        }),
+      ),
+    ),
+  )
+})

--- a/packages/opencode/test/kilocode/tool-task-model.test.ts
+++ b/packages/opencode/test/kilocode/tool-task-model.test.ts
@@ -46,6 +46,9 @@ const cfg = {
   modelID: ModelID.make("config-model"),
 }
 
+const savedVariant = "fast"
+const cfgVariant = "balanced"
+
 const it = testEffect(
   Layer.mergeAll(
     Agent.defaultLayer,
@@ -168,14 +171,16 @@ function run(input: { agent: "pinned" | "worker"; state?: unknown; client?: stri
 
         return {
           prompt: seen?.model,
+          variant: seen?.variant,
           model: result.metadata.model,
+          metadataVariant: result.metadata.variant,
         }
       }),
     {
       config: {
         agent: {
           worker: { mode: "subagent" },
-          pinned: { mode: "subagent", model: "config-provider/config-model" },
+          pinned: { mode: "subagent", model: "config-provider/config-model", variant: cfgVariant },
         },
       },
     },
@@ -186,12 +191,14 @@ describe("tool.task model resolution", () => {
   it.live("saved model beats agent config for pinned", () =>
     run({
       agent: "pinned",
-      state: { model: { pinned: saved } },
+      state: { model: { pinned: saved }, variant: { "saved-provider/saved-model": savedVariant } },
     }).pipe(
       Effect.tap((result) =>
         Effect.sync(() => {
           expect(result.prompt).toEqual(saved)
-          expect(result.model).toEqual(saved)
+          expect(result.variant).toEqual(savedVariant)
+          expect(result.model).toMatchObject({ ...saved, variant: savedVariant })
+          expect(result.metadataVariant).toEqual(savedVariant)
         }),
       ),
     ),
@@ -200,12 +207,46 @@ describe("tool.task model resolution", () => {
   it.live("saved model beats parent for worker", () =>
     run({
       agent: "worker",
+      state: { model: { worker: saved }, variant: { "saved-provider/saved-model": savedVariant } },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(saved)
+          expect(result.variant).toEqual(savedVariant)
+          expect(result.model).toMatchObject({ ...saved, variant: savedVariant })
+          expect(result.metadataVariant).toEqual(savedVariant)
+        }),
+      ),
+    ),
+  )
+
+  it.live("saved model without variant leaves variant undefined", () =>
+    run({
+      agent: "worker",
       state: { model: { worker: saved } },
     }).pipe(
       Effect.tap((result) =>
         Effect.sync(() => {
           expect(result.prompt).toEqual(saved)
+          expect(result.variant).toBeUndefined()
           expect(result.model).toEqual(saved)
+          expect(result.metadataVariant).toBeUndefined()
+        }),
+      ),
+    ),
+  )
+
+  it.live("unrelated saved variant key ignored", () =>
+    run({
+      agent: "worker",
+      state: { model: { worker: saved }, variant: { "other-provider/other-model": savedVariant } },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(saved)
+          expect(result.variant).toBeUndefined()
+          expect(result.model).toEqual(saved)
+          expect(result.metadataVariant).toBeUndefined()
         }),
       ),
     ),
@@ -219,7 +260,9 @@ describe("tool.task model resolution", () => {
       Effect.tap((result) =>
         Effect.sync(() => {
           expect(result.prompt).toEqual(cfg)
+          expect(result.variant).toEqual(cfgVariant)
           expect(result.model).toEqual(cfg)
+          expect(result.metadataVariant).toEqual(cfgVariant)
         }),
       ),
     ),
@@ -232,7 +275,9 @@ describe("tool.task model resolution", () => {
       Effect.tap((result) =>
         Effect.sync(() => {
           expect(result.prompt).toEqual(parent)
+          expect(result.variant).toBeUndefined()
           expect(result.model).toEqual(parent)
+          expect(result.metadataVariant).toBeUndefined()
         }),
       ),
     ),
@@ -273,13 +318,15 @@ describe("tool.task model resolution", () => {
           )
 
           expect(seen?.model).toEqual(cfg)
+          expect(seen?.variant).toEqual(cfgVariant)
           expect(result.metadata.model).toEqual(cfg)
+          expect(result.metadata.variant).toEqual(cfgVariant)
         }),
       {
         config: {
           agent: {
             worker: { mode: "subagent" },
-            pinned: { mode: "subagent", model: "config-provider/config-model" },
+            pinned: { mode: "subagent", model: "config-provider/config-model", variant: cfgVariant },
           },
         },
       },
@@ -290,12 +337,14 @@ describe("tool.task model resolution", () => {
     run({
       agent: "worker",
       client: "vscode",
-      state: { model: { worker: saved } },
+      state: { model: { worker: saved }, variant: { "saved-provider/saved-model": savedVariant } },
     }).pipe(
       Effect.tap((result) =>
         Effect.sync(() => {
           expect(result.prompt).toEqual(parent)
+          expect(result.variant).toBeUndefined()
           expect(result.model).toEqual(parent)
+          expect(result.metadataVariant).toBeUndefined()
         }),
       ),
     ),


### PR DESCRIPTION
## Context

Fixes #6904 

## Implementation

- Respect the model configurations in `~/.local/state/kilo/model.json` for subagents in the CLI (related: https://github.com/Kilo-Org/kilocode/issues/9184)

Currently the Task tool within the CLI does not look at the models in `~/.local/state/kilo/model.json`, it only looks at the models in `~/.config/kilo/kilo.json`. The CLI saves model info to the first file, while the VSCode extension saves model info to the second file. This means that while the Task tool uses the configured model correctly in VSCode, it always  uses the parent agent's model in the CLI, even if the user has configured a different model for the subagent type in `~/.local/state/kilo/model.json`.

This change ensures we look at both files, so that the Task tool respects model configurations for both the CLI and the VSCode extension.

## How to Test

- Run prompts in different modes which invoke the Task tool.
- See that the user's correct configured model is being used for the subagents, e.g. an Explore subagent should use the configured Explore model, not the model of the parent agent

## Notes from automated code review

1. Saved model not validity-checked against current provider/model inventory before use.
   - packages/opencode/src/kilocode/tool/task.ts:53-66
   - packages/opencode/src/tool/task.ts:115-121
   - This implementation mirrors existing narrow model.json read pattern from plan-followup.ts:186-195. No extra validation added at this time.

## Get in Touch

ExpedientFalcon on Discord
