### PR TITLE
feat(agent-manager): add GitHub PR status badge to worktree sidebar

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -8,6 +8,7 @@ import { WorktreeManager, type CreateWorktreeResult } from "./WorktreeManager"
 import { WorktreeStateManager, remoteRef } from "./WorktreeStateManager"
 import { chooseBaseBranch, normalizeBaseBranch } from "./base-branch"
 import { GitStatsPoller, type WorktreePresenceResult } from "./GitStatsPoller"
+import { PRStatusBridge } from "./pr-status-bridge"
 import { GitOps, type ApplyConflict } from "./GitOps"
 import { versionedName } from "./branch-name"
 import { normalizePath, classifyWorktreeError } from "./git-import"
@@ -53,6 +54,7 @@ export class AgentManagerProvider implements Disposable {
   private diffSessionId: string | undefined
   private lastDiffHash: string | undefined
   private statsPoller: GitStatsPoller
+  private prBridge!: PRStatusBridge
   private gitOps: GitOps
   private cachedDiffTarget: { sessionId: string; directory: string; baseBranch: string } | undefined
   private staleWorktreeIds = new Set<string>()
@@ -93,6 +95,15 @@ export class AgentManagerProvider implements Disposable {
       },
       log: (...args) => this.log(...args),
       git: this.gitOps,
+    })
+    this.prBridge = PRStatusBridge.create({
+      getWorktrees: () => this.state?.getWorktrees() ?? [],
+      getWorkspaceRoot: () => this.getRoot(),
+      postToWebview: (m) => this.postToWebview(m),
+      updateWorktreePR: (id, n, u, s) => this.state?.updateWorktreePR(id, n, u, s),
+      hasPersistedPR: (id: string) => !!this.state?.getWorktree(id)?.prNumber,
+      openExternal: (u) => this.host.openExternal(u),
+      log: (...a) => this.log(...a),
     })
   }
 
