### PR TITLE
fix(vscode): ignore confirmed command transport errors

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -27,6 +27,7 @@ import {
   mapSSEEventToWebviewMessage,
   getErrorMessage,
   isEventFromForeignProject,
+  MessageConfirmation,
   loadSessions as loadSessionsUtil,
   flushPendingSessionRefresh as flushPendingSessionRefreshUtil,
   resolveContextDirectory,
@@ -164,6 +165,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   /** Set when refreshSessions() is called before the client is ready.
    *  Cleared and retried once the connection transitions to "connected". */
   private pendingSessionRefresh = false
+  private readonly confirmations = new MessageConfirmation()
   private unsubscribeEvent: (() => void) | null = null
   private unsubscribeState: (() => void) | null = null
   /** Cached legacy migration data so migrate() doesn't re-read from disk/SecretStorage. */ // legacy-migration
@@ -2349,7 +2351,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * The webview receives `sessionStatus` messages with a countdown so the
    * user can see that a retry is in progress.
    */
-  private async withRetry(fn: () => Promise<{ error?: unknown; response: Response }>, sid: string): Promise<void> {
+  private async withRetry(
+    fn: () => Promise<{ error?: unknown; response?: Response }>,
+    sid: string,
+    messageID?: string,
+  ): Promise<void> {
     const abortController = new AbortController()
     this.retryAbortControllers.set(sid, abortController)
 
@@ -2362,6 +2368,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
         const result = await fn()
         if (!result.error) return
+        if (this.confirmations.has(messageID)) return
 
         const status = result.response?.status ?? 0
 
@@ -2390,12 +2397,16 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         })
 
         // Wait for delay or until aborted
-        await new Promise((resolve) => {
-          const timer = setTimeout(resolve, delay)
-          abortController.signal.addEventListener("abort", () => {
+        await new Promise<void>((resolve) => {
+          const done = () => {
             clearTimeout(timer)
-          })
+            abortController.signal.removeEventListener("abort", done)
+            resolve()
+          }
+          const timer = setTimeout(done, delay)
+          abortController.signal.addEventListener("abort", done, { once: true })
         })
+        if (this.confirmations.has(messageID)) return
       }
     } finally {
       this.retryAbortControllers.delete(sid)
@@ -2468,8 +2479,18 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             editorContext,
           }),
         sid,
+        messageID,
       )
     } catch (error) {
+      if (await this.confirmations.wait(messageID)) {
+        console.warn(
+          "[Kilo New] KiloProvider: Message request ended after server accepted it; ignoring transport error",
+          {
+            error: getErrorMessage(error),
+          },
+        )
+        return
+      }
       console.error("[Kilo New] KiloProvider: Failed to send message:", error)
       this.postMessage({
         type: "sendMessageFailed",
@@ -2534,8 +2555,18 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             parts,
           }),
         sid,
+        messageID,
       )
     } catch (error) {
+      if (await this.confirmations.wait(messageID)) {
+        console.warn(
+          "[Kilo New] KiloProvider: Command request ended after server accepted it; ignoring transport error",
+          {
+            error: getErrorMessage(error),
+          },
+        )
+        return
+      }
       console.error("[Kilo New] KiloProvider: Failed to send command:", error)
       this.postMessage({
         type: "sendMessageFailed",
@@ -2678,6 +2709,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       postMessage: (msg) => this.postMessage(msg),
       getWorkspaceDirectory: (sid) => this.getWorkspaceDirectory(sid),
       gatherEditorContext: () => this.gatherEditorContext(),
+      waitForMessageConfirmation: (id) => this.confirmations.wait(id),
     }
   }
 
@@ -2890,6 +2922,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // This must come first: the trackedSessionIds guard below would otherwise
     // let a foreign session through if it was accidentally tracked.
     if (isEventFromForeignProject(event, this.projectID)) return
+
+    if (event.type === "message.updated") {
+      this.confirmations.confirm(event.properties.info.id)
+    }
 
     // session.status events pass the onEventFiltered pre-filter for all providers (see line 842),
     // so this runs on every KiloProvider instance — including the Settings panel which has no

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2338,20 +2338,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   /** Abort controllers for active retry loops, keyed by session ID */
   private retryAbortControllers = new Map<string, AbortController>()
 
-  /**
-   * Execute an SDK call with exponential backoff on HTTP errors.
-   * Retries on 429, 5xx, and other retryable status codes.
-   * When the response includes `Retry-After` / `Retry-After-MS` headers,
-   * the delay honours that value (capped at 5 min). Otherwise uses the
-   * predefined backoff schedule: 5s -> 10s -> 30s -> 60s -> 300s.
-   *
-   * After MAX_RETRIES (5) attempts, automatically throws the error.
-   * Users can cancel via the cancel button in the UI which sends an abort
-   * message — this interrupts the backoff delay and stops the retry loop.
-   *
-   * The webview receives `sessionStatus` messages with a countdown so the
-   * user can see that a retry is in progress.
-   */
+  /** Execute an SDK call with visible exponential backoff for retryable HTTP errors. */
   private async withRetry(
     fn: () => Promise<{ error?: unknown; response?: Response }>,
     sid: string,

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2447,6 +2447,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     let resolved: { sid: string; dir: string } | undefined
+    const release = this.confirmations.track(messageID)
     try {
       resolved = await this.resolveSession(sessionID, draftID)
 
@@ -2501,6 +2502,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         messageID,
         files,
       })
+    } finally {
+      release()
     }
   }
 
