### PR TITLE
fix(vscode): reconcile stale session statuses on reconnect

### DIFF
--- a/packages/kilo-vscode/src/session-status.ts
+++ b/packages/kilo-vscode/src/session-status.ts
@@ -25,7 +25,8 @@ export async function seedSessionStatuses(
 ): Promise<void> {
   try {
     const result = await client.session.status({ directory: dir })
-    const active = result.data ?? {}
+    if (!result.data) return
+    const active = result.data
 
     // Seed/update entries the server knows about
     for (const [sid, info] of Object.entries(active) as [string, SessionStatus][]) {

--- a/packages/kilo-vscode/src/session-status.ts
+++ b/packages/kilo-vscode/src/session-status.ts
@@ -25,8 +25,10 @@ export async function seedSessionStatuses(
 ): Promise<void> {
   try {
     const result = await client.session.status({ directory: dir })
-    if (!result.data) return
-    for (const [sid, info] of Object.entries(result.data) as [string, SessionStatus][]) {
+    const active = result.data ?? {}
+
+    // Seed/update entries the server knows about
+    for (const [sid, info] of Object.entries(active) as [string, SessionStatus][]) {
       map.set(sid, info.type)
       post({
         type: "sessionStatus",
@@ -34,6 +36,15 @@ export async function seedSessionStatuses(
         status: info.type,
         ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
       })
+    }
+
+    // Reconcile: any locally non-idle session absent from the server response
+    // means the server lost its in-memory state (crash/restart). Reset to idle.
+    for (const [sid, status] of map) {
+      if (status !== "idle" && !active[sid]) {
+        map.set(sid, "idle")
+        post({ type: "sessionStatus", sessionID: sid, status: "idle" })
+      }
     }
   } catch (error) {
     console.error("[Kilo New] KiloProvider: Failed to seed session statuses:", error)

--- a/packages/kilo-vscode/tests/unit/session-status.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-status.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "bun:test"
+import { seedSessionStatuses, getBusySessionCount } from "../../src/session-status"
+import type { SessionStatus } from "@kilocode/sdk/v2/client"
+
+/**
+ * Minimal fake client that satisfies the KiloClient.session.status() call.
+ * Returns controlled data or throws to simulate server errors.
+ */
+function createClient(response: { data: Record<string, SessionStatus> | null } | Error) {
+  return {
+    session: {
+      status: async (_params: { directory: string }) => {
+        if (response instanceof Error) throw response
+        return response
+      },
+    },
+  } as Parameters<typeof seedSessionStatuses>[0]
+}
+
+function collect() {
+  const msgs: unknown[] = []
+  return { msgs, post: (msg: unknown) => msgs.push(msg) }
+}
+
+// ---------------------------------------------------------------------------
+// seedSessionStatuses
+// ---------------------------------------------------------------------------
+
+describe("seedSessionStatuses", () => {
+  it("seeds map and posts messages for non-idle sessions", async () => {
+    const client = createClient({
+      data: {
+        s1: { type: "busy" },
+        s2: { type: "retry", attempt: 3, message: "rate limited", next: 5000 },
+      },
+    })
+    const map = new Map<string, SessionStatus["type"]>()
+    const { msgs, post } = collect()
+
+    await seedSessionStatuses(client, "/repo", map, post)
+
+    expect(map.get("s1")).toBe("busy")
+    expect(map.get("s2")).toBe("retry")
+    expect(msgs).toEqual([
+      { type: "sessionStatus", sessionID: "s1", status: "busy" },
+      { type: "sessionStatus", sessionID: "s2", status: "retry", attempt: 3, message: "rate limited", next: 5000 },
+    ])
+  })
+
+  // ---- THE BUG: stale entries not cleared on reconnect ----
+
+  it("clears stale busy entries absent from server response", async () => {
+    const client = createClient({ data: {} })
+    const map = new Map<string, SessionStatus["type"]>([["s1", "busy"]])
+    const { msgs, post } = collect()
+
+    await seedSessionStatuses(client, "/repo", map, post)
+
+    expect(map.get("s1")).toBe("idle")
+    expect(msgs).toEqual([{ type: "sessionStatus", sessionID: "s1", status: "idle" }])
+  })
+
+  it("clears stale retry entries absent from server response", async () => {
+    const client = createClient({ data: {} })
+    const map = new Map<string, SessionStatus["type"]>([["s1", "retry"]])
+    const { msgs, post } = collect()
+
+    await seedSessionStatuses(client, "/repo", map, post)
+
+    expect(map.get("s1")).toBe("idle")
+    expect(msgs).toEqual([{ type: "sessionStatus", sessionID: "s1", status: "idle" }])
+  })
+
+  it("preserves entries that server confirms as still active", async () => {
+    const client = createClient({ data: { s1: { type: "busy" } } })
+    const map = new Map<string, SessionStatus["type"]>([["s1", "busy"]])
+    const { msgs, post } = collect()
+
+    await seedSessionStatuses(client, "/repo", map, post)
+
+    expect(map.get("s1")).toBe("busy")
+    expect(msgs).toEqual([{ type: "sessionStatus", sessionID: "s1", status: "busy" }])
+  })
+
+  it("does not send redundant idle for already-idle entries", async () => {
+    const client = createClient({ data: {} })
+    const map = new Map<string, SessionStatus["type"]>([["s1", "idle"]])
+    const { msgs, post } = collect()
+
+    await seedSessionStatuses(client, "/repo", map, post)
+
+    // Already idle — no message should be posted
+    expect(msgs).toEqual([])
+    expect(map.get("s1")).toBe("idle")
+  })
+
+  it("handles mixed: some stale, some confirmed, some new", async () => {
+    const client = createClient({
+      data: {
+        confirmed: { type: "busy" },
+        fresh: { type: "busy" },
+      },
+    })
+    const map = new Map<string, SessionStatus["type"]>([
+      ["stale", "busy"],
+      ["confirmed", "retry"],
+    ])
+    const { msgs, post } = collect()
+
+    await seedSessionStatuses(client, "/repo", map, post)
+
+    // stale: was busy locally, absent from server → idle
+    expect(map.get("stale")).toBe("idle")
+    // confirmed: was retry locally, server says busy → busy
+    expect(map.get("confirmed")).toBe("busy")
+    // fresh: new from server → busy
+    expect(map.get("fresh")).toBe("busy")
+    // Messages: server entries first (confirmed, fresh), then stale reconciliation
+    expect(msgs).toEqual([
+      { type: "sessionStatus", sessionID: "confirmed", status: "busy" },
+      { type: "sessionStatus", sessionID: "fresh", status: "busy" },
+      { type: "sessionStatus", sessionID: "stale", status: "idle" },
+    ])
+  })
+
+  it("handles server error gracefully — no map changes", async () => {
+    const client = createClient(new Error("connection refused"))
+    const map = new Map<string, SessionStatus["type"]>([["s1", "busy"]])
+    const { msgs, post } = collect()
+
+    await seedSessionStatuses(client, "/repo", map, post)
+
+    // Map unchanged on error — conservative behavior
+    expect(map.get("s1")).toBe("busy")
+    expect(msgs).toEqual([])
+  })
+
+  it("handles null data response — clears stale entries", async () => {
+    const client = createClient({ data: null })
+    const map = new Map<string, SessionStatus["type"]>([["s1", "busy"]])
+    const { msgs, post } = collect()
+
+    await seedSessionStatuses(client, "/repo", map, post)
+
+    expect(map.get("s1")).toBe("idle")
+    expect(msgs).toEqual([{ type: "sessionStatus", sessionID: "s1", status: "idle" }])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getBusySessionCount
+// ---------------------------------------------------------------------------
+
+describe("getBusySessionCount", () => {
+  it("returns 0 for empty map", () => {
+    expect(getBusySessionCount(new Map())).toBe(0)
+  })
+
+  it("counts only busy entries, not idle or retry", () => {
+    const map = new Map<string, SessionStatus["type"]>([
+      ["a", "busy"],
+      ["b", "idle"],
+      ["c", "retry"],
+      ["d", "busy"],
+    ])
+    expect(getBusySessionCount(map)).toBe(2)
+  })
+})

--- a/packages/kilo-vscode/tests/unit/session-status.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-status.test.ts
@@ -135,15 +135,17 @@ describe("seedSessionStatuses", () => {
     expect(msgs).toEqual([])
   })
 
-  it("handles null data response — clears stale entries", async () => {
+  it("handles null data response — no map changes", async () => {
     const client = createClient({ data: null })
     const map = new Map<string, SessionStatus["type"]>([["s1", "busy"]])
     const { msgs, post } = collect()
 
     await seedSessionStatuses(client, "/repo", map, post)
 
-    expect(map.get("s1")).toBe("idle")
-    expect(msgs).toEqual([{ type: "sessionStatus", sessionID: "s1", status: "idle" }])
+    // Null data could mean a non-2xx response (401/500), not "no active sessions".
+    // Conservative: leave map unchanged to avoid false-clearing busy sessions.
+    expect(map.get("s1")).toBe("busy")
+    expect(msgs).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Summary

- Fix session status stuck on "busy" after CLI server crash/restart (#7757)
- `seedSessionStatuses()` now reconciles stale entries: locally non-idle sessions absent from the server response are reset to idle
- 10 new unit tests covering the full reconciliation flow

## Steps to Reproduce

1. Open a workspace in VS Code with Kilo extension
2. Start a session and send a prompt that triggers tool use (e.g. file edits)
3. While the session is actively processing (spinner visible), kill the CLI backend process:
   - Find the PID: `ps aux | grep 'kilo serve'`
   - Kill it: `kill -9 <PID>`
4. The extension will reconnect to a fresh server automatically
5. **Before fix:** The session shows an infinite spinner and incrementing timer forever
6. **After fix:** The spinner clears on reconnect — the session shows as idle


https://github.com/user-attachments/assets/bbd2345a-a953-480a-a9a9-90c5d57885fe



## Root Cause

`SessionStatus` in the CLI is entirely in-memory. When the process crashes:
1. No `cancel()` runs, so no `session.status { type: "idle" }` SSE event is emitted
2. The new server starts with empty status (`SessionStatus.list()` returns `{}`)
3. `seedSessionStatuses()` only added entries from the server — it never cleared stale entries
4. The webview's `statusMap` + `busySinceMap` retained the stale "busy" state
5. `WorkingIndicator` showed the spinner forever (`status() !== "idle"`)

## TDD Approach

Commit 1 adds the failing tests that reproduce #7757. Commit 2 adds the fix that makes them pass.

Fixes #7757