### PR TITLE
fix(vscode): settings reverting after save due to stale cache race condition

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -32,6 +32,7 @@ import {
   resolveContextDirectory,
   resolveWorkspaceDirectory,
   mergeFileSearchResults,
+  patchConfig,
   type SessionRefreshContext,
 } from "./kilo-provider-utils"
 import { GitOps } from "./agent-manager/GitOps"
@@ -2264,12 +2265,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
       await this.client.global.config.update({ config: partial }, { throwOnError: true })
 
-      // Re-fetch the full merged config (global + project + all layers) so the
-      // webview receives the complete resolved config, not just global-only data.
-      // Config.state is reset by updateGlobal (via Instance.resetStateEntry) so
-      // config.get() returns fresh data without a full dispose cycle.
-      const dir = this.getWorkspaceDirectory()
-      const { data: merged } = await retry(() => this.client!.config.get({ directory: dir }, { throwOnError: true }))
+      // Optimistically merge the partial changes onto the cached full config
+      // instead of re-fetching via config.get(). The CLI's updateGlobal()
+      // fires Instance.disposeAll() as fire-and-forget, so the per-instance
+      // ScopedCache may still serve stale data at this point. The SSE-triggered
+      // reload (server.instance.disposed → reloadAfterAuthChange) will later
+      // bring the fully resolved config from the server.
+      const cached = (this.cachedConfigMessage as { config: Record<string, unknown> } | undefined)?.config ?? {}
+      const merged = patchConfig(cached, partial as Record<string, unknown>)
 
       this.cachedConfigMessage = { type: "configLoaded", config: merged }
       this.postMessage({ type: "configUpdated", config: merged })

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -481,3 +481,27 @@ export function mergeFileSearchResults(input: {
   const seen = new Set(tabs)
   return [...tabs, ...input.backend.filter((p) => !seen.has(p))]
 }
+
+/**
+ * Deep-merge a partial config patch onto a full config object.
+ * - Nested plain objects are merged recursively.
+ * - `null` values act as delete sentinels (the key is removed).
+ * - Arrays and primitives are replaced outright.
+ */
+export function patchConfig(target: Record<string, unknown>, patch: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...target }
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      delete result[key]
+    } else if (isRecord(value) && isRecord(result[key])) {
+      result[key] = patchConfig(result[key] as Record<string, unknown>, value)
+    } else {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}


### PR DESCRIPTION
## Summary

- Fix settings UI snapping back to old values after clicking Save, caused by a race condition between `Instance.disposeAll()` (fire-and-forget) and the immediate `config.get()` re-fetch that reads stale cached data
- Replace the stale `config.get()` call with an optimistic merge of the saved partial changes onto the cached full config; the SSE-triggered reload brings the fully resolved config afterward

## Root Cause

When settings are saved:

1. Extension sends `PATCH /global/config` — CLI writes config to disk correctly
2. CLI's `updateGlobal()` calls `Instance.disposeAll()` as **fire-and-forget** (not awaited)
3. HTTP response returns to the extension
4. Extension immediately calls `config.get()` — but the per-instance `ScopedCache` hasn't been invalidated yet (disposeAll still running in background)
5. Extension gets **stale cached config** and sends it to the webview as the save confirmation
6. Webview clears its draft and replaces UI state with old values

The comment at KiloProvider.ts:2269 referenced a non-existent `Instance.resetStateEntry` method, suggesting this cache invalidation was expected but never implemented for the `dispose=true` path.

## Changes

- **`kilo-provider-utils.ts`**: Add `patchConfig()` deep-merge utility (handles null-as-delete sentinels)
- **`KiloProvider.ts`**: Replace stale `config.get()` re-fetch with optimistic `patchConfig(cachedConfig, partial)`
