### PR TITLE
feat(ui): add copy button to assistant text responses

### DIFF
--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -8,7 +8,7 @@
   }
 
   [data-slot="text-part-copy-wrapper"] {
-    display: flex;
+    display: flex; justify-content: flex-end;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.15s ease;

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -8,16 +8,26 @@
   }
 
   [data-slot="text-part-copy-wrapper"] {
-    display: none;
-  }
-
-  [data-slot="text-part-copy-wrapper"][data-is-turn-copy] {
     display: flex;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
 
     [data-component="icon-button"] {
       width: 20px;
       height: 20px;
     }
+  }
+
+  &:hover [data-slot="text-part-copy-wrapper"],
+  &:focus-within [data-slot="text-part-copy-wrapper"] {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  [data-slot="text-part-copy-wrapper"][data-is-turn-copy] {
+    opacity: 1;
+    pointer-events: auto;
   }
 }
 

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1152,7 +1152,9 @@ PART_MAPPING["compaction"] = function CompactionPartDisplay() {
 
 PART_MAPPING["text"] = function TextPartDisplay(props) {
   const data = useData()
+  const i18n = useI18n()
   const part = () => props.part as TextPart
+  const [copied, setCopied] = createSignal(false)
 
   const displayText = () => (part().text ?? "").trim()
   const throttledText = createThrottledValue(displayText)
@@ -1162,6 +1164,27 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
     if (props.showAssistantCopyPartID !== part().id) return
     return props.turnDiffSummary
   })
+
+  const isLastTextPart = createMemo(() => {
+    const last = (data.store.part?.[props.message.id] ?? [])
+      .filter((item): item is TextPart => item?.type === "text" && !!item.text?.trim())
+      .at(-1)
+    return last?.id === part().id
+  })
+  const showCopy = createMemo(() => {
+    if (props.message.role !== "assistant") return isLastTextPart()
+    if (props.showAssistantCopyPartID === null) return false
+    if (typeof props.showAssistantCopyPartID === "string") return props.showAssistantCopyPartID === part().id
+    return isLastTextPart()
+  })
+
+  const handleCopy = async () => {
+    const content = displayText()
+    if (!content) return
+    await navigator.clipboard.writeText(content)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
 
   const handleMarkdownClick = (e: MouseEvent) => {
     if (!data.openFile) return
@@ -1196,6 +1219,25 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
       <div data-component="text-part">
         <div data-slot="text-part-body">
           <Markdown text={throttledText()} cacheKey={part().id} onClick={handleMarkdownClick} />
+        </div>
+        <div data-slot="text-part-copy-wrapper" data-is-turn-copy={showCopy() ? "" : undefined}>
+          <Tooltip
+            value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+            placement="top"
+            gutter={4}
+          >
+            <IconButton
+              icon={copied() ? "check" : "copy"}
+              size="normal"
+              variant="ghost"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={(event) => {
+                event.stopPropagation()
+                handleCopy()
+              }}
+              aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+            />
+          </Tooltip>
         </div>
         <Show when={summary()}>
           {(render) => (


### PR DESCRIPTION
## Context

Assistant text responses in the chat UI have no copy button. User messages, code blocks inside markdown, and bash tool output all have copy buttons — but assistant text parts don't. This adds one.

Closes #7870 

## Implementation

The rendering chain `ChatView → MessageList → VscodeSessionTurn → AssistantMessage → Part → TextPartDisplay` is shared across the sidebar, Agent Manager, and subagent viewer, so a single change in the shared `TextPartDisplay` component covers all three surfaces.

Most of the infrastructure was already in place:

- The CSS had a `[data-slot="text-part-copy-wrapper"]` selector with `display: none` — pre-wired but never connected
- i18n keys `ui.message.copyResponse` and `ui.message.copied` already translated in 16+ languages
- All imports (`Tooltip`, `IconButton`, `createSignal`, `useI18n`) already in the file
- `showAssistantCopyPartID` prop already plumbed through the component chain
- The same copy-button pattern used 4 other times in the same file

**CSS** (`message-part.css`): Changed the wrapper from `display: none` to `display: flex` with `opacity: 0; pointer-events: none` and a `0.15s` opacity transition. Hover over the parent `[data-component="text-part"]` reveals the button. When `data-is-turn-copy` is set (active/last text part), the button is always visible.

**TSX** (`message-part.tsx`): Added to `TextPartDisplay` — `useI18n()` call, `copied` signal, `isLastTextPart` memo (finds last text part in message), `showCopy` memo (uses `showAssistantCopyPartID` prop or falls back to `isLastTextPart`), `handleCopy` handler with 2s check icon toggle, and a `<Tooltip>` + `<IconButton>` block inside a `<div data-slot="text-part-copy-wrapper">`.

Zero new imports, zero new i18n keys, zero new CSS selectors, zero new props.

## Screenshots

### Before (no copy button):

<img width="1920" height="1080" alt="ShareX_pmdAMxWE2P" src="https://github.com/user-attachments/assets/a37782e3-0e3c-477e-b029-58520eb29aa3" />

### After:

https://github.com/user-attachments/assets/f29df8cf-9d20-4c71-8239-d6057451d13d



## How to Test

1. Open the Kilo sidebar chat
2. Send a message that generates an assistant response with multiple text parts
3. Hover over any assistant text part — a copy button should appear in the bottom-right
4. Click the copy button — it should briefly show a check icon and copy the text to clipboard
5. The last/active text part's copy button should be always visible (not just on hover)
6. Test in the Agent Manager panel — the same copy button should appear there too

## Get in Touch

My discord is `@iamcoder18` and I am in the Kilo Code discord server.