### PR TITLE
fix(vscode): show tool name in permission prompt title

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -110,8 +110,15 @@ export const PermissionDock: Component<{
     return value
   }
 
-  const title = () =>
-    fromChild() ? language.t("notification.permission.titleSubagent") : language.t("notification.permission.title")
+  const toolLabel = () => resolveLabel(props.request.toolName, language.t)
+
+  const title = () => {
+    const base = fromChild()
+      ? language.t("notification.permission.titleSubagent")
+      : language.t("notification.permission.title")
+    const label = toolLabel()
+    return label ? `${base}: ${label}` : base
+  }
 
   const focusPrompt = () => requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
 


### PR DESCRIPTION
## Context

Fixes #8738

The auto-approve permission prompt currently shows only "Permission required" in the title, with no indication of *which* tool is requesting approval. Users must expand the checkbox section to discover the tool name, which hurts discoverability — especially for MCP tools where the name carries important context (e.g. `playwright_click`, `github_create_issue`).

## Implementation

Appends the resolved tool label to the permission prompt title via the existing `resolveLabel` utility:

- **Built-in tools** get their translated label: `"Permission required: Read"`, `"Permission required: Bash"`
- **MCP tools** fall back to the raw tool name: `"Permission required: playwright_click"`
- **Subagent requests** also include the label: `"Permission required (subagent): Edit"`

One-file change, 9 lines added (net +7). No new dependencies, no i18n key changes, no CSS changes.

## How to Test

1. `bun run extension`
2. Trigger any permission prompt (e.g. a file edit, bash command, or MCP tool call)
3. Observe the title now includes the tool name
4. Verify the expanded checkbox section still shows the tool name as before (no regression)

## Screenshots

N/A — the change appends text to an existing header string. Before: `"Permission required"`. After: `"Permission required: Read"`.