### PR TITLE
feat(vscode): move agent manager settings to extension settings tab

### DIFF
--- a/packages/kilo-vscode/src/SettingsEditorProvider.ts
+++ b/packages/kilo-vscode/src/SettingsEditorProvider.ts
@@ -108,10 +108,34 @@ export class SettingsEditorProvider implements vscode.Disposable {
     }
     provider.resolveWebviewPanel(panel)
 
-    // Listen for closePanel from the webview (back button in panel mode)
-    const closePanelDisposable = panel.webview.onDidReceiveMessage((msg) => {
+    // Listen for closePanel and agent manager settings from the webview
+    const closePanelDisposable = panel.webview.onDidReceiveMessage(async (msg) => {
       if (msg.type === "closePanel") {
         panel.dispose()
+      }
+      // Forward agent manager setup script action to the registered command
+      if (msg.type === "agentManager.configureSetupScript") {
+        void vscode.commands.executeCommand("kilo-code.new.agentManager.configureSetupScript")
+      }
+      // Agent manager settings: read current values and push to webview
+      if (msg.type === "requestAgentManagerSettings") {
+        const settings = await vscode.commands.executeCommand("kilo-code.new.agentManager.getSettings")
+        provider.postMessage({ type: "agentManagerSettings", ...(settings as object) })
+      }
+      // Agent manager settings: write a value via command
+      if (msg.type === "setAgentManagerSetting") {
+        const { key, value } = msg as { key: string; value: unknown }
+        if (key === "defaultBaseBranch") {
+          void vscode.commands.executeCommand("kilo-code.new.agentManager.setDefaultBaseBranch", value)
+        }
+        if (key === "reviewDiffStyle") {
+          void vscode.commands.executeCommand("kilo-code.new.agentManager.setReviewDiffStyle", value)
+        }
+      }
+      // Agent manager branches: fetch branch list for the default base branch picker
+      if (msg.type === "requestAgentManagerBranches") {
+        const data = await vscode.commands.executeCommand("kilo-code.new.agentManager.getBranches")
+        provider.postMessage({ type: "agentManagerBranches", ...(data as object) })
       }
     })
 

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -30,6 +30,7 @@ import { WorktreeImporter } from "./worktree-importer"
 import { buildKeybindingMap } from "./format-keybinding"
 import { resolveVersionModels, buildInitialMessages, type CreatedVersion } from "./multi-version"
 import { Semaphore } from "./semaphore"
+import * as settings from "./settings-commands"
 import { PLATFORM } from "./constants"
 import type { AgentManagerOutMessage, AgentManagerInMessage } from "./types"
 import type { Host, PanelContext, OutputHandle, Disposable } from "./host"
@@ -380,6 +381,10 @@ export class AgentManagerProvider implements Disposable {
   ): Record<string, unknown> | null | undefined {
     if (m.type === "agentManager.configureSetupScript") {
       void this.configureSetupScript()
+      return null
+    }
+    if (m.type === "agentManager.openSettings") {
+      this.host.openSettings("agentManager")
       return null
     }
     if (handleRunMessage(this.run, m)) return null
@@ -1123,7 +1128,7 @@ export class AgentManagerProvider implements Disposable {
   // ---------------------------------------------------------------------------
 
   /** Open the worktree setup script in the editor for user configuration. */
-  private async configureSetupScript(): Promise<void> {
+  public async configureSetupScript(): Promise<void> {
     const service = this.getSetupScriptService()
     if (!service) return
     try {
@@ -1496,6 +1501,22 @@ export class AgentManagerProvider implements Disposable {
   public postMessage(message: unknown): void {
     this.panel?.postMessage(message)
   }
+
+  // Settings accessors (for extension commands wired to the settings tab)
+  private get settingsCtx(): import("./settings-commands").SettingsContext {
+    return {
+      stateReady: this.stateReady,
+      state: this.state ?? undefined,
+      getStateManager: () => this.getStateManager(),
+      getWorktreeManager: () => this.getWorktreeManager(),
+      pushState: () => this.pushState(),
+    }
+  }
+  public getDefaultBaseBranch = () => settings.getDefaultBaseBranch(this.settingsCtx)
+  public setDefaultBaseBranch = (v: string | undefined) => settings.setDefaultBaseBranch(this.settingsCtx, v)
+  public getReviewDiffStyle = () => settings.getReviewDiffStyle(this.settingsCtx)
+  public setReviewDiffStyle = (v: "unified" | "split") => settings.setReviewDiffStyle(this.settingsCtx, v)
+  public getBranches = () => settings.getBranches(this.settingsCtx)
 
   public dispose(): void {
     this.connectionService.unregisterFocused("agent-manager")

--- a/packages/kilo-vscode/src/agent-manager/host.ts
+++ b/packages/kilo-vscode/src/agent-manager/host.ts
@@ -125,6 +125,9 @@ export interface Host {
   /** Ask VS Code's git extension to re-scan repositories (e.g. after worktree ref migration). */
   refreshGit(): void
 
+  /** Open the extension settings panel, optionally navigating to a specific tab. */
+  openSettings(tab?: string): void
+
   /** Dispose all host resources. */
   dispose(): void
 }

--- a/packages/kilo-vscode/src/agent-manager/settings-commands.ts
+++ b/packages/kilo-vscode/src/agent-manager/settings-commands.ts
@@ -1,0 +1,57 @@
+import type { WorktreeStateManager } from "./WorktreeStateManager"
+import type { WorktreeManager } from "./WorktreeManager"
+import { normalizeBaseBranch } from "./base-branch"
+
+/** Minimal context needed by settings commands — avoids importing the full provider. */
+export interface SettingsContext {
+  stateReady: Promise<void> | undefined
+  state: WorktreeStateManager | undefined
+  getStateManager(): WorktreeStateManager | undefined
+  getWorktreeManager(): WorktreeManager | undefined
+  pushState(): void
+}
+
+async function ensure(ctx: SettingsContext): Promise<WorktreeStateManager | undefined> {
+  if (ctx.stateReady) {
+    await ctx.stateReady.catch(() => {})
+    if (ctx.state) return ctx.state
+  }
+  const state = ctx.getStateManager()
+  if (!state) return undefined
+  await state.load()
+  return state
+}
+
+export async function getDefaultBaseBranch(ctx: SettingsContext): Promise<string | undefined> {
+  const state = await ensure(ctx)
+  return state?.getDefaultBaseBranch()
+}
+
+export async function setDefaultBaseBranch(ctx: SettingsContext, value: string | undefined): Promise<void> {
+  const state = await ensure(ctx)
+  if (!state) return
+  state.setDefaultBaseBranch(normalizeBaseBranch(value))
+  ctx.pushState()
+}
+
+export async function getReviewDiffStyle(ctx: SettingsContext): Promise<"unified" | "split"> {
+  const state = await ensure(ctx)
+  return state?.getReviewDiffStyle() ?? "unified"
+}
+
+export async function setReviewDiffStyle(ctx: SettingsContext, value: "unified" | "split"): Promise<void> {
+  const state = await ensure(ctx)
+  if (!state) return
+  state.setReviewDiffStyle(value)
+  ctx.pushState()
+}
+
+export async function getBranches(ctx: SettingsContext): Promise<{
+  branches: Array<{ name: string; isLocal: boolean; isRemote: boolean; isDefault: boolean; lastCommitDate?: string }>
+  defaultBranch: string
+}> {
+  const manager = ctx.getWorktreeManager()
+  if (!manager) return { branches: [], defaultBranch: "main" }
+  const result = await manager.listBranches()
+  return { branches: result.branches, defaultBranch: result.defaultBranch }
+}

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -436,6 +436,10 @@ interface SetDefaultBaseBranchIn {
   branch?: string
 }
 
+interface OpenSettingsIn {
+  type: "agentManager.openSettings"
+}
+
 interface RequestExternalWorktreesIn {
   type: "agentManager.requestExternalWorktrees"
 }
@@ -669,6 +673,7 @@ export type AgentManagerInMessage =
   | SetSessionsCollapsedIn
   | SetReviewDiffStyleIn
   | SetDefaultBaseBranchIn
+  | OpenSettingsIn
   | RequestExternalWorktreesIn
   | ImportFromBranchIn
   | ImportFromPRIn

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -186,5 +186,9 @@ export class VscodeHost implements Host {
     void vscode.commands.executeCommand("git.refresh")
   }
 
+  openSettings(tab?: string): void {
+    void vscode.commands.executeCommand("kilo-code.new.settingsButtonClicked", tab)
+  }
+
   dispose(): void {}
 }

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -292,6 +292,20 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("kilo-code.new.agentManager.showShortcuts", () => {
       agentManagerProvider.postMessage({ type: "action", action: "showShortcuts" })
     }),
+    vscode.commands.registerCommand("kilo-code.new.agentManager.configureSetupScript", () => {
+      agentManagerProvider.configureSetupScript()
+    }),
+    vscode.commands.registerCommand("kilo-code.new.agentManager.getSettings", async () => ({
+      defaultBaseBranch: (await agentManagerProvider.getDefaultBaseBranch()) ?? "",
+      reviewDiffStyle: await agentManagerProvider.getReviewDiffStyle(),
+    })),
+    vscode.commands.registerCommand("kilo-code.new.agentManager.setDefaultBaseBranch", (branch: string) =>
+      agentManagerProvider.setDefaultBaseBranch(branch || undefined),
+    ),
+    vscode.commands.registerCommand("kilo-code.new.agentManager.setReviewDiffStyle", (style: "unified" | "split") =>
+      agentManagerProvider.setReviewDiffStyle(style),
+    ),
+    vscode.commands.registerCommand("kilo-code.new.agentManager.getBranches", () => agentManagerProvider.getBranches()),
 
     vscode.commands.registerCommand("kilo-code.new.agentManager.newTab", () => {
       agentManagerProvider.postMessage({ type: "action", action: "newTab" })

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -197,6 +197,7 @@ describe("Agent Manager Provider — onMessage routing", () => {
       "agentManager.persistSession",
       "agentManager.forgetSession",
       "agentManager.configureSetupScript",
+      "agentManager.openSettings",
       "agentManager.configureRunScript",
       "agentManager.runScript",
       "agentManager.stopRunScript",
@@ -449,43 +450,14 @@ describe("KiloProvider — pending session refresh on reconnect", () => {
 // handleChangeDefaultBaseBranch — listener leak fix
 // ---------------------------------------------------------------------------
 
-describe("Agent Manager — dialog listener cleanup", () => {
+describe("Agent Manager — settings moved to extension settings", () => {
   const tsx = fs.readFileSync(TSX_FILE, "utf-8")
 
-  /**
-   * Regression: handleChangeDefaultBaseBranch subscribes to vscode.onMessage
-   * for branch data. Previously unsub() was only called inside selectBranch()
-   * and the Escape keydown handler. If the dialog closed via backdrop click or
-   * external dialog.close(), the listener leaked and stacked on every reopen.
-   *
-   * The fix ties unsub() to Solid's onCleanup inside the dialog.show() render
-   * function so it always disposes regardless of how the dialog closes.
-   */
-  it("handleChangeDefaultBaseBranch uses onCleanup(unsub) inside dialog.show", () => {
-    const fnStart = tsx.indexOf("const handleChangeDefaultBaseBranch")
-    expect(fnStart, "handleChangeDefaultBaseBranch must exist").toBeGreaterThan(-1)
-
-    // Grab the function body (enough to cover the dialog.show callback)
-    const snippet = tsx.slice(fnStart, fnStart + 2000)
-
-    // The dialog.show callback must register onCleanup(unsub)
-    const showIdx = snippet.indexOf("dialog.show(")
-    expect(showIdx, "dialog.show() call must exist").toBeGreaterThan(-1)
-    const afterShow = snippet.slice(showIdx)
-    expect(afterShow, "onCleanup(unsub) must be inside dialog.show callback").toContain("onCleanup(unsub)")
-  })
-
-  it("selectBranch does not manually call unsub (handled by onCleanup)", () => {
-    const fnStart = tsx.indexOf("const handleChangeDefaultBaseBranch")
-    const snippet = tsx.slice(fnStart, fnStart + 2000)
-
-    // Find the selectBranch function body
-    const selStart = snippet.indexOf("const selectBranch")
-    expect(selStart, "selectBranch must exist").toBeGreaterThan(-1)
-    const selEnd = snippet.indexOf("}", selStart + 50)
-    const selBody = snippet.slice(selStart, selEnd + 1)
-
-    expect(selBody, "selectBranch should not call unsub() directly").not.toContain("unsub()")
+  it("settings gear opens extension settings instead of inline dropdown", () => {
+    // handleChangeDefaultBaseBranch was removed — settings are now in the extension settings panel
+    expect(tsx).not.toContain("const handleChangeDefaultBaseBranch")
+    expect(tsx).not.toContain("handleConfigureSetupScript")
+    expect(tsx).toContain("agentManager.openSettings")
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1647,106 +1647,6 @@ const AgentManagerContent: Component = () => {
 
   const revertCtl = createRevertFile(currentDiffSessionId, vscode, showToast, t)
 
-  const handleConfigureSetupScript = () => {
-    vscode.postMessage({ type: "agentManager.configureSetupScript" })
-  }
-
-  const handleChangeDefaultBaseBranch = () => {
-    const [search, setSearch] = createSignal("")
-    const [branches, setBranches] = createSignal<BranchInfo[]>([])
-    const [loading, setLoading] = createSignal(true)
-    const [highlighted, setHighlighted] = createSignal(-1)
-
-    const unsub = vscode.onMessage((msg) => {
-      if (msg.type === "agentManager.branches") {
-        const ev = msg as AgentManagerBranchesMessage
-        setBranches(ev.branches)
-        if (ev.defaultBranch) setRepoDetectedBranch(ev.defaultBranch)
-        setLoading(false)
-      }
-    })
-
-    vscode.postMessage({ type: "agentManager.requestBranches" })
-
-    const filtered = createMemo(() => {
-      const s = search().toLowerCase()
-      if (!s) return branches()
-      return branches().filter((b) => b.name.toLowerCase().includes(s))
-    })
-
-    const selectBranch = (name: string | undefined) => {
-      vscode.postMessage({ type: "agentManager.setDefaultBaseBranch", branch: name })
-      setDefaultBaseBranch(name)
-      dialog.close()
-    }
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      const items = filtered()
-      // offset by 1 for auto-detect option (-1 = auto-detect)
-      const total = items.length + 1
-      if (e.key === "ArrowDown") {
-        e.preventDefault()
-        e.stopPropagation()
-        setHighlighted((prev) => Math.min(prev + 1, total - 2))
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault()
-        e.stopPropagation()
-        setHighlighted((prev) => Math.max(prev - 1, -1))
-      } else if (e.key === "Enter") {
-        e.preventDefault()
-        e.stopPropagation()
-        const idx = highlighted()
-        if (idx === -1) {
-          selectBranch(undefined)
-        } else {
-          const branch = items[idx]
-          if (branch) selectBranch(branch.name)
-        }
-      } else if (e.key === "Escape") {
-        e.preventDefault()
-        e.stopPropagation()
-        dialog.close()
-      }
-    }
-
-    dialog.show(() => {
-      onCleanup(unsub)
-      return (
-        <Dialog title={t("agentManager.worktree.defaultBaseBranch")} fit>
-          <div class="am-default-base-branch">
-            <BranchSelect
-              branches={filtered()}
-              loading={loading()}
-              search={search()}
-              onSearch={(v) => {
-                setSearch(v)
-                setHighlighted(-1)
-              }}
-              onSelect={(b) => selectBranch(b.name)}
-              onSearchKeyDown={handleKeyDown}
-              selected={defaultBaseBranch()}
-              highlighted={highlighted()}
-              onHighlight={setHighlighted}
-              searchPlaceholder={t("agentManager.dialog.searchBranches")}
-              emptyLabel={t("agentManager.import.noMatchingBranches")}
-              loadingLabel={t("agentManager.import.loadingBranches")}
-              defaultLabel={t("agentManager.dialog.branchBadge.default")}
-              remoteLabel={t("agentManager.dialog.branchBadge.remote")}
-              defaultName={defaultBaseBranch()}
-              autoOption={{
-                label: t("agentManager.worktree.defaultBaseBranchAuto"),
-                hint: repoDetectedBranch(),
-                active: !hasConfiguredBranch(),
-                highlighted: highlighted() === -1,
-                onSelect: () => selectBranch(undefined),
-              }}
-            />
-          </div>
-        </Dialog>
-      )
-    })
-  }
-
   const handleShowKeyboardShortcuts = () => {
     const categories = buildShortcutCategories(kb(), t)
     dialog.show(() => (
@@ -2237,28 +2137,15 @@ const AgentManagerContent: Component = () => {
                     onClick={handleShowKeyboardShortcuts}
                   />
                 </TooltipKeybind>
-                <DropdownMenu gutter={4} placement="bottom-end">
-                  <DropdownMenu.Trigger
-                    as={IconButton}
+                <TooltipKeybind title={t("agentManager.worktree.settings")} keybind="" placement="bottom">
+                  <IconButton
                     icon="settings-gear"
                     size="small"
                     variant="ghost"
                     label={t("agentManager.worktree.settings")}
+                    onClick={() => vscode.postMessage({ type: "agentManager.openSettings" })}
                   />
-                  <DropdownMenu.Portal>
-                    <DropdownMenu.Content class="am-split-menu">
-                      <DropdownMenu.Item onSelect={handleConfigureSetupScript}>
-                        <DropdownMenu.ItemLabel>{t("agentManager.worktree.setupScript")}</DropdownMenu.ItemLabel>
-                      </DropdownMenu.Item>
-                      <DropdownMenu.Separator />
-                      <DropdownMenu.Item onSelect={handleChangeDefaultBaseBranch}>
-                        <DropdownMenu.ItemLabel>
-                          {t("agentManager.worktree.defaultBaseBranch")}: {repoDefaultBranch()}
-                        </DropdownMenu.ItemLabel>
-                      </DropdownMenu.Item>
-                    </DropdownMenu.Content>
-                  </DropdownMenu.Portal>
-                </DropdownMenu>
+                </TooltipKeybind>
               </div>
             </Show>
           </div>

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager-review.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager-review.css
@@ -456,16 +456,6 @@
   color: var(--syntax-diff-delete, #da3319);
 }
 
-/* ============ Default base branch picker dialog ============ */
-
-.am-default-base-branch {
-  min-width: 360px;
-}
-
-.am-default-base-branch .am-dropdown-list {
-  max-height: 320px;
-}
-
 .am-branch-hint {
   margin-left: auto;
   color: var(--text-weaker);

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -3652,16 +3652,6 @@ body.am-wt-dragging-active * {
   color: var(--syntax-diff-delete, #da3319);
 }
 
-/* ============ Default base branch picker dialog ============ */
-
-.am-default-base-branch {
-  min-width: 360px;
-}
-
-.am-default-base-branch .am-dropdown-list {
-  max-height: 320px;
-}
-
 .am-branch-hint {
   margin-left: auto;
   color: var(--text-weaker);

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentManagerTab.css
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentManagerTab.css
@@ -1,0 +1,123 @@
+/* Branch picker for Agent Manager settings tab */
+
+/* Override the 160px max-width from settings-row-input for the branch picker */
+.am-settings-branch-picker-row [data-slot="settings-row-input"] {
+  max-width: 220px;
+}
+
+.am-settings-branch-picker {
+  position: relative;
+}
+
+.am-settings-branch-trigger {
+  width: 100%;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.am-settings-branch-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.am-settings-branch-dropdown {
+  position: fixed;
+  width: 360px;
+  max-height: 380px;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-elevated, var(--vscode-dropdown-background));
+  border: 1px solid var(--color-border, var(--vscode-dropdown-border));
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  z-index: 100;
+}
+
+.am-settings-branch-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--color-border, var(--vscode-widget-border));
+}
+
+.am-settings-branch-search input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--color-text, var(--vscode-foreground));
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.am-settings-branch-list {
+  overflow-y: auto;
+  max-height: 320px;
+}
+
+.am-settings-branch-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  color: var(--color-text, var(--vscode-foreground));
+  cursor: pointer;
+  font-size: 13px;
+  font-family: inherit;
+  text-align: left;
+}
+
+.am-settings-branch-item.am-settings-branch-highlighted {
+  background: var(--color-bg-hover, var(--vscode-list-hoverBackground));
+}
+
+.am-settings-branch-item.am-settings-branch-active {
+  background: var(--color-bg-active, var(--vscode-list-activeSelectionBackground));
+}
+
+.am-settings-branch-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  flex: 1;
+  min-width: 0;
+}
+
+.am-settings-branch-left > span:nth-child(2) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.am-settings-branch-hint {
+  color: var(--color-text-secondary, var(--vscode-descriptionForeground));
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.am-settings-branch-badge {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--color-bg-secondary, var(--vscode-badge-background));
+  color: var(--color-text-secondary, var(--vscode-badge-foreground));
+  flex-shrink: 0;
+}
+
+.am-settings-branch-empty {
+  padding: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: center;
+  color: var(--color-text-secondary, var(--vscode-descriptionForeground));
+  font-size: 12px;
+}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentManagerTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentManagerTab.tsx
@@ -1,0 +1,286 @@
+import { Component, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js"
+import { Portal } from "solid-js/web"
+import { Select } from "@kilocode/kilo-ui/select"
+import { Button } from "@kilocode/kilo-ui/button"
+import { Card } from "@kilocode/kilo-ui/card"
+import { Icon } from "@kilocode/kilo-ui/icon"
+import { Spinner } from "@kilocode/kilo-ui/spinner"
+import { useVSCode } from "../../context/vscode"
+import { useLanguage } from "../../context/language"
+import type { BranchInfo } from "../../types/messages"
+import SettingsRow from "./SettingsRow"
+import "./AgentManagerTab.css"
+
+interface DiffOption {
+  value: "unified" | "split"
+  label: string
+}
+
+const DIFF_OPTIONS: DiffOption[] = [
+  { value: "unified", label: "Unified" },
+  { value: "split", label: "Split" },
+]
+
+const AgentManagerTab: Component = () => {
+  const vscode = useVSCode()
+  const language = useLanguage()
+
+  const [branch, setBranch] = createSignal("")
+  const [style, setStyle] = createSignal<"unified" | "split">("unified")
+  const [branches, setBranches] = createSignal<BranchInfo[]>([])
+  const [detected, setDetected] = createSignal("")
+  const [loading, setLoading] = createSignal(true)
+  const [search, setSearch] = createSignal("")
+  const [highlighted, setHighlighted] = createSignal(-1)
+  const [open, setOpen] = createSignal(false)
+
+  let triggerRef: HTMLButtonElement | undefined
+  let inputRef: HTMLInputElement | undefined
+  const [pos, setPos] = createSignal({ top: 0, right: 0 })
+
+  const filtered = createMemo(() => {
+    const s = search().toLowerCase()
+    if (!s) return branches()
+    return branches().filter((b) => b.name.toLowerCase().includes(s))
+  })
+
+  const label = () => {
+    const v = branch()
+    if (!v) {
+      const d = detected()
+      return d
+        ? `${language.t("settings.agentManager.defaultBaseBranch.auto")} (${d})`
+        : language.t("settings.agentManager.defaultBaseBranch.auto")
+    }
+    return v
+  }
+
+  const toggle = () => {
+    const next = !open()
+    if (next && triggerRef) {
+      const rect = triggerRef.getBoundingClientRect()
+      setPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right })
+    }
+    setOpen(next)
+    if (next) setTimeout(() => inputRef?.focus(), 0)
+    else {
+      setSearch("")
+      setHighlighted(-1)
+    }
+  }
+
+  const select = (name: string | undefined) => {
+    const v = name ?? ""
+    setBranch(v)
+    setOpen(false)
+    setSearch("")
+    setHighlighted(-1)
+    vscode.postMessage({ type: "setAgentManagerSetting", key: "defaultBaseBranch", value: v })
+  }
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    const items = filtered()
+    const total = items.length + 1
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      setHighlighted((p) => Math.min(p + 1, total - 2))
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault()
+      setHighlighted((p) => Math.max(p - 1, -1))
+    } else if (e.key === "Enter") {
+      e.preventDefault()
+      const idx = highlighted()
+      if (idx === -1) select(undefined)
+      else {
+        const b = items[idx]
+        if (b) select(b.name)
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault()
+      setOpen(false)
+    }
+  }
+
+  let dropdownRef: HTMLDivElement | undefined
+
+  // Close on outside click
+  const handleClickOutside = (e: MouseEvent) => {
+    if (!open()) return
+    const target = e.target as Node
+    if (triggerRef?.contains(target)) return
+    if (dropdownRef?.contains(target)) return
+    setOpen(false)
+    setSearch("")
+    setHighlighted(-1)
+  }
+  onMount(() => document.addEventListener("mousedown", handleClickOutside))
+  onCleanup(() => document.removeEventListener("mousedown", handleClickOutside))
+
+  onMount(() => {
+    const unsub = vscode.onMessage((msg) => {
+      if (msg.type === "agentManagerSettings") {
+        const s = msg as { defaultBaseBranch: string; reviewDiffStyle: "unified" | "split" }
+        setBranch(s.defaultBaseBranch)
+        setStyle(s.reviewDiffStyle)
+      }
+      if (msg.type === "agentManagerBranches") {
+        const s = msg as { branches: BranchInfo[]; defaultBranch: string }
+        setBranches(s.branches)
+        setDetected(s.defaultBranch)
+        setLoading(false)
+      }
+    })
+    vscode.postMessage({ type: "requestAgentManagerSettings" })
+    vscode.postMessage({ type: "requestAgentManagerBranches" })
+    onCleanup(unsub)
+  })
+
+  return (
+    <div>
+      <Card>
+        <div class="am-settings-branch-picker-row">
+          <SettingsRow
+            title={language.t("settings.agentManager.defaultBaseBranch.title")}
+            description={language.t("settings.agentManager.defaultBaseBranch.description")}
+          >
+            <div class="am-settings-branch-picker">
+              <Button
+                ref={triggerRef}
+                variant="secondary"
+                size="small"
+                onClick={toggle}
+                class="am-settings-branch-trigger"
+              >
+                <span class="am-settings-branch-label">{label()}</span>
+                <Icon name="selector" size="small" />
+              </Button>
+              <Show when={open()}>
+                <Portal>
+                  <div
+                    ref={dropdownRef}
+                    class="am-settings-branch-dropdown"
+                    style={{ top: `${pos().top}px`, right: `${pos().right}px` }}
+                  >
+                    <div class="am-settings-branch-search">
+                      <Icon name="magnifying-glass" size="small" />
+                      <input
+                        ref={inputRef}
+                        type="text"
+                        placeholder={language.t("settings.agentManager.defaultBaseBranch.search")}
+                        value={search()}
+                        onInput={(e) => {
+                          setSearch(e.currentTarget.value)
+                          setHighlighted(-1)
+                        }}
+                        onKeyDown={handleKeyDown}
+                      />
+                    </div>
+                    <div class="am-settings-branch-list">
+                      {/* Auto-detect option */}
+                      <button
+                        type="button"
+                        classList={{
+                          "am-settings-branch-item": true,
+                          "am-settings-branch-highlighted": highlighted() === -1,
+                          "am-settings-branch-active": !branch(),
+                        }}
+                        onClick={() => select(undefined)}
+                        onMouseEnter={() => setHighlighted(-1)}
+                      >
+                        <span class="am-settings-branch-left">
+                          <Icon name="branch" size="small" />
+                          <span>{language.t("settings.agentManager.defaultBaseBranch.auto")}</span>
+                        </span>
+                        <Show when={detected()}>
+                          <span class="am-settings-branch-hint">{detected()}</span>
+                        </Show>
+                      </button>
+
+                      <Show when={loading() && branches().length === 0}>
+                        <div class="am-settings-branch-empty">
+                          <Spinner />
+                          <span>{language.t("settings.agentManager.defaultBaseBranch.loading")}</span>
+                        </div>
+                      </Show>
+
+                      <For each={filtered()}>
+                        {(b, index) => (
+                          <button
+                            type="button"
+                            classList={{
+                              "am-settings-branch-item": true,
+                              "am-settings-branch-highlighted": highlighted() === index(),
+                              "am-settings-branch-active": branch() === b.name,
+                            }}
+                            onClick={() => select(b.name)}
+                            onMouseEnter={() => setHighlighted(index())}
+                          >
+                            <span class="am-settings-branch-left">
+                              <Icon name="branch" size="small" />
+                              <span>{b.name}</span>
+                              <Show when={b.isDefault}>
+                                <span class="am-settings-branch-badge">default</span>
+                              </Show>
+                              <Show when={!b.isLocal && b.isRemote}>
+                                <span class="am-settings-branch-badge am-settings-branch-badge-remote">remote</span>
+                              </Show>
+                            </span>
+                            <Show when={b.lastCommitDate}>
+                              <span class="am-settings-branch-hint">{b.lastCommitDate}</span>
+                            </Show>
+                          </button>
+                        )}
+                      </For>
+
+                      <Show when={!loading() && filtered().length === 0 && search()}>
+                        <div class="am-settings-branch-empty">
+                          {language.t("settings.agentManager.defaultBaseBranch.empty")}
+                        </div>
+                      </Show>
+                    </div>
+                  </div>
+                </Portal>
+              </Show>
+            </div>
+          </SettingsRow>
+        </div>
+
+        <SettingsRow
+          title={language.t("settings.agentManager.reviewDiffStyle.title")}
+          description={language.t("settings.agentManager.reviewDiffStyle.description")}
+        >
+          <Select
+            options={DIFF_OPTIONS}
+            current={DIFF_OPTIONS.find((o) => o.value === style())}
+            value={(o) => o.value}
+            label={(o) => o.label}
+            onSelect={(o) => {
+              if (!o || o.value === style()) return
+              setStyle(o.value)
+              vscode.postMessage({ type: "setAgentManagerSetting", key: "reviewDiffStyle", value: o.value })
+            }}
+            variant="secondary"
+            size="small"
+            triggerVariant="settings"
+          />
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.agentManager.setupScript.title")}
+          description={language.t("settings.agentManager.setupScript.description")}
+          last
+        >
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => vscode.postMessage({ type: "agentManager.configureSetupScript" })}
+          >
+            {language.t("settings.agentManager.setupScript.button")}
+          </Button>
+        </SettingsRow>
+      </Card>
+    </div>
+  )
+}
+
+export default AgentManagerTab

--- a/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
@@ -17,7 +17,7 @@ import DisplayTab from "./DisplayTab"
 import AutocompleteTab from "./AutocompleteTab"
 import NotificationsTab from "./NotificationsTab"
 import ContextTab from "./ContextTab"
-
+import AgentManagerTab from "./AgentManagerTab"
 import CommitMessageTab from "./CommitMessageTab"
 import ExperimentalTab from "./ExperimentalTab"
 import LanguageTab from "./LanguageTab"
@@ -139,6 +139,10 @@ const Settings: Component<SettingsProps> = (props) => {
             <span class="label">{language.t("settings.context.title")}</span>
           </Tabs.Trigger>
 
+          <Tabs.Trigger value="agentManager">
+            <Icon name="layers" />
+            <span class="label">{language.t("settings.agentManager.title")}</span>
+          </Tabs.Trigger>
           <Tabs.Trigger value="commitMessage">
             <Icon name="edit" />
             <span class="label">{language.t("settings.commitMessage.title")}</span>
@@ -198,6 +202,10 @@ const Settings: Component<SettingsProps> = (props) => {
           <ContextTab />
         </Tabs.Content>
 
+        <Tabs.Content value="agentManager">
+          <h3>{language.t("settings.agentManager.title")}</h3>
+          <AgentManagerTab />
+        </Tabs.Content>
         <Tabs.Content value="commitMessage">
           <h3>{language.t("settings.commitMessage.title")}</h3>
           <CommitMessageTab />

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -944,6 +944,20 @@ export const dict = {
   "settings.notifications.title": "الإشعارات",
   "settings.context.title": "السياق",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "تجريبي",
   "settings.language.title": "اللغة",
   "settings.aboutKiloCode.title": "حول Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -952,6 +952,20 @@ export const dict = {
   "settings.notifications.title": "Notificações",
   "settings.context.title": "Contexto",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Experimental",
   "settings.language.title": "Idioma",
   "settings.aboutKiloCode.title": "Sobre o Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -957,6 +957,20 @@ export const dict = {
   "settings.notifications.title": "Obavještenja",
   "settings.context.title": "Kontekst",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Eksperimentalno",
   "settings.language.title": "Jezik",
   "settings.aboutKiloCode.title": "O Kilo Code-u",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -950,6 +950,20 @@ export const dict = {
   "settings.notifications.title": "Notifikationer",
   "settings.context.title": "Kontekst",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Eksperimentelt",
   "settings.language.title": "Sprog",
   "settings.aboutKiloCode.title": "Om Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -962,6 +962,20 @@ export const dict = {
   "settings.notifications.title": "Benachrichtigungen",
   "settings.context.title": "Kontext",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Experimentell",
   "settings.language.title": "Sprache",
   "settings.aboutKiloCode.title": "Über Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -950,6 +950,20 @@ export const dict = {
   "settings.notifications.title": "Notifications",
   "settings.context.title": "Context",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Experimental",
   "settings.language.title": "Language",
   "settings.aboutKiloCode.title": "About Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -958,6 +958,20 @@ export const dict = {
   "settings.notifications.title": "Notificaciones",
   "settings.context.title": "Contexto",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Experimental",
   "settings.language.title": "Idioma",
   "settings.aboutKiloCode.title": "Acerca de Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -964,6 +964,20 @@ export const dict = {
   "settings.notifications.title": "Notifications",
   "settings.context.title": "Contexte",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Expérimental",
   "settings.language.title": "Langue",
   "settings.aboutKiloCode.title": "À propos de Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -949,6 +949,20 @@ export const dict = {
   "settings.notifications.title": "通知",
   "settings.context.title": "コンテキスト",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "実験的機能",
   "settings.language.title": "言語",
   "settings.aboutKiloCode.title": "Kilo Codeについて",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -949,6 +949,20 @@ export const dict = {
   "settings.notifications.title": "알림",
   "settings.context.title": "컨텍스트",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "실험적",
   "settings.language.title": "언어",
   "settings.aboutKiloCode.title": "Kilo Code 정보",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -951,6 +951,20 @@ export const dict = {
   "settings.notifications.title": "Meldingen",
   "settings.context.title": "Context",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Experimenteel",
   "settings.language.title": "Taal",
   "settings.aboutKiloCode.title": "Over Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -954,6 +954,20 @@ export const dict = {
   "settings.notifications.title": "Varslinger",
   "settings.context.title": "Kontekst",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Eksperimentelt",
   "settings.language.title": "Språk",
   "settings.aboutKiloCode.title": "Om Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -954,6 +954,20 @@ export const dict = {
   "settings.notifications.title": "Powiadomienia",
   "settings.context.title": "Kontekst",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Eksperymentalne",
   "settings.language.title": "Język",
   "settings.aboutKiloCode.title": "O Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -957,6 +957,20 @@ export const dict = {
   "settings.notifications.title": "Уведомления",
   "settings.context.title": "Контекст",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Экспериментальное",
   "settings.language.title": "Язык",
   "settings.aboutKiloCode.title": "О Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -946,6 +946,20 @@ export const dict = {
   "settings.notifications.title": "การแจ้งเตือน",
   "settings.context.title": "บริบท",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "ทดลอง",
   "settings.language.title": "ภาษา",
   "settings.aboutKiloCode.title": "เกี่ยวกับ Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -953,6 +953,20 @@ export const dict = {
   "settings.notifications.title": "Bildirimler",
   "settings.context.title": "Bağlam",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Deneysel",
   "settings.language.title": "Dil",
   "settings.aboutKiloCode.title": "Kilo Code Hakkında",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -954,6 +954,20 @@ export const dict = {
   "settings.notifications.title": "Сповіщення",
   "settings.context.title": "Контекст",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "Експериментальне",
   "settings.language.title": "Мова",
   "settings.aboutKiloCode.title": "Про Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -938,6 +938,20 @@ export const dict = {
   "settings.notifications.title": "通知",
   "settings.context.title": "上下文",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "实验性功能",
   "settings.language.title": "语言",
   "settings.aboutKiloCode.title": "关于 Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -940,6 +940,20 @@ export const dict = {
   "settings.notifications.title": "通知",
   "settings.context.title": "上下文",
 
+  "settings.agentManager.title": "Agent Manager",
+  "settings.agentManager.defaultBaseBranch.title": "Default Base Branch",
+  "settings.agentManager.defaultBaseBranch.description": "Branch used as the base when creating new worktrees.",
+  "settings.agentManager.defaultBaseBranch.auto": "Auto-detect",
+  "settings.agentManager.defaultBaseBranch.search": "Search branches...",
+  "settings.agentManager.defaultBaseBranch.loading": "Loading branches...",
+  "settings.agentManager.defaultBaseBranch.empty": "No matching branches",
+  "settings.agentManager.reviewDiffStyle.title": "Review Diff Style",
+  "settings.agentManager.reviewDiffStyle.description": "How diffs are displayed in the review panel.",
+  "settings.agentManager.setupScript.title": "Setup Script",
+  "settings.agentManager.setupScript.description":
+    "Script that runs automatically when a new worktree is created (e.g. install dependencies).",
+  "settings.agentManager.setupScript.button": "Edit Setup Script",
+
   "settings.experimental.title": "實驗性功能",
   "settings.language.title": "語言",
   "settings.aboutKiloCode.title": "關於 Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -426,6 +426,10 @@ export interface CompactionConfig {
   prune?: boolean
 }
 
+export interface CommitMessageConfig {
+  prompt?: string
+}
+
 export interface WatcherConfig {
   ignore?: string[]
 }
@@ -437,10 +441,6 @@ export interface ExperimentalConfig {
   primary_tools?: string[]
   continue_loop_on_deny?: boolean
   mcp_timeout?: number
-}
-
-export interface CommitMessageConfig {
-  prompt?: string
 }
 
 export interface Config {
@@ -464,9 +464,9 @@ export interface Config {
   formatter?: false | Record<string, unknown>
   lsp?: false | Record<string, unknown>
   compaction?: CompactionConfig
-  commit_message?: CommitMessageConfig
   tools?: Record<string, boolean>
   layout?: "auto" | "stretch"
+  commit_message?: CommitMessageConfig
   experimental?: ExperimentalConfig
 }
 
@@ -1548,6 +1548,8 @@ export type ExtensionMessage =
   | AgentManagerSessionForkedMessage
   | AgentManagerStateMessage
   | AgentManagerRunStatusMessage
+  | AgentManagerSettingsMessage
+  | AgentManagerBranchesSettingsMessage
   | AgentManagerKeybindingsMessage
   | AgentManagerMultiVersionProgressMessage
   | AgentManagerSetSessionModelMessage
@@ -2165,7 +2167,43 @@ export interface SetSessionsCollapsedRequest {
   collapsed: boolean
 }
 
-// Persist review diff style preference
+// Agent manager settings response (extension → webview, via SettingsEditorProvider)
+export interface AgentManagerSettingsMessage {
+  type: "agentManagerSettings"
+  defaultBaseBranch: string
+  reviewDiffStyle: "unified" | "split"
+}
+
+// Agent manager branches response (extension → webview, for default base branch picker)
+export interface AgentManagerBranchesSettingsMessage {
+  type: "agentManagerBranches"
+  branches: BranchInfo[]
+  defaultBranch: string
+}
+
+// Request agent manager settings from extension (via SettingsEditorProvider)
+export interface RequestAgentManagerSettingsMessage {
+  type: "requestAgentManagerSettings"
+}
+
+// Set a single agent manager setting (via SettingsEditorProvider → VS Code command)
+export interface SetAgentManagerSettingMessage {
+  type: "setAgentManagerSetting"
+  key: string
+  value: unknown
+}
+
+// Request branch list for default base branch picker
+export interface RequestAgentManagerBranchesMessage {
+  type: "requestAgentManagerBranches"
+}
+
+// Open extension settings panel (from agent manager)
+export interface OpenAgentManagerSettingsRequest {
+  type: "agentManager.openSettings"
+}
+
+// Persist review diff style from inline toggle (agent manager → extension)
 export interface SetReviewDiffStyleRequest {
   type: "agentManager.setReviewDiffStyle"
   style: "unified" | "split"
@@ -2546,6 +2584,10 @@ export type WebviewMessage =
   | SetWorktreeOrderRequest
   | SetSessionsCollapsedRequest
   | SetReviewDiffStyleRequest
+  | OpenAgentManagerSettingsRequest
+  | RequestAgentManagerSettingsMessage
+  | SetAgentManagerSettingMessage
+  | RequestAgentManagerBranchesMessage
   | PersistVariantRequest
   | RequestVariantsMessage
   | RequestCloudSessionDataMessage


### PR DESCRIPTION
## Summary

- Replace the inline settings dropdown in the agent manager with a dedicated **Agent Manager** tab in the extension settings panel
- Settings gear click now opens the settings panel directly on the Agent Manager tab
- Includes searchable branch picker (portal dropdown with keyboard navigation), diff style selector, and setup script button
- Data stays in `.kilo/agent-manager.json` via `WorktreeStateManager` — no storage migration needed
- Settings tab communicates through VS Code commands → `AgentManagerProvider` which ensures state is loaded before reads/writes, even without the agent manager panel open
- All legacy settings handlers removed from the agent manager webview

<img width="1351" height="578" alt="image" src="https://github.com/user-attachments/assets/21ee03a1-4d12-4f4c-84a4-46e7bf6730b8" />

## Test Plan

1. Open extension settings → Agent Manager tab appears between Context and Experimental
2. Change Default Base Branch → select from searchable dropdown → reflected immediately in agent manager
3. Change Review Diff Style → reflected immediately in agent manager diff panel
4. Click Edit Setup Script → opens the setup script file
5. Settings persist across tab switches and VS Code restarts
6. No running sessions are disrupted when changing settings