### PR TITLE
ci: fix broken CLI tests and run them in CI

### DIFF
--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "prepare": "effect-language-service patch || true",
     "typecheck": "tsgo --noEmit",
-    "test": "bun test --timeout 30000",
+    "test": "bun run script/test.ts",
     "build": "bun run script/build.ts",
     "upgrade-opentui": "bun run script/upgrade-opentui.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",

--- a/packages/opencode/script/test.ts
+++ b/packages/opencode/script/test.ts
@@ -1,0 +1,38 @@
+// kilocode_change - new file
+// RATIONALE: Bun's mock.module() replaces module resolution globally for the
+// entire process (oven-sh/bun#12823). Files using mock.module() must run in
+// isolated processes to prevent cross-test contamination.
+const polluters = [
+  "test/cli/tui/thread.test.ts",
+  "test/kilo-sessions/kilo-sessions-enable-remote.test.ts",
+  "test/kilocode/local-model.test.ts",
+  "test/kilocode/model-cache-org.test.ts",
+  "test/kilocode/run-network.test.ts",
+  "test/kilocode/session-import-service.test.ts",
+  "test/mcp/headers.test.ts",
+  "test/mcp/lifecycle.test.ts",
+  "test/mcp/oauth-auto-connect.test.ts",
+  "test/mcp/oauth-browser.test.ts",
+  "test/server/experimental-session-list.test.ts",
+  "test/server/global-session-list.test.ts",
+  "test/tool/recall.test.ts",
+  "src/commit-message/__tests__/generate.test.ts",
+  "src/commit-message/__tests__/git-context.test.ts",
+]
+
+const timeout = "30000"
+
+async function run(cmd: string[]) {
+  const proc = Bun.spawn(cmd, {
+    stdio: ["inherit", "inherit", "inherit"],
+    windowsHide: true,
+  })
+  const code = await proc.exited
+  if (code !== 0) process.exit(code)
+}
+
+await run(["bun", "test", "--timeout", timeout, ...polluters.flatMap((p) => ["--path-ignore-patterns", p])])
+
+for (const file of polluters) {
+  await run(["bun", "test", "--timeout", timeout, file])
+}

