### PR TITLE
fix(ci): prevent prerelease builds from clobbering stable release assets

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -311,7 +311,12 @@ if (Script.release) {
       archives.push(out) // kilocode_change
     }
   }
-  // kilocode_change start - use --clobber only for prereleases to prevent overwriting stable release assets
+  // kilocode_change start - log checksums for auditability and only clobber for prereleases
+  for (const archive of archives) {
+    const hasher = new Bun.CryptoHasher("sha256")
+    hasher.update(await Bun.file(archive).arrayBuffer())
+    console.log(`sha256 ${hasher.digest("hex")}  ${path.basename(archive)}`)
+  }
   const clobber = Script.preview ? ["--clobber"] : []
   await $`gh release upload v${Script.version} ${archives} ${clobber}`
   // kilocode_change end

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -312,10 +312,11 @@ if (Script.release) {
     }
   }
   // kilocode_change start - log checksums for auditability and only clobber for prereleases
+  console.log("\n=== release archive checksums (sha256) ===")
   for (const archive of archives) {
     const hasher = new Bun.CryptoHasher("sha256")
     hasher.update(await Bun.file(archive).arrayBuffer())
-    console.log(`sha256 ${hasher.digest("hex")}  ${path.basename(archive)}`)
+    console.log(`${hasher.digest("hex")}  ${path.basename(archive)}`)
   }
   const clobber = Script.preview ? ["--clobber"] : []
   await $`gh release upload v${Script.version} ${archives} ${clobber}`

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -311,10 +311,7 @@ if (Script.release) {
       archives.push(out) // kilocode_change
     }
   }
-  // kilocode_change start - use --clobber only for prereleases to prevent overwriting stable release assets
-  const clobber = Script.preview ? ["--clobber"] : []
-  await $`gh release upload v${Script.version} ${archives} ${clobber}`
-  // kilocode_change end
+  await $`gh release upload v${Script.version} ${archives} --clobber` // kilocode_change
 }
 
 export { binaries }

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -320,10 +320,9 @@ if (Script.release) {
   }
   // Only allow --clobber for drafts (fresh stable builds) and prereleases (retries).
   // Published stable releases reject overwrites to protect homebrew/AUR checksums.
-  const rel =
-    await $`gh release view v${Script.version} --json isPrerelease,isDraft --repo ${process.env.GH_REPO}`.json()
+  const rel = await $`gh release view v${Script.version} --json isPrerelease,isDraft`.json()
   const clobber = rel.isDraft || rel.isPrerelease ? ["--clobber"] : []
-  await $`gh release upload v${Script.version} ${archives} ${clobber} --repo ${process.env.GH_REPO}`
+  await $`gh release upload v${Script.version} ${archives} ${clobber}`
   // kilocode_change end
 }
 

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -311,7 +311,10 @@ if (Script.release) {
       archives.push(out) // kilocode_change
     }
   }
-  await $`gh release upload v${Script.version} ${archives} --clobber` // kilocode_change
+  // kilocode_change start - use --clobber only for prereleases to prevent overwriting stable release assets
+  const clobber = Script.preview ? ["--clobber"] : []
+  await $`gh release upload v${Script.version} ${archives} ${clobber}`
+  // kilocode_change end
 }
 
 export { binaries }

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -318,10 +318,12 @@ if (Script.release) {
     hasher.update(await Bun.file(archive).arrayBuffer())
     console.log(`${hasher.digest("hex")}  ${path.basename(archive)}`)
   }
-  // Verify the target release is actually a prerelease before allowing --clobber
-  const rel = await $`gh release view v${Script.version} --json isPrerelease,isDraft`.json()
-  const clobber = rel.isPrerelease || rel.isDraft ? ["--clobber"] : []
-  await $`gh release upload v${Script.version} ${archives} ${clobber}`
+  // Only allow --clobber for drafts (fresh stable builds) and prereleases (retries).
+  // Published stable releases reject overwrites to protect homebrew/AUR checksums.
+  const rel =
+    await $`gh release view v${Script.version} --json isPrerelease,isDraft --repo ${process.env.GH_REPO}`.json()
+  const clobber = rel.isDraft || rel.isPrerelease ? ["--clobber"] : []
+  await $`gh release upload v${Script.version} ${archives} ${clobber} --repo ${process.env.GH_REPO}`
   // kilocode_change end
 }
 

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -318,7 +318,9 @@ if (Script.release) {
     hasher.update(await Bun.file(archive).arrayBuffer())
     console.log(`${hasher.digest("hex")}  ${path.basename(archive)}`)
   }
