### PR TITLE
docs(kilo-docs): document asking the agent to configure kilo.json

### DIFF
--- a/packages/kilo-docs/pages/getting-started/index.md
+++ b/packages/kilo-docs/pages/getting-started/index.md
@@ -31,6 +31,10 @@ Your sessions sync across all of these, so you can start a task on your phone an
 2. [Connect an AI provider](/docs/ai-providers) or use Kilo's built-in provider & credits
 3. [Run your first task](/docs/getting-started/quickstart)
 
+{% callout type="tip" %}
+**The easiest way to configure Kilo is to ask the agent.** Just tell the agent what you want — "add this MCP server", "disable OpenAI", "add my Ollama endpoint". The agent has a built-in skill for reading and updating your `kilo.jsonc` configuration. [Learn more](/docs/getting-started/settings#configuring-with-the-agent)
+{% /callout %}
+
 New to AI coding assistants? Before learning what Kilo itself does, you can learn about agentic engineering at [path.kilo.ai](https://path.kilo.ai)
 
 Coming from Cursor or Windsurf? See our [migration guide](/docs/getting-started/migrating)

--- a/packages/kilo-docs/pages/getting-started/settings/index.md
+++ b/packages/kilo-docs/pages/getting-started/settings/index.md
@@ -15,7 +15,7 @@ The fastest way to change your Kilo configuration is to ask the agent to do it f
 
 - "Switch my default model to Claude Sonnet"
 - "Disable the OpenAI and Groq providers"
-- "Set up an MCP server for my local Postgres database"
+- "Set up an MCP server for Figma"
 - "Auto-approve all read and glob operations"
 - "Create a custom agent for code review"
 

--- a/packages/kilo-docs/pages/getting-started/settings/index.md
+++ b/packages/kilo-docs/pages/getting-started/settings/index.md
@@ -5,7 +5,25 @@ description: "Configure Kilo Code settings and preferences"
 
 # Settings
 
-The VS Code extension can be configured through the Settings window, opened by pressing the gear icon. Both the CLI and the extension can also be configured through interactions with the agent. The current VS Code extension and CLI share the same underlying settings, so changes in one are reflected in the other.
+The VS Code extension can be configured through the Settings window, opened by pressing the gear icon. The current VS Code extension and CLI share the same underlying settings, so changes in one are reflected in the other.
+
+## Configuring with the Agent
+
+The fastest way to change your Kilo configuration is to ask the agent to do it for you. The agent has a built-in skill that understands the full `kilo.jsonc` schema and can read, create, and update your config files directly.
+
+**Examples of things you can ask:**
+
+- "Switch my default model to Claude Sonnet"
+- "Disable the OpenAI and Groq providers"
+- "Set up an MCP server for my local Postgres database"
+- "Auto-approve all read and glob operations"
+- "Create a custom agent for code review"
+
+The agent will edit the appropriate config file (global or project-level) and explain what it changed. This works in both the CLI and VS Code extension.
+
+{% callout type="tip" %}
+This is especially useful for complex configuration like custom model definitions, MCP server setup, or permission patterns — the agent knows the correct syntax and will validate the config for you.
+{% /callout %}
 
 ## Managing Settings
 

--- a/packages/kilo-docs/pages/getting-started/settings/index.md
+++ b/packages/kilo-docs/pages/getting-started/settings/index.md
@@ -5,7 +5,7 @@ description: "Configure Kilo Code settings and preferences"
 
 # Settings
 
-The VS Code extension can be configured through the Settings window, opened by pressing the gear icon. The current VS Code extension and CLI share the same underlying settings, so changes in one are reflected in the other.
+The VS Code extension can be configured through the Settings window, opened by pressing the gear icon. Both the CLI and the extension can also be configured through interactions with the agent. The current VS Code extension and CLI share the same underlying settings, so changes in one are reflected in the other.
 
 ## Configuring with the Agent
 


### PR DESCRIPTION
## Summary

- Adds a tip callout to the Getting Started overview page highlighting that the easiest way to configure Kilo is to ask the agent
- Adds a full "Configuring with the Agent" section to the Settings page with concrete examples of what users can ask (provider setup, model switching, MCP servers, permissions, custom agents)
- Replaces a buried one-liner about agent configuration with a proper discoverable section