### PR TITLE
ci(vscode): run lint in extension workflow

### DIFF
--- a/.github/workflows/test-vscode.yml
+++ b/.github/workflows/test-vscode.yml
@@ -9,11 +9,13 @@ on:
       - "packages/kilo-vscode/**"
       - "packages/ui/**"
       - "packages/kilo-ui/**"
+      - ".github/workflows/test-vscode.yml"
   pull_request:
     paths:
       - "packages/kilo-vscode/**"
       - "packages/ui/**"
       - "packages/kilo-ui/**"
+      - ".github/workflows/test-vscode.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-vscode.yml
+++ b/.github/workflows/test-vscode.yml
@@ -3,6 +3,7 @@ name: test-vscode
 on:
   push:
     branches:
+      - main
       - dev
     paths:
       - "packages/kilo-vscode/**"
@@ -34,6 +35,10 @@ jobs:
       - name: Run unit tests
         working-directory: packages/kilo-vscode
         run: bun run test:unit
+
+      - name: Check lint (ESLint)
+        working-directory: packages/kilo-vscode
+        run: bun run lint
 
       - name: Check formatting (prettier)
         working-directory: packages/kilo-vscode


### PR DESCRIPTION
## Summary
- Run VS Code extension ESLint in the `test-vscode` workflow so `complexity` and `max-lines` rules are evaluated in CI.
- Trigger the VS Code workflow on `main` pushes in addition to `dev` pushes for mainline coverage.
- Include the workflow file itself in path filters so this CI change is exercised by the PR.

## Verification
- `bun run lint` from `packages/kilo-vscode`
- `bun run test:unit` from `packages/kilo-vscode`