### PR TITLE
fix(cli): scope session list to worktree

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -30,6 +30,7 @@ import { Installation } from "@/installation"
 import { ConfigMarkdown } from "./markdown"
 import { constants, existsSync } from "fs"
 import { Bus } from "@/bus"
+import { BusEvent } from "@/bus/bus-event" // kilocode_change
 import { GlobalBus } from "@/bus/global"
 import { Event } from "../server/event"
 import { Glob } from "../util/glob"
@@ -282,10 +283,16 @@ export namespace Config {
         }),
       )
 
-      result.command = mergeDeep(result.command ?? {}, await loadCommand(dir))
-      result.agent = mergeDeep(result.agent, await loadAgent(dir))
-      result.agent = mergeDeep(result.agent, await loadMode(dir))
-      result.plugin.push(...(await loadPlugin(dir)))
+      // kilocode_change start
+      try {
+        result.command = mergeDeep(result.command ?? {}, await loadCommand(dir))
+        result.agent = mergeDeep(result.agent, await loadAgent(dir))
+        result.agent = mergeDeep(result.agent, await loadMode(dir))
+        result.plugin.push(...(await loadPlugin(dir)))
+      } catch (err: unknown) {
+        log.error("failed to load config directory", { dir, err })
+      }
+      // kilocode_change end
     }
 
     // Inline config content overrides all non-managed config sources.
@@ -463,6 +470,34 @@ export namespace Config {
     return ext.length ? file.slice(0, -ext.length) : file
   }
 
