### PR TITLE
fix(cli): prevent unbounded log file growth with size-based rotation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -401,6 +401,7 @@
         "opentui-spinner": "0.0.6",
         "partial-json": "0.1.7",
         "remeda": "catalog:",
+        "rotating-file-stream": "3.2.9",
         "simple-git": "3.31.1",
         "solid-js": "catalog:",
         "strip-ansi": "7.1.2",
@@ -3796,6 +3797,8 @@
     "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
 
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
+
+    "rotating-file-stream": ["rotating-file-stream@3.2.9", "", {}, "sha512-i9i0KkHh12ryl4xtELg+0gyoFre2PJ9RcQQLzquWsiqygyYsrZLckrqqYrthhnJZGZb4g+KUHtcoWYVq34gaug=="],
 
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -126,6 +126,7 @@
     "opentui-spinner": "0.0.6",
     "partial-json": "0.1.7",
     "remeda": "catalog:",
+    "rotating-file-stream": "3.2.9",
     "simple-git": "3.31.1",
     "solid-js": "catalog:",
     "strip-ansi": "7.1.2",

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -100,31 +100,22 @@ export namespace Server {
           const username = Flag.KILO_SERVER_USERNAME ?? "kilo" // kilocode_change
           return basicAuth({ username, password })(c, next)
         })
+        // kilocode_change start - skip all logging for high-frequency internal endpoints
+        // and fix leaked log.time() "started" line by early-returning instead of conditional blocks
         .use(async (c, next) => {
-          // kilocode_change start
-          // kilocode change add telemetry because it is high volume
-          // add early return to prevent logging timing
-          const skipLogging = c.req.path === "/log" || c.req.path === "/telemetry/capture" 
-          if (skipLogging) {
-            await next()
-            return
-          }
-          // kilocode_change end
-          if (!skipLogging) {
-            log.info("request", {
-              method: c.req.method,
-              path: c.req.path,
-            })
-          }
+          if (c.req.path === "/log" || c.req.path === "/telemetry/capture") return next()
+          log.info("request", {
+            method: c.req.method,
+            path: c.req.path,
+          })
           const timer = log.time("request", {
             method: c.req.method,
             path: c.req.path,
           })
           await next()
-          if (!skipLogging) {
-            timer.stop()
-          }
+          timer.stop()
         })
