### PR TITLE
fix(vscode): reduce question dock font size and height

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-many-options-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-many-options-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3de2fd382cc403a5b0dff91cead7804941d75f84ccd4610e4854d63e5b1cbd74
-size 29490
+oid sha256:4edbb48beaf828c898636124e4d225490e70fe2e16bcb15a3ae40a5dbe2e7167
+size 29458

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-multi-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-multi-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2fa88bc34c4dafe5271612b3ba640027c92aba28b282863e09026afdf8902f5
-size 21883
+oid sha256:84fc57aa26819d69d570d07faeb77030d146158a6b1d4cfb45b79f1f317c30ba
+size 18278

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-single-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/question-dock-single-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82b35af7032de0f55d48a8a175042166d72890be8aa6e0f1d81bc7dfa7b2c592
-size 27585
+oid sha256:12643a0a583f41595bd8651d92d31d5be424ea77242843b0017364ce3c280b1f
+size 24611

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/question-above-chatbox-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/question-above-chatbox-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ff364be7ea176328dc7f4500e3568aed460a2caa9dd4dedca614cd1db273185
-size 25150
+oid sha256:1a1754c3326f29d1c40e71c305d4dabff482d3b1413bb6b25d3538e20d43858a
+size 29648

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -2752,7 +2752,7 @@ body.vscode-light
    ============================================ */
 
 [data-component="question-dock"] {
-  margin: 8px;
+  margin: 6px 8px;
   background-color: var(--surface-base);
   border-radius: 8px;
   overflow: hidden;
@@ -2762,8 +2762,8 @@ body.vscode-light
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 8px;
-    padding: 10px 10px 6px 14px;
+    gap: 6px;
+    padding: 6px 8px 4px 12px;
     cursor: pointer;
   }
 
@@ -2777,7 +2777,7 @@ body.vscode-light
 
   [data-slot="question-header-title"] {
     font-family: var(--font-family-sans);
-    font-size: 12px;
+    font-size: 11px;
     font-weight: var(--font-weight-medium);
     line-height: var(--line-height-large);
     color: var(--text-weak);
@@ -2786,7 +2786,7 @@ body.vscode-light
   /* Shown only when collapsed — truncated question preview */
   [data-slot="question-collapsed-preview"] {
     font-family: var(--font-family-sans);
-    font-size: 13px;
+    font-size: 12px;
     font-weight: var(--font-weight-medium);
     line-height: var(--line-height-large);
     color: var(--text-strong);
@@ -2865,34 +2865,34 @@ body.vscode-light
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 2px;
     padding-bottom: 2px;
   }
 
   /* ── Body content ── */
   [data-slot="question-text"] {
     font-family: var(--font-family-sans);
-    font-size: 14px;
+    font-size: 12px;
     font-weight: var(--font-weight-medium);
     line-height: var(--line-height-large);
     color: var(--text-strong);
-    padding: 0 14px;
+    padding: 0 12px;
   }
 
   [data-slot="question-hint"] {
     font-family: var(--font-family-sans);
-    font-size: 13px;
+    font-size: 11px;
     font-weight: var(--font-weight-regular);
     line-height: var(--line-height-large);
     color: var(--text-weak);
-    padding: 0 14px;
+    padding: 0 12px;
   }
 
   [data-slot="question-options"] {
     display: flex;
     flex-direction: column;
-    gap: 2px;
-    padding: 4px 4px;
+    gap: 1px;
+    padding: 2px 4px;
     max-height: 40vh;
     overflow-y: auto;
     scrollbar-width: none;
@@ -2905,8 +2905,8 @@ body.vscode-light
   [data-slot="question-option"] {
     display: flex;
     align-items: flex-start;
-    gap: 12px;
-    padding: 8px 10px;
+    gap: 8px;
+    padding: 5px 8px;
     background-color: transparent;
     border: none;
     border-radius: 6px;
@@ -2935,9 +2935,9 @@ body.vscode-light
   }
 
   [data-slot="question-option-box"] {
-    width: 16px;
-    height: 16px;
-    padding: 2px;
+    width: 14px;
+    height: 14px;
+    padding: 1px;
     border-radius: var(--radius-sm);
     border: 1px solid var(--border-base);
     display: inline-flex;
@@ -2998,7 +2998,7 @@ body.vscode-light
 
   [data-slot="option-label"] {
     font-family: var(--font-family-sans);
-    font-size: 14px;
+    font-size: 12px;
     font-weight: var(--font-weight-medium);
     line-height: var(--line-height-large);
     color: var(--text-strong);
@@ -3006,7 +3006,7 @@ body.vscode-light
 
   [data-slot="option-description"] {
     font-family: var(--font-family-sans);
-    font-size: 14px;
+    font-size: 11px;
     font-weight: var(--font-weight-regular);
     line-height: var(--line-height-large);
     color: var(--text-base);
@@ -3021,7 +3021,7 @@ body.vscode-light
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 6px 10px;
+    padding: 4px 8px;
     margin: 0 4px;
     background-color: var(--surface-raised-stronger-non-alpha);
     border: none;
@@ -3036,7 +3036,7 @@ body.vscode-light
     border: none;
     outline: none;
     font-family: var(--font-family-sans);
-    font-size: var(--font-size-base);
+    font-size: 12px;
     color: var(--text-base);
     line-height: var(--line-height-large);
 
@@ -3091,7 +3091,7 @@ body.vscode-light
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 6px 10px 10px;
+    padding: 4px 8px 6px;
   }
 
   [data-slot="question-footer-actions"] {


### PR DESCRIPTION
## Summary
- Decreased font sizes across all question dock elements (header, question text, options, descriptions, hints)
- Reduced padding, gaps, and margins throughout to make the dock slimmer and more compact
- Shrunk checkbox/radio indicators from 16px to 14px to match smaller text

<img width="622" height="501" alt="image" src="https://github.com/user-attachments/assets/c488b6a9-b219-4674-947a-f00e13ab730a" />


Purely CSS changes in `packages/kilo-vscode/webview-ui/src/styles/chat.css`.