### PR TITLE
fix: also restore provider-icons dir during upstream merge checkout

### DIFF
--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -269,7 +269,7 @@ async function main() {
 
   const author = options.author || (await getAuthor())
   const kiloVersion = await version.getCurrentKiloVersion()
-  const dirs = ["packages/ui/src/assets/icons/provider"]
+  const dirs = ["packages/ui/src/assets/icons/provider", "packages/ui/src/components/provider-icons"]
 
   logger.info("Resetting generated provider icons before checkout...")
   await git.restoreDirectories(dirs)


### PR DESCRIPTION
Also resets `packages/ui/src/components/provider-icons` before upstream checkout during the merge script, alongside the existing provider icons assets directory.

This prevents generated provider icon components from being overwritten by upstream changes during the merge process.