### PR TITLE
docs(architecture): add Gas Town section to architecture overview

### DIFF
--- a/packages/kilo-docs/pages/contributing/architecture/index.md
+++ b/packages/kilo-docs/pages/contributing/architecture/index.md
@@ -25,6 +25,7 @@ graph LR
     cloudagent["Cloud Agent"]
     bot["Kilo Bot"]
     claw["KiloClaw"]
+    gastown["Gas Town"]
     review["Code Review"]
     triage["Auto Triage"]
     appbuilder["App Builder"]
@@ -40,6 +41,8 @@ graph LR
   provider -- Gateway --> gateway
   gateway --> providers
   claw --> gateway
+  gastown -->|Container| cli
+  gastown --> gateway
 
   bot --> cloudagent
   review --> cloudagent
@@ -127,6 +130,28 @@ An automated issue triage service that classifies GitHub issues (bug, feature, q
 ### App Builder
 
 A service that builds and deploys user applications via the Cloud Agent. Users can generate full applications from prompts, with the App Builder orchestrating the Cloud Agent to scaffold, iterate, and deploy the result.
+
+### Gas Town
+
+A multi-agent orchestration platform that coordinates autonomous AI coding agents working on real Git repositories. Gas Town runs entirely on Cloudflare — a central Durable Object manages all state, while Docker containers on Cloudflare Containers run agent processes via the Kilo CLI.
+
+Key concepts:
+
+- **Town** — A workspace/project that contains one or more rigs (repositories)
+- **Rig** — A Git repository attached to a town where agents perform work
+- **Bead** — A unit of work (issue, task, merge request, or message)
+- **Convoy** — A batch of related beads with dependency tracking, dispatched together
+
+Agents operate in a hierarchy:
+
+| Agent    | Role                                                                                       |
+| -------- | ------------------------------------------------------------------------------------------ |
+| Mayor    | Persistent conversational coordinator — decomposes tasks and delegates to worker agents     |
+| Polecat  | Worker agent — clones repo worktrees, writes code, commits, pushes, and creates PRs        |
+| Refinery | Code review agent — reviews polecat branches, runs quality gates, merges or requests rework |
+| Triage   | Ephemeral agent that resolves ambiguous situations detected by automated patrol checks      |
+
+A reconciler loop running every 5 seconds drives all state transitions: dispatching agents, transitioning beads, polling PR status, managing convoys, and recovering from failures.
 
 ### Supporting Services
 
@@ -233,7 +258,7 @@ The project uses:
 | Repository                                                | Contents                                                                                                             |
 | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | [Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode) | CLI engine, VS Code extension, SDK, gateway client, telemetry, docs, UI components                                   |
-| Cloud (private)                                           | Web dashboard, Cloud Agent, Kilo Bot, KiloClaw, code review, auto triage, billing, and supporting Cloudflare Workers |
+| Cloud (private)                                           | Web dashboard, Cloud Agent, Kilo Bot, KiloClaw, Gas Town, code review, auto triage, billing, and supporting Cloudflare Workers |
 
 ## Further Reading
 


### PR DESCRIPTION
## Summary

- Adds a **Gas Town** section to the Architecture Overview page, covering the multi-agent orchestration platform that was entirely absent from the public docs
- Documents the four key domain concepts (Town, Rig, Bead, Convoy) and the agent hierarchy (Mayor, Polecat, Refinery, Triage)
- Adds Gas Town to the mermaid system diagram and the Repositories table
- Updates the Cloud (private) repo description to mention Gas Town

## Verification

- Rendered the docs site locally (`next dev --port 3002`) and confirmed the Gas Town section displays correctly with prose, bullet list, and agents table
- TypeScript typecheck passed via pre-push hook

## Visual Changes

Gas Town section renders between App Builder and Supporting Services with a description paragraph, key concepts bullet list, and an agents table.

## Reviewer Notes

Content is sourced from the private cloud repo codebase. No functional code changes — docs only.