### PR TITLE
fix(vscode): keep /new sessions in the active worktree

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -28,6 +28,7 @@ import {
   isEventFromForeignProject,
   loadSessions as loadSessionsUtil,
   flushPendingSessionRefresh as flushPendingSessionRefreshUtil,
+  resolveWorkspaceDirectory,
   type SessionRefreshContext,
 } from "./kilo-provider-utils"
 import { MarketplaceService } from "./services/marketplace"
@@ -86,6 +87,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
   private webview: vscode.Webview | null = null
   private currentSession: Session | null = null
+  /** Remembers the last selected session so /new can stay in the same worktree after clearSession. */
+  private contextSessionID: string | undefined
   private connectionState: "connecting" | "connected" | "disconnected" | "error" = "connecting"
   private loginAttempt = 0
   private isWebviewReady = false
@@ -330,6 +333,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    */
   public registerSession(session: Session): void {
     this.currentSession = session
+    this.contextSessionID = session.id
     this.trackedSessionIds.add(session.id)
     this.postMessage({
       type: "sessionCreated",
@@ -506,6 +510,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           await this.handleCreateSession()
           break
         case "clearSession":
+          this.contextSessionID = this.currentSession?.id ?? this.contextSessionID
           this.currentSession = null
           break
         case "loadMessages":
@@ -1034,6 +1039,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const workspaceDir = this.getWorkspaceDirectory()
       const { data: session } = await this.client.session.create({ directory: workspaceDir }, { throwOnError: true })
       this.currentSession = session
+      this.contextSessionID = session.id
       this.trackedSessionIds.add(session.id)
 
       // Notify webview of the new session
@@ -1056,6 +1062,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private async handleLoadMessages(sessionID: string): Promise<void> {
     // Track the session so we receive its SSE events
     this.trackedSessionIds.add(sessionID)
+    this.contextSessionID = sessionID
 
     if (!this.client) {
       this.postMessage({
@@ -1094,6 +1101,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         .then((result) => {
           if (result.data && !abort.signal.aborted) {
             this.currentSession = result.data
+            this.contextSessionID = result.data.id
           }
         })
         .catch((err: unknown) => console.warn("[Kilo New] KiloProvider: getSession failed (non-critical):", err))
@@ -1886,6 +1894,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (!sessionID && !this.currentSession) {
       const { data: session } = await this.client.session.create({ directory: dir }, { throwOnError: true })
       this.currentSession = session
+      this.contextSessionID = session.id
       this.trackedSessionIds.add(session.id)
       this.postMessage({
         type: "sessionCreated",
@@ -2145,6 +2154,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       },
       set currentSession(session) {
         self.currentSession = session
+        if (session) self.contextSessionID = session.id
       },
       trackedSessionIds: this.trackedSessionIds,
       connectionService: this.connectionService,
@@ -2384,10 +2394,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // Side effects that must happen before the webview message is sent
     if (event.type === "session.created" && !this.currentSession) {
       this.currentSession = event.properties.info
+      this.contextSessionID = event.properties.info.id
       this.trackedSessionIds.add(event.properties.info.id)
     }
     if (event.type === "session.updated" && this.currentSession?.id === event.properties.info.id) {
       this.currentSession = event.properties.info
+      this.contextSessionID = event.properties.info.id
     }
 
     const msg = mapSSEEventToWebviewMessage(event, sessionID)
@@ -2571,15 +2583,17 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * Checks session directory overrides first (e.g., worktree paths), then falls back to workspace root.
    */
   private getWorkspaceDirectory(sessionId?: string): string {
-    if (sessionId) {
-      const dir = this.sessionDirectories.get(sessionId)
-      if (dir) return dir
-    }
     const workspaceFolders = vscode.workspace.workspaceFolders
-    if (workspaceFolders && workspaceFolders.length > 0) {
-      return workspaceFolders[0].uri.fsPath
-    }
-    return process.cwd()
+    const workspaceDirectory =
+      workspaceFolders && workspaceFolders.length > 0 ? workspaceFolders[0].uri.fsPath : process.cwd()
+
+    return resolveWorkspaceDirectory({
+      sessionID: sessionId,
+      currentSessionID: this.currentSession?.id,
+      contextSessionID: this.contextSessionID,
+      sessionDirectories: this.sessionDirectories,
+      workspaceDirectory,
+    })
   }
 
   private getProjectDirectory(sessionId?: string): string | undefined {

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -28,6 +28,7 @@ import {
   isEventFromForeignProject,
   loadSessions as loadSessionsUtil,
   flushPendingSessionRefresh as flushPendingSessionRefreshUtil,
+  resolveContextDirectory,
   resolveWorkspaceDirectory,
   type SessionRefreshContext,
 } from "./kilo-provider-utils"
@@ -1036,10 +1037,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     try {
-      const workspaceDir = this.getWorkspaceDirectory()
+      const workspaceDir = this.getContextDirectory()
       const { data: session } = await this.client.session.create({ directory: workspaceDir }, { throwOnError: true })
       this.currentSession = session
       this.contextSessionID = session.id
+      this.trackDirectory(session.id, workspaceDir)
       this.trackedSessionIds.add(session.id)
 
       // Notify webview of the new session
@@ -1889,12 +1891,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private async resolveSession(sessionID?: string): Promise<{ sid: string; dir: string } | undefined> {
     if (!this.client) return undefined
 
-    const dir = this.getWorkspaceDirectory(sessionID || this.currentSession?.id)
+    const dir = sessionID ? this.getWorkspaceDirectory(sessionID) : this.getContextDirectory()
 
     if (!sessionID && !this.currentSession) {
       const { data: session } = await this.client.session.create({ directory: dir }, { throwOnError: true })
       this.currentSession = session
       this.contextSessionID = session.id
+      this.trackDirectory(session.id, dir)
       this.trackedSessionIds.add(session.id)
       this.postMessage({
         type: "sessionCreated",
@@ -2295,7 +2298,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       if (!key.startsWith(prefix)) continue
       const parts = key.split(".")
       const section = parts.slice(0, -1).join(".")
-      const leaf = parts[parts.length - 1]
+      const leaf = parts[parts.length - 1]!
       const config = vscode.workspace.getConfiguration(section)
       await config.update(leaf, undefined, vscode.ConfigurationTarget.Global)
     }
@@ -2583,17 +2586,36 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * Checks session directory overrides first (e.g., worktree paths), then falls back to workspace root.
    */
   private getWorkspaceDirectory(sessionId?: string): string {
-    const workspaceFolders = vscode.workspace.workspaceFolders
-    const workspaceDirectory =
-      workspaceFolders && workspaceFolders.length > 0 ? workspaceFolders[0].uri.fsPath : process.cwd()
-
     return resolveWorkspaceDirectory({
       sessionID: sessionId,
+      sessionDirectories: this.sessionDirectories,
+      workspaceDirectory: this.getRootDirectory(),
+    })
+  }
+
+  private getContextDirectory(): string {
+    return resolveContextDirectory({
       currentSessionID: this.currentSession?.id,
       contextSessionID: this.contextSessionID,
       sessionDirectories: this.sessionDirectories,
-      workspaceDirectory,
+      workspaceDirectory: this.getRootDirectory(),
     })
+  }
+
+  private getRootDirectory(): string {
+    const workspaceFolders = vscode.workspace.workspaceFolders
+    if (workspaceFolders && workspaceFolders.length > 0) {
+      return workspaceFolders[0]!.uri.fsPath
+    }
+    return process.cwd()
+  }
+
+  private trackDirectory(sessionId: string, dir: string) {
+    if (path.resolve(dir) === path.resolve(this.getRootDirectory())) {
+      this.sessionDirectories.delete(sessionId)
+      return
+    }
+    this.sessionDirectories.set(sessionId, dir)
   }
 
   private getProjectDirectory(sessionId?: string): string | undefined {

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -167,6 +167,22 @@ export function buildSettingPath(key: string): { section: string; leaf: string }
   return { section, leaf }
 }
 
+export function resolveWorkspaceDirectory(input: {
+  sessionID?: string
+  currentSessionID?: string
+  contextSessionID?: string
+  sessionDirectories: Map<string, string>
+  workspaceDirectory: string
+}) {
+  const target = input.sessionID ?? input.currentSessionID ?? input.contextSessionID
+  if (!target) return input.workspaceDirectory
+
+  const dir = input.sessionDirectories.get(target)
+  if (dir) return dir
+
+  return input.workspaceDirectory
+}
+
 export type WebviewMessage =
   | {
       type: "partUpdated"

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -169,18 +169,28 @@ export function buildSettingPath(key: string): { section: string; leaf: string }
 
 export function resolveWorkspaceDirectory(input: {
   sessionID?: string
+  sessionDirectories: Map<string, string>
+  workspaceDirectory: string
+}) {
+  if (!input.sessionID) return input.workspaceDirectory
+
+  const dir = input.sessionDirectories.get(input.sessionID)
+  if (dir) return dir
+
+  return input.workspaceDirectory
+}
+
+export function resolveContextDirectory(input: {
   currentSessionID?: string
   contextSessionID?: string
   sessionDirectories: Map<string, string>
   workspaceDirectory: string
 }) {
-  const target = input.sessionID ?? input.currentSessionID ?? input.contextSessionID
-  if (!target) return input.workspaceDirectory
-
-  const dir = input.sessionDirectories.get(target)
-  if (dir) return dir
-
-  return input.workspaceDirectory
+  return resolveWorkspaceDirectory({
+    sessionID: input.currentSessionID ?? input.contextSessionID,
+    sessionDirectories: input.sessionDirectories,
+    workspaceDirectory: input.workspaceDirectory,
+  })
 }
 
 export type WebviewMessage =

--- a/packages/kilo-vscode/tests/unit/kilo-provider-worktree-context.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-worktree-context.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test"
+import { resolveWorkspaceDirectory } from "../../src/kilo-provider-utils"
+
+describe("resolveWorkspaceDirectory", () => {
+  it("uses the active session worktree when a worktree session is selected", () => {
+    const dir = resolveWorkspaceDirectory({
+      currentSessionID: "ses_worktree",
+      sessionDirectories: new Map([["ses_worktree", "/repo/.kilo/worktrees/feature"]]),
+      workspaceDirectory: "/repo",
+    })
+
+    expect(dir).toBe("/repo/.kilo/worktrees/feature")
+  })
+
+  it("keeps the last worktree after clearSession removes the active session", () => {
+    const dir = resolveWorkspaceDirectory({
+      contextSessionID: "ses_worktree",
+      sessionDirectories: new Map([["ses_worktree", "/repo/.kilo/worktrees/feature"]]),
+      workspaceDirectory: "/repo",
+    })
+
+    expect(dir).toBe("/repo/.kilo/worktrees/feature")
+  })
+
+  it("falls back to the workspace root when no worktree override exists", () => {
+    const dir = resolveWorkspaceDirectory({
+      contextSessionID: "ses_local",
+      sessionDirectories: new Map(),
+      workspaceDirectory: "/repo",
+    })
+
+    expect(dir).toBe("/repo")
+  })
+})

--- a/packages/kilo-vscode/tests/unit/kilo-provider-worktree-context.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-worktree-context.test.ts
@@ -1,9 +1,30 @@
 import { describe, expect, it } from "bun:test"
-import { resolveWorkspaceDirectory } from "../../src/kilo-provider-utils"
+import { resolveContextDirectory, resolveWorkspaceDirectory } from "../../src/kilo-provider-utils"
 
 describe("resolveWorkspaceDirectory", () => {
-  it("uses the active session worktree when a worktree session is selected", () => {
+  it("uses an explicit session worktree override", () => {
     const dir = resolveWorkspaceDirectory({
+      sessionID: "ses_worktree",
+      sessionDirectories: new Map([["ses_worktree", "/repo/.kilo/worktrees/feature"]]),
+      workspaceDirectory: "/repo",
+    })
+
+    expect(dir).toBe("/repo/.kilo/worktrees/feature")
+  })
+
+  it("falls back to the workspace root without a session id", () => {
+    const dir = resolveWorkspaceDirectory({
+      sessionDirectories: new Map([["ses_worktree", "/repo/.kilo/worktrees/feature"]]),
+      workspaceDirectory: "/repo",
+    })
+
+    expect(dir).toBe("/repo")
+  })
+})
+
+describe("resolveContextDirectory", () => {
+  it("uses the active session worktree when a worktree session is selected", () => {
+    const dir = resolveContextDirectory({
       currentSessionID: "ses_worktree",
       sessionDirectories: new Map([["ses_worktree", "/repo/.kilo/worktrees/feature"]]),
       workspaceDirectory: "/repo",
@@ -13,7 +34,7 @@ describe("resolveWorkspaceDirectory", () => {
   })
 
   it("keeps the last worktree after clearSession removes the active session", () => {
-    const dir = resolveWorkspaceDirectory({
+    const dir = resolveContextDirectory({
       contextSessionID: "ses_worktree",
       sessionDirectories: new Map([["ses_worktree", "/repo/.kilo/worktrees/feature"]]),
       workspaceDirectory: "/repo",
@@ -23,7 +44,7 @@ describe("resolveWorkspaceDirectory", () => {
   })
 
   it("falls back to the workspace root when no worktree override exists", () => {
-    const dir = resolveWorkspaceDirectory({
+    const dir = resolveContextDirectory({
       contextSessionID: "ses_local",
       sessionDirectories: new Map(),
       workspaceDirectory: "/repo",


### PR DESCRIPTION
## Summary
- remember the last selected session when clearing Agent Manager chat state so `/new` keeps using the active worktree
- route workspace directory resolution through the remembered session context instead of falling back to the repo root
- add a regression test for worktree directory resolution after `clearSession`

## Testing
- bun test tests/unit/kilo-provider-worktree-context.test.ts tests/unit/session-model-store.test.ts

Fixes #7655.
Related #7679.