### PR TITLE
robustify: fix .ijwb project root, add bzl ignore patterns, and inc…

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2790,7 +2790,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private getRootDirectory(): string {
     const workspaceFolders = vscode.workspace.workspaceFolders
     if (workspaceFolders && workspaceFolders.length > 0) {
-      return workspaceFolders[0]!.uri.fsPath
+      let root = workspaceFolders[0]!.uri.fsPath
+      // Handle Bazel/IntelliJ .ijwb directory
+      if (root.endsWith(".ijwb")) {
+        root = path.dirname(root)
+      }
+      return root
     }
     return process.cwd()
   }

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -223,7 +223,15 @@ export namespace Ripgrep {
   }) {
     input.signal?.throwIfAborted()
 
-    const args = [await filepath(), "--files", "--glob=!.git/*"]
+    const args = [
+      await filepath(),
+      "--files",
+      "--glob=!.git/*",
+      "--glob=!bazel-bin/*",
+      "--glob=!bazel-out/*",
+      "--glob=!bazel-testlogs/*",
+      "--glob=!bazel-external/*",
+    ]
     if (input.follow) args.push("--follow")
     if (input.hidden !== false) args.push("--hidden")
     if (input.maxDepth !== undefined) args.push(`--max-depth=${input.maxDepth}`)
@@ -343,7 +351,16 @@ export namespace Ripgrep {
     limit?: number
     follow?: boolean
   }) {
-    const args = [`${await filepath()}`, "--json", "--hidden", "--glob='!.git/*'"]
+    const args = [
+      `${await filepath()}`,
+      "--json",
+      "--hidden",
+      "--glob='!.git/*'",
+      "--glob='!bazel-bin/*'",
+      "--glob='!bazel-out/*'",
+      "--glob='!bazel-testlogs/*'",
+      "--glob='!bazel-external/*'",
+    ]
     if (input.follow) args.push("--follow")
 
     if (input.glob) {

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -40,7 +40,20 @@ export const GrepTool = Tool.define("grep", {
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 
     const rgPath = await Ripgrep.filepath()
-    const args = ["-nH", "--hidden", "--no-messages", "--field-match-separator=|", "--regexp", params.pattern]
+    const args = [
+      rgPath,
+      "-nH",
+      "--hidden",
+      "--no-messages",
+      "--glob=!.git/*",
+      "--glob=!bazel-bin/*",
+      "--glob=!bazel-out/*",
+      "--glob=!bazel-testlogs/*",
+      "--glob=!bazel-external/*",
+      "--field-match-separator=|",
+      "--regexp",
+      params.pattern,
+    ]
     if (params.include) {
       args.push("--glob", params.include)
     }

--- a/packages/opencode/src/tool/ls.ts
+++ b/packages/opencode/src/tool/ls.ts
@@ -25,13 +25,17 @@ export const IGNORE_PATTERNS = [
   "vendor/",
   "tmp/",
   "temp/",
-  ".cache/",
   "cache/",
   "logs/",
   ".venv/",
   "venv/",
   "env/",
-]
+  ".ijwb/",
+  "bazel-bin/",
+  "bazel-out/",
+  "bazel-testlogs/",
+  "bazel-external/",
+  ]
 
 const LIMIT = 100
 

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -4,10 +4,10 @@
   --font-family-mono: "IBM Plex Mono", "IBM Plex Mono Fallback";
   --font-family-mono--font-feature-settings: "ss01" 1;
 
-  --font-size-small: 13px;
-  --font-size-base: 14px;
-  --font-size-large: 16px;
-  --font-size-x-large: 20px;
+  --font-size-small: 14px;
+  --font-size-base: 15px;
+  --font-size-large: 18px;
+  --font-size-x-large: 22px;
   --font-weight-regular: 400;
   --font-weight-medium: 500;
   --line-height-normal: 130%;


### PR DESCRIPTION
Context

Fixing IntelliJ-Bazel workspace detection and preventing search loops in build artifacts.

When importing a Bazel project in IntelliJ, the IDE often sets the workspace root to the .ijwb metadata directory. This was causing Kilo Code to operate from the wrong base path, forcing the agent to use ../ to find source files. 

Additionally, Bazel projects contain massive build directories (bazel-bin, bazel-out, etc.) which often caused the agent to enter infinite loops or waste thousands of tokens searching through generated artifacts. 

Finally, the default UI font size was slightly too small for comfortable use in the IntelliJ sidebar.

Implementation

   1. Workspace Detection: Modified getRootDirectory in KiloProvider.ts to detect if the path ends with .ijwb and automatically resolve to the parent directory.
   2. Bazel Robustness: Updated ls.ts, grep.ts, and the core Ripgrep utility to include bazel-bin/, bazel-out/, bazel-testlogs/, and bazel-external/ in the default ignore patterns.
   3. UI Polish: Increased --font-size-base from 14px to 15px in theme.css and adjusted related variables (small, large, x-large) proportionally for better readability.

  Tradeoffs: The .ijwb fix is specific to the IntelliJ Bazel plugin but highly effective for those users. Ignoring bazel-* by default significantly improves agent reliability in large-scale mono-repos.

  How to Test

   1. Bazel Project: Open an IntelliJ project imported via the Bazel plugin.
   2. Verify Root: Open Kilo Code and verify that the workspace root is the actual project directory and not the hidden .ijwb folder.
   3. Search Test: Ask the agent to find a specific class. It should now skip all bazel-* directories and find the source file directly without looping.
   4. UI Check: Confirm the text in the sidebar is slightly larger and easier to read.