### PR TITLE
feat(cli): monitor and recover from bad MCPs, LSPs, and plugins

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -677,6 +677,15 @@ export namespace Config {
         .positive()
         .optional()
         .describe("Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified."),
+      // kilocode_change start
+      memoryLimit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Memory limit in MB for the MCP server process. Kills the process if exceeded. Default: 512"),
+      autoReconnect: z.boolean().optional().describe("Automatically reconnect when the server crashes. Default: true"),
+      // kilocode_change end
     })
     .strict()
     .meta({
@@ -716,6 +725,12 @@ export namespace Config {
         .positive()
         .optional()
         .describe("Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified."),
+      // kilocode_change start
+      autoReconnect: z
+        .boolean()
+        .optional()
+        .describe("Automatically reconnect when the server disconnects. Default: true"),
+      // kilocode_change end
     })
     .strict()
     .meta({
@@ -1249,6 +1264,7 @@ export namespace Config {
               command: z.array(z.string()).optional(),
               environment: z.record(z.string(), z.string()).optional(),
               extensions: z.array(z.string()).optional(),
+              timeout: z.number().int().positive().optional(), // kilocode_change - execution timeout in seconds
             }),
           ),
         ])
@@ -1268,6 +1284,7 @@ export namespace Config {
                 disabled: z.boolean().optional(),
                 env: z.record(z.string(), z.string()).optional(),
                 initialization: z.record(z.string(), z.any()).optional(),
+                memoryLimit: z.number().int().positive().optional(), // kilocode_change - memory limit in MB
               }),
             ]),
           ),

--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -11,6 +11,7 @@ export interface Info {
   command: string[]
   environment?: Record<string, string>
   extensions: string[]
+  timeout?: number // kilocode_change - execution timeout in seconds
   enabled(): Promise<boolean>
 }
 

--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -9,6 +9,7 @@ import { Config } from "../config/config"
 import { mergeDeep } from "remeda"
 import { Instance } from "../project/instance"
 import { Process } from "../util/process"