-  const clobber = Script.preview ? ["--clobber"] : []
+  // Verify the target release is actually a prerelease before allowing --clobber
+  const rel = await $`gh release view v${Script.version} --json isPrerelease,isDraft`.json()
+  const clobber = rel.isPrerelease || rel.isDraft ? ["--clobber"] : []
   await $`gh release upload v${Script.version} ${archives} ${clobber}`
   // kilocode_change end
 }

--- a/script/version.ts
+++ b/script/version.ts
@@ -21,6 +21,16 @@ if (!Script.preview) {
   output.push(`tag=${release.tagName}`)
   // kilocode_change start - handle both beta and rc preview channels
 } else if (Script.channel === "beta" || Script.channel === "rc") {
+  // Safety check: abort if a stable (non-prerelease) release already exists for this version
+  const existing = await $`gh release view v${Script.version} --json tagName,isPrerelease --repo ${process.env.GH_REPO}`
+    .json()
+    .catch(() => null)
+  if (existing && !existing.isPrerelease) {
+    console.error(
+      `ERROR: stable release v${Script.version} already exists — refusing to create a prerelease with the same version`,
+    )
+    process.exit(1)
+  }
   await $`gh release create v${Script.version} -d --prerelease --title "v${Script.version}" --repo ${process.env.GH_REPO}`
   const release =
     await $`gh release view v${Script.version} --json tagName,databaseId --repo ${process.env.GH_REPO}`.json()

--- a/script/version.ts
+++ b/script/version.ts
@@ -21,14 +21,21 @@ if (!Script.preview) {
   output.push(`tag=${release.tagName}`)
   // kilocode_change start - handle both beta and rc preview channels
 } else if (Script.channel === "beta" || Script.channel === "rc") {
-  // Safety check: abort if a stable (non-prerelease) release already exists for this version
-  const existing = await $`gh release view v${Script.version} --json tagName,isPrerelease --repo ${process.env.GH_REPO}`
-    .json()
-    .catch(() => null)
-  if (existing && !existing.isPrerelease) {
-    console.error(
-      `ERROR: stable release v${Script.version} already exists — refusing to create a prerelease with the same version`,
-    )
+  // Safety check: abort if a stable (non-prerelease) release already exists for this version.
+  // Fail closed: only treat "not found" (exit code 1 with "release not found") as safe to proceed.
+  const check = await $`gh release view v${Script.version} --json tagName,isPrerelease --repo ${process.env.GH_REPO}`
+    .quiet()
+    .nothrow()
+  if (check.exitCode === 0) {
+    const existing = JSON.parse(check.stdout.toString())
+    if (!existing.isPrerelease) {
+      console.error(
+        `ERROR: stable release v${Script.version} already exists — refusing to create a prerelease with the same version`,
+      )
+      process.exit(1)
+    }
+  } else if (!check.stderr.toString().includes("release not found")) {
+    console.error(`ERROR: failed to check existing release for v${Script.version}: ${check.stderr}`)
     process.exit(1)
   }
   await $`gh release create v${Script.version} -d --prerelease --title "v${Script.version}" --repo ${process.env.GH_REPO}`


### PR DESCRIPTION
## Summary

Fixes #8796 — `brew install Kilo-Org/tap/kilo` was failing with a checksum mismatch because a prerelease publish run overwrote the v7.2.1 stable release binaries with `--clobber`.

**Root cause**: When the prerelease workflow computed a version that collided with an existing stable release (due to npm registry lag in `fetchHighest()`), `gh release upload --clobber` silently replaced the stable assets. The homebrew formula still had the original checksums.

**Fixes**:
1. `build.ts`: Only use `--clobber` for prerelease uploads. Stable releases will now fail-fast if assets already exist rather than silently overwriting them.
2. `version.ts`: Add a safety check that aborts the workflow if a stable (non-prerelease) GitHub release already exists for the computed version.

**Additionally**: The homebrew-tap formula has been updated directly to fix the immediate user-facing issue (commit pushed to `Kilo-Org/homebrew-tap`).
