### PR TITLE
fix(cli): guard against null theme in TUI resolveTheme and Proxy

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -178,7 +178,14 @@ export const DEFAULT_THEMES: Record<string, ThemeJson> = {
   colorblind, // kilocode_change
 }
 
+// kilocode_change start
+function isValidTheme(t: unknown): t is ThemeJson {
+  return t != null && typeof t === "object" && "theme" in t && t.theme != null && typeof t.theme === "object"
+}
+// kilocode_change end
+
 function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
+  if (!isValidTheme(theme)) return resolveTheme(kilo as ThemeJson, mode) // kilocode_change
   const defs = theme.defs ?? {}
   function resolveColor(c: ColorValue): RGBA {
     if (c instanceof RGBA) return c
@@ -356,15 +363,23 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       init()
     })
 
+    // kilocode_change start - safe fallback to kilo import if store lookup fails
     const values = createMemo(() => {
-      return resolveTheme(store.themes[store.active] ?? store.themes.kilo, store.mode)
+      try {
+        const active = store.themes[store.active] ?? store.themes.kilo ?? (kilo as ThemeJson)
+        return resolveTheme(active, store.mode)
+      } catch {
+        return resolveTheme(kilo as ThemeJson, store.mode)
+      }
     })
+    // kilocode_change end
 
     const syntax = createMemo(() => generateSyntax(values()))
     const subtleSyntax = createMemo(() => generateSubtleSyntax(values()))
 
+    // kilocode_change - use empty object as proxy target; all reads go through the getter
     return {
-      theme: new Proxy(values(), {
+      theme: new Proxy({} as Theme, {
         get(_target, prop) {
           // @ts-expect-error
           return values()[prop]
@@ -416,7 +431,12 @@ async function getCustomThemes() {
       symlink: true,
     })) {
       const name = path.basename(item, ".json")
-      result[name] = await Filesystem.readJson(item)
+      // kilocode_change start - validate custom theme JSON and protect built-in keys
+      if (name in DEFAULT_THEMES) continue
+      const json = await Filesystem.readJson(item).catch(() => null)
+      if (!isValidTheme(json)) continue
+      result[name] = json
+      // kilocode_change end
     }
   }
   return result

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -180,7 +180,10 @@ export const DEFAULT_THEMES: Record<string, ThemeJson> = {
 
 // kilocode_change start
 function isValidTheme(t: unknown): t is ThemeJson {
-  return t != null && typeof t === "object" && "theme" in t && t.theme != null && typeof t.theme === "object"
+  if (t == null || typeof t !== "object" || !("theme" in t)) return false
+  const theme = (t as Record<string, unknown>).theme
+  if (theme == null || typeof theme !== "object") return false
+  return "background" in theme && "text" in theme && "primary" in theme
 }
 // kilocode_change end
 


### PR DESCRIPTION
## Summary

- Add null guards to prevent TUI crashes when `theme.theme` is null/undefined during theme resolution
- Validate custom theme JSON files before loading and protect built-in theme keys from being overwritten
- Use safe Proxy target and try/catch fallback in theme resolution memo

## Details

When opening a new tab in the TUI, the application crashes with `Object.entries requires that input parameter not be null or undefined` followed by `A Proxy's 'target' should be an Object`. Both originate from `theme.tsx` where `resolveTheme()` and the Proxy constructor receive invalid input.

### Changes

1. **`isValidTheme()` type guard** — validates a value is a properly-shaped `ThemeJson` with a non-null `.theme` object
2. **Null guard in `resolveTheme()`** — falls back to built-in `kilo` theme if input fails validation
3. **Try/catch in `createMemo`** — catches any resolution errors and falls back to `kilo` theme
4. **Safe Proxy target** — uses `{} as Theme` instead of `values()` to prevent cascading Proxy crash
5. **Custom theme validation in `getCustomThemes()`** — skips built-in key collisions, catches `readJson` failures, validates JSON shape

Closes #8109