### PR TITLE
fix(vscode): wrap retry warning text

### DIFF
--- a/packages/kilo-ui/src/components/error-details.css
+++ b/packages/kilo-ui/src/components/error-details.css
@@ -6,6 +6,24 @@
   margin-top: 8px;
 }
 
+.error-card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.error-card-message {
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.error-details-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 0 4px;
+}
+
 .error-details-trigger {
   display: inline-flex;
   align-items: center;

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1252,7 +1252,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
               type: "sessionStatus",
               sessionID: sid,
               status: info.type,
-              ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
+              ...(info.type === "retry"
+                ? { attempt: info.attempt, message: info.message, next: info.next, details: info.details }
+                : {}),
             })
           }
         })

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -206,7 +206,15 @@ export type WebviewMessage =
       type: "messageCreated"
       message: Record<string, unknown>
     }
-  | { type: "sessionStatus"; sessionID: string; status: string; attempt?: number; message?: string; next?: number }
+  | {
+      type: "sessionStatus"
+      sessionID: string
+      status: string
+      attempt?: number
+      message?: string
+      next?: number
+      details?: string
+    }
   | {
       type: "permissionRequest"
       permission: {
@@ -278,7 +286,9 @@ export function mapSSEEventToWebviewMessage(event: Event, sessionID: string | un
         type: "sessionStatus",
         sessionID: event.properties.sessionID,
         status: info.type,
-        ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
+        ...(info.type === "retry"
+          ? { attempt: info.attempt, message: info.message, next: info.next, details: info.details }
+          : {}),
       }
     }
     case "permission.asked":

--- a/packages/kilo-vscode/src/session-status.ts
+++ b/packages/kilo-vscode/src/session-status.ts
@@ -41,7 +41,9 @@ export async function seedSessionStatuses(
         type: "sessionStatus",
         sessionID: sid,
         status: info.type,
-        ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
+        ...(info.type === "retry"
+          ? { attempt: info.attempt, message: info.message, next: info.next, details: info.details }
+          : {}),
       })
     }
 

