### PR TITLE
feat(cli,vscode): add memory profiling infrastructure for kilo serve

### DIFF
--- a/packages/kilo-vscode/docs/infrastructure/memory-profiling.md
+++ b/packages/kilo-vscode/docs/infrastructure/memory-profiling.md
@@ -1,0 +1,192 @@
+# Memory Profiling
+
+Infrastructure for profiling memory usage in the `kilo serve` backend process, primarily to investigate memory leaks that occur when the Agent Manager is used over extended periods.
+
+## Background
+
+When using the Agent Manager for an hour+ with large diffs between main and worktree branches, the `kilo serve` Bun process can accumulate multiple gigabytes of RSS. This is most severe on Windows, likely due to differences in process/pipe cleanup and memory allocator behavior.
+
+### Suspected causes
+
+| Suspect                            | Why                                                                                                                                                                                                                                                         |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Bun shell `$` stdout buffering** | Git commands use `$\`git diff ...\`.quiet()` which buffers all stdout into a single native buffer (outside V8 heap). Large diffs = large buffers per poll cycle. On Windows, pipe handles may not be released promptly.                                     |
+| **Instance cache never shrinks**   | Each worktree directory creates a permanent `InstanceContext` with file watchers, LSP, snapshot git repo, DB connections (`packages/opencode/src/project/instance.ts`). `Instance.dispose()` exists but the extension never calls it for deleted worktrees. |
+| **Aggressive diff polling**        | `GitStatsPoller` calls `diffSummary` every 5s per worktree. `WorktreeDiffController` calls `diffFile` every 2.5s. Each poll spawns git processes whose stdout is buffered entirely in memory.                                                               |
+| **Effect PubSub unbounded queues** | `PubSub.unbounded()` in `packages/opencode/src/bus/index.ts` — if a subscriber falls behind (stalled SSE connection on Windows), messages queue up indefinitely.                                                                                            |
+| **InstanceBootstrap per worktree** | Each worktree gets file watchers, LSP servers, snapshot repos. File watchers on Windows use ReadDirectoryChangesW which may hold more memory.                                                                                                               |
+
+### Important: heap vs native memory
+
+The memory growth is likely **outside the V8 heap** — in Bun's native allocations from child process stdout buffering. V8 heap snapshots capture JS objects but not native buffers. If `/global/debug/memory` shows RSS growing while `heapUsedMB` stays flat, the leak is in native memory and heap snapshots alone won't identify it. OS-level tools (`vmmap` on macOS, `!heap` / Process Explorer on Windows) are needed for that case.
+
+## Quick start
+
+### Launch the extension with profiling
+
+```bash
+bun run extension --profile
+```
+
+This sets `KILO_PROFILE=1` and `KILO_AUTO_HEAP_SNAPSHOT=1` in the environment. These propagate from the VS Code extension host to the spawned `kilo serve` child process (via `server-manager.ts` which spreads `process.env`).
+
+When profiling is active:
+
+- Memory stats are logged every 30 seconds in the CLI backend logs
+- Debug HTTP endpoints are enabled on the `kilo serve` process
+- Auto heap snapshots fire when RSS exceeds 2 GB
+
+The Extension Host output channel will print the debug endpoint URLs after the server starts.
+
+### Without the launch script
+
+Set the environment variables manually before launching VS Code:
+
+```bash
+KILO_PROFILE=1 KILO_AUTO_HEAP_SNAPSHOT=1 code .
+```
+
+## Debug endpoints
+
+All endpoints require `KILO_PROFILE=1` to be set (returns 403 otherwise). They are served on the `kilo serve` HTTP port which is printed in the Extension Host output.
+
+Authentication uses the same basic auth as all other server endpoints. The password is in the `KILO_SERVER_PASSWORD` env var of the `kilo serve` process.
+
+```bash
+# Find the password (macOS/Linux)
+PASSWORD=$(ps eww $(pgrep -f "kilo serve") | tr ' ' '\n' | grep KILO_SERVER_PASSWORD | cut -d= -f2)
+AUTH=$(echo -n "kilo:$PASSWORD" | base64)
+PORT=<port from Extension Host output>
+```
+
+### GET /global/debug/memory
+
+Returns current `process.memoryUsage()` stats.
+
+```bash
+curl -s -H "Authorization: Basic $AUTH" http://127.0.0.1:$PORT/global/debug/memory
+```
+
+Response:
+
+```json
+{
+  "rss": 229441536,
+  "heapTotal": 136283136,
+  "heapUsed": 178550515,
+  "external": 77595238,
+  "arrayBuffers": 29603240,
+  "rssMB": 218.8,
+  "heapUsedMB": 170.3,
+  "pid": 45130,
+  "uptime": 76.8
+}
+```
+
+- `rss` — total process memory (includes native allocations, V8 heap, etc.)
+- `heapUsed` — V8 JS heap usage
+- `external` — memory for V8 external allocations (Buffers, etc.)
+- `arrayBuffers` — memory for ArrayBuffer and SharedArrayBuffer
+
+If `rssMB` grows but `heapUsedMB` stays flat, the leak is in native memory.
+
+### POST /global/debug/snapshot
+
+Writes a V8 heap snapshot to `~/.local/share/kilo/log/` and returns the file path.
+
+```bash
+curl -s -X POST -H "Authorization: Basic $AUTH" http://127.0.0.1:$PORT/global/debug/snapshot
+```
+
+Response:
+
+```json
+{
+  "file": "/Users/you/.local/share/kilo/log/heap-45130-20260415T115924468Z.heapsnapshot",
+  "rssMB": 1398.1,
+  "heapUsedMB": 172.6
+}
+```
+
+Note: RSS will spike during snapshot creation (V8 serializes the entire heap graph). This is expected and temporary.
+
+### POST /global/debug/gc
+
+Forces garbage collection via `Bun.gc(true)` and reports before/after memory.
+
+```bash
+curl -s -X POST -H "Authorization: Basic $AUTH" http://127.0.0.1:$PORT/global/debug/gc
+```
+
+Response:
+
+```json
+{
+  "before": { "rssMB": 482.1, "heapUsedMB": 156.2 },
+  "after": { "rssMB": 484.1, "heapUsedMB": 156.2 },
+  "freedMB": 0.0
+}
+```
+
+If `freedMB` is 0 and RSS doesn't drop, the retained memory is not JS heap objects.
+
+## Profiling workflow
+
+### 1. Establish a baseline
+
+Start the extension with `--profile`, wait for it to fully initialize, then:
+
+```bash
+curl -s -H "Authorization: Basic $AUTH" http://127.0.0.1:$PORT/global/debug/memory
+curl -s -X POST -H "Authorization: Basic $AUTH" http://127.0.0.1:$PORT/global/debug/snapshot
+```
+
+### 2. Reproduce the leak
+
+Use the Agent Manager normally — create worktrees, run sessions, especially with branches that have large diffs from main. Wait 30-60 minutes.
+
+### 3. Take comparison measurements
+
+```bash
+# Check current memory
+curl -s -H "Authorization: Basic $AUTH" http://127.0.0.1:$PORT/global/debug/memory
+
+# Force GC to separate JS heap leaks from native leaks
+curl -s -X POST -H "Authorization: Basic $AUTH" http://127.0.0.1:$PORT/global/debug/gc
+
+# Take comparison snapshot
+curl -s -X POST -H "Authorization: Basic $AUTH" http://127.0.0.1:$PORT/global/debug/snapshot
+```
+
+### 4. Analyze snapshots
+
+**Chrome DevTools** (best for comparing two snapshots):
+
+1. Open `chrome://inspect` → "Open dedicated DevTools for Node"
+2. Memory tab → Load both `.heapsnapshot` files
+3. Select the later snapshot → switch to "Comparison" view
+4. Sort by "Size Delta" to see which object types grew
+
+**heap-snapshot-toolkit** (already a dev dependency):
+
+```bash
+bunx heap-snapshot-toolkit analyze ~/.local/share/kilo/log/heap-*.heapsnapshot
+```
+
+### 5. If the leak is native (RSS grows, heap stays flat)
+
+V8 heap snapshots won't help. Use OS-level tools instead:
+
+- **macOS**: `vmmap <pid> | grep MALLOC` — shows native heap regions
+- **Windows**: Process Explorer → Properties → Performance → Virtual Size breakdown, or `!heap` in WinDbg
+- **Cross-platform**: Track child process count over time — `pgrep -P <kilo_pid> | wc -l` — to check if git processes are accumulating
+
+## Files changed
+
+| File                                                              | What                                                                           |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `packages/opencode/src/flag/flag.ts`                              | `KILO_PROFILE` env var flag                                                    |
+| `packages/opencode/src/cli/heap.ts`                               | Periodic memory logging (every 30s) when `KILO_PROFILE=1`                      |
+| `packages/opencode/src/server/routes/global.ts`                   | `/global/debug/memory`, `/global/debug/snapshot`, `/global/debug/gc` endpoints |
+| `packages/kilo-vscode/script/launch.ts`                           | `--profile` flag for `bun run extension`                                       |
+| `packages/kilo-vscode/src/services/cli-backend/server-manager.ts` | Logs debug endpoint URLs when profiling is active                              |

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -13,6 +13,7 @@
  *   --insiders        Prefer VS Code Insiders over stable
  *   --wait            Block until the VS Code window is closed
  *   --clean           Wipe the user-data and extensions dirs before launching
