### PR TITLE
fix: Remove per-gitdir mutex lock from snapshot operation

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -10,7 +10,6 @@ import { Config } from "../config/config"
 import { Instance } from "../project/instance"
 import { Scheduler } from "../scheduler"
 import * as KiloSnapshot from "../kilocode/snapshot" // kilocode_change
-import { Lock } from "../util/lock" // kilocode_change
 
 export namespace Snapshot {
   const log = Log.create({ service: "snapshot" })
@@ -38,7 +37,7 @@ export namespace Snapshot {
       .then(() => true)
       .catch(() => false)
     if (!exists) return
-    using _lock = await Lock.write(git) // kilocode_change
+
     const result =
       await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} gc --prune=${prune}`
         .quiet()
@@ -60,7 +59,7 @@ export namespace Snapshot {
     const cfg = await Config.get()
     if (cfg.snapshot === false) return
     const git = await KiloSnapshot.prepare() // kilocode_change
-    using _lock = await Lock.write(git) // kilocode_change
+
     await add(git)
     const hash = await $`git --git-dir ${git} --work-tree ${Instance.worktree} write-tree`
       .quiet()
@@ -79,7 +78,7 @@ export namespace Snapshot {
 
   export async function patch(hash: string): Promise<Patch> {
     const git = await KiloSnapshot.prepare() // kilocode_change
-    using _lock = await Lock.write(git) // kilocode_change
+
     await add(git)
     const result =
       await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --name-only ${hash} -- .`
@@ -108,7 +107,7 @@ export namespace Snapshot {
   export async function restore(snapshot: string) {
     log.info("restore", { commit: snapshot })
     const git = await KiloSnapshot.prepare() // kilocode_change
-    using _lock = await Lock.write(git) // kilocode_change
+
     const result =
       await $`git -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} read-tree ${snapshot} && git -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} checkout-index -a -f`
         .quiet()
@@ -167,7 +166,14 @@ export namespace Snapshot {
       return
     }
 
-    const existing = new Set(tree.text().trim().split("\n").map((l) => l.trim()).filter(Boolean))
+    const existing = new Set(
+      tree
+        .text()
+        .trim()
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean),
+    )
 
     // Checkout files that exist in the snapshot
     const toCheckout = batch.filter((op) => existing.has(op.rel))
@@ -228,7 +234,7 @@ export namespace Snapshot {
 
   export async function revert(patches: Patch[]) {
     const git = await KiloSnapshot.prepare() // kilocode_change
-    using _lock = await Lock.write(git) // kilocode_change
+
     const worktree = Instance.worktree
 
     // Deduplicate files preserving patch order
@@ -254,7 +260,7 @@ export namespace Snapshot {
 
   export async function diff(hash: string) {
     const git = await KiloSnapshot.prepare() // kilocode_change
-    using _lock = await Lock.write(git) // kilocode_change
+
     await add(git)
     const result =
       await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff ${hash} -- .`
@@ -313,7 +319,7 @@ export namespace Snapshot {
 
   async function diffFullUncached(from: string, to: string): Promise<FileDiff[]> {
     const git = await KiloSnapshot.prepare() // kilocode_change
-    using _lock = await Lock.write(git) // kilocode_change
+
     const result: FileDiff[] = []
     const status = new Map<string, "added" | "deleted" | "modified">()
 

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -1181,31 +1181,6 @@ test("diffFull with whitespace changes", async () => {
 
 // ── Tests for snapshot optimizations (upstream #17878, #20564) ────────
 
-test("concurrent track() calls return consistent results", async () => {
-  await using tmp = await bootstrap()
-  await Instance.provide({
-    directory: tmp.path,
-    fn: async () => {
-      await Snapshot.track()
-
-      await Filesystem.write(`${tmp.path}/a.txt`, "concurrent-change")
-
-      const results = await Promise.all([
-        Snapshot.track(),
-        Snapshot.track(),
-        Snapshot.track(),
-        Snapshot.track(),
-        Snapshot.track(),
-      ])
-
-      const hashes = results.filter(Boolean)
-      expect(hashes.length).toBe(5)
-      // All concurrent calls must return the same hash
-      expect(new Set(hashes).size).toBe(1)
-    },
-  })
-})
-
 test("batch revert with many files sharing same hash", async () => {
   await using tmp = await tmpdir({
     git: true,
@@ -1351,11 +1326,7 @@ test("concurrent patch() calls return consistent results", async () => {
 
       await Filesystem.write(`${tmp.path}/a.txt`, "changed")
 
-      const results = await Promise.all([
-        Snapshot.patch(before!),
-        Snapshot.patch(before!),
-        Snapshot.patch(before!),
-      ])
+      const results = await Promise.all([Snapshot.patch(before!), Snapshot.patch(before!), Snapshot.patch(before!)])
 
       // All should report the same changed files
       for (const result of results) {
@@ -1465,52 +1436,6 @@ test("batch revert with multiple patches from different snapshots", async () => 
       // All files should be at v0 (snapA's state)
       for (let i = 0; i < 10; i++) {
         expect(await Filesystem.readText(`${tmp.path}/file${i}.txt`)).toBe(`v0-${i}`)
-      }
-    },
-  })
-})
-
-test("concurrent track calls each produce a valid snapshot", async () => {
-  await using tmp = await tmpdir({
-    git: true,
-    init: async (dir) => {
-      for (let i = 0; i < 10; i++) {
-        await Filesystem.write(`${dir}/file${i}.txt`, `original-${i}`)
-      }
-      await $`git add .`.cwd(dir).quiet()
-      await $`git commit --no-gpg-sign -m init`.cwd(dir).quiet()
-    },
-  })
-  await Instance.provide({
-    directory: tmp.path,
-    fn: async () => {
-      await Snapshot.track() // warm up
-
-      for (let i = 0; i < 10; i++) {
-        await Filesystem.write(`${tmp.path}/file${i}.txt`, `changed-${i}`)
-      }
-
-      // Fire 5 concurrent tracks, then verify each hash is a usable snapshot
-      const hashes = (await Promise.all([
-        Snapshot.track(),
-        Snapshot.track(),
-        Snapshot.track(),
-        Snapshot.track(),
-        Snapshot.track(),
-      ])).filter(Boolean) as string[]
-
-      expect(hashes.length).toBe(5)
-
-      // Every hash should produce a valid diffFull against itself (empty diff)
-      for (const hash of hashes) {
-        const diff = await Snapshot.diffFull(hash, hash)
-        expect(diff).toEqual([])
-      }
-
-      // Every hash should be usable for restore without error
-      await Snapshot.restore(hashes[0]!)
-      for (let i = 0; i < 10; i++) {
-        expect(await Filesystem.readText(`${tmp.path}/file${i}.txt`)).toBe(`changed-${i}`)
       }
     },
   })


### PR DESCRIPTION
## Context

Reverting per-gitdir mutext lock in snapshot operation that was fetched from future upstream release in #8445. This is an attempt to validate if this change is the culprit of some sessions hanging at "Considering Next Steps".

## Implementation

- Removed `Lock.write(git)` calls from all 7 snapshot functions: `cleanup`, `track`, `patch`, `restore`, `revert`, `diff`, and `diffFullUncached`
- Removed the `Lock` import from `snapshot/index.ts`
- Removed 2 concurrency tests that depended on the lock (`concurrent track() calls return consistent results` and `concurrent track calls each produce a valid snapshot`)
- Kept the other two optimizations from #8445 intact: incremental git add and batched revert

## Screenshots

N/A - backend change

## How to Test

1. Run snapshot tests: `cd packages/opencode && bun test test/snapshot/snapshot.test.ts test/kilocode/snapshot-cache.test.ts` - all 57 tests should pass (56 pass, 1 skip)
2. Use the extension with Agent Manager, edit multiple files across sessions, and verify no hangs at "Considering Next Steps"

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
