### PR TITLE
fix(vscode): prompt input text overlap on Windows

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -932,6 +932,9 @@
   resize: none;
   outline: none;
   scrollbar-gutter: stable;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-x: hidden;
 }
 
 .prompt-input:focus {


### PR DESCRIPTION
## Problem

On Windows, the prompt input in the VS Code sidebar shows a ~1 line vertical offset between the caret position and the rendered text after pasting blocks of text. The caret appears to be one line above where the text actually is.

## Root Cause

The `PromptInput` component uses a transparent `<textarea>` (shows only the caret) overlaid with an absolute-positioned `<div>` that renders the visible text with highlight styling. These two elements must have pixel-identical text layout for the caret and text to align.

Three CSS properties are set on the overlay `.prompt-input-highlight-overlay` (line 965) but missing from the textarea `.prompt-input` (line 922):

| Property | Textarea | Overlay |
|---|---|---|
| `white-space` | unset | `pre-wrap` |
| `word-wrap` | unset | `break-word` |
| `overflow-x` | unset | `hidden` |

Without these matching, the textarea wraps text differently from the overlay - especially on Windows Chromium where the defaults differ more from macOS. After pasting large text blocks the line count mismatch accumulates and the offset becomes very visible.

## Fix

Added the three missing properties to `.prompt-input` in `chat.css`:

```css
white-space: pre-wrap;
word-wrap: break-word;
overflow-x: hidden;
```

Now both elements use identical wrapping and overflow behavior, so line counts always match.

3 lines added, 0 removed. Pure CSS change, no logic affected.

Closes #7808