### PR TITLE
fix(vscode): enable scrolling in local session history list

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -2200,6 +2200,14 @@
   opacity: 0.7;
 }
 
+/* Session List (inside History View) */
+.session-list {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 /* Session List Items */
 .session-list [data-slot="list-item-title"],
 .cloud-session-list [data-slot="list-item-title"] {


### PR DESCRIPTION
## Context

The local session history list in the VS Code extension's HistoryView could not be scrolled. When users navigated to the History panel and had more sessions than fit on screen, the list was stuck — scrolling had no effect.

Closes #7856
Closes #7002

## Implementation

The `.session-list` wrapper div was missing CSS flex properties needed to constrain its height within the parent flex layout. Without `flex: 1` and `min-height: 0`, the list sized to its content height rather than being clipped by the flex container. Since the inner `[data-slot="list-scroll"]` element (which has `overflow-y: auto`) never overflowed, scrolling was impossible.

The cloud session list (`.cloud-session-list`) already had the correct properties:

```
.cloud-session-list {
  display: flex;
  flex-direction: column;
  flex: 1;
  min-height: 0;
}
```

The fix adds the equivalent block for `.session-list` in `chat.css`.

Layout chain:

```
.history-view             → flex column, height: 100%
  .history-view-header    → flex-shrink: 0
  .history-view-content   → flex: 1, min-height: 0
    .session-list         → flex: 1, min-height: 0  ← was missing
      [data-component="list"]   → overflow: hidden
        [data-slot="list-scroll"] → overflow-y: auto  ← now scrolls
```

## Screenshots

Before:

https://github.com/user-attachments/assets/4aed296c-d7d3-4fee-b542-64c2ee44cedb

After:

https://github.com/user-attachments/assets/4e1234c0-ad21-4aa7-845f-f2889eda6cff

## How to Test

1. Open the VS Code extension
2. Create enough sessions (10+) to overflow the sidebar height
3. Click the history button to open the HistoryView
4. Verify the Local tab session list scrolls

## Get in Touch

My discord is `@iamcoder18` and I am in the Kilo Code discord server.