### PR TITLE
fix(cli): Ctrl+V now pastes text from clipboard

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -948,12 +948,12 @@ export function Prompt(props: PromptProps) {
                     const text = content.data as string
                     // Normalize line endings
                     const normalizedText = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
-                    const pastedContent = normalizedText.trim()
-                    const summary = shouldPasteSummary(pastedContent)
+                    const summary = shouldPasteSummary(normalizedText)
                     if (summary.summarize && !sync.data.config.experimental?.disable_paste_summary) {
-                      pasteText(pastedContent, `[Pasted ~${summary.lines} lines]`)
+                      pasteText(normalizedText, `[Pasted ~${summary.lines} lines]`)
                     } else {
-                      pasteText(pastedContent, pastedContent)
+                      // Direct insertion allows user edits to be preserved
+                      input.insertText(normalizedText)
                     }
                     return
                   }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -942,7 +942,22 @@ export function Prompt(props: PromptProps) {
                     })
                     return
                   }
-                  // If no image, let the default paste behavior continue
+                  // If text in clipboard, paste it
+                  if (content?.mime === "text/plain") {
+                    e.preventDefault()
+                    const text = content.data as string
+                    // Normalize line endings
+                    const normalizedText = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+                    const pastedContent = normalizedText.trim()
+                    const summary = shouldPasteSummary(pastedContent)
+                    if (summary.summarize && !sync.data.config.experimental?.disable_paste_summary) {
+                      pasteText(pastedContent, `[Pasted ~${summary.lines} lines]`)
+                    } else {
+                      pasteText(pastedContent, pastedContent)
+                    }
+                    return
+                  }
+                  // If no content, let the default paste behavior continue
                 }
                 if (keybind.match("input_clear", e) && store.prompt.input !== "") {
                   input.clear()


### PR DESCRIPTION
## Summary

Fixes Ctrl+V paste functionality in the Kilo CLI TUI. Previously, Ctrl+V only pasted images from the clipboard. Text paste relied on terminal bracketed paste mode, which doesn't work in all terminal configurations. This fix adds explicit text clipboard handling when Ctrl+V is pressed.

## Problem

When users pressed Ctrl+V in the Kilo CLI prompt:
- If clipboard contained an image → worked correctly
- If clipboard contained text → nothing happened (in terminals without bracketed paste)

The issue occurred because the `input_paste` keybind handler only checked for images and did nothing for text content.

## Solution

Extended the `input_paste` handler in `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx` to:
1. Read clipboard content using `Clipboard.read()`
2. If it's an image → paste as attachment (existing behavior)
3. If it's text → normalize line endings, apply paste summary for large text, and insert at cursor position
4. Prevent default to avoid duplicate pastes

## Modified Files

- `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx` (lines 930-959)

## Testing

Tested with the following scenarios:
1. Text clipboard → Pastes at cursor position with proper formatting
2. Large text (>5 lines or >800 chars) → Shows paste summary badge
3. Image clipboard → Pastes as attachment (existing behavior preserved)
4. Multiple terminals → Works in terminals that forward Ctrl+V to the application

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Notes

This is a minimal fix that follows existing patterns in the codebase. The paste summary feature was already implemented and is reused here for consistency.