### PR TITLE
fix(cli): update simple-git to fix critical RCE

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -291,7 +291,7 @@
         "lru-cache": "^11.0.2",
         "openai": "^4.85.4",
         "quick-lru": "^7.0.0",
-        "simple-git": "3.31.1",
+        "simple-git": "3.35.2",
         "solid-js": "^1.9.11",
         "uri-js": "^4.4.1",
         "web-tree-sitter": "^0.24.7",
@@ -405,7 +405,7 @@
         "partial-json": "0.1.7",
         "remeda": "catalog:",
         "rotating-file-stream": "3.2.9",
-        "simple-git": "3.31.1",
+        "simple-git": "3.35.2",
         "solid-js": "catalog:",
         "stream-chat": "9.38.0",
         "strip-ansi": "7.1.2",
@@ -1593,6 +1593,10 @@
     "@shikijs/types": ["@shikijs/types@3.9.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-/M5L0Uc2ljyn2jKvj4Yiah7ow/W+DJSglVafvWAJ/b8AZDeeRAdMu3c2riDzB7N42VD+jSnWxeP9AKtd4TfYVw=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@simple-git/args-pathspec": ["@simple-git/args-pathspec@1.0.2", "", {}, "sha512-nEFVejViHUoL8wU8GTcwqrvqfUG40S5ts6S4fr1u1Ki5CklXlRDYThPVA/qurTmCYFGnaX3XpVUmICLHdvhLaA=="],
+
+    "@simple-git/argv-parser": ["@simple-git/argv-parser@1.0.3", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.2" } }, "sha512-NMKv9sJcSN2VvnPT9Ja7eKfGy8Q8mMFLwPTCcuZMtv3+mYcLIZflg31S/tp2XCCyiY7YAx6cgBHQ0fwA2fWHpQ=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
@@ -3896,7 +3900,7 @@
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
-    "simple-git": ["simple-git@3.31.1", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "debug": "^4.4.0" } }, "sha512-oiWP4Q9+kO8q9hHqkX35uuHmxiEbZNTrZ5IPxgMGrJwN76pzjm/jabkZO0ItEcqxAincqGAzL3QHSaHt4+knBg=="],
+    "simple-git": ["simple-git@3.35.2", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "@simple-git/args-pathspec": "^1.0.2", "@simple-git/argv-parser": "^1.0.3", "debug": "^4.4.0" } }, "sha512-ZMjl06lzTm1EScxEGuM6+mEX+NQd14h/B3x0vWU+YOXAMF8sicyi1K4cjTfj5is+35ChJEHDl1EjypzYFWH2FA=="],
 
     "simple-update-notifier": ["simple-update-notifier@2.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w=="],
 

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -842,7 +842,7 @@
     "lru-cache": "^11.0.2",
     "openai": "^4.85.4",
     "quick-lru": "^7.0.0",
-    "simple-git": "3.31.1",
+    "simple-git": "3.35.2",
     "solid-js": "^1.9.11",
     "uri-js": "^4.4.1",
     "web-tree-sitter": "^0.24.7",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -127,7 +127,7 @@
     "partial-json": "0.1.7",
     "remeda": "catalog:",
     "rotating-file-stream": "3.2.9",
-    "simple-git": "3.31.1",
+    "simple-git": "3.35.2",
     "solid-js": "catalog:",
     "stream-chat": "9.38.0",
     "strip-ansi": "7.1.2",


### PR DESCRIPTION
## Summary

- Updates `simple-git` from 3.31.1 to 3.35.2 in `packages/opencode/` and `packages/kilo-vscode/`
- Fixes [GHSA-r275-fr43-pm7q](https://github.com/advisories/GHSA-r275-fr43-pm7q) — `blockUnsafeOperationsPlugin` bypass via case-insensitive `protocol.allow` config key enables **remote code execution**
- Low risk: minor version bump, same API surface

## Advisories Fixed

| Advisory | Severity | Description |
|---|---|---|
| GHSA-r275-fr43-pm7q | Critical | RCE via blockUnsafeOperationsPlugin bypass |