### PR TITLE
fix(cli): make shell cancel race-safe with uninterruptible setup

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -742,182 +742,201 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         } satisfies MessageV2.TextPart)
       })
 
+      // kilocode_change start — use uninterruptibleMask so setup + message writes complete
+      // atomically, then acquireUseRelease guarantees finish runs on any interrupt
       const shellImpl = Effect.fn("SessionPrompt.shellImpl")(function* (input: ShellInput, signal: AbortSignal) {
-        const ctx = yield* InstanceState.context
-        const session = yield* sessions.get(input.sessionID)
-        if (session.revert) {
-          yield* Effect.promise(() => SessionRevert.cleanup(session))
-        }
-        const agent = yield* agents.get(input.agent)
-        if (!agent) {
-          const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)
-          const hint = available.length ? ` Available agents: ${available.join(", ")}` : ""
-          const error = new NamedError.Unknown({ message: `Agent not found: "${input.agent}".${hint}` })
-          yield* bus.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })
-          throw error
-        }
-        const model = input.model ?? agent.model ?? (yield* lastModel(input.sessionID))
-        const userMsg: MessageV2.User = {
-          id: input.messageID ?? MessageID.ascending(),
-          sessionID: input.sessionID,
-          time: { created: Date.now() },
-          role: "user",
-          agent: input.agent,
-          model: { providerID: model.providerID, modelID: model.modelID },
-        }
-        yield* sessions.updateMessage(userMsg)
-        const userPart: MessageV2.Part = {
-          type: "text",
-          id: PartID.ascending(),
-          messageID: userMsg.id,
-          sessionID: input.sessionID,
-          text: "The following tool was executed by the user",
-          synthetic: true,
-        }
-        yield* sessions.updatePart(userPart)
-
-        const msg: MessageV2.Assistant = {
-          id: MessageID.ascending(),
-          sessionID: input.sessionID,
-          parentID: userMsg.id,
-          mode: input.agent,
-          agent: input.agent,
-          cost: 0,
-          path: { cwd: ctx.directory, root: ctx.worktree },
-          time: { created: Date.now() },
-          role: "assistant",
-          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-          modelID: model.modelID,
-          providerID: model.providerID,
-        }
-        yield* sessions.updateMessage(msg)
-        const part: MessageV2.ToolPart = {
-          type: "tool",
-          id: PartID.ascending(),
-          messageID: msg.id,
-          sessionID: input.sessionID,
-          tool: "bash",
-          callID: ulid(),
-          state: {
-            status: "running",
-            time: { start: Date.now() },
-            input: { command: input.command },
-          },
-        }
-        yield* sessions.updatePart(part)
-
-        const sh = Shell.preferred()
-        const shellName = (
-          process.platform === "win32" ? path.win32.basename(sh, ".exe") : path.basename(sh)
-        ).toLowerCase()
-        const invocations: Record<string, { args: string[] }> = {
-          nu: { args: ["-c", input.command] },
-          fish: { args: ["-c", input.command] },
-          zsh: {
-            args: [
-              "-l",
-              "-c",
-              `
-                __oc_cwd=$PWD
-                [[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
-                [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
-                cd "$__oc_cwd"
-                eval ${JSON.stringify(input.command)}
-              `,
-            ],
-          },
-          bash: {
-            args: [
-              "-l",
-              "-c",
-              `
-                __oc_cwd=$PWD
-                shopt -s expand_aliases
-                [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
-                cd "$__oc_cwd"
-                eval ${JSON.stringify(input.command)}
-              `,
-            ],
-          },
-          cmd: { args: ["/c", input.command] },
-          powershell: { args: ["-NoProfile", "-Command", input.command] },
-          pwsh: { args: ["-NoProfile", "-Command", input.command] },
-          "": { args: ["-c", input.command] },
-        }
-
-        const args = (invocations[shellName] ?? invocations[""]).args
-        const cwd = ctx.directory
-        const shellEnv = yield* plugin.trigger(
-          "shell.env",
-          { cwd, sessionID: input.sessionID, callID: part.callID },
-          { env: {} },
-        )
-
-        const cmd = ChildProcess.make(sh, args, {
-          cwd,
-          extendEnv: true,
-          env: { ...shellEnv.env, TERM: "dumb" },
-          stdin: "ignore",
-          forceKillAfter: "3 seconds",
-        })
-
-        let output = ""
-
-        let aborted = false
-
-        const finish = Effect.uninterruptible(
+        return yield* Effect.uninterruptibleMask((restore) =>
           Effect.gen(function* () {
-            if (aborted) {
-              output += "\n\n" + ["<metadata>", "User aborted the command", "</metadata>"].join("\n")
+            const ctx = yield* InstanceState.context
+            const session = yield* sessions.get(input.sessionID)
+            if (session.revert) {
+              yield* Effect.promise(() => SessionRevert.cleanup(session))
             }
-            if (!msg.time.completed) {
-              msg.time.completed = Date.now()
-              yield* sessions.updateMessage(msg)
+            const agent = yield* agents.get(input.agent)
+            if (!agent) {
+              const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)
+              const hint = available.length ? ` Available agents: ${available.join(", ")}` : ""
+              const error = new NamedError.Unknown({ message: `Agent not found: "${input.agent}".${hint}` })
+              yield* bus.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })
+              throw error
             }
-            if (part.state.status === "running") {
-              part.state = {
-                status: "completed",
-                time: { ...part.state.time, end: Date.now() },
-                input: part.state.input,
-                title: "",
-                metadata: { output, description: "" },
-                output,
-              }
-              yield* sessions.updatePart(part)
+            const model = input.model ?? agent.model ?? (yield* lastModel(input.sessionID))
+            const userMsg: MessageV2.User = {
+              id: input.messageID ?? MessageID.ascending(),
+              sessionID: input.sessionID,
+              time: { created: Date.now() },
+              role: "user",
+              agent: input.agent,
+              model: { providerID: model.providerID, modelID: model.modelID },
             }
+            yield* sessions.updateMessage(userMsg)
+            const userPart: MessageV2.Part = {
+              type: "text",
+              id: PartID.ascending(),
+              messageID: userMsg.id,
+              sessionID: input.sessionID,
+              text: "The following tool was executed by the user",
+              synthetic: true,
+            }
+            yield* sessions.updatePart(userPart)
+
+            const msg: MessageV2.Assistant = {
+              id: MessageID.ascending(),
+              sessionID: input.sessionID,
+              parentID: userMsg.id,
+              mode: input.agent,
+              agent: input.agent,
+              cost: 0,
+              path: { cwd: ctx.directory, root: ctx.worktree },
+              time: { created: Date.now() },
+              role: "assistant",
+              tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              modelID: model.modelID,
+              providerID: model.providerID,
+            }
+            yield* sessions.updateMessage(msg)
+            const part: MessageV2.ToolPart = {
+              type: "tool",
+              id: PartID.ascending(),
+              messageID: msg.id,
+              sessionID: input.sessionID,
+              tool: "bash",
+              callID: ulid(),
+              state: {
+                status: "running",
+                time: { start: Date.now() },
+                input: { command: input.command },
+              },
+            }
+            yield* sessions.updatePart(part)
+
+            const sh = Shell.preferred()
+            const shellName = (
+              process.platform === "win32" ? path.win32.basename(sh, ".exe") : path.basename(sh)
+            ).toLowerCase()
+            const invocations: Record<string, { args: string[] }> = {
+              nu: { args: ["-c", input.command] },
+              fish: { args: ["-c", input.command] },
+              zsh: {
+                args: [
+                  "-l",
+                  "-c",
+                  `
+                    __oc_cwd=$PWD
+                    [[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
+                    [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
+                    cd "$__oc_cwd"
+                    eval ${JSON.stringify(input.command)}
+                  `,
+                ],
+              },
+              bash: {
+                args: [
+                  "-l",
+                  "-c",
+                  `
+                    __oc_cwd=$PWD
+                    shopt -s expand_aliases
+                    [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
+                    cd "$__oc_cwd"
+                    eval ${JSON.stringify(input.command)}
+                  `,
+                ],
+              },
+              cmd: { args: ["/c", input.command] },
+              powershell: { args: ["-NoProfile", "-Command", input.command] },
+              pwsh: { args: ["-NoProfile", "-Command", input.command] },
+              "": { args: ["-c", input.command] },
+            }
+
+            const args = (invocations[shellName] ?? invocations[""]).args
+            const cwd = ctx.directory
+            const shellEnv = yield* plugin.trigger(
+              "shell.env",
+              { cwd, sessionID: input.sessionID, callID: part.callID },
+              { env: {} },
+            )
+
+            const cmd = ChildProcess.make(sh, args, {
+              cwd,
+              extendEnv: true,
+              env: { ...shellEnv.env, TERM: "dumb" },
+              stdin: "ignore",
+              forceKillAfter: "3 seconds",
+            })
+
+            let output = ""
+            let aborted = false
+
+            // acquireUseRelease: acquire is uninterruptible (inherited), use is
+            // restored to interruptible so the process can be killed, release
+            // always runs to finalize the tool part
+            return yield* Effect.acquireUseRelease(
+              Effect.succeed({ msg, part }),
+              () =>
+                restore(
+                  Effect.gen(function* () {
+                    const exit = yield* Effect.gen(function* () {
+                      const handle = yield* spawner.spawn(cmd)
+                      yield* Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
+                        Effect.sync(() => {
+                          output += chunk
+                          if (part.state.status === "running") {
+                            part.state.metadata = { output, description: "" }
+                            void Effect.runFork(sessions.updatePart(part))
+                          }
+                        }),
+                      )
+                      yield* handle.exitCode
+                    }).pipe(
+                      Effect.scoped,
+                      Effect.onInterrupt(() =>
+                        Effect.sync(() => {
+                          aborted = true
+                        }),
+                      ),
+                      Effect.orDie,
+                      Effect.exit,
+                    )
+
+                    if (Exit.isFailure(exit) && !Cause.hasInterruptsOnly(exit.cause)) {
+                      return yield* Effect.failCause(exit.cause)
+                    }
+
+                    return { info: msg, parts: [part] } as MessageV2.WithParts
+                  }),
+                ),
+              (_resource, exit) =>
+                Effect.gen(function* () {
+                  // Detect abort: onInterrupt sets it when the spawn is running,
+                  // but if the interrupt arrives before use starts, check exit directly
+                  if (!aborted && Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)) {
+                    aborted = true
+                  }
+                  if (aborted) {
+                    output += "\n\n" + ["<metadata>", "User aborted the command", "</metadata>"].join("\n")
+                  }
+                  if (!msg.time.completed) {
+                    msg.time.completed = Date.now()
+                    yield* sessions.updateMessage(msg)
+                  }
+                  if (part.state.status === "running") {
+                    part.state = {
+                      status: "completed",
+                      time: { ...part.state.time, end: Date.now() },
+                      input: part.state.input,
+                      title: "",
+                      metadata: { output, description: "" },
+                      output,
+                    }
+                    yield* sessions.updatePart(part)
+                  }
+                }),
+            )
           }),
         )
