### PR TITLE
fix(cli): log stream error on log rotation

### DIFF
--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import { existsSync, writeFileSync } from "fs" // kilocode_change
 import fs from "fs/promises"
 import { Global } from "../global"
 import z from "zod"
@@ -71,8 +72,22 @@ export async function init(options: Options) {
   const stream = createStream(path.basename(logpath), {
     size: "50M",
     maxFiles: 10,
-    history: path.join(dir, ".log-history"),
+    history: ".log-history",
     path: dir,
+  })
+  stream.on("rotation", () => {
+    if (!existsSync(dir)) return
+
+    try {
+      // RATIONALE: If current log path was deleted while stream still holds the fd,
+      // rotating-file-stream will try to rename a missing path and emit ENOENT.
+      writeFileSync(logpath, "", { flag: "wx" })
+    } catch (err) {
+      if (typeof err === "object" && err && "code" in err && err.code === "EEXIST") return
+
+      const msg = err instanceof Error ? err.message : String(err)
+      process.stderr.write("log stream warning: " + msg + "\n")
+    }
   })
   stream.on("error", (err: Error) => {
     process.stderr.write("log stream error: " + err.message + "\n")

--- a/packages/opencode/test/fixture/log-init-worker.ts
+++ b/packages/opencode/test/fixture/log-init-worker.ts
@@ -1,0 +1,63 @@
+// kilocode_change - new file
+
+import fs from "fs/promises"
+import path from "path"
+
+const dir = process.argv[2]
+const mode = process.argv[3]
+
+if (!dir) {
+  throw new Error("missing temp dir")
+}
+
+process.env.XDG_DATA_HOME = path.join(dir, "share")
+process.env.XDG_CACHE_HOME = path.join(dir, "cache")
+process.env.XDG_CONFIG_HOME = path.join(dir, "config")
+process.env.XDG_STATE_HOME = path.join(dir, "state")
+process.env.KILO_TEST_HOME = path.join(dir, "home")
+
+const Log = await import("../../src/util/log")
+
+async function bytes(file: string) {
+  return fs
+    .stat(file)
+    .then((stat) => stat.size)
+    .catch(() => 0)
+}
+
+async function wait(file: string, need: number) {
+  for (let i = 0; i < 500; i++) {
+    if ((await bytes(file)) >= need) return
+    await Bun.sleep(10)
+  }
+
+  throw new Error(`log file did not reach ${need} bytes before missing-file test`)
+}
+
+await Log.init({
+  print: false,
+  dev: true,
+  level: "DEBUG",
+})
+
+const log = Log.create({ service: "test" })
+const msg = "x".repeat(1024 * 1024)
+const first = mode === "missing" ? 10 : 55
+
+await fs.mkdir(path.join(dir, "share", "kilo", "log"), { recursive: true })
+for (const _ of Array.from({ length: first })) {
+  log.info(msg)
+}
+
+if (mode === "missing") {
+  await wait(Log.file(), first * msg.length)
+  await fs.unlink(Log.file())
+
+  for (const _ of Array.from({ length: 45 })) {
+    log.info(msg)
+  }
+}
+
+await Bun.sleep(300)
+
+process.stdout.write(Log.file())

--- a/packages/opencode/test/util/log.test.ts
+++ b/packages/opencode/test/util/log.test.ts
@@ -3,6 +3,7 @@ import fs from "fs/promises"
 import path from "path"
 import { Global } from "../../src/global"
 import { Log } from "../../src/util"
+import * as Process from "../../src/util/process" // kilocode_change
 import { tmpdir } from "../fixture/fixture"
 
 const log = Global.Path.log
@@ -42,3 +43,47 @@ test("init cleanup keeps the newest timestamped logs", async () => {
   expect(next).not.toContain(list[0]!)
   expect(next).toContain(list.at(-1)!)
 })
+
+// kilocode_change start
+const root = path.join(import.meta.dir, "../..")
+const worker = path.join(import.meta.dir, "../fixture/log-init-worker.ts")
+
+test("uses single log directory for rotation history", async () => {
+  await using tmp = await tmpdir()
+
+  const out = await Process.run([process.execPath, "--conditions=browser", worker, tmp.path], {
+    cwd: root,
+    nothrow: true,
+  })
+
+  const dir = path.join(tmp.path, "share", "kilo", "log")
+  const history = path.join(dir, ".log-history")
+
+  expect(out.code).toBe(0)
+  expect(out.stderr.toString()).not.toContain("log stream error:")
+  expect(out.stdout.toString()).toBe(path.join(dir, "dev.log"))
+
+  const stat = await fs.stat(history)
+  expect(stat.isFile()).toBe(true)
+})
+
+test("skips rotation rename when active log file is missing", async () => {
+  await using tmp = await tmpdir()
+
+  const out = await Process.run([process.execPath, "--conditions=browser", worker, tmp.path, "missing"], {
+    cwd: root,
+    nothrow: true,
+  })
+
+  const dir = path.join(tmp.path, "share", "kilo", "log")
+  const list = (await fs.readdir(dir)).sort()
+  const next = list.filter((file) => /^\d{8}-\d{4}-\d{2}-dev\.log$/.test(file))
+  const stat = await fs.stat(path.join(dir, next[0]!))
+
+  expect(out.code).toBe(0)
+  expect(out.stderr.toString()).not.toContain("log stream error:")
+  expect(list).toContain("dev.log")
+  expect(next).toHaveLength(1)
+  expect(stat.size).toBe(0)
+})
+// kilocode_change end


### PR DESCRIPTION
## Context

Fixes #8252

## Implementation

- Removes unnecessary concatenation of log dir to avoid duplication.
- Adds a safety condition to avoid emitting an error if the original file doesn't exist (encountered during real usage after fixing the original bug)

## How to Test

- Have a long running session
- Should no longer see log stream error pop up in prompt input area

## Get in Touch

ExpedientFalcon on Discord
