### PR TITLE
fix(vscode): align prompt textarea wrapping with overlay

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -284,6 +284,9 @@
   font-family: var(--vscode-font-family);
   font-size: 13px;
   line-height: 1.4;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-x: hidden;
   resize: none;
   outline: none;
 }


### PR DESCRIPTION
## Context

Fixes `#7808`.

The VS Code prompt input uses a transparent `<textarea>` for input/caret positioning and an overlaid `<div>` for the visible highlighted text. On Windows, these two layers could wrap text differently, which caused the caret and rendered text to drift vertically, especially after pasting larger blocks of text.

## Implementation

Aligned the textarea wrapping behavior with the overlay by adding the missing properties to `.prompt-input` in `packages/kilo-vscode/webview-ui/src/styles/chat.css`:

- `white-space: pre-wrap`
- `word-wrap: break-word`
- `overflow-x: hidden`

This keeps the change narrowly scoped to the input CSS and leaves the component structure and behavior unchanged.

## Screenshots

| before | after |
| ------ | ----- |
| Add Windows repro screenshot from issue | Add screenshot showing caret/text alignment after paste |

## How to Test

1. Open the VS Code extension sidebar.
2. Paste a long multi-line block, including long lines that need wrapping, into the prompt input.
3. Confirm the caret position aligns with the visible text while typing, navigating, and scrolling.
4. Repeat on Windows, where the mismatch was previously visible.

## Get in Touch

Discord: add your handle here if you want maintainer follow-up there.
