### PR TITLE
Session migration improvements

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -45,6 +45,7 @@ import {
   checkAndShowMigrationWizard,
   handleRequestLegacyMigrationData,
   handleStartLegacyMigration,
+  handleFinalizeLegacyMigration,
   handleSkipLegacyMigration,
   handleClearLegacyData,
   type MigrationContext,
@@ -893,6 +894,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         case "clearLegacyData":
           void handleClearLegacyData(this.migrationCtx)
+          break
+        case "finalizeLegacyMigration":
+          void handleFinalizeLegacyMigration(this.migrationCtx)
           break
         // legacy-migration end
         case "enhancePrompt": {

--- a/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
@@ -35,6 +35,7 @@ export interface MigrationContext {
   refreshSessions(): void
   cachedLegacyData: LegacyMigrationData | null
   migrationCheckInFlight: boolean
+  lastMigrationHadErrors?: boolean
   disposeGlobal(): Promise<void>
   broadcastComplete(): void
 }
@@ -133,8 +134,10 @@ export async function handleStartLegacyMigration(
       ctx.cachedLegacyData?.sessions,
     )
 
+    ctx.lastMigrationHadErrors = results.some((item) => item.status === "error")
     ctx.postMessage({ type: "legacyMigrationComplete", results })
   } catch (error) {
+    ctx.lastMigrationHadErrors = true
     console.error("[Kilo New] KiloProvider: ❌ Migration failed", error)
     ctx.postMessage({
       type: "legacyMigrationComplete",
@@ -155,7 +158,7 @@ export async function handleFinalizeLegacyMigration(ctx: MigrationContext): Prom
   await ctx.disposeGlobal()
   await MigrationService.setMigrationStatus(
     ctx.extensionContext as Parameters<typeof MigrationService.setMigrationStatus>[0],
-    "completed",
+    ctx.lastMigrationHadErrors ? "completed_with_errors" : "completed",
   )
   ctx.broadcastComplete()
   ctx.refreshSessions()

--- a/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
@@ -39,10 +39,6 @@ export interface MigrationContext {
   broadcastComplete(): void
 }
 
-interface MigrationFinalization {
-  results: Awaited<ReturnType<typeof MigrationService.migrate>>
-}
-
 function postSessionProgress(ctx: MigrationContext, progress: MigrationSessionProgress): void {
   ctx.postMessage({
     type: "legacyMigrationSessionProgress",

--- a/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
@@ -6,7 +6,11 @@
  */
 
 import type { KiloClient } from "@kilocode/sdk/v2/client"
-import type { LegacyMigrationData, MigrationSelections } from "../../legacy-migration/legacy-types"
+import type {
+  LegacyMigrationData,
+  MigrationSelections,
+  MigrationSessionProgress,
+} from "../../legacy-migration/legacy-types"
 import * as MigrationService from "../../legacy-migration/migration-service"
 
 /** Subset of vscode.ExtensionContext needed by migration handlers. */
@@ -33,6 +37,19 @@ export interface MigrationContext {
   migrationCheckInFlight: boolean
   disposeGlobal(): Promise<void>
   broadcastComplete(): void
+}
+
+function postSessionProgress(ctx: MigrationContext, progress: MigrationSessionProgress): void {
+  ctx.postMessage({
+    type: "legacyMigrationSessionProgress",
+    session: progress.session,
+    index: progress.index,
+    total: progress.total,
+    phase: progress.phase,
+    current: progress.current,
+    count: progress.count,
+    error: progress.error,
+  })
 }
 
 /**
@@ -111,7 +128,11 @@ export async function handleStartLegacyMigration(
       (item, status, message) => {
         ctx.postMessage({ type: "legacyMigrationProgress", item, status, message })
       },
+      (progress: MigrationSessionProgress) => {
+        postSessionProgress(ctx, progress)
+      },
       ctx.cachedLegacyData?.settings,
+      ctx.cachedLegacyData?.sessions,
     )
 
     const failed = results.some((r) => r.status === "error")

--- a/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
@@ -39,6 +39,10 @@ export interface MigrationContext {
   broadcastComplete(): void
 }
 
+interface MigrationFinalization {
+  results: Awaited<ReturnType<typeof MigrationService.migrate>>
+}
+
 function postSessionProgress(ctx: MigrationContext, progress: MigrationSessionProgress): void {
   ctx.postMessage({
     type: "legacyMigrationSessionProgress",
@@ -135,21 +139,6 @@ export async function handleStartLegacyMigration(
       ctx.cachedLegacyData?.sessions,
     )
 
-    const failed = results.some((r) => r.status === "error")
-    const success = results.some((r) => r.status === "success")
-
-    if (!failed && success) {
-      // Dispose all instances after a fully successful migration.
-      // Reloading the data will be handled once the server replies with a global.disposed event.
-      await ctx.disposeGlobal()
-      await MigrationService.setMigrationStatus(
-        ctx.extensionContext as Parameters<typeof MigrationService.setMigrationStatus>[0],
-        "completed",
-      )
-      ctx.broadcastComplete()
-      ctx.refreshSessions()
-    }
-
     ctx.postMessage({ type: "legacyMigrationComplete", results })
   } catch (error) {
     console.error("[Kilo New] KiloProvider: ❌ Migration failed", error)
@@ -165,6 +154,17 @@ export async function handleStartLegacyMigration(
       ],
     })
   }
+}
+
+export async function handleFinalizeLegacyMigration(ctx: MigrationContext): Promise<void> {
+  if (!ctx.extensionContext) return
+  await ctx.disposeGlobal()
+  await MigrationService.setMigrationStatus(
+    ctx.extensionContext as Parameters<typeof MigrationService.setMigrationStatus>[0],
+    "completed",
+  )
+  ctx.broadcastComplete()
+  ctx.refreshSessions()
 }
 
 /** Record that the user skipped migration and broadcast to all instances. */

--- a/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/migration.ts
@@ -50,8 +50,6 @@ function postSessionProgress(ctx: MigrationContext, progress: MigrationSessionPr
     index: progress.index,
     total: progress.total,
     phase: progress.phase,
-    current: progress.current,
-    count: progress.count,
     error: progress.error,
   })
 }

--- a/packages/kilo-vscode/src/legacy-migration/legacy-types.ts
+++ b/packages/kilo-vscode/src/legacy-migration/legacy-types.ts
@@ -351,7 +351,7 @@ export interface MigrationSelections {
   settings: MigrationSettingsSelections
 }
 
-export type MigrationSessionPhase = "project" | "session" | "messages" | "parts" | "skipped" | "done" | "summary" | "error"
+export type MigrationSessionPhase = "preparing" | "project" | "session" | "messages" | "parts" | "skipped" | "done" | "summary" | "error"
 
 export interface MigrationSessionProgress {
   session: MigrationSessionInfo

--- a/packages/kilo-vscode/src/legacy-migration/legacy-types.ts
+++ b/packages/kilo-vscode/src/legacy-migration/legacy-types.ts
@@ -345,3 +345,15 @@ export interface MigrationSelections {
   defaultModel: boolean
   settings: MigrationSettingsSelections
 }
+
+export type MigrationSessionPhase = "project" | "session" | "messages" | "parts" | "skipped" | "done" | "error"
+
+export interface MigrationSessionProgress {
+  session: MigrationSessionInfo
+  index: number
+  total: number
+  phase: MigrationSessionPhase
+  current?: number
+  count?: number
+  error?: string
+}

--- a/packages/kilo-vscode/src/legacy-migration/legacy-types.ts
+++ b/packages/kilo-vscode/src/legacy-migration/legacy-types.ts
@@ -346,7 +346,7 @@ export interface MigrationSelections {
   settings: MigrationSettingsSelections
 }
 
-export type MigrationSessionPhase = "project" | "session" | "messages" | "parts" | "skipped" | "done" | "error"
+export type MigrationSessionPhase = "project" | "session" | "messages" | "parts" | "skipped" | "done" | "summary" | "error"
 
 export interface MigrationSessionProgress {
   session: MigrationSessionInfo

--- a/packages/kilo-vscode/src/legacy-migration/legacy-types.ts
+++ b/packages/kilo-vscode/src/legacy-migration/legacy-types.ts
@@ -337,11 +337,16 @@ export interface MigrationSettingsSelections {
   autocomplete: boolean
 }
 
+export interface MigrationSessionSelection {
+  id: string
+  force?: boolean
+}
+
 export interface MigrationSelections {
   providers: string[]
   mcpServers: string[]
   customModes: string[]
-  sessions?: string[]
+  sessions?: MigrationSessionSelection[]
   defaultModel: boolean
   settings: MigrationSettingsSelections
 }

--- a/packages/kilo-vscode/src/legacy-migration/legacy-types.ts
+++ b/packages/kilo-vscode/src/legacy-migration/legacy-types.ts
@@ -351,14 +351,12 @@ export interface MigrationSelections {
   settings: MigrationSettingsSelections
 }
 
-export type MigrationSessionPhase = "preparing" | "project" | "session" | "messages" | "parts" | "skipped" | "done" | "summary" | "error"
+export type MigrationSessionPhase = "preparing" | "storing" | "skipped" | "done" | "summary" | "error"
 
 export interface MigrationSessionProgress {
   session: MigrationSessionInfo
   index: number
   total: number
   phase: MigrationSessionPhase
-  current?: number
-  count?: number
   error?: string
 }

--- a/packages/kilo-vscode/src/legacy-migration/legacy-types.ts
+++ b/packages/kilo-vscode/src/legacy-migration/legacy-types.ts
@@ -299,11 +299,18 @@ export interface MigrationCustomModeInfo {
   nativeSlug?: string
 }
 
+export interface MigrationSessionInfo {
+  id: string
+  title: string
+  directory: string
+  time: number
+}
+
 export interface LegacyMigrationData {
   providers: MigrationProviderInfo[]
   mcpServers: MigrationMcpServerInfo[]
   customModes: MigrationCustomModeInfo[]
-  sessions?: string[]
+  sessions?: MigrationSessionInfo[]
   defaultModel?: { provider: string; model: string }
   settings?: LegacySettings
   hasData: boolean

--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -117,7 +117,10 @@ export async function detectLegacyData(context: vscode.ExtensionContext): Promis
 }
 
 async function readSessionsInGlobalStorage(context: vscode.ExtensionContext) {
-  const items = context.globalState.get<{ id: string; task?: string; workspace?: string; ts?: number }[]>("taskHistory", [])
+  const items = context.globalState.get<{ id: string; task?: string; workspace?: string; ts?: number }[]>(
+    "taskHistory",
+    [],
+  )
   const base = vscode.Uri.joinPath(context.globalStorageUri, "tasks")
   const sessions: MigrationSessionInfo[] = []
   for (const item of items) {

--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -149,6 +149,8 @@ export type ProgressCallback = (
 
 export type SessionProgressCallback = (progress: MigrationSessionProgress) => void
 
+const SESSION_DELAY = 300
+
 /**
  * Executes migration for the selected items.
  * Calls onProgress for each item with real-time status updates.
@@ -287,6 +289,9 @@ export async function migrate(
         message: reason,
       })
       onProgress(id, result.ok ? "success" : "error", reason)
+      if (index < list.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, SESSION_DELAY))
+      }
     }
   }
 

--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -33,6 +33,7 @@ import type {
   MigrationProviderInfo,
   MigrationMcpServerInfo,
   MigrationCustomModeInfo,
+  MigrationSessionInfo,
 } from "./legacy-types"
 import type { MigrationResultItem } from "./migration-types"
 import { createSessionID } from "./sessions/lib/ids"
@@ -114,18 +115,24 @@ export async function detectLegacyData(context: vscode.ExtensionContext): Promis
 }
 
 async function readSessionsInGlobalStorage(context: vscode.ExtensionContext) {
-  const items = context.globalState.get<{ id: string }[]>("taskHistory", [])
+  const items = context.globalState.get<{ id: string; task?: string; workspace?: string; ts?: number }[]>("taskHistory", [])
   const base = vscode.Uri.joinPath(context.globalStorageUri, "tasks")
-  const ids: string[] = []
+  const sessions: MigrationSessionInfo[] = []
   for (const item of items) {
     const file = vscode.Uri.joinPath(base, item.id, "api_conversation_history.json")
     const exists = await vscode.workspace.fs.stat(file).then(
       () => true,
       () => false,
     )
-    if (exists) ids.push(item.id)
+    if (!exists) continue
+    sessions.push({
+      id: item.id,
+      title: item.task?.trim() || item.id,
+      directory: item.workspace?.trim() || "",
+      time: item.ts ?? 0,
+    })
   }
-  return ids
+  return sessions
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -276,26 +276,26 @@ export async function migrate(
   if (selections.sessions?.length) {
     const info = cachedSessions ?? sessions
     const list = selections.sessions
-    for (const [index, id] of list.entries()) {
-      onProgress(id, "migrating")
-      const session = info.find((item: MigrationSessionInfo) => item.id === id)
+    for (const [index, item] of list.entries()) {
+      onProgress(item.id, "migrating")
+      const session = info.find((entry: MigrationSessionInfo) => entry.id === item.id)
       const meta = buildSessionMeta(session, index, list.length)
       const progress = buildSessionProgress(meta, onSessionProgress)
-      const result = await migrateSession(id, context, client, meta, progress)
+      const result = await migrateSession(item, context, client, meta, progress)
       const reason = result.ok ? "Session migrated" : result.message
       results.push({
-        item: id,
+        item: item.id,
         category: "session",
         status: result.ok ? "success" : "error",
         message: reason,
       })
-      onProgress(id, result.ok ? "success" : "error", reason)
+      onProgress(item.id, result.ok ? "success" : "error", reason)
       if (index < list.length - 1) {
         await new Promise((resolve) => setTimeout(resolve, SESSION_DELAY))
       }
     }
     const last = list.at(-1)
-    const session = last ? info.find((item: MigrationSessionInfo) => item.id === last) : undefined
+    const session = last ? info.find((item: MigrationSessionInfo) => item.id === last.id) : undefined
     if (session && onSessionProgress) {
       onSessionProgress({
         session,

--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -34,6 +34,7 @@ import type {
   MigrationMcpServerInfo,
   MigrationCustomModeInfo,
   MigrationSessionInfo,
+  MigrationSessionProgress,
 } from "./legacy-types"
 import type { MigrationResultItem } from "./migration-types"
 import { createSessionID } from "./sessions/lib/ids"
@@ -145,6 +146,8 @@ export type ProgressCallback = (
   message?: string,
 ) => void
 
+export type SessionProgressCallback = (progress: MigrationSessionProgress) => void
+
 /**
  * Executes migration for the selected items.
  * Calls onProgress for each item with real-time status updates.
@@ -157,13 +160,16 @@ export async function migrate(
   client: KiloClient,
   selections: MigrationSelections,
   onProgress: ProgressCallback,
+  onSessionProgress?: SessionProgressCallback,
   cachedSettings?: LegacySettings,
+  cachedSessions?: MigrationSessionInfo[],
 ): Promise<MigrationResultItem[]> {
   const profiles = await readLegacyProviderProfiles(context)
   const mcpSettings = await readLegacyMcpSettings(context)
   const customModes = await readLegacyCustomModes(context)
   const prompts = readLegacyCustomModePrompts(context)
   const legacySettings = cachedSettings ?? readLegacySettings(context)
+  const sessions = cachedSessions ?? (await readSessionsInGlobalStorage(context))
 
   const results: MigrationResultItem[] = []
 
@@ -264,8 +270,18 @@ export async function migrate(
   }
 
   if (selections.sessions?.length) {
+    const info = cachedSessions ?? sessions
     for (const id of selections.sessions) {
       onProgress(id, "migrating")
+      const session = info.find((item: MigrationSessionInfo) => item.id === id)
+      if (session && onSessionProgress) {
+        onSessionProgress({
+          session,
+          index: results.filter((item) => item.category === "session").length + 1,
+          total: selections.sessions.length,
+          phase: "session",
+        })
+      }
       const result = await migrateSession(id, context, client)
       const reason = result.ok ? "Session migrated" : result.message
       results.push({

--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -150,6 +150,7 @@ export type ProgressCallback = (
 export type SessionProgressCallback = (progress: MigrationSessionProgress) => void
 
 const SESSION_DELAY = 300
+const SESSION_SUMMARY_DELAY = 1000
 
 /**
  * Executes migration for the selected items.
@@ -292,6 +293,17 @@ export async function migrate(
       if (index < list.length - 1) {
         await new Promise((resolve) => setTimeout(resolve, SESSION_DELAY))
       }
+    }
+    const last = list.at(-1)
+    const session = last ? info.find((item: MigrationSessionInfo) => item.id === last) : undefined
+    if (session && onSessionProgress) {
+      onSessionProgress({
+        session,
+        index: list.length,
+        total: list.length,
+        phase: "summary",
+      })
+      await new Promise((resolve) => setTimeout(resolve, SESSION_SUMMARY_DELAY))
     }
   }
 

--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -274,11 +274,10 @@ export async function migrate(
   }
 
   if (selections.sessions?.length) {
-    const info = cachedSessions ?? sessions
     const list = selections.sessions
     for (const [index, item] of list.entries()) {
       onProgress(item.id, "migrating")
-      const session = info.find((entry: MigrationSessionInfo) => entry.id === item.id)
+      const session = sessions.find((entry: MigrationSessionInfo) => entry.id === item.id)
       const meta = buildSessionMeta(session, index, list.length)
       const progress = buildSessionProgress(meta, onSessionProgress)
       const result = await migrateSession(item, context, client, meta, progress)
@@ -295,7 +294,7 @@ export async function migrate(
       }
     }
     const last = list.at(-1)
-    const session = last ? info.find((item: MigrationSessionInfo) => item.id === last.id) : undefined
+    const session = last ? sessions.find((item: MigrationSessionInfo) => item.id === last.id) : undefined
     if (session && onSessionProgress) {
       onSessionProgress({
         session,

--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -36,6 +36,7 @@ import type {
   MigrationSessionInfo,
   MigrationSessionProgress,
 } from "./legacy-types"
+import { buildSessionMeta, buildSessionProgress } from "./migration-session-progress"
 import type { MigrationResultItem } from "./migration-types"
 import { createSessionID } from "./sessions/lib/ids"
 import { migrate as migrateSession } from "./sessions/migrate"
@@ -271,18 +272,13 @@ export async function migrate(
 
   if (selections.sessions?.length) {
     const info = cachedSessions ?? sessions
-    for (const id of selections.sessions) {
+    const list = selections.sessions
+    for (const [index, id] of list.entries()) {
       onProgress(id, "migrating")
       const session = info.find((item: MigrationSessionInfo) => item.id === id)
-      if (session && onSessionProgress) {
-        onSessionProgress({
-          session,
-          index: results.filter((item) => item.category === "session").length + 1,
-          total: selections.sessions.length,
-          phase: "session",
-        })
-      }
-      const result = await migrateSession(id, context, client)
+      const meta = buildSessionMeta(session, index, list.length)
+      const progress = buildSessionProgress(meta, onSessionProgress)
+      const result = await migrateSession(id, context, client, meta, progress)
       const reason = result.ok ? "Session migrated" : result.message
       results.push({
         item: id,

--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -49,7 +49,7 @@ const SECRET_KEY = "roo_cline_config_api_config"
 const CODEX_OAUTH_SECRET_KEY = "openai-codex-oauth-credentials"
 const MIGRATION_STATUS_KEY = "kilo.legacyMigrationStatus"
 
-type MigrationStatus = "completed" | "skipped"
+type MigrationStatus = "completed" | "completed_with_errors" | "skipped"
 
 // ---------------------------------------------------------------------------
 // Status helpers

--- a/packages/kilo-vscode/src/legacy-migration/migration-session-progress.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-session-progress.ts
@@ -28,8 +28,6 @@ export function buildSessionProgress(meta: MigrationSessionMeta | undefined, onP
       index: meta.index,
       total: meta.total,
       phase: progress.phase,
-      current: progress.current,
-      count: progress.count,
       error: progress.error,
     })
   }

--- a/packages/kilo-vscode/src/legacy-migration/migration-session-progress.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-session-progress.ts
@@ -1,0 +1,36 @@
+import type { MigrationSessionInfo, MigrationSessionProgress } from "./legacy-types"
+import type { SessionProgressCallback } from "./migration-service"
+
+export interface MigrationSessionMeta {
+  session: MigrationSessionInfo
+  index: number
+  total: number
+}
+
+export function buildSessionMeta(
+  session: MigrationSessionInfo | undefined,
+  index: number,
+  total: number,
+): MigrationSessionMeta | undefined {
+  if (!session) return undefined
+  return {
+    session,
+    index: index + 1,
+    total,
+  }
+}
+
+export function buildSessionProgress(meta: MigrationSessionMeta | undefined, onProgress: SessionProgressCallback | undefined) {
+  if (!meta || !onProgress) return undefined
+  return (progress: Omit<MigrationSessionProgress, "session" | "index" | "total">) => {
+    onProgress({
+      session: meta.session,
+      index: meta.index,
+      total: meta.total,
+      phase: progress.phase,
+      current: progress.current,
+      count: progress.count,
+      error: progress.error,
+    })
+  }
+}

--- a/packages/kilo-vscode/src/legacy-migration/migration-session-progress.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-session-progress.ts
@@ -20,7 +20,10 @@ export function buildSessionMeta(
   }
 }
 
-export function buildSessionProgress(meta: MigrationSessionMeta | undefined, onProgress: SessionProgressCallback | undefined) {
+export function buildSessionProgress(
+  meta: MigrationSessionMeta | undefined,
+  onProgress: SessionProgressCallback | undefined,
+) {
   if (!meta || !onProgress) return undefined
   return (progress: Omit<MigrationSessionProgress, "session" | "index" | "total">) => {
     onProgress({

--- a/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 import { getMigrationErrorMessage } from "../errors/migration-error"
+import type { MigrationSessionInfo, MigrationSessionProgress } from "../legacy-types"
 import type { LegacyHistoryItem } from "./lib/legacy-types"
 import { parseSession } from "./parser"
 
@@ -16,15 +17,39 @@ type Result =
       message: string
     }
 
-export async function migrate(id: string, context: vscode.ExtensionContext, client: KiloClient): Promise<Result> {
+type Progress = Omit<MigrationSessionProgress, "session" | "index" | "total">
+type ProgressCallback = (progress: Progress) => void
+
+function trimError(input: string) {
+  return input.length <= 100 ? input : `${input.slice(0, 100)}...`
+}
+
+export async function migrate(
+  id: string,
+  context: vscode.ExtensionContext,
+  client: KiloClient,
+  meta?: {
+    session: MigrationSessionInfo
+    index: number
+    total: number
+  },
+  onProgress?: ProgressCallback,
+): Promise<Result> {
   const dir = vscode.Uri.joinPath(context.globalStorageUri, "tasks").fsPath
   const items = context.globalState.get<LegacyHistoryItem[]>("taskHistory", [])
   const item = items.find((item) => item.id === id)
   const payload = await parseSession(id, dir, item)
 
+  const progress = (next: Progress) => {
+    if (!meta || !onProgress) return
+    onProgress(next)
+  }
+
   try {
+    progress({ phase: "project" })
     const project = await client.kilocode.sessionImport.project(payload.project, { throwOnError: true })
     const projectID = project.data?.id ?? payload.project.id
+    progress({ phase: "session" })
     const session = await client.kilocode.sessionImport.session(
       {
         ...payload.session,
@@ -36,6 +61,7 @@ export async function migrate(id: string, context: vscode.ExtensionContext, clie
     )
     // Skip child imports when the session already exists so rerunning migration only imports missing sessions.
     if (session.data?.skipped) {
+      progress({ phase: "skipped" })
       return {
         ok: true,
         skipped: true,
@@ -43,19 +69,29 @@ export async function migrate(id: string, context: vscode.ExtensionContext, clie
       }
     }
 
-    for (const msg of payload.messages) {
+    progress({ phase: "messages", current: 0, count: payload.messages.length })
+    for (const [index, msg] of payload.messages.entries()) {
       await client.kilocode.sessionImport.message(msg, { throwOnError: true })
+      progress({ phase: "messages", current: index + 1, count: payload.messages.length })
     }
 
-    for (const part of payload.parts) {
+    progress({ phase: "parts", current: 0, count: payload.parts.length })
+    for (const [index, part] of payload.parts.entries()) {
       await client.kilocode.sessionImport.part(part, { throwOnError: true })
+      progress({ phase: "parts", current: index + 1, count: payload.parts.length })
     }
+
+    progress({ phase: "done" })
 
     return {
       ok: true,
       payload,
     }
   } catch (error) {
+    progress({
+      phase: "error",
+      error: trimError(getMigrationErrorMessage(error)),
+    })
     return {
       ok: false,
       payload,

--- a/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
@@ -14,7 +14,7 @@ type Result =
     }
   | {
       ok: false
-      payload: Awaited<ReturnType<typeof parseSession>>
+      payload?: Awaited<ReturnType<typeof parseSession>>
       message: string
     }
 
@@ -46,7 +46,7 @@ export async function migrate(
     onProgress(next)
   }
 
-  const skip = async () => {
+  const skip = () => {
     progress({ phase: "skipped" })
     return {
       ok: true as const,
@@ -54,14 +54,14 @@ export async function migrate(
     }
   }
 
-  const fail = (error: unknown, payload: Payload) => {
+  const fail = (error: unknown, payload?: Payload) => {
     progress({
       phase: "error",
       error: trimError(getMigrationErrorMessage(error)),
     })
     return {
       ok: false as const,
-      payload,
+      ...(payload ? { payload } : {}),
       message: getMigrationErrorMessage(error),
     }
   }
@@ -112,7 +112,6 @@ export async function migrate(
       payload,
     }
   } catch (error) {
-    const payload = await parseSession(input.id, dir, item)
-    return fail(error, payload)
+    return fail(error)
   }
 }

--- a/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
@@ -19,6 +19,7 @@ type Result =
 
 type Progress = Omit<MigrationSessionProgress, "session" | "index" | "total">
 type ProgressCallback = (progress: Progress) => void
+type Payload = Awaited<ReturnType<typeof parseSession>>
 
 function trimError(input: string) {
   return input.length <= 100 ? input : `${input.slice(0, 100)}...`
@@ -38,14 +39,27 @@ export async function migrate(
   const dir = vscode.Uri.joinPath(context.globalStorageUri, "tasks").fsPath
   const items = context.globalState.get<LegacyHistoryItem[]>("taskHistory", [])
   const item = items.find((item) => item.id === input.id)
-  const payload = await parseSession(input.id, dir, item)
 
   const progress = (next: Progress) => {
     if (!meta || !onProgress) return
     onProgress(next)
   }
 
+  const fail = (error: unknown, payload: Payload) => {
+    progress({
+      phase: "error",
+      error: trimError(getMigrationErrorMessage(error)),
+    })
+    return {
+      ok: false as const,
+      payload,
+      message: getMigrationErrorMessage(error),
+    }
+  }
+
   try {
+    progress({ phase: "preparing" })
+    const payload = await parseSession(input.id, dir, item)
     progress({ phase: "project" })
     const project = await client.kilocode.sessionImport.project(payload.project, { throwOnError: true })
     const projectID = project.data?.id ?? payload.project.id
@@ -89,14 +103,7 @@ export async function migrate(
       payload,
     }
   } catch (error) {
-    progress({
-      phase: "error",
-      error: trimError(getMigrationErrorMessage(error)),
-    })
-    return {
-      ok: false,
-      payload,
-      message: getMigrationErrorMessage(error),
-    }
+    const payload = await parseSession(input.id, dir, item)
+    return fail(error, payload)
   }
 }

--- a/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode"
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 import { getMigrationErrorMessage } from "../errors/migration-error"
 import type { MigrationSessionInfo, MigrationSessionProgress, MigrationSessionSelection } from "../legacy-types"
+import { createSessionID } from "./lib/ids"
 import type { LegacyHistoryItem } from "./lib/legacy-types"
 import { parseSession } from "./parser"
 
@@ -9,7 +10,7 @@ type Result =
   | {
       ok: true
       skipped?: boolean
-      payload: Awaited<ReturnType<typeof parseSession>>
+      payload?: Awaited<ReturnType<typeof parseSession>>
     }
   | {
       ok: false
@@ -45,6 +46,14 @@ export async function migrate(
     onProgress(next)
   }
 
+  const skip = async () => {
+    progress({ phase: "skipped" })
+    return {
+      ok: true as const,
+      skipped: true,
+    }
+  }
+
   const fail = (error: unknown, payload: Payload) => {
     progress({
       phase: "error",
@@ -58,6 +67,11 @@ export async function migrate(
   }
 
   try {
+    if (!input.force) {
+      const result = await client.session.get({ sessionID: createSessionID(input.id) })
+      if (result.data) return skip()
+    }
+
     progress({ phase: "preparing" })
     const payload = await parseSession(input.id, dir, item)
     progress({ phase: "storing" })

--- a/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode"
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 import { getMigrationErrorMessage } from "../errors/migration-error"
-import type { MigrationSessionInfo, MigrationSessionProgress } from "../legacy-types"
+import type { MigrationSessionInfo, MigrationSessionProgress, MigrationSessionSelection } from "../legacy-types"
 import type { LegacyHistoryItem } from "./lib/legacy-types"
 import { parseSession } from "./parser"
 
@@ -25,7 +25,7 @@ function trimError(input: string) {
 }
 
 export async function migrate(
-  id: string,
+  input: MigrationSessionSelection,
   context: vscode.ExtensionContext,
   client: KiloClient,
   meta?: {
@@ -37,8 +37,8 @@ export async function migrate(
 ): Promise<Result> {
   const dir = vscode.Uri.joinPath(context.globalStorageUri, "tasks").fsPath
   const items = context.globalState.get<LegacyHistoryItem[]>("taskHistory", [])
-  const item = items.find((item) => item.id === id)
-  const payload = await parseSession(id, dir, item)
+  const item = items.find((item) => item.id === input.id)
+  const payload = await parseSession(input.id, dir, item)
 
   const progress = (next: Progress) => {
     if (!meta || !onProgress) return
@@ -56,6 +56,7 @@ export async function migrate(
         projectID,
         query_directory: payload.session.directory,
         body_directory: payload.session.directory,
+        ...(input.force ? { force: true } : {}),
       },
       { throwOnError: true },
     )

--- a/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
+++ b/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
@@ -60,10 +60,9 @@ export async function migrate(
   try {
     progress({ phase: "preparing" })
     const payload = await parseSession(input.id, dir, item)
-    progress({ phase: "project" })
+    progress({ phase: "storing" })
     const project = await client.kilocode.sessionImport.project(payload.project, { throwOnError: true })
     const projectID = project.data?.id ?? payload.project.id
-    progress({ phase: "session" })
     const session = await client.kilocode.sessionImport.session(
       {
         ...payload.session,
@@ -84,16 +83,12 @@ export async function migrate(
       }
     }
 
-    progress({ phase: "messages", current: 0, count: payload.messages.length })
-    for (const [index, msg] of payload.messages.entries()) {
+    for (const msg of payload.messages) {
       await client.kilocode.sessionImport.message(msg, { throwOnError: true })
-      progress({ phase: "messages", current: index + 1, count: payload.messages.length })
     }
 
-    progress({ phase: "parts", current: 0, count: payload.parts.length })
-    for (const [index, part] of payload.parts.entries()) {
+    for (const part of payload.parts) {
       await client.kilocode.sessionImport.part(part, { throwOnError: true })
-      progress({ phase: "parts", current: index + 1, count: payload.parts.length })
     }
 
     progress({ phase: "done" })

--- a/packages/kilo-vscode/tests/unit/legacy-migration/migrate.test.ts
+++ b/packages/kilo-vscode/tests/unit/legacy-migration/migrate.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test"
+import { createSessionID } from "../../../src/legacy-migration/sessions/lib/ids"
 
 const parseSession = mock(async () => ({
   project: {
@@ -43,8 +44,12 @@ function ctx() {
 
 function client() {
   const calls: Array<{ name: string; body: unknown }> = []
+  const get = mock(async () => ({ data: null as { id: string } | null }))
   return {
     calls,
+    session: {
+      get,
+    },
     kilocode: {
       sessionImport: {
         project: async (body: unknown) => {
@@ -73,9 +78,57 @@ describe("legacy migration migrate", () => {
     parseSession.mockClear()
   })
 
+  it("skips before parsing when the migrated session already exists and force is false", async () => {
+    const api = {
+      session: {
+        get: async (body: unknown) => {
+          expect(body).toEqual({ sessionID: createSessionID("legacy-task-1") })
+          return { data: { id: createSessionID("legacy-task-1") } }
+        },
+      },
+      kilocode: {
+        sessionImport: {
+          project: async () => {
+            throw new Error("should not import project")
+          },
+          session: async () => {
+            throw new Error("should not import session")
+          },
+          message: async () => {
+            throw new Error("should not import message")
+          },
+          part: async () => {
+            throw new Error("should not import part")
+          },
+        },
+      },
+    }
+
+    const result = await migrate({ id: "legacy-task-1" }, ctx() as never, api as never)
+
+    expect(result.ok).toBe(true)
+    expect(result).toHaveProperty("skipped", true)
+    expect(parseSession).not.toHaveBeenCalled()
+  })
+
+  it("continues with import when force is true even if the migrated session already exists", async () => {
+    const api = client()
+    api.session.get.mockImplementation(async () => ({ data: { id: createSessionID("legacy-task-1") } }))
+
+    await migrate({ id: "legacy-task-1", force: true }, ctx() as never, api as never)
+
+    expect(parseSession).toHaveBeenCalledTimes(1)
+    const call = api.calls.find((item) => item.name === "session")
+    expect(call).toBeDefined()
+    expect((call?.body as { force?: boolean }).force).toBe(true)
+  })
+
   it("inserts project then session then message then part in the correct order", async () => {
     const calls: string[] = []
     const api = {
+      session: {
+        get: async () => ({ data: null }),
+      },
       kilocode: {
         sessionImport: {
           project: async () => {
@@ -144,7 +197,7 @@ describe("legacy migration migrate", () => {
       ] as never,
     })
 
-    await migrate("legacy-task-1", ctx() as never, api as never)
+    await migrate({ id: "legacy-task-1" }, ctx() as never, api as never)
 
     expect(calls).toEqual(["project", "session", "message", "part"])
   })
@@ -152,7 +205,7 @@ describe("legacy migration migrate", () => {
   it("uses the projectID returned by backend when inserting the session", async () => {
     const api = client()
 
-    await migrate("legacy-task-1", ctx() as never, api as never)
+    await migrate({ id: "legacy-task-1" }, ctx() as never, api as never)
 
     const call = api.calls.find((x) => x.name === "session")
     expect(call).toBeDefined()
@@ -161,6 +214,9 @@ describe("legacy migration migrate", () => {
 
   it("returns ok false without throwing when one backend insert fails", async () => {
     const api = {
+      session: {
+        get: async () => ({ data: null }),
+      },
       kilocode: {
         sessionImport: {
           project: async () => ({ data: { id: "project-real" } }),
@@ -173,7 +229,7 @@ describe("legacy migration migrate", () => {
       },
     }
 
-    const result = await migrate("legacy-task-1", ctx() as never, api as never)
+    const result = await migrate({ id: "legacy-task-1" }, ctx() as never, api as never)
 
     expect(result.ok).toBe(false)
   })
@@ -181,6 +237,9 @@ describe("legacy migration migrate", () => {
   it("skips message and part imports when backend reports the session already exists", async () => {
     const calls: string[] = []
     const api = {
+      session: {
+        get: async () => ({ data: null }),
+      },
       kilocode: {
         sessionImport: {
           project: async () => {
@@ -203,7 +262,7 @@ describe("legacy migration migrate", () => {
       },
     }
 
-    const result = await migrate("legacy-task-1", ctx() as never, api as never)
+    const result = await migrate({ id: "legacy-task-1" }, ctx() as never, api as never)
 
     expect(result.ok).toBe(true)
     expect(result).toHaveProperty("skipped", true)

--- a/packages/kilo-vscode/tests/unit/legacy-migration/session-summary-state.test.ts
+++ b/packages/kilo-vscode/tests/unit/legacy-migration/session-summary-state.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test"
-import { createSessionItem, createSessionSummary, updateSessionSummary } from "../../../webview-ui/src/components/migration/session-migration-summary-state"
+import {
+  createSessionItem,
+  createSessionSummary,
+  updateSessionSummary,
+} from "../../../webview-ui/src/components/migration/session-migration-summary-state"
 
 const session = createSessionItem({
   id: "legacy-1",

--- a/packages/kilo-vscode/tests/unit/legacy-migration/session-summary-state.test.ts
+++ b/packages/kilo-vscode/tests/unit/legacy-migration/session-summary-state.test.ts
@@ -18,14 +18,12 @@ describe("session migration summary state", () => {
     expect(done.imported).toEqual([session])
   })
 
-  it("moves a session into errored and keeps lastError in sync", () => {
+  it("moves a session into errored and removes it from the other buckets", () => {
     const done = updateSessionSummary(createSessionSummary(), session, "done")
     const next = updateSessionSummary(done, { ...session, error: "Boom\nstack" }, "error")
 
     expect(next.imported).toHaveLength(0)
     expect(next.skipped).toHaveLength(0)
     expect(next.errored).toEqual([{ ...session, error: "Boom\nstack" }])
-    expect(next.lastError).toBe("Boom")
-    expect(next.lastErrorRaw).toBe("Boom\nstack")
   })
 })

--- a/packages/kilo-vscode/tests/unit/legacy-migration/session-summary-state.test.ts
+++ b/packages/kilo-vscode/tests/unit/legacy-migration/session-summary-state.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test"
+import { createSessionItem, createSessionSummary, updateSessionSummary } from "../../../webview-ui/src/components/migration/session-migration-summary-state"
+
+const session = createSessionItem({
+  id: "legacy-1",
+  title: "Legacy task",
+  directory: "/workspace/testing",
+  time: 1,
+})
+
+describe("session migration summary state", () => {
+  it("moves a session from skipped to imported when a force rerun finishes successfully", () => {
+    const skipped = updateSessionSummary(createSessionSummary(), session, "skipped")
+    const done = updateSessionSummary(skipped, session, "done")
+
+    expect(done.skipped).toHaveLength(0)
+    expect(done.errored).toHaveLength(0)
+    expect(done.imported).toEqual([session])
+  })
+
+  it("moves a session into errored and keeps lastError in sync", () => {
+    const done = updateSessionSummary(createSessionSummary(), session, "done")
+    const next = updateSessionSummary(done, { ...session, error: "Boom\nstack" }, "error")
+
+    expect(next.imported).toHaveLength(0)
+    expect(next.skipped).toHaveLength(0)
+    expect(next.errored).toEqual([{ ...session, error: "Boom\nstack" }])
+    expect(next.lastError).toBe("Boom")
+    expect(next.lastErrorRaw).toBe("Boom\nstack")
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/migration/ForceReimportDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/ForceReimportDialog.tsx
@@ -1,0 +1,41 @@
+import type { Component } from "solid-js"
+import { Dialog } from "@kilocode/kilo-ui/dialog"
+import { Button } from "@kilocode/kilo-ui/button"
+import { useDialog } from "@kilocode/kilo-ui/context/dialog"
+
+interface ForceReimportDialogProps {
+  count: number
+  onConfirm: () => void
+}
+
+const ForceReimportDialog: Component<ForceReimportDialogProps> = (props) => {
+  const dialog = useDialog()
+
+  return (
+    <Dialog title="Force Re-import" fit>
+      <div class="dialog-confirm-body">
+        <p>
+          Re-importing {props.count === 1 ? "this session" : `these ${props.count} sessions`} will overwrite them and
+          delete any progress already made in those migrated sessions.
+        </p>
+        <div class="dialog-confirm-actions">
+          <Button variant="secondary" size="large" onClick={() => dialog.close()}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="large"
+            onClick={() => {
+              props.onConfirm()
+              dialog.close()
+            }}
+          >
+            Proceed
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  )
+}
+
+export default ForceReimportDialog

--- a/packages/kilo-vscode/webview-ui/src/components/migration/ForceReimportDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/ForceReimportDialog.tsx
@@ -2,6 +2,7 @@ import type { Component } from "solid-js"
 import { Dialog } from "@kilocode/kilo-ui/dialog"
 import { Button } from "@kilocode/kilo-ui/button"
 import { useDialog } from "@kilocode/kilo-ui/context/dialog"
+import { useLanguage } from "../../context/language"
 
 interface ForceReimportDialogProps {
   count: number
@@ -10,17 +11,22 @@ interface ForceReimportDialogProps {
 
 const ForceReimportDialog: Component<ForceReimportDialogProps> = (props) => {
   const dialog = useDialog()
+  const language = useLanguage()
 
   return (
-    <Dialog title="Force Re-import" fit>
+    <Dialog title={language.t("migration.forceReimport.title")} fit>
       <div class="dialog-confirm-body">
         <p>
-          Re-importing {props.count === 1 ? "this session" : `these ${props.count} sessions`} will overwrite them and
-          delete any progress already made in those migrated sessions.
+          {language.t("migration.forceReimport.description", {
+            target:
+              props.count === 1
+                ? language.t("migration.forceReimport.target.one")
+                : language.t("migration.forceReimport.target.many", { count: String(props.count) }),
+          })}
         </p>
         <div class="dialog-confirm-actions">
           <Button variant="secondary" size="large" onClick={() => dialog.close()}>
-            Cancel
+            {language.t("common.cancel")}
           </Button>
           <Button
             variant="primary"
@@ -30,7 +36,7 @@ const ForceReimportDialog: Component<ForceReimportDialogProps> = (props) => {
               dialog.close()
             }}
           >
-            Proceed
+            {language.t("migration.forceReimport.proceed")}
           </Button>
         </div>
       </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -398,7 +398,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
         providers: selectedProviderNames,
         mcpServers: selectedMcpNames,
         customModes: selectedModesSlugs,
-        sessions: migrateSessions() ? sessions().map((session) => session.id) : [],
+        sessions: migrateSessions() ? sessions().map((session) => ({ id: session.id })) : [],
         defaultModel: migrateDefaultModel(),
         settings: {
           autoApproval,

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -21,6 +21,7 @@ import type {
   LegacySettings,
   LegacyMigrationDataMessage,
   LegacyMigrationProgressMessage,
+  LegacyMigrationSessionProgressMessage,
   LegacyMigrationCompleteMessage,
 } from "../../types/messages"
 import "./migration.css"
@@ -165,6 +166,16 @@ interface ProgressEntry {
   message?: string
 }
 
+interface SessionProgressState {
+  session: MigrationSessionInfo
+  index: number
+  total: number
+  phase: LegacyMigrationSessionProgressMessage["phase"]
+  current?: number
+  count?: number
+  error?: string
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -202,6 +213,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
   // Progress tracking
   const [progressEntries, setProgressEntries] = createSignal<ProgressEntry[]>([])
   const [results, setResults] = createSignal<MigrationResultItem[]>([])
+  const [sessionProgress, setSessionProgress] = createSignal<SessionProgressState | undefined>(undefined)
 
   // Cleanup preference
   const [clearLegacyData, setClearLegacyData] = createSignal(false)
@@ -259,6 +271,19 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
             message: update.message,
           }
           return existing >= 0 ? prev.map((e, i) => (i === existing ? entry : e)) : [...prev, entry]
+        })
+      }
+
+      if (msg?.type === "legacyMigrationSessionProgress") {
+        const update = msg as LegacyMigrationSessionProgressMessage
+        setSessionProgress({
+          session: update.session,
+          index: update.index,
+          total: update.total,
+          phase: update.phase,
+          current: update.current,
+          count: update.count,
+          error: update.error,
         })
       }
 

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -451,7 +451,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
               },
             },
           })
-          showToast({ variant: "success", title: "Force re-import started" })
+          showToast({ variant: "success", title: language.t("migration.forceReimport.toast.started") })
         }}
       />
     ))

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -12,6 +12,13 @@ import { showToast } from "@kilocode/kilo-ui/toast"
 import { useVSCode } from "../../context/vscode"
 import { useLanguage } from "../../context/language"
 import SessionMigrationProgress, { type SessionMigrationProgressState } from "./SessionMigrationProgress"
+import SessionMigrationSummary from "./SessionMigrationSummary"
+import {
+  createSessionItem,
+  createSessionSummary,
+  updateSessionSummary,
+  type SessionSummaryState,
+} from "./session-migration-summary-state"
 import type {
   MigrationProviderInfo,
   MigrationMcpServerInfo,
@@ -205,6 +212,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
   const [progressEntries, setProgressEntries] = createSignal<ProgressEntry[]>([])
   const [results, setResults] = createSignal<MigrationResultItem[]>([])
   const [sessionProgress, setSessionProgress] = createSignal<SessionMigrationProgressState | undefined>(undefined)
+  const [sessionSummary, setSessionSummary] = createSignal<SessionSummaryState>(createSessionSummary())
 
   // Cleanup preference
   const [clearLegacyData, setClearLegacyData] = createSignal(false)
@@ -267,6 +275,9 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
 
       if (msg?.type === "legacyMigrationSessionProgress") {
         const update = msg as LegacyMigrationSessionProgressMessage
+        setSessionSummary((prev) =>
+          updateSessionSummary(prev, createSessionItem(update.session, update.error), update.phase),
+        )
         setSessionProgress({
           session: update.session,
           index: update.index,
@@ -378,6 +389,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
     ]
 
     setProgressEntries(entries)
+    setSessionSummary(createSessionSummary())
     setPhase("migrating")
 
     vscode.postMessage({
@@ -713,7 +725,9 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
                       {language.t("migration.migrate.sessionsDetected", { count: String(sessions().length) })}
                     </div>
                     <Show when={migrateSessions() && phase() !== "selecting" && sessionProgress()}>
-                      <SessionMigrationProgress progress={sessionProgress()!} />
+                      <Show when={sessionProgress()?.phase === "summary"} fallback={<SessionMigrationProgress progress={sessionProgress()!} />}>
+                        <SessionMigrationSummary summary={sessionSummary()} />
+                      </Show>
                     </Show>
                     <Show
                       when={

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -11,6 +11,7 @@ import type { Component, JSX } from "solid-js"
 import { showToast } from "@kilocode/kilo-ui/toast"
 import { useVSCode } from "../../context/vscode"
 import { useLanguage } from "../../context/language"
+import SessionMigrationProgress, { type SessionMigrationProgressState } from "./SessionMigrationProgress"
 import type {
   MigrationProviderInfo,
   MigrationMcpServerInfo,
@@ -166,16 +167,6 @@ interface ProgressEntry {
   message?: string
 }
 
-interface SessionProgressState {
-  session: MigrationSessionInfo
-  index: number
-  total: number
-  phase: LegacyMigrationSessionProgressMessage["phase"]
-  current?: number
-  count?: number
-  error?: string
-}
-
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -213,7 +204,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
   // Progress tracking
   const [progressEntries, setProgressEntries] = createSignal<ProgressEntry[]>([])
   const [results, setResults] = createSignal<MigrationResultItem[]>([])
-  const [sessionProgress, setSessionProgress] = createSignal<SessionProgressState | undefined>(undefined)
+  const [sessionProgress, setSessionProgress] = createSignal<SessionMigrationProgressState | undefined>(undefined)
 
   // Cleanup preference
   const [clearLegacyData, setClearLegacyData] = createSignal(false)
@@ -719,6 +710,9 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
                     <div class="desc">
                       {language.t("migration.migrate.sessionsDetected", { count: String(sessions().length) })}
                     </div>
+                    <Show when={migrateSessions() && phase() !== "selecting" && sessionProgress()}>
+                      <SessionMigrationProgress progress={sessionProgress()!} />
+                    </Show>
                     <Show
                       when={
                         (phase() === "error" || phase() === "done") &&

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -786,7 +786,10 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
                       {language.t("migration.migrate.sessionsDetected", { count: String(sessions().length) })}
                     </div>
                     <Show when={migrateSessions() && phase() !== "selecting" && sessionProgress()}>
-                      <Show when={sessionProgress()?.phase === "summary"} fallback={<SessionMigrationProgress progress={sessionProgress()!} />}>
+                      <Show
+                        when={sessionProgress()?.phase === "summary"}
+                        fallback={<SessionMigrationProgress progress={sessionProgress()!} />}
+                      >
                         <SessionMigrationSummary summary={sessionSummary()} onForce={handleForceReimport} />
                       </Show>
                     </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -471,6 +471,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
   const totalCount = () => results().length
   const groupMessage = (group: string) =>
     progressEntries().find((entry) => entry.group === group && entry.status === "error")?.message
+  const sessionIconSpinning = () => phase() === "migrating" && migrateSessions() && hasSessions()
 
   // ---------------------------------------------------------------------------
   // Status icon renderer
@@ -478,17 +479,18 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
 
   const StatusIcon = (gProps: { group: string }): JSX.Element => {
     const status = () => groupStatus(gProps.group)
+    const spinning = () => (gProps.group === "sessions" ? sessionIconSpinning() : status() === "migrating")
     return (
       <>
-        <Show when={status() === "pending"}>
+        <Show when={status() === "pending" && !spinning()}>
           <div class="migration-wizard__status-icon migration-wizard__status-icon--pending" />
         </Show>
-        <Show when={status() === "migrating"}>
+        <Show when={spinning()}>
           <div class="migration-wizard__status-icon">
             <div class="migration-wizard__spinner" />
           </div>
         </Show>
-        <Show when={status() === "success"}>
+        <Show when={status() === "success" && !spinning()}>
           <div class="migration-wizard__status-icon migration-wizard__status-icon--success">
             <SuccessCheckSvg />
           </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -15,6 +15,7 @@ import type {
   MigrationProviderInfo,
   MigrationMcpServerInfo,
   MigrationCustomModeInfo,
+  MigrationSessionInfo,
   MigrationResultItem,
   MigrationAutoApprovalSelections,
   LegacySettings,
@@ -184,7 +185,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
   const [providers, setProviders] = createSignal<MigrationProviderInfo[]>([])
   const [mcpServers, setMcpServers] = createSignal<MigrationMcpServerInfo[]>([])
   const [customModes, setCustomModes] = createSignal<MigrationCustomModeInfo[]>([])
-  const [sessions, setSessions] = createSignal<string[]>([])
+  const [sessions, setSessions] = createSignal<MigrationSessionInfo[]>([])
   const [defaultModel, setDefaultModel] = createSignal<{ provider: string; model: string } | undefined>(undefined)
   const [legacySettings, setLegacySettings] = createSignal<LegacySettings | undefined>(undefined)
 
@@ -253,7 +254,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
           const existing = prev.findIndex((e) => e.item === update.item)
           const entry: ProgressEntry = {
             item: update.item,
-            group: existing >= 0 ? prev[existing].group : update.item,
+            group: existing >= 0 ? prev[existing]?.group || update.item : update.item,
             status: update.status,
             message: update.message,
           }
@@ -329,7 +330,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
         return { item: mode?.name ?? slug, group: "customModes", status: "pending" as const }
       }),
       ...(migrateSessions()
-        ? sessions().map((id) => ({ item: id, group: "sessions", status: "pending" as const }))
+        ? sessions().map((session) => ({ item: session.id, group: "sessions", status: "pending" as const }))
         : []),
       ...(migrateDefaultModel() && defaultModel()
         ? [{ item: "Default model", group: "defaultModel", status: "pending" as const }]
@@ -369,7 +370,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
         providers: selectedProviderNames,
         mcpServers: selectedMcpNames,
         customModes: selectedModesSlugs,
-        sessions: migrateSessions() ? sessions() : [],
+        sessions: migrateSessions() ? sessions().map((session) => session.id) : [],
         defaultModel: migrateDefaultModel(),
         settings: {
           autoApproval,

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -530,6 +530,9 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
   const groupStatus = (group: string): ProgressEntry["status"] => {
     const entries = progressEntries().filter((entry) => entry.group === group)
     if (entries.length === 0) return "pending"
+    if (group === "sessions" && running()) {
+      if (entries.some((entry) => entry.status === "migrating" || entry.status === "pending")) return "migrating"
+    }
     if (entries.some((entry) => entry.status === "error")) return "error"
     if (entries.some((entry) => entry.status === "warning")) return "warning"
     if (entries.every((entry) => entry.status === "success")) return "success"

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -283,8 +283,6 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
           index: update.index,
           total: update.total,
           phase: update.phase,
-          current: update.current,
-          count: update.count,
           error: update.error,
         })
       }

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -8,11 +8,14 @@
 
 import { Show, createSignal, onMount, onCleanup } from "solid-js"
 import type { Component, JSX } from "solid-js"
+import { useDialog } from "@kilocode/kilo-ui/context/dialog"
 import { showToast } from "@kilocode/kilo-ui/toast"
 import { useVSCode } from "../../context/vscode"
 import { useLanguage } from "../../context/language"
 import SessionMigrationProgress, { type SessionMigrationProgressState } from "./SessionMigrationProgress"
 import SessionMigrationSummary from "./SessionMigrationSummary"
+import ForceReimportDialog from "./ForceReimportDialog"
+import RunningMigrationDialog from "./RunningMigrationDialog"
 import {
   createSessionItem,
   createSessionSummary,
@@ -185,6 +188,7 @@ export interface MigrationWizardProps {
 
 const MigrationWizard: Component<MigrationWizardProps> = (props) => {
   const vscode = useVSCode()
+  const dialog = useDialog()
   const language = useLanguage()
 
   const [screen, setScreen] = createSignal<Screen>("whats-new")
@@ -213,6 +217,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
   const [results, setResults] = createSignal<MigrationResultItem[]>([])
   const [sessionProgress, setSessionProgress] = createSignal<SessionMigrationProgressState | undefined>(undefined)
   const [sessionSummary, setSessionSummary] = createSignal<SessionSummaryState>(createSessionSummary())
+  const [running, setRunning] = createSignal(false)
 
   // Cleanup preference
   const [clearLegacyData, setClearLegacyData] = createSignal(false)
@@ -290,6 +295,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
       if (msg?.type === "legacyMigrationComplete") {
         const complete = msg as LegacyMigrationCompleteMessage
         setResults(complete.results)
+        setRunning(false)
         const hasErrors = complete.results.some((r) => r.status === "error")
         setPhase(hasErrors ? "error" : "done")
         if (!hasErrors) {
@@ -388,6 +394,8 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
 
     setProgressEntries(entries)
     setSessionSummary(createSessionSummary())
+    setSessionProgress(undefined)
+    setRunning(true)
     setPhase("migrating")
 
     vscode.postMessage({
@@ -407,7 +415,63 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
     })
   }
 
+  const handleForceReimport = (ids: string[]) => {
+    dialog.show(() => (
+      <ForceReimportDialog
+        count={ids.length}
+        onConfirm={() => {
+          setRunning(true)
+          setPhase("migrating")
+          setSessionProgress(undefined)
+          setResults((prev) => prev.filter((item) => item.category !== "session"))
+          setProgressEntries((prev) => {
+            const keep = prev.filter((item) => item.group !== "sessions")
+            const next = ids.map((id) => ({ item: id, group: "sessions", status: "pending" as const }))
+            return [...keep, ...next]
+          })
+          vscode.postMessage({
+            type: "startLegacyMigration",
+            selections: {
+              providers: [],
+              mcpServers: [],
+              customModes: [],
+              sessions: ids.map((id) => ({ id, force: true })),
+              defaultModel: false,
+              settings: {
+                autoApproval: {
+                  commandRules: false,
+                  readPermission: false,
+                  writePermission: false,
+                  executePermission: false,
+                  mcpPermission: false,
+                  taskPermission: false,
+                },
+                language: false,
+                autocomplete: false,
+              },
+            },
+          })
+          showToast({ variant: "success", title: "Force re-import started" })
+        }}
+      />
+    ))
+  }
+
   const handleDone = () => {
+    if (running()) {
+      dialog.show(() => (
+        <RunningMigrationDialog
+          onConfirm={() => {
+            vscode.postMessage({ type: "finalizeLegacyMigration" })
+            if (clearLegacyData()) {
+              vscode.postMessage({ type: "clearLegacyData" })
+            }
+            props.onComplete()
+          }}
+        />
+      ))
+      return
+    }
     vscode.postMessage({ type: "finalizeLegacyMigration" })
     if (clearLegacyData()) {
       vscode.postMessage({ type: "clearLegacyData" })
@@ -720,7 +784,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
                     </div>
                     <Show when={migrateSessions() && phase() !== "selecting" && sessionProgress()}>
                       <Show when={sessionProgress()?.phase === "summary"} fallback={<SessionMigrationProgress progress={sessionProgress()!} />}>
-                        <SessionMigrationSummary summary={sessionSummary()} />
+                        <SessionMigrationSummary summary={sessionSummary()} onForce={handleForceReimport} />
                       </Show>
                     </Show>
                   </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -410,6 +410,7 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
   }
 
   const handleDone = () => {
+    vscode.postMessage({ type: "finalizeLegacyMigration" })
     if (clearLegacyData()) {
       vscode.postMessage({ type: "clearLegacyData" })
     }

--- a/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx
@@ -417,11 +417,6 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
     props.onComplete()
   }
 
-  const copySessionError = async (text: string) => {
-    await navigator.clipboard.writeText(text)
-    showToast({ variant: "success", title: language.t("migration.error.toast.copied") })
-  }
-
   // ---------------------------------------------------------------------------
   // Data helpers
   // ---------------------------------------------------------------------------
@@ -729,29 +724,6 @@ const MigrationWizard: Component<MigrationWizardProps> = (props) => {
                       <Show when={sessionProgress()?.phase === "summary"} fallback={<SessionMigrationProgress progress={sessionProgress()!} />}>
                         <SessionMigrationSummary summary={sessionSummary()} />
                       </Show>
-                    </Show>
-                    <Show
-                      when={
-                        (phase() === "error" || phase() === "done") &&
-                        groupStatus("sessions") === "error" &&
-                        groupMessage("sessions")
-                      }
-                    >
-                      <div class="migration-wizard__error-box">
-                        <div class="migration-wizard__error-box-header">
-                          <div class="migration-wizard__error-box-title">
-                            {language.t("migration.error.sessionFailed")}
-                          </div>
-                          <button
-                            type="button"
-                            class="migration-wizard__copy-btn"
-                            onClick={() => void copySessionError(groupMessage("sessions")!)}
-                          >
-                            {language.t("migration.error.action.copy")}
-                          </button>
-                        </div>
-                        <div class="migration-wizard__error-text">{groupMessage("sessions")}</div>
-                      </div>
                     </Show>
                   </div>
                 </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/RunningMigrationDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/RunningMigrationDialog.tsx
@@ -2,6 +2,7 @@ import type { Component } from "solid-js"
 import { Dialog } from "@kilocode/kilo-ui/dialog"
 import { Button } from "@kilocode/kilo-ui/button"
 import { useDialog } from "@kilocode/kilo-ui/context/dialog"
+import { useLanguage } from "../../context/language"
 
 interface RunningMigrationDialogProps {
   onConfirm: () => void
@@ -9,15 +10,16 @@ interface RunningMigrationDialogProps {
 
 const RunningMigrationDialog: Component<RunningMigrationDialogProps> = (props) => {
   const dialog = useDialog()
+  const language = useLanguage()
 
   return (
-    <Dialog title="Migration in Progress" fit>
+    <Dialog title={language.t("migration.running.title")} fit>
       <div class="dialog-confirm-body">
-        <p>You are about to finish while there are still sessions being migrated.</p>
-        <p>If you leave now, some sessions may remain incomplete.</p>
+        <p>{language.t("migration.running.description.line1")}</p>
+        <p>{language.t("migration.running.description.line2")}</p>
         <div class="dialog-confirm-actions">
           <Button variant="secondary" size="large" onClick={() => dialog.close()}>
-            Stay
+            {language.t("migration.running.stay")}
           </Button>
           <Button
             variant="primary"
@@ -27,7 +29,7 @@ const RunningMigrationDialog: Component<RunningMigrationDialogProps> = (props) =
               dialog.close()
             }}
           >
-            Proceed
+            {language.t("migration.running.proceed")}
           </Button>
         </div>
       </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/RunningMigrationDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/RunningMigrationDialog.tsx
@@ -1,0 +1,38 @@
+import type { Component } from "solid-js"
+import { Dialog } from "@kilocode/kilo-ui/dialog"
+import { Button } from "@kilocode/kilo-ui/button"
+import { useDialog } from "@kilocode/kilo-ui/context/dialog"
+
+interface RunningMigrationDialogProps {
+  onConfirm: () => void
+}
+
+const RunningMigrationDialog: Component<RunningMigrationDialogProps> = (props) => {
+  const dialog = useDialog()
+
+  return (
+    <Dialog title="Migration in Progress" fit>
+      <div class="dialog-confirm-body">
+        <p>You are about to finish while there are still sessions being migrated.</p>
+        <p>If you leave now, some sessions may remain incomplete.</p>
+        <div class="dialog-confirm-actions">
+          <Button variant="secondary" size="large" onClick={() => dialog.close()}>
+            Stay
+          </Button>
+          <Button
+            variant="primary"
+            size="large"
+            onClick={() => {
+              props.onConfirm()
+              dialog.close()
+            }}
+          >
+            Proceed
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  )
+}
+
+export default RunningMigrationDialog

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationCard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationCard.tsx
@@ -1,0 +1,11 @@
+import type { Component, JSX } from "solid-js"
+
+interface SessionMigrationCardProps {
+  children: JSX.Element
+}
+
+const SessionMigrationCard: Component<SessionMigrationCardProps> = (props) => {
+  return <div class="migration-session-card">{props.children}</div>
+}
+
+export default SessionMigrationCard

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
@@ -1,7 +1,9 @@
 import { For } from "solid-js"
 import type { Component } from "solid-js"
 import type { LegacyMigrationSessionPhase, MigrationSessionInfo } from "../../types/messages"
+import { useLanguage } from "../../context/language"
 import SessionMigrationCard from "./SessionMigrationCard"
+import { formatDate, formatText } from "./session-migration-format"
 
 export interface SessionMigrationProgressState {
   session: MigrationSessionInfo
@@ -18,33 +20,9 @@ interface SessionMigrationProgressProps {
 type Step = "preparing" | "storing"
 type StepState = "pending" | "active" | "success"
 
-const steps: Array<{ key: Step; label: string }> = [
-  { key: "preparing", label: "Preparing session" },
-  { key: "storing", label: "Storing session" },
-]
+const steps: Step[] = ["preparing", "storing"]
 
 const order: Step[] = ["preparing", "storing"]
-
-function formatDate(time: number) {
-  if (!time) return "Unknown date"
-  const date = new Date(time)
-  const hour = new Intl.DateTimeFormat("en", {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  }).format(date)
-  const day = new Intl.DateTimeFormat("en", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(date)
-  return `${hour} ${day}`
-}
-
-function text(value: string) {
-  const next = value.trim()
-  return next || "Unknown"
-}
 
 function current(phase: LegacyMigrationSessionPhase): Step | undefined {
   if (phase === "preparing" || phase === "storing") {
@@ -67,34 +45,45 @@ function state(step: Step, phase: LegacyMigrationSessionPhase): StepState {
   return "pending"
 }
 
-function label(step: Step, progress: SessionMigrationProgressState) {
-  if (step === "storing" && progress.phase === "skipped") return "Session skipped"
-  return steps.find((item) => item.key === step)?.label ?? ""
+function label(language: ReturnType<typeof useLanguage>, step: Step, progress: SessionMigrationProgressState) {
+  if (step === "storing" && progress.phase === "skipped") return language.t("migration.sessionProgress.skipped")
+  if (step === "preparing") return language.t("migration.sessionProgress.preparing")
+  return language.t("migration.sessionProgress.storing")
 }
 
 const SessionMigrationProgress: Component<SessionMigrationProgressProps> = (props) => {
+  const language = useLanguage()
+
   return (
     <SessionMigrationCard>
       <div class="migration-session-progress">
-        <div class="migration-session-progress__header">{`Migrating ${props.progress.index} of ${props.progress.total}`}</div>
+        <div class="migration-session-progress__header">
+          {language.t("migration.sessionProgress.header", {
+            current: String(props.progress.index),
+            total: String(props.progress.total),
+          })}
+        </div>
         <div class="migration-session-progress__meta">
-          <div class="migration-session-progress__directory" title={props.progress.session.directory || "Unknown"}>
-            {text(props.progress.session.directory)}
+          <div
+            class="migration-session-progress__directory"
+            title={props.progress.session.directory || language.t("migration.sessionFormat.unknown")}
+          >
+            {formatText(language, props.progress.session.directory)}
           </div>
           <div class="migration-session-progress__meta-row">
-            <span class="migration-session-progress__title" title={props.progress.session.title || "Unknown"}>
-              {text(props.progress.session.title)}
+            <span class="migration-session-progress__title" title={props.progress.session.title || language.t("migration.sessionFormat.unknown")}>
+              {formatText(language, props.progress.session.title)}
             </span>
-            <span class="migration-session-progress__date">{formatDate(props.progress.session.time)}</span>
+            <span class="migration-session-progress__date">{formatDate(language, props.progress.session.time)}</span>
           </div>
         </div>
         <div class="migration-session-progress__steps">
           <For each={steps}>
             {(step) => (
               <div class="migration-session-progress__step">
-                <div class={`migration-session-progress__dot migration-session-progress__dot--${state(step.key, props.progress.phase)}`} />
+                <div class={`migration-session-progress__dot migration-session-progress__dot--${state(step, props.progress.phase)}`} />
                 <div class="migration-session-progress__step-text">
-                  <span>{label(step.key, props.progress)}</span>
+                  <span>{label(language, step, props.progress)}</span>
                 </div>
               </div>
             )}

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
@@ -17,17 +17,18 @@ interface SessionMigrationProgressProps {
   progress: SessionMigrationProgressState
 }
 
-type Step = "project" | "session" | "messages" | "parts"
+type Step = "preparing" | "project" | "session" | "messages" | "parts"
 type StepState = "pending" | "active" | "success"
 
 const steps: Array<{ key: Step; label: string }> = [
+  { key: "preparing", label: "Preparing session" },
   { key: "project", label: "Storing project" },
   { key: "session", label: "Storing session" },
   { key: "messages", label: "Storing messages" },
   { key: "parts", label: "Storing parts" },
 ]
 
-const order: Step[] = ["project", "session", "messages", "parts"]
+const order: Step[] = ["preparing", "project", "session", "messages", "parts"]
 
 function formatDate(time: number) {
   if (!time) return "Unknown date"
@@ -51,7 +52,9 @@ function text(value: string) {
 }
 
 function current(phase: LegacyMigrationSessionPhase): Step | undefined {
-  if (phase === "project" || phase === "session" || phase === "messages" || phase === "parts") return phase
+  if (phase === "preparing" || phase === "project" || phase === "session" || phase === "messages" || phase === "parts") {
+    return phase
+  }
   if (phase === "skipped") return "session"
   if (phase === "done") return "parts"
   if (phase === "error") return undefined

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
@@ -1,6 +1,7 @@
 import { For } from "solid-js"
 import type { Component } from "solid-js"
 import type { LegacyMigrationSessionPhase, MigrationSessionInfo } from "../../types/messages"
+import SessionMigrationCard from "./SessionMigrationCard"
 
 export interface SessionMigrationProgressState {
   session: MigrationSessionInfo
@@ -81,35 +82,35 @@ function label(step: Step, progress: SessionMigrationProgressState) {
 
 const SessionMigrationProgress: Component<SessionMigrationProgressProps> = (props) => {
   return (
-    <div class="migration-session-progress">
-      <div class="migration-session-progress__header">{`Migrating ${props.progress.index} of ${props.progress.total}`}</div>
-      <div class="migration-session-progress__meta">
-        <div class="migration-session-progress__directory" title={props.progress.session.directory || "Unknown"}>
-          {text(props.progress.session.directory)}
+    <SessionMigrationCard>
+      <div class="migration-session-progress">
+        <div class="migration-session-progress__header">{`Migrating ${props.progress.index} of ${props.progress.total}`}</div>
+        <div class="migration-session-progress__meta">
+          <div class="migration-session-progress__directory" title={props.progress.session.directory || "Unknown"}>
+            {text(props.progress.session.directory)}
+          </div>
+          <div class="migration-session-progress__meta-row">
+            <span class="migration-session-progress__title" title={props.progress.session.title || "Unknown"}>
+              {text(props.progress.session.title)}
+            </span>
+            <span class="migration-session-progress__date">{formatDate(props.progress.session.time)}</span>
+          </div>
         </div>
-        <div class="migration-session-progress__meta-row">
-          <span class="migration-session-progress__title" title={props.progress.session.title || "Unknown"}>
-            {text(props.progress.session.title)}
-          </span>
-          <span class="migration-session-progress__date">{formatDate(props.progress.session.time)}</span>
-        </div>
-      </div>
-      <div class="migration-session-progress__steps">
-        <For each={steps}>
-          {(step) => (
-            <div class="migration-session-progress__step">
-              <div
-                class={`migration-session-progress__dot migration-session-progress__dot--${state(step.key, props.progress.phase)}`}
-              />
-              <div class="migration-session-progress__step-text">
-                <span>{label(step.key, props.progress)}</span>
-                <span class="migration-session-progress__count">{count(step.key, props.progress) ?? ""}</span>
+        <div class="migration-session-progress__steps">
+          <For each={steps}>
+            {(step) => (
+              <div class="migration-session-progress__step">
+                <div class={`migration-session-progress__dot migration-session-progress__dot--${state(step.key, props.progress.phase)}`} />
+                <div class="migration-session-progress__step-text">
+                  <span>{label(step.key, props.progress)}</span>
+                  <span class="migration-session-progress__count">{count(step.key, props.progress) ?? ""}</span>
+                </div>
               </div>
-            </div>
-          )}
-        </For>
+            )}
+          </For>
+        </div>
       </div>
-    </div>
+    </SessionMigrationCard>
   )
 }
 

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
@@ -30,14 +30,18 @@ const order: Step[] = ["project", "session", "messages", "parts"]
 
 function formatDate(time: number) {
   if (!time) return "Unknown date"
-  return new Intl.DateTimeFormat("en", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
+  const date = new Date(time)
+  const hour = new Intl.DateTimeFormat("en", {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
-  }).format(new Date(time))
+  }).format(date)
+  const day = new Intl.DateTimeFormat("en", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date)
+  return `${hour} ${day}`
 }
 
 function text(value: string) {
@@ -70,12 +74,25 @@ function count(step: Step, progress: SessionMigrationProgressState) {
   return `${progress.current ?? 0}/${progress.count}`
 }
 
+function label(step: Step, progress: SessionMigrationProgressState) {
+  if (step === "session" && progress.phase === "skipped") return "Session skipped"
+  return steps.find((item) => item.key === step)?.label ?? ""
+}
+
 const SessionMigrationProgress: Component<SessionMigrationProgressProps> = (props) => {
   return (
     <div class="migration-session-progress">
       <div class="migration-session-progress__header">{`Migrating ${props.progress.index} of ${props.progress.total}`}</div>
-      <div class="migration-session-progress__meta" title={props.progress.session.directory || "Unknown"}>
-        {`${formatDate(props.progress.session.time)} - ${text(props.progress.session.title)} on ${text(props.progress.session.directory)}`}
+      <div class="migration-session-progress__meta">
+        <div class="migration-session-progress__directory" title={props.progress.session.directory || "Unknown"}>
+          {text(props.progress.session.directory)}
+        </div>
+        <div class="migration-session-progress__meta-row">
+          <span class="migration-session-progress__title" title={props.progress.session.title || "Unknown"}>
+            {text(props.progress.session.title)}
+          </span>
+          <span class="migration-session-progress__date">{formatDate(props.progress.session.time)}</span>
+        </div>
       </div>
       <div class="migration-session-progress__steps">
         <For each={steps}>
@@ -85,7 +102,7 @@ const SessionMigrationProgress: Component<SessionMigrationProgressProps> = (prop
                 class={`migration-session-progress__dot migration-session-progress__dot--${state(step.key, props.progress.phase)}`}
               />
               <div class="migration-session-progress__step-text">
-                <span>{step.label}</span>
+                <span>{label(step.key, props.progress)}</span>
                 <span class="migration-session-progress__count">{count(step.key, props.progress) ?? ""}</span>
               </div>
             </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
@@ -8,8 +8,6 @@ export interface SessionMigrationProgressState {
   index: number
   total: number
   phase: LegacyMigrationSessionPhase
-  current?: number
-  count?: number
   error?: string
 }
 
@@ -17,18 +15,15 @@ interface SessionMigrationProgressProps {
   progress: SessionMigrationProgressState
 }
 
-type Step = "preparing" | "project" | "session" | "messages" | "parts"
+type Step = "preparing" | "storing"
 type StepState = "pending" | "active" | "success"
 
 const steps: Array<{ key: Step; label: string }> = [
   { key: "preparing", label: "Preparing session" },
-  { key: "project", label: "Storing project" },
-  { key: "session", label: "Storing session" },
-  { key: "messages", label: "Storing messages" },
-  { key: "parts", label: "Storing parts" },
+  { key: "storing", label: "Storing session" },
 ]
 
-const order: Step[] = ["preparing", "project", "session", "messages", "parts"]
+const order: Step[] = ["preparing", "storing"]
 
 function formatDate(time: number) {
   if (!time) return "Unknown date"
@@ -52,11 +47,11 @@ function text(value: string) {
 }
 
 function current(phase: LegacyMigrationSessionPhase): Step | undefined {
-  if (phase === "preparing" || phase === "project" || phase === "session" || phase === "messages" || phase === "parts") {
+  if (phase === "preparing" || phase === "storing") {
     return phase
   }
-  if (phase === "skipped") return "session"
-  if (phase === "done") return "parts"
+  if (phase === "skipped") return "storing"
+  if (phase === "done") return "storing"
   if (phase === "error") return undefined
   return undefined
 }
@@ -71,15 +66,8 @@ function state(step: Step, phase: LegacyMigrationSessionPhase): StepState {
   return "pending"
 }
 
-function count(step: Step, progress: SessionMigrationProgressState) {
-  if (step !== "messages" && step !== "parts") return undefined
-  if (progress.phase !== step && !(progress.phase === "done" && step === "parts")) return undefined
-  if (progress.count === undefined) return undefined
-  return `${progress.current ?? 0}/${progress.count}`
-}
-
 function label(step: Step, progress: SessionMigrationProgressState) {
-  if (step === "session" && progress.phase === "skipped") return "Session skipped"
+  if (step === "storing" && progress.phase === "skipped") return "Session skipped"
   return steps.find((item) => item.key === step)?.label ?? ""
 }
 
@@ -106,7 +94,6 @@ const SessionMigrationProgress: Component<SessionMigrationProgressProps> = (prop
                 <div class={`migration-session-progress__dot migration-session-progress__dot--${state(step.key, props.progress.phase)}`} />
                 <div class="migration-session-progress__step-text">
                   <span>{label(step.key, props.progress)}</span>
-                  <span class="migration-session-progress__count">{count(step.key, props.progress) ?? ""}</span>
                 </div>
               </div>
             )}

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
@@ -71,7 +71,10 @@ const SessionMigrationProgress: Component<SessionMigrationProgressProps> = (prop
             {formatText(language, props.progress.session.directory)}
           </div>
           <div class="migration-session-progress__meta-row">
-            <span class="migration-session-progress__title" title={props.progress.session.title || language.t("migration.sessionFormat.unknown")}>
+            <span
+              class="migration-session-progress__title"
+              title={props.progress.session.title || language.t("migration.sessionFormat.unknown")}
+            >
               {formatText(language, props.progress.session.title)}
             </span>
             <span class="migration-session-progress__date">{formatDate(language, props.progress.session.time)}</span>
@@ -81,7 +84,9 @@ const SessionMigrationProgress: Component<SessionMigrationProgressProps> = (prop
           <For each={steps}>
             {(step) => (
               <div class="migration-session-progress__step">
-                <div class={`migration-session-progress__dot migration-session-progress__dot--${state(step, props.progress.phase)}`} />
+                <div
+                  class={`migration-session-progress__dot migration-session-progress__dot--${state(step, props.progress.phase)}`}
+                />
                 <div class="migration-session-progress__step-text">
                   <span>{label(language, step, props.progress)}</span>
                 </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
@@ -1,0 +1,99 @@
+import { For } from "solid-js"
+import type { Component } from "solid-js"
+import type { LegacyMigrationSessionPhase, MigrationSessionInfo } from "../../types/messages"
+
+export interface SessionMigrationProgressState {
+  session: MigrationSessionInfo
+  index: number
+  total: number
+  phase: LegacyMigrationSessionPhase
+  current?: number
+  count?: number
+  error?: string
+}
+
+interface SessionMigrationProgressProps {
+  progress: SessionMigrationProgressState
+}
+
+type Step = "project" | "session" | "messages" | "parts"
+type StepState = "pending" | "active" | "success"
+
+const steps: Array<{ key: Step; label: string }> = [
+  { key: "project", label: "Storing project" },
+  { key: "session", label: "Storing session" },
+  { key: "messages", label: "Storing messages" },
+  { key: "parts", label: "Storing parts" },
+]
+
+const order: Step[] = ["project", "session", "messages", "parts"]
+
+function formatDate(time: number) {
+  if (!time) return "Unknown date"
+  return new Intl.DateTimeFormat("en", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(new Date(time))
+}
+
+function text(value: string) {
+  const next = value.trim()
+  return next || "Unknown"
+}
+
+function current(phase: LegacyMigrationSessionPhase): Step | undefined {
+  if (phase === "project" || phase === "session" || phase === "messages" || phase === "parts") return phase
+  if (phase === "skipped") return "session"
+  if (phase === "done") return "parts"
+  if (phase === "error") return undefined
+  return undefined
+}
+
+function state(step: Step, phase: LegacyMigrationSessionPhase): StepState {
+  const active = current(phase)
+  if (!active) return phase === "done" ? "success" : "pending"
+  const i = order.indexOf(step)
+  const a = order.indexOf(active)
+  if (i < a) return "success"
+  if (i === a) return phase === "done" ? "success" : "active"
+  return "pending"
+}
+
+function count(step: Step, progress: SessionMigrationProgressState) {
+  if (step !== "messages" && step !== "parts") return undefined
+  if (progress.phase !== step && !(progress.phase === "done" && step === "parts")) return undefined
+  if (progress.count === undefined) return undefined
+  return `${progress.current ?? 0}/${progress.count}`
+}
+
+const SessionMigrationProgress: Component<SessionMigrationProgressProps> = (props) => {
+  return (
+    <div class="migration-session-progress">
+      <div class="migration-session-progress__header">{`Migrating ${props.progress.index} of ${props.progress.total}`}</div>
+      <div class="migration-session-progress__meta" title={props.progress.session.directory || "Unknown"}>
+        {`${formatDate(props.progress.session.time)} - ${text(props.progress.session.title)} on ${text(props.progress.session.directory)}`}
+      </div>
+      <div class="migration-session-progress__steps">
+        <For each={steps}>
+          {(step) => (
+            <div class="migration-session-progress__step">
+              <div
+                class={`migration-session-progress__dot migration-session-progress__dot--${state(step.key, props.progress.phase)}`}
+              />
+              <div class="migration-session-progress__step-text">
+                <span>{step.label}</span>
+                <span class="migration-session-progress__count">{count(step.key, props.progress) ?? ""}</span>
+              </div>
+            </div>
+          )}
+        </For>
+      </div>
+    </div>
+  )
+}
+
+export default SessionMigrationProgress

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationProgress.tsx
@@ -59,6 +59,7 @@ function current(phase: LegacyMigrationSessionPhase): Step | undefined {
 function state(step: Step, phase: LegacyMigrationSessionPhase): StepState {
   const active = current(phase)
   if (!active) return phase === "done" ? "success" : "pending"
+  if (step === "preparing" && phase === "preparing") return "active"
   const i = order.indexOf(step)
   const a = order.indexOf(active)
   if (i < a) return "success"

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -3,13 +3,19 @@ import { For } from "solid-js"
 import SessionMigrationCard from "./SessionMigrationCard"
 import type { SessionSummaryState } from "./session-migration-summary-state"
 import { showToast } from "@kilocode/kilo-ui/toast"
-import { detail, line, report } from "./session-migration-summary-format"
+import { errored, line, report } from "./session-migration-summary-format"
 
 interface SessionMigrationSummaryProps {
   summary: SessionSummaryState
 }
 
 const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props) => {
+  const label = (name: string, count: number, desc?: string) => {
+    const suffix = count > 0 ? ` (${count})` : ""
+    const extra = desc ? ` - ${desc}` : ""
+    return `${name}${extra}${suffix}:`
+  }
+
   const handleCopy = async () => {
     const text = report(props.summary)
     if (!text) return
@@ -27,7 +33,7 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
           </button>
         </div>
         <div class="migration-session-summary__section">
-          <div class="migration-session-summary__label">- Successful</div>
+          <div class="migration-session-summary__label">{label("Successful", props.summary.imported.length)}</div>
           <div class="migration-session-summary__list migration-session-summary__list--success">
             <For each={props.summary.imported.length > 0 ? props.summary.imported : [undefined]}>
               {(item) => <div class="migration-session-summary__item">{item ? line(item) : "None"}</div>}
@@ -35,7 +41,7 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
           </div>
         </div>
         <div class="migration-session-summary__section">
-          <div class="migration-session-summary__label">- Skipped</div>
+          <div class="migration-session-summary__label">{label("Skipped", props.summary.skipped.length, "Already migrated")}</div>
           <div class="migration-session-summary__list migration-session-summary__list--skipped">
             <For each={props.summary.skipped.length > 0 ? props.summary.skipped : [undefined]}>
               {(item) => <div class="migration-session-summary__item">{item ? line(item) : "None"}</div>}
@@ -43,17 +49,14 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
           </div>
         </div>
         <div class="migration-session-summary__section">
-          <div class="migration-session-summary__label">- Errored</div>
+          <div class="migration-session-summary__label">{label("Errored", props.summary.errored.length)}</div>
           <div class="migration-session-summary__list migration-session-summary__list--errored">
-            <For each={props.summary.errored.length > 0 ? props.summary.errored : [undefined]}>
+            <For each={errored(props.summary)}>
               {(item) =>
-                item ? (
-                  <div class="migration-session-summary__entry">
-                    <div class="migration-session-summary__item">{line(item)}</div>
-                    <div class="migration-session-summary__detail">{detail(item)}</div>
-                  </div>
+                item.kind === "detail" ? (
+                  <div class="migration-session-summary__detail">{item.text}</div>
                 ) : (
-                  <div class="migration-session-summary__item">None</div>
+                  <div class="migration-session-summary__item">{item.text}</div>
                 )
               }
             </For>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -1,6 +1,8 @@
 import type { Component } from "solid-js"
 import { For, Show, createMemo, createSignal } from "solid-js"
+import { useDialog } from "@kilocode/kilo-ui/context/dialog"
 import SessionMigrationCard from "./SessionMigrationCard"
+import ForceReimportDialog from "./ForceReimportDialog"
 import type { SessionSummaryState } from "./session-migration-summary-state"
 import { showToast } from "@kilocode/kilo-ui/toast"
 import { errored, line, report } from "./session-migration-summary-format"
@@ -12,6 +14,7 @@ interface SessionMigrationSummaryProps {
 
 const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props) => {
   const vscode = useVSCode()
+  const dialog = useDialog()
   const [all, setAll] = createSignal(false)
   const [selected, setSelected] = createSignal<string[]>([])
 
@@ -48,29 +51,36 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
   const handleForce = () => {
     const list = picked()
     if (list.length === 0) return
-    vscode.postMessage({
-      type: "startLegacyMigration",
-      selections: {
-        providers: [],
-        mcpServers: [],
-        customModes: [],
-        sessions: list.map((id) => ({ id, force: true })),
-        defaultModel: false,
-        settings: {
-          autoApproval: {
-            commandRules: false,
-            readPermission: false,
-            writePermission: false,
-            executePermission: false,
-            mcpPermission: false,
-            taskPermission: false,
-          },
-          language: false,
-          autocomplete: false,
-        },
-      },
-    })
-    showToast({ variant: "success", title: "Force re-import started" })
+    dialog.show(() => (
+      <ForceReimportDialog
+        count={list.length}
+        onConfirm={() => {
+          vscode.postMessage({
+            type: "startLegacyMigration",
+            selections: {
+              providers: [],
+              mcpServers: [],
+              customModes: [],
+              sessions: list.map((id) => ({ id, force: true })),
+              defaultModel: false,
+              settings: {
+                autoApproval: {
+                  commandRules: false,
+                  readPermission: false,
+                  writePermission: false,
+                  executePermission: false,
+                  mcpPermission: false,
+                  taskPermission: false,
+                },
+                language: false,
+                autocomplete: false,
+              },
+            },
+          })
+          showToast({ variant: "success", title: "Force re-import started" })
+        }}
+      />
+    ))
   }
 
   return (

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -68,12 +68,12 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
             </For>
           </div>
         </div>
-        <div class="migration-session-summary__section">
-          <div class="migration-session-summary__label">{label("Skipped", props.summary.skipped.length, "Already migrated")}</div>
-          <div class="migration-session-summary__list migration-session-summary__list--skipped">
-            <For each={props.summary.skipped.length > 0 ? props.summary.skipped : [undefined]}>
-              {(item) =>
-                item ? (
+        <Show when={props.summary.skipped.length > 0}>
+          <div class="migration-session-summary__section">
+            <div class="migration-session-summary__label">{label("Skipped", props.summary.skipped.length, "Already migrated")}</div>
+            <div class="migration-session-summary__list migration-session-summary__list--skipped">
+              <For each={props.summary.skipped}>
+                {(item) => (
                   <label class="migration-session-summary__pick">
                     <span class="migration-session-summary__item">{line(item)}</span>
                     <input
@@ -87,13 +87,9 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
                       </svg>
                     </span>
                   </label>
-                ) : (
-                  <div class="migration-session-summary__item">None</div>
-                )
-              }
-            </For>
-          </div>
-          <Show when={props.summary.skipped.length > 0}>
+                )}
+              </For>
+            </div>
             <div class="migration-session-summary__actions">
               <label class="migration-session-summary__all">
                 <span>Re-import all</span>
@@ -113,22 +109,24 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
                 Force Re-import
               </button>
             </div>
-          </Show>
-        </div>
-        <div class="migration-session-summary__section">
-          <div class="migration-session-summary__label">{label("Errored", props.summary.errored.length)}</div>
-          <div class="migration-session-summary__list migration-session-summary__list--errored">
-            <For each={errored(props.summary)}>
-              {(item) =>
-                item.kind === "detail" ? (
-                  <div class="migration-session-summary__detail">{item.text}</div>
-                ) : (
-                  <div class="migration-session-summary__item">{item.text}</div>
-                )
-              }
-            </For>
           </div>
-        </div>
+        </Show>
+        <Show when={props.summary.errored.length > 0}>
+          <div class="migration-session-summary__section">
+            <div class="migration-session-summary__label">{label("Errored", props.summary.errored.length)}</div>
+            <div class="migration-session-summary__list migration-session-summary__list--errored">
+              <For each={errored(props.summary)}>
+                {(item) =>
+                  item.kind === "detail" ? (
+                    <div class="migration-session-summary__detail">{item.text}</div>
+                  ) : (
+                    <div class="migration-session-summary__item">{item.text}</div>
+                  )
+                }
+              </For>
+            </div>
+          </div>
+        </Show>
       </div>
     </SessionMigrationCard>
   )

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -1,20 +1,16 @@
 import type { Component } from "solid-js"
 import { For, Show, createMemo, createSignal } from "solid-js"
-import { useDialog } from "@kilocode/kilo-ui/context/dialog"
 import SessionMigrationCard from "./SessionMigrationCard"
-import ForceReimportDialog from "./ForceReimportDialog"
 import type { SessionSummaryState } from "./session-migration-summary-state"
 import { showToast } from "@kilocode/kilo-ui/toast"
 import { errored, line, report } from "./session-migration-summary-format"
-import { useVSCode } from "../../context/vscode"
 
 interface SessionMigrationSummaryProps {
   summary: SessionSummaryState
+  onForce: (ids: string[]) => void
 }
 
 const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props) => {
-  const vscode = useVSCode()
-  const dialog = useDialog()
   const [all, setAll] = createSignal(false)
   const [selected, setSelected] = createSignal<string[]>([])
 
@@ -51,36 +47,8 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
   const handleForce = () => {
     const list = picked()
     if (list.length === 0) return
-    dialog.show(() => (
-      <ForceReimportDialog
-        count={list.length}
-        onConfirm={() => {
-          vscode.postMessage({
-            type: "startLegacyMigration",
-            selections: {
-              providers: [],
-              mcpServers: [],
-              customModes: [],
-              sessions: list.map((id) => ({ id, force: true })),
-              defaultModel: false,
-              settings: {
-                autoApproval: {
-                  commandRules: false,
-                  readPermission: false,
-                  writePermission: false,
-                  executePermission: false,
-                  mcpPermission: false,
-                  taskPermission: false,
-                },
-                language: false,
-                autocomplete: false,
-              },
-            },
-          })
-          showToast({ variant: "success", title: "Force re-import started" })
-        }}
-      />
-    ))
+    props.onForce(list)
+    showToast({ variant: "success", title: "Force re-import started" })
   }
 
   return (

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -4,6 +4,7 @@ import SessionMigrationCard from "./SessionMigrationCard"
 import type { SessionSummaryState } from "./session-migration-summary-state"
 import { showToast } from "@kilocode/kilo-ui/toast"
 import { errored, line, report } from "./session-migration-summary-format"
+import { useLanguage } from "../../context/language"
 
 interface SessionMigrationSummaryProps {
   summary: SessionSummaryState
@@ -11,6 +12,7 @@ interface SessionMigrationSummaryProps {
 }
 
 const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props) => {
+  const language = useLanguage()
   const [all, setAll] = createSignal(false)
   const [selected, setSelected] = createSignal<string[]>([])
 
@@ -24,7 +26,7 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
     const text = report(props.summary)
     if (!text) return
     await navigator.clipboard.writeText(text)
-    showToast({ variant: "success", title: "Copied report" })
+    showToast({ variant: "success", title: language.t("migration.sessionSummary.toast.copied") })
   }
 
   const skipped = createMemo(() => props.summary.skipped)
@@ -48,16 +50,16 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
     const list = picked()
     if (list.length === 0) return
     props.onForce(list)
-    showToast({ variant: "success", title: "Force re-import started" })
+    showToast({ variant: "success", title: language.t("migration.forceReimport.toast.started") })
   }
 
   return (
     <SessionMigrationCard>
       <div class="migration-session-summary">
         <div class="migration-session-summary__row">
-          <div class="migration-session-summary__title">Summary:</div>
+          <div class="migration-session-summary__title">{language.t("migration.sessionSummary.title")}</div>
           <button type="button" class="migration-wizard__copy-btn" onClick={() => void handleCopy()}>
-            Copy Report
+            {language.t("migration.sessionSummary.copy")}
           </button>
         </div>
         <div class="migration-session-summary__section">
@@ -92,7 +94,7 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
             </div>
             <div class="migration-session-summary__actions">
               <label class="migration-session-summary__all">
-                <span>Re-import all</span>
+                <span>{language.t("migration.forceReimport.all")}</span>
                 <input type="checkbox" checked={all()} onChange={(event) => handleAll(event.currentTarget.checked)} />
                 <span class="migration-session-summary__pick-mark migration-session-summary__pick-mark--all">
                   <svg viewBox="0 0 12 12" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -106,7 +108,7 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
                 disabled={picked().length === 0}
                 onClick={() => handleForce()}
               >
-                Force Re-import
+                {language.t("migration.forceReimport.button")}
               </button>
             </div>
           </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -3,7 +3,7 @@ import { For } from "solid-js"
 import SessionMigrationCard from "./SessionMigrationCard"
 import type { SessionSummaryState } from "./session-migration-summary-state"
 import { showToast } from "@kilocode/kilo-ui/toast"
-import { copy as formatCopy, errors, line } from "./session-migration-summary-format"
+import { errors, line, report } from "./session-migration-summary-format"
 
 interface SessionMigrationSummaryProps {
   summary: SessionSummaryState
@@ -11,16 +11,21 @@ interface SessionMigrationSummaryProps {
 
 const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props) => {
   const handleCopy = async () => {
-    const text = formatCopy(props.summary)
+    const text = report(props.summary)
     if (!text) return
     await navigator.clipboard.writeText(text)
-    showToast({ variant: "success", title: "Copied errors" })
+    showToast({ variant: "success", title: "Copied report" })
   }
 
   return (
     <SessionMigrationCard>
       <div class="migration-session-summary">
-        <div class="migration-session-summary__title">Summary:</div>
+        <div class="migration-session-summary__row">
+          <div class="migration-session-summary__title">Summary:</div>
+          <button type="button" class="migration-wizard__copy-btn" onClick={() => void handleCopy()}>
+            Copy Report
+          </button>
+        </div>
         <div class="migration-session-summary__section">
           <div class="migration-session-summary__label">- Successful</div>
           <div class="migration-session-summary__list">
@@ -40,14 +45,7 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
           </div>
         </div>
         <div class="migration-session-summary__section">
-          <div class="migration-session-summary__row">
-            <div class="migration-session-summary__label">- Errors</div>
-            {props.summary.errored.length > 0 && (
-              <button type="button" class="migration-wizard__copy-btn" onClick={() => void handleCopy()}>
-                Copy
-              </button>
-            )}
-          </div>
+          <div class="migration-session-summary__label">- Errors</div>
           <div class="migration-session-summary__list">
             <For each={errors(props.summary)}>{(item) => <div class="migration-session-summary__item">- {item}</div>}</For>
           </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -62,17 +62,27 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
           </button>
         </div>
         <div class="migration-session-summary__section">
-          <div class="migration-session-summary__label">{label(language.t("migration.sessionSummary.successful"), props.summary.imported.length)}</div>
+          <div class="migration-session-summary__label">
+            {label(language.t("migration.sessionSummary.successful"), props.summary.imported.length)}
+          </div>
           <div class="migration-session-summary__list migration-session-summary__list--success">
             <For each={props.summary.imported.length > 0 ? props.summary.imported : [undefined]}>
-              {(item) => <div class="migration-session-summary__item">{item ? line(language, item) : language.t("migration.sessionSummary.none")}</div>}
+              {(item) => (
+                <div class="migration-session-summary__item">
+                  {item ? line(language, item) : language.t("migration.sessionSummary.none")}
+                </div>
+              )}
             </For>
           </div>
         </div>
         <Show when={props.summary.skipped.length > 0}>
           <div class="migration-session-summary__section">
             <div class="migration-session-summary__label">
-              {label(language.t("migration.sessionSummary.skipped"), props.summary.skipped.length, language.t("migration.sessionSummary.alreadyMigrated"))}
+              {label(
+                language.t("migration.sessionSummary.skipped"),
+                props.summary.skipped.length,
+                language.t("migration.sessionSummary.alreadyMigrated"),
+              )}
             </div>
             <div class="migration-session-summary__list migration-session-summary__list--skipped">
               <For each={props.summary.skipped}>
@@ -85,7 +95,14 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
                       onChange={(event) => toggle(item.id, event.currentTarget.checked)}
                     />
                     <span class="migration-session-summary__pick-mark">
-                      <svg viewBox="0 0 12 12" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <svg
+                        viewBox="0 0 12 12"
+                        fill="none"
+                        stroke="#fff"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
                         <polyline points="2.5 6 5 8.5 9.5 3.5" />
                       </svg>
                     </span>
@@ -98,7 +115,14 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
                 <span>{language.t("migration.forceReimport.all")}</span>
                 <input type="checkbox" checked={all()} onChange={(event) => handleAll(event.currentTarget.checked)} />
                 <span class="migration-session-summary__pick-mark migration-session-summary__pick-mark--all">
-                  <svg viewBox="0 0 12 12" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <svg
+                    viewBox="0 0 12 12"
+                    fill="none"
+                    stroke="#fff"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
                     <polyline points="2.5 6 5 8.5 9.5 3.5" />
                   </svg>
                 </span>
@@ -116,7 +140,9 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
         </Show>
         <Show when={props.summary.errored.length > 0}>
           <div class="migration-session-summary__section">
-            <div class="migration-session-summary__label">{label(language.t("migration.sessionSummary.errored"), props.summary.errored.length)}</div>
+            <div class="migration-session-summary__label">
+              {label(language.t("migration.sessionSummary.errored"), props.summary.errored.length)}
+            </div>
             <div class="migration-session-summary__list migration-session-summary__list--errored">
               <For each={errored(language, props.summary)}>
                 {(item) =>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -1,0 +1,35 @@
+import type { Component } from "solid-js"
+import SessionMigrationCard from "./SessionMigrationCard"
+import type { SessionSummaryState } from "./session-migration-summary-state"
+
+interface SessionMigrationSummaryProps {
+  summary: SessionSummaryState
+}
+
+const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props) => {
+  return (
+    <SessionMigrationCard>
+      <div class="migration-session-summary">
+        <div class="migration-session-summary__title">Summary:</div>
+        <div class="migration-session-summary__section">
+          <div class="migration-session-summary__label">- Imported:</div>
+          <div class="migration-session-summary__value">- {props.summary.imported.length} sessions</div>
+        </div>
+        <div class="migration-session-summary__section">
+          <div class="migration-session-summary__label">- Skipped: (Session was already imported)</div>
+          <div class="migration-session-summary__value">- {props.summary.skipped.length} sessions</div>
+        </div>
+        <div class="migration-session-summary__section">
+          <div class="migration-session-summary__label">- Errored:</div>
+          <div class="migration-session-summary__value">- {props.summary.errored.length} sessions</div>
+        </div>
+        <div class="migration-session-summary__section">
+          <div class="migration-session-summary__label">- LastError:</div>
+          <div class="migration-session-summary__value">- {props.summary.lastError || "None"}</div>
+        </div>
+      </div>
+    </SessionMigrationCard>
+  )
+}
+
+export default SessionMigrationSummary

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -23,7 +23,7 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
   }
 
   const handleCopy = async () => {
-    const text = report(props.summary)
+    const text = report(language, props.summary)
     if (!text) return
     await navigator.clipboard.writeText(text)
     showToast({ variant: "success", title: language.t("migration.sessionSummary.toast.copied") })
@@ -62,21 +62,23 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
           </button>
         </div>
         <div class="migration-session-summary__section">
-          <div class="migration-session-summary__label">{label("Successful", props.summary.imported.length)}</div>
+          <div class="migration-session-summary__label">{label(language.t("migration.sessionSummary.successful"), props.summary.imported.length)}</div>
           <div class="migration-session-summary__list migration-session-summary__list--success">
             <For each={props.summary.imported.length > 0 ? props.summary.imported : [undefined]}>
-              {(item) => <div class="migration-session-summary__item">{item ? line(item) : "None"}</div>}
+              {(item) => <div class="migration-session-summary__item">{item ? line(language, item) : language.t("migration.sessionSummary.none")}</div>}
             </For>
           </div>
         </div>
         <Show when={props.summary.skipped.length > 0}>
           <div class="migration-session-summary__section">
-            <div class="migration-session-summary__label">{label("Skipped", props.summary.skipped.length, "Already migrated")}</div>
+            <div class="migration-session-summary__label">
+              {label(language.t("migration.sessionSummary.skipped"), props.summary.skipped.length, language.t("migration.sessionSummary.alreadyMigrated"))}
+            </div>
             <div class="migration-session-summary__list migration-session-summary__list--skipped">
               <For each={props.summary.skipped}>
                 {(item) => (
                   <label class="migration-session-summary__pick">
-                    <span class="migration-session-summary__item">{line(item)}</span>
+                    <span class="migration-session-summary__item">{line(language, item)}</span>
                     <input
                       type="checkbox"
                       checked={all() || selected().includes(item.id)}
@@ -114,9 +116,9 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
         </Show>
         <Show when={props.summary.errored.length > 0}>
           <div class="migration-session-summary__section">
-            <div class="migration-session-summary__label">{label("Errored", props.summary.errored.length)}</div>
+            <div class="migration-session-summary__label">{label(language.t("migration.sessionSummary.errored"), props.summary.errored.length)}</div>
             <div class="migration-session-summary__list migration-session-summary__list--errored">
-              <For each={errored(props.summary)}>
+              <For each={errored(language, props.summary)}>
                 {(item) =>
                   item.kind === "detail" ? (
                     <div class="migration-session-summary__detail">{item.text}</div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -3,7 +3,7 @@ import { For } from "solid-js"
 import SessionMigrationCard from "./SessionMigrationCard"
 import type { SessionSummaryState } from "./session-migration-summary-state"
 import { showToast } from "@kilocode/kilo-ui/toast"
-import { errors, line, report } from "./session-migration-summary-format"
+import { detail, line, report } from "./session-migration-summary-format"
 
 interface SessionMigrationSummaryProps {
   summary: SessionSummaryState
@@ -46,15 +46,16 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
           <div class="migration-session-summary__label">- Errored</div>
           <div class="migration-session-summary__list migration-session-summary__list--errored">
             <For each={props.summary.errored.length > 0 ? props.summary.errored : [undefined]}>
-              {(item) => <div class="migration-session-summary__item">{item ? line(item) : "None"}</div>}
-            </For>
-          </div>
-        </div>
-        <div class="migration-session-summary__section">
-          <div class="migration-session-summary__label">- Errors</div>
-          <div class="migration-session-summary__list migration-session-summary__list--errored">
-            <For each={errors(props.summary).length > 0 ? errors(props.summary) : ["None"]}>
-              {(item) => <div class="migration-session-summary__item">{item === "None" ? item : `- ${item}`}</div>}
+              {(item) =>
+                item ? (
+                  <div class="migration-session-summary__entry">
+                    <div class="migration-session-summary__item">{line(item)}</div>
+                    <div class="migration-session-summary__detail">{detail(item)}</div>
+                  </div>
+                ) : (
+                  <div class="migration-session-summary__item">None</div>
+                )
+              }
             </For>
           </div>
         </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -1,17 +1,20 @@
 import type { Component } from "solid-js"
+import { For } from "solid-js"
 import SessionMigrationCard from "./SessionMigrationCard"
 import type { SessionSummaryState } from "./session-migration-summary-state"
 import { showToast } from "@kilocode/kilo-ui/toast"
+import { copy as formatCopy, errors, line } from "./session-migration-summary-format"
 
 interface SessionMigrationSummaryProps {
   summary: SessionSummaryState
 }
 
 const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props) => {
-  const copy = async () => {
-    if (!props.summary.lastErrorRaw) return
-    await navigator.clipboard.writeText(props.summary.lastErrorRaw)
-    showToast({ variant: "success", title: "Copied error" })
+  const handleCopy = async () => {
+    const text = formatCopy(props.summary)
+    if (!text) return
+    await navigator.clipboard.writeText(text)
+    showToast({ variant: "success", title: "Copied errors" })
   }
 
   return (
@@ -19,27 +22,35 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
       <div class="migration-session-summary">
         <div class="migration-session-summary__title">Summary:</div>
         <div class="migration-session-summary__section">
-          <div class="migration-session-summary__label">- Imported:</div>
-          <div class="migration-session-summary__value">- {props.summary.imported.length} sessions</div>
+          <div class="migration-session-summary__label">- Successful</div>
+          <div class="migration-session-summary__list">
+            <For each={props.summary.imported}>{(item) => <div class="migration-session-summary__item">{line(item)}</div>}</For>
+          </div>
         </div>
         <div class="migration-session-summary__section">
-          <div class="migration-session-summary__label">- Skipped: (Session was already imported)</div>
-          <div class="migration-session-summary__value">- {props.summary.skipped.length} sessions</div>
+          <div class="migration-session-summary__label">- Skipped</div>
+          <div class="migration-session-summary__list">
+            <For each={props.summary.skipped}>{(item) => <div class="migration-session-summary__item">{line(item)}</div>}</For>
+          </div>
         </div>
         <div class="migration-session-summary__section">
-          <div class="migration-session-summary__label">- Errored:</div>
-          <div class="migration-session-summary__value">- {props.summary.errored.length} sessions</div>
+          <div class="migration-session-summary__label">- Errored</div>
+          <div class="migration-session-summary__list">
+            <For each={props.summary.errored}>{(item) => <div class="migration-session-summary__item">{line(item)}</div>}</For>
+          </div>
         </div>
         <div class="migration-session-summary__section">
           <div class="migration-session-summary__row">
-            <div class="migration-session-summary__label">- LastError:</div>
-            {props.summary.lastErrorRaw && (
-              <button type="button" class="migration-wizard__copy-btn" onClick={() => void copy()}>
+            <div class="migration-session-summary__label">- Errors</div>
+            {props.summary.errored.length > 0 && (
+              <button type="button" class="migration-wizard__copy-btn" onClick={() => void handleCopy()}>
                 Copy
               </button>
             )}
           </div>
-          <div class="migration-session-summary__value">- {props.summary.lastError || "None"}</div>
+          <div class="migration-session-summary__list">
+            <For each={errors(props.summary)}>{(item) => <div class="migration-session-summary__item">- {item}</div>}</For>
+          </div>
         </div>
       </div>
     </SessionMigrationCard>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -28,26 +28,34 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
         </div>
         <div class="migration-session-summary__section">
           <div class="migration-session-summary__label">- Successful</div>
-          <div class="migration-session-summary__list">
-            <For each={props.summary.imported}>{(item) => <div class="migration-session-summary__item">{line(item)}</div>}</For>
+          <div class="migration-session-summary__list migration-session-summary__list--success">
+            <For each={props.summary.imported.length > 0 ? props.summary.imported : [undefined]}>
+              {(item) => <div class="migration-session-summary__item">{item ? line(item) : "None"}</div>}
+            </For>
           </div>
         </div>
         <div class="migration-session-summary__section">
           <div class="migration-session-summary__label">- Skipped</div>
-          <div class="migration-session-summary__list">
-            <For each={props.summary.skipped}>{(item) => <div class="migration-session-summary__item">{line(item)}</div>}</For>
+          <div class="migration-session-summary__list migration-session-summary__list--skipped">
+            <For each={props.summary.skipped.length > 0 ? props.summary.skipped : [undefined]}>
+              {(item) => <div class="migration-session-summary__item">{item ? line(item) : "None"}</div>}
+            </For>
           </div>
         </div>
         <div class="migration-session-summary__section">
           <div class="migration-session-summary__label">- Errored</div>
-          <div class="migration-session-summary__list">
-            <For each={props.summary.errored}>{(item) => <div class="migration-session-summary__item">{line(item)}</div>}</For>
+          <div class="migration-session-summary__list migration-session-summary__list--errored">
+            <For each={props.summary.errored.length > 0 ? props.summary.errored : [undefined]}>
+              {(item) => <div class="migration-session-summary__item">{item ? line(item) : "None"}</div>}
+            </For>
           </div>
         </div>
         <div class="migration-session-summary__section">
           <div class="migration-session-summary__label">- Errors</div>
-          <div class="migration-session-summary__list">
-            <For each={errors(props.summary)}>{(item) => <div class="migration-session-summary__item">- {item}</div>}</For>
+          <div class="migration-session-summary__list migration-session-summary__list--errored">
+            <For each={errors(props.summary).length > 0 ? errors(props.summary) : ["None"]}>
+              {(item) => <div class="migration-session-summary__item">{item === "None" ? item : `- ${item}`}</div>}
+            </For>
           </div>
         </div>
       </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -1,12 +1,19 @@
 import type { Component } from "solid-js"
 import SessionMigrationCard from "./SessionMigrationCard"
 import type { SessionSummaryState } from "./session-migration-summary-state"
+import { showToast } from "@kilocode/kilo-ui/toast"
 
 interface SessionMigrationSummaryProps {
   summary: SessionSummaryState
 }
 
 const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props) => {
+  const copy = async () => {
+    if (!props.summary.lastErrorRaw) return
+    await navigator.clipboard.writeText(props.summary.lastErrorRaw)
+    showToast({ variant: "success", title: "Copied error" })
+  }
+
   return (
     <SessionMigrationCard>
       <div class="migration-session-summary">
@@ -24,7 +31,14 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
           <div class="migration-session-summary__value">- {props.summary.errored.length} sessions</div>
         </div>
         <div class="migration-session-summary__section">
-          <div class="migration-session-summary__label">- LastError:</div>
+          <div class="migration-session-summary__row">
+            <div class="migration-session-summary__label">- LastError:</div>
+            {props.summary.lastErrorRaw && (
+              <button type="button" class="migration-wizard__copy-btn" onClick={() => void copy()}>
+                Copy
+              </button>
+            )}
+          </div>
           <div class="migration-session-summary__value">- {props.summary.lastError || "None"}</div>
         </div>
       </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -1,15 +1,20 @@
 import type { Component } from "solid-js"
-import { For } from "solid-js"
+import { For, Show, createMemo, createSignal } from "solid-js"
 import SessionMigrationCard from "./SessionMigrationCard"
 import type { SessionSummaryState } from "./session-migration-summary-state"
 import { showToast } from "@kilocode/kilo-ui/toast"
 import { errored, line, report } from "./session-migration-summary-format"
+import { useVSCode } from "../../context/vscode"
 
 interface SessionMigrationSummaryProps {
   summary: SessionSummaryState
 }
 
 const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props) => {
+  const vscode = useVSCode()
+  const [all, setAll] = createSignal(false)
+  const [selected, setSelected] = createSignal<string[]>([])
+
   const label = (name: string, count: number, desc?: string) => {
     const suffix = count > 0 ? ` (${count})` : ""
     const extra = desc ? ` - ${desc}` : ""
@@ -21,6 +26,51 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
     if (!text) return
     await navigator.clipboard.writeText(text)
     showToast({ variant: "success", title: "Copied report" })
+  }
+
+  const skipped = createMemo(() => props.summary.skipped)
+  const ids = createMemo(() => skipped().map((item) => item.id))
+  const picked = createMemo(() => (all() ? ids() : selected()))
+
+  const toggle = (id: string, next: boolean) => {
+    setAll(false)
+    setSelected((prev) => (next ? [...prev.filter((item) => item !== id), id] : prev.filter((item) => item !== id)))
+  }
+
+  const handleAll = (next: boolean) => {
+    setAll(next)
+    if (next) {
+      setSelected([])
+      return
+    }
+  }
+
+  const handleForce = () => {
+    const list = picked()
+    if (list.length === 0) return
+    vscode.postMessage({
+      type: "startLegacyMigration",
+      selections: {
+        providers: [],
+        mcpServers: [],
+        customModes: [],
+        sessions: list.map((id) => ({ id, force: true })),
+        defaultModel: false,
+        settings: {
+          autoApproval: {
+            commandRules: false,
+            readPermission: false,
+            writePermission: false,
+            executePermission: false,
+            mcpPermission: false,
+            taskPermission: false,
+          },
+          language: false,
+          autocomplete: false,
+        },
+      },
+    })
+    showToast({ variant: "success", title: "Force re-import started" })
   }
 
   return (
@@ -44,9 +94,48 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
           <div class="migration-session-summary__label">{label("Skipped", props.summary.skipped.length, "Already migrated")}</div>
           <div class="migration-session-summary__list migration-session-summary__list--skipped">
             <For each={props.summary.skipped.length > 0 ? props.summary.skipped : [undefined]}>
-              {(item) => <div class="migration-session-summary__item">{item ? line(item) : "None"}</div>}
+              {(item) =>
+                item ? (
+                  <label class="migration-session-summary__pick">
+                    <span class="migration-session-summary__item">{line(item)}</span>
+                    <input
+                      type="checkbox"
+                      checked={all() || selected().includes(item.id)}
+                      onChange={(event) => toggle(item.id, event.currentTarget.checked)}
+                    />
+                    <span class="migration-session-summary__pick-mark">
+                      <svg viewBox="0 0 12 12" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="2.5 6 5 8.5 9.5 3.5" />
+                      </svg>
+                    </span>
+                  </label>
+                ) : (
+                  <div class="migration-session-summary__item">None</div>
+                )
+              }
             </For>
           </div>
+          <Show when={props.summary.skipped.length > 0}>
+            <div class="migration-session-summary__actions">
+              <button
+                type="button"
+                class="migration-wizard__copy-btn"
+                disabled={picked().length === 0}
+                onClick={() => handleForce()}
+              >
+                Force Re-import
+              </button>
+              <label class="migration-session-summary__all">
+                <span>Re-import all</span>
+                <input type="checkbox" checked={all()} onChange={(event) => handleAll(event.currentTarget.checked)} />
+                <span class="migration-session-summary__pick-mark migration-session-summary__pick-mark--all">
+                  <svg viewBox="0 0 12 12" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="2.5 6 5 8.5 9.5 3.5" />
+                  </svg>
+                </span>
+              </label>
+            </div>
+          </Show>
         </div>
         <div class="migration-session-summary__section">
           <div class="migration-session-summary__label">{label("Errored", props.summary.errored.length)}</div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -95,14 +95,6 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
           </div>
           <Show when={props.summary.skipped.length > 0}>
             <div class="migration-session-summary__actions">
-              <button
-                type="button"
-                class="migration-wizard__copy-btn"
-                disabled={picked().length === 0}
-                onClick={() => handleForce()}
-              >
-                Force Re-import
-              </button>
               <label class="migration-session-summary__all">
                 <span>Re-import all</span>
                 <input type="checkbox" checked={all()} onChange={(event) => handleAll(event.currentTarget.checked)} />
@@ -112,6 +104,14 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
                   </svg>
                 </span>
               </label>
+              <button
+                type="button"
+                class="migration-wizard__copy-btn"
+                disabled={picked().length === 0}
+                onClick={() => handleForce()}
+              >
+                Force Re-import
+              </button>
             </div>
           </Show>
         </div>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/SessionMigrationSummary.tsx
@@ -50,7 +50,6 @@ const SessionMigrationSummary: Component<SessionMigrationSummaryProps> = (props)
     const list = picked()
     if (list.length === 0) return
     props.onForce(list)
-    showToast({ variant: "success", title: language.t("migration.forceReimport.toast.started") })
   }
 
   return (

--- a/packages/kilo-vscode/webview-ui/src/components/migration/index.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/index.ts
@@ -3,3 +3,4 @@
  * Delete this entire directory when dropping legacy migration support.
  */
 export { default as MigrationWizard } from "./MigrationWizard"
+export { default as SessionMigrationProgress } from "./SessionMigrationProgress"

--- a/packages/kilo-vscode/webview-ui/src/components/migration/index.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/index.ts
@@ -3,4 +3,6 @@
  * Delete this entire directory when dropping legacy migration support.
  */
 export { default as MigrationWizard } from "./MigrationWizard"
+export { default as SessionMigrationCard } from "./SessionMigrationCard"
 export { default as SessionMigrationProgress } from "./SessionMigrationProgress"
+export { default as SessionMigrationSummary } from "./SessionMigrationSummary"

--- a/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
@@ -396,6 +396,22 @@
   background: color-mix(in srgb, var(--vscode-editor-background) 92%, white 8%);
 }
 
+.migration-session-summary__entry {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.migration-session-summary__detail {
+  margin-left: 14px;
+  font-size: 10px;
+  line-height: 1.4;
+  color: color-mix(in srgb, var(--vscode-descriptionForeground) 88%, white 12%);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .migration-session-summary__list--success {
   border-color: color-mix(in srgb, var(--vscode-testing-iconPassed, #34c759) 45%, var(--vscode-panel-border) 55%);
 }

--- a/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
@@ -345,7 +345,7 @@
 
 .migration-session-progress {
   margin-top: 12px;
-  padding: 12px 14px;
+  padding: 12px;
   border: 1px solid var(--vscode-panel-border);
   border-radius: 12px;
   background: color-mix(in srgb, var(--vscode-editor-background) 94%, var(--vscode-button-background) 6%);
@@ -356,29 +356,59 @@
   font-weight: 700;
   line-height: 1.4;
   color: var(--vscode-foreground);
+  white-space: nowrap;
 }
 
 .migration-session-progress__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
   margin-top: 4px;
   font-size: 11px;
   line-height: 1.45;
   color: var(--vscode-descriptionForeground);
-  white-space: nowrap;
+}
+
+.migration-session-progress__meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.migration-session-progress__directory {
+  width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.migration-session-progress__title {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.migration-session-progress__date {
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .migration-session-progress__steps {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-top: 12px;
+  gap: 6px;
+  margin-top: 10px;
 }
 
 .migration-session-progress__step {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
 .migration-session-progress__dot {
@@ -404,10 +434,14 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 8px;
   font-size: 12px;
   line-height: 1.4;
   color: var(--vscode-foreground);
+}
+
+.migration-session-progress__step-text span:first-child {
+  white-space: nowrap;
 }
 
 .migration-session-progress__count {

--- a/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
@@ -374,9 +374,13 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
-  max-height: calc(1.45em * 3 + 8px);
+  max-height: calc(1.45em * 4 + 12px);
   overflow: auto;
   padding-right: 4px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--vscode-editor-background) 96%, white 4%);
+  padding: 6px;
 }
 
 .migration-session-summary__item {
@@ -387,6 +391,21 @@
   overflow: hidden;
   text-overflow: ellipsis;
   min-height: 1.45em;
+  padding: 2px 4px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--vscode-editor-background) 92%, white 8%);
+}
+
+.migration-session-summary__list--success {
+  border-color: color-mix(in srgb, var(--vscode-testing-iconPassed, #34c759) 45%, var(--vscode-panel-border) 55%);
+}
+
+.migration-session-summary__list--skipped {
+  border-color: color-mix(in srgb, var(--vscode-testing-iconQueued, #d7ba7d) 55%, var(--vscode-panel-border) 45%);
+}
+
+.migration-session-summary__list--errored {
+  border-color: color-mix(in srgb, var(--vscode-errorForeground) 55%, var(--vscode-panel-border) 45%);
 }
 
 .migration-session-summary__row {

--- a/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
@@ -370,6 +370,25 @@
   gap: 2px;
 }
 
+.migration-session-summary__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: calc(1.45em * 3 + 8px);
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.migration-session-summary__item {
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--vscode-descriptionForeground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-height: 1.45em;
+}
+
 .migration-session-summary__row {
   display: flex;
   align-items: center;

--- a/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
@@ -424,6 +424,103 @@
   border-color: color-mix(in srgb, var(--vscode-testing-iconQueued, #d7ba7d) 55%, var(--vscode-panel-border) 45%);
 }
 
+.migration-session-summary__pick {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 1.45em;
+  padding: 0 8px;
+  cursor: pointer;
+  position: relative;
+}
+
+.migration-session-summary__pick input {
+  position: absolute;
+  opacity: 0;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  pointer-events: none;
+  right: 8px;
+}
+
+.migration-session-summary__pick-mark {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1px solid color-mix(in srgb, var(--vscode-foreground) 34%, transparent);
+  background: color-mix(in srgb, var(--vscode-editor-background) 88%, white 12%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: all 0.15s;
+}
+
+.migration-session-summary__pick-mark svg {
+  width: 10px;
+  height: 10px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.migration-session-summary__pick input:checked + .migration-session-summary__pick-mark {
+  border-color: color-mix(in srgb, var(--vscode-foreground) 46%, transparent);
+}
+
+.migration-session-summary__pick input:checked + .migration-session-summary__pick-mark svg {
+  opacity: 1;
+}
+
+.migration-session-summary__pick .migration-session-summary__item {
+  padding: 0;
+  flex: 1;
+  min-width: 0;
+}
+
+.migration-session-summary__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.migration-session-summary__all {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  position: relative;
+  cursor: pointer;
+  min-width: 140px;
+}
+
+.migration-session-summary__all input {
+  position: absolute;
+  opacity: 0;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  pointer-events: none;
+  right: 0;
+}
+
+.migration-session-summary__all input:checked + .migration-session-summary__pick-mark {
+  border-color: color-mix(in srgb, var(--vscode-foreground) 46%, transparent);
+}
+
+.migration-session-summary__all input:checked + .migration-session-summary__pick-mark svg {
+  opacity: 1;
+}
+
+.migration-session-summary__pick-mark--all {
+  margin-left: auto;
+}
+
 .migration-session-summary__list--errored {
   border-color: color-mix(in srgb, var(--vscode-errorForeground) 55%, var(--vscode-panel-border) 45%);
 }

--- a/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
@@ -343,12 +343,44 @@
   word-break: break-word;
 }
 
-.migration-session-progress {
+.migration-session-card {
   margin-top: 12px;
   padding: 12px;
   border: 1px solid var(--vscode-panel-border);
   border-radius: 12px;
   background: color-mix(in srgb, var(--vscode-editor-background) 94%, var(--vscode-button-background) 6%);
+}
+
+.migration-session-summary__title {
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.4;
+  color: var(--vscode-foreground);
+}
+
+.migration-session-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.migration-session-summary__section {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.migration-session-summary__label,
+.migration-session-summary__value {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--vscode-foreground);
+}
+
+.migration-session-summary__value {
+  color: var(--vscode-descriptionForeground);
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .migration-session-progress__header {

--- a/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
@@ -343,6 +343,79 @@
   word-break: break-word;
 }
 
+.migration-session-progress {
+  margin-top: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--vscode-editor-background) 94%, var(--vscode-button-background) 6%);
+}
+
+.migration-session-progress__header {
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.4;
+  color: var(--vscode-foreground);
+}
+
+.migration-session-progress__meta {
+  margin-top: 4px;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--vscode-descriptionForeground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.migration-session-progress__steps {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.migration-session-progress__step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.migration-session-progress__dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  flex-shrink: 0;
+  background: color-mix(in srgb, var(--vscode-foreground) 16%, transparent);
+}
+
+.migration-session-progress__dot--active {
+  background: var(--vscode-button-background);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--vscode-button-background) 18%, transparent);
+}
+
+.migration-session-progress__dot--success {
+  background: var(--vscode-testing-iconPassed, #34c759);
+}
+
+.migration-session-progress__step-text {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--vscode-foreground);
+}
+
+.migration-session-progress__count {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+}
+
 .migration-wizard__copy-btn {
   appearance: none;
   border: 1px solid var(--vscode-panel-border);

--- a/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
@@ -482,7 +482,7 @@
 .migration-session-summary__actions {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 12px;
   margin-top: 8px;
 }
@@ -490,13 +490,12 @@
 .migration-session-summary__all {
   display: inline-flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 10px;
   font-size: 11px;
   color: var(--vscode-descriptionForeground);
   position: relative;
   cursor: pointer;
-  min-width: 140px;
 }
 
 .migration-session-summary__all input {

--- a/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
@@ -374,7 +374,7 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  max-height: calc(1.45em * 4 + 12px);
+  max-height: calc(1.7em * 4 + 18px);
   overflow: auto;
   padding-right: 2px;
   border: 1px solid var(--vscode-panel-border);
@@ -384,14 +384,14 @@
 }
 
 .migration-session-summary__item {
-  font-size: 12px;
-  line-height: 1.45;
+  font-size: 13px;
+  line-height: 1.7;
   color: var(--vscode-descriptionForeground);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  min-height: 1.45em;
-  padding: 0 8px;
+  min-height: 1.7em;
+  padding: 2px 10px;
   border-radius: 0;
   background: transparent;
 }
@@ -406,13 +406,13 @@
 
 .migration-session-summary__detail {
   margin-left: 14px;
-  font-size: 11px;
-  line-height: 1.4;
+  font-size: 12px;
+  line-height: 1.55;
   color: color-mix(in srgb, var(--vscode-descriptionForeground) 88%, white 12%);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  padding: 0 8px 2px 8px;
+  padding: 2px 10px 4px 10px;
   background: transparent;
 }
 
@@ -429,8 +429,8 @@
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  min-height: 1.45em;
-  padding: 0 8px;
+  min-height: 1.7em;
+  padding: 2px 10px;
   cursor: pointer;
   position: relative;
 }

--- a/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
@@ -373,43 +373,47 @@
 .migration-session-summary__list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0;
   max-height: calc(1.45em * 4 + 12px);
   overflow: auto;
-  padding-right: 4px;
+  padding-right: 2px;
   border: 1px solid var(--vscode-panel-border);
   border-radius: 8px;
   background: color-mix(in srgb, var(--vscode-editor-background) 96%, white 4%);
-  padding: 6px;
+  padding: 0;
 }
 
 .migration-session-summary__item {
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1.45;
   color: var(--vscode-descriptionForeground);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   min-height: 1.45em;
-  padding: 2px 4px;
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--vscode-editor-background) 92%, white 8%);
+  padding: 0 8px;
+  border-radius: 0;
+  background: transparent;
 }
 
-.migration-session-summary__entry {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.migration-session-summary__list > :nth-child(odd) {
+  background: color-mix(in srgb, var(--vscode-editor-background) 88%, white 12%);
+}
+
+.migration-session-summary__list > * + * {
+  border-top: 1px solid color-mix(in srgb, var(--vscode-panel-border) 80%, transparent 20%);
 }
 
 .migration-session-summary__detail {
   margin-left: 14px;
-  font-size: 10px;
+  font-size: 11px;
   line-height: 1.4;
   color: color-mix(in srgb, var(--vscode-descriptionForeground) 88%, white 12%);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  padding: 0 8px 2px 8px;
+  background: transparent;
 }
 
 .migration-session-summary__list--success {

--- a/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/migration.css
@@ -370,6 +370,13 @@
   gap: 2px;
 }
 
+.migration-session-summary__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .migration-session-summary__label,
 .migration-session-summary__value {
   font-size: 12px;

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-format.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-format.ts
@@ -1,0 +1,30 @@
+import type { LanguageContextValue } from "../../context/language"
+
+function pad(value: number) {
+  return String(value).padStart(2, "0")
+}
+
+export function formatDate(language: LanguageContextValue, time: number) {
+  if (!time) return language.t("migration.sessionFormat.unknownDate")
+  const value = new Date(time)
+  return `${pad(value.getHours())}:${pad(value.getMinutes())} ${pad(value.getMonth() + 1)}/${pad(value.getDate())}/${value.getFullYear()}`
+}
+
+export function formatPath(language: LanguageContextValue, value: string) {
+  const text = value.trim()
+  if (!text) return language.t("migration.sessionFormat.unknown")
+  const parts = text.split(/[\\/]/).filter(Boolean)
+  const last = parts.at(-1)
+  if (!last) return text
+  return `.../${last}`
+}
+
+export function formatText(language: LanguageContextValue, value: string) {
+  const text = value.trim()
+  return text || language.t("migration.sessionFormat.unknown")
+}
+
+export function formatError(language: LanguageContextValue, value?: string) {
+  if (!value) return language.t("migration.sessionFormat.unknownError")
+  return value.split("\n")[0]?.trim() || value
+}

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
@@ -1,61 +1,46 @@
 import type { SessionSummaryItem, SessionSummaryState } from "./session-migration-summary-state"
+import type { LanguageContextValue } from "../../context/language"
+import { formatDate, formatError, formatPath, formatText } from "./session-migration-format"
 
-function pad(value: number) {
-  return String(value).padStart(2, "0")
+export function line(language: LanguageContextValue, item: SessionSummaryItem) {
+  const dir = formatPath(language, item.directory)
+  const title = formatText(language, item.title)
+  return `${dir} ${title} ${formatDate(language, item.time)}`
 }
 
-function date(time: number) {
-  if (!time) return "Unknown date"
-  const value = new Date(time)
-  return `${pad(value.getHours())}:${pad(value.getMinutes())} ${pad(value.getMonth() + 1)}/${pad(value.getDate())}/${value.getFullYear()}`
+export function short(language: LanguageContextValue, error?: string) {
+  return formatError(language, error)
 }
 
-function path(value: string) {
-  const text = value.trim()
-  if (!text) return "Unknown"
-  const parts = text.split(/[\\/]/).filter(Boolean)
-  const last = parts.at(-1)
-  if (!last) return text
-  return `.../${last}`
+export function detail(language: LanguageContextValue, item: SessionSummaryItem) {
+  return short(language, item.error)
 }
 
-export function line(item: SessionSummaryItem) {
-  const dir = path(item.directory)
-  const title = item.title.trim() || "Unknown"
-  return `${dir} ${title} ${date(item.time)}`
-}
-
-export function short(error?: string) {
-  if (!error) return "Unknown error"
-  return error.split("\n")[0]?.trim() || error
-}
-
-export function detail(item: SessionSummaryItem) {
-  return short(item.error)
-}
-
-export function errored(summary: SessionSummaryState) {
-  if (summary.errored.length === 0) return [{ kind: "row", text: "None" }]
+export function errored(language: LanguageContextValue, summary: SessionSummaryState) {
+  if (summary.errored.length === 0) return [{ kind: "row", text: language.t("migration.sessionSummary.none") }]
   return summary.errored.flatMap((item) => [
-    { kind: "row", text: line(item) },
-    { kind: "detail", text: detail(item) },
+    { kind: "row", text: line(language, item) },
+    { kind: "detail", text: detail(language, item) },
   ])
 }
 
-export function report(summary: SessionSummaryState) {
+export function report(language: LanguageContextValue, summary: SessionSummaryState) {
   const block = (title: string, items: SessionSummaryItem[], full?: boolean) => {
-    const rows = items.length > 0 ? items.map((item) => (full ? `${line(item)}\n  ${short(item.error)}` : line(item))).join("\n") : "None"
+    const rows =
+      items.length > 0
+        ? items.map((item) => (full ? `${line(language, item)}\n  ${short(language, item.error)}` : line(language, item))).join("\n")
+        : language.t("migration.sessionSummary.none")
     return `${title}\n${rows}`
   }
 
   return [
-    "Summary:",
+    language.t("migration.sessionSummary.title"),
     "",
-    block("Successful", summary.imported),
+    block(language.t("migration.sessionSummary.successful"), summary.imported),
     "",
-    block("Skipped", summary.skipped),
+    block(language.t("migration.sessionSummary.skipped"), summary.skipped),
     "",
-    block("Errored", summary.errored, true),
+    block(language.t("migration.sessionSummary.errored"), summary.errored, true),
   ]
     .filter(Boolean)
     .join("\n")

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
@@ -22,7 +22,10 @@ export function short(error?: string) {
 }
 
 export function errors(summary: SessionSummaryState) {
-  return summary.errored.map((item, index) => `Error ${index + 1}: ${short(item.error)}`)
+  return summary.errored.map(
+    (item, index) =>
+      [`Error ${index + 1}`, `id: ${item.id}`, `directory: ${item.directory}`, `title: ${item.title}`, `date: ${date(item.time)}`, "", item.error || "Unknown error"].join("\n"),
+  )
 }
 
 export function copy(summary: SessionSummaryState) {
@@ -32,4 +35,27 @@ export function copy(summary: SessionSummaryState) {
         [`Error ${index + 1}`, `id: ${item.id}`, `directory: ${item.directory}`, `title: ${item.title}`, `date: ${date(item.time)}`, "", item.error || "Unknown error"].join("\n"),
     )
     .join("\n\n")
+}
+
+export function report(summary: SessionSummaryState) {
+  const block = (title: string, items: SessionSummaryItem[]) => {
+    const rows = items.length > 0 ? items.map((item) => line(item)).join("\n") : "None"
+    return `${title}\n${rows}`
+  }
+
+  const errs = errors(summary).length > 0 ? errors(summary).join("\n\n") : "None"
+
+  return [
+    "Summary:",
+    "",
+    block("Successful", summary.imported),
+    "",
+    block("Skipped", summary.skipped),
+    "",
+    block("Errored", summary.errored),
+    "",
+    `Errors\n${errs}`,
+  ]
+    .filter(Boolean)
+    .join("\n")
 }

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
@@ -34,6 +34,14 @@ export function detail(item: SessionSummaryItem) {
   return short(item.error)
 }
 
+export function errored(summary: SessionSummaryState) {
+  if (summary.errored.length === 0) return [{ kind: "row", text: "None" }]
+  return summary.errored.flatMap((item) => [
+    { kind: "row", text: line(item) },
+    { kind: "detail", text: detail(item) },
+  ])
+}
+
 export function errors(summary: SessionSummaryState) {
   return summary.errored.map(
     (item, index) =>

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
@@ -28,7 +28,9 @@ export function report(language: LanguageContextValue, summary: SessionSummarySt
   const block = (title: string, items: SessionSummaryItem[], full?: boolean) => {
     const rows =
       items.length > 0
-        ? items.map((item) => (full ? `${line(language, item)}\n  ${short(language, item.error)}` : line(language, item))).join("\n")
+        ? items
+            .map((item) => (full ? `${line(language, item)}\n  ${short(language, item.error)}` : line(language, item)))
+            .join("\n")
         : language.t("migration.sessionSummary.none")
     return `${title}\n${rows}`
   }

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
@@ -1,0 +1,35 @@
+import type { SessionSummaryItem, SessionSummaryState } from "./session-migration-summary-state"
+
+function pad(value: number) {
+  return String(value).padStart(2, "0")
+}
+
+function date(time: number) {
+  if (!time) return "Unknown date"
+  const value = new Date(time)
+  return `${pad(value.getHours())}:${pad(value.getMinutes())} ${pad(value.getMonth() + 1)}/${pad(value.getDate())}/${value.getFullYear()}`
+}
+
+export function line(item: SessionSummaryItem) {
+  const dir = item.directory.trim() || "Unknown"
+  const title = item.title.trim() || "Unknown"
+  return `${dir} ${title} ${date(item.time)}`
+}
+
+export function short(error?: string) {
+  if (!error) return "Unknown error"
+  return error.split("\n")[0]?.trim() || error
+}
+
+export function errors(summary: SessionSummaryState) {
+  return summary.errored.map((item, index) => `Error ${index + 1}: ${short(item.error)}`)
+}
+
+export function copy(summary: SessionSummaryState) {
+  return summary.errored
+    .map(
+      (item, index) =>
+        [`Error ${index + 1}`, `id: ${item.id}`, `directory: ${item.directory}`, `title: ${item.title}`, `date: ${date(item.time)}`, "", item.error || "Unknown error"].join("\n"),
+    )
+    .join("\n\n")
+}

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
@@ -42,22 +42,6 @@ export function errored(summary: SessionSummaryState) {
   ])
 }
 
-export function errors(summary: SessionSummaryState) {
-  return summary.errored.map(
-    (item, index) =>
-      [`Error ${index + 1}`, `id: ${item.id}`, `directory: ${item.directory}`, `title: ${item.title}`, `date: ${date(item.time)}`, "", item.error || "Unknown error"].join("\n"),
-  )
-}
-
-export function copy(summary: SessionSummaryState) {
-  return summary.errored
-    .map(
-      (item, index) =>
-        [`Error ${index + 1}`, `id: ${item.id}`, `directory: ${item.directory}`, `title: ${item.title}`, `date: ${date(item.time)}`, "", item.error || "Unknown error"].join("\n"),
-    )
-    .join("\n\n")
-}
-
 export function report(summary: SessionSummaryState) {
   const block = (title: string, items: SessionSummaryItem[], full?: boolean) => {
     const rows = items.length > 0 ? items.map((item) => (full ? `${line(item)}\n  ${short(item.error)}` : line(item))).join("\n") : "None"

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
@@ -10,8 +10,17 @@ function date(time: number) {
   return `${pad(value.getHours())}:${pad(value.getMinutes())} ${pad(value.getMonth() + 1)}/${pad(value.getDate())}/${value.getFullYear()}`
 }
 
+function path(value: string) {
+  const text = value.trim()
+  if (!text) return "Unknown"
+  const parts = text.split(/[\\/]/).filter(Boolean)
+  const last = parts.at(-1)
+  if (!last) return text
+  return `.../${last}`
+}
+
 export function line(item: SessionSummaryItem) {
-  const dir = item.directory.trim() || "Unknown"
+  const dir = path(item.directory)
   const title = item.title.trim() || "Unknown"
   return `${dir} ${title} ${date(item.time)}`
 }

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-format.ts
@@ -30,6 +30,10 @@ export function short(error?: string) {
   return error.split("\n")[0]?.trim() || error
 }
 
+export function detail(item: SessionSummaryItem) {
+  return short(item.error)
+}
+
 export function errors(summary: SessionSummaryState) {
   return summary.errored.map(
     (item, index) =>
@@ -47,12 +51,10 @@ export function copy(summary: SessionSummaryState) {
 }
 
 export function report(summary: SessionSummaryState) {
-  const block = (title: string, items: SessionSummaryItem[]) => {
-    const rows = items.length > 0 ? items.map((item) => line(item)).join("\n") : "None"
+  const block = (title: string, items: SessionSummaryItem[], full?: boolean) => {
+    const rows = items.length > 0 ? items.map((item) => (full ? `${line(item)}\n  ${short(item.error)}` : line(item))).join("\n") : "None"
     return `${title}\n${rows}`
   }
-
-  const errs = errors(summary).length > 0 ? errors(summary).join("\n\n") : "None"
 
   return [
     "Summary:",
@@ -61,9 +63,7 @@ export function report(summary: SessionSummaryState) {
     "",
     block("Skipped", summary.skipped),
     "",
-    block("Errored", summary.errored),
-    "",
-    `Errors\n${errs}`,
+    block("Errored", summary.errored, true),
   ]
     .filter(Boolean)
     .join("\n")

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-state.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-state.ts
@@ -13,6 +13,13 @@ export interface SessionSummaryState {
   skipped: SessionSummaryItem[]
   errored: SessionSummaryItem[]
   lastError?: string
+  lastErrorRaw?: string
+}
+
+function short(error?: string) {
+  if (!error) return undefined
+  const line = error.split("\n")[0]?.trim()
+  return line || error
 }
 
 export function createSessionItem(session: MigrationSessionInfo, error?: string): SessionSummaryItem {
@@ -45,7 +52,8 @@ export function updateSessionSummary(state: SessionSummaryState, item: SessionSu
     return {
       ...state,
       errored: [...state.errored.filter((entry) => entry.id !== item.id), item],
-      lastError: item.error,
+      lastError: short(item.error),
+      lastErrorRaw: item.error,
     }
   }
 

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-state.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-state.ts
@@ -1,0 +1,62 @@
+import type { MigrationSessionInfo } from "../../types/messages"
+
+export interface SessionSummaryItem {
+  id: string
+  title: string
+  directory: string
+  time: number
+  error?: string
+}
+
+export interface SessionSummaryState {
+  imported: SessionSummaryItem[]
+  skipped: SessionSummaryItem[]
+  errored: SessionSummaryItem[]
+  lastError?: string
+}
+
+export function createSessionItem(session: MigrationSessionInfo, error?: string): SessionSummaryItem {
+  return {
+    id: session.id,
+    title: session.title,
+    directory: session.directory,
+    time: session.time,
+    error,
+  }
+}
+
+export function createSessionSummary(): SessionSummaryState {
+  return {
+    imported: [],
+    skipped: [],
+    errored: [],
+  }
+}
+
+export function updateSessionSummary(state: SessionSummaryState, item: SessionSummaryItem, phase: string): SessionSummaryState {
+  if (phase === "skipped") {
+    return {
+      ...state,
+      skipped: [...state.skipped.filter((entry) => entry.id !== item.id), item],
+    }
+  }
+
+  if (phase === "error") {
+    return {
+      ...state,
+      errored: [...state.errored.filter((entry) => entry.id !== item.id), item],
+      lastError: item.error,
+    }
+  }
+
+  if (phase === "done") {
+    const seen = state.skipped.some((entry) => entry.id === item.id) || state.errored.some((entry) => entry.id === item.id)
+    if (seen) return state
+    return {
+      ...state,
+      imported: [...state.imported.filter((entry) => entry.id !== item.id), item],
+    }
+  }
+
+  return state
+}

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-state.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-state.ts
@@ -40,29 +40,41 @@ export function createSessionSummary(): SessionSummaryState {
   }
 }
 
+function strip(state: SessionSummaryState, id: string) {
+  return {
+    imported: state.imported.filter((entry) => entry.id !== id),
+    skipped: state.skipped.filter((entry) => entry.id !== id),
+    errored: state.errored.filter((entry) => entry.id !== id),
+  }
+}
+
 export function updateSessionSummary(state: SessionSummaryState, item: SessionSummaryItem, phase: string): SessionSummaryState {
   if (phase === "skipped") {
+    const next = strip(state, item.id)
     return {
       ...state,
-      skipped: [...state.skipped.filter((entry) => entry.id !== item.id), item],
+      ...next,
+      skipped: [...next.skipped, item],
     }
   }
 
   if (phase === "error") {
+    const next = strip(state, item.id)
     return {
       ...state,
-      errored: [...state.errored.filter((entry) => entry.id !== item.id), item],
+      ...next,
+      errored: [...next.errored, item],
       lastError: short(item.error),
       lastErrorRaw: item.error,
     }
   }
 
   if (phase === "done") {
-    const seen = state.skipped.some((entry) => entry.id === item.id) || state.errored.some((entry) => entry.id === item.id)
-    if (seen) return state
+    const next = strip(state, item.id)
     return {
       ...state,
-      imported: [...state.imported.filter((entry) => entry.id !== item.id), item],
+      ...next,
+      imported: [...next.imported, item],
     }
   }
 

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-state.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-state.ts
@@ -40,7 +40,11 @@ function strip(state: SessionSummaryState, id: string) {
   }
 }
 
-export function updateSessionSummary(state: SessionSummaryState, item: SessionSummaryItem, phase: string): SessionSummaryState {
+export function updateSessionSummary(
+  state: SessionSummaryState,
+  item: SessionSummaryItem,
+  phase: string,
+): SessionSummaryState {
   if (phase === "skipped") {
     const next = strip(state, item.id)
     return {

--- a/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-state.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/migration/session-migration-summary-state.ts
@@ -12,14 +12,6 @@ export interface SessionSummaryState {
   imported: SessionSummaryItem[]
   skipped: SessionSummaryItem[]
   errored: SessionSummaryItem[]
-  lastError?: string
-  lastErrorRaw?: string
-}
-
-function short(error?: string) {
-  if (!error) return undefined
-  const line = error.split("\n")[0]?.trim()
-  return line || error
 }
 
 export function createSessionItem(session: MigrationSessionInfo, error?: string): SessionSummaryItem {
@@ -64,8 +56,6 @@ export function updateSessionSummary(state: SessionSummaryState, item: SessionSu
       ...state,
       ...next,
       errored: [...next.errored, item],
-      lastError: short(item.error),
-      lastErrorRaw: item.error,
     }
   }
 

--- a/packages/kilo-vscode/webview-ui/src/context/language.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/language.tsx
@@ -211,7 +211,7 @@ export const LanguageProvider: ParentComponent<LanguageProviderProps> = (props) 
 // Expose locale + setLocale for the LanguageTab
 import { createContext, useContext } from "solid-js"
 
-interface LanguageContextValue {
+export interface LanguageContextValue {
   locale: Accessor<Locale>
   setLocale: (locale: Locale | "") => void
   userOverride: Accessor<Locale | "">

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1283,6 +1283,24 @@ export const dict = {
   "migration.error.continue": "متابعة",
   "migration.error.action.copy": "نسخ",
   "migration.error.toast.copied": "تم نسخ الخطأ إلى الحافظة",
+
+  "migration.sessionSummary.title": "الملخص:",
+  "migration.sessionSummary.copy": "نسخ التقرير",
+  "migration.sessionSummary.toast.copied": "تم نسخ التقرير",
+  "migration.forceReimport.title": "فرض إعادة الاستيراد",
+  "migration.forceReimport.description":
+    "ستؤدي إعادة استيراد {{target}} إلى استبدالها وحذف أي رسائل جديدة تم إنشاؤها بالفعل في تلك الجلسات.",
+  "migration.forceReimport.target.one": "هذه الجلسة",
+  "migration.forceReimport.target.many": "هذه الجلسات الـ {{count}}",
+  "migration.forceReimport.button": "فرض إعادة الاستيراد",
+  "migration.forceReimport.all": "إعادة استيراد الكل",
+  "migration.forceReimport.proceed": "متابعة",
+  "migration.forceReimport.toast.started": "بدأت إعادة الاستيراد القسرية",
+  "migration.running.title": "الترحيل قيد التنفيذ",
+  "migration.running.description.line1": "أنت على وشك الإنهاء بينما لا تزال هناك جلسات قيد الترحيل.",
+  "migration.running.description.line2": "إذا غادرت الآن، فقد تبقى بعض الجلسات غير مكتملة.",
+  "migration.running.stay": "البقاء",
+  "migration.running.proceed": "متابعة",
   // legacy-migration end
 
   "error.details.show": "التفاصيل",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1287,6 +1287,11 @@ export const dict = {
   "migration.sessionSummary.title": "الملخص:",
   "migration.sessionSummary.copy": "نسخ التقرير",
   "migration.sessionSummary.toast.copied": "تم نسخ التقرير",
+  "migration.sessionSummary.successful": "ناجحة",
+  "migration.sessionSummary.skipped": "تم تخطيها",
+  "migration.sessionSummary.alreadyMigrated": "تم ترحيلها بالفعل",
+  "migration.sessionSummary.errored": "حدثت بها أخطاء",
+  "migration.sessionSummary.none": "لا يوجد",
   "migration.forceReimport.title": "فرض إعادة الاستيراد",
   "migration.forceReimport.description":
     "ستؤدي إعادة استيراد {{target}} إلى استبدالها وحذف أي رسائل جديدة تم إنشاؤها بالفعل في تلك الجلسات.",
@@ -1301,6 +1306,13 @@ export const dict = {
   "migration.running.description.line2": "إذا غادرت الآن، فقد تبقى بعض الجلسات غير مكتملة.",
   "migration.running.stay": "البقاء",
   "migration.running.proceed": "متابعة",
+  "migration.sessionProgress.preparing": "جارٍ تحضير الجلسة",
+  "migration.sessionProgress.storing": "جارٍ حفظ الجلسة",
+  "migration.sessionProgress.skipped": "تم تخطي الجلسة",
+  "migration.sessionProgress.header": "جارٍ ترحيل {{current}} من {{total}}",
+  "migration.sessionFormat.unknownDate": "تاريخ غير معروف",
+  "migration.sessionFormat.unknown": "غير معروف",
+  "migration.sessionFormat.unknownError": "خطأ غير معروف",
   // legacy-migration end
 
   "error.details.show": "التفاصيل",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1312,6 +1312,24 @@ export const dict = {
   "migration.error.continue": "Continuar",
   "migration.error.action.copy": "Copiar",
   "migration.error.toast.copied": "Erro copiado para a área de transferência",
+
+  "migration.sessionSummary.title": "Resumo:",
+  "migration.sessionSummary.copy": "Copiar relatório",
+  "migration.sessionSummary.toast.copied": "Relatório copiado",
+  "migration.forceReimport.title": "Forçar reimportação",
+  "migration.forceReimport.description":
+    "Reimportar {{target}} vai sobrescrevê-los e apagar quaisquer novas mensagens já criadas nessas sessões.",
+  "migration.forceReimport.target.one": "esta sessão",
+  "migration.forceReimport.target.many": "estas {{count}} sessões",
+  "migration.forceReimport.button": "Forçar reimportação",
+  "migration.forceReimport.all": "Reimportar tudo",
+  "migration.forceReimport.proceed": "Prosseguir",
+  "migration.forceReimport.toast.started": "Reimportação forçada iniciada",
+  "migration.running.title": "Migração em andamento",
+  "migration.running.description.line1": "Você está prestes a concluir enquanto ainda há sessões sendo migradas.",
+  "migration.running.description.line2": "Se você sair agora, algumas sessões podem ficar incompletas.",
+  "migration.running.stay": "Ficar",
+  "migration.running.proceed": "Prosseguir",
   // legacy-migration end
 
   "error.details.show": "Detalhes",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1316,6 +1316,11 @@ export const dict = {
   "migration.sessionSummary.title": "Resumo:",
   "migration.sessionSummary.copy": "Copiar relatório",
   "migration.sessionSummary.toast.copied": "Relatório copiado",
+  "migration.sessionSummary.successful": "Bem-sucedidas",
+  "migration.sessionSummary.skipped": "Ignoradas",
+  "migration.sessionSummary.alreadyMigrated": "Já migradas",
+  "migration.sessionSummary.errored": "Com erro",
+  "migration.sessionSummary.none": "Nenhuma",
   "migration.forceReimport.title": "Forçar reimportação",
   "migration.forceReimport.description":
     "Reimportar {{target}} vai sobrescrevê-los e apagar quaisquer novas mensagens já criadas nessas sessões.",
@@ -1330,6 +1335,13 @@ export const dict = {
   "migration.running.description.line2": "Se você sair agora, algumas sessões podem ficar incompletas.",
   "migration.running.stay": "Ficar",
   "migration.running.proceed": "Prosseguir",
+  "migration.sessionProgress.preparing": "Preparando sessão",
+  "migration.sessionProgress.storing": "Salvando sessão",
+  "migration.sessionProgress.skipped": "Sessão ignorada",
+  "migration.sessionProgress.header": "Migrando {{current}} de {{total}}",
+  "migration.sessionFormat.unknownDate": "Data desconhecida",
+  "migration.sessionFormat.unknown": "Desconhecido",
+  "migration.sessionFormat.unknownError": "Erro desconhecido",
   // legacy-migration end
 
   "error.details.show": "Detalhes",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1312,6 +1312,11 @@ export const dict = {
   "migration.sessionSummary.title": "Sažetak:",
   "migration.sessionSummary.copy": "Kopiraj izvještaj",
   "migration.sessionSummary.toast.copied": "Izvještaj kopiran",
+  "migration.sessionSummary.successful": "Uspješne",
+  "migration.sessionSummary.skipped": "Preskočene",
+  "migration.sessionSummary.alreadyMigrated": "Već migrirane",
+  "migration.sessionSummary.errored": "S greškom",
+  "migration.sessionSummary.none": "Nijedna",
   "migration.forceReimport.title": "Prisilni ponovni uvoz",
   "migration.forceReimport.description":
     "Ponovni uvoz {{target}} će ih prepisati i obrisati sve nove poruke koje su već napravljene u tim sesijama.",
@@ -1326,6 +1331,13 @@ export const dict = {
   "migration.running.description.line2": "Ako sada izađete, neke sesije mogu ostati nedovršene.",
   "migration.running.stay": "Ostani",
   "migration.running.proceed": "Nastavi",
+  "migration.sessionProgress.preparing": "Priprema se sesija",
+  "migration.sessionProgress.storing": "Spremanje sesije",
+  "migration.sessionProgress.skipped": "Sesija je preskočena",
+  "migration.sessionProgress.header": "Migrira se {{current}} od {{total}}",
+  "migration.sessionFormat.unknownDate": "Nepoznat datum",
+  "migration.sessionFormat.unknown": "Nepoznato",
+  "migration.sessionFormat.unknownError": "Nepoznata greška",
   // legacy-migration end
 
   "error.details.show": "Detalji",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1308,6 +1308,24 @@ export const dict = {
   "migration.error.continue": "Nastavi",
   "migration.error.action.copy": "Kopiraj",
   "migration.error.toast.copied": "Greška kopirana u međuspremnik",
+
+  "migration.sessionSummary.title": "Sažetak:",
+  "migration.sessionSummary.copy": "Kopiraj izvještaj",
+  "migration.sessionSummary.toast.copied": "Izvještaj kopiran",
+  "migration.forceReimport.title": "Prisilni ponovni uvoz",
+  "migration.forceReimport.description":
+    "Ponovni uvoz {{target}} će ih prepisati i obrisati sve nove poruke koje su već napravljene u tim sesijama.",
+  "migration.forceReimport.target.one": "ovu sesiju",
+  "migration.forceReimport.target.many": "ovih {{count}} sesija",
+  "migration.forceReimport.button": "Prisilni ponovni uvoz",
+  "migration.forceReimport.all": "Ponovo uvezi sve",
+  "migration.forceReimport.proceed": "Nastavi",
+  "migration.forceReimport.toast.started": "Prisilni ponovni uvoz je pokrenut",
+  "migration.running.title": "Migracija je u toku",
+  "migration.running.description.line1": "Upravo ćete završiti dok se neke sesije još uvijek migriraju.",
+  "migration.running.description.line2": "Ako sada izađete, neke sesije mogu ostati nedovršene.",
+  "migration.running.stay": "Ostani",
+  "migration.running.proceed": "Nastavi",
   // legacy-migration end
 
   "error.details.show": "Detalji",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1299,6 +1299,24 @@ export const dict = {
   "migration.error.continue": "Fortsæt",
   "migration.error.action.copy": "Kopiér",
   "migration.error.toast.copied": "Fejl kopieret til udklipsholder",
+
+  "migration.sessionSummary.title": "Opsummering:",
+  "migration.sessionSummary.copy": "Kopiér rapport",
+  "migration.sessionSummary.toast.copied": "Rapport kopieret",
+  "migration.forceReimport.title": "Tving genimport",
+  "migration.forceReimport.description":
+    "Genimport af {{target}} vil overskrive dem og slette alle nye beskeder, der allerede er oprettet i disse sessioner.",
+  "migration.forceReimport.target.one": "denne session",
+  "migration.forceReimport.target.many": "disse {{count}} sessioner",
+  "migration.forceReimport.button": "Tving genimport",
+  "migration.forceReimport.all": "Genimportér alle",
+  "migration.forceReimport.proceed": "Fortsæt",
+  "migration.forceReimport.toast.started": "Tvungen genimport er startet",
+  "migration.running.title": "Migrering i gang",
+  "migration.running.description.line1": "Du er ved at afslutte, mens der stadig er sessioner, som bliver migreret.",
+  "migration.running.description.line2": "Hvis du forlader nu, kan nogle sessioner forblive ufuldstændige.",
+  "migration.running.stay": "Bliv",
+  "migration.running.proceed": "Fortsæt",
   // legacy-migration end
 
   "error.details.show": "Detaljer",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1303,6 +1303,11 @@ export const dict = {
   "migration.sessionSummary.title": "Opsummering:",
   "migration.sessionSummary.copy": "Kopiér rapport",
   "migration.sessionSummary.toast.copied": "Rapport kopieret",
+  "migration.sessionSummary.successful": "Vellykkede",
+  "migration.sessionSummary.skipped": "Sprunget over",
+  "migration.sessionSummary.alreadyMigrated": "Allerede migreret",
+  "migration.sessionSummary.errored": "Med fejl",
+  "migration.sessionSummary.none": "Ingen",
   "migration.forceReimport.title": "Tving genimport",
   "migration.forceReimport.description":
     "Genimport af {{target}} vil overskrive dem og slette alle nye beskeder, der allerede er oprettet i disse sessioner.",
@@ -1317,6 +1322,13 @@ export const dict = {
   "migration.running.description.line2": "Hvis du forlader nu, kan nogle sessioner forblive ufuldstændige.",
   "migration.running.stay": "Bliv",
   "migration.running.proceed": "Fortsæt",
+  "migration.sessionProgress.preparing": "Forbereder session",
+  "migration.sessionProgress.storing": "Gemmer session",
+  "migration.sessionProgress.skipped": "Session sprunget over",
+  "migration.sessionProgress.header": "Migrerer {{current}} af {{total}}",
+  "migration.sessionFormat.unknownDate": "Ukendt dato",
+  "migration.sessionFormat.unknown": "Ukendt",
+  "migration.sessionFormat.unknownError": "Ukendt fejl",
   // legacy-migration end
 
   "error.details.show": "Detaljer",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1330,6 +1330,11 @@ export const dict = {
   "migration.sessionSummary.title": "Zusammenfassung:",
   "migration.sessionSummary.copy": "Bericht kopieren",
   "migration.sessionSummary.toast.copied": "Bericht kopiert",
+  "migration.sessionSummary.successful": "Erfolgreich",
+  "migration.sessionSummary.skipped": "Übersprungen",
+  "migration.sessionSummary.alreadyMigrated": "Bereits migriert",
+  "migration.sessionSummary.errored": "Fehlgeschlagen",
+  "migration.sessionSummary.none": "Keine",
   "migration.forceReimport.title": "Erneuten Import erzwingen",
   "migration.forceReimport.description":
     "Ein erneuter Import von {{target}} überschreibt diese und löscht alle neuen Nachrichten, die in diesen Sitzungen bereits erstellt wurden.",
@@ -1344,6 +1349,13 @@ export const dict = {
   "migration.running.description.line2": "Wenn Sie jetzt gehen, bleiben einige Sitzungen möglicherweise unvollständig.",
   "migration.running.stay": "Bleiben",
   "migration.running.proceed": "Fortfahren",
+  "migration.sessionProgress.preparing": "Sitzung wird vorbereitet",
+  "migration.sessionProgress.storing": "Sitzung wird gespeichert",
+  "migration.sessionProgress.skipped": "Sitzung übersprungen",
+  "migration.sessionProgress.header": "Migriere {{current}} von {{total}}",
+  "migration.sessionFormat.unknownDate": "Unbekanntes Datum",
+  "migration.sessionFormat.unknown": "Unbekannt",
+  "migration.sessionFormat.unknownError": "Unbekannter Fehler",
   // legacy-migration end
 
   "error.details.show": "Details",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1326,6 +1326,24 @@ export const dict = {
   "migration.error.continue": "Weiter",
   "migration.error.action.copy": "Kopieren",
   "migration.error.toast.copied": "Fehler in die Zwischenablage kopiert",
+
+  "migration.sessionSummary.title": "Zusammenfassung:",
+  "migration.sessionSummary.copy": "Bericht kopieren",
+  "migration.sessionSummary.toast.copied": "Bericht kopiert",
+  "migration.forceReimport.title": "Erneuten Import erzwingen",
+  "migration.forceReimport.description":
+    "Ein erneuter Import von {{target}} überschreibt diese und löscht alle neuen Nachrichten, die in diesen Sitzungen bereits erstellt wurden.",
+  "migration.forceReimport.target.one": "diese Sitzung",
+  "migration.forceReimport.target.many": "diese {{count}} Sitzungen",
+  "migration.forceReimport.button": "Erneuten Import erzwingen",
+  "migration.forceReimport.all": "Alle erneut importieren",
+  "migration.forceReimport.proceed": "Fortfahren",
+  "migration.forceReimport.toast.started": "Erneuter Import gestartet",
+  "migration.running.title": "Migration läuft",
+  "migration.running.description.line1": "Sie sind dabei abzuschließen, während noch Sitzungen migriert werden.",
+  "migration.running.description.line2": "Wenn Sie jetzt gehen, bleiben einige Sitzungen möglicherweise unvollständig.",
+  "migration.running.stay": "Bleiben",
+  "migration.running.proceed": "Fortfahren",
   // legacy-migration end
 
   "error.details.show": "Details",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1311,6 +1311,11 @@ export const dict = {
   "migration.sessionSummary.title": "Summary:",
   "migration.sessionSummary.copy": "Copy Report",
   "migration.sessionSummary.toast.copied": "Copied report",
+  "migration.sessionSummary.successful": "Successful",
+  "migration.sessionSummary.skipped": "Skipped",
+  "migration.sessionSummary.alreadyMigrated": "Already migrated",
+  "migration.sessionSummary.errored": "Errored",
+  "migration.sessionSummary.none": "None",
   "migration.forceReimport.title": "Force Re-import",
   "migration.forceReimport.description":
     "Re-importing {{target}} will overwrite them and delete any new messages already made in those sessions.",
@@ -1325,6 +1330,13 @@ export const dict = {
   "migration.running.description.line2": "If you leave now, some sessions may remain incomplete.",
   "migration.running.stay": "Stay",
   "migration.running.proceed": "Proceed",
+  "migration.sessionProgress.preparing": "Preparing session",
+  "migration.sessionProgress.storing": "Storing session",
+  "migration.sessionProgress.skipped": "Session skipped",
+  "migration.sessionProgress.header": "Migrating {{current}} of {{total}}",
+  "migration.sessionFormat.unknownDate": "Unknown date",
+  "migration.sessionFormat.unknown": "Unknown",
+  "migration.sessionFormat.unknownError": "Unknown error",
   // legacy-migration end
 
   "error.details.show": "Details",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1308,6 +1308,23 @@ export const dict = {
   "migration.error.continue": "Continue",
   "migration.error.action.copy": "Copy",
   "migration.error.toast.copied": "Error copied to clipboard",
+  "migration.sessionSummary.title": "Summary:",
+  "migration.sessionSummary.copy": "Copy Report",
+  "migration.sessionSummary.toast.copied": "Copied report",
+  "migration.forceReimport.title": "Force Re-import",
+  "migration.forceReimport.description":
+    "Re-importing {{target}} will overwrite them and delete any new messages already made in those sessions.",
+  "migration.forceReimport.target.one": "this session",
+  "migration.forceReimport.target.many": "these {{count}} sessions",
+  "migration.forceReimport.button": "Force Re-import",
+  "migration.forceReimport.all": "Re-import all",
+  "migration.forceReimport.proceed": "Proceed",
+  "migration.forceReimport.toast.started": "Force re-import started",
+  "migration.running.title": "Migration in Progress",
+  "migration.running.description.line1": "You are about to finish while there are still sessions being migrated.",
+  "migration.running.description.line2": "If you leave now, some sessions may remain incomplete.",
+  "migration.running.stay": "Stay",
+  "migration.running.proceed": "Proceed",
   // legacy-migration end
 
   "error.details.show": "Details",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1316,6 +1316,23 @@ export const dict = {
   "migration.error.continue": "Continuar",
   "migration.error.action.copy": "Copiar",
   "migration.error.toast.copied": "Error copiado al portapapeles",
+  "migration.sessionSummary.title": "Resumen:",
+  "migration.sessionSummary.copy": "Copiar informe",
+  "migration.sessionSummary.toast.copied": "Informe copiado",
+  "migration.forceReimport.title": "Forzar reimportación",
+  "migration.forceReimport.description":
+    "Reimportar {{target}} sobrescribirá las sesiones y eliminará los mensajes nuevos ya realizados en ellas.",
+  "migration.forceReimport.target.one": "esta sesión",
+  "migration.forceReimport.target.many": "estas {{count}} sesiones",
+  "migration.forceReimport.button": "Forzar reimportación",
+  "migration.forceReimport.all": "Reimportar todo",
+  "migration.forceReimport.proceed": "Proceder",
+  "migration.forceReimport.toast.started": "Reimportación forzada iniciada",
+  "migration.running.title": "Migración en curso",
+  "migration.running.description.line1": "Vas a terminar mientras todavía hay sesiones migrándose.",
+  "migration.running.description.line2": "Si sales ahora, algunas sesiones pueden quedar incompletas.",
+  "migration.running.stay": "Quedarse",
+  "migration.running.proceed": "Proceder",
   // legacy-migration end
 
   "error.details.show": "Detalles",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1319,6 +1319,11 @@ export const dict = {
   "migration.sessionSummary.title": "Resumen:",
   "migration.sessionSummary.copy": "Copiar informe",
   "migration.sessionSummary.toast.copied": "Informe copiado",
+  "migration.sessionSummary.successful": "Correctas",
+  "migration.sessionSummary.skipped": "Omitidas",
+  "migration.sessionSummary.alreadyMigrated": "Ya migradas",
+  "migration.sessionSummary.errored": "Con error",
+  "migration.sessionSummary.none": "Ninguna",
   "migration.forceReimport.title": "Forzar reimportación",
   "migration.forceReimport.description":
     "Reimportar {{target}} sobrescribirá las sesiones y eliminará los mensajes nuevos ya realizados en ellas.",
@@ -1333,6 +1338,13 @@ export const dict = {
   "migration.running.description.line2": "Si sales ahora, algunas sesiones pueden quedar incompletas.",
   "migration.running.stay": "Quedarse",
   "migration.running.proceed": "Proceder",
+  "migration.sessionProgress.preparing": "Preparando sesión",
+  "migration.sessionProgress.storing": "Guardando sesión",
+  "migration.sessionProgress.skipped": "Sesión omitida",
+  "migration.sessionProgress.header": "Migrando {{current}} de {{total}}",
+  "migration.sessionFormat.unknownDate": "Fecha desconocida",
+  "migration.sessionFormat.unknown": "Desconocido",
+  "migration.sessionFormat.unknownError": "Error desconocido",
   // legacy-migration end
 
   "error.details.show": "Detalles",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1348,8 +1348,10 @@ export const dict = {
   "migration.forceReimport.proceed": "Continuer",
   "migration.forceReimport.toast.started": "Réimportation forcée lancée",
   "migration.running.title": "Migration en cours",
-  "migration.running.description.line1": "Vous êtes sur le point de terminer alors que certaines sessions sont encore en cours de migration.",
-  "migration.running.description.line2": "Si vous quittez maintenant, certaines sessions risquent de rester incomplètes.",
+  "migration.running.description.line1":
+    "Vous êtes sur le point de terminer alors que certaines sessions sont encore en cours de migration.",
+  "migration.running.description.line2":
+    "Si vous quittez maintenant, certaines sessions risquent de rester incomplètes.",
   "migration.running.stay": "Rester",
   "migration.running.proceed": "Continuer",
   "migration.sessionProgress.preparing": "Préparation de la session",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1329,6 +1329,24 @@ export const dict = {
   "migration.error.continue": "Continuer",
   "migration.error.action.copy": "Copier",
   "migration.error.toast.copied": "Erreur copiée dans le presse-papiers",
+
+  "migration.sessionSummary.title": "Résumé :",
+  "migration.sessionSummary.copy": "Copier le rapport",
+  "migration.sessionSummary.toast.copied": "Rapport copié",
+  "migration.forceReimport.title": "Forcer la réimportation",
+  "migration.forceReimport.description":
+    "Réimporter {{target}} les écrasera et supprimera tous les nouveaux messages déjà créés dans ces sessions.",
+  "migration.forceReimport.target.one": "cette session",
+  "migration.forceReimport.target.many": "ces {{count}} sessions",
+  "migration.forceReimport.button": "Forcer la réimportation",
+  "migration.forceReimport.all": "Tout réimporter",
+  "migration.forceReimport.proceed": "Continuer",
+  "migration.forceReimport.toast.started": "Réimportation forcée lancée",
+  "migration.running.title": "Migration en cours",
+  "migration.running.description.line1": "Vous êtes sur le point de terminer alors que certaines sessions sont encore en cours de migration.",
+  "migration.running.description.line2": "Si vous quittez maintenant, certaines sessions risquent de rester incomplètes.",
+  "migration.running.stay": "Rester",
+  "migration.running.proceed": "Continuer",
   // legacy-migration end
 
   "error.details.show": "Détails",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1333,6 +1333,11 @@ export const dict = {
   "migration.sessionSummary.title": "Résumé :",
   "migration.sessionSummary.copy": "Copier le rapport",
   "migration.sessionSummary.toast.copied": "Rapport copié",
+  "migration.sessionSummary.successful": "Réussies",
+  "migration.sessionSummary.skipped": "Ignorées",
+  "migration.sessionSummary.alreadyMigrated": "Déjà migrées",
+  "migration.sessionSummary.errored": "En erreur",
+  "migration.sessionSummary.none": "Aucune",
   "migration.forceReimport.title": "Forcer la réimportation",
   "migration.forceReimport.description":
     "Réimporter {{target}} les écrasera et supprimera tous les nouveaux messages déjà créés dans ces sessions.",
@@ -1347,6 +1352,13 @@ export const dict = {
   "migration.running.description.line2": "Si vous quittez maintenant, certaines sessions risquent de rester incomplètes.",
   "migration.running.stay": "Rester",
   "migration.running.proceed": "Continuer",
+  "migration.sessionProgress.preparing": "Préparation de la session",
+  "migration.sessionProgress.storing": "Enregistrement de la session",
+  "migration.sessionProgress.skipped": "Session ignorée",
+  "migration.sessionProgress.header": "Migration de {{current}} sur {{total}}",
+  "migration.sessionFormat.unknownDate": "Date inconnue",
+  "migration.sessionFormat.unknown": "Inconnu",
+  "migration.sessionFormat.unknownError": "Erreur inconnue",
   // legacy-migration end
 
   "error.details.show": "Détails",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1298,6 +1298,24 @@ export const dict = {
   "migration.error.continue": "続行",
   "migration.error.action.copy": "コピー",
   "migration.error.toast.copied": "エラーをクリップボードにコピーしました",
+
+  "migration.sessionSummary.title": "概要:",
+  "migration.sessionSummary.copy": "レポートをコピー",
+  "migration.sessionSummary.toast.copied": "レポートをコピーしました",
+  "migration.forceReimport.title": "再インポートを強制",
+  "migration.forceReimport.description":
+    "{{target}} を再インポートすると上書きされ、それらのセッションで既に作成された新しいメッセージは削除されます。",
+  "migration.forceReimport.target.one": "このセッション",
+  "migration.forceReimport.target.many": "これら {{count}} 件のセッション",
+  "migration.forceReimport.button": "再インポートを強制",
+  "migration.forceReimport.all": "すべて再インポート",
+  "migration.forceReimport.proceed": "続行",
+  "migration.forceReimport.toast.started": "強制再インポートを開始しました",
+  "migration.running.title": "移行を実行中",
+  "migration.running.description.line1": "まだ移行中のセッションがある状態で終了しようとしています。",
+  "migration.running.description.line2": "今離れると、一部のセッションは未完了のままになる可能性があります。",
+  "migration.running.stay": "このままにする",
+  "migration.running.proceed": "続行",
   // legacy-migration end
 
   "error.details.show": "詳細",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1302,6 +1302,11 @@ export const dict = {
   "migration.sessionSummary.title": "概要:",
   "migration.sessionSummary.copy": "レポートをコピー",
   "migration.sessionSummary.toast.copied": "レポートをコピーしました",
+  "migration.sessionSummary.successful": "成功",
+  "migration.sessionSummary.skipped": "スキップ",
+  "migration.sessionSummary.alreadyMigrated": "移行済み",
+  "migration.sessionSummary.errored": "エラーあり",
+  "migration.sessionSummary.none": "なし",
   "migration.forceReimport.title": "再インポートを強制",
   "migration.forceReimport.description":
     "{{target}} を再インポートすると上書きされ、それらのセッションで既に作成された新しいメッセージは削除されます。",
@@ -1316,6 +1321,13 @@ export const dict = {
   "migration.running.description.line2": "今離れると、一部のセッションは未完了のままになる可能性があります。",
   "migration.running.stay": "このままにする",
   "migration.running.proceed": "続行",
+  "migration.sessionProgress.preparing": "セッションを準備中",
+  "migration.sessionProgress.storing": "セッションを保存中",
+  "migration.sessionProgress.skipped": "セッションをスキップしました",
+  "migration.sessionProgress.header": "{{total}} 件中 {{current}} 件を移行中",
+  "migration.sessionFormat.unknownDate": "不明な日付",
+  "migration.sessionFormat.unknown": "不明",
+  "migration.sessionFormat.unknownError": "不明なエラー",
   // legacy-migration end
 
   "error.details.show": "詳細",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1290,6 +1290,11 @@ export const dict = {
   "migration.sessionSummary.title": "요약:",
   "migration.sessionSummary.copy": "보고서 복사",
   "migration.sessionSummary.toast.copied": "보고서가 복사되었습니다",
+  "migration.sessionSummary.successful": "성공",
+  "migration.sessionSummary.skipped": "건너뜀",
+  "migration.sessionSummary.alreadyMigrated": "이미 마이그레이션됨",
+  "migration.sessionSummary.errored": "오류 발생",
+  "migration.sessionSummary.none": "없음",
   "migration.forceReimport.title": "강제 재가져오기",
   "migration.forceReimport.description":
     "{{target}}을 다시 가져오면 덮어쓰게 되며, 해당 세션에서 이미 생성된 새 메시지는 삭제됩니다.",
@@ -1304,6 +1309,13 @@ export const dict = {
   "migration.running.description.line2": "지금 나가면 일부 세션이 완료되지 않은 상태로 남을 수 있습니다.",
   "migration.running.stay": "머무르기",
   "migration.running.proceed": "진행",
+  "migration.sessionProgress.preparing": "세션 준비 중",
+  "migration.sessionProgress.storing": "세션 저장 중",
+  "migration.sessionProgress.skipped": "세션 건너뜀",
+  "migration.sessionProgress.header": "{{total}}개 중 {{current}}개 마이그레이션 중",
+  "migration.sessionFormat.unknownDate": "알 수 없는 날짜",
+  "migration.sessionFormat.unknown": "알 수 없음",
+  "migration.sessionFormat.unknownError": "알 수 없는 오류",
   // legacy-migration end
 
   "error.details.show": "상세 정보",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1286,6 +1286,24 @@ export const dict = {
   "migration.error.continue": "계속",
   "migration.error.action.copy": "복사",
   "migration.error.toast.copied": "오류가 클립보드에 복사되었습니다",
+
+  "migration.sessionSummary.title": "요약:",
+  "migration.sessionSummary.copy": "보고서 복사",
+  "migration.sessionSummary.toast.copied": "보고서가 복사되었습니다",
+  "migration.forceReimport.title": "강제 재가져오기",
+  "migration.forceReimport.description":
+    "{{target}}을 다시 가져오면 덮어쓰게 되며, 해당 세션에서 이미 생성된 새 메시지는 삭제됩니다.",
+  "migration.forceReimport.target.one": "이 세션",
+  "migration.forceReimport.target.many": "이 {{count}}개 세션",
+  "migration.forceReimport.button": "강제 재가져오기",
+  "migration.forceReimport.all": "모두 다시 가져오기",
+  "migration.forceReimport.proceed": "진행",
+  "migration.forceReimport.toast.started": "강제 재가져오기가 시작되었습니다",
+  "migration.running.title": "마이그레이션 진행 중",
+  "migration.running.description.line1": "아직 마이그레이션 중인 세션이 남아 있는 상태에서 종료하려고 합니다.",
+  "migration.running.description.line2": "지금 나가면 일부 세션이 완료되지 않은 상태로 남을 수 있습니다.",
+  "migration.running.stay": "머무르기",
+  "migration.running.proceed": "진행",
   // legacy-migration end
 
   "error.details.show": "상세 정보",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1303,6 +1303,24 @@ export const dict = {
   "migration.error.continue": "Doorgaan",
   "migration.error.action.copy": "Kopiëren",
   "migration.error.toast.copied": "Fout gekopieerd naar het klembord",
+
+  "migration.sessionSummary.title": "Samenvatting:",
+  "migration.sessionSummary.copy": "Rapport kopiëren",
+  "migration.sessionSummary.toast.copied": "Rapport gekopieerd",
+  "migration.forceReimport.title": "Herimport forceren",
+  "migration.forceReimport.description":
+    "Het opnieuw importeren van {{target}} zal deze overschrijven en alle nieuwe berichten verwijderen die al in die sessies zijn gemaakt.",
+  "migration.forceReimport.target.one": "deze sessie",
+  "migration.forceReimport.target.many": "deze {{count}} sessies",
+  "migration.forceReimport.button": "Herimport forceren",
+  "migration.forceReimport.all": "Alles opnieuw importeren",
+  "migration.forceReimport.proceed": "Doorgaan",
+  "migration.forceReimport.toast.started": "Geforceerde herimport gestart",
+  "migration.running.title": "Migratie bezig",
+  "migration.running.description.line1": "Je staat op het punt af te ronden terwijl er nog sessies worden gemigreerd.",
+  "migration.running.description.line2": "Als je nu vertrekt, kunnen sommige sessies onvolledig blijven.",
+  "migration.running.stay": "Blijven",
+  "migration.running.proceed": "Doorgaan",
   // legacy-migration end
 
   "error.details.show": "Details",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1307,6 +1307,11 @@ export const dict = {
   "migration.sessionSummary.title": "Samenvatting:",
   "migration.sessionSummary.copy": "Rapport kopiëren",
   "migration.sessionSummary.toast.copied": "Rapport gekopieerd",
+  "migration.sessionSummary.successful": "Geslaagd",
+  "migration.sessionSummary.skipped": "Overgeslagen",
+  "migration.sessionSummary.alreadyMigrated": "Al gemigreerd",
+  "migration.sessionSummary.errored": "Met fouten",
+  "migration.sessionSummary.none": "Geen",
   "migration.forceReimport.title": "Herimport forceren",
   "migration.forceReimport.description":
     "Het opnieuw importeren van {{target}} zal deze overschrijven en alle nieuwe berichten verwijderen die al in die sessies zijn gemaakt.",
@@ -1321,6 +1326,13 @@ export const dict = {
   "migration.running.description.line2": "Als je nu vertrekt, kunnen sommige sessies onvolledig blijven.",
   "migration.running.stay": "Blijven",
   "migration.running.proceed": "Doorgaan",
+  "migration.sessionProgress.preparing": "Sessie voorbereiden",
+  "migration.sessionProgress.storing": "Sessie opslaan",
+  "migration.sessionProgress.skipped": "Sessie overgeslagen",
+  "migration.sessionProgress.header": "Bezig met migreren van {{current}} van {{total}}",
+  "migration.sessionFormat.unknownDate": "Onbekende datum",
+  "migration.sessionFormat.unknown": "Onbekend",
+  "migration.sessionFormat.unknownError": "Onbekende fout",
   // legacy-migration end
 
   "error.details.show": "Details",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1303,6 +1303,11 @@ export const dict = {
   "migration.sessionSummary.title": "Oppsummering:",
   "migration.sessionSummary.copy": "Kopier rapport",
   "migration.sessionSummary.toast.copied": "Rapport kopiert",
+  "migration.sessionSummary.successful": "Vellykkede",
+  "migration.sessionSummary.skipped": "Hoppet over",
+  "migration.sessionSummary.alreadyMigrated": "Allerede migrert",
+  "migration.sessionSummary.errored": "Med feil",
+  "migration.sessionSummary.none": "Ingen",
   "migration.forceReimport.title": "Tving ny import",
   "migration.forceReimport.description":
     "Hvis du importerer {{target}} på nytt, blir de overskrevet og alle nye meldinger som allerede er opprettet i disse øktene blir slettet.",
@@ -1317,6 +1322,13 @@ export const dict = {
   "migration.running.description.line2": "Hvis du går nå, kan noen økter forbli ufullstendige.",
   "migration.running.stay": "Bli",
   "migration.running.proceed": "Fortsett",
+  "migration.sessionProgress.preparing": "Forbereder økt",
+  "migration.sessionProgress.storing": "Lagrer økt",
+  "migration.sessionProgress.skipped": "Økt hoppet over",
+  "migration.sessionProgress.header": "Migrerer {{current}} av {{total}}",
+  "migration.sessionFormat.unknownDate": "Ukjent dato",
+  "migration.sessionFormat.unknown": "Ukjent",
+  "migration.sessionFormat.unknownError": "Ukjent feil",
   // legacy-migration end
 
   "task.todos.progress": "{{done}}/{{total}} oppgaver fullført",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1299,6 +1299,24 @@ export const dict = {
   "migration.error.continue": "Fortsett",
   "migration.error.action.copy": "Kopier",
   "migration.error.toast.copied": "Feil kopiert til utklippstavlen",
+
+  "migration.sessionSummary.title": "Oppsummering:",
+  "migration.sessionSummary.copy": "Kopier rapport",
+  "migration.sessionSummary.toast.copied": "Rapport kopiert",
+  "migration.forceReimport.title": "Tving ny import",
+  "migration.forceReimport.description":
+    "Hvis du importerer {{target}} på nytt, blir de overskrevet og alle nye meldinger som allerede er opprettet i disse øktene blir slettet.",
+  "migration.forceReimport.target.one": "denne økten",
+  "migration.forceReimport.target.many": "disse {{count}} øktene",
+  "migration.forceReimport.button": "Tving ny import",
+  "migration.forceReimport.all": "Importer alle på nytt",
+  "migration.forceReimport.proceed": "Fortsett",
+  "migration.forceReimport.toast.started": "Tvungen ny import startet",
+  "migration.running.title": "Migrering pågår",
+  "migration.running.description.line1": "Du er i ferd med å avslutte mens det fortsatt er økter som migreres.",
+  "migration.running.description.line2": "Hvis du går nå, kan noen økter forbli ufullstendige.",
+  "migration.running.stay": "Bli",
+  "migration.running.proceed": "Fortsett",
   // legacy-migration end
 
   "task.todos.progress": "{{done}}/{{total}} oppgaver fullført",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1307,6 +1307,24 @@ export const dict = {
   "migration.error.continue": "Kontynuuj",
   "migration.error.action.copy": "Kopiuj",
   "migration.error.toast.copied": "Błąd skopiowano do schowka",
+
+  "migration.sessionSummary.title": "Podsumowanie:",
+  "migration.sessionSummary.copy": "Kopiuj raport",
+  "migration.sessionSummary.toast.copied": "Skopiowano raport",
+  "migration.forceReimport.title": "Wymuś ponowny import",
+  "migration.forceReimport.description":
+    "Ponowny import {{target}} spowoduje ich nadpisanie i usunięcie wszystkich nowych wiadomości już utworzonych w tych sesjach.",
+  "migration.forceReimport.target.one": "tej sesji",
+  "migration.forceReimport.target.many": "tych {{count}} sesji",
+  "migration.forceReimport.button": "Wymuś ponowny import",
+  "migration.forceReimport.all": "Zaimportuj ponownie wszystko",
+  "migration.forceReimport.proceed": "Kontynuuj",
+  "migration.forceReimport.toast.started": "Rozpoczęto wymuszony ponowny import",
+  "migration.running.title": "Migracja w toku",
+  "migration.running.description.line1": "Zaraz zakończysz, podczas gdy część sesji wciąż się migruje.",
+  "migration.running.description.line2": "Jeśli wyjdziesz teraz, niektóre sesje mogą pozostać niekompletne.",
+  "migration.running.stay": "Zostań",
+  "migration.running.proceed": "Kontynuuj",
   // legacy-migration end
 
   "error.details.show": "Szczegóły",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1311,6 +1311,11 @@ export const dict = {
   "migration.sessionSummary.title": "Podsumowanie:",
   "migration.sessionSummary.copy": "Kopiuj raport",
   "migration.sessionSummary.toast.copied": "Skopiowano raport",
+  "migration.sessionSummary.successful": "Udane",
+  "migration.sessionSummary.skipped": "Pominięte",
+  "migration.sessionSummary.alreadyMigrated": "Już zmigrowane",
+  "migration.sessionSummary.errored": "Z błędem",
+  "migration.sessionSummary.none": "Brak",
   "migration.forceReimport.title": "Wymuś ponowny import",
   "migration.forceReimport.description":
     "Ponowny import {{target}} spowoduje ich nadpisanie i usunięcie wszystkich nowych wiadomości już utworzonych w tych sesjach.",
@@ -1325,6 +1330,13 @@ export const dict = {
   "migration.running.description.line2": "Jeśli wyjdziesz teraz, niektóre sesje mogą pozostać niekompletne.",
   "migration.running.stay": "Zostań",
   "migration.running.proceed": "Kontynuuj",
+  "migration.sessionProgress.preparing": "Przygotowywanie sesji",
+  "migration.sessionProgress.storing": "Zapisywanie sesji",
+  "migration.sessionProgress.skipped": "Sesja pominięta",
+  "migration.sessionProgress.header": "Migracja {{current}} z {{total}}",
+  "migration.sessionFormat.unknownDate": "Nieznana data",
+  "migration.sessionFormat.unknown": "Nieznane",
+  "migration.sessionFormat.unknownError": "Nieznany błąd",
   // legacy-migration end
 
   "error.details.show": "Szczegóły",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1306,6 +1306,24 @@ export const dict = {
   "migration.error.continue": "Продолжить",
   "migration.error.action.copy": "Копировать",
   "migration.error.toast.copied": "Ошибка скопирована в буфер обмена",
+
+  "migration.sessionSummary.title": "Сводка:",
+  "migration.sessionSummary.copy": "Скопировать отчёт",
+  "migration.sessionSummary.toast.copied": "Отчёт скопирован",
+  "migration.forceReimport.title": "Принудительный повторный импорт",
+  "migration.forceReimport.description":
+    "Повторный импорт {{target}} перезапишет их и удалит все новые сообщения, уже созданные в этих сессиях.",
+  "migration.forceReimport.target.one": "эту сессию",
+  "migration.forceReimport.target.many": "эти {{count}} сессии",
+  "migration.forceReimport.button": "Принудительно импортировать снова",
+  "migration.forceReimport.all": "Импортировать всё заново",
+  "migration.forceReimport.proceed": "Продолжить",
+  "migration.forceReimport.toast.started": "Принудительный повторный импорт запущен",
+  "migration.running.title": "Миграция выполняется",
+  "migration.running.description.line1": "Вы собираетесь завершить процесс, пока некоторые сессии всё ещё переносятся.",
+  "migration.running.description.line2": "Если вы уйдёте сейчас, некоторые сессии могут остаться незавершёнными.",
+  "migration.running.stay": "Остаться",
+  "migration.running.proceed": "Продолжить",
   // legacy-migration end
 
   "error.details.show": "Подробности",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1310,6 +1310,11 @@ export const dict = {
   "migration.sessionSummary.title": "Сводка:",
   "migration.sessionSummary.copy": "Скопировать отчёт",
   "migration.sessionSummary.toast.copied": "Отчёт скопирован",
+  "migration.sessionSummary.successful": "Успешно",
+  "migration.sessionSummary.skipped": "Пропущено",
+  "migration.sessionSummary.alreadyMigrated": "Уже перенесено",
+  "migration.sessionSummary.errored": "С ошибкой",
+  "migration.sessionSummary.none": "Нет",
   "migration.forceReimport.title": "Принудительный повторный импорт",
   "migration.forceReimport.description":
     "Повторный импорт {{target}} перезапишет их и удалит все новые сообщения, уже созданные в этих сессиях.",
@@ -1324,6 +1329,13 @@ export const dict = {
   "migration.running.description.line2": "Если вы уйдёте сейчас, некоторые сессии могут остаться незавершёнными.",
   "migration.running.stay": "Остаться",
   "migration.running.proceed": "Продолжить",
+  "migration.sessionProgress.preparing": "Подготовка сессии",
+  "migration.sessionProgress.storing": "Сохранение сессии",
+  "migration.sessionProgress.skipped": "Сессия пропущена",
+  "migration.sessionProgress.header": "Перенос {{current}} из {{total}}",
+  "migration.sessionFormat.unknownDate": "Неизвестная дата",
+  "migration.sessionFormat.unknown": "Неизвестно",
+  "migration.sessionFormat.unknownError": "Неизвестная ошибка",
   // legacy-migration end
 
   "error.details.show": "Подробности",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1286,6 +1286,11 @@ export const dict = {
   "migration.sessionSummary.title": "สรุป:",
   "migration.sessionSummary.copy": "คัดลอกรายงาน",
   "migration.sessionSummary.toast.copied": "คัดลอกรายงานแล้ว",
+  "migration.sessionSummary.successful": "สำเร็จ",
+  "migration.sessionSummary.skipped": "ข้ามแล้ว",
+  "migration.sessionSummary.alreadyMigrated": "ย้ายแล้ว",
+  "migration.sessionSummary.errored": "มีข้อผิดพลาด",
+  "migration.sessionSummary.none": "ไม่มี",
   "migration.forceReimport.title": "บังคับนำเข้าใหม่",
   "migration.forceReimport.description":
     "การนำเข้า {{target}} ใหม่จะเขียนทับและลบข้อความใหม่ใด ๆ ที่สร้างไว้แล้วในเซสชันเหล่านั้น",
@@ -1300,6 +1305,13 @@ export const dict = {
   "migration.running.description.line2": "หากคุณออกตอนนี้ บางเซสชันอาจยังไม่สมบูรณ์",
   "migration.running.stay": "อยู่ต่อ",
   "migration.running.proceed": "ดำเนินการต่อ",
+  "migration.sessionProgress.preparing": "กำลังเตรียมเซสชัน",
+  "migration.sessionProgress.storing": "กำลังบันทึกเซสชัน",
+  "migration.sessionProgress.skipped": "ข้ามเซสชันแล้ว",
+  "migration.sessionProgress.header": "กำลังย้าย {{current}} จาก {{total}}",
+  "migration.sessionFormat.unknownDate": "ไม่ทราบวันที่",
+  "migration.sessionFormat.unknown": "ไม่ทราบ",
+  "migration.sessionFormat.unknownError": "ข้อผิดพลาดที่ไม่ทราบสาเหตุ",
   // legacy-migration end
 
   "error.details.show": "รายละเอียด",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1282,6 +1282,24 @@ export const dict = {
   "migration.error.continue": "ดำเนินการต่อ",
   "migration.error.action.copy": "คัดลอก",
   "migration.error.toast.copied": "คัดลอกข้อผิดพลาดไปยังคลิปบอร์ดแล้ว",
+
+  "migration.sessionSummary.title": "สรุป:",
+  "migration.sessionSummary.copy": "คัดลอกรายงาน",
+  "migration.sessionSummary.toast.copied": "คัดลอกรายงานแล้ว",
+  "migration.forceReimport.title": "บังคับนำเข้าใหม่",
+  "migration.forceReimport.description":
+    "การนำเข้า {{target}} ใหม่จะเขียนทับและลบข้อความใหม่ใด ๆ ที่สร้างไว้แล้วในเซสชันเหล่านั้น",
+  "migration.forceReimport.target.one": "เซสชันนี้",
+  "migration.forceReimport.target.many": "{{count}} เซสชันเหล่านี้",
+  "migration.forceReimport.button": "บังคับนำเข้าใหม่",
+  "migration.forceReimport.all": "นำเข้าทั้งหมดใหม่",
+  "migration.forceReimport.proceed": "ดำเนินการต่อ",
+  "migration.forceReimport.toast.started": "เริ่มการนำเข้าใหม่แบบบังคับแล้ว",
+  "migration.running.title": "กำลังย้ายข้อมูล",
+  "migration.running.description.line1": "คุณกำลังจะเสร็จสิ้นในขณะที่ยังมีบางเซสชันกำลังย้ายข้อมูลอยู่",
+  "migration.running.description.line2": "หากคุณออกตอนนี้ บางเซสชันอาจยังไม่สมบูรณ์",
+  "migration.running.stay": "อยู่ต่อ",
+  "migration.running.proceed": "ดำเนินการต่อ",
   // legacy-migration end
 
   "error.details.show": "รายละเอียด",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1299,6 +1299,11 @@ export const dict = {
   "migration.sessionSummary.title": "Özet:",
   "migration.sessionSummary.copy": "Raporu kopyala",
   "migration.sessionSummary.toast.copied": "Rapor kopyalandı",
+  "migration.sessionSummary.successful": "Başarılı",
+  "migration.sessionSummary.skipped": "Atlandı",
+  "migration.sessionSummary.alreadyMigrated": "Zaten taşındı",
+  "migration.sessionSummary.errored": "Hatalı",
+  "migration.sessionSummary.none": "Yok",
   "migration.forceReimport.title": "Yeniden içe aktarmayı zorla",
   "migration.forceReimport.description":
     "{{target}} yeniden içe aktarılırsa üzerlerine yazılır ve bu oturumlarda zaten oluşturulmuş yeni mesajlar silinir.",
@@ -1313,6 +1318,13 @@ export const dict = {
   "migration.running.description.line2": "Şimdi çıkarsanız bazı oturumlar eksik kalabilir.",
   "migration.running.stay": "Kal",
   "migration.running.proceed": "Devam et",
+  "migration.sessionProgress.preparing": "Oturum hazırlanıyor",
+  "migration.sessionProgress.storing": "Oturum kaydediliyor",
+  "migration.sessionProgress.skipped": "Oturum atlandı",
+  "migration.sessionProgress.header": "{{total}} içinden {{current}} taşınıyor",
+  "migration.sessionFormat.unknownDate": "Bilinmeyen tarih",
+  "migration.sessionFormat.unknown": "Bilinmiyor",
+  "migration.sessionFormat.unknownError": "Bilinmeyen hata",
   // legacy-migration end
 
   "error.details.show": "Ayrıntılar",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1295,6 +1295,24 @@ export const dict = {
   "migration.error.continue": "Devam et",
   "migration.error.action.copy": "Kopyala",
   "migration.error.toast.copied": "Hata panoya kopyalandı",
+
+  "migration.sessionSummary.title": "Özet:",
+  "migration.sessionSummary.copy": "Raporu kopyala",
+  "migration.sessionSummary.toast.copied": "Rapor kopyalandı",
+  "migration.forceReimport.title": "Yeniden içe aktarmayı zorla",
+  "migration.forceReimport.description":
+    "{{target}} yeniden içe aktarılırsa üzerlerine yazılır ve bu oturumlarda zaten oluşturulmuş yeni mesajlar silinir.",
+  "migration.forceReimport.target.one": "bu oturum",
+  "migration.forceReimport.target.many": "bu {{count}} oturum",
+  "migration.forceReimport.button": "Yeniden içe aktarmayı zorla",
+  "migration.forceReimport.all": "Hepsini yeniden içe aktar",
+  "migration.forceReimport.proceed": "Devam et",
+  "migration.forceReimport.toast.started": "Zorunlu yeniden içe aktarma başlatıldı",
+  "migration.running.title": "Taşıma sürüyor",
+  "migration.running.description.line1": "Hâlâ taşınan oturumlar varken işlemi bitirmek üzeresiniz.",
+  "migration.running.description.line2": "Şimdi çıkarsanız bazı oturumlar eksik kalabilir.",
+  "migration.running.stay": "Kal",
+  "migration.running.proceed": "Devam et",
   // legacy-migration end
 
   "error.details.show": "Ayrıntılar",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1296,6 +1296,24 @@ export const dict = {
   "migration.error.continue": "Продовжити",
   "migration.error.action.copy": "Копіювати",
   "migration.error.toast.copied": "Помилку скопійовано до буфера обміну",
+
+  "migration.sessionSummary.title": "Підсумок:",
+  "migration.sessionSummary.copy": "Скопіювати звіт",
+  "migration.sessionSummary.toast.copied": "Звіт скопійовано",
+  "migration.forceReimport.title": "Примусово імпортувати повторно",
+  "migration.forceReimport.description":
+    "Повторний імпорт {{target}} перезапише їх і видалить усі нові повідомлення, уже створені в цих сесіях.",
+  "migration.forceReimport.target.one": "цю сесію",
+  "migration.forceReimport.target.many": "ці {{count}} сесії",
+  "migration.forceReimport.button": "Примусово імпортувати повторно",
+  "migration.forceReimport.all": "Імпортувати все повторно",
+  "migration.forceReimport.proceed": "Продовжити",
+  "migration.forceReimport.toast.started": "Примусовий повторний імпорт розпочато",
+  "migration.running.title": "Триває перенесення",
+  "migration.running.description.line1": "Ви збираєтеся завершити роботу, поки деякі сесії ще переносяться.",
+  "migration.running.description.line2": "Якщо ви вийдете зараз, деякі сесії можуть залишитися незавершеними.",
+  "migration.running.stay": "Залишитися",
+  "migration.running.proceed": "Продовжити",
   // legacy-migration end
 
   "error.details.show": "Деталі",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1300,6 +1300,11 @@ export const dict = {
   "migration.sessionSummary.title": "Підсумок:",
   "migration.sessionSummary.copy": "Скопіювати звіт",
   "migration.sessionSummary.toast.copied": "Звіт скопійовано",
+  "migration.sessionSummary.successful": "Успішно",
+  "migration.sessionSummary.skipped": "Пропущено",
+  "migration.sessionSummary.alreadyMigrated": "Уже перенесено",
+  "migration.sessionSummary.errored": "З помилкою",
+  "migration.sessionSummary.none": "Немає",
   "migration.forceReimport.title": "Примусово імпортувати повторно",
   "migration.forceReimport.description":
     "Повторний імпорт {{target}} перезапише їх і видалить усі нові повідомлення, уже створені в цих сесіях.",
@@ -1314,6 +1319,13 @@ export const dict = {
   "migration.running.description.line2": "Якщо ви вийдете зараз, деякі сесії можуть залишитися незавершеними.",
   "migration.running.stay": "Залишитися",
   "migration.running.proceed": "Продовжити",
+  "migration.sessionProgress.preparing": "Підготовка сесії",
+  "migration.sessionProgress.storing": "Збереження сесії",
+  "migration.sessionProgress.skipped": "Сесію пропущено",
+  "migration.sessionProgress.header": "Перенесення {{current}} з {{total}}",
+  "migration.sessionFormat.unknownDate": "Невідома дата",
+  "migration.sessionFormat.unknown": "Невідомо",
+  "migration.sessionFormat.unknownError": "Невідома помилка",
   // legacy-migration end
 
   "error.details.show": "Деталі",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1262,6 +1262,11 @@ export const dict = {
   "migration.sessionSummary.title": "摘要：",
   "migration.sessionSummary.copy": "复制报告",
   "migration.sessionSummary.toast.copied": "报告已复制",
+  "migration.sessionSummary.successful": "成功",
+  "migration.sessionSummary.skipped": "已跳过",
+  "migration.sessionSummary.alreadyMigrated": "已迁移",
+  "migration.sessionSummary.errored": "出错",
+  "migration.sessionSummary.none": "无",
   "migration.forceReimport.title": "强制重新导入",
   "migration.forceReimport.description":
     "重新导入 {{target}} 将覆盖它们，并删除这些会话中已创建的所有新消息。",
@@ -1276,6 +1281,13 @@ export const dict = {
   "migration.running.description.line2": "如果你现在离开，某些会话可能会保持未完成状态。",
   "migration.running.stay": "留下",
   "migration.running.proceed": "继续",
+  "migration.sessionProgress.preparing": "正在准备会话",
+  "migration.sessionProgress.storing": "正在保存会话",
+  "migration.sessionProgress.skipped": "已跳过会话",
+  "migration.sessionProgress.header": "正在迁移第 {{current}} / {{total}} 个",
+  "migration.sessionFormat.unknownDate": "未知日期",
+  "migration.sessionFormat.unknown": "未知",
+  "migration.sessionFormat.unknownError": "未知错误",
   // legacy-migration end
 
   "error.details.show": "详细信息",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1258,6 +1258,24 @@ export const dict = {
   "migration.error.continue": "继续",
   "migration.error.action.copy": "复制",
   "migration.error.toast.copied": "错误已复制到剪贴板",
+
+  "migration.sessionSummary.title": "摘要：",
+  "migration.sessionSummary.copy": "复制报告",
+  "migration.sessionSummary.toast.copied": "报告已复制",
+  "migration.forceReimport.title": "强制重新导入",
+  "migration.forceReimport.description":
+    "重新导入 {{target}} 将覆盖它们，并删除这些会话中已创建的所有新消息。",
+  "migration.forceReimport.target.one": "这个会话",
+  "migration.forceReimport.target.many": "这 {{count}} 个会话",
+  "migration.forceReimport.button": "强制重新导入",
+  "migration.forceReimport.all": "重新导入全部",
+  "migration.forceReimport.proceed": "继续",
+  "migration.forceReimport.toast.started": "已开始强制重新导入",
+  "migration.running.title": "迁移进行中",
+  "migration.running.description.line1": "仍有会话正在迁移时，你即将结束流程。",
+  "migration.running.description.line2": "如果你现在离开，某些会话可能会保持未完成状态。",
+  "migration.running.stay": "留下",
+  "migration.running.proceed": "继续",
   // legacy-migration end
 
   "error.details.show": "详细信息",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1268,8 +1268,7 @@ export const dict = {
   "migration.sessionSummary.errored": "出错",
   "migration.sessionSummary.none": "无",
   "migration.forceReimport.title": "强制重新导入",
-  "migration.forceReimport.description":
-    "重新导入 {{target}} 将覆盖它们，并删除这些会话中已创建的所有新消息。",
+  "migration.forceReimport.description": "重新导入 {{target}} 将覆盖它们，并删除这些会话中已创建的所有新消息。",
   "migration.forceReimport.target.one": "这个会话",
   "migration.forceReimport.target.many": "这 {{count}} 个会话",
   "migration.forceReimport.button": "强制重新导入",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1271,8 +1271,7 @@ export const dict = {
   "migration.sessionSummary.errored": "發生錯誤",
   "migration.sessionSummary.none": "無",
   "migration.forceReimport.title": "強制重新匯入",
-  "migration.forceReimport.description":
-    "重新匯入 {{target}} 將會覆寫它們，並刪除這些工作階段中已建立的所有新訊息。",
+  "migration.forceReimport.description": "重新匯入 {{target}} 將會覆寫它們，並刪除這些工作階段中已建立的所有新訊息。",
   "migration.forceReimport.target.one": "這個工作階段",
   "migration.forceReimport.target.many": "這 {{count}} 個工作階段",
   "migration.forceReimport.button": "強制重新匯入",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1265,6 +1265,11 @@ export const dict = {
   "migration.sessionSummary.title": "摘要：",
   "migration.sessionSummary.copy": "複製報告",
   "migration.sessionSummary.toast.copied": "報告已複製",
+  "migration.sessionSummary.successful": "成功",
+  "migration.sessionSummary.skipped": "已略過",
+  "migration.sessionSummary.alreadyMigrated": "已遷移",
+  "migration.sessionSummary.errored": "發生錯誤",
+  "migration.sessionSummary.none": "無",
   "migration.forceReimport.title": "強制重新匯入",
   "migration.forceReimport.description":
     "重新匯入 {{target}} 將會覆寫它們，並刪除這些工作階段中已建立的所有新訊息。",
@@ -1279,6 +1284,13 @@ export const dict = {
   "migration.running.description.line2": "如果你現在離開，部分工作階段可能會維持未完成狀態。",
   "migration.running.stay": "留下",
   "migration.running.proceed": "繼續",
+  "migration.sessionProgress.preparing": "正在準備工作階段",
+  "migration.sessionProgress.storing": "正在儲存工作階段",
+  "migration.sessionProgress.skipped": "已略過工作階段",
+  "migration.sessionProgress.header": "正在遷移第 {{current}} / {{total}} 個",
+  "migration.sessionFormat.unknownDate": "未知日期",
+  "migration.sessionFormat.unknown": "未知",
+  "migration.sessionFormat.unknownError": "未知錯誤",
   // legacy-migration end
 
   "error.details.show": "詳細資訊",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1261,6 +1261,24 @@ export const dict = {
   "migration.error.continue": "繼續",
   "migration.error.action.copy": "複製",
   "migration.error.toast.copied": "錯誤已複製到剪貼簿",
+
+  "migration.sessionSummary.title": "摘要：",
+  "migration.sessionSummary.copy": "複製報告",
+  "migration.sessionSummary.toast.copied": "報告已複製",
+  "migration.forceReimport.title": "強制重新匯入",
+  "migration.forceReimport.description":
+    "重新匯入 {{target}} 將會覆寫它們，並刪除這些工作階段中已建立的所有新訊息。",
+  "migration.forceReimport.target.one": "這個工作階段",
+  "migration.forceReimport.target.many": "這 {{count}} 個工作階段",
+  "migration.forceReimport.button": "強制重新匯入",
+  "migration.forceReimport.all": "全部重新匯入",
+  "migration.forceReimport.proceed": "繼續",
+  "migration.forceReimport.toast.started": "已開始強制重新匯入",
+  "migration.running.title": "遷移進行中",
+  "migration.running.description.line1": "目前仍有工作階段正在遷移，但你即將結束流程。",
+  "migration.running.description.line2": "如果你現在離開，部分工作階段可能會維持未完成狀態。",
+  "migration.running.stay": "留下",
+  "migration.running.proceed": "繼續",
   // legacy-migration end
 
   "error.details.show": "詳細資訊",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1147,6 +1147,10 @@ export interface SkipLegacyMigrationMessage {
 export interface ClearLegacyDataMessage {
   type: "clearLegacyData"
 }
+
+export interface FinalizeLegacyMigrationMessage {
+  type: "finalizeLegacyMigration"
+}
 // legacy-migration end
 
 // Enhance prompt result (extension → webview)
@@ -2184,6 +2188,7 @@ export type WebviewMessage =
   | StartLegacyMigrationMessage
   | SkipLegacyMigrationMessage
   | ClearLegacyDataMessage
+  | FinalizeLegacyMigrationMessage
   // legacy-migration end
   | ApplyWorktreeDiffMessage
   | EnhancePromptRequest

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1093,6 +1093,19 @@ export interface LegacyMigrationProgressMessage {
   message?: string
 }
 
+export type LegacyMigrationSessionPhase = "project" | "session" | "messages" | "parts" | "skipped" | "done" | "error"
+
+export interface LegacyMigrationSessionProgressMessage {
+  type: "legacyMigrationSessionProgress"
+  session: MigrationSessionInfo
+  index: number
+  total: number
+  phase: LegacyMigrationSessionPhase
+  current?: number
+  count?: number
+  error?: string
+}
+
 export interface LegacyMigrationCompleteMessage {
   type: "legacyMigrationComplete"
   results: MigrationResultItem[]
@@ -1337,6 +1350,7 @@ export type ExtensionMessage =
   | MigrationStateMessage
   | LegacyMigrationDataMessage
   | LegacyMigrationProgressMessage
+  | LegacyMigrationSessionProgressMessage
   | LegacyMigrationCompleteMessage
   // legacy-migration end
   | EnhancePromptResultMessage

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1093,7 +1093,7 @@ export interface LegacyMigrationProgressMessage {
   message?: string
 }
 
-export type LegacyMigrationSessionPhase = "project" | "session" | "messages" | "parts" | "skipped" | "done" | "summary" | "error"
+export type LegacyMigrationSessionPhase = "preparing" | "project" | "session" | "messages" | "parts" | "skipped" | "done" | "summary" | "error"
 
 export interface LegacyMigrationSessionProgressMessage {
   type: "legacyMigrationSessionProgress"

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1056,7 +1056,7 @@ export interface MigrationSessionInfo {
 
 export interface MigrationResultItem {
   item: string
-  category: "provider" | "mcpServer" | "customMode" | "defaultModel" | "settings"
+  category: "provider" | "mcpServer" | "customMode" | "session" | "defaultModel" | "settings"
   status: "success" | "warning" | "error"
   message?: string
 }

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1047,6 +1047,13 @@ export interface LegacySettings {
   autocomplete?: LegacyAutocompleteSettings
 }
 
+export interface MigrationSessionInfo {
+  id: string
+  title: string
+  directory: string
+  time: number
+}
+
 export interface MigrationResultItem {
   item: string
   category: "provider" | "mcpServer" | "customMode" | "defaultModel" | "settings"
@@ -1061,7 +1068,7 @@ export interface MigrationStateMessage {
     providers: MigrationProviderInfo[]
     mcpServers: MigrationMcpServerInfo[]
     customModes: MigrationCustomModeInfo[]
-    sessions?: string[]
+    sessions?: MigrationSessionInfo[]
     defaultModel?: { provider: string; model: string }
     settings?: LegacySettings
   }
@@ -1073,7 +1080,7 @@ export interface LegacyMigrationDataMessage {
     providers: MigrationProviderInfo[]
     mcpServers: MigrationMcpServerInfo[]
     customModes: MigrationCustomModeInfo[]
-    sessions?: string[]
+    sessions?: MigrationSessionInfo[]
     defaultModel?: { provider: string; model: string }
     settings?: LegacySettings
   }

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1093,7 +1093,7 @@ export interface LegacyMigrationProgressMessage {
   message?: string
 }
 
-export type LegacyMigrationSessionPhase = "preparing" | "project" | "session" | "messages" | "parts" | "skipped" | "done" | "summary" | "error"
+export type LegacyMigrationSessionPhase = "preparing" | "storing" | "skipped" | "done" | "summary" | "error"
 
 export interface LegacyMigrationSessionProgressMessage {
   type: "legacyMigrationSessionProgress"
@@ -1101,8 +1101,6 @@ export interface LegacyMigrationSessionProgressMessage {
   index: number
   total: number
   phase: LegacyMigrationSessionPhase
-  current?: number
-  count?: number
   error?: string
 }
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1124,13 +1124,18 @@ export interface MigrationAutoApprovalSelections {
   taskPermission: boolean
 }
 
+export interface MigrationSessionSelection {
+  id: string
+  force?: boolean
+}
+
 export interface StartLegacyMigrationMessage {
   type: "startLegacyMigration"
   selections: {
     providers: string[]
     mcpServers: string[]
     customModes: string[]
-    sessions?: string[]
+    sessions?: MigrationSessionSelection[]
     defaultModel: boolean
     settings: {
       autoApproval: MigrationAutoApprovalSelections

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1093,7 +1093,7 @@ export interface LegacyMigrationProgressMessage {
   message?: string
 }
 
-export type LegacyMigrationSessionPhase = "project" | "session" | "messages" | "parts" | "skipped" | "done" | "error"
+export type LegacyMigrationSessionPhase = "project" | "session" | "messages" | "parts" | "skipped" | "done" | "summary" | "error"
 
 export interface LegacyMigrationSessionProgressMessage {
   type: "legacyMigrationSessionProgress"

--- a/packages/opencode/src/kilocode/session-import/service.ts
+++ b/packages/opencode/src/kilocode/session-import/service.ts
@@ -9,7 +9,6 @@ const target = (input: unknown) => input as never
 
 export namespace SessionImportService {
   export async function project(input: SessionImportType.Project): Promise<SessionImportType.Result> {
-
     // Do not resolve an empty legacy worktree, because that would fall back to the current
     // process directory and silently attach the migrated session to the wrong project.
     if (!input.worktree.trim()) {
@@ -22,9 +21,12 @@ export namespace SessionImportService {
 
   export async function session(input: SessionImportType.Session): Promise<SessionImportType.Result> {
     const row = Database.use((db) => db.select().from(SessionTable).where(eq(target(SessionTable.id), input.id)).get())
-    if (row) return { ok: true, id: input.id, skipped: true }
+    if (row && !input.force) return { ok: true, id: input.id, skipped: true }
 
     Database.use((db) => {
+      if (row && input.force) {
+        db.delete(SessionTable).where(eq(target(SessionTable.id), input.id)).run()
+      }
       db.insert(SessionTable)
         .values({
           id: input.id,
@@ -47,8 +49,28 @@ export namespace SessionImportService {
           time_compacting: input.timeCompacting,
           time_archived: input.timeArchived,
         })
-        .onConflictDoNothing({
+        .onConflictDoUpdate({
           target: key(SessionTable.id),
+          set: {
+            project_id: input.projectID,
+            workspace_id: input.workspaceID,
+            parent_id: input.parentID,
+            slug: input.slug,
+            directory: input.directory,
+            title: input.title,
+            version: input.version,
+            share_url: input.shareURL,
+            summary_additions: input.summary?.additions,
+            summary_deletions: input.summary?.deletions,
+            summary_files: input.summary?.files,
+            summary_diffs: input.summary?.diffs as never,
+            revert: input.revert,
+            permission: input.permission as never,
+            time_created: input.timeCreated,
+            time_updated: input.timeUpdated,
+            time_compacting: input.timeCompacting,
+            time_archived: input.timeArchived,
+          },
         })
         .run()
     })

--- a/packages/opencode/src/kilocode/session-import/service.ts
+++ b/packages/opencode/src/kilocode/session-import/service.ts
@@ -27,6 +27,8 @@ export namespace SessionImportService {
       if (row && input.force) {
         db.delete(SessionTable).where(eq(target(SessionTable.id), input.id)).run()
       }
+      // We still keep onConflictDoUpdate here so forced reimports can recreate the session row
+      // and non-forced calls remain idempotent if they reach the DB after the existence guard.
       db.insert(SessionTable)
         .values({
           id: input.id,

--- a/packages/opencode/src/kilocode/session-import/types.ts
+++ b/packages/opencode/src/kilocode/session-import/types.ts
@@ -151,6 +151,7 @@ export namespace SessionImportType {
   export const Session = z.object({
     id: z.string(),
     projectID: z.string(),
+    force: z.boolean().optional(),
     workspaceID: z.string().optional(),
     parentID: z.string().optional(),
     slug: z.string(),

--- a/packages/opencode/test/kilocode/session-import-service.test.ts
+++ b/packages/opencode/test/kilocode/session-import-service.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+
+const use = mock((fn: (db: any) => unknown) => fn(db))
+const eq = (a: unknown, b: unknown) => ({ a, b })
+
+mock.module("../../src/storage/db", () => ({
+  Database: { use, close() {} },
+  eq,
+}))
+
+const { SessionImportService } = await import("../../src/kilocode/session-import/service")
+
+const sessionTable = { id: "session.id" }
+const db = {
+  select() {
+    return {
+      from() {
+        return {
+          where() {
+            return {
+              get() {
+                return rows.session
+              },
+            }
+          },
+        }
+      },
+    }
+  },
+  delete() {
+    return {
+      where() {
+        return {
+          run() {
+            deletes.push("session")
+            rows.session = undefined
+            rows.messages = []
+            rows.parts = []
+          },
+        }
+      },
+    }
+  },
+  insert() {
+    return {
+      values(input: Record<string, unknown>) {
+        return {
+          onConflictDoUpdate() {
+            return {
+              run() {
+                rows.session = { ...input }
+              },
+            }
+          },
+          run() {
+            rows.session = { ...input }
+          },
+        }
+      },
+    }
+  },
+}
+
+const rows = {
+  session: undefined as Record<string, unknown> | undefined,
+  messages: [] as string[],
+  parts: [] as string[],
+}
+
+const deletes: string[] = []
+
+function input(force?: boolean) {
+  return {
+    id: "ses_migrated_test",
+    projectID: "proj_test",
+    slug: "legacy-task",
+    directory: "/workspace/testing",
+    title: force ? "Reimported task" : "Legacy task",
+    version: "v2",
+    timeCreated: 1,
+    timeUpdated: 1,
+    ...(force ? { force: true } : {}),
+  }
+}
+
+describe("SessionImportService.session", () => {
+  beforeEach(() => {
+    use.mockClear()
+    deletes.length = 0
+    rows.session = undefined
+    rows.messages = []
+    rows.parts = []
+  })
+
+  afterEach(() => {
+    use.mockClear()
+  })
+
+  test("returns skipped when the session already exists and force is false", async () => {
+    rows.session = { id: "ses_migrated_test", title: "Legacy task" }
+
+    const result = await SessionImportService.session(input())
+
+    expect(result).toEqual({ ok: true, id: "ses_migrated_test", skipped: true })
+    expect(deletes).toEqual([])
+  })
+
+  test("deletes and recreates the session when force is true", async () => {
+    rows.session = { id: "ses_migrated_test", title: "Legacy task" }
+    rows.messages = ["msg_test"]
+    rows.parts = ["prt_test"]
+
+    const result = await SessionImportService.session(input(true))
+
+    expect(result).toEqual({ ok: true, id: "ses_migrated_test" })
+    expect(deletes).toEqual(["session"])
+    expect(rows.messages).toEqual([])
+    expect(rows.parts).toEqual([])
+    expect(rows.session).toMatchObject({ title: "Reimported task" })
+  })
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -3180,6 +3180,7 @@ export class SessionImport extends HeyApiClient {
       workspace?: string
       id?: string
       projectID?: string
+      force?: boolean
       workspaceID?: string
       parentID?: string
       slug?: string
@@ -3224,6 +3225,7 @@ export class SessionImport extends HeyApiClient {
             { in: "query", key: "workspace" },
             { in: "body", key: "id" },
             { in: "body", key: "projectID" },
+            { in: "body", key: "force" },
             { in: "body", key: "workspaceID" },
             { in: "body", key: "parentID" },
             { in: "body", key: "slug" },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4591,6 +4591,7 @@ export type KilocodeSessionImportSessionData = {
   body?: {
     id: string
     projectID: string
+    force?: boolean
     workspaceID?: string
     parentID?: string
     slug: string


### PR DESCRIPTION
Part of #8189 

## Context

Adds a detailed progress overview of the session migration. Shows the session migration progress per session, and creates a summary at the end. The user has the option to re-import sessions if they wish to do so. See video attached.

## Implementation

- The session migration now offers an insight on the migration process, showing details of the current session being migrated.
- The summary offers a list of sessions migrated successfully, sessions skipped and sessions errored, and the option to copy a report with those details.
- The user has the option to force re-import specific sessions, with a warning that they'll overwrite any progress made on the session.
- When migrating a session, there's now a `force` option which will do a delete + insert if the session was previously migrated.

## Video

https://github.com/user-attachments/assets/ffd21e66-095c-468a-a6f2-4b16af0c21a5


## Testing

- Checked unit tests pass
- Checked sessions are migrated correctly
- Checked re-imported sessions revert the session to the last message sent on old extension
- Manually triggered an error and checked this is displayed correctly
- Checked the "Copy Report" functionality works correctly
