### PR TITLE
fix(vscode): preserve terminal output tail

### DIFF
--- a/packages/kilo-vscode/src/services/code-actions/__tests__/terminal-content.spec.ts
+++ b/packages/kilo-vscode/src/services/code-actions/__tests__/terminal-content.spec.ts
@@ -19,4 +19,8 @@ describe("trimTerminalOutput", () => {
   it("drops a duplicated trailing prompt and keeps the matching command block", () => {
     expect(trimTerminalOutput("$ echo hi\nhi\n$")).toBe("$ echo hi\nhi")
   })
+
+  it("preserves earlier copied terminal history in all mode", () => {
+    expect(trimTerminalOutput("$ a\n1\n$ b\n2\n$", "all")).toBe("$ a\n1\n$ b\n2")
+  })
 })

--- a/packages/kilo-vscode/src/services/code-actions/__tests__/terminal-content.spec.ts
+++ b/packages/kilo-vscode/src/services/code-actions/__tests__/terminal-content.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { trimTerminalOutput } from "../terminal-content"
+
+describe("trimTerminalOutput", () => {
+  it("preserves one-line content", () => {
+    expect(trimTerminalOutput("echo hi")).toBe("echo hi")
+  })
+
+  it("preserves the last line when no trailing prompt was copied", () => {
+    expect(trimTerminalOutput("python main.py\nTraceback...\nValueError: boom")).toBe(
+      "python main.py\nTraceback...\nValueError: boom",
+    )
+  })
+
+  it("does not trim arbitrary trailing lines that happen to match an earlier prefix", () => {
+    expect(trimTerminalOutput("PASS a.test.ts\nPASS")).toBe("PASS a.test.ts\nPASS")
+  })
+
+  it("drops a duplicated trailing prompt and keeps the matching command block", () => {
+    expect(trimTerminalOutput("$ echo hi\nhi\n$")).toBe("$ echo hi\nhi")
+  })
+})

--- a/packages/kilo-vscode/src/services/code-actions/register-terminal-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-terminal-actions.ts
@@ -24,7 +24,7 @@ async function getTerminalContents(commands = -1): Promise<string> {
     await vscode.commands.executeCommand("workbench.action.terminal.copySelection")
     await vscode.commands.executeCommand("workbench.action.terminal.clearSelection")
 
-    let content = trimTerminalOutput(await vscode.env.clipboard.readText())
+    let content = trimTerminalOutput(await vscode.env.clipboard.readText(), commands < 0 ? "all" : "recent")
 
     await vscode.env.clipboard.writeText(saved)
 

--- a/packages/kilo-vscode/src/services/code-actions/register-terminal-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-terminal-actions.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode"
 import type { KiloProvider } from "../../KiloProvider"
 import type { AgentManagerProvider } from "../../agent-manager/AgentManagerProvider"
 import { createPrompt } from "./support-prompt"
+import { trimTerminalOutput } from "./terminal-content"
 
 /**
  * Read terminal content via clipboard.
@@ -23,23 +24,12 @@ async function getTerminalContents(commands = -1): Promise<string> {
     await vscode.commands.executeCommand("workbench.action.terminal.copySelection")
     await vscode.commands.executeCommand("workbench.action.terminal.clearSelection")
 
-    let content = (await vscode.env.clipboard.readText()).trim()
+    let content = trimTerminalOutput(await vscode.env.clipboard.readText())
 
     await vscode.env.clipboard.writeText(saved)
 
     if (saved === content) {
       return ""
-    }
-
-    // Trim duplicate trailing prompt line
-    const lines = content.split("\n")
-    const last = lines.pop()?.trim()
-    if (last) {
-      let i = lines.length - 1
-      while (i >= 0 && !lines[i].trim().startsWith(last)) {
-        i--
-      }
-      content = lines.slice(Math.max(i, 0)).join("\n")
     }
 
     return content

--- a/packages/kilo-vscode/src/services/code-actions/terminal-content.ts
+++ b/packages/kilo-vscode/src/services/code-actions/terminal-content.ts
@@ -1,0 +1,24 @@
+function isPrompt(line: string): boolean {
+  if (line.startsWith("PS ") && line.endsWith(">")) return true
+  return /[$#>%❯]$/.test(line)
+}
+
+export function trimTerminalOutput(content: string): string {
+  const text = content.trim()
+  if (!text) return ""
+
+  const lines = text.split("\n")
+  if (lines.length < 2) return text
+
+  const last = lines[lines.length - 1]?.trim()
+  if (!last) return text
+  if (!isPrompt(last)) return text
+
+  let i = lines.length - 2
+  while (i >= 0 && !lines[i]!.trim().startsWith(last)) {
+    i--
+  }
+
+  if (i < 0) return text
+  return lines.slice(i, -1).join("\n")
+}

--- a/packages/kilo-vscode/src/services/code-actions/terminal-content.ts
+++ b/packages/kilo-vscode/src/services/code-actions/terminal-content.ts
@@ -3,7 +3,7 @@ function isPrompt(line: string): boolean {
   return /[$#>%❯]$/.test(line)
 }
 
-export function trimTerminalOutput(content: string): string {
+export function trimTerminalOutput(content: string, mode: "all" | "recent" = "recent"): string {
   const text = content.trim()
   if (!text) return ""
 
@@ -20,5 +20,6 @@ export function trimTerminalOutput(content: string): string {
   }
 
   if (i < 0) return text
+  if (mode === "all") return lines.slice(0, -1).join("\n")
   return lines.slice(i, -1).join("\n")
 }


### PR DESCRIPTION
Fixes #7556

## Summary
- preserve copied terminal output when the last line is real output
- only trim the trailing line when it actually looks like a duplicated shell prompt
- add a focused unit test for the trimming helper

## Testing
- not run locally (`bun` is not available in this shell)