### PR TITLE
fix(vscode): handle network offline events to prevent session hangs

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -47,6 +47,7 @@ import { handleContinueInWorktree } from "./kilo-provider/continue-worktree"
 import { parseMessageFiles } from "./kilo-provider/message-files"
 import { matchFollowup, recordFollowup, type Followup } from "./kilo-provider/followup-session"
 import { childID } from "./kilo-provider/task-session"
+import { handleNetworkEvent, clearNetworkWaits } from "./kilo-provider/network"
 import { retryable, backoff, MAX_RETRIES } from "./util/retry"
 // legacy-migration start
 import {
@@ -2942,6 +2943,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       }
     }
 
+    handleNetworkEvent(event.type as string, event.properties as any, this.client, (s) => this.getWorkspaceDirectory(s))
+
     const msg = mapSSEEventToWebviewMessage(event, sessionID)
     if (msg) {
       if (msg.type === "partUpdated") {
@@ -3289,6 +3292,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.syncedChildSessions.clear()
     this.sessionDirectories.clear()
     this.sessionStatusMap.clear()
+    clearNetworkWaits()
     this.ignoreController?.dispose()
     this.chatAutocomplete?.dispose()
     this.marketplace?.dispose()

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -3288,11 +3288,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.webviewMessageDisposable?.dispose()
     this.isWebviewReady = false
     this.promptRecoveryQueued = false
+    clearNetworkWaits(this.trackedSessionIds)
     this.trackedSessionIds.clear()
     this.syncedChildSessions.clear()
     this.sessionDirectories.clear()
     this.sessionStatusMap.clear()
-    clearNetworkWaits()
     this.ignoreController?.dispose()
     this.chatAutocomplete?.dispose()
     this.marketplace?.dispose()

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -349,11 +349,24 @@ export function mapSSEEventToWebviewMessage(event: Event, sessionID: string | un
     }
     case "session.status": {
       const info = event.properties.status
+      // "offline" is not yet in the SDK SessionStatus type (pending SDK regeneration),
+      // so we use string comparison to forward the message field for offline status.
+      const status = info.type as string
+      const extra =
+        status === "retry"
+          ? {
+              attempt: (info as any).attempt as number,
+              message: (info as any).message as string,
+              next: (info as any).next as number,
+            }
+          : status === "offline"
+            ? { message: (info as any).message as string }
+            : {}
       return {
-        type: "sessionStatus",
+        type: "sessionStatus" as const,
         sessionID: event.properties.sessionID,
-        status: info.type,
-        ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
+        status,
+        ...extra,
       }
     }
     case "permission.asked":

--- a/packages/kilo-vscode/src/kilo-provider/network.ts
+++ b/packages/kilo-vscode/src/kilo-provider/network.ts
@@ -11,8 +11,8 @@
 
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 
-/** Pending network-offline requests: requestID -> sessionID. */
-const waits = new Map<string, string>()
+/** Pending network-offline requests: requestID -> { sessionID, refcount }. */
+const waits = new Map<string, { sid: string; refs: number }>()
 
 type Props = { id?: string; sessionID?: string; requestID?: string }
 type GetDir = (sessionID: string) => string
@@ -24,14 +24,16 @@ type GetDir = (sessionID: string) => string
  */
 export function handleNetworkEvent(type: string, props: Props, client: KiloClient | null, dir: GetDir) {
   if (type === "session.network.asked" && props.id && props.sessionID) {
-    waits.set(props.id, props.sessionID)
+    const existing = waits.get(props.id)
+    if (existing) existing.refs++
+    else waits.set(props.id, { sid: props.sessionID, refs: 1 })
     return
   }
   if (type === "session.network.restored" && props.requestID) {
-    const sid = waits.get(props.requestID)
-    if (!sid) return
+    const entry = waits.get(props.requestID)
+    if (!entry) return
     console.log("[Kilo New] network: auto-replying to restore", props.requestID)
-    void (client as any)?.network?.reply({ requestID: props.requestID, directory: dir(sid) })
+    void (client as any)?.network?.reply({ requestID: props.requestID, directory: dir(entry.sid) })
     waits.delete(props.requestID)
     return
   }
@@ -40,9 +42,14 @@ export function handleNetworkEvent(type: string, props: Props, client: KiloClien
   }
 }
 
-/** Clear tracked network waits for the given sessions (call on dispose). */
+/**
+ * Release network waits owned by a disposing provider. Each provider that
+ * received the `session.network.asked` event incremented the refcount, so
+ * the wait is only removed when the last provider referencing it disposes.
+ */
 export function clearNetworkWaits(sessions: Set<string>) {
-  for (const [rid, sid] of waits) {
-    if (sessions.has(sid)) waits.delete(rid)
+  for (const [rid, entry] of waits) {
+    if (!sessions.has(entry.sid)) continue
+    if (--entry.refs <= 0) waits.delete(rid)
   }
 }

--- a/packages/kilo-vscode/src/kilo-provider/network.ts
+++ b/packages/kilo-vscode/src/kilo-provider/network.ts
@@ -1,0 +1,46 @@
+/**
+ * Handles session.network.* SSE events for the VS Code extension.
+ *
+ * When the CLI backend detects a network failure (timeout, DNS, connection refused, etc.)
+ * it pauses the session and emits session.network.asked. A background DNS probe polls for
+ * recovery and emits session.network.restored when connectivity returns. The TUI asks the
+ * user to press Enter; `kilo run` auto-retries with backoff. This module implements auto-reply
+ * for the VS Code extension: once restored, it immediately calls network.reply() so the
+ * session resumes without user intervention.
+ */
+
+import type { KiloClient } from "@kilocode/sdk/v2/client"
+
+/** Pending network-offline requests: requestID -> sessionID. */
+const waits = new Map<string, string>()
+
+type Props = { id?: string; sessionID?: string; requestID?: string }
+type GetDir = (sessionID: string) => string
+
+/**
+ * Process a session.network.* event. Call from handleEvent() with the event
+ * type cast to `string` and properties cast to `Props` (these event types
+ * are not yet in the SDK Event union, pending SDK regeneration).
+ */
+export function handleNetworkEvent(type: string, props: Props, client: KiloClient | null, dir: GetDir) {
+  if (type === "session.network.asked" && props.id && props.sessionID) {
+    waits.set(props.id, props.sessionID)
+    return
+  }
+  if (type === "session.network.restored" && props.requestID) {
+    const sid = waits.get(props.requestID)
+    if (!sid) return
+    console.log("[Kilo New] network: auto-replying to restore", props.requestID)
+    void (client as any)?.network?.reply({ requestID: props.requestID, directory: dir(sid) })
+    waits.delete(props.requestID)
+    return
+  }
+  if ((type === "session.network.replied" || type === "session.network.rejected") && props.requestID) {
+    waits.delete(props.requestID)
+  }
+}
+
+/** Clear all tracked network waits (call on dispose). */
+export function clearNetworkWaits() {
+  waits.clear()
+}

--- a/packages/kilo-vscode/src/kilo-provider/network.ts
+++ b/packages/kilo-vscode/src/kilo-provider/network.ts
@@ -40,7 +40,9 @@ export function handleNetworkEvent(type: string, props: Props, client: KiloClien
   }
 }
 
-/** Clear all tracked network waits (call on dispose). */
-export function clearNetworkWaits() {
-  waits.clear()
+/** Clear tracked network waits for the given sessions (call on dispose). */
+export function clearNetworkWaits(sessions: Set<string>) {
+  for (const [rid, sid] of waits) {
+    if (sessions.has(sid)) waits.delete(rid)
+  }
 }

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -22,6 +22,28 @@ type DirectoryProvider = () => string[]
 const HEALTH_POLL_INTERVAL_MS = 10_000
 
 /**
+ * Reject all pending network-offline waits for a given directory.
+ * The network namespace is not yet in the SDK KiloClient type (pending SDK regeneration),
+ * so we access it via a type assertion.
+ */
+async function drainNetworkWaits(client: KiloClient, dir: string) {
+  const net = (client as any).network as
+    | {
+        list: (p: { directory: string }) => Promise<{ data?: { id: string }[]; error?: unknown }>
+        reject: (p: { requestID: string; directory: string }) => Promise<{ error?: unknown }>
+      }
+    | undefined
+  if (!net) return
+  const { data: waits, error: err } = await net.list({ directory: dir })
+  if (err) throw new Error(`Failed to list network waits for ${dir}: ${String(err)}`)
+  if (!waits) return
+  for (const w of waits) {
+    const { error } = await net.reject({ requestID: w.id, directory: dir })
+    if (error) throw new Error(`Failed to reject network wait ${w.id}: ${String(error)}`)
+  }
+}
+
+/**
  * Shared connection service that owns the single ServerManager, KiloClient (SDK), and SdkSSEAdapter.
  * Multiple KiloProvider instances subscribe to it for SSE events and state changes.
  */
@@ -358,6 +380,7 @@ export class KiloConnectionService {
           if (error) throw new Error(`Failed to reject question ${q.id}: ${String(error)}`)
         }
       }
+      await drainNetworkWaits(this.client, dir)
     }
     for (const listener of this.clearPendingPromptsListeners) {
       listener()

--- a/packages/kilo-vscode/src/services/cli-backend/connection-utils.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-utils.ts
@@ -42,6 +42,11 @@ export function resolveEventSessionId(
     case "question.rejected":
       return event.properties.sessionID
     default:
+      // session.network.* events are not yet in the SDK Event type union
+      // (pending SDK regeneration). Handle them via string comparison.
+      if ((event.type as string).startsWith("session.network.")) {
+        return (event.properties as { sessionID: string }).sessionID
+      }
       return undefined
   }
 }

--- a/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
@@ -63,6 +63,9 @@ export const WorkingIndicator: Component = () => {
       const retryMsg = info.message || language.t("session.status.retry")
       return countdown > 0 ? `${retryMsg} (${countdown}s)` : retryMsg
     }
+    if (info.type === "offline") {
+      return info.message || language.t("session.status.offline")
+    }
     return session.statusText() ?? language.t("ui.sessionTurn.status.thinking")
   }
 

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -927,7 +927,9 @@ export const SessionProvider: ParentComponent = (props) => {
     const info: SessionStatusInfo =
       newStatus === "retry"
         ? { type: "retry", attempt: attempt ?? 0, message: message ?? "", next: next ?? 0 }
-        : { type: newStatus }
+        : newStatus === "offline"
+          ? { type: "offline", message: message ?? "" }
+          : { type: newStatus }
     setStatusMap(sessionID, info)
     // Track busy start time
     if (prev.type === "idle" && newStatus !== "idle") {

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -934,6 +934,7 @@ export const dict = {
   "session.status.retry": "جارٍ إعادة المحاولة…",
   "session.status.retrying": "...إعادة المحاولة (المحاولة {{ attempt }})… {{ message }}",
   "session.status.working": "...جارٍ العمل",
+  "session.status.offline": "انقطع الاتصال بالشبكة — جارٍ إعادة الاتصال...",
 
   "ui.sessionTurn.cancel": "إلغاء",
   "ui.sessionTurn.status.thinking": "...جارٍ التفكير",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -942,6 +942,7 @@ export const dict = {
   "session.status.retry": "Tentando novamente…",
   "session.status.retrying": "Tentando novamente (tentativa {{ attempt }})… {{ message }}",
   "session.status.working": "Trabalhando…",
+  "session.status.offline": "Rede desconectada — reconectando...",
 
   "ui.sessionTurn.cancel": "Cancelar",
   "ui.sessionTurn.status.thinking": "Pensando...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -947,6 +947,7 @@ export const dict = {
   "session.status.retry": "Ponovni pokušaj…",
   "session.status.retrying": "Ponovni pokušaj (pokušaj {{ attempt }})… {{ message }}",
   "session.status.working": "Radim…",
+  "session.status.offline": "Mreža prekinuta — ponovno povezivanje...",
 
   "ui.sessionTurn.cancel": "Otkaži",
   "ui.sessionTurn.status.thinking": "Razmišljam...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -940,6 +940,7 @@ export const dict = {
   "session.status.retry": "Prøver igen…",
   "session.status.retrying": "Prøver igen (forsøg {{ attempt }})… {{ message }}",
   "session.status.working": "Arbejder…",
+  "session.status.offline": "Netværk afbrudt — genopretter forbindelse...",
 
   "ui.sessionTurn.cancel": "Annuller",
   "ui.sessionTurn.status.thinking": "Tænker...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -952,6 +952,7 @@ export const dict = {
   "session.status.retry": "Erneuter Versuch…",
   "session.status.retrying": "Erneuter Versuch ({{ attempt }})… {{ message }}",
   "session.status.working": "Wird bearbeitet…",
+  "session.status.offline": "Netzwerk getrennt — Verbindung wird wiederhergestellt...",
 
   "ui.sessionTurn.cancel": "Abbrechen",
   "ui.sessionTurn.status.thinking": "Denke nach...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -940,6 +940,7 @@ export const dict = {
   "session.status.retry": "Retrying…",
   "session.status.retrying": "Retrying (attempt {{ attempt }})… {{ message }}",
   "session.status.working": "Working...",
+  "session.status.offline": "Network disconnected — reconnecting...",
 
   "ui.sessionTurn.cancel": "Cancel",
   "ui.sessionTurn.status.thinking": "Thinking...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -948,6 +948,7 @@ export const dict = {
   "session.status.retry": "Reintentando…",
   "session.status.retrying": "Reintentando (intento {{ attempt }})… {{ message }}",
   "session.status.working": "Trabajando…",
+  "session.status.offline": "Red desconectada — reconectando...",
 
   "ui.sessionTurn.cancel": "Cancelar",
   "ui.sessionTurn.status.thinking": "Pensando...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -954,6 +954,7 @@ export const dict = {
   "session.status.retry": "Nouvelle tentative…",
   "session.status.retrying": "Nouvelle tentative (essai {{ attempt }})… {{ message }}",
   "session.status.working": "En cours…",
+  "session.status.offline": "Réseau déconnecté — reconnexion en cours...",
 
   "ui.sessionTurn.cancel": "Annuler",
   "ui.sessionTurn.status.thinking": "Réflexion...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -939,6 +939,7 @@ export const dict = {
   "session.status.retry": "再試行中…",
   "session.status.retrying": "再試行中（{{ attempt }}回目）… {{ message }}",
   "session.status.working": "作業中…",
+  "session.status.offline": "ネットワークが切断されました — 再接続中…",
 
   "ui.sessionTurn.cancel": "キャンセル",
   "ui.sessionTurn.status.thinking": "考え中...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -939,6 +939,7 @@ export const dict = {
   "session.status.retry": "재시도 중…",
   "session.status.retrying": "재시도 중 ({{ attempt }}번째 시도)… {{ message }}",
   "session.status.working": "작업 중...",
+  "session.status.offline": "네트워크 연결 끊김 — 다시 연결 중...",
 
   "ui.sessionTurn.cancel": "취소",
   "ui.sessionTurn.status.thinking": "생각 중...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -941,6 +941,7 @@ export const dict = {
   "session.status.retry": "Opnieuw proberen...",
   "session.status.retrying": "Opnieuw proberen (poging {{ attempt }})... {{ message }}",
   "session.status.working": "Bezig...",
+  "session.status.offline": "Netwerkverbinding verbroken — opnieuw verbinden...",
 
   "ui.sessionTurn.cancel": "Annuleren",
   "ui.sessionTurn.status.thinking": "Denken...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -944,6 +944,7 @@ export const dict = {
   "session.status.retry": "Prøver på nytt…",
   "session.status.retrying": "Prøver på nytt (forsøk {{ attempt }})… {{ message }}",
   "session.status.working": "Arbeider…",
+  "session.status.offline": "Nettverk frakoblet — kobler til på nytt...",
 
   "ui.sessionTurn.cancel": "Avbryt",
   "ui.sessionTurn.status.thinking": "Tenker...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -944,6 +944,7 @@ export const dict = {
   "session.status.retry": "Ponawianie…",
   "session.status.retrying": "Ponawiam próbę ({{ attempt }})… {{ message }}",
   "session.status.working": "Pracuję…",
+  "session.status.offline": "Odłączono od sieci — ponowne łączenie...",
 
   "ui.sessionTurn.cancel": "Anuluj",
   "ui.sessionTurn.status.thinking": "Myślę...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -947,6 +947,7 @@ export const dict = {
   "session.status.retry": "Повторная попытка…",
   "session.status.retrying": "Повторная попытка ({{ attempt }})… {{ message }}",
   "session.status.working": "Работаю…",
+  "session.status.offline": "Сеть отключена — переподключение...",
 
   "ui.sessionTurn.cancel": "Отмена",
   "ui.sessionTurn.status.thinking": "Думаю...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -935,6 +935,7 @@ export const dict = {
   "session.status.retry": "กำลังลองใหม่…",
   "session.status.retrying": "กำลังลองใหม่ (ครั้งที่ {{ attempt }})… {{ message }}",
   "session.status.working": "กำลังทำงาน...",
+  "session.status.offline": "เครือข่ายถูกตัดการเชื่อมต่อ — กำลังเชื่อมต่อใหม่...",
 
   "ui.sessionTurn.cancel": "ยกเลิก",
   "ui.sessionTurn.status.thinking": "กำลังคิด...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -943,6 +943,7 @@ export const dict = {
   "session.status.retry": "Yeniden deneniyor…",
   "session.status.retrying": "Yeniden deneniyor (deneme {{ attempt }})… {{ message }}",
   "session.status.working": "Çalışıyor...",
+  "session.status.offline": "Ağ bağlantısı kesildi — yeniden bağlanılıyor...",
 
   "ui.sessionTurn.cancel": "İptal",
   "ui.sessionTurn.status.thinking": "Düşünüyor...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -944,6 +944,7 @@ export const dict = {
   "session.status.retry": "Повторна спроба…",
   "session.status.retrying": "Повторна спроба (спроба {{ attempt }})… {{ message }}",
   "session.status.working": "Працює...",
+  "session.status.offline": "Мережу відключено — перепідключення...",
 
   "ui.sessionTurn.cancel": "Скасувати",
   "ui.sessionTurn.status.thinking": "Думаю...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -927,6 +927,7 @@ export const dict = {
   "session.status.retry": "正在重试…",
   "session.status.retrying": "正在重试（第 {{ attempt }} 次）… {{ message }}",
   "session.status.working": "处理中…",
+  "session.status.offline": "网络已断开 — 正在重连...",
 
   "ui.sessionTurn.cancel": "取消",
   "ui.sessionTurn.status.thinking": "思考中...",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -929,6 +929,7 @@ export const dict = {
   "session.status.retry": "正在重試…",
   "session.status.retrying": "正在重試（第 {{ attempt }} 次）… {{ message }}",
   "session.status.working": "處理中…",
+  "session.status.offline": "網路已斷線 — 正在重新連線...",
 
   "ui.sessionTurn.cancel": "取消",
   "ui.sessionTurn.status.thinking": "思考中...",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -8,13 +8,14 @@ import type { ProviderAuthAuthorization, ProviderAuthMethod } from "@kilocode/sd
 export type ConnectionState = "connecting" | "connected" | "disconnected" | "error"
 
 // Session status (simplified from backend)
-export type SessionStatus = "idle" | "busy" | "retry"
+export type SessionStatus = "idle" | "busy" | "retry" | "offline"
 
 // Rich status info for retry countdown and future extensions
 export type SessionStatusInfo =
   | { type: "idle" }
   | { type: "busy" }
   | { type: "retry"; attempt: number; message: string; next: number }
+  | { type: "offline"; message: string }
 
 // Tool state for tool parts
 export type ToolState =


### PR DESCRIPTION
## Summary

Closes #8689

When the CLI backend detects a network failure (timeout, DNS, connection refused), it pauses the session and emits `session.network.asked`, waiting for a `network.reply()` call to resume. The TUI handles this with a prompt; `kilo run` auto-retries with backoff. The VS Code extension had **zero handling** for these events — `session.network.*` events were silently dropped at `mapSSEEventToWebviewMessage`'s `default` branch, causing sessions to hang indefinitely.

## Approach

All changes are confined to `packages/kilo-vscode/` — zero modifications to `packages/opencode/`. This avoids merge conflicts with upstream OpenCode while fully resolving the user-visible hang.

The extension now **auto-replies on network restore**, matching `kilo run`'s behavior but smarter: instead of blind retries with backoff, it waits for the backend's DNS probe to confirm connectivity (`session.network.restored`) before calling `network.reply()`. This avoids unnecessary retries against a still-down network.

## Before / After

| Scenario | Before | After |
|---|---|---|
| Network drops during AI response | Session shows "Considering next steps..." forever — no recovery possible | Session shows "Network disconnected — reconnecting..." then auto-resumes when connectivity returns |
| Network drops + comes back | Session stays hung even after network recovers — user must cancel and retry | Extension auto-replies to `session.network.restored`, session resumes transparently |
| SSE reconnect with pending network waits | Pending network waits leaked — session hung permanently | `drainPendingPrompts()` now rejects pending network waits alongside permissions and questions |
| Status during offline window | Generic "Considering next steps..." (no indication of network issue) | Localized "Network disconnected — reconnecting..." in all 19 languages |