+import { ProcessMonitor } from "../util/process-monitor" // kilocode_change
 
 export namespace Format {
   const log = Log.create({ service: "format" })
@@ -111,6 +112,11 @@ export namespace Format {
       for (const item of await getFormatter(ext)) {
         log.info("running", { command: item.command })
         try {
+          // kilocode_change start — add timeout and process monitoring
+          const ctrl = new AbortController()
+          const ms = (item.timeout ?? 30) * 1000
+          const timer = setTimeout(() => ctrl.abort(), ms)
+          // kilocode_change end
           const proc = Process.spawn(
             item.command.map((x) => x.replace("$FILE", file)),
             {
@@ -118,9 +124,23 @@ export namespace Format {
               env: { ...process.env, ...item.environment },
               stdout: "ignore",
               stderr: "ignore",
+              abort: ctrl.signal, // kilocode_change
             },
           )
+          // kilocode_change start — register short-lived formatter with monitor
+          const pid = proc.pid
+          if (pid) {
+            ProcessMonitor.register({
+              pid,
+              label: `fmt:${item.name}`,
+              subsystem: "formatter",
+              limit: 256 * 1024 * 1024,
+            })
+          }
+          // kilocode_change end
           const exit = await proc.exited
+          clearTimeout(timer) // kilocode_change
+          if (pid) ProcessMonitor.unregister(pid) // kilocode_change
           if (exit !== 0)
             log.error("failed", {
               command: item.command,

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -11,6 +11,7 @@ import { spawn } from "child_process"
 import { Instance } from "../project/instance"
 import { Flag } from "@/flag/flag"
 import { TsClient } from "../kilocode/ts-client" // kilocode_change
+import { ProcessMonitor } from "@/util/process-monitor" // kilocode_change
 
 export namespace LSP {
   const log = Log.create({ service: "lsp" })
@@ -197,6 +198,22 @@ export namespace LSP {
       if (!handle) return undefined
       log.info("spawned lsp server", { serverID: server.id })
 
+      // kilocode_change start — detect process exit early (before the 45s init)
+      const pid = handle.process.pid
+      let exited = false
+      handle.process.on("exit", (code) => {
+        exited = true
+        if (pid) ProcessMonitor.unregister(pid)
+        const idx = s.clients.findIndex((x) => x.root === root && x.serverID === server.id)
+        if (idx !== -1) {
+          s.clients.splice(idx, 1)
+          s.broken.delete(key)
+          Bus.publish(Event.Updated, {})
+        }
+        log.warn("LSP server exited", { serverID: server.id, code, key })
+      })
+      // kilocode_change end
+
       const client = await LSPClient.create({
         serverID: server.id,
         server: handle,
@@ -212,12 +229,27 @@ export namespace LSP {
         handle.process.kill()
         return undefined
       }
+      if (exited) return undefined // kilocode_change — process died during init
 
       const existing = s.clients.find((x) => x.root === root && x.serverID === server.id)
       if (existing) {
         handle.process.kill()
         return existing
       }
+
+      // kilocode_change start — register with process monitor
+      if (pid) {
+        const cfg = await Config.get()
+        const lspCfg = typeof cfg.lsp === "object" ? cfg.lsp?.[server.id] : undefined
+        const limit = (lspCfg && "memoryLimit" in lspCfg ? lspCfg.memoryLimit : undefined) ?? 1024
+        ProcessMonitor.register({
+          pid,
+          label: `lsp:${server.id}`,
+          subsystem: "lsp",
+          limit: limit * 1024 * 1024,
+        })
+      }
+      // kilocode_change end
 
       s.clients.push(client)
       return client

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -32,10 +32,17 @@ import { BusEvent } from "../bus/bus-event"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
 import open from "open"
+import { ProcessMonitor } from "@/util/process-monitor" // kilocode_change
 
 export namespace MCP {
   const log = Log.create({ service: "mcp" })
   const DEFAULT_TIMEOUT = 30_000
+  // kilocode_change start — reconnect infrastructure
+  const DEFAULT_MCP_MEMORY_MB = 512
+  const MAX_RECONNECT = 3
+  const closing = new Set<string>() // names being intentionally closed
+  const reconnecting = new Set<string>() // names with active reconnect cycles
+  // kilocode_change end
 
   export const Resource = z
     .object({
@@ -192,6 +199,76 @@ export namespace MCP {
     return pids
   }
 
+  // kilocode_change start — wire up process monitoring and auto-reconnect for an MCP client
+  function wireClient(name: string, client: MCPClient, mcp: Config.Mcp) {
+    const pid = (client.transport as any)?.pid as number | undefined
+    const limit = mcp.type === "local" ? (mcp.memoryLimit ?? DEFAULT_MCP_MEMORY_MB) * 1024 * 1024 : 0
+    const reconnect = mcp.autoReconnect ?? true
+
+    if (pid && limit > 0) {
+      ProcessMonitor.register({
+        pid,
+        label: `mcp:${name}`,
+        subsystem: "mcp",
+        limit,
+        onExceeded: () => {
+          log.warn("killing MCP server due to memory limit", { name })
+        },
+      })
+    }
+
+    client.onclose = () => {
+      if (pid) ProcessMonitor.unregister(pid)
+      if (closing.has(name)) {
+        closing.delete(name)
+        return
+      }
+      if (!reconnect) {
+        state().then((s) => {
+          delete s.clients[name]
+          s.toolsCache.delete(name)
+          s.status[name] = { status: "failed", error: "Server disconnected" }
+        })
+        return
+      }
+      scheduleReconnect(name).catch((err) => {
+        log.error("reconnect error", { name, error: err })
+      })
+    }
+  }
+
+  async function scheduleReconnect(name: string) {
+    if (reconnecting.has(name)) return
+    reconnecting.add(name)
+
+    for (let attempt = 1; attempt <= MAX_RECONNECT; attempt++) {
+      const delay = Math.min(1000 * Math.pow(2, attempt - 1), 30_000)
+      log.info("reconnecting", { name, attempt, delay })
+      const s = await state()
+      s.status[name] = {
+        status: "failed",
+        error: `Reconnecting (attempt ${attempt}/${MAX_RECONNECT})...`,
+      }
+
+      await new Promise((r) => setTimeout(r, delay))
+      if (!reconnecting.has(name)) return // cancelled (e.g. user disconnected)
+
+      await connect(name)
+      const s2 = await state()
+      if (s2.status[name]?.status === "connected") {
+        reconnecting.delete(name)
+        log.info("reconnected", { name })
+        return
+      }
+    }
+
+    reconnecting.delete(name)
+    const s = await state()
+    s.status[name] = { status: "failed", error: "Reconnection failed after 3 attempts" }
+    log.error("reconnect failed", { name })
+  }
+  // kilocode_change end
+
   const state = Instance.state(
     async () => {
       const cfg = await Config.get()
@@ -219,6 +296,7 @@ export namespace MCP {
 
           if (result.mcpClient) {
             clients[key] = result.mcpClient
+            if (isMcpConfigured(mcp)) wireClient(key, result.mcpClient, mcp) // kilocode_change
           }
         }),
       )
@@ -234,7 +312,8 @@ export namespace MCP {
       // (e.g. Chrome) that the SDK never reaches, leaving them orphaned.
       // Kill the full descendant tree first so the server exits promptly
       // and no processes are left behind.
-      for (const client of Object.values(state.clients)) {
+      for (const [name, client] of Object.entries(state.clients)) {
+        closing.add(name) // kilocode_change — prevent onclose reconnect during dispose
         const pid = (client.transport as any)?.pid
         if (typeof pid !== "number") continue
         for (const dpid of await descendants(pid)) {
@@ -325,12 +404,14 @@ export namespace MCP {
     // Close existing client if present to prevent memory leaks
     const existingClient = s.clients[name]
     if (existingClient) {
+      closing.add(name) // kilocode_change — prevent onclose reconnect
       await existingClient.close().catch((error) => {
         log.error("Failed to close existing MCP client", { name, error })
       })
     }
     s.clients[name] = result.mcpClient
     s.status[name] = result.status
+    wireClient(name, result.mcpClient, mcp) // kilocode_change
 
     return {
       status: s.status,
@@ -593,19 +674,23 @@ export namespace MCP {
       // Close existing client if present to prevent memory leaks
       const existingClient = s.clients[name]
       if (existingClient) {
+        closing.add(name) // kilocode_change — prevent onclose reconnect
         await existingClient.close().catch((error) => {
           log.error("Failed to close existing MCP client", { name, error })
         })
       }
       s.clients[name] = result.mcpClient
+      wireClient(name, result.mcpClient, mcp) // kilocode_change
     }
   }
 
   export async function disconnect(name: string) {
+    reconnecting.delete(name) // kilocode_change — cancel any pending reconnect
     const s = await state()
     s.toolsCache.delete(name) // kilocode_change
     const client = s.clients[name]
     if (client) {
+      closing.add(name) // kilocode_change — prevent onclose reconnect
       await client.close().catch((error) => {
         log.error("Failed to close MCP client", { name, error })
       })

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -120,10 +120,16 @@ export namespace Plugin {
     for (const hook of await state().then((x) => x.hooks)) {
       const fn = hook[name]
       if (!fn) continue
-      // @ts-expect-error if you feel adventurous, please fix the typing, make sure to bump the try-counter if you
-      // give up.
-      // try-counter: 2
-      await fn(input, output)
+      // kilocode_change start — wrap in try/catch to prevent one bad plugin from crashing the agent
+      try {
+        // @ts-expect-error if you feel adventurous, please fix the typing, make sure to bump the try-counter if you
+        // give up.
+        // try-counter: 2
+        await fn(input, output)
+      } catch (err) {
+        log.error("plugin hook failed", { hook: name, error: err })
+      }
+      // kilocode_change end
     }
     return output
   }

--- a/packages/opencode/src/util/process-monitor.ts
+++ b/packages/opencode/src/util/process-monitor.ts
@@ -26,27 +26,23 @@ export namespace ProcessMonitor {
     () => {
       const entries = new Map<number, Tracked>()
       let active = false
-      const timer =
-        process.platform !== "win32"
-          ? setInterval(() => {
-              if (active) return
-              active = true
-              poll(entries).finally(() => {
-                active = false
-              })
-            }, POLL_MS)
-          : undefined
-      if (timer) timer.unref()
+      const timer = setInterval(() => {
+        if (active) return
+        active = true
+        poll(entries).finally(() => {
+          active = false
+        })
+      }, POLL_MS)
+      timer.unref()
       return { entries, timer }
     },
     async (s) => {
-      if (s.timer) clearInterval(s.timer)
+      clearInterval(s.timer)
       s.entries.clear()
     },
   )
 
   export function register(entry: Entry) {
-    if (process.platform === "win32") return
     state().entries.set(entry.pid, {
       ...entry,
       warned: false,
@@ -61,7 +57,6 @@ export namespace ProcessMonitor {
   }
 
   export function unregister(pid: number) {
-    if (process.platform === "win32") return
     state().entries.delete(pid)
   }
 
@@ -136,8 +131,12 @@ export namespace ProcessMonitor {
   }
 
   async function getRSS(pids: number[]): Promise<Map<number, number>> {
+    if (pids.length === 0) return new Map()
+    return process.platform === "win32" ? getRSSWindows(pids) : getRSSUnix(pids)
+  }
+
+  async function getRSSUnix(pids: number[]): Promise<Map<number, number>> {
     const result = new Map<number, number>()
-    if (pids.length === 0) return result
 
     try {
       const proc = Bun.spawn(["ps", "-o", "pid=,rss=", "-p", pids.join(",")], {
@@ -151,7 +150,7 @@ export namespace ProcessMonitor {
       // If ps fails with multiple PIDs (some may have exited), query individually
       if (code !== 0 && pids.length > 1) {
         for (const pid of pids) {
-          const one = await getRSS([pid])
+          const one = await getRSSUnix([pid])
           for (const [k, v] of one) result.set(k, v)
         }
         return result
@@ -163,6 +162,42 @@ export namespace ProcessMonitor {
         const p = parseInt(parts[0], 10)
         const kb = parseInt(parts[1], 10)
         if (!isNaN(p) && !isNaN(kb)) result.set(p, kb * 1024) // KB to bytes
+      }
+    } catch (err) {
+      log.error("rss query failed", { error: err })
+    }
+
+    return result
+  }
+
+  async function getRSSWindows(pids: number[]): Promise<Map<number, number>> {
+    const result = new Map<number, number>()
+    const wanted = new Set(pids)
+
+    try {
+      const proc = Bun.spawn(["tasklist", "/FO", "CSV", "/NH"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        windowsHide: true,
+      })
+      const [code, out] = await Promise.all([proc.exited, new Response(proc.stdout).text()]).catch(
+        () => [-1, ""] as const,
+      )
+
+      if (code !== 0) return result
+
+      // Format: "name.exe","1234","Console","1","52,428 K"
+      for (const line of out.trim().split("\n")) {
+        const cols = line.trim().split('","')
+        if (cols.length < 5) continue
+        const pid = parseInt(cols[1], 10)
+        if (!wanted.has(pid)) continue
+        const mem = cols[4]
+          .replace(/"/g, "")
+          .replace(/,/g, "")
+          .replace(/\s*K\s*$/i, "")
+        const kb = parseInt(mem, 10)
+        if (!isNaN(pid) && !isNaN(kb)) result.set(pid, kb * 1024) // KB to bytes
       }
     } catch (err) {
       log.error("rss query failed", { error: err })

--- a/packages/opencode/src/util/process-monitor.ts
+++ b/packages/opencode/src/util/process-monitor.ts
@@ -1,0 +1,173 @@
+// kilocode_change - new file
+import { Log } from "./log"
+import { Instance } from "../project/instance"
+
+export namespace ProcessMonitor {
+  const log = Log.create({ service: "process-monitor" })
+  const POLL_MS = 5_000
+  const GRACE_MS = 2_000
+
+  export interface Entry {
+    pid: number
+    label: string
+    subsystem: "mcp" | "lsp" | "formatter"
+    limit: number // RSS limit in bytes, 0 = no limit
+    onExceeded?: () => void
+    onExit?: (code: number | null) => void
+  }
+
+  interface Tracked extends Entry {
+    warned: boolean
+    killing: boolean
+    rss: number
+  }
+
+  const state = Instance.state(
+    () => {
+      const entries = new Map<number, Tracked>()
+      let active = false
+      const timer =
+        process.platform !== "win32"
+          ? setInterval(() => {
+              if (active) return
+              active = true
+              poll(entries).finally(() => {
+                active = false
+              })
+            }, POLL_MS)
+          : undefined
+      if (timer) timer.unref()
+      return { entries, timer }
+    },
+    async (s) => {
+      if (s.timer) clearInterval(s.timer)
+      s.entries.clear()
+    },
+  )
+
+  export function register(entry: Entry) {
+    if (process.platform === "win32") return
+    state().entries.set(entry.pid, {
+      ...entry,
+      warned: false,
+      killing: false,
+      rss: 0,
+    })
+    log.info("registered", {
+      pid: entry.pid,
+      label: entry.label,
+      limit: entry.limit > 0 ? Math.round(entry.limit / 1024 / 1024) + "MB" : "none",
+    })
+  }
+
+  export function unregister(pid: number) {
+    if (process.platform === "win32") return
+    state().entries.delete(pid)
+  }
+
+  export function snapshot() {
+    return [...state().entries.values()].map((e) => ({
+      pid: e.pid,
+      label: e.label,
+      subsystem: e.subsystem,
+      rss: e.rss,
+      limit: e.limit,
+    }))
+  }
+
+  async function poll(entries: Map<number, Tracked>) {
+    if (entries.size === 0) return
+    const pids = [...entries.keys()]
+    const rss = await getRSS(pids)
+
+    for (const [pid, entry] of entries) {
+      if (entry.killing) continue
+
+      const mem = rss.get(pid)
+      if (mem === undefined) {
+        entries.delete(pid)
+        log.info("process gone", { pid, label: entry.label })
+        try {
+          entry.onExit?.(null)
+        } catch {}
+        continue
+      }
+
+      entry.rss = mem
+      if (entry.limit <= 0) continue
+
+      if (mem >= entry.limit * 0.75 && !entry.warned) {
+        entry.warned = true
+        log.warn("high memory", {
+          label: entry.label,
+          pid,
+          rss: Math.round(mem / 1024 / 1024) + "MB",
+          limit: Math.round(entry.limit / 1024 / 1024) + "MB",
+        })
+      }
+
+      if (mem >= entry.limit) {
+        entry.killing = true
+        log.error("memory exceeded, killing", {
+          label: entry.label,
+          pid,
+          rss: Math.round(mem / 1024 / 1024) + "MB",
+          limit: Math.round(entry.limit / 1024 / 1024) + "MB",
+        })
+        try {
+          entry.onExceeded?.()
+        } catch {}
+        setTimeout(() => {
+          try {
+            process.kill(pid, "SIGTERM")
+          } catch {}
+          setTimeout(() => {
+            try {
+              process.kill(pid, "SIGKILL")
+            } catch {}
+            entries.delete(pid)
+            try {
+              entry.onExit?.(null)
+            } catch {}
+          }, GRACE_MS)
+        }, GRACE_MS)
+      }
+    }
+  }
+
+  async function getRSS(pids: number[]): Promise<Map<number, number>> {
+    const result = new Map<number, number>()
+    if (pids.length === 0) return result
+
+    try {
+      const proc = Bun.spawn(["ps", "-o", "pid=,rss=", "-p", pids.join(",")], {
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      const [code, out] = await Promise.all([proc.exited, new Response(proc.stdout).text()]).catch(
+        () => [-1, ""] as const,
+      )
+
+      // If ps fails with multiple PIDs (some may have exited), query individually
+      if (code !== 0 && pids.length > 1) {
+        for (const pid of pids) {
+          const one = await getRSS([pid])
+          for (const [k, v] of one) result.set(k, v)
+        }
+        return result
+      }
+
+      for (const line of out.trim().split("\n")) {
+        const parts = line.trim().split(/\s+/)
+        if (parts.length < 2) continue
+        const p = parseInt(parts[0], 10)
+        const kb = parseInt(parts[1], 10)
+        if (!isNaN(p) && !isNaN(kb)) result.set(p, kb * 1024) // KB to bytes
+      }
+    } catch (err) {
+      log.error("rss query failed", { error: err })
+    }
+
+    return result
+  }
+}


### PR DESCRIPTION
## Why

MCP servers, LSP servers, formatters, or plugins can consume unlimited memory and crash the entire Kilo process mid-session. When this happens, the agent loses its work — edits, debug sessions, test runs — with no recovery.

## What changed

Added a process monitor that watches the memory usage of every child process Kilo spawns (MCP servers, LSP servers, formatters). When a process exceeds its memory limit, it gets a warning at 75%, then gets killed gracefully before it can crash everything else. MCP servers now automatically reconnect after a crash — up to 3 retries with exponential backoff. LSP servers detect when their process dies and clean up the dead client so a fresh one spawns on the next file touch. Formatters now have a 30-second timeout so a hung formatter can't block forever. Plugin hooks are wrapped in try/catch so one bad plugin can't take down the whole agent loop. All limits are configurable per-server in `kilo.json`.

## How to test

1. Configure an MCP server in `kilo.json` with a low `memoryLimit` (e.g. `"memoryLimit": 50` for 50MB)
2. Use the MCP server until it exceeds the limit — check logs for "memory exceeded, killing" and "reconnecting" messages
3. Verify the server reconnects automatically and tools work again
4. Kill an LSP server process manually (`kill <pid>`) and verify diagnostics recover on next file edit
5. Set a formatter `timeout` to 1 second and run a slow formatter — verify it gets aborted instead of hanging