### PR TITLE
fix: MCP migrator ignores servers using 'transport' field (VS Code extension format)

### DIFF
--- a/packages/opencode/src/kilocode/mcp-migrator.ts
+++ b/packages/opencode/src/kilocode/mcp-migrator.ts
@@ -11,8 +11,18 @@ export namespace McpMigrator {
   // Remote transport types used by the Kilocode extension
   const REMOTE_TYPES = new Set(["streamable-http", "sse"])
 
+  /**
+   * Get the transport type for a server, checking both "type" and "transport" fields.
+   * The VS Code extension writes configs with "transport" (e.g., "transport": "sse"),
+   * but the CLI historically expected "type". We support both for compatibility.
+   */
+  function getTransportType(server: KilocodeMcpServer): string | undefined {
+    return server.type ?? server.transport
+  }
+
   function isRemote(server: KilocodeMcpServer): boolean {
-    return !!server.type && REMOTE_TYPES.has(server.type)
+    const transportType = getTransportType(server)
+    return !!transportType && REMOTE_TYPES.has(transportType)
   }
 
   // Kilocode MCP server structure
@@ -24,6 +34,7 @@ export namespace McpMigrator {
     alwaysAllow?: string[]
     // Remote server fields
     type?: string
+    transport?: string // VS Code extension writes "transport" instead of "type"
     url?: string
     headers?: Record<string, string>
   }

--- a/packages/opencode/test/kilocode/mcp-migrator.test.ts
+++ b/packages/opencode/test/kilocode/mcp-migrator.test.ts
@@ -529,6 +529,50 @@ describe("McpMigrator", () => {
 
         expect(result).not.toHaveProperty("headers")
       })
+
+      // Regression: VS Code extension writes "transport" instead of "type"
+      test("converts server using 'transport' field (VS Code extension format)", () => {
+        const server = {
+          transport: "sse",
+          url: "http://localhost:3000/api/mcp/sse",
+        } as any
+
+        const result = McpMigrator.convertServer("cipher-direct", server)
+
+        expect(result).toEqual({
+          type: "remote",
+          url: "http://localhost:3000/api/mcp/sse",
+        })
+      })
+
+      test("converts server using 'transport: streamable-http' field", () => {
+        const server = {
+          transport: "streamable-http",
+          url: "http://localhost:8001/v1/mcp",
+        } as any
+
+        const result = McpMigrator.convertServer("http-server", server)
+
+        expect(result).toEqual({
+          type: "remote",
+          url: "http://localhost:8001/v1/mcp",
+        })
+      })
+
+      test("'type' field takes precedence over 'transport' field", () => {
+        const server = {
+          type: "streamable-http",
+          transport: "sse",
+          url: "http://localhost:4321/mcp",
+        } as any
+
+        const result = McpMigrator.convertServer("precedence-test", server)
+
+        expect(result).toEqual({
+          type: "remote",
+          url: "http://localhost:4321/mcp",
+        })
+      })
     })
 
     describe("migrate", () => {
@@ -711,6 +755,91 @@ describe("McpMigrator", () => {
         expect(result.skipped).toContainEqual({
           name: "disabled",
           reason: "Server is disabled",
+        })
+      })
+
+      // Regression: VS Code extension writes "transport" instead of "type"
+      test("migrates server using 'transport' field (VS Code extension format)", async () => {
+        await using tmp = await tmpdir({
+          init: async (dir) => {
+            const settingsDir = path.join(dir, ".kilocode")
+            await Bun.write(
+              path.join(settingsDir, "mcp.json"),
+              JSON.stringify({
+                mcpServers: {
+                  "cipher-direct": {
+                    transport: "sse",
+                    url: "http://localhost:3000/api/mcp/sse",
+                  },
+                  "cipher-bridge": {
+                    transport: "sse",
+                    url: "http://localhost:3002/sse",
+                  },
+                },
+              }),
+            )
+          },
+        })
+
+        const result = await McpMigrator.migrate({
+          projectDir: tmp.path,
+          skipGlobalPaths: true,
+        })
+
+        expect(Object.keys(result.mcp)).toHaveLength(2)
+        expect(result.mcp["cipher-direct"]).toEqual({
+          type: "remote",
+          url: "http://localhost:3000/api/mcp/sse",
+        })
+        expect(result.mcp["cipher-bridge"]).toEqual({
+          type: "remote",
+          url: "http://localhost:3002/sse",
+        })
+      })
+
+      test("migrates mixed servers with 'type' and 'transport' fields", async () => {
+        await using tmp = await tmpdir({
+          init: async (dir) => {
+            const settingsDir = path.join(dir, ".kilo")
+            await Bun.write(
+              path.join(settingsDir, "mcp.json"),
+              JSON.stringify({
+                mcpServers: {
+                  filesystem: {
+                    command: "npx",
+                    args: ["-y", "@modelcontextprotocol/server-filesystem"],
+                  },
+                  "remote-api": {
+                    type: "streamable-http",
+                    url: "http://localhost:4321/mcp",
+                  },
+                  "sse-api": {
+                    transport: "sse",
+                    url: "https://mcp.example.com/sse",
+                  },
+                },
+              }),
+            )
+          },
+        })
+
+        const result = await McpMigrator.migrate({
+          projectDir: tmp.path,
+          skipGlobalPaths: true,
+        })
+
+        expect(Object.keys(result.mcp)).toHaveLength(3)
+        expect(result.mcp.filesystem).toEqual({
+          type: "local",
+          command: ["npx", "-y", "@modelcontextprotocol/server-filesystem"],
+        })
+        expect(result.mcp["remote-api"]).toEqual({
+          type: "remote",
+          url: "http://localhost:4321/mcp",
+        })
+        expect(result.mcp["sse-api"]).toEqual({
+          type: "remote",
+          url: "https://mcp.example.com/sse",
         })
       })
     })


### PR DESCRIPTION
## Problem

The VS Code extension writes MCP server configs with `transport` field (e.g., `"transport": "sse"`), but the CLI's `mcp-migrator.ts` only checks for the `type` field. This field name mismatch causes all SSE/HTTP transport servers to be silently skipped with:

```
WARN  service=kilocode.mcp-migrator name=cipher-direct local MCP server missing command, skipping
```

This means MCP servers configured via the VS Code extension UI are never loaded by the CLI.

## Root Cause

In `packages/opencode/src/kilocode/mcp-migrator.ts`:

```typescript
function isRemote(server: KilocodeMcpServer): boolean {
  return !!server.type && REMOTE_TYPES.has(server.type)
}
```

Only checks `server.type`, but the VS Code extension writes `server.transport`.

## Fix

- Added `getTransportType()` helper that checks both `type` and `transport` fields (with `type` taking precedence)
- Updated `isRemote()` to use `getTransportType()`
- Added `transport` field to `KilocodeMcpServer` interface
- Added 6 regression tests

## Config files affected

Any MCP config written by the VS Code extension UI uses `transport` instead of `type`, including:
- Global `mcp_settings.json`
- Project-level `.kilocode/mcp.json`