### PR TITLE
fix(cli): prevent excessive git process spawning by caching diffFull (#8379)

### DIFF
--- a/packages/opencode/src/file/ignore.ts
+++ b/packages/opencode/src/file/ignore.ts
@@ -31,6 +31,8 @@ export namespace FileIgnore {
     "mypy_cache",
     ".history",
     ".gradle",
+    ".kilocode", // kilocode_change — ignore legacy local storage (#8379)
+    ".opencode", // kilocode_change — ignore legacy local storage (#8379)
   ])
 
   const FILES = [

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -187,8 +187,31 @@ export namespace Snapshot {
       ref: "FileDiff",
     })
   export type FileDiff = z.infer<typeof FileDiff>
+
+  // kilocode_change start — cache diffFull results to prevent redundant git spawning (#8379)
+  const diffCache = new Map<string, Promise<FileDiff[]>>()
+  const DIFF_CACHE_MAX = 100
+
   export async function diffFull(from: string, to: string): Promise<FileDiff[]> {
+    if (from === to) return []
+    const key = `${from}:${to}`
+    const cached = diffCache.get(key)
+    if (cached) return cached
+    if (diffCache.size >= DIFF_CACHE_MAX) {
+      const first = diffCache.keys().next().value
+      if (first) diffCache.delete(first)
+    }
+    const pending = diffFullUncached(from, to).catch((err) => {
+      diffCache.delete(key)
+      throw err
+    })
+    diffCache.set(key, pending)
+    return pending
+  }
+
+  async function diffFullUncached(from: string, to: string): Promise<FileDiff[]> {
     const git = await KiloSnapshot.prepare() // kilocode_change
+  // kilocode_change end
     const result: FileDiff[] = []
     const status = new Map<string, "added" | "deleted" | "modified">()
 

--- a/packages/opencode/test/kilocode/snapshot-cache.test.ts
+++ b/packages/opencode/test/kilocode/snapshot-cache.test.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "bun:test"
+import { $ } from "bun"
+import { Snapshot } from "../../src/snapshot"
+import { Instance } from "../../src/project/instance"
+import { Filesystem } from "../../src/util/filesystem"
+import { tmpdir } from "../fixture/fixture"
+
+async function bootstrap() {
+  return tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Filesystem.write(`${dir}/a.txt`, "A")
+      await Filesystem.write(`${dir}/b.txt`, "B")
+      await $`git add .`.cwd(dir).quiet()
+      await $`git commit --no-gpg-sign -m init`.cwd(dir).quiet()
+    },
+  })
+}
+
+test("diffFull returns cached result for same hash pair", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      await Filesystem.write(`${tmp.path}/a.txt`, "MODIFIED")
+      const after = await Snapshot.track()
+      expect(after).toBeTruthy()
+      expect(after).not.toBe(before)
+
+      const first = await Snapshot.diffFull(before!, after!)
+      const second = await Snapshot.diffFull(before!, after!)
+
+      // Should be the exact same array reference (cached)
+      expect(second).toBe(first)
+      expect(first.length).toBeGreaterThan(0)
+    },
+  })
+})
+
+test("diffFull returns empty array when from === to", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const hash = await Snapshot.track()
+      expect(hash).toBeTruthy()
+
+      const result = await Snapshot.diffFull(hash!, hash!)
+      expect(result).toEqual([])
+    },
+  })
+})
+
+test("diffFull concurrent calls for same pair share one result", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      await Filesystem.write(`${tmp.path}/a.txt`, "CONCURRENT")
+      const after = await Snapshot.track()
+      expect(after).toBeTruthy()
+
+      // Fire multiple concurrent calls — they should all resolve to the same object
+      const results = await Promise.all([
+        Snapshot.diffFull(before!, after!),
+        Snapshot.diffFull(before!, after!),
+        Snapshot.diffFull(before!, after!),
+      ])
+
+      expect(results[0]).toBe(results[1])
+      expect(results[1]).toBe(results[2])
+      expect(results[0].length).toBeGreaterThan(0)
+    },
+  })
+})


### PR DESCRIPTION
## Context

Fixes #8379

Resolves an issue where users experience a "constant stream" of `git ls-tree -l` and `git show --textconv` processes while Kilo is generating a response, leading to high RAM usage and delays.

## Implementation

The excessive processes had two root causes:
1. **VS Code Git Extension Polling**: The output logs like `[info] > git ls-tree -l HEAD -- ...` are from the built-in VS Code Git Extension. It runs these status checks whenever it detects rapid filesystem modifications.
2. **Legacy `.kilocode` Folder Updates**: Kilo previously stored local session data directly inside the project root `.kilocode` folder. Streamed LLM updates mean writing to disk many times per second, triggering the Git Extension event storm. We now ignore `.kilocode` and `.opencode` recursively in the file watcher to prevent triggering on legacy local storage properties.
3. **Redundant Background Diffing**: Within Kilo, `SessionSummary.summarize()` triggers asynchronously on every `finish-step` event during the LLM loop. This calls `Snapshot.diffFull(from, to)`, which shells out multiple `git diff` and `git show` commands. Because this result wasn't cached and ran on every step for historical messages, an enormous backlog of redundant git processes forms.

Changes:
- Added a bounded caching layer (LRU evicted at max size 100) directly to `Snapshot.diffFull(from, to)`. Since `from` and `to` are immutable git hashes, the computed diff never changes. The cache prevents redundant `git` subprocesses.
- Explicitly ensure `.kilocode` and `.opencode` folders are ignored in `@parcel/watcher` / `ignore` matcher configurations, avoiding cyclical polling and Git Extensions storm if users have legacy tracking databases within their projects.

## Screenshots

### Before

```typescript
// packages/opencode/src/snapshot/index.ts
export async function diffFull(from: string, to: string): Promise<FileDiff[]> {
  const git = await KiloSnapshot.prepare() // kilocode_change
  const result: FileDiff[] = []
  // Calculates diff and shells out multiple `git` processes every single time...
}
```

### After

```typescript
// packages/opencode/src/snapshot/index.ts
// kilocode_change start — cache diffFull results to prevent redundant git spawning (#8379)
const diffCache = new Map<string, Promise<FileDiff[]>>()
const DIFF_CACHE_MAX = 100

export async function diffFull(from: string, to: string): Promise<FileDiff[]> {
  if (from === to) return []
  const key = `${from}:${to}`
  const cached = diffCache.get(key)
  if (cached) return cached

  if (diffCache.size >= DIFF_CACHE_MAX) {
    const first = diffCache.keys().next().value
    if (first) diffCache.delete(first)
  }

  const pending = diffFullUncached(from, to).catch((err) => {
    diffCache.delete(key)
    throw err
  })
  diffCache.set(key, pending)
  return pending
}
```

## How to Test

1. Use Kilo to execute a long completion within a repository containing a legacy `.kilocode` directory inside the project root.
2. Open the native VS Code "Git" Output channel.
3. Observe that there are no repetitive `git ls-tree -l` or `git show --textconv` commands flooding the channel while the AI writes to the session file.

## Get in Touch

@varuu Discord