### PR TITLE
fix(vscode): retry transient fetch failures in session.command and promptAsync

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -38,6 +38,7 @@ import { getWorkspaceRoot } from "./review-utils"
 import { MarketplaceService } from "./services/marketplace"
 import { resolveProjectDirectory } from "./project-directory"
 import { getBusySessionCount, seedSessionStatuses } from "./session-status"
+import { retry } from "./services/cli-backend/retry"
 import { slimPart, slimParts } from "./kilo-provider/slim-metadata"
 import { matchFollowup, recordFollowup, type Followup } from "./kilo-provider/followup-session"
 // legacy-migration start
@@ -281,7 +282,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // Use fire-and-forget (no throwOnError) to match old getProfile() which returned null on error.
     if (this.connectionState === "connected" && this.client) {
       console.log("[Kilo New] KiloProvider: 👤 syncWebviewState fetching profile...")
-      const profileResult = await this.client.kilo.profile()
+      const profileResult = await retry(() => this.client!.kilo.profile())
       const profileData = profileResult.data ?? null
       console.log("[Kilo New] KiloProvider: 👤 syncWebviewState profile:", profileData ? "received" : "null")
       this.postMessage({
@@ -1225,9 +1226,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     try {
       const workspaceDir = this.getWorkspaceDirectory(sessionID)
-      const { data: messagesData } = await this.client.session.messages(
-        { sessionID, directory: workspaceDir },
-        { throwOnError: true, signal: abort.signal },
+      const { data: messagesData } = await retry(() =>
+        this.client!.session.messages(
+          { sessionID, directory: workspaceDir },
+          { throwOnError: true, signal: abort.signal },
+        ),
       )
 
       // If this request was aborted while awaiting, skip posting stale results
@@ -1328,9 +1331,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     try {
       const workspaceDir = this.getWorkspaceDirectory(sessionID)
-      const { data: messagesData } = await this.client.session.messages(
-        { sessionID, directory: workspaceDir },
-        { throwOnError: true },
+      const { data: messagesData } = await retry(() =>
+        this.client!.session.messages({ sessionID, directory: workspaceDir }, { throwOnError: true }),
       )
 
       const messages = messagesData.map((m) => ({
@@ -1600,7 +1602,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     try {
       const workspaceDir = this.getWorkspaceDirectory()
-      const { data: agents } = await this.client.app.agents({ directory: workspaceDir }, { throwOnError: true })
+      const { data: agents } = await retry(() =>
+        this.client!.app.agents({ directory: workspaceDir }, { throwOnError: true }),
+      )
 
       const { visible, defaultAgent } = filterVisibleAgents(agents)
 
@@ -1634,7 +1638,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     try {
       const workspaceDir = this.getWorkspaceDirectory()
-      const { data: skills } = await this.client.app.skills({ directory: workspaceDir }, { throwOnError: true })
+      const { data: skills } = await retry(() =>
+        this.client!.app.skills({ directory: workspaceDir }, { throwOnError: true }),
+      )
 
       const message = {
         type: "skillsLoaded",
@@ -1657,7 +1663,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     try {
       const dir = this.getWorkspaceDirectory()
-      const { data: commands } = await this.client.command.list({ directory: dir }, { throwOnError: true })
+      const { data: commands } = await retry(() =>
+        this.client!.command.list({ directory: dir }, { throwOnError: true }),
+      )
 
       const message = {
         type: "commandsLoaded",
@@ -1679,7 +1687,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (!this.client) return undefined
     try {
       const dir = this.getWorkspaceDirectory()
-      const { data } = await this.client.app.skills({ directory: dir }, { throwOnError: true })
+      const { data } = await retry(() => this.client!.app.skills({ directory: dir }, { throwOnError: true }))
       return data
     } catch (error) {
       console.error("[Kilo New] KiloProvider: Failed to fetch CLI skills for marketplace:", error)
@@ -1787,7 +1795,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     try {
       const directory = this.getWorkspaceDirectory()
-      const { data } = await this.client.mcp.status({ directory })
+      const { data } = await retry(() => this.client!.mcp.status({ directory }))
       if (data) {
         const message = { type: "mcpStatusLoaded", status: data }
         this.cachedMcpStatusMessage = message
@@ -1898,7 +1906,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     try {
       const workspaceDir = this.getWorkspaceDirectory()
-      const { data: config } = await this.client.config.get({ directory: workspaceDir }, { throwOnError: true })
+      const { data: config } = await retry(() =>
+        this.client!.config.get({ directory: workspaceDir }, { throwOnError: true }),
+      )
 
       const message = {
         type: "configLoaded",
@@ -1945,7 +1955,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (!this.client || this.connectionState !== "connected") return
     try {
       const dir = this.getWorkspaceDirectory()
-      const { data: config } = await this.client.config.get({ directory: dir }, { throwOnError: true })
+      const { data: config } = await retry(() => this.client!.config.get({ directory: dir }, { throwOnError: true }))
       this.cachedConfigMessage = { type: "configLoaded", config }
       this.postMessage({ type: "configUpdated", config })
     } catch (error) {
@@ -1978,7 +1988,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     try {
-      const { data: all } = await this.client.kilo.notifications(undefined, { throwOnError: true })
+      const { data: all } = await retry(() => this.client!.kilo.notifications(undefined, { throwOnError: true }))
       const notifications = all.filter((n) => !n.showIn || n.showIn.includes("extension"))
       const existing = this.extensionContext?.globalState.get<string[]>("kilo.dismissedNotificationIds", []) ?? []
       const active = new Set(notifications.map((n) => n.id))
@@ -2093,7 +2103,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       // Config.state is reset by updateGlobal (via Instance.resetStateEntry) so
       // config.get() returns fresh data without a full dispose cycle.
       const dir = this.getWorkspaceDirectory()
-      const { data: merged } = await this.client.config.get({ directory: dir }, { throwOnError: true })
+      const { data: merged } = await retry(() => this.client!.config.get({ directory: dir }, { throwOnError: true }))
 
       this.cachedConfigMessage = { type: "configLoaded", config: merged }
       this.postMessage({ type: "configUpdated", config: merged })

--- a/packages/kilo-vscode/src/services/cli-backend/retry.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/retry.ts
@@ -1,0 +1,34 @@
+// Replicated from packages/util/src/retry.ts to avoid adding @opencode-ai/util
+// as a dependency of the extension. Keep in sync with the original.
+
+const TRANSIENT = [
+  "load failed",
+  "network connection was lost",
+  "network request failed",
+  "failed to fetch",
+  "fetch failed",
+  "econnreset",
+  "econnrefused",
+  "etimedout",
+  "socket hang up",
+]
+
+function transient(error: unknown): boolean {
+  if (!error) return false
+  const msg = String(error instanceof Error ? error.message : error).toLowerCase()
+  return TRANSIENT.some((m) => msg.includes(m))
+}
+
+export async function retry<T>(fn: () => Promise<T>, attempts = 3, delay = 500): Promise<T> {
+  let last: unknown
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn()
+    } catch (error) {
+      last = error
+      if (i === attempts - 1 || !transient(error)) throw error
+      await new Promise((r) => setTimeout(r, delay * 2 ** i))
+    }
+  }
+  throw last
+}

--- a/packages/kilo-vscode/tests/unit/retry.test.ts
+++ b/packages/kilo-vscode/tests/unit/retry.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "bun:test"
+import { retry } from "../../src/services/cli-backend/retry"
+
+describe("retry", () => {
+  it("returns on first success", async () => {
+    const result = await retry(() => Promise.resolve(42))
+    expect(result).toBe(42)
+  })
+
+  it("retries transient errors and succeeds", async () => {
+    let calls = 0
+    const result = await retry(
+      () => {
+        calls++
+        if (calls < 3) throw new TypeError("fetch failed")
+        return Promise.resolve("ok")
+      },
+      3,
+      10,
+    )
+    expect(result).toBe("ok")
+    expect(calls).toBe(3)
+  })
+
+  it("throws immediately on non-transient errors", async () => {
+    let calls = 0
+    await expect(
+      retry(
+        () => {
+          calls++
+          throw new Error("404 not found")
+        },
+        3,
+        10,
+      ),
+    ).rejects.toThrow("404 not found")
+    expect(calls).toBe(1)
+  })
+
+  it("throws after exhausting attempts on transient errors", async () => {
+    let calls = 0
+    await expect(
+      retry(
+        () => {
+          calls++
+          throw new Error("ECONNREFUSED")
+        },
+        3,
+        10,
+      ),
+    ).rejects.toThrow("ECONNREFUSED")
+    expect(calls).toBe(3)
+  })
+
+  it("detects all transient error messages", async () => {
+    const messages = [
+      "load failed",
+      "network connection was lost",
+      "network request failed",
+      "failed to fetch",
+      "fetch failed",
+      "ECONNRESET",
+      "ECONNREFUSED",
+      "ETIMEDOUT",
+      "socket hang up",
+    ]
+    for (const msg of messages) {
+      let calls = 0
+      await retry(
+        () => {
+          calls++
+          if (calls === 1) throw new Error(msg)
+          return Promise.resolve(true)
+        },
+        2,
+        10,
+      )
+      expect(calls).toBe(2)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Recovery of PR #7948 which was merged at 16:16 UTC but lost when kilo-maintainer[bot] force-pushed release v7.1.23 on a stale base at 16:19 UTC, overwriting the merge.

This is a clean cherry-pick of the original commits onto current main.

### Original PR description

- Scope retry to read-only SDK calls, remove from mutations
- Retry transient fetch failures in session.command and promptAsync