### PR TITLE
Fix remote control snapshot build

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -83,8 +83,7 @@ import {
   buildActionContext,
   computeDefaultSelection,
   fetchProviderData,
-  validateRecents,
-  validateFavorites,
+  handleStoredModelMessage,
   connectProvider as connectProviderAction,
   authorizeProviderOAuth as authorizeOAuthAction,
   completeProviderOAuth as completeOAuthAction,
@@ -539,6 +538,17 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         }
       }
 
+      if (
+        await handleStoredModelMessage({
+          msg: message,
+          store: this.extensionContext?.globalState,
+          postMessage: (msg) => this.postMessage(msg),
+          notifyFavoritesChanged: (favorites) => this.connectionService.notifyFavoritesChanged(favorites),
+        })
+      ) {
+        return
+      }
+
       switch (message.type) {
         case "webviewReady":
           console.log("[Kilo New] KiloProvider: ✅ webviewReady received")
@@ -941,44 +951,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "telemetry":
           TelemetryProxy.capture(message.event, message.properties)
           break
-        case "persistVariant": {
-          const stored = this.extensionContext?.globalState.get<Record<string, string>>("variantSelections") ?? {}
-          stored[message.key] = message.value
-          await this.extensionContext?.globalState.update("variantSelections", stored)
-          break
-        }
-        case "requestVariants": {
-          const variants = this.extensionContext?.globalState.get<Record<string, string>>("variantSelections") ?? {}
-          this.postMessage({ type: "variantsLoaded", variants })
-          break
-        }
-        case "persistRecents":
-          await this.extensionContext?.globalState.update("recentModels", validateRecents(message.recents))
-          break
-        case "requestRecents": {
-          const recents = validateRecents(this.extensionContext?.globalState.get("recentModels"))
-          this.postMessage({ type: "recentsLoaded", recents })
-          break
-        }
-        case "toggleFavorite": {
-          const current = validateFavorites(this.extensionContext?.globalState.get("favoriteModels"))
-          const key = `${message.providerID}/${message.modelID}`
-          const exists = current.some((f) => `${f.providerID}/${f.modelID}` === key)
-          const favorites =
-            message.action === "add" && !exists
-              ? [...current, { providerID: message.providerID, modelID: message.modelID }]
-              : message.action === "remove" && exists
-                ? current.filter((f) => `${f.providerID}/${f.modelID}` !== key)
-                : current
-          await this.extensionContext?.globalState.update("favoriteModels", favorites)
-          this.connectionService.notifyFavoritesChanged(favorites)
-          break
-        }
-        case "requestFavorites": {
-          const favorites = validateFavorites(this.extensionContext?.globalState.get("favoriteModels"))
-          this.postMessage({ type: "favoritesLoaded", favorites })
-          break
-        }
         // legacy-migration start
         case "requestLegacyMigrationData":
           void handleRequestLegacyMigrationData(this.migrationCtx)

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -348,49 +348,9 @@ export class AgentManagerProvider implements Disposable {
       void this.onRequestBranches()
       return null
     }
-    if (m.type === "agentManager.setTabOrder") {
-      this.state?.setTabOrder(m.key, m.order)
-      return null
-    }
-    if (m.type === "agentManager.setWorktreeOrder") {
-      this.state?.setWorktreeOrder(m.order)
-      return null
-    }
-    if (m.type === "agentManager.setSessionsCollapsed") {
-      this.state?.setSessionsCollapsed(m.collapsed)
-      return null
-    }
+    if (this.handleStateMessage(m)) return null
     if (this.handleSection(m)) return null
-    if (m.type === "agentManager.setReviewDiffStyle") {
-      this.state?.setReviewDiffStyle(m.style)
-      return null
-    }
-    if (m.type === "agentManager.setDefaultBaseBranch") {
-      const branch = normalizeBaseBranch(m.branch)
-      this.state?.setDefaultBaseBranch(branch)
-      this.pushState()
-      return null
-    }
-    if (m.type === "agentManager.requestExternalWorktrees") {
-      void this.onRequestExternalWorktrees()
-      return null
-    }
-    if (m.type === "agentManager.importFromBranch") {
-      void this.onImportFromBranch(m.branch)
-      return null
-    }
-    if (m.type === "agentManager.importFromPR") {
-      void this.onImportFromPR(m.url)
-      return null
-    }
-    if (m.type === "agentManager.importExternalWorktree") {
-      void this.onImportExternalWorktree(m.path, m.branch)
-      return null
-    }
-    if (m.type === "agentManager.importAllExternalWorktrees") {
-      void this.onImportAllExternalWorktrees()
-      return null
-    }
+    if (this.handleImportMessage(m)) return null
     if (m.type === "agentManager.requestWorktreeDiff") {
       void this.onRequestWorktreeDiff(m.sessionId)
       return null
@@ -475,6 +435,51 @@ export class AgentManagerProvider implements Disposable {
     }
 
     return msg
+  }
+
+  private handleStateMessage(m: AgentManagerInMessage): boolean {
+    switch (m.type) {
+      case "agentManager.setTabOrder":
+        this.state?.setTabOrder(m.key, m.order)
+        return true
+      case "agentManager.setWorktreeOrder":
+        this.state?.setWorktreeOrder(m.order)
+        return true
+      case "agentManager.setSessionsCollapsed":
+        this.state?.setSessionsCollapsed(m.collapsed)
+        return true
+      case "agentManager.setReviewDiffStyle":
+        this.state?.setReviewDiffStyle(m.style)
+        return true
+      case "agentManager.setDefaultBaseBranch": {
+        const branch = normalizeBaseBranch(m.branch)
+        this.state?.setDefaultBaseBranch(branch)
+        this.pushState()
+        return true
+      }
+    }
+    return false
+  }
+
+  private handleImportMessage(m: AgentManagerInMessage): boolean {
+    switch (m.type) {
+      case "agentManager.requestExternalWorktrees":
+        void this.onRequestExternalWorktrees()
+        return true
+      case "agentManager.importFromBranch":
+        void this.onImportFromBranch(m.branch)
+        return true
+      case "agentManager.importFromPR":
+        void this.onImportFromPR(m.url)
+        return true
+      case "agentManager.importExternalWorktree":
+        void this.onImportExternalWorktree(m.path, m.branch)
+        return true
+      case "agentManager.importAllExternalWorktrees":
+        void this.onImportAllExternalWorktrees()
+        return true
+    }
+    return false
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/kilo-vscode/src/provider-actions.ts
+++ b/packages/kilo-vscode/src/provider-actions.ts
@@ -102,6 +102,68 @@ export function computeDefaultSelection(
 
 type PostMessage = (message: unknown) => void
 type GetErrorMessage = (error: unknown) => string
+type Store = {
+  get<T>(key: string): T | undefined
+  update(key: string, value: unknown): PromiseLike<void>
+}
+
+type ModelSelection = { providerID: string; modelID: string }
+
+type StoredContext = {
+  msg: Record<string, unknown>
+  store?: Store
+  postMessage: PostMessage
+  notifyFavoritesChanged: (favorites: ModelSelection[]) => void
+}
+
+function updateFavorites(current: ModelSelection[], next: ModelSelection & { action: "add" | "remove" }) {
+  const key = `${next.providerID}/${next.modelID}`
+  const exists = current.some((f) => `${f.providerID}/${f.modelID}` === key)
+  if (next.action === "add" && !exists) return [...current, { providerID: next.providerID, modelID: next.modelID }]
+  if (next.action === "remove" && exists) return current.filter((f) => `${f.providerID}/${f.modelID}` !== key)
+  return current
+}
+
+export async function handleStoredModelMessage(ctx: StoredContext): Promise<boolean> {
+  switch (ctx.msg.type) {
+    case "persistVariant": {
+      const msg = ctx.msg as { key: string; value: string }
+      const stored = ctx.store?.get<Record<string, string>>("variantSelections") ?? {}
+      stored[msg.key] = msg.value
+      await ctx.store?.update("variantSelections", stored)
+      return true
+    }
+    case "requestVariants": {
+      const variants = ctx.store?.get<Record<string, string>>("variantSelections") ?? {}
+      ctx.postMessage({ type: "variantsLoaded", variants })
+      return true
+    }
+    case "persistRecents": {
+      const msg = ctx.msg as { recents: unknown }
+      await ctx.store?.update("recentModels", validateRecents(msg.recents))
+      return true
+    }
+    case "requestRecents": {
+      const recents = validateRecents(ctx.store?.get("recentModels"))
+      ctx.postMessage({ type: "recentsLoaded", recents })
+      return true
+    }
+    case "toggleFavorite": {
+      const msg = ctx.msg as ModelSelection & { action: "add" | "remove" }
+      const current = validateFavorites(ctx.store?.get("favoriteModels"))
+      const favorites = updateFavorites(current, msg)
+      await ctx.store?.update("favoriteModels", favorites)
+      ctx.notifyFavoritesChanged(favorites)
+      return true
+    }
+    case "requestFavorites": {
+      const favorites = validateFavorites(ctx.store?.get("favoriteModels"))
+      ctx.postMessage({ type: "favoritesLoaded", favorites })
+      return true
+    }
+  }
+  return false
+}
 
 interface ActionContext {
   client: KiloClient

--- a/packages/kilo-vscode/src/services/RemoteStatusService.ts
+++ b/packages/kilo-vscode/src/services/RemoteStatusService.ts
@@ -60,18 +60,16 @@ export class RemoteStatusService implements vscode.Disposable {
   /** Toggle remote on/off based on current state. */
   async toggle(): Promise<void> {
     if (!this.client) return
-    const { data } = await this.client.remote.status(undefined, { throwOnError: true })
+    const { data } = await this.client.remote.status({ throwOnError: true })
     await this.setEnabled(!data.enabled)
   }
 
   /** Enable or disable remote. State updates are pushed via events. */
   async setEnabled(enabled: boolean): Promise<void> {
     if (!this.client) return
-    if (enabled) {
-      await this.client.remote.enable(undefined, { throwOnError: true })
-    } else {
-      await this.client.remote.disable(undefined, { throwOnError: true })
-    }
+    await (enabled
+      ? this.client.remote.enable({ throwOnError: true })
+      : this.client.remote.disable({ throwOnError: true }))
     this.update({ enabled, connected: false })
   }
 

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -364,6 +364,44 @@ export class Global extends HeyApiClient {
   }
 }
 
+export class Remote extends HeyApiClient {
+  /**
+   * Enable remote connection
+   *
+   * Enable WebSocket connection to UserConnectionDO for real-time session relay and commands.
+   */
+  public enable<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).post<RemoteEnableResponses, unknown, ThrowOnError>({
+      url: "/remote/enable",
+      ...options,
+    })
+  }
+
+  /**
+   * Disable remote connection
+   *
+   * Close the remote WebSocket connection to UserConnectionDO.
+   */
+  public disable<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).post<RemoteDisableResponses, unknown, ThrowOnError>({
+      url: "/remote/disable",
+      ...options,
+    })
+  }
+
+  /**
+   * Get remote connection status
+   *
+   * Get the current state of the remote WebSocket connection.
+   */
+  public status<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<RemoteStatusResponses, unknown, ThrowOnError>({
+      url: "/remote/status",
+      ...options,
+    })
+  }
+}
+
 export class Auth extends HeyApiClient {
   /**
    * Remove auth credentials
@@ -2812,6 +2850,102 @@ export class Question extends HeyApiClient {
   }
 }
 
+export class Network extends HeyApiClient {
+  /**
+   * List pending network waits
+   *
+   * Get all pending network reconnect requests across all sessions.
+   */
+  public list<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<NetworkListResponses, unknown, ThrowOnError>({
+      url: "/network",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Resume after network wait
+   *
+   * Resume a pending session after reconnecting network-dependent services.
+   */
+  public reply<ThrowOnError extends boolean = false>(
+    parameters: {
+      requestID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "requestID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<NetworkReplyResponses, NetworkReplyErrors, ThrowOnError>({
+      url: "/network/{requestID}/reply",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Reject network resume request
+   *
+   * Stop a pending session instead of resuming after network reconnect.
+   */
+  public reject<ThrowOnError extends boolean = false>(
+    parameters: {
+      requestID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "requestID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<NetworkRejectResponses, NetworkRejectErrors, ThrowOnError>({
+      url: "/network/{requestID}/reject",
+      ...options,
+      ...params,
+    })
+  }
+}
+
 export class Oauth extends HeyApiClient {
   /**
    * OAuth authorize
@@ -3008,98 +3142,6 @@ export class Telemetry extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
-    })
-  }
-}
-
-export class Remote extends HeyApiClient {
-  /**
-   * Enable remote connection
-   *
-   * Enable WebSocket connection to UserConnectionDO for real-time session relay and commands.
-   */
-  public enable<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<RemoteEnableResponses, unknown, ThrowOnError>({
-      url: "/remote/enable",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Disable remote connection
-   *
-   * Close the remote WebSocket connection to UserConnectionDO.
-   */
-  public disable<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<RemoteDisableResponses, unknown, ThrowOnError>({
-      url: "/remote/disable",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Get remote connection status
-   *
-   * Get the current state of the remote WebSocket connection.
-   */
-  public status<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<RemoteStatusResponses, unknown, ThrowOnError>({
-      url: "/remote/status",
-      ...options,
-      ...params,
     })
   }
 }
@@ -5289,102 +5331,6 @@ export class Event extends HeyApiClient {
   }
 }
 
-export class Network extends HeyApiClient {
-  /**
-   * List pending network waits
-   *
-   * Get all pending network reconnect requests across all sessions.
-   */
-  public list<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<NetworkListResponses, unknown, ThrowOnError>({
-      url: "/network",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Resume after network wait
-   *
-   * Resume a pending session after reconnecting network-dependent services.
-   */
-  public reply<ThrowOnError extends boolean = false>(
-    parameters: {
-      requestID: string
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "requestID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<NetworkReplyResponses, NetworkReplyErrors, ThrowOnError>({
-      url: "/network/{requestID}/reply",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Reject network resume request
-   *
-   * Stop a pending session instead of resuming after network reconnect.
-   */
-  public reject<ThrowOnError extends boolean = false>(
-    parameters: {
-      requestID: string
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "requestID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<NetworkRejectResponses, NetworkRejectErrors, ThrowOnError>({
-      url: "/network/{requestID}/reject",
-      ...options,
-      ...params,
-    })
-  }
-}
-
 export class KiloClient extends HeyApiClient {
   public static readonly __registry = new HeyApiRegistry<KiloClient>()
 
@@ -5396,6 +5342,11 @@ export class KiloClient extends HeyApiClient {
   private _global?: Global
   get global(): Global {
     return (this._global ??= new Global({ client: this.client }))
+  }
+
+  private _remote?: Remote
+  get remote(): Remote {
+    return (this._remote ??= new Remote({ client: this.client }))
   }
 
   private _auth?: Auth
@@ -5453,6 +5404,11 @@ export class KiloClient extends HeyApiClient {
     return (this._question ??= new Question({ client: this.client }))
   }
 
+  private _network?: Network
+  get network(): Network {
+    return (this._network ??= new Network({ client: this.client }))
+  }
+
   private _provider?: Provider
   get provider(): Provider {
     return (this._provider ??= new Provider({ client: this.client }))
@@ -5461,11 +5417,6 @@ export class KiloClient extends HeyApiClient {
   private _telemetry?: Telemetry
   get telemetry(): Telemetry {
     return (this._telemetry ??= new Telemetry({ client: this.client }))
-  }
-
-  private _remote?: Remote
-  get remote(): Remote {
-    return (this._remote ??= new Remote({ client: this.client }))
   }
 
   private _commitMessage?: CommitMessage
@@ -5546,10 +5497,5 @@ export class KiloClient extends HeyApiClient {
   private _event?: Event
   get event(): Event {
     return (this._event ??= new Event({ client: this.client }))
-  }
-
-  private _network?: Network
-  get network(): Network {
-    return (this._network ??= new Network({ client: this.client }))
   }
 }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -97,6 +97,114 @@ export type EventFileEdited = {
   }
 }
 
+export type EventTuiPromptAppend = {
+  type: "tui.prompt.append"
+  properties: {
+    text: string
+  }
+}
+
+export type EventTuiCommandExecute = {
+  type: "tui.command.execute"
+  properties: {
+    command:
+      | "session.list"
+      | "session.new"
+      | "session.share"
+      | "session.interrupt"
+      | "session.compact"
+      | "session.page.up"
+      | "session.page.down"
+      | "session.line.up"
+      | "session.line.down"
+      | "session.half.page.up"
+      | "session.half.page.down"
+      | "session.first"
+      | "session.last"
+      | "prompt.clear"
+      | "prompt.submit"
+      | "agent.cycle"
+      | string
+  }
+}
+
+export type EventTuiToastShow = {
+  type: "tui.toast.show"
+  properties: {
+    title?: string
+    message: string
+    variant: "info" | "success" | "warning" | "error"
+    /**
+     * Duration in milliseconds
+     */
+    duration?: number
+  }
+}
+
+export type EventTuiSessionSelect = {
+  type: "tui.session.select"
+  properties: {
+    /**
+     * Session ID to navigate to
+     */
+    sessionID: string
+  }
+}
+
+export type EventMcpToolsChanged = {
+  type: "mcp.tools.changed"
+  properties: {
+    server: string
+  }
+}
+
+export type EventMcpBrowserOpenFailed = {
+  type: "mcp.browser.open.failed"
+  properties: {
+    mcpName: string
+    url: string
+  }
+}
+
+export type SessionNetworkWait = {
+  id: string
+  sessionID: string
+  message: string
+  restored: boolean
+  time: {
+    created: number
+  }
+}
+
+export type EventSessionNetworkAsked = {
+  type: "session.network.asked"
+  properties: SessionNetworkWait
+}
+
+export type EventSessionNetworkReplied = {
+  type: "session.network.replied"
+  properties: {
+    sessionID: string
+    requestID: string
+  }
+}
+
+export type EventSessionNetworkRejected = {
+  type: "session.network.rejected"
+  properties: {
+    sessionID: string
+    requestID: string
+  }
+}
+
+export type EventSessionNetworkRestored = {
+  type: "session.network.restored"
+  properties: {
+    sessionID: string
+    requestID: string
+  }
+}
+
 export type OutputFormatText = {
   type: "text"
 }
@@ -738,75 +846,6 @@ export type EventTodoUpdated = {
   }
 }
 
-export type EventTuiPromptAppend = {
-  type: "tui.prompt.append"
-  properties: {
-    text: string
-  }
-}
-
-export type EventTuiCommandExecute = {
-  type: "tui.command.execute"
-  properties: {
-    command:
-      | "session.list"
-      | "session.new"
-      | "session.share"
-      | "session.interrupt"
-      | "session.compact"
-      | "session.page.up"
-      | "session.page.down"
-      | "session.line.up"
-      | "session.line.down"
-      | "session.half.page.up"
-      | "session.half.page.down"
-      | "session.first"
-      | "session.last"
-      | "prompt.clear"
-      | "prompt.submit"
-      | "agent.cycle"
-      | string
-  }
-}
-
-export type EventTuiToastShow = {
-  type: "tui.toast.show"
-  properties: {
-    title?: string
-    message: string
-    variant: "info" | "success" | "warning" | "error"
-    /**
-     * Duration in milliseconds
-     */
-    duration?: number
-  }
-}
-
-export type EventTuiSessionSelect = {
-  type: "tui.session.select"
-  properties: {
-    /**
-     * Session ID to navigate to
-     */
-    sessionID: string
-  }
-}
-
-export type EventMcpToolsChanged = {
-  type: "mcp.tools.changed"
-  properties: {
-    server: string
-  }
-}
-
-export type EventMcpBrowserOpenFailed = {
-  type: "mcp.browser.open.failed"
-  properties: {
-    mcpName: string
-    url: string
-  }
-}
-
 export type EventCommandExecuted = {
   type: "command.executed"
   properties: {
@@ -1018,6 +1057,16 @@ export type Event =
   | EventLspClientDiagnostics
   | EventLspUpdated
   | EventFileEdited
+  | EventTuiPromptAppend
+  | EventTuiCommandExecute
+  | EventTuiToastShow
+  | EventTuiSessionSelect
+  | EventMcpToolsChanged
+  | EventMcpBrowserOpenFailed
+  | EventSessionNetworkAsked
+  | EventSessionNetworkReplied
+  | EventSessionNetworkRejected
+  | EventSessionNetworkRestored
   | EventMessageUpdated
   | EventMessageRemoved
   | EventMessagePartUpdated
@@ -1030,19 +1079,9 @@ export type Event =
   | EventQuestionAsked
   | EventQuestionReplied
   | EventQuestionRejected
-  | EventSessionNetworkAsked
-  | EventSessionNetworkReplied
-  | EventSessionNetworkRejected
-  | EventSessionNetworkRestored
   | EventSessionCompacted
   | EventFileWatcherUpdated
   | EventTodoUpdated
-  | EventTuiPromptAppend
-  | EventTuiCommandExecute
-  | EventTuiToastShow
-  | EventTuiSessionSelect
-  | EventMcpToolsChanged
-  | EventMcpBrowserOpenFailed
   | EventCommandExecuted
   | EventSessionCreated
   | EventSessionUpdated
@@ -1286,7 +1325,7 @@ export type ProviderConfig = {
      */
     setCacheKey?: boolean
     /**
-     * Timeout in milliseconds for requests to this provider. Default is 300000 (5 minutes). Set to false to disable timeout.
+     * Timeout in milliseconds for requests to this provider. Default is 120000 (2 minutes). Set to false to disable timeout.
      */
     timeout?: number | false
     [key: string]: unknown | string | boolean | number | false | undefined
@@ -2003,45 +2042,6 @@ export type FormatterStatus = {
   enabled: boolean
 }
 
-export type SessionNetworkWait = {
-  id: string
-  sessionID: string
-  message: string
-  restored: boolean
-  time: {
-    created: number
-  }
-}
-
-export type EventSessionNetworkAsked = {
-  type: "session.network.asked"
-  properties: SessionNetworkWait
-}
-
-export type EventSessionNetworkReplied = {
-  type: "session.network.replied"
-  properties: {
-    sessionID: string
-    requestID: string
-  }
-}
-
-export type EventSessionNetworkRejected = {
-  type: "session.network.rejected"
-  properties: {
-    sessionID: string
-    requestID: string
-  }
-}
-
-export type EventSessionNetworkRestored = {
-  type: "session.network.restored"
-  properties: {
-    sessionID: string
-    requestID: string
-  }
-}
-
 export type GlobalHealthData = {
   body?: never
   path?: never
@@ -2133,6 +2133,63 @@ export type GlobalDisposeResponses = {
 }
 
 export type GlobalDisposeResponse = GlobalDisposeResponses[keyof GlobalDisposeResponses]
+
+export type RemoteEnableData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/remote/enable"
+}
+
+export type RemoteEnableResponses = {
+  /**
+   * Remote connection enabled
+   */
+  200: {
+    enabled: boolean
+    connected: boolean
+  }
+}
+
+export type RemoteEnableResponse = RemoteEnableResponses[keyof RemoteEnableResponses]
+
+export type RemoteDisableData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/remote/disable"
+}
+
+export type RemoteDisableResponses = {
+  /**
+   * Remote connection disabled
+   */
+  200: {
+    enabled: boolean
+    connected: boolean
+  }
+}
+
+export type RemoteDisableResponse = RemoteDisableResponses[keyof RemoteDisableResponses]
+
+export type RemoteStatusData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/remote/status"
+}
+
+export type RemoteStatusResponses = {
+  /**
+   * Remote connection status
+   */
+  200: {
+    enabled: boolean
+    connected: boolean
+  }
+}
+
+export type RemoteStatusResponse = RemoteStatusResponses[keyof RemoteStatusResponses]
 
 export type AuthRemoveData = {
   body?: never
@@ -4292,6 +4349,93 @@ export type QuestionRejectResponses = {
 
 export type QuestionRejectResponse = QuestionRejectResponses[keyof QuestionRejectResponses]
 
+export type NetworkListData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/network"
+}
+
+export type NetworkListResponses = {
+  /**
+   * List of pending network reconnect requests
+   */
+  200: Array<SessionNetworkWait>
+}
+
+export type NetworkListResponse = NetworkListResponses[keyof NetworkListResponses]
+
+export type NetworkReplyData = {
+  body?: never
+  path: {
+    requestID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/network/{requestID}/reply"
+}
+
+export type NetworkReplyErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type NetworkReplyError = NetworkReplyErrors[keyof NetworkReplyErrors]
+
+export type NetworkReplyResponses = {
+  /**
+   * Network wait resumed successfully
+   */
+  200: boolean
+}
+
+export type NetworkReplyResponse = NetworkReplyResponses[keyof NetworkReplyResponses]
+
+export type NetworkRejectData = {
+  body?: never
+  path: {
+    requestID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/network/{requestID}/reject"
+}
+
+export type NetworkRejectErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type NetworkRejectError = NetworkRejectErrors[keyof NetworkRejectErrors]
+
+export type NetworkRejectResponses = {
+  /**
+   * Network wait rejected successfully
+   */
+  200: boolean
+}
+
+export type NetworkRejectResponse = NetworkRejectResponses[keyof NetworkRejectResponses]
+
 export type ProviderListData = {
   body?: never
   path?: never
@@ -4521,72 +4665,6 @@ export type TelemetryCaptureResponses = {
 }
 
 export type TelemetryCaptureResponse = TelemetryCaptureResponses[keyof TelemetryCaptureResponses]
-
-export type RemoteEnableData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/remote/enable"
-}
-
-export type RemoteEnableResponses = {
-  /**
-   * Remote connection enabled
-   */
-  200: {
-    enabled: boolean
-    connected: boolean
-  }
-}
-
-export type RemoteEnableResponse = RemoteEnableResponses[keyof RemoteEnableResponses]
-
-export type RemoteDisableData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/remote/disable"
-}
-
-export type RemoteDisableResponses = {
-  /**
-   * Remote connection disabled
-   */
-  200: {
-    enabled: boolean
-    connected: boolean
-  }
-}
-
-export type RemoteDisableResponse = RemoteDisableResponses[keyof RemoteDisableResponses]
-
-export type RemoteStatusData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/remote/status"
-}
-
-export type RemoteStatusResponses = {
-  /**
-   * Remote connection status
-   */
-  200: {
-    enabled: boolean
-    connected: boolean
-  }
-}
-
-export type RemoteStatusResponse = RemoteStatusResponses[keyof RemoteStatusResponses]
 
 export type CommitMessageGenerateData = {
   body?: {
@@ -6310,90 +6388,3 @@ export type EventSubscribeResponses = {
 }
 
 export type EventSubscribeResponse = EventSubscribeResponses[keyof EventSubscribeResponses]
-
-export type NetworkListData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/network"
-}
-
-export type NetworkListResponses = {
-  /**
-   * List of pending network reconnect requests
-   */
-  200: Array<SessionNetworkWait>
-}
-
-export type NetworkListResponse = NetworkListResponses[keyof NetworkListResponses]
-
-export type NetworkReplyData = {
-  body?: never
-  path: {
-    requestID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/network/{requestID}/reply"
-}
-
-export type NetworkReplyErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type NetworkReplyError = NetworkReplyErrors[keyof NetworkReplyErrors]
-
-export type NetworkReplyResponses = {
-  /**
-   * Network wait resumed successfully
-   */
-  200: boolean
-}
-
-export type NetworkReplyResponse = NetworkReplyResponses[keyof NetworkReplyResponses]
-
-export type NetworkRejectData = {
-  body?: never
-  path: {
-    requestID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/network/{requestID}/reject"
-}
-
-export type NetworkRejectErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type NetworkRejectError = NetworkRejectErrors[keyof NetworkRejectErrors]
-
-export type NetworkRejectResponses = {
-  /**
-   * Network wait rejected successfully
-   */
-  200: boolean
-}
-
-export type NetworkRejectResponse = NetworkRejectResponses[keyof NetworkRejectResponses]


### PR DESCRIPTION
## Summary
- Regenerate the v2 SDK so snapshot/release builds typecheck against current remote-control endpoints.
- Update the VS Code remote status service to use the regenerated one-argument SDK options shape.
- Extract message handling paths so the stricter snapshot build lint step stays under complexity and max-lines limits.

## Verification
- `bun run typecheck` from `packages/kilo-vscode`
- `bun run lint` from `packages/kilo-vscode`
- `bun run format:check` from `packages/kilo-vscode`
- `bun typecheck` from repo root
- `bun run snapshot:build` from `packages/kilo-vscode`