### PR TITLE
fix: Remove Bash string appearing before commands - opencode merge regression

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -280,7 +280,7 @@ async function parse(command: string, ps: boolean) {
   return tree.rootNode
 }
 
-async function ask(ctx: Tool.Context, scan: Scan) {
+async function ask(ctx: Tool.Context, scan: Scan, command: string) {
   if (scan.dirs.size > 0) {
     const globs = Array.from(scan.dirs).map((dir) => {
       if (process.platform === "win32") return Filesystem.normalizePathPattern(path.join(dir, "*"))
@@ -299,7 +299,7 @@ async function ask(ctx: Tool.Context, scan: Scan) {
     permission: "bash",
     patterns: Array.from(scan.patterns),
     always: Array.from(scan.always),
-    metadata: {},
+    metadata: { command }, // kilocode_change
   })
 }
 
@@ -479,7 +479,7 @@ export const BashTool = Tool.define("bash", async () => {
       const root = await parse(params.command, ps)
       const scan = await collect(root, cwd, ps, shell)
       if (!Instance.containsPath(cwd)) scan.dirs.add(cwd)
-      await ask(ctx, scan)
+      await ask(ctx, scan, params.command)
 
       return run(
         {

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -280,7 +280,7 @@ async function parse(command: string, ps: boolean) {
   return tree.rootNode
 }
 
-async function ask(ctx: Tool.Context, scan: Scan, command: string) {
+async function ask(ctx: Tool.Context, scan: Scan, command: string) { // kilocode_change
   if (scan.dirs.size > 0) {
     const globs = Array.from(scan.dirs).map((dir) => {
       if (process.platform === "win32") return Filesystem.normalizePathPattern(path.join(dir, "*"))
@@ -479,7 +479,7 @@ export const BashTool = Tool.define("bash", async () => {
       const root = await parse(params.command, ps)
       const scan = await collect(root, cwd, ps, shell)
       if (!Instance.containsPath(cwd)) scan.dirs.add(cwd)
-      await ask(ctx, scan, params.command)
+      await ask(ctx, scan, params.command) // kilocode_change
 
       return run(
         {

--- a/packages/opencode/test/kilocode/bash-permission-metadata.test.ts
+++ b/packages/opencode/test/kilocode/bash-permission-metadata.test.ts
@@ -1,0 +1,47 @@
+// regression test for bash permission metadata.command
+import { describe, expect, test } from "bun:test"
+import { BashTool } from "../../src/tool/bash"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import { Shell } from "../../src/shell/shell"
+import { SessionID, MessageID } from "../../src/session/schema"
+import type { Permission } from "../../src/permission"
+
+Shell.acceptable.reset()
+
+const baseCtx = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "code",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
+
+const capture = (requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">>) => ({
+  ...baseCtx,
+  ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
+    requests.push(req)
+  },
+})
+
+describe("bash permission metadata.command", () => {
+  test("permission prompt shows raw command without tool name prefix", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        const command = "echo hello"
+        await bash.execute({ command, description: "Echo hello" }, capture(requests))
+
+        const bashReq = requests.find((r) => r.permission === "bash")
+        expect(bashReq).toBeDefined()
+        expect(bashReq!.metadata.command).toBe(command)
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Context

Removing `Bash` string showing before bash commands on permission component. This was brought back in earlier opencode merges.

## Implementation

- Brought back the `command` argument to the `ask` method that needs the command in the `metadata` param to be able to show the command instead of the variant with Bash.
- Introduced a unit test to check if command is present in the metadata

e.g. `git status` (correct) vs `Bash git status` (incorrect)

## Screenshots

| before | after |
| ------ | ----- |
|  <img width="1849" height="937" alt="Screenshot 2026-04-17 at 17 40 46" src="https://github.com/user-attachments/assets/f2a7158c-821d-4bd8-ac25-061b493b68b9" /> |   <img width="1849" height="937" alt="Screenshot 2026-04-17 at 17 55 40" src="https://github.com/user-attachments/assets/2a04b949-21ce-4093-913c-c9105211c7b3" /> |

## How to Test

- Ran unit tests
- Executed Extension locally and compared before and after
- Added new unit to assert the metadata command is present

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
