### PR TITLE
fix(cli): continue queued follow-up prompts

### DIFF
--- a/.changeset/session-queued-followups.md
+++ b/.changeset/session-queued-followups.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Continue queued follow-up prompts after the active session turn finishes.

--- a/packages/opencode/src/kilocode/session/prompt-queue.ts
+++ b/packages/opencode/src/kilocode/session/prompt-queue.ts
@@ -1,0 +1,47 @@
+import { Effect } from "effect"
+import { SessionID } from "@/session/schema"
+
+type Slot = {
+  readonly version: number
+  readonly previous: Promise<void>
+  readonly done: PromiseWithResolvers<void>
+  readonly tail: Promise<void>
+}
+
+export namespace KiloSessionPromptQueue {
+  const tails = new Map<SessionID, Promise<void>>()
+  const versions = new Map<SessionID, number>()
+
+  const version = (sessionID: SessionID) => versions.get(sessionID) ?? 0
+
+  export function cancel(sessionID: SessionID) {
+    return Effect.sync(() => {
+      versions.set(sessionID, version(sessionID) + 1)
+    })
+  }
+
+  export function enqueue<A, E>(
+    sessionID: SessionID,
+    work: Effect.Effect<A, E>,
+    cancelled: Effect.Effect<A, E>,
+  ): Effect.Effect<A, E> {
+    return Effect.acquireUseRelease(
+      Effect.sync(() => {
+        const previous = tails.get(sessionID) ?? Promise.resolve()
+        const done = Promise.withResolvers<void>()
+        const tail = previous.catch(() => {}).then(() => done.promise)
+        tails.set(sessionID, tail)
+        return { version: version(sessionID), previous, done, tail } satisfies Slot
+      }),
+      (slot) =>
+        Effect.promise(() => slot.previous.catch(() => {})).pipe(
+          Effect.flatMap(() => (slot.version === version(sessionID) ? work : cancelled)),
+        ),
+      (slot) =>
+        Effect.sync(() => {
+          slot.done.resolve()
+          if (tails.get(sessionID) === slot.tail) tails.delete(sessionID)
+        }),
+    )
+  }
+}

--- a/packages/opencode/src/kilocode/session/prompt-queue.ts
+++ b/packages/opencode/src/kilocode/session/prompt-queue.ts
@@ -76,7 +76,10 @@ export namespace KiloSessionPromptQueue {
       (slot) =>
         Effect.sync(() => {
           slot.done.resolve()
-          if (tails.get(sessionID) === slot.tail) tails.delete(sessionID)
+          if (tails.get(sessionID) !== slot.tail) return
+          tails.delete(sessionID)
+          versions.delete(sessionID)
+          targets.delete(sessionID)
         }),
     )
   }

