### PR TITLE
fix(cli): avoid worktree diff patch generation

### DIFF
--- a/.changeset/large-worktree-diffs.md
+++ b/.changeset/large-worktree-diffs.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Reduce Agent Manager memory usage when viewing large worktree diffs.

--- a/packages/opencode/src/kilocode/review/worktree-diff.ts
+++ b/packages/opencode/src/kilocode/review/worktree-diff.ts
@@ -1,6 +1,5 @@
 // kilocode_change - new file
 import { $ } from "bun"
-import { createTwoFilesPatch } from "diff"
 import fs from "node:fs/promises"
 import path from "node:path"
 import z from "zod"
@@ -245,7 +244,7 @@ export namespace WorktreeDiff {
     const additions = meta.status === "added" && meta.additions === 0 && !meta.tracked ? lines(after) : meta.additions
     return {
       file: meta.file,
-      patch: createTwoFilesPatch(meta.file, meta.file, before, after),
+      patch: "",
       before,
       after,
       additions,

--- a/packages/opencode/test/kilocode/worktree-diff.test.ts
+++ b/packages/opencode/test/kilocode/worktree-diff.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe } from "bun:test"
 import { $ } from "bun"
 import { tmpdir } from "../fixture/fixture"
+import { WorktreeDiff } from "../../src/kilocode/review/worktree-diff"
 import path from "path"
 
 /**
@@ -143,6 +144,19 @@ describe("worktree diff git commands", () => {
     const allFiles = [...trackedFiles, ...untrackedFiles]
     expect(allFiles).toContain("existing.txt")
     expect(allFiles).toContain("new-file.py")
+  })
+
+  test("worktree detail does not include unused patch content", async () => {
+    await using tmp = await setupRepo()
+    const dir = tmp.path
+
+    await Bun.write(path.join(dir, "existing.txt"), "hello\nmodified\n")
+
+    const detail = await WorktreeDiff.detail({ dir, base: "HEAD", file: "existing.txt" })
+
+    expect(detail?.patch).toBe("")
+    expect(detail?.before).toBe("hello\n")
+    expect(detail?.after).toBe("hello\nmodified\n")
   })
 
   test("worktree scenario: branch with no new commits, only untracked files", async () => {


### PR DESCRIPTION
## Summary
- Stop generating unified patch strings for Agent Manager worktree diff details; the viewer renders from `before`/`after` and never consumes `patch`.
- Keep the API shape with `patch: ""` to avoid schema/SDK churn while preventing duplicate large diff payloads.

Refs #8951