### PR TITLE
fix(vscode): abort queued follow-up prompts

### DIFF
--- a/.changeset/abort-queued-followups.md
+++ b/.changeset/abort-queued-followups.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Clear queued follow-up prompts when aborting a running task.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -49,6 +49,7 @@ import { getTerminalContents } from "./services/terminal/context"
 import { matchFollowup, recordFollowup, type Followup } from "./kilo-provider/followup-session"
 import { childID } from "./kilo-provider/task-session"
 import { handleNetworkEvent, clearNetworkWaits } from "./kilo-provider/network"
+import { abortSession, parseQueued } from "./kilo-provider/abort"
 import { retryable, backoff, MAX_RETRIES } from "./util/retry"
 import { hasGit } from "./kilo-provider/git-status"
 // legacy-migration start
@@ -601,7 +602,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         }
         case "abort":
           this.cancelRetry(message.sessionID ?? "")
-          await this.handleAbort(message.sessionID)
+          await this.handleAbort(message.sessionID, parseQueued(message.queuedMessageIDs))
           break
         case "revertSession":
           this.handleRevertSession(message.sessionID, message.messageID).catch((e) =>
@@ -2558,10 +2559,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
-  /**
-   * Handle abort request from the webview.
-   */
-  private async handleAbort(sessionID?: string): Promise<void> {
+  private async handleAbort(sessionID?: string, queuedMessageIDs: string[] = []): Promise<void> {
     if (!this.client) {
       return
     }
@@ -2572,8 +2570,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     try {
-      const workspaceDir = this.getWorkspaceDirectory(targetSessionID)
-      await this.client.session.abort({ sessionID: targetSessionID, directory: workspaceDir }, { throwOnError: true })
+      await abortSession({
+        client: this.client,
+        sessionID: targetSessionID,
+        dir: this.getWorkspaceDirectory(targetSessionID),
+        queuedMessageIDs,
+      })
     } catch (error) {
       console.error("[Kilo New] KiloProvider: Failed to abort session:", error)
     }

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -590,6 +590,7 @@ interface ForkSessionIn {
 interface AbortIn {
   type: "abort"
   sessionID: string
+  queuedMessageIDs?: string[]
 }
 
 interface ContinueInWorktreeIn {

--- a/packages/kilo-vscode/src/kilo-provider/abort.ts
+++ b/packages/kilo-vscode/src/kilo-provider/abort.ts
@@ -1,0 +1,21 @@
+import type { KiloClient } from "@kilocode/sdk/v2/client"
+
+export function parseQueued(value: unknown) {
+  if (!Array.isArray(value)) return []
+  return value.filter((id): id is string => typeof id === "string")
+}
+
+export async function abortSession(input: {
+  client: KiloClient
+  sessionID: string
+  dir: string
+  queuedMessageIDs: string[]
+}) {
+  await input.client.session.abort({ sessionID: input.sessionID, directory: input.dir }, { throwOnError: true })
+
+  for (const mid of new Set(input.queuedMessageIDs)) {
+    await input.client.session
+      .deleteMessage({ sessionID: input.sessionID, messageID: mid, directory: input.dir }, { throwOnError: true })
+      .catch((err) => console.error("[Kilo New] KiloProvider: Failed to remove queued message:", err))
+  }
+}

--- a/packages/kilo-vscode/tests/unit/abort.test.ts
+++ b/packages/kilo-vscode/tests/unit/abort.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test"
+import type { KiloClient } from "@kilocode/sdk/v2/client"
+import { abortSession, parseQueued } from "../../src/kilo-provider/abort"
+
+function client(calls: unknown[], fail = false) {
+  return {
+    session: {
+      abort: async (params: unknown, opts: unknown) => {
+        calls.push({ type: "abort", params, opts })
+        if (fail) throw new Error("abort failed")
+        return { data: true }
+      },
+      deleteMessage: async (params: unknown, opts: unknown) => {
+        calls.push({ type: "delete", params, opts })
+        return { data: true }
+      },
+    },
+  } as unknown as KiloClient
+}
+
+describe("parseQueued", () => {
+  it("keeps only string queued message ids", () => {
+    expect(parseQueued(["message_1", 2, null, "message_2", {}])).toEqual(["message_1", "message_2"])
+  })
+
+  it("returns empty ids for invalid payloads", () => {
+    expect(parseQueued(undefined)).toEqual([])
+    expect(parseQueued({ queuedMessageIDs: ["message_1"] })).toEqual([])
+  })
+})
+
+describe("abortSession", () => {
+  it("aborts before removing queued follow-up messages", async () => {
+    const calls: unknown[] = []
+
+    await abortSession({
+      client: client(calls),
+      sessionID: "session_1",
+      dir: "/repo",
+      queuedMessageIDs: ["message_2", "message_3", "message_2"],
+    })
+
+    expect(calls).toEqual([
+      {
+        type: "abort",
+        params: { sessionID: "session_1", directory: "/repo" },
+        opts: { throwOnError: true },
+      },
+      {
+        type: "delete",
+        params: { sessionID: "session_1", messageID: "message_2", directory: "/repo" },
+        opts: { throwOnError: true },
+      },
+      {
+        type: "delete",
+        params: { sessionID: "session_1", messageID: "message_3", directory: "/repo" },
+        opts: { throwOnError: true },
+      },
+    ])
+  })
+
+  it("does not remove queued messages when abort fails", async () => {
+    const calls: unknown[] = []
+
+    await expect(
+      abortSession({
+        client: client(calls, true),
+        sessionID: "session_1",
+        dir: "/repo",
+        queuedMessageIDs: ["message_2"],
+      }),
+    ).rejects.toThrow("abort failed")
+
+    expect(calls).toEqual([
+      {
+        type: "abort",
+        params: { sessionID: "session_1", directory: "/repo" },
+        opts: { throwOnError: true },
+      },
+    ])
+  })
+})

--- a/packages/kilo-vscode/tests/unit/session-queue.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { activeUserMessageID } from "../../webview-ui/src/context/session-queue"
+import { activeUserMessageID, queuedUserMessageIDs } from "../../webview-ui/src/context/session-queue"
 import type { Message } from "../../webview-ui/src/types/messages"
 
 const base = {
@@ -16,6 +16,41 @@ const assistant = (id: string, parentID: string, opts: Partial<Message> = {}): M
   parentID,
   role: "assistant",
   ...opts,
+})
+
+describe("queuedUserMessageIDs", () => {
+  it("keeps follow-ups queued before the first assistant exists", () => {
+    const messages = [user("message_1"), user("message_2")]
+
+    expect(queuedUserMessageIDs(messages, { type: "busy" })).toEqual(["message_2"])
+  })
+
+  it("keeps follow-ups queued after a pending assistant parent", () => {
+    const messages = [
+      user("message_1"),
+      assistant("message_2", "message_1", { finish: "tool-calls" }),
+      user("message_3"),
+    ]
+
+    expect(queuedUserMessageIDs(messages, { type: "busy" })).toEqual(["message_3"])
+  })
+
+  it("keeps only later follow-ups queued after a terminal assistant", () => {
+    const messages = [
+      user("message_1"),
+      assistant("message_2", "message_1", { finish: "stop" }),
+      user("message_3"),
+      user("message_4"),
+    ]
+
+    expect(queuedUserMessageIDs(messages, { type: "busy" })).toEqual(["message_4"])
+  })
+
+  it("returns no queued messages while idle", () => {
+    const messages = [user("message_1"), user("message_2")]
+
+    expect(queuedUserMessageIDs(messages, { type: "idle" })).toEqual([])
+  })
 })
 
 describe("activeUserMessageID", () => {

--- a/packages/kilo-vscode/tests/unit/session-queue.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-queue.test.ts
@@ -40,4 +40,14 @@ describe("activeUserMessageID", () => {
 
     expect(activeUserMessageID(messages, { type: "busy" })).toBe("message_1")
   })
+
+  it("ignores aborted assistants without completed timestamps", () => {
+    const messages = [
+      user("message_1"),
+      assistant("message_2", "message_1", { error: { name: "MessageAbortedError" } }),
+      user("message_3"),
+    ]
+
+    expect(activeUserMessageID(messages, { type: "busy" })).toBe("message_3")
+  })
 })

--- a/packages/kilo-vscode/tests/unit/session-queue.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-queue.test.ts
@@ -54,6 +54,12 @@ describe("queuedUserMessageIDs", () => {
 })
 
 describe("activeUserMessageID", () => {
+  it("uses the first pending user before the first assistant exists", () => {
+    const messages = [user("message_1"), user("message_2")]
+
+    expect(activeUserMessageID(messages, { type: "busy" })).toBe("message_1")
+  })
+
   it("ignores terminal assistant updates without completed timestamps", () => {
     const messages = [user("message_1"), assistant("message_2", "message_1", { finish: "stop" }), user("message_3")]
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -78,10 +78,9 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   onMount(() => {
     if (props.readonly) return
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && session.status() === "busy" && !e.defaultPrevented) {
-        e.preventDefault()
-        session.abort()
-      }
+      if (e.key !== "Escape" || session.status() === "idle" || e.defaultPrevented) return
+      e.preventDefault()
+      session.abort()
     }
     document.addEventListener("keydown", handler)
     onCleanup(() => document.removeEventListener("keydown", handler))

--- a/packages/kilo-vscode/webview-ui/src/context/session-queue.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-queue.ts
@@ -1,8 +1,6 @@
 import type { Message, SessionStatusInfo } from "../types/messages"
 
-// Find the user message whose turn the server is actively processing.
-// Any user message after this one is "queued" (waiting for its turn).
-export function activeUserMessageID(messages: Message[], status: SessionStatusInfo) {
+function active(messages: Message[]) {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const msg = messages[i]
     if (msg.role !== "assistant") continue
@@ -15,6 +13,33 @@ export function activeUserMessageID(messages: Message[], status: SessionStatusIn
     break
   }
 
+  return undefined
+}
+
+function pending(messages: Message[]) {
+  const done = (() => {
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      const msg = messages[i]
+      if (msg.role !== "assistant") continue
+      if (typeof msg.time?.completed === "number") return i
+      if (msg.error) return i
+      if (msg.finish && !["tool-calls", "unknown"].includes(msg.finish)) return i
+    }
+    return -1
+  })()
+
+  for (let i = done + 1; i < messages.length; i += 1) {
+    if (messages[i].role === "user") return messages[i].id
+  }
+
+  return undefined
+}
+
+// Find the user message whose turn the server is actively processing.
+// Any user message after this one is "queued" (waiting for its turn).
+export function activeUserMessageID(messages: Message[], status: SessionStatusInfo) {
+  const id = active(messages)
+  if (id) return id
   if (status.type === "idle") return undefined
 
   for (let i = messages.length - 1; i >= 0; i -= 1) {
@@ -22,4 +47,13 @@ export function activeUserMessageID(messages: Message[], status: SessionStatusIn
   }
 
   return undefined
+}
+
+export function queuedUserMessageIDs(messages: Message[], status: SessionStatusInfo) {
+  if (status.type === "idle") return []
+  const users = messages.filter((msg) => msg.role === "user")
+  const id = active(messages) ?? pending(messages)
+  const idx = id ? users.findIndex((msg) => msg.id === id) : -1
+  if (idx < 0) return []
+  return users.slice(idx + 1).map((msg) => msg.id)
 }

--- a/packages/kilo-vscode/webview-ui/src/context/session-queue.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-queue.ts
@@ -7,6 +7,7 @@ export function activeUserMessageID(messages: Message[], status: SessionStatusIn
     const msg = messages[i]
     if (msg.role !== "assistant") continue
     if (typeof msg.time?.completed === "number") continue
+    if (msg.error) continue
     if (msg.finish && !["tool-calls", "unknown"].includes(msg.finish)) continue
     if (!msg.parentID) break
     const parent = messages.find((item) => item.id === msg.parentID)

--- a/packages/kilo-vscode/webview-ui/src/context/session-queue.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-queue.ts
@@ -41,12 +41,7 @@ export function activeUserMessageID(messages: Message[], status: SessionStatusIn
   const id = active(messages)
   if (id) return id
   if (status.type === "idle") return undefined
-
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (messages[i].role === "user") return messages[i].id
-  }
-
-  return undefined
+  return pending(messages)
 }
 
 export function queuedUserMessageIDs(messages: Message[], status: SessionStatusInfo) {

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -44,7 +44,7 @@ import {
 import { Identifier } from "../utils/id"
 import { resolveModelSelection } from "./model-selection"
 import { resolveSessionAgent } from "./session-agent"
-import { activeUserMessageID } from "./session-queue"
+import { queuedUserMessageIDs } from "./session-queue"
 import { KILO_AUTO, parseModelString } from "../../../src/shared/provider-model"
 
 const RECENT_LIMIT = 5
@@ -1489,10 +1489,7 @@ export const SessionProvider: ParentComponent = (props) => {
       return
     }
 
-    const active = activeUserMessageID(messages(), statusInfo())
-    const users = userMessages()
-    const idx = active ? users.findIndex((msg) => msg.id === active) : -1
-    const queuedMessageIDs = idx >= 0 ? users.slice(idx + 1).map((msg) => msg.id) : []
+    const queuedMessageIDs = queuedUserMessageIDs(messages(), statusInfo())
 
     vscode.postMessage({
       type: "abort",

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -44,6 +44,7 @@ import {
 import { Identifier } from "../utils/id"
 import { resolveModelSelection } from "./model-selection"
 import { resolveSessionAgent } from "./session-agent"
+import { activeUserMessageID } from "./session-queue"
 import { KILO_AUTO, parseModelString } from "../../../src/shared/provider-model"
 
 const RECENT_LIMIT = 5
@@ -1488,9 +1489,15 @@ export const SessionProvider: ParentComponent = (props) => {
       return
     }
 
+    const active = activeUserMessageID(messages(), statusInfo())
+    const users = userMessages()
+    const idx = active ? users.findIndex((msg) => msg.id === active) : -1
+    const queuedMessageIDs = idx >= 0 ? users.slice(idx + 1).map((msg) => msg.id) : []
+
     vscode.postMessage({
       type: "abort",
       sessionID,
+      queuedMessageIDs,
     })
   }
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -1594,6 +1594,7 @@ export interface SendMessageRequest {
 export interface AbortRequest {
   type: "abort"
   sessionID: string
+  queuedMessageIDs?: string[]
 }
 
 export interface RevertSessionRequest {


### PR DESCRIPTION
## Summary
- Abort extension sessions from any non-idle state so Escape works during retry/offline waits.
- Clear queued follow-up prompts after abort and ignore aborted assistant turns when deriving queued UI state.
- Add regression coverage for abort payload cleanup, duplicate queued IDs, abort failure ordering, and aborted assistant queued-state detection.

## Regression sources
- #8798 introduced retry/offline non-idle session states, while the extension Escape handler still only aborted `busy` sessions.
- #7029 moved follow-up sends to `promptAsync` with queued UI state, but abort only stopped the active backend run and did not clear already-persisted queued user messages.