### PR TITLE
Fix/vscode mcp oauth sign in

### DIFF
--- a/.changeset/restore-mcp-oauth-sign-in.md
+++ b/.changeset/restore-mcp-oauth-sign-in.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+---
+
+Restore the Sign in action for MCP servers that require OAuth authentication in VS Code settings.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -10,7 +10,6 @@ import type {
   TextPartInput,
   FilePartInput,
   Config,
-  McpStatus,
 } from "@kilocode/sdk/v2/client"
 import { type KiloConnectionService, ServerStartupError } from "./services/cli-backend"
 import type { EditorContext, IndexingStatus } from "./services/cli-backend/types"
@@ -67,6 +66,12 @@ import {
 import * as ModelState from "./kilo-provider/model-state"
 import { handleForkSession } from "./kilo-provider/fork-session"
 import { openConfig } from "./kilo-provider/open-config"
+import {
+  authenticateMcpServer,
+  connectMcpServer,
+  disconnectMcpServer,
+  openMcpOAuthUrlOnce,
+} from "./kilo-provider/mcp-oauth"
 import { retryable, backoff, MAX_RETRIES } from "./util/retry"
 import { hasGit } from "./kilo-provider/git-status"
 // legacy-migration start
@@ -143,11 +148,6 @@ const mapAgent = (a: Agent) => ({
 export class KiloProvider implements vscode.WebviewViewProvider, TelemetryPropertiesProvider {
   public static readonly viewType = "kilo-code.SidebarProvider"
   private readonly instanceId = crypto.randomUUID()
-  /**
-   * When several webviews subscribe to SSE, the same `mcp.browser.open.failed` is delivered
-   * to each provider — dedupe so we only call openExternal once per URL in a short window.
-   */
-  private static lastMcpBrowserOpen: { url: string; at: number } | null = null
 
   private webview: vscode.Webview | null = null
   private currentSession: Session | null = null
@@ -582,6 +582,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.webviewMessageDisposable?.dispose()
     this.autocompleteConfigDisposable?.dispose()
     this.autocompleteConfigDisposable = watchAutocompleteConfig((msg) => this.postMessage(msg))
+    // eslint-disable-next-line complexity -- exhaustive webview protocol switch
     this.webviewMessageDisposable = webview.onDidReceiveMessage(async (message) => {
       const intercepted = await interceptMessage(message, {
         workspaceDir: (sid) => this.getWorkspaceDirectory(sid ?? this.currentSession?.id),
@@ -802,19 +803,33 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "requestMcpStatus":
           this.fetchAndSendMcpStatus().catch((e) => console.error("[Kilo New] fetchAndSendMcpStatus failed:", e))
           break
-        case "connectMcp":
-          this.handleConnectMcp(message.name).catch((e) => console.error("[Kilo New] handleConnectMcp failed:", e))
+        case "connectMcp": {
+          const c1 = this.client
+          if (c1) {
+            void connectMcpServer(c1, message.name, this.getWorkspaceDirectory(), () => this.fetchAndSendMcpStatus()).catch(
+              (e) => console.error("[Kilo New] connectMcpServer failed:", e),
+            )
+          }
           break
-        case "disconnectMcp":
-          this.handleDisconnectMcp(message.name).catch((e) =>
-            console.error("[Kilo New] handleDisconnectMcp failed:", e),
-          )
+        }
+        case "disconnectMcp": {
+          const c2 = this.client
+          if (c2) {
+            void disconnectMcpServer(c2, message.name, this.getWorkspaceDirectory(), () =>
+              this.fetchAndSendMcpStatus(),
+            ).catch((e) => console.error("[Kilo New] disconnectMcpServer failed:", e))
+          }
           break
-        case "authenticateMcp":
-          this.handleAuthenticateMcp(message.name).catch((e) =>
-            console.error("[Kilo New] handleAuthenticateMcp failed:", e),
-          )
+        }
+        case "authenticateMcp": {
+          const c = this.client
+          if (c) {
+            void authenticateMcpServer(c, message.name, this.getWorkspaceDirectory(), () =>
+              this.fetchAndSendMcpStatus(),
+            ).catch((e) => console.error("[Kilo New] authenticateMcpServer failed:", e))
+          }
           break
+        }
 
         case "questionReply":
           this.noteFollowup(message.answers, message.sessionID)
@@ -1961,61 +1976,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
-  private async handleConnectMcp(name: string): Promise<void> {
-    if (!this.client) return
-    try {
-      const directory = this.getWorkspaceDirectory()
-      await this.client.mcp.connect({ name, directory })
-      await this.fetchAndSendMcpStatus()
-    } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to connect MCP:", name, error)
-      await this.fetchAndSendMcpStatus()
-    }
-  }
-
-  private async handleDisconnectMcp(name: string): Promise<void> {
-    if (!this.client) return
-    try {
-      const directory = this.getWorkspaceDirectory()
-      await this.client.mcp.disconnect({ name, directory })
-      await this.fetchAndSendMcpStatus()
-    } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to disconnect MCP:", name, error)
-      await this.fetchAndSendMcpStatus()
-    }
-  }
-
-  private openMcpOAuthUrlOnce(url: string): void {
-    const now = Date.now()
-    const last = KiloProvider.lastMcpBrowserOpen
-    if (last && last.url === url && now - last.at < 4000) return
-    KiloProvider.lastMcpBrowserOpen = { url, at: now }
-    void vscode.env.openExternal(vscode.Uri.parse(url))
-  }
-
-  private async handleAuthenticateMcp(name: string): Promise<void> {
-    if (!this.client) return
-    try {
-      const directory = this.getWorkspaceDirectory()
-      const { data, error } = await this.client.mcp.auth.authenticate({ name, directory })
-      if (error) {
-        vscode.window.showErrorMessage(`MCP sign-in failed: ${getErrorMessage(error)}`)
-        return
-      }
-      const status = data as McpStatus | undefined
-      if (status?.status === "failed") {
-        vscode.window.showErrorMessage(status.error || "MCP OAuth failed")
-      } else if (status?.status === "needs_client_registration") {
-        vscode.window.showErrorMessage(status.error || "MCP server requires client registration in config")
-      }
-    } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to authenticate MCP:", name, error)
-      vscode.window.showErrorMessage(getErrorMessage(error) || "MCP sign-in failed")
-    } finally {
-      await this.fetchAndSendMcpStatus()
-    }
-  }
-
   /**
    * Remove a marketplace item from a single scope and invalidate CLI caches.
    */
@@ -3021,7 +2981,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     if (event.type === "mcp.browser.open.failed") {
-      this.openMcpOAuthUrlOnce(event.properties.url)
+      openMcpOAuthUrlOnce(event.properties.url)
       return
     }
 

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -10,6 +10,7 @@ import type {
   TextPartInput,
   FilePartInput,
   Config,
+  McpStatus,
 } from "@kilocode/sdk/v2/client"
 import { type KiloConnectionService, ServerStartupError } from "./services/cli-backend"
 import type { EditorContext, IndexingStatus } from "./services/cli-backend/types"
@@ -142,6 +143,11 @@ const mapAgent = (a: Agent) => ({
 export class KiloProvider implements vscode.WebviewViewProvider, TelemetryPropertiesProvider {
   public static readonly viewType = "kilo-code.SidebarProvider"
   private readonly instanceId = crypto.randomUUID()
+  /**
+   * When several webviews subscribe to SSE, the same `mcp.browser.open.failed` is delivered
+   * to each provider — dedupe so we only call openExternal once per URL in a short window.
+   */
+  private static lastMcpBrowserOpen: { url: string; at: number } | null = null
 
   private webview: vscode.Webview | null = null
   private currentSession: Session | null = null
@@ -802,6 +808,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "disconnectMcp":
           this.handleDisconnectMcp(message.name).catch((e) =>
             console.error("[Kilo New] handleDisconnectMcp failed:", e),
+          )
+          break
+        case "authenticateMcp":
+          this.handleAuthenticateMcp(message.name).catch((e) =>
+            console.error("[Kilo New] handleAuthenticateMcp failed:", e),
           )
           break
 
@@ -1974,6 +1985,37 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
+  private openMcpOAuthUrlOnce(url: string): void {
+    const now = Date.now()
+    const last = KiloProvider.lastMcpBrowserOpen
+    if (last && last.url === url && now - last.at < 4000) return
+    KiloProvider.lastMcpBrowserOpen = { url, at: now }
+    void vscode.env.openExternal(vscode.Uri.parse(url))
+  }
+
+  private async handleAuthenticateMcp(name: string): Promise<void> {
+    if (!this.client) return
+    try {
+      const directory = this.getWorkspaceDirectory()
+      const { data, error } = await this.client.mcp.auth.authenticate({ name, directory })
+      if (error) {
+        vscode.window.showErrorMessage(`MCP sign-in failed: ${getErrorMessage(error)}`)
+        return
+      }
+      const status = data as McpStatus | undefined
+      if (status?.status === "failed") {
+        vscode.window.showErrorMessage(status.error || "MCP OAuth failed")
+      } else if (status?.status === "needs_client_registration") {
+        vscode.window.showErrorMessage(status.error || "MCP server requires client registration in config")
+      }
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to authenticate MCP:", name, error)
+      vscode.window.showErrorMessage(getErrorMessage(error) || "MCP sign-in failed")
+    } finally {
+      await this.fetchAndSendMcpStatus()
+    }
+  }
+
   /**
    * Remove a marketplace item from a single scope and invalidate CLI caches.
    */
@@ -2976,6 +3018,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
     if (event.type === "permission.replied") {
       this.permissionDirectories.delete(event.properties.requestID)
+    }
+
+    if (event.type === "mcp.browser.open.failed") {
+      this.openMcpOAuthUrlOnce(event.properties.url)
+      return
     }
 
     if (event.type === "message.updated") {

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -66,12 +66,7 @@ import {
 import * as ModelState from "./kilo-provider/model-state"
 import { handleForkSession } from "./kilo-provider/fork-session"
 import { openConfig } from "./kilo-provider/open-config"
-import {
-  authenticateMcpServer,
-  connectMcpServer,
-  disconnectMcpServer,
-  openMcpOAuthUrlOnce,
-} from "./kilo-provider/mcp-oauth"
+import * as McpOAuth from "./kilo-provider/mcp-oauth"
 import { retryable, backoff, MAX_RETRIES } from "./util/retry"
 import { hasGit } from "./kilo-provider/git-status"
 // legacy-migration start
@@ -582,7 +577,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.webviewMessageDisposable?.dispose()
     this.autocompleteConfigDisposable?.dispose()
     this.autocompleteConfigDisposable = watchAutocompleteConfig((msg) => this.postMessage(msg))
-    // eslint-disable-next-line complexity -- exhaustive webview protocol switch
     this.webviewMessageDisposable = webview.onDidReceiveMessage(async (message) => {
       const intercepted = await interceptMessage(message, {
         workspaceDir: (sid) => this.getWorkspaceDirectory(sid ?? this.currentSession?.id),
@@ -806,16 +800,16 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "connectMcp": {
           const c1 = this.client
           if (c1) {
-            void connectMcpServer(c1, message.name, this.getWorkspaceDirectory(), () => this.fetchAndSendMcpStatus()).catch(
-              (e) => console.error("[Kilo New] connectMcpServer failed:", e),
-            )
+            void McpOAuth.connectMcpServer(c1, message.name, this.getWorkspaceDirectory(), () =>
+              this.fetchAndSendMcpStatus(),
+            ).catch((e) => console.error("[Kilo New] connectMcpServer failed:", e))
           }
           break
         }
         case "disconnectMcp": {
           const c2 = this.client
           if (c2) {
-            void disconnectMcpServer(c2, message.name, this.getWorkspaceDirectory(), () =>
+            void McpOAuth.disconnectMcpServer(c2, message.name, this.getWorkspaceDirectory(), () =>
               this.fetchAndSendMcpStatus(),
             ).catch((e) => console.error("[Kilo New] disconnectMcpServer failed:", e))
           }
@@ -824,7 +818,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "authenticateMcp": {
           const c = this.client
           if (c) {
-            void authenticateMcpServer(c, message.name, this.getWorkspaceDirectory(), () =>
+            void McpOAuth.authenticateMcpServer(c, message.name, this.getWorkspaceDirectory(), () =>
               this.fetchAndSendMcpStatus(),
             ).catch((e) => console.error("[Kilo New] authenticateMcpServer failed:", e))
           }
@@ -2981,7 +2975,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     if (event.type === "mcp.browser.open.failed") {
-      openMcpOAuthUrlOnce(event.properties.url)
+      McpOAuth.openMcpOAuthUrlOnce(event.properties.url)
       return
     }
 

--- a/packages/kilo-vscode/src/kilo-provider/mcp-oauth.ts
+++ b/packages/kilo-vscode/src/kilo-provider/mcp-oauth.ts
@@ -9,7 +9,20 @@ export function openMcpOAuthUrlOnce(url: string): void {
   const now = Date.now()
   if (lastMcpBrowserOpen && lastMcpBrowserOpen.url === url && now - lastMcpBrowserOpen.at < 4000) return
   lastMcpBrowserOpen = { url, at: now }
-  void vscode.env.openExternal(vscode.Uri.parse(url))
+  void vscode.env.openExternal(vscode.Uri.parse(url)).then(
+    (opened) => {
+      if (opened) return
+      void vscode.window.showErrorMessage(
+        "MCP sign-in failed to open the browser. Check the Kilo logs for the authentication URL.",
+      )
+    },
+    (error) => {
+      console.error("[Kilo New] Failed to open MCP OAuth URL:", error)
+      void vscode.window.showErrorMessage(
+        "MCP sign-in failed to open the browser. Check the Kilo logs for the authentication URL.",
+      )
+    },
+  )
 }
 
 export async function connectMcpServer(

--- a/packages/kilo-vscode/src/kilo-provider/mcp-oauth.ts
+++ b/packages/kilo-vscode/src/kilo-provider/mcp-oauth.ts
@@ -1,0 +1,69 @@
+import * as vscode from "vscode"
+import type { KiloClient, McpStatus } from "@kilocode/sdk/v2/client"
+import { getErrorMessage } from "../kilo-provider-utils"
+
+let lastMcpBrowserOpen: { url: string; at: number } | null = null
+
+/** Dedupe when several webviews receive the same `mcp.browser.open.failed` SSE. */
+export function openMcpOAuthUrlOnce(url: string): void {
+  const now = Date.now()
+  if (lastMcpBrowserOpen && lastMcpBrowserOpen.url === url && now - lastMcpBrowserOpen.at < 4000) return
+  lastMcpBrowserOpen = { url, at: now }
+  void vscode.env.openExternal(vscode.Uri.parse(url))
+}
+
+export async function connectMcpServer(
+  client: KiloClient,
+  name: string,
+  directory: string,
+  refreshStatus: () => Promise<void>,
+): Promise<void> {
+  try {
+    await client.mcp.connect({ name, directory })
+    await refreshStatus()
+  } catch (error) {
+    console.error("[Kilo New] Failed to connect MCP:", name, error)
+    await refreshStatus()
+  }
+}
+
+export async function disconnectMcpServer(
+  client: KiloClient,
+  name: string,
+  directory: string,
+  refreshStatus: () => Promise<void>,
+): Promise<void> {
+  try {
+    await client.mcp.disconnect({ name, directory })
+    await refreshStatus()
+  } catch (error) {
+    console.error("[Kilo New] Failed to disconnect MCP:", name, error)
+    await refreshStatus()
+  }
+}
+
+export async function authenticateMcpServer(
+  client: KiloClient,
+  name: string,
+  directory: string,
+  refreshStatus: () => Promise<void>,
+): Promise<void> {
+  try {
+    const { data, error } = await client.mcp.auth.authenticate({ name, directory })
+    if (error) {
+      vscode.window.showErrorMessage(`MCP sign-in failed: ${getErrorMessage(error)}`)
+      return
+    }
+    const status = data as McpStatus | undefined
+    if (status?.status === "failed") {
+      vscode.window.showErrorMessage(status.error || "MCP OAuth failed")
+    } else if (status?.status === "needs_client_registration") {
+      vscode.window.showErrorMessage(status.error || "MCP server requires client registration in config")
+    }
+  } catch (error) {
+    console.error("[Kilo New] Failed to authenticate MCP:", name, error)
+    vscode.window.showErrorMessage(getErrorMessage(error) || "MCP sign-in failed")
+  } finally {
+    await refreshStatus()
+  }
+}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -658,6 +658,18 @@ const AgentBehaviourTab: Component = () => {
                         </span>
                       </div>
                       <div style={{ display: "flex", gap: "4px", "align-items": "center" }}>
+                        <Show when={session.mcpStatus()[name]?.status === "needs_auth"}>
+                          <div onClick={(e: MouseEvent) => e.stopPropagation()}>
+                            <Button
+                              variant="secondary"
+                              size="small"
+                              disabled={session.mcpLoading() === name}
+                              onClick={() => session.authenticateMcp(name)}
+                            >
+                              {language.t("common.signIn")}
+                            </Button>
+                          </div>
+                        </Show>
                         <div onClick={(e: MouseEvent) => e.stopPropagation()}>
                           <Switch
                             checked={isConnected(name)}

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -175,6 +175,7 @@ interface SessionContextValue {
   mcpLoading: Accessor<string | null>
   connectMcp: (name: string) => void
   disconnectMcp: (name: string) => void
+  authenticateMcp: (name: string) => void
   refreshMcpStatus: () => void
   selectedAgent: Accessor<string>
   selectAgent: (name: string) => void
@@ -354,6 +355,13 @@ export const SessionProvider: ParentComponent = (props) => {
     if (!server.isConnected()) return
     setMcpLoading(name)
     vscode.postMessage({ type: "disconnectMcp", name })
+  }
+
+  const authenticateMcp = (name: string) => {
+    if (mcpLoading()) return
+    if (!server.isConnected()) return
+    setMcpLoading(name)
+    vscode.postMessage({ type: "authenticateMcp", name })
   }
 
   const refreshMcpStatus = () => {
@@ -2219,6 +2227,7 @@ export const SessionProvider: ParentComponent = (props) => {
     mcpLoading,
     connectMcp,
     disconnectMcp,
+    authenticateMcp,
     refreshMcpStatus,
     selectedAgent: selectedAgentName,
     selectAgent,

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -259,6 +259,11 @@ export interface DisconnectMcpMessage {
   name: string
 }
 
+export interface AuthenticateMcpMessage {
+  type: "authenticateMcp"
+  name: string
+}
+
 export interface SetLanguageRequest {
   type: "setLanguage"
   locale: string
@@ -979,6 +984,7 @@ export type WebviewMessage =
   | RequestMcpStatusMessage
   | ConnectMcpMessage
   | DisconnectMcpMessage
+  | AuthenticateMcpMessage
   | SetLanguageRequest
   | QuestionReplyRequest
   | QuestionRejectRequest

--- a/packages/opencode/src/kilocode/mcp-oauth-callback.ts
+++ b/packages/opencode/src/kilocode/mcp-oauth-callback.ts
@@ -1,0 +1,94 @@
+import type { Server } from "http"
+
+const host = "127.0.0.1"
+export const enabled: boolean = true
+
+type State = {
+  server: Server | undefined
+  port: number
+  path: string
+}
+
+type Deps = {
+  redirectUri?: string
+  parse: (uri?: string) => { port: number; path: string }
+  state: () => State
+  set: (state: State) => void
+  create: () => Server
+  stop: () => Promise<void>
+  info: (msg: string, data?: Record<string, unknown>) => void
+  error: (msg: string, data?: Record<string, unknown>) => void
+}
+
+let active = host
+let start: Promise<void> | null = null
+
+export function parseHost(uri?: string): string {
+  if (!uri) return host
+  try {
+    return new URL(uri).hostname || host
+  } catch {
+    return host
+  }
+}
+
+export function listen(srv: Server, host: string, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const fail = (err: Error & { code?: string }) => {
+      srv.off("error", fail)
+      if (err.code === "EADDRINUSE") {
+        reject(
+          new Error(
+            `OAuth callback port ${port} is already in use. Close the other Kilo process or configure a different MCP OAuth redirect URI, then retry.`,
+          ),
+        )
+        return
+      }
+      reject(err)
+    }
+
+    srv.once("error", fail)
+    srv.listen(port, host, () => {
+      srv.off("error", fail)
+      resolve()
+    })
+  })
+}
+
+export async function ensureRunning(deps: Deps): Promise<void> {
+  const cfg = deps.parse(deps.redirectUri)
+  const nextHost = parseHost(deps.redirectUri)
+
+  if (start) await start
+
+  const state = deps.state()
+  if (state.server && (active !== nextHost || state.port !== cfg.port || state.path !== cfg.path)) {
+    deps.info("stopping oauth callback server to reconfigure", {
+      oldHost: active,
+      oldPort: state.port,
+      newHost: nextHost,
+      newPort: cfg.port,
+    })
+    await deps.stop()
+  }
+
+  if (deps.state().server) return
+
+  active = nextHost
+  const srv = deps.create()
+  start = listen(srv, active, cfg.port).then(() => {
+    deps.set({ server: srv, port: cfg.port, path: cfg.path })
+    deps.info("oauth callback server started", { host: active, port: cfg.port, path: cfg.path })
+  })
+
+  try {
+    await start
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("already in use")) {
+      deps.error("oauth callback bind failed: port already in use", { host: active, port: cfg.port, path: cfg.path })
+    }
+    throw err
+  } finally {
+    start = null
+  }
+}

--- a/packages/opencode/src/kilocode/mcp-oauth-callback.ts
+++ b/packages/opencode/src/kilocode/mcp-oauth-callback.ts
@@ -1,7 +1,6 @@
 import type { Server } from "http"
 
 const host = "127.0.0.1"
-export const enabled: boolean = true
 
 type State = {
   server: Server | undefined

--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -146,7 +146,7 @@ function handleRequest(req: import("http").IncomingMessage, res: import("http").
 }
 
 export async function ensureRunning(redirectUri?: string): Promise<void> {
-  // kilocode_change start - delegate Kilo-specific callback binding without replacing upstream fallback code
+  // kilocode_change start - delegate Kilo-specific callback binding from here because OAuth state lives in this module
   await KiloOAuthCallback.ensureRunning({
     redirectUri,
     parse: parseRedirectUri,

--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -147,23 +147,21 @@ function handleRequest(req: import("http").IncomingMessage, res: import("http").
 
 export async function ensureRunning(redirectUri?: string): Promise<void> {
   // kilocode_change start - delegate Kilo-specific callback binding without replacing upstream fallback code
-  if (KiloOAuthCallback.enabled) {
-    await KiloOAuthCallback.ensureRunning({
-      redirectUri,
-      parse: parseRedirectUri,
-      state: () => ({ server, port: currentPort, path: currentPath }),
-      set: (next) => {
-        server = next.server
-        currentPort = next.port
-        currentPath = next.path
-      },
-      create: () => createServer(handleRequest),
-      stop,
-      info: (msg, data) => log.info(msg, data),
-      error: (msg, data) => log.error(msg, data),
-    })
-    return
-  }
+  await KiloOAuthCallback.ensureRunning({
+    redirectUri,
+    parse: parseRedirectUri,
+    state: () => ({ server, port: currentPort, path: currentPath }),
+    set: (next) => {
+      server = next.server
+      currentPort = next.port
+      currentPath = next.path
+    },
+    create: () => createServer(handleRequest),
+    stop,
+    info: (msg, data) => log.info(msg, data),
+    error: (msg, data) => log.error(msg, data),
+  })
+  return
   // kilocode_change end
 
   // Parse the redirect URI to get port and path (uses defaults if not provided)

--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -2,6 +2,7 @@ import { createConnection } from "net"
 import { createServer } from "http"
 import { Log } from "../util"
 import { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH, parseRedirectUri } from "./oauth-provider"
+import * as KiloOAuthCallback from "../kilocode/mcp-oauth-callback" // kilocode_change
 
 const log = Log.create({ service: "mcp.oauth-callback" })
 
@@ -145,6 +146,26 @@ function handleRequest(req: import("http").IncomingMessage, res: import("http").
 }
 
 export async function ensureRunning(redirectUri?: string): Promise<void> {
+  // kilocode_change start - delegate Kilo-specific callback binding without replacing upstream fallback code
+  if (KiloOAuthCallback.enabled) {
+    await KiloOAuthCallback.ensureRunning({
+      redirectUri,
+      parse: parseRedirectUri,
+      state: () => ({ server, port: currentPort, path: currentPath }),
+      set: (next) => {
+        server = next.server
+        currentPort = next.port
+        currentPath = next.path
+      },
+      create: () => createServer(handleRequest),
+      stop,
+      info: (msg, data) => log.info(msg, data),
+      error: (msg, data) => log.error(msg, data),
+    })
+    return
+  }
+  // kilocode_change end
+
   // Parse the redirect URI to get port and path (uses defaults if not provided)
   const { port, path } = parseRedirectUri(redirectUri)
 

--- a/packages/opencode/test/kilocode/mcp-oauth-callback.test.ts
+++ b/packages/opencode/test/kilocode/mcp-oauth-callback.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test, afterEach } from "bun:test"
+import { createServer } from "http"
+import { McpOAuthCallback } from "../../src/mcp/oauth-callback"
+
+describe("Kilo MCP OAuth callback", () => {
+  afterEach(async () => {
+    await McpOAuthCallback.stop()
+  })
+
+  test("fails fast when the callback port belongs to another process", async () => {
+    const blocker = createServer((_req, res) => {
+      res.writeHead(200)
+      res.end("occupied")
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      blocker.once("error", reject)
+      blocker.listen(0, "127.0.0.1", resolve)
+    })
+
+    try {
+      const address = blocker.address()
+      if (!address || typeof address === "string") throw new Error("missing blocker address")
+
+      await expect(
+        McpOAuthCallback.ensureRunning(`http://127.0.0.1:${address.port}/mcp/oauth/callback`),
+      ).rejects.toThrow("already in use")
+      expect(McpOAuthCallback.isRunning()).toBe(false)
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()))
+    }
+  })
+})


### PR DESCRIPTION
## Context

Remote MCP servers with OAuth showed `needs auth` in VS Code settings but
provided no way to trigger the sign-in flow. Fixes #8904.

Two separate bugs caused this:
1. The settings UI had no control to start authentication when status was `needs_auth`.
2. The OAuth callback server (`127.0.0.1:19876`) was never bound in the VS Code
   process because `ensureRunning()` short-circuited on `isPortInUse()`, so the
   browser redirect always hit `ERR_CONNECTION_REFUSED`.

## Implementation

**UI fix (`packages/kilo-vscode`)**
- `AgentBehaviourTab` — renders a *Sign in* button when MCP status is `needs_auth`;
  sends `authenticateMcp` message which calls `POST /mcp/{name}/auth/authenticate`.
- `KiloProvider` — listens for `mcp.browser.open.failed` SSE and opens the auth
  URL via `vscode.env.openExternal`. The CLI's subprocess `open()` fails silently
  inside the VS Code extension host on some platforms, so the fallback is
  necessary. Deduped so multiple webviews don't open the same URL twice.
- Logic extracted to `kilo-provider/mcp-oauth.ts` to stay within ESLint
  `max-lines` / `complexity` limits.

**Callback server fix (`packages/opencode`)**
- Removed the `isPortInUse` probe in `McpOAuthCallback.ensureRunning()`.
  The old assumption — that a port already in use means another instance is
  serving the callback — was wrong: when VS Code spawns the CLI in-process,
  there is no other instance. Now `Bun.serve` is always attempted here.
- Concurrent `ensureRunning()` calls are serialized via `startInFlight`.
- `EADDRINUSE` is logged with an actionable hint instead of being swallowed.

## Screenshots

| before | after |
| ------ | ----- |
| `needs auth` with no action available | *Sign in* button → browser opens → *Authorization Successful* |

## How to Test

1. Add a remote MCP server with OAuth (e.g. `http://localhost:8080/mcp`) in
   *Agent Behaviour → MCP Servers*.
2. Toggle it ON — status shows `needs auth`.
3. A **Sign in** button appears next to the server — click it.
4. The browser opens to the OAuth authorization page.
5. Authorize — browser shows *Authorization Successful*.
6. Return to VS Code: MCP server status changes to `connected`.