### PR TITLE
fix: ensure plan mode can create plan files

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1419,6 +1419,11 @@ export namespace SessionPrompt {
     // Original logic when experimental plan mode is disabled
     if (!Flag.KILO_EXPERIMENTAL_PLAN_MODE) {
       if (input.agent.name === "plan") {
+        // kilocode_change start - ensure non-experimental plan mode still allows writing the plan file
+        const plan = Session.plan(input.session)
+        const exists = await Filesystem.exists(plan)
+        if (!exists) await fs.mkdir(path.dirname(plan), { recursive: true })
+
         userMessage.parts.push({
           id: Identifier.ascending("part"),
           messageID: userMessage.info.id,
@@ -1427,6 +1432,20 @@ export namespace SessionPrompt {
           text: PROMPT_PLAN,
           synthetic: true,
         })
+
+        userMessage.parts.push({
+          id: Identifier.ascending("part"),
+          messageID: userMessage.info.id,
+          sessionID: userMessage.info.sessionID,
+          type: "text",
+          text: `<system-reminder>
+## Plan File Info:
+${exists ? `A plan file already exists at ${plan}. You can read it and make incremental edits using the edit tool.` : `No plan file exists yet. You should create your plan at ${plan} using the write tool.`}
+You should build your plan incrementally by writing to or editing this file. NOTE that this is the only file you are allowed to edit - other than this you are only allowed to take READ-ONLY actions.
+</system-reminder>`,
+          synthetic: true,
+        })
+        // kilocode_change end
       }
       const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
       // kilocode_change start - renamed from "build" to "code"

--- a/packages/opencode/test/kilocode/plan-exit-detection.test.ts
+++ b/packages/opencode/test/kilocode/plan-exit-detection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { Identifier } from "../../src/id/id"
@@ -8,6 +8,8 @@ import { Question } from "../../src/question"
 import { Session } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
+import { SessionSummary } from "../../src/session/summary"
+import type { LLM as LLMType } from "../../src/session/llm"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 
@@ -114,6 +116,68 @@ async function waitQuestion(sessionID: string) {
 }
 
 describe("plan_exit detection", () => {
+  test("plan mode reminder includes plan path and creates plans dir", () =>
+    withInstance(async () => {
+      const { LLM } = await import("../../src/session/llm")
+      const session = await Session.create({ title: "plan mode prompt" })
+      const plan = Session.plan(session)
+      const dir = path.dirname(plan)
+      await fs.rm(dir, { recursive: true, force: true })
+
+      const seen = { text: "" }
+      const summary = spyOn(SessionSummary, "summarize").mockResolvedValue(undefined)
+      const llm = spyOn(LLM, "stream").mockImplementation(async (input: LLMType.StreamInput) => {
+        const msg = input.messages.findLast((item) => item.role === "user")
+        const text = msg
+          ? typeof msg.content === "string"
+            ? msg.content
+            : msg.content
+                .map((part) => {
+                  if (part.type === "text") return part.text
+                  return ""
+                })
+                .join("\n")
+          : ""
+        seen.text = text
+
+        const exists = await fs
+          .stat(dir)
+          .then((item) => item.isDirectory())
+          .catch(() => false)
+        expect(exists).toBe(true)
+
+        return {
+          fullStream: (async function* () {
+            yield { type: "start" }
+            yield { type: "start-step" }
+            yield {
+              type: "finish-step",
+              finishReason: "stop",
+              usage: { inputTokens: 1, completionTokens: 1, totalTokens: 2 },
+              providerMetadata: undefined,
+            }
+            yield { type: "finish" }
+          })(),
+        } as any
+      })
+
+      try {
+        await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "plan",
+          parts: [{ type: "text", text: "create a plan" }],
+        })
+      } finally {
+        llm.mockRestore()
+        summary.mockRestore()
+      }
+
+      expect(seen.text).toContain(plan)
+      expect(
+        seen.text.includes("exception of the plan file") || seen.text.includes("only file you are allowed to edit"),
+      ).toBe(true)
+    }))
+
   test("PlanFollowup.ask triggers when plan_exit tool is present", () =>
     withInstance(async () => {
       const seeded = await seed({


### PR DESCRIPTION
## Context

Fixes #6907

## Implementation

Two causes were suspected for this issue:
- First, it was suspected that the agent could fail to create the plan file if the plans directory does not exist. This seems to be the less likely cause, but we still add an explicit mkdir to ensure the directory exists.
- Second, the prompt for Plan mode too aggressively specifies that the agent should not make "ANY file edits" and it is "STRICTLY FORBIDDEN". It is likely that the Plan mode agent is following this instruction too strictly. To resolve this, we add a system reminder to instruct the agent that it should create or edit the plan file at the specified location--and no other files.

## How to Test

- Plan something in Plan mode
- Ensure that the plan file is written into `.kilo/plans` and that the file actually exists--behavior in `main` is that the agent reports that the file is created, but does not actually created.

## Get in Touch

ExpedientFalcon on Discord