### PR TITLE
Migrate MCP server timeout

### DIFF
--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -768,9 +768,17 @@ async function migrateLanguage(language: string): Promise<MigrationResultItem> {
 
 function convertMcpServer(server: LegacyMcpServer): McpLocalConfig | McpRemoteConfig | null {
   const enabled = server.disabled ? { enabled: false as const } : {}
+  // Legacy stores timeout in seconds, the new config expects milliseconds
+  const timeout = server.timeout !== undefined ? server.timeout * 1000 : undefined
   if (server.type === "sse" || server.type === "streamable-http") {
     if (!server.url) return null
-    return { type: "remote", url: server.url, headers: server.headers, ...enabled }
+    return {
+      type: "remote",
+      url: server.url,
+      headers: server.headers,
+      ...(timeout !== undefined && { timeout }),
+      ...enabled,
+    }
   }
   // Default: stdio
   if (!server.command) return null
@@ -779,7 +787,7 @@ function convertMcpServer(server: LegacyMcpServer): McpLocalConfig | McpRemoteCo
     type: "local",
     command,
     environment: server.env,
-    ...(server.timeout !== undefined && { timeout: server.timeout }),
+    ...(timeout !== undefined && { timeout }),
     ...enabled,
   }
 }


### PR DESCRIPTION
Part of #8097


## Context

MCP server timeout was being lost (partially or fully) during the legacy migration wizard.

## Implementation

Remote servers (sse/streamable-http) dropped the timeout entirely. the local server path already had the timeout spread, but the remote one didn't. So if you had a remote MCP server with a custom timeout, it vanished on migration.

Unit mismatch between legacy and new config. The legacy extension stores timeout in seconds (validated as 1–3600 by Zod, default 60). The new config expects milliseconds. During migration now the value is multiplied by 1000 to correctly reflect milliseconds


## Testing

- Stored a remote server with timeout `60` on old extension settings
- Run the migration wizard on new extension - Check it's stored with `timeout: 60000`
