### PR TITLE
feat(vscode): add supersize sidebar button

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -100,7 +100,12 @@
         "icon": "$(settings-gear)"
       },
       {
-        "command": "kilo-code.new.supersizeSidebar",
+        "command": "kilo-code.new.supersizeSidebarAux",
+        "title": "Supersize",
+        "icon": "$(screen-full)"
+      },
+      {
+        "command": "kilo-code.new.supersizeSidebarPrimary",
         "title": "Supersize",
         "icon": "$(screen-full)"
       },
@@ -358,9 +363,14 @@
           "when": "view == kilo-code.SidebarProvider"
         },
         {
-          "command": "kilo-code.new.supersizeSidebar",
+          "command": "kilo-code.new.supersizeSidebarAux",
           "group": "navigation@6",
-          "when": "view == kilo-code.SidebarProvider"
+          "when": "view == kilo-code.SidebarProvider && auxiliaryBarFocus"
+        },
+        {
+          "command": "kilo-code.new.supersizeSidebarPrimary",
+          "group": "navigation@6",
+          "when": "view == kilo-code.SidebarProvider && sideBarFocus"
         }
       ],
       "scm/title": [

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -100,12 +100,7 @@
         "icon": "$(settings-gear)"
       },
       {
-        "command": "kilo-code.new.supersizeSidebarAux",
-        "title": "Supersize",
-        "icon": "$(screen-full)"
-      },
-      {
-        "command": "kilo-code.new.supersizeSidebarPrimary",
+        "command": "kilo-code.new.supersizeSidebar",
         "title": "Supersize",
         "icon": "$(screen-full)"
       },
