### PR TITLE
fix(cli): strip unrecognized top-level config keys instead of crashing

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1546,7 +1546,7 @@ export namespace Config {
         })
         .optional(),
     })
-    .strict()
+    // kilocode_change - removed .strict() to silently strip unrecognized top-level keys instead of crashing (fixes #8751)
     .meta({
       ref: "Config",
     })

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -358,20 +358,22 @@ test("handles file inclusion with replacement tokens", async () => {
   })
 })
 
-test("validates config schema and throws on invalid fields", async () => {
+test("strips unrecognized top-level config keys instead of throwing", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await writeConfig(dir, {
         $schema: "https://app.kilo.ai/config.json",
-        invalid_field: "should cause error",
+        invalid_field: "should be stripped",
+        model: "test/model",
       })
     },
   })
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      // Strict schema should throw an error for invalid fields
-      await expect(Config.get()).rejects.toThrow()
+      const config = await Config.get()
+      expect(config.model).toBe("test/model")
+      expect((config as Record<string, unknown>).invalid_field).toBeUndefined()
     },
   })
 })

--- a/packages/opencode/test/kilocode/config-resilience.test.ts
+++ b/packages/opencode/test/kilocode/config-resilience.test.ts
@@ -197,10 +197,10 @@ Broken command`,
     })
   })
 
-  test("collects warnings for invalid schema in .kilo directory config", async () => {
+  test("strips unrecognized top-level keys in .kilo directory config without warning", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
-        await Filesystem.write(path.join(dir, ".kilo", "kilo.json"), JSON.stringify({ unknownField: true }))
+        await Filesystem.write(path.join(dir, ".kilo", "kilo.json"), JSON.stringify({ unknownField: true, model: "test/model" }))
       },
     })
 
@@ -211,7 +211,8 @@ Broken command`,
         const warns = await Config.warnings()
 
         expect(cfg).toBeDefined()
-        expect(warns.some((w) => w.path.includes("kilo.json") && w.message.includes("invalid"))).toBe(true)
+        expect(cfg.model).toBe("test/model")
+        expect(warns.some((w) => w.path.includes("kilo.json") && w.message.includes("invalid"))).toBe(false)
       },
     })
   })


### PR DESCRIPTION
Fixes #8751

**Failing scenario:** User runs Kilo on a feature branch that writes a new config key (e.g., `subagent_model`) to `~/.config/kilo/kilo.jsonc`. Switching back to `main` crashes Kilo with `Configuration is invalid … Unrecognized key`.

**Before:** The top-level `Config.Info` Zod schema uses `.strict()`, which rejects the entire config file when any single key is unrecognized — losing all valid settings.

**After:** `.strict()` is removed from the top-level schema so Zod silently strips unknown keys (default behavior). Valid config keys are preserved. Sub-schemas (`McpLocal`, `McpRemote`, etc.) retain `.strict()` to still catch typos in nested objects where the key space is small and well-defined.

**Note:** This also changes the generated JSON Schema (`additionalProperties` is no longer `false` at the top level), which improves forward-compatibility for IDE validation as well.

**Validation:** `bun test test/kilocode/config-resilience.test.ts` — 9/9 pass. `bun turbo typecheck` — 12/12 pass.