--- a/packages/opencode/src/commit-message/__tests__/generate.test.ts
+++ b/packages/opencode/src/commit-message/__tests__/generate.test.ts
@@ -29,6 +29,11 @@ mock.module("@/provider/provider", () => ({
 mock.module("@/session/llm", () => ({
   LLM: {
     stream: async () => ({
+      // kilocode_change start
+      textStream: (async function* () {
+        yield mockStreamText
+      })(),
+      // kilocode_change end
       text: Promise.resolve(mockStreamText),
     }),
   },

--- a/packages/opencode/src/kilocode/rules-migrator.ts
+++ b/packages/opencode/src/kilocode/rules-migrator.ts
@@ -5,7 +5,7 @@ import os from "os"
 export namespace RulesMigrator {
   // Only support .kilocoderules (no migration for .roorules or .clinerules)
   const LEGACY_RULE_FILE = ".kilocoderules"
-  const home = () => process.env.HOME || process.env.USERPROFILE || os.homedir()
+  const home = () => process.env.KILO_TEST_HOME || process.env.HOME || process.env.USERPROFILE || os.homedir()
 
   // Directory-based rules (read from both .kilo and .kilocode)
   const KILO_RULES_DIRS = [".kilo/rules", ".kilocode/rules"]

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -198,7 +198,7 @@ export namespace Permission {
         // kilocode_change end
 
         for (const pattern of request.patterns) {
-          const rule = evaluate(request.permission, pattern, ruleset, approved)
+          const rule = evaluate(request.permission, pattern, ruleset, approved, local) // kilocode_change — include session-scoped rules
           log.info("evaluated", { permission: request.permission, pattern, action: rule })
           if (rule.action === "deny") {
             return yield* new DeniedError({

--- a/packages/opencode/test/kilo-sessions/kilo-sessions-enable-remote.test.ts
+++ b/packages/opencode/test/kilo-sessions/kilo-sessions-enable-remote.test.ts
@@ -79,8 +79,19 @@ describe("KiloSessions.enableRemote", () => {
   })
 
   afterEach(async () => {
+    delete process.env["KILO_DISABLE_SESSION_INGEST"]
+    delete process.env["KILO_SESSION_INGEST_URL"]
+
+    await using tmp = await tmpdir()
+    const { Instance } = await import("../../src/project/instance")
     const { KiloSessions } = await import("../../src/kilo-sessions/kilo-sessions")
-    KiloSessions.disableRemote()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        KiloSessions.disableRemote()
+      },
+    })
   })
 
   test("concurrent enableRemote shares one connection", async () => {
@@ -94,6 +105,7 @@ describe("KiloSessions.enableRemote", () => {
         await Promise.all([KiloSessions.enableRemote(), KiloSessions.enableRemote(), KiloSessions.enableRemote()])
         expect(state.connects).toBe(1)
         expect(KiloSessions.remoteStatus()).toEqual({ enabled: true, connected: true })
+        KiloSessions.disableRemote()
       },
     })
   })
@@ -196,6 +208,7 @@ describe("KiloSessions.enableRemote", () => {
         expect(state.disposes).toBe(1)
         expect(state.closes).toBe(1)
         expect(KiloSessions.remoteStatus()).toEqual({ enabled: true, connected: true })
+        KiloSessions.disableRemote()
       },
     })
   })

--- a/packages/opencode/test/kilocode/mcp-docker-rm.test.ts
+++ b/packages/opencode/test/kilocode/mcp-docker-rm.test.ts
@@ -7,9 +7,10 @@ describe("ensureDockerRm", () => {
     expect(result).toEqual(["run", "--rm", "-i", "my-image"])
   })
 
-  test("keeps existing --rm and adds another (Docker treats duplicates as no-op)", () => {
-    const result = MCP.ensureDockerRm("docker", ["run", "--rm", "-i", "my-image"])
-    expect(result).toEqual(["run", "--rm", "--rm", "-i", "my-image"])
+  test("does not duplicate --rm when already present", () => {
+    const args = ["run", "--rm", "-i", "my-image"]
+    const result = MCP.ensureDockerRm("docker", args)
+    expect(result).toBe(args)
   })
 
   test("does not modify non-docker commands", () => {

--- a/packages/opencode/test/kilocode/paths.test.ts
+++ b/packages/opencode/test/kilocode/paths.test.ts
@@ -94,8 +94,9 @@ description: Nested skill
       })
 
       expect(result).toHaveLength(2)
-      expect(result.some((d) => d.includes("packages/nested"))).toBe(true)
-      expect(result.some((d) => !d.includes("packages/nested"))).toBe(true)
+      const nested = path.join("packages", "nested")
+      expect(result.some((d) => d.includes(nested))).toBe(true)
+      expect(result.some((d) => !d.includes(nested))).toBe(true)
     })
 
     test("handles .kilo directory without skills subdirectory", async () => {

--- a/packages/opencode/test/kilocode/permission/next.always-rules.test.ts
+++ b/packages/opencode/test/kilocode/permission/next.always-rules.test.ts
@@ -1,10 +1,24 @@
-import { test, expect, describe } from "bun:test"
+import { test, expect, describe, afterAll } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
 import { Permission } from "../../../src/permission"
 import { PermissionID } from "../../../src/permission/schema"
 import { SessionID } from "../../../src/session/schema"
 import { Instance } from "../../../src/project/instance"
-import { NotFoundError } from "../../../src/storage/db"
+import { Config } from "../../../src/config/config"
+import { Global } from "../../../src/global"
 import { tmpdir } from "../../fixture/fixture"
+
+// RATIONALE: saveAlwaysRules calls Config.updateGlobal() which writes bash
+// permission rules to the shared global config file. Clean it up so other
+// tests in the same process don't see stale permission keys.
+afterAll(async () => {
+  const dir = Global.Path.config
+  for (const file of ["kilo.jsonc", "kilo.json", "config.json", "opencode.json", "opencode.jsonc"]) {
+    await fs.rm(path.join(dir, file), { force: true }).catch(() => {})
+  }
+  await Config.invalidate(true)
+})
 
 describe("saveAlwaysRules", () => {
   test("approved rules auto-allow future requests", async () => {
@@ -88,7 +102,7 @@ describe("saveAlwaysRules", () => {
             requestID: PermissionID.make("permission_nonexistent"),
             approvedAlways: ["npm install"],
           }),
-        ).rejects.toBeInstanceOf(NotFoundError)
+        ).resolves.toBeUndefined()
       },
     })
   })
@@ -542,7 +556,7 @@ describe("saveAlwaysRules", () => {
         // Subagent B should auto-reject because "git log --oneline -10" matches denied "git log *"
         await Permission.reply({ requestID: PermissionID.make("permission_a5"), reply: "once" })
         await expect(askA).resolves.toBeUndefined()
-        await expect(askB).rejects.toBeInstanceOf(Permission.DeniedError)
+        await expect(askB).rejects.toBeInstanceOf(Permission.RejectedError)
       },
     })
   })

--- a/packages/opencode/test/kilocode/rules-migrator.test.ts
+++ b/packages/opencode/test/kilocode/rules-migrator.test.ts
@@ -6,12 +6,16 @@ import fs from "fs/promises"
 
 async function withHome<T>(home: string, fn: () => Promise<T>): Promise<T> {
   const prev = process.env.HOME
+  const prevTest = process.env.KILO_TEST_HOME
   process.env.HOME = home
+  process.env.KILO_TEST_HOME = home
   try {
     return await fn()
   } finally {
     if (prev) process.env.HOME = prev
     else delete process.env.HOME
+    if (prevTest) process.env.KILO_TEST_HOME = prevTest
+    else delete process.env.KILO_TEST_HOME
   }
 }
 
@@ -76,7 +80,7 @@ describe("RulesMigrator", () => {
 
       // Only one main.md should be found (.kilo wins)
       expect(mainRules).toHaveLength(1)
-      expect(mainRules[0].path).toContain(".kilo/")
+      expect(mainRules[0].path).toContain(`.kilo${path.sep}`)
     })
 
     test("discovers mode-specific directory rules", async () => {

--- a/packages/opencode/test/kilocode/session-processor-network-offline.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-network-offline.test.ts
@@ -111,6 +111,7 @@ describe("session processor network offline", () => {
       (dir) =>
         Effect.gen(function* () {
           const test = yield* TestLLM
+          const bus = yield* Bus.Service
           const processors = yield* SessionProcessor.Service
           const session = yield* Session.Service
 
@@ -134,7 +135,7 @@ describe("session processor network offline", () => {
 
           // Auto-reply to network reconnect request
           const statuses: unknown[] = []
-          const off = Bus.subscribe(SessionStatus.Event.Status, (event) => {
+          const off = yield* bus.subscribeCallback(SessionStatus.Event.Status, (event) => {
             statuses.push(event.properties.status)
           })
           const offAsk = Bus.subscribe(SessionNetwork.Event.Asked, (event) => {

--- a/packages/opencode/test/kilocode/session-processor-retry-limit.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-retry-limit.test.ts
@@ -5,7 +5,7 @@
 process.env.KILO_SESSION_RETRY_LIMIT = "2"
 
 import { NodeFileSystem } from "@effect/platform-node"
-import { afterEach, describe, expect, spyOn } from "bun:test"
+import { afterEach, describe, expect } from "bun:test"
 import { APICallError } from "ai"
 import { Effect, Layer, ServiceMap } from "effect"
 import * as Stream from "effect/Stream"
@@ -21,7 +21,7 @@ import { Session } from "../../src/session"
 import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionProcessor } from "../../src/session/processor"
-import { SessionRetry } from "../../src/session/retry"
+import { Flag } from "../../src/flag/flag"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { Snapshot } from "../../src/snapshot"
@@ -123,13 +123,17 @@ afterEach(() => {
 })
 
 describe("session processor retry limit", () => {
-  it.effect("stops after two retries with the normalized retryable error", () =>
+  it.live("stops after two retries with the normalized retryable error", () =>
     provideTmpdirInstance(
       (dir) =>
         Effect.gen(function* () {
           const test = yield* TestLLM
+          const bus = yield* Bus.Service
           const processors = yield* SessionProcessor.Service
           const session = yield* Session.Service
+          const flag = Flag as unknown as { KILO_SESSION_RETRY_LIMIT: number | undefined }
+          const prev = flag.KILO_SESSION_RETRY_LIMIT
+          flag.KILO_SESSION_RETRY_LIMIT = 2
 
           // 3 retryable 429 errors + sentinel (should not be reached)
           yield* test.push(Stream.fail(retryable429()))
@@ -139,14 +143,13 @@ describe("session processor retry limit", () => {
 
           const retry: number[] = []
           const errors: Array<MessageV2.Assistant["error"]> = []
-          const unsubStatus = Bus.subscribe(SessionStatus.Event.Status, (event) => {
+          const unsubStatus = yield* bus.subscribeCallback(SessionStatus.Event.Status, (event) => {
             if (event.properties.status.type !== "retry") return
             retry.push(event.properties.status.attempt)
           })
-          const unsubError = Bus.subscribe(Session.Event.Error, (event) => {
+          const unsubError = yield* bus.subscribeCallback(Session.Event.Error, (event) => {
             errors.push(event.properties.error)
           })
-          const delay = spyOn(SessionRetry, "delay").mockReturnValue(0)
 
           const chat = yield* session.create({})
           const parent = yield* session.updateMessage({
@@ -197,14 +200,13 @@ describe("session processor retry limit", () => {
 
             expect(result).toBe("stop")
             expect(calls).toBe(3)
-            expect(delay).toHaveBeenCalled()
             expect(retry).toStrictEqual([1, 2])
             expect(handle.message.error).toStrictEqual(expected)
             expect(errors).toStrictEqual([expected])
           } finally {
             unsubStatus()
             unsubError()
-            delay.mockRestore()
+            flag.KILO_SESSION_RETRY_LIMIT = prev
           }
         }),
       { git: true },

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -1,6 +1,10 @@
-import { afterEach, test, expect } from "bun:test"
+import { afterAll, afterEach, test, expect } from "bun:test" // kilocode_change
+import fs from "fs/promises" // kilocode_change
 import os from "os"
+import path from "path" // kilocode_change
 import { Bus } from "../../src/bus"
+import { Config } from "../../src/config/config" // kilocode_change
+import { Global } from "../../src/global" // kilocode_change
 import { Permission } from "../../src/permission"
 import { PermissionID } from "../../src/permission/schema"
 import { Instance } from "../../src/project/instance"
@@ -10,6 +14,19 @@ import { MessageID, SessionID } from "../../src/session/schema"
 afterEach(async () => {
   await Instance.disposeAll()
 })
+
+// kilocode_change start
+// RATIONALE: reply("always") calls Config.updateGlobal() which writes bash
+// permission rules to the shared global config file. Clean up so other tests
+// in the same process don't see stale permission keys.
+afterAll(async () => {
+  const dir = Global.Path.config
+  for (const file of ["kilo.jsonc", "kilo.json", "config.json", "opencode.json", "opencode.jsonc"]) {
+    await fs.rm(path.join(dir, file), { force: true }).catch(() => {})
+  }
+  await Config.invalidate(true)
+})
+// kilocode_change end
 
 async function rejectAll(message?: string) {
   for (const req of await Permission.list()) {

--- a/packages/opencode/test/server/experimental-session-list.test.ts
+++ b/packages/opencode/test/server/experimental-session-list.test.ts
@@ -33,7 +33,7 @@ describe("experimental.session.list", () => {
 
     try {
       await $`git worktree add ${worktree} -b test-branch-${Date.now()}`.cwd(first.path).quiet()
-      await Bun.write(path.join(first.path, ".git", "opencode"), "stale-project-id")
+      await Bun.write(path.join(first.path, ".git", "kilo"), "stale-project-id")
 
       const share = Config.get
       Config.get = async () => ({ share: "manual" }) as Awaited<ReturnType<typeof Config.get>>
@@ -51,6 +51,7 @@ describe("experimental.session.list", () => {
             session: await Session.create({ title: "root-session" }),
           }),
         })
+        await Bun.file(path.join(first.path, ".git", "kilo")).delete()
 
         const branch = await Instance.provide({
           directory: worktree,

--- a/packages/opencode/test/server/global-session-list.test.ts
+++ b/packages/opencode/test/server/global-session-list.test.ts
@@ -116,12 +116,13 @@ describe("Session.listGlobal", () => {
 
     try {
       await $`git worktree add ${worktree} -b test-branch-${Date.now()}`.cwd(first.path).quiet()
-      await Bun.write(path.join(first.path, ".git", "opencode"), "stale-project-id")
+      await Bun.write(path.join(first.path, ".git", "kilo"), "stale-project-id")
 
       const root = await Instance.provide({
         directory: first.path,
         fn: async () => Session.create({ title: "root-session" }),
       })
+      await Bun.file(path.join(first.path, ".git", "kilo")).delete()
       const branch = await Instance.provide({
         directory: worktree,
         fn: async () => Session.create({ title: "worktree-session" }),

--- a/packages/opencode/test/server/session-select.test.ts
+++ b/packages/opencode/test/server/session-select.test.ts
@@ -60,7 +60,9 @@ describe("tui.selectSession endpoint", () => {
     })
   })
 
-  test("should return 400 when session ID format is invalid", async () => {
+  // kilocode_change start - bun bug on windows causes segfault
+  test.skipIf(process.platform === "win32")("should return 400 when session ID format is invalid", async () => {
+    // kilocode_change end
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({
       directory: tmp.path,

--- a/packages/opencode/test/storage/db.test.ts
+++ b/packages/opencode/test/storage/db.test.ts
@@ -1,14 +1,22 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
+import { Flag } from "../../src/flag/flag" // kilocode_change
 import { Global } from "../../src/global"
 import { Installation } from "../../src/installation"
 import { Database } from "../../src/storage/db"
 
 describe("Database.Path", () => {
+  // kilocode_change start
+  // RATIONALE: preload sets KILO_DB=:memory: which takes precedence via iife evaluation
   test("returns database path for the current channel", () => {
-    const expected = ["latest", "beta"].includes(Installation.CHANNEL)
-      ? path.join(Global.Path.data, "kilo.db")
-      : path.join(Global.Path.data, `kilo-${Installation.CHANNEL.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`)
+    const expected = Flag.KILO_DB
+      ? Flag.KILO_DB === ":memory:" || path.isAbsolute(Flag.KILO_DB)
+        ? Flag.KILO_DB
+        : path.join(Global.Path.data, Flag.KILO_DB)
+      : ["latest", "beta"].includes(Installation.CHANNEL)
+        ? path.join(Global.Path.data, "kilo.db")
+        : path.join(Global.Path.data, `kilo-${Installation.CHANNEL.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`)
+    // kilocode_change end
     expect(Database.Path).toBe(expected)
   })
 })

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -890,9 +890,8 @@ describe("tool.bash permissions", () => {
         await bash.execute({ command: "ls -la", description: "List" }, capture(requests))
         const bashReq = requests.find((r) => r.permission === "bash")
         expect(bashReq).toBeDefined()
-        // kilocode_change start — hierarchy adds base wildcard + exact
+        // kilocode_change start — hierarchy adds base wildcard
         expect(bashReq!.always).toContain("ls *")
-        expect(bashReq!.metadata.rules).toContain("ls -la")
         // kilocode_change end
       },
     })

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,7 @@
       "dependsOn": [],
       "outputs": ["dist/**"]
     },
-    "opencode#test": {
+    "@kilocode/cli#test": {
       "dependsOn": ["^build"],
       "outputs": [],
       "passThroughEnv": ["*"]


### PR DESCRIPTION
## Context

I discovered that the CLI unit tests are not running as part of the CI flow. This means that breakages to the CLI could easily get merged into `main` without being caught.

## Implementation

- `turbo.json` has `"opencode#test"` but the package is named `@kilocode/cli`. This is the cause of CLI tests not running in CI.
- Isolate test files from `mock.module()` pollution. Several tests contain mock polluters which cause following test files to fail when the entire suite is run.
- Fix `RulesMigrator` home directory leaking real user config
- Fix `.git/opencode` → `.git/kilo` in worktree drift tests
- Fix stale test assertion — `ensureDockerRm` idempotency
- Fix stale test assertion — bash `metadata.rules`
- Fix broken tests that fail in isolation: `session-processor-network-offline.test.ts`, `session-processor-retry-limit.test.ts`, `next.always-rules.test.ts`
- Test bug: `test/storage/db.test.ts` - Test didn't account for `KILO_DB=:memory:` set by `test/preload.ts`
- Production bug: `src/permission/index.ts` - Session-scoped rules from `allowEverything()` were stored in `s.session[sessionID]` but never passed to `evaluate()` in `ask()`. Added `local` to the evaluate call.

Though there are several fixes, they are primarily small, with many isolated to kilo-specific test files.

## Get in Touch

ExpedientFalcon on Discord