### PR TITLE
fix(vscode): force CLI backend rebuild on F5 compile

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -743,7 +743,7 @@
   },
   "scripts": {
     "prepare:cli-binary": "bun script/local-bin.ts",
-    "compile": "bun run prepare:cli-binary && bun run rebuild-sdk && bun run typecheck && bun run lint && node esbuild.js",
+    "compile": "bun run prepare:cli-binary -- --force && bun run rebuild-sdk && bun run typecheck && bun run lint && node esbuild.js",
     "watch": "bun run rebuild-sdk && bun run --parallel watch:esbuild watch:tsc",
     "watch:esbuild": "bun run prepare:cli-binary && node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",


### PR DESCRIPTION
## Summary
- Force-rebuild the CLI backend binary (`bin/kilo`) every time the `compile` script runs (F5 preLaunchTask)
- Previously, `local-bin.ts` only rebuilt when it detected dirty/stale state in `packages/opencode/` via git, which could miss changes in dependency packages (e.g. `kilo-gateway`, `util`, `plugin`)
- Passes `--force` to `prepare:cli-binary` in the `compile` script so the backend is always fresh when launching the extension with F5
