### PR TITLE
perf(agent-manager): skip git stats polling for worktrees in collapsed sections

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -789,6 +789,7 @@ export class AgentManagerProvider implements Disposable {
       return null
     }
     // Remove from state BEFORE disk removal so pollers immediately stop targeting this worktree.
+    // Pre-emptive skip covers any in-flight poll that already captured getWorktrees().
     this.statsPoller.skipWorktree(worktreeId)
     this.prBridge.remove(worktreeId)
     this.run.remove(worktreeId)
@@ -1251,6 +1252,18 @@ export class AgentManagerProvider implements Disposable {
     }
   }
 
+  /** Sync the poller's skip set with currently collapsed sections. */
+  private syncPollerSkips(): void {
+    const state = this.state
+    if (!state) return
+    const skipped = new Set<string>()
+    for (const sec of state.getSections()) {
+      if (!sec.collapsed) continue
+      for (const id of state.getWorktreesInSection(sec.id)) skipped.add(id)
+    }
+    this.statsPoller.syncSkips(skipped)
+  }
+
   private pushState(): void {
     const state = this.state
     if (!state) return
@@ -1272,6 +1285,9 @@ export class AgentManagerProvider implements Disposable {
       ...run,
     })
 
+    // Sync skip set before enabling the poller so the first poll cycle
+    // already excludes worktrees in collapsed sections.
+    this.syncPollerSkips()
     this.statsPoller.setEnabled(worktrees.length > 0 || this.panel !== undefined)
     this.prBridge.poller.setEnabled(worktrees.length > 0)
   }

--- a/packages/kilo-vscode/src/agent-manager/GitStatsPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitStatsPoller.ts
@@ -84,12 +84,14 @@ export class GitStatsPoller {
     }
   }
 
-  skipWorktree(id: string): void {
-    this.skipWorktreeIds.add(id)
+  /** Replace the entire skip set with the given IDs. */
+  syncSkips(ids: Set<string>): void {
+    this.skipWorktreeIds = ids
   }
 
-  unskipWorktree(id: string): void {
-    this.skipWorktreeIds.delete(id)
+  /** Pre-emptively exclude a single worktree (e.g. before deletion). */
+  skipWorktree(id: string): void {
+    this.skipWorktreeIds.add(id)
   }
 
   setEnabled(enabled: boolean): void {

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -352,6 +352,15 @@ export class WorktreeStateManager {
     return this.sections.get(id)
   }
 
+  /** Return IDs of worktrees assigned to the given section. */
+  getWorktreesInSection(id: string): string[] {
+    const result: string[] = []
+    for (const wt of this.worktrees.values()) {
+      if (wt.sectionId === id) result.push(wt.id)
+    }
+    return result
+  }
+
   addSection(name: string, color: string | null, worktreeIds?: string[]): Section {
     this.setNormalizedWorktreeOrder(this.worktreeOrder)
     const id = generateId("sec")


### PR DESCRIPTION
## Summary

Syncs `GitStatsPoller`'s skip set with collapsed Agent Manager sections so worktrees hidden behind a collapsed section header are excluded from polling. Each skipped worktree saves 1 `aheadBehind` git subprocess + 1 `diffSummary` HTTP call per 5s poll cycle.

- Added declarative `syncSkips(Set)` on `GitStatsPoller` that replaces the skip set atomically based on current collapsed state
- `syncPollerSkips()` in the provider computes which worktrees belong to collapsed sections and is called from `pushState()`, covering all state mutations (section toggle, worktree move, section delete, initial load)
- Kept `skipWorktree(id)` for pre-emptive exclusion during deletion to cover in-flight polls

Closes #8900

## Related

- #8703 — visibility-aware polling and resolution caching (merged)
- #8896 — adaptive backoff with agent-awareness (open, follow-up)
- #8343 — original report of heavy git process load (closed)