+ *   --profile         Enable memory profiling for both the extension host and CLI backend
  *
  * Environment:
  *   VSCODE_EXEC_PATH  Path to VS Code executable (same as --app-path)
@@ -84,6 +85,7 @@ const insiders = opts["insiders"] === true
 const explicit = opts["app-path"] as string | undefined
 const blocking = opts["wait"] === true
 const clean = opts["clean"] === true
+const profile = opts["profile"] === true
 
 // ---------------------------------------------------------------------------
 // VS Code executable detection
@@ -308,6 +310,18 @@ async function launch() {
   const env = { ...process.env }
   for (const key of Object.keys(env)) {
     if (key.startsWith("ELECTRON_") || key.startsWith("VSCODE_")) delete env[key]
+  }
+
+  // --profile: enable memory profiling for both the extension host and CLI backend.
+  // KILO_PROFILE propagates from the VS Code extension host env to the spawned
+  // kilo serve child process (server-manager.ts spreads process.env). This enables:
+  //   - Periodic memory logging every 30s in the CLI backend
+  //   - /global/debug/memory, /global/debug/snapshot, /global/debug/gc HTTP endpoints
+  //   - Auto heap snapshots when RSS exceeds 2 GB
+  if (profile) {
+    env.KILO_PROFILE = "1"
+    env.KILO_AUTO_HEAP_SNAPSHOT = "1"
+    console.log("[launch] Memory profiling enabled (KILO_PROFILE=1, KILO_AUTO_HEAP_SNAPSHOT=1)")
   }
 
   console.log(`[launch] Starting VS Code (${mode} mode)`)

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -100,6 +100,12 @@ export class ServerManager {
         if (port !== null && !resolved) {
           resolved = true
           console.log("[Kilo New] ServerManager: 🎯 Port detected:", port)
+          if (process.env.KILO_PROFILE) {
+            console.log(`[Kilo New] ServerManager: 🔬 Memory profiling enabled. Debug endpoints:`)
+            console.log(`[Kilo New]   GET  http://127.0.0.1:${port}/global/debug/memory   — current memory stats`)
+            console.log(`[Kilo New]   POST http://127.0.0.1:${port}/global/debug/snapshot  — write heap snapshot`)
+            console.log(`[Kilo New]   POST http://127.0.0.1:${port}/global/debug/gc        — force GC + report`)
+          }
           resolve({ port, password, process: serverProcess })
         }
       })

