### PR TITLE
fix(vscode): forward session.created SSE events through pre-filter

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -969,9 +969,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           // KiloProvider instance. The Settings panel is a separate provider with no tracked
           // sessions, but it needs session.status to populate sessionStatusMap and allStatusMap
           // for the busy-session warning on Save.
-          // session.created must also pass through so new sessions (created externally or via
-          // SSE before trackedSessionIds is populated) can reach handleEvent and be registered.
-          if (event.type === "session.status" || event.type === "session.created") return true
+          // session.created and session.updated must also pass through so session metadata
+          // (title, timestamps) stays current in the session list even for sessions not yet
+          // or no longer in trackedSessionIds. The isEventFromForeignProject check in
+          // handleEvent filters cross-project events.
+          if (event.type === "session.status" || event.type === "session.created" || event.type === "session.updated")
+            return true
 
           return this.trackedSessionIds.has(sessionId)
         },
@@ -2518,10 +2521,15 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (!sessionID && (event.type === "message.part.updated" || event.type === "message.part.delta")) {
       return
     }
-    // session.created is exempt: the new session's ID is not yet in trackedSessionIds, but we
-    // need to forward it so the webview session list is updated. The tracking side-effect below
-    // (lines ~2548-2551) will add it to trackedSessionIds when appropriate.
-    if (sessionID && !this.trackedSessionIds.has(sessionID) && event.type !== "session.created") {
+    // session.created and session.updated are exempt: the session's ID may not be in
+    // trackedSessionIds yet (new session) or at all (externally created session), but we
+    // need to forward them so the webview session list stays current with titles/timestamps.
+    if (
+      sessionID &&
+      !this.trackedSessionIds.has(sessionID) &&
+      event.type !== "session.created" &&
+      event.type !== "session.updated"
+    ) {
       return
     }
 

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -969,7 +969,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           // KiloProvider instance. The Settings panel is a separate provider with no tracked
           // sessions, but it needs session.status to populate sessionStatusMap and allStatusMap
           // for the busy-session warning on Save.
-          if (event.type === "session.status") return true
+          // session.created must also pass through so new sessions (created externally or via
+          // SSE before trackedSessionIds is populated) can reach handleEvent and be registered.
+          if (event.type === "session.status" || event.type === "session.created") return true
 
           return this.trackedSessionIds.has(sessionId)
         },
@@ -2516,7 +2518,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (!sessionID && (event.type === "message.part.updated" || event.type === "message.part.delta")) {
       return
     }
