### PR TITLE
fix(vscode): add prompt stop bar

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -823,22 +823,24 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               <WandSparkles size={16} class={enhancing() ? "enhance-spinner" : ""} />
             </Button>
           </Tooltip>
-          <Tooltip
-            value={props.blocked?.() ? language.t("prompt.action.send.blocked") : language.t("prompt.action.send")}
-            placement="top"
-          >
-            <Button
-              variant="ghost"
-              size="small"
-              onClick={handleSend}
-              disabled={!canSend()}
-              aria-label={language.t("prompt.action.send")}
+          <Show when={!showStop()}>
+            <Tooltip
+              value={props.blocked?.() ? language.t("prompt.action.send.blocked") : language.t("prompt.action.send")}
+              placement="top"
             >
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                <path d="M1.5 1.5L14.5 8L1.5 14.5V9L10 8L1.5 7V1.5Z" />
-              </svg>
-            </Button>
-          </Tooltip>
+              <Button
+                variant="ghost"
+                size="small"
+                onClick={handleSend}
+                disabled={!canSend()}
+                aria-label={language.t("prompt.action.send")}
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M1.5 1.5L14.5 8L1.5 14.5V9L10 8L1.5 7V1.5Z" />
+                </svg>
+              </Button>
+            </Tooltip>
+          </Show>
         </div>
       </div>
     </div>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -3,7 +3,8 @@
  * Text input with send/abort buttons, ghost-text autocomplete, and @ file mention support
  */
 
-import { Component, createSignal, createEffect, on, For, Index, onCleanup, Show, untrack } from "solid-js"
+import { createSignal, createEffect, on, For, Index, onCleanup, Show, untrack } from "solid-js"
+import type { Component } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Dialog } from "@kilocode/kilo-ui/dialog"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
@@ -741,6 +742,21 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           </For>
         </div>
       </Show>
+      <Show when={showStop()}>
+        <button
+          type="button"
+          class="prompt-stop-bar"
+          onClick={() => session.abort()}
+          aria-label={language.t("prompt.action.stop")}
+        >
+          <span class="prompt-stop-bar-icon" aria-hidden="true">
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+              <rect x="3" y="3" width="10" height="10" rx="1" />
+            </svg>
+          </span>
+          <span>{language.t("prompt.action.stop")}</span>
+        </button>
+      </Show>
       <div class="prompt-input-wrapper">
         <div class="prompt-input-ghost-wrapper">
           <div class="prompt-input-highlight-overlay" ref={highlightRef} aria-hidden="true">
@@ -807,40 +823,22 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               <WandSparkles size={16} class={enhancing() ? "enhance-spinner" : ""} />
             </Button>
           </Tooltip>
-          <Show
-            when={showStop()}
-            fallback={
-              <Tooltip
-                value={props.blocked?.() ? language.t("prompt.action.send.blocked") : language.t("prompt.action.send")}
-                placement="top"
-              >
-                <Button
-                  variant="ghost"
-                  size="small"
-                  onClick={handleSend}
-                  disabled={!canSend()}
-                  aria-label={language.t("prompt.action.send")}
-                >
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M1.5 1.5L14.5 8L1.5 14.5V9L10 8L1.5 7V1.5Z" />
-                  </svg>
-                </Button>
-              </Tooltip>
-            }
+          <Tooltip
+            value={props.blocked?.() ? language.t("prompt.action.send.blocked") : language.t("prompt.action.send")}
+            placement="top"
           >
-            <Tooltip value={language.t("prompt.action.stop")} placement="top">
-              <Button
-                variant="ghost"
-                size="small"
-                onClick={() => session.abort()}
-                aria-label={language.t("prompt.action.stop")}
-              >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                  <rect x="3" y="3" width="10" height="10" rx="1" />
-                </svg>
-              </Button>
-            </Tooltip>
-          </Show>
+            <Button
+              variant="ghost"
+              size="small"
+              onClick={handleSend}
+              disabled={!canSend()}
+              aria-label={language.t("prompt.action.send")}
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M1.5 1.5L14.5 8L1.5 14.5V9L10 8L1.5 7V1.5Z" />
+              </svg>
+            </Button>
+          </Tooltip>
         </div>
       </div>
     </div>

