### PR TITLE
fix(cli): harden plan mode permissions and propagate restrictions to sub-agents

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -69,7 +69,11 @@ import {
   fetchAndSendPendingPermissions,
   type PermissionContext,
 } from "./kilo-provider/handlers/permission-handler"
-import { handleQuestionReply, handleQuestionReject } from "./kilo-provider/handlers/question"
+import {
+  handleQuestionReply,
+  handleQuestionReject,
+  fetchAndSendPendingQuestions,
+} from "./kilo-provider/handlers/question"
 
 import {
   buildActionContext,
@@ -1337,6 +1341,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         sessionID,
         messages,
       })
+
+      // Recover any missed permission/question prompts emitted by the child before
+      // we started tracking it.  Both run fire-and-forget after messagesLoaded so
+      // the webview isn't blocked.
+      void fetchAndSendPendingPermissions(this.permissionCtx)
+      void fetchAndSendPendingQuestions(this.questionCtx)
     } catch (err) {
       this.syncedChildSessions.delete(sessionID)
       console.error("[Kilo New] KiloProvider: Failed to sync child session:", err)
@@ -2361,6 +2371,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     return {
       client: this.client,
       currentSessionId: this.currentSession?.id,
+      trackedSessionIds: this.trackedSessionIds,
+      sessionDirectories: this.sessionDirectories,
       postMessage: (msg: unknown) => this.postMessage(msg),
       getWorkspaceDirectory: (sid?: string) => this.getWorkspaceDirectory(sid),
     }
@@ -2652,6 +2664,24 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (event.type === "session.updated" && this.currentSession?.id === event.properties.info.id) {
       this.currentSession = event.properties.info
       this.contextSessionID = event.properties.info.id
+    }
+
+    // Auto-adopt child sessions as soon as the task tool part reveals their ID.
+    // This means the child's permission/question events are tracked immediately —
+    // before the webview renderer has a chance to call syncSession — eliminating
+    // the race where the child blocks on a prompt that the UI never sees.
+    if (event.type === "message.part.updated") {
+      const part = event.properties.part as {
+        type?: string
+        tool?: string
+        metadata?: { sessionId?: string }
+        sessionID?: string
+      }
+      const childId = part.type === "tool" && part.tool === "task" ? part.metadata?.sessionId : undefined
+      if (childId && !this.trackedSessionIds.has(childId)) {
+        console.log("[Kilo New] KiloProvider: 🔗 Auto-adopting child session from task tool", { childId })
+        void this.handleSyncSession(childId, part.sessionID ?? sessionID)
+      }
     }
 
     const msg = mapSSEEventToWebviewMessage(event, sessionID)

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1057,6 +1057,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             await this.syncWebviewState("sse-connected")
             await this.flushPendingSessionRefresh("sse-connected")
             await fetchAndSendPendingPermissions(this.permissionCtx)
+            await fetchAndSendPendingQuestions(this.questionCtx)
           } catch (error) {
             console.error("[Kilo New] KiloProvider: ❌ Failed during connected state handling:", error)
             this.postMessage({

--- a/packages/kilo-vscode/src/kilo-provider/handlers/question.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/question.ts
@@ -1,7 +1,8 @@
 /**
  * Question handlers — extracted from KiloProvider.
  *
- * Manages question reply and reject flows from the tool question UI.
+ * Manages question reply and reject flows from the tool question UI,
+ * plus recovery of pending questions after SSE reconnections or child-session syncs.
  * No vscode dependency.
  */
 
@@ -10,8 +11,44 @@ import type { KiloClient } from "@kilocode/sdk/v2/client"
 interface QuestionContext {
   readonly client: KiloClient | null
   readonly currentSessionId: string | undefined
+  readonly trackedSessionIds: Set<string>
+  readonly sessionDirectories: ReadonlyMap<string, string>
   postMessage(msg: unknown): void
   getWorkspaceDirectory(sessionId?: string): string
+}
+
+/**
+ * Fetch all pending questions from the backend and forward any that belong
+ * to tracked sessions to the webview. Mirrors fetchAndSendPendingPermissions —
+ * called after child-session sync and after SSE reconnects so missed
+ * question.asked events don't leave the server blocked indefinitely.
+ */
+export async function fetchAndSendPendingQuestions(ctx: QuestionContext): Promise<void> {
+  if (!ctx.client) return
+  try {
+    const dirs = new Set<string>([ctx.getWorkspaceDirectory(), ...ctx.sessionDirectories.values()])
+    const seen = new Set<string>()
+    for (const dir of dirs) {
+      const { data } = await ctx.client.question.list({ directory: dir })
+      if (!data) continue
+      for (const q of data) {
+        if (seen.has(q.id)) continue
+        seen.add(q.id)
+        if (!ctx.trackedSessionIds.has(q.sessionID)) continue
+        ctx.postMessage({
+          type: "questionRequest",
+          question: {
+            id: q.id,
+            sessionID: q.sessionID,
+            questions: q.questions,
+            tool: q.tool,
+          },
+        })
+      }
+    }
+  } catch (error) {
+    console.error("[Kilo New] KiloProvider: Failed to fetch pending questions:", error)
+  }
 }
 
 /** Handle question reply from the webview. */

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1715,12 +1715,23 @@ export const SessionProvider: ParentComponent = (props) => {
   const statusText = createMemo<string | undefined>(() => {
     if (status() === "idle") return undefined
     const fallback = language.t("ui.sessionTurn.status.consideringNextSteps")
+    const id = currentSessionID()
     const msgs = messages()
     for (let i = msgs.length - 1; i >= 0; i--) {
       if (msgs[i].role !== "assistant") continue
       const parts = getParts(msgs[i].id)
       if (parts.length === 0) break
-      return computeStatus(parts[parts.length - 1], language.t) ?? fallback
+      const raw = computeStatus(parts[parts.length - 1], language.t) ?? fallback
+      // When delegating to a subagent and that subagent is blocked on a prompt,
+      // replace the generic "Delegating work" label with a more informative one
+      // so the user understands why nothing appears to be happening.
+      if (raw === language.t("ui.sessionTurn.status.delegating")) {
+        const scoped = scopedPermissions(id)
+        if (scoped.length > 0) return language.t("ui.sessionTurn.status.delegatingWaitingPermission")
+        const scopedQ = scopedQuestions(id)
+        if (scopedQ.length > 0) return language.t("ui.sessionTurn.status.delegatingWaitingQuestion")
+      }
+      return raw
     }
     return fallback
   })

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -231,6 +231,8 @@ export namespace Agent {
           PermissionNext.fromConfig({
             question: "allow",
             plan_exit: "allow",
+            bash: readOnlyBash, // kilocode_change: read-only bash for plan mode (mirrors ask agent)
+            ...mcpRules, // kilocode_change: MCP with user approval for plan mode
             external_directory: {
               [path.join(Global.Path.data, "plans", "*")]: "allow",
             },

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -224,7 +224,7 @@ export namespace Agent {
       },
       plan: {
         name: "plan",
-        description: "Plan mode. Disallows all edit tools.",
+        description: "Plan mode. Only allows editing plan files; asks before editing anything else.",
         options: {},
         permission: PermissionNext.merge(
           defaults,
@@ -235,7 +235,7 @@ export namespace Agent {
               [path.join(Global.Path.data, "plans", "*")]: "allow",
             },
             edit: {
-              "*": "deny",
+              "*": "ask", // kilocode_change: ask (not deny) so user can approve edits outside plan files
               [path.join(".kilo", "plans", "*.md")]: "allow", // kilocode_change
               [path.join(".opencode", "plans", "*.md")]: "allow", // kilocode_change: .opencode fallback
               [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -71,17 +71,15 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       // were themselves inherited from a grandparent, so both sources are needed.
       const caller = await Agent.get(ctx.agent)
       const callerSession = await Session.get(ctx.sessionID)
-      const callerRules = PermissionNext.merge(
-        caller?.permission ?? [],
-        callerSession.permission ?? [],
-      )
-      // Build the set of MCP permission identifiers (e.g. "servername_*") so we can
-      // include them in the inherited ruleset — same sanitisation logic as agent.ts.
-      const mcpPermissions = new Set(
-        Object.keys(config.mcp ?? {}).map((k) => k.replace(/[^a-zA-Z0-9_-]/g, "_") + "_*"),
-      )
+      const callerRules = PermissionNext.merge(caller?.permission ?? [], callerSession.permission ?? [])
+      // Build the set of MCP server prefixes (e.g. "servername_") so we can
+      // include both server-wide wildcards ("servername_*") and specific MCP tool
+      // permissions ("servername_create_issue") in the inherited ruleset.
+      // Same sanitisation logic as agent.ts.
+      const mcpPrefixes = Object.keys(config.mcp ?? {}).map((k) => k.replace(/[^a-zA-Z0-9_-]/g, "_") + "_")
+      const isMcpRule = (p: string) => mcpPrefixes.some((prefix) => p.startsWith(prefix))
       const inherited = callerRules.filter(
-        (r) => r.permission === "edit" || r.permission === "bash" || mcpPermissions.has(r.permission),
+        (r) => r.permission === "edit" || r.permission === "bash" || isMcpRule(r.permission),
       )
       // kilocode_change end
 

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -75,7 +75,14 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         caller?.permission ?? [],
         callerSession.permission ?? [],
       )
-      const inherited = callerRules.filter((r) => r.permission === "edit" || r.permission === "bash")
+      // Build the set of MCP permission identifiers (e.g. "servername_*") so we can
+      // include them in the inherited ruleset — same sanitisation logic as agent.ts.
+      const mcpPermissions = new Set(
+        Object.keys(config.mcp ?? {}).map((k) => k.replace(/[^a-zA-Z0-9_-]/g, "_") + "_*"),
+      )
+      const inherited = callerRules.filter(
+        (r) => r.permission === "edit" || r.permission === "bash" || mcpPermissions.has(r.permission),
+      )
       // kilocode_change end
 
       const session = await iife(async () => {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -63,10 +63,10 @@ export const TaskTool = Tool.define("task", async (ctx) => {
 
       const allowsTask = agent.permission.some((rule) => rule.permission === "task" && rule.action === "allow") // kilocode_change
 
-      // kilocode_change start — inherit edit restrictions from the calling agent so sub-agents
-      // cannot perform actions the parent agent is not allowed to perform.
+      // kilocode_change start — inherit edit and bash restrictions from the calling agent so
+      // sub-agents cannot perform actions the parent agent is not allowed to perform.
       const caller = await Agent.get(ctx.agent)
-      const editRules = caller?.permission.filter((r) => r.permission === "edit") ?? []
+      const inherited = caller?.permission.filter((r) => r.permission === "edit" || r.permission === "bash") ?? []
       // kilocode_change end
 
       const session = await iife(async () => {
@@ -103,7 +103,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
               action: "allow" as const,
               permission: t,
             })) ?? []),
-            ...editRules, // kilocode_change — propagate caller's edit restrictions
+            ...inherited, // kilocode_change — propagate caller's edit and bash restrictions
           ],
         })
       })

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -65,8 +65,17 @@ export const TaskTool = Tool.define("task", async (ctx) => {
 
       // kilocode_change start — inherit edit and bash restrictions from the calling agent so
       // sub-agents cannot perform actions the parent agent is not allowed to perform.
+      // We merge the static agent definition with the current session's accumulated permissions
+      // so that restrictions survive multi-hop chains (plan → general → explore).
+      // Agent.get() gives the base definition; session.permission carries restrictions that
+      // were themselves inherited from a grandparent, so both sources are needed.
       const caller = await Agent.get(ctx.agent)
-      const inherited = caller?.permission.filter((r) => r.permission === "edit" || r.permission === "bash") ?? []
+      const callerSession = await Session.get(ctx.sessionID)
+      const callerRules = PermissionNext.merge(
+        caller?.permission ?? [],
+        callerSession.permission ?? [],
+      )
+      const inherited = callerRules.filter((r) => r.permission === "edit" || r.permission === "bash")
       // kilocode_change end
 
       const session = await iife(async () => {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -63,6 +63,12 @@ export const TaskTool = Tool.define("task", async (ctx) => {
 
       const allowsTask = agent.permission.some((rule) => rule.permission === "task" && rule.action === "allow") // kilocode_change
 
+      // kilocode_change start — inherit edit restrictions from the calling agent so sub-agents
+      // cannot perform actions the parent agent is not allowed to perform.
+      const caller = await Agent.get(ctx.agent)
+      const editRules = caller?.permission.filter((r) => r.permission === "edit") ?? []
+      // kilocode_change end
+
       const session = await iife(async () => {
         if (params.task_id) {
           const found = await Session.get(params.task_id).catch(() => {})
@@ -97,6 +103,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
               action: "allow" as const,
               permission: t,
             })) ?? []),
+            ...editRules, // kilocode_change — propagate caller's edit restrictions
           ],
         })
       })

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -47,6 +47,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "إضافة رصيد",
 
   "ui.sessionTurn.status.delegating": "تفويض العمل",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "تخطيط الخطوات التالية",
   "ui.sessionTurn.status.gatheringContext": "استكشاف",
   "ui.sessionTurn.status.gatheredContext": "تم الاستكشاف",

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -47,6 +47,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "Adicionar créditos",
 
   "ui.sessionTurn.status.delegating": "Delegando trabalho",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Planejando próximos passos",
   "ui.sessionTurn.status.gatheringContext": "Explorando",
   "ui.sessionTurn.status.gatheredContext": "Explorado",

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -51,6 +51,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "Dodaj kredite",
 
   "ui.sessionTurn.status.delegating": "Delegiranje posla",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Planiranje sljedećih koraka",
   "ui.sessionTurn.status.gatheringContext": "Istraživanje",
   "ui.sessionTurn.status.gatheredContext": "Istraženo",

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -46,6 +46,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "Tilføj kreditter",
 
   "ui.sessionTurn.status.delegating": "Delegerer arbejde",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Planlægger næste trin",
   "ui.sessionTurn.status.gatheringContext": "Udforsker",
   "ui.sessionTurn.status.gatheredContext": "Udforsket",

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -52,6 +52,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "Guthaben aufladen",
 
   "ui.sessionTurn.status.delegating": "Arbeit delegieren",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Nächste Schritte planen",
   "ui.sessionTurn.status.gatheringContext": "Erkunden",
   "ui.sessionTurn.status.gatheredContext": "Erkundet",

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -48,6 +48,8 @@ export const dict: Record<string, string> = {
   "ui.sessionTurn.error.addCredits": "Add credits",
 
   "ui.sessionTurn.status.delegating": "Delegating work",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Planning next steps",
   "ui.sessionTurn.status.gatheringContext": "Exploring",
   "ui.sessionTurn.status.gatheredContext": "Explored",

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -47,6 +47,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "Añadir créditos",
 
   "ui.sessionTurn.status.delegating": "Delegando trabajo",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Planificando siguientes pasos",
   "ui.sessionTurn.status.gatheringContext": "Explorando",
   "ui.sessionTurn.status.gatheredContext": "Explorado",

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -47,6 +47,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "Ajouter des crédits",
 
   "ui.sessionTurn.status.delegating": "Délégation du travail",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Planification des prochaines étapes",
   "ui.sessionTurn.status.gatheringContext": "Exploration",
   "ui.sessionTurn.status.gatheredContext": "Exploré",

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -46,6 +46,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "クレジットを追加",
 
   "ui.sessionTurn.status.delegating": "作業を委任中",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "次のステップを計画中",
   "ui.sessionTurn.status.gatheringContext": "探索中",
   "ui.sessionTurn.status.gatheredContext": "探索済み",

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -47,6 +47,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "크레딧 추가",
 
   "ui.sessionTurn.status.delegating": "작업 위임 중",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "다음 단계 계획 중",
   "ui.sessionTurn.status.gatheringContext": "탐색 중",
   "ui.sessionTurn.status.gatheredContext": "탐색됨",

--- a/packages/ui/src/i18n/nl.ts
+++ b/packages/ui/src/i18n/nl.ts
@@ -48,6 +48,8 @@ export const dict: Record<string, string> = {
   "ui.sessionTurn.error.addCredits": "Credits toevoegen",
 
   "ui.sessionTurn.status.delegating": "Werk delegeren",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Volgende stappen plannen",
   "ui.sessionTurn.status.gatheringContext": "Verkennen",
   "ui.sessionTurn.status.gatheredContext": "Verkend",

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -50,6 +50,8 @@ export const dict: Record<Keys, string> = {
   "ui.sessionTurn.error.addCredits": "Legg til kreditt",
 
   "ui.sessionTurn.status.delegating": "Delegerer arbeid",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Planlegger neste trinn",
   "ui.sessionTurn.status.gatheringContext": "Utforsker",
   "ui.sessionTurn.status.gatheredContext": "Utforsket",

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -46,6 +46,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "Dodaj kredyty",
 
   "ui.sessionTurn.status.delegating": "Delegowanie pracy",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Planowanie kolejnych kroków",
   "ui.sessionTurn.status.gatheringContext": "Eksplorowanie",
   "ui.sessionTurn.status.gatheredContext": "Wyeksplorowano",

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -46,6 +46,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "Добавить кредиты",
 
   "ui.sessionTurn.status.delegating": "Делегирование работы",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Планирование следующих шагов",
   "ui.sessionTurn.status.gatheringContext": "Исследование",
   "ui.sessionTurn.status.gatheredContext": "Исследовано",

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -48,6 +48,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "เพิ่มเครดิต",
 
   "ui.sessionTurn.status.delegating": "มอบหมายงาน",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "วางแผนขั้นตอนถัดไป",
   "ui.sessionTurn.status.gatheringContext": "กำลังสำรวจ",
   "ui.sessionTurn.status.gatheredContext": "สำรวจแล้ว",

--- a/packages/ui/src/i18n/tr.ts
+++ b/packages/ui/src/i18n/tr.ts
@@ -53,6 +53,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "Kredi ekle",
 
   "ui.sessionTurn.status.delegating": "Görev devrediliyor",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Sonraki adımlar planlanıyor",
   "ui.sessionTurn.status.gatheringContext": "Keşfediliyor",
   "ui.sessionTurn.status.gatheredContext": "Keşfedildi",

--- a/packages/ui/src/i18n/uk.ts
+++ b/packages/ui/src/i18n/uk.ts
@@ -53,6 +53,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "Поповнити кредити",
 
   "ui.sessionTurn.status.delegating": "Делегування роботи",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "Планування наступних кроків",
   "ui.sessionTurn.status.gatheringContext": "Дослідження",
   "ui.sessionTurn.status.gatheredContext": "Досліджено",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -51,6 +51,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "添加积分",
 
   "ui.sessionTurn.status.delegating": "正在委派工作",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "正在规划下一步",
   "ui.sessionTurn.status.gatheringContext": "正在探索",
   "ui.sessionTurn.status.gatheredContext": "已探索",

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -51,6 +51,8 @@ export const dict = {
   "ui.sessionTurn.error.addCredits": "新增點數",
 
   "ui.sessionTurn.status.delegating": "正在委派工作",
+  "ui.sessionTurn.status.delegatingWaitingPermission": "Subagent waiting for permission",
+  "ui.sessionTurn.status.delegatingWaitingQuestion": "Subagent waiting for response",
   "ui.sessionTurn.status.planning": "正在規劃下一步",
   "ui.sessionTurn.status.gatheringContext": "正在探索",
   "ui.sessionTurn.status.gatheredContext": "已探索",


### PR DESCRIPTION
## Summary

Fixes two related security/correctness issues with plan mode permissions and sub-agent isolation.

This PR also incorporates the guidance and changes from PR #8360, which identified that `apply_patch` and `write` tool permissions were not properly restricted in plan mode.

---

## Problems Found

### 1. Plan mode could silently hard-block the model with no recourse

Plan mode had `edit: { "*": "deny" }` — any attempt to edit a file outside `.kilo/plans/` would throw a hard error that the model couldn't recover from. This caused confusing failures when a sub-agent or the plan agent itself tried to do something reasonable (e.g. update a config file the user approved).

### 2. Sub-agents did not inherit the calling agent's restrictions

When the plan agent spawned a sub-agent (e.g. `general` or `explore`) via the `task` tool, the child session was created with only `todowrite`/`todoread` deny rules. The sub-agent's own agent definition was used for everything else — which has fully permissive `edit` and standard `bash` permissions. This meant a sub-agent could freely write any file, bypassing plan mode entirely.

### 3. Plan mode had unrestricted bash access

The plan agent inherited `defaults` bash rules, which allow write operations (`touch`, `mkdir`, `cp`, `mv`) without restriction. Plan mode is supposed to be read-and-plan-only, so these should require approval or be blocked.

### 4. MCP tools were unavailable in plan mode

Plan mode had no MCP rules, so all MCP tool calls were denied. The ask agent (PR #7929) already solved this pattern with per-call approval — plan mode should benefit from the same.

### 5. Specific MCP tool restrictions were dropped when propagating to sub-agents

The inheritance filter in `task.ts` only preserved server-wide wildcard rules like `github_*`. Narrower rules targeting individual tools (e.g. `github_create_issue: deny`) were silently dropped, so sub-agents fell back to their own permissive `*` rule for those tools.

---

## Changes

### `packages/opencode/src/agent/agent.ts`

| Behaviour | Before | After |
|---|---|---|
| Edit outside plan files | ❌ Hard denied — model gets an error it cannot recover from | ⚠️ Asks user for approval — user stays in control |
| Edit plan files (`.kilo/plans/*.md`) | ✅ Allowed | ✅ Allowed (unchanged) |
| Bash write commands (`touch`, `cp`, `mv`, …) | ⚠️ Asks (inherited from defaults) | ❌ Denied — plan mode uses read-only bash |
| Bash unknown commands | ⚠️ Asks (inherited from defaults) | ❌ Denied — plan mode uses read-only bash |
| Bash read-only commands (`cat`, `grep`, `git log`, …) | ✅ Allowed | ✅ Allowed (unchanged) |
| MCP tools | ❌ Denied (no rules) | ⚠️ Asks per call — matches ask agent behaviour |

### `packages/opencode/src/tool/task.ts`

When any agent spawns a sub-agent via the `task` tool, the child session now inherits the calling agent's `edit`, `bash`, and MCP permission rules. Because permission evaluation uses `findLast`, the inherited rules are appended last and take precedence over the sub-agent's own defaults.

| Scenario | Before | After |
|---|---|---|
| `plan` → `general` sub-agent edit any file | ✅ Allowed (sub-agent used its own permissive defaults) | ⚠️ Asks — inherits plan's `edit: "*": "ask"` |
| `plan` → `general` sub-agent edit plan file | ✅ Allowed | ✅ Allowed — inherits plan's explicit allow rule |
| `plan` → `general` sub-agent bash write commands | ⚠️ Asks | ❌ Denied — inherits plan's `readOnlyBash` |
| `orchestrator` → sub-agent bash | ⚠️ Asks (sub-agent default) | ❌ Denied — inherits orchestrator's `bash: "deny"` |
| `code` → sub-agent edit | ✅ Allowed | ✅ Allowed — inherits code's permissive rules (no change) |
| Sub-agent with server-wide MCP wildcard (`github_*: deny`) | ❌ Denied (inherited correctly) | ❌ Denied (unchanged) |
| Sub-agent with specific MCP tool rule (`github_create_issue: deny`) | ✅ Allowed (rule was silently dropped — bug) | ❌ Denied — specific MCP tool rules are now preserved |

---

## Related

- PR #8360 — identified that `apply_patch`/`write` permissions were not restricted in plan mode; its guidance has been incorporated into this PR
- PR #7929 — introduced `readOnlyBash` + MCP for Ask agent (reused here for plan mode)
- PR #8384 — separate fix for plan file corruption on GPT-5 models (not addressed here)