--- a/packages/kilo-vscode/tests/unit/session-status.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-status.test.ts
@@ -31,7 +31,7 @@ describe("seedSessionStatuses", () => {
     const client = createClient({
       data: {
         s1: { type: "busy" },
-        s2: { type: "retry", attempt: 3, message: "rate limited", next: 5000 },
+        s2: { type: "retry", attempt: 3, message: "rate limited", next: 5000, details: '{"status":429}' },
       },
     })
     const map = new Map<string, SessionStatus["type"]>()
@@ -43,7 +43,15 @@ describe("seedSessionStatuses", () => {
     expect(map.get("s2")).toBe("retry")
     expect(msgs).toEqual([
       { type: "sessionStatus", sessionID: "s1", status: "busy" },
-      { type: "sessionStatus", sessionID: "s2", status: "retry", attempt: 3, message: "rate limited", next: 5000 },
+      {
+        type: "sessionStatus",
+        sessionID: "s2",
+        status: "retry",
+        attempt: 3,
+        message: "rate limited",
+        next: 5000,
+        details: '{"status":429}',
+      },
     ])
   })
 
@@ -164,7 +172,10 @@ describe("seedSessionStatuses", () => {
 
   it("still seeds server entries when reconcile=false", async () => {
     const client = createClient({
-      data: { s1: { type: "busy" }, s2: { type: "retry", attempt: 1, message: "err", next: 1000 } },
+      data: {
+        s1: { type: "busy" },
+        s2: { type: "retry", attempt: 1, message: "err", next: 1000, details: '{"error":"err"}' },
+      },
     })
     const map = new Map<string, SessionStatus["type"]>()
     const { msgs, post } = collect()
@@ -175,7 +186,15 @@ describe("seedSessionStatuses", () => {
     expect(map.get("s2")).toBe("retry")
     expect(msgs).toEqual([
       { type: "sessionStatus", sessionID: "s1", status: "busy" },
-      { type: "sessionStatus", sessionID: "s2", status: "retry", attempt: 1, message: "err", next: 1000 },
+      {
+        type: "sessionStatus",
+        sessionID: "s2",
+        status: "retry",
+        attempt: 1,
+        message: "err",
+        next: 1000,
+        details: '{"error":"err"}',
+      },
     ])
   })
 

--- a/packages/kilo-vscode/tests/unit/working-indicator.test.ts
+++ b/packages/kilo-vscode/tests/unit/working-indicator.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+
+const root = path.resolve(import.meta.dir, "../..")
+const tsx = path.join(root, "webview-ui/src/components/shared/WorkingIndicator.tsx")
+const css = path.join(root, "webview-ui/src/styles/chat.css")
+
+describe("WorkingIndicator retry wrapping", () => {
+  it("applies retry-specific wrap classes in the component", () => {
+    const src = fs.readFileSync(tsx, "utf-8")
+
+    expect(src).toContain('const retry = () => session.statusInfo().type === "retry"')
+    expect(src).toContain('"working-indicator-wrap": retry()')
+    expect(src).toContain('"working-text-wrap": retry()')
+  })
+
+  it("defines wrapping styles for retry text", () => {
+    const src = fs.readFileSync(css, "utf-8")
+
+    const wrap = src.match(/\.working-text-wrap\s*\{[^}]+\}/)?.[0]
+    const row = src.match(/\.working-indicator-wrap\s*\{[^}]+\}/)?.[0]
+
+    expect(wrap).toContain("white-space: normal;")
+    expect(wrap).toContain("overflow-wrap: anywhere;")
+    expect(row).toContain("align-items: flex-start;")
+  })
+})

--- a/packages/kilo-vscode/tests/unit/working-indicator.test.ts
+++ b/packages/kilo-vscode/tests/unit/working-indicator.test.ts
@@ -6,23 +6,32 @@ const root = path.resolve(import.meta.dir, "../..")
 const tsx = path.join(root, "webview-ui/src/components/shared/WorkingIndicator.tsx")
 const css = path.join(root, "webview-ui/src/styles/chat.css")
 
-describe("WorkingIndicator retry wrapping", () => {
-  it("applies retry-specific wrap classes in the component", () => {
+describe("WorkingIndicator retry UX", () => {
+  it("applies retry-specific wrap and details controls in the component", () => {
     const src = fs.readFileSync(tsx, "utf-8")
 
     expect(src).toContain('const retry = () => session.statusInfo().type === "retry"')
     expect(src).toContain('"working-indicator-wrap": retry()')
-    expect(src).toContain('"working-text-wrap": retry()')
+    expect(src).toContain('class="working-text working-text-wrap"')
+    expect(src).toContain("const retryDetails = () => {")
+    expect(src).toContain('<Collapsible.Trigger class="working-details-trigger">')
+    expect(src).toContain('onClick={() => copy(retryMsg() ?? statusText(), "message")}')
+    expect(src).toContain("const copyDetails = () => {")
+    expect(src).toContain("onClick={copyDetails}")
   })
 
-  it("defines wrapping styles for retry text", () => {
+  it("defines wrapping and details styles for retry text", () => {
     const src = fs.readFileSync(css, "utf-8")
 
     const wrap = src.match(/\.working-text-wrap\s*\{[^}]+\}/)?.[0]
     const row = src.match(/\.working-indicator-wrap\s*\{[^}]+\}/)?.[0]
+    const box = src.match(/\.working-details-box\s*\{[^}]+\}/)?.[0]
+    const pre = src.match(/\.working-details-pre\s*\{[^}]+\}/)?.[0]
 
     expect(wrap).toContain("white-space: normal;")
     expect(wrap).toContain("overflow-wrap: anywhere;")
     expect(row).toContain("align-items: flex-start;")
+    expect(box).toContain("border-radius: 6px;")
+    expect(pre).toContain("white-space: pre-wrap;")
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ErrorDisplay.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ErrorDisplay.tsx
@@ -1,8 +1,9 @@
-import { Component, createMemo, Switch, Match } from "solid-js"
+import { Component, createMemo, createSignal, Switch, Match } from "solid-js"
 import { Card } from "@kilocode/kilo-ui/card"
 import { Collapsible } from "@kilocode/kilo-ui/collapsible"
-import { ErrorDetails } from "@kilocode/kilo-ui/error-details"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Button } from "@kilocode/kilo-ui/button"
+import { showToast } from "@kilocode/kilo-ui/toast"
 import type { AssistantMessage } from "@kilocode/sdk/v2"
 import { useLanguage } from "../../context/language"
 import {
@@ -20,6 +21,7 @@ interface ErrorDisplayProps {
 export const ErrorDisplay: Component<ErrorDisplayProps> = (props) => {
   const { t } = useLanguage()
   const parsed = createMemo(() => parseAssistantError(props.error))
+  const [copied, setCopied] = createSignal<"message" | "details">()
 
   const errorText = createMemo(() => {
     const msg = props.error.data?.message
@@ -28,18 +30,46 @@ export const ErrorDisplay: Component<ErrorDisplayProps> = (props) => {
     return unwrapError(String(msg))
   })
 
+  const copy = (text: string, kind: "message" | "details") => {
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(kind)
+      showToast({ variant: "success", title: t("deviceAuth.toast.errorCopied") })
+      setTimeout(() => setCopied(undefined), 2000)
+    })
+  }
+
   return (
     <Switch
       fallback={
         <Card variant="error" class="error-card">
-          {errorText()}
+          <div class="error-card-header">
+            <span class="error-card-message">{errorText()}</span>
+            <IconButton
+              icon={copied() === "message" ? "check-small" : "copy"}
+              size="small"
+              variant="ghost"
+              aria-label={t("ui.permission.copyCommand")}
+              onClick={() => copy(errorText(), "message")}
+            />
+          </div>
           <Collapsible variant="ghost">
             <Collapsible.Trigger class="error-details-trigger">
               <span>{t("error.details.show")}</span>
               <Collapsible.Arrow />
             </Collapsible.Trigger>
             <Collapsible.Content>
-              <ErrorDetails error={props.error} />
+              <div class="error-details">
+                <div class="error-details-actions">
+                  <IconButton
+                    icon={copied() === "details" ? "check-small" : "copy"}
+                    size="small"
+                    variant="ghost"
+                    aria-label={t("ui.permission.copyCommand")}
+                    onClick={() => copy(JSON.stringify(props.error, null, 2), "details")}
+                  />
+                </div>
+                <pre class="error-detail-pre">{JSON.stringify(props.error, null, 2)}</pre>
+              </div>
             </Collapsible.Content>
           </Collapsible>
         </Card>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
@@ -80,11 +80,15 @@ export const WorkingIndicator: Component = () => {
     return perms.length > 0 || questions.length > 0
   }
 
+  const retry = () => session.statusInfo().type === "retry"
+
   return (
     <Show when={session.status() !== "idle" && !blocked()}>
-      <div class="working-indicator">
+      <div class="working-indicator" classList={{ "working-indicator-wrap": retry() }}>
         <Spinner />
-        <span class="working-text">{statusText()}</span>
+        <span class="working-text" classList={{ "working-text-wrap": retry() }}>
+          {statusText()}
+        </span>
         <Show when={elapsed() > 0}>
           <span class="working-elapsed">{formatElapsed()}</span>
         </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
@@ -5,7 +5,10 @@
  */
 
 import { Component, Show, createSignal, createEffect, onCleanup } from "solid-js"
+import { Collapsible } from "@kilocode/kilo-ui/collapsible"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
+import { showToast } from "@kilocode/kilo-ui/toast"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 
@@ -15,6 +18,8 @@ export const WorkingIndicator: Component = () => {
 
   const [elapsed, setElapsed] = createSignal(0)
   const [retryCountdown, setRetryCountdown] = createSignal(0)
+  const [open, setOpen] = createSignal(false)
+  const [copied, setCopied] = createSignal<"message" | "details">()
 
   createEffect(() => {
     const since = session.busySince()
@@ -38,6 +43,7 @@ export const WorkingIndicator: Component = () => {
     const info = session.statusInfo()
     if (info.type !== "retry") {
       setRetryCountdown(0)
+      setOpen(false)
       return
     }
 
@@ -57,10 +63,22 @@ export const WorkingIndicator: Component = () => {
     const info = session.statusInfo()
     if (info.type === "retry") {
       const countdown = retryCountdown()
-      const retryMsg = info.message || language.t("session.status.retry")
-      return countdown > 0 ? `${retryMsg} (${countdown}s)` : retryMsg
+      const msg = info.message || language.t("session.status.retry")
+      return countdown > 0 ? `${msg} (${countdown}s)` : msg
     }
     return session.statusText() ?? language.t("ui.sessionTurn.status.thinking")
+  }
+
+  const retryMsg = () => {
+    const info = session.statusInfo()
+    if (info.type !== "retry") return undefined
+    return info.message || language.t("session.status.retry")
+  }
+
+  const retryDetails = () => {
+    const info = session.statusInfo()
+    if (info.type !== "retry") return undefined
+    return info.details
   }
 
   const formatElapsed = () => {
@@ -82,15 +100,80 @@ export const WorkingIndicator: Component = () => {
 
   const retry = () => session.statusInfo().type === "retry"
 
+  const copy = (text: string, kind: "message" | "details") => {
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(kind)
+      showToast({ variant: "success", title: language.t("deviceAuth.toast.errorCopied") })
+      setTimeout(() => setCopied(undefined), 2000)
+    })
+  }
+
+  const copyDetails = () => {
+    const text = retryDetails()
+    if (!text) return
+    copy(text, "details")
+  }
+
   return (
     <Show when={session.status() !== "idle" && !blocked()}>
-      <div class="working-indicator" classList={{ "working-indicator-wrap": retry() }}>
+      <div
+        class="working-indicator"
+        classList={{
+          "working-indicator-wrap": retry(),
+          "working-indicator-details": retry() && !!retryDetails(),
+        }}
+      >
         <Spinner />
-        <span class="working-text" classList={{ "working-text-wrap": retry() }}>
-          {statusText()}
-        </span>
-        <Show when={elapsed() > 0}>
-          <span class="working-elapsed">{formatElapsed()}</span>
+        <Show
+          when={retry()}
+          fallback={
+            <>
+              <span class="working-text">{statusText()}</span>
+              <Show when={elapsed() > 0}>
+                <span class="working-elapsed">{formatElapsed()}</span>
+              </Show>
+            </>
+          }
+        >
+          <div class="working-body">
+            <div class="working-row">
+              <span class="working-text working-text-wrap">{statusText()}</span>
+              <Show when={elapsed() > 0}>
+                <span class="working-elapsed">{formatElapsed()}</span>
+              </Show>
+            </div>
+            <div class="working-actions">
+              <IconButton
+                icon={copied() === "message" ? "check-small" : "copy"}
+                size="small"
+                variant="ghost"
+                aria-label={language.t("ui.permission.copyCommand")}
+                onClick={() => copy(retryMsg() ?? statusText(), "message")}
+              />
+              <Show when={retryDetails()}>
+                <Collapsible open={open()} onOpenChange={setOpen} variant="ghost">
+                  <Collapsible.Trigger class="working-details-trigger">
+                    <span>{language.t("error.details.show")}</span>
+                    <Collapsible.Arrow />
+                  </Collapsible.Trigger>
+                  <Collapsible.Content>
+                    <div class="working-details-box">
+                      <div class="working-details-actions">
+                        <IconButton
+                          icon={copied() === "details" ? "check-small" : "copy"}
+                          size="small"
+                          variant="ghost"
+                          aria-label={language.t("ui.permission.copyCommand")}
+                          onClick={copyDetails}
+                        />
+                      </div>
+                      <pre class="working-details-pre">{retryDetails()}</pre>
+                    </div>
+                  </Collapsible.Content>
+                </Collapsible>
+              </Show>
+            </div>
+          </div>
         </Show>
       </div>
     </Show>

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -631,7 +631,14 @@ export const SessionProvider: ParentComponent = (props) => {
           break
 
         case "sessionStatus":
-          handleSessionStatus(message.sessionID, message.status, message.attempt, message.message, message.next)
+          handleSessionStatus(
+            message.sessionID,
+            message.status,
+            message.attempt,
+            message.message,
+            message.next,
+            message.details,
+          )
           break
 
         case "permissionRequest":
@@ -891,11 +898,12 @@ export const SessionProvider: ParentComponent = (props) => {
     attempt?: number,
     message?: string,
     next?: number,
+    details?: string,
   ) {
     const prev = statusMap[sessionID] ?? { type: "idle" }
     const info: SessionStatusInfo =
       newStatus === "retry"
-        ? { type: "retry", attempt: attempt ?? 0, message: message ?? "", next: next ?? 0 }
+        ? { type: "retry", attempt: attempt ?? 0, message: message ?? "", next: next ?? 0, details }
         : { type: newStatus }
     setStatusMap(sessionID, info)
     // Track busy start time

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -2235,12 +2235,23 @@
   color: var(--vscode-descriptionForeground);
 }
 
+.working-indicator-wrap {
+  align-items: flex-start;
+}
+
 .working-text {
   flex: 1;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.working-text-wrap {
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .working-elapsed {

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -2239,6 +2239,24 @@
   align-items: flex-start;
 }
 
+.working-indicator-details {
+  align-items: stretch;
+}
+
+.working-body {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.working-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
 .working-text {
   flex: 1;
   min-width: 0;
@@ -2252,6 +2270,44 @@
   text-overflow: clip;
   white-space: normal;
   overflow-wrap: anywhere;
+}
+
+.working-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.working-details-trigger {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--vscode-textLink-foreground);
+  cursor: pointer;
+}
+
+.working-details-box {
+  margin-top: 6px;
+  border: 1px solid var(--border-weak-base, var(--vscode-panel-border));
+  border-radius: 6px;
+  background: var(--vscode-textCodeBlock-background, var(--vscode-editorWidget-background));
+}
+
+.working-details-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 4px 0;
+}
+
+.working-details-pre {
+  margin: 0;
+  padding: 8px 10px 10px;
+  max-height: 180px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--vscode-foreground);
 }
 
 .working-elapsed {

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -14,7 +14,7 @@ export type SessionStatus = "idle" | "busy" | "retry"
 export type SessionStatusInfo =
   | { type: "idle" }
   | { type: "busy" }
-  | { type: "retry"; attempt: number; message: string; next: number }
+  | { type: "retry"; attempt: number; message: string; next: number; details?: string }
 
 // Tool state for tool parts
 export type ToolState =
@@ -474,6 +474,7 @@ export interface SessionStatusMessage {
   attempt?: number
   message?: string
   next?: number
+  details?: string
 }
 
 export interface SessionErrorMessage {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -424,6 +424,7 @@ export namespace SessionProcessor {
                   attempt,
                   message: retry,
                   next: Date.now() + delay,
+                  details: JSON.stringify(error, null, 2),
                 })
                 await SessionRetry.sleep(delay, input.abort).catch(() => {})
                 continue

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -14,6 +14,7 @@ export namespace SessionStatus {
         attempt: z.number(),
         message: z.string(),
         next: z.number(),
+        details: z.string().optional(),
       }),
       z.object({
         type: z.literal("busy"),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -600,6 +600,7 @@ export type SessionStatus =
       attempt: number
       message: string
       next: number
+      details?: string
     }
   | {
       type: "busy"

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -27,10 +27,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "healthy",
-                    "version"
-                  ]
+                  "required": ["healthy", "version"]
                 }
               }
             }
@@ -745,10 +742,7 @@
                         "type": "number"
                       }
                     },
-                    "required": [
-                      "rows",
-                      "cols"
-                    ]
+                    "required": ["rows", "cols"]
                   }
                 }
               }
@@ -1023,10 +1017,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "providers",
-                    "default"
-                  ]
+                  "required": ["providers", "default"]
                 }
               }
             }
@@ -1233,11 +1224,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "type",
-                  "branch",
-                  "extra"
-                ]
+                "required": ["type", "branch", "extra"]
               }
             }
           }
@@ -2148,9 +2135,7 @@
         ],
         "summary": "Get session",
         "description": "Retrieve detailed information about a specific Kilo session.",
-        "tags": [
-          "Session"
-        ],
+        "tags": ["Session"],
         "responses": {
           "200": {
             "description": "Get session",
@@ -2377,9 +2362,7 @@
           }
         ],
         "summary": "Get session children",
-        "tags": [
-          "Session"
-        ],
+        "tags": ["Session"],
         "description": "Retrieve all child sessions that were forked from the specified parent session.",
         "responses": {
           "200": {
@@ -2576,11 +2559,7 @@
                     "pattern": "^msg.*"
                   }
                 },
-                "required": [
-                  "modelID",
-                  "providerID",
-                  "messageID"
-                ]
+                "required": ["modelID", "providerID", "messageID"]
               }
             }
           }
@@ -3004,10 +2983,7 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "providerID",
-                  "modelID"
-                ]
+                "required": ["providerID", "modelID"]
               }
             }
           }
@@ -3077,10 +3053,7 @@
                         }
                       }
                     },
-                    "required": [
-                      "info",
-                      "parts"
-                    ]
+                    "required": ["info", "parts"]
                   }
                 }
               }
@@ -3161,10 +3134,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "info",
-                    "parts"
-                  ]
+                  "required": ["info", "parts"]
                 }
               }
             }
@@ -3210,10 +3180,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "providerID",
-                      "modelID"
-                    ]
+                    "required": ["providerID", "modelID"]
                   },
                   "agent": {
                     "type": "string"
@@ -3283,9 +3250,7 @@
                     }
                   }
                 },
-                "required": [
-                  "parts"
-                ]
+                "required": ["parts"]
               }
             }
           }
@@ -3355,10 +3320,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "info",
-                    "parts"
-                  ]
+                  "required": ["info", "parts"]
                 }
               }
             }
@@ -3725,10 +3687,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "providerID",
-                      "modelID"
-                    ]
+                    "required": ["providerID", "modelID"]
                   },
                   "agent": {
                     "type": "string"
@@ -3798,9 +3757,7 @@
                     }
                   }
                 },
-                "required": [
-                  "parts"
-                ]
+                "required": ["parts"]
               }
             }
           }
@@ -3861,10 +3818,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "info",
-                    "parts"
-                  ]
+                  "required": ["info", "parts"]
                 }
               }
             }
@@ -3942,20 +3896,13 @@
                               "$ref": "#/components/schemas/FilePartSource"
                             }
                           },
