### PR TITLE
Revert "fix(cli): restore directory tree in system prompt"

### DIFF
--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -74,7 +74,7 @@ export namespace SystemPrompt {
         `</env>`,
         `<directories>`,
         `  ${
-          project.vcs === "git"
+          project.vcs === "git" && false
             ? await Ripgrep.tree({
                 cwd: Instance.directory,
                 limit: 50,


### PR DESCRIPTION
Reverts Kilo-Org/kilocode#7949

See https://github.com/Kilo-Org/kilocode/pull/8027

also, this is now adding this information twice to the prompt in the vscode extension, and it's in the system prompt so it breaks caching

It's quite inefficient:

The function only needs directories, but it:

Lists all files (including leaf filenames it discards)
Materializes them all into memory before iterating
Only outputs 50 lines of the result
A more efficient approach would stream the generator and build the tree incrementally, or use rg --files piped through directory extraction without full materialization. But for repos under ~50k files, the current implementation completes in well under 100ms total, so it's unlikely to be a practical issue unless you're working in a very large monorepo or on a slow filesystem (e.g., network mount, Docker volume on macOS).

Uses more memory/time when the repo is bigger