### PR TITLE
fix: block same-agent recursive delegation causing hangs on 'considering next steps'

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -41,6 +41,7 @@ import { getBusySessionCount, seedSessionStatuses } from "./session-status"
 import { retry } from "./services/cli-backend/retry"
 import { slimPart, slimParts } from "./kilo-provider/slim-metadata"
 import { matchFollowup, recordFollowup, type Followup } from "./kilo-provider/followup-session"
+import { childID } from "./kilo-provider/task-session"
 import { retryable, backoff, MAX_RETRIES } from "./util/retry"
 // legacy-migration start
 import {
@@ -1343,7 +1344,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     this.syncedChildSessions.add(sessionID)
     this.trackedSessionIds.add(sessionID)
-
     // Inherit the parent's worktree directory so permission responses use
     // the correct backend Instance. Without this, child sessions in Agent
     // Manager worktrees fall back to workspace root and fail to find the
@@ -2835,7 +2835,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     const sessionID = this.connectionService.resolveEventSessionId(event)
-
     // Events without sessionID (server.connected, server.heartbeat) → always forward
     // Events with sessionID → only forward if this webview tracks that session
     // message.part.updated and message.part.delta are always session-scoped; drop if session unknown.
@@ -2888,9 +2887,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         type?: string
         tool?: string
         metadata?: { sessionId?: string }
+        state?: { metadata?: { sessionId?: string } }
         sessionID?: string
       }
