### PR TITLE
fix(vscode): auto-refresh rules in Agents Behaviour tab on file changes

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -143,6 +143,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private chatAutocomplete: ChatTextAreaAutocomplete | null = null
   private projectDirectory: string | null | undefined
   private slimEditMetadata = true
+  /** File watcher for rules files — triggers config refresh on external edits */
+  private rulesWatcher: vscode.FileSystemWatcher | null = null
+  private rulesDebounce: ReturnType<typeof setTimeout> | null = null
 
   /** Optional interceptor called before the standard message handler.
    *  Return null to consume the message, or return a (possibly transformed) message. */
@@ -294,6 +297,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // Handle messages from webview (shared handler)
     this.setupWebviewMessageHandler(webviewView.webview)
 
+    // Watch rules files for external edits so the Agents Behaviour tab auto-refreshes
+    this.setupRulesWatcher()
+
     // Initialize connection to CLI backend
     this.initializeConnection()
   }
@@ -315,6 +321,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     // Handle messages from webview (shared handler)
     this.setupWebviewMessageHandler(panel.webview)
+
+    // Watch rules files for external edits so the Agents Behaviour tab auto-refreshes
+    this.setupRulesWatcher()
 
     this.initializeConnection()
   }
@@ -1692,6 +1701,49 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   /**
+   * Create a file system watcher for rules-related files so that external edits
+   * (e.g. editing `.kilo/rules/*.md` in an editor) automatically refresh the
+   * Agents Behaviour tab without requiring a VS Code restart.
+   *
+   * Watches: .kilo/rules/**, .kilocode/rules/**, AGENTS.md, .kilocoderules*
+   */
+  private setupRulesWatcher(): void {
+    if (this.rulesWatcher) return
+
+    const pattern = "**/{.kilo/rules/**,.kilocode/rules/**,AGENTS.md,CLAUDE.md,CONTEXT.md,.kilocoderules*}"
+    this.rulesWatcher = vscode.workspace.createFileSystemWatcher(pattern)
+
+    const refresh = () => this.debouncedRulesRefresh()
+    this.rulesWatcher.onDidChange(refresh)
+    this.rulesWatcher.onDidCreate(refresh)
+    this.rulesWatcher.onDidDelete(refresh)
+  }
+
+  /**
+   * Debounced handler for rules file changes.
+   * Disposes the CLI instance so it rebuilds config (including re-discovered
+   * rules) from disk, then pushes the updated config to the webview.
+   */
+  private debouncedRulesRefresh(): void {
+    if (this.rulesDebounce) clearTimeout(this.rulesDebounce)
+    this.rulesDebounce = setTimeout(() => {
+      this.rulesDebounce = null
+      void this.refreshRulesConfig()
+    }, 500)
+  }
+
+  private async refreshRulesConfig(): Promise<void> {
+    if (!this.client || this.connectionState !== "connected") return
+    console.log("[Kilo New] KiloProvider: Rules file changed, refreshing config...")
+    const dir = this.getWorkspaceDirectory()
+    await this.client.instance.dispose({ directory: dir }).catch((e: unknown) => {
+      console.warn("[Kilo New] instance.dispose() after rules change failed:", e)
+    })
+    this.cachedConfigMessage = null
+    await this.fetchAndSendConfigUpdated()
+  }
+
+  /**
    * Fetch Kilo news/notifications and send to webview.
    * Uses the cached message pattern so the webview gets data immediately on refresh.
    */
@@ -2622,5 +2674,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.ignoreController?.dispose()
     this.chatAutocomplete?.dispose()
     this.marketplace?.dispose()
+    if (this.rulesDebounce) clearTimeout(this.rulesDebounce)
+    this.rulesWatcher?.dispose()
   }
 }

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -143,10 +143,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private chatAutocomplete: ChatTextAreaAutocomplete | null = null
   private projectDirectory: string | null | undefined
   private slimEditMetadata = true
-  /** File watcher for rules files — triggers config refresh on external edits */
-  private rulesWatcher: vscode.FileSystemWatcher | null = null
-  private rulesDebounce: ReturnType<typeof setTimeout> | null = null
-
   /** Optional interceptor called before the standard message handler.
    *  Return null to consume the message, or return a (possibly transformed) message. */
   private onBeforeMessage: ((msg: Record<string, unknown>) => Promise<Record<string, unknown> | null>) | null = null
@@ -297,9 +293,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // Handle messages from webview (shared handler)
     this.setupWebviewMessageHandler(webviewView.webview)
 
