### PR TITLE
fix: Reset All Settings now clears globalState items

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2303,10 +2303,24 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       await config.update(leaf, undefined, vscode.ConfigurationTarget.Global)
     }
 
+    // Clear globalState items that are not part of the configuration
+    await this.extensionContext?.globalState.update("variantSelections", undefined)
+    await this.extensionContext?.globalState.update("recentModels", undefined)
+    await this.extensionContext?.globalState.update("kilo.dismissedNotificationIds", undefined)
+
     // Re-send all settings to the webview so the UI reflects the reset
     this.sendAutocompleteSettings()
     this.sendBrowserSettings()
     this.sendNotificationSettings()
+
+    // Re-send globalState items to the webview
+    this.postMessage({ type: "variantsLoaded", variants: {} })
+    this.postMessage({ type: "recentsLoaded", recents: [] })
+
+    // Re-fetch notifications to reflect cleared dismissed IDs
+    await this.fetchAndSendNotifications()
+
+    vscode.window.showInformationMessage("Kilo Code settings have been reset to defaults.")
   }
 
   /**


### PR DESCRIPTION
## Problem
The "Reset All Settings" button was only resetting VS Code configuration settings with the 'kilo-code.new.' prefix, but it wasn't clearing globalState items that store user preferences like variant selections, recent models, and dismissed notification IDs.

This caused the modes and other settings to appear unchanged after clicking Reset, as reported in #7727.

## Solution
Extended the "handleResetAllSettings" function to also:
1. Clear globalState items (variantSelections, recentModels, kilo.dismissedNotificationIds)
2. Send updated state to the webview so UI reflects the reset
3. Re-fetch notifications to reflect cleared dismissed IDs
4. Show a confirmation message when reset is complete

## Changes
- Modified: packages/kilo-vscode/src/KiloProvider.ts

Fixes #7727