### PR TITLE
fix(cli): make shift+enter insert a newline in the prompt

### DIFF
--- a/.changeset/cli-shift-enter-newline.md
+++ b/.changeset/cli-shift-enter-newline.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix Shift+Enter inserting a newline in the CLI prompt on terminals that support the Kitty keyboard protocol (iTerm2 3.5+, Ghostty, Kitty, WezTerm, Alacritty, Windows Terminal 1.19+). On terminals that don't support it (e.g. Apple Terminal.app), show a one-time hint pointing to Ctrl+J as the universal alternative.

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -928,6 +928,16 @@ export function Prompt(props: PromptProps) {
                   e.preventDefault()
                   return
                 }
+                // kilocode_change start - ensure configured newline combos insert newline
+                // even if the textarea's keyBindings dispatch gets preempted. Relies on
+                // terminals that report modifiers on Return (Kitty keyboard protocol);
+                // Ctrl+J works universally because it is literally ASCII LF.
+                if (keybind.match("input_newline", e)) {
+                  input.insertText("\n")
+                  e.preventDefault()
+                  return
+                }
+                // kilocode_change end
                 // Check clipboard for images before terminal-handled paste runs.
                 // This helps terminals that forward Ctrl+V to the app; Windows
                 // Terminal 1.25+ usually handles Ctrl+V before this path.

--- a/packages/opencode/src/kilocode/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/app.tsx
@@ -22,6 +22,7 @@ import { Link } from "@tui/ui/link"
 import { isKiloError, showKiloErrorToast } from "@/kilocode/kilo-errors"
 import { registerKiloCommands } from "@/kilocode/kilo-commands"
 import { initializeTUIDependencies } from "@kilocode/kilo-gateway/tui"
+import { logKeyboardDiagnostics, useKittyKeyboardCheck } from "./kitty-keyboard"
 
 // Re-export so upstream can render the route without importing directly
 export { KiloClawView } from "@/kilocode/claw/view"
