### PR TITLE
fix(vscode): chat autocomplete ignores disabled setting

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -144,6 +144,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private unsubscribeLanguageChange: (() => void) | null = null
   private unsubscribeProfileChange: (() => void) | null = null
   private unsubscribeMigrationComplete: (() => void) | null = null // legacy-migration
+  private unsubscribeAutocompleteConfig: (() => void) | null = null
   private initConnectionPromise: Promise<void> | null = null
   private webviewMessageDisposable: vscode.Disposable | null = null
 
@@ -948,6 +949,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.unsubscribeNotificationDismiss?.()
     this.unsubscribeLanguageChange?.()
     this.unsubscribeProfileChange?.()
+    this.unsubscribeAutocompleteConfig?.()
 
     try {
       const workspaceDir = this.getWorkspaceDirectory()
@@ -1018,6 +1020,15 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.unsubscribeProfileChange = this.connectionService.onProfileChanged((data) => {
         this.postMessage({ type: "profileData", data })
       })
+
+      // Push updated autocomplete settings to the webview whenever VS Code config changes
+      // (e.g. via VS Code settings UI or another provider's updateAutocompleteSetting).
+      const configDisposable = vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration("kilo-code.new.autocomplete")) {
+          this.sendAutocompleteSettings()
+        }
+      })
+      this.unsubscribeAutocompleteConfig = () => configDisposable.dispose()
 
       // legacy-migration start
       // Subscribe to migration-complete broadcast from any KiloProvider instance
@@ -2853,6 +2864,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.unsubscribeLanguageChange?.()
     this.unsubscribeProfileChange?.()
     this.unsubscribeMigrationComplete?.()
+    this.unsubscribeAutocompleteConfig?.()
     this.webviewMessageDisposable?.dispose()
     this.trackedSessionIds.clear()
     this.syncedChildSessions.clear()

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -329,15 +329,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.statsPoller?.setEnabled(webviewView.visible)
     })
 
-    // Push updated autocomplete settings to the webview whenever VS Code config changes.
-    // Registered here (not inside doInitializeConnection) so it works even when disconnected.
-    this.unsubscribeAutocompleteConfig?.()
-    const configDisposable = vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("kilo-code.new.autocomplete")) {
-        this.sendAutocompleteSettings()
-      }
-    })
-    this.unsubscribeAutocompleteConfig = () => configDisposable.dispose()
+    // Register autocomplete config listener here (not inside doInitializeConnection) so it
+    // works even when the provider is disconnected or in an error state.
+    this.registerAutocompleteConfigListener()
 
     // Initialize connection to CLI backend
     this.initializeConnection()
@@ -361,15 +355,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // Handle messages from webview (shared handler)
     this.setupWebviewMessageHandler(panel.webview)
 
-    // Push updated autocomplete settings to the webview whenever VS Code config changes.
-    // Registered here (not inside doInitializeConnection) so it works even when disconnected.
-    this.unsubscribeAutocompleteConfig?.()
-    const configDisposable = vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("kilo-code.new.autocomplete")) {
-        this.sendAutocompleteSettings()
-      }
-    })
-    this.unsubscribeAutocompleteConfig = () => configDisposable.dispose()
+    // Register autocomplete config listener here (not inside doInitializeConnection) so it
+    // works even when the provider is disconnected or in an error state.
+    this.registerAutocompleteConfigListener()
 
     this.initializeConnection()
   }
@@ -453,6 +441,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.webview = webview
     this.onBeforeMessage = options?.onBeforeMessage ?? null
     this.setupWebviewMessageHandler(webview)
+
+    // Register autocomplete config listener here (not inside doInitializeConnection) so it
+    // works even when the provider is disconnected or in an error state.
+    this.registerAutocompleteConfigListener()
+
     this.initializeConnection()
   }
 
@@ -2585,6 +2578,21 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       }
       this.postMessage(msg)
     }
