### PR TITLE
test(cli): skip flaky prompt-during-active-run test

### DIFF
--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -844,9 +844,10 @@ it.live(
   3_000,
 )
 
+// kilocode_change start - skip flaky test, tracked in #8990
 it.live.skip(
-  // kilocode_change - flaky on CI, tracked in #8990
   "prompt submitted during an active run is included in the next LLM input",
+  // kilocode_change end
   () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -844,7 +844,7 @@ it.live(
   3_000,
 )
 
-it.live(
+it.live.skip(
   "prompt submitted during an active run is included in the next LLM input",
   () =>
     provideTmpdirServer(

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -845,6 +845,7 @@ it.live(
 )
 
 it.live.skip(
+  // kilocode_change - flaky on CI, tracked in #8990
   "prompt submitted during an active run is included in the next LLM input",
   () =>
     provideTmpdirServer(


### PR DESCRIPTION
## Summary
- Skip the flaky "prompt submitted during an active run is included in the next LLM input" test that fails intermittently on CI
- The test has a timeout contradiction: inner poll allows 5s but `it.live` timeout is only 3s, causing failures on slow runners

Tracked in #8990.