### PR TITLE
fix(cli): prioritize kilo config over opencode config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -280,7 +280,7 @@ export namespace Config {
     // Project config overrides global and remote config.
     if (!Flag.KILO_DISABLE_PROJECT_CONFIG) {
       // kilocode_change start
-      for (const file of ["kilo.jsonc", "kilo.json", "opencode.jsonc", "opencode.json"]) {
+      for (const file of ["opencode.jsonc", "opencode.json", "kilo.json", "kilo.jsonc"]) {
         try {
           result = mergeConfigConcatArrays(result, await loadFile(file))
         } catch (err) {
@@ -311,7 +311,7 @@ export namespace Config {
         dir.endsWith(".opencode") ||
         dir === Flag.KILO_CONFIG_DIR
       ) {
-        for (const file of ["kilo.jsonc", "kilo.json", "opencode.jsonc", "opencode.json"]) {
+        for (const file of ["opencode.jsonc", "opencode.json", "kilo.json", "kilo.jsonc"]) {
           log.debug(`loading config from ${path.join(dir, file)}`)
           try {
             result = mergeConfigConcatArrays(result, await loadFile(path.join(dir, file)))
@@ -1606,11 +1606,11 @@ export namespace Config {
       {},
       mergeDeep(await loadFile(path.join(Global.Path.config, "config.json"))),
       // kilocode_change start
+      mergeDeep(await loadFile(path.join(Global.Path.config, "opencode.json"))),
+      mergeDeep(await loadFile(path.join(Global.Path.config, "opencode.jsonc"))),
       mergeDeep(await loadFile(path.join(Global.Path.config, "kilo.json"))),
       mergeDeep(await loadFile(path.join(Global.Path.config, "kilo.jsonc"))),
       // kilocode_change end
-      mergeDeep(await loadFile(path.join(Global.Path.config, "opencode.json"))),
-      mergeDeep(await loadFile(path.join(Global.Path.config, "opencode.jsonc"))),
     )
 
     const legacy = path.join(Global.Path.config, "config")

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -178,6 +178,111 @@ test("merges multiple config files with correct precedence", async () => {
   })
 })
 
+test("prefers kilo.json over opencode.json in project config", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(
+        dir,
+        {
+          $schema: "https://app.kilo.ai/config.json",
+          model: "opencode/project",
+          username: "opencode-user",
+        },
+        "opencode.json",
+      )
+      await writeConfig(
+        dir,
+        {
+          $schema: "https://app.kilo.ai/config.json",
+          model: "kilo/project",
+        },
+        "kilo.json",
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.model).toBe("kilo/project")
+      expect(config.username).toBe("opencode-user")
+    },
+  })
+})
+
+test("prefers kilo.json over opencode.json in .kilo config directory", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(
+        path.join(dir, ".kilo", "opencode.json"),
+        JSON.stringify({
+          $schema: "https://app.kilo.ai/config.json",
+          model: "opencode/local",
+          username: "opencode-local",
+        }),
+      )
+      await Filesystem.write(
+        path.join(dir, ".kilo", "kilo.json"),
+        JSON.stringify({
+          $schema: "https://app.kilo.ai/config.json",
+          model: "kilo/local",
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.model).toBe("kilo/local")
+      expect(config.username).toBe("opencode-local")
+    },
+  })
+})
+
+test("prefers kilo.json over opencode.json in global config", async () => {
+  await using globalTmp = await tmpdir()
+  await using tmp = await tmpdir()
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = globalTmp.path
+  Config.global.reset()
+
+  try {
+    await writeConfig(
+      globalTmp.path,
+      {
+        $schema: "https://app.kilo.ai/config.json",
+        model: "opencode/global",
+        username: "opencode-global",
+      },
+      "opencode.json",
+    )
+    await writeConfig(
+      globalTmp.path,
+      {
+        $schema: "https://app.kilo.ai/config.json",
+        model: "kilo/global",
+      },
+      "kilo.json",
+    )
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.model).toBe("kilo/global")
+        expect(config.username).toBe("opencode-global")
+      },
+    })
+  } finally {
+    await Instance.disposeAll()
+    ;(Global.Path as { config: string }).config = prev
+    Config.global.reset()
+  }
+})
+
 test("prefers .kilo directory config over legacy .kilocode", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
## Summary

Fix config merge precedence so `kilo.json` / `kilo.jsonc` correctly override `opencode.json` / `opencode.jsonc` in all CLI config loading paths.

## Root cause

The CLI loaded Kilo config files before Opencode config files in three places:

- root project config loading
- local config directories like `.kilo/`
- global config loading

Because later merges win, that let `opencode.*` override `kilo.*`, which is backwards for Kilo CLI.

## Changes

- load `opencode.json{,c}` before `kilo.json{,c}` for project config resolution
- load `opencode.json{,c}` before `kilo.json{,c}` for local config directory resolution
- load `opencode.json{,c}` before `kilo.json{,c}` for global config resolution
- add regression tests covering project, local `.kilo`, and global precedence

## Validation

- `git push -u origin codex/fix-kilo-config-priority-7621`
  - passed the repo's pre-push `bun turbo typecheck`
- direct `bun --eval` repro from a temp repo confirmed `kilo.json` now wins while `opencode.json` still provides fallback fields
- `bun test test/config/config.test.ts`
  - this runner shows unrelated baseline failures in this checkout, including existing config tests outside this change

Fixes #7621