### PR TITLE
docs: document changeset workflow in contributing guide

### DIFF
--- a/packages/kilo-docs/pages/contributing/index.md
+++ b/packages/kilo-docs/pages/contributing/index.md
@@ -58,6 +58,33 @@ git checkout -b docs/your-change-description
 - Reference issue numbers when applicable
 - Keep commits focused on a single change
 
+### Changesets
+
+User-facing changes (features, fixes, breaking changes) require a changeset file so the update shows up in the next release notes. Run the interactive tool, or create the file by hand:
+
+```bash
+bunx changeset add
+```
+
+Or create `.changeset/<slug>.md` manually:
+
+```md
+---
+"kilo-code": minor
+---
+
+Short description of the change for the changelog.
+```
+
+Guidelines:
+
+- Use `patch` for bug fixes, `minor` for new features, `major` for breaking changes.
+- Descriptions are read by end users in release notes — keep them concise and feature-oriented. Describe **what changed from the user's perspective**, not implementation details.
+- Write in imperative mood (e.g. "Support exporting conversations as markdown" rather than "Add a new export handler that serializes session messages to .md files").
+- Changesets are consumed at release time by the `publish.yml` workflow, which generates changelog entries for the GitHub release notes.
+
+Skip the changeset only for internal refactors, CI tweaks, test-only changes, or docs that do not affect users.
+
 ### Testing Your Changes
 
 - Run the test suite:


### PR DESCRIPTION
## Summary
Add a Changesets section to the contributing overview so external contributors learn the `bunx changeset add` flow, bump levels, and that descriptions ship directly in user-facing release notes. Mirrors the guidance already in `AGENTS.md` and `.changeset/README.md`.