### PR TITLE
fix(vscode): keep scroll-to-bottom button above sticky accordion headers

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
@@ -97,6 +97,10 @@
   position: absolute;
   bottom: 12px;
   right: 12px;
+  /* Must sit above sticky accordion headers (z-index: 10 from
+     sticky-accordion-header.css), which otherwise paint over the button when
+     Edit/Write/apply_patch cards scroll past. */
+  z-index: 20;
   width: 32px;
   height: 32px;
   border-radius: 50%;


### PR DESCRIPTION
## Context

Follow-up to #9056 (review discussion about the scroll-to-bottom button appearing "overlapped" by a Write tool's accordion chevron).

Turned out not to be a layout problem at all — it's a z-index bug. The floating `.scroll-to-bottom-button` paints correctly over normal content (bash/terminal output, plain text), but Edit/Write/apply_patch tool cards paint **over** it. The reason: `sticky-accordion-header.css` sets `z-index: 10` on `[data-component="sticky-accordion-header"]` so the accordion header sticks cleanly when scrolling past, and the button had no `z-index`, so the sticky header wins the stacking order. Bash output has no sticky header, which is why terminal overlap has always looked right — the button sits on top, content flows under it.

## Implementation

One-rule fix in `chat-layout.css`:

```css
.scroll-to-bottom-button {
  ...
  z-index: 20; /* above the z-index: 10 sticky-accordion-header */
}
```

No layout shift, no repositioning, no reflow. The button now wins the stacking order against every tool card, so it behaves uniformly whether the scroll-past content is bash output, a text message, or an Edit/Write/apply_patch accordion.

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

1. Open the Kilo VS Code extension on any session that has Edit/Write/apply_patch tool cards.
2. Scroll up so the floating scroll-to-bottom button appears.
3. Scroll so a tool card's sticky accordion header is near the bottom-right of the viewport (where the button sits).
4. Confirm the button paints fully on top of the accordion chevron and any `Created` / `+N -M` badge — same as it already does over bash output.
5. Click the button — still resumes auto-scroll.

## Get in Touch

<!-- add discord handle -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)