### PR TITLE
ux(vscode): restrict size of model descriptions in picker

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
@@ -494,8 +494,13 @@
 }
 
 .mode-switcher-item-desc {
+  display: block;
   font-size: 11px;
   color: var(--text-weak, var(--vscode-descriptionForeground));
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .mode-switcher-item.selected .mode-switcher-item-name {


### PR DESCRIPTION
## Context

Currently custom agents with long descriptions can cause the model picker to take up the entire height of the extension, causing a very jarring user experience. This change limits the size of the description to one line, with trailing ellipses, to ensure each item has a consistent height.

## Screenshots

| before | after |
| ------ | ----- |
| <img width="443" height="1385" alt="Screenshot_20260409_212739" src="https://github.com/user-attachments/assets/6061e596-4318-444a-91a4-8cb45ad03776" />       |   <img width="476" height="1341" alt="Screenshot_20260409_212705" src="https://github.com/user-attachments/assets/554db119-3d6f-4ca7-92a2-fd9a23f8d3e5" />    |

## Get in Touch

ExpedientFalcon on Discord
