### PR TITLE
fix(cli&vsc): agent continues loop when todos are pending (#8476)

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -399,6 +399,7 @@ export namespace SessionPrompt {
             // kilocode_change start - preserve per-turn metadata so auto-continuation
             // inherits structured-output format, tool overrides, and editor context
             format: lastUser.format,
+            system: lastUser.system,
             tools: lastUser.tools,
             variant: lastUser.variant,
             editorContext: lastUser.editorContext,
@@ -615,6 +616,10 @@ ${pendingList}
             },
             agent: lastUser.agent,
             model: lastUser.model,
+            format: lastUser.format,
+            system: lastUser.system,
+            tools: lastUser.tools,
+            variant: lastUser.variant,
             editorContext: lastUser.editorContext, // kilocode_change — preserve editor context
           }
           await Session.updateMessage(summaryUserMsg)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -368,14 +368,12 @@ export namespace SessionPrompt {
         !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
         lastUser.id < lastAssistant.id
       ) {
-        // kilocode_change start - ask follow-up when plan_exit tool was called
+        // kilocode_change start - fix #8476: ask follow-up or continue loop with pending todos
         if (shouldAskPlanFollowup({ messages: msgs, abort })) {
           const action = await PlanFollowup.ask({ sessionID, messages: msgs, abort })
           if (action === "continue") continue
         }
-        // kilocode_change end
 
-        // kilocode_change start - fix #8476: continue loop with pending todos
         const pending = Todo.get(sessionID).filter(
           (t) => t.status === "pending" || t.status === "in_progress",
         )
@@ -396,14 +394,11 @@ export namespace SessionPrompt {
             time: { created: Date.now() },
             agent: lastUser.agent,
             model: lastUser.model,
-            // kilocode_change start - preserve per-turn metadata so auto-continuation
-            // inherits structured-output format, tool overrides, and editor context
             format: lastUser.format,
             system: lastUser.system,
             tools: lastUser.tools,
             variant: lastUser.variant,
             editorContext: lastUser.editorContext,
-            // kilocode_change end
           })
           await Session.updatePart({
             id: Identifier.ascending("part"),
@@ -424,13 +419,13 @@ ${pendingList}
             pendingCount: pending.length,
           })
         }
-        // kilocode_change end
 
         log.info("exiting loop", { sessionID })
         break
       }
+      // kilocode_change end
 
-      step++
+      step++ // kilocode_change
       if (step === 1)
         ensureTitle({
           session,
@@ -603,6 +598,7 @@ ${pendingList}
           } satisfies MessageV2.ToolPart)
         }
 
+        // kilocode_change start - synthetic summary turn for reasoning models
         if (task.command) {
           // Add synthetic user message to prevent certain reasoning models from erroring
           // If we create assistant messages w/ out user ones following mid loop thinking signatures
@@ -620,7 +616,7 @@ ${pendingList}
             system: lastUser.system,
             tools: lastUser.tools,
             variant: lastUser.variant,
-            editorContext: lastUser.editorContext, // kilocode_change — preserve editor context
+            editorContext: lastUser.editorContext,
           }
           await Session.updateMessage(summaryUserMsg)
           await Session.updatePart({
@@ -632,6 +628,7 @@ ${pendingList}
             synthetic: true,
           } satisfies MessageV2.TextPart)
         }
