### PR TITLE
Cli - Filter child/subagent sessions from remote heartbeat

### DIFF
--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -245,6 +245,7 @@ export namespace KiloSessions {
           [...ids].map(async (id) => {
             const session = await Session.get(id).catch(() => undefined)
             if (!session) return undefined
+            if (session.parentID) return undefined
             return {
               id,
               status: statuses[id]?.type ?? "idle",


### PR DESCRIPTION
## Summary

- Filter out child/subagent sessions from the `getSessions()` response used by the CLI heartbeat, so they don't appear in the cloud agent's sessions sidebar.
- Sessions with a `parentID` are now excluded. Child session events continue to flow via `RemoteSender` independently.