### PR TITLE
feat(vscode): add license

### DIFF
--- a/packages/kilo-vscode/LICENSE
+++ b/packages/kilo-vscode/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Kilo Code
+Copyright (c) 2025 opencode
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -17,6 +17,7 @@
   "engines": {
     "vscode": "^1.105.1"
   },
+  "license": "MIT",
   "author": {
     "name": "Kilo Code"
   },


### PR DESCRIPTION
`packages/kilo-vscode/` was missing both a `"license"` field in `package.json` and a `LICENSE` file. The `vsce package --skip-license` flag only suppresses the packaging warning — Open VSX enforces the license requirement server-side at publish time.

**Changes:**
- Add `"license": "MIT"` to `packages/kilo-vscode/package.json`
- Add `LICENSE` file (copy of repo root MIT license)'