### PR TITLE
fix(vscode): prevent spinner from disappearing during webview recreation

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -281,7 +281,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       // Seed session status map so the Settings panel knows about already-running sessions.
       // Must run after webview is ready (postMessage is a no-op before that).
-      void this.seedSessionStatusMap()
+      // Only reconcile (reset missing busy→idle) when the map is empty, i.e.
+      // on the very first seed before any real-time SSE events have arrived.
+      // On SSE reconnects or webview recreations the live SSE data is
+      // authoritative and reconciliation risks race-resetting busy sessions.
+      const reconcile = this.sessionStatusMap.size === 0
+      void this.seedSessionStatusMap(reconcile)
     }
 
     // legacy-migration start
@@ -1825,11 +1830,15 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * Seed sessionStatusMap with current session statuses on connect.
    * Without this, the Settings panel (which has no tracked sessions) would see
    * busyCount() = 0 for sessions that were already running before it opened.
+   *
+   * @param reconcile When true, reset locally-busy sessions absent from the
+   *   server response to idle (crash recovery). Set to false on SSE reconnects
+   *   to avoid a race where a brief HTTP fetch gap causes the spinner to vanish.
    */
-  private async seedSessionStatusMap(): Promise<void> {
+  private async seedSessionStatusMap(reconcile = true): Promise<void> {
     if (!this.client || this.connectionState !== "connected") return
     const dir = this.getWorkspaceDirectory()
-    await seedSessionStatuses(this.client, dir, this.sessionStatusMap, (msg) => this.postMessage(msg))
+    await seedSessionStatuses(this.client, dir, this.sessionStatusMap, (msg) => this.postMessage(msg), reconcile)
   }
 
   /**

--- a/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
@@ -143,8 +143,18 @@ export class SdkSSEAdapter {
         console.log("[Kilo New] SSE: 🎬 Calling SDK global.event()...")
         const events = await this.client.global.event({
           signal: attempt.signal,
+          // Disable SDK-internal retries — consumeLoop handles reconnection
+          // with its own outer while-loop. Without this the SDK's infinite
+          // retry loop with exponential backoff runs in parallel, causing
+          // duplicate connections and "error" state flicker.
+          sseMaxRetryAttempts: 1,
           onSseError: (error) => {
             if (signal.aborted) {
+              return
+            }
+            // Filter AbortErrors — they are expected during heartbeat timeout
+            // or manual reconnect() calls, not real connection failures.
+            if (error instanceof DOMException && error.name === "AbortError") {
               return
             }
             console.error("[Kilo New] SSE: ❌ SDK SSE error callback:", error)
@@ -171,7 +181,10 @@ export class SdkSSEAdapter {
 
         console.log("[Kilo New] SSE: 📭 Stream ended normally")
       } catch (error) {
-        if (!signal.aborted) {
+        // Suppress AbortErrors — they are expected when the heartbeat timer
+        // or reconnect() aborts the per-attempt controller.
+        const aborted = signal.aborted || (error instanceof DOMException && error.name === "AbortError")
+        if (!aborted) {
           console.error("[Kilo New] SSE: ❌ Stream error:", error)
           this.notifyError(error instanceof Error ? error : new Error(String(error)))
         }

--- a/packages/kilo-vscode/src/session-status.ts
+++ b/packages/kilo-vscode/src/session-status.ts
@@ -16,12 +16,18 @@ export function getBusySessionCount(map: Map<string, SessionStatus["type"]>): nu
  * Fetch all current session statuses and seed the provided map + webview.
  * Called on connect so the Settings panel knows about already-running sessions
  * without waiting for the next session.status SSE event.
+ *
+ * When `reconcile` is true (default: first seed), locally-busy sessions absent
+ * from the server response are reset to idle — covering server crash/restart.
+ * On SSE reconnects set `reconcile: false` to avoid a race where the HTTP
+ * fetch briefly returns stale data and the spinner disappears mid-stream.
  */
 export async function seedSessionStatuses(
   client: KiloClient,
   dir: string,
   map: Map<string, SessionStatus["type"]>,
   post: (msg: unknown) => void,
+  reconcile = true,
 ): Promise<void> {
   try {
     const result = await client.session.status({ directory: dir })
@@ -41,10 +47,14 @@ export async function seedSessionStatuses(
 
     // Reconcile: any locally non-idle session absent from the server response
     // means the server lost its in-memory state (crash/restart). Reset to idle.
-    for (const [sid, status] of map) {
-      if (status !== "idle" && !active[sid]) {
-        map.set(sid, "idle")
-        post({ type: "sessionStatus", sessionID: sid, status: "idle" })
+    // Skipped on SSE reconnects — the real-time SSE events are authoritative
+    // for status transitions and the brief HTTP fetch can race with them.
+    if (reconcile) {
+      for (const [sid, status] of map) {
+        if (status !== "idle" && !active[sid]) {
+          map.set(sid, "idle")
+          post({ type: "sessionStatus", sessionID: sid, status: "idle" })
+        }
       }
     }
   } catch (error) {

--- a/packages/kilo-vscode/tests/unit/session-status.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-status.test.ts
@@ -147,6 +147,54 @@ describe("seedSessionStatuses", () => {
     expect(map.get("s1")).toBe("busy")
     expect(msgs).toEqual([])
   })
+
+  // ---- reconcile=false (SSE reconnect) ----
+
+  it("skips reconciliation when reconcile=false", async () => {
+    const client = createClient({ data: {} })
+    const map = new Map<string, SessionStatus["type"]>([["s1", "busy"]])
+    const { msgs, post } = collect()
+
+    await seedSessionStatuses(client, "/repo", map, post, false)
+
+    // Session stays busy — reconciliation skipped on SSE reconnect
+    expect(map.get("s1")).toBe("busy")
+    expect(msgs).toEqual([])
+  })
+
+  it("still seeds server entries when reconcile=false", async () => {
+    const client = createClient({
+      data: { s1: { type: "busy" }, s2: { type: "retry", attempt: 1, message: "err", next: 1000 } },
+    })
+    const map = new Map<string, SessionStatus["type"]>()
+    const { msgs, post } = collect()
+
+    await seedSessionStatuses(client, "/repo", map, post, false)
+
+    expect(map.get("s1")).toBe("busy")
+    expect(map.get("s2")).toBe("retry")
+    expect(msgs).toEqual([
+      { type: "sessionStatus", sessionID: "s1", status: "busy" },
+      { type: "sessionStatus", sessionID: "s2", status: "retry", attempt: 1, message: "err", next: 1000 },
+    ])
+  })
+
+  it("does not reset stale entries when reconcile=false but updates confirmed ones", async () => {
+    const client = createClient({ data: { confirmed: { type: "busy" } } })
+    const map = new Map<string, SessionStatus["type"]>([
+      ["stale", "busy"],
+      ["confirmed", "retry"],
+    ])
+    const { msgs, post } = collect()
+
+    await seedSessionStatuses(client, "/repo", map, post, false)
+
+    // stale: stays busy (no reconciliation)
+    expect(map.get("stale")).toBe("busy")
+    // confirmed: updated to busy from server
+    expect(map.get("confirmed")).toBe("busy")
+    expect(msgs).toEqual([{ type: "sessionStatus", sessionID: "confirmed", status: "busy" }])
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix spinner briefly disappearing when VS Code recreates the sidebar webview (e.g. switching panels and back during active streaming)
- Only reconcile session statuses (reset missing busy→idle) on the very first seed before SSE events populate the map; after that, live SSE events are authoritative
- Add defensive SSE improvements matching the app's (`global-sdk.tsx`) behavior: disable SDK internal retry loop (`sseMaxRetryAttempts: 1`) and filter `AbortError` in `onSseError`

## Problem

When a session is actively streaming and the user switches sidebar panels, VS Code destroys and recreates the webview. On recreation, `syncWebviewState` calls `seedSessionStatuses()` which fetches session statuses via HTTP. The reconciliation logic resets any locally-busy session to idle if it's absent from the HTTP response — but this races with live SSE `session.status` events, causing the spinner to momentarily vanish.

## How to reproduce

1. Start a session that runs for a while (complex prompt)
2. While streaming (spinner visible), click a different sidebar icon (Explorer, Source Control)
3. Click back on the Kilo sidebar
4. Spinner briefly disappears before reappearing

## Changes

- `session-status.ts`: Added `reconcile` parameter to `seedSessionStatuses()` — when `false`, skips force-resetting missing entries to idle
- `KiloProvider.ts`: Pass `reconcile = this.sessionStatusMap.size === 0` so reconciliation only runs on the first seed
- `sdk-sse-adapter.ts`: Set `sseMaxRetryAttempts: 1` to prevent SDK's internal retry loop from conflicting with the adapter's reconnection loop; filter `AbortError` in both `onSseError` and catch block
- `session-status.test.ts`: Added 3 tests for `reconcile=false` behavior