### PR TITLE
fix(ui): prevent collapsible toggle on tools with hideDetails

### DIFF
--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -111,6 +111,7 @@ export function BasicTool(props: BasicToolProps) {
 
   const handleOpenChange = (value: boolean) => {
     if (pending()) return
+    if (props.hideDetails) return // kilocode_change
     if (props.locked && !value) return
     setOpen(value)
   }


### PR DESCRIPTION
## Summary

- Prevents the collapsible from toggling on tool cards that have `hideDetails=true` (Read, Task, Skill, Webfetch, etc.)
- These tools have no expandable content, but clicking them toggled `aria-expanded`, which activated a CSS `border-bottom` rule — producing a visible 2px empty box at the bottom of the card
- Tools with actual expandable content (Edit, Write, Bash, Glob, Grep, etc.) are unaffected since they never set `hideDetails`

<img width="557" height="51" alt="image" src="https://github.com/user-attachments/assets/6b3cdffd-f0a5-4a2b-aaae-a6ac4a2c4737" />

After (no body shown)

<img width="559" height="91" alt="image" src="https://github.com/user-attachments/assets/a08d2c34-23eb-4fde-be76-494c9ea472d7" />
