### PR TITLE
perf(agent-manager): reduce GitHub API usage in PR status polling

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
@@ -14,6 +14,7 @@ interface PRStatusPollerOptions {
 const GH_PROBE_TTL = 300_000 // 5 minutes — gh installation state rarely changes at runtime
 const MAX_BACKOFF = 120_000 // 2 minutes — cap for exponential backoff on repeated errors
 const BACKOFF_MULTIPLIER = 2
+const PR_LOOKUP_TTL = 60_000 // 1 minute — PR number for a branch rarely changes
 
 export class PRStatusPoller {
   private timer: ReturnType<typeof setTimeout> | undefined
@@ -27,6 +28,7 @@ export class PRStatusPoller {
   private ghProbeTime = 0
   private activeWorktreeId: string | undefined
   private cachedRepo: { owner: string; name: string; cwd: string } | undefined
+  private prCache = new Map<string, { result: PRResult | null; expires: number }>()
   private readonly intervalMs: number
 
   constructor(private readonly options: PRStatusPollerOptions) {
@@ -48,9 +50,12 @@ export class PRStatusPoller {
     this.visible = visible
     if (!this.active) return
     if (visible) {
-      // Resume — poll immediately then schedule normally
+      // Resume — expire all PR caches and fetch all worktrees once to catch up,
+      // then resume the normal active-only poll cycle.
       if (this.timer) clearTimeout(this.timer)
       this.timer = undefined
+      this.prCache.clear()
+      this.lastHash.clear()
       void this.poll()
       return
     }
@@ -74,16 +79,22 @@ export class PRStatusPoller {
     this.ghAvailable = undefined
     this.ghProbeTime = 0
     this.cachedRepo = undefined
+    this.prCache.clear()
   }
 
-  /** Force-refresh a specific worktree immediately. */
+  /** Force-refresh a specific worktree immediately, bypassing the PR cache. */
   refresh(worktreeId: string): void {
     if (!this.active) return
+    this.prCache.delete(worktreeId)
     void this.fetchOne(worktreeId)
   }
 
   setActiveWorktreeId(id: string | undefined): void {
+    const prev = this.activeWorktreeId
     this.activeWorktreeId = id
+    // When switching to a different worktree, fetch it immediately so the
+    // badge updates without waiting for the next poll cycle.
+    if (id && id !== prev && this.active) void this.fetchOne(id)
   }
 
   private start(): void {
@@ -146,8 +157,20 @@ export class PRStatusPoller {
     }
 
     this.lastError = undefined
+
+    // Only poll the active worktree on each timer tick. Inactive worktrees
+    // refresh when selected (setActiveWorktreeId) or manually (refresh()).
+    // On first poll (lastHash empty) fetch all worktrees once to populate badges.
     const worktrees = this.options.getWorktrees()
-    const results = await Promise.allSettled(worktrees.map((wt) => this.fetchOne(wt.id)))
+    const initial = this.lastHash.size === 0
+    const targets = initial ? worktrees : worktrees.filter((wt) => wt.id === this.activeWorktreeId)
+
+    if (targets.length === 0) {
+      this.failures = 0
+      return
+    }
+
+    const results = await Promise.allSettled(targets.map((wt) => this.fetchOne(wt.id)))
     const ok = results.every((r) => r.status === "fulfilled")
     if (ok) {
       this.failures = 0
@@ -164,7 +187,7 @@ export class PRStatusPoller {
     if (!this.options.getWorkspaceRoot()) return
 
     try {
-      const pr = await this.fetchPRForBranch(wt.branch, wt.path)
+      const pr = await this.cachedFetchPR(worktreeId, wt.branch, wt.path)
       if (!pr) {
         const hash = `${worktreeId}:none`
         if (this.lastHash.get(worktreeId) === hash) return
@@ -216,6 +239,15 @@ export class PRStatusPoller {
 
   private static readonly PR_JSON_FIELDS =
     "number,title,url,state,isDraft,reviewDecision,additions,deletions,changedFiles,headRefName,headRefOid"
+
+  /** Return a cached PR lookup if still fresh, otherwise fetch and cache. */
+  private async cachedFetchPR(worktreeId: string, branch: string, cwd: string): Promise<PRResult | null> {
+    const cached = this.prCache.get(worktreeId)
+    if (cached && Date.now() < cached.expires) return cached.result
+    const result = await this.fetchPRForBranch(branch, cwd)
+    this.prCache.set(worktreeId, { result, expires: Date.now() + PR_LOOKUP_TTL })
+    return result
+  }
 
   private async fetchPRForBranch(branch: string, cwd: string): Promise<PRResult | null> {
     // Strategy 1: bare `gh pr view` — resolves via the branch's tracking ref.


### PR DESCRIPTION
## Summary

- **Active-only polling**: Only poll the active worktree on each 15s timer tick instead of all worktrees simultaneously. Inactive worktrees refresh when selected or on manual refresh.
- **PR lookup cache**: Add a 60s TTL cache on `fetchPRForBranch` results so repeated polls skip the expensive multi-strategy `gh pr view` cascade and only re-fetch checks and comments (the fast-changing data).
- **Visibility catch-up**: When the panel becomes visible again, expire all caches and fetch all worktrees once to populate badges, then resume active-only polling.

## Problem

With 10 worktrees, the PR status poller was making ~5,000–9,800 GitHub API calls/hour — exceeding the 5,000/hr rate limit and causing `GraphQL: API rate limit already exceeded` errors.

Each 15s poll cycle fetched every worktree in parallel, with each worktree requiring 1–3 `gh pr view` calls (fallback strategies) + 1 `gh pr checks` call + 1 GraphQL call (active only). That's 21–41 API calls per cycle × 240 cycles/hour.

## After

| Metric | Before | After |
|---|---|---|
| Calls per poll cycle (10 worktrees) | 21–41 | 2–3 |
| Calls per hour | 5,000–9,800 | 480–720 |
| Reduction | — | ~85–93% |

Inactive worktree badges still stay fresh because:
1. All worktrees are fetched once on initial load and visibility resume
2. Switching to a worktree triggers an immediate fetch
3. Manual refresh button bypasses the cache