### PR TITLE
fix(vscode): isolate prompt drafts across pending sessions

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -474,6 +474,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
               z.object({
                 mime: z.string(),
                 url: z.string().refine((u) => u.startsWith("file://") || u.startsWith("data:")),
+                filename: z.string().optional(),
               }),
             )
             .optional()
@@ -483,6 +484,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             message.text,
             typeof message.messageID === "string" ? message.messageID : undefined,
             message.sessionID,
+            typeof message.draftID === "string" ? message.draftID : undefined,
             message.providerID,
             message.modelID,
             message.agent,
@@ -497,6 +499,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
               z.object({
                 mime: z.string(),
                 url: z.string().refine((u) => u.startsWith("file://") || u.startsWith("data:")),
+                filename: z.string().optional(),
               }),
             )
             .optional()
@@ -507,6 +510,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             message.arguments,
             typeof message.messageID === "string" ? message.messageID : undefined,
             message.sessionID,
+            typeof message.draftID === "string" ? message.draftID : undefined,
             message.providerID,
             message.modelID,
             message.agent,
@@ -2055,7 +2059,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * session ID and workspace directory, or undefined when the client is
    * disconnected.
    */
-  private async resolveSession(sessionID?: string): Promise<{ sid: string; dir: string } | undefined> {
+  private async resolveSession(
+    sessionID?: string,
+    draftID?: string,
+  ): Promise<{ sid: string; dir: string } | undefined> {
     if (!this.client) return undefined
 
     const dir = sessionID ? this.getWorkspaceDirectory(sessionID) : this.getContextDirectory()
@@ -2066,9 +2073,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.contextSessionID = session.id
       this.trackDirectory(session.id, dir)
       this.trackedSessionIds.add(session.id)
+      if (draftID) this.contextSessionID = session.id
       this.postMessage({
         type: "sessionCreated",
         session: this.sessionToWebview(session),
+        draftID,
       })
     }
 
@@ -2082,6 +2091,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     text: string,
     messageID?: string,
     sessionID?: string,
+    draftID?: string,
     providerID?: string,
     modelID?: string,
     agent?: string,
@@ -2094,6 +2104,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         error: "Not connected to CLI backend",
         text,
         sessionID,
+        draftID,
         messageID,
         files,
       })
@@ -2102,7 +2113,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     let resolved: { sid: string; dir: string } | undefined
     try {
-      resolved = await this.resolveSession(sessionID)
+      resolved = await this.resolveSession(sessionID, draftID)
 
       const parts: Array<TextPartInput | FilePartInput> = []
       if (files) {
@@ -2138,6 +2149,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         error: getErrorMessage(error) || "Failed to send message",
         text,
         sessionID: resolved?.sid ?? sessionID,
+        draftID,
         messageID,
         files,
       })
@@ -2149,6 +2161,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     args: string,
     messageID?: string,
     sessionID?: string,
+    draftID?: string,
     providerID?: string,
     modelID?: string,
     agent?: string,
@@ -2161,6 +2174,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         error: "Not connected to CLI backend",
         text: `/${command} ${args}`.trim(),
         sessionID,
+        draftID,
         messageID,
         files,
       })
