### PR TITLE
fix(vscode): show local review follow-up questions

### DIFF
--- a/.changeset/local-review-question-dock.md
+++ b/.changeset/local-review-question-dock.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep local review follow-up questions visible after review output so prompt input is not blocked by an invisible pending question.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -91,7 +91,6 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
             if (part.type !== "tool") return undefined
             const tp = part as unknown as ToolPart
             if (tp.tool !== "question") return undefined
-            if (tp.state?.status !== "pending" && tp.state?.status !== "running") return undefined
             return session.questions().find((q) => q.tool?.callID === tp.callID && q.tool?.messageID === tp.messageID)
           })
 


### PR DESCRIPTION
## Summary
- Keep active question tool requests visible in the VS Code chat even after the linked tool part is no longer marked pending/running.
- Add a patch changeset for the local review follow-up question fix.

## Regression
This regressed in #8649, which moved tool-linked questions inline with the assistant message and gated rendering on the tool part status. `/local-review` can finish writing the review while the backend still has a pending question request, so the prompt input was blocked by an active question that was no longer rendered.

## Why this fixes it
The question dock is now driven by the authoritative pending question request in `session.questions()` for matching question tool calls, instead of also requiring a transient tool-part status. If a question request is pending, the UI renders it and the user can answer or dismiss it, unblocking prompt input.

## Verification
- `bun run format`
- `bun run lint`
- `bun run script/check-opencode-annotations.ts`
- `bun run typecheck` and `bun run check-types:webview` are currently blocked by existing SDK/tree-sitter type errors unrelated to this change.