### PR TITLE
fix(vscode): sync mode picker from assistant messages too

### DIFF
--- a/packages/kilo-vscode/tests/unit/session-agent.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-agent.test.ts
@@ -26,13 +26,22 @@ describe("resolveSessionAgent", () => {
     expect(result).toBe("code")
   })
 
-  it("ignores assistant messages", () => {
+  it("returns the latest assistant agent when it is last", () => {
     const result = resolveSessionAgent(
-      [makeMessage({ role: "assistant", agent: "code" }), makeMessage({ agent: "plan" })],
+      [makeMessage({ agent: "plan" }), makeMessage({ role: "assistant", agent: "code" })],
       new Set(["plan", "code"]),
     )
 
-    expect(result).toBe("plan")
+    expect(result).toBe("code")
+  })
+
+  it("ignores unknown agent names on assistant messages", () => {
+    const result = resolveSessionAgent(
+      [makeMessage({ agent: "code" }), makeMessage({ role: "assistant", agent: "task" })],
+      new Set(["code"]),
+    )
+
+    expect(result).toBe("code")
   })
 
   it("ignores unknown agent names", () => {
@@ -49,9 +58,18 @@ describe("resolveSessionAgent", () => {
     expect(result).toBeUndefined()
   })
 
-  it("returns undefined when no valid user agent exists", () => {
+  it("returns agent from assistant when no user has agent", () => {
     const result = resolveSessionAgent(
-      [makeMessage({ role: "assistant", agent: "code" }), makeMessage({ agent: undefined })],
+      [makeMessage({ agent: undefined }), makeMessage({ role: "assistant", agent: "code" })],
+      new Set(["code"]),
+    )
+
+    expect(result).toBe("code")
+  })
+
+  it("returns undefined when no message has a valid agent", () => {
+    const result = resolveSessionAgent(
+      [makeMessage({ agent: undefined }), makeMessage({ role: "assistant", agent: undefined })],
       new Set(["code"]),
     )
 

--- a/packages/kilo-vscode/webview-ui/src/context/session-agent.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-agent.ts
@@ -2,9 +2,7 @@ import type { Message } from "../types/messages"
 
 export function resolveSessionAgent(messages: Message[], names: Set<string>): string | undefined {
   for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]
-    if (msg.role !== "user") continue
-    const name = msg.agent?.trim()
+    const name = messages[i]?.agent?.trim()
     if (!name) continue
     if (!names.has(name)) continue
     return name

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -851,11 +851,12 @@ export const SessionProvider: ParentComponent = (props) => {
       return [...msgs, message]
     })
 
-    if (message.role === "user") {
-      const agent = message.agent?.trim()
-      if (agent && agentNames().has(agent)) {
-        setStore("agentSelections", message.sessionID, agent)
-      }
+    // Sync mode picker from any message role (user or assistant).
+    // agentNames() already excludes subagent/hidden agents, so subtask
+    // assistant messages (e.g. "task" agent) are silently ignored.
+    const agent = message.agent?.trim()
+    if (agent && agentNames().has(agent)) {
+      setStore("agentSelections", message.sessionID, agent)
     }
 
     if (message.parts && message.parts.length > 0) {


### PR DESCRIPTION
## Summary

Follows up on #8426. The mode picker sync introduced there only considered **user messages** (`role === "user"`) when updating the selected agent. This PR extends it to also consider **assistant messages**, making the sync more robust.

## When the mode picker updates

| Scenario | Before (PR #8426) | After (this PR) |
|---|---|---|
| User picks mode from the mode switcher | ✅ Updates | ✅ Updates |
| User sends a message (user msg SSE arrives) | ✅ Updates | ✅ Updates |
| Plan → Code via PlanFollowup (synthetic user msg) | ✅ Updates | ✅ Updates |
| QuestionDock option with `mode` field | ✅ Updates (optimistic) | ✅ Updates (optimistic) |
| Session switch/reload, last msg is a user | ✅ Updates | ✅ Updates |
| Session switch/reload, last msg is an assistant | ❌ Falls back to default | ✅ Updates from assistant agent |
| User msg SSE missed, assistant msg SSE arrives | ❌ Picker stays stale | ✅ Updates from assistant agent |
| Assistant from subtask/subagent turn (e.g. "task") | ❌ Ignored | ❌ Ignored (filtered by `agentNames()`) |

## Problem

`handleMessageCreated` and `resolveSessionAgent` both filtered to user messages only. This meant the mode picker could stay stale when:

- A user message SSE event was missed but the assistant SSE arrived
- Session reload/switch where the last message in history is an assistant
- Any future backend flow where the assistant message carries the authoritative agent

## Why this is safe

**Subagent filtering is already handled**: `agentNames()` is built from `agents()`, which is populated via `filterVisibleAgents()` — this excludes agents with `mode === "subagent"` or `hidden === true`. So assistant messages from subtask turns (e.g. `"task"` agent) have agent names that are NOT in `agentNames()` and are silently ignored.

**No performance impact**: The added work per assistant message is a single `.trim()` + `Set.has()` check. In the typical case (user sends `agent: "code"`, assistant responds `agent: "code"`), the `setStore` writes the same value — SolidJS detects no change and triggers no re-renders.

## Why the original filter existed

PR #8426 introduced the user-only filter as a conservative approach: user messages are the explicit source of mode selection (set by the picker or PlanFollowup). Assistant messages were seen as just echoing the preceding user message's agent. That's true in normal operation, but too strict for edge cases.