### PR TITLE
fix(agent-manager): preserve sections missing from worktreeOrder during move and reorder

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -304,6 +304,11 @@ export class WorktreeStateManager {
       if (!wt.sectionId) top.add(wt.id)
     }
     this.worktreeOrder = order.filter((id) => top.has(id))
+    // Append any sections/ungrouped worktrees missing from the incoming order
+    const present = new Set(this.worktreeOrder)
+    for (const id of top) {
+      if (!present.has(id)) this.worktreeOrder.push(id)
+    }
     void this.save()
   }
 
@@ -380,6 +385,11 @@ export class WorktreeStateManager {
   }
 
   moveSection(id: string, dir: -1 | 1): void {
+    // Ensure the section is in worktreeOrder (it may be missing if drag-and-drop
+    // overwrote the order before this section was tracked)
+    if (this.sections.has(id) && !this.worktreeOrder.includes(id)) {
+      this.worktreeOrder.push(id)
+    }
     const top = this.worktreeOrder.filter((item) => {
       if (this.sections.has(item)) return true
       const wt = this.worktrees.get(item)

--- a/packages/kilo-vscode/tests/unit/worktree-state-sections.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-state-sections.test.ts
@@ -122,6 +122,17 @@ describe("WorktreeStateManager sections", () => {
     })
   })
 
+  describe("setWorktreeOrder", () => {
+    it("preserves sections missing from incoming order", () => {
+      const wt = mgr.addWorktree({ branch: "a", path: "/tmp/a", parentBranch: "main" })
+      const a = mgr.addSection("A", null)
+      const b = mgr.addSection("B", null)
+      // Simulate webview sending an order that omits section B
+      mgr.setWorktreeOrder([wt.id, a.id])
+      expect(mgr.getWorktreeOrder()).toContain(b.id)
+    })
+  })
+
   describe("moveToSection", () => {
     it("sets sectionId and removes from worktreeOrder", () => {
       const wt = mgr.addWorktree({ branch: "a", path: "/tmp/a", parentBranch: "main" })
@@ -218,6 +229,16 @@ describe("WorktreeStateManager sections", () => {
       mgr.moveSection(b.id, -1)
       expect(mgr.getWorktree(wt1.id)?.sectionId).toBe(a.id)
       expect(mgr.getWorktree(wt2.id)?.sectionId).toBe(a.id)
+    })
+
+    it("moves a section that is missing from worktreeOrder", () => {
+      const a = mgr.addSection("A", null)
+      const b = mgr.addSection("B", null)
+      // Simulate a drag-and-drop that lost section B from the order
+      mgr.setWorktreeOrder([a.id])
+      expect(mgr.getWorktreeOrder()).toEqual([a.id, b.id])
+      mgr.moveSection(b.id, -1)
+      expect(mgr.getWorktreeOrder()).toEqual([b.id, a.id])
     })
 
     it("persists reordered sections across save/load", async () => {


### PR DESCRIPTION
## Summary
- Sections could silently disappear from `worktreeOrder` when drag-and-drop sent a `setWorktreeOrder` call that omitted them, making "Move Up"/"Move Down" a no-op for the affected section.
- `setWorktreeOrder()` now appends any missing sections/ungrouped worktrees to the order array instead of silently dropping them.
- `moveSection()` self-heals by adding the section to `worktreeOrder` before attempting the swap if it's missing.
- Added tests for both edge cases.