### PR TITLE
feat(read): include total line/entry count in out-of-range errors

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -90,6 +90,13 @@ export const ReadTool = Tool.define("read", {
       const limit = params.limit ?? DEFAULT_READ_LIMIT
       const offset = params.offset ?? 1
       const start = offset - 1
+
+      if (entries.length > 0 && start >= entries.length) {
+        throw new Error(
+          `Offset ${offset} is out of range, directory only has ${entries.length} entr${entries.length === 1 ? "y" : "ies"}. Use offset=1 to list from the beginning.`,
+        )
+      }
+
       const sliced = entries.slice(start, start + limit)
       const truncated = start + sliced.length < entries.length
 
@@ -187,7 +194,9 @@ export const ReadTool = Tool.define("read", {
     }
 
     if (lines < offset && !(lines === 0 && offset === 1)) {
-      throw new Error(`Offset ${offset} is out of range for this file (${lines} lines)`)
+      throw new Error(
+        `Offset ${offset} is out of range, file only has ${lines} line${lines === 1 ? "" : "s"}. Use offset=1 to read from the beginning.`,
+      )
     }
 
     const content = raw.map((line, index) => {

--- a/packages/opencode/src/tool/read.txt
+++ b/packages/opencode/src/tool/read.txt
@@ -3,7 +3,7 @@ Read a file or directory from the local filesystem. If the path does not exist, 
 Usage:
 - The filePath parameter should be an absolute path.
 - By default, this tool returns up to 2000 lines from the start of the file.
-- The offset parameter is the line number to start from (1-indexed).
+- The offset parameter is the line number to start from (1-indexed). If out of range, the error will report the total number of lines in the file.
 - To read later sections, call this tool again with a larger offset.
 - Use the grep tool to find specific content in large files or files with long lines.
 - If you are unsure of the correct file path, use the glob tool to look up filenames by glob pattern.

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -296,7 +296,7 @@ describe("tool.read truncation", () => {
         const read = await ReadTool.init()
         await expect(
           read.execute({ filePath: path.join(tmp.path, "short.txt"), offset: 4, limit: 5 }, ctx),
-        ).rejects.toThrow("Offset 4 is out of range for this file (3 lines)")
+        ).rejects.toThrow("Offset 4 is out of range, file only has 3 lines. Use offset=1 to read from the beginning.")
       },
     })
   })
@@ -329,7 +329,26 @@ describe("tool.read truncation", () => {
       fn: async () => {
         const read = await ReadTool.init()
         await expect(read.execute({ filePath: path.join(tmp.path, "empty.txt"), offset: 2 }, ctx)).rejects.toThrow(
-          "Offset 2 is out of range for this file (0 lines)",
+          "Offset 2 is out of range, file only has 0 lines. Use offset=1 to read from the beginning.",
+        )
+      },
+    })
+  })
+
+  test("throws when directory offset is beyond entry count", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Promise.all(
+          Array.from({ length: 3 }, (_, i) => Bun.write(path.join(dir, "dir", `file-${i + 1}.txt`), `line${i}`)),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        await expect(read.execute({ filePath: path.join(tmp.path, "dir"), offset: 10, limit: 5 }, ctx)).rejects.toThrow(
+          "Offset 10 is out of range, directory only has 3 entries. Use offset=1 to list from the beginning.",
         )
       },
     })


### PR DESCRIPTION
## Summary
- Improve read tool out-of-range error messages to include total line/entry count and a suggested recovery action (e.g., `Use offset=1 to read from the beginning`)
- Add out-of-range check for directory listings, which previously silently returned empty results when offset exceeded entry count
- Update read tool description to document that OOB errors report total line count

Closes #6248

## Test plan
- [x] Updated existing OOB error message tests to match new format
- [x] Added new test for directory offset beyond entry count
- [x] All 36 tests in `test/tool/read.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)