### PR TITLE
fix(vscode): show stop button during rate limit retry state

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -244,7 +244,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   window.addEventListener("compactSession", onCompact)
   onCleanup(() => window.removeEventListener("compactSession", onCompact))
 
-  const isBusy = () => session.status() === "busy"
+  const isBusy = () => session.status() !== "idle"
   const isDisabled = () => !server.isConnected()
   const hasInput = () => text().trim().length > 0 || imageAttach.images().length > 0 || reviewComments().length > 0
   const canSend = () => hasInput() && !isDisabled() && !props.blocked?.()


### PR DESCRIPTION
## Summary

- The PromptInput `isBusy()` check only matched `"busy"` status, so the stop button and Escape-to-abort were disabled during `"retry"` state (rate limit). Changed to `status !== "idle"` so users can always abort, including during rate limit retries.

## Changes

One-line fix in `PromptInput.tsx`:
```diff
- const isBusy = () => session.status() === "busy"
+ const isBusy = () => session.status() !== "idle"
```

<img width="456" height="361" alt="image" src="https://github.com/user-attachments/assets/b1a9c028-2851-489c-b1aa-4403667c2645" />


This also correctly blocks the Enhance button and enables Escape-key abort during retry state.