### PR TITLE
KiloSessions - Add WebSocket activity watchdog with heartbeat ack

### DIFF
--- a/packages/opencode/src/kilo-sessions/remote-protocol.ts
+++ b/packages/opencode/src/kilo-sessions/remote-protocol.ts
@@ -71,7 +71,12 @@ export namespace RemoteProtocol {
   })
   export type System = z.infer<typeof System>
 
-  export const Inbound = z.discriminatedUnion("type", [Subscribe, Unsubscribe, Command, System])
+  export const HeartbeatAck = z.object({
+    type: z.literal("heartbeat_ack"),
+  })
+  export type HeartbeatAck = z.infer<typeof HeartbeatAck>
+
+  export const Inbound = z.discriminatedUnion("type", [Subscribe, Unsubscribe, Command, System, HeartbeatAck])
   export type Inbound = z.infer<typeof Inbound>
 
   /** Lightweight schema for diagnostic logging before full parse. */

--- a/packages/opencode/src/kilo-sessions/remote-ws.ts
+++ b/packages/opencode/src/kilo-sessions/remote-ws.ts
@@ -18,6 +18,8 @@ export namespace RemoteWS {
     withContext?: <R>(fn: () => R) => Promise<R> | R
     /** Called when the server permanently closes the connection (e.g. auth failure, conflict) */
     onClose?: (code: number, reason: string) => void
+    /** Inactivity timeout in ms — force-close if no inbound message within this window */
+    timeout?: number
   }
 
   export type Connection = {
@@ -56,6 +58,29 @@ export namespace RemoteWS {
       beat = undefined
     }
 
+    let activity = Date.now()
+    let watchdog: Timer | undefined
+    const timeout = options.timeout ?? 30_000
+
+    function startWatchdog() {
+      stopWatchdog()
+      watchdog = setInterval(
+        () => {
+          if (Date.now() - activity > timeout) {
+            options.log.warn("remote-ws activity timeout, forcing reconnect")
+            stopWatchdog()
+            ws?.close(4000, "activity timeout")
+          }
+        },
+        Math.min(interval, timeout),
+      )
+    }
+
+    function stopWatchdog() {
+      if (watchdog) clearInterval(watchdog)
+      watchdog = undefined
+    }
+
     async function open() {
       if (closed) return
       const token = await options.getToken()
@@ -73,10 +98,13 @@ export namespace RemoteWS {
         backoff = 1000
         for (const msg of buffer) ws!.send(msg)
         buffer.length = 0
+        activity = Date.now()
         startHeartbeat()
+        startWatchdog()
       }
 
       ws.onmessage = (event) => {
+        activity = Date.now()
         const raw = String(event.data)
         let json: unknown
         try {
@@ -99,6 +127,7 @@ export namespace RemoteWS {
         options.log.info("remote-ws closed", { code: event.code, reason: event.reason })
         ws = undefined
         stopHeartbeat()
+        stopWatchdog()
         if (event.code === 4401 || event.code === 4403 || event.code === 4409) {
           options.log.warn("remote-ws closed permanently", {
             code: event.code,
@@ -134,6 +163,7 @@ export namespace RemoteWS {
     function close() {
       closed = true
       stopHeartbeat()
+      stopWatchdog()
       if (timer) clearTimeout(timer)
       if (ws) ws.close()
     }

--- a/packages/opencode/test/kilo-sessions/remote-protocol.test.ts
+++ b/packages/opencode/test/kilo-sessions/remote-protocol.test.ts
@@ -237,4 +237,22 @@ describe("RemoteProtocol", () => {
     const result = RemoteProtocol.SessionInfo.safeParse({ id: "x" })
     expect(result.success).toBe(false)
   })
+
+  test("valid heartbeat_ack parses", () => {
+    const msg = { type: "heartbeat_ack" }
+    const result = RemoteProtocol.HeartbeatAck.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.type).toBe("heartbeat_ack")
+    }
+  })
+
+  test("inbound union picks heartbeat_ack", () => {
+    const msg = { type: "heartbeat_ack" }
+    const result = RemoteProtocol.Inbound.safeParse(msg)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.type).toBe("heartbeat_ack")
+    }
+  })
 })

--- a/packages/opencode/test/kilo-sessions/remote-ws.test.ts
+++ b/packages/opencode/test/kilo-sessions/remote-ws.test.ts
@@ -284,4 +284,84 @@ describe("RemoteWS", () => {
     expect(server.clients.length).toBe(0)
     expect(server.messages.length).toBe(0)
   })
+
+  test("force-reconnects on activity timeout", async () => {
+    server = createServer()
+    const ws1 = server.waitForConnect()
+
+    conn = RemoteWS.connect({
+      url: server.url,
+      getToken: async () => "tok",
+      getSessions: () => [],
+      log: nolog(),
+      heartbeat: 60_000,
+      timeout: 200,
+    })
+
+    await ws1
+    await settled()
+    expect(conn.connected).toBe(true)
+
+    // Don't send any server messages — timeout should fire
+    const ws2 = server.waitForConnect()
+    await Bun.sleep(450)
+
+    // Should have reconnected
+    await ws2
+    await settled()
+    expect(conn.connected).toBe(true)
+  })
+
+  test("resets activity timer on incoming messages", async () => {
+    server = createServer()
+    const ws1p = server.waitForConnect()
+
+    conn = RemoteWS.connect({
+      url: server.url,
+      getToken: async () => "tok",
+      getSessions: () => [],
+      log: nolog(),
+      heartbeat: 60_000,
+      timeout: 300,
+    })
+
+    const ws1 = await ws1p
+    await settled()
+
+    // Send server messages at 100ms intervals — each resets the timer
+    for (let i = 0; i < 4; i++) {
+      await Bun.sleep(100)
+      ws1.send(JSON.stringify({ type: "subscribe", sessionId: `s${i}` }))
+    }
+
+    await settled()
+    // Connection should still be alive — activity kept resetting the timer
+    expect(conn.connected).toBe(true)
+    expect(server.clients.length).toBe(1)
+  })
+
+  test("activity timeout uses custom timeout option", async () => {
+    server = createServer()
+    const ws1 = server.waitForConnect()
+
+    conn = RemoteWS.connect({
+      url: server.url,
+      getToken: async () => "tok",
+      getSessions: () => [],
+      log: nolog(),
+      heartbeat: 60_000,
+      timeout: 100,
+    })
+
+    await ws1
+    await settled()
+
+    // With 100ms timeout, should reconnect faster than default 30s
+    const ws2 = server.waitForConnect()
+    await Bun.sleep(250)
+
+    await ws2
+    await settled()
+    expect(conn.connected).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary

- Add an inactivity watchdog to `RemoteWS` that force-closes and reconnects the WebSocket when no inbound message arrives within a configurable `timeout` window (default 30s).
- Introduce a `heartbeat_ack` inbound message type in `RemoteProtocol` so the server can respond to heartbeat pings, resetting the activity timer.
- Add tests covering timeout-triggered reconnects, activity timer resets on incoming messages, and custom timeout configuration.