### PR TITLE
fix(ui): open Exa search result links via openUrl in VS Code webview

### DIFF
--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -669,6 +669,15 @@ function isContextGroupTool(part: PartType): part is ToolPart {
 
 function ExaOutput(props: { output?: string }) {
   const links = createMemo(() => urls(props.output))
+  const data = useData()
+
+  const open = (url: string, event: MouseEvent) => {
+    event.stopPropagation()
+    event.preventDefault()
+    const handler = data.openUrl
+    if (handler) return handler(url)
+    window.open(url, "_blank", "noopener,noreferrer")
+  }
 
   return (
     <Show when={links().length > 0}>
@@ -676,13 +685,7 @@ function ExaOutput(props: { output?: string }) {
         <div data-slot="exa-tool-links">
           <For each={links()}>
             {(url) => (
-              <a
-                data-slot="exa-tool-link"
-                href={url}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(event) => event.stopPropagation()}
-              >
+              <a data-slot="exa-tool-link" href={url} target="_blank" rel="noopener noreferrer" onClick={[open, url]}>
                 {url}
               </a>
             )}


### PR DESCRIPTION
## Summary

- Exa search result links now correctly open in the system browser from VS Code webview.

## Problem

VS Code webviews intercept all `<a target="_blank">` navigation. The `ExaOutput` component only called `event.stopPropagation()` on link clicks, which isn't sufficient — links silently failed to open.

## Fix

Applied the same `openUrl` pattern already used by `WebfetchMeta`: added `useData()` and an `open` handler that calls `data.openUrl` when available (routing through `vscode.env.openExternal`), falling back to `window.open` for non-VS Code contexts.

Related to #7709.