+  // kilocode_change start
+  // Local event definition that matches Session.Event.Error's type string.
+  // Avoids importing @/session during config init (which causes a circular dependency).
+  const SessionError = BusEvent.define("session.error", z.object({ error: z.any() }))
+
+  function detail(issues: z.core.$ZodIssue[]) {
+    return issues
+      .map((issue) => {
+        const loc = issue.path.map(String).join(".")
+        if (!loc) return issue.message
+        return `${loc}: ${issue.message}`
+      })
+      .join("\n")
+  }
+
+  async function invalid(kind: "agent" | "command", item: string, issues: z.core.$ZodIssue[], cause: Error) {
+    const text = detail(issues)
+    const message = text ? `Config file at ${item} is invalid: ${text}` : `Config file at ${item} is invalid`
+    Bus.publish(SessionError, { error: new NamedError.Unknown({ message }).toObject() })
+    const err = new InvalidError({ path: item, issues }, { cause })
+    if (kind === "command") {
+      log.error("failed to load command", { command: item, err })
+      return
+    }
+    log.error("failed to load agent", { agent: item, err })
+  }
+  // kilocode_change end
+
   async function loadCommand(dir: string) {
     const result: Record<string, Command> = {}
     for (const item of await Glob.scan("{command,commands}/**/*.md", {
@@ -505,7 +540,9 @@ export namespace Config {
         result[config.name] = parsed.data
         continue
       }
-      throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
+      // kilocode_change start
+      await invalid("command", item, parsed.error.issues, parsed.error)
+      // kilocode_change end
     }
     return result
   }
@@ -555,7 +592,9 @@ export namespace Config {
         result[config.name] = parsed.data
         continue
       }
-      throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
+      // kilocode_change start
+      await invalid("agent", item, parsed.error.issues, parsed.error)
+      // kilocode_change end
     }
     return result
   }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -594,6 +594,17 @@ export namespace Session {
       // kilocode_change start: vscode uri.fsPath gives lowercase drive letter on Windows; resolve() canonicalises to match stored path
       conditions.push(eq(SessionTable.directory, Filesystem.resolve(input.directory)))
       // kilocode_change end
+    } else {
+      // kilocode_change start: scope session list to the current worktree so that
+      // git worktrees / separate clones with the same root commit (same projectID)
+      // don't show each other's sessions.
+      const worktree = Instance.worktree
+      if (worktree && worktree !== "/") {
+        conditions.push(
+          or(eq(SessionTable.directory, worktree), like(SessionTable.directory, worktree + path.sep + "%"))!,
+        )
+      }
+      // kilocode_change end
     }
     if (input?.roots) {
       conditions.push(isNull(SessionTable.parent_id))

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -600,8 +600,9 @@ export namespace Session {
       // don't show each other's sessions.
       const worktree = Instance.worktree
       if (worktree && worktree !== "/") {
+        const escaped = worktree.replace(/[%_]/g, "\\$&")
         conditions.push(
-          or(eq(SessionTable.directory, worktree), like(SessionTable.directory, worktree + path.sep + "%"))!,
+          or(eq(SessionTable.directory, worktree), like(SessionTable.directory, escaped + path.sep + "%"))!,
         )
       }
       // kilocode_change end

--- a/packages/opencode/test/kilocode/config-resilience.test.ts
+++ b/packages/opencode/test/kilocode/config-resilience.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import path from "path"
+import { Bus } from "../../src/bus"
+import { Config } from "../../src/config/config"
+import { Instance } from "../../src/project/instance"
+import { Filesystem } from "../../src/util/filesystem"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+  Config.global.reset()
+})
+
+describe("config resilience", () => {
+  test("skips invalid agent markdown configs", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, ".kilo", "agent", "skip.md"),
+          `---
+mode: "banana"
+---
+Broken agent prompt`,
+        )
+        await Filesystem.write(
+          path.join(dir, ".kilo", "agent", "keep.md"),
+          `---
+model: test/model
+---
+Valid agent prompt`,
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const cfg = await Config.get()
+
+        expect(cfg.agent?.["skip"]).toBeUndefined()
+        expect(cfg.agent?.["keep"]).toMatchObject({
+          name: "keep",
+          model: "test/model",
+          prompt: "Valid agent prompt",
+        })
+      },
+    })
+  })
+
+  test("publishes an error for invalid agent markdown configs", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, ".kilo", "agent", "skip.md"),
+          `---
+mode: "banana"
+---
+Broken agent prompt`,
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const seen: Array<{ type: string; properties: { error: { name: string; data: { message: string } } } }> = []
+        const unsub = Bus.subscribeAll((event) => {
+          if (event.type === "session.error") seen.push(event)
+        })
+
+        await Config.get()
+        unsub()
+
+        expect(
+          seen.some(
+            (item) =>
+              item.properties.error.name === "UnknownError" &&
+              item.properties.error.data.message.includes("skip.md") &&
+              item.properties.error.data.message.includes("mode"),
+          ),
+        ).toBe(true)
+      },
+    })
+  })
+
+  test("skips invalid command markdown configs", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, ".kilo", "command", "skip.md"),
+          `---
+subtask: "banana"
+---
+Broken command template`,
+        )
+        await Filesystem.write(
+          path.join(dir, ".kilo", "command", "keep.md"),
+          `---
+description: Valid command
+---
+Valid command template`,
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const cfg = await Config.get()
+
+        expect(cfg.command?.["skip"]).toBeUndefined()
+        expect(cfg.command?.["keep"]).toEqual({
+          description: "Valid command",
+          template: "Valid command template",
+        })
+      },
+    })
+  })
+
+  test("publishes an error for invalid command markdown configs", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, ".kilo", "command", "skip.md"),
+          `---
+subtask: "banana"
+---
+Broken command template`,
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const seen: Array<{ type: string; properties: { error: { name: string; data: { message: string } } } }> = []
+        const unsub = Bus.subscribeAll((event) => {
+          if (event.type === "session.error") seen.push(event)
+        })
+
+        await Config.get()
+        unsub()
+
+        expect(
+          seen.some(
+            (item) =>
+              item.properties.error.name === "UnknownError" &&
+              item.properties.error.data.message.includes("skip.md") &&
+              item.properties.error.data.message.includes("subtask"),
+          ),
+        ).toBe(true)
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Why

When you use git worktrees (or multiple clones of the same repo), opening Kilo in one worktree shows sessions from all worktrees. This means you can accidentally resume or see messages from a completely different working directory.

## What changed

The session list query now filters by the current worktree directory. Previously it only filtered by project ID, which is derived from the repo's root commit — identical across worktrees. Now each worktree only sees sessions that were created within its own directory tree, so sessions stay isolated even when multiple `bun dev` instances run on the same repo.

## How to test

1. Create two git worktrees for the same repository
2. Run `bun dev` in each worktree
3. Create a session and send a message in worktree A
4. Switch to worktree B — the session from worktree A should no longer appear in the session list
5. Sessions created in worktree B should only appear in worktree B