### PR TITLE
docs(readme): clarify release assets for CLI and VS Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@
 - Install CLI: `npm install -g @kilocode/cli`
 - [Official Kilo.ai Home page](https://kilo.ai) (learn more)
 
+## Release Assets
+
+GitHub releases contain both CLI binaries and editor extension assets. Download the asset matching your OS and CPU architecture.
+
+| Asset                       | Description                                                             |
+| --------------------------- | ----------------------------------------------------------------------- |
+| `kilo-*-[os]-[arch].tar.gz` | CLI binary for your OS and architecture (e.g., `kilo-linux-x64.tar.gz`) |
+| `kilo-vscode*.vsix`         | VS Code extension package (usually install via VS Code Marketplace)     |
+| `darwin`                    | macOS                                                                   |
+| `x64`                       | Standard x86-64 (most modern CPUs)                                      |
+| `x64_baseline`              | Older x86-64 CPUs (safer choice for compatibility)                      |
+
 ## Key Features
 
 - **Code Generation:** Kilo can generate code using natural language.


### PR DESCRIPTION
Fixes #6293

## What
- add a "Release Assets" section to README
- explain which asset to download for the Kilo CLI
- clarify that `kilo-vscode*.vsix` files are VS Code extensions
- document `darwin`, `x64`, and `x64_baseline` meanings

## Why
New users are confused by the large number of release assets and unclear naming. This adds a minimal explanation directly in the README.

## Risk
Low. Documentation-only change in a single file.