### PR TITLE
fix(vscode): write Kilo auth as OAuth during legacy migration

### DIFF
--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -374,6 +374,24 @@ async function migrateProvider(
     return { item: profileName, category: "provider", status: "warning", message: "No API key found in profile" }
   }
 
+  // The profile endpoint requires type:"oauth". The legacy extension stored the same Kilo
+  // API token — write it in the OAuth format the new extension expects (matching device-auth:
+  // access + refresh + 1-year expiry).
+  if (mapping.id === "kilo") {
+    const org = mapping.organizationIdField ? (settings[mapping.organizationIdField] as string | undefined) : undefined
+    await client.auth.set({
+      providerID: "kilo",
+      auth: {
+        type: "oauth" as const,
+        access: apiKey,
+        refresh: apiKey,
+        expires: Date.now() + 365 * 24 * 60 * 60 * 1000,
+        accountId: org,
+      },
+    })
+    return { item: profileName, category: "provider", status: "success" }
+  }
+
   // For providers that support an organization ID (e.g. Kilo Gateway), migrate using OAuth
   // auth so the CLI can read accountId for org-scoped API requests.
   const organizationId = mapping.organizationIdField


### PR DESCRIPTION
## Summary

- Legacy migration wrote Kilo auth as `type: "api"` for personal accounts (no org ID), but the profile endpoint requires `type: "oauth"` — causing an immediate 401 and logging the user out after migration
- Now always writes the legacy Kilo token in OAuth format (`access` + `refresh` + 1-year expiry) matching what device-auth produces, so migrated users stay logged in

## Demo

https://github.com/user-attachments/assets/6070b6a9-cdc7-4fc1-b88d-b07b9cc1ca4f

## Root cause

`migrateProvider()` used a generic path that chose between `type: "oauth"` (if org ID present) and `type: "api"` (if no org ID). The `/kilo/profile` route rejects anything that isn't `type: "oauth"`:

```ts
if (!auth || auth.type !== "oauth") {
  return c.json({ error: "Not authenticated with Kilo Gateway" }, 401)
}
```

Personal accounts always hit this 401 after migration. Org accounts passed the type check but failed at the Kilo API with a stale token.

## Fix

Early-return for `mapping.id === "kilo"` in `migrateProvider()` that writes the token in the correct OAuth format before the generic path runs.