### PR TITLE
fix(vscode): strip Electron env vars in dev launch script

### DIFF
--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -303,6 +303,13 @@ async function launch() {
     args.push("--wait")
   }
 
+  // Strip Electron/VS Code env vars so the spawned instance doesn't attach
+  // to the current Electron process (e.g. when launched from a VS Code task).
+  const env = { ...process.env }
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("ELECTRON_") || key.startsWith("VSCODE_")) delete env[key]
+  }
+
   console.log(`[launch] Starting VS Code (${mode} mode)`)
   console.log(`[launch] Executable: ${app}`)
   console.log(`[launch] Workspace:  ${workspace}`)
@@ -311,18 +318,11 @@ async function launch() {
   if (blocking) {
     const result = Bun.spawnSync([app, ...args], {
       cwd: workspace,
-      env: process.env,
+      env,
       stdio: ["ignore", "inherit", "inherit"],
     })
     console.log(`[launch] VS Code exited (code ${result.exitCode})`)
     return
-  }
-
-  // Strip Electron/VS Code env vars so the spawned instance doesn't attach
-  // to the current Electron process (e.g. when launched from a VS Code task).
-  const env = { ...process.env }
-  for (const key of Object.keys(env)) {
-    if (key.startsWith("ELECTRON_") || key.startsWith("VSCODE_")) delete env[key]
   }
 
   const child = spawn(app, args, {

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -318,10 +318,17 @@ async function launch() {
     return
   }
 
+  // Strip Electron/VS Code env vars so the spawned instance doesn't attach
+  // to the current Electron process (e.g. when launched from a VS Code task).
+  const env = { ...process.env }
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("ELECTRON_") || key.startsWith("VSCODE_")) delete env[key]
+  }
+
   const child = spawn(app, args, {
     cwd: workspace,
     detached: !win,
-    env: process.env,
+    env,
     stdio: "ignore",
     ...(win ? { shell: true } : {}),
   })


### PR DESCRIPTION
## Summary

When running `bun run extension` from the Agent Manager run button (Cmd+E), VS Code doesn't open a new window — it silently reuses the existing instance. Running the same command from a standalone terminal works fine.

**Root cause:** The run button executes inside a VS Code Task, which inherits the extension host's environment. This environment contains `ELECTRON_RUN_AS_NODE`, `VSCODE_PID`, `VSCODE_IPC_HOOK`, and other Electron/VS Code variables. When `launch.ts` spawns VS Code with these variables in `process.env`, the VS Code binary detects them and hands off to the already-running Electron instance instead of starting a new window.

In a normal terminal, these variables don't exist, so VS Code starts fresh.

**Fix:** Strip `ELECTRON_*` and `VSCODE_*` environment variables before spawning VS Code in both the blocking (`--wait`) and non-blocking launch paths. This is safe because `launch.ts` is a dev-only script — it's never shipped to end users.