### PR TITLE
fix(vscode): move Agent Manager button to earlier toolbar position

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -329,12 +329,12 @@
           "when": "view == kilo-code.SidebarProvider"
         },
         {
-          "command": "kilo-code.new.historyButtonClicked",
+          "command": "kilo-code.new.agentManagerOpen",
           "group": "navigation@1",
           "when": "view == kilo-code.SidebarProvider"
         },
         {
-          "command": "kilo-code.new.agentManagerOpen",
+          "command": "kilo-code.new.historyButtonClicked",
           "group": "navigation@2",
           "when": "view == kilo-code.SidebarProvider"
         },


### PR DESCRIPTION
## Summary

The Agent Manager button was missing from the VS Code extension sidebar toolbar and overflow menu, even though the keyboard shortcut (Cmd+Shift+M / Ctrl+Shift+M) worked fine.

## Root Cause

The button was registered at `navigation@2` in the `view/title` menu, which is too far to the right. VS Code's toolbar has limited horizontal space and pushes buttons that don't fit into the overflow menu. With 6 buttons total, Agent Manager at position 2 was being hidden.

## Changes

Moved Agent Manager from `navigation@2` to `navigation@1` in `packages/kilo-vscode/package.json` so it appears immediately after the New Task button.

**Before:** New Task → History → Agent Manager → Marketplace → Profile → Settings
**After:** New Task → Agent Manager → History → Marketplace → Profile → Settings

Fixes #8253

## Notes

Based on feedback from PR #8269, this PR contains ONLY the toolbar fix - no other changes bundled.