### PR TITLE
docs(jetbrains): expand Kotlin UI DSL v2 reference in AGENTS.md

### DIFF
--- a/packages/kilo-jetbrains/AGENTS.md
+++ b/packages/kilo-jetbrains/AGENTS.md
@@ -416,11 +416,13 @@ Bind component values to model properties. Values are applied on `DialogPanel.ap
 | `buttonsGroup {}.bind(model::prop)`          | radio group  |
 
 ```kotlin
+enum class Theme { LIGHT, DARK }
+
 data class Settings(
     var name: String = "",
     var count: Int = 0,
     var enabled: Boolean = false,
-    var color: Color = Color.GREY,
+    var theme: Theme = Theme.LIGHT,
 )
 
 val model = Settings()
@@ -435,10 +437,10 @@ val panel = panel {
     row {
         checkBox("Enabled").bindSelected(model::enabled)
     }
-    buttonsGroup("Color:") {
-        row { radioButton("White", Color.WHITE) }
-        row { radioButton("Grey", Color.GREY) }
-    }.bind(model::color)
+    buttonsGroup("Theme:") {
+        row { radioButton("Light", Theme.LIGHT) }
+        row { radioButton("Dark", Theme.DARK) }
+    }.bind(model::theme)
 }
 
 // Later:

--- a/packages/kilo-jetbrains/AGENTS.md
+++ b/packages/kilo-jetbrains/AGENTS.md
@@ -92,29 +92,427 @@ Official references:
 
 ### When to Use What
 
