### PR TITLE
feat(vscode): add pre-release publishing support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 name: publish
-run-name: "${{ format('release {0}', inputs.bump) }}"
+run-name: "${{ format('{0} {1}', inputs.pre_release && 'pre-release' || 'release', inputs.bump) }}"
 
 on:
   # push:
@@ -22,6 +22,11 @@ on:
         description: "Override version (optional)"
         required: false
         type: string
+      pre_release:
+        description: "Publish as pre-release (VS Code marketplace)"
+        required: false
+        type: boolean
+        default: false
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.version || inputs.bump }}
 
@@ -117,6 +122,7 @@ jobs:
         env:
           CLI_DIST_DIR: ../../packages/opencode/dist
           KILO_VERSION: ${{ needs.build-cli.outputs.version }}
+          KILO_PRE_RELEASE: ${{ inputs.pre_release }}
           GH_REPO: ${{ github.repository }}
 
       - uses: actions/upload-artifact@v4
@@ -394,6 +400,7 @@ jobs:
         env:
           KILO_VERSION: ${{ needs.version.outputs.version }}
           KILO_RELEASE: ${{ needs.version.outputs.release }}
+          KILO_PRE_RELEASE: ${{ inputs.pre_release }}
           GH_REPO: ${{ github.repository }}
           AUR_KEY: ${{ secrets.AUR_KEY }}
           GITHUB_TOKEN: ${{ steps.committer.outputs.token }}

--- a/packages/kilo-vscode/script/build.ts
+++ b/packages/kilo-vscode/script/build.ts
@@ -6,8 +6,9 @@ import { existsSync, mkdirSync, rmSync, chmodSync } from "node:fs"
 const packageJsonPath = join(import.meta.dir, "..", "package.json")
 const packageJson = await Bun.file(packageJsonPath).json()
 const version = process.env.KILO_VERSION ? process.env.KILO_VERSION : packageJson.version
+const prerelease = process.env.KILO_PRE_RELEASE === "true"
 
-console.log(`Building VSCode extension version: ${version}`)
+console.log(`Building VSCode extension version: ${version}${prerelease ? " (pre-release)" : ""}`)
 
 if (packageJson.version !== version) {
   console.log(`Updating package.json version from ${packageJson.version} to ${version}`)
@@ -80,9 +81,11 @@ for (const config of targets) {
 
   console.log(`  ✅ Binary ready at ${targetBinary}`)
 
-  console.log(`  📦 Packaging .vsix for ${config.target}...`)
+  console.log(`  📦 Packaging .vsix for ${config.target}${prerelease ? " (pre-release)" : ""}...`)
   const vsixPath = join(outDir, `kilo-vscode-${config.target}.vsix`)
-  await $`vsce package --no-dependencies --skip-license --target ${config.target} -o ${vsixPath}`.env({
+  const args = ["--no-dependencies", "--skip-license", "--target", config.target, "-o", vsixPath]
+  if (prerelease) args.push("--pre-release")
+  await $`vsce package ${args}`.env({
     ...process.env,
     npm_config_ignore_scripts: "true",
   })

--- a/packages/kilo-vscode/script/publish.ts
+++ b/packages/kilo-vscode/script/publish.ts
@@ -4,7 +4,9 @@ import { join } from "node:path"
 import { existsSync } from "node:fs"
 import { Script } from "@opencode-ai/script"
 
-console.log(`Publishing VSCode extension for release: v${Script.version}`)
+const prerelease = process.env.KILO_PRE_RELEASE === "true"
+
+console.log(`Publishing VSCode extension for ${prerelease ? "pre-release" : "release"}: v${Script.version}`)
 
 const outDir = process.env.VSIX_DIR || join(import.meta.dir, "..", "out")
 
@@ -36,14 +38,16 @@ for (const target of targets) {
 
 console.log(`\nFound ${vsixFiles.length} VSIX files`)
 
+const flag = prerelease ? ["--pre-release"] : []
+
 for (const target of targets) {
   const vsixPath = join(outDir, `kilo-vscode-${target}.vsix`)
-  console.log(`\n🚀 Publishing ${target} to VS Code Marketplace...`)
-  await $`vsce publish --packagePath ${vsixPath}`
+  console.log(`\n🚀 Publishing ${target} to VS Code Marketplace${prerelease ? " (pre-release)" : ""}...`)
+  await $`vsce publish ${flag} --packagePath ${vsixPath}`
   console.log(`  ✅ Published ${target} to VS Code Marketplace`)
 
-  console.log(`\n📤 Publishing ${target} to Open VSX...`)
-  await $`npx ovsx publish --pat ${process.env.OPENVSX_TOKEN} --packagePath ${vsixPath}`
+  console.log(`\n📤 Publishing ${target} to Open VSX${prerelease ? " (pre-release)" : ""}...`)
+  await $`npx ovsx publish ${flag} --pat ${process.env.OPENVSX_TOKEN} --packagePath ${vsixPath}`
   console.log(`  ✅ Published ${target} to Open VSX`)
 }
 

--- a/script/release
+++ b/script/release
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
 BUMP_TYPE=${1:-patch}
+PRE_RELEASE=${2:-false}
 
-gh workflow run publish.yml -f bump="$BUMP_TYPE"
+gh workflow run publish.yml -f bump="$BUMP_TYPE" -f pre_release="$PRE_RELEASE"


### PR DESCRIPTION
## Summary

- Adds a `pre_release` checkbox to the publish workflow for publishing to the VS Code Marketplace pre-release channel
- Passes `--pre-release` to `vsce package`, `vsce publish`, and `ovsx publish` when checked
- Updates `script/release` to accept an optional second argument for pre-release

## How it works

No special versioning scheme needed. Versions keep incrementing monotonically. The checkbox controls whether a given publish goes to the pre-release channel or the release channel.

| Version | Checkbox | Release users see | Pre-release users see |
| --- | --- | --- | --- |
| 8.7.0 | release | 8.7.0 | 8.7.0 |
| 8.8.0 | pre-release | stay on 8.7.0 | 8.8.0 |
| 8.9.0 | release | 8.9.0 | 8.9.0 (higher wins) |

Pre-release users always get the highest version (release or pre-release). Release users only get non-pre-release versions. Per [VS Code docs](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions):

> "Note that while pre-release users will be updated to a release version if it is higher, they still remain eligible to automatically update to future pre-releases with higher version numbers than the release version."

## Usage

**Via GitHub Actions UI**: Check the "Publish as pre-release" checkbox when dispatching the publish workflow.

**Via CLI**: `script/release patch true`

## Changes

| File | Change |
| --- | --- |
| `.github/workflows/publish.yml` | Add `pre_release` boolean input, pass as `KILO_PRE_RELEASE` env var |
| `packages/kilo-vscode/script/build.ts` | Conditionally add `--pre-release` to `vsce package` |
| `packages/kilo-vscode/script/publish.ts` | Conditionally add `--pre-release` to `vsce publish` and `ovsx publish` |
| `script/release` | Accept and forward pre-release flag as second argument |

Closes #8156
