### PR TITLE
fix: align pre-release version publishing

### DIFF
--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -36,6 +36,26 @@ const CHANNEL = await (async () => {
 const IS_PREVIEW = CHANNEL !== "latest"
 
 // kilocode_change start - shared helpers for version computation
+function parseVersion(input: string) {
+  const match = input.trim().match(/^v?(\d+)\.(\d+)\.(\d+)$/)
+  if (!match) return
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    value: `${match[1]}.${match[2]}.${match[3]}`,
+  }
+}
+
+function compareVersion(
+  a: NonNullable<ReturnType<typeof parseVersion>>,
+  b: NonNullable<ReturnType<typeof parseVersion>>,
+) {
+  if (a.major !== b.major) return a.major - b.major
+  if (a.minor !== b.minor) return a.minor - b.minor
+  return a.patch - b.patch
+}
+
 async function fetchLatest() {
   const data: any = await fetch("https://registry.npmjs.org/@kilocode/cli/latest").then((res) => {
     if (!res.ok) throw new Error(res.statusText)
@@ -44,28 +64,42 @@ async function fetchLatest() {
   return data.version as string
 }
 
+async function fetchHighest() {
+  if (!env.KILO_RELEASE || !process.env.GH_REPO) return fetchLatest()
+  const data: { tagName: string }[] = await $`gh release list --json tagName --limit 100 --repo ${process.env.GH_REPO}`
+    .json()
+    .catch(() => [])
+  const versions = data.flatMap((item) => {
+    const version = parseVersion(item.tagName)
+    if (!version) return []
+    return [version]
+  })
+  const highest = versions.sort(compareVersion).at(-1)
+  if (highest) return highest.value
+  return fetchLatest()
+}
+
 function bumpVersion(current: string, type: string) {
-  const [major, minor, patch] = current.split(".").map((x: string) => Number(x) || 0)
-  if (type === "major") return `${major + 1}.0.0`
-  if (type === "minor") return `${major}.${minor + 1}.0`
-  return `${major}.${minor}.${patch + 1}`
+  const version = parseVersion(current)
+  if (!version) throw new Error(`Invalid version: ${current}`)
+  if (type === "major") return `${version.major + 1}.0.0`
+  if (type === "minor") return `${version.major}.${version.minor + 1}.0`
+  return `${version.major}.${version.minor}.${version.patch + 1}`
 }
 // kilocode_change end
 
 const VERSION = await (async () => {
   if (env.KILO_VERSION) return env.KILO_VERSION // kilocode_change
   if (IS_PREVIEW) {
-    // kilocode_change start - compute semver prerelease for rc channel
+    // kilocode_change start - rc releases use plain semver required by VS Code Marketplace
     if (env.KILO_BUMP && env.KILO_PRE_RELEASE === "true") {
-      const current = await fetchLatest()
-      const base = bumpVersion(current, env.KILO_BUMP.toLowerCase())
-      const stamp = new Date().toISOString().slice(0, 16).replace(/[-:T]/g, "")
-      return `${base}-rc.${stamp}`
+      const current = await fetchHighest()
+      return bumpVersion(current, env.KILO_BUMP.toLowerCase())
     }
     // kilocode_change end
     return `0.0.0-${CHANNEL}-${new Date().toISOString().slice(0, 16).replace(/[-:T]/g, "")}`
   }
-  const version = await fetchLatest() // kilocode_change
+  const version = await fetchHighest() // kilocode_change
   return bumpVersion(version, env.KILO_BUMP?.toLowerCase() ?? "patch") // kilocode_change
 })()
 

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -62,13 +62,8 @@ if (Script.release) {
   await $`git commit -am "release: v${Script.version}"`
   await $`git tag v${Script.version}`
   await $`git fetch origin`
-  if (!Script.preview) {
-    await $`git cherry-pick HEAD..origin/main`.nothrow()
-    await $`git push origin HEAD --tags --no-verify --force-with-lease`
-  }
-  if (Script.preview) {
-    await $`git push origin HEAD --tags`
-  }
+  await $`git cherry-pick HEAD..origin/main`.nothrow()
+  await $`git push origin HEAD --tags --no-verify --force-with-lease`
   await new Promise((resolve) => setTimeout(resolve, 5_000))
   // kilocode_change end
 

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -63,7 +63,7 @@ if (Script.release) {
   await $`git tag v${Script.version}`
   await $`git fetch origin`
   if (!Script.preview) {
-    await $`git cherry-pick HEAD..origin/dev`.nothrow()
+    await $`git cherry-pick HEAD..origin/main`.nothrow()
     await $`git push origin HEAD --tags --no-verify --force-with-lease`
   }
   if (Script.preview) {

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -58,14 +58,19 @@ await $`bun install`
 await import(`../packages/sdk/js/script/build.ts`)
 
 if (Script.release) {
+  // kilocode_change start - commit and tag both release and rc version bumps
+  await $`git commit -am "release: v${Script.version}"`
+  await $`git tag v${Script.version}`
+  await $`git fetch origin`
   if (!Script.preview) {
-    await $`git commit -am "release: v${Script.version}"`
-    await $`git tag v${Script.version}`
-    await $`git fetch origin`
     await $`git cherry-pick HEAD..origin/dev`.nothrow()
     await $`git push origin HEAD --tags --no-verify --force-with-lease`
-    await new Promise((resolve) => setTimeout(resolve, 5_000))
   }
+  if (Script.preview) {
+    await $`git push origin HEAD --tags`
+  }
+  await new Promise((resolve) => setTimeout(resolve, 5_000))
+  // kilocode_change end
 
   // kilocode_change start
   // await import(`../packages/desktop/scripts/finalize-latest-json.ts`)


### PR DESCRIPTION
## Summary
- Keep pre-release publishes on plain semver versions so VS Code Marketplace accepts `--pre-release` packages.
- Compute release bumps from the highest GitHub release tag across stable and RC releases so versions stay monotonic.
- Commit and tag RC release bumps without extending the stable release force-push path.

## Validation
- `bun --bun packages/script/src/index.ts`
- `KILO_PRE_RELEASE=true KILO_BUMP=patch KILO_RELEASE=123 GH_REPO=Kilo-Org/kilocode bun --bun packages/script/src/index.ts`
- `KILO_PRE_RELEASE=true KILO_BUMP=minor KILO_RELEASE=123 GH_REPO=Kilo-Org/kilocode bun --bun packages/script/src/index.ts`
- `bun turbo typecheck` via git pre-push hook