-    // Watch rules files for external edits so the Agents Behaviour tab auto-refreshes
-    this.setupRulesWatcher()
-
     // Initialize connection to CLI backend
     this.initializeConnection()
   }
@@ -321,9 +314,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     // Handle messages from webview (shared handler)
     this.setupWebviewMessageHandler(panel.webview)
-
-    // Watch rules files for external edits so the Agents Behaviour tab auto-refreshes
-    this.setupRulesWatcher()
 
     this.initializeConnection()
   }
@@ -1701,49 +1691,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   /**
-   * Create a file system watcher for rules-related files so that external edits
-   * (e.g. editing `.kilo/rules/*.md` in an editor) automatically refresh the
-   * Agents Behaviour tab without requiring a VS Code restart.
-   *
-   * Watches: .kilo/rules/**, .kilocode/rules/**, AGENTS.md, .kilocoderules*
-   */
-  private setupRulesWatcher(): void {
-    if (this.rulesWatcher) return
-
-    const pattern = "**/{.kilo/rules/**,.kilocode/rules/**,AGENTS.md,CLAUDE.md,CONTEXT.md,.kilocoderules*}"
-    this.rulesWatcher = vscode.workspace.createFileSystemWatcher(pattern)
-
-    const refresh = () => this.debouncedRulesRefresh()
-    this.rulesWatcher.onDidChange(refresh)
-    this.rulesWatcher.onDidCreate(refresh)
-    this.rulesWatcher.onDidDelete(refresh)
-  }
-
-  /**
-   * Debounced handler for rules file changes.
-   * Disposes the CLI instance so it rebuilds config (including re-discovered
-   * rules) from disk, then pushes the updated config to the webview.
-   */
-  private debouncedRulesRefresh(): void {
-    if (this.rulesDebounce) clearTimeout(this.rulesDebounce)
-    this.rulesDebounce = setTimeout(() => {
-      this.rulesDebounce = null
-      void this.refreshRulesConfig()
-    }, 500)
-  }
-
-  private async refreshRulesConfig(): Promise<void> {
-    if (!this.client || this.connectionState !== "connected") return
-    console.log("[Kilo New] KiloProvider: Rules file changed, refreshing config...")
-    const dir = this.getWorkspaceDirectory()
-    await this.client.instance.dispose({ directory: dir }).catch((e: unknown) => {
-      console.warn("[Kilo New] instance.dispose() after rules change failed:", e)
-    })
-    this.cachedConfigMessage = null
-    await this.fetchAndSendConfigUpdated()
-  }
-
-  /**
    * Fetch Kilo news/notifications and send to webview.
    * Uses the cached message pattern so the webview gets data immediately on refresh.
    */
@@ -2674,7 +2621,5 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.ignoreController?.dispose()
     this.chatAutocomplete?.dispose()
     this.marketplace?.dispose()
