### PR TITLE
fix(vscode): recover agent manager on restart

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -276,14 +276,12 @@ export class AgentManagerProvider implements Disposable {
           // already emitted before the webview was ready to receive messages.
           if (this.cachedWorktreeStats) this.postToWebview(this.cachedWorktreeStats)
           if (this.cachedLocalStats) this.postToWebview(this.cachedLocalStats)
-          // Refresh sessions after pushState so the webview's sessionsLoaded
-          // handler is guaranteed to be registered (requestState fires from
-          // onMount). Without this, the initial refreshSessions() in
-          // initializeState() can race ahead of webview mount, causing
-          // sessionsLoaded to never flip to true.
-          if (this.state.getSessions().length > 0) {
-            this.panel?.sessions.refreshSessions()
-          }
+          // Always refresh sessions after pushState so the webview receives
+          // a sessionsLoaded message. Without this unconditional call, closing
+          // and reopening the panel (or recovering from a backend crash) can
+          // leave sessionsLoaded stuck on false because the initial
+          // refreshSessions() in initializeState() raced ahead of mount.
+          this.panel?.sessions.refreshSessions()
         })
         .catch((err) => {
           this.log("initializeState failed, pushing partial state:", err)

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -321,13 +321,12 @@ describe("Agent Manager Webview — non-git sessionsLoaded fix", () => {
   /**
    * Regression: when isGitRepo is false, the Kilo server never sends a
    * "sessionsLoaded" message, so the skeleton was stuck forever.
-   * The fix must set sessionsLoaded(true) when receiving a state message
-   * with isGitRepo === false.
+   * The fix must set sessionsLoaded(true) from the state-application path
+   * when isGitRepo === false.
    */
   it("sets sessionsLoaded when agentManager.state arrives with isGitRepo false", () => {
-    // Find the agentManager.state handler block
-    const start = tsx.indexOf('"agentManager.state"')
-    expect(start, "agentManager.state handler must exist").toBeGreaterThan(-1)
+    const start = tsx.indexOf("const applyState =")
+    expect(start, "applyState helper must exist").toBeGreaterThan(-1)
     const snippet = tsx.slice(start, start + 800)
     expect(snippet, "must call setSessionsLoaded in the non-git branch").toContain("setSessionsLoaded")
     expect(snippet, "must check isGitRepo === false before setting sessionsLoaded").toMatch(

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -312,6 +312,44 @@ const AgentManagerContent: Component = () => {
   const repoDefaultBranch = () => defaultBaseBranch() ?? repoDetectedBranch() ?? "main"
   const hasConfiguredBranch = () => !!defaultBaseBranch()
 
+  const applyState = (state: AgentManagerStateMessage) => {
+    setWorktrees(state.worktrees)
+    setManagedSessions(state.sessions)
+    setStaleWorktreeIds(new Set(state.staleWorktreeIds ?? []))
+    if (state.isGitRepo !== undefined) setIsGitRepo(state.isGitRepo)
+    if (!worktreesLoaded()) setWorktreesLoaded(true)
+    if (state.isGitRepo === false && !sessionsLoaded()) setSessionsLoaded(true)
+    if (state.tabOrder) setWorktreeTabOrder(state.tabOrder)
+    if (state.worktreeOrder) setSidebarWorktreeOrder(state.worktreeOrder)
+    if (state.reviewDiffStyle === "split" || state.reviewDiffStyle === "unified") {
+      setReviewDiffStyle(state.reviewDiffStyle)
+    }
+    if ("defaultBaseBranch" in state) setDefaultBaseBranch(state.defaultBaseBranch || undefined)
+    const current = session.currentSessionID()
+    if (current) {
+      const ms = state.sessions.find((s) => s.id === current)
+      if (ms?.worktreeId) setSelection(ms.worktreeId)
+    }
+    const localOrder = state.tabOrder?.[LOCAL]
+    if (localOrder && localSessionIDs().length > 0) {
+      const reordered = applyTabOrder(
+        localSessionIDs().map((id) => ({ id })),
+        localOrder,
+      ).map((item) => item.id)
+      setLocalSessionIDs(reordered)
+    }
+    if (state.sessionsCollapsed !== undefined) setSessionsCollapsed(state.sessionsCollapsed)
+    const ids = new Set(state.worktrees.map((wt) => wt.id))
+    setBusyWorktrees((prev) => {
+      const next = new Map([...prev].filter(([id]) => ids.has(id)))
+      return next.size === prev.size ? prev : next
+    })
+  }
+
+  const requestState = () => {
+    vscode.postMessage({ type: "agentManager.requestState" })
+  }
+
   const DEFAULT_SIDEBAR_WIDTH = 260
   const MIN_SIDEBAR_WIDTH = 200
   const MAX_SIDEBAR_WIDTH_RATIO = 0.4
@@ -997,6 +1035,41 @@ const AgentManagerContent: Component = () => {
     if (agent) session.selectAgent(agent.name)
   }
 
+  // Subscribe outside onMount so early sessionsLoaded messages (posted before
+  // the component mounts) are not missed. This matches the codebase pattern for
+  // loaded-message listeners and prevents the loading skeleton from persisting
+  // after a backend crash/restart + panel reopen.
+  const unsubState = vscode.onMessage((msg) => {
+    if (msg.type !== "agentManager.state") return
+    applyState(msg as AgentManagerStateMessage)
+  })
+  onCleanup(unsubState)
+
+  const unsubSessions = vscode.onMessage((msg) => {
+    if (msg.type !== "sessionsLoaded") return
+    if (!sessionsLoaded()) setSessionsLoaded(true)
+  })
+  onCleanup(unsubSessions)
+
+  // Retry state requests while the panel is bootstrapping so reopening after a
+  // backend restart cannot get stuck behind a missed requestState/refresh race.
+  const retryMs = 500
+  const maxRetries = 10
+  let retries = 0
+  const retry = setInterval(() => {
+    if (worktreesLoaded() && sessionsLoaded()) {
+      clearInterval(retry)
+      return
+    }
+    retries++
+    if (retries >= maxRetries) {
+      clearInterval(retry)
+      return
+    }
+    requestState()
+  }, retryMs)
+  onCleanup(() => clearInterval(retry))
+
   onMount(() => {
     const handler = (event: MessageEvent) => {
       const msg = event.data as ExtensionMessage
@@ -1100,11 +1173,6 @@ const AgentManagerContent: Component = () => {
       }
     })
 
-    // Mark sessions loaded as soon as the session context receives data (even if empty)
-    const unsubSessions = vscode.onMessage((msg) => {
-      if (msg.type === "sessionsLoaded" && !sessionsLoaded()) setSessionsLoaded(true)
-    })
-
     const unsub = vscode.onMessage((msg) => {
       if (msg.type === "agentManager.repoInfo") {
         const info = msg as AgentManagerRepoInfoMessage
@@ -1176,46 +1244,6 @@ const AgentManagerContent: Component = () => {
       if (msg.type === "agentManager.keybindings") {
         const ev = msg as AgentManagerKeybindingsMessage
         setKb(ev.bindings)
-      }
-
-      if (msg.type === "agentManager.state") {
-        const state = msg as AgentManagerStateMessage
-        setWorktrees(state.worktrees)
-        setManagedSessions(state.sessions)
-        setStaleWorktreeIds(new Set(state.staleWorktreeIds ?? []))
-        if (state.isGitRepo !== undefined) setIsGitRepo(state.isGitRepo)
-        if (!worktreesLoaded()) setWorktreesLoaded(true)
-        // When not a git repo, also mark sessions as loaded since the Kilo
-        // server won't connect to send the sessionsLoaded message.
-        if (state.isGitRepo === false && !sessionsLoaded()) setSessionsLoaded(true)
-        if (state.tabOrder) setWorktreeTabOrder(state.tabOrder)
-        if (state.worktreeOrder) setSidebarWorktreeOrder(state.worktreeOrder)
-        if (state.reviewDiffStyle === "split" || state.reviewDiffStyle === "unified") {
-          setReviewDiffStyle(state.reviewDiffStyle)
-        }
-        if ("defaultBaseBranch" in state) setDefaultBaseBranch(state.defaultBaseBranch || undefined)
-        const current = session.currentSessionID()
-        if (current) {
-          const ms = state.sessions.find((s) => s.id === current)
-          if (ms?.worktreeId) setSelection(ms.worktreeId)
-        }
-        // Recover local tab order from persisted state
-        const localOrder = state.tabOrder?.[LOCAL]
-        if (localOrder && localSessionIDs().length > 0) {
-          const reordered = applyTabOrder(
-            localSessionIDs().map((id) => ({ id })),
-            localOrder,
-          ).map((item) => item.id)
-          setLocalSessionIDs(reordered)
-        }
-        // Recover sessions collapsed state from extension-persisted state
-        if (state.sessionsCollapsed !== undefined) setSessionsCollapsed(state.sessionsCollapsed)
-        // Clear busy state for worktrees that have been removed
-        const ids = new Set(state.worktrees.map((wt) => wt.id))
-        setBusyWorktrees((prev) => {
-          const next = new Map([...prev].filter(([id]) => ids.has(id)))
-          return next.size === prev.size ? prev : next
-        })
       }
 
       // When a multi-version progress update arrives, mark newly created worktrees as loading
@@ -1385,7 +1413,6 @@ const AgentManagerContent: Component = () => {
       window.removeEventListener("keydown", deleteKeyHandler)
       window.removeEventListener("focus", onWindowFocus)
       unsubCreate()
-      unsubSessions()
       unsub()
     })
   })
@@ -1395,7 +1422,7 @@ const AgentManagerContent: Component = () => {
     selectLocal()
     // Request worktree/session state from extension — handles race where
     // initializeState() pushState fires before the webview is mounted
-    vscode.postMessage({ type: "agentManager.requestState" })
+    requestState()
     // Open a pending "New Session" tab if there are no persisted local sessions
     if (localSessionIDs().length === 0) {
       addPendingTab()


### PR DESCRIPTION
## Why

If the Kilo helper process stops, opening Agent Manager again can leave it stuck on loading blocks. You can still send a message, but the side lists never come back.

## What changed

The panel now asks for its starting data again while it opens and gives that request a short retry window. It also starts listening for state updates earlier, so it does not miss the message that fills in the lists. The app now refreshes the session list every time the panel asks for state, even when no worktree session exists yet. This lets Agent Manager recover cleanly after the server restarts.

### Before


https://github.com/user-attachments/assets/6c044763-761c-4d67-b092-a0ba61b07af5



### After


https://github.com/user-attachments/assets/360a7334-2f67-4bb6-be9a-c326ace51fdb



## How to test

1. Open Agent Manager and make sure the side lists appear.
2. Kill the `kilo serve` process while the panel is open.
3. Close Agent Manager, open it again, and wait a few seconds.
4. Confirm the lists load again instead of staying on loading blocks.
5. Send a message and confirm the panel still works.