### PR TITLE
fix: pass resourceName to Azure provider from env or config

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -165,7 +165,11 @@ export namespace Provider {
         options: {},
       }
     },
-    azure: async () => {
+    azure: async (provider) => {
+      const resourceName =
+        provider.options?.["resourceName"] ??
+        Env.get("AZURE_RESOURCE_NAME") ??
+        Env.get("AZURE_OPENAI_RESOURCE_NAME")
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
@@ -175,7 +179,9 @@ export namespace Provider {
             return sdk.responses(modelID)
           }
         },
-        options: {},
+        options: {
+          ...(resourceName ? { resourceName } : {}),
+        },
       }
     },
     "azure-cognitive-services": async () => {


### PR DESCRIPTION
## Summary

Fixes #8273

The `azure` custom loader in `provider.ts` was returning empty `options: {}`, which meant the `@ai-sdk/azure` SDK never received a `resourceName`. The SDK requires this value either via the `resourceName` option or the `AZURE_RESOURCE_NAME` environment variable — but because Kilo's `Env` module uses a shallow copy of `process.env`, the env var was not visible to the SDK when read through the normal `process.env` path.

## Fix

The `azure` loader now explicitly reads `resourceName` using `Env.get()` (with fallback to `AZURE_OPENAI_RESOURCE_NAME` as an alternate env var name), and also respects a `resourceName` set in the provider's config `options`. This is consistent with how `azure-cognitive-services` already handles its `AZURE_COGNITIVE_SERVICES_RESOURCE_NAME`.

Priority of `resourceName` resolution:
1. `provider.options.resourceName` (from `kilo.json` config)
2. `AZURE_RESOURCE_NAME` env var
3. `AZURE_OPENAI_RESOURCE_NAME` env var

## Changes

- `packages/opencode/src/provider/provider.ts`: Updated `azure` loader to accept `provider` argument and pass resolved `resourceName` to SDK options