### PR TITLE
Cli - Add CI check for kilocode_change annotations

### DIFF
--- a/.github/workflows/check-opencode-annotations.yml
+++ b/.github/workflows/check-opencode-annotations.yml
@@ -1,0 +1,31 @@
+name: Check opencode annotations
+
+on:
+  pull_request:
+    paths:
+      - "packages/opencode/**"
+      - "script/check-opencode-annotations.ts"
+      - ".github/workflows/check-opencode-annotations.yml"
+  workflow_dispatch:
+
+jobs:
+  check-annotations:
+    name: Check kilocode_change annotations
+    if: github.repository == 'Kilo-Org/kilocode'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Check kilocode_change annotations in shared opencode files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ -n "$BASE_SHA" ]; then
+            bun run script/check-opencode-annotations.ts --base "$BASE_SHA"
+          else
+            echo "No PR base SHA available (workflow_dispatch without PR context) — skipping."
+          fi

--- a/.github/workflows/check-opencode-annotations.yml
+++ b/.github/workflows/check-opencode-annotations.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Kilo CLI is an open source AI coding agent that generates code from natural lang
 - **Knip** (unused exports): `bun run knip` from `packages/kilo-vscode/`. CI runs this — all exported types/functions must be imported somewhere. Remove or unexport unused exports before pushing.
 - **Source links**: After adding or changing URLs in `packages/kilo-vscode/`, `packages/kilo-vscode/webview-ui/`, or `packages/opencode/src/`, run `bun run script/extract-source-links.ts` from the repo root and commit the updated `packages/kilo-docs/source-links.md`. CI runs this check — the build fails if the file is stale.
 - **kilocode_change check**: `bun run check-kilocode-change` from `packages/kilo-vscode/`. CI runs this — `kilocode_change` is a marker for upstream merge conflicts and must not appear in `packages/kilo-vscode/` or `packages/kilo-ui/` (these are entirely Kilo Code additions). Remove the markers before pushing.
+- **opencode annotation check**: `bun run script/check-opencode-annotations.ts` from repo root. CI runs this on PRs touching `packages/opencode/` — every Kilo-specific change in shared opencode files must be annotated with `kilocode_change` markers. Exempt paths (no markers needed): `packages/opencode/src/kilocode/`, `packages/opencode/test/kilocode/`, and any path containing `kilocode` in the name.
 
 ## Products
 

