### PR TITLE
fix(vscode): surface config save errors instead of silently swallowing them

### DIFF
--- a/.changeset/settings-save-error.md
+++ b/.changeset/settings-save-error.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show an inline error in the Settings save bar when the configuration fails to save (for example, due to an invalid value) so the user can correct the config and retry instead of losing their unsaved changes silently.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2258,41 +2258,39 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       partial.disabled_providers !== undefined ||
       partial.enabled_providers !== undefined
 
-    // Belt-and-suspenders guard: prevent fetchAndSendConfig from sending a
-    // stale configLoaded while this write is in flight (the SSE-triggered reload
-    // races with the async config.update() write on the CLI backend).
+    // Guard against fetchAndSendConfig pushing stale data while the write is in flight.
     this.pending++
+
+    // Phase 1: write. Errors here = real save failures the user can fix + retry.
     try {
-      // Reject all pending permissions and questions across every provider
-      // so their CLI-side Promises resolve before disposeAll() wipes
-      // Instance state.  Throws on failure to abort the config save.
       await this.connectionService.drainPendingPrompts()
-
       await this.client.global.config.update({ config: partial }, { throwOnError: true })
-
-      // Re-fetch the full merged config (global + project + all layers) so the
-      // webview receives the complete resolved config, not just global-only data.
-      // Config.state is reset by updateGlobal (via Instance.resetStateEntry) so
-      // config.get() returns fresh data without a full dispose cycle.
-      const dir = this.getWorkspaceDirectory()
-      const { data: merged } = await retry(() => this.client!.config.get({ directory: dir }, { throwOnError: true }))
-
-      this.cachedConfigMessage = { type: "configLoaded", config: merged }
-      this.postMessage({ type: "configUpdated", config: merged })
-
-      if (refreshProviders) {
-        await this.fetchAndSendProviders()
-      }
     } catch (error) {
       console.error("[Kilo New] KiloProvider: Failed to update config:", error)
-      // Send a dedicated failure message so the webview can surface the error
-      // inline in the settings save bar and keep the draft + isDirty state so
-      // the user can correct the invalid config and retry.
       this.postMessage({
         type: "configUpdateFailed",
         message: getErrorMessage(error) || "Failed to update config",
         details: getConfigErrorDetails(error),
       })
+      this.pending--
+      return
+    }
+
+    // Phase 2: refresh. Config is already on disk — post-write errors are
+    // transient, so send an optimistic configUpdated to clear the webview's
+    // saving/draft state. SSE global.config.updated pushes the real data next.
+    try {
+      const dir = this.getWorkspaceDirectory()
+      const { data: merged } = await retry(() => this.client!.config.get({ directory: dir }, { throwOnError: true }))
+      this.cachedConfigMessage = { type: "configLoaded", config: merged }
+      this.postMessage({ type: "configUpdated", config: merged })
+      if (refreshProviders) await this.fetchAndSendProviders()
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Config write succeeded but post-write refresh failed:", error)
+      const cached = (this.cachedConfigMessage as { config?: unknown } | null)?.config
+      const optimistic =
+        cached && typeof cached === "object" ? { ...(cached as Record<string, unknown>), ...partial } : partial
+      this.postMessage({ type: "configUpdated", config: optimistic })
     } finally {
       this.pending--
     }

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -24,6 +24,7 @@ import {
   buildSettingPath,
   mapSSEEventToWebviewMessage,
   getErrorMessage,
+  getConfigErrorDetails,
   isEventFromForeignProject,
   MessageConfirmation,
   runWithMessageConfirmation,
@@ -2248,7 +2249,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    */
   private async handleUpdateConfig(partial: Partial<Config>): Promise<void> {
     if (!this.client || this.connectionState !== "connected") {
-      this.postMessage({ type: "error", message: "Not connected to CLI backend" })
+      this.postMessage({ type: "configUpdateFailed", message: "Not connected to CLI backend" })
       return
     }
 
@@ -2284,15 +2285,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       }
     } catch (error) {
       console.error("[Kilo New] KiloProvider: Failed to update config:", error)
+      // Send a dedicated failure message so the webview can surface the error
+      // inline in the settings save bar and keep the draft + isDirty state so
+      // the user can correct the invalid config and retry.
       this.postMessage({
-        type: "error",
+        type: "configUpdateFailed",
         message: getErrorMessage(error) || "Failed to update config",
+        details: getConfigErrorDetails(error),
       })
-      // Send configUpdated with the last known good config so the webview
-      // clears its saving flag and reverts optimistic state.
-      if (this.cachedConfigMessage) {
-        this.postMessage({ type: "configUpdated", config: (this.cachedConfigMessage as { config: unknown }).config })
-      }
     } finally {
       this.pending--
     }

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -1,4 +1,5 @@
 import type { Session, Agent, Event, ProviderListResponse } from "@kilocode/sdk/v2/client"
+import { prettifyError } from "zod/v4"
 import type { CloudSessionMessage } from "./services/cli-backend/types"
 import type { PartBatch, PartUpdate } from "./kilo-provider/session-stream-scheduler"
 
