### PR TITLE
Prevent Migration Wizard re-trigger on every launch

### DIFF
--- a/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
@@ -125,14 +125,14 @@ export async function handleStartLegacyMigration(
         ctx.extensionContext as Parameters<typeof MigrationService.setMigrationStatus>[0],
         "completed",
       )
-      ctx.broadcastComplete()
       ctx.refreshSessions()
-    } else if (failed) {
+    } else {
       await MigrationService.setMigrationStatus(
         ctx.extensionContext as Parameters<typeof MigrationService.setMigrationStatus>[0],
         "failed",
       )
     }
+    ctx.broadcastComplete()
 
     ctx.postMessage({ type: "legacyMigrationComplete", results })
   } catch (error) {
@@ -141,6 +141,7 @@ export async function handleStartLegacyMigration(
       ctx.extensionContext as Parameters<typeof MigrationService.setMigrationStatus>[0],
       "failed",
     )
+    ctx.broadcastComplete()
     ctx.postMessage({
       type: "legacyMigrationComplete",
       results: [

--- a/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
@@ -127,11 +127,20 @@ export async function handleStartLegacyMigration(
       )
       ctx.broadcastComplete()
       ctx.refreshSessions()
+    } else if (failed) {
+      await MigrationService.setMigrationStatus(
+        ctx.extensionContext as Parameters<typeof MigrationService.setMigrationStatus>[0],
+        "failed",
+      )
     }
 
     ctx.postMessage({ type: "legacyMigrationComplete", results })
   } catch (error) {
     console.error("[Kilo New] KiloProvider: ❌ Migration failed", error)
+    await MigrationService.setMigrationStatus(
+      ctx.extensionContext as Parameters<typeof MigrationService.setMigrationStatus>[0],
+      "failed",
+    )
     ctx.postMessage({
       type: "legacyMigrationComplete",
       results: [

--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -46,7 +46,7 @@ const SECRET_KEY = "roo_cline_config_api_config"
 const CODEX_OAUTH_SECRET_KEY = "openai-codex-oauth-credentials"
 const MIGRATION_STATUS_KEY = "kilo.legacyMigrationStatus"
 
-type MigrationStatus = "completed" | "skipped"
+type MigrationStatus = "completed" | "skipped" | "failed"
 
 // ---------------------------------------------------------------------------
 // Status helpers


### PR DESCRIPTION
Part of #8094

## Context

Fixes the Migration Wizard re-triggering on every launch.

## Implementation

If any migration item failed (e.g. a provider key, a session, autocomplete), the wizard never persisted any status to globalState — so on the next launch, getMigrationStatus() returned undefined and the wizard showed up again, every time, forever.

Added `"failed"` to the MigrationStatus type in `migration-service.ts` and two `setMigrationStatus(ctx, "failed")` calls in `migration.ts`: one in the `if (failed)` branch after migration results, and one in the catch block for unhandled exceptions. Since `getMigrationStatus()` already gates on any truthy value, `"failed"` prevents re-trigger. The user can still re-launch the wizard manually from Settings.


## Testing

Forced `migrateAutocomplete` to return `status: "error"`, confirmed the wizard re-triggered on every launch, applied the fix, confirmed it no longer re-triggers.