### PR TITLE
feat(vscode): add image attachment path mode for MCP file path handling

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -783,6 +783,15 @@
           "type": "boolean",
           "default": true,
           "description": "Show the task timeline graph in the chat header"
+        },
+        "kilo-code.new.attachments.imageMode": {
+          "type": "string",
+          "default": "data",
+          "enum": [
+            "data",
+            "path"
+          ],
+          "description": "How to send image attachments: 'data' sends base64 data URLs, 'path' sends file:// paths for MCP servers that expect file paths."
         }
       }
     }

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -186,6 +186,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private webviewMessageDisposable: vscode.Disposable | null = null
   private viewStateDisposable: vscode.Disposable | null = null
   private visibilityDisposable: vscode.Disposable | null = null
+  private configChangeDisposable: vscode.Disposable | null = null
 
   /** Lazily initialized ignore controller for .kilocodeignore filtering */
   private ignoreController: FileIgnoreController | null = null
@@ -226,7 +227,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     TelemetryProxy.getInstance().setProvider(this)
 
     // Listen for imageMode setting changes and push to webview
-    vscode.workspace.onDidChangeConfiguration((e) => {
+    this.configChangeDisposable = vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration("kilo-code.new.attachments")) {
         this.sendImageMode()
       }
@@ -3330,6 +3331,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.viewStateDisposable?.dispose()
     this.visibilityDisposable?.dispose()
     this.webviewMessageDisposable?.dispose()
+    this.configChangeDisposable?.dispose()
     this.isWebviewReady = false
     this.promptRecoveryQueued = false
     clearNetworkWaits(this.trackedSessionIds)

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -687,6 +687,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "previewImage":
           this.handlePreviewImage(message.dataUrl, message.filename)
           break
+        case "saveImageToTemp":
+          await this.handleSaveImageToTemp(message.id, message.mime, message.base64, message.filename)
+          break
         case "openFile":
           if (message.filePath) {
             this.handleOpenFile(message.filePath, message.line, message.column)
@@ -847,6 +850,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         case "requestClaudeCompatSetting":
           this.sendClaudeCompatSetting()
+          break
+        case "requestImageMode":
+          this.sendImageMode()
           break
         case "requestNotificationSettings":
           this.sendNotificationSettings()
@@ -2720,6 +2726,27 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       .then(open, (err) => console.error("[Kilo New] KiloProvider: Failed to preview image:", err))
   }
 
+  private async handleSaveImageToTemp(id: string, mime: string, base64: string, filename: string): Promise<void> {
+    const tempDir = vscode.env.tempFilesStoragePath
+    if (!tempDir) {
+      console.error("[Kilo New] KiloProvider: tempFilesStoragePath not available")
+      return
+    }
+
+    try {
+      const uri = vscode.Uri.joinPath(vscode.Uri.file(tempDir), `image-${Date.now()}-${filename}`)
+      const data = Buffer.from(base64, "base64")
+      await vscode.workspace.fs.writeFile(uri, data)
+      this.postMessage({
+        type: "imageSaved",
+        id,
+        filePath: uri.toString(),
+      })
+    } catch (err) {
+      console.error("[Kilo New] KiloProvider: Failed to save image to temp:", err)
+    }
+  }
+
   /**
    * Handle openFile request from the webview — open a file in the VS Code editor.
    * Resolves relative paths against the current session's directory (which may be
@@ -2827,6 +2854,15 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.postMessage({
       type: "claudeCompatSettingLoaded",
       enabled: enabled ?? false,
+    })
+  }
+
+  private sendImageMode(): void {
+    const config = vscode.workspace.getConfiguration("kilo-code.new.attachments")
+    const mode = config.get<"data" | "path">("imageMode", "data")
+    this.postMessage({
+      type: "imageModeLoaded",
+      mode,
     })
   }
 

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -224,6 +224,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.slimEditMetadata = options?.slimEditMetadata ?? true
 
     TelemetryProxy.getInstance().setProvider(this)
+
+    // Listen for imageMode setting changes and push to webview
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("kilo-code.new.attachments")) {
+        this.sendImageMode()
+      }
+    })
   }
 
   setRemoteService(service: RemoteStatusService): void {
@@ -2741,6 +2748,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         type: "imageSaved",
         id,
         filePath: uri.toString(),
+        mime,
       })
     } catch (err) {
       console.error("[Kilo New] KiloProvider: Failed to save image to temp:", err)

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -18,6 +18,7 @@ import { ProviderProvider, useProvider } from "./context/provider"
 import { ConfigProvider } from "./context/config"
 import { SessionProvider, useSession } from "./context/session"
 import { LanguageProvider } from "./context/language"
+import { ImageModeProvider } from "./context/ImageModeContext"
 import { ChatView } from "./components/chat"
 import { MarketplaceView } from "./components/marketplace"
 import { registerExpandedTaskTool } from "./components/chat/TaskToolExpanded"
@@ -285,11 +286,13 @@ const App: Component = () => {
                       <ProviderProvider>
                         <ConfigProvider>
                           <NotificationsProvider>
-                            <SessionProvider>
-                              <DataBridge>
-                                <AppContent />
-                              </DataBridge>
-                            </SessionProvider>
+                            <ImageModeProvider>
+                              <SessionProvider>
+                                <DataBridge>
+                                  <AppContent />
+                                </DataBridge>
+                              </SessionProvider>
+                            </ImageModeProvider>
                           </NotificationsProvider>
                         </ConfigProvider>
                       </ProviderProvider>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -15,6 +15,7 @@ import { useServer } from "../../context/server"
 import { useLanguage } from "../../context/language"
 import { useVSCode } from "../../context/vscode"
 import { useWorktreeMode } from "../../context/worktree-mode"
+import { useImageMode } from "../../context/ImageModeContext"
 import { ModelSelector } from "../shared/ModelSelector"
 import { ModeSwitcher } from "../shared/ModeSwitcher"
 import { ThinkingSelector } from "../shared/ThinkingSelector"
@@ -56,11 +57,25 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const language = useLanguage()
   const vscode = useVSCode()
   const worktree = useWorktreeMode()
+  const imageMode = useImageMode()
   const dialog = useDialog()
   const mention = useFileMention(vscode)
   const excluded = worktree ? new Set(["sessions"]) : undefined
   const slash = useSlashCommand(vscode, excluded)
-  const imageAttach = useImageAttachments()
+  const imageAttach = useImageAttachments({ imageMode: imageMode })
+
+  createEffect(() => {
+    const mode = imageMode()
+    imageAttach.replace([])
+  })
+
+  onCleanup(
+    vscode.onMessage((msg: any) => {
+      if (msg.type === "imageSaved") {
+        imageAttach.handleImageSaved(msg.id, msg.filePath)
+      }
+    }),
+  )
   imageAttach.setFilePathDropHandler((paths) => {
     const cwd = server.workspaceDirectory()
     const resolved = paths.map((p) => convertToMentionPath(p, cwd))

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -72,7 +72,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   onCleanup(
     vscode.onMessage((msg: any) => {
       if (msg.type === "imageSaved") {
-        imageAttach.handleImageSaved(msg.id, msg.filePath)
+        imageAttach.handleImageSaved(msg.id, msg.filePath, msg.mime)
       }
     }),
   )

--- a/packages/kilo-vscode/webview-ui/src/context/ImageModeContext.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/ImageModeContext.tsx
@@ -1,0 +1,49 @@
+/**
+ * ImageModeContext
+ * Provides the current image attachment mode setting ("data" or "path").
+ * "data" sends base64 data URLs, "path" sends file:// paths for MCP servers.
+ */
+
+import { createContext, useContext, createSignal, onCleanup, ParentComponent, createEffect } from "solid-js"
+import type { Accessor } from "solid-js"
+import { useVSCode } from "./vscode"
+import type { ExtensionMessage } from "../types/messages"
+
+export type ImageMode = "data" | "path"
+
+interface ImageModeContextValue {
+  imageMode: Accessor<ImageMode>
+}
+
+export const ImageModeContext = createContext<ImageModeContextValue>()
+
+export const ImageModeProvider: ParentComponent = (props) => {
+  const vscode = useVSCode()
+  const [imageMode, setImageMode] = createSignal<ImageMode>("data")
+
+  const unsubscribe = vscode.onMessage((message: ExtensionMessage) => {
+    if (message.type === "imageModeLoaded") {
+      setImageMode(message.mode)
+    }
+  })
+
+  onCleanup(unsubscribe)
+
+  vscode.postMessage({ type: "requestImageMode" })
+
+  const value: ImageModeContextValue = { imageMode }
+
+  return <ImageModeContext.Provider value={value}>{props.children}</ImageModeContext.Provider>
+}
+
+export function useImageModeContext(): ImageModeContextValue {
+  const context = useContext(ImageModeContext)
+  if (!context) {
+    throw new Error("useImageModeContext must be used within an ImageModeProvider")
+  }
+  return context
+}
+
+export function useImageMode(): Accessor<ImageMode> {
+  return useImageModeContext().imageMode
+}

--- a/packages/kilo-vscode/webview-ui/src/context/ImageModeContext.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/ImageModeContext.tsx
@@ -4,7 +4,7 @@
  * "data" sends base64 data URLs, "path" sends file:// paths for MCP servers.
  */
 
-import { createContext, useContext, createSignal, onCleanup, ParentComponent, createEffect } from "solid-js"
+import { createContext, useContext, createSignal, onCleanup, ParentComponent } from "solid-js"
 import type { Accessor } from "solid-js"
 import { useVSCode } from "./vscode"
 import type { ExtensionMessage } from "../types/messages"
@@ -29,6 +29,7 @@ export const ImageModeProvider: ParentComponent = (props) => {
 
   onCleanup(unsubscribe)
 
+  // Request initial value and listen for changes
   vscode.postMessage({ type: "requestImageMode" })
 
   const value: ImageModeContextValue = { imageMode }

--- a/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js"
+import { createSignal, type Accessor } from "solid-js"
 import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, isDragLeavingComponent } from "./image-attachments-utils"
 import { extractDropPaths } from "../utils/path-mentions"
 
@@ -12,18 +12,38 @@ export interface ImageAttachment {
 /** Callback for handling text/URI file path drops. */
 export type FilePathDropHandler = (paths: string[]) => void
 
-export function useImageAttachments() {
+export interface UseImageAttachmentsOptions {
+  imageMode?: Accessor<"data" | "path">
+}
+
+export function useImageAttachments(options: UseImageAttachmentsOptions = {}) {
   const [images, setImages] = createSignal<ImageAttachment[]>([])
   const [dragging, setDragging] = createSignal(false)
   let onFilePaths: FilePathDropHandler | undefined
 
-  /** Register a handler for file path drops (text/URI-list). */
-  const setFilePathDropHandler = (handler: FilePathDropHandler) => {
-    onFilePaths = handler
-  }
+  const getMode = () => options.imageMode?.() ?? "data"
 
   const add = (file: File) => {
     if (!isAcceptedImageType(file.type)) return
+    const mode = getMode()
+    if (mode === "path") {
+      const reader = new FileReader()
+      reader.onload = () => {
+        const dataUrl = reader.result as string
+        const base64 = dataUrl.split(",")[1]
+        if (!base64) return
+        const id = crypto.randomUUID()
+        window.vscode?.postMessage({
+          type: "saveImageToTemp",
+          id,
+          mime: file.type || "image/png",
+          base64,
+          filename: file.name || "image.png",
+        })
+      }
+      reader.readAsDataURL(file)
+      return
+    }
     const reader = new FileReader()
     reader.onload = () => {
       const attachment: ImageAttachment = {
@@ -35,6 +55,11 @@ export function useImageAttachments() {
       setImages((prev) => [...prev, attachment])
     }
     reader.readAsDataURL(file)
+  }
+
+  /** Register a handler for file path drops (text/URI-list). */
+  const setFilePathDropHandler = (handler: FilePathDropHandler) => {
+    onFilePaths = handler
   }
 
   const remove = (id: string) => {
@@ -59,8 +84,6 @@ export function useImageAttachments() {
   const handleDragOver = (event: DragEvent) => {
     const types = event.dataTransfer?.types
     if (!types) return
-    // Accept file drops and VS Code URI-list drops (explorer, editor tabs).
-    // Do NOT accept bare text/plain here — that would intercept normal text drags.
     const acceptable = types.includes("Files") || types.includes("application/vnd.code.uri-list")
     if (!acceptable) return
     event.preventDefault()
@@ -79,17 +102,25 @@ export function useImageAttachments() {
     const dt = event.dataTransfer
     if (!dt) return
 
-    // First: check for text/URI file path drops (VS Code explorer, editor tabs)
     const paths = extractDropPaths(dt)
     if (paths && paths.length > 0 && onFilePaths) {
       onFilePaths(paths)
       return
     }
 
-    // Second: fall through to image file drops
     const files = dt.files
     if (!files) return
     for (const file of Array.from(files)) add(file)
+  }
+
+  const handleImageSaved = (id: string, filePath: string) => {
+    const attachment: ImageAttachment = {
+      id,
+      filename: filePath.split("/").pop() || "image",
+      mime: "image/png",
+      dataUrl: `file://${filePath}`,
+    }
+    setImages((prev) => [...prev, attachment])
   }
 
   return {
@@ -104,5 +135,6 @@ export function useImageAttachments() {
     handleDragLeave,
     handleDrop,
     setFilePathDropHandler,
+    handleImageSaved,
   }
 }

--- a/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
@@ -113,12 +113,12 @@ export function useImageAttachments(options: UseImageAttachmentsOptions = {}) {
     for (const file of Array.from(files)) add(file)
   }
 
-  const handleImageSaved = (id: string, filePath: string) => {
+  const handleImageSaved = (id: string, filePath: string, mime: string) => {
     const attachment: ImageAttachment = {
       id,
       filename: filePath.split("/").pop() || "image",
-      mime: "image/png",
-      dataUrl: `file://${filePath}`,
+      mime: mime || "image/png",
+      dataUrl: filePath,
     }
     setImages((prev) => [...prev, attachment])
   }

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1441,6 +1441,8 @@ export type ExtensionMessage =
   | QuestionErrorMessage
   | BrowserSettingsLoadedMessage
   | ClaudeCompatSettingLoadedMessage
+  | ImageModeLoadedMessage
+  | ImageSavedMessage
   | ConfigLoadedMessage
   | ConfigUpdatedMessage
   | GlobalConfigLoadedMessage
@@ -1808,6 +1810,21 @@ export interface ClaudeCompatSettingLoadedMessage {
   enabled: boolean
 }
 
+export interface RequestImageModeMessage {
+  type: "requestImageMode"
+}
+
+export interface ImageModeLoadedMessage {
+  type: "imageModeLoaded"
+  mode: "data" | "path"
+}
+
+export interface ImageSavedMessage {
+  type: "imageSaved"
+  id: string
+  filePath: string
+}
+
 export interface RequestConfigMessage {
   type: "requestConfig"
 }
@@ -1932,6 +1949,14 @@ export interface RenameWorktreeRequest {
   type: "agentManager.renameWorktree"
   worktreeId: string
   label: string
+}
+
+export interface SaveImageToTempRequest {
+  type: "saveImageToTemp"
+  id: string
+  mime: string
+  base64: string
+  filename: string
 }
 
 export interface RequestRepoInfoMessage {
@@ -2374,6 +2399,7 @@ export type WebviewMessage =
   | RequestTimelineSettingMessage
   | RequestBrowserSettingsMessage
   | RequestClaudeCompatSettingMessage
+  | RequestImageModeMessage
   | RequestConfigMessage
   | RequestGlobalConfigMessage
   | UpdateConfigMessage
@@ -2468,6 +2494,7 @@ export type WebviewMessage =
   | ToggleSectionCollapsedRequest
   | MoveToSectionRequest
   | MoveSectionRequest
+  | SaveImageToTempRequest
 
 // ============================================
 // VS Code API type

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1823,6 +1823,7 @@ export interface ImageSavedMessage {
   type: "imageSaved"
   id: string
   filePath: string
+  mime: string
 }
 
 export interface RequestConfigMessage {


### PR DESCRIPTION
## Context

Add a configurable `kilo-code.new.attachments.imageMode` setting to control how attached images are sent to the CLI backend. When set to `"path"`, images are saved as temp files and sent as `file://` URLs instead of base64 data URLs. This enables smooth integration with MCP servers (like Z.AI image understanding) that expect file paths rather than raw image data.

## Implementation

The implementation adds a new VS Code configuration setting `attachments.imageMode` with two values:
- `"data"` (default): current behavior, sends `data:` URLs  
- `"path"`: saves images to temp files (`vscode.env.tempFilesStoragePath`) and sends `file://` URLs

**Flow for path mode:**
1. User pastes/drops an image
2. Webview sends `saveImageToTemp` message with base64 data
3. Extension saves to temp dir and responds with `imageSaved` containing `file://` path
4. Image is attached to message using the file path

Key changes:
- `KiloProvider.ts`: handles `saveImageToTemp` and `requestImageMode` messages
- `ImageModeContext.tsx`: new context for reactive image mode state
- `useImageAttachments.ts`: conditionally sends to temp or reads as dataURL based on mode
- `PromptInput.tsx`: listens for `imageSaved` messages to handle async path responses

## How to Test

1. Open VS Code with the extension in dev mode (`bun run extension`)
2. Paste a screenshot into the chat with default settings (should send base64)
3. Go to VS Code settings and set `kilo-code.new.attachments.imageMode` to `"path"`
4. Paste another screenshot — it should now be sent as a `file://` path
5. Verify the behavior differs based on the setting

## Get in Touch

Brightlyviryaa on [Kilo Code Discord](https://kilo.ai/discord)