--- a/packages/kilo-vscode/webview-ui/src/stories/prompt-input.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/prompt-input.stories.tsx
@@ -47,6 +47,23 @@ const PromptProviders: ParentComponent<{ variants?: boolean; modelOverride?: boo
   )
 }
 
+const BusyPromptProviders: ParentComponent = (props) => {
+  const base = mockSessionValue({ status: "busy" })
+  const session = {
+    ...base,
+    agents: () => agents,
+    selectedAgent: () => "code",
+  }
+
+  return (
+    <StoryProviders noPadding status="busy">
+      <div style={{ overflow: "hidden" }}>
+        <SessionContext.Provider value={session as any}>{props.children}</SessionContext.Provider>
+      </div>
+    </StoryProviders>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Meta — fullscreen so the screenshot is exactly the component width
 // ---------------------------------------------------------------------------
@@ -116,10 +133,28 @@ export const WithModelOverride420: Story = {
 }
 
 export const WithModelOverride200: Story = {
-  name: "With model override — 200px",
+  name: "With model override - 200px",
   render: () => (
     <PromptProviders modelOverride>
       <PromptInput />
     </PromptProviders>
+  ),
+}
+
+export const Busy420: Story = {
+  name: "Busy with stop bar - 420px",
+  render: () => (
+    <BusyPromptProviders>
+      <PromptInput />
+    </BusyPromptProviders>
+  ),
+}
+
+export const Busy200: Story = {
+  name: "Busy with stop bar - 200px",
+  render: () => (
+    <BusyPromptProviders>
+      <PromptInput />
+    </BusyPromptProviders>
   ),
 }

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -949,6 +949,45 @@
   align-items: flex-end;
 }
 
+.prompt-stop-bar {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--vscode-errorForeground, #f14c4c) 40%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--vscode-errorForeground, #f14c4c) 12%, transparent);
+  color: var(--vscode-errorForeground, #f14c4c);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease;
+}
+
+.prompt-stop-bar:hover {
+  background: color-mix(in srgb, var(--vscode-errorForeground, #f14c4c) 18%, transparent);
+  border-color: color-mix(in srgb, var(--vscode-errorForeground, #f14c4c) 55%, transparent);
+}
+
+.prompt-stop-bar:focus-visible {
+  outline: 1px solid var(--border-focus, var(--vscode-focusBorder, #007fd4));
+  outline-offset: 1px;
+}
+
+.prompt-stop-bar-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .prompt-input {
   flex: 1;
   min-height: 54px;
@@ -1094,6 +1133,7 @@
       stroke: var(--border-focus, var(--vscode-focusBorder, #007fd4));
     }
   }
+
   [data-component="icon-button"] {
     [data-slot="icon-svg"] {
       color: var(--icon-base) !important;


### PR DESCRIPTION
Fixes #7998 

## Context

Make the running-state stop control easier to discover in the VS Code prompt input. The existing stop action lived in the small trailing icon slot, which made it easy to miss while a request was in progress.

## Implementation

- render a full-width stop bar above the prompt when the session is busy and the draft is empty
- hide the normal send button while that stop bar is visible so the running state has a single, clear primary action
- add Storybook busy-state stories for both sidebar widths and keep the stop bar styling in `chat.css`

## Screenshots
Old:

<img width="651" height="253" alt="afbeelding" src="https://github.com/user-attachments/assets/f4e23414-da67-4b3e-840e-26683e45dcd9" />

New:

<img width="578" height="227" alt="Schermafdruk van 2026-03-31 18-17-17" src="https://github.com/user-attachments/assets/41d4cf68-59f9-46a4-9697-938beeb23b9e" />


## How to Test

- Run the VS Code extension or Storybook for `packages/kilo-vscode/webview-ui/`
- Open a chat session and submit a prompt so the session becomes busy
- Confirm the send icon is replaced by a full-width stop bar when the input is otherwise empty
- Click the stop bar and confirm it aborts the running session
- Type text while the session is busy and confirm the stop bar hides and the normal send controls return
- Check the `Busy with stop bar` stories at both 420px and 200px widths

## Get in Touch

thomas07374