### PR TITLE
docs(cli): document how to disable built-in providers

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/index.md
+++ b/packages/kilo-docs/pages/ai-providers/index.md
@@ -63,7 +63,7 @@ In the **VSCode (Legacy)** version, API keys use VS Code's Secret Storage. In th
 
 ## Disabling Built-in Providers
 
-You can prevent specific providers from loading using `disabled_providers` in your `kilo.json`. This is useful to hide providers from the model picker that you don't intend to use.
+You can prevent specific providers from loading using `disabled_providers` in your `kilo.json`. This is useful to hide models from built-in or detected providers that you don't intend to use.
 
 ```json
 {

--- a/packages/kilo-docs/pages/ai-providers/index.md
+++ b/packages/kilo-docs/pages/ai-providers/index.md
@@ -63,7 +63,7 @@ In the **VSCode (Legacy)** version, API keys use VS Code's Secret Storage. In th
 
 ## Disabling Built-in Providers
 
-You can prevent specific providers from loading using `disabled_providers` in your `kilo.jsonc`. This is useful to hide models from built-in or detected providers that you don't intend to use.
+You can prevent specific providers from loading using `disabled_providers` in your `kilo.json` (or `kilo.jsonc`). This is useful to hide models from built-in or detected providers that you don't intend to use.
 
 ```json
 {

--- a/packages/kilo-docs/pages/ai-providers/index.md
+++ b/packages/kilo-docs/pages/ai-providers/index.md
@@ -61,6 +61,28 @@ Route requests through unified APIs with additional features:
 In the **VSCode (Legacy)** version, API keys use VS Code's Secret Storage. In the current **VSCode & CLI** version, keys are set via environment variables or referenced in `kilo.json` config files. See individual provider pages for setup instructions for each platform.
 {% /callout %}
 
+## Disabling Built-in Providers
+
+You can prevent specific providers from loading using `disabled_providers` in your `kilo.json`. This is useful to hide providers from the model picker that you don't intend to use.
+
+```json
+{
+  "$schema": "https://app.kilo.ai/config.json",
+  "disabled_providers": ["kilo", "openai"]
+}
+```
+
+To allow only specific providers and disable everything else, use `enabled_providers` instead:
+
+```json
+{
+  "$schema": "https://app.kilo.ai/config.json",
+  "enabled_providers": ["anthropic"]
+}
+```
+
+Both fields accept provider IDs — the lowercase identifier used in the `provider/model` format (e.g. `anthropic`, `openai`, `google`, `groq`).
+
 ## Next Steps
 
 - **New to Kilo Code?** Start with the [Kilo Code provider](/docs/ai-providers/kilocode) - no setup required

--- a/packages/kilo-docs/pages/ai-providers/index.md
+++ b/packages/kilo-docs/pages/ai-providers/index.md
@@ -63,7 +63,7 @@ In the **VSCode (Legacy)** version, API keys use VS Code's Secret Storage. In th
 
 ## Disabling Built-in Providers
 
-You can prevent specific providers from loading using `disabled_providers` in your `kilo.json`. This is useful to hide models from built-in or detected providers that you don't intend to use.
+You can prevent specific providers from loading using `disabled_providers` in your `kilo.jsonc`. This is useful to hide models from built-in or detected providers that you don't intend to use.
 
 ```json
 {
@@ -81,7 +81,7 @@ To allow only specific providers and disable everything else, use `enabled_provi
 }
 ```
 
-Both fields accept provider IDs — the lowercase identifier used in the `provider/model` format (e.g. `anthropic`, `openai`, `google`, `groq`).
+Both fields accept provider IDs — the lowercase identifier used in the `provider/model` format (e.g. `kilo`, `anthropic`, `openai`, `google`, `groq`).
 
 ## Next Steps
 

--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -140,6 +140,45 @@ Disable an inherited server: `{ "server-name": { "enabled": false } }`.
 }
 ```
 
