### PR TITLE
feat(agent-manager): jump to changed line when clicking line number in diff

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -3016,10 +3016,10 @@ const AgentManagerContent: Component = () => {
                       onClose={() => setSidePanel(null)}
                       onExpand={selection() !== null ? openReviewTab : undefined}
                       onRequestDiff={requestDiffFile}
-                      onOpenFile={(file) => {
+                      onOpenFile={(file, line) => {
                         const id = currentDiffSessionId()
-                        if (id) vscode.postMessage({ type: "agentManager.openFile", sessionId: id, filePath: file })
-                        else if (selection() === LOCAL) vscode.postMessage({ type: "openFile", filePath: file })
+                        if (id) vscode.postMessage({ type: "agentManager.openFile", sessionId: id, filePath: file, line })
+                        else if (selection() === LOCAL) vscode.postMessage({ type: "openFile", filePath: file, line })
                       }}
                       onRevertFile={revertCtl.revert}
                       revertingFiles={revertCtl.reverting()}
@@ -3044,10 +3044,10 @@ const AgentManagerContent: Component = () => {
                 diffStyle={reviewDiffStyle()}
                 onDiffStyleChange={setSharedDiffStyle}
                 onRequestDiff={requestDiffFile}
-                onOpenFile={(file) => {
+                onOpenFile={(file, line) => {
                   const id = currentDiffSessionId()
-                  if (id) vscode.postMessage({ type: "agentManager.openFile", sessionId: id, filePath: file })
-                  else if (selection() === LOCAL) vscode.postMessage({ type: "openFile", filePath: file })
+                  if (id) vscode.postMessage({ type: "agentManager.openFile", sessionId: id, filePath: file, line })
+                  else if (selection() === LOCAL) vscode.postMessage({ type: "openFile", filePath: file, line })
                 }}
                 onRevertFile={revertCtl.revert}
                 revertingFiles={revertCtl.reverting()}

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -3018,7 +3018,8 @@ const AgentManagerContent: Component = () => {
                       onRequestDiff={requestDiffFile}
                       onOpenFile={(file, line) => {
                         const id = currentDiffSessionId()
-                        if (id) vscode.postMessage({ type: "agentManager.openFile", sessionId: id, filePath: file, line })
+                        if (id)
+                          vscode.postMessage({ type: "agentManager.openFile", sessionId: id, filePath: file, line })
                         else if (selection() === LOCAL) vscode.postMessage({ type: "openFile", filePath: file, line })
                       }}
                       onRevertFile={revertCtl.revert}

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -40,7 +40,7 @@ interface DiffPanelProps {
   onClose: () => void
   onExpand?: () => void
   onRequestDiff?: (file: string) => void
-  onOpenFile?: (relativePath: string) => void
+  onOpenFile?: (relativePath: string, line?: number) => void
   onRevertFile?: (file: string) => void
   revertingFiles?: Set<string>
 }
@@ -520,6 +520,10 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                             renderAnnotation={buildAnnotation}
                             enableGutterUtility={true}
                             onGutterUtilityClick={(result) => handleGutterClick(diff.file, result)}
+                            onLineNumberClick={(event) => {
+                              if (event.annotationSide === "deletions") return
+                              props.onOpenFile?.(diff.file, event.lineNumber)
+                            }}
                           />
                         </Show>
                       </Show>

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -40,7 +40,7 @@ interface FullScreenDiffViewProps {
   diffStyle: DiffStyle
   onDiffStyleChange: (style: DiffStyle) => void
   onRequestDiff?: (file: string) => void
-  onOpenFile?: (relativePath: string) => void
+  onOpenFile?: (relativePath: string, line?: number) => void
   onRevertFile?: (file: string) => void
   revertingFiles?: Set<string>
   onClose: () => void
@@ -596,6 +596,10 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                                 renderAnnotation={buildAnnotation}
                                 enableGutterUtility={true}
                                 onGutterUtilityClick={(result) => handleGutterClick(diff.file, result)}
+                                onLineNumberClick={(event) => {
+                                  if (event.annotationSide === "deletions") return
+                                  props.onOpenFile?.(diff.file, event.lineNumber)
+                                }}
                               />
                             </Show>
                           </Show>

--- a/packages/ui/src/pierre/index.ts
+++ b/packages/ui/src/pierre/index.ts
@@ -143,7 +143,7 @@ const unsafeCSS = `
   }
 
   &[data-interactive-line-numbers] [data-column-number] {
-    cursor: default !important;
+    cursor: pointer !important;
   }
 
   &[data-interactive-lines] [data-line] {


### PR DESCRIPTION
## Context

Fixes #6076 — when clicking on a diff in the agent chat/review panel, the file should open with focus at the start of the changed lines instead of always at line 1.

## Implementation

The `@pierre/diffs` library already exposes an `onLineNumberClick` callback on `FileDiff` that fires when a user clicks a line number, providing `lineNumber` and `annotationSide`. The extension backend (`openWorktreeFile`) and message protocol (`OpenFileIn`, `GenericOpenFileIn`) already supported an optional `line` parameter — the wire was all there, just never connected.

Changes:

- **`DiffPanel.tsx` / `FullScreenDiffView.tsx`**: Extended the `onOpenFile` prop to accept an optional `line` parameter. Added `onLineNumberClick` to each `<Diff>` component — when a line number on the additions (or context) side is clicked, it calls `onOpenFile(file, lineNumber)`. Deletion-side line numbers are skipped since they reference the old file version.
- **`AgentManagerApp.tsx`**: Updated both `onOpenFile` callbacks to forward the `line` argument in the `postMessage` payload.
- **`packages/ui/src/pierre/index.ts`**: Changed the cursor on interactive line number columns from `default` to `pointer`, giving users a visual affordance that line numbers are clickable.

## Screenshots

| before | after |
| ------ | ----- |
| File opens at line 1 | File opens at the clicked diff line |

## How to Test

1. Start a Kilo session and let it make edits to a file
2. Open the diff review panel (side panel or full-screen)
3. Click a line number (the numbered column on the left) in any diff hunk
4. The file should open in the editor with the cursor positioned at that exact line

## Get in Touch

<!-- Discord handle if applicable -->