### PR TITLE
fix: RevertBanner UI shows no changes after successful file revert

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -130,6 +130,7 @@ export namespace Session {
           additions: z.number(),
           deletions: z.number(),
           files: z.number(),
+          // kilocode_change start - lightweight diff summary (no file contents)
           diffs: z
             .array(
               z.object({
@@ -140,6 +141,7 @@ export namespace Session {
               }),
             )
             .optional(),
+          // kilocode_change end
         })
         .optional(),
       share: z
@@ -492,7 +494,7 @@ export namespace Session {
             summary_additions: input.summary?.additions,
             summary_deletions: input.summary?.deletions,
             summary_files: input.summary?.files,
-            summary_diffs: input.summary?.diffs ?? null,
+            summary_diffs: input.summary?.diffs ?? null, // kilocode_change
             time_updated: Date.now(),
           })
           .where(eq(SessionTable.id, input.sessionID))

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -483,6 +483,7 @@ export namespace Session {
             summary_additions: input.summary?.additions,
             summary_deletions: input.summary?.deletions,
             summary_files: input.summary?.files,
+            summary_diffs: input.summary?.diffs ?? null,
             time_updated: Date.now(),
           })
           .where(eq(SessionTable.id, input.sessionID))

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -130,7 +130,16 @@ export namespace Session {
           additions: z.number(),
           deletions: z.number(),
           files: z.number(),
-          diffs: Snapshot.FileDiff.array().optional(),
+          diffs: z
+            .array(
+              z.object({
+                file: z.string(),
+                additions: z.number(),
+                deletions: z.number(),
+                status: z.enum(["added", "deleted", "modified"]).optional(),
+              }),
+            )
+            .optional(),
         })
         .optional(),
       share: z

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -58,27 +58,26 @@ export namespace SessionRevert {
       const session = await Session.get(input.sessionID)
       revert.snapshot = session.revert?.snapshot ?? (await Snapshot.track())
 
-      // Compute diffs BEFORE reverting files so the diff reflects the changes
-      // being undone (from == pre-change snapshot, to == current files on disk).
+      // kilocode_change start - compute diffs BEFORE reverting files so the diff
+      // reflects changes being undone (files on disk still have AI modifications)
       const rangeMessages = all.filter((msg) => msg.info.id >= revert!.messageID)
       const diffs = await SessionSummary.computeDiff({ messages: rangeMessages })
-
       await Snapshot.revert(patches)
-
       if (revert.snapshot) revert.diff = await Snapshot.diff(revert.snapshot)
+      // kilocode_change end
       await Storage.write(["session_diff", input.sessionID], diffs)
       Bus.publish(Session.Event.Diff, {
         sessionID: input.sessionID,
         diff: diffs,
       })
-      // Strip full file contents before persisting to DB — the webview
-      // RevertBanner only needs file, additions, deletions, status.
+      // kilocode_change start - strip full file contents before persisting to DB
       const summaryDiffs = diffs.map((d) => ({
         file: d.file,
         additions: d.additions,
         deletions: d.deletions,
         status: d.status,
       }))
+      // kilocode_change end
       return Session.setRevert({
         sessionID: input.sessionID,
         revert,
@@ -86,7 +85,7 @@ export namespace SessionRevert {
           additions: diffs.reduce((sum, x) => sum + x.additions, 0),
           deletions: diffs.reduce((sum, x) => sum + x.deletions, 0),
           files: diffs.length,
-          diffs: summaryDiffs,
+          diffs: summaryDiffs, // kilocode_change
         },
       })
     }

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -57,10 +57,15 @@ export namespace SessionRevert {
     if (revert) {
       const session = await Session.get(input.sessionID)
       revert.snapshot = session.revert?.snapshot ?? (await Snapshot.track())
-      await Snapshot.revert(patches)
-      if (revert.snapshot) revert.diff = await Snapshot.diff(revert.snapshot)
+
+      // Compute diffs BEFORE reverting files so the diff reflects the changes
+      // being undone (from == pre-change snapshot, to == current files on disk).
       const rangeMessages = all.filter((msg) => msg.info.id >= revert!.messageID)
       const diffs = await SessionSummary.computeDiff({ messages: rangeMessages })
+
+      await Snapshot.revert(patches)
+
+      if (revert.snapshot) revert.diff = await Snapshot.diff(revert.snapshot)
       await Storage.write(["session_diff", input.sessionID], diffs)
       Bus.publish(Session.Event.Diff, {
         sessionID: input.sessionID,
@@ -73,6 +78,7 @@ export namespace SessionRevert {
           additions: diffs.reduce((sum, x) => sum + x.additions, 0),
           deletions: diffs.reduce((sum, x) => sum + x.deletions, 0),
           files: diffs.length,
+          diffs,
         },
       })
     }

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -71,6 +71,14 @@ export namespace SessionRevert {
         sessionID: input.sessionID,
         diff: diffs,
       })
