### PR TITLE
fix: track snapshot before each file-modifying tool execution

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -17,6 +17,7 @@ import type {
   ToolPart,
 } from "@kilocode/sdk/v2"
 import { useData } from "@kilocode/kilo-ui/context/data"
+import { useSession } from "../../context/session"
 
 // Tools that the upstream message-part renderer suppresses (returns null for).
 // We render these ourselves via ToolRegistry when they complete,
@@ -67,12 +68,19 @@ function TodoToolCard(props: { part: ToolPart }) {
 
 export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
   const data = useData()
+  const session = useSession()
 
   const parts = createMemo(() => {
     const stored = data.store.part?.[props.message.id]
     if (!stored) return []
     return (stored as SDKPart[]).filter((part) => isRenderable(part))
   })
+
+  const handleToolRevert = (partID: string) => {
+    session.revertSession(props.message.id, partID)
+  }
+
+  const fileModifyingTools = new Set(["edit", "write", "apply_patch", "bash", "task"])
 
   return (
     <>
@@ -82,9 +90,17 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
           // so we detect them here and render via ToolRegistry directly.
           const isUpstreamSuppressed =
             part.type === "tool" && UPSTREAM_SUPPRESSED_TOOLS.has((part as SDKPart & { tool: string }).tool)
+          const toolPart = part as unknown as ToolPart
+          const hasSnapshot = part.type === "tool" && fileModifyingTools.has(toolPart.tool) && toolPart.snapshot
           return (
             <Show when={isUpstreamSuppressed || PART_MAPPING[part.type]}>
-              <div data-component="tool-part-wrapper" data-part-type={part.type}>
+              <div
+                data-component="tool-part-wrapper"
+                data-part-type={part.type}
+                style={hasSnapshot ? "cursor: pointer; position: relative;" : undefined}
+                onClick={hasSnapshot ? () => handleToolRevert(toolPart.id) : undefined}
+                title={hasSnapshot ? "Click to revert to this tool" : undefined}
+              >
                 <Show
                   when={isUpstreamSuppressed}
                   fallback={

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -91,7 +91,8 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
           const isUpstreamSuppressed =
             part.type === "tool" && UPSTREAM_SUPPRESSED_TOOLS.has((part as SDKPart & { tool: string }).tool)
           const toolPart = part as unknown as ToolPart
-          const hasSnapshot = part.type === "tool" && fileModifyingTools.has(toolPart.tool) && toolPart.snapshot
+          const hasSnapshot =
+            part.type === "tool" && fileModifyingTools.has(toolPart.tool) && toolPart.snapshot && toolPart.snapshotFiles
           return (
             <Show when={isUpstreamSuppressed || PART_MAPPING[part.type]}>
               <div

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -168,7 +168,7 @@ interface SessionContextValue {
   worktreeStats: Accessor<{ files: number; additions: number; deletions: number } | undefined>
 
   // Actions
-  revertSession: (messageID: string) => void
+  revertSession: (messageID: string, partID?: string) => void
   unrevertSession: () => void
   sendMessage: (text: string, providerID?: string, modelID?: string, files?: FileAttachment[], draftID?: string) => void
   sendCommand: (
@@ -1676,20 +1676,20 @@ export const SessionProvider: ParentComponent = (props) => {
     return id ? (store.sessions[id]?.summary ?? undefined) : undefined
   })
 
-  function revertSession(messageID: string) {
+  function revertSession(messageID: string, partID?: string) {
     const id = currentSessionID()
     if (!id) return
     // Restore the reverted user message's prompt text into the input.
     // Dispatch as a window message so PromptInput picks it up via onMessage.
     const parts = store.parts[messageID]
-    if (parts) {
+    if (parts && !partID) {
       const text = parts
         .filter((p) => p.type === "text" && !(p as { synthetic?: boolean }).synthetic)
         .map((p) => (p as { text: string }).text ?? "")
         .join("")
       if (text) window.postMessage({ type: "setChatBoxMessage", text }, "*")
     }
-    vscode.postMessage({ type: "revertSession", sessionID: id, messageID })
+    vscode.postMessage({ type: "revertSession", sessionID: id, messageID, partID })
   }
 
   function unrevertSession() {

--- a/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
@@ -177,7 +177,7 @@ export function mockSessionValue(overrides?: {
     revertedCount: () => 0,
     summary: () => undefined,
     worktreeStats: () => undefined,
-    revertSession: noop,
+    revertSession: (_messageID: string, _partID?: string) => {},
     unrevertSession: noop,
     favoriteModels: () => [],
     toggleFavorite: noop,

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1414,6 +1414,7 @@ export interface RevertSessionRequest {
   type: "revertSession"
   sessionID: string
   messageID: string
+  partID?: string
 }
 
 export interface UnrevertSessionRequest {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -337,6 +337,7 @@ export namespace MessageV2 {
     tool: z.string(),
     state: ToolState,
     snapshot: z.string().optional(),
+    snapshotFiles: z.string().array().optional(),
     metadata: z.record(z.string(), z.any()).optional(),
   }).meta({
     ref: "ToolPart",

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -336,6 +336,7 @@ export namespace MessageV2 {
     callID: z.string(),
     tool: z.string(),
     state: ToolState,
+    snapshot: z.string().optional(),
     metadata: z.record(z.string(), z.any()).optional(),
   }).meta({
     ref: "ToolPart",

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -159,9 +159,10 @@ export namespace SessionProcessor {
                     toolcalls[value.toolCallId] = created as MessageV2.ToolPart
                   }
                   // kilocode_change end
-                  // kilocode_change start - track snapshot before file-modifying tool execution
+                  // kilocode_change start - track snapshot before file-modifying tool execution (VSCode only)
                   const fileModifyingTools = ["edit", "write", "apply_patch", "bash", "task"]
-                  const shouldSnapshot = fileModifyingTools.includes(value.toolName)
+                  const shouldSnapshot =
+                    process.env.KILO_PLATFORM === "vscode" && fileModifyingTools.includes(value.toolName)
                   const toolSnapshot = shouldSnapshot ? await Snapshot.track() : undefined
                   // kilocode_change end
                   const match = toolcalls[value.toolCallId]
@@ -214,7 +215,7 @@ export namespace SessionProcessor {
                   const match = toolcalls[value.toolCallId]
                   if (match && match.state.status === "running") {
                     let snapshotFiles: string[] | undefined
-                    if (match.snapshot) {
+                    if (process.env.KILO_PLATFORM === "vscode" && match.snapshot) {
                       const patch = await Snapshot.patch(match.snapshot)
                       snapshotFiles = patch.files
                     }
@@ -244,7 +245,7 @@ export namespace SessionProcessor {
                   const match = toolcalls[value.toolCallId]
                   if (match && match.state.status === "running") {
                     let snapshotFiles: string[] | undefined
-                    if (match.snapshot) {
+                    if (process.env.KILO_PLATFORM === "vscode" && match.snapshot) {
                       const patch = await Snapshot.patch(match.snapshot)
                       snapshotFiles = patch.files
                     }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -159,11 +159,17 @@ export namespace SessionProcessor {
                     toolcalls[value.toolCallId] = created as MessageV2.ToolPart
                   }
                   // kilocode_change end
+                  // kilocode_change start - track snapshot before file-modifying tool execution
+                  const fileModifyingTools = ["edit", "write", "apply_patch", "bash", "task"]
+                  const shouldSnapshot = fileModifyingTools.includes(value.toolName)
+                  const toolSnapshot = shouldSnapshot ? await Snapshot.track() : undefined
+                  // kilocode_change end
                   const match = toolcalls[value.toolCallId]
                   if (match) {
                     const part = await Session.updatePart({
                       ...match,
                       tool: value.toolName,
+                      snapshot: toolSnapshot,
                       state: {
                         status: "running",
                         input: value.input,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -243,8 +243,14 @@ export namespace SessionProcessor {
                 case "tool-error": {
                   const match = toolcalls[value.toolCallId]
                   if (match && match.state.status === "running") {
+                    let snapshotFiles: string[] | undefined
+                    if (match.snapshot) {
+                      const patch = await Snapshot.patch(match.snapshot)
+                      snapshotFiles = patch.files
+                    }
                     await Session.updatePart({
                       ...match,
+                      snapshotFiles,
                       state: {
                         status: "error",
                         input: value.input ?? match.state.input,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -213,8 +213,14 @@ export namespace SessionProcessor {
                 case "tool-result": {
                   const match = toolcalls[value.toolCallId]
                   if (match && match.state.status === "running") {
+                    let snapshotFiles: string[] | undefined
+                    if (match.snapshot) {
+                      const patch = await Snapshot.patch(match.snapshot)
+                      snapshotFiles = patch.files
+                    }
                     await Session.updatePart({
                       ...match,
+                      snapshotFiles,
                       state: {
                         status: "completed",
                         input: value.input ?? match.state.input,

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -62,13 +62,11 @@ export namespace SessionRevert {
         const isTargetMessage = msg.info.id === revert!.messageID
         for (const part of msg.parts) {
           if (isTargetMessage && revert!.partID && part.id !== revert!.partID && part.id > revert!.partID) break
-          if (part.type === "tool" && part.snapshot) {
+          if (part.type === "tool" && part.snapshot && part.snapshotFiles) {
             if (part.state.status === "completed" || part.state.status === "error") {
-              const patchPart = msg.parts.find((p) => p.type === "patch" && "hash" in p && p.hash === part.snapshot)
-              const patchFiles = patchPart && "files" in patchPart ? patchPart.files : []
               toolPatches.push({
                 hash: part.snapshot,
-                files: patchFiles,
+                files: part.snapshotFiles,
               })
             }
           }

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -42,7 +42,6 @@ export namespace SessionRevert {
 
         if (!revert) {
           if ((msg.info.id === input.messageID && !input.partID) || part.id === input.partID) {
-            // if no useful parts left in message, same as reverting whole message
             const partID = remaining.some((item) => ["text", "tool"].includes(item.type)) ? input.partID : undefined
             revert = {
               messageID: !partID && lastUser ? lastUser.id : msg.info.id,
@@ -55,29 +54,48 @@ export namespace SessionRevert {
     }
 
     if (revert) {
-      const session = await Session.get(input.sessionID)
-      revert.snapshot = session.revert?.snapshot ?? (await Snapshot.track())
-
-      // kilocode_change start - compute diffs BEFORE reverting files so the diff
-      // reflects changes being undone (files on disk still have AI modifications)
       const rangeMessages = all.filter((msg) => msg.info.id >= revert!.messageID)
-      const diffs = await SessionSummary.computeDiff({ messages: rangeMessages })
-      await Snapshot.revert(patches)
-      if (revert.snapshot) revert.diff = await Snapshot.diff(revert.snapshot)
-      // kilocode_change end
+
+      const toolPatches: Snapshot.Patch[] = []
+
+      for (const msg of rangeMessages) {
+        for (const part of msg.parts) {
+          if (part.type === "tool" && part.snapshot) {
+            const toolPatch = await Snapshot.patch(part.snapshot)
+            if (toolPatch.files.length) {
+              toolPatches.push(toolPatch)
+            }
+          }
+        }
+      }
+
+      let diffs: Snapshot.FileDiff[]
+
+      if (toolPatches.length > 0) {
+        await Snapshot.revert(toolPatches)
+        if (toolPatches[0]?.hash) {
+          diffs = await Snapshot.diffFull(toolPatches[0].hash, "HEAD")
+        } else {
+          diffs = []
+        }
+      } else {
+        revert.snapshot = session.revert?.snapshot ?? (await Snapshot.track())
+        diffs = await SessionSummary.computeDiff({ messages: rangeMessages })
+        await Snapshot.revert(patches)
+        if (revert.snapshot) revert.diff = await Snapshot.diff(revert.snapshot)
+      }
+
       await Storage.write(["session_diff", input.sessionID], diffs)
       Bus.publish(Session.Event.Diff, {
         sessionID: input.sessionID,
         diff: diffs,
       })
-      // kilocode_change start - strip full file contents before persisting to DB
       const summaryDiffs = diffs.map((d) => ({
         file: d.file,
         additions: d.additions,
         deletions: d.deletions,
         status: d.status,
       }))
-      // kilocode_change end
       return Session.setRevert({
         sessionID: input.sessionID,
         revert,
@@ -85,7 +103,7 @@ export namespace SessionRevert {
           additions: diffs.reduce((sum, x) => sum + x.additions, 0),
           deletions: diffs.reduce((sum, x) => sum + x.deletions, 0),
           files: diffs.length,
-          diffs: summaryDiffs, // kilocode_change
+          diffs: summaryDiffs,
         },
       })
     }

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -59,11 +59,17 @@ export namespace SessionRevert {
       const toolPatches: Snapshot.Patch[] = []
 
       for (const msg of rangeMessages) {
+        const isTargetMessage = msg.info.id === revert!.messageID
         for (const part of msg.parts) {
+          if (isTargetMessage && revert!.partID && part.id !== revert!.partID && part.id > revert!.partID) break
           if (part.type === "tool" && part.snapshot) {
-            const toolPatch = await Snapshot.patch(part.snapshot)
-            if (toolPatch.files.length) {
-              toolPatches.push(toolPatch)
+            if (part.state.status === "completed" || part.state.status === "error") {
+              const patchPart = msg.parts.find((p) => p.type === "patch" && "hash" in p && p.hash === part.snapshot)
+              const patchFiles = patchPart && "files" in patchPart ? patchPart.files : []
+              toolPatches.push({
+                hash: part.snapshot,
+                files: patchFiles,
+              })
             }
           }
         }
@@ -73,17 +79,19 @@ export namespace SessionRevert {
 
       if (toolPatches.length > 0) {
         await Snapshot.revert(toolPatches)
-        if (toolPatches[0]?.hash) {
-          diffs = await Snapshot.diffFull(toolPatches[0].hash, "HEAD")
+        const revertedHash = toolPatches[0]?.hash
+        if (revertedHash) {
+          diffs = await Snapshot.diffFull(revertedHash, "HEAD")
         } else {
           diffs = []
         }
       } else {
-        revert.snapshot = session.revert?.snapshot ?? (await Snapshot.track())
         diffs = await SessionSummary.computeDiff({ messages: rangeMessages })
         await Snapshot.revert(patches)
-        if (revert.snapshot) revert.diff = await Snapshot.diff(revert.snapshot)
       }
+
+      revert.snapshot = session.revert?.snapshot ?? (await Snapshot.track())
+      if (revert.snapshot) revert.diff = await Snapshot.diff(revert.snapshot)
 
       await Storage.write(["session_diff", input.sessionID], diffs)
       Bus.publish(Session.Event.Diff, {


### PR DESCRIPTION
This fix addresses the checkpoint issue where snapshots were only created on the first LLM response (start-step) instead of before each file edit.

Changes:
- Add snapshot field to ToolPart schema in message-v2.ts
- Track snapshot before each file-modifying tool execution (edit, write, apply_patch, bash, task)
- Update revert.ts to use per-tool snapshots when available, falling back to session snapshot

The fix ensures:
1. Checkpoints appear before ANY file editing, not just the first prompt
2. Each edit tool execution has its own snapshot for accurate revert
3. User files are not affected by revert (only Kilo-modified files are reverted)

Fixes: Kilo-Org/kilocode#8511

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
