### PR TITLE
feat(vscode): add stop controls for running terminal parts

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -518,6 +518,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "abort":
           await this.handleAbort(message.sessionID)
           break
+        case "abortPart":
+          await this.handleAbortPart(message.sessionID, message.partID)
+          break
         case "revertSession":
           this.handleRevertSession(message.sessionID, message.messageID).catch((e) =>
             console.error("[Kilo New] handleRevertSession failed:", e),
@@ -2222,6 +2225,16 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       await this.client.session.abort({ sessionID: targetSessionID, directory: workspaceDir }, { throwOnError: true })
     } catch (error) {
       console.error("[Kilo New] KiloProvider: Failed to abort session:", error)
+    }
+  }
+
+  private async handleAbortPart(sessionID: string, partID: string): Promise<void> {
+    if (!this.client) return
+    try {
+      const workspaceDir = this.getWorkspaceDirectory(sessionID)
+      await this.client.session.abortPart({ sessionID, directory: workspaceDir, partID }, { throwOnError: true })
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to abort part:", error)
     }
   }
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -71,7 +71,7 @@ function TodoToolCard(props: { part: ToolPart }) {
 
 function canStop(part: ToolPart) {
   if (part.state?.status !== "running") return false
-  return part.tool === "bash" || part.tool === "task"
+  return part.tool === "bash"
 }
 
 export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
@@ -110,7 +110,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                       onClick={(e) => {
                         e.stopPropagation()
                         const item = part as ToolPart
-                        session.abortPart(item.sessionID, item.id)
+                        session.abortPart(item.sessionID, item.callID || item.id)
                       }}
                     />
                   </div>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -7,7 +7,8 @@
  * Active questions and permissions are rendered in the bottom dock.
  */
 
-import { Component, For, Show, createMemo } from "solid-js"
+import { For, Show, createMemo } from "solid-js"
+import type { Component } from "solid-js"
 import { Dynamic } from "solid-js/web"
 import { Part, PART_MAPPING, ToolRegistry } from "@kilocode/kilo-ui/message-part"
 import type {
@@ -17,6 +18,9 @@ import type {
   ToolPart,
 } from "@kilocode/sdk/v2"
 import { useData } from "@kilocode/kilo-ui/context/data"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
+import { useSession } from "../../context/session"
+import { useLanguage } from "../../context/language"
 
 // Tools that the upstream message-part renderer suppresses (returns null for).
 // We render these ourselves via ToolRegistry when they complete,
@@ -65,8 +69,15 @@ function TodoToolCard(props: { part: ToolPart }) {
   )
 }
 
+function canStop(part: ToolPart) {
+  if (part.state?.status !== "running") return false
+  return part.tool === "bash" || part.tool === "task"
+}
+
 export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
   const data = useData()
+  const session = useSession()
+  const language = useLanguage()
 
   const parts = createMemo(() => {
     const stored = data.store.part?.[props.message.id]
@@ -85,6 +96,25 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
           return (
             <Show when={isUpstreamSuppressed || PART_MAPPING[part.type]}>
               <div data-component="tool-part-wrapper" data-part-type={part.type}>
+                <Show
+                  when={
+                    part.type === "tool" && canStop(part as ToolPart) && part.sessionID === session.currentSessionID()
+                  }
+                >
+                  <div data-slot="tool-part-actions">
+                    <IconButton
+                      icon="circle-x"
+                      size="small"
+                      variant="ghost"
+                      aria-label={language.t("prompt.action.stopTool")}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        const item = part as ToolPart
+                        session.abortPart(item.sessionID, item.id)
+                      }}
+                    />
+                  </div>
+                </Show>
                 <Show
                   when={isUpstreamSuppressed}
                   fallback={

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -19,6 +19,11 @@ import { useSession } from "../../context/session"
 import { useVSCode } from "../../context/vscode"
 import type { ToolPart, Message as SDKMessage } from "@kilocode/sdk/v2"
 
+function canStop(item: ToolPart) {
+  if (item.state?.status !== "running") return false
+  return item.tool === "bash" || item.tool === "task"
+}
+
 /** Collect all tool parts from all assistant messages in a given session. */
 function getSessionToolParts(store: ReturnType<typeof useData>["store"], sessionId: string): ToolPart[] {
   const messages = (store.message?.[sessionId] as SDKMessage[] | undefined)?.filter((m) => m.role === "assistant")
@@ -127,6 +132,18 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
                     <span data-slot="task-tool-title">{info().title}</span>
                     <Show when={subtitle()}>
                       <span data-slot="task-tool-subtitle">{subtitle()}</span>
+                    </Show>
+                    <Show when={canStop(item)}>
+                      <IconButton
+                        icon="circle-x"
+                        size="small"
+                        variant="ghost"
+                        aria-label={i18n.t("prompt.action.stopSubtask")}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          session.abortPart(childSessionId() || "", item.id)
+                        }}
+                      />
                     </Show>
                   </div>
                 )

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -21,7 +21,7 @@ import type { ToolPart, Message as SDKMessage } from "@kilocode/sdk/v2"
 
 function canStop(item: ToolPart) {
   if (item.state?.status !== "running") return false
-  return item.tool === "bash" || item.tool === "task"
+  return item.tool === "bash"
 }
 
 /** Collect all tool parts from all assistant messages in a given session. */
@@ -141,7 +141,7 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
                         aria-label={i18n.t("prompt.action.stopSubtask")}
                         onClick={(e) => {
                           e.stopPropagation()
-                          session.abortPart(childSessionId() || "", item.id)
+                          session.abortPart(childSessionId() || "", item.callID || item.id)
                         }}
                       />
                     </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
@@ -6,6 +6,7 @@
 
 import { Component, Show, createSignal, createEffect, onCleanup } from "solid-js"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
+import { Button } from "@kilocode/kilo-ui/button"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 
@@ -80,6 +81,8 @@ export const WorkingIndicator: Component = () => {
     return perms.length > 0 || questions.length > 0
   }
 
+  const long = () => session.status() !== "idle" && elapsed() >= 15
+
   return (
     <Show when={session.status() !== "idle" && !blocked()}>
       <div class="working-indicator">
@@ -87,6 +90,16 @@ export const WorkingIndicator: Component = () => {
         <span class="working-text">{statusText()}</span>
         <Show when={elapsed() > 0}>
           <span class="working-elapsed">{formatElapsed()}</span>
+        </Show>
+        <Show when={long()}>
+          <div class="working-actions">
+            <Button size="small" variant="ghost" onClick={() => void 0}>
+              {language.t("migration.whatsNew.continue")}
+            </Button>
+            <Button size="small" variant="ghost" onClick={() => session.abort()}>
+              {language.t("prompt.action.stop")}
+            </Button>
+          </div>
         </Show>
       </div>
     </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
@@ -16,23 +16,38 @@ export const WorkingIndicator: Component = () => {
 
   const [elapsed, setElapsed] = createSignal(0)
   const [retryCountdown, setRetryCountdown] = createSignal(0)
+  const [continued, setContinued] = createSignal<Record<string, boolean>>({})
+
+  const mark = () => {
+    const id = session.currentSessionID()
+    if (!id) return
+    setContinued((map) => ({ ...map, [id]: true }))
+  }
 
   createEffect(() => {
     const since = session.busySince()
     const status = session.status()
+    const id = session.currentSessionID()
 
-    if (status === "idle" || !since) {
+    if (!id || status === "idle" || !since) {
+      if (id && continued()[id]) {
+        setContinued((map) => {
+          const next = { ...map }
+          delete next[id]
+          return next
+        })
+      }
       setElapsed(0)
       return
     }
 
     setElapsed(Math.floor((Date.now() - since) / 1000))
 
-    const id = setInterval(() => {
+    const timer = setInterval(() => {
       setElapsed(Math.floor((Date.now() - since) / 1000))
     }, 1000)
 
-    onCleanup(() => clearInterval(id))
+    onCleanup(() => clearInterval(timer))
   })
 
   createEffect(() => {
@@ -45,13 +60,13 @@ export const WorkingIndicator: Component = () => {
     const target = info.next
     setRetryCountdown(Math.max(0, Math.ceil((target - Date.now()) / 1000)))
 
-    const id = setInterval(() => {
+    const timer = setInterval(() => {
       const remaining = Math.max(0, Math.ceil((target - Date.now()) / 1000))
       setRetryCountdown(remaining)
-      if (remaining <= 0) clearInterval(id)
+      if (remaining <= 0) clearInterval(timer)
     }, 1000)
 
-    onCleanup(() => clearInterval(id))
+    onCleanup(() => clearInterval(timer))
   })
 
   const statusText = () => {
@@ -81,7 +96,11 @@ export const WorkingIndicator: Component = () => {
     return perms.length > 0 || questions.length > 0
   }
 
-  const long = () => session.status() !== "idle" && elapsed() >= 15
+  const long = () => {
+    const id = session.currentSessionID()
+    if (!id || continued()[id]) return false
+    return session.status() !== "idle" && elapsed() >= 15
+  }
 
   return (
     <Show when={session.status() !== "idle" && !blocked()}>
@@ -93,7 +112,7 @@ export const WorkingIndicator: Component = () => {
         </Show>
         <Show when={long()}>
           <div class="working-actions">
-            <Button size="small" variant="ghost" onClick={() => void 0}>
+            <Button size="small" variant="ghost" onClick={mark}>
               {language.t("migration.whatsNew.continue")}
             </Button>
             <Button size="small" variant="ghost" onClick={() => session.abort()}>

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -177,6 +177,7 @@ interface SessionContextValue {
   sendMessage: (text: string, providerID?: string, modelID?: string, files?: FileAttachment[]) => void
   sendCommand: (command: string, args: string, providerID?: string, modelID?: string, files?: FileAttachment[]) => void
   abort: () => void
+  abortPart: (sessionID: string, partID: string) => void
   compact: () => void
   respondToPermission: (
     permissionId: string,
@@ -1400,6 +1401,14 @@ export const SessionProvider: ParentComponent = (props) => {
     })
   }
 
+  function abortPart(sessionID: string, partID: string) {
+    vscode.postMessage({
+      type: "abortPart",
+      sessionID,
+      partID,
+    })
+  }
+
   function compact() {
     if (!server.isConnected()) {
       console.warn("[Kilo New] Cannot compact: not connected")
@@ -1763,6 +1772,7 @@ export const SessionProvider: ParentComponent = (props) => {
     sendMessage,
     sendCommand,
     abort,
+    abortPart,
     compact,
     respondToPermission,
     replyToQuestion,

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -241,6 +241,8 @@ export const dict = {
   "prompt.action.send": "إرسال",
   "prompt.action.send.blocked": "أجب عن السؤال المعلق أو تجاهله أولاً",
   "prompt.action.stop": "توقف",
+  "prompt.action.stopTool": "إيقاف الأداة",
+  "prompt.action.stopSubtask": "إيقاف المهمة الفرعية",
   "prompt.action.enhance": "تحسين النص",
   "prompt.action.resetModel": "إعادة تعيين النموذج إلى الافتراضي",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -242,6 +242,8 @@ export const dict = {
   "prompt.action.send": "Enviar",
   "prompt.action.send.blocked": "Responda ou feche a pergunta pendente primeiro",
   "prompt.action.stop": "Parar",
+  "prompt.action.stopTool": "Parar ferramenta",
+  "prompt.action.stopSubtask": "Parar subtarefa",
   "prompt.action.enhance": "Melhorar prompt",
   "prompt.action.resetModel": "Redefinir modelo para o padrão",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -243,6 +243,8 @@ export const dict = {
   "prompt.action.send": "Pošalji",
   "prompt.action.send.blocked": "Prvo odgovorite ili odbacite pitanje na čekanju",
   "prompt.action.stop": "Zaustavi",
+  "prompt.action.stopTool": "Zaustavi alat",
+  "prompt.action.stopSubtask": "Zaustavi podzadatak",
   "prompt.action.enhance": "Poboljšaj prompt",
   "prompt.action.resetModel": "Resetuj model na zadani",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -242,6 +242,8 @@ export const dict = {
   "prompt.action.send": "Send",
   "prompt.action.send.blocked": "Besvar eller afvis det afventende spørgsmål først",
   "prompt.action.stop": "Stop",
+  "prompt.action.stopTool": "Stop værktøj",
+  "prompt.action.stopSubtask": "Stop delopgave",
   "prompt.action.enhance": "Forbedr prompt",
   "prompt.action.resetModel": "Nulstil model til standard",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -246,6 +246,8 @@ export const dict = {
   "prompt.action.send": "Senden",
   "prompt.action.send.blocked": "Beantworten oder verwerfen Sie zuerst die ausstehende Frage",
   "prompt.action.stop": "Stopp",
+  "prompt.action.stopTool": "Tool stoppen",
+  "prompt.action.stopSubtask": "Teilaufgabe stoppen",
   "prompt.action.enhance": "Prompt verbessern",
   "prompt.action.resetModel": "Modell auf Standard zurücksetzen",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -243,6 +243,8 @@ export const dict = {
   "prompt.action.send": "Send",
   "prompt.action.send.blocked": "Answer or dismiss the pending question first",
   "prompt.action.stop": "Stop",
+  "prompt.action.stopTool": "Stop tool",
+  "prompt.action.stopSubtask": "Stop subtask",
   "prompt.action.enhance": "Enhance prompt",
   "prompt.action.resetModel": "Reset model to default",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -242,6 +242,8 @@ export const dict = {
   "prompt.action.send": "Enviar",
   "prompt.action.send.blocked": "Responda o descarte la pregunta pendiente primero",
   "prompt.action.stop": "Detener",
+  "prompt.action.stopTool": "Detener herramienta",
+  "prompt.action.stopSubtask": "Detener subtarea",
   "prompt.action.enhance": "Mejorar prompt",
   "prompt.action.resetModel": "Restablecer modelo al predeterminado",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -243,6 +243,8 @@ export const dict = {
   "prompt.action.send": "Envoyer",
   "prompt.action.send.blocked": "Répondez ou rejetez d'abord la question en attente",
   "prompt.action.stop": "Arrêter",
+  "prompt.action.stopTool": "Arrêter l'outil",
+  "prompt.action.stopSubtask": "Arrêter la sous-tâche",
   "prompt.action.enhance": "Améliorer le prompt",
   "prompt.action.resetModel": "Réinitialiser le modèle par défaut",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -241,6 +241,8 @@ export const dict = {
   "prompt.action.send": "送信",
   "prompt.action.send.blocked": "最初に保留中の質問に答えるか、閉じてください",
   "prompt.action.stop": "停止",
+  "prompt.action.stopTool": "ツールを停止",
+  "prompt.action.stopSubtask": "サブタスクを停止",
   "prompt.action.enhance": "プロンプトを改善",
   "prompt.action.resetModel": "モデルをデフォルトにリセット",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -245,6 +245,8 @@ export const dict = {
   "prompt.action.send": "전송",
   "prompt.action.send.blocked": "먼저 대기 중인 질문에 답하거나 닫아주세요",
   "prompt.action.stop": "중지",
+  "prompt.action.stopTool": "도구 중지",
+  "prompt.action.stopSubtask": "하위 작업 중지",
   "prompt.action.enhance": "프롬프트 개선",
   "prompt.action.resetModel": "모델을 기본값으로 재설정",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -243,6 +243,8 @@ export const dict = {
   "prompt.action.send": "Verzenden",
   "prompt.action.send.blocked": "Beantwoord of negeer eerst de openstaande vraag",
   "prompt.action.stop": "Stop",
+  "prompt.action.stopTool": "Tool stoppen",
+  "prompt.action.stopSubtask": "Subtaak stoppen",
   "prompt.action.enhance": "Prompt verbeteren",
   "prompt.action.resetModel": "Model terugzetten naar standaard",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -245,6 +245,8 @@ export const dict = {
   "prompt.action.send": "Send",
   "prompt.action.send.blocked": "Svar på eller avvis det ventende spørsmålet først",
   "prompt.action.stop": "Stopp",
+  "prompt.action.stopTool": "Stopp verktøy",
+  "prompt.action.stopSubtask": "Stopp deloppgave",
   "prompt.action.enhance": "Forbedre prompt",
   "prompt.action.resetModel": "Tilbakestill modell til standard",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -242,6 +242,8 @@ export const dict = {
   "prompt.action.send": "Wyślij",
   "prompt.action.send.blocked": "Najpierw odpowiedz na oczekujące pytanie lub je odrzuć",
   "prompt.action.stop": "Zatrzymaj",
+  "prompt.action.stopTool": "Zatrzymaj narzędzie",
+  "prompt.action.stopSubtask": "Zatrzymaj podzadanie",
   "prompt.action.enhance": "Ulepsz prompt",
   "prompt.action.resetModel": "Zresetuj model do domyślnego",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -242,6 +242,8 @@ export const dict = {
   "prompt.action.send": "Отправить",
   "prompt.action.send.blocked": "Сначала ответьте на ожидающий вопрос или отклоните его",
   "prompt.action.stop": "Остановить",
+  "prompt.action.stopTool": "Остановить инструмент",
+  "prompt.action.stopSubtask": "Остановить подзадачу",
   "prompt.action.enhance": "Улучшить промпт",
   "prompt.action.resetModel": "Сбросить модель на значение по умолчанию",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -242,6 +242,8 @@ export const dict = {
   "prompt.action.send": "ส่ง",
   "prompt.action.send.blocked": "โปรดตอบหรือข้ามคำถามที่รอดำเนินการก่อน",
   "prompt.action.stop": "หยุด",
+  "prompt.action.stopTool": "หยุดเครื่องมือ",
+  "prompt.action.stopSubtask": "หยุดงานย่อย",
   "prompt.action.enhance": "ปรับปรุงพรอมต์",
   "prompt.action.resetModel": "รีเซ็ตโมเดลเป็นค่าเริ่มต้น",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -242,6 +242,8 @@ export const dict = {
   "prompt.action.send": "Gönder",
   "prompt.action.send.blocked": "Bekleyen soruyu önce yanıtlayın veya kapatın",
   "prompt.action.stop": "Durdur",
+  "prompt.action.stopTool": "Aracı durdur",
+  "prompt.action.stopSubtask": "Alt görevi durdur",
   "prompt.action.enhance": "Komutu geliştir",
   "prompt.action.resetModel": "Modeli varsayılana sıfırla",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -242,6 +242,8 @@ export const dict = {
   "prompt.action.send": "发送",
   "prompt.action.send.blocked": "请先回答或忽略待处理的问题",
   "prompt.action.stop": "停止",
+  "prompt.action.stopTool": "停止工具",
+  "prompt.action.stopSubtask": "停止子任务",
   "prompt.action.enhance": "优化提示词",
   "prompt.action.resetModel": "重置模型为默认值",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -242,6 +242,8 @@ export const dict = {
   "prompt.action.send": "傳送",
   "prompt.action.send.blocked": "請先回答或忽略待處理的問題",
   "prompt.action.stop": "停止",
+  "prompt.action.stopTool": "停止工具",
+  "prompt.action.stopSubtask": "停止子任務",
   "prompt.action.enhance": "改善提示詞",
   "prompt.action.resetModel": "重置模型為預設值",
   "prompt.action.enhanceDescription":

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -2201,6 +2201,31 @@
   opacity: 0.7;
 }
 
+.working-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+[data-component="tool-part-wrapper"] {
+  position: relative;
+}
+
+[data-slot="tool-part-actions"] {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 1;
+}
+
+[data-slot="task-tool-item"] {
+  display: grid;
+  grid-template-columns: auto minmax(0, auto) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+}
+
 /* Session List (inside History View) */
 .session-list {
   display: flex;

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1371,6 +1371,12 @@ export interface AbortRequest {
   sessionID: string
 }
 
+export interface AbortPartRequest {
+  type: "abortPart"
+  sessionID: string
+  partID: string
+}
+
 export interface RevertSessionRequest {
   type: "revertSession"
   sessionID: string
@@ -2022,6 +2028,7 @@ export interface ContinueInWorktreeProgressMessage {
 export type WebviewMessage =
   | SendMessageRequest
   | AbortRequest
+  | AbortPartRequest
   | RevertSessionRequest
   | UnrevertSessionRequest
   | PermissionResponseRequest

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -381,6 +381,43 @@ export const SessionRoutes = lazy(() =>
       },
     )
     .post(
+      "/:sessionID/abort-part",
+      describeRoute({
+        summary: "Abort running part",
+        description: "Abort a specific running tool or shell part within an active session.",
+        operationId: "session.abortPart",
+        responses: {
+          200: {
+            description: "Aborted part",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string(),
+        }),
+      ),
+      validator(
+        "json",
+        z.object({
+          partID: z.string(),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        const result = await SessionPrompt.cancelPart({ sessionID, partID: body.partID })
+        return c.json(result)
+      },
+    )
+    .post(
       "/:sessionID/share",
       describeRoute({
         summary: "Share session",

--- a/packages/opencode/src/session/interrupt.ts
+++ b/packages/opencode/src/session/interrupt.ts
@@ -2,19 +2,18 @@
 export namespace SessionInterrupt {
   type Item = {
     sessionID: string
-    partID: string
-    callID?: string
+    id: string
     kill(): Promise<void>
   }
 
   const state = new Map<string, Item>()
 
   export async function register(input: Item) {
-    state.set(input.partID, input)
+    state.set(input.id, input)
   }
 
-  export async function unregister(partID: string) {
-    state.delete(partID)
+  export async function unregister(id: string) {
+    state.delete(id)
   }
 
   export async function cancel(input: { sessionID: string; partID: string }) {
@@ -22,15 +21,5 @@ export namespace SessionInterrupt {
     if (!item || item.sessionID !== input.sessionID) return false
     await item.kill()
     return true
-  }
-
-  export async function cancelCall(input: { sessionID: string; callID: string }) {
-    for (const item of state.values()) {
-      if (item.sessionID !== input.sessionID) continue
-      if (item.callID !== input.callID) continue
-      await item.kill()
-      return true
-    }
-    return false
   }
 }

--- a/packages/opencode/src/session/interrupt.ts
+++ b/packages/opencode/src/session/interrupt.ts
@@ -1,0 +1,36 @@
+// kilocode_change - new file
+export namespace SessionInterrupt {
+  type Item = {
+    sessionID: string
+    partID: string
+    callID?: string
+    kill(): Promise<void>
+  }
+
+  const state = new Map<string, Item>()
+
+  export async function register(input: Item) {
+    state.set(input.partID, input)
+  }
+
+  export async function unregister(partID: string) {
+    state.delete(partID)
+  }
+
+  export async function cancel(input: { sessionID: string; partID: string }) {
+    const item = state.get(input.partID)
+    if (!item || item.sessionID !== input.sessionID) return false
+    await item.kill()
+    return true
+  }
+
+  export async function cancelCall(input: { sessionID: string; callID: string }) {
+    for (const item of state.values()) {
+      if (item.sessionID !== input.sessionID) continue
+      if (item.callID !== input.callID) continue
+      await item.kill()
+      return true
+    }
+    return false
+  }
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -42,6 +42,7 @@ import { TaskTool } from "@/tool/task"
 import { Tool } from "@/tool/tool"
 import { PermissionNext } from "@/permission/next"
 import { SessionStatus } from "./status"
+import { SessionInterrupt } from "./interrupt"
 import { LLM } from "./llm"
 import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
@@ -291,6 +292,10 @@ export namespace SessionPrompt {
     delete s[sessionID]
     SessionStatus.set(sessionID, { type: "idle" })
     return
+  }
+
+  export async function cancelPart(input: { sessionID: string; partID: string }) {
+    return SessionInterrupt.cancel(input)
   }
 
   export const LoopInput = z.object({
@@ -1773,6 +1778,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
     const kill = () => Shell.killTree(proc, { exited: () => exited })
 
+    await SessionInterrupt.register({
+      sessionID: input.sessionID,
+      partID: part.id,
+      callID: part.callID,
+      kill,
+    })
+
     if (abort.aborted) {
       aborted = true
       await kill()
@@ -1789,6 +1801,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       proc.on("close", () => {
         exited = true
         abort.removeEventListener("abort", abortHandler)
+        void SessionInterrupt.unregister(part.id)
         resolve()
       })
     })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1780,8 +1780,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
     await SessionInterrupt.register({
       sessionID: input.sessionID,
-      partID: part.id,
-      callID: part.callID,
+      id: part.id,
       kill,
     })
 

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -224,8 +224,7 @@ export const BashTool = Tool.define("bash", async () => {
       if (ctx.callID) {
         await SessionInterrupt.register({
           sessionID: ctx.sessionID,
-          partID: ctx.callID,
-          callID: ctx.callID,
+          id: ctx.callID,
           kill,
         })
       }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -19,6 +19,7 @@ import { BashArity } from "@/permission/arity"
 import { BashHierarchy } from "@/kilocode/bash-hierarchy" // kilocode_change
 import { Truncate } from "./truncation"
 import { Plugin } from "@/plugin"
+import { SessionInterrupt } from "@/session/interrupt"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
@@ -220,6 +221,15 @@ export const BashTool = Tool.define("bash", async () => {
 
       const kill = () => Shell.killTree(proc, { exited: () => exited })
 
+      if (ctx.callID) {
+        await SessionInterrupt.register({
+          sessionID: ctx.sessionID,
+          partID: ctx.callID,
+          callID: ctx.callID,
+          kill,
+        })
+      }
+
       if (ctx.abort.aborted) {
         aborted = true
         await kill()
@@ -241,6 +251,9 @@ export const BashTool = Tool.define("bash", async () => {
         const cleanup = () => {
           clearTimeout(timeoutTimer)
           ctx.abort.removeEventListener("abort", abortHandler)
+          if (ctx.callID) {
+            void SessionInterrupt.unregister(ctx.callID)
+          }
         }
 
         // kilocode_change - use "close" instead of "exit" so stdio streams are fully drained

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -141,6 +141,8 @@ import type {
   RemoteEnableResponses,
   RemoteStatusResponses,
   SessionAbortErrors,
+  SessionAbortPartErrors,
+  SessionAbortPartResponses,
   SessionAbortResponses,
   SessionChildrenErrors,
   SessionChildrenResponses,
@@ -1781,6 +1783,45 @@ export class Session2 extends HeyApiClient {
       url: "/session/{sessionID}/abort",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * Abort running part
+   *
+   * Abort a specific running tool or shell part within an active session.
+   */
+  public abortPart<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      partID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "partID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionAbortPartResponses, SessionAbortPartErrors, ThrowOnError>({
+      url: "/session/{sessionID}/abort-part",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3269,6 +3269,42 @@ export type SessionAbortResponses = {
 
 export type SessionAbortResponse = SessionAbortResponses[keyof SessionAbortResponses]
 
+export type SessionAbortPartData = {
+  body?: {
+    partID: string
+  }
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/abort-part"
+}
+
+export type SessionAbortPartErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionAbortPartError = SessionAbortPartErrors[keyof SessionAbortPartErrors]
+
+export type SessionAbortPartResponses = {
+  /**
+   * Aborted part
+   */
+  200: boolean
+}
+
+export type SessionAbortPartResponse = SessionAbortPartResponses[keyof SessionAbortPartResponses]
+
 export type SessionUnshareData = {
   body?: never
   path: {


### PR DESCRIPTION
## Context

Restore the long-running terminal controls in the VS Code chat UI and add per-part stop actions so users can cancel individual running bash tools or subtasks without aborting the entire session.

## Implementation

- add backend session interrupt tracking for running bash and shell parts, plus a new `session.abortPart` API route
- expose the new abort-part action through the regenerated SDK and the VS Code extension bridge
- add stop buttons for running top-level tool parts and task child parts, restore the long-running action bar, and localize the new stop labels across webview locales

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

- Start a VS Code session that triggers a long-running `bash` tool call
- Wait at least 15 seconds and confirm the working indicator shows `Continue` and `Stop`
- Click `Stop` and confirm the whole session aborts
- Start another session that runs multiple tool parts or a subtask with a running bash command
- Click the per-tool or per-subtask stop icon and confirm only that running part stops while the rest of the session remains available
- Verify the stop buttons have localized labels in the webview UI
- Run `bun turbo typecheck`

## Get in Touch

Discord: thomas07374