### PR TITLE
fix(agent-manager): remove fixed max-width on tab labels

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -735,7 +735,6 @@ button.am-section-toggle:hover .am-section-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 150px;
 }
 
 .am-tab-close {


### PR DESCRIPTION
## Summary
- Removed the hardcoded `max-width: 150px` on `.am-tab-label` that was truncating session tab titles
- Session titles like "New session - 2026-03-25T..." now display fully instead of being cut off with ellipsis
- The tab bar already handles overflow via `overflow-x: auto` with fade indicators, so the fixed constraint was unnecessary