-      const childId = part.type === "tool" && part.tool === "task" ? part.metadata?.sessionId : undefined
+      const childId = childID(part)
       if (childId && !this.trackedSessionIds.has(childId)) {
         console.log("[Kilo New] KiloProvider: 🔗 Auto-adopting child session from task tool", { childId })
         void this.handleSyncSession(childId, part.sessionID ?? sessionID)

--- a/packages/kilo-vscode/src/kilo-provider/task-session.ts
+++ b/packages/kilo-vscode/src/kilo-provider/task-session.ts
@@ -1,0 +1,20 @@
+type Meta = { sessionId?: string }
+
+type State = {
+  metadata?: Meta
+  input?: Record<string, unknown>
+  title?: string
+  status?: string
+}
+
+type TaskPart = {
+  type?: string
+  tool?: string
+  metadata?: Meta
+  state?: State
+}
+
+export function childID(part: TaskPart): string | undefined {
+  if (part.type !== "tool" || part.tool !== "task") return undefined
+  return part.metadata?.sessionId ?? part.state?.metadata?.sessionId
+}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -17,6 +17,7 @@ import { useI18n } from "@kilocode/kilo-ui/context/i18n"
 import { createAutoScroll } from "@kilocode/kilo-ui/hooks"
 import { useSession } from "../../context/session"
 import { useVSCode } from "../../context/vscode"
+import { childID } from "../../context/session-utils"
 import type { ToolPart, Message as SDKMessage } from "@kilocode/sdk/v2"
 
 /** Collect all tool parts from all assistant messages in a given session. */
@@ -41,7 +42,13 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
   const session = useSession()
   const vscode = useVSCode()
 
-  const childSessionId = () => props.metadata.sessionId as string | undefined
+  const childSessionId = () =>
+    childID({
+      type: "tool",
+      tool: props.tool,
+      metadata: props.metadata as { sessionId?: string } | undefined,
+      state: { metadata: props.metadata as { sessionId?: string } | undefined },
+    })
 
   const running = createMemo(() => props.status === "pending" || props.status === "running")
 

--- a/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
@@ -9,6 +9,18 @@ type ToolState = {
   metadata?: { sessionId?: string }
 }
 
+type TaskPart = {
+  type: string
+  tool?: string
+  metadata?: { sessionId?: string }
+  state?: ToolState
+}
+
+export function childID(part: TaskPart): string | undefined {
+  if (part.type !== "tool" || part.tool !== "task") return undefined
+  return part.metadata?.sessionId ?? part.state?.metadata?.sessionId
+}
+
 /**
  * Derive a human-readable status string from the last streaming part.
  * Returns undefined for part types that don't map to a status.
@@ -108,7 +120,7 @@ export function buildFamilyLabels(
       if (!list) continue
       for (const p of list) {
         if (p.type !== "tool") continue
-        const child = p.state?.metadata?.sessionId
+        const child = childID(p as TaskPart)
         if (!child || !family.has(child)) continue
         const raw = p.state?.input?.subagent_type || p.state?.input?.description || p.tool || "task"
         const desc = raw.length > LABEL_CAP ? raw.slice(0, LABEL_CAP - 2) + "…" : raw

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -39,6 +39,7 @@ import {
   buildFamilyCosts,
   buildFamilyLabels,
   buildCostBreakdown,
+  childID,
 } from "./session-utils"
 import { Identifier } from "../utils/id"
 import { resolveModelSelection } from "./model-selection"
@@ -1037,7 +1038,14 @@ export const SessionProvider: ParentComponent = (props) => {
         if (!parts) continue
         for (const p of parts) {
           if (p.type !== "tool") continue
-          const child = (p as { state?: { metadata?: { sessionId?: string } } }).state?.metadata?.sessionId
+          const child = childID(
+            p as {
+              type: string
+              tool?: string
+              metadata?: { sessionId?: string }
+              state?: { metadata?: { sessionId?: string } }
+            },
+          )
           if (child && !family.has(child)) {
             family.add(child)
             queue.push(child)

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -11,6 +11,16 @@ import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { PermissionNext } from "@/permission/next"
 
+// kilocode_change start — metadata type for self-loop early return compatibility
+type Meta = {
+  sessionId?: string
+  model?: {
+    modelID: string
+    providerID: string
+  }
+}
+// kilocode_change end
+
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
   prompt: z.string().describe("The task for the agent to perform"),
@@ -24,7 +34,7 @@ const parameters = z.object({
   command: z.string().describe("The command that triggered this task").optional(),
 })
 
-export const TaskTool = Tool.define("task", async (ctx) => {
+export const TaskTool = Tool.define<typeof parameters, Meta>("task", async (ctx) => { // kilocode_change
   const agents = await Agent.list().then((x) => x.filter((a) => a.mode !== "primary"))
 
   // Filter agents by permissions if agent provided
@@ -43,6 +53,19 @@ export const TaskTool = Tool.define("task", async (ctx) => {
     description,
     parameters,
     async execute(params: z.infer<typeof parameters>, ctx) {
+      // kilocode_change start — block same-agent recursive delegation to prevent hang loops
+      if (ctx.agent === params.subagent_type) {
+        return {
+          title: params.description,
+          metadata: {},
+          output: [
+            "<task_result>",
+            `Delegation to @${params.subagent_type} was blocked to prevent recursive hangs. Continue the investigation in the current agent or choose a different subagent.`,
+            "</task_result>",
+          ].join("\n"),
+        }
+      }
+      // kilocode_change end
       const config = await Config.get()
 
       // Skip permission check when user explicitly invoked via @ or command subtask


### PR DESCRIPTION
## Summary
- Block same-agent recursive delegation in the task tool to prevent infinite child session chains
- Normalize child session ID lookup across extension and webview to fix orphaned child session tracking

## Root Cause

When an agent (e.g. Explore Agent) was delegated a task, it could recursively delegate to **the same agent type** via the task tool. This created an unbounded chain of child sessions:

```
Main Agent → Explore Agent → Explore Agent → Explore Agent → ...
```

Each delegation spawned a new child session (`session.created`) that remained `busy` indefinitely. The parent agent appeared permanently stuck on **"considering next steps"** because it was waiting for a child that would never finish — it just kept spawning more children.

A secondary issue compounded this: child session IDs were stored in `metadata.sessionId` by the task tool but some code paths only read from `state.metadata.sessionId`. This caused the extension to lose track of child sessions, preventing:
- Permission dialogs from child sessions from surfacing in the parent agent's UI
- The webview from correctly associating task tool parts with their child sessions

## Changes

### Task tool self-loop guard (`packages/opencode/src/tool/task.ts`)
When `ctx.agent === params.subagent_type`, the task tool now returns immediately with a message telling the agent to continue directly or choose a different subagent. No child session is created.

### Child session ID normalization (`packages/kilo-vscode/`)
- New shared `childID()` helper checks both `metadata.sessionId` and `state.metadata.sessionId`
- Used consistently in:
  - `KiloProvider.ts` — auto-adoption of child sessions
  - `TaskToolExpanded.tsx` — linking task tool UI to child session
  - `session-utils.ts` — family label building
  - `session.tsx` — family tree traversal

## Testing
- Ran aggressive delegation prompts that previously caused infinite child session chains
- Verified the self-loop guard blocks `Explore → Explore` delegation
- Verified permission dialogs now surface correctly in the parent agent
- Typecheck passes across all packages
- Example aggressive test prompts used against this repo: https://gist.github.com/kirillk/8ce7368fae0ccdd25e61c2eb85c86b0d

## Screenshots

### Before

<img width="932" height="845" alt="before" src="https://github.com/user-attachments/assets/9b7d9e88-262b-476c-bf6f-f0839ad220f3" />

### After

<img width="864" height="973" alt="after" src="https://github.com/user-attachments/assets/da133b9b-ac89-488c-9365-abc07e417e95" />
