### PR TITLE
feat(vscode): add /export slash command to export session as JSON

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -710,6 +710,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "compact":
           await this.handleCompact(message.sessionID, message.providerID, message.modelID)
           break
+        case "export":
+          await this.handleExport(message.sessionID)
+          break
         case "requestAgents":
           this.fetchAndSendAgents().catch((e) => console.error("[Kilo New] fetchAndSendAgents failed:", e))
           break
@@ -2598,6 +2601,41 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         type: "error",
         message: getErrorMessage(error) || "Failed to compact session",
       })
+    }
+  }
+
+  /** Handle export session request from the webview. */
+  private async handleExport(sessionID?: string): Promise<void> {
+    if (!this.client) {
+      this.postMessage({ type: "error", message: "Not connected to CLI backend" })
+      return
+    }
+    const target = sessionID || this.currentSession?.id
+    if (!target) return
+
+    try {
+      const dir = this.getWorkspaceDirectory(target)
+      const { data: info } = await this.client.session.get(
+        { sessionID: target, directory: dir },
+        { throwOnError: true },
+      )
+      const { data: msgs } = await this.client.session.messages(
+        { sessionID: target, directory: dir },
+        { throwOnError: true },
+      )
+      const payload = { info, messages: msgs.map((m) => ({ info: m.info, parts: m.parts })) }
+      const filename = `${info.title?.replace(/[^a-zA-Z0-9-_ ]/g, "") || "session"}-${target.slice(-8)}.json`
+      const uri = await vscode.window.showSaveDialog({
+        defaultUri: vscode.Uri.file(filename),
+        filters: { JSON: ["json"] },
+        title: "Export Session",
+      })
+      if (!uri) return
+      await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(JSON.stringify(payload, null, 2)))
+      vscode.window.showInformationMessage(`Session exported to ${uri.fsPath}`)
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to export session:", error)
+      this.postMessage({ type: "error", message: getErrorMessage(error) || "Failed to export session" })
     }
   }
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -263,6 +263,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   window.addEventListener("compactSession", onCompact)
   onCleanup(() => window.removeEventListener("compactSession", onCompact))
 
+  const onExport = () => {
+    session.export()
+  }
+  window.addEventListener("exportSession", onExport)
+  onCleanup(() => window.removeEventListener("exportSession", onExport))
+
   const isBusy = () => session.status() !== "idle"
   const isDisabled = () => !server.isConnected()
   const hasInput = () => text().trim().length > 0 || imageAttach.images().length > 0 || reviewComments().length > 0

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1517,6 +1517,11 @@ export const SessionProvider: ParentComponent = (props) => {
       return
     }
 
+    if (cloudPreviewId()) {
+      console.warn("[Kilo New] Cannot export: cloud session preview")
+      return
+    }
+
     const sessionID = currentSessionID()
     if (!sessionID) {
       console.warn("[Kilo New] Cannot export: no current session")

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -183,6 +183,7 @@ interface SessionContextValue {
   ) => void
   abort: () => void
   compact: () => void
+  export: () => void
   respondToPermission: (
     permissionId: string,
     response: "once" | "always" | "reject",
@@ -1510,6 +1511,24 @@ export const SessionProvider: ParentComponent = (props) => {
     })
   }
 
