### PR TITLE
fix(vscode): abort retry loop when model is changed in chat selector

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -361,6 +361,11 @@ export const SessionProvider: ParentComponent = (props) => {
 
   function selectModel(providerID: string, modelID: string) {
     applyModel(selectedAgentName(), { providerID, modelID })
+    // If the session is stuck in a retry loop (e.g. hit a free-model cap),
+    // abort it so the user can re-send with the newly selected model.
+    if (status() === "retry") {
+      abort()
+    }
   }
 
   /** The config/default model for the current mode (what settings says). */


### PR DESCRIPTION
## Summary

- When a free model hits its rate/usage cap the CLI enters a retry loop; the chat model selector did not cancel it, leaving the session stuck.
- `selectModel()` in `session.tsx` now calls `abort()` when the current session status is `"retry"`, immediately cancelling the backoff sleep so the user can re-send with the new model.
- Changing the model via the Settings panel already worked as a workaround; this fix makes the in-chat selector behave the same way.

Closes #7781
Supersedes #7782