### PR TITLE
fix(agent-manager): route plan follow-up sessions to worktree instead of LOCAL

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -199,6 +199,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private slimEditMetadata = true
 
   private pendingFollowup: Followup | null = null
+  private followupListeners: Array<(session: Session, directory: string) => void> = []
   /** Worktree diff stats poller for the sidebar badge — reuses GitStatsPoller (local stats only) */
   private statsPoller: GitStatsPoller | null = null
   private statsGitOps: GitOps | null = null
@@ -478,6 +479,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    */
   public refreshSessions(): void {
     void this.handleLoadSessions()
+  }
+
+  /** Register a listener invoked when a plan follow-up session is adopted. */
+  public onFollowupAdopted(cb: (session: Session, directory: string) => void): void {
+    this.followupListeners.push(cb)
   }
 
   /** Recover permission/question prompts after sessions and directories are tracked. */
@@ -3219,6 +3225,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     this.pendingFollowup = null
     this.trackDirectory(session.id, session.directory)
+    for (const cb of this.followupListeners) cb(session, session.directory)
     this.registerSession(session)
     void this.handleLoadMessages(session.id)
     return true

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -193,6 +193,10 @@ export class AgentManagerProvider implements Disposable {
       this.statsPoller.setVisible(visible)
     })
 
+    ctx.sessions.onFollowupAdopted((session, directory) => {
+      this.adoptFollowupInWorktree(session, directory)
+    })
+
     this.stateReady = this.initializeState()
     void this.sendRepoInfo()
     this.sendKeybindings()
@@ -1199,6 +1203,24 @@ export class AgentManagerProvider implements Disposable {
     // was tracked. The CLI backend may have emitted permission.asked between
     // session.create() returning and this registration completing.
     this.panel.sessions.recoverPendingPrompts()
+  }
+
+  /** Route a plan follow-up session to its worktree instead of LOCAL. */
+  private adoptFollowupInWorktree(session: Session, directory: string): void {
+    const state = this.getStateManager()
+    if (!state) return
+    const worktree = state.findWorktreeByPath(directory)
+    if (!worktree) return
+
+    state.addSession(session.id, worktree.id)
+    this.registerWorktreeSession(session.id, directory)
+    this.pushState()
+    this.postToWebview({
+      type: "agentManager.sessionAdded",
+      sessionId: session.id,
+      worktreeId: worktree.id,
+    })
+    this.log(`Adopted follow-up session ${session.id} into worktree ${worktree.id}`)
   }
 
   private onWorktreePresence(result: WorktreePresenceResult): void {

--- a/packages/kilo-vscode/src/agent-manager/host.ts
+++ b/packages/kilo-vscode/src/agent-manager/host.ts
@@ -40,6 +40,10 @@ export interface SessionProvider {
   registerSession(session: Session): void
   /** Recover any pending permission/question prompts for tracked sessions. */
   recoverPendingPrompts(): void
+  /** Register a callback invoked when a plan follow-up session is adopted.
+   *  The callback receives the new session and its directory so the Agent Manager
+   *  can route it to the correct worktree instead of LOCAL. */
+  onFollowupAdopted(cb: (session: Session, directory: string) => void): void
   dispose(): void
 }
 

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -96,6 +96,7 @@ export class VscodeHost implements Host {
       refreshSessions: () => provider.refreshSessions(),
       registerSession: (s) => provider.registerSession(s),
       recoverPendingPrompts: () => provider.recoverPendingPrompts(),
+      onFollowupAdopted: (cb) => provider.onFollowupAdopted(cb),
       dispose: () => provider.dispose(),
     }
 

--- a/packages/kilo-vscode/src/kilo-provider/followup-session.ts
+++ b/packages/kilo-vscode/src/kilo-provider/followup-session.ts
@@ -11,10 +11,7 @@ export interface Followup {
 export function recordFollowup(input: { answers: string[][]; dir: string; now: number }): Followup | undefined {
   const answer = input.answers[0]?.[0]?.trim()
   if (answer !== LABEL) return
-  return {
-    dir: input.dir,
-    time: input.now,
-  }
+  return { dir: input.dir, time: input.now }
 }
 
 export function matchFollowup(input: { pending: Followup | null; dir: string; now: number }): boolean {

--- a/packages/kilo-vscode/tests/unit/kilo-provider-followup.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-followup.test.ts
@@ -130,4 +130,37 @@ describe("KiloProvider follow-up sessions", () => {
       },
     ])
   })
+
+  it("calls onFollowupAdopted listeners with session and directory", async () => {
+    const service = connection()
+    const provider = new KiloProvider({} as never, service as never)
+    const internal = provider as unknown as Internals
+    const adopted: Array<{ id: string; dir: string }> = []
+
+    internal.webview = { postMessage: async () => true }
+    internal.syncWebviewState = async () => {}
+    internal.flushPendingSessionRefresh = async () => {}
+    internal.fetchAndSendProviders = async () => {}
+    internal.fetchAndSendAgents = async () => {}
+    internal.fetchAndSendSkills = async () => {}
+    internal.fetchAndSendCommands = async () => {}
+    internal.fetchAndSendConfig = async () => {}
+    internal.fetchAndSendNotifications = async () => {}
+    internal.seedSessionStatusMap = async () => {}
+    internal.sendNotificationSettings = () => {}
+    internal.startStatsPolling = () => {}
+    internal.handleLoadMessages = async () => {}
+
+    await internal.initializeConnection()
+
+    provider.onFollowupAdopted((session, directory) => {
+      adopted.push({ id: session.id, dir: directory })
+    })
+
+    internal.pendingFollowup = { dir: "/repo/.kilo/worktrees/feat", time: Date.now() }
+    service.emit(created({ id: "ses-wt", directory: "/repo/.kilo/worktrees/feat" }))
+    await Promise.resolve()
+
+    expect(adopted).toEqual([{ id: "ses-wt", dir: "/repo/.kilo/worktrees/feat" }])
+  })
 })


### PR DESCRIPTION
## Summary
- Plan follow-up "Start new session" from a worktree now stays in that worktree instead of defaulting to the LOCAL tab
- Adds `onFollowupAdopted` callback to `SessionProvider` so `AgentManagerProvider` can register the session in the correct worktree state before the webview receives `sessionCreated`

Fixes #8957