### PR TITLE
fix: skip request logging for /telemetry/capture endpoint

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -90,7 +90,7 @@ export namespace Server {
           return basicAuth({ username, password })(c, next)
         })
         .use(async (c, next) => {
-          const skipLogging = c.req.path === "/log"
+          const skipLogging = c.req.path === "/log" || c.req.path === "/telemetry/capture" // kilocode_change
           if (!skipLogging) {
             log.info("request", {
               method: c.req.method,


### PR DESCRIPTION
The server middleware logs 3 lines per HTTP request (request, started, completed). For /telemetry/capture this creates unnecessary log volume since autocomplete telemetry can fire multiple events per keystroke (Suggestion Requested, LLM Suggestion Returned, Unique Suggestion Shown).

Add /telemetry/capture to the skipLogging check alongside /log to reduce noise in the kilo server log files at ~/.local/share/kilo/log/.
