### PR TITLE
fix(cli): use path.join for tilde/$HOME expansion on Windows

### DIFF
--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -11,16 +11,17 @@ import { Wildcard } from "@/util/wildcard"
 import { drainCovered } from "@/kilocode/permission/drain" // kilocode_change
 import { ConfigProtection } from "@/kilocode/permission/config-paths" // kilocode_change
 import os from "os"
+import path from "path"
 import z from "zod"
 
 export namespace PermissionNext {
   const log = Log.create({ service: "permission" })
 
   function expand(pattern: string): string {
-    if (pattern.startsWith("~/")) return os.homedir() + pattern.slice(1)
+    if (pattern.startsWith("~/")) return path.join(os.homedir(), pattern.slice(2))
     if (pattern === "~") return os.homedir()
-    if (pattern.startsWith("$HOME/")) return os.homedir() + pattern.slice(5)
-    if (pattern.startsWith("$HOME")) return os.homedir() + pattern.slice(5)
+    if (pattern.startsWith("$HOME/")) return path.join(os.homedir(), pattern.slice(6))
+    if (pattern.startsWith("$HOME")) return path.join(os.homedir(), pattern.slice(5))
     return pattern
   }
 


### PR DESCRIPTION
## Summary

- Fix Windows path construction bug in `expand()` function where `os.homedir() + pattern.slice(1)` produced broken paths missing the separator before dot-directories (e.g. `C:\Users\user1.config\kilo\...` instead of `C:\Users\user1\.config\kilo\...`)
- Replace string concatenation with `path.join()` and adjust slice indices to skip the `~/` and `$HOME/` prefixes correctly
- Consistent with every other tilde expansion in the codebase (prompt.ts, instruction.ts, paths.ts, skill.ts) which all use `path.join()`

## Root Cause

The `expand()` function in `packages/opencode/src/permission/next.ts` used string concatenation to build paths:

```ts
// Before (broken on Windows)
if (pattern.startsWith("~/")) return os.homedir() + pattern.slice(1)
//   os.homedir() = "C:\Users\user1"
//   pattern.slice(1) = "/.config/kilo/*"
//   result: "C:\Users\user1/.config/kilo/*"
//   After normalization: "C:\Users\user1.config\kilo\*" ← missing separator!
```

```ts
// After (correct on all platforms)
if (pattern.startsWith("~/")) return path.join(os.homedir(), pattern.slice(2))
//   result: "C:\Users\user1\.config\kilo\*" ✓
```

The same issue applied to the `$HOME/` and bare `$HOME` expansion branches.

Fixes #7784
Supersedes #7785


## Before

## After
<img width="1038" height="542" alt="image" src="https://github.com/user-attachments/assets/e47576a3-684c-40e0-a440-e23f2ad6a282" />
