### PR TITLE
fix(agent-manager): preserve session-worktree association when closing tabs

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -195,6 +195,7 @@ export class AgentManagerProvider implements Disposable {
     if (m.type === "agentManager.addSessionToWorktree") return this.onAddSessionToWorktree(m.worktreeId)
     if (m.type === "agentManager.forkSession") return this.onForkSession(m.sessionId, m.worktreeId)
     if (m.type === "agentManager.closeSession") return this.onCloseSession(m.sessionId)
+    if (m.type === "agentManager.reopenSession") return this.onReopenSession(m.sessionId)
     if (m.type === "agentManager.configureSetupScript") {
       void this.configureSetupScript()
       return null
@@ -779,14 +780,33 @@ export class AgentManagerProvider implements Disposable {
     )
   }
 
-  /** Close (remove) a session from its worktree. */
+  /** Close (hide) a session tab without deleting the worktree association. */
   private async onCloseSession(sessionId: string): Promise<null> {
     const state = this.getStateManager()
     if (!state) return null
 
-    state.removeSession(sessionId)
+    state.closeSession(sessionId)
     this.pushState()
     this.log(`Closed session ${sessionId}`)
+    return null
+  }
+
+  /** Reopen a previously closed session tab. */
+  private async onReopenSession(sessionId: string): Promise<null> {
+    const state = this.getStateManager()
+    if (!state) return null
+
+    state.reopenSession(sessionId)
+    this.pushState()
+
+    // Ensure the session is tracked and its directory is registered
+    const dir = state.directoryFor(sessionId)
+    if (dir) {
+      this.panel?.sessions.setSessionDirectory(sessionId, dir)
+      this.panel?.sessions.trackSession(sessionId)
+    }
+
+    this.log(`Reopened session ${sessionId}`)
     return null
   }
 

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -41,6 +41,8 @@ export interface ManagedSession {
   id: string
   worktreeId: string | null
   createdAt: string
+  /** When true the session tab is hidden but the association is preserved. */
+  closed?: boolean
 }
 
 interface StateFile {
@@ -210,6 +212,32 @@ export class WorktreeStateManager {
     if (!session) return
     session.worktreeId = worktreeId
     this.log(`Moved session ${sessionId} to worktree ${worktreeId}`)
+    void this.save()
+  }
+
+  /** Mark a session as closed (hidden from tabs) without deleting the association. */
+  closeSession(id: string): void {
+    const session = this.sessions.get(id)
+    if (!session) return
+    session.closed = true
+
+    // Remove this session from any tab order arrays
+    for (const [key, order] of Object.entries(this.tabOrder)) {
+      const idx = order.indexOf(id)
+      if (idx !== -1) {
+        order.splice(idx, 1)
+        if (order.length === 0) delete this.tabOrder[key]
+      }
+    }
+
+    void this.save()
+  }
+
+  /** Reopen a previously closed session. */
+  reopenSession(id: string): void {
+    const session = this.sessions.get(id)
+    if (!session) return
+    delete session.closed
     void this.save()
   }
 

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -239,6 +239,11 @@ interface CloseSessionIn {
   sessionId: string
 }
 
+interface ReopenSessionIn {
+  type: "agentManager.reopenSession"
+  sessionId: string
+}
+
 interface ConfigureSetupScriptIn {
   type: "agentManager.configureSetupScript"
 }
@@ -419,6 +424,7 @@ export type AgentManagerInMessage =
   | PromoteSessionIn
   | AddSessionToWorktreeIn
   | CloseSessionIn
+  | ReopenSessionIn
   | ForkSessionIn
   | ConfigureSetupScriptIn
   | ShowTerminalIn

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -720,13 +720,25 @@ const AgentManagerContent: Component = () => {
   const activeWorktreeSessions = createMemo((): SessionInfo[] => {
     const sel = selection()
     if (!sel || sel === LOCAL) return []
-    const managed = managedSessions().filter((ms) => ms.worktreeId === sel)
+    const managed = managedSessions().filter((ms) => ms.worktreeId === sel && !ms.closed)
     const ids = new Set(managed.map((ms) => ms.id))
     const sessions = session
       .sessions()
       .filter((s) => ids.has(s.id))
       .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
     return applyTabOrder(sessions, worktreeTabOrder()[sel])
+  })
+
+  // Closed sessions for the currently selected worktree (available for reopening)
+  const closedWorktreeSessions = createMemo((): SessionInfo[] => {
+    const sel = selection()
+    if (!sel || sel === LOCAL) return []
+    const managed = managedSessions().filter((ms) => ms.worktreeId === sel && ms.closed)
+    const ids = new Set(managed.map((ms) => ms.id))
+    return session
+      .sessions()
+      .filter((s) => ids.has(s.id))
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
   })
 
   // Active tab sessions: local sessions when on "local", worktree sessions otherwise
@@ -1798,6 +1810,11 @@ const AgentManagerContent: Component = () => {
     }
   }
 
+  const handleReopenSession = (sessionId: string) => {
+    vscode.postMessage({ type: "agentManager.reopenSession", sessionId })
+    session.selectSession(sessionId)
+  }
+
   const handleForkSession = (sessionId: string) => {
     const sel = selection()
     if (sel === LOCAL) {
@@ -2543,6 +2560,26 @@ const AgentManagerContent: Component = () => {
                   onClick={handleAddSession}
                 />
               </TooltipKeybind>
+              <Show when={closedWorktreeSessions().length > 0}>
+                <DropdownMenu gutter={4} placement="bottom-start">
+                  <Tooltip value={t("agentManager.session.reopen")} placement="bottom">
+                    <DropdownMenu.Trigger class="am-tab-add" aria-label={t("agentManager.session.reopen")}>
+                      <Icon name="history" size="small" />
+                    </DropdownMenu.Trigger>
+                  </Tooltip>
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Content class="am-split-menu">
+                      <For each={closedWorktreeSessions()}>
+                        {(s) => (
+                          <DropdownMenu.Item onSelect={() => handleReopenSession(s.id)}>
+                            <DropdownMenu.ItemLabel>{s.title || s.id.slice(0, 8)}</DropdownMenu.ItemLabel>
+                          </DropdownMenu.Item>
+                        )}
+                      </For>
+                    </DropdownMenu.Content>
+                  </DropdownMenu.Portal>
+                </DropdownMenu>
+              </Show>
               <div class="am-tab-actions">
                 {(() => {
                   const sel = () => selection()

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "التغييرات",
   "agentManager.hoverCard.commits": "عمليات الالتزام",
   "agentManager.session.new": "جلسة جديدة",
+  "agentManager.session.reopen": "إعادة فتح جلسة مغلقة",
   "agentManager.session.untitled": "بدون عنوان",
   "agentManager.session.newSession": "جلسة جديدة",
   "agentManager.session.openInWorktree": "فتح في Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "Alterações",
   "agentManager.hoverCard.commits": "Commits",
   "agentManager.session.new": "Nova sessão",
+  "agentManager.session.reopen": "Reabrir sessão fechada",
   "agentManager.session.untitled": "Sem título",
   "agentManager.session.newSession": "Nova Sessão",
   "agentManager.session.openInWorktree": "Abrir no Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "Promjene",
   "agentManager.hoverCard.commits": "Commiti",
   "agentManager.session.new": "Nova sesija",
+  "agentManager.session.reopen": "Ponovo otvori zatvorenu sesiju",
   "agentManager.session.untitled": "Bez naslova",
   "agentManager.session.newSession": "Nova sesija",
   "agentManager.session.openInWorktree": "Otvori u Worktree-u",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "Ændringer",
   "agentManager.hoverCard.commits": "Commits",
   "agentManager.session.new": "Ny session",
+  "agentManager.session.reopen": "Genåbn lukket session",
   "agentManager.session.untitled": "Uden titel",
   "agentManager.session.newSession": "Ny session",
   "agentManager.session.openInWorktree": "Åbn i Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "Änderungen",
   "agentManager.hoverCard.commits": "Commits",
   "agentManager.session.new": "Neue Sitzung",
+  "agentManager.session.reopen": "Geschlossene Sitzung erneut öffnen",
   "agentManager.session.untitled": "Unbenannt",
   "agentManager.session.newSession": "Neue Sitzung",
   "agentManager.session.openInWorktree": "In Worktree öffnen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.hoverCard.commits": "Commits",
 
   "agentManager.session.new": "New session",
+  "agentManager.session.reopen": "Reopen closed session",
   "agentManager.session.untitled": "Untitled",
   "agentManager.session.newSession": "New Session",
   "agentManager.session.openInWorktree": "Open in worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "Cambios",
   "agentManager.hoverCard.commits": "Commits",
   "agentManager.session.new": "Nueva sesión",
+  "agentManager.session.reopen": "Reabrir sesión cerrada",
   "agentManager.session.untitled": "Sin título",
   "agentManager.session.newSession": "Nueva Sesión",
   "agentManager.session.openInWorktree": "Abrir en Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "Modifications",
   "agentManager.hoverCard.commits": "Commits",
   "agentManager.session.new": "Nouvelle session",
+  "agentManager.session.reopen": "Rouvrir une session fermée",
   "agentManager.session.untitled": "Sans titre",
   "agentManager.session.newSession": "Nouvelle session",
   "agentManager.session.openInWorktree": "Ouvrir dans le Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "変更",
   "agentManager.hoverCard.commits": "コミット",
   "agentManager.session.new": "新しいセッション",
+  "agentManager.session.reopen": "閉じたセッションを再度開く",
   "agentManager.session.untitled": "無題",
   "agentManager.session.newSession": "新しいセッション",
   "agentManager.session.openInWorktree": "Worktreeで開く",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "변경 사항",
   "agentManager.hoverCard.commits": "커밋",
   "agentManager.session.new": "새 세션",
+  "agentManager.session.reopen": "닫힌 세션 다시 열기",
   "agentManager.session.untitled": "제목 없음",
   "agentManager.session.newSession": "새 세션",
   "agentManager.session.openInWorktree": "Worktree에서 열기",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.hoverCard.commits": "Commits",
 
   "agentManager.session.new": "Nieuwe sessie",
+  "agentManager.session.reopen": "Gesloten sessie heropenen",
   "agentManager.session.untitled": "Naamloos",
   "agentManager.session.newSession": "Nieuwe sessie",
   "agentManager.session.openInWorktree": "Openen in worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "Endringer",
   "agentManager.hoverCard.commits": "Commits",
   "agentManager.session.new": "Ny økt",
+  "agentManager.session.reopen": "Gjenåpne lukket økt",
   "agentManager.session.untitled": "Uten tittel",
   "agentManager.session.newSession": "Ny økt",
   "agentManager.session.openInWorktree": "Åpne i Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "Zmiany",
   "agentManager.hoverCard.commits": "Commity",
   "agentManager.session.new": "Nowa sesja",
+  "agentManager.session.reopen": "Otwórz ponownie zamkniętą sesję",
   "agentManager.session.untitled": "Bez tytułu",
   "agentManager.session.newSession": "Nowa sesja",
   "agentManager.session.openInWorktree": "Otwórz w Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "Изменения",
   "agentManager.hoverCard.commits": "Коммиты",
   "agentManager.session.new": "Новая сессия",
+  "agentManager.session.reopen": "Открыть закрытую сессию",
   "agentManager.session.untitled": "Без названия",
   "agentManager.session.newSession": "Новая сессия",
   "agentManager.session.openInWorktree": "Открыть в Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "การเปลี่ยนแปลง",
   "agentManager.hoverCard.commits": "คอมมิต",
   "agentManager.session.new": "เซสชันใหม่",
+  "agentManager.session.reopen": "เปิดเซสชันที่ปิดอีกครั้ง",
   "agentManager.session.untitled": "ไม่มีชื่อ",
   "agentManager.session.newSession": "เซสชันใหม่",
   "agentManager.session.openInWorktree": "เปิดใน Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -29,6 +29,7 @@ export const dict = {
   "agentManager.hoverCard.commits": "Commit'ler",
 
   "agentManager.session.new": "Yeni oturum",
+  "agentManager.session.reopen": "Kapatılmış oturumu yeniden aç",
   "agentManager.session.untitled": "Adsız",
   "agentManager.session.newSession": "Yeni Oturum",
   "agentManager.session.openInWorktree": "Worktree içinde aç",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "更改",
   "agentManager.hoverCard.commits": "提交",
   "agentManager.session.new": "新建会话",
+  "agentManager.session.reopen": "重新打开已关闭的会话",
   "agentManager.session.untitled": "无标题",
   "agentManager.session.newSession": "新建会话",
   "agentManager.session.openInWorktree": "在 Worktree 中打开",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -26,6 +26,7 @@ export const dict = {
   "agentManager.hoverCard.changes": "變更",
   "agentManager.hoverCard.commits": "提交",
   "agentManager.session.new": "新建工作階段",
+  "agentManager.session.reopen": "重新開啟已關閉的工作階段",
   "agentManager.session.untitled": "未命名",
   "agentManager.session.newSession": "新建工作階段",
   "agentManager.session.openInWorktree": "在 Worktree 中開啟",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -784,6 +784,8 @@ export interface ManagedSessionState {
   id: string
   worktreeId: string | null
   createdAt: string
+  /** When true the session tab is hidden but the association is preserved. */
+  closed?: boolean
 }
 
 // Agent Manager session added to an existing worktree (no setup overlay needed)
@@ -1635,6 +1637,12 @@ export interface CloseSessionRequest {
   sessionId: string
 }
 
+// Reopen a previously closed session tab
+export interface ReopenSessionRequest {
+  type: "agentManager.reopenSession"
+  sessionId: string
+}
+
 // Rename a worktree's display label
 export interface RenameWorktreeRequest {
   type: "agentManager.renameWorktree"
@@ -1950,6 +1958,7 @@ export type WebviewMessage =
   | AddSessionToWorktreeRequest
   | ForkSessionRequest
   | CloseSessionRequest
+  | ReopenSessionRequest
   | RenameWorktreeRequest
   | TelemetryRequest
   | RequestRepoInfoMessage


### PR DESCRIPTION
## Summary

Closing a session tab in the Agent Manager previously called `removeSession()` which permanently deleted the session from state (both in-memory and `.kilo/agent-manager.json`). This made it impossible to reopen the session or review its changes without the workaround of opening the worktree in a separate VS Code window.

This PR changes the close behavior to set a `closed` flag on the session instead of deleting it, preserving the session-worktree association. A history button appears in the tab bar when closed sessions exist, allowing users to reopen them.

## Changes

- **WorktreeStateManager**: Add `closeSession()` (sets `closed: true`) and `reopenSession()` (removes the flag), keeping `removeSession()` for actual deletion (e.g. worktree removal)
- **AgentManagerProvider**: `onCloseSession` now calls `closeSession` instead of `removeSession`; new `onReopenSession` handler re-registers the session directory and tracking
- **Webview**: Filter closed sessions from active tabs; add `closedWorktreeSessions` memo and a history dropdown button to reopen them
- **Types/Messages**: Add `closed` field to `ManagedSession`/`ManagedSessionState`, add `ReopenSessionIn`/`ReopenSessionRequest` message types
- **i18n**: Add `agentManager.session.reopen` key to all 18 locales

Fixes #7586