### PR TITLE
fix(kilo-docs): correct Agent Manager keyboard shortcuts and claims

### DIFF
--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -75,7 +75,7 @@ Each session has a dedicated integrated terminal. Press `Cmd+/` to focus the ter
 
 ## Setup Scripts
 
-Place an executable script at `.kilo/setup-script` in your project root. It runs automatically whenever a new worktree is created (useful for `npm install`, env setup, etc.).
+Place an executable script at `.kilo/setup-script` in your project root. It runs automatically whenever a new worktree is created (useful for `npm install`, env setup, etc.). Root-level `.env` and `.env.*` files are also auto-copied from the main repo before the setup script runs.
 
 ## Session State and Persistence
 

--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -33,7 +33,7 @@ Each Agent Manager session runs in an isolated git worktree on a separate branch
 
 ### Creating a New Worktree Session
 
-1. Click **New Worktree** or press `Cmd+Shift+W` to create a new worktree
+1. Click **New Worktree** or press `Cmd+N` to create a new worktree
 2. Enter a branch name (or let Kilo generate one)
 3. Type your first message to start the agent
 
@@ -63,7 +63,7 @@ You can run up to 4 parallel implementations of the same prompt across separate 
 
 ## Diff / Review Panel
 
-Press `Cmd+Alt+D` to toggle the diff panel. It shows a live-updating diff between the worktree and its parent branch.
+Press `Cmd+D` to toggle the diff panel. It shows a live-updating diff between the worktree and its parent branch.
 
 - Select files and click **Apply to Main Branch** to merge changes
 - Conflicts are surfaced with a resolution dialog
@@ -71,11 +71,11 @@ Press `Cmd+Alt+D` to toggle the diff panel. It shows a live-updating diff betwee
 
 ## Terminals
 
-Each session has a dedicated integrated terminal. Press `Cmd+Alt+T` to focus the terminal for the active session.
+Each session has a dedicated integrated terminal. Press `Cmd+/` to focus the terminal for the active session.
 
 ## Setup Scripts
 
-Place an executable script at `.kilo/setup-script` in your project root. It runs automatically whenever a new worktree is created (useful for `npm install`, env setup, etc.). `.env` files are also auto-copied from the main repo.
+Place an executable script at `.kilo/setup-script` in your project root. It runs automatically whenever a new worktree is created (useful for `npm install`, env setup, etc.).
 
 ## Session State and Persistence
 
@@ -83,26 +83,26 @@ Agent Manager state is persisted in `.kilo/agent-manager.json`. Sessions, worktr
 
 ## Keyboard Shortcuts (Agent Manager Panel)
 
-| Shortcut          | Action                            |
-| ----------------- | --------------------------------- |
-| `Cmd+Shift+M`     | Open Agent Manager                |
-| `Cmd+Shift+W`     | New worktree                      |
-| `Cmd+Shift+O`     | Import/open worktree              |
-| `Cmd+Shift+X`     | Close current worktree            |
-| `Cmd+N`           | New tab (session) in worktree     |
-| `Cmd+W`           | Close current tab                 |
-| `Cmd+Alt+[` / `]` | Previous / next worktree          |
-| `Cmd+Alt+,` / `.` | Previous / next tab in worktree   |
-| `Cmd+Alt+T`       | Show terminal for current session |
-| `Cmd+Alt+D`       | Toggle diff panel                 |
-| `Cmd+Alt+?`       | Show keyboard shortcuts           |
-| `Cmd+1` … `Cmd+9` | Jump to worktree/session by index |
+| Shortcut (macOS)         | Action                            |
+| ------------------------ | --------------------------------- |
+| `Cmd+Shift+M`            | Open Agent Manager                |
+| `Cmd+N`                  | New worktree                      |
+| `Cmd+Shift+N`            | New worktree (advanced options)   |
+| `Cmd+Shift+O`            | Import/open worktree              |
+| `Cmd+Shift+W`            | Close current worktree            |
+| `Cmd+T`                  | New tab (session) in worktree     |
+| `Cmd+W`                  | Close current tab                 |
+| `Cmd+Alt+Up` / `Down`    | Previous / next worktree          |
+| `Cmd+Alt+Left` / `Right` | Previous / next tab in worktree   |
+| `Cmd+/`                  | Show terminal for current session |
+| `Cmd+D`                  | Toggle diff panel                 |
+| `Cmd+Shift+/`            | Show keyboard shortcuts           |
+| `Cmd+1` … `Cmd+9`        | Jump to worktree/session by index |
 
 ## Troubleshooting
 
 - **"Please open a folder…" error** — the Agent Manager requires a VS Code workspace folder
-- **"Cannot use parallel mode from within a git worktree"** — open the main repository (where `.git` is a directory), not a worktree checkout
-- **Worktree creation fails** — ensure Git is installed and the workspace is a valid git repository
+- **Worktree creation fails** — ensure Git is installed and the workspace is a valid git repository. Open the main repository (where `.git` is a directory), not an existing worktree checkout.
 
 {% /tab %}
 {% tab label="VSCode (Legacy)" %}

--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -33,7 +33,7 @@ Each Agent Manager session runs in an isolated git worktree on a separate branch
 
 ### Creating a New Worktree Session
 
