### PR TITLE
feat(agent-manager): add "Copy Diff" to worktree right-click context menu

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -5,7 +5,7 @@ import type { KiloConnectionService } from "../services/cli-backend"
 import { getErrorMessage } from "../kilo-provider-utils"
 import { isAbsolutePath } from "../path-utils"
 import { WorktreeManager, type CreateWorktreeResult } from "./WorktreeManager"
-import { WorktreeStateManager } from "./WorktreeStateManager"
+import { WorktreeStateManager, remoteRef } from "./WorktreeStateManager"
 import { handleSection } from "./section-handler"
 import { chooseBaseBranch, normalizeBaseBranch } from "./base-branch"
 import { GitStatsPoller, type WorktreePresenceResult } from "./GitStatsPoller"
@@ -464,6 +464,10 @@ export class AgentManagerProvider implements Disposable {
     }
     if (m.type === "agentManager.revertWorktreeFile") {
       void this.diffs.revert(m.sessionId, m.file)
+      return null
+    }
+    if (m.type === "agentManager.copyDiff") {
+      void this.onCopyDiff(m.worktreeId)
       return null
     }
     if (m.type === "agentManager.startDiffWatch") {
@@ -1352,6 +1356,13 @@ export class AgentManagerProvider implements Disposable {
       return
     }
     this.host.openFile(resolved, line, column)
+  }
+
+  private async onCopyDiff(id: string): Promise<void> {
+    const wt = this.getStateManager()?.getWorktree(id)
+    if (!wt) return
+    const diff = await this.gitOps.buildUnifiedDiff(wt.path, remoteRef(wt)).catch(() => "")
+    this.host.copyToClipboard(diff || "No changes")
   }
 
   private postToWebview(message: AgentManagerOutMessage): void {

--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -247,6 +247,37 @@ export class GitOps {
   }
 
   /**
+   * Build a human-readable unified diff of all working-tree changes relative
+   * to the merge-base with `baseBranch`, including untracked files.
+   * Uses the same temp-index approach as `buildWorktreePatch` to capture
+   * both committed and uncommitted changes in a single diff.
+   */
+  async buildUnifiedDiff(cwd: string, base: string): Promise<string> {
+    const tmp = await fs.mkdtemp(nodePath.join(os.tmpdir(), "kilo-diff-"))
+    const index = nodePath.join(tmp, "index")
+    const env = { ...process.env, GIT_INDEX_FILE: index }
+
+    try {
+      const ancestor = (await this.raw(["merge-base", "HEAD", base], cwd)).trim()
+      const tree = (await this.raw(["rev-parse", `${ancestor}^{tree}`], cwd)).trim()
+
+      const read = await this.exec(["read-tree", "HEAD"], cwd, { env })
+      if (read.code !== 0) return ""
+
+      const add = await this.exec(["add", "-A", "--", "."], cwd, { env })
+      if (add.code !== 0) return ""
+
+      const snap = await this.exec(["write-tree"], cwd, { env })
+      if (snap.code !== 0) return ""
+
+      const diff = await this.exec(["diff", "--find-renames", "--no-color", tree, snap.stdout.trim()], cwd)
+      return diff.stdout
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true })
+    }
+  }
+
+  /**
    * Build a binary-safe patch of all working-tree changes relative to the
    * merge-base with `baseBranch`. Optionally scoped to `selectedFiles`.
    */

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -484,6 +484,11 @@ interface OpenSessionsIn {
   sessionIDs: string[]
 }
 
