### PR TITLE
fix(cli): gate Kilo API calls behind enabled_providers to prevent data leaks

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1592,8 +1592,16 @@ export namespace ACP {
     if (specified) return specified
 
     // kilocode_change start
-    const freeModel = await fetchDefaultModel()
-    return { providerID: "kilo", modelID: freeModel }
+    // Only fall back to the Kilo provider if it was present in the available
+    // providers list. When teams configure enabled_providers to use only their
+    // own models, this prevents silently routing requests to an external API.
+    // Note: LiteLLM / custom provider users won't reach here — the function
+    // returns earlier via `specified` (config.model) or the sorted providers list.
+    if (providers.some((p) => p.id === "kilo")) {
+      const freeModel = await fetchDefaultModel()
+      return { providerID: "kilo", modelID: freeModel }
+    }
+    throw new Error("no model available: no providers are configured and no default model is set")
     // kilocode_change end
   }
 

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -139,8 +139,15 @@ export namespace ModelsDev {
     }
 
     // Inject kilo provider with dynamic model fetching
-    if (!providers["kilo"]) {
-      const config = await Config.get()
+    // Skip injection entirely when enabled_providers is set and doesn't include "kilo",
+    // or when "kilo" is in disabled_providers. This prevents unnecessary network calls
+    // to the Kilo API for teams using only their own providers (e.g. LiteLLM).
+    const config = await Config.get()
+    const disabled = new Set(config.disabled_providers ?? [])
+    const enabled = config.enabled_providers ? new Set(config.enabled_providers) : null
+    const kiloAllowed = (!enabled || enabled.has("kilo")) && !disabled.has("kilo")
+
+    if (kiloAllowed && !providers["kilo"]) {
       const kiloOptions = config.provider?.kilo?.options
       // kilocode_change start - resolve org ID from auth (OAuth accountId) not just config
       const kiloAuth = await Auth.get("kilo")

--- a/packages/opencode/src/server/routes/config.ts
+++ b/packages/opencode/src/server/routes/config.ts
@@ -89,10 +89,16 @@ export const ConfigRoutes = lazy(() =>
         const providers = await Provider.list()
 
         // kilocode_change start - Fetch default model from Kilo API
-        const kiloAuth = await Auth.get("kilo")
-        const token = kiloAuth?.type === "oauth" ? kiloAuth.access : kiloAuth?.key
-        const organizationId = kiloAuth?.type === "oauth" ? kiloAuth.accountId : undefined
-        const kiloApiDefault = await fetchDefaultModel(token, organizationId)
+        // Only call the Kilo API when the kilo provider is actually available.
+        // This prevents unnecessary network calls for teams using only their
+        // own providers (e.g. LiteLLM) via enabled_providers config.
+        let kiloApiDefault: string | undefined
+        if (providers["kilo"]) {
+          const kiloAuth = await Auth.get("kilo")
+          const token = kiloAuth?.type === "oauth" ? kiloAuth.access : kiloAuth?.key
+          const organizationId = kiloAuth?.type === "oauth" ? kiloAuth.accountId : undefined
+          kiloApiDefault = await fetchDefaultModel(token, organizationId)
+        }
         // kilocode_change end
 
         // kilocode_change start - Use API default for Kilo provider if valid


### PR DESCRIPTION
## Summary

Teams using only their own models (e.g. via LiteLLM proxy) with `enabled_providers` config were still making external network calls to `api.kilo.ai` — leaking the fact that the tool is in use and potentially routing requests through Kilo's infrastructure.

This PR gates all Kilo API call paths behind the existing `enabled_providers` / `disabled_providers` config:

- **`models.ts`**: Skip Kilo provider injection (and its `ModelCache.fetch` network call) when Kilo is not in the allowed provider list
- **`config.ts` route**: Skip `fetchDefaultModel()` call to Kilo API when the Kilo provider isn't loaded
- **`acp/agent.ts`**: Don't silently fall back to `kilo/kilo-auto/free` when Kilo was explicitly excluded — throw a clear error instead

### Behavior

- **New users with no config**: Unaffected. Kilo free works immediately on first start.
- **Teams with `enabled_providers: ["my-litellm"]`**: Zero external calls to `api.kilo.ai`. All model usage routes through their own infrastructure.
- **Users with custom provider but no `enabled_providers`**: Both Kilo and custom provider coexist (no change).

### Recommended config for teams wanting full data isolation

```json
{
  "enabled_providers": ["my-litellm"],
  "model": "my-litellm/main-model",
  "small_model": "my-litellm/small-model",
  "provider": {
    "my-litellm": {
      "name": "Team LiteLLM",
      "api": "https://litellm.example.com/v1",
      "env": ["LITELLM_API_KEY"],
      "options": { "litellmProxy": true },
      "models": {
        "main-model": { "name": "Main", "tool_call": true },
        "small-model": { "name": "Small", "tool_call": true }
      }
    }
  }
}
```