### PR TITLE
feat(vscode): MCP server connect/disconnect toggle and status display

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -113,6 +113,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private cachedCommandsMessage: unknown = null
   /** Cached configLoaded payload so requestConfig can be served before client is ready */
   private cachedConfigMessage: unknown = null
+  /** Cached mcpStatusLoaded payload so requestMcpStatus can be served before client is ready */
+  private cachedMcpStatusMessage: unknown = null
   /** Ref-count of in-flight handleUpdateConfig calls; prevents fetchAndSendConfig from sending stale data */
   private pending = 0
   /** Cached notificationsLoaded payload */
@@ -641,6 +643,17 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         case "removeMcp":
           this.handleRemoveMcp(message.name).catch((e) => console.error("[Kilo New] handleRemoveMcp failed:", e))
+          break
+        case "requestMcpStatus":
+          this.fetchAndSendMcpStatus().catch((e) => console.error("[Kilo New] fetchAndSendMcpStatus failed:", e))
+          break
+        case "connectMcp":
+          this.handleConnectMcp(message.name).catch((e) => console.error("[Kilo New] handleConnectMcp failed:", e))
+          break
+        case "disconnectMcp":
+          this.handleDisconnectMcp(message.name).catch((e) =>
+            console.error("[Kilo New] handleDisconnectMcp failed:", e),
+          )
           break
 
         case "questionReply":
@@ -1647,6 +1660,51 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       await this.fetchAndSendConfig()
     } else {
       console.error("[Kilo New] KiloProvider: Failed to remove MCP server:", name)
+    }
+  }
+
+  private async fetchAndSendMcpStatus(): Promise<void> {
+    if (!this.client) {
+      if (this.cachedMcpStatusMessage) {
+        this.postMessage(this.cachedMcpStatusMessage)
+      }
+      return
+    }
+
+    try {
+      const directory = this.getWorkspaceDirectory()
+      const { data } = await this.client.mcp.status({ directory })
+      if (data) {
+        const message = { type: "mcpStatusLoaded", status: data }
+        this.cachedMcpStatusMessage = message
+        this.postMessage(message)
+      }
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to fetch MCP status:", error)
+    }
+  }
+
+  private async handleConnectMcp(name: string): Promise<void> {
+    if (!this.client) return
+    try {
+      const directory = this.getWorkspaceDirectory()
+      await this.client.mcp.connect({ name, directory })
+      await this.fetchAndSendMcpStatus()
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to connect MCP:", name, error)
+      await this.fetchAndSendMcpStatus()
+    }
+  }
+
+  private async handleDisconnectMcp(name: string): Promise<void> {
+    if (!this.client) return
+    try {
+      const directory = this.getWorkspaceDirectory()
+      await this.client.mcp.disconnect({ name, directory })
+      await this.fetchAndSendMcpStatus()
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to disconnect MCP:", name, error)
+      await this.fetchAndSendMcpStatus()
     }
   }
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -6,6 +6,7 @@ import { Button } from "@kilocode/kilo-ui/button"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Dialog } from "@kilocode/kilo-ui/dialog"
 import { useDialog } from "@kilocode/kilo-ui/context/dialog"
+import { Switch } from "@kilocode/kilo-ui/switch"
 
 import { useConfig } from "../../context/config"
 import { useSession } from "../../context/session"
@@ -478,6 +479,31 @@ const AgentBehaviourTab: Component = () => {
       setExpanded((prev) => ({ ...prev, [name]: !prev[name] }))
     }
 
