### PR TITLE
feat(vscode): add default thinking effort variant per agent in settings

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/settings/agent-behaviour-edit-custom-mode-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/settings/agent-behaviour-edit-custom-mode-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:84a03047098fe237bcd3e278e66c07d9e75c222c306e4e7ac9cf065cb58fb5b5
-size 40689
+oid sha256:b3b499c9fc54dee5561edd5c84b2d4573a50a8dd39f41c9815145f05a56265d8
+size 46006

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
@@ -1,5 +1,6 @@
 import { Component, Show, createMemo } from "solid-js"
 import { TextField } from "@kilocode/kilo-ui/text-field"
+import { Select } from "@kilocode/kilo-ui/select"
 import { Card } from "@kilocode/kilo-ui/card"
 import { Button } from "@kilocode/kilo-ui/button"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
@@ -15,6 +16,14 @@ interface Props {
   onBack: () => void
   onRemove: (agent: AgentInfo) => void
 }
+
+const variantOptions = [
+  { value: "", label: "Default" },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "max", label: "Max" },
+]
 
 const ModeEditView: Component<Props> = (props) => {
   const language = useLanguage()
@@ -122,6 +131,25 @@ const ModeEditView: Component<Props> = (props) => {
             value={cfg().model ?? ""}
             placeholder="e.g. anthropic/claude-sonnet-4-20250514"
             onChange={(val) => update({ model: val || undefined })}
+          />
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.agentBehaviour.variant.title")}
+          description={language.t("settings.agentBehaviour.variant.description")}
+        >
+          <Select
+            options={variantOptions}
+            current={variantOptions.find((o) => o.value === (cfg().variant ?? ""))}
+            value={(o) => o.value}
+            label={(o) => o.label}
+            onSelect={(o) => {
+              if (!o) return
+              update({ variant: o.value || undefined })
+            }}
+            variant="secondary"
+            size="small"
+            triggerVariant="settings"
           />
         </SettingsRow>
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
@@ -17,7 +17,12 @@ interface Props {
   onRemove: (agent: AgentInfo) => void
 }
 
-const variantOptions = [
+interface VariantOption {
+  value: string
+  label: string
+}
+
+const BUILTIN_VARIANTS: VariantOption[] = [
   { value: "", label: "Default" },
   { value: "none", label: "None" },
   { value: "minimal", label: "Minimal" },
@@ -27,6 +32,8 @@ const variantOptions = [
   { value: "xhigh", label: "Extra High" },
   { value: "max", label: "Max" },
 ]
+
+const known = new Set(BUILTIN_VARIANTS.map((o) => o.value))
 
 const ModeEditView: Component<Props> = (props) => {
   const language = useLanguage()
@@ -40,6 +47,13 @@ const ModeEditView: Component<Props> = (props) => {
   const native = () => agent()?.native ?? false
 
   const cfg = createMemo<AgentConfig>(() => config().agent?.[props.name] ?? {})
+
+  // Build variant options dynamically so custom/gateway-defined values show up
+  const variants = createMemo<VariantOption[]>(() => {
+    const current = cfg().variant ?? ""
+    if (!current || known.has(current)) return BUILTIN_VARIANTS
+    return [...BUILTIN_VARIANTS, { value: current, label: current }]
+  })
 
   const update = (partial: Partial<AgentConfig>) => {
     const existing = config().agent ?? {}
@@ -142,8 +156,8 @@ const ModeEditView: Component<Props> = (props) => {
           description={language.t("settings.agentBehaviour.variant.description")}
         >
           <Select
-            options={variantOptions}
-            current={variantOptions.find((o) => o.value === (cfg().variant ?? ""))}
+            options={variants()}
+            current={variants().find((o) => o.value === (cfg().variant ?? ""))}
             value={(o) => o.value}
             label={(o) => o.label}
             onSelect={(o) => {

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
@@ -1,6 +1,5 @@
 import { Component, Show, createMemo } from "solid-js"
 import { TextField } from "@kilocode/kilo-ui/text-field"
-import { Select } from "@kilocode/kilo-ui/select"
 import { Card } from "@kilocode/kilo-ui/card"
 import { Button } from "@kilocode/kilo-ui/button"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
@@ -17,24 +16,6 @@ interface Props {
   onRemove: (agent: AgentInfo) => void
 }
 
-interface VariantOption {
-  value: string
-  label: string
-}
-
-const BUILTIN_VARIANTS: VariantOption[] = [
-  { value: "", label: "Default" },
-  { value: "none", label: "None" },
-  { value: "minimal", label: "Minimal" },
-  { value: "low", label: "Low" },
-  { value: "medium", label: "Medium" },
-  { value: "high", label: "High" },
-  { value: "xhigh", label: "Extra High" },
-  { value: "max", label: "Max" },
-]
-
-const known = new Set(BUILTIN_VARIANTS.map((o) => o.value))
-
 const ModeEditView: Component<Props> = (props) => {
   const language = useLanguage()
   const { config, updateConfig } = useConfig()
@@ -47,13 +28,6 @@ const ModeEditView: Component<Props> = (props) => {
   const native = () => agent()?.native ?? false
 
   const cfg = createMemo<AgentConfig>(() => config().agent?.[props.name] ?? {})
-
-  // Build variant options dynamically so custom/gateway-defined values show up
-  const variants = createMemo<VariantOption[]>(() => {
-    const current = cfg().variant ?? ""
-    if (!current || known.has(current)) return BUILTIN_VARIANTS
-    return [...BUILTIN_VARIANTS, { value: current, label: current }]
-  })
 
   const update = (partial: Partial<AgentConfig>) => {
     const existing = config().agent ?? {}
@@ -155,18 +129,10 @@ const ModeEditView: Component<Props> = (props) => {
           title={language.t("settings.agentBehaviour.variant.title")}
           description={language.t("settings.agentBehaviour.variant.description")}
         >
-          <Select
-            options={variants()}
-            current={variants().find((o) => o.value === (cfg().variant ?? ""))}
-            value={(o) => o.value}
-            label={(o) => o.label}
-            onSelect={(o) => {
-              if (!o) return
-              update({ variant: o.value || undefined })
-            }}
-            variant="secondary"
-            size="small"
-            triggerVariant="settings"
+          <TextField
+            value={cfg().variant ?? ""}
+            placeholder={language.t("settings.agentBehaviour.variant.placeholder")}
+            onChange={(val) => update({ variant: val.trim() || undefined })}
           />
         </SettingsRow>
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
@@ -19,9 +19,12 @@ interface Props {
 
 const variantOptions = [
   { value: "", label: "Default" },
+  { value: "none", label: "None" },
+  { value: "minimal", label: "Minimal" },
   { value: "low", label: "Low" },
   { value: "medium", label: "Medium" },
   { value: "high", label: "High" },
+  { value: "xhigh", label: "Extra High" },
   { value: "max", label: "Max" },
 ]
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1032,6 +1032,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "حرارة أخذ العينات (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "معامل أخذ العينات النووي (0-1)",
+  "settings.agentBehaviour.variant.title": "مستوى التفكير الافتراضي",
+  "settings.agentBehaviour.variant.description": "مستوى جهد التفكير/الاستدلال الافتراضي لهذا الوكيل",
   "settings.agentBehaviour.maxSteps.title": "الحد الأقصى للخطوات",
   "settings.agentBehaviour.maxSteps.description": "الحد الأقصى لتكرارات الوكيل",
   "settings.agentBehaviour.discoveredSkills": "المهارات المكتشفة",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1034,6 +1034,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "معامل أخذ العينات النووي (0-1)",
   "settings.agentBehaviour.variant.title": "مستوى التفكير الافتراضي",
   "settings.agentBehaviour.variant.description": "مستوى جهد التفكير/الاستدلال الافتراضي لهذا الوكيل",
+  "settings.agentBehaviour.variant.placeholder": "مثال: low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "الحد الأقصى للخطوات",
   "settings.agentBehaviour.maxSteps.description": "الحد الأقصى لتكرارات الوكيل",
   "settings.agentBehaviour.discoveredSkills": "المهارات المكتشفة",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1045,6 +1045,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "Temperatura de amostragem (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "Parâmetro de amostragem nucleus (0-1)",
+  "settings.agentBehaviour.variant.title": "Esforço de Pensamento Padrão",
+  "settings.agentBehaviour.variant.description": "Nível padrão de esforço de pensamento/raciocínio para este agente",
   "settings.agentBehaviour.maxSteps.title": "Passos máximos",
   "settings.agentBehaviour.maxSteps.description": "Iterações máximas do agente",
   "settings.agentBehaviour.discoveredSkills": "Habilidades descobertas",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1047,6 +1047,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Parâmetro de amostragem nucleus (0-1)",
   "settings.agentBehaviour.variant.title": "Esforço de Pensamento Padrão",
   "settings.agentBehaviour.variant.description": "Nível padrão de esforço de pensamento/raciocínio para este agente",
+  "settings.agentBehaviour.variant.placeholder": "ex.: low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "Passos máximos",
   "settings.agentBehaviour.maxSteps.description": "Iterações máximas do agente",
   "settings.agentBehaviour.discoveredSkills": "Habilidades descobertas",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1045,6 +1045,9 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "Temperatura uzorkovanja (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "Nucleus parametar uzorkovanja (0-1)",
+  "settings.agentBehaviour.variant.title": "Podrazumijevani nivo razmišljanja",
+  "settings.agentBehaviour.variant.description":
+    "Podrazumijevani nivo napora razmišljanja/zaključivanja za ovog agenta",
   "settings.agentBehaviour.maxSteps.title": "Maks. koraci",
   "settings.agentBehaviour.maxSteps.description": "Maksimalne iteracije agenta",
   "settings.agentBehaviour.discoveredSkills": "Otkrivene vještine",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1048,6 +1048,7 @@ export const dict = {
   "settings.agentBehaviour.variant.title": "Podrazumijevani nivo razmišljanja",
   "settings.agentBehaviour.variant.description":
     "Podrazumijevani nivo napora razmišljanja/zaključivanja za ovog agenta",
+  "settings.agentBehaviour.variant.placeholder": "npr. low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "Maks. koraci",
   "settings.agentBehaviour.maxSteps.description": "Maksimalne iteracije agenta",
   "settings.agentBehaviour.discoveredSkills": "Otkrivene vještine",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1040,6 +1040,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "Samplingtemperatur (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "Nucleus-samplingparameter (0-1)",
+  "settings.agentBehaviour.variant.title": "Standard tænkeindsats",
+  "settings.agentBehaviour.variant.description": "Standard tænke-/ræsonneringsindsatsniveau for denne agent",
   "settings.agentBehaviour.maxSteps.title": "Maks. trin",
   "settings.agentBehaviour.maxSteps.description": "Maksimale agentiterationer",
   "settings.agentBehaviour.discoveredSkills": "Opdagede skills",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1042,6 +1042,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Nucleus-samplingparameter (0-1)",
   "settings.agentBehaviour.variant.title": "Standard tænkeindsats",
   "settings.agentBehaviour.variant.description": "Standard tænke-/ræsonneringsindsatsniveau for denne agent",
+  "settings.agentBehaviour.variant.placeholder": "f.eks. low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "Maks. trin",
   "settings.agentBehaviour.maxSteps.description": "Maksimale agentiterationer",
   "settings.agentBehaviour.discoveredSkills": "Opdagede skills",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1058,6 +1058,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "Sampling-Temperatur (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "Nucleus-Sampling-Parameter (0-1)",
+  "settings.agentBehaviour.variant.title": "Standard-Denkaufwand",
+  "settings.agentBehaviour.variant.description": "Standard-Denk-/Schlussfolgerungsaufwand für diesen Agenten",
   "settings.agentBehaviour.maxSteps.title": "Max. Schritte",
   "settings.agentBehaviour.maxSteps.description": "Maximale Agent-Iterationen",
   "settings.agentBehaviour.discoveredSkills": "Erkannte Skills",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1060,6 +1060,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Nucleus-Sampling-Parameter (0-1)",
   "settings.agentBehaviour.variant.title": "Standard-Denkaufwand",
   "settings.agentBehaviour.variant.description": "Standard-Denk-/Schlussfolgerungsaufwand für diesen Agenten",
+  "settings.agentBehaviour.variant.placeholder": "z.B. low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "Max. Schritte",
   "settings.agentBehaviour.maxSteps.description": "Maximale Agent-Iterationen",
   "settings.agentBehaviour.discoveredSkills": "Erkannte Skills",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1046,6 +1046,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "Sampling temperature (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "Nucleus sampling parameter (0-1)",
+  "settings.agentBehaviour.variant.title": "Default Thinking Effort",
+  "settings.agentBehaviour.variant.description": "Default thinking/reasoning effort level for this agent",
   "settings.agentBehaviour.maxSteps.title": "Max Steps",
   "settings.agentBehaviour.maxSteps.description": "Maximum agentic iterations",
   "settings.agentBehaviour.discoveredSkills": "Discovered Skills",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1048,6 +1048,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Nucleus sampling parameter (0-1)",
   "settings.agentBehaviour.variant.title": "Default Thinking Effort",
   "settings.agentBehaviour.variant.description": "Default thinking/reasoning effort level for this agent",
+  "settings.agentBehaviour.variant.placeholder": "e.g. low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "Max Steps",
   "settings.agentBehaviour.maxSteps.description": "Maximum agentic iterations",
   "settings.agentBehaviour.discoveredSkills": "Discovered Skills",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1048,6 +1048,9 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "Temperatura de muestreo (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "Parámetro de muestreo nucleus (0-1)",
+  "settings.agentBehaviour.variant.title": "Esfuerzo de pensamiento predeterminado",
+  "settings.agentBehaviour.variant.description":
+    "Nivel predeterminado de esfuerzo de pensamiento/razonamiento para este agente",
   "settings.agentBehaviour.maxSteps.title": "Pasos máximos",
   "settings.agentBehaviour.maxSteps.description": "Iteraciones máximas del agente",
   "settings.agentBehaviour.discoveredSkills": "Habilidades descubiertas",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1051,6 +1051,7 @@ export const dict = {
   "settings.agentBehaviour.variant.title": "Esfuerzo de pensamiento predeterminado",
   "settings.agentBehaviour.variant.description":
     "Nivel predeterminado de esfuerzo de pensamiento/razonamiento para este agente",
+  "settings.agentBehaviour.variant.placeholder": "p. ej. low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "Pasos máximos",
   "settings.agentBehaviour.maxSteps.description": "Iteraciones máximas del agente",
   "settings.agentBehaviour.discoveredSkills": "Habilidades descubiertas",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1060,6 +1060,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "Température d'échantillonnage (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "Paramètre d'échantillonnage nucleus (0-1)",
+  "settings.agentBehaviour.variant.title": "Effort de réflexion par défaut",
+  "settings.agentBehaviour.variant.description": "Niveau d'effort de réflexion/raisonnement par défaut pour cet agent",
   "settings.agentBehaviour.maxSteps.title": "Étapes max.",
   "settings.agentBehaviour.maxSteps.description": "Itérations maximales de l'agent",
   "settings.agentBehaviour.discoveredSkills": "Compétences découvertes",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1062,6 +1062,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Paramètre d'échantillonnage nucleus (0-1)",
   "settings.agentBehaviour.variant.title": "Effort de réflexion par défaut",
   "settings.agentBehaviour.variant.description": "Niveau d'effort de réflexion/raisonnement par défaut pour cet agent",
+  "settings.agentBehaviour.variant.placeholder": "p. ex. low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "Étapes max.",
   "settings.agentBehaviour.maxSteps.description": "Itérations maximales de l'agent",
   "settings.agentBehaviour.discoveredSkills": "Compétences découvertes",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1040,6 +1040,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "サンプリング温度（0-2）",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "核サンプリングパラメータ（0-1）",
+  "settings.agentBehaviour.variant.title": "デフォルト思考エフォート",
+  "settings.agentBehaviour.variant.description": "このエージェントのデフォルトの思考・推論エフォートレベル",
   "settings.agentBehaviour.maxSteps.title": "最大ステップ数",
   "settings.agentBehaviour.maxSteps.description": "最大エージェント反復回数",
   "settings.agentBehaviour.discoveredSkills": "検出されたスキル",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1042,6 +1042,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "核サンプリングパラメータ（0-1）",
   "settings.agentBehaviour.variant.title": "デフォルト思考エフォート",
   "settings.agentBehaviour.variant.description": "このエージェントのデフォルトの思考・推論エフォートレベル",
+  "settings.agentBehaviour.variant.placeholder": "例: low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "最大ステップ数",
   "settings.agentBehaviour.maxSteps.description": "最大エージェント反復回数",
   "settings.agentBehaviour.discoveredSkills": "検出されたスキル",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1037,6 +1037,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "샘플링 온도 (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "핵 샘플링 매개변수 (0-1)",
+  "settings.agentBehaviour.variant.title": "기본 사고 노력",
+  "settings.agentBehaviour.variant.description": "이 에이전트의 기본 사고/추론 노력 수준",
   "settings.agentBehaviour.maxSteps.title": "최대 단계",
   "settings.agentBehaviour.maxSteps.description": "최대 에이전트 반복 횟수",
   "settings.agentBehaviour.discoveredSkills": "검색된 스킬",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1039,6 +1039,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "핵 샘플링 매개변수 (0-1)",
   "settings.agentBehaviour.variant.title": "기본 사고 노력",
   "settings.agentBehaviour.variant.description": "이 에이전트의 기본 사고/추론 노력 수준",
+  "settings.agentBehaviour.variant.placeholder": "예: low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "최대 단계",
   "settings.agentBehaviour.maxSteps.description": "최대 에이전트 반복 횟수",
   "settings.agentBehaviour.discoveredSkills": "검색된 스킬",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1050,6 +1050,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "Sampling temperatuur (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "Nucleus sampling parameter (0-1)",
+  "settings.agentBehaviour.variant.title": "Standaard denkinspanning",
+  "settings.agentBehaviour.variant.description": "Standaard denk-/redeneringsinspanningsniveau voor deze agent",
   "settings.agentBehaviour.maxSteps.title": "Max Stappen",
   "settings.agentBehaviour.maxSteps.description": "Maximale agent iteraties",
   "settings.agentBehaviour.discoveredSkills": "Ontdekte Skills",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1052,6 +1052,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Nucleus sampling parameter (0-1)",
   "settings.agentBehaviour.variant.title": "Standaard denkinspanning",
   "settings.agentBehaviour.variant.description": "Standaard denk-/redeneringsinspanningsniveau voor deze agent",
+  "settings.agentBehaviour.variant.placeholder": "bijv. low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "Max Stappen",
   "settings.agentBehaviour.maxSteps.description": "Maximale agent iteraties",
   "settings.agentBehaviour.discoveredSkills": "Ontdekte Skills",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1043,6 +1043,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "Samplingstemperatur (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "Nucleus-samplingsparameter (0-1)",
+  "settings.agentBehaviour.variant.title": "Standard tankeinnsats",
+  "settings.agentBehaviour.variant.description": "Standard tanke-/resonneringsinnsatsnivå for denne agenten",
   "settings.agentBehaviour.maxSteps.title": "Maks. trinn",
   "settings.agentBehaviour.maxSteps.description": "Maksimale agentiterasjoner",
   "settings.agentBehaviour.discoveredSkills": "Oppdagede ferdigheter",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1045,6 +1045,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Nucleus-samplingsparameter (0-1)",
   "settings.agentBehaviour.variant.title": "Standard tankeinnsats",
   "settings.agentBehaviour.variant.description": "Standard tanke-/resonneringsinnsatsnivå for denne agenten",
+  "settings.agentBehaviour.variant.placeholder": "f.eks. low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "Maks. trinn",
   "settings.agentBehaviour.maxSteps.description": "Maksimale agentiterasjoner",
   "settings.agentBehaviour.discoveredSkills": "Oppdagede ferdigheter",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1043,6 +1043,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "Temperatura próbkowania (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "Parametr próbkowania nucleus (0-1)",
+  "settings.agentBehaviour.variant.title": "Domyślny poziom myślenia",
+  "settings.agentBehaviour.variant.description": "Domyślny poziom wysiłku myślenia/rozumowania dla tego agenta",
   "settings.agentBehaviour.maxSteps.title": "Maks. kroki",
   "settings.agentBehaviour.maxSteps.description": "Maksymalna liczba iteracji agenta",
   "settings.agentBehaviour.discoveredSkills": "Wykryte umiejętności",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1045,6 +1045,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Parametr próbkowania nucleus (0-1)",
   "settings.agentBehaviour.variant.title": "Domyślny poziom myślenia",
   "settings.agentBehaviour.variant.description": "Domyślny poziom wysiłku myślenia/rozumowania dla tego agenta",
+  "settings.agentBehaviour.variant.placeholder": "np. low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "Maks. kroki",
   "settings.agentBehaviour.maxSteps.description": "Maksymalna liczba iteracji agenta",
   "settings.agentBehaviour.discoveredSkills": "Wykryte umiejętności",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1046,6 +1046,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "Температура сэмплирования (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "Параметр nucleus-сэмплирования (0-1)",
+  "settings.agentBehaviour.variant.title": "Уровень мышления по умолчанию",
+  "settings.agentBehaviour.variant.description": "Уровень усилий мышления/рассуждения по умолчанию для этого агента",
   "settings.agentBehaviour.maxSteps.title": "Макс. шагов",
   "settings.agentBehaviour.maxSteps.description": "Максимальное число итераций агента",
   "settings.agentBehaviour.discoveredSkills": "Обнаруженные навыки",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1048,6 +1048,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Параметр nucleus-сэмплирования (0-1)",
   "settings.agentBehaviour.variant.title": "Уровень мышления по умолчанию",
   "settings.agentBehaviour.variant.description": "Уровень усилий мышления/рассуждения по умолчанию для этого агента",
+  "settings.agentBehaviour.variant.placeholder": "напр. low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "Макс. шагов",
   "settings.agentBehaviour.maxSteps.description": "Максимальное число итераций агента",
   "settings.agentBehaviour.discoveredSkills": "Обнаруженные навыки",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1033,6 +1033,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "อุณหภูมิการสุ่มตัวอย่าง (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "พารามิเตอร์ nucleus sampling (0-1)",
+  "settings.agentBehaviour.variant.title": "ระดับความพยายามในการคิดเริ่มต้น",
+  "settings.agentBehaviour.variant.description": "ระดับความพยายามในการคิด/ใช้เหตุผลเริ่มต้นสำหรับเอเจนต์นี้",
   "settings.agentBehaviour.maxSteps.title": "ขั้นตอนสูงสุด",
   "settings.agentBehaviour.maxSteps.description": "จำนวนรอบเอเจนต์สูงสุด",
   "settings.agentBehaviour.discoveredSkills": "ทักษะที่ค้นพบ",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1035,6 +1035,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "พารามิเตอร์ nucleus sampling (0-1)",
   "settings.agentBehaviour.variant.title": "ระดับความพยายามในการคิดเริ่มต้น",
   "settings.agentBehaviour.variant.description": "ระดับความพยายามในการคิด/ใช้เหตุผลเริ่มต้นสำหรับเอเจนต์นี้",
+  "settings.agentBehaviour.variant.placeholder": "เช่น low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "ขั้นตอนสูงสุด",
   "settings.agentBehaviour.maxSteps.description": "จำนวนรอบเอเจนต์สูงสุด",
   "settings.agentBehaviour.discoveredSkills": "ทักษะที่ค้นพบ",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1049,6 +1049,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "Örnekleme sıcaklığı (0-2)",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "Çekirdek örnekleme parametresi (0-1)",
+  "settings.agentBehaviour.variant.title": "Varsayılan Düşünme Çabası",
+  "settings.agentBehaviour.variant.description": "Bu ajan için varsayılan düşünme/akıl yürütme çaba düzeyi",
   "settings.agentBehaviour.maxSteps.title": "Maksimum Adım",
   "settings.agentBehaviour.maxSteps.description": "Maksimum ajanlık yinelemesi",
   "settings.agentBehaviour.discoveredSkills": "Keşfedilen Beceriler",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1051,6 +1051,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "Çekirdek örnekleme parametresi (0-1)",
   "settings.agentBehaviour.variant.title": "Varsayılan Düşünme Çabası",
   "settings.agentBehaviour.variant.description": "Bu ajan için varsayılan düşünme/akıl yürütme çaba düzeyi",
+  "settings.agentBehaviour.variant.placeholder": "örn. low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "Maksimum Adım",
   "settings.agentBehaviour.maxSteps.description": "Maksimum ajanlık yinelemesi",
   "settings.agentBehaviour.discoveredSkills": "Keşfedilen Beceriler",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1026,6 +1026,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "采样温度（0-2）",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "核采样参数（0-1）",
+  "settings.agentBehaviour.variant.title": "默认思考力度",
+  "settings.agentBehaviour.variant.description": "此代理的默认思考/推理力度级别",
   "settings.agentBehaviour.maxSteps.title": "最大步数",
   "settings.agentBehaviour.maxSteps.description": "最大智能体迭代次数",
   "settings.agentBehaviour.discoveredSkills": "已发现的技能",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1028,6 +1028,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "核采样参数（0-1）",
   "settings.agentBehaviour.variant.title": "默认思考力度",
   "settings.agentBehaviour.variant.description": "此代理的默认思考/推理力度级别",
+  "settings.agentBehaviour.variant.placeholder": "例如 low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "最大步数",
   "settings.agentBehaviour.maxSteps.description": "最大智能体迭代次数",
   "settings.agentBehaviour.discoveredSkills": "已发现的技能",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1027,6 +1027,8 @@ export const dict = {
   "settings.agentBehaviour.temperature.description": "取樣溫度（0-2）",
   "settings.agentBehaviour.topP.title": "Top P",
   "settings.agentBehaviour.topP.description": "核取樣參數（0-1）",
+  "settings.agentBehaviour.variant.title": "預設思考力度",
+  "settings.agentBehaviour.variant.description": "此代理的預設思考/推理力度級別",
   "settings.agentBehaviour.maxSteps.title": "最大步數",
   "settings.agentBehaviour.maxSteps.description": "最大 Agent 迭代次數",
   "settings.agentBehaviour.discoveredSkills": "已發現的 Skill",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1029,6 +1029,7 @@ export const dict = {
   "settings.agentBehaviour.topP.description": "核取樣參數（0-1）",
   "settings.agentBehaviour.variant.title": "預設思考力度",
   "settings.agentBehaviour.variant.description": "此代理的預設思考/推理力度級別",
+  "settings.agentBehaviour.variant.placeholder": "例如 low, medium, high, max",
   "settings.agentBehaviour.maxSteps.title": "最大步數",
   "settings.agentBehaviour.maxSteps.description": "最大 Agent 迭代次數",
   "settings.agentBehaviour.discoveredSkills": "已發現的 Skill",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -323,6 +323,7 @@ export interface AgentConfig {
   model?: string | null
   prompt?: string
   description?: string
+  variant?: string
   mode?: "subagent" | "primary" | "all"
   temperature?: number
   top_p?: number


### PR DESCRIPTION
## Summary

- Adds a "Default Thinking Effort" selector to the per-agent config overrides in the agent edit view (`ModeEditView.tsx`)
- Options: Default, Low, Medium, High, Max — writes to `config.agent[name].variant`
- Adds `variant` field to the webview `AgentConfig` type in `messages.ts`
- i18n strings with proper translations across all 18 locale files

Closes #7593
