### PR TITLE
fix(vscode): restore prompt focus after model selection

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -217,7 +217,22 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
 
   // Focus textarea when any part of the app requests it
-  const onFocusPrompt = () => textareaRef?.focus()
+  const onFocusPrompt = () => {
+    const focus = () => {
+      const ref = textareaRef
+      if (!ref) return
+      window.focus()
+      ref.focus({ preventScroll: true })
+    }
+    focus()
+    queueMicrotask(focus)
+    requestAnimationFrame(() => {
+      focus()
+      requestAnimationFrame(focus)
+      setTimeout(focus, 0)
+      setTimeout(focus, 50)
+    })
+  }
   window.addEventListener("focusPrompt", onFocusPrompt)
   onCleanup(() => window.removeEventListener("focusPrompt", onFocusPrompt))
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -217,20 +217,24 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
 
   // Focus textarea when any part of the app requests it
-  const onFocusPrompt = () => {
+  const onFocusPrompt = (event: Event) => {
     const focus = () => {
       const ref = textareaRef
       if (!ref) return
-      window.focus()
       ref.focus({ preventScroll: true })
     }
     focus()
-    queueMicrotask(focus)
-    requestAnimationFrame(() => {
+    if (!(event instanceof CustomEvent) || !event.detail?.restore) return
+    const restore = () => {
+      window.focus()
       focus()
-      requestAnimationFrame(focus)
-      setTimeout(focus, 0)
-      setTimeout(focus, 50)
+    }
+    queueMicrotask(restore)
+    requestAnimationFrame(() => {
+      restore()
+      requestAnimationFrame(restore)
+      setTimeout(restore, 0)
+      setTimeout(restore, 50)
     })
   }
   window.addEventListener("focusPrompt", onFocusPrompt)

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -721,7 +721,7 @@ export const ModelSelector: Component = () => {
         session.selectModel(providerID, modelID)
       }}
       onPick={() => {
-        requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
+        requestAnimationFrame(() => window.dispatchEvent(new CustomEvent("focusPrompt", { detail: { restore: true } })))
       }}
     />
   )

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -78,6 +78,8 @@ export interface ModelSelectorBaseProps {
   value: ModelSelection | null
   /** Called when the user picks a model */
   onSelect: (providerID: string, modelID: string) => void
+  /** Called after a pick closes the popover */
+  onPick?: () => void
   /** Popover placement — defaults to "top-start" */
   placement?: "top-start" | "bottom-start" | "bottom-end" | "top-end"
   /** Allow clearing the selection (shows a "Not set" option) */
@@ -364,6 +366,7 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
   function pick(model: EnrichedModel) {
     props.onSelect(model.providerID, model.id)
     setOpen(false)
+    props.onPick?.()
   }
 
   function pickClear() {
@@ -372,6 +375,7 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
     setPreviewKey(CLEAR_KEY)
     props.onSelect("", "")
     setOpen(false)
+    props.onPick?.()
   }
 
   function setRow(key: string) {
@@ -715,6 +719,8 @@ export const ModelSelector: Component = () => {
       value={session.selected()}
       onSelect={(providerID, modelID) => {
         session.selectModel(providerID, modelID)
+      }}
+      onPick={() => {
         requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
       }}
     />


### PR DESCRIPTION
## Summary
- Restore real keyboard focus to the prompt textarea after selecting a model from `/models`.
- Scope model-picker refocus to the chat wrapper so settings/branch picker popovers are unaffected.
- Retry prompt focus across popover close autofocus timing introduced by shared popover focus handling.

## Test Plan
- `bun run format` from `packages/kilo-vscode`
- `bun script/typecheck.ts --project webview-ui/tsconfig.json` from `packages/kilo-vscode`
- `git diff --check -- packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx`
- Manual: `/models` -> select model with keyboard -> Enter -> type in prompt