### PR TITLE
feat(kilo-ui): enhance MCP tool display with input/output sections an…

### DIFF
--- a/.changeset/mcp-input-output-i18n.md
+++ b/.changeset/mcp-input-output-i18n.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show MCP tool call inputs alongside outputs in chat, with JSON syntax highlighting for both.

--- a/packages/kilo-ui/src/components/basic-tool.css
+++ b/packages/kilo-ui/src/components/basic-tool.css
@@ -156,6 +156,24 @@ html[data-theme="kilo-vscode"] [data-component="tool-part-wrapper"][data-part-ty
     }
   }
 
+  /* Reposition copy button tooltip to appear below (not above) to avoid clipping */
+  [data-component="tool-output"] [data-slot="markdown-copy-button"]::after {
+    bottom: auto;
+    top: calc(100% + 4px);
+  }
+
+  [data-slot="mcp-section-label"] {
+    padding: 6px 12px 0;
+    font-size: 11px;
+    color: var(--text-weak, var(--vscode-descriptionForeground));
+  }
+
+  [data-slot="mcp-tool-divider"] {
+    height: 1px;
+    background: var(--border-weak-base, var(--vscode-panel-border));
+    margin-top: 4px;
+  }
+
   /* Expandable tool output content */
   [data-component="tool-output"] {
     padding: 8px 12px;

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1026,6 +1026,7 @@ function ToolFileAccordion(props: { path: string; actions?: JSX.Element; childre
 // GenericTool (upstream) does not render output; this override does.
 // When hideDetails is true, render as a row (no content), otherwise as a panel with markdown output.
 function McpTool(props: ToolProps) {
+  const i18n = useI18n()
   const labelKeys = ["description", "query", "url", "filePath", "path", "pattern", "name"]
   const skipKeys = new Set(labelKeys)
 
@@ -1085,7 +1086,7 @@ function McpTool(props: ToolProps) {
         <Show when={formatted()}>
           {(text) => (
             <>
-              <div data-slot="mcp-section-label">Input</div>
+              <div data-slot="mcp-section-label">{i18n.t("ui.messagePart.mcp.input")}</div>
               <div data-component="tool-output" data-scrollable>
                 <Markdown text={text()} />
               </div>
@@ -1098,7 +1099,7 @@ function McpTool(props: ToolProps) {
               <Show when={formatted()}>
                 <div data-slot="mcp-tool-divider" />
               </Show>
-              <div data-slot="mcp-section-label">Output</div>
+              <div data-slot="mcp-section-label">{i18n.t("ui.messagePart.mcp.output")}</div>
               <div data-component="tool-output" data-scrollable>
                 <Markdown text={text()} />
               </div>

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1026,24 +1026,83 @@ function ToolFileAccordion(props: { path: string; actions?: JSX.Element; childre
 // GenericTool (upstream) does not render output; this override does.
 // When hideDetails is true, render as a row (no content), otherwise as a panel with markdown output.
 function McpTool(props: ToolProps) {
+  const labelKeys = ["description", "query", "url", "filePath", "path", "pattern", "name"]
+  const skipKeys = new Set(labelKeys)
+
+  const subtitle = () =>
+    labelKeys
+      .map((key) => props.input?.[key])
+      .find((value): value is string => typeof value === "string" && value.length > 0)
+
+  const inputArgs = () => {
+    if (!props.input) return []
+    return Object.entries(props.input)
+      .filter(([key]) => !skipKeys.has(key))
+      .flatMap(([key, value]) => {
+        if (typeof value === "string") return [`${key}=${value}`]
+        if (typeof value === "number") return [`${key}=${value}`]
+        if (typeof value === "boolean") return [`${key}=${value}`]
+        return []
+      })
+      .slice(0, 3)
+  }
+
+  const formatted = createMemo(() => {
+    if (!props.input || Object.keys(props.input).length === 0) return ""
+    return "```json\n" + JSON.stringify(props.input, null, 2) + "\n```"
+  })
+
+  const formattedOutput = createMemo(() => {
+    if (!props.output) return undefined
+    try {
+      const parsed = JSON.parse(props.output)
+      return "```json\n" + JSON.stringify(parsed, null, 2) + "\n```"
+    } catch {
+      return props.output
+    }
+  })
+
   return (
     <Show
       when={!props.hideDetails}
-      fallback={<BasicTool hideDetails icon="mcp" status={props.status} trigger={{ title: props.tool }} />}
+      fallback={
+        <BasicTool
+          hideDetails
+          icon="mcp"
+          status={props.status}
+          trigger={{ title: props.tool, subtitle: subtitle(), args: inputArgs() }}
+        />
+      }
     >
       <BasicTool
         icon="mcp"
         status={props.status}
-        trigger={{ title: props.tool }}
+        trigger={{ title: props.tool, subtitle: subtitle(), args: inputArgs() }}
         defaultOpen={props.defaultOpen}
         forceOpen={props.forceOpen}
         locked={props.locked}
       >
-        <Show when={props.output}>
-          {(output) => (
-            <div data-component="tool-output" data-scrollable>
-              <Markdown text={output()} />
-            </div>
+        <Show when={formatted()}>
+          {(text) => (
+            <>
+              <div data-slot="mcp-section-label">Input</div>
+              <div data-component="tool-output" data-scrollable>
+                <Markdown text={text()} />
+              </div>
+            </>
+          )}
+        </Show>
+        <Show when={formattedOutput()}>
+          {(text) => (
+            <>
+              <Show when={formatted()}>
+                <div data-slot="mcp-tool-divider" />
+              </Show>
+              <div data-slot="mcp-section-label">Output</div>
+              <div data-component="tool-output" data-scrollable>
+                <Markdown text={text()} />
+              </div>
+            </>
           )}
         </Show>
       </BasicTool>
@@ -1068,7 +1127,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
 
   return (
     <Show when={!hideQuestion()}>
-      <div data-component="tool-part-wrapper" data-tool={part.tool}>
+      <div data-component="tool-part-wrapper" data-part-type="tool" data-tool={part.tool}>
         <Switch>
           <Match when={part.state.status === "error" && part.state.error}>
             {(error) => {

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -76,6 +76,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} قائمة",
   "ui.messagePart.context.list.other": "{{count}} قوائم",
   "ui.messagePart.diagnostic.error": "خطأ",
+  "ui.messagePart.mcp.input": "الإدخال",
+  "ui.messagePart.mcp.output": "الإخراج",
   "ui.messagePart.title.edit": "تحرير",
   "ui.messagePart.title.write": "كتابة",
   "ui.messagePart.option.typeOwnAnswer": "اكتب إجابتك الخاصة",

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -76,6 +76,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} lista",
   "ui.messagePart.context.list.other": "{{count}} listas",
   "ui.messagePart.diagnostic.error": "Erro",
+  "ui.messagePart.mcp.input": "Entrada",
+  "ui.messagePart.mcp.output": "Saída",
   "ui.messagePart.title.edit": "Editar",
   "ui.messagePart.title.write": "Escrever",
   "ui.messagePart.option.typeOwnAnswer": "Digite sua própria resposta",

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -80,6 +80,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} lista",
   "ui.messagePart.context.list.other": "{{count}} liste",
   "ui.messagePart.diagnostic.error": "Greška",
+  "ui.messagePart.mcp.input": "Ulaz",
+  "ui.messagePart.mcp.output": "Izlaz",
   "ui.messagePart.title.edit": "Uredi",
   "ui.messagePart.title.write": "Napiši",
   "ui.messagePart.option.typeOwnAnswer": "Unesi svoj odgovor",

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -75,6 +75,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} liste",
   "ui.messagePart.context.list.other": "{{count}} lister",
   "ui.messagePart.diagnostic.error": "Fejl",
+  "ui.messagePart.mcp.input": "Input",
+  "ui.messagePart.mcp.output": "Output",
   "ui.messagePart.title.edit": "Rediger",
   "ui.messagePart.title.write": "Skriv",
   "ui.messagePart.option.typeOwnAnswer": "Skriv dit eget svar",

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -81,6 +81,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} Liste",
   "ui.messagePart.context.list.other": "{{count}} Listen",
   "ui.messagePart.diagnostic.error": "Fehler",
+  "ui.messagePart.mcp.input": "Eingabe",
+  "ui.messagePart.mcp.output": "Ausgabe",
   "ui.messagePart.title.edit": "Bearbeiten",
   "ui.messagePart.title.write": "Schreiben",
   "ui.messagePart.option.typeOwnAnswer": "Eigene Antwort eingeben",

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -69,6 +69,8 @@ export const dict: Record<string, string> = {
   "ui.sessionTurn.status.consideringNextSteps": "Considering next steps",
 
   "ui.messagePart.diagnostic.error": "Error",
+  "ui.messagePart.mcp.input": "Input",
+  "ui.messagePart.mcp.output": "Output",
   "ui.messagePart.title.edit": "Edit",
   "ui.messagePart.title.write": "Write",
   "ui.messagePart.option.typeOwnAnswer": "Type your own answer",

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -76,6 +76,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} lista",
   "ui.messagePart.context.list.other": "{{count}} listas",
   "ui.messagePart.diagnostic.error": "Error",
+  "ui.messagePart.mcp.input": "Entrada",
+  "ui.messagePart.mcp.output": "Salida",
   "ui.messagePart.title.edit": "Editar",
   "ui.messagePart.title.write": "Escribir",
   "ui.messagePart.option.typeOwnAnswer": "Escribe tu propia respuesta",

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -76,6 +76,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} liste",
   "ui.messagePart.context.list.other": "{{count}} listes",
   "ui.messagePart.diagnostic.error": "Erreur",
+  "ui.messagePart.mcp.input": "Entrée",
+  "ui.messagePart.mcp.output": "Sortie",
   "ui.messagePart.title.edit": "Modifier",
   "ui.messagePart.title.write": "Écrire",
   "ui.messagePart.option.typeOwnAnswer": "Tapez votre propre réponse",

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -75,6 +75,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} 件のリスト",
   "ui.messagePart.context.list.other": "{{count}} 件のリスト",
   "ui.messagePart.diagnostic.error": "エラー",
+  "ui.messagePart.mcp.input": "入力",
+  "ui.messagePart.mcp.output": "出力",
   "ui.messagePart.title.edit": "編集",
   "ui.messagePart.title.write": "作成",
   "ui.messagePart.option.typeOwnAnswer": "自分の回答を入力",

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -76,6 +76,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}}개 목록",
   "ui.messagePart.context.list.other": "{{count}}개 목록",
   "ui.messagePart.diagnostic.error": "오류",
+  "ui.messagePart.mcp.input": "입력",
+  "ui.messagePart.mcp.output": "출력",
   "ui.messagePart.title.edit": "편집",
   "ui.messagePart.title.write": "작성",
   "ui.messagePart.option.typeOwnAnswer": "직접 답변 입력",

--- a/packages/ui/src/i18n/nl.ts
+++ b/packages/ui/src/i18n/nl.ts
@@ -69,6 +69,8 @@ export const dict: Record<string, string> = {
   "ui.sessionTurn.status.consideringNextSteps": "Volgende stappen overwegen",
 
   "ui.messagePart.diagnostic.error": "Fout",
+  "ui.messagePart.mcp.input": "Invoer",
+  "ui.messagePart.mcp.output": "Uitvoer",
   "ui.messagePart.title.edit": "Bewerken",
   "ui.messagePart.title.write": "Schrijven",
   "ui.messagePart.option.typeOwnAnswer": "Typ je eigen antwoord",

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -79,6 +79,8 @@ export const dict: Record<Keys, string> = {
   "ui.messagePart.context.list.one": "{{count}} liste",
   "ui.messagePart.context.list.other": "{{count}} lister",
   "ui.messagePart.diagnostic.error": "Feil",
+  "ui.messagePart.mcp.input": "Inndata",
+  "ui.messagePart.mcp.output": "Utdata",
   "ui.messagePart.title.edit": "Rediger",
   "ui.messagePart.title.write": "Skriv",
   "ui.messagePart.option.typeOwnAnswer": "Skriv ditt eget svar",

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -75,6 +75,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} lista",
   "ui.messagePart.context.list.other": "{{count}} listy",
   "ui.messagePart.diagnostic.error": "Błąd",
+  "ui.messagePart.mcp.input": "Wejście",
+  "ui.messagePart.mcp.output": "Wyjście",
   "ui.messagePart.title.edit": "Edycja",
   "ui.messagePart.title.write": "Pisanie",
   "ui.messagePart.option.typeOwnAnswer": "Wpisz własną odpowiedź",

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -75,6 +75,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} список",
   "ui.messagePart.context.list.other": "{{count}} списков",
   "ui.messagePart.diagnostic.error": "Ошибка",
+  "ui.messagePart.mcp.input": "Ввод",
+  "ui.messagePart.mcp.output": "Вывод",
   "ui.messagePart.title.edit": "Редактировать",
   "ui.messagePart.title.write": "Написать",
   "ui.messagePart.option.typeOwnAnswer": "Введите свой ответ",

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -77,6 +77,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "รายการ {{count}} รายการ",
   "ui.messagePart.context.list.other": "รายการ {{count}} รายการ",
   "ui.messagePart.diagnostic.error": "ข้อผิดพลาด",
+  "ui.messagePart.mcp.input": "อินพุต",
+  "ui.messagePart.mcp.output": "เอาต์พุต",
   "ui.messagePart.title.edit": "แก้ไข",
   "ui.messagePart.title.write": "เขียน",
   "ui.messagePart.option.typeOwnAnswer": "พิมพ์คำตอบของคุณเอง",

--- a/packages/ui/src/i18n/tr.ts
+++ b/packages/ui/src/i18n/tr.ts
@@ -82,6 +82,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} liste",
   "ui.messagePart.context.list.other": "{{count}} liste",
   "ui.messagePart.diagnostic.error": "Hata",
+  "ui.messagePart.mcp.input": "Giriş",
+  "ui.messagePart.mcp.output": "Çıkış",
   "ui.messagePart.title.edit": "Düzenle",
   "ui.messagePart.title.write": "Yaz",
   "ui.messagePart.option.typeOwnAnswer": "Kendi cevabınızı yazın",

--- a/packages/ui/src/i18n/uk.ts
+++ b/packages/ui/src/i18n/uk.ts
@@ -82,6 +82,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} список",
   "ui.messagePart.context.list.other": "{{count}} списків",
   "ui.messagePart.diagnostic.error": "Помилка",
+  "ui.messagePart.mcp.input": "Вхід",
+  "ui.messagePart.mcp.output": "Вихід",
   "ui.messagePart.title.edit": "Редагувати",
   "ui.messagePart.title.write": "Записати",
   "ui.messagePart.option.typeOwnAnswer": "Введіть власну відповідь",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -80,6 +80,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} 个列表",
   "ui.messagePart.context.list.other": "{{count}} 个列表",
   "ui.messagePart.diagnostic.error": "错误",
+  "ui.messagePart.mcp.input": "输入",
+  "ui.messagePart.mcp.output": "输出",
   "ui.messagePart.title.edit": "编辑",
   "ui.messagePart.title.write": "写入",
   "ui.messagePart.option.typeOwnAnswer": "输入自己的答案",

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -80,6 +80,8 @@ export const dict = {
   "ui.messagePart.context.list.one": "{{count}} 個清單",
   "ui.messagePart.context.list.other": "{{count}} 個清單",
   "ui.messagePart.diagnostic.error": "錯誤",
+  "ui.messagePart.mcp.input": "輸入",
+  "ui.messagePart.mcp.output": "輸出",
   "ui.messagePart.title.edit": "編輯",
   "ui.messagePart.title.write": "寫入",
   "ui.messagePart.option.typeOwnAnswer": "輸入自己的答案",


### PR DESCRIPTION
…d improved styling

- Add subtitle and args display to MCP tool triggers for better context
- Separate input and output sections with labels and dividers
- Format input and output as JSON with proper syntax highlighting
- Reposition copy button tooltip to prevent clipping in tool output
- Add styling for MCP section labels and tool dividers

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

I added some more information to each MCP tool calls that the agent makes during a chat session with the user. The reason for this is to include the inputs that the agent has supplied to a MCP tool for improved understanding of why certain MCP tool calls gave certain outputs and also improved the readability by using JSON syntax highlighting/formatting on both inputs and outputs to a MCP tool call.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

All I did was to essentially mirror similar behavior as observed in the legacy version of Kilo Code when it comes to displaying both inputs and outputs for each made MCP tool call. Whether it is the best practice now and/or it is supposed to look differently from now on in the new version of Kilo Code is left open for further discussion.

## Screenshots

| before | after |
| ------ | ----- |
|   <img width="269" height="669" alt="image" src="https://github.com/user-attachments/assets/eafa1b98-5b64-48b8-9dc0-8ee57650240e" /> |    <img width="359" height="564" alt="image" src="https://github.com/user-attachments/assets/98eecab5-898a-458a-bd57-0cfa5651bf86" /> |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

All I did was to start two terminals from the main VS Code window using following commands:

- Terminal 1: `cd packages/kilo-vscode && bun run watch`
- Terminal 2: `bun run extension -- --no-build --wait`

The command run in second terminal should then open a "Extension Host Development" VS Code window and then you can add any random MCP (in my case, I had already added a globally configured MCP that I just used for testing) and try to make calls with it to observe the enhanced appearance of the MCP tool calls in some chat session.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
