### PR TITLE
fix(agent): resolve agents by display name when slug lookup fails (#9096)

### DIFF
--- a/.changeset/fix-agent-slug-name.md
+++ b/.changeset/fix-agent-slug-name.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix: resolve agents by display name when slug lookup fails (#9096)

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -306,7 +306,7 @@ export namespace Agent {
           }
 
           const get = Effect.fnUntraced(function* (agent: string) {
-            return agents[KiloAgent.resolveKey(agent)] // kilocode_change - treat "build" as "code"
+            return agents[KiloAgent.resolveAgentKey(agent, agents)] // kilocode_change - slug/name fallback
           })
 
           const list = Effect.fnUntraced(function* () {

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -151,6 +151,29 @@ export function resolveKey(name: string): string {
   return name === "build" ? "code" : name
 }
 
+// Resolve an agent key with case-insensitive fallback and name-to-slug mapping.
+// When the exact key isn't found, searches for agents whose `name` field matches
+// (case-insensitive), so LLMs can use display names like "Jarvis" to find the
+// agent defined in jarvis.md.
+export function resolveAgentKey(
+  key: string,
+  agents: Record<string, { name: string }>,
+): string {
+  const resolved = resolveKey(key)
+  if (agents[resolved]) return resolved
+
+  // Case-insensitive slug match
+  const lower = resolved.toLowerCase()
+  const slugMatch = Object.keys(agents).find((k) => k.toLowerCase() === lower)
+  if (slugMatch) return slugMatch
+
+  // Match by agent name field (case-insensitive)
+  const nameMatch = Object.entries(agents).find(([, v]) => v.name.toLowerCase() === lower)
+  if (nameMatch) return nameMatch[0]
+
+  return resolved
+}
+
 // Remap "build" → "code" in agent config entries for backward compat in the config loop.
 export function preprocessConfig<T>(agentConfig: Record<string, T>): Record<string, T> {
   const result: Record<string, T> = {}

--- a/packages/opencode/test/kilocode/resolve-agent-key.test.ts
+++ b/packages/opencode/test/kilocode/resolve-agent-key.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "bun:test"
+import { resolveAgentKey, resolveKey } from "../../src/kilocode/agent"
+
+const agents = {
+  code: { name: "code" },
+  jarvis: { name: "Jarvis" },
+  "my-agent": { name: "My Custom Agent" },
+  plan: { name: "plan" },
+}
+
+test("resolveKey maps build to code", () => {
+  expect(resolveKey("build")).toBe("code")
+  expect(resolveKey("plan")).toBe("plan")
+})
+
+test("resolveAgentKey returns exact slug match", () => {
+  expect(resolveAgentKey("code", agents)).toBe("code")
+  expect(resolveAgentKey("jarvis", agents)).toBe("jarvis")
+})
+
+test("resolveAgentKey handles build→code mapping", () => {
+  expect(resolveAgentKey("build", agents)).toBe("code")
+})
+
+test("resolveAgentKey resolves case-insensitive slug", () => {
+  expect(resolveAgentKey("Jarvis", agents)).toBe("jarvis")
+  expect(resolveAgentKey("JARVIS", agents)).toBe("jarvis")
+  expect(resolveAgentKey("Plan", agents)).toBe("plan")
+})
+
+test("resolveAgentKey resolves by display name", () => {
+  expect(resolveAgentKey("My Custom Agent", agents)).toBe("my-agent")
+})
+
+test("resolveAgentKey returns input when no match found", () => {
+  expect(resolveAgentKey("nonexistent", agents)).toBe("nonexistent")
+})


### PR DESCRIPTION
## Summary

Fixes #9096 — when an LLM's task tool delegates to a subagent using the agent's display name (e.g. `Jarvis`) instead of its config slug (`jarvis`), the lookup fails silently because the agents map is keyed by slug.

## Problem

`Agent.get(name)` uses `resolveKey()` which only handles the `build→code` rename. When a user defines an agent in `.kilo/agent/jarvis.md` with `name: Jarvis` (capital J), the slug key is `jarvis` but the LLM uses `Jarvis` to delegate — the lookup returns `undefined`.

## Solution

Add `resolveAgentKey(key, agents)` with a three-tier fallback:
1. **Exact slug** (existing behavior via `resolveKey`)
2. **Case-insensitive slug** — `Jarvis` → `jarvis`
3. **Name field match** — search agents by their `name` property (case-insensitive)

Update `Agent.get()` to use `resolveAgentKey` instead of `resolveKey`.

## Test plan

- Added unit tests for all `resolveAgentKey` paths (exact match, case-insensitive slug, name lookup, no match)
- Existing tests continue to pass (build→code mapping preserved)