### PR TITLE
fix(vscode): improve @ file mention results with open tabs priority

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -31,6 +31,7 @@ import {
   flushPendingSessionRefresh as flushPendingSessionRefreshUtil,
   resolveContextDirectory,
   resolveWorkspaceDirectory,
+  mergeFileSearchResults,
   type SessionRefreshContext,
 } from "./kilo-provider-utils"
 import { GitOps } from "./agent-manager/GitOps"
@@ -801,17 +802,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             const dir = this.getWorkspaceDirectory(this.currentSession?.id)
             const openPaths = dir ? await this.getOpenTabPaths(dir) : new Set<string>()
             void sdkClient.find
-              .files({ query: message.query, directory: dir }, { throwOnError: true })
+              .files({ query: message.query, directory: dir, type: "file", limit: 50 }, { throwOnError: true })
               .then(({ data: paths }) => {
-                // Prioritize open files: open tabs first, then the rest
-                const open = paths.filter((p) => openPaths.has(p))
-                const rest = paths.filter((p) => !openPaths.has(p))
-                this.postMessage({
-                  type: "fileSearchResult",
-                  paths: [...open, ...rest],
-                  dir,
-                  requestId: message.requestId,
-                })
+                const uri = vscode.window.activeTextEditor?.document.uri
+                const active =
+                  uri?.scheme === "file" && dir ? path.relative(dir, uri.fsPath).replaceAll("\\", "/") : undefined
+                const result = mergeFileSearchResults({ query: message.query, backend: paths, open: openPaths, active })
+                this.postMessage({ type: "fileSearchResult", paths: result, dir, requestId: message.requestId })
               })
               .catch((error: unknown) => {
                 console.error("[Kilo New] File search failed:", error)

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -446,3 +446,26 @@ export function isEventFromForeignProject(event: Event, expectedProjectID: strin
   }
   return false
 }
+
+/**
+ * Merge open-tab paths with backend file search results for the @ mention dropdown.
+ *
+ * Ordering: active file → other open tabs → backend results (all deduplicated).
+ * When a query is present, open tabs are filtered to only include matches.
+ * The `active` path (if provided) is placed first when it exists in `open`.
+ */
+export function mergeFileSearchResults(input: {
+  query: string
+  backend: string[]
+  open: Set<string>
+  active?: string
+}): string[] {
+  const query = input.query.trim().toLowerCase()
+  const ok = (p: string) => !query || p.toLowerCase().includes(query)
+  const tabs =
+    input.active && input.open.has(input.active) && ok(input.active)
+      ? [input.active, ...[...input.open].filter((p) => p !== input.active && ok(p))]
+      : [...input.open].filter(ok)
+  const seen = new Set(tabs)
+  return [...tabs, ...input.backend.filter((p) => !seen.has(p))]
+}

--- a/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
@@ -8,6 +8,7 @@ import {
   isEventFromForeignProject,
   mapCloudSessionMessageToWebviewMessage,
   MessageConfirmation,
+  mergeFileSearchResults,
   type ProviderInfo,
 } from "../../src/kilo-provider-utils"
 import type { CloudSessionMessage } from "../../src/services/cli-backend/types"
@@ -560,5 +561,100 @@ describe("mapCloudSessionMessage", () => {
   it("maps user role correctly", () => {
     const msg = mapCloudSessionMessageToWebviewMessage(makeCloudMessage({ role: "user" }))
     expect(msg.role).toBe("user")
+  })
+})
+
+describe("mergeFileSearchResults", () => {
+  it("returns backend results when no open files", () => {
+    const result = mergeFileSearchResults({
+      query: "",
+      backend: ["src/a.ts", "src/b.ts"],
+      open: new Set(),
+    })
+    expect(result).toEqual(["src/a.ts", "src/b.ts"])
+  })
+
+  it("places open files before backend results", () => {
+    const result = mergeFileSearchResults({
+      query: "",
+      backend: ["src/a.ts", "src/b.ts", "src/c.ts"],
+      open: new Set(["src/c.ts", "src/d.ts"]),
+    })
+    expect(result).toEqual(["src/c.ts", "src/d.ts", "src/a.ts", "src/b.ts"])
+  })
+
+  it("places active file first among open files", () => {
+    const result = mergeFileSearchResults({
+      query: "",
+      backend: ["src/a.ts"],
+      open: new Set(["src/b.ts", "src/c.ts"]),
+      active: "src/c.ts",
+    })
+    expect(result).toEqual(["src/c.ts", "src/b.ts", "src/a.ts"])
+  })
+
+  it("ignores active file when it is not in open set", () => {
+    const result = mergeFileSearchResults({
+      query: "",
+      backend: ["src/a.ts"],
+      open: new Set(["src/b.ts"]),
+      active: "src/x.ts",
+    })
+    expect(result).toEqual(["src/b.ts", "src/a.ts"])
+  })
+
+  it("deduplicates open files from backend results", () => {
+    const result = mergeFileSearchResults({
+      query: "",
+      backend: ["src/a.ts", "src/b.ts"],
+      open: new Set(["src/a.ts"]),
+    })
+    expect(result).toEqual(["src/a.ts", "src/b.ts"])
+  })
+
+  it("filters open files by query", () => {
+    const result = mergeFileSearchResults({
+      query: "config",
+      backend: ["src/config.ts", "src/util.ts"],
+      open: new Set(["src/index.ts", "src/config.ts", "README.md"]),
+    })
+    expect(result).toEqual(["src/config.ts", "src/util.ts"])
+  })
+
+  it("query filtering is case-insensitive", () => {
+    const result = mergeFileSearchResults({
+      query: "READ",
+      backend: [],
+      open: new Set(["README.md", "src/index.ts"]),
+    })
+    expect(result).toEqual(["README.md"])
+  })
+
+  it("shows all open files on empty query", () => {
+    const result = mergeFileSearchResults({
+      query: "",
+      backend: [],
+      open: new Set(["src/a.ts", "src/b.ts"]),
+    })
+    expect(result).toEqual(["src/a.ts", "src/b.ts"])
+  })
+
+  it("shows all open files on whitespace-only query", () => {
+    const result = mergeFileSearchResults({
+      query: "  ",
+      backend: ["src/x.ts"],
+      open: new Set(["src/a.ts"]),
+    })
+    expect(result).toEqual(["src/a.ts", "src/x.ts"])
+  })
+
+  it("handles forward-slash paths (Windows-normalized)", () => {
+    const result = mergeFileSearchResults({
+      query: "",
+      backend: ["src/utils/path.ts"],
+      open: new Set(["src/utils/path.ts", "src/index.ts"]),
+      active: "src/utils/path.ts",
+    })
+    expect(result).toEqual(["src/utils/path.ts", "src/index.ts"])
   })
 })


### PR DESCRIPTION
## Summary

Fixes the `@` file mention dropdown to show relevant files instead of arbitrary directory names. Closes #8709

- Request `type: "file"` with `limit: 50` from the backend (was: no type filter, limit 10 — which returned sorted directory names on empty query)
- Inject all open editor tabs at the top of results (active file first), not just reorder the backend's small result set
- Filter injected open tabs by query when the user is typing (e.g. `@config` won't show unrelated open files)
- Extract merge logic into `mergeFileSearchResults` in `kilo-provider-utils.ts` with 10 unit tests