### PR TITLE
feat(cli): add org support for /kiloclaw command

### DIFF
--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -8,7 +8,7 @@
 import { fetchProfile, fetchBalance } from "../api/profile.js"
 import { fetchKilocodeNotifications, KilocodeNotificationSchema } from "../api/notifications.js"
 import { fetchOrganizationModes, clearModesCache } from "../api/modes.js"
-import { KILO_API_BASE, HEADER_FEATURE } from "../api/constants.js"
+import { KILO_API_BASE, HEADER_FEATURE, HEADER_ORGANIZATIONID } from "../api/constants.js"
 import { buildKiloHeaders } from "../headers.js"
 import type { ImportDeps, DrizzleDb } from "../cloud-sessions.js"
 import { fetchCloudSession, fetchCloudSessionForImport, importSessionToDb } from "../cloud-sessions.js"
@@ -536,12 +536,18 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
           const token = auth.type === "api" ? auth.key : auth.type === "oauth" ? auth.access : undefined
           if (!token) return c.json({ error: "No valid token found" }, 401)
 
-          const response = await fetch(`${KILO_API_BASE}/api/kiloclaw/status`, {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              "Content-Type": "application/json",
-            },
-          })
+          // kilocode_change start - pass org context for org-scoped instances
+          const orgId = auth.type === "oauth" ? auth.accountId : undefined
+          const headers: Record<string, string> = {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          }
+          if (orgId) {
+            headers[HEADER_ORGANIZATIONID] = orgId
+          }
+          // kilocode_change end
+
+          const response = await fetch(`${KILO_API_BASE}/api/kiloclaw/status`, { headers })
 
           if (!response.ok) {
             const text = await response.text()
@@ -589,12 +595,18 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
           const token = auth.type === "api" ? auth.key : auth.type === "oauth" ? auth.access : undefined
           if (!token) return c.json({ error: "No valid token found" }, 401)
 
-          const response = await fetch(`${KILO_API_BASE}/api/kiloclaw/chat-credentials`, {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              "Content-Type": "application/json",
-            },
-          })
+          // kilocode_change start - pass org context for org-scoped instances
+          const orgId = auth.type === "oauth" ? auth.accountId : undefined
+          const headers: Record<string, string> = {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          }
+          if (orgId) {
+            headers[HEADER_ORGANIZATIONID] = orgId
+          }
+          // kilocode_change end
+
+          const response = await fetch(`${KILO_API_BASE}/api/kiloclaw/chat-credentials`, { headers })
 
           if (!response.ok) {
             const text = await response.text()

--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -537,13 +537,13 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
           if (!token) return c.json({ error: "No valid token found" }, 401)
 
           // kilocode_change start - pass org context for org-scoped instances
-          const orgId = auth.type === "oauth" ? auth.accountId : undefined
+          const organizationId = auth.type === "oauth" ? auth.accountId : undefined
           const headers: Record<string, string> = {
             Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           }
-          if (orgId) {
-            headers[HEADER_ORGANIZATIONID] = orgId
+          if (organizationId) {
+            headers[HEADER_ORGANIZATIONID] = organizationId
           }
           // kilocode_change end
 
@@ -596,13 +596,13 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
           if (!token) return c.json({ error: "No valid token found" }, 401)
 
           // kilocode_change start - pass org context for org-scoped instances
-          const orgId = auth.type === "oauth" ? auth.accountId : undefined
+          const organizationId = auth.type === "oauth" ? auth.accountId : undefined
           const headers: Record<string, string> = {
             Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           }
-          if (orgId) {
-            headers[HEADER_ORGANIZATIONID] = orgId
+          if (organizationId) {
+            headers[HEADER_ORGANIZATIONID] = organizationId
           }
           // kilocode_change end
 

--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -536,7 +536,6 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
           const token = auth.type === "api" ? auth.key : auth.type === "oauth" ? auth.access : undefined
           if (!token) return c.json({ error: "No valid token found" }, 401)
 
-          // kilocode_change start - pass org context for org-scoped instances
           const organizationId = auth.type === "oauth" ? auth.accountId : undefined
           const headers: Record<string, string> = {
             Authorization: `Bearer ${token}`,
@@ -545,7 +544,6 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
           if (organizationId) {
             headers[HEADER_ORGANIZATIONID] = organizationId
           }
-          // kilocode_change end
 
           const response = await fetch(`${KILO_API_BASE}/api/kiloclaw/status`, { headers })
 
@@ -595,7 +593,6 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
           const token = auth.type === "api" ? auth.key : auth.type === "oauth" ? auth.access : undefined
           if (!token) return c.json({ error: "No valid token found" }, 401)
 
-          // kilocode_change start - pass org context for org-scoped instances
           const organizationId = auth.type === "oauth" ? auth.accountId : undefined
           const headers: Record<string, string> = {
             Authorization: `Bearer ${token}`,
@@ -604,7 +601,6 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
           if (organizationId) {
             headers[HEADER_ORGANIZATIONID] = organizationId
           }
-          // kilocode_change end
 
           const response = await fetch(`${KILO_API_BASE}/api/kiloclaw/chat-credentials`, { headers })
 

--- a/packages/opencode/src/kilocode/components/dialog-claw-setup.tsx
+++ b/packages/opencode/src/kilocode/components/dialog-claw-setup.tsx
@@ -13,9 +13,11 @@ import { useTheme } from "@tui/context/theme"
 import { useDialog } from "@tui/ui/dialog"
 import { Link } from "@tui/ui/link"
 
-export function DialogClawSetup() {
+export function DialogClawSetup(props: { orgId?: string | null }) {
   const { theme } = useTheme()
   const dialog = useDialog()
+
+  const url = props.orgId ? `https://app.kilo.ai/organizations/${props.orgId}/claw` : "https://app.kilo.ai/claw"
 
   useKeyboard((evt: any) => {
     if (evt.name === "return") {
@@ -56,7 +58,7 @@ export function DialogClawSetup() {
       <box flexDirection="row" justifyContent="flex-end" paddingBottom={1}>
         <box paddingLeft={3} paddingRight={3} backgroundColor={theme.primary} flexDirection="row">
           <text fg={theme.text}>{"🦀 "}</text>
-          <Link href="https://app.kilo.ai/claw" fg={theme.selectedListItemText}>
+          <Link href={url} fg={theme.selectedListItemText}>
             Try KiloClaw
           </Link>
         </box>

--- a/packages/opencode/src/kilocode/components/dialog-claw-upgrade.tsx
+++ b/packages/opencode/src/kilocode/components/dialog-claw-upgrade.tsx
@@ -13,9 +13,11 @@ import { useTheme } from "@tui/context/theme"
 import { useDialog } from "@tui/ui/dialog"
 import { Link } from "@tui/ui/link"
 
-export function DialogClawUpgrade() {
+export function DialogClawUpgrade(props: { orgId?: string | null }) {
   const { theme } = useTheme()
   const dialog = useDialog()
+
+  const url = props.orgId ? `https://app.kilo.ai/organizations/${props.orgId}/claw` : "https://app.kilo.ai/claw"
 
   useKeyboard((evt: any) => {
     if (evt.name === "return") {
@@ -44,7 +46,7 @@ export function DialogClawUpgrade() {
 
       <box flexDirection="row" justifyContent="flex-end" paddingBottom={1}>
         <box paddingLeft={3} paddingRight={3} backgroundColor={theme.primary}>
-          <Link href="https://app.kilo.ai/claw" fg={theme.selectedListItemText}>
+          <Link href={url} fg={theme.selectedListItemText}>
             Dashboard
           </Link>
         </box>

--- a/packages/opencode/src/kilocode/kilo-commands.tsx
+++ b/packages/opencode/src/kilocode/kilo-commands.tsx
@@ -52,13 +52,17 @@ export function registerKiloCommands(useSDK: () => UseSDK) {
       enabled: isKiloConnected(),
       hidden: !isKiloConnected(),
       onSelect: async () => {
-        // Check instance status first
-        const res = await sdk.client.kilo.claw.status().catch(() => null)
+        // Fetch profile (for org context) and instance status in parallel
+        const [profileRes, res] = await Promise.all([
+          sdk.client.kilo.profile().catch(() => null),
+          sdk.client.kilo.claw.status().catch(() => null),
+        ])
+        const orgId = profileRes?.data?.currentOrgId ?? null
         const status = res?.data as ClawStatus | undefined
 
         // No instance provisioned
         if (!status || !status.userId || res.error) {
-          dialog.replace(() => <DialogClawSetup />)
+          dialog.replace(() => <DialogClawSetup orgId={orgId} />)
           return
         }
 
@@ -67,7 +71,7 @@ export function registerKiloCommands(useSDK: () => UseSDK) {
 
         if (!creds?.data || creds.error) {
           // Instance exists but no chat credentials — needs upgrade
-          dialog.replace(() => <DialogClawUpgrade />)
+          dialog.replace(() => <DialogClawUpgrade orgId={orgId} />)
           return
         }
 


### PR DESCRIPTION
## Context

The `/kiloclaw` command always resolved the user's **personal** KiloClaw instance, even when the user had selected an organization via `/teams`. This PR adds organization support so the command resolves the correct org-scoped instance when a team is active.

## Implementation

The org context flows through 3 layers, following the same pattern used by existing org-aware endpoints (`/notifications`, `/fim`, `/modes`):

1. **Gateway** (`packages/kilo-gateway/src/server/routes.ts`): Both `/claw/status` and `/claw/chat-credentials` handlers now read `auth.accountId` (set by `/teams`) and forward it as the `X-KiloCode-OrganizationId` header when proxying to the cloud API.

2. **Command handler** (`packages/opencode/src/kilocode/kilo-commands.tsx`): The `/kiloclaw` `onSelect` now fetches `sdk.client.kilo.profile()` in parallel with the status check to obtain `currentOrgId`, and passes it to the setup/upgrade dialogs.

3. **Dialogs** (`dialog-claw-setup.tsx`, `dialog-claw-upgrade.tsx`): Both accept an `orgId` prop and construct the correct dashboard URL — `https://app.kilo.ai/organizations/{orgId}/claw` when in org context, falling back to `https://app.kilo.ai/claw` for personal.

**Cloud changes** (separate repo — `cloud/`): The REST API routes `/api/kiloclaw/status` and `/api/kiloclaw/chat-credentials` need a corresponding update to destructure `organizationId` from `getUserFromAuth()` and use `getActiveOrgInstance()` when present. The cloud already has org membership validation in `getUserFromAuth()` and the `getActiveOrgInstance()` function in the instance registry.

No SDK regeneration needed — the Hono route signatures are unchanged.

## Screenshots

N/A — TUI changes, no visual diff.

## How to Test

1. Authenticate with Kilo Gateway (`/login`)
2. Select an organization that has a KiloClaw instance via `/teams`
3. Run `/kiloclaw`
   - If the org has no instance: the setup dialog should link to `https://app.kilo.ai/organizations/{orgId}/claw`
   - If the org has an instance with chat: the full-screen chat view should connect to the org instance
4. Switch back to Personal Account via `/teams`
5. Run `/kiloclaw` again — should resolve the personal instance and link to `https://app.kilo.ai/claw`