### PR TITLE
fix(vscode): truncate tab title to 50 chars when running Kilo in editor tab

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -16,6 +16,7 @@ import type { EditorContext } from "./services/cli-backend/types"
 import { FileIgnoreController } from "./services/autocomplete/shims/FileIgnoreController"
 import { ChatTextAreaAutocomplete } from "./services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete"
 import { buildWebviewHtml } from "./utils"
+import { EXTENSION_DISPLAY_NAME } from "./constants"
 import { TelemetryProxy, type TelemetryPropertiesProvider } from "./services/telemetry"
 import {
   sessionToWebview,
@@ -230,6 +231,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private diffVirtualProvider: import("./DiffVirtualProvider").DiffVirtualProvider | undefined
   private remoteService: RemoteStatusService | null = null
   private unsubscribeRemote: (() => void) | null = null
+  /** Panel reference for editor tab instances — used to update the tab title. */
+  private panel: vscode.WebviewPanel | null = null
 
   constructor(
     private readonly extensionUri: vscode.Uri,
@@ -422,6 +425,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // WebviewPanel can be restored/reloaded; ensure we don't treat it as ready prematurely.
     this.isWebviewReady = false
     this.webview = panel.webview
+    this.panel = panel
 
     panel.webview.options = {
       enableScripts: true,
@@ -438,6 +442,20 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.initializeConnection()
   }
 
+  private static readonly MAX_TAB_TITLE = 50
+
+  /** Update the VS Code editor tab title from the current session title, truncated. */
+  private updatePanelTitle(): void {
+    if (!this.panel) return
+    const title = this.currentSession?.title
+    if (!title || /^(New|Child) session - \d{4}-/.test(title)) {
+      this.panel.title = EXTENSION_DISPLAY_NAME
+      return
+    }
+    this.panel.title =
+      title.length > KiloProvider.MAX_TAB_TITLE ? title.substring(0, KiloProvider.MAX_TAB_TITLE - 1) + "…" : title
+  }
+
   /**
    * Register a session created externally (e.g., worktree sessions from AgentManagerProvider).
    * Sets currentSession, adds to trackedSessionIds, and notifies the webview.
@@ -446,6 +464,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.currentSession = session
     this.contextSessionID = session.id
     this.trackedSessionIds.add(session.id)
+    this.updatePanelTitle()
     this.postMessage({
       type: "sessionCreated",
       session: this.sessionToWebview(session),
@@ -645,6 +664,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "clearSession":
           this.contextSessionID = this.currentSession?.id ?? this.contextSessionID
           this.currentSession = null
+          this.updatePanelTitle()
           this.focusSession()
           break
         case "loadMessages":
@@ -1274,6 +1294,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.contextSessionID = session.id
       this.trackDirectory(session.id, workspaceDir)
       this.trackedSessionIds.add(session.id)
+      this.updatePanelTitle()
 
       // Notify webview of the new session
       this.postMessage({
@@ -1298,6 +1319,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         if (r.data && !signal?.aborted) {
           this.currentSession = r.data
           this.contextSessionID = r.data.id
+          this.updatePanelTitle()
         }
       })
       .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: getSession failed (non-critical):", e))
@@ -1537,6 +1559,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.connectionService.pruneSession(sessionID)
       if (this.currentSession?.id === sessionID) {
         this.currentSession = null
+        this.updatePanelTitle()
         this.focusSession(undefined)
       }
       this.postMessage({ type: "sessionDeleted", sessionID })
@@ -1566,6 +1589,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       )
       if (this.currentSession?.id === sessionID) {
         this.currentSession = updated
+        this.updatePanelTitle()
       }
       this.postMessage({ type: "sessionUpdated", session: this.sessionToWebview(updated) })
     } catch (error) {
@@ -2320,6 +2344,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.contextSessionID = session.id
       this.trackDirectory(session.id, dir)
       this.trackedSessionIds.add(session.id)
+      this.updatePanelTitle()
       if (draftID) this.contextSessionID = session.id
       this.postMessage({
         type: "sessionCreated",
@@ -2967,10 +2992,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.currentSession = event.properties.info
       this.contextSessionID = event.properties.info.id
       this.trackedSessionIds.add(event.properties.info.id)
+      this.updatePanelTitle()
     }
     if (event.type === "session.updated" && this.currentSession?.id === event.properties.info.id) {
       this.currentSession = event.properties.info
       this.contextSessionID = event.properties.info.id
+      this.updatePanelTitle()
     }
 
     // Auto-adopt child sessions as soon as the task tool part reveals their ID.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -16,7 +16,7 @@ import type { EditorContext } from "./services/cli-backend/types"
 import { FileIgnoreController } from "./services/autocomplete/shims/FileIgnoreController"
 import { ChatTextAreaAutocomplete } from "./services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete"
 import { buildWebviewHtml } from "./utils"
-import { EXTENSION_DISPLAY_NAME } from "./constants"
+import { panelTitle } from "./kilo-provider/tab-title"
 import { TelemetryProxy, type TelemetryPropertiesProvider } from "./services/telemetry"
 import {
   sessionToWebview,
@@ -442,18 +442,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.initializeConnection()
   }
 
-  private static readonly MAX_TAB_TITLE = 50
-
-  /** Update the VS Code editor tab title from the current session title, truncated. */
   private updatePanelTitle(): void {
     if (!this.panel) return
-    const title = this.currentSession?.title
-    if (!title || /^(New|Child) session - \d{4}-/.test(title)) {
-      this.panel.title = EXTENSION_DISPLAY_NAME
-      return
-    }
-    this.panel.title =
-      title.length > KiloProvider.MAX_TAB_TITLE ? title.substring(0, KiloProvider.MAX_TAB_TITLE - 1) + "…" : title
+    this.panel.title = panelTitle(this.currentSession?.title)
   }
 
   /**

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -15,8 +15,8 @@ import { type KiloConnectionService, type KilocodeNotification, ServerStartupErr
 import type { EditorContext } from "./services/cli-backend/types"
 import { FileIgnoreController } from "./services/autocomplete/shims/FileIgnoreController"
 import { ChatTextAreaAutocomplete } from "./services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete"
-import { buildWebviewHtml } from "./utils"
 import { panelTitle } from "./kilo-provider/tab-title"
+import { webviewHtml } from "./kilo-provider/webview-html"
 import { TelemetryProxy, type TelemetryPropertiesProvider } from "./services/telemetry"
 import {
   sessionToWebview,
@@ -392,19 +392,18 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     _context: vscode.WebviewViewResolveContext,
     _token: vscode.CancellationToken,
   ) {
-    // Store the webview references
     this.isWebviewReady = false
     this.webview = webviewView.webview
-
-    // Set up webview options
     webviewView.webview.options = {
       enableScripts: true,
       localResourceRoots: [this.extensionUri],
     }
-
-    webviewView.webview.html = this._getHtmlForWebview(webviewView.webview)
+    webviewView.webview.html = webviewHtml(
+      webviewView.webview,
+      this.extensionUri,
+      this.connectionService.getServerInfo()?.port,
+    )
     this.setupWebviewMessageHandler(webviewView.webview)
-
     vscode.commands.executeCommand("setContext", "kilo-code.new.sidebarVisible", webviewView.visible)
     this.visibilityDisposable?.dispose()
     this.visibilityDisposable = webviewView.onDidChangeVisibility(() => {
@@ -418,22 +417,15 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.initializeConnection()
   }
 
-  /**
-   * Resolve a WebviewPanel for displaying the Kilo webview in an editor tab.
-   */
   public resolveWebviewPanel(panel: vscode.WebviewPanel): void {
-    // WebviewPanel can be restored/reloaded; ensure we don't treat it as ready prematurely.
     this.isWebviewReady = false
     this.webview = panel.webview
     this.panel = panel
-
     panel.webview.options = {
       enableScripts: true,
       localResourceRoots: [this.extensionUri],
     }
-
-    panel.webview.html = this._getHtmlForWebview(panel.webview)
-
+    panel.webview.html = webviewHtml(panel.webview, this.extensionUri, this.connectionService.getServerInfo()?.port)
     this.setupWebviewMessageHandler(panel.webview)
     this.viewStateDisposable?.dispose()
     this.viewStateDisposable = panel.onDidChangeViewState(() =>
@@ -3254,17 +3246,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
   private getProjectDirectory(sessionId?: string): string | undefined {
     return resolveProjectDirectory(this.projectDirectory, () => this.getWorkspaceDirectory(sessionId))
-  }
-
-  private _getHtmlForWebview(webview: vscode.Webview): string {
-    return buildWebviewHtml(webview, {
-      scriptUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "webview.js")),
-      styleUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "webview.css")),
-      iconsBaseUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "assets", "icons")),
-      title: "Kilo Code",
-      port: this.connectionService.getServerInfo()?.port,
-      extraStyles: `.container { height: 100%; display: flex; flex-direction: column; height: 100vh; border-right: 1px solid var(--border-weak-base); }`,
-    })
   }
 
   // legacy-migration start -------------------------------------------------------

