### PR TITLE
fix: preserve separator style when migrating .kilocode to .kilo paths

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -318,8 +318,11 @@ export class WorktreeStateManager {
       this.reviewDiffStyle = "unified"
 
       for (const [id, wt] of Object.entries(data.worktrees ?? {})) {
-        // Rewrite stale .kilocode/ paths (handles both Unix / and Windows \ separators)
-        const fixed = wt.path?.replace(/[/\\]\.kilocode[/\\]/g, `${path.sep}.kilo${path.sep}`) ?? wt.path
+        // Rewrite stale .kilocode paths while preserving the separator style already stored.
+        const fixed =
+          wt.path?.replace(/([/\\])\.kilocode([/\\])/g, (_match, leadingSep, trailingSep) => {
+            return `${leadingSep}.kilo${trailingSep}`
+          }) ?? wt.path
         this.worktrees.set(id, { id, ...wt, path: fixed })
       }
       for (const [id, s] of Object.entries(data.sessions ?? {})) {

--- a/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
@@ -548,9 +548,8 @@ describe("WorktreeStateManager", () => {
 
       await manager.load()
 
-      // path.sep is / on unix, \ on windows — the rewrite uses path.sep
-      const expected = `C:${path.sep}.kilo${path.sep}worktrees\\fix`
-      expect(manager.getWorktrees()[0].path).toBe(expected)
+      // Separator style from the stored path is preserved (backslashes stay as backslashes)
+      expect(manager.getWorktrees()[0].path).toBe("C:\\.kilo\\worktrees\\fix")
     })
   })
 })


### PR DESCRIPTION
## Context

This fixes a path migration bug in the pre-release VS Code extension's Agent Manager state loader.

When rewriting stale `.kilocode` worktree paths to `.kilo`, the existing code used `path.sep`. On Windows, that corrupts stored paths that use Unix-style separators, producing mixed-separator paths like `/repo\.kilo\worktrees/fix`.

## Implementation

The migration rewrite now preserves the separator style already present in the stored path instead of forcing the current OS separator.

This keeps Unix-style stored paths as `/repo/.kilo/worktrees/fix` and Windows-style stored paths as `C:\.kilo\worktrees\fix`.

## How to Test

Run:

```bash
bun test tests/unit/worktree-state-manager.test.ts
Expected:

the rewrites stale .kilocode paths in worktree entries (unix) test passes
the rewrites stale .kilocode paths with backslashes (windows) test passes