### PR TITLE
fix(cli): update hono to fix auth bypass and server vulnerabilities

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -604,7 +604,7 @@
     "drizzle-kit": "1.0.0-beta.16-ea816b6",
     "drizzle-orm": "1.0.0-beta.16-ea816b6",
     "fuzzysort": "3.1.0",
-    "hono": "4.10.7",
+    "hono": "4.12.12",
     "hono-openapi": "1.1.2",
     "luxon": "3.6.1",
     "marked": "17.0.1",
@@ -3014,7 +3014,7 @@
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
-    "hono": ["hono@4.10.7", "", {}, "sha512-icXIITfw/07Q88nLSkB9aiUrd8rYzSweK681Kjo/TSggaGbOX4RRyxxm71v+3PC8C/j+4rlxGeoTRxQDkaJkUw=="],
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
 
     "hono-openapi": ["hono-openapi@1.1.2", "", { "peerDependencies": { "@hono/standard-validator": "^0.2.0", "@standard-community/standard-json": "^0.3.5", "@standard-community/standard-openapi": "^0.2.9", "@types/json-schema": "^7.0.15", "hono": "^4.8.3", "openapi-types": "^12.1.3" }, "optionalPeers": ["@hono/standard-validator", "hono"] }, "sha512-toUcO60MftRBxqcVyxsHNYs2m4vf4xkQaiARAucQx3TiBPDtMNNkoh+C4I1vAretQZiGyaLOZNWn1YxfSyUA5g=="],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
       "drizzle-kit": "1.0.0-beta.16-ea816b6",
       "drizzle-orm": "1.0.0-beta.16-ea816b6",
       "ai": "5.0.124",
-      "hono": "4.10.7",
+      "hono": "4.12.12",
       "hono-openapi": "1.1.2",
       "fuzzysort": "3.1.0",
       "luxon": "3.6.1",

--- a/packages/opencode/src/server/routes/pty.ts
+++ b/packages/opencode/src/server/routes/pty.ts
@@ -151,6 +151,7 @@ export const PtyRoutes = lazy(() =>
       validator("param", z.object({ ptyID: z.string() })),
       upgradeWebSocket((c) => {
         const id = c.req.param("ptyID")
+        if (!id) throw new Error("Missing ptyID")
         const cursor = (() => {
           const value = c.req.query("cursor")
           if (!value) return


### PR DESCRIPTION
## Summary

- Updates `hono` catalog version from 4.10.7 to 4.12.12
- Fixes 14 advisories including JWT algorithm confusion, CORS bypass, XSS, path traversal, and more
- Adds null guard for `ptyID` param in `pty.ts` to satisfy hono 4.12's stricter `c.req.param()` return type
- No JWT middleware is used directly (confirmed via grep) — the JWT `alg` breaking change has zero impact

## Pre-check

Grepped `packages/opencode/src/` for `hono/jwt` — no usage found. The server uses basic auth via `KILO_SERVER_PASSWORD`, not JWT middleware.

## Advisories Fixed

| Advisory | Severity | Description |
|---|---|---|
| GHSA-f67f-6cw9-8mq4 | High | JWT Algorithm Confusion allows token forgery |
| GHSA-3vhc-576x-3qv4 | High | JWK Auth JWT algorithm confusion |
| GHSA-m732-5p4w-x69g | High | Improper Authorization |
| GHSA-q5qw-h33p-qvwr | High | Arbitrary file access via serveStatic |
| GHSA-q7jf-gf43-6x6p | Moderate | Vary Header Injection / CORS Bypass |
| GHSA-92vj-g62v-jqhh | Moderate | Body Limit Middleware Bypass |
| GHSA-9r54-q6cx-xmh5 | Moderate | XSS through ErrorBoundary |
| GHSA-6wqw-2p9w-4vw4 | Moderate | Cache middleware ignores Cache-Control: private |
| GHSA-r354-f388-2fhh | Moderate | IPv4 validation bypass in IP Restriction |
| GHSA-w332-q679-j88p | Moderate | Arbitrary Key Read in serveStatic (CF Workers) |
| GHSA-5pq2-9x2x-5p6w | Moderate | Cookie Attribute Injection via setCookie() |
| GHSA-p6xx-57qc-3wxr | Moderate | SSE Control Field Injection via writeSSE() |
| GHSA-v8w9-8mx6-g223 | Moderate | Prototype Pollution via parseBody |
| GHSA-gq3j-xvxp-8hrf | Low | Timing comparison hardening |