### PR TITLE
fix(cli): restore agent picker labels

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -265,7 +265,7 @@ export namespace Agent {
       },
       orchestrator: {
         name: "orchestrator",
-        description: "Deprecated. Coordinate complex tasks by delegating to specialized agents in parallel.",
+        description: "Coordinate complex tasks by delegating to specialized agents in parallel.",
         prompt: PROMPT_ORCHESTRATOR,
         options: {},
         permission: PermissionNext.merge(

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -13,8 +13,7 @@ export function DialogAgent() {
         value: item.name,
         title: item.displayName ?? item.name, // kilocode_change
         description:
-          [item.deprecated && "deprecated", item.native && "native", item.description].filter(Boolean).join(", ") ||
-          undefined,
+          [item.deprecated && "deprecated", item.native && "native"].filter(Boolean).join(", ") || item.description,
       }
     }),
   )


### PR DESCRIPTION
## Why

The recent agent update made the picker show extra text that did not belong there. It also showed \"deprecated\" twice for the orchestrator, which made the warning look broken.

## What changed

This follow-up to #7888 puts the agent picker back to the old behavior for built-in agents, so it shows short labels instead of long extra text. It also keeps the deprecation warning in one place instead of saying it twice. The picker still warns people that the orchestrator is old, but the message is easier to read. This makes the list clearer and avoids mixed signals.

## How to test

1. Run `bun dev` from the repo root.
2. Open the agent picker in the CLI and check a built-in agent like `code` or `debug`; it should show `native` and not add the full description.
3. Check `orchestrator`; it should show `deprecated, native` once and not repeat `Deprecated.` in the text.