### PR TITLE
fix(vscode): normalize migrated session paths

### DIFF
--- a/packages/kilo-vscode/src/legacy-migration/sessions/lib/messages.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/lib/messages.ts
@@ -10,11 +10,12 @@ type Assistant = Extract<Data, { role: "assistant" }>
 export function parseMessagesFromConversation(
   conversation: LegacyApiMessage[],
   id: string,
+  dir: string,
   item?: LegacyHistoryItem,
 ): Array<NonNullable<Message["body"]>> {
   return conversation
     .filter((entry) => entry.role === "user" || entry.role === "assistant")
-    .map((entry, index) => parseMessage(entry, index, id, item))
+    .map((entry, index) => parseMessage(entry, index, id, dir, item))
     .filter((message): message is NonNullable<Message["body"]> => Boolean(message))
 }
 
@@ -22,6 +23,7 @@ function parseMessage(
   entry: LegacyApiMessage,
   index: number,
   id: string,
+  dir: string,
   item?: LegacyHistoryItem,
 ): NonNullable<Message["body"]> | undefined {
   const created = entry.ts ?? item?.ts ?? 0
@@ -55,8 +57,8 @@ function parseMessage(
       mode: item?.mode ?? "code",
       agent: "main",
       path: {
-        cwd: item?.workspace ?? "",
-        root: item?.workspace ?? "",
+        cwd: dir,
+        root: dir,
       },
       cost: 0,
       tokens: {

--- a/packages/kilo-vscode/src/legacy-migration/sessions/lib/messages.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/lib/messages.ts
@@ -13,7 +13,7 @@ export function parseMessagesFromConversation(
   dirOrItem?: string | LegacyHistoryItem,
   item?: LegacyHistoryItem,
 ): Array<NonNullable<Message["body"]>> {
-  const dir = typeof dirOrItem === "string" ? dirOrItem : dirOrItem?.workspace ?? ""
+  const dir = typeof dirOrItem === "string" ? dirOrItem : (dirOrItem?.workspace ?? "")
   const next = typeof dirOrItem === "string" ? item : dirOrItem
 
   return conversation

--- a/packages/kilo-vscode/src/legacy-migration/sessions/lib/messages.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/lib/messages.ts
@@ -10,12 +10,15 @@ type Assistant = Extract<Data, { role: "assistant" }>
 export function parseMessagesFromConversation(
   conversation: LegacyApiMessage[],
   id: string,
-  dir: string,
+  dirOrItem?: string | LegacyHistoryItem,
   item?: LegacyHistoryItem,
 ): Array<NonNullable<Message["body"]>> {
+  const dir = typeof dirOrItem === "string" ? dirOrItem : dirOrItem?.workspace ?? ""
+  const next = typeof dirOrItem === "string" ? item : dirOrItem
+
   return conversation
     .filter((entry) => entry.role === "user" || entry.role === "assistant")
-    .map((entry, index) => parseMessage(entry, index, id, dir, item))
+    .map((entry, index) => parseMessage(entry, index, id, dir, next))
     .filter((message): message is NonNullable<Message["body"]> => Boolean(message))
 }
 

--- a/packages/kilo-vscode/src/legacy-migration/sessions/lib/path.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/lib/path.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs/promises"
+import * as path from "path"
+
+export async function normalizeLegacyPath(input?: string): Promise<string> {
+  const raw = input?.trim()
+  if (!raw) return ""
+
+  // Collapse legacy paths into one stable absolute form before importing them.
+  const normalized = path.normalize(path.resolve(raw))
+  const canonical = normalizeWindowsDriveLetter(normalized)
+
+  return fs.realpath(canonical).catch(() => canonical)
+}
+
+export function isWindowsDrivePath(input: string): boolean {
+  return /^[a-z]:[\\/]/i.test(input)
+}
+
+function normalizeWindowsDriveLetter(input: string): string {
+  // Match the canonical drive-letter casing used later by Windows path filters.
+  if (!isWindowsDrivePath(input)) return input
+  const head = input[0]
+  if (!head) return input
+  return head.toUpperCase() + input.slice(1)
+}

--- a/packages/kilo-vscode/src/legacy-migration/sessions/lib/project.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/lib/project.ts
@@ -4,12 +4,13 @@ import { createProjectID } from "./ids"
 
 export function createProject(item?: LegacyHistoryItem): NonNullable<Project["body"]> {
   const project = makeProject()
+  const dir = item?.workspace ?? ""
 
-  project.id = createProjectID(item?.workspace)
+  project.id = createProjectID(dir)
 
-  project.worktree = item?.workspace ?? ""
+  project.worktree = dir
 
-  project.sandboxes = item?.workspace ? [item.workspace] : []
+  project.sandboxes = dir ? [dir] : []
 
   project.timeCreated = item?.ts ?? 0
 

--- a/packages/kilo-vscode/src/legacy-migration/sessions/lib/session.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/lib/session.ts
@@ -1,15 +1,14 @@
 import type { KilocodeSessionImportSessionData as Session } from "@kilocode/sdk/v2"
 import type { LegacyHistoryItem } from "./legacy-types"
 import { createSessionID } from "./ids"
-import { normalizeLegacyPath } from "./path"
 
-export async function createSession(
+export function createSession(
   id: string,
   item: LegacyHistoryItem | undefined,
   projectID: string,
-): Promise<NonNullable<Session["body"]>> {
+  dir: string,
+): NonNullable<Session["body"]> {
   const session = makeSession()
-  const dir = await normalizeLegacyPath(item?.workspace)
 
   session.id = createSessionID(id)
 

--- a/packages/kilo-vscode/src/legacy-migration/sessions/lib/session.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/lib/session.ts
@@ -1,13 +1,15 @@
 import type { KilocodeSessionImportSessionData as Session } from "@kilocode/sdk/v2"
 import type { LegacyHistoryItem } from "./legacy-types"
 import { createSessionID } from "./ids"
+import { normalizeLegacyPath } from "./path"
 
-export function createSession(
+export async function createSession(
   id: string,
   item: LegacyHistoryItem | undefined,
   projectID: string,
-): NonNullable<Session["body"]> {
+): Promise<NonNullable<Session["body"]>> {
   const session = makeSession()
+  const dir = await normalizeLegacyPath(item?.workspace)
 
   session.id = createSessionID(id)
 
@@ -15,7 +17,7 @@ export function createSession(
 
   session.slug = id
 
-  session.directory = item?.workspace ?? ""
+  session.directory = dir
 
   session.title = item?.task ?? id
 

--- a/packages/kilo-vscode/src/legacy-migration/sessions/parser.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/parser.ts
@@ -20,7 +20,7 @@ export interface NormalizedSession {
 
 export async function parseSession(id: string, dir: string, item?: LegacyHistoryItem): Promise<NormalizedSession> {
   const project = createProject(item)
-  const session = createSession(id, item, project.id)
+  const session = await createSession(id, item, project.id)
   const file = await getApiConversationHistory(id, dir)
   const conversation = parseFile(file)
   const messages = parseMessagesFromConversation(conversation, id, item)

--- a/packages/kilo-vscode/src/legacy-migration/sessions/parser.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/parser.ts
@@ -8,6 +8,7 @@ import type {
 import { getApiConversationHistory, parseFile } from "./lib/legacy-conversation"
 import { parseMessagesFromConversation } from "./lib/messages"
 import { parsePartsFromConversation } from "./lib/parts/parts"
+import { normalizeLegacyPath } from "./lib/path"
 import { createProject } from "./lib/project"
 import { createSession } from "./lib/session"
 
@@ -19,11 +20,13 @@ export interface NormalizedSession {
 }
 
 export async function parseSession(id: string, dir: string, item?: LegacyHistoryItem): Promise<NormalizedSession> {
-  const project = createProject(item)
-  const session = await createSession(id, item, project.id)
+  const root = await normalizeLegacyPath(item?.workspace)
+  const next = item ? { ...item, workspace: root } : undefined
+  const project = createProject(next)
+  const session = createSession(id, next, project.id, root)
   const file = await getApiConversationHistory(id, dir)
   const conversation = parseFile(file)
-  const messages = parseMessagesFromConversation(conversation, id, item)
+  const messages = parseMessagesFromConversation(conversation, id, root, next)
   const parts = parsePartsFromConversation(conversation, id, item)
 
   return {

--- a/packages/kilo-vscode/tests/unit/legacy-migration/messages.test.ts
+++ b/packages/kilo-vscode/tests/unit/legacy-migration/messages.test.ts
@@ -43,7 +43,7 @@ function sample(): LegacyApiMessage[] {
 
 describe("legacy migration messages", () => {
   it("parses a basic legacy conversation into ordered user and assistant messages with stable ids", () => {
-    const list = parseMessagesFromConversation(sample(), id, item)
+    const list = parseMessagesFromConversation(sample(), id, item.workspace, item)
 
     expect(list).toHaveLength(2)
     expect(list[0]?.data.role).toBe("user")
@@ -53,7 +53,7 @@ describe("legacy migration messages", () => {
   })
 
   it("creates valid assistant message metadata for the SDK/backend shape", () => {
-    const list = parseMessagesFromConversation(sample(), id, item)
+    const list = parseMessagesFromConversation(sample(), id, item.workspace, item)
     const msg = list.find((x) => x.data.role === "assistant")
 
     expect(msg?.data.role).toBe("assistant")
@@ -66,7 +66,7 @@ describe("legacy migration messages", () => {
   })
 
   it("ignores unsupported legacy entries instead of producing broken messages", () => {
-    const list = parseMessagesFromConversation(sample(), id, item)
+    const list = parseMessagesFromConversation(sample(), id, item.workspace, item)
 
     expect(list).toHaveLength(2)
     expect(list.some((x) => x.data.role !== "user" && x.data.role !== "assistant")).toBe(false)
@@ -92,6 +92,7 @@ describe("legacy migration messages", () => {
         },
       ],
       id,
+      item.workspace,
       item,
     )
 

--- a/packages/kilo-vscode/tests/unit/legacy-migration/parser.test.ts
+++ b/packages/kilo-vscode/tests/unit/legacy-migration/parser.test.ts
@@ -15,14 +15,14 @@ const item = {
 describe("legacy migration parser", () => {
   it("uses the final deterministic ids expected for migration", () => {
     const project = createProject(item)
-    const session = createSession(id, item, project.id)
+    const session = createSession(id, item, project.id, item.workspace)
     const msg1 = createMessageID(id, 0)
     const msg2 = createMessageID(id, 1)
     const prt1 = createPartID(id, 0, 0)
     const prt2 = createPartID(id, 1, 0)
 
     expect(project.id).toBe(createProject(item).id)
-    expect(session.id).toBe(createSession(id, item, project.id).id)
+    expect(session.id).toBe(createSession(id, item, project.id, item.workspace).id)
     expect(session.id.startsWith("ses_migrated_")).toBe(true)
     expect(msg1).toBe(createMessageID(id, 0))
     expect(msg2).toBe(createMessageID(id, 1))

--- a/packages/kilo-vscode/tests/unit/legacy-migration/path.test.ts
+++ b/packages/kilo-vscode/tests/unit/legacy-migration/path.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+
+const realpath = mock(async (input: string) => input)
+
+mock.module("fs/promises", () => ({
+  realpath,
+}))
+
+const { isWindowsDrivePath, normalizeLegacyPath } = await import("../../../src/legacy-migration/sessions/lib/path")
+
+describe("legacy migration path", () => {
+  beforeEach(() => {
+    realpath.mockReset()
+    realpath.mockImplementation(async (input: string) => input)
+  })
+
+  afterEach(() => {})
+
+  it("returns an empty string for empty legacy paths", async () => {
+    expect(await normalizeLegacyPath("   ")).toBe("")
+    expect(realpath).not.toHaveBeenCalled()
+  })
+
+  it("detects Windows drive paths without relying on runtime platform", () => {
+    expect(isWindowsDrivePath("c:\\repo")).toBe(true)
+    expect(isWindowsDrivePath("C:/repo")).toBe(true)
+    expect(isWindowsDrivePath("/repo")).toBe(false)
+  })
+
+  it("uppercases the Windows drive letter before resolving the final path", async () => {
+    const value = await normalizeLegacyPath("c:\\repo\\..\\repo\\file.txt")
+
+    expect(realpath).toHaveBeenCalledTimes(1)
+    expect(realpath.mock.calls[0]?.[0]).toBe("C:\\repo\\file.txt")
+    expect(value).toBe("C:\\repo\\file.txt")
+  })
+
+  it("falls back to the normalized path when realpath fails", async () => {
+    realpath.mockRejectedValueOnce(new Error("missing"))
+
+    const value = await normalizeLegacyPath("c:\\repo\\.\\child")
+
+    expect(value).toBe("C:\\repo\\child")
+  })
+})

--- a/packages/kilo-vscode/tests/unit/legacy-migration/path.test.ts
+++ b/packages/kilo-vscode/tests/unit/legacy-migration/path.test.ts
@@ -27,13 +27,14 @@ describe("legacy migration path", () => {
   })
 
   it("uppercases the Windows drive letter before resolving the final path", async () => {
-    realpath.mockImplementation(async (input: string) => input.replaceAll("/", "\\"))
+    realpath.mockImplementation(async (input: string) => input)
 
-    const value = await normalizeLegacyPath("C:/repo/../repo/file.txt")
+    const value = await normalizeLegacyPath("c:/repo/../repo/file.txt")
+    const expected = path.normalize(path.resolve("c:/repo/../repo/file.txt"))
 
     expect(realpath).toHaveBeenCalledTimes(1)
-    expect(realpath.mock.calls[0]?.[0]).toBe(path.normalize(path.resolve("C:/repo/../repo/file.txt")))
-    expect(value).toBe("C:\\repo\\file.txt")
+    expect(realpath.mock.calls[0]?.[0]).toBe(expected.replace(/^c:/, "C:"))
+    expect(value).toBe(expected.replace(/^c:/, "C:"))
   })
 
   it("falls back to the normalized path when realpath fails", async () => {

--- a/packages/kilo-vscode/tests/unit/legacy-migration/path.test.ts
+++ b/packages/kilo-vscode/tests/unit/legacy-migration/path.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+import * as path from "path"
 
 const realpath = mock(async (input: string) => input)
 
@@ -14,8 +15,6 @@ describe("legacy migration path", () => {
     realpath.mockImplementation(async (input: string) => input)
   })
 
-  afterEach(() => {})
-
   it("returns an empty string for empty legacy paths", async () => {
     expect(await normalizeLegacyPath("   ")).toBe("")
     expect(realpath).not.toHaveBeenCalled()
@@ -28,18 +27,21 @@ describe("legacy migration path", () => {
   })
 
   it("uppercases the Windows drive letter before resolving the final path", async () => {
-    const value = await normalizeLegacyPath("c:\\repo\\..\\repo\\file.txt")
+    realpath.mockImplementation(async (input: string) => input.replaceAll("/", "\\"))
+
+    const value = await normalizeLegacyPath("C:/repo/../repo/file.txt")
 
     expect(realpath).toHaveBeenCalledTimes(1)
-    expect(realpath.mock.calls[0]?.[0]).toBe("C:\\repo\\file.txt")
+    expect(realpath.mock.calls[0]?.[0]).toBe(path.normalize(path.resolve("C:/repo/../repo/file.txt")))
     expect(value).toBe("C:\\repo\\file.txt")
   })
 
   it("falls back to the normalized path when realpath fails", async () => {
     realpath.mockRejectedValueOnce(new Error("missing"))
 
-    const value = await normalizeLegacyPath("c:\\repo\\.\\child")
+    const input = "C:/repo/./child"
+    const value = await normalizeLegacyPath(input)
 
-    expect(value).toBe("C:\\repo\\child")
+    expect(value).toBe(path.normalize(path.resolve(input)))
   })
 })

--- a/packages/kilo-vscode/tests/unit/legacy-migration/session.test.ts
+++ b/packages/kilo-vscode/tests/unit/legacy-migration/session.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "bun:test"
 import { createSession } from "../../../src/legacy-migration/sessions/lib/session"
 
 describe("legacy migration session", () => {
-  it("builds a session from legacy task metadata and the resolved project id", () => {
-    const session = createSession(
+  it("builds a session from legacy task metadata and the resolved project id", async () => {
+    const session = await createSession(
       "019d3df5-d5d9-73dc-bc2c-43a6304ac62c",
       {
         id: "019d3df5-d5d9-73dc-bc2c-43a6304ac62c",
@@ -23,16 +23,16 @@ describe("legacy migration session", () => {
     expect(session.timeUpdated).toBe(1774861014564)
   })
 
-  it("creates a deterministic session id from the legacy task id", () => {
-    const a = createSession("legacy-task-1", undefined, "project-1")
-    const b = createSession("legacy-task-1", undefined, "project-1")
+  it("creates a deterministic session id from the legacy task id", async () => {
+    const a = await createSession("legacy-task-1", undefined, "project-1")
+    const b = await createSession("legacy-task-1", undefined, "project-1")
 
     expect(a.id).toBe(b.id)
     expect(a.id.startsWith("ses_migrated_")).toBe(true)
   })
 
-  it("falls back to the legacy id as title when task metadata is missing", () => {
-    const session = createSession("legacy-task-1", undefined, "project-1")
+  it("falls back to the legacy id as title when task metadata is missing", async () => {
+    const session = await createSession("legacy-task-1", undefined, "project-1")
 
     expect(session.slug).toBe("legacy-task-1")
     expect(session.title).toBe("legacy-task-1")

--- a/packages/kilo-vscode/tests/unit/legacy-migration/session.test.ts
+++ b/packages/kilo-vscode/tests/unit/legacy-migration/session.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "bun:test"
 import { createSession } from "../../../src/legacy-migration/sessions/lib/session"
 
 describe("legacy migration session", () => {
-  it("builds a session from legacy task metadata and the resolved project id", async () => {
-    const session = await createSession(
+  it("builds a session from legacy task metadata and the resolved project id", () => {
+    const session = createSession(
       "019d3df5-d5d9-73dc-bc2c-43a6304ac62c",
       {
         id: "019d3df5-d5d9-73dc-bc2c-43a6304ac62c",
@@ -13,6 +13,7 @@ describe("legacy migration session", () => {
         mode: "code",
       },
       "project-1",
+      "/workspace/testing",
     )
 
     expect(session.projectID).toBe("project-1")
@@ -23,16 +24,16 @@ describe("legacy migration session", () => {
     expect(session.timeUpdated).toBe(1774861014564)
   })
 
-  it("creates a deterministic session id from the legacy task id", async () => {
-    const a = await createSession("legacy-task-1", undefined, "project-1")
-    const b = await createSession("legacy-task-1", undefined, "project-1")
+  it("creates a deterministic session id from the legacy task id", () => {
+    const a = createSession("legacy-task-1", undefined, "project-1", "")
+    const b = createSession("legacy-task-1", undefined, "project-1", "")
 
     expect(a.id).toBe(b.id)
     expect(a.id.startsWith("ses_migrated_")).toBe(true)
   })
 
-  it("falls back to the legacy id as title when task metadata is missing", async () => {
-    const session = await createSession("legacy-task-1", undefined, "project-1")
+  it("falls back to the legacy id as title when task metadata is missing", () => {
+    const session = createSession("legacy-task-1", undefined, "project-1", "")
 
     expect(session.slug).toBe("legacy-task-1")
     expect(session.title).toBe("legacy-task-1")


### PR DESCRIPTION
## What changed
- Normalized legacy workspace paths once during migration so imported sessions keep a stable project path.
- Reused that same normalized path for the migrated project, session, and message context so everything stays aligned.
- Added focused unit coverage for the new path helper and updated migration tests around the new flow.

## Why this matters
- Migrated sessions on Windows could be stored with a path format that did not match the one used later to load sessions.
- That mismatch made old migrated sessions disappear from the normal session list even though they were present in the database.
- This change keeps migrated paths consistent and avoids recalculating different versions of the same workspace path.

## Testing
- Ran unit tests for the legacy migration path helper and updated migration-related tests.
- Did a manual check on macOS to confirm the migration flow still builds the expected project and session payloads.
- Did a manual check on Windows to confirm newly migrated sessions show up in the normal session list after import.