-                          "required": [
-                            "type",
-                            "mime",
-                            "url"
-                          ]
+                          "required": ["type", "mime", "url"]
                         }
                       ]
                     }
                   }
                 },
-                "required": [
-                  "arguments",
-                  "command"
-                ]
+                "required": ["arguments", "command"]
               }
             }
           }
@@ -4049,19 +3996,13 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "providerID",
-                      "modelID"
-                    ]
+                    "required": ["providerID", "modelID"]
                   },
                   "command": {
                     "type": "string"
                   }
                 },
-                "required": [
-                  "agent",
-                  "command"
-                ]
+                "required": ["agent", "command"]
               }
             }
           }
@@ -4150,9 +4091,7 @@
                     "pattern": "^prt.*"
                   }
                 },
-                "required": [
-                  "messageID"
-                ]
+                "required": ["messageID"]
               }
             }
           }
@@ -4312,16 +4251,10 @@
                 "properties": {
                   "response": {
                     "type": "string",
-                    "enum": [
-                      "once",
-                      "always",
-                      "reject"
-                    ]
+                    "enum": ["once", "always", "reject"]
                   }
                 },
-                "required": [
-                  "response"
-                ]
+                "required": ["response"]
               }
             }
           }
@@ -4458,19 +4391,13 @@
                 "properties": {
                   "reply": {
                     "type": "string",
-                    "enum": [
-                      "once",
-                      "always",
-                      "reject"
-                    ]
+                    "enum": ["once", "always", "reject"]
                   },
                   "message": {
                     "type": "string"
                   }
                 },
-                "required": [
-                  "reply"
-                ]
+                "required": ["reply"]
               }
             }
           }
@@ -4738,9 +4665,7 @@
                     }
                   }
                 },
-                "required": [
-                  "answers"
-                ]
+                "required": ["answers"]
               }
             }
           }
@@ -4917,15 +4842,10 @@
                                       "properties": {
                                         "field": {
                                           "type": "string",
-                                          "enum": [
-                                            "reasoning_content",
-                                            "reasoning_details"
-                                          ]
+                                          "enum": ["reasoning_content", "reasoning_details"]
                                         }
                                       },
-                                      "required": [
-                                        "field"
-                                      ],
+                                      "required": ["field"],
                                       "additionalProperties": false
                                     }
                                   ]
@@ -4961,16 +4881,10 @@
                                           "type": "number"
                                         }
                                       },
-                                      "required": [
-                                        "input",
-                                        "output"
-                                      ]
+                                      "required": ["input", "output"]
                                     }
                                   },
-                                  "required": [
-                                    "input",
-                                    "output"
-                                  ]
+                                  "required": ["input", "output"]
                                 },
                                 "limit": {
                                   "type": "object",
@@ -4985,10 +4899,7 @@
                                       "type": "number"
                                     }
                                   },
-                                  "required": [
-                                    "context",
-                                    "output"
-                                  ]
+                                  "required": ["context", "output"]
                                 },
                                 "modalities": {
                                   "type": "object",
@@ -4997,70 +4908,39 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "audio",
-                                          "image",
-                                          "video",
-                                          "pdf"
-                                        ]
+                                        "enum": ["text", "audio", "image", "video", "pdf"]
                                       }
                                     },
                                     "output": {
                                       "type": "array",
                                       "items": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "audio",
-                                          "image",
-                                          "video",
-                                          "pdf"
-                                        ]
+                                        "enum": ["text", "audio", "image", "video", "pdf"]
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "input",
-                                    "output"
-                                  ]
+                                  "required": ["input", "output"]
                                 },
                                 "recommendedIndex": {
                                   "type": "number"
                                 },
                                 "prompt": {
                                   "type": "string",
-                                  "enum": [
-                                    "codex",
-                                    "gemini",
-                                    "beast",
-                                    "anthropic",
-                                    "trinity",
-                                    "anthropic_without_todo"
-                                  ]
+                                  "enum": ["codex", "gemini", "beast", "anthropic", "trinity", "anthropic_without_todo"]
                                 },
                                 "isFree": {
                                   "type": "boolean"
                                 },
                                 "ai_sdk_provider": {
                                   "type": "string",
-                                  "enum": [
-                                    "anthropic",
-                                    "openai",
-                                    "openai-compatible",
-                                    "openrouter"
-                                  ]
+                                  "enum": ["anthropic", "openai", "openai-compatible", "openrouter"]
                                 },
                                 "experimental": {
                                   "type": "boolean"
                                 },
                                 "status": {
                                   "type": "string",
-                                  "enum": [
-                                    "alpha",
-                                    "beta",
-                                    "deprecated"
-                                  ]
+                                  "enum": ["alpha", "beta", "deprecated"]
                                 },
                                 "options": {
                                   "type": "object",
@@ -5117,12 +4997,7 @@
                             }
                           }
                         },
-                        "required": [
-                          "name",
-                          "env",
-                          "id",
-                          "models"
-                        ]
+                        "required": ["name", "env", "id", "models"]
                       }
                     },
                     "default": {
@@ -5141,11 +5016,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "all",
-                    "default",
-                    "connected"
-                  ]
+                  "required": ["all", "default", "connected"]
                 }
               }
             }
@@ -5272,9 +5143,7 @@
                     "type": "number"
                   }
                 },
-                "required": [
-                  "method"
-                ]
+                "required": ["method"]
               }
             }
           }
@@ -5354,9 +5223,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "method"
-                ]
+                "required": ["method"]
               }
             }
           }
@@ -5431,9 +5298,7 @@
                     "additionalProperties": {}
                   }
                 },
-                "required": [
-                  "event"
-                ]
+                "required": ["event"]
               }
             }
           }
@@ -5482,10 +5347,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "enabled",
-                    "connected"
-                  ]
+                  "required": ["enabled", "connected"]
                 }
               }
             }
@@ -5535,10 +5397,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "enabled",
-                    "connected"
-                  ]
+                  "required": ["enabled", "connected"]
                 }
               }
             }
@@ -5588,10 +5447,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "enabled",
-                    "connected"
-                  ]
+                  "required": ["enabled", "connected"]
                 }
               }
             }
@@ -5638,9 +5494,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "message"
-                  ]
+                  "required": ["message"]
                 }
               }
             }
@@ -5678,9 +5532,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "path"
-                ]
+                "required": ["path"]
               }
             }
           }
@@ -5726,9 +5578,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "text"
-                  ]
+                  "required": ["text"]
                 }
               }
             }
@@ -5756,9 +5606,7 @@
                     "minLength": 1
                   }
                 },
-                "required": [
-                  "text"
-                ]
+                "required": ["text"]
               }
             }
           }
@@ -5810,10 +5658,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "ok",
-                    "id"
-                  ]
+                  "required": ["ok", "id"]
                 }
               }
             }
@@ -5877,13 +5722,7 @@
                     }
                   }
                 },
-                "required": [
-                  "id",
-                  "worktree",
-                  "timeCreated",
-                  "timeUpdated",
-                  "sandboxes"
-                ]
+                "required": ["id", "worktree", "timeCreated", "timeUpdated", "sandboxes"]
               }
             }
           }
@@ -5935,10 +5774,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "ok",
-                    "id"
-                  ]
+                  "required": ["ok", "id"]
                 }
               }
             }
@@ -6010,11 +5846,7 @@
                         }
                       }
                     },
-                    "required": [
-                      "additions",
-                      "deletions",
-                      "files"
-                    ]
+                    "required": ["additions", "deletions", "files"]
                   },
                   "revert": {
                     "type": "object",
@@ -6032,9 +5864,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "messageID"
-                    ]
+                    "required": ["messageID"]
                   },
                   "permission": {
                     "type": "object",
@@ -6056,16 +5886,7 @@
                     "type": "number"
                   }
                 },
-                "required": [
-                  "id",
-                  "projectID",
-                  "slug",
-                  "directory",
-                  "title",
-                  "version",
-                  "timeCreated",
-                  "timeUpdated"
-                ]
+                "required": ["id", "projectID", "slug", "directory", "title", "version", "timeCreated", "timeUpdated"]
               }
             }
           }
@@ -6117,10 +5938,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "ok",
-                    "id"
-                  ]
+                  "required": ["ok", "id"]
                 }
               }
             }
@@ -6167,9 +5985,7 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "created"
-                            ]
+                            "required": ["created"]
                           },
                           "agent": {
                             "type": "string"
@@ -6184,10 +6000,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "providerID",
-                              "modelID"
-                            ]
+                            "required": ["providerID", "modelID"]
                           },
                           "tools": {
                             "type": "object",
@@ -6199,12 +6012,7 @@
                             }
                           }
                         },
-                        "required": [
-                          "role",
-                          "time",
-                          "agent",
-                          "model"
-                        ]
+                        "required": ["role", "time", "agent", "model"]
                       },
                       {
                         "type": "object",
@@ -6223,9 +6031,7 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "created"
-                            ]
+                            "required": ["created"]
                           },
                           "parentID": {
                             "type": "string"
@@ -6252,10 +6058,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "cwd",
-                              "root"
-                            ]
+                            "required": ["cwd", "root"]
                           },
                           "summary": {
                             "type": "boolean"
@@ -6288,18 +6091,10 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "read",
-                                  "write"
-                                ]
+                                "required": ["read", "write"]
                               }
                             },
-                            "required": [
-                              "input",
-                              "output",
-                              "reasoning",
-                              "cache"
-                            ]
+                            "required": ["input", "output", "reasoning", "cache"]
                           },
                           "structured": {},
                           "variant": {
@@ -6325,12 +6120,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "id",
-                  "sessionID",
-                  "timeCreated",
-                  "data"
-                ]
+                "required": ["id", "sessionID", "timeCreated", "data"]
               }
             }
           }
@@ -6382,10 +6172,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "ok",
-                    "id"
-                  ]
+                  "required": ["ok", "id"]
                 }
               }
             }
@@ -6447,9 +6234,7 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "start"
-                            ]
+                            "required": ["start"]
                           },
                           "metadata": {
                             "type": "object",
@@ -6459,10 +6244,7 @@
                             "additionalProperties": {}
                           }
                         },
-                        "required": [
-                          "type",
-                          "text"
-                        ]
+                        "required": ["type", "text"]
                       },
                       {
                         "type": "object",
@@ -6491,16 +6273,10 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "start"
-                            ]
+                            "required": ["start"]
                           }
                         },
-                        "required": [
-                          "type",
-                          "text",
-                          "time"
-                        ]
+                        "required": ["type", "text", "time"]
                       },
                       {
                         "type": "object",
@@ -6535,11 +6311,7 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "status",
-                                  "input",
-                                  "raw"
-                                ]
+                                "required": ["status", "input", "raw"]
                               },
                               {
                                 "type": "object",
@@ -6572,16 +6344,10 @@
                                         "type": "number"
                                       }
                                     },
-                                    "required": [
-                                      "start"
-                                    ]
+                                    "required": ["start"]
                                   }
                                 },
-                                "required": [
-                                  "status",
-                                  "input",
-                                  "time"
-                                ]
+                                "required": ["status", "input", "time"]
                               },
                               {
                                 "type": "object",
@@ -6623,20 +6389,10 @@
                                         "type": "number"
                                       }
                                     },
