### PR TITLE
feat(vscode): chat history visualizer (task timeline) — prototype

### DIFF
--- a/packages/kilo-vscode/tests/unit/timeline-colors.test.ts
+++ b/packages/kilo-vscode/tests/unit/timeline-colors.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "bun:test"
+import { classify, cssColor, partLabel } from "../../webview-ui/src/utils/timeline/colors"
+import type { Part } from "../../webview-ui/src/types/messages"
+
+describe("classify", () => {
+  it("classifies user text parts as 'user'", () => {
+    const part: Part = { type: "text", id: "p1", text: "hello" }
+    expect(classify(part, "user")).toBe("user")
+  })
+
+  it("classifies assistant text parts as 'assistant'", () => {
+    const part: Part = { type: "text", id: "p1", text: "hello" }
+    expect(classify(part, "assistant")).toBe("assistant")
+  })
+
+  it("classifies reasoning parts as 'assistant'", () => {
+    const part: Part = { type: "reasoning", id: "p1", text: "thinking..." }
+    expect(classify(part, "assistant")).toBe("assistant")
+  })
+
+  it("classifies read/glob/grep tools as 'read'", () => {
+    for (const tool of ["read", "glob", "grep"]) {
+      const part: Part = { type: "tool", id: "p1", tool, state: { status: "running", input: {} } }
+      expect(classify(part, "assistant")).toBe("read")
+    }
+  })
+
+  it("classifies edit/write tools as 'write'", () => {
+    for (const tool of ["edit", "write"]) {
+      const part: Part = { type: "tool", id: "p1", tool, state: { status: "running", input: {} } }
+      expect(classify(part, "assistant")).toBe("write")
+    }
+  })
+
+  it("classifies bash/webfetch/task/todowrite tools as 'tool'", () => {
+    for (const tool of ["bash", "webfetch", "task", "todowrite"]) {
+      const part: Part = { type: "tool", id: "p1", tool, state: { status: "running", input: {} } }
+      expect(classify(part, "assistant")).toBe("tool")
+    }
+  })
+
+  it("classifies errored tool parts as 'error'", () => {
+    const part: Part = { type: "tool", id: "p1", tool: "read", state: { status: "error", input: {}, error: "fail" } }
+    expect(classify(part, "assistant")).toBe("error")
+  })
+
+  it("returns null for step-start parts", () => {
+    const part: Part = { type: "step-start", id: "p1" }
+    expect(classify(part, "assistant")).toBeNull()
+  })
+
+  it("returns null for step-finish parts", () => {
+    const part: Part = { type: "step-finish", id: "p1" }
+    expect(classify(part, "assistant")).toBeNull()
+  })
+
+  it("returns null for file parts", () => {
+    const part: Part = { type: "file", id: "p1", mime: "image/png", url: "data:..." }
+    expect(classify(part, "assistant")).toBeNull()
+  })
+
+  it("is case-insensitive for tool names", () => {
+    const part: Part = { type: "tool", id: "p1", tool: "Read", state: { status: "running", input: {} } }
+    expect(classify(part, "assistant")).toBe("read")
+  })
+})
+
+describe("cssColor", () => {
+  it("returns a string for every color type", () => {
+    const colors = ["user", "read", "write", "tool", "success", "error", "assistant", "question", "default"] as const
+    for (const color of colors) {
+      const css = cssColor(color)
+      expect(typeof css).toBe("string")
+      expect(css.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("returns VS Code CSS variable references", () => {
+    expect(cssColor("read")).toContain("--vscode-")
+    expect(cssColor("error")).toContain("--vscode-")
+  })
+
+  it("returns color-mix for composite colors", () => {
+    expect(cssColor("user")).toContain("color-mix")
+    expect(cssColor("question")).toContain("color-mix")
+  })
+})
+
+describe("partLabel", () => {
+  it("labels text parts as 'Text'", () => {
+    const part: Part = { type: "text", id: "p1", text: "hi" }
+    expect(partLabel(part)).toBe("Text")
+  })
+
+  it("labels reasoning parts as 'Thinking'", () => {
+    const part: Part = { type: "reasoning", id: "p1", text: "hmm" }
+    expect(partLabel(part)).toBe("Thinking")
+  })
+
+  it("labels read tools as 'File Read'", () => {
+    const part: Part = { type: "tool", id: "p1", tool: "read", state: { status: "running", input: {} } }
+    expect(partLabel(part)).toBe("File Read")
+  })
+
+  it("labels edit tools as 'File Write'", () => {
+    const part: Part = { type: "tool", id: "p1", tool: "edit", state: { status: "running", input: {} } }
+    expect(partLabel(part)).toBe("File Write")
+  })
+
+  it("labels bash tool as 'Command'", () => {
+    const part: Part = { type: "tool", id: "p1", tool: "bash", state: { status: "running", input: {} } }
+    expect(partLabel(part)).toBe("Command")
+  })
+
+  it("labels task tool as 'Sub-agent'", () => {
+    const part: Part = { type: "tool", id: "p1", tool: "task", state: { status: "running", input: {} } }
+    expect(partLabel(part)).toBe("Sub-agent")
+  })
+
+  it("labels unknown tools with 'Tool: name'", () => {
+    const part: Part = { type: "tool", id: "p1", tool: "custom", state: { status: "running", input: {} } }
+    expect(partLabel(part)).toBe("Tool: custom")
+  })
+
+  it("labels step-start as 'Action'", () => {
+    const part: Part = { type: "step-start", id: "p1" }
+    expect(partLabel(part)).toBe("Action")
+  })
+})

--- a/packages/kilo-vscode/tests/unit/timeline-sizes.test.ts
+++ b/packages/kilo-vscode/tests/unit/timeline-sizes.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "bun:test"
+import { compute, MAX_HEIGHT } from "../../webview-ui/src/utils/timeline/sizes"
+import type { Message, Part } from "../../webview-ui/src/types/messages"
+
+const MIN_WIDTH = 8
+const MAX_WIDTH = 32
+const MIN_HEIGHT_BAR = 8
+const TOP_PAD = 4
+
+function msg(id: string, role: "user" | "assistant", opts: Partial<Message> = {}): Message {
+  return { id, sessionID: "s1", role, createdAt: new Date().toISOString(), ...opts }
+}
+
+function parts(map: Record<string, Part[]>): (id: string) => Part[] {
+  return (id) => map[id] ?? []
+}
+
+describe("compute", () => {
+  it("returns empty array for empty messages", () => {
+    expect(compute([], parts({}))).toEqual([])
+  })
+
+  it("returns empty when messages have no parts and no content", () => {
+    const msgs = [msg("m1", "user")]
+    expect(compute(msgs, parts({}))).toEqual([])
+  })
+
+  it("creates a synthetic bar for user messages with content but no parts", () => {
+    const msgs = [msg("m1", "user", { content: "hello world" })]
+    const bars = compute(msgs, parts({}))
+    expect(bars).toHaveLength(1)
+    expect(bars[0].id).toBe("msg-m1")
+    expect(bars[0].color).toBe("user")
+    expect(bars[0].label).toBe("User")
+    expect(bars[0].messageID).toBe("m1")
+  })
+
+  it("creates a synthetic bar for assistant messages with content but no parts", () => {
+    const msgs = [msg("m1", "assistant", { content: "Hi!" })]
+    const bars = compute(msgs, parts({}))
+    expect(bars).toHaveLength(1)
+    expect(bars[0].color).toBe("assistant")
+    expect(bars[0].label).toBe("Assistant")
+  })
+
+  it("creates bars from real parts and skips step-start/step-finish", () => {
+    const msgs = [msg("m1", "assistant")]
+    const p = parts({
+      m1: [
+        { type: "step-start", id: "ss1" },
+        { type: "text", id: "t1", text: "hello" },
+        { type: "tool", id: "tl1", tool: "read", state: { status: "completed", input: {}, output: "ok", title: "" } },
+        { type: "step-finish", id: "sf1" },
+      ],
+    })
+    const bars = compute(msgs, p)
+    expect(bars).toHaveLength(2) // text + tool, step-start/finish skipped
+    expect(bars[0].color).toBe("assistant")
+    expect(bars[1].color).toBe("read")
+  })
+
+  it("prefers real parts over synthetic bar", () => {
+    const msgs = [msg("m1", "user", { content: "hello" })]
+    const p = parts({
+      m1: [{ type: "text", id: "t1", text: "hello world" }],
+    })
+    const bars = compute(msgs, p)
+    expect(bars).toHaveLength(1)
+    expect(bars[0].id).toBe("t1") // real part id, not synthetic
+  })
+
+  it("gives the last bar MIN_WIDTH", () => {
+    const msgs = [
+      msg("m1", "user", { content: "hi", time: { created: 1000 } }),
+      msg("m2", "assistant", { content: "hello there, this is a response", time: { created: 5000 } }),
+    ]
+    const bars = compute(msgs, parts({}))
+    expect(bars).toHaveLength(2)
+    expect(bars[bars.length - 1].width).toBe(MIN_WIDTH)
+  })
+
+  it("calculates widths within bounds", () => {
+    const msgs = [
+      msg("m1", "user", { content: "a", time: { created: 0 } }),
+      msg("m2", "assistant", { content: "b", time: { created: 1000 } }),
+      msg("m3", "user", { content: "c", time: { created: 10000 } }),
+    ]
+    const bars = compute(msgs, parts({}))
+    for (const bar of bars) {
+      expect(bar.width).toBeGreaterThanOrEqual(MIN_WIDTH)
+      expect(bar.width).toBeLessThanOrEqual(MAX_WIDTH)
+    }
+  })
+
+  it("calculates heights within bounds", () => {
+    const msgs = [msg("m1", "user", { content: "a" }), msg("m2", "assistant", { content: "b".repeat(5000) })]
+    const bars = compute(msgs, parts({}))
+    for (const bar of bars) {
+      expect(bar.height).toBeGreaterThanOrEqual(MIN_HEIGHT_BAR)
+      expect(bar.height).toBeLessThanOrEqual(MAX_HEIGHT - TOP_PAD)
+    }
+  })
+
+  it("assigns CSS color strings from the palette", () => {
+    const msgs = [msg("m1", "user", { content: "hi" })]
+    const bars = compute(msgs, parts({}))
+    expect(bars[0].css).toContain("color-mix")
+  })
+
+  it("handles multiple messages with mixed parts", () => {
+    const msgs = [
+      msg("m1", "user", { content: "do stuff", time: { created: 0 } }),
+      msg("m2", "assistant", { time: { created: 2000 } }),
+      msg("m3", "user", { content: "more", time: { created: 8000 } }),
+    ]
+    const p = parts({
+      m2: [
+        { type: "text", id: "t1", text: "ok" },
+        { type: "tool", id: "tl1", tool: "edit", state: { status: "running", input: { path: "/f" } } },
+        { type: "tool", id: "tl2", tool: "bash", state: { status: "running", input: { command: "ls" } } },
+      ],
+    })
+    const bars = compute(msgs, p)
+    // m1: 1 synthetic (user content), m2: 3 real parts, m3: 1 synthetic
+    expect(bars).toHaveLength(5)
+    expect(bars[0].color).toBe("user")
+    expect(bars[1].color).toBe("assistant")
+    expect(bars[2].color).toBe("write")
+    expect(bars[3].color).toBe("tool")
+    expect(bars[4].color).toBe("user")
+  })
+
+  it("uses timing between messages for width", () => {
+    const msgs = [
+      msg("m1", "user", { content: "a", time: { created: 0 } }),
+      msg("m2", "assistant", { content: "b", time: { created: 100 } }), // fast
+      msg("m3", "user", { content: "c", time: { created: 10000 } }), // slow
+    ]
+    const bars = compute(msgs, parts({}))
+    // m1 has small timing (100ms), m2 has large timing (9900ms), m3 is last (MIN_WIDTH)
+    expect(bars[0].width).toBeLessThan(bars[1].width)
+    expect(bars[2].width).toBe(MIN_WIDTH)
+  })
+
+  it("uses content length for height", () => {
+    const msgs = [
+      msg("m1", "user", { content: "a" }), // tiny
+      msg("m2", "assistant", { content: "x".repeat(10000) }), // huge
+    ]
+    const bars = compute(msgs, parts({}))
+    expect(bars[0].height).toBeLessThan(bars[1].height)
+    expect(bars[1].height).toBe(MAX_HEIGHT - TOP_PAD) // max ratio → max height
+  })
+
+  it("handles null timing gracefully (no time data)", () => {
+    const msgs = [msg("m1", "user", { content: "a" }), msg("m2", "assistant", { content: "b" })]
+    // No time fields → all timings null → fallback to AVG_TIMING
+    const bars = compute(msgs, parts({}))
+    expect(bars).toHaveLength(2)
+    expect(bars[0].width).toBeGreaterThanOrEqual(MIN_WIDTH)
+  })
+})
+
+describe("MAX_HEIGHT constant", () => {
+  it("matches the legacy value of 26", () => {
+    expect(MAX_HEIGHT).toBe(26)
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -122,12 +122,19 @@ export const ChatView: Component<ChatViewProps> = (props) => {
     session.respondToPermission(perm.id, response, approvedAlways, deniedAlways)
   }
 
+  // Timeline hover signal — passed to TaskHeader (sets it) and MessageList (reads it for gutter bars)
+  const [timelineHover, setTimelineHover] = createSignal(false)
+
   return (
     <div class="chat-view">
-      <TaskHeader readonly={props.readonly} />
+      <TaskHeader readonly={props.readonly} onTimelineHover={setTimelineHover} />
       <div class="chat-messages-wrapper">
         <div class="chat-messages">
-          <MessageList onSelectSession={props.onSelectSession} onShowHistory={props.onShowHistory} />
+          <MessageList
+            onSelectSession={props.onSelectSession}
+            onShowHistory={props.onShowHistory}
+            timelineHover={timelineHover()}
+          />
         </div>
       </div>
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ContextProgress.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ContextProgress.tsx
@@ -1,0 +1,67 @@
+/**
+ * ContextProgress — three-segment context window progress bar.
+ * Matches the legacy ContextWindowProgress.tsx appearance exactly.
+ * Segments: used (darkest) | reserved for output (medium) | available (transparent).
+ */
+
+import { Component, Show, createMemo } from "solid-js"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
+interface Props {
+  tokens: number
+  limit: number
+  reserved?: number
+}
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
+export const ContextProgress: Component<Props> = (props) => {
+  const dist = createMemo(() => {
+    const limit = Math.max(1, props.limit)
+    const used = Math.max(0, props.tokens)
+    const reserved = Math.min(props.reserved ?? 0, limit - used)
+    const available = Math.max(0, limit - used - reserved)
+
+    return {
+      current: Math.min(100, (used / limit) * 100),
+      reserved: Math.min(100, (reserved / limit) * 100),
+      available: Math.min(100, (available / limit) * 100),
+      usedN: used,
+      reservedN: reserved,
+      availableN: available,
+      limit,
+    }
+  })
+
+  const warning = createMemo(() => dist().current >= 50)
+
+  const tip = createMemo(() => {
+    const d = dist()
+    const parts = [`${fmt(d.usedN)} of ${fmt(d.limit)} tokens used`]
+    if (d.reservedN > 0) parts.push(`${fmt(d.reservedN)} reserved for response`)
+    if (d.availableN > 0) parts.push(`${fmt(d.availableN)} available`)
+    return parts.join("\n")
+  })
+
+  return (
+    <div data-component="context-progress">
+      <span data-slot="context-progress-label">{fmt(props.tokens)}</span>
+      <Tooltip value={tip()} placement="top">
+        <div data-slot="context-progress-track">
+          <div
+            data-slot="context-progress-used"
+            data-warning={warning() ? "" : undefined}
+            style={{ width: `${dist().current}%` }}
+          />
+          <Show when={dist().reserved > 0}>
+            <div data-slot="context-progress-reserved" style={{ width: `${dist().reserved}%` }} />
+          </Show>
+        </div>
+      </Tooltip>
+      <span data-slot="context-progress-label">{fmt(props.limit)}</span>
+    </div>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/GutterBar.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/GutterBar.tsx
@@ -1,0 +1,24 @@
+/**
+ * GutterBar — 4px colored vertical bar on the left edge of each chat turn.
+ * Color matches the turn's first renderable part's timeline color.
+ * Visible (opacity 0.7) only when the user is hovering over the TaskTimeline.
+ */
+
+import { Component } from "solid-js"
+import type { TimelineColor } from "../../utils/timeline/colors"
+import { cssColor } from "../../utils/timeline/colors"
+
+interface Props {
+  color: TimelineColor
+  visible: boolean
+}
+
+export const GutterBar: Component<Props> = (props) => {
+  return (
+    <div
+      data-slot="gutter-bar"
+      data-visible={props.visible ? "" : undefined}
+      style={{ "background-color": cssColor(props.color) }}
+    />
+  )
+}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -40,6 +40,7 @@ const KiloLogo = (): JSX.Element => {
 interface MessageListProps {
   onSelectSession?: (id: string) => void
   onShowHistory?: () => void
+  timelineHover?: boolean
 }
 
 export const MessageList: Component<MessageListProps> = (props) => {
@@ -153,6 +154,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
                     sessionID={session.currentSessionID() ?? ""}
                     messageID={msg.id}
                     queued={queued()}
+                    timelineHover={props.timelineHover}
                   />
                 )
               }}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -1,7 +1,8 @@
 /**
  * TaskHeader component
  * Sticky header above the chat messages showing session title,
- * cost, context usage, and a compact button.
+ * cost, context usage, task timeline, context progress bar, and token breakdown.
+ * Collapsible: click title row to expand/collapse the detail panel.
  * Also shows todo progress when the session has todos.
  */
 
@@ -11,15 +12,27 @@ import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Checkbox } from "@kilocode/kilo-ui/checkbox"
 import { useSession } from "../../context/session"
+import { useProvider } from "../../context/provider"
 import { useLanguage } from "../../context/language"
-import type { TodoItem } from "../../types/messages"
+import type { TodoItem, StepFinishPart } from "../../types/messages"
+import { compute } from "../../utils/timeline/sizes"
+import { TaskTimeline } from "./TaskTimeline"
+import { ContextProgress } from "./ContextProgress"
 
 interface TaskHeaderProps {
   readonly?: boolean
+  onTimelineHover?: (hovering: boolean) => void
+}
+
+function fmtNum(n: number, locale: string): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return n.toLocaleString(locale)
 }
 
 export const TaskHeader: Component<TaskHeaderProps> = (props) => {
   const session = useSession()
+  const provider = useProvider()
   const language = useLanguage()
 
   const title = createMemo(() => session.currentSession()?.title ?? language.t("command.session.new"))
@@ -44,6 +57,70 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
     return { tokens, pct }
   })
 
+  // Timeline bars — recomputes reactively when messages or parts change
+  const bars = createMemo(() => {
+    const msgs = session.messages()
+    if (msgs.length === 0) return []
+    return compute(msgs, session.getParts)
+  })
+
+  // Model context limit and max output tokens for the progress bar
+  const model = createMemo(() => {
+    const sel = session.selected()
+    return sel ? provider.findModel(sel) : undefined
+  })
+  const limit = createMemo(() => model()?.limit?.context ?? model()?.contextLength ?? 0)
+  const reserved = createMemo(() => model()?.limit?.output)
+
+  // Cumulative token breakdown from all StepFinishParts across the session
+  const breakdown = createMemo(() => {
+    const msgs = session.messages()
+    let input = 0
+    let output = 0
+    let reasoning = 0
+    let read = 0
+    let write = 0
+    for (const m of msgs) {
+      if (m.role !== "assistant") continue
+      for (const p of session.getParts(m.id)) {
+        if (p.type !== "step-finish") continue
+        const sf = p as StepFinishPart
+        if (!sf.tokens) continue
+        input += sf.tokens.input
+        output += sf.tokens.output
+        reasoning += sf.tokens.reasoning ?? 0
+        read += sf.tokens.cache?.read ?? 0
+        write += sf.tokens.cache?.write ?? 0
+      }
+    }
+    if (input === 0 && output === 0) return undefined
+    const cache = read || write ? { read, write } : undefined
+    return { input, output, reasoning, cache }
+  })
+
+  // Click-to-scroll: find the turn containing this message and scroll to it.
+  // Turns have data-message set to the user message ID, so for assistant message
+  // bars we need to find the preceding user message that owns the turn.
+  function scrollTo(messageID: string) {
+    // Direct match (user message bars)
+    const direct = document.querySelector(`[data-message="${messageID}"]`)
+    if (direct) {
+      direct.scrollIntoView({ behavior: "smooth", block: "center" })
+      return
+    }
+    // Find the user message that precedes this assistant message
+    const msgs = session.messages()
+    let owner: string | undefined
+    for (const m of msgs) {
+      if (m.role === "user") owner = m.id
+      if (m.id === messageID) break
+    }
+    if (owner) {
+      const el = document.querySelector(`[data-message="${owner}"]`)
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "center" })
+    }
+  }
+
   const todos = createMemo(() => session.todos())
   const hasTodos = createMemo(() => todos().length > 0)
   const doneCount = createMemo(() => todos().filter((t: TodoItem) => t.status === "completed").length)
@@ -59,9 +136,13 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
   })
 
   const [todosOpen, setTodosOpen] = createSignal(false)
+  // Default collapsed — matches legacy where the header starts compact
+  const [expanded, setExpanded] = createSignal(false)
+  const loc = () => language.locale()
 
   return (
     <Show when={hasMessages()}>
+      {/* Title row with expand toggle */}
       <div data-component="task-header">
         <div data-slot="task-header-title" title={title()}>
           {title()}
@@ -96,8 +177,62 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
               />
             </Tooltip>
           </Show>
+          {/* Expand/collapse toggle for metrics detail */}
+          <Tooltip value={expanded() ? "Hide details" : "Show details"} placement="bottom">
+            <IconButton
+              icon="chevron-down"
+              size="small"
+              variant="ghost"
+              onClick={() => setExpanded((v) => !v)}
+              aria-label="Toggle details"
+              data-slot="task-header-expand"
+              data-expanded={expanded() ? "" : undefined}
+            />
+          </Tooltip>
         </div>
       </div>
+
+      {/* Everything below title is only visible when expanded */}
+      <Show when={expanded()}>
+        <Show when={bars().length > 0}>
+          <TaskTimeline bars={bars()} active={busy()} onBarClick={scrollTo} onHover={props.onTimelineHover} />
+        </Show>
+        <Show when={session.contextUsage() && limit() > 0}>
+          <ContextProgress tokens={session.contextUsage()!.tokens} limit={limit()} reserved={reserved()} />
+        </Show>
+        <Show when={breakdown()}>
+          {(bd) => (
+            <div data-slot="task-header-tokens">
+              <Tooltip value="Input tokens" placement="bottom">
+                <span data-slot="token-in">
+                  {"\u2191"}
+                  {fmtNum(bd().input, loc())}
+                </span>
+              </Tooltip>
+              <Tooltip value="Output tokens" placement="bottom">
+                <span data-slot="token-out">
+                  {"\u2193"}
+                  {fmtNum(bd().output, loc())}
+                </span>
+              </Tooltip>
+              <Show when={bd().cache}>
+                {(cache) => (
+                  <>
+                    <Tooltip value="Cache read" placement="bottom">
+                      <span data-slot="token-cache">R:{fmtNum(cache().read, loc())}</span>
+                    </Tooltip>
+                    <Tooltip value="Cache write" placement="bottom">
+                      <span data-slot="token-cache">W:{fmtNum(cache().write, loc())}</span>
+                    </Tooltip>
+                  </>
+                )}
+              </Show>
+            </div>
+          )}
+        </Show>
+      </Show>
+
+      {/* Todos */}
       <Show when={hasTodos()}>
         <div data-component="task-header-todos">
           <button

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -1,0 +1,121 @@
+/**
+ * TaskTimeline — horizontal strip of colored bars representing session activity.
+ * Each bar is a message part; color = type, width = timing, height = content length.
+ * Port of the legacy extension's TaskTimeline + TaskTimelineMessage.
+ */
+
+import { Component, For, createSignal, createEffect, onCleanup } from "solid-js"
+import { MAX_HEIGHT, type BarData } from "../../utils/timeline/sizes"
+
+const SCROLLBAR_HIDE = 25
+const TAP_THRESHOLD = 5 // px — movement under this counts as a click, not a drag
+
+interface Props {
+  bars: BarData[]
+  active: boolean
+  onBarClick?: (messageID: string) => void
+  onHover?: (hovering: boolean) => void
+}
+
+export const TaskTimeline: Component<Props> = (props) => {
+  let inner: HTMLDivElement | undefined
+  const [prev, setPrev] = createSignal(0)
+
+  // Drag-scroll state
+  let dragging = false
+  let moved = false
+  let startX = 0
+  let startScroll = 0
+
+  function onPointerDown(e: PointerEvent) {
+    if (!inner) return
+    dragging = true
+    moved = false
+    startX = e.clientX
+    startScroll = inner.scrollLeft
+    inner.setPointerCapture(e.pointerId)
+    inner.style.cursor = "grabbing"
+    inner.style.userSelect = "none"
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!dragging || !inner) return
+    const dx = e.clientX - startX
+    if (Math.abs(dx) > TAP_THRESHOLD) moved = true
+    inner.scrollLeft = startScroll - dx
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (!inner) return
+    dragging = false
+    inner.releasePointerCapture(e.pointerId)
+    inner.style.cursor = "grab"
+    inner.style.userSelect = "auto"
+  }
+
+  function onWheel(e: WheelEvent) {
+    if (!inner) return
+    e.preventDefault()
+    inner.scrollLeft += e.deltaY || e.deltaX
+  }
+
+  function onBarClick(messageID: string) {
+    // Only fire click if we didn't drag
+    if (!moved) props.onBarClick?.(messageID)
+  }
+
+  // Auto-scroll to end when new bars appear
+  createEffect(() => {
+    const len = props.bars.length
+    const old = prev()
+    if (len > old && inner) {
+      const behavior = old === 0 ? "instant" : "smooth"
+      inner.scrollTo({ left: inner.scrollWidth, behavior: behavior as ScrollBehavior })
+    }
+    setPrev(len)
+  })
+
+  // Reset hover when timeline is removed from DOM (e.g. collapse)
+  onCleanup(() => props.onHover?.(false))
+
+  return (
+    <div
+      data-component="task-timeline"
+      onMouseEnter={() => props.onHover?.(true)}
+      onMouseLeave={() => props.onHover?.(false)}
+    >
+      <div
+        ref={inner}
+        data-slot="task-timeline-scroller"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onWheel={onWheel}
+      >
+        <For each={props.bars}>
+          {(bar, idx) => {
+            const active = () => props.active && idx() === props.bars.length - 1
+            const pct = () => `${(bar.height / MAX_HEIGHT) * 100}%`
+            return (
+              <div
+                data-slot="timeline-bar"
+                title={`${bar.label} #${idx() + 1}`}
+                style={{ width: `${bar.width}px`, height: `${MAX_HEIGHT}px` }}
+                onClick={() => onBarClick(bar.messageID)}
+              >
+                <div
+                  data-slot="timeline-bar-inner"
+                  data-active={active() ? "" : undefined}
+                  style={{
+                    height: pct(),
+                    "background-color": bar.css,
+                  }}
+                />
+              </div>
+            )
+          }}
+        </For>
+      </div>
+    </div>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
@@ -28,9 +28,12 @@ import type {
   FileDiff,
 } from "@kilocode/sdk/v2"
 import { ErrorDisplay } from "./ErrorDisplay"
+import { GutterBar } from "./GutterBar"
 import { useServer } from "../../context/server"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
+import { classify } from "../../utils/timeline/colors"
+import type { Part as WebviewPart } from "../../types/messages"
 
 function getDirectory(path: string): string {
   const sep = path.includes("/") ? "/" : "\\"
@@ -48,6 +51,7 @@ interface VscodeSessionTurnProps {
   sessionID: string
   messageID: string
   queued?: boolean
+  timelineHover?: boolean
 }
 
 export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
@@ -148,10 +152,30 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
     return undefined
   })
 
+  // Determine the turn's timeline color from the first renderable part of the user message
+  const turnColor = createMemo(() => {
+    const msgParts = session.getParts(props.messageID) as WebviewPart[]
+    for (const p of msgParts) {
+      const c = classify(p, "user")
+      if (c) return c
+    }
+    // Fallback: check assistant parts
+    const assistants = assistantMessages()
+    for (const am of assistants) {
+      const aParts = session.getParts(am.id) as WebviewPart[]
+      for (const p of aParts) {
+        const c = classify(p, "assistant")
+        if (c) return c
+      }
+    }
+    return "user" as const
+  })
+
   return (
     <Show when={message()}>
       {(msg) => (
         <div class="vscode-session-turn" data-message={msg().id}>
+          <GutterBar color={turnColor()} visible={!!props.timelineHover} />
           {/* User message */}
           <div
             class="vscode-session-turn-user"

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -4,6 +4,178 @@
  */
 
 /* ============================================
+   Task Timeline
+   Matches legacy KiloTaskHeader → TaskTimeline → TaskTimelineMessage exactly.
+   Outer: overflow:hidden clips scrollbar. Inner: overflow-x:auto, taller to push scrollbar out of view.
+   Each bar: relative container with absolute-positioned colored fill anchored at bottom.
+   ============================================ */
+
+[data-component="task-timeline"] {
+  width: 100%;
+  height: 26px;
+  padding: 0 8px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+[data-slot="task-timeline-scroller"] {
+  display: flex;
+  flex-direction: row;
+  height: 51px; /* 26 + 25 to hide scrollbar */
+  overflow-x: auto;
+  overflow-y: hidden;
+  touch-action: none;
+  cursor: grab;
+  width: 100%;
+}
+
+[data-slot="task-timeline-scroller"]:active {
+  cursor: grabbing;
+}
+
+/* Legacy: mr-0.5 relative overflow-hidden, inline width+height */
+[data-slot="timeline-bar"] {
+  position: relative;
+  overflow: hidden;
+  margin-right: 2px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+[data-slot="timeline-bar"]:hover [data-slot="timeline-bar-inner"] {
+  opacity: 0.7;
+}
+
+/* Legacy: absolute bottom-0 left-0 right-0 rounded-t-xs transition-all duration-200 */
+[data-slot="timeline-bar-inner"] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 1px 1px 0 0;
+  transition: all 0.2s;
+}
+
+@keyframes timeline-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+
+[data-slot="timeline-bar-inner"][data-active] {
+  animation: timeline-pulse 2s ease-in-out infinite;
+  animation-delay: 0.5s;
+}
+
+/* ============================================
+   Context Progress Bar
+   ============================================ */
+
+[data-component="context-progress"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  white-space: nowrap;
+  padding: 0 8px;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  flex-shrink: 0;
+  box-sizing: border-box;
+}
+
+[data-slot="context-progress-label"] {
+  font-variant-numeric: tabular-nums;
+}
+
+[data-slot="context-progress-track"] {
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  overflow: hidden;
+  display: flex;
+  background: color-mix(in srgb, var(--vscode-foreground) 20%, transparent);
+}
+
+[data-slot="context-progress-used"] {
+  height: 100%;
+  background: color-mix(in srgb, var(--vscode-foreground) 50%, transparent);
+  transition: width 0.3s ease-out;
+}
+
+[data-slot="context-progress-used"][data-warning] {
+  background: color-mix(in srgb, var(--vscode-errorForeground) 70%, transparent);
+}
+
+[data-slot="context-progress-reserved"] {
+  height: 100%;
+  background: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
+  transition: width 0.3s ease-out;
+}
+
+/* ============================================
+   Task Header Expand Toggle
+   ============================================ */
+
+[data-slot="task-header-expand"] {
+  transition: transform 0.2s;
+}
+
+[data-slot="task-header-expand"][data-expanded] {
+  transform: rotate(180deg);
+}
+
+/* ============================================
+   Token Breakdown
+   ============================================ */
+
+[data-slot="task-header-tokens"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+[data-slot="token-in"] {
+  color: var(--vscode-textLink-foreground);
+}
+
+[data-slot="token-out"] {
+  color: var(--vscode-descriptionForeground);
+}
+
+[data-slot="token-cache"] {
+  opacity: 0.7;
+}
+
+/* ============================================
+   Gutter Bar
+   ============================================ */
+
+[data-slot="gutter-bar"] {
+  position: absolute;
+  width: 4px;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  opacity: 0;
+  transition: opacity 0.15s;
+  border-radius: 2px;
+}
+
+[data-slot="gutter-bar"][data-visible] {
+  opacity: 0.7;
+}
+
+/* ============================================
    Task Header Todos
    ============================================ */
 
@@ -2505,6 +2677,7 @@ body.vscode-light
   width: 100%;
   min-width: 0;
   padding: 0 4px;
+  position: relative;
 }
 
 .vscode-session-turn + .vscode-session-turn {

--- a/packages/kilo-vscode/webview-ui/src/utils/timeline/colors.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/timeline/colors.ts
@@ -1,0 +1,94 @@
+/**
+ * Timeline color classification for message parts.
+ * Maps Part types to VS Code theme-aware CSS colors,
+ * matching the legacy extension's color palette exactly.
+ */
+
+import type { Part } from "../../types/messages"
+
+export type TimelineColor =
+  | "user"
+  | "read"
+  | "write"
+  | "tool"
+  | "success"
+  | "error"
+  | "assistant"
+  | "question"
+  | "default"
+
+/**
+ * CSS color strings using VS Code theme variables.
+ * Matches the legacy extension's `taskTimelineColorPalette` exactly.
+ */
+const palette: Record<TimelineColor, string> = {
+  user: "color-mix(in srgb, var(--vscode-editor-findMatchBackground) 50%, var(--vscode-errorForeground))",
+  read: "var(--vscode-textLink-foreground)",
+  write: "var(--vscode-focusBorder)",
+  tool: "var(--vscode-activityBarBadge-background)",
+  success: "var(--vscode-editorGutter-addedBackground)",
+  error: "var(--vscode-errorForeground)",
+  assistant: "var(--vscode-descriptionForeground)",
+  question: "color-mix(in srgb, var(--vscode-editor-findMatchBackground) 60%, var(--vscode-foreground))",
+  default: "var(--vscode-badge-background)",
+}
+
+const READ_TOOLS = new Set(["read", "glob", "grep"])
+const WRITE_TOOLS = new Set(["edit", "write"])
+
+/**
+ * Classify a Part into a timeline color.
+ * Returns null for parts that should not appear as bars (step-start, step-finish, file).
+ */
+export function classify(part: Part, role: "user" | "assistant"): TimelineColor | null {
+  switch (part.type) {
+    case "text":
+      return role === "user" ? "user" : "assistant"
+
+    case "reasoning":
+      return "assistant"
+
+    case "tool": {
+      if (part.state.status === "error") return "error"
+      const name = part.tool.toLowerCase()
+      if (READ_TOOLS.has(name)) return "read"
+      if (WRITE_TOOLS.has(name)) return "write"
+      return "tool"
+    }
+
+    case "step-start":
+    case "step-finish":
+    case "file":
+      return null
+
+    default:
+      return "default"
+  }
+}
+
+/** Return the CSS color string for a given TimelineColor. */
+export function cssColor(color: TimelineColor): string {
+  return palette[color]
+}
+
+/** Human-readable label for a part type, used in tooltip. */
+export function partLabel(part: Part): string {
+  switch (part.type) {
+    case "text":
+      return "Text"
+    case "reasoning":
+      return "Thinking"
+    case "tool": {
+      const name = part.tool
+      if (READ_TOOLS.has(name)) return "File Read"
+      if (WRITE_TOOLS.has(name)) return "File Write"
+      if (name === "bash") return "Command"
+      if (name === "webfetch") return "Web Fetch"
+      if (name === "task") return "Sub-agent"
+      if (name === "todowrite" || name === "todoread") return "Planning"
+      return `Tool: ${name}`
+    }
+    default:
+      return "Action"
+  }
+}

--- a/packages/kilo-vscode/webview-ui/src/utils/timeline/sizes.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/timeline/sizes.ts
@@ -1,0 +1,118 @@
+/**
+ * Timeline bar size calculation.
+ * Computes width (from timing) and height (from content length) for each bar,
+ * matching the legacy extension's constants and algorithm exactly.
+ */
+
+import type { Message, Part } from "../../types/messages"
+import { classify, cssColor, partLabel, type TimelineColor } from "./colors"
+
+/** Same constants as legacy calculateTaskTimelineSizes.ts */
+export const MAX_HEIGHT = 26
+const AVG_TIMING = 3000
+const MIN_WIDTH = 8
+const MAX_WIDTH = 32
+const MIN_HEIGHT = 8
+const TOP_PAD = 4
+
+export interface BarData {
+  id: string
+  messageID: string
+  color: TimelineColor
+  css: string
+  width: number
+  height: number
+  label: string
+}
+
+interface RawBar {
+  id: string
+  messageID: string
+  color: TimelineColor
+  label: string
+  content: number
+  timing: number | null
+}
+
+/** Compute all timeline bars from messages and their parts. */
+export function compute(messages: Message[], parts: (id: string) => Part[]): BarData[] {
+  const raw: RawBar[] = []
+
+  for (let mi = 0; mi < messages.length; mi++) {
+    const msg = messages[mi]!
+    const msgParts = parts(msg.id)
+    const next: Message | undefined = messages[mi + 1]
+    const timing = msgTiming(msg, next)
+    let added = false
+
+    for (const p of msgParts) {
+      const color = classify(p, msg.role)
+      if (!color) continue
+
+      raw.push({
+        id: p.id,
+        messageID: msg.id,
+        color,
+        label: partLabel(p),
+        content: partContent(p),
+        timing,
+      })
+      added = true
+    }
+
+    // User messages may have no parts — their text is in message.content.
+    // Create a synthetic bar so they appear in the timeline.
+    if (!added && msg.content) {
+      raw.push({
+        id: `msg-${msg.id}`,
+        messageID: msg.id,
+        color: msg.role === "user" ? "user" : "assistant",
+        label: msg.role === "user" ? "User" : "Assistant",
+        content: Math.max(1, msg.content.length),
+        timing,
+      })
+    }
+  }
+
+  if (raw.length === 0) return []
+
+  const maxContent = Math.max(...raw.map((d) => d.content))
+  const valid = raw.map((d) => d.timing).filter((t): t is number => t !== null)
+  const maxTiming = valid.length > 0 ? Math.max(...valid) : AVG_TIMING
+
+  return raw.map((d, i) => {
+    const cRatio = Math.min(1, d.content / Math.max(1, maxContent))
+    const eff = i === raw.length - 1 ? MIN_WIDTH : (d.timing ?? AVG_TIMING)
+    const tRatio = Math.min(1, eff / Math.max(1, maxTiming))
+
+    return {
+      id: d.id,
+      messageID: d.messageID,
+      color: d.color,
+      css: cssColor(d.color),
+      width: Math.round(MIN_WIDTH + tRatio * (MAX_WIDTH - MIN_WIDTH)),
+      height: Math.round(MIN_HEIGHT + cRatio * (MAX_HEIGHT - MIN_HEIGHT - TOP_PAD)),
+      label: d.label,
+    }
+  })
+}
+
+function partContent(p: Part): number {
+  switch (p.type) {
+    case "text":
+    case "reasoning":
+      return Math.max(1, p.text.length)
+    case "tool":
+      return Math.max(1, JSON.stringify(p.state.input).length)
+    default:
+      return 1
+  }
+}
+
+function msgTiming(current: Message, next: Message | undefined): number | null {
+  if (!next) return null
+  const a = current.time?.created
+  const b = next.time?.created
+  if (!a || !b) return null
+  return Math.max(0, b - a)
+}

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,632 @@
+# Plan: Chat History Visualizer (Task Timeline)
+
+Reverse-engineer the legacy "colorful vertical bars / token usage / cost" panel from `kilocode-legacy` and implement it in the new `packages/kilo-vscode/` extension.
+
+## What the Feature Is (Exact Legacy Behavior)
+
+The legacy extension has a **Task Timeline** inside `KiloTaskHeader.tsx` — a horizontal strip of colored bars where each bar represents a message/action. The header has two states: **collapsed** and **expanded**.
+
+### Collapsed State (legacy layout)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ ▶ Task: summarized text...                         [X]   │  ← chevron + task title + close
+│ ▐▐▐ ▐▐▐▐ ▐▐ ▐▐▐▐▐▐ ▐▐ ▐▐▐ ▐▐▐▐▐▐ ▐▐▐                  │  ← TaskTimeline (26px height)
+│ 12.3k [═══════════░░░░] 128k  [condense] [share] +8 −4  │  ← ContextWindowProgress + buttons + diff + cost
+│                                                  $0.12   │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Expanded State (legacy layout)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ ▼ Task                                             [X]   │
+│ Full task text with @mentions and /commands...            │
+│ [thumbnails if images]                                   │
+│ ▐▐▐ ▐▐▐▐ ▐▐ ▐▐▐▐▐▐ ▐▐ ▐▐▐ ▐▐▐▐▐▐ ▐▐▐                  │  ← TaskTimeline
+│ Context Window: 12.3k [═══════════░░░░] 128k [condense]  │
+│ Tokens: ↑12.3k ↓2.1k                                    │
+│ Cache: ☁↑1.1k ☁↓8.2k                                    │
+│ API Cost: $0.12                              [actions]   │
+│ Changes: +8 −4 ■■■■□                                    │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Timeline Bar Specifics (from legacy source)
+
+- Each bar is a `<div>` absolutely positioned at the bottom of a 26px container
+- **Width** = 8-32px, proportional to time delta to next message (normalized by max timing). Last message always gets `MIN_WIDTH_PX` (8px)
+- **Height** = 8-26px (minus 4px top padding), proportional to content length (text + reasoning + images×100 + condense summary). Minimum 1 char
+- **Colors** use VS Code CSS variables via `color-mix()` — NOT hardcoded hex values:
+  - `USER_INTERACTION`: `bg-[color-mix(in_srgb,var(--vscode-editor-findMatchBackground)_50%,var(--vscode-errorForeground))]`
+  - `SYSTEM_READ`: `bg-[var(--vscode-textLink-foreground)]`
+  - `SYSTEM_WRITE`: `bg-[var(--vscode-focusBorder)]`
+  - `SYSTEM_GENERAL_TOOL`: `bg-[var(--vscode-activityBarBadge-background)]`
+  - `SUCCESS`: `bg-[var(--vscode-editorGutter-addedBackground)]`
+  - `ERROR`: `bg-[var(--vscode-errorForeground)]`
+  - `ASSISTANT_MUTTERING`: `bg-[var(--vscode-descriptionForeground)]`
+  - `ASSISTANT_QUESTION`: `bg-[color-mix(in_srgb,var(--vscode-editor-findMatchBackground)_60%,var(--vscode-foreground))]`
+  - `GROUPED`: `bg-[var(--vscode-textLink-activeForeground)]`
+  - `DEFAULT`: `bg-[var(--vscode-badge-background)]`
+- Bars have `rounded-t-xs`, `transition-all duration-200`, `hover:opacity-70`
+- New bars get `animate-fade-in` (disappears after 1s)
+- Active (last) bar gets `animate-slow-pulse-delayed`
+- Container has `overflow: hidden` at 26px height, inner Virtuoso scroll area is 26px+25px (hides scrollbar)
+- `HorizontalScroller`: converts vertical mouse wheel to horizontal scroll, supports drag-scroll via `@use-gesture/react` with pointer capture, `filterTaps: true`, `axis: "x"`, `touchAction: "pan-x"`
+- Auto-scrolls to latest bar on new messages (smooth) and on initial mount (instant)
+
+### Gutter Bars (from legacy source)
+
+- 4px wide absolute-positioned left bar on each chat row
+- Uses same `getTaskTimelineMessageColor()` color mapping
+- `opacity-0` by default, transitions to `opacity-70` when `hoveringTaskTimeline` is true (set by `onMouseEnter`/`onMouseLeave` on the TaskTimeline container)
+
+### Context Window Progress Bar (from legacy source)
+
+- Three-segment horizontal bar: used (darkest) | reserved for output (medium) | available (transparent)
+- Background: `color-mix(in_srgb,var(--vscode-foreground)_20%,transparent)`
+- Used segment turns red (`color-mix` with `errorForeground`) when `>= 50%`
+- Reserved: `color-mix(in_srgb,var(--vscode-foreground)_30%,transparent)`
+- Shows token count (left) and context window size (right) flanking the bar
+- Tooltip shows: tokens used/total, reserved for response, available space
+
+## What Already Exists in the New Extension
+
+The new extension has in `TaskHeader.tsx` (`webview-ui/src/components/chat/TaskHeader.tsx`):
+
+- Session title
+- Total session cost (formatted as Intl currency)
+- Context usage (tokens + percentage as tooltip)
+- Todo progress section
+- Compact button
+
+Data available in the session context (`useSession()`) from `session.tsx`:
+
+- `totalCost()` (line 1559) — `createMemo(() => calcTotalCost(messages()))` — reactive, recomputes on any message change
+- `contextUsage()` (lines 1575-1588) — scans backwards for last assistant message with `tokens`, computes vs model context limit
+- `messages()` — full message list with `cost`, `tokens`, `time`, `parts` per message
+- `getParts(messageID)` — individual parts per message
+- `status()` — session status (idle/busy/retry)
+- `sessions()` — all sessions sorted by update time
+
+**Gap**: No timeline visualization, no per-message color mapping, no gutter bars, no segmented context window progress bar, no token breakdown, no diff stats.
+
+## Token/Cost Data Flow — Critical Details
+
+### How cost/tokens arrive from OpenRouter
+
+1. **Backend** (`packages/opencode/src/session/index.ts:842-951`): `getUsage()` extracts cost from `providerMetadata.openrouter.usage`:
+   - **Kilo BYOK**: Uses `costDetails.upstreamInferenceCost` (excludes OpenRouter's 5% fee)
+   - **Direct OpenRouter**: Uses `openrouterUsage.cost` (includes OpenRouter's fee)
+   - **Fallback**: Per-million-token calculation from model rate card
+
+2. **Per-step accumulation** (`packages/opencode/src/session/processor.ts:248-287`):
+   - `assistantMessage.cost += usage.cost` — **accumulated** across steps
+   - `assistantMessage.tokens = usage.tokens` — **overwritten** each step (last step only)
+   - Each `step-finish` part carries per-step `cost` and `tokens`
+
+3. **SSE to webview** (`packages/kilo-vscode/src/kilo-provider-utils.ts:256-264`): `message.updated` passes through `cost` and `tokens` via spread. No filtering.
+
+4. **Reactive chain**: SSE → `handleMessageCreated` upserts in store → `messages()` signal → `totalCost` and `contextUsage` memos auto-recompute.
+
+### Implications for Display
+
+| Data                               | Source                                                              | Correctness                                                                               |
+| ---------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **Session total cost**             | `totalCost()` = sum of `message.cost` across all assistant messages | Correct — cost is accumulated per-step                                                    |
+| **Context usage**                  | `contextUsage()` = last assistant message's `tokens`                | Correct for context monitoring — last step sends full conversation                        |
+| **Per-message tokens**             | `message.tokens`                                                    | Shows **last step's** tokens only. For multi-step messages, earlier steps are overwritten |
+| **Per-step tokens**                | `StepFinishPart.tokens` in `getParts(messageID)`                    | Individually correct per step                                                             |
+| **Token breakdown (in/out/cache)** | `message.tokens.{input, output, reasoning, cache.{read, write}}`    | Correct for the last step; for cumulative, must sum `StepFinishPart` tokens               |
+
+**Decision**: For the header token breakdown display, use cumulative sums from ALL `StepFinishPart` parts across the session — this gives accurate totals. For context usage percentage, continue using the existing `contextUsage()` memo (correct as-is).
+
+## Implementation Plan
+
+### Phase 1: Color Classification System
+
+**New file**: `webview-ui/src/utils/timeline/colors.ts`
+
+Port the exact color palette from legacy `messageColors.ts`, using the same VS Code CSS variable bindings. Adapt the classification from legacy `ClineMessage` ask/say subtypes to the new extension's `Part` types.
+
+**Exact color variable mapping** (same CSS as legacy):
+
+```ts
+export const palette = {
+  USER: "var(--vscode-editor-findMatchBackground)", // mixed with errorForeground
+  READ: "var(--vscode-textLink-foreground)",
+  WRITE: "var(--vscode-focusBorder)",
+  TOOL: "var(--vscode-activityBarBadge-background)",
+  SUCCESS: "var(--vscode-editorGutter-addedBackground)",
+  ERROR: "var(--vscode-errorForeground)",
+  ASSISTANT: "var(--vscode-descriptionForeground)",
+  QUESTION: "var(--vscode-editor-findMatchBackground)", // mixed with foreground
+  DEFAULT: "var(--vscode-badge-background)",
+}
+```
+
+**Part → color mapping**:
+
+| Part type               | Tool name                                   | Color              |
+| ----------------------- | ------------------------------------------- | ------------------ |
+| `tool` (any state)      | `read`, `glob`, `grep`                      | READ               |
+| `tool` (any state)      | `edit`, `write`                             | WRITE              |
+| `tool` (any state)      | `bash`                                      | TOOL               |
+| `tool` (any state)      | `webfetch`, `task`, `todowrite`, `todoread` | TOOL               |
+| `tool` (error state)    | any                                         | ERROR              |
+| `text` (role=user)      | —                                           | USER               |
+| `text` (role=assistant) | —                                           | ASSISTANT          |
+| `reasoning`             | —                                           | ASSISTANT          |
+| `step-start`            | —                                           | (skip — not a bar) |
+| `step-finish`           | —                                           | (skip — not a bar) |
+
+The legacy extension classifies at the `ClineMessage` level (ask/say); the new extension has `Part` types within `Message`. Each visible Part becomes one bar. Messages with only step-start/step-finish parts are skipped.
+
+Export:
+
+```ts
+export type TimelineColor =
+  | "user"
+  | "read"
+  | "write"
+  | "tool"
+  | "success"
+  | "error"
+  | "assistant"
+  | "question"
+  | "default"
+export function classify(part: Part, role: "user" | "assistant"): TimelineColor | null
+export function cssColor(color: TimelineColor): string // returns the color-mix CSS string
+export function label(part: Part, t: TranslateFunction): string // tooltip label
+```
+
+### Phase 2: Timeline Size Calculation
+
+**New file**: `webview-ui/src/utils/timeline/sizes.ts`
+
+Port exactly from legacy `calculateTaskTimelineSizes.ts`. Identical constants:
+
+```ts
+export const MAX_HEIGHT = 26
+const AVG_TIMING = 3000
+const MIN_WIDTH = 8
+const MAX_WIDTH = 32
+const MIN_HEIGHT = 8
+const TOP_PAD = 4
+```
+
+```ts
+export interface BarData {
+  id: string // part.id or message.id
+  messageID: string
+  color: TimelineColor
+  width: number // 8-32
+  height: number // 8-22 (26 - 4 padding)
+  label: string // tooltip text
+}
+
+export function compute(messages: Message[], parts: (id: string) => Part[], t: TranslateFunction): BarData[]
+```
+
+Logic:
+
+1. Iterate messages, for each get parts via `parts(message.id)`
+2. Filter parts to renderable types (text, tool, reasoning — skip step-start, step-finish)
+3. Compute content length per part: `text.length` for text/reasoning, `JSON.stringify(state.input).length` for tool parts
+4. Compute timing: `message.time.completed - message.time.created` (or delta to next message's `time.created`)
+5. Find max content length and max timing across all bars
+6. Normalize and lerp to get width (from timing) and height (from content length)
+7. Last bar gets `MIN_WIDTH` (legacy behavior)
+
+### Phase 3: TaskTimeline Component
+
+**New file**: `webview-ui/src/components/chat/TaskTimeline.tsx`
+
+SolidJS component matching the exact legacy rendering. Key differences from legacy (React → SolidJS):
+
+- `react-virtuoso` → plain CSS horizontal scroll (SolidJS has no virtuoso equivalent; typical sessions have <500 bars so virtualization is unnecessary)
+- `@use-gesture/react` → native `onWheel` + `onPointerDown`/`onPointerMove`/`onPointerUp` for drag-scroll
+- `memo` → SolidJS fine-grained reactivity (no memoization needed)
+- `useState`/`useEffect` → `createSignal`/`onMount`/`onCleanup`
+
+```tsx
+interface Props {
+  bars: BarData[]
+  active: boolean // is session busy (pulse last bar)
+  onBarClick?: (messageID: string) => void
+  onHover?: (hovering: boolean) => void
+}
+```
+
+**Exact rendering per bar** (matching legacy `TaskTimelineMessage.tsx`):
+
+```tsx
+<div style={{ width: `${bar.width}px`, height: `${MAX_HEIGHT}px` }} class="mr-0.5 relative overflow-hidden">
+  <Tooltip>
+    <div
+      class="absolute bottom-0 left-0 right-0 cursor-pointer rounded-t-xs transition-all duration-200 hover:opacity-70"
+      classList={{ "animate-fade-in": isNew(), "animate-slow-pulse-delayed": isActive }}
+      style={{ height: `${(bar.height / MAX_HEIGHT) * 100}%`, "background-color": cssColor(bar.color) }}
+      onClick={() => props.onBarClick?.(bar.messageID)}
+    />
+  </Tooltip>
+</div>
+```
+
+**Container** (matching legacy):
+
+- Outer div: `w-full px-2 overflow-hidden`, height `26px` (clips scrollbar)
+- Inner div: `overflow-x-auto overflow-y-hidden touch-none cursor-grab`, height `51px` (26+25 for scrollbar hiding)
+- `display: flex; align-items: flex-end` for skyline effect
+- `onWheel`: `e.preventDefault(); container.scrollLeft += e.deltaY` (vertical → horizontal)
+- Drag scroll: `onPointerDown` sets grabbing cursor, `onPointerMove` adjusts `scrollLeft`, `onPointerUp` resets
+- `onMouseEnter`/`onMouseLeave` → call `props.onHover(true/false)`
+
+**Auto-scroll**: Use `createEffect` watching `bars.length` — on increase, scroll to end. On mount with data, instant scroll; on streaming, smooth scroll.
+
+### Phase 4: Context Window Progress Bar
+
+**New file**: `webview-ui/src/components/chat/ContextProgress.tsx`
+
+Port exactly from legacy `ContextWindowProgress.tsx`. A segmented horizontal bar.
+
+```tsx
+interface Props {
+  tokens: number
+  limit: number
+  reserved?: number // max output tokens
+}
+```
+
+Three segments matching legacy CSS:
+
+1. **Used**: `background-color: color-mix(in srgb, var(--vscode-foreground) 50%, transparent)` — turns red (`color-mix(in srgb, var(--vscode-errorForeground) 70%, transparent)`) when `>= 50%`
+2. **Reserved for output**: `background-color: color-mix(in srgb, var(--vscode-foreground) 30%, transparent)`
+3. **Available**: transparent (remainder of bar)
+
+Bar container: 4px height, `rounded-[2px]`, background `color-mix(in srgb, var(--vscode-foreground) 20%, transparent)`
+
+Layout: `[token_count] [bar] [context_window_size]` in a flex row with `gap-2`, matching legacy exactly.
+
+Tooltip (matching legacy):
+
+- "X of Y tokens used"
+- "Z reserved for response" (if reserved > 0)
+- "W available space" (if available > 0)
+
+### Phase 5: Integrate into TaskHeader — DO NOT DISTURB EXISTING ROW
+
+The existing `TaskHeader.tsx` title+stats row must remain **unchanged**. The timeline and context bar are **additions below** the existing content.
+
+**Modify** `webview-ui/src/components/chat/TaskHeader.tsx`:
+
+Add below the existing header content (after the `task-header-stats` div, before todos):
+
+```tsx
+<Show when={showTimeline()}>
+  <TaskTimeline
+    bars={bars()}
+    active={session.status() === "busy"}
+    onBarClick={scrollToMessage}
+    onHover={setHovering}
+  />
+</Show>
+<Show when={contextUsage()}>
+  <ContextProgress
+    tokens={contextUsage()!.tokens}
+    limit={contextLimit()}
+    reserved={maxOutputTokens()}
+  />
+</Show>
+<Show when={tokenBreakdown()}>
+  {(breakdown) => (
+    <div data-slot="task-header-tokens">
+      <span>↑{formatNumber(breakdown().input)}</span>
+      <span>↓{formatNumber(breakdown().output)}</span>
+      <Show when={breakdown().cache}>
+        {(cache) => (
+          <>
+            <span>cache R:{formatNumber(cache().read)}</span>
+            <span>W:{formatNumber(cache().write)}</span>
+          </>
+        )}
+      </Show>
+    </div>
+  )}
+</Show>
+```
+
+**Token breakdown computation**: Create a `createMemo` that accumulates ALL `StepFinishPart` tokens from the entire session:
+
+```ts
+const tokenBreakdown = createMemo(() => {
+  const msgs = session.messages()
+  let input = 0,
+    output = 0,
+    reasoning = 0,
+    read = 0,
+    write = 0
+  for (const m of msgs) {
+    if (m.role !== "assistant") continue
+    for (const p of session.getParts(m.id)) {
+      if (p.type !== "step-finish" || !p.tokens) continue
+      input += p.tokens.input
+      output += p.tokens.output
+      reasoning += p.tokens.reasoning ?? 0
+      read += p.tokens.cache?.read ?? 0
+      write += p.tokens.cache?.write ?? 0
+    }
+  }
+  if (input === 0 && output === 0) return undefined
+  return { input, output, reasoning, cache: read || write ? { read, write } : undefined }
+})
+```
+
+This is **correct for OpenRouter** because:
+
+- Each `step-finish` part has accurate per-step tokens from OpenRouter's `usage` response
+- Summing all step-finish parts gives the true cumulative totals
+- This avoids the `message.tokens` overwrite issue where only the last step's tokens survive
+
+### Phase 6: Gutter Bars on Chat Rows
+
+**New file**: `webview-ui/src/components/chat/GutterBar.tsx`
+
+Exact port of legacy `KiloChatRowGutterBar.tsx`:
+
+```tsx
+export function GutterBar(props: { color: TimelineColor; hovering: boolean }) {
+  return (
+    <div
+      style={{ "background-color": cssColor(props.color) }}
+      class="absolute w-[4px] left-[4px] top-0 bottom-0 opacity-0 transition-opacity"
+      classList={{ "opacity-70": props.hovering }}
+    />
+  )
+}
+```
+
+**Reactivity**: The `hovering` boolean comes from a signal in the parent, set by `TaskTimeline`'s `onHover` callback. This signal must be:
+
+1. Defined at a level accessible to both `TaskTimeline` and the chat row components
+2. Updated on `mouseenter`/`mouseleave` on the timeline container
+3. Reactive — SolidJS signals propagate automatically, so when hovering changes, all `GutterBar` instances re-render their opacity
+
+**Option A**: Add `hovering` signal to the session context (simple, global)
+**Option B**: Use a SolidJS context provider wrapping the chat view (more scoped)
+
+Recommend **Option A** — add `[timelineHover, setTimelineHover] = createSignal(false)` to the chat view level and pass down via props, matching the legacy pattern where `hoveringTaskTimeline` was in `ExtensionStateContext`.
+
+### Phase 7: Click-to-Scroll & Reactivity on Session Changes
+
+**Click-to-scroll** (matching legacy behavior):
+
+1. Each `BarData` has a `messageID`
+2. On click: find DOM element `[data-message-id="${messageID}"]` (add `data-message-id` to chat row containers if not already present)
+3. `element.scrollIntoView({ behavior: "smooth", block: "center" })`
+4. Optional: flash highlight animation (CSS animation toggled via a signal)
+
+**Reactivity on session actions** — the timeline must update when:
+
+- **New message arrives** — `messages()` signal updates → `bars` memo recomputes → `<For each={bars()}>` adds new bar
+- **Session changes** (user selects different session) — `currentSessionID()` changes → `messages()` returns new session's messages → full timeline remount
+- **New session created** — `messages()` becomes empty → timeline shows nothing → bars appear as messages stream in
+- **Parts update** (streaming) — `getParts(messageID)` updates → if `bars` memo depends on it, recomputes. Need to ensure `compute()` is called reactively by tracking both `messages()` length AND the parts for each message
+- **Session status changes** (idle→busy→idle) — `status()` signal → `active` prop on timeline → last bar pulse animation
+
+The key reactive dependency is:
+
+```ts
+const bars = createMemo(() => {
+  const msgs = session.messages() // tracks messages signal
+  return compute(msgs, session.getParts, language.t) // getParts is a function, called per msg
+})
+```
+
+Since `getParts` reads from the store (which is a SolidJS store with fine-grained tracking), accessing `session.getParts(m.id)` inside the memo tracks those specific store paths. When a part updates via SSE → store mutation, the memo recomputes.
+
+**However**: `createMemo` in SolidJS only tracks signals accessed during its **synchronous** execution. Since `getParts` accesses `store.parts[messageID]`, and the store uses Solid's `createStore`, these accesses ARE tracked. The bars memo WILL recompute when:
+
+- A new message is added to `store.messages[sessionID]`
+- A part is added/updated in `store.parts[messageID]` for any messageID accessed by the memo
+
+This means the timeline updates reactively on every streaming event — no manual refresh needed.
+
+### Phase 8: Settings Toggle
+
+Add a `showTaskTimeline` setting:
+
+1. **Session context or config context**: Add a `showTimeline` signal, default `true`
+2. **Persistence**: Store in VS Code `globalState` via the existing config flow
+3. **Settings UI**: Add checkbox — "Show task timeline: Visual minimap of session activity"
+4. **TaskHeader**: Wrap `<TaskTimeline>` in `<Show when={showTimeline()}>`
+
+### Phase 9: CSS / Theming
+
+**Add to**: `webview-ui/src/styles/chat.css`
+
+```css
+/* Task Timeline */
+[data-component="task-timeline"] {
+  display: flex;
+  align-items: flex-end;
+  overflow-x: auto;
+  overflow-y: hidden;
+  touch-action: none;
+  cursor: grab;
+  width: 100%;
+  padding: 0 8px;
+}
+
+[data-component="task-timeline"]:active {
+  cursor: grabbing;
+}
+
+[data-slot="timeline-bar"] {
+  position: relative;
+  margin-right: 2px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+[data-slot="timeline-bar-inner"] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  cursor: pointer;
+  border-radius: 1px 1px 0 0;
+  transition: all 0.2s;
+}
+
+[data-slot="timeline-bar-inner"]:hover {
+  opacity: 0.7;
+}
+
+/* Context Progress */
+[data-component="context-progress"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  white-space: nowrap;
+}
+
+[data-slot="context-progress-bar"] {
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  overflow: hidden;
+  display: flex;
+  background: color-mix(in srgb, var(--vscode-foreground) 20%, transparent);
+}
+
+[data-slot="context-progress-used"] {
+  height: 100%;
+  background: color-mix(in srgb, var(--vscode-foreground) 50%, transparent);
+  transition: width 0.3s ease-out;
+}
+
+[data-slot="context-progress-used"][data-warning] {
+  background: color-mix(in srgb, var(--vscode-errorForeground) 70%, transparent);
+}
+
+[data-slot="context-progress-reserved"] {
+  height: 100%;
+  background: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
+  transition: width 0.3s ease-out;
+}
+
+/* Gutter Bar */
+[data-slot="gutter-bar"] {
+  position: absolute;
+  width: 4px;
+  left: 4px;
+  top: 0;
+  bottom: 0;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+[data-slot="gutter-bar"][data-visible] {
+  opacity: 0.7;
+}
+
+/* Token Breakdown */
+[data-slot="task-header-tokens"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--vscode-font-size);
+  color: var(--vscode-descriptionForeground);
+}
+
+/* Animations */
+@keyframes timeline-fade-in {
+  from {
+    opacity: 0;
+    transform: scaleY(0);
+  }
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+@keyframes timeline-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+
+[data-slot="timeline-bar-inner"][data-new] {
+  animation: timeline-fade-in 0.3s ease-out;
+}
+
+[data-slot="timeline-bar-inner"][data-active] {
+  animation: timeline-pulse 2s ease-in-out infinite;
+  animation-delay: 0.5s;
+}
+```
+
+## Files to Create/Modify
+
+### New Files
+
+| File                                                 | Purpose                                                 |
+| ---------------------------------------------------- | ------------------------------------------------------- |
+| `webview-ui/src/utils/timeline/colors.ts`            | Part → color classification, CSS variable mapping       |
+| `webview-ui/src/utils/timeline/sizes.ts`             | Bar width/height calculation (same constants as legacy) |
+| `webview-ui/src/components/chat/TaskTimeline.tsx`    | Horizontal bar strip with drag-scroll, auto-scroll      |
+| `webview-ui/src/components/chat/ContextProgress.tsx` | Three-segment context window progress bar               |
+| `webview-ui/src/components/chat/GutterBar.tsx`       | Per-row 4px colored indicator                           |
+
+### Modified Files
+
+| File                                            | Change                                                                        |
+| ----------------------------------------------- | ----------------------------------------------------------------------------- |
+| `webview-ui/src/components/chat/TaskHeader.tsx` | Add timeline, context bar, token breakdown BELOW existing content             |
+| `webview-ui/src/styles/chat.css`                | Add Task Timeline, Context Progress, Gutter Bar, Token Breakdown CSS sections |
+| Chat message row component                      | Add `data-message-id` attribute and `<GutterBar>` child                       |
+
+### No Backend Changes Needed
+
+All required data is already flowing from CLI → SSE → webview:
+
+- `Message.cost` (accumulated per-step, correct for OpenRouter)
+- `Message.tokens` (last step's tokens — adequate for context usage display)
+- `StepFinishPart.cost` and `.tokens` (per-step, correct — use these for cumulative token breakdown)
+- `Message.time.{created, completed}` (for bar width timing)
+- `Part` types (text, tool, reasoning — for bar color classification)
+
+## Dependencies
+
+- **No new npm dependencies**
+- Legacy uses `react-virtuoso` → replaced with plain CSS horizontal scroll (sufficient for <500 bars)
+- Legacy uses `@use-gesture/react` → replaced with native pointer events (onPointerDown/Move/Up)
+- SolidJS primitives (`createSignal`, `createMemo`, `For`, `Show`, `onMount`, `onCleanup`, `createEffect`) replace React hooks
+
+## Testing
+
+- Unit tests for `colors.ts` — part classification for all tool types
+- Unit tests for `sizes.ts` — bar dimension calculation, edge cases (empty, single message, no timing)
+- Unit tests for token breakdown accumulation from StepFinishParts
+- Visual regression tests via Storybook if applicable
+- Manual testing: verify colors match VS Code theme, bars appear on streaming, click-to-scroll works, gutter bars highlight on hover, timeline updates on session switch/create
+
+## Implementation Order
+
+1. `colors.ts` + `sizes.ts` — pure logic, testable first
+2. `TaskTimeline.tsx` — render the bars
+3. `TaskHeader.tsx` integration — visible result, timeline appears
+4. `ContextProgress.tsx` — segmented bar below timeline
+5. Token breakdown display — cumulative StepFinishPart sums
+6. `GutterBar.tsx` + hover interaction — polish
+7. Click-to-scroll wiring
+8. Settings toggle (show/hide)
+9. CSS animations and theming refinement


### PR DESCRIPTION
## Summary

Prototype port of the legacy extension's **task timeline** feature — the colorful vertical bars, context window progress, and token breakdown panel.

This reverse-engineers the legacy `KiloTaskHeader`, `TaskTimeline`, `TaskTimelineMessage`, `ContextWindowProgress`, and `KiloChatRowGutterBar` components and reimplements them in SolidJS for the new extension.
<img width="846" height="234" alt="image" src="https://github.com/user-attachments/assets/ef49bebb-9299-4a6d-a928-1721f9debe15" />
<img width="466" height="151" alt="image" src="https://github.com/user-attachments/assets/f5915a79-4eee-46d6-9935-5b8c3b78ac9e" />
<img width="417" height="192" alt="image" src="https://github.com/user-attachments/assets/15b6aa24-b135-4816-8bc4-9b5f05f24ed8" />


## What's included

- **Task Timeline**: Horizontal strip of colored bars representing session activity
  - Color = part type (read=blue, write=dark blue, tool=indigo, error=red, user=amber, assistant=gray)
  - Width = proportional to time between messages
  - Height = proportional to content length
  - Uses exact VS Code CSS variable palette from legacy (`color-mix()`, `--vscode-textLink-foreground`, etc.)
- **Context Progress Bar**: Three-segment bar (used / reserved for output / available)
- **Token Breakdown**: Cumulative input/output/cache counts from all StepFinishParts
- **Gutter Bars**: 4px colored indicator on each chat turn, visible when hovering the timeline
- **Expand/Collapse**: Chevron toggle in the header stats area — everything hidden by default
- **Click-to-scroll**: Click a bar to scroll to the corresponding message turn
- **Drag-scroll**: Click-and-drag horizontally, mouse wheel converts to horizontal scroll
- **37 unit tests** for color classification and bar size calculation

## Known issues (WIP)

- **Navigation**: Click-to-scroll from the timeline bars does not always land on the exact right message — assistant message bars navigate to the parent turn but not the specific part within it
- **Message highlighting**: The gutter bar highlight on hover works but there's no per-message flash animation on click-to-scroll yet
- **Horizontal scaling**: Bar widths could be better tuned — short sessions have very wide bars, long sessions compress too much

## Files

### New (7)
| File | Purpose |
|---|---|
| `webview-ui/src/utils/timeline/colors.ts` | Part → color classification |
| `webview-ui/src/utils/timeline/sizes.ts` | Bar width/height calculation |
| `webview-ui/src/components/chat/TaskTimeline.tsx` | Horizontal bar strip |
| `webview-ui/src/components/chat/ContextProgress.tsx` | Context window progress bar |
| `webview-ui/src/components/chat/GutterBar.tsx` | Per-turn colored indicator |
| `tests/unit/timeline-colors.test.ts` | 20 tests for color classification |
| `tests/unit/timeline-sizes.test.ts` | 17 tests for bar sizing |

### Modified (5)
| File | Change |
|---|---|
| `TaskHeader.tsx` | Added timeline, context progress, token breakdown, expand toggle |
| `ChatView.tsx` | Added timelineHover signal |
| `MessageList.tsx` | Passes timelineHover to turns |
| `VscodeSessionTurn.tsx` | Renders GutterBar with timeline color |
| `chat.css` | Timeline, context progress, token, gutter bar, expand toggle styles |