### PR TITLE
fix(agent-manager): fix tab header tooltip-trigger breaking height chain

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/agentmanager/tab-bar-multiple-tabs-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/agentmanager/tab-bar-multiple-tabs-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee8d8e04b09b58973a1ff66d5a3d8648ba590f88312cf1f37412c39ccdac0480
+size 3973

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/agentmanager/tab-bar-single-tab-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/agentmanager/tab-bar-single-tab-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0e9ea1be8fbb44f05bed7960d1ba13f0d4c5e904e4025e4ab4743c4991e93c8
+size 4696

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/agentmanager/tab-bar-with-review-tab-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/agentmanager/tab-bar-with-review-tab-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66a7ecedac685e17c442bb036d7392320e0642ef43da77ed8dc23be29bc7988e
+size 2935

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1143,6 +1143,11 @@ button.am-section-toggle:hover .am-section-label {
   touch-action: none;
 }
 
+.am-tab-sortable > [data-component="tooltip-trigger"],
+.am-tab-sortable > [data-slot="context-menu-trigger"] > [data-component="tooltip-trigger"] {
+  height: 100%;
+}
+
 .am-tab-dragging {
   opacity: 0.25;
 }

--- a/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource solid-js */
 /**
  * Stories for Agent Manager components:
- * FileTree, DiffPanel, FullScreenDiffView, WorktreeItem
+ * FileTree, DiffPanel, FullScreenDiffView, WorktreeItem, TabBar
  */
 
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
@@ -10,6 +10,10 @@ import { FileTree } from "../../agent-manager/FileTree"
 import { DiffPanel } from "../../agent-manager/DiffPanel"
 import { FullScreenDiffView } from "../../agent-manager/FullScreenDiffView"
 import { WorktreeItem } from "../../agent-manager/WorktreeItem"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
+import { Icon } from "@kilocode/kilo-ui/icon"
+import { TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
+import { ContextMenu } from "@kilocode/kilo-ui/context-menu"
 import type { WorktreeFileDiff, WorktreeState, WorktreeGitStats, PRStatus } from "../types/messages"
 import "../../agent-manager/agent-manager.css"
 import "../../agent-manager/agent-manager-review.css"
@@ -443,4 +447,128 @@ export const WorktreeItemGrouped: Story = {
       </StoryProviders>
     )
   },
