### PR TITLE
feat(vscode): render question tool inline in conversation

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/question-above-chatbox-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/question-above-chatbox-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a1754c3326f29d1c40e71c305d4dabff482d3b1413bb6b25d3538e20d43858a
-size 29648
+oid sha256:c5223aa923783e200838f744eba2b5adc4aae18575412bb05f32606f2a5c823e
+size 16857

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -4,7 +4,7 @@
  * Unlike the upstream AssistantParts, this renders each read/glob/grep/list tool
  * individually for maximum verbosity in the VS Code sidebar context.
  *
- * Active questions and permissions are rendered in the bottom dock.
+ * Active questions render inline via QuestionDock; permissions are in the bottom dock.
  */
 
 import { Component, For, Show, createMemo } from "solid-js"
@@ -17,6 +17,8 @@ import type {
   ToolPart,
 } from "@kilocode/sdk/v2"
 import { useData } from "@kilocode/kilo-ui/context/data"
+import { useSession } from "../../context/session"
+import { QuestionDock } from "./QuestionDock"
 
 // Tools that the upstream message-part renderer suppresses (returns null for).
 // We render these ourselves via ToolRegistry when they complete,
@@ -31,7 +33,7 @@ function isRenderable(part: SDKPart): boolean {
       // Show todo parts only when completed (permissions are now in the dock)
       return state.status === "completed"
     }
-    if (tool === "question" && (state.status === "pending" || state.status === "running")) return false
+    // Always render question tool parts — active ones get the inline QuestionDock
     return true
   }
   if (part.type === "text") return !!(part as SDKPart & { text: string }).text?.trim()