--- a/packages/opencode/src/kilocode/session/prompt-queue.ts
+++ b/packages/opencode/src/kilocode/session/prompt-queue.ts
@@ -15,6 +15,11 @@ export namespace KiloSessionPromptQueue {
   const targets = new Map<SessionID, MessageID>()
 
   const version = (sessionID: SessionID) => versions.get(sessionID) ?? 0
+  const settle = (promise: Promise<void>) =>
+    promise.then(
+      () => undefined,
+      () => undefined,
+    )
 
   export function cancel(sessionID: SessionID) {
     return Effect.sync(() => {
@@ -50,12 +55,13 @@ export namespace KiloSessionPromptQueue {
       Effect.sync(() => {
         const previous = tails.get(sessionID) ?? Promise.resolve()
         const done = Promise.withResolvers<void>()
-        const tail = previous.catch(() => {}).then(() => done.promise)
+        // Keep later queued prompts moving; each caller still observes its own failure.
+        const tail = settle(previous).then(() => done.promise)
         tails.set(sessionID, tail)
         return { version: version(sessionID), previous, done, tail } satisfies Slot
       }),
       (slot) =>
-        Effect.promise(() => slot.previous.catch(() => {})).pipe(
+        Effect.promise(() => settle(slot.previous)).pipe(
           Effect.flatMap(() => {
             if (slot.version !== version(sessionID)) return cancelled
             return Effect.acquireUseRelease(

--- a/packages/opencode/src/kilocode/session/prompt-queue.ts
+++ b/packages/opencode/src/kilocode/session/prompt-queue.ts
@@ -39,10 +39,7 @@ export namespace KiloSessionPromptQueue {
       if (item.info.role === "assistant") return !hidden.has(item.info.parentID)
       return true
     })
-    const index = visible.findIndex((item) => item.info.role === "user" && item.info.id === target)
-    const hit = index >= 0 ? visible[index] : undefined
-    if (!hit) return visible
-    return [...visible.slice(0, index), ...visible.slice(index + 1), hit]
+    return visible
   }
 
   export function enqueue<A, E>(

--- a/packages/opencode/src/kilocode/session/prompt-queue.ts
+++ b/packages/opencode/src/kilocode/session/prompt-queue.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect"
-import { SessionID } from "@/session/schema"
+import { MessageV2 } from "@/session/message-v2"
+import { MessageID, SessionID } from "@/session/schema"
 
 type Slot = {
   readonly version: number
@@ -11,6 +12,7 @@ type Slot = {
 export namespace KiloSessionPromptQueue {
   const tails = new Map<SessionID, Promise<void>>()
   const versions = new Map<SessionID, number>()
+  const targets = new Map<SessionID, MessageID>()
 
   const version = (sessionID: SessionID) => versions.get(sessionID) ?? 0
 
@@ -20,8 +22,27 @@ export namespace KiloSessionPromptQueue {
     })
   }
 
+  export function scope(sessionID: SessionID, messages: MessageV2.WithParts[]) {
+    const target = targets.get(sessionID)
+    if (!target) return messages
+
+    const hidden = new Set(
+      messages.filter((item) => item.info.role === "user" && item.info.id > target).map((item) => item.info.id),
+    )
+    const visible = messages.filter((item) => {
+      if (item.info.role === "user") return item.info.id <= target
+      if (item.info.role === "assistant") return !hidden.has(item.info.parentID)
+      return true
+    })
+    const index = visible.findIndex((item) => item.info.role === "user" && item.info.id === target)
+    const hit = index >= 0 ? visible[index] : undefined
+    if (!hit) return visible
+    return [...visible.slice(0, index), ...visible.slice(index + 1), hit]
+  }
+
   export function enqueue<A, E>(
     sessionID: SessionID,
+    target: MessageID,
     work: Effect.Effect<A, E>,
     cancelled: Effect.Effect<A, E>,
   ): Effect.Effect<A, E> {
@@ -35,7 +56,19 @@ export namespace KiloSessionPromptQueue {
       }),
       (slot) =>
         Effect.promise(() => slot.previous.catch(() => {})).pipe(
-          Effect.flatMap(() => (slot.version === version(sessionID) ? work : cancelled)),
+          Effect.flatMap(() => {
+            if (slot.version !== version(sessionID)) return cancelled
+            return Effect.acquireUseRelease(
+              Effect.sync(() => {
+                targets.set(sessionID, target)
+              }),
+              () => work,
+              () =>
+                Effect.sync(() => {
+                  if (targets.get(sessionID) === target) targets.delete(sessionID)
+                }),
+            )
+          }),
         ),
       (slot) =>
         Effect.sync(() => {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1276,23 +1276,26 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         function* (input: PromptInput) {
           const session = yield* sessions.get(input.sessionID)
           yield* Effect.promise(() => SessionRevert.cleanup(session))
-          const message = yield* createUserMessage(input)
-          yield* sessions.touch(input.sessionID)
+          // kilocode_change start - queue prompt creation with its loop so follow-up prompts stay ordered
+          const create = Effect.gen(function* () {
+            const message = yield* createUserMessage(input)
+            yield* sessions.touch(input.sessionID)
 
-          const permissions: Permission.Ruleset = []
-          for (const [t, enabled] of Object.entries(input.tools ?? {})) {
-            permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
-          }
-          if (permissions.length > 0) {
-            session.permission = permissions
-            yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
-          }
+            const permissions: Permission.Ruleset = []
+            for (const [t, enabled] of Object.entries(input.tools ?? {})) {
+              permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
+            }
+            if (permissions.length > 0) {
+              session.permission = permissions
+              yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
+            }
+            return message
+          })
 
-          if (input.noReply === true) return message
-          // kilocode_change start - queue prompt-created loops without changing shared runner semantics
+          if (input.noReply === true) return yield* create
           return yield* KiloSessionPromptQueue.enqueue(
             input.sessionID,
-            loop({ sessionID: input.sessionID }),
+            create.pipe(Effect.flatMap(() => loop({ sessionID: input.sessionID }))),
             lastAssistant(input.sessionID),
           )
           // kilocode_change end

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1276,31 +1276,29 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         function* (input: PromptInput) {
           const session = yield* sessions.get(input.sessionID)
           yield* Effect.promise(() => SessionRevert.cleanup(session))
-          // kilocode_change start - queue prompt creation with its loop so follow-up prompts stay ordered
-          const create = Effect.gen(function* () {
-            const message = yield* createUserMessage(input)
-            yield* sessions.touch(input.sessionID)
+          // kilocode_change start - persist queued prompts immediately while serializing each follow-up loop
+          const message = yield* createUserMessage(input)
+          yield* sessions.touch(input.sessionID)
 
-            const permissions: Permission.Ruleset = []
-            for (const [t, enabled] of Object.entries(input.tools ?? {})) {
-              permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
-            }
-            if (permissions.length > 0) {
-              session.permission = permissions
-              yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
-            }
-            return message
-          })
+          const permissions: Permission.Ruleset = []
+          for (const [t, enabled] of Object.entries(input.tools ?? {})) {
+            permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
+          }
+          if (permissions.length > 0) {
+            session.permission = permissions
+            yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
+          }
 
-          if (input.noReply === true) return yield* create
+          if (input.noReply === true) return message
           return yield* KiloSessionPromptQueue.enqueue(
             input.sessionID,
-            create.pipe(Effect.flatMap(() => loop({ sessionID: input.sessionID }))),
+            message.info.id,
+            loop({ sessionID: input.sessionID }),
             lastAssistant(input.sessionID),
           )
-          // kilocode_change end
         },
       )
+      // kilocode_change end
 
       const lastAssistant = (sessionID: SessionID) =>
         Effect.promise(async () => {
@@ -1336,6 +1334,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             log.info("loop", { step, sessionID })
 
             let msgs = yield* MessageV2.filterCompactedEffect(sessionID)
+            msgs = KiloSessionPromptQueue.scope(sessionID, msgs) // kilocode_change - hide later queued prompts
 
             let lastUser: MessageV2.User | undefined
             let lastAssistant: MessageV2.Assistant | undefined
@@ -1367,6 +1366,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               lastAssistant?.finish &&
               !["tool-calls"].includes(lastAssistant.finish) &&
               !hasToolCalls &&
+              lastAssistant.parentID === lastUser.id && // kilocode_change - unrelated later assistants do not answer this turn
               lastUser.id < lastAssistant.id
             ) {
               // kilocode_change start - ask follow-up when plan_exit tool was called

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2,6 +2,7 @@ import path from "path"
 import os from "os"
 import fs from "fs/promises"
 import { KiloSessionPrompt } from "@/kilocode/session/prompt" // kilocode_change
+import { KiloSessionPromptQueue } from "@/kilocode/session/prompt-queue" // kilocode_change
 import { KiloSession } from "@/kilocode/session" // kilocode_change
 import z from "zod"
 import { SessionID, MessageID, PartID } from "./schema"
@@ -107,6 +108,7 @@ export namespace SessionPrompt {
 
       const cancel = Effect.fn("SessionPrompt.cancel")(function* (sessionID: SessionID) {
         log.info("cancel", { sessionID })
+        yield* KiloSessionPromptQueue.cancel(sessionID) // kilocode_change - drop queued follow-up loops on abort
         yield* state.cancel(sessionID)
       })
 
@@ -1287,7 +1289,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
 
           if (input.noReply === true) return message
-          return yield* loop({ sessionID: input.sessionID })
+          // kilocode_change start - queue prompt-created loops without changing shared runner semantics
+          return yield* KiloSessionPromptQueue.enqueue(
+            input.sessionID,
+            loop({ sessionID: input.sessionID }),
+            lastAssistant(input.sessionID),
+          )
+          // kilocode_change end
         },
       )
 

--- a/packages/opencode/test/kilocode/local-model.test.ts
+++ b/packages/opencode/test/kilocode/local-model.test.ts
@@ -189,15 +189,8 @@ async function initLocal(options?: { prewrite?: Record<string, any> }): Promise<
 }
 
 async function readModelJson(): Promise<any> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    const text = await fs.readFile(modelJsonPath, "utf-8")
-    try {
-      return JSON.parse(text)
-    } catch (err) {
-      if (attempt === 99) throw err
-      await Bun.sleep(10)
-    }
-  }
+  const text = await fs.readFile(modelJsonPath, "utf-8")
+  return JSON.parse(text)
 }
 
 async function removeModelJson() {

--- a/packages/opencode/test/kilocode/local-model.test.ts
+++ b/packages/opencode/test/kilocode/local-model.test.ts
@@ -189,8 +189,15 @@ async function initLocal(options?: { prewrite?: Record<string, any> }): Promise<
 }
 
 async function readModelJson(): Promise<any> {
-  const text = await fs.readFile(modelJsonPath, "utf-8")
-  return JSON.parse(text)
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const text = await fs.readFile(modelJsonPath, "utf-8")
+    try {
+      return JSON.parse(text)
+    } catch (err) {
+      if (attempt === 99) throw err
+      await Bun.sleep(10)
+    }
+  }
 }
 
 async function removeModelJson() {

--- a/packages/opencode/test/kilocode/session-prompt-queue.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-queue.test.ts
@@ -1,8 +1,13 @@
 import path from "path"
 import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { KiloSessionPromptQueue } from "../../src/kilocode/session/prompt-queue"
+import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
+import { MessageID, SessionID } from "../../src/session/schema"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 
@@ -55,7 +60,67 @@ function hasText(msg: Awaited<ReturnType<typeof SessionPrompt.prompt>>, text: st
   return msg.parts.some((part) => part.type === "text" && part.text.includes(text))
 }
 
+function user(sessionID: SessionID, id: MessageID): MessageV2.WithParts {
+  return {
+    info: {
+      id,
+      sessionID,
+      role: "user",
+      time: { created: 1 },
+      agent: "code",
+      model: { providerID: ProviderID.make("test"), modelID: ModelID.make("model") },
+    },
+    parts: [],
+  }
+}
+
+function assistant(sessionID: SessionID, id: MessageID, parentID: MessageID): MessageV2.WithParts {
+  return {
+    info: {
+      id,
+      sessionID,
+      role: "assistant",
+      time: { created: 1, completed: 2 },
+      parentID,
+      modelID: ModelID.make("model"),
+      providerID: ProviderID.make("test"),
+      mode: "code",
+      agent: "code",
+      path: { cwd: "/tmp", root: "/tmp" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      finish: "stop",
+    },
+    parts: [],
+  }
+}
+
 describe("session prompt queue", () => {
+  test("scopes queued turns without moving prior assistant history", async () => {
+    const sessionID = SessionID.make("session_scope")
+    const one = MessageID.make("message_01")
+    const ans = MessageID.make("message_02")
+    const two = MessageID.make("message_03")
+    const three = MessageID.make("message_04")
+    const messages = [
+      user(sessionID, one),
+      assistant(sessionID, ans, one),
+      user(sessionID, two),
+      user(sessionID, three),
+    ]
+
+    const ids = await Effect.runPromise(
+      KiloSessionPromptQueue.enqueue(
+        sessionID,
+        two,
+        Effect.sync(() => KiloSessionPromptQueue.scope(sessionID, messages).map((item) => item.info.id)),
+        Effect.succeed([]),
+      ),
+    )
+
+    expect(ids).toEqual([one, ans, two])
+  })
+
   test("continues a queued prompt after the active run finishes", async () => {
     const ready = Promise.withResolvers<void>()
     const release = Promise.withResolvers<void>()

--- a/packages/opencode/test/kilocode/session-prompt-queue.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-queue.test.ts
@@ -131,6 +131,9 @@ describe("session prompt queue", () => {
 
           await Bun.sleep(20)
           expect(calls).toHaveLength(1)
+          const queued = await Session.messages({ sessionID: session.id })
+          expect(queued.filter((msg) => msg.info.role === "user")).toHaveLength(3)
+          expect(queued.filter((msg) => msg.info.role === "assistant")).toHaveLength(1)
 
           release.resolve()
           await first

--- a/packages/opencode/test/kilocode/session-prompt-queue.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-queue.test.ts
@@ -1,0 +1,156 @@
+import path from "path"
+import { describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+function line(input: unknown) {
+  return `data: ${JSON.stringify(input)}\n\n`
+}
+
+function chunk(input: { delta?: Record<string, unknown>; finish?: string }) {
+  return {
+    id: "chatcmpl-queue-test",
+    object: "chat.completion.chunk",
+    choices: [
+      {
+        delta: input.delta ?? {},
+        ...(input.finish ? { finish_reason: input.finish } : {}),
+      },
+    ],
+  }
+}
+
+function reply(input: { text: string; ready?: () => void; wait?: Promise<unknown> }) {
+  const enc = new TextEncoder()
+  const head = line(chunk({ delta: { role: "assistant" } }))
+  const tail = [
+    line(chunk({ delta: { content: input.text } })),
+    line(chunk({ finish: "stop" })),
+    "data: [DONE]\n\n",
+  ].join("")
+
+  return new ReadableStream<Uint8Array>({
+    start(ctrl) {
+      ctrl.enqueue(enc.encode(head))
+      input.ready?.()
+      const done = () => {
+        ctrl.enqueue(enc.encode(tail))
+        ctrl.close()
+      }
+      if (input.wait) {
+        void input.wait.then(done)
+        return
+      }
+      done()
+    },
+  })
+}
+
+function hasText(msg: Awaited<ReturnType<typeof SessionPrompt.prompt>>, text: string) {
+  return msg.parts.some((part) => part.type === "text" && part.text.includes(text))
+}
+
+describe("session prompt queue", () => {
+  test("continues a queued prompt after the active run finishes", async () => {
+    const ready = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<void>()
+    const calls: number[] = []
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url)
+        if (!url.pathname.endsWith("/chat/completions")) return new Response("not found", { status: 404 })
+
+        calls.push(Date.now())
+        const body =
+          calls.length === 1
+            ? reply({ text: "first reply", ready: ready.resolve, wait: release.promise })
+            : reply({ text: "second reply" })
+        return new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              enabled_providers: ["alibaba"],
+              provider: {
+                alibaba: {
+                  options: {
+                    apiKey: "test-key",
+                    baseURL: `${server.url.origin}/v1`,
+                  },
+                },
+              },
+              agent: {
+                code: {
+                  model: "alibaba/qwen-plus",
+                },
+              },
+            }),
+          )
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({ title: "Queued prompt regression" })
+          const first = SessionPrompt.prompt({
+            sessionID: session.id,
+            agent: "code",
+            parts: [{ type: "text", text: "first prompt" }],
+          })
+
+          await ready.promise
+
+          const second = SessionPrompt.prompt({
+            sessionID: session.id,
+            agent: "code",
+            parts: [{ type: "text", text: "second prompt" }],
+          })
+
+          await Bun.sleep(20)
+          expect(calls).toHaveLength(1)
+
+          release.resolve()
+          await first
+          const two = await second
+
+          expect(hasText(two, "second reply")).toBe(true)
+          expect(calls).toHaveLength(2)
+
+          const msgs = await Session.messages({ sessionID: session.id })
+          const users = msgs.filter((msg) => msg.info.role === "user")
+          const assistants = msgs.filter((msg) => msg.info.role === "assistant")
+          const text = assistants.flatMap((msg) =>
+            msg.parts.filter((part) => part.type === "text").map((part) => part.text),
+          )
+          expect(users).toHaveLength(2)
+          expect(assistants).toHaveLength(2)
+          expect(text).toContain("first reply")
+          expect(text).toContain("second reply")
+          const last = assistants.at(-1)?.info
+          const user = users.at(-1)?.info
+          if (last?.role !== "assistant" || user?.role !== "user") throw new Error("missing final turn")
+          expect(last.parentID).toBe(user.id)
+        },
+      })
+    } finally {
+      server.stop(true)
+    }
+  })
+})

--- a/packages/opencode/test/kilocode/session-prompt-queue.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-queue.test.ts
@@ -60,6 +60,7 @@ describe("session prompt queue", () => {
     const ready = Promise.withResolvers<void>()
     const release = Promise.withResolvers<void>()
     const calls: number[] = []
+    const replies = ["first reply", "second reply", "third reply"]
     const server = Bun.serve({
       port: 0,
       fetch(req) {
@@ -69,8 +70,8 @@ describe("session prompt queue", () => {
         calls.push(Date.now())
         const body =
           calls.length === 1
-            ? reply({ text: "first reply", ready: ready.resolve, wait: release.promise })
-            : reply({ text: "second reply" })
+            ? reply({ text: replies[0], ready: ready.resolve, wait: release.promise })
+            : reply({ text: replies[calls.length - 1] ?? "extra reply" })
         return new Response(body, {
           status: 200,
           headers: { "Content-Type": "text/event-stream" },
@@ -122,6 +123,11 @@ describe("session prompt queue", () => {
             agent: "code",
             parts: [{ type: "text", text: "second prompt" }],
           })
+          const third = SessionPrompt.prompt({
+            sessionID: session.id,
+            agent: "code",
+            parts: [{ type: "text", text: "third prompt" }],
+          })
 
           await Bun.sleep(20)
           expect(calls).toHaveLength(1)
@@ -129,9 +135,11 @@ describe("session prompt queue", () => {
           release.resolve()
           await first
           const two = await second
+          const three = await third
 
           expect(hasText(two, "second reply")).toBe(true)
-          expect(calls).toHaveLength(2)
+          expect(hasText(three, "third reply")).toBe(true)
+          expect(calls).toHaveLength(3)
 
           const msgs = await Session.messages({ sessionID: session.id })
           const users = msgs.filter((msg) => msg.info.role === "user")
@@ -139,14 +147,16 @@ describe("session prompt queue", () => {
           const text = assistants.flatMap((msg) =>
             msg.parts.filter((part) => part.type === "text").map((part) => part.text),
           )
-          expect(users).toHaveLength(2)
-          expect(assistants).toHaveLength(2)
+          expect(users).toHaveLength(3)
+          expect(assistants).toHaveLength(3)
           expect(text).toContain("first reply")
           expect(text).toContain("second reply")
-          const last = assistants.at(-1)?.info
-          const user = users.at(-1)?.info
-          if (last?.role !== "assistant" || user?.role !== "user") throw new Error("missing final turn")
-          expect(last.parentID).toBe(user.id)
+          expect(text).toContain("third reply")
+          for (const [index, item] of assistants.entries()) {
+            const user = users[index]?.info
+            if (item.info.role !== "assistant" || user?.role !== "user") throw new Error("missing turn")
+            expect(item.info.parentID).toBe(user.id)
+          }
         },
       })
     } finally {

--- a/packages/opencode/test/kilocode/session-prompt-queue.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-queue.test.ts
@@ -231,4 +231,93 @@ describe("session prompt queue", () => {
       server.stop(true)
     }
   })
+
+  test("cancel drops queued prompts and resets internal state", async () => {
+    const ready = Promise.withResolvers<void>()
+    const calls: number[] = []
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url)
+        if (!url.pathname.endsWith("/chat/completions")) return new Response("not found", { status: 404 })
+
+        calls.push(Date.now())
+        const body = reply({ text: "first reply", ready: ready.resolve, wait: new Promise(() => {}) })
+        return new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              enabled_providers: ["alibaba"],
+              provider: {
+                alibaba: {
+                  options: { apiKey: "test-key", baseURL: `${server.url.origin}/v1` },
+                },
+              },
+              agent: { code: { model: "alibaba/qwen-plus" } },
+            }),
+          )
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({ title: "Queued cancel regression" })
+          const first = SessionPrompt.prompt({
+            sessionID: session.id,
+            agent: "code",
+            parts: [{ type: "text", text: "first prompt" }],
+          })
+          await ready.promise
+
+          const second = SessionPrompt.prompt({
+            sessionID: session.id,
+            agent: "code",
+            parts: [{ type: "text", text: "second prompt" }],
+          })
+          const third = SessionPrompt.prompt({
+            sessionID: session.id,
+            agent: "code",
+            parts: [{ type: "text", text: "third prompt" }],
+          })
+
+          await Bun.sleep(20)
+          expect(calls).toHaveLength(1)
+
+          await SessionPrompt.cancel(session.id)
+          await Promise.all([first, second, third])
+
+          expect(calls).toHaveLength(1)
+          const msgs = await Session.messages({ sessionID: session.id })
+          const assistants = msgs.filter((msg) => msg.info.role === "assistant")
+          expect(assistants).toHaveLength(1)
+          expect(msgs.filter((msg) => msg.info.role === "user")).toHaveLength(3)
+
+          // Internal state should have no lingering tail/version/target entries after the last release.
+          const ids = await Effect.runPromise(
+            KiloSessionPromptQueue.enqueue(
+              session.id,
+              MessageID.make("message_probe"),
+              Effect.succeed(KiloSessionPromptQueue.scope(session.id, []).map((item) => item.info.id)),
+              Effect.succeed([]),
+            ),
+          )
+          expect(ids).toEqual([])
+        },
+      })
+    } finally {
+      server.stop(true)
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Queue Kilo prompt-created session loops so follow-up messages sent during an active turn continue after that turn finishes.
- Keep the runtime fix isolated to Kilo-specific session queue code, with only a small shared prompt hook.
- Stabilize the Windows local-model persistence test by retrying reads that race an in-progress JSON write.

## Regression source
- Regressed when #8722 (`fix(vscode): ignore confirmed command transport errors`) switched VS Code sends to `session.promptAsync`.
- `promptAsync` persists the user message and returns immediately; if another prompt is sent while the previous turn is still running, the existing session runner dedupes to the active run instead of scheduling a follow-up run.
- The result is an orphaned user message at the end of the session: the UI shows the prompt/check-session state, but no assistant turn is created for that final message. #9036 made the queued/abort behavior cleaner, but it did not address this backend continuation gap.

## Manual reproduction
1. Check out `main` before this PR, open the VS Code extension, and start a normal chat session.
2. Send a prompt that keeps the assistant busy long enough to interact with it, for example asking it to inspect or edit files.
3. Before the assistant turn fully finishes, send a second prompt in the same session.
4. Wait for the first assistant turn to complete.
5. Observe that the second user message remains at the end without a corresponding assistant response; interacting with the session can leave it appearing stuck around check-session/queued state.
6. Repeat on this PR: the second prompt is processed after the first turn finishes and gets its own assistant response.