### PR TITLE
test(cli): restore kilo-config legacy paths test

### DIFF
--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -167,4 +167,36 @@ Use this skill.
       process.env.KILO_TEST_HOME = home
     }
   })
+
+  test("built-in kilo-config includes named command lookup guidance", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const home = process.env.KILO_TEST_HOME
+    process.env.KILO_TEST_HOME = tmp.path
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const tool = await SkillTool.init()
+          const ctx: Tool.Context = {
+            ...baseCtx,
+            ask: async () => {},
+          }
+
+          const result = await tool.execute({ name: "kilo-config" }, ctx)
+
+          expect(tool.description).toContain("where it loads things from")
+          expect(result.metadata.dir).toBe("builtin")
+          expect(result.output).toContain("Finding a named command")
+          expect(result.output).toContain("~/.config/kilo/")
+          expect(result.output).toContain("~/.kilocode/")
+          expect(result.output).toContain("**/command/")
+          expect(result.output).toContain("explicit search")
+        },
+      })
+    } finally {
+      process.env.KILO_TEST_HOME = home
+    }
+  })
 })


### PR DESCRIPTION
## Why

PR #8474 added a test verifying the built-in kilo-config skill includes legacy path guidance. The v1.4.0 compat refactoring (commit 4fc1e026) accidentally dropped that test when it bulk-renamed `OPENCODE_TEST_HOME` to `KILO_TEST_HOME` across the file — the Kilo-specific test appended at the end was lost in the process. The skill content itself was never affected, but there was no test catching regressions to it.

## What changed

Restored the test that loads the built-in kilo-config skill and checks it contains the "Finding a named command" section with legacy config paths like `~/.kilocode/` and glob patterns like `**/command/<name>.md`. The assertions were adapted to match the current HTML-rendered output format instead of raw markdown, since built-in skill content is now served as HTML.

## How to test

1. Run `bun test test/tool/skill.test.ts` from `packages/opencode/`
2. All 4 tests should pass, including "built-in kilo-config includes named command lookup guidance"