### PR TITLE
fix(vscode): restore chat tool spacing

### DIFF
--- a/.changeset/vscode-chat-spacing.md
+++ b/.changeset/vscode-chat-spacing.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore spacing between tool output and queued user messages in the VS Code chat.

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/message-list-tool-to-queued-user-spacing-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/message-list-tool-to-queued-user-spacing-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:123f32340a93af21146d08bb40738710bdd84099a27d0310316bb937360ca9f9
+size 14605

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -109,7 +109,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
         role="log"
         aria-live="polite"
       >
-        <div ref={autoScroll.contentRef} class={isEmpty() ? "message-list-content-empty" : undefined}>
+        <div ref={autoScroll.contentRef} class={isEmpty() ? "message-list-content-empty" : "message-list-content"}>
           <Show when={session.loading()}>
             <div class="message-list-loading" role="status">
               <Spinner />

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -8,10 +8,11 @@
  */
 
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
-import { StoryProviders, mockSessionValue } from "./StoryProviders"
+import { StoryProviders, defaultMockData, mockSessionValue } from "./StoryProviders"
 import { ChatView } from "../components/chat/ChatView"
 import { TaskHeader } from "../components/chat/TaskHeader"
 import { QuestionDock } from "../components/chat/QuestionDock"
+import { MessageList } from "../components/chat/MessageList"
 import { SessionContext } from "../context/session"
 import { ServerContext } from "../context/server"
 import type { QuestionRequest, TodoItem } from "../types/messages"
@@ -170,6 +171,100 @@ export const QuestionDockManyOptions: Story = {
       </div>
     </StoryProviders>
   ),
+}
+
+const toolUserID = "user-msg-spacing-001"
+const toolAssistantID = "asst-msg-spacing-001"
+const queuedUserID = "user-msg-spacing-002"
+const toolNow = 1_700_000_000_000
+const spacingMessages = [
+  {
+    id: toolUserID,
+    sessionID: SESSION_ID,
+    role: "user",
+    time: { created: toolNow - 9000 },
+  },
+  {
+    id: toolAssistantID,
+    sessionID: SESSION_ID,
+    role: "assistant",
+    parentID: toolUserID,
+    time: { created: toolNow - 8000 },
+    modelID: "claude-sonnet-4-20250514",
+    providerID: "anthropic",
+    mode: "default",
+    agent: "default",
+    path: { cwd: "/project", root: "/project" },
+  },
+  {
+    id: queuedUserID,
+    sessionID: SESSION_ID,
+    role: "user",
+    time: { created: toolNow - 1000 },
+  },
+]
+const spacingParts = {
+  [toolUserID]: [
+    {
+      id: "part-user-spacing-001",
+      sessionID: SESSION_ID,
+      messageID: toolUserID,
+      type: "text",
+      text: "Run a shell command and stop so I can test the spacing.",
+    },
+  ],
+  [toolAssistantID]: [
+    {
+      id: "part-bash-spacing-001",
+      sessionID: SESSION_ID,
+      messageID: toolAssistantID,
+      type: "tool",
+      callID: "call-bash-spacing-001",
+      tool: "bash",
+      state: {
+        status: "completed",
+        input: { command: "pwd", description: "Print current directory" },
+        output: "/Users/marius/Documents/git/kilocode/.kilo/worktrees/zest-kettledrum",
+        title: "pwd",
+        metadata: {},
+        time: { start: toolNow - 7000, end: toolNow - 6500 },
+      },
+    },
+  ],
+  [queuedUserID]: [
+    {
+      id: "part-user-spacing-002",
+      sessionID: SESSION_ID,
+      messageID: queuedUserID,
+      type: "text",
+      text: "ok",
+    },
+  ],
+}
+const spacingData = {
+  ...defaultMockData,
+  message: { [SESSION_ID]: spacingMessages },
+  part: spacingParts,
+}
+
+export const MessageListToolToQueuedUserSpacing: Story = {
+  name: "MessageList — tool to queued user spacing",
+  render: () => {
+    const session = {
+      ...mockSessionValue({ id: SESSION_ID, status: "idle" }),
+      messages: () => spacingMessages,
+      userMessages: () => spacingMessages.filter((msg) => msg.role === "user"),
+    }
+    return (
+      <StoryProviders data={spacingData} sessionID={SESSION_ID} status="idle" noPadding>
+        <SessionContext.Provider value={session as any}>
+          <div style={{ height: "420px", display: "flex", "flex-direction": "column" }}>
+            <MessageList />
+          </div>
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
@@ -63,6 +63,13 @@
   font-size: 13px;
 }
 
+.message-list-content {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .message-list-content-empty {
   display: flex;
   min-height: 100%;
@@ -151,10 +158,6 @@
   width: 100%;
   min-width: 0;
   padding: 0 4px;
-}
-
-.vscode-session-turn + .vscode-session-turn {
-  margin-top: 12px;
 }
 
 .vscode-session-turn-user {


### PR DESCRIPTION
## Summary
- Restore explicit VS Code chat message-list spacing so queued user messages stay separated from preceding tool output.
- Add a Storybook visual regression story for the tool-output-to-queued-user spacing case so CI can generate the screenshot baseline.

Before:
<img width="285" height="239" alt="image" src="https://github.com/user-attachments/assets/117f2859-6dc7-4b00-b675-cd94d32cd813" />
After:
<img width="429" height="242" alt="image" src="https://github.com/user-attachments/assets/74c1edea-17a1-4a35-b600-a5c26c35a0be" />