@@ -67,6 +69,7 @@ function TodoToolCard(props: { part: ToolPart }) {
 
 export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
   const data = useData()
+  const session = useSession()
 
   const parts = createMemo(() => {
     const stored = data.store.part?.[props.message.id]
@@ -82,25 +85,42 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
           // so we detect them here and render via ToolRegistry directly.
           const isUpstreamSuppressed =
             part.type === "tool" && UPSTREAM_SUPPRESSED_TOOLS.has((part as SDKPart & { tool: string }).tool)
+
+          // Active question tool parts render the interactive QuestionDock inline
+          const activeQuestion = createMemo(() => {
+            if (part.type !== "tool") return undefined
+            const tp = part as unknown as ToolPart
+            if (tp.tool !== "question") return undefined
+            if (tp.state?.status !== "pending" && tp.state?.status !== "running") return undefined
+            return session.questions().find((q) => q.tool?.callID === tp.callID && q.tool?.messageID === tp.messageID)
+          })
+
           return (
-            <Show when={isUpstreamSuppressed || PART_MAPPING[part.type]}>
+            <Show when={isUpstreamSuppressed || activeQuestion() || PART_MAPPING[part.type]}>
               <div data-component="tool-part-wrapper" data-part-type={part.type}>
                 <Show
-                  when={isUpstreamSuppressed}
+                  when={activeQuestion()}
                   fallback={
-                    <Part
-                      part={part}
-                      message={props.message as SDKMessage}
-                      showAssistantCopyPartID={props.showAssistantCopyPartID}
-                      animate={
-                        part.type === "tool" &&
-                        ((part as unknown as ToolPart).state?.status === "pending" ||
-                          (part as unknown as ToolPart).state?.status === "running")
+                    <Show
+                      when={isUpstreamSuppressed}
+                      fallback={
+                        <Part
+                          part={part}
+                          message={props.message as SDKMessage}
+                          showAssistantCopyPartID={props.showAssistantCopyPartID}
+                          animate={
+                            part.type === "tool" &&
+                            ((part as unknown as ToolPart).state?.status === "pending" ||
+                              (part as unknown as ToolPart).state?.status === "running")
+                          }
+                        />
                       }
-                    />
+                    >
+                      <TodoToolCard part={part as unknown as ToolPart} />
+                    </Show>
                   }
                 >
-                  <TodoToolCard part={part as unknown as ToolPart} />
+                  {(req) => <QuestionDock request={req()} />}
                 </Show>
               </div>
             </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -12,7 +12,6 @@ import { showToast } from "@kilocode/kilo-ui/toast"
 import { TaskHeader } from "./TaskHeader"
 import { MessageList } from "./MessageList"
 import { PromptInput } from "./PromptInput"
-import { QuestionDock } from "./QuestionDock"
 import { PermissionDock } from "./PermissionDock"
 import { StartupErrorBanner } from "./StartupErrorBanner"
 import { useSession } from "../../context/session"
@@ -57,17 +56,15 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   const familyPermissions = createMemo(() => session.scopedPermissions(id()))
   const familyQuestions = createMemo(() => session.scopedQuestions(id()))
 
-  // Prefer non-tool questions in the dock: current-session non-tool first,
-  // then any non-tool, then fall back to any remaining scoped question.
-  const questionRequest = () =>
-    familyQuestions().find((q) => q.sessionID === id() && !q.tool) ??
-    familyQuestions().find((q) => !q.tool) ??
-    familyQuestions()[0]
+  // Non-tool questions (standalone, not from the question tool) render inline in
+  // the message list since they don't have an associated tool part in the conversation.
+  // Tool-linked questions render inline at their tool part position via AssistantMessage.
+  const standaloneQuestions = createMemo(() => familyQuestions().filter((q) => !q.tool))
   const permissionRequest = () => familyPermissions().find((p) => p.sessionID === id()) ?? familyPermissions()[0]
   const blocked = () => familyPermissions().length > 0 || familyQuestions().length > 0
-  const dock = () => !props.readonly || !!questionRequest() || !!permissionRequest()
+  const dock = () => !props.readonly || !!permissionRequest()
 
-  // When a bottom-dock permission/question disappears while the session is busy,
+  // When a bottom-dock permission disappears while the session is busy,
   // the scroll container grows taller. Dispatch a custom event so MessageList can
   // resume auto-scroll.
   createEffect(
@@ -129,7 +126,11 @@ export const ChatView: Component<ChatViewProps> = (props) => {
       <TaskHeader readonly={props.readonly} />
       <div class="chat-messages-wrapper">
         <div class="chat-messages">
-          <MessageList onSelectSession={props.onSelectSession} onShowHistory={props.onShowHistory} />
+          <MessageList
+            onSelectSession={props.onSelectSession}
+            onShowHistory={props.onShowHistory}
+            questions={standaloneQuestions}
+          />
         </div>
       </div>
 
@@ -137,9 +138,6 @@ export const ChatView: Component<ChatViewProps> = (props) => {
         <div class="chat-input">
           <Show when={server.connectionState() === "error" && server.errorMessage()}>
             <StartupErrorBanner errorMessage={server.errorMessage()!} errorDetails={server.errorDetails()!} />
-          </Show>
-          <Show when={questionRequest()} keyed>
-            {(req) => <QuestionDock request={req} />}
           </Show>
           <Show when={permissionRequest()} keyed>
             {(perm) => (

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -22,7 +22,9 @@ import { RevertBanner } from "./RevertBanner"
 import { AccountSwitcher } from "../shared/AccountSwitcher"
 import { KiloNotifications } from "./KiloNotifications"
 import { WorkingIndicator } from "../shared/WorkingIndicator"
+import { QuestionDock } from "./QuestionDock"
 import { activeUserMessageID as getActiveUserMessageID } from "../../context/session-queue"
+import type { QuestionRequest } from "../../types/messages"
 
 const KiloLogo = (): JSX.Element => {
   const iconsBaseUri = (window as { ICONS_BASE_URI?: string }).ICONS_BASE_URI || ""
@@ -40,6 +42,8 @@ const KiloLogo = (): JSX.Element => {
 interface MessageListProps {
   onSelectSession?: (id: string) => void
   onShowHistory?: () => void
+  /** Non-tool question requests to render inline at the bottom of the message list */
+  questions?: () => QuestionRequest[]
 }
 
 export const MessageList: Component<MessageListProps> = (props) => {
@@ -161,6 +165,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
               <RevertBanner />
             </Show>
             <WorkingIndicator />
+            <For each={props.questions?.()}>{(req) => <QuestionDock request={req} />}</For>
           </Show>
         </div>
       </div>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -214,7 +214,15 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     if (single()) submit()
   }
 
-  const toggleCollapse = () => setStore("collapsed", !store.collapsed)
+  const toggleCollapse = () => {
+    const collapsing = !store.collapsed
+    setStore("collapsed", collapsing)
+    // When collapsing inline, the content shrinks and can leave an empty gap
+    // below the viewport. Scroll the dock into view so the gap is eliminated.
+    if (collapsing) {
+      requestAnimationFrame(() => root?.scrollIntoView({ block: "nearest", behavior: "smooth" }))
+    }
+  }
 
   const onRoot = (e: KeyboardEvent) => {
     if (e.key === "Escape") {


### PR DESCRIPTION
## Summary

Moves the question tool UI from the fixed bottom dock into the scrollable conversation flow, so questions appear inline at their natural position in the message history.

## Motivation

Users frequently scroll up to review previous conversation context around a question. Having the question locked at the bottom of the viewport feels unintuitive — it breaks the reading flow and disconnects the question from its surrounding context. With this change, users can fluidly scroll through the entire conversation including questions, just like any other message.


<img width="600" height="730" alt="image" src="https://github.com/user-attachments/assets/8f85fb38-9351-4125-92e2-aaa7e4d84404" />


## Changes

- **AssistantMessage.tsx** — Active question tool parts now render an interactive `QuestionDock` inline at their tool part position instead of being hidden. Matches `QuestionRequest` to tool parts via `callID`/`messageID`.
- **ChatView.tsx** — Removed `QuestionDock` from the bottom dock area. Non-tool (standalone) questions are passed to `MessageList` for inline rendering.
- **MessageList.tsx** — Accepts and renders standalone question requests at the bottom of the scrollable message list.
- **QuestionDock.tsx** — Added `scrollIntoView` on collapse to prevent empty gaps when the dock shrinks inline.

## How it works

1. **Tool-linked questions** render inline at their natural position in the assistant's message
2. **Standalone questions** (not from the question tool) render at the bottom of the scrollable message list
3. Auto-scroll naturally brings questions into view as they appear
4. Collapsing a question scrolls it into view to prevent empty space below