### PR TITLE
fix(cli,vscode): cancel retry/backoff loop on abort and show stop button during retries

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -42,7 +42,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
 
   const id = () => session.currentSessionID()
   const hasMessages = () => session.messages().length > 0
-  const idle = () => session.status() !== "busy"
+  const idle = () => session.status() === "idle"
 
   // "Continue in Worktree" state
   const [transferring, setTransferring] = createSignal(false)
@@ -79,7 +79,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   onMount(() => {
     if (props.readonly) return
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && session.status() === "busy" && !e.defaultPrevented) {
+      if (e.key === "Escape" && session.status() !== "idle" && !e.defaultPrevented) {
         e.preventDefault()
         session.abort()
       }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -216,7 +216,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   // Compact/summarize the current session (mirrors canCompact guards in TaskHeader)
   const onCompact = () => {
-    if (session.status() === "busy") return
+    if (session.status() !== "idle") return
     if (session.messages().length === 0) return
     if (!session.selected()) return
     session.compact()
@@ -224,7 +224,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   window.addEventListener("compactSession", onCompact)
   onCleanup(() => window.removeEventListener("compactSession", onCompact))
 
-  const isBusy = () => session.status() === "busy"
+  const isBusy = () => session.status() === "busy" || session.status() === "retry"
   const isDisabled = () => !server.isConnected()
   const hasInput = () => text().trim().length > 0 || imageAttach.images().length > 0 || reviewComments().length > 0
   const canSend = () => hasInput() && !isDisabled() && !props.blocked?.()

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -402,6 +402,9 @@ export namespace SessionProcessor {
                   next: Date.now() + delay,
                 })
                 await SessionRetry.sleep(delay, input.abort).catch(() => {})
+                // kilocode_change start - break out of retry loop when aborted (e.g. stop button or model change)
+                if (input.abort.aborted) break
+                // kilocode_change end
                 continue
               }
               input.assistantMessage.error = error


### PR DESCRIPTION
## Summary

Fixes #7768 — When a rate limit retry loop is active, the user was stuck with no way to cancel or stop it. The Stop button and Escape key did not work during the retry/backoff state, and changing the model via the chat selector was ignored.

### Root Causes

1. **`processor.ts`**: After `SessionRetry.sleep()` was aborted (via the abort signal from pressing Stop), `.catch(() => {})` silently swallowed the `AbortError` and `continue` restarted the retry loop — the abort signal was never checked between retry attempts.

2. **`PromptInput.tsx`**: The `isBusy()` helper only checked for `status === "busy"`, but during retry the status is `"retry"`. This meant the Stop button was hidden and Escape didn't trigger abort during retries.

3. **`ChatView.tsx`**: The Escape key handler only fired when `status === "busy"`, missing the `"retry"` state entirely. Additionally, `idle()` was defined as `status !== "busy"`, which incorrectly treated the `"retry"` state as idle (showing the "new task" button during retries).

### Changes

- **`packages/opencode/src/session/processor.ts`**: After the retry sleep resolves (or is aborted), check `input.abort.aborted` and `break` out of the retry loop. This ensures the Stop button and model changes properly cancel the retry cycle.
- **`packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx`**: Update `isBusy()` to include `"retry"` status, so the Stop button is visible and Escape works during retries. Also fix the compact guard to block during retry.
- **`packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx`**: Fix Escape handler to work for any non-idle status. Fix `idle()` to correctly identify only the `"idle"` state.

Supersedes #7776