+      // Strip full file contents before persisting to DB — the webview
+      // RevertBanner only needs file, additions, deletions, status.
+      const summaryDiffs = diffs.map((d) => ({
+        file: d.file,
+        additions: d.additions,
+        deletions: d.deletions,
+        status: d.status,
+      }))
       return Session.setRevert({
         sessionID: input.sessionID,
         revert,
@@ -78,7 +86,7 @@ export namespace SessionRevert {
           additions: diffs.reduce((sum, x) => sum + x.additions, 0),
           deletions: diffs.reduce((sum, x) => sum + x.deletions, 0),
           files: diffs.length,
-          diffs,
+          diffs: summaryDiffs,
         },
       })
     }

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -25,7 +25,9 @@ export const SessionTable = sqliteTable(
     summary_additions: integer(),
     summary_deletions: integer(),
     summary_files: integer(),
-    summary_diffs: text({ mode: "json" }).$type<Snapshot.FileDiff[]>(),
+    summary_diffs: text({ mode: "json" }).$type<
+      { file: string; additions: number; deletions: number; status?: "added" | "deleted" | "modified" }[]
+    >(),
     revert: text({ mode: "json" }).$type<{ messageID: string; partID?: string; snapshot?: string; diff?: string }>(),
     permission: text({ mode: "json" }).$type<PermissionNext.Ruleset>(),
     ...Timestamps,

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -25,9 +25,11 @@ export const SessionTable = sqliteTable(
     summary_additions: integer(),
     summary_deletions: integer(),
     summary_files: integer(),
+    // kilocode_change start - lightweight diff type (no file contents)
     summary_diffs: text({ mode: "json" }).$type<
       { file: string; additions: number; deletions: number; status?: "added" | "deleted" | "modified" }[]
     >(),
+    // kilocode_change end
     revert: text({ mode: "json" }).$type<{ messageID: string; partID?: string; snapshot?: string; diff?: string }>(),
     permission: text({ mode: "json" }).$type<PermissionNext.Ruleset>(),
     ...Timestamps,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -833,7 +833,12 @@ export type Session = {
     additions: number
     deletions: number
     files: number
-    diffs?: Array<FileDiff>
+    diffs?: Array<{
+      file: string
+      additions: number
+      deletions: number
+      status?: "added" | "deleted" | "modified"
+    }>
   }
   share?: {
     url: string
@@ -1749,7 +1754,12 @@ export type GlobalSession = {
     additions: number
     deletions: number
     files: number
-    diffs?: Array<FileDiff>
+    diffs?: Array<{
+      file: string
+      additions: number
+      deletions: number
+      status?: "added" | "deleted" | "modified"
+    }>
   }
   share?: {
     url: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -5805,6 +5805,9 @@
                     },
                     "id": {
                       "type": "string"
+                    },
+                    "skipped": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -5927,6 +5930,9 @@
                     },
                     "id": {
                       "type": "string"
+                    },
+                    "skipped": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -6106,6 +6112,9 @@
                     },
                     "id": {
                       "type": "string"
+                    },
+                    "skipped": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -6368,6 +6377,9 @@
                     },
                     "id": {
                       "type": "string"
+                    },
+                    "skipped": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -12487,7 +12499,31 @@
               "diffs": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/FileDiff"
+                  "type": "object",
+                  "properties": {
+                    "file": {
+                      "type": "string"
+                    },
+                    "additions": {
+                      "type": "number"
+                    },
+                    "deletions": {
+                      "type": "number"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "added",
+                        "deleted",
+                        "modified"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "file",
+                    "additions",
+                    "deletions"
+                  ]
                 }
               }
             },
