### PR TITLE
Remove local storage folders from ignored folders

### DIFF
--- a/packages/opencode/src/file/ignore.ts
+++ b/packages/opencode/src/file/ignore.ts
@@ -31,8 +31,6 @@ export namespace FileIgnore {
     "mypy_cache",
     ".history",
     ".gradle",
-    ".kilocode", // kilocode_change — ignore legacy local storage (#8379)
-    ".opencode", // kilocode_change — ignore legacy local storage (#8379)
   ])
 
   const FILES = [


### PR DESCRIPTION
## Context

Removes from FileIgnore the `.kilocode` and `.opencode` folders



## How to Test


