### PR TITLE
fix: ensure search functionality resolves and displays the correct path

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "opencode",
@@ -3199,7 +3198,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#4af877d", {}, "anomalyco-ghostty-web-4af877d", "sha512-fbEK8mtr7ar4ySsF+JUGjhaZrane7dKphanN+SxHt5XXI6yLMAh/Hpf6sNCOyyVa2UlGCd7YpXG/T2v2RUAX+A=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#4af877d", {}, "anomalyco-ghostty-web-4af877d"],
 
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1666,6 +1666,7 @@ ToolRegistry.register({
     if (props.input.pattern) args.push("pattern=" + props.input.pattern)
     if (props.input.include) args.push("include=" + props.input.include)
     const pending = createMemo(() => busy(props.status))
+    const path = createMemo(() => props.metadata.path ?? props.input.path)
     return (
       <BasicTool
         {...props}
@@ -1674,7 +1675,7 @@ ToolRegistry.register({
           <ToolTriggerRow
             title={i18n.t("ui.tool.grep")}
             pending={pending()}
-            subtitle={getDirectory(props.input.path)}
+            subtitle={getDirectory(path())}
             args={args}
             animate={props.reveal}
           />

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -43,9 +43,16 @@ export const PermissionDock: Component<{
     const cmd = props.request.args?.command
     return typeof cmd === "string" ? cmd : undefined
   }
-  const description = createMemo(() =>
-    command() ? null : describePatterns(props.request.toolName, props.request.patterns, language.t),
-  )
+  const description = createMemo(() => {
+    if (command()) return null
+    const path = props.request.args?.path
+    return describePatterns(
+      props.request.toolName,
+      props.request.patterns,
+      language.t,
+      typeof path === "string" ? path : undefined,
+    )
+  })
 
   const filediff = () => {
     if (props.request.toolName !== "edit" && props.request.toolName !== "write") return null

--- a/packages/kilo-vscode/webview-ui/src/components/chat/permission-dock-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/permission-dock-utils.ts
@@ -63,12 +63,17 @@ export function describePatterns(
   tool: string,
   patterns: string[],
   t: (key: string) => string,
+  path?: string,
 ): PatternDescription | null {
   const filtered = patterns.filter((p) => p !== "*")
   if (filtered.length === 0) return null
 
   const key = TOOL_LABEL_KEYS[tool]
   const label = key ? t(key) : tool
-  if (filtered.length === 1) return { kind: "single", text: `${label} ${filtered[0]}` }
-  return { kind: "multi", title: `${label}:`, paths: filtered }
+  if (filtered.length === 1) {
+    let text = `${label} ${filtered[0]}`
+    if (path) text += ` in ${path}`
+    return { kind: "single", text }
+  }
+  return { kind: "multi", title: path ? `${label} in ${path}:` : `${label}:`, paths: filtered }
 }

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -91,7 +91,7 @@ function glob(info: ToolProps<typeof GlobTool>) {
 }
 
 function grep(info: ToolProps<typeof GrepTool>) {
-  const root = info.input.path ?? ""
+  const root = info.metadata.path ?? info.input.path ?? ""
   const title = `Grep "${info.input.pattern}"`
   const suffix = root ? `in ${normalizePath(root)}` : ""
   const num = info.metadata.matches

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -76,10 +76,10 @@ function fallback(part: ToolPart) {
   })
 }
 
-function glob(info: ToolProps<typeof GlobTool>) {
-  const root = info.input.path ?? ""
+function glob(info: ToolProps<typeof GlobTool>, attached?: boolean) {
+  const root = info.metadata.path ?? info.input.path ?? ""
   const title = `Glob "${info.input.pattern}"`
-  const suffix = root ? `in ${normalizePath(root)}` : ""
+  const suffix = root ? `in ${normalizePath(root, attached)}` : ""
   const num = info.metadata.count
   const description =
     num === undefined ? suffix : `${suffix}${suffix ? " · " : ""}${num} ${num === 1 ? "match" : "matches"}`
@@ -90,10 +90,10 @@ function glob(info: ToolProps<typeof GlobTool>) {
   })
 }
 
-function grep(info: ToolProps<typeof GrepTool>) {
+function grep(info: ToolProps<typeof GrepTool>, attached?: boolean) {
   const root = info.metadata.path ?? info.input.path ?? ""
   const title = `Grep "${info.input.pattern}"`
-  const suffix = root ? `in ${normalizePath(root)}` : ""
+  const suffix = root ? `in ${normalizePath(root, attached)}` : ""
   const num = info.metadata.matches
   const description =
     num === undefined ? suffix : `${suffix}${suffix ? " · " : ""}${num} ${num === 1 ? "match" : "matches"}`
@@ -104,16 +104,16 @@ function grep(info: ToolProps<typeof GrepTool>) {
   })
 }
 
-function list(info: ToolProps<typeof ListTool>) {
-  const dir = info.input.path ? normalizePath(info.input.path) : ""
+function list(info: ToolProps<typeof ListTool>, attached?: boolean) {
+  const dir = info.input.path ? normalizePath(info.input.path, attached) : ""
   inline({
     icon: "→",
     title: dir ? `List ${dir}` : "List",
   })
 }
 
-function read(info: ToolProps<typeof ReadTool>) {
-  const file = normalizePath(info.input.filePath)
+function read(info: ToolProps<typeof ReadTool>, attached?: boolean) {
+  const file = normalizePath(info.input.filePath, attached)
   const pairs = Object.entries(info.input).filter(([key, value]) => {
     if (key === "filePath") return false
     return typeof value === "string" || typeof value === "number" || typeof value === "boolean"
@@ -126,11 +126,11 @@ function read(info: ToolProps<typeof ReadTool>) {
   })
 }
 
-function write(info: ToolProps<typeof WriteTool>) {
+function write(info: ToolProps<typeof WriteTool>, attached?: boolean) {
   block(
     {
       icon: "←",
-      title: `Write ${normalizePath(info.input.filePath)}`,
+      title: `Write ${normalizePath(info.input.filePath, attached)}`,
     },
     info.part.state.status === "completed" ? info.part.state.output : undefined,
   )
@@ -143,8 +143,8 @@ function webfetch(info: ToolProps<typeof WebFetchTool>) {
   })
 }
 
-function edit(info: ToolProps<typeof EditTool>) {
-  const title = normalizePath(info.input.filePath)
+function edit(info: ToolProps<typeof EditTool>, attached?: boolean) {
+  const title = normalizePath(info.input.filePath, attached)
   const diff = info.metadata.diff
   block(
     {
@@ -214,10 +214,13 @@ function todo(info: ToolProps<typeof TodoWriteTool>) {
   )
 }
 
-function normalizePath(input?: string) {
+function normalizePath(input?: string, attached?: boolean) {
   if (!input) return ""
-  if (path.isAbsolute(input)) return path.relative(process.cwd(), input) || "."
-  return input
+  if (attached) return input
+  if (!path.isAbsolute(input)) return input
+  const relative = path.relative(process.cwd(), input)
+  if (relative.startsWith("..")) return input
+  return relative || "."
 }
 
 export const RunCommand = cmd({
@@ -436,16 +439,17 @@ export const RunCommand = cmd({
     }
 
     async function execute(sdk: KiloClient) {
+      const attached = !!args.attach
       function tool(part: ToolPart) {
         try {
           if (part.tool === "bash") return bash(props<typeof BashTool>(part))
-          if (part.tool === "glob") return glob(props<typeof GlobTool>(part))
-          if (part.tool === "grep") return grep(props<typeof GrepTool>(part))
-          if (part.tool === "list") return list(props<typeof ListTool>(part))
-          if (part.tool === "read") return read(props<typeof ReadTool>(part))
-          if (part.tool === "write") return write(props<typeof WriteTool>(part))
+          if (part.tool === "glob") return glob(props<typeof GlobTool>(part), attached)
+          if (part.tool === "grep") return grep(props<typeof GrepTool>(part), attached)
+          if (part.tool === "list") return list(props<typeof ListTool>(part), attached)
+          if (part.tool === "read") return read(props<typeof ReadTool>(part), attached)
+          if (part.tool === "write") return write(props<typeof WriteTool>(part), attached)
           if (part.tool === "webfetch") return webfetch(props<typeof WebFetchTool>(part))
-          if (part.tool === "edit") return edit(props<typeof EditTool>(part))
+          if (part.tool === "edit") return edit(props<typeof EditTool>(part), attached)
           if (part.tool === "codesearch") return codesearch(props<typeof CodeSearchTool>(part))
           if (part.tool === "websearch") return websearch(props<typeof WebSearchTool>(part))
           if (part.tool === "task") return task(props<typeof TaskTool>(part))

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1985,9 +1985,10 @@ function Read(props: ToolProps<typeof ReadTool>) {
 }
 
 function Grep(props: ToolProps<typeof GrepTool>) {
+  const path = createMemo(() => props.metadata.path ?? props.input.path)
   return (
     <InlineTool icon="✱" pending="Searching content..." complete={props.input.pattern} part={props.part}>
-      Grep "{props.input.pattern}" <Show when={props.input.path}>in {normalizePath(props.input.path)} </Show>
+      Grep "{props.input.pattern}" <Show when={path()}>in {normalizePath(path())} </Show>
       <Show when={props.metadata.matches}>
         ({props.metadata.matches} {props.metadata.matches === 1 ? "match" : "matches"})
       </Show>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -258,15 +258,20 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
 
             if (permission === "grep") {
               const pattern = typeof data.pattern === "string" ? data.pattern : ""
+              const raw = props.request.metadata?.path ?? data.path
+              const dir = typeof raw === "string" ? raw : ""
               return {
                 icon: "✱",
-                title: `Grep "${pattern}"`,
+                title: `Grep "${pattern}"` + (dir ? ` in ${normalizePath(dir)}` : ""),
                 body: (
-                  <Show when={pattern}>
-                    <box paddingLeft={1}>
+                  <box paddingLeft={1} gap={1}>
+                    <Show when={pattern}>
                       <text fg={theme.textMuted}>{"Pattern: " + pattern}</text>
-                    </box>
-                  </Show>
+                    </Show>
+                    <Show when={dir}>
+                      <text fg={theme.textMuted}>{"Path: " + normalizePath(dir)}</text>
+                    </Show>
+                  </box>
                 ),
               }
             }

--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -19,18 +19,18 @@ export const GlobTool = Tool.define("glob", {
       ),
   }),
   async execute(params, ctx) {
+    let search = params.path ?? Instance.directory
+    search = path.isAbsolute(search) ? search : path.resolve(Instance.directory, search)
+
     await ctx.ask({
       permission: "glob",
       patterns: [params.pattern],
       always: ["*"],
       metadata: {
         pattern: params.pattern,
-        path: params.path,
+        path: search,
       },
     })
-
-    let search = params.path ?? Instance.directory
-    search = path.isAbsolute(search) ? search : path.resolve(Instance.directory, search)
     await assertExternalDirectory(ctx, search, { kind: "directory" })
 
     const limit = 100
@@ -71,6 +71,7 @@ export const GlobTool = Tool.define("glob", {
       metadata: {
         count: files.length,
         truncated,
+        path: search,
       },
       output: output.join("\n"),
     }

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -24,19 +24,19 @@ export const GrepTool = Tool.define("grep", {
       throw new Error("pattern is required")
     }
 
+    let searchPath = params.path ?? Instance.directory
+    searchPath = path.isAbsolute(searchPath) ? searchPath : path.resolve(Instance.directory, searchPath)
+
     await ctx.ask({
       permission: "grep",
       patterns: [params.pattern],
       always: ["*"],
       metadata: {
         pattern: params.pattern,
-        path: params.path,
+        path: searchPath,
         include: params.include,
       },
     })
-
-    let searchPath = params.path ?? Instance.directory
-    searchPath = path.isAbsolute(searchPath) ? searchPath : path.resolve(Instance.directory, searchPath)
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 
     const rgPath = await Ripgrep.filepath()
@@ -66,7 +66,7 @@ export const GrepTool = Tool.define("grep", {
     if (exitCode === 1 || (exitCode === 2 && !output.trim())) {
       return {
         title: params.pattern,
-        metadata: { matches: 0, truncated: false },
+        metadata: { matches: 0, truncated: false, path: searchPath },
         output: "No files found",
       }
     }
@@ -110,7 +110,7 @@ export const GrepTool = Tool.define("grep", {
     if (finalMatches.length === 0) {
       return {
         title: params.pattern,
-        metadata: { matches: 0, truncated: false },
+        metadata: { matches: 0, truncated: false, path: searchPath },
         output: "No files found",
       }
     }
@@ -149,6 +149,7 @@ export const GrepTool = Tool.define("grep", {
       metadata: {
         matches: totalMatches,
         truncated,
+        path: searchPath,
       },
       output: outputLines.join("\n"),
     }


### PR DESCRIPTION
I have addressed issue #8881 by resolving the search path to an absolute path before execution and propagation to the UI.

Changes:
- packages/opencode/src/tool: Resolved the search path before execution and included it in result metadata.
- packages/opencode/src/cli/cmd/tui/routes/session/index.tsx: Use the resolved path from metadata in the search results display.
- packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx: Show the resolved path in the search permission prompt.
- packages/opencode/src/cli/cmd/run.ts: Show the resolved path in the CLI output.
- packages/kilo-ui/src/components/message-part.tsx: Use the resolved path in the shared search UI component.
- packages/kilo-vscode/webview-ui/src/components/chat: Updated the permission dock and utilities to propagate and display the absolute path in pattern descriptions.
