### PR TITLE
fix(agent-manager): fix version group splitting when sections exist

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2420,7 +2420,9 @@ const AgentManagerContent: Component = () => {
                                       </SectionHeader>
                                     )
                                   }
-                                  return renderWt(item.wt, idx)
+                                  const ug = ungrouped()
+                                  const wtIdx = () => ug.indexOf(item.wt)
+                                  return renderWt(item.wt, wtIdx, false, ug)
                                 }}
                               </For>
                             )


### PR DESCRIPTION
## Summary

- Fixes multi-version worktrees showing as separate "N versions" groups instead of being grouped together when user-defined sections exist in the sidebar.

## Root Cause

When sections exist, `topLevelItems()` is a mixed array of sections and worktrees. The `<For>` loop index refers to the position in this mixed array, but `renderWt` passes that index to `isGroupStart`/`isGroupEnd` which look up neighbors in `sortedWorktrees()` — a different, worktree-only array. Since index N in `topLevelItems` doesn't correspond to index N in `sortedWorktrees`, group boundary checks compare against wrong neighbors, making each grouped worktree appear as its own group.

## Fix

Pass `ungrouped()` (the unsectioned worktrees list) and the correct index within it to `renderWt` for top-level worktree items, so `isGroupStart`/`isGroupEnd` check neighbors in the right list.