-                                    "required": [
-                                      "start",
-                                      "end"
-                                    ]
+                                    "required": ["start", "end"]
                                   }
                                 },
-                                "required": [
-                                  "status",
-                                  "input",
-                                  "output",
-                                  "title",
-                                  "metadata",
-                                  "time"
-                                ]
+                                "required": ["status", "input", "output", "title", "metadata", "time"]
                               },
                               {
                                 "type": "object",
@@ -6672,18 +6428,10 @@
                                         "type": "number"
                                       }
                                     },
-                                    "required": [
-                                      "start",
-                                      "end"
-                                    ]
+                                    "required": ["start", "end"]
                                   }
                                 },
-                                "required": [
-                                  "status",
-                                  "input",
-                                  "error",
-                                  "time"
-                                ]
+                                "required": ["status", "input", "error", "time"]
                               }
                             ]
                           },
@@ -6695,22 +6443,12 @@
                             "additionalProperties": {}
                           }
                         },
-                        "required": [
-                          "type",
-                          "callID",
-                          "tool",
-                          "state"
-                        ]
+                        "required": ["type", "callID", "tool", "state"]
                       }
                     ]
                   }
                 },
-                "required": [
-                  "id",
-                  "messageID",
-                  "sessionID",
-                  "data"
-                ]
+                "required": ["id", "messageID", "sessionID", "data"]
               }
             }
           }
@@ -6776,9 +6514,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "location"
-                ]
+                "required": ["location"]
               }
             }
           }
@@ -6844,9 +6580,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "name"
-                ]
+                "required": ["name"]
               }
             }
           }
@@ -6912,17 +6646,11 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "id",
-                              "name",
-                              "role"
-                            ]
+                            "required": ["id", "name", "role"]
                           }
                         }
                       },
-                      "required": [
-                        "email"
-                      ]
+                      "required": ["email"]
                     },
                     "balance": {
                       "anyOf": [
@@ -6933,9 +6661,7 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "balance"
-                          ]
+                          "required": ["balance"]
                         },
                         {
                           "type": "null"
@@ -6953,11 +6679,7 @@
                       ]
                     }
                   },
-                  "required": [
-                    "profile",
-                    "balance",
-                    "currentOrgId"
-                  ]
+                  "required": ["profile", "balance", "currentOrgId"]
                 }
               }
             }
@@ -7041,9 +6763,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "organizationId"
-                ]
+                "required": ["organizationId"]
               }
             }
           }
@@ -7171,9 +6891,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "modes"
-                  ]
+                  "required": ["modes"]
                 }
               }
             }
@@ -7284,10 +7002,7 @@
                     "type": "number"
                   }
                 },
-                "required": [
-                  "prefix",
-                  "suffix"
-                ]
+                "required": ["prefix", "suffix"]
               }
             }
           }
@@ -7350,10 +7065,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "actionText",
-                          "actionURL"
-                        ]
+                        "required": ["actionText", "actionURL"]
                       },
                       "showIn": {
                         "type": "array",
@@ -7365,11 +7077,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "id",
-                      "title",
-                      "message"
-                    ]
+                    "required": ["id", "title", "message"]
                   }
                 }
               }
@@ -7512,9 +7220,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "sessionId"
-                ]
+                "required": ["sessionId"]
               }
             }
           }
@@ -7560,14 +7266,7 @@
                       "anyOf": [
                         {
                           "type": "string",
-                          "enum": [
-                            "provisioned",
-                            "starting",
-                            "restarting",
-                            "running",
-                            "stopped",
-                            "destroying"
-                          ]
+                          "enum": ["provisioned", "starting", "restarting", "running", "stopped", "destroying"]
                         },
                         {
                           "type": "null"
@@ -7590,10 +7289,7 @@
                           "type": "number"
                         }
                       },
-                      "required": [
-                        "cpus",
-                        "memory_mb"
-                      ]
+                      "required": ["cpus", "memory_mb"]
                     },
                     "openclawVersion": {
                       "anyOf": [
@@ -7635,9 +7331,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "status"
-                  ]
+                  "required": ["status"]
                 }
               }
             }
@@ -7695,12 +7389,7 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "apiKey",
-                        "userId",
-                        "userToken",
-                        "channelId"
-                      ]
+                      "required": ["apiKey", "userId", "userToken", "channelId"]
                     },
                     {
                       "type": "null"
@@ -7797,13 +7486,7 @@
                             "type": "number"
                           }
                         },
-                        "required": [
-                          "session_id",
-                          "title",
-                          "created_at",
-                          "updated_at",
-                          "version"
-                        ]
+                        "required": ["session_id", "title", "created_at", "updated_at", "version"]
                       }
                     },
                     "nextCursor": {
@@ -7817,10 +7500,7 @@
                       ]
                     }
                   },
-                  "required": [
-                    "cliSessions",
-                    "nextCursor"
-                  ]
+                  "required": ["cliSessions", "nextCursor"]
                 }
               }
             }
@@ -7890,9 +7570,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "text"
-                        ]
+                        "required": ["text"]
                       },
                       "lines": {
                         "type": "object",
@@ -7901,9 +7579,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "text"
-                        ]
+                        "required": ["text"]
                       },
                       "line_number": {
                         "type": "number"
@@ -7923,9 +7599,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "text"
-                              ]
+                              "required": ["text"]
                             },
                             "start": {
                               "type": "number"
@@ -7934,21 +7608,11 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "match",
-                            "start",
-                            "end"
-                          ]
+                          "required": ["match", "start", "end"]
                         }
                       }
                     },
-                    "required": [
-                      "path",
-                      "lines",
-                      "line_number",
-                      "absolute_offset",
-                      "submatches"
-                    ]
+                    "required": ["path", "lines", "line_number", "absolute_offset", "submatches"]
                   }
                 }
               }
@@ -7994,10 +7658,7 @@
             "name": "dirs",
             "schema": {
               "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
+              "enum": ["true", "false"]
             }
           },
           {
@@ -8005,10 +7666,7 @@
             "name": "type",
             "schema": {
               "type": "string",
-              "enum": [
-                "file",
-                "directory"
-              ]
+              "enum": ["file", "directory"]
             }
           },
           {
@@ -8357,10 +8015,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "name",
-                  "config"
-                ]
+                "required": ["name", "config"]
               }
             }
           }
@@ -8415,9 +8070,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "authorizationUrl"
-                  ]
+                  "required": ["authorizationUrl"]
                 }
               }
             }
@@ -8491,9 +8144,7 @@
                       "const": true
                     }
                   },
-                  "required": [
-                    "success"
-                  ]
+                  "required": ["success"]
                 }
               }
             }
@@ -8589,9 +8240,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "code"
-                ]
+                "required": ["code"]
               }
             }
           }
@@ -8822,9 +8471,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "text"
-                ]
+                "required": ["text"]
               }
             }
           }
@@ -9136,9 +8783,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "command"
-                ]
+                "required": ["command"]
               }
             }
           }
@@ -9198,12 +8843,7 @@
                   },
                   "variant": {
                     "type": "string",
-                    "enum": [
-                      "info",
-                      "success",
-                      "warning",
-                      "error"
-                    ]
+                    "enum": ["info", "success", "warning", "error"]
                   },
                   "duration": {
                     "description": "Duration in milliseconds",
@@ -9211,10 +8851,7 @@
                     "type": "number"
                   }
                 },
-                "required": [
-                  "message",
-                  "variant"
-                ]
+                "required": ["message", "variant"]
               }
             }
           }
@@ -9365,9 +9002,7 @@
                     "pattern": "^ses"
                   }
                 },
-                "required": [
-                  "sessionID"
-                ]
+                "required": ["sessionID"]
               }
             }
           }
@@ -9414,10 +9049,7 @@
                     },
                     "body": {}
                   },
-                  "required": [
-                    "path",
-                    "body"
-                  ]
+                  "required": ["path", "body"]
                 }
               }
             }
@@ -9702,12 +9334,7 @@
                   "level": {
                     "description": "Log level",
                     "type": "string",
-                    "enum": [
-                      "debug",
-                      "info",
-                      "error",
-                      "warn"
-                    ]
+                    "enum": ["debug", "info", "error", "warn"]
                   },
                   "message": {
                     "description": "Log message",
@@ -9722,11 +9349,7 @@
                     "additionalProperties": {}
                   }
                 },
-                "required": [
-                  "service",
-                  "level",
-                  "message"
-                ]
+                "required": ["service", "level", "message"]
               }
             }
           }
@@ -9827,12 +9450,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "name",
-                      "description",
-                      "location",
-                      "content"
-                    ]
+                    "required": ["name", "description", "location", "content"]
                   }
                 }
               }
@@ -9993,15 +9611,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "version"
-            ]
+            "required": ["version"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.installation.update-available": {
         "type": "object",
@@ -10017,15 +9630,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "version"
-            ]
+            "required": ["version"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Project": {
         "type": "object",
@@ -10079,10 +9687,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "created",
-              "updated"
-            ]
+            "required": ["created", "updated"]
           },
           "sandboxes": {
             "type": "array",
@@ -10091,12 +9696,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "worktree",
-          "time",
-          "sandboxes"
-        ]
+        "required": ["id", "worktree", "time", "sandboxes"]
       },
       "Event.project.updated": {
         "type": "object",
@@ -10109,10 +9709,7 @@
             "$ref": "#/components/schemas/Project"
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.server.instance.disposed": {
         "type": "object",
@@ -10128,15 +9725,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "directory"
-            ]
+            "required": ["directory"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.server.connected": {
         "type": "object",
@@ -10150,10 +9742,7 @@
             "properties": {}
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.global.disposed": {
         "type": "object",
@@ -10167,10 +9756,7 @@
             "properties": {}
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.global.config.updated": {
         "type": "object",
@@ -10184,10 +9770,7 @@
             "properties": {}
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.lsp.client.diagnostics": {
         "type": "object",
@@ -10206,16 +9789,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "serverID",
-              "path"
-            ]
+            "required": ["serverID", "path"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.lsp.updated": {
         "type": "object",
@@ -10229,10 +9806,7 @@
             "properties": {}
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.file.edited": {
         "type": "object",
@@ -10248,15 +9822,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "file"
-            ]
+            "required": ["file"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "OutputFormatText": {
         "type": "object",
@@ -10266,9 +9835,7 @@
             "const": "text"
           }
         },
-        "required": [
-          "type"
-        ]
+        "required": ["type"]
       },
       "JSONSchema": {
         "type": "object",
@@ -10294,10 +9861,7 @@
             "maximum": 9007199254740991
           }
         },
-        "required": [
-          "type",
-          "schema"
-        ]
+        "required": ["type", "schema"]
       },
       "OutputFormat": {
         "anyOf": [
@@ -10329,20 +9893,10 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "added",
-              "deleted",
-              "modified"
-            ]
+            "enum": ["added", "deleted", "modified"]
           }
         },
-        "required": [
-          "file",
-          "before",
-          "after",
-          "additions",
-          "deletions"
-        ]
+        "required": ["file", "before", "after", "additions", "deletions"]
       },
       "UserMessage": {
         "type": "object",
@@ -10364,9 +9918,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "created"
-            ]
+            "required": ["created"]
           },
           "format": {
             "$ref": "#/components/schemas/OutputFormat"
@@ -10387,9 +9939,7 @@
                 }
               }
             },
