### PR TITLE
fix(vscode): track leading-edge FIM requests as pending to reduce redundant API calls

### DIFF
--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
@@ -126,6 +126,8 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
   private recentlyVisitedRangesService: RecentlyVisitedRangesService
   private recentlyEditedTracker: RecentlyEditedTracker
   private debounceTimer: NodeJS.Timeout | null = null
+  /** The pending request associated with the current debounce timer (if any) */
+  private debouncedPendingRequest: PendingRequest | null = null
   private isFirstCall: boolean = true
   private ignoreController: Promise<FileIgnoreController>
   /** Abort controller for the current in-flight FIM request */
@@ -297,6 +299,8 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
       clearTimeout(this.debounceTimer)
       this.debounceTimer = null
     }
+    this.debouncedPendingRequest = null
+    this.pendingRequests.length = 0
     this.fimAbortController?.abort()
     this.fimAbortController = null
     this.telemetry?.dispose()
@@ -503,21 +507,22 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
     // but still track it as a pending request so subsequent calls can reuse it
     if (this.isFirstCall && this.debounceTimer === null) {
       this.isFirstCall = false
-      const leading: PendingRequest = {
-        prefix,
-        suffix,
-        promise: null!,
-      }
-      leading.promise = this.fetchAndCacheSuggestion(prompt, prefix, suffix, languageId).finally(() => {
-        this.removePendingRequest(leading)
-      })
+      const promise = this.fetchAndCacheSuggestion(prompt, prefix, suffix, languageId)
+      const leading: PendingRequest = { prefix, suffix, promise }
+      promise.finally(() => this.removePendingRequest(leading))
       this.pendingRequests.push(leading)
-      return leading.promise
+      return promise
     }
 
-    // Clear any existing timer (reset the debounce)
+    // Clear any existing timer and remove the stale pending request it belongs to.
+    // The cancelled timer's callback will never fire, so the pending entry would
+    // otherwise linger with a never-resolving promise.
     if (this.debounceTimer !== null) {
       clearTimeout(this.debounceTimer)
+      if (this.debouncedPendingRequest) {
+        this.removePendingRequest(this.debouncedPendingRequest)
+        this.debouncedPendingRequest = null
+      }
     }
 
     // Create the pending request object first so we can reference it in the cleanup
@@ -530,6 +535,7 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
     const requestPromise = new Promise<void>((resolve) => {
       this.debounceTimer = setTimeout(async () => {
         this.debounceTimer = null
+        this.debouncedPendingRequest = null
         this.isFirstCall = true // Reset for next sequence
         await this.fetchAndCacheSuggestion(prompt, prefix, suffix, languageId)
         // Remove this request from pending when done
@@ -540,6 +546,9 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
 
     // Complete the pending request object
     pendingRequest.promise = requestPromise
+
+    // Track so we can remove it if the timer is cleared by a subsequent call
+    this.debouncedPendingRequest = pendingRequest
 
     // Add to the list of pending requests
     this.pendingRequests.push(pendingRequest)

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
@@ -500,9 +500,19 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
     }
 
     // If this is the first call (no pending debounce), execute immediately
+    // but still track it as a pending request so subsequent calls can reuse it
     if (this.isFirstCall && this.debounceTimer === null) {
       this.isFirstCall = false
-      return this.fetchAndCacheSuggestion(prompt, prefix, suffix, languageId)
+      const leading: PendingRequest = {
+        prefix,
+        suffix,
+        promise: null!,
+      }
+      leading.promise = this.fetchAndCacheSuggestion(prompt, prefix, suffix, languageId).finally(() => {
+        this.removePendingRequest(leading)
+      })
+      this.pendingRequests.push(leading)
+      return leading.promise
     }
 
     // Clear any existing timer (reset the debounce)

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/__tests__/AutocompleteInlineCompletionProvider.test.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/__tests__/AutocompleteInlineCompletionProvider.test.ts
@@ -1973,6 +1973,57 @@ describe("AutocompleteInlineCompletionProvider", () => {
       expect(callCount).toBe(1)
     })
 
+    it("should reuse slow leading-edge request when user types forward before it completes", async () => {
+      // Mock the model with a slow response that takes 500ms
+      let callCount = 0
+      let resolvers: Array<() => void> = []
+      vi.mocked(mockModel.generateFimResponse).mockImplementation(async (_prefix, _suffix, onChunk) => {
+        callCount++
+        // Simulate a slow FIM response — wait for manual resolution
+        await new Promise<void>((resolve) => {
+          resolvers.push(resolve)
+        })
+        if (onChunk) {
+          onChunk("console.log('test');")
+        }
+        return {
+          cost: 0.01,
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheWriteTokens: 0,
+          cacheReadTokens: 0,
+        }
+      })
+
+      // First request: leading edge fires immediately for "const x = 1"
+      const doc1 = new MockTextDocument(vscode.Uri.file("/test.ts"), "const x = 1\nconst y = 2")
+      const pos1 = new vscode.Position(0, 11)
+      const promise1 = provider.provideInlineCompletionItems(doc1, pos1, mockContext, mockToken)
+
+      // Leading edge should have started the request immediately
+      expect(callCount).toBe(1)
+
+      // User types "c" while the leading-edge request is still in-flight
+      const doc2 = new MockTextDocument(vscode.Uri.file("/test.ts"), "const x = 1c\nconst y = 2")
+      const pos2 = new vscode.Position(0, 12)
+      const promise2 = provider.provideInlineCompletionItems(doc2, pos2, mockContext, mockToken)
+
+      // The second request should NOT have triggered a new FIM call —
+      // it should reuse the leading-edge pending request since the prefix
+      // extends and the suffix is unchanged
+      expect(callCount).toBe(1)
+
+      // Now resolve the FIM response
+      resolvers[0]()
+      await vi.advanceTimersByTimeAsync(500)
+
+      await promise1
+      await promise2
+
+      // Only one FIM request should have been made total
+      expect(callCount).toBe(1)
+    })
+
     it("should NOT reuse pending request when suffix changes", async () => {
       // Mock the model to track call count
       let callCount = 0


### PR DESCRIPTION
## Summary

- Track leading-edge (first) FIM requests in `pendingRequests` so `findCoveringPendingRequest` can reuse them when the user types forward
- Previously, the leading-edge call in `debouncedFetchAndCacheSuggestion` fired immediately but was never registered as a pending request, making it invisible to subsequent calls
- This caused redundant FIM requests when the user typed quickly: each keystroke after the leading edge would create a new debounced request instead of piggy-backing on the in-flight one

## What Changed

**`AutocompleteInlineCompletionProvider.ts`**: The leading-edge code path now wraps `fetchAndCacheSuggestion` in a `PendingRequest` with a `.finally()` cleanup, matching how trailing-edge requests are already tracked.

**`AutocompleteInlineCompletionProvider.test.ts`**: Added a test that simulates a slow FIM response with a user typing forward before it completes, verifying that only one FIM call is made.

## Why This Matters

When comparing FIM request volume between kilocode-3 and kilocode-legacy-5, this was identified as a source of redundant requests. With fast FIM responses the impact is modest, but with slower responses (higher latency providers, cold starts) the leading-edge request could be in-flight for hundreds of milliseconds during which every keystroke would set up a new debounced request instead of reusing the in-flight one.
