### PR TITLE
fix(cli): broaden upstream merge detection in annotation check

### DIFF
--- a/.github/workflows/check-opencode-annotations.yml
+++ b/.github/workflows/check-opencode-annotations.yml
@@ -24,8 +24,11 @@ jobs:
       - name: Check kilocode_change annotations in shared opencode files
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SKIP_ANNOTATIONS: ${{ contains(github.event.pull_request.labels.*.name, 'upstream-merge') }}
         run: |
-          if [ -n "$BASE_SHA" ]; then
+          if [ "$SKIP_ANNOTATIONS" = "true" ]; then
+            echo "Skipping — PR has 'upstream-merge' label."
+          elif [ -n "$BASE_SHA" ]; then
             bun run script/check-opencode-annotations.ts --base "$BASE_SHA"
           else
             echo "No PR base SHA available (workflow_dispatch without PR context) — skipping."

--- a/script/check-opencode-annotations.ts
+++ b/script/check-opencode-annotations.ts
@@ -55,9 +55,15 @@ function isUpstreamMerge() {
   const out = run("git", ["log", "--format=%P%x09%s", `${base}..HEAD`])
   return out.split("\n").some((line) => {
     const [parents = "", subject = ""] = line.split("\t")
-    if (!parents.includes(" ")) return false
     const s = subject.toLowerCase()
-    return s.startsWith("merge: upstream ") || s.startsWith("resolve merge conflict")
+    // Automated upstream merge script commits (script/upstream/merge.ts)
+    if (parents.includes(" ")) {
+      if (s.startsWith("merge: upstream ")) return true
+      if (s.includes("resolve merge conflict")) return true
+    }
+    // Manual upstream merge PRs typically include an upstream release commit
+    if (/^release:\s*v\d+/.test(s)) return true
+    return false
   })
 }
 

--- a/script/check-opencode-annotations.ts
+++ b/script/check-opencode-annotations.ts
@@ -55,15 +55,11 @@ function isUpstreamMerge() {
   const out = run("git", ["log", "--format=%P%x09%s", `${base}..HEAD`])
   return out.split("\n").some((line) => {
     const [parents = "", subject = ""] = line.split("\t")
+    if (!parents.includes(" ")) return false
     const s = subject.toLowerCase()
     // Automated upstream merge script commits (script/upstream/merge.ts)
-    if (parents.includes(" ")) {
-      if (s.startsWith("merge: upstream ")) return true
-      if (s.includes("resolve merge conflict")) return true
-    }
-    // Manual upstream merge PRs typically include an upstream release commit
-    if (/^release:\s*v\d+/.test(s)) return true
-    return false
+    // For manual upstream merges, add the 'upstream-merge' label to the PR instead.
+    return s.startsWith("merge: upstream ") || s.includes("resolve merge conflict")
   })
 }
 


### PR DESCRIPTION
## Summary

- Relaxes \`isUpstreamMerge()\` to catch conflict resolution commits with any prefix (e.g. \`chore: Resolve merge conflicts\`).
- Adds an \`upstream-merge\` label escape hatch in CI for manual upstream merge PRs where the heuristic doesn't apply.
- Fixes the annotation check falsely failing on upstream merge PRs like #8028.

## Problem

PR #8683 added skip logic to \`check-opencode-annotations\` for upstream merges, but only recognized commits produced by the automated \`script/upstream/merge.ts\` script — merge commits with subjects starting with \`merge: upstream \`. PR #8028 (OpenCode v1.2.25) was done manually and has none of those patterns:

| Commit subject on #8028 | Why it didn't match |
|---|---|
| \`Merge branch 'main' into ...\` | Standard git message, not \`merge: upstream\` |
| \`chore: Resolve merge conflicts\` | \`startsWith("resolve merge conflict")\` missed the \`chore:\` prefix |

## Changes

**\`script/check-opencode-annotations.ts\`** — \`isUpstreamMerge()\` now matches conflict resolution commits with any prefix (\`includes\` instead of \`startsWith\`) while keeping the merge-commit requirement.

**\`.github/workflows/check-opencode-annotations.yml\`** — PRs with the \`upstream-merge\` label skip the check entirely, as a reliable escape hatch for manual upstream merge PRs where the commit-subject heuristic doesn't apply.

Follows up on #8683. Unblocks #8028.