### PR TITLE
fix(agent-manager): show helpful error when repo has no commits

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -859,18 +859,12 @@ export class WorktreeManager {
     }
 
     // Check if this is an empty repo with no commits (unborn branch).
-    // In this state HEAD exists as a symbolic ref to a branch that has no
-    // commits, so rev-parse, branch --list, etc. all return nothing.
+    // rev-parse --verify HEAD exits non-zero only when HEAD has no target
+    // commit, which is the definitive test for an unborn branch.
     try {
-      const status = await this.git.status()
-      if (status.current) {
-        // There IS a branch name (e.g. "main") but no commits — unborn branch
-        throw new Error("This repository has no commits yet. Create an initial commit before using worktrees.")
-      }
-    } catch (e) {
-      // Re-throw our own descriptive error; swallow git failures
-      if (e instanceof Error && e.message.includes("no commits yet")) throw e
-      this.log(`defaultBranch: status check failed: ${e}`)
+      await this.git.raw(["rev-parse", "--verify", "HEAD"])
+    } catch {
+      throw new Error("This repository has no commits yet. Create an initial commit before using worktrees.")
     }
 
     throw new Error("Could not determine default branch")

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -858,6 +858,21 @@ export class WorktreeManager {
       this.log(`defaultBranch: branchLocal failed: ${e}`)
     }
 
+    // Check if this is an empty repo with no commits (unborn branch).
+    // In this state HEAD exists as a symbolic ref to a branch that has no
+    // commits, so rev-parse, branch --list, etc. all return nothing.
+    try {
+      const status = await this.git.status()
+      if (status.current) {
+        // There IS a branch name (e.g. "main") but no commits — unborn branch
+        throw new Error("This repository has no commits yet. Create an initial commit before using worktrees.")
+      }
+    } catch (e) {
+      // Re-throw our own descriptive error; swallow git failures
+      if (e instanceof Error && e.message.includes("no commits yet")) throw e
+      this.log(`defaultBranch: status check failed: ${e}`)
+    }
+
     throw new Error("Could not determine default branch")
   }
 

