### PR TITLE
feat(ui): add copy button for assistant messages

### DIFF
--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -19,6 +19,18 @@
       height: 20px;
     }
   }
+
+  [data-slot="assistant-copy-wrapper"] {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    margin-top: 2px;
+
+    [data-component="icon-button"] {
+      width: 20px;
+      height: 20px;
+    }
+  }
 }
 
 /* Prevent long title/path from hiding the collapsible expand arrow */

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1155,6 +1155,7 @@ PART_MAPPING["compaction"] = function CompactionPartDisplay() {
 
 PART_MAPPING["text"] = function TextPartDisplay(props) {
   const data = useData()
+  const i18n = useI18n()
   const part = () => props.part as TextPart
 
   const displayText = () => (part().text ?? "").trim()
@@ -1165,6 +1166,21 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
     if (props.showAssistantCopyPartID !== part().id) return
     return props.turnDiffSummary
   })
+
+  const showCopy = createMemo(() => {
+    if (props.message.role !== "assistant") return false
+    if (props.showAssistantCopyPartID === null) return false
+    return props.showAssistantCopyPartID === part().id
+  })
+  const [copied, setCopied] = createSignal(false)
+
+  const handleCopy = async () => {
+    const content = displayText()
+    if (!content) return
+    await navigator.clipboard.writeText(content)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
 
   const handleMarkdownClick = (e: MouseEvent) => {
     if (!data.openFile) return
@@ -1200,6 +1216,24 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
         <div data-slot="text-part-body">
           <Markdown text={throttledText()} cacheKey={part().id} onClick={handleMarkdownClick} />
         </div>
+        <Show when={showCopy()}>
+          <div data-slot="assistant-copy-wrapper">
+            <Tooltip
+              value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+              placement="right"
+              gutter={4}
+            >
+              <IconButton
+                icon={copied() ? "check" : "copy"}
+                size="normal"
+                variant="ghost"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={handleCopy}
+                aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+              />
+            </Tooltip>
+          </div>
+        </Show>
         <Show when={summary()}>
           {(render) => (
             <GrowBox animate={!!props.animate} fade gap={4} class="w-full min-w-0">


### PR DESCRIPTION
## Summary

- Adds a copy-to-clipboard button on assistant text responses in the kilo-ui (VS Code extension webview)
- Mirrors the existing user message copy button pattern: ghost IconButton with tooltip, same 20x20 icon size
- Left-aligned with minimal margin (margin-top: 2px) to avoid excessive spacing
- Only shown on the last text part of a completed assistant turn (uses existing showAssistantCopyPartID logic)

<img width="656" height="226" alt="image" src="https://github.com/user-attachments/assets/0e60b8c4-856e-4c7d-9c9d-a8e91e151ffd" />
<img width="390" height="238" alt="image" src="https://github.com/user-attachments/assets/9f528226-2170-48de-8109-c8e5f37d6f6f" />
