### PR TITLE
feat(agent-manager): add expand/collapse all button to inline diff panel

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -307,6 +307,11 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
     sendAllToChat()
   }
 
+  const handleExpandAll = () => {
+    const allOpen = open().length === props.diffs.length
+    setOpen(allOpen ? [] : props.diffs.map((d) => d.file))
+  }
+
   const totals = createMemo(() => ({
     files: props.diffs.length,
     additions: props.diffs.reduce((sum, diff) => sum + diff.additions, 0),
@@ -354,6 +359,28 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
           </Show>
         </div>
         <div class="am-diff-header-actions">
+          <Show when={props.diffs.length > 0}>
+            <Tooltip
+              value={
+                open().length === props.diffs.length
+                  ? t("ui.sessionReview.collapseAll")
+                  : t("ui.sessionReview.expandAll")
+              }
+              placement="bottom"
+            >
+              <IconButton
+                icon="chevron-grabber-vertical"
+                size="small"
+                variant="ghost"
+                label={
+                  open().length === props.diffs.length
+                    ? t("ui.sessionReview.collapseAll")
+                    : t("ui.sessionReview.expandAll")
+                }
+                onClick={handleExpandAll}
+              />
+            </Tooltip>
+          </Show>
           <Show when={props.onExpand}>
             <Tooltip value={t("command.review.toggle")} placement="bottom">
               <IconButton


### PR DESCRIPTION
## Summary

- Ports the expand/collapse all toggle from the fullscreen diff viewer (`FullScreenDiffView.tsx`) to the inline diff panel (`DiffPanel.tsx`)
- Adds an `IconButton` with `chevron-grabber-vertical` icon in the header actions area, with tooltip showing "Expand all" / "Collapse all"
- Reuses existing `open`/`setOpen` state and i18n keys — no new dependencies or translations needed