### PR TITLE
fix(cli): always use github releases for version lookup when GH_REPO is set

### DIFF
--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -66,7 +66,7 @@ async function fetchLatest() {
 }
 
 async function fetchHighest() {
-  if (!env.KILO_RELEASE || !process.env.GH_REPO) return fetchLatest()
+  if (!process.env.GH_REPO) return fetchLatest()
   const data: { tagName: string }[] = await $`gh release list --json tagName --limit 100 --repo ${process.env.GH_REPO}`
     .json()
     .catch(() => [])


### PR DESCRIPTION
`fetchHighest()` was gated on `KILO_RELEASE` being set, causing it to fall back to npm for version lookups when that var was absent. Since GitHub releases are always more up-to-date, use them whenever `GH_REPO` is provided regardless of `KILO_RELEASE`.