@@ -363,14 +358,9 @@
           "when": "view == kilo-code.SidebarProvider"
         },
         {
-          "command": "kilo-code.new.supersizeSidebarAux",
+          "command": "kilo-code.new.supersizeSidebar",
           "group": "navigation@6",
-          "when": "view == kilo-code.SidebarProvider && auxiliaryBarFocus"
-        },
-        {
-          "command": "kilo-code.new.supersizeSidebarPrimary",
-          "group": "navigation@6",
-          "when": "view == kilo-code.SidebarProvider && sideBarFocus"
+          "when": "view == kilo-code.SidebarProvider"
         }
       ],
       "scm/title": [

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -100,6 +100,11 @@
         "icon": "$(settings-gear)"
       },
       {
+        "command": "kilo-code.new.supersizeSidebar",
+        "title": "Supersize",
+        "icon": "$(screen-full)"
+      },
+      {
         "command": "kilo-code.new.openInTab",
         "title": "Kilo Code",
         "icon": {
@@ -350,6 +355,11 @@
         {
           "command": "kilo-code.new.settingsButtonClicked",
           "group": "navigation@5",
+          "when": "view == kilo-code.SidebarProvider"
+        },
+        {
+          "command": "kilo-code.new.supersizeSidebar",
+          "group": "navigation@6",
           "when": "view == kilo-code.SidebarProvider"
         }
       ],

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -85,6 +85,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   public static readonly viewType = "kilo-code.SidebarProvider"
 
   private webview: vscode.Webview | null = null
+  public view: vscode.WebviewView | null = null
   private currentSession: Session | null = null
   private connectionState: "connecting" | "connected" | "disconnected" | "error" = "connecting"
   private loginAttempt = 0
@@ -285,6 +286,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   ) {
     // Store the webview references
     this.isWebviewReady = false
+    this.view = webviewView
     this.webview = webviewView.webview
 
     // Set up webview options

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -181,7 +181,12 @@ export function activate(context: vscode.ExtensionContext) {
       settingsEditorProvider.openPanel("settings", tab)
     }),
     vscode.commands.registerCommand("kilo-code.new.supersizeSidebar", async () => {
-      await vscode.commands.executeCommand("workbench.action.focusSideBar")
+      // Focus our view first, then try to resize whichever sidebar it's in.
+      // There's no VS Code API to detect primary vs secondary sidebar, so we
+      // try the auxiliary bar (secondary sidebar) first — if it's not visible
+      // that command is a no-op — then also increase the primary sidebar size.
+      await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
+      await vscode.commands.executeCommand("workbench.action.maximizeAuxiliaryBar")
       for (let i = 0; i < 20; i++) {
         await vscode.commands.executeCommand("workbench.action.increaseViewSize")
       }

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -183,39 +183,19 @@ export function activate(context: vscode.ExtensionContext) {
     (() => {
       let maximized = false
       return vscode.commands.registerCommand("kilo-code.new.supersizeSidebar", async () => {
-        // Detect which sidebar the view is in by focusing the auxiliary bar
-        // and checking if our WebviewView becomes visible.
-        const view = provider.view
-        if (!view) return
-
-        // Focus our view so it's guaranteed active
         await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
-
-        // Check if view is in auxiliary bar: toggle auxiliary bar off,
-        // if our view becomes invisible it was there.
-        await vscode.commands.executeCommand("workbench.action.toggleAuxiliaryBar")
-        const inAuxiliary = !view.visible
-        // Restore auxiliary bar to original state
-        await vscode.commands.executeCommand("workbench.action.toggleAuxiliaryBar")
-
+        // increaseViewSize only affects the primary sidebar, and
+        // maximizeAuxiliaryBar only affects the secondary sidebar,
+        // so calling both is safe — only the relevant one has effect.
         if (maximized) {
-          if (inAuxiliary) {
-            await vscode.commands.executeCommand("workbench.action.restoreAuxiliaryBar")
-          } else {
-            await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
-            for (let i = 0; i < 20; i++) {
-              await vscode.commands.executeCommand("workbench.action.decreaseViewSize")
-            }
+          await vscode.commands.executeCommand("workbench.action.restoreAuxiliaryBar")
+          for (let i = 0; i < 20; i++) {
+            await vscode.commands.executeCommand("workbench.action.decreaseViewSize")
           }
         } else {
-          if (inAuxiliary) {
-            await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
-            await vscode.commands.executeCommand("workbench.action.maximizeAuxiliaryBar")
-          } else {
-            await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
-            for (let i = 0; i < 20; i++) {
-              await vscode.commands.executeCommand("workbench.action.increaseViewSize")
-            }
+          await vscode.commands.executeCommand("workbench.action.maximizeAuxiliaryBar")
+          for (let i = 0; i < 20; i++) {
+            await vscode.commands.executeCommand("workbench.action.increaseViewSize")
           }
         }
         maximized = !maximized

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -181,17 +181,27 @@ export function activate(context: vscode.ExtensionContext) {
       settingsEditorProvider.openPanel("settings", tab)
     }),
     (() => {
-      let maximized = false
-      return vscode.commands.registerCommand("kilo-code.new.supersizeSidebar", async () => {
-        if (maximized) {
-          await vscode.commands.executeCommand("workbench.action.restoreAuxiliaryBar")
-          maximized = false
-        } else {
+      let auxMaximized = false
+      let primaryExpanded = false
+      return vscode.Disposable.from(
+        vscode.commands.registerCommand("kilo-code.new.supersizeSidebarAux", async () => {
+          if (auxMaximized) {
+            await vscode.commands.executeCommand("workbench.action.restoreAuxiliaryBar")
+          } else {
+            await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
+            await vscode.commands.executeCommand("workbench.action.maximizeAuxiliaryBar")
+          }
+          auxMaximized = !auxMaximized
+        }),
+        vscode.commands.registerCommand("kilo-code.new.supersizeSidebarPrimary", async () => {
           await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
-          await vscode.commands.executeCommand("workbench.action.maximizeAuxiliaryBar")
-          maximized = true
-        }
-      })
+          const cmd = primaryExpanded ? "workbench.action.decreaseViewSize" : "workbench.action.increaseViewSize"
+          for (let i = 0; i < 20; i++) {
+            await vscode.commands.executeCommand(cmd)
+          }
+          primaryExpanded = !primaryExpanded
+        }),
+      )
     })(),
     // legacy-migration start
     vscode.commands.registerCommand("kilo-code.new.openMigrationWizard", () => {

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -183,19 +183,32 @@ export function activate(context: vscode.ExtensionContext) {
     (() => {
       let maximized = false
       return vscode.commands.registerCommand("kilo-code.new.supersizeSidebar", async () => {
+        const view = provider.view
+        if (!view) return
+
+        // Detect which sidebar we're in: toggle the primary sidebar and
+        // check if our view disappears. If it does, we're in primary.
         await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
-        // increaseViewSize only affects the primary sidebar, and
-        // maximizeAuxiliaryBar only affects the secondary sidebar,
-        // so calling both is safe — only the relevant one has effect.
+        await vscode.commands.executeCommand("workbench.action.toggleSidebarVisibility")
+        const inPrimary = !view.visible
+        await vscode.commands.executeCommand("workbench.action.toggleSidebarVisibility")
+        await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
+
         if (maximized) {
-          await vscode.commands.executeCommand("workbench.action.restoreAuxiliaryBar")
-          for (let i = 0; i < 20; i++) {
-            await vscode.commands.executeCommand("workbench.action.decreaseViewSize")
+          if (inPrimary) {
+            for (let i = 0; i < 20; i++) {
+              await vscode.commands.executeCommand("workbench.action.decreaseViewSize")
+            }
+          } else {
+            await vscode.commands.executeCommand("workbench.action.restoreAuxiliaryBar")
           }
         } else {
-          await vscode.commands.executeCommand("workbench.action.maximizeAuxiliaryBar")
-          for (let i = 0; i < 20; i++) {
-            await vscode.commands.executeCommand("workbench.action.increaseViewSize")
+          if (inPrimary) {
+            for (let i = 0; i < 20; i++) {
+              await vscode.commands.executeCommand("workbench.action.increaseViewSize")
+            }
+          } else {
+            await vscode.commands.executeCommand("workbench.action.maximizeAuxiliaryBar")
           }
         }
         maximized = !maximized

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -180,6 +180,12 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("kilo-code.new.settingsButtonClicked", (tab?: string) => {
       settingsEditorProvider.openPanel("settings", tab)
     }),
+    vscode.commands.registerCommand("kilo-code.new.supersizeSidebar", async () => {
+      await vscode.commands.executeCommand("workbench.action.focusSideBar")
+      for (let i = 0; i < 20; i++) {
+        await vscode.commands.executeCommand("workbench.action.increaseViewSize")
+      }
+    }),
     // legacy-migration start
     vscode.commands.registerCommand("kilo-code.new.openMigrationWizard", () => {
       provider.postMessage({ type: "navigate", view: "migration" })

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -180,17 +180,19 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("kilo-code.new.settingsButtonClicked", (tab?: string) => {
       settingsEditorProvider.openPanel("settings", tab)
     }),
-    vscode.commands.registerCommand("kilo-code.new.supersizeSidebar", async () => {
-      // Focus our view first, then try to resize whichever sidebar it's in.
-      // There's no VS Code API to detect primary vs secondary sidebar, so we
-      // try the auxiliary bar (secondary sidebar) first — if it's not visible
-      // that command is a no-op — then also increase the primary sidebar size.
-      await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
-      await vscode.commands.executeCommand("workbench.action.maximizeAuxiliaryBar")
-      for (let i = 0; i < 20; i++) {
-        await vscode.commands.executeCommand("workbench.action.increaseViewSize")
-      }
-    }),
+    (() => {
+      let maximized = false
+      return vscode.commands.registerCommand("kilo-code.new.supersizeSidebar", async () => {
+        if (maximized) {
+          await vscode.commands.executeCommand("workbench.action.restoreAuxiliaryBar")
+          maximized = false
+        } else {
+          await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
+          await vscode.commands.executeCommand("workbench.action.maximizeAuxiliaryBar")
+          maximized = true
+        }
+      })
+    })(),
     // legacy-migration start
     vscode.commands.registerCommand("kilo-code.new.openMigrationWizard", () => {
       provider.postMessage({ type: "navigate", view: "migration" })

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -181,27 +181,45 @@ export function activate(context: vscode.ExtensionContext) {
       settingsEditorProvider.openPanel("settings", tab)
     }),
     (() => {
-      let auxMaximized = false
-      let primaryExpanded = false
-      return vscode.Disposable.from(
-        vscode.commands.registerCommand("kilo-code.new.supersizeSidebarAux", async () => {
-          if (auxMaximized) {
+      let maximized = false
+      return vscode.commands.registerCommand("kilo-code.new.supersizeSidebar", async () => {
+        // Detect which sidebar the view is in by focusing the auxiliary bar
+        // and checking if our WebviewView becomes visible.
+        const view = provider.view
+        if (!view) return
+
+        // Focus our view so it's guaranteed active
+        await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
+
+        // Check if view is in auxiliary bar: toggle auxiliary bar off,
+        // if our view becomes invisible it was there.
+        await vscode.commands.executeCommand("workbench.action.toggleAuxiliaryBar")
+        const inAuxiliary = !view.visible
+        // Restore auxiliary bar to original state
+        await vscode.commands.executeCommand("workbench.action.toggleAuxiliaryBar")
+
+        if (maximized) {
+          if (inAuxiliary) {
             await vscode.commands.executeCommand("workbench.action.restoreAuxiliaryBar")
           } else {
             await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
+            for (let i = 0; i < 20; i++) {
+              await vscode.commands.executeCommand("workbench.action.decreaseViewSize")
+            }
+          }
+        } else {
+          if (inAuxiliary) {
+            await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
             await vscode.commands.executeCommand("workbench.action.maximizeAuxiliaryBar")
+          } else {
+            await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
+            for (let i = 0; i < 20; i++) {
+              await vscode.commands.executeCommand("workbench.action.increaseViewSize")
+            }
           }
-          auxMaximized = !auxMaximized
-        }),
-        vscode.commands.registerCommand("kilo-code.new.supersizeSidebarPrimary", async () => {
-          await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
-          const cmd = primaryExpanded ? "workbench.action.decreaseViewSize" : "workbench.action.increaseViewSize"
-          for (let i = 0; i < 20; i++) {
-            await vscode.commands.executeCommand(cmd)
-          }
-          primaryExpanded = !primaryExpanded
-        }),
-      )
+        }
+        maximized = !maximized
+      })
     })(),
     // legacy-migration start
     vscode.commands.registerCommand("kilo-code.new.openMigrationWizard", () => {


### PR DESCRIPTION
## Summary

- Adds a **Supersize** button (`$(screen-full)` icon) to the sidebar toolbar (`view/title` menu, `navigation@6`)
- When clicked, focuses the sidebar and calls `workbench.action.increaseViewSize` 20 times to significantly enlarge it
- Fixes the previous approach (#7640) which used the non-existent `workbench.action.setSidebarWidth` command
- Intended for testing/development use
