### PR TITLE
fix: bound hung state disposal during provider auth refresh

### DIFF
--- a/packages/kilo-vscode/src/provider-actions.ts
+++ b/packages/kilo-vscode/src/provider-actions.ts
@@ -44,6 +44,9 @@ export function buildActionContext(
     getErrorMessage: errFn,
     workspaceDir: dir,
     disposeGlobal: async (reason: string) => {
+      // Wait for the server to finish disposing before refreshing providers.
+      // Shared State.dispose() now has a hard per-disposer timeout, so this
+      // wait is bounded without needing a client-side timeout here.
       await client.global.dispose().catch((error: unknown) => {
         console.warn(`[Kilo New] KiloProvider: global.dispose() after ${reason} failed:`, error)
       })

--- a/packages/opencode/src/project/state.ts
+++ b/packages/opencode/src/project/state.ts
@@ -61,11 +61,23 @@ export namespace State {
 
       const label = typeof init === "function" ? init.name : String(init)
 
-      const task = Promise.resolve(entry.state)
-        .then((state) => entry.dispose!(state))
-        .catch((error) => {
-          log.error("Error while disposing state:", { error, key, init: label })
-        })
+      // kilocode_change start — hard timeout per disposer so a single hung callback
+      // (e.g. MCP client.close()) cannot block the entire disposal indefinitely.
+      // This is a backend safety bound, not a UI timeout: desktop, VS Code, and
+      // other callers all wait on State.dispose() through Instance.disposeAll().
+      // The race only stops waiting after 15 s; it does not cancel the underlying
+      // disposer. That is still acceptable here because the important recovery step
+      // is letting State.dispose() continue to entries.clear()/recordsByKey.delete()
+      // so the next state access re-initializes from fresh config instead of hanging.
+      const task = Promise.race([
+        Promise.resolve(entry.state).then((state) => entry.dispose!(state)),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error(`state disposer "${label}" timed out after 15 s`)), 15_000).unref(),
+        ),
+      ]).catch((error) => {
+        log.error("Error while disposing state:", { error, key, init: label })
+      })
+      // kilocode_change end
 
       tasks.push(task)
     }

--- a/packages/opencode/test/project/state.test.ts
+++ b/packages/opencode/test/project/state.test.ts
@@ -1,0 +1,84 @@
+// kilocode_change - new file
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { Log } from "../../src/util/log"
+import { State } from "../../src/project/state"
+
+Log.init({ print: false })
+
+const clock = { now: 0 }
+const tasks = new Map<number, { at: number; fn: () => void }>()
+let next = 1
+
+const realSetTimeout = globalThis.setTimeout
+
+function schedule(fn: () => void, ms = 0) {
+  const id = next
+  next += 1
+  const timer = {
+    unref() {
+      return timer
+    },
+  }
+  tasks.set(id, { at: clock.now + ms, fn })
+  return timer as unknown as ReturnType<typeof globalThis.setTimeout>
+}
+
+function flush() {
+  while (true) {
+    const due = Array.from(tasks.entries())
+      .filter(([, task]) => task.at <= clock.now)
+      .sort((a, b) => a[1].at - b[1].at)
+    if (due.length === 0) return
+    for (const [id, task] of due) {
+      tasks.delete(id)
+      task.fn()
+    }
+  }
+}
+
+describe("State.dispose", () => {
+  beforeEach(() => {
+    clock.now = 0
+    tasks.clear()
+    next = 1
+    globalThis.setTimeout = schedule as typeof globalThis.setTimeout
+  })
+
+  afterEach(() => {
+    globalThis.setTimeout = realSetTimeout
+  })
+
+  test("continues after a disposer times out", async () => {
+    const calls: string[] = []
+    const root = () => "test-key"
+    const hung = State.create(
+      root,
+      () => "hung",
+      async () => {
+        calls.push("hung:start")
+        await new Promise(() => {})
+      },
+    )
+    const fast = State.create(
+      root,
+      () => "fast",
+      async () => {
+        calls.push("fast")
+      },
+    )
+
+    hung()
+    fast()
+
+    const dispose = State.dispose("test-key")
+    await Promise.resolve()
+    expect(calls).toEqual(["hung:start", "fast"])
+
+    clock.now = 15_000
+    flush()
+    await dispose
+
+    const again = State.create(root, () => "again")
+    expect(again()).toBe("again")
+  })
+})


### PR DESCRIPTION
## Summary
- add a hard per-disposer timeout in shared state disposal so one hung cleanup cannot block `global.dispose()` indefinitely
- keep provider connect and disconnect waiting for disposal to finish before refreshing, so provider state reinitializes from fresh config
- add a regression test that covers a hung disposer timing out while the rest of state cleanup still completes

## Testing
- `bun test test/project/state.test.ts`
- `bun run compile` (from `packages/kilo-vscode`)

Fixes #8068