@@ -2169,7 +2183,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     let resolved: { sid: string; dir: string } | undefined
     try {
-      resolved = await this.resolveSession(sessionID)
+      resolved = await this.resolveSession(sessionID, draftID)
 
       if (messageID) {
         this.connectionService.recordMessageSessionId(messageID, resolved!.sid)
@@ -2198,6 +2212,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         error: getErrorMessage(error) || "Failed to send command",
         text: `/${command} ${args}`.trim(),
         sessionID: resolved?.sid ?? sessionID,
+        draftID,
         messageID,
         files,
       })

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -223,6 +223,9 @@ export class AgentManagerProvider implements Disposable {
     if (m.type === "agentManager.addSessionToWorktree") return this.onAddSessionToWorktree(m.worktreeId)
     if (m.type === "agentManager.forkSession") return this.onForkSession(m.sessionId, m.worktreeId)
     if (m.type === "agentManager.closeSession") return this.onCloseSession(m.sessionId)
+    if ((m.type === "sendMessage" || m.type === "sendCommand") && m.draftID && !m.sessionID) {
+      this.activeSessionId = m.draftID
+    }
     if (m.type === "agentManager.configureSetupScript") {
       void this.configureSetupScript()
       return null

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -401,6 +401,33 @@ interface LoadMessagesIn {
   sessionID: string
 }
 
+interface SendMessageIn {
+  type: "sendMessage"
+  text: string
+  messageID?: string
+  sessionID?: string
+  draftID?: string
+  providerID?: string
+  modelID?: string
+  agent?: string
+  variant?: string
+  files?: Array<{ mime: string; url: string; filename?: string }>
+}
+
+interface SendCommandIn {
+  type: "sendCommand"
+  command: string
+  arguments: string
+  messageID?: string
+  sessionID?: string
+  draftID?: string
+  providerID?: string
+  modelID?: string
+  agent?: string
+  variant?: string
+  files?: Array<{ mime: string; url: string; filename?: string }>
+}
+
 interface ClearSessionIn {
   type: "clearSession"
 }
@@ -460,6 +487,8 @@ export type AgentManagerInMessage =
   | GenericOpenFileIn
   | PreviewImageIn
   | LoadMessagesIn
+  | SendMessageIn
+  | SendCommandIn
   | ClearSessionIn
   | AbortIn
   | ContinueInWorktreeIn

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -225,7 +225,7 @@ export type WebviewMessage =
   | { type: "questionResolved"; requestID: string }
   | { type: "permissionResolved"; permissionID: string }
   | { type: "permissionError"; permissionID: string }
-  | { type: "sessionCreated"; session: ReturnType<typeof sessionToWebview> }
+  | { type: "sessionCreated"; session: ReturnType<typeof sessionToWebview>; draftID?: string }
   | { type: "sessionUpdated"; session: ReturnType<typeof sessionToWebview> }
   | { type: "messageRemoved"; sessionID: string; messageID: string }
   | { type: "sessionError"; sessionID?: string; error?: unknown }

--- a/packages/kilo-vscode/src/kilo-provider/handlers/cloud-session.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/cloud-session.ts
@@ -215,6 +215,7 @@ export async function handleImportAndSend(
       error: err instanceof Error ? err.message : "Failed to send message after import",
       text,
       sessionID: session.id,
+      draftID: session.id,
       messageID,
       files,
     })

--- a/packages/kilo-vscode/tests/unit/kilo-provider-followup.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-followup.test.ts
@@ -60,9 +60,11 @@ function connection() {
     },
     onStateChange: () => () => undefined,
     onNotificationDismissed: () => () => undefined,
+    onClearPendingPrompts: () => () => undefined,
     onLanguageChanged: () => () => undefined,
     onProfileChanged: () => () => undefined,
     onMigrationComplete: () => () => undefined,
+    registerDirectoryProvider: () => () => undefined,
     getServerInfo: () => ({ port: 12345 }),
     getConnectionState: () => "connected" as const,
     resolveEventSessionId: (event: Event) => (event.type === "session.created" ? event.properties.info.id : undefined),
@@ -123,6 +125,7 @@ describe("KiloProvider follow-up sessions", () => {
           revert: null,
           summary: null,
         },
+        draftID: undefined,
       },
     ])
   })

