### PR TITLE
fix(agent-manager): persist non-worktree sessions to agent-manager.json

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -184,18 +184,13 @@ export class AgentManagerProvider implements Disposable {
       this.host.refreshGit()
     }
 
-    // Do not auto-remove stale worktrees on load.
-    // Presence checks run in the shared poller and require explicit user cleanup.
-
-    // Register all worktree sessions with the session provider
-    for (const worktree of state.getWorktrees()) {
-      for (const session of state.getSessions(worktree.id)) {
-        this.panel?.sessions.setSessionDirectory(session.id, worktree.path)
-        this.panel?.sessions.trackSession(session.id)
+    for (const wt of state.getWorktrees()) {
+      for (const s of state.getSessions(wt.id)) {
+        this.panel?.sessions.setSessionDirectory(s.id, wt.path)
+        this.panel?.sessions.trackSession(s.id)
       }
     }
-
-    // Push full state to webview
+    for (const s of state.getSessions()) if (!s.worktreeId) this.panel?.sessions.trackSession(s.id)
     this.pushState()
 
     // Refresh sessions so worktree sessions appear in the list
@@ -218,8 +213,12 @@ export class AgentManagerProvider implements Disposable {
     if (m.type === "agentManager.removeStaleWorktree") return this.onRemoveStaleWorktree(m.worktreeId)
     if (m.type === "agentManager.promoteSession") return this.onPromoteSession(m.sessionId)
     if (m.type === "agentManager.openLocally") {
-      if (!this.panel) return null
-      this.panel.sessions.clearSessionDirectory(m.sessionId)
+      this.panel?.sessions.clearSessionDirectory(m.sessionId)
+      const st = this.getStateManager()
+      if (st?.getSession(m.sessionId)) {
+        st.moveSession(m.sessionId, null)
+        this.pushState()
+      }
       return null
     }
     if (m.type === "continueInWorktree") {
@@ -231,6 +230,15 @@ export class AgentManagerProvider implements Disposable {
     if (m.type === "agentManager.addSessionToWorktree") return this.onAddSessionToWorktree(m.worktreeId)
     if (m.type === "agentManager.forkSession") return this.onForkSession(m.sessionId, m.worktreeId)
     if (m.type === "agentManager.closeSession") return this.onCloseSession(m.sessionId)
+    if (m.type === "agentManager.persistSession" || m.type === "agentManager.forgetSession") {
+      const persist = m.type === "agentManager.persistSession"
+      void this.stateReady?.then(() => {
+        const st = this.getStateManager()
+        if (st)
+          persist ? !st.getSession(m.sessionId) && st.addSession(m.sessionId, null) : st.removeSession(m.sessionId)
+      })
+      return null
+    }
     if ((m.type === "sendMessage" || m.type === "sendCommand") && m.draftID && !m.sessionID) {
       this.activeSessionId = m.draftID
     }

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -204,12 +204,12 @@ export class WorktreeStateManager {
     return session
   }
 
-  /** Move an existing session to a worktree (promotion). */
-  moveSession(sessionId: string, worktreeId: string): void {
+  /** Move an existing session to a worktree (or back to local when null). */
+  moveSession(sessionId: string, worktreeId: string | null): void {
     const session = this.sessions.get(sessionId)
     if (!session) return
     session.worktreeId = worktreeId
-    this.log(`Moved session ${sessionId} to worktree ${worktreeId}`)
+    this.log(`Moved session ${sessionId} to ${worktreeId ?? "local"}`)
     void this.save()
   }
 

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -244,6 +244,18 @@ interface CloseSessionIn {
   sessionId: string
 }
 
+/** Persist a non-worktree session to agent-manager.json (worktreeId = null). */
+interface PersistSessionIn {
+  type: "agentManager.persistSession"
+  sessionId: string
+}
+
+/** Remove a non-worktree session from agent-manager.json. */
+interface ForgetSessionIn {
+  type: "agentManager.forgetSession"
+  sessionId: string
+}
+
 interface ConfigureSetupScriptIn {
   type: "agentManager.configureSetupScript"
 }
@@ -462,6 +474,8 @@ export type AgentManagerInMessage =
   | OpenLocallyIn
   | AddSessionToWorktreeIn
   | CloseSessionIn
+  | PersistSessionIn
+  | ForgetSessionIn
   | ForkSessionIn
   | ConfigureSetupScriptIn
   | ShowTerminalIn

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -177,6 +177,8 @@ describe("Agent Manager Provider — onMessage routing", () => {
       "agentManager.addSessionToWorktree",
       "agentManager.forkSession",
       "agentManager.closeSession",
+      "agentManager.persistSession",
+      "agentManager.forgetSession",
       "agentManager.configureSetupScript",
       "agentManager.showTerminal",
       "agentManager.showLocalTerminal",

--- a/packages/kilo-vscode/tests/unit/navigate.test.ts
+++ b/packages/kilo-vscode/tests/unit/navigate.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "bun:test"
-import { resolveNavigation, validateLocalSession, adjacentHint, LOCAL } from "../../webview-ui/agent-manager/navigate"
+import {
+  resolveNavigation,
+  validateLocalSession,
+  adjacentHint,
+  restoreLocalSessions,
+  LOCAL,
+} from "../../webview-ui/agent-manager/navigate"
 
 const ids = ["a", "b", "c", "d"]
 
@@ -178,5 +184,101 @@ describe("adjacentHint", () => {
   it("works with single-item list", () => {
     expect(adjacentHint("a", "b", ["a", "b"], "prev", "next")).toBe("prev")
     expect(adjacentHint("b", "a", ["a", "b"], "prev", "next")).toBe("next")
+  })
+})
+
+describe("restoreLocalSessions", () => {
+  const identity = (items: { id: string }[], _order: string[]) => items
+  const isPending = (id: string) => id.startsWith("pending-")
+
+  // Simulates applyTabOrder: reorders items to match the order array
+  const reorder = (items: { id: string }[], order: string[]) => {
+    const lookup = new Map(items.map((item) => [item.id, item]))
+    const result: { id: string }[] = []
+    for (const id of order) {
+      const item = lookup.get(id)
+      if (item) {
+        result.push(item)
+        lookup.delete(id)
+      }
+    }
+    for (const item of lookup.values()) result.push(item)
+    return result
+  }
+
+  it("restores local sessions when current list is empty", () => {
+    const sessions = [
+      { id: "s1", worktreeId: null },
+      { id: "s2", worktreeId: null },
+    ]
+    const result = restoreLocalSessions(sessions, [], undefined, isPending, identity)
+    expect(result).toEqual(["s1", "s2"])
+  })
+
+  it("skips worktree-bound sessions", () => {
+    const sessions = [
+      { id: "s1", worktreeId: "wt-1" },
+      { id: "s2", worktreeId: null },
+      { id: "s3", worktreeId: "wt-2" },
+    ]
+    const result = restoreLocalSessions(sessions, [], undefined, isPending, identity)
+    expect(result).toEqual(["s2"])
+  })
+
+  it("applies tab order on restore", () => {
+    const sessions = [
+      { id: "s1", worktreeId: null },
+      { id: "s2", worktreeId: null },
+      { id: "s3", worktreeId: null },
+    ]
+    const result = restoreLocalSessions(sessions, [], ["s3", "s1", "s2"], isPending, reorder)
+    expect(result).toEqual(["s3", "s1", "s2"])
+  })
+
+  it("does not overwrite existing real sessions", () => {
+    const sessions = [
+      { id: "s1", worktreeId: null },
+      { id: "s2", worktreeId: null },
+    ]
+    // Current already has real sessions — don't replace
+    const result = restoreLocalSessions(sessions, ["s1", "s2"], undefined, isPending, identity)
+    expect(result).toBeUndefined()
+  })
+
+  it("does restore when current only has pending tabs", () => {
+    const sessions = [
+      { id: "s1", worktreeId: null },
+      { id: "s2", worktreeId: null },
+    ]
+    const result = restoreLocalSessions(sessions, ["pending-1"], undefined, isPending, identity)
+    expect(result).toEqual(["s1", "s2"])
+  })
+
+  it("returns undefined when no local sessions and no tab order", () => {
+    const sessions = [{ id: "s1", worktreeId: "wt-1" }]
+    const result = restoreLocalSessions(sessions, [], undefined, isPending, identity)
+    expect(result).toBeUndefined()
+  })
+
+  it("applies tab order to existing sessions", () => {
+    const sessions = [{ id: "s1", worktreeId: null }]
+    const result = restoreLocalSessions(sessions, ["s2", "s1"], ["s1", "s2"], isPending, reorder)
+    expect(result).toEqual(["s1", "s2"])
+  })
+
+  it("merges disk session missing from stale webview state", () => {
+    const sessions = [
+      { id: "s1", worktreeId: null },
+      { id: "s2", worktreeId: null },
+      { id: "s3", worktreeId: null },
+    ]
+    // webview state is stale: has s1, s2 but not s3 (debounce didn't fire)
+    const result = restoreLocalSessions(sessions, ["s1", "s2"], undefined, isPending, identity)
+    expect(result).toEqual(["s1", "s2", "s3"])
+  })
+
+  it("returns undefined when no disk sessions and no tab order", () => {
+    const result = restoreLocalSessions([], [], undefined, isPending, identity)
+    expect(result).toBeUndefined()
   })
 })

--- a/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
@@ -95,6 +95,15 @@ describe("WorktreeStateManager", () => {
       expect(manager.getSession("s1")?.worktreeId).toBe(wt2.id)
     })
 
+    it("moves session back to local (null worktreeId)", () => {
+      const wt = manager.addWorktree({ branch: "a", path: "/tmp/a", parentBranch: "main" })
+      manager.addSession("s1", wt.id)
+      expect(manager.getSession("s1")?.worktreeId).toBe(wt.id)
+
+      manager.moveSession("s1", null)
+      expect(manager.getSession("s1")?.worktreeId).toBeNull()
+    })
+
     it("moveSession is a no-op for nonexistent session", () => {
       manager.moveSession("nonexistent", "wt-1")
       expect(manager.getSessions()).toHaveLength(0)

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -80,7 +80,7 @@ import { NewWorktreeDialog } from "./NewWorktreeDialog"
 import { LanguageBridge, DataBridge } from "../src/App"
 import { useLanguage } from "../src/context/language"
 import { formatRelativeDate } from "../src/utils/date"
-import { validateLocalSession, nextSelectionAfterDelete, adjacentHint, LOCAL } from "./navigate"
+import { validateLocalSession, nextSelectionAfterDelete, adjacentHint, restoreLocalSessions, LOCAL } from "./navigate"
 import { reorderTabs, applyTabOrder, firstOrderedTitle } from "./tab-order"
 import { ConstrainDragYAxis, SortableReviewTab, SortableTab } from "./sortable-tab"
 import { DiffPanel } from "./DiffPanel"
@@ -649,8 +649,13 @@ const AgentManagerContent: Component = () => {
     const all = session.sessions()
     if (all.length === 0) return // sessions not loaded yet
     const ids = all.map((s) => s.id)
-    const valid = localSessionIDs().filter((lid) => isPending(lid) || validateLocalSession(lid, ids))
-    if (valid.length !== localSessionIDs().length) {
+    const prev = localSessionIDs()
+    const valid = prev.filter((lid) => isPending(lid) || validateLocalSession(lid, ids))
+    if (valid.length !== prev.length) {
+      const removed = prev.filter((lid) => !isPending(lid) && !valid.includes(lid))
+      for (const id of removed) {
+        vscode.postMessage({ type: "agentManager.forgetSession", sessionId: id })
+      }
       setLocalSessionIDs(valid)
     }
   })
@@ -1101,6 +1106,7 @@ const AgentManagerContent: Component = () => {
         setLocalSessionIDs((prev) => [...prev, created.session.id])
         setSelection(LOCAL)
       }
+      vscode.postMessage({ type: "agentManager.persistSession", sessionId: created.session.id })
       session.selectSession(created.session.id)
     })
 
@@ -1175,6 +1181,7 @@ const AgentManagerContent: Component = () => {
             if (idx >= 0) return [...prev.slice(0, idx + 1), ev.sessionId, ...prev.slice(idx + 1)]
             return [...prev, ev.sessionId]
           })
+          vscode.postMessage({ type: "agentManager.persistSession", sessionId: ev.sessionId })
         }
         session.selectSession(ev.sessionId)
       }
@@ -1205,15 +1212,15 @@ const AgentManagerContent: Component = () => {
           const ms = state.sessions.find((s) => s.id === current)
           if (ms?.worktreeId) setSelection(ms.worktreeId)
         }
-        // Recover local tab order from persisted state
-        const localOrder = state.tabOrder?.[LOCAL]
-        if (localOrder && localSessionIDs().length > 0) {
-          const reordered = applyTabOrder(
-            localSessionIDs().map((id) => ({ id })),
-            localOrder,
-          ).map((item) => item.id)
-          setLocalSessionIDs(reordered)
-        }
+        // Restore local session IDs from persisted state (sessions with no worktreeId)
+        const restored = restoreLocalSessions(
+          state.sessions,
+          localSessionIDs(),
+          state.tabOrder?.[LOCAL],
+          isPending,
+          applyTabOrder,
+        )
+        if (restored) setLocalSessionIDs(restored)
         // Recover sessions collapsed state from extension-persisted state
         if (state.sessionsCollapsed !== undefined) setSessionsCollapsed(state.sessionsCollapsed)
         // Clear busy state for worktrees that have been removed
@@ -1851,6 +1858,9 @@ const AgentManagerContent: Component = () => {
     }
     if (pending || localSet().has(sessionId)) {
       setLocalSessionIDs((prev) => prev.filter((id) => id !== sessionId))
+      if (!pending) {
+        vscode.postMessage({ type: "agentManager.forgetSession", sessionId })
+      }
     } else {
       vscode.postMessage({ type: "agentManager.closeSession", sessionId })
     }

--- a/packages/kilo-vscode/webview-ui/agent-manager/navigate.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/navigate.ts
@@ -75,6 +75,54 @@ export function adjacentHint(
 }
 
 /**
+ * Compute which session IDs should populate the "local" tab on state restore.
+ *
+ * Managed sessions with `worktreeId === null` are non-worktree sessions that
+ * were persisted to agent-manager.json.  On restore we use them as the local
+ * tab list, optionally applying a persisted tab order.
+ *
+ * @param sessions   - All managed sessions from agent-manager.json
+ * @param current    - The webview's current localSessionIDs (may contain pending tabs)
+ * @param tabOrder   - Persisted tab order for the "local" key, if any
+ * @param isPending  - Predicate to identify pending (not-yet-created) tab IDs
+ * @param applyOrder - Reorder helper: (items, order) → ordered items
+ */
+export function restoreLocalSessions(
+  sessions: { id: string; worktreeId: string | null }[],
+  current: string[],
+  tabOrder: string[] | undefined,
+  isPending: (id: string) => boolean,
+  applyOrder: (items: { id: string }[], order: string[]) => { id: string }[],
+): string[] | undefined {
+  const locals = sessions.filter((s) => !s.worktreeId).map((s) => s.id)
+  const real = current.filter((id) => !isPending(id))
+
+  // First restore: current has no real sessions but disk has some
+  if (locals.length > 0 && real.length === 0) {
+    if (!tabOrder) return locals
+    return applyOrder(
+      locals.map((id) => ({ id })),
+      tabOrder,
+    ).map((item) => item.id)
+  }
+
+  // Merge any disk-persisted sessions missing from current (e.g. vscode.setState
+  // debounce didn't fire before close, but persistSession already wrote to disk)
+  const missing = locals.filter((id) => !current.includes(id))
+  const merged = missing.length > 0 ? [...current, ...missing] : current
+
+  // Apply tab order if present
+  if (tabOrder && merged.length > 0) {
+    return applyOrder(
+      merged.map((id) => ({ id })),
+      tabOrder,
+    ).map((item) => item.id)
+  }
+
+  return missing.length > 0 ? merged : undefined
+}
+
+/**
  * After removing a worktree, pick the nearest remaining sidebar neighbor.
  * Order: the worktree just below → the one above → LOCAL.
  */

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1795,6 +1795,18 @@ export interface CloseSessionRequest {
   sessionId: string
 }
 
+/** Persist a non-worktree session to agent-manager.json (worktreeId = null). */
+export interface PersistSessionRequest {
+  type: "agentManager.persistSession"
+  sessionId: string
+}
+
+/** Remove a non-worktree session from agent-manager.json. */
+export interface ForgetSessionRequest {
+  type: "agentManager.forgetSession"
+  sessionId: string
+}
+
 // Rename a worktree's display label
 export interface RenameWorktreeRequest {
   type: "agentManager.renameWorktree"
@@ -2168,6 +2180,8 @@ export type WebviewMessage =
   | AddSessionToWorktreeRequest
   | ForkSessionRequest
   | CloseSessionRequest
+  | PersistSessionRequest
+  | ForgetSessionRequest
   | RenameWorktreeRequest
   | TelemetryRequest
   | RequestRepoInfoMessage


### PR DESCRIPTION
## Summary

- Non-worktree sessions (Local tab) were only stored in `vscode.setState()` — lost when the panel tab was closed or VS Code restarted
- Now persisted to `agent-manager.json` as `ManagedSession` entries with `worktreeId: null`
- Restored on startup via `initializeState` + `restoreLocalSessions()`

## Changes

- **`persistSession` / `forgetSession` messages** — webview notifies extension when a non-worktree session is created or closed
- **`openLocally` handler** — now calls `moveSession(id, null)` so the session stays persisted when moved from a worktree to local
- **`moveSession` signature** — accepts `string | null` to support moving sessions back to local
- **`restoreLocalSessions()` helper** — pure function extracted into `navigate.ts` with 8 unit tests covering restore, tab order, pending tabs, no-op cases
- **`initializeState`** — registers non-worktree sessions with the session provider so the CLI backend loads their data

Closes #7801