-            "required": [
-              "diffs"
-            ]
+            "required": ["diffs"]
           },
           "agent": {
             "type": "string"
@@ -10404,10 +9954,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "providerID",
-              "modelID"
-            ]
+            "required": ["providerID", "modelID"]
           },
           "system": {
             "type": "string"
@@ -10448,14 +9995,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "role",
-          "time",
-          "agent",
-          "model"
-        ]
+        "required": ["id", "sessionID", "role", "time", "agent", "model"]
       },
       "ProviderAuthError": {
         "type": "object",
@@ -10474,16 +10014,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "providerID",
-              "message"
-            ]
+            "required": ["providerID", "message"]
           }
         },
-        "required": [
-          "name",
-          "data"
-        ]
+        "required": ["name", "data"]
       },
       "UnknownError": {
         "type": "object",
@@ -10499,15 +10033,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "message"
-            ]
+            "required": ["message"]
           }
         },
-        "required": [
-          "name",
-          "data"
-        ]
+        "required": ["name", "data"]
       },
       "MessageOutputLengthError": {
         "type": "object",
@@ -10521,10 +10050,7 @@
             "properties": {}
           }
         },
-        "required": [
-          "name",
-          "data"
-        ]
+        "required": ["name", "data"]
       },
       "MessageAbortedError": {
         "type": "object",
@@ -10540,15 +10066,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "message"
-            ]
+            "required": ["message"]
           }
         },
-        "required": [
-          "name",
-          "data"
-        ]
+        "required": ["name", "data"]
       },
       "StructuredOutputError": {
         "type": "object",
@@ -10567,16 +10088,10 @@
                 "type": "number"
               }
             },
-            "required": [
-              "message",
-              "retries"
-            ]
+            "required": ["message", "retries"]
           }
         },
-        "required": [
-          "name",
-          "data"
-        ]
+        "required": ["name", "data"]
       },
       "ContextOverflowError": {
         "type": "object",
@@ -10595,15 +10110,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "message"
-            ]
+            "required": ["message"]
           }
         },
-        "required": [
-          "name",
-          "data"
-        ]
+        "required": ["name", "data"]
       },
       "APIError": {
         "type": "object",
@@ -10646,16 +10156,10 @@
                 }
               }
             },
-            "required": [
-              "message",
-              "isRetryable"
-            ]
+            "required": ["message", "isRetryable"]
           }
         },
-        "required": [
-          "name",
-          "data"
-        ]
+        "required": ["name", "data"]
       },
       "AssistantMessage": {
         "type": "object",
@@ -10680,9 +10184,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "created"
-            ]
+            "required": ["created"]
           },
           "error": {
             "anyOf": [
@@ -10734,10 +10236,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "cwd",
-              "root"
-            ]
+            "required": ["cwd", "root"]
           },
           "summary": {
             "type": "boolean"
@@ -10770,18 +10269,10 @@
                     "type": "number"
                   }
                 },
-                "required": [
-                  "read",
-                  "write"
-                ]
+                "required": ["read", "write"]
               }
             },
-            "required": [
-              "input",
-              "output",
-              "reasoning",
-              "cache"
-            ]
+            "required": ["input", "output", "reasoning", "cache"]
           },
           "structured": {},
           "variant": {
@@ -10830,15 +10321,10 @@
                 "$ref": "#/components/schemas/Message"
               }
             },
-            "required": [
-              "info"
-            ]
+            "required": ["info"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.message.removed": {
         "type": "object",
@@ -10857,16 +10343,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "sessionID",
-              "messageID"
-            ]
+            "required": ["sessionID", "messageID"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "TextPart": {
         "type": "object",
@@ -10903,9 +10383,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "start"
-            ]
+            "required": ["start"]
           },
           "metadata": {
             "type": "object",
@@ -10915,13 +10393,7 @@
             "additionalProperties": {}
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "messageID",
-          "type",
-          "text"
-        ]
+        "required": ["id", "sessionID", "messageID", "type", "text"]
       },
       "SubtaskPart": {
         "type": "object",
@@ -10958,24 +10430,13 @@
                 "type": "string"
               }
             },
-            "required": [
-              "providerID",
-              "modelID"
-            ]
+            "required": ["providerID", "modelID"]
           },
           "command": {
             "type": "string"
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "messageID",
-          "type",
-          "prompt",
-          "description",
-          "agent"
-        ]
+        "required": ["id", "sessionID", "messageID", "type", "prompt", "description", "agent"]
       },
       "ReasoningPart": {
         "type": "object",
@@ -11013,19 +10474,10 @@
                 "type": "number"
               }
             },
-            "required": [
-              "start"
-            ]
+            "required": ["start"]
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "messageID",
-          "type",
-          "text",
-          "time"
-        ]
+        "required": ["id", "sessionID", "messageID", "type", "text", "time"]
       },
       "FilePartSourceText": {
         "type": "object",
@@ -11044,11 +10496,7 @@
             "maximum": 9007199254740991
           }
         },
-        "required": [
-          "value",
-          "start",
-          "end"
-        ]
+        "required": ["value", "start", "end"]
       },
       "FileSource": {
         "type": "object",
@@ -11064,11 +10512,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "text",
-          "type",
-          "path"
-        ]
+        "required": ["text", "type", "path"]
       },
       "Range": {
         "type": "object",
@@ -11083,10 +10527,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "line",
-              "character"
-            ]
+            "required": ["line", "character"]
           },
           "end": {
             "type": "object",
@@ -11098,16 +10539,10 @@
                 "type": "number"
               }
             },
-            "required": [
-              "line",
-              "character"
-            ]
+            "required": ["line", "character"]
           }
         },
-        "required": [
-          "start",
-          "end"
-        ]
+        "required": ["start", "end"]
       },
       "SymbolSource": {
         "type": "object",
@@ -11134,14 +10569,7 @@
             "maximum": 9007199254740991
           }
         },
-        "required": [
-          "text",
-          "type",
-          "path",
-          "range",
-          "name",
-          "kind"
-        ]
+        "required": ["text", "type", "path", "range", "name", "kind"]
       },
       "ResourceSource": {
         "type": "object",
@@ -11160,12 +10588,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "text",
-          "type",
-          "clientName",
-          "uri"
-        ]
+        "required": ["text", "type", "clientName", "uri"]
       },
       "FilePartSource": {
         "anyOf": [
@@ -11209,14 +10632,7 @@
             "$ref": "#/components/schemas/FilePartSource"
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "messageID",
-          "type",
-          "mime",
-          "url"
-        ]
+        "required": ["id", "sessionID", "messageID", "type", "mime", "url"]
       },
       "ToolStatePending": {
         "type": "object",
@@ -11236,11 +10652,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "status",
-          "input",
-          "raw"
-        ]
+        "required": ["status", "input", "raw"]
       },
       "ToolStateRunning": {
         "type": "object",
@@ -11273,16 +10685,10 @@
                 "type": "number"
               }
             },
-            "required": [
-              "start"
-            ]
+            "required": ["start"]
           }
         },
-        "required": [
-          "status",
-          "input",
-          "time"
-        ]
+        "required": ["status", "input", "time"]
       },
       "ToolStateCompleted": {
         "type": "object",
@@ -11324,10 +10730,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "start",
-              "end"
-            ]
+            "required": ["start", "end"]
           },
           "attachments": {
             "type": "array",
@@ -11336,14 +10739,7 @@
             }
           }
         },
-        "required": [
-          "status",
-          "input",
-          "output",
-          "title",
-          "metadata",
-          "time"
-        ]
+        "required": ["status", "input", "output", "title", "metadata", "time"]
       },
       "ToolStateError": {
         "type": "object",
@@ -11379,18 +10775,10 @@
                 "type": "number"
               }
             },
-            "required": [
-              "start",
-              "end"
-            ]
+            "required": ["start", "end"]
           }
         },
-        "required": [
-          "status",
-          "input",
-          "error",
-          "time"
-        ]
+        "required": ["status", "input", "error", "time"]
       },
       "ToolState": {
         "anyOf": [
@@ -11441,15 +10829,7 @@
             "additionalProperties": {}
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "messageID",
-          "type",
-          "callID",
-          "tool",
-          "state"
-        ]
+        "required": ["id", "sessionID", "messageID", "type", "callID", "tool", "state"]
       },
       "StepStartPart": {
         "type": "object",
@@ -11471,12 +10851,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "messageID",
-          "type"
-        ]
+        "required": ["id", "sessionID", "messageID", "type"]
       },
       "StepFinishPart": {
         "type": "object",
@@ -11528,29 +10903,13 @@
                     "type": "number"
                   }
                 },
-                "required": [
-                  "read",
-                  "write"
-                ]
+                "required": ["read", "write"]
               }
             },
-            "required": [
-              "input",
-              "output",
-              "reasoning",
-              "cache"
-            ]
+            "required": ["input", "output", "reasoning", "cache"]
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "messageID",
-          "type",
-          "reason",
-          "cost",
-          "tokens"
-        ]
+        "required": ["id", "sessionID", "messageID", "type", "reason", "cost", "tokens"]
       },
       "SnapshotPart": {
         "type": "object",
@@ -11572,13 +10931,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "messageID",
-          "type",
-          "snapshot"
-        ]
+        "required": ["id", "sessionID", "messageID", "type", "snapshot"]
       },
       "PatchPart": {
         "type": "object",
@@ -11606,14 +10959,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "messageID",
-          "type",
-          "hash",
-          "files"
-        ]
+        "required": ["id", "sessionID", "messageID", "type", "hash", "files"]
       },
       "AgentPart": {
         "type": "object",
@@ -11651,20 +10997,10 @@
                 "maximum": 9007199254740991
               }
             },
-            "required": [
-              "value",
-              "start",
-              "end"
-            ]
+            "required": ["value", "start", "end"]
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "messageID",
-          "type",
-          "name"
-        ]
+        "required": ["id", "sessionID", "messageID", "type", "name"]
       },
       "RetryPart": {
         "type": "object",
@@ -11695,20 +11031,10 @@
                 "type": "number"
               }
             },
-            "required": [
-              "created"
-            ]
+            "required": ["created"]
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "messageID",
-          "type",
-          "attempt",
-          "error",
-          "time"
-        ]
+        "required": ["id", "sessionID", "messageID", "type", "attempt", "error", "time"]
       },
       "CompactionPart": {
         "type": "object",
@@ -11733,13 +11059,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "messageID",
-          "type",
-          "auto"
-        ]
+        "required": ["id", "sessionID", "messageID", "type", "auto"]
       },
       "Part": {
         "anyOf": [
@@ -11795,15 +11115,10 @@
                 "$ref": "#/components/schemas/Part"
               }
             },
