### PR TITLE
fix(provider): use 'low' instead of 'minimal' reasoning effort for GitHub Copilot models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -923,11 +923,13 @@ export namespace ProviderTransform {
   }
 
   export function smallOptions(model: Provider.Model) {
-    if (
-      model.providerID === "openai" ||
-      model.api.npm === "@ai-sdk/openai" ||
-      model.api.npm === "@ai-sdk/github-copilot"
-    ) {
+    if (model.api.npm === "@ai-sdk/github-copilot") {
+      if (model.api.id.includes("gpt-5")) {
+        return { store: false, reasoningEffort: "low" }
+      }
+      return { store: false }
+    }
+    if (model.providerID === "openai" || model.api.npm === "@ai-sdk/openai") {
       if (model.api.id.includes("gpt-5")) {
         if (model.api.id.includes("5.")) {
           return { store: false, reasoningEffort: "low" }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3138,6 +3138,50 @@ describe("ProviderTransform.variants", () => {
         expect(result).toEqual({ reasoning: { enabled: false } })
       })
     })
+
+    describe("@ai-sdk/github-copilot", () => {
+      test("gpt-5-mini uses low instead of minimal", () => {
+        const model = createMockModel({
+          id: "copilot/gpt-5-mini",
+          providerID: "copilot",
+          api: {
+            id: "gpt-5-mini",
+            url: "https://api.githubcopilot.com",
+            npm: "@ai-sdk/github-copilot",
+          },
+        })
+        const result = ProviderTransform.smallOptions(model)
+        expect(result).toEqual({ store: false, reasoningEffort: "low" })
+      })
+
+      test("gpt-5 uses low instead of minimal", () => {
+        const model = createMockModel({
+          id: "copilot/gpt-5",
+          providerID: "copilot",
+          api: {
+            id: "gpt-5",
+            url: "https://api.githubcopilot.com",
+            npm: "@ai-sdk/github-copilot",
+          },
+        })
+        const result = ProviderTransform.smallOptions(model)
+        expect(result).toEqual({ store: false, reasoningEffort: "low" })
+      })
+
+      test("non-gpt-5 model returns store false only", () => {
+        const model = createMockModel({
+          id: "copilot/gpt-4o",
+          providerID: "copilot",
+          api: {
+            id: "gpt-4o",
+            url: "https://api.githubcopilot.com",
+            npm: "@ai-sdk/github-copilot",
+          },
+        })
+        const result = ProviderTransform.smallOptions(model)
+        expect(result).toEqual({ store: false })
+      })
+    })
   })
 
   describe("@ai-sdk/groq", () => {


### PR DESCRIPTION
## Problem

Closes #9143

When using GPT-5-Mini via GitHub Copilot as the model for prompt enhancement or title generation, the `smallOptions()` function sends `reasoningEffort: "minimal"`, which Copilot's API rejects with:

> `AI_APICallError: reasoning_effort "minimal" is not supported by model gpt-5-mini; supported values: [low medium high]`

## Root Cause

`smallOptions()` grouped `@ai-sdk/openai` and `@ai-sdk/github-copilot` together, but only the native OpenAI API supports `"minimal"`. The `variants()` function already correctly handles this — it uses `WIDELY_SUPPORTED_EFFORTS` (`["low", "medium", "high"]`) for Copilot models.

## Fix

Separate the `@ai-sdk/github-copilot` case in `smallOptions()` to use `"low"` instead of `"minimal"` for GPT-5 models, consistent with how `variants()` handles Copilot providers.

## Changes

- `packages/opencode/src/provider/transform.ts`: Split Copilot from OpenAI in `smallOptions()`, use `"low"` for all Copilot GPT-5 models
- `packages/opencode/test/provider/transform.test.ts`: Added 3 test cases for Copilot `smallOptions()` behavior