### PR TITLE
ci: disable smoke-test job in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -261,7 +261,7 @@ jobs:
     needs:
       - version
       - build-cli
-    if: false # kilocode_change - temporarily disabled
+    if: false # Disable the smoketest job until it works when called on draft releases
     uses: ./.github/workflows/smoke-test.yml
     with:
       cli_version: ${{ needs.version.outputs.version }}
@@ -272,7 +272,7 @@ jobs:
       - version
       - build-cli
       - build-vscode
-      # - smoke-test # kilocode_change - temporarily disabled
+      # - smoke-test # Disable the smoketest job until it works when called on draft releases
       # - build-tauri
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -261,7 +261,7 @@ jobs:
     needs:
       - version
       - build-cli
-    if: github.repository == 'Kilo-Org/kilocode'
+    if: false # kilocode_change - temporarily disabled
     uses: ./.github/workflows/smoke-test.yml
     with:
       cli_version: ${{ needs.version.outputs.version }}
@@ -272,7 +272,7 @@ jobs:
       - version
       - build-cli
       - build-vscode
-      - smoke-test
+      # - smoke-test # kilocode_change - temporarily disabled
       # - build-tauri
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Temporarily disables the pre-publish smoke-test gate.