### PR TITLE
feat(vscode): add import/export for agent mode definitions

### DIFF
--- a/packages/kilo-vscode/tests/unit/mode-io.test.ts
+++ b/packages/kilo-vscode/tests/unit/mode-io.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "bun:test"
+import { parseImport, buildExport, MAX_IMPORT_SIZE } from "../../webview-ui/src/components/settings/mode-io"
+
+describe("parseImport", () => {
+  it("parses a valid full definition", () => {
+    const json = JSON.stringify({
+      name: "reviewer",
+      description: "Reviews code",
+      prompt: "You review code.",
+      model: "anthropic/claude-sonnet-4-20250514",
+      mode: "primary",
+      temperature: 0.7,
+      top_p: 0.9,
+      steps: 10,
+    })
+    const result = parseImport(json, [])
+    expect(result).toEqual({
+      ok: true,
+      name: "reviewer",
+      config: {
+        description: "Reviews code",
+        prompt: "You review code.",
+        model: "anthropic/claude-sonnet-4-20250514",
+        mode: "primary",
+        temperature: 0.7,
+        top_p: 0.9,
+        steps: 10,
+      },
+    })
+  })
+
+  it("defaults mode to primary when omitted", () => {
+    const json = JSON.stringify({ name: "my-agent" })
+    const result = parseImport(json, [])
+    expect(result).toEqual({
+      ok: true,
+      name: "my-agent",
+      config: { mode: "primary" },
+    })
+  })
+
+  it("rejects invalid JSON", () => {
+    expect(parseImport("not json", [])).toEqual({ ok: false, error: "invalidJson" })
+  })
+
+  it("rejects missing name", () => {
+    expect(parseImport("{}", [])).toEqual({ ok: false, error: "invalidName" })
+  })
+
+  it("rejects name starting with number", () => {
+    expect(parseImport(JSON.stringify({ name: "1agent" }), [])).toEqual({ ok: false, error: "invalidName" })
+  })
+
+  it("rejects name with uppercase", () => {
+    expect(parseImport(JSON.stringify({ name: "MyAgent" }), [])).toEqual({ ok: false, error: "invalidName" })
+  })
+
+  it("rejects name with spaces", () => {
+    expect(parseImport(JSON.stringify({ name: "my agent" }), [])).toEqual({ ok: false, error: "invalidName" })
+  })
+
+  it("rejects duplicate name", () => {
+    const json = JSON.stringify({ name: "existing" })
+    expect(parseImport(json, ["existing", "other"])).toEqual({ ok: false, error: "nameTaken" })
+  })
+
+  it("ignores invalid mode values", () => {
+    const json = JSON.stringify({ name: "test", mode: "bogus" })
+    const result = parseImport(json, [])
+    expect(result).toEqual({
+      ok: true,
+      name: "test",
+      config: { mode: "primary" },
+    })
+  })
+
+  it("accepts all valid mode values", () => {
+    for (const mode of ["subagent", "primary", "all"] as const) {
+      const json = JSON.stringify({ name: "test", mode })
+      const result = parseImport(json, [])
+      expect(result).toEqual({ ok: true, name: "test", config: { mode } })
+    }
+  })
+
+  it("ignores non-string and non-number fields", () => {
+    const json = JSON.stringify({
+      name: "test",
+      description: 123,
+      prompt: true,
+      model: [],
+      temperature: "hot",
+      top_p: null,
+      steps: "many",
+    })
+    const result = parseImport(json, [])
+    expect(result).toEqual({ ok: true, name: "test", config: { mode: "primary" } })
+  })
+
+  it("trims whitespace from name", () => {
+    const json = JSON.stringify({ name: "  trimmed  " })
+    // "trimmed" doesn't have hyphens or digits so it should be valid
+    const result = parseImport(json, [])
+    expect(result).toEqual({ ok: true, name: "trimmed", config: { mode: "primary" } })
+  })
+})
+
+describe("buildExport", () => {
+  it("includes name and all config fields", () => {
+    const result = buildExport("reviewer", {
+      description: "Reviews code",
+      prompt: "You review code.",
+      model: "anthropic/claude-sonnet-4-20250514",
+      mode: "primary",
+      temperature: 0.7,
+      top_p: 0.9,
+      steps: 10,
+    })
+    expect(result).toEqual({
+      name: "reviewer",
+      description: "Reviews code",
+      prompt: "You review code.",
+      model: "anthropic/claude-sonnet-4-20250514",
+      mode: "primary",
+      temperature: 0.7,
+      top_p: 0.9,
+      steps: 10,
+    })
+  })
+
+  it("handles empty config", () => {
+    expect(buildExport("minimal", {})).toEqual({ name: "minimal" })
+  })
+})
+
+describe("MAX_IMPORT_SIZE", () => {
+  it("is 1 MB", () => {
+    expect(MAX_IMPORT_SIZE).toBe(1_048_576)
+  })
+})

--- a/packages/kilo-vscode/tests/unit/mode-io.test.ts
+++ b/packages/kilo-vscode/tests/unit/mode-io.test.ts
@@ -102,6 +102,57 @@ describe("parseImport", () => {
     const result = parseImport(json, [])
     expect(result).toEqual({ ok: true, name: "trimmed", config: { mode: "primary" } })
   })
+
+  it("preserves valid permission entries", () => {
+    const json = JSON.stringify({
+      name: "reviewer",
+      permission: { read: "allow", bash: "allow", edit: "deny", mcp: "ask" },
+    })
+    const result = parseImport(json, [])
+    expect(result).toEqual({
+      ok: true,
+      name: "reviewer",
+      config: {
+        mode: "primary",
+        permission: { read: "allow", bash: "allow", edit: "deny", mcp: "ask" },
+      },
+    })
+  })
+
+  it("drops invalid permission values", () => {
+    const json = JSON.stringify({
+      name: "test",
+      permission: { read: "allow", bad: "nope", num: 42, arr: [] },
+    })
+    const result = parseImport(json, [])
+    expect(result).toEqual({
+      ok: true,
+      name: "test",
+      config: { mode: "primary", permission: { read: "allow" } },
+    })
+  })
+
+  it("ignores non-object permission field", () => {
+    const json = JSON.stringify({ name: "test", permission: "allow" })
+    const result = parseImport(json, [])
+    expect(result).toEqual({ ok: true, name: "test", config: { mode: "primary" } })
+  })
+
+  it("round-trips permission through export and import", () => {
+    const cfg = {
+      mode: "primary" as const,
+      prompt: "Review code",
+      permission: { read: "allow" as const, edit: "deny" as const },
+    }
+    const exported = buildExport("reviewer", cfg)
+    const json = JSON.stringify(exported)
+    const result = parseImport(json, [])
+    expect(result).toEqual({
+      ok: true,
+      name: "reviewer",
+      config: { mode: "primary", prompt: "Review code", permission: { read: "allow", edit: "deny" } },
+    })
+  })
 })
 
 describe("buildExport", () => {

--- a/packages/kilo-vscode/tests/unit/mode-io.test.ts
+++ b/packages/kilo-vscode/tests/unit/mode-io.test.ts
@@ -43,6 +43,22 @@ describe("parseImport", () => {
     expect(parseImport("not json", [])).toEqual({ ok: false, error: "invalidJson" })
   })
 
+  it("rejects JSON null", () => {
+    expect(parseImport("null", [])).toEqual({ ok: false, error: "invalidJson" })
+  })
+
+  it("rejects JSON array", () => {
+    expect(parseImport("[]", [])).toEqual({ ok: false, error: "invalidJson" })
+  })
+
+  it("rejects JSON string", () => {
+    expect(parseImport('"hello"', [])).toEqual({ ok: false, error: "invalidJson" })
+  })
+
+  it("rejects JSON number", () => {
+    expect(parseImport("42", [])).toEqual({ ok: false, error: "invalidJson" })
+  })
+
   it("rejects missing name", () => {
     expect(parseImport("{}", [])).toEqual({ ok: false, error: "invalidName" })
   })
@@ -129,6 +145,22 @@ describe("parseImport", () => {
       ok: true,
       name: "test",
       config: { mode: "primary", permission: { read: "allow" } },
+    })
+  })
+
+  it("preserves nested per-pattern permission rules", () => {
+    const json = JSON.stringify({
+      name: "test",
+      permission: { bash: { "*": "ask", uname: "allow" }, read: "allow" },
+    })
+    const result = parseImport(json, [])
+    expect(result).toEqual({
+      ok: true,
+      name: "test",
+      config: {
+        mode: "primary",
+        permission: { bash: { "*": "ask", uname: "allow" }, read: "allow" },
+      },
     })
   })
 

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/settings/mode-edit-export-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/settings/mode-edit-export-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dcc9ddf87e9c5b6e5cf736bfa5d42005020d14e2bb6fe7cd99a82a149db3e5c
+size 37073

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -10,10 +10,12 @@ import { useDialog } from "@kilocode/kilo-ui/context/dialog"
 import { useConfig } from "../../context/config"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
