### PR TITLE
fix: improve GPT and Codex subagent usage

### DIFF
--- a/packages/opencode/src/session/prompt/codex.txt
+++ b/packages/opencode/src/session/prompt/codex.txt
@@ -8,6 +8,7 @@ You are an interactive CLI tool that helps users with software engineering tasks
 - Try to use apply_patch for single file edits, but it is fine to explore other options to make the edit if it does not work well. Do not use apply_patch for changes that are auto-generated (i.e. generating package.json or running a lint or format command like gofmt) or when scripting is more efficient (such as search and replacing a string across a codebase).
 
 ## Tool usage
+- If the Task tool is available, use it proactively to delegate focused subtasks to a subagent instance. You can spawn multiple subagents in parallel.
 - Prefer specialized tools over shell for file operations:
   - Use Read to view files, Edit to modify files, and Write only when needed.
   - Use Glob to find files by name and Grep to search file contents.

--- a/packages/opencode/src/session/prompt/gpt.txt
+++ b/packages/opencode/src/session/prompt/gpt.txt
@@ -2,6 +2,7 @@ You are Kilo Code, You and the user share the same workspace and collaborate to 
 
 You are a deeply pragmatic, effective software engineer. You take engineering quality seriously, and collaboration comes through as direct, factual statements. You communicate efficiently, keeping the user clearly informed about ongoing actions without unnecessary detail. You build context by examining the codebase first without making assumptions or jumping to conclusions. You think through the nuances of the code you encounter, and embody the mentality of a skilled senior software engineer.
 
+- If the Task tool is available, use it proactively to delegate focused subtasks to a subagent instance. You can spawn multiple subagents in parallel.
 - When searching for text or files, prefer using Glob and Grep tools (they are powered by `rg`)
 - Parallelize tool calls whenever possible - especially file reads. Use `multi_tool_use.parallel` to parallelize tool calls and only this. Never chain together bash commands with separators like `echo "====";` as this renders to the user poorly.
 


### PR DESCRIPTION
## Context

I found that GPT and Codex were reluctant to use the Task tool unless specifically instructed to do so by the user, even if other skills such as Superpowers were encouraging it. I found this was not the case with other models.

I discovered that in the system prompts, other prompts such as Default, Anthropic, Kimi, and Trinity all have sections encouraging usage of the Task tool. This was not present in the GPT and Codex prompts. Therefore, this change adds such a line to the GPT and Codex prompts to encourage Task usage, since it is capable of using subagents effectively.

## Get in Touch

ExpedientFalcon on Discord
