### PR TITLE
fix(cli): infinite empty tool-calls loop when model returns tool_calls with no tools

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -443,6 +443,13 @@ export namespace SessionProcessor {
               })
             }
           }
+          // kilocode_change start — guard empty tool-calls (#7756)
+          const empty = input.assistantMessage.finish === "tool-calls" && !p.some((part) => part.type === "tool")
+          if (empty) {
+            log.warn("empty tool-calls", { messageID: input.assistantMessage.id })
+            input.assistantMessage.finish = "stop"
+          }
+          // kilocode_change end
           input.assistantMessage.time.completed = Date.now()
           await Session.updateMessage(input.assistantMessage)
           if (needsCompaction) return "compact"

--- a/packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, mock, spyOn, test } from "bun:test"
+
+mock.module("@/kilo-sessions/remote-sender", () => ({
+  RemoteSender: {
+    create() {
+      return {
+        queue() {},
+        flush: async () => undefined,
+      }
+    },
+  },
+}))
+
+import type { Provider } from "../../src/provider/provider"
+import type { LLM as LLMType } from "../../src/session/llm"
+import type { MessageV2 } from "../../src/session/message-v2"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+function model(): Provider.Model {
+  return {
+    id: "gpt-4",
+    providerID: "openai",
+    name: "GPT-4",
+    limit: {
+      context: 128000,
+      input: 0,
+      output: 4096,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    capabilities: {
+      toolcall: true,
+      attachment: false,
+      reasoning: false,
+      temperature: true,
+      input: { text: true, image: false, audio: false, video: false },
+      output: { text: true, image: false, audio: false, video: false },
+    },
+    api: { id: "openai", url: "https://api.openai.com/v1", npm: "@ai-sdk/openai" },
+    options: {},
+    headers: {},
+  } as Provider.Model
+}
+
+function stream(events: Array<Record<string, unknown>>): any {
+  return {
+    fullStream: (async function* () {
+      for (const e of events) yield e
+    })(),
+  }
+}
+
+describe("session processor empty tool-calls", () => {
+  test("converts finish to stop when model returns tool-calls with no tools", async () => {
+    const { Instance } = await import("../../src/project/instance")
+    const { LLM } = await import("../../src/session/llm")
+    const { Identifier } = await import("../../src/id/id")
+    const { MessageV2 } = await import("../../src/session/message-v2")
+
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { Session } = await import("../../src/session")
+        const { SessionProcessor } = await import("../../src/session/processor")
+        const m = model()
+        const session = await Session.create({})
+        const user = (await Session.updateMessage({
+          id: Identifier.ascending("message"),
+          role: "user",
+          sessionID: session.id,
+          time: { created: Date.now() },
+          agent: "code",
+          model: { providerID: m.providerID, modelID: m.id },
+          tools: {},
+        })) as MessageV2.User
+        const assistant = (await Session.updateMessage({
+          id: Identifier.ascending("message"),
+          parentID: user.id,
+          role: "assistant",
+          mode: "code",
+          agent: "code",
+          path: { cwd: Instance.directory, root: Instance.worktree },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: m.id,
+          providerID: m.providerID,
+          time: { created: Date.now() },
+          sessionID: session.id,
+        })) as MessageV2.Assistant
+
+        // Stream with finish_reason "tool-calls" but zero tool events
+        const llm = spyOn(LLM, "stream").mockResolvedValueOnce(
+          stream([
+            { type: "start" },
+            { type: "start-step" },
+            {
+              type: "finish-step",
+              finishReason: "tool-calls",
+              usage: { inputTokens: 100, completionTokens: 41, totalTokens: 141 },
+              providerMetadata: undefined,
+            },
+            { type: "finish" },
+          ]),
+        )
+
+        const processor = SessionProcessor.create({
+          assistantMessage: assistant,
+          sessionID: session.id,
+          model: m,
+          abort: AbortSignal.any([]),
+        })
+        const inp: LLMType.StreamInput = {
+          user,
+          sessionID: session.id,
+          model: m,
+          agent: { name: "code", mode: "primary", permission: [], options: {} } as any,
+          system: [],
+          abort: AbortSignal.any([]),
+          messages: [],
+          tools: {},
+        }
+
+        try {
+          const result = await processor.process(inp)
+          // The processor must convert "tool-calls" → "stop" when no tools were emitted
+          expect(processor.message.finish).toBe("stop")
+          // Verify no tool parts exist on the message
+          const parts = await MessageV2.parts(assistant.id)
+          const tools = parts.filter((p: any) => p.type === "tool")
+          expect(tools.length).toBe(0)
+        } finally {
+          llm.mockRestore()
+        }
+      },
+    })
+  })
+
+  test("preserves tool-calls finish when tool parts exist", async () => {
+    const { Instance } = await import("../../src/project/instance")
+    const { LLM } = await import("../../src/session/llm")
+    const { Identifier } = await import("../../src/id/id")
+    const { MessageV2 } = await import("../../src/session/message-v2")
+
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { Session } = await import("../../src/session")
+        const { SessionProcessor } = await import("../../src/session/processor")
+        const m = model()
+        const session = await Session.create({})
+        const user = (await Session.updateMessage({
+          id: Identifier.ascending("message"),
+          role: "user",
+          sessionID: session.id,
+          time: { created: Date.now() },
+          agent: "code",
+          model: { providerID: m.providerID, modelID: m.id },
+          tools: {},
+        })) as MessageV2.User
+        const assistant = (await Session.updateMessage({
+          id: Identifier.ascending("message"),
+          parentID: user.id,
+          role: "assistant",
+          mode: "code",
+          agent: "code",
+          path: { cwd: Instance.directory, root: Instance.worktree },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: m.id,
+          providerID: m.providerID,
+          time: { created: Date.now() },
+          sessionID: session.id,
+        })) as MessageV2.Assistant
+
+        // Stream with finish_reason "tool-calls" AND a tool-input-start event
+        const llm = spyOn(LLM, "stream").mockResolvedValueOnce(
+          stream([
+            { type: "start" },
+            { type: "start-step" },
+            { type: "tool-input-start", id: "call_1", toolName: "test_tool" },
+            {
+              type: "finish-step",
+              finishReason: "tool-calls",
+              usage: { inputTokens: 100, completionTokens: 41, totalTokens: 141 },
+              providerMetadata: undefined,
+            },
+            { type: "finish" },
+          ]),
+        )
+
+        const processor = SessionProcessor.create({
+          assistantMessage: assistant,
+          sessionID: session.id,
+          model: m,
+          abort: AbortSignal.any([]),
+        })
+        const inp: LLMType.StreamInput = {
+          user,
+          sessionID: session.id,
+          model: m,
+          agent: { name: "code", mode: "primary", permission: [], options: {} } as any,
+          system: [],
+          abort: AbortSignal.any([]),
+          messages: [],
+          tools: {},
+        }
+
+        try {
+          const result = await processor.process(inp)
+          // finish must remain "tool-calls" because a tool part WAS created
+          expect(processor.message.finish).toBe("tool-calls")
+          expect(result).toBe("continue")
+          // Verify the tool part exists
+          const parts = await MessageV2.parts(assistant.id)
+          const tools = parts.filter((p: any) => p.type === "tool")
+          expect(tools.length).toBe(1)
+        } finally {
+          llm.mockRestore()
+        }
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #7756. When the LLM returns `finish_reason: "tool-calls"` but emits zero actual tool call parts, the prompt loop creates a new empty assistant message every ~6 seconds indefinitely. Observed in a production session that accumulated 173 empty messages in ~15 minutes with ~$10 wasted API cost.

The fix detects this degenerate case in the session processor: if `finish` is `"tool-calls"` but the assistant message has no tool parts, it converts `finish` to `"stop"` so the prompt loop's existing exit checks terminate normally.

## Steps to Reproduce

1. Start any session with a model that supports tool calling
2. Trigger a condition where the model returns `finish_reason: "tool-calls"` with no actual tool call events in the stream (observed after API errors like "model does not support assistant message prefill" in long sessions)
3. **Before fix:** Infinite loop — new empty assistant message every ~6 seconds, session grows unboundedly, abort + retry re-enters the loop because `toModelMessages()` strips empty assistant turns making the model see identical context each iteration
4. **After fix:** Session completes normally, `finish` is converted to `"stop"`

## Root Cause

Both exit checks in `prompt.ts` exclude `"tool-calls"` from termination:

- **Top-of-loop** (`prompt.ts:364`): `!["tool-calls", "unknown"].includes(lastAssistant.finish)` → false
- **Post-process** (`prompt.ts:770`): `modelFinished` = false for same reason

The processor returns `"continue"` (no error/blocked/compaction), so the loop spins.

**Secondary amplifier:** `toModelMessages()` at `message-v2.ts:789` filters out messages whose only parts are `step-start`, so empty assistant turns are invisible to the model — making the response perfectly stable and self-reinforcing.

## Changes

- **`packages/opencode/src/session/processor.ts`** — After stream completes, detect empty tool-calls (finish is `"tool-calls"` but no tool parts exist) and convert finish to `"stop"`. Reuses the already-queried parts array, no extra DB call.
- **`packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts`** — Two tests:
  1. Reproduces the bug: mock stream with `finishReason: "tool-calls"` and no tool events → asserts finish is converted to `"stop"`
  2. Control: mock stream with `tool-input-start` event → asserts finish stays `"tool-calls"` and result is `"continue"`