### PR TITLE
Add HTML entity decoding to math rendering which fixes VS Code latex

### DIFF
--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -377,29 +377,40 @@ registerCustomTheme("Kilo", () => {
   } as unknown as ThemeRegistrationResolved)
 })
 
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&dollar;/g, "$")
+    .replace(/&nbsp;/g, " ")
+}
+
 function renderMathInText(text: string): string {
   let result = text
 
-  // Display math: $$...$$
-  const displayMathRegex = /\$\$([\s\S]*?)\$\$/g
-  result = result.replace(displayMathRegex, (_, math) => {
+  result = decodeHtmlEntities(result)
+
+  result = result.replace(/\$\$([\s\S]*?)\$\$/g, (_, math) => {
     try {
       return katex.renderToString(math, {
         displayMode: true,
         throwOnError: false,
+        strict: false,
       })
     } catch {
       return `$$${math}$$`
     }
   })
 
-  // Inline math: $...$
-  const inlineMathRegex = /(?<!\$)\$(?!\$)((?:[^$\\]|\\.)+?)\$(?!\$)/g
-  result = result.replace(inlineMathRegex, (_, math) => {
+  result = result.replace(/(?<!\$)\$(?!\$)((?:[^$\\]|\\.)+?)\$(?!\$)/g, (_, math) => {
     try {
       return katex.renderToString(math, {
         displayMode: false,
         throwOnError: false,
+        strict: false,
       })
     } catch {
       return `$${math}$`
@@ -410,15 +421,12 @@ function renderMathInText(text: string): string {
 }
 
 function renderMathExpressions(html: string): string {
-  // Split on code/pre/kbd tags to avoid processing their contents
   const codeBlockPattern = /(<(?:pre|code|kbd)[^>]*>[\s\S]*?<\/(?:pre|code|kbd)>)/gi
   const parts = html.split(codeBlockPattern)
 
   return parts
     .map((part, i) => {
-      // Odd indices are the captured code blocks - leave them alone
       if (i % 2 === 1) return part
-      // Process math only in non-code parts
       return renderMathInText(part)
     })
     .join("")
@@ -664,7 +672,7 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
       },
       markedKatex({
         throwOnError: false,
-        nonStandard: true,
+        strict: false,
       }),
       markedShiki({
         async highlight(code, lang) {


### PR DESCRIPTION
<h2 style="box-sizing: border-box; margin: 0px 0px 0.75rem; padding: 0px; border: 0px solid; font-size: 13px; font-weight: 500; color: rgb(171, 178, 191); line-height: 19.5px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 25, 29); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p style="box-sizing: border-box; margin: 0px 0px 1rem; padding: 0px; border: 0px solid; color: rgb(171, 178, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 25, 29); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fixes LaTeX rendering in the Kilo Code VS Code extension chat. Math expressions were not being rendered due to HTML entities interfering with KateX delimiter detection.</p><h2 style="box-sizing: border-box; margin: 0px 0px 0.75rem; padding: 0px; border: 0px solid; font-size: 13px; font-weight: 500; color: rgb(171, 178, 191); line-height: 19.5px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 25, 29); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Context</h2><p style="box-sizing: border-box; margin: 0px 0px 1rem; padding: 0px; border: 0px solid; color: rgb(171, 178, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 25, 29); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">When AI responses contain LaTeX equations like<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">$E=mc^2$</code><span> </span>or<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">$$\int_0^\infty$$</code>, they appeared as raw text instead of rendered math. The issue was in how<span> </span><code class="file-link" data-file-path="marked.tsx" style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500; cursor: pointer; text-decoration-line: underline; text-decoration-style: dotted; text-underline-offset: 2px; transition: color 0.15s;">marked.tsx</code><span> </span>processed math expressions - HTML entities from the parsing process weren't being decoded before KateX attempted to render them.</p><h2 style="box-sizing: border-box; margin: 0px 0px 0.75rem; padding: 0px; border: 0px solid; font-size: 13px; font-weight: 500; color: rgb(171, 178, 191); line-height: 19.5px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 25, 29); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Implementation</h2><p style="box-sizing: border-box; margin: 0px 0px 1rem; padding: 0px; border: 0px solid; color: rgb(171, 178, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 25, 29); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Added a<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">decodeHtmlEntities()</code><span> </span>function that converts HTML entities (<code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">&amp;lt;</code>,<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">&amp;gt;</code>,<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">&amp;amp;</code>, etc.) back to their original characters before KateX processes the math delimiters (<code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">$...$</code>,<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">$$...$$</code>).</p><p style="box-sizing: border-box; margin: 0px 0px 1rem; padding: 0px; border: 0px solid; color: rgb(171, 178, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 25, 29); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Key changes:</p><ol style="box-sizing: border-box; margin: 0.5rem 0px 1rem; padding: 0px 0px 0px 1.5rem; border: 0px solid; list-style: outside decimal; color: rgb(171, 178, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 25, 29); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin: 0px 0px 0.5rem; padding: 0px; border: 0px solid;">Added<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">decodeHtmlEntities()</code><span> </span>to convert HTML entities to characters</li><li style="box-sizing: border-box; margin: 0px 0px 0.5rem; padding: 0px; border: 0px solid;">Updated<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">renderMathInText()</code><span> </span>to call<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">decodeHtmlEntities()</code><span> </span>before matching math delimiters</li><li style="box-sizing: border-box; margin: 0px 0px 0.5rem; padding: 0px; border: 0px solid;">Changed<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">markedKatex</code><span> </span>config from<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">nonStandard: true</code><span> </span>to<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">strict: false</code><span> </span>for better compatibility</li></ol><h2 style="box-sizing: border-box; margin: 0px 0px 0.75rem; padding: 0px; border: 0px solid; font-size: 13px; font-weight: 500; color: rgb(171, 178, 191); line-height: 19.5px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 25, 29); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Screenshots</h2>
<img width="99" height="35" alt="image" src="https://github.com/user-attachments/assets/6c6239a7-3b4c-4506-b5b9-350df299cd7c" />
<img width="175" height="30" alt="image" src="https://github.com/user-attachments/assets/073a7543-3f45-4cbb-9beb-b03b47927a86" />

<h2 style="box-sizing: border-box; margin: 0px 0px 0.75rem; padding: 0px; border: 0px solid; font-size: 13px; font-weight: 500; color: rgb(171, 178, 191); line-height: 19.5px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 25, 29); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">How to Test</h2><ul style="box-sizing: border-box; margin: 0.5rem 0px 1rem; padding: 0px 0px 0px 1.5rem; border: 0px solid; list-style: outside disc; color: rgb(171, 178, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 25, 29); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin: 0px 0px 0.5rem; padding: 0px; border: 0px solid;">Build the VS Code extension from<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">packages/kilo-vscode</code></li><li style="box-sizing: border-box; margin: 0px 0px 0.5rem; padding: 0px; border: 0px solid;">Open Kilo Code chat in VS Code</li><li style="box-sizing: border-box; margin: 0px 0px 0.5rem; padding: 0px; border: 0px solid;">Send a message containing LaTeX like:<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">$E = mc^2$</code><span> </span>or<span> </span><code style="font-family: &quot;Droid Sans Mono&quot;, monospace; color: rgb(206, 145, 120); background-color: transparent; padding: 0px; border-radius: 0px; box-sizing: border-box; margin: 0px; border: 0px solid; font-feature-settings: &quot;ss01&quot;; font-variation-settings: normal; font-size: 1em; font-weight: 500;">$$\frac{a}{b}$$</code></li><li style="box-sizing: border-box; margin: 0px 0px 0.5rem; padding: 0px; border: 0px solid;">Verify the math renders correctly instead of showing raw delimiters</li></ul>