### PR TITLE
fix(agent-manager): log errors and trigger git refresh in worktree migration

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -173,8 +173,16 @@ export class AgentManagerProvider implements Disposable {
       return
     }
 
-    await state.load()
+    const migration = await state.load()
     manager.cleanupOrphanedTempDirs()
+
+    // When the .kilocode → .kilo migration rewrote git worktree refs, nudge
+    // VS Code's git extension to re-discover them. Without this, worktrees
+    // won't appear in Source Control until the next VS Code restart.
+    if (migration.refsFixed > 0) {
+      this.log(`Migration fixed ${migration.refsFixed} git worktree ref(s), refreshing git`)
+      this.host.refreshGit()
+    }
 
     // Do not auto-remove stale worktrees on load.
     // Presence checks run in the shared poller and require explicit user cleanup.

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -53,7 +53,7 @@ interface StateFile {
   defaultBaseBranch?: string
 }
 
-import { KILO_DIR, migrateAgentManagerData } from "./constants"
+import { KILO_DIR, migrateAgentManagerData, type MigrationResult } from "./constants"
 
 const STATE_FILE = "agent-manager.json"
 
@@ -302,11 +302,12 @@ export class WorktreeStateManager {
   // Persistence
   // ---------------------------------------------------------------------------
 
-  async load(): Promise<void> {
+  async load(): Promise<MigrationResult> {
     // Migrate Agent Manager data from .kilocode → .kilo before first read
+    let migration: MigrationResult = { refsFixed: 0 }
     if (!this.migrated) {
       this.migrated = true
-      await migrateAgentManagerData(this.root, this.log)
+      migration = await migrateAgentManagerData(this.root, this.log)
     }
     try {
       const content = await fs.promises.readFile(this.file, "utf-8")
@@ -346,6 +347,7 @@ export class WorktreeStateManager {
         this.log(`Failed to load state: ${error}`)
       }
     }
+    return migration
   }
 
   /** Remove worktrees whose directories no longer exist on disk. */

--- a/packages/kilo-vscode/src/agent-manager/constants.ts
+++ b/packages/kilo-vscode/src/agent-manager/constants.ts
@@ -30,6 +30,12 @@ const AGENT_MANAGER_ITEMS = [
   "setup-script.bat",
 ]
 
+/** Result of the migration so callers can react (e.g. refresh VS Code git). */
+export interface MigrationResult {
+  /** Number of git worktree refs that were rewritten from .kilocode → .kilo. */
+  refsFixed: number
+}
+
 /**
  * Migrate Agent Manager data from .kilocode/ to .kilo/.
  *
@@ -43,7 +49,7 @@ const AGENT_MANAGER_ITEMS = [
  *
  * Idempotent: safe to call on every startup.
  */
-export async function migrateAgentManagerData(root: string, log: (msg: string) => void): Promise<void> {
+export async function migrateAgentManagerData(root: string, log: (msg: string) => void): Promise<MigrationResult> {
   const legacy = path.join(root, LEGACY_DIR)
   const target = path.join(root, KILO_DIR)
 
@@ -77,9 +83,12 @@ export async function migrateAgentManagerData(root: string, log: (msg: string) =
     }
   }
 
+  let refsFixed = 0
   if (await isDirectory(path.join(target, "worktrees"))) {
-    await fixGitWorktreeRefs(root, log)
+    refsFixed = await fixGitWorktreeRefs(root, log)
   }
+
+  return { refsFixed }
 }
 
 async function exists(filepath: string): Promise<boolean> {
@@ -114,7 +123,7 @@ async function resolveGitDir(root: string): Promise<string | undefined> {
 
     const content = await fs.promises.readFile(gitPath, "utf-8")
     const match = content.match(/^gitdir:\s*(.+)$/m)
-    if (!match) return undefined
+    if (!match?.[1]) return undefined
     // gitdir points to e.g. /repo/.git/worktrees/foo — go up two levels to /repo/.git
     return path.resolve(path.dirname(gitPath), match[1].trim(), "..", "..")
   } catch {
@@ -128,21 +137,29 @@ async function resolveGitDir(root: string): Promise<string | undefined> {
  * Git stores absolute paths in .git/worktrees/{name}/gitdir. When the
  * worktree directory moves, those paths become stale. This rewrites any
  * gitdir files that reference the old .kilocode path.
+ *
+ * Returns the number of refs that were successfully fixed so callers can
+ * tell whether a VS Code git refresh is warranted.
  */
-async function fixGitWorktreeRefs(root: string, log: (msg: string) => void): Promise<void> {
+async function fixGitWorktreeRefs(root: string, log: (msg: string) => void): Promise<number> {
   const gitDir = await resolveGitDir(root)
-  if (!gitDir) return
+  if (!gitDir) {
+    log("fixGitWorktreeRefs: could not resolve git directory")
+    return 0
+  }
 
   const gitWorktreesDir = path.join(gitDir, "worktrees")
   try {
     const stat = await fs.promises.stat(gitWorktreesDir)
-    if (!stat.isDirectory()) return
-  } catch {
-    return
+    if (!stat.isDirectory()) return 0
+  } catch (err) {
+    log(`fixGitWorktreeRefs: ${gitWorktreesDir} not accessible: ${err}`)
+    return 0
   }
 
   const oldSegment = path.join(root, LEGACY_DIR) + path.sep
   const newSegment = path.join(root, KILO_DIR) + path.sep
+  let fixed = 0
 
   try {
     const entries = await fs.promises.readdir(gitWorktreesDir, { withFileTypes: true })
@@ -151,15 +168,26 @@ async function fixGitWorktreeRefs(root: string, log: (msg: string) => void): Pro
       const gitdirFile = path.join(gitWorktreesDir, entry.name, "gitdir")
       try {
         const content = await fs.promises.readFile(gitdirFile, "utf-8")
-        if (content.includes(oldSegment)) {
-          await fs.promises.writeFile(gitdirFile, content.replaceAll(oldSegment, newSegment))
+        if (!content.includes(oldSegment)) continue
+
+        const updated = content.replaceAll(oldSegment, newSegment)
+        await fs.promises.writeFile(gitdirFile, updated)
+
+        // Verify the write persisted — catch silent FS failures (e.g. read-only mount)
+        const verify = await fs.promises.readFile(gitdirFile, "utf-8")
+        if (verify === updated) {
+          fixed++
           log(`Fixed git worktree ref: ${entry.name}`)
+        } else {
+          log(`Warning: git worktree ref write did not persist for ${entry.name}`)
         }
-      } catch {
-        // gitdir file missing or unreadable — skip
+      } catch (err) {
+        log(`Warning: could not fix git worktree ref ${entry.name}: ${err}`)
       }
     }
-  } catch {
-    // .git/worktrees unreadable — skip
+  } catch (err) {
+    log(`Warning: could not read ${gitWorktreesDir}: ${err}`)
   }
+
+  return fixed
 }

--- a/packages/kilo-vscode/src/agent-manager/host.ts
+++ b/packages/kilo-vscode/src/agent-manager/host.ts
@@ -104,6 +104,9 @@ export interface Host {
   /** Capture a telemetry event. */
   capture(event: string, properties?: Record<string, unknown>): void
 
+  /** Ask VS Code's git extension to re-scan repositories (e.g. after worktree ref migration). */
+  refreshGit(): void
+
   /** Dispose all host resources. */
   dispose(): void
 }

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -156,5 +156,11 @@ export class VscodeHost implements Host {
     TelemetryProxy.capture(event as TelemetryEventName, properties)
   }
 
+  refreshGit(): void {
+    // Trigger VS Code's built-in git extension to re-scan repositories.
+    // This picks up worktrees whose gitdir refs were just rewritten by migration.
+    void vscode.commands.executeCommand("git.refresh")
+  }
+
   dispose(): void {}
 }


### PR DESCRIPTION
## Summary

- **`fixGitWorktreeRefs` silently swallowed errors** during the `.kilocode → .kilo` migration (`catch {}` blocks). If the gitdir rewrite failed (permissions, file locks, race with VS Code's git extension), worktrees moved on disk but git internal refs still pointed to `.kilocode/` paths — causing `git worktree list` to return stale paths and VS Code to stop showing worktrees in Source Control.
- All `catch` blocks in `fixGitWorktreeRefs` now **log errors** instead of silently skipping
- After writing a gitdir file, the fix **reads it back to verify** the write persisted (catches read-only mounts, silent FS failures)
- Migration now **returns a count** of fixed refs so callers can react
- When refs were rewritten, triggers **`git.refresh`** so VS Code re-discovers worktrees without requiring a manual restart

## Context

User report: worktrees that used to appear in VS Code Source Control disappeared after updating. Root cause traced to commit `466644eb25` (`.kilocode → .kilo` rename) where the migration's error handling silently swallowed failures, leaving git worktree references permanently broken.

## Test plan

- `bun run compile` passes (typecheck + lint + build)
- All 46 agent-manager unit tests pass
- No new test failures introduced