### PR TITLE
fix(vscode): fix Traditional Chinese locale detection for both auto-detect and manual selection

### DIFF
--- a/packages/kilo-vscode/src/services/cli-backend/i18n/index.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/i18n/index.ts
@@ -42,6 +42,7 @@ const bundles: Record<string, Record<string, string>> = {
 function resolveLocale(lang: string): string {
   const lower = lang.toLowerCase()
   if (lower.startsWith("zh")) {
+    if (lower === "zht") return "zht"
     const traditional =
       lower.includes("hant") || lower.includes("-tw") || lower.includes("-hk") || lower.includes("-mo")
     return traditional ? "zht" : "zh"

--- a/packages/kilo-vscode/src/services/cli-backend/i18n/index.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/i18n/index.ts
@@ -41,7 +41,11 @@ const bundles: Record<string, Record<string, string>> = {
 
 function resolveLocale(lang: string): string {
   const lower = lang.toLowerCase()
-  if (lower.startsWith("zh")) return lower.includes("hant") ? "zht" : "zh"
+  if (lower.startsWith("zh")) {
+    const traditional =
+      lower.includes("hant") || lower.includes("-tw") || lower.includes("-hk") || lower.includes("-mo")
+    return traditional ? "zht" : "zh"
+  }
   if (lower.startsWith("nb") || lower.startsWith("nn")) return "no"
   if (lower.startsWith("pt")) return "br"
   for (const key of Object.keys(bundles)) {

--- a/packages/kilo-vscode/tests/unit/language-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/language-utils.test.ts
@@ -15,6 +15,7 @@ describe("normalizeLocale", () => {
   })
 
   it("returns 'zht' for Traditional Chinese", () => {
+    expect(normalizeLocale("zht")).toBe("zht")
     expect(normalizeLocale("zh-Hant")).toBe("zht")
     expect(normalizeLocale("zh-TW")).toBe("zht")
     expect(normalizeLocale("zh-HK")).toBe("zht")

--- a/packages/kilo-vscode/tests/unit/language-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/language-utils.test.ts
@@ -16,7 +16,9 @@ describe("normalizeLocale", () => {
 
   it("returns 'zht' for Traditional Chinese", () => {
     expect(normalizeLocale("zh-Hant")).toBe("zht")
-    expect(normalizeLocale("zh-TW")).toBe("zh")
+    expect(normalizeLocale("zh-TW")).toBe("zht")
+    expect(normalizeLocale("zh-HK")).toBe("zht")
+    expect(normalizeLocale("zh-MO")).toBe("zht")
     expect(normalizeLocale("zh-hant-TW")).toBe("zht")
   })
 

--- a/packages/kilo-vscode/webview-ui/src/context/language-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/language-utils.ts
@@ -46,6 +46,7 @@ export const LOCALES: readonly Locale[] = [
 export function normalizeLocale(lang: string): Locale {
   const lower = lang.toLowerCase()
   if (lower.startsWith("zh")) {
+    if (lower === "zht") return "zht"
     const traditional =
       lower.includes("hant") || lower.includes("-tw") || lower.includes("-hk") || lower.includes("-mo")
     return traditional ? "zht" : "zh"

--- a/packages/kilo-vscode/webview-ui/src/context/language-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/language-utils.ts
@@ -46,7 +46,9 @@ export const LOCALES: readonly Locale[] = [
 export function normalizeLocale(lang: string): Locale {
   const lower = lang.toLowerCase()
   if (lower.startsWith("zh")) {
-    return lower.includes("hant") ? "zht" : "zh"
+    const traditional =
+      lower.includes("hant") || lower.includes("-tw") || lower.includes("-hk") || lower.includes("-mo")
+    return traditional ? "zht" : "zh"
   }
   for (const loc of LOCALES) {
     if (lower.startsWith(loc)) {


### PR DESCRIPTION
## Summary

Fixes #7914 — Traditional Chinese (繁體中文) was incorrectly falling back to Simplified Chinese in two distinct scenarios.

## Root Causes

### 1. Auto-detect: region-based BCP 47 tags not recognized

`normalizeLocale` (webview) and `resolveLocale` (extension host) both used `lower.includes("hant")` as the sole indicator of Traditional Chinese. However, VS Code reports `zh-tw` when the user selects "Chinese (Traditional)" as their display language — this uses a **region code**, not the explicit `Hant` script subtag.

The three affected region-based Traditional Chinese locales:
- `zh-TW` — Taiwan (what VS Code uses)
- `zh-HK` — Hong Kong
- `zh-MO` — Macau

### 2. Manual selection: bare `"zht"` misclassified as Simplified

When a user explicitly selected Traditional Chinese from the settings dropdown, the bare string `"zht"` was passed through `normalizeLocale`. Since `"zht".startsWith("zh")` is true, it entered the Chinese branch but matched none of the BCP 47 traditional markers (`hant`, `-tw`, `-hk`, `-mo`), incorrectly returning `"zh"` (Simplified).

## Changes

- `webview-ui/src/context/language-utils.ts`: extend `normalizeLocale` to handle the bare `"zht"` input and return `"zht"` for `-tw`, `-hk`, and `-mo` subtags in addition to `hant`
- `src/services/cli-backend/i18n/index.ts`: same fixes in `resolveLocale` (extension-host side)
- `tests/unit/language-utils.test.ts`: correct the wrong assertion (`zh-TW` → `"zh"` → `"zht"`), add coverage for `zh-HK`, `zh-MO`, and the bare `"zht"` input
