### PR TITLE
fix(vscode): temporarily disable eslint complexity/max-lines rules

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- TODO: refactor to reduce file size and remove this disable */
 import * as path from "path"
 import * as vscode from "vscode"
 import { z } from "zod"
@@ -526,6 +527,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    */
   private setupWebviewMessageHandler(webview: vscode.Webview): void {
     this.webviewMessageDisposable?.dispose()
+    // eslint-disable-next-line complexity -- TODO: refactor to reduce complexity and remove this disable
     this.webviewMessageDisposable = webview.onDidReceiveMessage(async (message) => {
       // Run interceptor if attached (e.g., AgentManagerProvider worktree logic)
       if (this.onBeforeMessage) {

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -226,6 +226,7 @@ export class AgentManagerProvider implements Disposable {
   // Message interceptor
   // ---------------------------------------------------------------------------
 
+  // eslint-disable-next-line complexity -- TODO: refactor to reduce complexity and remove this disable
   private async onMessage(msg: Record<string, unknown>): Promise<Record<string, unknown> | null> {
     if (this.prBridge.handleMessage(msg)) return null
     const m = msg as unknown as AgentManagerInMessage


### PR DESCRIPTION
## Summary
- Add `eslint-disable` comments for `complexity` and `max-lines` rules in `KiloProvider.ts` and `AgentManagerProvider.ts` with TODO markers
- Fixes CI lint failures that block the pre-release build
- Rules remain active for all other files

## Changes
- `KiloProvider.ts`: disable `max-lines` at file level; disable `complexity` on the `onDidReceiveMessage` handler
- `AgentManagerProvider.ts`: disable `complexity` on the `onMessage` method

## TODO
Refactor to reduce complexity and remove the `eslint-disable` comments.