### PR TITLE
feat(vscode): add open locally action for unassigned sessions

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -192,6 +192,11 @@ export class AgentManagerProvider implements Disposable {
     if (m.type === "agentManager.deleteWorktree") return this.onDeleteWorktree(m.worktreeId)
     if (m.type === "agentManager.removeStaleWorktree") return this.onRemoveStaleWorktree(m.worktreeId)
     if (m.type === "agentManager.promoteSession") return this.onPromoteSession(m.sessionId)
+    if (m.type === "agentManager.openLocally") {
+      if (!this.panel) return null
+      this.panel.sessions.clearSessionDirectory(m.sessionId)
+      return null
+    }
     if (m.type === "agentManager.addSessionToWorktree") return this.onAddSessionToWorktree(m.worktreeId)
     if (m.type === "agentManager.forkSession") return this.onForkSession(m.sessionId, m.worktreeId)
     if (m.type === "agentManager.closeSession") return this.onCloseSession(m.sessionId)

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -229,6 +229,11 @@ interface PromoteSessionIn {
   sessionId: string
 }
 
+interface OpenLocallyIn {
+  type: "agentManager.openLocally"
+  sessionId: string
+}
+
 interface AddSessionToWorktreeIn {
   type: "agentManager.addSessionToWorktree"
   worktreeId: string
@@ -417,6 +422,7 @@ export type AgentManagerInMessage =
   | DeleteWorktreeIn
   | RemoveStaleWorktreeIn
   | PromoteSessionIn
+  | OpenLocallyIn
   | AddSessionToWorktreeIn
   | CloseSessionIn
   | ForkSessionIn

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1790,6 +1790,21 @@ const AgentManagerContent: Component = () => {
     vscode.postMessage({ type: "agentManager.promoteSession", sessionId })
   }
 
+  const openLocally = (sid: string) => {
+    saveTabMemory()
+    const pending = activePendingId()
+    if (pending) {
+      setLocalSessionIDs((prev) => prev.map((id) => (id === pending ? sid : id)))
+      setActivePendingId(undefined)
+    } else {
+      setLocalSessionIDs((prev) => [...prev, sid])
+    }
+    setSelection(LOCAL)
+    setReviewActive(false)
+    session.selectSession(sid)
+    vscode.postMessage({ type: "agentManager.openLocally", sessionId: sid })
+  }
+
   const handleAddSession = () => {
     const sel = selection()
     if (sel === LOCAL) {
@@ -2434,22 +2449,7 @@ const AgentManagerContent: Component = () => {
                             <Icon name="branch" size="small" />
                             <ContextMenu.ItemLabel>{t("agentManager.session.openInWorktree")}</ContextMenu.ItemLabel>
                           </ContextMenu.Item>
-                          <ContextMenu.Item
-                            onSelect={() => {
-                              saveTabMemory()
-                              const pending = activePendingId()
-                              if (pending) {
-                                setLocalSessionIDs((prev) => prev.map((id) => (id === pending ? s.id : id)))
-                                setActivePendingId(undefined)
-                              } else {
-                                setLocalSessionIDs((prev) => [...prev, s.id])
-                              }
-                              setSelection(LOCAL)
-                              setReviewActive(false)
-                              session.selectSession(s.id)
-                              vscode.postMessage({ type: "agentManager.openLocally", sessionId: s.id })
-                            }}
-                          >
+                          <ContextMenu.Item onSelect={() => openLocally(s.id)}>
                             <Icon name="folder" size="small" />
                             <ContextMenu.ItemLabel>{t("agentManager.session.openLocally")}</ContextMenu.ItemLabel>
                           </ContextMenu.Item>
@@ -2750,22 +2750,12 @@ const AgentManagerContent: Component = () => {
             <div class="am-chat-wrapper">
               <ChatView
                 onSelectSession={(id) => {
-                  const already = localSessionIDs().includes(id)
-                  if (already) {
+                  if (localSessionIDs().includes(id)) {
                     session.selectSession(id)
                     if (selection() === null) setSelection(LOCAL)
                     return
                   }
-                  const pending = activePendingId()
-                  if (pending) {
-                    setLocalSessionIDs((prev) => prev.map((sid) => (sid === pending ? id : sid)))
-                    setActivePendingId(undefined)
-                  } else {
-                    setLocalSessionIDs((prev) => [...prev, id])
-                  }
-                  setSelection(LOCAL)
-                  setReviewActive(false)
-                  session.selectSession(id)
+                  openLocally(id)
                 }}
                 readonly={readOnly()}
               />
@@ -2780,15 +2770,7 @@ const AgentManagerContent: Component = () => {
                       if (!loaded()) return
                       const sid = session.currentSessionID()
                       if (!sid) return
-                      const pending = activePendingId()
-                      if (pending) {
-                        setLocalSessionIDs((prev) => prev.map((id) => (id === pending ? sid : id)))
-                        setActivePendingId(undefined)
-                      } else {
-                        setLocalSessionIDs((prev) => [...prev, sid])
-                      }
-                      setSelection(LOCAL)
-                      vscode.postMessage({ type: "agentManager.openLocally", sessionId: sid })
+                      openLocally(sid)
                     }}
                   >
                     {t("agentManager.session.openLocally")}

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2766,7 +2766,6 @@ const AgentManagerContent: Component = () => {
                   setSelection(LOCAL)
                   setReviewActive(false)
                   session.selectSession(id)
-                  vscode.postMessage({ type: "agentManager.openLocally", sessionId: id })
                 }}
                 readonly={readOnly()}
               />

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2434,6 +2434,25 @@ const AgentManagerContent: Component = () => {
                             <Icon name="branch" size="small" />
                             <ContextMenu.ItemLabel>{t("agentManager.session.openInWorktree")}</ContextMenu.ItemLabel>
                           </ContextMenu.Item>
+                          <ContextMenu.Item
+                            onSelect={() => {
+                              saveTabMemory()
+                              const pending = activePendingId()
+                              if (pending) {
+                                setLocalSessionIDs((prev) => prev.map((id) => (id === pending ? s.id : id)))
+                                setActivePendingId(undefined)
+                              } else {
+                                setLocalSessionIDs((prev) => [...prev, s.id])
+                              }
+                              setSelection(LOCAL)
+                              setReviewActive(false)
+                              session.selectSession(s.id)
+                              vscode.postMessage({ type: "agentManager.openLocally", sessionId: s.id })
+                            }}
+                          >
+                            <Icon name="folder" size="small" />
+                            <ContextMenu.ItemLabel>{t("agentManager.session.openLocally")}</ContextMenu.ItemLabel>
+                          </ContextMenu.Item>
                         </ContextMenu.Content>
                       </ContextMenu.Portal>
                     </ContextMenu>
@@ -2731,8 +2750,23 @@ const AgentManagerContent: Component = () => {
             <div class="am-chat-wrapper">
               <ChatView
                 onSelectSession={(id) => {
-                  // If on local and selecting a different session, keep local context
+                  const already = localSessionIDs().includes(id)
+                  if (already) {
+                    session.selectSession(id)
+                    if (selection() === null) setSelection(LOCAL)
+                    return
+                  }
+                  const pending = activePendingId()
+                  if (pending) {
+                    setLocalSessionIDs((prev) => prev.map((sid) => (sid === pending ? id : sid)))
+                    setActivePendingId(undefined)
+                  } else {
+                    setLocalSessionIDs((prev) => [...prev, id])
+                  }
+                  setSelection(LOCAL)
+                  setReviewActive(false)
                   session.selectSession(id)
+                  vscode.postMessage({ type: "agentManager.openLocally", sessionId: id })
                 }}
                 readonly={readOnly()}
               />
@@ -2740,6 +2774,26 @@ const AgentManagerContent: Component = () => {
                 <div class="am-readonly-banner">
                   <Icon name="branch" size="small" />
                   <span class="am-readonly-text">{t("agentManager.session.readonly")}</span>
+                  <Button
+                    variant="secondary"
+                    size="small"
+                    onClick={() => {
+                      if (!loaded()) return
+                      const sid = session.currentSessionID()
+                      if (!sid) return
+                      const pending = activePendingId()
+                      if (pending) {
+                        setLocalSessionIDs((prev) => prev.map((id) => (id === pending ? sid : id)))
+                        setActivePendingId(undefined)
+                      } else {
+                        setLocalSessionIDs((prev) => [...prev, sid])
+                      }
+                      setSelection(LOCAL)
+                      vscode.postMessage({ type: "agentManager.openLocally", sessionId: sid })
+                    }}
+                  >
+                    {t("agentManager.session.openLocally")}
+                  </Button>
                   <Button
                     variant="primary"
                     size="small"

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "بدون عنوان",
   "agentManager.session.newSession": "جلسة جديدة",
   "agentManager.session.openInWorktree": "فتح في Worktree",
+  "agentManager.session.openLocally": "فتح محليًا",
   "agentManager.session.readonly": "جلسة للقراءة فقط",
   "agentManager.session.noSessions": "لا توجد جلسات مفتوحة",
   "agentManager.tab.close": "إغلاق",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "Sem título",
   "agentManager.session.newSession": "Nova Sessão",
   "agentManager.session.openInWorktree": "Abrir no Worktree",
+  "agentManager.session.openLocally": "Abrir localmente",
   "agentManager.session.readonly": "Sessão somente leitura",
   "agentManager.session.noSessions": "Nenhuma sessão aberta",
   "agentManager.tab.close": "Fechar",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "Bez naslova",
   "agentManager.session.newSession": "Nova sesija",
   "agentManager.session.openInWorktree": "Otvori u Worktree-u",
+  "agentManager.session.openLocally": "Otvori lokalno",
   "agentManager.session.readonly": "Sesija samo za čitanje",
   "agentManager.session.noSessions": "Nema otvorenih sesija",
   "agentManager.tab.close": "Zatvori",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "Uden titel",
   "agentManager.session.newSession": "Ny session",
   "agentManager.session.openInWorktree": "Åbn i Worktree",
+  "agentManager.session.openLocally": "Åbn lokalt",
   "agentManager.session.readonly": "Skrivebeskyttet session",
   "agentManager.session.noSessions": "Ingen åbne sessioner",
   "agentManager.tab.close": "Luk",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "Unbenannt",
   "agentManager.session.newSession": "Neue Sitzung",
   "agentManager.session.openInWorktree": "In Worktree öffnen",
+  "agentManager.session.openLocally": "Lokal öffnen",
   "agentManager.session.readonly": "Schreibgeschützte Sitzung",
   "agentManager.session.noSessions": "Keine Sitzungen geöffnet",
   "agentManager.tab.close": "Schließen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -32,6 +32,7 @@ export const dict = {
   "agentManager.session.untitled": "Untitled",
   "agentManager.session.newSession": "New Session",
   "agentManager.session.openInWorktree": "Open in worktree",
+  "agentManager.session.openLocally": "Open locally",
   "agentManager.session.readonly": "Read-only session",
   "agentManager.session.noSessions": "No sessions open",
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "Sin título",
   "agentManager.session.newSession": "Nueva Sesión",
   "agentManager.session.openInWorktree": "Abrir en Worktree",
+  "agentManager.session.openLocally": "Abrir localmente",
   "agentManager.session.readonly": "Sesión de solo lectura",
   "agentManager.session.noSessions": "No hay sesiones abiertas",
   "agentManager.tab.close": "Cerrar",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "Sans titre",
   "agentManager.session.newSession": "Nouvelle session",
   "agentManager.session.openInWorktree": "Ouvrir dans le Worktree",
+  "agentManager.session.openLocally": "Ouvrir localement",
   "agentManager.session.readonly": "Session en lecture seule",
   "agentManager.session.noSessions": "Aucune session ouverte",
   "agentManager.tab.close": "Fermer",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "無題",
   "agentManager.session.newSession": "新しいセッション",
   "agentManager.session.openInWorktree": "Worktreeで開く",
+  "agentManager.session.openLocally": "ローカルで開く",
   "agentManager.session.readonly": "読み取り専用セッション",
   "agentManager.session.noSessions": "開いているセッションがありません",
   "agentManager.tab.close": "閉じる",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "제목 없음",
   "agentManager.session.newSession": "새 세션",
   "agentManager.session.openInWorktree": "Worktree에서 열기",
+  "agentManager.session.openLocally": "로컬에서 열기",
   "agentManager.session.readonly": "읽기 전용 세션",
   "agentManager.session.noSessions": "열린 세션 없음",
   "agentManager.tab.close": "닫기",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -32,6 +32,7 @@ export const dict = {
   "agentManager.session.untitled": "Naamloos",
   "agentManager.session.newSession": "Nieuwe sessie",
   "agentManager.session.openInWorktree": "Openen in worktree",
+  "agentManager.session.openLocally": "Lokaal openen",
   "agentManager.session.readonly": "Alleen-lezen sessie",
   "agentManager.session.noSessions": "Geen open sessies",
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "Uten tittel",
   "agentManager.session.newSession": "Ny økt",
   "agentManager.session.openInWorktree": "Åpne i Worktree",
+  "agentManager.session.openLocally": "Åpne lokalt",
   "agentManager.session.readonly": "Skrivebeskyttet økt",
   "agentManager.session.noSessions": "Ingen åpne økter",
   "agentManager.tab.close": "Lukk",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "Bez tytułu",
   "agentManager.session.newSession": "Nowa sesja",
   "agentManager.session.openInWorktree": "Otwórz w Worktree",
+  "agentManager.session.openLocally": "Otwórz lokalnie",
   "agentManager.session.readonly": "Sesja tylko do odczytu",
   "agentManager.session.noSessions": "Brak otwartych sesji",
   "agentManager.tab.close": "Zamknij",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "Без названия",
   "agentManager.session.newSession": "Новая сессия",
   "agentManager.session.openInWorktree": "Открыть в Worktree",
+  "agentManager.session.openLocally": "Открыть локально",
   "agentManager.session.readonly": "Сессия только для чтения",
   "agentManager.session.noSessions": "Нет открытых сессий",
   "agentManager.tab.close": "Закрыть",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "ไม่มีชื่อ",
   "agentManager.session.newSession": "เซสชันใหม่",
   "agentManager.session.openInWorktree": "เปิดใน Worktree",
+  "agentManager.session.openLocally": "เปิดในเครื่อง",
   "agentManager.session.readonly": "เซสชันอ่านอย่างเดียว",
   "agentManager.session.noSessions": "ไม่มีเซสชันที่เปิดอยู่",
   "agentManager.tab.close": "ปิด",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -32,6 +32,7 @@ export const dict = {
   "agentManager.session.untitled": "Adsız",
   "agentManager.session.newSession": "Yeni Oturum",
   "agentManager.session.openInWorktree": "Worktree içinde aç",
+  "agentManager.session.openLocally": "Yerel olarak aç",
   "agentManager.session.readonly": "Salt okunur oturum",
   "agentManager.session.noSessions": "Açık oturum yok",
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "无标题",
   "agentManager.session.newSession": "新建会话",
   "agentManager.session.openInWorktree": "在 Worktree 中打开",
+  "agentManager.session.openLocally": "在本地打开",
   "agentManager.session.readonly": "只读会话",
   "agentManager.session.noSessions": "没有打开的会话",
   "agentManager.tab.close": "关闭",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.session.untitled": "未命名",
   "agentManager.session.newSession": "新建工作階段",
   "agentManager.session.openInWorktree": "在 Worktree 中開啟",
+  "agentManager.session.openLocally": "在本機開啟",
   "agentManager.session.readonly": "唯讀工作階段",
   "agentManager.session.noSessions": "沒有開啟的工作階段",
   "agentManager.tab.close": "關閉",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1618,6 +1618,12 @@ export interface PromoteSessionRequest {
   sessionId: string
 }
 
+// Open an unassigned session locally (clear any worktree directory override)
+export interface OpenLocallyRequest {
+  type: "agentManager.openLocally"
+  sessionId: string
+}
+
 // Add a new session to an existing worktree
 export interface AddSessionToWorktreeRequest {
   type: "agentManager.addSessionToWorktree"
@@ -1949,6 +1955,7 @@ export type WebviewMessage =
   | DeleteWorktreeRequest
   | RemoveStaleWorktreeRequest
   | PromoteSessionRequest
+  | OpenLocallyRequest
   | AddSessionToWorktreeRequest
   | ForkSessionRequest
   | CloseSessionRequest


### PR DESCRIPTION
## Summary

- Fix `onSelectSession` bug where clicking a recent session left the pending tab active, causing `clearCurrentSession()` to destroy the loaded session on the next click
- Add `agentManager.openLocally` message that clears a session's worktree directory override so it falls back to workspace root
- Expose "Open locally" action via context menu on unassigned sessions and as a secondary button in the read-only banner

## Context
Closes https://github.com/Kilo-Org/kilocode/issues/6959, closes https://github.com/Kilo-Org/kilocode/issues/7620

When viewing an unassigned session (not in a worktree, not in local tabs), the Agent Manager shows a read-only banner with only "Open in worktree". There was no way to open an unassigned session locally without first promoting it to a worktree. This PR adds that missing action.

Additionally, the recent sessions list in the empty chat state (`ChatView` → `MessageList`) had a bug: clicking a session would call `session.selectSession(id)` but never add it to `localSessionIDs` or clear the pending tab, so the session would load but the pending "New session" tab stayed active — clicking it again would destroy the loaded session via `clearCurrentSession()`.

## Screenshots

<img width="645" height="65" alt="image" src="https://github.com/user-attachments/assets/7fe63346-5cc8-49e1-9d65-773f9ec579e1" />

## Testing

- [x] `bun turbo typecheck` — all 12 tasks pass
- [x] `bun run format` — no changes needed
- [x] `bun run lint` — no errors
- [x] `bun run knip` — no unused exports
- [x] `bun run check-kilocode-change` — no source markers in kilo-vscode
- [x] Unit tests — 84 tests, 4963 expects, all pass
- [x] `source-links.md` — unchanged