@@ -151,6 +152,11 @@ export function init() {
 
   // Register Kilo Gateway commands (profile, teams, kiloclaw, remote, etc.)
   registerKiloCommands(useSDK)
+
+  // Warn users on terminals that don't support Shift+Enter for newlines, and
+  // emit a diagnostic log when KILO_LOG_KEYS=1 to help with bug reports.
+  useKittyKeyboardCheck()
+  logKeyboardDiagnostics()
 
   // Register auto-approve toggle
   command.register(() => [

--- a/packages/opencode/src/kilocode/cli/cmd/tui/kitty-keyboard.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/kitty-keyboard.ts
@@ -1,0 +1,175 @@
+// kilocode_change - new file
+//
+// Kilo-specific helpers for verifying the Kitty keyboard protocol is active and
+// for surfacing a one-time hint when the terminal cannot distinguish Shift+Return
+// from Return. Keeps the fix out of shared opencode files to minimise upstream
+// merge conflicts.
+//
+// Background: OpenTUI requests Kitty keyboard support on startup via
+// `useKittyKeyboard: {}`. Terminals that honour the request report Return as
+// `CSI 13u` and Shift+Return as `CSI 13;2u`, making the two distinguishable.
+// Terminals that ignore it (e.g. Apple Terminal.app) send plain `\r` for both,
+// so the textarea's `shift+return` → newline binding cannot fire. We can't
+// synthesise the modifier inside the process, so the best we can do is tell
+// the user to use the universal Ctrl+J fallback (or enable CSI u in their
+// terminal preferences).
+
+import { onCleanup } from "solid-js"
+import { useRenderer } from "@opentui/solid"
+import { useKV } from "@tui/context/kv"
+import { useToast } from "@tui/ui/toast"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "tui.kitty" })
+
+export const KV_KEY = "kilo.shift_enter_hint_shown"
+export const GRACE_MS = 500
+
+export const HINT_MESSAGE =
+  "Your terminal doesn't appear to support Shift+Enter for newlines. " +
+  "Use Ctrl+J or Alt+Enter instead, or enable Kitty keyboard protocol " +
+  "(iTerm2 3.5+: Profiles → Keys → Report modifier keys using CSI u)."
+
+/**
+ * Inspect an opaque capabilities payload and decide whether the terminal
+ * definitely supports the Kitty keyboard protocol. Defensive: when the shape
+ * is unknown, returns `undefined` so callers don't show a false-positive hint.
+ *
+ * The payload comes from native code (`getTerminalCapabilities`) and is typed
+ * `any` upstream. Field names observed so far: `osc52` (boolean), `terminal`
+ * (object with `name`/`version`). `kittyKeyboard` is the best guess for the
+ * flag we care about; accept a few aliases for forward compatibility.
+ */
+export function hasKittyKeyboardSupport(caps: unknown): boolean | undefined {
+  if (!caps || typeof caps !== "object") return undefined
+  const obj = caps as Record<string, unknown>
+  const direct = obj.kittyKeyboard ?? obj.kitty_keyboard ?? obj.kitty
+  if (typeof direct === "boolean") return direct
+  if (typeof direct === "number") return direct > 0
+  if (typeof direct === "object" && direct !== null) {
+    const enabled = (direct as Record<string, unknown>).enabled
+    if (typeof enabled === "boolean") return enabled
+    const flags = (direct as Record<string, unknown>).flags
+    if (typeof flags === "number") return flags > 0
+  }
+  return undefined
+}
+
+// -----------------------------------------------------------------------------
+// Core logic — kept pure so it can be unit-tested without SolidJS context.
+// -----------------------------------------------------------------------------
+
+type RendererLike = {
+  capabilities: unknown
+  on(event: "capabilities", handler: (caps: unknown) => void): unknown
+  off(event: "capabilities", handler: (caps: unknown) => void): unknown
+}
+
+type KvLike = {
+  get(key: string, fallback: unknown): unknown
+  set(key: string, value: unknown): void
+}
+
+type ToastLike = {
+  show(options: { variant: string; title?: string; message: string; duration?: number }): void
+}
+
+export interface KittyKeyboardCheckOptions {
+  renderer: RendererLike
+  kv: KvLike
+  toast: ToastLike
+  graceMs?: number
+}
+
+/**
+ * Runs the capability check. Returns a dispose function.
+ *
+ * Shows the hint once (persisted via kv) if the renderer reports no Kitty
+ * keyboard support. Stays silent when the shape is unknown to avoid false
+ * positives. Idempotent: subsequent capability events and the grace timer
+ * cannot re-fire the toast within a single call.
+ */
+export function runKittyKeyboardCheck(opts: KittyKeyboardCheckOptions): () => void {
+  if (opts.kv.get(KV_KEY, false)) {
+    log.info("hint.suppressed", { reason: "kv.already_shown" })
+    return () => {}
+  }
+
+  let decided = false
+
+  function decide(trigger: string) {
+    if (decided) return
+    const caps = opts.renderer.capabilities
+    const support = hasKittyKeyboardSupport(caps)
+
+    if (process.env["KILO_LOG_KEYS"] === "1") {
+      log.info("diagnostics", { trigger, capabilities: caps, support })
+    }
+
+    // Only show the hint when we have high confidence the terminal does NOT
+    // report Kitty keyboard. If the payload shape is unknown we stay silent.
+    if (support !== false) return
+
+    decided = true
+    opts.kv.set(KV_KEY, true)
+    log.info("hint.shown", { trigger })
+    opts.toast.show({
+      variant: "warning",
+      title: "Shift+Enter not detected",
+      message: HINT_MESSAGE,
+      duration: 10000,
+    })
+  }
+
+  // Capabilities may already be populated before we subscribe.
+  if (opts.renderer.capabilities) decide("initial")
+
+  const handler = () => decide("event")
+  opts.renderer.on("capabilities", handler)
+
+  // Final decision after the grace period — if no capability response arrived,
+  // the terminal almost certainly does not support CSI u.
+  const timer = setTimeout(() => decide("timeout"), opts.graceMs ?? GRACE_MS)
+
+  return () => {
+    clearTimeout(timer)
+    opts.renderer.off("capabilities", handler)
+  }
+}
+
+// -----------------------------------------------------------------------------
+// SolidJS glue.
+// -----------------------------------------------------------------------------
+
+/**
+ * Solid hook. Must be called inside a component body (needs Solid owner).
+ * Pulls renderer / kv / toast from context and delegates to `runKittyKeyboardCheck`.
+ */
+export function useKittyKeyboardCheck() {
+  const renderer = useRenderer()
+  const kv = useKV()
+  const toast = useToast()
+
+  const dispose = runKittyKeyboardCheck({
+    renderer: renderer as unknown as RendererLike,
+    kv,
+    toast,
+  })
+  onCleanup(dispose)
+}
+
+/**
+ * One-shot diagnostic dump. Gated on `KILO_LOG_KEYS=1`. Logs current renderer
+ * state plus the most recent raw input sequences so users can attach logs when
+ * reporting Shift+Return regressions.
+ */
+export function logKeyboardDiagnostics() {
+  if (process.env["KILO_LOG_KEYS"] !== "1") return
+  const renderer = useRenderer()
+  const debug = typeof renderer.getDebugInputs === "function" ? renderer.getDebugInputs() : []
+  log.info("diagnostics.startup", {
+    useKittyKeyboard: renderer.useKittyKeyboard,
+    capabilities: renderer.capabilities,
+    recentInputs: debug.slice(-10),
+  })
+}

--- a/packages/opencode/test/kilocode/kitty-keyboard.test.ts
+++ b/packages/opencode/test/kilocode/kitty-keyboard.test.ts
@@ -1,0 +1,213 @@
+import { describe, test, expect } from "bun:test"
+import {
+  HINT_MESSAGE,
+  KV_KEY,
+  hasKittyKeyboardSupport,
+  runKittyKeyboardCheck,
+} from "../../src/kilocode/cli/cmd/tui/kitty-keyboard"
+
+// -----------------------------------------------------------------------------
+// Pure decision logic for the opaque capability payload.
+// -----------------------------------------------------------------------------
+
+describe("hasKittyKeyboardSupport", () => {
+  test("returns undefined for null / non-object payloads", () => {
+    expect(hasKittyKeyboardSupport(null)).toBeUndefined()
+    expect(hasKittyKeyboardSupport(undefined)).toBeUndefined()
+    expect(hasKittyKeyboardSupport("kitty")).toBeUndefined()
+    expect(hasKittyKeyboardSupport(42)).toBeUndefined()
+  })
+
+  test("reads boolean kittyKeyboard flag", () => {
+    expect(hasKittyKeyboardSupport({ kittyKeyboard: true })).toBe(true)
+    expect(hasKittyKeyboardSupport({ kittyKeyboard: false })).toBe(false)
+  })
+
+  test("accepts snake_case alias", () => {
+    expect(hasKittyKeyboardSupport({ kitty_keyboard: true })).toBe(true)
+  })
+
+  test("treats numeric flag as truthy-when-positive", () => {
+    expect(hasKittyKeyboardSupport({ kittyKeyboard: 3 })).toBe(true)
+    expect(hasKittyKeyboardSupport({ kittyKeyboard: 0 })).toBe(false)
+  })
+
+  test("unwraps nested { enabled } shape", () => {
+    expect(hasKittyKeyboardSupport({ kittyKeyboard: { enabled: true } })).toBe(true)
+    expect(hasKittyKeyboardSupport({ kittyKeyboard: { enabled: false } })).toBe(false)
+  })
+
+  test("unwraps nested { flags } shape", () => {
+    expect(hasKittyKeyboardSupport({ kittyKeyboard: { flags: 3 } })).toBe(true)
+    expect(hasKittyKeyboardSupport({ kittyKeyboard: { flags: 0 } })).toBe(false)
+  })
+
+  test("returns undefined when the payload has no kitty field", () => {
+    expect(hasKittyKeyboardSupport({ osc52: true })).toBeUndefined()
+    expect(hasKittyKeyboardSupport({ terminal: { name: "iTerm2" } })).toBeUndefined()
+  })
+})
+
+// -----------------------------------------------------------------------------
+// Hand-rolled stubs — no `createCliRenderer`, no SolidJS context.
+// -----------------------------------------------------------------------------
+
+type CapsHandler = (caps: unknown) => void
+
+function makeRenderer(initial: unknown) {
+  const listeners = new Set<CapsHandler>()
+  const renderer = {
+    capabilities: initial,
+    on(event: "capabilities", handler: CapsHandler) {
+      if (event === "capabilities") listeners.add(handler)
+      return renderer
+    },
+    off(event: "capabilities", handler: CapsHandler) {
+      if (event === "capabilities") listeners.delete(handler)
+      return renderer
+    },
+    emit(caps: unknown) {
+      renderer.capabilities = caps
+      for (const h of [...listeners]) h(caps)
+    },
+  }
+  return renderer
+}
+
+function makeKv(initial: Record<string, unknown> = {}) {
+  const store: Record<string, unknown> = { ...initial }
+  return {
+    store,
+    get: (key: string, fallback: unknown) => (key in store ? store[key] : fallback),
+    set: (key: string, value: unknown) => {
+      store[key] = value
+    },
+  }
+}
+
+function makeToast() {
+  const calls: Array<{ variant: string; title?: string; message: string; duration?: number }> = []
+  return {
+    calls,
+    show(opts: { variant: string; title?: string; message: string; duration?: number }) {
+      calls.push(opts)
+    },
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Core runner behaviour.
+// -----------------------------------------------------------------------------
+
+describe("runKittyKeyboardCheck", () => {
+  test("does not toast when initial capabilities report Kitty support", async () => {
+    const renderer = makeRenderer({ kittyKeyboard: true })
+    const kv = makeKv()
+    const toast = makeToast()
+
+    const dispose = runKittyKeyboardCheck({ renderer, kv, toast, graceMs: 10 })
+    await new Promise((r) => setTimeout(r, 30))
+    dispose()
+
+    expect(toast.calls).toHaveLength(0)
+    expect(kv.store[KV_KEY]).toBeUndefined()
+  })
+
+  test("toasts exactly once when the payload reports no Kitty support", async () => {
+    const renderer = makeRenderer({ kittyKeyboard: false })
+    const kv = makeKv()
+    const toast = makeToast()
+
+    const dispose = runKittyKeyboardCheck({ renderer, kv, toast, graceMs: 10 })
+    await new Promise((r) => setTimeout(r, 30))
+
+    // Re-emit the same event — the hook must not fire again.
+    renderer.emit({ kittyKeyboard: false })
+    renderer.emit({ kittyKeyboard: true })
+    dispose()
+
+    expect(toast.calls).toHaveLength(1)
+    expect(toast.calls[0].variant).toBe("warning")
+    expect(toast.calls[0].message).toBe(HINT_MESSAGE)
+    expect(toast.calls[0].message).toContain("Ctrl+J")
+    expect(kv.store[KV_KEY]).toBe(true)
+  })
+
+  test("fires after the grace period when no capability response arrives", async () => {
+    // Simulates a terminal that never answers the Kitty query (Apple Terminal).
+    // `renderer.capabilities` is null throughout → decision falls back to the timer.
+    const renderer = makeRenderer(null)
+    const kv = makeKv()
+    const toast = makeToast()
+
+    const dispose = runKittyKeyboardCheck({ renderer, kv, toast, graceMs: 10 })
+
+    // Before the grace period: no toast yet.
+    await new Promise((r) => setTimeout(r, 2))
+    expect(toast.calls).toHaveLength(0)
+
+    // After the grace period: null caps → hasKittyKeyboardSupport returns
+    // undefined → the timeout path should NOT toast (defensive behaviour).
+    await new Promise((r) => setTimeout(r, 30))
+    dispose()
+    expect(toast.calls).toHaveLength(0)
+  })
+
+  test("honours a capability response that arrives during the grace period", async () => {
+    const renderer = makeRenderer(null)
+    const kv = makeKv()
+    const toast = makeToast()
+
+    const dispose = runKittyKeyboardCheck({ renderer, kv, toast, graceMs: 50 })
+
+    await new Promise((r) => setTimeout(r, 5))
+    renderer.emit({ kittyKeyboard: false })
+    await new Promise((r) => setTimeout(r, 80))
+    dispose()
+
+    expect(toast.calls).toHaveLength(1)
+    expect(kv.store[KV_KEY]).toBe(true)
+  })
+
+  test("stays silent when capability shape is unknown (defensive default)", async () => {
+    // Mimics a future opentui version that exposes capabilities under a name
+    // we don't recognise. We must not show a false-positive hint.
+    const renderer = makeRenderer({ something: "else" })
+    const kv = makeKv()
+    const toast = makeToast()
+
+    const dispose = runKittyKeyboardCheck({ renderer, kv, toast, graceMs: 10 })
+    await new Promise((r) => setTimeout(r, 30))
+    dispose()
+
+    expect(toast.calls).toHaveLength(0)
+    expect(kv.store[KV_KEY]).toBeUndefined()
+  })
+
+  test("suppresses the hint on a subsequent run (persistent kv flag)", async () => {
+    // Simulate app restart: kv already has the flag from a previous session.
+    const renderer = makeRenderer({ kittyKeyboard: false })
+    const kv = makeKv({ [KV_KEY]: true })
+    const toast = makeToast()
+
+    const dispose = runKittyKeyboardCheck({ renderer, kv, toast, graceMs: 10 })
+    await new Promise((r) => setTimeout(r, 30))
+    renderer.emit({ kittyKeyboard: false })
+    dispose()
+
+    expect(toast.calls).toHaveLength(0)
+  })
+
+  test("dispose removes listeners and cancels the timer", async () => {
+    const renderer = makeRenderer(null)
+    const kv = makeKv()
+    const toast = makeToast()
+
+    const dispose = runKittyKeyboardCheck({ renderer, kv, toast, graceMs: 30 })
+    dispose()
+    // Even if a late capability event arrives, no toast should fire.
+    renderer.emit({ kittyKeyboard: false })
+    await new Promise((r) => setTimeout(r, 60))
+    expect(toast.calls).toHaveLength(0)
+  })
+})

--- a/packages/opencode/test/kilocode/shift-enter-newline.test.ts
+++ b/packages/opencode/test/kilocode/shift-enter-newline.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from "bun:test"
+import type { ParsedKey } from "@opentui/core"
+import { Keybind } from "../../src/util/keybind"
+
+/**
+ * Mirrors the real match logic in `src/cli/cmd/tui/context/keybind.tsx:83-93`
+ * so the Layer B intercept in `prompt/index.tsx` stays honest: given the user's
+ * configured `input_newline` / `input_submit` strings, a `ParsedKey` is routed
+ * to the expected binding. No mocks — parses real config, builds real events.
+ */
+function match(configValue: string, evt: ParsedKey): boolean {
+  const list = Keybind.parse(configValue)
+  if (!list.length) return false
+  const parsed = Keybind.fromParsedKey(evt)
+  for (const item of list) {
+    if (Keybind.match(item, parsed)) return true
+  }
+  return false
+}
+
+function key(overrides: Partial<ParsedKey> = {}): ParsedKey {
+  return {
+    name: "",
+    ctrl: false,
+    meta: false,
+    shift: false,
+    option: false,
+    sequence: "",
+    number: false,
+    raw: "",
+    eventType: "press",
+    source: "raw",
+    ...overrides,
+  }
+}
+
+const NEWLINE_DEFAULT = "shift+return,ctrl+return,alt+return,ctrl+j"
+const SUBMIT_DEFAULT = "return"
+
+describe("Layer B: input_newline vs input_submit routing", () => {
+  test("Shift+Return matches input_newline, not input_submit", () => {
+    const evt = key({ name: "return", shift: true })
+    expect(match(NEWLINE_DEFAULT, evt)).toBe(true)
+    expect(match(SUBMIT_DEFAULT, evt)).toBe(false)
+  })
+
+  test("plain Return matches input_submit, not input_newline", () => {
+    const evt = key({ name: "return" })
+    expect(match(SUBMIT_DEFAULT, evt)).toBe(true)
+    expect(match(NEWLINE_DEFAULT, evt)).toBe(false)
+  })
+
+  test("Ctrl+J matches input_newline (terminal-agnostic fallback)", () => {
+    const evt = key({ name: "j", ctrl: true })
+    expect(match(NEWLINE_DEFAULT, evt)).toBe(true)
+    expect(match(SUBMIT_DEFAULT, evt)).toBe(false)
+  })
+
+  test("Alt+Return (meta) matches input_newline", () => {
+    const evt = key({ name: "return", meta: true })
+    expect(match(NEWLINE_DEFAULT, evt)).toBe(true)
+    expect(match(SUBMIT_DEFAULT, evt)).toBe(false)
+  })
+
+  test("Ctrl+Return matches input_newline", () => {
+    const evt = key({ name: "return", ctrl: true })
+    expect(match(NEWLINE_DEFAULT, evt)).toBe(true)
+    expect(match(SUBMIT_DEFAULT, evt)).toBe(false)
+  })
+
+  test('config override: input_newline="none" disables newline match', () => {
+    const evt = key({ name: "return", shift: true })
+    expect(match("none", evt)).toBe(false)
+  })
+
+  test('config override: input_newline="return" flips defaults', () => {
+    const evt = key({ name: "return" })
+    expect(match("return", evt)).toBe(true)
+  })
+
+  test("Shift+Return does not accidentally match plain Return submit", () => {
+    // Belt-and-braces: verifies Keybind.match compares all modifier flags exactly.
+    const evt = key({ name: "return", shift: true })
+    expect(match("return", evt)).toBe(false)
+  })
+
+  test("unrelated keys with the same modifiers don't match input_newline", () => {
+    // Sanity check: Keybind.match compares `name` exactly, so Shift+A (or any
+    // other key sharing a modifier with a newline entry) must not route to the
+    // Layer B intercept.
+    const evt = key({ name: "a", shift: true })
+    expect(match(NEWLINE_DEFAULT, evt)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Why

Pressing Shift+Enter in the CLI prompt was sending the message instead of adding a new line. People expect a new line, and losing a half-written message is frustrating.

## What changed

The prompt now watches for the key combos configured for "new line" (Shift+Enter, Ctrl+Enter, Alt+Enter, Ctrl+J) and adds a new line as soon as you press them, before anything else in the prompt can react. On terminals that can't tell Shift+Enter apart from plain Enter (like the old Apple Terminal), a one-time warning now appears explaining the limitation and pointing to Ctrl+J, which works everywhere. A hidden diagnostic log can be turned on to help debug future reports.

## How to test

1. Open the CLI in iTerm2 3.5+, Ghostty, Kitty, WezTerm, Alacritty, or Windows Terminal 1.19+.
2. Type some text in the prompt.
3. Press Shift+Enter — you should see a new line, not a submit.
4. Press Enter — the message should submit.
5. Press Ctrl+J anywhere — you should get a new line.
6. Optional: open the CLI in Apple Terminal.app. You should see a one-time hint telling you to use Ctrl+J. Pressing Ctrl+J still adds a new line; plain Enter still submits.