### PR TITLE
feat(vscode): enforce cyclomatic complexity lint rule

### DIFF
--- a/packages/kilo-vscode/eslint.config.mjs
+++ b/packages/kilo-vscode/eslint.config.mjs
@@ -29,13 +29,76 @@ export default [
       eqeqeq: "warn",
       "no-throw-literal": "warn",
       "max-lines": ["error", 3000],
+      complexity: ["error", 20],
     },
   },
+
+  // ── Complexity exceptions ─────────────────────────────────────────
+  // Existing violations capped at their current max.
+  // New code must stay ≤ 20. Do not raise these caps; refactor instead.
   {
     files: ["src/KiloProvider.ts"],
-    rules: {
-      "max-lines": ["error", 3300],
-    },
+    rules: { complexity: ["error", 140], "max-lines": ["error", 3300] },
   },
+  {
+    files: ["webview-ui/agent-manager/AgentManagerApp.tsx"],
+    rules: { complexity: ["error", 73] },
+  },
+  {
+    files: ["src/agent-manager/AgentManagerProvider.ts"],
+    rules: { complexity: ["error", 63] },
+  },
+  {
+    files: ["webview-ui/src/components/chat/PromptInput.tsx"],
+    rules: { complexity: ["error", 48] },
+  },
+  {
+    files: ["src/legacy-migration/migration-service.ts"],
+    rules: { complexity: ["error", 45] },
+  },
+  {
+    files: ["webview-ui/src/components/migration/MigrationWizard.tsx"],
+    rules: { complexity: ["error", 37] },
+  },
+  {
+    files: ["webview-ui/src/context/session.tsx"],
+    rules: { complexity: ["error", 31] },
+  },
+  {
+    files: ["src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts"],
+    rules: { complexity: ["error", 30] },
+  },
+  {
+    files: ["src/agent-manager/WorktreeManager.ts", "webview-ui/src/components/chat/QuestionDock.tsx"],
+    rules: { complexity: ["error", 28] },
+  },
+  {
+    files: [
+      "src/kilo-provider-utils.ts",
+      "src/services/autocomplete/continuedev/core/autocomplete/postprocessing/index.ts",
+    ],
+    rules: { complexity: ["error", 27] },
+  },
+  {
+    files: ["webview-ui/src/components/settings/CustomProviderDialog.tsx"],
+    rules: { complexity: ["error", 26] },
+  },
+  {
+    files: ["src/agent-manager/WorktreeStateManager.ts"],
+    rules: { complexity: ["error", 24] },
+  },
+  {
+    files: ["webview-ui/src/utils/errorUtils.ts"],
+    rules: { complexity: ["error", 23] },
+  },
+  {
+    files: ["src/services/autocomplete/continuedev/core/autocomplete/filtering/BracketMatchingService.ts"],
+    rules: { complexity: ["error", 22] },
+  },
+  {
+    files: ["webview-ui/src/context/server.tsx"],
+    rules: { complexity: ["error", 21] },
+  },
+
   eslintConfigPrettier,
 ]


### PR DESCRIPTION
## Summary

- Adds ESLint's built-in `complexity` rule at threshold **20** (error severity) to `packages/kilo-vscode/`
- Any new function with cyclomatic complexity > 20 will fail lint (and therefore `compile`, `package`, and CI)
- 17 existing files with violations get per-file exception caps at their current max — they can't get worse but don't block today
- No new dependencies — uses ESLint's built-in rule

## Current state

| Functions > threshold | Count |
|---|---|
| > 50 | 3 |
| 30–49 | 10 |
| 20–29 | 19 |
| 15–19 | 25 |
| 11–14 | 64 |

Top offenders: `KiloProvider.ts` (140), `AgentManagerApp.tsx` (73), `AgentManagerProvider.ts` (63)

## Going forward

- New code must stay ≤ 20
- When refactoring an excepted file, lower its cap to match the new max
- Goal: ratchet all exceptions down to 20 over time and remove overrides