### PR TITLE
fix: handle trailing assistant messages for Claude 4.6 no-prefill models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -60,12 +60,18 @@ export namespace ProviderTransform {
   }
 
   // Text-only trailing assistants (e.g. MAX_STEPS hint) are re-roled to "user"
-  // to preserve their instruction content. Trailing assistants with tool-call
+  // to preserve their instruction content; reasoning parts are stripped since
+  // they are invalid in user messages. Trailing assistants with tool-call
   // parts (e.g. from aborted turns or partial stream failures) are stripped.
   function fixTrailingAssistant(msgs: ModelMessage[]): ModelMessage[] {
     if (msgs.length === 0 || msgs[msgs.length - 1].role !== "assistant") return msgs
     const last = msgs[msgs.length - 1]
     if (isTextOnlyContent(last.content)) {
+      if (Array.isArray(last.content)) {
+        const textOnly = last.content.filter((p) => p.type !== "reasoning")
+        if (textOnly.length === 0) return msgs.slice(0, -1)
+        return [...msgs.slice(0, -1), { ...last, role: "user" as const, content: textOnly }]
+      }
       return [...msgs.slice(0, -1), { ...last, role: "user" as const }]
     }
     return msgs.slice(0, -1)

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -46,11 +46,43 @@ export namespace ProviderTransform {
     return undefined
   }
 
+  // kilocode_change start - Claude 4.6 models do not support assistant message prefill
+  const CLAUDE_NO_PREFILL = ["opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6"]
+  export function supportsAssistantPrefill(model: Provider.Model): boolean {
+    const id = model.api.id.toLowerCase()
+    return !CLAUDE_NO_PREFILL.some((v) => id.includes(v))
+  }
+
+  function isTextOnlyContent(content: ModelMessage["content"]): boolean {
+    if (typeof content === "string") return true
+    if (!Array.isArray(content)) return false
+    return content.every((p) => p.type === "text" || p.type === "reasoning")
+  }
+
+  // Text-only trailing assistants (e.g. MAX_STEPS hint) are re-roled to "user"
+  // to preserve their instruction content. Trailing assistants with tool-call
+  // parts (e.g. from aborted turns or partial stream failures) are stripped.
+  function fixTrailingAssistant(msgs: ModelMessage[]): ModelMessage[] {
+    if (msgs.length === 0 || msgs[msgs.length - 1].role !== "assistant") return msgs
+    const last = msgs[msgs.length - 1]
+    if (isTextOnlyContent(last.content)) {
+      return [...msgs.slice(0, -1), { ...last, role: "user" as const }]
+    }
+    return msgs.slice(0, -1)
+  }
+  // kilocode_change end
+
   function normalizeMessages(
     msgs: ModelMessage[],
     model: Provider.Model,
     options: Record<string, unknown>,
   ): ModelMessage[] {
+    // kilocode_change start - fix trailing assistant messages for models that don't support prefill
+    if (!supportsAssistantPrefill(model)) {
+      msgs = fixTrailingAssistant(msgs)
+    }
+    // kilocode_change end
+
     // Anthropic rejects messages with empty content - filter out empty string messages
     // and remove empty text/reasoning parts from array content
     if (model.api.npm === "@ai-sdk/anthropic") {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2737,3 +2737,157 @@ describe("ProviderTransform.variants", () => {
   })
 })
 // kilocode_change end
+
+// kilocode_change start - tests for Claude 4.6 prefill fix
+describe("ProviderTransform.supportsAssistantPrefill", () => {
+  const model = (apiId: string) => ({ api: { id: apiId } }) as any
+
+  test("returns false for claude opus 4.6", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-opus-4.6-20250601"))).toBe(false)
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-opus-4-6-20250601"))).toBe(false)
+  })
+
+  test("returns false for claude sonnet 4.6", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-sonnet-4.6-20260101"))).toBe(false)
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-sonnet-4-6-20260101"))).toBe(false)
+  })
+
+  test("returns true for claude sonnet 4.5 (prefill still supported)", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-sonnet-4.5-20250514"))).toBe(true)
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-sonnet-4-5-20250514"))).toBe(true)
+  })
+
+  test("returns true for claude sonnet 4", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-sonnet-4-20250514"))).toBe(true)
+  })
+
+  test("returns true for claude 3.5 sonnet", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("claude-3-5-sonnet-20241022"))).toBe(true)
+  })
+
+  test("returns true for non-claude models", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("gpt-5.4"))).toBe(true)
+    expect(ProviderTransform.supportsAssistantPrefill(model("gemini-3-pro"))).toBe(true)
+  })
+
+  test("handles case-insensitive model IDs", () => {
+    expect(ProviderTransform.supportsAssistantPrefill(model("Claude-Opus-4.6-20250601"))).toBe(false)
+    expect(ProviderTransform.supportsAssistantPrefill(model("CLAUDE-SONNET-4-6-20260101"))).toBe(false)
+  })
+})
+
+describe("ProviderTransform.message - fix trailing assistant for Claude 4.6", () => {
+  const claudeModel = (apiId: string, npm = "@ai-sdk/anthropic", providerID = "anthropic"): any => ({
+    id: `${'${providerID}/${apiId}'}`,
+    providerID,
+    api: { id: apiId, npm, url: "" },
+    name: apiId,
+    family: "claude",
+    release_date: "2026-01-01",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: true },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0, output: 0 },
+    limit: { context: 200000, output: 32000 },
+    options: {},
+    headers: {},
+  })
+
+  test("re-roles text-only trailing assistant to user for claude-opus-4-6", () => {
+    const msgs: any[] = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "MAX_STEPS hint" },
+    ]
+    const result = ProviderTransform.message(msgs, claudeModel("claude-opus-4-6"), {})
+    expect(result).toHaveLength(2)
+    expect(result[1].role).toBe("user")
+    expect(result[1].content).toBe("MAX_STEPS hint")
+  })
+
+  test("re-roles array text content trailing assistant to user", () => {
+    const msgs: any[] = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: [{ type: "text", text: "summary" }] },
+    ]
+    const result = ProviderTransform.message(msgs, claudeModel("claude-sonnet-4.6-20260101"), {})
+    expect(result).toHaveLength(2)
+    expect(result[1].role).toBe("user")
+  })
+
+  test("strips trailing assistant with tool-call content (partial stream failure)", () => {
+    const msgs: any[] = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: [{ type: "tool-call", toolCallId: "tc_1", toolName: "read", args: {} }] },
+    ]
+    const result = ProviderTransform.message(msgs, claudeModel("claude-opus-4-6"), {})
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe("user")
+  })
+
+  test("preserves trailing assistant for claude-sonnet-4.5 (supports prefill)", () => {
+    const msgs: any[] = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+    ]
+    const result = ProviderTransform.message(msgs, claudeModel("claude-sonnet-4.5-20250514"), {})
+    expect(result[result.length - 1].role).toBe("assistant")
+  })
+
+  test("preserves trailing assistant for claude-sonnet-4 (supports prefill)", () => {
+    const msgs: any[] = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+    ]
+    const result = ProviderTransform.message(msgs, claudeModel("claude-sonnet-4-20250514"), {})
+    expect(result[result.length - 1].role).toBe("assistant")
+  })
+
+  test("preserves trailing assistant for claude-3-5-sonnet (supports prefill)", () => {
+    const msgs: any[] = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+    ]
+    const result = ProviderTransform.message(msgs, claudeModel("claude-3-5-sonnet-20241022"), {})
+    expect(result[result.length - 1].role).toBe("assistant")
+  })
+
+  test("no-op when last message is already user", () => {
+    const msgs: any[] = [
+      { role: "assistant", content: "Hi" },
+      { role: "user", content: "Hello" },
+    ]
+    const result = ProviderTransform.message(msgs, claudeModel("claude-opus-4-6"), {})
+    expect(result).toHaveLength(2)
+    expect(result[result.length - 1].role).toBe("user")
+  })
+
+  test("works for openai-compatible provider with claude 4.6 model", () => {
+    const msgs: any[] = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+    ]
+    const model = claudeModel("claude-opus-4-6", "@ai-sdk/openai-compatible", "my-proxy")
+    const result = ProviderTransform.message(msgs, model, {})
+    expect(result[1].role).toBe("user")
+    expect(result[1].content).toBe("Hi there")
+  })
+
+  test("preserves trailing assistant for non-claude model", () => {
+    const model = claudeModel("gpt-5.4")
+    model.family = "gpt"
+    model.api.id = "gpt-5.4"
+    const msgs: any[] = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi" },
+    ]
+    const result = ProviderTransform.message(msgs, model, {})
+    expect(result[result.length - 1].role).toBe("assistant")
+  })
+})
+// kilocode_change end

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2889,5 +2889,58 @@ describe("ProviderTransform.message - fix trailing assistant for Claude 4.6", ()
     const result = ProviderTransform.message(msgs, model, {})
     expect(result[result.length - 1].role).toBe("assistant")
   })
