### PR TITLE
Sessions - Add session_status ingest message for status tracking

### DIFF
--- a/packages/opencode/src/kilo-sessions/ingest-queue.ts
+++ b/packages/opencode/src/kilo-sessions/ingest-queue.ts
@@ -48,6 +48,10 @@ export namespace IngestQueue {
         type: "session_close"
         data: { reason: CloseReason }
       }
+    | {
+        type: "session_status"
+        data: { status: "idle" | "busy" | "question" | "permission" | "retry" }
+      }
 
   type Share = {
     ingestPath: string
@@ -123,6 +127,7 @@ export namespace IngestQueue {
       if (item.type === "session_diff") return "session_diff"
       if (item.type === "session_open") return "session_open"
       if (item.type === "session_close") return "session_close"
+      if (item.type === "session_status") return "session_status"
 
       if (item.type === "message") {
         const value = id(item.data)

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -23,6 +23,8 @@ import { RemoteWS } from "@/kilo-sessions/remote-ws"
 import { RemoteSender } from "@/kilo-sessions/remote-sender"
 import { SessionStatus } from "@/session/status"
 import { Telemetry } from "@kilocode/kilo-telemetry"
+import { Question } from "@/question"
+import { Permission } from "@/permission"
 
 export namespace KiloSessions {
   export const Event = {
@@ -153,6 +155,24 @@ export namespace KiloSessions {
   let remoteSeq = 0
   const focused = new Set<string>()
   const opened = new Set<string>()
+  const statusSyncs = new Map<string, Promise<void>>()
+
+  async function deriveStatus(sessionID: string): Promise<"idle" | "busy" | "question" | "permission" | "retry"> {
+    const permissions = (await Permission.list()).filter((p) => p.sessionID === sessionID)
+    if (permissions.length > 0) return "permission"
+
+    const questions = (await Question.list()).filter((q) => q.sessionID === sessionID)
+    if (questions.length > 0) return "question"
+
+    const status = await SessionStatus.get(SessionID.make(sessionID))
+    if (status.type === "offline") return "retry"
+    return status.type
+  }
+
+  async function deriveAndSyncStatus(sessionID: string) {
+    const status = await deriveStatus(sessionID)
+    await ingest.sync(sessionID, [{ type: "session_status", data: { status } }])
+  }
 
   export async function init() {
     if (ingestDisabled) return
@@ -225,6 +245,27 @@ export namespace KiloSessions {
     Bus.subscribe(Session.Event.TurnClose, async (evt) => {
       await ingest.sync(evt.properties.sessionID, [{ type: "session_close", data: { reason: evt.properties.reason } }])
     })
+
+    // Session status changes (busy/idle/retry), question lifecycle, permission lifecycle
+    const syncStatus = (evt: { properties: { sessionID: string } }) => {
+      const sessionID = evt.properties.sessionID
+      const prev = statusSyncs.get(sessionID) ?? Promise.resolve()
+      const next = prev
+        .then(() => deriveAndSyncStatus(sessionID))
+        .catch((error) => {
+          log.error("status sync failed", { sessionID, error: String(error) })
+        })
+      statusSyncs.set(sessionID, next)
+      void next.finally(() => {
+        if (statusSyncs.get(sessionID) === next) statusSyncs.delete(sessionID)
+      })
+    }
+    Bus.subscribe(SessionStatus.Event.Status, syncStatus)
+    Bus.subscribe(Question.Event.Asked, syncStatus)
+    Bus.subscribe(Question.Event.Replied, syncStatus)
+    Bus.subscribe(Question.Event.Rejected, syncStatus)
+    Bus.subscribe(Permission.Event.Asked, syncStatus)
+    Bus.subscribe(Permission.Event.Replied, syncStatus)
 
     const cfg = await Config.getGlobal()
     if (remoteEnabled || cfg.remote_control)
@@ -565,6 +606,10 @@ export namespace KiloSessions {
       {
         type: "model",
         data: models,
+      },
+      {
+        type: "session_status",
+        data: { status: await deriveStatus(sessionId) },
       },
     ])
   }

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -156,7 +156,7 @@ export namespace KiloSessions {
   let remoteSeq = 0
   const focused = new Set<string>()
   const opened = new Set<string>()
-  const statusSyncs = new Map<string, Promise<void>>()
+  const statusSyncs = new Map<string, { running: boolean; dirty: boolean }>()
   const STATUS_TIMEOUT_MS = 3_000
 
   async function deriveStatus(sessionID: string): Promise<"idle" | "busy" | "question" | "permission" | "retry"> {
@@ -172,7 +172,7 @@ export namespace KiloSessions {
   }
 
   async function deriveAndSyncStatus(sessionID: string) {
-    const status = await deriveStatus(sessionID)
+    const status = await withTimeout(deriveStatus(sessionID), STATUS_TIMEOUT_MS)
     await ingest.sync(sessionID, [{ type: "session_status", data: { status } }])
   }
 
@@ -249,19 +249,36 @@ export namespace KiloSessions {
     })
 
     // Session status changes (busy/idle/retry), question lifecycle, permission lifecycle.
-    // withTimeout prevents a hung derive from holding the per-session promise chain open forever.
     const syncStatus = (evt: { properties: { sessionID: string } }) => {
       const sessionID = evt.properties.sessionID
-      const prev = statusSyncs.get(sessionID) ?? Promise.resolve()
-      const next = prev
-        .then(() => withTimeout(deriveAndSyncStatus(sessionID), STATUS_TIMEOUT_MS))
-        .catch((error) => {
-          log.error("status sync failed", { sessionID, error: String(error) })
-        })
-      statusSyncs.set(sessionID, next)
-      void next.finally(() => {
-        if (statusSyncs.get(sessionID) === next) statusSyncs.delete(sessionID)
-      })
+      const current = statusSyncs.get(sessionID)
+      if (current?.running) {
+        current.dirty = true
+        return
+      }
+
+      const state = current ?? { running: false, dirty: false }
+      statusSyncs.set(sessionID, state)
+
+      const fail = (error: unknown) => {
+        const dirty = state.dirty
+        statusSyncs.delete(sessionID)
+        log.error("status sync failed", { sessionID, error: String(error) })
+        if (dirty) syncStatus(evt)
+      }
+
+      const loop = async () => {
+        state.running = true
+        state.dirty = false
+        await deriveAndSyncStatus(sessionID)
+        if (state.dirty) {
+          void loop().catch(fail)
+          return
+        }
+        statusSyncs.delete(sessionID)
+      }
+
+      void loop().catch(fail)
     }
     Bus.subscribe(SessionStatus.Event.Status, syncStatus)
     Bus.subscribe(Question.Event.Asked, syncStatus)

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -25,6 +25,7 @@ import { SessionStatus } from "@/session/status"
 import { Telemetry } from "@kilocode/kilo-telemetry"
 import { Question } from "@/question"
 import { Permission } from "@/permission"
+import { withTimeout } from "@/util/timeout"
 
 export namespace KiloSessions {
   export const Event = {
@@ -156,6 +157,7 @@ export namespace KiloSessions {
   const focused = new Set<string>()
   const opened = new Set<string>()
   const statusSyncs = new Map<string, Promise<void>>()
+  const STATUS_TIMEOUT_MS = 3_000
 
   async function deriveStatus(sessionID: string): Promise<"idle" | "busy" | "question" | "permission" | "retry"> {
     const permissions = (await Permission.list()).filter((p) => p.sessionID === sessionID)
@@ -246,12 +248,13 @@ export namespace KiloSessions {
       await ingest.sync(evt.properties.sessionID, [{ type: "session_close", data: { reason: evt.properties.reason } }])
     })
 
-    // Session status changes (busy/idle/retry), question lifecycle, permission lifecycle
+    // Session status changes (busy/idle/retry), question lifecycle, permission lifecycle.
+    // withTimeout prevents a hung derive from holding the per-session promise chain open forever.
     const syncStatus = (evt: { properties: { sessionID: string } }) => {
       const sessionID = evt.properties.sessionID
       const prev = statusSyncs.get(sessionID) ?? Promise.resolve()
       const next = prev
-        .then(() => deriveAndSyncStatus(sessionID))
+        .then(() => withTimeout(deriveAndSyncStatus(sessionID), STATUS_TIMEOUT_MS))
         .catch((error) => {
           log.error("status sync failed", { sessionID, error: String(error) })
         })

--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -377,9 +377,9 @@ export namespace RemoteSender {
       if (msg.type === "subscribe") {
         if (sessions.has(msg.sessionId)) return
         sessions.add(msg.sessionId)
+        if (!unsub) unsub = sub(forwarder)
         void backfillChildren(msg.sessionId)
         void backfillPendingState(msg.sessionId)
-        if (!unsub) unsub = sub(forwarder)
         return
       }
       if (msg.type === "unsubscribe") {

--- a/packages/opencode/test/kilocode/sessions/ingest-queue.test.ts
+++ b/packages/opencode/test/kilocode/sessions/ingest-queue.test.ts
@@ -335,6 +335,44 @@ describe("share ingest queue", () => {
     expect((close?.data as { reason: string }).reason).toBe("error")
   })
 
+  test("session_status uses stable key and coalesces", async () => {
+    const sent: unknown[] = []
+    const sched = scheduler(() => clock.now)
+
+    const q = IngestQueue.create({
+      now: () => clock.now,
+      setTimeout: sched.setTimeout,
+      clearTimeout: sched.clearTimeout,
+      log: { error: () => {} },
+      getShare: async () => ({ ingestPath: "/ingest" }),
+      getClient: async () => ({
+        url: "https://ingest.test",
+        fetch: async (_input, init) => {
+          sent.push(JSON.parse((init?.body as string) ?? "{}"))
+          return new Response("{}", { status: 200 })
+        },
+      }),
+    })
+
+    await q.sync("s10", [{ type: "session_status", data: { status: "busy" } }])
+    clock.now = 100
+    await q.sync("s10", [{ type: "session_status", data: { status: "question" } }])
+    clock.now = 200
+    await q.sync("s10", [{ type: "session_status", data: { status: "idle" } }])
+
+    clock.now = 1000
+    sched.run()
+    await Bun.sleep(0)
+    expect(sent.length).toBe(1)
+
+    const payload = sent[0] as { data: { type: string; data: unknown }[] }
+    const statuses = payload.data.filter((d) => d.type === "session_status")
+    // Only one session_status due to stable key
+    expect(statuses.length).toBe(1)
+    // Should have the latest status
+    expect((statuses[0]!.data as { status: string }).status).toBe("idle")
+  })
+
   test("flush sends request with ?v=1 query parameter", async () => {
     const urls: string[] = []
     const sched = scheduler(() => clock.now)


### PR DESCRIPTION
## Summary
- Add `session_status` message type to the ingest queue for tracking session status (idle/busy/question/permission/retry)
- Subscribe to SessionStatus, Question, and Permission events to sync status changes to ingest
- Add test coverage for stable key coalescing behavior