### PR TITLE
fix: register Turkish (tr) locale in test configuration

### DIFF
--- a/packages/kilo-vscode/tests/unit/agent-manager-i18n-split.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-i18n-split.test.ts
@@ -15,6 +15,7 @@ import { dict as appNo } from "../../webview-ui/src/i18n/no"
 import { dict as appBr } from "../../webview-ui/src/i18n/br"
 import { dict as appTh } from "../../webview-ui/src/i18n/th"
 import { dict as appBs } from "../../webview-ui/src/i18n/bs"
+import { dict as appTr } from "../../webview-ui/src/i18n/tr"
 import { dict as amEn } from "../../webview-ui/agent-manager/i18n/en"
 import { dict as amZh } from "../../webview-ui/agent-manager/i18n/zh"
 import { dict as amZht } from "../../webview-ui/agent-manager/i18n/zht"
@@ -31,6 +32,7 @@ import { dict as amNo } from "../../webview-ui/agent-manager/i18n/no"
 import { dict as amBr } from "../../webview-ui/agent-manager/i18n/br"
 import { dict as amTh } from "../../webview-ui/agent-manager/i18n/th"
 import { dict as amBs } from "../../webview-ui/agent-manager/i18n/bs"
+import { dict as amTr } from "../../webview-ui/agent-manager/i18n/tr"
 
 const PREFIX = "agentManager."
 
