### PR TITLE
fix(vscode): prevent Escape in slash/mention menus from aborting agent

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -79,7 +79,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   onMount(() => {
     if (props.readonly) return
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && session.status() === "busy") {
+      if (e.key === "Escape" && session.status() === "busy" && !e.defaultPrevented) {
         e.preventDefault()
         session.abort()
       }

--- a/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
@@ -152,6 +152,7 @@ export function useFileMention(vscode: VSCodeContext): FileMention {
     }
     if (e.key === "Escape") {
       e.preventDefault()
+      e.stopPropagation()
       closeMention()
       return true
     }

--- a/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
@@ -205,6 +205,7 @@ export function useSlashCommand(vscode: VSCodeContext, exclude?: Set<string>): S
     }
     if (e.key === "Escape") {
       e.preventDefault()
+      e.stopPropagation()
       close()
       return true
     }


### PR DESCRIPTION
## Summary

- Pressing Escape while the `/` command menu or `@` mention menu is open no longer aborts the running agent — it just closes the menu.

## Problem

Solid.js delegates `onKeyDown` handlers to the `document` level. ChatView registers a separate `document.addEventListener("keydown", ...)` that calls `session.abort()` on Escape. Both handlers fire at the same DOM level, so `stopPropagation()` from the menu handlers has no effect on the ChatView listener.

## Fix

Added `!e.defaultPrevented` check to ChatView's global Escape handler. The slash command and file mention hooks already call `e.preventDefault()` when closing their menus, so the ChatView handler now respects that signal and skips the abort.