### PR TITLE
perf: parallelize model fetches and add stale-while-revalidate to reduce model picker latency

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1131,6 +1131,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         this.seedSessionStatusMap(),
       ])
       this.sendNotificationSettings()
+      this.postMessage({ type: "extensionDataReady" })
 
       // Start polling worktree diff stats for the sidebar badge
       this.startStatsPolling()

--- a/packages/kilo-vscode/webview-ui/src/context/config.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/config.tsx
@@ -71,25 +71,20 @@ export const ConfigProvider: ParentComponent = (props) => {
 
   onCleanup(unsubscribe)
 
-  // Request config in case the initial push was missed.
-  // Retry a few times because the extension's httpClient may
-  // not be ready yet when the first request arrives.
-  let retries = 0
-  const maxRetries = 5
-  const retryMs = 500
-
+  // Request config immediately; if the extension's httpClient is not yet ready,
+  // the extensionDataReady signal will arrive once initialization completes and
+  // we retry once at that point if data still hasn't loaded.
   vscode.postMessage({ type: "requestConfig" })
 
-  const retryTimer = setInterval(() => {
-    retries++
-    if (!loading() || retries >= maxRetries) {
-      clearInterval(retryTimer)
-      return
+  const unsubReady = vscode.onMessage((message: ExtensionMessage) => {
+    if (message.type !== "extensionDataReady") return
+    unsubReady()
+    if (loading()) {
+      vscode.postMessage({ type: "requestConfig" })
     }
-    vscode.postMessage({ type: "requestConfig" })
-  }, retryMs)
+  })
 
-  onCleanup(() => clearInterval(retryTimer))
+  onCleanup(unsubReady)
 
   function updateConfig(partial: Partial<Config>) {
     // Optimistically update local state with deep merge + null stripping

--- a/packages/kilo-vscode/webview-ui/src/context/config.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/config.tsx
@@ -73,18 +73,29 @@ export const ConfigProvider: ParentComponent = (props) => {
 
   // Request config immediately; if the extension's httpClient is not yet ready,
   // the extensionDataReady signal will arrive once initialization completes and
-  // we retry once at that point if data still hasn't loaded.
+  // we retry once at that point. A 3s fallback covers edge cases where the signal
+  // is delayed (e.g. one fetcher is slow and blocks the Promise.all).
   vscode.postMessage({ type: "requestConfig" })
+
+  const fallback = setTimeout(() => {
+    if (loading()) {
+      vscode.postMessage({ type: "requestConfig" })
+    }
+  }, 3000)
 
   const unsubReady = vscode.onMessage((message: ExtensionMessage) => {
     if (message.type !== "extensionDataReady") return
     unsubReady()
+    clearTimeout(fallback)
     if (loading()) {
       vscode.postMessage({ type: "requestConfig" })
     }
   })
 
-  onCleanup(unsubReady)
+  onCleanup(() => {
+    unsubReady()
+    clearTimeout(fallback)
+  })
 
   function updateConfig(partial: Partial<Config>) {
     // Optimistically update local state with deep merge + null stripping

--- a/packages/kilo-vscode/webview-ui/src/context/provider.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/provider.tsx
@@ -64,25 +64,20 @@ export const ProviderProvider: ParentComponent = (props) => {
 
   onCleanup(unsubscribe)
 
-  // Request providers in case the initial push was missed.
-  // Retry a few times because the extension's httpClient may
-  // not be ready yet when the first request arrives.
-  let retries = 0
-  const maxRetries = 5
-  const retryMs = 500
-
+  // Request providers immediately; if the extension's httpClient is not yet ready,
+  // the extensionDataReady signal will arrive once initialization completes and
+  // we retry once at that point if data still hasn't loaded.
   vscode.postMessage({ type: "requestProviders" })
 
-  const retryTimer = setInterval(() => {
-    retries++
-    if (Object.keys(providers()).length > 0 || retries >= maxRetries) {
-      clearInterval(retryTimer)
-      return
+  const unsubReady = vscode.onMessage((message: ExtensionMessage) => {
+    if (message.type !== "extensionDataReady") return
+    unsubReady()
+    if (Object.keys(providers()).length === 0) {
+      vscode.postMessage({ type: "requestProviders" })
     }
-    vscode.postMessage({ type: "requestProviders" })
-  }, retryMs)
+  })
 
-  onCleanup(() => clearInterval(retryTimer))
+  onCleanup(unsubReady)
 
   const value: ProviderContextValue = {
     providers,

--- a/packages/kilo-vscode/webview-ui/src/context/provider.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/provider.tsx
@@ -66,18 +66,29 @@ export const ProviderProvider: ParentComponent = (props) => {
 
   // Request providers immediately; if the extension's httpClient is not yet ready,
   // the extensionDataReady signal will arrive once initialization completes and
-  // we retry once at that point if data still hasn't loaded.
+  // we retry once at that point. A 3s fallback covers edge cases where the signal
+  // is delayed (e.g. one fetcher is slow and blocks the Promise.all).
   vscode.postMessage({ type: "requestProviders" })
+
+  const fallback = setTimeout(() => {
+    if (Object.keys(providers()).length === 0) {
+      vscode.postMessage({ type: "requestProviders" })
+    }
+  }, 3000)
 
   const unsubReady = vscode.onMessage((message: ExtensionMessage) => {
     if (message.type !== "extensionDataReady") return
     unsubReady()
+    clearTimeout(fallback)
     if (Object.keys(providers()).length === 0) {
       vscode.postMessage({ type: "requestProviders" })
     }
   })
 
-  onCleanup(unsubReady)
+  onCleanup(() => {
+    unsubReady()
+    clearTimeout(fallback)
+  })
 
   const value: ProviderContextValue = {
     providers,

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -482,23 +482,10 @@ export const SessionProvider: ParentComponent = (props) => {
     )
   })
 
-  // Request agents in case the initial push was missed.
-  // Retry a few times because the extension's httpClient may
-  // not be ready yet when the first request arrives.
-  let agentRetries = 0
-  const agentMaxRetries = 5
-  const agentRetryMs = 500
-
+  // Request agents immediately; if the extension's httpClient is not yet ready,
+  // the extensionDataReady signal will arrive once initialization completes and
+  // we retry once at that point if data still hasn't loaded.
   vscode.postMessage({ type: "requestAgents" })
-
-  const agentRetryTimer = setInterval(() => {
-    agentRetries++
-    if (agents().length > 0 || agentRetries >= agentMaxRetries) {
-      clearInterval(agentRetryTimer)
-      return
-    }
-    vscode.postMessage({ type: "requestAgents" })
-  }, agentRetryMs)
 
   // Skills loaded from the CLI backend
   const unsubSkills = vscode.onMessage((message: ExtensionMessage) => {
@@ -524,24 +511,21 @@ export const SessionProvider: ParentComponent = (props) => {
     }
   })
 
-  // Request MCP status on init with retry (same pattern as agents)
-  let mcpRetries = 0
+  // Request MCP status immediately; retry once on extensionDataReady if still missing.
   vscode.postMessage({ type: "requestMcpStatus" })
-  const mcpRetryTimer = setInterval(() => {
-    mcpRetries++
-    if (Object.keys(mcpStatus()).length > 0 || mcpRetries >= 5) {
-      clearInterval(mcpRetryTimer)
-      return
-    }
-    vscode.postMessage({ type: "requestMcpStatus" })
-  }, 500)
+
+  const unsubDataReady = vscode.onMessage((message: ExtensionMessage) => {
+    if (message.type !== "extensionDataReady") return
+    unsubDataReady()
+    if (agents().length === 0) vscode.postMessage({ type: "requestAgents" })
+    if (Object.keys(mcpStatus()).length === 0) vscode.postMessage({ type: "requestMcpStatus" })
+  })
 
   onCleanup(() => {
     unsubAgents()
     unsubSkills()
     unsubMcpStatus()
-    clearInterval(agentRetryTimer)
-    clearInterval(mcpRetryTimer)
+    unsubDataReady()
   })
 
   // Variant (thinking effort) selection — keyed by "providerID/modelID"

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -512,11 +512,19 @@ export const SessionProvider: ParentComponent = (props) => {
   })
 
   // Request MCP status immediately; retry once on extensionDataReady if still missing.
+  // A 3s fallback covers edge cases where the signal is delayed (e.g. one fetcher
+  // is slow and blocks the Promise.all in initializeConnection).
   vscode.postMessage({ type: "requestMcpStatus" })
+
+  const fallback = setTimeout(() => {
+    if (agents().length === 0) vscode.postMessage({ type: "requestAgents" })
+    if (Object.keys(mcpStatus()).length === 0) vscode.postMessage({ type: "requestMcpStatus" })
+  }, 3000)
 
   const unsubDataReady = vscode.onMessage((message: ExtensionMessage) => {
     if (message.type !== "extensionDataReady") return
     unsubDataReady()
+    clearTimeout(fallback)
     if (agents().length === 0) vscode.postMessage({ type: "requestAgents" })
     if (Object.keys(mcpStatus()).length === 0) vscode.postMessage({ type: "requestMcpStatus" })
   })
@@ -526,6 +534,7 @@ export const SessionProvider: ParentComponent = (props) => {
     unsubSkills()
     unsubMcpStatus()
     unsubDataReady()
+    clearTimeout(fallback)
   })
 
   // Variant (thinking effort) selection — keyed by "providerID/modelID"

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1190,6 +1190,10 @@ export interface ClearPendingPromptsMessage {
   type: "clearPendingPrompts"
 }
 
+export interface ExtensionDataReadyMessage {
+  type: "extensionDataReady"
+}
+
 // ============================================
 // Marketplace Messages
 // ============================================
@@ -1380,6 +1384,7 @@ export type ExtensionMessage =
   | WorktreeStatsLoadedMessage
   | McpStatusLoadedMessage
   | ClearPendingPromptsMessage
+  | ExtensionDataReadyMessage
 
 // ============================================
 // Messages FROM webview TO extension

--- a/packages/opencode/src/provider/model-cache.ts
+++ b/packages/opencode/src/provider/model-cache.ts
@@ -21,11 +21,11 @@ export namespace ModelCache {
   const inFlightRefresh = new Map<string, Promise<Record<string, any>>>()
 
   /**
-   * Get cached models if available and not expired
+   * Get cached models if available (returns stale entries too, caller decides)
    * @param providerID - Provider identifier (e.g., "kilo")
-   * @returns Cached models or undefined if cache miss or expired
+   * @returns Cached entry with stale flag, or undefined on cache miss
    */
-  export function get(providerID: string): Record<string, any> | undefined {
+  export function get(providerID: string): { models: Record<string, any>; stale: boolean } | undefined {
     const cached = cache.get(providerID)
 
     if (!cached) {
@@ -33,33 +33,37 @@ export namespace ModelCache {
       return undefined
     }
 
-    const now = Date.now()
-    const age = now - cached.timestamp
+    const age = Date.now() - cached.timestamp
 
     if (age > TTL) {
-      log.debug("cache expired", { providerID, age })
-      cache.delete(providerID)
-      return undefined
+      log.debug("cache stale", { providerID, age })
+      return { models: cached.models, stale: true }
     }
 
     log.debug("cache hit", { providerID, age })
-    return cached.models
+    return { models: cached.models, stale: false }
   }
 
   /**
-   * Fetch models with cache-first approach
+   * Fetch models with cache-first + stale-while-revalidate approach.
+   * If cached data exists but is stale, it is returned immediately while
+   * a background refresh is kicked off to update the cache.
    * @param providerID - Provider identifier
    * @param options - Provider options
    * @returns Models from cache or freshly fetched
    */
   export async function fetch(providerID: string, options?: any): Promise<Record<string, any>> {
-    // Check cache first
-    const cached = get(providerID)
-    if (cached) {
-      return cached
+    const entry = get(providerID)
+
+    if (entry) {
+      if (!entry.stale) return entry.models
+      // Stale — return immediately and revalidate in background
+      log.info("returning stale models, revalidating in background", { providerID })
+      refresh(providerID, options).catch(() => {})
+      return entry.models
     }
 
-    // Cache miss - fetch models
+    // Cold cache miss — must block on fetch
     log.info("fetching models", { providerID })
 
     try {
@@ -68,7 +72,6 @@ export namespace ModelCache {
 
       const models = await fetchModels(providerID, mergedOptions)
 
-      // Store in cache
       cache.set(providerID, {
         models,
         timestamp: Date.now(),

--- a/packages/opencode/src/provider/model-cache.ts
+++ b/packages/opencode/src/provider/model-cache.ts
@@ -21,6 +21,8 @@ export namespace ModelCache {
 
   const TTL = 5 * 60 * 1000 // 5 minutes
   const inFlightRefresh = new Map<string, Promise<Record<string, any>>>()
+  // Set of keys whose in-flight refresh has been cancelled by clear()
+  const cancelled = new Set<string>()
 
   /**
    * Stable fingerprint of the options that affect which models are returned.
@@ -121,6 +123,9 @@ export namespace ModelCache {
       return existing
     }
 
+    // Track cancellation for this key before starting the async work
+    cancelled.delete(key)
+
     // Create new refresh promise
     const refreshPromise = (async () => {
       log.info("refreshing models", { key })
@@ -131,12 +136,18 @@ export namespace ModelCache {
 
         const models = await fetchModels(providerID, mergedOptions)
 
-        cache.set(key, {
-          models,
-          timestamp: Date.now(),
-        })
+        // Only write back if this refresh was not cancelled by clear()
+        if (!cancelled.has(key)) {
+          cache.set(key, {
+            models,
+            timestamp: Date.now(),
+          })
+          log.info("models refreshed", { key, count: Object.keys(models).length })
+        } else {
+          log.info("refresh cancelled by clear(), discarding result", { key })
+          cancelled.delete(key)
+        }
 
-        log.info("models refreshed", { key, count: Object.keys(models).length })
         return models
       } catch (error) {
         log.error("failed to refresh models", { key, error })
@@ -172,6 +183,14 @@ export namespace ModelCache {
       if (key === providerID || key.startsWith(prefix)) {
         cache.delete(key)
         count++
+      }
+    }
+    // Also cancel any in-flight refreshes for this provider so that a stale
+    // refresh completing after the clear cannot write old models back into cache.
+    for (const key of inFlightRefresh.keys()) {
+      if (key === providerID || key.startsWith(prefix)) {
+        cancelled.add(key)
+        inFlightRefresh.delete(key)
       }
     }
     if (count > 0) {

--- a/packages/opencode/src/provider/model-cache.ts
+++ b/packages/opencode/src/provider/model-cache.ts
@@ -8,7 +8,9 @@ import { Log } from "../util/log"
 export namespace ModelCache {
   const log = Log.create({ service: "model-cache" })
 
-  // Cache structure
+  // Cache structure — keyed by "providerID:optionsFingerprint" so that
+  // config changes (org ID, base URL, etc.) automatically cause a cache miss
+  // rather than serving the previous model set until TTL expiry.
   const cache = new Map<
     string,
     {
@@ -21,26 +23,42 @@ export namespace ModelCache {
   const inFlightRefresh = new Map<string, Promise<Record<string, any>>>()
 
   /**
-   * Get cached models if available (returns stale entries too, caller decides)
-   * @param providerID - Provider identifier (e.g., "kilo")
+   * Stable fingerprint of the options that affect which models are returned.
+   * Only includes fields that change the model set (org ID, base URL).
+   * Keeps the key short and deterministic without a full JSON sort.
+   */
+  function fingerprint(providerID: string, options?: any): string {
+    if (!options) return providerID
+    const parts: string[] = [providerID]
+    if (options.kilocodeOrganizationId) parts.push(`org:${options.kilocodeOrganizationId}`)
+    if (options.baseURL) parts.push(`url:${options.baseURL}`)
+    return parts.join("|")
+  }
+
+  /**
+   * Get cached models for a provider + options combination.
+   * Returns stale entries too (caller decides what to do with them).
+   * @param providerID - Provider identifier
+   * @param options - Same options passed to fetch/refresh
    * @returns Cached entry with stale flag, or undefined on cache miss
    */
-  export function get(providerID: string): { models: Record<string, any>; stale: boolean } | undefined {
-    const cached = cache.get(providerID)
+  export function get(providerID: string, options?: any): { models: Record<string, any>; stale: boolean } | undefined {
+    const key = fingerprint(providerID, options)
+    const cached = cache.get(key)
 
     if (!cached) {
-      log.debug("cache miss", { providerID })
+      log.debug("cache miss", { key })
       return undefined
     }
 
     const age = Date.now() - cached.timestamp
 
     if (age > TTL) {
-      log.debug("cache stale", { providerID, age })
+      log.debug("cache stale", { key, age })
       return { models: cached.models, stale: true }
     }
 
-    log.debug("cache hit", { providerID, age })
+    log.debug("cache hit", { key, age })
     return { models: cached.models, stale: false }
   }
 
@@ -49,22 +67,23 @@ export namespace ModelCache {
    * If cached data exists but is stale, it is returned immediately while
    * a background refresh is kicked off to update the cache.
    * @param providerID - Provider identifier
-   * @param options - Provider options
+   * @param options - Provider options (org ID, base URL, etc.)
    * @returns Models from cache or freshly fetched
    */
   export async function fetch(providerID: string, options?: any): Promise<Record<string, any>> {
-    const entry = get(providerID)
+    const key = fingerprint(providerID, options)
+    const entry = get(providerID, options)
 
     if (entry) {
       if (!entry.stale) return entry.models
       // Stale — return immediately and revalidate in background
-      log.info("returning stale models, revalidating in background", { providerID })
+      log.info("returning stale models, revalidating in background", { key })
       refresh(providerID, options).catch(() => {})
       return entry.models
     }
 
     // Cold cache miss — must block on fetch
-    log.info("fetching models", { providerID })
+    log.info("fetching models", { key })
 
     try {
       const authOptions = await getAuthOptions(providerID)
@@ -72,15 +91,15 @@ export namespace ModelCache {
 
       const models = await fetchModels(providerID, mergedOptions)
 
-      cache.set(providerID, {
+      cache.set(key, {
         models,
         timestamp: Date.now(),
       })
 
-      log.info("models fetched and cached", { providerID, count: Object.keys(models).length })
+      log.info("models fetched and cached", { key, count: Object.keys(models).length })
       return models
     } catch (error) {
-      log.error("failed to fetch models", { providerID, error })
+      log.error("failed to fetch models", { key, error })
       return {}
     }
   }
@@ -93,16 +112,18 @@ export namespace ModelCache {
    * @returns Freshly fetched models
    */
   export async function refresh(providerID: string, options?: any): Promise<Record<string, any>> {
-    // Check if refresh already in progress
-    const existing = inFlightRefresh.get(providerID)
+    const key = fingerprint(providerID, options)
+
+    // Check if refresh already in progress for this exact key
+    const existing = inFlightRefresh.get(key)
     if (existing) {
-      log.debug("refresh already in progress, returning existing promise", { providerID })
+      log.debug("refresh already in progress, returning existing promise", { key })
       return existing
     }
 
     // Create new refresh promise
     const refreshPromise = (async () => {
-      log.info("refreshing models", { providerID })
+      log.info("refreshing models", { key })
 
       try {
         const authOptions = await getAuthOptions(providerID)
@@ -110,21 +131,19 @@ export namespace ModelCache {
 
         const models = await fetchModels(providerID, mergedOptions)
 
-        // Update cache with new models
-        cache.set(providerID, {
+        cache.set(key, {
           models,
           timestamp: Date.now(),
         })
 
-        log.info("models refreshed", { providerID, count: Object.keys(models).length })
+        log.info("models refreshed", { key, count: Object.keys(models).length })
         return models
       } catch (error) {
-        log.error("failed to refresh models", { providerID, error })
+        log.error("failed to refresh models", { key, error })
 
-        // Return existing cache or empty object
-        const cached = cache.get(providerID)
+        const cached = cache.get(key)
         if (cached) {
-          log.debug("returning stale cache after refresh failure", { providerID })
+          log.debug("returning stale cache after refresh failure", { key })
           return cached.models
         }
 
@@ -132,25 +151,31 @@ export namespace ModelCache {
       }
     })()
 
-    // Track in-flight refresh
-    inFlightRefresh.set(providerID, refreshPromise)
+    inFlightRefresh.set(key, refreshPromise)
 
     try {
       return await refreshPromise
     } finally {
-      // Clean up in-flight tracking
-      inFlightRefresh.delete(providerID)
+      inFlightRefresh.delete(key)
     }
   }
 
   /**
-   * Clear cached models for a provider
+   * Clear all cached entries for a provider (all option variants).
+   * Called on auth changes — wipes every fingerprinted key for the providerID.
    * @param providerID - Provider identifier
    */
   export function clear(providerID: string): void {
-    const deleted = cache.delete(providerID)
-    if (deleted) {
-      log.info("cache cleared", { providerID })
+    const prefix = providerID + "|"
+    let count = 0
+    for (const key of cache.keys()) {
+      if (key === providerID || key.startsWith(prefix)) {
+        cache.delete(key)
+        count++
+      }
+    }
+    if (count > 0) {
+      log.info("cache cleared", { providerID, count })
     } else {
       log.debug("no cache to clear", { providerID })
     }

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -164,7 +164,20 @@ export namespace ModelsDev {
         : "https://api.kilo.ai/api/openrouter"
       const providerBaseURL = normalizedBaseURL ?? defaultBaseURL
       const ensureTrailingSlash = (value: string): string => (value.endsWith("/") ? value : `${value}/`)
-      const kiloModels = await ModelCache.fetch("kilo", kiloFetchOptions).catch(() => ({}))
+      const apertisConfigObj = await Config.get()
+      const apertisConfig = apertisConfigObj.provider?.apertis?.options
+      const apertisBaseURL = apertisConfig?.baseURL ?? "https://api.apertis.ai/v1"
+      const apertisFetchOptions = {
+        ...(apertisConfig?.baseURL ? { baseURL: apertisConfig.baseURL } : {}),
+      }
+
+      const [kiloModels, apertisModels] = await Promise.all([
+        ModelCache.fetch("kilo", kiloFetchOptions).catch(() => ({})),
+        providers["apertis"]
+          ? Promise.resolve(null)
+          : ModelCache.fetch("apertis", apertisFetchOptions).catch(() => ({})),
+      ])
+
       providers["kilo"] = {
         id: "kilo",
         name: "Kilo Gateway",
@@ -176,10 +189,21 @@ export namespace ModelsDev {
       if (Object.keys(kiloModels).length === 0) {
         ModelCache.refresh("kilo", kiloFetchOptions).catch(() => {})
       }
-    }
 
-    // Inject Apertis provider with dynamic model fetching
-    if (!providers["apertis"]) {
+      if (!providers["apertis"] && apertisModels !== null) {
+        providers["apertis"] = {
+          id: "apertis",
+          name: "Apertis",
+          env: ["APERTIS_API_KEY"],
+          api: apertisBaseURL,
+          npm: "@ai-sdk/openai-compatible",
+          models: apertisModels,
+        }
+        if (Object.keys(apertisModels).length === 0) {
+          ModelCache.refresh("apertis", apertisFetchOptions).catch(() => {})
+        }
+      }
+    } else if (!providers["apertis"]) {
       const apertisConfigObj = await Config.get()
       const apertisConfig = apertisConfigObj.provider?.apertis?.options
       const apertisBaseURL = apertisConfig?.baseURL ?? "https://api.apertis.ai/v1"

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1025,14 +1025,20 @@ export namespace Provider {
       }
     }
 
-    for (const [providerID, fn] of Object.entries(CUSTOM_LOADERS)) {
-      if (disabled.has(providerID)) continue
-      const data = database[providerID]
-      if (!data) {
-        log.error("Provider does not exist in model list " + providerID)
-        continue
+    const loaderEntries = Object.entries(CUSTOM_LOADERS).filter(([id]) => {
+      if (disabled.has(id)) return false
+      if (!database[id]) {
+        log.error("Provider does not exist in model list " + id)
+        return false
       }
-      const result = await fn(data)
+      return true
+    })
+    const loaded = await Promise.allSettled(
+      loaderEntries.map(async ([id, fn]) => ({ id, result: await fn(database[id]) })),
+    )
+    for (const item of loaded) {
+      if (item.status === "rejected") continue
+      const { id: providerID, result } = item.value
       if (result && (result.autoload || providers[providerID])) {
         if (result.getModel) modelLoaders[providerID] = result.getModel
         const opts = result.options ?? {}


### PR DESCRIPTION
## Context

The model picker was experiencing multi-second delays on open. The delay doesn't happen in the picker itself (it reads from pre-fetched in-memory data), but during the server-side initialization that populates that data. This PR addresses the highest-impact bottlenecks identified in a root cause analysis.

## Implementation

Four changes, each independent:

**1. Parallelize Kilo + Apertis model fetches (`models.ts`)**

`ModelsDev.get()` was awaiting `ModelCache.fetch("kilo")` then `ModelCache.fetch("apertis")` sequentially, each with a 10s timeout. Replaced with `Promise.all([...])`. Worst-case latency: 20s → 10s.

**2. Parallelize custom provider loaders (`provider.ts`)**

The `for...of` loop that `await`ed 19 `CUSTOM_LOADERS` entries (Anthropic, OpenAI, Bedrock, Vertex, etc.) one-by-one is replaced with `Promise.allSettled()`. Each loader does async I/O (config reads, auth lookups, AWS/Google credential chains). They're now all in-flight concurrently. Post-settlement merging remains sequential since it's synchronous and order-independent.

**3. Stale-while-revalidate for `ModelCache` (`model-cache.ts`)**

`get()` no longer eagerly deletes expired entries — it returns them with a `stale: boolean` flag. `fetch()` now: on a fresh hit returns immediately, on a stale hit returns the stale data and fires `refresh()` in the background, on a cold miss blocks on the network as before. After the first successful fetch, users never block on model list retrieval at TTL expiry.

**4. Replace webview polling with `extensionDataReady` signal (`KiloProvider.ts` + context files)**

The webview used 4 independent `setInterval(500ms) × 5 retries` polling loops (for providers, config, agents, MCP status) because the extension's HTTP client might not be ready when the webview first requests data. This is replaced with an event-driven approach: `KiloProvider` sends `{ type: "extensionDataReady" }` after `initializeConnection` completes (all `fetchAndSend*` calls done). Each webview context makes its initial request immediately, then listens for `extensionDataReady` and retries once if data still hasn't arrived. Eliminates up to 2.5s of polling delay.

## Screenshots

N/A — performance change, no visual diff.

## How to Test

1. Open the extension in VS Code
2. Open the model picker
3. Providers and models should appear faster, especially on first load or after re-authentication
4. Disconnect and reconnect a provider — model list should update without a noticeable delay

## Get in Touch

kirillk on Discord