+        // kilocode_change end
         .use(
           cors({
             origin(input) {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -100,22 +100,31 @@ export namespace Server {
           const username = Flag.KILO_SERVER_USERNAME ?? "kilo" // kilocode_change
           return basicAuth({ username, password })(c, next)
         })
-        // kilocode_change start - skip all logging for high-frequency internal endpoints
-        // and fix leaked log.time() "started" line by early-returning instead of conditional blocks
         .use(async (c, next) => {
-          if (c.req.path === "/log" || c.req.path === "/telemetry/capture") return next()
-          log.info("request", {
-            method: c.req.method,
-            path: c.req.path,
-          })
+          // kilocode_change start
+          // kilocode change add telemetry because it is high volume
+          // add early return to prevent logging timing
+          const skipLogging = c.req.path === "/log" || c.req.path === "/telemetry/capture" 
+          if (skipLogging) {
+            await next()
+            return
+          }
+          // kilocode_change end
+          if (!skipLogging) {
+            log.info("request", {
+              method: c.req.method,
+              path: c.req.path,
+            })
+          }
           const timer = log.time("request", {
             method: c.req.method,
             path: c.req.path,
           })
           await next()
-          timer.stop()
+          if (!skipLogging) {
+            timer.stop()
+          }
         })
-        // kilocode_change end
         .use(
           cors({
             origin(input) {

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -70,7 +70,7 @@ export namespace Log {
     const dir = path.dirname(logpath)
     const stream = createStream(path.basename(logpath), {
       size: "50M",
-      maxFiles: 1,
+      maxFiles: 10,
       history: path.join(dir, ".log-history"),
       path: dir,
     })

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -70,7 +70,7 @@ export namespace Log {
     const dir = path.dirname(logpath)
     const stream = createStream(path.basename(logpath), {
       size: "50M",
-      maxFiles: 3,
+      maxFiles: 1,
       history: path.join(dir, ".log-history"),
       path: dir,
     })

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -67,10 +67,18 @@ export namespace Log {
     )
     await fs.truncate(logpath).catch(() => {})
     // kilocode_change start - use rotating-file-stream to cap log files at 50 MB
+    const dir = path.dirname(logpath)
     const stream = createStream(path.basename(logpath), {
       size: "50M",
-      maxFiles: 1,
-      path: path.dirname(logpath),
+      maxFiles: 3,
+      history: path.join(dir, ".log-history"),
+      path: dir,
+    })
+    stream.on("error", (err: Error) => {
+      process.stderr.write("log stream error: " + err.message + "\n")
+    })
+    stream.on("warning", (err: Error) => {
+      process.stderr.write("log stream warning: " + err.message + "\n")
     })
     write = (msg: any) => {
       stream.write(msg)

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -1,9 +1,9 @@
 import path from "path"
 import fs from "fs/promises"
-import { createWriteStream } from "fs"
 import { Global } from "../global"
 import z from "zod"
 import { Glob } from "./glob"
+import { createStream } from "rotating-file-stream" // kilocode_change
 
 export namespace Log {
   export const Level = z.enum(["DEBUG", "INFO", "WARN", "ERROR"]).meta({ ref: "LogLevel", description: "Log level" })
@@ -66,15 +66,17 @@ export namespace Log {
       options.dev ? "dev.log" : new Date().toISOString().split(".")[0].replace(/:/g, "") + ".log",
     )
     await fs.truncate(logpath).catch(() => {})
-    const stream = createWriteStream(logpath, { flags: "a" })
-    write = async (msg: any) => {
-      return new Promise((resolve, reject) => {
-        stream.write(msg, (err) => {
-          if (err) reject(err)
-          else resolve(msg.length)
-        })
-      })
+    // kilocode_change start - use rotating-file-stream to cap log files at 50 MB
+    const stream = createStream(path.basename(logpath), {
+      size: "50M",
+      maxFiles: 1,
+      path: path.dirname(logpath),
+    })
+    write = (msg: any) => {
+      stream.write(msg)
+      return msg.length
     }
+    // kilocode_change end
   }
 
   async function cleanup(dir: string) {


### PR DESCRIPTION
## Problem

Users are seeing `~/.local/share/kilo/log/` consume 50+ GB of disk space, with individual log files reaching 26 GB. This happens during long-running `kilo serve` sessions (e.g. the VS Code extension keeping the server alive for days).

## Fix: Size-based log rotation via `rotating-file-stream`

**File:** `packages/opencode/src/util/log.ts`

The existing cleanup logic only runs **once at startup** and only manages the *number* of log files (keeps last 10). There is **no size-based limit**. A `kilo serve` process kept alive by the VS Code extension for days writes to a single `.log` file indefinitely — that's how individual files reach 26 GB.

**Fix:** Replace `fs.createWriteStream` with [`rotating-file-stream`](https://github.com/iccicci/rotating-file-stream) (MIT, ~170K weekly downloads, maintained since 2015) configured with:

- `size: "50M"` — rotate when the active log exceeds 50 MB
- `maxFiles: 10` — keep up to 10 rotated files before deleting the oldest
- `history` — explicitly set to `.log-history` to control the tracking file location

This caps disk usage at **~550 MB per session** (50 MB active + up to 10 × 50 MB rotated files). The existing `cleanup()` function continues to manage retention across sessions (keeps last 10 session log files).

### Error handling

The stream's `error` and `warning` events are handled by writing to stderr, so log stream failures are visible rather than silently swallowed.

### Package trust (`rotating-file-stream@3.2.9`)

- MIT license, ~170K weekly downloads, no known CVEs
- Single maintainer (iccicci/Daniele Ricci), consistently maintained for 10 years with latest release Feb 2026
- TypeScript-native with bundled types