@@ -147,13 +158,14 @@ export class AgentManagerProvider implements Disposable {
     this.stateReady = this.initializeState()
     void this.sendRepoInfo()
     this.sendKeybindings()
-
+    this.prBridge.attachPanel(ctx)
     ctx.onDidDispose(() => {
       // Only clear if this is still the active panel — a newer panel may
       // have already replaced us via attachPanel.
       if (this.panel === ctx) {
         this.log("Panel disposed")
         this.statsPoller.stop()
+        this.prBridge.poller.stop()
         this.stopDiffPolling()
         this.panel = undefined
       }
@@ -209,6 +221,7 @@ export class AgentManagerProvider implements Disposable {
   // ---------------------------------------------------------------------------
 
   private async onMessage(msg: Record<string, unknown>): Promise<Record<string, unknown> | null> {
+    if (this.prBridge.handleMessage(msg)) return null
     const m = msg as unknown as AgentManagerInMessage
 
     if (m.type === "agentManager.createWorktree") {
@@ -292,6 +305,7 @@ export class AgentManagerProvider implements Disposable {
           // already emitted before the webview was ready to receive messages.
           if (this.cachedWorktreeStats) this.postToWebview(this.cachedWorktreeStats)
           if (this.cachedLocalStats) this.postToWebview(this.cachedLocalStats)
+          this.prBridge.replay()
           // Refresh sessions after pushState so the webview's sessionsLoaded
           // handler is guaranteed to be registered (requestState fires from
           // onMount). Without this, the initial refreshSessions() in
@@ -408,6 +422,7 @@ export class AgentManagerProvider implements Disposable {
     if (m.type === "loadMessages") {
       this.activeSessionId = m.sessionID
       this.terminalManager.syncOnSessionSwitch(m.sessionID)
+      this.prBridge.poller.setActiveWorktreeId(this.state?.getSession(m.sessionID)?.worktreeId ?? undefined)
     }
 
     // After clearSession, clear active tracking and re-register worktree sessions
@@ -671,6 +686,7 @@ export class AgentManagerProvider implements Disposable {
     }
     // Remove from state BEFORE disk removal so pollers immediately stop targeting this worktree.
     this.statsPoller.skipWorktree(worktreeId)
+    this.prBridge.remove(worktreeId)
     const orphaned = state.removeWorktree(worktreeId)
     if (shouldStopDiffPolling(worktree.path, orphaned, this.cachedDiffTarget, this.diffSessionId)) {
       this.stopDiffPolling()
@@ -1474,6 +1490,7 @@ export class AgentManagerProvider implements Disposable {
     })
 
     this.statsPoller.setEnabled(worktrees.length > 0 || this.panel !== undefined)
+    this.prBridge.poller.setEnabled(worktrees.length > 0)
   }
 
   /** Push empty state when the folder is not a git repo or has no folder open. */
@@ -1893,6 +1910,7 @@ export class AgentManagerProvider implements Disposable {
   public dispose(): void {
     this.stopDiffPolling()
     this.statsPoller.stop()
+    this.prBridge.poller.stop()
     this.terminalManager.dispose()
     this.panel?.dispose()
     this.outputChannel.dispose()

--- a/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
@@ -1,0 +1,486 @@
+import type { Worktree } from "./WorktreeStateManager"
+import type { PRStatus, PRCheck, PRComment, CheckStatus, AggregateCheckStatus, PRState, ReviewDecision } from "./types"
+import { execWithShellEnv } from "./shell-env"
+import { classifyPRError } from "./git-import"
+
+interface PRStatusPollerOptions {
+  getWorktrees: () => Worktree[]
+  getWorkspaceRoot: () => string | undefined
+  onStatus: (worktreeId: string, pr: PRStatus | null, error?: "gh_missing" | "gh_auth" | "fetch_failed") => void
+  log: (...args: unknown[]) => void
+  intervalMs?: number
+}
+
+const GH_PROBE_TTL = 300_000 // 5 minutes — gh installation state rarely changes at runtime
+const MAX_BACKOFF = 120_000 // 2 minutes — cap for exponential backoff on repeated errors
+const BACKOFF_MULTIPLIER = 2
+
+export class PRStatusPoller {
+  private timer: ReturnType<typeof setTimeout> | undefined
+  private active = false
+  private visible = true
+  private busy = false
+  private lastHash = new Map<string, string>()
+  private lastError: string | undefined // tracks global error state for de-duplication
+  private failures = 0 // consecutive failure count for backoff
+  private ghAvailable: boolean | undefined
+  private ghProbeTime = 0
+  private activeWorktreeId: string | undefined
+  private cachedRepo: { owner: string; name: string; cwd: string } | undefined
+  private readonly intervalMs: number
+
+  constructor(private readonly options: PRStatusPollerOptions) {
+    this.intervalMs = options.intervalMs ?? 15_000
+  }
+
+  setEnabled(enabled: boolean): void {
+    if (enabled) {
+      if (this.active) return
+      this.start()
+      return
+    }
+    this.stop()
+  }
+
+  /** Pause/resume polling based on panel visibility. */
+  setVisible(visible: boolean): void {
+    if (this.visible === visible) return
+    this.visible = visible
+    if (!this.active) return
+    if (visible) {
+      // Resume — poll immediately then schedule normally
+      if (this.timer) clearTimeout(this.timer)
+      this.timer = undefined
+      void this.poll()
+      return
+    }
+    // Pause — cancel pending timer
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+    }
+  }
+
+  stop(): void {
+    this.active = false
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+    }
+    this.busy = false
+    this.lastHash.clear()
+    this.lastError = undefined
+    this.failures = 0
+    this.ghAvailable = undefined
+    this.ghProbeTime = 0
+    this.cachedRepo = undefined
+  }
+
+  /** Force-refresh a specific worktree immediately. */
+  refresh(worktreeId: string): void {
+    if (!this.active) return
+    void this.fetchOne(worktreeId)
+  }
+
+  setActiveWorktreeId(id: string | undefined): void {
+    this.activeWorktreeId = id
+  }
+
+  private start(): void {
+    this.stop()
+    this.active = true
+    // Don't override this.visible — it may already be set to false by
+    // setVisible() before setEnabled(true) is called.
+    void this.poll()
+  }
+
+  private nextDelay(): number {
+    if (this.failures === 0) return this.intervalMs
+    return Math.min(this.intervalMs * Math.pow(BACKOFF_MULTIPLIER, this.failures), MAX_BACKOFF)
+  }
+
+  private schedule(): void {
+    if (!this.active || !this.visible) return
+    const delay = this.nextDelay()
+    this.timer = setTimeout(() => {
+      void this.poll()
+    }, delay)
+  }
+
+  private poll(): Promise<void> {
+    if (!this.active || !this.visible) return Promise.resolve()
+    if (this.busy) return Promise.resolve()
+    this.busy = true
+    return this.fetchAll().finally(() => {
+      this.busy = false
+      this.schedule()
+    })
+  }
+
+  private async probeGh(): Promise<boolean> {
+    const now = Date.now()
+    if (this.ghAvailable !== undefined && now - this.ghProbeTime < GH_PROBE_TTL) {
+      return this.ghAvailable
+    }
+    try {
+      await execWithShellEnv("gh", ["--version"], { timeout: 5_000 })
+      this.ghAvailable = true
+    } catch {
+      this.ghAvailable = false
+    }
+    this.ghProbeTime = Date.now()
+    return this.ghAvailable
+  }
+
+  private async fetchAll(): Promise<void> {
+    if (!(await this.probeGh())) {
+      // De-duplicate: only emit gh_missing once, not every poll cycle
+      if (this.lastError !== "gh_missing") {
+        this.lastError = "gh_missing"
+        for (const wt of this.options.getWorktrees()) {
+          this.options.onStatus(wt.id, null, "gh_missing")
+        }
+      }
+      this.failures++
+      return
+    }
+
+    this.lastError = undefined
+    const worktrees = this.options.getWorktrees()
+    const results = await Promise.allSettled(worktrees.map((wt) => this.fetchOne(wt.id)))
+    const ok = results.every((r) => r.status === "fulfilled")
+    if (ok) {
+      this.failures = 0
+      return
+    }
+    this.failures++
+  }
+
+  private async fetchOne(worktreeId: string): Promise<void> {
+    const worktrees = this.options.getWorktrees()
+    const wt = worktrees.find((w) => w.id === worktreeId)
+    if (!wt) return
+
+    if (!this.options.getWorkspaceRoot()) return
+
+    try {
+      const pr = await this.fetchPRForBranch(wt.branch, wt.path)
+      if (!pr) {
+        const hash = `${worktreeId}:none`
+        if (this.lastHash.get(worktreeId) === hash) return
+        this.lastHash.set(worktreeId, hash)
+        this.options.onStatus(worktreeId, null)
+        return
+      }
+
+      const [checks, comments] = await Promise.all([
+        this.fetchChecks(pr.number, wt.path),
+        this.activeWorktreeId === worktreeId ? this.fetchComments(pr.number, wt.path) : undefined,
+      ])
+
+      const status: PRStatus = {
+        number: pr.number,
+        title: pr.title,
+        url: pr.url,
+        state: pr.state,
+        review: pr.review,
+        checks,
+        ...(comments && { comments }),
+        additions: pr.additions,
+        deletions: pr.deletions,
+        files: pr.files,
+      }
+
+      const hash = `${worktreeId}:${pr.number}:${pr.state}:${pr.review}:${checks.status}:${checks.passed}/${checks.total}:${comments?.total ?? ""}:${comments?.unresolved ?? ""}`
+      if (this.lastHash.get(worktreeId) === hash) return
+      this.lastHash.set(worktreeId, hash)
+
+      this.options.onStatus(worktreeId, status)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      const kind = classifyPRError(msg)
+      this.options.log(`PR fetch failed for ${wt.branch}:`, msg)
+
+      const errKey = kind === "gh_missing" ? "gh_missing" : kind === "gh_auth" ? "gh_auth" : "fetch_failed"
+      if (kind === "gh_missing") this.ghAvailable = false
+
+      // De-duplicate: only emit if the error state changed for this worktree
+      const hash = `${worktreeId}:error:${errKey}`
+      if (this.lastHash.get(worktreeId) !== hash) {
+        this.lastHash.set(worktreeId, hash)
+        this.options.onStatus(worktreeId, null, errKey)
+      }
+      throw err // propagate so fetchAll can track failures for backoff
+    }
+  }
+
+  private static readonly PR_JSON_FIELDS =
+    "number,title,url,state,isDraft,reviewDecision,additions,deletions,changedFiles,headRefName,headRefOid"
+
+  private async fetchPRForBranch(branch: string, cwd: string): Promise<PRResult | null> {
+    // Strategy 1: bare `gh pr view` — resolves via the branch's tracking ref.
+    // Works for fork PRs checked out with `gh pr checkout` (tracking ref = refs/pull/N/head).
+    // Strategy 2: `gh pr view <branch>` — works for same-repo branches pushed to origin.
+    // Strategy 3: `gh pr list --search "<sha>"` — last resort, finds PRs by HEAD commit SHA.
+    return (await this.ghPRView(cwd)) ?? (await this.ghPRView(cwd, branch)) ?? (await this.ghPRListBySHA(cwd))
+  }
+
+  /** Run `gh pr view [branch] --json ...` and parse the result, or return null. */
+  private async ghPRView(cwd: string, branch?: string): Promise<PRResult | null> {
+    try {
+      const args = ["pr", "view"]
+      if (branch) args.push(branch)
+      args.push("--json", PRStatusPoller.PR_JSON_FIELDS)
+
+      const { stdout } = await execWithShellEnv("gh", args, { cwd, timeout: 15_000 })
+      return parsePRResult(stdout)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg.includes("no pull requests found") || msg.includes("Could not resolve")) return null
+      throw err
+    }
+  }
+
+  /** Search for PRs containing the current HEAD SHA. Finds PRs when branch name/tracking ref don't match. */
+  private async ghPRListBySHA(cwd: string): Promise<PRResult | null> {
+    try {
+      const { stdout: sha } = await execWithShellEnv("git", ["rev-parse", "HEAD"], { cwd, timeout: 5_000 })
+      const head = sha.trim()
+      if (!head) return null
+
+      const { stdout } = await execWithShellEnv(
+        "gh",
+        [
+          "pr",
+          "list",
+          "--state",
+          "all",
+          "--search",
+          `${head} is:pr`,
+          "--limit",
+          "5",
+          "--json",
+          PRStatusPoller.PR_JSON_FIELDS,
+        ],
+        { cwd, timeout: 15_000 },
+      )
+      const items = JSON.parse(stdout) as unknown[]
+      if (!Array.isArray(items) || items.length === 0) return null
+
+      // Only accept PRs where headRefOid matches our HEAD exactly
+      for (const item of items) {
+        const data = item as Record<string, unknown>
+        if (data.headRefOid === head) return parsePRResult(JSON.stringify(data))
+      }
+      return null
+    } catch {
+      return null
+    }
+  }
+
+  private async fetchChecks(
+    prNumber: number,
+    cwd: string,
+  ): Promise<{
+    status: AggregateCheckStatus
+    total: number
+    passed: number
+    failed: number
+    pending: number
+    items: PRCheck[]
+  }> {
+    try {
+      const { stdout } = await execWithShellEnv(
+        "gh",
+        ["pr", "checks", String(prNumber), "--json", "name,state,link,startedAt,completedAt"],
+        { cwd, timeout: 15_000 },
+      )
+      const data = JSON.parse(stdout) as Array<{
+        name: string
+        state: string
+        link?: string
+        startedAt?: string
+        completedAt?: string
+      }>
+
+      const items: PRCheck[] = data.map((c) => ({
+        name: c.name,
+        status: mapCheckStatus(c.state),
+        url: c.link,
+        duration: formatCheckDuration(c.startedAt, c.completedAt),
+      }))
+
+      const total = items.length
+      const passed = items.filter((c) => c.status === "success").length
+      const failed = items.filter((c) => c.status === "failure").length
+      const pending = items.filter((c) => c.status === "pending").length
+
+      const status: AggregateCheckStatus =
+        total === 0 ? "none" : failed > 0 ? "failure" : pending > 0 ? "pending" : "success"
+
+      return { status, total, passed, failed, pending, items }
+    } catch {
+      return { status: "none", total: 0, passed: 0, failed: 0, pending: 0, items: [] }
+    }
+  }
+
+  private async getRepoInfo(cwd: string): Promise<{ owner: string; name: string }> {
+    if (this.cachedRepo && this.cachedRepo.cwd === cwd) {
+      return this.cachedRepo
+    }
+    const { stdout } = await execWithShellEnv("gh", ["repo", "view", "--json", "owner,name"], {
+      cwd,
+      timeout: 10_000,
+    })
+    const data = JSON.parse(stdout)
+    const info = { owner: data.owner.login as string, name: data.name as string, cwd }
+    this.cachedRepo = info
+    return info
+  }
+
+  private async fetchComments(
+    prNumber: number,
+    cwd: string,
+  ): Promise<{ total: number; unresolved: number; items: PRComment[] }> {
+    try {
+      const repo = await this.getRepoInfo(cwd)
+
+      const query = `query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviewThreads(first: 100) {
+              nodes {
+                isResolved
+                comments(first: 1) {
+                  nodes {
+                    id
+                    author { login avatarUrl }
+                    body
+                    path
+                    line
+                    url
+                    createdAt
+                  }
+                }
+              }
+            }
+          }
+        }
+      }`
+
+      const { stdout } = await execWithShellEnv(
+        "gh",
+        [
+          "api",
+          "graphql",
+          "-f",
+          `query=${query}`,
+          "-F",
+          `owner=${repo.owner}`,
+          "-F",
+          `repo=${repo.name}`,
+          "-F",
+          `number=${prNumber}`,
+        ],
+        { cwd, timeout: 15_000 },
+      )
+      const result = JSON.parse(stdout)
+      const threads = result?.data?.repository?.pullRequest?.reviewThreads?.nodes ?? []
+
+      const items: PRComment[] = []
+      for (const thread of threads) {
+        const first = thread.comments?.nodes?.[0]
+        if (!first) continue
+        items.push({
+          id: first.id,
+          author: first.author?.login ?? "unknown",
+          avatar: first.author?.avatarUrl,
+          body: first.body ?? "",
+          file: first.path,
+          line: first.line,
+          url: first.url,
+          resolved: thread.isResolved ?? false,
+          createdAt: first.createdAt ? new Date(first.createdAt).getTime() : undefined,
+        })
+      }
+
+      const total = items.length
+      const unresolved = items.filter((c) => !c.resolved).length
+      return { total, unresolved, items }
+    } catch (err) {
+      this.options.log("Failed to fetch PR comments:", err)
+      return { total: 0, unresolved: 0, items: [] }
+    }
+  }
+}
+
+interface PRResult {
+  number: number
+  title: string
+  url: string
+  state: PRState
+  review: ReviewDecision | null
+  additions: number
+  deletions: number
+  files: number
+}
+
+function parsePRResult(json: string): PRResult | null {
+  const data = JSON.parse(json)
+  if (!data.number) return null
+  return {
+    number: data.number,
+    title: data.title ?? "",
+    url: data.url ?? "",
+    state: parsePRState(data.isDraft, data.state),
+    review: parseReviewDecision(data.reviewDecision),
+    additions: data.additions ?? 0,
+    deletions: data.deletions ?? 0,
+    files: data.changedFiles ?? 0,
+  }
+}
+
+function parsePRState(isDraft: boolean, ghState: string): PRState {
+  if (isDraft) return "draft"
+  if (ghState === "MERGED") return "merged"
+  if (ghState === "CLOSED") return "closed"
+  return "open"
+}
+
+function parseReviewDecision(decision: string | undefined): ReviewDecision | null {
+  if (decision === "APPROVED") return "approved"
+  if (decision === "CHANGES_REQUESTED") return "changes_requested"
+  if (decision === "REVIEW_REQUIRED") return "pending"
+  return null
+}
+
+function mapCheckStatus(state: string): CheckStatus {
+  switch (state.toUpperCase()) {
+    case "SUCCESS":
+      return "success"
+    case "FAILURE":
+    case "ERROR":
+      return "failure"
+    case "PENDING":
+    case "QUEUED":
+    case "IN_PROGRESS":
+    case "REQUESTED":
+    case "WAITING":
+      return "pending"
+    case "SKIPPED":
+      return "skipped"
+    case "CANCELLED":
+    case "TIMED_OUT":
+    case "STALE":
+    case "STARTUP_FAILURE":
+      return "cancelled"
+    default:
+      return "pending"
+  }
+}
+
+function formatCheckDuration(startedAt?: string, completedAt?: string): string | undefined {
+  if (!startedAt || !completedAt) return undefined
+  const secs = Math.round((new Date(completedAt).getTime() - new Date(startedAt).getTime()) / 1000)
+  return secs < 60 ? `${secs}s` : `${Math.floor(secs / 60)}m ${secs % 60}s`
+}

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -26,6 +26,12 @@ export interface Worktree {
   groupId?: string
   /** User-provided display name for the worktree. */
   label?: string
+  /** Cached PR number for instant badge display on reload. */
+  prNumber?: number
+  /** Cached PR URL for instant badge display on reload. */
+  prUrl?: string
+  /** Cached PR state for correct badge color on reload (open/merged/closed/draft). */
+  prState?: string
 }
 
 /**
@@ -168,6 +174,16 @@ export class WorktreeStateManager {
     if (!wt) return
     wt.label = label || undefined
     this.log(`Updated worktree ${id} label to "${label}"`)
+    void this.save()
+  }
+
+  updateWorktreePR(id: string, prNumber?: number, prUrl?: string, prState?: string): void {
+    const wt = this.worktrees.get(id)
+    if (!wt) return
+    if (wt.prNumber === prNumber && wt.prUrl === prUrl && wt.prState === prState) return
+    wt.prNumber = prNumber
+    wt.prUrl = prUrl
+    wt.prState = prState
     void this.save()
   }
 

--- a/packages/kilo-vscode/src/agent-manager/host.ts
+++ b/packages/kilo-vscode/src/agent-manager/host.ts
@@ -56,8 +56,14 @@ export interface PanelContext {
   /** Whether the panel is currently the active tab. */
   readonly active: boolean
 
+  /** Whether the panel is visible (may be unfocused in a split editor group). */
+  readonly visible: boolean
+
   /** Session provider wired to this panel. */
   readonly sessions: SessionProvider
+
+  /** Register a callback for when panel visibility changes. */
+  onDidChangeVisibility(cb: (visible: boolean) => void): Disposable
 
   /** Register a callback for when the panel is disposed. */
   onDidDispose(cb: () => void): Disposable
@@ -106,6 +112,9 @@ export interface Host {
 
   /** Capture a telemetry event. */
   capture(event: string, properties?: Record<string, unknown>): void
+
+  /** Open a URL in the user's default browser. */
+  openExternal(url: string): void
 
   /** Ask VS Code's git extension to re-scan repositories (e.g. after worktree ref migration). */
   refreshGit(): void

--- a/packages/kilo-vscode/src/agent-manager/pr-status-bridge.ts
+++ b/packages/kilo-vscode/src/agent-manager/pr-status-bridge.ts
@@ -1,0 +1,110 @@
+/**
+ * Bridges the PRStatusPoller with the AgentManagerProvider.
+ *
+ * Owns the poller instance, the cached PR messages, and all message/panel handling
+ * so the provider only needs thin delegation calls.
+ */
+import type { Worktree } from "./WorktreeStateManager"
+import type { AgentManagerOutMessage, PRStatus } from "./types"
+import type { Disposable } from "./host"
+import { PRStatusPoller } from "./PRStatusPoller"
+
+interface PRBridgeHost {
+  getWorktrees(): Worktree[]
+  getWorkspaceRoot(): string | undefined
+  postToWebview(msg: AgentManagerOutMessage): void
+  updateWorktreePR(id: string, number?: number, url?: string, state?: string): void
+  hasPersistedPR(id: string): boolean
+  openExternal(url: string): void
+  log(...args: unknown[]): void
+}
+
+/** Minimal panel surface needed by the bridge (subset of PanelContext). */
+interface PanelLike {
+  readonly visible: boolean
+  onDidChangeVisibility(cb: (visible: boolean) => void): Disposable
+}
+
+export class PRStatusBridge {
+  readonly poller: PRStatusPoller
+  private readonly cache = new Map<string, AgentManagerOutMessage>()
+  private readonly host: PRBridgeHost
+
+  constructor(host: PRBridgeHost) {
+    this.host = host
+    this.poller = new PRStatusPoller(bridgePollerOpts(this, host))
+  }
+
+  static create(opts: {
+    getWorktrees: () => Worktree[]
+    getWorkspaceRoot: () => string | undefined
+    postToWebview: (msg: AgentManagerOutMessage) => void
+    updateWorktreePR: (id: string, n?: number, u?: string, s?: string) => void
+    hasPersistedPR: (id: string) => boolean
+    openExternal: (url: string) => void
+    log: (...args: unknown[]) => void
+  }): PRStatusBridge {
+    return new PRStatusBridge(opts)
+  }
+
+  /** Wire visibility tracking to a panel — pauses polling when hidden. */
+  attachPanel(panel: PanelLike): void {
+    this.poller.setVisible(panel.visible)
+    panel.onDidChangeVisibility((v) => {
+      this.poller.setVisible(v)
+    })
+  }
+
+  /** Replay cached PR statuses to a freshly-connected webview. */
+  replay(): void {
+    this.cache.forEach((msg) => this.host.postToWebview(msg))
+  }
+
+  /** Handle an incoming webview message. Returns true if handled. */
+  handleMessage(m: Record<string, unknown>): boolean {
+    if (m.type === "agentManager.refreshPR") {
+      this.poller.refresh(m.worktreeId as string)
+      return true
+    }
+    if (m.type === "agentManager.openPR") {
+      const wt = this.host.getWorktrees().find((w: Worktree) => w.id === m.worktreeId)
+      if (wt?.prUrl) this.host.openExternal(wt.prUrl)
+      return true
+    }
+    return false
+  }
+
+  /** Remove cached status for a deleted worktree. */
+  remove(worktreeId: string): void {
+    this.cache.delete(worktreeId)
+  }
+}
+
+/** Build PRStatusPoller options that forward events through the bridge cache. */
+function bridgePollerOpts(bridge: PRStatusBridge, host: PRBridgeHost) {
+  return {
+    getWorktrees: () => host.getWorktrees(),
+    getWorkspaceRoot: () => host.getWorkspaceRoot(),
+    onStatus: (id: string, pr: PRStatus | null, err?: "gh_missing" | "gh_auth" | "fetch_failed") => {
+      if (err) {
+        // Don't forward errors to the webview when we have prior PR data
+        // (in-memory cache or persisted prNumber) — that would overwrite
+        // the live badge with pr:null. Only forward when there's truly no
+        // prior data (first poll failed, nothing persisted).
+        if (!bridge["cache"].has(id) && !host.hasPersistedPR(id))
+          host.postToWebview({
+            type: "agentManager.prStatus",
+            worktreeId: id,
+            pr: null,
+            error: err,
+          } as AgentManagerOutMessage)
+        return
+      }
+      const msg = { type: "agentManager.prStatus", worktreeId: id, pr, error: err } as AgentManagerOutMessage
+      bridge["cache"].set(id, msg)
+      host.postToWebview(msg)
+      host.updateWorktreePR(id, pr?.number, pr?.url, pr?.state)
+    },
+    log: (...args: unknown[]) => host.log(...args),
+  }
+}

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -30,6 +30,58 @@ export type WorktreeDiffEntry = FileDiff & {
 }
 
 // ---------------------------------------------------------------------------
+// PR status types
+// ---------------------------------------------------------------------------
+
+export type PRState = "open" | "draft" | "merged" | "closed"
+export type ReviewDecision = "approved" | "changes_requested" | "pending"
+export type CheckStatus = "success" | "failure" | "pending" | "skipped" | "cancelled"
+export type AggregateCheckStatus = "success" | "failure" | "pending" | "none"
+
+export interface PRCheck {
+  name: string
+  status: CheckStatus
+  url?: string
+  duration?: string
+}
+
+export interface PRComment {
+  id: string
+  author: string
+  avatar?: string
+  body: string
+  file?: string
+  line?: number
+  url?: string
+  resolved: boolean
+  createdAt?: number
+}
+
+export interface PRStatus {
+  number: number
+  title: string
+  url: string
+  state: PRState
+  review: ReviewDecision | null
+  checks: {
+    status: AggregateCheckStatus
+    total: number
+    passed: number
+    failed: number
+    pending: number
+    items: PRCheck[]
+  }
+  comments?: {
+    total: number
+    unresolved: number
+    items: PRComment[]
+  }
+  additions: number
+  deletions: number
+  files: number
+}
+
+// ---------------------------------------------------------------------------
 // Extension → Webview messages (postToWebview)
 // ---------------------------------------------------------------------------
 
@@ -175,6 +227,13 @@ interface WorktreeDiffFileMessage {
   diff: WorktreeDiffEntry | null
 }
 
+interface PRStatusOutMessage {
+  type: "agentManager.prStatus"
+  worktreeId: string
+  pr: PRStatus | null
+  error?: "gh_missing" | "gh_auth" | "fetch_failed"
+}
+
 interface ActionOutMessage {
   type: "action"
   action: string
@@ -202,6 +261,7 @@ export type AgentManagerOutMessage =
   | WorktreeDiffLoadingMessage
   | WorktreeDiffMessage
   | WorktreeDiffFileMessage
+  | PRStatusOutMessage
   | ActionOutMessage
 
 // ---------------------------------------------------------------------------
@@ -379,6 +439,16 @@ interface StopDiffWatchIn {
   type: "agentManager.stopDiffWatch"
 }
 
+interface RefreshPRIn {
+  type: "agentManager.refreshPR"
+  worktreeId: string
+}
+
+interface OpenPRIn {
+  type: "agentManager.openPR"
+  worktreeId: string
+}
+
 interface OpenFileIn {
   type: "agentManager.openFile"
   sessionId: string
@@ -489,6 +559,8 @@ export type AgentManagerInMessage =
   | ApplyWorktreeDiffIn
   | StartDiffWatchIn
   | StopDiffWatchIn
+  | RefreshPRIn
+  | OpenPRIn
   | OpenFileIn
   | GenericOpenFileIn
   | PreviewImageIn

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -92,6 +92,9 @@ export class VscodeHost implements Host {
       get active() {
         return panel.active
       },
+      get visible() {
+        return panel.visible
+      },
       postMessage(msg) {
         void panel.webview.postMessage(msg)
       },
@@ -99,6 +102,9 @@ export class VscodeHost implements Host {
         panel.reveal(vscode.ViewColumn.One, preserveFocus ?? false)
       },
       sessions,
+      onDidChangeVisibility(cb) {
+        return panel.onDidChangeViewState((e) => cb(e.webviewPanel.visible))
+      },
       onDidDispose(cb) {
         return panel.onDidDispose(cb)
       },
@@ -160,9 +166,11 @@ export class VscodeHost implements Host {
     TelemetryProxy.capture(event as TelemetryEventName, properties)
   }
 
+  openExternal(url: string): void {
+    void vscode.env.openExternal(vscode.Uri.parse(url))
+  }
+
   refreshGit(): void {
-    // Trigger VS Code's built-in git extension to re-scan repositories.
-    // This picks up worktrees whose gitdir refs were just rewritten by migration.
     void vscode.commands.executeCommand("git.refresh")
   }
 

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -532,7 +532,7 @@ const VSCODE_ALLOWED: Record<string, { note: string }> = {
  */
 const MAX_LINES: Record<string, { maxLines: number; note: string }> = {
   "AgentManagerProvider.ts": {
-    maxLines: 1910,
+    maxLines: 2000,
     note: "primary extraction target: break into smaller orchestrators",
   },
 }

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -34,6 +34,8 @@ import type {
   WorktreeGitStats,
   LocalGitStats,
   WorktreeState,
+  PRStatus,
+  AgentManagerPRStatusMessage,
   ManagedSessionState,
   SessionInfo,
   BranchInfo,
@@ -119,6 +121,8 @@ interface ApplyState {
 
 /** Sidebar selection: LOCAL for local repo, worktree ID for a worktree, or null for an unassigned session. */
 type SidebarSelection = typeof LOCAL | string | null
+
+type SidePanel = "diff" | "pr" | null
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent)
 
@@ -328,8 +332,8 @@ const AgentManagerContent: Component = () => {
   let diffRaf: number | undefined
   let pendingDiffWidth: number | undefined
 
-  // Diff panel state
-  const [diffOpen, setDiffOpen] = createSignal(false)
+  const [sidePanel, setSidePanel] = createSignal<SidePanel>(null)
+  const diffOpen = () => sidePanel() === "diff"
   const [diffDatas, setDiffDatas] = createSignal<Record<string, WorktreeFileDiff[]>>({})
   const [diffLoading, setDiffLoading] = createSignal(false)
   const [diffFileLoading, setDiffFileLoading] = createSignal<Record<string, Record<string, true>>>({})
@@ -344,6 +348,9 @@ const AgentManagerContent: Component = () => {
 
   // Per-worktree git stats (diff additions/deletions, commits missing from origin)
   const [worktreeStats, setWorktreeStats] = createSignal<Record<string, WorktreeGitStats>>({})
+
+  // Per-worktree PR status data
+  const [prStatuses, setPrStatuses] = createSignal<Record<string, PRStatus | null>>({})
 
   // Local repo git stats (branch name, diff additions/deletions, commits)
   const [localStats, setLocalStats] = createSignal<LocalGitStats | undefined>()
@@ -1012,9 +1019,9 @@ const AgentManagerContent: Component = () => {
       } else if (msg.action === "toggleDiff") {
         if (reviewActive()) {
           closeReviewTab()
-          setDiffOpen(true)
+          setSidePanel("diff")
         } else {
-          setDiffOpen((prev) => !prev)
+          setSidePanel((prev) => (prev === "diff" ? null : "diff"))
         }
       } else if (msg.action === "newTab") handleNewTabForCurrentSelection()
       else if (msg.action === "closeTab") closeActiveTab()
@@ -1153,7 +1160,7 @@ const AgentManagerContent: Component = () => {
             setSelection(ev.worktreeId)
           }
           // Close diff/review panels — nothing to show during setup
-          setDiffOpen(false)
+          setSidePanel(null)
           setReviewActive(false)
           setSetup({ active: true, message: ev.message, branch: ev.branch, worktreeId: ev.worktreeId })
         }
@@ -1383,6 +1390,11 @@ const AgentManagerContent: Component = () => {
         setLocalStats(ev.stats)
         setRepoBranch(ev.stats.branch)
       }
+
+      if (msg.type === "agentManager.prStatus") {
+        const ev = msg as AgentManagerPRStatusMessage
+        setPrStatuses((prev) => ({ ...prev, [ev.worktreeId]: ev.pr }))
+      }
     })
 
     onCleanup(() => {
@@ -1458,7 +1470,7 @@ const AgentManagerContent: Component = () => {
   const openReviewTab = () => {
     const sel = selection()
     if (sel === null) return
-    setDiffOpen(false)
+    setSidePanel(null)
     setReviewOpenForContext(sel, true)
     setReviewActive(true)
   }
@@ -2327,6 +2339,34 @@ const AgentManagerContent: Component = () => {
                                   renameValue={renameValue()}
                                   closeKeybind={kb().closeWorktree ?? ""}
                                   openKeybind={kb().openWorktree ?? ""}
+                                  pr={
+                                    prStatuses()[wt.id] !== undefined
+                                      ? prStatuses()[wt.id]
+                                      : wt.prNumber
+                                        ? {
+                                            number: wt.prNumber,
+                                            title: "",
+                                            url: wt.prUrl ?? "",
+                                            state: (wt.prState ?? "open") as PRStatus["state"],
+                                            review: null,
+                                            checks: {
+                                              status: "none" as const,
+                                              total: 0,
+                                              passed: 0,
+                                              failed: 0,
+                                              pending: 0,
+                                              items: [],
+                                            },
+                                            comments: { total: 0, unresolved: 0, items: [] },
+                                            additions: 0,
+                                            deletions: 0,
+                                            files: 0,
+                                          }
+                                        : undefined
+                                  }
+                                  onOpenPR={() =>
+                                    vscode.postMessage({ type: "agentManager.openPR", worktreeId: wt.id })
+                                  }
                                   onClick={() => {
                                     if (pendingDelete() === wt.id) {
                                       confirmDeleteWorktree(wt.id)
@@ -2622,10 +2662,10 @@ const AgentManagerContent: Component = () => {
                           onClick={() => {
                             if (reviewActive()) {
                               closeReviewTab()
-                              setDiffOpen(true)
+                              setSidePanel("diff")
                               return
                             }
-                            setDiffOpen((prev) => !prev)
+                            setSidePanel((prev) => (prev === "diff" ? null : "diff"))
                           }}
                           title={t("agentManager.diff.toggle")}
                         >
@@ -2752,7 +2792,7 @@ const AgentManagerContent: Component = () => {
         <Show when={!contextEmpty()}>
           {/* Chat + side diff panel (hidden when review tab is active) */}
           <div
-            class={`am-detail-content ${diffOpen() ? "am-detail-split" : ""}`}
+            class={`am-detail-content ${sidePanel() !== null ? "am-detail-split" : ""}`}
             style={{ display: reviewActive() ? "none" : undefined }}
           >
             <div class="am-chat-wrapper">
@@ -2810,7 +2850,7 @@ const AgentManagerContent: Component = () => {
                 </div>
               </Show>
             </div>
-            <Show when={diffOpen()}>
+            <Show when={sidePanel() !== null}>
               <div class="am-diff-resize" style={{ width: `${diffWidth()}px` }}>
                 <ResizeHandle
                   direction="horizontal"
@@ -2829,25 +2869,27 @@ const AgentManagerContent: Component = () => {
                   }}
                 />
                 <div class="am-diff-panel-wrapper">
-                  <DiffPanel
-                    diffs={reviewDiffs()}
-                    loading={diffLoading()}
-                    loadingFiles={diffFileLoadingForCurrent()}
-                    sessionId={currentDiffSessionId()}
-                    sessionKey={diffSessionKey()}
-                    diffStyle={reviewDiffStyle()}
-                    onDiffStyleChange={setSharedDiffStyle}
-                    comments={reviewComments()}
-                    onCommentsChange={setReviewCommentsForSelection}
-                    onClose={() => setDiffOpen(false)}
-                    onExpand={selection() !== null ? openReviewTab : undefined}
-                    onRequestDiff={requestDiffFile}
-                    onOpenFile={(file) => {
-                      const id = currentDiffSessionId()
-                      if (id) vscode.postMessage({ type: "agentManager.openFile", sessionId: id, filePath: file })
-                      else if (selection() === LOCAL) vscode.postMessage({ type: "openFile", filePath: file })
-                    }}
-                  />
+                  <Show when={sidePanel() === "diff"}>
+                    <DiffPanel
+                      diffs={reviewDiffs()}
+                      loading={diffLoading()}
+                      loadingFiles={diffFileLoadingForCurrent()}
+                      sessionId={currentDiffSessionId()}
+                      sessionKey={diffSessionKey()}
+                      diffStyle={reviewDiffStyle()}
+                      onDiffStyleChange={setSharedDiffStyle}
+                      comments={reviewComments()}
+                      onCommentsChange={setReviewCommentsForSelection}
+                      onClose={() => setSidePanel(null)}
+                      onExpand={selection() !== null ? openReviewTab : undefined}
+                      onRequestDiff={requestDiffFile}
+                      onOpenFile={(file) => {
+                        const id = currentDiffSessionId()
+                        if (id) vscode.postMessage({ type: "agentManager.openFile", sessionId: id, filePath: file })
+                        else if (selection() === LOCAL) vscode.postMessage({ type: "openFile", filePath: file })
+                      }}
+                    />
+                  </Show>
                 </div>
               </div>
             </Show>

--- a/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
@@ -10,7 +10,7 @@ import { Tooltip, TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
 import { HoverCard } from "@kilocode/kilo-ui/hover-card"
 import { ContextMenu } from "@kilocode/kilo-ui/context-menu"
 import { Button } from "@kilocode/kilo-ui/button"
-import type { WorktreeState, WorktreeGitStats } from "../src/types/messages"
+import type { WorktreeState, WorktreeGitStats, PRStatus } from "../src/types/messages"
 import { useLanguage } from "../src/context/language"
 import { formatRelativeDate } from "../src/utils/date"
 
@@ -51,6 +51,10 @@ interface WorktreeItemProps {
   closeKeybind: string
   /** Keybinding string for the open-in-vscode action. */
   openKeybind: string
+  /** PR status for this worktree's branch, or null if no PR. */
+  pr?: PRStatus | null
+  /** Callback when the PR badge is clicked. */
+  onOpenPR?: () => void
 
   onClick: () => void
   onDelete: (e: MouseEvent) => void
@@ -68,10 +72,40 @@ const MAX_SHORTCUT = 9
 const hasStats = (s: WorktreeGitStats | undefined): s is WorktreeGitStats =>
   !!s && (s.files > 0 || s.additions > 0 || s.deletions > 0 || s.ahead > 0 || s.behind > 0)
 
+/** Returns the accent color for a PR badge based on state priority. */
+export function prAccentColor(pr: PRStatus): string {
+  if (pr.state === "draft") return "var(--text-weaker)"
+  if (pr.state === "merged") return "#a78bfa"
+  if (pr.state === "closed") return "#f87171"
+  if (pr.checks.status === "failure") return "#ef4444"
+  if (pr.review === "changes_requested") return "#fbbf24"
+  if (pr.checks.status === "pending") return "#fbbf24"
+  return "#34d399"
+}
+
+function prStateLabel(state: PRStatus["state"]): string {
+  if (state === "draft") return "Draft"
+  if (state === "merged") return "Merged"
+  if (state === "closed") return "Closed"
+  return "Open"
+}
+
+function reviewLabel(review: string): string {
+  if (review === "approved") return "Approved"
+  if (review === "changes_requested") return "Changes Requested"
+  return "Pending"
+}
+
 export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
   const { t } = useLanguage()
   const [hovered, setHovered] = createSignal(false)
   const [overClose, setOverClose] = createSignal(false)
+
+  const handleOpenPR = (e: MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+    props.onOpenPR?.()
+  }
 
   return (
     <>
@@ -102,128 +136,159 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
                 data-sidebar-id={props.worktree.id}
                 onClick={() => props.onClick()}
               >
-                <Show when={!props.busy && !props.working} fallback={<Spinner class="am-worktree-spinner" />}>
-                  <Icon name="branch" size="small" />
-                </Show>
-                <Show when={props.stale}>
-                  <Tooltip
-                    value={t("agentManager.worktree.staleTooltip")}
-                    placement="top"
-                    contentClass="am-tooltip-wrap"
-                  >
-                    <span class="am-worktree-stale-badge">
-                      <Icon name="warning" size="small" />
-                    </span>
-                  </Tooltip>
-                </Show>
-                <Show
-                  when={props.renaming}
-                  fallback={
-                    <span
-                      class="am-worktree-branch"
-                      onDblClick={(e) => {
-                        e.stopPropagation()
-                        props.onStartRename(props.label)
-                      }}
-                      title={t("agentManager.worktree.doubleClickRename")}
-                    >
-                      {props.label}
-                    </span>
-                  }
-                >
-                  <input
-                    class="am-worktree-rename-input"
-                    value={props.renameValue}
-                    onInput={(e) => props.onRenameInput(e.currentTarget.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault()
-                        props.onCommitRename()
-                      }
-                      if (e.key === "Escape") {
-                        e.preventDefault()
-                        props.onCancelRename()
-                      }
-                    }}
-                    onBlur={() => props.onCommitRename()}
-                    onClick={(e) => e.stopPropagation()}
-                    ref={(el) =>
-                      requestAnimationFrame(() =>
-                        requestAnimationFrame(() => {
-                          el.focus()
-                          el.select()
-                        }),
-                      )
-                    }
-                  />
-                </Show>
-                <Show when={props.shortcut >= 2 && props.shortcut <= MAX_SHORTCUT}>
-                  <span class="am-shortcut-badge">
-                    {isMac ? "⌘" : "Ctrl+"}
-                    {props.shortcut}
-                  </span>
-                </Show>
-                <Show when={props.stats === undefined}>
-                  <div class="am-worktree-stats-skeleton">
-                    <div class="am-worktree-stats-skeleton-row" />
-                    <div class="am-worktree-stats-skeleton-row" style={{ width: "70%" }} />
-                  </div>
-                </Show>
-                <Show when={hasStats(props.stats)}>
-                  <div class="am-worktree-stats">
+                <div class="am-wt-icon">
+                  <Show when={!props.busy && !props.working} fallback={<Spinner class="am-worktree-spinner" />}>
+                    <Icon name="branch" size="small" />
+                  </Show>
+                </div>
+                <div class="am-wt-content">
+                  {/* Row 1: label + stale badge + stats/hover-actions overlay */}
+                  <div class="am-wt-row1">
+                    <Show when={props.stale}>
+                      <Tooltip
+                        value={t("agentManager.worktree.staleTooltip")}
+                        placement="top"
+                        contentClass="am-tooltip-wrap"
+                      >
+                        <span class="am-worktree-stale-badge">
+                          <Icon name="warning" size="small" />
+                        </span>
+                      </Tooltip>
+                    </Show>
                     <Show
-                      when={props.stats!.additions > 0 || props.stats!.deletions > 0}
+                      when={props.renaming}
                       fallback={
-                        <Show when={props.stats!.files > 0}>
-                          <span class="am-stat-files">{props.stats!.files}f</span>
+                        <span
+                          class="am-worktree-branch"
+                          onDblClick={(e) => {
+                            e.stopPropagation()
+                            props.onStartRename(props.label)
+                          }}
+                          title={t("agentManager.worktree.doubleClickRename")}
+                        >
+                          {props.label}
+                        </span>
+                      }
+                    >
+                      <input
+                        class="am-worktree-rename-input"
+                        value={props.renameValue}
+                        onInput={(e) => props.onRenameInput(e.currentTarget.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault()
+                            props.onCommitRename()
+                          }
+                          if (e.key === "Escape") {
+                            e.preventDefault()
+                            props.onCancelRename()
+                          }
+                        }}
+                        onBlur={() => props.onCommitRename()}
+                        onClick={(e) => e.stopPropagation()}
+                        ref={(el) =>
+                          requestAnimationFrame(() =>
+                            requestAnimationFrame(() => {
+                              el.focus()
+                              el.select()
+                            }),
+                          )
+                        }
+                      />
+                    </Show>
+                    {/* Grid cell: stats visible by default, hover actions on top */}
+                    <div class="am-wt-actions-cell">
+                      <Show when={props.stats === undefined}>
+                        <div class="am-worktree-stats-skeleton">
+                          <div class="am-worktree-stats-skeleton-row" />
+                        </div>
+                      </Show>
+                      <Show when={hasStats(props.stats)}>
+                        <div class="am-worktree-stats">
+                          <Show when={props.stats!.behind > 0}>
+                            <span class="am-worktree-behind">↓{props.stats!.behind}</span>
+                          </Show>
+                          <Show when={props.stats!.ahead > 0}>
+                            <span class="am-worktree-commits">↑{props.stats!.ahead}</span>
+                          </Show>
+                          <Show
+                            when={props.stats!.additions > 0 || props.stats!.deletions > 0}
+                            fallback={
+                              <Show when={props.stats!.files > 0}>
+                                <span class="am-stat-files">{props.stats!.files}f</span>
+                              </Show>
+                            }
+                          >
+                            <Show when={props.stats!.additions > 0}>
+                              <span class="am-stat-additions">+{props.stats!.additions}</span>
+                            </Show>
+                            <Show when={props.stats!.deletions > 0}>
+                              <span class="am-stat-deletions">−{props.stats!.deletions}</span>
+                            </Show>
+                          </Show>
+                        </div>
+                      </Show>
+                      <Show when={props.pendingDelete && !props.busy}>
+                        <span class="am-worktree-delete-hint">{t("agentManager.worktree.confirmDelete")}</span>
+                      </Show>
+                      <div class="am-wt-hover-actions">
+                        <Show when={props.shortcut >= 2 && props.shortcut <= MAX_SHORTCUT}>
+                          <span class="am-shortcut-badge">
+                            {isMac ? "⌘" : "Ctrl+"}
+                            {props.shortcut}
+                          </span>
+                        </Show>
+                        <Show when={!props.busy && !props.pendingDelete}>
+                          <div
+                            class="am-worktree-close"
+                            onMouseEnter={() => setOverClose(true)}
+                            onMouseLeave={() => setOverClose(false)}
+                          >
+                            <TooltipKeybind
+                              title={t("agentManager.worktree.delete")}
+                              keybind={props.closeKeybind}
+                              placement="top"
+                            >
+                              <IconButton
+                                icon="trash"
+                                size="small"
+                                variant="ghost"
+                                label={t("agentManager.worktree.delete")}
+                                onClick={(e: MouseEvent) => props.onDelete(e)}
+                              />
+                            </TooltipKeybind>
+                          </div>
+                        </Show>
+                      </div>
+                    </div>
+                  </div>
+                  {/* Row 2: always rendered for consistent height; PR badge or skeleton */}
+                  <div class="am-wt-row2">
+                    <Show
+                      when={props.pr}
+                      fallback={
+                        <Show when={props.stats === undefined}>
+                          <div class="am-pr-badge-skeleton" />
                         </Show>
                       }
                     >
-                      <div class="am-worktree-stats-row">
-                        <Show when={props.stats!.additions > 0}>
-                          <span class="am-stat-additions">+{props.stats!.additions}</span>
-                        </Show>
-                        <Show when={props.stats!.deletions > 0}>
-                          <span class="am-stat-deletions">−{props.stats!.deletions}</span>
-                        </Show>
-                      </div>
-                    </Show>
-                    <Show when={props.stats!.ahead > 0 || props.stats!.behind > 0}>
-                      <div class="am-worktree-stats-row">
-                        <Show when={props.stats!.ahead > 0}>
-                          <span class="am-worktree-commits">↑{props.stats!.ahead}</span>
-                        </Show>
-                        <Show when={props.stats!.behind > 0}>
-                          <span class="am-worktree-behind">↓{props.stats!.behind}</span>
-                        </Show>
-                      </div>
+                      {(pr) => {
+                        const accent = () => prAccentColor(pr())
+                        return (
+                          <span
+                            class="am-pr-badge"
+                            style={{ "--pr-accent": accent() }}
+                            data-pending={pr().state === "open" && pr().checks.status === "pending" ? "" : undefined}
+                            onClick={handleOpenPR}
+                          >
+                            <Icon name="branch" size="small" />
+                            <span class="am-pr-badge-number">#{pr().number}</span>
+                          </span>
+                        )
+                      }}
                     </Show>
                   </div>
-                </Show>
-                <Show when={props.pendingDelete && !props.busy}>
-                  <span class="am-worktree-delete-hint">{t("agentManager.worktree.confirmDelete")}</span>
-                </Show>
-                <Show when={!props.busy && !props.pendingDelete}>
-                  <div
-                    class="am-worktree-close"
-                    onMouseEnter={() => setOverClose(true)}
-                    onMouseLeave={() => setOverClose(false)}
-                  >
-                    <TooltipKeybind
-                      title={t("agentManager.worktree.delete")}
-                      keybind={props.closeKeybind}
-                      placement="top"
-                    >
-                      <IconButton
-                        icon="trash"
-                        size="small"
-                        variant="ghost"
-                        label={t("agentManager.worktree.delete")}
-                        onClick={(e: MouseEvent) => props.onDelete(e)}
-                      />
-                    </TooltipKeybind>
-                  </div>
-                </Show>
+                </div>
               </div>
             </ContextMenu.Trigger>
           }
@@ -312,6 +377,34 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
                   </span>
                 </div>
               </Show>
+            </Show>
+            <Show when={props.pr}>
+              {(pr) => (
+                <>
+                  <div class="am-hover-card-divider" />
+                  <div class="am-hover-card-row">
+                    <span class="am-hover-card-row-label">PR #{pr().number}</span>
+                    <span class="am-hover-card-row-value">
+                      <span class="am-pr-link" onClick={handleOpenPR}>
+                        <Icon name="link" size="small" />
+                      </span>
+                      {prStateLabel(pr().state)}
+                    </span>
+                  </div>
+                  <Show when={pr().review}>
+                    <div class="am-hover-card-row">
+                      <span class="am-hover-card-row-label">Review</span>
+                      <span class="am-hover-card-row-value">{reviewLabel(pr().review!)}</span>
+                    </div>
+                  </Show>
+                  <div class="am-hover-card-row">
+                    <span class="am-hover-card-row-label">Checks</span>
+                    <span class="am-hover-card-row-value">
+                      {pr().checks.passed}/{pr().checks.total} passed
+                    </span>
+                  </div>
+                </>
+              )}
             </Show>
             <div class="am-hover-card-divider" />
             <div class="am-hover-card-hint">

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -181,12 +181,11 @@ button.am-section-toggle:hover .am-section-label {
 }
 
 .am-worktree-item {
-  position: relative;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
-  padding: 8px 10px;
-  min-height: 40px;
+  padding: 6px 10px;
+  min-height: 36px;
   box-sizing: border-box;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -195,6 +194,72 @@ button.am-section-toggle:hover .am-section-label {
   min-width: 0;
   width: 100%;
   transition: background 200ms ease;
+}
+
+/* Left icon column — shrink-0, vertically centered with first row */
+.am-wt-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  height: 20px;
+}
+
+/* Right content column — flex-1 with two rows */
+.am-wt-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* Row 1: label + stats/hover-actions */
+.am-wt-row1 {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+/* Grid overlay cell: stats visible by default, hover actions stacked on top */
+.am-wt-actions-cell {
+  position: relative;
+  flex-shrink: 0;
+  display: grid;
+  align-items: center;
+  margin-left: auto;
+}
+.am-wt-actions-cell > * {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+/* Hover actions (shortcut badge + close button) — hidden by default, shown on hover */
+.am-wt-hover-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  opacity: 0;
+  visibility: hidden;
+}
+.am-worktree-item:hover .am-wt-hover-actions {
+  opacity: 1;
+  visibility: visible;
+}
+/* Stats fade out on hover (replaced by hover actions in same grid cell) */
+.am-worktree-item:hover .am-wt-actions-cell > .am-worktree-stats,
+.am-worktree-item:hover .am-wt-actions-cell > .am-worktree-stats-skeleton {
+  opacity: 0;
+  visibility: hidden;
+}
+
+/* Row 2: always present for consistent height; PR badge right-aligned */
+.am-wt-row2 {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-height: 14px;
 }
 
 .am-worktree-item:hover {
@@ -238,13 +303,9 @@ button.am-section-toggle:hover .am-section-label {
   outline: none;
 }
 
-/* Shortcut badge — hover-reveal index badge (⌘1, ⌘2, etc.) matching Superset style */
+/* Shortcut badge — hover-reveal index badge (⌘1, ⌘2, etc.) */
 
 .am-shortcut-badge {
-  position: absolute;
-  right: 30px;
-  opacity: 0;
-  transition: opacity 150ms ease;
   font-size: 10px;
   font-variant-numeric: tabular-nums;
   color: var(--text-weaker);
@@ -256,8 +317,7 @@ button.am-section-toggle:hover .am-section-label {
   right: 8px;
 }
 
-.am-local-item:hover .am-shortcut-badge,
-.am-worktree-item:hover .am-shortcut-badge {
+.am-local-item:hover .am-shortcut-badge {
   opacity: 1;
 }
 
@@ -278,29 +338,27 @@ button.am-section-toggle:hover .am-section-label {
   color: var(--text-weak);
 }
 
-.am-worktree-item:has(.am-worktree-rename-input) .am-shortcut-badge {
-  opacity: 0;
+.am-worktree-item:has(.am-worktree-rename-input) .am-wt-row2 {
+  display: none;
 }
 
 .am-worktree-close {
-  position: absolute;
-  right: 4px;
   flex-shrink: 0;
+}
+/* Compact close button inside worktree items */
+.am-worktree-close [data-component="icon-button"] {
+  width: 18px;
+  height: 18px;
+  padding: 2px;
+}
+.am-worktree-close [data-component="icon"] {
+  width: 14px;
+  height: 14px;
+}
+
+.am-worktree-item:has(.am-worktree-rename-input) .am-wt-hover-actions {
   opacity: 0;
-}
-
-.am-worktree-item:hover .am-worktree-branch {
-  mask-image: linear-gradient(to right, black calc(100% - 72px), transparent calc(100% - 36px));
-  -webkit-mask-image: linear-gradient(to right, black calc(100% - 72px), transparent calc(100% - 36px));
-}
-
-.am-worktree-item:hover .am-worktree-close {
-  opacity: 1;
-}
-
-.am-worktree-item:has(.am-worktree-rename-input) .am-worktree-close {
-  opacity: 0;
-  pointer-events: none;
+  visibility: hidden;
 }
 
 /* Inline delete confirmation */
@@ -325,16 +383,22 @@ button.am-section-toggle:hover .am-section-label {
   display: none;
 }
 
-.am-worktree-pending-delete .am-shortcut-badge {
+.am-worktree-pending-delete .am-wt-row2 {
+  visibility: hidden;
+}
+
+.am-worktree-pending-delete .am-wt-hover-actions {
   opacity: 0 !important;
+  visibility: hidden !important;
 }
 
 .am-worktree-delete-hint {
+  position: absolute;
+  right: 0;
   font-size: var(--font-size-small);
   color: var(--text-on-brand-base);
   background: var(--surface-critical-strong);
   white-space: nowrap;
-  flex-shrink: 0;
   padding: 1px 8px;
   border-radius: 4px;
   cursor: pointer;
@@ -383,16 +447,14 @@ button.am-section-toggle:hover .am-section-label {
 .am-worktree-spinner {
   width: 16px;
   height: 16px;
-  flex-shrink: 0;
 }
 
 /* Per-worktree git stats (diff lines + commits missing from origin) */
 
 .am-worktree-stats {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 1px;
+  align-items: center;
+  gap: 4px;
   flex-shrink: 0;
   font-family: var(--font-mono, monospace);
   font-size: 10px;
@@ -408,9 +470,7 @@ button.am-section-toggle:hover .am-section-label {
 
 .am-worktree-stats-skeleton {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 3px;
+  align-items: center;
   flex-shrink: 0;
 }
 
@@ -422,8 +482,14 @@ button.am-section-toggle:hover .am-section-label {
   animation: am-skeleton-pulse 1.5s ease-in-out infinite;
 }
 
-.am-worktree-stats-skeleton-row:nth-child(2) {
-  animation-delay: 0.15s;
+.am-pr-badge-skeleton {
+  width: 52px;
+  height: 14px;
+  border-radius: 6px;
+  background: var(--text-base);
+  animation: am-skeleton-pulse 1.5s ease-in-out infinite;
+  animation-delay: 0.3s;
+  opacity: 0;
 }
 
 .am-stat-files {
@@ -436,6 +502,75 @@ button.am-section-toggle:hover .am-section-label {
 
 .am-stat-deletions {
   color: #f87171;
+}
+
+/* PR pill badge — second row inside am-wt-row2.
+   Uses --pr-accent custom property (set inline) to derive all colors. */
+.am-pr-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 7px 2px 4px;
+  border-radius: 6px;
+  border: none;
+  background: color-mix(in srgb, var(--pr-accent) 12%, transparent);
+  color: var(--pr-accent);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  transition: background 150ms ease;
+}
+.am-pr-badge:hover {
+  background: color-mix(in srgb, var(--pr-accent) 25%, transparent);
+}
+.am-pr-badge [data-component="icon"] {
+  width: 12px;
+  height: 12px;
+  color: var(--pr-accent);
+}
+.am-pr-badge-number {
+  line-height: 1;
+  color: var(--text-muted);
+}
+.am-pr-badge:hover .am-pr-badge-number {
+  color: var(--pr-accent);
+}
+.am-pr-badge[data-pending] {
+  animation: am-pr-pulse 1.5s ease-in-out infinite;
+}
+@keyframes am-pr-pulse {
+  0%,
+  100% {
+    opacity: 0.9;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.am-worktree-item-active .am-pr-badge {
+  background: color-mix(in srgb, var(--pr-accent) 18%, transparent);
+}
+.am-worktree-item-active .am-pr-badge:hover {
+  background: color-mix(in srgb, var(--pr-accent) 30%, transparent);
+}
+
+/* Clickable link icon in hover card to open PR on GitHub */
+.am-pr-link {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 3px;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: opacity 100ms ease;
+}
+.am-pr-link:hover {
+  opacity: 1;
+}
+.am-pr-link [data-component="icon"] {
+  width: 11px;
+  height: 11px;
 }
 
 .am-worktree-item-active .am-stat-files {
@@ -470,8 +605,6 @@ button.am-section-toggle:hover .am-section-label {
   color: #fca5a5;
 }
 
-.am-worktree-item:hover .am-worktree-stats,
-.am-worktree-item:hover .am-worktree-stats-skeleton,
 .am-local-item:hover .am-worktree-stats,
 .am-local-item:hover .am-worktree-stats-skeleton {
   opacity: 0;

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -799,6 +799,64 @@ export interface WorktreeState {
   groupId?: string
   /** User-provided display name for the worktree. */
   label?: string
+  /** Cached PR number for instant badge display on reload. */
+  prNumber?: number
+  /** Cached PR URL for instant badge display on reload. */
+  prUrl?: string
+  /** Cached PR state for correct badge color on reload (open/merged/closed/draft). */
+  prState?: string
+}
+
+// ---------------------------------------------------------------------------
+// PR status types (mirrored from extension types.ts)
+// ---------------------------------------------------------------------------
+
+export type PRState = "open" | "draft" | "merged" | "closed"
+export type ReviewDecision = "approved" | "changes_requested" | "pending"
+export type CheckStatus = "success" | "failure" | "pending" | "skipped" | "cancelled"
+export type AggregateCheckStatus = "success" | "failure" | "pending" | "none"
+
+export interface PRCheck {
+  name: string
+  status: CheckStatus
+  url?: string
+  duration?: string
+}
+
+export interface PRComment {
+  id: string
+  author: string
+  avatar?: string
+  body: string
+  file?: string
+  line?: number
+  url?: string
+  resolved: boolean
+  createdAt?: number
+}
+
+export interface PRStatus {
+  number: number
+  title: string
+  url: string
+  state: PRState
+  review: ReviewDecision | null
+  checks: {
+    status: AggregateCheckStatus
+    total: number
+    passed: number
+    failed: number
+    pending: number
+    items: PRCheck[]
+  }
+  comments?: {
+    total: number
+    unresolved: number
+    items: PRComment[]
+  }
+  additions: number
+  deletions: number
+  files: number
 }
 
 export interface ManagedSessionState {
@@ -981,6 +1039,14 @@ export interface LocalGitStats {
 export interface AgentManagerLocalStatsMessage {
   type: "agentManager.localStats"
   stats: LocalGitStats
+}
+
+// Agent Manager: PR status push (extension → webview)
+export interface AgentManagerPRStatusMessage {
+  type: "agentManager.prStatus"
+  worktreeId: string
+  pr: PRStatus | null
+  error?: "gh_missing" | "gh_auth" | "fetch_failed"
 }
 
 // Sidebar: Live worktree diff stats (extension → webview)
@@ -1360,6 +1426,7 @@ export type ExtensionMessage =
   | AgentManagerApplyWorktreeDiffResultMessage
   | AgentManagerWorktreeStatsMessage
   | AgentManagerLocalStatsMessage
+  | AgentManagerPRStatusMessage
   // legacy-migration start
   | MigrationStateMessage
   | LegacyMigrationDataMessage
@@ -1959,6 +2026,17 @@ export interface StopDiffWatchMessage {
   type: "agentManager.stopDiffWatch"
 }
 
+// Agent Manager: PR messages (webview → extension)
+export interface RefreshPRMessage {
+  type: "agentManager.refreshPR"
+  worktreeId: string
+}
+
+export interface OpenPRMessage {
+  type: "agentManager.openPR"
+  worktreeId: string
+}
+
 export interface ApplyWorktreeDiffMessage {
   type: "agentManager.applyWorktreeDiff"
   worktreeId: string
@@ -2198,6 +2276,8 @@ export type WebviewMessage =
   | RequestWorktreeDiffFileMessage
   | StartDiffWatchMessage
   | StopDiffWatchMessage
+  | RefreshPRMessage
+  | OpenPRMessage
   // legacy-migration start
   | RequestLegacyMigrationDataMessage
   | StartLegacyMigrationMessage


### PR DESCRIPTION
Add read-only GitHub PR awareness to the Agent Manager sidebar. Worktrees with open PRs show a colored status dot that reflects PR state, CI checks, and review status. PR details appear in the worktree hover card. Data is fetched via the gh CLI with polling and hash-based deduplication.

## Context

Implements Phases 1-3 of #7533 (GitHub PR Status Integration). The goal is to let users see at a glance whether a worktree has a PR, what state it's in, and whether CI is passing — without leaving VS Code. Phases 4-5 (tab bar PR button and PR detail panel) are planned as follow-up work and foundation is laid.

## Implementation

**Phase 1 — Data layer:** New `PRStatusPoller` that polls `gh pr view`, `gh pr checks`, and `gh api graphql` (for review comments) per worktree. Uses hash-based deduplication to avoid redundant updates. Follows the existing `GitStatsPoller` pattern (timer/busy-guard/schedule lifecycle). Degrades when `gh` is not installed or not authenticated. PR number and URL are persisted to `agent-manager.json` for instant badge display on reload.

  **Phase 2 — Side panel refactor:** Replaced the `diffOpen` boolean with a `sidePanel: "diff" | "pr" | null` signal to prepare for the future PR panel. A derived `diffOpen()` accessor preserves backward compatibility with all existing diff logic.

  **Phase 3 — Sidebar PR badge:** Worktree items show a colored dot when a PR exists. The dot color reflects PR state using a priority system: checks failing (red) > changes requested (amber) > checks pending (amber pulse) > passing (green), plus draft (grey), merged (purple), closed (muted red). The dot hides on hover (controlled by the HoverCard's `hovered` signal, not CSS `:hover`, to avoid state mismatch when the cursor moves to the HoverCard portal). The hover card gains a PR section showing PR number, state, review decision, checks, and comments.

  **Key decisions:**
  - Inline styles for dot colors instead of per-color CSS classes (avoids arch test failures from dynamic class construction)
  - `data-pulse` attribute triggers the CSS animation for pending checks
  - `openExternal` added to the `Host` interface so the PR badge click opens the PR on GitHub

## Screenshots

| before | after |
| ------ | ----- |
|  <img width="1428" height="890" alt="Screenshot 2026-03-31 at 6 10 05 AM" src="https://github.com/user-attachments/assets/02962b69-379c-44dd-9597-4f81a2365063" /> <img width="1428" height="890" alt="Screenshot 2026-03-31 at 6 09 44 AM" src="https://github.com/user-attachments/assets/64b422c0-d782-43a3-9f2d-a32c76bd292c" />  |  <img width="1428" height="890" alt="Screenshot 2026-03-31 at 6 16 04 AM" src="https://github.com/user-attachments/assets/637ba4e3-d683-4583-92dc-2f3fd83f20f8" />  <img width="1428" height="890" alt="Screenshot 2026-03-31 at 6 18 35 AM" src="https://github.com/user-attachments/assets/fa4bac6f-3404-46ac-9df1-bdae5b17e2ee" />  |

## How to Test

  1. Ensure `gh` CLI is installed and authenticated (`gh auth status`)
  2. Open a repository that has open pull requests in the Agent Manager
  3. Create a worktree for a branch that has an open PR
  4. Verify: a colored dot appears next to the worktree name at rest
  5. Hover the worktree item — dot hides, hover card shows PR section (number, state, checks)
  6. Create a worktree for a branch with no PR — verify no dot appears
  7. Double-click to rename — verify the dot hides during rename
  8. Close and reopen the Agent Manager — verify the dot reappears (persisted data)

## Get in Touch

Discord: Debossssssssssss
