### PR TITLE
fix(agent-manager): review comment edit button not triggering re-render

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -14,7 +14,12 @@ import type { DiffLineAnnotation, AnnotationSide, SelectedLineRange } from "@pie
 import type { WorktreeFileDiff } from "../src/types/messages"
 import { useLanguage } from "../src/context/language"
 import { getDirectory, getFilename, lineCount, sanitizeReviewComments, type ReviewComment } from "./review-comments"
-import { buildReviewAnnotation, type AnnotationLabels, type AnnotationMeta } from "./review-annotations"
+import {
+  buildFileAnnotations,
+  buildReviewAnnotation,
+  type AnnotationLabels,
+  type AnnotationMeta,
+} from "./review-annotations"
 import { LONG_DIFF_MARKER_FILE_COUNT, initialOpenFiles, isLargeDiffFile } from "./diff-open-policy"
 import { DiffEndMarker } from "./DiffEndMarker"
 
@@ -242,22 +247,9 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
   })
 
   const annotationsForFile = (file: string): DiffLineAnnotation<AnnotationMeta>[] => {
-    const fileComments = commentsByFile().get(file) ?? []
-    const result: DiffLineAnnotation<AnnotationMeta>[] = fileComments.map((c) => ({
-      side: c.side,
-      lineNumber: c.line,
-      metadata: { type: "comment" as const, comment: c, file: c.file, side: c.side, line: c.line },
-    }))
-
-    const d = draft()
-    if (d && d.file === file) {
-      // Reuse stable reference for draft to prevent pierre cache invalidation
-      if (!draftMeta || draftMeta.file !== d.file || draftMeta.side !== d.side || draftMeta.line !== d.line) {
-        draftMeta = { type: "draft", comment: null, file: d.file, side: d.side, line: d.line }
-      }
-      result.push({ side: d.side, lineNumber: d.line, metadata: draftMeta })
-    }
-    return result
+    const result = buildFileAnnotations(file, commentsByFile().get(file) ?? [], editing(), draft(), draftMeta)
+    draftMeta = result.draftMeta
+    return result.annotations
   }
 
   const buildAnnotation = (annotation: DiffLineAnnotation<AnnotationMeta>): HTMLElement | undefined => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -16,7 +16,12 @@ import type { WorktreeFileDiff } from "../src/types/messages"
 import { useLanguage } from "../src/context/language"
 import { FileTree } from "./FileTree"
 import { getDirectory, getFilename, lineCount, sanitizeReviewComments, type ReviewComment } from "./review-comments"
-import { buildReviewAnnotation, type AnnotationLabels, type AnnotationMeta } from "./review-annotations"
+import {
+  buildFileAnnotations,
+  buildReviewAnnotation,
+  type AnnotationLabels,
+  type AnnotationMeta,
+} from "./review-annotations"
 import { LONG_DIFF_MARKER_FILE_COUNT, initialOpenFiles, isLargeDiffFile } from "./diff-open-policy"
 import { DiffEndMarker } from "./DiffEndMarker"
 
@@ -248,21 +253,9 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
   })
 
   const annotationsForFile = (file: string): DiffLineAnnotation<AnnotationMeta>[] => {
-    const fileComments = commentsByFile().get(file) ?? []
-    const result: DiffLineAnnotation<AnnotationMeta>[] = fileComments.map((c) => ({
-      side: c.side,
-      lineNumber: c.line,
-      metadata: { type: "comment" as const, comment: c, file: c.file, side: c.side, line: c.line },
-    }))
-
-    const d = draft()
-    if (d && d.file === file) {
-      if (!draftMeta || draftMeta.file !== d.file || draftMeta.side !== d.side || draftMeta.line !== d.line) {
-        draftMeta = { type: "draft", comment: null, file: d.file, side: d.side, line: d.line }
-      }
-      result.push({ side: d.side, lineNumber: d.line, metadata: draftMeta })
-    }
-    return result
+    const result = buildFileAnnotations(file, commentsByFile().get(file) ?? [], editing(), draft(), draftMeta)
+    draftMeta = result.draftMeta
+    return result.annotations
   }
 
   const buildAnnotation = (annotation: DiffLineAnnotation<AnnotationMeta>): HTMLElement | undefined => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/review-annotations.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/review-annotations.ts
@@ -20,6 +20,7 @@ export interface AnnotationMeta {
   file: string
   side: AnnotationSide
   line: number
+  editing?: boolean
 }
 
 interface AnnotationHandlers {
@@ -69,6 +70,35 @@ function makeActionButton(title: string, icon: SVGSVGElement, action: () => void
     action()
   })
   return button
+}
+
+export function buildFileAnnotations(
+  file: string,
+  fileComments: ReviewComment[],
+  edit: string | null,
+  draft: { file: string; side: AnnotationSide; line: number } | null,
+  draftMeta: AnnotationMeta | null,
+): { annotations: DiffLineAnnotation<AnnotationMeta>[]; draftMeta: AnnotationMeta | null } {
+  const result: DiffLineAnnotation<AnnotationMeta>[] = fileComments.map((c) => ({
+    side: c.side,
+    lineNumber: c.line,
+    metadata: {
+      type: "comment" as const,
+      comment: c,
+      file: c.file,
+      side: c.side,
+      line: c.line,
+      editing: c.id === edit,
+    },
+  }))
+
+  if (draft && draft.file === file) {
+    if (!draftMeta || draftMeta.file !== draft.file || draftMeta.side !== draft.side || draftMeta.line !== draft.line) {
+      draftMeta = { type: "draft", comment: null, file: draft.file, side: draft.side, line: draft.line }
+    }
+    result.push({ side: draft.side, lineNumber: draft.line, metadata: draftMeta })
+  }
+  return { annotations: result, draftMeta }
 }
 
 export function buildReviewAnnotation(
@@ -146,7 +176,7 @@ export function buildReviewAnnotation(
   }
 
   const comment = meta.comment!
-  if (handlers.editing === comment.id) {
+  if (meta.editing) {
     wrapper.className = "am-annotation am-annotation-draft"
 
     const header = document.createElement("div")


### PR DESCRIPTION
## Summary

- Fix the edit button on review comments in the Agent Manager diff view doing nothing when clicked
- Include `editing` state in annotation metadata so pierre detects the change and re-renders the annotation in edit mode
- Use `meta.editing` in `buildReviewAnnotation` instead of re-deriving from `handlers.editing === comment.id` (approach from #7633)
- Extract duplicated `annotationsForFile` logic from `DiffPanel.tsx` and `FullScreenDiffView.tsx` into a shared `buildFileAnnotations` helper in `review-annotations.ts`

Closes #7585