### PR TITLE
perf(vscode): speed up large session rendering

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -300,6 +300,7 @@
         "simple-git": "3.35.2",
         "solid-js": "^1.9.11",
         "uri-js": "^4.4.1",
+        "virtua": "catalog:",
         "web-tree-sitter": "^0.24.7",
         "yaml": "2.8.3",
         "zod": "^3.24.2",

--- a/bun.lock
+++ b/bun.lock
@@ -381,8 +381,8 @@
         "@opencode-ai/script": "workspace:*",
         "@opencode-ai/util": "workspace:*",
         "@openrouter/ai-sdk-provider": "2.3.3",
-        "@opentui/core": "0.1.92",
-        "@opentui/solid": "0.1.92",
+        "@opentui/core": "0.1.95",
+        "@opentui/solid": "0.1.95",
         "@parcel/watcher": "2.5.1",
         "@pierre/diffs": "catalog:",
         "@solid-primitives/event-bus": "1.1.2",
@@ -475,16 +475,16 @@
         "zod": "catalog:",
       },
       "devDependencies": {
-        "@opentui/core": "0.1.92",
-        "@opentui/solid": "0.1.92",
+        "@opentui/core": "0.1.95",
+        "@opentui/solid": "0.1.95",
         "@tsconfig/node22": "catalog:",
         "@types/node": "catalog:",
         "@typescript/native-preview": "catalog:",
         "typescript": "catalog:",
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.92",
-        "@opentui/solid": ">=0.1.92",
+        "@opentui/core": ">=0.1.95",
+        "@opentui/solid": ">=0.1.95",
       },
       "optionalPeers": [
         "@opentui/core",
@@ -1476,21 +1476,21 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
-    "@opentui/core": ["@opentui/core@0.1.92", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.92", "@opentui/core-darwin-x64": "0.1.92", "@opentui/core-linux-arm64": "0.1.92", "@opentui/core-linux-x64": "0.1.92", "@opentui/core-win32-arm64": "0.1.92", "@opentui/core-win32-x64": "0.1.92", "bun-webgpu": "0.1.5", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-c+KdYAIH3M8n24RYaor+t7AQtKZ3l84L7xdP7DEaN4xtuYH8W08E6Gi+wUal4g+HSai3HS9irox68yFf0VPAxw=="],
+    "@opentui/core": ["@opentui/core@0.1.95", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.95", "@opentui/core-darwin-x64": "0.1.95", "@opentui/core-linux-arm64": "0.1.95", "@opentui/core-linux-x64": "0.1.95", "@opentui/core-win32-arm64": "0.1.95", "@opentui/core-win32-x64": "0.1.95", "bun-webgpu": "0.1.5", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-Ha73I+PPSy6Jk8CTZgdGRHU+nnmrPAs7m6w0k6ge1/kWbcNcZB0lY67sWQMdoa6bSINQMNWg7SjbNCC9B/0exg=="],
 
-    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.92", "", { "os": "darwin", "cpu": "arm64" }, "sha512-NX/qFRuc7My0pazyOrw9fdTXmU7omXcZzQuHcsaVnwssljaT52UYMrJ7mCKhSo69RhHw0lnGCymTorvz3XBdsA=="],
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.95", "", { "os": "darwin", "cpu": "arm64" }, "sha512-92joqr0ucGaIBCl9uYhe5DwAPbgGMTaCsCeY8Yf3VQ72wjGbOTwnC1TvU5wC6bUmiyqfijCqMyuUnj83teIVVQ=="],
 
-    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.1.92", "", { "os": "darwin", "cpu": "x64" }, "sha512-Zb4jn33hOf167llINKLniOabQIycs14LPOBZnQ6l4khbeeTPVJdG8gy9PhlAyIQygDKmRTFncVlP0RP+L6C7og=="],
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.1.95", "", { "os": "darwin", "cpu": "x64" }, "sha512-+TLL3Kp3x7DTWEAkCAYe+RjRhl58QndoeXMstZNS8GQyrjSpUuivzwidzAz0HZK9SbZJfvaxZmXsToAIdI2fag=="],
 
-    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.1.92", "", { "os": "linux", "cpu": "arm64" }, "sha512-4VA1A91OTMPJ3LkAyaxKEZVJsk5jIc3Kz0gV2vip8p2aGLPpYHHpkFZpXP/FyzsnJzoSGftBeA6ya1GKa5bkXg=="],
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.1.95", "", { "os": "linux", "cpu": "arm64" }, "sha512-dAYeRqh7P8o0xFZleDDR1Abt4gSvCISqw6syOrbH3dl7pMbVdGgzA5stM9jqMgdPUVE7Ngumo17C23ehkGv93A=="],
 
-    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.1.92", "", { "os": "linux", "cpu": "x64" }, "sha512-tr7va8hfKS1uY+TBmulQBoBlwijzJk56K/U/L9/tbHfW7oJctqxPVwEFHIh1HDcOQ3/UhMMWGvMfeG6cFiK8/A=="],
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.1.95", "", { "os": "linux", "cpu": "x64" }, "sha512-O54TCgK8E7j2NKrDXUOTZqO4sb8JjeAfnhrStxAMMEw4RFCGWx3p3wLesqR16uKfFFJFDyoh2OWZ698tO88EAA=="],
 
-    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.1.92", "", { "os": "win32", "cpu": "arm64" }, "sha512-34YM3uPtDjzUVeSnJWIK2J8mxyduzV7f3mYc4Hub0glNpUdM1jjzF2HvvvnrKK5ElzTsIcno3c3lOYT8yvG1Zg=="],
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.1.95", "", { "os": "win32", "cpu": "arm64" }, "sha512-T1RlZ6U/95eYDN6rUm4SLOVA5LBR7iL3TcBroQhV/883bVczXIBPhriEXQayup5FsAemnQba1BzMNvy6128SUw=="],
 
-    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.1.92", "", { "os": "win32", "cpu": "x64" }, "sha512-uk442kA2Vn0mmJHHqk5sPM+Zai/AN9sgl7egekhoEOUx2VK3gxftKsVlx2YVpCHTvTE/S+vnD2WpQaJk2SNjww=="],
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.1.95", "", { "os": "win32", "cpu": "x64" }, "sha512-lH2FHO0HSP2xWT+ccoz0BkLYFsMm7e6OYOh63BUHHh5b7ispnzP4aTyxiaLWrfJwdL0M9rp5cLIY32bhBKF2oA=="],
 
-    "@opentui/solid": ["@opentui/solid@0.1.92", "", { "dependencies": { "@babel/core": "7.28.0", "@babel/preset-typescript": "7.27.1", "@opentui/core": "0.1.92", "babel-plugin-module-resolver": "5.0.2", "babel-preset-solid": "1.9.10", "entities": "7.0.1", "s-js": "^0.4.9" }, "peerDependencies": { "solid-js": "1.9.11" } }, "sha512-0Sx1+6zRpmMJ5oDEY0JS9b9+eGd/Q0fPndNllrQNnp7w2FCjpXmvHdBdq+pFI6kFp01MHq2ZOkUU5zX5/9YMSQ=="],
+    "@opentui/solid": ["@opentui/solid@0.1.95", "", { "dependencies": { "@babel/core": "7.28.0", "@babel/preset-typescript": "7.27.1", "@opentui/core": "0.1.95", "babel-plugin-module-resolver": "5.0.2", "babel-preset-solid": "1.9.10", "entities": "7.0.1", "s-js": "^0.4.9" }, "peerDependencies": { "solid-js": "1.9.11" } }, "sha512-iotYCvULgDurLXv3vgOzTLnEOySHFOa/6cEDex76jBt+gkniOEh2cjxxIVt6lkfTsk6UNTk6yCdwNK3nca/j+Q=="],
 
     "@oslojs/asn1": ["@oslojs/asn1@1.0.0", "", { "dependencies": { "@oslojs/binary": "1.0.0" } }, "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA=="],
 

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -875,6 +875,7 @@
     "simple-git": "3.35.2",
     "solid-js": "^1.9.11",
     "uri-js": "^4.4.1",
+    "virtua": "catalog:",
     "web-tree-sitter": "^0.24.7",
     "yaml": "2.8.3",
     "zod": "^3.24.2"

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -46,6 +46,8 @@ import { slimPart, slimParts } from "./kilo-provider/slim-metadata"
 import { handleContinueInWorktree } from "./kilo-provider/continue-worktree"
 import { parseMessageFiles } from "./kilo-provider/message-files"
 import { matchFollowup, recordFollowup, type Followup } from "./kilo-provider/followup-session"
+import { clearCommandsCache, loadCommands } from "./kilo-provider/commands"
+import { fetchMessagePage, MESSAGE_PAGE_LIMIT } from "./kilo-provider/message-page"
 import { childID } from "./kilo-provider/task-session"
 import { handleNetworkEvent, clearNetworkWaits } from "./kilo-provider/network"
 import { retryable, backoff, MAX_RETRIES } from "./util/retry"
@@ -104,6 +106,8 @@ type KiloProviderOptions = {
   projectDirectory?: string | null
   slimEditMetadata?: boolean
 }
+
+type MessageLoadMode = "replace" | "prepend" | "focus"
 
 // Helper to map agent data to the subset of fields sent to the webview
 const mapAgent = (a: Agent) => ({
@@ -445,6 +449,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.trackedSessionIds.add(sessionId)
   }
 
+  public loadMessages(sessionID: string): Promise<void> {
+    return this.handleLoadMessages(sessionID)
+  }
+
   /**
    * Register a directory override for a session (e.g., worktree path).
    * When set, all operations for this session use this directory instead of the workspace root.
@@ -623,7 +631,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "loadMessages":
           // Don't await: allow parallel loads so rapid session switching
           // isn't blocked by slow responses for earlier sessions.
-          void this.handleLoadMessages(message.sessionID)
+          void this.handleLoadMessages(message.sessionID, {
+            mode: message.mode,
+            before: message.before,
+            limit: message.limit,
+          })
           break
         case "syncSession":
           this.handleSyncSession(message.sessionID, message.parentSessionID).catch((e) =>
@@ -1200,7 +1212,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         this.fetchAndSendProviders(),
         this.fetchAndSendAgents(),
         this.fetchAndSendSkills(),
-        this.fetchAndSendCommands(),
         this.fetchAndSendConfig(),
         this.fetchAndSendNotifications(),
         this.seedSessionStatusMap(),
@@ -1267,14 +1278,63 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
+  private refreshSessionDetails(sessionID: string, workspaceDir: string, signal?: AbortSignal): void {
+    if (!this.client) return
+
+    // Update currentSession so fallback logic in handleSendMessage/handleAbort
+    // references the correct session after switching. Non-blocking: don't let a
+    // failure here prevent messages from loading. 404s are expected for
+    // cross-worktree sessions.
+    this.client.session
+      .get({ sessionID, directory: workspaceDir })
+      .then((result) => {
+        if (result.data && !signal?.aborted) {
+          this.currentSession = result.data
+          this.contextSessionID = result.data.id
+        }
+      })
+      .catch((err: unknown) => console.warn("[Kilo New] KiloProvider: getSession failed (non-critical):", err))
+
+    this.postMessage({
+      type: "workspaceDirectoryChanged",
+      directory: this.getWorkspaceDirectory(sessionID),
+    })
+
+    // Fetch current session status so the webview has the correct busy/idle
+    // state after switching tabs (SSE events may have been missed).
+    this.client.session
+      .status({ directory: workspaceDir })
+      .then((result) => {
+        if (!result.data || signal?.aborted) return
+        for (const [sid, info] of Object.entries(result.data) as [string, SessionStatus][]) {
+          if (!this.trackedSessionIds.has(sid)) continue
+          this.postMessage({
+            type: "sessionStatus",
+            sessionID: sid,
+            status: info.type,
+            ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
+          })
+        }
+      })
+      .catch((err: unknown) => console.error("[Kilo New] KiloProvider: Failed to fetch session statuses:", err))
+  }
+
   /**
    * Handle loading messages for a session.
    */
-  private async handleLoadMessages(sessionID: string): Promise<void> {
-    // Track the session so we receive its SSE events
-    this.trackedSessionIds.add(sessionID)
-    this.focusSession(sessionID)
-    this.contextSessionID = sessionID
+  private async handleLoadMessages(
+    sessionID: string,
+    options: { mode?: MessageLoadMode; before?: string; limit?: number } = {},
+  ): Promise<void> {
+    const mode = options.mode ?? "replace"
+    const focus = mode !== "prepend"
+
+    if (focus) {
+      // Track the session so we receive its SSE events
+      this.trackedSessionIds.add(sessionID)
+      this.focusSession(sessionID)
+      this.contextSessionID = sessionID
+    }
 
     if (!this.client) {
       this.postMessage({
@@ -1285,65 +1345,36 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       return
     }
 
-    // Abort any previous in-flight loadMessages request so the backend
-    // isn't overwhelmed when the user switches sessions rapidly.
-    this.loadMessagesAbort?.abort()
-    const abort = new AbortController()
-    this.loadMessagesAbort = abort
+    const workspaceDir = this.getWorkspaceDirectory(sessionID)
+
+    if (mode === "focus") {
+      this.refreshSessionDetails(sessionID, workspaceDir)
+      return
+    }
+
+    const abort = mode === "replace" ? new AbortController() : undefined
+    if (abort) {
+      // Abort any previous initial load so the backend isn't overwhelmed when
+      // the user switches sessions rapidly. Older-page loads are independent.
+      this.loadMessagesAbort?.abort()
+      this.loadMessagesAbort = abort
+    }
+
+    if (focus) this.refreshSessionDetails(sessionID, workspaceDir, abort?.signal)
 
     try {
-      const workspaceDir = this.getWorkspaceDirectory(sessionID)
-      const { data: messagesData } = await retry(() =>
-        this.client!.session.messages(
-          { sessionID, directory: workspaceDir },
-          { throwOnError: true, signal: abort.signal },
-        ),
-      )
-
-      // If this request was aborted while awaiting, skip posting stale results
-      if (abort.signal.aborted) return
-
-      // Update currentSession so fallback logic in handleSendMessage/handleAbort
-      // references the correct session after switching.  loadMessages is the
-      // canonical "user switched to this session" signal, so always update —
-      // the old guard `this.currentSession.id === sessionID` prevented updates
-      // when switching between different sessions.
-      // Non-blocking: don't let a failure here prevent messages from loading.
-      // 404s are expected for cross-worktree sessions — use silent to suppress HTTP error logs.
-      this.client.session
-        .get({ sessionID, directory: workspaceDir })
-        .then((result) => {
-          if (result.data && !abort.signal.aborted) {
-            this.currentSession = result.data
-            this.contextSessionID = result.data.id
-          }
-        })
-        .catch((err: unknown) => console.warn("[Kilo New] KiloProvider: getSession failed (non-critical):", err))
-
-      this.postMessage({
-        type: "workspaceDirectoryChanged",
-        directory: this.getWorkspaceDirectory(sessionID),
+      const page = await fetchMessagePage(this.client, {
+        sessionID,
+        workspaceDir,
+        limit: options.limit ?? MESSAGE_PAGE_LIMIT,
+        before: options.before,
+        signal: abort?.signal,
       })
 
-      // Fetch current session status so the webview has the correct busy/idle
-      // state after switching tabs (SSE events may have been missed).
-      this.client.session
-        .status({ directory: workspaceDir })
-        .then((result) => {
-          if (!result.data) return
-          for (const [sid, info] of Object.entries(result.data) as [string, SessionStatus][]) {
-            if (!this.trackedSessionIds.has(sid)) continue
-            this.postMessage({
-              type: "sessionStatus",
-              sessionID: sid,
-              status: info.type,
-              ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
-            })
-          }
-        })
-        .catch((err: unknown) => console.error("[Kilo New] KiloProvider: Failed to fetch session statuses:", err))
+      // If this request was aborted while awaiting, skip posting stale results
+      if (abort?.signal.aborted) return
 
-      const messages = messagesData.map((m) => ({
+      const messages = page.items.map((m) => ({
         ...m.info,
         parts: this.slimParts(m.parts),
         createdAt: new Date(m.info.time.created).toISOString(),
@@ -1357,13 +1388,16 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         type: "messagesLoaded",
         sessionID,
         messages,
+        mode,
+        cursor: page.cursor,
+        hasMore: Boolean(page.cursor),
       })
 
       // Recover any prompts missed while the webview was loading or during an SSE reconnection.
       this.recoverPendingPrompts()
     } catch (error) {
       // Silently ignore aborted requests — the user switched to a different session
-      if (abort.signal.aborted) return
+      if (abort?.signal.aborted) return
       console.error("[Kilo New] KiloProvider: Failed to load messages:", error)
       this.postMessage({
         type: "error",
@@ -1415,6 +1449,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         type: "messagesLoaded",
         sessionID,
         messages,
+        mode: "replace",
+        hasMore: false,
       })
 
       // Recover any prompts emitted by the child before we started tracking it.
@@ -1709,6 +1745,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
+  private clearCommandsCache(): void {
+    this.cachedCommandsMessage = null
+    clearCommandsCache()
+  }
+
   private async fetchAndSendCommands(): Promise<void> {
     if (!this.client) {
       if (this.cachedCommandsMessage) {
@@ -1719,19 +1760,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     try {
       const dir = this.getWorkspaceDirectory()
-      const { data: commands } = await retry(() =>
-        this.client!.command.list({ directory: dir }, { throwOnError: true }),
-      )
+      const message = await loadCommands(this.client, dir)
 
-      const message = {
-        type: "commandsLoaded",
-        commands: commands.map((c) => ({
-          name: c.name,
-          description: c.description,
-          source: c.source,
-          hints: c.hints,
-        })),
-      }
       this.cachedCommandsMessage = message
       this.postMessage(message)
     } catch (error) {
@@ -1764,7 +1794,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       if (result.error) {
         console.error("[Kilo New] removeSkill returned error:", result.error)
         this.cachedSkillsMessage = null
-        this.cachedCommandsMessage = null
+        this.clearCommandsCache()
         await Promise.all([this.fetchAndSendSkills(), this.fetchAndSendCommands()])
         return false
       }

--- a/packages/kilo-vscode/src/SubAgentViewerProvider.ts
+++ b/packages/kilo-vscode/src/SubAgentViewerProvider.ts
@@ -61,18 +61,8 @@ export class SubAgentViewerProvider implements vscode.Disposable {
         // sessionCreated to the webview.
         provider.registerSession(session)
 
-        // Fetch and send existing messages
-        const { data: messagesData } = await client.session.messages({ sessionID }, { throwOnError: true })
-        const messages = messagesData.map((m) => ({
-          ...m.info,
-          parts: m.parts,
-          createdAt: new Date(m.info.time.created).toISOString(),
-        }))
-        provider.postMessage({
-          type: "messagesLoaded",
-          sessionID,
-          messages,
-        })
+        // Fetch the newest page before navigating so the tab opens on the latest turn.
+        await provider.loadMessages(sessionID)
 
         // Navigate to the sub-agent viewer
         provider.postMessage({ type: "viewSubAgentSession", sessionID })

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -532,6 +532,9 @@ interface PreviewImageIn {
 interface LoadMessagesIn {
   type: "loadMessages"
   sessionID: string
+  mode?: "replace" | "prepend" | "focus"
+  before?: string
+  limit?: number
 }
 
 interface SendMessageIn {

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -325,6 +325,7 @@ export function activate(context: vscode.ExtensionContext) {
         const match = uri.path.match(/^\/kilocode\/s\/([a-zA-Z0-9_-]+)$/)
         if (!match) return
         const sessionId = match[1]
+        if (!sessionId) return
         console.log("[Kilo New] URI handler: opening cloud session:", sessionId)
         await vscode.commands.executeCommand(`${KiloProvider.viewType}.focus`)
         provider.openCloudSession(sessionId)

--- a/packages/kilo-vscode/src/kilo-provider/commands.ts
+++ b/packages/kilo-vscode/src/kilo-provider/commands.ts
@@ -1,0 +1,30 @@
+import type { KiloClient } from "@kilocode/sdk/v2/client"
+import { retry } from "../services/cli-backend/retry"
+
+const promises = new Map<string, Promise<unknown>>()
+
+export function clearCommandsCache(): void {
+  promises.clear()
+}
+
+export async function loadCommands(client: KiloClient, dir: string): Promise<unknown> {
+  const pending = promises.get(dir)
+  if (pending) return pending
+
+  const promise = retry(() => client.command.list({ directory: dir }, { throwOnError: true })).then(({ data }) => ({
+    type: "commandsLoaded",
+    commands: data.map((cmd) => ({
+      name: cmd.name,
+      description: cmd.description,
+      source: cmd.source,
+      hints: cmd.hints,
+    })),
+  }))
+
+  promises.set(dir, promise)
+  try {
+    return await promise
+  } finally {
+    if (promises.get(dir) === promise) promises.delete(dir)
+  }
+}

--- a/packages/kilo-vscode/src/kilo-provider/message-page.ts
+++ b/packages/kilo-vscode/src/kilo-provider/message-page.ts
@@ -1,0 +1,45 @@
+import type { KiloClient } from "@kilocode/sdk/v2/client"
+import { retry } from "../services/cli-backend/retry"
+
+export const MESSAGE_PAGE_LIMIT = 80
+
+export async function fetchMessagePage(
+  client: KiloClient,
+  input: {
+    sessionID: string
+    workspaceDir: string
+    limit: number
+    before?: string
+    signal?: AbortSignal
+  },
+) {
+  const read = async (before?: string) => {
+    const result = await retry(() =>
+      client.session.messages(
+        { sessionID: input.sessionID, directory: input.workspaceDir, limit: input.limit, before },
+        { throwOnError: true, signal: input.signal },
+      ),
+    )
+    const cursor = result.response.headers.get("X-Next-Cursor") ?? undefined
+    return {
+      items: result.data,
+      cursor,
+    }
+  }
+
+  const suffix = (items: Awaited<ReturnType<typeof read>>["items"]) => {
+    const index = [...items].reverse().findIndex((item) => item.info.role === "user")
+    if (index === -1) return items
+    return items.slice(items.length - index - 1)
+  }
+
+  const fill = async (page: Awaited<ReturnType<typeof read>>): Promise<Awaited<ReturnType<typeof read>>> => {
+    if (page.items[0]?.info.role !== "assistant") return page
+    if (!page.cursor || input.signal?.aborted) return page
+    const next = await read(page.cursor)
+    const items = [...suffix(next.items), ...page.items]
+    return fill({ items, cursor: next.cursor })
+  }
+
+  return fill(await read(input.before))
+}

--- a/packages/kilo-vscode/src/kilo-provider/slim-metadata.ts
+++ b/packages/kilo-vscode/src/kilo-provider/slim-metadata.ts
@@ -139,15 +139,21 @@ function slimWrite(state: Record<string, unknown>): Record<string, unknown> {
   return next
 }
 
-/** bash: truncate metadata.output (up to 30KB) and state.output (up to 50KB). */
-function slimBash(state: Record<string, unknown>): Record<string, unknown> {
+/** read/list/search: keep the rendered tool details lightweight on historical loads. */
+function slimOutput(state: Record<string, unknown>): Record<string, unknown> {
   const next = { ...state }
+  if (typeof state.output === "string" && state.output.length > OUTPUT_CAP) {
+    next.output = cap(state.output)
+  }
+  return next
+}
+
+/** bash: truncate metadata.output and state.output. */
+function slimBash(state: Record<string, unknown>): Record<string, unknown> {
+  const next = slimOutput(state)
   const meta = state.metadata
   if (isObj(meta) && typeof meta.output === "string" && meta.output.length > OUTPUT_CAP) {
     next.metadata = { ...meta, output: cap(meta.output) }
-  }
-  if (typeof state.output === "string" && (state.output as string).length > OUTPUT_CAP) {
-    next.output = cap(state.output)
   }
   return next
 }
@@ -157,6 +163,10 @@ function slimBash(state: Record<string, unknown>): Record<string, unknown> {
 // ---------------------------------------------------------------------------
 
 const slimmers: Record<string, (state: Record<string, unknown>) => Record<string, unknown>> = {
+  read: slimOutput,
+  list: slimOutput,
+  glob: slimOutput,
+  grep: slimOutput,
   edit: slimEdit,
   apply_patch: slimPatch,
   multiedit: slimMultiedit,

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -765,20 +765,31 @@ const AgentManagerContent: Component = () => {
     return result
   })
 
-  // Sessions for the currently selected worktree (tab bar), respecting custom order if set
+  const sessionsForWorktree = (worktreeId: string): SessionInfo[] => {
+    const lookup = new Map(session.sessions().map((s) => [s.id, s]))
+    return applyTabOrder(
+      managedSessions()
+        .filter((ms) => ms.worktreeId === worktreeId)
+        .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+        .map(
+          (ms) =>
+            lookup.get(ms.id) ?? {
+              id: ms.id,
+              title: t("agentManager.session.untitled"),
+              createdAt: ms.createdAt,
+              updatedAt: ms.createdAt,
+            },
+        ),
+      worktreeTabOrder()[worktreeId],
+    )
+  }
+
   const activeWorktreeSessions = createMemo((): SessionInfo[] => {
     const sel = selection()
     if (!sel || sel === LOCAL) return []
-    const managed = managedSessions().filter((ms) => ms.worktreeId === sel)
-    const ids = new Set(managed.map((ms) => ms.id))
-    const sessions = session
-      .sessions()
-      .filter((s) => ids.has(s.id))
-      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
-    return applyTabOrder(sessions, worktreeTabOrder()[sel])
+    return sessionsForWorktree(sel)
   })
 
-  // Active tab sessions: local sessions when on "local", worktree sessions otherwise
   const activeTabs = createMemo((): SessionInfo[] => {
     const sel = selection()
     if (sel === LOCAL) return localSessions()
@@ -786,7 +797,6 @@ const AgentManagerContent: Component = () => {
     return []
   })
 
-  // Whether the selected context has zero sessions
   const contextEmpty = createMemo(() => {
     const sel = selection()
     if (sel === LOCAL) return localSessionIDs().length === 0
@@ -805,8 +815,6 @@ const AgentManagerContent: Component = () => {
     }
   })
 
-  // Scroll the sidebar to the focused item whenever selection changes (covers keyboard
-  // navigation, new worktree creation, and any other programmatic selection change).
   createEffect(() => {
     const id = selection() ?? session.currentSessionID()
     if (!id) return
@@ -816,22 +824,16 @@ const AgentManagerContent: Component = () => {
     })
   })
 
-  // Read-only mode: viewing an unassigned session (not in a worktree or local)
   const readOnly = createMemo(() => selection() === null && !!session.currentSessionID())
 
-  // Tab scroll: hidden scrollbar with fade overflow indicators
   const visibleTabId = createMemo(() =>
     reviewActive() ? REVIEW_TAB_ID : (session.currentSessionID() ?? activePendingId()),
   )
   const tabScroll = useTabScroll(activeTabs, visibleTabId)
 
-  // Display name for worktree — prefers persisted label, then first session title, then branch
   const worktreeLabel = (wt: WorktreeState): string => {
     if (wt.label) return wt.label
-    const managed = managedSessions().filter((ms) => ms.worktreeId === wt.id)
-    const ids = new Set(managed.map((ms) => ms.id))
-    const sessions = session.sessions().filter((s) => ids.has(s.id))
-    return firstOrderedTitle(sessions, worktreeTabOrder()[wt.id], wt.branch)
+    return firstOrderedTitle(sessionsForWorktree(wt.id), worktreeTabOrder()[wt.id], wt.branch)
   }
 
   const worktreeSubtitle = (wt: WorktreeState): string | undefined => {
@@ -841,7 +843,6 @@ const AgentManagerContent: Component = () => {
 
   const isStaleWorktree = (worktreeId: string): boolean => staleWorktreeIds().has(worktreeId)
 
-  /** True when any session in the given ID list is actively working (busy/retry and not blocked by permissions/questions). */
   const isAnySessionBusy = (ids: string[]): boolean => {
     if (ids.length === 0) return false
     const statuses = session.allStatusMap()
@@ -1015,9 +1016,7 @@ const AgentManagerContent: Component = () => {
   const selectWorktree = (worktreeId: string) => {
     saveTabMemory()
     setSelection(worktreeId)
-    const managed = managedSessions().filter((ms) => ms.worktreeId === worktreeId)
-    const ids = new Set(managed.map((ms) => ms.id))
-    const sessions = session.sessions().filter((s) => ids.has(s.id))
+    const sessions = sessionsForWorktree(worktreeId)
     const remembered = tabMemory()[worktreeId]
     const target = remembered ? sessions.find((s) => s.id === remembered) : undefined
     const fallback = target ?? sessions[0]

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -7,7 +7,7 @@
  * Shows recent sessions in the empty state for quick resumption.
  */
 
-import { Component, For, Show, createEffect, createMemo, onCleanup, JSX } from "solid-js"
+import { Component, For, Show, createEffect, createMemo, createSignal, on, onCleanup, JSX } from "solid-js"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { useDialog } from "@kilocode/kilo-ui/context/dialog"
@@ -17,12 +17,13 @@ import { useServer } from "../../context/server"
 import { useLanguage } from "../../context/language"
 import { formatRelativeDate } from "../../utils/date"
 import { FeedbackDialog } from "./FeedbackDialog"
-import { VscodeSessionTurn } from "./VscodeSessionTurn"
+import { VscodeSessionTurn, type VscodeTurn } from "./VscodeSessionTurn"
 import { RevertBanner } from "./RevertBanner"
 import { AccountSwitcher } from "../shared/AccountSwitcher"
 import { KiloNotifications } from "./KiloNotifications"
 import { WorkingIndicator } from "../shared/WorkingIndicator"
 import { QuestionDock } from "./QuestionDock"
+import { Virtualizer } from "virtua/solid"
 import { activeUserMessageID as getActiveUserMessageID } from "../../context/session-queue"
 import type { QuestionRequest } from "../../types/messages"
 
@@ -69,14 +70,25 @@ export const MessageList: Component<MessageListProps> = (props) => {
     }
   })
 
-  const allUserMessages = () => session.userMessages()
+  const [scrollEl, setScrollEl] = createSignal<HTMLElement>()
+  const positions = new Map<string, { top: number; userScrolled: boolean }>()
+
   const boundary = () => session.revert()?.messageID
-  const userMessages = createMemo(() => {
+  const turns = createMemo<VscodeTurn[]>(() => {
+    const result: VscodeTurn[] = []
     const b = boundary()
-    if (!b) return allUserMessages()
-    return allUserMessages().filter((m) => m.id < b)
+    for (const msg of session.messages()) {
+      if (msg.role === "user") {
+        if (b && msg.id >= b) break
+        result.push({ id: msg.id, user: msg, assistant: [] })
+        continue
+      }
+      const turn = result[result.length - 1]
+      if (turn && msg.role === "assistant") turn.assistant.push(msg)
+    }
+    return result
   })
-  const isEmpty = () => userMessages().length === 0 && !session.loading() && !boundary()
+  const isEmpty = () => turns().length === 0 && !session.loading() && !boundary()
 
   const recent = createMemo(() =>
     [...session.sessions()]
@@ -89,8 +101,61 @@ export const MessageList: Component<MessageListProps> = (props) => {
   const activeUserIndex = createMemo(() => {
     const active = activeUserID()
     if (!active) return -1
-    return userMessages().findIndex((msg) => msg.id === active)
+    return turns().findIndex((turn) => turn.user.id === active)
   })
+
+  const save = (id: string | undefined) => {
+    const el = scrollEl()
+    if (!id || !el) return
+    positions.set(id, { top: el.scrollTop, userScrolled: autoScroll.userScrolled() })
+  }
+
+  const maybeLoadOlder = () => {
+    const el = scrollEl()
+    if (!el || el.scrollTop > 600) return
+    session.loadOlderMessages()
+  }
+
+  const handleScroll = () => {
+    autoScroll.handleScroll()
+    maybeLoadOlder()
+  }
+
+  const setScrollRef = (el: HTMLElement | undefined) => {
+    setScrollEl(el)
+    autoScroll.scrollRef(el)
+  }
+
+  const [pendingRestore, setPendingRestore] = createSignal<string>()
+
+  createEffect(
+    on(session.currentSessionID, (id, prev) => {
+      save(prev)
+      setPendingRestore(id)
+    }),
+  )
+
+  createEffect(() => {
+    const id = pendingRestore()
+    if (!id || session.loading()) return
+    turns().length
+    requestAnimationFrame(() => {
+      if (pendingRestore() !== id) return
+      const el = scrollEl()
+      if (!el) return
+      const pos = positions.get(id)
+      if (pos?.userScrolled) {
+        el.scrollTop = pos.top
+        autoScroll.pause()
+      } else {
+        autoScroll.forceScrollToBottom()
+      }
+      setPendingRestore(undefined)
+      maybeLoadOlder()
+    })
+  })
+
+  onCleanup(() => save(session.currentSessionID()))
 
   return (
     <div class="message-list-container">
@@ -100,13 +165,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
           <KiloNotifications />
         </div>
       </Show>
-      <div
-        ref={autoScroll.scrollRef}
-        onScroll={autoScroll.handleScroll}
-        class="message-list"
-        role="log"
-        aria-live="polite"
-      >
+      <div ref={setScrollRef} onScroll={handleScroll} class="message-list" role="log" aria-live="polite">
         <div ref={autoScroll.contentRef} class={isEmpty() ? "message-list-content-empty" : undefined}>
           <Show when={session.loading()}>
             <div class="message-list-loading" role="status">
@@ -143,24 +202,37 @@ export const MessageList: Component<MessageListProps> = (props) => {
               </button>
             </div>
           </Show>
-          <Show when={!session.loading()}>
-            <For each={userMessages()}>
-              {(msg, index) => {
-                const queued = createMemo(() => {
-                  const active = activeUserIndex()
-                  if (active === -1) return false
-                  return index() > active
-                })
+          <Show when={!session.loading() && !isEmpty()}>
+            <Show when={session.loadingOlderMessages()}>
+              <div class="message-list-page-loader" role="status">
+                <Spinner />
+                <span>{language.t("session.messages.loadingEarlier")}</span>
+              </div>
+            </Show>
+            <Show when={session.hasOlderMessages() && !session.loadingOlderMessages()}>
+              <button class="message-list-load-older" onClick={() => session.loadOlderMessages()}>
+                {language.t("session.messages.loadEarlier")}
+              </button>
+            </Show>
+            <Show when={scrollEl()}>
+              <Virtualizer
+                data={turns()}
+                scrollRef={scrollEl()}
+                shift={session.messageMutation() === "prepend"}
+                overscan={6}
+                itemSize={260}
+              >
+                {(turn, index) => {
+                  const queued = createMemo(() => {
+                    const active = activeUserIndex()
+                    if (active === -1) return false
+                    return index() > active
+                  })
 
-                return (
-                  <VscodeSessionTurn
-                    sessionID={session.currentSessionID() ?? ""}
-                    messageID={msg.id}
-                    queued={queued()}
-                  />
-                )
-              }}
-            </For>
+                  return <VscodeSessionTurn turn={turn} queued={queued()} />
+                }}
+              </Virtualizer>
+            </Show>
             <Show when={boundary()}>
               <RevertBanner />
             </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
@@ -31,6 +31,7 @@ import { ErrorDisplay } from "./ErrorDisplay"
 import { useServer } from "../../context/server"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
+import type { Message as WebMessage } from "../../types/messages"
 
 function getDirectory(path: string): string {
   const sep = path.includes("/") ? "/" : "\\"
@@ -44,9 +45,14 @@ function getFilename(path: string): string {
   return idx === -1 ? path : path.slice(idx + 1)
 }
 
+export interface VscodeTurn {
+  id: string
+  user: WebMessage
+  assistant: WebMessage[]
+}
+
 interface VscodeSessionTurnProps {
-  sessionID: string
-  messageID: string
+  turn: VscodeTurn
   queued?: boolean
 }
 
@@ -58,45 +64,17 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
   const session = useSession()
   const language = useLanguage()
 
-  const emptyMessages: SDKMessage[] = []
   const emptyParts: SDKPart[] = []
   const emptyDiffs: FileDiff[] = []
 
-  const allMessages = createMemo(() => {
-    const msgs = data.store.message?.[props.sessionID]
-    return (msgs ?? emptyMessages) as SDKMessage[]
-  })
-
-  const message = createMemo(() => {
-    return allMessages().find((m) => m.id === props.messageID && m.role === "user") as
-      | (SDKMessage & { role: "user" })
-      | undefined
-  })
+  const message = createMemo(() => props.turn.user as SDKMessage & { role: "user" })
 
   const parts = createMemo(() => {
     const msg = message()
-    if (!msg) return emptyParts
     return (data.store.part?.[msg.id] ?? emptyParts) as SDKPart[]
   })
 
-  const messageIndex = createMemo(() => {
-    const msgs = allMessages()
-    return msgs.findIndex((m) => m.id === props.messageID)
-  })
-
-  const assistantMessages = createMemo(() => {
-    const index = messageIndex()
-    if (index < 0) return [] as SDKAssistantMessage[]
-    const msgs = allMessages()
-    const result: SDKAssistantMessage[] = []
-    for (let i = index + 1; i < msgs.length; i++) {
-      const m = msgs[i]
-      if (!m) continue
-      if (m.role === "user") break
-      if (m.role === "assistant") result.push(m as SDKAssistantMessage)
-    }
-    return result
-  })
+  const assistantMessages = createMemo(() => props.turn.assistant as SDKAssistantMessage[])
 
   const interrupted = createMemo(() => assistantMessages().some((m) => m.error?.name === "MessageAbortedError"))
 
@@ -173,7 +151,7 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
                 assistantMessages().length > 0 && !session.revert()
                   ? () => {
                       if (session.status() !== "idle") return
-                      session.revertSession(props.messageID)
+                      session.revertSession(msg().id)
                     }
                   : undefined
               }

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -31,6 +31,7 @@ import type {
   FileAttachment,
   SendMessageFailedMessage,
   McpStatusEntry,
+  MessageLoadMode,
 } from "../types/messages"
 import { removeSessionPermissions, upsertPermission } from "./permission-queue"
 import {
@@ -47,6 +48,25 @@ import { resolveSessionAgent } from "./session-agent"
 import { KILO_AUTO, parseModelString } from "../../../src/shared/provider-model"
 
 const RECENT_LIMIT = 5
+const MESSAGE_PAGE_LIMIT = 80
+
+type MessageMutation = Exclude<MessageLoadMode, "focus"> | "append" | "update"
+
+interface MessagePageState {
+  initialLoaded: boolean
+  loadingInitial: boolean
+  loadingOlder: boolean
+  before?: string
+  hasMore: boolean
+  lastMutation?: MessageMutation
+}
+
+const emptyPageState: MessagePageState = {
+  initialLoaded: false,
+  loadingInitial: false,
+  loadingOlder: false,
+  hasMore: false,
+}
 
 // Store structure for messages and parts
 interface SessionStore {
@@ -77,6 +97,9 @@ interface SessionContextValue {
   statusText: Accessor<string | undefined>
   busySince: Accessor<number | undefined>
   loading: Accessor<boolean>
+  loadingOlderMessages: Accessor<boolean>
+  hasOlderMessages: Accessor<boolean>
+  messageMutation: Accessor<MessageMutation | undefined>
 
   // Messages for current session
   messages: Accessor<Message[]>
@@ -194,6 +217,7 @@ interface SessionContextValue {
   createSession: () => void
   clearCurrentSession: () => void
   loadSessions: () => void
+  loadOlderMessages: () => void
   selectSession: (id: string) => void
   deleteSession: (id: string) => void
   renameSession: (id: string, title: string) => void
@@ -238,6 +262,7 @@ export const SessionProvider: ParentComponent = (props) => {
 
   const [loading, setLoading] = createSignal(false)
   const [loaded, setLoaded] = createSignal<Set<string>>(new Set())
+  const [pages, setPages] = createStore<Record<string, MessagePageState>>({})
 
   // Pending permissions
   const [permissions, setPermissions] = createSignal<PermissionRequest[]>([])
@@ -640,6 +665,11 @@ export const SessionProvider: ParentComponent = (props) => {
     vscode.postMessage({ type: "toggleFavorite", action, providerID, modelID })
   }
 
+  function handleError(message: Extract<ExtensionMessage, { type: "error" }>) {
+    if (!message.sessionID || message.sessionID === currentSessionID()) setLoading(false)
+    if (message.sessionID) patchPage(message.sessionID, { loadingInitial: false, loadingOlder: false })
+  }
+
   // Handle messages from extension
   onMount(() => {
     const unsubscribe = vscode.onMessage((message: ExtensionMessage) => {
@@ -649,7 +679,11 @@ export const SessionProvider: ParentComponent = (props) => {
           break
 
         case "messagesLoaded":
-          handleMessagesLoaded(message.sessionID, message.messages)
+          handleMessagesLoaded(message.sessionID, message.messages, {
+            mode: message.mode,
+            cursor: message.cursor,
+            hasMore: message.hasMore,
+          })
           break
 
         case "messageCreated":
@@ -722,9 +756,7 @@ export const SessionProvider: ParentComponent = (props) => {
         }
 
         case "error":
-          // Only clear loading if the error is for the current session
-          // (or has no sessionID for backwards compatibility)
-          if (!message.sessionID || message.sessionID === currentSessionID()) setLoading(false)
+          handleError(message)
           break
 
         case "sendMessageFailed":
@@ -790,7 +822,36 @@ export const SessionProvider: ParentComponent = (props) => {
     })
   }
 
-  function handleMessagesLoaded(sessionID: string, messages: Message[]) {
+  function patchPage(sessionID: string, patch: Partial<MessagePageState>) {
+    setPages(sessionID, { ...(pages[sessionID] ?? emptyPageState), ...patch })
+  }
+
+  function mergeMessages(current: Message[], incoming: Message[], mode: Exclude<MessageLoadMode, "focus">) {
+    const seen = new Set<string>()
+    const source = mode === "prepend" ? [...incoming, ...current] : incoming
+    return source.filter((msg) => {
+      if (seen.has(msg.id)) return false
+      seen.add(msg.id)
+      return true
+    })
+  }
+
+  function withPending(sessionID: string, messages: Message[]) {
+    const pending = pendingOptimistic.get(sessionID)
+    if (!pending || pending.size === 0) return messages
+    const ids = new Set(messages.map((msg) => msg.id))
+    const current = store.messages[sessionID] ?? []
+    const orphans = current.filter((msg) => pending.has(msg.id) && !ids.has(msg.id))
+    return [...messages, ...orphans]
+  }
+
+  function handleMessagesLoaded(
+    sessionID: string,
+    messages: Message[],
+    input: { mode?: Exclude<MessageLoadMode, "focus">; cursor?: string; hasMore?: boolean } = {},
+  ) {
+    const mode = input.mode ?? "replace"
+    const reset = mode === "prepend"
     batch(() => {
       setLoaded((prev) => {
         if (prev.has(sessionID)) return prev
@@ -800,18 +861,9 @@ export const SessionProvider: ParentComponent = (props) => {
       })
       if (sessionID === currentSessionID()) setLoading(false)
 
-      // Preserve optimistic messages that haven't been confirmed yet.
-      // The server may not have created the message record by the time
-      // this session's messages are loaded (e.g. on session switch).
-      const pending = pendingOptimistic.get(sessionID)
-      if (pending && pending.size > 0) {
-        const loadedIds = new Set(messages.map((m) => m.id))
-        const current = store.messages[sessionID] ?? []
-        const orphans = current.filter((m) => pending.has(m.id) && !loadedIds.has(m.id))
-        setStore("messages", sessionID, reconcile([...messages, ...orphans], { key: "id" }))
-      } else {
-        setStore("messages", sessionID, reconcile(messages, { key: "id" }))
-      }
+      const current = store.messages[sessionID] ?? []
+      const merged = mode === "prepend" ? mergeMessages(current, messages, mode) : withPending(sessionID, messages)
+      setStore("messages", sessionID, reconcile(merged, { key: "id" }))
 
       // Also extract parts from messages
       for (const msg of messages) {
@@ -820,11 +872,21 @@ export const SessionProvider: ParentComponent = (props) => {
         }
       }
 
-      const agent = resolveSessionAgent(messages, agentNames())
+      setPages(sessionID, {
+        initialLoaded: true,
+        loadingInitial: false,
+        loadingOlder: false,
+        before: input.cursor,
+        hasMore: input.hasMore ?? Boolean(input.cursor),
+        lastMutation: mode,
+      })
+
+      const agent = resolveSessionAgent(merged, agentNames())
       if (agent) {
         setStore("agentSelections", sessionID, agent)
       }
     })
+    if (reset) requestAnimationFrame(() => patchPage(sessionID, { lastMutation: undefined }))
   }
 
   function handleMessageCreated(message: Message) {
@@ -845,6 +907,7 @@ export const SessionProvider: ParentComponent = (props) => {
       )
     }
 
+    const exists = (store.messages[message.sessionID] ?? []).some((msg) => msg.id === message.id)
     setStore("messages", message.sessionID, (msgs = []) => {
       // Check if message already exists (optimistic or update case).
       // Since we now use the same messageID for optimistic and server messages,
@@ -857,6 +920,7 @@ export const SessionProvider: ParentComponent = (props) => {
       }
       return [...msgs, message]
     })
+    patchPage(message.sessionID, { initialLoaded: true, lastMutation: exists ? "update" : "append" })
 
     // Sync mode picker from any message role (user or assistant).
     // agentNames() already excludes subagent/hidden agents, so subtask
@@ -884,6 +948,8 @@ export const SessionProvider: ParentComponent = (props) => {
       console.warn("[Kilo New] Part updated without messageID:", part.id, part.type)
       return
     }
+
+    if (sessionID) patchPage(sessionID, { lastMutation: "update" })
 
     setStore(
       "parts",
@@ -1010,6 +1076,7 @@ export const SessionProvider: ParentComponent = (props) => {
       pendingOptimistic.get(message.sessionID)?.delete(message.messageID)
       batch(() => {
         setStore("messages", message.sessionID!, (msgs = []) => msgs.filter((m) => m.id !== message.messageID))
+
         setStore(
           "parts",
           produce((parts) => {
@@ -1173,6 +1240,11 @@ export const SessionProvider: ParentComponent = (props) => {
           delete todos[sessionID]
         }),
       )
+      setPages(
+        produce((map) => {
+          delete map[sessionID]
+        }),
+      )
       setStore(
         "agentSelections",
         produce((selections) => {
@@ -1238,6 +1310,7 @@ export const SessionProvider: ParentComponent = (props) => {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       })
+      patchPage(key, { initialLoaded: true, hasMore: false, lastMutation: "replace" })
       setStore("messages", key, messages)
       for (const msg of messages) {
         if (msg.parts && msg.parts.length > 0) {
@@ -1311,7 +1384,8 @@ export const SessionProvider: ParentComponent = (props) => {
     })
     // Load real messages in the background (picks up server-assigned IDs
     // and the new user message once the send completes via SSE)
-    vscode.postMessage({ type: "loadMessages", sessionID: session.id })
+    patchPage(session.id, { loadingInitial: true, before: undefined, hasMore: false })
+    vscode.postMessage({ type: "loadMessages", sessionID: session.id, mode: "replace", limit: MESSAGE_PAGE_LIMIT })
   }
 
   // Actions
@@ -1368,6 +1442,7 @@ export const SessionProvider: ParentComponent = (props) => {
 
     setStore("messages", sid, (msgs = []) => [...msgs, temp])
     setStore("parts", messageID, parts)
+    patchPage(sid, { initialLoaded: true, lastMutation: "append" })
     queueMicrotask(() => window.dispatchEvent(new CustomEvent("resumeAutoScroll")))
   }
 
@@ -1594,6 +1669,21 @@ export const SessionProvider: ParentComponent = (props) => {
     vscode.postMessage({ type: "loadSessions" })
   }
 
+  function loadOlderMessages() {
+    const id = currentSessionID()
+    if (!id || !server.isConnected()) return
+    const page = pages[id] ?? emptyPageState
+    if (!page.hasMore || page.loadingOlder || page.loadingInitial || !page.before) return
+    patchPage(id, { loadingOlder: true })
+    vscode.postMessage({
+      type: "loadMessages",
+      sessionID: id,
+      mode: "prepend",
+      before: page.before,
+      limit: MESSAGE_PAGE_LIMIT,
+    })
+  }
+
   function selectSession(id: string) {
     if (!server.isConnected()) {
       console.warn("[Kilo New] Cannot select session: not connected")
@@ -1603,10 +1693,16 @@ export const SessionProvider: ParentComponent = (props) => {
       console.warn("[Kilo New] Cannot select cloud preview session via selectSession")
       return
     }
+    const ready = loaded().has(id)
     setCurrentSessionID(id)
     setDraftSessionID(id)
-    setLoading(!loaded().has(id))
-    vscode.postMessage({ type: "loadMessages", sessionID: id })
+    setLoading(!ready)
+    if (ready) {
+      vscode.postMessage({ type: "loadMessages", sessionID: id, mode: "focus" })
+      return
+    }
+    patchPage(id, { loadingInitial: true, loadingOlder: false, before: undefined, hasMore: false })
+    vscode.postMessage({ type: "loadMessages", sessionID: id, mode: "replace", limit: MESSAGE_PAGE_LIMIT })
   }
 
   function selectCloudSession(cloudSessionId: string) {
@@ -1656,6 +1752,15 @@ export const SessionProvider: ParentComponent = (props) => {
     const id = currentSessionID()
     return id ? store.sessions[id] : undefined
   }
+
+  const pageState = () => {
+    const id = currentSessionID()
+    return id ? (pages[id] ?? emptyPageState) : emptyPageState
+  }
+
+  const loadingOlderMessages = () => pageState().loadingOlder
+  const hasOlderMessages = () => pageState().hasMore
+  const messageMutation = () => pageState().lastMutation
 
   const messages = () => {
     const id = currentSessionID()
@@ -1802,6 +1907,9 @@ export const SessionProvider: ParentComponent = (props) => {
     statusText,
     busySince,
     loading,
+    loadingOlderMessages,
+    hasOlderMessages,
+    messageMutation,
     messages,
     userMessages,
     getParts,
@@ -1876,6 +1984,7 @@ export const SessionProvider: ParentComponent = (props) => {
     createSession,
     clearCurrentSession,
     loadSessions,
+    loadOlderMessages,
     selectSession,
     deleteSession,
     renameSession,

--- a/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
@@ -1,4 +1,4 @@
-import { createSignal, onCleanup, onMount } from "solid-js"
+import { createSignal, onCleanup } from "solid-js"
 import type { Accessor } from "solid-js"
 import type { SlashCommandInfo, WebviewMessage, ExtensionMessage } from "../types/messages"
 
@@ -39,6 +39,7 @@ export function useSlashCommand(vscode: VSCodeContext, exclude?: Set<string>): S
   const [server, setServer] = createSignal<SlashCommandInfo[]>([])
   const [query, setQuery] = createSignal<string | null>(null)
   const [index, setIndex] = createSignal(0)
+  const [requested, setRequested] = createSignal(false)
 
   const all: SlashCommandEntry[] = [
     {
@@ -118,6 +119,12 @@ export function useSlashCommand(vscode: VSCodeContext, exclude?: Set<string>): S
 
   const show = () => query() !== null
 
+  const request = () => {
+    if (requested()) return
+    setRequested(true)
+    vscode.postMessage({ type: "requestCommands" })
+  }
+
   const results = () => {
     const q = query()
     if (q === null) return []
@@ -137,10 +144,6 @@ export function useSlashCommand(vscode: VSCodeContext, exclude?: Set<string>): S
     setServer(message.commands)
   })
 
-  onMount(() => {
-    vscode.postMessage({ type: "requestCommands" })
-  })
-
   onCleanup(() => {
     unsubscribe()
   })
@@ -153,6 +156,7 @@ export function useSlashCommand(vscode: VSCodeContext, exclude?: Set<string>): S
     const before = val.substring(0, cursor)
     const match = before.match(SLASH_PATTERN)
     if (match) {
+      request()
       setQuery(match[1])
       setIndex(0)
     } else {

--- a/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
@@ -63,6 +63,33 @@
   font-size: 13px;
 }
 
+.message-list-page-loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 0 12px;
+  color: var(--vscode-descriptionForeground);
+  font-size: 12px;
+}
+
+.message-list-load-older {
+  display: block;
+  margin: 0 auto 12px;
+  border: 1px solid var(--vscode-button-border, transparent);
+  border-radius: 6px;
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  cursor: pointer;
+  padding: 5px 10px;
+  font: inherit;
+  font-size: 12px;
+}
+
+.message-list-load-older:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
 .message-list-content-empty {
   display: flex;
   min-height: 100%;

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -554,10 +554,15 @@ export interface MessageRemovedMessage {
   messageID: string
 }
 
+export type MessageLoadMode = "replace" | "prepend" | "focus"
+
 export interface MessagesLoadedMessage {
   type: "messagesLoaded"
   sessionID: string
   messages: Message[]
+  mode?: Exclude<MessageLoadMode, "focus">
+  cursor?: string
+  hasMore?: boolean
 }
 
 export interface MessageCreatedMessage {
@@ -1592,6 +1597,9 @@ export interface ClearSessionRequest {
 export interface LoadMessagesRequest {
   type: "loadMessages"
   sessionID: string
+  mode?: MessageLoadMode
+  before?: string
+  limit?: number
 }
 
 export interface LoadSessionsRequest {

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -308,6 +308,23 @@ export function Markdown(
       copy: i18n.t("ui.message.copy"),
       copied: i18n.t("ui.message.copied"),
     }
+
+    // kilocode_change start: avoid morphdom's expensive tree matching on first
+    // paint for completed historical markdown. Large session switches mount many
+    // stable markdown blocks, and the trace showed morphdom + Parse HTML as the
+    // dominant webview cost.
+    if (!local.streaming && container.childNodes.length === 0) {
+      container.innerHTML = content
+      decorate(container, labels)
+      if (!copyCleanup)
+        copyCleanup = setupCodeCopy(container, () => ({
+          copy: i18n.t("ui.message.copy"),
+          copied: i18n.t("ui.message.copied"),
+        }))
+      return
+    }
+    // kilocode_change end
+
     const temp = document.createElement("div")
     temp.innerHTML = content
     decorate(temp, labels)

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1516,6 +1516,7 @@ ToolRegistry.register({
       <BasicTool
         {...props}
         icon="bullet-list"
+        defer
         trigger={{ title: i18n.t("ui.tool.list"), subtitle: getDirectory(props.input.path || "/") }}
       >
         <Show when={props.output}>
@@ -1536,6 +1537,7 @@ ToolRegistry.register({
       <BasicTool
         {...props}
         icon="magnifying-glass-menu"
+        defer
         trigger={{
           title: i18n.t("ui.tool.glob"),
           subtitle: getDirectory(props.input.path || "/"),
@@ -1563,6 +1565,7 @@ ToolRegistry.register({
       <BasicTool
         {...props}
         icon="magnifying-glass-menu"
+        defer
         trigger={{
           title: i18n.t("ui.tool.grep"),
           subtitle: getDirectory(props.input.path || "/"),
@@ -1757,6 +1760,7 @@ ToolRegistry.register({
       <BasicTool
         {...props}
         icon="console"
+        defer
         trigger={
           <div data-slot="basic-tool-tool-info-structured">
             <div data-slot="basic-tool-tool-info-main">


### PR DESCRIPTION
## Summary
- Load session transcripts incrementally and virtualize turn rendering so large conversations open at the latest turn without mounting full history.
- Defer expensive historical markdown/tool-output work and lazy-load slash commands to reduce webview parse/render time during session switches.
- Reduce payload and first-paint markdown work for large historical tool outputs.

Closes #8607