### PR TITLE
Add heap snapshot command to VSCode extension

### DIFF
--- a/.changeset/vscode-heap-snapshot.md
+++ b/.changeset/vscode-heap-snapshot.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Support writing a heap snapshot for the bundled CLI from the VS Code Command Palette.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -326,6 +326,11 @@
         "command": "kilo-code.new.generateTerminalCommand",
         "title": "Generate Terminal Command",
         "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.takeHeapSnapshot",
+        "title": "Take Heap Snapshot",
+        "category": "Kilo Code"
       }
     ],
     "submenus": [

--- a/packages/kilo-vscode/src/commands/heap-snapshot.ts
+++ b/packages/kilo-vscode/src/commands/heap-snapshot.ts
@@ -1,0 +1,36 @@
+import * as vscode from "vscode"
+import type { KiloConnectionService } from "../services/cli-backend/connection-service"
+
+export function registerHeapSnapshot(context: vscode.ExtensionContext, connectionService: KiloConnectionService): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("kilo-code.new.takeHeapSnapshot", async () => {
+      try {
+        const file = await snapshot(connectionService)
+        vscode.window.showInformationMessage(`Heap snapshot written to ${file}`)
+      } catch (err) {
+        vscode.window.showErrorMessage(`Failed to write heap snapshot: ${message(err)}`)
+      }
+    }),
+  )
+}
+
+async function snapshot(connectionService: KiloConnectionService) {
+  await connectionService.getClientAsync()
+  const cfg = connectionService.getServerConfig()
+  if (!cfg) throw new Error("CLI server is not connected")
+
+  const auth = Buffer.from(`kilo:${cfg.password}`).toString("base64")
+  const res = await fetch(`${cfg.baseUrl}/kilocode/heap/snapshot`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${auth}`,
+    },
+  })
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return (await res.json()) as string
+}
+
+function message(err: unknown) {
+  if (err instanceof Error) return err.message
+  return String(err)
+}

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -16,6 +16,7 @@ import { TelemetryProxy } from "./services/telemetry"
 import { registerCommitMessageService } from "./services/commit-message"
 import { registerCodeActions, registerTerminalActions, KiloCodeActionProvider } from "./services/code-actions"
 import { registerToggleAutoApprove } from "./commands/toggle-auto-approve"
+import { registerHeapSnapshot } from "./commands/heap-snapshot"
 import { RemoteStatusService } from "./services/RemoteStatusService"
 
 // Activated via "onStartupFinished" (package.json) so that commands, code actions, keybindings,
@@ -361,6 +362,8 @@ export function activate(context: vscode.ExtensionContext) {
       return [...dirs]
     },
   )
+
+  registerHeapSnapshot(context, connectionService)
 
   // Register code actions (editor context menus, terminal context menus, keyboard shortcuts)
   registerCodeActions(context, provider, agentManagerProvider)

--- a/packages/opencode/src/kilocode/cli/heap-snapshot.ts
+++ b/packages/opencode/src/kilocode/cli/heap-snapshot.ts
@@ -1,0 +1,13 @@
+import path from "path"
+import { writeHeapSnapshot } from "node:v8"
+import { Global } from "@/global"
+
+export namespace HeapSnapshot {
+  export function write() {
+    const file = path.join(
+      Global.Path.log,
+      `heap-${process.pid}-${new Date().toISOString().replace(/[:.]/g, "")}.heapsnapshot`,
+    )
+    return writeHeapSnapshot(file)
+  }
+}

--- a/packages/opencode/src/server/routes/kilocode.ts
+++ b/packages/opencode/src/server/routes/kilocode.ts
@@ -9,10 +9,33 @@ import { Agent } from "../../agent/agent"
 import { lazy } from "../../util/lazy"
 import { errors } from "../error"
 import { SessionImportRoutes } from "../../kilocode/session-import/routes"
+import { HeapSnapshot } from "../../kilocode/cli/heap-snapshot"
 
 export const KilocodeRoutes = lazy(() =>
   new Hono()
     .route("/session-import", SessionImportRoutes())
+    .post(
+      "/heap/snapshot",
+      describeRoute({
+        summary: "Write heap snapshot",
+        description: "Write a heap snapshot for the CLI process to the log directory.",
+        operationId: "kilocode.heap.snapshot",
+        responses: {
+          200: {
+            description: "Heap snapshot file path",
+            content: {
+              "application/json": {
+                schema: resolver(z.string()),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      async (c) => {
+        return c.json(HeapSnapshot.write())
+      },
+    )
     .post(
       "/skill/remove",
       describeRoute({

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -66,6 +66,8 @@ import type {
   KiloCloudSessionImportResponses,
   KiloCloudSessionsErrors,
   KiloCloudSessionsResponses,
+  KilocodeHeapSnapshotErrors,
+  KilocodeHeapSnapshotResponses,
   KilocodeRemoveAgentErrors,
   KilocodeRemoveAgentResponses,
   KilocodeRemoveSkillErrors,
@@ -5125,6 +5127,42 @@ export class SessionImport extends HeyApiClient {
   }
 }
 
+export class Heap extends HeyApiClient {
+  /**
+   * Write heap snapshot
+   *
+   * Write a heap snapshot for the CLI process to the log directory.
+   */
+  public snapshot<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      KilocodeHeapSnapshotResponses,
+      KilocodeHeapSnapshotErrors,
+      ThrowOnError
+    >({
+      url: "/kilocode/heap/snapshot",
+      ...options,
+      ...params,
+    })
+  }
+}
+
 export class Kilocode extends HeyApiClient {
   /**
    * Remove a skill
@@ -5207,6 +5245,11 @@ export class Kilocode extends HeyApiClient {
   private _sessionImport?: SessionImport
   get sessionImport(): SessionImport {
     return (this._sessionImport ??= new SessionImport({ client: this.client }))
+  }
+
+  private _heap?: Heap
+  get heap(): Heap {
+    return (this._heap ??= new Heap({ client: this.client }))
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -6194,6 +6194,34 @@ export type KilocodeSessionImportPartResponses = {
 export type KilocodeSessionImportPartResponse =
   KilocodeSessionImportPartResponses[keyof KilocodeSessionImportPartResponses]
 
+export type KilocodeHeapSnapshotData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/heap/snapshot"
+}
+
+export type KilocodeHeapSnapshotErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type KilocodeHeapSnapshotError = KilocodeHeapSnapshotErrors[keyof KilocodeHeapSnapshotErrors]
+
+export type KilocodeHeapSnapshotResponses = {
+  /**
+   * Heap snapshot file path
+   */
+  200: string
+}
+
+export type KilocodeHeapSnapshotResponse = KilocodeHeapSnapshotResponses[keyof KilocodeHeapSnapshotResponses]
+
 export type KilocodeRemoveSkillData = {
   body?: {
     location: string


### PR DESCRIPTION

## Context

- We need to analyze the different memory issues reported by users. Added a way to create a heap snapshot in the VSCode extension.


## Implementation


Introduce a "Take Heap Snapshot" command in the VS Code Command Palette that triggers the bundled CLI process to write a V8 heap snapshot to the log directory. This includes:

- New server route POST /kilocode/heap/snapshot in opencode
- HeapSnapshot module using node:v8 writeHeapSnapshot
- VS Code command registration and client-side fetch logic
- Generated SDK types and client methods for the new endpoint


## Testing

- Checked I can create a heap snapshot, it's named correctly, it's located in the logs folder, and I can load it in Chrome Dev tools to do a memory profile
