### PR TITLE
feat: diff on edit/create files permission

### DIFF
--- a/packages/kilo-ui/src/components/diff.tsx
+++ b/packages/kilo-ui/src/components/diff.tsx
@@ -142,6 +142,24 @@ export function Diff<T>(props: DiffProps<T>) {
     host.removeAttribute("data-color-scheme")
   }
 
+  // Patch a bug in @pierre/diffs where `grid-template-columns: 100% auto` is set
+  // for `line-info-basic` separators under `@media (pointer: fine)`, causing the
+  // expand button to consume 100% of the gutter width and overlap the separator
+  // content text. We inject into `@layer unsafe` which overrides `@layer base`.
+  let separatorPatchSheet: CSSStyleSheet | null = null
+  const patchSeparatorLayout = () => {
+    const root = getRoot()
+    if (!root) return
+    if (!separatorPatchSheet) {
+      separatorPatchSheet = new CSSStyleSheet()
+      separatorPatchSheet.replaceSync(
+        `@layer unsafe { @media (pointer: fine) { [data-separator='line-info-basic'][data-expand-index] [data-separator-wrapper] { grid-template-columns: 34px auto; } } }`,
+      )
+    }
+    if (!root.adoptedStyleSheets.includes(separatorPatchSheet))
+      root.adoptedStyleSheets = [...root.adoptedStyleSheets, separatorPatchSheet]
+  }
+
   const lineIndex = (split: boolean, element: HTMLElement) => {
     const raw = element.dataset.lineIndex
     if (!raw) return
@@ -576,6 +594,7 @@ export function Diff<T>(props: DiffProps<T>) {
     })
 
     applyScheme()
+    patchSeparatorLayout()
 
     setRendered((value) => value + 1)
     notifyRendered()

--- a/packages/kilo-vscode/esbuild.js
+++ b/packages/kilo-vscode/esbuild.js
@@ -191,23 +191,34 @@ async function main() {
   // Build Diff Viewer webview (SolidJS, reuses Agent Manager diff components)
   const diffViewerCtx = await createBrowserWebviewContext("webview-ui/diff-viewer/index.tsx", "dist/diff-viewer.js")
 
+  // Build Diff Virtual webview (lightweight single-file diff for permission approval)
+  const diffVirtualCtx = await createBrowserWebviewContext("webview-ui/diff-virtual/index.tsx", "dist/diff-virtual.js")
+
   // Build webview
   const webviewCtx = await createBrowserWebviewContext("webview-ui/src/index.tsx", "dist/webview.js")
 
   if (watch) {
-    await Promise.all([extensionCtx.watch(), webviewCtx.watch(), agentManagerCtx.watch(), diffViewerCtx.watch()])
+    await Promise.all([
+      extensionCtx.watch(),
+      webviewCtx.watch(),
+      agentManagerCtx.watch(),
+      diffViewerCtx.watch(),
+      diffVirtualCtx.watch(),
+    ])
   } else {
     await Promise.all([
       extensionCtx.rebuild(),
       webviewCtx.rebuild(),
       agentManagerCtx.rebuild(),
       diffViewerCtx.rebuild(),
+      diffVirtualCtx.rebuild(),
     ])
     await Promise.all([
       extensionCtx.dispose(),
       webviewCtx.dispose(),
       agentManagerCtx.dispose(),
       diffViewerCtx.dispose(),
+      diffVirtualCtx.dispose(),
     ])
   }
 }

--- a/packages/kilo-vscode/knip.json
+++ b/packages/kilo-vscode/knip.json
@@ -4,6 +4,7 @@
     "src/extension.ts",
     "webview-ui/agent-manager/index.tsx",
     "webview-ui/diff-viewer/index.tsx",
+    "webview-ui/diff-virtual/index.tsx",
     "webview-ui/src/index.tsx",
     "src/**/__tests__/**/*.{ts,spec.ts}",
     "src/**/*.test.ts",