-import type { AgentConfig, AgentInfo, SkillInfo } from "../../types/messages"
+import type { AgentInfo, SkillInfo } from "../../types/messages"
 import ModeEditView from "./ModeEditView"
 import ModeCreateView from "./ModeCreateView"
 import WorkflowsTab from "./agent-behaviour/WorkflowsTab"
+import { parseImport, MAX_IMPORT_SIZE } from "./mode-io"
+import type { ImportError } from "./mode-io"
 
 type SubtabId = "agents" | "mcpServers" | "rules" | "workflows" | "skills"
 
@@ -229,42 +231,24 @@ const AgentBehaviourTab: Component = () => {
 
   const [importError, setImportError] = createSignal("")
 
+  const errorKey = (tag: ImportError) => `settings.agentBehaviour.importMode.${tag}` as const
+
   const importMode = (file: File) => {
     setImportError("")
-    if (file.size > 1_048_576) {
-      setImportError(language.t("settings.agentBehaviour.importMode.tooLarge"))
+    if (file.size > MAX_IMPORT_SIZE) {
+      setImportError(language.t(errorKey("tooLarge")))
       return
     }
     const reader = new FileReader()
     reader.onload = () => {
-      try {
-        const data = JSON.parse(reader.result as string)
-        const name = typeof data.name === "string" ? data.name.trim() : ""
-        if (!name || !/^[a-z][a-z0-9-]*$/.test(name)) {
-          setImportError(language.t("settings.agentBehaviour.importMode.invalidName"))
-          return
-        }
-        if (agentNames().includes(name)) {
-          setImportError(language.t("settings.agentBehaviour.importMode.nameTaken"))
-          return
-        }
-        const partial: Partial<AgentConfig> = {}
-        if (typeof data.description === "string") partial.description = data.description
-        if (typeof data.prompt === "string") partial.prompt = data.prompt
-        if (typeof data.model === "string") partial.model = data.model
-        const modes = ["subagent", "primary", "all"] as const
-        if (typeof data.mode === "string" && modes.includes(data.mode)) partial.mode = data.mode
-        if (typeof data.temperature === "number") partial.temperature = data.temperature
-        if (typeof data.top_p === "number") partial.top_p = data.top_p
-        if (typeof data.steps === "number") partial.steps = data.steps
-        const existing = config().agent ?? {}
-        updateConfig({
-          agent: { ...existing, [name]: { ...partial, mode: partial.mode ?? "primary" } },
-        })
-        setImportError("")
-      } catch {
-        setImportError(language.t("settings.agentBehaviour.importMode.invalidJson"))
+      const result = parseImport(reader.result as string, agentNames())
+      if (!result.ok) {
+        setImportError(language.t(errorKey(result.error)))
+        return
       }
+      const existing = config().agent ?? {}
+      updateConfig({ agent: { ...existing, [result.name]: result.config } })
+      setImportError("")
     }
     reader.readAsText(file)
   }

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -231,6 +231,10 @@ const AgentBehaviourTab: Component = () => {
 
   const importMode = (file: File) => {
     setImportError("")
+    if (file.size > 1_048_576) {
+      setImportError(language.t("settings.agentBehaviour.importMode.tooLarge"))
+      return
+    }
     const reader = new FileReader()
     reader.onload = () => {
       try {

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -10,7 +10,7 @@ import { useDialog } from "@kilocode/kilo-ui/context/dialog"
 import { useConfig } from "../../context/config"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
-import type { AgentInfo, SkillInfo } from "../../types/messages"
+import type { AgentConfig, AgentInfo, SkillInfo } from "../../types/messages"
 import ModeEditView from "./ModeEditView"
 import ModeCreateView from "./ModeCreateView"
 import WorkflowsTab from "./agent-behaviour/WorkflowsTab"
@@ -227,6 +227,54 @@ const AgentBehaviourTab: Component = () => {
     setEditingAgent("")
   }
 
+  const [importError, setImportError] = createSignal("")
+
+  const importMode = (file: File) => {
+    setImportError("")
+    const reader = new FileReader()
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result as string)
+        const name = typeof data.name === "string" ? data.name.trim() : ""
+        if (!name || !/^[a-z][a-z0-9-]*$/.test(name)) {
+          setImportError(language.t("settings.agentBehaviour.importMode.invalidName"))
+          return
+        }
+        if (agentNames().includes(name)) {
+          setImportError(language.t("settings.agentBehaviour.importMode.nameTaken"))
+          return
+        }
+        const partial: Partial<AgentConfig> = {}
+        if (typeof data.description === "string") partial.description = data.description
+        if (typeof data.prompt === "string") partial.prompt = data.prompt
+        if (typeof data.model === "string") partial.model = data.model
+        if (typeof data.mode === "string") partial.mode = data.mode as AgentConfig["mode"]
+        if (typeof data.temperature === "number") partial.temperature = data.temperature
+        if (typeof data.top_p === "number") partial.top_p = data.top_p
+        if (typeof data.steps === "number") partial.steps = data.steps
+        const existing = config().agent ?? {}
+        updateConfig({
+          agent: { ...existing, [name]: { ...partial, mode: partial.mode ?? "primary" } },
+        })
+        setImportError("")
+      } catch {
+        setImportError(language.t("settings.agentBehaviour.importMode.invalidJson"))
+      }
+    }
+    reader.readAsText(file)
+  }
+
+  const triggerImport = () => {
+    const input = document.createElement("input")
+    input.type = "file"
+    input.accept = ".json"
+    input.onchange = () => {
+      const file = input.files?.[0]
+      if (file) importMode(file)
+    }
+    input.click()
+  }
+
   const renderAgentsSubtab = () => {
     const view = agentView()
     if (view === "create") return <ModeCreateView taken={agentNames()} onBack={back} />
@@ -270,10 +318,27 @@ const AgentBehaviourTab: Component = () => {
           }}
         >
           <div data-slot="settings-row-label-title">{language.t("settings.agentBehaviour.availableAgents")}</div>
-          <Button variant="secondary" size="small" onClick={() => setAgentView("create")}>
-            {language.t("settings.agentBehaviour.createMode")}
-          </Button>
+          <div style={{ display: "flex", gap: "8px" }}>
+            <Button variant="ghost" size="small" onClick={triggerImport}>
+              {language.t("settings.agentBehaviour.importMode")}
+            </Button>
+            <Button variant="secondary" size="small" onClick={() => setAgentView("create")}>
+              {language.t("settings.agentBehaviour.createMode")}
+            </Button>
+          </div>
         </div>
+
+        <Show when={importError()}>
+          <div
+            style={{
+              "font-size": "12px",
+              color: "var(--vscode-errorForeground)",
+              "margin-bottom": "8px",
+            }}
+          >
+            {importError()}
+          </div>
+        </Show>
 
         {/* Agents list - clickable to edit */}
         <Show

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -248,7 +248,8 @@ const AgentBehaviourTab: Component = () => {
         if (typeof data.description === "string") partial.description = data.description
         if (typeof data.prompt === "string") partial.prompt = data.prompt
         if (typeof data.model === "string") partial.model = data.model
-        if (typeof data.mode === "string") partial.mode = data.mode as AgentConfig["mode"]
+        const modes = ["subagent", "primary", "all"] as const
+        if (typeof data.mode === "string" && modes.includes(data.mode)) partial.mode = data.mode
         if (typeof data.temperature === "number") partial.temperature = data.temperature
         if (typeof data.top_p === "number") partial.top_p = data.top_p
         if (typeof data.steps === "number") partial.steps = data.steps

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
@@ -68,15 +68,15 @@ const ModeEditView: Component<Props> = (props) => {
             {language.t("settings.agentBehaviour.editMode")} — {props.name}
           </span>
         </div>
-        <div style={{ display: "flex", gap: "4px" }}>
-          <IconButton
-            size="small"
-            variant="ghost"
-            icon="download"
-            title={language.t("settings.agentBehaviour.exportMode")}
-            onClick={exportMode}
-          />
-          <Show when={!native()}>
+        <Show when={!native()}>
+          <div style={{ display: "flex", gap: "4px" }}>
+            <IconButton
+              size="small"
+              variant="ghost"
+              icon="download"
+              title={language.t("settings.agentBehaviour.exportMode")}
+              onClick={exportMode}
+            />
             <IconButton
               size="small"
               variant="ghost"
@@ -86,8 +86,8 @@ const ModeEditView: Component<Props> = (props) => {
                 if (a) props.onRemove(a)
               }}
             />
-          </Show>
-        </div>
+          </div>
+        </Show>
       </div>
 
       <Show when={native()}>

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
@@ -40,6 +40,18 @@ const ModeEditView: Component<Props> = (props) => {
     })
   }
 
+  const exportMode = () => {
+    const data = { name: props.name, ...cfg() }
+    const json = JSON.stringify(data, null, 2)
+    const blob = new Blob([json], { type: "application/json" })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = `${props.name}.agent.json`
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }
+
   return (
     <div>
       <div
@@ -56,17 +68,26 @@ const ModeEditView: Component<Props> = (props) => {
             {language.t("settings.agentBehaviour.editMode")} — {props.name}
           </span>
         </div>
-        <Show when={!native()}>
+        <div style={{ display: "flex", gap: "4px" }}>
           <IconButton
             size="small"
             variant="ghost"
-            icon="close"
-            onClick={() => {
-              const a = agent()
-              if (a) props.onRemove(a)
-            }}
+            icon="download"
+            title={language.t("settings.agentBehaviour.exportMode")}
+            onClick={exportMode}
           />
-        </Show>
+          <Show when={!native()}>
+            <IconButton
+              size="small"
+              variant="ghost"
+              icon="close"
+              onClick={() => {
+                const a = agent()
+                if (a) props.onRemove(a)
+              }}
+            />
+          </Show>
+        </div>
       </div>
 
       <Show when={native()}>

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
@@ -9,6 +9,7 @@ import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import type { AgentConfig, AgentInfo } from "../../types/messages"
 import SettingsRow from "./SettingsRow"
+import { buildExport } from "./mode-io"
 
 interface Props {
   name: string
@@ -41,7 +42,7 @@ const ModeEditView: Component<Props> = (props) => {
   }
 
   const exportMode = () => {
-    const data = { name: props.name, ...cfg() }
+    const data = buildExport(props.name, cfg())
     const json = JSON.stringify(data, null, 2)
     const blob = new Blob([json], { type: "application/json" })
     const url = URL.createObjectURL(blob)

--- a/packages/kilo-vscode/webview-ui/src/components/settings/mode-io.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/mode-io.ts
@@ -1,0 +1,55 @@
+import type { AgentConfig } from "../../types/messages"
+
+/** Maximum import file size in bytes (1 MB). */
+export const MAX_IMPORT_SIZE = 1_048_576
+
+const NAME_RE = /^[a-z][a-z0-9-]*$/
+const MODES = ["subagent", "primary", "all"] as const
+
+export type ImportError = "invalidJson" | "invalidName" | "nameTaken" | "tooLarge"
+
+export type ImportResult = { ok: true; name: string; config: AgentConfig } | { ok: false; error: ImportError }
+
+/**
+ * Parse a raw JSON string into a validated agent name + config.
+ * Returns an error tag (matching the i18n key suffix) on failure.
+ */
+export function parseImport(json: string, taken: string[]): ImportResult {
+  let data: Record<string, unknown>
+  try {
+    data = JSON.parse(json)
+  } catch {
+    return { ok: false, error: "invalidJson" }
+  }
+
+  const name = typeof data.name === "string" ? data.name.trim() : ""
+  if (!name || !NAME_RE.test(name)) {
+    return { ok: false, error: "invalidName" }
+  }
+  if (taken.includes(name)) {
+    return { ok: false, error: "nameTaken" }
+  }
+
+  const partial: Partial<AgentConfig> = {}
+  if (typeof data.description === "string") partial.description = data.description
+  if (typeof data.prompt === "string") partial.prompt = data.prompt
+  if (typeof data.model === "string") partial.model = data.model
+  if (typeof data.mode === "string" && (MODES as readonly string[]).includes(data.mode))
+    partial.mode = data.mode as AgentConfig["mode"]
+  if (typeof data.temperature === "number") partial.temperature = data.temperature
+  if (typeof data.top_p === "number") partial.top_p = data.top_p
+  if (typeof data.steps === "number") partial.steps = data.steps
+
+  return {
+    ok: true,
+    name,
+    config: { ...partial, mode: partial.mode ?? "primary" },
+  }
+}
+
+/**
+ * Build the JSON-serialisable export payload for a mode.
+ */
+export function buildExport(name: string, cfg: AgentConfig): Record<string, unknown> {
+  return { name, ...cfg }
+}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/mode-io.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/mode-io.ts
@@ -1,14 +1,29 @@
-import type { AgentConfig } from "../../types/messages"
+import type { AgentConfig, PermissionConfig } from "../../types/messages"
 
 /** Maximum import file size in bytes (1 MB). */
 export const MAX_IMPORT_SIZE = 1_048_576
 
 const NAME_RE = /^[a-z][a-z0-9-]*$/
 const MODES = ["subagent", "primary", "all"] as const
+const LEVELS = new Set(["allow", "ask", "deny"])
 
 export type ImportError = "invalidJson" | "invalidName" | "nameTaken" | "tooLarge"
 
 export type ImportResult = { ok: true; name: string; config: AgentConfig } | { ok: false; error: ImportError }
+
+/** Validate and extract a permission map, dropping unknown entries. */
+function parsePermission(raw: unknown): PermissionConfig | undefined {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return undefined
+  const out: PermissionConfig = {}
+  let count = 0
+  for (const [key, val] of Object.entries(raw)) {
+    if (typeof val === "string" && LEVELS.has(val)) {
+      out[key] = val as PermissionConfig[string]
+      count++
+    }
+  }
+  return count > 0 ? out : undefined
+}
 
 /**
  * Parse a raw JSON string into a validated agent name + config.
@@ -39,6 +54,8 @@ export function parseImport(json: string, taken: string[]): ImportResult {
   if (typeof data.temperature === "number") partial.temperature = data.temperature
   if (typeof data.top_p === "number") partial.top_p = data.top_p
   if (typeof data.steps === "number") partial.steps = data.steps
+  const perms = parsePermission(data.permission)
+  if (perms) partial.permission = perms
 
   return {
     ok: true,

--- a/packages/kilo-vscode/webview-ui/src/components/settings/mode-io.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/mode-io.ts
@@ -11,15 +11,34 @@ export type ImportError = "invalidJson" | "invalidName" | "nameTaken" | "tooLarg
 
 export type ImportResult = { ok: true; name: string; config: AgentConfig } | { ok: false; error: ImportError }
 
+/** Check if a value is a valid permission level string. */
+function isLevel(v: unknown): boolean {
+  return typeof v === "string" && LEVELS.has(v)
+}
+
 /** Validate and extract a permission map, dropping unknown entries. */
 function parsePermission(raw: unknown): PermissionConfig | undefined {
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return undefined
   const out: PermissionConfig = {}
   let count = 0
   for (const [key, val] of Object.entries(raw)) {
-    if (typeof val === "string" && LEVELS.has(val)) {
+    if (isLevel(val)) {
       out[key] = val as PermissionConfig[string]
       count++
+    } else if (typeof val === "object" && val !== null && !Array.isArray(val)) {
+      // Nested per-pattern rules like { "*": "ask", "uname": "allow" }
+      const nested: Record<string, string | null> = {}
+      let valid = 0
+      for (const [pat, lev] of Object.entries(val)) {
+        if (isLevel(lev)) {
+          nested[pat] = lev as string
+          valid++
+        }
+      }
+      if (valid > 0) {
+        out[key] = nested as PermissionConfig[string]
+        count++
+      }
     }
   }
   return count > 0 ? out : undefined
@@ -30,14 +49,18 @@ function parsePermission(raw: unknown): PermissionConfig | undefined {
  * Returns an error tag (matching the i18n key suffix) on failure.
  */
 export function parseImport(json: string, taken: string[]): ImportResult {
-  let data: Record<string, unknown>
+  let data: unknown
   try {
     data = JSON.parse(json)
   } catch {
     return { ok: false, error: "invalidJson" }
   }
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    return { ok: false, error: "invalidJson" }
+  }
+  const obj = data as Record<string, unknown>
 
-  const name = typeof data.name === "string" ? data.name.trim() : ""
+  const name = typeof obj.name === "string" ? obj.name.trim() : ""
   if (!name || !NAME_RE.test(name)) {
     return { ok: false, error: "invalidName" }
   }
@@ -46,15 +69,15 @@ export function parseImport(json: string, taken: string[]): ImportResult {
   }
 
   const partial: Partial<AgentConfig> = {}
-  if (typeof data.description === "string") partial.description = data.description
-  if (typeof data.prompt === "string") partial.prompt = data.prompt
-  if (typeof data.model === "string") partial.model = data.model
-  if (typeof data.mode === "string" && (MODES as readonly string[]).includes(data.mode))
-    partial.mode = data.mode as AgentConfig["mode"]
-  if (typeof data.temperature === "number") partial.temperature = data.temperature
-  if (typeof data.top_p === "number") partial.top_p = data.top_p
-  if (typeof data.steps === "number") partial.steps = data.steps
-  const perms = parsePermission(data.permission)
+  if (typeof obj.description === "string") partial.description = obj.description
+  if (typeof obj.prompt === "string") partial.prompt = obj.prompt
+  if (typeof obj.model === "string") partial.model = obj.model
+  if (typeof obj.mode === "string" && (MODES as readonly string[]).includes(obj.mode))
+    partial.mode = obj.mode as AgentConfig["mode"]
+  if (typeof obj.temperature === "number") partial.temperature = obj.temperature
+  if (typeof obj.top_p === "number") partial.top_p = obj.top_p
+  if (typeof obj.steps === "number") partial.steps = obj.steps
+  const perms = parsePermission(obj.permission)
   if (perms) partial.permission = perms
 
   return {

--- a/packages/kilo-vscode/webview-ui/src/components/shared/PopupSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/PopupSelector.tsx
@@ -22,10 +22,8 @@ import {
 import { Popover } from "@kilocode/kilo-ui/popover"
 import type { PopoverProps } from "@kilocode/kilo-ui/popover"
 
-export interface PopupSelectorProps<T extends ValidComponent = ValidComponent> extends Omit<
-  PopoverProps<T>,
-  "style" | "children"
-> {
+export interface PopupSelectorProps<T extends ValidComponent = ValidComponent>
+  extends Omit<PopoverProps<T>, "style" | "children"> {
   /** Whether the selector is in expanded mode (wider + taller). */
   expanded: boolean
   /** Preferred width when collapsed. Default: 250 */

--- a/packages/kilo-vscode/webview-ui/src/components/shared/PopupSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/PopupSelector.tsx
@@ -22,8 +22,10 @@ import {
 import { Popover } from "@kilocode/kilo-ui/popover"
 import type { PopoverProps } from "@kilocode/kilo-ui/popover"
 
-export interface PopupSelectorProps<T extends ValidComponent = ValidComponent>
-  extends Omit<PopoverProps<T>, "style" | "children"> {
+export interface PopupSelectorProps<T extends ValidComponent = ValidComponent> extends Omit<
+  PopoverProps<T>,
+  "style" | "children"
+> {
   /** Whether the selector is in expanded mode (wider + taller). */
   expanded: boolean
   /** Preferred width when collapsed. Default: 250 */

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1059,6 +1059,12 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "الاسم مطلوب",
   "settings.agentBehaviour.createMode.nameInvalid": "يجب أن يحتوي الاسم على أحرف صغيرة وأرقام وشرطات فقط",
   "settings.agentBehaviour.createMode.nameTaken": "يوجد وضع بهذا الاسم بالفعل",
+  "settings.agentBehaviour.importMode": "استيراد",
+  "settings.agentBehaviour.importMode.invalidName":
+    "اسم الوضع في الملف غير صالح. يجب أن يبدأ الاسم بحرف صغير ويحتوي فقط على أحرف صغيرة وأرقام وشرطات.",
+  "settings.agentBehaviour.importMode.nameTaken": "يوجد وضع بهذا الاسم بالفعل.",
+  "settings.agentBehaviour.importMode.invalidJson": "ملف JSON غير صالح. يرجى اختيار ملف تعريف وكيل صالح.",
+  "settings.agentBehaviour.exportMode": "تصدير تعريف الوكيل",
   "settings.agentBehaviour.editMode": "تعديل الوضع",
   "settings.agentBehaviour.editMode.description": "الوصف",
   "settings.agentBehaviour.editMode.prompt": "موجه النظام",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1064,6 +1064,7 @@ export const dict = {
     "اسم الوضع في الملف غير صالح. يجب أن يبدأ الاسم بحرف صغير ويحتوي فقط على أحرف صغيرة وأرقام وشرطات.",
   "settings.agentBehaviour.importMode.nameTaken": "يوجد وضع بهذا الاسم بالفعل.",
   "settings.agentBehaviour.importMode.invalidJson": "ملف JSON غير صالح. يرجى اختيار ملف تعريف وكيل صالح.",
+  "settings.agentBehaviour.importMode.tooLarge": "الملف كبير جدًا. يجب أن تكون تعريفات الوكيل أقل من 1 ميجابايت.",
   "settings.agentBehaviour.exportMode": "تصدير تعريف الوكيل",
   "settings.agentBehaviour.editMode": "تعديل الوضع",
   "settings.agentBehaviour.editMode.description": "الوصف",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1072,6 +1072,13 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "Nome é obrigatório",
   "settings.agentBehaviour.createMode.nameInvalid": "O nome deve conter apenas letras minúsculas, números e hífens",
   "settings.agentBehaviour.createMode.nameTaken": "Já existe um modo com este nome",
+  "settings.agentBehaviour.importMode": "Importar",
+  "settings.agentBehaviour.importMode.invalidName":
+    "Nome de modo inválido no arquivo. O nome deve começar com uma letra minúscula e conter apenas letras minúsculas, números e hífens.",
+  "settings.agentBehaviour.importMode.nameTaken": "Já existe um modo com este nome.",
+  "settings.agentBehaviour.importMode.invalidJson":
+    "Arquivo JSON inválido. Por favor, selecione um arquivo de definição de agente válido.",
+  "settings.agentBehaviour.exportMode": "Exportar definição do agente",
   "settings.agentBehaviour.editMode": "Editar Modo",
   "settings.agentBehaviour.editMode.description": "Descrição",
   "settings.agentBehaviour.editMode.prompt": "Prompt do Sistema",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1078,6 +1078,7 @@ export const dict = {
   "settings.agentBehaviour.importMode.nameTaken": "Já existe um modo com este nome.",
   "settings.agentBehaviour.importMode.invalidJson":
     "Arquivo JSON inválido. Por favor, selecione um arquivo de definição de agente válido.",
+  "settings.agentBehaviour.importMode.tooLarge": "Arquivo muito grande. Definições de agente devem ter menos de 1 MB.",
   "settings.agentBehaviour.exportMode": "Exportar definição do agente",
   "settings.agentBehaviour.editMode": "Editar Modo",
   "settings.agentBehaviour.editMode.description": "Descrição",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1072,6 +1072,13 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "Naziv je obavezan",
   "settings.agentBehaviour.createMode.nameInvalid": "Naziv smije sadržavati samo mala slova, brojeve i crtice",
   "settings.agentBehaviour.createMode.nameTaken": "Mod s ovim nazivom već postoji",
+  "settings.agentBehaviour.importMode": "Uvezi",
+  "settings.agentBehaviour.importMode.invalidName":
+    "Nevažeći naziv moda u datoteci. Naziv mora počinjati malim slovom i sadržavati samo mala slova, brojeve i crtice.",
+  "settings.agentBehaviour.importMode.nameTaken": "Mod s ovim nazivom već postoji.",
+  "settings.agentBehaviour.importMode.invalidJson":
+    "Nevažeća JSON datoteka. Molimo odaberite važeću datoteku definicije agenta.",
+  "settings.agentBehaviour.exportMode": "Izvezi definiciju agenta",
   "settings.agentBehaviour.editMode": "Uredi mod",
   "settings.agentBehaviour.editMode.description": "Opis",
   "settings.agentBehaviour.editMode.prompt": "Sistemski prompt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1078,6 +1078,7 @@ export const dict = {
   "settings.agentBehaviour.importMode.nameTaken": "Mod s ovim nazivom već postoji.",
   "settings.agentBehaviour.importMode.invalidJson":
     "Nevažeća JSON datoteka. Molimo odaberite važeću datoteku definicije agenta.",
+  "settings.agentBehaviour.importMode.tooLarge": "Datoteka je prevelika. Definicije agenta moraju biti manje od 1 MB.",
   "settings.agentBehaviour.exportMode": "Izvezi definiciju agenta",
   "settings.agentBehaviour.editMode": "Uredi mod",
   "settings.agentBehaviour.editMode.description": "Opis",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1067,6 +1067,12 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "Navn er påkrævet",
   "settings.agentBehaviour.createMode.nameInvalid": "Navn må kun indeholde små bogstaver, tal og bindestreger",
   "settings.agentBehaviour.createMode.nameTaken": "En tilstand med dette navn eksisterer allerede",
+  "settings.agentBehaviour.importMode": "Importér",
+  "settings.agentBehaviour.importMode.invalidName":
+    "Ugyldigt tilstandsnavn i filen. Navnet skal starte med et lille bogstav og kun indeholde små bogstaver, tal og bindestreger.",
+  "settings.agentBehaviour.importMode.nameTaken": "En tilstand med dette navn eksisterer allerede.",
+  "settings.agentBehaviour.importMode.invalidJson": "Ugyldig JSON-fil. Vælg venligst en gyldig agentdefinitionsfil.",
+  "settings.agentBehaviour.exportMode": "Eksportér agentdefinition",
   "settings.agentBehaviour.editMode": "Rediger tilstand",
   "settings.agentBehaviour.editMode.description": "Beskrivelse",
   "settings.agentBehaviour.editMode.prompt": "Systemprompt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1072,6 +1072,7 @@ export const dict = {
     "Ugyldigt tilstandsnavn i filen. Navnet skal starte med et lille bogstav og kun indeholde små bogstaver, tal og bindestreger.",
   "settings.agentBehaviour.importMode.nameTaken": "En tilstand med dette navn eksisterer allerede.",
   "settings.agentBehaviour.importMode.invalidJson": "Ugyldig JSON-fil. Vælg venligst en gyldig agentdefinitionsfil.",
+  "settings.agentBehaviour.importMode.tooLarge": "Filen er for stor. Agentdefinitioner skal være under 1 MB.",
   "settings.agentBehaviour.exportMode": "Eksportér agentdefinition",
   "settings.agentBehaviour.editMode": "Rediger tilstand",
   "settings.agentBehaviour.editMode.description": "Beskrivelse",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1085,6 +1085,13 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "Name ist erforderlich",
   "settings.agentBehaviour.createMode.nameInvalid": "Name darf nur Kleinbuchstaben, Zahlen und Bindestriche enthalten",
   "settings.agentBehaviour.createMode.nameTaken": "Ein Modus mit diesem Namen existiert bereits",
+  "settings.agentBehaviour.importMode": "Importieren",
+  "settings.agentBehaviour.importMode.invalidName":
+    "Ungültiger Modusname in der Datei. Der Name muss mit einem Kleinbuchstaben beginnen und darf nur Kleinbuchstaben, Zahlen und Bindestriche enthalten.",
+  "settings.agentBehaviour.importMode.nameTaken": "Ein Modus mit diesem Namen existiert bereits.",
+  "settings.agentBehaviour.importMode.invalidJson":
+    "Ungültige JSON-Datei. Bitte wählen Sie eine gültige Agenten-Definitionsdatei aus.",
+  "settings.agentBehaviour.exportMode": "Agenten-Definition exportieren",
   "settings.agentBehaviour.editMode": "Modus bearbeiten",
   "settings.agentBehaviour.editMode.description": "Beschreibung",
   "settings.agentBehaviour.editMode.prompt": "System-Prompt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1091,6 +1091,7 @@ export const dict = {
   "settings.agentBehaviour.importMode.nameTaken": "Ein Modus mit diesem Namen existiert bereits.",
   "settings.agentBehaviour.importMode.invalidJson":
     "Ungültige JSON-Datei. Bitte wählen Sie eine gültige Agenten-Definitionsdatei aus.",
+  "settings.agentBehaviour.importMode.tooLarge": "Datei ist zu groß. Agentdefinitionen müssen unter 1 MB sein.",
   "settings.agentBehaviour.exportMode": "Agenten-Definition exportieren",
   "settings.agentBehaviour.editMode": "Modus bearbeiten",
   "settings.agentBehaviour.editMode.description": "Beschreibung",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1109,6 +1109,7 @@ export const dict = {
     "Invalid mode name in file. Name must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens.",
   "settings.agentBehaviour.importMode.nameTaken": "A mode with this name already exists.",
   "settings.agentBehaviour.importMode.invalidJson": "Invalid JSON file. Please select a valid agent definition file.",
+  "settings.agentBehaviour.importMode.tooLarge": "File is too large. Agent definitions must be under 1 MB.",
   "settings.agentBehaviour.exportMode": "Export agent definition",
   "settings.agentBehaviour.editMode": "Edit Mode",
   "settings.agentBehaviour.editMode.description": "Description",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1104,6 +1104,12 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameInvalid":
     "Name must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens",
   "settings.agentBehaviour.createMode.nameTaken": "A mode with this name already exists",
+  "settings.agentBehaviour.importMode": "Import",
+  "settings.agentBehaviour.importMode.invalidName":
+    "Invalid mode name in file. Name must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens.",
+  "settings.agentBehaviour.importMode.nameTaken": "A mode with this name already exists.",
+  "settings.agentBehaviour.importMode.invalidJson": "Invalid JSON file. Please select a valid agent definition file.",
+  "settings.agentBehaviour.exportMode": "Export agent definition",
   "settings.agentBehaviour.editMode": "Edit Mode",
   "settings.agentBehaviour.editMode.description": "Description",
   "settings.agentBehaviour.editMode.prompt": "System Prompt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1076,6 +1076,13 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameInvalid":
     "El nombre solo puede contener letras minúsculas, números y guiones",
   "settings.agentBehaviour.createMode.nameTaken": "Ya existe un modo con este nombre",
+  "settings.agentBehaviour.importMode": "Importar",
+  "settings.agentBehaviour.importMode.invalidName":
+    "Nombre de modo no válido en el archivo. El nombre debe comenzar con una letra minúscula y contener solo letras minúsculas, números y guiones.",
+  "settings.agentBehaviour.importMode.nameTaken": "Ya existe un modo con este nombre.",
+  "settings.agentBehaviour.importMode.invalidJson":
+    "Archivo JSON no válido. Por favor, seleccione un archivo de definición de agente válido.",
+  "settings.agentBehaviour.exportMode": "Exportar definición del agente",
   "settings.agentBehaviour.editMode": "Editar modo",
   "settings.agentBehaviour.editMode.description": "Descripción",
   "settings.agentBehaviour.editMode.prompt": "Prompt del sistema",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1082,6 +1082,8 @@ export const dict = {
   "settings.agentBehaviour.importMode.nameTaken": "Ya existe un modo con este nombre.",
   "settings.agentBehaviour.importMode.invalidJson":
     "Archivo JSON no válido. Por favor, seleccione un archivo de definición de agente válido.",
+  "settings.agentBehaviour.importMode.tooLarge":
+    "El archivo es demasiado grande. Las definiciones de agente deben ser menores de 1 MB.",
   "settings.agentBehaviour.exportMode": "Exportar definición del agente",
   "settings.agentBehaviour.editMode": "Editar modo",
   "settings.agentBehaviour.editMode.description": "Descripción",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1089,6 +1089,13 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameInvalid":
     "Le nom ne doit contenir que des minuscules, des chiffres et des tirets",
   "settings.agentBehaviour.createMode.nameTaken": "Un mode avec ce nom existe déjà",
+  "settings.agentBehaviour.importMode": "Importer",
+  "settings.agentBehaviour.importMode.invalidName":
+    "Nom de mode invalide dans le fichier. Le nom doit commencer par une lettre minuscule et ne contenir que des lettres minuscules, des chiffres et des tirets.",
+  "settings.agentBehaviour.importMode.nameTaken": "Un mode avec ce nom existe déjà.",
+  "settings.agentBehaviour.importMode.invalidJson":
+    "Fichier JSON invalide. Veuillez sélectionner un fichier de définition d'agent valide.",
+  "settings.agentBehaviour.exportMode": "Exporter la définition de l'agent",
   "settings.agentBehaviour.editMode": "Modifier le mode",
   "settings.agentBehaviour.editMode.description": "Description",
   "settings.agentBehaviour.editMode.prompt": "Prompt système",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1095,6 +1095,8 @@ export const dict = {
   "settings.agentBehaviour.importMode.nameTaken": "Un mode avec ce nom existe déjà.",
   "settings.agentBehaviour.importMode.invalidJson":
     "Fichier JSON invalide. Veuillez sélectionner un fichier de définition d'agent valide.",
+  "settings.agentBehaviour.importMode.tooLarge":
+    "Le fichier est trop volumineux. Les définitions d'agent doivent faire moins de 1 Mo.",
   "settings.agentBehaviour.exportMode": "Exporter la définition de l'agent",
   "settings.agentBehaviour.editMode": "Modifier le mode",
   "settings.agentBehaviour.editMode.description": "Description",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1067,6 +1067,13 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "名前は必須です",
   "settings.agentBehaviour.createMode.nameInvalid": "名前には小文字、数字、ハイフンのみ使用できます",
   "settings.agentBehaviour.createMode.nameTaken": "この名前のモードはすでに存在します",
+  "settings.agentBehaviour.importMode": "インポート",
+  "settings.agentBehaviour.importMode.invalidName":
+    "ファイル内のモード名が無効です。名前は小文字で始まり、小文字、数字、ハイフンのみを含む必要があります。",
+  "settings.agentBehaviour.importMode.nameTaken": "この名前のモードはすでに存在します。",
+  "settings.agentBehaviour.importMode.invalidJson":
+    "無効なJSONファイルです。有効なエージェント定義ファイルを選択してください。",
+  "settings.agentBehaviour.exportMode": "エージェント定義をエクスポート",
   "settings.agentBehaviour.editMode": "モードを編集",
   "settings.agentBehaviour.editMode.description": "説明",
   "settings.agentBehaviour.editMode.prompt": "システムプロンプト",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1073,6 +1073,8 @@ export const dict = {
   "settings.agentBehaviour.importMode.nameTaken": "この名前のモードはすでに存在します。",
   "settings.agentBehaviour.importMode.invalidJson":
     "無効なJSONファイルです。有効なエージェント定義ファイルを選択してください。",
+  "settings.agentBehaviour.importMode.tooLarge":
+    "ファイルが大きすぎます。エージェント定義は1 MB以下である必要があります。",
   "settings.agentBehaviour.exportMode": "エージェント定義をエクスポート",
   "settings.agentBehaviour.editMode": "モードを編集",
   "settings.agentBehaviour.editMode.description": "説明",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1063,6 +1063,12 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "이름은 필수입니다",
   "settings.agentBehaviour.createMode.nameInvalid": "이름에는 소문자, 숫자, 하이픈만 포함될 수 있습니다",
   "settings.agentBehaviour.createMode.nameTaken": "이 이름의 모드가 이미 존재합니다",
+  "settings.agentBehaviour.importMode": "가져오기",
+  "settings.agentBehaviour.importMode.invalidName":
+    "파일의 모드 이름이 잘못되었습니다. 이름은 소문자로 시작하고 소문자, 숫자, 하이픈만 포함해야 합니다.",
+  "settings.agentBehaviour.importMode.nameTaken": "이 이름의 모드가 이미 존재합니다.",
+  "settings.agentBehaviour.importMode.invalidJson": "잘못된 JSON 파일입니다. 유효한 에이전트 정의 파일을 선택하세요.",
+  "settings.agentBehaviour.exportMode": "에이전트 정의 내보내기",
   "settings.agentBehaviour.editMode": "모드 편집",
   "settings.agentBehaviour.editMode.description": "설명",
   "settings.agentBehaviour.editMode.prompt": "시스템 프롬프트",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1068,6 +1068,7 @@ export const dict = {
     "파일의 모드 이름이 잘못되었습니다. 이름은 소문자로 시작하고 소문자, 숫자, 하이픈만 포함해야 합니다.",
   "settings.agentBehaviour.importMode.nameTaken": "이 이름의 모드가 이미 존재합니다.",
   "settings.agentBehaviour.importMode.invalidJson": "잘못된 JSON 파일입니다. 유효한 에이전트 정의 파일을 선택하세요.",
+  "settings.agentBehaviour.importMode.tooLarge": "파일이 너무 큽니다. 에이전트 정의는 1 MB 미만이어야 합니다.",
   "settings.agentBehaviour.exportMode": "에이전트 정의 내보내기",
   "settings.agentBehaviour.editMode": "모드 편집",
   "settings.agentBehaviour.editMode.description": "설명",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1060,6 +1060,13 @@ export const dict = {
     "Geen skills ontdekt. Voeg hieronder skill mappaden of URL's toe om skills beschikbaar te maken.",
   "settings.agentBehaviour.availableModes": "Beschikbare Aangepaste Modi",
   "settings.agentBehaviour.noModesFound": "Geen modi gevonden.",
+  "settings.agentBehaviour.importMode": "Importeren",
+  "settings.agentBehaviour.importMode.invalidName":
+    "Ongeldige modusnaam in bestand. De naam moet beginnen met een kleine letter en mag alleen kleine letters, cijfers en streepjes bevatten.",
+  "settings.agentBehaviour.importMode.nameTaken": "Er bestaat al een modus met deze naam.",
+  "settings.agentBehaviour.importMode.invalidJson":
+    "Ongeldig JSON-bestand. Selecteer een geldig agentdefinitiebestand.",
+  "settings.agentBehaviour.exportMode": "Agentdefinitie exporteren",
   "settings.agentBehaviour.removeMode.title": "Verwijder modus",
   "settings.agentBehaviour.removeMode.confirm":
     'Modus "{{name}}" verwijderen? Dit zal de modus uitschakelen door je configuratie bij te werken.',

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1066,6 +1066,7 @@ export const dict = {
   "settings.agentBehaviour.importMode.nameTaken": "Er bestaat al een modus met deze naam.",
   "settings.agentBehaviour.importMode.invalidJson":
     "Ongeldig JSON-bestand. Selecteer een geldig agentdefinitiebestand.",
+  "settings.agentBehaviour.importMode.tooLarge": "Bestand is te groot. Agentdefinities moeten kleiner zijn dan 1 MB.",
   "settings.agentBehaviour.exportMode": "Agentdefinitie exporteren",
   "settings.agentBehaviour.removeMode.title": "Verwijder modus",
   "settings.agentBehaviour.removeMode.confirm":

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1070,6 +1070,12 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "Navn er påkrevd",
   "settings.agentBehaviour.createMode.nameInvalid": "Navn kan bare inneholde små bokstaver, tall og bindestreker",
   "settings.agentBehaviour.createMode.nameTaken": "En modus med dette navnet eksisterer allerede",
+  "settings.agentBehaviour.importMode": "Importer",
+  "settings.agentBehaviour.importMode.invalidName":
+    "Ugyldig modusnavn i filen. Navnet må starte med en liten bokstav og bare inneholde små bokstaver, tall og bindestreker.",
+  "settings.agentBehaviour.importMode.nameTaken": "En modus med dette navnet eksisterer allerede.",
+  "settings.agentBehaviour.importMode.invalidJson": "Ugyldig JSON-fil. Vennligst velg en gyldig agentdefinisjonsfil.",
+  "settings.agentBehaviour.exportMode": "Eksporter agentdefinisjon",
   "settings.agentBehaviour.editMode": "Rediger modus",
   "settings.agentBehaviour.editMode.description": "Beskrivelse",
   "settings.agentBehaviour.editMode.prompt": "Systemprompt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1075,6 +1075,7 @@ export const dict = {
     "Ugyldig modusnavn i filen. Navnet må starte med en liten bokstav og bare inneholde små bokstaver, tall og bindestreker.",
   "settings.agentBehaviour.importMode.nameTaken": "En modus med dette navnet eksisterer allerede.",
   "settings.agentBehaviour.importMode.invalidJson": "Ugyldig JSON-fil. Vennligst velg en gyldig agentdefinisjonsfil.",
+  "settings.agentBehaviour.importMode.tooLarge": "Filen er for stor. Agentdefinisjoner må være under 1 MB.",
   "settings.agentBehaviour.exportMode": "Eksporter agentdefinisjon",
   "settings.agentBehaviour.editMode": "Rediger modus",
   "settings.agentBehaviour.editMode.description": "Beskrivelse",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1071,6 +1071,13 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "Nazwa jest wymagana",
   "settings.agentBehaviour.createMode.nameInvalid": "Nazwa może zawierać tylko małe litery, cyfry i myślniki",
   "settings.agentBehaviour.createMode.nameTaken": "Tryb o tej nazwie już istnieje",
+  "settings.agentBehaviour.importMode": "Importuj",
+  "settings.agentBehaviour.importMode.invalidName":
+    "Nieprawidłowa nazwa trybu w pliku. Nazwa musi zaczynać się od małej litery i zawierać tylko małe litery, cyfry i myślniki.",
+  "settings.agentBehaviour.importMode.nameTaken": "Tryb o tej nazwie już istnieje.",
+  "settings.agentBehaviour.importMode.invalidJson":
+    "Nieprawidłowy plik JSON. Proszę wybrać prawidłowy plik definicji agenta.",
+  "settings.agentBehaviour.exportMode": "Eksportuj definicję agenta",
   "settings.agentBehaviour.editMode": "Edytuj tryb",
   "settings.agentBehaviour.editMode.description": "Opis",
   "settings.agentBehaviour.editMode.prompt": "Prompt systemowy",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1077,6 +1077,7 @@ export const dict = {
   "settings.agentBehaviour.importMode.nameTaken": "Tryb o tej nazwie już istnieje.",
   "settings.agentBehaviour.importMode.invalidJson":
     "Nieprawidłowy plik JSON. Proszę wybrać prawidłowy plik definicji agenta.",
+  "settings.agentBehaviour.importMode.tooLarge": "Plik jest za duży. Definicje agentów muszą mieć mniej niż 1 MB.",
   "settings.agentBehaviour.exportMode": "Eksportuj definicję agenta",
   "settings.agentBehaviour.editMode": "Edytuj tryb",
   "settings.agentBehaviour.editMode.description": "Opis",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1074,6 +1074,13 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "Название обязательно",
   "settings.agentBehaviour.createMode.nameInvalid": "Название может содержать только строчные буквы, цифры и дефисы",
   "settings.agentBehaviour.createMode.nameTaken": "Режим с таким названием уже существует",
+  "settings.agentBehaviour.importMode": "Импорт",
+  "settings.agentBehaviour.importMode.invalidName":
+    "Недопустимое имя режима в файле. Имя должно начинаться со строчной буквы и содержать только строчные буквы, цифры и дефисы.",
+  "settings.agentBehaviour.importMode.nameTaken": "Режим с таким названием уже существует.",
+  "settings.agentBehaviour.importMode.invalidJson":
+    "Недопустимый файл JSON. Пожалуйста, выберите корректный файл определения агента.",
+  "settings.agentBehaviour.exportMode": "Экспортировать определение агента",
   "settings.agentBehaviour.editMode": "Редактировать режим",
   "settings.agentBehaviour.editMode.description": "Описание",
   "settings.agentBehaviour.editMode.prompt": "Системный промпт",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1080,6 +1080,7 @@ export const dict = {
   "settings.agentBehaviour.importMode.nameTaken": "Режим с таким названием уже существует.",
   "settings.agentBehaviour.importMode.invalidJson":
     "Недопустимый файл JSON. Пожалуйста, выберите корректный файл определения агента.",
+  "settings.agentBehaviour.importMode.tooLarge": "Файл слишком большой. Определения агентов должны быть менее 1 МБ.",
   "settings.agentBehaviour.exportMode": "Экспортировать определение агента",
   "settings.agentBehaviour.editMode": "Редактировать режим",
   "settings.agentBehaviour.editMode.description": "Описание",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1059,6 +1059,12 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "ต้องระบุชื่อ",
   "settings.agentBehaviour.createMode.nameInvalid": "ชื่อต้องประกอบด้วยตัวอักษรพิมพ์เล็ก ตัวเลข และขีดกลางเท่านั้น",
   "settings.agentBehaviour.createMode.nameTaken": "มีโหมดที่มีชื่อนี้อยู่แล้ว",
+  "settings.agentBehaviour.importMode": "นำเข้า",
+  "settings.agentBehaviour.importMode.invalidName":
+    "ชื่อโหมดในไฟล์ไม่ถูกต้อง ชื่อต้องขึ้นต้นด้วยตัวอักษรพิมพ์เล็กและประกอบด้วยตัวอักษรพิมพ์เล็ก ตัวเลข และขีดกลางเท่านั้น",
+  "settings.agentBehaviour.importMode.nameTaken": "มีโหมดที่มีชื่อนี้อยู่แล้ว",
+  "settings.agentBehaviour.importMode.invalidJson": "ไฟล์ JSON ไม่ถูกต้อง กรุณาเลือกไฟล์นิยามเอเจนต์ที่ถูกต้อง",
+  "settings.agentBehaviour.exportMode": "ส่งออกนิยามเอเจนต์",
   "settings.agentBehaviour.editMode": "แก้ไขโหมด",
   "settings.agentBehaviour.editMode.description": "คำอธิบาย",
   "settings.agentBehaviour.editMode.prompt": "System Prompt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1064,6 +1064,7 @@ export const dict = {
     "ชื่อโหมดในไฟล์ไม่ถูกต้อง ชื่อต้องขึ้นต้นด้วยตัวอักษรพิมพ์เล็กและประกอบด้วยตัวอักษรพิมพ์เล็ก ตัวเลข และขีดกลางเท่านั้น",
   "settings.agentBehaviour.importMode.nameTaken": "มีโหมดที่มีชื่อนี้อยู่แล้ว",
   "settings.agentBehaviour.importMode.invalidJson": "ไฟล์ JSON ไม่ถูกต้อง กรุณาเลือกไฟล์นิยามเอเจนต์ที่ถูกต้อง",
+  "settings.agentBehaviour.importMode.tooLarge": "ไฟล์มีขนาดใหญ่เกินไป คำจำกัดความเอเจนต์ต้องมีขนาดไม่เกิน 1 MB",
   "settings.agentBehaviour.exportMode": "ส่งออกนิยามเอเจนต์",
   "settings.agentBehaviour.editMode": "แก้ไขโหมด",
   "settings.agentBehaviour.editMode.description": "คำอธิบาย",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1059,6 +1059,13 @@ export const dict = {
     "Keşfedilen beceri yok. Becerileri kullanılabilir kılmak için aşağıya beceri klasör yolları veya URL'ler ekleyin.",
   "settings.agentBehaviour.availableModes": "Mevcut Özel Modlar",
   "settings.agentBehaviour.noModesFound": "Mod bulunamadı.",
+  "settings.agentBehaviour.importMode": "İçe Aktar",
+  "settings.agentBehaviour.importMode.invalidName":
+    "Dosyadaki mod adı geçersiz. Ad küçük harfle başlamalı ve yalnızca küçük harfler, rakamlar ve tire içermelidir.",
+  "settings.agentBehaviour.importMode.nameTaken": "Bu ada sahip bir mod zaten mevcut.",
+  "settings.agentBehaviour.importMode.invalidJson":
+    "Geçersiz JSON dosyası. Lütfen geçerli bir ajan tanım dosyası seçin.",
+  "settings.agentBehaviour.exportMode": "Ajan tanımını dışa aktar",
   "settings.agentBehaviour.removeMode.title": "Modu kaldır",
   "settings.agentBehaviour.removeMode.confirm":
     '"{{name}}" modu kaldırılsın mı? Bu, yapılandırmanızı güncelleyerek modu devre dışı bırakacak.',

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1065,6 +1065,7 @@ export const dict = {
   "settings.agentBehaviour.importMode.nameTaken": "Bu ada sahip bir mod zaten mevcut.",
   "settings.agentBehaviour.importMode.invalidJson":
     "Geçersiz JSON dosyası. Lütfen geçerli bir ajan tanım dosyası seçin.",
+  "settings.agentBehaviour.importMode.tooLarge": "Dosya çok büyük. Ajan tanımları 1 MB'den küçük olmalıdır.",
   "settings.agentBehaviour.exportMode": "Ajan tanımını dışa aktar",
   "settings.agentBehaviour.removeMode.title": "Modu kaldır",
   "settings.agentBehaviour.removeMode.confirm":

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1050,6 +1050,12 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "名称为必填项",
   "settings.agentBehaviour.createMode.nameInvalid": "名称只能包含小写字母、数字和连字符",
   "settings.agentBehaviour.createMode.nameTaken": "此名称的模式已存在",
+  "settings.agentBehaviour.importMode": "导入",
+  "settings.agentBehaviour.importMode.invalidName":
+    "文件中的模式名称无效。名称必须以小写字母开头，且仅包含小写字母、数字和连字符。",
+  "settings.agentBehaviour.importMode.nameTaken": "此名称的模式已存在。",
+  "settings.agentBehaviour.importMode.invalidJson": "无效的 JSON 文件。请选择有效的代理定义文件。",
+  "settings.agentBehaviour.exportMode": "导出代理定义",
   "settings.agentBehaviour.editMode": "编辑模式",
   "settings.agentBehaviour.editMode.description": "描述",
   "settings.agentBehaviour.editMode.prompt": "系统提示",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1055,6 +1055,7 @@ export const dict = {
     "文件中的模式名称无效。名称必须以小写字母开头，且仅包含小写字母、数字和连字符。",
   "settings.agentBehaviour.importMode.nameTaken": "此名称的模式已存在。",
   "settings.agentBehaviour.importMode.invalidJson": "无效的 JSON 文件。请选择有效的代理定义文件。",
+  "settings.agentBehaviour.importMode.tooLarge": "文件太大。代理定义必须小于 1 MB。",
   "settings.agentBehaviour.exportMode": "导出代理定义",
   "settings.agentBehaviour.editMode": "编辑模式",
   "settings.agentBehaviour.editMode.description": "描述",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1052,6 +1052,12 @@ export const dict = {
   "settings.agentBehaviour.createMode.nameRequired": "名稱為必填項",
   "settings.agentBehaviour.createMode.nameInvalid": "名稱只能包含小寫字母、數字和連字號",
   "settings.agentBehaviour.createMode.nameTaken": "此名稱的模式已存在",
+  "settings.agentBehaviour.importMode": "匯入",
+  "settings.agentBehaviour.importMode.invalidName":
+    "檔案中的模式名稱無效。名稱必須以小寫字母開頭，且僅包含小寫字母、數字和連字號。",
+  "settings.agentBehaviour.importMode.nameTaken": "此名稱的模式已存在。",
+  "settings.agentBehaviour.importMode.invalidJson": "無效的 JSON 檔案。請選擇有效的代理定義檔案。",
+  "settings.agentBehaviour.exportMode": "匯出代理定義",
   "settings.agentBehaviour.editMode": "編輯模式",
   "settings.agentBehaviour.editMode.description": "描述",
   "settings.agentBehaviour.editMode.prompt": "系統提示",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1057,6 +1057,7 @@ export const dict = {
     "檔案中的模式名稱無效。名稱必須以小寫字母開頭，且僅包含小寫字母、數字和連字號。",
   "settings.agentBehaviour.importMode.nameTaken": "此名稱的模式已存在。",
   "settings.agentBehaviour.importMode.invalidJson": "無效的 JSON 檔案。請選擇有效的代理定義檔案。",
+  "settings.agentBehaviour.importMode.tooLarge": "檔案太大。代理定義必須小於 1 MB。",
   "settings.agentBehaviour.exportMode": "匯出代理定義",
   "settings.agentBehaviour.editMode": "編輯模式",
   "settings.agentBehaviour.editMode.description": "描述",

--- a/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
@@ -10,6 +10,7 @@ import { SessionContext } from "../context/session"
 import Settings from "../components/settings/Settings"
 import ProvidersTab from "../components/settings/ProvidersTab"
 import AgentBehaviourTab from "../components/settings/AgentBehaviourTab"
+import ModeEditView from "../components/settings/ModeEditView"
 import type { AgentConfig, CommandConfig } from "../types/messages"
 
 const meta: Meta = {
@@ -209,6 +210,38 @@ export const AgentBehaviourWorkflowsEmpty: Story = {
       <StoryProviders sessionID="workflows-empty-story" status="idle">
         <SessionContext.Provider value={session as any}>
           <SubtabWrapper tab="workflows" />
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
+}
+
+export const ModeEditExport: Story = {
+  name: "ModeEditView — export button",
+  render: () => {
+    const cfg: Record<string, AgentConfig> = {
+      reviewer: {
+        description: "Review code for quality and best practices",
+        prompt: "You are a code reviewer. Focus on code quality, best practices, and potential bugs.",
+        model: "anthropic/claude-sonnet-4-20250514",
+        temperature: 0.3,
+      },
+    }
+    const session = {
+      ...mockSessionValue({ id: "export-story", status: "idle" }),
+      agents: () => MOCK_AGENTS,
+      removeMode: noop,
+      removeMcp: noop,
+      skills: () => [],
+      refreshSkills: noop,
+      removeSkill: noop,
+    }
+    return (
+      <StoryProviders sessionID="export-story" status="idle" config={{ agent: cfg } as any}>
+        <SessionContext.Provider value={session as any}>
+          <div style={{ width: "420px", height: "700px", overflow: "auto" }}>
+            <ModeEditView name="reviewer" onBack={noop} onRemove={noop} />
+          </div>
         </SessionContext.Provider>
       </StoryProviders>
     )


### PR DESCRIPTION
## Summary

- Adds an **Export** button (download icon) to the agent edit view header that serializes the agent config to a `.agent.json` file download
- Adds an **Import** button to the agents list that opens a file picker for `.json` files and creates the agent from the file contents
- Import validates: JSON format, name format (lowercase + hyphens), duplicate name check
- Shows inline error messages for invalid imports
- JSON format includes: name, description, prompt, model, mode, temperature, top_p, steps
- i18n strings with proper translations across all 18 locale files

Closes #7592
