### PR TITLE
fix(agent-manager): prune orphaned sessions to prevent unbounded state file growth

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -218,12 +218,12 @@ export class WorktreeStateManager {
     const removed = this.worktrees.delete(id)
     if (!removed) return []
 
-    // Dissociate all sessions from this worktree (set worktreeId to null)
+    // Collect and remove all sessions belonging to this worktree
     const orphaned: ManagedSession[] = []
     for (const s of this.sessions.values()) {
       if (s.worktreeId === id) {
-        s.worktreeId = null
-        orphaned.push(s)
+        orphaned.push({ ...s })
+        this.sessions.delete(s.id)
       }
     }
 
@@ -234,7 +234,7 @@ export class WorktreeStateManager {
     const idx = this.worktreeOrder.indexOf(id)
     if (idx !== -1) this.worktreeOrder.splice(idx, 1)
 
-    this.log(`Removed worktree ${id}, orphaned ${orphaned.length} sessions`)
+    this.log(`Removed worktree ${id}, removed ${orphaned.length} sessions`)
     void this.save()
     return orphaned
   }
@@ -491,7 +491,13 @@ export class WorktreeStateManager {
           }) ?? wt.path
         this.worktrees.set(id, { id, ...wt, path: fixed })
       }
+      let pruned = 0
       for (const [id, s] of Object.entries(data.sessions ?? {})) {
+        // Skip orphaned sessions (null worktreeId or referencing a deleted worktree)
+        if (!s.worktreeId || !this.worktrees.has(s.worktreeId)) {
+          pruned++
+          continue
+        }
         this.sessions.set(id, { id, ...s })
       }
       for (const [id, sec] of Object.entries(data.sections ?? {})) {
@@ -517,6 +523,10 @@ export class WorktreeStateManager {
       }
       this.defaultBase = data.defaultBaseBranch
       this.log(`Loaded state: ${this.worktrees.size} worktrees, ${this.sessions.size} sessions`)
+      if (pruned > 0) {
+        this.log(`Pruned ${pruned} orphaned sessions`)
+        void this.save()
+      }
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code
       if (code !== "ENOENT") {
@@ -526,7 +536,7 @@ export class WorktreeStateManager {
     return migration
   }
 
-  /** Remove worktrees whose directories no longer exist on disk. */
+  /** Remove worktrees whose directories no longer exist on disk and prune orphaned sessions. */
   async validate(root: string): Promise<void> {
     let changed = false
     for (const wt of [...this.worktrees.values()]) {
@@ -537,7 +547,17 @@ export class WorktreeStateManager {
         changed = true
       }
     }
-    if (changed) await this.save()
+    // Prune orphaned sessions (worktreeId is null or references a deleted worktree)
+    for (const s of [...this.sessions.values()]) {
+      if (!s.worktreeId || !this.worktrees.has(s.worktreeId)) {
+        this.sessions.delete(s.id)
+        changed = true
+      }
+    }
+    if (changed) {
+      this.log(`Pruned orphaned sessions during validation`)
+      await this.save()
+    }
   }
 
   /** Wait for any in-flight save to complete without triggering a new one. */

--- a/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
@@ -41,7 +41,7 @@ describe("WorktreeStateManager", () => {
       expect(manager.findWorktreeByPath("/tmp/c")).toBeUndefined()
     })
 
-    it("removes worktree and orphans sessions", () => {
+    it("removes worktree and deletes its sessions", () => {
       const wt = manager.addWorktree({ branch: "fix", path: "/tmp/fix", parentBranch: "main" })
       manager.addSession("s1", wt.id)
       manager.addSession("s2", wt.id)
@@ -49,9 +49,10 @@ describe("WorktreeStateManager", () => {
       const orphaned = manager.removeWorktree(wt.id)
       expect(orphaned).toHaveLength(2)
       expect(manager.getWorktrees()).toHaveLength(0)
-      // Sessions still exist but with null worktreeId
-      expect(manager.getSession("s1")?.worktreeId).toBeNull()
-      expect(manager.getSession("s2")?.worktreeId).toBeNull()
+      // Sessions are removed from state
+      expect(manager.getSession("s1")).toBeUndefined()
+      expect(manager.getSession("s2")).toBeUndefined()
+      expect(manager.getSessions()).toHaveLength(0)
     })
 
     it("returns empty array when removing nonexistent worktree", () => {
@@ -140,7 +141,7 @@ describe("WorktreeStateManager", () => {
   })
 
   describe("persistence", () => {
-    it("saves and loads state", async () => {
+    it("saves and loads state, pruning orphaned sessions", async () => {
       const wt = manager.addWorktree({ branch: "fix", path: "/tmp/fix", parentBranch: "main" })
       manager.addSession("s1", wt.id)
       manager.addSession("s2", null)
@@ -153,9 +154,10 @@ describe("WorktreeStateManager", () => {
 
       expect(loaded.getWorktrees()).toHaveLength(1)
       expect(loaded.getWorktrees()[0].branch).toBe("fix")
-      expect(loaded.getSessions()).toHaveLength(2)
+      // s2 had null worktreeId so it gets pruned on load
+      expect(loaded.getSessions()).toHaveLength(1)
       expect(loaded.getSession("s1")?.worktreeId).toBe(wt.id)
-      expect(loaded.getSession("s2")?.worktreeId).toBeNull()
+      expect(loaded.getSession("s2")).toBeUndefined()
     })
 
     it("load is a no-op when file does not exist", async () => {
@@ -285,20 +287,35 @@ describe("WorktreeStateManager", () => {
   })
 
   describe("validate", () => {
-    it("removes worktrees whose directories do not exist", async () => {
+    it("removes worktrees whose directories do not exist and prunes their sessions", async () => {
       const existing = path.join(root, "wt-exists")
       fs.mkdirSync(existing, { recursive: true })
 
       manager.addWorktree({ branch: "exists", path: existing, parentBranch: "main" })
-      manager.addWorktree({ branch: "gone", path: path.join(root, "wt-gone"), parentBranch: "main" })
-      manager.addSession("s1", manager.getWorktrees()[1].id)
+      const gone = manager.addWorktree({ branch: "gone", path: path.join(root, "wt-gone"), parentBranch: "main" })
+      manager.addSession("s1", gone.id)
 
       await manager.validate(root)
 
       expect(manager.getWorktrees()).toHaveLength(1)
       expect(manager.getWorktrees()[0].branch).toBe("exists")
-      // Session orphaned (worktreeId set to null)
-      expect(manager.getSession("s1")?.worktreeId).toBeNull()
+      // Session removed along with its worktree
+      expect(manager.getSession("s1")).toBeUndefined()
+    })
+
+    it("prunes orphaned sessions with null worktreeId on validate", async () => {
+      const existing = path.join(root, "wt-exists")
+      fs.mkdirSync(existing, { recursive: true })
+
+      const wt = manager.addWorktree({ branch: "exists", path: existing, parentBranch: "main" })
+      manager.addSession("s1", wt.id)
+      manager.addSession("s2", null)
+
+      await manager.validate(root)
+
+      // s1 stays (its worktree exists), s2 is pruned (null worktreeId)
+      expect(manager.getSession("s1")).toBeTruthy()
+      expect(manager.getSession("s2")).toBeUndefined()
     })
 
     it("resolves relative paths against root", async () => {
@@ -319,8 +336,9 @@ describe("WorktreeStateManager", () => {
       for (let i = 0; i < 20; i++) {
         manager.addWorktree({ branch: `b-${i}`, path: `/tmp/b-${i}`, parentBranch: "main" })
       }
+      const wts = manager.getWorktrees()
       for (let i = 0; i < 20; i++) {
-        manager.addSession(`s-${i}`, null)
+        manager.addSession(`s-${i}`, wts[i]!.id)
       }
 
       // Wait for all fire-and-forget saves to settle
@@ -355,9 +373,9 @@ describe("WorktreeStateManager", () => {
 
       expect(loaded.getWorktrees()).toHaveLength(1)
       expect(loaded.getWorktrees()[0].branch).toBe("keep")
-      // s2 was orphaned when wt2 was removed, s1 and s3 belong to wt1
+      // s2 was removed when wt2 was removed, s1 and s3 belong to wt1
       expect(loaded.getSession("s1")?.worktreeId).toBe(wt1.id)
-      expect(loaded.getSession("s2")?.worktreeId).toBeNull()
+      expect(loaded.getSession("s2")).toBeUndefined()
       expect(loaded.getSession("s3")?.worktreeId).toBe(wt1.id)
     })
 
@@ -419,7 +437,7 @@ describe("WorktreeStateManager", () => {
       expect(manager.getSessions()).toHaveLength(0)
     })
 
-    it("handles partial data with missing worktrees key", async () => {
+    it("handles partial data with missing worktrees key and prunes orphaned sessions", async () => {
       const file = path.join(root, ".kilo", "agent-manager.json")
       fs.writeFileSync(
         file,
@@ -430,7 +448,8 @@ describe("WorktreeStateManager", () => {
       await manager.load()
 
       expect(manager.getWorktrees()).toHaveLength(0)
-      expect(manager.getSessions()).toHaveLength(1)
+      // Orphaned session with null worktreeId is pruned on load
+      expect(manager.getSessions()).toHaveLength(0)
     })
   })
 


### PR DESCRIPTION
## Summary

When a worktree is deleted, its sessions had `worktreeId` set to `null` but were never removed from `agent-manager.json`. These orphaned sessions were invisible in the UI and could never be reassigned, causing the file to grow unboundedly.

## Problem

Think of `agent-manager.json` as a hotel registry book:

**Before (broken):**
```
ROOMS (worktrees):
  Room 101 - "fix-bug"       ← active
  Room 102 - "add-feature"   ← active

GUESTS (sessions):
  Alice  → Room 101          ← active, visible in UI
  Bob    → Room 102          ← active, visible in UI
  Carol  → Room NULL         ← Room 103 was demolished last week
  Dave   → Room NULL         ← Room 103 was demolished last week
  Eve    → Room NULL         ← Room 104 was demolished last month
  Frank  → Room NULL         ← Room 104 was demolished last month
  ... 160 more guests pointing to demolished rooms ...
```

**After (fixed):**
```
ROOMS (worktrees):
  Room 101 - "fix-bug"
  Room 102 - "add-feature"

GUESTS (sessions):
  Alice  → Room 101
  Bob    → Room 102
```

When Room 102 is deleted, Bob is removed from the registry. But Bob himself (the CLI session with all chat history and data) still exists in the CLI backend's database — `agent-manager.json` only tracks the worktree-to-session mapping.

Real example: a user had **8 active worktrees** but **~170 session entries**, with ~160 being dead orphans.

## Changes

- **`removeWorktree()`** now deletes sessions from state instead of setting `worktreeId = null`. Still returns the removed sessions array (as copies) so callers can clean up diff polling and session directories.
- **`load()`** skips orphaned sessions during deserialization — provides one-time cleanup for existing bloated files.
- **`validate()`** also prunes orphaned sessions for completeness.

## Safety

No data loss — `agent-manager.json` is a UI association layer, not a data store. CLI sessions (chat history, messages, tool calls) live in the CLI backend's database, completely independent. Audited all 13 session read paths: every consumer already handles missing sessions gracefully via optional chaining or early returns.