### PR TITLE
Implement KaTeX rendering for LaTeX and math blocks

### DIFF
--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -443,6 +443,13 @@ async function highlightCodeBlocks(html: string): Promise<string> {
       .replace(/&quot;/g, '"')
       .replace(/&#39;/g, "'")
 
+    // Render latex/math/tex blocks with KaTeX as display math
+    if (lang === "latex" || lang === "math" || lang === "tex") {
+      const rendered = katex.renderToString(code, { displayMode: true, throwOnError: false })
+      result = result.replace(fullMatch, () => rendered)
+      continue
+    }
+
     let language = lang || "text"
     if (!(language in bundledLanguages)) {
       language = "text"
@@ -646,6 +653,11 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
             return `<code>${escaped}</code>`
           },
           code({ text, lang }) {
+            // Render latex/math/tex fenced code blocks with KaTeX as display math
+            // instead of as a syntax-highlighted code block.
+            if (lang === "latex" || lang === "math" || lang === "tex") {
+              return katex.renderToString(text, { displayMode: true, throwOnError: false })
+            }
             const escaped = text
               .replace(/&/g, "&amp;")
               .replace(/</g, "&lt;")


### PR DESCRIPTION
**Added support for rendering LaTeX, math, and TeX blocks using KaTeX in both inline and fenced code.**

## Context

Fenced code blocks with language tags `latex`, `math`, or `tex` were previously rendered as plain syntax-highlighted code blocks, making mathematical notation unreadable. This change intercepts those blocks and renders them as proper display-mode math using KaTeX.

## Implementation

Two code paths handle this fix:

1. **JS parser path** (`code()` renderer in `marked` config, `packages/ui/src/context/marked.tsx:658`): When a fenced code block has `lang === "latex" || "math" || "tex"`, it short-circuits before the normal escaped/highlighted code path and returns `katex.renderToString(text, { displayMode: true })` directly.

2. **Native parser path** (`highlightCodeBlocks()`, `packages/ui/src/context/marked.tsx:447`): The same guard is applied before the Shiki highlighting loop — matching blocks are replaced with KaTeX-rendered HTML and skipped via `continue`.

Inline and `$$`-delimited display math were already handled by the existing `renderMathInText` / `markedKatex` integration. This change closes the gap for fenced code blocks explicitly tagged as math languages.

No refactoring of surrounding logic was needed; both insertions are isolated early-return guards.

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

- Start a chat and ask the model to show the quadratic formula using a fenced `latex` code block: