### PR TITLE
fix: stabilize worktree branch selector popovers

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/BranchSelect.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/BranchSelect.tsx
@@ -1,6 +1,6 @@
 // Reusable branch selector: search input + scrollable list with keyboard navigation
 
-import { type Component, For, Show, onMount } from "solid-js"
+import { type Component, For, Show } from "solid-js"
 import type { BranchInfo } from "../src/types/messages"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
@@ -34,10 +34,6 @@ interface BranchSelectProps {
 }
 
 export const BranchSelect: Component<BranchSelectProps> = (props) => {
-  let ref: HTMLInputElement | undefined
-
-  onMount(() => requestAnimationFrame(() => ref?.focus()))
-
   const isDefault = (branch: BranchInfo) => {
     if (props.defaultName) return branch.name === props.defaultName
     return branch.isDefault
@@ -48,7 +44,7 @@ export const BranchSelect: Component<BranchSelectProps> = (props) => {
       <div class="am-dropdown-search">
         <Icon name="magnifying-glass" size="small" />
         <input
-          ref={ref}
+          data-autofocus
           class="am-dropdown-search-input"
           type="text"
           placeholder={props.searchPlaceholder}

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -380,8 +380,10 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                           setHighlightedIndex(0)
                         }
                       }}
-                      placement="bottom-start"
+                      placement="top-start"
+                      flip={false}
                       sameWidth
+                      portal={false}
                       class="am-dropdown"
                       trigger={
                         <button class="am-selector-trigger" type="button">
@@ -625,8 +627,10 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
               <Popover
                 open={branchOpen()}
                 onOpenChange={setBranchOpen}
-                placement="bottom-start"
+                placement="top-start"
+                flip={false}
                 sameWidth
+                portal={false}
                 class="am-dropdown"
                 trigger={
                   <button class="am-selector-trigger" disabled={isPending()} type="button">

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -59,6 +59,14 @@ export function Popover<T extends ValidComponent = "div">(props: PopoverProps<T>
     return uncontrolledOpen()
   }
 
+  const focus = (node?: ParentNode | null) => {
+    const root = node ?? contentRef()
+    if (!root) return
+    const target = root.querySelector<HTMLElement>("[data-autofocus]")
+    if (!target) return
+    target.focus()
+  }
+
   const onOpenChange = (next: boolean) => {
     if (next) setDismiss(null)
     if (local.onOpenChange) local.onOpenChange(next)
@@ -135,6 +143,14 @@ export function Popover<T extends ValidComponent = "div">(props: PopoverProps<T>
     })
   })
 
+  createEffect(() => {
+    if (!opened()) return
+    const node = contentRef()
+    if (!node) return
+    const id = requestAnimationFrame(() => focus(node))
+    onCleanup(() => cancelAnimationFrame(id))
+  })
+
   const content = () => (
     <Kobalte.Content
       ref={(el: HTMLElement | undefined) => setContentRef(el)}
@@ -152,6 +168,12 @@ export function Popover<T extends ValidComponent = "div">(props: PopoverProps<T>
       }}
       onFocusOutside={(event: Event) => {
         event.preventDefault()
+      }}
+      onOpenAutoFocus={(event: Event) => {
+        const node = event.currentTarget as ParentNode | null
+        if (!node) return
+        event.preventDefault()
+        focus(node)
       }}
       onCloseAutoFocus={(event: Event) => {
         if (dismiss() === "outside") event.preventDefault()

--- a/packages/ui/src/context/dialog.tsx
+++ b/packages/ui/src/context/dialog.tsx
@@ -30,6 +30,7 @@ function init() {
   const [active, setActive] = createSignal<Active | undefined>()
   const timer = { current: undefined as ReturnType<typeof setTimeout> | undefined }
   const lock = { value: false }
+  const hasPopover = () => !!document.querySelector('[data-component="popover-content"]')
 
   onCleanup(() => {
     if (timer.current === undefined) return
@@ -63,6 +64,7 @@ function init() {
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return
+      if (hasPopover()) return
       close()
       event.preventDefault()
       event.stopPropagation()


### PR DESCRIPTION
## Summary
- render the worktree branch selector popovers inline so the dialog focus trap no longer blocks the search input
- autofocus the branch filter field when the popover opens and move branch selector inputs to shared `data-autofocus` behavior
- keep the branch selector popovers anchored above the trigger without flipping as filtered results change size

## Demo

### Before

Arrow keys don't work, typing doesn't work

https://github.com/user-attachments/assets/3bf10e01-5370-4156-aedf-cc551b423d25


### After

https://github.com/user-attachments/assets/b1db187f-a541-4daf-9541-5b6f45651c91


