### PR TITLE
fix(vscode): preserve custom provider keys on edit

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1488,6 +1488,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
     const method = typeof msg.method === "number" ? msg.method : 0
     const key = typeof msg.apiKey === "string" ? msg.apiKey : undefined
+    const keyChanged = msg.apiKeyChanged === true
     const code = typeof msg.code === "string" ? msg.code : undefined
     const config = msg.config && typeof msg.config === "object" ? (msg.config as Record<string, unknown>) : undefined
     if (msg.type === "connectProvider" && key) return connectProviderAction(ctx, rid, pid, key)
@@ -1495,7 +1496,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (msg.type === "completeProviderOAuth") return completeOAuthAction(ctx, rid, pid, method, code)
     if (msg.type === "disconnectProvider") return disconnectProviderAction(ctx, rid, pid, this.cachedConfigMessage, set)
     if (msg.type === "saveCustomProvider" && config)
-      return saveCustomProviderAction(ctx, rid, pid, config, key, this.cachedConfigMessage, set)
+      return saveCustomProviderAction(ctx, rid, pid, config, key, keyChanged, this.cachedConfigMessage, set)
   }
 
   private async handleFetchCustomProviderModels(msg: Record<string, unknown>): Promise<void> {

--- a/packages/kilo-vscode/src/provider-actions.ts
+++ b/packages/kilo-vscode/src/provider-actions.ts
@@ -4,7 +4,7 @@
  */
 import type { KiloClient } from "@kilocode/sdk/v2"
 import { validateProviderID as validateProviderIDShared } from "./shared/custom-provider"
-import { sanitizeCustomProviderConfig } from "./shared/custom-provider"
+import { resolveCustomProviderAuth, sanitizeCustomProviderConfig } from "./shared/custom-provider"
 import { KILO_AUTO, parseModelString } from "./shared/provider-model"
 
 /**
@@ -28,7 +28,17 @@ export async function fetchProviderData(client: KiloClient, dir: string) {
     authRequest,
   ])
   const authStates: Record<string, AuthState> = {}
-  return { response, authMethods, authStates }
+  const all = response.all.map((item) => {
+    const raw = item as Record<string, unknown>
+    if (typeof raw.id === "string" && typeof raw.key === "string" && raw.key) {
+      authStates[raw.id] = "api"
+    }
+    if (!("key" in raw)) return item
+    const next = { ...raw }
+    delete next.key
+    return next as (typeof response.all)[number]
+  })
+  return { response: { ...response, all }, authMethods, authStates }
 }
 
 export function buildActionContext(
@@ -246,6 +256,7 @@ export async function saveCustomProvider(
   providerID: string,
   provider: Record<string, unknown>,
   apiKey: string | undefined,
+  apiKeyChanged: boolean,
   cachedConfigMessage: unknown,
   setCachedConfig: (msg: unknown) => void,
 ) {
@@ -281,10 +292,13 @@ export async function saveCustomProvider(
     setCachedConfig(msg)
     ctx.postMessage({ type: "configUpdated", config: updated })
 
+    const auth = resolveCustomProviderAuth(apiKey, apiKeyChanged)
+
     try {
-      if (apiKey) {
-        await ctx.client.auth.set({ providerID: id, auth: { type: "api", key: apiKey } }, { throwOnError: true })
-      } else {
+      if (auth.mode === "set") {
+        await ctx.client.auth.set({ providerID: id, auth: { type: "api", key: auth.key } }, { throwOnError: true })
+      }
+      if (auth.mode === "clear") {
         await ctx.client.auth.remove({ providerID: id }, { throwOnError: true })
       }
     } catch (error) {

--- a/packages/kilo-vscode/src/shared/custom-provider.ts
+++ b/packages/kilo-vscode/src/shared/custom-provider.ts
@@ -51,6 +51,10 @@ export type SanitizedProviderConfig = {
   models: Record<string, { name: string }>
 }
 
+export type CustomProviderAuthChange = { mode: "preserve" } | { mode: "clear" } | { mode: "set"; key: string }
+
+export const MASKED_CUSTOM_PROVIDER_KEY = "********"
+
 type Issue = { error: string; issue?: z.ZodIssue }
 
 function fail(error: string, issue?: z.ZodIssue): Issue {
@@ -76,6 +80,18 @@ export function parseCustomProviderSecret(raw: string): { value: { apiKey?: stri
   if (result.success) return { value: { env: result.data } }
   const issue = result.error.issues[0]
   return fail(issue?.message ?? INVALID_ENV, issue)
+}
+
+export function resolveCustomProviderAuth(apiKey: string | undefined, changed: boolean): CustomProviderAuthChange {
+  const key = apiKey?.trim()
+  if (!changed) return { mode: "preserve" }
+  if (key) return { mode: "set", key }
+  return { mode: "clear" }
+}
+
+export function resolveCustomProviderKey(auth: "api" | "oauth" | "wellknown" | undefined) {
+  if (auth !== "api") return ""
+  return MASKED_CUSTOM_PROVIDER_KEY
 }
 
 export function normalizeCustomProviderConfig(

--- a/packages/kilo-vscode/tests/unit/custom-provider.test.ts
+++ b/packages/kilo-vscode/tests/unit/custom-provider.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test"
 import {
+  MASKED_CUSTOM_PROVIDER_KEY,
   parseCustomProviderSecret,
+  resolveCustomProviderKey,
+  resolveCustomProviderAuth,
   sanitizeCustomProviderConfig,
   validateProviderID,
 } from "../../src/shared/custom-provider"
@@ -28,6 +31,34 @@ describe("parseCustomProviderSecret", () => {
   it("rejects invalid env references", () => {
     const result = parseCustomProviderSecret("{env:bad-name}")
     expect("error" in result ? result.error : "").toBe("Invalid environment variable name")
+  })
+})
+
+describe("resolveCustomProviderAuth", () => {
+  it("preserves auth when the api key field is unchanged", () => {
+    expect(resolveCustomProviderAuth(undefined, false)).toEqual({ mode: "preserve" })
+  })
+
+  it("stores a changed api key", () => {
+    expect(resolveCustomProviderAuth(" sk-test ", true)).toEqual({ mode: "set", key: "sk-test" })
+  })
+
+  it("clears auth when the field was changed to empty", () => {
+    expect(resolveCustomProviderAuth(undefined, true)).toEqual({ mode: "clear" })
+  })
+})
+
+describe("resolveCustomProviderKey", () => {
+  it("returns a masked value for api-backed providers", () => {
+    expect(resolveCustomProviderKey("api")).toBe(MASKED_CUSTOM_PROVIDER_KEY)
+  })
+
+  it("hides non-api auth from the edit form", () => {
+    expect(resolveCustomProviderKey("oauth")).toBe("")
+  })
+
+  it("returns empty when there is no saved key", () => {
+    expect(resolveCustomProviderKey(undefined)).toBe("")
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/provider-actions-save.test.ts
+++ b/packages/kilo-vscode/tests/unit/provider-actions-save.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test"
+import { fetchProviderData, saveCustomProvider } from "../../src/provider-actions"
+
+function createCtx() {
+  const calls = {
+    set: [] as Array<{ providerID: string; auth: { type: string; key: string } }>,
+    remove: [] as Array<{ providerID: string }>,
+    posts: [] as unknown[],
+    config: [] as unknown[],
+    cached: [] as unknown[],
+    refresh: 0,
+    dispose: 0,
+  }
+
+  const ctx = {
+    client: {
+      auth: {
+        set: async (input: { providerID: string; auth: { type: string; key: string } }) => {
+          calls.set.push(input)
+          return { data: true }
+        },
+        remove: async (input: { providerID: string }) => {
+          calls.remove.push(input)
+          return { data: true }
+        },
+      },
+      global: {
+        config: {
+          get: async () => ({ data: { disabled_providers: [] } }),
+          update: async (input: unknown) => {
+            calls.config.push(input)
+            return { data: input }
+          },
+        },
+      },
+    },
+    postMessage: (message: unknown) => calls.posts.push(message),
+    getErrorMessage: (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    workspaceDir: "/tmp",
+    disposeGlobal: async () => {
+      calls.dispose += 1
+    },
+    fetchAndSendProviders: async () => {
+      calls.refresh += 1
+    },
+  } as unknown as Parameters<typeof saveCustomProvider>[0]
+
+  return {
+    calls,
+    ctx,
+    setCachedConfig: (message: unknown) => calls.cached.push(message),
+  }
+}
+
+function createProvider() {
+  return {
+    name: "My Provider",
+    options: { baseURL: "https://example.com/v1" },
+    models: {
+      "model-1": { name: "Model One" },
+    },
+  }
+}
+
+describe("saveCustomProvider", () => {
+  it("preserves auth when the api key field is unchanged", async () => {
+    const { ctx, calls, setCachedConfig } = createCtx()
+
+    await saveCustomProvider(ctx, "req", "myprovider", createProvider(), undefined, false, null, setCachedConfig)
+
+    expect(calls.set).toHaveLength(0)
+    expect(calls.remove).toHaveLength(0)
+    expect(calls.refresh).toBe(1)
+  })
+
+  it("clears auth when the api key field was intentionally cleared", async () => {
+    const { ctx, calls, setCachedConfig } = createCtx()
+
+    await saveCustomProvider(ctx, "req", "myprovider", createProvider(), undefined, true, null, setCachedConfig)
+
+    expect(calls.set).toHaveLength(0)
+    expect(calls.remove).toEqual([{ providerID: "myprovider" }])
+  })
+
+  it("stores a changed api key", async () => {
+    const { ctx, calls, setCachedConfig } = createCtx()
+
+    await saveCustomProvider(ctx, "req", "myprovider", createProvider(), " sk-test ", true, null, setCachedConfig)
+
+    expect(calls.remove).toHaveLength(0)
+    expect(calls.set).toEqual([{ providerID: "myprovider", auth: { type: "api", key: "sk-test" } }])
+  })
+})
+
+describe("fetchProviderData", () => {
+  it("derives api auth state and strips keys from provider payloads", async () => {
+    const client = {
+      provider: {
+        list: async () => ({
+          data: {
+            all: [
+              {
+                id: "groq-test",
+                name: "Groq Test",
+                source: "config",
+                key: "sk-test",
+                env: [],
+                models: {},
+              },
+            ],
+            connected: ["groq-test"],
+            default: { "groq-test": "llama-3.1-8b-instant" },
+          },
+        }),
+        auth: async () => ({ data: {} }),
+      },
+    } as unknown as Parameters<typeof fetchProviderData>[0]
+
+    const result = await fetchProviderData(client, "/tmp")
+    const item = result.response.all[0] as Record<string, unknown>
+
+    expect(result.authStates).toEqual({ "groq-test": "api" })
+    expect("key" in item).toBe(false)
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
@@ -14,6 +14,7 @@ import { useProvider } from "../../context/provider"
 import { useVSCode } from "../../context/vscode"
 import type { ExtensionMessage, ProviderConfig } from "../../types/messages"
 import { createProviderAction } from "../../utils/provider-action"
+import { MASKED_CUSTOM_PROVIDER_KEY, resolveCustomProviderKey } from "../../../../src/shared/custom-provider"
 
 const PROVIDER_ID = /^[a-z0-9][a-z0-9-_]*$/
 const OPENAI_COMPATIBLE = "@ai-sdk/openai-compatible"
@@ -219,11 +220,17 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
     return entries.map(([key, value]) => ({ key, value }))
   }
 
+  const auth = props.existing?.config?.env?.length
+    ? undefined
+    : props.existing
+      ? provider.authStates()[props.existing.providerID]
+      : undefined
+
   const [form, setForm] = createStore<FormState>({
     providerID: props.existing?.providerID ?? "",
     name: props.existing?.name ?? "",
     baseURL: (props.existing?.config?.options as { baseURL?: string } | undefined)?.baseURL ?? "",
-    apiKey: "",
+    apiKey: resolveCustomProviderKey(auth),
     models: initModels(),
     headers: initHeaders(),
     saving: false,
@@ -236,6 +243,7 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
     models: form.models.map(() => ({})),
     headers: form.headers.map(() => ({})),
   })
+  const [apiTouched, setApiTouched] = createSignal(false)
 
   // ── Fetch models state ──────────────────────────────────────────────
 
@@ -271,7 +279,7 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
   // (including setForm("models", ...)) invalidates effects that read from
   // the same store, causing unwanted re-runs that wipe the model picker.
   const [fetchURL, setFetchURL] = createSignal(form.baseURL)
-  const [fetchKey, setFetchKey] = createSignal(form.apiKey)
+  const [fetchKey, setFetchKey] = createSignal("")
   let fetchVersion = 0
 
   createEffect(() => {
@@ -400,7 +408,8 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
     if (picked.length === 0) return
 
     // Replace the single empty row or append
-    const empty = form.models.length === 1 && !form.models[0].id.trim() && !form.models[0].name.trim()
+    const row = form.models[0]
+    const empty = form.models.length === 1 && !!row && !row.id.trim() && !row.name.trim()
     const merged = empty ? picked : [...form.models, ...picked]
 
     setForm("models", merged)
@@ -477,7 +486,8 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
         type: "saveCustomProvider",
         providerID: result.providerID,
         config: result.config,
-        apiKey: result.key,
+        apiKey: apiTouched() ? result.key : undefined,
+        apiKeyChanged: apiTouched(),
       },
       {
         onConnected: () => {
@@ -589,8 +599,10 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
               description={language.t("provider.custom.field.apiKey.description")}
               value={form.apiKey}
               onChange={(v) => {
-                setForm("apiKey", v)
-                setFetchKey(v)
+                const key = !apiTouched() && form.apiKey === MASKED_CUSTOM_PROVIDER_KEY ? v.replace(/^\*+/, "") : v
+                setApiTouched(true)
+                setForm("apiKey", key)
+                setFetchKey(key)
               }}
             />
           </div>

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1972,6 +1972,7 @@ export interface SaveCustomProviderMessage {
   providerID: string
   config: ProviderConfig
   apiKey?: string
+  apiKeyChanged?: boolean
 }
 
 export interface FetchCustomProviderModelsMessage {


### PR DESCRIPTION
## Summary
- preserve saved API auth for custom OpenAI-compatible providers when editing non-secret fields
- show a masked value in the custom provider API key field without sending the real key to the webview
- add unit coverage for unchanged edits, explicit clears, replacements, and provider payload sanitization

## Testing
- bun test tests/unit/custom-provider.test.ts tests/unit/provider-actions-save.test.ts

Closes #7989