-            "required": [
-              "part"
-            ]
+            "required": ["part"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.message.part.delta": {
         "type": "object",
@@ -11831,19 +11146,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "sessionID",
-              "messageID",
-              "partID",
-              "field",
-              "delta"
-            ]
+            "required": ["sessionID", "messageID", "partID", "field", "delta"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.message.part.removed": {
         "type": "object",
@@ -11865,17 +11171,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "sessionID",
-              "messageID",
-              "partID"
-            ]
+            "required": ["sessionID", "messageID", "partID"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "PermissionRequest": {
         "type": "object",
@@ -11920,20 +11219,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "messageID",
-              "callID"
-            ]
+            "required": ["messageID", "callID"]
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "permission",
-          "patterns",
-          "metadata",
-          "always"
-        ]
+        "required": ["id", "sessionID", "permission", "patterns", "metadata", "always"]
       },
       "Event.permission.asked": {
         "type": "object",
@@ -11946,10 +11235,7 @@
             "$ref": "#/components/schemas/PermissionRequest"
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.permission.replied": {
         "type": "object",
@@ -11969,24 +11255,13 @@
               },
               "reply": {
                 "type": "string",
-                "enum": [
-                  "once",
-                  "always",
-                  "reject"
-                ]
+                "enum": ["once", "always", "reject"]
               }
             },
-            "required": [
-              "sessionID",
-              "requestID",
-              "reply"
-            ]
+            "required": ["sessionID", "requestID", "reply"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "SessionStatus": {
         "anyOf": [
@@ -11998,9 +11273,7 @@
                 "const": "idle"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           {
             "type": "object",
@@ -12017,14 +11290,12 @@
               },
               "next": {
                 "type": "number"
+              },
+              "details": {
+                "type": "string"
               }
             },
-            "required": [
-              "type",
-              "attempt",
-              "message",
-              "next"
-            ]
+            "required": ["type", "attempt", "message", "next"]
           },
           {
             "type": "object",
@@ -12034,9 +11305,7 @@
                 "const": "busy"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           }
         ]
       },
@@ -12057,16 +11326,10 @@
                 "$ref": "#/components/schemas/SessionStatus"
               }
             },
-            "required": [
-              "sessionID",
-              "status"
-            ]
+            "required": ["sessionID", "status"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.session.idle": {
         "type": "object",
@@ -12082,15 +11345,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "sessionID"
-            ]
+            "required": ["sessionID"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "QuestionOption": {
         "type": "object",
@@ -12108,10 +11366,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "label",
-          "description"
-        ]
+        "required": ["label", "description"]
       },
       "QuestionInfo": {
         "type": "object",
@@ -12140,11 +11395,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "question",
-          "header",
-          "options"
-        ]
+        "required": ["question", "header", "options"]
       },
       "QuestionRequest": {
         "type": "object",
@@ -12174,17 +11425,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "messageID",
-              "callID"
-            ]
+            "required": ["messageID", "callID"]
           }
         },
-        "required": [
-          "id",
-          "sessionID",
-          "questions"
-        ]
+        "required": ["id", "sessionID", "questions"]
       },
       "Event.question.asked": {
         "type": "object",
@@ -12197,10 +11441,7 @@
             "$ref": "#/components/schemas/QuestionRequest"
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "QuestionAnswer": {
         "type": "array",
@@ -12231,17 +11472,10 @@
                 }
               }
             },
-            "required": [
-              "sessionID",
-              "requestID",
-              "answers"
-            ]
+            "required": ["sessionID", "requestID", "answers"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.question.rejected": {
         "type": "object",
@@ -12260,16 +11494,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "sessionID",
-              "requestID"
-            ]
+            "required": ["sessionID", "requestID"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.session.compacted": {
         "type": "object",
@@ -12285,15 +11513,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "sessionID"
-            ]
+            "required": ["sessionID"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.file.watcher.updated": {
         "type": "object",
@@ -12325,16 +11548,10 @@
                 ]
               }
             },
-            "required": [
-              "file",
-              "event"
-            ]
+            "required": ["file", "event"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Todo": {
         "type": "object",
@@ -12352,11 +11569,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "content",
-          "status",
-          "priority"
-        ]
+        "required": ["content", "status", "priority"]
       },
       "Event.todo.updated": {
         "type": "object",
@@ -12378,16 +11591,10 @@
                 }
               }
             },
-            "required": [
-              "sessionID",
-              "todos"
-            ]
+            "required": ["sessionID", "todos"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.tui.prompt.append": {
         "type": "object",
@@ -12403,15 +11610,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "text"
-            ]
+            "required": ["text"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.tui.command.execute": {
         "type": "object",
@@ -12452,15 +11654,10 @@
                 ]
               }
             },
-            "required": [
-              "command"
-            ]
+            "required": ["command"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.tui.toast.show": {
         "type": "object",
@@ -12480,12 +11677,7 @@
               },
               "variant": {
                 "type": "string",
-                "enum": [
-                  "info",
-                  "success",
-                  "warning",
-                  "error"
-                ]
+                "enum": ["info", "success", "warning", "error"]
               },
               "duration": {
                 "description": "Duration in milliseconds",
@@ -12493,16 +11685,10 @@
                 "type": "number"
               }
             },
-            "required": [
-              "message",
-              "variant"
-            ]
+            "required": ["message", "variant"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.tui.session.select": {
         "type": "object",
@@ -12520,15 +11706,10 @@
                 "pattern": "^ses"
               }
             },
-            "required": [
-              "sessionID"
-            ]
+            "required": ["sessionID"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.mcp.tools.changed": {
         "type": "object",
@@ -12544,15 +11725,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "server"
-            ]
+            "required": ["server"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.mcp.browser.open.failed": {
         "type": "object",
@@ -12571,16 +11747,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "mcpName",
-              "url"
-            ]
+            "required": ["mcpName", "url"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.command.executed": {
         "type": "object",
@@ -12607,26 +11777,14 @@
                 "pattern": "^msg.*"
               }
             },
-            "required": [
-              "name",
-              "sessionID",
-              "arguments",
-              "messageID"
-            ]
+            "required": ["name", "sessionID", "arguments", "messageID"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "PermissionAction": {
         "type": "string",
-        "enum": [
-          "allow",
-          "deny",
-          "ask"
-        ]
+        "enum": ["allow", "deny", "ask"]
       },
       "PermissionRule": {
         "type": "object",
@@ -12641,11 +11799,7 @@
             "$ref": "#/components/schemas/PermissionAction"
           }
         },
-        "required": [
-          "permission",
-          "pattern",
-          "action"
-        ]
+        "required": ["permission", "pattern", "action"]
       },
       "PermissionRuleset": {
         "type": "array",
@@ -12704,26 +11858,14 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "added",
-                        "deleted",
-                        "modified"
-                      ]
+                      "enum": ["added", "deleted", "modified"]
                     }
                   },
-                  "required": [
-                    "file",
-                    "additions",
-                    "deletions"
-                  ]
+                  "required": ["file", "additions", "deletions"]
                 }
               }
             },
-            "required": [
-              "additions",
-              "deletions",
-              "files"
-            ]
+            "required": ["additions", "deletions", "files"]
           },
           "share": {
             "type": "object",
@@ -12732,9 +11874,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "url"
-            ]
+            "required": ["url"]
           },
           "title": {
             "type": "string"
@@ -12758,10 +11898,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "created",
-              "updated"
-            ]
+            "required": ["created", "updated"]
           },
           "permission": {
             "$ref": "#/components/schemas/PermissionRuleset"
@@ -12782,20 +11919,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "messageID"
-            ]
+            "required": ["messageID"]
           }
         },
-        "required": [
-          "id",
-          "slug",
-          "projectID",
-          "directory",
-          "title",
-          "version",
-          "time"
-        ]
+        "required": ["id", "slug", "projectID", "directory", "title", "version", "time"]
       },
       "Event.session.created": {
         "type": "object",
@@ -12811,15 +11938,10 @@
                 "$ref": "#/components/schemas/Session"
               }
             },
-            "required": [
-              "info"
-            ]
+            "required": ["info"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.session.updated": {
         "type": "object",
@@ -12835,15 +11957,10 @@
                 "$ref": "#/components/schemas/Session"
               }
             },
-            "required": [
-              "info"
-            ]
+            "required": ["info"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.session.deleted": {
         "type": "object",
@@ -12859,15 +11976,10 @@
                 "$ref": "#/components/schemas/Session"
               }
             },
-            "required": [
-              "info"
-            ]
+            "required": ["info"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.session.diff": {
         "type": "object",
@@ -12889,16 +12001,10 @@
                 }
               }
             },
-            "required": [
-              "sessionID",
-              "diff"
-            ]
+            "required": ["sessionID", "diff"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.session.error": {
         "type": "object",
@@ -12941,10 +12047,7 @@
             }
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.session.turn.open": {
         "type": "object",
@@ -12960,15 +12063,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "sessionID"
-            ]
+            "required": ["sessionID"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.session.turn.close": {
         "type": "object",
@@ -12985,23 +12083,13 @@
               },
               "reason": {
                 "type": "string",
-                "enum": [
-                  "completed",
-                  "error",
-                  "interrupted"
-                ]
+                "enum": ["completed", "error", "interrupted"]
               }
             },
-            "required": [
-              "sessionID",
-              "reason"
-            ]
+            "required": ["sessionID", "reason"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.vcs.branch.updated": {
         "type": "object",
@@ -13019,10 +12107,7 @@
             }
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.workspace.ready": {
         "type": "object",
@@ -13038,15 +12123,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "name"
-            ]
+            "required": ["name"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.workspace.failed": {
         "type": "object",
@@ -13062,15 +12142,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "message"
-            ]
+            "required": ["message"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Pty": {
         "type": "object",
@@ -13096,24 +12171,13 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "running",
-              "exited"
-            ]
+            "enum": ["running", "exited"]
           },
           "pid": {
             "type": "number"
           }
         },
-        "required": [
-          "id",
-          "title",
-          "command",
-          "args",
-          "cwd",
-          "status",
-          "pid"
-        ]
+        "required": ["id", "title", "command", "args", "cwd", "status", "pid"]
       },
       "Event.pty.created": {
         "type": "object",
@@ -13129,15 +12193,10 @@
                 "$ref": "#/components/schemas/Pty"
               }
             },
-            "required": [
-              "info"
-            ]
+            "required": ["info"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.pty.updated": {
         "type": "object",
@@ -13153,15 +12212,10 @@
                 "$ref": "#/components/schemas/Pty"
               }
             },
-            "required": [
-              "info"
-            ]
+            "required": ["info"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.pty.exited": {
         "type": "object",
@@ -13181,16 +12235,10 @@
                 "type": "number"
               }
             },
-            "required": [
-              "id",
-              "exitCode"
-            ]
+            "required": ["id", "exitCode"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.pty.deleted": {
         "type": "object",
@@ -13207,15 +12255,10 @@
                 "pattern": "^pty.*"
               }
             },
-            "required": [
-              "id"
-            ]
+            "required": ["id"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.worktree.ready": {
         "type": "object",
@@ -13234,16 +12277,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "name",
-              "branch"
-            ]
+            "required": ["name", "branch"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event.worktree.failed": {
         "type": "object",
@@ -13259,15 +12296,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "message"
-            ]
+            "required": ["message"]
           }
         },
-        "required": [
-          "type",
-          "properties"
-        ]
+        "required": ["type", "properties"]
       },
       "Event": {
         "anyOf": [
@@ -13427,20 +12459,12 @@
             "$ref": "#/components/schemas/Event"
           }
         },
