### PR TITLE
fix: restrict write and apply_patch permissions for plan mode

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -234,6 +234,18 @@ export namespace Agent {
             external_directory: {
               [path.join(Global.Path.data, "plans", "*")]: "allow",
             },
+            apply_patch: {
+              "*": "deny",
+              [path.join(".kilo", "plans", "*.md")]: "allow", // kilocode_change
+              [path.join(".opencode", "plans", "*.md")]: "allow", // kilocode_change: .opencode fallback
+              [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
+            },
+            write: {
+              "*": "deny",
+              [path.join(".kilo", "plans", "*.md")]: "allow", // kilocode_change
+              [path.join(".opencode", "plans", "*.md")]: "allow", // kilocode_change: .opencode fallback
+              [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
+            },
             edit: {
               "*": "deny",
               [path.join(".kilo", "plans", "*.md")]: "allow", // kilocode_change


### PR DESCRIPTION
## Context

This was discovered while debugging #8358. The permissions in `agent.ts` were restricting the directories where the Plan agent can use the Edit tool, but not the ApplyPatch and Write tools. This change also applies the restrictions to ApplyPatch and Write to ensure that Plan mode cannot edit outside of the plans directory.

## Get in Touch

ExpedientFalcon on Discord.