--- a/packages/opencode/src/cli/heap.ts
+++ b/packages/opencode/src/cli/heap.ts
@@ -14,6 +14,24 @@ export namespace Heap {
   let armed = true
 
   export function start() {
+    // kilocode_change start - periodic memory logging when KILO_PROFILE is set
+    if (Flag.KILO_PROFILE) {
+      const interval = 30_000
+      const profiler = setInterval(() => {
+        const mem = process.memoryUsage()
+        log.info("memory", {
+          rss: +(mem.rss / 1024 / 1024).toFixed(1),
+          heap: +(mem.heapUsed / 1024 / 1024).toFixed(1),
+          external: +(mem.external / 1024 / 1024).toFixed(1),
+          buffers: +(mem.arrayBuffers / 1024 / 1024).toFixed(1),
+          pid: process.pid,
+        })
+      }, interval)
+      profiler.unref?.()
+      log.info("memory profiling enabled", { interval })
+    }
+    // kilocode_change end
+
     if (!Flag.KILO_AUTO_HEAP_SNAPSHOT) return
     if (timer) return
 

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -16,6 +16,7 @@ export namespace Flag {
 
   export const KILO_AUTO_SHARE = truthy("KILO_AUTO_SHARE")
   export const KILO_AUTO_HEAP_SNAPSHOT = truthy("KILO_AUTO_HEAP_SNAPSHOT")
+  export const KILO_PROFILE = truthy("KILO_PROFILE") // kilocode_change
   export const KILO_GIT_BASH_PATH = process.env["KILO_GIT_BASH_PATH"]
   export const KILO_CONFIG = process.env["KILO_CONFIG"]
   export declare const KILO_PURE: boolean

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -12,6 +12,7 @@ import { Log } from "../../util/log"
 import { lazy } from "../../util/lazy"
 import { Config } from "../../config/config"
 import { errors } from "../error"
+import { Flag } from "../../flag/flag" // kilocode_change
 
 const log = Log.create({ service: "server" })
 
@@ -80,246 +81,298 @@ async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>
   })
 }
 
