### PR TITLE
docs(vscode): document supported image types and Shift+drag requirement

### DIFF
--- a/packages/kilo-vscode/docs/features/file-attachments.md
+++ b/packages/kilo-vscode/docs/features/file-attachments.md
@@ -5,6 +5,19 @@
 
 Image attachments and `@file` path mentions work. Non-image file content attachments are missing.
 
+## Supported Image Types
+
+The following image formats are supported for paste and drag-and-drop:
+
+- PNG (`image/png`)
+- JPEG (`image/jpeg`)
+- GIF (`image/gif`)
+- WebP (`image/webp`)
+
+## Drag-and-Drop (Shift Required)
+
+VS Code disables webview pointer-events during drag operations so it can handle drops in the editor area. To drop images into the chat input, **hold Shift while dragging**. This re-enables the webview to receive drop events (VS Code 1.91+, see [microsoft/vscode#182449](https://github.com/microsoft/vscode/issues/182449)).
+
 ## Remaining Work
 
 - Add a file attachment button to the chat input toolbar (paperclip icon or similar)


### PR DESCRIPTION
## Summary
- Document supported image types (PNG, JPEG, GIF, WebP) in file-attachments docs
- Document that **Shift must be held while dragging** to drop images into the webview chat input (VS Code platform behavior since 1.91)

Relates to #8451