### PR TITLE
fix(agent-manager): route clipboard write through extension host

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -239,6 +239,10 @@ export class AgentManagerProvider implements Disposable {
       this.openWorktreeDirectory(m.worktreeId)
       return null
     }
+    if (m.type === "agentManager.copyToClipboard") {
+      this.host.copyToClipboard(m.text)
+      return null
+    }
     if (m.type === "previewImage") {
       return msg
     }

--- a/packages/kilo-vscode/src/agent-manager/host.ts
+++ b/packages/kilo-vscode/src/agent-manager/host.ts
@@ -101,6 +101,9 @@ export interface Host {
   /** Get the CLI server port (for webview CSP). */
   serverPort(): number | undefined
 
+  /** Copy text to the system clipboard. */
+  copyToClipboard(text: string): void
+
   /** Capture a telemetry event. */
   capture(event: string, properties?: Record<string, unknown>): void
 

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -262,6 +262,11 @@ interface OpenWorktreeIn {
   worktreeId: string
 }
 
+interface CopyToClipboardIn {
+  type: "agentManager.copyToClipboard"
+  text: string
+}
+
 interface ShowExistingLocalTerminalIn {
   type: "agentManager.showExistingLocalTerminal"
 }
@@ -435,6 +440,7 @@ export type AgentManagerInMessage =
   | ShowTerminalIn
   | ShowLocalTerminalIn
   | OpenWorktreeIn
+  | CopyToClipboardIn
   | ShowExistingLocalTerminalIn
   | RequestRepoInfoIn
   | CreateMultiVersionIn

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -152,6 +152,10 @@ export class VscodeHost implements Host {
     return this.connectionService.getServerInfo()?.port
   }
 
+  copyToClipboard(text: string): void {
+    void vscode.env.clipboard.writeText(text)
+  }
+
   capture(event: string, properties?: Record<string, unknown>): void {
     TelemetryProxy.capture(event as TelemetryEventName, properties)
   }

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2340,7 +2340,9 @@ const AgentManagerContent: Component = () => {
                                   onCommitRename={() => commitRename(wt.id)}
                                   onCancelRename={cancelRename}
                                   onRemoveStale={() => confirmRemoveStaleWorktree(wt.id)}
-                                  onCopyPath={() => navigator.clipboard.writeText(wt.path)}
+                                  onCopyPath={() =>
+                                    vscode.postMessage({ type: "agentManager.copyToClipboard", text: wt.path })
+                                  }
                                   onOpen={() =>
                                     vscode.postMessage({ type: "agentManager.openWorktree", worktreeId: wt.id })
                                   }

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1768,6 +1768,12 @@ export interface OpenWorktreeRequest {
   worktreeId: string
 }
 
+// Copy text to the system clipboard via the extension host
+export interface CopyToClipboardRequest {
+  type: "agentManager.copyToClipboard"
+  text: string
+}
+
 // Show existing local terminal when switching to local context (no-op if none exists)
 export interface ShowExistingLocalTerminalRequest {
   type: "agentManager.showExistingLocalTerminal"
@@ -2091,6 +2097,7 @@ export type WebviewMessage =
   | ShowTerminalRequest
   | ShowLocalTerminalRequest
   | OpenWorktreeRequest
+  | CopyToClipboardRequest
   | ShowExistingLocalTerminalRequest
   | AgentManagerOpenFileRequest
   | CreateMultiVersionRequest


### PR DESCRIPTION
## Summary

- Fix `NotAllowedError: Failed to execute 'writeText' on 'Clipboard': Document is not focused` when using "Copy Path" from the worktree context menu in the Agent Manager
- The webview loses focus when the context menu opens, so `navigator.clipboard.writeText()` fails. Route through `vscode.env.clipboard.writeText()` via the Host abstraction instead, which works regardless of webview focus state.

## Changes

- Added `copyToClipboard(text)` to the `Host` interface and `VscodeHost` implementation
- Added `agentManager.copyToClipboard` message type to both extension and webview type systems
- Replaced direct `navigator.clipboard.writeText()` call with `vscode.postMessage()` in `AgentManagerApp.tsx`