-| Need                                                        | API                                                                                                                          |
-| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Dialogs and settings pages with input fields bound to state | [Kotlin UI DSL v2](https://plugins.jetbrains.com/docs/intellij/kotlin-ui-dsl-version-2.html) (`com.intellij.ui.dsl.builder`) |
-| Tool window panels, action-driven UI, custom components     | Standard Swing with IntelliJ Platform component replacements (see below)                                                     |
-| Menus and toolbars                                          | [Action System](https://plugins.jetbrains.com/docs/intellij/action-system.html)                                              |
+| Need                                                       | API                                                                                                                                         |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Dialogs, settings pages, forms, any layout with components | **Preferred**: [Kotlin UI DSL v2](https://plugins.jetbrains.com/docs/intellij/kotlin-ui-dsl-version-2.html) (`com.intellij.ui.dsl.builder`) |
+| Tool window panels, action-driven UI, custom components    | Standard Swing with IntelliJ Platform component replacements (see below)                                                                    |
+| Menus and toolbars                                         | [Action System](https://plugins.jetbrains.com/docs/intellij/action-system.html)                                                             |
 
-### Kotlin UI DSL v2
+### Kotlin UI DSL v2 (Preferred)
 
-Use `panel { }` as the top-level builder — returns a `DialogPanel`. Structure: `panel` → `row` → cells (factory methods like `textField()`, `checkBox()`, `label()`). The DSL is for forms with bindings (`bindText`, `bindSelected`, etc.) and is **not** intended for general tool window UI.
+**Use Kotlin UI DSL v2 as the default way to build UI** for dialogs, settings pages, forms, and any layout composed of standard components. It produces correct spacing, label alignment, HiDPI scaling, and accessibility automatically. Only fall back to manual Swing layout when you need a fully custom component (e.g. a canvas, rich list renderer, or tool-window chrome that the DSL can't express).
+
+The top-level builder is `panel { }` (returns `DialogPanel`). Structure: **panel → row → cells**. Cell factory methods (`textField()`, `checkBox()`, `label()`, etc.) add components. The DSL lives in `com.intellij.ui.dsl.builder`.
+
+To explore DSL capabilities interactively: **Tools → Internal Actions → UI → Kotlin UI DSL → UI DSL Showcase** (requires internal mode: `-Didea.is.internal=true`).
+
+Reference: [Kotlin UI DSL v2 docs](https://plugins.jetbrains.com/docs/intellij/kotlin-ui-dsl-version-2.html)
+
+#### Basics — Panel / Row / Cell
+
+Rows occupy full width. The last cell in a row takes remaining space. Rows have a `layout` property (see Row Layout below).
 
 ```kotlin
-// Settings/dialog example
 panel {
-    row("Label:") { textField().bindText(model::value) }
-    group("Section") {
-        row { checkBox("Enable feature").bindSelected(model::enabled) }
+    row("Row1 label:") {
+        textField()
+        label("Some text")
+    }
+    row("Row2:") {
+        label("This text is aligned with previous row")
     }
 }
 ```
 
-Key patterns: `group {}` for titled sections, `indent {}` for left indent, `collapsibleGroup {}` for expandable sections, `buttonsGroup {}` for radio groups, `enabledIf()`/`visibleIf()` for reactive visibility, `.align(AlignX.FILL)` to stretch components.
+#### Row Layout
 
-To explore DSL capabilities interactively: **Tools → Internal Actions → UI → Kotlin UI DSL → UI DSL Showcase** (requires internal mode).
+Every row uses one of three layouts. Default is `LABEL_ALIGNED` when a label is provided for the row, `INDEPENDENT` otherwise.
+
+| Layout          | Behavior                                             |
+| --------------- | ---------------------------------------------------- |
+| `LABEL_ALIGNED` | Label column + content columns, aligned across rows  |
+| `INDEPENDENT`   | All cells are independent, no cross-row alignment    |
+| `PARENT_GRID`   | Cells align with the parent grid columns across rows |
+
+```kotlin
+panel {
+    row("PARENT_GRID:") {
+        label("Col 1")
+        label("Col 2")
+    }.layout(RowLayout.PARENT_GRID)
+
+    row("PARENT_GRID:") {
+        textField()
+        textField()
+    }.layout(RowLayout.PARENT_GRID)
+
+    row("LABEL_ALIGNED (default with label):") {
+        textField()
+    }
+
+    row {
+        label("INDEPENDENT (default without label):")
+        textField()
+    }
+}
+```
+
+#### Components Reference
+
+All cell factory methods available inside `row { }`:
+
+| Method                                             | Description                                                |
+| -------------------------------------------------- | ---------------------------------------------------------- |
+| `checkBox("text")`                                 | Checkbox                                                   |
+| `threeStateCheckBox("text")`                       | Three-state checkbox                                       |
+| `radioButton("text", value)`                       | Radio button (must be inside `buttonsGroup {}`)            |
+| `button("text") {}`                                | Push button                                                |
+| `actionButton(action)`                             | Icon button bound to an `AnAction`                         |
+| `actionsButton(action1, action2, ...)`             | Dropdown actions button                                    |
+| `segmentedButton(items) { text = it }`             | Segmented control                                          |
+| `tabbedPaneHeader(items)`                          | Tab header strip                                           |
+| `label("text")`                                    | Static label                                               |
+| `text("html")`                                     | Rich text with links, icons, line-width control            |
+| `link("text") {}`                                  | Focusable clickable link                                   |
+| `browserLink("text", "url")`                       | Opens URL in browser                                       |
+| `dropDownLink("default", listOf(...))`             | Dropdown link selector                                     |
+| `icon(AllIcons.*)`                                 | Icon display                                               |
+| `contextHelp("description", "title")`              | Help icon with popup                                       |
+| `textField()`                                      | Text input                                                 |
+| `passwordField()`                                  | Password input                                             |
+| `textFieldWithBrowseButton()`                      | Text field + browse dialog                                 |
+| `expandableTextField()`                            | Expandable multi-line text field                           |
+| `extendableTextField()`                            | Text field with extension icons                            |
+| `intTextField(range)`                              | Integer input with validation                              |
+| `spinner(intRange)` / `spinner(doubleRange, step)` | Numeric spinner                                            |
+| `slider(min, max, minorTick, majorTick)`           | Slider (use `.labelTable()` for tick labels)               |
+| `textArea()`                                       | Multi-line text (use `.rows(n)` and `.align(AlignX.FILL)`) |
+| `comboBox(items)`                                  | Combo box / dropdown                                       |
+| `comment("text")`                                  | Gray comment text (standalone)                             |
+| `cell(component)`                                  | Wrap any arbitrary Swing component                         |
+| `scrollCell(component)`                            | Wrap component in a scroll pane                            |
+| `cell()`                                           | Empty placeholder cell for grid alignment                  |
+
+Key component examples:
+
+```kotlin
+panel {
+    // Radio button group
+    var color = "grey"
+    buttonsGroup {
+        row("Color:") {
+            radioButton("White", "white")
+            radioButton("Grey", "grey")
+        }
+    }.bind({ color }, { color = it })
+
+    // Slider with tick labels
+    row("slider:") {
+        slider(0, 10, 1, 5)
+            .labelTable(mapOf(
+                0 to JLabel("0"),
+                5 to JLabel("5"),
+                10 to JLabel("10"),
+            ))
+    }
+
+    // Text area with proper alignment
+    row {
+        label("textArea:")
+            .align(AlignY.TOP)
+            .gap(RightGap.SMALL)
+        textArea()
+            .rows(5)
+            .align(AlignX.FILL)
+    }.layout(RowLayout.PARENT_GRID)
+}
+```
+
+#### Component Labels
+
+Labels for modifiable components **must** be connected via one of two methods — this ensures correct spacing, mnemonic support, and accessibility:
+
+- **Row label**: `row("&Label:") { textField() }` — mnemonic via `&`, label in left column
+- **Cell label**: `textField().label("&Label:", LabelPosition.TOP)` — label attached to cell, optionally on top
+
+```kotlin
+panel {
+    row("&Row label:") {
+        textField()
+        textField()
+            .label("Cell label at &left:")
+    }
+    row {
+        textField()
+            .label("Cell label at &top:", LabelPosition.TOP)
+    }
+}
+```
+
+Note: when a row contains a `checkBox` or `radioButton`, the DSL automatically increases space after the row label per [UI Guidelines](https://plugins.jetbrains.com/docs/intellij/layout.html#checkboxes-and-radio-buttons).
+
+#### Comments
+
+Three types of comments, each with different placement and semantics:
+
+| Type                  | Method                              | Placement            |
+| --------------------- | ----------------------------------- | -------------------- |
+| Cell comment (bottom) | `cell.comment("text")`              | Below the cell       |
+| Cell comment (right)  | `cell.commentRight("text")`         | Right of the cell    |
+| Cell context help     | `cell.contextHelp("text", "title")` | Help icon with popup |
+| Row comment           | `row.rowComment("text")`            | Below the entire row |
+| Arbitrary comment     | `comment("text")`                   | Standalone gray text |
+
+```kotlin
+panel {
+    row {
+        textField()
+            .comment("Bottom comment")
+        textField()
+            .commentRight("Right comment")
+        textField()
+            .contextHelp("Help popup text")
+    }
+
+    row("Label:") {
+        textField()
+    }.rowComment("This comment sits below the whole row")
+
+    row {
+        comment("Standalone comment, supports <a href='link'>links</a> and <icon src='AllIcons.General.Information'>&nbsp;icons")
+    }
+}
+```
+
+Comments support HTML with clickable links (pass a lambda for the click handler), bundled icons via `<icon src='...'>`, and line width control via `maxLineLength` parameter. Use `MAX_LINE_LENGTH_NO_WRAP` to prevent wrapping.
+
+#### Groups and Structure
+
+| Method                         | Grid        | Description                                                |
+| ------------------------------ | ----------- | ---------------------------------------------------------- |
+| `panel {}`                     | Own grid    | Sub-panel occupying full width                             |
+| `rowsRange {}`                 | Parent grid | Grouped rows sharing parent grid — useful with `enabledIf` |
+| `group("Title") {}`            | Own grid    | Titled section with vertical spacing before/after          |
+| `groupRowsRange("Title") {}`   | Parent grid | Titled section sharing parent grid alignment               |
+| `collapsibleGroup("Title") {}` | Own grid    | Expandable section (Tab-focusable, supports mnemonics)     |
+| `buttonsGroup("Title") {}`     | —           | Groups `radioButton` or `checkBox` under a title           |
+| `separator()`                  | —           | Horizontal separator line                                  |
+| Row `panel {}`                 | Own grid    | Sub-panel inside a cell                                    |
+
+```kotlin
+panel {
+    group("Settings") {
+        row("Name:") { textField() }
+        row("Path:") { textFieldWithBrowseButton() }
+    }
+
+    collapsibleGroup("Advanced") {
+        row("Timeout:") { intTextField(0..1000) }
+    }
+
+    var enabled = true
+    buttonsGroup("Mode:") {
+        row { radioButton("Automatic", true) }
+        row { radioButton("Manual", false) }
+    }.bind({ enabled }, { enabled = it })
+
+    separator()
+
+    row {
+        label("Nested panels:")
+        panel {
+            row("Sub row 1:") { textField() }
+            row("Sub row 2:") { textField() }
+        }
+    }
+}
+```
+
+#### Gaps and Spacing
+
+- **Horizontal gaps**: `cell.gap(RightGap.SMALL)` between a label-like checkbox and its related field. Medium gap is the default between cells.
+- **Two-column layout**: `twoColumnsRow({}, {})` or `gap(RightGap.COLUMNS)` with `.layout(RowLayout.PARENT_GRID)`.
+- **Left indent**: `indent {}` for indented sub-content.
+- **Vertical gaps**: `.topGap(TopGap.MEDIUM)` / `.bottomGap(BottomGap.MEDIUM)` on rows to separate unrelated groups. Attach gaps to the "related" row so hiding rows doesn't break layout.
+
+```kotlin
+panel {
+    group("Horizontal Gaps") {
+        row {
+            val cb = checkBox("Use mail:")
+                .gap(RightGap.SMALL)
+            textField()
+                .enabledIf(cb.selected)
+        }
+        row("Width:") {
+            textField()
+                .gap(RightGap.SMALL)
+            label("pixels")
+        }
+    }
+
+    group("Indent") {
+        row { label("Not indented") }
+        indent {
+            row { label("Indented row") }
+        }
+    }
+
+    group("Two Columns") {
+        twoColumnsRow({
+            checkBox("First column")
+        }, {
+            checkBox("Second column")
+        })
+    }
+
+    group("Vertical Gaps") {
+        row { checkBox("Option 1") }
+        row { checkBox("Option 2") }
+        row { checkBox("Unrelated option") }
+            .topGap(TopGap.MEDIUM)
+    }
+}
+```
+
+#### Enabled / Visible (Reactive State)
+
+Bind enabled/visible state to a checkbox or other observable. Works on rows, `indent {}` blocks, `rowsRange {}`, and individual cells.
+
+```kotlin
+panel {
+    group("Enabled") {
+        lateinit var cb: Cell<JBCheckBox>
+        row { cb = checkBox("Enable options") }
+        indent {
+            row { checkBox("Option 1") }
+            row { checkBox("Option 2") }
+        }.enabledIf(cb.selected)
+    }
+
+    group("Visible") {
+        lateinit var cb: Cell<JBCheckBox>
+        row { cb = checkBox("Show options") }
+        indent {
+            row { checkBox("Option 1") }
+            row { checkBox("Option 2") }
+        }.visibleIf(cb.selected)
+    }
+}
+```
+
+#### Binding (Property Binding)
+
+Bind component values to model properties. Values are applied on `DialogPanel.apply()`, checked with `.isModified()`, and reverted with `.reset()`.
+
+| Method                                       | Component    |
+| -------------------------------------------- | ------------ |
+| `bindSelected(model::prop)`                  | checkBox     |
+| `bindText(model::prop)`                      | textField    |
+| `bindIntText(model::prop)`                   | intTextField |
+| `bindItem(model::prop.toNullableProperty())` | comboBox     |
+| `bindValue(model::prop)`                     | slider       |
+| `bindIntValue(model::prop)`                  | spinner      |
+| `buttonsGroup {}.bind(model::prop)`          | radio group  |
+
+```kotlin
+data class Settings(
+    var name: String = "",
+    var count: Int = 0,
+    var enabled: Boolean = false,
+    var color: Color = Color.GREY,
+)
+
+val model = Settings()
+
+val panel = panel {
+    row("Name:") {
+        textField().bindText(model::name)
+    }
+    row("Count:") {
+        intTextField(0..100).bindIntText(model::count)
+    }
+    row {
+        checkBox("Enabled").bindSelected(model::enabled)
+    }
+    buttonsGroup("Color:") {
+        row { radioButton("White", Color.WHITE) }
+        row { radioButton("Grey", Color.GREY) }
+    }.bind(model::color)
+}
+
+// Later:
+panel.isModified()  // true if UI differs from model
+panel.apply()       // write UI values to model
+panel.reset()       // revert UI to model values
+```
+
+#### Validation
+
+Attach input validation rules to cells. Rules run continuously and display inline error/warning indicators.
+
+```kotlin
+panel {
+    row("Username:") {
+        textField()
+            .columns(COLUMNS_MEDIUM)
+            .cellValidation {
+                addInputRule("Must not be empty") {
+                    it.text.isBlank()
+                }
+            }
+    }
+    row("Port:") {
+        textField()
+            .columns(COLUMNS_MEDIUM)
+            .cellValidation {
+                addInputRule("Contains non-numeric characters", level = Level.WARNING) {
+                    it.text.contains(Regex("[^0-9]"))
+                }
+            }
+    }
+}
+```
+
+Activate validators by calling `dialogPanel.registerValidators(disposable)` after creating the panel.
+
+#### Tips and Common Patterns
+
+| Pattern                    | Usage                                                           |
+| -------------------------- | --------------------------------------------------------------- |
+| `.bold()`                  | Bold text on any cell                                           |
+| `.columns(COLUMNS_MEDIUM)` | Set preferred width of textField / comboBox / textArea          |
+| `.text("initial")`         | Set initial text on text components                             |
+| `.resizableColumn()`       | Column fills remaining horizontal space                         |
+| `cell()`                   | Empty placeholder cell for grid alignment                       |
+| `.widthGroup("name")`      | Equalize widths across rows (cannot combine with `AlignX.FILL`) |
+| `.align(AlignX.FILL)`      | Stretch component to fill available width                       |
+| `.align(AlignY.TOP)`       | Top-align component in its cell                                 |
+| `.applyToComponent { }`    | Direct access to the underlying Swing component                 |
+| `.selected(true)`          | Default-select a radioButton when no bound value matches        |
+| `.gap(RightGap.COLUMNS)`   | Column-level gap for multi-column layouts                       |
+
+```kotlin
+panel {
+    row { label("Title").bold() }
+
+    row("Name:") {
+        textField()
+            .columns(COLUMNS_MEDIUM)
+            .resizableColumn()
+            .align(AlignX.FILL)
+    }
+
+    row("") {
+        textField()
+    }.rowComment("""Use row("") for an empty label column that aligns with labeled rows""")
+
+    row {
+        text("Comment-colored text")
+            .applyToComponent { foreground = JBUI.CurrentTheme.ContextHelp.FOREGROUND }
+    }
+}
+```
 
 ### Tool Windows
 


### PR DESCRIPTION
## Summary

- Expand the brief 16-line Kotlin UI DSL v2 section in `packages/kilo-jetbrains/AGENTS.md` into a comprehensive ~400-line reference derived from the [official IntelliJ UI DSL Showcase](https://github.com/JetBrains/intellij-community/tree/master/platform/platform-impl/internal/src/com/intellij/internal/ui/uiDslShowcase)
- Mark UI DSL v2 as the **preferred** approach for building all form/dialog UI in the "When to Use What" table
- Cover 12 topics with explanations and code examples: basics, row layout, full components catalog, component labels, comments, groups/structure, gaps/spacing, reactive enabled/visible state, property binding, validation, and tips/patterns