### PR TITLE
dev: add kilo plans directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ target
 opencode-dev
 logs/
 *.bun-build
+.kilo/plans
 
 # Telemetry ID
 telemetry-id


### PR DESCRIPTION
## Context

Currently, plan files generated by kilo are not gitignored. We typically do not want these committed, since they are development files, so this change adds that directory to the gitignore.