### PR TITLE
fix: make webfetch URL and open-url icon clickable to open in browser

### DIFF
--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -10,14 +10,12 @@ import type { QuestionAnswer } from "@kilocode/sdk/v2"
 import { decode64 } from "@/utils/base64"
 import { showToast } from "@opencode-ai/ui/toast"
 import { useLanguage } from "@/context/language"
-import { usePlatform } from "@/context/platform"
 
 function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
   const params = useParams()
   const navigate = useNavigate()
   const sync = useSync()
   const sdk = useSDK()
-  const platform = usePlatform()
 
   return (
     <DataProvider
@@ -33,7 +31,6 @@ function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
       onNavigateToSession={(sessionID: string) => navigate(`/${params.dir}/session/${sessionID}`)}
       onSessionHref={(sessionID: string) => `/${params.dir}/session/${sessionID}`}
       onSyncSession={(sessionID: string) => sync.session.sync(sessionID)}
-      onOpenUrl={(url: string) => platform.openLink(url)}
     >
       <LocalProvider>{props.children}</LocalProvider>
     </DataProvider>

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -10,12 +10,14 @@ import type { QuestionAnswer } from "@kilocode/sdk/v2"
 import { decode64 } from "@/utils/base64"
 import { showToast } from "@opencode-ai/ui/toast"
 import { useLanguage } from "@/context/language"
+import { usePlatform } from "@/context/platform"
 
 function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
   const params = useParams()
   const navigate = useNavigate()
   const sync = useSync()
   const sdk = useSDK()
+  const platform = usePlatform()
 
   return (
     <DataProvider
@@ -31,6 +33,7 @@ function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
       onNavigateToSession={(sessionID: string) => navigate(`/${params.dir}/session/${sessionID}`)}
       onSessionHref={(sessionID: string) => `/${params.dir}/session/${sessionID}`}
       onSyncSession={(sessionID: string) => sync.session.sync(sessionID)}
+      onOpenUrl={(url: string) => platform.openLink(url)}
     >
       <LocalProvider>{props.children}</LocalProvider>
     </DataProvider>

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -83,8 +83,19 @@ export const DataBridge: Component<{ children: any }> = (props) => {
     vscode.postMessage({ type: "openFile", filePath, line, column })
   }
 
+  const openUrl = (url: string) => {
+    vscode.postMessage({ type: "openExternal", url })
+  }
+
   return (
-    <DataProvider data={data()} directory="" onPermissionRespond={respond} onSyncSession={sync} onOpenFile={open}>
+    <DataProvider
+      data={data()}
+      directory=""
+      onPermissionRespond={respond}
+      onSyncSession={sync}
+      onOpenFile={open}
+      onOpenUrl={openUrl}
+    >
       {props.children}
     </DataProvider>
   )

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -366,6 +366,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: var(--surface-hover);
+  }
 }
 
 [data-component="todos"] {

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -875,16 +875,29 @@ ToolRegistry.register({
   name: "webfetch",
   render(props) {
     const i18n = useI18n()
+    const data = useData() // kilocode_change
+    // kilocode_change start
+    const url = () => props.input.url || ""
+    const handleOpen = (e: MouseEvent) => {
+      e.stopPropagation()
+      if (url() && data.openUrl) data.openUrl(url())
+    }
+    // kilocode_change end
     return (
       <BasicTool
         {...props}
         icon="window-cursor"
+        // kilocode_change - add onSubtitleClick to open the URL
+        onSubtitleClick={() => {
+          if (url() && data.openUrl) data.openUrl(url())
+        }}
         trigger={{
           title: i18n.t("ui.tool.webfetch"),
-          subtitle: props.input.url || "",
+          subtitle: url(),
           args: props.input.format ? ["format=" + props.input.format] : [],
           action: (
-            <div data-component="tool-action">
+            // kilocode_change - onClick to open URL in browser
+            <div data-component="tool-action" onClick={handleOpen}>
               <Icon name="square-arrow-top-right" size="small" />
             </div>
           ),

--- a/packages/ui/src/context/data.tsx
+++ b/packages/ui/src/context/data.tsx
@@ -54,6 +54,8 @@ export type SyncSessionFn = (sessionID: string) => void | Promise<void>
 
 export type OpenFileFn = (filePath: string, line?: number, column?: number) => void // kilocode_change
 
+export type OpenUrlFn = (url: string) => void // kilocode_change
+
 export const { use: useData, provider: DataProvider } = createSimpleContext({
   name: "Data",
   init: (props: {
@@ -66,6 +68,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     onSessionHref?: SessionHrefFn
     onSyncSession?: SyncSessionFn
     onOpenFile?: OpenFileFn // kilocode_change
+    onOpenUrl?: OpenUrlFn // kilocode_change
   }) => {
     return {
       get store() {
@@ -81,6 +84,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       sessionHref: props.onSessionHref,
       syncSession: props.onSyncSession,
       openFile: props.onOpenFile, // kilocode_change
+      openUrl: props.onOpenUrl, // kilocode_change
     }
   },
 })


### PR DESCRIPTION
## Summary

- The webfetch tool's external link icon and URL text were not clickable — clicking them just toggled the collapsible output panel because they were inside the `Collapsible.Trigger`
- Added an `openUrl` callback to `DataProvider` (following the existing `openFile` pattern), wired it through the VS Code extension via `openExternal` and the desktop app via `platform.openLink`
- Attached `onClick` handlers with `stopPropagation` to both the icon and subtitle (URL text) so they open the URL in the default browser instead of toggling the collapsible
- Added hover styles to the tool-action icon for better affordance

## Changes

| File | Change |
| --- | --- |
| `packages/ui/src/context/data.tsx` | Add `OpenUrlFn` type and `onOpenUrl` callback to DataProvider |
| `packages/ui/src/components/message-part.tsx` | Wire webfetch action icon and subtitle click to `data.openUrl` with `stopPropagation` |
| `packages/ui/src/components/message-part.css` | Add cursor/hover styles to `tool-action` div |
| `packages/kilo-vscode/webview-ui/src/App.tsx` | Pass `onOpenUrl` to DataProvider using `openExternal` message |
| `packages/app/src/pages/directory-layout.tsx` | Pass `onOpenUrl` to DataProvider using `platform.openLink` |
