### PR TITLE
feat(vscode): release VS Code extension to GA

### DIFF
--- a/packages/kilo-vscode/script/build.ts
+++ b/packages/kilo-vscode/script/build.ts
@@ -36,10 +36,9 @@ const targets = [
 const binDir = join(import.meta.dir, "..", "bin")
 const distDir = join(import.meta.dir, "..", "dist")
 const outDir = join(import.meta.dir, "..", "out")
-const outDirProd = join(import.meta.dir, "..", "out", "prod")
 
 console.log("\n🧹 Cleaning up directories...")
-for (const dir of [binDir, distDir, outDir, outDirProd]) {
+for (const dir of [binDir, distDir, outDir]) {
   if (existsSync(dir)) {
     rmSync(dir, { recursive: true, force: true })
     console.log(`  ✓ Cleaned ${dir}`)
@@ -48,7 +47,6 @@ for (const dir of [binDir, distDir, outDir, outDirProd]) {
 
 mkdirSync(outDir, { recursive: true })
 mkdirSync(distDir, { recursive: true })
-mkdirSync(outDirProd, { recursive: true })
 
 console.log("\n🔄 Rebuilding SDK types (ensures dist/ is in sync with server API)...")
 await $`bun run --cwd ${join(import.meta.dir, "..", "..", "sdk", "js")} build`
@@ -84,18 +82,11 @@ for (const config of targets) {
 
   console.log(`  📦 Packaging .vsix for ${config.target}...`)
   const vsixPath = join(outDir, `kilo-vscode-${config.target}.vsix`)
-  await $`vsce package --pre-release --no-dependencies --skip-license --target ${config.target} -o ${vsixPath}`.env({
+  await $`vsce package --no-dependencies --skip-license --target ${config.target} -o ${vsixPath}`.env({
     ...process.env,
     npm_config_ignore_scripts: "true",
   })
   console.log(`  ✅ Created ${vsixPath}`)
-
-  const prodVsixPath = join(outDirProd, `kilo-vscode-${config.target}.vsix`)
-  await $`vsce package --no-dependencies --skip-license --target ${config.target} -o ${prodVsixPath}`.env({
-    ...process.env,
-    npm_config_ignore_scripts: "true",
-  })
-  console.log(`  ✅ Created ${prodVsixPath}`)
 }
 
 console.log("\n✨ All VSIX packages built successfully!")

--- a/packages/kilo-vscode/script/publish.ts
+++ b/packages/kilo-vscode/script/publish.ts
@@ -7,7 +7,6 @@ import { Script } from "@opencode-ai/script"
 console.log(`Publishing VSCode extension for release: v${Script.version}`)
 
 const outDir = process.env.VSIX_DIR || join(import.meta.dir, "..", "out")
-const outDirProd = join(outDir, "prod")
 
 console.log(`Using VSIX directory: ${outDir}`)
 
@@ -40,12 +39,11 @@ console.log(`\nFound ${vsixFiles.length} VSIX files`)
 for (const target of targets) {
   const vsixPath = join(outDir, `kilo-vscode-${target}.vsix`)
   console.log(`\n🚀 Publishing ${target} to VS Code Marketplace...`)
-  await $`vsce publish --pre-release --packagePath ${vsixPath}`
+  await $`vsce publish --packagePath ${vsixPath}`
   console.log(`  ✅ Published ${target} to VS Code Marketplace`)
 
-  const prodVsixPath = join(outDirProd, `kilo-vscode-${target}.vsix`)
   console.log(`\n📤 Publishing ${target} to Open VSX...`)
-  await $`npx ovsx publish --pat ${process.env.OPENVSX_TOKEN} --packagePath ${prodVsixPath}`
+  await $`npx ovsx publish --pat ${process.env.OPENVSX_TOKEN} --packagePath ${vsixPath}`
   console.log(`  ✅ Published Prod ${target} to Open VSX`)
 }
 


### PR DESCRIPTION
## Context

The VS Code extension has been publishing as **pre-release** on the VS Code Marketplace while shipping a separate **production** build to Open VSX. This PR removes the pre-release distinction and unifies the build/publish pipeline so that a single GA (General Availability) `.vsix` is produced and published to both marketplaces.

## Implementation

**`packages/kilo-vscode/script/build.ts`**
- Removed the separate `out/prod` output directory and its dedicated `vsce package` step.
- Dropped the `--pre-release` flag from the remaining `vsce package` call so every build is now a GA release.

**`packages/kilo-vscode/script/publish.ts`**
- Removed the `--pre-release` flag from `vsce publish` for the VS Code Marketplace.
- Changed Open VSX publishing to use the same `.vsix` from `out/` instead of the removed `out/prod/` directory.

The net effect is one build artifact per target, published identically to both VS Code Marketplace and Open VSX.

## Screenshots

N/A — build/publish script changes only.

## How to Test

1. Run the build script: `bun run --cwd packages/kilo-vscode script/build.ts`
2. Verify only `out/*.vsix` files are produced (no `out/prod/` directory).
3. Inspect any `.vsix` to confirm it is **not** flagged as pre-release.
