### PR TITLE
feat(vscode): add login banner to welcome screen for unauthenticated users

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,17 @@
       "env": {
         "KILO_API_URL": "http://localhost:3000"
       }
+    },
+    {
+      "name": "VSCode - Run Extension (Dev CLI Data Dirs)",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--disable-extensions", "--extensionDevelopmentPath=${workspaceFolder}/packages/kilo-vscode"],
+      "outFiles": ["${workspaceFolder}/packages/kilo-vscode/dist/**/*.js"],
+      "preLaunchTask": "VSCode - Compile",
+      "env": {
+        "KILO_DEV": "1"
+      }
     }
   ]
 }

--- a/packages/kilo-i18n/src/ar.ts
+++ b/packages/kilo-i18n/src/ar.ts
@@ -69,4 +69,7 @@ export const dict = {
   "marketplace.warning.busyMany": "عدة جلسات تعمل وستتوقف",
   "marketplace.warning.installAnyway": "تثبيت على أي حال",
   "marketplace.warning.cancel": "إلغاء",
+
+  "welcome.login.title": "تسجيل الدخول باستخدام Kilo Code",
+  "welcome.login.desc": "أكثر من 500 نموذج، سجل سحابي وحسابات فِرق",
 }

--- a/packages/kilo-i18n/src/br.ts
+++ b/packages/kilo-i18n/src/br.ts
@@ -69,4 +69,7 @@ export const dict = {
   "marketplace.warning.busyMany": "Várias sessões estão em execução e serão interrompidas",
   "marketplace.warning.installAnyway": "Instalar mesmo assim",
   "marketplace.warning.cancel": "Cancelar",
+
+  "welcome.login.title": "Entrar com Kilo Code",
+  "welcome.login.desc": "Mais de 500 modelos, histórico na nuvem e contas de equipe",
 }

--- a/packages/kilo-i18n/src/bs.ts
+++ b/packages/kilo-i18n/src/bs.ts
@@ -74,4 +74,7 @@ export const dict = {
   "marketplace.warning.busyMany": "Nekoliko sesija je pokrenuto i bit će prekinuto",
   "marketplace.warning.installAnyway": "Instaliraj svejedno",
   "marketplace.warning.cancel": "Otkaži",
+
+  "welcome.login.title": "Prijavite se sa Kilo Code",
+  "welcome.login.desc": "500+ modela, historija u oblaku i timski nalozi",
 }

--- a/packages/kilo-i18n/src/da.ts
+++ b/packages/kilo-i18n/src/da.ts
@@ -69,4 +69,7 @@ export const dict = {
   "marketplace.warning.busyMany": "Flere sessioner kører og vil blive afbrudt",
   "marketplace.warning.installAnyway": "Installer alligevel",
   "marketplace.warning.cancel": "Annuller",
+
+  "welcome.login.title": "Log ind med Kilo Code",
+  "welcome.login.desc": "500+ modeller, skyhistorik og teamkonti",
 }

--- a/packages/kilo-i18n/src/de.ts
+++ b/packages/kilo-i18n/src/de.ts
@@ -69,4 +69,7 @@ export const dict = {
   "marketplace.warning.busyMany": "Mehrere Sitzungen laufen und werden unterbrochen",
   "marketplace.warning.installAnyway": "Trotzdem installieren",
   "marketplace.warning.cancel": "Abbrechen",
+
+  "welcome.login.title": "Mit Kilo Code anmelden",
+  "welcome.login.desc": "Über 500 Modelle, Cloud-Verlauf & Teamkonten",
 }

