### PR TITLE
fix(ui): fix missing path separator in diff viewer file headers

### DIFF
--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1005,7 +1005,7 @@ function ToolFileAccordion(props: { path: string; actions?: JSX.Element; childre
                 <FileIcon node={{ path: props.path, type: "file" }} />
                 <div data-slot="apply-patch-file-name-container">
                   <Show when={props.path.includes("/")}>
-                    <span data-slot="apply-patch-directory">{`\u202A${getDirectory(props.path)}\u202C`}</span>
+                    <span data-slot="apply-patch-directory">{`\u2066${getDirectory(props.path)}\u2069`}</span>
                   </Show>
                   <span data-slot="apply-patch-filename">{getFilename(props.path)}</span>
                 </div>
@@ -1517,7 +1517,7 @@ function ToolMetaLine(props: {
     >
       <span data-slot="message-part-title-filename">{props.filename}</span>
       <Show when={props.path}>
-        <span data-slot="message-part-directory-inline">{props.path}</span>
+        <span data-slot="message-part-directory-inline">{`\u2066${props.path}\u2069`}</span>
       </Show>
       <Show when={props.changes}>{(changes) => <DiffChanges changes={changes()} />}</Show>
     </span>
@@ -2196,7 +2196,7 @@ ToolRegistry.register({
                                   <FileIcon node={{ path: file.relativePath, type: "file" }} />
                                   <div data-slot="apply-patch-file-name-container">
                                     <Show when={file.relativePath.includes("/")}>
-                                      <span data-slot="apply-patch-directory">{`\u202A${getDirectory(file.relativePath)}\u202C`}</span>
+                                      <span data-slot="apply-patch-directory">{`\u2066${getDirectory(file.relativePath)}\u2069`}</span>
                                     </Show>
 
                                     <span

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -431,7 +431,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                             <FileIcon node={{ path: diff.file, type: "file" }} />
                             <div data-slot="session-review-file-name-container">
                               <Show when={diff.file.includes("/")}>
-                                <span data-slot="session-review-directory">{getDirectory(diff.file)}</span>
+                                <span data-slot="session-review-directory">{`\u2066${getDirectory(diff.file)}\u2069`}</span>
                               </Show>
                               <span data-slot="session-review-filename">{getFilename(diff.file)}</span>
                               <Show when={fileCommentCount() > 0}>

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -507,7 +507,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                                 <FileIcon node={{ path: diff.file, type: "file" }} />
                                 <div data-slot="session-review-file-name-container">
                                   <Show when={diff.file.includes("/")}>
-                                    <span data-slot="session-review-directory">{`\u202A${getDirectory(diff.file)}\u202C`}</span>
+                                    <span data-slot="session-review-directory">{`\u2066${getDirectory(diff.file)}\u2069`}</span>
                                   </Show>
                                   <span data-slot="session-review-filename">{getFilename(diff.file)}</span>
                                   <Show when={fileCommentCount() > 0}>

--- a/packages/kilo-vscode/webview-ui/diff-virtual/DiffVirtualApp.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-virtual/DiffVirtualApp.tsx
@@ -85,7 +85,7 @@ const DiffVirtualContent: Component = () => {
                 <span class="am-review-toolbar-stats">
                   <FileIcon node={{ path: d().file, type: "file" }} />
                   <Show when={directory()}>
-                    <span class="am-review-toolbar-dir">{`\u202A${directory()}/\u202C`}</span>
+                    <span class="am-review-toolbar-dir">{`\u2066${directory()}/\u2069`}</span>
                   </Show>
                   <span class="am-review-toolbar-fname">{filename()}</span>
                   <span class="am-review-toolbar-adds">+{d().additions}</span>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDiff.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDiff.tsx
@@ -64,7 +64,7 @@ export const PermissionDiff: Component<PermissionDiffProps> = (props) => {
             </svg>
           </div>
           <div data-slot="permission-diff-filename">
-            {directory() && <span data-slot="permission-diff-directory">{directory()}/</span>}
+            {directory() && <span data-slot="permission-diff-directory">{`\u2066${directory()}/\u2069`}</span>}
             <span data-slot="permission-diff-name">{filename()}</span>
           </div>
         </div>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
@@ -246,7 +246,7 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
                                       <span data-slot="session-turn-diff-path">
                                         <Show when={diff.file.includes("/")}>
                                           <span data-slot="session-turn-diff-directory">
-                                            {`\u202A${getDirectory(diff.file)}\u202C`}
+                                            {`\u2066${getDirectory(diff.file)}\u2069`}
                                           </span>
                                         </Show>
                                         <span data-slot="session-turn-diff-filename">{getFilename(diff.file)}</span>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1301,7 +1301,7 @@ function ToolFileAccordion(props: { path: string; actions?: JSX.Element; childre
                 <FileIcon node={{ path: props.path, type: "file" }} />
                 <div data-slot="apply-patch-file-name-container">
                   <Show when={props.path.includes("/")}>
-                    <span data-slot="apply-patch-directory">{`\u202A${getDirectory(props.path)}\u202C`}</span>
+                    <span data-slot="apply-patch-directory">{`\u2066${getDirectory(props.path)}\u2069`}</span>
                   </Show>
                   <span data-slot="apply-patch-filename">{getFilename(props.path)}</span>
                 </div>
@@ -2112,7 +2112,7 @@ ToolRegistry.register({
                                   <FileIcon node={{ path: file.relativePath, type: "file" }} />
                                   <div data-slot="apply-patch-file-name-container">
                                     <Show when={file.relativePath.includes("/")}>
-                                      <span data-slot="apply-patch-directory">{`\u202A${getDirectory(file.relativePath)}\u202C`}</span>
+                                      <span data-slot="apply-patch-directory">{`\u2066${getDirectory(file.relativePath)}\u2069`}</span>
                                     </Show>
                                     <span data-slot="apply-patch-filename">{getFilename(file.relativePath)}</span>
                                   </div>

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -509,7 +509,7 @@ export const SessionReview = (props: SessionReviewProps) => {
                                 <FileIcon node={{ path: file, type: "file" }} />
                                 <div data-slot="session-review-file-name-container">
                                   <Show when={file.includes("/")}>
-                                    <span data-slot="session-review-directory">{`\u202A${getDirectory(file)}\u202C`}</span>
+                                    <span data-slot="session-review-directory">{`\u2066${getDirectory(file)}\u2069`}</span>
                                   </Show>
                                   <span data-slot="session-review-filename">{getFilename(file)}</span>
                                   <Show when={props.onViewFile}>

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -499,7 +499,7 @@ export function SessionTurn(
                                     <span data-slot="session-turn-diff-path">
                                       <Show when={diff.file.includes("/")}>
                                         <span data-slot="session-turn-diff-directory">
-                                          {`\u202A${getDirectory(diff.file)}\u202C`}
+                                          {`\u2066${getDirectory(diff.file)}\u2069`}
                                         </span>
                                       </Show>
                                       <span data-slot="session-turn-diff-filename">{getFilename(diff.file)}</span>


### PR DESCRIPTION
## Summary
- Replace LTR Embedding (`\u202A`/`\u202C`) with LTR Isolate (`\u2066`/`\u2069`) Unicode bidi characters in directory path spans across all diff viewer components
- Fixes the trailing `/` in directory paths (e.g. `routes/`) being visually swallowed by the CSS `direction: rtl` used for front-ellipsis truncation, causing paths like `routesglobal.ts` instead of `routes/global.ts`
- Also adds missing bidi wrapping to `DiffPanel.tsx` which had none

Before: 

<img width="562" height="100" alt="image" src="https://github.com/user-attachments/assets/1a2387c0-80af-4629-8cfe-c1634c7aa654" />

After:

<img width="478" height="101" alt="image" src="https://github.com/user-attachments/assets/7c3a6b3e-ddef-493d-a3d9-1e30b8563797" />


