### PR TITLE
docs(kilo-docs): expand KiloClaw chat platform guides with DM and channel configuration

### DIFF
--- a/packages/kilo-docs/pages/kiloclaw/chat-platforms/discord.md
+++ b/packages/kilo-docs/pages/kiloclaw/chat-platforms/discord.md
@@ -1,11 +1,15 @@
 ---
 title: "Discord"
-description: "Connect your KiloClaw agent to Discord"
+description: "Use KiloClaw with Discord: setup, DM access control, and channel configuration"
 ---
 
 # Discord
 
-Connect your KiloClaw agent to Discord by creating a bot in the Discord Developer Portal and linking it to your KiloClaw dashboard.
+This page covers everything you need to use KiloClaw with Discord: connecting your bot, controlling who can DM it, and adding it to specific channels.
+
+## Connecting KiloClaw to Discord
+
+Create a bot in the Discord Developer Portal and link it to your KiloClaw dashboard.
 
 ## Prerequisites
 
@@ -65,3 +69,78 @@ After saving your token, click **Redeploy** (the yellow button at the top of the
 3. You should get a response back with a pairing code
 4. Return to [app.kilo.ai/claw](https://app.kilo.ai/claw) and confirm the pairing code and approve
 5. You should now be able to chat with the bot from Discord
+
+## Restricting KiloClaw to DMs Only (Just You)
+
+By default, KiloClaw will respond to any DMs. To lock it down to only DMs with you:
+
+### Step 1: Find your Discord user ID
+
+1. In Discord, go to **User Settings** → **Advanced** → enable **Developer Mode**
+2. Right-click your own avatar or username → **Copy User ID**
+
+Your user ID is a large number (e.g. `987654321098765432`).
+
+### Step 2: Configure DM-only access
+
+Tell your KiloClaw agent (via DM):
+
+> "Set Discord DM policy to allowlist with my user ID `987654321098765432` and disable guild responses."
+
+Or configure it directly in the OpenClaw Control UI config:
+
+```json
+{
+  "channels": {
+    "discord": {
+      "dmPolicy": "allowlist",
+      "allowFrom": ["987654321098765432"],
+      "groupPolicy": "disabled"
+    }
+  }
+}
+```
+
+## Adding KiloClaw to a Specific Discord Channel
+
+By default, your KiloClaw will not respond in channels, even if added. To have KiloClaw participate in a specific channel:
+
+### Step 1: Get your server and channel IDs
+
+With Developer Mode enabled (User Settings → Advanced → Developer Mode):
+
+- Right-click the **server icon** → **Copy Server ID**
+- Right-click the **channel name** in the sidebar → **Copy Channel ID**
+
+### Step 2: Configure the channel
+
+Tell your KiloClaw agent:
+
+> "Add Discord server `YOUR_SERVER_ID` and channel `YOUR_CHANNEL_ID` to the allowlist. Only respond to user `YOUR_USER_ID`."
+
+Or configure it directly:
+
+```json
+{
+  "channels": {
+    "discord": {
+      "groupPolicy": "allowlist",
+      "guilds": {
+        "YOUR_SERVER_ID": {
+          "requireMention": true,
+          "users": ["YOUR_USER_ID"],
+          "channels": {
+            "YOUR_CHANNEL_ID": { "allow": true }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Set `requireMention: false` if you want the bot to respond to every message without needing an @mention.
+
+{% callout type="tip" %}
+Non-listed channels in a guild that has a `channels` block configured are automatically denied. Add each channel you want explicitly. See the [OpenClaw Discord documentation](https://docs.openclaw.ai/channels/discord) for advanced access control options.
+{% /callout %}

--- a/packages/kilo-docs/pages/kiloclaw/chat-platforms/slack.md
+++ b/packages/kilo-docs/pages/kiloclaw/chat-platforms/slack.md
@@ -1,15 +1,19 @@
 ---
 title: "Slack"
-description: "Connect your KiloClaw agent to Slack"
+description: "Using KiloClaw with Slack"
 ---
 
 # Slack
 
+This page covers everything you need to use KiloClaw with Slack: connecting your bot, controlling who can DM it, and adding it to channels.
+
+## Connecting KiloClaw to Slack
+
 {% youtube url="https://youtu.be/Q5bt-qH-_pY" title="Slack Setup Guide" caption="How to connect your KiloClaw agent to Slack" /%}
 
-Connect your KiloClaw agent to Slack by creating a Slack app from the OpenClaw manifest and linking it to your KiloClaw dashboard.
+Create a Slack app from the OpenClaw manifest and link it to your KiloClaw dashboard.
 
-## Step 1: Create a Slack App from the OpenClaw Manifest
+### Step 1: Create a Slack App from the OpenClaw Manifest
 
 1. Go to [Slack App Management](https://api.slack.com/apps) and click **Create New App** → **From a Manifest**
 2. Copy the manifest from the [OpenClaw docs](https://docs.openclaw.ai/channels/slack#manifest-and-scope-checklist)
@@ -19,7 +23,7 @@ Connect your KiloClaw agent to Slack by creating a Slack app from the OpenClaw m
    - Update the slash command if desired (e.g., `/kiloclaw`)
 5. Click **Create**
 
-## Step 2: Generate Tokens
+### Step 2: Generate Tokens
 
 You need two tokens from Slack:
 
@@ -36,7 +40,7 @@ You need two tokens from Slack:
 2. Install the app to your workspace
 3. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
 
-## Step 3: Connect Slack to KiloClaw
+### Step 3: Connect Slack to KiloClaw
 
 1. In the [KiloClaw UI](https://app.kilo.ai/claw), find the Slack integration section (may show "not configured")
 2. Enter both tokens:
@@ -45,10 +49,94 @@ You need two tokens from Slack:
 3. Click **Save**
 4. Scroll to the top of the KiloClaw UI and click **Redeploy**. Wait for the instance to come back up
 
-## Step 4: Pair Slack with KiloClaw
+### Step 4: Pair Slack with KiloClaw
 
 1. In Slack, DM the app and send any message — this triggers the pairing flow
-
 2. The app will return a pairing code
 3. Return to [app.kilocode.ai/claw](https://app.kilocode.ai/claw) and confirm the pairing code and approve
 4. You should now be able to DM the bot from Slack. You will need to add the bot to any individual channels and tell it to update its config for any channels you want it to participate in.
+
+## Changing Response Behavior
+
+By default, KiloClaw can respond to any DMs and will not respond in Slack channels, even if added.
+
+## Making KiloClaw DM-Only (from you)
+
+By default, KiloClaw will respond to DMs from any user in Slack.
+
+### Step 1: Find your Slack user ID
+
+1. In Slack, click your name or profile picture
+2. Click **Profile**
+3. Click the **More** (⋯) menu → **Copy member ID**
+
+Your user ID starts with `U` (e.g. `U12345678`).
+
+### Step 2: Configure DM-only access
+
+Tell your KiloClaw agent:
+
+> "Set my Slack DM policy to allowlist with my user ID `U12345678` and disable group/channel responses."
+
+Or configure it directly in the OpenClaw Control UI config:
+
+```json
+{
+  "channels": {
+    "slack": {
+      "dmPolicy": "allowlist",
+      "allowFrom": ["U12345678"],
+      "groupPolicy": "disabled"
+    }
+  }
+}
+```
+
+This allows only your user ID to DM the bot and blocks it from responding in any channels.
+
+## Adding KiloClaw to a Slack Channel
+
+By default, KiloClaw will not respond in Slack channels, even if added. To have KiloClaw participate in a Slack channel:
+
+### Step 1: Invite the bot to the channel
+
+1. Open the Slack channel where you want to add the bot
+2. Type `/invite @YourBotName` (use whatever name you gave your app)
+3. The bot should appear in the channel member list
+
+### Step 2: Get the channel ID
+
+Channel IDs are more reliable than names. To find a channel's ID:
+
+1. Open the channel in Slack
+2. Click the channel name at the top to open channel details
+3. Scroll to the bottom — the channel ID starts with `C` (e.g. `C01234567`)
+
+### Step 3: Configure the channel
+
+Tell your KiloClaw agent (via DM):
+
+> "Allow responses in Slack channel `C01234567`. Require an @mention to respond."
+
+Or configure it directly:
+
+```json
+{
+  "channels": {
+    "slack": {
+      "groupPolicy": "allowlist",
+      "channels": {
+        "C01234567": {
+          "requireMention": true
+        }
+      }
+    }
+  }
+}
+```
+
+Set `requireMention: false` if you want the bot to respond to every message in the channel without needing an @mention.
+
+{% callout type="tip" %}
+You can restrict which channel members can trigger the bot by adding a `users` allowlist inside the channel config entry. See the [OpenClaw Slack documentation](https://docs.openclaw.ai/channels/slack) for advanced access control options.
+{% /callout %}

--- a/packages/kilo-docs/pages/kiloclaw/chat-platforms/slack.md
+++ b/packages/kilo-docs/pages/kiloclaw/chat-platforms/slack.md
@@ -53,7 +53,7 @@ You need two tokens from Slack:
 
 1. In Slack, DM the app and send any message — this triggers the pairing flow
 2. The app will return a pairing code
-3. Return to [app.kilocode.ai/claw](https://app.kilocode.ai/claw) and confirm the pairing code and approve
+3. Return to [app.kilo.ai/claw](https://app.kilo.ai/claw) and confirm the pairing code and approve
 4. You should now be able to DM the bot from Slack. You will need to add the bot to any individual channels and tell it to update its config for any channels you want it to participate in.
 
 ## Changing Response Behavior

--- a/packages/kilo-docs/pages/kiloclaw/chat-platforms/telegram.md
+++ b/packages/kilo-docs/pages/kiloclaw/chat-platforms/telegram.md
@@ -1,13 +1,17 @@
 ---
 title: "Telegram"
-description: "Connect your KiloClaw agent to Telegram"
+description: "Use KiloClaw with Telegram: setup, DM access control, and group chat configuration"
 ---
 
 # Telegram
 
+This page covers everything you need to use KiloClaw with Telegram: connecting your bot, controlling who can DM it, and adding it to group chats.
+
+## Connecting KiloClaw to Telegram
+
 {% youtube url="https://youtu.be/hIfKz073hGw" title="Telegram Setup Guide" caption="How to connect your KiloClaw agent to Telegram" /%}
 
-Connect your KiloClaw agent to Telegram by creating a bot via BotFather and linking it to your KiloClaw dashboard.
+Create a bot via BotFather and link it to your KiloClaw dashboard.
 
 1. Open Telegram and search for [@BotFather](https://t.me/BotFather)
 2. Send `/newbot` and follow the prompts to create your bot
@@ -22,5 +26,60 @@ Connect your KiloClaw agent to Telegram by creating a bot via BotFather and link
 
 You can remove or replace a configured token at any time.
 
-> ℹ️ **Info**
-> Advanced settings such as DM policy, allow lists, and groups can be configured in the OpenClaw Control UI after connecting.
+## Adding KiloClaw to a Telegram Group Chat
+
+By default, KiloClaw will not participate in a group chat, even if added. If you would like to use your KiloClaw in a group chat, you must configure the KiloClaw settings.
+
+### Step 1: Add the bot to your group
+
+1. Open the Telegram group where you want to add your bot
+2. Tap the group name at the top to open group info
+3. Tap **Add Members**
+4. Search for your bot's username and add it
+
+### Step 2: Set group visibility (Privacy Mode)
+
+By default, Telegram bots only see messages that directly mention them. To allow your bot to see all group messages:
+
+1. Open a chat with [@BotFather](https://t.me/BotFather)
+2. Send `/setprivacy` and select your bot
+3. Choose **Disable**
+4. Remove the bot from the group and re-add it for the change to take effect
+
+### Step 3: Get the group chat ID
+
+You need the group's chat ID to configure access. Use one of these methods:
+
+- Forward a message from the group to [@userinfobot](https://t.me/userinfobot) — it will show the chat ID
+- Or run `openclaw logs --follow` after sending a message in the group and read the `chat.id` value
+
+Group and supergroup IDs are negative numbers (e.g. `-1001234567890`).
+
+### Step 4: Configure the group in OpenClaw
+
+Tell your KiloClaw bot to add the group to its configuration. You can do this via DM:
+
+> "Add Telegram group `-1001234567890` to my allowed groups. Require a @mention to respond."
+
+Or configure it directly in the OpenClaw Control UI config:
+
+```json
+{
+  "channels": {
+    "telegram": {
+      "groupPolicy": "allowlist",
+      "groups": {
+        "-1001234567890": {
+          "requireMention": true
+        }
+      }
+    }
+  }
+}
+```
+
+Set `requireMention: false` if you want the bot to respond to every message in the group without needing to be @mentioned.
+
+{% callout type="tip" %}
+To restrict which group members can trigger the bot, add your user IDs to `allowFrom` inside the group config. See the [OpenClaw groups documentation](https://docs.openclaw.ai/channels/groups) for advanced access control patterns.
+{% /callout %}

--- a/packages/kilo-docs/pages/kiloclaw/chat-platforms/telegram.md
+++ b/packages/kilo-docs/pages/kiloclaw/chat-platforms/telegram.md
@@ -5,7 +5,7 @@ description: "Use KiloClaw with Telegram: setup, DM access control, and group ch
 
 # Telegram
 
-This page covers everything you need to use KiloClaw with Telegram: connecting your bot, controlling who can DM it, and adding it to group chats.
+This page covers everything you need to use KiloClaw with Telegram: connecting your bot and adding it to group chats.
 
 ## Connecting KiloClaw to Telegram
 

--- a/packages/kilo-docs/tsconfig.json
+++ b/packages/kilo-docs/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -14,17 +10,11 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }

--- a/packages/kilo-docs/tsconfig.json
+++ b/packages/kilo-docs/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -10,11 +14,17 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Expands the Discord, Slack, and Telegram KiloClaw docs with sections on DM access control and channel/group configuration.