### PR TITLE
perf(server): skip logging for /log and /telemetry/capture via early return

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -101,7 +101,15 @@ export namespace Server {
           return basicAuth({ username, password })(c, next)
         })
         .use(async (c, next) => {
-          const skipLogging = c.req.path === "/log" || c.req.path === "/telemetry/capture" // kilocode_change
+          // kilocode_change start
+          // kilocode change add telemetry because it is high volume
+          // add early return to prevent logging timing
+          const skipLogging = c.req.path === "/log" || c.req.path === "/telemetry/capture" 
+          if (skipLogging) {
+            await next()
+            return
+          }
+          // kilocode_change end
           if (!skipLogging) {
             log.info("request", {
               method: c.req.method,


### PR DESCRIPTION
## Summary

- Skip logging middleware entirely for high-volume `/log` and `/telemetry/capture` endpoints by adding an early return, avoiding unnecessary timing and log overhead

Addresses but not fully https://github.com/Kilo-Org/kilocode/issues/8120