### PR TITLE
fix(agent-manager): isolate prompt input drafts per pending tab

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -74,7 +74,7 @@ import { ProviderProvider } from "../src/context/provider"
 import { ConfigProvider } from "../src/context/config"
 import { NotificationsProvider } from "../src/context/notifications"
 import { SessionProvider, useSession } from "../src/context/session"
-import { WorktreeModeProvider } from "../src/context/worktree-mode"
+import { WorktreeModeProvider, useWorktreeMode } from "../src/context/worktree-mode"
 import { ChatView } from "../src/components/chat"
 import { NewWorktreeDialog } from "./NewWorktreeDialog"
 import { LanguageBridge, DataBridge } from "../src/App"
@@ -358,6 +358,10 @@ const AgentManagerContent: Component = () => {
   let pendingCounter = 0
   const PENDING_PREFIX = "pending:"
   const [activePendingId, setActivePendingId] = createSignal<string | undefined>()
+
+  // Sync activePendingId into WorktreeMode context so PromptInput can key drafts per pending tab
+  const worktreeCtx = useWorktreeMode()
+  createEffect(() => worktreeCtx?.setPendingId(activePendingId()))
 
   // Inline delete confirmation: tracks which worktree is awaiting a second click/press
   const [pendingDelete, setPendingDelete] = createSignal<string | null>(null)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -78,7 +78,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
   const history = usePromptHistory()
 
-  const sessionKey = () => session.currentSessionID() ?? "__new__"
+  const sessionKey = () => session.currentSessionID() ?? worktree?.pendingId() ?? "__new__"
 
   const [text, setText] = createSignal("")
   const [reviewComments, setReviewComments] = createSignal<ReviewComment[]>([])

--- a/packages/kilo-vscode/webview-ui/src/context/worktree-mode.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/worktree-mode.tsx
@@ -14,14 +14,22 @@ export type SessionMode = "local" | "worktree"
 interface WorktreeModeContextValue {
   mode: Accessor<SessionMode>
   setMode: (mode: SessionMode) => void
+  /** Active pending tab ID (e.g. "pending:1") — set by Agent Manager so PromptInput can key drafts per tab. */
+  pendingId: Accessor<string | undefined>
+  setPendingId: (id: string | undefined) => void
 }
 
 const WorktreeModeContext = createContext<WorktreeModeContextValue>()
 
 export const WorktreeModeProvider: ParentComponent = (props) => {
   const [mode, setMode] = createSignal<SessionMode>("local")
+  const [pendingId, setPendingId] = createSignal<string | undefined>()
 
-  return <WorktreeModeContext.Provider value={{ mode, setMode }}>{props.children}</WorktreeModeContext.Provider>
+  return (
+    <WorktreeModeContext.Provider value={{ mode, setMode, pendingId, setPendingId }}>
+      {props.children}
+    </WorktreeModeContext.Provider>
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix prompt input text bleeding across multiple new/pending tabs in the Agent Manager's local tab
- Each pending tab now gets a unique draft key via `WorktreeModeContext.pendingId`, so typing in one tab no longer overwrites another's draft

## Problem

All pending tabs shared a single `"__new__"` key in the module-level `drafts` Map because `sessionKey()` fell back to `"__new__"` whenever `currentSessionID()` was `undefined`. Since all pending tabs have no session ID, they all mapped to the same key. Additionally, switching between pending tabs didn't trigger the draft save/restore effect since the key never changed.

## Changes

- **`worktree-mode.tsx`**: Added `pendingId` / `setPendingId` signals to `WorktreeModeContext`
- **`AgentManagerApp.tsx`**: Sync `activePendingId` into the worktree context via a `createEffect`
- **`PromptInput.tsx`**: Use `worktree?.pendingId()` as fallback in `sessionKey()` so each pending tab gets its own draft entry