+  function exportSession() {
+    if (!server.isConnected()) {
+      console.warn("[Kilo New] Cannot export: not connected")
+      return
+    }
+
+    const sessionID = currentSessionID()
+    if (!sessionID) {
+      console.warn("[Kilo New] Cannot export: no current session")
+      return
+    }
+
+    vscode.postMessage({
+      type: "export",
+      sessionID,
+    })
+  }
+
   function respondToPermission(
     permissionId: string,
     response: "once" | "always" | "reject",
@@ -1870,6 +1889,7 @@ export const SessionProvider: ParentComponent = (props) => {
     sendCommand,
     abort,
     compact,
+    export: exportSession,
     respondToPermission,
     replyToQuestion,
     rejectQuestion,

--- a/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
@@ -91,6 +91,14 @@ export function useSlashCommand(vscode: VSCodeContext, exclude?: Set<string>): S
       },
     },
     {
+      name: "export",
+      description: "Export session to JSON file for debugging",
+      hints: ["debug", "save", "json"],
+      action: () => {
+        window.dispatchEvent(new CustomEvent("exportSession"))
+      },
+    },
+    {
       name: "settings",
       description: "Open settings",
       hints: [],

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "انتظر انتهاء الوكيل",
   "command.session.compact": "ضغط الجلسة",
   "command.session.compact.description": "تلخيص الجلسة لتقليل حجم السياق",
+  "command.session.export": "تصدير الجلسة",
+  "command.session.export.description": "تصدير الجلسة إلى ملف JSON لتصحيح الأخطاء",
   "command.session.fork": "تشعب من الرسالة",
   "command.session.fork.description": "إنشاء جلسة جديدة من رسالة سابقة",
   "command.session.share": "مشاركة الجلسة",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Aguarde o agente terminar",
   "command.session.compact": "Compactar sessão",
   "command.session.compact.description": "Resumir a sessão para reduzir o tamanho do contexto",
+  "command.session.export": "Exportar sessão",
+  "command.session.export.description": "Exportar a sessão para um arquivo JSON para depuração",
   "command.session.fork": "Bifurcar da mensagem",
   "command.session.fork.description": "Criar uma nova sessão a partir de uma mensagem anterior",
   "command.session.share": "Compartilhar sessão",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Sačekajte da agent završi",
   "command.session.compact": "Sažmi sesiju",
   "command.session.compact.description": "Sažmi sesiju kako bi se smanjio kontekst",
+  "command.session.export": "Izvezi sesiju",
+  "command.session.export.description": "Izvezi sesiju u JSON datoteku za otklanjanje grešaka",
   "command.session.fork": "Fork iz poruke",
   "command.session.fork.description": "Kreiraj novu sesiju iz prethodne poruke",
   "command.session.share": "Podijeli sesiju",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Vent på at agenten er færdig",
   "command.session.compact": "Komprimér session",
   "command.session.compact.description": "Opsummer sessionen for at reducere kontekststørrelsen",
+  "command.session.export": "Eksporter session",
+  "command.session.export.description": "Eksporter session til JSON-fil til fejlfinding",
   "command.session.fork": "Forgren fra besked",
   "command.session.fork.description": "Opret en ny session fra en tidligere besked",
   "command.session.share": "Del session",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -90,6 +90,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Warten bis der Agent fertig ist",
   "command.session.compact": "Sitzung komprimieren",
   "command.session.compact.description": "Sitzung zusammenfassen, um die Kontextgröße zu reduzieren",
+  "command.session.export": "Sitzung exportieren",
+  "command.session.export.description": "Sitzung zum Debuggen in eine JSON-Datei exportieren",
   "command.session.fork": "Von Nachricht abzweigen",
   "command.session.fork.description": "Neue Sitzung aus einer früheren Nachricht erstellen",
   "command.session.share": "Sitzung teilen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Wait for agent to finish",
   "command.session.compact": "Compact session",
   "command.session.compact.description": "Summarize the session to reduce context size",
+  "command.session.export": "Export session",
+  "command.session.export.description": "Export session to JSON file for debugging",
   "command.session.fork": "Fork from message",
   "command.session.fork.description": "Create a new session from a previous message",
   "command.session.share": "Share session",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Espera a que el agente termine",
   "command.session.compact": "Compactar sesión",
   "command.session.compact.description": "Resumir la sesión para reducir el tamaño del contexto",
+  "command.session.export": "Exportar sesión",
+  "command.session.export.description": "Exportar la sesión a un archivo JSON para depuración",
   "command.session.fork": "Bifurcar desde mensaje",
   "command.session.fork.description": "Crear una nueva sesión desde un mensaje anterior",
   "command.session.share": "Compartir sesión",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -87,6 +87,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Attendre la fin de l'agent",
   "command.session.compact": "Compacter la session",
   "command.session.compact.description": "Résumer la session pour réduire la taille du contexte",
+  "command.session.export": "Exporter la session",
+  "command.session.export.description": "Exporter la session vers un fichier JSON pour le débogage",
   "command.session.fork": "Bifurquer à partir du message",
   "command.session.fork.description": "Créer une nouvelle session à partir d'un message précédent",
   "command.session.share": "Partager la session",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "エージェントの完了を待ってください",
   "command.session.compact": "セッションを圧縮",
   "command.session.compact.description": "セッションを要約してコンテキストサイズを削減",
+  "command.session.export": "セッションをエクスポート",
+  "command.session.export.description": "デバッグ用にセッションを JSON ファイルにエクスポート",
   "command.session.fork": "メッセージからフォーク",
   "command.session.fork.description": "以前のメッセージから新しいセッションを作成",
   "command.session.share": "セッションを共有",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -90,6 +90,8 @@ export const dict = {
   "revert.disabled.agentBusy": "에이전트가 완료될 때까지 기다리세요",
   "command.session.compact": "세션 압축",
   "command.session.compact.description": "컨텍스트 크기를 줄이기 위해 세션 요약",
+  "command.session.export": "세션 내보내기",
+  "command.session.export.description": "디버깅을 위해 세션을 JSON 파일로 내보내기",
   "command.session.fork": "메시지에서 분기",
   "command.session.fork.description": "이전 메시지에서 새 세션 생성",
   "command.session.share": "세션 공유",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Wacht tot de agent klaar is",
   "command.session.compact": "Sessie comprimeren",
   "command.session.compact.description": "De sessie samenvatten om de contextgrootte te verkleinen",
+  "command.session.export": "Sessie exporteren",
+  "command.session.export.description": "Sessie exporteren naar JSON-bestand voor foutopsporing",
   "command.session.fork": "Afsplitsen van bericht",
   "command.session.fork.description": "Een nieuwe sessie aanmaken vanaf een eerder bericht",
   "command.session.share": "Sessie delen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -89,6 +89,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Vent til agenten er ferdig",
   "command.session.compact": "Komprimer sesjon",
   "command.session.compact.description": "Oppsummer sesjonen for å redusere kontekststørrelsen",
+  "command.session.export": "Eksporter økt",
+  "command.session.export.description": "Eksporter økt til JSON-fil for feilsøking",
   "command.session.fork": "Forgren fra melding",
   "command.session.fork.description": "Opprett en ny sesjon fra en tidligere melding",
   "command.session.share": "Del sesjon",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Poczekaj aż agent zakończy",
   "command.session.compact": "Kompaktuj sesję",
   "command.session.compact.description": "Podsumuj sesję, aby zmniejszyć rozmiar kontekstu",
+  "command.session.export": "Eksportuj sesję",
+  "command.session.export.description": "Eksportuj sesję do pliku JSON w celu debugowania",
   "command.session.fork": "Rozwidlij od wiadomości",
   "command.session.fork.description": "Utwórz nową sesję od poprzedniej wiadomości",
   "command.session.share": "Udostępnij sesję",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Дождитесь завершения агента",
   "command.session.compact": "Сжать сессию",
   "command.session.compact.description": "Сократить сессию для уменьшения размера контекста",
+  "command.session.export": "Экспортировать сессию",
+  "command.session.export.description": "Экспортировать сессию в файл JSON для отладки",
   "command.session.fork": "Создать ответвление",
   "command.session.fork.description": "Создать новую сессию из сообщения",
   "command.session.share": "Поделиться сессией",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "รอให้เอเจนต์ทำงานเสร็จ",
   "command.session.compact": "บีบอัดเซสชัน",
   "command.session.compact.description": "สรุปเซสชันเพื่อลดขนาดบริบท",
+  "command.session.export": "ส่งออกเซสชัน",
+  "command.session.export.description": "ส่งออกเซสชันไปยังไฟล์ JSON สำหรับการดีบัก",
   "command.session.fork": "แตกแขนงจากข้อความ",
   "command.session.fork.description": "สร้างเซสชันใหม่จากข้อความก่อนหน้า",
   "command.session.share": "แชร์เซสชัน",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Ajanın bitmesini bekleyin",
   "command.session.compact": "Oturumu sıkıştır",
   "command.session.compact.description": "Bağlam boyutunu azaltmak için oturumu özetle",
+  "command.session.export": "Oturumu dışa aktar",
+  "command.session.export.description": "Hata ayıklama için oturumu JSON dosyasına dışa aktar",
   "command.session.fork": "Mesajdan dallandır",
   "command.session.fork.description": "Önceki bir mesajdan yeni oturum oluştur",
   "command.session.share": "Oturumu paylaş",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -86,6 +86,8 @@ export const dict = {
   "revert.disabled.agentBusy": "Зачекайте завершення агента",
   "command.session.compact": "Стиснути сесію",
   "command.session.compact.description": "Підсумувати сесію для зменшення розміру контексту",
+  "command.session.export": "Експортувати сесію",
+  "command.session.export.description": "Експортувати сесію у файл JSON для налагодження",
   "command.session.fork": "Розгалужити від повідомлення",
   "command.session.fork.description": "Створити нову сесію від попереднього повідомлення",
   "command.session.share": "Відкрити доступ до сесії",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -90,6 +90,8 @@ export const dict = {
   "revert.disabled.agentBusy": "等待智能体完成",
   "command.session.compact": "精简会话",
   "command.session.compact.description": "总结会话以减少上下文大小",
+  "command.session.export": "导出会话",
+  "command.session.export.description": "将会话导出为 JSON 文件以进行调试",
   "command.session.fork": "从消息分叉",
   "command.session.fork.description": "从之前的消息创建新会话",
   "command.session.share": "分享会话",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -90,6 +90,8 @@ export const dict = {
   "revert.disabled.agentBusy": "等待 Agent 完成",
   "command.session.compact": "精簡工作階段",
   "command.session.compact.description": "總結工作階段以減少上下文大小",
+  "command.session.export": "匯出工作階段",
+  "command.session.export.description": "將工作階段匯出為 JSON 檔案以進行偵錯",
   "command.session.fork": "從訊息分支",
   "command.session.fork.description": "從先前的訊息建立新工作階段",
   "command.session.share": "分享工作階段",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1651,6 +1651,11 @@ export interface CompactRequest {
   modelID?: string
 }
 
+export interface ExportRequest {
+  type: "export"
+  sessionID: string
+}
+
 export interface OpenSettingsPanelRequest {
   type: "openSettingsPanel"
   tab?: string
@@ -2350,6 +2355,7 @@ export type WebviewMessage =
   | WebviewReadyRequest
   | RequestProvidersMessage
   | CompactRequest
+  | ExportRequest
   | RequestAgentsMessage
   | RequestSkillsMessage
   | RequestCommandsMessage


### PR DESCRIPTION
Adds a `/export` slash command to the VS Code extension chat interface that exports the current session to a JSON file for debugging.

When triggered, it fetches the session info and messages via the SDK client, prompts the user with a VS Code save dialog, and writes the same `{ info, messages }` JSON structure as `kilo export <sessionID>` produces.