--- a/packages/kilo-vscode/tests/unit/prompt-drafts.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-drafts.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "bun:test"
+import { pendingDraftKey, scopeDraftKey, sessionDraftKey } from "../../webview-ui/src/utils/prompt-drafts"
+
+describe("sessionDraftKey", () => {
+  it("prefixes session ids", () => {
+    expect(sessionDraftKey("abc")).toBe("session:abc")
+  })
+
+  it("returns undefined when no id is present", () => {
+    expect(sessionDraftKey()).toBeUndefined()
+  })
+})
+
+describe("pendingDraftKey", () => {
+  it("prefixes pending ids", () => {
+    expect(pendingDraftKey("pending:1")).toBe("pending:1")
+  })
+
+  it("returns undefined when no id is present", () => {
+    expect(pendingDraftKey()).toBeUndefined()
+  })
+})
+
+describe("scopeDraftKey", () => {
+  it("scopes raw keys to a prompt box", () => {
+    expect(scopeDraftKey("prompt:1", "session:abc")).toBe("prompt:1:session:abc")
+  })
+
+  it("falls back to an empty key when raw key is missing", () => {
+    expect(scopeDraftKey("prompt:1")).toBe("prompt:1:empty")
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2775,6 +2775,8 @@ const AgentManagerContent: Component = () => {
                 }}
                 readonly={readOnly()}
                 continueInWorktree={selection() === LOCAL}
+                promptBoxId={`agent-manager:${selection() ?? "unassigned"}`}
+                pendingSessionID={selection() === LOCAL ? activePendingId() : undefined}
               />
               <Show when={readOnly()}>
                 <div class="am-readonly-banner">

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -225,12 +225,13 @@ const AppContent: Component = () => {
       <Show
         when={migrationNeeded()}
         fallback={
-          <Switch fallback={<ChatView continueInWorktree />}>
+          <Switch fallback={<ChatView continueInWorktree promptBoxId="sidebar:fallback" />}>
             <Match when={currentView() === "newTask"}>
               <ChatView
                 onSelectSession={handleSelectSession}
                 onShowHistory={() => setCurrentView("history")}
                 continueInWorktree
+                promptBoxId="sidebar:new-task"
               />
             </Match>
             <Match when={currentView() === "marketplace"}>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -27,6 +27,8 @@ interface ChatViewProps {
   readonly?: boolean
   /** When true, show the "Continue in Worktree" button. Defaults to true in the sidebar. */
   continueInWorktree?: boolean
+  promptBoxId?: string
+  pendingSessionID?: string
 }
 
 export const ChatView: Component<ChatViewProps> = (props) => {
@@ -214,7 +216,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
             </div>
           </Show>
           <Show when={!props.readonly}>
-            <PromptInput blocked={blocked} />
+            <PromptInput blocked={blocked} boxId={props.promptBoxId} pendingSessionID={props.pendingSessionID} />
           </Show>
         </div>
       </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -223,9 +223,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   // Start a new task, carrying over the current prompt text (without auto-sending it)
   const onNewTaskRequest = () => {
-    const key = draftKey()
-    saveDraft(key, text().trim(), reviewComments(), imageAttach.images())
+    const draft = text().trim()
+    const comments = reviewComments()
+    const imgs = imageAttach.images()
     session.clearCurrentSession()
+    // After clearing, draftKey() points to the "new" bucket — save there
+    // so the session-switch effect restores the prompt in the new-task view.
+    saveDraft(draftKey(), draft, comments, imgs)
   }
   window.addEventListener("newTaskRequest", onNewTaskRequest)
   onCleanup(() => window.removeEventListener("newTaskRequest", onNewTaskRequest))

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -3,7 +3,7 @@
  * Text input with send/abort buttons, ghost-text autocomplete, and @ file mention support
  */
 
-import { Component, createSignal, createEffect, on, For, Index, onCleanup, Show, untrack } from "solid-js"
+import { createSignal, createEffect, on, For, Index, onCleanup, Show, untrack, type Component } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Dialog } from "@kilocode/kilo-ui/dialog"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
@@ -21,17 +21,19 @@ import { ThinkingSelector } from "../shared/ThinkingSelector"
 import { useFileMention } from "../../hooks/useFileMention"
 import { useSlashCommand } from "../../hooks/useSlashCommand"
 import { useGhostText } from "../../hooks/useGhostText"
-import { useImageAttachments } from "../../hooks/useImageAttachments"
+import { useImageAttachments, type ImageAttachment } from "../../hooks/useImageAttachments"
 import { convertToMentionPath } from "../../utils/path-mentions"
 import { usePromptHistory } from "../../hooks/usePromptHistory"
 import { WandSparkles } from "@kilocode/kilo-ui/lucide"
 import { fileName, dirName, buildHighlightSegments, atEnd } from "./prompt-input-utils"
 import type { ReviewComment, TextPart } from "../../types/messages"
 import { formatReviewCommentsMarkdown } from "../../utils/review-comment-markdown"
+import { pendingDraftKey, scopeDraftKey, sessionDraftKey } from "../../utils/prompt-drafts"
 
 // Per-session input text storage (module-level so it survives remounts)
 const drafts = new Map<string, string>()
 const reviewDrafts = new Map<string, ReviewComment[]>()
+const imageDrafts = new Map<string, ImageAttachment[]>()
 
 function mergeReviewComments(current: ReviewComment[], incoming: ReviewComment[]): ReviewComment[] {
   if (incoming.length === 0) return current
@@ -44,6 +46,8 @@ function mergeReviewComments(current: ReviewComment[], incoming: ReviewComment[]
 
 interface PromptInputProps {
   blocked?: () => boolean
+  boxId?: string
+  pendingSessionID?: string
 }
 
 export const PromptInput: Component<PromptInputProps> = (props) => {
@@ -78,7 +82,20 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
   const history = usePromptHistory()
 
-  const sessionKey = () => session.currentSessionID() ?? "__new__"
+  const boxKey = () => props.boxId ?? "prompt:default"
+  const rawKey = () =>
+    sessionDraftKey(session.currentSessionID()) ??
+    pendingDraftKey(props.pendingSessionID ?? session.draftSessionID()) ??
+    "new"
+  const draftKey = () => scopeDraftKey(boxKey(), rawKey())
+  const saveDraft = (key: string, next: string, comments: ReviewComment[], imgs: ImageAttachment[]) => {
+    if (next) drafts.set(key, next)
+    else drafts.delete(key)
+    if (comments.length > 0) reviewDrafts.set(key, comments)
+    else reviewDrafts.delete(key)
+    if (imgs.length > 0) imageDrafts.set(key, imgs)
+    else imageDrafts.delete(key)
+  }
 
   const [text, setText] = createSignal("")
   const [reviewComments, setReviewComments] = createSignal<ReviewComment[]>([])
@@ -91,10 +108,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const replaceReviewComments = (next: ReviewComment[]) => {
     setReviewComments(next)
     if (next.length === 0) {
-      reviewDrafts.delete(sessionKey())
+      reviewDrafts.delete(draftKey())
       return
     }
-    reviewDrafts.set(sessionKey(), next)
+    reviewDrafts.set(draftKey(), next)
   }
 
   const clearReviewComments = () => replaceReviewComments([])
@@ -156,19 +173,17 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   let dropdownRef: HTMLDivElement | undefined
   let slashDropdownRef: HTMLDivElement | undefined
   // Save/restore input text when switching sessions.
-  // Uses `on()` to track only sessionKey — avoids re-running on every keystroke.
+  // Uses `on()` to track only draftKey — avoids re-running on every keystroke.
   createEffect(
-    on(sessionKey, (key, prev) => {
+    on(draftKey, (key, prev) => {
       if (prev !== undefined && prev !== key) {
-        drafts.set(prev, untrack(text))
-        const pending = untrack(reviewComments)
-        if (pending.length > 0) reviewDrafts.set(prev, pending)
-        else reviewDrafts.delete(prev)
+        saveDraft(prev, untrack(text), untrack(reviewComments), untrack(imageAttach.images))
       }
       const draft = drafts.get(key) ?? ""
       const pending = reviewDrafts.get(key) ?? []
       setText(draft)
       setReviewComments(pending)
+      imageAttach.replace(imageDrafts.get(key) ?? [])
       setEnhancing(false)
       preEnhanceText = null
       history.reset()
@@ -208,9 +223,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   // Start a new task, carrying over the current prompt text (without auto-sending it)
   const onNewTaskRequest = () => {
-    const prompt = text().trim()
-    // Pre-populate the draft for the new (empty) session so the effect restores it
-    if (prompt) drafts.set("__new__", prompt)
+    const key = draftKey()
+    saveDraft(key, text().trim(), reviewComments(), imageAttach.images())
     session.clearCurrentSession()
   }
   window.addEventListener("newTaskRequest", onNewTaskRequest)
@@ -288,8 +302,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       const failed = message as import("../../types/messages").SendMessageFailedMessage
       // Only restore draft if the failure is for the current session and the
       // input is empty (user hasn't started typing something new).
-      const target = failed.sessionID ?? "__new__"
-      if (target === sessionKey() && !text().trim() && imageAttach.images().length === 0) {
+      const target = scopeDraftKey(
+        boxKey(),
+        sessionDraftKey(failed.sessionID) ?? pendingDraftKey(failed.draftID) ?? "new",
+      )
+      if (target === draftKey() && !text().trim() && imageAttach.images().length === 0) {
         if (failed.text) {
           setText(failed.text)
           if (textareaRef) {
@@ -306,7 +323,27 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             mime: f.mime,
             dataUrl: f.url,
           }))
-        if (images.length > 0) imageAttach.replace(images)
+        if (images.length > 0) {
+          imageAttach.replace(images)
+          imageDrafts.set(target, images)
+        }
+      }
+    }
+
+    if (message.type === "sessionCreated" && message.draftID) {
+      const target = scopeDraftKey(boxKey(), pendingDraftKey(message.draftID) ?? "new")
+      const next = scopeDraftKey(boxKey(), sessionDraftKey(message.session.id) ?? "new")
+      const draft = drafts.get(target)
+      const pending = reviewDrafts.get(target)
+      const imgs = imageDrafts.get(target)
+      if (draft !== undefined) drafts.set(next, draft)
+      if (pending) reviewDrafts.set(next, pending)
+      if (imgs) imageDrafts.set(next, imgs)
+      drafts.delete(target)
+      reviewDrafts.delete(target)
+      imageDrafts.delete(target)
+      if (!session.currentSessionID() && (props.pendingSessionID ?? session.draftSessionID()) === message.draftID) {
+        session.setDraftSessionID(message.session.id)
       }
     }
 
@@ -316,7 +353,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     if (message.type === "enhancePromptResult") {
       const result = message as import("../../types/messages").EnhancePromptResultMessage
-      if (result.requestId === `enhance-${sessionKey()}-${enhanceCounter}`) {
+      if (result.requestId === `enhance-${draftKey()}-${enhanceCounter}`) {
         setText(result.text)
         setEnhancing(false)
         if (textareaRef) {
@@ -329,7 +366,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     if (message.type === "enhancePromptError") {
       const result = message as import("../../types/messages").EnhancePromptErrorMessage
-      if (result.requestId === `enhance-${sessionKey()}-${enhanceCounter}`) {
+      if (result.requestId === `enhance-${draftKey()}-${enhanceCounter}`) {
         setEnhancing(false)
       }
     }
@@ -337,11 +374,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   onCleanup(() => {
     // Persist current draft before unmounting
-    const current = text()
-    if (current) drafts.set(sessionKey(), current)
-    const pending = reviewComments()
-    if (pending.length > 0) reviewDrafts.set(sessionKey(), pending)
-    else reviewDrafts.delete(sessionKey())
+    saveDraft(draftKey(), text(), reviewComments(), imageAttach.images())
     unsubscribe()
   })
 
@@ -508,7 +541,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     preEnhanceText = text()
     enhanceCounter++
     setEnhancing(true)
-    vscode.postMessage({ type: "enhancePrompt", text: draft, requestId: `enhance-${sessionKey()}-${enhanceCounter}` })
+    vscode.postMessage({ type: "enhancePrompt", text: draft, requestId: `enhance-${draftKey()}-${enhanceCounter}` })
   }
 
   const handleSend = () => {
@@ -530,7 +563,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       imageAttach.clear()
       mention.closeMention()
       slash.close()
-      drafts.delete(sessionKey())
+      drafts.delete(draftKey())
+      reviewDrafts.delete(draftKey())
+      imageDrafts.delete(draftKey())
       if (textareaRef) textareaRef.style.height = "auto"
       matched.action()
       return
@@ -549,13 +584,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const sel = session.selected()
     const attachments = allFiles.length > 0 ? allFiles : undefined
 
+    const key = draftKey()
+    const pendingId = props.pendingSessionID ?? session.draftSessionID()
     // Server-side slash command (cmdMatch/matched already computed above)
     if (matched) {
       const rest = draft.slice(cmdMatch![0].length).trim()
       const args = review && rest ? `${review}\n\n${rest}` : rest || review
-      session.sendCommand(matched.name, args, sel?.providerID, sel?.modelID, attachments)
+      session.sendCommand(matched.name, args, sel?.providerID, sel?.modelID, attachments, pendingId)
     } else {
-      session.sendMessage(message, sel?.providerID, sel?.modelID, attachments)
+      session.sendMessage(message, sel?.providerID, sel?.modelID, attachments, pendingId)
     }
 
     history.append(draft)
@@ -565,7 +602,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     imageAttach.clear()
     mention.closeMention()
     slash.close()
-    drafts.delete(sessionKey())
+    drafts.delete(key)
+    reviewDrafts.delete(key)
+    imageDrafts.delete(key)
 
     if (textareaRef) textareaRef.style.height = "auto"
   }

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -4,18 +4,8 @@
  * Also owns global (extension-lifetime) model selection (provider context is catalog-only).
  */
 
-import {
-  createContext,
-  useContext,
-  createSignal,
-  createMemo,
-  createEffect,
-  onMount,
-  onCleanup,
-  ParentComponent,
-  Accessor,
-  batch,
-} from "solid-js"
+import { createContext, useContext, createSignal, createMemo, createEffect, onMount, onCleanup, batch } from "solid-js"
+import type { ParentComponent, Accessor } from "solid-js"
 import { createStore, produce, reconcile } from "solid-js/store"
 import { useVSCode } from "./vscode"
 import { useServer } from "./server"
@@ -174,8 +164,15 @@ interface SessionContextValue {
   // Actions
   revertSession: (messageID: string) => void
   unrevertSession: () => void
-  sendMessage: (text: string, providerID?: string, modelID?: string, files?: FileAttachment[]) => void
-  sendCommand: (command: string, args: string, providerID?: string, modelID?: string, files?: FileAttachment[]) => void
+  sendMessage: (text: string, providerID?: string, modelID?: string, files?: FileAttachment[], draftID?: string) => void
+  sendCommand: (
+    command: string,
+    args: string,
+    providerID?: string,
+    modelID?: string,
+    files?: FileAttachment[],
+    draftID?: string,
+  ) => void
   abort: () => void
   compact: () => void
   respondToPermission: (
@@ -197,6 +194,8 @@ interface SessionContextValue {
   // Cloud session preview
   cloudPreviewId: Accessor<string | null>
   selectCloudSession: (cloudSessionId: string) => void
+  draftSessionID: Accessor<string | undefined>
+  setDraftSessionID: (id: string | undefined) => void
 }
 
 export const SessionContext = createContext<SessionContextValue>()
@@ -210,6 +209,7 @@ export const SessionProvider: ParentComponent = (props) => {
 
   // Current session ID
   const [currentSessionID, setCurrentSessionID] = createSignal<string | undefined>()
+  const [draftSessionID, setDraftSessionID] = createSignal<string | undefined>()
 
   // Per-session status map — keyed by sessionID
   const [statusMap, setStatusMap] = createStore<Record<string, SessionStatusInfo>>({})
@@ -591,7 +591,7 @@ export const SessionProvider: ParentComponent = (props) => {
     const unsubscribe = vscode.onMessage((message: ExtensionMessage) => {
       switch (message.type) {
         case "sessionCreated":
-          handleSessionCreated(message.session)
+          handleSessionCreated(message.session, message.draftID)
           break
 
         case "messagesLoaded":
@@ -719,7 +719,7 @@ export const SessionProvider: ParentComponent = (props) => {
   })
 
   // Event handlers
-  function handleSessionCreated(session: SessionInfo) {
+  function handleSessionCreated(session: SessionInfo, draftID?: string) {
     batch(() => {
       setStore("sessions", session.id, session)
 
@@ -739,7 +739,12 @@ export const SessionProvider: ParentComponent = (props) => {
         setPendingAgentSelection(null)
       }
 
-      setCurrentSessionID(session.id)
+      const active = currentSessionID()
+      const draft = draftSessionID()
+      if (!draftID || draft === draftID || active === draftID) {
+        setCurrentSessionID(session.id)
+        setDraftSessionID(session.id)
+      }
     })
   }
 
@@ -962,6 +967,10 @@ export const SessionProvider: ParentComponent = (props) => {
       title: language.t("prompt.toast.promptSendFailed.title") ?? "Failed to send message",
       description: message.error,
     })
+
+    if (!message.sessionID && message.draftID) {
+      setDraftSessionID(message.draftID)
+    }
   }
 
   /**
@@ -1297,7 +1306,13 @@ export const SessionProvider: ParentComponent = (props) => {
     queueMicrotask(() => window.dispatchEvent(new CustomEvent("resumeAutoScroll")))
   }
 
-  function sendMessage(text: string, providerID?: string, modelID?: string, files?: FileAttachment[]) {
+  function sendMessage(
+    text: string,
+    providerID?: string,
+    modelID?: string,
+    files?: FileAttachment[],
+    draftID?: string,
+  ) {
     if (!server.isConnected()) {
       console.warn("[Kilo New] Cannot send message: not connected")
       return
@@ -1332,6 +1347,7 @@ export const SessionProvider: ParentComponent = (props) => {
       text,
       messageID,
       sessionID: sid,
+      draftID,
       providerID,
       modelID,
       agent,
@@ -1340,7 +1356,14 @@ export const SessionProvider: ParentComponent = (props) => {
     })
   }
 
-  function sendCommand(command: string, args: string, providerID?: string, modelID?: string, files?: FileAttachment[]) {
+  function sendCommand(
+    command: string,
+    args: string,
+    providerID?: string,
+    modelID?: string,
+    files?: FileAttachment[],
+    draftID?: string,
+  ) {
     if (!server.isConnected()) {
       console.warn("[Kilo New] Cannot send command: not connected")
       return
@@ -1379,6 +1402,7 @@ export const SessionProvider: ParentComponent = (props) => {
       arguments: args,
       messageID,
       sessionID: sid,
+      draftID,
       providerID,
       modelID,
       agent,
@@ -1490,6 +1514,7 @@ export const SessionProvider: ParentComponent = (props) => {
 
   function clearCurrentSession() {
     setCurrentSessionID(undefined)
+    setDraftSessionID(undefined)
     setCloudPreviewId(null)
     setLoading(false)
     setPendingAgentSelection(defaultAgent())
@@ -1514,6 +1539,7 @@ export const SessionProvider: ParentComponent = (props) => {
       return
     }
     setCurrentSessionID(id)
+    setDraftSessionID(id)
     setLoading(!loaded().has(id))
     vscode.postMessage({ type: "loadMessages", sessionID: id })
   }
@@ -1526,6 +1552,7 @@ export const SessionProvider: ParentComponent = (props) => {
     const key = `cloud:${cloudSessionId}`
     setCloudPreviewId(cloudSessionId)
     setCurrentSessionID(key)
+    setDraftSessionID(key)
     setLoading(true)
     vscode.postMessage({ type: "requestCloudSessionData", sessionId: cloudSessionId })
   }
@@ -1776,6 +1803,8 @@ export const SessionProvider: ParentComponent = (props) => {
     syncSession,
     cloudPreviewId,
     selectCloudSession,
+    draftSessionID,
+    setDraftSessionID,
   }
 
   return <SessionContext.Provider value={value}>{props.children}</SessionContext.Provider>

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -453,6 +453,7 @@ export interface SendMessageFailedMessage {
   error: string
   text: string
   sessionID?: string
+  draftID?: string
   messageID?: string
   files?: FileAttachment[]
 }
@@ -505,6 +506,7 @@ export interface TodoUpdatedMessage {
 export interface SessionCreatedMessage {
   type: "sessionCreated"
   session: SessionInfo
+  draftID?: string
 }
 
 export interface SessionUpdatedMessage {
@@ -1359,6 +1361,7 @@ export interface SendMessageRequest {
   text: string
   messageID?: string
   sessionID?: string
+  draftID?: string
   providerID?: string
   modelID?: string
   agent?: string
@@ -1513,6 +1516,7 @@ export interface SendCommandRequest {
   arguments: string
   messageID?: string
   sessionID?: string
+  draftID?: string
   providerID?: string
   modelID?: string
   agent?: string

--- a/packages/kilo-vscode/webview-ui/src/utils/prompt-drafts.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/prompt-drafts.ts
@@ -1,0 +1,15 @@
+export function sessionDraftKey(id?: string): string | undefined {
+  if (!id) return undefined
+  return `session:${id}`
+}
+
+export function pendingDraftKey(id?: string): string | undefined {
+  if (!id) return undefined
+  if (id.startsWith("pending:")) return id
+  return `pending:${id}`
+}
+
+export function scopeDraftKey(box: string, raw?: string): string {
+  if (!raw) return `${box}:empty`
+  return `${box}:${raw}`
+}


### PR DESCRIPTION
## Summary
- scope prompt drafts by prompt box and pending/session identity so local tabs, worktrees, sidebar chats, and editor tabs keep independent text and image state
- carry pending draft state forward when a new session is created and restore failed sends to the correct pending prompt box
- add draft-key tests and plumb draft metadata through the VS Code provider and agent manager message flow

## Testing
- bun run format
- bun script/typecheck.ts
- bun script/typecheck.ts --project webview-ui/tsconfig.json
- bun test tests/unit/prompt-drafts.test.ts tests/unit/prompt-input-utils.test.ts tests/unit/kilo-provider-followup.test.ts tests/unit/kilo-provider-utils.test.ts