### PR TITLE
fix(agent-manager): suppress interactive prompts during background git fetch

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -9,7 +9,7 @@ interface GitOpsOptions {
   log: (...args: unknown[]) => void
   refreshMs?: number
   /** Override git command execution for testing. */
-  runGit?: (args: string[], cwd: string) => Promise<string>
+  runGit?: (args: string[], cwd: string, env?: Record<string, string>) => Promise<string>
 }
 
 export interface ApplyConflict {
@@ -40,26 +40,47 @@ interface ExecResult {
   stderr: string
 }
 
+/**
+ * Build environment variables that prevent git and SSH from opening interactive
+ * prompts. Used for background operations (e.g. periodic fetch) so users with
+ * SSH keys that require passphrase confirmation are not bombarded with dialogs.
+ *
+ * Returns a full `process.env` overlay suitable for `simple-git.env()` or
+ * `child_process.spawn`. `GIT_SSH_COMMAND` is only overridden when the user
+ * hasn't already configured their own.
+ */
+export function nonInteractiveEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    GIT_TERMINAL_PROMPT: "0",
+  }
+  if (!process.env.GIT_SSH_COMMAND) {
+    env.GIT_SSH_COMMAND = "ssh -o BatchMode=yes"
+  }
+  return env
+}
+
 export class GitOps {
   private lastFetch = new Map<string, number>()
   private inflightFetch = new Map<string, Promise<void>>()
   private readonly refreshMs: number
   private readonly log: (...args: unknown[]) => void
-  private readonly runGit: (args: string[], cwd: string) => Promise<string>
+  private readonly runGit: (args: string[], cwd: string, env?: Record<string, string>) => Promise<string>
 
   constructor(options: GitOpsOptions) {
     this.refreshMs = options.refreshMs ?? 120000
     this.log = options.log
     this.runGit =
       options.runGit ??
-      ((args, cwd) =>
-        simpleGit(cwd)
-          .raw(args)
-          .then((out) => out.trim()))
+      ((args, cwd, env) => {
+        const git = simpleGit(cwd)
+        if (env) git.env({ ...process.env, ...env })
+        return git.raw(args).then((out) => out.trim())
+      })
   }
 
-  private raw(args: string[], cwd: string): Promise<string> {
-    return this.runGit(args, cwd)
+  private raw(args: string[], cwd: string, env?: Record<string, string>): Promise<string> {
+    return this.runGit(args, cwd, env)
   }
 
   /** Return the name of the currently checked-out branch, or `"HEAD"` if detached. */
@@ -129,7 +150,11 @@ export class GitOps {
     if (now - prev < this.refreshMs) return
     this.lastFetch.set(key, now)
 
-    const job = this.raw(["fetch", "--quiet", "--no-tags", remote], cwd)
+    const env = {
+      GIT_TERMINAL_PROMPT: "0",
+      ...(process.env.GIT_SSH_COMMAND ? {} : { GIT_SSH_COMMAND: "ssh -o BatchMode=yes" }),
+    }
+    const job = this.raw(["fetch", "--quiet", "--no-tags", remote], cwd, env)
       .catch((err) => {
         this.log(`Failed to refresh remote refs for ${cwd}:`, err)
       })

--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -7,9 +7,8 @@ import { parseWorktreeList, normalizePath } from "./git-import"
 
 interface GitOpsOptions {
   log: (...args: unknown[]) => void
-  refreshMs?: number
   /** Override git command execution for testing. */
-  runGit?: (args: string[], cwd: string, env?: Record<string, string>) => Promise<string>
+  runGit?: (args: string[], cwd: string) => Promise<string>
 }
 
 export interface ApplyConflict {
@@ -61,26 +60,21 @@ export function nonInteractiveEnv(): NodeJS.ProcessEnv {
 }
 
 export class GitOps {
-  private lastFetch = new Map<string, number>()
-  private inflightFetch = new Map<string, Promise<void>>()
-  private readonly refreshMs: number
   private readonly log: (...args: unknown[]) => void
-  private readonly runGit: (args: string[], cwd: string, env?: Record<string, string>) => Promise<string>
+  private readonly runGit: (args: string[], cwd: string) => Promise<string>
 
   constructor(options: GitOpsOptions) {
-    this.refreshMs = options.refreshMs ?? 120000
     this.log = options.log
     this.runGit =
       options.runGit ??
-      ((args, cwd, env) => {
-        const git = simpleGit(cwd)
-        if (env) git.env({ ...process.env, ...env })
-        return git.raw(args).then((out) => out.trim())
-      })
+      ((args, cwd) =>
+        simpleGit(cwd)
+          .raw(args)
+          .then((out) => out.trim()))
   }
 
-  private raw(args: string[], cwd: string, env?: Record<string, string>): Promise<string> {
-    return this.runGit(args, cwd, env)
+  private raw(args: string[], cwd: string): Promise<string> {
+    return this.runGit(args, cwd)
   }
 
   /** Return the name of the currently checked-out branch, or `"HEAD"` if detached. */
@@ -133,37 +127,6 @@ export class GitOps {
     return this.raw(["rev-parse", "--verify", "--quiet", `refs/remotes/${ref}`], cwd)
       .then(() => true)
       .catch(() => false)
-  }
-
-  async refreshRemote(cwd: string, remote: string): Promise<void> {
-    if (!remote) return
-
-    const commonRaw = await this.raw(["rev-parse", "--git-common-dir"], cwd).catch(() => cwd)
-    const common = nodePath.isAbsolute(commonRaw) ? commonRaw : nodePath.resolve(cwd, commonRaw)
-    const key = `${common}:${remote}`
-
-    const existing = this.inflightFetch.get(key)
-    if (existing) return existing
-
-    const prev = this.lastFetch.get(key) ?? 0
-    const now = Date.now()
-    if (now - prev < this.refreshMs) return
-    this.lastFetch.set(key, now)
-
-    const env = {
-      GIT_TERMINAL_PROMPT: "0",
-      ...(process.env.GIT_SSH_COMMAND ? {} : { GIT_SSH_COMMAND: "ssh -o BatchMode=yes" }),
-    }
-    const job = this.raw(["fetch", "--quiet", "--no-tags", remote], cwd, env)
-      .catch((err) => {
-        this.log(`Failed to refresh remote refs for ${cwd}:`, err)
-      })
-      .then(() => undefined)
-      .finally(() => {
-        this.inflightFetch.delete(key)
-      })
-    this.inflightFetch.set(key, job)
-    return job
   }
 
   /** Return the set of worktree paths for the repo, excluding bare entries. */
@@ -236,12 +199,11 @@ export class GitOps {
   /**
    * Count commits ahead and behind using `rev-list --left-right --count`.
    * Callers are expected to pass a fully-qualified ref (e.g. "origin/main").
-   * Pass `remote` explicitly to refresh the tracking ref before counting;
-   * the remote is NOT inferred from the ref to avoid misinterpreting
-   * branch names that contain slashes (e.g. "release/1.0").
+   * Counts are computed against local tracking refs only — no fetch is
+   * performed, so values may be stale until an explicit git operation
+   * (push, pull, etc.) updates the refs.
    */
-  async aheadBehind(cwd: string, base: string, remote?: string): Promise<{ ahead: number; behind: number }> {
-    if (remote) await this.refreshRemote(cwd, remote)
+  async aheadBehind(cwd: string, base: string): Promise<{ ahead: number; behind: number }> {
     return this.parseLeftRight(cwd, base)
   }
 

--- a/packages/kilo-vscode/src/agent-manager/GitStatsPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitStatsPoller.ts
@@ -159,7 +159,7 @@ export class GitStatsPoller {
             const base = remoteRef(wt)
             const [{ data: diffs }, ab] = await Promise.all([
               client.worktree.diffSummary({ directory: wt.path, base }, { throwOnError: true }),
-              this.git.aheadBehind(wt.path, base, wt.remote),
+              this.git.aheadBehind(wt.path, base),
             ])
             const files = diffs.length
             const additions = diffs.reduce((sum: number, diff: FileDiff) => sum + diff.additions, 0)
@@ -248,7 +248,6 @@ export class GitStatsPoller {
 
       const tracking = await this.git.resolveTrackingBranch(root, branch)
       const base = tracking ?? (await this.git.resolveDefaultBranch(root, branch))
-      const remote = await this.git.resolveRemote(root, branch).catch(() => undefined)
 
       let files: number
       let additions: number
@@ -260,7 +259,7 @@ export class GitStatsPoller {
           this.options.log(`Local stats: using HTTP client with base=${base}`)
           const [{ data: diffs }, ab] = await Promise.all([
             client.worktree.diffSummary({ directory: root, base }, { throwOnError: true }),
-            this.git.aheadBehind(root, base, remote),
+            this.git.aheadBehind(root, base),
           ])
           files = diffs.length
           additions = diffs.reduce((sum: number, d: FileDiff) => sum + d.additions, 0)

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -11,7 +11,7 @@ import * as fs from "fs"
 import { randomUUID } from "crypto"
 import simpleGit, { type SimpleGit } from "simple-git"
 import { generateBranchName, sanitizeBranchName } from "./branch-name"
-import type { GitOps } from "./GitOps"
+import { type GitOps, nonInteractiveEnv } from "./GitOps"
 import { execWithShellEnv } from "./shell-env"
 import {
   parsePRUrl,
@@ -662,10 +662,11 @@ export class WorktreeManager {
         }
       }
 
-      // Either not cached or cache is stale - do the fetch
+      // Either not cached or cache is stale - do the fetch.
+      // Use non-interactive env to prevent SSH passphrase popups.
       onProgress?.("fetching", `Fetching ${remote}/${branch}...`)
       try {
-        await this.git.fetch(remote, branch)
+        await simpleGit(this.root).env(nonInteractiveEnv()).fetch(remote, branch)
         WorktreeManager.fetchCache.set(cacheKey, Date.now())
         if (await this.refExistsLocally(`${remote}/${branch}`)) {
           return {

--- a/packages/kilo-vscode/tests/unit/git-ops.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-ops.test.ts
@@ -8,7 +8,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-function ops(handler: (args: string[], cwd: string) => Promise<string>): GitOps {
+function ops(handler: (args: string[], cwd: string, env?: Record<string, string>) => Promise<string>): GitOps {
   return new GitOps({ log: () => undefined, refreshMs: 120000, runGit: handler })
 }
 
@@ -248,6 +248,60 @@ describe("GitOps", () => {
       await Promise.all([git.refreshRemote("/repo", "origin"), git.refreshRemote("/repo", "origin")])
       const fetches = commands.filter((c) => c[0] === "fetch")
       expect(fetches.length).toBe(1)
+    })
+
+    it("passes non-interactive env only for fetch commands", async () => {
+      const captured: { args: string[]; env?: Record<string, string> }[] = []
+      const git = ops(async (args, _cwd, env) => {
+        captured.push({ args, env })
+        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return "/repo/.git"
+        return ""
+      })
+      await git.refreshRemote("/repo", "origin")
+
+      const revParse = captured.find((c) => c.args[0] === "rev-parse")
+      expect(revParse?.env).toBeUndefined()
+
+      const fetch = captured.find((c) => c.args[0] === "fetch")
+      expect(fetch?.env).toBeDefined()
+      expect(fetch?.env?.GIT_TERMINAL_PROMPT).toBe("0")
+    })
+
+    it("sets GIT_SSH_COMMAND when not already configured", async () => {
+      const prev = process.env.GIT_SSH_COMMAND
+      delete process.env.GIT_SSH_COMMAND
+      try {
+        const captured: { args: string[]; env?: Record<string, string> }[] = []
+        const git = ops(async (args, _cwd, env) => {
+          captured.push({ args, env })
+          if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return "/repo/.git"
+          return ""
+        })
+        await git.refreshRemote("/repo", "origin")
+        const fetch = captured.find((c) => c.args[0] === "fetch")
+        expect(fetch?.env?.GIT_SSH_COMMAND).toBe("ssh -o BatchMode=yes")
+      } finally {
+        if (prev !== undefined) process.env.GIT_SSH_COMMAND = prev
+      }
+    })
+
+    it("preserves existing GIT_SSH_COMMAND", async () => {
+      const prev = process.env.GIT_SSH_COMMAND
+      process.env.GIT_SSH_COMMAND = "ssh -i ~/.ssh/custom_key"
+      try {
+        const captured: { args: string[]; env?: Record<string, string> }[] = []
+        const git = ops(async (args, _cwd, env) => {
+          captured.push({ args, env })
+          if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return "/repo/.git"
+          return ""
+        })
+        await git.refreshRemote("/repo", "origin")
+        const fetch = captured.find((c) => c.args[0] === "fetch")
+        expect(fetch?.env?.GIT_SSH_COMMAND).toBeUndefined()
+      } finally {
+        if (prev !== undefined) process.env.GIT_SSH_COMMAND = prev
+        else delete process.env.GIT_SSH_COMMAND
+      }
     })
   })
 

--- a/packages/kilo-vscode/tests/unit/git-ops.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-ops.test.ts
@@ -4,12 +4,8 @@ import * as os from "os"
 import * as nodePath from "path"
 import { GitOps } from "../../src/agent-manager/GitOps"
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
-function ops(handler: (args: string[], cwd: string, env?: Record<string, string>) => Promise<string>): GitOps {
-  return new GitOps({ log: () => undefined, refreshMs: 120000, runGit: handler })
+function ops(handler: (args: string[], cwd: string) => Promise<string>): GitOps {
+  return new GitOps({ log: () => undefined, runGit: handler })
 }
 
 function runGit(cwd: string, args: string[]): string {
@@ -193,160 +189,29 @@ describe("GitOps", () => {
     })
   })
 
-  describe("refreshRemote", () => {
-    it("fetches the remote", async () => {
-      const commands: string[][] = []
-      const git = ops(async (args) => {
-        commands.push(args)
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return "/repo/.git"
-        return ""
-      })
-      await git.refreshRemote("/repo", "origin")
-      const fetches = commands.filter((c) => c[0] === "fetch")
-      expect(fetches.length).toBe(1)
-      expect(fetches[0]![3]).toBe("origin")
-    })
-
-    it("skips empty remote name", async () => {
-      const commands: string[][] = []
-      const git = ops(async (args) => {
-        commands.push(args)
-        return ""
-      })
-      await git.refreshRemote("/repo", "")
-      expect(commands.length).toBe(0)
-    })
-
-    it("throttles repeated fetches for the same remote", async () => {
-      const commands: string[][] = []
-      const git = ops(async (args) => {
-        commands.push(args)
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return "/repo/.git"
-        return ""
-      })
-      await git.refreshRemote("/repo", "origin")
-      await git.refreshRemote("/repo", "origin")
-      const fetches = commands.filter((c) => c[0] === "fetch")
-      expect(fetches.length).toBe(1)
-    })
-
-    it("deduplicates inflight fetches", async () => {
-      const commands: string[][] = []
-      const git = new GitOps({
-        log: () => undefined,
-        refreshMs: 0,
-        runGit: async (args) => {
-          commands.push(args)
-          if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return "/repo/.git"
-          if (args[0] === "fetch") {
-            await sleep(50)
-            return ""
-          }
-          return ""
-        },
-      })
-      await Promise.all([git.refreshRemote("/repo", "origin"), git.refreshRemote("/repo", "origin")])
-      const fetches = commands.filter((c) => c[0] === "fetch")
-      expect(fetches.length).toBe(1)
-    })
-
-    it("passes non-interactive env only for fetch commands", async () => {
-      const captured: { args: string[]; env?: Record<string, string> }[] = []
-      const git = ops(async (args, _cwd, env) => {
-        captured.push({ args, env })
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return "/repo/.git"
-        return ""
-      })
-      await git.refreshRemote("/repo", "origin")
-
-      const revParse = captured.find((c) => c.args[0] === "rev-parse")
-      expect(revParse?.env).toBeUndefined()
-
-      const fetch = captured.find((c) => c.args[0] === "fetch")
-      expect(fetch?.env).toBeDefined()
-      expect(fetch?.env?.GIT_TERMINAL_PROMPT).toBe("0")
-    })
-
-    it("sets GIT_SSH_COMMAND when not already configured", async () => {
-      const prev = process.env.GIT_SSH_COMMAND
-      delete process.env.GIT_SSH_COMMAND
-      try {
-        const captured: { args: string[]; env?: Record<string, string> }[] = []
-        const git = ops(async (args, _cwd, env) => {
-          captured.push({ args, env })
-          if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return "/repo/.git"
-          return ""
-        })
-        await git.refreshRemote("/repo", "origin")
-        const fetch = captured.find((c) => c.args[0] === "fetch")
-        expect(fetch?.env?.GIT_SSH_COMMAND).toBe("ssh -o BatchMode=yes")
-      } finally {
-        if (prev !== undefined) process.env.GIT_SSH_COMMAND = prev
-      }
-    })
-
-    it("preserves existing GIT_SSH_COMMAND", async () => {
-      const prev = process.env.GIT_SSH_COMMAND
-      process.env.GIT_SSH_COMMAND = "ssh -i ~/.ssh/custom_key"
-      try {
-        const captured: { args: string[]; env?: Record<string, string> }[] = []
-        const git = ops(async (args, _cwd, env) => {
-          captured.push({ args, env })
-          if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return "/repo/.git"
-          return ""
-        })
-        await git.refreshRemote("/repo", "origin")
-        const fetch = captured.find((c) => c.args[0] === "fetch")
-        expect(fetch?.env?.GIT_SSH_COMMAND).toBeUndefined()
-      } finally {
-        if (prev !== undefined) process.env.GIT_SSH_COMMAND = prev
-        else delete process.env.GIT_SSH_COMMAND
-      }
-    })
-  })
-
   describe("aheadBehind", () => {
     it("counts commits ahead and behind using the provided ref", async () => {
       const git = ops(async (args) => {
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return ".git"
-        if (args[0] === "fetch") return ""
         if (args[0] === "rev-list" && args[1] === "--left-right") return "1\t3"
         return ""
       })
       expect(await git.aheadBehind("/repo", "origin/main")).toEqual({ ahead: 3, behind: 1 })
     })
 
-    it("fetches the explicitly-provided remote before counting", async () => {
+    it("does not fetch from remote", async () => {
       const commands: string[][] = []
       const git = ops(async (args) => {
         commands.push(args)
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return ".git"
-        if (args[0] === "fetch") return ""
         if (args[0] === "rev-list" && args[1] === "--left-right") return "0\t4"
         return ""
       })
-      expect(await git.aheadBehind("/repo", "myfork/main", "myfork")).toEqual({ ahead: 4, behind: 0 })
-      const fetches = commands.filter((c) => c[0] === "fetch")
-      expect(fetches.length).toBe(1)
-      expect(fetches[0]![3]).toBe("myfork")
-    })
-
-    it("skips fetch when no remote is provided", async () => {
-      const commands: string[][] = []
-      const git = ops(async (args) => {
-        commands.push(args)
-        if (args[0] === "rev-list" && args[1] === "--left-right") return "0\t2"
-        return ""
-      })
-      expect(await git.aheadBehind("/repo", "main")).toEqual({ ahead: 2, behind: 0 })
+      await git.aheadBehind("/repo", "myfork/main")
       const fetches = commands.filter((c) => c[0] === "fetch")
       expect(fetches.length).toBe(0)
     })
 
     it("returns zeros when rev-list fails", async () => {
       const git = ops(async (args) => {
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return ".git"
-        if (args[0] === "fetch") return ""
         if (args[0] === "rev-list") throw new Error("fatal")
         return ""
       })
@@ -356,8 +221,6 @@ describe("GitOps", () => {
     it("uses the ref directly without double-prefixing", async () => {
       const refs: string[] = []
       const git = ops(async (args) => {
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return ".git"
-        if (args[0] === "fetch") return ""
         if (args[0] === "rev-list" && args[1] === "--left-right") {
           refs.push(args[3]!)
           return "0\t1"

--- a/packages/kilo-vscode/tests/unit/git-stats-poller.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-stats-poller.test.ts
@@ -66,9 +66,6 @@ describe("GitStatsPoller", () => {
       log: () => undefined,
       intervalMs: 5,
       git: gitOps(async (args) => {
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return ".git"
-        if (args[0] === "rev-parse" && args[3] === "@{upstream}") return "origin/main"
-        if (args[0] === "fetch") return ""
         if (args[0] === "rev-list" && args[1] === "--left-right") return "0\t1"
         return ""
       }),
@@ -106,9 +103,7 @@ describe("GitStatsPoller", () => {
       log: () => undefined,
       intervalMs: 5,
       git: gitOps(async (args) => {
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return ".git"
         if (args[0] === "rev-parse" && args[3] === "@{upstream}") return "origin/main"
-        if (args[0] === "fetch") return ""
         if (args[0] === "rev-list" && args[1] === "--left-right") return "0\t2"
         return ""
       }),
@@ -231,9 +226,7 @@ describe("GitStatsPoller", () => {
         if (args[0] === "worktree") {
           return `worktree ${wtAPath}\nbranch refs/heads/branch-a\n`
         }
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return ".git"
         if (args[0] === "rev-parse" && args[3] === "@{upstream}") return "origin/main"
-        if (args[0] === "fetch") return ""
         if (args[0] === "rev-list") return "1"
         return ""
       }),
@@ -287,8 +280,6 @@ describe("GitStatsPoller", () => {
       git: gitOps(async (args) => {
         if (args[0] === "rev-parse" && args[1] === "--abbrev-ref" && args[2] === "HEAD") return "feature"
         if (args[0] === "rev-parse" && args[1] === "--abbrev-ref" && args[2] === "@{upstream}") return "origin/feature"
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return ".git"
-        if (args[0] === "fetch") return ""
         if (args[0] === "rev-list" && args[1] === "--left-right") return "0\t3"
         if (args[0] === "branch") return "feature"
         if (args[0] === "config") return "origin"
@@ -341,8 +332,6 @@ describe("GitStatsPoller", () => {
         // myfork/HEAD resolves to the default branch
         if (args[0] === "symbolic-ref" && args[2] === "refs/remotes/myfork/HEAD") return "myfork/develop"
         if (args[0] === "branch") return "my-feature"
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return ".git"
-        if (args[0] === "fetch") return ""
         if (args[0] === "rev-list" && args[1] === "--left-right") return "0\t5"
         return ""
       }),
@@ -406,7 +395,7 @@ describe("GitStatsPoller", () => {
     })
   })
 
-  it("refreshes upstream remote once for concurrent worktrees", async () => {
+  it("does not fetch from remote for ahead/behind counts", async () => {
     const commands: string[][] = []
     const emitted: Array<
       Array<{ worktreeId: string; files: number; additions: number; deletions: number; ahead: number; behind: number }>
@@ -416,7 +405,6 @@ describe("GitStatsPoller", () => {
       worktree: { diffSummary: async () => ({ data: diff(0, 0) }) },
     } as unknown as KiloClient
 
-    // Worktrees store remote="upstream" so aheadBehind receives "upstream/main"
     const poller = new GitStatsPoller({
       getWorktrees: () => [worktree("a", "upstream"), worktree("b", "upstream")],
       getWorkspaceRoot: () => undefined,
@@ -427,8 +415,6 @@ describe("GitStatsPoller", () => {
       intervalMs: 500,
       git: gitOps(async (args) => {
         commands.push(args)
-        if (args[0] === "rev-parse" && args[1] === "--git-common-dir") return "/repo/.git"
-        if (args[0] === "fetch") return ""
         if (args[0] === "rev-list" && args[1] === "--left-right") return "0\t0"
         return ""
       }),
@@ -439,9 +425,6 @@ describe("GitStatsPoller", () => {
     poller.stop()
 
     const fetches = commands.filter((cmd) => cmd[0] === "fetch")
-    expect(fetches.length).toBe(1)
-    const fetch = fetches[0]
-    if (!fetch) throw new Error("expected fetch command")
-    expect(fetch[3]).toBe("upstream")
+    expect(fetches.length).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

- Remove background `git fetch` from `GitOps.refreshRemote()` — the method and all supporting state (`lastFetch`, `inflightFetch`, `refreshMs`) are deleted
- The stats poller still runs and computes file diffs and ahead/behind counts, but no longer fetches from the remote first — ahead/behind is computed against local tracking refs which may be stale
- Local tracking refs update when the user does an explicit git operation (push, pull, fetch from terminal or VS Code source control)
- `nonInteractiveEnv` kept for `WorktreeManager.resolveStartPoint()` (worktree creation fetch, user-initiated)

Closes #8179