### PR TITLE
fix(agent-manager): add missing NotificationsProvider to agent manager provider chain

### DIFF
--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -605,3 +605,66 @@ describe("Agent Manager — VS Code import boundary", () => {
     ).toEqual([])
   })
 })
+
+// ---------------------------------------------------------------------------
+// Provider chain parity — sidebar App.tsx vs AgentManagerApp.tsx
+//
+// The agent manager reuses ChatView (and therefore MessageList, etc.) from the
+// sidebar. Any context provider that ChatView's tree may call useXxx() on must
+// also be present in the agent manager's provider chain. A missing provider
+// crashes the entire SolidJS component tree silently.
+//
+// Regression: PR #7473 moved KiloNotifications into MessageList. It calls
+// useNotifications(), but NotificationsProvider was only in App.tsx — the agent
+// manager rendered a blank screen.
+// ---------------------------------------------------------------------------
+
+const APP_FILE = path.join(ROOT, "webview-ui/src/App.tsx")
+const AGENT_MANAGER_APP_FILE = path.join(ROOT, "webview-ui/agent-manager/AgentManagerApp.tsx")
+
+describe("Agent Manager — provider chain parity with sidebar", () => {
+  /**
+   * Extract provider component names used as JSX elements in a file.
+   * Matches `<FooProvider` and `<FooProvider>` patterns, returning the names.
+   */
+  function extractProviders(content: string): string[] {
+    const matches = [...content.matchAll(/<(\w+Provider)\b/g)]
+    return [...new Set(matches.map((m) => m[1]!))]
+  }
+
+  /**
+   * Providers that the agent manager intentionally omits because it does not
+   * use the components that depend on them. If a shared component (ChatView,
+   * MessageList, etc.) starts using one of these, the test will fail and
+   * force the developer to add the provider to AgentManagerApp.tsx.
+   */
+  const KNOWN_EXCLUSIONS: string[] = [
+    // These are wrapped by LanguageBridge and DataBridge respectively,
+    // which the agent manager already includes in its provider chain.
+    "LanguageProvider",
+    "DataProvider",
+  ]
+
+  it("agent manager includes all context providers from sidebar App.tsx", () => {
+    const sidebar = fs.readFileSync(APP_FILE, "utf-8")
+    const agent = fs.readFileSync(AGENT_MANAGER_APP_FILE, "utf-8")
+
+    const sidebarProviders = extractProviders(sidebar)
+    const agentProviders = extractProviders(agent)
+    const agentSet = new Set(agentProviders)
+    const excluded = new Set(KNOWN_EXCLUSIONS)
+
+    const missing = sidebarProviders.filter((p) => !agentSet.has(p) && !excluded.has(p))
+
+    expect(
+      missing,
+      `These providers are in App.tsx but missing from AgentManagerApp.tsx.\n` +
+        `The agent manager reuses ChatView — any provider that ChatView's component\n` +
+        `tree depends on must be present in both provider chains.\n\n` +
+        `Missing providers:\n` +
+        missing.map((p) => `  - ${p}`).join("\n") +
+        `\n\nFix: add the missing <${missing[0]}> to AgentManagerApp.tsx's provider chain,\n` +
+        `or add it to KNOWN_EXCLUSIONS with a justification if it's truly unused.`,
+    ).toEqual([])
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -72,6 +72,7 @@ import { VSCodeProvider, useVSCode } from "../src/context/vscode"
 import { ServerProvider } from "../src/context/server"
 import { ProviderProvider } from "../src/context/provider"
 import { ConfigProvider } from "../src/context/config"
+import { NotificationsProvider } from "../src/context/notifications"
 import { SessionProvider, useSession } from "../src/context/session"
 import { WorktreeModeProvider } from "../src/context/worktree-mode"
 import { ChatView } from "../src/components/chat"
@@ -2838,13 +2839,15 @@ export const AgentManagerApp: Component = () => {
                     <FileComponentProvider component={File}>
                       <ProviderProvider>
                         <ConfigProvider>
-                          <SessionProvider>
-                            <WorktreeModeProvider>
-                              <DataBridge>
-                                <AgentManagerContent />
-                              </DataBridge>
-                            </WorktreeModeProvider>
-                          </SessionProvider>
+                          <NotificationsProvider>
+                            <SessionProvider>
+                              <WorktreeModeProvider>
+                                <DataBridge>
+                                  <AgentManagerContent />
+                                </DataBridge>
+                              </WorktreeModeProvider>
+                            </SessionProvider>
+                          </NotificationsProvider>
                         </ConfigProvider>
                       </ProviderProvider>
                     </FileComponentProvider>


### PR DESCRIPTION
## Summary

- Adds `NotificationsProvider` to the agent manager's provider chain, fixing a blank screen regression caused by PR #7473
- Adds a regression test that statically verifies provider chain parity between `App.tsx` and `AgentManagerApp.tsx`

## Root Cause

PR #7473 moved `<KiloNotifications />` from `App.tsx` into `MessageList.tsx`. The agent manager reuses `ChatView` → `MessageList`, so `KiloNotifications` now renders inside the agent manager. It calls `useNotifications()`, but `NotificationsProvider` was only in the sidebar's `App.tsx` — not in `AgentManagerApp.tsx`. The missing context crashes the entire SolidJS component tree, rendering the agent manager blank (no sessions or worktrees load).

## Test

The new test in `agent-manager-arch.test.ts` extracts all `*Provider` JSX elements from both `App.tsx` and `AgentManagerApp.tsx` and asserts the agent manager includes every provider the sidebar uses. If someone adds a new provider to the sidebar that `ChatView`'s tree depends on but forgets the agent manager, the test fails with a clear message telling them which provider to add.