### PR TITLE
fix(ui): detect upward scroll to prevent auto-follow fighting keyboard navigation

### DIFF
--- a/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
@@ -114,6 +114,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
     if (distance < threshold()) {
       if (store.userScrolled) setStore("userScrolled", false)
+      lastScrollTop = el.scrollTop
       return
     }
 

--- a/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
@@ -17,6 +17,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
   let stopTimer: ReturnType<typeof setTimeout> | undefined
   let cleanup: (() => void) | undefined
   let userInitiated = false
+  let lastScrollTop: number | undefined
 
   const threshold = () => options.bottomThreshold ?? 10
 
@@ -116,7 +117,12 @@ export function createAutoScroll(options: AutoScrollOptions) {
     }
 
     if (!store.userScrolled && !byUser) {
-      scrollToBottomNow("auto")
+      if (el.scrollTop < (lastScrollTop ?? el.scrollTop)) {
+        stop()
+      } else {
+        scrollToBottomNow("auto")
+      }
+      lastScrollTop = el.scrollTop
       return
     }
 

--- a/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
@@ -55,6 +55,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
     // `scrollTop` assignment bypasses any CSS `scroll-behavior: smooth`.
     el.scrollTop = el.scrollHeight
+    lastScrollTop = el.scrollTop
   }
 
   const scrollToBottom = (force: boolean) => {


### PR DESCRIPTION
Follows up on #7588

## Context

When scrolling up with keyboard arrows or Page Up during agent execution, the chat would fight the user — snapping back to the bottom on every frame, causing a visible trembling effect. This was worse in VS Code webviews where `keydown` events don't reach the scroll container (VS Code intercepts them), so the `userInitiated` flag was never set.

## Implementation

- **Track `lastScrollTop` to detect upward scroll direction.** When a scroll event arrives without physical user input (`!byUser`) and `userScrolled` is false, the hook now compares `el.scrollTop` against the previous value. If it decreased, something moved the scroll upward — this triggers `stop()` to respect the user's intent. If it increased or stayed the same, it's a layout-induced shift and gets corrected with `scrollToBottomNow` as before.

## Testing

- Manually tested in the VS Code extension — keyboard arrow scrolling now detaches auto-follow immediately without trembling. Wheel scrolling and auto-follow during streaming remain unaffected.