### PR TITLE
feat: make file:line references in chat markdown clickable

### DIFF
--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1170,6 +1170,16 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
     if (!data.openFile) return
     const target = e.target
     if (!(target instanceof HTMLElement)) return
+    // kilocode_change start: handle symbol (class/method) link clicks
+    const symbolLink = target.closest(".symbol-link[data-symbol-link]")
+    if (symbolLink) {
+      const sym = symbolLink.getAttribute("data-symbol-link")
+      if (sym) {
+        data.openFile(`__kilo_symbol__${sym}`)
+        return
+      }
+    }
+    // kilocode_change end
     // Handle .file-link code spans (e.g. `src/foo.ts:42`)
     const fileLink = target.closest(".file-link[data-file-path]")
     if (fileLink) {

--- a/packages/kilo-ui/src/file-path.ts
+++ b/packages/kilo-ui/src/file-path.ts
@@ -26,6 +26,24 @@ export function parseFilePath(text: string): { path: string; line?: number; colu
   }
 }
 
+// kilocode_change: detect class/method symbol references in inline code
+// Method: identifier() or Namespace.Method()  e.g. BuildFrame(), ShapeEditorContext.BuildFrame()
+const SYMBOL_METHOD_RE = /^([a-zA-Z][a-zA-Z0-9]*(?:\.[a-zA-Z][a-zA-Z0-9]*)?)\(\)$/
+// Class/type: PascalCase, at least 7 chars, alphanumeric only  e.g. ShapeEditorContext
+const SYMBOL_CLASS_RE = /^([A-Z][a-zA-Z0-9]{6,})$/
+
+/**
+ * Parse an inline code span into a symbol reference (class name or method call).
+ * Returns the raw text (e.g. "BuildFrame()" or "ShapeEditorContext") for routing
+ * through the openFile channel with "__kilo_symbol__" prefix, or undefined.
+ */
+export function parseSymbolRef(text: string): string | undefined {
+  const trimmed = text.trim()
+  if (SYMBOL_METHOD_RE.test(trimmed)) return trimmed
+  if (SYMBOL_CLASS_RE.test(trimmed)) return trimmed
+  return undefined
+}
+
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/
 
 /**

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2526,6 +2526,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
   // kilocode_change start: navigate to a symbol (class/method) by name
   /**
+   * Cache: symbol raw text → resolved URI + position, to avoid re-scanning on repeated clicks.
+   * Cleared when the workspace changes or the extension is deactivated.
+   */
+  private readonly symbolCache = new Map<string, { uri: vscode.Uri; index: number }>()
+
+  /**
    * Search the workspace for a symbol by name and navigate to its definition.
    * First tries the LSP workspace symbol provider (e.g. OmniSharp, tsserver).
    * Falls back to a regex content search across workspace files when LSP is
@@ -2554,32 +2560,36 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     // Phase 2: content search with two-tier matching
+    // Return cached result immediately if available
+    const cached = this.symbolCache.get(rawSymbol)
+    if (cached) {
+      const doc = await vscode.workspace.openTextDocument(cached.uri)
+      const pos = doc.positionAt(cached.index)
+      await vscode.window.showTextDocument(doc, { selection: new vscode.Range(pos, pos), preview: true })
+      return
+    }
+
     const esc = symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-    const CHUNK = 50
+    // Cap per-extension to 300 files — enough to cover large monorepos while
+    // keeping peak memory manageable. Sequential reads (chunk=1) avoid GC pressure
+    // from many simultaneous Uint8Array + TextDecoder allocations.
+    const MAX_FILES_PER_EXT = 300
     const exts = ["cs", "ts", "tsx", "js", "jsx", "mts", "py", "go", "rs", "cpp", "java", "kt", "swift"]
 
     type Hit = { uri: vscode.Uri; index: number }
 
     const searchWithPattern = async (pattern: RegExp): Promise<Hit | undefined> => {
       for (const ext of exts) {
-        const uris = await vscode.workspace.findFiles(`**/*.${ext}`, "**/node_modules/**")
-        if (uris.length === 0) continue
-        for (let i = 0; i < uris.length; i += CHUNK) {
-          const chunk = uris.slice(i, i + CHUNK)
-          const hits = await Promise.all(
-            chunk.map(async (uri) => {
-              try {
-                const bytes = await vscode.workspace.fs.readFile(uri)
-                const text = new TextDecoder().decode(bytes)
-                const match = pattern.exec(text)
-                return match ? { uri, index: match.index } : null
-              } catch {
-                return null
-              }
-            }),
-          )
-          const hit = hits.find((h) => h !== null)
-          if (hit) return hit
+        const uris = await vscode.workspace.findFiles(`**/*.${ext}`, "**/node_modules/**", MAX_FILES_PER_EXT)
+        for (const uri of uris) {
+          try {
+            const bytes = await vscode.workspace.fs.readFile(uri)
+            const text = new TextDecoder().decode(bytes)
+            const match = pattern.exec(text)
+            if (match) return { uri, index: match.index }
+          } catch {
+            // skip unreadable files
+          }
         }
       }
       return undefined
@@ -2618,6 +2628,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         selection: new vscode.Range(pos, pos),
         preview: true,
       })
+      // Cache so repeated clicks are instant
+      this.symbolCache.set(rawSymbol, hit)
       return
     }
 

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2489,8 +2489,15 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * kilocode_change start: bare filenames (no path separator) are resolved via
    * workspace.findFiles so that clicking a "ShapeEditorContext.cs:129" link in chat
    * works without knowing the full path.
+   * Paths prefixed with "__kilo_symbol__" are routed to openSymbol() for class/method
+   * navigation — this reuses the proven file-link postMessage channel.
    */
   private handleOpenFile(filePath: string, line?: number, column?: number): void {
+    // kilocode_change: symbol navigation piggybacks on the openFile channel
+    if (filePath.startsWith("__kilo_symbol__")) {
+      void openSymbol(filePath.slice("__kilo_symbol__".length))
+      return
+    }
     const hasSeparator = filePath.includes("/") || filePath.includes("\\")
     if (!isAbsolutePath(filePath) && !hasSeparator) {
       vscode.workspace.findFiles(`**/${filePath}`, "**/node_modules/**", 1).then((files) => {

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2478,11 +2478,31 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * Resolves relative paths against the current session's directory (which may be
    * a worktree path registered via setSessionDirectory), falling back to workspace root.
    * Absolute paths (Unix `/…` or Windows `C:\…`) are used as-is.
+   * kilocode_change start: bare filenames (no path separator) are resolved via
+   * workspace.findFiles so that clicking a "ShapeEditorContext.cs:129" link in chat
+   * works without knowing the full path.
    */
   private handleOpenFile(filePath: string, line?: number, column?: number): void {
+    const hasSeparator = filePath.includes("/") || filePath.includes("\\")
+    if (!isAbsolutePath(filePath) && !hasSeparator) {
+      vscode.workspace.findFiles(`**/${filePath}`, "**/node_modules/**", 1).then((files) => {
+        if (files.length > 0) {
+          this.openUriAtLine(files[0], line, column)
+        } else {
+          console.warn(`[Kilo New] KiloProvider: File not found in workspace: ${filePath}`)
+        }
+      })
+      return
+    }
     const uri = isAbsolutePath(filePath)
       ? vscode.Uri.file(filePath)
       : vscode.Uri.joinPath(vscode.Uri.file(this.getWorkspaceDirectory(this.currentSession?.id)), filePath)
+    this.openUriAtLine(uri, line, column)
+  }
+
+  /** Open a resolved URI at an optional line/column in the editor. */
+  private openUriAtLine(uri: vscode.Uri, line?: number, column?: number): void {
+    // kilocode_change end
     vscode.workspace.openTextDocument(uri).then(
       (doc) => {
         const options: vscode.TextDocumentShowOptions = { preview: true }

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2570,17 +2570,15 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     const esc = symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-    // Cap per-extension to 300 files — enough to cover large monorepos while
-    // keeping peak memory manageable. Sequential reads (chunk=1) avoid GC pressure
-    // from many simultaneous Uint8Array + TextDecoder allocations.
-    const MAX_FILES_PER_EXT = 300
+    // No file count cap — sequential reads are memory-safe (one file at a time).
+    // The previous Promise.all approach was the cause of memory spikes, not the file count.
     const exts = ["cs", "ts", "tsx", "js", "jsx", "mts", "py", "go", "rs", "cpp", "java", "kt", "swift"]
 
     type Hit = { uri: vscode.Uri; index: number }
 
     const searchWithPattern = async (pattern: RegExp): Promise<Hit | undefined> => {
       for (const ext of exts) {
-        const uris = await vscode.workspace.findFiles(`**/*.${ext}`, "**/node_modules/**", MAX_FILES_PER_EXT)
+        const uris = await vscode.workspace.findFiles(`**/*.${ext}`, "**/node_modules/**")
         for (const uri of uris) {
           try {
             const bytes = await vscode.workspace.fs.readFile(uri)
@@ -2616,8 +2614,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         hit = await searchWithPattern(anyNonCommentPattern)
       }
     } else {
-      // Type declarations are distinctive — class/struct/interface/enum/record before the name
-      const declPattern = new RegExp(`(?:class|struct|interface|enum|record)\\s+${esc}\\b`, "m")
+      // Type declaration — require access modifiers or bare declaration keyword,
+      // and exclude comment lines (// or *) to avoid matching XML doc comments.
+      // Matches: "public class ShapeEditorContext"  "class ShapeEditorContext"
+      // Skips:   "// class ShapeEditorContext"      "/// see class ShapeEditorContext"
+      const declPattern = new RegExp(
+        `^[ \\t]*(?![ \\t]*//)(?![ \\t]*\\*)(?:(?:public|private|protected|internal|static|abstract|sealed|partial)[ \\t]+)*(?:class|struct|interface|enum|record)[ \\t]+${esc}\\b`,
+        "m",
+      )
       hit = await searchWithPattern(declPattern)
     }
 

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -644,6 +644,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             this.handleOpenFile(message.filePath, message.line, message.column)
           }
           break
+        // kilocode_change start: open symbol (class/method) by name via workspace symbol provider
+        case "openSymbol":
+          if (message.symbol) {
+            this.handleOpenSymbol(message.symbol)
+          }
+          break
+        // kilocode_change end
         case "requestProviders":
           this.fetchAndSendProviders().catch((e) => console.error("[Kilo New] fetchAndSendProviders failed:", e))
           break
@@ -2516,6 +2523,107 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       (err) => console.error("[Kilo New] KiloProvider: Failed to open file:", uri.fsPath, err),
     )
   }
+
+  // kilocode_change start: navigate to a symbol (class/method) by name
+  /**
+   * Search the workspace for a symbol by name and navigate to its definition.
+   * First tries the LSP workspace symbol provider (e.g. OmniSharp, tsserver).
+   * Falls back to a regex content search across workspace files when LSP is
+   * unavailable (common in Unity / non-LSP projects).
+   * Strips trailing "()" so both "BuildFrame" and "BuildFrame()" resolve correctly.
+   */
+  private async handleOpenSymbol(rawSymbol: string): Promise<void> {
+    const symbol = rawSymbol.replace(/\(\)$/, "").split(".").pop() ?? rawSymbol
+    const isMethod = rawSymbol.endsWith("()")
+
+    // Phase 1: try the workspace symbol provider (requires an active LSP)
+    try {
+      const results = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+        "vscode.executeWorkspaceSymbolProvider",
+        symbol,
+      )
+      if (results && results.length > 0) {
+        const exact = results.find((s) => s.name === symbol || s.name === rawSymbol.replace(/\(\)$/, ""))
+        const target = exact ?? results[0]
+        const doc = await vscode.workspace.openTextDocument(target.location.uri)
+        await vscode.window.showTextDocument(doc, { selection: target.location.range, preview: true })
+        return
+      }
+    } catch {
+      // LSP unavailable — fall through to content search
+    }
+
+    // Phase 2: content search with two-tier matching
+    const esc = symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    const CHUNK = 50
+    const exts = ["cs", "ts", "tsx", "js", "jsx", "mts", "py", "go", "rs", "cpp", "java", "kt", "swift"]
+
+    type Hit = { uri: vscode.Uri; index: number }
+
+    const searchWithPattern = async (pattern: RegExp): Promise<Hit | undefined> => {
+      for (const ext of exts) {
+        const uris = await vscode.workspace.findFiles(`**/*.${ext}`, "**/node_modules/**")
+        if (uris.length === 0) continue
+        for (let i = 0; i < uris.length; i += CHUNK) {
+          const chunk = uris.slice(i, i + CHUNK)
+          const hits = await Promise.all(
+            chunk.map(async (uri) => {
+              try {
+                const bytes = await vscode.workspace.fs.readFile(uri)
+                const text = new TextDecoder().decode(bytes)
+                const match = pattern.exec(text)
+                return match ? { uri, index: match.index } : null
+              } catch {
+                return null
+              }
+            }),
+          )
+          const hit = hits.find((h) => h !== null)
+          if (hit) return hit
+        }
+      }
+      return undefined
+    }
+
+    let hit: Hit | undefined
+
+    if (isMethod) {
+      // Tier 1: declaration — line starts with access modifiers (not a comment or plain call)
+      // Matches: "    public static void BuildFrame("
+      // Skips:   "    // BuildFrame(" and "    BuildFrame();"
+      const declPattern = new RegExp(
+        `^[ \\t]*(?![ \\t]*//)(?:(?:public|private|protected|internal|static|virtual|override|abstract|async|sealed|unsafe|partial|new|extern)[ \\t]+)+[^\\n]*\\b${esc}\\s*\\(`,
+        "m",
+      )
+      hit = await searchWithPattern(declPattern)
+
+      // Tier 2: any occurrence that isn't on a pure comment line
+      if (!hit) {
+        const anyNonCommentPattern = new RegExp(
+          `^[ \\t]*(?![ \\t]*//)(?![ \\t]*\\*)(?:[^\\n]*)\\b${esc}\\s*\\(`,
+          "m",
+        )
+        hit = await searchWithPattern(anyNonCommentPattern)
+      }
+    } else {
+      // Type declarations are distinctive — class/struct/interface/enum/record before the name
+      const declPattern = new RegExp(`(?:class|struct|interface|enum|record)\\s+${esc}\\b`, "m")
+      hit = await searchWithPattern(declPattern)
+    }
+
+    if (hit) {
+      const doc = await vscode.workspace.openTextDocument(hit.uri)
+      const pos = doc.positionAt(hit.index)
+      await vscode.window.showTextDocument(doc, {
+        selection: new vscode.Range(pos, pos),
+        preview: true,
+      })
+      return
+    }
+
+    vscode.window.showInformationMessage(`Symbol not found: ${rawSymbol}`)
+  }
+  // kilocode_change end
 
   /**
    * Handle a generic setting update from the webview.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2647,14 +2647,19 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const pos = doc.positionAt(hit.index)
       await vscode.window.showTextDocument(doc, {
         selection: new vscode.Range(pos, pos),
-        preview: true,
+        preview: false,    // open in persistent tab so it doesn't get replaced
+        preserveFocus: false, // focus the editor so user sees the jump
       })
       // Cache so repeated clicks are instant
       this.symbolCache.set(rawSymbol, hit)
       return
     }
 
-    vscode.window.showInformationMessage(`Symbol not found: ${rawSymbol}`)
+    // Show which files were searched so the user can diagnose missing results
+    const searched = exts.map((e) => `*.${e}`).join(", ")
+    vscode.window.showInformationMessage(
+      `Symbol not found: ${rawSymbol} (searched ${searched} in workspace)`,
+    )
   }
   // kilocode_change end
 

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2580,6 +2580,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       for (const ext of exts) {
         const uris = await vscode.workspace.findFiles(`**/*.${ext}`, "**/node_modules/**")
         for (const uri of uris) {
+          // Guard: skip files whose path doesn't match the expected extension
+          if (!uri.fsPath.toLowerCase().endsWith(`.${ext}`)) continue
           try {
             const bytes = await vscode.workspace.fs.readFile(uri)
             const text = new TextDecoder().decode(bytes)
@@ -2622,16 +2624,17 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       )
 
       // Phase A: same-name file, exclude documentation folders to avoid false positives
-      // (.ReadMe/ShapeEditorContext.cs snippets should not take priority over the real source file)
       const docExclude = "**/{node_modules,.ReadMe,.readme,docs,documentation,wiki,.doc}/**"
       for (const ext of exts) {
         const files = await vscode.workspace.findFiles(`**/${symbol}.${ext}`, docExclude, 5)
         for (const uri of files) {
+          // Guard: skip any file whose path doesn't end with the expected extension
+          // (works around VS Code glob quirks on Windows that may return wrong files)
+          if (!uri.fsPath.toLowerCase().endsWith(`.${ext}`)) continue
           try {
             const bytes = await vscode.workspace.fs.readFile(uri)
             const text = new TextDecoder().decode(bytes)
             const match = declPattern.exec(text)
-            // Only accept if declaration is actually found; no fallback to position 0
             if (match) { hit = { uri, index: match.index }; break }
           } catch { /* skip */ }
         }

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode"
 import { z } from "zod"
 import { buildPreviewPath, getPreviewCommand, getPreviewDir, parseImage, trimEntries } from "./image-preview"
 import { isAbsolutePath } from "./path-utils"
+import { openSymbol } from "./open-symbol"
 import type {
   KiloClient,
   Session,
@@ -647,7 +648,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         // kilocode_change start: open symbol (class/method) by name via workspace symbol provider
         case "openSymbol":
           if (message.symbol) {
-            this.handleOpenSymbol(message.symbol)
+            openSymbol(message.symbol)
           }
           break
         // kilocode_change end
@@ -2525,147 +2526,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   // kilocode_change start: navigate to a symbol (class/method) by name
-  /**
-   * Cache: symbol raw text → resolved URI + position, to avoid re-scanning on repeated clicks.
-   * Cleared when the workspace changes or the extension is deactivated.
-   */
-  private readonly symbolCache = new Map<string, { uri: vscode.Uri; index: number }>()
-
-  /**
-   * Search the workspace for a symbol by name and navigate to its definition.
-   * First tries the LSP workspace symbol provider (e.g. OmniSharp, tsserver).
-   * Falls back to a regex content search across workspace files when LSP is
-   * unavailable (common in Unity / non-LSP projects).
-   * Strips trailing "()" so both "BuildFrame" and "BuildFrame()" resolve correctly.
-   */
-  private async handleOpenSymbol(rawSymbol: string): Promise<void> {
-    const symbol = rawSymbol.replace(/\(\)$/, "").split(".").pop() ?? rawSymbol
-    const isMethod = rawSymbol.endsWith("()")
-
-    // Phase 1: try the workspace symbol provider (requires an active LSP)
-    try {
-      const results = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
-        "vscode.executeWorkspaceSymbolProvider",
-        symbol,
-      )
-      if (results && results.length > 0) {
-        const exact = results.find((s) => s.name === symbol || s.name === rawSymbol.replace(/\(\)$/, ""))
-        const target = exact ?? results[0]
-        const doc = await vscode.workspace.openTextDocument(target.location.uri)
-        await vscode.window.showTextDocument(doc, { selection: target.location.range, preview: true })
-        return
-      }
-    } catch {
-      // LSP unavailable — fall through to content search
-    }
-
-    // Phase 2: content search with two-tier matching
-    // Return cached result immediately if available
-    const cached = this.symbolCache.get(rawSymbol)
-    if (cached) {
-      const doc = await vscode.workspace.openTextDocument(cached.uri)
-      const pos = doc.positionAt(cached.index)
-      await vscode.window.showTextDocument(doc, { selection: new vscode.Range(pos, pos), preview: true })
-      return
-    }
-
-    const esc = symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-    // No file count cap — sequential reads are memory-safe (one file at a time).
-    // The previous Promise.all approach was the cause of memory spikes, not the file count.
-    const exts = ["cs", "ts", "tsx", "js", "jsx", "mts", "py", "go", "rs", "cpp", "java", "kt", "swift"]
-
-    type Hit = { uri: vscode.Uri; index: number }
-
-    const searchWithPattern = async (pattern: RegExp): Promise<Hit | undefined> => {
-      for (const ext of exts) {
-        const uris = await vscode.workspace.findFiles(`**/*.${ext}`, "**/node_modules/**")
-        for (const uri of uris) {
-          // Guard: skip files whose path doesn't match the expected extension
-          if (!uri.fsPath.toLowerCase().endsWith(`.${ext}`)) continue
-          try {
-            const bytes = await vscode.workspace.fs.readFile(uri)
-            const text = new TextDecoder().decode(bytes)
-            const match = pattern.exec(text)
-            if (match) return { uri, index: match.index }
-          } catch {
-            // skip unreadable files
-          }
-        }
-      }
-      return undefined
-    }
-
-    let hit: Hit | undefined
-
-    if (isMethod) {
-      // Tier 1: declaration — line starts with access modifiers (not a comment or plain call)
-      // Matches: "    public static void BuildFrame("
-      // Skips:   "    // BuildFrame(" and "    BuildFrame();"
-      const declPattern = new RegExp(
-        `^[ \\t]*(?![ \\t]*//)(?:(?:public|private|protected|internal|static|virtual|override|abstract|async|sealed|unsafe|partial|new|extern)[ \\t]+)+[^\\n]*\\b${esc}\\s*\\(`,
-        "m",
-      )
-      hit = await searchWithPattern(declPattern)
-
-      // Tier 2: any occurrence that isn't on a pure comment line
-      if (!hit) {
-        const anyNonCommentPattern = new RegExp(
-          `^[ \\t]*(?![ \\t]*//)(?![ \\t]*\\*)(?:[^\\n]*)\\b${esc}\\s*\\(`,
-          "m",
-        )
-        hit = await searchWithPattern(anyNonCommentPattern)
-      }
-    } else {
-      // Type declaration — Phase A: find a file named exactly "SymbolName.ext".
-      // Phase B: global content search fallback.
-      const declPattern = new RegExp(
-        `^[ \\t]*(?![ \\t]*//)(?![ \\t]*\\*)(?:(?:public|private|protected|internal|static|abstract|sealed|partial)[ \\t]+)*(?:class|struct|interface|enum|record)[ \\t]+${esc}\\b`,
-        "m",
-      )
-
-      // Phase A: same-name file, exclude documentation folders to avoid false positives
-      const docExclude = "**/{node_modules,.ReadMe,.readme,docs,documentation,wiki,.doc}/**"
-      for (const ext of exts) {
-        const files = await vscode.workspace.findFiles(`**/${symbol}.${ext}`, docExclude, 5)
-        for (const uri of files) {
-          // Guard: skip any file whose path doesn't end with the expected extension
-          // (works around VS Code glob quirks on Windows that may return wrong files)
-          if (!uri.fsPath.toLowerCase().endsWith(`.${ext}`)) continue
-          try {
-            const bytes = await vscode.workspace.fs.readFile(uri)
-            const text = new TextDecoder().decode(bytes)
-            const match = declPattern.exec(text)
-            if (match) { hit = { uri, index: match.index }; break }
-          } catch { /* skip */ }
-        }
-        if (hit) break
-      }
-
-      // Phase B: global content search fallback
-      if (!hit) hit = await searchWithPattern(declPattern)
-    }
-
-    if (hit) {
-      const doc = await vscode.workspace.openTextDocument(hit.uri)
-      const pos = doc.positionAt(hit.index)
-      await vscode.window.showTextDocument(doc, {
-        selection: new vscode.Range(pos, pos),
-        preview: false,    // open in persistent tab so it doesn't get replaced
-        preserveFocus: false, // focus the editor so user sees the jump
-      })
-      // Cache so repeated clicks are instant
-      this.symbolCache.set(rawSymbol, hit)
-      return
-    }
-
-    // Show which files were searched so the user can diagnose missing results
-    const searched = exts.map((e) => `*.${e}`).join(", ")
-    vscode.window.showInformationMessage(
-      `Symbol not found: ${rawSymbol} (searched ${searched} in workspace)`,
-    )
-  }
-  // kilocode_change end
-
   /**
    * Handle a generic setting update from the webview.
    * The key uses dot notation relative to `kilo-code.new` (e.g. "browserAutomation.enabled").

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2614,15 +2614,44 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         hit = await searchWithPattern(anyNonCommentPattern)
       }
     } else {
-      // Type declaration — require access modifiers or bare declaration keyword,
-      // and exclude comment lines (// or *) to avoid matching XML doc comments.
-      // Matches: "public class ShapeEditorContext"  "class ShapeEditorContext"
-      // Skips:   "// class ShapeEditorContext"      "/// see class ShapeEditorContext"
+      // Type declaration search — two phases:
+      //
+      // Phase A: look for a file named exactly "SymbolName.ext" (e.g. ShapeEditorContext.cs).
+      //   Classes are almost always in a same-name file; this is fast, precise, and avoids
+      //   false positives from scanning thousands of files.
+      //
+      // Phase B: global content search as fallback when no same-name file exists.
       const declPattern = new RegExp(
         `^[ \\t]*(?![ \\t]*//)(?![ \\t]*\\*)(?:(?:public|private|protected|internal|static|abstract|sealed|partial)[ \\t]+)*(?:class|struct|interface|enum|record)[ \\t]+${esc}\\b`,
         "m",
       )
-      hit = await searchWithPattern(declPattern)
+
+      // Phase A: same-name file search
+      for (const ext of exts) {
+        const files = await vscode.workspace.findFiles(`**/${symbol}.${ext}`, "**/node_modules/**", 5)
+        for (const uri of files) {
+          try {
+            const bytes = await vscode.workspace.fs.readFile(uri)
+            const text = new TextDecoder().decode(bytes)
+            const match = declPattern.exec(text)
+            // Found declaration inside the same-name file
+            if (match) {
+              hit = { uri, index: match.index }
+              break
+            }
+            // File exists but pattern not matched — open at top as fallback
+            if (!hit) hit = { uri, index: 0 }
+          } catch {
+            // skip
+          }
+        }
+        if (hit) break
+      }
+
+      // Phase B: global content search (fallback when no same-name file)
+      if (!hit) {
+        hit = await searchWithPattern(declPattern)
+      }
     }
 
     if (hit) {

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2614,44 +2614,32 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         hit = await searchWithPattern(anyNonCommentPattern)
       }
     } else {
-      // Type declaration search — two phases:
-      //
-      // Phase A: look for a file named exactly "SymbolName.ext" (e.g. ShapeEditorContext.cs).
-      //   Classes are almost always in a same-name file; this is fast, precise, and avoids
-      //   false positives from scanning thousands of files.
-      //
-      // Phase B: global content search as fallback when no same-name file exists.
+      // Type declaration — Phase A: find a file named exactly "SymbolName.ext".
+      // Phase B: global content search fallback.
       const declPattern = new RegExp(
         `^[ \\t]*(?![ \\t]*//)(?![ \\t]*\\*)(?:(?:public|private|protected|internal|static|abstract|sealed|partial)[ \\t]+)*(?:class|struct|interface|enum|record)[ \\t]+${esc}\\b`,
         "m",
       )
 
