### PR TITLE
fix(vscode): singular/plural for aggregated session tooltip label

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -48,7 +48,9 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
     const items = breakdown()
     if (items.length <= 1) return <span>{language.t("context.usage.sessionCost")}</span>
     const collapsed = collapseCostBreakdown(items, (n) =>
-      language.t("context.usage.olderSessions", { count: String(n) }),
+      n === 1
+        ? language.t("context.usage.olderSessions_one", { count: String(n) })
+        : language.t("context.usage.olderSessions_other", { count: String(n) }),
     )
     return (
       <div style={{ "text-align": "left", "white-space": "nowrap" }}>

--- a/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
@@ -154,9 +154,11 @@ const VISIBLE_CHILDREN = 8
 /**
  * Collapse a cost breakdown for display in the tooltip.
  * - The root entry (first item) always stays at the top.
- * - Child entries are shown in reverse order (most recent first).
+ * - Child entries are shown in reverse discovery order (approximately
+ *   newest-first for direct children; nested subagents may appear
+ *   out of strict chronological order).
  * - When there are more than VISIBLE_CHILDREN child entries, the
- *   oldest are aggregated into a single summary line.
+ *   tail entries are aggregated into a single summary line.
  *
  * Pure function — no store dependency.
  */

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -947,7 +947,8 @@ export const dict = {
   "prompt.placeholder.default": "اكتب رسالة... (Enter للإرسال، Shift+Enter لسطر جديد)",
 
   "context.usage.sessionCost": "تكلفة الجلسة",
-  "context.usage.olderSessions": "{{count}} جلسات أقدم",
+  "context.usage.olderSessions_one": "{{count}} جلسة أقدم",
+  "context.usage.olderSessions_other": "{{count}} جلسات أقدم",
   "context.stats.thisSession": "هذه الجلسة",
 
   "time.justNow": "الآن",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -955,7 +955,8 @@ export const dict = {
   "prompt.placeholder.default": "Digite uma mensagem... (Enter para enviar, Shift+Enter para nova linha)",
 
   "context.usage.sessionCost": "Custo da sessão",
-  "context.usage.olderSessions": "{{count}} sessões anteriores",
+  "context.usage.olderSessions_one": "{{count}} sessão anterior",
+  "context.usage.olderSessions_other": "{{count}} sessões anteriores",
   "context.stats.thisSession": "Esta sessão",
 
   "time.justNow": "agora mesmo",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -960,7 +960,8 @@ export const dict = {
   "prompt.placeholder.default": "Unesite poruku... (Enter za slanje, Shift+Enter za novi red)",
 
   "context.usage.sessionCost": "Cijena sesije",
-  "context.usage.olderSessions": "{{count}} starijih sesija",
+  "context.usage.olderSessions_one": "{{count}} starija sesija",
+  "context.usage.olderSessions_other": "{{count}} starijih sesija",
   "context.stats.thisSession": "Ova sesija",
 
   "time.justNow": "upravo sada",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -953,7 +953,8 @@ export const dict = {
   "prompt.placeholder.default": "Skriv en besked... (Enter for at sende, Shift+Enter for ny linje)",
 
   "context.usage.sessionCost": "Sessionsomkostning",
-  "context.usage.olderSessions": "{{count}} ældre sessioner",
+  "context.usage.olderSessions_one": "{{count}} ældre session",
+  "context.usage.olderSessions_other": "{{count}} ældre sessioner",
   "context.stats.thisSession": "Denne session",
 
   "time.justNow": "lige nu",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -966,7 +966,8 @@ export const dict = {
   "prompt.placeholder.default": "Nachricht eingeben... (Enter zum Senden, Shift+Enter für neue Zeile)",
 
   "context.usage.sessionCost": "Sitzungskosten",
-  "context.usage.olderSessions": "{{count}} ältere Sitzungen",
+  "context.usage.olderSessions_one": "{{count}} ältere Sitzung",
+  "context.usage.olderSessions_other": "{{count}} ältere Sitzungen",
   "context.stats.thisSession": "Diese Sitzung",
 
   "time.justNow": "gerade eben",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -953,7 +953,8 @@ export const dict = {
   "prompt.placeholder.error": "Connection failed. Check the output panel or restart the extension.",
 
   "context.usage.sessionCost": "Session cost",
-  "context.usage.olderSessions": "{{count}} older sessions",
+  "context.usage.olderSessions_one": "{{count}} older session",
+  "context.usage.olderSessions_other": "{{count}} older sessions",
   "context.stats.thisSession": "This session",
 
   "time.justNow": "just now",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -961,7 +961,8 @@ export const dict = {
   "prompt.placeholder.default": "Escribe un mensaje... (Enter para enviar, Shift+Enter para nueva línea)",
 
   "context.usage.sessionCost": "Coste de la sesión",
-  "context.usage.olderSessions": "{{count}} sesiones anteriores",
+  "context.usage.olderSessions_one": "{{count}} sesión anterior",
+  "context.usage.olderSessions_other": "{{count}} sesiones anteriores",
   "context.stats.thisSession": "Esta sesión",
 
   "time.justNow": "justo ahora",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -967,7 +967,8 @@ export const dict = {
   "prompt.placeholder.default": "Tapez un message... (Entrée pour envoyer, Maj+Entrée pour un saut de ligne)",
 
   "context.usage.sessionCost": "Coût de la session",
-  "context.usage.olderSessions": "{{count}} sessions précédentes",
+  "context.usage.olderSessions_one": "{{count}} session précédente",
+  "context.usage.olderSessions_other": "{{count}} sessions précédentes",
   "context.stats.thisSession": "Cette session",
 
   "time.justNow": "à l'instant",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -952,7 +952,8 @@ export const dict = {
   "prompt.placeholder.default": "メッセージを入力... (Enterで送信、Shift+Enterで改行)",
 
   "context.usage.sessionCost": "セッションコスト",
-  "context.usage.olderSessions": "{{count}} 件の古いセッション",
+  "context.usage.olderSessions_one": "{{count}} 件の古いセッション",
+  "context.usage.olderSessions_other": "{{count}} 件の古いセッション",
   "context.stats.thisSession": "このセッション",
 
   "time.justNow": "たった今",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -952,7 +952,8 @@ export const dict = {
   "prompt.placeholder.default": "메시지를 입력하세요... (Enter로 전송, Shift+Enter로 줄 바꿈)",
 
   "context.usage.sessionCost": "세션 비용",
-  "context.usage.olderSessions": "{{count}}개의 이전 세션",
+  "context.usage.olderSessions_one": "{{count}}개의 이전 세션",
+  "context.usage.olderSessions_other": "{{count}}개의 이전 세션",
   "context.stats.thisSession": "이 세션",
 
   "time.justNow": "방금",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -954,7 +954,8 @@ export const dict = {
   "prompt.placeholder.error": "Verbinding mislukt. Controleer het uitvoerpaneel of herstart de extensie.",
 
   "context.usage.sessionCost": "Sessiekosten",
-  "context.usage.olderSessions": "{{count}} oudere sessies",
+  "context.usage.olderSessions_one": "{{count}} oudere sessie",
+  "context.usage.olderSessions_other": "{{count}} oudere sessies",
   "context.stats.thisSession": "Deze sessie",
 
   "time.justNow": "zojuist",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -957,7 +957,8 @@ export const dict = {
   "prompt.placeholder.default": "Skriv en melding... (Enter for å sende, Shift+Enter for ny linje)",
 
   "context.usage.sessionCost": "Sesjonskostnad",
-  "context.usage.olderSessions": "{{count}} eldre sesjoner",
+  "context.usage.olderSessions_one": "{{count}} eldre sesjon",
+  "context.usage.olderSessions_other": "{{count}} eldre sesjoner",
   "context.stats.thisSession": "Denne sesjonen",
 
   "time.justNow": "akkurat nå",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -957,7 +957,8 @@ export const dict = {
   "prompt.placeholder.default": "Wpisz wiadomość... (Enter, aby wysłać, Shift+Enter dla nowej linii)",
 
   "context.usage.sessionCost": "Koszt sesji",
-  "context.usage.olderSessions": "{{count}} starszych sesji",
+  "context.usage.olderSessions_one": "{{count}} starsza sesja",
+  "context.usage.olderSessions_other": "{{count}} starszych sesji",
   "context.stats.thisSession": "Ta sesja",
 
   "time.justNow": "przed chwilą",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -960,7 +960,8 @@ export const dict = {
   "prompt.placeholder.default": "Введите сообщение... (Enter для отправки, Shift+Enter для новой строки)",
 
   "context.usage.sessionCost": "Стоимость сессии",
-  "context.usage.olderSessions": "{{count}} предыдущих сессий",
+  "context.usage.olderSessions_one": "{{count}} предыдущая сессия",
+  "context.usage.olderSessions_other": "{{count}} предыдущих сессий",
   "context.stats.thisSession": "Эта сессия",
 
   "time.justNow": "только что",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -948,7 +948,8 @@ export const dict = {
   "prompt.placeholder.default": "พิมพ์ข้อความ... (Enter เพื่อส่ง, Shift+Enter เพื่อขึ้นบรรทัดใหม่)",
 
   "context.usage.sessionCost": "ค่าใช้จ่ายเซสชัน",
-  "context.usage.olderSessions": "{{count}} เซสชันก่อนหน้า",
+  "context.usage.olderSessions_one": "{{count}} เซสชันก่อนหน้า",
+  "context.usage.olderSessions_other": "{{count}} เซสชันก่อนหน้า",
   "context.stats.thisSession": "เซสชันนี้",
 
   "time.justNow": "เมื่อสักครู่",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -956,7 +956,8 @@ export const dict = {
   "prompt.placeholder.error": "Bağlantı başarısız. Çıktı panelini kontrol edin veya uzantıyı yeniden başlatın.",
 
   "context.usage.sessionCost": "Oturum maliyeti",
-  "context.usage.olderSessions": "{{count}} eski oturum",
+  "context.usage.olderSessions_one": "{{count}} eski oturum",
+  "context.usage.olderSessions_other": "{{count}} eski oturum",
   "context.stats.thisSession": "Bu oturum",
 
   "time.justNow": "az önce",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -957,7 +957,8 @@ export const dict = {
   "prompt.placeholder.error": "Підключення не вдалося. Перевірте панель виводу або перезапустіть розширення.",
 
   "context.usage.sessionCost": "Вартість сесії",
-  "context.usage.olderSessions": "{{count}} старіших сесій",
+  "context.usage.olderSessions_one": "{{count}} старіша сесія",
+  "context.usage.olderSessions_other": "{{count}} старіших сесій",
   "context.stats.thisSession": "Ця сесія",
 
   "time.justNow": "щойно",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -940,7 +940,8 @@ export const dict = {
   "prompt.placeholder.default": "输入消息... (Enter 发送，Shift+Enter 换行)",
 
   "context.usage.sessionCost": "会话费用",
-  "context.usage.olderSessions": "{{count}} 个较早的会话",
+  "context.usage.olderSessions_one": "{{count}} 个较早的会话",
+  "context.usage.olderSessions_other": "{{count}} 个较早的会话",
   "context.stats.thisSession": "此会话",
 
   "time.justNow": "刚刚",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -942,7 +942,8 @@ export const dict = {
   "prompt.placeholder.default": "輸入訊息... (Enter 送出，Shift+Enter 換行)",
 
   "context.usage.sessionCost": "工作階段費用",
-  "context.usage.olderSessions": "{{count}} 個較早的工作階段",
+  "context.usage.olderSessions_one": "{{count}} 個較早的工作階段",
+  "context.usage.olderSessions_other": "{{count}} 個較早的工作階段",
   "context.stats.thisSession": "此工作階段",
 
   "time.justNow": "剛剛",


### PR DESCRIPTION
## Summary

Addresses review comments from #8822:
- Fixes singular/plural for the aggregated session label — "1 older session" instead of "1 older sessions" when exactly 9 children trigger aggregation
- Updates docstring to accurately describe that reverse order is discovery-based, not strictly chronological for nested subagents
