### PR TITLE
fix(vscode): retry webview load on service worker failure

### DIFF
--- a/packages/kilo-vscode/src/DiffViewerProvider.ts
+++ b/packages/kilo-vscode/src/DiffViewerProvider.ts
@@ -26,6 +26,13 @@ export class DiffViewerProvider implements vscode.Disposable {
   private outputChannel: vscode.OutputChannel
   private onSendComments: ((comments: unknown[], autoSend: boolean) => void) | undefined
 
+  /** Retry state for webview service worker failures (microsoft/vscode#125993) */
+  private readyTimer: ReturnType<typeof setTimeout> | null = null
+  private readyRetries = 0
+  private ready = false
+  private static READY_TIMEOUT = 8_000
+  private static MAX_RETRIES = 3
+
   constructor(
     private readonly extensionUri: vscode.Uri,
     private readonly connectionService: KiloConnectionService,
@@ -73,17 +80,49 @@ export class DiffViewerProvider implements vscode.Disposable {
     panel.webview.onDidReceiveMessage((msg) => this.onMessage(msg), undefined, [])
     panel.webview.html = this.getHtml(panel.webview)
 
+    // Detect service worker failures and retry (microsoft/vscode#125993)
+    this.ready = false
+    this.scheduleReadyCheck()
+
     panel.onDidDispose(() => {
       this.log("Panel disposed")
+      this.cancelReadyCheck()
       this.stopDiffPolling()
       this.panel = undefined
     })
+  }
+
+  private scheduleReadyCheck(): void {
+    this.cancelReadyCheck()
+    this.readyRetries = 0
+    this.readyTimer = setTimeout(() => this.retryWebview(), DiffViewerProvider.READY_TIMEOUT)
+  }
+
+  private retryWebview(): void {
+    if (this.ready || !this.panel) return
+    if (this.readyRetries >= DiffViewerProvider.MAX_RETRIES) {
+      this.log("Webview not ready after retries — likely VS Code service worker bug (microsoft/vscode#125993)")
+      return
+    }
+    this.readyRetries++
+    this.log(`Webview not ready, retrying (${this.readyRetries}/${DiffViewerProvider.MAX_RETRIES})`)
+    this.panel.webview.html = this.getHtml(this.panel.webview)
+    this.readyTimer = setTimeout(() => this.retryWebview(), DiffViewerProvider.READY_TIMEOUT)
+  }
+
+  private cancelReadyCheck(): void {
+    if (this.readyTimer) {
+      clearTimeout(this.readyTimer)
+      this.readyTimer = null
+    }
   }
 
   private onMessage(msg: Record<string, unknown>): void {
     const type = msg.type as string
 
     if (type === "webviewReady") {
+      this.cancelReadyCheck()
+      this.ready = true
       this.post({
         type: "ready",
         vscodeLanguage: vscode.env.language,
@@ -211,6 +250,7 @@ export class DiffViewerProvider implements vscode.Disposable {
   }
 
   public dispose(): void {
+    this.cancelReadyCheck()
     this.stopDiffPolling()
     this.panel?.dispose()
     this.outputChannel.dispose()

--- a/packages/kilo-vscode/src/DiffViewerProvider.ts
+++ b/packages/kilo-vscode/src/DiffViewerProvider.ts
@@ -2,6 +2,8 @@ import * as vscode from "vscode"
 import type { FileDiff } from "@kilocode/sdk/v2/client"
 import type { KiloConnectionService } from "./services/cli-backend"
 import { buildWebviewHtml } from "./utils"
+import { WebviewReadyRetry, showWebviewReloadWarning, type WebviewReadyRetryEvent } from "./webview-ready-retry"
+import { TelemetryEventName, TelemetryProxy } from "./services/telemetry"
 import { GitOps } from "./agent-manager/GitOps"
 import {
   appendOutput,
@@ -26,12 +28,7 @@ export class DiffViewerProvider implements vscode.Disposable {
   private outputChannel: vscode.OutputChannel
   private onSendComments: ((comments: unknown[], autoSend: boolean) => void) | undefined
 
-  /** Retry state for webview service worker failures (microsoft/vscode#125993) */
-  private readyTimer: ReturnType<typeof setTimeout> | null = null
-  private readyRetries = 0
-  private ready = false
-  private static READY_TIMEOUT = 8_000
-  private static MAX_RETRIES = 3
+  private loader: WebviewReadyRetry
 
   constructor(
     private readonly extensionUri: vscode.Uri,
@@ -39,10 +36,30 @@ export class DiffViewerProvider implements vscode.Disposable {
   ) {
     this.gitOps = new GitOps({ log: (...args) => this.log(...args) })
     this.outputChannel = vscode.window.createOutputChannel("Kilo Diff Viewer")
+    this.loader = new WebviewReadyRetry({
+      name: "DiffViewer",
+      active: () => Boolean(this.panel),
+      html: () => (this.panel ? this.getHtml(this.panel.webview) : undefined),
+      load: (html) => {
+        if (!this.panel) return
+        this.panel.webview.html = html
+      },
+      warn: (msg) => this.log(msg),
+      log: (msg) => this.log(msg),
+      notify: () => showWebviewReloadWarning(),
+      capture: (event, props) => this.captureRetry(event, props),
+    })
   }
 
   private log(...args: unknown[]) {
     appendOutput(this.outputChannel, "DiffViewer", ...args)
+  }
+
+  private captureRetry(event: WebviewReadyRetryEvent, props: Record<string, unknown>): void {
+    TelemetryProxy.capture(
+      event === "retry" ? TelemetryEventName.WEBVIEW_READY_RETRY : TelemetryEventName.WEBVIEW_READY_FAILED,
+      props,
+    )
   }
 
   public setCommentHandler(handler: (comments: unknown[], autoSend: boolean) => void): void {
@@ -81,48 +98,21 @@ export class DiffViewerProvider implements vscode.Disposable {
     panel.webview.html = this.getHtml(panel.webview)
 
     // Detect service worker failures and retry (microsoft/vscode#125993)
-    this.ready = false
-    this.scheduleReadyCheck()
+    this.loader.start()
 
     panel.onDidDispose(() => {
       this.log("Panel disposed")
-      this.cancelReadyCheck()
+      this.loader.dispose()
       this.stopDiffPolling()
       this.panel = undefined
     })
-  }
-
-  private scheduleReadyCheck(): void {
-    this.cancelReadyCheck()
-    this.readyRetries = 0
-    this.readyTimer = setTimeout(() => this.retryWebview(), DiffViewerProvider.READY_TIMEOUT)
-  }
-
-  private retryWebview(): void {
-    if (this.ready || !this.panel) return
-    if (this.readyRetries >= DiffViewerProvider.MAX_RETRIES) {
-      this.log("Webview not ready after retries — likely VS Code service worker bug (microsoft/vscode#125993)")
-      return
-    }
-    this.readyRetries++
-    this.log(`Webview not ready, retrying (${this.readyRetries}/${DiffViewerProvider.MAX_RETRIES})`)
-    this.panel.webview.html = this.getHtml(this.panel.webview)
-    this.readyTimer = setTimeout(() => this.retryWebview(), DiffViewerProvider.READY_TIMEOUT)
-  }
-
-  private cancelReadyCheck(): void {
-    if (this.readyTimer) {
-      clearTimeout(this.readyTimer)
-      this.readyTimer = null
-    }
   }
 
   private onMessage(msg: Record<string, unknown>): void {
     const type = msg.type as string
 
     if (type === "webviewReady") {
-      this.cancelReadyCheck()
-      this.ready = true
+      this.loader.done()
       this.post({
         type: "ready",
         vscodeLanguage: vscode.env.language,
@@ -250,7 +240,7 @@ export class DiffViewerProvider implements vscode.Disposable {
   }
 
   public dispose(): void {
-    this.cancelReadyCheck()
+    this.loader.dispose()
     this.stopDiffPolling()
     this.panel?.dispose()
     this.outputChannel.dispose()

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -17,7 +17,8 @@ import type { EditorContext } from "./services/cli-backend/types"
 import { FileIgnoreController } from "./services/autocomplete/shims/FileIgnoreController"
 import { ChatTextAreaAutocomplete } from "./services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete"
 import { buildWebviewHtml } from "./utils"
-import { TelemetryProxy, type TelemetryPropertiesProvider } from "./services/telemetry"
+import { WebviewReadyRetry, showWebviewReloadWarning, type WebviewReadyRetryEvent } from "./webview-ready-retry"
+import { TelemetryEventName, TelemetryProxy, type TelemetryPropertiesProvider } from "./services/telemetry"
 import {
   sessionToWebview,
   indexProvidersById,
@@ -170,12 +171,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private statsPoller: GitStatsPoller | null = null
   private cachedStats: unknown = null
 
-  /** Retry state for webview service worker failures (VS Code platform bug, see microsoft/vscode#125993) */
-  private readyTimer: ReturnType<typeof setTimeout> | null = null
-  private readyRetries = 0
-  private htmlGenerator: (() => string) | null = null
-  private static READY_TIMEOUT = 8_000
-  private static MAX_RETRIES = 3
+  private loader: WebviewReadyRetry
 
   /** Optional interceptor called before the standard message handler.
    *  Return null to consume the message, or return a (possibly transformed) message. */
@@ -194,6 +190,19 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   ) {
     this.projectDirectory = options?.projectDirectory
     this.slimEditMetadata = options?.slimEditMetadata ?? true
+    this.loader = new WebviewReadyRetry({
+      name: "KiloProvider",
+      active: () => Boolean(this.webview),
+      html: () => (this.webview ? this._getHtmlForWebview(this.webview) : undefined),
+      load: (html) => {
+        if (!this.webview) return
+        this.webview.html = html
+      },
+      warn: (msg) => console.warn(msg),
+      log: (msg) => console.error(msg),
+      notify: () => showWebviewReloadWarning(),
+      capture: (event, props) => this.captureRetry(event, props),
+    })
 
     TelemetryProxy.getInstance().setProvider(this)
   }
@@ -214,6 +223,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       machineId: vscode.env.machineId,
       vscodeIsTelemetryEnabled: vscode.env.isTelemetryEnabled,
     }
+  }
+
+  private captureRetry(event: WebviewReadyRetryEvent, props: Record<string, unknown>): void {
+    TelemetryProxy.capture(
+      event === "retry" ? TelemetryEventName.WEBVIEW_READY_RETRY : TelemetryEventName.WEBVIEW_READY_FAILED,
+      props,
+    )
   }
 
   /**
@@ -349,7 +365,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     })
 
     // Detect service worker failures and retry (microsoft/vscode#125993)
-    this.scheduleReadyCheck()
+    this.loader.start()
 
     // Initialize connection to CLI backend
     this.initializeConnection()
@@ -374,7 +390,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.setupWebviewMessageHandler(panel.webview)
 
     // Detect service worker failures and retry (microsoft/vscode#125993)
-    this.scheduleReadyCheck()
+    this.loader.start()
 
     this.initializeConnection()
   }
@@ -446,18 +462,23 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * Attach to a webview that already has its own HTML set.
    * Sets up message handling and connection without overriding HTML content.
    *
+   * @param options.html - Optional HTML generator for retrying panels with custom bundles.
    * @param options.onBeforeMessage - Optional interceptor called before the standard handler.
    *   Return null to consume the message (stop propagation), or return the message
    *   (possibly transformed) to continue with standard handling.
    */
   public attachToWebview(
     webview: vscode.Webview,
-    options?: { onBeforeMessage?: (msg: Record<string, unknown>) => Promise<Record<string, unknown> | null> },
+    options?: {
+      html?: () => string
+      onBeforeMessage?: (msg: Record<string, unknown>) => Promise<Record<string, unknown> | null>
+    },
   ): void {
     this.isWebviewReady = false
     this.webview = webview
     this.onBeforeMessage = options?.onBeforeMessage ?? null
     this.setupWebviewMessageHandler(webview)
+    this.loader.start(options?.html)
     this.initializeConnection()
   }
 
@@ -482,8 +503,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       switch (message.type) {
         case "webviewReady":
-          console.log("[Kilo New] KiloProvider: ✅ webviewReady received")
-          this.cancelReadyCheck()
+          console.log("[Kilo New] KiloProvider: webviewReady received")
+          this.loader.done()
           this.isWebviewReady = true
           await this.syncWebviewState("webviewReady")
           this.flushPendingReviewComments()
@@ -2958,58 +2979,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     return resolveProjectDirectory(this.projectDirectory, () => this.getWorkspaceDirectory(sessionId))
   }
 
-  /**
-   * Schedule a timer that detects when the webview fails to send "webviewReady"
-   * (typically caused by VS Code's internal service worker failing to register —
-   * see microsoft/vscode#125993). On timeout, re-assigns webview.html to force
-   * a fresh iframe + service worker registration attempt.
-   *
-   * @param html Optional HTML generator. Defaults to this._getHtmlForWebview().
-   */
-  public scheduleReadyCheck(html?: () => string): void {
-    this.cancelReadyCheck()
-    this.readyRetries = 0
-    this.htmlGenerator = html ?? null
-    this.readyTimer = setTimeout(() => this.retryWebview(), KiloProvider.READY_TIMEOUT)
-  }
-
-  private retryWebview(): void {
-    if (this.isWebviewReady || !this.webview) return
-    if (this.readyRetries >= KiloProvider.MAX_RETRIES) {
-      console.error(
-        `[Kilo New] KiloProvider: webview not ready after ${KiloProvider.MAX_RETRIES} retries — ` +
-          "likely VS Code service worker bug (microsoft/vscode#125993). " +
-          'Try "Developer: Reload Window".',
-      )
-      void vscode.window
-        .showWarningMessage(
-          "Kilo Code failed to load. This is a known VS Code issue. Try reloading the window.",
-          "Reload Window",
-        )
-        .then((choice: string | undefined) => {
-          if (choice === "Reload Window") {
-            void vscode.commands.executeCommand("workbench.action.reloadWindow")
-          }
-        })
-      return
-    }
-    this.readyRetries++
-    console.warn(
-      `[Kilo New] KiloProvider: webview not ready after ${KiloProvider.READY_TIMEOUT}ms, ` +
-        `retrying (${this.readyRetries}/${KiloProvider.MAX_RETRIES})`,
-    )
-    const gen = this.htmlGenerator
-    this.webview.html = gen ? gen() : this._getHtmlForWebview(this.webview)
-    this.readyTimer = setTimeout(() => this.retryWebview(), KiloProvider.READY_TIMEOUT)
-  }
-
-  private cancelReadyCheck(): void {
-    if (this.readyTimer) {
-      clearTimeout(this.readyTimer)
-      this.readyTimer = null
-    }
-  }
-
   private _getHtmlForWebview(webview: vscode.Webview): string {
     return buildWebviewHtml(webview, {
       scriptUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "webview.js")),
@@ -3087,7 +3056,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * Does NOT kill the server — that's the connection service's job.
    */
   dispose(): void {
-    this.cancelReadyCheck()
+    this.loader.dispose()
     this.statsPoller?.stop()
     this.unsubscribeEvent?.()
     this.unsubscribeState?.()

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -170,6 +170,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private statsPoller: GitStatsPoller | null = null
   private cachedStats: unknown = null
 
+  /** Retry state for webview service worker failures (VS Code platform bug, see microsoft/vscode#125993) */
+  private readyTimer: ReturnType<typeof setTimeout> | null = null
+  private readyRetries = 0
+  private htmlGenerator: (() => string) | null = null
+  private static READY_TIMEOUT = 8_000
+  private static MAX_RETRIES = 3
+
   /** Optional interceptor called before the standard message handler.
    *  Return null to consume the message, or return a (possibly transformed) message. */
   private onBeforeMessage: ((msg: Record<string, unknown>) => Promise<Record<string, unknown> | null>) | null = null
@@ -341,6 +348,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.statsPoller?.setEnabled(webviewView.visible)
     })
 
+    // Detect service worker failures and retry (microsoft/vscode#125993)
+    this.scheduleReadyCheck()
+
     // Initialize connection to CLI backend
     this.initializeConnection()
   }
@@ -362,6 +372,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     // Handle messages from webview (shared handler)
     this.setupWebviewMessageHandler(panel.webview)
+
+    // Detect service worker failures and retry (microsoft/vscode#125993)
+    this.scheduleReadyCheck()
 
     this.initializeConnection()
   }
@@ -470,6 +483,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       switch (message.type) {
         case "webviewReady":
           console.log("[Kilo New] KiloProvider: ✅ webviewReady received")
+          this.cancelReadyCheck()
           this.isWebviewReady = true
           await this.syncWebviewState("webviewReady")
           this.flushPendingReviewComments()
@@ -2944,6 +2958,58 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     return resolveProjectDirectory(this.projectDirectory, () => this.getWorkspaceDirectory(sessionId))
   }
 
+  /**
+   * Schedule a timer that detects when the webview fails to send "webviewReady"
+   * (typically caused by VS Code's internal service worker failing to register —
+   * see microsoft/vscode#125993). On timeout, re-assigns webview.html to force
+   * a fresh iframe + service worker registration attempt.
+   *
+   * @param html Optional HTML generator. Defaults to this._getHtmlForWebview().
+   */
+  public scheduleReadyCheck(html?: () => string): void {
+    this.cancelReadyCheck()
+    this.readyRetries = 0
+    this.htmlGenerator = html ?? null
+    this.readyTimer = setTimeout(() => this.retryWebview(), KiloProvider.READY_TIMEOUT)
+  }
+
+  private retryWebview(): void {
+    if (this.isWebviewReady || !this.webview) return
+    if (this.readyRetries >= KiloProvider.MAX_RETRIES) {
+      console.error(
+        `[Kilo New] KiloProvider: webview not ready after ${KiloProvider.MAX_RETRIES} retries — ` +
+          "likely VS Code service worker bug (microsoft/vscode#125993). " +
+          'Try "Developer: Reload Window".',
+      )
+      void vscode.window
+        .showWarningMessage(
+          "Kilo Code failed to load. This is a known VS Code issue. Try reloading the window.",
+          "Reload Window",
+        )
+        .then((choice: string | undefined) => {
+          if (choice === "Reload Window") {
+            void vscode.commands.executeCommand("workbench.action.reloadWindow")
+          }
+        })
+      return
+    }
+    this.readyRetries++
+    console.warn(
+      `[Kilo New] KiloProvider: webview not ready after ${KiloProvider.READY_TIMEOUT}ms, ` +
+        `retrying (${this.readyRetries}/${KiloProvider.MAX_RETRIES})`,
+    )
+    const gen = this.htmlGenerator
+    this.webview.html = gen ? gen() : this._getHtmlForWebview(this.webview)
+    this.readyTimer = setTimeout(() => this.retryWebview(), KiloProvider.READY_TIMEOUT)
+  }
+
+  private cancelReadyCheck(): void {
+    if (this.readyTimer) {
+      clearTimeout(this.readyTimer)
+      this.readyTimer = null
+    }
+  }
+
   private _getHtmlForWebview(webview: vscode.Webview): string {
     return buildWebviewHtml(webview, {
       scriptUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "webview.js")),
@@ -3021,6 +3087,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * Does NOT kill the server — that's the connection service's job.
    */
   dispose(): void {
+    this.cancelReadyCheck()
     this.statsPoller?.stop()
     this.unsubscribeEvent?.()
     this.unsubscribeState?.()

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -78,6 +78,17 @@ export class VscodeHost implements Host {
       onBeforeMessage: opts.onBeforeMessage,
     })
 
+    // Detect service worker failures and retry (microsoft/vscode#125993)
+    const html = () =>
+      buildWebviewHtml(panel.webview, {
+        scriptUri: panel.webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "agent-manager.js")),
+        styleUri: panel.webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "agent-manager.css")),
+        iconsBaseUri: panel.webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "assets", "icons")),
+        title: "Agent Manager",
+        port: this.connectionService.getServerInfo()?.port,
+      })
+    provider.scheduleReadyCheck(html)
+
     const sessions: SessionProvider = {
       setSessionDirectory: (id, dir) => provider.setSessionDirectory(id, dir),
       clearSessionDirectory: (id) => provider.clearSessionDirectory(id),

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -62,23 +62,6 @@ export class VscodeHost implements Host {
       dark: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-dark.svg"),
     }
 
-    const port = this.connectionService.getServerInfo()?.port
-    panel.webview.html = buildWebviewHtml(panel.webview, {
-      scriptUri: panel.webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "agent-manager.js")),
-      styleUri: panel.webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "agent-manager.css")),
-      iconsBaseUri: panel.webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "assets", "icons")),
-      title: "Agent Manager",
-      port,
-    })
-
-    const provider = new KiloProvider(this.extensionUri, this.connectionService, this.context, {
-      slimEditMetadata: true,
-    })
-    provider.attachToWebview(panel.webview, {
-      onBeforeMessage: opts.onBeforeMessage,
-    })
-
-    // Detect service worker failures and retry (microsoft/vscode#125993)
     const html = () =>
       buildWebviewHtml(panel.webview, {
         scriptUri: panel.webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "agent-manager.js")),
@@ -87,7 +70,15 @@ export class VscodeHost implements Host {
         title: "Agent Manager",
         port: this.connectionService.getServerInfo()?.port,
       })
-    provider.scheduleReadyCheck(html)
+    panel.webview.html = html()
+
+    const provider = new KiloProvider(this.extensionUri, this.connectionService, this.context, {
+      slimEditMetadata: true,
+    })
+    provider.attachToWebview(panel.webview, {
+      html,
+      onBeforeMessage: opts.onBeforeMessage,
+    })
 
     const sessions: SessionProvider = {
       setSessionDirectory: (id, dir) => provider.setSessionDirectory(id, dir),

--- a/packages/kilo-vscode/src/services/telemetry/types.ts
+++ b/packages/kilo-vscode/src/services/telemetry/types.ts
@@ -75,6 +75,8 @@ export enum TelemetryEventName {
   AUTO_PURGE_FAILED = "Auto Purge Failed",
   MANUAL_PURGE_TRIGGERED = "Manual Purge Triggered",
   WEBVIEW_MEMORY_USAGE = "Webview Memory Usage",
+  WEBVIEW_READY_RETRY = "Webview Ready Retry",
+  WEBVIEW_READY_FAILED = "Webview Ready Failed",
   MEMORY_WARNING_SHOWN = "Memory Warning Shown",
   ASK_APPROVAL = "Ask Approval",
   NOTIFICATION_CLICKED = "Notification Clicked",

--- a/packages/kilo-vscode/src/webview-ready-retry.ts
+++ b/packages/kilo-vscode/src/webview-ready-retry.ts
@@ -1,0 +1,140 @@
+import * as vscode from "vscode"
+
+export const WEBVIEW_READY_TIMEOUT = 8_000
+export const WEBVIEW_READY_RETRIES = 3
+
+type Scheduler = {
+  set(callback: () => void, timeout: number): unknown
+  clear(timer: unknown): void
+}
+
+export type WebviewReadyRetryEvent = "retry" | "failed"
+
+export type WebviewReadyRetryOptions = {
+  name: string
+  active?: () => boolean
+  html: () => string | undefined
+  load: (html: string) => void
+  log?: (message: string) => void
+  warn?: (message: string) => void
+  notify?: () => void
+  capture?: (event: WebviewReadyRetryEvent, props: Record<string, unknown>) => void
+  scheduler?: Scheduler
+  timeout?: number
+  retries?: number
+}
+
+const scheduler: Scheduler = {
+  set: (callback, timeout) => setTimeout(callback, timeout),
+  clear: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+}
+
+export class WebviewReadyRetry {
+  private timer: unknown = null
+  private attempts = 0
+  private ready = false
+  private html: () => string | undefined
+
+  constructor(private readonly opts: WebviewReadyRetryOptions) {
+    this.html = opts.html
+  }
+
+  start(html?: () => string | undefined): void {
+    this.stop()
+    this.ready = false
+    this.attempts = 0
+    this.html = html ?? this.opts.html
+    this.arm()
+  }
+
+  done(): void {
+    this.ready = true
+    this.stop()
+  }
+
+  dispose(): void {
+    this.stop()
+  }
+
+  private get active(): boolean {
+    return this.opts.active?.() ?? true
+  }
+
+  private get delay(): number {
+    return (this.opts.timeout ?? WEBVIEW_READY_TIMEOUT) * (this.attempts + 1)
+  }
+
+  private get retries(): number {
+    return this.opts.retries ?? WEBVIEW_READY_RETRIES
+  }
+
+  private get scheduler(): Scheduler {
+    return this.opts.scheduler ?? scheduler
+  }
+
+  private arm(): void {
+    this.timer = this.scheduler.set(() => this.retry(), this.delay)
+  }
+
+  private retry(): void {
+    const delay = this.delay
+    this.timer = null
+
+    if (this.ready || !this.active) return
+
+    if (this.attempts >= this.retries) {
+      this.log(
+        `webview not ready after ${this.retries} retries - likely VS Code service worker bug ` +
+          `(microsoft/vscode#125993). Try "Developer: Reload Window".`,
+      )
+      this.opts.capture?.("failed", { name: this.opts.name, retries: this.retries })
+      this.opts.notify?.()
+      return
+    }
+
+    this.attempts++
+    this.warn(`webview not ready after ${delay}ms, retrying (${this.attempts}/${this.retries})`)
+    this.opts.capture?.("retry", {
+      name: this.opts.name,
+      attempt: this.attempts,
+      retries: this.retries,
+      timeout: delay,
+    })
+
+    const html = this.html()
+    if (this.ready || !this.active || html === undefined) return
+
+    this.opts.load(html)
+    if (this.ready || !this.active) return
+
+    this.arm()
+  }
+
+  private stop(): void {
+    const timer = this.timer
+    if (timer === null) return
+
+    this.scheduler.clear(timer)
+    this.timer = null
+  }
+
+  private log(message: string): void {
+    this.opts.log?.(`[Kilo New] ${this.opts.name}: ${message}`)
+  }
+
+  private warn(message: string): void {
+    this.opts.warn?.(`[Kilo New] ${this.opts.name}: ${message}`)
+  }
+}
+
+export function showWebviewReloadWarning(): void {
+  void vscode.window
+    .showWarningMessage(
+      "Kilo Code failed to load. This is a known VS Code issue. Try reloading the window.",
+      "Reload Window",
+    )
+    .then((choice) => {
+      if (choice !== "Reload Window") return
+      void vscode.commands.executeCommand("workbench.action.reloadWindow")
+    })
+}

--- a/packages/kilo-vscode/tests/unit/webview-ready-retry.test.ts
+++ b/packages/kilo-vscode/tests/unit/webview-ready-retry.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test"
+import { WEBVIEW_READY_RETRIES, WEBVIEW_READY_TIMEOUT, WebviewReadyRetry } from "../../src/webview-ready-retry"
+
+class Scheduler {
+  delays: number[] = []
+  cleared: unknown[] = []
+  private seq = 0
+  private tasks = new Map<number, () => void>()
+
+  set(callback: () => void, timeout: number): number {
+    const id = this.seq + 1
+    this.seq = id
+    this.delays.push(timeout)
+    this.tasks.set(id, callback)
+    return id
+  }
+
+  clear(timer: unknown): void {
+    this.cleared.push(timer)
+    if (typeof timer !== "number") return
+    this.tasks.delete(timer)
+  }
+
+  run(): void {
+    const id = this.tasks.keys().next().value
+    if (id === undefined) return
+
+    const task = this.tasks.get(id)
+    this.tasks.delete(id)
+    task?.()
+  }
+
+  get pending(): number {
+    return this.tasks.size
+  }
+}
+
+describe("WebviewReadyRetry", () => {
+  it("cancels the timer when the webview is ready", () => {
+    const scheduler = new Scheduler()
+    const loads: string[] = []
+    const retry = new WebviewReadyRetry({
+      name: "Test",
+      html: () => "html",
+      load: (html) => loads.push(html),
+      scheduler,
+    })
+
+    retry.start()
+    retry.done()
+    scheduler.run()
+
+    expect(loads).toEqual([])
+    expect(scheduler.pending).toBe(0)
+    expect(scheduler.cleared).toEqual([1])
+  })
+
+  it("retries with backoff and stops after the cap", () => {
+    const scheduler = new Scheduler()
+    const loads: string[] = []
+    const notices: string[] = []
+    const events: string[] = []
+    const retry = new WebviewReadyRetry({
+      name: "Test",
+      html: () => "html",
+      load: (html) => loads.push(html),
+      notify: () => notices.push("reload"),
+      capture: (event) => events.push(event),
+      scheduler,
+    })
+
+    retry.start()
+    for (const _ of Array.from({ length: WEBVIEW_READY_RETRIES })) scheduler.run()
+    scheduler.run()
+
+    expect(loads).toEqual(["html", "html", "html"])
+    expect(notices).toEqual(["reload"])
+    expect(events).toEqual(["retry", "retry", "retry", "failed"])
+    expect(scheduler.pending).toBe(0)
+    expect(scheduler.delays).toEqual([
+      WEBVIEW_READY_TIMEOUT,
+      WEBVIEW_READY_TIMEOUT * 2,
+      WEBVIEW_READY_TIMEOUT * 3,
+      WEBVIEW_READY_TIMEOUT * 4,
+    ])
+  })
+
+  it("cancels the timer on dispose", () => {
+    const scheduler = new Scheduler()
+    const retry = new WebviewReadyRetry({
+      name: "Test",
+      html: () => "html",
+      load: () => undefined,
+      scheduler,
+    })
+
+    retry.start()
+    retry.dispose()
+
+    expect(scheduler.pending).toBe(0)
+    expect(scheduler.cleared).toEqual([1])
+  })
+
+  it("does not reload if ready flips during html generation", () => {
+    const scheduler = new Scheduler()
+    const loads: string[] = []
+    const box: { retry?: WebviewReadyRetry } = {}
+    const retry = new WebviewReadyRetry({
+      name: "Test",
+      html: () => {
+        box.retry?.done()
+        return "html"
+      },
+      load: (html) => loads.push(html),
+      scheduler,
+    })
+    box.retry = retry
+
+    retry.start()
+    scheduler.run()
+
+    expect(loads).toEqual([])
+    expect(scheduler.pending).toBe(0)
+  })
+})

--- a/packages/kilo-vscode/tests/unit/webview-ready-retry.test.ts
+++ b/packages/kilo-vscode/tests/unit/webview-ready-retry.test.ts
@@ -122,4 +122,51 @@ describe("WebviewReadyRetry", () => {
     expect(loads).toEqual([])
     expect(scheduler.pending).toBe(0)
   })
+
+  it("stops retrying when active returns false", () => {
+    const scheduler = new Scheduler()
+    const loads: string[] = []
+    let active = true
+    const retry = new WebviewReadyRetry({
+      name: "Test",
+      active: () => active,
+      html: () => "html",
+      load: (html) => loads.push(html),
+      scheduler,
+    })
+
+    retry.start()
+    active = false
+    scheduler.run()
+
+    expect(loads).toEqual([])
+    expect(scheduler.pending).toBe(0)
+  })
+
+  it("resets attempt counter when start is called again", () => {
+    const scheduler = new Scheduler()
+    const loads: string[] = []
+    const events: string[] = []
+    const retry = new WebviewReadyRetry({
+      name: "Test",
+      html: () => "html",
+      load: (html) => loads.push(html),
+      capture: (event) => events.push(event),
+      scheduler,
+    })
+
+    // Exhaust two retries then restart
+    retry.start()
+    scheduler.run()
+    scheduler.run()
+    expect(loads).toHaveLength(2)
+
+    // Restart should clear attempts and schedule a fresh timer
+    retry.start()
+    expect(scheduler.pending).toBe(1)
+
+    // The fresh timer should fire at the base timeout (no backoff from previous run)
+    const delay = scheduler.delays[scheduler.delays.length - 1]
+    expect(delay).toBe(WEBVIEW_READY_TIMEOUT)
+  })
 })


### PR DESCRIPTION
## Summary

- Mitigate VS Code platform bug ([microsoft/vscode#125993](https://github.com/microsoft/vscode/issues/125993)) where the internal service worker fails to register, leaving all webviews blank with "Error loading webview: Could not register service worker: InvalidStateError"
- After setting `webview.html`, an 8-second timer monitors for `webviewReady`. If it never arrives, re-assigns the HTML to force a fresh iframe + service worker registration attempt. Retries up to 3 times, then shows a "Reload Window" notification.
- Covers all webview surfaces: sidebar, tab panels, Agent Manager, DiffViewer, SettingsEditor, and SubAgentViewer

Closes #8512