-
-        const exit = yield* Effect.gen(function* () {
-          const handle = yield* spawner.spawn(cmd)
-          yield* Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
-            Effect.sync(() => {
-              output += chunk
-              if (part.state.status === "running") {
-                part.state.metadata = { output, description: "" }
-                void Effect.runFork(sessions.updatePart(part))
-              }
-            }),
-          )
-          yield* handle.exitCode
-        }).pipe(
-          Effect.scoped,
-          Effect.onInterrupt(() =>
-            Effect.sync(() => {
-              aborted = true
-            }),
-          ),
-          Effect.orDie,
-          Effect.ensuring(finish),
-          Effect.exit,
-        )
-
-        if (Exit.isFailure(exit) && !Cause.hasInterruptsOnly(exit.cause)) {
-          return yield* Effect.failCause(exit.cause)
-        }
-
-        return { info: msg, parts: [part] }
       })
+      // kilocode_change end
 
       const getModel = Effect.fn("SessionPrompt.getModel")(function* (
         providerID: ProviderID,


### PR DESCRIPTION
Shell cancel was flaky because the fiber could be interrupted before messages were persisted to the database, causing `lastAssistant` to throw "Impossible". Also, the finish cleanup only covered the spawn phase, leaving tool parts stuck in "running" state when the interrupt landed between setup and spawn.

Wrap setup in `uninterruptibleMask` and use `acquireUseRelease` to guarantee the finish release runs on every exit path, including immediate interrupts that arrive before the spawn phase starts.

## How to Test

Run the following 3 tests, which are flaky in `main`, repeatedly in a loop:

```
cancel interrupts shell and resolves cleanly
cancel persists aborted shell result when shell ignores TERM
cancel interrupts loop queued behind shell
```

Expected behavior: 100% pass rate (observed on this branch)

## Get in Touch

ExpedientFalcon on Discord
