### PR TITLE
perf(cli): cache MCP listTools results to avoid redundant RPCs per loop step

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -121,6 +121,7 @@ export namespace MCP {
   function registerNotificationHandlers(client: MCPClient, serverName: string) {
     client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
       log.info("tools list changed notification received", { server: serverName })
+      ;(await state()).toolsCache.delete(serverName) // kilocode_change
       Bus.publish(ToolsChanged, { server: serverName })
     })
   }
@@ -224,6 +225,7 @@ export namespace MCP {
       return {
         status,
         clients,
+        toolsCache: new Map<string, MCPToolDef[]>(), // kilocode_change — per-server listTools cache
       }
     },
     async (state) => {
@@ -302,6 +304,7 @@ export namespace MCP {
 
   export async function add(name: string, mcp: Config.Mcp) {
     const s = await state()
+    s.toolsCache.delete(name) // kilocode_change
     const result = await create(name, mcp)
     if (!result) {
       const status = {
@@ -559,6 +562,7 @@ export namespace MCP {
   }
 
   export async function connect(name: string) {
+    ;(await state()).toolsCache.delete(name) // kilocode_change
     const cfg = await Config.get()
     const config = cfg.mcp ?? {}
     const mcp = config[name]
@@ -599,6 +603,7 @@ export namespace MCP {
 
   export async function disconnect(name: string) {
     const s = await state()
+    s.toolsCache.delete(name) // kilocode_change
     const client = s.clients[name]
     if (client) {
       await client.close().catch((error) => {
@@ -623,6 +628,12 @@ export namespace MCP {
 
     const toolsResults = await Promise.all(
       connectedClients.map(async ([clientName, client]) => {
+        // kilocode_change start — use cached listTools when available
+        const cached = s.toolsCache.get(clientName)
+        if (cached) {
+          return { clientName, client, toolsResult: { tools: cached } }
+        }
+        // kilocode_change end
         const toolsResult = await client.listTools().catch((e) => {
           log.error("failed to get tools", { clientName, error: e.message })
           const failedStatus = {
@@ -633,6 +644,7 @@ export namespace MCP {
           delete s.clients[clientName]
           return undefined
         })
+        if (toolsResult) s.toolsCache.set(clientName, toolsResult.tools) // kilocode_change
         return { clientName, client, toolsResult }
       }),
     )


### PR DESCRIPTION
## Summary
- Cache MCP `listTools()` results per server so they aren't re-fetched on every agent loop iteration
- Previously, every step in the agent loop called `client.listTools()` for all connected MCP servers — adding 300-750ms overhead per step for remote servers (e.g. Vercel MCP)
- Cache is invalidated on `ToolListChangedNotification`, server add/connect/disconnect, and instance dispose (config change/project switch)

This optimization is most likely missing on the upstream. Because of the impact (but small blast radius) I suggest we fix it here directly.

## Measured impact (3 MCP servers)

Profiled in the extension:

| Metric | Before | After |
|--------|--------|-------|
| `MCP.tools()` per step (cached) | 285-745ms | 0-1ms |
| 8-step conversation MCP overhead | ~5.5s | ~4.2s once + ~0ms thereafter |