@@ -81,31 +82,28 @@ export function getErrorMessage(error: unknown): string {
  * the file path and every Zod issue. Used as the expandable details next to
  * the short getErrorMessage() summary.
  *
+ * Zod issues are formatted via zod's built-in `prettifyError` so the output
+ * matches Zod's canonical format (array indices rendered as `foo[0].bar`, etc).
+ *
  * Returns undefined when the error doesn't carry structured config data —
  * callers should omit the details section in that case.
  */
 export function getConfigErrorDetails(error: unknown): string | undefined {
   if (!error || typeof error !== "object") return undefined
-  const obj = error as Record<string, unknown>
-  const data = obj.data
+  const data = (error as Record<string, unknown>).data
   if (!data || typeof data !== "object") return undefined
   const scoped = data as Record<string, unknown>
   const path = typeof scoped.path === "string" ? scoped.path : undefined
   const issues = Array.isArray(scoped.issues) ? scoped.issues : undefined
-  if (!path && !issues) return undefined
+  if (!path && (!issues || issues.length === 0)) return undefined
 
   const out: string[] = []
   if (path) out.push(`File: ${path}`)
   if (issues && issues.length > 0) {
     if (out.length > 0) out.push("")
-    out.push(issues.length === 1 ? "Issue:" : `${issues.length} issues:`)
-    for (const raw of issues) {
-      if (!raw || typeof raw !== "object") continue
-      const issue = raw as Record<string, unknown>
-      const msg = typeof issue.message === "string" ? issue.message : String(issue)
-      const ipath = Array.isArray(issue.path) ? issue.path.join(".") : ""
-      out.push(ipath ? `  • ${ipath}: ${msg}` : `  • ${msg}`)
-    }
+    // prettifyError accepts any object with an `issues` array; the cast is
+    // safe because it only reads the issues field.
+    out.push(prettifyError({ issues } as Parameters<typeof prettifyError>[0]))
   }
   return out.join("\n")
 }

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -17,48 +17,97 @@ export type ProviderInfo = ProviderListResponse["all"][number]
  * - NotFoundError: { name: "NotFoundError", data: { message: "..." } }
  * - Plain string (raw text response)
  */
+/** Extract a message from the first element of an array of strings or `{ message }` objects. */
+function firstMessage(arr: unknown): string | undefined {
+  if (!Array.isArray(arr) || arr.length === 0) return undefined
+  const first = arr[0]
+  if (typeof first === "string") return first
+  if (first && typeof first === "object") {
+    const msg = (first as Record<string, unknown>).message
+    if (typeof msg === "string") return msg
+  }
+  return undefined
+}
+
+/** Extract a message from SDK error `data` field shapes (NotFoundError, ConfigInvalidError, Hono validator). */
+function messageFromData(data: Record<string, unknown>): string | undefined {
+  if (typeof data.message === "string") return data.message
+  // ConfigInvalidError: { path, issues: [{ message, path, code }] }
+  const fromIssues = firstMessage(data.issues)
+  if (fromIssues) return fromIssues
+  // Hono validator: { data, error: [...], success: false }
+  return firstMessage(data.error)
+}
+
+function safeStringify(value: unknown): string | undefined {
+  try {
+    const json = JSON.stringify(value)
+    if (json !== "{}" && json.length < 500) return json
+  } catch (err) {
+    console.warn("[Kilo New] getErrorMessage: JSON.stringify failed", err)
+  }
+  return undefined
+}
+
 export function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message
   if (typeof error === "string") return error
-  if (error && typeof error === "object") {
-    const obj = error as Record<string, unknown>
-    // Direct .message field
-    if (typeof obj.message === "string") return obj.message
-    // Direct .error field (string)
-    if (typeof obj.error === "string") return obj.error
-    // SDK throwOnError shape: { error: { message: "..." } } or { error: { ... } }
-    if (obj.error && typeof obj.error === "object") {
-      const nested = obj.error as Record<string, unknown>
-      if (typeof nested.message === "string") return nested.message
-    }
-    // NotFoundError shape: { data: { message: "..." } }
-    if (obj.data && typeof obj.data === "object") {
-      const data = obj.data as Record<string, unknown>
-      if (typeof data.message === "string") return data.message
-      // Hono validator shape: { data: ..., error: [...], success: false }
-      if (Array.isArray(data.error) && data.error.length > 0) {
-        const first = data.error[0]
-        if (typeof first === "string") return first
-        if (first && typeof first === "object" && typeof (first as Record<string, unknown>).message === "string") {
-          return (first as Record<string, unknown>).message as string
-        }
-      }
-    }
-    // BadRequestError shape: { errors: [{ message: "..." }] }
-    if (Array.isArray(obj.errors) && obj.errors.length > 0) {
-      const first = obj.errors[0]
-      if (typeof first === "string") return first
-      if (first && typeof first.message === "string") return first.message
-    }
-    // Last resort: try JSON.stringify for debuggability
-    try {
-      const json = JSON.stringify(error)
-      if (json !== "{}" && json.length < 500) return json
-    } catch (err) {
-      console.warn("[Kilo New] getErrorMessage: JSON.stringify failed", err)
+  if (!error || typeof error !== "object") return String(error)
+
+  const obj = error as Record<string, unknown>
+  if (typeof obj.message === "string") return obj.message
+  if (typeof obj.error === "string") return obj.error
+
+  // SDK throwOnError shape: { error: { message: "..." } }
+  if (obj.error && typeof obj.error === "object") {
+    const nested = (obj.error as Record<string, unknown>).message
+    if (typeof nested === "string") return nested
+  }
+
+  if (obj.data && typeof obj.data === "object") {
+    const fromData = messageFromData(obj.data as Record<string, unknown>)
+    if (fromData) return fromData
+  }
+
+  // BadRequestError: { errors: [...] }
+  const fromErrors = firstMessage(obj.errors)
+  if (fromErrors) return fromErrors
+
+  return safeStringify(error) ?? String(error)
+}
+
+/**
+ * Format a full human-readable breakdown of a config save failure, including
+ * the file path and every Zod issue. Used as the expandable details next to
+ * the short getErrorMessage() summary.
+ *
+ * Returns undefined when the error doesn't carry structured config data —
+ * callers should omit the details section in that case.
+ */
+export function getConfigErrorDetails(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined
+  const obj = error as Record<string, unknown>
+  const data = obj.data
+  if (!data || typeof data !== "object") return undefined
+  const scoped = data as Record<string, unknown>
+  const path = typeof scoped.path === "string" ? scoped.path : undefined
+  const issues = Array.isArray(scoped.issues) ? scoped.issues : undefined
+  if (!path && !issues) return undefined
+
+  const out: string[] = []
+  if (path) out.push(`File: ${path}`)
+  if (issues && issues.length > 0) {
+    out.push("")
+    out.push(issues.length === 1 ? "Issue:" : `${issues.length} issues:`)
+    for (const raw of issues) {
+      if (!raw || typeof raw !== "object") continue
+      const issue = raw as Record<string, unknown>
+      const msg = typeof issue.message === "string" ? issue.message : String(issue)
+      const ipath = Array.isArray(issue.path) ? issue.path.join(".") : ""
+      out.push(ipath ? `  • ${ipath}: ${msg}` : `  • ${msg}`)
     }
   }
-  return String(error)
+  return out.join("\n")
 }
 
 export class MessageConfirmation {

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -97,7 +97,7 @@ export function getConfigErrorDetails(error: unknown): string | undefined {
   const out: string[] = []
   if (path) out.push(`File: ${path}`)
   if (issues && issues.length > 0) {
-    out.push("")
+    if (out.length > 0) out.push("")
     out.push(issues.length === 1 ? "Issue:" : `${issues.length} issues:`)
     for (const raw of issues) {
       if (!raw || typeof raw !== "object") continue

--- a/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
@@ -9,6 +9,8 @@ import {
   mapCloudSessionMessageToWebviewMessage,
   MessageConfirmation,
   mergeFileSearchResults,
+  getErrorMessage,
+  getConfigErrorDetails,
   type ProviderInfo,
 } from "../../src/kilo-provider-utils"
 import type { CloudSessionMessage } from "../../src/services/cli-backend/types"
@@ -656,5 +658,146 @@ describe("mergeFileSearchResults", () => {
       active: "src/utils/path.ts",
     })
     expect(result).toEqual(["src/utils/path.ts", "src/index.ts"])
+  })
+})
+
+describe("getErrorMessage", () => {
+  it("extracts message from an Error instance", () => {
+    expect(getErrorMessage(new Error("boom"))).toBe("boom")
+  })
+
+  it("returns the string as-is", () => {
+    expect(getErrorMessage("plain text failure")).toBe("plain text failure")
+  })
+
+  it("reads a direct .message field", () => {
+    expect(getErrorMessage({ message: "bad input" })).toBe("bad input")
+  })
+
+  it("reads a direct .error string field", () => {
+    expect(getErrorMessage({ error: "nope" })).toBe("nope")
+  })
+
+  it("reads SDK throwOnError shape { error: { message } }", () => {
+    expect(getErrorMessage({ error: { message: "sdk said no" } })).toBe("sdk said no")
+  })
+
+  it("reads NotFoundError shape { data: { message } }", () => {
+    expect(getErrorMessage({ name: "NotFoundError", data: { message: "not found" } })).toBe("not found")
+  })
+
+  it("reads the first Zod issue message from ConfigInvalidError", () => {
+    const err = {
+      name: "ConfigInvalidError",
+      data: {
+        path: "/Users/me/.config/kilo/kilo.json",
+        issues: [
+          { code: "unrecognized_keys", keys: ["indexing"], path: [], message: 'Unrecognized key: "indexing"' },
+          { code: "invalid_type", path: ["timeout"], message: "Expected number" },
+        ],
+      },
+    }
+    expect(getErrorMessage(err)).toBe('Unrecognized key: "indexing"')
+  })
+
+  it("reads Hono validator shape { data: { error: [{ message }] } }", () => {
+    const err = { data: { error: [{ message: "required" }] }, success: false }
+    expect(getErrorMessage(err)).toBe("required")
+  })
+
+  it("reads Hono validator shape with string errors", () => {
+    expect(getErrorMessage({ data: { error: ["bad field"] } })).toBe("bad field")
+  })
+
+  it("reads BadRequestError shape { errors: [{ message }] }", () => {
+    expect(getErrorMessage({ errors: [{ message: "first error" }, { message: "second" }] })).toBe("first error")
+  })
+
+  it("reads BadRequestError shape with string errors", () => {
+    expect(getErrorMessage({ errors: ["boom"] })).toBe("boom")
+  })
+
+  it("falls back to JSON for unknown object shapes", () => {
+    expect(getErrorMessage({ weird: true, code: 42 })).toBe('{"weird":true,"code":42}')
+  })
+
+  it("falls back to String() for non-serializable values", () => {
+    expect(getErrorMessage(undefined)).toBe("undefined")
+    expect(getErrorMessage(null)).toBe("null")
+    expect(getErrorMessage(42)).toBe("42")
+  })
+
+  it("skips JSON fallback for empty objects", () => {
+    expect(getErrorMessage({})).toBe("[object Object]")
+  })
+
+  it("prefers .message over nested shapes", () => {
+    const err = { message: "outer", data: { issues: [{ message: "inner" }] } }
+    expect(getErrorMessage(err)).toBe("outer")
+  })
+
+  it("falls through when the first issue has no message", () => {
+    // firstMessage only inspects index 0, so an invalid first entry causes the
+    // branch to skip and the JSON fallback kicks in.
+    const err = { data: { issues: [{ code: "bad" }] } }
+    expect(getErrorMessage(err)).toBe('{"data":{"issues":[{"code":"bad"}]}}')
+  })
+})
+
+describe("getConfigErrorDetails", () => {
+  it("returns undefined for non-object errors", () => {
+    expect(getConfigErrorDetails("oops")).toBeUndefined()
+    expect(getConfigErrorDetails(undefined)).toBeUndefined()
+    expect(getConfigErrorDetails(null)).toBeUndefined()
+    expect(getConfigErrorDetails(42)).toBeUndefined()
+  })
+
+  it("returns undefined when .data is missing", () => {
+    expect(getConfigErrorDetails({ message: "hi" })).toBeUndefined()
+  })
+
+  it("returns undefined when .data has no path or issues", () => {
+    expect(getConfigErrorDetails({ data: { unrelated: true } })).toBeUndefined()
+  })
+
+  it("formats a single-issue ConfigInvalidError", () => {
+    const err = {
+      data: {
+        path: "/home/me/.config/kilo/kilo.json",
+        issues: [{ code: "unrecognized_keys", keys: ["indexing"], path: [], message: 'Unrecognized key: "indexing"' }],
+      },
+    }
+    expect(getConfigErrorDetails(err)).toBe(
+      'File: /home/me/.config/kilo/kilo.json\n\nIssue:\n  • Unrecognized key: "indexing"',
+    )
+  })
+
+  it("formats a multi-issue ConfigInvalidError with paths", () => {
+    const err = {
+      data: {
+        path: "/cfg.json",
+        issues: [
+          { path: ["timeout"], message: "Expected number" },
+          { path: ["nested", "field"], message: "Required" },
+        ],
+      },
+    }
+    expect(getConfigErrorDetails(err)).toBe(
+      "File: /cfg.json\n\n2 issues:\n  • timeout: Expected number\n  • nested.field: Required",
+    )
+  })
+
+  it("omits the path line when only issues are present", () => {
+    const err = { data: { issues: [{ path: [], message: "something" }] } }
+    expect(getConfigErrorDetails(err)).toBe("Issue:\n  • something")
+  })
+
+  it("omits the issues section when only the path is present", () => {
+    expect(getConfigErrorDetails({ data: { path: "/cfg.json" } })).toBe("File: /cfg.json")
+  })
+
+  it("skips non-object issues entries", () => {
+    const err = { data: { path: "/c", issues: [null, "bad", { message: "ok" }] } }
+    expect(getConfigErrorDetails(err)).toBe("File: /c\n\n3 issues:\n  • ok")
   })
 })

--- a/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
@@ -767,37 +767,34 @@ describe("getConfigErrorDetails", () => {
         issues: [{ code: "unrecognized_keys", keys: ["indexing"], path: [], message: 'Unrecognized key: "indexing"' }],
       },
     }
-    expect(getConfigErrorDetails(err)).toBe(
-      'File: /home/me/.config/kilo/kilo.json\n\nIssue:\n  • Unrecognized key: "indexing"',
-    )
+    expect(getConfigErrorDetails(err)).toBe('File: /home/me/.config/kilo/kilo.json\n\n✖ Unrecognized key: "indexing"')
   })
 