+    const statusColor = (name: string) => {
+      const s = session.mcpStatus()[name]?.status
+      if (s === "connected") return "var(--vscode-testing-iconPassed, #4caf50)"
+      if (s === "failed") return "var(--vscode-testing-iconFailed, #f44336)"
+      if (s === "needs_auth" || s === "needs_client_registration")
+        return "var(--vscode-editorWarning-foreground, #ff9800)"
+      if (s === "disabled") return "var(--vscode-disabledForeground, #888)"
+      return "var(--vscode-disabledForeground, #888)"
+    }
+
+    const statusLabel = (name: string) => {
+      const s = session.mcpStatus()[name]?.status
+      if (!s) return ""
+      const key = {
+        connected: "mcp.status.connected",
+        failed: "mcp.status.failed",
+        needs_auth: "mcp.status.needs_auth",
+        disabled: "mcp.status.disabled",
+        needs_client_registration: "mcp.status.needs_auth",
+      }[s]
+      return key ? language.t(key) : s
+    }
+
+    const isConnected = (name: string) => session.mcpStatus()[name]?.status === "connected"
+
     if (editingMcp()) {
       return (
         <McpEditView
@@ -513,6 +539,10 @@ const AgentBehaviourTab: Component = () => {
               {([name, mcp], index) => {
                 const open = () => expanded()[name] ?? false
                 const env = () => Object.entries(mcp.environment ?? mcp.env ?? {})
+                const error = () => {
+                  const s = session.mcpStatus()[name]
+                  return s?.status === "failed" ? s.error : undefined
+                }
                 return (
                   <div
                     style={{
@@ -540,6 +570,16 @@ const AgentBehaviourTab: Component = () => {
                             toggle(name)
                           }}
                         />
+                        {/* Status dot */}
+                        <div
+                          style={{
+                            width: "6px",
+                            height: "6px",
+                            "border-radius": "50%",
+                            "background-color": statusColor(name),
+                            "flex-shrink": "0",
+                          }}
+                        />
                         <div style={{ "font-weight": "500" }}>{name}</div>
                         <span
                           style={{
@@ -547,10 +587,26 @@ const AgentBehaviourTab: Component = () => {
                             color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
                           }}
                         >
-                          {mcp.url ? "remote" : "stdio"}
+                          {statusLabel(name) || (mcp.url ? "remote" : "stdio")}
                         </span>
                       </div>
-                      <div style={{ display: "flex", gap: "4px" }}>
+                      <div style={{ display: "flex", gap: "4px", "align-items": "center" }}>
+                        <div onClick={(e: MouseEvent) => e.stopPropagation()}>
+                          <Switch
+                            checked={isConnected(name)}
+                            disabled={session.mcpLoading() === name}
+                            onChange={() => {
+                              if (isConnected(name)) {
+                                session.disconnectMcp(name)
+                              } else {
+                                session.connectMcp(name)
+                              }
+                            }}
+                            hideLabel
+                          >
+                            {name}
+                          </Switch>
+                        </div>
                         <IconButton
                           size="small"
                           variant="ghost"
@@ -571,6 +627,20 @@ const AgentBehaviourTab: Component = () => {
                         />
                       </div>
                     </div>
+
+                    {/* Error message */}
+                    <Show when={error()}>
+                      <div
+                        style={{
+                          "padding-left": "28px",
+                          "padding-bottom": "4px",
+                          "font-size": "11px",
+                          color: "var(--vscode-errorForeground)",
+                        }}
+                      >
+                        {error()}
+                      </div>
+                    </Show>
 
                     {/* Expandable detail */}
                     <Show when={open()}>
@@ -635,16 +705,6 @@ const AgentBehaviourTab: Component = () => {
                               </div>
                             )}
                           </For>
-                        </Show>
-                        <Show when={mcp.enabled === false}>
-                          <div
-                            style={{
-                              "margin-top": "4px",
-                              color: "var(--vscode-errorForeground)",
-                            }}
-                          >
-                            {language.t("settings.agentBehaviour.mcpDetail.disabled")}
-                          </div>
                         </Show>
                       </div>
                     </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -497,7 +497,7 @@ const AgentBehaviourTab: Component = () => {
         failed: "mcp.status.failed",
         needs_auth: "mcp.status.needs_auth",
         disabled: "mcp.status.disabled",
-        needs_client_registration: "mcp.status.needs_auth",
+        needs_client_registration: "mcp.status.needs_registration",
       }[s]
       return key ? language.t(key) : s
     }
@@ -541,7 +541,9 @@ const AgentBehaviourTab: Component = () => {
                 const env = () => Object.entries(mcp.environment ?? mcp.env ?? {})
                 const error = () => {
                   const s = session.mcpStatus()[name]
-                  return s?.status === "failed" ? s.error : undefined
+                  if (s?.status === "failed") return s.error
+                  if (s?.status === "needs_client_registration") return s.error
+                  return undefined
                 }
                 return (
                   <div

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -40,6 +40,7 @@ import type {
   ExtensionMessage,
   FileAttachment,
   SendMessageFailedMessage,
+  McpStatusEntry,
 } from "../types/messages"
 import { removeSessionPermissions, upsertPermission } from "./permission-queue"
 import { computeStatus, calcTotalCost, calcContextUsage } from "./session-utils"
@@ -137,6 +138,13 @@ interface SessionContextValue {
   agents: Accessor<AgentInfo[]>
   removeMode: (name: string) => void
   removeMcp: (name: string) => void
+
+  // MCP server status (runtime connect/disconnect)
+  mcpStatus: Accessor<Record<string, McpStatusEntry>>
+  mcpLoading: Accessor<string | null>
+  connectMcp: (name: string) => void
+  disconnectMcp: (name: string) => void
+  refreshMcpStatus: () => void
   selectedAgent: Accessor<string>
   selectAgent: (name: string) => void
   getSessionAgent: (sessionID: string) => string
@@ -261,6 +269,26 @@ export const SessionProvider: ParentComponent = (props) => {
 
   const removeMcp = (name: string) => {
     vscode.postMessage({ type: "removeMcp", name })
+  }
+
+  // MCP runtime status
+  const [mcpStatus, setMcpStatus] = createSignal<Record<string, McpStatusEntry>>({})
+  const [mcpLoading, setMcpLoading] = createSignal<string | null>(null)
+
+  const connectMcp = (name: string) => {
+    if (mcpLoading()) return
+    setMcpLoading(name)
+    vscode.postMessage({ type: "connectMcp", name })
+  }
+
+  const disconnectMcp = (name: string) => {
+    if (mcpLoading()) return
+    setMcpLoading(name)
+    vscode.postMessage({ type: "disconnectMcp", name })
+  }
+
+  const refreshMcpStatus = () => {
+    vscode.postMessage({ type: "requestMcpStatus" })
   }
 
   // Pending agent selection for before a session exists
@@ -474,10 +502,32 @@ export const SessionProvider: ParentComponent = (props) => {
     vscode.postMessage({ type: "removeSkill", location })
   }
 
+  // MCP status loaded from CLI backend
+  const unsubMcpStatus = vscode.onMessage((message: ExtensionMessage) => {
+    if (message.type === "mcpStatusLoaded") {
+      setMcpStatus(message.status)
+      setMcpLoading(null)
+    }
+  })
+
+  // Request MCP status on init with retry (same pattern as agents)
+  let mcpRetries = 0
+  vscode.postMessage({ type: "requestMcpStatus" })
+  const mcpRetryTimer = setInterval(() => {
+    mcpRetries++
+    if (Object.keys(mcpStatus()).length > 0 || mcpRetries >= 5) {
+      clearInterval(mcpRetryTimer)
+      return
+    }
+    vscode.postMessage({ type: "requestMcpStatus" })
+  }, 500)
+
   onCleanup(() => {
     unsubAgents()
     unsubSkills()
+    unsubMcpStatus()
     clearInterval(agentRetryTimer)
+    clearInterval(mcpRetryTimer)
   })
 
   // Variant (thinking effort) selection — keyed by "providerID/modelID"
@@ -1631,6 +1681,11 @@ export const SessionProvider: ParentComponent = (props) => {
     removeSkill,
     removeMode,
     removeMcp,
+    mcpStatus,
+    mcpLoading,
+    connectMcp,
+    disconnectMcp,
+    refreshMcpStatus,
     selectedAgent: selectedAgentName,
     selectAgent,
     getSessionAgent: (sessionID: string) => store.agentSelections[sessionID] ?? defaultAgent(),

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -277,12 +277,14 @@ export const SessionProvider: ParentComponent = (props) => {
 
   const connectMcp = (name: string) => {
     if (mcpLoading()) return
+    if (!server.isConnected()) return
     setMcpLoading(name)
     vscode.postMessage({ type: "connectMcp", name })
   }
 
   const disconnectMcp = (name: string) => {
     if (mcpLoading()) return
+    if (!server.isConnected()) return
     setMcpLoading(name)
     vscode.postMessage({ type: "disconnectMcp", name })
   }

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -266,6 +266,7 @@ export const dict = {
   "mcp.status.connected": "متصل",
   "mcp.status.failed": "فشل",
   "mcp.status.needs_auth": "يحتاج إلى مصادقة",
+  "mcp.status.needs_registration": "يحتاج إلى تسجيل العميل",
   "mcp.status.disabled": "معطل",
 
   "dialog.fork.empty": "لا توجد رسائل للتفرع منها",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -266,6 +266,7 @@ export const dict = {
   "mcp.status.connected": "conectado",
   "mcp.status.failed": "falhou",
   "mcp.status.needs_auth": "precisa de autenticação",
+  "mcp.status.needs_registration": "precisa de registro do cliente",
   "mcp.status.disabled": "desabilitado",
 
   "dialog.fork.empty": "Nenhuma mensagem para bifurcar",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -268,6 +268,7 @@ export const dict = {
   "mcp.status.connected": "povezano",
   "mcp.status.failed": "neuspjelo",
   "mcp.status.needs_auth": "potrebna autentifikacija",
+  "mcp.status.needs_registration": "potrebna registracija klijenta",
   "mcp.status.disabled": "onemogućeno",
 
   "dialog.fork.empty": "Nema poruka za fork",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -267,6 +267,7 @@ export const dict = {
   "mcp.status.connected": "forbundet",
   "mcp.status.failed": "mislykkedes",
   "mcp.status.needs_auth": "kræver godkendelse",
+  "mcp.status.needs_registration": "kræver klientregistrering",
   "mcp.status.disabled": "deaktiveret",
 
   "dialog.fork.empty": "Ingen beskeder at forgrene fra",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -272,6 +272,7 @@ export const dict = {
   "mcp.status.connected": "verbunden",
   "mcp.status.failed": "fehlgeschlagen",
   "mcp.status.needs_auth": "benötigt Authentifizierung",
+  "mcp.status.needs_registration": "Client-Registrierung erforderlich",
   "mcp.status.disabled": "deaktiviert",
 
   "dialog.fork.empty": "Keine Nachrichten zum Abzweigen vorhanden",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -268,6 +268,7 @@ export const dict = {
   "mcp.status.connected": "connected",
   "mcp.status.failed": "failed",
   "mcp.status.needs_auth": "needs auth",
+  "mcp.status.needs_registration": "needs client registration",
   "mcp.status.disabled": "disabled",
 
   "dialog.fork.empty": "No messages to fork from",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -267,6 +267,7 @@ export const dict = {
   "mcp.status.connected": "conectado",
   "mcp.status.failed": "fallido",
   "mcp.status.needs_auth": "necesita auth",
+  "mcp.status.needs_registration": "necesita registro de cliente",
   "mcp.status.disabled": "deshabilitado",
 
   "dialog.fork.empty": "No hay mensajes desde donde bifurcar",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -268,6 +268,7 @@ export const dict = {
   "mcp.status.connected": "connecté",
   "mcp.status.failed": "échoué",
   "mcp.status.needs_auth": "nécessite auth",
+  "mcp.status.needs_registration": "nécessite enregistrement client",
   "mcp.status.disabled": "désactivé",
 
   "dialog.fork.empty": "Aucun message à partir duquel bifurquer",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -266,6 +266,7 @@ export const dict = {
   "mcp.status.connected": "接続済み",
   "mcp.status.failed": "失敗",
   "mcp.status.needs_auth": "認証が必要",
+  "mcp.status.needs_registration": "クライアント登録が必要",
   "mcp.status.disabled": "無効",
 
   "dialog.fork.empty": "フォーク元のメッセージがありません",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -270,6 +270,7 @@ export const dict = {
   "mcp.status.connected": "연결됨",
   "mcp.status.failed": "실패",
   "mcp.status.needs_auth": "인증 필요",
+  "mcp.status.needs_registration": "클라이언트 등록 필요",
   "mcp.status.disabled": "비활성화됨",
 
   "dialog.fork.empty": "분기할 메시지 없음",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -268,6 +268,7 @@ export const dict = {
   "mcp.status.connected": "verbonden",
   "mcp.status.failed": "mislukt",
   "mcp.status.needs_auth": "authenticatie vereist",
+  "mcp.status.needs_registration": "clientregistratie vereist",
   "mcp.status.disabled": "uitgeschakeld",
 
   "dialog.fork.empty": "Geen berichten om van af te splitsen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -270,6 +270,7 @@ export const dict = {
   "mcp.status.connected": "tilkoblet",
   "mcp.status.failed": "mislyktes",
   "mcp.status.needs_auth": "trenger autentisering",
+  "mcp.status.needs_registration": "trenger klientregistrering",
   "mcp.status.disabled": "deaktivert",
 
   "dialog.fork.empty": "Ingen meldinger å forgrene fra",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -267,6 +267,7 @@ export const dict = {
   "mcp.status.connected": "połączono",
   "mcp.status.failed": "niepowodzenie",
   "mcp.status.needs_auth": "wymaga autoryzacji",
+  "mcp.status.needs_registration": "wymaga rejestracji klienta",
   "mcp.status.disabled": "wyłączone",
 
   "dialog.fork.empty": "Brak wiadomości do rozwidlenia",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -267,6 +267,7 @@ export const dict = {
   "mcp.status.connected": "подключено",
   "mcp.status.failed": "ошибка",
   "mcp.status.needs_auth": "требуется авторизация",
+  "mcp.status.needs_registration": "требуется регистрация клиента",
   "mcp.status.disabled": "отключено",
 
   "dialog.fork.empty": "Нет сообщений для ответвления",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -267,6 +267,7 @@ export const dict = {
   "mcp.status.connected": "เชื่อมต่อแล้ว",
   "mcp.status.failed": "ล้มเหลว",
   "mcp.status.needs_auth": "ต้องการการตรวจสอบสิทธิ์",
+  "mcp.status.needs_registration": "ต้องการลงทะเบียนไคลเอนต์",
   "mcp.status.disabled": "ปิดใช้งาน",
 
   "dialog.fork.empty": "ไม่มีข้อความให้แตกแขนง",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -267,6 +267,7 @@ export const dict = {
   "mcp.status.connected": "bağlı",
   "mcp.status.failed": "başarısız",
   "mcp.status.needs_auth": "kimlik doğrulama gerekli",
+  "mcp.status.needs_registration": "istemci kaydı gerekli",
   "mcp.status.disabled": "devre dışı",
 
   "dialog.fork.empty": "Dallandırılacak mesaj yok",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -267,6 +267,7 @@ export const dict = {
   "mcp.status.connected": "已连接",
   "mcp.status.failed": "失败",
   "mcp.status.needs_auth": "需要授权",
+  "mcp.status.needs_registration": "需要客户端注册",
   "mcp.status.disabled": "已禁用",
 
   "dialog.fork.empty": "没有可用于分叉的消息",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -267,6 +267,7 @@ export const dict = {
   "mcp.status.connected": "已連線",
   "mcp.status.failed": "失敗",
   "mcp.status.needs_auth": "需要授權",
+  "mcp.status.needs_registration": "需要客戶端註冊",
   "mcp.status.disabled": "已停用",
 
   "dialog.fork.empty": "沒有可用於分支的訊息",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1313,6 +1313,7 @@ export type ExtensionMessage =
   | LanguageChangedMessage
   | ContinueInWorktreeProgressMessage
   | WorktreeStatsLoadedMessage
+  | McpStatusLoadedMessage
 
 // ============================================
 // Messages FROM webview TO extension
@@ -1499,6 +1500,30 @@ export interface RemoveModeMessage {
 export interface RemoveMcpMessage {
   type: "removeMcp"
   name: string
+}
+
+export interface RequestMcpStatusMessage {
+  type: "requestMcpStatus"
+}
+
+export interface ConnectMcpMessage {
+  type: "connectMcp"
+  name: string
+}
+
+export interface DisconnectMcpMessage {
+  type: "disconnectMcp"
+  name: string
+}
+
+export interface McpStatusEntry {
+  status: "connected" | "disabled" | "failed" | "needs_auth" | "needs_client_registration"
+  error?: string
+}
+
+export interface McpStatusLoadedMessage {
+  type: "mcpStatusLoaded"
+  status: Record<string, McpStatusEntry>
 }
 
 export interface SetLanguageRequest {
@@ -1985,6 +2010,9 @@ export type WebviewMessage =
   | RemoveSkillMessage
   | RemoveModeMessage
   | RemoveMcpMessage
+  | RequestMcpStatusMessage
+  | ConnectMcpMessage
+  | DisconnectMcpMessage
   | SetLanguageRequest
   | QuestionReplyRequest
   | QuestionRejectRequest


### PR DESCRIPTION
## Summary
- Wire the existing CLI MCP APIs (`GET /mcp`, `POST /mcp/:name/connect`, `POST /mcp/:name/disconnect`) into the extension webview
- Users can now toggle MCP servers on/off and see live connection status directly in Settings → Agent Behaviour → MCP Servers — no config file editing needed
- Each MCP server row shows a status dot (green/red/yellow/grey), status label, error details for failed servers, and a Switch toggle

<img width="887" height="211" alt="image" src="https://github.com/user-attachments/assets/b918b809-9e21-4d7f-8aba-cef89af669b4" />


## Changes
- **`messages.ts`** — New message types: `RequestMcpStatusMessage`, `ConnectMcpMessage`, `DisconnectMcpMessage`, `McpStatusLoadedMessage`, `McpStatusEntry`
- **`KiloProvider.ts`** — `fetchAndSendMcpStatus()`, `handleConnectMcp()`, `handleDisconnectMcp()` methods using `client.mcp.*` SDK calls, with cached message pattern
- **`session.tsx`** — `mcpStatus` signal, `connectMcp`/`disconnectMcp`/`refreshMcpStatus` functions, message subscription with retry on init
- **`AgentBehaviourTab.tsx`** — MCP subtab enhanced with status dots, status labels, error display, and `Switch` toggle per server row

Closes #7806