--- a/packages/kilo-vscode/src/kilo-provider/tab-title.ts
+++ b/packages/kilo-vscode/src/kilo-provider/tab-title.ts
@@ -1,0 +1,9 @@
+import { EXTENSION_DISPLAY_NAME } from "../constants"
+
+const MAX = 50
+
+export function panelTitle(title?: string): string {
+  if (!title || /^(New|Child) session - \d{4}-/.test(title)) return EXTENSION_DISPLAY_NAME
+  if (title.length <= MAX) return title
+  return title.substring(0, MAX - 1) + "…"
+}

--- a/packages/kilo-vscode/src/kilo-provider/webview-html.ts
+++ b/packages/kilo-vscode/src/kilo-provider/webview-html.ts
@@ -1,0 +1,13 @@
+import * as vscode from "vscode"
+import { buildWebviewHtml } from "../utils"
+
+export function webviewHtml(webview: vscode.Webview, uri: vscode.Uri, port?: number): string {
+  return buildWebviewHtml(webview, {
+    scriptUri: webview.asWebviewUri(vscode.Uri.joinPath(uri, "dist", "webview.js")),
+    styleUri: webview.asWebviewUri(vscode.Uri.joinPath(uri, "dist", "webview.css")),
+    iconsBaseUri: webview.asWebviewUri(vscode.Uri.joinPath(uri, "assets", "icons")),
+    title: "Kilo Code",
+    port,
+    extraStyles: `.container { height: 100%; display: flex; flex-direction: column; height: 100vh; border-right: 1px solid var(--border-weak-base); }`,
+  })
+}


### PR DESCRIPTION
## Summary

- Dynamically updates the VS Code editor tab title from the session title when running Kilo in a tab (not sidebar or agent manager), capped at 50 characters with ellipsis to prevent excessively wide tabs
- Falls back to "Kilo Code" when no meaningful session title exists (new/child sessions with default timestamp titles)

Closes #8817

---

Replaces #8824

<img width="2148" height="976" alt="CleanShot 2026-04-20 at 16 37 47@2x" src="https://github.com/user-attachments/assets/05238153-b0eb-4aaa-ab72-495d03896c31" />
