### PR TITLE
fix: prevent Enter from sending message during IME composition

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -482,7 +482,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       session.abort()
       return
     }
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
       e.preventDefault()
       handleSend()
     }

--- a/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
@@ -132,6 +132,7 @@ export function useFileMention(vscode: VSCodeContext): FileMention {
     onSelect?: () => void,
   ): boolean => {
     if (!showMention()) return false
+    if (e.isComposing) return false
 
     if (e.key === "ArrowDown") {
       e.preventDefault()

--- a/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
@@ -183,6 +183,7 @@ export function useSlashCommand(vscode: VSCodeContext, exclude?: Set<string>): S
     onSelect?: () => void,
   ): boolean => {
     if (!show()) return false
+    if (e.isComposing) return false
 
     const filtered = results()
 


### PR DESCRIPTION
## Summary

  - Check `e.isComposing` in `PromptInput` keydown handler to skip send during IME composition
  - Return early from `useSlashCommand` and `useFileMention` keydown handlers when `e.isComposing` is true

  ## Root Cause

  When using CJK input methods (Chinese, Japanese, Korean), pressing Enter to confirm a candidate word fires a
  `keydown` event with the same `key: 'Enter'` as a regular submit. Without checking `e.isComposing`, the
  message was sent prematurely.

  ## Test Plan

  - [ ] Enable a CJK IME (e.g. Chinese Pinyin or Japanese)
  - [ ] Type a message in the chat input
  - [ ] Press Enter to select an IME candidate — message should NOT be sent
  - [ ] Press Enter again (no composition) — message should be sent normally

  Fixes #7659