### PR TITLE
fix(sdk): pass duplex in fetch init to survive VS Code proxy-agent wrapper

### DIFF
--- a/packages/sdk/js/src/client.ts
+++ b/packages/sdk/js/src/client.ts
@@ -8,12 +8,13 @@ export { type Config as KiloClientConfig, KiloClient }
 export function createKiloClient(config?: Config & { directory?: string }) {
   if (!config?.fetch) {
     const customFetch: any = (req: any) => {
-      // @ts-ignore
-      req.timeout = false
       // Pass duplex in the init arg so it survives VS Code's proxy-agent
       // fetch wrapper, which calls originalFetch(request, { ...init, dispatcher })
       // and would otherwise drop duplex from the cloned Request.
-      return fetch(req, { duplex: "half" } as any)
+      // timeout: false disables Bun's default request timeout for long-running
+      // streaming calls (replaces the old req.timeout = false assignment which
+      // wouldn't survive the clone triggered by passing an init object).
+      return fetch(req, { duplex: "half", timeout: false } as any)
     }
     config = {
       ...config,

--- a/packages/sdk/js/src/client.ts
+++ b/packages/sdk/js/src/client.ts
@@ -10,7 +10,10 @@ export function createKiloClient(config?: Config & { directory?: string }) {
     const customFetch: any = (req: any) => {
       // @ts-ignore
       req.timeout = false
-      return fetch(req)
+      // Pass duplex in the init arg so it survives VS Code's proxy-agent
+      // fetch wrapper, which calls originalFetch(request, { ...init, dispatcher })
+      // and would otherwise drop duplex from the cloned Request.
+      return fetch(req, { duplex: "half" } as any)
     }
     config = {
       ...config,

--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -10,7 +10,10 @@ export function createKiloClient(config?: Config & { directory?: string; experim
     const customFetch: any = (req: any) => {
       // @ts-ignore
       req.timeout = false
-      return fetch(req)
+      // Pass duplex in the init arg so it survives VS Code's proxy-agent
+      // fetch wrapper, which calls originalFetch(request, { ...init, dispatcher })
+      // and would otherwise drop duplex from the cloned Request.
+      return fetch(req, { duplex: "half" } as any)
     }
     config = {
       ...config,

--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -8,12 +8,13 @@ export { type Config as KiloClientConfig, KiloClient }
 export function createKiloClient(config?: Config & { directory?: string; experimental_workspaceID?: string }) {
   if (!config?.fetch) {
     const customFetch: any = (req: any) => {
-      // @ts-ignore
-      req.timeout = false
       // Pass duplex in the init arg so it survives VS Code's proxy-agent
       // fetch wrapper, which calls originalFetch(request, { ...init, dispatcher })
       // and would otherwise drop duplex from the cloned Request.
-      return fetch(req, { duplex: "half" } as any)
+      // timeout: false disables Bun's default request timeout for long-running
+      // streaming calls (replaces the old req.timeout = false assignment which
+      // wouldn't survive the clone triggered by passing an init object).
+      return fetch(req, { duplex: "half", timeout: false } as any)
     }
     config = {
       ...config,


### PR DESCRIPTION
## Summary

- Passes `{ duplex: "half" }` as the explicit `init` argument in the SDK's custom fetch wrapper so it survives VS Code's proxy-agent `{ ...init, dispatcher }` spread
- Fixes the `"RequestInit: duplex option is required when sending a body"` error that persists on Windows machines despite the previous fix in #7811

## Problem

The previous fix (#7811) set `duplex: "half"` on the SDK config object, which correctly propagated to `new Request(url, requestInit)` construction. However, the SDK's custom fetch wrapper called `fetch(request)` with **no `init` argument**.

VS Code's [`vscode-proxy-agent`](https://github.com/microsoft/vscode-proxy-agent) wraps `globalThis.fetch` in the extension host. When proxy support or certificate loading is active (common on corporate Windows machines), the wrapper does:

```ts
const modifiedInit = { ...init, dispatcher: agent };
return originalFetch(request, modifiedInit);
```

Since `init` was `undefined`, `modifiedInit` became `{ dispatcher: agent }` — **no `duplex`**. Undici's internal `new Request(existingRequest, { dispatcher })` then threw because `duplex` was missing from the new init.

**Why Windows but not Mac:** The proxy-agent fetch patch activates when `addCerts` is true or a proxy is configured — typical on corporate Windows. On macOS dev machines without proxy/cert settings, the wrapper passes through unchanged.

## Fix

```ts
// Before
return fetch(req)

// After
return fetch(req, { duplex: "half" } as any)
```

The existing config-level `duplex` fix from #7811 is kept as defense-in-depth for the `new Request()` construction path.

Fixes #7847
Fixes #7872