### PR TITLE
feat(vscode): display active mode badge in subagent execution window

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -12,6 +12,7 @@ import { Icon } from "@kilocode/kilo-ui/icon"
 import { Checkbox } from "@kilocode/kilo-ui/checkbox"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
+import { formatAgentLabel } from "../shared/ModeSwitcher"
 import type { TodoItem } from "../../types/messages"
 
 interface TaskHeaderProps {
@@ -44,6 +45,15 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
     return { tokens, pct }
   })
 
+  const activeAgent = createMemo(() => {
+    if (!props.readonly) return undefined
+    const id = session.currentSessionID()
+    if (!id) return undefined
+    const name = session.getSessionAgent(id)
+    const info = session.agents().find((a) => a.name === name)
+    return info ? formatAgentLabel(info) : name
+  })
+
   const todos = createMemo(() => session.todos())
   const hasTodos = createMemo(() => todos().length > 0)
   const doneCount = createMemo(() => todos().filter((t: TodoItem) => t.status === "completed").length)
@@ -65,6 +75,7 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
       <div data-component="task-header">
         <div data-slot="task-header-title" title={title()}>
           {title()}
+          <Show when={activeAgent()}>{(label) => <span data-slot="task-header-mode-badge">{label()}</span>}</Show>
         </div>
         <div data-slot="task-header-stats">
           <Show when={cost()}>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -15,7 +15,7 @@ import { useLanguage } from "../../context/language"
 import type { AgentInfo } from "../../types/messages"
 
 /** Format an agent for display. Uses displayName if available, otherwise title-cases the slug. */
-function formatAgentLabel(agent: AgentInfo): string {
+export function formatAgentLabel(agent: AgentInfo): string {
   if (agent.displayName) return agent.displayName
   return agent.name
     .split(/[-_]/)

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -4,6 +4,24 @@
  */
 
 /* ============================================
+   Task Header Mode Badge
+   ============================================ */
+
+[data-slot="task-header-mode-badge"] {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  background-color: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
+/* ============================================
    Task Header Todos
    ============================================ */
 


### PR DESCRIPTION
## Summary

- Adds an active mode/agent badge to `TaskHeader` when viewing a subagent session in read-only mode (subagent execution window)
- Exports `formatAgentLabel` from `ModeSwitcher` for reuse
- Adds CSS styling for the new `[data-slot="task-header-mode-badge"]` element

Closes #8005
