### PR TITLE
fix: clarify built-in mode banner to avoid read-only confusion

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1134,7 +1134,8 @@ export const dict = {
   "settings.agentBehaviour.editMode.prompt": "System Prompt",
   "settings.agentBehaviour.editMode.save": "Done",
   "settings.agentBehaviour.editMode.back": "Back to list",
-  "settings.agentBehaviour.editMode.native": "Built-in mode (read-only definition)",
+  "settings.agentBehaviour.editMode.native":
+    "This is a built-in mode. Its base definition cannot be changed, but you can configure overrides below.",
   "settings.agentBehaviour.editMode.promptOverride": "Custom prompt override for this built-in mode",
 
   "settings.autoApprove.description":


### PR DESCRIPTION
## Summary

- Fixes the misleading "Built-in mode (read-only definition)" banner text in the agent mode edit view
- The old wording caused users to believe the entire edit view should be read-only, when in fact override fields (model, temperature, top_p, steps, prompt) are intentionally editable for built-in modes
- Updated the banner to clearly explain that the base definition cannot be changed, but overrides can be configured

Closes #7672

## Test plan

- [ ] Open Settings > Agent Behaviour > click on a built-in mode (e.g., "code", "plan")
- [ ] Verify the banner now reads: "This is a built-in mode. Its base definition cannot be changed, but you can configure overrides below."
- [ ] Verify override fields (model, temperature, top_p, steps, prompt) remain editable
- [ ] Verify the description field is still hidden for built-in modes
- [ ] Verify custom modes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)