### PR TITLE
fix(vscode): stop settings update from spreading all agents/MCPs into config patch

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1614,6 +1614,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           native: a.native,
           color: a.color,
           deprecated: a.deprecated,
+          source: (a.options?.source as string) || undefined,
         })),
         defaultAgent,
       }

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -249,8 +249,7 @@ const AgentBehaviourTab: Component = () => {
         setImportError(language.t(errorKey(result.error)))
         return
       }
-      const existing = config().agent ?? {}
-      updateConfig({ agent: { ...existing, [result.name]: result.config } })
+      updateConfig({ agent: { [result.name]: result.config } })
       setImportError("")
     }
     reader.readAsText(file)

--- a/packages/kilo-vscode/webview-ui/src/components/settings/McpEditView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/McpEditView.tsx
@@ -25,10 +25,8 @@ const McpEditView: Component<Props> = (props) => {
   const [envVal, setEnvVal] = createSignal("")
 
   const update = (partial: Partial<McpConfig>) => {
-    const existing = config().mcp ?? {}
-    const current = existing[props.name] ?? {}
     updateConfig({
-      mcp: { ...existing, [props.name]: { ...current, ...partial } },
+      mcp: { [props.name]: partial },
     })
   }
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModeCreateView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModeCreateView.tsx
@@ -50,14 +50,13 @@ const ModeCreateView: Component<Props> = (props) => {
       setError(msg)
       return
     }
-    const existing = config().agent ?? {}
     const partial: Partial<AgentConfig> = {
       mode: "primary",
       description: description().trim() || undefined,
       prompt: prompt().trim() || undefined,
     }
     updateConfig({
-      agent: { ...existing, [slug]: { ...(existing[slug] ?? {}), ...partial } },
+      agent: { [slug]: partial },
     })
     reset()
     props.onBack()

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
@@ -165,7 +165,7 @@ const ModeEditView: Component<Props> = (props) => {
           <TextField
             value={cfg().model ?? ""}
             placeholder="e.g. anthropic/claude-sonnet-4-20250514"
-            onChange={(val) => update({ model: val || undefined })}
+            onChange={(val) => update({ model: val || null })}
           />
         </SettingsRow>
 
@@ -178,7 +178,7 @@ const ModeEditView: Component<Props> = (props) => {
             placeholder={language.t("common.default")}
             onChange={(val) => {
               const parsed = parseFloat(val)
-              update({ temperature: isNaN(parsed) ? undefined : parsed })
+              update({ temperature: isNaN(parsed) ? null : parsed })
             }}
           />
         </SettingsRow>
@@ -192,7 +192,7 @@ const ModeEditView: Component<Props> = (props) => {
             placeholder={language.t("common.default")}
             onChange={(val) => {
               const parsed = parseFloat(val)
-              update({ top_p: isNaN(parsed) ? undefined : parsed })
+              update({ top_p: isNaN(parsed) ? null : parsed })
             }}
           />
         </SettingsRow>
@@ -206,7 +206,7 @@ const ModeEditView: Component<Props> = (props) => {
             placeholder={language.t("common.default")}
             onChange={(val) => {
               const parsed = parseInt(val, 10)
-              update({ steps: isNaN(parsed) ? undefined : parsed })
+              update({ steps: isNaN(parsed) ? null : parsed })
             }}
           />
         </SettingsRow>

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
@@ -28,6 +28,12 @@ const ModeEditView: Component<Props> = (props) => {
   // custom modes) and all fields read from cfg() which comes from config context.
   const agent = () => session.agents().find((a) => a.name === props.name)
   const native = () => agent()?.native ?? false
+  // Agents from .md files or organization API have their prompt/description managed
+  // externally — edits to global config would be overridden by the higher-precedence source.
+  const managed = () => {
+    const src = agent()?.source
+    return src === "file" || src === "organization"
+  }
 
   const cfg = createMemo<AgentConfig>(() => config().agent?.[props.name] ?? {})
 
@@ -67,7 +73,7 @@ const ModeEditView: Component<Props> = (props) => {
             {language.t("settings.agentBehaviour.editMode")} — {props.name}
           </span>
         </div>
-        <Show when={!native()}>
+        <Show when={!native() && !managed()}>
           <div style={{ display: "flex", gap: "4px" }}>
             <IconButton
               size="small"
@@ -103,7 +109,23 @@ const ModeEditView: Component<Props> = (props) => {
         </Card>
       </Show>
 
-      {/* Description (full-width, custom modes only) */}
+      <Show when={managed()}>
+        <Card style={{ "margin-bottom": "12px" }}>
+          <div
+            style={{
+              "font-size": "12px",
+              color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
+              padding: "4px 0",
+            }}
+          >
+            {agent()?.source === "organization"
+              ? language.t("settings.agentBehaviour.editMode.managed.organization")
+              : language.t("settings.agentBehaviour.editMode.managed.file")}
+          </div>
+        </Card>
+      </Show>
+
+      {/* Description (full-width, custom modes only — read-only for managed agents) */}
       <Show when={!native()}>
         <Card style={{ "margin-bottom": "12px" }}>
           <div data-slot="settings-row-label-title" style={{ "margin-bottom": "8px" }}>
@@ -113,11 +135,12 @@ const ModeEditView: Component<Props> = (props) => {
             value={cfg().description ?? ""}
             placeholder={language.t("settings.agentBehaviour.createMode.description.placeholder")}
             onChange={(val) => update({ description: val || undefined })}
+            disabled={managed()}
           />
         </Card>
       </Show>
 
-      {/* Prompt (full-width, auto-resizing) */}
+      {/* Prompt (full-width, auto-resizing — read-only for managed agents) */}
       <Card style={{ "margin-bottom": "12px" }}>
         <div data-slot="settings-row-label-title" style={{ "margin-bottom": "8px" }}>
           {native()
@@ -129,6 +152,7 @@ const ModeEditView: Component<Props> = (props) => {
           placeholder={language.t("settings.agentBehaviour.createMode.prompt.placeholder")}
           multiline
           onChange={(val) => update({ prompt: val || undefined })}
+          disabled={managed()}
         />
       </Card>
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
@@ -32,12 +32,9 @@ const ModeEditView: Component<Props> = (props) => {
   const cfg = createMemo<AgentConfig>(() => config().agent?.[props.name] ?? {})
 
   const update = (partial: Partial<AgentConfig>) => {
-    const existing = config().agent ?? {}
-    const current = existing[props.name] ?? {}
     updateConfig({
       agent: {
-        ...existing,
-        [props.name]: { ...current, ...partial },
+        [props.name]: partial,
       },
     })
   }

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1173,6 +1173,10 @@ export const dict = {
   "settings.agentBehaviour.editMode.back": "Back to list",
   "settings.agentBehaviour.editMode.native": "Built-in mode (read-only definition)",
   "settings.agentBehaviour.editMode.promptOverride": "Custom prompt override for this built-in mode",
+  "settings.agentBehaviour.editMode.managed.file":
+    "This agent is defined in a .md file. Its prompt and description are read-only here — edit the source file to change them. Other settings like model, temperature, and steps can still be overridden.",
+  "settings.agentBehaviour.editMode.managed.organization":
+    "This agent is managed by your organization. Its prompt and description are read-only — manage it from the cloud dashboard. Other settings like model, temperature, and steps can still be overridden.",
 
   "settings.autoApprove.description":
     "Define how tools are allowed to run. Most tools default to Allow. doom_loop and external_directory default to Ask.",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -223,6 +223,8 @@ export interface AgentInfo {
   hidden?: boolean
   deprecated?: boolean
   color?: string
+  /** Where this agent was defined: "file" (.md), "organization" (cloud API), or undefined (user config / native). */
+  source?: string
 }
 
 // Server info

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -331,9 +331,9 @@ export interface AgentConfig {
   mode?: "subagent" | "primary" | "all"
   hidden?: boolean
   disable?: boolean
-  temperature?: number
-  top_p?: number
-  steps?: number
+  temperature?: number | null
+  top_p?: number | null
+  steps?: number | null
   permission?: PermissionConfig
 }
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -552,7 +552,11 @@ export namespace Config {
       }
       const parsed = Agent.safeParse(config)
       if (parsed.success) {
-        result[config.name] = parsed.data
+        // kilocode_change — tag file-based agents so the UI knows prompt is managed
+        const data = parsed.data
+        data.options = { ...data.options, source: "file" }
+        result[config.name] = data
+        // kilocode_change end
         continue
       }
       throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
@@ -588,6 +592,9 @@ export namespace Config {
       if (parsed.success) {
         result[config.name] = {
           ...parsed.data,
+          // kilocode_change — tag file-based modes so the UI knows prompt is managed
+          options: { ...parsed.data.options, source: "file" },
+          // kilocode_change end
           mode: "primary" as const,
         }
         continue

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -826,8 +826,10 @@ export namespace Config {
         .string()
         .optional()
         .describe("Default model variant for this agent (applies only when using the agent's configured model)."),
-      temperature: z.number().optional(),
-      top_p: z.number().optional(),
+      // kilocode_change start — nullable for delete sentinel (null = unset / revert to default)
+      temperature: z.number().nullable().optional(),
+      top_p: z.number().nullable().optional(),
+      // kilocode_change end
       prompt: z.string().optional(),
       tools: z.record(z.string(), z.boolean()).optional().describe("@deprecated Use 'permission' field instead"),
       disable: z.boolean().optional(),
@@ -845,10 +847,12 @@ export namespace Config {
         ])
         .optional()
         .describe("Hex color code (e.g., #FF5733) or theme color (e.g., primary)"),
+      // kilocode_change — nullable for delete sentinel
       steps: z
         .number()
         .int()
         .positive()
+        .nullable()
         .optional()
         .describe("Maximum number of agentic iterations before forcing text-only response"),
       maxSteps: z.number().int().positive().optional().describe("@deprecated Use 'steps' field instead."),


### PR DESCRIPTION
## Summary

- Fix config corruption caused by settings UI spreading **all** agents/MCPs into every update patch
- Prevent editing prompt/description for managed agents (`.md` files and organization API) since those edits can't persist
- Hide delete/export buttons for managed agents

## Problem 1: Config corruption from `...existing` spread

`Config.get()` returns the fully-merged config across all layers — global config, project config, skill files (`.opencode/agent/*.md`), organization modes, etc. The settings UI components (`ModeEditView`, `ModeCreateView`, `McpEditView`, `AgentBehaviourTab`) all used a pattern like:

```ts
const existing = config().agent ?? {}
updateConfig({ agent: { ...existing, [props.name]: { ...current, ...partial } } })
```

When a user edited any agent setting (e.g. setting temperature on the "code" agent), `...existing` spread **every** agent into the draft — including skill-derived agents like `translator` whose config contains a massive prompt with newlines, special characters, path references like `path/to/file`, etc.

This full snapshot was then written to the global config file via `updateGlobal()`, corrupting it with content that doesn't belong there and causing "file not found" errors from invalid path references in the persisted skill prompts.

### Fix

Removed `...existing` spreading from all four affected components. `updateConfig()` already uses `deepMerge` to accumulate draft changes, and the backend's `mergeConfig`/`patchJsonc` handles deep-merging patches into existing config — so only the specific changed field needs to be sent:

```ts
// Before (broken): spreads ALL agents into the patch
updateConfig({ agent: { ...existing, [props.name]: { ...current, ...partial } } })

// After (fixed): sends only the changed field for the specific agent
updateConfig({ agent: { [props.name]: partial } })
```

## Problem 2: Managed agent edits don't persist / deletion reverts

Agents from `.md` files (e.g. `.opencode/agent/translator.md`) and organization API load at higher config precedence than global config. Edits to prompt/description were written to global config but immediately overwritten on reload. Deletion also failed because the source `.md` file still existed.

### Fix

- Tag file-based agents with `source: "file"` in `loadAgent`/`loadMode` (organization agents already had `source: "organization"`)
- Expose `AgentInfo.source` from KiloProvider to the webview
- Disable prompt/description fields for managed agents in `ModeEditView`
- Hide export/delete buttons for managed agents
- Show explanatory banner explaining where to edit the agent

Other settings (model override, temperature, top_p, steps, hidden, disable) remain editable since those write to global config and merge correctly at the agent level.

## Affected components

| File | Change |
| --- | --- |
| `ModeEditView.tsx` | Remove spread, disable prompt/description for managed, hide delete |
| `ModeCreateView.tsx` | Remove spread |
| `McpEditView.tsx` | Remove spread |
| `AgentBehaviourTab.tsx` | Remove spread (import path) |
| `KiloProvider.ts` | Expose `source` field in agentsLoaded message |
| `messages.ts` | Add `source` to `AgentInfo` |
| `en.ts` | Add i18n strings for managed agent banners |
| `config.ts` (CLI) | Tag file-based agents/modes with `source: "file"` |
