### PR TITLE
fix(vscode): correct model price display inflated by double 1M multiplication

### DIFF
--- a/packages/kilo-vscode/tests/unit/model-price-format.test.ts
+++ b/packages/kilo-vscode/tests/unit/model-price-format.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "bun:test"
+import { fmtPrice } from "../../webview-ui/src/components/shared/model-preview-utils"
+
+// Prices arriving at fmtPrice are already in $/M tokens (converted by parseApiPrice).
+// This test suite guards against the double-multiplication bug where fmtPrice was
+// incorrectly multiplying by 1_000_000 again, turning $3.00/1M into $3,000,000.00/1M.
+
+describe("fmtPrice", () => {
+  it("formats Claude Sonnet 4.6 input price correctly ($3/1M)", () => {
+    expect(fmtPrice(3)).toBe("$3.00/1M")
+  })
+
+  it("formats Claude Sonnet 4.6 output price correctly ($15/1M)", () => {
+    expect(fmtPrice(15)).toBe("$15.00/1M")
+  })
+
+  it("returns 'Free' for zero price", () => {
+    expect(fmtPrice(0)).toBe("Free")
+  })
+
+  it("uses 4 decimal places for sub-cent prices", () => {
+    expect(fmtPrice(0.005)).toBe("$0.0050/1M")
+  })
+
+  it("uses 2 decimal places at the $0.01 boundary", () => {
+    expect(fmtPrice(0.01)).toBe("$0.01/1M")
+  })
+
+  it("formats a typical cheap model price ($0.50/1M)", () => {
+    expect(fmtPrice(0.5)).toBe("$0.50/1M")
+  })
+
+  it("formats a high-cost model price ($75/1M)", () => {
+    expect(fmtPrice(75)).toBe("$75.00/1M")
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
@@ -2,15 +2,10 @@ import { Component, Show, For } from "solid-js"
 import type { EnrichedModel } from "../../context/provider"
 import { Markdown } from "@kilocode/kilo-ui/markdown"
 import { sanitizeName } from "./model-selector-utils"
+import { fmtPrice } from "./model-preview-utils"
 
 interface Props {
   model: EnrichedModel | null
-}
-
-function fmtPrice(n: number): string {
-  if (n === 0) return "Free"
-  if (n < 0.01) return `$${n.toFixed(4)}/1M`
-  return `$${n.toFixed(2)}/1M`
 }
 
 function fmtContext(n: number): string {

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
@@ -9,9 +9,8 @@ interface Props {
 
 function fmtPrice(n: number): string {
   if (n === 0) return "Free"
-  const per1M = n * 1_000_000
-  if (per1M < 0.01) return `$${per1M.toFixed(4)}/1M`
-  return `$${per1M.toFixed(2)}/1M`
+  if (n < 0.01) return `$${n.toFixed(4)}/1M`
+  return `$${n.toFixed(2)}/1M`
 }
 
 function fmtContext(n: number): string {

--- a/packages/kilo-vscode/webview-ui/src/components/shared/model-preview-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/model-preview-utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Format a model price for display.
+ * Expects `n` in $/M tokens (as stored in model.cost.input / model.cost.output).
+ */
+export function fmtPrice(n: number): string {
+  if (n === 0) return "Free"
+  if (n < 0.01) return `$${n.toFixed(4)}/1M`
+  return `$${n.toFixed(2)}/1M`
+}


### PR DESCRIPTION
## Summary

- `parseApiPrice()` in `packages/kilo-gateway/src/api/models.ts` already converts prices from $/token → $/M tokens (multiplies by 1,000,000)
- `fmtPrice()` in `ModelPreview.tsx` was then multiplying by 1,000,000 **again**, showing e.g. Claude Sonnet 4.6 input as \$3,000,000.00/1M instead of \$3.00/1M
- Fix removes the redundant multiplication — values in `cost.input`/`cost.output` are already in $/M tokens

## Screenshot

## Before
<img width="302" height="252" alt="Screen Shot 2026-03-26 at 9 26 39 AM" src="https://github.com/user-attachments/assets/d510b82d-817d-494e-b23c-2f7ecf7d21dc" />

## After

<img width="384" height="290" alt="Screen Shot 2026-03-26 at 9 35 15 AM" src="https://github.com/user-attachments/assets/68ad75ea-1ff5-4ee3-b8e0-93dc35e2b86b" />

