### PR TITLE
feat(vscode): add configurable agent manager worktree prefix

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -783,6 +783,11 @@
           "type": "boolean",
           "default": true,
           "description": "Show the task timeline graph in the chat header"
+        },
+        "kilo-code.new.agentManager.worktreePrefix": {
+          "type": "string",
+          "default": "kilo-worktree",
+          "description": "Prefix used for auto-generated Agent Manager worktree branch names. Use an empty string to disable the prefix."
         }
       }
     }

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -11,7 +11,7 @@ import { chooseBaseBranch, normalizeBaseBranch } from "./base-branch"
 import { GitStatsPoller, type WorktreePresenceResult } from "./GitStatsPoller"
 import { PRStatusBridge } from "./pr-status-bridge"
 import { GitOps } from "./GitOps"
-import { versionedName } from "./branch-name"
+import { DEFAULT_WORKTREE_PREFIX, versionedName } from "./branch-name"
 import { classifyWorktreeError } from "./git-import"
 import { SetupScriptService } from "./SetupScriptService"
 import { SetupScriptRunner } from "./SetupScriptRunner"
@@ -1280,6 +1280,7 @@ export class AgentManagerProvider implements Disposable {
       root,
       (msg) => this.outputChannel.appendLine(`[WorktreeManager] ${msg}`),
       this.gitOps,
+      { prefix: () => this.host.setting("agentManager.worktreePrefix", DEFAULT_WORKTREE_PREFIX) },
     )
     return this.worktrees
   }

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -589,7 +589,7 @@ export class AgentManagerProvider implements Disposable {
     let result: CreateWorktreeResult
     try {
       result = await manager.createWorktree({
-        prompt: opts?.name || "kilo",
+        prompt: opts?.name?.trim() && opts.name.trim() !== "kilo" ? opts.name.trim() : undefined,
         baseBranch: effectiveBase ?? opts?.baseBranch,
         branchName: opts?.branchName,
         existingBranch: opts?.existingBranch,

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -10,7 +10,7 @@ import * as path from "path"
 import * as fs from "fs"
 import { randomUUID } from "crypto"
 import simpleGit, { type SimpleGit } from "simple-git"
-import { generateBranchName, sanitizeBranchName } from "./branch-name"
+import { DEFAULT_WORKTREE_PREFIX, generateBranchName, sanitizeBranchName } from "./branch-name"
 import { type GitOps, nonInteractiveEnv } from "./GitOps"
 import { execWithShellEnv } from "./shell-env"
 import {
@@ -92,14 +92,16 @@ export class WorktreeManager {
   private readonly git: SimpleGit
   private readonly ops: GitOps | undefined
   private readonly log: (msg: string) => void
+  private readonly prefix: (() => string) | undefined
   private migrated = false
 
-  constructor(root: string, log: (msg: string) => void, ops?: GitOps) {
+  constructor(root: string, log: (msg: string) => void, ops?: GitOps, opts?: { prefix?: () => string }) {
     this.root = root
     this.dir = path.join(root, KILO_DIR, "worktrees")
     this.git = simpleGit(root)
     this.ops = ops
     this.log = log
+    this.prefix = opts?.prefix
   }
 
   /** Run once before first read/write to migrate Agent Manager data from .kilocode → .kilo. */
@@ -231,7 +233,7 @@ export class WorktreeManager {
         .branch()
         .then((b) => b.all)
         .catch(() => [] as string[])
-      branch = generateBranchName(params.prompt || "agent-task", existing)
+      branch = generateBranchName(params.prompt, existing, this.prefix?.() ?? DEFAULT_WORKTREE_PREFIX)
     }
 
     if (params.existingBranch) {

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -153,6 +153,21 @@ export class WorktreeManager {
     return this.withGitLock(() => this.createWorktreeImpl(params))
   }
 
+  private async resolveBranchName(params: {
+    prompt?: string
+    existingBranch?: string
+    branchName?: string
+  }): Promise<string> {
+    const sanitized = params.branchName ? sanitizeBranchName(params.branchName) : undefined
+    if (params.existingBranch) return params.existingBranch
+    if (sanitized) return sanitized
+    const existing = await this.git
+      .branch()
+      .then((b) => b.all)
+      .catch(() => [] as string[])
+    return generateBranchName(params.prompt, existing, this.prefix?.() ?? DEFAULT_WORKTREE_PREFIX)
+  }
+
   private async ensureGitAvailable(): Promise<void> {
     try {
       await execWithShellEnv("git", ["--version"])
@@ -222,19 +237,7 @@ export class WorktreeManager {
       parentRemote = startPoint.remote
     }
 
-    const sanitized = params.branchName ? sanitizeBranchName(params.branchName) : undefined
-    let branch: string
-    if (params.existingBranch) {
-      branch = params.existingBranch
-    } else if (sanitized) {
-      branch = sanitized
-    } else {
-      const existing = await this.git
-        .branch()
-        .then((b) => b.all)
-        .catch(() => [] as string[])
-      branch = generateBranchName(params.prompt, existing, this.prefix?.() ?? DEFAULT_WORKTREE_PREFIX)
-    }
+    let branch = await this.resolveBranchName(params)
 
     if (params.existingBranch) {
       const exists = await this.branchExists(branch)

--- a/packages/kilo-vscode/src/agent-manager/__tests__/AgentManagerProvider.spec.ts
+++ b/packages/kilo-vscode/src/agent-manager/__tests__/AgentManagerProvider.spec.ts
@@ -77,7 +77,11 @@ function createMockHost(): Host {
     createOutput: () => ({ appendLine: vi.fn(), dispose: vi.fn() }) as OutputHandle,
     extensionKeybindings: () => [],
     serverPort: () => undefined,
+    setting: (_key, fallback) => fallback,
+    copyToClipboard: vi.fn(),
     capture: vi.fn(),
+    openExternal: vi.fn(),
+    refreshGit: vi.fn(),
     dispose: vi.fn(),
   }
 }

--- a/packages/kilo-vscode/src/agent-manager/branch-name.ts
+++ b/packages/kilo-vscode/src/agent-manager/branch-name.ts
@@ -5,7 +5,7 @@ const FALLBACK_MAX_SUFFIX = 100
 export const DEFAULT_WORKTREE_PREFIX = "kilo-worktree"
 
 export function normalizeWorktreePrefix(prefix: string | undefined): string {
-  return sanitizeBranchName(prefix ?? "").replace(/\/+$/g, "")
+  return sanitizeBranchName(prefix ?? "", 255).replace(/\/+$/g, "")
 }
 
 function applyPrefix(prefix: string | undefined, name: string): string {
@@ -32,6 +32,8 @@ export function sanitizeBranchName(name: string, maxLength = 50): string {
 
 /**
  * Generate an auto branch name for a worktree.
+ * Uses the prompt when available, falls back to friendly words when not,
+ * and applies the configured prefix unless it is empty.
  */
 export function generateBranchName(
   prompt: string | undefined,

--- a/packages/kilo-vscode/src/agent-manager/branch-name.ts
+++ b/packages/kilo-vscode/src/agent-manager/branch-name.ts
@@ -2,26 +2,42 @@ import friendlyWords from "friendly-words"
 
 const MAX_ATTEMPTS = 10
 const FALLBACK_MAX_SUFFIX = 100
+export const DEFAULT_WORKTREE_PREFIX = "kilo-worktree"
+
+export function normalizeWorktreePrefix(prefix: string | undefined): string {
+  return sanitizeBranchName(prefix ?? "").replace(/\/+$/g, "")
+}
+
+function applyPrefix(prefix: string | undefined, name: string): string {
+  const base = normalizeWorktreePrefix(prefix)
+  if (!base) return name
+  return `${base}/${name}`
+}
 
 /**
  * Sanitize a string into a valid git branch name segment.
- * Keeps lowercase alphanumeric chars and hyphens, collapses runs, strips edges.
+ * Keeps lowercase alphanumeric chars, hyphens, and slashes, collapses runs, strips edges.
  */
 export function sanitizeBranchName(name: string, maxLength = 50): string {
   return name
     .slice(0, maxLength)
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
+    .replace(/[^a-z0-9/]+/g, "-")
+    .replace(/^[-/]+|[-/]+$/g, "")
     .replace(/-+/g, "-")
+    .replace(/\/+/g, "/")
+    .replace(/-\//g, "/")
+    .replace(/\/-/g, "/")
 }
 
 /**
- * Generate a natural two-word branch name (e.g. "ambitious-keyboard") using
- * the friendly-words package.  Checks `existingBranches` to avoid collisions,
- * falling back to a numeric suffix and ultimately a timestamp.
+ * Generate an auto branch name for a worktree.
  */
-export function generateBranchName(_prompt: string, existingBranches: string[] = []): string {
+export function generateBranchName(
+  prompt: string | undefined,
+  existingBranches: string[] = [],
+  prefix = DEFAULT_WORKTREE_PREFIX,
+): string {
   const predicates = friendlyWords.predicates as string[]
   const objects = friendlyWords.objects as string[]
   const existing = new Set(existingBranches.map((b) => b.toLowerCase()))
@@ -29,24 +45,29 @@ export function generateBranchName(_prompt: string, existingBranches: string[] =
   const random = () => {
     const predicate = predicates[Math.floor(Math.random() * predicates.length)]
     const object = objects[Math.floor(Math.random() * objects.length)]
-    return `${predicate}-${object}`
+    return applyPrefix(prefix, `${predicate}-${object}`)
   }
 
-  // Try up to MAX_ATTEMPTS unique two-word combos
+  const unique = (base: string) => {
+    if (!existing.has(base.toLowerCase())) return base
+
+    for (let n = 2; n < FALLBACK_MAX_SUFFIX + 2; n++) {
+      const candidate = `${base}-${n}`
+      if (!existing.has(candidate.toLowerCase())) return candidate
+    }
+
+    return `${base}-${Date.now()}`
+  }
+
+  const slug = prompt ? sanitizeBranchName(prompt) : ""
+  if (slug) return unique(applyPrefix(prefix, slug))
+
   for (let i = 0; i < MAX_ATTEMPTS; i++) {
     const candidate = random()
-    if (!existing.has(candidate)) return candidate
+    if (!existing.has(candidate.toLowerCase())) return candidate
   }
 
-  // Append numeric suffix 0–99
-  const base = random()
-  for (let n = 0; n < FALLBACK_MAX_SUFFIX; n++) {
-    const candidate = `${base}-${n}`
-    if (!existing.has(candidate)) return candidate
-  }
-
-  // Last resort: timestamp
-  return `${base}-${Date.now()}`
+  return unique(random())
 }
 
 /**

--- a/packages/kilo-vscode/src/agent-manager/branch-name.ts
+++ b/packages/kilo-vscode/src/agent-manager/branch-name.ts
@@ -2,10 +2,11 @@ import friendlyWords from "friendly-words"
 
 const MAX_ATTEMPTS = 10
 const FALLBACK_MAX_SUFFIX = 100
+const MAX_PREFIX_LENGTH = 255
 export const DEFAULT_WORKTREE_PREFIX = "kilo-worktree"
 
 export function normalizeWorktreePrefix(prefix: string | undefined): string {
-  return sanitizeBranchName(prefix ?? "", 255).replace(/\/+$/g, "")
+  return sanitizeBranchName(prefix ?? "", MAX_PREFIX_LENGTH).replace(/\/+$/g, "")
 }
 
 function applyPrefix(prefix: string | undefined, name: string): string {

--- a/packages/kilo-vscode/src/agent-manager/host.ts
+++ b/packages/kilo-vscode/src/agent-manager/host.ts
@@ -109,6 +109,9 @@ export interface Host {
   /** Get the CLI server port (for webview CSP). */
   serverPort(): number | undefined
 
+  /** Read a Kilo Code setting. */
+  setting<T>(key: string, fallback: T): T
+
   /** Copy text to the system clipboard. */
   copyToClipboard(text: string): void
 

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -170,7 +170,7 @@ export class VscodeHost implements Host {
   }
 
   setting<T>(key: string, fallback: T): T {
-    return vscode.workspace.getConfiguration("kilo-code.new").get<T>(key, fallback) ?? fallback
+    return vscode.workspace.getConfiguration("kilo-code.new").get<T>(key, fallback)
   }
 
   copyToClipboard(text: string): void {

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -169,6 +169,10 @@ export class VscodeHost implements Host {
     return this.connectionService.getServerInfo()?.port
   }
 
+  setting<T>(key: string, fallback: T): T {
+    return vscode.workspace.getConfiguration("kilo-code.new").get<T>(key, fallback) ?? fallback
+  }
+
   copyToClipboard(text: string): void {
     void vscode.env.clipboard.writeText(text)
   }

--- a/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
@@ -3,7 +3,13 @@ import os from "node:os"
 import path from "node:path"
 import fs from "node:fs/promises"
 import { WorktreeManager } from "../../src/agent-manager/WorktreeManager"
-import { generateBranchName, sanitizeBranchName, versionedName } from "../../src/agent-manager/branch-name"
+import {
+  DEFAULT_WORKTREE_PREFIX,
+  generateBranchName,
+  normalizeWorktreePrefix,
+  sanitizeBranchName,
+  versionedName,
+} from "../../src/agent-manager/branch-name"
 import { WorktreeStateManager } from "../../src/agent-manager/WorktreeStateManager"
 import simpleGit from "simple-git"
 
@@ -32,9 +38,11 @@ async function createTempRepo(): Promise<string> {
   return dir
 }
 
-function createManager(root: string): WorktreeManager {
+function createManager(root: string, prefix?: string): WorktreeManager {
   const logs: string[] = []
-  return new WorktreeManager(root, (msg) => logs.push(msg))
+  return new WorktreeManager(root, (msg) => logs.push(msg), undefined, {
+    prefix: () => prefix ?? DEFAULT_WORKTREE_PREFIX,
+  })
 }
 
 /** Create a temp repo with a bare origin remote so origin/<branch> refs exist. */
@@ -73,34 +81,26 @@ async function createTempRepoWithOrigin(): Promise<{ bare: string; clone: string
 // ---------------------------------------------------------------------------
 
 describe("generateBranchName", () => {
-  it("generates a two-word predicate-object name", () => {
-    const name = generateBranchName("anything")
-    // Should be two lowercase words joined by a hyphen
-    expect(name).toMatch(/^[a-z]+-[a-z]+$/)
+  it("uses the default prefix for prompt-based names", () => {
+    expect(generateBranchName("Fix login bug")).toBe("kilo-worktree/fix-login-bug")
   })
 
-  it("avoids existing branches", () => {
-    // Generate 50 names and collect them; none should collide with the existing list
-    const existing = ["brave-piano", "sunny-cloud"]
-    for (let i = 0; i < 50; i++) {
-      const name = generateBranchName("task", existing)
-      expect(existing).not.toContain(name)
-    }
+  it("uses a custom prefix for prompt-based names", () => {
+    expect(generateBranchName("Fix login bug", [], "team-worktree")).toBe("team-worktree/fix-login-bug")
   })
 
-  it("falls back to numeric suffix when collisions are likely", () => {
-    // Supply a huge existing list — eventually a numeric suffix or timestamp is used
-    const name = generateBranchName("task", [])
-    expect(typeof name).toBe("string")
-    expect(name.length).toBeGreaterThan(0)
+  it("disables the prefix when configured empty", () => {
+    expect(generateBranchName("Fix login bug", [], "")).toBe("fix-login-bug")
   })
 
-  it("ignores the prompt and always returns friendly words", () => {
-    const a = generateBranchName("")
-    const b = generateBranchName("FIX BUG")
-    // Both should be lowercase word-hyphen-word patterns
-    expect(a).toMatch(/^[a-z]+-[a-z]+/)
-    expect(b).toMatch(/^[a-z]+-[a-z]+/)
+  it("adds a numeric suffix when a prompt-based branch already exists", () => {
+    const existing = ["kilo-worktree/fix-login-bug"]
+    expect(generateBranchName("Fix login bug", existing)).toBe("kilo-worktree/fix-login-bug-2")
+  })
+
+  it("falls back to prefixed friendly words when no prompt is available", () => {
+    const name = generateBranchName(undefined, [])
+    expect(name).toMatch(/^kilo-worktree\/[a-z]+-[a-z]+$/)
   })
 })
 
@@ -145,6 +145,20 @@ describe("sanitizeBranchName", () => {
   it("handles custom maxLength", () => {
     const result = sanitizeBranchName("abcdefghij", 5)
     expect(result).toBe("abcde")
+  })
+
+  it("preserves forward slash as namespace separator", () => {
+    expect(sanitizeBranchName("team/worktree/fix-login-bug")).toBe("team/worktree/fix-login-bug")
+  })
+})
+
+describe("normalizeWorktreePrefix", () => {
+  it("sanitizes prefix input", () => {
+    expect(normalizeWorktreePrefix(" Team Worktree / ")).toBe("team-worktree")
+  })
+
+  it("allows empty prefix", () => {
+    expect(normalizeWorktreePrefix("")).toBe("")
   })
 })
 
@@ -237,14 +251,13 @@ describe("WorktreeStateManager.updateWorktreeLabel", () => {
 // ---------------------------------------------------------------------------
 
 describe("WorktreeManager.createWorktree", () => {
-  it("creates a worktree with a new branch", async () => {
+  it("creates a worktree with the default prefix", async () => {
     const root = await createTempRepo()
     const mgr = createManager(root)
 
     const result = await mgr.createWorktree({ prompt: "test task" })
 
-    // Branch should be a friendly two-word name (e.g. "brave-piano")
-    expect(result.branch).toMatch(/^[a-z]+-[a-z]+/)
+    expect(result.branch).toBe("kilo-worktree/test-task")
     expect(result.parentBranch).toBeTruthy()
 
     // Worktree directory should exist and have a .git file (not directory)
@@ -255,6 +268,24 @@ describe("WorktreeManager.createWorktree", () => {
     const git = simpleGit(root)
     const branches = await git.branch()
     expect(branches.all).toContain(result.branch)
+  })
+
+  it("creates a worktree with a custom prefix", async () => {
+    const root = await createTempRepo()
+    const mgr = createManager(root, "team-worktree")
+
+    const result = await mgr.createWorktree({ prompt: "test task" })
+
+    expect(result.branch).toBe("team-worktree/test-task")
+  })
+
+  it("creates a worktree without a prefix when disabled", async () => {
+    const root = await createTempRepo()
+    const mgr = createManager(root, "")
+
+    const result = await mgr.createWorktree({ prompt: "test task" })
+
+    expect(result.branch).toBe("test-task")
   })
 
   it("uses existing branch when specified", async () => {

--- a/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
@@ -100,7 +100,7 @@ describe("generateBranchName", () => {
 
   it("falls back to prefixed friendly words when no prompt is available", () => {
     const name = generateBranchName(undefined, [])
-    expect(name).toMatch(/^kilo-worktree\/[a-z]+-[a-z]+$/)
+    expect(name).toMatch(new RegExp(`^${DEFAULT_WORKTREE_PREFIX}\\/[a-z]+-[a-z]+$`))
   })
 })
 


### PR DESCRIPTION
## Context

This PR adds a new `kilo-code.new.agentManager.worktreePrefix` setting to the VS Code extension so Agent Manager worktrees can use a configurable branch prefix.

This makes auto-generated worktree branch names easier to organize across teams and workflows, while still allowing the prefix to be disabled entirely when plain branch names are preferred.

## Implementation

The VS Code extension now contributes a new string setting for the Agent Manager worktree prefix and exposes settings access through the Agent Manager host so the provider can pass the configured value into `WorktreeManager`.

Worktree branch generation was updated to:

- use sanitized prompt-based slugs when a prompt is available
- apply a normalized prefix by default using `kilo-worktree`
- preserve `/` separators so prefixes can create branch namespaces
- allow an empty prefix to disable namespacing
- add numeric suffixes when a generated branch already exists
- fall back to friendly-word names when no prompt is available

Tests were updated to cover the new setting plumbing, prefix normalization, prompt-based naming, collision handling, and worktree creation with default, custom, and disabled prefixes.

## Screenshots

| before | after |
| ------ | ----- |
| N/A    | N/A   |

## How to Test

- Open the VS Code extension and use Agent Manager to create a new worktree from a prompt such as `Fix login bug`.
- Confirm the generated branch name uses the default prefix: `kilo-worktree/fix-login-bug`.
- Set `kilo-code.new.agentManager.worktreePrefix` to `team-worktree`.
- Create another worktree from the same or a similar prompt.
- Confirm the generated branch name uses the custom prefix: `team-worktree/fix-login-bug`.
- Set `kilo-code.new.agentManager.worktreePrefix` to an empty string.
- Create another worktree from a prompt.
- Confirm the generated branch name has no prefix, for example `fix-login-bug`.
- Optionally create another worktree with the same prompt and confirm the branch name gets a numeric suffix instead of colliding.

## Get in Touch

Discord: thomas07374
