### PR TITLE
fix(suggest): auto-dismiss after timeout to prevent stuck sessions

### DIFF
--- a/.changeset/suggest-timeout.md
+++ b/.changeset/suggest-timeout.md
@@ -1,0 +1,9 @@
+---
+"@kilocode/cli": patch
+---
+
+fix(suggest): auto-dismiss suggestions after 5-minute timeout to prevent stuck sessions
+
+When a suggestion goes unanswered (e.g. user closes VS Code or misses the prompt), the session could become stuck indefinitely in a false "queued" state. Adds a server-side timeout that auto-dismisses pending suggestions after 5 minutes, ensuring sessions always recover.
+
+Fixes #9150

--- a/packages/opencode/src/kilocode/suggestion/index.ts
+++ b/packages/opencode/src/kilocode/suggestion/index.ts
@@ -8,6 +8,9 @@ import z from "zod"
 export namespace Suggestion {
   const log = Log.create({ service: "suggestion" })
 
+  /** Default timeout for suggestions in milliseconds (5 minutes). */
+  const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000
+
   export const Action = z
     .object({
       label: z.string().describe("Button or option label (1-5 words)"),
@@ -94,6 +97,7 @@ export namespace Suggestion {
     actions: Action[]
     blocking?: boolean
     tool?: { messageID: string; callID: string }
+    timeoutMs?: number
   }): Promise<Action> {
     const s = await state()
     const id = Identifier.ascending("suggestion")
@@ -109,10 +113,27 @@ export namespace Suggestion {
         blocking: input.blocking,
         tool: input.tool,
       }
+
+      const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS
+      const timer = setTimeout(() => {
+        if (!s.pending[id]) return
+        log.info("timed out", { id, timeoutMs })
+        dismiss(id)
+      }, timeoutMs)
+
+      const originalResolve = resolve
+      const originalReject = reject
+
       s.pending[id] = {
         info,
-        resolve,
-        reject,
+        resolve: (action) => {
+          clearTimeout(timer)
+          originalResolve(action)
+        },
+        reject: (error) => {
+          clearTimeout(timer)
+          originalReject(error)
+        },
       }
       Bus.publish(Event.Shown, info)
     })

--- a/packages/opencode/test/kilocode/suggestion/suggestion.test.ts
+++ b/packages/opencode/test/kilocode/suggestion/suggestion.test.ts
@@ -142,4 +142,80 @@ describe("suggestion", () => {
       },
     })
   })
+
+  test("suggestion auto-dismisses after timeout", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const ask = Suggestion.show({
+          sessionID: "ses_test",
+          text: "Review?",
+          actions: [{ label: "Go", prompt: "/review" }],
+          timeoutMs: 50, // 50ms timeout for test
+        })
+
+        // Suggestion should be pending
+        expect(await Suggestion.list()).toHaveLength(1)
+
+        // Wait for timeout
+        await new Promise((r) => setTimeout(r, 100))
+
+        // Should auto-dismiss
+        await expect(ask).rejects.toBeInstanceOf(Suggestion.DismissedError)
+        expect(await Suggestion.list()).toEqual([])
+      },
+    })
+  })
+
+  test("timeout is cleared when suggestion is accepted before expiry", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const ask = Suggestion.show({
+          sessionID: "ses_test",
+          text: "Review?",
+          actions: [{ label: "Go", prompt: "/review" }],
+          timeoutMs: 200,
+        })
+
+        const list = await Suggestion.list()
+        await Suggestion.accept({ requestID: list[0]!.id, index: 0 })
+
+        await expect(ask).resolves.toEqual({
+          label: "Go",
+          prompt: "/review",
+        })
+
+        // Wait past the original timeout to verify no errors
+        await new Promise((r) => setTimeout(r, 250))
+        expect(await Suggestion.list()).toEqual([])
+      },
+    })
+  })
+
+  test("timeout is cleared when suggestion is dismissed before expiry", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const ask = Suggestion.show({
+          sessionID: "ses_test",
+          text: "Review?",
+          actions: [{ label: "Go", prompt: "/review" }],
+          timeoutMs: 200,
+        })
+
+        const list = await Suggestion.list()
+        await Suggestion.dismiss(list[0]!.id)
+
+        await expect(ask).rejects.toBeInstanceOf(Suggestion.DismissedError)
+
+        // Wait past the original timeout to verify no double-dismiss
+        await new Promise((r) => setTimeout(r, 250))
+        expect(await Suggestion.list()).toEqual([])
+      },
+    })
+  })
 })


### PR DESCRIPTION
## Summary

When a suggestion goes unanswered — user closes VS Code, misses the prompt, or becomes inactive — the session enters a false "queued" state indefinitely because the suggest tool's promise never resolves.

## Changes

- **`packages/opencode/src/kilocode/suggestion/index.ts`**: Add a server-side timeout (default 5 minutes) to `Suggestion.show()`. When the timeout fires, the suggestion is auto-dismissed via `dismiss()`, which rejects the promise and publishes the `suggestion.dismissed` event — the same path as a manual dismiss. The timeout is cleared if the user accepts or dismisses the suggestion before it expires. Callers can override via the optional `timeoutMs` parameter.

- **`packages/opencode/test/kilocode/suggestion/suggestion.test.ts`**: Add 3 tests:
  - Suggestion auto-dismisses after timeout
  - Timeout is cleared on accept before expiry
  - Timeout is cleared on dismiss before expiry

## How it works

The timeout races against user interaction:
1. `show()` starts a `setTimeout` alongside the promise
2. If timeout fires first → calls `dismiss(id)` → same DismissedError path
3. If user acts first → `clearTimeout` in the wrapped resolve/reject callbacks

The 5-minute default is generous enough for normal interaction but prevents indefinite session stalls.

Closes #9150