+        // kilocode_change end
 
         continue
       }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -396,6 +396,13 @@ export namespace SessionPrompt {
             time: { created: Date.now() },
             agent: lastUser.agent,
             model: lastUser.model,
+            // kilocode_change start - preserve per-turn metadata so auto-continuation
+            // inherits structured-output format, tool overrides, and editor context
+            format: lastUser.format,
+            tools: lastUser.tools,
+            variant: lastUser.variant,
+            editorContext: lastUser.editorContext,
+            // kilocode_change end
           })
           await Session.updatePart({
             id: Identifier.ascending("part"),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -46,6 +46,7 @@ import { LLM } from "./llm"
 import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncation"
+import { Todo } from "./todo" // kilocode_change - fix #8476: continue loop with pending todos
 import { PlanFollowup } from "@/kilocode/plan-followup" // kilocode_change
 import { environmentDetails } from "@/kilocode/editor-context" // kilocode_change
 
@@ -331,6 +332,7 @@ export namespace SessionPrompt {
     let envUser: string | undefined
 
     let step = 0
+    let reminders = 0 // kilocode_change - fix #8476: resets per user turn, tracks reminder injections
     const session = await Session.get(sessionID)
     while (true) {
       SessionStatus.set(sessionID, { type: "busy" })
@@ -372,6 +374,50 @@ export namespace SessionPrompt {
           if (action === "continue") continue
         }
         // kilocode_change end
+
+        // kilocode_change start - fix #8476: continue loop with pending todos
+        const pending = Todo.get(sessionID).filter(
+          (t) => t.status === "pending" || t.status === "in_progress",
+        )
+        if (pending.length > 0 && reminders < 3) {
+          reminders++
+          step++ // respect agent's maxSteps limit
+          log.info("continuing loop with pending todos", {
+            sessionID,
+            pendingCount: pending.length,
+            reminders,
+          })
+          const pendingList = pending.map((t) => `- [${t.status}] ${t.content}`).join("\n")
+          const synthMsgId = Identifier.ascending("message")
+          await Session.updateMessage({
+            id: synthMsgId,
+            sessionID,
+            role: "user",
+            time: { created: Date.now() },
+            agent: lastUser.agent,
+            model: lastUser.model,
+          })
+          await Session.updatePart({
+            id: Identifier.ascending("part"),
+            sessionID,
+            messageID: synthMsgId,
+            type: "text",
+            text: `<system-reminder>
+You have ${pending.length} pending task(s) remaining. Please continue working on them:
+${pendingList}
+</system-reminder>`,
+            synthetic: true,
+          })
+          continue
+        }
+        if (pending.length > 0) {
+          log.info("reminder limit reached, exiting with pending todos", {
+            sessionID,
+            pendingCount: pending.length,
+          })
+        }
+        // kilocode_change end
+
         log.info("exiting loop", { sessionID })
         break
       }


### PR DESCRIPTION
## Context

Fixes #8476 where the AI agent prematurely stops its working loop after creating a todo list instead of continuing naturally to complete the pending tasks. 

Previously, the session processing loop would exit immediately whenever the language model returned a finish reason other than "tool-calls" or "unknown". This caused the agent to stop after simply writing out the task list using the `todowrite` tool, forcing the user to manually send a follow-up message to resume the session.

## Implementation

This PR completely resolves the issue by intercepting the exit sequence and injecting an automatic system reminder if tasks are left in a pending state:

- **Todo State Inspection**: Before exiting the main loop, we now query `Todo.get(sessionID)` to check for items marked as `pending` or `in_progress`.
- **Synthetic Reminder Messages**: If unresolved tasks exist, we programmatically construct and inject a new `<system-reminder>` user message containing the remaining task list. This signals the LLM to resume executing tools for the unfinished work.
- **Runaway Loop Guard**: To prevent infinite loops if the LLM gets stuck, we've introduced a `reminders` tracker that restricts auto-continuations to a maximum of 3 times per user turn. Upon hitting this cap, it gracefully falls through to the standard exit log.
- **Respect Boundaries**: The synthetic injected turn correctly increments the `step` counter before `continue`, ensuring that the new cycles continue to strictly honor the configured `maxSteps` limits of the agent.

## Edge Cases Handled

1. **Infinite Loops via Agent Stalling:** If an agent gets "stuck" returning standard text without invoking the tool or completing its tasks, the loop could run forever. We mitigated this by introducing a strict cap of 3 reminders per turn (`reminders < 3`), guaranteeing an eventual graceful exit.
2. **Step Counter Evasion:** By manually incrementing `step++` before triggering the `continue` statement, we ensured that synthetic reminder turns correctly count toward the agent's `maxSteps` allowance, preventing the agent from bypassing its configured token or iteration bounds.
3. **Database Memory Leaks**: Rather than attempting to track reminder states dynamically through the heavyweight `Instance.state()` key mapping, we utilize a lightweight, per-turn `let reminders = 0` counter exactly where it's needed—safely resetting upon actual un-synthetic user replies while safely persisting across internal sub-loops.
4. **Conversation Threading Integrity:** The synthetic user message is created with `Identifier.ascending("message")`. This avoids schema-breaking `parentID` mutations on the `User` tree, seamlessly ensuring that the next loop iteration organically picks it up as the correct `lastUser` prompt.

## UX Impact

Because the injection is processed as a standard user message, it is perfectly visible in the UI chat window. The system renders the generated `<system-reminder>` tag containing the list of pending tasks explicitly to the user. This creates a highly transparent user experience: 
- Users are never confused as to why the agent is unexpectedly thinking for a longer duration.
- It proves to the user that the system is actively monitoring and self-correcting the agent's work.
- It guarantees that the user always has full context about what specific tasks the agent still considers "pending."

## Screenshots

**What was changed in `packages/opencode/src/session/prompt.ts`:**

### Before
```typescript
      if (
        lastAssistant?.finish &&
        !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
        lastUser.id < lastAssistant.id
      ) {
        // kilocode_change start - ask follow-up when plan_exit tool was called
        if (shouldAskPlanFollowup({ messages: msgs, abort })) {
          const action = await PlanFollowup.ask({ sessionID, messages: msgs, abort })
          if (action === "continue") continue
        }
        // kilocode_change end

        log.info("exiting loop", { sessionID })
        break
      }
```

### After
```typescript
    let step = 0
    let reminders = 0 // kilocode_change - fix #8476: resets per user turn, tracks reminder injections
    const session = await Session.get(sessionID)
    while (true) {
// ...
      if (
        lastAssistant?.finish &&
        !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
        lastUser.id < lastAssistant.id
      ) {
        // kilocode_change start - ask follow-up when plan_exit tool was called
        if (shouldAskPlanFollowup({ messages: msgs, abort })) {
          const action = await PlanFollowup.ask({ sessionID, messages: msgs, abort })
          if (action === "continue") continue
        }
        // kilocode_change end

        // kilocode_change start - fix #8476: continue loop with pending todos
        const pending = Todo.get(sessionID).filter(
          (t) => t.status === "pending" || t.status === "in_progress",
        )
        if (pending.length > 0 && reminders < 3) {
          reminders++
          step++ // respect agent's maxSteps limit
          log.info("continuing loop with pending todos", {
            sessionID,
            pendingCount: pending.length,
            reminders,
          })
          const pendingList = pending.map((t) => `- [${t.status}] ${t.content}`).join("\n")
          const synthMsgId = Identifier.ascending("message")
          await Session.updateMessage({
            id: synthMsgId,
            sessionID,
            role: "user",
            time: { created: Date.now() },
            agent: lastUser.agent,
            model: lastUser.model,
          })
          await Session.updatePart({
            id: Identifier.ascending("part"),
            sessionID,
            messageID: synthMsgId,
            type: "text",
            text: `<system-reminder>
You have ${pending.length} pending task(s) remaining. Please continue working on them:
${pendingList}
</system-reminder>`,
            synthetic: true,
          })
          continue
        }
        if (pending.length > 0) {
          log.info("reminder limit reached, exiting with pending todos", {
            sessionID,
            pendingCount: pending.length,
          })
        }
        // kilocode_change end

        log.info("exiting loop", { sessionID })
        break
      }
```

## How to Test

1. Start Kilo CLI or launch the Kilo Code VS Code extension in dev mode.
2. Provide a prompt to the agent: "Create a todo list with 3 dummy items and then do them".
3. Verify that the agent uses the `todowrite` tool.
4. When the agent attempts to stop without completing the task list, a synthetic user message with the `<system-reminder>` tag should automatically appear in the chat log, urging it to continue working on pending issues.
5. Watch the model auto-continue without manual user babysitting, successfully fulfilling request #8476.
6. To test the limiter, you can hard code the model to finish instantly in the core loop and observe that it stops after exactly 3 injected system reminders.

## Get in Touch

<!-- Please share your Discord handle here -->