--- a/packages/kilo-vscode/src/DiffVirtualProvider.ts
+++ b/packages/kilo-vscode/src/DiffVirtualProvider.ts
@@ -1,0 +1,107 @@
+import * as vscode from "vscode"
+import { buildWebviewHtml } from "./utils"
+import { appendOutput, getWorkspaceRoot } from "./review-utils"
+
+export interface DiffVirtualFile {
+  file: string
+  before: string
+  after: string
+  additions: number
+  deletions: number
+}
+
+/**
+ * DiffVirtualProvider opens a lightweight diff viewer for a single in-memory
+ * file diff (not backed by git). Used by the permission approval dock to show
+ * edit changes before the user approves or rejects them.
+ */
+export class DiffVirtualProvider implements vscode.Disposable {
+  private panel: vscode.WebviewPanel | undefined
+  private pending: DiffVirtualFile | undefined
+  private outputChannel: vscode.OutputChannel
+
+  constructor(private readonly extensionUri: vscode.Uri) {
+    this.outputChannel = vscode.window.createOutputChannel("Kilo Diff Virtual")
+  }
+
+  private log(...args: unknown[]) {
+    appendOutput(this.outputChannel, "DiffVirtual", ...args)
+  }
+
+  public open(diff: DiffVirtualFile): void {
+    this.pending = diff
+    const filename = diff.file.split("/").pop() ?? diff.file
+    const title = `Changes: ${filename}`
+
+    if (this.panel) {
+      this.panel.title = title
+      this.panel.reveal(vscode.ViewColumn.One)
+      this.pushData()
+      return
+    }
+
+    const panel = vscode.window.createWebviewPanel("kilo-code.new.DiffVirtualPanel", title, vscode.ViewColumn.One, {
+      enableScripts: true,
+      retainContextWhenHidden: true,
+      localResourceRoots: [this.extensionUri],
+    })
+
+    panel.iconPath = {
+      light: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-light.svg"),
+      dark: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-dark.svg"),
+    }
+
+    panel.webview.html = this.getHtml(panel.webview)
+    panel.webview.onDidReceiveMessage((msg) => this.onMessage(msg))
+    panel.onDidDispose(() => {
+      this.log("Panel disposed")
+      this.panel = undefined
+      this.pending = undefined
+    })
+
+    this.panel = panel
+  }
+
+  private onMessage(msg: Record<string, unknown>): void {
+    const type = msg.type as string
+
+    if (type === "webviewReady") {
+      this.post({
+        type: "ready",
+        vscodeLanguage: vscode.env.language,
+        languageOverride: vscode.workspace.getConfiguration("kilo-code.new").get<string>("language"),
+        workspaceDirectory: getWorkspaceRoot(),
+      })
+      this.pushData()
+      return
+    }
+
+    if (type === "diffVirtual.close") {
+      this.panel?.dispose()
+    }
+  }
+
+  private pushData(): void {
+    if (!this.pending) return
+    this.post({ type: "diffVirtual.data", diff: this.pending })
+  }
+
+  private post(message: Record<string, unknown>): void {
+    if (this.panel?.webview) void this.panel.webview.postMessage(message)
+  }
+
+  private getHtml(webview: vscode.Webview): string {
+    return buildWebviewHtml(webview, {
+      scriptUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "diff-virtual.js")),
+      styleUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "diff-virtual.css")),
+      iconsBaseUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "assets", "icons")),
+      title: "Diff Virtual",
+      extraStyles: "#root { display: flex; flex-direction: column; height: 100%; }",
+    })
+  }
+
+  public dispose(): void {
+    this.panel?.dispose()
+    this.outputChannel.dispose()
+  }
+}

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -197,6 +197,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     | ((sessionId: string, progress: (status: string, detail?: string, error?: string) => void) => Promise<void>)
     | null = null
 
