### PR TITLE
Cli - Add configurable session retry limit

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -35,7 +35,6 @@ export namespace Flag {
   export const KILO_SERVER_PASSWORD = process.env["KILO_SERVER_PASSWORD"]
   export const KILO_SERVER_USERNAME = process.env["KILO_SERVER_USERNAME"]
   export const KILO_ENABLE_QUESTION_TOOL = truthy("KILO_ENABLE_QUESTION_TOOL")
-
   // Experimental
   export const KILO_EXPERIMENTAL = truthy("KILO_EXPERIMENTAL")
   export const KILO_EXPERIMENTAL_FILEWATCHER = truthy("KILO_EXPERIMENTAL_FILEWATCHER")
@@ -58,6 +57,7 @@ export namespace Flag {
   export const KILO_MODELS_URL = process.env["KILO_MODELS_URL"]
   export const KILO_MODELS_PATH = process.env["KILO_MODELS_PATH"]
   export const KILO_SKIP_MIGRATIONS = truthy("KILO_SKIP_MIGRATIONS")
+  export declare const KILO_SESSION_RETRY_LIMIT: number | undefined
 
   function number(key: string) {
     const value = process.env[key]
@@ -106,6 +106,20 @@ Object.defineProperty(Flag, "KILO_CONFIG_DIR", {
 Object.defineProperty(Flag, "KILO_CLIENT", {
   get() {
     return process.env["KILO_CLIENT"] ?? "cli"
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+// Dynamic getter for KILO_SESSION_RETRY_LIMIT
+// This must be evaluated at access time, not module load time,
+// because tests and runtime tooling may set this env var later
+Object.defineProperty(Flag, "KILO_SESSION_RETRY_LIMIT", {
+  get() {
+    const value = process.env["KILO_SESSION_RETRY_LIMIT"]
+    if (!value) return undefined
+    const parsed = Number(value)
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
   },
   enumerable: true,
   configurable: false,

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -35,6 +35,7 @@ export namespace Flag {
   export const KILO_SERVER_PASSWORD = process.env["KILO_SERVER_PASSWORD"]
   export const KILO_SERVER_USERNAME = process.env["KILO_SERVER_USERNAME"]
   export const KILO_ENABLE_QUESTION_TOOL = truthy("KILO_ENABLE_QUESTION_TOOL")
+
   // Experimental
   export const KILO_EXPERIMENTAL = truthy("KILO_EXPERIMENTAL")
   export const KILO_EXPERIMENTAL_FILEWATCHER = truthy("KILO_EXPERIMENTAL_FILEWATCHER")
@@ -57,7 +58,6 @@ export namespace Flag {
   export const KILO_MODELS_URL = process.env["KILO_MODELS_URL"]
   export const KILO_MODELS_PATH = process.env["KILO_MODELS_PATH"]
   export const KILO_SKIP_MIGRATIONS = truthy("KILO_SKIP_MIGRATIONS")
-  export declare const KILO_SESSION_RETRY_LIMIT: number | undefined
 
   function number(key: string) {
     const value = process.env[key]
@@ -65,6 +65,8 @@ export namespace Flag {
     const parsed = Number(value)
     return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
   }
+
+  export const KILO_SESSION_RETRY_LIMIT = number("KILO_SESSION_RETRY_LIMIT")
 }
 
 // Dynamic getter for KILO_DISABLE_PROJECT_CONFIG
@@ -106,20 +108,6 @@ Object.defineProperty(Flag, "KILO_CONFIG_DIR", {
 Object.defineProperty(Flag, "KILO_CLIENT", {
   get() {
     return process.env["KILO_CLIENT"] ?? "cli"
-  },
-  enumerable: true,
-  configurable: false,
-})
-
-// Dynamic getter for KILO_SESSION_RETRY_LIMIT
-// This must be evaluated at access time, not module load time,
-// because tests and runtime tooling may set this env var later
-Object.defineProperty(Flag, "KILO_SESSION_RETRY_LIMIT", {
-  get() {
-    const value = process.env["KILO_SESSION_RETRY_LIMIT"]
-    if (!value) return undefined
-    const parsed = Number(value)
-    return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
   },
   enumerable: true,
   configurable: false,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -16,6 +16,7 @@ import { SessionCompaction } from "./compaction"
 import { PermissionNext } from "@/permission/next"
 import { Question } from "@/question"
 import { Telemetry } from "@kilocode/kilo-telemetry" // kilocode_change
+import { Flag } from "@/flag/flag" // kilocode_change
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
@@ -387,7 +388,11 @@ export namespace SessionProcessor {
               })
             } else {
               const retry = SessionRetry.retryable(error)
-              if (retry !== undefined) {
+              if (
+                retry !== undefined &&
+                (Flag.KILO_SESSION_RETRY_LIMIT === undefined || attempt < Flag.KILO_SESSION_RETRY_LIMIT)
+              ) {
+                // kilocode_change
                 attempt++
                 const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
                 SessionStatus.set(input.sessionID, {

--- a/packages/opencode/test/kilocode/session-processor-retry-limit.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-retry-limit.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+
+mock.module("@/kilo-sessions/remote-sender", () => ({
+  RemoteSender: {
+    create() {
+      return {
+        queue() {},
+        flush: async () => undefined,
+      }
+    },
+  },
+}))
+
+import { APICallError } from "ai"
+import { Bus } from "../../src/bus"
+import { Flag } from "../../src/flag/flag"
+import { Identifier } from "../../src/id/id"
+import { Instance } from "../../src/project/instance"
+import type { Provider } from "../../src/provider/provider"
+import { LLM } from "../../src/session/llm"
+import type { LLM as LLMType } from "../../src/session/llm"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionRetry } from "../../src/session/retry"
+import { SessionStatus } from "../../src/session/status"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+function createModel(): Provider.Model {
+  return {
+    id: "gpt-4",
+    providerID: "openai",
+    name: "GPT-4",
+    limit: {
+      context: 128000,
+      input: 0,
+      output: 4096,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    capabilities: {
+      toolcall: true,
+      attachment: false,
+      reasoning: false,
+      temperature: true,
+      input: { text: true, image: false, audio: false, video: false },
+      output: { text: true, image: false, audio: false, video: false },
+    },
+    api: { id: "openai", url: "https://api.openai.com/v1", npm: "@ai-sdk/openai" },
+    options: {},
+    headers: {},
+  } as Provider.Model
+}
+
+function retryable429() {
+  return new APICallError({
+    message: "429 status code (no body)",
+    url: "https://api.openai.com/v1/chat/completions",
+    requestBodyValues: {},
+    statusCode: 429,
+    responseHeaders: { "content-type": "application/json" },
+    isRetryable: true,
+  })
+}
+
+function sentinel() {
+  return new Error("unexpected extra llm call")
+}
+
+async function seed(model: Provider.Model) {
+  const { Session } = await import("../../src/session")
+  const session = await Session.create({})
+  const user = (await Session.updateMessage({
+    id: Identifier.ascending("message"),
+    role: "user",
+    sessionID: session.id,
+    time: { created: Date.now() },
+    agent: "code",
+    model: { providerID: model.providerID, modelID: model.id },
+    tools: {},
+  })) as MessageV2.User
+  const assistant = (await Session.updateMessage({
+    id: Identifier.ascending("message"),
+    parentID: user.id,
+    role: "assistant",
+    mode: "code",
+    agent: "code",
+    path: {
+      cwd: Instance.directory,
+      root: Instance.worktree,
+    },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    modelID: model.id,
+    providerID: model.providerID,
+    time: { created: Date.now() },
+    sessionID: session.id,
+  })) as MessageV2.Assistant
+  return { assistant, session, user }
+}
+
+function input(model: Provider.Model, sessionID: string, user: MessageV2.User): LLMType.StreamInput {
+  return {
+    user,
+    sessionID,
+    model,
+    agent: { name: "code", mode: "primary", permission: [], options: {} } as any,
+    system: [],
+    abort: AbortSignal.any([]),
+    messages: [],
+    tools: {},
+  }
+}
+
+afterEach(() => {
+  delete process.env.KILO_SESSION_RETRY_LIMIT
+})
+
+describe("session processor retry limit", () => {
+  test("stops after two retries with the normalized retryable error", async () => {
+    await using tmp = await tmpdir({ git: true })
+    process.env.KILO_SESSION_RETRY_LIMIT = "2"
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { Session } = await import("../../src/session")
+        const { SessionProcessor } = await import("../../src/session/processor")
+        const model = createModel()
+        const seeded = await seed(model)
+        const retry: number[] = []
+        const errors: Array<MessageV2.Assistant["error"]> = []
+        const unsubStatus = Bus.subscribe(SessionStatus.Event.Status, (event) => {
+          if (event.properties.sessionID !== seeded.session.id) return
+          if (event.properties.status.type !== "retry") return
+          retry.push(event.properties.status.attempt)
+        })
+        const unsubError = Bus.subscribe(Session.Event.Error, (event) => {
+          if (event.properties.sessionID !== seeded.session.id) return
+          errors.push(event.properties.error)
+        })
+        const llm = spyOn(LLM, "stream")
+          .mockRejectedValueOnce(retryable429())
+          .mockRejectedValueOnce(retryable429())
+          .mockRejectedValueOnce(retryable429())
+          .mockRejectedValue(sentinel())
+        const sleep = spyOn(SessionRetry, "sleep").mockResolvedValue(undefined)
+        const processor = SessionProcessor.create({
+          assistantMessage: seeded.assistant,
+          sessionID: seeded.session.id,
+          model,
+          abort: AbortSignal.any([]),
+        })
+
+        try {
+          const result = await processor.process(input(model, seeded.session.id, seeded.user))
+          const expected = MessageV2.fromError(retryable429(), { providerID: "openai" })
+
+          expect(result).toBe("stop")
+          expect(llm).toHaveBeenCalledTimes(3)
+          expect(sleep).toHaveBeenCalledTimes(2)
+          expect(retry).toStrictEqual([1, 2])
+          expect(processor.message.error).toStrictEqual(expected)
+          expect(errors).toStrictEqual([expected])
+        } finally {
+          unsubStatus()
+          unsubError()
+          llm.mockRestore()
+          sleep.mockRestore()
+        }
+      },
+    })
+  })
+
+  test("only positive integers enable the limit", () => {
+    delete process.env.KILO_SESSION_RETRY_LIMIT
+    expect(Flag.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
+
+    process.env.KILO_SESSION_RETRY_LIMIT = "0"
+    expect(Flag.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
+
+    process.env.KILO_SESSION_RETRY_LIMIT = "-1"
+    expect(Flag.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
+
+    process.env.KILO_SESSION_RETRY_LIMIT = "abc"
+    expect(Flag.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
+
+    process.env.KILO_SESSION_RETRY_LIMIT = "2"
+    expect(Flag.KILO_SESSION_RETRY_LIMIT).toBe(2)
+  })
+})

--- a/packages/opencode/test/kilocode/session-processor-retry-limit.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-retry-limit.test.ts
@@ -1,3 +1,9 @@
+// Set env before any imports that transitively load flag.ts (e.g. LLM, SessionRetry).
+// This MUST happen before static imports, but ES module imports are hoisted.
+// So we set it here and use mock.module + dynamic imports for modules that
+// transitively load flag.ts to ensure the env is captured at load time.
+process.env.KILO_SESSION_RETRY_LIMIT = "2"
+
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 
 mock.module("@/kilo-sessions/remote-sender", () => ({
@@ -11,17 +17,11 @@ mock.module("@/kilo-sessions/remote-sender", () => ({
   },
 }))
 
+// Modules that do NOT transitively import flag.ts can be statically imported.
 import { APICallError } from "ai"
-import { Bus } from "../../src/bus"
-import { Flag } from "../../src/flag/flag"
-import { Identifier } from "../../src/id/id"
-import { Instance } from "../../src/project/instance"
 import type { Provider } from "../../src/provider/provider"
-import { LLM } from "../../src/session/llm"
 import type { LLM as LLMType } from "../../src/session/llm"
-import { MessageV2 } from "../../src/session/message-v2"
-import { SessionRetry } from "../../src/session/retry"
-import { SessionStatus } from "../../src/session/status"
+import type { MessageV2 } from "../../src/session/message-v2"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 
@@ -67,64 +67,22 @@ function sentinel() {
   return new Error("unexpected extra llm call")
 }
 
-async function seed(model: Provider.Model) {
-  const { Session } = await import("../../src/session")
-  const session = await Session.create({})
-  const user = (await Session.updateMessage({
-    id: Identifier.ascending("message"),
-    role: "user",
-    sessionID: session.id,
-    time: { created: Date.now() },
-    agent: "code",
-    model: { providerID: model.providerID, modelID: model.id },
-    tools: {},
-  })) as MessageV2.User
-  const assistant = (await Session.updateMessage({
-    id: Identifier.ascending("message"),
-    parentID: user.id,
-    role: "assistant",
-    mode: "code",
-    agent: "code",
-    path: {
-      cwd: Instance.directory,
-      root: Instance.worktree,
-    },
-    cost: 0,
-    tokens: {
-      input: 0,
-      output: 0,
-      reasoning: 0,
-      cache: { read: 0, write: 0 },
-    },
-    modelID: model.id,
-    providerID: model.providerID,
-    time: { created: Date.now() },
-    sessionID: session.id,
-  })) as MessageV2.Assistant
-  return { assistant, session, user }
-}
-
-function input(model: Provider.Model, sessionID: string, user: MessageV2.User): LLMType.StreamInput {
-  return {
-    user,
-    sessionID,
-    model,
-    agent: { name: "code", mode: "primary", permission: [], options: {} } as any,
-    system: [],
-    abort: AbortSignal.any([]),
-    messages: [],
-    tools: {},
-  }
-}
-
 afterEach(() => {
   delete process.env.KILO_SESSION_RETRY_LIMIT
 })
 
 describe("session processor retry limit", () => {
   test("stops after two retries with the normalized retryable error", async () => {
+    // Dynamic imports so that flag.ts sees KILO_SESSION_RETRY_LIMIT="2" set above
+    const { Bus } = await import("../../src/bus")
+    const { Identifier } = await import("../../src/id/id")
+    const { Instance } = await import("../../src/project/instance")
+    const { LLM } = await import("../../src/session/llm")
+    const { MessageV2 } = await import("../../src/session/message-v2")
+    const { SessionRetry } = await import("../../src/session/retry")
+    const { SessionStatus } = await import("../../src/session/status")
+
     await using tmp = await tmpdir({ git: true })
-    process.env.KILO_SESSION_RETRY_LIMIT = "2"
 
     await Instance.provide({
       directory: tmp.path,
@@ -132,16 +90,48 @@ describe("session processor retry limit", () => {
         const { Session } = await import("../../src/session")
         const { SessionProcessor } = await import("../../src/session/processor")
         const model = createModel()
-        const seeded = await seed(model)
+        const session = await Session.create({})
+        const user = (await Session.updateMessage({
+          id: Identifier.ascending("message"),
+          role: "user",
+          sessionID: session.id,
+          time: { created: Date.now() },
+          agent: "code",
+          model: { providerID: model.providerID, modelID: model.id },
+          tools: {},
+        })) as MessageV2.User
+        const assistant = (await Session.updateMessage({
+          id: Identifier.ascending("message"),
+          parentID: user.id,
+          role: "assistant",
+          mode: "code",
+          agent: "code",
+          path: {
+            cwd: Instance.directory,
+            root: Instance.worktree,
+          },
+          cost: 0,
+          tokens: {
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          modelID: model.id,
+          providerID: model.providerID,
+          time: { created: Date.now() },
+          sessionID: session.id,
+        })) as MessageV2.Assistant
+
         const retry: number[] = []
         const errors: Array<MessageV2.Assistant["error"]> = []
         const unsubStatus = Bus.subscribe(SessionStatus.Event.Status, (event) => {
-          if (event.properties.sessionID !== seeded.session.id) return
+          if (event.properties.sessionID !== session.id) return
           if (event.properties.status.type !== "retry") return
           retry.push(event.properties.status.attempt)
         })
         const unsubError = Bus.subscribe(Session.Event.Error, (event) => {
-          if (event.properties.sessionID !== seeded.session.id) return
+          if (event.properties.sessionID !== session.id) return
           errors.push(event.properties.error)
         })
         const llm = spyOn(LLM, "stream")
@@ -151,14 +141,25 @@ describe("session processor retry limit", () => {
           .mockRejectedValue(sentinel())
         const sleep = spyOn(SessionRetry, "sleep").mockResolvedValue(undefined)
         const processor = SessionProcessor.create({
-          assistantMessage: seeded.assistant,
-          sessionID: seeded.session.id,
+          assistantMessage: assistant,
+          sessionID: session.id,
           model,
           abort: AbortSignal.any([]),
         })
 
+        const inp: LLMType.StreamInput = {
+          user,
+          sessionID: session.id,
+          model,
+          agent: { name: "code", mode: "primary", permission: [], options: {} } as any,
+          system: [],
+          abort: AbortSignal.any([]),
+          messages: [],
+          tools: {},
+        }
+
         try {
-          const result = await processor.process(input(model, seeded.session.id, seeded.user))
+          const result = await processor.process(inp)
           const expected = MessageV2.fromError(retryable429(), { providerID: "openai" })
 
           expect(result).toBe("stop")
@@ -177,20 +178,31 @@ describe("session processor retry limit", () => {
     })
   })
 
-  test("only positive integers enable the limit", () => {
+  test("only positive integers enable the limit", async () => {
+    const key = () => JSON.stringify({ time: Date.now(), rand: Math.random() })
+
     delete process.env.KILO_SESSION_RETRY_LIMIT
-    expect(Flag.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
+    expect((await import("../../src/flag/flag?" + key())).Flag.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
 
     process.env.KILO_SESSION_RETRY_LIMIT = "0"
-    expect(Flag.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
+    expect((await import("../../src/flag/flag?" + key())).Flag.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
 
     process.env.KILO_SESSION_RETRY_LIMIT = "-1"
-    expect(Flag.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
+    expect((await import("../../src/flag/flag?" + key())).Flag.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
 
     process.env.KILO_SESSION_RETRY_LIMIT = "abc"
-    expect(Flag.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
+    expect((await import("../../src/flag/flag?" + key())).Flag.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
 
     process.env.KILO_SESSION_RETRY_LIMIT = "2"
-    expect(Flag.KILO_SESSION_RETRY_LIMIT).toBe(2)
+    expect((await import("../../src/flag/flag?" + key())).Flag.KILO_SESSION_RETRY_LIMIT).toBe(2)
+  })
+
+  test("does not change after import", async () => {
+    delete process.env.KILO_SESSION_RETRY_LIMIT
+    const id = JSON.stringify({ time: Date.now(), rand: Math.random() })
+    const { Flag: loaded } = await import("../../src/flag/flag?" + id)
+    expect(loaded.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
+    process.env.KILO_SESSION_RETRY_LIMIT = "5"
+    expect(loaded.KILO_SESSION_RETRY_LIMIT).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- Add `KILO_SESSION_RETRY_LIMIT` as an optional positive-integer outer session retry cap.
- Stop the session with the normalized underlying error when that cap is exhausted.
- Add regression coverage for retry exhaustion and env parsing.