### PR TITLE
fix(cli): re-apply dead-stream detection to SSE endpoints to prevent memory leak on Windows

### DIFF
--- a/packages/opencode/src/bus/global.ts
+++ b/packages/opencode/src/bus/global.ts
@@ -8,3 +8,4 @@ export const GlobalBus = new EventEmitter<{
     },
   ]
 }>()
+GlobalBus.setMaxListeners(50) // kilocode_change — surface warning if SSE listeners accumulate

--- a/packages/opencode/src/server/routes/event.ts
+++ b/packages/opencode/src/server/routes/event.ts
@@ -70,14 +70,26 @@ export const EventRoutes = () =>
 
         stream.onAbort(stop)
 
+        // kilocode_change start
+        // On Windows, stream.onAbort() may never fire after a client disconnects
+        // (delayed TCP RST detection via IOCP). Without this try/catch, the
+        // GlobalBus listener, heartbeat interval, and AsyncQueue stay alive
+        // indefinitely for each dead connection — leaking memory on every
+        // SSE reconnect. Catching write errors lets us clean up eagerly.
         try {
           for await (const data of q) {
             if (data === null) return
-            await stream.writeSSE({ data })
+            try {
+              await stream.writeSSE({ data })
+            } catch {
+              stop()
+              return
+            }
           }
         } finally {
           stop()
         }
+        // kilocode_change end
       })
     },
   )

--- a/packages/opencode/src/server/routes/event.ts
+++ b/packages/opencode/src/server/routes/event.ts
@@ -82,6 +82,7 @@ export const EventRoutes = () =>
             try {
               await stream.writeSSE({ data })
             } catch {
+              log.info("event write failed, cleaning up dead stream")
               stop()
               return
             }

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -56,14 +56,26 @@ async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>
 
     stream.onAbort(stop)
 
+    // kilocode_change start
+    // On Windows, stream.onAbort() may never fire after a client disconnects
+    // (delayed TCP RST detection via IOCP). Without this try/catch, the
+    // GlobalBus listener, heartbeat interval, and AsyncQueue stay alive
+    // indefinitely for each dead connection — leaking memory on every
+    // SSE reconnect. Catching write errors lets us clean up eagerly.
     try {
       for await (const data of q) {
         if (data === null) return
-        await stream.writeSSE({ data })
+        try {
+          await stream.writeSSE({ data })
+        } catch {
+          stop()
+          return
+        }
       }
     } finally {
       stop()
     }
+    // kilocode_change end
   })
 }
 

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -68,6 +68,7 @@ async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>
         try {
           await stream.writeSSE({ data })
         } catch {
+          log.info("global event write failed, cleaning up dead stream")
           stop()
           return
         }


### PR DESCRIPTION
## Summary

Re-apply dead-stream detection to SSE endpoints that was lost during the OpenCode v1.3.0 upstream merge, fixing a memory leak on Windows that is significantly amplified by Agent Manager with large diffs.

## Investigation & Findings

### Symptom

Memory leak on Windows only. Fairly slow on a single session, but spikes fast with Agent Manager open. Reproducible by having a large diff on the main repo and creating a worktree in Agent Manager that also has a large diff. Does **not** happen on macOS.

### How we narrowed it down

**v7.2.0** (April 7) was the last GA release with no leak. The leak appeared in builds after v7.2.0. Between v7.2.0 and v7.2.6, the major changes were OpenCode upstream merges: v1.2.25 through v1.3.17.

The upstream merge **v1.3.0** included commit `0540751897` ("fix(core): use a queue to process events in event routes") which completely rewrote the SSE event routes in `global.ts` and `event.ts` to use an `AsyncQueue`-based `streamEvents()` pattern. This rewrite replaced the code that contained our dead-stream detection fix (`81a0d87c25`), effectively deleting it during merge conflict resolution.

### Root cause

The SSE endpoints (`/global/event`, `/global/sync-event`, `/event`) use `stream.onAbort(stop)` as the **sole** mechanism to detect disconnected clients and clean up resources (GlobalBus listener, heartbeat interval, AsyncQueue).

On **macOS**, `onAbort` fires within milliseconds of client disconnect (kqueue-based socket notification). On **Windows**, it can take minutes or never fire (IOCP with default 2-hour TCP keepalive timers).

When the VS Code extension's `SdkSSEAdapter` detects a stale connection (15s heartbeat timeout) and reconnects, the old server-side SSE handler stays alive on Windows:
- `GlobalBus.on("event", handler)` listener remains registered permanently
- `setInterval` heartbeat (10s) keeps pushing to the `AsyncQueue` forever
- The `AsyncQueue` grows without bound as events keep arriving but nobody reads them

### Why "Windows only" excludes other candidates

During investigation we identified several other memory concerns. The Windows-only constraint eliminates all of them as the primary cause:

| Candidate | Why excluded |
|---|---|
| `diffFullCached` — module-level cache of up to 100 `FileDiff[]` arrays (kilocode/snapshot/index.ts:130) | Pure JS Map, platform-independent — would leak equally on Mac |
| `messageSessionIdsByMessageId` — unbounded Map in connection-service.ts:75 | Pure JS Map in extension process, identical on all platforms |
| `formatPatch` with `context: MAX_SAFE_INTEGER` — inflated patch strings (snapshot/index.ts:634) | Inflates data size but is platform-independent |
| Effect `Bus.subscribe` orphaned fibers in kilo-sessions.ts | Effect-ts runtime, platform-independent |
| `retryAbortControllers` not cleaned in KiloProvider.dispose() | Pure JS, same on both platforms |

These are filed as follow-up issues (#8949, #8950, #8951) for general memory optimization but are not the Windows leak.

### Why "large diffs + worktree" reproduces it faster

Large diffs amplify the leak because `Session.Event.Diff` publishes full `FileDiff[]` arrays (with `context: MAX_SAFE_INTEGER` patches — entire file contents, not just changed lines) through `GlobalBus` → every SSE handler including leaked dead ones. Each leaked connection's `AsyncQueue` accumulates these multi-MB payloads. Two large diffs (main repo + worktree) double the event rate with massive payloads, making memory growth visible within minutes.

### Why Agent Manager makes it worse

Agent Manager tracks multiple sessions across worktrees, producing higher SSE event volume. More events = leaked connections accumulate data faster. Additionally, `retainContextWhenHidden: true` on the Agent Manager panel means the webview and its state persist even when the tab is hidden.

## Changes

### 1. Dead-stream detection in `global.ts` and `event.ts`

Wrap `stream.writeSSE()` in try/catch inside the `for await` loop. When a write fails (broken TCP socket), call `stop()` immediately — cleaning up the GlobalBus listener, heartbeat interval, and AsyncQueue — instead of waiting for `onAbort` which may never fire on Windows.

### 2. `GlobalBus.setMaxListeners(50)` in `global.ts` (bus)

Safety net. Normal operation uses ~2 listeners. If this warning ever fires in logs, it signals leaked connections are accumulating again. Does not limit functionality — only controls when Node.js emits a warning.

## Related

- Follow-up issues for platform-independent memory optimizations: #8949, #8950, #8951
- Original dead-stream fix that was lost: `81a0d87c25`
- Upstream commit that overwrote it: `0540751897`