### PR TITLE
fix(vscode): fix health check permanently killing SSE connection

### DIFF
--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -282,7 +282,7 @@ export class KiloConnectionService {
       const healthy = await this.checkHealth(baseUrl, password)
       if (!healthy && this.state === "connected") {
         console.warn("[Kilo New] ConnectionService: ❤️‍🩹 Health check failed — forcing SSE reconnect")
-        this.sseClient?.disconnect()
+        this.sseClient?.reconnect()
       }
     }, HEALTH_POLL_INTERVAL_MS)
 

--- a/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
@@ -32,6 +32,7 @@ export class SdkSSEAdapter {
   private readonly stateHandlers = new Set<SSEStateHandler>()
 
   private abortController: AbortController | null = null
+  private attemptController: AbortController | null = null
   private heartbeatTimer: ReturnType<typeof setTimeout> | null = null
 
   // 15s matches packages/app/src/context/global-sdk.tsx — server sends heartbeats
@@ -71,7 +72,22 @@ export class SdkSSEAdapter {
     console.log("[Kilo New] SSE: 🔌 disconnect() called")
     this.abortController?.abort()
     this.abortController = null
+    this.attemptController = null
     this.clearHeartbeat()
+  }
+
+  /**
+   * Force the current SSE attempt to reconnect without killing the outer loop.
+   * Aborts only the per-attempt controller so `consumeLoop` re-enters its
+   * reconnection path instead of terminating permanently.
+   */
+  reconnect(): void {
+    if (!this.attemptController) {
+      console.log("[Kilo New] SSE: ⚠️ reconnect() called but no active attempt")
+      return
+    }
+    console.log("[Kilo New] SSE: 🔄 reconnect() — aborting current attempt")
+    this.attemptController.abort()
   }
 
   /**
@@ -121,6 +137,8 @@ export class SdkSSEAdapter {
       const onAbort = () => attempt.abort()
       signal.addEventListener("abort", onAbort)
 
+      this.attemptController = attempt
+
       try {
         console.log("[Kilo New] SSE: 🎬 Calling SDK global.event()...")
         const events = await this.client.global.event({
@@ -159,6 +177,7 @@ export class SdkSSEAdapter {
         }
       } finally {
         signal.removeEventListener("abort", onAbort)
+        this.attemptController = null
         this.clearHeartbeat()
       }
 


### PR DESCRIPTION
## Summary

Fixes a critical bug where a single transient health check failure permanently kills the SSE connection, making the entire extension non-functional (no session loading, no session continuation, no new sessions).

## Problem

The health poll in `KiloConnectionService` runs every 10 seconds. When the `/global/health` endpoint fails (e.g. server momentarily busy, network hiccup, or the 3-second timeout is exceeded), it calls `sseClient.disconnect()`.

`SdkSSEAdapter.disconnect()` aborts the **outer** `AbortController` — the one that controls the `while (!signal.aborted)` reconnection loop in `consumeLoop()`. This causes the loop to exit permanently. The SSE connection dies and is never re-established.

**Observed symptoms:**
- Sessions appear in the "Recent" list and Agent Manager tabs (loaded from cached state / initial fetch before the health check fires)
- Clicking any session does nothing — the webview logs `"Cannot select session: not connected"` repeatedly
- The sidebar shows the welcome screen instead of session content
- Agent Manager tabs show but sessions cannot be loaded
- No recovery without restarting VS Code

**Root cause sequence from actual user logs:**
```
ConnectionService:  Health check failed — forcing SSE reconnect
SSE:  disconnect() called          ← kills the outer loop permanently
SSE:  Stream ended normally
Connection state changed: disconnected
Cannot select session: not connected  ← every subsequent click fails
```

## Fix

The `consumeLoop` already has a two-level abort architecture:
- **Outer signal** (`this.abortController`): permanent shutdown via `disconnect()`
- **Per-attempt controller**: transient reconnect — used by heartbeat timeout, which correctly triggers reconnection

The health poll was using the wrong level. Added a `reconnect()` method to `SdkSSEAdapter` that aborts only the per-attempt controller, letting the outer `while` loop continue its reconnection cycle. Changed the health poll to call `reconnect()` instead of `disconnect()`.

## Changes

- **`sdk-sse-adapter.ts`**: Track `attemptController` as instance field; add `reconnect()` method that aborts only the current attempt
- **`connection-service.ts`**: Health poll calls `reconnect()` instead of `disconnect()`