### PR TITLE
fix(vscode): keep worktree sessions across project id changes

### DIFF
--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -206,10 +206,9 @@ export async function loadSessions(ctx: SessionRefreshContext): Promise<string |
   const seen = new Set(sessions.map((s) => s.id))
   for (const batch of extra) {
     for (const s of batch) {
-      if (!seen.has(s.id) && (!projectID || s.projectID === projectID)) {
-        sessions.push(s)
-        seen.add(s.id)
-      }
+      if (seen.has(s.id)) continue
+      sessions.push(s)
+      seen.add(s.id)
     }
   }
 
@@ -218,7 +217,7 @@ export async function loadSessions(ctx: SessionRefreshContext): Promise<string |
     sessions: sessions.map((s) => sessionToWebview(s)),
   })
 
-  return sessions[0]?.projectID
+  return projectID
 }
 
 /**

--- a/packages/kilo-vscode/tests/unit/kilo-provider-session-refresh.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-session-refresh.test.ts
@@ -93,6 +93,70 @@ function createConnection(client: ReturnType<typeof createClient>) {
 }
 
 describe("KiloProvider pending session refresh", () => {
+  it("keeps worktree sessions with legacy project ids", async () => {
+    const sent: unknown[] = []
+    const ctx = createContext({
+      connectionState: "connected",
+      sessionDirectories: new Map([["ses_worktree", "/worktree"]]),
+      listSessions: async (dir) => {
+        if (dir === "/repo") {
+          return [
+            {
+              id: "ses_root",
+              projectID: "project-new",
+              title: "root",
+              directory: "/repo",
+              time: { created: 1, updated: 1 },
+            },
+          ] as never
+        }
+        return [
+          {
+            id: "ses_worktree",
+            projectID: "project-old",
+            title: "worktree",
+            directory: "/worktree",
+            time: { created: 2, updated: 2 },
+          },
+        ] as never
+      },
+      postMessage: (msg) => sent.push(msg),
+    })
+
+    const project = await loadSessions(ctx)
+
+    expect(project).toBe("project-new")
+    expect(sent).toHaveLength(1)
+    expect((sent[0] as { sessions: { id: string }[] }).sessions.map((s) => s.id)).toEqual(["ses_root", "ses_worktree"])
+  })
+
+  it("does not use legacy worktree sessions as canonical project", async () => {
+    const sent: unknown[] = []
+    const ctx = createContext({
+      connectionState: "connected",
+      sessionDirectories: new Map([["ses_worktree", "/worktree"]]),
+      listSessions: async (dir) => {
+        if (dir === "/repo") return [] as never
+        return [
+          {
+            id: "ses_worktree",
+            projectID: "project-old",
+            title: "worktree",
+            directory: "/worktree",
+            time: { created: 2, updated: 2 },
+          },
+        ] as never
+      },
+      postMessage: (msg) => sent.push(msg),
+    })
+
+    const project = await loadSessions(ctx)
+
+    expect(project).toBeUndefined()
+    expect(sent).toHaveLength(1)
+    expect((sent[0] as { sessions: { id: string }[] }).sessions.map((s) => s.id)).toEqual(["ses_worktree"])
+  })
+
   it("flushes deferred refresh via flushPendingSessionRefresh", async () => {
     const { calls, fn } = createListSessions()
     const ctx = createContext()

--- a/packages/opencode/src/kilocode/session/index.ts
+++ b/packages/opencode/src/kilocode/session/index.ts
@@ -1,7 +1,7 @@
 // kilocode_change - new file
 import z from "zod"
 import { BusEvent } from "@/bus/bus-event"
-import { Database, eq, and, gte, isNull, desc, like, inArray, lt } from "@/storage/db"
+import { Database, eq, and, gte, isNull, desc, like, inArray, lt, or } from "@/storage/db"
 import type { SQL } from "@/storage/db"
 import { ProjectTable } from "@/project/project.sql"
 import { ProjectID } from "@/project/schema"
@@ -77,6 +77,15 @@ export namespace KiloSession {
         .map((item) => item.id),
     )
     return ids.length ? ids : [id]
+  }
+
+  export function filters(input: { projectID: ProjectID; directory?: string }): SQL[] {
+    const dir = input.directory ? Filesystem.resolve(input.directory) : undefined
+    if (!dir) return [eq(SessionTable.project_id, input.projectID)]
+    return [
+      or(eq(SessionTable.project_id, input.projectID), eq(SessionTable.directory, dir)),
+      eq(SessionTable.directory, dir),
+    ].filter((item): item is SQL => item !== undefined)
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -9,7 +9,7 @@ import { Config } from "../config/config"
 import { Flag } from "../flag/flag"
 import { Installation } from "../installation"
 
-import { Database, NotFoundError, eq, and, gte, isNull, desc, like } from "../storage/db"
+import { Database, NotFoundError, eq, and, gte, isNull, desc, like, or } from "../storage/db" // kilocode_change
 import { SyncEvent } from "../sync"
 import { SessionTable } from "./session.sql"
 import { Storage } from "@/storage/storage"
@@ -795,16 +795,23 @@ export namespace Session {
     limit?: number
   }) {
     const project = Instance.project
-    const conditions = [eq(SessionTable.project_id, project.id)]
+    // kilocode_change start: preserve directory lookups across project id changes
+    const dir = input?.directory ? Filesystem.resolve(input.directory) : undefined
+    const conditions = [
+      dir
+        ? or(eq(SessionTable.project_id, project.id), eq(SessionTable.directory, dir))
+        : eq(SessionTable.project_id, project.id),
+    ]
+    // kilocode_change end
 
+    // kilocode_change start: preserve directory lookups across project id changes
     if (input?.workspaceID) {
       conditions.push(eq(SessionTable.workspace_id, input.workspaceID))
     }
-    if (input?.directory) {
-      // kilocode_change start: vscode uri.fsPath gives lowercase drive letter on Windows; resolve() canonicalises to match stored path
-      conditions.push(eq(SessionTable.directory, Filesystem.resolve(input.directory)))
-      // kilocode_change end
+    if (dir) {
+      conditions.push(eq(SessionTable.directory, dir))
     }
+    // kilocode_change end
     if (input?.roots) {
       conditions.push(isNull(SessionTable.parent_id))
     }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -9,7 +9,7 @@ import { Config } from "../config/config"
 import { Flag } from "../flag/flag"
 import { Installation } from "../installation"
 
-import { Database, NotFoundError, eq, and, gte, isNull, desc, like, or } from "../storage/db" // kilocode_change
+import { Database, NotFoundError, eq, and, gte, isNull, desc, like } from "../storage/db"
 import { SyncEvent } from "../sync"
 import { SessionTable } from "./session.sql"
 import { Storage } from "@/storage/storage"
@@ -25,7 +25,6 @@ import { Snapshot } from "@/snapshot"
 import { ProjectID } from "../project/schema"
 import { WorkspaceID } from "../control-plane/schema"
 import { SessionID, MessageID, PartID } from "./schema"
-import { Filesystem } from "../util/filesystem" // kilocode_change: normalize directory for Windows drive-letter casing
 import { KiloSession } from "@/kilocode/session" // kilocode_change
 
 import type { Provider } from "@/provider/provider"
@@ -795,23 +794,11 @@ export namespace Session {
     limit?: number
   }) {
     const project = Instance.project
-    // kilocode_change start: preserve directory lookups across project id changes
-    const dir = input?.directory ? Filesystem.resolve(input.directory) : undefined
-    const conditions = [
-      dir
-        ? or(eq(SessionTable.project_id, project.id), eq(SessionTable.directory, dir))
-        : eq(SessionTable.project_id, project.id),
-    ]
-    // kilocode_change end
+    const conditions = KiloSession.filters({ projectID: project.id, directory: input?.directory }) // kilocode_change
 
-    // kilocode_change start: preserve directory lookups across project id changes
     if (input?.workspaceID) {
       conditions.push(eq(SessionTable.workspace_id, input.workspaceID))
     }
-    if (dir) {
-      conditions.push(eq(SessionTable.directory, dir))
-    }
-    // kilocode_change end
     if (input?.roots) {
       conditions.push(isNull(SessionTable.parent_id))
     }

--- a/packages/opencode/test/kilocode/session-list.test.ts
+++ b/packages/opencode/test/kilocode/session-list.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { ProjectTable } from "../../src/project/project.sql"
+import { ProjectID } from "../../src/project/schema"
+import { Session } from "../../src/session"
+import { SessionTable } from "../../src/session/session.sql"
+import { Database, eq } from "../../src/storage/db"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("Kilo Session.list", () => {
+  test("includes directory matches from legacy project ids", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({ title: "legacy-session" })
+        const project = ProjectID.make("legacy-project")
+        Database.use((db) => {
+          db.insert(ProjectTable)
+            .values({
+              id: project,
+              worktree: tmp.path,
+              vcs: "git",
+              time_created: Date.now(),
+              time_updated: Date.now(),
+              sandboxes: [],
+            })
+            .run()
+          db.update(SessionTable).set({ project_id: project }).where(eq(SessionTable.id, session.id)).run()
+        })
+
+        const sessions = [...Session.list({ directory: tmp.path })]
+        const ids = sessions.map((item) => item.id)
+
+        expect(ids).toContain(session.id)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Instance } from "../../src/project/instance"
-import { ProjectID } from "../../src/project/schema" // kilocode_change
-import { ProjectTable } from "../../src/project/project.sql" // kilocode_change
 import { Session } from "../../src/session"
-import { SessionTable } from "../../src/session/session.sql" // kilocode_change
-import { Database, eq } from "../../src/storage/db" // kilocode_change
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 
@@ -36,37 +32,6 @@ describe("Session.list", () => {
       },
     })
   })
-
-  // kilocode_change start: test legacy project id directory lookup
-  test("includes directory matches from legacy project ids", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const session = await Session.create({ title: "legacy-session" })
-        const project = ProjectID.make("legacy-project")
-        Database.use((db) => {
-          db.insert(ProjectTable)
-            .values({
-              id: project,
-              worktree: tmp.path,
-              vcs: "git",
-              time_created: Date.now(),
-              time_updated: Date.now(),
-              sandboxes: [],
-            })
-            .run()
-          db.update(SessionTable).set({ project_id: project }).where(eq(SessionTable.id, session.id)).run()
-        })
-
-        const sessions = [...Session.list({ directory: tmp.path })]
-        const ids = sessions.map((s) => s.id)
-
-        expect(ids).toContain(session.id)
-      },
-    })
-  })
-  // kilocode_change end
 
   test("filters root sessions", async () => {
     await using tmp = await tmpdir({ git: true })

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Instance } from "../../src/project/instance"
+import { ProjectID } from "../../src/project/schema" // kilocode_change
+import { ProjectTable } from "../../src/project/project.sql" // kilocode_change
 import { Session } from "../../src/session"
+import { SessionTable } from "../../src/session/session.sql" // kilocode_change
+import { Database, eq } from "../../src/storage/db" // kilocode_change
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 
@@ -32,6 +36,37 @@ describe("Session.list", () => {
       },
     })
   })
+
+  // kilocode_change start: test legacy project id directory lookup
+  test("includes directory matches from legacy project ids", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({ title: "legacy-session" })
+        const project = ProjectID.make("legacy-project")
+        Database.use((db) => {
+          db.insert(ProjectTable)
+            .values({
+              id: project,
+              worktree: tmp.path,
+              vcs: "git",
+              time_created: Date.now(),
+              time_updated: Date.now(),
+              sandboxes: [],
+            })
+            .run()
+          db.update(SessionTable).set({ project_id: project }).where(eq(SessionTable.id, session.id)).run()
+        })
+
+        const sessions = [...Session.list({ directory: tmp.path })]
+        const ids = sessions.map((s) => s.id)
+
+        expect(ids).toContain(session.id)
+      },
+    })
+  })
+  // kilocode_change end
 
   test("filters root sessions", async () => {
     await using tmp = await tmpdir({ git: true })


### PR DESCRIPTION
## Summary
- Keep Agent Manager worktree sessions returned from registered worktree directories even when their project ID differs from the root session list.
- Add regression coverage for legacy project IDs so existing worktree sessions continue after backend project identity changes.