### PR TITLE
Fix reasoning toggle not working for some Responses API models

### DIFF
--- a/packages/opencode/src/kilocode/provider-options.ts
+++ b/packages/opencode/src/kilocode/provider-options.ts
@@ -14,7 +14,7 @@ export function kiloProviderOptions(options: { [x: string]: any }) {
       openrouter.reasoning && "effort" in openrouter.reasoning ? openrouter.reasoning?.effort : undefined,
     textVerbosity: openrouter.verbosity,
     store: false,
-    //forceReasoning: openrouter.reasoning?.enabled, // ai sdk v6
+    forceReasoning: openrouter.reasoning?.enabled,
   } satisfies OpenAIResponsesProviderOptions
   result.anthropic = {
     thinking: { type: openrouter.reasoning?.enabled ? "adaptive" : "disabled" },


### PR DESCRIPTION
the package has some internal logic to determine which models are reasoning model based on the model id, which gets in the way quite often