### PR TITLE
fix(vscode): show default agent errors in chat and settings

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -965,11 +965,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             return event.type !== "message.part.updated" && event.type !== "message.part.delta"
           }
 
-          // session.status must always pass through — even for sessions not tracked by this
-          // KiloProvider instance. The Settings panel is a separate provider with no tracked
-          // sessions, but it needs session.status to populate sessionStatusMap and allStatusMap
-          // for the busy-session warning on Save.
-          if (event.type === "session.status") return true
+          // session.status and session.error must always pass through — even for sessions not
+          // tracked by this KiloProvider instance. The Settings panel is a separate provider with
+          // no tracked sessions, but it needs status updates; session.error must also make it to
+          // the owning provider during first-turn startup failures so chat can render the error.
+          if (event.type === "session.status" || event.type === "session.error") return true
 
           return this.trackedSessionIds.has(sessionId)
         },
@@ -2493,14 +2493,18 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // let a foreign session through if it was accidentally tracked.
     if (isEventFromForeignProject(event, this.projectID)) return
 
-    // session.status events pass the onEventFiltered pre-filter for all providers (see line 842),
-    // so this runs on every KiloProvider instance — including the Settings panel which has no
-    // tracked sessions. Update sessionStatusMap and forward to webview before the
-    // trackedSessionIds guard so the Settings panel's allStatusMap stays current for the
-    // busy-session warning on Save.
+    // session.status and session.error events pass the onEventFiltered pre-filter for all
+    // providers, so this runs on every KiloProvider instance — including the Settings panel
+    // which has no tracked sessions. Handle them before the trackedSessionIds guard.
     if (event.type === "session.status") {
       const sid = event.properties.sessionID
       this.sessionStatusMap.set(sid, event.properties.status.type)
+      const msg = mapSSEEventToWebviewMessage(event, sid)
+      if (msg) this.postMessage(msg)
+      return
+    }
+    if (event.type === "session.error") {
+      const sid = event.properties.sessionID
       const msg = mapSSEEventToWebviewMessage(event, sid)
       if (msg) this.postMessage(msg)
       return

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ErrorDisplay.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ErrorDisplay.tsx
@@ -1,8 +1,6 @@
-import { Component, createMemo, Switch, Match } from "solid-js"
-import { Card } from "@kilocode/kilo-ui/card"
-import { Collapsible } from "@kilocode/kilo-ui/collapsible"
-import { ErrorDetails } from "@kilocode/kilo-ui/error-details"
+import { Component, createMemo, Switch, Match, createSignal, Show } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
+import { ErrorDetails } from "@kilocode/kilo-ui/error-details"
 import type { AssistantMessage } from "@kilocode/sdk/v2"
 import { useLanguage } from "../../context/language"
 import {
@@ -20,6 +18,7 @@ interface ErrorDisplayProps {
 export const ErrorDisplay: Component<ErrorDisplayProps> = (props) => {
   const { t } = useLanguage()
   const parsed = createMemo(() => parseAssistantError(props.error))
+  const [expanded, setExpanded] = createSignal(false)
 
   const errorText = createMemo(() => {
     const msg = props.error.data?.message
@@ -31,18 +30,32 @@ export const ErrorDisplay: Component<ErrorDisplayProps> = (props) => {
   return (
     <Switch
       fallback={
-        <Card variant="error" class="error-card">
-          {errorText()}
-          <Collapsible variant="ghost">
-            <Collapsible.Trigger class="error-details-trigger">
-              <span>{t("error.details.show")}</span>
-              <Collapsible.Arrow />
-            </Collapsible.Trigger>
-            <Collapsible.Content>
+        <div class="startup-error-banner error-inline-banner">
+          <div
+            class="startup-error-header"
+            onClick={() => setExpanded((v) => !v)}
+            role="button"
+            aria-expanded={expanded()}
+          >
+            <span class="startup-error-title">
+              Error: <span class="startup-error-firstline">{errorText()}</span>
+            </span>
+            <button
+              class="startup-error-retry"
+              onClick={(e) => {
+                e.stopPropagation()
+                setExpanded((v) => !v)
+              }}
+            >
+              {t("error.details.show")}
+            </button>
+          </div>
+          <Show when={expanded()}>
+            <div class="error-inline-details">
               <ErrorDetails error={props.error} />
-            </Collapsible.Content>
-          </Collapsible>
-        </Card>
+            </div>
+          </Show>
+        </div>
       }
     >
       <Match when={isUnauthorizedPaidModelError(parsed())}>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -72,7 +72,14 @@ export const MessageList: Component<MessageListProps> = (props) => {
     if (!b) return allUserMessages()
     return allUserMessages().filter((m) => m.id < b)
   })
-  const isEmpty = () => userMessages().length === 0 && !session.loading() && !boundary()
+  const assistantErrors = createMemo(() =>
+    session
+      .messages()
+      .filter((m) => m.role === "assistant" && !!m.error && !m.parentID)
+      .map((m) => m.id),
+  )
+  const isEmpty = () =>
+    userMessages().length === 0 && assistantErrors().length === 0 && !session.loading() && !boundary()
 
   const recent = createMemo(() =>
     [...session.sessions()]
@@ -156,6 +163,9 @@ export const MessageList: Component<MessageListProps> = (props) => {
                   />
                 )
               }}
+            </For>
+            <For each={assistantErrors()}>
+              {(id) => <VscodeSessionTurn sessionID={session.currentSessionID() ?? ""} messageID={id} queued={false} />}
             </For>
             <Show when={boundary()}>
               <RevertBanner />

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
@@ -109,6 +109,7 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
   const error = createMemo(
     () => assistantMessages().find((m) => m.error && m.error.name !== "MessageAbortedError")?.error,
   )
+  const revertable = createMemo(() => assistantMessages().length > 0 && !error())
 
   // Diffs from message summary
   const diffs = createMemo(() => {
@@ -178,7 +179,7 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
                   interrupted={interrupted()}
                   queued={props.queued}
                   onRevert={
-                    assistantMessages().length > 0 && !session.revert()
+                    revertable() && !session.revert()
                       ? () => {
                           if (session.status() !== "idle") return
                           session.revertSession(props.messageID)
@@ -192,7 +193,7 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
 
           {/* Assistant parts — flat list, no context grouping */}
           <Show when={assistantMessages().length > 0}>
-            <div class="vscode-session-turn-assistant">
+            <div class="vscode-session-turn-assistant" data-standalone={message() ? undefined : ""}>
               <For each={assistantMessages()}>
                 {(msg) => <AssistantMessage message={msg} showAssistantCopyPartID={showAssistantCopyPartID()} />}
               </For>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
@@ -67,10 +67,14 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
     return (msgs ?? emptyMessages) as SDKMessage[]
   })
 
+  const root = createMemo(() => allMessages().find((m) => m.id === props.messageID))
+
   const message = createMemo(() => {
-    return allMessages().find((m) => m.id === props.messageID && m.role === "user") as
-      | (SDKMessage & { role: "user" })
-      | undefined
+    const msg = root()
+    if (msg?.role === "user") {
+      return msg as SDKMessage & { role: "user" }
+    }
+    return undefined
   })
 
   const parts = createMemo(() => {
@@ -85,6 +89,8 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
   })
 
   const assistantMessages = createMemo(() => {
+    const rootMsg = root()
+    if (rootMsg?.role === "assistant") return [rootMsg as SDKAssistantMessage]
     const index = messageIndex()
     if (index < 0) return [] as SDKAssistantMessage[]
     const msgs = allMessages()
@@ -149,36 +155,40 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
   })
 
   return (
-    <Show when={message()}>
-      {(msg) => (
-        <div class="vscode-session-turn" data-message={msg().id}>
+    <Show when={root()}>
+      {(rootMsg) => (
+        <div class="vscode-session-turn" data-message={rootMsg().id}>
           {/* User message */}
-          <div
-            class="vscode-session-turn-user"
-            data-revert-disabled={
-              assistantMessages().length > 0 && !session.revert() && session.status() !== "idle" ? "" : undefined
-            }
-            title={
-              assistantMessages().length > 0 && !session.revert() && session.status() !== "idle"
-                ? language.t("revert.disabled.agentBusy")
-                : undefined
-            }
-          >
-            <UserMessageDisplay
-              message={msg() as unknown as Parameters<typeof UserMessageDisplay>[0]["message"]}
-              parts={parts() as unknown as Parameters<typeof UserMessageDisplay>[0]["parts"]}
-              interrupted={interrupted()}
-              queued={props.queued}
-              onRevert={
-                assistantMessages().length > 0 && !session.revert()
-                  ? () => {
-                      if (session.status() !== "idle") return
-                      session.revertSession(props.messageID)
-                    }
-                  : undefined
-              }
-            />
-          </div>
+          <Show when={message()}>
+            {(msg) => (
+              <div
+                class="vscode-session-turn-user"
+                data-revert-disabled={
+                  assistantMessages().length > 0 && !session.revert() && session.status() !== "idle" ? "" : undefined
+                }
+                title={
+                  assistantMessages().length > 0 && !session.revert() && session.status() !== "idle"
+                    ? language.t("revert.disabled.agentBusy")
+                    : undefined
+                }
+              >
+                <UserMessageDisplay
+                  message={msg() as unknown as Parameters<typeof UserMessageDisplay>[0]["message"]}
+                  parts={parts() as unknown as Parameters<typeof UserMessageDisplay>[0]["parts"]}
+                  interrupted={interrupted()}
+                  queued={props.queued}
+                  onRevert={
+                    assistantMessages().length > 0 && !session.revert()
+                      ? () => {
+                          if (session.status() !== "idle") return
+                          session.revertSession(props.messageID)
+                        }
+                      : undefined
+                  }
+                />
+              </div>
+            )}
+          </Show>
 
           {/* Assistant parts — flat list, no context grouping */}
           <Show when={assistantMessages().length > 0}>

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -88,6 +88,21 @@ const AgentBehaviourTab: Component = () => {
     ...agentNames().map((name) => ({ value: name, label: name })),
   ])
 
+  const invalidDefaultAgent = createMemo(() => {
+    const name = config().default_agent?.trim()
+    if (!name) return undefined
+    return agentNames().includes(name) ? undefined : name
+  })
+
+  const selectedDefaultAgent = createMemo<SelectOption | undefined>(() => {
+    const name = config().default_agent ?? ""
+    const match = defaultAgentOptions().find((o) => o.value === name)
+    if (match) return match
+    const invalid = invalidDefaultAgent()
+    if (!invalid) return undefined
+    return { value: invalid, label: invalid }
+  })
+
   const instructions = () => config().instructions ?? []
 
   const addInstruction = () => {
@@ -273,9 +288,15 @@ const AgentBehaviourTab: Component = () => {
           >
             <Select
               options={defaultAgentOptions()}
-              current={defaultAgentOptions().find((o) => o.value === (config().default_agent ?? ""))}
+              current={selectedDefaultAgent()}
               value={(o) => o.value}
               label={(o) => o.label}
+              valueClass={invalidDefaultAgent() ? "settings-select-invalid" : undefined}
+              children={(o) => (
+                <span class={invalidDefaultAgent() === o?.value ? "settings-select-invalid" : undefined}>
+                  {o?.label ?? ""}
+                </span>
+              )}
               onSelect={(o) => {
                 if (!o) return
                 const next = o.value || undefined

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -652,6 +652,7 @@ export const SessionProvider: ParentComponent = (props) => {
           if (message.error?.name === "MessageAbortedError") break
           const sid = message.sessionID ?? currentSessionID()
           if (!sid) break
+          if (sid === currentSessionID()) setLoading(false)
           // Find the last user message in this session to use as parentID
           const msgs = store.messages[sid] ?? []
           const parent = [...msgs].reverse().find((m) => m.role === "user")

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -2565,6 +2565,10 @@ body.vscode-light
   width: 100%;
 }
 
+.vscode-session-turn-assistant[data-standalone] {
+  padding-block: 2px;
+}
+
 .vscode-session-turn-diffs {
   width: 100%;
 }
@@ -2963,6 +2967,20 @@ body.vscode-light
 /* ============================================
    Auth Prompt (sign in / sign up error displays)
    ============================================ */
+
+.error-inline-banner {
+  margin: 0;
+}
+
+.error-inline-banner .startup-error-header {
+  align-items: flex-start;
+}
+
+.error-inline-details {
+  padding: 8px 10px;
+  border-top: 1px solid var(--vscode-inputValidation-errorBorder, #f14c4c);
+  background: var(--vscode-editor-background);
+}
 
 [data-component="auth-prompt"] {
   display: flex;

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -3092,6 +3092,17 @@ body.vscode-light
   }
 }
 
+.settings-select-invalid {
+  color: var(--vscode-errorForeground, #f14c4c);
+}
+
+[data-component="select"] .settings-select-invalid,
+[data-component="select"] [data-slot="select-select-trigger-value"] .settings-select-invalid,
+[data-component="select-content"] .settings-select-invalid,
+[data-component="select-content"] [data-slot="select-select-item-label"] .settings-select-invalid {
+  color: var(--vscode-errorForeground, #f14c4c) !important;
+}
+
 /* Wider inputs inside cards with data-variant="wide-input" (e.g. edit mode config) */
 [data-variant="wide-input"] [data-slot="settings-row-input"] {
   flex: 1 1 0%;

--- a/packages/opencode/src/kilocode/default-agent.ts
+++ b/packages/opencode/src/kilocode/default-agent.ts
@@ -1,0 +1,16 @@
+// kilocode_change - new file
+import { Agent } from "../agent/agent"
+import { Session } from "../session"
+import { Bus } from "../bus"
+import { NamedError } from "@opencode-ai/util/error"
+
+export async function defaultAgent(sessionID: string) {
+  return Agent.defaultAgent().catch((e) => {
+    const message = e instanceof Error ? e.message : String(e)
+    Bus.publish(Session.Event.Error, {
+      sessionID,
+      error: new NamedError.Unknown({ message }).toObject(),
+    })
+    throw e
+  })
+}

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -16,6 +16,8 @@ import { Log } from "../../util/log"
 import { PermissionNext } from "@/permission/next"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
+import { Bus } from "../../bus" // kilocode_change
+import { NamedError } from "@opencode-ai/util/error" // kilocode_change
 
 const log = Log.create({ service: "server" })
 
@@ -795,7 +797,19 @@ export const SessionRoutes = lazy(() =>
         return stream(c, async () => {
           const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          SessionPrompt.prompt({ ...body, sessionID })
+          void SessionPrompt.prompt({ ...body, sessionID }).catch((error) => {
+            const message = error instanceof Error ? error.message : String(error)
+            // kilocode_change start - surface async prompt failures to SSE/webview chat
+            Bus.publish(Session.Event.Error, {
+              sessionID,
+              error: new NamedError.Unknown({ message }).toObject(),
+            })
+            // kilocode_change end
+            log.error("prompt_async failed", {
+              sessionID,
+              error: message,
+            })
+          })
         })
       },
     )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -38,6 +38,7 @@ import { SessionSummary } from "./summary"
 import { NamedError } from "@opencode-ai/util/error"
 import { fn } from "@/util/fn"
 import { SessionProcessor } from "./processor"
+import { defaultAgent as kiloDefaultAgent } from "../kilocode/default-agent" // kilocode_change
 import { TaskTool } from "@/tool/task"
 import { Tool } from "@/tool/tool"
 import { PermissionNext } from "@/permission/next"
@@ -1955,7 +1956,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         ]
       : [...templateParts, ...(input.parts ?? [])]
 
-    const userAgent = isSubtask ? (input.agent ?? (await Agent.defaultAgent())) : agentName
+    const userAgent = isSubtask ? (input.agent ?? (await kiloDefaultAgent(input.sessionID))) : agentName // kilocode_change
     const userModel = isSubtask
       ? input.model
         ? Provider.parseModel(input.model)


### PR DESCRIPTION
## Summary
- surface async CLI prompt startup failures in the VS Code chat by publishing `session.error` and rendering assistant-only error turns
- reuse the startup error banner styling for chat errors and hide revert/empty-state UI that should not appear for failed turns
- show invalid default agent values directly in Settings with VS Code error styling so broken config is visible and recoverable
### Demo

#### Before

When default agent is invalid that chat doesn't show any errors and just unusable

https://github.com/user-attachments/assets/8efbd015-b7b8-4ce5-bdf6-f68189ff6d6b

#### After

Error shown and the invalid default agents is highlighted in settings

https://github.com/user-attachments/assets/35292b92-6804-487c-bf4e-d5e913c204ba

<img width="1527" height="913" alt="Screen Shot 2026-03-30 at 5 47 32 PM" src="https://github.com/user-attachments/assets/c39a14ec-108c-42a1-a924-b969ba7ff6d9" />

