### PR TITLE
fix(vscode, ui): prevent sticky file headers from floating over diff content in sidebar chat

### DIFF
--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -79,6 +79,15 @@
   }
 }
 
+/* Disable sticky file headers inside tool content — in the sidebar chat the
+   nearest scroll ancestor is the message list viewport, so sticky headers
+   float over diff lines as the user scrolls, appearing in the middle of the diff. */
+[data-component="edit-tool"] [data-component="sticky-accordion-header"],
+[data-component="write-tool"] [data-component="sticky-accordion-header"],
+[data-component="apply-patch-tool"] [data-component="sticky-accordion-header"] {
+  position: relative;
+}
+
 /* Prevent long filenames in apply-patch accordion from hiding diff changes */
 [data-component="accordion"][data-scope="apply-patch"] {
   [data-slot="apply-patch-filename"] {

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -2635,6 +2635,13 @@ body.vscode-light
   width: 100%;
 }
 
+/* Disable sticky headers in turn diff summary — the scroll container is
+   the message list, not a dedicated diff panel, so sticky headers float
+   over diff content as the user scrolls. */
+.vscode-session-turn-diffs [data-component="sticky-accordion-header"] {
+  position: relative;
+}
+
 /* ============================================
    Todo tool — align checkboxes with icon in header
    ============================================ */


### PR DESCRIPTION
## Summary

Fixes a bug where file name headers in expanded diffs float over the diff content when scrolling the sidebar chat message list.

### Problem

`StickyAccordionHeader` uses `position: sticky` which resolves against the nearest scrollable ancestor. In the sidebar chat, that ancestor is the **message list viewport** — not a dedicated diff scroll container. When scrolling through expanded diffs, the file name header sticks at the top of the viewport and appears to float in the middle of the diff content.

**Screenshots from the user report:**

| Sticky header floating over diff content | Turn diff summary showing the issue | Multi-file diff with floating header |
|---|---|---|
|  ![sticky-header-1](https://github.com/user-attachments/assets/c8cd5a40-9243-4ebe-acf0-14e179a1778e) |  ![sticky-header-2](https://github.com/user-attachments/assets/a0ff54f2-5b02-4749-bf8e-76d40c4e5ada)  |  ![sticky-header-3](https://github.com/user-attachments/assets/a37153a0-1882-426d-886e-57737d21628e)  |

> The header floats on top of the content and stops once it hits the next section.

### Fix

Override `position: sticky` → `position: relative` on `StickyAccordionHeader` elements in two sidebar chat contexts:

1. **`message-part.css`** — inside `edit-tool`, `write-tool`, and `apply-patch-tool` wrapper components
2. **`chat.css`** — inside `.vscode-session-turn-diffs` (the "Modified N files" turn diff summary)

### Not affected

- **Agent Manager diff panel** — has its own scroll container (`.am-diff-content` with `overflow-y: auto`)
- **Agent Manager full-screen diff view** — has its own scroll container (`.am-review-diff`)
- **Session review panel** — has its own scroll container