### PR TITLE
fix(vscode): enable stop button and disable input during rate-limit retry

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -814,7 +814,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             onBlur={syncGhost}
             onSelect={syncGhost}
             onScroll={syncHighlightScroll}
-            disabled={isDisabled()}
+            disabled={retrying()}
             aria-disabled={isDisabled()}
             rows={1}
           />

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -245,10 +245,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   onCleanup(() => window.removeEventListener("compactSession", onCompact))
 
   const isBusy = () => session.status() === "busy"
-  const isDisabled = () => !server.isConnected()
+  const retrying = () => session.status() === "retry" // kilocode_change
+  const isDisabled = () => !server.isConnected() || retrying() // kilocode_change - block input during retry countdown
   const hasInput = () => text().trim().length > 0 || imageAttach.images().length > 0 || reviewComments().length > 0
   const canSend = () => hasInput() && !isDisabled() && !props.blocked?.()
-  const showStop = () => isBusy() && !hasInput()
+  const showStop = () => (isBusy() && !hasInput()) || retrying() // kilocode_change - show stop during retry countdown
   const isAtEnd = () =>
     textareaRef ? atEnd(textareaRef.selectionStart, textareaRef.selectionEnd, textareaRef.value.length) : false
   const placeholder = () => {
@@ -813,6 +814,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             onBlur={syncGhost}
             onSelect={syncGhost}
             onScroll={syncHighlightScroll}
+            disabled={isDisabled()}
             aria-disabled={isDisabled()}
             rows={1}
           />


### PR DESCRIPTION
# Final Report: Fix Issue #8330 — Stop generation during retry countdown

## Investigation
- **Problem**: In the sidebar chat UI, hitting a rate limit triggers a "retry" state. During this time, the "Stop" button disappeared and the input field remained active, which confused users and led to unintended message queuing.
- **Root Cause**: The `PromptInput` component only looked for `status === "busy"` to show the stop button and didn't check for `status === "retry"` at all.

## Solution
- **Enhanced signals**: Updated the `isDisabled` and `showStop` signals in `PromptInput.tsx` to include the `retry` state.
- **Native blocking**: Added the `disabled` attribute to the `<textarea>` to provide native browser-level input protection during the countdown.
- **E2E Compatibility**: Verified that the existing `session.abort()` logic correctly clears the backend retry timer and returns the UI to an `idle` state.

---

# Draft Pull Request

**Title**: `fix(vscode): enable stop button and disable input during rate-limit retry`

## Context
Resolves [GitHub Issue #8330](https://github.com/Kilo-Org/kilocode/issues/8330), [GitHub Issue #8401](https://github.com/Kilo-Org/kilocode/issues/8401), [GitHub Issue #8240](https://github.com/Kilo-Org/kilocode/issues/8240), [GitHub Issue #7796](https://github.com/Kilo-Org/kilocode/issues/7796).
Currently, when the extension hits a rate limit and enters the retry countdown, the user cannot stop the impending retry and can continue typing messages that get improperly queued.

## Implementation
Updated `packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx`:
1.  **`retrying` signal**: Added a reactive signal to check for the `"retry"` session status.
2.  **`isDisabled` logic**: Chat input and Send actions are now disabled when `retrying()` is true.
3.  **`showStop` logic**: The Stop button is now visible if either the session is busy OR if it is in the retry countdown.
4.  **Native `disabled` attribute**: Added `disabled={isDisabled()}` to the textarea for consistent behavior.

## How to Test
1.  **Trigger Retry**: Use a model that hits a rate limit, or simulate it using a backend mock that sends `status: "retry"`.
2.  **Verify UI**:
    - The chat input should be grayed out and un-editable.
    - The "Send" icon should be replaced by a "Stop" (square) icon.
3.  **Verify Stop**: Click the "Stop" button. The countdown should clear immediately and the input should re-enable.

## commit message
`fix(vscode): show stop button and disable input during retry`


## me!
Discord: Varuu 