### PR TITLE
fix(vscode): hide duplicate preview in question tool custom answer

### DIFF
--- a/.changeset/question-custom-answer-duplicate.md
+++ b/.changeset/question-custom-answer-duplicate.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix duplicate text shown when typing a custom answer in the question tool. The preview text above the input field is now hidden while editing, so only the input value is visible.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -370,9 +370,11 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
                   </span>
                   <span data-slot="question-option-main">
                     <span data-slot="option-label">{language.t("ui.messagePart.option.typeOwnAnswer")}</span>
-                    <span data-slot="option-description" data-placeholder={!input()}>
-                      {input() || language.t("ui.question.custom.placeholder")}
-                    </span>
+                    <Show when={!store.editing}>
+                      <span data-slot="option-description" data-placeholder={!input()}>
+                        {input() || language.t("ui.question.custom.placeholder")}
+                      </span>
+                    </Show>
                   </span>
                 </button>
                 <Show when={store.editing}>


### PR DESCRIPTION
## Summary

The question tool's custom answer option rendered the user's input twice: once as a description inside the option button, and again in the input field below. Wrapped the preview span in `<Show when={!store.editing}>` so it disappears while the input form is active.