### PR TITLE
fix(vscode): avoid optimistic session delete

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -986,6 +986,13 @@ export const SessionProvider: ParentComponent = (props) => {
   function handleSessionDeleted(sessionID: string) {
     pendingOptimistic.delete(sessionID)
     batch(() => {
+      setLoaded((prev) => {
+        if (!prev.has(sessionID)) return prev
+        const next = new Set(prev)
+        next.delete(sessionID)
+        return next
+      })
+
       // Collect message IDs so we can clean up their parts
       const msgs = store.messages[sessionID] ?? []
       const msgIds = msgs.map((m) => m.id)

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1446,19 +1446,8 @@ export const SessionProvider: ParentComponent = (props) => {
       console.warn("[Kilo New] Cannot delete session: not connected")
       return
     }
-    // Optimistically remove from the list so the UI updates immediately
-    setStore(
-      "sessions",
-      produce((sessions) => {
-        delete sessions[id]
-      }),
-    )
-    setLoaded((prev) => {
-      if (!prev.has(id)) return prev
-      const next = new Set(prev)
-      next.delete(id)
-      return next
-    })
+    // Wait for sessionDeleted from the extension so a backend failure does not
+    // leave the history list out of sync with the real session state.
     vscode.postMessage({ type: "deleteSession", sessionID: id })
   }
 


### PR DESCRIPTION
Fixes #7553.

This removes the optimistic session deletion from the VS Code webview session store.

The history list now waits for `sessionDeleted` from the extension host before removing a session, so a failed backend delete no longer leaves the UI out of sync with the real session state.

Testing:
- not run locally in this shell (`bun` not available)
