### PR TITLE
feat(agent-manager): show branch name as subtitle in worktree sidebar

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -793,6 +793,11 @@ const AgentManagerContent: Component = () => {
     return firstOrderedTitle(sessions, worktreeTabOrder()[wt.id], wt.branch)
   }
 
+  const worktreeSubtitle = (wt: WorktreeState): string | undefined => {
+    const label = worktreeLabel(wt)
+    return label !== wt.branch ? wt.branch : undefined
+  }
+
   const isStaleWorktree = (worktreeId: string): boolean => staleWorktreeIds().has(worktreeId)
 
   /** True when any session in the given ID list is actively working (busy/retry and not blocked by permissions/questions). */
@@ -2322,6 +2327,7 @@ const AgentManagerContent: Component = () => {
                                 <WorktreeItem
                                   worktree={wt}
                                   label={worktreeLabel(wt)}
+                                  subtitle={worktreeSubtitle(wt)}
                                   active={selection() === wt.id}
                                   pendingDelete={pendingDelete() === wt.id}
                                   busy={busyWorktrees().has(wt.id)}

--- a/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
@@ -22,6 +22,8 @@ interface WorktreeItemProps {
   worktree: WorktreeState
   /** Display label (resolved from label, first session title, or branch). */
   label: string
+  /** Branch name shown as subtitle when it differs from the label. */
+  subtitle?: string
   active: boolean
   pendingDelete: boolean
   busy: boolean
@@ -262,8 +264,11 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
                       </div>
                     </div>
                   </div>
-                  {/* Row 2: always rendered for consistent height; PR badge or skeleton */}
+                  {/* Row 2: branch subtitle + PR badge */}
                   <div class="am-wt-row2">
+                    <Show when={props.subtitle}>
+                      <span class="am-worktree-subtitle">{props.subtitle}</span>
+                    </Show>
                     <Show
                       when={props.pr}
                       fallback={

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -62,8 +62,7 @@
 }
 
 .am-local-item-active .am-local-branch {
-  color: var(--text-on-interactive-base);
-  opacity: 0.7;
+  color: color-mix(in srgb, var(--text-on-interactive-base) 70%, transparent);
 }
 
 .am-local-item-active .am-stat-files {
@@ -92,8 +91,8 @@
 }
 
 .am-local-branch {
-  font-size: var(--font-size-small);
-  color: var(--text-weak);
+  font-size: 10px;
+  color: var(--text-weaker);
   line-height: 1.2;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -258,8 +257,23 @@ button.am-section-toggle:hover .am-section-label {
 .am-wt-row2 {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  gap: 6px;
   min-height: 14px;
+}
+
+.am-worktree-subtitle {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10px;
+  color: var(--text-weaker);
+  line-height: 1.2;
+  min-width: 0;
+}
+
+.am-worktree-item-active .am-worktree-subtitle {
+  color: color-mix(in srgb, var(--text-on-interactive-base) 70%, transparent);
 }
 
 .am-worktree-item:hover {
@@ -373,7 +387,8 @@ button.am-section-toggle:hover .am-section-label {
   background: color-mix(in srgb, var(--surface-critical-strong) 25%, transparent);
 }
 
-.am-worktree-pending-delete .am-worktree-branch {
+.am-worktree-pending-delete .am-worktree-branch,
+.am-worktree-pending-delete .am-worktree-subtitle {
   opacity: 0.5;
   transition: opacity 200ms ease;
 }
@@ -490,6 +505,7 @@ button.am-section-toggle:hover .am-section-label {
   animation: am-skeleton-pulse 1.5s ease-in-out infinite;
   animation-delay: 0.3s;
   opacity: 0;
+  margin-left: auto;
 }
 
 .am-stat-files {
@@ -520,6 +536,7 @@ button.am-section-toggle:hover .am-section-label {
   font-weight: 500;
   font-variant-numeric: tabular-nums;
   transition: background 150ms ease;
+  margin-left: auto;
 }
 .am-pr-badge:hover {
   background: color-mix(in srgb, var(--pr-accent) 25%, transparent);


### PR DESCRIPTION
## Summary
- Display the git branch name as a subtitle beneath the worktree label when it differs from the display name (e.g. when a session title or user-set label is shown)
- Align the local card's branch text style to match worktree subtitles (10px, `--text-weaker`, consistent active state via `color-mix`)
- Branch subtitle shares row2 with the PR badge, hidden during rename and pending-delete states

<img width="487" height="510" alt="image" src="https://github.com/user-attachments/assets/dfda6f26-0041-46a7-8f15-4adc889ce3ce" />
