### PR TITLE
fix(vscode): fix bun run extension on Windows

### DIFF
--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -323,7 +323,6 @@ async function launch() {
     detached: !win,
     env: process.env,
     stdio: "ignore",
-    ...(win ? { shell: true } : {}),
   })
   child.unref()
 

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -156,7 +156,16 @@ function detect(): string {
   }
 
   const found = candidates.find((c) => existsSync(c))
-  if (found) return found
+  if (found) {
+    // On Windows, Code.exe is the raw Electron binary and cannot be launched directly
+    // with folder/extension args — use the bin/code.cmd (or code-insiders.cmd) wrapper instead.
+    if (win) {
+      const cmd = found.toLowerCase().includes("insiders") ? "code-insiders.cmd" : "code.cmd"
+      const wrapper = join(found, "..", "bin", cmd)
+      if (existsSync(wrapper)) return wrapper
+    }
+    return found
+  }
 
   // Last resort: PATH lookup
   const path = insiders ? (which("code-insiders") ?? which("code")) : (which("code") ?? which("code-insiders"))
@@ -309,7 +318,9 @@ async function launch() {
   console.log(`[launch] State:      ${base}`)
 
   if (blocking) {
-    const result = Bun.spawnSync([app, ...args], {
+    // On Windows, .cmd files cannot be executed directly — invoke via cmd.exe /c.
+    const cmd = win && app.endsWith(".cmd") ? ["cmd.exe", "/c", app, ...args] : [app, ...args]
+    const result = Bun.spawnSync(cmd, {
       cwd: workspace,
       env: process.env,
       stdio: ["ignore", "inherit", "inherit"],
@@ -318,12 +329,17 @@ async function launch() {
     return
   }
 
-  const child = spawn(app, args, {
+  // On Windows, .cmd files require shell:true. Quote all args so cmd.exe
+  // handles paths with spaces correctly.
+  const spawnArgs = win ? args.map((a) => (a.includes(" ") ? `"${a}"` : a)) : args
+  const child = spawn(win ? `"${app}"` : app, spawnArgs, {
     cwd: workspace,
     detached: !win,
     env: process.env,
     stdio: "ignore",
+    ...(win ? { shell: true } : {}),
   })
+
   child.unref()
 
   console.log(`[launch] VS Code launched (pid ${child.pid})`)

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -117,6 +117,15 @@ function wrapper(app: string): string {
   return app
 }
 
+function quote(arg: string): string {
+  return `"${arg.replaceAll('"', '""')}"`
+}
+
+function command(app: string, args: string[]) {
+  if (!batch(app)) return { file: app, args }
+  return { file: "cmd.exe", args: ["/d", "/s", "/c", [app, ...args].map(quote).join(" ")] }
+}
+
 function detect(): string {
   const env = explicit ?? process.env["VSCODE_EXEC_PATH"]
   if (env && existsSync(env)) return wrapper(env)
@@ -322,23 +331,23 @@ async function launch() {
   console.log(`[launch] Workspace:  ${workspace}`)
   console.log(`[launch] State:      ${base}`)
 
+  const cmd = command(app, args)
+
   if (blocking) {
-    const result = Bun.spawnSync([app, ...args], {
+    const result = Bun.spawnSync([cmd.file, ...cmd.args], {
       cwd: workspace,
       env: process.env,
       stdio: ["ignore", "inherit", "inherit"],
-      ...(batch(app) ? { shell: true } : {}),
     })
     console.log(`[launch] VS Code exited (code ${result.exitCode})`)
     return
   }
 
-  const child = spawn(app, args, {
+  const child = spawn(cmd.file, cmd.args, {
     cwd: workspace,
     detached: !win,
     env: process.env,
     stdio: "ignore",
-    ...(batch(app) ? { shell: true } : {}),
   })
 
   child.unref()

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -103,9 +103,23 @@ function which(name: string): string | null {
   return null
 }
 
+function batch(path: string): boolean {
+  return win && /\.(cmd|bat)$/i.test(path)
+}
+
+function wrapper(app: string): string {
+  if (!win || batch(app)) return app
+  const lower = app.toLowerCase()
+  if (!lower.endsWith(".exe")) return app
+  const cmd = lower.includes("insiders") ? "code-insiders.cmd" : "code.cmd"
+  const file = join(app, "..", "bin", cmd)
+  if (existsSync(file)) return file
+  return app
+}
+
 function detect(): string {
   const env = explicit ?? process.env["VSCODE_EXEC_PATH"]
-  if (env && existsSync(env)) return env
+  if (env && existsSync(env)) return wrapper(env)
 
   const candidates: string[] = []
   const prefer = insiders ? "insiders" : "stable"
@@ -156,16 +170,7 @@ function detect(): string {
   }
 
   const found = candidates.find((c) => existsSync(c))
-  if (found) {
-    // On Windows, Code.exe is the raw Electron binary and cannot be launched directly
-    // with folder/extension args — use the bin/code.cmd (or code-insiders.cmd) wrapper instead.
-    if (win) {
-      const cmd = found.toLowerCase().includes("insiders") ? "code-insiders.cmd" : "code.cmd"
-      const wrapper = join(found, "..", "bin", cmd)
-      if (existsSync(wrapper)) return wrapper
-    }
-    return found
-  }
+  if (found) return wrapper(found)
 
   // Last resort: PATH lookup
   const path = insiders ? (which("code-insiders") ?? which("code")) : (which("code") ?? which("code-insiders"))
@@ -318,26 +323,22 @@ async function launch() {
   console.log(`[launch] State:      ${base}`)
 
   if (blocking) {
-    // On Windows, .cmd files cannot be executed directly — invoke via cmd.exe /c.
-    const cmd = win && app.endsWith(".cmd") ? ["cmd.exe", "/c", app, ...args] : [app, ...args]
-    const result = Bun.spawnSync(cmd, {
+    const result = Bun.spawnSync([app, ...args], {
       cwd: workspace,
       env: process.env,
       stdio: ["ignore", "inherit", "inherit"],
+      ...(batch(app) ? { shell: true } : {}),
     })
     console.log(`[launch] VS Code exited (code ${result.exitCode})`)
     return
   }
 
-  // On Windows, .cmd files require shell:true. Quote all args so cmd.exe
-  // handles paths with spaces correctly.
-  const spawnArgs = win ? args.map((a) => (a.includes(" ") ? `"${a}"` : a)) : args
-  const child = spawn(win ? `"${app}"` : app, spawnArgs, {
+  const child = spawn(app, args, {
     cwd: workspace,
     detached: !win,
     env: process.env,
     stdio: "ignore",
-    ...(win ? { shell: true } : {}),
+    ...(batch(app) ? { shell: true } : {}),
   })
 
   child.unref()

--- a/packages/kilo-vscode/script/local-bin.ts
+++ b/packages/kilo-vscode/script/local-bin.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { $ } from "bun"
 import { join, relative, dirname, basename } from "node:path"
-import { chmodSync, statSync, rmSync, readdirSync, existsSync } from "node:fs"
+import { chmodSync, statSync, rmSync, readdirSync, existsSync, mkdirSync, copyFileSync } from "node:fs"
 
 const forceRebuild = process.argv.includes("--force")
 
@@ -175,8 +175,8 @@ async function main() {
   }
 
   const sourceBinPath = await ensureBuiltBinary()
-  await $`mkdir -p ${targetBinDir}`
-  await $`cp ${sourceBinPath} ${targetBinPath}`
+  mkdirSync(targetBinDir, { recursive: true })
+  copyFileSync(sourceBinPath, targetBinPath)
   chmodSync(targetBinPath, 0o755)
 
   // Record the CLI source version so future runs detect when a rebuild is needed


### PR DESCRIPTION
## Summary

- Replace Unix-only shell commands `mkdir -p` and `cp` in `local-bin.ts` with cross-platform Node.js `mkdirSync` and `copyFileSync`
- These commands fail on Windows causing `bun run extension` to error out when copying the CLI binary

## Root Cause

`packages/kilo-vscode/script/local-bin.ts` used `$ \`mkdir -p ...\`` and `$ \`cp ...\`` via Bun's shell (`$`). On Windows, these Unix commands are not available in the default shell, so they fail when the script attempts to create the `bin/` directory and copy the built CLI binary into it.