### PR TITLE
chore: enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Enforce LF line endings for all text files
+* text=auto eol=lf
+
 # Git LFS tracking for binary/media files
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.mp4 filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary

- Adds `* text=auto eol=lf` to `.gitattributes` to enforce LF line endings for all text files repo-wide
- Eliminates the CRLF conversion warnings Git shows on Windows when `core.autocrlf=true`