### PR TITLE
fix: re-prevent plan file corruption for OpenAI models by preserving write tool

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -271,7 +271,7 @@ export namespace ToolRegistry {
             KiloToolRegistry.e2e() || // kilocode_change
             (input.modelID.includes("gpt-") && !input.modelID.includes("oss") && !input.modelID.includes("gpt-4"))
           if (tool.id === ApplyPatchTool.id) return usePatch
-          if (tool.id === EditTool.id || tool.id === WriteTool.id) return !usePatch
+          if (tool.id === EditTool.id) return !usePatch // kilocode_change
 
           return true
         })


### PR DESCRIPTION
See #8384. This fix was reverted in one of the OpenCode rebases because it did not have a `kilocode_change` annotation. This PR reapplies the fix.