### PR TITLE
Add configurable system prompt overrides

### DIFF
--- a/packages/kilo-vscode/tests/unit/settings-io.test.ts
+++ b/packages/kilo-vscode/tests/unit/settings-io.test.ts
@@ -88,6 +88,11 @@ describe("buildExport", () => {
     expect(result.share).toBe("manual")
   })
 
+  it("preserves null system_prompt so exports can clear overrides", () => {
+    const result = buildExport({ system_prompt: null })
+    expect(result.system_prompt).toBeNull()
+  })
+
   it("handles empty config", () => {
     const result = buildExport({})
     expect(result._meta).toBeDefined()

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -963,6 +963,36 @@ const AgentBehaviourTab: Component = () => {
         {language.t("settings.agentBehaviour.rules.description")}
       </div>
 
+      <Card style={{ "margin-bottom": "16px" }}>
+        <div data-slot="settings-row-label-title" style={{ "margin-bottom": "8px" }}>
+          {language.t("settings.agentBehaviour.systemPrompt.title")}
+        </div>
+        <div data-slot="settings-row-label-subtitle" style={{ "margin-bottom": "8px" }}>
+          {language.t("settings.agentBehaviour.systemPrompt.description")}
+        </div>
+        <div
+          style={{
+            "font-size": "12px",
+            color: config().system_prompt
+              ? "var(--text-success-base, var(--vscode-testing-iconPassed))"
+              : "var(--text-weak-base, var(--vscode-descriptionForeground))",
+            "margin-bottom": "8px",
+          }}
+        >
+          {language.t(
+            config().system_prompt
+              ? "settings.agentBehaviour.systemPrompt.statusCustom"
+              : "settings.agentBehaviour.systemPrompt.statusDefault",
+          )}
+        </div>
+        <TextField
+          value={config().system_prompt ?? ""}
+          placeholder={language.t("settings.agentBehaviour.systemPrompt.placeholder")}
+          multiline
+          onChange={(val) => updateConfig({ system_prompt: val || null })}
+        />
+      </Card>
+
       <Card>
         <div
           style={{

--- a/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
@@ -25,6 +25,7 @@ export const KNOWN_KEYS: ReadonlyArray<string> = [
   "remote_control",
   "share",
   "username",
+  "system_prompt",
   "watcher",
   "formatter",
   "lsp",

--- a/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
@@ -63,7 +63,8 @@ export function buildExport(cfg: Config): Record<string, unknown> {
   const out: Record<string, unknown> = { _meta: meta }
 
   for (const [key, value] of Object.entries(cfg)) {
-    if (value === undefined || value === null) continue
+    if (value === undefined) continue
+    if (value === null && key !== "system_prompt") continue
     out[key] = value
   }
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1165,6 +1165,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "إزالة",
   "settings.agentBehaviour.rules.description":
     "القواعد هي ملفات تعليمات توجه سلوك الوكيل. يتم تضمينها في موجه النظام لكل محادثة. أضف مسارات الملفات أدناه لتضمين قواعد إضافية.",
+  "settings.agentBehaviour.systemPrompt.title": "تجاوز مطالبة النظام",
+  "settings.agentBehaviour.systemPrompt.description":
+    "استبدل مطالبة النظام الأساسية الافتراضية في Kilo لكل محادثة. اتركه فارغًا للإبقاء على المطالبة الافتراضية.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "مطالبة النظام الافتراضية في Kilo نشطة.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "تجاوز مطالبة النظام المخصصة نشط.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "أدخل مطالبة نظام مخصصة...",
   "settings.agentBehaviour.instructionFiles": "ملفات تعليمات إضافية",
   "settings.agentBehaviour.instructionFiles.description": "مسارات ملفات التعليمات الإضافية في موجه النظام",
   "settings.agentBehaviour.claudeCompat.heading": "توافق Claude Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1185,6 +1185,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Remover",
   "settings.agentBehaviour.rules.description":
     "Regras são arquivos de instrução que orientam o comportamento do agente. Elas são incluídas no prompt do sistema para cada conversa. Adicione caminhos de arquivos abaixo para incluir regras adicionais.",
+  "settings.agentBehaviour.systemPrompt.title": "Substituição do Prompt do Sistema",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Substitua o prompt de sistema principal padrão do Kilo para todas as conversas. Deixe em branco para manter o prompt padrão.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "O prompt de sistema padrão do Kilo está ativo.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "A substituição personalizada do prompt do sistema está ativa.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Insira um prompt de sistema personalizado...",
   "settings.agentBehaviour.instructionFiles": "Arquivos de instruções adicionais",
   "settings.agentBehaviour.instructionFiles.description":
     "Caminhos para arquivos de instruções adicionais no prompt do sistema",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1182,6 +1182,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Ukloni",
   "settings.agentBehaviour.rules.description":
     "Pravila su datoteke uputa koje usmjeravaju ponašanje agenta. Uključena su u sistemski prompt za svaki razgovor. Dodajte putanje datoteka ispod kako biste uključili dodatna pravila.",
+  "settings.agentBehaviour.systemPrompt.title": "Zamjena sistemskog prompta",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Zamijenite Kilov zadani osnovni sistemski prompt za svaki razgovor. Ostavite prazno da zadržite zadani prompt.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Zadani Kilo sistemski prompt je aktivan.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "Prilagođena zamjena sistemskog prompta je aktivna.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Unesite prilagođeni sistemski prompt...",
   "settings.agentBehaviour.instructionFiles": "Dodatne datoteke uputa",
   "settings.agentBehaviour.instructionFiles.description": "Putanje do dodatnih datoteka uputa u sistemskom promptu",
   "settings.agentBehaviour.claudeCompat.heading": "Claude Code kompatibilnost",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1175,6 +1175,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Fjern",
   "settings.agentBehaviour.rules.description":
     "Regler er instruktionsfiler, der styrer agentens adfærd. De inkluderes i systemprompten for hver samtale. Tilføj filstier nedenfor for at inkludere yderligere regler.",
+  "settings.agentBehaviour.systemPrompt.title": "Tilsidesættelse af systemprompt",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Erstat Kilos standardprompt for kernesystemet i hver samtale. Lad feltet stå tomt for at beholde standardprompten.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Kilos standard systemprompt er aktiv.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "Brugerdefineret tilsidesættelse af systemprompt er aktiv.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Indtast en brugerdefineret systemprompt...",
   "settings.agentBehaviour.instructionFiles": "Yderligere instruktionsfiler",
   "settings.agentBehaviour.instructionFiles.description": "Stier til yderligere instruktionsfiler i systemprompten",
   "settings.agentBehaviour.claudeCompat.heading": "Claude Code-kompatibilitet",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1198,6 +1198,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Entfernen",
   "settings.agentBehaviour.rules.description":
     "Regeln sind Anweisungsdateien, die das Verhalten des Agenten steuern. Sie werden in den System-Prompt für jede Konversation eingebunden. Fügen Sie unten Dateipfade hinzu, um zusätzliche Regeln einzubinden.",
+  "settings.agentBehaviour.systemPrompt.title": "System-Prompt überschreiben",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Ersetzt Kilos standardmäßigen Kern-System-Prompt für jede Unterhaltung. Leer lassen, um den Standard-Prompt beizubehalten.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Der standardmäßige Kilo-System-Prompt ist aktiv.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "Die benutzerdefinierte System-Prompt-Überschreibung ist aktiv.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Benutzerdefinierten System-Prompt eingeben...",
   "settings.agentBehaviour.instructionFiles": "Zusätzliche Anweisungsdateien",
   "settings.agentBehaviour.instructionFiles.description": "Pfade zu zusätzlichen Anweisungsdateien im System-Prompt",
   "settings.agentBehaviour.claudeCompat.heading": "Claude Code-Kompatibilität",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1118,6 +1118,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Remove",
   "settings.agentBehaviour.rules.description":
     "Rules are instruction files that guide agent behaviour. They are included in the system prompt for every conversation. Add file paths below to include additional rules.",
+  "settings.agentBehaviour.systemPrompt.title": "System Prompt Override",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Replace Kilo's default core system prompt for every conversation. Leave blank to keep the default prompt.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Default Kilo system prompt is active.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "Custom system prompt override is active.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Enter a custom system prompt...",
   "settings.agentBehaviour.instructionFiles": "Additional Instruction Files",
   "settings.agentBehaviour.instructionFiles.description":
     "Paths to additional instruction files that are included in the system prompt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1189,6 +1189,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Eliminar",
   "settings.agentBehaviour.rules.description":
     "Las reglas son archivos de instrucciones que guían el comportamiento del agente. Se incluyen en el prompt del sistema para cada conversación. Añada rutas de archivos a continuación para incluir reglas adicionales.",
+  "settings.agentBehaviour.systemPrompt.title": "Anulación del prompt del sistema",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Reemplaza el prompt principal del sistema predeterminado de Kilo para cada conversación. Déjalo en blanco para conservar el prompt predeterminado.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "El prompt del sistema predeterminado de Kilo está activo.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "La anulación personalizada del prompt del sistema está activa.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Introduce un prompt del sistema personalizado...",
   "settings.agentBehaviour.instructionFiles": "Archivos de instrucciones adicionales",
   "settings.agentBehaviour.instructionFiles.description":
     "Rutas a archivos de instrucciones adicionales incluidos en el prompt del sistema",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1202,6 +1202,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Supprimer",
   "settings.agentBehaviour.rules.description":
     "Les règles sont des fichiers d'instructions qui guident le comportement de l'agent. Elles sont incluses dans le prompt système pour chaque conversation. Ajoutez des chemins de fichiers ci-dessous pour inclure des règles supplémentaires.",
+  "settings.agentBehaviour.systemPrompt.title": "Remplacement du prompt système",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Remplace le prompt système principal par défaut de Kilo pour chaque conversation. Laissez vide pour conserver le prompt par défaut.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Le prompt système par défaut de Kilo est actif.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "Le remplacement personnalisé du prompt système est actif.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Saisissez un prompt système personnalisé...",
   "settings.agentBehaviour.instructionFiles": "Fichiers d'instructions supplémentaires",
   "settings.agentBehaviour.instructionFiles.description": "Chemins vers des fichiers d'instructions supplémentaires",
   "settings.agentBehaviour.claudeCompat.heading": "Compatibilité Claude Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1176,6 +1176,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "削除",
   "settings.agentBehaviour.rules.description":
     "ルールはエージェントの動作を導く指示ファイルです。すべての会話のシステムプロンプトに含まれます。追加のルールを含めるには、以下にファイルパスを追加してください。",
+  "settings.agentBehaviour.systemPrompt.title": "システムプロンプトの上書き",
+  "settings.agentBehaviour.systemPrompt.description":
+    "すべての会話で Kilo の既定のコアシステムプロンプトを置き換えます。既定のプロンプトを使う場合は空のままにします。",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Kilo の既定のシステムプロンプトが有効です。",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "カスタムシステムプロンプトの上書きが有効です。",
+  "settings.agentBehaviour.systemPrompt.placeholder": "カスタムシステムプロンプトを入力...",
   "settings.agentBehaviour.instructionFiles": "追加の指示ファイル",
   "settings.agentBehaviour.instructionFiles.description": "システムプロンプトに含まれる追加の指示ファイルへのパス",
   "settings.agentBehaviour.claudeCompat.heading": "Claude Code 互換性",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1170,6 +1170,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "제거",
   "settings.agentBehaviour.rules.description":
     "규칙은 에이전트 동작을 안내하는 지시 파일입니다. 모든 대화의 시스템 프롬프트에 포함됩니다. 추가 규칙을 포함하려면 아래에 파일 경로를 추가하세요.",
+  "settings.agentBehaviour.systemPrompt.title": "시스템 프롬프트 재정의",
+  "settings.agentBehaviour.systemPrompt.description":
+    "모든 대화에서 Kilo의 기본 핵심 시스템 프롬프트를 대체합니다. 기본 프롬프트를 유지하려면 비워 두세요.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Kilo 기본 시스템 프롬프트가 활성화되어 있습니다.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "사용자 지정 시스템 프롬프트 재정의가 활성화되어 있습니다.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "사용자 지정 시스템 프롬프트 입력...",
   "settings.agentBehaviour.instructionFiles": "추가 지시 파일",
   "settings.agentBehaviour.instructionFiles.description": "시스템 프롬프트에 포함되는 추가 지시 파일 경로",
   "settings.agentBehaviour.claudeCompat.heading": "Claude Code 호환성",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1136,6 +1136,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Verwijderen",
   "settings.agentBehaviour.rules.description":
     "Regels zijn instructiebestanden die het gedrag van de agent sturen. Ze worden opgenomen in de systeemprompt voor elk gesprek. Voeg hieronder bestandspaden toe om aanvullende regels op te nemen.",
+  "settings.agentBehaviour.systemPrompt.title": "Systeemprompt overschrijven",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Vervang Kilo's standaard kern-systeemprompt voor elk gesprek. Laat leeg om de standaardprompt te behouden.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "De standaard systeemprompt van Kilo is actief.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "De aangepaste systeemprompt-override is actief.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Voer een aangepaste systeemprompt in...",
   "settings.agentBehaviour.instructionFiles": "Aanvullende Instructiebestanden",
   "settings.agentBehaviour.instructionFiles.description":
     "Paden naar aanvullende instructiebestanden die zijn opgenomen in de systeem prompt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1178,6 +1178,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Fjern",
   "settings.agentBehaviour.rules.description":
     "Regler er instruksjonsfiler som styrer agentens atferd. De inkluderes i systemprompten for hver samtale. Legg til filstier nedenfor for å inkludere ekstra regler.",
+  "settings.agentBehaviour.systemPrompt.title": "Overstyr systemprompt",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Erstatt Kilos standard kjerne-systemprompt for hver samtale. La stå tomt for å beholde standardprompten.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Kilos standard systemprompt er aktiv.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "Egendefinert overstyring av systemprompt er aktiv.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Skriv inn en egendefinert systemprompt...",
   "settings.agentBehaviour.instructionFiles": "Ekstra instruksjonsfiler",
   "settings.agentBehaviour.instructionFiles.description": "Stier til ekstra instruksjonsfiler i systemprompten",
   "settings.agentBehaviour.claudeCompat.heading": "Claude Code-kompatibilitet",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1181,6 +1181,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Usuń",
   "settings.agentBehaviour.rules.description":
     "Reguły to pliki instrukcji, które kierują zachowaniem agenta. Są one dołączane do promptu systemowego dla każdej rozmowy. Dodaj poniżej ścieżki plików, aby dołączyć dodatkowe reguły.",
+  "settings.agentBehaviour.systemPrompt.title": "Nadpisanie promptu systemowego",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Zastąp domyślny główny prompt systemowy Kilo dla każdej rozmowy. Pozostaw puste, aby zachować domyślny prompt.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Domyślny prompt systemowy Kilo jest aktywny.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "Niestandardowe nadpisanie promptu systemowego jest aktywne.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Wpisz niestandardowy prompt systemowy...",
   "settings.agentBehaviour.instructionFiles": "Dodatkowe pliki instrukcji",
   "settings.agentBehaviour.instructionFiles.description":
     "Ścieżki do dodatkowych plików instrukcji w prompcie systemowym",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1183,6 +1183,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Удалить",
   "settings.agentBehaviour.rules.description":
     "Правила — это файлы инструкций, которые направляют поведение агента. Они включаются в системный промпт для каждого разговора. Добавьте пути к файлам ниже, чтобы включить дополнительные правила.",
+  "settings.agentBehaviour.systemPrompt.title": "Переопределение системного промпта",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Заменяет основной системный промпт Kilo по умолчанию для каждого разговора. Оставьте поле пустым, чтобы сохранить промпт по умолчанию.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Системный промпт Kilo по умолчанию активен.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "Пользовательское переопределение системного промпта активно.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Введите пользовательский системный промпт...",
   "settings.agentBehaviour.instructionFiles": "Дополнительные файлы инструкций",
   "settings.agentBehaviour.instructionFiles.description": "Пути к дополнительным файлам инструкций в системном промпте",
   "settings.agentBehaviour.claudeCompat.heading": "Совместимость с Claude Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1166,6 +1166,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "ลบ",
   "settings.agentBehaviour.rules.description":
     "กฎคือไฟล์คำสั่งที่แนะนำพฤติกรรมของเอเจนต์ กฎเหล่านี้จะถูกรวมอยู่ในพรอมต์ระบบสำหรับทุกการสนทนา เพิ่มเส้นทางไฟล์ด้านล่างเพื่อรวมกฎเพิ่มเติม",
+  "settings.agentBehaviour.systemPrompt.title": "แทนที่พรอมต์ระบบ",
+  "settings.agentBehaviour.systemPrompt.description":
+    "แทนที่พรอมต์ระบบหลักเริ่มต้นของ Kilo สำหรับทุกการสนทนา เว้นว่างไว้เพื่อใช้พรอมต์เริ่มต้นต่อไป",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "พรอมต์ระบบเริ่มต้นของ Kilo กำลังใช้งานอยู่",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "การแทนที่พรอมต์ระบบแบบกำหนดเองกำลังใช้งานอยู่",
+  "settings.agentBehaviour.systemPrompt.placeholder": "ป้อนพรอมต์ระบบแบบกำหนดเอง...",
   "settings.agentBehaviour.instructionFiles": "ไฟล์คำสั่งเพิ่มเติม",
   "settings.agentBehaviour.instructionFiles.description": "เส้นทางไฟล์คำสั่งเพิ่มเติมในพรอมต์ระบบ",
   "settings.agentBehaviour.claudeCompat.heading": "ความเข้ากันได้กับ Claude Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1132,6 +1132,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Kaldır",
   "settings.agentBehaviour.rules.description":
     "Kurallar, ajanın davranışını yönlendiren talimat dosyalarıdır. Her konuşma için sistem komutuna dahil edilirler. Ek kurallar eklemek için aşağıya dosya yolları ekleyin.",
+  "settings.agentBehaviour.systemPrompt.title": "Sistem Promptunu Geçersiz Kılma",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Her konuşma için Kilo'nun varsayılan çekirdek sistem promptunu değiştirin. Varsayılan promptu korumak için boş bırakın.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Varsayılan Kilo sistem promptu etkin.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "Özel sistem promptu geçersiz kılması etkin.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Özel bir sistem promptu girin...",
   "settings.agentBehaviour.instructionFiles": "Ek Talimat Dosyaları",
   "settings.agentBehaviour.instructionFiles.description":
     "Sistem komutuna dahil edilen ek talimat dosyalarının yolları",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1134,6 +1134,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "Видалити",
   "settings.agentBehaviour.rules.description":
     "Правила — це файли інструкцій, що спрямовують поведінку агента. Вони включаються до системного запиту для кожної розмови. Додайте шляхи до файлів нижче для додаткових правил.",
+  "settings.agentBehaviour.systemPrompt.title": "Перевизначення системного промпта",
+  "settings.agentBehaviour.systemPrompt.description":
+    "Замініть стандартний основний системний промпт Kilo для кожної розмови. Залиште порожнім, щоб зберегти стандартний промпт.",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Стандартний системний промпт Kilo активний.",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "Користувацьке перевизначення системного промпта активне.",
+  "settings.agentBehaviour.systemPrompt.placeholder": "Введіть користувацький системний промпт...",
   "settings.agentBehaviour.instructionFiles": "Додаткові файли інструкцій",
   "settings.agentBehaviour.instructionFiles.description":
     "Шляхи до додаткових файлів інструкцій, що включаються до системного запиту",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1148,6 +1148,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "移除",
   "settings.agentBehaviour.rules.description":
     "规则是指导代理行为的指令文件。它们会被包含在每次对话的系统提示词中。在下方添加文件路径以包含额外的规则。",
+  "settings.agentBehaviour.systemPrompt.title": "覆盖系统提示词",
+  "settings.agentBehaviour.systemPrompt.description":
+    "为每次对话替换 Kilo 的默认核心系统提示词。留空则保留默认提示词。",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Kilo 默认系统提示词已启用。",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "自定义系统提示词覆盖已启用。",
+  "settings.agentBehaviour.systemPrompt.placeholder": "输入自定义系统提示词...",
   "settings.agentBehaviour.instructionFiles": "附加指令文件",
   "settings.agentBehaviour.instructionFiles.description": "包含在系统提示词中的附加指令文件路径",
   "settings.agentBehaviour.claudeCompat.heading": "Claude Code 兼容性",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1152,6 +1152,12 @@ export const dict = {
   "settings.agentBehaviour.removeSkill.button": "移除",
   "settings.agentBehaviour.rules.description":
     "規則是引導代理行為的指令檔案。它們會被包含在每次對話的系統提示詞中。在下方新增檔案路徑以包含額外的規則。",
+  "settings.agentBehaviour.systemPrompt.title": "覆寫系統提示詞",
+  "settings.agentBehaviour.systemPrompt.description":
+    "為每次對話取代 Kilo 的預設核心系統提示詞。留空則保留預設提示詞。",
+  "settings.agentBehaviour.systemPrompt.statusDefault": "Kilo 預設系統提示詞已啟用。",
+  "settings.agentBehaviour.systemPrompt.statusCustom": "自訂系統提示詞覆寫已啟用。",
+  "settings.agentBehaviour.systemPrompt.placeholder": "輸入自訂系統提示詞...",
   "settings.agentBehaviour.instructionFiles": "附加指令檔案",
   "settings.agentBehaviour.instructionFiles.description": "包含在系統提示詞中的附加指令檔案路徑",
   "settings.agentBehaviour.claudeCompat.heading": "Claude Code 相容性",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -425,6 +425,7 @@ export interface Config {
   remote_control?: boolean
   share?: "manual" | "auto" | "disabled"
   username?: string
+  system_prompt?: string | null
   watcher?: WatcherConfig
   formatter?: false | Record<string, unknown>
   lsp?: false | Record<string, unknown>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1026,6 +1026,13 @@ export namespace Config {
         .string()
         .optional()
         .describe("Custom username to display in conversations instead of system username"),
+      // kilocode_change start - configurable core system prompt
+      system_prompt: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("Override Kilo's default core system prompt. Set to null to remove the override."),
+      // kilocode_change end
       mode: z
         .object({
           build: Agent.optional(),

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -115,14 +115,20 @@ export namespace LLM {
     // TODO: move this to a proper hook
     const isOpenaiOauth = provider.id === "openai" && auth?.type === "oauth"
 
+    // kilocode_change start - allow config to override Kilo default prompts
+    const custom = typeof cfg.system_prompt === "string"
+    const soul = custom ? cfg.system_prompt : SystemPrompt.soul()
+    const prompts = input.agent.prompt ? [input.agent.prompt] : custom ? [] : SystemPrompt.provider(input.model)
+    // kilocode_change end
+
     const system: string[] = []
     system.push(
       [
         // kilocode_change start - soul defines core identity and personality
-        ...(isOpenaiOauth ? [] : [SystemPrompt.soul()]),
+        ...(isOpenaiOauth ? [] : [soul]),
         // kilocode_change end
-        // use agent prompt otherwise provider prompt
-        ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
+        // use agent prompt, or provider prompt when no system prompt override is configured
+        ...prompts,
         // any custom prompt passed into this call
         ...input.system,
         // any custom prompt from last user message
@@ -161,8 +167,8 @@ export namespace LLM {
       mergeDeep(variant),
     )
     if (isOpenaiOauth) {
-      // kilocode_change start - prepend soul to instructions
-      options.instructions = SystemPrompt.soul() + "\n" + system.join("\n")
+      // kilocode_change start - prepend configurable soul to instructions
+      options.instructions = [soul, system.join("\n")].filter((x) => x).join("\n")
       // kilocode_change end
     }
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -124,11 +124,11 @@ export namespace LLM {
     const system: string[] = []
     system.push(
       [
-        // kilocode_change start - soul defines core identity and personality
+        // kilocode_change start - configurable core/default prompt selection
         ...(isOpenaiOauth ? [] : [soul]),
-        // kilocode_change end
         // use agent prompt, or provider prompt when no system prompt override is configured
         ...prompts,
+        // kilocode_change end
         // any custom prompt passed into this call
         ...input.system,
         // any custom prompt from last user message

--- a/packages/opencode/test/kilocode/system-prompt-override.test.ts
+++ b/packages/opencode/test/kilocode/system-prompt-override.test.ts
@@ -1,0 +1,306 @@
+import { expect, test } from "bun:test"
+import { rm } from "fs/promises"
+import path from "path"
+import type { ModelMessage } from "ai"
+import { LLM } from "../../src/session/llm"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { Auth } from "../../src/auth"
+import { Global } from "../../src/global"
+import type { Agent } from "../../src/agent/agent"
+import type { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { tmpdir } from "../fixture/fixture"
+
+type Body = Record<string, unknown> & {
+  instructions?: string
+  messages?: Array<{ role?: string; content?: string }>
+}
+
+type Fixture = {
+  models: Record<string, { id: string } & Record<string, unknown>>
+}
+
+function defer<T>() {
+  const result = {} as { promise: Promise<T>; resolve: (value: T) => void }
+  result.promise = new Promise((resolve) => {
+    result.resolve = resolve
+  })
+  return result
+}
+
+function chat(text: string) {
+  const data =
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl-system-prompt",
+        object: "chat.completion.chunk",
+        choices: [{ delta: { role: "assistant" } }],
+      })}`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl-system-prompt",
+        object: "chat.completion.chunk",
+        choices: [{ delta: { content: text } }],
+      })}`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl-system-prompt",
+        object: "chat.completion.chunk",
+        choices: [{ delta: {}, finish_reason: "stop" }],
+      })}`,
+      "data: [DONE]",
+    ].join("\n\n") + "\n\n"
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(data))
+      controller.close()
+    },
+  })
+}
+
+function responses(model: string) {
+  const data =
+    [
+      `data: ${JSON.stringify({
+        type: "response.created",
+        response: {
+          id: "resp-system-prompt",
+          created_at: Math.floor(Date.now() / 1000),
+          model,
+          service_tier: null,
+        },
+      })}`,
+      `data: ${JSON.stringify({
+        type: "response.output_text.delta",
+        item_id: "item-system-prompt",
+        delta: "ok",
+        logprobs: null,
+      })}`,
+      `data: ${JSON.stringify({
+        type: "response.completed",
+        response: {
+          incomplete_details: null,
+          usage: {
+            input_tokens: 1,
+            input_tokens_details: null,
+            output_tokens: 1,
+            output_tokens_details: null,
+          },
+          service_tier: null,
+        },
+      })}`,
+      "data: [DONE]",
+    ].join("\n\n") + "\n\n"
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(data))
+      controller.close()
+    },
+  })
+}
+
+async function fixture(provider: string, model: string) {
+  const file = path.join(import.meta.dir, "../tool/fixtures/models-api.json")
+  const data = (await Bun.file(file).json()) as Record<string, Fixture>
+  const item = data[provider]?.models[model]
+  if (!item) throw new Error(`Missing fixture model: ${provider}/${model}`)
+  return item
+}
+
+async function body(input: RequestInit["body"] | null | undefined) {
+  if (!input) return ""
+  if (typeof input === "string") return input
+  return new Response(input).text()
+}
+
+test("system_prompt config suppresses default provider prompt for agents without a prompt", async () => {
+  const req = defer<Body>()
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      req.resolve((await request.json()) as Body)
+      return new Response(chat("ok"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    },
+  })
+
+  try {
+    const provider = "alibaba"
+    const model = "qwen-plus"
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://app.kilo.ai/config.json",
+            enabled_providers: [provider],
+            system_prompt: "Custom core prompt",
+            provider: {
+              [provider]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(ProviderID.make(provider), ModelID.make(model))
+        const sessionID = SessionID.make("session-system-prompt")
+        const agent = {
+          name: "code",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const user = {
+          id: MessageID.make("user-system-prompt"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(provider), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const result = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["Runtime context"],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }] satisfies ModelMessage[],
+          tools: {},
+        })
+
+        for await (const _ of result.fullStream) {
+        }
+      },
+    })
+
+    const body = await req.promise
+    const sys = body.messages?.find((msg) => msg.role === "system")?.content ?? ""
+
+    expect(sys.startsWith("Custom core prompt")).toBe(true)
+    expect(sys).toContain("Runtime context")
+    expect(sys).not.toContain("You are Kilo")
+    expect(sys).not.toContain("You are an interactive CLI tool")
+  } finally {
+    server.stop()
+  }
+})
+
+test("system_prompt config suppresses default provider prompt for OpenAI OAuth instructions", async () => {
+  const req = defer<Body>()
+  const model = await fixture("openai", "gpt-5.2")
+  const fetch = globalThis.fetch
+  globalThis.fetch = (async (_input, init) => {
+    const text = await body(init?.body)
+    req.resolve(text ? (JSON.parse(text) as Body) : {})
+    return new Response(responses(model.id), {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    })
+  }) as typeof fetch
+
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://app.kilo.ai/config.json",
+            enabled_providers: ["openai"],
+            system_prompt: "Custom OAuth prompt",
+            provider: {
+              openai: {
+                name: "OpenAI",
+                env: ["OPENAI_API_KEY"],
+                npm: "@ai-sdk/openai",
+                api: "https://api.openai.com/v1",
+                models: {
+                  [model.id]: model,
+                },
+                options: {
+                  apiKey: "test-openai-key",
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const auth = path.join(Global.Path.data, "auth.json")
+        const before = await Bun.file(auth)
+          .text()
+          .catch(() => undefined)
+        await Auth.set("openai", {
+          type: "oauth",
+          access: "test-openai-oauth-token",
+          refresh: "test-openai-refresh-token",
+          expires: Date.now() + 3_600_000,
+        })
+        try {
+          const resolved = await Provider.getModel(ProviderID.openai, ModelID.make(model.id))
+          const sessionID = SessionID.make("session-system-prompt-oauth")
+          const agent = {
+            name: "code",
+            mode: "primary",
+            options: {},
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          } satisfies Agent.Info
+          const user = {
+            id: MessageID.make("user-system-prompt-oauth"),
+            sessionID,
+            role: "user",
+            time: { created: Date.now() },
+            agent: agent.name,
+            model: { providerID: ProviderID.openai, modelID: resolved.id },
+          } satisfies MessageV2.User
+
+          const result = await LLM.stream({
+            user,
+            sessionID,
+            model: resolved,
+            agent,
+            system: ["Runtime context"],
+            abort: new AbortController().signal,
+            messages: [{ role: "user", content: "Hello" }] satisfies ModelMessage[],
+            tools: {},
+          })
+
+          for await (const _ of result.fullStream) {
+          }
+        } finally {
+          if (before === undefined) await rm(auth, { force: true })
+          else await Bun.write(auth, before)
+        }
+      },
+    })
+
+    const body = await req.promise
+    const instructions = body.instructions ?? ""
+
+    expect(instructions.startsWith("Custom OAuth prompt")).toBe(true)
+    expect(instructions).toContain("Runtime context")
+    expect(instructions).not.toContain("You are Kilo")
+    expect(instructions).not.toContain("You are an interactive CLI tool")
+  } finally {
+    globalThis.fetch = fetch
+  }
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -332,6 +332,21 @@ export type EventTodoUpdated = {
   }
 }
 
+export type EventSessionTurnOpen = {
+  type: "session.turn.open"
+  properties: {
+    sessionID: string
+  }
+}
+
+export type EventSessionTurnClose = {
+  type: "session.turn.close"
+  properties: {
+    sessionID: string
+    reason: "completed" | "error" | "interrupted"
+  }
+}
+
 export type SessionStatus =
   | {
       type: "idle"
@@ -395,21 +410,6 @@ export type EventCommandExecuted = {
     sessionID: string
     arguments: string
     messageID: string
-  }
-}
-
-export type EventSessionTurnOpen = {
-  type: "session.turn.open"
-  properties: {
-    sessionID: string
-  }
-}
-
-export type EventSessionTurnClose = {
-  type: "session.turn.close"
-  properties: {
-    sessionID: string
-    reason: "completed" | "error" | "interrupted"
   }
 }
 
@@ -1075,14 +1075,14 @@ export type Event =
   | EventQuestionReplied
   | EventQuestionRejected
   | EventTodoUpdated
+  | EventSessionTurnOpen
+  | EventSessionTurnClose
   | EventSessionStatus
   | EventSessionIdle
   | EventSessionCompacted
   | EventFileEdited
   | EventFileWatcherUpdated
   | EventCommandExecuted
-  | EventSessionTurnOpen
-  | EventSessionTurnClose
   | EventSessionDiff
   | EventSessionError
   | EventVcsBranchUpdated
@@ -1604,6 +1604,10 @@ export type Config = {
    * Custom username to display in conversations instead of system username
    */
   username?: string
+  /**
+   * Override Kilo's default core system prompt. Set to null to remove the override.
+   */
+  system_prompt?: string | null
   /**
    * @deprecated Use `agent` field instead.
    */

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10879,6 +10879,48 @@
         },
         "required": ["type", "properties"]
       },
+      "Event.session.turn.open": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.turn.open"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              }
+            },
+            "required": ["sessionID"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
+      "Event.session.turn.close": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.turn.close"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string",
+                "enum": ["completed", "error", "interrupted"]
+              }
+            },
+            "required": ["sessionID", "reason"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
       "SessionStatus": {
         "anyOf": [
           {
@@ -11081,48 +11123,6 @@
               }
             },
             "required": ["name", "sessionID", "arguments", "messageID"]
-          }
-        },
-        "required": ["type", "properties"]
-      },
-      "Event.session.turn.open": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.turn.open"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string"
-              }
-            },
-            "required": ["sessionID"]
-          }
-        },
-        "required": ["type", "properties"]
-      },
-      "Event.session.turn.close": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.turn.close"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string"
-              },
-              "reason": {
-                "type": "string",
-                "enum": ["completed", "error", "interrupted"]
-              }
-            },
-            "required": ["sessionID", "reason"]
           }
         },
         "required": ["type", "properties"]
@@ -13099,6 +13099,12 @@
             "$ref": "#/components/schemas/Event.todo.updated"
           },
           {
+            "$ref": "#/components/schemas/Event.session.turn.open"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.turn.close"
+          },
+          {
             "$ref": "#/components/schemas/Event.session.status"
           },
           {
@@ -13115,12 +13121,6 @@
           },
           {
             "$ref": "#/components/schemas/Event.command.executed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.turn.open"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.turn.close"
           },
           {
             "$ref": "#/components/schemas/Event.session.diff"
@@ -14413,6 +14413,17 @@
           "username": {
             "description": "Custom username to display in conversations instead of system username",
             "type": "string"
+          },
+          "system_prompt": {
+            "description": "Override Kilo's default core system prompt. Set to null to remove the override.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "mode": {
             "description": "@deprecated Use `agent` field instead.",


### PR DESCRIPTION
Adds a settings option and config field for overriding Kilo's default core system prompt.

This lets users replace the built-in identity/provider prompt while preserving explicit mode prompts, rules, and runtime context.

Closes #8691