-      // Phase A: same-name file search
+      // Phase A: same-name file, exclude documentation folders to avoid false positives
+      // (.ReadMe/ShapeEditorContext.cs snippets should not take priority over the real source file)
+      const docExclude = "**/{node_modules,.ReadMe,.readme,docs,documentation,wiki,.doc}/**"
       for (const ext of exts) {
-        const files = await vscode.workspace.findFiles(`**/${symbol}.${ext}`, "**/node_modules/**", 5)
+        const files = await vscode.workspace.findFiles(`**/${symbol}.${ext}`, docExclude, 5)
         for (const uri of files) {
           try {
             const bytes = await vscode.workspace.fs.readFile(uri)
             const text = new TextDecoder().decode(bytes)
             const match = declPattern.exec(text)
-            // Found declaration inside the same-name file
-            if (match) {
-              hit = { uri, index: match.index }
-              break
-            }
-            // File exists but pattern not matched — open at top as fallback
-            if (!hit) hit = { uri, index: 0 }
-          } catch {
-            // skip
-          }
+            // Only accept if declaration is actually found; no fallback to position 0
+            if (match) { hit = { uri, index: match.index }; break }
+          } catch { /* skip */ }
         }
         if (hit) break
       }
 
-      // Phase B: global content search (fallback when no same-name file)
-      if (!hit) {
-        hit = await searchWithPattern(declPattern)
-      }
+      // Phase B: global content search fallback
+      if (!hit) hit = await searchWithPattern(declPattern)
     }
 
     if (hit) {

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -405,9 +405,9 @@ export class AgentManagerProvider implements Disposable {
     }
 
     // kilocode_change start: handle symbol navigation from chat markdown links
-    if (m.type === "openSymbol" && m.symbol) {
-      openSymbol(m.symbol)
-      return null
+    if ((m as { type: string; symbol?: string }).type === "openSymbol") {
+      const sym = (m as { symbol?: string }).symbol
+      if (sym) { openSymbol(sym); return null }
     }
     // kilocode_change end
 

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -395,6 +395,11 @@ export class AgentManagerProvider implements Disposable {
     // Local sessions fall through to the session provider which resolves against the repo root.
     // Uses activeSessionId (set synchronously by loadMessages) rather than
     // the session provider's currentSession which can be stale during rapid tab switches.
+    // kilocode_change: __kilo_symbol__ prefix routes to openSymbol, not worktree file resolution
+    if (m.type === "openFile" && typeof m.filePath === "string" && m.filePath.startsWith("__kilo_symbol__")) {
+      openSymbol(m.filePath.slice("__kilo_symbol__".length))
+      return null
+    }
     if (m.type === "openFile") {
       const sessionId = this.activeSessionId
       const state = this.getStateManager()

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -3,6 +3,7 @@ import * as path from "path"
 import type { KiloClient, Session } from "@kilocode/sdk/v2/client"
 import type { KiloConnectionService } from "../services/cli-backend"
 import { getErrorMessage } from "../kilo-provider-utils"
+import { openSymbol } from "../open-symbol"
 import { isAbsolutePath } from "../path-utils"
 import { WorktreeManager, type CreateWorktreeResult } from "./WorktreeManager"
 import { WorktreeStateManager, remoteRef } from "./WorktreeStateManager"
@@ -402,6 +403,13 @@ export class AgentManagerProvider implements Disposable {
         return null
       }
     }
+
+    // kilocode_change start: handle symbol navigation from chat markdown links
+    if (m.type === "openSymbol" && m.symbol) {
+      openSymbol(m.symbol)
+      return null
+    }
+    // kilocode_change end
 
     // Track the active session synchronously so worktree-aware file resolution
     // uses the correct session even before the session provider's async session.get completes.

--- a/packages/kilo-vscode/src/open-symbol.ts
+++ b/packages/kilo-vscode/src/open-symbol.ts
@@ -12,6 +12,7 @@ const symbolCache = new Map<string, { uri: vscode.Uri; index: number }>()
 export async function openSymbol(rawSymbol: string): Promise<void> {
   const symbol = rawSymbol.replace(/\(\)$/, "").split(".").pop() ?? rawSymbol
   const isMethod = rawSymbol.endsWith("()")
+  console.log(`[Kilo] openSymbol called: raw="${rawSymbol}" symbol="${symbol}" isMethod=${isMethod}`)
 
   // Phase 1: LSP
   try {

--- a/packages/kilo-vscode/src/open-symbol.ts
+++ b/packages/kilo-vscode/src/open-symbol.ts
@@ -1,0 +1,111 @@
+// kilocode_change start: shared symbol navigation used by KiloProvider and AgentManagerProvider
+import * as vscode from "vscode"
+
+/** Module-level cache — cleared when the VS Code window reloads. */
+const symbolCache = new Map<string, { uri: vscode.Uri; index: number }>()
+
+/**
+ * Search the workspace for a symbol (class / method) by name and navigate to its definition.
+ * Phase 1: LSP workspace symbol provider (requires an active language server).
+ * Phase 2: File content search — same-name file first, then global scan.
+ */
+export async function openSymbol(rawSymbol: string): Promise<void> {
+  const symbol = rawSymbol.replace(/\(\)$/, "").split(".").pop() ?? rawSymbol
+  const isMethod = rawSymbol.endsWith("()")
+
+  // Phase 1: LSP
+  try {
+    const results = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+      "vscode.executeWorkspaceSymbolProvider",
+      symbol,
+    )
+    if (results && results.length > 0) {
+      const exact = results.find((s) => s.name === symbol || s.name === rawSymbol.replace(/\(\)$/, ""))
+      const target = exact ?? results[0]
+      const doc = await vscode.workspace.openTextDocument(target.location.uri)
+      await vscode.window.showTextDocument(doc, { selection: target.location.range, preview: false, preserveFocus: false })
+      return
+    }
+  } catch { /* LSP unavailable */ }
+
+  // Phase 2: content search
+  const cached = symbolCache.get(rawSymbol)
+  if (cached) {
+    const doc = await vscode.workspace.openTextDocument(cached.uri)
+    const pos = doc.positionAt(cached.index)
+    await vscode.window.showTextDocument(doc, { selection: new vscode.Range(pos, pos), preview: false, preserveFocus: false })
+    return
+  }
+
+  const esc = symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const exts = ["cs", "ts", "tsx", "js", "jsx", "mts", "py", "go", "rs", "cpp", "java", "kt", "swift"]
+  type Hit = { uri: vscode.Uri; index: number }
+
+  const searchWithPattern = async (pattern: RegExp): Promise<Hit | undefined> => {
+    for (const ext of exts) {
+      const uris = await vscode.workspace.findFiles(`**/*.${ext}`, "**/node_modules/**")
+      for (const uri of uris) {
+        if (!uri.fsPath.toLowerCase().endsWith(`.${ext}`)) continue
+        try {
+          const bytes = await vscode.workspace.fs.readFile(uri)
+          const text = new TextDecoder().decode(bytes)
+          const match = pattern.exec(text)
+          if (match) return { uri, index: match.index }
+        } catch { /* skip */ }
+      }
+    }
+    return undefined
+  }
+
+  let hit: Hit | undefined
+
+  if (isMethod) {
+    const declPattern = new RegExp(
+      `^[ \\t]*(?![ \\t]*//)(?:(?:public|private|protected|internal|static|virtual|override|abstract|async|sealed|unsafe|partial|new|extern)[ \\t]+)+[^\\n]*\\b${esc}\\s*\\(`,
+      "m",
+    )
+    hit = await searchWithPattern(declPattern)
+    if (!hit) {
+      hit = await searchWithPattern(
+        new RegExp(`^[ \\t]*(?![ \\t]*//)(?![ \\t]*\\*)(?:[^\\n]*)\\b${esc}\\s*\\(`, "m"),
+      )
+    }
+  } else {
+    const declPattern = new RegExp(
+      `^[ \\t]*(?![ \\t]*//)(?![ \\t]*\\*)(?:(?:public|private|protected|internal|static|abstract|sealed|partial)[ \\t]+)*(?:class|struct|interface|enum|record)[ \\t]+${esc}\\b`,
+      "m",
+    )
+    const docExclude = "**/{node_modules,.ReadMe,.readme,docs,documentation,wiki,.doc}/**"
+    for (const ext of exts) {
+      const files = await vscode.workspace.findFiles(`**/${symbol}.${ext}`, docExclude, 5)
+      for (const uri of files) {
+        if (!uri.fsPath.toLowerCase().endsWith(`.${ext}`)) continue
+        try {
+          const bytes = await vscode.workspace.fs.readFile(uri)
+          const text = new TextDecoder().decode(bytes)
+          const match = declPattern.exec(text)
+          if (match) { hit = { uri, index: match.index }; break }
+        } catch { /* skip */ }
+      }
+      if (hit) break
+    }
+    if (!hit) hit = await searchWithPattern(declPattern)
+  }
+
+  if (hit) {
+    const doc = await vscode.workspace.openTextDocument(hit.uri)
+    const pos = doc.positionAt(hit.index)
+    await vscode.window.showTextDocument(doc, {
+      selection: new vscode.Range(pos, pos),
+      preview: false,
+      preserveFocus: false,
+    })
+    symbolCache.set(rawSymbol, hit)
+    return
+  }
+
+  vscode.window.showInformationMessage(
+    `Symbol not found: ${rawSymbol} (searched ${exts.map((e) => `*.${e}`).join(", ")})`,
+  )
+}
+// kilocode_change end

--- a/packages/kilo-vscode/src/open-symbol.ts
+++ b/packages/kilo-vscode/src/open-symbol.ts
@@ -12,7 +12,6 @@ const symbolCache = new Map<string, { uri: vscode.Uri; index: number }>()
 export async function openSymbol(rawSymbol: string): Promise<void> {
   const symbol = rawSymbol.replace(/\(\)$/, "").split(".").pop() ?? rawSymbol
   const isMethod = rawSymbol.endsWith("()")
-  console.log(`[Kilo] openSymbol called: raw="${rawSymbol}" symbol="${symbol}" isMethod=${isMethod}`)
 
   // Phase 1: LSP
   try {
@@ -72,11 +71,20 @@ export async function openSymbol(rawSymbol: string): Promise<void> {
       )
     }
   } else {
-    const declPattern = new RegExp(
-      `^[ \\t]*(?![ \\t]*//)(?![ \\t]*\\*)(?:(?:public|private|protected|internal|static|abstract|sealed|partial)[ \\t]+)*(?:class|struct|interface|enum|record)[ \\t]+${esc}\\b`,
+    // For type declarations use a STRICTER pattern that requires at least one
+    // access modifier before the keyword. This prevents matching class names
+    // that appear inside markdown code-blocks or XML doc comments where there
+    // is no preceding modifier.
+    const strictDeclPattern = new RegExp(
+      `^[ \\t]*(?![ \\t]*//)(?![ \\t]*\\*)(?:(?:public|private|protected|internal|static|abstract|sealed|partial)[ \\t]+)+(?:class|struct|interface|enum|record)[ \\t]+${esc}\\b`,
       "m",
     )
-    const docExclude = "**/{node_modules,.ReadMe,.readme,docs,documentation,wiki,.doc}/**"
+
+    // Phase A: same-name file only. No Phase B fallback — global search risks
+    // matching class names in markdown/documentation files. In Unity C# every
+    // class lives in a file with the matching name, so Phase A is sufficient.
+    // Exclude documentation dirs AND worktree copies (.kilo/worktrees/).
+    const docExclude = "**/{node_modules,.ReadMe,.readme,docs,documentation,wiki,.doc,.kilo,worktrees}/**"
     for (const ext of exts) {
       const files = await vscode.workspace.findFiles(`**/${symbol}.${ext}`, docExclude, 5)
       for (const uri of files) {
@@ -84,13 +92,13 @@ export async function openSymbol(rawSymbol: string): Promise<void> {
         try {
           const bytes = await vscode.workspace.fs.readFile(uri)
           const text = new TextDecoder().decode(bytes)
-          const match = declPattern.exec(text)
+          const match = strictDeclPattern.exec(text)
           if (match) { hit = { uri, index: match.index }; break }
         } catch { /* skip */ }
       }
       if (hit) break
     }
-    if (!hit) hit = await searchWithPattern(declPattern)
+    // No Phase B: avoid false positives from .md and design-doc files
   }
 
   if (hit) {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1085,12 +1085,15 @@ const AgentManagerContent: Component = () => {
     window.addEventListener("focus", onWindowFocus)
 
     // kilocode_change start: forward file:line and symbol link clicks from markdown to the extension
+    console.log("[Kilo] AgentManagerApp: registering kilo link handlers")
     const fileLinkHandler = (e: Event) => {
       const { file, line } = (e as CustomEvent<{ file: string; line?: number }>).detail
+      console.log("[Kilo] kilo:openFileAtLine", file, line)
       vscode.postMessage({ type: "openFile", filePath: file, line })
     }
     const symbolLinkHandler = (e: Event) => {
       const { symbol } = (e as CustomEvent<{ symbol: string }>).detail
+      console.log("[Kilo] kilo:openSymbol", symbol)
       vscode.postMessage({ type: "openSymbol", symbol })
     }
     document.addEventListener("kilo:openFileAtLine", fileLinkHandler)

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1085,23 +1085,13 @@ const AgentManagerContent: Component = () => {
     window.addEventListener("focus", onWindowFocus)
 
     // kilocode_change start: forward file:line and symbol link clicks from markdown to the extension
-    console.log("[Kilo] AgentManagerApp: registering kilo link handlers")
+    // Symbol links use "__kilo_symbol__" prefix — same fileLinkHandler covers both.
     const fileLinkHandler = (e: Event) => {
       const { file, line } = (e as CustomEvent<{ file: string; line?: number }>).detail
-      console.log("[Kilo] kilo:openFileAtLine", file, line)
       vscode.postMessage({ type: "openFile", filePath: file, line })
     }
-    const symbolLinkHandler = (e: Event) => {
-      const { symbol } = (e as CustomEvent<{ symbol: string }>).detail
-      console.log("[Kilo] kilo:openSymbol", symbol)
-      vscode.postMessage({ type: "openSymbol", symbol })
-    }
     document.addEventListener("kilo:openFileAtLine", fileLinkHandler)
-    document.addEventListener("kilo:openSymbol", symbolLinkHandler)
-    onCleanup(() => {
-      document.removeEventListener("kilo:openFileAtLine", fileLinkHandler)
-      document.removeEventListener("kilo:openSymbol", symbolLinkHandler)
-    })
+    onCleanup(() => document.removeEventListener("kilo:openFileAtLine", fileLinkHandler))
     // kilocode_change end
 
     // When a session is created, add it as a local tab. This handles both direct

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1084,6 +1084,23 @@ const AgentManagerContent: Component = () => {
     }
     window.addEventListener("focus", onWindowFocus)
 
+    // kilocode_change start: forward file:line and symbol link clicks from markdown to the extension
+    const fileLinkHandler = (e: Event) => {
+      const { file, line } = (e as CustomEvent<{ file: string; line?: number }>).detail
+      vscode.postMessage({ type: "openFile", filePath: file, line })
+    }
+    const symbolLinkHandler = (e: Event) => {
+      const { symbol } = (e as CustomEvent<{ symbol: string }>).detail
+      vscode.postMessage({ type: "openSymbol", symbol })
+    }
+    document.addEventListener("kilo:openFileAtLine", fileLinkHandler)
+    document.addEventListener("kilo:openSymbol", symbolLinkHandler)
+    onCleanup(() => {
+      document.removeEventListener("kilo:openFileAtLine", fileLinkHandler)
+      document.removeEventListener("kilo:openSymbol", symbolLinkHandler)
+    })
+    // kilocode_change end
+
     // When a session is created, add it as a local tab. This handles both direct
     // creation from the prompt input and backend-created follow-up sessions (plan
     // follow-up "Start new session"). Guard against duplicates (HTTP + SSE can both fire).

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -212,6 +212,15 @@ const AppContent: Component = () => {
     }
     window.addEventListener("message", handler)
     onCleanup(() => window.removeEventListener("message", handler))
+
+    // kilocode_change start: handle file:line link clicks from the markdown renderer
+    const fileLinkHandler = (e: Event) => {
+      const { file, line } = (e as CustomEvent<{ file: string; line: number }>).detail
+      vscode.postMessage({ type: "openFile", filePath: file, line })
+    }
+    document.addEventListener("kilo:openFileAtLine", fileLinkHandler)
+    onCleanup(() => document.removeEventListener("kilo:openFileAtLine", fileLinkHandler))
+    // kilocode_change end
   })
 
   const handleSelectSession = (id: string) => {

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -220,6 +220,14 @@ const AppContent: Component = () => {
     }
     document.addEventListener("kilo:openFileAtLine", fileLinkHandler)
     onCleanup(() => document.removeEventListener("kilo:openFileAtLine", fileLinkHandler))
+
+    // handle symbol (class/method) link clicks from the markdown renderer
+    const symbolLinkHandler = (e: Event) => {
+      const { symbol } = (e as CustomEvent<{ symbol: string }>).detail
+      vscode.postMessage({ type: "openSymbol", symbol })
+    }
+    document.addEventListener("kilo:openSymbol", symbolLinkHandler)
+    onCleanup(() => document.removeEventListener("kilo:openSymbol", symbolLinkHandler))
     // kilocode_change end
   })
 

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -213,21 +213,14 @@ const AppContent: Component = () => {
     window.addEventListener("message", handler)
     onCleanup(() => window.removeEventListener("message", handler))
 
-    // kilocode_change start: handle file:line link clicks from the markdown renderer
+    // kilocode_change start: handle file:line and symbol link clicks from the markdown renderer
+    // Symbol links reuse the openFile channel with "__kilo_symbol__" prefix — no separate handler needed.
     const fileLinkHandler = (e: Event) => {
-      const { file, line } = (e as CustomEvent<{ file: string; line: number }>).detail
+      const { file, line } = (e as CustomEvent<{ file: string; line?: number }>).detail
       vscode.postMessage({ type: "openFile", filePath: file, line })
     }
     document.addEventListener("kilo:openFileAtLine", fileLinkHandler)
     onCleanup(() => document.removeEventListener("kilo:openFileAtLine", fileLinkHandler))
-
-    // handle symbol (class/method) link clicks from the markdown renderer
-    const symbolLinkHandler = (e: Event) => {
-      const { symbol } = (e as CustomEvent<{ symbol: string }>).detail
-      vscode.postMessage({ type: "openSymbol", symbol })
-    }
-    document.addEventListener("kilo:openSymbol", symbolLinkHandler)
-    onCleanup(() => document.removeEventListener("kilo:openSymbol", symbolLinkHandler))
     // kilocode_change end
   })
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -2074,6 +2074,13 @@ export interface ContinueInWorktreeRequest {
   sessionId: string
 }
 
+// kilocode_change start: open a symbol (class/method) by name via workspace symbol provider
+export interface OpenSymbolRequest {
+  type: "openSymbol"
+  symbol: string
+}
+// kilocode_change end
+
 export type ContinueInWorktreeStatus =
   | "capturing"
   | "creating"
@@ -2216,6 +2223,9 @@ export type WebviewMessage =
   | ToggleFavoriteRequest
   | RequestFavoritesMessage
   | ContinueInWorktreeRequest
+  // kilocode_change start
+  | OpenSymbolRequest
+  // kilocode_change end
 
 // ============================================
 // VS Code API type

--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -231,6 +231,19 @@
         text-decoration-style: solid;
       }
     }
+
+    &.symbol-link {
+      cursor: pointer;
+      text-decoration-line: underline;
+      text-decoration-style: dashed;
+      text-underline-offset: 2px;
+      transition: color 0.15s ease;
+
+      &:hover {
+        color: var(--vscode-symbolIcon-classForeground, var(--text-interactive-base));
+        text-decoration-style: solid;
+      }
+    }
     /* kilocode_change end */
   }
 

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -293,10 +293,13 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
     if (!(target instanceof Element)) return
 
     // kilocode_change start: handle clicks on file:line code links
-    const fileCode = target.closest("code.file-link")
+    // Registered on document in CAPTURE phase so it fires before any parent
+    // capture handlers (e.g. Kilo tool-call result containers that intercept
+    // clicks and navigate to the referenced file).
+     const fileCode = target.closest("code.file-link")
     if (fileCode instanceof HTMLElement && fileCode.dataset.fileLink) {
+      event.stopImmediatePropagation()
       event.preventDefault()
-      event.stopPropagation() // prevent bubbling to tool-call parent handlers
       document.dispatchEvent(
         new CustomEvent("kilo:openFileAtLine", {
           detail: {
@@ -313,13 +316,10 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
     // kilocode_change end
 
     // kilocode_change start: handle clicks on symbol (class/method) code links
-    // Route through the same kilo:openFileAtLine mechanism as file links (which
-    // is proven to work in both sidebar and Agent Manager contexts) using a
-    // "__kilo_symbol__" prefix so handleOpenFile can distinguish it.
-    const symbolCode = target.closest("code.symbol-link")
+     const symbolCode = target.closest("code.symbol-link")
     if (symbolCode instanceof HTMLElement && symbolCode.dataset.symbolLink) {
+      event.stopImmediatePropagation()
       event.preventDefault()
-      event.stopPropagation() // prevent bubbling to tool-call parent handlers
       document.dispatchEvent(
         new CustomEvent("kilo:openFileAtLine", {
           detail: { file: `__kilo_symbol__${symbolCode.dataset.symbolLink}` },
@@ -329,6 +329,7 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
     }
     // kilocode_change end
 
+    // Only handle copy button clicks that belong to this markdown root
     const button = target.closest('[data-slot="markdown-copy-button"]')
     if (!(button instanceof HTMLButtonElement)) return
     const code = button.closest('[data-component="markdown-code"]')?.querySelector("code")
@@ -351,10 +352,14 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
     if (button instanceof HTMLButtonElement) updateLabel(button)
   }
 
-  root.addEventListener("click", handleClick)
+  // kilocode_change: use document capture phase so our handler fires BEFORE
+  // any parent element's capture-phase handler (e.g. Kilo tool-call result
+  // containers that intercept clicks). root.contains() guards ensure we only
+  // act on clicks that belong to this markdown instance.
+  document.addEventListener("click", handleClick, true)
 
   return () => {
-    root.removeEventListener("click", handleClick)
+    document.removeEventListener("click", handleClick, true)
     for (const timeout of timeouts.values()) {
       clearTimeout(timeout)
     }

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -112,6 +112,49 @@ function markFileLinks(root: HTMLDivElement) {
 }
 // kilocode_change end
 
+// kilocode_change start: symbol link detection (class/method names)
+// Method: identifier() or Namespace.Method()  e.g. BuildFrame(), ShapeEditorContext.BuildFrame()
+const symbolMethodPattern = /^([a-zA-Z][a-zA-Z0-9]*(?:\.[a-zA-Z][a-zA-Z0-9]*)?)\(\)$/
+// Class/type: PascalCase, at least 7 chars, alphanumeric only  e.g. ShapeEditorContext
+const symbolClassPattern = /^([A-Z][a-zA-Z0-9]{6,})$/
+
+function codeSymbolLink(text: string): string | undefined {
+  const trimmed = text.trim()
+  const methodMatch = symbolMethodPattern.exec(trimmed)
+  if (methodMatch) return methodMatch[1]
+  const classMatch = symbolClassPattern.exec(trimmed)
+  if (classMatch) return classMatch[1]
+  return undefined
+}
+
+function markSymbolLinks(root: HTMLDivElement) {
+  const codeNodes = Array.from(root.querySelectorAll(":not(pre) > code"))
+  for (const code of codeNodes) {
+    if (!(code instanceof HTMLElement)) continue
+    // Skip already-tagged file links or external URL links
+    if (code.classList.contains("file-link")) continue
+    if (
+      code.parentElement instanceof HTMLAnchorElement &&
+      code.parentElement.classList.contains("external-link")
+    )
+      continue
+    const rawText = (code.textContent ?? "").trim()
+    const symbol = codeSymbolLink(rawText)
+    if (!symbol) {
+      if (code.classList.contains("symbol-link")) {
+        code.classList.remove("symbol-link")
+        delete code.dataset.symbolLink
+      }
+      continue
+    }
+    code.classList.add("symbol-link")
+    // Store the full original text (e.g. "BuildFrame()") so handleOpenSymbol
+    // can detect isMethod via rawSymbol.endsWith("()")
+    code.dataset.symbolLink = rawText
+  }
+}
+// kilocode_change end
+
 function createIcon(path: string, slot: string) {
   const icon = document.createElement("div")
   icon.setAttribute("data-component", "icon")
@@ -218,6 +261,9 @@ function decorate(root: HTMLDivElement, labels: CopyLabels) {
   // kilocode_change start: mark inline code containing file:line references
   markFileLinks(root)
   // kilocode_change end
+  // kilocode_change start: mark inline code containing symbol names (class/method)
+  markSymbolLinks(root)
+  // kilocode_change end
 }
 
 function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
@@ -242,6 +288,18 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
             file: fileCode.dataset.fileLink,
             line: parseInt(fileCode.dataset.fileLine ?? "1", 10),
           },
+        }),
+      )
+      return
+    }
+    // kilocode_change end
+
+    // kilocode_change start: handle clicks on symbol (class/method) code links
+    const symbolCode = target.closest("code.symbol-link")
+    if (symbolCode instanceof HTMLElement && symbolCode.dataset.symbolLink) {
+      document.dispatchEvent(
+        new CustomEvent("kilo:openSymbol", {
+          detail: { symbol: symbolCode.dataset.symbolLink },
         }),
       )
       return

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -76,14 +76,21 @@ function codeUrl(text: string) {
 }
 
 // kilocode_change start: file:line link detection
-const fileLinkPattern =
-  /^([\w.\-/\\]*?\.(?:cs|ts|tsx|js|jsx|mts|mjs|cjs|cts|py|go|rs|cpp|cxx|c|h|hpp|java|kt|swift|rb|php|lua|sh|bash|zsh|json|xml|yaml|yml|toml)):(\d+)$/i
+const KNOWN_EXTS =
+  "cs|ts|tsx|js|jsx|mts|mjs|cjs|cts|py|go|rs|cpp|cxx|c|h|hpp|java|kt|swift|rb|php|lua|sh|bash|zsh|json|xml|yaml|yml|toml"
 
-function codeFileLink(text: string): { file: string; line: number } | undefined {
+// filename.ext:lineNumber  e.g. ShapeEditorContext.cs:129
+const fileLinkPattern = new RegExp(`^([\\w.\\-/\\\\]*?\\.(?:${KNOWN_EXTS})):(\\d+)$`, "i")
+// bare filename without line  e.g. ShapeEditorContext.cs
+const fileOnlyPattern = new RegExp(`^([\\w.\\-/\\\\]+\\.(?:${KNOWN_EXTS}))$`, "i")
+
+function codeFileLink(text: string): { file: string; line?: number } | undefined {
   const trimmed = text.trim()
-  const match = fileLinkPattern.exec(trimmed)
-  if (!match) return undefined
-  return { file: match[1], line: parseInt(match[2], 10) }
+  let match = fileLinkPattern.exec(trimmed)
+  if (match) return { file: match[1], line: parseInt(match[2], 10) }
+  match = fileOnlyPattern.exec(trimmed)
+  if (match) return { file: match[1] }
+  return undefined
 }
 
 function markFileLinks(root: HTMLDivElement) {
@@ -107,7 +114,12 @@ function markFileLinks(root: HTMLDivElement) {
     }
     code.classList.add("file-link")
     code.dataset.fileLink = link.file
-    code.dataset.fileLine = String(link.line)
+    // Only set fileLine when a line number is present; omitting it opens the file at top
+    if (link.line !== undefined) {
+      code.dataset.fileLine = String(link.line)
+    } else {
+      delete code.dataset.fileLine
+    }
   }
 }
 // kilocode_change end
@@ -286,7 +298,10 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
         new CustomEvent("kilo:openFileAtLine", {
           detail: {
             file: fileCode.dataset.fileLink,
-            line: parseInt(fileCode.dataset.fileLine ?? "1", 10),
+            line:
+              fileCode.dataset.fileLine !== undefined
+                ? parseInt(fileCode.dataset.fileLine, 10)
+                : undefined,
           },
         }),
       )

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -163,6 +163,8 @@ function markSymbolLinks(root: HTMLDivElement) {
     // Store the full original text (e.g. "BuildFrame()") so handleOpenSymbol
     // can detect isMethod via rawSymbol.endsWith("()")
     code.dataset.symbolLink = rawText
+    // title helps user verify they are hovering the symbol link (not a nearby file reference)
+    code.title = `Go to symbol: ${rawText}`
   }
 }
 // kilocode_change end

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -75,6 +75,43 @@ function codeUrl(text: string) {
   }
 }
 
+// kilocode_change start: file:line link detection
+const fileLinkPattern =
+  /^([\w.\-/\\]*?\.(?:cs|ts|tsx|js|jsx|mts|mjs|cjs|cts|py|go|rs|cpp|cxx|c|h|hpp|java|kt|swift|rb|php|lua|sh|bash|zsh|json|xml|yaml|yml|toml)):(\d+)$/i
+
+function codeFileLink(text: string): { file: string; line: number } | undefined {
+  const trimmed = text.trim()
+  const match = fileLinkPattern.exec(trimmed)
+  if (!match) return undefined
+  return { file: match[1], line: parseInt(match[2], 10) }
+}
+
+function markFileLinks(root: HTMLDivElement) {
+  const codeNodes = Array.from(root.querySelectorAll(":not(pre) > code"))
+  for (const code of codeNodes) {
+    if (!(code instanceof HTMLElement)) continue
+    // Skip elements already wrapped in an external URL link
+    if (
+      code.parentElement instanceof HTMLAnchorElement &&
+      code.parentElement.classList.contains("external-link")
+    )
+      continue
+    const link = codeFileLink(code.textContent ?? "")
+    if (!link) {
+      if (code.classList.contains("file-link")) {
+        code.classList.remove("file-link")
+        delete code.dataset.fileLink
+        delete code.dataset.fileLine
+      }
+      continue
+    }
+    code.classList.add("file-link")
+    code.dataset.fileLink = link.file
+    code.dataset.fileLine = String(link.line)
+  }
+}
+// kilocode_change end
+
 function createIcon(path: string, slot: string) {
   const icon = document.createElement("div")
   icon.setAttribute("data-component", "icon")
@@ -178,6 +215,9 @@ function decorate(root: HTMLDivElement, labels: CopyLabels) {
     ensureCodeWrapper(block, labels)
   }
   markCodeLinks(root)
+  // kilocode_change start: mark inline code containing file:line references
+  markFileLinks(root)
+  // kilocode_change end
 }
 
 function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
@@ -191,6 +231,22 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
   const handleClick = async (event: MouseEvent) => {
     const target = event.target
     if (!(target instanceof Element)) return
+
+    // kilocode_change start: handle clicks on file:line code links
+    const fileCode = target.closest("code.file-link")
+    if (fileCode instanceof HTMLElement && fileCode.dataset.fileLink) {
+      event.preventDefault()
+      document.dispatchEvent(
+        new CustomEvent("kilo:openFileAtLine", {
+          detail: {
+            file: fileCode.dataset.fileLink,
+            line: parseInt(fileCode.dataset.fileLine ?? "1", 10),
+          },
+        }),
+      )
+      return
+    }
+    // kilocode_change end
 
     const button = target.closest('[data-slot="markdown-copy-button"]')
     if (!(button instanceof HTMLButtonElement)) return

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -312,11 +312,14 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
     // kilocode_change end
 
     // kilocode_change start: handle clicks on symbol (class/method) code links
+    // Route through the same kilo:openFileAtLine mechanism as file links (which
+    // is proven to work in both sidebar and Agent Manager contexts) using a
+    // "__kilo_symbol__" prefix so handleOpenFile can distinguish it.
     const symbolCode = target.closest("code.symbol-link")
     if (symbolCode instanceof HTMLElement && symbolCode.dataset.symbolLink) {
       document.dispatchEvent(
-        new CustomEvent("kilo:openSymbol", {
-          detail: { symbol: symbolCode.dataset.symbolLink },
+        new CustomEvent("kilo:openFileAtLine", {
+          detail: { file: `__kilo_symbol__${symbolCode.dataset.symbolLink}` },
         }),
       )
       return

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -296,6 +296,7 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
     const fileCode = target.closest("code.file-link")
     if (fileCode instanceof HTMLElement && fileCode.dataset.fileLink) {
       event.preventDefault()
+      event.stopPropagation() // prevent bubbling to tool-call parent handlers
       document.dispatchEvent(
         new CustomEvent("kilo:openFileAtLine", {
           detail: {
@@ -317,6 +318,8 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
     // "__kilo_symbol__" prefix so handleOpenFile can distinguish it.
     const symbolCode = target.closest("code.symbol-link")
     if (symbolCode instanceof HTMLElement && symbolCode.dataset.symbolLink) {
+      event.preventDefault()
+      event.stopPropagation() // prevent bubbling to tool-call parent handlers
       document.dispatchEvent(
         new CustomEvent("kilo:openFileAtLine", {
           detail: { file: `__kilo_symbol__${symbolCode.dataset.symbolLink}` },

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -3,7 +3,7 @@ import markedKatex from "marked-katex-extension"
 import markedShiki from "marked-shiki"
 import katex from "katex"
 import { bundledLanguages, type BundledLanguage } from "shiki"
-import { parseFilePath } from "../file-path" // kilocode_change
+import { parseFilePath, parseSymbolRef } from "../file-path" // kilocode_change
 import { createSimpleContext } from "./helper"
 import { getSharedHighlighter, registerCustomTheme, ThemeRegistrationResolved } from "@pierre/diffs"
 
@@ -642,6 +642,11 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
               const lineAttr = file.line ? ` data-file-line="${file.line}"` : ""
               const colAttr = file.column ? ` data-file-col="${file.column}"` : ""
               return `<code class="file-link" data-file-path="${file.path}"${lineAttr}${colAttr}>${escaped}</code>`
+            }
+            // kilocode_change: detect class/method symbol references
+            const sym = parseSymbolRef(text)
+            if (sym) {
+              return `<code class="symbol-link" data-symbol-link="${sym}">${escaped}</code>`
             }
             return `<code>${escaped}</code>`
           },


### PR DESCRIPTION
## Summary

Make inline code elements in chat messages clickable for navigation:

### File + Line navigation
Detect backtick code matching `filename.ext:lineNumber` (e.g. `ShapeEditorContext.cs:129`) and jump directly to that file and line.

### Symbol navigation
Detect PascalCase class names (e.g. `ShapeEditorContext`) and method calls (e.g. `BuildFrame()`) and navigate to their definition using a two-phase search:
1. VSCode workspace symbol provider (LSP, if available)
2. File content search fallback - declaration-aware regex that prefers access-modifier lines and skips comment lines; parallel chunk reads, no file-count cap

### Visual distinction
- File:line links - dotted underline
- Symbol links - dashed underline

## Files changed
- `packages/ui/src/components/markdown.tsx` - markFileLinks() + markSymbolLinks() + click handlers dispatching CustomEvents
- `packages/ui/src/components/markdown.css` - code.file-link and code.symbol-link styles
- `packages/kilo-vscode/webview-ui/src/App.tsx` - listen for both events, forward via vscode.postMessage
- `packages/kilo-vscode/webview-ui/src/types/messages.ts` - add OpenSymbolRequest to WebviewMessage
- `packages/kilo-vscode/src/KiloProvider.ts` - handleOpenFile (bare filename via findFiles) + handleOpenSymbol (LSP + content search fallback) + openUriAtLine helper