### PR TITLE
fix(vscode): sync mode picker with agent mode changes from backend

### DIFF
--- a/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
@@ -363,11 +363,21 @@ describe("mapSSEEventToWebviewMessage", () => {
       properties: {
         id: "q1",
         sessionID: "sess-1",
-        questions: [],
+        questions: [
+          {
+            question: "Ready to implement?",
+            header: "Implement",
+            options: [{ label: "Implement", description: "Switch to code", mode: "code" }],
+          },
+        ],
       },
     }
     const msg = mapSSEEventToWebviewMessage(event, "sess-1")
     expect(msg?.type).toBe("questionRequest")
+    if (msg?.type === "questionRequest") {
+      const questions = msg.question.questions as Array<{ options?: Array<{ mode?: string }> }>
+      expect(questions[0]?.options?.[0]?.mode).toBe("code")
+    }
   })
 
   it("maps question.replied to questionResolved", () => {

--- a/packages/kilo-vscode/tests/unit/question-dock-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/question-dock-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "bun:test"
-import { resolveQuestionMode, toggleAnswer } from "../../webview-ui/src/components/chat/question-dock-utils"
+import {
+  resolveOptimisticQuestionAgent,
+  resolveQuestionMode,
+  resolveSelectedQuestionMode,
+  toggleAnswer,
+} from "../../webview-ui/src/components/chat/question-dock-utils"
 
 describe("toggleAnswer", () => {
   it("adds answer when not present", () => {
@@ -58,5 +63,68 @@ describe("resolveQuestionMode", () => {
   it("returns undefined when option has no mode", () => {
     const result = resolveQuestionMode([{ label: "Stay", description: "Remain here" }], "Stay")
     expect(result).toBeUndefined()
+  })
+})
+
+describe("resolveSelectedQuestionMode", () => {
+  it("returns the selected mode from predefined answers", () => {
+    const result = resolveSelectedQuestionMode(
+      [
+        [
+          { label: "Implement", description: "Switch to code", mode: "code" },
+          { label: "Stay", description: "Remain here" },
+        ],
+      ].map((options) => ({ options })),
+      [["Implement"]],
+    )
+
+    expect(result).toBe("code")
+  })
+
+  it("ignores custom answers that replace a mode option", () => {
+    const result = resolveSelectedQuestionMode(
+      [{ options: [{ label: "Implement", description: "Switch to code", mode: "code" }] }],
+      [["Implement custom flow"]],
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  it("keeps mode answers from other questions", () => {
+    const result = resolveSelectedQuestionMode(
+      [
+        { options: [{ label: "Implement", description: "Switch to code", mode: "code" }] },
+        { options: [{ label: "Stay", description: "Remain here" }] },
+      ],
+      [["Implement"], ["Stay"]],
+    )
+
+    expect(result).toBe("code")
+  })
+})
+
+describe("resolveOptimisticQuestionAgent", () => {
+  it("stores the previous agent when applying an optimistic mode", () => {
+    const result = resolveOptimisticQuestionAgent(undefined, "ask", "code")
+
+    expect(result).toEqual({ base: "ask", agent: "code" })
+  })
+
+  it("reverts to the stored previous agent when the mode is cleared", () => {
+    const result = resolveOptimisticQuestionAgent("ask", "code", undefined)
+
+    expect(result).toEqual({ base: undefined, agent: "ask" })
+  })
+
+  it("avoids switching when the selected mode already matches the current agent", () => {
+    const result = resolveOptimisticQuestionAgent(undefined, "code", "code")
+
+    expect(result).toEqual({ base: undefined, agent: undefined })
+  })
+
+  it("keeps the original base agent while changing between mode answers", () => {
+    const result = resolveOptimisticQuestionAgent("ask", "code", "architect")
+
+    expect(result).toEqual({ base: "ask", agent: "architect" })
   })
 })

--- a/packages/kilo-vscode/tests/unit/question-dock-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/question-dock-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { toggleAnswer } from "../../webview-ui/src/components/chat/question-dock-utils"
+import { resolveQuestionMode, toggleAnswer } from "../../webview-ui/src/components/chat/question-dock-utils"
 
 describe("toggleAnswer", () => {
   it("adds answer when not present", () => {
@@ -34,5 +34,29 @@ describe("toggleAnswer", () => {
   it("only removes the first occurrence (deduplication edge case)", () => {
     const result = toggleAnswer(["a", "a"], "a")
     expect(result).toEqual(["a"])
+  })
+})
+
+describe("resolveQuestionMode", () => {
+  it("returns mode for matching predefined option", () => {
+    const result = resolveQuestionMode(
+      [
+        { label: "Implement", description: "Switch to code", mode: "code" },
+        { label: "Stay", description: "Remain here" },
+      ],
+      "Implement",
+    )
+
+    expect(result).toBe("code")
+  })
+
+  it("returns undefined for unknown answer", () => {
+    const result = resolveQuestionMode([{ label: "Implement", description: "Switch", mode: "code" }], "Custom")
+    expect(result).toBeUndefined()
+  })
+
+  it("returns undefined when option has no mode", () => {
+    const result = resolveQuestionMode([{ label: "Stay", description: "Remain here" }], "Stay")
+    expect(result).toBeUndefined()
   })
 })

--- a/packages/kilo-vscode/tests/unit/session-agent.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-agent.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "bun:test"
+import { resolveSessionAgent } from "../../webview-ui/src/context/session-agent"
+import type { Message } from "../../webview-ui/src/types/messages"
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "msg-1",
+    sessionID: "sess-1",
+    role: "user",
+    createdAt: new Date(0).toISOString(),
+    ...overrides,
+  }
+}
+
+describe("resolveSessionAgent", () => {
+  it("returns the latest valid user agent", () => {
+    const result = resolveSessionAgent(
+      [
+        makeMessage({ id: "1", agent: "plan" }),
+        makeMessage({ id: "2", role: "assistant", agent: "ask" }),
+        makeMessage({ id: "3", agent: "code" }),
+      ],
+      new Set(["plan", "code", "ask"]),
+    )
+
+    expect(result).toBe("code")
+  })
+
+  it("ignores assistant messages", () => {
+    const result = resolveSessionAgent(
+      [makeMessage({ role: "assistant", agent: "code" }), makeMessage({ agent: "plan" })],
+      new Set(["plan", "code"]),
+    )
+
+    expect(result).toBe("plan")
+  })
+
+  it("ignores unknown agent names", () => {
+    const result = resolveSessionAgent(
+      [makeMessage({ agent: "missing" }), makeMessage({ agent: "code" })],
+      new Set(["code"]),
+    )
+
+    expect(result).toBe("code")
+  })
+
+  it("ignores empty agent values", () => {
+    const result = resolveSessionAgent([makeMessage({ agent: "  " })], new Set(["code"]))
+    expect(result).toBeUndefined()
+  })
+
+  it("returns undefined when no valid user agent exists", () => {
+    const result = resolveSessionAgent(
+      [makeMessage({ role: "assistant", agent: "code" }), makeMessage({ agent: undefined })],
+      new Set(["code"]),
+    )
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -30,11 +30,16 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
   })
 
   let root!: HTMLDivElement
+  let prevAgent: string | undefined
 
-  // Reset sending state when an error occurs for this question
+  // Reset sending state and roll back the optimistic agent change on error
   createEffect(() => {
     if (session.questionErrors().has(props.request.id)) {
       setStore("sending", false)
+      if (prevAgent !== undefined) {
+        session.selectAgent(prevAgent)
+        prevAgent = undefined
+      }
     }
   })
 
@@ -64,6 +69,8 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     setStore("sending", true)
     session.replyToQuestion(props.request.id, answers)
     focusPrompt()
+    // prevAgent is intentionally left set until either questionError (rollback)
+    // or the question is dismissed (success — the question unmounts, so no cleanup needed)
   }
 
   const reject = () => {
@@ -96,6 +103,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     }
 
     if (mode && !custom) {
+      prevAgent = session.selectedAgent()
       session.selectAgent(mode)
     }
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -11,7 +11,7 @@ import { Icon } from "@kilocode/kilo-ui/icon"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import type { QuestionRequest } from "../../types/messages"
-import { toggleAnswer } from "./question-dock-utils"
+import { resolveQuestionMode, toggleAnswer } from "./question-dock-utils"
 
 export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => {
   const session = useSession()
@@ -84,6 +84,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
   }
 
   const pick = (answer: string, custom = false) => {
+    const mode = resolveQuestionMode(options(), answer)
     const answers = [...store.answers]
     answers[store.tab] = [answer]
     setStore("answers", answers)
@@ -92,6 +93,10 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
       const inputs = [...store.custom]
       inputs[store.tab] = answer
       setStore("custom", inputs)
+    }
+
+    if (mode && !custom) {
+      session.selectAgent(mode)
     }
 
     if (!single() && !multi()) {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -4,14 +4,15 @@
  * Uses kilo-ui's DockPrompt component for proper surface styling.
  */
 
-import { Component, For, Show, createMemo, createEffect } from "solid-js"
+import { For, Show, createMemo, createEffect } from "solid-js"
+import type { Component } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import type { QuestionRequest } from "../../types/messages"
-import { resolveQuestionMode, toggleAnswer } from "./question-dock-utils"
+import { resolveOptimisticQuestionAgent, resolveSelectedQuestionMode, toggleAnswer } from "./question-dock-utils"
 
 export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => {
   const session = useSession()
@@ -24,6 +25,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     tab: 0,
     answers: [] as string[][],
     custom: [] as string[],
+    kinds: [] as Record<string, "option" | "custom">[],
     editing: false,
     sending: false,
     collapsed: false,
@@ -90,11 +92,24 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     setStore("editing", false)
   }
 
+  const syncAgent = (answers: string[][], kinds: Record<string, "option" | "custom">[] = store.kinds) => {
+    const mode = resolveSelectedQuestionMode(questions(), answers, kinds)
+    const next = resolveOptimisticQuestionAgent(prevAgent, session.selectedAgent(), mode)
+
+    prevAgent = next.base
+    if (!next.agent) return
+    if (next.agent === session.selectedAgent()) return
+    session.selectAgent(next.agent)
+  }
+
   const pick = (answer: string, custom = false) => {
-    const mode = resolveQuestionMode(options(), answer)
     const answers = [...store.answers]
     answers[store.tab] = [answer]
     setStore("answers", answers)
+
+    const kinds = [...store.kinds]
+    kinds[store.tab] = { [answer]: custom ? "custom" : "option" }
+    setStore("kinds", kinds)
 
     if (custom) {
       const inputs = [...store.custom]
@@ -102,10 +117,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
       setStore("custom", inputs)
     }
 
-    if (mode && !custom) {
-      prevAgent = session.selectedAgent()
-      session.selectAgent(mode)
-    }
+    syncAgent(answers, kinds)
 
     if (!single() && !multi()) {
       setStore("tab", store.tab + 1)
@@ -117,6 +129,13 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     const answers = [...store.answers]
     answers[store.tab] = next
     setStore("answers", answers)
+    const kinds = [...store.kinds]
+    const current = { ...(kinds[store.tab] ?? {}) }
+    if (next.includes(answer)) current[answer] = "option"
+    else delete current[answer]
+    kinds[store.tab] = current
+    setStore("kinds", kinds)
+    syncAgent(answers, kinds)
   }
 
   const selectTab = (index: number) => {
@@ -180,6 +199,12 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
       const answers = [...store.answers]
       answers[store.tab] = next
       setStore("answers", answers)
+      const kinds = [...store.kinds]
+      const current = { ...(kinds[store.tab] ?? {}) }
+      current[value] = "custom"
+      kinds[store.tab] = current
+      setStore("kinds", kinds)
+      syncAgent(answers, kinds)
       setStore("editing", false)
       return
     }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/question-dock-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/question-dock-utils.ts
@@ -1,7 +1,13 @@
+import type { QuestionOption } from "../../types/messages"
+
 export function toggleAnswer(existing: string[], answer: string): string[] {
   const next = [...existing]
   const index = next.indexOf(answer)
   if (index === -1) next.push(answer)
   if (index !== -1) next.splice(index, 1)
   return next
+}
+
+export function resolveQuestionMode(options: QuestionOption[], answer: string): string | undefined {
+  return options.find((item) => item.label === answer)?.mode
 }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/question-dock-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/question-dock-utils.ts
@@ -11,3 +11,43 @@ export function toggleAnswer(existing: string[], answer: string): string[] {
 export function resolveQuestionMode(options: QuestionOption[], answer: string): string | undefined {
   return options.find((item) => item.label === answer)?.mode
 }
+
+export function resolveSelectedQuestionMode(
+  questions: Array<{ options?: QuestionOption[] }>,
+  answers: string[][],
+  kinds: Record<string, "option" | "custom">[] = [],
+): string | undefined {
+  let mode: string | undefined
+
+  for (const [i, list] of answers.entries()) {
+    const options = questions[i]?.options ?? []
+    for (const answer of list) {
+      if (kinds[i]?.[answer] === "custom") continue
+      const next = resolveQuestionMode(options, answer)
+      if (next) mode = next
+    }
+  }
+
+  return mode
+}
+
+export function resolveOptimisticQuestionAgent(base: string | undefined, current: string, mode: string | undefined) {
+  if (!mode) {
+    return {
+      base: undefined,
+      agent: base,
+    }
+  }
+
+  if (base === undefined && current === mode) {
+    return {
+      base: undefined,
+      agent: undefined,
+    }
+  }
+
+  return {
+    base: base ?? current,
+    agent: mode,
+  }
+}

--- a/packages/kilo-vscode/webview-ui/src/context/session-agent.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-agent.ts
@@ -1,0 +1,12 @@
+import type { Message } from "../types/messages"
+
+export function resolveSessionAgent(messages: Message[], names: Set<string>): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]
+    if (msg.role !== "user") continue
+    const name = msg.agent?.trim()
+    if (!name) continue
+    if (!names.has(name)) continue
+    return name
+  }
+}

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -483,6 +483,17 @@ export const SessionProvider: ParentComponent = (props) => {
         }
       }),
     )
+
+    // Rescan already-loaded message history so sessions whose messagesLoaded
+    // arrived before agentsLoaded (and therefore got no agent selection) are
+    // backfilled now that we know the valid agent names.
+    batch(() => {
+      for (const [sid, msgs] of Object.entries(store.messages)) {
+        if (store.agentSelections[sid]) continue
+        const agent = resolveSessionAgent(msgs, names)
+        if (agent) setStore("agentSelections", sid, agent)
+      }
+    })
   })
 
   // Request agents in case the initial push was missed.

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -42,6 +42,7 @@ import {
 } from "./session-utils"
 import { Identifier } from "../utils/id"
 import { resolveModelSelection } from "./model-selection"
+import { resolveSessionAgent } from "./session-agent"
 import { KILO_AUTO, parseModelString } from "../../../src/shared/provider-model"
 
 const RECENT_LIMIT = 5
@@ -341,6 +342,8 @@ export const SessionProvider: ParentComponent = (props) => {
     }
     return pendingAgentSelection() ?? defaultAgent()
   })
+
+  const agentNames = createMemo(() => new Set(agents().map((agent) => agent.name)))
 
   /** Per-mode model from config (e.g. config.agent.code.model). */
   function getModeModel(agentName: string): ModelSelection | null {
@@ -801,6 +804,11 @@ export const SessionProvider: ParentComponent = (props) => {
           setStore("parts", msg.id, reconcile(msg.parts, { key: "id" }))
         }
       }
+
+      const agent = resolveSessionAgent(messages, agentNames())
+      if (agent) {
+        setStore("agentSelections", sessionID, agent)
+      }
     })
   }
 
@@ -834,6 +842,13 @@ export const SessionProvider: ParentComponent = (props) => {
       }
       return [...msgs, message]
     })