+interface CopyDiffIn {
+  type: "agentManager.copyDiff"
+  worktreeId: string
+}
+
 interface OpenFileIn {
   type: "agentManager.openFile"
   sessionId: string
@@ -641,6 +646,7 @@ export type AgentManagerInMessage =
   | RefreshPRIn
   | OpenPRIn
   | OpenSessionsIn
+  | CopyDiffIn
   | OpenFileIn
   | GenericOpenFileIn
   | PreviewImageIn

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2372,6 +2372,9 @@ const AgentManagerContent: Component = () => {
                                   onCancelRename={cancelRename}
                                   onRemoveStale={() => confirmRemoveStaleWorktree(wt.id)}
                                   onCopyPath={() => navigator.clipboard.writeText(wt.path)}
+                                  onCopyDiff={() =>
+                                    vscode.postMessage({ type: "agentManager.copyDiff", worktreeId: wt.id })
+                                  }
                                   onOpen={() =>
                                     vscode.postMessage({ type: "agentManager.openWorktree", worktreeId: wt.id })
                                   }

--- a/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
@@ -75,6 +75,7 @@ interface WorktreeItemProps {
   onCancelRename: () => void
   onRemoveStale: () => void
   onCopyPath: () => void
+  onCopyDiff: () => void
   onOpen: () => void
 }
 
@@ -461,6 +462,10 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
             <ContextMenu.Item onSelect={() => props.onCopyPath()}>
               <Icon name="copy" size="small" />
               <ContextMenu.ItemLabel>{t("agentManager.worktree.copyPath")}</ContextMenu.ItemLabel>
+            </ContextMenu.Item>
+            <ContextMenu.Item onSelect={() => props.onCopyDiff()}>
+              <Icon name="copy" size="small" />
+              <ContextMenu.ItemLabel>{t("agentManager.worktree.copyDiff")}</ContextMenu.ItemLabel>
             </ContextMenu.Item>
             <ContextMenu.Separator />
             <ContextMenu.Item onSelect={() => props.onMoveToNewSection?.()}>

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "الفرع الأساسي الافتراضي",
   "agentManager.worktree.defaultBaseBranchAuto": "اكتشاف تلقائي",
   "agentManager.worktree.copyPath": "نسخ المسار",
+  "agentManager.worktree.copyDiff": "نسخ الفرق",
   "agentManager.worktree.openInVscode": "فتح في VS Code",
   "agentManager.worktree.rename": "إعادة تسمية",
   "agentManager.worktree.moveToSection": "نقل إلى القسم",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Branch base padrão",
   "agentManager.worktree.defaultBaseBranchAuto": "Detecção automática",
   "agentManager.worktree.copyPath": "Copiar Caminho",
+  "agentManager.worktree.copyDiff": "Copiar Diff",
   "agentManager.worktree.openInVscode": "Abrir no VS Code",
   "agentManager.worktree.rename": "Renomear",
   "agentManager.worktree.moveToSection": "Mover para a Seção",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Zadana bazna grana",
   "agentManager.worktree.defaultBaseBranchAuto": "Automatsko otkrivanje",
   "agentManager.worktree.copyPath": "Kopiraj putanju",
+  "agentManager.worktree.copyDiff": "Kopiraj razlike",
   "agentManager.worktree.openInVscode": "Otvori u VS Code",
   "agentManager.worktree.rename": "Preimenuj",
   "agentManager.worktree.moveToSection": "Premjesti u sekciju",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Standard basisgren",
   "agentManager.worktree.defaultBaseBranchAuto": "Automatisk registrering",
   "agentManager.worktree.copyPath": "Kopier sti",
+  "agentManager.worktree.copyDiff": "Kopier diff",
   "agentManager.worktree.openInVscode": "Åbn i VS Code",
   "agentManager.worktree.rename": "Omdøb",
   "agentManager.worktree.moveToSection": "Flyt til sektion",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Standard-Basiszweig",
   "agentManager.worktree.defaultBaseBranchAuto": "Automatisch erkennen",
   "agentManager.worktree.copyPath": "Pfad kopieren",
+  "agentManager.worktree.copyDiff": "Diff kopieren",
   "agentManager.worktree.openInVscode": "In VS Code öffnen",
   "agentManager.worktree.rename": "Umbenennen",
   "agentManager.worktree.moveToSection": "In Bereich verschieben",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -18,6 +18,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Default Base Branch",
   "agentManager.worktree.defaultBaseBranchAuto": "Auto-detect",
   "agentManager.worktree.copyPath": "Copy Path",
+  "agentManager.worktree.copyDiff": "Copy Diff",
   "agentManager.worktree.openInVscode": "Open in VS Code",
   "agentManager.worktree.rename": "Rename",
   "agentManager.worktree.moveToSection": "Move to Section",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Rama base predeterminada",
   "agentManager.worktree.defaultBaseBranchAuto": "Detección automática",
   "agentManager.worktree.copyPath": "Copiar ruta",
+  "agentManager.worktree.copyDiff": "Copiar Diff",
   "agentManager.worktree.openInVscode": "Abrir en VS Code",
   "agentManager.worktree.rename": "Renombrar",
   "agentManager.worktree.moveToSection": "Mover a la sección",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Branche de base par défaut",
   "agentManager.worktree.defaultBaseBranchAuto": "Détection automatique",
   "agentManager.worktree.copyPath": "Copier le chemin",
+  "agentManager.worktree.copyDiff": "Copier le diff",
   "agentManager.worktree.openInVscode": "Ouvrir dans VS Code",
   "agentManager.worktree.rename": "Renommer",
   "agentManager.worktree.moveToSection": "Déplacer vers la section",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "デフォルトベースブランチ",
   "agentManager.worktree.defaultBaseBranchAuto": "自動検出",
   "agentManager.worktree.copyPath": "パスをコピー",
+  "agentManager.worktree.copyDiff": "差分をコピー",
   "agentManager.worktree.openInVscode": "VS Codeで開く",
   "agentManager.worktree.rename": "名前を変更",
   "agentManager.worktree.moveToSection": "セクションに移動",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "기본 베이스 브랜치",
   "agentManager.worktree.defaultBaseBranchAuto": "자동 감지",
   "agentManager.worktree.copyPath": "경로 복사",
+  "agentManager.worktree.copyDiff": "차이점 복사",
   "agentManager.worktree.openInVscode": "VS Code에서 열기",
   "agentManager.worktree.rename": "이름 바꾸기",
   "agentManager.worktree.moveToSection": "섹션으로 이동",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -18,6 +18,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Standaard basis branch",
   "agentManager.worktree.defaultBaseBranchAuto": "Automatisch detecteren",
   "agentManager.worktree.copyPath": "Pad kopiëren",
+  "agentManager.worktree.copyDiff": "Diff kopiëren",
   "agentManager.worktree.openInVscode": "Openen in VS Code",
   "agentManager.worktree.rename": "Hernoemen",
   "agentManager.worktree.moveToSection": "Verplaatsen naar sectie",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Standard basisgren",
   "agentManager.worktree.defaultBaseBranchAuto": "Automatisk gjenkjenning",
   "agentManager.worktree.copyPath": "Kopier sti",
+  "agentManager.worktree.copyDiff": "Kopier diff",
   "agentManager.worktree.openInVscode": "Åpne i VS Code",
   "agentManager.worktree.rename": "Gi nytt navn",
   "agentManager.worktree.moveToSection": "Flytt til seksjon",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Domyślna gałąź bazowa",
   "agentManager.worktree.defaultBaseBranchAuto": "Automatyczne wykrywanie",
   "agentManager.worktree.copyPath": "Kopiuj ścieżkę",
+  "agentManager.worktree.copyDiff": "Kopiuj różnice",
   "agentManager.worktree.openInVscode": "Otwórz w VS Code",
   "agentManager.worktree.rename": "Zmień nazwę",
   "agentManager.worktree.moveToSection": "Przenieś do sekcji",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Базовая ветка по умолчанию",
   "agentManager.worktree.defaultBaseBranchAuto": "Автоопределение",
   "agentManager.worktree.copyPath": "Копировать путь",
+  "agentManager.worktree.copyDiff": "Копировать diff",
   "agentManager.worktree.openInVscode": "Открыть в VS Code",
   "agentManager.worktree.rename": "Переименовать",
   "agentManager.worktree.moveToSection": "Переместить в раздел",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "สาขาฐานเริ่มต้น",
   "agentManager.worktree.defaultBaseBranchAuto": "ตรวจจับอัตโนมัติ",
   "agentManager.worktree.copyPath": "คัดลอกเส้นทาง",
+  "agentManager.worktree.copyDiff": "คัดลอก Diff",
   "agentManager.worktree.openInVscode": "เปิดใน VS Code",
   "agentManager.worktree.rename": "เปลี่ยนชื่อ",
   "agentManager.worktree.moveToSection": "ย้ายไปที่ส่วน",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -18,6 +18,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Varsayılan Temel Dal",
   "agentManager.worktree.defaultBaseBranchAuto": "Otomatik algıla",
   "agentManager.worktree.copyPath": "Yolu Kopyala",
+  "agentManager.worktree.copyDiff": "Diff'i Kopyala",
   "agentManager.worktree.openInVscode": "VS Code'da Aç",
   "agentManager.worktree.rename": "Yeniden Adlandır",
   "agentManager.worktree.moveToSection": "Bölüme Taşı",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -18,6 +18,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "Гілка за замовчуванням",
   "agentManager.worktree.defaultBaseBranchAuto": "Автоматичне визначення",
   "agentManager.worktree.copyPath": "Копіювати шлях",
+  "agentManager.worktree.copyDiff": "Копіювати diff",
   "agentManager.worktree.openInVscode": "Відкрити у VS Code",
   "agentManager.worktree.rename": "Перейменувати",
   "agentManager.worktree.moveToSection": "Перемістити до розділу",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "默认基础分支",
   "agentManager.worktree.defaultBaseBranchAuto": "自动检测",
   "agentManager.worktree.copyPath": "复制路径",
+  "agentManager.worktree.copyDiff": "复制差异",
   "agentManager.worktree.openInVscode": "在 VS Code 中打开",
   "agentManager.worktree.rename": "重命名",
   "agentManager.worktree.moveToSection": "移动到分区",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -17,6 +17,7 @@ export const dict = {
   "agentManager.worktree.defaultBaseBranch": "預設基礎分支",
   "agentManager.worktree.defaultBaseBranchAuto": "自動偵測",
   "agentManager.worktree.copyPath": "複製路徑",
+  "agentManager.worktree.copyDiff": "複製差異",
   "agentManager.worktree.openInVscode": "在 VS Code 中打開",
   "agentManager.worktree.rename": "重新命名",
   "agentManager.worktree.moveToSection": "移動到分區",

--- a/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
@@ -179,6 +179,7 @@ const defaultProps = {
   onCancelRename: noop,
   onRemoveStale: noop,
   onCopyPath: noop,
+  onCopyDiff: noop,
   onOpen: noop,
 }
 

--- a/packages/kilo-vscode/webview-ui/src/stories/section-header.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/section-header.stories.tsx
@@ -77,6 +77,7 @@ const wtProps = {
   onCancelRename: noop,
   onRemoveStale: noop,
   onCopyPath: noop,
+  onCopyDiff: noop,
   onOpen: noop,
 }
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1969,6 +1969,12 @@ export interface CopyToClipboardRequest {
   text: string
 }
 
+// Copy the full unified diff of a worktree to the clipboard
+export interface CopyDiffRequest {
+  type: "agentManager.copyDiff"
+  worktreeId: string
+}
+
 // Show existing local terminal when switching to local context (no-op if none exists)
 export interface ShowExistingLocalTerminalRequest {
   type: "agentManager.showExistingLocalTerminal"
@@ -2402,6 +2408,7 @@ export type WebviewMessage =
   | ShowLocalTerminalRequest
   | OpenWorktreeRequest
   | CopyToClipboardRequest
+  | CopyDiffRequest
   | ShowExistingLocalTerminalRequest
   | AgentManagerOpenFileRequest
   | CreateMultiVersionRequest


### PR DESCRIPTION
## Summary

- Adds a **Copy Diff** option to the worktree right-click context menu in the Agent Manager, allowing users to copy the complete unified diff of a worktree to the clipboard
- Uses the same merge-base diff mechanism as the diff viewer panel — stages all changes (including untracked files) into a temporary index and diffs the snapshot tree against the ancestor, ensuring the copied diff matches exactly what the diff viewer shows
- Includes i18n translations for all 18 supported languages

<img width="259" height="190" alt="image" src="https://github.com/user-attachments/assets/241db466-5851-41bf-980b-5c5410d2caf8" />
