### PR TITLE
fix(sdk): add duplex: half to fix fetch in Node.js/Electron environments

### DIFF
--- a/packages/sdk/js/src/client.ts
+++ b/packages/sdk/js/src/client.ts
@@ -25,6 +25,11 @@ export function createKiloClient(config?: Config & { directory?: string }) {
     }
   }
 
+  // Node.js/Electron require duplex: "half" when creating Request objects
+  // with a body. The option propagates through config → opts → requestInit
+  // and is harmless in environments that don't need it (Bun, browsers).
+  ;(config as any).duplex = "half"
+
   const client = createClient(config)
   return new KiloClient({ client })
 }

--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -34,6 +34,11 @@ export function createKiloClient(config?: Config & { directory?: string; experim
     }
   }
 
+  // Node.js/Electron require duplex: "half" when creating Request objects
+  // with a body. The option propagates through config → opts → requestInit
+  // and is harmless in environments that don't need it (Bun, browsers).
+  ;(config as any).duplex = "half"
+
   const client = createClient(config)
   return new KiloClient({ client })
 }


### PR DESCRIPTION
## Summary

- Adds `duplex: "half"` to the SDK client config so it propagates to all `new Request()` calls in the generated HTTP and SSE clients
- Fixes the `"RequestInit: duplex option is required when sending a body"` error that breaks the VS Code extension for some users

## Problem

Node.js undici requires `duplex: "half"` when a `Request` object has a `ReadableStream` body. The SDK's generated client creates `new Request(url, requestInit)` with string bodies that get auto-converted to `ReadableStream` internally by the `Request` constructor. In certain Electron versions bundled with VS Code, this triggers the duplex requirement, making the extension completely non-functional — users can't send prompts, create sessions, or do anything that requires a POST request.

## Fix

Rather than patching the auto-generated `*.gen.ts` files (which would be overwritten on next SDK regeneration), the fix sets `duplex: "half"` on the config object in the non-generated `client.ts` wrapper. This propagates through the config spread chain (`config → _config → opts → requestInit`) to every `new Request()` call. The option is harmless in environments that don't need it (Bun, browsers).

Fixes #7661, #7566, #7560