-1. Click **New Worktree** or press `Cmd+N` to create a new worktree
+1. Click **New Worktree** or press `Cmd+N` (macOS) / `Ctrl+N` (Windows/Linux) to create a new worktree
 2. Enter a branch name (or let Kilo generate one)
 3. Type your first message to start the agent
 
@@ -63,7 +63,7 @@ You can run up to 4 parallel implementations of the same prompt across separate 
 
 ## Diff / Review Panel
 
-Press `Cmd+D` to toggle the diff panel. It shows a live-updating diff between the worktree and its parent branch.
+Press `Cmd+D` (macOS) / `Ctrl+D` (Windows/Linux) to toggle the diff panel. It shows a live-updating diff between the worktree and its parent branch.
 
 - Select files and click **Apply to Main Branch** to merge changes
 - Conflicts are surfaced with a resolution dialog
@@ -71,7 +71,7 @@ Press `Cmd+D` to toggle the diff panel. It shows a live-updating diff between th
 
 ## Terminals
 
-Each session has a dedicated integrated terminal. Press `Cmd+/` to focus the terminal for the active session.
+Each session has a dedicated integrated terminal. Press `Cmd+/` (macOS) / `Ctrl+/` (Windows/Linux) to focus the terminal for the active session.
 
 ## Setup Scripts
 
@@ -83,21 +83,21 @@ Agent Manager state is persisted in `.kilo/agent-manager.json`. Sessions, worktr
 
 ## Keyboard Shortcuts (Agent Manager Panel)
 
-| Shortcut (macOS)         | Action                            |
-| ------------------------ | --------------------------------- |
-| `Cmd+Shift+M`            | Open Agent Manager                |
-| `Cmd+N`                  | New worktree                      |
-| `Cmd+Shift+N`            | New worktree (advanced options)   |
-| `Cmd+Shift+O`            | Import/open worktree              |
-| `Cmd+Shift+W`            | Close current worktree            |
-| `Cmd+T`                  | New tab (session) in worktree     |
-| `Cmd+W`                  | Close current tab                 |
-| `Cmd+Alt+Up` / `Down`    | Previous / next worktree          |
-| `Cmd+Alt+Left` / `Right` | Previous / next tab in worktree   |
-| `Cmd+/`                  | Show terminal for current session |
-| `Cmd+D`                  | Toggle diff panel                 |
-| `Cmd+Shift+/`            | Show keyboard shortcuts           |
-| `Cmd+1` … `Cmd+9`        | Jump to worktree/session by index |
+| Shortcut (macOS)         | Shortcut (Windows/Linux)  | Action                            |
+| ------------------------ | ------------------------- | --------------------------------- |
+| `Cmd+Shift+M`            | `Ctrl+Shift+M`            | Open Agent Manager                |
+| `Cmd+N`                  | `Ctrl+N`                  | New worktree                      |
+| `Cmd+Shift+N`            | `Ctrl+Shift+N`            | New worktree (advanced options)   |
+| `Cmd+Shift+O`            | `Ctrl+Shift+O`            | Import/open worktree              |
+| `Cmd+Shift+W`            | `Ctrl+Shift+W`            | Close current worktree            |
+| `Cmd+T`                  | `Ctrl+T`                  | New tab (session) in worktree     |
+| `Cmd+W`                  | `Ctrl+W`                  | Close current tab                 |
+| `Cmd+Alt+Up` / `Down`    | `Ctrl+Alt+Up` / `Down`    | Previous / next worktree          |
+| `Cmd+Alt+Left` / `Right` | `Ctrl+Alt+Left` / `Right` | Previous / next tab in worktree   |
+| `Cmd+/`                  | `Ctrl+/`                  | Show terminal for current session |
+| `Cmd+D`                  | `Ctrl+D`                  | Toggle diff panel                 |
+| `Cmd+Shift+/`            | `Ctrl+Shift+/`            | Show keyboard shortcuts           |
+| `Cmd+1` … `Cmd+9`        | `Ctrl+1` … `Ctrl+9`       | Jump to worktree/session by index |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Fix 8 of 12 keyboard shortcuts in the Agent Manager docs table — validated against `package.json` keybinding definitions
- Fix 3 body text references to wrong shortcuts
- Remove false `.env` auto-copy claim (it's a commented-out example in the setup script template)
- Remove non-existent error message from troubleshooting

## Keyboard Shortcut Corrections

| Docs (before) | Actual binding | Action |
|---|---|---|
| `Cmd+Shift+W` | `Cmd+N` | New worktree |
| `Cmd+Shift+X` | `Cmd+Shift+W` | Close worktree |
| `Cmd+N` | `Cmd+T` | New tab |
| `Cmd+Alt+[` / `]` | `Cmd+Alt+Up` / `Down` | Prev/next worktree |
| `Cmd+Alt+,` / `.` | `Cmd+Alt+Left` / `Right` | Prev/next tab |
| `Cmd+Alt+T` | `Cmd+/` | Show terminal |
| `Cmd+Alt+D` | `Cmd+D` | Toggle diff |
| `Cmd+Alt+?` | `Cmd+Shift+/` | Show shortcuts |

Also added missing: `Cmd+Shift+N` (advanced worktree), `Cmd+T` (new tab).

Found during validation of platform tabs PRs (#7510).