### PR TITLE
fix(agent-manager): restore subtitle, pr, and onOpenPR props in section renderWt

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2332,6 +2332,7 @@ const AgentManagerContent: Component = () => {
                                 <WorktreeItem
                                   worktree={wt}
                                   label={worktreeLabel(wt)}
+                                  subtitle={worktreeSubtitle(wt)}
                                   active={selection() === wt.id}
                                   pendingDelete={pendingDelete() === wt.id}
                                   busy={busyWorktrees().has(wt.id)}
@@ -2349,6 +2350,12 @@ const AgentManagerContent: Component = () => {
                                   renameValue={renameValue()}
                                   closeKeybind={kb().closeWorktree ?? ""}
                                   openKeybind={kb().openWorktree ?? ""}
+                                  pr={
+                                    prStatuses()[wt.id] !== undefined ? (prStatuses()[wt.id] ?? undefined) : undefined
+                                  }
+                                  onOpenPR={() =>
+                                    vscode.postMessage({ type: "agentManager.openPR", worktreeId: wt.id })
+                                  }
                                   sections={sections()}
                                   currentSectionId={wt.sectionId}
                                   onMoveToSection={(secId) => moveToSection([wt.id], secId)}


### PR DESCRIPTION
Follow-up fix for #8225. The section rendering refactor dropped subtitle, pr, and onOpenPR props from WorktreeItem in the renderWt function. 1 file, 7 lines added.