--- a/packages/kilo-vscode/src/agent-manager/git-import.ts
+++ b/packages/kilo-vscode/src/agent-manager/git-import.ts
@@ -29,7 +29,7 @@ interface WorktreeEntry {
 
 type PRErrorKind = "not_found" | "gh_missing" | "gh_auth" | "unknown"
 
-export type WorktreeSetupErrorCode = "git_not_found" | "not_git_repo" | "lfs_missing"
+export type WorktreeSetupErrorCode = "git_not_found" | "not_git_repo" | "lfs_missing" | "no_commits"
 
 export function parsePRUrl(url: string): PRUrlParts | null {
   let normalized = url.trim()
@@ -158,5 +158,6 @@ export function classifyWorktreeError(msg: string): WorktreeSetupErrorCode | und
   if (msg.includes("ENOENT") || msg.includes("not found in PATH")) return "git_not_found"
   if (msg.includes("not a git repository")) return "not_git_repo"
   if (msg.includes("Git LFS") && msg.includes("not found")) return "lfs_missing"
+  if (msg.includes("no commits yet")) return "no_commits"
   return undefined
 }

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -54,6 +54,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "افتح مجلدًا يحتوي على مستودع git لاستخدام مساحات العمل (worktrees).",
   "agentManager.setup.error.lfs_missing":
     "يستخدم هذا المستودع Git LFS، ولكن لم يتم العثور على git-lfs. يرجى تثبيت Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "هذا المستودع لا يحتوي على أي التزامات (commits) بعد. قم بإنشاء التزام أولي قبل استخدام مساحات العمل (worktrees).",
   "agentManager.shortcuts.title": "اختصارات لوحة المفاتيح",
   "agentManager.shortcuts.category.sidebar": "الشريط الجانبي",
   "agentManager.shortcuts.category.tabs": "علامات التبويب",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -55,6 +55,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "Abra uma pasta que contém um repositório git para usar worktrees.",
   "agentManager.setup.error.lfs_missing":
     "Este repositório usa Git LFS, mas o git-lfs não foi encontrado. Instale o Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "Este repositório ainda não possui commits. Crie um commit inicial antes de usar worktrees.",
   "agentManager.shortcuts.title": "Atalhos de Teclado",
   "agentManager.shortcuts.category.sidebar": "Barra lateral",
   "agentManager.shortcuts.category.tabs": "Abas",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -56,6 +56,8 @@ export const dict = {
     "Otvorite fasciklu koja sadrži git repozitorijum da biste koristili worktrees.",
   "agentManager.setup.error.lfs_missing":
     "Ovaj repozitorijum koristi Git LFS, ali git-lfs nije pronađen. Molimo instalirajte Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "Ovaj repozitorijum još uvek nema commit-ova. Napravite početni commit pre korišćenja worktrees.",
   "agentManager.shortcuts.title": "Prečice na tastaturi",
   "agentManager.shortcuts.category.sidebar": "Bočna traka",
   "agentManager.shortcuts.category.tabs": "Kartice",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -55,6 +55,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "Åbn en mappe, der indeholder et git-repository for at bruge worktrees.",
   "agentManager.setup.error.lfs_missing":
     "Dette repository bruger Git LFS, men git-lfs blev ikke fundet. Installer venligst Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "Dette repository har ingen commits endnu. Opret et indledende commit før du bruger worktrees.",
   "agentManager.shortcuts.title": "Tastaturgenveje",
   "agentManager.shortcuts.category.sidebar": "Sidebjælke",
   "agentManager.shortcuts.category.tabs": "Faner",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -56,6 +56,8 @@ export const dict = {
     "Öffnen Sie einen Ordner, der ein Git-Repository enthält, um Worktrees zu verwenden.",
   "agentManager.setup.error.lfs_missing":
     "Dieses Repository verwendet Git LFS, aber git-lfs wurde nicht gefunden. Bitte installieren Sie Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "Dieses Repository hat noch keine Commits. Erstellen Sie einen initialen Commit, bevor Sie Worktrees verwenden.",
   "agentManager.shortcuts.title": "Tastenkombinationen",
   "agentManager.shortcuts.category.sidebar": "Seitenleiste",
   "agentManager.shortcuts.category.tabs": "Tabs",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -60,6 +60,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "Open a folder that contains a git repository to use worktrees.",
   "agentManager.setup.error.lfs_missing":
     "This repository uses Git LFS, but git-lfs was not found. Please install Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "This repository has no commits yet. Create an initial commit before using worktrees.",
   "agentManager.shortcuts.title": "Keyboard Shortcuts",
   "agentManager.shortcuts.category.sidebar": "Sidebar",
   "agentManager.shortcuts.category.tabs": "Tabs",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -55,6 +55,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "Abra una carpeta que contenga un repositorio git para usar worktrees.",
   "agentManager.setup.error.lfs_missing":
     "Este repositorio usa Git LFS, pero no se encontró git-lfs. Por favor instale Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "Este repositorio aún no tiene commits. Cree un commit inicial antes de usar worktrees.",
   "agentManager.shortcuts.title": "Atajos de teclado",
   "agentManager.shortcuts.category.sidebar": "Barra lateral",
   "agentManager.shortcuts.category.tabs": "Pestañas",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -55,6 +55,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "Ouvrez un dossier contenant un dépôt git pour utiliser les worktrees.",
   "agentManager.setup.error.lfs_missing":
     "Ce dépôt utilise Git LFS, mais git-lfs n'a pas été trouvé. Veuillez installer Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "Ce dépôt n'a pas encore de commits. Créez un commit initial avant d'utiliser les worktrees.",
   "agentManager.shortcuts.title": "Raccourcis clavier",
   "agentManager.shortcuts.category.sidebar": "Barre latérale",
   "agentManager.shortcuts.category.tabs": "Onglets",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -55,6 +55,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "worktreesを使用するには、gitリポジトリを含むフォルダーを開いてください。",
   "agentManager.setup.error.lfs_missing":
     "このリポジトリはGit LFSを使用していますが、git-lfsが見つかりませんでした。Git LFSをインストールしてください。",
+  "agentManager.setup.error.no_commits":
+    "このリポジトリにはまだコミットがありません。worktreesを使用する前に最初のコミットを作成してください。",
   "agentManager.shortcuts.title": "キーボードショートカット",
   "agentManager.shortcuts.category.sidebar": "サイドバー",
   "agentManager.shortcuts.category.tabs": "タブ",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -55,6 +55,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "worktrees를 사용하려면 git 리포지토리가 포함된 폴더를 여세요.",
   "agentManager.setup.error.lfs_missing":
     "이 리포지토리는 Git LFS를 사용하지만 git-lfs를 찾을 수 없습니다. Git LFS를 설치하세요.",
+  "agentManager.setup.error.no_commits":
+    "이 리포지토리에는 아직 커밋이 없습니다. worktrees를 사용하기 전에 초기 커밋을 생성하세요.",
   "agentManager.shortcuts.title": "키보드 단축키",
   "agentManager.shortcuts.category.sidebar": "사이드바",
   "agentManager.shortcuts.category.tabs": "탭",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -60,6 +60,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "Open een map die een git repository bevat om worktrees te gebruiken.",
   "agentManager.setup.error.lfs_missing":
     "Deze repository gebruikt Git LFS, maar git-lfs is niet gevonden. Installeer Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "Deze repository heeft nog geen commits. Maak een initiële commit voordat je worktrees gebruikt.",
   "agentManager.shortcuts.title": "Sneltoetsen",
   "agentManager.shortcuts.category.sidebar": "Zijbalk",
   "agentManager.shortcuts.category.tabs": "Tabbladen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -55,6 +55,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "Åpne en mappe som inneholder et git-repositorium for å bruke worktrees.",
   "agentManager.setup.error.lfs_missing":
     "Dette repositoriet bruker Git LFS, men git-lfs ble ikke funnet. Vennligst installer Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "Dette repositoriet har ingen commits ennå. Opprett en første commit før du bruker worktrees.",
   "agentManager.shortcuts.title": "Tastatursnarveier",
   "agentManager.shortcuts.category.sidebar": "Sidepanel",
   "agentManager.shortcuts.category.tabs": "Faner",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -55,6 +55,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "Otwórz folder zawierający repozytorium git, aby używać worktrees.",
   "agentManager.setup.error.lfs_missing":
     "To repozytorium używa Git LFS, ale nie znaleziono git-lfs. Zainstaluj Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "To repozytorium nie ma jeszcze commitów. Utwórz początkowy commit przed użyciem worktrees.",
   "agentManager.shortcuts.title": "Skróty klawiszowe",
   "agentManager.shortcuts.category.sidebar": "Pasek boczny",
   "agentManager.shortcuts.category.tabs": "Karty",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -55,6 +55,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "Откройте папку, содержащую репозиторий git, чтобы использовать worktrees.",
   "agentManager.setup.error.lfs_missing":
     "Этот репозиторий использует Git LFS, но git-lfs не найден. Пожалуйста, установите Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "В этом репозитории еще нет коммитов. Создайте начальный коммит перед использованием worktrees.",
   "agentManager.shortcuts.title": "Сочетания клавиш",
   "agentManager.shortcuts.category.sidebar": "Боковая панель",
   "agentManager.shortcuts.category.tabs": "Вкладки",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -53,6 +53,7 @@ export const dict = {
   "agentManager.setup.error.git_not_found": "ไม่ได้ติดตั้ง Git หรือไม่พบใน PATH โปรดติดตั้ง Git และรีสตาร์ท VS Code",
   "agentManager.setup.error.not_git_repo": "เปิดโฟลเดอร์ที่มีที่เก็บ git เพื่อใช้ worktrees",
   "agentManager.setup.error.lfs_missing": "ที่เก็บนี้ใช้ Git LFS แต่ไม่พบ git-lfs โปรดติดตั้ง Git LFS",
+  "agentManager.setup.error.no_commits": "ที่เก็บนี้ยังไม่มีการคอมมิต สร้างการคอมมิตเริ่มต้นก่อนใช้ worktrees",
   "agentManager.shortcuts.title": "ปุ่มลัดแป้นพิมพ์",
   "agentManager.shortcuts.category.sidebar": "แถบด้านข้าง",
   "agentManager.shortcuts.category.tabs": "แท็บ",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -60,6 +60,8 @@ export const dict = {
   "agentManager.setup.error.not_git_repo": "Worktree'leri kullanmak için bir git deposu içeren bir klasör açın.",
   "agentManager.setup.error.lfs_missing":
     "Bu depo Git LFS kullanıyor, ancak git-lfs bulunamadı. Lütfen Git LFS'yi yükleyin.",
+  "agentManager.setup.error.no_commits":
+    "Bu depoda henüz commit bulunmuyor. Worktree'leri kullanmadan önce bir başlangıç commit'i oluşturun.",
   "agentManager.shortcuts.title": "Klavye Kısayolları",
   "agentManager.shortcuts.category.sidebar": "Kenar Çubuğu",
   "agentManager.shortcuts.category.tabs": "Sekmeler",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -61,6 +61,8 @@ export const dict = {
     "Відкрийте папку, що містить git-репозиторій, щоб використовувати робочі дерева.",
   "agentManager.setup.error.lfs_missing":
     "Цей репозиторій використовує Git LFS, але git-lfs не знайдено. Будь ласка, встановіть Git LFS.",
+  "agentManager.setup.error.no_commits":
+    "У цьому репозиторії ще немає коммітів. Створіть початковий комміт перед використанням worktrees.",
   "agentManager.shortcuts.title": "Клавіатурні скорочення",
   "agentManager.shortcuts.category.sidebar": "Бічна панель",
   "agentManager.shortcuts.category.tabs": "Вкладки",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -53,6 +53,7 @@ export const dict = {
   "agentManager.setup.error.git_not_found": "未安装 Git 或在 PATH 中找不到 Git。请安装 Git 并重新启动 VS Code。",
   "agentManager.setup.error.not_git_repo": "打开一个包含 git 存储库的文件夹以使用 worktrees。",
   "agentManager.setup.error.lfs_missing": "此存储库使用 Git LFS，但找不到 git-lfs。请安装 Git LFS。",
+  "agentManager.setup.error.no_commits": "此存储库尚无提交。在使用 worktrees 之前，请创建一个初始提交。",
   "agentManager.shortcuts.title": "键盘快捷键",
   "agentManager.shortcuts.category.sidebar": "侧边栏",
   "agentManager.shortcuts.category.tabs": "标签页",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -53,6 +53,7 @@ export const dict = {
   "agentManager.setup.error.git_not_found": "未安裝 Git 或在 PATH 中找不到 Git。請安裝 Git 並重新啟動 VS Code。",
   "agentManager.setup.error.not_git_repo": "開啟一個包含 git 儲存庫的資料夾以使用 worktrees。",
   "agentManager.setup.error.lfs_missing": "此儲存庫使用 Git LFS，但找不到 git-lfs。請安裝 Git LFS。",
+  "agentManager.setup.error.no_commits": "此儲存庫尚無提交。在使用 worktrees 之前，請建立一個初始提交。",
   "agentManager.shortcuts.title": "鍵盤快捷鍵",
   "agentManager.shortcuts.category.sidebar": "側邊欄",
   "agentManager.shortcuts.category.tabs": "分頁",


### PR DESCRIPTION
## Summary

- Detects the "unborn branch" state (new git repo, no commits) in `WorktreeManager.defaultBranch()` using `git status`, which works even when `rev-parse` and `branch --list` fail
- Adds `no_commits` error code to `classifyWorktreeError()` so the UI shows a localized, user-friendly message instead of the raw "Could not determine default branch"
- Adds translated `agentManager.setup.error.no_commits` i18n strings for all 19 locales

<img width="467" height="256" alt="image" src="https://github.com/user-attachments/assets/1dbcde99-9649-4f8d-a56a-13eb15a07bbe" />


## Before
The user sees a generic "Could not determine default branch" error with no guidance.

## After
The user sees: "This repository has no commits yet. Create an initial commit before using worktrees."