### PR TITLE
feat(vscode): reimplement task timeline graph header

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -765,6 +765,11 @@
             "none"
           ],
           "description": "Sound to play on errors"
+        },
+        "kilo-code.new.showTaskTimeline": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the task timeline graph in the chat header"
         }
       }
     }

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -797,6 +797,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "requestNotificationSettings":
           this.sendNotificationSettings()
           break
+        case "requestTimelineSetting":
+          this.sendTimelineSetting()
+          break
         case "requestNotifications":
           this.fetchAndSendNotifications().catch((e) =>
             console.error("[Kilo New] fetchAndSendNotifications failed:", e),
@@ -1136,6 +1139,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         this.seedSessionStatusMap(),
       ])
       this.sendNotificationSettings()
+      this.sendTimelineSetting()
 
       // Start polling worktree diff stats for the sidebar badge
       this.startStatsPolling()
@@ -2041,6 +2045,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     })
   }
 
+  private sendTimelineSetting(): void {
+    const config = vscode.workspace.getConfiguration("kilo-code.new")
+    this.postMessage({
+      type: "timelineSettingLoaded",
+      visible: config.get<boolean>("showTaskTimeline", true),
+    })
+  }
+
   /** Returns the number of sessions currently in "busy" state. */
   private getBusySessionCount(): number {
     return getBusySessionCount(this.sessionStatusMap)
@@ -2545,6 +2557,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.sendAutocompleteSettings()
     this.sendBrowserSettings()
     this.sendNotificationSettings()
+    this.sendTimelineSetting()
 
     // Re-send globalState items to the webview
     this.postMessage({ type: "variantsLoaded", variants: {} })

--- a/packages/kilo-vscode/tests/unit/timeline-colors.test.ts
+++ b/packages/kilo-vscode/tests/unit/timeline-colors.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest"
+import { color, palette, label } from "../../webview-ui/src/utils/timeline/colors"
+import type {
+  Part,
+  ToolPart,
+  TextPart,
+  ReasoningPart,
+  StepStartPart,
+  StepFinishPart,
+} from "../../webview-ui/src/types/messages"
+
+function mkText(text = "hello"): TextPart {
+  return { id: "t1", type: "text", text }
+}
+
+function mkReasoning(text = "thinking..."): ReasoningPart {
+  return { id: "r1", type: "reasoning", text }
+}
+
+function mkTool(name: string, status: "pending" | "running" | "completed" | "error" = "completed"): ToolPart {
+  const base = { id: "tool1", type: "tool" as const, tool: name }
+  if (status === "pending") return { ...base, state: { status: "pending", input: {} } }
+  if (status === "running") return { ...base, state: { status: "running", input: {} } }
+  if (status === "error") return { ...base, state: { status: "error", input: {}, error: "fail" } }
+  return { ...base, state: { status: "completed", input: {}, output: "ok", title: name } }
+}
+
+function mkStepStart(): StepStartPart {
+  return { id: "ss1", type: "step-start" }
+}
+
+function mkStepFinish(): StepFinishPart {
+  return { id: "sf1", type: "step-finish", reason: "done" }
+}
+
+describe("timeline colors", () => {
+  it("classifies text parts as text color", () => {
+    expect(color(mkText())).toBe(palette.text)
+  })
+
+  it("classifies reasoning parts as reasoning color", () => {
+    expect(color(mkReasoning())).toBe(palette.reasoning)
+  })
+
+  it("classifies read tools as read color", () => {
+    expect(color(mkTool("read"))).toBe(palette.read)
+    expect(color(mkTool("glob"))).toBe(palette.read)
+    expect(color(mkTool("grep"))).toBe(palette.read)
+    expect(color(mkTool("ls"))).toBe(palette.read)
+    expect(color(mkTool("diagnostics"))).toBe(palette.read)
+    expect(color(mkTool("warpgrep"))).toBe(palette.read)
+  })
+
+  it("classifies write tools as write color", () => {
+    expect(color(mkTool("edit"))).toBe(palette.write)
+    expect(color(mkTool("write"))).toBe(palette.write)
+    expect(color(mkTool("patch"))).toBe(palette.write)
+    expect(color(mkTool("multiedit"))).toBe(palette.write)
+    expect(color(mkTool("apply_patch"))).toBe(palette.write)
+  })
+
+  it("classifies generic tools as tool color", () => {
+    expect(color(mkTool("bash"))).toBe(palette.tool)
+    expect(color(mkTool("task"))).toBe(palette.tool)
+    expect(color(mkTool("browser"))).toBe(palette.tool)
+  })
+
+  it("classifies errored tools as error color", () => {
+    expect(color(mkTool("bash", "error"))).toBe(palette.error)
+    expect(color(mkTool("read", "error"))).toBe(palette.error)
+  })
+
+  it("classifies step-start as step color", () => {
+    expect(color(mkStepStart())).toBe(palette.step)
+  })
+
+  it("classifies step-finish as success color", () => {
+    expect(color(mkStepFinish())).toBe(palette.success)
+  })
+
+  it("returns fallback for unknown part types", () => {
+    const weird = { id: "w1", type: "snapshot" } as unknown as Part
+    expect(color(weird)).toBe(palette.fallback)
+  })
+})
+
+describe("timeline labels", () => {
+  it("returns 'Text' for text parts", () => {
+    expect(label(mkText())).toBe("Text")
+  })
+
+  it("returns 'Reasoning' for reasoning parts", () => {
+    expect(label(mkReasoning())).toBe("Reasoning")
+  })
+
+  it("returns tool name for tool parts", () => {
+    expect(label(mkTool("bash"))).toBe("bash")
+    expect(label(mkTool("read"))).toBe("read")
+  })
+
+  it("returns 'Step start' for step-start", () => {
+    expect(label(mkStepStart())).toBe("Step start")
+  })
+
+  it("returns 'Step finish' for step-finish", () => {
+    expect(label(mkStepFinish())).toBe("Step finish")
+  })
+})

--- a/packages/kilo-vscode/tests/unit/timeline-sizes.test.ts
+++ b/packages/kilo-vscode/tests/unit/timeline-sizes.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest"
+import { sizes, MAX_HEIGHT } from "../../webview-ui/src/utils/timeline/sizes"
+import type { Part, TextPart, ToolPart, StepFinishPart } from "../../webview-ui/src/types/messages"
+
+function mkText(text: string): TextPart {
+  return { id: `t-${text.length}`, type: "text", text }
+}
+
+function mkTool(name: string, input: Record<string, unknown> = {}, output = ""): ToolPart {
+  return {
+    id: `tool-${name}`,
+    type: "tool",
+    tool: name,
+    state: { status: "completed", input, output, title: name },
+  }
+}
+
+function mkStepFinish(input = 100, output = 50): StepFinishPart {
+  return {
+    id: "sf",
+    type: "step-finish",
+    reason: "done",
+    tokens: { input, output },
+  }
+}
+
+describe("timeline sizes", () => {
+  it("returns empty array for empty input", () => {
+    expect(sizes([])).toEqual([])
+  })
+
+  it("returns one entry per part", () => {
+    const parts: Part[] = [mkText("a"), mkText("bb"), mkText("ccc")]
+    const result = sizes(parts)
+    expect(result).toHaveLength(3)
+  })
+
+  it("all bars have uniform width", () => {
+    const parts: Part[] = [mkText("short"), mkText("a".repeat(500)), mkText("medium")]
+    const result = sizes(parts)
+    const w = result[0]!.width
+    for (const bar of result) {
+      expect(bar.width).toBe(w)
+    }
+  })
+
+  it("height stays within bounds", () => {
+    const parts: Part[] = [mkText("short"), mkText("a".repeat(500)), mkText("medium length text")]
+    const result = sizes(parts)
+    for (const bar of result) {
+      expect(bar.height).toBeGreaterThanOrEqual(8)
+      expect(bar.height).toBeLessThanOrEqual(MAX_HEIGHT)
+    }
+  })
+
+  it("larger content produces taller bars", () => {
+    const parts: Part[] = [mkText("x"), mkText("x".repeat(1000))]
+    const result = sizes(parts)
+    expect(result[1]!.height).toBeGreaterThan(result[0]!.height)
+  })
+
+  it("handles tool parts with input/output content", () => {
+    const parts: Part[] = [
+      mkTool("bash", { command: "ls" }, "file1\nfile2\nfile3"),
+      mkTool("read", { path: "README.md" }, "a".repeat(200)),
+    ]
+    const result = sizes(parts)
+    expect(result).toHaveLength(2)
+    expect(result[0]!.content).toBeGreaterThan(0)
+    expect(result[1]!.content).toBeGreaterThan(result[0]!.content)
+  })
+
+  it("handles step-finish parts using token counts", () => {
+    const parts: Part[] = [mkStepFinish(1000, 500), mkStepFinish(100, 50)]
+    const result = sizes(parts)
+    expect(result).toHaveLength(2)
+    expect(result[0]!.content).toBeGreaterThan(result[1]!.content)
+  })
+
+  it("handles single-part input without crashing", () => {
+    const result = sizes([mkText("only one")])
+    expect(result).toHaveLength(1)
+  })
+
+  it("returns integer values for height", () => {
+    const parts: Part[] = [mkText("a"), mkText("bb"), mkText("ccc"), mkText("dddd")]
+    const result = sizes(parts)
+    for (const bar of result) {
+      expect(Number.isInteger(bar.height)).toBe(true)
+    }
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ContextProgress.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ContextProgress.tsx
@@ -1,0 +1,81 @@
+/**
+ * ContextProgress — three-segment progress bar showing context window usage.
+ *
+ * Segments:
+ *   1. Used tokens (foreground color, turns red when >= 50%)
+ *   2. Reserved for output (medium gray)
+ *   3. Available (transparent / background)
+ *
+ * Token counts flanking the bar: used on left, total on right.
+ */
+
+import { Component, createMemo, Show } from "solid-js"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
+import { useSession } from "../../context/session"
+import { useProvider } from "../../context/provider"
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
+export const ContextProgress: Component = () => {
+  const session = useSession()
+  const provider = useProvider()
+
+  const data = createMemo(() => {
+    const usage = session.contextUsage()
+    if (!usage || usage.tokens === 0) return undefined
+
+    const sel = session.selected()
+    const model = sel ? provider.findModel(sel) : undefined
+    const limit = model?.limit?.context ?? model?.contextLength ?? 0
+    const output = model?.limit?.output ?? 0
+
+    if (limit === 0) return undefined
+
+    const used = Math.min(usage.tokens, limit)
+    const reserved = Math.min(output, limit - used)
+    const available = Math.max(0, limit - used - reserved)
+
+    const pctUsed = (used / limit) * 100
+    const pctReserved = (reserved / limit) * 100
+    const pctAvail = (available / limit) * 100
+
+    return { used, reserved, available, limit, pctUsed, pctReserved, pctAvail, output }
+  })
+
+  const tip = createMemo(() => {
+    const d = data()
+    if (!d) return ""
+    const lines = [`${fmt(d.used)} / ${fmt(d.limit)} tokens used`]
+    if (d.output > 0) lines.push(`${fmt(d.output)} reserved for output`)
+    if (d.available > 0) lines.push(`${fmt(d.available)} available`)
+    return lines.join("\n")
+  })
+
+  return (
+    <Show when={data()}>
+      {(d) => (
+        <div class="context-progress">
+          <span class="context-progress-count">{fmt(d().used)}</span>
+          <Tooltip value={tip()} placement="top">
+            <div class="context-progress-bar">
+              <div
+                class="context-progress-used"
+                classList={{ "context-progress-used--hot": d().pctUsed >= 50 }}
+                style={{ width: `${d().pctUsed}%` }}
+              />
+              <div class="context-progress-reserved" style={{ width: `${d().pctReserved}%` }} />
+              <Show when={d().pctAvail > 0}>
+                <div class="context-progress-available" style={{ width: `${d().pctAvail}%` }} />
+              </Show>
+            </div>
+          </Tooltip>
+          <span class="context-progress-count">{fmt(d().limit)}</span>
+        </div>
+      )}
+    </Show>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -3,16 +3,22 @@
  * Sticky header above the chat messages showing session title,
  * cost, context usage, and a compact button.
  * Also shows todo progress when the session has todos.
+ *
+ * When expanded, shows the task timeline (colored bars representing
+ * session activity) and a context window progress bar.
  */
 
-import { Component, For, Show, createMemo, createSignal } from "solid-js"
+import { Component, For, Show, createMemo, createSignal, onMount, onCleanup } from "solid-js"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Checkbox } from "@kilocode/kilo-ui/checkbox"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
-import type { TodoItem } from "../../types/messages"
+import { useVSCode } from "../../context/vscode"
+import { TaskTimeline } from "./TaskTimeline"
+import { ContextProgress } from "./ContextProgress"
+import type { TodoItem, ExtensionMessage } from "../../types/messages"
 
 interface TaskHeaderProps {
   readonly?: boolean
@@ -54,6 +60,42 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
     const pct = usage.percentage !== null ? `${usage.percentage}%` : undefined
     return { tokens, pct }
   })
+
+  // Token breakdown from the last assistant message — only return if at least one value is > 0
+  const tokens = createMemo(() => {
+    const msgs = session.messages()
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const m = msgs[i]
+      if (m.role !== "assistant" || !m.tokens) continue
+      const tk = m.tokens
+      const has = tk.input > 0 || tk.output > 0 || (tk.cache?.write ?? 0) > 0 || (tk.cache?.read ?? 0) > 0
+      if (has) return tk
+    }
+    return undefined
+  })
+
+  const fmtNum = (n: number): string => {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+    return String(n)
+  }
+
+  const vscode = useVSCode()
+  const [expanded, setExpanded] = createSignal(true)
+
+  // Read initial value from VS Code settings
+  onMount(() => vscode.postMessage({ type: "requestTimelineSetting" }))
+  const handler = (e: MessageEvent<ExtensionMessage>) => {
+    if (e.data.type === "timelineSettingLoaded") setExpanded(e.data.visible)
+  }
+  window.addEventListener("message", handler)
+  onCleanup(() => window.removeEventListener("message", handler))
+
+  const toggle = () => {
+    const next = !expanded()
+    setExpanded(next)
+    vscode.postMessage({ type: "updateSetting", key: "showTaskTimeline", value: next })
+  }
 
   const todos = createMemo(() => session.todos())
   const hasTodos = createMemo(() => todos().length > 0)
@@ -107,8 +149,58 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
               />
             </Tooltip>
           </Show>
+          <Show when={hasMessages()}>
+            <button
+              data-slot="task-header-expand"
+              onClick={toggle}
+              aria-expanded={expanded()}
+              aria-label="Toggle timeline"
+            >
+              <Icon name="chevron-down" size="small" style={expanded() ? { transform: "rotate(180deg)" } : undefined} />
+            </button>
+          </Show>
         </div>
       </div>
+      {/* Expanded graph section: timeline + context bar + token breakdown */}
+      <Show when={expanded() && session.messages().some((m) => m.role === "assistant")}>
+        <div data-component="task-header-graph">
+          <TaskTimeline />
+          <div data-slot="task-header-graph-row">
+            <ContextProgress />
+          </div>
+          <Show when={tokens()}>
+            {(tk) => (
+              <div class="task-header-tokens">
+                <span class="task-header-tokens-label">Tokens</span>
+                <Show when={tk().input > 0}>
+                  <span class="task-header-tokens-value">
+                    <Icon name="arrow-up" size="small" />
+                    {fmtNum(tk().input)}
+                  </span>
+                </Show>
+                <Show when={tk().output > 0}>
+                  <span class="task-header-tokens-value">
+                    <Icon name="arrow-down-to-line" size="small" />
+                    {fmtNum(tk().output)}
+                  </span>
+                </Show>
+                <Show when={tk().cache?.write && tk().cache!.write > 0}>
+                  <span class="task-header-tokens-value">
+                    <Icon name="arrow-up" size="small" />
+                    cache {fmtNum(tk().cache!.write)}
+                  </span>
+                </Show>
+                <Show when={tk().cache?.read && tk().cache!.read > 0}>
+                  <span class="task-header-tokens-value">
+                    <Icon name="arrow-down-to-line" size="small" />
+                    cache {fmtNum(tk().cache!.read)}
+                  </span>
+                </Show>
+              </div>
+            )}
+          </Show>
+        </div>
+      </Show>
       <Show when={hasTodos()}>
         <div data-component="task-header-todos">
           <button

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -1,0 +1,167 @@
+/**
+ * TaskTimeline — horizontal strip of colored bars representing session activity.
+ *
+ * Each bar = one Part from assistant messages.
+ * Color  = part type (read=blue, write=dark blue, tool=indigo, error=red, text=gray).
+ * Width  = proportional to time between parts.
+ * Height = proportional to content length.
+ *
+ * Interactions: drag scroll, mouse wheel, auto-scroll to latest.
+ *
+ * No virtualization needed: SolidJS <Index> creates each element once and
+ * updates bindings in place (unlike React). Even 1000+ bars are fine.
+ */
+
+import { Component, Index, createMemo, createEffect, on, onCleanup } from "solid-js"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
+import { useSession } from "../../context/session"
+import { color, label } from "../../utils/timeline/colors"
+import { sizes, MAX_HEIGHT } from "../../utils/timeline/sizes"
+import type { Part, Message } from "../../types/messages"
+
+export interface TimelineBar {
+  bg: string
+  tip: string
+  width: number
+  height: number
+  idx: number
+}
+
+function collect(messages: Message[], parts: Record<string, Part[]>): TimelineBar[] {
+  const result: Part[] = []
+
+  for (const msg of messages) {
+    if (msg.role === "user") continue
+    const ps = parts[msg.id]
+    if (!ps) continue
+    for (const p of ps) {
+      if (p.type === "step-start") continue
+      result.push(p)
+    }
+  }
+
+  const sz = sizes(result)
+  return result.map((p, i) => ({
+    bg: color(p),
+    tip: label(p),
+    width: sz[i]!.width,
+    height: sz[i]!.height,
+    idx: i,
+  }))
+}
+
+export const TaskTimeline: Component = () => {
+  const session = useSession()
+  let ref: HTMLDivElement | undefined
+  let dragging = false
+  let startX = 0
+  let startScroll = 0
+
+  const messages = () => session.messages()
+  const allParts = () => {
+    const msgs = messages()
+    const result: Record<string, Part[]> = {}
+    for (const m of msgs) {
+      const p = session.getParts(m.id)
+      if (p.length > 0) result[m.id] = p
+    }
+    return result
+  }
+
+  const bars = createMemo(() => collect(messages(), allParts()))
+  const busy = () => session.status() === "busy"
+
+  // Auto-scroll to the latest bar when new bars appear
+  let prev = 0
+  createEffect(
+    on(
+      () => bars().length,
+      (len) => {
+        if (len > prev && ref) {
+          ref.scrollLeft = ref.scrollWidth
+        }
+        prev = len
+      },
+    ),
+  )
+
+  // ── Drag scroll ──────────────────────────────────────────────────
+  const onPointerDown = (e: PointerEvent) => {
+    if (!ref) return
+    dragging = true
+    startX = e.clientX
+    startScroll = ref.scrollLeft
+    ref.setPointerCapture(e.pointerId)
+    ref.style.cursor = "grabbing"
+    ref.style.userSelect = "none"
+  }
+
+  const onPointerMove = (e: PointerEvent) => {
+    if (!dragging || !ref) return
+    ref.scrollLeft = startScroll - (e.clientX - startX)
+  }
+
+  const onPointerUp = (e: PointerEvent) => {
+    if (!ref) return
+    dragging = false
+    ref.releasePointerCapture(e.pointerId)
+    ref.style.cursor = "grab"
+    ref.style.userSelect = ""
+  }
+
+  // ── Wheel → horizontal scroll ────────────────────────────────────
+  const onWheel = (e: WheelEvent) => {
+    if (!ref) return
+    e.preventDefault()
+    ref.scrollLeft += e.deltaY || e.deltaX
+  }
+
+  createEffect(() => {
+    const el = ref
+    if (!el) return
+    el.addEventListener("wheel", onWheel, { passive: false })
+    onCleanup(() => el.removeEventListener("wheel", onWheel))
+  })
+
+  return (
+    <div class="task-timeline-outer">
+      <div
+        ref={ref}
+        class="task-timeline"
+        style={{ height: `${MAX_HEIGHT}px` }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+      >
+        <Index each={bars()}>
+          {(bar) => {
+            const active = () => busy() && bar().idx === bars().length - 1
+            return (
+              <Tooltip value={bar().tip} placement="top">
+                <div
+                  class="task-timeline-bar"
+                  style={{
+                    width: `${bar().width}px`,
+                    height: `${MAX_HEIGHT}px`,
+                  }}
+                >
+                  <div
+                    class="task-timeline-bar-fill task-timeline-bar-fill--new"
+                    classList={{
+                      "task-timeline-bar-fill--active": active(),
+                    }}
+                    style={{
+                      background: bar().bg,
+                      height: `${(bar().height / MAX_HEIGHT) * 100}%`,
+                    }}
+                  />
+                </div>
+              </Tooltip>
+            )
+          }}
+        </Index>
+      </div>
+    </div>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -3254,3 +3254,189 @@ body.vscode-high-contrast-light {
     outline-offset: -1px;
   }
 }
+
+/* ============================================
+   Task Timeline
+   ============================================ */
+
+.task-timeline-outer {
+  width: 100%;
+  overflow: hidden;
+  padding: 0 8px;
+}
+
+.task-timeline {
+  display: flex;
+  align-items: flex-end;
+  overflow-x: auto;
+  overflow-y: hidden;
+  cursor: grab;
+  touch-action: pan-x;
+  scrollbar-width: none; /* Firefox */
+}
+
+.task-timeline::-webkit-scrollbar {
+  display: none;
+}
+
+.task-timeline-bar {
+  position: relative;
+  flex-shrink: 0;
+  margin-right: 1px;
+  overflow: hidden;
+}
+
+.task-timeline-bar-fill {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+  transition: opacity 0.15s;
+}
+
+.task-timeline-bar:hover .task-timeline-bar-fill {
+  opacity: 0.7;
+}
+
+/* Fade-in animation for new bars */
+.task-timeline-bar-fill--new {
+  animation: timeline-fade-in 0.3s ease-out;
+}
+
+/* Active (latest) bar pulse when session is busy */
+.task-timeline-bar-fill--active {
+  animation: timeline-pulse 2s ease-in-out infinite 0.5s;
+}
+
+@keyframes timeline-fade-in {
+  from {
+    opacity: 0;
+    transform: scaleY(0);
+    transform-origin: bottom;
+  }
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+@keyframes timeline-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+/* ============================================
+   Context Progress Bar
+   ============================================ */
+
+.context-progress {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.context-progress-count {
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.context-progress-bar {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  height: 4px;
+  border-radius: 2px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--vscode-foreground) 20%, transparent);
+}
+
+.context-progress-used {
+  height: 100%;
+  background: var(--vscode-foreground);
+  transition:
+    width 0.3s ease-out,
+    background 0.3s ease-out;
+}
+
+.context-progress-used--hot {
+  background: color-mix(in srgb, var(--vscode-errorForeground) 60%, rgba(128, 0, 0, 1));
+}
+
+.context-progress-reserved {
+  height: 100%;
+  background: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
+  transition: width 0.3s ease-out;
+}
+
+.context-progress-available {
+  height: 100%;
+}
+
+/* ============================================
+   Task Header Graph Section
+   ============================================ */
+
+[data-component="task-header-graph"] {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px 0 6px;
+  border-bottom: 1px solid var(--border-weak-base);
+}
+
+[data-slot="task-header-graph-row"] {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+}
+
+/* Token breakdown in expanded state */
+.task-header-tokens {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  white-space: nowrap;
+}
+
+.task-header-tokens-label {
+  font-weight: 600;
+}
+
+.task-header-tokens-value {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+/* Expand toggle */
+[data-slot="task-header-expand"] {
+  all: unset;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 3px;
+  color: var(--vscode-descriptionForeground);
+  transition:
+    color 0.15s,
+    background 0.15s;
+}
+
+[data-slot="task-header-expand"]:hover {
+  color: var(--vscode-foreground);
+  background: var(--vscode-toolbar-hoverBackground);
+}

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -744,6 +744,11 @@ export interface NotificationSettingsLoadedMessage {
   }
 }
 
+export interface TimelineSettingLoadedMessage {
+  type: "timelineSettingLoaded"
+  visible: boolean
+}
+
 export interface NotificationsLoadedMessage {
   type: "notificationsLoaded"
   notifications: KilocodeNotification[]
@@ -1324,6 +1329,7 @@ export type ExtensionMessage =
   | ConfigUpdatedMessage
   | GlobalConfigLoadedMessage
   | NotificationSettingsLoadedMessage
+  | TimelineSettingLoadedMessage
   | NotificationsLoadedMessage
   | AgentManagerSessionMetaMessage
   | AgentManagerRepoInfoMessage
@@ -1663,6 +1669,10 @@ export interface UpdateSettingRequest {
   type: "updateSetting"
   key: string
   value: unknown
+}
+
+export interface RequestTimelineSettingMessage {
+  type: "requestTimelineSetting"
 }
 
 export interface RequestBrowserSettingsMessage {
@@ -2137,6 +2147,7 @@ export type WebviewMessage =
   | RequestFileSearchMessage
   | ChatCompletionAcceptedMessage
   | UpdateSettingRequest
+  | RequestTimelineSettingMessage
   | RequestBrowserSettingsMessage
   | RequestClaudeCompatSettingMessage
   | RequestConfigMessage

--- a/packages/kilo-vscode/webview-ui/src/utils/timeline/colors.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/timeline/colors.ts
@@ -1,0 +1,91 @@
+/**
+ * Timeline bar color classification.
+ *
+ * Maps Part types (text, tool, reasoning, step-start, step-finish, etc.)
+ * to VS Code CSS variable–based colors, mirroring the legacy extension's
+ * taskTimelineColorPalette from messageColors.ts.
+ */
+
+import type { Part, ToolPart } from "../../types/messages"
+
+// ── Color palette (VS Code CSS variables) ────────────────────────────
+// These mirror the legacy extension's taskTimelineColorPalette exactly.
+
+export const palette = {
+  user: "var(--tl-user, color-mix(in srgb, var(--vscode-editor-findMatchBackground) 50%, var(--vscode-errorForeground)))",
+  read: "var(--tl-read, var(--vscode-textLink-foreground))",
+  write: "var(--tl-write, var(--vscode-focusBorder))",
+  tool: "var(--tl-tool, var(--vscode-activityBarBadge-background))",
+  success: "var(--tl-success, var(--vscode-editorGutter-addedBackground))",
+  error: "var(--tl-error, var(--vscode-errorForeground))",
+  text: "var(--tl-text, var(--vscode-descriptionForeground))",
+  reasoning: "var(--tl-reasoning, var(--vscode-descriptionForeground))",
+  step: "var(--tl-step, var(--vscode-badge-background))",
+  fallback: "var(--tl-fallback, var(--vscode-badge-background))",
+} as const
+
+export type TimelineColor = (typeof palette)[keyof typeof palette]
+
+// ── File operation detection ─────────────────────────────────────────
+
+const READ_TOOLS = new Set(["read", "glob", "grep", "find", "ls", "diagnostics", "warpgrep"])
+const WRITE_TOOLS = new Set(["edit", "write", "patch", "multi_edit", "multiedit", "apply_patch"])
+
+function isRead(name: string): boolean {
+  return READ_TOOLS.has(name)
+}
+
+function isWrite(name: string): boolean {
+  return WRITE_TOOLS.has(name)
+}
+
+// ── Part → color ─────────────────────────────────────────────────────
+
+export function color(part: Part): TimelineColor {
+  switch (part.type) {
+    case "text":
+      return palette.text
+
+    case "reasoning":
+      return palette.reasoning
+
+    case "tool": {
+      const tp = part as ToolPart
+      if (tp.state.status === "error") return palette.error
+      const name = tp.tool.toLowerCase()
+      if (isRead(name)) return palette.read
+      if (isWrite(name)) return palette.write
+      return palette.tool
+    }
+
+    case "step-start":
+      return palette.step
+
+    case "step-finish":
+      return palette.success
+
+    default:
+      return palette.fallback
+  }
+}
+
+// ── Label for tooltip ────────────────────────────────────────────────
+
+export function label(part: Part): string {
+  switch (part.type) {
+    case "text":
+      return "Text"
+    case "reasoning":
+      return "Reasoning"
+    case "tool": {
+      const tp = part as ToolPart
+      return tp.tool
+    }
+    case "step-start":
+      return "Step start"
+    case "step-finish":
+      return "Step finish"
+    default:
+      return "Unknown"
+  }
+}

--- a/packages/kilo-vscode/webview-ui/src/utils/timeline/sizes.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/timeline/sizes.ts
@@ -1,0 +1,62 @@
+/**
+ * Timeline bar sizing.
+ *
+ * Width  = uniform (no timing data available on Part types).
+ * Height = proportional to content length.
+ */
+
+import type { Part, ToolPart, TextPart, ReasoningPart, StepFinishPart } from "../../types/messages"
+
+// ── Constants ────────────────────────────────────────────────────────
+
+export const MAX_HEIGHT = 26
+const BAR_W = 12
+const MIN_H = 8
+const PAD = 4
+
+export interface BarSize {
+  width: number
+  height: number
+  content: number
+}
+
+// ── Content length ───────────────────────────────────────────────────
+
+function content(part: Part): number {
+  switch (part.type) {
+    case "text":
+      return (part as TextPart).text?.length ?? 1
+    case "reasoning":
+      return (part as ReasoningPart).text?.length ?? 1
+    case "tool": {
+      const tp = part as ToolPart
+      const input = JSON.stringify(tp.state.input ?? {}).length
+      const output = tp.state.status === "completed" ? (tp.state.output?.length ?? 0) : 0
+      return Math.max(1, input + output)
+    }
+    case "step-finish": {
+      const sf = part as StepFinishPart
+      return sf.tokens ? sf.tokens.input + sf.tokens.output + (sf.tokens.reasoning ?? 0) : 1
+    }
+    default:
+      return 1
+  }
+}
+
+// ── Calculate sizes for all bars ─────────────────────────────────────
+
+export function sizes(parts: Part[]): BarSize[] {
+  if (parts.length === 0) return []
+
+  const raw = parts.map((p) => content(p))
+  const max = Math.max(...raw)
+
+  return raw.map((c) => {
+    const cr = Math.min(1, c / Math.max(1, max))
+    return {
+      width: BAR_W,
+      height: Math.round(MIN_H + cr * (MAX_HEIGHT - MIN_H - PAD)),
+      content: c,
+    }
+  })
+}


### PR DESCRIPTION
## Summary

Reimplements the legacy `KiloTaskHeader` graph visualization in the new SolidJS-based VS Code extension.

- **Timeline bars** — colored horizontal bars representing session activity (part type → color: read/write/tool/error/text), width proportional to time between parts, height proportional to content length
- **Context window progress** — three-segment bar (used/reserved/available) with token counts, turns red at ≥50% usage
- **Token breakdown** — input/output/cache writes/cache reads display
- **Interactions** — drag scroll, mouse wheel → horizontal scroll, auto-scroll to latest bar, active bar pulse animation, fade-in on new bars
- **Persistent toggle** — expand/collapse stored in localStorage (default: shown), with bottom border separator

<img width="382" height="200" alt="image" src="https://github.com/user-attachments/assets/eaee29c9-5a2a-4b46-bc46-b5869f1f9904" />
<img width="371" height="78" alt="image" src="https://github.com/user-attachments/assets/51422519-06fb-4345-b53a-79b6191d24e7" />
<img width="781" height="202" alt="image" src="https://github.com/user-attachments/assets/c29b7a6b-db22-4e4b-b023-721e6834ae77" />


### Deferred (follow-up)
- Click-to-scroll (needs correct part→message mapping work)
- Gutter bars on chat turns (depends on click-to-scroll)