### PR TITLE
fix(cli): make FreeUsageLimitError non-retryable to prevent unrecoverable backoff loop

### DIFF
--- a/packages/kilo-docs/source-links.md
+++ b/packages/kilo-docs/source-links.md
@@ -7,7 +7,6 @@
   <!-- packages/opencode/src/cli/cmd/github.ts -->
 - <https://app.kilo.ai>
   <!-- packages/opencode/src/kilocode/kilo-commands.tsx -->
-  <!-- packages/opencode/src/session/retry.ts -->
 - <https://app.kilo.ai/config.json>
   <!-- packages/opencode/src/config/config.ts -->
 - <https://app.kilo.ai/credits>

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -67,8 +67,11 @@ export namespace SessionRetry {
       if (isKiloError(error)) return undefined
       // kilocode_change end
       if (!error.data.isRetryable) return undefined
-      if (error.data.responseBody?.includes("FreeUsageLimitError"))
-        return `Free usage exceeded, add credits https://app.kilo.ai` // kilocode_change
+      // kilocode_change start - FreeUsageLimitError is not retryable: retrying the same
+      // capped model is futile and the backoff loop cannot be broken by switching
+      // models in the chat selector (the retry loop holds a stale model ref).
+      if (error.data.responseBody?.includes("FreeUsageLimitError")) return undefined
+      // kilocode_change end
       return error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message
     }
 

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -122,6 +122,16 @@ describe("session.retry.retryable", () => {
 
     expect(SessionRetry.retryable(error)).toBeUndefined()
   })
+
+  test("does not retry FreeUsageLimitError", () => {
+    const error = new MessageV2.APIError({
+      message: "rate limit exceeded",
+      isRetryable: true,
+      responseBody: '{"error":{"code":"FreeUsageLimitError"}}',
+    }).toObject() as ReturnType<NamedError["toObject"]>
+
+    expect(SessionRetry.retryable(error)).toBeUndefined()
+  })
 })
 
 describe("session.message-v2.fromError", () => {


### PR DESCRIPTION
## Summary

- Makes `FreeUsageLimitError` non-retryable instead of entering an infinite backoff loop
- When a free model hits its usage cap, the error now surfaces immediately so users can switch models

## Problem

When a free model hits its rate limit cap, the retry/backoff loop in `SessionProcessor.process()` would retry indefinitely with the same stale model reference captured at creation time. Switching models in the chat selector could not break the loop because:

1. The retry loop in `processor.ts` captures the model once and reuses it on every `continue`
2. Model changes in the chat selector only take effect on the **next user message**
3. `KILO_SESSION_RETRY_LIMIT` is undefined by default (unlimited retries)

Only changing the default model in settings could clear it (after cancelling and restarting).

## Fix

`FreeUsageLimitError` is now classified as non-retryable (same treatment as `PAID_MODEL_AUTH_REQUIRED` and `PROMOTION_MODEL_LIMIT_REACHED`). Retrying a capped free model is futile — the error should surface to the user immediately.

Closes #7743