### PR TITLE
fix: prevent plan file corruption for OpenAI models by preserving write tool

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -152,7 +152,7 @@ export namespace ToolRegistry {
           const usePatch =
             model.modelID.includes("gpt-") && !model.modelID.includes("oss") && !model.modelID.includes("gpt-4")
           if (t.id === "apply_patch") return usePatch
-          if (t.id === "edit" || t.id === "write") return !usePatch
+          if (t.id === "edit") return !usePatch
 
           return true
         })


### PR DESCRIPTION
Fixes #8358

**Problem:**
OpenAI models (`gpt-5.*`) fail to write plan files. The agent attempts to use `apply_patch` to generate fresh, massive markdown files, which expects git-diff payloads and reliably corrupts the output.

**Root Cause:**
In `packages/opencode/src/tool/registry.ts`, when `usePatch` evaluates to true for `gpt-5.*` models, the `write` tool is explicitly filtered out alongside `edit`.

**Solution:**
Removed `t.id === "write"` from the `usePatch` exclusion condition. This preserves the `write` tool for file creation tasks while properly maintaining `apply_patch` for code modifications.