### PR TITLE
fix(agent-manager): preserve scroll position when agent edits files in diff viewer

### DIFF
--- a/packages/kilo-ui/src/components/diff.tsx
+++ b/packages/kilo-ui/src/components/diff.tsx
@@ -234,6 +234,8 @@ export function Diff<T>(props: DiffProps<T>) {
       observer = undefined
       requestAnimationFrame(() => {
         if (token !== renderToken) return
+        // Clear the height pin now that Pierre has rendered new content.
+        container.style.minHeight = ""
         setSelectedLines(lastSelection)
         local.onRendered?.()
       })
@@ -273,6 +275,7 @@ export function Diff<T>(props: DiffProps<T>) {
 
     const root = getRoot()
     if (typeof MutationObserver === "undefined") {
+      container.style.minHeight = ""
       if (!root || !isReady(root)) return
       setSelectedLines(lastSelection)
       local.onRendered?.()
@@ -570,6 +573,13 @@ export function Diff<T>(props: DiffProps<T>) {
       if (!large()) return sampledChecksum(contents, contents.length)
       return sampledChecksum(contents)
     }
+
+    // Preserve container height during re-render to prevent scroll jumps.
+    // When Pierre tears down the DOM (innerHTML = ""), the container collapses
+    // to 0 height, causing layout shifts that reset the scroll position of
+    // any ancestor scroller. Pinning min-height prevents the collapse.
+    const height = container.offsetHeight
+    if (height > 0) container.style.minHeight = `${height}px`
 
     instance?.cleanUp()
     instance = virtualizer

--- a/packages/kilo-vscode/tests/unit/agent-manager-diff-state.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-diff-state.test.ts
@@ -23,22 +23,29 @@ describe("agent manager diff state", () => {
   it("preserves loaded detail when summary metadata is unchanged", () => {
     const prev = [diff({ summarized: false, before: "old\n", after: "new\n" })]
     const next = [diff({ summarized: true })]
+    const result = mergeWorktreeDiffs(prev, next)
 
-    expect(mergeWorktreeDiffs(prev, next)).toEqual([diff({ summarized: false, before: "old\n", after: "new\n" })])
+    expect(result.diffs).toEqual([diff({ summarized: false, before: "old\n", after: "new\n" })])
+    expect(result.diffs[0]).toBe(prev[0])
+    expect(result.stale.size).toBe(0)
   })
 
-  it("drops cached detail when summary metadata changes", () => {
+  it("preserves cached content and marks stale when summary metadata changes", () => {
     const prev = [diff({ summarized: false, before: "old\n", after: "new\n", additions: 1 })]
     const next = [diff({ summarized: true, additions: 2 })]
+    const result = mergeWorktreeDiffs(prev, next)
 
-    expect(mergeWorktreeDiffs(prev, next)).toEqual(next)
+    expect(result.diffs[0]).toBe(prev[0])
+    expect(result.stale).toEqual(new Set(["src/app.ts"]))
   })
 
-  it("drops cached detail when the summary stamp changes", () => {
+  it("preserves cached content and marks stale when summary stamp changes", () => {
     const prev = [diff({ summarized: false, before: "old\n", after: "new\n", stamp: "1:1" })]
     const next = [diff({ summarized: true, stamp: "1:2" })]
+    const result = mergeWorktreeDiffs(prev, next)
 
-    expect(mergeWorktreeDiffs(prev, next)).toEqual(next)
+    expect(result.diffs[0]).toBe(prev[0])
+    expect(result.stale).toEqual(new Set(["src/app.ts"]))
   })
 
   it("does not auto-open generated-like files or large diff sets", () => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1372,28 +1372,18 @@ const AgentManagerContent: Component = () => {
 
       if (msg.type === "agentManager.worktreeDiff") {
         const ev = msg as AgentManagerWorktreeDiffMessage
+        let staleFiles: Set<string> | undefined
         setDiffDatas((prev) => {
           const existing = prev[ev.sessionId]
-          const next = existing ? mergeWorktreeDiffs(existing, ev.diffs) : ev.diffs
-          if (existing && existing.length === next.length) {
-            const same = existing.every((old, i) => {
-              const item = next[i]!
-              return (
-                old.file === item.file &&
-                old.before === item.before &&
-                old.after === item.after &&
-                old.status === item.status &&
-                old.tracked === item.tracked &&
-                old.generatedLike === item.generatedLike &&
-                old.summarized === item.summarized &&
-                old.additions === item.additions &&
-                old.deletions === item.deletions
-              )
-            })
-            if (same) return prev
-          }
+          const merged = existing
+            ? mergeWorktreeDiffs(existing, ev.diffs)
+            : { diffs: ev.diffs, stale: new Set<string>() }
+          staleFiles = merged.stale
+          const next = merged.diffs
+          if (existing && existing.length === next.length && existing.every((old, i) => old === next[i])) return prev
           return { ...prev, [ev.sessionId]: next }
         })
+        if (staleFiles) refreshStaleDiffs(ev.sessionId, staleFiles)
       }
 
       if (msg.type === "agentManager.worktreeDiffFile") {
@@ -1638,6 +1628,15 @@ const AgentManagerContent: Component = () => {
     if (diffFileLoading()[sessionId]?.[file]) return
     setDiffFilePending(sessionId, file, true)
     vscode.postMessage({ type: "agentManager.requestWorktreeDiffFile", sessionId, file })
+  }
+
+  const refreshStaleDiffs = (sessionId: string, files: Set<string>) => {
+    const loading = diffFileLoading()[sessionId] ?? {}
+    for (const file of files) {
+      if (loading[file]) continue
+      setDiffFilePending(sessionId, file, true)
+      vscode.postMessage({ type: "agentManager.requestWorktreeDiffFile", sessionId, file })
+    }
   }
 
   const diffFileLoadingForCurrent = createMemo(() => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/diff-state.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/diff-state.ts
@@ -13,14 +13,45 @@ export function sameDiffMeta(left: WorktreeFileDiff, right: WorktreeFileDiff) {
   )
 }
 
-export function mergeWorktreeDiffs(prev: WorktreeFileDiff[], next: WorktreeFileDiff[]) {
+export interface MergeResult {
+  diffs: WorktreeFileDiff[]
+  /** Files whose metadata changed while we preserved cached content.
+   *  The caller should re-request fresh content for these. */
+  stale: Set<string>
+}
+
+export function mergeWorktreeDiffs(prev: WorktreeFileDiff[], next: WorktreeFileDiff[]): MergeResult {
   const map = new Map(prev.map((diff) => [diff.file, diff]))
-  return next.map((diff) => {
+  const stale = new Set<string>()
+  const diffs = next.map((diff) => {
     const existing = map.get(diff.file)
     if (!existing) return diff
+    // Preserve referential identity when content hasn't changed — this
+    // prevents Solid's <For> from re-rendering unchanged <Diff> components,
+    // which avoids Pierre's full DOM teardown and the scroll reset it causes.
+    if (
+      existing.file === diff.file &&
+      existing.before === diff.before &&
+      existing.after === diff.after &&
+      sameDiffMeta(existing, diff)
+    )
+      return existing
     if (existing.summarized) return diff
     if (!diff.summarized) return diff
-    if (!sameDiffMeta({ ...existing, summarized: true }, diff)) return diff
-    return { ...diff, before: existing.before, after: existing.after, summarized: false }
+    // Metadata matches — restore cached content as before.
+    if (sameDiffMeta({ ...existing, summarized: true }, diff)) {
+      const merged = { ...diff, before: existing.before, after: existing.after, summarized: false }
+      if (existing.before === merged.before && existing.after === merged.after && sameDiffMeta(existing, merged))
+        return existing
+      return merged
+    }
+    // Metadata changed (agent edited the file) but we have cached content.
+    // Keep the existing reference so <For> doesn't re-render and cause a
+    // scroll jump. Track the file as stale so the caller re-requests fresh
+    // content. The header stats will be slightly behind until the detail
+    // arrives, which is an acceptable trade-off for scroll stability.
+    stale.add(diff.file)
+    return existing
   })
+  return { diffs, stale }
 }


### PR DESCRIPTION
## Summary
- Prevent the diff viewer from resetting scroll position when the agent modifies files in a worktree session
- `mergeWorktreeDiffs` now preserves referential identity for unchanged items and keeps existing references for stale files, immediately re-requesting fresh content in the background
- The `<Diff>` component pins `min-height` during re-renders to prevent layout shifts from Pierre's `innerHTML` teardown