+  private diffVirtualProvider: import("./DiffVirtualProvider").DiffVirtualProvider | undefined
+
   constructor(
     private readonly extensionUri: vscode.Uri,
     private readonly connectionService: KiloConnectionService,
@@ -213,6 +215,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (this.projectDirectory === directory) return
     this.projectDirectory = directory
     this.postMessage({ type: "workspaceDirectoryChanged", directory: directory ?? "" })
+  }
+
+  public setDiffVirtualProvider(provider: import("./DiffVirtualProvider").DiffVirtualProvider): void {
+    this.diffVirtualProvider = provider
   }
 
   getTelemetryProperties(): Record<string, unknown> {
@@ -626,6 +632,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         case "openChanges":
           vscode.commands.executeCommand("kilo-code.new.showChanges")
+          break
+        case "openDiffVirtual":
+          if (this.diffVirtualProvider && message.diff) {
+            this.diffVirtualProvider.open(message.diff)
+          }
           break
         case "continueInWorktree":
           if (message.sessionId && this.continueInWorktreeHandler) {

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -9,16 +9,23 @@ import * as vscode from "vscode"
 import type { Host, PanelContext, OutputHandle, SessionProvider, Disposable } from "./host"
 import type { KiloConnectionService } from "../services/cli-backend"
 import { KiloProvider } from "../KiloProvider"
+import { DiffVirtualProvider } from "../DiffVirtualProvider"
 import { buildWebviewHtml } from "../utils"
 import { openFileInEditor, getWorkspaceRoot } from "../review-utils"
 import { TelemetryProxy, type TelemetryEventName } from "../services/telemetry"
 
 export class VscodeHost implements Host {
+  private diffVirtual: DiffVirtualProvider | undefined
+
   constructor(
     private readonly extensionUri: vscode.Uri,
     private readonly connectionService: KiloConnectionService,
     private readonly context: vscode.ExtensionContext,
   ) {}
+
+  setDiffVirtualProvider(provider: DiffVirtualProvider): void {
+    this.diffVirtual = provider
+  }
 
   openPanel(opts: {
     onBeforeMessage: (msg: Record<string, unknown>) => Promise<Record<string, unknown> | null>
@@ -74,6 +81,9 @@ export class VscodeHost implements Host {
     const provider = new KiloProvider(this.extensionUri, this.connectionService, this.context, {
       slimEditMetadata: true,
     })
+    if (this.diffVirtual) {
+      provider.setDiffVirtualProvider(this.diffVirtual)
+    }
     provider.attachToWebview(panel.webview, {
       onBeforeMessage: opts.onBeforeMessage,
     })

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -106,6 +106,7 @@ export function activate(context: vscode.ExtensionContext) {
         tabProvider.setContinueInWorktreeHandler((sessionId, progress) =>
           agentManagerProvider.continueFromSidebar(sessionId, progress),
         )
+        tabProvider.setDiffVirtualProvider(diffVirtualProvider)
         tabProvider.resolveWebviewPanel(panel)
         tabPanels.set(panel, tabProvider)
         panel.onDidDispose(
@@ -227,7 +228,7 @@ export function activate(context: vscode.ExtensionContext) {
       provider.postMessage({ type: "triggerTask", text: `Generate a terminal command: ${input}` })
     }),
     vscode.commands.registerCommand("kilo-code.new.openInTab", () => {
-      return openKiloInNewTab(context, connectionService, agentManagerProvider, tabPanels)
+      return openKiloInNewTab(context, connectionService, agentManagerProvider, tabPanels, diffVirtualProvider)
     }),
     vscode.commands.registerCommand("kilo-code.new.showChanges", () => {
       diffViewerProvider.openPanel()
@@ -359,6 +360,7 @@ async function openKiloInNewTab(
   connectionService: KiloConnectionService,
   agentManagerProvider: AgentManagerProvider,
   tabPanels: Map<vscode.WebviewPanel, KiloProvider>,
+  diffVirtualProvider: DiffVirtualProvider,
 ) {
   const lastCol = Math.max(...vscode.window.visibleTextEditors.map((e) => e.viewColumn || 0), 0)
   const hasVisibleEditors = vscode.window.visibleTextEditors.length > 0
@@ -384,6 +386,7 @@ async function openKiloInNewTab(
   tabProvider.setContinueInWorktreeHandler((sessionId, progress) =>
     agentManagerProvider.continueFromSidebar(sessionId, progress),
   )
+  tabProvider.setDiffVirtualProvider(diffVirtualProvider)
   tabProvider.resolveWebviewPanel(panel)
   tabPanels.set(panel, tabProvider)
 

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -133,6 +133,7 @@ export function activate(context: vscode.ExtensionContext) {
   // Create diff virtual provider (lightweight single-file diff for permission approval)
   const diffVirtualProvider = new DiffVirtualProvider(context.extensionUri)
   provider.setDiffVirtualProvider(diffVirtualProvider)
+  agentManagerHost.setDiffVirtualProvider(diffVirtualProvider)
   context.subscriptions.push(diffVirtualProvider)
 
   // Create settings/profile editor provider (opens in editor area, not sidebar)

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -3,6 +3,7 @@ import { KiloProvider } from "./KiloProvider"
 import { AgentManagerProvider } from "./agent-manager/AgentManagerProvider"
 import { VscodeHost } from "./agent-manager/vscode-host"
 import { DiffViewerProvider } from "./DiffViewerProvider"
+import { DiffVirtualProvider } from "./DiffVirtualProvider"
 import { SettingsEditorProvider } from "./SettingsEditorProvider"
 import { SubAgentViewerProvider } from "./SubAgentViewerProvider"
 import { EXTENSION_DISPLAY_NAME } from "./constants"
@@ -127,6 +128,11 @@ export function activate(context: vscode.ExtensionContext) {
     void provider.appendReviewComments(comments, autoSend)
   })
   context.subscriptions.push(diffViewerProvider)
+
+  // Create diff virtual provider (lightweight single-file diff for permission approval)
+  const diffVirtualProvider = new DiffVirtualProvider(context.extensionUri)
+  provider.setDiffVirtualProvider(diffVirtualProvider)
+  context.subscriptions.push(diffVirtualProvider)
 
   // Create settings/profile editor provider (opens in editor area, not sidebar)
   const settingsEditorProvider = new SettingsEditorProvider(context.extensionUri, connectionService, context)

--- a/packages/kilo-vscode/src/kilo-provider/slim-metadata.ts
+++ b/packages/kilo-vscode/src/kilo-provider/slim-metadata.ts
@@ -112,12 +112,28 @@ function slimMultiedit(state: Record<string, unknown>): Record<string, unknown> 
   return next
 }
 
-/** write: strip input.content (entire file). Keep filePath + diagnostics. */
+/** write: strip input.content, raw diff text, and filediff.before/after. Keep filepath + exists + diagnostics. */
 function slimWrite(state: Record<string, unknown>): Record<string, unknown> {
   const next = { ...state }
   const input = state.input
   if (isObj(input) && typeof input.content === "string") {
     next.input = { ...input, content: undefined }
+  }
+  const meta = state.metadata
+  if (isObj(meta)) {
+    const slim: Record<string, unknown> = {}
+    if (meta.filepath) slim.filepath = meta.filepath
+    if (meta.exists !== undefined) slim.exists = meta.exists
+    if (meta.diagnostics) slim.diagnostics = meta.diagnostics
+    const fd = meta.filediff
+    if (isObj(fd)) {
+      slim.filediff = {
+        ...(typeof fd.file === "string" ? { file: fd.file } : {}),
+        additions: typeof fd.additions === "number" ? fd.additions : 0,
+        deletions: typeof fd.deletions === "number" ? fd.deletions : 0,
+      }
+    }
+    next.metadata = slim
   }
   return next
 }

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -32,6 +32,7 @@ const TSX_FILES = [
   path.join(ROOT, "webview-ui/agent-manager/BranchSelect.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/WorktreeItem.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/SectionHeader.tsx"),
+  path.join(ROOT, "webview-ui/diff-virtual/DiffVirtualApp.tsx"),
 ]
 const TSX_FILE = TSX_FILES[0]
 const PROVIDER_FILE = path.join(ROOT, "src/agent-manager/AgentManagerProvider.ts")

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -3252,6 +3252,23 @@ body.am-wt-dragging-active * {
   font-weight: 500;
 }
 
+/* Virtual diff panel: file path in toolbar stats area */
+
+.am-review-toolbar-dir {
+  color: var(--text-weak);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 1;
+}
+
+.am-review-toolbar-fname {
+  color: var(--text-base);
+  white-space: nowrap;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
 /* Review body: file tree + diff viewer */
 
 .am-review-body {

--- a/packages/kilo-vscode/webview-ui/diff-virtual/DiffVirtualApp.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-virtual/DiffVirtualApp.tsx
@@ -1,0 +1,125 @@
+import { createSignal, onCleanup, Show } from "solid-js"
+import type { Component } from "solid-js"
+import { CodeComponentProvider } from "@kilocode/kilo-ui/context/code"
+import { DiffComponentProvider } from "@kilocode/kilo-ui/context/diff"
+import { FileComponentProvider } from "@kilocode/kilo-ui/context/file"
+import { MarkedProvider } from "@kilocode/kilo-ui/context/marked"
+import { Code } from "@kilocode/kilo-ui/code"
+import { Diff } from "@kilocode/kilo-ui/diff"
+import { File } from "@kilocode/kilo-ui/file"
+import { FileIcon } from "@kilocode/kilo-ui/file-icon"
+import { RadioGroup } from "@kilocode/kilo-ui/radio-group"
+import { ThemeProvider } from "@kilocode/kilo-ui/theme"
+import { LanguageProvider, useLanguage } from "../src/context/language"
+import { ServerProvider, useServer } from "../src/context/server"
+import { VSCodeProvider } from "../src/context/vscode"
+
+type DiffStyle = "unified" | "split"
+
+interface DiffVirtualFile {
+  file: string
+  before: string
+  after: string
+  additions: number
+  deletions: number
+}
+
+const DiffVirtualContent: Component = () => {
+  const { t } = useLanguage()
+  const [diff, setDiff] = createSignal<DiffVirtualFile | null>(null)
+  const [style, setStyle] = createSignal<DiffStyle>("unified")
+
+  const handler = (event: MessageEvent) => {
+    const msg = event.data as { type: string; diff?: DiffVirtualFile }
+    if (msg?.type === "diffVirtual.data" && msg.diff) {
+      setDiff(msg.diff)
+    }
+  }
+
+  window.addEventListener("message", handler)
+  onCleanup(() => window.removeEventListener("message", handler))
+
+  const filename = () => {
+    const f = diff()?.file ?? ""
+    return f.includes("/") ? (f.split("/").pop() ?? f) : f
+  }
+
+  const directory = () => {
+    const f = diff()?.file ?? ""
+    if (!f.includes("/")) return null
+    return f.split("/").slice(0, -1).join("/")
+  }
+
+  return (
+    <div class="am-review-layout">
+      <Show when={diff()}>
+        {(d) => (
+          <>
+            <div class="am-review-toolbar">
+              <div class="am-review-toolbar-left">
+                <RadioGroup
+                  options={["unified", "split"] as const}
+                  current={style()}
+                  size="small"
+                  value={(s) => s}
+                  label={(s) =>
+                    s === "unified" ? t("ui.sessionReview.diffStyle.unified") : t("ui.sessionReview.diffStyle.split")
+                  }
+                  onSelect={(s) => {
+                    if (s) setStyle(s)
+                  }}
+                />
+                <span class="am-review-toolbar-stats">
+                  <FileIcon node={{ path: d().file, type: "file" }} />
+                  <Show when={directory()}>
+                    <span class="am-review-toolbar-dir">{`\u202A${directory()}/\u202C`}</span>
+                  </Show>
+                  <span class="am-review-toolbar-fname">{filename()}</span>
+                  <span class="am-review-toolbar-adds">+{d().additions}</span>
+                  <span class="am-review-toolbar-dels">-{d().deletions}</span>
+                </span>
+              </div>
+            </div>
+            <div class="am-review-diff" style={{ width: "100%" }}>
+              <Diff
+                before={{ name: d().file, contents: d().before }}
+                after={{ name: d().file, contents: d().after }}
+                diffStyle={style()}
+              />
+            </div>
+          </>
+        )}
+      </Show>
+    </div>
+  )
+}
+
+const DiffVirtualShell: Component = () => {
+  const server = useServer()
+
+  return (
+    <LanguageProvider vscodeLanguage={server.vscodeLanguage} languageOverride={server.languageOverride}>
+      <DiffComponentProvider component={Diff}>
+        <CodeComponentProvider component={Code}>
+          <FileComponentProvider component={File}>
+            <MarkedProvider>
+              <DiffVirtualContent />
+            </MarkedProvider>
+          </FileComponentProvider>
+        </CodeComponentProvider>
+      </DiffComponentProvider>
+    </LanguageProvider>
+  )
+}
+
+export const DiffVirtualApp: Component = () => {
+  return (
+    <ThemeProvider defaultTheme="kilo-vscode">
+      <VSCodeProvider>
+        <ServerProvider>
+          <DiffVirtualShell />
+        </ServerProvider>
+      </VSCodeProvider>
+    </ThemeProvider>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/diff-virtual/index.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-virtual/index.tsx
@@ -1,0 +1,10 @@
+import { render } from "solid-js/web"
+import "@kilocode/kilo-ui/styles"
+import "../src/styles/chat.css"
+import "../agent-manager/agent-manager.css"
+import { DiffVirtualApp } from "./DiffVirtualApp"
+
+const root = document.getElementById("root")
+if (root) {
+  render(() => <DiffVirtualApp />, root)
+}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDiff.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDiff.tsx
@@ -65,8 +65,8 @@ export const PermissionDiff: Component<PermissionDiffProps> = (props) => {
       </div>
       <div data-slot="permission-diff-content">
         <Diff
-          before={{ name: props.filediff.file, contents: props.filediff.before }}
-          after={{ name: props.filediff.file, contents: props.filediff.after }}
+          before={{ name: props.filediff.file, contents: props.filediff.before ?? "" }}
+          after={{ name: props.filediff.file, contents: props.filediff.after ?? "" }}
           diffStyle="unified"
         />
       </div>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDiff.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDiff.tsx
@@ -1,0 +1,75 @@
+import { type Component, createMemo } from "solid-js"
+import { Diff } from "@kilocode/kilo-ui/diff"
+import { DiffChanges } from "@kilocode/kilo-ui/diff-changes"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
+import type { PermissionFileDiff } from "../../types/messages"
+import { useVSCode } from "../../context/vscode"
+
+interface PermissionDiffProps {
+  filediff: PermissionFileDiff
+}
+
+export const PermissionDiff: Component<PermissionDiffProps> = (props) => {
+  const vscode = useVSCode()
+  const filename = createMemo(() => {
+    const parts = props.filediff.file.split("/")
+    return parts[parts.length - 1] ?? props.filediff.file
+  })
+
+  const directory = createMemo(() => {
+    const parts = props.filediff.file.split("/")
+    if (parts.length <= 1) return null
+    return parts.slice(0, -1).join("/")
+  })
+
+  const openInTab = () => {
+    vscode.postMessage({
+      type: "openDiffVirtual",
+      diff: props.filediff,
+    })
+  }
+
+  return (
+    <div data-slot="permission-diff">
+      <div data-slot="permission-diff-header">
+        <div data-slot="permission-diff-file-info">
+          <div data-slot="permission-diff-icon">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              data-component="file-icon"
+            >
+              <path
+                d="M3 2C3 1.44772 3.44772 1 4 1H10.1716C10.4368 1 10.6911 1.10536 10.8787 1.29289L13.7071 4.12132C13.8946 4.30886 14 4.56312 14 4.82843V13C14 13.5523 13.5523 14 13 14H4C3.44772 14 3 13.5523 3 13V2Z"
+                fill="var(--vscode-editorLineNumber-foreground, #858585)"
+                stroke="var(--vscode-editorLineNumber-foreground, #858585)"
+                stroke-width="0.5"
+              />
+            </svg>
+          </div>
+          <div data-slot="permission-diff-filename">
+            {directory() && <span data-slot="permission-diff-directory">{directory()}/</span>}
+            <span data-slot="permission-diff-name">{filename()}</span>
+          </div>
+        </div>
+        <div data-slot="permission-diff-actions">
+          <DiffChanges changes={props.filediff} />
+          <Tooltip value="View in new tab">
+            <IconButton size="small" icon="expand" onClick={openInTab} aria-label="View diff in new tab" />
+          </Tooltip>
+        </div>
+      </div>
+      <div data-slot="permission-diff-content">
+        <Diff
+          before={{ name: props.filediff.file, contents: props.filediff.before }}
+          after={{ name: props.filediff.file, contents: props.filediff.after }}
+          diffStyle="unified"
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -19,6 +19,7 @@ import { useLanguage } from "../../context/language"
 import { useConfig } from "../../context/config"
 import { describePatterns, resolveLabel, savedRuleStates, type RuleDecision } from "./permission-dock-utils"
 import { PermissionCommand } from "./PermissionCommand"
+import { PermissionDiff } from "./PermissionDiff"
 import type { PermissionRequest } from "../../types/messages"
 
 let rulesExpandedPreference = false
@@ -45,6 +46,13 @@ export const PermissionDock: Component<{
   const description = createMemo(() =>
     command() ? null : describePatterns(props.request.toolName, props.request.patterns, language.t),
   )
+
+  const filediff = () => {
+    if (props.request.toolName !== "edit" && props.request.toolName !== "write") return null
+    const fd = props.request.args?.filediff
+    if (!fd || typeof fd !== "object") return null
+    return fd as NonNullable<PermissionRequest["args"]["filediff"]>
+  }
 
   // Pre-populate toggle states from existing config rules so previously
   // approved/denied patterns show their saved state immediately.
@@ -234,6 +242,8 @@ export const PermissionDock: Component<{
             </div>
           )
         })()}
+
+        <Show when={filediff()}>{(fd) => <PermissionDiff filediff={fd()} />}</Show>
 
         <div data-slot="permission-actions">
           <Button

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -523,6 +523,24 @@ export const SessionProvider: ParentComponent = (props) => {
     vscode.postMessage({ type: "removeSkill", location })
   }
 
+  // Handle permission events immediately (not in onMount) so we never miss
+  // the first permission request that may arrive before the DOM mounts.
+  // This matches the pattern already used for agentsLoaded and skillsLoaded.
+  const unsubPermissions = vscode.onMessage((message: ExtensionMessage) => {
+    switch (message.type) {
+      case "permissionRequest":
+        handlePermissionRequest(message.permission)
+        break
+      case "permissionResolved":
+        handlePermissionResolved(message.permissionID)
+        break
+      case "permissionError":
+        handlePermissionError(message.permissionID)
+        break
+    }
+  })
+  onCleanup(unsubPermissions)
+
   // MCP status loaded from CLI backend
   const unsubMcpStatus = vscode.onMessage((message: ExtensionMessage) => {
     if (message.type === "mcpStatusLoaded") {
@@ -643,18 +661,6 @@ export const SessionProvider: ParentComponent = (props) => {
 
         case "sessionStatus":
           handleSessionStatus(message.sessionID, message.status, message.attempt, message.message, message.next)
-          break
-
-        case "permissionRequest":
-          handlePermissionRequest(message.permission)
-          break
-
-        case "permissionResolved":
-          handlePermissionResolved(message.permissionID)
-          break
-
-        case "permissionError":
-          handlePermissionError(message.permissionID)
           break
 
         case "todoUpdated":

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -1996,6 +1996,101 @@
     word-break: break-all;
   }
 
+  [data-slot="permission-diff"] {
+    margin: 8px 0;
+    border: 1px solid var(--border-weak-base);
+    border-radius: 4px;
+    overflow: hidden;
+    --diffs-light-bg: var(--vscode-editor-background, #1e1e1e);
+    --diffs-dark-bg: var(--vscode-editor-background, #1e1e1e);
+    --syntax-diff-add: #2ea043;
+    --syntax-diff-delete: #da3633;
+    --diffs-bg-deletion-override: color-mix(
+      in lab,
+      var(--vscode-editor-background, #1e1e1e) 82%,
+      var(--syntax-diff-delete, #da3633)
+    );
+    --diffs-bg-deletion-number-override: color-mix(
+      in lab,
+      var(--vscode-editor-background, #1e1e1e) 72%,
+      var(--syntax-diff-delete, #da3633)
+    );
+    --diffs-bg-addition-override: color-mix(
+      in lab,
+      var(--vscode-editor-background, #1e1e1e) 82%,
+      var(--syntax-diff-add, #2ea043)
+    );
+    --diffs-bg-addition-number-override: color-mix(
+      in lab,
+      var(--vscode-editor-background, #1e1e1e) 72%,
+      var(--syntax-diff-add, #2ea043)
+    );
+  }
+
+  [data-slot="permission-diff-header"] {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 6px 12px;
+    background: var(--surface-base, var(--vscode-editorWidget-background));
+    border-bottom: 1px solid var(--border-weak-base);
+  }
+
+  [data-slot="permission-diff-file-info"] {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  [data-slot="permission-diff-icon"] {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  [data-slot="permission-diff-filename"] {
+    display: flex;
+    align-items: center;
+    font-size: 12px;
+    font-family: var(--vscode-editor-font-family, monospace);
+    color: var(--text-base, var(--vscode-foreground));
+    min-width: 0;
+    flex: 1;
+  }
+
+  [data-slot="permission-diff-directory"] {
+    color: var(--text-weak, var(--vscode-descriptionForeground));
+    flex-shrink: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    direction: rtl;
+    text-align: left;
+  }
+
+  [data-slot="permission-diff-name"] {
+    flex-shrink: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [data-slot="permission-diff-actions"] {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+
+  [data-slot="permission-diff-content"] {
+    max-height: 300px;
+    overflow: auto;
+  }
+
   [data-slot="permission-rules"] {
     margin: 0;
     max-height: 160px;

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -155,13 +155,26 @@ export interface CloudSessionInfo {
 }
 
 // Permission request
+export interface PermissionFileDiff {
+  file: string
+  before?: string
+  after?: string
+  additions: number
+  deletions: number
+}
+
 export interface PermissionRequest {
   id: string
   sessionID: string
   toolName: string
   patterns: string[]
   always: string[]
-  args: Record<string, unknown> & { rules?: string[] }
+  args: Record<string, unknown> & {
+    rules?: string[]
+    diff?: string
+    filepath?: string
+    filediff?: PermissionFileDiff
+  }
   message?: string
   tool?: { messageID: string; callID: string }
 }
@@ -2093,6 +2106,12 @@ export interface OpenChangesRequest {
   type: "openChanges"
 }
 
+// Open diff virtual (permission diff) in the lightweight diff virtual panel
+export interface OpenDiffVirtualRequest {
+  type: "openDiffVirtual"
+  diff: PermissionFileDiff
+}
+
 export interface RetryConnectionRequest {
   type: "retryConnection"
 }
@@ -2356,6 +2375,7 @@ export type WebviewMessage =
   | ApplyWorktreeDiffMessage
   | EnhancePromptRequest
   | OpenChangesRequest
+  | OpenDiffVirtualRequest
   | RetryConnectionRequest
   | OpenSubAgentViewerRequest
   | PreviewImageRequest

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -20,6 +20,27 @@ import { assertExternalDirectory } from "./external-directory"
 import { filterDiagnostics } from "./diagnostics" // kilocode_change
 
 const MAX_DIAGNOSTICS_PER_FILE = 20
+const MAX_DIFF_CONTENT = 500_000 // kilocode_change
+
+// kilocode_change start
+export function buildFileDiff(file: string, before: string, after: string): Snapshot.FileDiff {
+  const tooLarge = before.length > MAX_DIFF_CONTENT || after.length > MAX_DIFF_CONTENT
+  const fd: Snapshot.FileDiff = {
+    file,
+    before: tooLarge ? "" : before,
+    after: tooLarge ? "" : after,
+    additions: 0,
+    deletions: 0,
+  }
+  if (!tooLarge) {
+    for (const change of diffLines(before, after)) {
+      if (change.added) fd.additions += change.count || 0
+      if (change.removed) fd.deletions += change.count || 0
+    }
+  }
+  return fd
+}
+// kilocode_change end
 
 function normalizeLineEndings(text: string): string {
   return text.replaceAll("\r\n", "\n")
@@ -57,11 +78,14 @@ export const EditTool = Tool.define("edit", {
     let diff = ""
     let contentOld = ""
     let contentNew = ""
+    let cachedFilediff: Snapshot.FileDiff | undefined // kilocode_change
     await FileTime.withLock(filePath, async () => {
       if (params.oldString === "") {
         const existed = await Filesystem.exists(filePath)
+        if (existed) contentOld = await Filesystem.readText(filePath) // kilocode_change
         contentNew = params.newString
         diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
+        cachedFilediff = buildFileDiff(filePath, contentOld, contentNew) // kilocode_change
         await ctx.ask({
           permission: "edit",
           patterns: [path.relative(Instance.worktree, filePath)],
@@ -69,6 +93,7 @@ export const EditTool = Tool.define("edit", {
           metadata: {
             filepath: filePath,
             diff,
+            filediff: cachedFilediff, // kilocode_change
           },
         })
         await Filesystem.write(filePath, params.newString)
@@ -98,6 +123,7 @@ export const EditTool = Tool.define("edit", {
       diff = trimDiff(
         createTwoFilesPatch(filePath, filePath, normalizeLineEndings(contentOld), normalizeLineEndings(contentNew)),
       )
+      cachedFilediff = buildFileDiff(filePath, contentOld, contentNew) // kilocode_change
       await ctx.ask({
         permission: "edit",
         patterns: [path.relative(Instance.worktree, filePath)],
@@ -105,6 +131,7 @@ export const EditTool = Tool.define("edit", {
         metadata: {
           filepath: filePath,
           diff,
+          filediff: cachedFilediff, // kilocode_change
         },
       })
 
@@ -123,22 +150,12 @@ export const EditTool = Tool.define("edit", {
       FileTime.read(ctx.sessionID, filePath)
     })
 
-    const filediff: Snapshot.FileDiff = {
-      file: filePath,
-      before: contentOld,
-      after: contentNew,
-      additions: 0,
-      deletions: 0,
-    }
-    for (const change of diffLines(contentOld, contentNew)) {
-      if (change.added) filediff.additions += change.count || 0
-      if (change.removed) filediff.deletions += change.count || 0
-    }
+    const filediff = cachedFilediff ?? buildFileDiff(filePath, contentOld, contentNew) // kilocode_change
 
     ctx.metadata({
       metadata: {
         diff,
-        filediff,
+        filediff, // kilocode_change
         diagnostics: {},
       },
     })
@@ -160,7 +177,7 @@ export const EditTool = Tool.define("edit", {
       metadata: {
         diagnostics: filterDiagnostics(diagnostics, [normalizedFilePath]), // kilocode_change
         diff,
-        filediff,
+        filediff, // kilocode_change
       },
       title: `${path.relative(Instance.worktree, filePath)}`,
       output,

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -10,7 +10,7 @@ import { FileWatcher } from "../file/watcher"
 import { FileTime } from "../file/time"
 import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
-import { trimDiff } from "./edit"
+import { trimDiff, buildFileDiff } from "./edit" // kilocode_change
 import { assertExternalDirectory } from "./external-directory"
 import { filterDiagnostics } from "./diagnostics" // kilocode_change
 
@@ -32,6 +32,7 @@ export const WriteTool = Tool.define("write", {
     if (exists) await FileTime.assert(ctx.sessionID, filepath)
 
     const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, params.content))
+    const filediff = buildFileDiff(filepath, contentOld, params.content) // kilocode_change
     await ctx.ask({
       permission: "edit",
       patterns: [path.relative(Instance.worktree, filepath)],
@@ -39,6 +40,7 @@ export const WriteTool = Tool.define("write", {
       metadata: {
         filepath,
         diff,
+        filediff, // kilocode_change
       },
     })
 
@@ -78,6 +80,8 @@ export const WriteTool = Tool.define("write", {
         diagnostics: filterDiagnostics(diagnostics, [normalizedFilepath]), // kilocode_change
         filepath,
         exists: exists,
+        diff, // kilocode_change
+        filediff, // kilocode_change
       },
       output,
     }

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2627,6 +2627,36 @@ export class Permission extends HeyApiClient {
   }
 
   /**
+   * List pending permissions
+   *
+   * Get all pending permission requests across all sessions.
+   */
+  public list<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<PermissionListResponses, unknown, ThrowOnError>({
+      url: "/permission",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
    * Allow everything
    *
    * Enable or disable allowing all permissions without prompts.
@@ -2668,36 +2698,6 @@ export class Permission extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
-    })
-  }
-
-  /**
-   * List pending permissions
-   *
-   * Get all pending permission requests across all sessions.
-   */
-  public list<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<PermissionListResponses, unknown, ThrowOnError>({
-      url: "/permission",
-      ...options,
-      ...params,
     })
   }
 }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4086,6 +4086,25 @@ export type PermissionSaveAlwaysRulesResponses = {
 export type PermissionSaveAlwaysRulesResponse =
   PermissionSaveAlwaysRulesResponses[keyof PermissionSaveAlwaysRulesResponses]
 
+export type PermissionListData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/permission"
+}
+
+export type PermissionListResponses = {
+  /**
+   * List of pending permissions
+   */
+  200: Array<PermissionRequest>
+}
+
+export type PermissionListResponse = PermissionListResponses[keyof PermissionListResponses]
+
 export type PermissionAllowEverythingData = {
   body?: {
     enable: boolean
@@ -4122,25 +4141,6 @@ export type PermissionAllowEverythingResponses = {
 
 export type PermissionAllowEverythingResponse =
   PermissionAllowEverythingResponses[keyof PermissionAllowEverythingResponses]
-
-export type PermissionListData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/permission"
-}
-
-export type PermissionListResponses = {
-  /**
-   * List of pending permissions
-   */
-  200: Array<PermissionRequest>
-}
-
-export type PermissionListResponse = PermissionListResponses[keyof PermissionListResponses]
 
 export type QuestionListData = {
   body?: never


### PR DESCRIPTION
## Context

- Resolve: #8264

When an AI agent requests permission to edit or create a file, the permission prompt now displays an inline diff so the user can see exactly what changes are being made before approving.

## Implementation

- **CLI (`packages/opencode/`)**: Added a `buildFileDiff` helper in `edit.ts` that computes a `FileDiff` (before/after content + line additions/deletions) and attaches it to the permission request metadata. The diff is built before the `ctx.ask()` call so it's available in the permission prompt. A `MAX_DIFF_CONTENT` (500KB) guard prevents sending oversized payloads. The same approach is applied to the `write.ts` tool for new file creation.
- **VS Code Extension (`packages/kilo-vscode/`)**: 
  - Added `PermissionFileDiff` type and `filediff` field to `PermissionRequest` in message types.
  - `PermissionDiff` component renders the diff using `@kilocode/kilo-ui/diff` and `@kilocode/kilo-ui/diff-changes`, with an "expand to new tab" button.
  - `PermissionDock` conditionally renders `PermissionDiff` when a filediff is present.
  - A new `DiffVirtualApp` webview + `DiffVirtualProvider` implements the "open diff in new tab" functionality using VS Code's virtual document API.
  - CSS added to `chat.css` and `agent-manager.css` for the diff UI layout.
  - Session context updated to pass `filediff` through from SSE permission events.

**Tradeoffs**: Diffs for very large files (>500KB) are intentionally omitted to avoid performance issues — the permission prompt still appears but without the inline diff.

## Screenshots

<img width="3048" height="2160" alt="image" src="https://github.com/user-attachments/assets/e65917c3-4deb-4f83-b696-d070fad1ac96" />
<img width="3048" height="2160" alt="image" src="https://github.com/user-attachments/assets/3310fdb8-34af-4cad-aaf0-8613aa36d6aa" />
<img width="3048" height="2160" alt="image" src="https://github.com/user-attachments/assets/a94fb785-3f9a-46b3-bc65-342522be9515" />


## How to Test

1. Open a workspace with some files
2. Start a Kilo session and ask the agent to edit an existing file (e.g. "Add a comment to README.md")
3. When the permission prompt appears for the edit, you should see an inline diff showing the exact changes
4. Click the expand icon to open the diff in a new VS Code tab
5. Approve or reject the change
6. Repeat with a new file creation request — diff should show the full new file contents as additions