### PR TITLE
feat(vscode): show cost and sub-agent type in popout header

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -607,7 +607,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           )
           break
         case "openSubAgentViewer":
-          vscode.commands.executeCommand("kilo-code.new.openSubAgentViewer", message.sessionID, message.title)
+          vscode.commands.executeCommand(
+            "kilo-code.new.openSubAgentViewer",
+            message.sessionID,
+            message.title,
+            message.agent,
+          )
           break
         case "previewImage":
           this.handlePreviewImage(message.dataUrl, message.filename)

--- a/packages/kilo-vscode/src/SubAgentViewerProvider.ts
+++ b/packages/kilo-vscode/src/SubAgentViewerProvider.ts
@@ -21,7 +21,7 @@ export class SubAgentViewerProvider implements vscode.Disposable {
     private readonly context: vscode.ExtensionContext,
   ) {}
 
-  openPanel(sessionID: string, title?: string): void {
+  openPanel(sessionID: string, title?: string, agent?: string): void {
     const existing = this.panels.get(sessionID)
     if (existing) {
       existing.reveal(vscode.ViewColumn.One)
@@ -75,7 +75,7 @@ export class SubAgentViewerProvider implements vscode.Disposable {
         })
 
         // Navigate to the sub-agent viewer
-        provider.postMessage({ type: "viewSubAgentSession", sessionID })
+        provider.postMessage({ type: "viewSubAgentSession", sessionID, agent })
       } catch (err) {
         console.error("[Kilo New] SubAgentViewerProvider: Failed to load session:", err)
       }

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -201,9 +201,12 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("kilo-code.new.showChanges", () => {
       diffViewerProvider.openPanel()
     }),
-    vscode.commands.registerCommand("kilo-code.new.openSubAgentViewer", (sessionID: string, title?: string) => {
-      subAgentViewerProvider.openPanel(sessionID, title)
-    }),
+    vscode.commands.registerCommand(
+      "kilo-code.new.openSubAgentViewer",
+      (sessionID: string, title?: string, agent?: string) => {
+        subAgentViewerProvider.openPanel(sessionID, title, agent)
+      },
+    ),
     vscode.commands.registerCommand("kilo-code.new.agentManager.previousSession", () => {
       agentManagerProvider.postMessage({ type: "action", action: "sessionPrevious" })
     }),

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -137,6 +137,7 @@ export const LanguageBridge: Component<{ children: any }> = (props) => {
 const AppContent: Component = () => {
   const [currentView, setCurrentView] = createSignal<ViewType>("newTask")
   const [settingsTab, setSettingsTab] = createSignal<string | undefined>()
+  const [subagent, setSubagent] = createSignal<string | undefined>()
   // legacy-migration: state-driven flag independent of currentView to avoid
   // race conditions with SettingsEditorProvider's navigate messages.
   const [migrationNeeded, setMigrationNeeded] = createSignal(false)
@@ -202,6 +203,7 @@ const AppContent: Component = () => {
       if (message?.type === "viewSubAgentSession" && message.sessionID) {
         console.log("[Kilo New] App: 🔍 viewSubAgentSession:", message.sessionID)
         session.setCurrentSessionID(message.sessionID)
+        setSubagent(message.agent)
         setCurrentView("subAgentViewer")
       }
       // legacy-migration: state-driven migration wizard
@@ -257,7 +259,7 @@ const AppContent: Component = () => {
               />
             </Match>
             <Match when={currentView() === "subAgentViewer"}>
-              <ChatView readonly />
+              <ChatView readonly agent={subagent()} />
             </Match>
           </Switch>
         }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -27,6 +27,8 @@ interface ChatViewProps {
   readonly?: boolean
   /** When true, show the "Continue in Worktree" button. Defaults to true in the sidebar. */
   continueInWorktree?: boolean
+  /** Sub-agent type name displayed in the header when viewing a sub-agent session. */
+  agent?: string
 }
 
 export const ChatView: Component<ChatViewProps> = (props) => {
@@ -124,7 +126,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
 
   return (
     <div class="chat-view">
-      <TaskHeader readonly={props.readonly} />
+      <TaskHeader readonly={props.readonly} agent={props.agent} />
       <div class="chat-messages-wrapper">
         <div class="chat-messages">
           <MessageList onSelectSession={props.onSelectSession} onShowHistory={props.onShowHistory} />

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -16,6 +16,8 @@ import type { TodoItem } from "../../types/messages"
 
 interface TaskHeaderProps {
   readonly?: boolean
+  /** Sub-agent type name (e.g. "explore", "code") shown in the header for popout viewers. */
+  agent?: string
 }
 
 export const TaskHeader: Component<TaskHeaderProps> = (props) => {
@@ -67,6 +69,16 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
           {title()}
         </div>
         <div data-slot="task-header-stats">
+          <Show when={props.agent}>
+            {(agent) => (
+              <Tooltip value="Sub-agent type" placement="bottom">
+                <span data-slot="task-header-agent">
+                  <Icon name="brain" size="small" />
+                  {agent()}
+                </span>
+              </Tooltip>
+            )}
+          </Show>
           <Show when={cost()}>
             {(c) => (
               <Tooltip value={language.t("context.usage.sessionCost")} placement="bottom">

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -75,7 +75,12 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
     e.stopPropagation()
     const id = childSessionId()
     if (!id) return
-    vscode.postMessage({ type: "openSubAgentViewer", sessionID: id, title: description() })
+    vscode.postMessage({
+      type: "openSubAgentViewer",
+      sessionID: id,
+      title: description(),
+      agent: props.input.subagent_type as string | undefined,
+    })
   }
 
   const trigger = () => (

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -64,6 +64,19 @@
 }
 
 /* ============================================
+   Task Header Agent Badge
+   ============================================ */
+
+[data-slot="task-header-agent"] {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-weak);
+  text-transform: capitalize;
+}
+
+/* ============================================
    Chat View Layout
    ============================================ */
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1139,6 +1139,7 @@ export interface EnhancePromptErrorMessage {
 export interface ViewSubAgentSessionMessage {
   type: "viewSubAgentSession"
   sessionID: string
+  agent?: string
 }
 
 export interface DiffViewerDiffsMessage {
@@ -1920,6 +1921,7 @@ export interface OpenSubAgentViewerRequest {
   type: "openSubAgentViewer"
   sessionID: string
   title?: string
+  agent?: string
 }
 
 // Preview an image attachment in VS Code's built-in image viewer


### PR DESCRIPTION
## Summary
- Thread the sub-agent type (`subagent_type`) from `TaskToolExpanded` through the extension host to the popout viewer webview
- Display the sub-agent type (e.g. "explore", "code", "general") with a brain icon in the `TaskHeader` alongside the existing cost display
- The cost was already shown in the `TaskHeader` — this PR makes it visible in the sub-agent popout by passing the `agent` field through the full message chain: `TaskToolExpanded` → `openSubAgentViewer` message → `KiloProvider` → VS Code command → `SubAgentViewerProvider` → `viewSubAgentSession` message → `App.tsx` → `ChatView` → `TaskHeader`

## Changes
- `webview-ui/src/types/messages.ts`: Added `agent?: string` to `ViewSubAgentSessionMessage` and `OpenSubAgentViewerRequest`
- `webview-ui/src/components/chat/TaskToolExpanded.tsx`: Pass `subagent_type` as `agent` in `openSubAgentViewer` message
- `src/KiloProvider.ts`: Forward `message.agent` to the VS Code command
- `src/extension.ts`: Accept `agent` param in command registration
- `src/SubAgentViewerProvider.ts`: Accept `agent` in `openPanel()`, forward to `viewSubAgentSession`
- `webview-ui/src/App.tsx`: Store `agent` in signal, pass to `ChatView`
- `webview-ui/src/components/chat/ChatView.tsx`: Accept `agent` prop, forward to `TaskHeader`
- `webview-ui/src/components/chat/TaskHeader.tsx`: Display agent badge with brain icon and tooltip
- `webview-ui/src/styles/chat.css`: Add styling for `task-header-agent` slot
