### PR TITLE
fix(agent-manager): preserve section ordering state

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -355,6 +355,7 @@ export class AgentManagerProvider implements Disposable {
     }
     if (m.type === "agentManager.setWorktreeOrder") {
       this.state?.setWorktreeOrder(m.order)
+      this.pushState()
       return null
     }
     if (m.type === "agentManager.setSessionsCollapsed") {

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -44,7 +44,7 @@ export interface Section {
   name: string
   /** Color label (e.g. "Red", "Blue") mapped to VS Code theme CSS vars at render time, or null for default. */
   color: string | null
-  /** Position among top-level sidebar children (interleaved with ungrouped worktrees). */
+  /** Position among top-level sidebar children (sections and ungrouped worktrees). */
   order: number
   collapsed: boolean
 }
@@ -179,6 +179,7 @@ export class WorktreeStateManager {
     if (params.groupId) wt.groupId = params.groupId
     if (params.label) wt.label = params.label
     this.worktrees.set(id, wt)
+    this.setNormalizedWorktreeOrder(this.worktreeOrder)
     this.log(
       `Added worktree ${id}: ${params.branch}${params.label ? ` (label=${params.label})` : ""}${params.groupId ? ` (group=${params.groupId})` : ""}`,
     )
@@ -230,9 +231,7 @@ export class WorktreeStateManager {
     // Clean up tab order for this worktree
     delete this.tabOrder[id]
 
-    // Remove from worktree order
-    const idx = this.worktreeOrder.indexOf(id)
-    if (idx !== -1) this.worktreeOrder.splice(idx, 1)
+    this.setNormalizedWorktreeOrder(this.worktreeOrder.filter((item) => item !== id))
 
     this.log(`Removed worktree ${id}, removed ${orphaned.length} sessions`)
     void this.save()
@@ -298,18 +297,47 @@ export class WorktreeStateManager {
   }
 
   setWorktreeOrder(order: string[]): void {
-    const top = new Set<string>()
-    for (const sec of this.sections.values()) top.add(sec.id)
-    for (const wt of this.worktrees.values()) {
-      if (!wt.sectionId) top.add(wt.id)
-    }
-    this.worktreeOrder = order.filter((id) => top.has(id))
-    // Append any sections/ungrouped worktrees missing from the incoming order
-    const present = new Set(this.worktreeOrder)
-    for (const id of top) {
-      if (!present.has(id)) this.worktreeOrder.push(id)
-    }
+    this.setNormalizedWorktreeOrder(order)
     void this.save()
+  }
+
+  private setNormalizedWorktreeOrder(order: string[]): boolean {
+    const valid = new Set<string>()
+    for (const sec of this.sections.values()) valid.add(sec.id)
+    for (const wt of this.worktrees.values()) valid.add(wt.id)
+
+    const result: string[] = []
+    const seen = new Set<string>()
+    const add = (id: string) => {
+      if (!valid.has(id) || seen.has(id)) return
+      result.push(id)
+      seen.add(id)
+    }
+
+    for (const id of order) add(id)
+    for (const sec of [...this.sections.values()].sort((a, b) => a.order - b.order)) add(sec.id)
+    for (const wt of this.worktrees.values()) add(wt.id)
+
+    const changed =
+      result.length !== this.worktreeOrder.length || result.some((id, idx) => id !== this.worktreeOrder[idx])
+    this.worktreeOrder = result
+    return this.syncSectionOrder() || changed
+  }
+
+  private syncSectionOrder(): boolean {
+    const top = this.worktreeOrder.filter((id) => {
+      if (this.sections.has(id)) return true
+      const wt = this.worktrees.get(id)
+      return !!wt && !wt.sectionId
+    })
+    const index = new Map(top.map((id, idx) => [id, idx] as const))
+    const changes = [...this.sections.values()].map((sec) => {
+      const order = index.get(sec.id)
+      if (order === undefined || sec.order === order) return false
+      sec.order = order
+      return true
+    })
+    return changes.some(Boolean)
   }
 
   // ---------------------------------------------------------------------------
@@ -317,7 +345,7 @@ export class WorktreeStateManager {
   // ---------------------------------------------------------------------------
 
   getSections(): Section[] {
-    return [...this.sections.values()]
+    return [...this.sections.values()].sort((a, b) => a.order - b.order)
   }
 
   getSection(id: string): Section | undefined {
@@ -325,22 +353,23 @@ export class WorktreeStateManager {
   }
 
   addSection(name: string, color: string | null, worktreeIds?: string[]): Section {
+    this.setNormalizedWorktreeOrder(this.worktreeOrder)
     const id = generateId("sec")
-    const order = this.worktreeOrder.length
+    const order = this.worktreeOrder.filter((item) => {
+      if (this.sections.has(item)) return true
+      const wt = this.worktrees.get(item)
+      return !!wt && !wt.sectionId
+    }).length
     const sec: Section = { id, name, color, order, collapsed: false }
     this.sections.set(id, sec)
     this.worktreeOrder.push(id)
     if (worktreeIds) {
       for (const wtId of worktreeIds) {
         const wt = this.worktrees.get(wtId)
-        if (wt) {
-          wt.sectionId = id
-          // Remove from top-level worktreeOrder since it's now inside a section
-          const idx = this.worktreeOrder.indexOf(wtId)
-          if (idx !== -1) this.worktreeOrder.splice(idx, 1)
-        }
+        if (wt) wt.sectionId = id
       }
     }
+    this.setNormalizedWorktreeOrder(this.worktreeOrder)
     this.log(`Added section ${id}: "${name}"`)
     void this.save()
     return sec
@@ -372,24 +401,15 @@ export class WorktreeStateManager {
     if (!this.sections.delete(id)) return
     // Ungroup all worktrees in this section — do NOT delete them
     for (const wt of this.worktrees.values()) {
-      if (wt.sectionId === id) {
-        wt.sectionId = undefined
-        if (!this.worktreeOrder.includes(wt.id)) this.worktreeOrder.push(wt.id)
-      }
+      if (wt.sectionId === id) wt.sectionId = undefined
     }
-    // Remove from sidebar order
-    const idx = this.worktreeOrder.indexOf(id)
-    if (idx !== -1) this.worktreeOrder.splice(idx, 1)
+    this.setNormalizedWorktreeOrder(this.worktreeOrder.filter((item) => item !== id))
     this.log(`Deleted section ${id}, ungrouped its worktrees`)
     void this.save()
   }
 
   moveSection(id: string, dir: -1 | 1): void {
-    // Ensure the section is in worktreeOrder (it may be missing if drag-and-drop
-    // overwrote the order before this section was tracked)
-    if (this.sections.has(id) && !this.worktreeOrder.includes(id)) {
-      this.worktreeOrder.push(id)
-    }
+    const repaired = this.setNormalizedWorktreeOrder(this.worktreeOrder)
     const top = this.worktreeOrder.filter((item) => {
       if (this.sections.has(item)) return true
       const wt = this.worktrees.get(item)
@@ -397,15 +417,21 @@ export class WorktreeStateManager {
     })
     const idx = top.indexOf(id)
     const next = idx + dir
-    if (idx === -1 || next < 0 || next >= top.length) return
+    if (idx === -1 || next < 0 || next >= top.length) {
+      if (repaired) void this.save()
+      return
+    }
     const target = top[next]!
     const result = [...this.worktreeOrder]
     const fi = result.indexOf(id)
-    if (fi === -1 || result.indexOf(target) === -1) return
+    if (fi === -1 || result.indexOf(target) === -1) {
+      if (repaired) void this.save()
+      return
+    }
     result.splice(fi, 1)
     const insertAt = result.indexOf(target) + (dir === 1 ? 1 : 0)
     result.splice(insertAt, 0, id)
-    this.worktreeOrder = result
+    this.setNormalizedWorktreeOrder(result)
     void this.save()
   }
 
@@ -423,13 +449,8 @@ export class WorktreeStateManager {
       const wt = this.worktrees.get(wtId)
       if (!wt) continue
       wt.sectionId = sectionId ?? undefined
-      if (sectionId) {
-        const idx = this.worktreeOrder.indexOf(wtId)
-        if (idx !== -1) this.worktreeOrder.splice(idx, 1)
-      } else {
-        if (!this.worktreeOrder.includes(wtId)) this.worktreeOrder.push(wtId)
-      }
     }
+    this.setNormalizedWorktreeOrder(this.worktreeOrder)
     void this.save()
   }
 
@@ -519,22 +540,15 @@ export class WorktreeStateManager {
       if (data.worktreeOrder) {
         this.worktreeOrder = data.worktreeOrder
       }
-      // Normalize: ensure all section IDs and ungrouped worktree IDs are in worktreeOrder
-      const present = new Set(this.worktreeOrder)
-      for (const id of this.sections.keys()) {
-        if (!present.has(id)) this.worktreeOrder.push(id)
-      }
-      for (const wt of this.worktrees.values()) {
-        if (!wt.sectionId && !present.has(wt.id)) this.worktreeOrder.push(wt.id)
-      }
+      const repaired = this.setNormalizedWorktreeOrder(this.worktreeOrder)
       this.collapsed = data.sessionsCollapsed ?? false
       if (data.reviewDiffStyle === "split") {
         this.reviewDiffStyle = "split"
       }
       this.defaultBase = data.defaultBaseBranch
       this.log(`Loaded state: ${this.worktrees.size} worktrees, ${this.sessions.size} sessions`)
-      if (pruned > 0) {
-        this.log(`Pruned ${pruned} orphaned sessions`)
+      if (pruned > 0 || repaired) {
+        if (pruned > 0) this.log(`Pruned ${pruned} orphaned sessions`)
         void this.save()
       }
     } catch (error) {

--- a/packages/kilo-vscode/tests/unit/section-helpers.test.ts
+++ b/packages/kilo-vscode/tests/unit/section-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   buildTopLevelItems,
   buildSidebarOrder,
   buildShortcutMap,
+  completeSidebarOrder,
   isGrouped,
   isGroupStart,
   isGroupEnd,
@@ -63,6 +64,32 @@ describe("buildTopLevelItems", () => {
     const w1 = wt("w1")
     const result = buildTopLevelItems([s1], [w1], [w1], ["s1", "w1", "s1", "w1"])
     expect(result).toHaveLength(2)
+  })
+
+  it("ignores section member ids while placing top-level sections", () => {
+    const s1 = sec("s1", 0)
+    const w1 = wt("w1", { sectionId: "s1" })
+    const w2 = wt("w2")
+    const result = buildTopLevelItems([s1], [w2], [w1, w2], ["w1", "s1", "w2"])
+    expect(result).toEqual([
+      { kind: "section", section: s1 },
+      { kind: "worktree", wt: w2 },
+    ])
+  })
+})
+
+describe("completeSidebarOrder", () => {
+  it("keeps section ids while adding missing worktree ids", () => {
+    const s1 = sec("s1", 0)
+    const w1 = wt("w1", { sectionId: "s1" })
+    const w2 = wt("w2")
+    expect(completeSidebarOrder([s1], [w1, w2], ["w2", "s1"])).toEqual(["w2", "s1", "w1"])
+  })
+
+  it("drops stale ids and skips duplicates", () => {
+    const s1 = sec("s1", 0)
+    const w1 = wt("w1")
+    expect(completeSidebarOrder([s1], [w1], ["old", "w1", "w1", "s1"])).toEqual(["w1", "s1"])
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/worktree-state-sections.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-state-sections.test.ts
@@ -44,8 +44,8 @@ describe("WorktreeStateManager sections", () => {
       const sec = mgr.addSection("Group", "Red", [wt1.id])
       expect(mgr.getWorktree(wt1.id)?.sectionId).toBe(sec.id)
       expect(mgr.getWorktree(wt2.id)?.sectionId).toBeUndefined()
-      // wt1 removed from top-level order, wt2 remains
-      expect(mgr.getWorktreeOrder()).not.toContain(wt1.id)
+      // Worktree ids stay in the persisted order so section member order can be restored.
+      expect(mgr.getWorktreeOrder()).toContain(wt1.id)
       expect(mgr.getWorktreeOrder()).toContain(wt2.id)
     })
   })
@@ -122,32 +122,21 @@ describe("WorktreeStateManager sections", () => {
     })
   })
 
-  describe("setWorktreeOrder", () => {
-    it("preserves sections missing from incoming order", () => {
-      const wt = mgr.addWorktree({ branch: "a", path: "/tmp/a", parentBranch: "main" })
-      const a = mgr.addSection("A", null)
-      const b = mgr.addSection("B", null)
-      // Simulate webview sending an order that omits section B
-      mgr.setWorktreeOrder([wt.id, a.id])
-      expect(mgr.getWorktreeOrder()).toContain(b.id)
-    })
-  })
-
   describe("moveToSection", () => {
-    it("sets sectionId and removes from worktreeOrder", () => {
+    it("sets sectionId and keeps worktreeOrder for section member sorting", () => {
       const wt = mgr.addWorktree({ branch: "a", path: "/tmp/a", parentBranch: "main" })
       mgr.setWorktreeOrder([wt.id])
       const sec = mgr.addSection("Target", null)
 
       mgr.moveToSection([wt.id], sec.id)
       expect(mgr.getWorktree(wt.id)?.sectionId).toBe(sec.id)
-      expect(mgr.getWorktreeOrder()).not.toContain(wt.id)
+      expect(mgr.getWorktreeOrder()).toContain(wt.id)
     })
 
-    it("ungroups worktrees with null sectionId and adds back to order", () => {
+    it("ungroups worktrees with null sectionId and keeps them in order", () => {
       const wt = mgr.addWorktree({ branch: "a", path: "/tmp/a", parentBranch: "main" })
-      const sec = mgr.addSection("Temp", null, [wt.id])
-      expect(mgr.getWorktreeOrder()).not.toContain(wt.id)
+      mgr.addSection("Temp", null, [wt.id])
+      expect(mgr.getWorktreeOrder()).toContain(wt.id)
 
       mgr.moveToSection([wt.id], null)
       expect(mgr.getWorktree(wt.id)?.sectionId).toBeUndefined()
@@ -231,16 +220,6 @@ describe("WorktreeStateManager sections", () => {
       expect(mgr.getWorktree(wt2.id)?.sectionId).toBe(a.id)
     })
 
-    it("moves a section that is missing from worktreeOrder", () => {
-      const a = mgr.addSection("A", null)
-      const b = mgr.addSection("B", null)
-      // Simulate a drag-and-drop that lost section B from the order
-      mgr.setWorktreeOrder([a.id])
-      expect(mgr.getWorktreeOrder()).toEqual([a.id, b.id])
-      mgr.moveSection(b.id, -1)
-      expect(mgr.getWorktreeOrder()).toEqual([b.id, a.id])
-    })
-
     it("persists reordered sections across save/load", async () => {
       const a = mgr.addSection("A", null)
       const b = mgr.addSection("B", null)
@@ -250,6 +229,29 @@ describe("WorktreeStateManager sections", () => {
       const loaded = new WorktreeStateManager(root, () => {})
       await loaded.load()
       expect(loaded.getWorktreeOrder()).toEqual([b.id, a.id])
+    })
+
+    it("updates section order fields when moving", () => {
+      const a = mgr.addSection("A", null)
+      const b = mgr.addSection("B", null)
+
+      mgr.moveSection(b.id, -1)
+
+      expect(mgr.getSection(b.id)?.order).toBe(0)
+      expect(mgr.getSection(a.id)?.order).toBe(1)
+    })
+
+    it("repairs stale orders missing section ids before moving", () => {
+      const wt = mgr.addWorktree({ branch: "a", path: "/tmp/a", parentBranch: "main" })
+      const a = mgr.addSection("A", null)
+      const b = mgr.addSection("B", null)
+
+      mgr.setWorktreeOrder([wt.id])
+      mgr.moveSection(b.id, -1)
+
+      expect(mgr.getWorktreeOrder()).toContain(a.id)
+      expect(mgr.getWorktreeOrder()).toContain(b.id)
+      expect(mgr.getWorktreeOrder().indexOf(b.id)).toBeLessThan(mgr.getWorktreeOrder().indexOf(a.id))
     })
   })
 
@@ -297,6 +299,21 @@ describe("WorktreeStateManager sections", () => {
       const file = path.join(root, ".kilo", "agent-manager.json")
       const data = JSON.parse(fs.readFileSync(file, "utf-8"))
       data.worktreeOrder = [] // worktree ID missing
+      fs.writeFileSync(file, JSON.stringify(data))
+
+      const loaded = new WorktreeStateManager(root, () => {})
+      await loaded.load()
+      expect(loaded.getWorktreeOrder()).toContain(wt.id)
+    })
+
+    it("normalizes worktreeOrder on load to include section member worktrees", async () => {
+      const wt = mgr.addWorktree({ branch: "a", path: "/tmp/a", parentBranch: "main" })
+      const sec = mgr.addSection("S", null, [wt.id])
+      await mgr.flush()
+      await mgr.save()
+      const file = path.join(root, ".kilo", "agent-manager.json")
+      const data = JSON.parse(fs.readFileSync(file, "utf-8"))
+      data.worktreeOrder = [sec.id]
       fs.writeFileSync(file, JSON.stringify(data))
 
       const loaded = new WorktreeStateManager(root, () => {})

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -81,7 +81,7 @@ import { NewWorktreeDialog } from "./NewWorktreeDialog"
 import { LanguageBridge, DataBridge } from "../src/App"
 import { useLanguage } from "../src/context/language"
 import { formatRelativeDate } from "../src/utils/date"
-import { validateLocalSession, nextSelectionAfterDelete, adjacentHint, restoreLocalSessions, LOCAL } from "./navigate"
+import { validateLocalSession, nextSelectionAfterDelete, adjacentHint, LOCAL } from "./navigate"
 import { reorderTabs, applyTabOrder, firstOrderedTitle } from "./tab-order"
 import { ConstrainDragYAxis, SortableReviewTab, SortableTab } from "./sortable-tab"
 import { DiffPanel } from "./DiffPanel"
@@ -98,6 +98,7 @@ import {
   buildTopLevelItems,
   buildSidebarOrder,
   buildShortcutMap,
+  completeSidebarOrder,
   isGrouped,
   isGroupStart,
   isGroupEnd,
@@ -106,7 +107,6 @@ import {
 import { sectionAwareDetector } from "./section-dnd"
 import { ConstrainDragXAxis } from "./constrain-drag-x"
 import { mergeWorktreeDiffs } from "./diff-state"
-import { trackOpenSessions } from "./open-sessions"
 import "./agent-manager.css"
 import "./agent-manager-review.css"
 
@@ -672,17 +672,11 @@ const AgentManagerContent: Component = () => {
     const all = session.sessions()
     if (all.length === 0) return // sessions not loaded yet
     const ids = all.map((s) => s.id)
-    const prev = localSessionIDs()
-    const valid = prev.filter((lid) => isPending(lid) || validateLocalSession(lid, ids))
-    if (valid.length !== prev.length) {
-      const removed = prev.filter((lid) => !isPending(lid) && !valid.includes(lid))
-      for (const id of removed) {
-        vscode.postMessage({ type: "agentManager.forgetSession", sessionId: id })
-      }
+    const valid = localSessionIDs().filter((lid) => isPending(lid) || validateLocalSession(lid, ids))
+    if (valid.length !== localSessionIDs().length) {
       setLocalSessionIDs(valid)
     }
   })
-  trackOpenSessions(localSessionIDs, isPending, managedSessions, vscode.postMessage)
 
   // Drop in-memory review state for worktrees that no longer exist.
   createEffect(() => {
@@ -1125,7 +1119,6 @@ const AgentManagerContent: Component = () => {
         setLocalSessionIDs((prev) => [...prev, created.session.id])
         setSelection(LOCAL)
       }
-      vscode.postMessage({ type: "agentManager.persistSession", sessionId: created.session.id })
       session.selectSession(created.session.id)
     })
 
@@ -1200,7 +1193,6 @@ const AgentManagerContent: Component = () => {
             if (idx >= 0) return [...prev.slice(0, idx + 1), ev.sessionId, ...prev.slice(idx + 1)]
             return [...prev, ev.sessionId]
           })
-          vscode.postMessage({ type: "agentManager.persistSession", sessionId: ev.sessionId })
         }
         session.selectSession(ev.sessionId)
       }
@@ -1239,15 +1231,15 @@ const AgentManagerContent: Component = () => {
           const ms = state.sessions.find((s) => s.id === current)
           if (ms?.worktreeId) setSelection(ms.worktreeId)
         }
-        // Restore local session IDs from persisted state (sessions with no worktreeId)
-        const restored = restoreLocalSessions(
-          state.sessions,
-          localSessionIDs(),
-          state.tabOrder?.[LOCAL],
-          isPending,
-          applyTabOrder,
-        )
-        if (restored) setLocalSessionIDs(restored)
+        // Recover local tab order from persisted state
+        const localOrder = state.tabOrder?.[LOCAL]
+        if (localOrder && localSessionIDs().length > 0) {
+          const reordered = applyTabOrder(
+            localSessionIDs().map((id) => ({ id })),
+            localOrder,
+          ).map((item) => item.id)
+          setLocalSessionIDs(reordered)
+        }
         // Recover sessions collapsed state from extension-persisted state
         if (state.sessionsCollapsed !== undefined) setSessionsCollapsed(state.sessionsCollapsed)
         // Clear busy state for worktrees that have been removed
@@ -1898,9 +1890,6 @@ const AgentManagerContent: Component = () => {
     }
     if (pending || localSet().has(sessionId)) {
       setLocalSessionIDs((prev) => prev.filter((id) => id !== sessionId))
-      if (!pending) {
-        vscode.postMessage({ type: "agentManager.forgetSession", sessionId })
-      }
     } else {
       vscode.postMessage({ type: "agentManager.closeSession", sessionId })
     }
@@ -2288,10 +2277,7 @@ const AgentManagerContent: Component = () => {
                     if (typeof from !== "string" || typeof to !== "string") return
                     if (secIds().has(to)) return
                     setSidebarWorktreeOrder((prev) => {
-                      const cur = applyTabOrder(
-                        sortedWorktrees().map((w) => ({ id: w.id })),
-                        prev,
-                      ).map((i) => i.id)
+                      const cur = completeSidebarOrder(sections(), sortedWorktrees(), prev)
                       return reorderTabs(cur, from, to) ?? prev
                     })
                   }
@@ -2301,6 +2287,7 @@ const AgentManagerContent: Component = () => {
                     setDraggingWorktree(undefined)
                     document.body.classList.remove("am-wt-dragging-active")
                     if (typeof from === "string" && typeof to === "string" && secIds().has(to)) {
+                      vscode.postMessage({ type: "agentManager.setWorktreeOrder", order: sidebarWorktreeOrder() })
                       moveToSection([from], to)
                       return
                     }

--- a/packages/kilo-vscode/webview-ui/agent-manager/section-helpers.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/section-helpers.ts
@@ -8,6 +8,22 @@ export type TopLevelItem = { kind: "section"; section: SectionState } | { kind: 
 
 export type SidebarItem = { type: "local" | "wt" | "session"; id: string }
 
+/** Build a canonical sidebar order containing section IDs and every worktree ID. */
+export function completeSidebarOrder(secs: SectionState[], all: WorktreeState[], order: string[]): string[] {
+  const valid = new Set([...secs.map((sec) => sec.id), ...all.map((wt) => wt.id)])
+  const result: string[] = []
+  const seen = new Set<string>()
+  const add = (id: string) => {
+    if (!valid.has(id) || seen.has(id)) return
+    result.push(id)
+    seen.add(id)
+  }
+  for (const id of order) add(id)
+  for (const sec of secs) add(sec.id)
+  for (const wt of all) add(wt.id)
+  return result
+}
+
 /** Check if this worktree is part of a multi-version group. */
 export const isGrouped = (wt: WorktreeState) => !!wt.groupId
 


### PR DESCRIPTION
## Summary
- Keep Agent Manager section IDs and worktree IDs in the persisted sidebar order so section moves do not become no-ops after drag/drop or stale state.
- Sync section order fields with the canonical order and repair malformed `.kilo/agent-manager.json` state on load and before moves.
- Preserve section IDs during webview drag reorder and add regression coverage for stale section ordering.

## Validation
- `bun test tests/unit/worktree-state-sections.test.ts tests/unit/section-helpers.test.ts`
- `bun test tests/unit/`
- `bunx eslint src/agent-manager/WorktreeStateManager.ts src/agent-manager/AgentManagerProvider.ts webview-ui/agent-manager/AgentManagerApp.tsx webview-ui/agent-manager/section-helpers.ts tests/unit/worktree-state-sections.test.ts tests/unit/section-helpers.test.ts`
- `git diff --check`