### PR TITLE
fix(cli): Shift+Enter now correctly inserts a newline instead of submitting (#9055)

### DIFF
--- a/.changeset/fix-shift-enter-newline.md
+++ b/.changeset/fix-shift-enter-newline.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+fix(cli): Shift+Enter now correctly inserts a newline instead of submitting (#9055)

--- a/packages/opencode/src/cli/cmd/tui/component/textarea-keybindings.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/textarea-keybindings.ts
@@ -65,9 +65,11 @@ export function useTextareaKeybindings() {
     const keybinds = keybind.all
 
     return [
+      ...TEXTAREA_ACTIONS.flatMap((action) => mapTextareaKeybindings(keybinds, action)),
+      // Hardcoded fallbacks come after config so user/default keybindings
+      // (e.g. shift+return → newline) take priority over the generic submit.
       { name: "return", action: "submit" },
       { name: "return", meta: true, action: "newline" },
-      ...TEXTAREA_ACTIONS.flatMap((action) => mapTextareaKeybindings(keybinds, action)),
     ] satisfies KeyBinding[]
   })
 }


### PR DESCRIPTION
## Summary

Fixes #9055 — Shift+Enter submits the message instead of inserting a newline in the CLI.

## Root cause

In `textarea-keybindings.ts`, the keybinding array placed hardcoded defaults **before** config-derived bindings:

```typescript
return [
  { name: "return", action: "submit" },           // ← matches ALL Return variants
  { name: "return", meta: true, action: "newline" },
  ...configBindings,                                // ← shift+return→newline never reached
]
```

The generic `{ name: "return" }` binding matches first regardless of modifier keys, so the config-defined `shift+return → newline` binding (from the default `input_newline: "shift+return,ctrl+return,alt+return,ctrl+j"`) is never reached.

## Fix

Move config-derived bindings before the hardcoded fallbacks:

```typescript
return [
  ...configBindings,                                // ← shift+return→newline matched first
  { name: "return", action: "submit" },           // ← fallback for unmodified Return
  { name: "return", meta: true, action: "newline" },
]
```

This ensures more-specific bindings (with shift/ctrl/alt modifiers) take priority, while the bare Enter → submit still works as a fallback.

## Test plan

- Verified config defaults include `input_newline: "shift+return,ctrl+return,alt+return,ctrl+j"` and `input_submit: "return"`
- The reordering ensures config bindings are matched first by the keybinding system