### PR TITLE
fix(agent-manager): make review comment edit button reactive

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -242,11 +242,19 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
   })
 
   const annotationsForFile = (file: string): DiffLineAnnotation<AnnotationMeta>[] => {
+    const currentEditing = editing()
     const fileComments = commentsByFile().get(file) ?? []
     const result: DiffLineAnnotation<AnnotationMeta>[] = fileComments.map((c) => ({
       side: c.side,
       lineNumber: c.line,
-      metadata: { type: "comment" as const, comment: c, file: c.file, side: c.side, line: c.line },
+      metadata: {
+        type: "comment" as const,
+        comment: c,
+        file: c.file,
+        side: c.side,
+        line: c.line,
+        isEditing: currentEditing === c.id,
+      },
     }))
 
     const d = draft()

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -248,11 +248,19 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
   })
 
   const annotationsForFile = (file: string): DiffLineAnnotation<AnnotationMeta>[] => {
+    const currentEditing = editing()
     const fileComments = commentsByFile().get(file) ?? []
     const result: DiffLineAnnotation<AnnotationMeta>[] = fileComments.map((c) => ({
       side: c.side,
       lineNumber: c.line,
-      metadata: { type: "comment" as const, comment: c, file: c.file, side: c.side, line: c.line },
+      metadata: {
+        type: "comment" as const,
+        comment: c,
+        file: c.file,
+        side: c.side,
+        line: c.line,
+        isEditing: currentEditing === c.id,
+      },
     }))
 
     const d = draft()

--- a/packages/kilo-vscode/webview-ui/agent-manager/review-annotations.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/review-annotations.ts
@@ -20,6 +20,8 @@ export interface AnnotationMeta {
   file: string
   side: AnnotationSide
   line: number
+  /** When true the annotation should render in edit mode (textarea). */
+  isEditing?: boolean
 }
 
 interface AnnotationHandlers {
@@ -146,7 +148,7 @@ export function buildReviewAnnotation(
   }
 
   const comment = meta.comment!
-  if (handlers.editing === comment.id) {
+  if (meta.isEditing) {
     wrapper.className = "am-annotation am-annotation-draft"
 
     const header = document.createElement("div")


### PR DESCRIPTION
## Summary

- Fixes the review comment edit button not working in the Agent Manager (#7585)
- The `editing` signal was updated on click, but `annotationsForFile()` didn't depend on it, so the Diff component never re-rendered with the edit textarea
- Added `isEditing` flag to `AnnotationMeta` and read `editing()` inside `annotationsForFile` so annotation arrays change when edit state changes, triggering a re-render

## Changes

- `review-annotations.ts`: Added `isEditing` field to `AnnotationMeta`, use `meta.isEditing` instead of comparing `handlers.editing === comment.id`
- `DiffPanel.tsx`: Read `editing()` inside `annotationsForFile` and set `isEditing` on each comment annotation
- `FullScreenDiffView.tsx`: Same fix as DiffPanel

## Test plan

- [ ] Open Agent Manager review panel with file diffs
- [ ] Add a review comment on any line
- [ ] Click the edit (pencil) button on the comment
- [ ] Verify the comment switches to an editable textarea
- [ ] Edit the text and press Enter or click Save — verify it updates
- [ ] Press Escape or click Cancel — verify it reverts to static display
- [ ] Repeat in full-screen diff view