-    if (sessionID && !this.trackedSessionIds.has(sessionID)) {
+    // session.created is exempt: the new session's ID is not yet in trackedSessionIds, but we
+    // need to forward it so the webview session list is updated. The tracking side-effect below
+    // (lines ~2548-2551) will add it to trackedSessionIds when appropriate.
+    if (sessionID && !this.trackedSessionIds.has(sessionID) && event.type !== "session.created") {
       return
     }
 

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -308,6 +308,13 @@ export const SessionProvider: ParentComponent = (props) => {
   // Prevents handleMessagesLoaded from wiping them when it replaces the array.
   const pendingOptimistic = new Map<string, Set<string>>()
 
+  // Session IDs received via handleSessionCreated that haven't yet been
+  // confirmed by a loadSessions response. Guards against the race where
+  // a session is created after the loadSessions HTTP request is sent but
+  // before the response arrives — without this, handleSessionsLoaded
+  // would delete the newly-created session from the store.
+  const pending = new Set<string>()
+
   // Store for sessions, messages, parts, todos, modelSelections, agentSelections
   const [store, setStore] = createStore<SessionStore>({
     sessions: {},
@@ -708,6 +715,7 @@ export const SessionProvider: ParentComponent = (props) => {
 
   // Event handlers
   function handleSessionCreated(session: SessionInfo) {
+    pending.add(session.id)
     batch(() => {
       setStore("sessions", session.id, session)
 
@@ -1038,11 +1046,9 @@ export const SessionProvider: ParentComponent = (props) => {
     batch(() => {
       // Reconcile: remove sessions not in the loaded list to prevent stale
       // entries from other projects accumulating in the store.
-      // However, preserve sessions that have a messages entry — these were
-      // added via sessionCreated (locally active) and may have been created
-      // after this loadSessions request was sent. Deleting them would cause
-      // a race where the server hadn't persisted the session yet when the
-      // HTTP list response arrived, wiping a session the user just created.
+      // Preserve sessions in `pending` — these arrived via sessionCreated
+      // after the loadSessions request was sent and may not be in the
+      // server's response yet. Any other stale session is removed.
       const ids = new Set(loaded.map((s) => s.id))
       setStore(
         "sessions",
@@ -1050,11 +1056,13 @@ export const SessionProvider: ParentComponent = (props) => {
           for (const id of Object.keys(sessions)) {
             if (id.startsWith("cloud:")) continue
             if (ids.has(id)) continue
-            if (store.messages[id] !== undefined) continue
+            if (pending.has(id)) continue
             delete sessions[id]
           }
         }),
       )
+      // Sessions confirmed by the server are no longer pending
+      for (const id of ids) pending.delete(id)
       for (const s of loaded) {
         setStore("sessions", s.id, s)
       }

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1038,13 +1038,20 @@ export const SessionProvider: ParentComponent = (props) => {
     batch(() => {
       // Reconcile: remove sessions not in the loaded list to prevent stale
       // entries from other projects accumulating in the store.
+      // However, preserve sessions that have a messages entry — these were
+      // added via sessionCreated (locally active) and may have been created
+      // after this loadSessions request was sent. Deleting them would cause
+      // a race where the server hadn't persisted the session yet when the
+      // HTTP list response arrived, wiping a session the user just created.
       const ids = new Set(loaded.map((s) => s.id))
       setStore(
         "sessions",
         produce((sessions) => {
           for (const id of Object.keys(sessions)) {
             if (id.startsWith("cloud:")) continue
-            if (!ids.has(id)) delete sessions[id]
+            if (ids.has(id)) continue
+            if (store.messages[id] !== undefined) continue
+            delete sessions[id]
           }
         }),
       )


### PR DESCRIPTION
## Summary

- New sessions were never appearing in the session list due to two separate bugs that were both present

## Bug 1: session.created SSE events dropped by pre-filter (KiloProvider.ts)

`session.created` events were silently blocked by two `trackedSessionIds` guards — a new session's ID is not yet tracked when the event arrives, creating a chicken-and-egg deadlock:

1. **`onEventFiltered` pre-filter** (~line 974): checked `trackedSessionIds.has(sessionId)` for all session-scoped events → event dropped before reaching `handleEvent`
2. **`handleEvent` guard** (~line 2524): a second `trackedSessionIds.has(sessionID)` check would also drop the event

Sessions created via the UI button appeared to work only because that path bypasses SSE entirely (direct HTTP + `postMessage`); any session created externally was invisible.

**Fix:** Add `session.created` as an exemption in both guards, mirroring how `session.status` is already exempted. The existing `isEventFromForeignProject` check in `handleEvent` continues to filter cross-project sessions correctly.

## Bug 2: handleSessionsLoaded reconciliation race condition (session.tsx)

When the webview first loads with an empty session store, `MessageList.tsx` calls `loadSessions`. If the user sends a message quickly, `sessionCreated` adds the new session to `store.sessions`. But when the `loadSessions` HTTP response arrives with an empty list (the session wasn't persisted on the server yet when the request was sent), `handleSessionsLoaded` deleted the session from the store — leaving the session list empty until the user opened the history panel (explaining the "appeared a minute later" observation).

**Fix:** Skip deletion of any session that has a `messages` entry in the store. Sessions added via `handleSessionCreated` always initialize `store.messages[id]`, reliably identifying locally-active sessions created after the load request was sent.