### PR TITLE
feat(cli): allow specifying base branch for /local-review command

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -34,15 +34,13 @@ export namespace Command {
       template: z.promise(z.string()).or(z.string()),
       subtask: z.boolean().optional(),
       hints: z.array(z.string()),
-      // kilocode_change - optional builder that receives raw arguments for commands needing args at template-generation time
-      build: z.function().optional(),
     })
     .meta({
       ref: "Command",
     })
 
   // for some reason zod is inferring `string` for z.promise(z.string()).or(z.string()) so we have to manually override it
-  export type Info = Omit<z.infer<typeof Info>, "template" | "build"> & {
+  export type Info = Omit<z.infer<typeof Info>, "template"> & {
     template: Promise<string> | string
     // kilocode_change - optional builder that receives raw arguments for commands needing args at template-generation time
     build?: (args: string) => Promise<string>

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -34,13 +34,19 @@ export namespace Command {
       template: z.promise(z.string()).or(z.string()),
       subtask: z.boolean().optional(),
       hints: z.array(z.string()),
+      // kilocode_change - optional builder that receives raw arguments for commands needing args at template-generation time
+      build: z.function().optional(),
     })
     .meta({
       ref: "Command",
     })
 
   // for some reason zod is inferring `string` for z.promise(z.string()).or(z.string()) so we have to manually override it
-  export type Info = Omit<z.infer<typeof Info>, "template"> & { template: Promise<string> | string }
+  export type Info = Omit<z.infer<typeof Info>, "template" | "build"> & {
+    template: Promise<string> | string
+    // kilocode_change - optional builder that receives raw arguments for commands needing args at template-generation time
+    build?: (args: string) => Promise<string>
+  }
 
   export function hints(template: string): string[] {
     const result: string[] = []

--- a/packages/opencode/src/kilocode/review/command.ts
+++ b/packages/opencode/src/kilocode/review/command.ts
@@ -17,14 +17,19 @@ export function localReviewUncommittedCommand(): Command.Info {
 
 /**
  * /local-review - local review (current branch vs base)
+ * Accepts an optional base branch argument: /local-review origin/develop
  */
 export function localReviewCommand(): Command.Info {
   return {
     name: "local-review",
-    description: "local review (current branch)",
+    description: "local review (current branch) [base-branch]",
     get template() {
       return Review.buildReviewPromptBranch()
     },
-    hints: [],
+    build(args: string) {
+      const branch = args.trim() || undefined
+      return Review.buildReviewPromptBranch(branch)
+    },
+    hints: ["$ARGUMENTS"],
   }
 }

--- a/packages/opencode/src/kilocode/review/review.ts
+++ b/packages/opencode/src/kilocode/review/review.ts
@@ -278,10 +278,11 @@ export namespace Review {
   /**
    * Build review prompt for branch diff vs base branch
    *
+   * @param baseBranch - Optional base branch to diff against. If not provided, auto-detects.
    * @returns Complete prompt string ready for LLM
    */
-  export async function buildReviewPromptBranch(): Promise<string> {
-    const base = await getBaseBranch()
+  export async function buildReviewPromptBranch(baseBranch?: string): Promise<string> {
+    const base = baseBranch || (await getBaseBranch())
     const currentBranch = await getCurrentBranch()
     const diff = await getBranchChanges(base)
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1863,7 +1863,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const raw = input.arguments.match(argsRegex) ?? []
     const args = raw.map((arg) => arg.replace(quoteTrimRegex, ""))
 
-    const templateCommand = await command.template
+    // kilocode_change - use build(args) when the command needs arguments at template-generation time
+    const templateCommand = command.build ? await command.build(input.arguments) : await command.template
 
     const placeholders = templateCommand.match(placeholderRegex) ?? []
     let last = 0


### PR DESCRIPTION
## Summary

- Adds optional base branch argument to `/local-review` so users can run `/local-review origin/develop` instead of relying on auto-detection (main > master > dev > develop)
- Introduces a `build` function on `Command.Info` that receives raw arguments at template-generation time, enabling commands whose templates depend on user input
- Works in both CLI and VS Code extension since slash commands flow through the same server-side prompt processing

Closes #8724