### PR TITLE
fix(vscode): wire continueInWorktreeHandler for tab panels

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -598,6 +598,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
                 error: err instanceof Error ? err.message : String(err),
               })
             })
+          } else if (message.sessionId) {
+            console.error("[Kilo New] continueInWorktree: no handler registered")
+            this.postMessage({
+              type: "continueInWorktreeProgress",
+              status: "error",
+              error: "Continue in Worktree is not available",
+            })
           }
           break
         case "retryConnection":

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -90,6 +90,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.window.registerWebviewPanelSerializer("kilo-code.new.TabPanel", {
       deserializeWebviewPanel(panel: vscode.WebviewPanel) {
         const tabProvider = new KiloProvider(context.extensionUri, connectionService, context)
+        tabProvider.setContinueInWorktreeHandler((sessionId, progress) =>
+          agentManagerProvider.continueFromSidebar(sessionId, progress),
+        )
         tabProvider.resolveWebviewPanel(panel)
         panel.onDidDispose(
           () => {
@@ -196,7 +199,7 @@ export function activate(context: vscode.ExtensionContext) {
       provider.postMessage({ type: "triggerTask", text: `Generate a terminal command: ${input}` })
     }),
     vscode.commands.registerCommand("kilo-code.new.openInTab", () => {
-      return openKiloInNewTab(context, connectionService)
+      return openKiloInNewTab(context, connectionService, agentManagerProvider)
     }),
     vscode.commands.registerCommand("kilo-code.new.showChanges", () => {
       diffViewerProvider.openPanel()
@@ -323,7 +326,11 @@ export function deactivate() {
   TelemetryProxy.getInstance().shutdown()
 }
 
-async function openKiloInNewTab(context: vscode.ExtensionContext, connectionService: KiloConnectionService) {
+async function openKiloInNewTab(
+  context: vscode.ExtensionContext,
+  connectionService: KiloConnectionService,
+  agentManagerProvider: AgentManagerProvider,
+) {
   const lastCol = Math.max(...vscode.window.visibleTextEditors.map((e) => e.viewColumn || 0), 0)
   const hasVisibleEditors = vscode.window.visibleTextEditors.length > 0
 
@@ -345,6 +352,9 @@ async function openKiloInNewTab(context: vscode.ExtensionContext, connectionServ
   }
 
   const tabProvider = new KiloProvider(context.extensionUri, connectionService, context)
+  tabProvider.setContinueInWorktreeHandler((sessionId, progress) =>
+    agentManagerProvider.continueFromSidebar(sessionId, progress),
+  )
   tabProvider.resolveWebviewPanel(panel)
 
   // Wait for the new panel to become active before locking the editor group.

--- a/packages/kilo-vscode/tests/unit/extension-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/extension-arch.test.ts
@@ -14,6 +14,8 @@ import path from "node:path"
 const ROOT = path.resolve(import.meta.dir, "../..")
 const PKG_JSON_FILE = path.join(ROOT, "package.json")
 const SRC_DIR = path.join(ROOT, "src")
+const EXTENSION_FILE = path.join(ROOT, "src/extension.ts")
+const KILO_PROVIDER_FILE = path.join(ROOT, "src/KiloProvider.ts")
 
 function readSrcFiles(dir: string): string {
   const parts: string[] = []
@@ -82,5 +84,102 @@ describe("Extension — package.json command sync", () => {
       bad,
       `Commands without "kilo-code.new." prefix — use the namespaced form:\n` + bad.map((b) => `  - ${b}`).join("\n"),
     ).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// KiloProvider handler wiring — every new KiloProvider() must get
+// setContinueInWorktreeHandler() called before resolving its webview.
+//
+// Regression: tab panels created via openKiloInNewTab() and the TabPanel
+// deserializer were missing the handler, causing "Capturing changes..." to
+// spin forever because the webview message was silently dropped.
+// ---------------------------------------------------------------------------
+
+describe("Extension — KiloProvider handler wiring", () => {
+  const ext = fs.readFileSync(EXTENSION_FILE, "utf-8")
+
+  /**
+   * Every `new KiloProvider(` in extension.ts must be followed (before the
+   * next `new KiloProvider(`) by a `setContinueInWorktreeHandler` call.
+   * This prevents future tab/panel additions from silently missing the handler.
+   */
+  it("every KiloProvider instance gets setContinueInWorktreeHandler wired", () => {
+    const pattern = /new KiloProvider\(/g
+    const instances: number[] = []
+    let match
+    while ((match = pattern.exec(ext)) !== null) {
+      instances.push(match.index)
+    }
+
+    expect(
+      instances.length,
+      "expected at least 3 KiloProvider instances (sidebar, tab, deserializer)",
+    ).toBeGreaterThanOrEqual(3)
+
+    const missing: string[] = []
+    for (let i = 0; i < instances.length; i++) {
+      const start = instances[i]
+      const end = instances[i + 1] ?? ext.length
+      const region = ext.slice(start, end)
+
+      if (!region.includes("setContinueInWorktreeHandler")) {
+        const line = ext.slice(0, start).split("\n").length
+        missing.push(`KiloProvider at line ${line}`)
+      }
+    }
+
+    expect(
+      missing,
+      `These KiloProvider instances are missing setContinueInWorktreeHandler.\n` +
+        `Without it, "Continue in Worktree" silently no-ops and the spinner\n` +
+        `stays stuck on "Capturing changes..." forever.\n\n` +
+        missing.map((m) => `  - ${m}`).join("\n"),
+    ).toEqual([])
+  })
+
+  it("openKiloInNewTab wires setContinueInWorktreeHandler before resolveWebviewPanel", () => {
+    const fn = ext.indexOf("function openKiloInNewTab")
+    expect(fn, "openKiloInNewTab must exist").toBeGreaterThan(-1)
+    const body = ext.slice(fn, fn + 1500)
+    const handler = body.indexOf("setContinueInWorktreeHandler")
+    const resolve = body.indexOf("resolveWebviewPanel")
+    expect(handler, "setContinueInWorktreeHandler must be called").toBeGreaterThan(-1)
+    expect(resolve, "resolveWebviewPanel must be called").toBeGreaterThan(-1)
+    expect(handler, "handler must be wired before resolving the panel").toBeLessThan(resolve)
+  })
+
+  it("TabPanel deserializer wires setContinueInWorktreeHandler before resolveWebviewPanel", () => {
+    const serializer = ext.indexOf('"kilo-code.new.TabPanel"')
+    expect(serializer, "TabPanel serializer must exist").toBeGreaterThan(-1)
+    const body = ext.slice(serializer, serializer + 800)
+    const handler = body.indexOf("setContinueInWorktreeHandler")
+    const resolve = body.indexOf("resolveWebviewPanel")
+    expect(handler, "setContinueInWorktreeHandler must be called in deserializer").toBeGreaterThan(-1)
+    expect(resolve, "resolveWebviewPanel must be called in deserializer").toBeGreaterThan(-1)
+    expect(handler, "handler must be wired before resolving the panel").toBeLessThan(resolve)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// KiloProvider — continueInWorktree error fallback
+//
+// Regression: when continueInWorktreeHandler is null, the message handler
+// must send an error back to the webview so the spinner resets. Previously
+// it silently no-op'd, leaving the UI stuck.
+// ---------------------------------------------------------------------------
+
+describe("KiloProvider — continueInWorktree error fallback", () => {
+  const provider = fs.readFileSync(KILO_PROVIDER_FILE, "utf-8")
+
+  it("sends error progress when handler is missing", () => {
+    const caseStart = provider.indexOf('case "continueInWorktree"')
+    expect(caseStart, "continueInWorktree case must exist").toBeGreaterThan(-1)
+    const caseEnd = provider.indexOf("break", caseStart)
+    const block = provider.slice(caseStart, caseEnd)
+
+    expect(block, "must have else branch for missing handler").toContain("else if")
+    expect(block, "must send error status back to webview").toContain('"error"')
+    expect(block, "must use continueInWorktreeProgress message type").toContain("continueInWorktreeProgress")
   })
 })


### PR DESCRIPTION
## Summary

- Fix "Capturing changes..." spinner stuck forever when clicking "Continue in Worktree" from a tab panel (Open in Tab or restored tab)
- Root cause: tab `KiloProvider` instances were missing `setContinueInWorktreeHandler`, so the `continueInWorktree` message was silently dropped and no progress was ever sent back to the webview
- Wire the handler for both `openKiloInNewTab()` and the `TabPanel` deserializer
- Add defensive error fallback in `KiloProvider` when the handler is unexpectedly null
- Add architecture regression tests to prevent this from happening again