+
+    if (message.role === "user") {
+      const agent = message.agent?.trim()
+      if (agent && agentNames().has(agent)) {
+        setStore("agentSelections", message.sessionID, agent)
+      }
+    }
 
     if (message.parts && message.parts.length > 0) {
       setStore("parts", message.id, message.parts)

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -177,6 +177,7 @@ export interface TodoItem {
 export interface QuestionOption {
   label: string
   description: string
+  mode?: string
 }
 
 export interface QuestionInfo {


### PR DESCRIPTION
## Problem

When the agent switched modes automatically — for example from `plan` to `code` after a plan follow-up — the VS Code mode picker stayed stuck on the old value (e.g. `ask`). This was confusing because the agent was already operating in a different mode while the UI still showed the previous one.

The root cause: `agentSelections` in the session store was only written on explicit user picker actions. It was never updated from incoming backend message events.

## What this PR fixes

## Demo

https://github.com/user-attachments/assets/17344dad-e8ab-43ef-83e3-25ec11fa8e2d


Every backend agent/mode change manifests as a user message with the `agent` field set, followed by a `message.updated` SSE event. The fix intercepts those messages in two places to keep the picker in sync.

| Scenario | Mechanism | Fixed? |
|---|---|---|
| User sends a message with a non-default agent | `createUserMessage()` sets `agent` on user msg → `message.updated` SSE | ✅ via `handleMessageCreated` |
| Plan follow-up "Continue here" (plan → code) | `PlanFollowup.inject()` writes synthetic user msg with `agent: "code"` → SSE | ✅ via `handleMessageCreated` |
| Plan follow-up custom answer | `PlanFollowup.inject()` writes synthetic user msg with `agent: "plan"` → SSE | ✅ via `handleMessageCreated` |
| Shell command | `shell()` creates user msg with `agent: input.agent` → SSE | ✅ via `handleMessageCreated` |
| Command execution | `command()` → `createUserMessage()` with resolved agent → SSE | ✅ via `handleMessageCreated` |
| Session reload / switch | Extension calls `loadMessages` → history batch load | ✅ via `handleMessagesLoaded` |
| Question option with `mode` field clicked | `QuestionDock.pick()` detects `option.mode` | ✅ optimistic update via `selectAgent()` |

## Changes

- **`session-agent.ts`** — new pure helper `resolveSessionAgent(messages, names)` that finds the latest valid user-message agent from a message list, ignoring assistant messages and unrecognized names
- **`session.tsx`** — `handleMessagesLoaded` now calls `resolveSessionAgent` and writes result to `agentSelections`; `handleMessageCreated` updates `agentSelections` when a user message with a changed `agent` arrives
- **`types/messages.ts`** — added `mode?: string` to `QuestionOption` so the VS Code webview preserves the same question option metadata the backend and shared app already support
- **`question-dock-utils.ts`** — new `resolveQuestionMode(options, answer)` helper
- **`QuestionDock.tsx`** — calls `session.selectAgent(mode)` on pick when the selected option carries a `mode`, giving instant feedback before the next user message arrives

## Tests

- `packages/kilo-vscode/tests/unit/session-agent.test.ts` — 5 unit tests for the reconciliation helper
- `packages/kilo-vscode/tests/unit/question-dock-utils.test.ts` — 3 new cases for `resolveQuestionMode`
- `packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts` — extended question.asked test to assert `option.mode` survives SSE mapping