-        "required": [
-          "directory",
-          "payload"
-        ]
+        "required": ["directory", "payload"]
       },
       "LogLevel": {
         "description": "Log level",
         "type": "string",
-        "enum": [
-          "DEBUG",
-          "INFO",
-          "WARN",
-          "ERROR"
-        ]
+        "enum": ["DEBUG", "INFO", "WARN", "ERROR"]
       },
       "ServerConfig": {
         "description": "Server configuration for kilo serve and web commands",
@@ -13478,11 +12502,7 @@
         "anyOf": [
           {
             "type": "string",
-            "enum": [
-              "ask",
-              "allow",
-              "deny"
-            ]
+            "enum": ["ask", "allow", "deny"]
           },
           {
             "type": "null"
@@ -13625,11 +12645,7 @@
           },
           "mode": {
             "type": "string",
-            "enum": [
-              "subagent",
-              "primary",
-              "all"
-            ]
+            "enum": ["subagent", "primary", "all"]
           },
           "hidden": {
             "description": "Hide this subagent from the @ autocomplete menu (default: false, only applies to mode: subagent)",
@@ -13651,15 +12667,7 @@
               },
               {
                 "type": "string",
-                "enum": [
-                  "primary",
-                  "secondary",
-                  "accent",
-                  "success",
-                  "warning",
-                  "error",
-                  "info"
-                ]
+                "enum": ["primary", "secondary", "accent", "success", "warning", "error", "info"]
               }
             ]
           },
@@ -13745,15 +12753,10 @@
                       "properties": {
                         "field": {
                           "type": "string",
-                          "enum": [
-                            "reasoning_content",
-                            "reasoning_details"
-                          ]
+                          "enum": ["reasoning_content", "reasoning_details"]
                         }
                       },
-                      "required": [
-                        "field"
-                      ],
+                      "required": ["field"],
                       "additionalProperties": false
                     }
                   ]
@@ -13789,16 +12792,10 @@
                           "type": "number"
                         }
                       },
-                      "required": [
-                        "input",
-                        "output"
-                      ]
+                      "required": ["input", "output"]
                     }
                   },
-                  "required": [
-                    "input",
-                    "output"
-                  ]
+                  "required": ["input", "output"]
                 },
                 "limit": {
                   "type": "object",
@@ -13813,10 +12810,7 @@
                       "type": "number"
                     }
                   },
-                  "required": [
-                    "context",
-                    "output"
-                  ]
+                  "required": ["context", "output"]
                 },
                 "modalities": {
                   "type": "object",
@@ -13825,70 +12819,39 @@
                       "type": "array",
                       "items": {
                         "type": "string",
-                        "enum": [
-                          "text",
-                          "audio",
-                          "image",
-                          "video",
-                          "pdf"
-                        ]
+                        "enum": ["text", "audio", "image", "video", "pdf"]
                       }
                     },
                     "output": {
                       "type": "array",
                       "items": {
                         "type": "string",
-                        "enum": [
-                          "text",
-                          "audio",
-                          "image",
-                          "video",
-                          "pdf"
-                        ]
+                        "enum": ["text", "audio", "image", "video", "pdf"]
                       }
                     }
                   },
-                  "required": [
-                    "input",
-                    "output"
-                  ]
+                  "required": ["input", "output"]
                 },
                 "recommendedIndex": {
                   "type": "number"
                 },
                 "prompt": {
                   "type": "string",
-                  "enum": [
-                    "codex",
-                    "gemini",
-                    "beast",
-                    "anthropic",
-                    "trinity",
-                    "anthropic_without_todo"
-                  ]
+                  "enum": ["codex", "gemini", "beast", "anthropic", "trinity", "anthropic_without_todo"]
                 },
                 "isFree": {
                   "type": "boolean"
                 },
                 "ai_sdk_provider": {
                   "type": "string",
-                  "enum": [
-                    "anthropic",
-                    "openai",
-                    "openai-compatible",
-                    "openrouter"
-                  ]
+                  "enum": ["anthropic", "openai", "openai-compatible", "openrouter"]
                 },
                 "experimental": {
                   "type": "boolean"
                 },
                 "status": {
                   "type": "string",
-                  "enum": [
-                    "alpha",
-                    "beta",
-                    "deprecated"
-                  ]
+                  "enum": ["alpha", "beta", "deprecated"]
                 },
                 "options": {
                   "type": "object",
@@ -14024,10 +12987,7 @@
             "maximum": 9007199254740991
           }
         },
-        "required": [
-          "type",
-          "command"
-        ],
+        "required": ["type", "command"],
         "additionalProperties": false
       },
       "McpOAuthConfig": {
@@ -14093,19 +13053,13 @@
             "maximum": 9007199254740991
           }
         },
-        "required": [
-          "type",
-          "url"
-        ],
+        "required": ["type", "url"],
         "additionalProperties": false
       },
       "LayoutConfig": {
         "description": "@deprecated Always uses stretch layout.",
         "type": "string",
-        "enum": [
-          "auto",
-          "stretch"
-        ]
+        "enum": ["auto", "stretch"]
       },
       "Config": {
         "type": "object",
@@ -14145,9 +13099,7 @@
                   "type": "boolean"
                 }
               },
-              "required": [
-                "template"
-              ]
+              "required": ["template"]
             }
           },
           "skills": {
@@ -14193,11 +13145,7 @@
           "share": {
             "description": "Control sharing behavior:'manual' allows manual sharing via commands, 'auto' enables automatic sharing, 'disabled' disables all sharing",
             "type": "string",
-            "enum": [
-              "manual",
-              "auto",
-              "disabled"
-            ]
+            "enum": ["manual", "auto", "disabled"]
           },
           "autoshare": {
             "description": "@deprecated Use 'share' field instead. Share newly created sessions automatically",
@@ -14352,9 +13300,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "enabled"
-                  ],
+                  "required": ["enabled"],
                   "additionalProperties": false
                 }
               ]
@@ -14424,9 +13370,7 @@
                           "const": true
                         }
                       },
-                      "required": [
-                        "disabled"
-                      ]
+                      "required": ["disabled"]
                     },
                     {
                       "type": "object",
@@ -14463,9 +13407,7 @@
                           "additionalProperties": {}
                         }
                       },
-                      "required": [
-                        "command"
-                      ]
+                      "required": ["command"]
                     }
                   ]
                 }
@@ -14582,11 +13524,7 @@
             "const": false
           }
         },
-        "required": [
-          "data",
-          "errors",
-          "success"
-        ]
+        "required": ["data", "errors", "success"]
       },
       "OAuth": {
         "type": "object",
@@ -14611,12 +13549,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "refresh",
-          "access",
-          "expires"
-        ]
+        "required": ["type", "refresh", "access", "expires"]
       },
       "ApiAuth": {
         "type": "object",
@@ -14629,10 +13562,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "key"
-        ]
+        "required": ["type", "key"]
       },
       "WellKnownAuth": {
         "type": "object",
@@ -14648,11 +13578,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "key",
-          "token"
-        ]
+        "required": ["type", "key", "token"]
       },
       "Auth": {
         "anyOf": [
@@ -14681,15 +13607,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "message"
-            ]
+            "required": ["message"]
           }
         },
-        "required": [
-          "name",
-          "data"
-        ]
+        "required": ["name", "data"]
       },
       "Model": {
         "type": "object",
@@ -14713,11 +13634,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "id",
-              "url",
-              "npm"
-            ]
+            "required": ["id", "url", "npm"]
           },
           "name": {
             "type": "string"
@@ -14759,13 +13676,7 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "text",
-                  "audio",
-                  "image",
-                  "video",
-                  "pdf"
-                ]
+                "required": ["text", "audio", "image", "video", "pdf"]
               },
               "output": {
                 "type": "object",
@@ -14786,13 +13697,7 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "text",
-                  "audio",
-                  "image",
-                  "video",
-                  "pdf"
-                ]
+                "required": ["text", "audio", "image", "video", "pdf"]
               },
               "interleaved": {
                 "anyOf": [
@@ -14804,28 +13709,15 @@
                     "properties": {
                       "field": {
                         "type": "string",
-                        "enum": [
-                          "reasoning_content",
-                          "reasoning_details"
-                        ]
+                        "enum": ["reasoning_content", "reasoning_details"]
                       }
                     },
-                    "required": [
-                      "field"
-                    ]
+                    "required": ["field"]
                   }
                 ]
               }
             },
-            "required": [
-              "temperature",
-              "reasoning",
-              "attachment",
-              "toolcall",
-              "input",
-              "output",
-              "interleaved"
-            ]
+            "required": ["temperature", "reasoning", "attachment", "toolcall", "input", "output", "interleaved"]
           },
           "cost": {
             "type": "object",
@@ -14846,10 +13738,7 @@
                     "type": "number"
                   }
                 },
-                "required": [
-                  "read",
-                  "write"
-                ]
+                "required": ["read", "write"]
               },
               "experimentalOver200K": {
                 "type": "object",
@@ -14870,24 +13759,13 @@
                         "type": "number"
                       }
                     },
-                    "required": [
-                      "read",
-                      "write"
-                    ]
+                    "required": ["read", "write"]
                   }
                 },
-                "required": [
-                  "input",
-                  "output",
-                  "cache"
-                ]
+                "required": ["input", "output", "cache"]
               }
             },
-            "required": [
-              "input",
-              "output",
-              "cache"
-            ]
+            "required": ["input", "output", "cache"]
           },
           "limit": {
             "type": "object",
@@ -14902,19 +13780,11 @@
                 "type": "number"
               }
             },
-            "required": [
-              "context",
-              "output"
-            ]
+            "required": ["context", "output"]
           },
           "status": {
             "type": "string",
-            "enum": [
-              "alpha",
-              "beta",
-              "deprecated",
-              "active"
-            ]
+            "enum": ["alpha", "beta", "deprecated", "active"]
           },
           "options": {
             "type": "object",
@@ -14953,26 +13823,14 @@
           },
           "prompt": {
             "type": "string",
-            "enum": [
-              "codex",
-              "gemini",
-              "beast",
-              "anthropic",
-              "trinity",
-              "anthropic_without_todo"
-            ]
+            "enum": ["codex", "gemini", "beast", "anthropic", "trinity", "anthropic_without_todo"]
           },
           "isFree": {
             "type": "boolean"
           },
           "ai_sdk_provider": {
             "type": "string",
-            "enum": [
-              "anthropic",
-              "openai",
-              "openai-compatible",
-              "openrouter"
-            ]
+            "enum": ["anthropic", "openai", "openai-compatible", "openrouter"]
           }
         },
         "required": [
@@ -15000,12 +13858,7 @@
           },
           "source": {
             "type": "string",
-            "enum": [
-              "env",
-              "config",
-              "custom",
-              "api"
-            ]
+            "enum": ["env", "config", "custom", "api"]
           },
           "env": {
             "type": "array",
@@ -15033,14 +13886,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "name",
-          "source",
-          "env",
-          "options",
-          "models"
-        ]
+        "required": ["id", "name", "source", "env", "options", "models"]
       },
       "ToolIDs": {
         "type": "array",
@@ -15059,11 +13905,7 @@
           },
           "parameters": {}
         },
