### PR TITLE
fix(vscode): add padding to marketplace install dialog

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/marketplace/marketplace.css
+++ b/packages/kilo-vscode/webview-ui/src/components/marketplace/marketplace.css
@@ -214,6 +214,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  padding: 0 20px 20px;
 }
 
 .install-modal-section {
@@ -247,7 +248,7 @@
 
 .install-modal-result {
   text-align: center;
-  padding: 12px 0;
+  padding: 12px 20px 20px;
 }
 
 .install-modal-success {


### PR DESCRIPTION
## Summary
- Add horizontal (`20px`) and bottom padding to the marketplace install dialog body (`.install-modal-body`) and result view (`.install-modal-result`)
- Content was previously flush against the dialog edges with no spacing, making it look cramped
- Padding now matches the dialog header's horizontal spacing for visual consistency

| Before | After |
| --- | --- |
| <img width="1268" height="940" alt="CleanShot 2026-03-26 at 11 26 49@2x" src="https://github.com/user-attachments/assets/d76e3d26-8b34-4252-9e88-021b44969c17" />| <img width="1164" height="982" alt="CleanShot 2026-03-26 at 11 27 16@2x" src="https://github.com/user-attachments/assets/a2403b4d-6b8c-4616-8adf-7eaf620c053b" /> |

fixes https://github.com/Kilo-Org/kilocode/issues/7665