+}
+
+// ---------------------------------------------------------------------------
+// TabBar — renders tab bar structure matching SortableTab / SortableReviewTab
+// DOM to verify the tooltip-trigger height chain is correct.
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock tab matching the real SortableTab DOM:
+ *   .am-tab-sortable > [context-menu-trigger] > [tooltip-trigger] > .am-tab
+ */
+const MockTab = (props: { title: string; active?: boolean }) => (
+  <div class="am-tab-sortable">
+    <ContextMenu>
+      <ContextMenu.Trigger as="div" style={{ display: "contents" }}>
+        <TooltipKeybind title={props.title} keybind="⌘1" placement="bottom" inactive={props.active}>
+          <div class={`am-tab ${props.active ? "am-tab-active" : ""}`}>
+            <span class="am-tab-label">{props.title}</span>
+            <TooltipKeybind title="Close" keybind="⌘W" placement="bottom">
+              <IconButton icon="close-small" size="small" variant="ghost" label="Close" class="am-tab-close" />
+            </TooltipKeybind>
+          </div>
+        </TooltipKeybind>
+      </ContextMenu.Trigger>
+    </ContextMenu>
+  </div>
+)
+
+/** Mock review tab matching SortableReviewTab DOM (no ContextMenu wrapper). */
+const MockReviewTab = (props: { active?: boolean }) => (
+  <div class="am-tab-sortable">
+    <TooltipKeybind title="Toggle review" keybind="⌘⇧R" placement="bottom" inactive={props.active}>
+      <div class={`am-tab am-tab-review ${props.active ? "am-tab-active" : ""}`}>
+        <Icon name="layers" size="small" />
+        <span class="am-tab-label">Review</span>
+        <TooltipKeybind title="Close" keybind="⌘W" placement="bottom">
+          <IconButton icon="close-small" size="small" variant="ghost" label="Close" class="am-tab-close" />
+        </TooltipKeybind>
+      </div>
+    </TooltipKeybind>
+  </div>
+)
+
+export const TabBarMultipleTabs: Story = {
+  name: "TabBar — multiple tabs with active",
+  render: () => (
+    <StoryProviders noPadding>
+      <div class="am-tab-bar">
+        <div class="am-tab-scroll-area">
+          <div class="am-tab-list">
+            <MockTab title="Implement auth" active />
+            <MockTab title="Fix button styles" />
+            <MockTab title="Add unit tests" />
+          </div>
+        </div>
+        <TooltipKeybind title="New session" keybind="⌘T" placement="bottom">
+          <IconButton icon="plus" size="small" variant="ghost" label="New session" class="am-tab-add" />
+        </TooltipKeybind>
+        <div class="am-tab-actions">
+          <button class="am-diff-toggle-btn am-diff-toggle-has-changes">
+            <Icon name="layers" size="small" />
+            <span class="am-diff-toggle-stats">
+              <span class="am-stat-files">4f</span>
+              <span class="am-stat-additions">+32</span>
+              <span class="am-stat-deletions">−8</span>
+            </span>
+          </button>
+          <IconButton icon="console" size="small" variant="ghost" label="Terminal" />
+        </div>
+      </div>
+    </StoryProviders>
+  ),
+}
+
+export const TabBarWithReviewTab: Story = {
+  name: "TabBar — with review tab",
+  render: () => (
+    <StoryProviders noPadding>
+      <div class="am-tab-bar">
+        <div class="am-tab-scroll-area">
+          <div class="am-tab-list">
+            <MockTab title="Implement auth" />
+            <MockReviewTab active />
+          </div>
+        </div>
+        <TooltipKeybind title="New session" keybind="⌘T" placement="bottom">
+          <IconButton icon="plus" size="small" variant="ghost" label="New session" class="am-tab-add" />
+        </TooltipKeybind>
+        <div class="am-tab-actions">
+          <IconButton icon="expand" size="small" variant="ghost" label="Review" class="am-tab-diff-btn-active" />
+          <IconButton icon="console" size="small" variant="ghost" label="Terminal" />
+        </div>
+      </div>
+    </StoryProviders>
+  ),
+}
+
+export const TabBarSingleTab: Story = {
+  name: "TabBar — single active tab",
+  render: () => (
+    <StoryProviders noPadding>
+      <div class="am-tab-bar">
+        <div class="am-tab-scroll-area">
+          <div class="am-tab-list">
+            <MockTab title="PR #6966 worktree checkout" active />
+          </div>
+        </div>
+        <TooltipKeybind title="New session" keybind="⌘T" placement="bottom">
+          <IconButton icon="plus" size="small" variant="ghost" label="New session" class="am-tab-add" />
+        </TooltipKeybind>
+        <div class="am-tab-actions">
+          <button class="am-diff-toggle-btn am-diff-toggle-has-changes">
+            <Icon name="layers" size="small" />
+            <span class="am-diff-toggle-stats">
+              <span class="am-stat-files">188f</span>
+              <span class="am-stat-additions">+23625</span>
+              <span class="am-stat-deletions">−359</span>
+            </span>
+          </button>
+          <IconButton icon="console" size="small" variant="ghost" label="Terminal" />
+        </div>
+      </div>
+    </StoryProviders>
+  ),
 }


### PR DESCRIPTION
## Summary

- Fix tooltip-trigger `div` breaking the CSS height chain in the agent manager tab bar, causing tabs to appear collapsed with missing pixels on the active indicator border
- Add three TabBar visual regression stories (`TabBarMultipleTabs`, `TabBarWithReviewTab`, `TabBarSingleTab`) that mirror the real DOM structure to catch future regressions