### PR TITLE
docs: clarify changeset descriptions should be concise and user-directed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ Tests MUST test actual implementation, do not duplicate logic into a test.
 
 User-facing changes (features, fixes, breaking changes) require a changeset file for release notes. Run `bunx changeset add` or manually create `.changeset/<slug>.md`. Use `patch` for bug fixes, `minor` for new features, `major` for breaking changes. See `.changeset/README.md` for details.
 
-Changeset descriptions appear directly in release notes and are read by end users. Keep them concise and user-directed — describe **what changed from the user's perspective**, not implementation details. Write in imperative mood (e.g. "Add dark mode toggle" not "Added a new React component for dark mode toggling in the settings panel").
+Changeset descriptions appear directly in release notes and are read by end users. Keep them concise and feature-oriented — describe **what changed from the user's perspective**, not implementation details. Write in imperative mood (e.g. "Support exporting conversations as markdown" not "Add a new export handler that serializes session messages to .md files").
 
 ## Pull Requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,8 @@ Tests MUST test actual implementation, do not duplicate logic into a test.
 
 User-facing changes (features, fixes, breaking changes) require a changeset file for release notes. Run `bunx changeset add` or manually create `.changeset/<slug>.md`. Use `patch` for bug fixes, `minor` for new features, `major` for breaking changes. See `.changeset/README.md` for details.
 
+Changeset descriptions appear directly in release notes and are read by end users. Keep them concise and user-directed — describe **what changed from the user's perspective**, not implementation details. Write in imperative mood (e.g. "Add dark mode toggle" not "Added a new React component for dark mode toggling in the settings panel").
+
 ## Pull Requests
 
 PR descriptions should be 2-3 lines covering **what** changed and **why**. Focus on intent and context a reviewer can't get from the diff — skip file-by-file inventories, test result summaries, and anything obvious from the code itself.


### PR DESCRIPTION
## Summary

- Add guidance to AGENTS.md that changeset descriptions appear directly in release notes, so they should be concise, user-directed, and written in imperative mood.