### PR TITLE
feat(agent-manager): drag-and-drop diff file headers into chat as @mentions

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -12,6 +12,7 @@ import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { Tooltip, TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
 import type { DiffLineAnnotation, AnnotationSide, SelectedLineRange } from "@pierre/diffs"
 import type { WorktreeFileDiff } from "../src/types/messages"
+import { KILO_FILE_PATH_MIME } from "../src/utils/path-mentions"
 import { useLanguage } from "../src/context/language"
 import { getDirectory, getFilename, lineCount, sanitizeReviewComments, type ReviewComment } from "./review-comments"
 import {
@@ -427,7 +428,15 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                     <StickyAccordionHeader>
                       <Accordion.Trigger>
                         <div data-slot="session-review-trigger-content">
-                          <div data-slot="session-review-file-info">
+                          <div
+                            data-slot="session-review-file-info"
+                            draggable={true}
+                            onDragStart={(e: DragEvent) => {
+                              e.dataTransfer?.setData(KILO_FILE_PATH_MIME, diff.file)
+                              e.dataTransfer?.setData("text/plain", diff.file)
+                              e.stopPropagation()
+                            }}
+                          >
                             <FileIcon node={{ path: diff.file, type: "file" }} />
                             <div data-slot="session-review-file-name-container">
                               <Show when={diff.file.includes("/")}>

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -13,6 +13,7 @@ import { ResizeHandle } from "@kilocode/kilo-ui/resize-handle"
 import { Tooltip, TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
 import type { DiffLineAnnotation, AnnotationSide, SelectedLineRange } from "@pierre/diffs"
 import type { WorktreeFileDiff } from "../src/types/messages"
+import { KILO_FILE_PATH_MIME } from "../src/utils/path-mentions"
 import { useLanguage } from "../src/context/language"
 import { FileTree } from "./FileTree"
 import { treeOrder } from "./file-tree-utils"
@@ -503,7 +504,15 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                         <StickyAccordionHeader>
                           <Accordion.Trigger>
                             <div data-slot="session-review-trigger-content">
-                              <div data-slot="session-review-file-info">
+                              <div
+                                data-slot="session-review-file-info"
+                                draggable={true}
+                                onDragStart={(e: DragEvent) => {
+                                  e.dataTransfer?.setData(KILO_FILE_PATH_MIME, diff.file)
+                                  e.dataTransfer?.setData("text/plain", diff.file)
+                                  e.stopPropagation()
+                                }}
+                              >
                                 <FileIcon node={{ path: diff.file, type: "file" }} />
                                 <div data-slot="session-review-file-name-container">
                                   <Show when={diff.file.includes("/")}>

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1617,6 +1617,12 @@ body.am-wt-dragging-active * {
 .am-review-diff-content [data-slot="session-review-file-info"] {
   min-width: 0;
   flex: 1 1 auto;
+  cursor: grab;
+}
+
+.am-diff-content [data-slot="session-review-file-info"]:active,
+.am-review-diff-content [data-slot="session-review-file-info"]:active {
+  cursor: grabbing;
 }
 
 .am-diff-content [data-slot="session-review-file-name-container"],

--- a/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
@@ -1,6 +1,6 @@
 import { createSignal } from "solid-js"
 import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, isDragLeavingComponent } from "./image-attachments-utils"
-import { extractDropPaths } from "../utils/path-mentions"
+import { extractDropPaths, KILO_FILE_PATH_MIME } from "../utils/path-mentions"
 
 export interface ImageAttachment {
   id: string
@@ -59,9 +59,10 @@ export function useImageAttachments() {
   const handleDragOver = (event: DragEvent) => {
     const types = event.dataTransfer?.types
     if (!types) return
-    // Accept file drops and VS Code URI-list drops (explorer, editor tabs).
+    // Accept file drops, VS Code URI-list drops, and internal file-path drags.
     // Do NOT accept bare text/plain here — that would intercept normal text drags.
-    const acceptable = types.includes("Files") || types.includes("application/vnd.code.uri-list")
+    const acceptable =
+      types.includes("Files") || types.includes("application/vnd.code.uri-list") || types.includes(KILO_FILE_PATH_MIME)
     if (!acceptable) return
     event.preventDefault()
     setDragging(true)

--- a/packages/kilo-vscode/webview-ui/src/utils/path-mentions.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/path-mentions.ts
@@ -58,16 +58,30 @@ function isFilePath(line: string): boolean {
 }
 
 /**
+ * Custom MIME type used for internal drag-and-drop of relative file paths
+ * (e.g. from diff panel file headers). Unlike VS Code's URI list, these
+ * are workspace-relative paths that can be used directly as @mentions.
+ */
+export const KILO_FILE_PATH_MIME = "application/x-kilo-file-path"
+
+/**
  * Extract file paths from a drop's DataTransfer.
- * Only considers the URI-list data type (set by VS Code when dragging files
- * from the explorer or editor tabs). Falls back to text/plain but only when
- * every non-empty line looks like a file URI or absolute path, to avoid
- * intercepting normal text drags from the editor.
+ * Checks (in order):
+ * 1. Internal relative-path drag (application/x-kilo-file-path)
+ * 2. VS Code URI-list (application/vnd.code.uri-list)
+ * 3. text/plain — only when every line looks like an absolute file path
  *
  * Returns null if no file paths are found.
  */
 export function extractDropPaths(dt: DataTransfer): string[] | null {
-  // Prefer the VS Code-specific URI list — this is always file paths
+  // Internal relative-path drag from diff file headers etc.
+  const kilo = dt.getData(KILO_FILE_PATH_MIME)
+  if (kilo) {
+    const paths = kilo.split(/\r?\n/).filter((line) => line.trim() !== "")
+    if (paths.length > 0) return paths
+  }
+
+  // VS Code-specific URI list (explorer, editor tabs)
   const uri = dt.getData("application/vnd.code.uri-list")
   if (uri) {
     const paths = uri.split(/\r?\n/).filter((line) => line.trim() !== "")


### PR DESCRIPTION
## Summary
- Make diff panel file headers draggable so users can drop them into the Agent Manager chat input to add `@file` references
- Introduce `application/x-kilo-file-path` custom MIME type for internal relative-path drag-and-drop, keeping existing VS Code explorer/editor tab drop behavior intact