### PR TITLE
fix(vscode): enable sub-agent open-in-tab button in Agent Manager

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -17,7 +17,6 @@ import { useI18n } from "@kilocode/kilo-ui/context/i18n"
 import { createAutoScroll } from "@kilocode/kilo-ui/hooks"
 import { useSession } from "../../context/session"
 import { useVSCode } from "../../context/vscode"
-import { useWorktreeMode } from "../../context/worktree-mode"
 import type { ToolPart, Message as SDKMessage } from "@kilocode/sdk/v2"
 
 /** Collect all tool parts from all assistant messages in a given session. */
@@ -41,9 +40,6 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
   const i18n = useI18n()
   const session = useSession()
   const vscode = useVSCode()
-  const worktreeMode = useWorktreeMode()
-  // Hide the open-in-tab button inside the Agent Manager
-  const inAgentManager = worktreeMode !== undefined
 
   const childSessionId = () => props.metadata.sessionId as string | undefined
 
@@ -97,7 +93,7 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
           </span>
         </Show>
       </div>
-      <Show when={!inAgentManager && childSessionId()}>
+      <Show when={childSessionId()}>
         <IconButton
           icon="square-arrow-top-right"
           size="small"


### PR DESCRIPTION
## Summary

- Removes the `inAgentManager` guard that was hiding the "open sub-agent in tab" button in the Agent Manager
- The button was disabled preemptively when the feature was new (2b8ff2e799), but the message routing already works end-to-end — `AgentManagerProvider` passes `openSubAgentViewer` through to `KiloProvider`, which opens a read-only panel via `SubAgentViewerProvider`
- Also removes the now-unused `useWorktreeMode` import