+### Disabling Built-in Providers
+
+Use `disabled_providers` to prevent specific providers from loading. This is useful when you want to exclude providers that are auto-detected via environment variables or that you don't want available in the model picker.
+
+```jsonc
+{
+  "$schema": "https://app.kilo.ai/config.json",
+  "disabled_providers": ["kilo", "openai"],
+}
+```
+
+The provider ID is the lowercase name used in the `provider/model` format (e.g., `kilo`, `openai`, `anthropic`, `google`, `groq`).
+
+**Common provider IDs:**
+
+| Provider  | ID          | Notes                   |
+| --------- | ----------- | ----------------------- |
+| Kilo      | `kilo`      | Default Kilo AI Gateway |
+| OpenAI    | `openai`    |                         |
+| Anthropic | `anthropic` |                         |
+| Google    | `google`    |                         |
+| Groq      | `groq`      |                         |
+| Ollama    | `ollama`    | Local models            |
+| LM Studio | `lmstudio`  | Local models            |
+
+**Interaction with `enabled_providers`:**
+
+- `disabled_providers` removes specific providers from the auto-loaded set
+- `enabled_providers` is more restrictive — when set, ONLY the listed providers will be enabled, ignoring all others
+- If both are set, `enabled_providers` takes precedence
+
+To disable all auto-detected providers except one:
+
+```jsonc
+{
+  "enabled_providers": ["anthropic"],
+}
+```
+
 ## Skills
 
 Additional skill directories and remote URLs:

--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -155,15 +155,15 @@ The provider ID is the lowercase name used in the `provider/model` format (e.g.,
 
 **Common provider IDs:**
 
-| Provider  | ID          | Notes                   |
-| --------- | ----------- | ----------------------- |
-| Kilo      | `kilo`      | Default Kilo AI Gateway |
-| OpenAI    | `openai`    |                         |
-| Anthropic | `anthropic` |                         |
-| Google    | `google`    |                         |
-| Groq      | `groq`      |                         |
-| Ollama    | `ollama`    | Local models            |
-| LM Studio | `lmstudio`  | Local models            |
+| Provider       | ID             |
+| -------------- | -------------- |
+| Kilo           | `kilo`         |
+| OpenAI         | `openai`       |
+| Anthropic      | `anthropic`    |
+| Google         | `google`       |
+| Groq           | `groq`         |
+| LM Studio      | `lmstudio`     |
+| Ollama (cloud) | `ollama-cloud` |
 
 **Interaction with `enabled_providers`:**
 

--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -142,7 +142,9 @@ Disable an inherited server: `{ "server-name": { "enabled": false } }`.
 
 ### Disabling Built-in Providers
 
-Use `disabled_providers` to prevent specific providers from loading. This is useful when you want to exclude providers that are auto-detected via environment variables or that you don't want available in the model picker.
+Use `disabled_providers` to prevent specific providers from loading. This is useful when you want to exclude providers that are built-in, or auto-detected via environment variables, from appearing in the model picker.
+
+For example, this configuration will hide all models from the built-in Kilo Gateway as well as any from the OpenAI provider which may be enabled automatically through environment variables.
 
 ```jsonc
 {
@@ -153,23 +155,11 @@ Use `disabled_providers` to prevent specific providers from loading. This is use
 
 The provider ID is the lowercase name used in the `provider/model` format (e.g., `kilo`, `openai`, `anthropic`, `google`, `groq`).
 
-**Common provider IDs:**
-
-| Provider       | ID             |
-| -------------- | -------------- |
-| Kilo           | `kilo`         |
-| OpenAI         | `openai`       |
-| Anthropic      | `anthropic`    |
-| Google         | `google`       |
-| Groq           | `groq`         |
-| LM Studio      | `lmstudio`     |
-| Ollama (cloud) | `ollama-cloud` |
-
 **Interaction with `enabled_providers`:**
 
 - `disabled_providers` removes specific providers from the auto-loaded set
 - `enabled_providers` is more restrictive — when set, ONLY the listed providers will be enabled, ignoring all others
-- If both are set, `enabled_providers` takes precedence
+- If both are set, providers must appear in `enabled_providers` and not appear in `disabled_providers`
 
 To disable all auto-detected providers except one:
 


### PR DESCRIPTION
## Summary

- Adds a "Disabling Built-in Providers" subsection to the Providers section in the kilo-config skill
- Documents the `disabled_providers` config field with an example using the `$schema` field
- Includes a table of common provider IDs (`kilo`, `openai`, `anthropic`, `google`, `groq`, `ollama`, `lmstudio`)
- Explains the interaction between `disabled_providers` and `enabled_providers`