### PR TITLE
Cli - Track remote connection opened event in PostHog

### DIFF
--- a/packages/kilo-telemetry/src/events.ts
+++ b/packages/kilo-telemetry/src/events.ts
@@ -25,6 +25,9 @@ export enum TelemetryEvent {
   MCP_SERVER_CONNECTED = "MCP Server Connected",
   MCP_SERVER_ERROR = "MCP Server Error",
 
+  // Remote Events
+  REMOTE_CONNECTION_OPENED = "Remote Connection Opened",
+
   // Auth Events
   AUTH_SUCCESS = "Auth Success",
   AUTH_LOGOUT = "Auth Logout",

--- a/packages/kilo-telemetry/src/telemetry.ts
+++ b/packages/kilo-telemetry/src/telemetry.ts
@@ -184,6 +184,11 @@ export namespace Telemetry {
     track(TelemetryEvent.MCP_SERVER_ERROR, { server, error })
   }
 
+  // Remote
+  export function trackRemoteConnectionOpened() {
+    track(TelemetryEvent.REMOTE_CONNECTION_OPENED)
+  }
+
   // Auth
   export function trackAuthSuccess(provider: string) {
     track(TelemetryEvent.AUTH_SUCCESS, { provider })

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -17,6 +17,7 @@ import simpleGit from "simple-git"
 import { RemoteWS } from "@/kilo-sessions/remote-ws"
 import { RemoteSender } from "@/kilo-sessions/remote-sender"
 import { SessionStatus } from "@/session/status"
+import { Telemetry } from "@kilocode/kilo-telemetry"
 
 export namespace KiloSessions {
   const log = Log.create({ service: "kilo-sessions" })
@@ -293,6 +294,7 @@ export namespace KiloSessions {
 
       remote = { conn, sender, heartbeat }
       log.info("remote connection enabled")
+      Telemetry.trackRemoteConnectionOpened()
     })().finally(() => {
       if (remoteSeq === seq) enabling = undefined
     })


### PR DESCRIPTION
## Summary
- Add PostHog event tracking for when a remote connection is opened in the CLI
- Track this event in kilo-sessions when a remote connection is established