### PR TITLE
fix(agent-manager): prevent model comparison popover from dismissing on interaction

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -515,7 +515,8 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                 <Popover
                   open={compareOpen()}
                   onOpenChange={setCompareOpen}
-                  placement="bottom-start"
+                  placement="top-start"
+                  flip={false}
                   sameWidth
                   class="am-compare-popover"
                   trigger={

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -106,11 +106,6 @@ export function Popover<T extends ValidComponent = "div">(props: PopoverProps<T>
       if (inside(target)) return
       // Node was detached by a reactive update — treat as inside
       if (!target.isConnected) return
-      // Focus left a popover child for an external node — but if the
-      // previously-focused element was inside, the shift was likely
-      // caused by a framework re-render rather than a real outside click
-      const related = event.relatedTarget
-      if (related instanceof Node && inside(related)) return
       close("outside")
     }
 

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -95,6 +95,8 @@ export function Popover<T extends ValidComponent = "div">(props: PopoverProps<T>
       const target = event.target
       if (!(target instanceof Node)) return
       if (inside(target)) return
+      // Node was detached by a reactive update — treat as inside
+      if (!target.isConnected) return
       close("outside")
     }
 
@@ -102,6 +104,13 @@ export function Popover<T extends ValidComponent = "div">(props: PopoverProps<T>
       const target = event.target
       if (!(target instanceof Node)) return
       if (inside(target)) return
+      // Node was detached by a reactive update — treat as inside
+      if (!target.isConnected) return
+      // Focus left a popover child for an external node — but if the
+      // previously-focused element was inside, the shift was likely
+      // caused by a framework re-render rather than a real outside click
+      const related = event.relatedTarget
+      if (related instanceof Node && inside(related)) return
       close("outside")
     }
 
@@ -140,8 +149,14 @@ export function Popover<T extends ValidComponent = "div">(props: PopoverProps<T>
         [local.class ?? ""]: !!local.class,
       }}
       style={local.style}
+      onInteractOutside={(event: Event) => {
+        // Custom window-level handlers manage outside dismissal;
+        // always prevent Kobalte's built-in interact-outside close
+        // to avoid double-firing and stale-node false positives.
+        event.preventDefault()
+      }}
       onFocusOutside={(event: Event) => {
-        if (!ready()) event.preventDefault()
+        event.preventDefault()
       }}
       onCloseAutoFocus={(event: Event) => {
         if (dismiss() === "outside") event.preventDefault()


### PR DESCRIPTION
## Summary
- Fixes the multi-model selector popover in the Agent Manager's worktree creation dialog dismissing immediately on any click (reported on Windows)
- Hardens the shared `Popover` component's dismiss logic against SolidJS DOM node detachment during reactive updates
- Changes the compare popover placement to always open upward (`top-start`) with `flip={false}`)

## Changes

### `packages/ui/src/components/popover.tsx`
- Added `!target.isConnected` guard in `onPointerDown` and `onFocusIn` handlers — prevents false-positive outside-click detection when SolidJS detaches DOM nodes during reactive updates
- Added `relatedTarget` check in `onFocusIn` — if the element that lost focus was inside the popover, the focus shift was caused by a framework re-render, not a genuine outside interaction
- Added `onInteractOutside` with `preventDefault()` and changed `onFocusOutside` to always prevent — disables Kobalte's built-in dismiss in favor of the custom window-level handlers which are more resilient to DOM mutations

### `packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx`
- Changed compare popover `placement` from `bottom-start` to `top-start`
- Added `flip={false}` to prevent auto-flipping back to bottom

Closes #7990