### PR TITLE
docs: add New Version FAQ and update announcement banner

### DIFF
--- a/packages/kilo-docs/components/TopNav.tsx
+++ b/packages/kilo-docs/components/TopNav.tsx
@@ -336,8 +336,8 @@ export function TopNav({ onMobileMenuToggle, isMobileMenuOpen = false, showMobil
       {/* Announcement banner */}
       <div className="announcement-banner">
         <p>
-          We've <Link href="https://blog.kilo.ai/p/kilo-cli">replatformed our extensions on the new Kilo CLI</Link>.
-          Contribute at <Link href="https://github.com/Kilo-Org/kilocode">Kilo-Org/kilocode</Link>.
+          Upgraded to the new extension? Check our <Link href="/code-with-ai/new-version-faq">New Version FAQ</Link> for
+          answers to common questions →
         </p>
       </div>
 

--- a/packages/kilo-docs/components/TopNav.tsx
+++ b/packages/kilo-docs/components/TopNav.tsx
@@ -336,8 +336,8 @@ export function TopNav({ onMobileMenuToggle, isMobileMenuOpen = false, showMobil
       {/* Announcement banner */}
       <div className="announcement-banner">
         <p>
-          Upgraded to the new extension? Check our <Link href="/code-with-ai/new-version-faq">New Version FAQ</Link> for
-          answers to common questions →
+          The all-new Kilo Code extension is here, rebuilt on the <Link href="/code-with-ai/whats-new">Kilo CLI</Link>{" "}
+          for speed, flexibility, and 500+ models →
         </p>
       </div>
 

--- a/packages/kilo-docs/lib/nav/code-with-ai.ts
+++ b/packages/kilo-docs/lib/nav/code-with-ai.ts
@@ -6,6 +6,7 @@ export const CodeWithAiNav: NavSection[] = [
     links: [
       { href: "/code-with-ai", children: "Overview" },
       { href: "/code-with-ai/platforms/vscode", children: "VS Code Extension" },
+      { href: "/code-with-ai/new-version-faq", children: "New Version FAQ" },
       {
         href: "/code-with-ai/platforms/jetbrains",
         children: "JetBrains Extension",

--- a/packages/kilo-docs/lib/nav/code-with-ai.ts
+++ b/packages/kilo-docs/lib/nav/code-with-ai.ts
@@ -6,7 +6,7 @@ export const CodeWithAiNav: NavSection[] = [
     links: [
       { href: "/code-with-ai", children: "Overview" },
       { href: "/code-with-ai/platforms/vscode", children: "VS Code Extension" },
-      { href: "/code-with-ai/new-version-faq", children: "New Version FAQ" },
+      { href: "/code-with-ai/whats-new", children: "What's New" },
       {
         href: "/code-with-ai/platforms/jetbrains",
         children: "JetBrains Extension",

--- a/packages/kilo-docs/pages/code-with-ai/new-version-faq.md
+++ b/packages/kilo-docs/pages/code-with-ai/new-version-faq.md
@@ -1,0 +1,56 @@
+---
+title: "New Version FAQ"
+description: "Common questions and answers about the new Kilo Code VS Code extension version"
+---
+
+# New Version FAQ
+
+If you've recently upgraded to the new Kilo Code VS Code extension (built on the Kilo CLI), you may notice some changes. This FAQ addresses the most common questions about the new version.
+
+## Where did code indexing go?
+
+Code indexing is temporarily unavailable in the new extension. It is actively being worked on and is expected to return soon.
+
+## How do checkpoints work in the new extension?
+
+Checkpoints are available in the new extension. You can use them to save and restore your workspace state during a task. See the [Checkpoints documentation](/docs/code-with-ai/features/checkpoints) for details on how to use them.
+
+## Where is the auto-confirm commands settings UI?
+
+The auto-confirm commands settings have moved to the new settings panel. The UI has changed, but the functionality is the same. Open the settings panel to configure which commands are auto-approved. See [Auto-Approving Actions](/docs/getting-started/settings/auto-approving-actions) for more information.
+
+## Where did the file reading settings go?
+
+File reading settings are available in the new settings panel. Open settings to configure file reading behavior.
+
+## Where is the UI for configuring local LLM providers?
+
+Local LLM providers can be configured through the new settings panel. See the [Local Models](/docs/automate/extending/local-models) documentation for setup instructions.
+
+## The model selection feels bloated. Can I simplify it?
+
+Model selection has been streamlined in the new extension. You can configure your preferred models to reduce clutter. See [Model Selection](/docs/code-with-ai/agents/model-selection) for details on how to customize which models appear in the selector.
+
+## Is the context progress graph still available?
+
+The context progress graph is being evaluated for the new extension. This feature may be reintroduced in a future update.
+
+## Where are the copy buttons in chat?
+
+Copy functionality is available in the chat interface. Hover over a message or code block to reveal the copy button.
+
+## Where did the in-chat UI for skills, commands, and MCPs go?
+
+MCP configuration has been migrated to the new settings panel. If you had MCPs configured in the old extension, they are automatically migrated to the new version. You can manage MCP servers, skills, and commands through the settings panel. See [MCP Overview](/docs/customize/mcp/overview) for more information.
+
+## Where is the diff view for file changes?
+
+The diff view is still available when reviewing file changes. When the agent proposes changes to a file, you can review the diff before approving.
+
+## How do I do code reviews in the new extension?
+
+Code reviews follow the CLI workflow in the new extension. See the [CLI documentation](/docs/code-with-ai/platforms/cli) for current instructions. Documentation specific to code reviews in the VS Code extension is being updated.
+
+## Settings include Linux commands that don't exist on Windows
+
+This is a known issue. The default command allowlist currently shows bash/Linux commands regardless of your platform. A fix is being worked on to make the default commands platform-dependent. In the meantime, you can manually edit the command allowlist in your settings to match your operating system.

--- a/packages/kilo-docs/pages/code-with-ai/whats-new.md
+++ b/packages/kilo-docs/pages/code-with-ai/whats-new.md
@@ -49,7 +49,7 @@ Copy functionality is available in the chat interface. Hover over a message or c
 
 ### Where did the in-chat UI for skills, commands, and MCPs go?
 
-MCP configuration has been migrated to the new settings panel. If you had MCPs configured in the old extension, they are automatically migrated to the new version. You can manage MCP servers, skills, and commands through the settings panel. See [MCP Overview](/docs/customize/mcp/overview) for more information.
+MCP configuration has been migrated to the new settings panel. If you had MCPs configured in the old extension, they are automatically migrated to the new version. You can manage MCP servers, skills, and commands through the settings panel. See [MCP Overview](/docs/automate/mcp/overview) for more information.
 
 ### Where is the diff view for file changes?
 

--- a/packages/kilo-docs/pages/code-with-ai/whats-new.md
+++ b/packages/kilo-docs/pages/code-with-ai/whats-new.md
@@ -1,56 +1,64 @@
 ---
-title: "New Version FAQ"
-description: "Common questions and answers about the new Kilo Code VS Code extension version"
+title: "What's New in Kilo Code"
+description: "The Kilo Code extension has been rebuilt from the ground up on the Kilo CLI — faster, more flexible, and with access to 500+ models."
 ---
 
-# New Version FAQ
+# What's New in Kilo Code
 
-If you've recently upgraded to the new Kilo Code VS Code extension (built on the Kilo CLI), you may notice some changes. This FAQ addresses the most common questions about the new version.
+The Kilo Code extension has been completely rebuilt on the [Kilo CLI](https://blog.kilo.ai/p/kilo-cli) — a powerful, open-source foundation designed for agentic engineering anywhere you code. This is the biggest update we've ever shipped: a faster, more capable extension with access to 500+ models, seamless terminal-to-IDE workflows, and the flexibility to use the right model for every task.
 
-## Where did code indexing go?
+Whether you're writing features in VS Code, debugging over SSH, or reviewing code on Slack, Kilo now goes with you. Read the [full announcement on the Kilo Blog](https://blog.kilo.ai/p/kilo-cli) for the complete story behind the rebuild.
+
+---
+
+## Adjusting to the new version
+
+A lot has changed under the hood, and some things have moved around. If you're coming from the previous extension, you might have questions about where to find certain features or how things work now. We've collected the most common ones below.
+
+### Where did code indexing go?
 
 Code indexing is temporarily unavailable in the new extension. It is actively being worked on and is expected to return soon.
 
-## How do checkpoints work in the new extension?
+### How do checkpoints work in the new extension?
 
 Checkpoints are available in the new extension. You can use them to save and restore your workspace state during a task. See the [Checkpoints documentation](/docs/code-with-ai/features/checkpoints) for details on how to use them.
 
-## Where is the auto-confirm commands settings UI?
+### Where is the auto-confirm commands settings UI?
 
 The auto-confirm commands settings have moved to the new settings panel. The UI has changed, but the functionality is the same. Open the settings panel to configure which commands are auto-approved. See [Auto-Approving Actions](/docs/getting-started/settings/auto-approving-actions) for more information.
 
-## Where did the file reading settings go?
+### Where did the file reading settings go?
 
 File reading settings are available in the new settings panel. Open settings to configure file reading behavior.
 
-## Where is the UI for configuring local LLM providers?
+### Where is the UI for configuring local LLM providers?
 
 Local LLM providers can be configured through the new settings panel. See the [Local Models](/docs/automate/extending/local-models) documentation for setup instructions.
 
-## The model selection feels bloated. Can I simplify it?
+### The model selection feels bloated. Can I simplify it?
 
 Model selection has been streamlined in the new extension. You can configure your preferred models to reduce clutter. See [Model Selection](/docs/code-with-ai/agents/model-selection) for details on how to customize which models appear in the selector.
 
-## Is the context progress graph still available?
+### Is the context progress graph still available?
 
 The context progress graph is being evaluated for the new extension. This feature may be reintroduced in a future update.
 
-## Where are the copy buttons in chat?
+### Where are the copy buttons in chat?
 
 Copy functionality is available in the chat interface. Hover over a message or code block to reveal the copy button.
 
-## Where did the in-chat UI for skills, commands, and MCPs go?
+### Where did the in-chat UI for skills, commands, and MCPs go?
 
 MCP configuration has been migrated to the new settings panel. If you had MCPs configured in the old extension, they are automatically migrated to the new version. You can manage MCP servers, skills, and commands through the settings panel. See [MCP Overview](/docs/customize/mcp/overview) for more information.
 
-## Where is the diff view for file changes?
+### Where is the diff view for file changes?
 
 The diff view is still available when reviewing file changes. When the agent proposes changes to a file, you can review the diff before approving.
 
-## How do I do code reviews in the new extension?
+### How do I do code reviews in the new extension?
 
 Code reviews follow the CLI workflow in the new extension. See the [CLI documentation](/docs/code-with-ai/platforms/cli) for current instructions. Documentation specific to code reviews in the VS Code extension is being updated.
 
-## Settings include Linux commands that don't exist on Windows
+### Settings include Linux commands that don't exist on Windows
 
 This is a known issue. The default command allowlist currently shows bash/Linux commands regardless of your platform. A fix is being worked on to make the default commands platform-dependent. In the meantime, you can manually edit the command allowlist in your settings to match your operating system.


### PR DESCRIPTION
## Summary

- Adds a **New Version FAQ** page (`packages/kilo-docs/pages/code-with-ai/new-version-faq.md`) addressing 12 common user questions about the new VS Code extension version:
  - Code indexing, checkpoints, auto-confirm commands, file reading settings, local LLM providers, model selection, context progress graph, copy buttons, skills/commands/MCPs UI, file change diffs, code reviews, and platform-specific commands
- Updates the **announcement banner** in `TopNav.tsx` to link to the new FAQ page instead of the previous blog post
- Adds the FAQ page to the **sidebar navigation** under "Code with AI > Platforms", positioned immediately after "VS Code Extension"

Replaces #8170 (rebased on latest main).
