### PR TITLE
fix: gate publish on smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -254,16 +254,14 @@ jobs:
   #         APPLE_API_KEY_PATH: ${{ runner.temp }}/apple-api-key.p8
 
   # kilocode_change start
-  # Smoke test disabled as a release gate due to infrastructure issues.
-  # The job is skipped via `if: false` so it no longer blocks publishing.
-  # Re-enable by restoring the original `if:` condition and uncommenting
-  # `- smoke-test` in the publish job's `needs` list below.
+  # Run smoke tests against CLI assets uploaded to the draft GitHub release
+  # before publishing the release and package artifacts.
   smoke-test:
-    name: Smoke Test (pre-publish gate) [DISABLED]
+    name: Smoke Test (pre-publish gate)
     needs:
       - version
       - build-cli
-    if: false # was: github.repository == 'Kilo-Org/kilocode'
+    if: github.repository == 'Kilo-Org/kilocode'
     runs-on: ubuntu-24.04
     steps:
       - name: Trigger kilo-bench smoke test
@@ -276,7 +274,11 @@ jobs:
           gh api repos/Kilo-Org/kilo-bench/dispatches \
             --method POST \
             -f event_type=smoke-test \
+            -f 'client_payload[cli_version]=${{ needs.version.outputs.version }}' \
             -f 'client_payload[release_tag]=${{ needs.version.outputs.tag }}' \
+            -f 'client_payload[release_id]=${{ needs.version.outputs.release }}' \
+            -f 'client_payload[pre_release]=${{ inputs.pre_release }}' \
+            -f 'client_payload[source_repo]=${{ github.repository }}' \
             -f 'client_payload[source_run_id]=${{ github.run_id }}'
 
           # Poll for the run created after our dispatch timestamp.
@@ -336,7 +338,7 @@ jobs:
       - version
       - build-cli
       - build-vscode
-      # - smoke-test  # disabled: infrastructure issues (see smoke-test job comment)
+      - smoke-test
       # - build-tauri
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -262,76 +262,10 @@ jobs:
       - version
       - build-cli
     if: github.repository == 'Kilo-Org/kilocode'
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Trigger kilo-bench smoke test
-        id: trigger
-        env:
-          GH_TOKEN: ${{ secrets.BENCH_GITHUB_TOKEN }}
-        run: |
-          BEFORE=$(date -u -d '60 seconds ago' +%Y-%m-%dT%H:%M:%SZ)
-
-          gh api repos/Kilo-Org/kilo-bench/dispatches \
-            --method POST \
-            -f event_type=smoke-test \
-            -f 'client_payload[cli_version]=${{ needs.version.outputs.version }}' \
-            -f 'client_payload[release_tag]=${{ needs.version.outputs.tag }}' \
-            -f 'client_payload[release_id]=${{ needs.version.outputs.release }}' \
-            -f 'client_payload[pre_release]=${{ inputs.pre_release }}' \
-            -f 'client_payload[source_repo]=${{ github.repository }}' \
-            -f 'client_payload[source_run_id]=${{ github.run_id }}'
-
-          # Poll for the run created after our dispatch timestamp.
-          # The dispatch API returns no run ID, so we query by created time
-          # and pick the oldest match to avoid grabbing an unrelated run.
-          echo "Waiting for smoke-test run to appear (dispatched after $BEFORE)..."
-          for attempt in $(seq 1 30); do
-            RUN_ID=$(gh api \
-              "repos/Kilo-Org/kilo-bench/actions/workflows/smoke-test.yml/runs?event=repository_dispatch&created=>=$BEFORE" \
-              --jq '.workflow_runs | sort_by(.created_at) | .[0].id // empty')
-
-            if [[ -n "$RUN_ID" && "$RUN_ID" != "null" ]]; then
-              echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
-              echo "::notice::Smoke test run: https://github.com/Kilo-Org/kilo-bench/actions/runs/$RUN_ID"
-              exit 0
-            fi
-
-            echo "  attempt $attempt: run not yet registered, retrying in 10s..."
-            sleep 10
-          done
-
-          echo "::error::Smoke test run did not appear within 5 minutes after dispatch."
-          exit 1
-
-      - name: Wait for smoke test to complete
-        env:
-          GH_TOKEN: ${{ secrets.BENCH_GITHUB_TOKEN }}
-        run: |
-          RUN_ID="${{ steps.trigger.outputs.run_id }}"
-          echo "Waiting for run $RUN_ID..."
-
-          for i in $(seq 1 60); do
-            CONCLUSION=$(gh run view "$RUN_ID" \
-              --repo Kilo-Org/kilo-bench \
-              --json conclusion \
-              --jq '.conclusion')
-
-            echo "  attempt $i: $CONCLUSION"
-
-            if [[ "$CONCLUSION" == "success" ]]; then
-              echo "::notice::Smoke test passed."
-              exit 0
-            elif [[ "$CONCLUSION" != "null" && "$CONCLUSION" != "" ]]; then
-              echo "::error::Smoke test failed with conclusion: $CONCLUSION"
-              echo "See: https://github.com/Kilo-Org/kilo-bench/actions/runs/$RUN_ID"
-              exit 1
-            fi
-
-            sleep 30
-          done
-
-          echo "::error::Smoke test did not complete within 30 minutes."
-          exit 1
+    uses: ./.github/workflows/smoke-test.yml
+    with:
+      cli_version: ${{ needs.version.outputs.version }}
+    secrets: inherit
   # kilocode_change end
   publish:
     needs:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -7,7 +7,7 @@
 #
 # Triggers:
 #   - workflow_dispatch: manually from Actions tab (optionally pass a CLI version)
-#   - push to main: automatically after every merge
+#   - workflow_call: from publish.yml after draft release assets are uploaded
 #
 # Required secrets:
 #   KILO_API_KEY         — Kilo Gateway key
@@ -21,6 +21,12 @@ on:
     inputs:
       cli_version:
         description: "CLI version to test (e.g. 7.0.36). Leave blank for latest npm release."
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      cli_version:
+        description: "CLI version to test from draft release assets."
         required: false
         type: string
 


### PR DESCRIPTION
## Summary
- Gate publish on the in-repo smoke-test workflow after draft CLI release assets are available.
- Pass the draft CLI version into the reusable smoke-test workflow so it can validate the release before packages publish.