-        "required": [
-          "id",
-          "description",
-          "parameters"
-        ]
+        "required": ["id", "description", "parameters"]
       },
       "ToolList": {
         "type": "array",
@@ -15123,15 +13965,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "id",
-          "type",
-          "branch",
-          "name",
-          "directory",
-          "extra",
-          "projectID"
-        ]
+        "required": ["id", "type", "branch", "name", "directory", "extra", "projectID"]
       },
       "Worktree": {
         "type": "object",
@@ -15146,11 +13980,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "name",
-          "branch",
-          "directory"
-        ]
+        "required": ["name", "branch", "directory"]
       },
       "WorktreeCreateInput": {
         "type": "object",
@@ -15171,9 +14001,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "directory"
-        ]
+        "required": ["directory"]
       },
       "WorktreeResetInput": {
         "type": "object",
@@ -15182,9 +14010,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "directory"
-        ]
+        "required": ["directory"]
       },
       "WorktreeDiffItem": {
         "type": "object",
@@ -15206,11 +14032,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "added",
-              "deleted",
-              "modified"
-            ]
+            "enum": ["added", "deleted", "modified"]
           },
           "tracked": {
             "type": "boolean"
@@ -15250,10 +14072,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "id",
-          "worktree"
-        ]
+        "required": ["id", "worktree"]
       },
       "GlobalSession": {
         "type": "object",
@@ -15306,26 +14125,14 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "added",
-                        "deleted",
-                        "modified"
-                      ]
+                      "enum": ["added", "deleted", "modified"]
                     }
                   },
-                  "required": [
-                    "file",
-                    "additions",
-                    "deletions"
-                  ]
+                  "required": ["file", "additions", "deletions"]
                 }
               }
             },
-            "required": [
-              "additions",
-              "deletions",
-              "files"
-            ]
+            "required": ["additions", "deletions", "files"]
           },
           "share": {
             "type": "object",
@@ -15334,9 +14141,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "url"
-            ]
+            "required": ["url"]
           },
           "title": {
             "type": "string"
@@ -15360,10 +14165,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "created",
-              "updated"
-            ]
+            "required": ["created", "updated"]
           },
           "permission": {
             "$ref": "#/components/schemas/PermissionRuleset"
@@ -15384,9 +14186,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "messageID"
-            ]
+            "required": ["messageID"]
           },
           "project": {
             "anyOf": [
@@ -15399,16 +14199,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "slug",
-          "projectID",
-          "directory",
-          "title",
-          "version",
-          "time",
-          "project"
-        ]
+        "required": ["id", "slug", "projectID", "directory", "title", "version", "time", "project"]
       },
       "McpResource": {
         "type": "object",
@@ -15429,11 +14220,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "name",
-          "uri",
-          "client"
-        ]
+        "required": ["name", "uri", "client"]
       },
       "TextPartInput": {
         "type": "object",
@@ -15464,9 +14251,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "start"
-            ]
+            "required": ["start"]
           },
           "metadata": {
             "type": "object",
@@ -15476,10 +14261,7 @@
             "additionalProperties": {}
           }
         },
-        "required": [
-          "type",
-          "text"
-        ]
+        "required": ["type", "text"]
       },
       "FilePartInput": {
         "type": "object",
@@ -15504,11 +14286,7 @@
             "$ref": "#/components/schemas/FilePartSource"
           }
         },
-        "required": [
-          "type",
-          "mime",
-          "url"
-        ]
+        "required": ["type", "mime", "url"]
       },
       "AgentPartInput": {
         "type": "object",
@@ -15540,17 +14318,10 @@
                 "maximum": 9007199254740991
               }
             },
-            "required": [
-              "value",
-              "start",
-              "end"
-            ]
+            "required": ["value", "start", "end"]
           }
         },
-        "required": [
-          "type",
-          "name"
-        ]
+        "required": ["type", "name"]
       },
       "SubtaskPartInput": {
         "type": "object",
@@ -15581,21 +14352,13 @@
                 "type": "string"
               }
             },
-            "required": [
-              "providerID",
-              "modelID"
-            ]
+            "required": ["providerID", "modelID"]
           },
           "command": {
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "prompt",
-          "description",
-          "agent"
-        ]
+        "required": ["type", "prompt", "description", "agent"]
       },
       "ProviderAuthMethod": {
         "type": "object",
@@ -15616,10 +14379,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "label"
-        ]
+        "required": ["type", "label"]
       },
       "ProviderAuthAuthorization": {
         "type": "object",
@@ -15643,11 +14403,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "url",
-          "method",
-          "instructions"
-        ]
+        "required": ["url", "method", "instructions"]
       },
       "Symbol": {
         "type": "object",
@@ -15668,17 +14424,10 @@
                 "$ref": "#/components/schemas/Range"
               }
             },
-            "required": [
-              "uri",
-              "range"
-            ]
+            "required": ["uri", "range"]
           }
         },
-        "required": [
-          "name",
-          "kind",
-          "location"
-        ]
+        "required": ["name", "kind", "location"]
       },
       "FileNode": {
         "type": "object",
@@ -15694,32 +14443,20 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "file",
-              "directory"
-            ]
+            "enum": ["file", "directory"]
           },
           "ignored": {
             "type": "boolean"
           }
         },
-        "required": [
-          "name",
-          "path",
-          "absolute",
-          "type",
-          "ignored"
-        ]
+        "required": ["name", "path", "absolute", "type", "ignored"]
       },
       "FileContent": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "text",
-              "binary"
-            ]
+            "enum": ["text", "binary"]
           },
           "content": {
             "type": "string"
@@ -15766,24 +14503,14 @@
                       }
                     }
                   },
-                  "required": [
-                    "oldStart",
-                    "oldLines",
-                    "newStart",
-                    "newLines",
-                    "lines"
-                  ]
+                  "required": ["oldStart", "oldLines", "newStart", "newLines", "lines"]
                 }
               },
               "index": {
                 "type": "string"
               }
             },
-            "required": [
-              "oldFileName",
-              "newFileName",
-              "hunks"
-            ]
+            "required": ["oldFileName", "newFileName", "hunks"]
           },
           "encoding": {
             "type": "string",
@@ -15793,10 +14520,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "content"
-        ]
+        "required": ["type", "content"]
       },
       "File": {
         "type": "object",
@@ -15816,19 +14540,10 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "added",
-              "deleted",
-              "modified"
-            ]
+            "enum": ["added", "deleted", "modified"]
           }
         },
-        "required": [
-          "path",
-          "added",
-          "removed",
-          "status"
-        ]
+        "required": ["path", "added", "removed", "status"]
       },
       "MCPStatusConnected": {
         "type": "object",
@@ -15838,9 +14553,7 @@
             "const": "connected"
           }
         },
-        "required": [
-          "status"
-        ]
+        "required": ["status"]
       },
       "MCPStatusDisabled": {
         "type": "object",
@@ -15850,9 +14563,7 @@
             "const": "disabled"
           }
         },
-        "required": [
-          "status"
-        ]
+        "required": ["status"]
       },
       "MCPStatusFailed": {
         "type": "object",
@@ -15865,10 +14576,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "status",
-          "error"
-        ]
+        "required": ["status", "error"]
       },
       "MCPStatusNeedsAuth": {
         "type": "object",
@@ -15878,9 +14586,7 @@
             "const": "needs_auth"
           }
         },
-        "required": [
-          "status"
-        ]
+        "required": ["status"]
       },
       "MCPStatusNeedsClientRegistration": {
         "type": "object",
@@ -15893,10 +14599,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "status",
-          "error"
-        ]
+        "required": ["status", "error"]
       },
       "MCPStatus": {
         "anyOf": [
@@ -15936,13 +14639,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "home",
-          "state",
-          "config",
-          "worktree",
-          "directory"
-        ]
+        "required": ["home", "state", "config", "worktree", "directory"]
       },
       "VcsInfo": {
         "type": "object",
@@ -15951,9 +14648,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "branch"
-        ]
+        "required": ["branch"]
       },
       "Command": {
         "type": "object",
@@ -15972,11 +14667,7 @@
           },
           "source": {
             "type": "string",
-            "enum": [
-              "command",
-              "mcp",
-              "skill"
-            ]
+            "enum": ["command", "mcp", "skill"]
           },
           "template": {
             "anyOf": [
@@ -15998,11 +14689,7 @@
             }
           }
         },
-        "required": [
-          "name",
-          "template",
-          "hints"
-        ]
+        "required": ["name", "template", "hints"]
       },
       "Agent": {
         "type": "object",
@@ -16018,11 +14705,7 @@
           },
           "mode": {
             "type": "string",
-            "enum": [
-              "subagent",
-              "primary",
-              "all"
-            ]
+            "enum": ["subagent", "primary", "all"]
           },
           "native": {
             "type": "boolean"
@@ -16055,10 +14738,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "modelID",
-              "providerID"
-            ]
+            "required": ["modelID", "providerID"]
           },
           "variant": {
             "type": "string"
@@ -16079,12 +14759,7 @@
             "maximum": 9007199254740991
           }
         },
-        "required": [
-          "name",
-          "mode",
-          "permission",
-          "options"
-        ]
+        "required": ["name", "mode", "permission", "options"]
       },
       "LSPStatus": {
         "type": "object",
@@ -16111,12 +14786,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "name",
-          "root",
-          "status"
-        ]
+        "required": ["id", "name", "root", "status"]
       },
       "FormatterStatus": {
         "type": "object",
@@ -16134,11 +14804,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "name",
-          "extensions",
-          "enabled"
-        ]
+        "required": ["name", "extensions", "enabled"]
       }
     }
   }


### PR DESCRIPTION
## Context

This PR restores the retry/error visibility that older Kilo builds exposed in the VS Code sidebar. Provider retry states could surface useful metadata for debugging local LLMs and OpenAI-compatible backends, but the current sidebar experience truncates long retry text and does not give reviewers or users an easy way to inspect or copy the raw payload behind 429/retry responses.

## Implementation

- Add retry `details` to the session status payload in `packages/opencode`, regenerate the SDK types, and thread that field through the VS Code extension bridge into the webview session state.
- Update the VS Code working indicator so retry messages wrap cleanly, expose a copy action for the short retry message, and show expandable/copyable raw retry details when the provider returns them.
- Update the assistant error display to match that workflow with copy actions for the visible error message and the raw serialized error payload.
- Add focused regression coverage for the retry status transport and the working-indicator UI contract.

## Screenshots

| before | after |
| ------ | ----- |
| Retry/rate-limit text could stay cramped in a single row and the raw provider payload was not available from the sidebar. | Retry text wraps inline, the short message can be copied, and raw retry/provider details can be expanded and copied from the sidebar. |

## How to Test

- Trigger a retry or rate-limit response in the VS Code extension (for example with a local LLM or OpenAI-compatible provider that returns retry metadata).
- Confirm the working indicator wraps the retry text instead of truncating it on one line.
- Use the copy button beside the retry message and confirm it copies the short retry text.
- Expand **Show details** and confirm the raw retry payload is visible and can be copied.
- Trigger an assistant error card and confirm the message copy button and raw error copy button both work.
- Run `bun test tests/unit/working-indicator.test.ts tests/unit/session-status.test.ts`.
- Run `bun run compile`.
- Run `bun turbo typecheck`.

## Get in Touch

- GitHub: @Githubguy132010
