### PR TITLE
docs: rewrite zenmux provider doc to match standard format and add to sidebar nav

### DIFF
--- a/packages/kilo-docs/lib/nav/ai-providers.ts
+++ b/packages/kilo-docs/lib/nav/ai-providers.ts
@@ -35,6 +35,7 @@ export const AiProvidersNav: NavSection[] = [
         href: "/ai-providers/vercel-ai-gateway",
         children: "Vercel AI Gateway",
       },
+      { href: "/ai-providers/zenmux", children: "ZenMux" },
     ],
   },
   {

--- a/packages/kilo-docs/pages/ai-providers/zenmux.md
+++ b/packages/kilo-docs/pages/ai-providers/zenmux.md
@@ -1,197 +1,35 @@
 ---
-title: ZenMux
+sidebar_label: ZenMux
 ---
-
-import Codicon from "@site/src/components/Codicon";
 
 # Using ZenMux With Kilo Code
 
-[ZenMux](https://zenmux.ai) provides a unified API gateway to access multiple AI models from different providers through a single endpoint. It supports OpenAI, Anthropic, Google, and other major AI providers, automatically handling routing, fallbacks, and cost optimization.
+ZenMux is an AI gateway that provides access to multiple AI models from different providers through a single API endpoint, with automatic routing, fallbacks, and cost optimization.
 
-## Getting Started
+**Website:** [https://zenmux.ai](https://zenmux.ai)
 
-1. **Sign up for ZenMux:** Visit [zenmux.ai](https://zenmux.ai) to create an account.
-2. **Get your API key:** After signing up, navigate to your dashboard to generate an API key.
-3. **Configure in Kilo Code:** Add your API key to Kilo Code settings.
+## Getting an API Key
+
+1.  **Sign Up:** Visit [zenmux.ai](https://zenmux.ai) to create an account.
+2.  **Get API Key:** After signing up, navigate to your dashboard to generate an API key.
+3.  **Copy the Key:** Copy the API key.
 
 ## Configuration in Kilo Code
 
-1. **Open Kilo Code Settings:** Click the gear icon (<Codicon name="gear" />) in the Kilo Code panel.
-2. **Select Provider:** Choose "ZenMux" from the "API Provider" dropdown.
-3. **Enter API Key:** Paste your ZenMux API key into the "ZenMux API Key" field.
-4. **Select Model:** Choose your desired model from the "Model" dropdown.
-5. **(Optional) Custom Base URL:** If you need to use a custom base URL for the ZenMux API, check "Use custom base URL" and enter the URL. Leave this blank for most users.
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "ZenMux" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your ZenMux API key into the "ZenMux API Key" field.
+4.  **Select Model:** Choose your desired model from the "Model" dropdown.
+5.  **(Optional) Custom Base URL:** If you need to use a custom base URL for the ZenMux API, check "Use custom base URL" and enter the URL. Leave this blank for most users.
 
 ## Supported Models
 
-ZenMux supports a wide range of models from various providers:
+ZenMux supports models from OpenAI, Anthropic, Google, Meta, Mistral, and other providers. Visit [zenmux.ai/models](https://zenmux.ai/models) to see the complete list of available models.
 
-Visi [zenmux.ai/models](https://zenmux.ai/models) to see the complete list of available models.
+## Tips and Notes
 
-### Other Providers
-
-ZenMux also supports models from Meta, Mistral, and many other providers. Check your ZenMux dashboard for the complete list of available models.
-
-## API Compatibility
-
-ZenMux provides multiple API endpoints for different protocols:
-
-### OpenAI Compatible API
-
-Use the standard OpenAI SDK with ZenMux's base URL:
-
-```javascript
-import OpenAI from "openai"
-
-const openai = new OpenAI({
-  baseURL: "https://zenmux.ai/api/v1",
-  apiKey: "<ZENMUX_API_KEY>",
-})
-
-async function main() {
-  const completion = await openai.chat.completions.create({
-    model: "openai/gpt-5",
-    messages: [
-      {
-        role: "user",
-        content: "What is the meaning of life?",
-      },
-    ],
-  })
-
-  console.log(completion.choices[0].message)
-}
-
-main()
-```
-
-### Anthropic API
-
-For Anthropic models, use the dedicated endpoint:
-
-```typescript
-import Anthropic from "@anthropic-ai/sdk"
-
-// 1. Initialize the Anthropic client
-const anthropic = new Anthropic({
-  // 2. Replace with the API key from your ZenMux console
-  apiKey: "<YOUR ZENMUX_API_KEY>",
-  // 3. Point the base URL to the ZenMux endpoint
-  baseURL: "https://zenmux.ai/api/anthropic",
-})
-
-async function main() {
-  const msg = await anthropic.messages.create({
-    model: "anthropic/claude-sonnet-4.5",
-    max_tokens: 1024,
-    messages: [{ role: "user", content: "Hello, Claude" }],
-  })
-  console.log(msg)
-}
-
-main()
-```
-
-### Platform API
-
-The Get generation interface is used to query generation information, such as usage and costs.
-
-```bash
-curl https://zenmux.ai/api/v1/generation?id=<generation_id> \
-  -H "Authorization: Bearer $ZENMUX_API_KEY"
-```
-
-### Google Vertex AI API
-
-For Google models:
-
-```typescript
-const genai = require("@google/genai")
-
-const client = new genai.GoogleGenAI({
-  apiKey: "$ZENMUX_API_KEY",
-  vertexai: true,
-  httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai",
-    apiVersion: "v1",
-  },
-})
-
-const response = await client.models.generateContent({
-  model: "google/gemini-2.5-pro",
-  contents: "How does AI work?",
-})
-console.log(response)
-```
-
-## Features
-
-### Automatic Routing
-
-ZenMux automatically routes your requests to the best available provider based on:
-
-- Model availability
-- Response time
-- Cost optimization
-- Provider health status
-
-### Fallback Support
-
-If a provider is unavailable, ZenMux automatically falls back to alternative providers that support the same model capabilities.
-
-### Cost Optimization
-
-ZenMux can be configured to optimize for cost, routing requests to the most cost-effective provider while maintaining quality.
-
-### Zero Data Retention (ZDR)
-
-Enable ZDR mode to ensure that no request or response data is stored by ZenMux, providing maximum privacy for sensitive applications.
-
-## Advanced Configuration
-
-### Provider Routing
-
-You can specify routing preferences:
-
-- **Price**: Route to the lowest cost provider
-- **Throughput**: Route to the provider with highest tokens/second
-- **Latency**: Route to the provider with fastest response time
-
-### Data Collection Settings
-
-Control how ZenMux handles your data:
-
-- **Allow**: Allow data collection for service improvement
-- **Deny**: Disable all data collection
-
-### Middle-Out Transform
-
-Enable the middle-out transform feature to optimize prompts that exceed model context limits.
-
-## Troubleshooting
-
-### API Key Issues
-
-- Ensure your API key is correctly copied without any extra spaces
-- Check that your ZenMux account is active and has available credits
-- Verify the API key has the necessary permissions
-
-### Model Availability
-
-- Some models may have regional restrictions
-- Check the ZenMux dashboard for current model availability
-- Ensure your account tier has access to the desired models
-
-### Connection Issues
-
-- Verify your internet connection
-- Check if you're behind a firewall that might block API requests
-- Try using a custom base URL if the default endpoint is blocked
-
-## Support
-
-For additional support:
-
-- Visit the [ZenMux documentation](https://zenmux.ai/docs)
-- Contact ZenMux support through their dashboard
-- Check the [Kilo Code GitHub repository](https://github.com/Kilo-Org/kilocode) for integration-specific issues
+- **Pricing:** ZenMux charges based on the underlying model's pricing. Check your ZenMux dashboard for usage and cost details.
+- **Routing:** ZenMux can route requests based on price, throughput, or latency preferences.
+- **Fallback:** If a provider is unavailable, ZenMux automatically falls back to alternative providers that support the same model.
+- **Zero Data Retention:** ZenMux offers a ZDR mode for maximum privacy.
+- **Prompt Compression:** ZenMux supports a middle-out transform to optimize prompts that exceed model context limits.


### PR DESCRIPTION
## Summary

- Rewrote `packages/kilo-docs/pages/ai-providers/zenmux.md` to follow the same format as other provider docs (e.g., OpenRouter, Glama, Requesty)
- Added ZenMux to the AI Gateways section in `packages/kilo-docs/lib/nav/ai-providers.ts` sidebar navigation
- Removed unrelated API code examples and redundant product feature descriptions that belong in ZenMux's own docs

### Changes
- Replaced `title` frontmatter with `sidebar_label` for consistency with other provider docs
- Added `**Website:**` link matching the standard format
- Replaced `<Codicon>` JSX import with `{% codicon %}` Markdoc tag used by all other provider docs
- Removed large code blocks (OpenAI SDK, Anthropic SDK, Google Vertex AI, Platform API examples)
- Removed redundant Features, Advanced Configuration, Troubleshooting, and Support sections
- Consolidated into standard sections: Getting an API Key, Configuration in Kilo Code, Supported Models, Tips and Notes
- Fixed "Visi" typo (missing "t" in "Visit")

Closes #6141

## How to Test

1. Run the docs dev server: `bun run --cwd packages/kilo-docs dev`
2. Navigate to the AI Providers sidebar — ZenMux should now appear under "AI Gateways"
3. Click ZenMux — the page should render with the standard provider doc format
4. Compare with other provider docs (e.g., OpenRouter, Glama) to verify consistent structure

## Test plan

- [x] `bun run --cwd packages/kilo-docs test` passes (3 tests)
- [x] `bun turbo typecheck` passes (12 packages)
- [ ] Visual verification that ZenMux appears in sidebar nav
- [ ] Visual verification that page renders correctly with Markdoc codicon tag