### PR TITLE
fix(cli): skip opencode annotation check on upstream merge PRs

### DIFF
--- a/.github/workflows/check-opencode-annotations.yml
+++ b/.github/workflows/check-opencode-annotations.yml
@@ -11,12 +11,7 @@ on:
 jobs:
   check-annotations:
     name: Check kilocode_change annotations
-    if: >-
-      github.repository == 'Kilo-Org/kilocode' &&
-      (
-        github.event_name != 'pull_request' ||
-        !contains(github.event.pull_request.head.ref, 'kilo-opencode-')
-      )
+    if: github.repository == 'Kilo-Org/kilocode'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check-opencode-annotations.yml
+++ b/.github/workflows/check-opencode-annotations.yml
@@ -11,7 +11,12 @@ on:
 jobs:
   check-annotations:
     name: Check kilocode_change annotations
-    if: github.repository == 'Kilo-Org/kilocode'
+    if: >-
+      github.repository == 'Kilo-Org/kilocode' &&
+      (
+        github.event_name != 'pull_request' ||
+        !contains(github.event.pull_request.head.ref, 'kilo-opencode-')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/script/check-opencode-annotations.ts
+++ b/script/check-opencode-annotations.ts
@@ -54,7 +54,8 @@ function isUpstreamMerge() {
   const out = run("git", ["log", "--format=%P%x09%s", `${base}..HEAD`])
   return out.split("\n").some((line) => {
     const [parents = "", subject = ""] = line.split("\t")
-    return parents.includes(" ") && subject.startsWith("merge: upstream ")
+    if (!parents.includes(" ")) return false
+    return subject.startsWith("merge: upstream ") || subject.startsWith("Resolve merge conflict")
   })
 }
 

--- a/script/check-opencode-annotations.ts
+++ b/script/check-opencode-annotations.ts
@@ -50,28 +50,12 @@ function changedFiles() {
   return out ? out.split("\n").filter(Boolean) : []
 }
 
-function branch() {
-  return process.env.GITHUB_HEAD_REF || process.env.HEAD_REF || run("git", ["branch", "--show-current"])
-}
-
-function commits() {
+function isUpstreamMerge() {
   const out = run("git", ["log", "--format=%P%x09%s", `${base}..HEAD`])
-  return out ? out.split("\n").filter(Boolean) : []
-}
-
-function skip() {
-  const name = branch()
-  if (name.includes("kilo-opencode-")) {
-    return `upstream merge branch '${name}'`
-  }
-
-  const hit = commits().find((line) => {
+  return out.split("\n").some((line) => {
     const [parents = "", subject = ""] = line.split("\t")
     return parents.includes(" ") && subject.startsWith("merge: upstream ")
   })
-
-  if (hit) return "upstream merge commit"
-  return ""
 }
 
 function isExempt(file: string) {
@@ -144,9 +128,8 @@ function coveredLines(text: string): { lines: string[]; covered: Set<number> } {
 
 // --- main ---
 
-const why = skip()
-if (why) {
-  console.log(`Skipping opencode annotation check for ${why}.`)
+if (isUpstreamMerge()) {
+  console.log("Skipping opencode annotation check — upstream opencode merge detected.")
   process.exit(0)
 }
 

--- a/script/check-opencode-annotations.ts
+++ b/script/check-opencode-annotations.ts
@@ -55,7 +55,8 @@ function isUpstreamMerge() {
   return out.split("\n").some((line) => {
     const [parents = "", subject = ""] = line.split("\t")
     if (!parents.includes(" ")) return false
-    return subject.startsWith("merge: upstream ") || subject.startsWith("Resolve merge conflict")
+    const s = subject.toLowerCase()
+    return s.startsWith("merge: upstream ") || s.startsWith("resolve merge conflict")
   })
 }
 

--- a/script/check-opencode-annotations.ts
+++ b/script/check-opencode-annotations.ts
@@ -50,6 +50,30 @@ function changedFiles() {
   return out ? out.split("\n").filter(Boolean) : []
 }
 
+function branch() {
+  return process.env.GITHUB_HEAD_REF || process.env.HEAD_REF || run("git", ["branch", "--show-current"])
+}
+
+function commits() {
+  const out = run("git", ["log", "--format=%P%x09%s", `${base}..HEAD`])
+  return out ? out.split("\n").filter(Boolean) : []
+}
+
+function skip() {
+  const name = branch()
+  if (name.includes("kilo-opencode-")) {
+    return `upstream merge branch '${name}'`
+  }
+
+  const hit = commits().find((line) => {
+    const [parents = "", subject = ""] = line.split("\t")
+    return parents.includes(" ") && subject.startsWith("merge: upstream ")
+  })
+
+  if (hit) return "upstream merge commit"
+  return ""
+}
+
 function isExempt(file: string) {
   const norm = file.replaceAll("\\", "/").toLowerCase()
   return norm.split("/").some((part) => part.includes("kilocode"))
@@ -119,6 +143,12 @@ function coveredLines(text: string): { lines: string[]; covered: Set<number> } {
 }
 
 // --- main ---
+
+const why = skip()
+if (why) {
+  console.log(`Skipping opencode annotation check for ${why}.`)
+  process.exit(0)
+}
 
 const files = changedFiles().filter((f) => !isExempt(f) && isSource(f))
 


### PR DESCRIPTION
## Summary

- Skips the `check-opencode-annotations` CI check when the PR contains an upstream opencode merge commit (identified by a merge commit with subject starting `merge: upstream `).
- This prevents false failures on upstream sync PRs where `kilocode_change` annotation enforcement doesn't apply.
- Normal PRs with only regular commits are still fully checked.

Closes / follows up on #8531.