--- a/packages/kilo-telemetry/src/events.ts
+++ b/packages/kilo-telemetry/src/events.ts
@@ -25,6 +25,9 @@ export enum TelemetryEvent {
   MCP_SERVER_CONNECTED = "MCP Server Connected",
   MCP_SERVER_ERROR = "MCP Server Error",
 
+  // Remote Events
+  REMOTE_CONNECTION_OPENED = "Remote Connection Opened",
+
   // Auth Events
   AUTH_SUCCESS = "Auth Success",
   AUTH_LOGOUT = "Auth Logout",

--- a/packages/kilo-telemetry/src/telemetry.ts
+++ b/packages/kilo-telemetry/src/telemetry.ts
@@ -184,6 +184,11 @@ export namespace Telemetry {
     track(TelemetryEvent.MCP_SERVER_ERROR, { server, error })
   }
 
+  // Remote
+  export function trackRemoteConnectionOpened() {
+    track(TelemetryEvent.REMOTE_CONNECTION_OPENED)
+  }
+
   // Auth
   export function trackAuthSuccess(provider: string) {
     track(TelemetryEvent.AUTH_SUCCESS, { provider })

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -17,6 +17,7 @@ import simpleGit from "simple-git"
 import { RemoteWS } from "@/kilo-sessions/remote-ws"
 import { RemoteSender } from "@/kilo-sessions/remote-sender"
 import { SessionStatus } from "@/session/status"
+import { Telemetry } from "@kilocode/kilo-telemetry"
 
 export namespace KiloSessions {
   const log = Log.create({ service: "kilo-sessions" })
@@ -293,6 +294,7 @@ export namespace KiloSessions {
 
       remote = { conn, sender, heartbeat }
       log.info("remote connection enabled")
+      Telemetry.trackRemoteConnectionOpened()
     })().finally(() => {
       if (remoteSeq === seq) enabling = undefined
     })

--- a/script/check-opencode-annotations.ts
+++ b/script/check-opencode-annotations.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env bun
+
+/**
+ * Verifies that every Kilo-specific change in shared packages/opencode/ files
+ * is annotated with a kilocode_change marker.
+ *
+ * Usage:
+ *   bun run script/check-opencode-annotations.ts                  # diff against origin/main
+ *   bun run script/check-opencode-annotations.ts --base <ref>     # diff against <ref>
+ *
+ * A line is "covered" if it:
+ *   - contains // kilocode_change                        (inline annotation)
+ *   - falls inside a // kilocode_change start/end block  (block annotation)
+ *   - is in a file whose first non-empty line is         (whole-file annotation)
+ *     // kilocode_change - new file
+ *   - is empty / whitespace-only                         (skipped)
+ *   - is itself a marker line                            (auto-covered)
+ *
+ * Exempt paths (no markers needed — entirely Kilo-specific):
+ *   - packages/opencode/src/kilocode/**
+ *   - packages/opencode/test/kilocode/**
+ *   - Any path containing "kilocode" in directory or filename
+ */
+
+import { spawnSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+
+const ROOT = path.resolve(import.meta.dir, "..")
+const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx"])
+
+const args = process.argv.slice(2)
+const baseIdx = args.indexOf("--base")
+const base = baseIdx !== -1 ? args[baseIdx + 1] : "origin/main"
+
+function run(cmd: string, args: string[]) {
+  const result = spawnSync(cmd, args, { cwd: ROOT, encoding: "utf8" })
+  return result.stdout?.trim() ?? ""
+}
+
+function isMergeCommit() {
+  const out = run("git", ["cat-file", "-p", "HEAD"])
+  return out.split("\n").filter((l) => l.startsWith("parent ")).length >= 2
+}
+
+function changedFiles() {
+  const out = run("git", ["diff", "--name-only", "--diff-filter=AMRT", `${base}...HEAD`, "--", "packages/opencode"])
+  return out ? out.split("\n").filter(Boolean) : []
+}
+
+function isExempt(file: string) {
+  const norm = file.replaceAll("\\", "/")
+  if (norm.includes("/kilocode/")) return true
+  if (path.basename(norm).includes("kilocode")) return true
+  return false
+}
+
+function isSource(file: string) {
+  return SOURCE_EXTS.has(path.extname(file))
+}
+
+function addedLines(file: string): Set<number> {
+  const diff = run("git", ["diff", "--unified=0", "--diff-filter=AMRT", `${base}...HEAD`, "--", file])
+  const out = new Set<number>()
+  for (const line of diff.split("\n")) {
+    const m = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/)
+    if (!m) continue
+    const start = Number(m[1])
+    const count = m[2] !== undefined ? Number(m[2]) : 1
+    for (let i = 0; i < count; i++) out.add(start + i)
+  }
+  return out
+}
+
+function coveredLines(text: string): { lines: string[]; covered: Set<number> } {
+  const lines = text.split(/\r?\n/)
+  const covered = new Set<number>()
+
+  // Whole-file annotation: first non-empty line is "// kilocode_change - new file"
+  const first = lines.find((x) => x.trim() !== "")
+  if (first?.match(/\/\/\s*kilocode_change\s*-\s*new\s*file\b/)) {
+    for (let i = 1; i <= lines.length; i++) covered.add(i)
+    return { lines, covered }
+  }
+
+  let block = false
+  for (let i = 0; i < lines.length; i++) {
+    const n = i + 1
+    const line = lines[i]
+
+    if (line.match(/\/\/\s*kilocode_change\s+start\b/)) {
+      block = true
+      covered.add(n)
+      continue
+    }
+
+    if (line.match(/\/\/\s*kilocode_change\s+end\b/)) {
+      covered.add(n)
+      block = false
+      continue
+    }
+
+    if (block) {
+      covered.add(n)
+      continue
+    }
+
+    if (line.match(/\/\/\s*kilocode_change\b/)) covered.add(n)
+  }
+
+  return { lines, covered }
+}
+
+// --- main ---
+
+if (isMergeCommit()) {
+  console.log("HEAD is a merge commit — skipping annotation check (upstream merge).")
+  process.exit(0)
+}
+
+const files = changedFiles().filter((f) => !isExempt(f) && isSource(f))
+
+if (files.length === 0) {
+  console.log("No shared opencode source files changed — nothing to check.")
+  process.exit(0)
+}
+
+const violations: string[] = []
+
+for (const file of files) {
+  const nums = addedLines(file)
+  if (nums.size === 0) continue
+
+  const abs = path.join(ROOT, file)
+  const text = readFileSync(abs, "utf8")
+  const { lines, covered } = coveredLines(text)
+
+  for (const n of nums) {
+    const line = lines[n - 1] ?? ""
+    const trim = line.trim()
+    if (!trim) continue
+    if (trim.match(/\/\/\s*kilocode_change\b/)) continue
+    if (!covered.has(n)) violations.push(`  ${file}:${n}: ${trim}`)
+  }
+}
+
+if (violations.length === 0) {
+  console.log("All shared opencode changes are annotated with kilocode_change markers.")
+  process.exit(0)
+}
+
+console.error(
+  [
+    "Unannotated Kilo changes found in shared opencode files:",
+    "",
+    ...violations,
+    "",
+    "Every Kilo-specific change in packages/opencode/ must be annotated.",
+    "",
+    "Inline (single line):",
+    "  const url = Flag.KILO_MODELS_URL || 'https://models.dev' // kilocode_change",
+    "",
+    "Block (multiple lines):",
+    "  // kilocode_change start",
+    "  ...",
+    "  // kilocode_change end",
+    "",
+    "New file:",
+    "  // kilocode_change - new file",
+    "",
+    "Exempt paths (no markers needed):",
+    "  - packages/opencode/src/kilocode/**",
+    "  - packages/opencode/test/kilocode/**",
+    "  - Any path containing 'kilocode' in the directory or filename",
+    "",
+    "See AGENTS.md for details.",
+  ].join("\n"),
+)
+
+process.exit(1)

--- a/script/check-opencode-annotations.ts
+++ b/script/check-opencode-annotations.ts
@@ -38,11 +38,6 @@ function run(cmd: string, args: string[]) {
   return result.stdout?.trim() ?? ""
 }
 
-function isMergeCommit() {
-  const out = run("git", ["cat-file", "-p", "HEAD"])
-  return out.split("\n").filter((l) => l.startsWith("parent ")).length >= 2
-}
-
 function changedFiles() {
   const out = run("git", ["diff", "--name-only", "--diff-filter=AMRT", `${base}...HEAD`, "--", "packages/opencode"])
   return out ? out.split("\n").filter(Boolean) : []
@@ -84,7 +79,7 @@ function coveredLines(text: string): { lines: string[]; covered: Set<number> } {
   let block = false
   for (let i = 0; i < lines.length; i++) {
     const n = i + 1
-    const line = lines[i]
+    const line = lines[i] ?? ""
 
     if (line.match(/\/\/\s*kilocode_change\s+start\b/)) {
       block = true
@@ -110,11 +105,6 @@ function coveredLines(text: string): { lines: string[]; covered: Set<number> } {
 }
 
 // --- main ---
-
-if (isMergeCommit()) {
-  console.log("HEAD is a merge commit — skipping annotation check (upstream merge).")
-  process.exit(0)
-}
 
 const files = changedFiles().filter((f) => !isExempt(f) && isSource(f))
 

--- a/script/check-opencode-annotations.ts
+++ b/script/check-opencode-annotations.ts
@@ -49,10 +49,8 @@ function changedFiles() {
 }
 
 function isExempt(file: string) {
-  const norm = file.replaceAll("\\", "/")
-  if (norm.includes("/kilocode/")) return true
-  if (path.basename(norm).includes("kilocode")) return true
-  return false
+  const norm = file.replaceAll("\\", "/").toLowerCase()
+  return norm.split("/").some((part) => part.includes("kilocode"))
 }
 
 function isSource(file: string) {


### PR DESCRIPTION
## Summary
- Add CI check script to verify `kilocode_change` annotations in shared opencode files
- Exempt paths containing `kilocode` in any segment from the annotation requirement
- Run the annotation check on PR head commits
- Add PostHog event tracking for when a remote connection is opened in the CLI