-export const GlobalRoutes = lazy(() =>
-  new Hono()
-    .get(
-      "/health",
-      describeRoute({
-        summary: "Get health",
-        description: "Get health information about the OpenCode server.",
-        operationId: "global.health",
-        responses: {
-          200: {
-            description: "Health information",
-            content: {
-              "application/json": {
-                schema: resolver(z.object({ healthy: z.literal(true), version: z.string() })),
-              },
-            },
-          },
-        },
-      }),
-      async (c) => {
-        return c.json({ healthy: true, version: Installation.VERSION })
-      },
-    )
-    .get(
-      "/event",
-      describeRoute({
-        summary: "Get global events",
-        description: "Subscribe to global events from the OpenCode system using server-sent events.",
-        operationId: "global.event",
-        responses: {
-          200: {
-            description: "Event stream",
-            content: {
-              "text/event-stream": {
-                schema: resolver(
-                  z
-                    .object({
-                      directory: z.string(),
-                      payload: BusEvent.payloads(),
-                    })
-                    .meta({
-                      ref: "GlobalEvent",
-                    }),
-                ),
-              },
-            },
-          },
-        },
-      }),
-      async (c) => {
-        log.info("global event connected")
-        c.header("Cache-Control", "no-cache, no-transform")
-        c.header("X-Accel-Buffering", "no")
-        c.header("X-Content-Type-Options", "nosniff")
-
-        return streamEvents(c, (q) => {
-          async function handler(event: any) {
-            q.push(JSON.stringify(event))
-          }
-          GlobalBus.on("event", handler)
-          return () => GlobalBus.off("event", handler)
-        })
-      },
-    )
-    .get(
-      "/sync-event",
-      describeRoute({
-        summary: "Subscribe to global sync events",
-        description: "Get global sync events",
-        operationId: "global.sync-event.subscribe",
-        responses: {
-          200: {
-            description: "Event stream",
-            content: {
-              "text/event-stream": {
-                schema: resolver(
-                  z
-                    .object({
-                      payload: SyncEvent.payloads(),
-                    })
-                    .meta({
-                      ref: "SyncEvent",
-                    }),
-                ),
-              },
-            },
-          },
-        },
-      }),
-      async (c) => {
-        log.info("global sync event connected")
-        c.header("Cache-Control", "no-cache, no-transform")
-        c.header("X-Accel-Buffering", "no")
-        c.header("X-Content-Type-Options", "nosniff")
-        return streamEvents(c, (q) => {
-          return SyncEvent.subscribeAll(({ def, event }) => {
-            // TODO: don't pass def, just pass the type (and it should
-            // be versioned)
-            q.push(
-              JSON.stringify({
-                payload: {
-                  ...event,
-                  type: SyncEvent.versionedType(def.type, def.version),
+export const GlobalRoutes = lazy(
+  () =>
+    new Hono()
+      .get(
+        "/health",
+        describeRoute({
+          summary: "Get health",
+          description: "Get health information about the OpenCode server.",
+          operationId: "global.health",
+          responses: {
+            200: {
+              description: "Health information",
+              content: {
+                "application/json": {
+                  schema: resolver(z.object({ healthy: z.literal(true), version: z.string() })),
                 },
-              }),
-            )
-          })
-        })
-      },
-    )
-    .get(
-      "/config",
-      describeRoute({
-        summary: "Get global configuration",
-        description: "Retrieve the current global OpenCode configuration settings and preferences.",
-        operationId: "global.config.get",
-        responses: {
-          200: {
-            description: "Get global config info",
-            content: {
-              "application/json": {
-                schema: resolver(Config.Info),
               },
             },
           },
-        },
-      }),
-      async (c) => {
-        return c.json(await Config.getGlobal())
-      },
-    )
-    .patch(
-      "/config",
-      describeRoute({
-        summary: "Update global configuration",
-        description: "Update global OpenCode configuration settings and preferences.",
-        operationId: "global.config.update",
-        responses: {
-          200: {
-            description: "Successfully updated global config",
-            content: {
-              "application/json": {
-                schema: resolver(Config.Info),
-              },
-            },
-          },
-          ...errors(400),
-        },
-      }),
-      validator("json", Config.Info),
-      async (c) => {
-        const config = c.req.valid("json")
-        const next = await Config.updateGlobal(config)
-        return c.json(next)
-      },
-    )
-    .post(
-      "/dispose",
-      describeRoute({
-        summary: "Dispose instance",
-        description: "Clean up and dispose all OpenCode instances, releasing all resources.",
-        operationId: "global.dispose",
-        responses: {
-          200: {
-            description: "Global disposed",
-            content: {
-              "application/json": {
-                schema: resolver(z.boolean()),
-              },
-            },
-          },
-        },
-      }),
-      async (c) => {
-        await Config.invalidate() // kilocode_change - reset cached global config so re-init reads fresh data from disk
-        GlobalBus.emit("event", {
-          directory: "global",
-          payload: {
-            type: GlobalDisposedEvent.type,
-            properties: {},
-          },
-        })
-        return c.json(true)
-      },
-    )
-    .post(
-      "/upgrade",
-      describeRoute({
-        summary: "Upgrade kilo", // kilocode_change
-        description: "Upgrade kilo to the specified version or latest if not specified.", // kilocode_change
-        operationId: "global.upgrade",
-        responses: {
-          200: {
-            description: "Upgrade result",
-            content: {
-              "application/json": {
-                schema: resolver(
-                  z.union([
-                    z.object({
-                      success: z.literal(true),
-                      version: z.string(),
-                    }),
-                    z.object({
-                      success: z.literal(false),
-                      error: z.string(),
-                    }),
-                  ]),
-                ),
-              },
-            },
-          },
-          ...errors(400),
-        },
-      }),
-      validator(
-        "json",
-        z.object({
-          target: z.string().optional(),
         }),
-      ),
-      async (c) => {
-        const method = await Installation.method()
-        if (method === "unknown") {
-          return c.json({ success: false, error: "Unknown installation method" }, 400)
-        }
-        const target = c.req.valid("json").target || (await Installation.latest(method))
-        const result = await Installation.upgrade(method, target)
-          .then(() => ({ success: true as const, version: target }))
-          .catch((e) => ({ success: false as const, error: e instanceof Error ? e.message : String(e) }))
-        if (result.success) {
+        async (c) => {
+          return c.json({ healthy: true, version: Installation.VERSION })
+        },
+      )
+      .get(
+        "/event",
+        describeRoute({
+          summary: "Get global events",
+          description: "Subscribe to global events from the OpenCode system using server-sent events.",
+          operationId: "global.event",
+          responses: {
+            200: {
+              description: "Event stream",
+              content: {
+                "text/event-stream": {
+                  schema: resolver(
+                    z
+                      .object({
+                        directory: z.string(),
+                        payload: BusEvent.payloads(),
+                      })
+                      .meta({
+                        ref: "GlobalEvent",
+                      }),
+                  ),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          log.info("global event connected")
+          c.header("Cache-Control", "no-cache, no-transform")
+          c.header("X-Accel-Buffering", "no")
+          c.header("X-Content-Type-Options", "nosniff")
+
+          return streamEvents(c, (q) => {
+            async function handler(event: any) {
+              q.push(JSON.stringify(event))
+            }
+            GlobalBus.on("event", handler)
+            return () => GlobalBus.off("event", handler)
+          })
+        },
+      )
+      .get(
+        "/sync-event",
+        describeRoute({
+          summary: "Subscribe to global sync events",
+          description: "Get global sync events",
+          operationId: "global.sync-event.subscribe",
+          responses: {
+            200: {
+              description: "Event stream",
+              content: {
+                "text/event-stream": {
+                  schema: resolver(
+                    z
+                      .object({
+                        payload: SyncEvent.payloads(),
+                      })
+                      .meta({
+                        ref: "SyncEvent",
+                      }),
+                  ),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          log.info("global sync event connected")
+          c.header("Cache-Control", "no-cache, no-transform")
+          c.header("X-Accel-Buffering", "no")
+          c.header("X-Content-Type-Options", "nosniff")
+          return streamEvents(c, (q) => {
+            return SyncEvent.subscribeAll(({ def, event }) => {
+              // TODO: don't pass def, just pass the type (and it should
+              // be versioned)
+              q.push(
+                JSON.stringify({
+                  payload: {
+                    ...event,
+                    type: SyncEvent.versionedType(def.type, def.version),
+                  },
+                }),
+              )
+            })
+          })
+        },
+      )
+      .get(
+        "/config",
+        describeRoute({
+          summary: "Get global configuration",
+          description: "Retrieve the current global OpenCode configuration settings and preferences.",
+          operationId: "global.config.get",
+          responses: {
+            200: {
+              description: "Get global config info",
+              content: {
+                "application/json": {
+                  schema: resolver(Config.Info),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          return c.json(await Config.getGlobal())
+        },
+      )
+      .patch(
+        "/config",
+        describeRoute({
+          summary: "Update global configuration",
+          description: "Update global OpenCode configuration settings and preferences.",
+          operationId: "global.config.update",
+          responses: {
+            200: {
+              description: "Successfully updated global config",
+              content: {
+                "application/json": {
+                  schema: resolver(Config.Info),
+                },
+              },
+            },
+            ...errors(400),
+          },
+        }),
+        validator("json", Config.Info),
+        async (c) => {
+          const config = c.req.valid("json")
+          const next = await Config.updateGlobal(config)
+          return c.json(next)
+        },
+      )
+      .post(
+        "/dispose",
+        describeRoute({
+          summary: "Dispose instance",
+          description: "Clean up and dispose all OpenCode instances, releasing all resources.",
+          operationId: "global.dispose",
+          responses: {
+            200: {
+              description: "Global disposed",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          await Config.invalidate() // kilocode_change - reset cached global config so re-init reads fresh data from disk
           GlobalBus.emit("event", {
             directory: "global",
             payload: {
-              type: Installation.Event.Updated.type,
-              properties: { version: target },
+              type: GlobalDisposedEvent.type,
+              properties: {},
             },
           })
-          return c.json(result)
-        }
-        return c.json(result, 500)
-      },
-    ),
+          return c.json(true)
+        },
+      )
+      .post(
+        "/upgrade",
+        describeRoute({
+          summary: "Upgrade kilo", // kilocode_change
+          description: "Upgrade kilo to the specified version or latest if not specified.", // kilocode_change
+          operationId: "global.upgrade",
+          responses: {
+            200: {
+              description: "Upgrade result",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.union([
+                      z.object({
+                        success: z.literal(true),
+                        version: z.string(),
+                      }),
+                      z.object({
+                        success: z.literal(false),
+                        error: z.string(),
+                      }),
+                    ]),
+                  ),
+                },
+              },
+            },
+            ...errors(400),
+          },
+        }),
+        validator(
+          "json",
+          z.object({
+            target: z.string().optional(),
+          }),
+        ),
+        async (c) => {
+          const method = await Installation.method()
+          if (method === "unknown") {
+            return c.json({ success: false, error: "Unknown installation method" }, 400)
+          }
+          const target = c.req.valid("json").target || (await Installation.latest(method))
+          const result = await Installation.upgrade(method, target)
+            .then(() => ({ success: true as const, version: target }))
+            .catch((e) => ({ success: false as const, error: e instanceof Error ? e.message : String(e) }))
+          if (result.success) {
+            GlobalBus.emit("event", {
+              directory: "global",
+              payload: {
+                type: Installation.Event.Updated.type,
+                properties: { version: target },
+              },
+            })
+            return c.json(result)
+          }
+          return c.json(result, 500)
+        },
+      )
+      // kilocode_change start - debug/profiling endpoints for memory leak investigation
+      .get("/debug/memory", async (c) => {
+        if (!Flag.KILO_PROFILE) return c.json({ error: "profiling not enabled" }, 403)
+        const mem = process.memoryUsage()
+        return c.json({
+          rss: mem.rss,
+          heapTotal: mem.heapTotal,
+          heapUsed: mem.heapUsed,
+          external: mem.external,
+          arrayBuffers: mem.arrayBuffers,
+          rssMB: +(mem.rss / 1024 / 1024).toFixed(1),
+          heapUsedMB: +(mem.heapUsed / 1024 / 1024).toFixed(1),
+          pid: process.pid,
+          uptime: process.uptime(),
+        })
+      })
+      .post("/debug/snapshot", async (c) => {
+        if (!Flag.KILO_PROFILE) return c.json({ error: "profiling not enabled" }, 403)
+        const { writeHeapSnapshot } = await import("node:v8")
+        const { join } = await import("node:path")
+        const { Global } = await import("../../global")
+        const ts = new Date().toISOString().replace(/[:.]/g, "")
+        const file = join(Global.Path.log, `heap-${process.pid}-${ts}.heapsnapshot`)
+        log.warn("writing heap snapshot", { file })
+        const result = writeHeapSnapshot(file)
+        const mem = process.memoryUsage()
+        return c.json({
+          file: result,
+          rssMB: +(mem.rss / 1024 / 1024).toFixed(1),
+          heapUsedMB: +(mem.heapUsed / 1024 / 1024).toFixed(1),
+        })
+      })
+      .post("/debug/gc", async (c) => {
+        if (!Flag.KILO_PROFILE) return c.json({ error: "profiling not enabled" }, 403)
+        const before = process.memoryUsage()
+        if (typeof Bun !== "undefined") Bun.gc(true)
+        else if (typeof globalThis.gc === "function") globalThis.gc()
+        const after = process.memoryUsage()
+        return c.json({
+          before: {
+            rssMB: +(before.rss / 1024 / 1024).toFixed(1),
+            heapUsedMB: +(before.heapUsed / 1024 / 1024).toFixed(1),
+          },
+          after: {
+            rssMB: +(after.rss / 1024 / 1024).toFixed(1),
+            heapUsedMB: +(after.heapUsed / 1024 / 1024).toFixed(1),
+          },
+          freedMB: +((before.heapUsed - after.heapUsed) / 1024 / 1024).toFixed(1),
+        })
+      }),
+  // kilocode_change end
 )


### PR DESCRIPTION
Don't review this, only to profile memory issues on Windows

## Summary

- Adds `KILO_PROFILE=1` env flag and `--profile` option to `bun run extension` that enables memory profiling of the `kilo serve` backend process
- Adds HTTP debug endpoints (`/global/debug/memory`, `/global/debug/snapshot`, `/global/debug/gc`) for on-demand memory inspection and heap snapshot capture
- Adds periodic memory logging (every 30s) when profiling is enabled
- Includes documentation at `packages/kilo-vscode/docs/infrastructure/memory-profiling.md` covering the full profiling workflow, suspected causes, and analysis techniques

This is investigative tooling for the Windows memory leak where the Bun process accumulates multiple GB of RSS over extended Agent Manager usage with large worktree diffs. The doc describes what we know so far (RSS grows outside V8 heap, pointing to native buffer accumulation from git stdout buffering) and how to reproduce/measure it.