### PR TITLE
fix(vscode): restore chat turn spacing broken by virtualizer

### DIFF
--- a/.changeset/vscode-subagent-spacing.md
+++ b/.changeset/vscode-subagent-spacing.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore spacing between sub-agent output and the following user message in the VS Code chat.

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/message-list-subagent-to-queued-user-spacing-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/chat/message-list-subagent-to-queued-user-spacing-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54c85aa9565b91d2a1f848e02d2b21883dc05cb57df92fd359df83c207995455
+size 10247

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/diff-summary-collapsed-chromium-linux.png
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts-snapshots/composite-webview/diff-summary-collapsed-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b57a543bd799f92b35d2c6037a4ffc932a37f59790213006a021bebef9e94b38
-size 6897
+oid sha256:4cb00b7e8e69e0e8d8c975b4ae119ebfcdea955247d0223dead873356044d1a2
+size 6940

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -326,6 +326,110 @@ export const MessageListToolToQueuedUserSpacing: Story = {
 }
 
 // ---------------------------------------------------------------------------
+// MessageList — sub-agent (task tool) to queued user spacing
+// Verifies the same vertical gap applies when the last assistant part is a
+// sub-agent's expanded task tool, not just a regular tool like bash.
+// ---------------------------------------------------------------------------
+
+const subUserID = "user-msg-subagent-spacing-001"
+const subAssistantID = "asst-msg-subagent-spacing-001"
+const subQueuedUserID = "user-msg-subagent-spacing-002"
+const subChildSessionID = "story-session-child-subagent-001"
+const subNow = 1_700_000_100_000
+const subagentSpacingMessages = [
+  {
+    id: subUserID,
+    sessionID: SESSION_ID,
+    role: "user",
+    time: { created: subNow - 9000 },
+  },
+  {
+    id: subAssistantID,
+    sessionID: SESSION_ID,
+    role: "assistant",
+    parentID: subUserID,
+    time: { created: subNow - 8000 },
+    modelID: "claude-sonnet-4-20250514",
+    providerID: "anthropic",
+    mode: "default",
+    agent: "default",
+    path: { cwd: "/project", root: "/project" },
+  },
+  {
+    id: subQueuedUserID,
+    sessionID: SESSION_ID,
+    role: "user",
+    time: { created: subNow - 1000 },
+  },
+]
+const subagentSpacingParts = {
+  [subUserID]: [
+    {
+      id: "part-user-subagent-spacing-001",
+      sessionID: SESSION_ID,
+      messageID: subUserID,
+      type: "text",
+      text: "Delegate a search to a sub-agent so I can test the spacing.",
+    },
+  ],
+  [subAssistantID]: [
+    {
+      id: "part-task-subagent-spacing-001",
+      sessionID: SESSION_ID,
+      messageID: subAssistantID,
+      type: "tool",
+      callID: "call-task-subagent-spacing-001",
+      tool: "task",
+      state: {
+        status: "completed",
+        input: { description: "Find auth usage", subagent_type: "explore" },
+        output: "done",
+        title: "Find auth usage",
+        metadata: { sessionId: subChildSessionID },
+        time: { start: subNow - 7000, end: subNow - 6500 },
+      },
+    },
+  ],
+  [subQueuedUserID]: [
+    {
+      id: "part-user-subagent-spacing-002",
+      sessionID: SESSION_ID,
+      messageID: subQueuedUserID,
+      type: "text",
+      text: "continue",
+    },
+  ],
+}
+const subagentSpacingData = {
+  ...defaultMockData,
+  message: {
+    [SESSION_ID]: subagentSpacingMessages,
+    [subChildSessionID]: [],
+  },
+  part: subagentSpacingParts,
+}
+
+export const MessageListSubagentToQueuedUserSpacing: Story = {
+  name: "MessageList — sub-agent to queued user spacing",
+  render: () => {
+    const session = {
+      ...mockSessionValue({ id: SESSION_ID, status: "idle" }),
+      messages: () => subagentSpacingMessages,
+      userMessages: () => subagentSpacingMessages.filter((msg) => msg.role === "user"),
+    }
+    return (
+      <StoryProviders data={subagentSpacingData} sessionID={SESSION_ID} status="idle" noPadding>
+        <SessionContext.Provider value={session as any}>
+          <div style={{ height: "420px", display: "flex", "flex-direction": "column" }}>
+            <MessageList />
+          </div>
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
+}
+
+// ---------------------------------------------------------------------------
 // TaskHeader with todos
 // ---------------------------------------------------------------------------
 

--- a/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
@@ -178,13 +178,18 @@
    VscodeSessionTurn layout
    ============================================ */
 
+/* Virtua positions turns absolutely based on measured box size, so flex `gap`
+   on `.message-list-content` can't add spacing between turns. Bake the gap
+   into the turn's own padding — it's included in the measured height and so
+   shows up as spacing between turns (e.g. tool output to queued user message,
+   including sub-agent task tools which expand inline). */
 .vscode-session-turn {
   display: flex;
   flex-direction: column;
   gap: 12px;
   width: 100%;
   min-width: 0;
-  padding: 0 4px;
+  padding: 0 4px 12px;
 }
 
 .vscode-session-turn-user {


### PR DESCRIPTION
## Summary

- The prior spacing fix (#9025) relied on flex `gap` on `.message-list-content`, but #8911 introduced virtua's `Virtualizer` which positions items absolutely based on measured box size — so `gap` no longer applied between turns.
- The missing spacing was most visible when the last assistant part was a sub-agent's expanded task tool (two bordered boxes with 0px between them, per user report).
- Bakes the 12px into each turn's own `padding-bottom` so virtua measures it as part of the item height. This uniformly restores spacing for all turn terminators (text, bash, todos, diffs, subagents, errors).
- Adds a Storybook story (`MessageList — sub-agent to queued user spacing`) that reproduces the failing case.

Before:

<img width="599" height="545" alt="image" src="https://github.com/user-attachments/assets/3ce6bda7-c6bf-4271-bd5a-a06a12725b97" />
<img width="652" height="413" alt="image" src="https://github.com/user-attachments/assets/eb4de77f-1f7c-4503-a518-53cd7e407374" />

After:
<img width="826" height="345" alt="image" src="https://github.com/user-attachments/assets/a676158a-806b-4d59-b648-60d89d9d095d" />
<img width="649" height="388" alt="image" src="https://github.com/user-attachments/assets/98d4aa8a-4296-4e0b-9cbc-75d36a467369" />