+  }
+
+  /**
+   * Register a VS Code config-change listener that pushes autocomplete settings to the webview
+   * whenever the `kilo-code.new.autocomplete` section changes. Safe to call multiple times —
+   * any previous listener is disposed first.
+   */
+  private registerAutocompleteConfigListener(): void {
+    this.unsubscribeAutocompleteConfig?.()
+    const disposable = vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("kilo-code.new.autocomplete")) {
+        this.sendAutocompleteSettings()
+      }
+    })
+    this.unsubscribeAutocompleteConfig = () => disposable.dispose()
   }
 
   /**

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -329,6 +329,16 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.statsPoller?.setEnabled(webviewView.visible)
     })
 
+    // Push updated autocomplete settings to the webview whenever VS Code config changes.
+    // Registered here (not inside doInitializeConnection) so it works even when disconnected.
+    this.unsubscribeAutocompleteConfig?.()
+    const configDisposable = vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("kilo-code.new.autocomplete")) {
+        this.sendAutocompleteSettings()
+      }
+    })
+    this.unsubscribeAutocompleteConfig = () => configDisposable.dispose()
+
     // Initialize connection to CLI backend
     this.initializeConnection()
   }
@@ -350,6 +360,16 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     // Handle messages from webview (shared handler)
     this.setupWebviewMessageHandler(panel.webview)
+
+    // Push updated autocomplete settings to the webview whenever VS Code config changes.
+    // Registered here (not inside doInitializeConnection) so it works even when disconnected.
+    this.unsubscribeAutocompleteConfig?.()
+    const configDisposable = vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("kilo-code.new.autocomplete")) {
+        this.sendAutocompleteSettings()
+      }
+    })
+    this.unsubscribeAutocompleteConfig = () => configDisposable.dispose()
 
     this.initializeConnection()
   }
@@ -949,7 +969,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.unsubscribeNotificationDismiss?.()
     this.unsubscribeLanguageChange?.()
     this.unsubscribeProfileChange?.()
-    this.unsubscribeAutocompleteConfig?.()
 
     try {
       const workspaceDir = this.getWorkspaceDirectory()
@@ -1020,15 +1039,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.unsubscribeProfileChange = this.connectionService.onProfileChanged((data) => {
         this.postMessage({ type: "profileData", data })
       })
-
-      // Push updated autocomplete settings to the webview whenever VS Code config changes
-      // (e.g. via VS Code settings UI or another provider's updateAutocompleteSetting).
-      const configDisposable = vscode.workspace.onDidChangeConfiguration((e) => {
-        if (e.affectsConfiguration("kilo-code.new.autocomplete")) {
-          this.sendAutocompleteSettings()
-        }
-      })
-      this.unsubscribeAutocompleteConfig = () => configDisposable.dispose()
 
       // legacy-migration start
       // Subscribe to migration-complete broadcast from any KiloProvider instance

--- a/packages/kilo-vscode/src/services/autocomplete/AutocompleteServiceManager.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/AutocompleteServiceManager.ts
@@ -25,7 +25,7 @@ function readSettings(): AutocompleteServiceSettings {
   return {
     enableAutoTrigger: config.get<boolean>("enableAutoTrigger") ?? true,
     enableSmartInlineTaskKeybinding: config.get<boolean>("enableSmartInlineTaskKeybinding") ?? true,
-    enableChatAutocomplete: config.get<boolean>("enableChatAutocomplete") ?? true,
+    enableChatAutocomplete: config.get<boolean>("enableChatAutocomplete") ?? false,
     snoozeUntil: config.get<number>("snoozeUntil"),
   }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `KiloProvider` had no `onDidChangeConfiguration` listener for `kilo-code.new.autocomplete`, so when the user toggled `enableChatAutocomplete` off in the settings panel (or via VS Code settings UI), the webview was never notified and the `useGhostText` hook retained the old `enabled = true` state.
- **Fix**: Add a `vscode.workspace.onDidChangeConfiguration` subscription in `resolveWebviewView()` and `resolveWebviewPanel()` that calls `sendAutocompleteSettings()` whenever the autocomplete config section changes. Registering it here (rather than inside `doInitializeConnection`) ensures the listener is active even when the provider is disconnected or in an error state.
- **Secondary fix**: Corrected the `readSettings()` fallback for `enableChatAutocomplete` from `?? true` to `?? false` to match the `package.json` declared default.

Fixes #7758

Supersedes #7916