--- a/packages/kilo-i18n/src/en.ts
+++ b/packages/kilo-i18n/src/en.ts
@@ -14,6 +14,10 @@ export const dict = {
   "dialog.provider.group.recommended": "Recommended",
   "dialog.provider.kilo.note": "Access 500+ AI models",
 
+  // Welcome screen login banner
+  "welcome.login.title": "Login with Kilo Code",
+  "welcome.login.desc": "500+ models, cloud history & team accounts",
+
   // Reasoning block label
   "ui.permission.run": "Run",
   "ui.reasoning.label": "Reasoning",

--- a/packages/kilo-i18n/src/es.ts
+++ b/packages/kilo-i18n/src/es.ts
@@ -69,4 +69,7 @@ export const dict = {
   "marketplace.warning.busyMany": "Varias sesiones están en ejecución y se interrumpirán",
   "marketplace.warning.installAnyway": "Instalar de todas formas",
   "marketplace.warning.cancel": "Cancelar",
+
+  "welcome.login.title": "Iniciar sesión con Kilo Code",
+  "welcome.login.desc": "Más de 500 modelos, historial en la nube y cuentas de equipo",
 }

--- a/packages/kilo-i18n/src/fr.ts
+++ b/packages/kilo-i18n/src/fr.ts
@@ -69,4 +69,7 @@ export const dict = {
   "marketplace.warning.busyMany": "Plusieurs sessions sont en cours et seront interrompues",
   "marketplace.warning.installAnyway": "Installer quand même",
   "marketplace.warning.cancel": "Annuler",
+
+  "welcome.login.title": "Se connecter avec Kilo Code",
+  "welcome.login.desc": "Plus de 500 modèles, historique cloud & comptes d'équipe",
 }

--- a/packages/kilo-i18n/src/ja.ts
+++ b/packages/kilo-i18n/src/ja.ts
@@ -67,4 +67,7 @@ export const dict = {
   "marketplace.warning.busyMany": "複数のセッションが実行中で中断されます",
   "marketplace.warning.installAnyway": "それでもインストール",
   "marketplace.warning.cancel": "キャンセル",
+
+  "welcome.login.title": "Kilo Code でログイン",
+  "welcome.login.desc": "500以上のモデル、クラウド履歴、チームアカウント",
 }

--- a/packages/kilo-i18n/src/ko.ts
+++ b/packages/kilo-i18n/src/ko.ts
@@ -67,4 +67,7 @@ export const dict = {
   "marketplace.warning.busyMany": "여러 세션이 실행 중이며 중단됩니다",
   "marketplace.warning.installAnyway": "그래도 설치",
   "marketplace.warning.cancel": "취소",
+
+  "welcome.login.title": "Kilo Code로 로그인",
+  "welcome.login.desc": "500개 이상의 모델, 클라우드 기록 및 팀 계정",
 }

--- a/packages/kilo-i18n/src/nl.ts
+++ b/packages/kilo-i18n/src/nl.ts
@@ -71,4 +71,7 @@ export const dict = {
   "marketplace.warning.busyMany": "Er zijn meerdere sessies actief en deze zullen worden onderbroken",
   "marketplace.warning.installAnyway": "Toch installeren",
   "marketplace.warning.cancel": "Annuleren",
+
+  "welcome.login.title": "Inloggen met Kilo Code",
+  "welcome.login.desc": "500+ modellen, cloudgeschiedenis & teamaccounts",
 }

--- a/packages/kilo-i18n/src/no.ts
+++ b/packages/kilo-i18n/src/no.ts
@@ -69,4 +69,7 @@ export const dict = {
   "marketplace.warning.busyMany": "Flere økter kjører og vil bli avbrutt",
   "marketplace.warning.installAnyway": "Installer uansett",
   "marketplace.warning.cancel": "Avbryt",
+
+  "welcome.login.title": "Logg inn med Kilo Code",
+  "welcome.login.desc": "500+ modeller, skyhistorikk og teamkontoer",
 }

--- a/packages/kilo-i18n/src/pl.ts
+++ b/packages/kilo-i18n/src/pl.ts
@@ -69,4 +69,7 @@ export const dict = {
   "marketplace.warning.busyMany": "Kilka sesji jest uruchomionych i zostanie przerwanych",
   "marketplace.warning.installAnyway": "Zainstaluj mimo to",
   "marketplace.warning.cancel": "Anuluj",
+
+  "welcome.login.title": "Zaloguj się przez Kilo Code",
+  "welcome.login.desc": "Ponad 500 modeli, historia w chmurze i konta zespołowe",
 }

--- a/packages/kilo-i18n/src/ru.ts
+++ b/packages/kilo-i18n/src/ru.ts
@@ -69,4 +69,7 @@ export const dict = {
   "marketplace.warning.busyMany": "Несколько сеансов выполняются и будут прерваны",
   "marketplace.warning.installAnyway": "Установить в любом случае",
   "marketplace.warning.cancel": "Отмена",
+
+  "welcome.login.title": "Войти с Kilo Code",
+  "welcome.login.desc": "Более 500 моделей, облачная история и командные аккаунты",
 }

--- a/packages/kilo-i18n/src/th.ts
+++ b/packages/kilo-i18n/src/th.ts
@@ -69,4 +69,7 @@ export const dict = {
   "marketplace.warning.busyMany": "มีหลายเซสชันกำลังทำงานและจะถูกขัดจังหวะ",
   "marketplace.warning.installAnyway": "ติดตั้งต่อไป",
   "marketplace.warning.cancel": "ยกเลิก",
+
+  "welcome.login.title": "เข้าสู่ระบบด้วย Kilo Code",
+  "welcome.login.desc": "โมเดลมากกว่า 500 แบบ, ประวัติบนคลาวด์ และบัญชีทีม",
 }

--- a/packages/kilo-i18n/src/tr.ts
+++ b/packages/kilo-i18n/src/tr.ts
@@ -69,4 +69,7 @@ export const dict = {
   "marketplace.warning.busyMany": "Birden fazla oturum çalışıyor ve kesintiye uğrayacak",
   "marketplace.warning.installAnyway": "Yine de yükle",
   "marketplace.warning.cancel": "İptal",
+
+  "welcome.login.title": "Kilo Code ile Giriş Yap",
+  "welcome.login.desc": "500+ model, bulut geçmişi ve ekip hesapları",
 }

--- a/packages/kilo-i18n/src/zh.ts
+++ b/packages/kilo-i18n/src/zh.ts
@@ -66,4 +66,7 @@ export const dict = {
   "marketplace.warning.busyMany": "多个会话正在运行，将被中断",
   "marketplace.warning.installAnyway": "仍然安装",
   "marketplace.warning.cancel": "取消",
+
+  "welcome.login.title": "使用 Kilo Code 登录",
+  "welcome.login.desc": "500+ 个模型、云端历史记录与团队账号",
 }

--- a/packages/kilo-i18n/src/zht.ts
+++ b/packages/kilo-i18n/src/zht.ts
@@ -66,4 +66,7 @@ export const dict = {
   "marketplace.warning.busyMany": "多個工作階段正在執行，將被中斷",
   "marketplace.warning.installAnyway": "仍然安裝",
   "marketplace.warning.cancel": "取消",
+
+  "welcome.login.title": "使用 Kilo Code 登入",
+  "welcome.login.desc": "500+ 個模型、雲端歷史紀錄與團隊帳號",
 }

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -770,7 +770,8 @@
     "test:visual:update": "playwright test --update-snapshots",
     "snapshot:build": "bun script/dev-snapshot.ts build",
     "snapshot:install": "bun script/dev-snapshot.ts install",
-    "extension": "bun script/launch.ts"
+    "extension": "bun script/launch.ts",
+    "extension:dev-data-dirs": "bun script/launch.ts --dev-data-dirs"
   },
   "devDependencies": {
     "@playwright/test": "1.57.0",

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -13,6 +13,12 @@
  *   --insiders        Prefer VS Code Insiders over stable
  *   --wait            Block until the VS Code window is closed
  *   --clean           Wipe the user-data and extensions dirs before launching
+ *   --dev-data-dirs   Use dev-specific CLI data dirs (separate auth, sessions, config from your main install)
+ *                    Sets KILO_DEV=1 which makes the CLI use "kilo-dev" as the app name:
+ *                    e.g. ~/.local/share/kilo-dev/  (data: auth, sessions)
+ *                         ~/.config/kilo-dev/        (config)
+ *                         ~/.local/state/kilo-dev/   (state)
+ *                         ~/.cache/kilo-dev/          (cache)
  *
  * Environment:
  *   VSCODE_EXEC_PATH  Path to VS Code executable (same as --app-path)
@@ -84,6 +90,7 @@ const insiders = opts["insiders"] === true
 const explicit = opts["app-path"] as string | undefined
 const blocking = opts["wait"] === true
 const clean = opts["clean"] === true
+const devDataDirs = opts["dev-data-dirs"] === true
 
 // ---------------------------------------------------------------------------
 // VS Code executable detection
@@ -303,15 +310,18 @@ async function launch() {
     args.push("--wait")
   }
 
+  const env = devDataDirs ? { ...process.env, KILO_DEV: "1" } : process.env
+
   console.log(`[launch] Starting VS Code (${mode} mode)`)
   console.log(`[launch] Executable: ${app}`)
   console.log(`[launch] Workspace:  ${workspace}`)
   console.log(`[launch] State:      ${base}`)
+  if (devDataDirs) console.log(`[launch] Dev data:   using kilo-dev dirs (KILO_DEV=1)`)
 
   if (blocking) {
     const result = Bun.spawnSync([app, ...args], {
       cwd: workspace,
-      env: process.env,
+      env,
       stdio: ["ignore", "inherit", "inherit"],
     })
     console.log(`[launch] VS Code exited (code ${result.exitCode})`)
@@ -321,7 +331,7 @@ async function launch() {
   const child = spawn(app, args, {
     cwd: workspace,
     detached: !win,
-    env: process.env,
+    env,
     stdio: "ignore",
     ...(win ? { shell: true } : {}),
   })

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -555,6 +555,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "openSettingsPanel":
           vscode.commands.executeCommand("kilo-code.new.settingsButtonClicked", message.tab)
           break
+        case "openProfilePanel":
+          vscode.commands.executeCommand("kilo-code.new.profileButtonClicked")
+          break
         case "openChanges":
           vscode.commands.executeCommand("kilo-code.new.showChanges")
           break

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -2,6 +2,7 @@ import { type ChildProcess } from "child_process"
 import { spawn } from "../../util/process"
 import * as crypto from "crypto"
 import * as fs from "fs"
+import * as os from "os"
 import * as path from "path"
 import * as vscode from "vscode"
 import { t } from "./i18n"
@@ -63,6 +64,17 @@ export class ServerManager {
     const stat = fs.statSync(cliPath)
     console.log("[Kilo New] ServerManager: 📄 CLI isFile:", stat.isFile())
     console.log("[Kilo New] ServerManager: 📄 CLI mode (octal):", (stat.mode & 0o777).toString(8))
+
+    const app = process.env.KILO_DEV ? "kilo-dev" : "kilo"
+    const xdgData = process.env.XDG_DATA_HOME ?? path.join(os.homedir(), ".local", "share")
+    const xdgConfig = process.env.XDG_CONFIG_HOME ?? path.join(os.homedir(), ".config")
+    const xdgState = process.env.XDG_STATE_HOME ?? path.join(os.homedir(), ".local", "state")
+    const xdgCache = process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache")
+    console.log("[Kilo New] ServerManager: 📂 CLI data dirs:")
+    console.log("[Kilo New] ServerManager:   - data:  ", path.join(xdgData, app))
+    console.log("[Kilo New] ServerManager:   - config:", path.join(xdgConfig, app))
+    console.log("[Kilo New] ServerManager:   - state: ", path.join(xdgState, app))
+    console.log("[Kilo New] ServerManager:   - cache: ", path.join(xdgCache, app))
 
     return new Promise((resolve, reject) => {
       console.log("[Kilo New] ServerManager: 🎬 Spawning CLI process:", cliPath, ["serve", "--port", "0"])

--- a/packages/kilo-vscode/src/services/marketplace/paths.ts
+++ b/packages/kilo-vscode/src/services/marketplace/paths.ts
@@ -3,11 +3,12 @@ import * as os from "os"
 
 /**
  * Global config dir: ~/.config/kilo/ (XDG_CONFIG_HOME/kilo)
- * This matches where the CLI reads global config from.
+ * In KILO_DEV mode uses 'kilo-dev' to match the CLI's isolated data dirs.
  */
 function globalConfigDir(): string {
   const xdg = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config")
-  return path.join(xdg, "kilo")
+  const app = process.env.KILO_DEV ? "kilo-dev" : "kilo"
+  return path.join(xdg, app)
 }
 
 export class MarketplacePaths {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -15,6 +15,7 @@ import { createAutoScroll } from "@kilocode/kilo-ui/hooks"
 import { useSession } from "../../context/session"
 import { useServer } from "../../context/server"
 import { useLanguage } from "../../context/language"
+import { useVSCode } from "../../context/vscode"
 import { formatRelativeDate } from "../../utils/date"
 import { FeedbackDialog } from "./FeedbackDialog"
 import { VscodeSessionTurn } from "./VscodeSessionTurn"
@@ -47,6 +48,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
   const server = useServer()
   const language = useLanguage()
   const dialog = useDialog()
+  const vscode = useVSCode()
 
   const autoScroll = createAutoScroll({
     working: () => session.status() !== "idle",
@@ -93,6 +95,16 @@ export const MessageList: Component<MessageListProps> = (props) => {
       <Show when={isEmpty()}>
         <div class="welcome-header">
           <AccountSwitcher class="account-switcher-welcome" />
+          <Show when={!server.profileData()}>
+            <button
+              type="button"
+              class="kilo-login-banner"
+              onClick={() => vscode.postMessage({ type: "openProfilePanel" })}
+            >
+              <span class="kilo-login-banner-title">{language.t("welcome.login.title")}</span>
+              <span class="kilo-login-banner-desc">{language.t("welcome.login.desc")}</span>
+            </button>
+          </Show>
           <KiloNotifications />
         </div>
       </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -15,12 +15,12 @@ import { createAutoScroll } from "@kilocode/kilo-ui/hooks"
 import { useSession } from "../../context/session"
 import { useServer } from "../../context/server"
 import { useLanguage } from "../../context/language"
-import { useVSCode } from "../../context/vscode"
 import { formatRelativeDate } from "../../utils/date"
 import { FeedbackDialog } from "./FeedbackDialog"
 import { VscodeSessionTurn } from "./VscodeSessionTurn"
 import { RevertBanner } from "./RevertBanner"
 import { AccountSwitcher } from "../shared/AccountSwitcher"
+import { LoginBanner } from "../shared/LoginBanner"
 import { KiloNotifications } from "./KiloNotifications"
 import { WorkingIndicator } from "../shared/WorkingIndicator"
 import { activeUserMessageID as getActiveUserMessageID } from "../../context/session-queue"
@@ -48,7 +48,6 @@ export const MessageList: Component<MessageListProps> = (props) => {
   const server = useServer()
   const language = useLanguage()
   const dialog = useDialog()
-  const vscode = useVSCode()
 
   const autoScroll = createAutoScroll({
     working: () => session.status() !== "idle",
@@ -95,16 +94,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
       <Show when={isEmpty()}>
         <div class="welcome-header">
           <AccountSwitcher class="account-switcher-welcome" />
-          <Show when={!server.profileData()}>
-            <button
-              type="button"
-              class="kilo-login-banner"
-              onClick={() => vscode.postMessage({ type: "openProfilePanel" })}
-            >
-              <span class="kilo-login-banner-title">{language.t("welcome.login.title")}</span>
-              <span class="kilo-login-banner-desc">{language.t("welcome.login.desc")}</span>
-            </button>
-          </Show>
+          <LoginBanner />
           <KiloNotifications />
         </div>
       </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/LoginBanner.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/LoginBanner.tsx
@@ -1,0 +1,25 @@
+/**
+ * LoginBanner component
+ * Shown in the welcome screen header when the user is not logged in.
+ * Clicking opens the profile editor tab.
+ */
+
+import { Component, Show } from "solid-js"
+import { useServer } from "../../context/server"
+import { useVSCode } from "../../context/vscode"
+import { useLanguage } from "../../context/language"
+
+export const LoginBanner: Component = () => {
+  const server = useServer()
+  const vscode = useVSCode()
+  const language = useLanguage()
+
+  return (
+    <Show when={!server.profileData()}>
+      <button type="button" class="kilo-login-banner" onClick={() => vscode.postMessage({ type: "openProfilePanel" })}>
+        <span class="kilo-login-banner-title">{language.t("welcome.login.title")}</span>
+        <span class="kilo-login-banner-desc">{language.t("welcome.login.desc")}</span>
+      </button>
+    </Show>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/src/components/shared/LoginBanner.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/LoginBanner.tsx
@@ -15,7 +15,7 @@ export const LoginBanner: Component = () => {
   const language = useLanguage()
 
   return (
-    <Show when={!server.profileData()}>
+    <Show when={server.profileLoaded() && !server.profileData()}>
       <button type="button" class="kilo-login-banner" onClick={() => vscode.postMessage({ type: "openProfilePanel" })}>
         <span class="kilo-login-banner-title">{language.t("welcome.login.title")}</span>
         <span class="kilo-login-banner-desc">{language.t("welcome.login.desc")}</span>

--- a/packages/kilo-vscode/webview-ui/src/context/server.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/server.tsx
@@ -15,6 +15,7 @@ interface ServerContextValue {
   errorDetails: Accessor<string | undefined>
   isConnected: Accessor<boolean>
   profileData: Accessor<ProfileData | null>
+  profileLoaded: Accessor<boolean>
   deviceAuth: Accessor<DeviceAuthState>
   startLogin: () => void
   vscodeLanguage: Accessor<string | undefined>
@@ -35,6 +36,7 @@ export const ServerProvider: ParentComponent = (props) => {
   const [errorMessage, setErrorMessage] = createSignal<string | undefined>()
   const [errorDetails, setErrorDetails] = createSignal<string | undefined>()
   const [profileData, setProfileData] = createSignal<ProfileData | null>(null)
+  const [profileLoaded, setProfileLoaded] = createSignal(false)
   const [deviceAuth, setDeviceAuth] = createSignal<DeviceAuthState>(initialDeviceAuth)
   const [vscodeLanguage, setVscodeLanguage] = createSignal<string | undefined>()
   const [languageOverride, setLanguageOverride] = createSignal<string | undefined>()
@@ -90,6 +92,7 @@ export const ServerProvider: ParentComponent = (props) => {
         case "profileData":
           console.log("[Kilo New] Profile data:", message.data ? "received" : "null")
           setProfileData(message.data)
+          setProfileLoaded(true)
           break
 
         case "deviceAuthStarted":
@@ -146,6 +149,7 @@ export const ServerProvider: ParentComponent = (props) => {
     errorDetails,
     isConnected: () => connectionState() === "connected",
     profileData,
+    profileLoaded,
     deviceAuth,
     startLogin,
     vscodeLanguage,

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1805,6 +1805,49 @@
   white-space: nowrap;
 }
 
+/* Login Banner */
+
+.kilo-login-banner {
+  width: 100%;
+  cursor: pointer;
+  border: 1px solid var(--vscode-panel-border);
+  background: var(--vscode-editor-background);
+  color: var(--vscode-foreground);
+  border-radius: 6px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  font-family: inherit;
+  font-size: var(--vscode-font-size);
+  text-align: left;
+  transition:
+    background 150ms,
+    border-color 150ms;
+}
+
+.kilo-login-banner:hover {
+  background: var(--vscode-list-hoverBackground);
+}
+
+.kilo-login-banner:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
+.kilo-login-banner-title {
+  font-weight: 600;
+  width: 100%;
+}
+
+.kilo-login-banner-desc {
+  width: 100%;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  line-height: 1.4;
+}
+
 /* ============================================
    Permission Dock (VS Code overrides)
    ============================================ */

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1442,6 +1442,10 @@ export interface OpenSettingsPanelRequest {
   tab?: string
 }
 
+export interface OpenProfilePanelRequest {
+  type: "openProfilePanel"
+}
+
 export interface RequestAgentsMessage {
   type: "requestAgents"
 }
@@ -1945,6 +1949,7 @@ export type WebviewMessage =
   | RefreshProfileRequest
   | OpenExternalRequest
   | OpenSettingsPanelRequest
+  | OpenProfilePanelRequest
   | OpenFileRequest
   | CancelLoginRequest
   | SetOrganizationRequest

--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -4,7 +4,7 @@ import path from "path"
 import os from "os"
 import { Filesystem } from "../util/filesystem"
 
-const app = "kilo" // kilocode_change
+const app = process.env.KILO_DEV ? "kilo-dev" : "kilo" // kilocode_change
 
 const data = path.join(xdgData!, app)
 const cache = path.join(xdgCache!, app)


### PR DESCRIPTION
## Context

When a user is not logged in, the chat welcome screen shows no prompt to sign in. This adds a login banner in the same position and style as the `AccountSwitcher` component so unauthenticated users have a clear, native-feeling call to action.

Also fixes a dev isolation gap: in `--dev-data-dirs` mode the marketplace service was still writing global config to `~/.config/kilo/kilo.json` instead of the dev-isolated `~/.config/kilo-dev/kilo.json`.

## Implementation

- Added a `LoginBanner` component (`components/shared/LoginBanner.tsx`) shown in the welcome header when `server.profileData()` is null. Clicking posts an `openProfilePanel` webview→extension message.
- Added `OpenProfilePanelRequest` to the `WebviewMessage` union in `messages.ts`.
- Handled `openProfilePanel` in `KiloProvider.ts` by executing `kilo-code.new.profileButtonClicked`, which opens the profile as an editor tab via `SettingsEditorProvider` — the same action as the toolbar profile button.
- Added `welcome.login.title` and `welcome.login.desc` i18n keys to all 18 language bundles.
- Styled the banner using VS Code theme variables (`--vscode-panel-border`, `--vscode-editor-background`, `--vscode-foreground`, `--vscode-descriptionForeground`, `--vscode-list-hoverBackground`), no hardcoded colours or widths.
- Fixed `MarketplacePaths.globalConfigDir()` to use `kilo-dev` when `KILO_DEV` is set, matching the CLI's isolated data dirs.
- Added a `VSCode - Run Extension (Dev CLI Data Dirs)` launch config and `extension:dev-data-dirs` npm script. Running with this config sets `KILO_DEV=1`, which makes the CLI and the marketplace service both use `~/.config/kilo-dev/` so dev sessions are fully isolated from the real user config.

## Screenshot

<img width="517" height="869" alt="Screen Shot 2026-03-26 at 3 55 36 PM" src="https://github.com/user-attachments/assets/ebdb277e-7840-4665-a1be-610bff3dd262" />

## Demo

https://github.com/user-attachments/assets/71032340-bb4a-47b3-97f8-fe4ba1f64e4f

## How to Test

**Login banner:**
- Open the extension while not logged in to Kilo Code
- The welcome screen should show a "Login with Kilo Code" banner below the account switcher area
- Clicking the banner should open the Kilo Profile editor tab (same as clicking the profile button in the toolbar)
- Log in — the banner should disappear

**Dev data dirs:**
- Launch VS Code using the `VSCode - Run Extension (Dev CLI Data Dirs)` launch config (or run `bun run extension:dev-data-dirs`)
- Install a marketplace item at global scope — it should write to `~/.config/kilo-dev/kilo.json`, not `~/.config/kilo/kilo.json`