### PR TITLE
CLI - Add remote_control Config Option

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1159,6 +1159,10 @@ export namespace Config {
         .boolean()
         .optional()
         .describe("@deprecated Use 'share' field instead. Share newly created sessions automatically"),
+      remote_control: z // kilocode_change
+        .boolean()
+        .optional()
+        .describe("Enable remote control of sessions via Kilo Cloud. Equivalent to running /remote on startup."),
       autoupdate: z
         .union([z.boolean(), z.literal("notify")])
         .optional()

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -206,7 +206,7 @@ export namespace KiloSessions {
       await ingest.sync(evt.properties.sessionID, [{ type: "session_close", data: { reason: evt.properties.reason } }])
     })
 
-    const cfg = await Config.get()
+    const cfg = await Config.getGlobal()
     if (remoteEnabled || cfg.remote_control)
       enableRemote().catch((err) => log.warn("remote not enabled", { error: String(err) }))
     Bus.subscribe(Bus.InstanceDisposed, () => disableRemote())

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -10,6 +10,7 @@ import { clearInFlightCache, withInFlightCache } from "@/kilo-sessions/inflight-
 import type * as SDK from "@kilocode/sdk/v2"
 import z from "zod"
 import { KILO_API_BASE } from "@kilocode/kilo-gateway"
+import { Config } from "@/config/config"
 import { Instance } from "@/project/instance"
 import { Vcs } from "@/project/vcs"
 import simpleGit from "simple-git"
@@ -205,7 +206,9 @@ export namespace KiloSessions {
       await ingest.sync(evt.properties.sessionID, [{ type: "session_close", data: { reason: evt.properties.reason } }])
     })
 
-    if (remoteEnabled) enableRemote().catch((err) => log.warn("remote not enabled", { error: String(err) }))
+    const cfg = await Config.get()
+    if (remoteEnabled || cfg.remote_control)
+      enableRemote().catch((err) => log.warn("remote not enabled", { error: String(err) }))
     Bus.subscribe(Bus.InstanceDisposed, () => disableRemote())
   }
 


### PR DESCRIPTION
## Summary

- Adds a `remote_control` boolean config field to enable remote session relay by default on startup
- When `"remote_control": true` is set in global config (`~/.config/kilo/kilo.json`), `KiloSessions.init()` auto-enables remote without needing the `KILO_REMOTE=1` env var or `/remote` command
- Only reads from global config — project-level config is intentionally ignored

## Changes

- `packages/opencode/src/config/config.ts` — new `remote_control` optional boolean in `Config.Info` schema
- `packages/opencode/src/kilo-sessions/kilo-sessions.ts` — read global config via `Config.getGlobal()` in `init()` and enable remote when either `KILO_REMOTE=1` or `remote_control` is truthy