### PR TITLE
Cli - Include parentSessionId in heartbeat session info

### DIFF
--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -249,6 +249,7 @@ export namespace KiloSessions {
               id,
               status: statuses[id]?.type ?? "idle",
               title: session.title,
+              parentSessionId: session.parentID,
               gitUrl,
               gitBranch,
             }

--- a/packages/opencode/src/kilo-sessions/remote-protocol.ts
+++ b/packages/opencode/src/kilo-sessions/remote-protocol.ts
@@ -7,6 +7,7 @@ export namespace RemoteProtocol {
     id: z.string(),
     status: z.string(),
     title: z.string(),
+    parentSessionId: z.string().optional(),
     gitUrl: z.string().optional(),
     gitBranch: z.string().optional(),
   })

--- a/packages/opencode/test/kilo-sessions/remote-protocol.test.ts
+++ b/packages/opencode/test/kilo-sessions/remote-protocol.test.ts
@@ -17,6 +17,18 @@ describe("RemoteProtocol", () => {
     }
   })
 
+  test("heartbeat with parentSessionId parses", () => {
+    const msg = {
+      type: "heartbeat",
+      sessions: [{ id: "ses_child", status: "busy", title: "Sub task", parentSessionId: "ses_root" }],
+    }
+    const result = RemoteProtocol.Heartbeat.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sessions[0].parentSessionId).toBe("ses_root")
+    }
+  })
+
   test("valid event parses", () => {
     const msg = {
       type: "event",


### PR DESCRIPTION
Adds `parentSessionId` to the `RemoteProtocol.SessionInfo` schema so that parent-child session relationships are communicated via heartbeat messages in the remote control protocol.

Changes:
- Added optional `parentSessionId` field to `SessionInfo` in `remote-protocol.ts`
- Populated from `session.parentID` in `getSessions()` within `kilo-sessions.ts`
- Added test coverage for heartbeat messages containing `parentSessionId`