### PR TITLE
fix(vscode): distinguish timeout from user cancellation in commit message generation

### DIFF
--- a/packages/kilo-vscode/src/services/commit-message/index.ts
+++ b/packages/kilo-vscode/src/services/commit-message/index.ts
@@ -65,6 +65,8 @@ export function registerCommitMessageService(
 
       const previousMessage = lastWorkspacePath === path ? lastGeneratedMessage : undefined
 
+      let userCancelled = false
+      let timedOut = false
       const controller = new AbortController()
 
       await vscode.window
@@ -76,13 +78,19 @@ export function registerCommitMessageService(
           },
           async (_progress, token) => {
             // Wire VS Code cancellation to abort the HTTP request
-            token.onCancellationRequested(() => controller.abort())
+            token.onCancellationRequested(() => {
+              userCancelled = true
+              controller.abort()
+            })
 
             // Client-side safety timeout (35s) — slightly longer than the
             // server-side 30s timeout so the server can respond with a proper
             // error first, but still ensures the spinner never hangs forever.
             const timeout = 35_000
-            const timer = setTimeout(() => controller.abort(), timeout)
+            const timer = setTimeout(() => {
+              timedOut = true
+              controller.abort()
+            }, timeout)
 
             try {
               const { data } = await client.commitMessage.generate(
@@ -100,8 +108,13 @@ export function registerCommitMessageService(
           },
         )
         .then(undefined, (error: unknown) => {
-          if (controller.signal.aborted) {
-            console.log("[Kilo New] Commit message generation was cancelled or timed out")
+          if (userCancelled) {
+            console.log("[Kilo New] Commit message generation was cancelled by user")
+            return
+          }
+          if (timedOut) {
+            console.log("[Kilo New] Commit message generation timed out")
+            vscode.window.showErrorMessage("Commit message generation timed out. Please try again.")
             return
           }
           const msg = getErrorMessage(error)


### PR DESCRIPTION
Closes #8366

## Context

Fixes #8366 — extension process crash (silent failure) when clicking
"Generate Commit Message".

Two bugs existed in the commit message generation service:

1. When the 35-second client-side timeout fired, the error handler
   silently swallowed it — the spinner disappeared with no feedback,
   which users perceived as a crash.
2. Two tests ("uses the matching repository when SourceControl arg is
   provided" and "falls back to first repository when SourceControl arg
   has no match") passed {} as the VS Code cancellation token mock,
   causing token.onCancellationRequested is not a function to throw.

> **Note:** The stack trace in the issue references JetBrains/PyCharm,
> but the root cause exists in the shared VS Code extension service.
> JetBrains may need a separate follow-up.

## Implementation

In index.ts, the single controller.signal.aborted check conflated user
cancellation and timeout. Replaced with two explicit flags (userCancelled,
timedOut) set in their respective abort callbacks:
- User cancels: silent (they know)
- 35s timeout: shows "Commit message generation timed out. Please try again."
- Server/network error: shows the error message as before

In index.spec.ts, the two affected test mocks now pass
{ onCancellationRequested: vi.fn() } instead of {} so the production
code path executes correctly.

## Screenshots

| before | after |
| ------ | ----- |
| Spinner disappears silently on timeout | "Commit message generation timed out. Please try again." shown |

## How to Test

1. Open a git repository in VS Code with the Kilo Code extension
2. Go to the Source Control panel
3. Click the Kilo "Generate Commit Message" button
4. Disconnect the Kilo backend and wait 35s — you should now see
   "Commit message generation timed out. Please try again." instead of
   a silent spinner disappearance
5. Click cancel -> should dismiss silently as before

Unit tests: npx vitest run src/services/commit-message/__tests__/index.spec.ts
-> 11/11 pass

## Get in Touch

Discord: sanan9
