### PR TITLE
fix(vscode): drain pending permissions and questions before config save

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -65,6 +65,7 @@ import {
 import {
   handlePermissionResponse,
   fetchAndSendPendingPermissions,
+  recoveryDirs,
   type PermissionContext,
 } from "./kilo-provider/handlers/permission-handler"
 import { handleQuestionReply, handleQuestionReject } from "./kilo-provider/handlers/question"
@@ -1988,6 +1989,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // races with the async config.update() write on the CLI backend).
     this.pending++
     try {
+      // Reject all pending permissions and questions so their CLI-side
+      // Promises resolve before disposeAll() wipes Instance state.
+      await this.drainPendingPrompts()
+
       await this.client.global.config.update({ config: partial }, { throwOnError: true })
 
       // Re-fetch the full merged config (global + project + all layers) so the
@@ -1999,6 +2004,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       this.cachedConfigMessage = { type: "configLoaded", config: merged }
       this.postMessage({ type: "configUpdated", config: merged })
+
+      // Clear stale permission/question UI after the dispose cycle.
+      // The drain above resolved them on the CLI side, but SSE events
+      // may race with the dispose — this ensures the webview is clean.
+      this.postMessage({ type: "clearPendingPrompts" })
 
       if (refreshProviders) {
         await this.fetchAndSendProviders()
@@ -2020,10 +2030,29 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   /**
-   * Handle sending a message from the webview.
-   * Uses promptAsync (fire-and-forget) — the server queues concurrent prompts
-   * internally, so the client doesn't need to block on busy sessions.
+   * Reject all pending permission requests and questions across all tracked
+   * directories. Called before config saves that trigger Instance.disposeAll()
+   * on the CLI backend, to prevent orphaned Promises from freezing sessions.
    */
+  private async drainPendingPrompts(): Promise<void> {
+    if (!this.client) return
+    const dirs = recoveryDirs(this.getWorkspaceDirectory(), this.sessionDirectories)
+    for (const dir of dirs) {
+      const { data: perms } = await this.client.permission.list({ directory: dir })
+      if (perms) {
+        for (const perm of perms) {
+          await this.client.permission.reply({ requestID: perm.id, reply: "reject", directory: dir })
+        }
+      }
+      const { data: qs } = await this.client.question.list({ directory: dir })
+      if (qs) {
+        for (const q of qs) {
+          await this.client.question.reject({ requestID: q.id, directory: dir })
+        }
+      }
+    }
+  }
+
   /**
    * Ensure a session exists, creating one if needed. Returns the resolved
    * session ID and workspace directory, or undefined when the client is

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -65,7 +65,6 @@ import {
 import {
   handlePermissionResponse,
   fetchAndSendPendingPermissions,
-  recoveryDirs,
   type PermissionContext,
 } from "./kilo-provider/handlers/permission-handler"
 import { handleQuestionReply, handleQuestionReject } from "./kilo-provider/handlers/question"
@@ -145,6 +144,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private unsubscribeLanguageChange: (() => void) | null = null
   private unsubscribeProfileChange: (() => void) | null = null
   private unsubscribeMigrationComplete: (() => void) | null = null // legacy-migration
+  private unsubscribeClearPendingPrompts: (() => void) | null = null
+  private unsubscribeDirectoryProvider: (() => void) | null = null
   private initConnectionPromise: Promise<void> | null = null
   private webviewMessageDisposable: vscode.Disposable | null = null
 
@@ -956,6 +957,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.unsubscribeNotificationDismiss?.()
     this.unsubscribeLanguageChange?.()
     this.unsubscribeProfileChange?.()
+    this.unsubscribeClearPendingPrompts?.()
+    this.unsubscribeDirectoryProvider?.()
 
     try {
       const workspaceDir = this.getWorkspaceDirectory()
@@ -1033,6 +1036,16 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         this.postMessage({ type: "migrationState", needed: false })
       })
       // legacy-migration end
+
+      // Subscribe to clear-pending-prompts broadcast (fired after config save drains prompts)
+      this.unsubscribeClearPendingPrompts = this.connectionService.onClearPendingPrompts(() => {
+        this.postMessage({ type: "clearPendingPrompts" })
+      })
+
+      // Register this provider's directories so drainPendingPrompts() covers all instances
+      this.unsubscribeDirectoryProvider = this.connectionService.registerDirectoryProvider(() => {
+        return [this.getWorkspaceDirectory(), ...this.sessionDirectories.values()]
+      })
 
       // Get current state and push to webview
       const serverInfo = this.connectionService.getServerInfo()
@@ -1989,9 +2002,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // races with the async config.update() write on the CLI backend).
     this.pending++
     try {
-      // Reject all pending permissions and questions so their CLI-side
-      // Promises resolve before disposeAll() wipes Instance state.
-      await this.drainPendingPrompts()
+      // Reject all pending permissions and questions across every provider
+      // so their CLI-side Promises resolve before disposeAll() wipes
+      // Instance state.  Throws on failure to abort the config save.
+      await this.connectionService.drainPendingPrompts()
 
       await this.client.global.config.update({ config: partial }, { throwOnError: true })
 
@@ -2004,11 +2018,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       this.cachedConfigMessage = { type: "configLoaded", config: merged }
       this.postMessage({ type: "configUpdated", config: merged })
-
-      // Clear stale permission/question UI after the dispose cycle.
-      // The drain above resolved them on the CLI side, but SSE events
-      // may race with the dispose — this ensures the webview is clean.
-      this.postMessage({ type: "clearPendingPrompts" })
 
       if (refreshProviders) {
         await this.fetchAndSendProviders()
@@ -2026,30 +2035,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       }
     } finally {
       this.pending--
-    }
-  }
-
-  /**
-   * Reject all pending permission requests and questions across all tracked
-   * directories. Called before config saves that trigger Instance.disposeAll()
-   * on the CLI backend, to prevent orphaned Promises from freezing sessions.
-   */
-  private async drainPendingPrompts(): Promise<void> {
-    if (!this.client) return
-    const dirs = recoveryDirs(this.getWorkspaceDirectory(), this.sessionDirectories)
-    for (const dir of dirs) {
-      const { data: perms } = await this.client.permission.list({ directory: dir })
-      if (perms) {
-        for (const perm of perms) {
-          await this.client.permission.reply({ requestID: perm.id, reply: "reject", directory: dir })
-        }
-      }
-      const { data: qs } = await this.client.question.list({ directory: dir })
-      if (qs) {
-        for (const q of qs) {
-          await this.client.question.reject({ requestID: q.id, directory: dir })
-        }
-      }
     }
   }
 
@@ -2890,6 +2875,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.unsubscribeLanguageChange?.()
     this.unsubscribeProfileChange?.()
     this.unsubscribeMigrationComplete?.()
+    this.unsubscribeClearPendingPrompts?.()
+    this.unsubscribeDirectoryProvider?.()
     this.webviewMessageDisposable?.dispose()
     this.trackedSessionIds.clear()
     this.syncedChildSessions.clear()

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -283,7 +283,8 @@ export class KiloConnectionService {
 
     // Also include every project directory the CLI backend knows about.
     // This covers worktree sessions whose KiloProvider was already disposed.
-    const { data: projects } = await this.client.project.list()
+    const { data: projects, error: projectsErr } = await this.client.project.list()
+    if (projectsErr) throw new Error(`Failed to list projects: ${String(projectsErr)}`)
     if (projects) {
       for (const p of projects) {
         dirs.add(p.worktree)

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -258,21 +258,38 @@ export class KiloConnectionService {
 
   /**
    * Reject all pending permission requests and questions across every
-   * directory known to any KiloProvider. Must be called before operations
-   * that trigger Instance.disposeAll() (e.g. config save) to prevent
-   * orphaned Promises from freezing sessions.
+   * directory known to any KiloProvider **and** every project the CLI
+   * backend has ever opened. The project list covers worktree sessions
+   * whose provider was disposed (panel/sidebar closed) while the CLI
+   * backend kept running.
+   *
+   * Must be called before operations that trigger Instance.disposeAll()
+   * (e.g. config save) to prevent orphaned Promises from freezing
+   * sessions.
    *
    * Throws if any list/reject call fails so callers can abort the
    * destructive operation.
    */
   async drainPendingPrompts(): Promise<void> {
     if (!this.client) return
+
+    // Collect directories from all mounted providers (root + worktree dirs).
     const dirs = new Set<string>()
     for (const provider of this.directoryProviders) {
       for (const dir of provider()) {
         dirs.add(dir)
       }
     }
+
+    // Also include every project directory the CLI backend knows about.
+    // This covers worktree sessions whose KiloProvider was already disposed.
+    const { data: projects } = await this.client.project.list()
+    if (projects) {
+      for (const p of projects) {
+        dirs.add(p.worktree)
+      }
+    }
+
     for (const dir of dirs) {
       const { data: perms, error: permsErr } = await this.client.permission.list({ directory: dir })
       if (permsErr) throw new Error(`Failed to list permissions for ${dir}: ${String(permsErr)}`)

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -13,6 +13,8 @@ type NotificationDismissListener = (notificationId: string) => void
 type LanguageChangeListener = (locale: string) => void
 type ProfileChangeListener = (data: unknown) => void
 type MigrationCompleteListener = () => void
+type ClearPendingPromptsListener = () => void
+type DirectoryProvider = () => string[]
 
 // Poll /global/health at the same interval as packages/app/src/context/server.tsx.
 // This provides a second detection channel for server death independent of the SSE heartbeat.
@@ -38,6 +40,8 @@ export class KiloConnectionService {
   private readonly languageChangeListeners: Set<LanguageChangeListener> = new Set()
   private readonly profileChangeListeners: Set<ProfileChangeListener> = new Set()
   private readonly migrationCompleteListeners: Set<MigrationCompleteListener> = new Set()
+  private readonly clearPendingPromptsListeners: Set<ClearPendingPromptsListener> = new Set()
+  private readonly directoryProviders: Set<DirectoryProvider> = new Set()
 
   /**
    * Shared mapping used to resolve session scope for events that don't reliably include a sessionID.
@@ -229,6 +233,70 @@ export class KiloConnectionService {
   }
 
   /**
+   * Subscribe to clear-pending-prompts broadcast. Returns unsubscribe function.
+   * Fired after a config save drains all pending permissions/questions so each
+   * webview can clear stale prompt UI.
+   */
+  onClearPendingPrompts(listener: ClearPendingPromptsListener): () => void {
+    this.clearPendingPromptsListeners.add(listener)
+    return () => {
+      this.clearPendingPromptsListeners.delete(listener)
+    }
+  }
+
+  /**
+   * Register a callback that returns workspace directories tracked by a
+   * KiloProvider (root + worktree dirs). Used by drainPendingPrompts() to
+   * cover all active Instance directories across every provider.
+   */
+  registerDirectoryProvider(provider: DirectoryProvider): () => void {
+    this.directoryProviders.add(provider)
+    return () => {
+      this.directoryProviders.delete(provider)
+    }
+  }
+
+  /**
+   * Reject all pending permission requests and questions across every
+   * directory known to any KiloProvider. Must be called before operations
+   * that trigger Instance.disposeAll() (e.g. config save) to prevent
+   * orphaned Promises from freezing sessions.
+   *
+   * Throws if any list/reject call fails so callers can abort the
+   * destructive operation.
+   */
+  async drainPendingPrompts(): Promise<void> {
+    if (!this.client) return
+    const dirs = new Set<string>()
+    for (const provider of this.directoryProviders) {
+      for (const dir of provider()) {
+        dirs.add(dir)
+      }
+    }
+    for (const dir of dirs) {
+      const { data: perms, error: permsErr } = await this.client.permission.list({ directory: dir })
+      if (permsErr) throw new Error(`Failed to list permissions for ${dir}: ${String(permsErr)}`)
+      if (perms) {
+        for (const perm of perms) {
+          const { error } = await this.client.permission.reply({ requestID: perm.id, reply: "reject", directory: dir })
+          if (error) throw new Error(`Failed to reject permission ${perm.id}: ${String(error)}`)
+        }
+      }
+      const { data: qs, error: qsErr } = await this.client.question.list({ directory: dir })
+      if (qsErr) throw new Error(`Failed to list questions for ${dir}: ${String(qsErr)}`)
+      if (qs) {
+        for (const q of qs) {
+          const { error } = await this.client.question.reject({ requestID: q.id, directory: dir })
+          if (error) throw new Error(`Failed to reject question ${q.id}: ${String(error)}`)
+        }
+      }
+    }
+    for (const listener of this.clearPendingPromptsListeners) {
+      listener()
+    }
+  }
+
+  /**
    * Subscribe to connection state changes. Returns unsubscribe function.
    */
   onStateChange(listener: StateListener): () => void {
@@ -250,6 +318,8 @@ export class KiloConnectionService {
     this.notificationDismissListeners.clear()
     this.profileChangeListeners.clear()
     this.migrationCompleteListeners.clear()
+    this.clearPendingPromptsListeners.clear()
+    this.directoryProviders.clear()
     this.messageSessionIdsByMessageId.clear()
     this.client = null
     this.sseClient = null

--- a/packages/kilo-vscode/tests/unit/kilo-provider-session-refresh.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-session-refresh.test.ts
@@ -81,6 +81,8 @@ function createConnection(client: ReturnType<typeof createClient>) {
     onLanguageChanged: () => () => undefined,
     onProfileChanged: () => () => undefined,
     onMigrationComplete: () => () => undefined,
+    onClearPendingPrompts: () => () => undefined,
+    registerDirectoryProvider: () => () => undefined,
     getServerInfo: () => ({ port: 12345 }),
     getConnectionState: () => "connected" as const,
     resolveEventSessionId: () => undefined,

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -638,6 +638,12 @@ export const SessionProvider: ParentComponent = (props) => {
           handleQuestionError(message.requestID)
           break
 
+        case "clearPendingPrompts":
+          setPermissions([])
+          setQuestions([])
+          setRespondingPermissions(new Set<string>())
+          break
+
         case "sessionsLoaded":
           handleSessionsLoaded(message.sessions)
           break

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1152,6 +1152,10 @@ export interface DiffViewerLoadingMessage {
   loading: boolean
 }
 
+export interface ClearPendingPromptsMessage {
+  type: "clearPendingPrompts"
+}
+
 // ============================================
 // Marketplace Messages
 // ============================================
@@ -1338,6 +1342,7 @@ export type ExtensionMessage =
   | ContinueInWorktreeProgressMessage
   | WorktreeStatsLoadedMessage
   | McpStatusLoadedMessage
+  | ClearPendingPromptsMessage
 
 // ============================================
 // Messages FROM webview TO extension


### PR DESCRIPTION
## Context

Fixes #7673. When a user saves settings while a session has a pending permission prompt or question open, the session permanently freezes and becomes unusable.

The root cause: `handleUpdateConfig()` calls `client.global.config.update()`, which triggers `Instance.disposeAll()` on the CLI backend. This silently orphans the pending Permission and Question Promises (their `resolve`/`reject` callbacks are garbage collected when state is cleared), permanently blocking the agent thread.

## Implementation

Before calling `config.update()`, the extension now **drains all pending prompts** — it lists and rejects all pending permissions (`permission.reply({ reply: "reject" })`) and questions (`question.reject()`) via the SDK. This ensures the CLI-side Promises are properly resolved before `disposeAll()` wipes the Instance state.

After the config update, a new `clearPendingPrompts` message is posted to the webview to clear any stale permission/question UI state that SSE events might not clean up due to race conditions with the dispose cycle.

**Changes:**
- `src/KiloProvider.ts`: Added `drainPendingPrompts()` method; called before `config.update()` in `handleUpdateConfig()`; posts `clearPendingPrompts` after the update
- `webview-ui/src/types/messages.ts`: Added `ClearPendingPromptsMessage` to the `ExtensionMessage` union
- `webview-ui/src/context/session.tsx`: Handles `clearPendingPrompts` message by clearing `permissions`, `questions`, and `respondingPermissions` signals

**Tradeoffs:**
- This is an extension-only fix. The CLI backend still calls `disposeAll()` on config updates (the `{ dispose: false }` option exists but isn't used by the HTTP route). A backend fix would be cleaner long-term, but this approach works without modifying `packages/opencode/`.
- Pending permissions and questions are rejected (not silently dropped), so the agent receives proper rejection signals and can handle them gracefully.

## Screenshots

<img width="3823" height="2160" alt="image" src="https://github.com/user-attachments/assets/f96cfa86-742b-4c00-a97a-c7504baa950b" />
<img width="3823" height="2160" alt="image" src="https://github.com/user-attachments/assets/bed0d020-0fb8-4fb9-b911-ceb9fbdc00d9" />
<img width="3823" height="2160" alt="image" src="https://github.com/user-attachments/assets/6dc735c6-59e4-4cd3-be2e-5c4c7fc04b6c" />

## How to Test

1. Start a session and trigger a permission prompt (e.g., have the agent try to run a shell command)
2. While the permission prompt is visible, go to Settings and change any setting (e.g., toggle an auto-approve option)
3. Click Save (if busy sessions exist, confirm via the toast warning)
4. **Before fix**: The session freezes — the permission prompt remains but buttons do nothing, the agent is stuck
5. **After fix**: The permission prompt is cleared, the session can continue normally (the agent receives a rejection and can proceed)
6. Repeat with a question prompt open (e.g., trigger the `question` tool) to verify the same fix applies