-    if (this.rulesDebounce) clearTimeout(this.rulesDebounce)
-    this.rulesWatcher?.dispose()
   }
 }

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -30,6 +30,9 @@ export class KiloConnectionService {
   private state: ConnectionState = "disconnected"
   private connectPromise: Promise<void> | null = null
   private healthPollTimer: ReturnType<typeof setInterval> | null = null
+  /** Shared rules file watcher — one per connection, not per provider. */
+  private rulesWatcher: vscode.FileSystemWatcher | null = null
+  private rulesDebounce: ReturnType<typeof setTimeout> | null = null
 
   private readonly eventListeners: Set<SSEEventListener> = new Set()
   private readonly stateListeners: Set<StateListener> = new Set()
@@ -218,10 +221,60 @@ export class KiloConnectionService {
   }
 
   /**
+   * Set up a shared file system watcher for rules-related files so that
+   * external edits (e.g. editing `.kilo/rules/*.md` in an editor) trigger
+   * a lightweight config reload on the backend.
+   *
+   * Uses RelativePattern scoped to the workspace root to avoid noisy
+   * watcher traffic from nested directories or unrelated projects.
+   * A single watcher is shared across all KiloProvider instances.
+   */
+  private setupRulesWatcher(dir: string): void {
+    if (this.rulesWatcher) return
+
+    const folder = vscode.workspace.workspaceFolders?.find((f) => f.uri.fsPath === dir)
+    const base = folder ?? vscode.Uri.file(dir)
+    const pattern = new vscode.RelativePattern(
+      base,
+      "{.kilo/rules/**,.kilocode/rules/**,AGENTS.md,CLAUDE.md,CONTEXT.md,.kilocoderules*}",
+    )
+    this.rulesWatcher = vscode.workspace.createFileSystemWatcher(pattern)
+
+    const refresh = () => this.debouncedRulesReload(dir)
+    this.rulesWatcher.onDidChange(refresh)
+    this.rulesWatcher.onDidCreate(refresh)
+    this.rulesWatcher.onDidDelete(refresh)
+  }
+
+  /**
+   * Debounced handler — coalesces rapid saves then calls the lightweight
+   * config.reload endpoint (no instance disposal, no session interruption).
+   */
+  private debouncedRulesReload(dir: string): void {
+    if (this.rulesDebounce) clearTimeout(this.rulesDebounce)
+    this.rulesDebounce = setTimeout(() => {
+      this.rulesDebounce = null
+      if (this.state !== "connected" || !this.client) return
+      console.log("[Kilo New] ConnectionService: Rules file changed, reloading config...")
+      this.client.config.reload({ directory: dir }).catch((e: unknown) => {
+        console.warn("[Kilo New] config.reload after rules change failed:", e)
+      })
+    }, 500)
+  }
+
+  private disposeRulesWatcher(): void {
+    if (this.rulesDebounce) clearTimeout(this.rulesDebounce)
+    this.rulesWatcher?.dispose()
+    this.rulesWatcher = null
+    this.rulesDebounce = null
+  }
+
+  /**
    * Clean up everything: kill server, close SSE, clear listeners.
    */
   dispose(): void {
     this.stopHealthPoll()
+    this.disposeRulesWatcher()
     this.sseClient?.dispose()
     this.serverManager.dispose()
     this.eventListeners.clear()
@@ -365,5 +418,8 @@ export class KiloConnectionService {
 
     // Start the independent health poll once we are confirmed connected.
     this.startHealthPoll(config.baseUrl, config.password)
+
+    // Watch rules files so external edits trigger a lightweight config reload.
+    this.setupRulesWatcher(workspaceDir)
   }
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -24,6 +24,7 @@ import {
 } from "jsonc-parser"
 // kilocode_change end
 import { Instance } from "../project/instance"
+import { State } from "../project/state" // kilocode_change
 import { LSPServer } from "../lsp/server"
 import { BunProc } from "@/bun"
 import { Installation } from "@/installation"
@@ -1654,6 +1655,27 @@ export namespace Config {
   export async function directories() {
     return state().then((x) => x.directories)
   }
+
+  // kilocode_change start — lightweight config reload without full instance disposal
+  /**
+   * Invalidate the cached Config.state for the current instance so the next
+   * Config.get() re-reads and re-merges all layers (global + project + rules)
+   * from disk. Emits `global.config.updated` so SSE clients know to refresh.
+   *
+   * Unlike Instance.dispose(), this does NOT tear down MCP connections, LSP
+   * servers, or abort running sessions.
+   */
+  export function reload() {
+    State.resetEntry(Instance.directory, stateInit)
+    GlobalBus.emit("event", {
+      directory: "global",
+      payload: {
+        type: Event.ConfigUpdated.type,
+        properties: {},
+      },
+    })
+  }
+  // kilocode_change end
 }
 Filesystem.write
 Filesystem.write

--- a/packages/opencode/src/server/routes/config.ts
+++ b/packages/opencode/src/server/routes/config.ts
@@ -62,6 +62,31 @@ export const ConfigRoutes = lazy(() =>
         return c.json(config)
       },
     )
+    // kilocode_change start — lightweight config reload without full instance disposal
+    .post(
+      "/reload",
+      describeRoute({
+        summary: "Reload configuration",
+        description:
+          "Invalidate the cached configuration for the current instance so the next read re-merges all layers from disk. Does not dispose the instance.",
+        operationId: "config.reload",
+        responses: {
+          200: {
+            description: "Config cache invalidated",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        Config.reload()
+        return c.json(true)
+      },
+    )
+    // kilocode_change end
     .get(
       "/providers",
       describeRoute({

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -19,6 +19,7 @@ import type {
   Config as Config3,
   ConfigGetResponses,
   ConfigProvidersResponses,
+  ConfigReloadResponses,
   ConfigUpdateErrors,
   ConfigUpdateResponses,
   EnhancePromptEnhanceErrors,
@@ -826,6 +827,36 @@ export class Config2 extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
+    })
+  }
+
+  /**
+   * Reload configuration
+   *
+   * Invalidate the cached configuration for the current instance so the next read re-merges all layers from disk. Does not dispose the instance.
+   */
+  public reload<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ConfigReloadResponses, unknown, ThrowOnError>({
+      url: "/config/reload",
+      ...options,
+      ...params,
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2447,6 +2447,25 @@ export type ConfigUpdateResponses = {
 
 export type ConfigUpdateResponse = ConfigUpdateResponses[keyof ConfigUpdateResponses]
 
+export type ConfigReloadData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/config/reload"
+}
+
+export type ConfigReloadResponses = {
+  /**
+   * Config cache invalidated
+   */
+  200: boolean
+}
+
+export type ConfigReloadResponse = ConfigReloadResponses[keyof ConfigReloadResponses]
+
 export type ConfigProvidersData = {
   body?: never
   path?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -978,6 +978,47 @@
         ]
       }
     },
+    "/config/reload": {
+      "post": {
+        "operationId": "config.reload",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Reload configuration",
+        "description": "Invalidate the cached configuration for the current instance so the next read re-merges all layers from disk. Does not dispose the instance.",
+        "responses": {
+          "200": {
+            "description": "Config cache invalidated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.config.reload({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/config/providers": {
       "get": {
         "operationId": "config.providers",
@@ -4987,6 +5028,15 @@
                                 "isFree": {
                                   "type": "boolean"
                                 },
+                                "ai_sdk_provider": {
+                                  "type": "string",
+                                  "enum": [
+                                    "anthropic",
+                                    "openai",
+                                    "openai-compatible",
+                                    "openrouter"
+                                  ]
+                                },
                                 "experimental": {
                                   "type": "boolean"
                                 },
@@ -5953,7 +6003,32 @@
                               },
                               "groups": {
                                 "type": "array",
-                                "items": {}
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "prefixItems": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "fileRegex": {
+                                              "type": "string"
+                                            },
+                                            "description": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
                               }
                             }
                           }
@@ -12454,6 +12529,15 @@
                 "isFree": {
                   "type": "boolean"
                 },
+                "ai_sdk_provider": {
+                  "type": "string",
+                  "enum": [
+                    "anthropic",
+                    "openai",
+                    "openai-compatible",
+                    "openrouter"
+                  ]
+                },
                 "experimental": {
                   "type": "boolean"
                 },
@@ -13535,6 +13619,15 @@
           },
           "isFree": {
             "type": "boolean"
+          },
+          "ai_sdk_provider": {
+            "type": "string",
+            "enum": [
+              "anthropic",
+              "openai",
+              "openai-compatible",
+              "openrouter"
+            ]
           }
         },
         "required": [


### PR DESCRIPTION
## Summary

- Adds a `FileSystemWatcher` to `KiloProvider` that monitors rules-related files for external edits, so the Agents Behaviour tab auto-refreshes without requiring a VS Code restart
- When rules files change on disk, the CLI instance is disposed (forcing it to rebuild config with re-discovered rules), then the updated config is pushed to the webview
- The watcher is debounced (500ms) to coalesce rapid saves, and properly disposed on cleanup

Fixes #7582

## Details

### Problem

When editing rules files (`.kilo/rules/*.md`, `.kilocode/rules/*.md`, `AGENTS.md`, etc.) outside the Settings UI, the Agents Behaviour tab did not reflect changes until VS Code was fully restarted. The legacy extension handled this by re-reading rules when the settings tab was reopened.

### Root Cause

The extension had no file watcher for rules/instruction files. Config was only refreshed via:
1. SSE `global.config.updated` events (only fired for API-initiated config writes)
2. `requestConfig` messages on webview mount (only on initial load)
3. Full server disposal events (requires restart)

### Solution

Added a `FileSystemWatcher` in `KiloProvider` (the core webview provider) that watches:

```
**/{.kilo/rules/**,.kilocode/rules/**,AGENTS.md,CLAUDE.md,CONTEXT.md,.kilocoderules*}
```

On change/create/delete:
1. A 500ms debounce timer coalesces rapid edits
2. `instance.dispose()` is called on the CLI backend to force it to rebuild config from disk (including re-running `RulesMigrator.discoverRules()`)
3. The cached config is invalidated
4. `fetchAndSendConfigUpdated()` re-fetches the merged config and pushes `configUpdated` to the webview

The watcher is set up in both `resolveWebviewView()` (sidebar) and `resolveWebviewPanel()` (editor tabs), and disposed in the provider's `dispose()` method.

### Files Changed

| File | Change |
|---|---|
| `packages/kilo-vscode/src/KiloProvider.ts` | Added `rulesWatcher`, `rulesDebounce` fields; `setupRulesWatcher()`, `debouncedRulesRefresh()`, `refreshRulesConfig()` methods; watcher setup in resolve methods; disposal in `dispose()` |

Replaces #7584