@@ -51,6 +53,7 @@ const locales = {
   br: amBr,
   th: amTh,
   bs: amBs,
+  tr: amTr,
 }
 
 const appLocales = {
@@ -70,6 +73,7 @@ const appLocales = {
   br: appBr,
   th: appTh,
   bs: appBs,
+  tr: appTr,
 }
 
 function placeholders(text: string): string[] {

--- a/packages/kilo-vscode/tests/unit/i18n-keys.test.ts
+++ b/packages/kilo-vscode/tests/unit/i18n-keys.test.ts
@@ -37,6 +37,7 @@ import { dict as appNo } from "../../webview-ui/src/i18n/no"
 import { dict as appBr } from "../../webview-ui/src/i18n/br"
 import { dict as appTh } from "../../webview-ui/src/i18n/th"
 import { dict as appBs } from "../../webview-ui/src/i18n/bs"
+import { dict as appTr } from "../../webview-ui/src/i18n/tr"
 
 // Layer 2: upstream UI (@opencode-ai/ui re-exported via @kilocode/kilo-ui)
 import { dict as uiEn } from "../../../ui/src/i18n/en"
@@ -55,6 +56,7 @@ import { dict as uiNo } from "../../../ui/src/i18n/no"
 import { dict as uiBr } from "../../../ui/src/i18n/br"
 import { dict as uiTh } from "../../../ui/src/i18n/th"
 import { dict as uiBs } from "../../../ui/src/i18n/bs"
+import { dict as uiTr } from "../../../ui/src/i18n/tr"
 
 // Layer 3: kilo-i18n overrides
 import { dict as kiloEn } from "../../../kilo-i18n/src/en"
@@ -73,6 +75,7 @@ import { dict as kiloNo } from "../../../kilo-i18n/src/no"
 import { dict as kiloBr } from "../../../kilo-i18n/src/br"
 import { dict as kiloTh } from "../../../kilo-i18n/src/th"
 import { dict as kiloBs } from "../../../kilo-i18n/src/bs"
+import { dict as kiloTr } from "../../../kilo-i18n/src/tr"
 
 // Layer 4: agent manager (locale alignment already tested in agent-manager-i18n-split.test.ts)
 import { dict as amEn } from "../../webview-ui/agent-manager/i18n/en"
@@ -95,6 +98,7 @@ import { dict as cliNo } from "../../src/services/cli-backend/i18n/no"
 import { dict as cliBr } from "../../src/services/cli-backend/i18n/br"
 import { dict as cliTh } from "../../src/services/cli-backend/i18n/th"
 import { dict as cliBs } from "../../src/services/cli-backend/i18n/bs"
+import { dict as cliTr } from "../../src/services/cli-backend/i18n/tr"
 
 import { dict as acEn } from "../../src/services/autocomplete/i18n/en"
 
@@ -119,6 +123,7 @@ const appLocales: Record<string, Record<string, string>> = {
   br: appBr,
   th: appTh,
   bs: appBs,
+  tr: appTr,
 }
 
 const kiloLocales: Record<string, Record<string, string>> = {
@@ -138,6 +143,7 @@ const kiloLocales: Record<string, Record<string, string>> = {
   br: kiloBr,
   th: kiloTh,
   bs: kiloBs,
+  tr: kiloTr,
 }
 
 const uiLocales: Record<string, Record<string, string>> = {
@@ -157,6 +163,7 @@ const uiLocales: Record<string, Record<string, string>> = {
   br: uiBr,
   th: uiTh,
   bs: uiBs,
+  tr: uiTr,
 }
 
 const cliLocales: Record<string, Record<string, string>> = {
@@ -176,6 +183,7 @@ const cliLocales: Record<string, Record<string, string>> = {
   br: cliBr,
   th: cliTh,
   bs: cliBs,
+  tr: cliTr,
 }
 
 // Merge webview dictionaries in the same priority order as language.tsx

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1271,4 +1271,31 @@ export const dict = {
   "notifications.action.next": "Next",
   "notifications.action.close": "Close",
   "notifications.action.tryModel": "Try model",
+
+  "settings.agentBehaviour.createMode": "Yeni Mod Oluştur",
+  "settings.agentBehaviour.createMode.name": "Ad",
+  "settings.agentBehaviour.createMode.name.placeholder": "ör. gozden-geciren",
+  "settings.agentBehaviour.createMode.name.description":
+    "Mod için benzersiz tanımlayıcı. Yalnızca küçük harfler, sayılar ve tire kullanın.",
+  "settings.agentBehaviour.createMode.description": "Açıklama",
+  "settings.agentBehaviour.createMode.description.placeholder": "ör. Kalite ve en iyi uygulamalar için kodu inceler",
+  "settings.agentBehaviour.createMode.description.help": "Bu modun ne yaptığının kısa açıklaması.",
+  "settings.agentBehaviour.createMode.prompt": "Sistem İstemi",
+  "settings.agentBehaviour.createMode.prompt.placeholder":
+    "ör. Sen bir kod inceleyicisin. Kod kalitesi, en iyi uygulamalar ve olası hatalara odaklan.",
+  "settings.agentBehaviour.createMode.prompt.help": "Bu mod kullanılırken yapay zeka ajanı için talimatlar.",
+  "settings.agentBehaviour.createMode.button": "Oluştur",
+  "settings.agentBehaviour.createMode.cancel": "İptal",
+  "settings.agentBehaviour.createMode.nameRequired": "Ad gereklidir",
+  "settings.agentBehaviour.createMode.nameInvalid":
+    "Ad küçük harfle başlamalı ve yalnızca küçük harfler, sayılar ve tire içermelidir",
+  "settings.agentBehaviour.createMode.nameTaken": "Bu adla bir mod zaten mevcut",
+  "settings.agentBehaviour.editMode": "Modu Düzenle",
+  "settings.agentBehaviour.editMode.description": "Açıklama",
+  "settings.agentBehaviour.editMode.prompt": "Sistem İstemi",
+  "settings.agentBehaviour.editMode.save": "Tamam",
+  "settings.agentBehaviour.editMode.back": "Listeye dön",
+  "settings.agentBehaviour.editMode.native": "Yerleşik mod (salt okunur tanım)",
+  "settings.agentBehaviour.editMode.promptOverride": "Bu yerleşik mod için özel istem geçersiz kılma",
+  "profile.switchingAccount": "Hesap değiştiriliyor…",
 }


### PR DESCRIPTION
## Summary
- Add Turkish (`tr`) locale entries to `i18n-keys.test.ts` locale maps (`appLocales`, `uiLocales`, `kiloLocales`, `cliLocales`) so locale completeness tests cover Turkish
- Add Turkish (`tr`) locale entries to `agent-manager-i18n-split.test.ts` locale maps (`locales`, `appLocales`) so agent manager i18n tests cover Turkish
- Add 23 missing translation keys to `webview-ui/src/i18n/tr.ts` that were added to `en.ts` after the initial Turkish locale merge (createMode, editMode, and profile.switchingAccount keys)

## Test plan
- [x] `bun test tests/unit/i18n-keys.test.ts` — 7 pass, 0 fail
- [x] `bun test tests/unit/agent-manager-i18n-split.test.ts` — 5 pass, 0 fail
- [x] Full unit test suite — 1271 pass, 0 fail
- [x] ESLint — no issues
- [x] TypeScript typecheck — passes (pre-existing unrelated errors only)

Closes #7271

🤖 Generated with [Claude Code](https://claude.com/claude-code)