### PR TITLE
fix(cli): reset provider icons before upstream merge checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ logs/
 # Telemetry ID
 telemetry-id
 tsconfig.tsbuildinfo
+
+# Kilo
+.kilo/plans/*

--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -269,6 +269,10 @@ async function main() {
 
   const author = options.author || (await getAuthor())
   const kiloVersion = await version.getCurrentKiloVersion()
+  const dirs = ["packages/ui/src/assets/icons/provider"]
+
+  logger.info("Cleaning untracked provider icons before checkout...")
+  await git.cleanDirectories(dirs)
 
   // Create backup branch
   await git.checkout(config.baseBranch)

--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -271,7 +271,8 @@ async function main() {
   const kiloVersion = await version.getCurrentKiloVersion()
   const dirs = ["packages/ui/src/assets/icons/provider"]
 
-  logger.info("Cleaning untracked provider icons before checkout...")
+  logger.info("Resetting generated provider icons before checkout...")
+  await git.restoreDirectories(dirs)
   await git.cleanDirectories(dirs)
 
   // Create backup branch

--- a/script/upstream/utils/git.ts
+++ b/script/upstream/utils/git.ts
@@ -146,6 +146,12 @@ export async function hasUncommittedChanges(): Promise<boolean> {
   return result.trim().length > 0
 }
 
+export async function restoreDirectories(dirs: string[]): Promise<void> {
+  for (const dir of dirs) {
+    await $`git restore ${dir}`.quiet().nothrow()
+  }
+}
+
 export async function stageAll(): Promise<void> {
   await $`git add -A`
 }


### PR DESCRIPTION
Fixes an issue where generated provider icon files in `packages/ui/src/assets/icons/provider` would cause merge conflicts during upstream checkout.

The upstream merge script now restores and cleans that directory before switching branches, preventing dirty state from blocking the checkout step.