+
+  test("strips reasoning parts when re-roling trailing assistant", () => {
+    const msgs: any[] = [
+      { role: "user", content: "Hello" },
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "Let me think..." },
+          { type: "text", text: "Here is my answer" },
+        ],
+      },
+    ]
+    const result = ProviderTransform.message(msgs, claudeModel("claude-opus-4-6"), {})
+    expect(result).toHaveLength(2)
+    expect(result[1].role).toBe("user")
+    expect(result[1].content).toEqual([{ type: "text", text: "Here is my answer" }])
+  })
+
+  test("strips trailing assistant with only reasoning content", () => {
+    const msgs: any[] = [
+      { role: "user", content: "Hello" },
+      {
+        role: "assistant",
+        content: [{ type: "reasoning", text: "Thinking only, no text output" }],
+      },
+    ]
+    const result = ProviderTransform.message(msgs, claudeModel("claude-sonnet-4.6-20260101"), {})
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe("user")
+    expect(result[0].content).toBe("Hello")
+  })
+
+  test("keeps all text parts and strips all reasoning parts when re-roling", () => {
+    const msgs: any[] = [
+      { role: "user", content: "Hello" },
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "Step 1 thinking" },
+          { type: "text", text: "First answer" },
+          { type: "reasoning", text: "Step 2 thinking" },
+          { type: "text", text: "Second answer" },
+        ],
+      },
+    ]
+    const result = ProviderTransform.message(msgs, claudeModel("claude-opus-4-6"), {})
+    expect(result).toHaveLength(2)
+    expect(result[1].role).toBe("user")
+    expect(result[1].content).toEqual([
+      { type: "text", text: "First answer" },
+      { type: "text", text: "Second answer" },
+    ])
+  })
 })
 // kilocode_change end