@@ -13975,6 +14011,10 @@
             "description": "@deprecated Use 'share' field instead. Share newly created sessions automatically",
             "type": "boolean"
           },
+          "remote_control": {
+            "description": "Enable remote control of sessions via Kilo Cloud. Equivalent to running /remote on startup.",
+            "type": "boolean"
+          },
           "autoupdate": {
             "description": "Automatically update to the latest version. Set to true to auto-update, false to disable, or 'notify' to show update notifications",
             "anyOf": [
@@ -15061,7 +15101,31 @@
               "diffs": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/FileDiff"
+                  "type": "object",
+                  "properties": {
+                    "file": {
+                      "type": "string"
+                    },
+                    "additions": {
+                      "type": "number"
+                    },
+                    "deletions": {
+                      "type": "number"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "added",
+                        "deleted",
+                        "modified"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "file",
+                    "additions",
+                    "deletions"
+                  ]
                 }
               }
             },


### PR DESCRIPTION
## Context

### **IMPORTANT: The revert button was reverting changes correctly, it just didn't convey that in the banner, causing confusion.**

The "Revert to here" button in the VS Code extension sidebar appears to not revert file changes — after clicking it, messages disappear but the RevertBanner shows no file change information. This gives the impression that only chat messages are reverted and not the associated git/file changes. In reality, `Snapshot.revert(patches)` was always reverting files correctly. The actual bug is that the diff data never reaches the webview, so the RevertBanner is always empty after revert.

Closes #8048

Two bugs contribute to this:

1. **`computeDiff()` called after file revert** — `SessionSummary.computeDiff()` was called _after_ `Snapshot.revert(patches)`. By that point files on disk already matched the `revert.snapshot` baseline, so `Snapshot.diffFull(from, to)` compared identical states and returned an empty diff.

2. **Diffs not persisted to the database** — `Session.setRevert()` stored `summary_additions`, `summary_deletions`, and `summary_files` but not `summary_diffs`. The column exists in the schema but was never written. The webview reads `session.summary()?.diffs` for the RevertBanner, which was always `undefined`.

Additionally, revert does not work in repositories with no commits (e.g., `git init` but no commits yet) because the snapshot system's initial `git rev-list --max-parents=0 --all` returns empty, causing the project to be stored without git VCS tracking. This is a pre-existing limitation, not addressed in this PR.

## Implementation

Two files changed:

### `packages/opencode/src/session/revert.ts`

- **Compute diffs before reverting files**: Moved `SessionSummary.computeDiff()` to execute _before_ `Snapshot.revert(patches)`. The diff captures changes being undone while files on disk still reflect the AI's modifications. `Snapshot.revert` itself was not changed — it was always working correctly.

- **Include `diffs` in the summary**: The `setRevert` call now passes `diffs` in the summary so it propagates through `sessionToWebview` to the webview's RevertBanner.

### `packages/opencode/src/session/index.ts`

- **Persist `summary_diffs` in `setRevert`**: Added `summary_diffs: input.summary?.diffs ?? null` to the Drizzle `.set()` call. The `summary_diffs` column already exists in the schema but was never written during revert operations.

## Screenshots

| before                                                  | after                                                         |
| ------------------------------------------------------- | ------------------------------------------------------------- |
|<img width="439" height="93" alt="before" src="https://github.com/user-attachments/assets/136ae2cb-016f-4a91-8fb5-d48ccd8dac1b" /> | <img width="427" height="110" alt="after" src="https://github.com/user-attachments/assets/f85e37e4-6101-475f-b123-4900dd5caff2" /> |


## How to Test

1. Open a git-initialized project with existing files (must have at least one commit)
2. Ask the AI to modify a file (e.g., "add a comment to the top of README.md")
3. Wait for the AI to complete and verify the file was modified
4. Click the revert arrow on your user message
5. Verify:
   - The file on disk is reverted to its previous state (this already worked before this fix)
   - The RevertBanner now shows the file changes (additions, deletions, file names) — this is the fix
   - Any files you edited independently are NOT reverted
6. Click "Redo" and verify the changes are restored

## Get in Touch

My discord is `@iamcoder18` and I am in the Kilo Code discord server.