### PR TITLE
feat: add heap snapshot command to VS Code extension

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -320,6 +320,11 @@
         "command": "kilo-code.new.generateTerminalCommand",
         "title": "Generate Terminal Command",
         "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.createHeapSnapshot",
+        "title": "Create Heap Snapshot",
+        "category": "Kilo Code"
       }
     ],
     "submenus": [
@@ -466,6 +471,11 @@
         "command": "kilo-code.new.generateTerminalCommand",
         "key": "ctrl+shift+g",
         "mac": "cmd+shift+g"
+      },
+      {
+        "command": "kilo-code.new.createHeapSnapshot",
+        "key": "ctrl+shift+h",
+        "mac": "cmd+shift+h"
       },
       {
         "command": "kilo-code.new.agentManagerOpen",

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import * as v8 from "v8"
 import * as fs from "fs"
+import * as os from "os"
 import path from "path"
 import { KiloProvider } from "./KiloProvider"
 import { AgentManagerProvider } from "./agent-manager/AgentManagerProvider"
@@ -315,12 +316,13 @@ export function activate(context: vscode.ExtensionContext) {
       }),
     ),
     vscode.commands.registerCommand("kilo-code.new.createHeapSnapshot", async () => {
-      const dir = path.join(context.extensionPath, "heap-snapshots")
+      const dir = path.join(os.tmpdir(), "kilo-heap-snapshots")
       fs.mkdirSync(dir, { recursive: true })
       const filename = `heap-${Date.now()}.heapsnapshot`
       const filePath = path.join(dir, filename)
       const snapshotPath = v8.writeHeapSnapshot(filePath)
       const content = fs.readFileSync(snapshotPath, "utf-8")
+      fs.unlinkSync(snapshotPath)
       await vscode.env.clipboard.writeText(content)
       vscode.window.showInformationMessage("Heap snapshot copied to clipboard. Paste in GitHub issue.")
     }),

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -1,4 +1,7 @@
 import * as vscode from "vscode"
+import * as v8 from "v8"
+import * as fs from "fs"
+import path from "path"
 import { KiloProvider } from "./KiloProvider"
 import { AgentManagerProvider } from "./agent-manager/AgentManagerProvider"
 import { VscodeHost } from "./agent-manager/vscode-host"
@@ -311,6 +314,16 @@ export function activate(context: vscode.ExtensionContext) {
         agentManagerProvider.postMessage({ type: "action", action: `jumpTo${i + 1}` })
       }),
     ),
+    vscode.commands.registerCommand("kilo-code.new.createHeapSnapshot", async () => {
+      const dir = path.join(context.extensionPath, "heap-snapshots")
+      fs.mkdirSync(dir, { recursive: true })
+      const filename = `heap-${Date.now()}.heapsnapshot`
+      const filePath = path.join(dir, filename)
+      const snapshotPath = v8.writeHeapSnapshot(filePath)
+      const content = fs.readFileSync(snapshotPath, "utf-8")
+      await vscode.env.clipboard.writeText(content)
+      vscode.window.showInformationMessage("Heap snapshot copied to clipboard. Paste in GitHub issue.")
+    }),
   )
 
   // Register URI handler for session imports (vscode://kilocode.kilo-code/kilocode/s/{sessionId})


### PR DESCRIPTION
## Context

Add a command to the VS Code extension that allows users to create a heap snapshot and copy it to the clipboard for easy sharing in GitHub issues.

Closes #8652

## Implementation

- Added new command `kilo-code.new.createHeapSnapshot` bound to `Ctrl+Shift+H` (macOS: `Cmd+Shift+H`)
- Uses Node.js `v8.writeHeapSnapshot()` to generate heap snapshot in the extension's directory
- Reads the snapshot file and uses `vscode.env.clipboard.writeText()` to copy content to clipboard
- Shows information message confirming the snapshot was copied

## How to Test

- Install the extension with the new changes
- Press `Ctrl+Shift+H` (or `Cmd+Shift+H` on macOS) or run "Kilo Code: Create Heap Snapshot" from the command palette
- Heap snapshot content should be copied to clipboard
- Paste in a GitHub issue or text editor to verify

## Get in Touch

My discord is `@iamcoder18` and I'm in the Kilo discord server.