### PR TITLE
feat(commit-message): inject user instructions into SCM commit message generation

### DIFF
--- a/packages/opencode/src/commit-message/__tests__/generate.test.ts
+++ b/packages/opencode/src/commit-message/__tests__/generate.test.ts
@@ -10,6 +10,7 @@ const realLog = await import("@/util/log")
 const realProvider = await import("@/provider/provider")
 const realLLM = await import("@/session/llm")
 const realAgent = await import("@/agent/agent")
+const realInstruction = await import("@/session/instruction")
 
 let mockGitContext: GitContext = {
   branch: "main",
@@ -56,6 +57,16 @@ mock.module("@/agent/agent", () => ({
   Agent: {},
 }))
 
+let mockInstructions: string[] = []
+
+mock.module("@/session/instruction", () => ({
+  ...realInstruction,
+  Instruction: {
+    ...realInstruction.Instruction,
+    system: async () => mockInstructions,
+  },
+}))
+
 mock.module("@/util/log", () => ({
   ...realLog,
   Log: {
@@ -79,6 +90,7 @@ describe("commit-message.generate", () => {
       files: [{ status: "modified" as const, path: "src/index.ts", diff: "+console.log('hello')" }],
     }
     mockStreamText = "feat(src): add hello world logging"
+    mockInstructions = []
   })
 
   describe("prompt construction", () => {

--- a/packages/opencode/src/commit-message/generate.ts
+++ b/packages/opencode/src/commit-message/generate.ts
@@ -1,6 +1,7 @@
 import { Provider } from "@/provider/provider"
 import { LLM } from "@/session/llm"
 import { Agent } from "@/agent/agent"
+import { Instruction } from "@/session/instruction"
 import { Log } from "@/util/log"
 import type { CommitMessageRequest, CommitMessageResponse, GitContext } from "./types"
 import { getGitContext } from "./git-context"
@@ -149,6 +150,16 @@ export async function generateCommitMessage(request: CommitMessageRequest): Prom
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
 
+  // Load user-configured instructions (AGENTS.md, instructions in kilo.jsonc, etc.)
+  let userInstructions: string[] = []
+  try {
+    userInstructions = await Instruction.system()
+  } catch (err) {
+    log.warn("failed to load user instructions, proceeding without them", {
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+
   try {
     const stream = await LLM.stream({
       agent,
@@ -176,7 +187,7 @@ export async function generateCommitMessage(request: CommitMessageRequest): Prom
       ],
       abort: controller.signal,
       sessionID: "commit-message",
-      system: [],
+      system: userInstructions,
       retries: 3,
     })
 

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -248,6 +248,10 @@ export namespace Instruction {
     return runPromise((svc) => svc.systemPaths())
   }
 
+  export async function system() {
+    return runPromise((svc) => svc.system())
+  }
+
   export function loaded(messages: MessageV2.WithParts[]) {
     return extract(messages)
   }


### PR DESCRIPTION
## Summary

Fixes #8899

- Expose `Instruction.system()` as a public static method so commit-message generation can load user-configured instruction files
- Load `AGENTS.md`, `CLAUDE.md`, and `kilo.jsonc` instructions into the commit message LLM call, replacing the previous empty `system: []`
- Gracefully fall back to the hardcoded prompt if instruction loading fails

## Changes

- **`packages/opencode/src/session/instruction.ts`** — Added `Instruction.system()` public static method (mirrors existing `systemPaths()` pattern)
- **`packages/opencode/src/commit-message/generate.ts`** — Import `Instruction`, load user instructions before the LLM call, pass them via `system` array
- **`packages/opencode/src/commit-message/__tests__/generate.test.ts`** — Added `Instruction.system()` mock for test isolation

## Test plan

- [x] All 11 existing unit tests pass
- [x] Typecheck passes (`bun typecheck`)
- [x] When `AGENTS.md` or `kilo.jsonc` contains commit message conventions, the generated message follows them
- [x] When no instruction files exist, commit message generation works as before (hardcoded conventional commits prompt)
- [x] When instruction loading fails, generation proceeds with a warning log and no user-visible error

🤖 Generated with [Claude Code](https://claude.com/claude-code)