### PR TITLE
fix(vscode): revert agent manager icon to circuit-board

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -77,7 +77,7 @@
       {
         "command": "kilo-code.new.agentManagerOpen",
         "title": "Agent Manager",
-        "icon": "$(agent)"
+        "icon": "$(circuit-board)"
       },
       {
         "command": "kilo-code.new.marketplaceButtonClicked",


### PR DESCRIPTION
## Summary

- Reverts the Agent Manager toolbar button icon from `$(agent)` back to `$(circuit-board)`

## Screenshot
<img width="453" height="200" alt="Screen Shot 2026-03-26 at 9 17 18 AM" src="https://github.com/user-attachments/assets/2f97b261-6733-4af2-a48d-2a1601d53b56" />