@@ -2530,6 +2533,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     let resolved: { sid: string; dir: string } | undefined
+    const release = this.confirmations.track(messageID)
     try {
       resolved = await this.resolveSession(sessionID, draftID)
 
@@ -2577,6 +2581,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         messageID,
         files,
       })
+    } finally {
+      release()
     }
   }
 
@@ -2709,6 +2715,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       postMessage: (msg) => this.postMessage(msg),
       getWorkspaceDirectory: (sid) => this.getWorkspaceDirectory(sid),
       gatherEditorContext: () => this.gatherEditorContext(),
+      trackMessageConfirmation: (id) => this.confirmations.track(id),
       waitForMessageConfirmation: (id) => this.confirmations.wait(id),
     }
   }

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -28,6 +28,7 @@ import {
   getErrorMessage,
   isEventFromForeignProject,
   MessageConfirmation,
+  runWithMessageConfirmation,
   loadSessions as loadSessionsUtil,
   flushPendingSessionRefresh as flushPendingSessionRefreshUtil,
   resolveContextDirectory,
@@ -2447,7 +2448,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     let resolved: { sid: string; dir: string } | undefined
-    const release = this.confirmations.track(messageID)
     try {
       resolved = await this.resolveSession(sessionID, draftID)
 
@@ -2467,31 +2467,24 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       const sid = resolved!.sid
       const dir = resolved!.dir
-      await this.withRetry(
-        () =>
-          this.client!.session.promptAsync({
-            sessionID: sid,
-            directory: dir,
-            messageID,
-            parts,
-            model: providerID && modelID ? { providerID, modelID } : undefined,
-            agent,
-            variant,
-            editorContext,
-          }),
-        sid,
-        messageID,
+      await runWithMessageConfirmation(this.confirmations, messageID, "KiloProvider: Message request", () =>
+        this.withRetry(
+          () =>
+            this.client!.session.promptAsync({
+              sessionID: sid,
+              directory: dir,
+              messageID,
+              parts,
+              model: providerID && modelID ? { providerID, modelID } : undefined,
+              agent,
+              variant,
+              editorContext,
+            }),
+          sid,
+          messageID,
+        ),
       )
     } catch (error) {
-      if (await this.confirmations.wait(messageID)) {
-        console.warn(
-          "[Kilo New] KiloProvider: Message request ended after server accepted it; ignoring transport error",
-          {
-            error: getErrorMessage(error),
-          },
-        )
-        return
-      }
       console.error("[Kilo New] KiloProvider: Failed to send message:", error)
       this.postMessage({
         type: "sendMessageFailed",
@@ -2502,8 +2495,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         messageID,
         files,
       })
-    } finally {
-      release()
     }
   }
 
@@ -2533,7 +2524,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     let resolved: { sid: string; dir: string } | undefined
-    const release = this.confirmations.track(messageID)
     try {
       resolved = await this.resolveSession(sessionID, draftID)
 
@@ -2545,32 +2535,25 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       const sid = resolved!.sid
       const dir = resolved!.dir
-      await this.withRetry(
-        () =>
-          this.client!.session.command({
-            sessionID: sid,
-            directory: dir,
-            command,
-            arguments: args,
-            messageID,
-            model: providerID && modelID ? `${providerID}/${modelID}` : undefined,
-            agent,
-            variant,
-            parts,
-          }),
-        sid,
-        messageID,
+      await runWithMessageConfirmation(this.confirmations, messageID, "KiloProvider: Command request", () =>
+        this.withRetry(
+          () =>
+            this.client!.session.command({
+              sessionID: sid,
+              directory: dir,
+              command,
+              arguments: args,
+              messageID,
+              model: providerID && modelID ? `${providerID}/${modelID}` : undefined,
+              agent,
+              variant,
+              parts,
+            }),
+          sid,
+          messageID,
+        ),
       )
     } catch (error) {
-      if (await this.confirmations.wait(messageID)) {
-        console.warn(
-          "[Kilo New] KiloProvider: Command request ended after server accepted it; ignoring transport error",
-          {
-            error: getErrorMessage(error),
-          },
-        )
-        return
-      }
       console.error("[Kilo New] KiloProvider: Failed to send command:", error)
       this.postMessage({
         type: "sendMessageFailed",
@@ -2581,8 +2564,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         messageID,
         files,
       })
-    } finally {
-      release()
     }
   }
 
@@ -2715,8 +2696,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       postMessage: (msg) => this.postMessage(msg),
       getWorkspaceDirectory: (sid) => this.getWorkspaceDirectory(sid),
       gatherEditorContext: () => this.gatherEditorContext(),
-      trackMessageConfirmation: (id) => this.confirmations.track(id),
-      waitForMessageConfirmation: (id) => this.confirmations.wait(id),
+      runWithMessageConfirmation: (id, label, run) => runWithMessageConfirmation(this.confirmations, id, label, run),
     }
   }
 

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -59,40 +59,46 @@ export function getErrorMessage(error: unknown): string {
 }
 
 export class MessageConfirmation {
-  private readonly ids = new Set<string>()
-  private readonly waits = new Map<string, Set<() => void>>()
+  private readonly ids = new Map<string, { confirmed: boolean; waits: Set<() => void> }>()
+
+  track(id?: string): () => void {
+    if (!id) return () => {}
+    const entry = this.ids.get(id) ?? { confirmed: false, waits: new Set<() => void>() }
+    this.ids.set(id, entry)
+    return () => {
+      this.ids.delete(id)
+    }
+  }
 
   confirm(id: string): void {
-    this.ids.add(id)
-    const waits = this.waits.get(id)
-    if (!waits) return
-    for (const done of [...waits]) {
+    const entry = this.ids.get(id)
+    if (!entry) return
+    entry.confirmed = true
+    for (const done of [...entry.waits]) {
       done()
     }
   }
 
   has(id?: string): boolean {
     if (!id) return false
-    return this.ids.has(id)
+    return this.ids.get(id)?.confirmed ?? false
   }
 
   wait(id?: string, timeout = 1_500): Promise<boolean> {
     if (!id) return Promise.resolve(false)
-    if (this.ids.has(id)) return Promise.resolve(true)
+    const entry = this.ids.get(id)
+    if (!entry) return Promise.resolve(false)
+    if (entry.confirmed) return Promise.resolve(true)
 
     return new Promise((resolve) => {
-      const waits = this.waits.get(id) ?? new Set<() => void>()
-      this.waits.set(id, waits)
-
       const timer = setTimeout(() => {
         cleanup()
-        resolve(this.ids.has(id))
+        resolve(entry.confirmed)
       }, timeout)
 
       const cleanup = () => {
         clearTimeout(timer)
-        waits.delete(done)
-        if (waits.size === 0) this.waits.delete(id)
+        entry.waits.delete(done)
       }
 
       const done = () => {
@@ -100,7 +106,7 @@ export class MessageConfirmation {
         resolve(true)
       }
 
-      waits.add(done)
+      entry.waits.add(done)
     })
   }
 }

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -58,6 +58,53 @@ export function getErrorMessage(error: unknown): string {
   return String(error)
 }
 
+export class MessageConfirmation {
+  private readonly ids = new Set<string>()
+  private readonly waits = new Map<string, Set<() => void>>()
+
+  confirm(id: string): void {
+    this.ids.add(id)
+    const waits = this.waits.get(id)
+    if (!waits) return
+    for (const done of [...waits]) {
+      done()
+    }
+  }
+
+  has(id?: string): boolean {
+    if (!id) return false
+    return this.ids.has(id)
+  }
+
+  wait(id?: string, timeout = 1_500): Promise<boolean> {
+    if (!id) return Promise.resolve(false)
+    if (this.ids.has(id)) return Promise.resolve(true)
+
+    return new Promise((resolve) => {
+      const waits = this.waits.get(id) ?? new Set<() => void>()
+      this.waits.set(id, waits)
+
+      const timer = setTimeout(() => {
+        cleanup()
+        resolve(this.ids.has(id))
+      }, timeout)
+
+      const cleanup = () => {
+        clearTimeout(timer)
+        waits.delete(done)
+        if (waits.size === 0) this.waits.delete(id)
+      }
+
+      const done = () => {
+        cleanup()
+        resolve(true)
+      }
+
+      waits.add(done)
+    })
+  }
+}
+
 export function sessionToWebview(session: Session) {
   return {
     id: session.id,

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -111,6 +111,28 @@ export class MessageConfirmation {
   }
 }
 
+export async function runWithMessageConfirmation<T>(
+  state: MessageConfirmation,
+  id: string | undefined,
+  label: string,
+  run: () => Promise<T>,
+): Promise<T | undefined> {
+  const release = state.track(id)
+  try {
+    return await run()
+  } catch (error) {
+    if (await state.wait(id)) {
+      console.warn(`[Kilo New] ${label} ended after server accepted it; ignoring transport error`, {
+        error: getErrorMessage(error),
+      })
+      return undefined
+    }
+    throw error
+  } finally {
+    release()
+  }
+}
+
 export function sessionToWebview(session: Session) {
   return {
     id: session.id,

--- a/packages/kilo-vscode/src/kilo-provider/handlers/cloud-session.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/cloud-session.ts
@@ -19,6 +19,7 @@ export interface CloudSessionContext {
   postMessage(msg: unknown): void
   getWorkspaceDirectory(sessionId?: string): string
   gatherEditorContext(): Promise<EditorContext>
+  waitForMessageConfirmation?(messageID?: string): Promise<boolean>
 }
 
 /** Fetch cloud sessions list and send to webview. */
@@ -209,6 +210,12 @@ export async function handleImportAndSend(
       )
     }
   } catch (err) {
+    if (await ctx.waitForMessageConfirmation?.(messageID)) {
+      console.warn("[Kilo New] Cloud import send ended after server accepted it; ignoring transport error", {
+        error: getErrorMessage(err),
+      })
+      return
+    }
     console.error("[Kilo New] Failed to send message after cloud import:", err)
     ctx.postMessage({
       type: "sendMessageFailed",

--- a/packages/kilo-vscode/src/kilo-provider/handlers/cloud-session.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/cloud-session.ts
@@ -19,6 +19,7 @@ export interface CloudSessionContext {
   postMessage(msg: unknown): void
   getWorkspaceDirectory(sessionId?: string): string
   gatherEditorContext(): Promise<EditorContext>
+  trackMessageConfirmation?(messageID?: string): () => void
   waitForMessageConfirmation?(messageID?: string): Promise<boolean>
 }
 
@@ -164,6 +165,7 @@ export async function handleImportAndSend(
   })
 
   // Step 2: Send the user's message/command on the new local session
+  const release = ctx.trackMessageConfirmation?.(messageID) ?? (() => {})
   try {
     if (messageID) {
       ctx.connectionService.recordMessageSessionId(messageID, session.id)
@@ -226,5 +228,7 @@ export async function handleImportAndSend(
       messageID,
       files,
     })
+  } finally {
+    release()
   }
 }

--- a/packages/kilo-vscode/src/kilo-provider/handlers/cloud-session.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/cloud-session.ts
@@ -19,8 +19,11 @@ export interface CloudSessionContext {
   postMessage(msg: unknown): void
   getWorkspaceDirectory(sessionId?: string): string
   gatherEditorContext(): Promise<EditorContext>
-  trackMessageConfirmation?(messageID?: string): () => void
-  waitForMessageConfirmation?(messageID?: string): Promise<boolean>
+  runWithMessageConfirmation?<T>(
+    messageID: string | undefined,
+    label: string,
+    run: () => Promise<T>,
+  ): Promise<T | undefined>
 }
 
 /** Fetch cloud sessions list and send to webview. */
@@ -125,6 +128,7 @@ export async function handleImportAndSend(
     return
   }
 
+  const client = ctx.client
   const dir = ctx.getWorkspaceDirectory()
 
   // Step 1: Import the cloud session with fresh IDs
@@ -165,29 +169,32 @@ export async function handleImportAndSend(
   })
 
   // Step 2: Send the user's message/command on the new local session
-  const release = ctx.trackMessageConfirmation?.(messageID) ?? (() => {})
+  const run = ctx.runWithMessageConfirmation ?? ((_id, _label, fn) => fn())
   try {
-    if (messageID) {
-      ctx.connectionService.recordMessageSessionId(messageID, session.id)
-    }
+    await run(messageID, "Cloud import send", async () => {
+      if (messageID) {
+        ctx.connectionService.recordMessageSessionId(messageID, session.id)
+      }
 
-    if (command) {
-      const parts = files?.map((f) => ({ type: "file" as const, mime: f.mime, url: f.url }))
-      await ctx.client.session.command(
-        {
-          sessionID: session.id,
-          directory: dir,
-          command,
-          arguments: commandArgs ?? "",
-          messageID,
-          model: providerID && modelID ? `${providerID}/${modelID}` : undefined,
-          agent,
-          variant,
-          parts,
-        },
-        { throwOnError: true },
-      )
-    } else {
+      if (command) {
+        const parts = files?.map((f) => ({ type: "file" as const, mime: f.mime, url: f.url }))
+        await client.session.command(
+          {
+            sessionID: session.id,
+            directory: dir,
+            command,
+            arguments: commandArgs ?? "",
+            messageID,
+            model: providerID && modelID ? `${providerID}/${modelID}` : undefined,
+            agent,
+            variant,
+            parts,
+          },
+          { throwOnError: true },
+        )
+        return
+      }
+
       const parts: Array<TextPartInput | FilePartInput> = []
       if (files) {
         for (const f of files) {
@@ -197,7 +204,7 @@ export async function handleImportAndSend(
       parts.push({ type: "text", text })
 
       const editorContext = await ctx.gatherEditorContext()
-      await ctx.client.session.promptAsync(
+      await client.session.promptAsync(
         {
           sessionID: session.id,
           directory: dir,
@@ -210,14 +217,8 @@ export async function handleImportAndSend(
         },
         { throwOnError: true },
       )
-    }
+    })
   } catch (err) {
-    if (await ctx.waitForMessageConfirmation?.(messageID)) {
-      console.warn("[Kilo New] Cloud import send ended after server accepted it; ignoring transport error", {
-        error: getErrorMessage(err),
-      })
-      return
-    }
     console.error("[Kilo New] Failed to send message after cloud import:", err)
     ctx.postMessage({
       type: "sendMessageFailed",
@@ -228,7 +229,5 @@ export async function handleImportAndSend(
       messageID,
       files,
     })
-  } finally {
-    release()
   }
 }

--- a/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
@@ -175,7 +175,10 @@ export class SdkSSEAdapter {
 
           // The SDK yields GlobalEvent = { directory, payload: Event }.
           const globalEvent = event as GlobalEvent
-          console.log("[Kilo New] SSE: 📨 Event:", globalEvent.payload.type)
+          const type = (globalEvent.payload as { type: string }).type
+          if (type !== "server.heartbeat") {
+            console.log("[Kilo New] SSE: 📨 Event:", type)
+          }
           this.notifyEvent(globalEvent.payload)
         }
 

--- a/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
@@ -7,6 +7,7 @@ import {
   mapSSEEventToWebviewMessage,
   isEventFromForeignProject,
   mapCloudSessionMessageToWebviewMessage,
+  MessageConfirmation,
   type ProviderInfo,
 } from "../../src/kilo-provider-utils"
 import type { CloudSessionMessage } from "../../src/services/cli-backend/types"
@@ -92,6 +93,31 @@ function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): Assist
     ...overrides,
   }
 }
+
+describe("MessageConfirmation", () => {
+  it("reports already confirmed messages", async () => {
+    const state = new MessageConfirmation()
+    state.confirm("msg-1")
+
+    expect(state.has("msg-1")).toBe(true)
+    expect(await state.wait("msg-1", 1)).toBe(true)
+  })
+
+  it("resolves waiters when a message is confirmed", async () => {
+    const state = new MessageConfirmation()
+    const wait = state.wait("msg-1", 50)
+
+    state.confirm("msg-1")
+
+    expect(await wait).toBe(true)
+  })
+
+  it("returns false when confirmation does not arrive", async () => {
+    const state = new MessageConfirmation()
+
+    expect(await state.wait("msg-1", 1)).toBe(false)
+  })
+})
 
 describe("sessionToWebview", () => {
   it("converts epoch timestamps to ISO strings", () => {

--- a/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
@@ -95,8 +95,9 @@ function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): Assist
 }
 
 describe("MessageConfirmation", () => {
-  it("reports already confirmed messages", async () => {
+  it("reports tracked confirmed messages", async () => {
     const state = new MessageConfirmation()
+    state.track("msg-1")
     state.confirm("msg-1")
 
     expect(state.has("msg-1")).toBe(true)
@@ -105,6 +106,7 @@ describe("MessageConfirmation", () => {
 
   it("resolves waiters when a message is confirmed", async () => {
     const state = new MessageConfirmation()
+    state.track("msg-1")
     const wait = state.wait("msg-1", 50)
 
     state.confirm("msg-1")
@@ -114,8 +116,19 @@ describe("MessageConfirmation", () => {
 
   it("returns false when confirmation does not arrive", async () => {
     const state = new MessageConfirmation()
+    state.track("msg-1")
 
     expect(await state.wait("msg-1", 1)).toBe(false)
+  })
+
+  it("forgets confirmations after release", () => {
+    const state = new MessageConfirmation()
+    const release = state.track("msg-1")
+    state.confirm("msg-1")
+
+    release()
+
+    expect(state.has("msg-1")).toBe(false)
   })
 })
 


### PR DESCRIPTION
Treat SSE message.updated as the authoritative signal that a VS Code webview send was accepted, so late local fetch failures do not remove an already-running command or message.
This also quiets routine SSE heartbeat logs to make real extension transport errors easier to spot.

Related: #8557