### PR TITLE
fix(vscode): fix continue-in-worktree progress labels and recent session routing

### DIFF
--- a/packages/kilo-vscode/tests/unit/continue-in-worktree.test.ts
+++ b/packages/kilo-vscode/tests/unit/continue-in-worktree.test.ts
@@ -80,14 +80,6 @@ describe("continue-in-worktree steps", () => {
     })
   })
 
-  describe("captureState", () => {
-    it("returns ok with snapshot data on a real git repo", async () => {
-      // This test just verifies the StepResult wrapper — git-transfer.test.ts covers the details.
-      // We can't easily test the error path without mocks since git commands resolve gracefully.
-      // The error wrapping is tested indirectly through forkSession error tests.
-    })
-  })
-
   describe("forkSession", () => {
     it("returns error when client is unavailable", async () => {
       const c = ctx()

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2761,6 +2761,7 @@ const AgentManagerContent: Component = () => {
                     if (ms?.worktreeId) {
                       selectWorktree(ms.worktreeId)
                       session.selectSession(id)
+                      setReviewActive(false)
                       return
                     }
                   }

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2755,6 +2755,15 @@ const AgentManagerContent: Component = () => {
                     if (selection() === null) setSelection(LOCAL)
                     return
                   }
+                  // Navigate to owning worktree instead of forcing into local mode
+                  if (worktreeSessionIds().has(id)) {
+                    const ms = managedSessions().find((s) => s.id === id)
+                    if (ms?.worktreeId) {
+                      selectWorktree(ms.worktreeId)
+                      session.selectSession(id)
+                      return
+                    }
+                  }
                   openLocally(id)
                 }}
                 readonly={readOnly()}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -110,7 +110,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
         showToast({ title: m.error ?? "Failed to continue in worktree" })
         return
       }
-      setTransferDetail(labels[status] ?? "Working...")
+      setTransferDetail(labels[m.status] ?? "Working...")
     })
     onCleanup(cleanup)
   }


### PR DESCRIPTION
## Summary

Follow-up fixes for #7541 ("Continue in Worktree" feature):

- **Fix progress label bug**: `labels[status]` referenced an undefined variable after renaming to `m` — progress text was always "Working..." instead of step-specific labels like "Creating worktree..."
- **Prevent worktree sessions from opening locally**: When a worktree-scoped session appears in the Agent Manager's "recent" list and is clicked, navigate to its owning worktree instead of calling `openLocally()` which strips the directory mapping and leaves the session in a broken state
- **Remove empty test placeholder**: Deleted the no-op `captureState` test that was just a comment