### PR TITLE
fix(cli): invalidate provider state after auth changes

### DIFF
--- a/.changeset/fix-provider-auth-invalidation.md
+++ b/.changeset/fix-provider-auth-invalidation.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Fixed default model falling back to the free model after login or org switch by invalidating cached provider state when auth changes.

--- a/packages/kilo-gateway/src/cloud-sessions.ts
+++ b/packages/kilo-gateway/src/cloud-sessions.ts
@@ -61,6 +61,7 @@ export interface ImportDeps {
   Instance: {
     readonly directory: string
     readonly project: { readonly id: string }
+    disposeAll(): Promise<void>
   }
   SessionTable: object
   MessageTable: object

--- a/packages/kilo-gateway/src/cloud-sessions.ts
+++ b/packages/kilo-gateway/src/cloud-sessions.ts
@@ -61,7 +61,6 @@ export interface ImportDeps {
   Instance: {
     readonly directory: string
     readonly project: { readonly id: string }
-    disposeAll(): Promise<void>
   }
   SessionTable: object
   MessageTable: object

--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -206,6 +206,7 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
 
         ModelCache.clear("kilo")
         clearModesCache()
+        await Instance.disposeAll()
 
         return c.json(true)
       },

--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -32,6 +32,7 @@ interface KiloRoutesDeps extends ImportDeps {
   Auth: Auth
   ModelCache: ModelCache
   z: Z
+  Instance: ImportDeps["Instance"] & { disposeAll(): Promise<void> }
 }
 
 /**

--- a/packages/opencode/src/kilocode/server/server.ts
+++ b/packages/opencode/src/kilocode/server/server.ts
@@ -3,6 +3,7 @@
 // Imported by ../../server/server.ts with minimal kilocode_change markers.
 
 import { ModelCache } from "../../provider/model-cache"
+import { Instance } from "../../project/instance"
 
 /** Extra paths to skip request logging for */
 export function skipLogging(path: string): boolean {
@@ -17,9 +18,10 @@ export function corsOrigin(input: string): string | undefined {
   return undefined
 }
 
-/** Invalidate model cache after auth change */
-export function authChanged(providerID: string) {
+/** Invalidate model cache and provider state after auth change */
+export async function authChanged(providerID: string) {
   ModelCache.clear(providerID)
+  await Instance.disposeAll()
 }
 
 export const DOC_TITLE = "kilo"

--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -10,6 +10,7 @@ import z from "zod"
 
 import { Telemetry } from "@kilocode/kilo-telemetry" // kilocode_change
 import { ModelCache } from "./model-cache" // kilocode_change
+import { Instance } from "@/project/instance" // kilocode_change
 
 export namespace ProviderAuth {
   export const Method = z
@@ -263,6 +264,7 @@ export namespace ProviderAuth {
     }
     Telemetry.trackAuthSuccess(input.providerID)
     ModelCache.clear(input.providerID)
+    await Instance.disposeAll()
     // kilocode_change end
   }
 }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -132,7 +132,7 @@ export namespace Server {
           const providerID = c.req.valid("param").providerID
           const info = c.req.valid("json")
           await Auth.set(providerID, info)
-          KiloServer.authChanged(providerID) // kilocode_change
+          await KiloServer.authChanged(providerID) // kilocode_change
           return c.json(true)
         },
       )
@@ -163,7 +163,7 @@ export namespace Server {
         async (c) => {
           const providerID = c.req.valid("param").providerID
           await Auth.remove(providerID)
-          KiloServer.authChanged(providerID) // kilocode_change
+          await KiloServer.authChanged(providerID) // kilocode_change
           return c.json(true)
         },
       )


### PR DESCRIPTION
## Summary

- Invalidate `InstanceState` (provider cache) after auth changes so the `hasKey` check re-evaluates with updated credentials
- After the Effect migration in #8870, the provider `hasKey` decision was cached via `ScopedCache` and never refreshed — causing authenticated users to be stuck on the free model when auth state changed after provider init

Relates to #8870