-  it("formats a multi-issue ConfigInvalidError with paths", () => {
+  it("formats a multi-issue ConfigInvalidError with paths (including array indices)", () => {
     const err = {
       data: {
         path: "/cfg.json",
         issues: [
           { path: ["timeout"], message: "Expected number" },
-          { path: ["nested", "field"], message: "Required" },
+          { path: ["agents", 0, "name"], message: "Required" },
         ],
       },
     }
     expect(getConfigErrorDetails(err)).toBe(
-      "File: /cfg.json\n\n2 issues:\n  • timeout: Expected number\n  • nested.field: Required",
+      "File: /cfg.json\n\n✖ Expected number\n  → at timeout\n✖ Required\n  → at agents[0].name",
     )
   })
 
   it("omits the path line when only issues are present", () => {
     const err = { data: { issues: [{ path: [], message: "something" }] } }
-    expect(getConfigErrorDetails(err)).toBe("Issue:\n  • something")
+    expect(getConfigErrorDetails(err)).toBe("✖ something")
   })
 
   it("omits the issues section when only the path is present", () => {
     expect(getConfigErrorDetails({ data: { path: "/cfg.json" } })).toBe("File: /cfg.json")
   })
 
-  it("skips non-object issues entries", () => {
-    const err = { data: { path: "/c", issues: [null, "bad", { message: "ok" }] } }
-    expect(getConfigErrorDetails(err)).toBe("File: /c\n\n3 issues:\n  • ok")
+  it("returns undefined when issues array is empty and no path", () => {
+    expect(getConfigErrorDetails({ data: { issues: [] } })).toBeUndefined()
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
@@ -34,9 +34,10 @@ const Settings: Component<SettingsProps> = (props) => {
   const server = useServer()
   const language = useLanguage()
   const vscode = useVSCode()
-  const { isDirty, saveConfig, discardConfig } = useConfig()
+  const { isDirty, saving, saveError, saveConfig, discardConfig } = useConfig()
   const session = useSession()
   const [active, setActive] = createSignal(props.tab ?? "models")
+  const [errorExpanded, setErrorExpanded] = createSignal(false)
 
   const busyCount = () => Object.values(session.allStatusMap()).filter((s) => s.type === "busy").length
 
@@ -222,19 +223,46 @@ const Settings: Component<SettingsProps> = (props) => {
       </Tabs>
 
       {/* Save bar — slides in when there are unsaved config changes */}
-      <div
-        class={`settings-save-bar${isDirty() ? " settings-save-bar--visible" : ""}`}
-        inert={!isDirty() || undefined}
-        aria-hidden={!isDirty()}
-      >
-        <span class="settings-save-bar-label">{language.t("settings.saveBar.unsavedChanges")}</span>
-        <Button variant="ghost" size="small" onClick={discardConfig}>
-          {language.t("settings.saveBar.discard")}
-        </Button>
-        <Button variant="primary" size="small" onClick={handleSave}>
-          {language.t("settings.saveBar.save")}
-        </Button>
-      </div>
+      <Show when={isDirty()}>
+        <div class="settings-save-bar-wrap">
+          <Show when={saveError()}>
+            {(err) => (
+              <div class="settings-save-bar-error">
+                <div
+                  class="settings-save-bar-error-header"
+                  onClick={() => setErrorExpanded((v) => !v)}
+                  role="button"
+                  aria-expanded={errorExpanded()}
+                >
+                  <span
+                    class={`settings-save-bar-error-chevron${
+                      errorExpanded() ? " settings-save-bar-error-chevron-expanded" : ""
+                    }`}
+                  >
+                    <Icon name="chevron-right" size="small" />
+                  </span>
+                  <span class="settings-save-bar-error-title">
+                    {language.t("settings.saveBar.saveFailed")}:{" "}
+                    <span class="settings-save-bar-error-firstline">{err().message}</span>
+                  </span>
+                </div>
+                <Show when={errorExpanded()}>
+                  <pre class="settings-save-bar-error-details">{err().details ?? err().message}</pre>
+                </Show>
+              </div>
+            )}
+          </Show>
+          <div class="settings-save-bar">
+            <span class="settings-save-bar-label">{language.t("settings.saveBar.unsavedChanges")}</span>
+            <Button variant="ghost" size="small" onClick={discardConfig} disabled={saving()}>
+              {language.t("settings.saveBar.discard")}
+            </Button>
+            <Button variant="primary" size="small" onClick={handleSave} disabled={saving()}>
+              {saving() ? language.t("settings.saveBar.saving") : language.t("settings.saveBar.save")}
+            </Button>
+          </div>
+        </div>
+      </Show>
     </div>
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/context/config.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/config.tsx
@@ -14,10 +14,17 @@ import { useVSCode } from "./vscode"
 import type { Config, ExtensionMessage } from "../types/messages"
 import { deepMerge, stripNulls, resolveConfig } from "../utils/config-utils"
 
+export interface SaveError {
+  message: string
+  details?: string
+}
+
 interface ConfigContextValue {
   config: Accessor<Config>
   loading: Accessor<boolean>
   isDirty: Accessor<boolean>
+  saving: Accessor<boolean>
+  saveError: Accessor<SaveError | null>
   updateConfig: (partial: Partial<Config>) => void
   saveConfig: () => void
   discardConfig: () => void
@@ -36,7 +43,10 @@ export const ConfigProvider: ParentComponent = (props) => {
   const [saved, setSaved] = createSignal<Config>({})
   // True while a saveConfig() write is in-flight — used to clear draft on success
   // and to guard against stale configLoaded messages overwriting optimistic state.
-  let saving = false
+  const [saving, setSaving] = createSignal(false)
+  // Error from the most recent saveConfig() attempt, or null if no error.
+  // Cleared when the user edits the draft again or starts a new save.
+  const [saveError, setSaveError] = createSignal<SaveError | null>(null)
 
   // Register handler immediately (not in onMount) so we never miss
   // a configLoaded message that arrives before the DOM mount.
@@ -44,7 +54,7 @@ export const ConfigProvider: ParentComponent = (props) => {
     if (message.type === "configLoaded") {
       // Skip if a save is in-flight — a stale configLoaded must not overwrite
       // the optimistically-updated state while the write is being confirmed.
-      if (saving) return
+      if (saving()) return
       // Re-apply the draft on top so pending changes (e.g. a toggled switch the
       // user hasn't saved yet) stay visible instead of snapping back.
       setConfig(resolveConfig(message.config, draft(), isDirty()))
@@ -53,12 +63,13 @@ export const ConfigProvider: ParentComponent = (props) => {
       return
     }
     if (message.type === "configUpdated") {
-      if (saving) {
+      if (saving()) {
         // This configUpdated is the confirmation of our saveConfig() write.
         // Clear the draft now that the server has confirmed the write.
-        saving = false
+        setSaving(false)
         setDraft({})
         setIsDirty(false)
+        setSaveError(null)
         setConfig(message.config)
       } else {
         // configUpdated from a different source (e.g. PermissionDock save).
@@ -66,6 +77,13 @@ export const ConfigProvider: ParentComponent = (props) => {
         setConfig(resolveConfig(message.config, draft(), isDirty()))
       }
       setSaved(message.config)
+      return
+    }
+    if (message.type === "configUpdateFailed") {
+      // The write was rejected (e.g. schema validation) — surface the error
+      // and keep the draft + isDirty so the user can correct and retry.
+      setSaving(false)
+      setSaveError({ message: message.message, details: message.details })
       return
     }
   })
@@ -102,6 +120,9 @@ export const ConfigProvider: ParentComponent = (props) => {
     // Accumulate in draft — will be sent on saveConfig()
     setDraft((prev) => deepMerge(prev as Config, partial))
     setIsDirty(true)
+    // Clear any stale error from a previous failed save — the user is editing
+    // again, so the old error message no longer reflects the current draft.
+    setSaveError(null)
   }
 
   function saveConfig() {
@@ -109,7 +130,8 @@ export const ConfigProvider: ParentComponent = (props) => {
     if (Object.keys(changes).length === 0) return
     // Don't clear draft/isDirty yet — wait for configUpdated confirmation.
     // If the write fails, the save bar stays visible so the user can retry.
-    saving = true
+    setSaving(true)
+    setSaveError(null)
     vscode.postMessage({ type: "updateConfig", config: changes })
   }
 
@@ -117,12 +139,15 @@ export const ConfigProvider: ParentComponent = (props) => {
     setConfig(saved())
     setDraft({})
     setIsDirty(false)
+    setSaveError(null)
   }
 
   const value: ConfigContextValue = {
     config,
     loading,
     isDirty,
+    saving,
+    saveError,
     updateConfig,
     saveConfig,
     discardConfig,

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1387,6 +1387,8 @@ export const dict = {
   "settings.saveBar.warning.many": "عدة جلسات تعمل وستتوقف",
   "settings.saveBar.saveAnyway": "حفظ على أي حال",
   "settings.saveBar.cancel": "إلغاء",
+  "settings.saveBar.saving": "جارٍ الحفظ…",
+  "settings.saveBar.saveFailed": "تعذر حفظ الإعدادات",
   "notifications.action.next": "التالي",
   "notifications.action.close": "إغلاق",
   "notifications.action.tryModel": "جرّب {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1416,6 +1416,8 @@ export const dict = {
   "settings.saveBar.warning.many": "Várias sessões estão em execução e serão interrompidas",
   "settings.saveBar.saveAnyway": "Salvar mesmo assim",
   "settings.saveBar.cancel": "Cancelar",
+  "settings.saveBar.saving": "Salvando…",
+  "settings.saveBar.saveFailed": "Não foi possível salvar as configurações",
   "notifications.action.next": "Próximo",
   "notifications.action.close": "Fechar",
   "notifications.action.tryModel": "Experimentar {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1412,6 +1412,8 @@ export const dict = {
   "settings.saveBar.warning.many": "Nekoliko sesija je pokrenuto i bit će prekinuto",
   "settings.saveBar.saveAnyway": "Spremi svejedno",
   "settings.saveBar.cancel": "Otkaži",
+  "settings.saveBar.saving": "Spremanje…",
+  "settings.saveBar.saveFailed": "Postavke nije moguće spremiti",
   "notifications.action.next": "Sljedeći",
   "notifications.action.close": "Zatvori",
   "notifications.action.tryModel": "Probaj {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1403,6 +1403,8 @@ export const dict = {
   "settings.saveBar.warning.many": "Flere sessioner kører og vil blive afbrudt",
   "settings.saveBar.saveAnyway": "Gem alligevel",
   "settings.saveBar.cancel": "Annuller",
+  "settings.saveBar.saving": "Gemmer…",
+  "settings.saveBar.saveFailed": "Kunne ikke gemme indstillinger",
   "notifications.action.next": "Næste",
   "notifications.action.close": "Luk",
   "notifications.action.tryModel": "Prøv {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1430,6 +1430,8 @@ export const dict = {
   "settings.saveBar.warning.many": "Mehrere Sitzungen laufen und werden unterbrochen",
   "settings.saveBar.saveAnyway": "Trotzdem speichern",
   "settings.saveBar.cancel": "Abbrechen",
+  "settings.saveBar.saving": "Speichern…",
+  "settings.saveBar.saveFailed": "Einstellungen konnten nicht gespeichert werden",
   "notifications.action.next": "Weiter",
   "notifications.action.close": "Schließen",
   "notifications.action.tryModel": "{{model}} ausprobieren",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1408,10 +1408,12 @@ export const dict = {
   "settings.saveBar.unsavedChanges": "Unsaved changes",
   "settings.saveBar.discard": "Discard",
   "settings.saveBar.save": "Save",
+  "settings.saveBar.saving": "Saving…",
   "settings.saveBar.warning.one": "One session is running and will be interrupted",
   "settings.saveBar.warning.many": "Several sessions are running and will be interrupted",
   "settings.saveBar.saveAnyway": "Save anyway",
   "settings.saveBar.cancel": "Cancel",
+  "settings.saveBar.saveFailed": "Couldn't save settings",
 
   "notifications.action.next": "Next",
   "notifications.action.close": "Close",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1419,6 +1419,8 @@ export const dict = {
   "settings.saveBar.warning.many": "Varias sesiones están en ejecución y se interrumpirán",
   "settings.saveBar.saveAnyway": "Guardar de todas formas",
   "settings.saveBar.cancel": "Cancelar",
+  "settings.saveBar.saving": "Guardando…",
+  "settings.saveBar.saveFailed": "No se pudieron guardar los ajustes",
   "notifications.action.next": "Siguiente",
   "notifications.action.close": "Cerrar",
   "notifications.action.tryModel": "Probar {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1434,6 +1434,8 @@ export const dict = {
   "settings.saveBar.warning.one": "Une session est en cours et sera interrompue",
   "settings.saveBar.warning.many": "Plusieurs sessions sont en cours et seront interrompues",
   "settings.saveBar.saveAnyway": "Enregistrer quand même",
+  "settings.saveBar.saving": "Enregistrement…",
+  "settings.saveBar.saveFailed": "Impossible d'enregistrer les paramètres",
   "settings.saveBar.cancel": "Annuler",
   "notifications.action.next": "Suivant",
   "notifications.action.close": "Fermer",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1402,6 +1402,8 @@ export const dict = {
   "settings.saveBar.warning.many": "複数のセッションが実行中で中断されます",
   "settings.saveBar.saveAnyway": "それでも保存",
   "settings.saveBar.cancel": "キャンセル",
+  "settings.saveBar.saving": "保存中…",
+  "settings.saveBar.saveFailed": "設定を保存できませんでした",
   "notifications.action.next": "次へ",
   "notifications.action.close": "閉じる",
   "notifications.action.tryModel": "{{model}}を試す",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1390,6 +1390,8 @@ export const dict = {
   "settings.saveBar.warning.many": "여러 세션이 실행 중이며 중단됩니다",
   "settings.saveBar.saveAnyway": "그래도 저장",
   "settings.saveBar.cancel": "취소",
+  "settings.saveBar.saving": "저장 중…",
+  "settings.saveBar.saveFailed": "설정을 저장할 수 없습니다",
   "notifications.action.next": "다음",
   "notifications.action.close": "닫기",
   "notifications.action.tryModel": "{{model}} 시도",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1397,6 +1397,8 @@ export const dict = {
   "settings.saveBar.warning.many": "Meerdere sessies zijn actief en worden onderbroken",
   "settings.saveBar.saveAnyway": "Toch opslaan",
   "settings.saveBar.cancel": "Annuleren",
+  "settings.saveBar.saving": "Bezig met opslaan…",
+  "settings.saveBar.saveFailed": "Instellingen konden niet worden opgeslagen",
   "notifications.action.next": "Volgende",
   "notifications.action.close": "Sluiten",
   "notifications.action.tryModel": "Probeer {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1401,6 +1401,8 @@ export const dict = {
   "settings.saveBar.warning.many": "Flere økter kjører og vil bli avbrutt",
   "settings.saveBar.saveAnyway": "Lagre uansett",
   "settings.saveBar.cancel": "Avbryt",
+  "settings.saveBar.saving": "Lagrer…",
+  "settings.saveBar.saveFailed": "Kunne ikke lagre innstillinger",
   "notifications.action.next": "Neste",
   "notifications.action.close": "Lukk",
   "notifications.action.tryModel": "Prøv {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1411,6 +1411,8 @@ export const dict = {
   "settings.saveBar.warning.many": "Kilka sesji jest uruchomionych i zostanie przerwanych",
   "settings.saveBar.saveAnyway": "Zapisz mimo to",
   "settings.saveBar.cancel": "Anuluj",
+  "settings.saveBar.saving": "Zapisywanie…",
+  "settings.saveBar.saveFailed": "Nie można zapisać ustawień",
   "notifications.action.next": "Następny",
   "notifications.action.close": "Zamknij",
   "notifications.action.tryModel": "Wypróbuj {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1410,6 +1410,8 @@ export const dict = {
   "settings.saveBar.warning.many": "Несколько сеансов выполняются и будут прерваны",
   "settings.saveBar.saveAnyway": "Сохранить в любом случае",
   "settings.saveBar.cancel": "Отмена",
+  "settings.saveBar.saving": "Сохранение…",
+  "settings.saveBar.saveFailed": "Не удалось сохранить настройки",
   "notifications.action.next": "Далее",
   "notifications.action.close": "Закрыть",
   "notifications.action.tryModel": "Попробовать {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1386,6 +1386,8 @@ export const dict = {
   "settings.saveBar.warning.many": "มีหลายเซสชันกำลังทำงานและจะถูกขัดจังหวะ",
   "settings.saveBar.saveAnyway": "บันทึกต่อไป",
   "settings.saveBar.cancel": "ยกเลิก",
+  "settings.saveBar.saving": "กำลังบันทึก…",
+  "settings.saveBar.saveFailed": "ไม่สามารถบันทึกการตั้งค่าได้",
   "notifications.action.next": "ถัดไป",
   "notifications.action.close": "ปิด",
   "notifications.action.tryModel": "ลองใช้ {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1389,6 +1389,8 @@ export const dict = {
   "settings.saveBar.warning.many": "Birden fazla oturum çalışıyor ve kesintiye uğrayacak",
   "settings.saveBar.saveAnyway": "Yine de kaydet",
   "settings.saveBar.cancel": "İptal",
+  "settings.saveBar.saving": "Kaydediliyor…",
+  "settings.saveBar.saveFailed": "Ayarlar kaydedilemedi",
   "notifications.action.next": "Sonraki",
   "notifications.action.close": "Kapat",
   "notifications.action.tryModel": "Dene {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1390,6 +1390,8 @@ export const dict = {
   "settings.saveBar.warning.many": "Кілька сесій виконуються і будуть перервані",
   "settings.saveBar.saveAnyway": "Зберегти все одно",
   "settings.saveBar.cancel": "Скасувати",
+  "settings.saveBar.saving": "Збереження…",
+  "settings.saveBar.saveFailed": "Не вдалося зберегти налаштування",
   "notifications.action.next": "Далі",
   "notifications.action.close": "Закрити",
   "notifications.action.tryModel": "Спробувати {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1358,6 +1358,8 @@ export const dict = {
   "settings.saveBar.warning.one": "一个会话正在运行，将被中断",
   "settings.saveBar.warning.many": "多个会话正在运行，将被中断",
   "settings.saveBar.saveAnyway": "仍然保存",
+  "settings.saveBar.saving": "保存中…",
+  "settings.saveBar.saveFailed": "无法保存设置",
   "settings.saveBar.cancel": "取消",
   "notifications.action.next": "下一个",
   "notifications.action.close": "关闭",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1363,6 +1363,8 @@ export const dict = {
   "settings.saveBar.warning.many": "多個工作階段正在執行，將被中斷",
   "settings.saveBar.saveAnyway": "仍然儲存",
   "settings.saveBar.cancel": "取消",
+  "settings.saveBar.saving": "儲存中…",
+  "settings.saveBar.saveFailed": "無法儲存設定",
   "notifications.action.next": "下一個",
   "notifications.action.close": "關閉",
   "notifications.action.tryModel": "嘗試 {{model}}",

--- a/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
@@ -227,6 +227,8 @@ const ConfigWrapper: ParentComponent<{ config?: Config }> = (props) => {
       config: () => props.config!,
       loading: () => false,
       isDirty: () => false,
+      saving: () => false,
+      saveError: () => null,
       updateConfig: noop,
       saveConfig: noop,
       discardConfig: noop,

--- a/packages/kilo-vscode/webview-ui/src/styles/settings.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/settings.css
@@ -1,23 +1,15 @@
 /* Settings save bar */
+.settings-save-bar-wrap {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--border-weak-base);
+}
+
 .settings-save-bar {
   display: flex;
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
-  padding: 0 16px;
-  border-top: 1px solid var(--border-weak-base);
-  overflow: hidden;
-  max-height: 0;
-  opacity: 0;
-  transition:
-    max-height 0.2s ease,
-    opacity 0.2s ease,
-    padding 0.2s ease;
-}
-
-.settings-save-bar--visible {
-  max-height: 52px;
-  opacity: 1;
   padding: 8px 16px;
 }
 
@@ -25,6 +17,62 @@
   font-size: 12px;
   color: var(--foreground-secondary);
   margin-right: auto;
+}
+
+/* Save error — mirrors the startup-error-banner style */
+.settings-save-bar-error {
+  border: 1px solid var(--vscode-inputValidation-errorBorder, #f14c4c);
+  border-radius: 4px;
+  background: var(--vscode-inputValidation-errorBackground, rgba(241, 76, 76, 0.1));
+  margin: 8px 16px 0 16px;
+  font-size: 12px;
+}
+
+.settings-save-bar-error-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  user-select: none;
+  min-width: 0;
+}
+
+.settings-save-bar-error-title {
+  flex: 1;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.settings-save-bar-error-firstline {
+  font-weight: 400;
+}
+
+.settings-save-bar-error-chevron {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  transition: transform 150ms;
+}
+
+.settings-save-bar-error-chevron-expanded {
+  transform: rotate(90deg);
+}
+
+.settings-save-bar-error-details {
+  margin: 0;
+  padding: 8px 10px;
+  border-top: 1px solid var(--vscode-inputValidation-errorBorder, #f14c4c);
+  background: var(--vscode-editor-background);
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 200px;
+  overflow-y: auto;
 }
 
 [data-slot="settings-row"] {

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -786,6 +786,12 @@ export interface ConfigUpdatedMessage {
   config: Config
 }
 
+export interface ConfigUpdateFailedMessage {
+  type: "configUpdateFailed"
+  message: string
+  details?: string
+}
+
 export interface GlobalConfigLoadedMessage {
   type: "globalConfigLoaded"
   config: Config
@@ -1500,6 +1506,7 @@ export type ExtensionMessage =
   | ClaudeCompatSettingLoadedMessage
   | ConfigLoadedMessage
   | ConfigUpdatedMessage
+  | ConfigUpdateFailedMessage
   | GlobalConfigLoadedMessage
   | NotificationSettingsLoadedMessage
   | TimelineSettingLoadedMessage


### PR DESCRIPTION
## Summary

When saving settings failed (e.g. an invalid `kilo.json` rejected by the Zod validator), the error was logged to the console, the save bar cleared itself, and the user was left thinking the save succeeded. Now the validator's message shows inline in an expandable banner above the save bar, using the same style as the existing `StartupErrorBanner`.

## Why

The previous flow posted a generic `error` message that was only consumed by unrelated handlers (the chat connection banner and session loading flag), then rolled back the draft with a misleading `configUpdated`. `getErrorMessage` also didn't understand the `ConfigInvalidError` shape (`{ data: { path, issues: [...] } }`), so even when the error reached a handler it was rendered as raw JSON. Users had no way to know what was wrong or that their changes hadn't saved.

## What

- Dedicated `configUpdateFailed` message carrying `{ message, details }`
- `getErrorMessage` extracts Zod issue messages; new `getConfigErrorDetails` formats file path + every issue for the expandable section
- Config context keeps the draft + `isDirty` on failure so the user can retry or discard
- Banner mirrors `StartupErrorBanner` (red border, chevron, monospace `<pre>` details)


<img width="839" height="251" alt="image" src="https://github.com/user-attachments/assets/38151eb2-07e6-41f1-969e-f101c987a5d9" />
<img width="876" height="153" alt="image" src="https://github.com/user-attachments/assets/6e479bf4-1366-4355-88ac-fd1314198134" />