### PR DESCRIPTION
Closes #8260

## Context

Claude 4.6 models (Opus/Sonnet) do not support assistant message prefill. Per [Anthropic release notes (Feb 5, 2026)](https://platform.claude.com/docs/en/release-notes/overview): *"Opus 4.6 does not support prefilling assistant messages."*

When using Claude 4.6 via any provider (including openai-compatible), the conversation must end with a user message. Currently, `normalizeMessages()` does not account for this, so trailing assistant messages (e.g. the MAX_STEPS hint injected by `prompt.ts`) are sent as-is, resulting in:

> *This model does not support assistant message prefill. The conversation must end with a user message.*

## Implementation

Adds a targeted `fixTrailingAssistant()` strategy:

- **`CLAUDE_NO_PREFILL`** — Explicit list of model ID substrings that don't support prefill (`opus-4-6`, `opus-4.6`, `sonnet-4-6`, `sonnet-4.6`), covering both `-` and `.` version formats.
- **`supportsAssistantPrefill(model)`** — Case-insensitive check against the list. Exported for testability.
- **`isTextOnlyContent(content)`** — Distinguishes text/reasoning-only content from tool-call content.
- **`fixTrailingAssistant(msgs)`** — Applied at the top of `normalizeMessages()` before any provider-specific transforms:
  - Text-only trailing assistant → **re-roled to `"user"`** (preserves the instruction content)
  - Tool-call trailing assistant → **stripped** (partial stream failure artifact, no useful instruction to preserve)

This runs before the existing Anthropic empty-content filter and Claude toolCallId sanitizer, so all downstream transforms still apply normally.

**16 test cases** added covering: prefill detection for 4.6/4.5/4/3.5/non-Claude, re-role behavior, strip behavior, no-op when already user-terminated, openai-compatible provider path, and case-insensitivity.


## How to Test

1. Add an openai-compatible provider (or use Anthropic directly) with a Claude 4.6 model (e.g. `claude-opus-4-6`, `claude-sonnet-4.6-20260101`)
2. Start a task and let it run until it hits the max steps limit (or trigger any scenario that appends a trailing assistant message)
3. **Before fix**: observe `"does not support assistant message prefill"` error
4. **After fix**: the conversation completes normally; the MAX_STEPS instruction is preserved (re-roled as user message)
5. Verify that Claude 4.5 / Sonnet 4 / Claude 3.5 / non-Claude models are unaffected (trailing assistant messages remain as-is)
