### PR TITLE
fix(cli): default image input to true for OpenAI-compatible providers

### DIFF
--- a/packages/opencode/src/provider/model-cache.ts
+++ b/packages/opencode/src/provider/model-cache.ts
@@ -209,7 +209,7 @@ export namespace ModelCache {
         name: model.id,
         family: model.owned_by ?? "",
         release_date: "",
-        attachment: false,
+        attachment: true,
         reasoning: false,
         temperature: true,
         tool_call: true,
@@ -217,7 +217,7 @@ export namespace ModelCache {
         limit: { context: 128000, output: 4096 },
         options: {},
         modalities: {
-          input: ["text"],
+          input: ["text", "image"],
           output: ["text"],
         },
       }


### PR DESCRIPTION
## Summary

Default `input.image` and `attachment` capabilities to `true` for models auto-discovered via the OpenAI-compatible `/v1/models` endpoint (Apertis provider path in `model-cache.ts`).

Fixes #8715

## Problem

Vision-capable models on OpenAI-compatible providers (e.g. Qwen3.5-27B, GPT5.4-mini) were incorrectly reported as not supporting image input. The root cause is a cascading default-to-false chain:

1. The OpenAI-compatible `/v1/models` endpoint only returns `{ id, owned_by }` — no modality or capability metadata
2. `model-cache.ts` hardcoded `input: ["text"]` and `attachment: false` for these models
3. `transform.ts:unsupportedParts()` checks `model.capabilities.input.image` — when `false`, it silently replaces image content with `"ERROR: Cannot read image (this model does not support image input)"`
4. The model then parrots back that error text as if it genuinely can't process images

## Legacy behavior

The legacy extension (`kilocode-legacy`) handled this correctly via `openAiModelInfoSaneDefaults`:

```ts
export const openAiModelInfoSaneDefaults: ModelInfo = {
    supportsImages: true,  // default for all OpenAI-compatible providers
    // ...
}
```

Users could override per-model via `openAiCustomModelInfo` in their provider settings to set `supportsImages: false`.

## What this PR changes

Only `model-cache.ts` — the function that builds model objects from OpenAI-compatible `/v1/models` responses:
- `attachment: false` → `attachment: true`
- `input: ["text"]` → `input: ["text", "image"]`

## Scope

**Affected:** Models auto-discovered from OpenAI-compatible endpoints (Apertis provider fetch path)

**Not affected:**
- Models from models.dev (all major providers have explicit modality data)
- Models from Kilo Gateway / OpenRouter (separate fetch paths with their own modality handling)
- User-configured models in config (`provider.ts` fallback defaults are unchanged)
- Known first-party providers (Anthropic, OpenAI native, Google, etc.)

## Tradeoffs

**Default `true` (this PR):** Vision-capable models work correctly out of the box. Non-vision models receive a real API error from the provider (e.g. HTTP 400 "this model does not support image inputs") — clear and actionable.

**Default `false` (before):** Vision-capable models are silently broken. Non-vision models get a slightly friendlier pre-flight message, but it looks identical to the broken case so users can't distinguish between "model genuinely can't do images" and "Kilo is blocking images from a capable model."

The API error path is strictly better — it's honest, and most modern models served via OpenAI-compatible endpoints support images.

## What this doesn't fix

Users who manually configure models in their config file (not auto-discovered) still default to `input.image: false` via the `provider.ts` fallback chain. We intentionally left that unchanged to avoid affecting all config-defined models globally. Those users can opt in with:

```json
{
  "provider": {
    "my-provider": {
      "models": {
        "my-model": {
          "modalities": { "input": ["text", "image"] }
        }
      }
    }
  }
}
```